### PR TITLE
fix(sdk): skip collateral checks for CCTP/OFT warp routes

### DIFF
--- a/.changeset/warp-token-type-collateral-check.md
+++ b/.changeset/warp-token-type-collateral-check.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/sdk": patch
+"@hyperlane-xyz/cli": patch
+---
+
+The warp core config preserved warp route deploy token types, and destination collateral checks were skipped for CCTP and OFT collateral route tokens.

--- a/.changeset/warp-token-type-collateral-check.md
+++ b/.changeset/warp-token-type-collateral-check.md
@@ -3,4 +3,6 @@
 "@hyperlane-xyz/cli": patch
 ---
 
-The warp core config preserved warp route deploy token types, and destination collateral checks were skipped for CCTP and OFT collateral route tokens.
+Warp core configs preserved warp route deploy token types, and destination collateral checks were skipped for CCTP and OFT collateral routes that settle through their protocol bridge rather than on-chain escrow.
+
+Existing CCTP and OFT registry routes require token type backfills in hyperlane-registry#1550 to use the exemption.

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -382,6 +382,7 @@ function generateTokenConfigs(
     warpCoreConfig.tokens.push({
       chainName,
       standard: tokenTypeToStandard(protocol as ProtocolType, config.type),
+      tokenType: config.type,
       decimals: tokenMetadataMap.getDecimals(chainName)!,
       symbol: config.symbol || tokenMetadataMap.getSymbol(chainName)!,
       name: tokenMetadataMap.getName(chainName)!,

--- a/typescript/cli/src/tests/ethereum/warp/warp-deploy-2.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-deploy-2.e2e-test.ts
@@ -179,6 +179,13 @@ describe('hyperlane warp deploy e2e tests', async function () {
         (config) => config.chainName === CHAIN_NAME_2,
       );
       expect(chain2TokenConfig).to.exist;
+      expect(chain2TokenConfig.tokenType).to.equal(TokenType.collateral);
+
+      const [chain3TokenConfig] = coreConfig.tokens.filter(
+        (config) => config.chainName === CHAIN_NAME_3,
+      );
+      expect(chain3TokenConfig).to.exist;
+      expect(chain3TokenConfig.tokenType).to.equal(TokenType.synthetic);
 
       const movableToken = MovableCollateralRouter__factory.connect(
         chain2TokenConfig.addressOrDenom!,

--- a/typescript/sdk/src/token/ITokenMetadata.ts
+++ b/typescript/sdk/src/token/ITokenMetadata.ts
@@ -14,6 +14,8 @@ import { TokenStandard } from './TokenStandard.js';
 import { TokenType } from './config.js';
 import { TokenMetadataSchema } from './types.js';
 
+// standard selects runtime adapters/checks; tokenType preserves deploy-time
+// semantics when multiple deploy types share a standard.
 export const TokenConfigSchema = z.object({
   chainName: ZChainName.describe(
     'The name of the chain, must correspond to a chain in the multiProvider chainMetadata',

--- a/typescript/sdk/src/token/ITokenMetadata.ts
+++ b/typescript/sdk/src/token/ITokenMetadata.ts
@@ -11,6 +11,7 @@ import {
   TokenConnectionConfigSchema,
 } from './TokenConnection.js';
 import { TokenStandard } from './TokenStandard.js';
+import { TokenType } from './config.js';
 import { TokenMetadataSchema } from './types.js';
 
 export const TokenConfigSchema = z.object({
@@ -20,6 +21,12 @@ export const TokenConfigSchema = z.object({
   standard: z
     .nativeEnum(TokenStandard)
     .describe('The type of token. See TokenStandard for valid values.'),
+  tokenType: z
+    .nativeEnum(TokenType)
+    .optional()
+    .describe(
+      'The warp route deploy token type. Used to preserve route implementation semantics when multiple deploy token types share the same token standard.',
+    ),
   decimals: ZUint.lt(256).describe('The decimals value (e.g. 18 for Eth)'),
   symbol: z.string().min(1).describe('The symbol of the token'),
   name: z.string().min(1).describe('The name of the token'),

--- a/typescript/sdk/src/token/TokenMetadata.ts
+++ b/typescript/sdk/src/token/TokenMetadata.ts
@@ -67,6 +67,7 @@ function matchesUnderlyingAsset(
 export class TokenMetadata implements ITokenMetadata {
   declare chainName: TokenArgs['chainName'];
   declare standard: TokenArgs['standard'];
+  declare tokenType: TokenArgs['tokenType'];
   declare decimals: TokenArgs['decimals'];
   declare symbol: TokenArgs['symbol'];
   declare name: TokenArgs['name'];

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -20,6 +20,7 @@ import { Token } from '../token/Token.js';
 import { TokenAmount } from '../token/TokenAmount.js';
 import { TokenStandard } from '../token/TokenStandard.js';
 import { InterchainGasQuote } from '../token/adapters/ITokenAdapter.js';
+import { TokenType } from '../token/config.js';
 import { ChainName } from '../types.js';
 
 import { encodeAbiParameters, zeroAddress } from 'viem';
@@ -41,6 +42,7 @@ const BIG_TRANSFER_AMOUNT = BigInt('100000000000000000000'); // 100 units @ 18 d
 const MOCK_BALANCE = BigInt('10000000000000000000'); // 10 units @ 18 decimals
 const MEDIUM_MOCK_BALANCE = BigInt('50000000000000000000'); // 50 units at @ 18 decimals
 const MOCK_ADDRESS = '0x0000000000000000000000000000000000000001';
+const MOCK_ADDRESS_2 = '0x0000000000000000000000000000000000000002';
 
 describe('WarpCore', () => {
   const multiProvider = MultiProtocolProvider.createTestMultiProtocolProvider();
@@ -100,6 +102,41 @@ describe('WarpCore', () => {
     expect(fromArgs).to.be.instanceOf(WarpCore);
     expect(fromConfig).to.be.instanceOf(WarpCore);
     expect(fromConfig.tokens.length).to.equal(exampleConfig.tokens.length);
+  });
+
+  it('Preserves warp route deploy token type in token metadata', () => {
+    const fromConfig = WarpCore.FromConfig(multiProvider, {
+      tokens: [
+        {
+          chainName: test1.name,
+          standard: TokenStandard.EvmHypCollateral,
+          tokenType: TokenType.collateralOft,
+          decimals: 6,
+          symbol: 'USDT',
+          name: 'Tether USD',
+          addressOrDenom: MOCK_ADDRESS,
+          collateralAddressOrDenom: MOCK_ADDRESS,
+          connections: [
+            {
+              token: `ethereum|${test2.name}|${MOCK_ADDRESS_2}`,
+            },
+          ],
+        },
+        {
+          chainName: test2.name,
+          standard: TokenStandard.EvmHypCollateral,
+          tokenType: TokenType.collateralOft,
+          decimals: 6,
+          symbol: 'USDT',
+          name: 'Tether USD',
+          addressOrDenom: MOCK_ADDRESS_2,
+          collateralAddressOrDenom: MOCK_ADDRESS_2,
+        },
+      ],
+    });
+
+    expect(fromConfig.tokens[0].tokenType).to.equal(TokenType.collateralOft);
+    expect(fromConfig.tokens[1].tokenType).to.equal(TokenType.collateralOft);
   });
 
   it('Finds tokens', () => {
@@ -239,6 +276,57 @@ describe('WarpCore', () => {
     await testCollateral(evmHypNative, testXERC20Lockbox.name, false);
 
     stubs.forEach((s) => s.restore());
+  });
+
+  it('Skips destination collateral checks for protocol-backed collateral token types', async () => {
+    for (const tokenType of [
+      TokenType.collateralCctp,
+      TokenType.collateralOft,
+    ]) {
+      const originToken = new Token({
+        chainName: test1.name,
+        standard: TokenStandard.EvmHypCollateral,
+        tokenType,
+        decimals: 6,
+        symbol: 'USDC',
+        name: 'USD Coin',
+        addressOrDenom: MOCK_ADDRESS,
+        collateralAddressOrDenom: MOCK_ADDRESS,
+        connections: [],
+      });
+      const destinationToken = new Token({
+        chainName: test2.name,
+        standard: TokenStandard.EvmHypCollateral,
+        tokenType,
+        decimals: 6,
+        symbol: 'USDC',
+        name: 'USD Coin',
+        addressOrDenom: MOCK_ADDRESS_2,
+        collateralAddressOrDenom: MOCK_ADDRESS_2,
+        connections: [],
+      });
+      originToken.addConnection({ token: destinationToken });
+      const protocolBackedWarpCore = new WarpCore(multiProvider, [
+        originToken,
+        destinationToken,
+      ]);
+      const destinationAdapterStub = sinon
+        .stub(destinationToken, 'getAdapter')
+        .throws(new Error('destination collateral should not be read'));
+      const destinationHypAdapterStub = sinon
+        .stub(destinationToken, 'getHypAdapter')
+        .throws(new Error('destination collateral should not be read'));
+
+      const result =
+        await protocolBackedWarpCore.isDestinationCollateralSufficient({
+          originTokenAmount: originToken.amount(BIG_TRANSFER_AMOUNT),
+          destination: test2.name,
+        });
+
+      expect(result).to.be.true;
+      sinon.assert.notCalled(destinationAdapterStub);
+      sinon.assert.notCalled(destinationHypAdapterStub);
+    }
   });
 
   it('Checks for destination collateral with scaling factors', async () => {

--- a/typescript/sdk/src/warp/WarpCore.test.ts
+++ b/typescript/sdk/src/warp/WarpCore.test.ts
@@ -278,11 +278,8 @@ describe('WarpCore', () => {
     stubs.forEach((s) => s.restore());
   });
 
-  it('Skips destination collateral checks for protocol-backed collateral token types', async () => {
-    for (const tokenType of [
-      TokenType.collateralCctp,
-      TokenType.collateralOft,
-    ]) {
+  [TokenType.collateralCctp, TokenType.collateralOft].forEach((tokenType) => {
+    it(`Skips destination collateral checks for ${tokenType}`, async () => {
       const originToken = new Token({
         chainName: test1.name,
         standard: TokenStandard.EvmHypCollateral,
@@ -326,7 +323,56 @@ describe('WarpCore', () => {
       expect(result).to.be.true;
       sinon.assert.notCalled(destinationAdapterStub);
       sinon.assert.notCalled(destinationHypAdapterStub);
-    }
+    });
+  });
+
+  it('Checks destination collateral for non-exempt collateral token types', async () => {
+    const originToken = new Token({
+      chainName: test1.name,
+      standard: TokenStandard.EvmHypCollateral,
+      tokenType: TokenType.collateral,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
+      addressOrDenom: MOCK_ADDRESS,
+      collateralAddressOrDenom: MOCK_ADDRESS,
+      connections: [],
+    });
+    const destinationToken = new Token({
+      chainName: test2.name,
+      standard: TokenStandard.EvmHypCollateral,
+      tokenType: TokenType.collateral,
+      decimals: 6,
+      symbol: 'USDC',
+      name: 'USD Coin',
+      addressOrDenom: MOCK_ADDRESS_2,
+      collateralAddressOrDenom: MOCK_ADDRESS_2,
+      connections: [],
+    });
+    originToken.addConnection({ token: destinationToken });
+    const collateralWarpCore = new WarpCore(multiProvider, [
+      originToken,
+      destinationToken,
+    ]);
+    const getBalanceStub = sinon.stub().resolves(MOCK_BALANCE);
+    const destinationAdapterStub = sinon
+      .stub(destinationToken, 'getAdapter')
+      .returns({
+        getBalance: getBalanceStub,
+      } as any);
+    const destinationHypAdapterStub = sinon
+      .stub(destinationToken, 'getHypAdapter')
+      .throws(new Error('destination hyp adapter should not be read'));
+
+    const result = await collateralWarpCore.isDestinationCollateralSufficient({
+      originTokenAmount: originToken.amount(BIG_TRANSFER_AMOUNT),
+      destination: test2.name,
+    });
+
+    expect(result).to.be.false;
+    sinon.assert.calledOnce(destinationAdapterStub);
+    sinon.assert.calledOnceWithExactly(getBalanceStub, MOCK_ADDRESS_2);
+    sinon.assert.notCalled(destinationHypAdapterStub);
   });
 
   it('Checks for destination collateral with scaling factors', async () => {

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -82,6 +82,8 @@ const DESTINATION_COLLATERAL_EXEMPT_TOKEN_TYPES = new Set<TokenType>([
   TokenType.collateralOft,
 ]);
 
+// CCTP/OFT both map to EvmHypCollateral, so standard alone cannot distinguish
+// protocol-backed collateral from escrowed collateral.
 function isDestinationCollateralExemptToken(token: IToken): boolean {
   return (
     token.tokenType !== undefined &&

--- a/typescript/sdk/src/warp/WarpCore.ts
+++ b/typescript/sdk/src/warp/WarpCore.ts
@@ -36,6 +36,7 @@ import {
   TOKEN_STANDARD_TO_PROVIDER_TYPE,
   TokenStandard,
 } from '../token/TokenStandard.js';
+import { TokenType } from '../token/config.js';
 import {
   EVM_TRANSFER_REMOTE_GAS_ESTIMATE,
   EvmHypCollateralFiatAdapter,
@@ -74,6 +75,18 @@ export interface WarpCoreOptions {
   localFeeConstants?: FeeConstantConfig;
   interchainFeeConstants?: FeeConstantConfig;
   routeBlacklist?: RouteBlacklist;
+}
+
+const DESTINATION_COLLATERAL_EXEMPT_TOKEN_TYPES = new Set<TokenType>([
+  TokenType.collateralCctp,
+  TokenType.collateralOft,
+]);
+
+function isDestinationCollateralExemptToken(token: IToken): boolean {
+  return (
+    token.tokenType !== undefined &&
+    DESTINATION_COLLATERAL_EXEMPT_TOKEN_TYPES.has(token.tokenType)
+  );
 }
 
 export class WarpCore {
@@ -1341,6 +1354,13 @@ export class WarpCore {
       destination,
       destinationToken,
     });
+
+    if (isDestinationCollateralExemptToken(resolvedDestinationToken)) {
+      this.logger.debug(
+        `${resolvedDestinationToken.symbol} uses ${resolvedDestinationToken.tokenType}, skipping destination collateral check`,
+      );
+      return true;
+    }
 
     if (
       !TOKEN_COLLATERALIZED_STANDARDS.includes(


### PR DESCRIPTION
## Summary

This PR updates WarpCore token metadata so a warp core config can preserve the route deploy token type alongside the existing token standard.

Changes made:
- Added optional `tokenType` to WarpCore token config/metadata.
- Updated CLI warp route config generation to emit `tokenType: config.type`.
- Updated `WarpCore.isDestinationCollateralSufficient` to skip destination collateral balance checks for `collateralCctp` and `collateralOft` destination tokens.
- Added WarpCore tests covering token type preservation and the CCTP/OFT collateral-check exemption.
- Refreshed generated testnet agent config expected by CI.

## Why

`collateralCctp` and `collateralOft` currently map to `EvmHypCollateral`, so downstream code cannot distinguish them from ordinary collateral routes by `standard` alone.

That matters for destination collateral checks. Ordinary collateral warp routes need destination inventory because delivery depends on tokens held by the destination router. CCTP and OFT routes are different: delivery happens through the underlying Circle CCTP or OFT/LayerZero network, not by paying out destination router-held collateral. Checking destination router collateral for these routes can therefore incorrectly block valid sends.

Preserving `tokenType` gives WarpCore enough information to treat these route implementations correctly while keeping the existing standard-based behavior for older configs and ordinary collateral routes.

## Compatibility

This is backward-compatible for existing warp core configs. If a route does not include `tokenType`, WarpCore keeps the existing collateral-check behavior.

For existing registry routes to get the new behavior, their warp core configs need to be regenerated or patched to include:
- `tokenType: collateralCctp` for CCTP routes such as `USDC/mainnet-cctp-v2-standard`
- `tokenType: collateralOft` for OFT routes such as `USDT/oft`

This PR changes the SDK/CLI behavior only; registry route regeneration can be handled separately.

## Verification

- `pnpm turbo run build --filter=@hyperlane-xyz/sdk --filter=@hyperlane-xyz/cli`
- `pnpm -C typescript/sdk build`
- `pnpm -C typescript/cli build`
- `pnpm -C typescript/sdk exec mocha --config .mocharc.json './src/warp/WarpCore.test.ts' --exit`
- `REGISTRY_URI=/Users/mo/dev/hyperlane/env8/hyperlane-registry-ci-8844 pnpm -C typescript/infra update-agent-config:testnet4`
- `git diff --check`