### PR TITLE
fix(infra): decode CCR/Oft/DepositAddr/RoutingHook/Ism safe txs

### DIFF
--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -219,6 +219,18 @@ function summarizeError(error: unknown): string {
   return 'unknown error';
 }
 
+function matchesFunctionSignature(
+  decoded: ethers.utils.TransactionDescription,
+  iface: ethers.utils.Interface,
+  signature: string,
+): boolean {
+  try {
+    return decoded.sighash === iface.getSighash(signature);
+  } catch {
+    return false;
+  }
+}
+
 export class GovernTransactionReader {
   errors: any[] = [];
 
@@ -1051,6 +1063,14 @@ export class GovernTransactionReader {
     );
   }
 
+  private formatDomain(domain: number | BigNumber): string {
+    const domainNumber = BigNumber.isBigNumber(domain)
+      ? domain.toNumber()
+      : domain;
+    const chainName = this.multiProvider.tryGetChainName(domainNumber);
+    return chainName ? `${domainNumber} (${chainName})` : `${domainNumber}`;
+  }
+
   private async readWarpModuleTransaction(
     chain: ChainName,
     tx: AnnotatedEV5Transaction,
@@ -1145,20 +1165,32 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['setDestinationGas((uint32,uint256)[])']
-        .name
+      matchesFunctionSignature(
+        decoded,
+        tokenRouterInterface,
+        'setDestinationGas((uint32,uint256)[])',
+      )
     ) {
       const [gasConfigs] = decoded.args;
       const insights = gasConfigs.map(
         (config: { domain: number; gas: BigNumber }) => {
-          const chainName = this.multiProvider.getChainName(config.domain);
-          return `domain ${
-            config.domain
-          } (${chainName}) to ${config.gas.toString()}`;
+          return `domain ${this.formatDomain(config.domain)} to ${config.gas.toString()}`;
         },
       );
       insight = `Set destination gas for ${insights.join(', ')}`;
+    }
+
+    if (
+      matchesFunctionSignature(
+        decoded,
+        tokenRouterInterface,
+        'setDestinationGas(uint32,uint256)',
+      )
+    ) {
+      const [domain, gas] = decoded.args;
+      insight = `Set destination gas for domain ${this.formatDomain(
+        domain,
+      )} to ${gas.toString()}`;
     }
 
     if (
@@ -1255,8 +1287,11 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      cctpV2Interface.functions['setMaxFeePpm(uint256)'].name
+      matchesFunctionSignature(
+        decoded,
+        cctpV2Interface,
+        'setMaxFeePpm(uint256)',
+      )
     ) {
       const [maxFeePpm] = decoded.args;
       const bps = BigNumber.from(maxFeePpm).toNumber() / 100;
@@ -1264,9 +1299,11 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      ccrInterface.functions['enrollCrossCollateralRouters(uint32[],bytes32[])']
-        .name
+      matchesFunctionSignature(
+        decoded,
+        ccrInterface,
+        'enrollCrossCollateralRouters(uint32[],bytes32[])',
+      )
     ) {
       const [domains, routers] = decoded.args;
       const insights = domains.map((domain: number, index: number) => {
@@ -1277,10 +1314,11 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      ccrInterface.functions[
-        'unenrollCrossCollateralRouters(uint32[],bytes32[])'
-      ].name
+      matchesFunctionSignature(
+        decoded,
+        ccrInterface,
+        'unenrollCrossCollateralRouters(uint32[],bytes32[])',
+      )
     ) {
       const [domains, routers] = decoded.args;
       const insights = domains.map((domain: number, index: number) => {
@@ -1291,8 +1329,11 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      oftInterface.functions['addDomain(uint32,uint32)'].name
+      matchesFunctionSignature(
+        decoded,
+        oftInterface,
+        'addDomain(uint32,uint32)',
+      )
     ) {
       const [hypDomain, lzEid] = decoded.args;
       const chainName = this.multiProvider.tryGetChainName(hypDomain);
@@ -1300,8 +1341,7 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      oftInterface.functions['removeDomain(uint32)'].name
+      matchesFunctionSignature(decoded, oftInterface, 'removeDomain(uint32)')
     ) {
       const [hypDomain] = decoded.args;
       const chainName = this.multiProvider.tryGetChainName(hypDomain);
@@ -1309,18 +1349,18 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      oftInterface.functions['setExtraOptions(bytes)'].name
+      matchesFunctionSignature(decoded, oftInterface, 'setExtraOptions(bytes)')
     ) {
       const [options] = decoded.args;
       insight = `Set LayerZero extraOptions to ${options}`;
     }
 
     if (
-      decoded.functionFragment.name ===
-      depositAddrInterface.functions[
-        'addDestinationConfig(uint32,address,bytes32,uint256)'
-      ].name
+      matchesFunctionSignature(
+        decoded,
+        depositAddrInterface,
+        'addDestinationConfig(uint32,address,bytes32,uint256)',
+      )
     ) {
       const [destination, depositAddress, recipient, feeBps] = decoded.args;
       const chainName = this.multiProvider.tryGetChainName(destination);
@@ -1328,9 +1368,11 @@ export class GovernTransactionReader {
     }
 
     if (
-      decoded.functionFragment.name ===
-      depositAddrInterface.functions['removeDestinationConfig(uint32,bytes32)']
-        .name
+      matchesFunctionSignature(
+        decoded,
+        depositAddrInterface,
+        'removeDestinationConfig(uint32,bytes32)',
+      )
     ) {
       const [destination, recipient] = decoded.args;
       const chainName = this.multiProvider.tryGetChainName(destination);
@@ -1467,73 +1509,179 @@ export class GovernTransactionReader {
     movableIface: ethers.utils.Interface,
     decoded: ethers.utils.TransactionDescription,
   ): string {
-    const name = decoded.functionFragment.name;
     const args = decoded.args;
-    const fmtDomain = (d: number) => {
-      const cn = this.multiProvider.tryGetChainName(d);
-      return cn ? `${d} (${cn})` : `${d}`;
-    };
 
-    switch (name) {
-      case 'addBridge':
-        return `Set bridge for origin domain ${fmtDomain(args[0])} to ${args[1]}`;
-      case 'removeBridge':
-        return `Remove bridge ${args[1]} from domain ${fmtDomain(args[0])}`;
-      case 'enrollRemoteRouter':
-        return `Enroll remote router for domain ${fmtDomain(args[0])} to ${args[1]}`;
-      case 'enrollRemoteRouters': {
-        const [domains, routers] = args;
-        const lines = domains.map(
-          (d: number, i: number) => `domain ${fmtDomain(d)} to ${routers[i]}`,
-        );
-        return `Enroll remote routers for ${lines.join(', ')}`;
-      }
-      case 'unenrollRemoteRouter':
-        return `Unenroll remote router for domain ${fmtDomain(args[0])}`;
-      case 'unenrollRemoteRouters': {
-        const lines = args[0].map((d: number) => `domain ${fmtDomain(d)}`);
-        return `Unenroll remote routers for ${lines.join(', ')}`;
-      }
-      case 'setDestinationGas': {
-        const lines = args[0].map(
-          (c: { domain: number; gas: BigNumber }) =>
-            `domain ${fmtDomain(c.domain)} to ${c.gas.toString()}`,
-        );
-        return `Set destination gas for ${lines.join(', ')}`;
-      }
-      case 'setHook':
-        return `Set hook to ${args[0]}`;
-      case 'setInterchainSecurityModule':
-        return `Set ISM to ${args[0]}`;
-      case 'setFeeRecipient':
-        return `Set fee recipient to ${args[0]}`;
-      case 'addRebalancer':
-        return `Add rebalancer ${args[0]}`;
-      case 'removeRebalancer':
-        return `Remove rebalancer ${args[0]}`;
-      case 'setRecipient':
-        return `Set rebalance recipient for domain ${fmtDomain(args[0])} to ${args[1]}`;
-      case 'removeRecipient':
-        return `Remove rebalance recipient for domain ${fmtDomain(args[0])}`;
-      case 'approveTokenForBridge':
-        return `Approve token ${args[0]} for bridge ${args[1]}`;
-      case 'enrollCrossCollateralRouters': {
-        const [domains, routers] = args;
-        const lines = domains.map(
-          (d: number, i: number) => `domain ${fmtDomain(d)} to ${routers[i]}`,
-        );
-        return `Enroll cross-collateral routers for ${lines.join(', ')}`;
-      }
-      case 'unenrollCrossCollateralRouters': {
-        const [domains, routers] = args;
-        const lines = domains.map(
-          (d: number, i: number) => `domain ${fmtDomain(d)} from ${routers[i]}`,
-        );
-        return `Unenroll cross-collateral routers for ${lines.join(', ')}`;
-      }
-      default:
-        return `Call ${decoded.signature}`;
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'addBridge(uint32,address)',
+      )
+    ) {
+      return `Set bridge for origin domain ${this.formatDomain(args[0])} to ${args[1]}`;
     }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'removeBridge(uint32,address)',
+      )
+    ) {
+      return `Remove bridge ${args[1]} from domain ${this.formatDomain(args[0])}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'enrollRemoteRouter(uint32,bytes32)',
+      )
+    ) {
+      return `Enroll remote router for domain ${this.formatDomain(args[0])} to ${args[1]}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'enrollRemoteRouters(uint32[],bytes32[])',
+      )
+    ) {
+      const [domains, routers] = args;
+      const lines = domains.map(
+        (d: number, i: number) =>
+          `domain ${this.formatDomain(d)} to ${routers[i]}`,
+      );
+      return `Enroll remote routers for ${lines.join(', ')}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'unenrollRemoteRouter(uint32)',
+      )
+    ) {
+      return `Unenroll remote router for domain ${this.formatDomain(args[0])}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'unenrollRemoteRouters(uint32[])',
+      )
+    ) {
+      const lines = args[0].map(
+        (d: number) => `domain ${this.formatDomain(d)}`,
+      );
+      return `Unenroll remote routers for ${lines.join(', ')}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'setDestinationGas((uint32,uint256)[])',
+      )
+    ) {
+      const lines = args[0].map(
+        (c: { domain: number; gas: BigNumber }) =>
+          `domain ${this.formatDomain(c.domain)} to ${c.gas.toString()}`,
+      );
+      return `Set destination gas for ${lines.join(', ')}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'setDestinationGas(uint32,uint256)',
+      )
+    ) {
+      return `Set destination gas for domain ${this.formatDomain(args[0])} to ${args[1].toString()}`;
+    }
+    if (matchesFunctionSignature(decoded, movableIface, 'setHook(address)')) {
+      return `Set hook to ${args[0]}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'setInterchainSecurityModule(address)',
+      )
+    ) {
+      return `Set ISM to ${args[0]}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'setFeeRecipient(address)',
+      )
+    ) {
+      return `Set fee recipient to ${args[0]}`;
+    }
+    if (
+      matchesFunctionSignature(decoded, movableIface, 'addRebalancer(address)')
+    ) {
+      return `Add rebalancer ${args[0]}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'removeRebalancer(address)',
+      )
+    ) {
+      return `Remove rebalancer ${args[0]}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'setRecipient(uint32,bytes32)',
+      )
+    ) {
+      return `Set rebalance recipient for domain ${this.formatDomain(args[0])} to ${args[1]}`;
+    }
+    if (
+      matchesFunctionSignature(decoded, movableIface, 'removeRecipient(uint32)')
+    ) {
+      return `Remove rebalance recipient for domain ${this.formatDomain(args[0])}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        movableIface,
+        'approveTokenForBridge(address,address)',
+      )
+    ) {
+      return `Approve token ${args[0]} for bridge ${args[1]}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        ccrIface,
+        'enrollCrossCollateralRouters(uint32[],bytes32[])',
+      )
+    ) {
+      const [domains, routers] = args;
+      const lines = domains.map(
+        (d: number, i: number) =>
+          `domain ${this.formatDomain(d)} to ${routers[i]}`,
+      );
+      return `Enroll cross-collateral routers for ${lines.join(', ')}`;
+    }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        ccrIface,
+        'unenrollCrossCollateralRouters(uint32[],bytes32[])',
+      )
+    ) {
+      const [domains, routers] = args;
+      const lines = domains.map(
+        (d: number, i: number) =>
+          `domain ${this.formatDomain(d)} from ${routers[i]}`,
+      );
+      return `Unenroll cross-collateral routers for ${lines.join(', ')}`;
+    }
+    return `Call ${decoded.signature}`;
   }
 
   private formatTokenBridgeOftInsight(
@@ -1541,20 +1689,16 @@ export class GovernTransactionReader {
     decoded: ethers.utils.TransactionDescription,
   ): string {
     const args = decoded.args;
-    const fmtDomain = (d: number) => {
-      const cn = this.multiProvider.tryGetChainName(d);
-      return cn ? `${d} (${cn})` : `${d}`;
-    };
-    switch (decoded.functionFragment.name) {
-      case 'addDomain':
-        return `Map Hyperlane domain ${fmtDomain(args[0])} to LayerZero EID ${args[1]}`;
-      case 'removeDomain':
-        return `Remove Hyperlane domain ${fmtDomain(args[0])} mapping`;
-      case 'setExtraOptions':
-        return `Set extra LayerZero options`;
-      default:
-        return `Call ${decoded.signature}`;
+    if (matchesFunctionSignature(decoded, iface, 'addDomain(uint32,uint32)')) {
+      return `Map Hyperlane domain ${this.formatDomain(args[0])} to LayerZero EID ${args[1]}`;
     }
+    if (matchesFunctionSignature(decoded, iface, 'removeDomain(uint32)')) {
+      return `Remove Hyperlane domain ${this.formatDomain(args[0])} mapping`;
+    }
+    if (matchesFunctionSignature(decoded, iface, 'setExtraOptions(bytes)')) {
+      return `Set extra LayerZero options`;
+    }
+    return `Call ${decoded.signature}`;
   }
 
   private formatTokenBridgeDepositAddressInsight(
@@ -1562,18 +1706,25 @@ export class GovernTransactionReader {
     decoded: ethers.utils.TransactionDescription,
   ): string {
     const args = decoded.args;
-    const fmtDomain = (d: number) => {
-      const cn = this.multiProvider.tryGetChainName(d);
-      return cn ? `${d} (${cn})` : `${d}`;
-    };
-    switch (decoded.functionFragment.name) {
-      case 'addDestinationConfig':
-        return `Add destination config: domain ${fmtDomain(args[0])}, depositAddress ${args[1]}, recipient ${args[2]}, feeBps ${args[3].toString()}`;
-      case 'removeDestinationConfig':
-        return `Remove destination config: domain ${fmtDomain(args[0])}, recipient ${args[1]}`;
-      default:
-        return `Call ${decoded.signature}`;
+    if (
+      matchesFunctionSignature(
+        decoded,
+        iface,
+        'addDestinationConfig(uint32,address,bytes32,uint256)',
+      )
+    ) {
+      return `Add destination config: domain ${this.formatDomain(args[0])}, depositAddress ${args[1]}, recipient ${args[2]}, feeBps ${args[3].toString()}`;
     }
+    if (
+      matchesFunctionSignature(
+        decoded,
+        iface,
+        'removeDestinationConfig(uint32,bytes32)',
+      )
+    ) {
+      return `Remove destination config: domain ${this.formatDomain(args[0])}, recipient ${args[1]}`;
+    }
+    return `Call ${decoded.signature}`;
   }
 
   private formatCrossCollateralRoutingFeeInsight(
@@ -1581,24 +1732,24 @@ export class GovernTransactionReader {
     decoded: ethers.utils.TransactionDescription,
   ): string {
     const args = decoded.args;
-    const fmtDomain = (d: number) => {
-      const cn = this.multiProvider.tryGetChainName(d);
-      return cn ? `${d} (${cn})` : `${d}`;
-    };
-    switch (decoded.functionFragment.name) {
-      case 'setCrossCollateralRouterFeeContracts': {
-        const [destinations, targetRouters, feeContracts] = args;
-        const lines = destinations.map(
-          (d: number, i: number) =>
-            `domain ${fmtDomain(d)} router ${targetRouters[i]} → fee ${feeContracts[i]}`,
-        );
-        return `Set per-router fee contracts: ${lines.join(', ')}`;
-      }
-      case 'claim':
-        return `Claim ${args[1]} balance to ${args[0]}`;
-      default:
-        return `Call ${decoded.signature}`;
+    if (
+      matchesFunctionSignature(
+        decoded,
+        iface,
+        'setCrossCollateralRouterFeeContracts(uint32[],bytes32[],address[])',
+      )
+    ) {
+      const [destinations, targetRouters, feeContracts] = args;
+      const lines = destinations.map(
+        (d: number, i: number) =>
+          `domain ${this.formatDomain(d)} router ${targetRouters[i]} → fee ${feeContracts[i]}`,
+      );
+      return `Set per-router fee contracts: ${lines.join(', ')}`;
     }
+    if (matchesFunctionSignature(decoded, iface, 'claim(address,address)')) {
+      return `Claim ${args[1]} balance to ${args[0]}`;
+    }
+    return `Call ${decoded.signature}`;
   }
 
   private formatDomainRoutingHookInsight(
@@ -1606,23 +1757,22 @@ export class GovernTransactionReader {
     decoded: ethers.utils.TransactionDescription,
   ): string {
     const args = decoded.args;
-    const fmtDomain = (d: number) => {
-      const cn = this.multiProvider.tryGetChainName(d);
-      return cn ? `${d} (${cn})` : `${d}`;
-    };
-    switch (decoded.functionFragment.name) {
-      case 'setHook':
-        return `Set hook for destination ${fmtDomain(args[0])} to ${args[1]}`;
-      case 'setHooks': {
-        const lines = args[0].map(
-          (cfg: { destination: number; hook: string }) =>
-            `destination ${fmtDomain(cfg.destination)} → ${cfg.hook}`,
-        );
-        return `Set hooks: ${lines.join(', ')}`;
-      }
-      default:
-        return `Call ${decoded.signature}`;
+    if (matchesFunctionSignature(decoded, iface, 'setHook(uint32,address)')) {
+      return `Set hook for destination ${this.formatDomain(args[0])} to ${args[1]}`;
     }
+    if (matchesFunctionSignature(decoded, iface, 'setHook(address)')) {
+      return `Set mailbox client hook to ${args[0]}`;
+    }
+    if (
+      matchesFunctionSignature(decoded, iface, 'setHooks((uint32,address)[])')
+    ) {
+      const lines = args[0].map(
+        (cfg: { destination: number; hook: string }) =>
+          `destination ${this.formatDomain(cfg.destination)} → ${cfg.hook}`,
+      );
+      return `Set hooks: ${lines.join(', ')}`;
+    }
+    return `Call ${decoded.signature}`;
   }
 
   private formatDomainRoutingIsmInsight(
@@ -1630,18 +1780,13 @@ export class GovernTransactionReader {
     decoded: ethers.utils.TransactionDescription,
   ): string {
     const args = decoded.args;
-    const fmtDomain = (d: number) => {
-      const cn = this.multiProvider.tryGetChainName(d);
-      return cn ? `${d} (${cn})` : `${d}`;
-    };
-    switch (decoded.functionFragment.name) {
-      case 'set':
-        return `Set ISM for origin ${fmtDomain(args[0])} to ${args[1]}`;
-      case 'remove':
-        return `Remove ISM for origin ${fmtDomain(args[0])}`;
-      default:
-        return `Call ${decoded.signature}`;
+    if (matchesFunctionSignature(decoded, iface, 'set(uint32,address)')) {
+      return `Set ISM for origin ${this.formatDomain(args[0])} to ${args[1]}`;
     }
+    if (matchesFunctionSignature(decoded, iface, 'remove(uint32)')) {
+      return `Remove ISM for origin ${this.formatDomain(args[0])}`;
+    }
+    return `Call ${decoded.signature}`;
   }
 
   /**

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -13,6 +13,10 @@ import { BigNumber, ethers } from 'ethers';
 
 import {
   BaseFee__factory,
+  CrossCollateralRouter__factory,
+  CrossCollateralRoutingFee__factory,
+  DomainRoutingHook__factory,
+  DomainRoutingIsm__factory,
   ERC20__factory,
   HypXERC20Lockbox__factory,
   IXERC20VS__factory,
@@ -20,6 +24,8 @@ import {
   MovableCollateralRouter__factory,
   Ownable__factory,
   TokenBridgeCctpV2__factory,
+  TokenBridgeDepositAddress__factory,
+  TokenBridgeOft__factory,
   ProxyAdmin__factory,
   RoutingFee__factory,
   TimelockController__factory,
@@ -187,59 +193,6 @@ async function parseHookMetadataWithInsight(
     refundAddress,
     insight,
   };
-}
-
-// Ethers.js error codes that are unambiguously transient RPC/transport failures
-const TRANSIENT_RPC_ERROR_CODES = new Set([
-  'SERVER_ERROR',
-  'NETWORK_ERROR',
-  'TIMEOUT',
-]);
-
-/**
- * Returns true only for transient RPC/transport errors that are safe to swallow.
- * CALL_EXCEPTION with revert data or JSON-RPC code 3 indicates a real contract
- * revert (permanent) and is NOT treated as transient — mirroring the distinction
- * in SmartProvider.
- */
-function isRpcOrTransportError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const code = (error as any).code;
-    if (typeof code === 'string') {
-      if (TRANSIENT_RPC_ERROR_CODES.has(code)) return true;
-      // CALL_EXCEPTION: only transient when there's no revert data and no
-      // JSON-RPC error code 3 (which definitively indicates a contract revert)
-      if (code === 'CALL_EXCEPTION') {
-        const data = (error as any).data;
-        const hasRevertData = !!data && data !== '0x' && data !== '';
-        const nestedError = (error as any).error;
-        const jsonRpcErrorCode = nestedError?.error?.code ?? nestedError?.code;
-        const isJsonRpcRevert = jsonRpcErrorCode === 3;
-        const isEmptyReturnDecodeFailure = !hasRevertData && !nestedError;
-        // Real reverts (with data, JSON-RPC code 3, or decode failures) are permanent
-        if (hasRevertData || isJsonRpcRevert || isEmptyReturnDecodeFailure)
-          return false;
-        // No revert data and not a JSON-RPC revert → likely transient RPC issue
-        return true;
-      }
-    }
-    // Common transport-layer patterns
-    if (/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|fetch failed/i.test(error.message))
-      return true;
-  }
-  return false;
-}
-
-function isAbiDecodingError(error: unknown): boolean {
-  if (
-    error instanceof Error &&
-    'code' in error &&
-    (error as { code: string }).code === 'INVALID_ARGUMENT' &&
-    error.message.includes('sighash')
-  ) {
-    return true;
-  }
-  return false;
 }
 
 // Patterns that may contain secrets in ethers.js RPC error messages
@@ -476,6 +429,17 @@ export class GovernTransactionReader {
     // If it's a fee contract transaction
     if (await this.isFeeTransaction(chain, tx)) {
       return this.readFeeTransaction(chain, tx);
+    }
+
+    // Try to decode against known Hyperlane contract ABIs by selector before
+    // falling back to bytecode-pattern matchers. Covers contracts not yet
+    // registered (new warp routes, standalone routing hooks/ISMs, token bridge
+    // adapters, cross-collateral routing fees, etc.). Placed before
+    // isProxyAdminTransaction since its bytecode check can false-positive on
+    // contracts that happen to embed all required selectors.
+    const knownContractDecode = this.tryReadByKnownContractInterface(chain, tx);
+    if (knownContractDecode) {
+      return knownContractDecode;
     }
 
     // If it's to a Proxy Admin
@@ -1098,19 +1062,42 @@ export class GovernTransactionReader {
     const { symbol } = await this.multiProvider.getNativeToken(chain);
     const tokenRouterInterface =
       MovableCollateralRouter__factory.createInterface();
+    const ccrInterface = CrossCollateralRouter__factory.createInterface();
     const cctpV2Interface = TokenBridgeCctpV2__factory.createInterface();
+    const oftInterface = TokenBridgeOft__factory.createInterface();
+    const depositAddrInterface =
+      TokenBridgeDepositAddress__factory.createInterface();
 
-    let decoded;
-    try {
-      decoded = tokenRouterInterface.parseTransaction({
-        data: tx.data,
-        value: tx.value,
-      });
-    } catch {
-      decoded = cctpV2Interface.parseTransaction({
-        data: tx.data,
-        value: tx.value,
-      });
+    // Try each interface; some registry-listed contracts are bridge adapters
+    // (TokenBridgeOft, TokenBridgeDepositAddress) rather than full Routers.
+    const parseAttempts: Array<() => ethers.utils.TransactionDescription> = [
+      () =>
+        tokenRouterInterface.parseTransaction({
+          data: tx.data!,
+          value: tx.value,
+        }),
+      () => ccrInterface.parseTransaction({ data: tx.data!, value: tx.value }),
+      () =>
+        cctpV2Interface.parseTransaction({ data: tx.data!, value: tx.value }),
+      () => oftInterface.parseTransaction({ data: tx.data!, value: tx.value }),
+      () =>
+        depositAddrInterface.parseTransaction({
+          data: tx.data!,
+          value: tx.value,
+        }),
+    ];
+    let decoded: ethers.utils.TransactionDescription | undefined;
+    let lastError: unknown;
+    for (const attempt of parseAttempts) {
+      try {
+        decoded = attempt();
+        break;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    if (!decoded) {
+      throw lastError;
     }
 
     let insight: string | undefined;
@@ -1276,6 +1263,80 @@ export class GovernTransactionReader {
       insight = `Set max fee to ${maxFeePpm} ppm (${bps} bps)`;
     }
 
+    if (
+      decoded.functionFragment.name ===
+      ccrInterface.functions['enrollCrossCollateralRouters(uint32[],bytes32[])']
+        .name
+    ) {
+      const [domains, routers] = decoded.args;
+      const insights = domains.map((domain: number, index: number) => {
+        const chainName = this.multiProvider.tryGetChainName(domain);
+        return `domain ${domain}${chainName ? ` (${chainName})` : ''} to ${routers[index]}`;
+      });
+      insight = `Enroll cross-collateral routers for ${insights.join(', ')}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      ccrInterface.functions[
+        'unenrollCrossCollateralRouters(uint32[],bytes32[])'
+      ].name
+    ) {
+      const [domains, routers] = decoded.args;
+      const insights = domains.map((domain: number, index: number) => {
+        const chainName = this.multiProvider.tryGetChainName(domain);
+        return `domain ${domain}${chainName ? ` (${chainName})` : ''} from ${routers[index]}`;
+      });
+      insight = `Unenroll cross-collateral routers for ${insights.join(', ')}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      oftInterface.functions['addDomain(uint32,uint32)'].name
+    ) {
+      const [hypDomain, lzEid] = decoded.args;
+      const chainName = this.multiProvider.tryGetChainName(hypDomain);
+      insight = `Map Hyperlane domain ${hypDomain}${chainName ? ` (${chainName})` : ''} to LayerZero EID ${lzEid}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      oftInterface.functions['removeDomain(uint32)'].name
+    ) {
+      const [hypDomain] = decoded.args;
+      const chainName = this.multiProvider.tryGetChainName(hypDomain);
+      insight = `Remove Hyperlane domain ${hypDomain}${chainName ? ` (${chainName})` : ''} mapping`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      oftInterface.functions['setExtraOptions(bytes)'].name
+    ) {
+      const [options] = decoded.args;
+      insight = `Set LayerZero extraOptions to ${options}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      depositAddrInterface.functions[
+        'addDestinationConfig(uint32,address,bytes32,uint256)'
+      ].name
+    ) {
+      const [destination, depositAddress, recipient, feeBps] = decoded.args;
+      const chainName = this.multiProvider.tryGetChainName(destination);
+      insight = `Add destination config: domain ${destination}${chainName ? ` (${chainName})` : ''}, depositAddress ${depositAddress}, recipient ${recipient}, feeBps ${feeBps.toString()}`;
+    }
+
+    if (
+      decoded.functionFragment.name ===
+      depositAddrInterface.functions['removeDestinationConfig(uint32,bytes32)']
+        .name
+    ) {
+      const [destination, recipient] = decoded.args;
+      const chainName = this.multiProvider.tryGetChainName(destination);
+      insight = `Remove destination config: domain ${destination}${chainName ? ` (${chainName})` : ''}, recipient ${recipient}`;
+    }
+
     let ownableTx = {};
     if (!insight) {
       ownableTx = await this.readOwnableTransaction(chain, tx);
@@ -1294,6 +1355,293 @@ export class GovernTransactionReader {
       signature: decoded.signature,
       ...(feeDetails && { feeDetails }),
     };
+  }
+
+  /**
+   * Selector-based fallback for known Hyperlane contract types that may not be
+   * present in the warp route registry (e.g. newly-deployed warp routes,
+   * standalone routing hooks/ISMs, token bridge adapters, cross-collateral
+   * routing fee contracts). Returns undefined if no interface matches.
+   */
+  private tryReadByKnownContractInterface(
+    chain: ChainName,
+    tx: AnnotatedEV5Transaction,
+  ): GovernTransaction | undefined {
+    if (!tx.data || tx.data.length < 10 || !tx.to) return undefined;
+
+    const tryParse = (iface: ethers.utils.Interface) => {
+      try {
+        return iface.parseTransaction({ data: tx.data!, value: tx.value });
+      } catch {
+        return undefined;
+      }
+    };
+
+    const formatBase = (
+      contractType: string,
+      decoded: ethers.utils.TransactionDescription,
+      insight: string,
+    ) => ({
+      chain,
+      to: `${contractType} (${chain} ${tx.to})`,
+      insight,
+      signature: decoded.signature,
+    });
+
+    // CrossCollateralRouter / MovableCollateralRouter (TokenRouter base) - newly
+    // deployed warp routes not yet in the registry.
+    const ccrIface = CrossCollateralRouter__factory.createInterface();
+    const movableIface = MovableCollateralRouter__factory.createInterface();
+    const ccrDecoded = tryParse(ccrIface) ?? tryParse(movableIface);
+    if (ccrDecoded) {
+      const insight = this.formatRouterCallInsight(
+        ccrIface,
+        movableIface,
+        ccrDecoded,
+      );
+      return formatBase('Warp Route (unregistered)', ccrDecoded, insight);
+    }
+
+    // TokenBridgeOft adapter (LayerZero OFT bridge for warp routes).
+    const oftIface = TokenBridgeOft__factory.createInterface();
+    const oftDecoded = tryParse(oftIface);
+    if (oftDecoded) {
+      const insight = this.formatTokenBridgeOftInsight(oftIface, oftDecoded);
+      return formatBase('TokenBridgeOft', oftDecoded, insight);
+    }
+
+    // TokenBridgeDepositAddress adapter (deposit-address-based bridges).
+    const depositAddrIface =
+      TokenBridgeDepositAddress__factory.createInterface();
+    const depositAddrDecoded = tryParse(depositAddrIface);
+    if (depositAddrDecoded) {
+      const insight = this.formatTokenBridgeDepositAddressInsight(
+        depositAddrIface,
+        depositAddrDecoded,
+      );
+      return formatBase(
+        'TokenBridgeDepositAddress',
+        depositAddrDecoded,
+        insight,
+      );
+    }
+
+    // CrossCollateralRoutingFee - per-router fee contract routing.
+    const ccrFeeIface = CrossCollateralRoutingFee__factory.createInterface();
+    const ccrFeeDecoded = tryParse(ccrFeeIface);
+    if (ccrFeeDecoded) {
+      const insight = this.formatCrossCollateralRoutingFeeInsight(
+        ccrFeeIface,
+        ccrFeeDecoded,
+      );
+      return formatBase('CrossCollateralRoutingFee', ccrFeeDecoded, insight);
+    }
+
+    // DomainRoutingHook.setHook / setHooks
+    const routingHookIface = DomainRoutingHook__factory.createInterface();
+    const routingHookDecoded = tryParse(routingHookIface);
+    if (routingHookDecoded) {
+      const insight = this.formatDomainRoutingHookInsight(
+        routingHookIface,
+        routingHookDecoded,
+      );
+      return formatBase('DomainRoutingHook', routingHookDecoded, insight);
+    }
+
+    // DomainRoutingIsm.set / remove
+    const routingIsmIface = DomainRoutingIsm__factory.createInterface();
+    const routingIsmDecoded = tryParse(routingIsmIface);
+    if (routingIsmDecoded) {
+      const insight = this.formatDomainRoutingIsmInsight(
+        routingIsmIface,
+        routingIsmDecoded,
+      );
+      return formatBase('DomainRoutingIsm', routingIsmDecoded, insight);
+    }
+
+    return undefined;
+  }
+
+  private formatRouterCallInsight(
+    ccrIface: ethers.utils.Interface,
+    movableIface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string {
+    const name = decoded.functionFragment.name;
+    const args = decoded.args;
+    const fmtDomain = (d: number) => {
+      const cn = this.multiProvider.tryGetChainName(d);
+      return cn ? `${d} (${cn})` : `${d}`;
+    };
+
+    switch (name) {
+      case 'addBridge':
+        return `Set bridge for origin domain ${fmtDomain(args[0])} to ${args[1]}`;
+      case 'removeBridge':
+        return `Remove bridge ${args[1]} from domain ${fmtDomain(args[0])}`;
+      case 'enrollRemoteRouter':
+        return `Enroll remote router for domain ${fmtDomain(args[0])} to ${args[1]}`;
+      case 'enrollRemoteRouters': {
+        const [domains, routers] = args;
+        const lines = domains.map(
+          (d: number, i: number) => `domain ${fmtDomain(d)} to ${routers[i]}`,
+        );
+        return `Enroll remote routers for ${lines.join(', ')}`;
+      }
+      case 'unenrollRemoteRouter':
+        return `Unenroll remote router for domain ${fmtDomain(args[0])}`;
+      case 'unenrollRemoteRouters': {
+        const lines = args[0].map((d: number) => `domain ${fmtDomain(d)}`);
+        return `Unenroll remote routers for ${lines.join(', ')}`;
+      }
+      case 'setDestinationGas': {
+        const lines = args[0].map(
+          (c: { domain: number; gas: BigNumber }) =>
+            `domain ${fmtDomain(c.domain)} to ${c.gas.toString()}`,
+        );
+        return `Set destination gas for ${lines.join(', ')}`;
+      }
+      case 'setHook':
+        return `Set hook to ${args[0]}`;
+      case 'setInterchainSecurityModule':
+        return `Set ISM to ${args[0]}`;
+      case 'setFeeRecipient':
+        return `Set fee recipient to ${args[0]}`;
+      case 'addRebalancer':
+        return `Add rebalancer ${args[0]}`;
+      case 'removeRebalancer':
+        return `Remove rebalancer ${args[0]}`;
+      case 'setRecipient':
+        return `Set rebalance recipient for domain ${fmtDomain(args[0])} to ${args[1]}`;
+      case 'removeRecipient':
+        return `Remove rebalance recipient for domain ${fmtDomain(args[0])}`;
+      case 'approveTokenForBridge':
+        return `Approve token ${args[0]} for bridge ${args[1]}`;
+      case 'enrollCrossCollateralRouters': {
+        const [domains, routers] = args;
+        const lines = domains.map(
+          (d: number, i: number) => `domain ${fmtDomain(d)} to ${routers[i]}`,
+        );
+        return `Enroll cross-collateral routers for ${lines.join(', ')}`;
+      }
+      case 'unenrollCrossCollateralRouters': {
+        const [domains, routers] = args;
+        const lines = domains.map(
+          (d: number, i: number) => `domain ${fmtDomain(d)} from ${routers[i]}`,
+        );
+        return `Unenroll cross-collateral routers for ${lines.join(', ')}`;
+      }
+      default:
+        return `Call ${decoded.signature}`;
+    }
+  }
+
+  private formatTokenBridgeOftInsight(
+    iface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string {
+    const args = decoded.args;
+    const fmtDomain = (d: number) => {
+      const cn = this.multiProvider.tryGetChainName(d);
+      return cn ? `${d} (${cn})` : `${d}`;
+    };
+    switch (decoded.functionFragment.name) {
+      case 'addDomain':
+        return `Map Hyperlane domain ${fmtDomain(args[0])} to LayerZero EID ${args[1]}`;
+      case 'removeDomain':
+        return `Remove Hyperlane domain ${fmtDomain(args[0])} mapping`;
+      case 'setExtraOptions':
+        return `Set extra LayerZero options`;
+      default:
+        return `Call ${decoded.signature}`;
+    }
+  }
+
+  private formatTokenBridgeDepositAddressInsight(
+    iface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string {
+    const args = decoded.args;
+    const fmtDomain = (d: number) => {
+      const cn = this.multiProvider.tryGetChainName(d);
+      return cn ? `${d} (${cn})` : `${d}`;
+    };
+    switch (decoded.functionFragment.name) {
+      case 'addDestinationConfig':
+        return `Add destination config: domain ${fmtDomain(args[0])}, depositAddress ${args[1]}, recipient ${args[2]}, feeBps ${args[3].toString()}`;
+      case 'removeDestinationConfig':
+        return `Remove destination config: domain ${fmtDomain(args[0])}, recipient ${args[1]}`;
+      default:
+        return `Call ${decoded.signature}`;
+    }
+  }
+
+  private formatCrossCollateralRoutingFeeInsight(
+    iface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string {
+    const args = decoded.args;
+    const fmtDomain = (d: number) => {
+      const cn = this.multiProvider.tryGetChainName(d);
+      return cn ? `${d} (${cn})` : `${d}`;
+    };
+    switch (decoded.functionFragment.name) {
+      case 'setCrossCollateralRouterFeeContracts': {
+        const [destinations, targetRouters, feeContracts] = args;
+        const lines = destinations.map(
+          (d: number, i: number) =>
+            `domain ${fmtDomain(d)} router ${targetRouters[i]} → fee ${feeContracts[i]}`,
+        );
+        return `Set per-router fee contracts: ${lines.join(', ')}`;
+      }
+      case 'claim':
+        return `Claim ${args[1]} balance to ${args[0]}`;
+      default:
+        return `Call ${decoded.signature}`;
+    }
+  }
+
+  private formatDomainRoutingHookInsight(
+    iface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string {
+    const args = decoded.args;
+    const fmtDomain = (d: number) => {
+      const cn = this.multiProvider.tryGetChainName(d);
+      return cn ? `${d} (${cn})` : `${d}`;
+    };
+    switch (decoded.functionFragment.name) {
+      case 'setHook':
+        return `Set hook for destination ${fmtDomain(args[0])} to ${args[1]}`;
+      case 'setHooks': {
+        const lines = args[0].map(
+          (cfg: { destination: number; hook: string }) =>
+            `destination ${fmtDomain(cfg.destination)} → ${cfg.hook}`,
+        );
+        return `Set hooks: ${lines.join(', ')}`;
+      }
+      default:
+        return `Call ${decoded.signature}`;
+    }
+  }
+
+  private formatDomainRoutingIsmInsight(
+    iface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string {
+    const args = decoded.args;
+    const fmtDomain = (d: number) => {
+      const cn = this.multiProvider.tryGetChainName(d);
+      return cn ? `${d} (${cn})` : `${d}`;
+    };
+    switch (decoded.functionFragment.name) {
+      case 'set':
+        return `Set ISM for origin ${fmtDomain(args[0])} to ${args[1]}`;
+      case 'remove':
+        return `Remove ISM for origin ${fmtDomain(args[0])}`;
+      default:
+        return `Call ${decoded.signature}`;
+    }
   }
 
   /**
@@ -1894,15 +2242,12 @@ export class GovernTransactionReader {
         }
       }
     } catch (error: unknown) {
-      if (!isRpcOrTransportError(error)) {
-        throw error;
-      }
       this.logger.warn(
         `Failed to derive ICA address for ${remoteChainName}, using expected address: ${summarizeError(error)}`,
       );
       remoteIcaAddress =
         expectedRemoteIcaAddress ?? expectedLegacyRemoteIcaAddress;
-      remoteIcaInsight = `⚠️ could not verify ICA (RPC error on ${remoteChainName})`;
+      remoteIcaInsight = `⚠️ could not verify ICA on ${remoteChainName} (${summarizeError(error)})`;
     }
 
     const decodedCalls = await Promise.all(
@@ -1915,15 +2260,12 @@ export class GovernTransactionReader {
         try {
           return await this.read(remoteChainName, icaCallAsTx);
         } catch (error: unknown) {
-          if (!isRpcOrTransportError(error)) {
-            throw error;
-          }
           this.logger.warn(
             `Failed to decode ICA call to ${icaCallAsTx.to} on ${remoteChainName}: ${summarizeError(error)}`,
           );
           return {
             chain: remoteChainName,
-            insight: `⚠️ could not decode call (RPC error on ${remoteChainName})`,
+            insight: `⚠️ failed to decode (${summarizeError(error)})`,
             to: icaCallAsTx.to,
             data: call[2],
           };
@@ -1983,9 +2325,6 @@ export class GovernTransactionReader {
             decoded,
           };
         } catch (error: unknown) {
-          if (!isRpcOrTransportError(error) && !isAbiDecodingError(error)) {
-            throw error;
-          }
           this.logger.warn(
             `Failed to decode multisend at index ${index}: ${summarizeError(error)}`,
           );

--- a/typescript/infra/src/tx/govern-transaction-reader.ts
+++ b/typescript/infra/src/tx/govern-transaction-reader.ts
@@ -224,11 +224,12 @@ function matchesFunctionSignature(
   iface: ethers.utils.Interface,
   signature: string,
 ): boolean {
-  try {
-    return decoded.sighash === iface.getSighash(signature);
-  } catch {
-    return false;
-  }
+  const fragment = iface.functions[signature];
+  assert(
+    fragment,
+    `matchesFunctionSignature: signature not found in interface: ${signature}`,
+  );
+  return decoded.sighash === iface.getSighash(fragment);
 }
 
 export class GovernTransactionReader {
@@ -1080,159 +1081,53 @@ export class GovernTransactionReader {
     }
 
     const { symbol } = await this.multiProvider.getNativeToken(chain);
-    const tokenRouterInterface =
-      MovableCollateralRouter__factory.createInterface();
-    const ccrInterface = CrossCollateralRouter__factory.createInterface();
-    const cctpV2Interface = TokenBridgeCctpV2__factory.createInterface();
-    const oftInterface = TokenBridgeOft__factory.createInterface();
-    const depositAddrInterface =
+    const movableIface = MovableCollateralRouter__factory.createInterface();
+    const ccrIface = CrossCollateralRouter__factory.createInterface();
+    const cctpV2Iface = TokenBridgeCctpV2__factory.createInterface();
+    const oftIface = TokenBridgeOft__factory.createInterface();
+    const depositAddrIface =
       TokenBridgeDepositAddress__factory.createInterface();
 
     // Try each interface; some registry-listed contracts are bridge adapters
     // (TokenBridgeOft, TokenBridgeDepositAddress) rather than full Routers.
-    const parseAttempts: Array<() => ethers.utils.TransactionDescription> = [
-      () =>
-        tokenRouterInterface.parseTransaction({
-          data: tx.data!,
-          value: tx.value,
-        }),
-      () => ccrInterface.parseTransaction({ data: tx.data!, value: tx.value }),
-      () =>
-        cctpV2Interface.parseTransaction({ data: tx.data!, value: tx.value }),
-      () => oftInterface.parseTransaction({ data: tx.data!, value: tx.value }),
-      () =>
-        depositAddrInterface.parseTransaction({
-          data: tx.data!,
-          value: tx.value,
-        }),
+    // Keep the first error for re-throw so the most-likely-relevant decode
+    // failure is surfaced rather than the last attempt's error.
+    const parseAttempts: ethers.utils.Interface[] = [
+      movableIface,
+      ccrIface,
+      cctpV2Iface,
+      oftIface,
+      depositAddrIface,
     ];
+
     let decoded: ethers.utils.TransactionDescription | undefined;
-    let lastError: unknown;
-    for (const attempt of parseAttempts) {
+    let firstError: unknown;
+    for (const iface of parseAttempts) {
       try {
-        decoded = attempt();
+        decoded = iface.parseTransaction({ data: tx.data, value: tx.value });
         break;
       } catch (err) {
-        lastError = err;
+        if (firstError === undefined) firstError = err;
       }
     }
     if (!decoded) {
-      throw lastError;
+      throw firstError;
     }
 
     let insight: string | undefined;
     let feeDetails: Record<string, any> | undefined;
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['setHook(address)'].name
-    ) {
-      const [hookAddress] = decoded.args;
-      insight = `Set hook to ${hookAddress}`;
-    }
 
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['addBridge(uint32,address)'].name
-    ) {
-      const [domain, bridgeAddress] = decoded.args;
-      insight = `Set bridge for origin domain ${domain} to ${bridgeAddress}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['removeBridge(uint32,address)'].name
-    ) {
-      const [domain, bridgeAddress] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(domain);
-      insight = `Remove bridge ${bridgeAddress} from domain ${domain}${chainName ? ` (${chainName})` : ''}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['addRebalancer(address)'].name
-    ) {
-      const [rebalancer] = decoded.args;
-      insight = `Add rebalancer ${rebalancer}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['setInterchainSecurityModule(address)']
-        .name
-    ) {
-      const [ismAddress] = decoded.args;
-      insight = `Set ISM to ${ismAddress}`;
-    }
-
+    // setFeeRecipient is special: it reads the fee contract on-chain to
+    // produce a richer insight, so it cannot be served by the sync format
+    // helpers below.
     if (
       matchesFunctionSignature(
         decoded,
-        tokenRouterInterface,
-        'setDestinationGas((uint32,uint256)[])',
+        movableIface,
+        'setFeeRecipient(address)',
       )
-    ) {
-      const [gasConfigs] = decoded.args;
-      const insights = gasConfigs.map(
-        (config: { domain: number; gas: BigNumber }) => {
-          return `domain ${this.formatDomain(config.domain)} to ${config.gas.toString()}`;
-        },
-      );
-      insight = `Set destination gas for ${insights.join(', ')}`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        tokenRouterInterface,
-        'setDestinationGas(uint32,uint256)',
-      )
-    ) {
-      const [domain, gas] = decoded.args;
-      insight = `Set destination gas for domain ${this.formatDomain(
-        domain,
-      )} to ${gas.toString()}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['enrollRemoteRouters(uint32[],bytes32[])']
-        .name
-    ) {
-      const [domains, routers] = decoded.args;
-      const insights = domains.map((domain: number, index: number) => {
-        const chainName = this.multiProvider.getChainName(domain);
-        return `domain ${domain} (${chainName}) to ${routers[index]}`;
-      });
-      insight = `Enroll remote routers for ${insights.join(', ')}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['unenrollRemoteRouter(uint32)'].name
-    ) {
-      const [domain] = decoded.args;
-      const chainName = this.multiProvider.getChainName(domain);
-      insight = `Unenroll remote router for domain ${domain} (${chainName})`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['unenrollRemoteRouters(uint32[])'].name
-    ) {
-      const [domains] = decoded.args;
-      const insights = domains.map((domain: number) => {
-        const chainName = this.multiProvider.getChainName(domain);
-        return `domain ${domain} (${chainName})`;
-      });
-      insight = `Unenroll remote routers for ${insights.join(', ')}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['setFeeRecipient(address)'].name
     ) {
       const [recipient] = decoded.args;
-      // Read fee contract details (handles address(0), non-fee contracts gracefully)
       const feeInfo = await this.readFeeContractDetails(
         chain,
         tx.to!,
@@ -1240,143 +1135,18 @@ export class GovernTransactionReader {
       );
       insight = feeInfo.insight;
       feeDetails = feeInfo.feeDetails;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['removeRebalancer(address)'].name
-    ) {
-      const [rebalancer] = decoded.args;
-      insight = `Remove rebalancer ${rebalancer}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['setRecipient(uint32,bytes32)'].name
-    ) {
-      const [domain, recipient] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(domain);
-      insight = `Set rebalance recipient for domain ${domain}${chainName ? ` (${chainName})` : ''} to ${recipient}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['removeRecipient(uint32)'].name
-    ) {
-      const [domain] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(domain);
-      insight = `Remove rebalance recipient for domain ${domain}${chainName ? ` (${chainName})` : ''}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['approveTokenForBridge(address,address)']
-        .name
-    ) {
-      const [token, bridge] = decoded.args;
-      insight = `Approve token ${token} for bridge ${bridge}`;
-    }
-
-    if (
-      decoded.functionFragment.name ===
-      tokenRouterInterface.functions['enrollRemoteRouter(uint32,bytes32)'].name
-    ) {
-      const [domain, router] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(domain);
-      insight = `Enroll remote router for domain ${domain}${chainName ? ` (${chainName})` : ''} to ${router}`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        cctpV2Interface,
-        'setMaxFeePpm(uint256)',
-      )
-    ) {
-      const [maxFeePpm] = decoded.args;
-      const bps = BigNumber.from(maxFeePpm).toNumber() / 100;
-      insight = `Set max fee to ${maxFeePpm} ppm (${bps} bps)`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        ccrInterface,
-        'enrollCrossCollateralRouters(uint32[],bytes32[])',
-      )
-    ) {
-      const [domains, routers] = decoded.args;
-      const insights = domains.map((domain: number, index: number) => {
-        const chainName = this.multiProvider.tryGetChainName(domain);
-        return `domain ${domain}${chainName ? ` (${chainName})` : ''} to ${routers[index]}`;
-      });
-      insight = `Enroll cross-collateral routers for ${insights.join(', ')}`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        ccrInterface,
-        'unenrollCrossCollateralRouters(uint32[],bytes32[])',
-      )
-    ) {
-      const [domains, routers] = decoded.args;
-      const insights = domains.map((domain: number, index: number) => {
-        const chainName = this.multiProvider.tryGetChainName(domain);
-        return `domain ${domain}${chainName ? ` (${chainName})` : ''} from ${routers[index]}`;
-      });
-      insight = `Unenroll cross-collateral routers for ${insights.join(', ')}`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        oftInterface,
-        'addDomain(uint32,uint32)',
-      )
-    ) {
-      const [hypDomain, lzEid] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(hypDomain);
-      insight = `Map Hyperlane domain ${hypDomain}${chainName ? ` (${chainName})` : ''} to LayerZero EID ${lzEid}`;
-    }
-
-    if (
-      matchesFunctionSignature(decoded, oftInterface, 'removeDomain(uint32)')
-    ) {
-      const [hypDomain] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(hypDomain);
-      insight = `Remove Hyperlane domain ${hypDomain}${chainName ? ` (${chainName})` : ''} mapping`;
-    }
-
-    if (
-      matchesFunctionSignature(decoded, oftInterface, 'setExtraOptions(bytes)')
-    ) {
-      const [options] = decoded.args;
-      insight = `Set LayerZero extraOptions to ${options}`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        depositAddrInterface,
-        'addDestinationConfig(uint32,address,bytes32,uint256)',
-      )
-    ) {
-      const [destination, depositAddress, recipient, feeBps] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(destination);
-      insight = `Add destination config: domain ${destination}${chainName ? ` (${chainName})` : ''}, depositAddress ${depositAddress}, recipient ${recipient}, feeBps ${feeBps.toString()}`;
-    }
-
-    if (
-      matchesFunctionSignature(
-        decoded,
-        depositAddrInterface,
-        'removeDestinationConfig(uint32,bytes32)',
-      )
-    ) {
-      const [destination, recipient] = decoded.args;
-      const chainName = this.multiProvider.tryGetChainName(destination);
-      insight = `Remove destination config: domain ${destination}${chainName ? ` (${chainName})` : ''}, recipient ${recipient}`;
+    } else {
+      // Selector collisions exist between adapter ifaces (e.g. addDomain is in
+      // both cctpV2 and oft). Try every helper and take the first that
+      // recognises the sighash, regardless of which iface decoded.
+      insight =
+        this.formatRouterCallInsight(
+          { ccr: ccrIface, movable: movableIface },
+          decoded,
+        ) ??
+        this.formatTokenBridgeCctpV2Insight(cctpV2Iface, decoded) ??
+        this.formatTokenBridgeOftInsight(oftIface, decoded) ??
+        this.formatTokenBridgeDepositAddressInsight(depositAddrIface, decoded);
     }
 
     let ownableTx = {};
@@ -1430,25 +1200,42 @@ export class GovernTransactionReader {
       signature: decoded.signature,
     });
 
-    // CrossCollateralRouter / MovableCollateralRouter (TokenRouter base) - newly
-    // deployed warp routes not yet in the registry.
+    const fallback = (decoded: ethers.utils.TransactionDescription) =>
+      `Call ${decoded.signature}`;
+
+    // CrossCollateralRouter / MovableCollateralRouter (TokenRouter base) -
+    // newly deployed warp routes not yet in the registry. Try movable first
+    // since CCR-specific selectors are also parseable by movable.
     const ccrIface = CrossCollateralRouter__factory.createInterface();
     const movableIface = MovableCollateralRouter__factory.createInterface();
-    const ccrDecoded = tryParse(ccrIface) ?? tryParse(movableIface);
-    if (ccrDecoded) {
-      const insight = this.formatRouterCallInsight(
-        ccrIface,
-        movableIface,
-        ccrDecoded,
-      );
-      return formatBase('Warp Route (unregistered)', ccrDecoded, insight);
+    const movableDecoded = tryParse(movableIface) ?? tryParse(ccrIface);
+    if (movableDecoded) {
+      const insight =
+        this.formatRouterCallInsight(
+          { ccr: ccrIface, movable: movableIface },
+          movableDecoded,
+        ) ?? fallback(movableDecoded);
+      return formatBase('Warp Route (unregistered)', movableDecoded, insight);
+    }
+
+    // TokenBridgeCctpV2 adapter (CCTP v2) - in case a CctpV2 router is
+    // deployed outside the warp registry.
+    const cctpV2Iface = TokenBridgeCctpV2__factory.createInterface();
+    const cctpV2Decoded = tryParse(cctpV2Iface);
+    if (cctpV2Decoded) {
+      const insight =
+        this.formatTokenBridgeCctpV2Insight(cctpV2Iface, cctpV2Decoded) ??
+        fallback(cctpV2Decoded);
+      return formatBase('TokenBridgeCctpV2', cctpV2Decoded, insight);
     }
 
     // TokenBridgeOft adapter (LayerZero OFT bridge for warp routes).
     const oftIface = TokenBridgeOft__factory.createInterface();
     const oftDecoded = tryParse(oftIface);
     if (oftDecoded) {
-      const insight = this.formatTokenBridgeOftInsight(oftIface, oftDecoded);
+      const insight =
+        this.formatTokenBridgeOftInsight(oftIface, oftDecoded) ??
+        fallback(oftDecoded);
       return formatBase('TokenBridgeOft', oftDecoded, insight);
     }
 
@@ -1457,10 +1244,11 @@ export class GovernTransactionReader {
       TokenBridgeDepositAddress__factory.createInterface();
     const depositAddrDecoded = tryParse(depositAddrIface);
     if (depositAddrDecoded) {
-      const insight = this.formatTokenBridgeDepositAddressInsight(
-        depositAddrIface,
-        depositAddrDecoded,
-      );
+      const insight =
+        this.formatTokenBridgeDepositAddressInsight(
+          depositAddrIface,
+          depositAddrDecoded,
+        ) ?? fallback(depositAddrDecoded);
       return formatBase(
         'TokenBridgeDepositAddress',
         depositAddrDecoded,
@@ -1472,10 +1260,11 @@ export class GovernTransactionReader {
     const ccrFeeIface = CrossCollateralRoutingFee__factory.createInterface();
     const ccrFeeDecoded = tryParse(ccrFeeIface);
     if (ccrFeeDecoded) {
-      const insight = this.formatCrossCollateralRoutingFeeInsight(
-        ccrFeeIface,
-        ccrFeeDecoded,
-      );
+      const insight =
+        this.formatCrossCollateralRoutingFeeInsight(
+          ccrFeeIface,
+          ccrFeeDecoded,
+        ) ?? fallback(ccrFeeDecoded);
       return formatBase('CrossCollateralRoutingFee', ccrFeeDecoded, insight);
     }
 
@@ -1483,10 +1272,11 @@ export class GovernTransactionReader {
     const routingHookIface = DomainRoutingHook__factory.createInterface();
     const routingHookDecoded = tryParse(routingHookIface);
     if (routingHookDecoded) {
-      const insight = this.formatDomainRoutingHookInsight(
-        routingHookIface,
-        routingHookDecoded,
-      );
+      const insight =
+        this.formatDomainRoutingHookInsight(
+          routingHookIface,
+          routingHookDecoded,
+        ) ?? fallback(routingHookDecoded);
       return formatBase('DomainRoutingHook', routingHookDecoded, insight);
     }
 
@@ -1494,45 +1284,45 @@ export class GovernTransactionReader {
     const routingIsmIface = DomainRoutingIsm__factory.createInterface();
     const routingIsmDecoded = tryParse(routingIsmIface);
     if (routingIsmDecoded) {
-      const insight = this.formatDomainRoutingIsmInsight(
-        routingIsmIface,
-        routingIsmDecoded,
-      );
+      const insight =
+        this.formatDomainRoutingIsmInsight(
+          routingIsmIface,
+          routingIsmDecoded,
+        ) ?? fallback(routingIsmDecoded);
       return formatBase('DomainRoutingIsm', routingIsmDecoded, insight);
     }
 
     return undefined;
   }
 
+  // `interfaces.movable` covers most MovableCollateralRouter/TokenRouter admin
+  // calls; `interfaces.ccr` is only checked for CrossCollateralRouter-specific
+  // selectors (enrollCrossCollateralRouters/unenrollCrossCollateralRouters).
+  // Returns undefined if no signature matches.
   private formatRouterCallInsight(
-    ccrIface: ethers.utils.Interface,
-    movableIface: ethers.utils.Interface,
+    interfaces: {
+      ccr: ethers.utils.Interface;
+      movable: ethers.utils.Interface;
+    },
     decoded: ethers.utils.TransactionDescription,
-  ): string {
+  ): string | undefined {
+    const { ccr, movable } = interfaces;
     const args = decoded.args;
 
     if (
-      matchesFunctionSignature(
-        decoded,
-        movableIface,
-        'addBridge(uint32,address)',
-      )
+      matchesFunctionSignature(decoded, movable, 'addBridge(uint32,address)')
     ) {
       return `Set bridge for origin domain ${this.formatDomain(args[0])} to ${args[1]}`;
     }
     if (
-      matchesFunctionSignature(
-        decoded,
-        movableIface,
-        'removeBridge(uint32,address)',
-      )
+      matchesFunctionSignature(decoded, movable, 'removeBridge(uint32,address)')
     ) {
       return `Remove bridge ${args[1]} from domain ${this.formatDomain(args[0])}`;
     }
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'enrollRemoteRouter(uint32,bytes32)',
       )
     ) {
@@ -1541,7 +1331,7 @@ export class GovernTransactionReader {
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'enrollRemoteRouters(uint32[],bytes32[])',
       )
     ) {
@@ -1553,18 +1343,14 @@ export class GovernTransactionReader {
       return `Enroll remote routers for ${lines.join(', ')}`;
     }
     if (
-      matchesFunctionSignature(
-        decoded,
-        movableIface,
-        'unenrollRemoteRouter(uint32)',
-      )
+      matchesFunctionSignature(decoded, movable, 'unenrollRemoteRouter(uint32)')
     ) {
       return `Unenroll remote router for domain ${this.formatDomain(args[0])}`;
     }
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'unenrollRemoteRouters(uint32[])',
       )
     ) {
@@ -1576,7 +1362,7 @@ export class GovernTransactionReader {
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'setDestinationGas((uint32,uint256)[])',
       )
     ) {
@@ -1589,65 +1375,49 @@ export class GovernTransactionReader {
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'setDestinationGas(uint32,uint256)',
       )
     ) {
       return `Set destination gas for domain ${this.formatDomain(args[0])} to ${args[1].toString()}`;
     }
-    if (matchesFunctionSignature(decoded, movableIface, 'setHook(address)')) {
+    if (matchesFunctionSignature(decoded, movable, 'setHook(address)')) {
       return `Set hook to ${args[0]}`;
     }
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'setInterchainSecurityModule(address)',
       )
     ) {
       return `Set ISM to ${args[0]}`;
     }
     if (
-      matchesFunctionSignature(
-        decoded,
-        movableIface,
-        'setFeeRecipient(address)',
-      )
+      matchesFunctionSignature(decoded, movable, 'setFeeRecipient(address)')
     ) {
       return `Set fee recipient to ${args[0]}`;
     }
-    if (
-      matchesFunctionSignature(decoded, movableIface, 'addRebalancer(address)')
-    ) {
+    if (matchesFunctionSignature(decoded, movable, 'addRebalancer(address)')) {
       return `Add rebalancer ${args[0]}`;
     }
     if (
-      matchesFunctionSignature(
-        decoded,
-        movableIface,
-        'removeRebalancer(address)',
-      )
+      matchesFunctionSignature(decoded, movable, 'removeRebalancer(address)')
     ) {
       return `Remove rebalancer ${args[0]}`;
     }
     if (
-      matchesFunctionSignature(
-        decoded,
-        movableIface,
-        'setRecipient(uint32,bytes32)',
-      )
+      matchesFunctionSignature(decoded, movable, 'setRecipient(uint32,bytes32)')
     ) {
       return `Set rebalance recipient for domain ${this.formatDomain(args[0])} to ${args[1]}`;
     }
-    if (
-      matchesFunctionSignature(decoded, movableIface, 'removeRecipient(uint32)')
-    ) {
+    if (matchesFunctionSignature(decoded, movable, 'removeRecipient(uint32)')) {
       return `Remove rebalance recipient for domain ${this.formatDomain(args[0])}`;
     }
     if (
       matchesFunctionSignature(
         decoded,
-        movableIface,
+        movable,
         'approveTokenForBridge(address,address)',
       )
     ) {
@@ -1656,7 +1426,7 @@ export class GovernTransactionReader {
     if (
       matchesFunctionSignature(
         decoded,
-        ccrIface,
+        ccr,
         'enrollCrossCollateralRouters(uint32[],bytes32[])',
       )
     ) {
@@ -1670,7 +1440,7 @@ export class GovernTransactionReader {
     if (
       matchesFunctionSignature(
         decoded,
-        ccrIface,
+        ccr,
         'unenrollCrossCollateralRouters(uint32[],bytes32[])',
       )
     ) {
@@ -1681,13 +1451,13 @@ export class GovernTransactionReader {
       );
       return `Unenroll cross-collateral routers for ${lines.join(', ')}`;
     }
-    return `Call ${decoded.signature}`;
+    return undefined;
   }
 
   private formatTokenBridgeOftInsight(
     iface: ethers.utils.Interface,
     decoded: ethers.utils.TransactionDescription,
-  ): string {
+  ): string | undefined {
     const args = decoded.args;
     if (matchesFunctionSignature(decoded, iface, 'addDomain(uint32,uint32)')) {
       return `Map Hyperlane domain ${this.formatDomain(args[0])} to LayerZero EID ${args[1]}`;
@@ -1696,15 +1466,15 @@ export class GovernTransactionReader {
       return `Remove Hyperlane domain ${this.formatDomain(args[0])} mapping`;
     }
     if (matchesFunctionSignature(decoded, iface, 'setExtraOptions(bytes)')) {
-      return `Set extra LayerZero options`;
+      return `Set LayerZero extraOptions to ${args[0]}`;
     }
-    return `Call ${decoded.signature}`;
+    return undefined;
   }
 
   private formatTokenBridgeDepositAddressInsight(
     iface: ethers.utils.Interface,
     decoded: ethers.utils.TransactionDescription,
-  ): string {
+  ): string | undefined {
     const args = decoded.args;
     if (
       matchesFunctionSignature(
@@ -1724,13 +1494,26 @@ export class GovernTransactionReader {
     ) {
       return `Remove destination config: domain ${this.formatDomain(args[0])}, recipient ${args[1]}`;
     }
-    return `Call ${decoded.signature}`;
+    return undefined;
+  }
+
+  private formatTokenBridgeCctpV2Insight(
+    iface: ethers.utils.Interface,
+    decoded: ethers.utils.TransactionDescription,
+  ): string | undefined {
+    const args = decoded.args;
+    if (matchesFunctionSignature(decoded, iface, 'setMaxFeePpm(uint256)')) {
+      const [maxFeePpm] = args;
+      const bps = BigNumber.from(maxFeePpm).toNumber() / 100;
+      return `Set max fee to ${maxFeePpm} ppm (${bps} bps)`;
+    }
+    return undefined;
   }
 
   private formatCrossCollateralRoutingFeeInsight(
     iface: ethers.utils.Interface,
     decoded: ethers.utils.TransactionDescription,
-  ): string {
+  ): string | undefined {
     const args = decoded.args;
     if (
       matchesFunctionSignature(
@@ -1749,13 +1532,13 @@ export class GovernTransactionReader {
     if (matchesFunctionSignature(decoded, iface, 'claim(address,address)')) {
       return `Claim ${args[1]} balance to ${args[0]}`;
     }
-    return `Call ${decoded.signature}`;
+    return undefined;
   }
 
   private formatDomainRoutingHookInsight(
     iface: ethers.utils.Interface,
     decoded: ethers.utils.TransactionDescription,
-  ): string {
+  ): string | undefined {
     const args = decoded.args;
     if (matchesFunctionSignature(decoded, iface, 'setHook(uint32,address)')) {
       return `Set hook for destination ${this.formatDomain(args[0])} to ${args[1]}`;
@@ -1772,13 +1555,13 @@ export class GovernTransactionReader {
       );
       return `Set hooks: ${lines.join(', ')}`;
     }
-    return `Call ${decoded.signature}`;
+    return undefined;
   }
 
   private formatDomainRoutingIsmInsight(
     iface: ethers.utils.Interface,
     decoded: ethers.utils.TransactionDescription,
-  ): string {
+  ): string | undefined {
     const args = decoded.args;
     if (matchesFunctionSignature(decoded, iface, 'set(uint32,address)')) {
       return `Set ISM for origin ${this.formatDomain(args[0])} to ${args[1]}`;
@@ -1786,7 +1569,7 @@ export class GovernTransactionReader {
     if (matchesFunctionSignature(decoded, iface, 'remove(uint32)')) {
       return `Remove ISM for origin ${this.formatDomain(args[0])}`;
     }
-    return `Call ${decoded.signature}`;
+    return undefined;
   }
 
   /**
@@ -2387,7 +2170,10 @@ export class GovernTransactionReader {
         }
       }
     } catch (error: unknown) {
-      this.logger.warn(
+      // Best-effort path: a single ICA derivation failure shouldn't abort
+      // parsing of the surrounding governance tx. Log at error level so real
+      // bugs (vs. transient RPC) stand out.
+      this.logger.error(
         `Failed to derive ICA address for ${remoteChainName}, using expected address: ${summarizeError(error)}`,
       );
       remoteIcaAddress =
@@ -2405,7 +2191,7 @@ export class GovernTransactionReader {
         try {
           return await this.read(remoteChainName, icaCallAsTx);
         } catch (error: unknown) {
-          this.logger.warn(
+          this.logger.error(
             `Failed to decode ICA call to ${icaCallAsTx.to} on ${remoteChainName}: ${summarizeError(error)}`,
           );
           return {
@@ -2470,7 +2256,7 @@ export class GovernTransactionReader {
             decoded,
           };
         } catch (error: unknown) {
-          this.logger.warn(
+          this.logger.error(
             `Failed to decode multisend at index ${index}: ${summarizeError(error)}`,
           );
           return {


### PR DESCRIPTION
## Summary

`pnpm tsx scripts/safes/parse-txs.ts -e mainnet3 --governanceType {abacusWorks,warpFees} -c ethereum` was aborting on recent multisends due to two classes of decoder gaps:

1. **Unknown selectors on registry-listed bridge adapters.** `readWarpModuleTransaction` only attempted `MovableCollateralRouter`/`TokenBridgeCctpV2` ABIs, so `CrossCollateralRouter` (e.g. `enrollCrossCollateralRouters`, `setDestinationGas`), `TokenBridgeOft` (`addDomain`), and `TokenBridgeDepositAddress` (`addDestinationConfig`) calls threw mid-parse.

2. **Standalone admin calls to contracts not in the warp registry.** `DomainRoutingIsm.set(uint32,address)`, `DomainRoutingHook.setHooks((uint32,address)[])`, and `CrossCollateralRoutingFee.setCrossCollateralRouterFeeContracts(uint32[],bytes32[],address[])` fell through every matcher. `isProxyAdminTransaction`'s bytecode check then false-positived on some of them and threw inside `parseTransaction`.

### Changes

- Extend `readWarpModuleTransaction` to also try `CrossCollateralRouter`, `TokenBridgeOft`, and `TokenBridgeDepositAddress` interfaces and emit insights for their admin functions.
- Add `tryReadByKnownContractInterface` selector-based fallback (placed before `isProxyAdminTransaction` to avoid the bytecode false-positive) covering `DomainRoutingIsm`, `DomainRoutingHook`, `CrossCollateralRoutingFee`, and unregistered router-like contracts.
- Relax the catches in `readIcaRemoteCall` (ICA derivation + per-call read) and `readMultisendTransaction` so a single un-decodable inner call surfaces as an insight rather than aborting the script. Drops the now-unused `isRpcOrTransportError`/`isAbiDecodingError` helpers.

## Test plan

- [x] `pnpm tsx scripts/safes/parse-txs.ts -e mainnet3 --governanceType abacusWorks -c ethereum` → `✅ No fatal errors`
- [x] `pnpm tsx scripts/safes/parse-txs.ts -e mainnet3 --governanceType warpFees -c ethereum` → `✅ No fatal errors`
- [x] `pnpm turbo build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)