### PR TITLE
chore(license): switch commercial Solidity contracts to BUSL-1.1

### DIFF
--- a/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/middleware/InterchainQueryRouter.sol
+++ b/solidity/contracts/middleware/InterchainQueryRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============

--- a/solidity/contracts/middleware/MinimalInterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/MinimalInterchainAccountRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/middleware/libs/Call.sol
+++ b/solidity/contracts/middleware/libs/Call.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {CallLib} from "./Call.sol";

--- a/solidity/contracts/middleware/libs/InterchainQueryMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainQueryMessage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 import {CallLib} from "./Call.sol";

--- a/solidity/contracts/middleware/libs/OwnableMulticall.sol
+++ b/solidity/contracts/middleware/libs/OwnableMulticall.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
 // ============ Internal Imports ============

--- a/solidity/contracts/token/TokenBridgeCctpBase.sol
+++ b/solidity/contracts/token/TokenBridgeCctpBase.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {TokenRouter} from "./libs/TokenRouter.sol";

--- a/solidity/contracts/token/TokenBridgeCctpV1.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV1.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {TokenBridgeCctpBase} from "./TokenBridgeCctpBase.sol";

--- a/solidity/contracts/token/TokenBridgeCctpV2.sol
+++ b/solidity/contracts/token/TokenBridgeCctpV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {TokenBridgeCctpBase} from "./TokenBridgeCctpBase.sol";

--- a/solidity/contracts/token/extensions/HypERC4626.sol
+++ b/solidity/contracts/token/extensions/HypERC4626.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/token/extensions/HypERC4626Collateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626Collateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol
+++ b/solidity/contracts/token/extensions/HypERC4626OwnerCollateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 /*@@@@@@@       @@@@@@@@@

--- a/solidity/contracts/token/extensions/HypERC721URICollateral.sol
+++ b/solidity/contracts/token/extensions/HypERC721URICollateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {HypERC721Collateral} from "../HypERC721Collateral.sol";

--- a/solidity/contracts/token/extensions/HypERC721URIStorage.sol
+++ b/solidity/contracts/token/extensions/HypERC721URIStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {HypERC721} from "../HypERC721.sol";

--- a/solidity/contracts/token/extensions/HypFiatToken.sol
+++ b/solidity/contracts/token/extensions/HypFiatToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IFiatToken} from "../interfaces/IFiatToken.sol";

--- a/solidity/contracts/token/extensions/HypXERC20.sol
+++ b/solidity/contracts/token/extensions/HypXERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IXERC20} from "../interfaces/IXERC20.sol";

--- a/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
+++ b/solidity/contracts/token/extensions/HypXERC20Lockbox.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IXERC20Lockbox} from "../interfaces/IXERC20Lockbox.sol";

--- a/solidity/contracts/token/extensions/OPL2ToL1TokenBridgeNative.sol
+++ b/solidity/contracts/token/extensions/OPL2ToL1TokenBridgeNative.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {HypNative} from "../../token/HypNative.sol";

--- a/solidity/contracts/token/extensions/WHypERC4626.sol
+++ b/solidity/contracts/token/extensions/WHypERC4626.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/solidity/contracts/token/libs/AmountPartition.sol
+++ b/solidity/contracts/token/libs/AmountPartition.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 // ============ External Imports ============

--- a/solidity/contracts/token/libs/LpCollateralRouter.sol
+++ b/solidity/contracts/token/libs/LpCollateralRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============

--- a/solidity/contracts/token/libs/MovableCollateralRouter.sol
+++ b/solidity/contracts/token/libs/MovableCollateralRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {ITokenBridge, Quote} from "../../interfaces/ITokenBridge.sol";

--- a/solidity/contracts/token/libs/Quotes.sol
+++ b/solidity/contracts/token/libs/Quotes.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {Quote} from "../../interfaces/ITokenBridge.sol";

--- a/solidity/contracts/token/libs/TokenCollateral.sol
+++ b/solidity/contracts/token/libs/TokenCollateral.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.8.0;
 
 import {IWETH} from "../interfaces/IWETH.sol";


### PR DESCRIPTION
## Summary

Updates the `SPDX-License-Identifier` header on 26 commercial Solidity contracts from `Apache-2.0` / `MIT OR Apache-2.0` / `MIT` to `BUSL-1.1`. No source logic changes.

Companion to #8804, which introduces the root `LICENSE-BUSL-1.1`, `LICENSE-APACHE-2.0`, and rewritten `LICENSE.md`. Either PR can land first; both must land together for SPDX identifiers to be valid against the repo root license set. Recommend reviewing #8804 first since it carries the license parameters (Licensor, Change Date, Additional Use Grant).

## What stays Apache-2.0 (untouched in this PR)

Core protocol — `Mailbox.sol`, `interfaces/`, `libs/`, `client/`, `isms/`, `hooks/`, `upgrade/`, `PackageVersioned.sol`. Basic warp routes — `HypERC20`, `HypERC20Collateral`, `HypERC721`, `HypERC721Collateral`, `HypNative`, `TokenRouter`, `TokenMessage`.

## What becomes BUSL-1.1 (this PR)

**Middleware (8 files)**
- `middleware/AbstractInterchainAccountRouter.sol`
- `middleware/InterchainAccountRouter.sol`
- `middleware/InterchainQueryRouter.sol`
- `middleware/MinimalInterchainAccountRouter.sol`
- `middleware/libs/Call.sol`
- `middleware/libs/InterchainAccountMessage.sol`
- `middleware/libs/InterchainQueryMessage.sol`
- `middleware/libs/OwnableMulticall.sol`

**CCTP token bridge (3 files)**
- `token/TokenBridgeCctpBase.sol`
- `token/TokenBridgeCctpV1.sol`
- `token/TokenBridgeCctpV2.sol`

**Advanced token extensions (10 files)**
- `token/extensions/HypERC4626.sol`
- `token/extensions/HypERC4626Collateral.sol`
- `token/extensions/HypERC4626OwnerCollateral.sol`
- `token/extensions/HypERC721URICollateral.sol`
- `token/extensions/HypERC721URIStorage.sol`
- `token/extensions/HypFiatToken.sol`
- `token/extensions/HypXERC20.sol`
- `token/extensions/HypXERC20Lockbox.sol`
- `token/extensions/OPL2ToL1TokenBridgeNative.sol`
- `token/extensions/WHypERC4626.sol`

**Select token libs (5 files)**
- `token/libs/AmountPartition.sol`
- `token/libs/LpCollateralRouter.sol`
- `token/libs/MovableCollateralRouter.sol`
- `token/libs/Quotes.sol`
- `token/libs/TokenCollateral.sol`

## Scope split

PR 2 of 2. PR 1 (#8804) handles repo-level license metadata. TypeScript per-file headers (`typescript/infra/`, `typescript/cli/`) are tracked separately and not included here.

This supersedes #8414, which bundled everything into one PR.

## Test plan

- [ ] CI passes — only license header lines changed, no logic
- [ ] Solidity build/test still passes (`pnpm -C solidity test`)
- [ ] SPDX identifiers parse cleanly against root `LICENSE-BUSL-1.1` once #8804 lands