### PR TITLE
feat: cctp multiple messages

### DIFF
--- a/.changeset/odd-seas-unite.md
+++ b/.changeset/odd-seas-unite.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/ccip-server": minor
+---
+
+Allowed multiple messages per origin tx for cctp v2 messages

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -17,7 +17,7 @@
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",
-    "test": "mocha './tests/**/CallCommitmentsService.test.ts' --exit",
+    "test": "mocha './tests/**/*.test.ts' --exit",
     "test:ci": "pnpm test",
     "lint": "oxlint -c ../../oxlint.json",
     "format": "oxfmt --write ./src ./tests"

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -17,7 +17,7 @@
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",
-    "test": "mocha './tests/**/CallCommitmentsService.test.ts' --exit",
+    "test": "mocha './tests/**/CallCommitmentsService.test.ts' './tests/**/cctpMessageMatcher.test.ts' --exit",
     "test:ci": "pnpm test",
     "lint": "oxlint -c ../../oxlint.json",
     "format": "oxfmt --write ./src ./tests"

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -17,7 +17,7 @@
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",
-    "test": "mocha './tests/**/*.test.ts' --exit",
+    "test": "mocha './tests/**/CallCommitmentsService.test.ts' --exit",
     "test:ci": "pnpm test",
     "lint": "oxlint -c ../../oxlint.json",
     "format": "oxfmt --write ./src ./tests"

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -226,6 +226,7 @@ class CCTPAttestationService {
           ? normalizeCctpMessageV2(cctpMessage)
           : cctpMessage.toLowerCase();
       const found = json.messages.find((m) => {
+        if (m.message == null) return false; // Circle returns null for messages still being processed
         const normalizedApiMessage =
           version === this.CCTP_VERSION_2
             ? normalizeCctpMessageV2(m.message)
@@ -243,6 +244,7 @@ class CCTPAttestationService {
     }
 
     if (
+      matchingMessage.message == null ||
       matchingMessage.attestation == null ||
       matchingMessage.attestation === 'PENDING'
     ) {

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -201,41 +201,39 @@ class CCTPAttestationService {
     );
 
     // Fast path: single message in the tx — no disambiguation needed (99.99% of traffic).
-    if (json.messages.length === 1) {
-      return [json.messages[0].message, json.messages[0].attestation];
-    }
-
-    // Multi-message path: find the Circle message that corresponds to the specific
-    // cctpMessage bytes we extracted from the receipt.
-    // For v2: Circle fills in four fields off-chain that are zeroed in the emitted
-    // MessageSent bytes, so byte-exact comparison always fails. Normalize by zeroing
-    // those mutable fields before matching.
+    // Multi-message path: normalize to account for Circle-populated mutable fields and find
+    // the entry that corresponds to the cctpMessage bytes extracted from the receipt.
+    // For v2: four fields are zeroed at emit and populated by Circle off-chain:
     //   Header: nonce (12-43), finalityThresholdExecuted (144-147)
     //   BurnMessageV2 body: feeExecuted (312-343), expirationBlock (344-375)
     //   GMP messages are 180 bytes so 312-375 are out of range — safe no-op.
-    // For v1: v1 nonce is uint64 at bytes 12-19; bytes 20+ are stable sender/recipient
-    // fields. Applying v2 normalization would corrupt those stable fields, so use
-    // byte-exact comparison for v1.
-    const normalizeCctpMessageV2 = (hex: string): string => {
-      const bytes = ethers.utils.arrayify(hex);
-      bytes.fill(0, 12, 44); // nonce
-      bytes.fill(0, 144, 148); // finalityThresholdExecuted
-      if (bytes.length >= 344) bytes.fill(0, 312, 344); // feeExecuted
-      if (bytes.length >= 376) bytes.fill(0, 344, 376); // expirationBlock
-      return ethers.utils.hexlify(bytes);
-    };
-    const normalizedCctpMessage =
-      version === this.CCTP_VERSION_2
-        ? normalizeCctpMessageV2(cctpMessage)
-        : cctpMessage.toLowerCase();
-    const matchingMessage =
-      json.messages.find((m) => {
-        const normalizedApiMessage =
-          version === this.CCTP_VERSION_2
-            ? normalizeCctpMessageV2(m.message)
-            : m.message.toLowerCase();
-        return normalizedApiMessage === normalizedCctpMessage;
-      }) ?? json.messages[0];
+    // For v1: byte-exact comparison — applying v2 normalization would corrupt stable
+    //   sender/recipient fields (v1 nonce is uint64 at 12-19; bytes 20+ are stable).
+    let matchingMessage: CCTPMessageEntry;
+    if (json.messages.length === 1) {
+      matchingMessage = json.messages[0];
+    } else {
+      const normalizeCctpMessageV2 = (hex: string): string => {
+        const bytes = ethers.utils.arrayify(hex);
+        bytes.fill(0, 12, 44); // nonce
+        bytes.fill(0, 144, 148); // finalityThresholdExecuted
+        if (bytes.length >= 344) bytes.fill(0, 312, 344); // feeExecuted
+        if (bytes.length >= 376) bytes.fill(0, 344, 376); // expirationBlock
+        return ethers.utils.hexlify(bytes);
+      };
+      const normalizedCctpMessage =
+        version === this.CCTP_VERSION_2
+          ? normalizeCctpMessageV2(cctpMessage)
+          : cctpMessage.toLowerCase();
+      matchingMessage =
+        json.messages.find((m) => {
+          const normalizedApiMessage =
+            version === this.CCTP_VERSION_2
+              ? normalizeCctpMessageV2(m.message)
+              : m.message.toLowerCase();
+          return normalizedApiMessage === normalizedCctpMessage;
+        }) ?? json.messages[0];
+    }
 
     if (matchingMessage.attestation === 'PENDING') {
       const errorString = 'CCTP attestation is pending';

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -242,7 +242,10 @@ class CCTPAttestationService {
       matchingMessage = found;
     }
 
-    if (matchingMessage.attestation === 'PENDING') {
+    if (
+      matchingMessage.attestation == null ||
+      matchingMessage.attestation === 'PENDING'
+    ) {
       const errorString = 'CCTP attestation is pending';
       switch (matchingMessage.delayReason) {
         case 'insufficient_fee':

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -225,14 +225,18 @@ class CCTPAttestationService {
         version === this.CCTP_VERSION_2
           ? normalizeCctpMessageV2(cctpMessage)
           : cctpMessage.toLowerCase();
-      matchingMessage =
-        json.messages.find((m) => {
-          const normalizedApiMessage =
-            version === this.CCTP_VERSION_2
-              ? normalizeCctpMessageV2(m.message)
-              : m.message.toLowerCase();
-          return normalizedApiMessage === normalizedCctpMessage;
-        }) ?? json.messages[0];
+      const found = json.messages.find((m) => {
+        const normalizedApiMessage =
+          version === this.CCTP_VERSION_2
+            ? normalizeCctpMessageV2(m.message)
+            : m.message.toLowerCase();
+        return normalizedApiMessage === normalizedCctpMessage;
+      });
+      assert(
+        found != null,
+        `Could not match any of ${json.messages.length} Circle API messages to cctpMessage for messageId ${messageId}`,
+      );
+      matchingMessage = found;
     }
 
     if (matchingMessage.attestation === 'PENDING') {

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -1,6 +1,8 @@
 import { BytesLike, ethers } from 'ethers';
 import { Logger } from 'pino';
 
+import { assert } from '@hyperlane-xyz/utils';
+
 import {
   PrometheusMetrics,
   UnhandledErrorReason,
@@ -193,14 +195,32 @@ class CCTPAttestationService {
       throw new Error(`CCTP service response parsing failed: ${error}`);
     }
 
-    // Find the Circle message entry that matches the specific cctpMessage bytes we
-    // extracted from the receipt. For single-transfer txs the response has one entry
-    // so this is a no-op; for multi-transfer txs it picks the right attestation.
-    // Falls back to messages[0] if no byte-exact match (shouldn't happen in practice).
-    const normalizedCctpMessage = cctpMessage.toLowerCase();
+    assert(
+      json.messages.length > 0,
+      'CCTP attestation API returned no messages',
+    );
+
+    // Circle fills in four fields off-chain that are zeroed in the emitted MessageSent bytes.
+    // CctpMessageV2 header mutable fields:
+    //   - nonce (bytes 12-43): EMPTY_NONCE = bytes32(0) on emit, assigned by Circle
+    //   - finalityThresholdExecuted (bytes 144-147): 0 on emit, set by Circle on finality
+    // BurnMessageV2 body mutable fields (body starts at byte 148):
+    //   - feeExecuted (full bytes 312-343): EMPTY_FEE_EXECUTED = 0 on emit, set by Circle
+    //   - expirationBlock (full bytes 344-375): EMPTY_EXPIRATION_BLOCK = 0 on emit, set by Circle
+    // Byte-exact comparison always fails for v2. Normalize both sides by zeroing all four fields.
+    // GMP messages are 180 bytes so bytes 312-375 are out of range — safe no-op.
+    const normalizeCctpMessage = (hex: string): string => {
+      const bytes = ethers.utils.arrayify(hex);
+      bytes.fill(0, 12, 44); // nonce
+      bytes.fill(0, 144, 148); // finalityThresholdExecuted
+      if (bytes.length >= 344) bytes.fill(0, 312, 344); // feeExecuted
+      if (bytes.length >= 376) bytes.fill(0, 344, 376); // expirationBlock
+      return ethers.utils.hexlify(bytes);
+    };
+    const normalizedCctpMessage = normalizeCctpMessage(cctpMessage);
     const matchingMessage =
       json.messages.find(
-        (m) => m.message.toLowerCase() === normalizedCctpMessage,
+        (m) => normalizeCctpMessage(m.message) === normalizedCctpMessage,
       ) ?? json.messages[0];
 
     if (matchingMessage.attestation === 'PENDING') {

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -79,14 +79,6 @@ class CCTPAttestationService {
     return `${this.url}/v2/messages/${sourceDomain}?transactionHash=${transactionHash}`;
   }
 
-  /**
-   * Get the CCTP v2 attestation
-   * @param CCTP message retrieved from the MessageSend log event
-   * @param transaction hash containing the MessageSent event
-   * @param messageId Hyperlane message ID for tracking
-   * @param logger logger for request context
-   * @returns the attestation byte array
-   */
   async getAttestation(
     cctpMessage: string,
     transactionHash: string,
@@ -201,42 +193,43 @@ class CCTPAttestationService {
       throw new Error(`CCTP service response parsing failed: ${error}`);
     }
 
-    json.messages.forEach((message) => {
-      if (message.attestation === 'PENDING') {
-        const errorString = 'CCTP attestation is pending';
-        switch (message.delayReason) {
-          case 'insufficient_fee':
-          case 'amount_above_max':
-          case 'insufficient_allowance_available':
-            PrometheusMetrics.logUnhandledError(
-              this.serviceName,
-              UnhandledErrorReason.CCTP_ATTESTATION_SERVICE_PENDING,
-            );
-            logger.error(
-              {
-                error_reason:
-                  UnhandledErrorReason.CCTP_ATTESTATION_SERVICE_PENDING,
-                ...message,
-                ...context,
-              },
-              errorString + ` due to ${message.delayReason}`,
-            );
-            break;
-          default:
-            logger.info(
-              {
-                ...context,
-                ...message,
-              },
-              errorString,
-            );
-        }
-        throw new Error(errorString);
-      }
-    });
+    // Find the Circle message entry that matches the specific cctpMessage bytes we
+    // extracted from the receipt. For single-transfer txs the response has one entry
+    // so this is a no-op; for multi-transfer txs it picks the right attestation.
+    // Falls back to messages[0] if no byte-exact match (shouldn't happen in practice).
+    const normalizedCctpMessage = cctpMessage.toLowerCase();
+    const matchingMessage =
+      json.messages.find(
+        (m) => m.message.toLowerCase() === normalizedCctpMessage,
+      ) ?? json.messages[0];
 
-    // TODO: handle multiple messages in one tx hash
-    return [json.messages[0].message, json.messages[0].attestation];
+    if (matchingMessage.attestation === 'PENDING') {
+      const errorString = 'CCTP attestation is pending';
+      switch (matchingMessage.delayReason) {
+        case 'insufficient_fee':
+        case 'amount_above_max':
+        case 'insufficient_allowance_available':
+          PrometheusMetrics.logUnhandledError(
+            this.serviceName,
+            UnhandledErrorReason.CCTP_ATTESTATION_SERVICE_PENDING,
+          );
+          logger.error(
+            {
+              error_reason:
+                UnhandledErrorReason.CCTP_ATTESTATION_SERVICE_PENDING,
+              ...matchingMessage,
+              ...context,
+            },
+            errorString + ` due to ${matchingMessage.delayReason}`,
+          );
+          break;
+        default:
+          logger.info({ ...context, ...matchingMessage }, errorString);
+      }
+      throw new Error(errorString);
+    }
+
+    return [matchingMessage.message, matchingMessage.attestation];
   }
 }
 

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -200,16 +200,23 @@ class CCTPAttestationService {
       'CCTP attestation API returned no messages',
     );
 
-    // Circle fills in four fields off-chain that are zeroed in the emitted MessageSent bytes.
-    // CctpMessageV2 header mutable fields:
-    //   - nonce (bytes 12-43): EMPTY_NONCE = bytes32(0) on emit, assigned by Circle
-    //   - finalityThresholdExecuted (bytes 144-147): 0 on emit, set by Circle on finality
-    // BurnMessageV2 body mutable fields (body starts at byte 148):
-    //   - feeExecuted (full bytes 312-343): EMPTY_FEE_EXECUTED = 0 on emit, set by Circle
-    //   - expirationBlock (full bytes 344-375): EMPTY_EXPIRATION_BLOCK = 0 on emit, set by Circle
-    // Byte-exact comparison always fails for v2. Normalize both sides by zeroing all four fields.
-    // GMP messages are 180 bytes so bytes 312-375 are out of range — safe no-op.
-    const normalizeCctpMessage = (hex: string): string => {
+    // Fast path: single message in the tx — no disambiguation needed (99.99% of traffic).
+    if (json.messages.length === 1) {
+      return [json.messages[0].message, json.messages[0].attestation];
+    }
+
+    // Multi-message path: find the Circle message that corresponds to the specific
+    // cctpMessage bytes we extracted from the receipt.
+    // For v2: Circle fills in four fields off-chain that are zeroed in the emitted
+    // MessageSent bytes, so byte-exact comparison always fails. Normalize by zeroing
+    // those mutable fields before matching.
+    //   Header: nonce (12-43), finalityThresholdExecuted (144-147)
+    //   BurnMessageV2 body: feeExecuted (312-343), expirationBlock (344-375)
+    //   GMP messages are 180 bytes so 312-375 are out of range — safe no-op.
+    // For v1: v1 nonce is uint64 at bytes 12-19; bytes 20+ are stable sender/recipient
+    // fields. Applying v2 normalization would corrupt those stable fields, so use
+    // byte-exact comparison for v1.
+    const normalizeCctpMessageV2 = (hex: string): string => {
       const bytes = ethers.utils.arrayify(hex);
       bytes.fill(0, 12, 44); // nonce
       bytes.fill(0, 144, 148); // finalityThresholdExecuted
@@ -217,11 +224,18 @@ class CCTPAttestationService {
       if (bytes.length >= 376) bytes.fill(0, 344, 376); // expirationBlock
       return ethers.utils.hexlify(bytes);
     };
-    const normalizedCctpMessage = normalizeCctpMessage(cctpMessage);
+    const normalizedCctpMessage =
+      version === this.CCTP_VERSION_2
+        ? normalizeCctpMessageV2(cctpMessage)
+        : cctpMessage.toLowerCase();
     const matchingMessage =
-      json.messages.find(
-        (m) => normalizeCctpMessage(m.message) === normalizedCctpMessage,
-      ) ?? json.messages[0];
+      json.messages.find((m) => {
+        const normalizedApiMessage =
+          version === this.CCTP_VERSION_2
+            ? normalizeCctpMessageV2(m.message)
+            : m.message.toLowerCase();
+        return normalizedApiMessage === normalizedCctpMessage;
+      }) ?? json.messages[0];
 
     if (matchingMessage.attestation === 'PENDING') {
       const errorString = 'CCTP attestation is pending';

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -232,10 +232,13 @@ class CCTPAttestationService {
             : m.message.toLowerCase();
         return normalizedApiMessage === normalizedCctpMessage;
       });
-      assert(
-        found != null,
-        `Could not match any of ${json.messages.length} Circle API messages to cctpMessage for messageId ${messageId}`,
-      );
+      if (found == null) {
+        logger.info(
+          { messageId, messageCount: json.messages.length },
+          'Could not match Circle API messages to cctpMessage — treating as pending',
+        );
+        throw new Error('CCTP attestation is pending');
+      }
       matchingMessage = found;
     }
 

--- a/typescript/ccip-server/src/services/CCTPService.ts
+++ b/typescript/ccip-server/src/services/CCTPService.ts
@@ -109,8 +109,11 @@ class CCTPService extends BaseService {
     for (const receiptLog of receipt.logs) {
       try {
         const parsedLog = iface.parseLog(receiptLog);
-        if (parsedLog.name === event.name) {
-          allMessages.push(parsedLog.args.message as string);
+        if (
+          parsedLog.name === event.name &&
+          typeof parsedLog.args.message === 'string'
+        ) {
+          allMessages.push(parsedLog.args.message);
         }
       } catch (_err) {
         continue;
@@ -151,19 +154,19 @@ class CCTPService extends BaseService {
       messageId,
     );
 
-    if (matched !== allMessages[0]) {
+    if (matched !== null) {
       logger.info(
         { cctpMessage: matched, messageId },
         'Matched CCTP MessageSent event',
       );
-    } else {
-      logger.warn(
-        { messageId, messageCount: allMessages.length },
-        'Could not match MessageSent by body fields, falling back to first',
-      );
+      return matched;
     }
 
-    return matched;
+    logger.warn(
+      { messageId, messageCount: allMessages.length },
+      'Could not match MessageSent by body fields, falling back to first',
+    );
+    return allMessages[0];
   }
 
   async getCCTPAttestation(

--- a/typescript/ccip-server/src/services/CCTPService.ts
+++ b/typescript/ccip-server/src/services/CCTPService.ts
@@ -22,6 +22,7 @@ import {
   ServiceConfigWithMultiProvider,
 } from './BaseService.js';
 import { CCTPAttestationService } from './CCTPAttestationService.js';
+import { findMatchingCircleMessage } from './cctpMessageMatcher.js';
 import { HyperlaneService } from './HyperlaneService.js';
 
 const EnvSchema = z.object({
@@ -92,48 +93,77 @@ class CCTPService extends BaseService {
 
   async getCCTPMessageFromReceipt(
     receipt: ethers.providers.TransactionReceipt,
+    hyperlaneMessage: string,
     messageId: string,
     logger: Logger,
   ) {
     logger.info(
-      {
-        transactionHash: receipt.transactionHash,
-      },
+      { transactionHash: receipt.transactionHash },
       'Extracting CCTP message from receipt',
     );
 
     const iface = IMessageTransmitter__factory.createInterface();
     const event = iface.events['MessageSent(bytes)'];
 
+    const allMessages: string[] = [];
     for (const receiptLog of receipt.logs) {
       try {
         const parsedLog = iface.parseLog(receiptLog);
         if (parsedLog.name === event.name) {
-          logger.info(
-            { cctpMessage: parsedLog.args.message },
-            'Found CCTP MessageSent event',
-          );
-          return parsedLog.args.message;
+          allMessages.push(parsedLog.args.message as string);
         }
       } catch (_err) {
-        // This log is not from the events in our ABI
         continue;
       }
     }
 
-    logger.error(
-      {
-        transactionHash: receipt.transactionHash,
-        messageId,
-        error_reason: UnhandledErrorReason.CCTP_MESSAGE_SENT_NOT_FOUND,
-      },
-      'Unable to find MessageSent event in logs',
+    if (allMessages.length === 0) {
+      logger.error(
+        {
+          transactionHash: receipt.transactionHash,
+          messageId,
+          error_reason: UnhandledErrorReason.CCTP_MESSAGE_SENT_NOT_FOUND,
+        },
+        'Unable to find MessageSent event in logs',
+      );
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.CCTP_MESSAGE_SENT_NOT_FOUND,
+      );
+      throw new Error('Unable to find MessageSent event in logs');
+    }
+
+    // Fast path: only one MessageSent in this tx, no disambiguation needed.
+    if (allMessages.length === 1) {
+      logger.info(
+        { cctpMessage: allMessages[0] },
+        'Found CCTP MessageSent event',
+      );
+      return allMessages[0];
+    }
+
+    // Multiple MessageSent events in the same tx — delegate to the matcher.
+    const parsedMsg = parseMessage(hyperlaneMessage);
+    const bodyBytes = ethers.utils.arrayify(parsedMsg.body);
+    const matched = findMatchingCircleMessage(
+      allMessages,
+      bodyBytes,
+      messageId,
     );
-    PrometheusMetrics.logUnhandledError(
-      this.config.serviceName,
-      UnhandledErrorReason.CCTP_MESSAGE_SENT_NOT_FOUND,
-    );
-    throw new Error('Unable to find MessageSent event in logs');
+
+    if (matched !== allMessages[0]) {
+      logger.info(
+        { cctpMessage: matched, messageId },
+        'Matched CCTP MessageSent event',
+      );
+    } else {
+      logger.warn(
+        { messageId, messageCount: allMessages.length },
+        'Could not match MessageSent by body fields, falling back to first',
+      );
+    }
+
+    return matched;
   }
 
   async getCCTPAttestation(
@@ -179,6 +209,7 @@ class CCTPService extends BaseService {
       .getTransactionReceipt(txHash);
     const cctpMessage = await this.getCCTPMessageFromReceipt(
       receipt,
+      message,
       messageId,
       log,
     );

--- a/typescript/ccip-server/src/services/CCTPService.ts
+++ b/typescript/ccip-server/src/services/CCTPService.ts
@@ -152,6 +152,7 @@ class CCTPService extends BaseService {
       allMessages,
       bodyBytes,
       messageId,
+      parsedMsg.sender,
     );
 
     if (matched !== null) {
@@ -162,11 +163,17 @@ class CCTPService extends BaseService {
       return matched;
     }
 
-    logger.warn(
+    logger.error(
       { messageId, messageCount: allMessages.length },
-      'Could not match MessageSent by body fields, falling back to first',
+      'Could not match MessageSent to Hyperlane message',
     );
-    return allMessages[0];
+    PrometheusMetrics.logUnhandledError(
+      this.config.serviceName,
+      UnhandledErrorReason.CCTP_MESSAGE_SENT_NOT_FOUND,
+    );
+    throw new Error(
+      `Could not match any of ${allMessages.length} MessageSent events to messageId ${messageId}`,
+    );
   }
 
   async getCCTPAttestation(

--- a/typescript/ccip-server/src/services/cctpMessageMatcher.ts
+++ b/typescript/ccip-server/src/services/cctpMessageMatcher.ts
@@ -1,0 +1,95 @@
+import { ethers } from 'ethers';
+
+// CctpMessageV2 + BurnMessageV2 field offsets within the full Circle message.
+// CctpMessageV2 header is 148 bytes; BurnMessageV2 body follows immediately.
+// BurnMessageV2: version(4) burnToken(32) mintRecipient(32) amount(32) ...
+const CIRCLE_HEADER_LENGTH = 148;
+const BURN_MSG_MINT_RECIPIENT_OFFSET = 36; // within BurnMessageV2 body
+const BURN_MSG_AMOUNT_OFFSET = 68; // within BurnMessageV2 body
+export const CIRCLE_MINT_RECIPIENT_OFFSET =
+  CIRCLE_HEADER_LENGTH + BURN_MSG_MINT_RECIPIENT_OFFSET; // 184
+export const CIRCLE_AMOUNT_OFFSET =
+  CIRCLE_HEADER_LENGTH + BURN_MSG_AMOUNT_OFFSET; // 216
+const CIRCLE_BURN_MSG_MIN_LENGTH = CIRCLE_AMOUNT_OFFSET + 32; // 248
+
+// Circle GMP message body = abi.encode(messageId) = 32 bytes starting at header end.
+const CIRCLE_GMP_BODY_OFFSET = CIRCLE_HEADER_LENGTH; // 148
+const CIRCLE_GMP_MSG_LENGTH = CIRCLE_HEADER_LENGTH + 32; // 180
+
+// TokenMessage body layout (Hyperlane warp route):
+// recipient(32) amount(32) [metadata...]
+const TOKEN_MSG_RECIPIENT_OFFSET = 0;
+const TOKEN_MSG_AMOUNT_OFFSET = 32;
+const TOKEN_MSG_MIN_LENGTH = 64;
+
+/**
+ * Given a list of raw Circle message hex strings from a transaction receipt,
+ * return the one that corresponds to the given Hyperlane message.
+ *
+ * Strategy 1 — token transfer (depositForBurn path):
+ *   Matches by (mintRecipient, amount) from the Hyperlane TokenMessage body
+ *   against BurnMessageV2 fields. Circle burn messages are ≥ 248 bytes.
+ *
+ * Strategy 2 — GMP hook path (sendMessageIdToIsm):
+ *   The Circle message body is abi.encode(messageId) = the 32-byte Hyperlane
+ *   message ID at offset 148. Circle GMP messages are exactly 180 bytes.
+ *
+ * Falls back to circleMessages[0] if neither strategy finds a match.
+ */
+export function findMatchingCircleMessage(
+  circleMessages: string[],
+  hyperlaneBody: Uint8Array,
+  messageId: string,
+): string {
+  if (circleMessages.length === 1) return circleMessages[0];
+
+  // Strategy 1: token transfer — match by (mintRecipient, amount)
+  if (hyperlaneBody.length >= TOKEN_MSG_MIN_LENGTH) {
+    const hlRecipient = hyperlaneBody.slice(
+      TOKEN_MSG_RECIPIENT_OFFSET,
+      TOKEN_MSG_RECIPIENT_OFFSET + 32,
+    );
+    const hlAmount = hyperlaneBody.slice(
+      TOKEN_MSG_AMOUNT_OFFSET,
+      TOKEN_MSG_AMOUNT_OFFSET + 32,
+    );
+
+    for (const msg of circleMessages) {
+      const bytes = ethers.utils.arrayify(msg);
+      if (bytes.length < CIRCLE_BURN_MSG_MIN_LENGTH) continue;
+
+      const mintRecipient = bytes.slice(
+        CIRCLE_MINT_RECIPIENT_OFFSET,
+        CIRCLE_MINT_RECIPIENT_OFFSET + 32,
+      );
+      const amount = bytes.slice(
+        CIRCLE_AMOUNT_OFFSET,
+        CIRCLE_AMOUNT_OFFSET + 32,
+      );
+
+      if (
+        Buffer.from(mintRecipient).equals(Buffer.from(hlRecipient)) &&
+        Buffer.from(amount).equals(Buffer.from(hlAmount))
+      ) {
+        return msg;
+      }
+    }
+  }
+
+  // Strategy 2: GMP — match by messageId in Circle message body
+  const messageIdBytes = ethers.utils.arrayify(messageId);
+  for (const msg of circleMessages) {
+    const bytes = ethers.utils.arrayify(msg);
+    if (bytes.length < CIRCLE_GMP_MSG_LENGTH) continue;
+
+    const circleBodyId = bytes.slice(
+      CIRCLE_GMP_BODY_OFFSET,
+      CIRCLE_GMP_BODY_OFFSET + 32,
+    );
+    if (Buffer.from(circleBodyId).equals(Buffer.from(messageIdBytes))) {
+      return msg;
+    }
+  }
+
+  return circleMessages[0];
+}

--- a/typescript/ccip-server/src/services/cctpMessageMatcher.ts
+++ b/typescript/ccip-server/src/services/cctpMessageMatcher.ts
@@ -4,15 +4,18 @@ import { ethers } from 'ethers';
 // so multi-message V1 transactions will not match either strategy and return null.
 // CctpMessageV2 + BurnMessageV2 field offsets within the full Circle message.
 // CctpMessageV2 header is 148 bytes; BurnMessageV2 body follows immediately.
-// BurnMessageV2: version(4) burnToken(32) mintRecipient(32) amount(32) ...
+// BurnMessageV2: version(4) burnToken(32) mintRecipient(32) amount(32) messageSender(32) ...
 const CIRCLE_HEADER_LENGTH = 148;
 const BURN_MSG_MINT_RECIPIENT_OFFSET = 36; // within BurnMessageV2 body
 const BURN_MSG_AMOUNT_OFFSET = 68; // within BurnMessageV2 body
+const BURN_MSG_SENDER_OFFSET = 100; // within BurnMessageV2 body
 export const CIRCLE_MINT_RECIPIENT_OFFSET =
   CIRCLE_HEADER_LENGTH + BURN_MSG_MINT_RECIPIENT_OFFSET; // 184
 export const CIRCLE_AMOUNT_OFFSET =
   CIRCLE_HEADER_LENGTH + BURN_MSG_AMOUNT_OFFSET; // 216
-const CIRCLE_BURN_MSG_MIN_LENGTH = CIRCLE_AMOUNT_OFFSET + 32; // 248
+export const CIRCLE_SENDER_OFFSET =
+  CIRCLE_HEADER_LENGTH + BURN_MSG_SENDER_OFFSET; // 248
+const CIRCLE_BURN_MSG_MIN_LENGTH = CIRCLE_SENDER_OFFSET + 32; // 280
 
 // Circle GMP message body = abi.encode(messageId) = 32 bytes starting at header end.
 const CIRCLE_GMP_BODY_OFFSET = CIRCLE_HEADER_LENGTH; // 148
@@ -29,8 +32,9 @@ const TOKEN_MSG_MIN_LENGTH = 64;
  * return the one that corresponds to the given Hyperlane message.
  *
  * Strategy 1 — token transfer (depositForBurn path):
- *   Matches by (mintRecipient, amount) from the Hyperlane TokenMessage body
- *   against BurnMessageV2 fields. Circle burn messages are ≥ 248 bytes.
+ *   Matches by (messageSender, amount, mintRecipient) from the Hyperlane message
+ *   against BurnMessageV2 fields, mirroring TokenBridgeCctpV2._validateTokenMessage.
+ *   Circle burn messages are ≥ 280 bytes.
  *
  * Strategy 2 — GMP hook path (sendMessageIdToIsm):
  *   The Circle message body is abi.encode(messageId) = the 32-byte Hyperlane
@@ -42,10 +46,12 @@ export function findMatchingCircleMessage(
   circleMessages: string[],
   hyperlaneBody: Uint8Array,
   messageId: string,
+  hyperlaneSender: string,
 ): string | null {
   if (circleMessages.length === 1) return circleMessages[0];
 
-  // Strategy 1: token transfer — match by (mintRecipient, amount)
+  // Strategy 1: token transfer — match by (messageSender, amount, mintRecipient),
+  // mirroring the three-field check in TokenBridgeCctpV2._validateTokenMessage.
   if (hyperlaneBody.length >= TOKEN_MSG_MIN_LENGTH) {
     const hlRecipient = hyperlaneBody.slice(
       TOKEN_MSG_RECIPIENT_OFFSET,
@@ -55,6 +61,7 @@ export function findMatchingCircleMessage(
       TOKEN_MSG_AMOUNT_OFFSET,
       TOKEN_MSG_AMOUNT_OFFSET + 32,
     );
+    const hlSenderBytes = ethers.utils.arrayify(hyperlaneSender);
 
     for (const msg of circleMessages) {
       const bytes = ethers.utils.arrayify(msg);
@@ -68,8 +75,13 @@ export function findMatchingCircleMessage(
         CIRCLE_AMOUNT_OFFSET,
         CIRCLE_AMOUNT_OFFSET + 32,
       );
+      const circleSender = bytes.slice(
+        CIRCLE_SENDER_OFFSET,
+        CIRCLE_SENDER_OFFSET + 32,
+      );
 
       if (
+        Buffer.from(circleSender).equals(Buffer.from(hlSenderBytes)) &&
         Buffer.from(mintRecipient).equals(Buffer.from(hlRecipient)) &&
         Buffer.from(amount).equals(Buffer.from(hlAmount))
       ) {
@@ -82,7 +94,7 @@ export function findMatchingCircleMessage(
   const messageIdBytes = ethers.utils.arrayify(messageId);
   for (const msg of circleMessages) {
     const bytes = ethers.utils.arrayify(msg);
-    if (bytes.length < CIRCLE_GMP_MSG_LENGTH) continue;
+    if (bytes.length !== CIRCLE_GMP_MSG_LENGTH) continue;
 
     const circleBodyId = bytes.slice(
       CIRCLE_GMP_BODY_OFFSET,

--- a/typescript/ccip-server/src/services/cctpMessageMatcher.ts
+++ b/typescript/ccip-server/src/services/cctpMessageMatcher.ts
@@ -1,5 +1,7 @@
 import { ethers } from 'ethers';
 
+// NOTE: Offsets below are for CctpMessageV2 only. V1 header is 116 bytes (not 148),
+// so multi-message V1 transactions will not match either strategy and return null.
 // CctpMessageV2 + BurnMessageV2 field offsets within the full Circle message.
 // CctpMessageV2 header is 148 bytes; BurnMessageV2 body follows immediately.
 // BurnMessageV2: version(4) burnToken(32) mintRecipient(32) amount(32) ...
@@ -34,13 +36,13 @@ const TOKEN_MSG_MIN_LENGTH = 64;
  *   The Circle message body is abi.encode(messageId) = the 32-byte Hyperlane
  *   message ID at offset 148. Circle GMP messages are exactly 180 bytes.
  *
- * Falls back to circleMessages[0] if neither strategy finds a match.
+ * Returns null if neither strategy finds a match.
  */
 export function findMatchingCircleMessage(
   circleMessages: string[],
   hyperlaneBody: Uint8Array,
   messageId: string,
-): string {
+): string | null {
   if (circleMessages.length === 1) return circleMessages[0];
 
   // Strategy 1: token transfer — match by (mintRecipient, amount)
@@ -91,5 +93,5 @@ export function findMatchingCircleMessage(
     }
   }
 
-  return circleMessages[0];
+  return null;
 }

--- a/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
@@ -120,7 +120,7 @@ describe('findMatchingCircleMessage', () => {
   });
 
   describe('fallback', () => {
-    it('returns messages[0] when no strategy matches', () => {
+    it('returns null when no strategy matches', () => {
       const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
       const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
       // Body has wrong recipient/amount and messageId does not match either
@@ -130,7 +130,7 @@ describe('findMatchingCircleMessage', () => {
       );
       expect(
         findMatchingCircleMessage([msgA, msgB], wrongBody, MESSAGE_ID_A),
-      ).to.equal(msgA);
+      ).to.equal(null);
     });
   });
 });

--- a/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
@@ -4,20 +4,23 @@ import { ethers } from 'ethers';
 import {
   CIRCLE_AMOUNT_OFFSET,
   CIRCLE_MINT_RECIPIENT_OFFSET,
+  CIRCLE_SENDER_OFFSET,
   findMatchingCircleMessage,
 } from '../../src/services/cctpMessageMatcher.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Build a minimal CctpMessageV2 + BurnMessageV2 Circle message (≥ 248 bytes).
- *  Only mintRecipient and amount are set meaningfully; everything else is zeros. */
+/** Build a minimal CctpMessageV2 + BurnMessageV2 Circle message (≥ 280 bytes).
+ *  Sets mintRecipient, amount, and messageSender; everything else is zeros. */
 function makeBurnCircleMessage(
   mintRecipient: Uint8Array,
   amount: Uint8Array,
+  sender: Uint8Array = Buffer.alloc(32, 0x00),
 ): string {
-  const buf = Buffer.alloc(248);
+  const buf = Buffer.alloc(280);
   mintRecipient.forEach((b, i) => (buf[CIRCLE_MINT_RECIPIENT_OFFSET + i] = b));
   amount.forEach((b, i) => (buf[CIRCLE_AMOUNT_OFFSET + i] = b));
+  sender.forEach((b, i) => (buf[CIRCLE_SENDER_OFFSET + i] = b));
   return ethers.utils.hexlify(buf);
 }
 
@@ -42,6 +45,10 @@ const RECIPIENT_A = Buffer.alloc(32, 0xaa);
 const RECIPIENT_B = Buffer.alloc(32, 0xbb);
 const AMOUNT_A = Buffer.alloc(32, 0x01);
 const AMOUNT_B = Buffer.alloc(32, 0x02);
+const SENDER_A = Buffer.alloc(32, 0x11);
+const SENDER_B = Buffer.alloc(32, 0x22);
+const SENDER_ZERO = Buffer.alloc(32, 0x00);
+const SENDER_ZERO_HEX = ethers.utils.hexlify(SENDER_ZERO);
 const MESSAGE_ID_A = ethers.utils.hexZeroPad('0xaa', 32);
 const MESSAGE_ID_B = ethers.utils.hexZeroPad('0xbb', 32);
 
@@ -52,27 +59,56 @@ describe('findMatchingCircleMessage', () => {
     it('returns the only message without inspecting its content', () => {
       const msg = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
       const body = makeTokenBody(RECIPIENT_B, AMOUNT_B); // deliberately different
-      const result = findMatchingCircleMessage([msg], body, MESSAGE_ID_A);
+      const result = findMatchingCircleMessage(
+        [msg],
+        body,
+        MESSAGE_ID_A,
+        SENDER_ZERO_HEX,
+      );
       expect(result).to.equal(msg);
     });
   });
 
   describe('multiple token transfer messages', () => {
-    it('matches message A by (mintRecipient, amount)', () => {
-      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
-      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
+    it('matches message A by (messageSender, amount, mintRecipient)', () => {
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B, SENDER_B);
       const bodyA = makeTokenBody(RECIPIENT_A, AMOUNT_A);
       expect(
-        findMatchingCircleMessage([msgA, msgB], bodyA, MESSAGE_ID_A),
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          bodyA,
+          MESSAGE_ID_A,
+          ethers.utils.hexlify(SENDER_A),
+        ),
       ).to.equal(msgA);
     });
 
-    it('matches message B by (mintRecipient, amount)', () => {
-      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
-      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
+    it('matches message B by (messageSender, amount, mintRecipient)', () => {
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B, SENDER_B);
       const bodyB = makeTokenBody(RECIPIENT_B, AMOUNT_B);
       expect(
-        findMatchingCircleMessage([msgA, msgB], bodyB, MESSAGE_ID_B),
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          bodyB,
+          MESSAGE_ID_B,
+          ethers.utils.hexlify(SENDER_B),
+        ),
+      ).to.equal(msgB);
+    });
+
+    it('disambiguates by sender when recipient and amount are identical', () => {
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A, SENDER_B);
+      const body = makeTokenBody(RECIPIENT_A, AMOUNT_A);
+      expect(
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          body,
+          MESSAGE_ID_A,
+          ethers.utils.hexlify(SENDER_B),
+        ),
       ).to.equal(msgB);
     });
   });
@@ -83,7 +119,12 @@ describe('findMatchingCircleMessage', () => {
       const msgB = makeGmpCircleMessage(MESSAGE_ID_B);
       const emptyBody = new Uint8Array(0); // GMP body is not a TokenMessage
       expect(
-        findMatchingCircleMessage([msgA, msgB], emptyBody, MESSAGE_ID_A),
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          emptyBody,
+          MESSAGE_ID_A,
+          SENDER_ZERO_HEX,
+        ),
       ).to.equal(msgA);
     });
 
@@ -92,19 +133,29 @@ describe('findMatchingCircleMessage', () => {
       const msgB = makeGmpCircleMessage(MESSAGE_ID_B);
       const emptyBody = new Uint8Array(0);
       expect(
-        findMatchingCircleMessage([msgA, msgB], emptyBody, MESSAGE_ID_B),
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          emptyBody,
+          MESSAGE_ID_B,
+          SENDER_ZERO_HEX,
+        ),
       ).to.equal(msgB);
     });
   });
 
   describe('mixed token transfer + GMP in same tx', () => {
     it('matches the burn message for a token transfer', () => {
-      const burnMsg = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const burnMsg = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A, SENDER_A);
       const gmpMsg = makeGmpCircleMessage(MESSAGE_ID_B);
       const tokenBody = makeTokenBody(RECIPIENT_A, AMOUNT_A);
       // Strategy 1 finds the burn message; GMP message is too short for strategy 1
       expect(
-        findMatchingCircleMessage([burnMsg, gmpMsg], tokenBody, MESSAGE_ID_A),
+        findMatchingCircleMessage(
+          [burnMsg, gmpMsg],
+          tokenBody,
+          MESSAGE_ID_A,
+          ethers.utils.hexlify(SENDER_A),
+        ),
       ).to.equal(burnMsg);
     });
 
@@ -114,22 +165,72 @@ describe('findMatchingCircleMessage', () => {
       const emptyBody = new Uint8Array(0);
       // Strategy 1 finds nothing (empty body); strategy 2 finds the GMP message
       expect(
-        findMatchingCircleMessage([burnMsg, gmpMsg], emptyBody, MESSAGE_ID_B),
+        findMatchingCircleMessage(
+          [burnMsg, gmpMsg],
+          emptyBody,
+          MESSAGE_ID_B,
+          SENDER_ZERO_HEX,
+        ),
       ).to.equal(gmpMsg);
+    });
+  });
+
+  // Golden vector: byte positions are hardcoded as literals (not via CIRCLE_* constants)
+  // so a wrong constant in cctpMessageMatcher.ts will cause a test failure here.
+  //
+  // CctpMessageV2 header = 148 bytes; BurnMessageV2 body immediately follows:
+  //   version(4) burnToken(32) mintRecipient(32) amount(32) messageSender(32) ...
+  //   ├─ mintRecipient: header(148) + version(4) + burnToken(32) = absolute 184
+  //   ├─ amount:        184 + 32                                 = absolute 216
+  //   └─ messageSender: 216 + 32                                 = absolute 248
+  describe('golden vector — offsets hardcoded, not derived from constants', () => {
+    it('matches the correct burn message by (sender, amount, mintRecipient)', () => {
+      // Burn message A: build entirely from literal byte positions.
+      const burnA = Buffer.alloc(280);
+      burnA.fill(0xaa, 184, 216); // mintRecipient
+      burnA.fill(0x01, 216, 248); // amount
+      burnA.fill(0x11, 248, 280); // messageSender
+
+      // Burn message B: different fields at the same literal positions.
+      const burnB = Buffer.alloc(280);
+      burnB.fill(0xbb, 184, 216); // mintRecipient
+      burnB.fill(0x02, 216, 248); // amount
+      burnB.fill(0x22, 248, 280); // messageSender
+
+      // Hyperlane TokenMessage body: recipient(32) + amount(32)
+      const bodyA = Buffer.alloc(64);
+      bodyA.fill(0xaa, 0, 32); // recipient matches burnA mintRecipient
+      bodyA.fill(0x01, 32, 64); // amount matches burnA amount
+
+      const senderA = ethers.utils.hexlify(Buffer.alloc(32, 0x11));
+
+      expect(
+        findMatchingCircleMessage(
+          [ethers.utils.hexlify(burnA), ethers.utils.hexlify(burnB)],
+          bodyA,
+          MESSAGE_ID_A,
+          senderA,
+        ),
+      ).to.equal(ethers.utils.hexlify(burnA));
     });
   });
 
   describe('fallback', () => {
     it('returns null when no strategy matches', () => {
-      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
-      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
-      // Body has wrong recipient/amount and messageId does not match either
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B, SENDER_B);
+      // Body has wrong recipient/amount/sender and messageId does not match either
       const wrongBody = makeTokenBody(
         Buffer.alloc(32, 0xff),
         Buffer.alloc(32, 0xff),
       );
       expect(
-        findMatchingCircleMessage([msgA, msgB], wrongBody, MESSAGE_ID_A),
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          wrongBody,
+          MESSAGE_ID_A,
+          SENDER_ZERO_HEX,
+        ),
       ).to.equal(null);
     });
   });

--- a/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
@@ -1,0 +1,136 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import {
+  CIRCLE_AMOUNT_OFFSET,
+  CIRCLE_MINT_RECIPIENT_OFFSET,
+  findMatchingCircleMessage,
+} from '../../src/services/cctpMessageMatcher.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a minimal CctpMessageV2 + BurnMessageV2 Circle message (≥ 248 bytes).
+ *  Only mintRecipient and amount are set meaningfully; everything else is zeros. */
+function makeBurnCircleMessage(
+  mintRecipient: Uint8Array,
+  amount: Uint8Array,
+): string {
+  const buf = Buffer.alloc(248);
+  mintRecipient.forEach((b, i) => (buf[CIRCLE_MINT_RECIPIENT_OFFSET + i] = b));
+  amount.forEach((b, i) => (buf[CIRCLE_AMOUNT_OFFSET + i] = b));
+  return ethers.utils.hexlify(buf);
+}
+
+/** Build a CctpMessageV2 GMP Circle message (exactly 180 bytes).
+ *  Body = messageId at bytes [148, 180). */
+function makeGmpCircleMessage(messageId: string): string {
+  const buf = Buffer.alloc(180);
+  const idBytes = ethers.utils.arrayify(messageId);
+  idBytes.forEach((b, i) => (buf[148 + i] = b));
+  return ethers.utils.hexlify(buf);
+}
+
+/** Build a Hyperlane TokenMessage body: recipient(32) + amount(32). */
+function makeTokenBody(recipient: Uint8Array, amount: Uint8Array): Uint8Array {
+  const buf = Buffer.alloc(64);
+  recipient.forEach((b, i) => (buf[i] = b));
+  amount.forEach((b, i) => (buf[32 + i] = b));
+  return buf;
+}
+
+const RECIPIENT_A = Buffer.alloc(32, 0xaa);
+const RECIPIENT_B = Buffer.alloc(32, 0xbb);
+const AMOUNT_A = Buffer.alloc(32, 0x01);
+const AMOUNT_B = Buffer.alloc(32, 0x02);
+const MESSAGE_ID_A = ethers.utils.hexZeroPad('0xaa', 32);
+const MESSAGE_ID_B = ethers.utils.hexZeroPad('0xbb', 32);
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('findMatchingCircleMessage', () => {
+  describe('single message', () => {
+    it('returns the only message without inspecting its content', () => {
+      const msg = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const body = makeTokenBody(RECIPIENT_B, AMOUNT_B); // deliberately different
+      const result = findMatchingCircleMessage([msg], body, MESSAGE_ID_A);
+      expect(result).to.equal(msg);
+    });
+  });
+
+  describe('multiple token transfer messages', () => {
+    it('matches message A by (mintRecipient, amount)', () => {
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
+      const bodyA = makeTokenBody(RECIPIENT_A, AMOUNT_A);
+      expect(
+        findMatchingCircleMessage([msgA, msgB], bodyA, MESSAGE_ID_A),
+      ).to.equal(msgA);
+    });
+
+    it('matches message B by (mintRecipient, amount)', () => {
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
+      const bodyB = makeTokenBody(RECIPIENT_B, AMOUNT_B);
+      expect(
+        findMatchingCircleMessage([msgA, msgB], bodyB, MESSAGE_ID_B),
+      ).to.equal(msgB);
+    });
+  });
+
+  describe('multiple GMP messages', () => {
+    it('matches GMP message A by messageId', () => {
+      const msgA = makeGmpCircleMessage(MESSAGE_ID_A);
+      const msgB = makeGmpCircleMessage(MESSAGE_ID_B);
+      const emptyBody = new Uint8Array(0); // GMP body is not a TokenMessage
+      expect(
+        findMatchingCircleMessage([msgA, msgB], emptyBody, MESSAGE_ID_A),
+      ).to.equal(msgA);
+    });
+
+    it('matches GMP message B by messageId', () => {
+      const msgA = makeGmpCircleMessage(MESSAGE_ID_A);
+      const msgB = makeGmpCircleMessage(MESSAGE_ID_B);
+      const emptyBody = new Uint8Array(0);
+      expect(
+        findMatchingCircleMessage([msgA, msgB], emptyBody, MESSAGE_ID_B),
+      ).to.equal(msgB);
+    });
+  });
+
+  describe('mixed token transfer + GMP in same tx', () => {
+    it('matches the burn message for a token transfer', () => {
+      const burnMsg = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const gmpMsg = makeGmpCircleMessage(MESSAGE_ID_B);
+      const tokenBody = makeTokenBody(RECIPIENT_A, AMOUNT_A);
+      // Strategy 1 finds the burn message; GMP message is too short for strategy 1
+      expect(
+        findMatchingCircleMessage([burnMsg, gmpMsg], tokenBody, MESSAGE_ID_A),
+      ).to.equal(burnMsg);
+    });
+
+    it('matches the GMP message for a GMP transfer', () => {
+      const burnMsg = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const gmpMsg = makeGmpCircleMessage(MESSAGE_ID_B);
+      const emptyBody = new Uint8Array(0);
+      // Strategy 1 finds nothing (empty body); strategy 2 finds the GMP message
+      expect(
+        findMatchingCircleMessage([burnMsg, gmpMsg], emptyBody, MESSAGE_ID_B),
+      ).to.equal(gmpMsg);
+    });
+  });
+
+  describe('fallback', () => {
+    it('returns messages[0] when no strategy matches', () => {
+      const msgA = makeBurnCircleMessage(RECIPIENT_A, AMOUNT_A);
+      const msgB = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B);
+      // Body has wrong recipient/amount and messageId does not match either
+      const wrongBody = makeTokenBody(
+        Buffer.alloc(32, 0xff),
+        Buffer.alloc(32, 0xff),
+      );
+      expect(
+        findMatchingCircleMessage([msgA, msgB], wrongBody, MESSAGE_ID_A),
+      ).to.equal(msgA);
+    });
+  });
+});


### PR DESCRIPTION
### Description

Fixes the ccip-server so multiple CCTP V2 transfers in the same origin transaction are relayed correctly.

**Root cause:** when a transaction contains N CCTP transfers (token or GMP), the receipt has N `MessageSent` logs and Circle's attestation API returns N entries. The ccip-server was called once per Hyperlane message but always returned `messages[0]` — the first Circle message and attestation — regardless of which Hyperlane message was being processed. Every message beyond the first received the wrong attestation and could never be delivered.

**Fix:** extract a pure `findMatchingCircleMessage` function that identifies the correct Circle message for a given Hyperlane message using two strategies:

- **Token transfers (depositForBurn path):** match by `(mintRecipient, amount)` from the Hyperlane `TokenMessage` body against `BurnMessageV2` fields at bytes `[184,216)` and `[216,248)` of the Circle message. Burn messages are ≥ 248 bytes so GMP messages (180 bytes) are naturally skipped.
- **GMP hook path (sendMessageIdToIsm):** match by the Hyperlane message ID at bytes `[148,180)` of the Circle message body, where `_sendMessageIdToIsm` places `abi.encode(messageId)`.

Falls back to `messages[0]` in both the receipt scan and the Circle API response if neither strategy matches (backwards compatible with single-transfer txs).

`CCTPAttestationService.getAttestation` is also fixed to find the matching attestation entry by byte-comparing the Circle message instead of hardcoding `messages[0]`.

### Drive-by changes

None.

### Related issues

<!-- - Fixes #[issue number here] -->

### Backward compatibility

Yes. The fast path (`allMessages.length === 1`) is unchanged. The new matching only activates when there are multiple `MessageSent` events in the same tx, and falls back to `messages[0]` if no match is found — identical to the previous behaviour for single-transfer txs.

### Testing

Unit tests added for `findMatchingCircleMessage` covering:
- Single message (fast path)
- Multiple token transfers (Strategy 1)
- Multiple GMP messages (Strategy 2)
- Mixed token + GMP in the same tx
- Fallback to `messages[0]` when no strategy matches