### PR TITLE
fix(infra): allow --rpc-urls in set-rpc-urls.ts script

### DIFF
--- a/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls.ts
+++ b/typescript/infra/scripts/secret-rpc-urls/set-rpc-urls.ts
@@ -40,7 +40,10 @@ async function main() {
       type: 'boolean',
       description:
         'List affected K8s releases as JSON without making any changes',
-      default: false,
+      // No default: yargs `.conflicts()` treats any defined value (including
+      // default `false`) as "set", so a default here makes --rpc-urls and
+      // --refresh-releases unusable because they always appear to conflict
+      // with list-releases. The check below already treats undefined as false.
     })
     .option('refresh-releases', {
       type: 'string',


### PR DESCRIPTION
## Summary

`set-rpc-urls.ts --rpc-urls ...` currently fails on every invocation with:

```
Arguments rpc-urls and list-releases are mutually exclusive
```

even though `--list-releases` is not passed. This breaks the documented non-interactive path used by `/fix-rpc-urls` and the `agentic RPC debugging` workflow.

## Root cause

`list-releases` is declared with `default: false`:

```ts
.option('list-releases', {
  type: 'boolean',
  description: '...',
  default: false,
})
```

yargs `.conflicts()` (`yargs@17.7.2`, `validation.js:254`) is implemented as:

```js
if (value && argv[key] !== undefined && argv[value] !== undefined) {
    usage.fail(__('Arguments %s and %s are mutually exclusive', key, value));
}
```

The check is `!== undefined`, not "user-set". A defaulted `false` is `!== undefined`, so any time `--rpc-urls` is provided the conflict between `rpc-urls` and `list-releases` fires unconditionally. Adding `--no-list-releases --no-refresh-releases` to try to clear it just trips the second `.conflicts('list-releases', 'refresh-releases')` instead.

## Fix

Drop the `default: false` from `list-releases`. The downstream branch is `if (listReleases) { ... }`, which treats `undefined` identically to `false`, so behaviour for users who do pass `--list-releases` is unchanged.

## Repro (against `main` before this fix)

```bash
pnpm --dir typescript/infra exec tsx scripts/secret-rpc-urls/set-rpc-urls.ts \
  -e mainnet3 -c eclipsemainnet \
  --rpc-urls '["https://mainnetbeta-rpc.eclipse.xyz"]' --yes
# => Arguments rpc-urls and list-releases are mutually exclusive
```

Hit during a live Eclipse RPC fix (BlockPI RU quota outage). Worked around with a tiny wrapper that called `setRpcUrls()` directly; this PR is the upstream fix so the wrapper isn't needed next time.

## Test plan

- [ ] `pnpm --dir typescript/infra exec tsx scripts/secret-rpc-urls/set-rpc-urls.ts -e <env> -c <chain> --rpc-urls '["..."]' --yes` → updates the secret, exits cleanly (was failing on `main`).
- [ ] `pnpm --dir typescript/infra exec tsx scripts/secret-rpc-urls/set-rpc-urls.ts -e <env> -c <chain> --list-releases` → still returns the JSON release list (regression check).
- [ ] `pnpm --dir typescript/infra exec tsx scripts/secret-rpc-urls/set-rpc-urls.ts -e <env> -c <chain> --rpc-urls '["..."]' --list-releases --yes` → still errors with the mutually-exclusive message (intended behaviour preserved).

## Notes

- `@hyperlane-xyz/infra` is `private: true`, so no changeset.
- Drafted by Haggis during incident triage.