### PR TITLE
chore: update Claude opus model to 4.8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
     types: [created]
 
 env:
-  CLAUDE_OPUS_MODEL: claude-opus-4-7
+  CLAUDE_OPUS_MODEL: claude-opus-4-8
   CLAUDE_SONNET_MODEL: claude-sonnet-4-6
 
 concurrency:


### PR DESCRIPTION
## Summary
- Bumps `CLAUDE_OPUS_MODEL` from `claude-opus-4-7` to `claude-opus-4-8` in `.github/workflows/claude-code-review.yml`.

## Test plan
- [ ] CI workflow uses new model on next PR review trigger.