### PR TITLE
chore(license): introduce BUSL-1.1 alongside Apache-2.0 at repo level

### DIFF
--- a/LICENSE-APACHE-2.0
+++ b/LICENSE-APACHE-2.0
@@ -1,0 +1,193 @@
+# Apache License
+
+_Version 2.0, January 2004_  
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+- **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+  this License; and
+- **(b)** You must cause any modified files to carry prominent notices stating that You
+  changed the files; and
+- **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+  all copyright, patent, trademark, and attribution notices from the Source form
+  of the Work, excluding those notices that do not pertain to any part of the
+  Derivative Works; and
+- **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+  Derivative Works that You distribute must include a readable copy of the
+  attribution notices contained within such NOTICE file, excluding those notices
+  that do not pertain to any part of the Derivative Works, in at least one of the
+  following places: within a NOTICE text file distributed as part of the
+  Derivative Works; within the Source form or documentation, if provided along
+  with the Derivative Works; or, within a display generated by the Derivative
+  Works, if and wherever such third-party notices normally appear. The contents of
+  the NOTICE file are for informational purposes only and do not modify the
+  License. You may add Your own attribution notices within Derivative Works that
+  You distribute, alongside or as an addendum to the NOTICE text from the Work,
+  provided that such additional attribution notices cannot be construed as
+  modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/LICENSE-BUSL-1.1
+++ b/LICENSE-BUSL-1.1
@@ -1,0 +1,115 @@
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             Abacus Works, Inc.
+
+Licensed Work:        Hyperlane (portions as designated by SPDX headers)
+                      The Licensed Work is (c) 2024-2026 Abacus Works, Inc.
+
+Additional Use Grant: You may make use of the Licensed Work, provided that
+                      you do not use the Licensed Work for a Commercial
+                      Purpose.
+
+                      A "Commercial Purpose" means use in or for a product or
+                      service that competes with the Licensed Work or any
+                      other product or service made available by the Licensor,
+                      including but not limited to cross-chain token bridging,
+                      stablecoin routing, interchain swap infrastructure, and
+                      interchain account or query middleware.
+
+                      You may use the Licensed Work for non-production
+                      purposes including development, testing, and personal
+                      education.
+
+Change Date:          Four years from the date of each release of the
+                      Licensed Work.
+
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed
+Work, please contact: licensing@hyperlane.xyz
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,193 +1,51 @@
-# Apache License
+# Licenses
 
-_Version 2.0, January 2004_  
-_&lt;<http://www.apache.org/licenses/>&gt;_
+This repository contains code under multiple licenses.
+Each source file indicates its license via an SPDX-License-Identifier header.
 
-### Terms and Conditions for use, reproduction, and distribution
+## Apache License 2.0 / MIT
 
-#### 1. Definitions
+Core protocol contracts, interfaces, base libraries, agents, SDK, and
+utilities are licensed under Apache-2.0 (or MIT OR Apache-2.0 for some files).
 
-“License” shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 9 of this document.
+See `LICENSE-APACHE-2.0` for the full Apache 2.0 license text.
 
-“Licensor” shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.
+## Business Source License 1.1
 
-“Legal Entity” shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, “control” means **(i)** the power, direct or
-indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
-outstanding shares, or **(iii)** beneficial ownership of such entity.
+Commercial and product code including advanced token contracts, middleware,
+infrastructure tooling, and CLI are licensed under BUSL-1.1.
 
-“You” (or “Your”) shall mean an individual or Legal Entity exercising
-permissions granted by this License.
+See `LICENSE-BUSL-1.1` for the full license text including the
+Additional Use Grant and Change Date.
 
-“Source” form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and configuration
-files.
+## Directory Breakdown
 
