### PR TITLE
fix(sdk): max transfer simulation and fee estimation for native token routes

### DIFF
--- a/.changeset/chilled-camels-look.md
+++ b/.changeset/chilled-camels-look.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed max transfer simulation for nexus

--- a/.changeset/chilled-camels-look.md
+++ b/.changeset/chilled-camels-look.md
@@ -1,5 +1,0 @@
----
-"@hyperlane-xyz/sdk": patch
----
-
-Fixed max transfer simulation for nexus

--- a/.changeset/yellow-apricots-deliver.md
+++ b/.changeset/yellow-apricots-deliver.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed max transfer simulation by providing a minimum amount

--- a/.changeset/yellow-apricots-deliver.md
+++ b/.changeset/yellow-apricots-deliver.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/sdk": patch
 ---
 
-Fixed max transfer simulation by providing a minimum amount
+Fixed max transfer simulation and fee display for native-token warp routes by reverting to the minimal-amount fallback in getLocalTransferFee for non-predicate flows.

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -1558,4 +1558,181 @@ describe('WarpCore', () => {
     stubs.forEach((s) => s.restore());
     adapterStubs.forEach((s) => s.restore());
   });
+
+  describe('estimateTransferRemoteFees / estimateCrossCollateralFees attestation gating', () => {
+    // Regression: amount must only be forwarded to getLocalTransferFeeAmount when attestation is present.
+    // Without this gate, simulating large balances on native routes causes eth_estimateGas failures.
+
+    it('does not forward amount to getLocalTransferFeeAmount when no attestation', async () => {
+      const interchainFeeStub = sinon
+        .stub(warpCore as any, 'getInterchainTransferFee')
+        .resolves({
+          igpQuote: evmHypNative.amount(20_000n),
+          tokenFeeQuote: undefined,
+        });
+      const localFeeStub = sinon
+        .stub(warpCore as any, 'getLocalTransferFeeAmount')
+        .resolves(evmHypNative.amount(200_000n));
+
+      try {
+        await warpCore.estimateTransferRemoteFees({
+          originTokenAmount: evmHypNative.amount(MOCK_BALANCE),
+          destination: test2.name,
+          sender: MOCK_ADDRESS,
+          recipient: MOCK_ADDRESS,
+        });
+
+        sinon.assert.calledOnce(localFeeStub);
+        const localFeeArgs = localFeeStub.firstCall.args[0];
+        expect(localFeeArgs.amount).to.be.undefined;
+      } finally {
+        interchainFeeStub.restore();
+        localFeeStub.restore();
+      }
+    });
+
+    it('forwards amount to getLocalTransferFeeAmount when attestation is present', async () => {
+      const mockAttestation = { signature: '0xdeadbeef' } as any;
+      const interchainFeeStub = sinon
+        .stub(warpCore as any, 'getInterchainTransferFee')
+        .resolves({
+          igpQuote: evmHypNative.amount(20_000n),
+          tokenFeeQuote: undefined,
+        });
+      const localFeeStub = sinon
+        .stub(warpCore as any, 'getLocalTransferFeeAmount')
+        .resolves(evmHypNative.amount(200_000n));
+
+      try {
+        await warpCore.estimateTransferRemoteFees({
+          originTokenAmount: evmHypNative.amount(MOCK_BALANCE),
+          destination: test2.name,
+          sender: MOCK_ADDRESS,
+          recipient: MOCK_ADDRESS,
+          attestation: mockAttestation,
+        });
+
+        sinon.assert.calledOnce(localFeeStub);
+        const localFeeArgs = localFeeStub.firstCall.args[0];
+        expect(localFeeArgs.amount).to.equal(MOCK_BALANCE);
+      } finally {
+        interchainFeeStub.restore();
+        localFeeStub.restore();
+      }
+    });
+
+    it('does not forward amount in estimateCrossCollateralFees without attestation', async () => {
+      const originCrossStub = sinon
+        .stub(evmHypNative, 'isCrossCollateralToken')
+        .returns(true);
+      const destCrossStub = sinon
+        .stub(evmHypSynthetic, 'isCrossCollateralToken')
+        .returns(true);
+      const interchainFeeStub = sinon
+        .stub(warpCore as any, 'getInterchainTransferFee')
+        .resolves({
+          igpQuote: evmHypNative.amount(20_000n),
+          tokenFeeQuote: undefined,
+        });
+      const localFeeStub = sinon
+        .stub(warpCore as any, 'getLocalTransferFeeAmount')
+        .resolves(evmHypNative.amount(200_000n));
+
+      try {
+        await warpCore.estimateTransferRemoteFees({
+          originTokenAmount: evmHypNative.amount(MOCK_BALANCE),
+          destination: test2.name,
+          sender: MOCK_ADDRESS,
+          recipient: MOCK_ADDRESS,
+          destinationToken: evmHypSynthetic,
+        });
+
+        sinon.assert.calledOnce(localFeeStub);
+        const localFeeArgs = localFeeStub.firstCall.args[0];
+        expect(localFeeArgs.amount).to.be.undefined;
+      } finally {
+        originCrossStub.restore();
+        destCrossStub.restore();
+        interchainFeeStub.restore();
+        localFeeStub.restore();
+      }
+    });
+  });
+
+  describe('getMaxTransferAmount fee calculation', () => {
+    // Regression: getInterchainTransferFee must receive the full balance (for percentage-based fees),
+    // and getLocalTransferFeeAmount must receive no amount (to avoid eth_estimateGas failures on
+    // native routes where the full balance leaves nothing to cover gas).
+
+    it('calls getInterchainTransferFee with full balance and getLocalTransferFeeAmount with no amount', async () => {
+      const interchainFeeStub = sinon
+        .stub(warpCore as any, 'getInterchainTransferFee')
+        .resolves({
+          igpQuote: evmHypNative.amount(20_000n),
+          tokenFeeQuote: undefined,
+        });
+      const localFeeStub = sinon
+        .stub(warpCore as any, 'getLocalTransferFeeAmount')
+        .resolves(evmHypNative.amount(200_000n));
+
+      try {
+        const balance = evmHypNative.amount(MOCK_BALANCE);
+        await warpCore.getMaxTransferAmount({
+          balance,
+          destination: test2.name,
+          sender: MOCK_ADDRESS,
+          recipient: MOCK_ADDRESS,
+        });
+
+        // First call: fee calculation pass with full balance
+        sinon.assert.calledWithMatch(interchainFeeStub.firstCall, {
+          originTokenAmount: sinon.match(
+            (v: TokenAmount) => v.amount === MOCK_BALANCE,
+          ),
+        });
+
+        // getLocalTransferFeeAmount called without amount
+        sinon.assert.calledOnce(localFeeStub);
+        const localFeeArgs = localFeeStub.firstCall.args[0];
+        expect(localFeeArgs.amount).to.be.undefined;
+      } finally {
+        interchainFeeStub.restore();
+        localFeeStub.restore();
+      }
+    });
+
+    it('skips fee calculation and uses provided feeEstimate', async () => {
+      const interchainFeeStub = sinon.stub(
+        warpCore as any,
+        'getInterchainTransferFee',
+      );
+      const localFeeStub = sinon.stub(
+        warpCore as any,
+        'getLocalTransferFeeAmount',
+      );
+
+      try {
+        const balance = evmHypNative.amount(MOCK_BALANCE);
+        const feeEstimate = {
+          interchainQuote: evmHypNative.amount(20_000n),
+          localQuote: evmHypNative.amount(200_000n),
+          tokenFeeQuote: undefined,
+        };
+        const result = await warpCore.getMaxTransferAmount({
+          balance,
+          destination: test2.name,
+          sender: MOCK_ADDRESS,
+          recipient: MOCK_ADDRESS,
+          feeEstimate,
+        });
+
+        sinon.assert.notCalled(interchainFeeStub);
+        sinon.assert.notCalled(localFeeStub);
+        expect(result.amount).to.equal(MOCK_BALANCE - 20_000n - 200_000n);
+      } finally {
+        interchainFeeStub.restore();
+        localFeeStub.restore();
+      }
+    });
+  });
 });

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -1154,7 +1154,11 @@ export class WarpCore {
       interchainFee: igpQuote,
       tokenFeeQuote,
       attestation,
-      amount: originTokenAmount.amount,
+      // Only pass amount for predicate flows — it feeds the attested msg_value into
+      // eth_estimateGas. For non-predicate flows, let getLocalTransferFee use its
+      // minimal-amount fallback so simulation doesn't fail on large balances or
+      // placeholder senders (e.g. 0x...dead) that have no ETH.
+      amount: attestation ? originTokenAmount.amount : undefined,
     });
 
     return {
@@ -1208,7 +1212,7 @@ export class WarpCore {
       interchainFee: interchainQuote,
       tokenFeeQuote,
       attestation,
-      amount: originTokenAmount.amount,
+      amount: attestation ? originTokenAmount.amount : undefined,
       destinationToken: resolvedDestinationToken,
     });
 
