### PR TITLE
fix: correct Solana prioritization fee unit in gas estimation

### DIFF
--- a/.changeset/sweet-rockets-own.md
+++ b/.changeset/sweet-rockets-own.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed solana fee estimation

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -161,11 +161,13 @@ export async function estimateTransactionFeeSolanaWeb3({
   assert(!value.err, `Solana gas estimation failed: ${JSON.stringify(value)}`);
   const gasUnits = BigInt(value.unitsConsumed || 0);
   const recentFees = await connection.getRecentPrioritizationFees();
-  const gasPrice = BigInt(recentFees[0].prioritizationFee);
+  // prioritizationFee is in micro-lamports per compute unit; divide by 1e6 to get lamports
+  const microLamportsPerCu = BigInt(recentFees[0]?.prioritizationFee ?? 0);
+  const fee = (gasUnits * microLamportsPerCu) / 1_000_000n;
   return {
     gasUnits,
-    gasPrice,
-    fee: gasUnits * gasPrice,
+    gasPrice: microLamportsPerCu,
+    fee,
   };
 }
 


### PR DESCRIPTION
## Summary

- `estimateTransactionFeeSolanaWeb3` was computing `fee = gasUnits × prioritizationFee` where `prioritizationFee` comes from `getRecentPrioritizationFees()` in **micro-lamports per compute unit**
- The result (micro-lamports) was used directly as lamports — a **1,000,000× overestimate** whenever testnet/mainnet slots have any non-zero prioritization fee
- This inflated `localQuote` causes `getMaxTransferAmount` to undercount the max transferable amount, triggering a false "Insufficient balance for gas and transfer" pre-flight error even when the user has more than enough SOL
- Also fixes a crash: `recentFees[0]?.prioritizationFee ?? 0` guards against an empty array

## Root cause

The bug was introduced in the original file (`254466f11a`) and only surfaces when `getRecentPrioritizationFees()` returns non-zero values. It was previously masked because:
1. `SealevelHypNativeAdapter.getMedianPriorityFee()` returns `undefined`, so transactions are built with 0 priority fee — testnet often has all-zero recent fees too, making `fee = 0`
2. On mainnet, users have large enough balances that the overestimate doesn't exceed them

The SOL→Aleo testnet route exposed it by hitting testnet at a time when recent prioritization fees were non-zero.

## Fix

```typescript
// Before
const gasPrice = BigInt(recentFees[0].prioritizationFee);
fee: gasUnits * gasPrice,

// After — divide by 1e6 to convert micro-lamports → lamports
const microLamportsPerCu = BigInt(recentFees[0]?.prioritizationFee ?? 0);
fee: (gasUnits * microLamportsPerCu) / 1_000_000n,
```

This only affects the pre-flight balance check, not the actual on-chain fee. Making the estimate more accurate means fewer false "insufficient balance" rejections with no risk of allowing underfunded transactions (the validator handles that).