### PR TITLE
feat(cli): add hook deploy command

### DIFF
--- a/.changeset/gentle-pots-appear.md
+++ b/.changeset/gentle-pots-appear.md
@@ -1,0 +1,12 @@
+---
+"@hyperlane-xyz/provider-sdk": minor
+"@hyperlane-xyz/starknet-sdk": minor
+"@hyperlane-xyz/cosmos-sdk": minor
+"@hyperlane-xyz/radix-sdk": minor
+"@hyperlane-xyz/aleo-sdk": minor
+"@hyperlane-xyz/tron-sdk": minor
+"@hyperlane-xyz/sealevel-sdk": minor
+"@hyperlane-xyz/cli": minor
+---
+
+Added new hook deploy command

--- a/.github/workflows/test-cli-e2e.yml
+++ b/.github/workflows/test-cli-e2e.yml
@@ -80,6 +80,8 @@ jobs:
           - core-deploy
           - core-init
           - core-read
+          # Hook Commands
+          - hook-deploy
           # ISM Commands
           - ism
           # Other commands
@@ -181,6 +183,8 @@ jobs:
           - core-check
           - core-deploy
           - core-read
+          # Hook Commands
+          - hook-deploy
           # ISM Commands
           - ism
           # Warp Commands

--- a/typescript/aleo-sdk/src/clients/protocol.ts
+++ b/typescript/aleo-sdk/src/clients/protocol.ts
@@ -204,6 +204,7 @@ export class AleoProtocolProvider implements ProtocolProvider {
       TEST_SEND_GAS: 0n,
       AVS_GAS: 0n,
       ISM_DEPLOY_GAS: 0n,
+      HOOK_DEPLOY_GAS: 0n,
     };
   }
 }

--- a/typescript/cli/src/commands/hook.ts
+++ b/typescript/cli/src/commands/hook.ts
@@ -1,12 +1,17 @@
 import { type CommandModule } from 'yargs';
 
-import { type CommandModuleWithContext } from '../context/types.js';
+import {
+  type CommandModuleWithContext,
+  type CommandModuleWithWriteContext,
+} from '../context/types.js';
+import { runHookDeploy } from '../hook/deploy.js';
 import { readHookConfig } from '../hook/read.js';
 import { log, logGray } from '../logger.js';
 
 import {
   addressCommandOption,
   chainCommandOption,
+  inputFileCommandOption,
   outputFileCommandOption,
 } from './options.js';
 
