### PR TITLE
docs: add validator terraform quickstart

### DIFF
--- a/rust/main/terraform/README.md
+++ b/rust/main/terraform/README.md
@@ -4,4 +4,28 @@ This Terraform module is designed to set up the necessary infrastructure for a H
 
 > **Note:** This module is intended to be an example of running a validator for a core supported network. You may have to modify the validator module to support more advanced configurations. It is recommended to test thoroughly before using in a production environment.
 
+## Quick start
+
+Copy the example variables file and set the validator name and origin chain you want to run:
+
+```sh
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+```
+
+Then initialize and review the AWS resources Terraform will create:
+
+```sh
+terraform init
+terraform plan
+```
+
+For first-time setup, you can keep the validator task disabled while creating the supporting AWS resources, then fund the reported validator address before enabling the task:
+
+```hcl
+validator_task_disabled = true
+```
+
+Add that setting to the `module "validator"` block in `main.tf` for the initial apply, then remove it or set it to `false` once the validator signer has been funded.
+
 For more information, read the [Deploy with Terraform](https://hyp-v3-docs-git-feat-aws-agent-guide-abacus-works.vercel.app/docs/operate/deploy-with-terraform) documentation.

--- a/rust/main/terraform/README.md
+++ b/rust/main/terraform/README.md
@@ -28,6 +28,6 @@ For first-time setup, you can keep the validator task disabled while creating th
 validator_task_disabled = true
 ```
 
-Uncomment the existing `validator_task_disabled = true` line in the `module "validator"` block in `main.tf`, or add `validator_task_disabled = true` to that block if it is not present. After funding the validator signer, remove the `validator_task_disabled` setting or set it to `false`.
+Set `validator_task_disabled = true` in `terraform.tfvars` during first-time setup. After funding the validator signer, set it back to `false`.
 
-For more information, read the [Deploy with Terraform](https://hyp-v3-docs-git-feat-aws-agent-guide-abacus-works.vercel.app/docs/operate/deploy-with-terraform) documentation.
+For more information, read the [Deploy with Terraform](https://docs.hyperlane.xyz/docs/operate/guides/deploy-with-terraform) documentation.

--- a/rust/main/terraform/README.md
+++ b/rust/main/terraform/README.md
@@ -20,12 +20,14 @@ terraform init
 terraform plan
 ```
 
+If the plan looks correct, run `terraform apply` to create the resources. Use `terraform apply -auto-approve` only in automation or when you have already reviewed the plan.
+
 For first-time setup, you can keep the validator task disabled while creating the supporting AWS resources, then fund the reported validator address before enabling the task:
 
 ```hcl
 validator_task_disabled = true
 ```
 
-Add that setting to the `module "validator"` block in `main.tf` for the initial apply, then remove it or set it to `false` once the validator signer has been funded.
+Uncomment the existing `validator_task_disabled = true` line in the `module "validator"` block in `main.tf`, or add `validator_task_disabled = true` to that block if it is not present. After funding the validator signer, remove the `validator_task_disabled` setting or set it to `false`.
 
 For more information, read the [Deploy with Terraform](https://hyp-v3-docs-git-feat-aws-agent-guide-abacus-works.vercel.app/docs/operate/deploy-with-terraform) documentation.

--- a/rust/main/terraform/main.tf
+++ b/rust/main/terraform/main.tf
@@ -11,6 +11,7 @@ module "validator" {
   validator_subnet_id      = aws_subnet.validator_subnet.id
   validator_sg_id          = aws_security_group.validator_sg.id
   validator_nat_gateway_id = aws_nat_gateway.validator_nat_gateway.id
+  validator_task_disabled  = var.validator_task_disabled
 
   # Disabling the validator task allows you to set up all the required infrastructure
   # without running the actual validator yet. This is useful when setting up a validator for

--- a/rust/main/terraform/main.tf
+++ b/rust/main/terraform/main.tf
@@ -1,10 +1,10 @@
 # Configure a Hyperlane Validator
 # Replaces https://docs.hyperlane.xyz/docs/operate/validators/run-validators
-module "your_validator_name" {
+module "validator" {
   source = "./modules/validator"
 
-  validator_name    = "your-validator-name"
-  origin_chain_name = "originChainName"
+  validator_name    = var.validator_name
+  origin_chain_name = var.origin_chain_name
 
   aws_region               = var.aws_region
   validator_cluster_id     = aws_ecs_cluster.validator_cluster.id

--- a/rust/main/terraform/outputs.tf
+++ b/rust/main/terraform/outputs.tf
@@ -1,4 +1,4 @@
-output "your_validator_name" {
-  value = module.your_validator_name.validator_info
+output "validator" {
+  value     = module.validator.validator_info
   sensitive = true
 }

--- a/rust/main/terraform/terraform.tfvars.example
+++ b/rust/main/terraform/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Copy this file to terraform.tfvars and edit the values before running Terraform.
+
+aws_region        = "us-east-1"
+validator_name    = "your-validator-name"
+origin_chain_name = "ethereum"

--- a/rust/main/terraform/terraform.tfvars.example
+++ b/rust/main/terraform/terraform.tfvars.example
@@ -3,3 +3,8 @@
 aws_region        = "us-east-1"
 validator_name    = "your-validator-name"
 origin_chain_name = "ethereum"
+
+# Set to true during first-time setup to create supporting infrastructure
+# without starting the validator ECS task. Set back to false after funding
+# the validator signer.
+validator_task_disabled = false

--- a/rust/main/terraform/variables.tf
+++ b/rust/main/terraform/variables.tf
@@ -3,3 +3,13 @@ variable "aws_region" {
   type        = string
   default     = "us-east-1"
 }
+
+variable "validator_name" {
+  description = "Name used for validator AWS resources"
+  type        = string
+}
+
+variable "origin_chain_name" {
+  description = "Origin chain name for the validator to sign checkpoints for"
+  type        = string
+}

--- a/rust/main/terraform/variables.tf
+++ b/rust/main/terraform/variables.tf
@@ -13,3 +13,9 @@ variable "origin_chain_name" {
   description = "Origin chain name for the validator to sign checkpoints for"
   type        = string
 }
+
+variable "validator_task_disabled" {
+  description = "Whether to keep the validator ECS task disabled during setup"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Adds Terraform input variables for validator name and origin chain instead of hardcoded placeholders
- Adds a terraform.tfvars.example for the AWS validator module
- Documents the minimal quick-start flow for planning the validator AWS deployment

## Test Plan
- [x] Basic text checks for Terraform files (line counts, trailing newlines, no tabs)
- [x] Pre-commit hook passed: gitleaks + lint-staged/oxfmt
- [ ] Terraform CLI validation not run locally because Terraform is not installed in this environment

Refs #4644