### PR TITLE
docs(review): add e2e coverage, allocation, and concurrent-review learnings

### DIFF
--- a/.claude/skills/claude-review/SKILL.md
+++ b/.claude/skills/claude-review/SKILL.md
@@ -17,6 +17,8 @@ Use this skill to review code changes against Hyperlane monorepo standards.
 
 Read and apply the guidelines from `REVIEW.md` to review the code changes.
 
+When delegating the review to subagents/teams, pass `REVIEW.md` to each one so every checklist item (e2e tests, casts, allocations, enums) is actually applied — findings the rules already cover should never slip through.
+
 ### For PR Reviews
 
 When reviewing a PR, deliver feedback as a **single consolidated GitHub review** using `/inline-pr-comments`. Each run produces a separate review — nothing is overwritten.

--- a/.claude/skills/inline-pr-comments/SKILL.md
+++ b/.claude/skills/inline-pr-comments/SKILL.md
@@ -38,6 +38,8 @@ Use this context to:
 - **Flag unresolved issues** — if a prior review raised something that still isn't fixed, note it briefly (e.g. "Still unresolved from prior review: ...")
 - **Avoid contradictions** — don't suggest the opposite of what a human reviewer requested
 
+**Re-fetch immediately before submitting.** Other reviewers may be reviewing concurrently. Critically, the GitHub API does **not** expose a reviewer's draft/pending comments until they submit — so you can post a review seconds before a concurrent reviewer submits theirs and never have seen their notes. Re-run the fetch right before Step 4, and state the HEAD commit your review is based on in the body (e.g. "Reviewed at `<sha>`") so readers know the snapshot.
+
 ### Step 2: Collect All Findings
 
 Complete the full review. Collect:

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -26,10 +26,12 @@
 - Edge cases that should be tested
 - **New utility functions need unit tests**
 - **CLI changes need e2e tests** - `test:ethereum:e2e`, `test:cosmosnative:e2e`
+- **New CLI subcommands need e2e coverage** - A new command (e.g. `hook deploy`) should add at least one EVM e2e test AND one altVM e2e test to prove both deploy paths work. If a PR adds a command with no e2e test, flag the gap explicitly — green unit/codecov coverage does not satisfy this.
 
 ## Performance
 
 - Unnecessary allocations or computations
+- **Hoist invariant constants out of function bodies** - Arrays, objects, and regexes that don't depend on arguments should be module-level `const`s, not recreated on every call (e.g. a fixed `unsupportedTypes` list).
 
 ## Changesets
 
@@ -90,3 +92,15 @@ The only acceptable cast is one with a `// CAST:` comment explaining why it's un
 - **Interface changes** - Deprecate before removing; add new methods alongside old
 - **Storage layout** - Document migration path for upgradeable contracts
 - **Config schema changes** - Ensure backward compatibility or migration scripts
+
+## Validation Gaps to Watch For
+
+- **Recursive/nested configs bypass top-level guards** - If a command rejects unsupported types by checking only the top-level discriminant (e.g. `hookConfig.type`), verify nested configs can't smuggle an unsupported type through. Aggregation/routing hooks and ISMs recurse into `hooks`/`domains`/`fallback`/sub-ISMs; a guard that only inspects the root lets a nested unsupported type fail deep in the deploy instead of up front.
+- **Partial provisioning** - A command that provisions only the origin `--chain` (signer/preflight/balances) but accepts config referencing other chains (destination, remote domains) will fail partway. Confirm the accepted config schema can't require resources the command never sets up.
+
+## Reviewing Process
+
+- **Seed review agents with this file** - When delegating review to subagents, pass `REVIEW.md` so every checklist item (e2e tests, casts, allocations, enums) is actually applied. Findings the rules already cover should never be missed.
+- **Account for prior reviews** - Read existing reviews, inline threads, and author responses first; acknowledge what's already addressed rather than re-raising it.
+- **Pending reviews are invisible until submitted** - The GitHub API does not expose another reviewer's draft/pending comments until they submit. You may post a review seconds before a concurrent reviewer submits theirs and never see their notes. State the HEAD commit your review is based on, and re-fetch reviews/comments immediately before posting to catch anything newly submitted.
+- **Test coverage is a first-class review dimension** - Don't let green codecov/unit numbers substitute for checking that the right _kind_ of test exists (e.g. e2e for a new CLI command).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -97,10 +97,3 @@ The only acceptable cast is one with a `// CAST:` comment explaining why it's un
 
 - **Recursive/nested configs bypass top-level guards** - If a command rejects unsupported types by checking only the top-level discriminant (e.g. `hookConfig.type`), verify nested configs can't smuggle an unsupported type through. Aggregation/routing hooks and ISMs recurse into `hooks`/`domains`/`fallback`/sub-ISMs; a guard that only inspects the root lets a nested unsupported type fail deep in the deploy instead of up front.
 - **Partial provisioning** - A command that provisions only the origin `--chain` (signer/preflight/balances) but accepts config referencing other chains (destination, remote domains) will fail partway. Confirm the accepted config schema can't require resources the command never sets up.
-
-## Reviewing Process
-
-- **Seed review agents with this file** - When delegating review to subagents, pass `REVIEW.md` so every checklist item (e2e tests, casts, allocations, enums) is actually applied. Findings the rules already cover should never be missed.
-- **Account for prior reviews** - Read existing reviews, inline threads, and author responses first; acknowledge what's already addressed rather than re-raising it.
-- **Pending reviews are invisible until submitted** - The GitHub API does not expose another reviewer's draft/pending comments until they submit. You may post a review seconds before a concurrent reviewer submits theirs and never see their notes. State the HEAD commit your review is based on, and re-fetch reviews/comments immediately before posting to catch anything newly submitted.
-- **Test coverage is a first-class review dimension** - Don't let green codecov/unit numbers substitute for checking that the right _kind_ of test exists (e.g. e2e for a new CLI command).


### PR DESCRIPTION
## Summary

Adds review-checklist learnings surfaced while reviewing #8834, where two valid points raised by a concurrent reviewer were missed.

**`REVIEW.md` (what-to-look-for-in-code checklist):**
- **New CLI subcommands need e2e coverage** — at least one EVM e2e + one altVM e2e; green codecov/unit numbers don't satisfy this.
- **Hoist invariant constants out of function bodies** — fixed arrays/objects/regexes shouldn't be recreated per call.
- **Validation Gaps to Watch For** (new section) — recursive/nested configs bypassing top-level guards; partial provisioning when a command sets up only the origin chain but accepts config referencing other chains.

**Review skills (process/workflow guidance — kept out of REVIEW.md):**
- `claude-review`: when delegating to subagents/teams, seed each with `REVIEW.md` so checklist items are actually applied.
- `inline-pr-comments`: re-fetch reviews/comments immediately before submitting and state the reviewed HEAD sha — the GitHub API doesn't expose a reviewer's **pending/draft** comments until they submit, so a concurrent reviewer can submit moments after you and you'll never have seen their notes.

## Background

On #8834 an approving review posted ~52s before another reviewer submitted overlapping notes (missing e2e tests, an array recreated per call). Both points were already covered by `REVIEW.md` but weren't applied because the review subagents weren't seeded with it. Process guidance lives in the skills; REVIEW.md stays a pure code checklist.

## Test plan

- [x] Docs/skill-only change; pre-commit hooks (oxfmt) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
