### PR TITLE
chore: update warp monitor

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -50,7 +50,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   checkWarpDeploy: 'main',
   // standalone services
   keyFunder: '3b17358-20260315-183126',
-  warpMonitor: 'a915865-20260424-083851',
+  warpMonitor: '744b3bb-20260521-215958',
   rebalancer: '1a19513-20260413-090011',
   feeQuoting: '12d899d-20260325-184337',
 };


### PR DESCRIPTION
### Description

update warp monitor to fix the USDT/ethereum-igra monitor: https://abacusworks.grafana.net/d/ddz6ma94rnzswc/warp-routes?orgId=1&from=now-5m&to=now&timezone=browser&var-warp_route_id=USDT%2Fethereum-igra

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