@@ -1243,14 +1247,29 @@ export class WarpCore {
     const originToken = balance.token;
 
     if (!feeEstimate) {
-      feeEstimate = await this.estimateTransferRemoteFees({
-        originTokenAmount: balance,
+      // Get IGP and token fee quotes using the full balance so amount-dependent fees
+      // (e.g. percentage-based token fees) are correctly computed and subtracted.
+      const { igpQuote: interchainQuote, tokenFeeQuote } =
+        await this.getInterchainTransferFee({
+          originTokenAmount: balance,
+          destination,
+          recipient,
+          sender,
+          destinationToken,
+        });
+      // Estimate local gas with no amount so getLocalTransferFee uses its minimal-amount
+      // fallback — avoids eth_estimateGas failures on native token routes where simulating
+      // the full balance leaves nothing to cover gas.
+      const localQuote = await this.getLocalTransferFeeAmount({
+        originToken,
         destination,
-        recipient,
         sender,
         senderPubKey,
+        interchainFee: interchainQuote,
+        tokenFeeQuote,
         destinationToken,
       });
+      feeEstimate = { interchainQuote, localQuote, tokenFeeQuote };
     }
     const { localQuote, interchainQuote, tokenFeeQuote } = feeEstimate;
 


### PR DESCRIPTION
## Summary

SDK v35 added `amount: originTokenAmount.amount` to `getLocalTransferFeeAmount` calls inside `estimateTransferRemoteFees` and `estimateCrossCollateralFees` to support predicate attestation flows (which need the real transfer amount to match the attested `msg_value`). This introduced two regressions for non-predicate routes:

- **Max button broken**: `getMaxTransferAmount` called `estimateTransferRemoteFees` with the full wallet balance. For native token routes, `eth_estimateGas` runs with `value = full_balance + IGP_fee`, leaving nothing for gas — simulation fails.
- **Fee display broken**: The fallback sender (`0x...dead`, used when the real sender's fee quote fails) has no ETH. With a non-zero `value` in the gas estimation tx, `eth_estimateGas` always fails for this address on routes with ETH-valued IGP fees.

## Changes

**`estimateTransferRemoteFees` / `estimateCrossCollateralFees`**: Only pass `amount` to `getLocalTransferFeeAmount` when an `attestation` is present. For non-predicate flows, `amount: undefined` causes `getLocalTransferFee` to use its existing minimal-amount fallback (`10^(originDecimals - destDecimals)`), avoiding the full-balance simulation failure.

**`getMaxTransferAmount`**: Replaced the internal `estimateTransferRemoteFees(minimalAmount)` call with two separate calls:
1. `getInterchainTransferFee(balance)` — uses the full balance so amount-dependent fees (e.g. percentage-based token fees like Everclear) are correctly computed. A minimal amount would round these to zero, causing the token fee to not be subtracted from the max, which then fails `validateTransfer`'s balance check.
2. `getLocalTransferFeeAmount` with no `amount` — falls back to the minimal-amount estimation, avoiding the simulation failure.

## Test plan

- [x] Max button on native token routes fills correctly and passes validation
- [x] Fee display is stable when connected sender has insufficient balance (fallback to `0x...dead` no longer throws)
- [x] Routes with percentage-based token fees (Everclear) compute correct max transfer amount
- [x] Predicate routes unaffected — `attestation` presence still passes real amount to gas estimation

🤖 Generated with [Claude Code](https://claude.com/claude-code)