### PR TITLE
feat(keyfunder): support OP Stack bridge top-ups

### DIFF
--- a/.changeset/opstack-keyfunder-bridge.md
+++ b/.changeset/opstack-keyfunder-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/keyfunder': minor
+---
+
+Add optional OP Stack bridge top-ups for child-chain funder wallets.

--- a/.changeset/opstack-keyfunder-bridge.md
+++ b/.changeset/opstack-keyfunder-bridge.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/keyfunder': minor
 ---
 
-Add optional OP Stack bridge top-ups for child-chain funder wallets.
+Added optional OP Stack bridge top-ups for child-chain funder wallets.

--- a/typescript/keyfunder/README.md
+++ b/typescript/keyfunder/README.md
@@ -41,7 +41,7 @@ chains:
       threshold: '0.3'
       targetMultiplier: 1.5
       triggerMultiplier: 2.0
-  arbitrum:
+  optimism:
     balances:
       hyperlane-relayer: '0.1'
     igp:

--- a/typescript/keyfunder/README.md
+++ b/typescript/keyfunder/README.md
@@ -47,6 +47,14 @@ chains:
     igp:
       address: '0x3b6044acd6767f017e99318AA6Ef93b7B06A5a22'
       claimThreshold: '0.1'
+    bridge:
+      type: 'opstack'
+      parentChain: 'ethereum'
+      standardBridge: '0x4200000000000000000000000000000000000010'
+      threshold: '0.1'
+      targetBalance: '0.5'
+      minGasLimit: 200000
+      extraData: '0x'
 
 metrics:
   jobName: 'keyfunder-mainnet3'
@@ -74,6 +82,14 @@ chainsToSkip: []
 | `chains.<chain>.sweep.threshold`         | Base threshold for sweep calculations (required when enabled; decimal string; up to 18 decimals) |
 | `chains.<chain>.sweep.targetMultiplier`  | Multiplier for target balance (default: 1.5; 2 decimal precision, floored)                       |
 | `chains.<chain>.sweep.triggerMultiplier` | Multiplier for trigger threshold (default: 2.0; 2 decimal precision, floored)                    |
+| `chains.<chain>.bridge`                  | Optional bridge configuration for topping up the funder wallet before key funding                |
+| `chains.<chain>.bridge.type`             | Bridge type. Currently supports `opstack`                                                        |
+| `chains.<chain>.bridge.parentChain`      | Parent chain that holds the funder balance used for bridging                                     |
+| `chains.<chain>.bridge.standardBridge`   | OP Stack `L1StandardBridge` contract address on the parent chain                                 |
+| `chains.<chain>.bridge.threshold`        | Child-chain funder balance below which bridging is triggered                                     |
+| `chains.<chain>.bridge.targetBalance`    | Child-chain funder balance to restore through bridging. Must be greater than `threshold`         |
+| `chains.<chain>.bridge.minGasLimit`      | OP Stack bridge gas limit passed to `bridgeETHTo` (default: 200000)                              |
+| `chains.<chain>.bridge.extraData`        | Hex bytes passed to `bridgeETHTo` (default: `0x`)                                                |
 | `metrics.jobName`                        | Job name for metrics                                                                             |
 | `metrics.labels`                         | Additional labels for metrics                                                                    |
 | `chainsToSkip`                           | Array of chain names to skip                                                                     |
@@ -142,6 +158,12 @@ Keys are funded when their balance drops below 40% of the desired balance. The f
 ### IGP Claims
 
 When the IGP contract balance exceeds the claim threshold, accumulated fees are claimed to the funder wallet.
+
+### OP Stack Bridge Top-Ups
+
+For OP Stack child chains, KeyFunder can top up the child-chain funder wallet from a parent-chain `L1StandardBridge` before it funds keys.
+
+When the child funder balance is below `bridge.threshold`, KeyFunder sends enough native tokens through `bridgeETHTo` to restore the child balance to `bridge.targetBalance`. The parent-chain funder must have enough balance to cover the bridge amount.
 
 ### Sweep
 

