### PR TITLE
feat: add Anvil fork manager

### DIFF
--- a/.changeset/quiet-ants-fork.md
+++ b/.changeset/quiet-ants-fork.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/sdk': minor
 ---
 
-The Anvil fork helpers were encapsulated in an exported AnvilFork class while preserving the existing function exports.
+The Anvil fork helpers were encapsulated in exported AnvilFork and AnvilForkConfig public APIs while preserving the existing function exports.

--- a/.changeset/quiet-ants-fork.md
+++ b/.changeset/quiet-ants-fork.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The Anvil fork helpers were encapsulated in an exported AnvilFork class while preserving the existing function exports.

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -944,6 +944,8 @@ export type {
 export { filterByChains } from './utils/filter.js';
 export {
   ANVIL_RPC_METHODS,
+  AnvilFork,
+  type AnvilForkConfig,
   getLocalProvider,
   impersonateAccount,
   impersonateAccounts,

--- a/typescript/sdk/src/utils/fork.test.ts
+++ b/typescript/sdk/src/utils/fork.test.ts
@@ -41,6 +41,24 @@ describe(AnvilFork.name, () => {
 
     expect(sentRequests).to.deep.equal([[ANVIL_RPC_METHODS.RESET, []]]);
   });
+
+  it('stops impersonating with the validated full address', async () => {
+    const address = '0x0000000000000000000000000000000000000001';
+    const sentRequests: unknown[][] = [];
+    const manager = new AnvilFork();
+    manager.getProvider = () =>
+      ({
+        send: async (method: string, params: unknown[]) => {
+          sentRequests.push([method, params]);
+        },
+      }) as ReturnType<AnvilFork['getProvider']>;
+
+    await manager.stopImpersonatingAccount(address);
+
+    expect(sentRequests).to.deep.equal([
+      [ANVIL_RPC_METHODS.STOP_IMPERSONATING_ACCOUNT, [address]],
+    ]);
+  });
 });
 
 describe(getLocalProvider.name, () => {

--- a/typescript/sdk/src/utils/fork.test.ts
+++ b/typescript/sdk/src/utils/fork.test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 
-import { AnvilFork, getLocalProvider } from './fork.js';
+import { ANVIL_RPC_METHODS, AnvilFork, getLocalProvider } from './fork.js';
 
 describe(AnvilFork.name, () => {
   it('builds providers from the configured anvil endpoint', () => {
     const provider = new AnvilFork({
-      anvilIPAddr: '://127.0.0.1',
+      anvilIPAddr: '127.0.0.1',
       anvilPort: 9555,
     }).getProvider();
 
@@ -14,7 +14,7 @@ describe(AnvilFork.name, () => {
 
   it('supports updating endpoint configuration with setters', () => {
     const manager = new AnvilFork()
-      .setAnvilIPAddr('://127.0.0.1')
+      .setAnvilIPAddr('http://127.0.0.1')
       .setAnvilPort(9666);
 
     expect(manager.getProvider().connection.url).to.equal(
@@ -27,16 +27,30 @@ describe(AnvilFork.name, () => {
       'http://127.0.0.1:9777',
     );
   });
+  it('resets the local node without re-fork params', async () => {
+    const sentRequests: unknown[][] = [];
+    const manager = new AnvilFork();
+    manager.getProvider = () =>
+      ({
+        send: async (method: string, params: unknown[]) => {
+          sentRequests.push([method, params]);
+        },
+      }) as ReturnType<AnvilFork['getProvider']>;
+
+    await manager.reset();
+
+    expect(sentRequests).to.deep.equal([[ANVIL_RPC_METHODS.RESET, []]]);
+  });
 });
 
 describe(getLocalProvider.name, () => {
-  it('falls back to the configured anvil endpoint for invalid URL overrides', () => {
-    const provider = getLocalProvider({
-      anvilIPAddr: '://127.0.0.1',
-      anvilPort: 9888,
-      urlOverride: '127.0.0.1:9999',
-    });
-
-    expect(provider.connection.url).to.equal('http://127.0.0.1:9888');
+  it('throws for invalid URL overrides', () => {
+    expect(() =>
+      getLocalProvider({
+        anvilIPAddr: '127.0.0.1',
+        anvilPort: 9888,
+        urlOverride: '127.0.0.1:9999',
+      }),
+    ).to.throw('URL override must be a valid HTTP(S) URL');
   });
 });

--- a/typescript/sdk/src/utils/fork.test.ts
+++ b/typescript/sdk/src/utils/fork.test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import { AnvilFork, getLocalProvider } from './fork.js';
+
+describe(AnvilFork.name, () => {
+  it('builds providers from the configured anvil endpoint', () => {
+    const provider = new AnvilFork({
+      anvilIPAddr: '://127.0.0.1',
+      anvilPort: 9555,
+    }).getProvider();
+
+    expect(provider.connection.url).to.equal('http://127.0.0.1:9555');
+  });
+
+  it('supports updating endpoint configuration with setters', () => {
+    const manager = new AnvilFork()
+      .setAnvilIPAddr('://127.0.0.1')
+      .setAnvilPort(9666);
+
+    expect(manager.getProvider().connection.url).to.equal(
+      'http://127.0.0.1:9666',
+    );
+
+    manager.setUrlOverride('http://127.0.0.1:9777');
+
+    expect(manager.getProvider().connection.url).to.equal(
+      'http://127.0.0.1:9777',
+    );
+  });
+});
+
+describe(getLocalProvider.name, () => {
+  it('falls back to the configured anvil endpoint for invalid URL overrides', () => {
+    const provider = getLocalProvider({
+      anvilIPAddr: '://127.0.0.1',
+      anvilPort: 9888,
+      urlOverride: '127.0.0.1:9999',
+    });
+
+    expect(provider.connection.url).to.equal('http://127.0.0.1:9888');
+  });
+});

--- a/typescript/sdk/src/utils/fork.ts
+++ b/typescript/sdk/src/utils/fork.ts
@@ -5,8 +5,8 @@ import { Address, isValidAddressEvm, rootLogger } from '@hyperlane-xyz/utils';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
-const ENDPOINT_PREFIX = 'http';
 const DEFAULT_ANVIL_ENDPOINT = 'http://127.0.0.1:8545';
+const HTTP_PROTOCOL_REGEX = /^https?:\/\//i;
 
 export interface AnvilForkConfig {
   anvilIPAddr?: string;
@@ -61,13 +61,7 @@ export class AnvilFork {
   async reset(): Promise<void> {
     rootLogger.info(`Resetting forked network...`);
 
-    await this.getProvider().send(ANVIL_RPC_METHODS.RESET, [
-      {
-        forking: {
-          jsonRpcUrl: DEFAULT_ANVIL_ENDPOINT,
-        },
-      },
-    ]);
+    await this.getProvider().send(ANVIL_RPC_METHODS.RESET, []);
 
     rootLogger.info(`✅ Successfully reset forked network`);
   }
@@ -204,20 +198,36 @@ export const getLocalProvider = ({
 } = {}): providers.JsonRpcProvider => {
   let envUrl;
   if (anvilIPAddr && anvilPort)
-    envUrl = `${ENDPOINT_PREFIX}${anvilIPAddr}:${anvilPort}`;
+    envUrl = getAnvilEndpoint(anvilIPAddr, anvilPort);
 
-  if (urlOverride && !urlOverride.startsWith(ENDPOINT_PREFIX)) {
-    rootLogger.warn(
-      `⚠️ Provided URL override (${urlOverride}) does not begin with ${ENDPOINT_PREFIX}. Defaulting to ${
-        envUrl ?? DEFAULT_ANVIL_ENDPOINT
-      }`,
-    );
-    urlOverride = undefined;
-  }
+  if (urlOverride) validateHttpUrl(urlOverride, 'URL override');
 
   const url = urlOverride ?? envUrl ?? DEFAULT_ANVIL_ENDPOINT;
 
   return new providers.JsonRpcProvider(url);
+};
+
+const getAnvilEndpoint = (anvilIPAddr: string, anvilPort: number): string => {
+  const host = HTTP_PROTOCOL_REGEX.test(anvilIPAddr)
+    ? anvilIPAddr
+    : `http://${anvilIPAddr}`;
+  const endpoint = `${host}:${anvilPort}`;
+
+  validateHttpUrl(endpoint, 'Anvil endpoint');
+
+  return endpoint;
+};
+
+const validateHttpUrl = (url: string, label: string): void => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`${label} must be a valid HTTP(S) URL: ${url}`);
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol) || !parsed.hostname)
+    throw new Error(`${label} must be a valid HTTP(S) URL: ${url}`);
 };
 
 export async function setBalance(

--- a/typescript/sdk/src/utils/fork.ts
+++ b/typescript/sdk/src/utils/fork.ts
@@ -111,7 +111,7 @@ export class AnvilFork {
 
     await this.getProvider().send(
       ANVIL_RPC_METHODS.STOP_IMPERSONATING_ACCOUNT,
-      [address.substring(2)],
+      [address],
     );
 
     rootLogger.info(
@@ -173,9 +173,7 @@ export const stopImpersonatingAccount = async (
     );
 
   const provider = getLocalProvider({ urlOverride: anvilEndPoint });
-  await provider.send(ANVIL_RPC_METHODS.STOP_IMPERSONATING_ACCOUNT, [
-    address.substring(2),
-  ]);
+  await provider.send(ANVIL_RPC_METHODS.STOP_IMPERSONATING_ACCOUNT, [address]);
 
   rootLogger.info(
     `✅ Successfully stopped account impersonation for address (${address})`,

--- a/typescript/sdk/src/utils/fork.ts
+++ b/typescript/sdk/src/utils/fork.ts
@@ -8,6 +8,12 @@ import { ChainName } from '../types.js';
 const ENDPOINT_PREFIX = 'http';
 const DEFAULT_ANVIL_ENDPOINT = 'http://127.0.0.1:8545';
 
+export interface AnvilForkConfig {
+  anvilIPAddr?: string;
+  anvilPort?: number;
+  urlOverride?: string;
+}
+
 export enum ANVIL_RPC_METHODS {
   RESET = 'anvil_reset',
   IMPERSONATE_ACCOUNT = 'anvil_impersonateAccount',
@@ -21,23 +27,110 @@ export enum ANVIL_RPC_METHODS {
   INCREASE_TIME = 'evm_increaseTime',
 }
 
+export class AnvilFork {
+  private config: AnvilForkConfig;
+
+  constructor(config: AnvilForkConfig = {}) {
+    this.config = { ...config };
+  }
+
+  setAnvilIPAddr(anvilIPAddr?: string): this {
+    this.config.anvilIPAddr = anvilIPAddr;
+    return this;
+  }
+
+  setAnvilPort(anvilPort?: number): this {
+    this.config.anvilPort = anvilPort;
+    return this;
+  }
+
+  setUrlOverride(urlOverride?: string): this {
+    this.config.urlOverride = urlOverride;
+    return this;
+  }
+
+  setConfig(config: AnvilForkConfig): this {
+    this.config = { ...this.config, ...config };
+    return this;
+  }
+
+  getProvider(): providers.JsonRpcProvider {
+    return getLocalProvider(this.config);
+  }
+
+  async reset(): Promise<void> {
+    rootLogger.info(`Resetting forked network...`);
+
+    await this.getProvider().send(ANVIL_RPC_METHODS.RESET, [
+      {
+        forking: {
+          jsonRpcUrl: DEFAULT_ANVIL_ENDPOINT,
+        },
+      },
+    ]);
+
+    rootLogger.info(`✅ Successfully reset forked network`);
+  }
+
+  async fork(
+    multiProvider: MultiProvider,
+    chain: ChainName | number,
+  ): Promise<void> {
+    rootLogger.info(`Forking ${chain} for dry-run...`);
+
+    const provider = this.getProvider();
+    const currentChainMetadata = multiProvider.metadata[chain];
+
+    await provider.send(ANVIL_RPC_METHODS.RESET, [
+      {
+        forking: {
+          jsonRpcUrl: currentChainMetadata.rpcUrls[0].http,
+        },
+      },
+    ]);
+
+    multiProvider.setProvider(chain, provider);
+
+    rootLogger.info(`✅ Successfully forked ${chain} for dry-run`);
+  }
+
+  async impersonateAccount(address: Address): Promise<providers.JsonRpcSigner> {
+    rootLogger.info(`Impersonating account (${address})...`);
+
+    const provider = this.getProvider();
+    await provider.send(ANVIL_RPC_METHODS.IMPERSONATE_ACCOUNT, [address]);
+
+    rootLogger.info(`✅ Successfully impersonated account (${address})`);
+
+    return provider.getSigner(address);
+  }
+
+  async stopImpersonatingAccount(address: Address): Promise<void> {
+    rootLogger.info(
+      `Stopping account impersonation for address (${address})...`,
+    );
+
+    if (!isValidAddressEvm(address))
+      throw new Error(
+        `Cannot stop account impersonation: invalid address format: ${address}`,
+      );
+
+    await this.getProvider().send(
+      ANVIL_RPC_METHODS.STOP_IMPERSONATING_ACCOUNT,
+      [address.substring(2)],
+    );
+
+    rootLogger.info(
+      `✅ Successfully stopped account impersonation for address (${address})`,
+    );
+  }
+}
+
 /**
  * Resets the local node to it's original state (anvil [31337] at block zero).
  */
-export const resetFork = async (anvilIPAddr?: string, anvilPort?: number) => {
-  rootLogger.info(`Resetting forked network...`);
-
-  const provider = getLocalProvider({ anvilIPAddr, anvilPort });
-  await provider.send(ANVIL_RPC_METHODS.RESET, [
-    {
-      forking: {
-        jsonRpcUrl: DEFAULT_ANVIL_ENDPOINT,
-      },
-    },
-  ]);
-
-  rootLogger.info(`✅ Successfully reset forked network`);
-};
+export const resetFork = async (anvilIPAddr?: string, anvilPort?: number) =>
+  new AnvilFork({ anvilIPAddr, anvilPort }).reset();
 
 /**
  * Forks a chain onto the local node at the latest block of the forked network.
@@ -49,24 +142,7 @@ export const setFork = async (
   chain: ChainName | number,
   anvilIPAddr?: string,
   anvilPort?: number,
-) => {
-  rootLogger.info(`Forking ${chain} for dry-run...`);
-
-  const provider = getLocalProvider({ anvilIPAddr, anvilPort });
-  const currentChainMetadata = multiProvider.metadata[chain];
-
-  await provider.send(ANVIL_RPC_METHODS.RESET, [
-    {
-      forking: {
-        jsonRpcUrl: currentChainMetadata.rpcUrls[0].http,
-      },
-    },
-  ]);
-
-  multiProvider.setProvider(chain, provider);
-
-  rootLogger.info(`✅ Successfully forked ${chain} for dry-run`);
-};
+) => new AnvilFork({ anvilIPAddr, anvilPort }).fork(multiProvider, chain);
 
 /**
  * Impersonates an EOA for a provided address.


### PR DESCRIPTION
## Summary
- Encapsulates SDK Anvil fork helpers in an exported `AnvilFork` class with endpoint setters
- Preserves the existing `resetFork` and `setFork` function exports by delegating to the class
- Adds unit coverage for provider endpoint configuration and invalid URL override fallback

## Test Plan
- `NODE_OPTIONS='--import tsx/esm' ./node_modules/.bin/mocha --config .mocharc.json './src/utils/fork.test.ts' --exit` from `typescript/sdk` (3 passing)
- `./node_modules/.bin/oxlint -c oxlint.json typescript/sdk/src/utils/fork.ts typescript/sdk/src/utils/fork.test.ts typescript/sdk/src/index.ts` (0 errors)

Part of #3652