### PR TITLE
feat: tron ccip support

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6394,6 +6394,7 @@ dependencies = [
  "num-traits",
  "prost 0.13.4",
  "prost-types 0.13.4",
+ "regex",
  "reqwest 0.11.27",
  "reqwest-utils",
  "serde",

--- a/rust/main/agents/relayer/src/relayer/destination.rs
+++ b/rust/main/agents/relayer/src/relayer/destination.rs
@@ -133,7 +133,10 @@ impl DestinationFactory {
     ) -> Option<Signers> {
         let start_entity_init = Instant::now();
 
-        if !matches!(domain.domain_protocol(), HyperlaneDomainProtocol::Ethereum) {
+        if !matches!(
+            domain.domain_protocol(),
+            HyperlaneDomainProtocol::Ethereum | HyperlaneDomainProtocol::Tron
+        ) {
             return None;
         }
 

--- a/rust/main/agents/relayer/src/relayer/destination.rs
+++ b/rust/main/agents/relayer/src/relayer/destination.rs
@@ -146,7 +146,7 @@ impl DestinationFactory {
             .build::<Signers>()
             .await
             .map_err(|e| {
-                warn!(error = ?e, "Failed to build Ethereum signer for CCIP-read ISM.");
+                warn!(error = ?e, domain = %domain.name(), "Failed to build signer for CCIP-read ISM.");
                 e
             })
             .ok();

--- a/rust/main/chains/hyperlane-tron/Cargo.toml
+++ b/rust/main/chains/hyperlane-tron/Cargo.toml
@@ -50,6 +50,7 @@ abigen = { path = "../../utils/abigen", features = ["ethers"] }
 hyperlane-core = { path = "../../hyperlane-core", features = ["test-utils"] }
 
 [dev-dependencies]
+regex.workspace = true
 tracing-test.workspace = true
 
 [features]

--- a/rust/main/chains/hyperlane-tron/abis/ICcipReadIsm.abi.json
+++ b/rust/main/chains/hyperlane-tron/abis/ICcipReadIsm.abi.json
@@ -1,0 +1,83 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "urls",
+        "type": "string[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "callbackFunction",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "OffchainLookup",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      }
+    ],
+    "name": "getOffchainVerifyInfo",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "moduleType",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_metadata",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      }
+    ],
+    "name": "verify",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/rust/main/chains/hyperlane-tron/src/ism.rs
+++ b/rust/main/chains/hyperlane-tron/src/ism.rs
@@ -1,6 +1,10 @@
-pub use {aggregation_ism::*, interchain_security_module::*, multisig_ism::*, routing_ism::*};
+pub use {
+    aggregation_ism::*, ccip_read_ism::*, interchain_security_module::*, multisig_ism::*,
+    routing_ism::*,
+};
 
 mod aggregation_ism;
+mod ccip_read_ism;
 mod interchain_security_module;
 mod multisig_ism;
 mod routing_ism;

--- a/rust/main/chains/hyperlane-tron/src/ism/ccip_read_ism.rs
+++ b/rust/main/chains/hyperlane-tron/src/ism/ccip_read_ism.rs
@@ -52,13 +52,14 @@ impl HyperlaneContract for TronCcipReadIsm {
 
 #[async_trait]
 impl CcipReadIsm for TronCcipReadIsm {
-    #[instrument(err)]
+    #[instrument(err, skip(self, message))]
     async fn get_offchain_verify_info(&self, message: Vec<u8>) -> ChainResult<()> {
-        // On Tron, reverted constant calls return the revert data as a successful
-        // response in constant_result rather than as an RPC error. Call the provider
-        // directly to get raw bytes, then surface any non-empty result as an error
-        // so the CCIP read metadata builder can extract and decode the OffchainLookup
-        // revert payload.
+        // On Tron, reverted constant calls return the revert data in constant_result
+        // rather than as an RPC error. Call the provider directly to get raw bytes,
+        // then surface any non-empty result as a "0x{hex}" error string so the CCIP
+        // read metadata builder's regex can extract and decode the OffchainLookup
+        // revert payload. TronProvider::call() prioritizes constant_result over
+        // result.code, so the payload is preserved even if a node sets code.
         let call = self.contract.get_offchain_verify_info(message.into());
         let raw = self
             .contract
@@ -76,5 +77,55 @@ impl CcipReadIsm for TronCcipReadIsm {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers::abi::{AbiDecode, AbiEncode};
+    use hyperlane_ethereum::OffchainLookup;
+    use regex::Regex;
+
+    /// Pins the data-format contract between get_offchain_verify_info and the
+    /// CCIP read metadata builder: revert bytes encoded as "0x{hex}" must
+    /// survive the builder's regex → hex_decode → OffchainLookup::decode
+    /// round-trip, and empty bytes must yield the Ok(()) branch.
+    #[test]
+    fn offchain_lookup_revert_roundtrip() {
+        let original = OffchainLookup {
+            sender: "4ee6ecad1c2dae9f525404de8555724e3c35d07b".parse().unwrap(),
+            urls: vec!["https://example.com/{sender}/{data}.json".to_string()],
+            call_data: b"calldata".to_vec().into(),
+            callback_function: [0xde, 0xad, 0xbe, 0xef],
+            extra_data: b"extra".to_vec().into(),
+        };
+
+        // Mimic what get_offchain_verify_info produces for a non-empty constant_result.
+        let encoded = original.clone().encode();
+        let error_str = format!("0x{}", hex::encode(&encoded));
+
+        // Mimic what the CCIP read metadata builder does with that error string.
+        let re = Regex::new(r"0x[[:xdigit:]]+").unwrap();
+        let cap = re.captures(&error_str).expect("regex must match");
+        let hex_val = hex::decode(&cap[0][2..]).expect("hex decode must succeed");
+        let decoded = OffchainLookup::decode(hex_val).expect("ABI decode must succeed");
+
+        assert_eq!(decoded.sender, original.sender);
+        assert_eq!(decoded.urls, original.urls);
+        assert_eq!(decoded.call_data, original.call_data);
+        assert_eq!(decoded.callback_function, original.callback_function);
+        assert_eq!(decoded.extra_data, original.extra_data);
+    }
+
+    #[test]
+    fn empty_constant_result_is_ok() {
+        // Empty raw bytes must not produce an error string — the ISM returns Ok(()).
+        let raw: &[u8] = &[];
+        assert!(raw.is_empty(), "empty slice must take the Ok(()) branch");
+        // Negative: a non-empty slice must produce a "0x…" string.
+        let raw_nonempty = b"\xde\xad";
+        let err_str = format!("0x{}", hex::encode(raw_nonempty));
+        assert!(err_str.starts_with("0x"));
+        assert_eq!(err_str, "0xdead");
     }
 }

--- a/rust/main/chains/hyperlane-tron/src/ism/ccip_read_ism.rs
+++ b/rust/main/chains/hyperlane-tron/src/ism/ccip_read_ism.rs
@@ -1,0 +1,63 @@
+#![allow(clippy::enum_variant_names)]
+#![allow(missing_docs)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::instrument;
+
+use hyperlane_core::{
+    CcipReadIsm, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+    HyperlaneProvider, H256,
+};
+
+use crate::interfaces::i_ccip_read_ism::ICcipReadIsm as TronCcipReadIsmInternal;
+use crate::TronProvider;
+
+/// A reference to a CcipReadIsm contract on some Tron chain
+#[derive(Debug)]
+pub struct TronCcipReadIsm {
+    contract: Arc<TronCcipReadIsmInternal<TronProvider>>,
+    domain: HyperlaneDomain,
+}
+
+impl TronCcipReadIsm {
+    /// Creates a new TronCcipReadIsm instance
+    pub fn new(provider: TronProvider, locator: &ContractLocator) -> Self {
+        Self {
+            contract: Arc::new(TronCcipReadIsmInternal::new(
+                locator.address,
+                Arc::new(provider),
+            )),
+            domain: locator.domain.clone(),
+        }
+    }
+}
+
+impl HyperlaneChain for TronCcipReadIsm {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.contract.client().clone())
+    }
+}
+
+impl HyperlaneContract for TronCcipReadIsm {
+    fn address(&self) -> H256 {
+        self.contract.address().into()
+    }
+}
+
+#[async_trait]
+impl CcipReadIsm for TronCcipReadIsm {
+    #[instrument(err)]
+    async fn get_offchain_verify_info(&self, message: Vec<u8>) -> ChainResult<()> {
+        self.contract
+            .get_offchain_verify_info(message.into())
+            .call()
+            .await?;
+        Ok(())
+    }
+}

--- a/rust/main/chains/hyperlane-tron/src/ism/ccip_read_ism.rs
+++ b/rust/main/chains/hyperlane-tron/src/ism/ccip_read_ism.rs
@@ -4,12 +4,12 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::instrument;
-
+use ethers::providers::Middleware;
 use hyperlane_core::{
-    CcipReadIsm, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneProvider, H256,
+    CcipReadIsm, ChainCommunicationError, ChainResult, ContractLocator, HyperlaneChain,
+    HyperlaneContract, HyperlaneDomain, HyperlaneProvider, H256,
 };
+use tracing::instrument;
 
 use crate::interfaces::i_ccip_read_ism::ICcipReadIsm as TronCcipReadIsmInternal;
 use crate::TronProvider;
@@ -54,10 +54,27 @@ impl HyperlaneContract for TronCcipReadIsm {
 impl CcipReadIsm for TronCcipReadIsm {
     #[instrument(err)]
     async fn get_offchain_verify_info(&self, message: Vec<u8>) -> ChainResult<()> {
-        self.contract
-            .get_offchain_verify_info(message.into())
-            .call()
-            .await?;
+        // On Tron, reverted constant calls return the revert data as a successful
+        // response in constant_result rather than as an RPC error. Call the provider
+        // directly to get raw bytes, then surface any non-empty result as an error
+        // so the CCIP read metadata builder can extract and decode the OffchainLookup
+        // revert payload.
+        let call = self.contract.get_offchain_verify_info(message.into());
+        let raw = self
+            .contract
+            .client()
+            .as_ref()
+            .call(&call.tx, call.block)
+            .await
+            .map_err(ChainCommunicationError::from_other)?;
+
+        if !raw.is_empty() {
+            return Err(ChainCommunicationError::from_other_str(&format!(
+                "0x{}",
+                hex::encode(raw)
+            )));
+        }
+
         Ok(())
     }
 }

--- a/rust/main/chains/hyperlane-tron/src/lib.rs
+++ b/rust/main/chains/hyperlane-tron/src/lib.rs
@@ -14,6 +14,7 @@ pub use {
     contracts::TronMerkleTreeHookIndexer,
     contracts::TronValidatorAnnounce,
     ism::TronAggregationIsm,
+    ism::TronCcipReadIsm,
     ism::TronInterchainSecurityModule,
     ism::TronMultisigIsm,
     ism::TronRoutingIsm,

--- a/rust/main/chains/hyperlane-tron/src/provider/tron.rs
+++ b/rust/main/chains/hyperlane-tron/src/provider/tron.rs
@@ -374,7 +374,15 @@ impl Middleware for TronProvider {
             .await
             .map_err(|e| ProviderError::CustomError(e.to_string()))?;
 
-        // Check for contract call failure
+        // Prefer constant_result when non-empty: CCIP-read reverts return their
+        // OffchainLookup payload there even when result.code is set on some node
+        // versions. Only fall back to the error code when constant_result is absent.
+        if let Some(data) = call.constant_result.first() {
+            return Ok(Bytes::from(hex::decode(data).map_err(|e| {
+                ProviderError::CustomError(format!("Failed to decode hex constant_result: {e}"))
+            })?));
+        }
+
         if let Some(ref result) = call.result {
             if result.code.is_some() {
                 return Err(ProviderError::CustomError(format!(
@@ -384,19 +392,9 @@ impl Middleware for TronProvider {
             }
         }
 
-        let data = call
-            .constant_result
-            .first()
-            .ok_or_else(|| {
-                ProviderError::CustomError(
-                    "No constant result returned from trigger_constant_contract".into(),
-                )
-            })?
-            .clone();
-
-        Ok(Bytes::from(hex::decode(&data).map_err(|e| {
-            ProviderError::CustomError(format!("Failed to decode hex constant_result: {e}"))
-        })?))
+        Err(ProviderError::CustomError(
+            "No constant result returned from trigger_constant_contract".into(),
+        ))
     }
 
     async fn estimate_gas(

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1344,8 +1344,10 @@ impl ChainConf {
             ChainConnectionConf::Radix(_) => {
                 Err(eyre!("Radix does not support CCIP read ISM yet")).context(ctx)
             }
-            ChainConnectionConf::Tron(_) => {
-                Err(eyre!("Tron does not support CCIP read ISM yet")).context(ctx)
+            ChainConnectionConf::Tron(conf) => {
+                let provider = build_tron_provider(self, conf, metrics, &locator, None)?;
+                let ism = h_tron::TronCcipReadIsm::new(provider, &locator);
+                Ok(Box::new(ism) as Box<dyn CcipReadIsm>)
             }
             #[cfg(feature = "aleo")]
             ChainConnectionConf::Aleo(_) => Err(eyre!("Aleo support missing")).context(ctx),


### PR DESCRIPTION
### Description

Adds CCIP read ISM support for Tron destinations in the relayer. Previously, any message destined for Tron whose ISM resolved to a CCIP read ISM would permanently fail with \`FailedToBuild(\"Failed to build CCIP read ISM: Building CcipRead ISM\")\` because the builder returned a hard error for Tron.

Three issues were found and fixed end-to-end:

**1. Missing CCIP read ISM implementation for Tron**

Added `TronCcipReadIsm` struct implementing the `CcipReadIsm` trait, mirroring the existing pattern for `TronMultisigIsm` / `TronAggregationIsm`. Wired it into `build_ccip_read_ism` in `hyperlane-base`.

**2. Tron returns revert data as a successful response**

On Tron, `trigger_constant_contract` (Tron's view-call API) returns revert data in `constant_result` as a successful response rather than as an RPC error (unlike Ethereum's `eth_call`). The CCIP read flow depends on `getOffchainVerifyInfo` reverting with an `OffchainLookup` custom error — when the provider returned `Ok(bytes)` instead of `Err`, ethers decoded the void return as `Ok(())` and the metadata builder logged "incorrectly configured getOffchainVerifyInfo, expected revert".

Fixed by calling the provider directly via `Middleware::call()` to get raw bytes, then surfacing any non-empty response as an error string `"0x<hex>"` so the metadata builder's existing regex can extract and decode the `OffchainLookup` payload.

**3. CCIP signer not initialized for Tron destinations**

`init_ccip_signer` had a guard that only built a signer for `HyperlaneDomainProtocol::Ethereum` destinations. Tron destinations always got `None`, causing the relayer to send unsigned offchain lookup requests — rejected by the offchain server with HTTP 400 `"Expected string, received null"` on the `signature` field.

Fixed by adding `HyperlaneDomainProtocol::Tron` to the protocol allowlist.

### Drive-by changes

None

### Related issues

N/A (discovered via stuck message `0x4378eeb018b48968a1d3bb9a767ad3ed90d97303960abda2442f6ea0a3843564`)

### Backward compatibility

Yes. No changes to on-chain contracts or config schemas. Adds a new code path that was previously a hard error.

### Testing

Manual — tested end-to-end on the RC relayer against the stuck message above.