--- a/typescript/keyfunder/src/config/types.test.ts
+++ b/typescript/keyfunder/src/config/types.test.ts
@@ -5,6 +5,7 @@ import { calculateMultipliedBalance } from '../core/KeyFunder.js';
 
 import {
   ChainConfigSchema,
+  BridgeType,
   KeyFunderConfigSchema,
   RoleConfigSchema,
   SweepConfigSchema,
@@ -213,6 +214,55 @@ describe('KeyFunderConfig Schemas', () => {
       };
       const result = ChainConfigSchema.safeParse(config);
       expect(result.success).to.be.true;
+    });
+
+    it('should validate OP Stack bridge config with defaults', () => {
+      const config = {
+        bridge: {
+          type: BridgeType.OpStack,
+          parentChain: 'ethereum',
+          standardBridge: '0x4200000000000000000000000000000000000010',
+          threshold: '0.1',
+          targetBalance: '0.5',
+        },
+      };
+      const result = ChainConfigSchema.safeParse(config);
+      expect(result.success).to.be.true;
+      if (result.success) {
+        expect(result.data.bridge?.type).to.equal(BridgeType.OpStack);
+        expect(result.data.bridge?.minGasLimit).to.equal(200_000);
+        expect(result.data.bridge?.extraData).to.equal('0x');
+      }
+    });
+
+    it('should reject OP Stack bridge zero address', () => {
+      const config = {
+        bridge: {
+          type: BridgeType.OpStack,
+          parentChain: 'ethereum',
+          standardBridge: '0x0000000000000000000000000000000000000000',
+          threshold: '0.1',
+          targetBalance: '0.5',
+        },
+      };
+      const result = ChainConfigSchema.safeParse(config);
+      expect(result.success).to.be.false;
+    });
+
+    it('should reject OP Stack bridge target at or below threshold', () => {
+      for (const targetBalance of ['1', '0.9']) {
+        const config = {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '1',
+            targetBalance,
+          },
+        };
+        const result = ChainConfigSchema.safeParse(config);
+        expect(result.success).to.be.false;
+      }
     });
   });
 

--- a/typescript/keyfunder/src/config/types.ts
+++ b/typescript/keyfunder/src/config/types.ts
@@ -7,6 +7,12 @@ const AddressSchema = z
     'Must be a valid Ethereum address (0x-prefixed, 40 hex characters)',
   );
 
+const NonZeroAddressSchema = AddressSchema.refine(
+  (address) =>
+    address.toLowerCase() !== '0x0000000000000000000000000000000000000000',
+  'Must not be the zero address',
+);
+
 // Requires leading digit (e.g., "0.5" not ".5") for YAML readability
 const BalanceStringSchema = z
   .string()
@@ -67,10 +73,59 @@ export const SweepConfigSchema = z
     },
   );
 
