### PR TITLE
fix(infra): update testnet4 agent config after .registryrc bump

### DIFF
--- a/rust/main/config/testnet_config.json
+++ b/rust/main/config/testnet_config.json
@@ -460,7 +460,7 @@
       "aggregationHook": "0xe3147d5618f5e2e100690B50ec923009a4cde14A",
       "blockExplorers": [
         {
-          "apiKey": "CYUPN3Q66JIMRGQWYUDXJKQH4SX8YIYZMW",
+          "apiKey": "GP69JEAP2W7YFJT9ZJTEPGQT6Y6KMW44ZN",
           "apiUrl": "https://api-sepolia.etherscan.io/api",
           "family": "etherscan",
           "name": "Etherscan",
@@ -1364,7 +1364,7 @@
       "protocol": "aleo",
       "rpcUrls": [
         {
-          "http": "https://api.explorer.provable.com/v1"
+          "http": "https://api.explorer.provable.com/v2"
         }
       ],
       "mailbox": "aleo1jps66qyy3mwhtdyrx4n7u3j5qnh8d7fdc4pwx3t0g9mwcs0xjuxqc3lsxu",


### PR DESCRIPTION
## Summary

Fixes the testnet agent configs CI which has been failing since #8842 was merged. The NES/bsc warp route PR only ran `pnpm -C typescript/infra update-agent-config:mainnet3` and missed the corresponding testnet4 update. This PR runs the full `pnpm agent-configs` from repo root (which covers both mainnet3 + testnet4) and commits the resulting testnet4 diff.

## Changes

- `rust/main/config/testnet_config.json`:
  - Sepolia etherscan API key rotation (registry update)
  - Aleo testnet RPC URL bumped from `v1` → `v2`

## Notes

- No code changes — this is purely the auto-generated testnet config that #8842 should have included
- Going forward, `.registryrc` PRs should run `pnpm agent-configs` from repo root rather than the env-specific script

🤖 Generated with [Claude Code](https://claude.com/claude-code)