### PR TITLE
fix: rate limit recipient

### DIFF
--- a/.changeset/shaggy-poems-battle.md
+++ b/.changeset/shaggy-poems-battle.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed rate limit return values to not include recipient anymore

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-ism-updates.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-ism-updates.e2e-test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 
+import { RateLimitedIsm__factory } from '@hyperlane-xyz/core';
 import { AltVM } from '@hyperlane-xyz/provider-sdk';
 import {
   type IsmConfig,
@@ -26,6 +27,7 @@ import {
   HYP_DEPLOYER_ADDRESS_BY_PROTOCOL,
   HYP_KEY_BY_PROTOCOL,
   REGISTRY_PATH,
+  TEST_CHAIN_METADATA_BY_PROTOCOL,
   TEST_CHAIN_NAMES_BY_PROTOCOL,
 } from '../../../constants.js';
 import { deployTestOffchainLookupISM } from '../../commands/helpers.js';
@@ -230,11 +232,21 @@ describe('hyperlane warp apply E2E (ISM updates)', async function () {
     );
 
     const ism = updatedConfig[chain2]
-      .interchainSecurityModule as RateLimitedIsmConfig;
+      .interchainSecurityModule as RateLimitedIsmConfig & { address: string };
     expect(ism).to.exist;
     expect(ism.type).to.equal(IsmType.RATE_LIMITED);
     expect(ism.maxCapacity).to.equal(maxCapacity);
-    expect(ism.recipient).to.not.be.undefined;
-    expect(ism.recipient!.toLowerCase()).to.equal(tokenAddress.toLowerCase());
+    // recipient is stripped from read() output — verify on-chain directly
+    expect(ism.address).to.not.be.undefined;
+    const chain2Metadata =
+      TEST_CHAIN_METADATA_BY_PROTOCOL.ethereum.CHAIN_NAME_2;
+    const provider = new ethers.providers.JsonRpcProvider(
+      chain2Metadata.rpcUrl,
+    );
+    const onChainRecipient = await RateLimitedIsm__factory.connect(
+      ism.address,
+      provider,
+    ).recipient();
+    expect(onChainRecipient.toLowerCase()).to.equal(tokenAddress.toLowerCase());
   });
 });

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy-2.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy-2.e2e-test.ts
@@ -731,9 +731,6 @@ describe('hyperlane warp deploy e2e tests', async function () {
       expect(ism).to.exist;
       expect(ism.type).to.equal(IsmType.RATE_LIMITED);
       expect(ism.maxCapacity).to.equal(maxCapacity);
-      expect(normalizeAddressEvm(ism.recipient!)).to.equal(
-        normalizeAddressEvm(syntheticTokenConfig!.addressOrDenom!),
-      );
     });
 
     it('should round down RateLimitedIsm maxCapacity to nearest multiple of 86400', () => {

--- a/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
@@ -129,6 +129,11 @@ describe('EvmIsmModule', async () => {
     const normalizedDerivedConfig = normalizeConfig(derivedConfiig);
     const normalizedConfig = normalizeConfig(testConfig);
 
+    // recipient is a deploy-time constructor arg not returned by read()
+    if (normalizedConfig.type === IsmType.RATE_LIMITED) {
+      delete normalizedConfig.recipient;
+    }
+
     assert.deepStrictEqual(normalizedDerivedConfig, normalizedConfig);
   });
 

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -147,11 +147,23 @@ export class EvmIsmModule extends HyperlaneModule<
     // Check if we need to deploy a new ISM
     //
     // Special case: RATE_LIMITED recipient is immutable — must redeploy if it changes.
-    const rateLimitedRecipientChanged =
+    // read() omits recipient (immutable constructor arg), so fetch on-chain to compare.
+    let rateLimitedRecipientChanged = false;
+    if (
       typeof normalizedCurrentConfig !== 'string' &&
       normalizedCurrentConfig.type === IsmType.RATE_LIMITED &&
       normalizedTargetConfig.type === IsmType.RATE_LIMITED &&
-      normalizedCurrentConfig.recipient !== normalizedTargetConfig.recipient;
+      normalizedTargetConfig.recipient !== undefined
+    ) {
+      const onChainRecipient = (
+        await RateLimitedIsm__factory.connect(
+          this.args.addresses.deployedIsm,
+          this.multiProvider.getProvider(this.chain),
+        ).recipient()
+      ).toLowerCase();
+      rateLimitedRecipientChanged =
+        onChainRecipient !== normalizedTargetConfig.recipient;
+    }
     if (
       rateLimitedRecipientChanged ||
       typeof normalizedCurrentConfig === 'string' ||

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -660,7 +660,7 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
       this.provider,
     );
     try {
-      await rateLimitedIsm.recipient();
+      await rateLimitedIsm.recipient(); // probe selector only; recipient is a constructor arg omitted from read()
       const maxCapacity = (await rateLimitedIsm.maxCapacity()).toString();
       const owner = await rateLimitedIsm.owner();
       return {

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -660,13 +660,12 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
       this.provider,
     );
     try {
-      const recipient = await rateLimitedIsm.recipient();
+      await rateLimitedIsm.recipient();
       const maxCapacity = (await rateLimitedIsm.maxCapacity()).toString();
       const owner = await rateLimitedIsm.owner();
       return {
         address,
         type: IsmType.RATE_LIMITED,
-        recipient,
         maxCapacity,
         owner,
       };


### PR DESCRIPTION
### Description

Do not return unnecessary `recipient` field for rate limit isms during warp reards

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