+export const BridgeType = {
+  OpStack: 'opstack',
+} as const;
+
+function compareBalanceStrings(left: string, right: string): number {
+  const [leftWholeRaw, leftFractionRaw = ''] = left.split('.');
+  const [rightWholeRaw, rightFractionRaw = ''] = right.split('.');
+
+  const leftWhole = leftWholeRaw.replace(/^0+/, '') || '0';
+  const rightWhole = rightWholeRaw.replace(/^0+/, '') || '0';
+
+  if (leftWhole.length !== rightWhole.length) {
+    return leftWhole.length > rightWhole.length ? 1 : -1;
+  }
+
+  const wholeComparison = leftWhole.localeCompare(rightWhole);
+  if (wholeComparison !== 0) {
+    return wholeComparison;
+  }
+
+  const leftFraction = leftFractionRaw.padEnd(18, '0');
+  const rightFraction = rightFractionRaw.padEnd(18, '0');
+  return leftFraction.localeCompare(rightFraction);
+}
+
+export const OpStackBridgeConfigSchema = z
+  .object({
+    type: z.literal(BridgeType.OpStack),
+    parentChain: z.string().min(1),
+    standardBridge: NonZeroAddressSchema,
+    threshold: BalanceStringSchema,
+    targetBalance: BalanceStringSchema,
+    minGasLimit: z.number().int().positive().default(200_000),
+    extraData: z
+      .string()
+      .regex(/^0x(?:[a-fA-F0-9]{2})*$/, 'Must be hex bytes')
+      .default('0x'),
+  })
+  .refine(
+    (data) => compareBalanceStrings(data.targetBalance, data.threshold) > 0,
+    {
+      message: 'Bridge targetBalance must be greater than threshold',
+      path: ['targetBalance'],
+    },
+  );
+
+export const BridgeConfigSchema = OpStackBridgeConfigSchema;
+
 export const ChainConfigSchema = z.object({
   balances: z.record(z.string(), BalanceStringSchema).optional(),
   igp: IgpConfigSchema.optional(),
   sweep: SweepConfigSchema.optional(),
+  bridge: BridgeConfigSchema.optional(),
 });
 
 export const MetricsConfigSchema = z.object({
@@ -108,6 +163,8 @@ export const KeyFunderConfigSchema = z
 export type RoleConfig = z.infer<typeof RoleConfigSchema>;
 export type IgpConfig = z.infer<typeof IgpConfigSchema>;
 export type SweepConfig = z.infer<typeof SweepConfigSchema>;
+export type OpStackBridgeConfig = z.infer<typeof OpStackBridgeConfigSchema>;
+export type BridgeConfig = z.infer<typeof BridgeConfigSchema>;
 export type ChainConfig = z.infer<typeof ChainConfigSchema>;
 export type MetricsConfig = z.infer<typeof MetricsConfigSchema>;
 export type KeyFunderConfig = z.infer<typeof KeyFunderConfigSchema>;

--- a/typescript/keyfunder/src/core/KeyFunder.test.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.test.ts
@@ -1,12 +1,24 @@
 import { expect } from 'chai';
+import { ethers } from 'ethers';
 import type { Logger } from 'pino';
 import sinon from 'sinon';
 
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 
-import type { KeyFunderConfig } from '../config/types.js';
+import { BridgeType, type KeyFunderConfig } from '../config/types.js';
 
 import { KeyFunder } from './KeyFunder.js';
+
+function makeTestLogger(): Logger {
+  const logger = {
+    child: () => logger,
+    debug: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  };
+  return logger as unknown as Logger;
+}
 
 describe('KeyFunder', () => {
   afterEach(() => {
@@ -85,5 +97,113 @@ describe('KeyFunder', () => {
     expect(
       (infoArgs[0] as { durationSeconds: unknown }).durationSeconds,
     ).to.be.a('number');
+  });
+
+  it('should bridge OP Stack child funder when below threshold', async () => {
+    const childSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x2222222222222222222222222222222222222222'),
+      getBalance: sinon.stub().resolves(ethers.utils.parseEther('0.1')),
+    };
+    const parentSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x3333333333333333333333333333333333333333'),
+      getBalance: sinon.stub().resolves(ethers.utils.parseEther('2')),
+    };
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getSigner.withArgs('optimism').returns(childSigner as never);
+    multiProvider.getSigner.withArgs('ethereum').returns(parentSigner as never);
+    multiProvider.getSignerAddress
+      .withArgs('optimism')
+      .resolves('0x2222222222222222222222222222222222222222');
+    multiProvider.tryGetExplorerTxUrl.returns('https://explorer/tx/0xabc');
+
+    const bridgeETHTo = sinon.stub().resolves({
+      hash: '0xabc',
+      wait: sinon.stub().resolves({ transactionHash: '0xabc' }),
+    });
+    const opStackStandardBridgeFactory = sinon.stub().returns({
+      bridgeETHTo,
+    });
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {},
+      chains: {
+        optimism: {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '0.5',
+            targetBalance: '1',
+            minGasLimit: 150_000,
+            extraData: '0x1234',
+          },
+        },
+      },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger: makeTestLogger(),
+      opStackStandardBridgeFactory,
+    });
+
+    await keyFunder.fundChain('optimism');
+
+    sinon.assert.calledOnceWithExactly(
+      opStackStandardBridgeFactory,
+      '0x4200000000000000000000000000000000000010',
+      parentSigner,
+    );
+    sinon.assert.calledOnceWithExactly(
+      bridgeETHTo,
+      '0x2222222222222222222222222222222222222222',
+      150_000,
+      '0x1234',
+      { value: ethers.utils.parseEther('0.9') },
+    );
+  });
+
+  it('should skip OP Stack bridge when child funder is above threshold', async () => {
+    const childSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x2222222222222222222222222222222222222222'),
+      getBalance: sinon.stub().resolves(ethers.utils.parseEther('0.6')),
+    };
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getSigner.withArgs('optimism').returns(childSigner as never);
+    multiProvider.getSignerAddress
+      .withArgs('optimism')
+      .resolves('0x2222222222222222222222222222222222222222');
+    const opStackStandardBridgeFactory = sinon.stub();
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {},
+      chains: {
+        optimism: {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '0.5',
+            targetBalance: '1',
+            minGasLimit: 200_000,
+            extraData: '0x',
+          },
+        },
+      },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger: makeTestLogger(),
+      opStackStandardBridgeFactory,
+    });
+
+    await keyFunder.fundChain('optimism');
+
+    sinon.assert.notCalled(opStackStandardBridgeFactory);
   });
 });