-“Object” form shall mean any form resulting from mechanical transformation or
-translation of a Source form, including but not limited to compiled object code,
-generated documentation, and conversions to other media types.
+### Apache 2.0 (or MIT OR Apache-2.0)
+- `solidity/contracts/Mailbox.sol`
+- `solidity/contracts/interfaces/` (all)
+- `solidity/contracts/libs/`
+- `solidity/contracts/client/`
+- `solidity/contracts/isms/`
+- `solidity/contracts/hooks/`
+- `solidity/contracts/upgrade/`
+- `solidity/contracts/PackageVersioned.sol`
+- `solidity/contracts/token/HypERC20.sol`
+- `solidity/contracts/token/HypERC20Collateral.sol`
+- `solidity/contracts/token/HypERC721.sol`
+- `solidity/contracts/token/HypERC721Collateral.sol`
+- `solidity/contracts/token/HypNative.sol`
+- `solidity/contracts/token/libs/TokenRouter.sol`
+- `solidity/contracts/token/libs/TokenMessage.sol`
+- `rust/`
+- `typescript/sdk/`
+- `typescript/utils/`
 
-“Work” shall mean the work of authorship, whether in Source or Object form, made
-available under the License, as indicated by a copyright notice that is included
-in or attached to the work (an example is provided in the Appendix below).
-
-“Derivative Works” shall mean any work, whether in Source or Object form, that
-is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative Works
-shall not include works that remain separable from, or merely link (or bind by
-name) to the interfaces of, the Work and Derivative Works thereof.
-
-“Contribution” shall mean any work of authorship, including the original version
-of the Work and any modifications or additions to that Work or Derivative Works
-thereof, that is intentionally submitted to Licensor for inclusion in the Work
-by the copyright owner or by an individual or Legal Entity authorized to submit
-on behalf of the copyright owner. For the purposes of this definition,
-“submitted” means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems, and
-issue tracking systems that are managed by, or on behalf of, the Licensor for
-the purpose of discussing and improving the Work, but excluding communication
-that is conspicuously marked or otherwise designated in writing by the copyright
-owner as “Not a Contribution.”
-
-“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently
-incorporated within the Work.
-
-#### 2. Grant of Copyright License
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the Work and such
-Derivative Works in Source or Object form.
-
-#### 3. Grant of Patent License
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable (except as stated in this section) patent license to make, have
-made, use, offer to sell, sell, import, and otherwise transfer the Work, where
-such license applies only to those patent claims licensable by such Contributor
-that are necessarily infringed by their Contribution(s) alone or by combination
-of their Contribution(s) with the Work to which such Contribution(s) was
-submitted. If You institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work or a
-Contribution incorporated within the Work constitutes direct or contributory
-patent infringement, then any patent licenses granted to You under this License
-for that Work shall terminate as of the date such litigation is filed.
-
-#### 4. Redistribution
-
-You may reproduce and distribute copies of the Work or Derivative Works thereof
-in any medium, with or without modifications, and in Source or Object form,
-provided that You meet the following conditions:
-
-- **(a)** You must give any other recipients of the Work or Derivative Works a copy of
-  this License; and
-- **(b)** You must cause any modified files to carry prominent notices stating that You
-  changed the files; and
-- **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
-  all copyright, patent, trademark, and attribution notices from the Source form
-  of the Work, excluding those notices that do not pertain to any part of the
-  Derivative Works; and
-- **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
-  Derivative Works that You distribute must include a readable copy of the
-  attribution notices contained within such NOTICE file, excluding those notices
-  that do not pertain to any part of the Derivative Works, in at least one of the
-  following places: within a NOTICE text file distributed as part of the
-  Derivative Works; within the Source form or documentation, if provided along
-  with the Derivative Works; or, within a display generated by the Derivative
-  Works, if and wherever such third-party notices normally appear. The contents of
-  the NOTICE file are for informational purposes only and do not modify the
-  License. You may add Your own attribution notices within Derivative Works that
-  You distribute, alongside or as an addendum to the NOTICE text from the Work,
-  provided that such additional attribution notices cannot be construed as
-  modifying the License.
-
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction, or
-distribution of Your modifications, or for any such Derivative Works as a whole,
-provided Your use, reproduction, and distribution of the Work otherwise complies
-with the conditions stated in this License.
-
-#### 5. Submission of Contributions
-
-Unless You explicitly state otherwise, any Contribution intentionally submitted
-for inclusion in the Work by You to the Licensor shall be under the terms and
-conditions of this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify the terms of
-any separate license agreement you may have executed with Licensor regarding
-such Contributions.
-
-#### 6. Trademarks
-
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of the Licensor, except as required for
-reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-#### 7. Disclaimer of Warranty
-
-Unless required by applicable law or agreed to in writing, Licensor provides the
-Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
-including, without limitation, any warranties or conditions of TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
-solely responsible for determining the appropriateness of using or
-redistributing the Work and assume any risks associated with Your exercise of
-permissions under this License.
-
-#### 8. Limitation of Liability
-
-In no event and under no legal theory, whether in tort (including negligence),
-contract, or otherwise, unless required by applicable law (such as deliberate
-and grossly negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special, incidental,
-or consequential damages of any character arising as a result of this License or
-out of the use or inability to use the Work (including but not limited to
-damages for loss of goodwill, work stoppage, computer failure or malfunction, or
-any and all other commercial damages or losses), even if such Contributor has
-been advised of the possibility of such damages.
-
-#### 9. Accepting Warranty or Additional Liability
-
-While redistributing the Work or Derivative Works thereof, You may choose to
-offer, and charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this License. However,
-in accepting such obligations, You may act only on Your own behalf and on Your
-sole responsibility, not on behalf of any other Contributor, and only if You
-agree to indemnify, defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason of your
-accepting any such warranty or additional liability.
-
-_END OF TERMS AND CONDITIONS_
-
-### APPENDIX: How to apply the Apache License to your work
-
-To apply the Apache License to your work, attach the following boilerplate
-notice, with the fields enclosed by brackets `[]` replaced with your own
-identifying information. (Don't include the brackets!) The text should be
-enclosed in the appropriate comment syntax for the file format. We also
-recommend that a file or class name and description of purpose be included on
-the same “printed page” as the copyright notice for easier identification within
-third-party archives.
-
-    Copyright [yyyy] [name of copyright owner]
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+### BUSL-1.1
+- `solidity/contracts/token/TokenBridgeCctpBase.sol`
+- `solidity/contracts/token/TokenBridgeCctpV1.sol`
+- `solidity/contracts/token/TokenBridgeCctpV2.sol`
+- `solidity/contracts/token/extensions/` (all)
+- `solidity/contracts/token/libs/` (all files EXCEPT TokenRouter.sol and TokenMessage.sol)
+- `solidity/contracts/middleware/` (all)
+- `typescript/infra/`
+- `typescript/cli/`

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -21,6 +21,7 @@ Additional Use Grant and Change Date.
 ## Directory Breakdown
 
 ### Apache 2.0 (or MIT OR Apache-2.0)
+
 - `solidity/contracts/Mailbox.sol`
 - `solidity/contracts/interfaces/` (all)
 - `solidity/contracts/libs/`
@@ -41,6 +42,7 @@ Additional Use Grant and Change Date.
 - `typescript/utils/`
 
 ### BUSL-1.1
+
 - `solidity/contracts/token/TokenBridgeCctpBase.sol`
 - `solidity/contracts/token/TokenBridgeCctpV1.sol`
 - `solidity/contracts/token/TokenBridgeCctpV2.sol`

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Hyperlane
 
-[![GitHub Actions][gha-badge]][gha] [![codecov](https://codecov.io/gh/hyperlane-xyz/hyperlane-monorepo/branch/main/graph/badge.svg?token=APC7C3Q2GS)](https://codecov.io/gh/hyperlane-xyz/hyperlane-monorepo) [![Foundry][foundry-badge]][foundry] [![License: MIT][license-badge]][license]
+[![GitHub Actions][gha-badge]][gha] [![codecov](https://codecov.io/gh/hyperlane-xyz/hyperlane-monorepo/branch/main/graph/badge.svg?token=APC7C3Q2GS)](https://codecov.io/gh/hyperlane-xyz/hyperlane-monorepo) [![Foundry][foundry-badge]][foundry] [![License][license-badge]][license]
 
 [gha]: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions
 [gha-badge]: https://github.com/PaulRBerg/prb-math/actions/workflows/ci.yml/badge.svg
 [codecov-badge]: https://img.shields.io/codecov/c/github/hyperlane-xyz/hyperlane-monorepo
 [foundry]: https://getfoundry.sh/
 [foundry-badge]: https://img.shields.io/badge/Built%20with-Foundry-FFDB1C.svg
-[license]: https://www.apache.org/licenses/LICENSE-2.0
-[license-badge]: https://img.shields.io/badge/License-Apache-blue.svg
+[license]: ./LICENSE.md
+[license-badge]: https://img.shields.io/badge/License-Apache--2.0%20%7C%20BUSL--1.1-blue.svg
 
 ## Versioning
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "A pnpm workspace of core Hyperlane packages",
+  "license": "Apache-2.0 AND BUSL-1.1",
   "scripts": {
     "agent-configs": "pnpm -C typescript/infra update-agent-config:mainnet3 && pnpm -C typescript/infra update-agent-config:testnet4",
     "build": "turbo run build",


### PR DESCRIPTION
## Summary

Repo-level groundwork for the Apache-2.0 → BUSL-1.1 transition on commercial/product code. This PR only changes root-level license metadata; per-file SPDX headers are split into a follow-up PR.

- Adds `LICENSE-BUSL-1.1` (full text + parameters: Licensor = Abacus Works, Inc.; Change Date = four years from each release; Change License = Apache-2.0; Additional Use Grant limits Commercial Purpose competing with Hyperlane).
- Adds `LICENSE-APACHE-2.0` (existing Apache 2.0 text moved here).
- Rewrites `LICENSE.md` to describe the dual-license layout and per-directory breakdown.
- Updates the root `README.md` license badge to reflect dual licensing.
- Adds a `"license": "Apache-2.0 AND BUSL-1.1"` field to the root `package.json`.

## Scope split

This is PR 1 of 2:
1. **This PR** — root license files + repo-level metadata
2. **Follow-up PR** — per-file `SPDX-License-Identifier` header updates for the 26 commercial Solidity contracts (advanced token contracts, middleware, CCTP bridge, select token libs)

TypeScript (`infra/`, `cli/`) per-file headers are tracked separately and not included here.

This supersedes #8414, which bundled everything into one PR.

## What stays Apache-2.0

Core protocol: `Mailbox.sol`, `interfaces/`, `libs/`, `client/`, `isms/`, `hooks/`, `upgrade/`, `PackageVersioned.sol`, basic warp routes (`HypERC20`, `HypERC20Collateral`, `HypERC721`, `HypERC721Collateral`, `HypNative`, `TokenRouter`, `TokenMessage`), all of `rust/`, `typescript/sdk/`, `typescript/utils/`.

## What becomes BUSL-1.1

Advanced token contracts (ERC4626 variants, FiatToken, XERC20, CCTP bridges, extensions), all middleware (`InterchainAccountRouter`, `InterchainQueryRouter`), select token libs (`AmountPartition`, `LpCollateralRouter`, `MovableCollateralRouter`, `Quotes`, `TokenCollateral`), `typescript/infra/`, `typescript/cli/`.

## Test plan

- [ ] Verify `LICENSE.md` renders correctly on GitHub
- [ ] Verify `LICENSE-BUSL-1.1` and `LICENSE-APACHE-2.0` parameters are correct
- [ ] Confirm README badge renders
- [ ] CI passes (no source files changed in this PR)