@@ -16,8 +21,47 @@ import {
 export const hookCommand: CommandModule = {
   command: 'hook',
   describe: 'Operations relating to Hooks',
-  builder: (yargs) => yargs.command(read).version(false).demandCommand(),
+  builder: (yargs) =>
+    yargs.command(deploy).command(read).version(false).demandCommand(),
   handler: () => log('Command required'),
+};
+
+// Examples for testing:
+// Deploy a merkle tree hook:
+//     hyperlane hook deploy --chain sepolia --config ./hook-config.yaml
+// Deploy with output file:
+//     hyperlane hook deploy --chain sepolia --config ./hook-config.yaml --out ./deployed-hook.json
+export const deploy: CommandModuleWithWriteContext<{
+  chain: string;
+  config: string;
+  out?: string;
+}> = {
+  command: 'deploy',
+  describe: 'Deploys a Hook to a chain',
+  builder: {
+    chain: {
+      ...chainCommandOption,
+      demandOption: true,
+    },
+    config: inputFileCommandOption({
+      description: 'Path to Hook configuration file (YAML or JSON)',
+      demandOption: true,
+    }),
+    out: outputFileCommandOption(
+      undefined,
+      false,
+      'Output file path for deployed Hook address',
+    ),
+  },
+  handler: async ({ context, chain, config, out }) => {
+    await runHookDeploy({
+      context,
+      chain,
+      configPath: config,
+      outPath: out,
+    });
+    process.exit(0);
+  },
 };
 
 // Examples for testing:

--- a/typescript/cli/src/commands/signCommands.ts
+++ b/typescript/cli/src/commands/signCommands.ts
@@ -51,4 +51,6 @@ export enum CommandType {
   ICA_DEPLOY = 'ica:deploy',
   ISM_DEPLOY = 'ism:deploy',
   ISM_READ = 'ism:read',
+  HOOK_DEPLOY = 'hook:deploy',
+  HOOK_READ = 'hook:read',
 }

--- a/typescript/cli/src/consts.ts
+++ b/typescript/cli/src/consts.ts
@@ -4,6 +4,7 @@ export const ETHEREUM_MINIMUM_GAS: MinimumRequiredGasByAction = {
   CORE_DEPLOY_GAS: BigInt(1e8),
   WARP_DEPLOY_GAS: BigInt(3e7),
   ISM_DEPLOY_GAS: BigInt(5e5),
+  HOOK_DEPLOY_GAS: BigInt(5e5),
   TEST_SEND_GAS: BigInt(3e5),
   AVS_GAS: BigInt(3e6),
 };

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -70,6 +70,8 @@ export async function resolveChains(
     case CommandType.CORE_CHECK:
     case CommandType.ISM_DEPLOY:
     case CommandType.ISM_READ:
+    case CommandType.HOOK_DEPLOY:
+    case CommandType.HOOK_READ:
       return resolveChain(argv);
     case CommandType.ICA_DEPLOY:
       return resolveIcaDeployChains(argv);

--- a/typescript/cli/src/hook/deploy.ts
+++ b/typescript/cli/src/hook/deploy.ts
@@ -1,0 +1,203 @@
+import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
+import { createHookWriter } from '@hyperlane-xyz/deploy-sdk';
+import { GasAction } from '@hyperlane-xyz/provider-sdk';
+import {
+  type HookConfig as ProviderHookConfig,
+  hookConfigToArtifact,
+} from '@hyperlane-xyz/provider-sdk/hook';
+import {
+  ContractVerifier,
+  EvmHookModule,
+  ExplorerLicenseType,
+  type HookConfig,
+  HookConfigSchema,
+  altVmChainLookup,
+  extractIsmAndHookFactoryAddresses,
+  isHookCompatible,
+} from '@hyperlane-xyz/sdk';
+import { type Address, assert, isEVMLike, mustGet } from '@hyperlane-xyz/utils';
+
+import { requestAndSaveApiKeys } from '../context/apiKeys.js';
+import { type WriteCommandContext } from '../context/types.js';
+import {
+  completeDeploy,
+  getBalances,
+  runPreflightChecksForChains,
+} from '../deploy/utils.js';
+import { log, logBlue, logCommandHeader, logGreen } from '../logger.js';
+import { readYamlOrJson, writeFileAtPath } from '../utils/files.js';
+
+interface HookDeployParams {
+  context: WriteCommandContext;
+  chain: string;
+  configPath: string;
+  outPath?: string;
+}
+
+export async function runHookDeploy({
+  context,
+  chain,
+  configPath,
+  outPath,
+}: HookDeployParams): Promise<void> {
+  logCommandHeader('Hyperlane Hook Deploy');
+
+  const { multiProvider, registry, skipConfirmation, chainMetadata } = context;
+
+  const rawConfig = await readYamlOrJson(configPath);
+  const parseResult = HookConfigSchema.safeParse(rawConfig);
+  if (!parseResult.success) {
+    const firstIssue = parseResult.error.issues[0];
+    throw new Error(
+      `Invalid Hook config: ${firstIssue.path.join('.')} => ${firstIssue.message}`,
+    );
+  }
+  const hookConfig: HookConfig = parseResult.data;
+
+  assert(
+    typeof hookConfig !== 'string',
+    'Hook config must be an object, not an address string',
+  );
+
+  const { technicalStack } = multiProvider.getChainMetadata(chain);
+  assert(
+    isHookCompatible({
+      hookType: hookConfig.type,
+      chainTechnicalStack: technicalStack,
+    }),
+    `Hook type ${hookConfig.type} is not compatible with chain ${chain} (technical stack: ${technicalStack})`,
+  );
+
+  const chainAddresses = await registry.getChainAddresses(chain);
+  assert(chainAddresses, `No registry addresses found for chain ${chain}`);
+  assert(chainAddresses.mailbox, `No mailbox address found for chain ${chain}`);
+
+  let apiKeys: Record<string, string> = {};
+  if (!skipConfirmation) {
+    apiKeys = await requestAndSaveApiKeys([chain], chainMetadata, registry);
+  }
+
+  await runPreflightChecksForChains({
+    context,
+    chains: [chain],
+    minGas: GasAction.HOOK_DEPLOY_GAS,
+  });
+
+  const initialBalances = await getBalances(context, [chain]);
+
+  logBlue(`Deploying ${hookConfig.type} Hook to ${chain}...`);
+
+  const protocol = multiProvider.getProtocol(chain);
+  let deployedAddress: Address;
+
+  if (isEVMLike(protocol)) {
+    deployedAddress = await deployEvmHook({
+      context,
+      chain,
+      hookConfig,
+      chainAddresses,
+      apiKeys,
+    });
+  } else {
+    deployedAddress = await deployNonEvmHook({
+      context,
+      chain,
+      hookConfig,
+    });
+  }
+
+  logGreen(`\n✅ Hook deployed successfully!`);
+  log(`Hook Address: ${deployedAddress}`);
+  log(`Chain: ${chain}`);
+  log(`Type: ${hookConfig.type}`);
+
+  if (outPath) {
+    const output = {
+      chain,
+      type: hookConfig.type,
+      address: deployedAddress,
+    };
+    writeFileAtPath(outPath, JSON.stringify(output, null, 2) + '\n');
+    logGreen(`Output written to ${outPath}`);
+  }
+
+  await completeDeploy(context, 'hook', initialBalances, null, [chain]);
+}
+
+async function deployEvmHook({
+  context,
+  chain,
+  hookConfig,
+  chainAddresses,
+  apiKeys,
+}: {
+  context: WriteCommandContext;
+  chain: string;
+  hookConfig: Exclude<HookConfig, string>;
+  chainAddresses: Record<string, string>;
+  apiKeys: Record<string, string>;
+}): Promise<Address> {
+  const { multiProvider } = context;
+
+  const contractVerifier = new ContractVerifier(
+    multiProvider,
+    apiKeys,
+    coreBuildArtifact,
+    ExplorerLicenseType.MIT,
+  );
+
+  const proxyFactoryFactories =
+    extractIsmAndHookFactoryAddresses(chainAddresses);
+
+  assert(
+    chainAddresses.proxyAdmin,
+    `No proxyAdmin address found for chain ${chain}`,
+  );
+
+  const evmHookModule = await EvmHookModule.create({
+    chain,
+    multiProvider,
+    coreAddresses: {
+      mailbox: chainAddresses.mailbox,
+      proxyAdmin: chainAddresses.proxyAdmin,
+    },
+    config: hookConfig,
+    proxyFactoryFactories,
+    contractVerifier,
+  });
+
+  const { deployedHook } = evmHookModule.serialize();
+  return deployedHook;
+}
+
+async function deployNonEvmHook({
+  context,
+  chain,
+  hookConfig,
+}: {
+  context: WriteCommandContext;
+  chain: string;
+  hookConfig: Exclude<HookConfig, string>;
+}): Promise<Address> {
+  const { multiProvider, altVmSigners, registry } = context;
+
+  const signer = mustGet(altVmSigners, chain);
+  const chainLookup = altVmChainLookup(multiProvider);
+  const chainMetadata = chainLookup.getChainMetadata(chain);
+
+  const addresses = await registry.getChainAddresses(chain);
+  const writer = createHookWriter(chainMetadata, chainLookup, signer, {
+    mailbox: addresses?.mailbox,
+  });
+
+  const artifact = hookConfigToArtifact(
+    hookConfig as ProviderHookConfig,
+    chainLookup,
+  );
+  const result = await writer.create(artifact);
+  assert(
+    result.length > 0,
+    `Hook deployment via writer.create() returned no results for chain ${chain}`,
+  );
+  return result[0].deployed.address;
+}

--- a/typescript/cli/src/hook/deploy.ts
+++ b/typescript/cli/src/hook/deploy.ts
@@ -11,6 +11,7 @@ import {
   ExplorerLicenseType,
   type HookConfig,
   HookConfigSchema,
+  HookType,
   altVmChainLookup,
   extractIsmAndHookFactoryAddresses,
   isHookCompatible,
@@ -59,6 +60,16 @@ export async function runHookDeploy({
     'Hook config must be an object, not an address string',
   );
 
+  const unsupportedByDeployCommand: string[] = [
+    HookType.RATE_LIMITED,
+    HookType.OP_STACK,
+    HookType.ARB_L2_TO_L1,
+  ];
+  assert(
+    !unsupportedByDeployCommand.includes(hookConfig.type),
+    `Hook type ${hookConfig.type} is not supported by 'hook deploy': it requires additional chain or contract context not wired up by this command`,
+  );
+
   const { technicalStack } = multiProvider.getChainMetadata(chain);
   assert(
     isHookCompatible({
@@ -103,6 +114,7 @@ export async function runHookDeploy({
       context,
       chain,
       hookConfig,
+      chainAddresses,
     });
   }
 
@@ -170,28 +182,61 @@ async function deployEvmHook({
   return deployedHook;
 }
 
+function toProviderHookConfig(
+  config: Exclude<HookConfig, string>,
+): ProviderHookConfig {
+  switch (config.type) {
+    case HookType.MERKLE_TREE:
+      return { type: 'merkleTreeHook' };
+    case HookType.INTERCHAIN_GAS_PAYMASTER:
+      return {
+        type: 'interchainGasPaymaster',
+        owner: config.owner,
+        beneficiary: config.beneficiary,
+        oracleKey: config.oracleKey,
+        overhead: config.overhead,
+        oracleConfig: config.oracleConfig,
+      };
+    case HookType.PROTOCOL_FEE:
+      return {
+        type: 'protocolFee',
+        owner: config.owner,
+        beneficiary: config.beneficiary,
+        maxProtocolFee: config.maxProtocolFee,
+        protocolFee: config.protocolFee,
+      };
+    case HookType.UNKNOWN:
+      return { type: 'unknownHook' };
+    default:
+      throw new Error(
+        `Hook type '${config.type}' is not supported for non-EVM deployment`,
+      );
+  }
+}
+
 async function deployNonEvmHook({
   context,
   chain,
   hookConfig,
+  chainAddresses,
 }: {
   context: WriteCommandContext;
   chain: string;
   hookConfig: Exclude<HookConfig, string>;
+  chainAddresses: Record<string, string>;
 }): Promise<Address> {
-  const { multiProvider, altVmSigners, registry } = context;
+  const { multiProvider, altVmSigners } = context;
 
   const signer = mustGet(altVmSigners, chain);
   const chainLookup = altVmChainLookup(multiProvider);
   const chainMetadata = chainLookup.getChainMetadata(chain);
 
-  const addresses = await registry.getChainAddresses(chain);
   const writer = createHookWriter(chainMetadata, chainLookup, signer, {
-    mailbox: addresses?.mailbox,
+    mailbox: chainAddresses.mailbox,
   });
 
   const artifact = hookConfigToArtifact(
-    hookConfig as ProviderHookConfig,
+    toProviderHookConfig(hookConfig),
     chainLookup,
   );
   const result = await writer.create(artifact);

--- a/typescript/cli/src/hook/deploy.ts
+++ b/typescript/cli/src/hook/deploy.ts
@@ -28,6 +28,34 @@ import {
 import { log, logBlue, logCommandHeader, logGreen } from '../logger.js';
 import { readYamlOrJson, writeFileAtPath } from '../utils/files.js';
 
+const UNSUPPORTED_BY_DEPLOY_COMMAND = new Set<string>([
+  HookType.RATE_LIMITED,
+  HookType.OP_STACK,
+  HookType.ARB_L2_TO_L1,
+  HookType.CCIP,
+]);
+
+function collectHookTypes(config: HookConfig): string[] {
+  if (typeof config === 'string') return [];
+  const types: string[] = [config.type];
+  if (config.type === HookType.AGGREGATION) {
+    for (const h of config.hooks) types.push(...collectHookTypes(h));
+  } else if (
+    config.type === HookType.ROUTING ||
+    config.type === HookType.FALLBACK_ROUTING
+  ) {
+    for (const h of Object.values(config.domains))
+      types.push(...collectHookTypes(h));
+    if (config.type === HookType.FALLBACK_ROUTING) {
+      types.push(...collectHookTypes(config.fallback));
+    }
+  } else if (config.type === HookType.AMOUNT_ROUTING) {
+    types.push(...collectHookTypes(config.lowerHook));
+    types.push(...collectHookTypes(config.upperHook));
+  }
+  return types;
+}
+
 interface HookDeployParams {
   context: WriteCommandContext;
   chain: string;
@@ -60,15 +88,12 @@ export async function runHookDeploy({
     'Hook config must be an object, not an address string',
   );
 
-  const unsupportedByDeployCommand: string[] = [
-    HookType.RATE_LIMITED,
-    HookType.OP_STACK,
-    HookType.ARB_L2_TO_L1,
-  ];
-  assert(
-    !unsupportedByDeployCommand.includes(hookConfig.type),
-    `Hook type ${hookConfig.type} is not supported by 'hook deploy': it requires additional chain or contract context not wired up by this command`,
-  );
+  for (const type of collectHookTypes(hookConfig)) {
+    assert(
+      !UNSUPPORTED_BY_DEPLOY_COMMAND.has(type),
+      `Hook type ${type} is not supported by 'hook deploy': it requires additional chain or contract context not wired up by this command`,
+    );
+  }
 
   const { technicalStack } = multiProvider.getChainMetadata(chain);
   assert(

--- a/typescript/cli/src/tests/commands/hook.ts
+++ b/typescript/cli/src/tests/commands/hook.ts
@@ -1,0 +1,39 @@
+import { $, type ProcessPromise } from 'zx';
+
+import { localTestRunCmdPrefix } from './helpers.js';
+
+$.verbose = true;
+
+export function hyperlaneHookDeploy({
+  chain,
+  configPath,
+  keyFlags,
+  registryPath,
+  outPath,
+}: {
+  chain: string;
+  configPath: string;
+  keyFlags: string[];
+  registryPath: string;
+  outPath?: string;
+}): ProcessPromise {
+  const cmdPrefix = localTestRunCmdPrefix();
+  const flags = [
+    '--chain',
+    chain,
+    '--config',
+    configPath,
+    ...keyFlags,
+    '--registry',
+    registryPath,
+    '--verbosity',
+    'debug',
+    '--yes',
+  ];
+
+  if (outPath) {
+    flags.push('--out', outPath);
+  }
+
+  return $`${cmdPrefix} hyperlane hook deploy ${flags}`;
+}

--- a/typescript/cli/src/tests/cosmosnative/hook/hook-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/hook/hook-deploy.e2e-test.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+
+import { HookType } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { HyperlaneE2ECoreTestCommands } from '../../commands/core.js';
+import { hyperlaneHookDeploy } from '../../commands/hook.js';
+import {
+  CHAIN_NAME_1,
+  CORE_CONFIG_PATH,
+  CORE_READ_CONFIG_PATH_1,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  HYP_KEY,
+  REGISTRY_PATH,
+  TEMP_PATH,
+} from '../consts.js';
+
+const HOOK_CONFIG_PATH = `${TEMP_PATH}/hook-deploy-cosmos-config.yaml`;
+const HOOK_OUTPUT_PATH = `${TEMP_PATH}/hook-deploy-cosmos-output.json`;
+
+describe('hyperlane hook deploy e2e tests (CosmosNative)', async function () {
+  this.timeout(DEFAULT_E2E_TEST_TIMEOUT);
+
+  const hyperlaneCore = new HyperlaneE2ECoreTestCommands(
+    ProtocolType.CosmosNative,
+    CHAIN_NAME_1,
+    REGISTRY_PATH,
+    CORE_CONFIG_PATH,
+    CORE_READ_CONFIG_PATH_1,
+  );
+
+  before(async () => {
+    await hyperlaneCore.deployOrUseExistingCore(HYP_KEY);
+  });
+
+  it('should deploy a merkleTree hook and return its address', async () => {
+    writeYamlOrJson(HOOK_CONFIG_PATH, {
+      type: HookType.MERKLE_TREE,
+    });
+
+    const output = await hyperlaneHookDeploy({
+      chain: CHAIN_NAME_1,
+      configPath: HOOK_CONFIG_PATH,
+      keyFlags: [`--key.${ProtocolType.CosmosNative}`, HYP_KEY],
+      registryPath: REGISTRY_PATH,
+      outPath: HOOK_OUTPUT_PATH,
+    });
+
+    expect(output.exitCode).to.equal(0);
+    expect(output.stdout).to.include('Hook deployed successfully');
+
+    const result: { chain: string; type: string; address: string } =
+      readYamlOrJson(HOOK_OUTPUT_PATH);
+    expect(result.chain).to.equal(CHAIN_NAME_1);
+    expect(result.type).to.equal(HookType.MERKLE_TREE);
+    expect(result.address).to.be.a('string').and.not.empty;
+  });
+});

--- a/typescript/cli/src/tests/cosmosnative/run-e2e-test.sh
+++ b/typescript/cli/src/tests/cosmosnative/run-e2e-test.sh
@@ -17,7 +17,7 @@ function run() {
     echo "Running only ${CLI_E2E_TEST} test"
     pnpm mocha --config src/tests/cosmosnative/.mocharc-e2e.json "src/tests/cosmosnative/**/${CLI_E2E_TEST}.e2e-test.ts"
   else
-    pnpm mocha --config src/tests/cosmosnative/.mocharc-e2e.json "src/tests/cosmosnative/**/core-deploy.e2e-test.ts"
+    pnpm mocha --config src/tests/cosmosnative/.mocharc-e2e.json "src/tests/cosmosnative/**/core-deploy.e2e-test.ts" "src/tests/cosmosnative/**/hook-deploy.e2e-test.ts"
   fi
 }
 

--- a/typescript/cli/src/tests/ethereum/hook/hook-deploy.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/hook/hook-deploy.e2e-test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+
+import { HookType } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { HyperlaneE2ECoreTestCommands } from '../../commands/core.js';
+import { hyperlaneHookDeploy } from '../../commands/hook.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CORE_CONFIG_PATH,
+  CORE_READ_CONFIG_PATH_2,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  TEMP_PATH,
+} from '../consts.js';
+
+const HOOK_CONFIG_PATH = `${TEMP_PATH}/hook-deploy-evm-config.yaml`;
+const HOOK_OUTPUT_PATH = `${TEMP_PATH}/hook-deploy-evm-output.json`;
+
+describe('hyperlane hook deploy e2e tests (EVM)', async function () {
+  this.timeout(DEFAULT_E2E_TEST_TIMEOUT);
+
+  const hyperlaneCore = new HyperlaneE2ECoreTestCommands(
+    ProtocolType.Ethereum,
+    CHAIN_NAME_2,
+    REGISTRY_PATH,
+    CORE_CONFIG_PATH,
+    CORE_READ_CONFIG_PATH_2,
+  );
+
+  before(async () => {
+    await hyperlaneCore.deployOrUseExistingCore(ANVIL_KEY);
+  });
+
+  it('should deploy a protocolFee hook and return its address', async () => {
+    writeYamlOrJson(HOOK_CONFIG_PATH, {
+      type: HookType.PROTOCOL_FEE,
+      maxProtocolFee: '1000000000000000000',
+      protocolFee: '200000000000000',
+      beneficiary: ANVIL_DEPLOYER_ADDRESS,
+      owner: ANVIL_DEPLOYER_ADDRESS,
+    });
+
+    const output = await hyperlaneHookDeploy({
+      chain: CHAIN_NAME_2,
+      configPath: HOOK_CONFIG_PATH,
+      keyFlags: ['--key', ANVIL_KEY],
+      registryPath: REGISTRY_PATH,
+      outPath: HOOK_OUTPUT_PATH,
+    });
+
+    expect(output.exitCode).to.equal(0);
+    expect(output.stdout).to.include('Hook deployed successfully');
+
+    const result: { chain: string; type: string; address: string } =
+      readYamlOrJson(HOOK_OUTPUT_PATH);
+    expect(result.chain).to.equal(CHAIN_NAME_2);
+    expect(result.type).to.equal(HookType.PROTOCOL_FEE);
+    expect(result.address).to.match(/^0x[0-9a-fA-F]{40}$/);
+    expect(result.address).to.not.equal(
+      '0x0000000000000000000000000000000000000000',
+    );
+  });
+});

--- a/typescript/cosmos-sdk/src/clients/protocol.ts
+++ b/typescript/cosmos-sdk/src/clients/protocol.ts
@@ -132,6 +132,7 @@ export class CosmosNativeProtocolProvider implements ProtocolProvider {
       TEST_SEND_GAS: BigInt(3e5),
       AVS_GAS: BigInt(3e6),
       ISM_DEPLOY_GAS: BigInt(5e5),
+      HOOK_DEPLOY_GAS: BigInt(5e5),
     };
   }
 }

--- a/typescript/provider-sdk/src/mingas.ts
+++ b/typescript/provider-sdk/src/mingas.ts
@@ -2,6 +2,7 @@ export enum GasAction {
   CORE_DEPLOY_GAS = 'CORE_DEPLOY_GAS',
   WARP_DEPLOY_GAS = 'WARP_DEPLOY_GAS',
   ISM_DEPLOY_GAS = 'ISM_DEPLOY_GAS',
+  HOOK_DEPLOY_GAS = 'HOOK_DEPLOY_GAS',
   TEST_SEND_GAS = 'TEST_SEND_GAS',
   AVS_GAS = 'AVS_GAS',
 }
@@ -10,6 +11,7 @@ export type MinimumRequiredGasByAction = {
   [GasAction.CORE_DEPLOY_GAS]: bigint;
   [GasAction.WARP_DEPLOY_GAS]: bigint;
   [GasAction.ISM_DEPLOY_GAS]: bigint;
+  [GasAction.HOOK_DEPLOY_GAS]: bigint;
   [GasAction.TEST_SEND_GAS]: bigint;
   [GasAction.AVS_GAS]: bigint;
 };

--- a/typescript/radix-sdk/src/clients/protocol.ts
+++ b/typescript/radix-sdk/src/clients/protocol.ts
@@ -125,6 +125,7 @@ export class RadixProtocolProvider implements ProtocolProvider {
       TEST_SEND_GAS: 0n,
       AVS_GAS: 0n,
       ISM_DEPLOY_GAS: 0n,
+      HOOK_DEPLOY_GAS: 0n,
     };
   }
 

--- a/typescript/starknet-sdk/src/clients/protocol.ts
+++ b/typescript/starknet-sdk/src/clients/protocol.ts
@@ -104,6 +104,7 @@ export class StarknetProtocolProvider implements ProtocolProvider {
       TEST_SEND_GAS: BigInt(3e7),
       AVS_GAS: BigInt(3e8),
       ISM_DEPLOY_GAS: BigInt(5e7),
+      HOOK_DEPLOY_GAS: BigInt(5e7),
     };
   }
 }

--- a/typescript/svm-sdk/src/clients/protocol.ts
+++ b/typescript/svm-sdk/src/clients/protocol.ts
@@ -105,6 +105,7 @@ export class SvmProtocolProvider implements ProtocolProvider {
       TEST_SEND_GAS: 0n,
       AVS_GAS: 0n,
       ISM_DEPLOY_GAS: 0n,
+      HOOK_DEPLOY_GAS: 0n,
     };
   }
 

--- a/typescript/tron-sdk/src/clients/protocol.ts
+++ b/typescript/tron-sdk/src/clients/protocol.ts
@@ -100,6 +100,7 @@ export class TronProtocolProvider implements ProtocolProvider {
       CORE_DEPLOY_GAS: BigInt(1e9),
       WARP_DEPLOY_GAS: BigInt(1e9),
       ISM_DEPLOY_GAS: BigInt(1e9),
+      HOOK_DEPLOY_GAS: BigInt(1e9),
       TEST_SEND_GAS: BigInt(1e9),
       AVS_GAS: BigInt(1e9),
     };


### PR DESCRIPTION
## Summary

- Adds `hyperlane hook deploy --chain <chain> --config <path> [--out <path>]` command mirroring `ism deploy`
- Adds `HOOK_DEPLOY_GAS` to `GasAction` enum and `MinimumRequiredGasByAction` type in `provider-sdk`, with values filled in for all chain SDKs (aleo, cosmos, radix, starknet, svm, tron)
- Registers `HOOK_DEPLOY` and `HOOK_READ` in `CommandType` and `chainResolver` so the signer middleware scopes to the specified chain only — fixes spurious key prompts for unrelated protocols (e.g. Tron when deploying to Ethereum)

## Test plan

- [x] `hyperlane hook deploy --chain sepolia --config ./hook-config.yaml` deploys hook and logs address
- [x] `--out ./deployed.json` writes `{ chain, type, address }` to file
- [x] Running against an Ethereum chain does not prompt for Tron key
- [x] Invalid config produces a clear error message
- [x] Incompatible hook type for chain technical stack is rejected with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)