--- a/typescript/keyfunder/src/core/KeyFunder.test.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.test.ts
@@ -104,7 +104,12 @@ describe('KeyFunder', () => {
       getAddress: sinon
         .stub()
         .resolves('0x2222222222222222222222222222222222222222'),
-      getBalance: sinon.stub().resolves(ethers.utils.parseEther('0.1')),
+      getBalance: sinon
+        .stub()
+        .onFirstCall()
+        .resolves(ethers.utils.parseEther('0.1'))
+        .onSecondCall()
+        .resolves(ethers.utils.parseEther('1')),
     };
     const parentSigner = {
       getAddress: sinon
@@ -124,7 +129,11 @@ describe('KeyFunder', () => {
       hash: '0xabc',
       wait: sinon.stub().resolves({ transactionHash: '0xabc' }),
     });
+    const estimateBridgeETHToFee = sinon
+      .stub()
+      .resolves(ethers.utils.parseEther('0.01'));
     const opStackStandardBridgeFactory = sinon.stub().returns({
+      estimateBridgeETHToFee,
       bridgeETHTo,
     });
     const config: KeyFunderConfig = {
@@ -158,12 +167,175 @@ describe('KeyFunder', () => {
       parentSigner,
     );
     sinon.assert.calledOnceWithExactly(
+      estimateBridgeETHToFee,
+      '0x2222222222222222222222222222222222222222',
+      150_000,
+      '0x1234',
+      { value: ethers.utils.parseEther('0.9') },
+    );
+    sinon.assert.calledOnceWithExactly(
       bridgeETHTo,
       '0x2222222222222222222222222222222222222222',
       150_000,
       '0x1234',
       { value: ethers.utils.parseEther('0.9') },
     );
+  });
+
+  it('should include estimated bridge fee in parent balance preflight', async () => {
+    const childSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x2222222222222222222222222222222222222222'),
+      getBalance: sinon.stub().resolves(ethers.utils.parseEther('0.1')),
+    };
+    const parentSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x3333333333333333333333333333333333333333'),
+      getBalance: sinon.stub().resolves(ethers.utils.parseEther('0.9')),
+    };
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getSigner.withArgs('optimism').returns(childSigner as never);
+    multiProvider.getSigner.withArgs('ethereum').returns(parentSigner as never);
+    multiProvider.getSignerAddress
+      .withArgs('optimism')
+      .resolves('0x2222222222222222222222222222222222222222');
+
+    const bridgeETHTo = sinon.stub();
+    const opStackStandardBridgeFactory = sinon.stub().returns({
+      estimateBridgeETHToFee: sinon
+        .stub()
+        .resolves(ethers.utils.parseEther('0.01')),
+      bridgeETHTo,
+    });
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {},
+      chains: {
+        optimism: {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '0.5',
+            targetBalance: '1',
+            minGasLimit: 150_000,
+            extraData: '0x1234',
+          },
+        },
+      },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger: makeTestLogger(),
+      opStackStandardBridgeFactory,
+    });
+
+    let thrown: unknown;
+    try {
+      await keyFunder.fundChain('optimism');
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(Error);
+    expect((thrown as Error).message).to.include(
+      'including estimated bridge fee',
+    );
+    sinon.assert.notCalled(bridgeETHTo);
+  });
+
+  it('should wait for OP Stack bridge relay before funding child keys', async () => {
+    const childSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x2222222222222222222222222222222222222222'),
+      getBalance: sinon
+        .stub()
+        .onFirstCall()
+        .resolves(ethers.utils.parseEther('0.1'))
+        .onSecondCall()
+        .resolves(ethers.utils.parseEther('1')),
+    };
+    const parentSigner = {
+      getAddress: sinon
+        .stub()
+        .resolves('0x3333333333333333333333333333333333333333'),
+      getBalance: sinon.stub().resolves(ethers.utils.parseEther('2')),
+    };
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getSigner.withArgs('optimism').returns(childSigner as never);
+    multiProvider.getSigner.withArgs('ethereum').returns(parentSigner as never);
+    multiProvider.getSignerAddress
+      .withArgs('optimism')
+      .resolves('0x2222222222222222222222222222222222222222');
+    multiProvider.tryGetExplorerTxUrl.returns('https://explorer/tx/0xabc');
+
+    const bridgeETHTo = sinon.stub().resolves({
+      hash: '0xabc',
+      wait: sinon.stub().resolves({ transactionHash: '0xabc' }),
+    });
+    const opStackStandardBridgeFactory = sinon.stub().returns({
+      estimateBridgeETHToFee: sinon
+        .stub()
+        .resolves(ethers.utils.parseEther('0.01')),
+      bridgeETHTo,
+    });
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {
+        relayer: { address: '0x1111111111111111111111111111111111111111' },
+      },
+      chains: {
+        optimism: {
+          bridge: {
+            type: BridgeType.OpStack,
+            parentChain: 'ethereum',
+            standardBridge: '0x4200000000000000000000000000000000000010',
+            threshold: '0.5',
+            targetBalance: '1',
+            minGasLimit: 150_000,
+            extraData: '0x1234',
+          },
+          balances: {
+            relayer: '1',
+          },
+        },
+      },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger: makeTestLogger(),
+      opStackStandardBridgeFactory,
+    });
+    const recordFunderBalanceStub = sinon
+      .stub(
+        keyFunder as unknown as {
+          recordFunderBalance: (chain: string) => Promise<void>;
+        },
+        'recordFunderBalance',
+      )
+      .callsFake(async () => {
+        sinon.assert.calledTwice(childSigner.getBalance);
+      });
+    const fundKeysStub = sinon
+      .stub(
+        keyFunder as unknown as {
+          fundKeys: (chain: string, keys: unknown[]) => Promise<void>;
+        },
+        'fundKeys',
+      )
+      .callsFake(async () => {
+        sinon.assert.calledTwice(childSigner.getBalance);
+      });
+
+    await keyFunder.fundChain('optimism');
+
+    sinon.assert.calledOnce(bridgeETHTo);
+    sinon.assert.calledTwice(childSigner.getBalance);
+    sinon.assert.calledOnce(recordFunderBalanceStub);
+    sinon.assert.calledOnce(fundKeysStub);
   });
 
   it('should skip OP Stack bridge when child funder is above threshold', async () => {

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -303,14 +303,20 @@ export class KeyFunder {
         parentSigner,
       ) ??
       createOpStackStandardBridge(bridgeConfig.standardBridge, parentSigner);
-    const tx = await bridge.bridgeETHTo(
-      childFunderAddress,
-      bridgeConfig.minGasLimit,
-      bridgeConfig.extraData,
-      { value: bridgeAmount },
-    );
-    const receipt = await tx.wait();
-    const txHash = receipt.transactionHash ?? tx.hash;
+    let txHash: string;
+    try {
+      const tx = await bridge.bridgeETHTo(
+        childFunderAddress,
+        bridgeConfig.minGasLimit,
+        bridgeConfig.extraData,
+        { value: bridgeAmount },
+      );
+      const receipt = await tx.wait();
+      txHash = receipt.transactionHash ?? tx.hash;
+    } catch (error) {
+      logger.error({ error }, 'OP Stack bridge transaction failed');
+      throw error;
+    }
 
     logger.info(
       {
@@ -547,10 +553,17 @@ function createOpStackStandardBridge(
 ): OpStackStandardBridge {
   const contract = new Contract(address, OP_STACK_STANDARD_BRIDGE_ABI, signer);
   return {
-    bridgeETHTo: async (to, minGasLimit, extraData, overrides) =>
-      contract.bridgeETHTo(to, minGasLimit, extraData, overrides) as Promise<{
-        hash: string;
-        wait: () => Promise<{ transactionHash?: string }>;
-      }>,
+    bridgeETHTo: async (to, minGasLimit, extraData, overrides) => {
+      const tx = await contract.bridgeETHTo(
+        to,
+        minGasLimit,
+        extraData,
+        overrides,
+      );
+      return {
+        hash: tx.hash,
+        wait: async () => tx.wait(),
+      };
+    },
   };
 }

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -1,11 +1,13 @@
-import { BigNumber, ethers } from 'ethers';
+import { BigNumber, Contract, ethers } from 'ethers';
 import type { Logger } from 'pino';
 
 import { HyperlaneIgp, MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
 import type {
   ChainConfig,
   KeyFunderConfig,
+  OpStackBridgeConfig,
   ResolvedKeyConfig,
 } from '../config/types.js';
 import type { KeyFunderMetrics } from '../metrics/Metrics.js';
@@ -15,11 +17,31 @@ const MIN_DELTA_DENOMINATOR = BigNumber.from(10);
 
 const CHAIN_FUNDING_TIMEOUT_MS = 60_000;
 
+const OP_STACK_STANDARD_BRIDGE_ABI = [
+  'function bridgeETHTo(address _to, uint32 _minGasLimit, bytes _extraData) payable',
+] as const;
+
+export interface OpStackStandardBridge {
+  bridgeETHTo(
+    to: string,
+    minGasLimit: number,
+    extraData: string,
+    overrides: { value: BigNumber },
+  ): Promise<{
+    hash: string;
+    wait: () => Promise<{ transactionHash?: string }>;
+  }>;
+}
+
 export interface KeyFunderOptions {
   logger: Logger;
   metrics?: KeyFunderMetrics;
   skipIgpClaim?: boolean;
   igp?: HyperlaneIgp;
+  opStackStandardBridgeFactory?: (
+    address: string,
+    signer: ethers.Signer,
+  ) => OpStackStandardBridge;
 }
 
 export class KeyFunder {
@@ -90,6 +112,8 @@ export class KeyFunder {
     if (!this.options.skipIgpClaim && chainConfig.igp) {
       await this.claimFromIgp(chain, chainConfig);
     }
+
+    await this.bridgeIfRequired(chain, chainConfig);
 
     try {
       await this.recordFunderBalance(chain);
@@ -199,6 +223,105 @@ export class KeyFunder {
       );
       logger.info('IGP claim completed');
     }
+  }
+
+  private async bridgeIfRequired(
+    chain: string,
+    chainConfig: ChainConfig,
+  ): Promise<void> {
+    if (!chainConfig.bridge) {
+      return;
+    }
+
+    await this.bridgeToOpStack(chain, chainConfig.bridge);
+  }
+
+  private async bridgeToOpStack(
+    childChain: string,
+    bridgeConfig: OpStackBridgeConfig,
+  ): Promise<void> {
+    const logger = this.options.logger.child({
+      chain: childChain,
+      parentChain: bridgeConfig.parentChain,
+      operation: 'op-stack-bridge',
+    });
+    const childFunderAddress =
+      await this.multiProvider.getSignerAddress(childChain);
+    const childBalance = await this.multiProvider
+      .getSigner(childChain)
+      .getBalance();
+    const threshold = ethers.utils.parseEther(bridgeConfig.threshold);
+
+    logger.info(
+      {
+        childFunderAddress,
+        childBalance: ethers.utils.formatEther(childBalance),
+        threshold: ethers.utils.formatEther(threshold),
+      },
+      'Checking OP Stack bridge conditions',
+    );
+
+    if (childBalance.gte(threshold)) {
+      logger.debug('Child funder balance above bridge threshold, skipping');
+      return;
+    }
+
+    const targetBalance = ethers.utils.parseEther(bridgeConfig.targetBalance);
+    const bridgeAmount = targetBalance.sub(childBalance);
+    const parentSigner = this.multiProvider.getSigner(bridgeConfig.parentChain);
+    const parentFunderAddress = await parentSigner.getAddress();
+    const parentBalance = await parentSigner.getBalance();
+
+    if (parentBalance.lt(bridgeAmount)) {
+      logger.error(
+        {
+          parentFunderAddress,
+          parentBalance: ethers.utils.formatEther(parentBalance),
+          requiredAmount: ethers.utils.formatEther(bridgeAmount),
+        },
+        'Parent funder balance insufficient to bridge',
+      );
+    }
+    assert(
+      parentBalance.gte(bridgeAmount),
+      `Insufficient parent funder balance on ${bridgeConfig.parentChain}: has ${ethers.utils.formatEther(parentBalance)}, needs ${ethers.utils.formatEther(bridgeAmount)}`,
+    );
+
+    logger.info(
+      {
+        childFunderAddress,
+        parentFunderAddress,
+        bridgeAmount: ethers.utils.formatEther(bridgeAmount),
+        standardBridge: bridgeConfig.standardBridge,
+      },
+      'Bridging funds to OP Stack child chain',
+    );
+
+    const bridge =
+      this.options.opStackStandardBridgeFactory?.(
+        bridgeConfig.standardBridge,
+        parentSigner,
+      ) ??
+      createOpStackStandardBridge(bridgeConfig.standardBridge, parentSigner);
+    const tx = await bridge.bridgeETHTo(
+      childFunderAddress,
+      bridgeConfig.minGasLimit,
+      bridgeConfig.extraData,
+      { value: bridgeAmount },
+    );
+    const receipt = await tx.wait();
+    const txHash = receipt.transactionHash ?? tx.hash;
+
+    logger.info(
+      {
+        txHash,
+        txUrl: this.multiProvider.tryGetExplorerTxUrl(
+          bridgeConfig.parentChain,
+          { hash: txHash },
+        ),
+      },
+      'OP Stack bridge transaction completed',
+    );
   }
 
   private async fundKeys(
@@ -415,5 +538,19 @@ function createTimeoutPromise(
     cleanup: () => {
       clearTimeout(timeoutId);
     },
+  };
+}
+
+function createOpStackStandardBridge(
+  address: string,
+  signer: ethers.Signer,
+): OpStackStandardBridge {
+  const contract = new Contract(address, OP_STACK_STANDARD_BRIDGE_ABI, signer);
+  return {
+    bridgeETHTo: async (to, minGasLimit, extraData, overrides) =>
+      contract.bridgeETHTo(to, minGasLimit, extraData, overrides) as Promise<{
+        hash: string;
+        wait: () => Promise<{ transactionHash?: string }>;
+      }>,
   };
 }

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -15,13 +15,21 @@ import type { KeyFunderMetrics } from '../metrics/Metrics.js';
 const MIN_DELTA_NUMERATOR = BigNumber.from(6);
 const MIN_DELTA_DENOMINATOR = BigNumber.from(10);
 
-const CHAIN_FUNDING_TIMEOUT_MS = 60_000;
+const CHAIN_FUNDING_TIMEOUT_MS = 240_000;
+const OP_STACK_RELAY_TIMEOUT_MS = 180_000;
+const OP_STACK_RELAY_POLL_INTERVAL_MS = 5_000;
 
 const OP_STACK_STANDARD_BRIDGE_ABI = [
   'function bridgeETHTo(address _to, uint32 _minGasLimit, bytes _extraData) payable',
 ] as const;
 
 export interface OpStackStandardBridge {
+  estimateBridgeETHToFee(
+    to: string,
+    minGasLimit: number,
+    extraData: string,
+    overrides: { value: BigNumber },
+  ): Promise<BigNumber>;
   bridgeETHTo(
     to: string,
     minGasLimit: number,
@@ -271,20 +279,37 @@ export class KeyFunder {
     const parentSigner = this.multiProvider.getSigner(bridgeConfig.parentChain);
     const parentFunderAddress = await parentSigner.getAddress();
     const parentBalance = await parentSigner.getBalance();
+    const bridge =
+      this.options.opStackStandardBridgeFactory?.(
+        bridgeConfig.standardBridge,
+        parentSigner,
+      ) ??
+      createOpStackStandardBridge(bridgeConfig.standardBridge, parentSigner);
+    const estimatedBridgeFee = await bridge.estimateBridgeETHToFee(
+      childFunderAddress,
+      bridgeConfig.minGasLimit,
+      bridgeConfig.extraData,
+      { value: bridgeAmount },
+    );
+    const requiredParentBalance = bridgeAmount.add(estimatedBridgeFee);
 
-    if (parentBalance.lt(bridgeAmount)) {
+    if (parentBalance.lt(requiredParentBalance)) {
       logger.error(
         {
           parentFunderAddress,
           parentBalance: ethers.utils.formatEther(parentBalance),
           requiredAmount: ethers.utils.formatEther(bridgeAmount),
+          estimatedBridgeFee: ethers.utils.formatEther(estimatedBridgeFee),
+          requiredParentBalance: ethers.utils.formatEther(
+            requiredParentBalance,
+          ),
         },
         'Parent funder balance insufficient to bridge',
       );
     }
     assert(
-      parentBalance.gte(bridgeAmount),
-      `Insufficient parent funder balance on ${bridgeConfig.parentChain}: has ${ethers.utils.formatEther(parentBalance)}, needs ${ethers.utils.formatEther(bridgeAmount)}`,
+      parentBalance.gte(requiredParentBalance),
+      `Insufficient parent funder balance on ${bridgeConfig.parentChain}: has ${ethers.utils.formatEther(parentBalance)}, needs ${ethers.utils.formatEther(requiredParentBalance)} including estimated bridge fee`,
     );
 
     logger.info(
@@ -292,17 +317,12 @@ export class KeyFunder {
         childFunderAddress,
         parentFunderAddress,
         bridgeAmount: ethers.utils.formatEther(bridgeAmount),
+        estimatedBridgeFee: ethers.utils.formatEther(estimatedBridgeFee),
         standardBridge: bridgeConfig.standardBridge,
       },
       'Bridging funds to OP Stack child chain',
     );
 
-    const bridge =
-      this.options.opStackStandardBridgeFactory?.(
-        bridgeConfig.standardBridge,
-        parentSigner,
-      ) ??
-      createOpStackStandardBridge(bridgeConfig.standardBridge, parentSigner);
     let txHash: string;
     try {
       const tx = await bridge.bridgeETHTo(
@@ -313,6 +333,12 @@ export class KeyFunder {
       );
       const receipt = await tx.wait();
       txHash = receipt.transactionHash ?? tx.hash;
+      await this.waitForOpStackRelay(
+        childChain,
+        childFunderAddress,
+        targetBalance,
+        logger,
+      );
     } catch (error) {
       logger.error({ error }, 'OP Stack bridge transaction failed');
       throw error;
@@ -328,6 +354,47 @@ export class KeyFunder {
       },
       'OP Stack bridge transaction completed',
     );
+  }
+
+  private async waitForOpStackRelay(
+    childChain: string,
+    childFunderAddress: string,
+    targetBalance: BigNumber,
+    logger: Logger,
+  ): Promise<void> {
+    const childSigner = this.multiProvider.getSigner(childChain);
+    const deadline = Date.now() + OP_STACK_RELAY_TIMEOUT_MS;
+
+    for (;;) {
+      const relayedBalance = await childSigner.getBalance();
+      if (relayedBalance.gte(targetBalance)) {
+        logger.info(
+          {
+            childFunderAddress,
+            childBalance: ethers.utils.formatEther(relayedBalance),
+            targetBalance: ethers.utils.formatEther(targetBalance),
+          },
+          'OP Stack bridge relay observed on child chain',
+        );
+        return;
+      }
+
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out waiting for OP Stack bridge relay on ${childChain}: ${childFunderAddress} has ${ethers.utils.formatEther(relayedBalance)}, expected at least ${ethers.utils.formatEther(targetBalance)}`,
+        );
+      }
+
+      logger.debug(
+        {
+          childFunderAddress,
+          childBalance: ethers.utils.formatEther(relayedBalance),
+          targetBalance: ethers.utils.formatEther(targetBalance),
+        },
+        'Waiting for OP Stack bridge relay on child chain',
+      );
+      await sleep(OP_STACK_RELAY_POLL_INTERVAL_MS);
+    }
   }
 
   private async fundKeys(
@@ -547,12 +614,26 @@ function createTimeoutPromise(
   };
 }
 
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function createOpStackStandardBridge(
   address: string,
   signer: ethers.Signer,
 ): OpStackStandardBridge {
   const contract = new Contract(address, OP_STACK_STANDARD_BRIDGE_ABI, signer);
   return {
+    estimateBridgeETHToFee: async (to, minGasLimit, extraData, overrides) => {
+      const gasLimit = await contract.estimateGas.bridgeETHTo(
+        to,
+        minGasLimit,
+        extraData,
+        overrides,
+      );
+      const gasPrice = await contract.provider.getGasPrice();
+      return gasLimit.mul(gasPrice).mul(12).div(10);
+    },
     bridgeETHTo: async (to, minGasLimit, extraData, overrides) => {
       const tx = await contract.bridgeETHTo(
         to,

--- a/typescript/keyfunder/src/index.ts
+++ b/typescript/keyfunder/src/index.ts
@@ -4,6 +4,9 @@ export {
   RoleConfigSchema,
   IgpConfigSchema,
   SweepConfigSchema,
+  BridgeType,
+  BridgeConfigSchema,
+  OpStackBridgeConfigSchema,
   ChainConfigSchema,
   MetricsConfigSchema,
 } from './config/types.js';
@@ -13,6 +16,8 @@ export type {
   RoleConfig,
   IgpConfig,
   SweepConfig,
+  BridgeConfig,
+  OpStackBridgeConfig,
   ChainConfig,
   MetricsConfig,
   ResolvedKeyConfig,
@@ -21,6 +26,7 @@ export type {
 export {
   KeyFunder,
   calculateMultipliedBalance,
+  type OpStackStandardBridge,
   type KeyFunderOptions,
 } from './core/KeyFunder.js';
 export { KeyFunderMetrics } from './metrics/Metrics.js';


### PR DESCRIPTION
### Description

Adds optional OP Stack bridge top-ups to the new KeyFunder so OP Stack child-chain funder wallets can be restored from a configured parent-chain `L1StandardBridge` before key funding runs.

Changes:
- add OP Stack bridge config schema, defaults, validation, and exports
- bridge from the configured parent-chain signer when the child-chain funder balance falls below threshold
- record bridge execution logs and fail fast when parent funds are insufficient
- document the OP Stack bridge config and add a changeset
- cover schema validation plus execute/skip bridge behavior in tests

Fixes #3402
/claim #3402

### Backward compatibility

Existing KeyFunder configs continue to work because `chains.<chain>.bridge` is optional. Bridge behavior only runs for chains that opt into the new OP Stack bridge config.

### Testing

- `pnpm --filter @hyperlane-xyz/keyfunder... build`
- `pnpm -C typescript/keyfunder build`
- `pnpm -C typescript/keyfunder test`
- `pnpm -C typescript/keyfunder lint`
- `pnpm -C typescript/keyfunder format`
- `git diff --check`
