### PR TITLE
chore(aleo): add incident report on aleotestnet broadcast blackhole

### DIFF
--- a/aleo-testnet-broadcast-blackhole-report.md
+++ b/aleo-testnet-broadcast-blackhole-report.md
@@ -1,0 +1,227 @@
+# Aleo Testnet — `/transaction/broadcast` accepts submissions but txs never land
+
+**Reporter:** Hyperlane (Abacus Works) on-call
+**Date of report:** 2026-05-28
+**Affected RPC:** `https://api.explorer.provable.com/v1/testnet`
+**Affected network:** Aleo Testnet (`chainId=1`, network `testnet`)
+**Aleo mainnet:** **Unaffected** (same Provable provider works fine on mainnet)
+**Approximate onset:** 2026-05-19 ~16:17 UTC (first relayer client-side timeouts observed 2026-05-21 13:02:06 UTC). Behavior unchanged for ~9 days as of this writing.
+
+---
+
+## TL;DR
+
+`POST https://api.explorer.provable.com/v1/testnet/transaction/broadcast` returns success (the request body's tx_id is echoed back in the response) for our Hyperlane `process()` transactions, but **the transactions never appear in any block and never appear in the mempool either**. Every subsequent lookup of those tx_ids via any of the read endpoints returns HTTP 404. We have observed this across **100+ distinct tx_ids** (each a freshly-generated ZK proof) over the past several days. Other programs on the same testnet (e.g. `dara_dp_sol_v5.aleo`) do still get confirmed, so the chain itself is alive and producing blocks (current height ≈ 16,786,884) — but our submissions are silently disappearing somewhere between Provable's broadcast endpoint and Aleo testnet block production.
+
+---
+
+## Reproduction summary
+
+For any tx_id `T` from the list below:
+
+```bash
+# All three return HTTP 404
+curl -s "https://api.explorer.provable.com/v1/testnet/transaction/confirmed/$T"
+curl -s "https://api.explorer.provable.com/v1/testnet/transaction/unconfirmed/$T"
+curl -s "https://api.explorer.provable.com/v1/testnet/transaction/$T"
+```
+
+Example raw responses (taken 2026-05-28 07:27 UTC for tx `at1k2lxxuqar2cxzr98rjz04ecx3k5ydvrl4g3khm68wxk58s6sm5gq3hpwnv`, submitted 2026-05-28 07:23:34 UTC):
+
+```
+GET /v1/testnet/transaction/confirmed/at1k2lxx...3hpwnv
+HTTP/2 404
+{"statusCode":404,"timestamp":"2026-05-28T07:27:22.318Z",
+ "path":"/v1/testnet/transaction/confirmed/at1k2lxxuqar2cxzr98rjz04ecx3k5ydvrl4g3khm68wxk58s6sm5gq3hpwnv",
+ "method":"GET","message":"Confirmed transaction at1k2lxx...3hpwnv not found"}
+
+GET /v1/testnet/transaction/unconfirmed/at1k2lxx...3hpwnv
+HTTP/2 404
+{"statusCode":404,"timestamp":"2026-05-28T07:27:22.535Z",
+ "path":"/v1/testnet/transaction/unconfirmed/at1k2lxxuqar2cxzr98rjz04ecx3k5ydvrl4g3khm68wxk58s6sm5gq3hpwnv",
+ "method":"GET","message":"Missing unconfirmed transaction for ID at1k2lxx...3hpwnv"}
+
+GET /v1/testnet/transaction/at1k2lxx...3hpwnv
+HTTP/2 404
+{"statusCode":404,"timestamp":"2026-05-28T07:27:22.743Z",
+ "path":"/v1/testnet/transaction/at1k2lxxuqar2cxzr98rjz04ecx3k5ydvrl4g3khm68wxk58s6sm5gq3hpwnv",
+ "method":"GET","message":"Transaction at1k2lxx...3hpwnv not found"}
+```
+
+Meanwhile `/latest/height` and `/block/{h}` work fine, and one can find other (non-Hyperlane) confirmed transactions in recent blocks, e.g. `at1fa2zngpz6cs0eqed6sh85lxtz96hsmklau283enxxvkpwgnjxu9qufgf6d` (`dara_dp_sol_v5.aleo/propose_settlement`) in block 16,740,000 at 2026-05-26 15:04:54 UTC.
+
+---
+
+## What the client does (so you can correlate on your side)
+
+The Hyperlane Rust relayer submits a `Transaction<TestnetV0>` to `POST /v1/testnet/transaction/broadcast` with a JSON body containing the full serialized snarkVM testnet transaction (including ZK proof).
+
+After a successful broadcast, the relayer polls the three GET endpoints listed above (using the same bech32 `at1...` id that the broadcast endpoint accepted) for 30 seconds at 2-second intervals before giving up. Then the message is re-prepared, a brand new ZK proof / brand new tx_id is generated, and the cycle repeats every ~3 minutes per stuck message.
+
+We have ruled out client-side id mismatch — see the curl results above using the raw `at1...` ids directly, which match the ids the broadcast endpoint accepted.
+
+Relevant code pointers (open source, github.com/hyperlane-xyz/hyperlane-monorepo):
+- Broadcast + verification: `rust/main/chains/hyperlane-aleo/src/provider/aleo.rs` lines 503-512
+  - We fail fast if `/transaction/broadcast` returns a body that is **not** equal to our locally computed `transaction.id()`. We do **not** see such an error in logs, so broadcast is acknowledging the expected id.
+- HTTP layer: `rust/main/chains/hyperlane-aleo/src/provider/traits.rs:225-261`
+- Conversion test: `rust/main/chains/hyperlane-aleo/src/utils/tests.rs:70-92` (`test_h512_to_tx_id_roundtrip`)
+
+---
+
+## Programs / contracts involved
+
+Every failing submission is a call to **`process`** on one of two Hyperlane testnet warp-route programs, which in turn calls into the testnet mailbox:
+
+| Component                  | Aleo identifier                                                                                  |
+|----------------------------|--------------------------------------------------------------------------------------------------|
+| Mailbox program            | `test_hyp_mailbox.aleo` (`aleo1jps66qyy3mwhtdyrx4n7u3j5qnh8d7fdc4pwx3t0g9mwcs0xjuxqc3lsxu`)        |
+| Hook manager               | `test_hyp_hook_manager.aleo` (`aleo175xvd3uqmswt9ckt2d4drnxrqu8gzuzz3u3cjlt3cxhru74d2qqsnf5t46`)  |
+| Validator announce         | `test_hyp_validator_announce.aleo` (`aleo1exucqw8zpx05swkl8dt7us3xl9z88fypla7nvwy4vt2rvfvazy8s0phz2l`) |
+| Warp route program (SOL)   | `test_hyp_warp_token_sol.aleo/process`                                                            |
+| Warp route program (USDC)  | `test_hyp_warp_token_usdc.aleo/process`                                                           |
+
+Deployer: Abacus Works. Programs were deployed and successfully processing inbound messages until 2026-05-19.
+
+---
+
+## Frequency of attempts
+
+The relayer reprepares each stuck Hyperlane message every ~2-3 minutes; each retry generates a fresh ZK proof and therefore a fresh `at1...` tx_id. We currently have multiple Hyperlane messages stuck and being re-submitted simultaneously, e.g.
+
+- Hyperlane message `0xa2adf89e6ab3bfa0327ab6b14055578339202c181a2718a471770c2ab981b8bd` (sepolia → aleotestnet, nonce 870032, recipient program `test_hyp_warp_token_sol.aleo`)
+- Hyperlane message `0x40fb5a99a1fb7ee5da14af5274ad89adf9787b64d90a9695fa2597cd39e3cc68`
+- Hyperlane message `0xa48492d1baabfc789c5dd64054ec972e6b18dbcdeb188bc625b90415e631a6aa`
+
+In the past 4 hours alone we logged 100 distinct broadcast attempts to the same RPC, all with the same outcome.
+
+---
+
+## Verified facts
+
+1. **Chain liveness:** `GET /v1/testnet/latest/height` returns ≈ 16,786,884 and is monotonically increasing. Blocks are being produced. Read endpoints are healthy.
+2. **Block contents have non-Hyperlane txs:** `GET /v1/testnet/block/16740000` contains `at1fa2zngpz6cs0eqed6sh85lxtz96hsmklau283enxxvkpwgnjxu9qufgf6d` calling `dara_dp_sol_v5.aleo/propose_settlement` and accepted normally. So it is not a chain halt — only our txs are not landing. Block 16,527,000 (2026-05-17 12:28 UTC) similarly has `dara_dp_sol_v5.aleo/approve_settlement` accepted.
+3. **Broadcast endpoint is alive and validating request bodies:** `POST /v1/testnet/transaction/broadcast` with `{}` returns `HTTP 500 "Debug node error: \"Invalid transaction data: Failed to deserialize the JSON body into the target type: Failed to parse transaction ID: The \"id\" field is missing\""` — so it does reject malformed bodies. It accepts our well-formed bodies (otherwise our relayer's `output != id.to_string()` check would error, and we never see that error in logs).
+4. **Aleo mainnet on the same Provable RPC base host is unaffected.** Hyperlane's aleo-mainnet relayer continues to deliver normally.
+5. **Other RPC methods are healthy:** `/block/*`, `/program/*`, `/stateRoot/latest`, `/latest/*` all return correct data at expected QPS. Only our broadcasts are vanishing.
+
+---
+
+## What we'd like the Aleo / Provable team to check
+
+1. **Search the broadcast endpoint logs for any of the tx_ids in Appendix A.** They should show as accepted by `/transaction/broadcast` followed by either:
+   - **(a) silently dropped before being gossiped to the network** (broadcast endpoint or bridge node bug), or
+   - **(b) gossiped to the network but rejected by validators at execution / proof verification** without surfacing an error to the caller, or
+   - **(c) admitted to mempool but never selected for a block** (priority/mempool scheduling issue).
+2. **Check if Aleo testnet validators are rejecting (or silently dropping) execute transactions targeting `test_hyp_warp_token_sol.aleo`, `test_hyp_warp_token_usdc.aleo`, or `test_hyp_mailbox.aleo`.** The programs were deployed by Abacus Works and were processing messages until ~2026-05-19 16:17 UTC.
+3. **Verify whether testnet had any validator-side policy change after 2026-05-19** (proof size limit, transition count limit, gas/credit accounting change, program-level deny list, snarkVM version bump, etc.) that could be silently rejecting our shape of execute tx.
+4. If you can share the **response body of `/transaction/broadcast`** that you log on your side for any of these tx_ids, that would confirm whether the broadcast endpoint considered itself successful, and would tell us whether to keep submitting or escalate further.
+
+We are happy to coordinate live; we can submit additional test transactions on demand for whatever instrumentation you have available.
+
+---
+
+## Appendix A — 100 failing tx_ids (last 4 hours, oldest → newest)
+
+`submitted_at_utc | program_called | aleo_tx_id`
+
+pairs=100 |  | 
+2026-05-28T03:52:44.635574667Z | ? | at1vdf87eeh3urtkr9y5pnpcggg3t8ee70mcxkrfcts6lwm724qgcqqff47g2
+2026-05-28T03:55:00.488596385Z | test_hyp_warp_token_sol.aleo/process | at1p5lddahp62f4ynzs62nevd8evx733vkepvhc60fnzycycl7tty9swrvmh4
+2026-05-28T03:57:12.980970858Z | test_hyp_warp_token_usdc.aleo/process | at1eeqszsgmdpckwekmgw7e89sx8dzzn9weqrazatllmaffdjv9mcpsc25zks
+2026-05-28T03:59:26.577519545Z | test_hyp_warp_token_sol.aleo/process | at1qfugq5q658dtms8mgjgq0vs3jwectf6ct2e3qa45htxhmyfzv5qs0nel3l
+2026-05-28T04:01:42.519203168Z | test_hyp_warp_token_usdc.aleo/process | at1c0sxk8an0z3m24qkvfewqh2n82e7rrpxvtd337vtjfqaaxg7a5pq28nzt2
+2026-05-28T04:03:57.795234683Z | test_hyp_warp_token_sol.aleo/process | at1hm8dglh4549k4555g0m8zhdfsu7f8npqkl49t6ar7u0x6dalngrsqhfs6p
+2026-05-28T04:06:14.370164810Z | test_hyp_warp_token_usdc.aleo/process | at1ur5nrjgwd8q26qtpn5tne6ef4terkq7fhf3lxeyxuchwxegjeg8s6cmc79
+2026-05-28T04:08:32.463001063Z | test_hyp_warp_token_sol.aleo/process | at166k3hf2t7vxhyvluhau6x4gcrhlujsh8np59jndlwlts0l84jcpsyqk9yd
+2026-05-28T04:10:49.750906385Z | test_hyp_warp_token_usdc.aleo/process | at1zpgy9s9tkg05j4arvz592chhwzarq52raf2ftlyh3203n8mwngqq8wn6cl
+2026-05-28T04:13:04.647570646Z | test_hyp_warp_token_sol.aleo/process | at1nraawg0ukdzek35ahcrjhs6403w672k0p9l6ykcj5rt92qvjgv9s39zekt
+2026-05-28T04:15:19.394213197Z | test_hyp_warp_token_usdc.aleo/process | at1cqsnwctn25zeegut9m3h59h3euzawsgmtpaqgalywuqdc837qq8szjreka
+2026-05-28T04:17:34.217294031Z | test_hyp_warp_token_sol.aleo/process | at1qskhwjcmkzzr9dtwzjwh9k52y29u5yjg739w3753newt6lhe3s9q8mrcp6
+2026-05-28T04:19:51.623356410Z | test_hyp_warp_token_usdc.aleo/process | at1ar3qu2ue067llcqpqlns4p82dvu5nty5fu34znd88dcrn5xeag9s3je0d7
+2026-05-28T04:22:06.334522742Z | test_hyp_warp_token_sol.aleo/process | at194uvycr5djkt97tdprskqglrrpckyswf88382hjd8ux4cmk69uzql9g6gs
+2026-05-28T04:24:21.404131776Z | test_hyp_warp_token_usdc.aleo/process | at14r8ptgq0e3a25mte9lmkpum92lusx8sul2lq6uh4vlyf8nkyncyqcq4rhk
+2026-05-28T04:26:35.931769750Z | test_hyp_warp_token_sol.aleo/process | at1t2tqhmg37f8l9sc0uwfuhjk8vsjdw6dfpql4jr5j5x4eapu7n5pq5nxgxe
+2026-05-28T04:28:53.133800038Z | test_hyp_warp_token_usdc.aleo/process | at16adft860hq852kk4rspnfwd2qeaxjkjxfy425yrpzdt9lnx7l59sh2qg4f
+2026-05-28T04:31:07.345244549Z | test_hyp_warp_token_sol.aleo/process | at1axtgakkz3txcps77wklsrkgaamd5ea694smp483vvxcrgncr85gss2snpl
+2026-05-28T04:33:22.819958148Z | test_hyp_warp_token_usdc.aleo/process | at1mqfpjpmt27lm5pk7lshjlqdw95xylc9zkw8un2cnq657x4gquqpsch8c3y
+2026-05-28T04:35:36.659480578Z | test_hyp_warp_token_sol.aleo/process | at1nzf3xwjkaekgysp293fx5axq9ecz9dhtxcxgh5xj5lhjdem27sgsllcfex
+2026-05-28T04:37:49.806576110Z | test_hyp_warp_token_usdc.aleo/process | at1mcfl6gez8kfv36rtv4zy300qfarrzvhthm5wxnwlt3yffu4qvvxqapum4z
+2026-05-28T04:40:05.128937374Z | test_hyp_warp_token_sol.aleo/process | at1z7snmertpqa5tsqehrlqs9jrcczzqh89q3vw0lgs4l5d94ynnc8qwdgmm4
+2026-05-28T04:42:19.127584997Z | test_hyp_warp_token_usdc.aleo/process | at1q6q3pfs5z9r8kg75crqmkgevslx8putg5htt2w88u0zqkj6styqq8gh9nl
+2026-05-28T04:44:34.111376238Z | test_hyp_warp_token_sol.aleo/process | at1u0uh0wjl0uagjp5uktedq2vt3x07vejm0rhs0nlv3znnz99pzvyqkq35cn
+2026-05-28T04:46:50.480220577Z | test_hyp_warp_token_usdc.aleo/process | at1nfqz7gfzg59zkaux04u6rc54wty43l4r655kwmfle8z3jnhy6gyqsv5scs
+2026-05-28T04:49:06.527352039Z | test_hyp_warp_token_sol.aleo/process | at1g8red8r40y85s5gsq89jpdklk6cmtk5feuuesj8e45cyers6cczsc4l9yj
+2026-05-28T04:51:22.620728786Z | test_hyp_warp_token_usdc.aleo/process | at18tgecylj9r6d63ktkm48h27lftt8jfj3kw2wz0ucqjck85aur5ysd6xw0w
+2026-05-28T04:53:37.431215426Z | test_hyp_warp_token_sol.aleo/process | at10kqxwr7rndrx2q5s587n8jtn785d7qzk5nwr0qptd9qnwcdj4szsg9j49t
+2026-05-28T04:55:52.008886131Z | test_hyp_warp_token_usdc.aleo/process | at1lsmz35ew3nquckdhmu4mmmtnfkh4vu5dv53sgw0l7z9wd8d28sysg4efhh
+2026-05-28T04:58:06.592994864Z | test_hyp_warp_token_sol.aleo/process | at1l47l9t7mwwx4dq56g033s4gd6n5f09yrm63rjpkhypphsd39nvqsdrskel
+2026-05-28T05:00:19.888919291Z | test_hyp_warp_token_usdc.aleo/process | at12c850z7k90n0zwa52m4n7tde7ycml834e0ws47r3zhft2hlhz5yqyyp9tk
+2026-05-28T05:02:34.061891653Z | test_hyp_warp_token_sol.aleo/process | at1vnagtudhnfn0cp8snd7ptfnlncc3zzcnjafvr2x2jwh77zthvy9sdqr4kw
+2026-05-28T05:04:49.538628458Z | test_hyp_warp_token_usdc.aleo/process | at1653lxsggzn9g79086sunz9rep0kg87eqytj7jchkcxg87qrvcvzs42e9r8
+2026-05-28T05:07:05.539920901Z | test_hyp_warp_token_sol.aleo/process | at1r2fz0ls5d6lrqdns5ca39ptq9e72lyd2ntzf8lf35w8m6lckyvfq0884w5
+2026-05-28T05:09:23.238296552Z | test_hyp_warp_token_usdc.aleo/process | at14sup5waxuvwdu8ujcgze7vnymjqruudt6crg4y24a6pqpm62d5qsmheyc8
+2026-05-28T05:11:36.696125586Z | test_hyp_warp_token_sol.aleo/process | at1cgd4z68mg7xlfvdmupvg2np7ftantx0lzg2vz05fd25d9hx2gvyqck24vq
+2026-05-28T05:13:49.898238783Z | test_hyp_warp_token_usdc.aleo/process | at1wzjlrqwh7v8fke088wajnt8m7dg9r9ncvcujuykvkhm2z6c99vgqkm900w
+2026-05-28T05:16:03.312615519Z | test_hyp_warp_token_sol.aleo/process | at17hu7m43dpxlzspd55xqd2urkegnuu8yzwqes8heuhn5u5rspmu9qqn9ywy
+2026-05-28T05:18:15.759830151Z | test_hyp_warp_token_usdc.aleo/process | at15hnjtw65zelzh7gtxqta89866gem57s5utg7mkvrh29aqghpycxq5wrmeh
+2026-05-28T05:20:28.317920844Z | test_hyp_warp_token_sol.aleo/process | at1fczzua2dw3703etutjv3yhpsken27wkptzj3p9c0gt0v9w3w3s8swdg8s7
+2026-05-28T05:22:41.912861817Z | test_hyp_warp_token_usdc.aleo/process | at1dt3205mzlye5vj0rxxqc3l6swz9dv84cfd6mtl7thgejc02gcu8ssns2ns
+2026-05-28T05:24:56.386720222Z | test_hyp_warp_token_sol.aleo/process | at1lxa8f08gtpsqzghhwq6v428cf3d9v6h2uu25vyg0xqnnh70z3yzqfwy8z8
+2026-05-28T05:27:09.316010427Z | test_hyp_warp_token_usdc.aleo/process | at1lx2fnx99mrh9c3arvllh0hma0h7wgggznmwqflu4y5z6wragdyyq69xafl
+2026-05-28T05:29:24.162463144Z | test_hyp_warp_token_sol.aleo/process | at1khe2spdpnysssyl5cfcxa6syhl4zt0gfruk9ag8vwkx0ayu99sfqmencye
+2026-05-28T05:31:39.113358390Z | test_hyp_warp_token_usdc.aleo/process | at1qam5uujxyk8a29a8e6f5ny9grpfc3lcy7nwalshdjr5k5fxqjvqslf2ues
+2026-05-28T05:33:52.280420749Z | test_hyp_warp_token_sol.aleo/process | at1f6a7tsmthczu5wfvm88etxaqj5khq5yd3jwz2jl0zp6je5q9cuxqzueq2w
+2026-05-28T05:36:04.667618187Z | test_hyp_warp_token_usdc.aleo/process | at1hk8up577n95rt8cx2n6xeyf9d3q3v9f8xasgq24an4wm98sftuzsjs8u5l
+2026-05-28T05:38:16.226820603Z | test_hyp_warp_token_sol.aleo/process | at1s6nf8wjpu4tg8j7zmrtlcuy4d2ph9gdrudqljpdfkgjlcd8p2gyqd8ucgc
+2026-05-28T05:40:30.998799764Z | test_hyp_warp_token_usdc.aleo/process | at17xzt58azrlstzy6a6fn0g7x905aggp0hyw24lkyv7kal3s77qqyqzvfnyh
+2026-05-28T05:42:45.149922997Z | test_hyp_warp_token_sol.aleo/process | at1t7qckgvm03zhcc56e2yc6pqq44hmctdqmpd80mkm5axafr95dcqqe5qvt3
+2026-05-28T05:44:57.993898863Z | test_hyp_warp_token_usdc.aleo/process | at1gjh7p3dsdhyqetgw6tzxfdd7fdmnpldtguftlldtselg9vvlqqxsme8tnw
+2026-05-28T05:47:12.755294363Z | test_hyp_warp_token_sol.aleo/process | at17ntw7z9ja4qly9lyaw6s2ks8jwd288esvx7ywyk4z9lwvgf8gyqs54h05a
+2026-05-28T05:49:27.027538541Z | test_hyp_warp_token_usdc.aleo/process | at1kw72garmn4a95ajfkghnxeha7t8wevhx5h7tdtr4qt9tzk0v2crsltzlpu
+2026-05-28T05:51:40.967399261Z | test_hyp_warp_token_sol.aleo/process | at1x0dcchdwhheh990qdya0gngjaad2kxuvfqmvt6vps9j7yklwc5gq7ypkdh
+2026-05-28T05:53:54.021265867Z | test_hyp_warp_token_usdc.aleo/process | at14wzf3ahevmj80jmcquu5wdg9jx7wqeh08ch7kfd0kyl47yr22ugs2t0kyc
+2026-05-28T05:56:08.693044643Z | test_hyp_warp_token_sol.aleo/process | at1yk4dtjs7xryplpes6rm377me6rqpkwsgvukzc8ctvhluxtdhhgxqud077f
+2026-05-28T05:58:23.902762326Z | test_hyp_warp_token_usdc.aleo/process | at19pkvseg5c0m8v64yqckws30hx785qr0d6vd8c35h26kjf8ylmcxqjrzwr3
+2026-05-28T06:00:45.384730882Z | test_hyp_warp_token_sol.aleo/process | at15dvpyxdlvz7agag2m8f8hzefa436mywsue8qcv3yqax4llpezvrqhp2txx
+2026-05-28T06:02:58.282028994Z | test_hyp_warp_token_usdc.aleo/process | at16w8llzesskrqdzumku3e9mjsyz56xscfl053e3r2axjhtcmut5fqdgfkz9
+2026-05-28T06:05:12.858669198Z | test_hyp_warp_token_sol.aleo/process | at1lue4h0z906hwxklp8m0xad5jj8j2j8uzmzmjzqye0jzkjdnm7yrshzlv60
+2026-05-28T06:07:27.498585680Z | test_hyp_warp_token_usdc.aleo/process | at16cyau3z2syz770z3kjufqu3qgwyqfzrd73mggxwraupclt20uuqq7sr3xh
+2026-05-28T06:09:44.913062296Z | test_hyp_warp_token_sol.aleo/process | at1pp9lndvs6duza3l90x4myffh285l4dttut3ch7hys84tgaq7qygsv9wnhp
+2026-05-28T06:11:59.512256662Z | test_hyp_warp_token_usdc.aleo/process | at16jkgp0wvzlpy4qrp92t8afyw3wt4jdcsrkqeudkrcjwasln68qrsfyjqk3
+2026-05-28T06:14:12.340752923Z | test_hyp_warp_token_sol.aleo/process | at1qjm0ra7qck7n95q424jndxuz8zrjjvy90j4dp9s0yukz2g8dwqpswc8rqv
+2026-05-28T06:16:26.172459055Z | test_hyp_warp_token_usdc.aleo/process | at1v79gn9m78jqvhdqre95g20j4vf2zzge406hpz54u68aazcznev9swrzrdw
+2026-05-28T06:18:40.694258383Z | test_hyp_warp_token_sol.aleo/process | at18hgu4z3q2ngm9av8memk2mkhdagz6fueg0y5jkw7rdurs7wdycrqqexsl8
+2026-05-28T06:20:54.701163841Z | test_hyp_warp_token_usdc.aleo/process | at1uglzqs2d5pjj890y87mn4xjphtk6tv428rtm7llf5wyq5c4sly8s2ffaw4
+2026-05-28T06:23:08.405445865Z | test_hyp_warp_token_sol.aleo/process | at16ycwee5xpzamzspk0k5rudzjd2q58ac4wppgshadgq58tp8v5vpsxzhedx
+2026-05-28T06:25:20.679194698Z | test_hyp_warp_token_usdc.aleo/process | at1jszcksntpdj4aelcr4s59a66negskeqhs7p0ttya8rrfscv40yrq0c46es
+2026-05-28T06:27:34.023548602Z | test_hyp_warp_token_sol.aleo/process | at13834ghd57p4762wxedktgs9fphj35l8kh0n6q8qpylg9kvl2asqqpg6c6z
+2026-05-28T06:29:48.488735860Z | test_hyp_warp_token_usdc.aleo/process | at18nx849xeptcrwdqw7gytvmhcdc49jamv2gyuwz3t9spw2prnyupsqm9ym2
+2026-05-28T06:32:04.824131474Z | test_hyp_warp_token_sol.aleo/process | at1rd3zw4gcjgsan4c5cx4p55rqr8sjxfheku8z2juafe23n3kc559su9d0yl
+2026-05-28T06:34:21.590228500Z | test_hyp_warp_token_usdc.aleo/process | at1sl0qe8ad6gjclxvpjfz8m5nyc86y5c20qlpgrspstecy33rl9crq0gmznv
+2026-05-28T06:36:38.921858803Z | test_hyp_warp_token_sol.aleo/process | at1s95nv8h80fr3llspfhav4p8c5m9nak7mjehqeguxt2hma3zd9crskmk5gn
+2026-05-28T06:38:52.371007144Z | test_hyp_warp_token_usdc.aleo/process | at19xp2xvfhr9k0lavgn2zr2c60qx2xul3h6583dw8wsvn373m5vczszwm738
+2026-05-28T06:41:06.809874483Z | test_hyp_warp_token_sol.aleo/process | at12xd2x5ugapw9409qczd97ucwqjytgcwf8n2gucr5ztxf2jwkdszqx4ywmu
+2026-05-28T06:43:22.063048844Z | test_hyp_warp_token_usdc.aleo/process | at1v2ff6qp4cgfyuvdxcsjfsjf5dsu2svv2g5pvgc4lm9rqejhq4grspudsvh
+2026-05-28T06:45:34.810211287Z | test_hyp_warp_token_sol.aleo/process | at1ds5rkzzs0vn3mcdkwcm3kczw67l0vjs4r3y0xwxfnd6ttkq2xuyqqp5avj
+2026-05-28T06:47:47.663191733Z | test_hyp_warp_token_usdc.aleo/process | at14rmg9mmlsgvcde68a4xcw6ljyxjhxw2dy9j9xf87ppfpw3dczugqsdmptz
+2026-05-28T06:50:00.498448088Z | test_hyp_warp_token_sol.aleo/process | at1td4hka7pdm9ss0c3ts7cc2e5awg9e2y57nl7e5pjpuycslaglg9slt8q32
+2026-05-28T06:52:14.229047563Z | test_hyp_warp_token_usdc.aleo/process | at1y2rat5nzwssv4hsaa9c59s9ka65xfxdyyaj2r5545hjuwsjdvvfqz23hsc
+2026-05-28T06:54:29.338192767Z | test_hyp_warp_token_sol.aleo/process | at1me9hx20zmfrsv53d48vr8rl8r780gwcqnl82mvjx7p0sp3psdq8st4fn5w
+2026-05-28T06:56:43.150841393Z | test_hyp_warp_token_usdc.aleo/process | at1xllnve2uhtsjqk2083jqcgze2u39vlzf6v0m7pxpnaek4v6j8yysrlfzhg
+2026-05-28T06:58:58.587803236Z | test_hyp_warp_token_sol.aleo/process | at19lxnw32wdpna40cyysyf9l2kuuzlzfvguzgtw6d4vkdangnw8qqqxdewva
+2026-05-28T07:01:12.073905237Z | test_hyp_warp_token_usdc.aleo/process | at1q7ew7stpm4fmgckg5kae3tyth3e9qtsx0upf8s654wk00zuh9ggsc69ywf
+2026-05-28T07:03:26.488132025Z | test_hyp_warp_token_sol.aleo/process | at1v4ms0efvcud86azzf95xwgrm9ncg9hh2wjh4vt2fp9dmzuqh6yrqkkzkdj
+2026-05-28T07:05:42.196736223Z | test_hyp_warp_token_usdc.aleo/process | at1frpfqlg3x0jn9dnn9upfz4tdm979yese5hlm00229qrzuxmeus9qpywzd9
+2026-05-28T07:07:57.182065043Z | test_hyp_warp_token_sol.aleo/process | at1mqwp42hmcjpg6dtuau4rz0czs9wxmtk0uctsc80pw5sh3c6ma59s62xuws
+2026-05-28T07:10:12.076982484Z | test_hyp_warp_token_usdc.aleo/process | at1lmuw8734gcwy9uk5sahwdnxkq43nu7qnnxud42vvqsmuccclacgqfhv7x6
+2026-05-28T07:12:26.580957602Z | test_hyp_warp_token_sol.aleo/process | at1fzz4narjxd98jatay239d4uge0nly7lagc4uc7uzx2edn6gurvpstwe374
+2026-05-28T07:14:39.849055315Z | test_hyp_warp_token_usdc.aleo/process | at193fj24gjjtuzujkq83wujuenntvlmg24w3p7uzy40zy0wyyxquqqjk495c
+2026-05-28T07:16:54.363870523Z | test_hyp_warp_token_sol.aleo/process | at1mh8xl2swynrq3jy0rj3slm7lheacnkgglgwut8kxztalmtuurgpqkqyx4r
+2026-05-28T07:19:07.745933642Z | test_hyp_warp_token_usdc.aleo/process | at1qxhmrky4ga06n5f7g2th5vyu3m93h3clsjy47s52qhe3fc2wyyzsm2eqqg
+2026-05-28T07:21:20.642818182Z | test_hyp_warp_token_sol.aleo/process | at1d6reyf56xypgfus6hmdtk5ytqrqjyjac9ymh5ye08d48yn2r7cys78uxsh
+2026-05-28T07:23:34.686158142Z | test_hyp_warp_token_usdc.aleo/process | at1k2lxxuqar2cxzr98rjz04ecx3k5ydvrl4g3khm68wxk58s6sm5gq3hpwnv
+2026-05-28T07:25:49.094386515Z | test_hyp_warp_token_sol.aleo/process | at1u98ss7chm8673ew6ppd9ryr8s3e5rf4nuwhzlv3pwrg2af4e4s8s0e8zs6
+2026-05-28T07:28:04.547934847Z | test_hyp_warp_token_usdc.aleo/process | at15y78vzf5gaajmy0ngwlgx0rmrletzsh0wjqnlsadxdh2v7093vpqsm97e7
+2026-05-28T07:30:18.672443372Z | test_hyp_warp_token_sol.aleo/process | at16lrawj37fyrz6354nkwsy9xkysa9wfetauv53y82wddwvewu7yzsw2wffx
+2026-05-28T07:32:32.087922914Z | test_hyp_warp_token_usdc.aleo/process | at13m9q0alw7sk3uh5fzv3fgnk4lec5egrx8zcrdhwe3gl5y3z0tyyq4knnve
+2026-05-28T07:34:46.600555849Z | test_hyp_warp_token_sol.aleo/process | at15s43mv0c24jhf8ejkxkz63swey38sq07ltu0vreazh3vx74hegqshaql6w


### PR DESCRIPTION
## Summary

Adds a self-contained markdown report (intended to be forwarded to the Aleo / Provable team) documenting that Provable's Aleo testnet `POST /transaction/broadcast` endpoint acknowledges Hyperlane `process()` submissions but the transactions never land in a block and never appear in the mempool either.

Key contents:
- Reproduction: 3 GET endpoints per tx_id, all return HTTP 404, with worked example.
- 100 recent failing Aleo tx_ids (last 4 hours at time of writing) with submit timestamps and the program (`test_hyp_warp_token_sol.aleo/process` / `test_hyp_warp_token_usdc.aleo/process`) that produced each.
- Affected mailbox, hook-manager, and validator-announce program identifiers.
- Verified facts: Aleo testnet chain is alive (height ~16.79M), other programs (e.g. `dara_dp_sol_v5.aleo`) still confirm in blocks, broadcast endpoint validates well-formed bodies, Aleo mainnet on the same Provable provider is unaffected.
- Specific questions for Provable / Aleo testnet to investigate (silent drop pre-gossip, validator-rejected without surfacing error, admitted-to-mempool-never-selected).

Onset 2026-05-19 ~16:17 UTC. Confirmed unchanged after the v1→v2 Provable endpoint switch on 2026-05-28 — the report applies to both endpoints.

Draft PR for visibility — the report is intended for outbound communication to Provable / Aleo, not as a long-lived doc to ship; happy to relocate (e.g. under `docs/` or close after the upstream issue resolves) per reviewer preference.

## Test plan

- [ ] Confirm no secrets in the file (signer keys/private keys deliberately excluded).
- [ ] Decide whether to keep under repo root, move under a docs path, or close after the Provable team is contacted.

Related root-cause incident group: `01KS0GP0N7B7B893FS6ABQ9WJJ`.