### PR TITLE
fix: set from address in estimateCallGas for newer chains

### DIFF
--- a/typescript/sdk/src/middleware/account/InterchainAccount.test.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.test.ts
@@ -364,6 +364,7 @@ describe('InterchainAccount.estimateIcaHandleGas', () => {
 
     // Stub getProvider after app creation to avoid affecting constructor
     sandbox.stub(multiProvider, 'getProvider').returns(mockProvider as any);
+    sandbox.stub(multiProvider, 'getSignerAddress').resolves(randomAddress());
   });
 
   afterEach(() => {

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -278,6 +278,12 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
 
     try {
       const provider = this.multiProvider.getProvider(destination);
+      let from: string | undefined;
+      try {
+        from = await this.multiProvider.getSignerAddress(destination);
+      } catch {
+        // Signer not available — estimate without from (works on older chains)
+      }
       const individualEstimates = await Promise.all(
         formattedCalls.map((call) =>
           estimateCallGas({
@@ -285,6 +291,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
             to: bytes32ToAddress(call.to),
             data: call.data,
             value: call.value,
+            from,
           }),
         ),
       );

--- a/typescript/sdk/src/utils/gas.ts
+++ b/typescript/sdk/src/utils/gas.ts
@@ -18,6 +18,7 @@ export interface EstimateCallGasParams {
   to: Address;
   data: string;
   value?: BigNumber;
+  from?: Address;
   fallback?: BigNumber;
 }
 
@@ -55,6 +56,7 @@ export async function estimateCallGas(
       to: params.to,
       data: params.data,
       value: params.value,
+      from: params.from,
     });
   } catch {
     return fallback;


### PR DESCRIPTION
## Summary
- Adds optional `from` parameter to `estimateCallGas()` in `gas.ts`, passed through to `provider.estimateGas()`
- Updates `InterchainAccount.estimateIcaHandleGas()` to pass signer address when available
- On newer chains (e.g. Citrea), `eth_estimateGas` fails with "Not enough funds for L1 fee" when `from` is not set because the zero address has no balance

## Fixes
Closes #4585

## Test plan
- [ ] Verify `estimateCallGas` passes `from` to provider
- [ ] Verify ICA handle gas estimation works on chains requiring non-zero sender
- [ ] Unit tests pass: `pnpm -C typescript/sdk test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)