### PR TITLE
feat(sealevel): svm transient quote management update

### DIFF
--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/accounts.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/accounts.rs
@@ -383,12 +383,45 @@ impl ValidatableQuote for TransientQuote {
 // --- Quote context and data parsing ---
 
 /// Trait for quote context types. Implementations parse from raw bytes
-/// and validate against the QuoteFee instruction data.
+/// and validate against the context-specific QuoteFee validation input.
 pub trait QuoteContext: Sized {
+    /// Validation input accepted by this context type.
+    type Validation<'a>;
+
     /// Parses a QuoteContext from raw context bytes stored in a quote PDA.
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, ProgramError>;
-    /// Validates that the stored context matches the fields of a QuoteFee instruction.
-    fn validate(&self, quote_fee: &crate::instruction::QuoteFee) -> Result<(), ProgramError>;
+    /// Validates that the stored context matches the fields of a QuoteFee
+    /// instruction, returning the validated QuoteFee for fee computation.
+    fn validate<'a>(
+        &self,
+        validation: Self::Validation<'a>,
+    ) -> Result<&'a crate::instruction::QuoteFee, ProgramError>;
+}
+
+/// QuoteFee wrapper that carries the active CC routing scope.
+pub enum CcQuoteFeeValidation<'a> {
+    /// CC with specific route active at `(dest, quote_fee.target_router)` —
+    /// the transient's stored `target_router` must equal `quote_fee.target_router`.
+    Specific(&'a crate::instruction::QuoteFee),
+    /// CC with default route active — specific route is unconfigured, routing
+    /// fell back to `(dest, DEFAULT_ROUTER)`, so the transient's stored
+    /// `target_router` must equal `DEFAULT_ROUTER`.
+    Default(&'a crate::instruction::QuoteFee),
+}
+
+impl<'a> CcQuoteFeeValidation<'a> {
+    /// Returns the wrapped QuoteFee only when `target_router` matches the
+    /// active routing scope.
+    pub fn unwrap_for_router(
+        self,
+        target_router: H256,
+    ) -> Result<&'a crate::instruction::QuoteFee, ProgramError> {
+        match self {
+            Self::Specific(qf) if target_router == qf.target_router => Ok(qf),
+            Self::Default(qf) if target_router == DEFAULT_ROUTER => Ok(qf),
+            _ => Err(QuoteValidationError::TransientContextMismatch.into()),
+        }
+    }
 }
 
 /// Quote context for Leaf and Routing fee accounts.
@@ -404,6 +437,8 @@ pub struct FeeQuoteContext {
 }
 
 impl QuoteContext for FeeQuoteContext {
+    type Validation<'a> = &'a crate::instruction::QuoteFee;
+
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, ProgramError> {
         if bytes.len() != std::mem::size_of::<u32>() + 32 + std::mem::size_of::<u64>() {
             return Err(ProgramError::InvalidInstructionData);
@@ -423,7 +458,10 @@ impl QuoteContext for FeeQuoteContext {
         })
     }
 
-    fn validate(&self, quote_fee: &crate::instruction::QuoteFee) -> Result<(), ProgramError> {
+    fn validate<'a>(
+        &self,
+        quote_fee: Self::Validation<'a>,
+    ) -> Result<&'a crate::instruction::QuoteFee, ProgramError> {
         // Wildcard sentinels (`WILDCARD_DOMAIN`, `WILDCARD_RECIPIENT`,
         // `WILDCARD_AMOUNT`) on any field skip the equality check, mirroring
         // EVM's `_matchesTransient`. Off-chain quoters issue wildcard transients
@@ -442,7 +480,7 @@ impl QuoteContext for FeeQuoteContext {
             return Err(QuoteValidationError::TransientContextMismatch.into());
         }
 
-        Ok(())
+        Ok(quote_fee)
     }
 }
 
@@ -461,6 +499,8 @@ pub struct CcFeeQuoteContext {
 }
 
 impl QuoteContext for CcFeeQuoteContext {
+    type Validation<'a> = CcQuoteFeeValidation<'a>;
+
     fn try_from_bytes(bytes: &[u8]) -> Result<Self, ProgramError> {
         if bytes.len() != std::mem::size_of::<u32>() + 32 + std::mem::size_of::<u64>() + 32 {
             return Err(ProgramError::InvalidInstructionData);
@@ -481,10 +521,13 @@ impl QuoteContext for CcFeeQuoteContext {
         })
     }
 
-    fn validate(&self, quote_fee: &crate::instruction::QuoteFee) -> Result<(), ProgramError> {
+    fn validate<'a>(
+        &self,
+        validation: Self::Validation<'a>,
+    ) -> Result<&'a crate::instruction::QuoteFee, ProgramError> {
+        let quote_fee = validation.unwrap_for_router(self.target_router)?;
+
         // dest/recipient/amount mirror EVM's `_matchesTransient` wildcard logic.
-        // `target_router` is strict — it's the routing binding that scopes the
-        // quote to a specific fee config, not a filter the signer leaves open.
         if self.destination_domain != WILDCARD_DOMAIN
             && self.destination_domain != quote_fee.destination_domain
         {
@@ -496,10 +539,7 @@ impl QuoteContext for CcFeeQuoteContext {
         if self.amount != WILDCARD_AMOUNT && self.amount != quote_fee.amount {
             return Err(QuoteValidationError::TransientContextMismatch.into());
         }
-        if self.target_router != quote_fee.target_router {
-            return Err(QuoteValidationError::TransientContextMismatch.into());
-        }
-        Ok(())
+        Ok(quote_fee)
     }
 }
 

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/error.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/error.rs
@@ -61,11 +61,6 @@ pub enum Error {
     /// but the account is uninitialized or has the wrong discriminator.
     #[error("Transient quote slot expected but PDA is missing or invalid")]
     InvalidTransientSlot = 18,
-    /// CC transient quote signed with `target_router == DEFAULT_ROUTER` is
-    /// unconsumable: real QuoteFee callers always pass a specific target_router
-    /// and the consume-time validate is strict.
-    #[error("DEFAULT_ROUTER target not allowed for CC transient quotes")]
-    DefaultRouterNotAllowedForTransientQuote = 19,
 }
 
 impl From<Error> for ProgramError {

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/quote.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/quote.rs
@@ -15,9 +15,10 @@ use solana_program::{
 
 use crate::{
     accounts::{
-        CcFeeQuoteContext, CrossCollateralRouteAccount, FeeAccountData, FeeData, FeeQuoteContext,
-        FeeStandingQuotePdaAccount, QuoteContext, RouteDomainAccount, TransientQuoteAccount,
-        DEFAULT_ROUTER, TRANSIENT_QUOTE_DISCRIMINATOR, WILDCARD_DOMAIN, WILDCARD_RECIPIENT,
+        CcFeeQuoteContext, CcQuoteFeeValidation, CrossCollateralRouteAccount, FeeAccountData,
+        FeeData, FeeQuoteContext, FeeStandingQuotePdaAccount, QuoteContext, RouteDomainAccount,
+        TransientQuoteAccount, DEFAULT_ROUTER, TRANSIENT_QUOTE_DISCRIMINATOR, WILDCARD_DOMAIN,
+        WILDCARD_RECIPIENT,
     },
     cc_route_pda_seeds,
     error::Error,
@@ -172,19 +173,26 @@ pub(super) fn process_quote_fee(
     // --- Quote cascade: transient → standing → on-chain fallback ---
 
     // Step 1: Transient quote — override params, compute fee, autoclose.
-    // Dispatch the correct context type based on fee data variant.
+    // Dispatch the correct context type and validation scope based on fee data variant.
     if let Some(transient_acct) = transient_info {
         let fee = match &fee_account.fee_data {
-            FeeData::CrossCollateralRouting(_) => try_consume_transient_quote::<CcFeeQuoteContext>(
-                program_id,
-                transient_acct,
-                payer_info,
-                fee_account_info.key,
-                &strategy,
-                &data,
-                fee_account.min_issued_at,
-                &clock,
-            )?,
+            FeeData::CrossCollateralRouting(_) => {
+                let validation = if cc_specific_route_active {
+                    CcQuoteFeeValidation::Specific(&data)
+                } else {
+                    CcQuoteFeeValidation::Default(&data)
+                };
+                try_consume_transient_quote::<CcFeeQuoteContext>(
+                    program_id,
+                    transient_acct,
+                    payer_info,
+                    fee_account_info.key,
+                    &strategy,
+                    validation,
+                    fee_account.min_issued_at,
+                    &clock,
+                )?
+            }
             _ => try_consume_transient_quote::<FeeQuoteContext>(
                 program_id,
                 transient_acct,
@@ -299,7 +307,7 @@ fn try_consume_transient_quote<C: QuoteContext>(
     payer_info: &AccountInfo,
     fee_account_key: &Pubkey,
     strategy: &FeeDataStrategy,
-    quote_fee_data: &QuoteFee,
+    validation: C::Validation<'_>,
     min_issued_at: i64,
     clock: &Clock,
 ) -> Result<u64, ProgramError> {
@@ -329,7 +337,7 @@ fn try_consume_transient_quote<C: QuoteContext>(
     // Parse and validate context using the generic context type.
     let ctx = C::try_from_bytes(&transient.context)
         .map_err(|_| QuoteValidationError::TransientContextMismatch)?;
-    ctx.validate(quote_fee_data)?;
+    let quote_fee_data = ctx.validate(validation)?;
 
     // Parse quoted strategy and verify curve variant matches on-chain.
     let quoted_strategy = FeeDataStrategy::try_from(transient.data.as_slice())

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/simulation.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/simulation.rs
@@ -13,9 +13,7 @@ use solana_system_interface::program as system_program;
 
 use crate::{
     accounts::{FeeAccountData, FeeData, DEFAULT_ROUTER, WILDCARD_DOMAIN},
-    cc_route_pda_seeds,
-    error::Error,
-    fee_standing_quote_pda_seeds,
+    cc_route_pda_seeds, fee_standing_quote_pda_seeds,
     instruction::{GetQuoteAccountMetas, GetSubmitQuoteAccountMetas},
     route_domain_pda_seeds, transient_quote_pda_seeds,
 };
@@ -206,18 +204,6 @@ pub(super) fn process_get_submit_quote_account_metas(
     // The caller's ctx.target_router selects the route directly — no cascade.
     let domain_le = data.destination_domain.to_le_bytes();
     let is_wildcard = data.destination_domain == WILDCARD_DOMAIN;
-
-    // Mirror the runtime guard at process_submit_quote: a CC transient signed
-    // with ctx.target_router == DEFAULT_ROUTER is rejected as unconsumable.
-    // Emitting metas for that shape would hand SDK clients a layout for a tx
-    // that can never succeed.
-    if matches!(fee_account.fee_data, FeeData::CrossCollateralRouting(_))
-        && data.scoped_salt.is_some()
-        && !is_wildcard
-        && data.target_router == DEFAULT_ROUTER
-    {
-        return Err(Error::DefaultRouterNotAllowedForTransientQuote.into());
-    }
 
     match &fee_account.fee_data {
         FeeData::Leaf(_) => {}

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/submit.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/submit.rs
@@ -24,7 +24,7 @@ use crate::{
     accounts::{
         CcFeeQuoteContext, CrossCollateralRouteAccount, FeeAccountData, FeeData, FeeQuoteContext,
         FeeStandingQuotePda, FeeStandingQuotePdaAccount, FeeStandingQuoteValue, QuoteContext,
-        RouteDomainAccount, TransientQuote, TransientQuoteAccount, DEFAULT_ROUTER, WILDCARD_AMOUNT,
+        RouteDomainAccount, TransientQuote, TransientQuoteAccount, WILDCARD_AMOUNT,
         WILDCARD_DOMAIN, WILDCARD_RECIPIENT,
     },
     cc_route_pda_seeds,
@@ -88,10 +88,7 @@ pub(super) fn process_submit_quote(
     // - CC exact (transient or standing): NO cascade. The signer's
     //   `ctx.target_router` directly selects the route whose signers must
     //   verify. `ctx.target_router == DEFAULT_ROUTER` is the explicit way to
-    //   sign for the default scope; for standing quotes the result lands at
-    //   the (dest, DEFAULT_ROUTER) PDA, while for transient it's rejected as
-    //   unconsumable (see sanity guard below).
-    let is_transient = quote.is_transient();
+    //   sign for the default scope.
     let resolved_signers: BTreeSet<H160> = match &fee_account.fee_data {
         FeeData::Leaf(cfg) => cfg.signers.clone(),
         FeeData::Routing(_) => {
@@ -121,21 +118,17 @@ pub(super) fn process_submit_quote(
         }
         FeeData::CrossCollateralRouting(_) => {
             let ctx = CcFeeQuoteContext::try_from_bytes(&quote.context)?;
+            // `ctx.target_router == H256::zero()` produces a transient that is
+            // unconsumable at every scope (Specific requires a real router; Default
+            // requires DEFAULT_ROUTER). Reject up front in both wildcard and
+            // exact-domain branches to keep the submit surface symmetric and
+            // prevent operators from stranding rent on dead transients.
+            if ctx.target_router == hyperlane_core::H256::zero() {
+                return Err(Error::ZeroTargetRouterNotAllowed.into());
+            }
             if ctx.destination_domain == WILDCARD_DOMAIN {
                 Some(fee_account.fee_data.cc_wildcard_signers()?.clone())
             } else {
-                if ctx.target_router == hyperlane_core::H256::zero() {
-                    return Err(Error::ZeroTargetRouterNotAllowed.into());
-                }
-                // Sanity guard: a transient signed with ctx.target_router ==
-                // DEFAULT_ROUTER would be unconsumable because real QuoteFee
-                // callers always pass a specific target_router and the
-                // consume-time validate is strict. Reject early to prevent
-                // operator footguns. Standing quotes use DEFAULT_ROUTER as the
-                // explicit default-scope storage signal, so it's allowed there.
-                if is_transient && ctx.target_router == DEFAULT_ROUTER {
-                    return Err(Error::DefaultRouterNotAllowedForTransientQuote.into());
-                }
                 // Direct route lookup (no cascade): ctx.target_router selects the
                 // route whose signers must verify. This mirrors EVM's per-fee-
                 // contract isolation — each route's signers sign for that route's

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional.rs
@@ -464,6 +464,47 @@ fn build_quote_fee_cc_ix(
     )
 }
 
+/// Builds a QuoteFee instruction for CrossCollateralRouting mode with a
+/// transient quote PDA in slot 2.
+fn build_quote_fee_cc_transient_ix(
+    fee_account: &Pubkey,
+    payer: &Pubkey,
+    transient_pda: Pubkey,
+    destination_domain: u32,
+    recipient: H256,
+    amount: u64,
+    target_router: H256,
+) -> Instruction {
+    let specific_domain_quotes_pda =
+        cc_standing_quote_pda_for(fee_account, destination_domain, &target_router);
+    let default_domain_quotes_pda =
+        cc_standing_quote_pda_for(fee_account, destination_domain, &DEFAULT_ROUTER);
+    let wildcard_quotes_pda =
+        cc_standing_quote_pda_for(fee_account, WILDCARD_DOMAIN, &target_router);
+    let cc_specific_pda = cc_route_pda_for(fee_account, destination_domain, &target_router);
+    let cc_default_pda = cc_route_pda_for(fee_account, destination_domain, &DEFAULT_ROUTER);
+
+    Instruction::new_with_borsh(
+        fee_program_id(),
+        &FeeInstruction::QuoteFee(hyperlane_sealevel_fee::instruction::QuoteFee {
+            destination_domain,
+            recipient,
+            amount,
+            target_router,
+        }),
+        vec![
+            AccountMeta::new_readonly(*fee_account, false),
+            AccountMeta::new(*payer, true),
+            AccountMeta::new(transient_pda, false),
+            AccountMeta::new_readonly(specific_domain_quotes_pda, false),
+            AccountMeta::new_readonly(default_domain_quotes_pda, false),
+            AccountMeta::new_readonly(wildcard_quotes_pda, false),
+            AccountMeta::new_readonly(cc_specific_pda, false),
+            AccountMeta::new_readonly(cc_default_pda, false),
+        ],
+    )
+}
+
 fn build_add_quote_signer_ix(fee_account: &Pubkey, owner: &Pubkey, signer: H160) -> Instruction {
     build_add_quote_signer_ix_with_route(fee_account, owner, signer, None)
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional/helpers.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional/helpers.rs
@@ -588,12 +588,8 @@ async fn test_cc_transient_submit_metas_round_trip() {
         .unwrap();
 }
 
-/// Simulation must mirror the runtime guard at `process_submit_quote`: a CC
-/// transient signed with `ctx.target_router == DEFAULT_ROUTER` is rejected,
-/// so emitting a meta layout for that shape would hand SDKs a tx that can
-/// never succeed.
 #[tokio::test]
-async fn test_cc_transient_default_router_simulation_rejected() {
+async fn test_cc_transient_default_router_submit_metas_emitted() {
     let (mut banks_client, payer) = setup_client().await;
     let fee_key = init_fee_account(
         &mut banks_client,
@@ -606,37 +602,33 @@ async fn test_cc_transient_default_router_simulation_rejected() {
     )
     .await;
 
-    let instruction = Instruction::new_with_borsh(
-        fee_program_id(),
-        &FeeInstruction::GetSubmitQuoteAccountMetas(
-            hyperlane_sealevel_fee::instruction::GetSubmitQuoteAccountMetas {
-                destination_domain: 42,
-                target_router: DEFAULT_ROUTER,
-                scoped_salt: Some(H256::random()),
-            },
-        ),
-        vec![AccountMeta::new_readonly(fee_key, false)],
-    );
-    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
-    let simulation = banks_client
-        .simulate_transaction(Transaction::new_unsigned(Message::new_with_blockhash(
-            &[instruction],
-            Some(&payer.pubkey()),
-            &recent_blockhash,
-        )))
-        .await
-        .unwrap();
-    let err = simulation
-        .result
-        .expect("simulation must produce a result")
-        .expect_err("simulation must fail for CC transient with DEFAULT_ROUTER");
+    let dest = 42;
+    let scoped_salt = H256::random();
+    let metas = simulate_get_submit_metas(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        Some(scoped_salt),
+    )
+    .await;
+
+    // system + payer + fee_account + DEFAULT route PDA + transient PDA
+    assert_eq!(metas.len(), 5);
     assert_eq!(
-        err,
-        TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(FeeError::DefaultRouterNotAllowedForTransientQuote as u32),
-        ),
+        metas[3].pubkey,
+        cc_route_pda_for(&fee_key, dest, &DEFAULT_ROUTER)
     );
+    assert_eq!(
+        metas[4].pubkey,
+        Pubkey::find_program_address(
+            transient_quote_pda_seeds!(fee_key, scoped_salt),
+            &fee_program_id()
+        )
+        .0
+    );
+    assert!(metas[4].is_writable);
 }
 
 mod get_program_version {

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional/transient.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional/transient.rs
@@ -1,5 +1,76 @@
 use crate::*;
 
+async fn init_cc_fee_account(banks_client: &mut BanksClient, payer: &Keypair) -> Pubkey {
+    init_fee_account(
+        banks_client,
+        payer,
+        default_salt(),
+        payer.pubkey(),
+        FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig {
+            wildcard_signers: BTreeSet::new(),
+        }),
+    )
+    .await
+}
+
+async fn set_cc_route(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    fee_key: &Pubkey,
+    dest: u32,
+    target_router: H256,
+    strategy: FeeDataStrategy,
+) {
+    process_tx(
+        banks_client,
+        payer,
+        build_set_cc_route_ix(fee_key, &payer.pubkey(), dest, target_router, strategy),
+        &[],
+    )
+    .await
+    .unwrap();
+}
+
+async fn add_cc_route_signer(
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    fee_key: &Pubkey,
+    dest: u32,
+    target_router: H256,
+    signer_address: H160,
+) {
+    process_tx(
+        banks_client,
+        payer,
+        build_add_quote_signer_ix_with_route(
+            fee_key,
+            &payer.pubkey(),
+            signer_address,
+            Some(instruction::RouteKey::CrossCollateral {
+                destination: dest,
+                target_router,
+            }),
+        ),
+        &[],
+    )
+    .await
+    .unwrap();
+}
+
+fn transient_pda_for_quote(fee_key: &Pubkey, payer: &Pubkey, quote: &SvmSignedQuote) -> Pubkey {
+    let scoped_salt = quote.compute_scoped_salt(payer);
+    Pubkey::find_program_address(
+        transient_quote_pda_seeds!(fee_key, scoped_salt),
+        &fee_program_id(),
+    )
+    .0
+}
+
+async fn assert_transient_exists(banks_client: &mut BanksClient, transient_pda: Pubkey) {
+    let account = banks_client.get_account(transient_pda).await.unwrap();
+    assert!(account.is_some_and(|account| !account.data.is_empty()));
+}
+
 #[tokio::test]
 async fn test_submit_transient_quote() {
     let (mut banks_client, payer) = setup_client().await;
@@ -1235,88 +1306,527 @@ async fn test_cc_context_wrong_target_router_fails() {
     );
 }
 
-/// A CC transient quote signed with `ctx.target_router == DEFAULT_ROUTER` would
-/// be unconsumable: real QuoteFee callers always pass a concrete target_router
-/// and the consume-time validation is strict on that field. The submit handler
-/// rejects this shape early to prevent operator footguns / rent stranding.
 #[tokio::test]
-async fn test_cc_transient_default_router_target_rejected() {
+async fn test_cc_default_router_transient_consumed_when_specific_unconfigured() {
     let (mut banks_client, payer) = setup_client().await;
     let signing_key = SigningKey::random(&mut rand::thread_rng());
     let signer_address = eth_address(&signing_key);
 
-    let fee_key = init_fee_account(
+    let fee_key = init_cc_fee_account(&mut banks_client, &payer).await;
+    let dest = 42u32;
+    let target_router = H256::random();
+    let recipient = H256::zero();
+    let amount = 500u64;
+
+    set_cc_route(
         &mut banks_client,
         &payer,
-        default_salt(),
-        payer.pubkey(),
-        FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig {
-            wildcard_signers: BTreeSet::new(),
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        FeeDataStrategy::Linear(FeeParams {
+            max_fee: 100,
+            half_amount: 50,
         }),
     )
     .await;
-
-    let dest = 42u32;
-
-    // Set up the DEFAULT_ROUTER CC route + signer so the route PDA exists and
-    // signer resolution would otherwise succeed — proving the rejection comes
-    // from the explicit transient-DEFAULT_ROUTER guard, not from missing state.
-    process_tx(
+    add_cc_route_signer(
         &mut banks_client,
         &payer,
-        build_set_cc_route_ix(
-            &fee_key,
-            &payer.pubkey(),
-            dest,
-            DEFAULT_ROUTER,
-            FeeDataStrategy::Linear(FeeParams {
-                max_fee: 100,
-                half_amount: 50,
-            }),
-        ),
-        &[],
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        signer_address,
     )
-    .await
-    .unwrap();
-    process_tx(
-        &mut banks_client,
-        &payer,
-        build_add_quote_signer_ix_with_route(
-            &fee_key,
-            &payer.pubkey(),
-            signer_address,
-            Some(instruction::RouteKey::CrossCollateral {
-                destination: dest,
-                target_router: DEFAULT_ROUTER,
-            }),
-        ),
-        &[],
-    )
-    .await
-    .unwrap();
+    .await;
 
-    let context = encode_cc_context(dest, H256::zero(), 100, DEFAULT_ROUTER);
+    let context = encode_cc_context(dest, recipient, amount, DEFAULT_ROUTER);
     let quote = make_signed_transient_quote(
         &signing_key,
         &fee_key,
         LOCAL_DOMAIN,
         &payer.pubkey(),
         context,
-        encode_linear_data(1000, 500),
+        encode_linear_data(3000, 1500),
         encode_u48(100),
     );
 
     let route_pda = cc_route_pda_for(&fee_key, dest, &DEFAULT_ROUTER);
     let submit_ix =
         build_submit_transient_ix_with_routes(&fee_key, &payer.pubkey(), &quote, &[route_pda]);
+    process_tx(&mut banks_client, &payer, submit_ix, &[])
+        .await
+        .unwrap();
+
+    let transient_pda = transient_pda_for_quote(&fee_key, &payer.pubkey(), &quote);
+    let quote_ix = build_quote_fee_cc_transient_ix(
+        &fee_key,
+        &payer.pubkey(),
+        transient_pda,
+        dest,
+        recipient,
+        amount,
+        target_router,
+    );
+    let fee = simulate_quote_fee(&mut banks_client, &payer, quote_ix.clone()).await;
+    assert_eq!(fee, 500);
+
+    process_tx(&mut banks_client, &payer, quote_ix, &[])
+        .await
+        .unwrap();
+    let account = banks_client.get_account(transient_pda).await.unwrap();
+    assert!(account.is_none() || account.unwrap().data.is_empty());
+}
+
+#[tokio::test]
+async fn test_cc_default_router_transient_rejected_when_specific_configured() {
+    let (mut banks_client, payer) = setup_client().await;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+
+    let fee_key = init_cc_fee_account(&mut banks_client, &payer).await;
+    let dest = 42u32;
+    let target_router = H256::random();
+    let recipient = H256::zero();
+
+    set_cc_route(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        FeeDataStrategy::Linear(FeeParams {
+            max_fee: 100,
+            half_amount: 50,
+        }),
+    )
+    .await;
+    add_cc_route_signer(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        signer_address,
+    )
+    .await;
+
+    let quote = make_signed_transient_quote(
+        &signing_key,
+        &fee_key,
+        LOCAL_DOMAIN,
+        &payer.pubkey(),
+        encode_cc_context(dest, recipient, 100, DEFAULT_ROUTER),
+        encode_linear_data(1000, 500),
+        encode_u48(100),
+    );
+    let default_route_pda = cc_route_pda_for(&fee_key, dest, &DEFAULT_ROUTER);
+    let submit_ix = build_submit_transient_ix_with_routes(
+        &fee_key,
+        &payer.pubkey(),
+        &quote,
+        &[default_route_pda],
+    );
+    process_tx(&mut banks_client, &payer, submit_ix, &[])
+        .await
+        .unwrap();
+
+    set_cc_route(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        target_router,
+        FeeDataStrategy::Linear(FeeParams {
+            max_fee: 200,
+            half_amount: 100,
+        }),
+    )
+    .await;
+
+    let transient_pda = transient_pda_for_quote(&fee_key, &payer.pubkey(), &quote);
+    let quote_ix = build_quote_fee_cc_transient_ix(
+        &fee_key,
+        &payer.pubkey(),
+        transient_pda,
+        dest,
+        recipient,
+        100,
+        target_router,
+    );
+    let result = process_tx(&mut banks_client, &payer, quote_ix, &[]).await;
+    assert_tx_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(QuoteValidationError::TransientContextMismatch as u32),
+        ),
+    );
+    assert_transient_exists(&mut banks_client, transient_pda).await;
+    process_tx(
+        &mut banks_client,
+        &payer,
+        build_close_transient_ix(&fee_key, &transient_pda, &payer.pubkey()),
+        &[],
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_cc_specific_router_transient_submit_rejected_when_only_default_configured() {
+    let (mut banks_client, payer) = setup_client().await;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+
+    let fee_key = init_cc_fee_account(&mut banks_client, &payer).await;
+    let dest = 42u32;
+    let target_router = H256::random();
+
+    set_cc_route(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        FeeDataStrategy::Linear(FeeParams {
+            max_fee: 100,
+            half_amount: 50,
+        }),
+    )
+    .await;
+    add_cc_route_signer(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        signer_address,
+    )
+    .await;
+
+    let quote = make_signed_transient_quote(
+        &signing_key,
+        &fee_key,
+        LOCAL_DOMAIN,
+        &payer.pubkey(),
+        encode_cc_context(dest, H256::zero(), 100, target_router),
+        encode_linear_data(1000, 500),
+        encode_u48(100),
+    );
+    let missing_specific_route = cc_route_pda_for(&fee_key, dest, &target_router);
+    let submit_ix = build_submit_transient_ix_with_routes(
+        &fee_key,
+        &payer.pubkey(),
+        &quote,
+        &[missing_specific_route],
+    );
     let result = process_tx(&mut banks_client, &payer, submit_ix, &[]).await;
     assert_tx_error(
         result,
         TransactionError::InstructionError(
             0,
-            InstructionError::Custom(FeeError::DefaultRouterNotAllowedForTransientQuote as u32),
+            InstructionError::Custom(FeeError::RouteNotFound as u32),
         ),
     );
+}
+
+#[tokio::test]
+async fn test_cc_specific_router_transient_rejected_after_specific_route_removed() {
+    let (mut banks_client, payer) = setup_client().await;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+
+    let fee_key = init_cc_fee_account(&mut banks_client, &payer).await;
+    let dest = 42u32;
+    let target_router = H256::random();
+    let recipient = H256::zero();
+
+    for router in [DEFAULT_ROUTER, target_router] {
+        set_cc_route(
+            &mut banks_client,
+            &payer,
+            &fee_key,
+            dest,
+            router,
+            FeeDataStrategy::Linear(FeeParams {
+                max_fee: 100,
+                half_amount: 50,
+            }),
+        )
+        .await;
+    }
+    add_cc_route_signer(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        target_router,
+        signer_address,
+    )
+    .await;
+
+    let quote = make_signed_transient_quote(
+        &signing_key,
+        &fee_key,
+        LOCAL_DOMAIN,
+        &payer.pubkey(),
+        encode_cc_context(dest, recipient, 100, target_router),
+        encode_linear_data(1000, 500),
+        encode_u48(100),
+    );
+    let specific_route_pda = cc_route_pda_for(&fee_key, dest, &target_router);
+    let submit_ix = build_submit_transient_ix_with_routes(
+        &fee_key,
+        &payer.pubkey(),
+        &quote,
+        &[specific_route_pda],
+    );
+    process_tx(&mut banks_client, &payer, submit_ix, &[])
+        .await
+        .unwrap();
+
+    process_tx(
+        &mut banks_client,
+        &payer,
+        build_remove_cc_route_ix(&fee_key, &payer.pubkey(), dest, target_router),
+        &[],
+    )
+    .await
+    .unwrap();
+
+    let transient_pda = transient_pda_for_quote(&fee_key, &payer.pubkey(), &quote);
+    let quote_ix = build_quote_fee_cc_transient_ix(
+        &fee_key,
+        &payer.pubkey(),
+        transient_pda,
+        dest,
+        recipient,
+        100,
+        target_router,
+    );
+    let result = process_tx(&mut banks_client, &payer, quote_ix, &[]).await;
+    assert_tx_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(QuoteValidationError::TransientContextMismatch as u32),
+        ),
+    );
+    assert_transient_exists(&mut banks_client, transient_pda).await;
+}
+
+#[tokio::test]
+async fn test_cc_wildcard_domain_default_router_transient_consumed_for_default_scope() {
+    let (mut banks_client, payer) = setup_client().await;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+    let mut wildcard_signers = BTreeSet::new();
+    wildcard_signers.insert(signer_address);
+
+    let fee_key = init_fee_account(
+        &mut banks_client,
+        &payer,
+        default_salt(),
+        payer.pubkey(),
+        FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig { wildcard_signers }),
+    )
+    .await;
+    let dest = 42u32;
+    let target_router = H256::random();
+    let recipient = H256::zero();
+
+    set_cc_route(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        FeeDataStrategy::Linear(FeeParams {
+            max_fee: 100,
+            half_amount: 50,
+        }),
+    )
+    .await;
+
+    let quote = make_signed_transient_quote(
+        &signing_key,
+        &fee_key,
+        LOCAL_DOMAIN,
+        &payer.pubkey(),
+        encode_cc_context(WILDCARD_DOMAIN, recipient, 100, DEFAULT_ROUTER),
+        encode_linear_data(1000, 500),
+        encode_u48(100),
+    );
+    let submit_ix = build_submit_transient_ix_with_routes(&fee_key, &payer.pubkey(), &quote, &[]);
+    process_tx(&mut banks_client, &payer, submit_ix, &[])
+        .await
+        .unwrap();
+
+    let transient_pda = transient_pda_for_quote(&fee_key, &payer.pubkey(), &quote);
+    let quote_ix = build_quote_fee_cc_transient_ix(
+        &fee_key,
+        &payer.pubkey(),
+        transient_pda,
+        dest,
+        recipient,
+        100,
+        target_router,
+    );
+    let fee = simulate_quote_fee(&mut banks_client, &payer, quote_ix.clone()).await;
+    assert_eq!(fee, 100);
+    process_tx(&mut banks_client, &payer, quote_ix, &[])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_cc_wildcard_domain_default_router_transient_rejected_for_specific_scope() {
+    let (mut banks_client, payer) = setup_client().await;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+    let mut wildcard_signers = BTreeSet::new();
+    wildcard_signers.insert(signer_address);
+
+    let fee_key = init_fee_account(
+        &mut banks_client,
+        &payer,
+        default_salt(),
+        payer.pubkey(),
+        FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig { wildcard_signers }),
+    )
+    .await;
+    let dest = 42u32;
+    let target_router = H256::random();
+    let recipient = H256::zero();
+
+    for router in [DEFAULT_ROUTER, target_router] {
+        set_cc_route(
+            &mut banks_client,
+            &payer,
+            &fee_key,
+            dest,
+            router,
+            FeeDataStrategy::Linear(FeeParams {
+                max_fee: 100,
+                half_amount: 50,
+            }),
+        )
+        .await;
+    }
+
+    let quote = make_signed_transient_quote(
+        &signing_key,
+        &fee_key,
+        LOCAL_DOMAIN,
+        &payer.pubkey(),
+        encode_cc_context(WILDCARD_DOMAIN, recipient, 100, DEFAULT_ROUTER),
+        encode_linear_data(1000, 500),
+        encode_u48(100),
+    );
+    let submit_ix = build_submit_transient_ix_with_routes(&fee_key, &payer.pubkey(), &quote, &[]);
+    process_tx(&mut banks_client, &payer, submit_ix, &[])
+        .await
+        .unwrap();
+
+    let transient_pda = transient_pda_for_quote(&fee_key, &payer.pubkey(), &quote);
+    let quote_ix = build_quote_fee_cc_transient_ix(
+        &fee_key,
+        &payer.pubkey(),
+        transient_pda,
+        dest,
+        recipient,
+        100,
+        target_router,
+    );
+    let result = process_tx(&mut banks_client, &payer, quote_ix, &[]).await;
+    assert_tx_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(QuoteValidationError::TransientContextMismatch as u32),
+        ),
+    );
+    assert_transient_exists(&mut banks_client, transient_pda).await;
+}
+
+/// Wildcard-reverse: a wildcard-domain transient signed with a *specific*
+/// `ctx.target_router = X` must be rejected at any destination where the
+/// on-chain cascade falls back to DEFAULT (i.e., `(dest, X)` is unconfigured).
+/// Locks down the symmetric invariant to
+/// `test_cc_wildcard_domain_default_router_transient_rejected_for_specific_scope`:
+/// a wildcard signer cannot have a specific-router-tagged transient consumed
+/// against the Default scope (which would let them set a price for a route
+/// the specific-route signers are meant to authorize).
+#[tokio::test]
+async fn test_cc_wildcard_domain_specific_router_transient_rejected_for_default_scope() {
+    let (mut banks_client, payer) = setup_client().await;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+    let mut wildcard_signers = BTreeSet::new();
+    wildcard_signers.insert(signer_address);
+
+    let fee_key = init_fee_account(
+        &mut banks_client,
+        &payer,
+        default_salt(),
+        payer.pubkey(),
+        FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig { wildcard_signers }),
+    )
+    .await;
+    let dest = 42u32;
+    let target_router = H256::random();
+    let recipient = H256::zero();
+
+    // Only the DEFAULT route is configured on-chain — `(dest, target_router)` is
+    // uninitialized, so the consume cascade resolves to `CcConsumeScope::Default`.
+    set_cc_route(
+        &mut banks_client,
+        &payer,
+        &fee_key,
+        dest,
+        DEFAULT_ROUTER,
+        FeeDataStrategy::Linear(FeeParams {
+            max_fee: 100,
+            half_amount: 50,
+        }),
+    )
+    .await;
+
+    // Wildcard-domain transient bound to a *specific* router (not DEFAULT_ROUTER).
+    let quote = make_signed_transient_quote(
+        &signing_key,
+        &fee_key,
+        LOCAL_DOMAIN,
+        &payer.pubkey(),
+        encode_cc_context(WILDCARD_DOMAIN, recipient, 100, target_router),
+        encode_linear_data(1000, 500),
+        encode_u48(100),
+    );
+    let submit_ix = build_submit_transient_ix_with_routes(&fee_key, &payer.pubkey(), &quote, &[]);
+    process_tx(&mut banks_client, &payer, submit_ix, &[])
+        .await
+        .unwrap();
+
+    let transient_pda = transient_pda_for_quote(&fee_key, &payer.pubkey(), &quote);
+    let quote_ix = build_quote_fee_cc_transient_ix(
+        &fee_key,
+        &payer.pubkey(),
+        transient_pda,
+        dest,
+        recipient,
+        100,
+        target_router,
+    );
+    let result = process_tx(&mut banks_client, &payer, quote_ix, &[]).await;
+    assert_tx_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(QuoteValidationError::TransientContextMismatch as u32),
+        ),
+    );
+    assert_transient_exists(&mut banks_client, transient_pda).await;
 }
 
 #[tokio::test]

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
@@ -4339,6 +4339,678 @@ async fn test_cc_remote_transfer_with_fee_cc_routing_mode() {
     assert_token_balance(&mut ctx.banks_client, &fee_beneficiary_ata, expected_fee).await;
 }
 
+/// CC TransferRemoteTo with an offchain transient quote signed against
+/// `DEFAULT_ROUTER`. Only the `(REMOTE_DOMAIN, DEFAULT_ROUTER)` route is
+/// configured on-chain; the caller passes a different specific `target_router`.
+/// The fee program's QuoteFee falls back to the DEFAULT scope, validates the
+/// transient (ctx.target_router == DEFAULT_ROUTER under `CcConsumeScope::Default`),
+/// consumes it, and the fee amount comes from the transient quote — not the
+/// on-chain DEFAULT route rate.
+#[tokio::test]
+async fn test_cc_remote_transfer_with_default_router_transient_quote() {
+    use hyperlane_sealevel_fee::accounts::CrossCollateralRoutingFeeConfig;
+
+    let mut ctx = TestContext::new(true).await;
+    let igp = ctx.igp_accounts.as_ref().unwrap();
+    let (igp_program, igp_program_data, igp_overhead_igp, igp_igp) =
+        (igp.program, igp.program_data, igp.overhead_igp, igp.igp);
+
+    // Caller's specific target_router is unconfigured on-chain → CC cascade
+    // falls back to DEFAULT.
+    let target_router = H256::random();
+    set_cc_routers(
+        &mut ctx.banks_client,
+        &ctx.program_id,
+        &ctx.payer,
+        vec![CrossCollateralRouterUpdate::Add {
+            domain: REMOTE_DOMAIN,
+            router: target_router,
+        }],
+    )
+    .await
+    .unwrap();
+
+    let fee_beneficiary_owner = Pubkey::new_unique();
+    let fee_salt = H256::zero();
+    let fp = fee_program_id();
+    let (fee_account_key, _) = Pubkey::find_program_address(fee_account_pda_seeds!(fee_salt), &fp);
+
+    // On-chain DEFAULT route — small, low values so we can prove the transient
+    // quote took precedence (transient max_fee is 12345, on-chain caps at 75).
+    let route_max_fee: u64 = 75;
+    let route_half_amount: u64 = 500_000;
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[
+                fee_instruction::init_fee_instruction(
+                    fp,
+                    ctx.payer.pubkey(),
+                    fee_salt,
+                    fee_beneficiary_owner,
+                    FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig {
+                        wildcard_signers: std::collections::BTreeSet::new(),
+                    }),
+                    LOCAL_DOMAIN,
+                )
+                .unwrap(),
+                // Only the DEFAULT_ROUTER route is configured (no specific route for `target_router`).
+                fee_instruction::set_remote_fee_route_instruction(
+                    fp,
+                    fee_account_key,
+                    ctx.payer.pubkey(),
+                    REMOTE_DOMAIN,
+                    Some(DEFAULT_ROUTER),
+                    FeeDataStrategy::Linear(FeeParams {
+                        max_fee: route_max_fee,
+                        half_amount: route_half_amount,
+                    }),
+                    None,
+                )
+                .unwrap(),
+                // Add the offchain signer to the (REMOTE_DOMAIN, DEFAULT_ROUTER) CC route.
+                fee_instruction::set_quote_signer_instruction(
+                    fp,
+                    fee_account_key,
+                    ctx.payer.pubkey(),
+                    fee_instruction::SetQuoteSignerOperation::Add(signer_address),
+                    Some(fee_instruction::RouteKey::CrossCollateral {
+                        destination: REMOTE_DOMAIN,
+                        target_router: DEFAULT_ROUTER,
+                    }),
+                )
+                .unwrap(),
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    // Set fee config on the token.
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                ctx.program_id,
+                &HyperlaneTokenInstruction::SetFeeConfig(Some(FeeConfig {
+                    fee_program: fp,
+                    fee_account: fee_account_key,
+                }))
+                .encode()
+                .unwrap(),
+                vec![
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new(ctx.cc.token, false),
+                    AccountMeta::new(ctx.payer.pubkey(), true),
+                    AccountMeta::new_readonly(fp, false),
+                    AccountMeta::new_readonly(fee_account_key, false),
+                ],
+            )],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    // Beneficiary ATA.
+    let fee_beneficiary_ata =
+        spl_associated_token_account::get_associated_token_address_with_program_id(
+            &fee_beneficiary_owner,
+            &ctx.mint,
+            &ctx.spl_token_program_id,
+        );
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[
+                spl_associated_token_account::instruction::create_associated_token_account(
+                    &ctx.payer.pubkey(),
+                    &fee_beneficiary_owner,
+                    &ctx.mint,
+                    &ctx.spl_token_program_id,
+                ),
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    let (token_sender, token_sender_ata) = ctx
+        .create_funded_sender(100 * 10u64.pow(LOCAL_DECIMALS_U32))
+        .await;
+    let token_sender_pubkey = token_sender.pubkey();
+    let transfer_amount = 69 * 10u64.pow(LOCAL_DECIMALS_U32);
+    let recipient = H256::random();
+
+    // Sign a CC transient quote with ctx.target_router == DEFAULT_ROUTER.
+    // Transient params are deliberately large vs on-chain so the assertion
+    // distinguishes "transient consumed" (fee = 12345) from "fell through to
+    // on-chain DEFAULT" (fee = 75).
+    let transient_max_fee: u64 = 12345;
+    let transient_half_amount: u64 = 1_000_000_000;
+    let mut context = Vec::with_capacity(76);
+    context.extend_from_slice(&REMOTE_DOMAIN.to_le_bytes());
+    context.extend_from_slice(recipient.as_bytes());
+    context.extend_from_slice(&transfer_amount.to_le_bytes());
+    context.extend_from_slice(DEFAULT_ROUTER.as_bytes());
+    let data = borsh::to_vec(&FeeDataStrategy::Linear(FeeParams {
+        max_fee: transient_max_fee,
+        half_amount: transient_half_amount,
+    }))
+    .unwrap();
+    let clock: solana_program::clock::Clock = ctx.banks_client.get_sysvar().await.unwrap();
+    let issued_at = encode_u48(clock.unix_timestamp);
+
+    let mut quote = SvmSignedQuote {
+        context,
+        data,
+        issued_at,
+        expiry: issued_at, // transient
+        client_salt: H256::random(),
+        signature: [0u8; 65],
+    };
+    let scoped_salt = quote.compute_scoped_salt(&token_sender_pubkey);
+    let message_hash = quote.build_message_hash(&fee_account_key, LOCAL_DOMAIN, &scoped_salt);
+    quote.signature = sign_hash(&signing_key, message_hash.as_fixed_bytes());
+
+    // Submit transient: signer set is fetched from (REMOTE_DOMAIN, DEFAULT_ROUTER) CC route PDA.
+    let cc_default_route_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            cc_route_pda_seeds!(fee_account_key, &d, &DEFAULT_ROUTER),
+            &fp,
+        )
+        .0
+    };
+    let submit_ix = fee_instruction::submit_transient_quote_instruction(
+        fp,
+        token_sender_pubkey,
+        fee_account_key,
+        scoped_salt,
+        quote.clone(),
+        &[cc_default_route_pda],
+    )
+    .unwrap();
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[submit_ix],
+            Some(&token_sender_pubkey),
+            &[&token_sender],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    let (transient_pda, _) = Pubkey::find_program_address(
+        hyperlane_sealevel_fee::transient_quote_pda_seeds!(fee_account_key, scoped_salt),
+        &fp,
+    );
+
+    // Build the full TransferRemoteTo with the transient PDA inserted in the
+    // fee section right after the fee_account.
+    let unique_msg = Keypair::new();
+    let (dispatched_msg_key, _) = Pubkey::find_program_address(
+        mailbox_dispatched_message_pda_seeds!(&unique_msg.pubkey()),
+        &ctx.mailbox_program_id,
+    );
+    let (gas_payment_pda_key, _) = Pubkey::find_program_address(
+        igp_gas_payment_pda_seeds!(&unique_msg.pubkey()),
+        &igp_program_id(),
+    );
+
+    let specific_domain_standing_quote_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            fee_standing_quote_pda_seeds!(&fee_account_key, &d, &target_router),
+            &fp,
+        )
+        .0
+    };
+    let default_domain_standing_quote_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            fee_standing_quote_pda_seeds!(&fee_account_key, &d, &DEFAULT_ROUTER),
+            &fp,
+        )
+        .0
+    };
+    let wildcard_standing_quote_pda = {
+        let d = WILDCARD_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            fee_standing_quote_pda_seeds!(&fee_account_key, &d, &target_router),
+            &fp,
+        )
+        .0
+    };
+    let cc_route_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            cc_route_pda_seeds!(fee_account_key, &d, &target_router),
+            &fp,
+        )
+        .0
+    };
+
+    let ixn_data = CrossCollateralInstruction::TransferRemoteTo(TransferRemoteTo {
+        destination_domain: REMOTE_DOMAIN,
+        recipient,
+        amount_or_id: transfer_amount.into(),
+        target_router,
+    })
+    .encode()
+    .unwrap();
+
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                ctx.program_id,
+                &ixn_data,
+                vec![
+                    // CC prefix
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new_readonly(ctx.cc.token, false),
+                    AccountMeta::new_readonly(ctx.cc.cc_state, false),
+                    AccountMeta::new_readonly(account_utils::SPL_NOOP_PROGRAM_ID, false),
+                    // Core
+                    AccountMeta::new_readonly(ctx.mailbox_program_id, false),
+                    AccountMeta::new(ctx.mailbox_accounts.outbox, false),
+                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new(token_sender_pubkey, true),
+                    AccountMeta::new_readonly(unique_msg.pubkey(), true),
+                    AccountMeta::new(dispatched_msg_key, false),
+                    // Fee section: transient PDA before the standing/route PDAs.
+                    AccountMeta::new_readonly(fp, false),
+                    AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new(transient_pda, false), // writable for autoclose
+                    AccountMeta::new_readonly(specific_domain_standing_quote_pda, false),
+                    AccountMeta::new_readonly(default_domain_standing_quote_pda, false),
+                    AccountMeta::new_readonly(wildcard_standing_quote_pda, false),
+                    AccountMeta::new_readonly(cc_route_pda, false),
+                    AccountMeta::new_readonly(cc_default_route_pda, false),
+                    AccountMeta::new(fee_beneficiary_ata, false),
+                    // IGP
+                    AccountMeta::new_readonly(igp_program, false),
+                    AccountMeta::new(igp_program_data, false),
+                    AccountMeta::new(gas_payment_pda_key, false),
+                    AccountMeta::new_readonly(igp_overhead_igp, false),
+                    AccountMeta::new(igp_igp, false),
+                    // Plugin
+                    AccountMeta::new_readonly(ctx.spl_token_program_id, false),
+                    AccountMeta::new(ctx.mint, false),
+                    AccountMeta::new(token_sender_ata, false),
+                    AccountMeta::new(ctx.cc.escrow, false),
+                ],
+            )],
+            Some(&token_sender_pubkey),
+            &[&token_sender, &unique_msg],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    // Fee must come from the transient quote (12345), not the on-chain DEFAULT
+    // route (75). Distinguishing values prove the DEFAULT-router transient was
+    // resolved and consumed via the `Default` scope branch.
+    let expected_fee = transient_max_fee;
+    assert_token_balance(
+        &mut ctx.banks_client,
+        &token_sender_ata,
+        (100 * 10u64.pow(LOCAL_DECIMALS_U32)) - transfer_amount - expected_fee,
+    )
+    .await;
+    assert_token_balance(&mut ctx.banks_client, &fee_beneficiary_ata, expected_fee).await;
+
+    // Transient PDA autoclosed after successful consume.
+    let transient_account = ctx.banks_client.get_account(transient_pda).await.unwrap();
+    assert!(
+        transient_account.is_none() || transient_account.unwrap().data.is_empty(),
+        "transient PDA should be closed after consumption"
+    );
+}
+
+/// Negative variant of the DEFAULT-router transient flow: when both the
+/// DEFAULT and the specific `target_router` routes are configured on-chain,
+/// a DEFAULT-signed transient cannot consume against the specific scope.
+/// `TransferRemoteTo` with the specific `target_router` resolves
+/// `cc_specific_route_active = true` → scope = `CcConsumeScope::Specific` →
+/// `ctx.target_router (DEFAULT_ROUTER) != quote_fee.target_router (target_router)`
+/// → `QuoteValidationError::TransientContextMismatch` aborts the whole tx.
+/// The transient PDA must remain on-chain for the payer to close manually.
+#[tokio::test]
+async fn test_cc_remote_transfer_with_default_router_transient_rejected_when_specific_configured() {
+    use hyperlane_sealevel_fee::accounts::CrossCollateralRoutingFeeConfig;
+    use quote_verifier::QuoteValidationError;
+
+    let mut ctx = TestContext::new(true).await;
+    let igp = ctx.igp_accounts.as_ref().unwrap();
+    let (igp_program, igp_program_data, igp_overhead_igp, igp_igp) =
+        (igp.program, igp.program_data, igp.overhead_igp, igp.igp);
+
+    let target_router = H256::random();
+    set_cc_routers(
+        &mut ctx.banks_client,
+        &ctx.program_id,
+        &ctx.payer,
+        vec![CrossCollateralRouterUpdate::Add {
+            domain: REMOTE_DOMAIN,
+            router: target_router,
+        }],
+    )
+    .await
+    .unwrap();
+
+    let fee_beneficiary_owner = Pubkey::new_unique();
+    let fee_salt = H256::zero();
+    let fp = fee_program_id();
+    let (fee_account_key, _) = Pubkey::find_program_address(fee_account_pda_seeds!(fee_salt), &fp);
+
+    let signing_key = SigningKey::random(&mut rand::thread_rng());
+    let signer_address = eth_address(&signing_key);
+
+    // Configure BOTH routes — DEFAULT (signer set) + specific target_router
+    // (no signer needed here, just initialized so cc_specific_route_active=true
+    // at consume time).
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[
+                fee_instruction::init_fee_instruction(
+                    fp,
+                    ctx.payer.pubkey(),
+                    fee_salt,
+                    fee_beneficiary_owner,
+                    FeeData::CrossCollateralRouting(CrossCollateralRoutingFeeConfig {
+                        wildcard_signers: std::collections::BTreeSet::new(),
+                    }),
+                    LOCAL_DOMAIN,
+                )
+                .unwrap(),
+                fee_instruction::set_remote_fee_route_instruction(
+                    fp,
+                    fee_account_key,
+                    ctx.payer.pubkey(),
+                    REMOTE_DOMAIN,
+                    Some(DEFAULT_ROUTER),
+                    FeeDataStrategy::Linear(FeeParams {
+                        max_fee: 75,
+                        half_amount: 500_000,
+                    }),
+                    None,
+                )
+                .unwrap(),
+                fee_instruction::set_remote_fee_route_instruction(
+                    fp,
+                    fee_account_key,
+                    ctx.payer.pubkey(),
+                    REMOTE_DOMAIN,
+                    Some(target_router),
+                    FeeDataStrategy::Linear(FeeParams {
+                        max_fee: 200,
+                        half_amount: 1_000_000,
+                    }),
+                    None,
+                )
+                .unwrap(),
+                fee_instruction::set_quote_signer_instruction(
+                    fp,
+                    fee_account_key,
+                    ctx.payer.pubkey(),
+                    fee_instruction::SetQuoteSignerOperation::Add(signer_address),
+                    Some(fee_instruction::RouteKey::CrossCollateral {
+                        destination: REMOTE_DOMAIN,
+                        target_router: DEFAULT_ROUTER,
+                    }),
+                )
+                .unwrap(),
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    // Set fee config on the token.
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                ctx.program_id,
+                &HyperlaneTokenInstruction::SetFeeConfig(Some(FeeConfig {
+                    fee_program: fp,
+                    fee_account: fee_account_key,
+                }))
+                .encode()
+                .unwrap(),
+                vec![
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new(ctx.cc.token, false),
+                    AccountMeta::new(ctx.payer.pubkey(), true),
+                    AccountMeta::new_readonly(fp, false),
+                    AccountMeta::new_readonly(fee_account_key, false),
+                ],
+            )],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    let fee_beneficiary_ata =
+        spl_associated_token_account::get_associated_token_address_with_program_id(
+            &fee_beneficiary_owner,
+            &ctx.mint,
+            &ctx.spl_token_program_id,
+        );
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[
+                spl_associated_token_account::instruction::create_associated_token_account(
+                    &ctx.payer.pubkey(),
+                    &fee_beneficiary_owner,
+                    &ctx.mint,
+                    &ctx.spl_token_program_id,
+                ),
+            ],
+            Some(&ctx.payer.pubkey()),
+            &[&ctx.payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    let (token_sender, token_sender_ata) = ctx
+        .create_funded_sender(100 * 10u64.pow(LOCAL_DECIMALS_U32))
+        .await;
+    let token_sender_pubkey = token_sender.pubkey();
+    let transfer_amount = 69 * 10u64.pow(LOCAL_DECIMALS_U32);
+    let recipient = H256::random();
+
+    // Sign a transient against DEFAULT_ROUTER even though a specific route
+    // exists — the off-chain quoter's mistake we want the on-chain to catch.
+    let mut context = Vec::with_capacity(76);
+    context.extend_from_slice(&REMOTE_DOMAIN.to_le_bytes());
+    context.extend_from_slice(recipient.as_bytes());
+    context.extend_from_slice(&transfer_amount.to_le_bytes());
+    context.extend_from_slice(DEFAULT_ROUTER.as_bytes());
+    let data = borsh::to_vec(&FeeDataStrategy::Linear(FeeParams {
+        max_fee: 12345,
+        half_amount: 1_000_000_000,
+    }))
+    .unwrap();
+    let clock: solana_program::clock::Clock = ctx.banks_client.get_sysvar().await.unwrap();
+    let issued_at = encode_u48(clock.unix_timestamp);
+
+    let mut quote = SvmSignedQuote {
+        context,
+        data,
+        issued_at,
+        expiry: issued_at,
+        client_salt: H256::random(),
+        signature: [0u8; 65],
+    };
+    let scoped_salt = quote.compute_scoped_salt(&token_sender_pubkey);
+    let message_hash = quote.build_message_hash(&fee_account_key, LOCAL_DOMAIN, &scoped_salt);
+    quote.signature = sign_hash(&signing_key, message_hash.as_fixed_bytes());
+
+    let cc_default_route_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            cc_route_pda_seeds!(fee_account_key, &d, &DEFAULT_ROUTER),
+            &fp,
+        )
+        .0
+    };
+    // Submit succeeds — the transient is authorized by DEFAULT route signers,
+    // regardless of what other routes exist on-chain.
+    let submit_ix = fee_instruction::submit_transient_quote_instruction(
+        fp,
+        token_sender_pubkey,
+        fee_account_key,
+        scoped_salt,
+        quote.clone(),
+        &[cc_default_route_pda],
+    )
+    .unwrap();
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    ctx.banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[submit_ix],
+            Some(&token_sender_pubkey),
+            &[&token_sender],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    let (transient_pda, _) = Pubkey::find_program_address(
+        hyperlane_sealevel_fee::transient_quote_pda_seeds!(fee_account_key, scoped_salt),
+        &fp,
+    );
+
+    let unique_msg = Keypair::new();
+    let (dispatched_msg_key, _) = Pubkey::find_program_address(
+        mailbox_dispatched_message_pda_seeds!(&unique_msg.pubkey()),
+        &ctx.mailbox_program_id,
+    );
+    let (gas_payment_pda_key, _) = Pubkey::find_program_address(
+        igp_gas_payment_pda_seeds!(&unique_msg.pubkey()),
+        &igp_program_id(),
+    );
+    let specific_domain_standing_quote_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            fee_standing_quote_pda_seeds!(&fee_account_key, &d, &target_router),
+            &fp,
+        )
+        .0
+    };
+    let default_domain_standing_quote_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            fee_standing_quote_pda_seeds!(&fee_account_key, &d, &DEFAULT_ROUTER),
+            &fp,
+        )
+        .0
+    };
+    let wildcard_standing_quote_pda = {
+        let d = WILDCARD_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            fee_standing_quote_pda_seeds!(&fee_account_key, &d, &target_router),
+            &fp,
+        )
+        .0
+    };
+    let cc_route_pda = {
+        let d = REMOTE_DOMAIN.to_le_bytes();
+        Pubkey::find_program_address(
+            cc_route_pda_seeds!(fee_account_key, &d, &target_router),
+            &fp,
+        )
+        .0
+    };
+
+    let ixn_data = CrossCollateralInstruction::TransferRemoteTo(TransferRemoteTo {
+        destination_domain: REMOTE_DOMAIN,
+        recipient,
+        amount_or_id: transfer_amount.into(),
+        target_router,
+    })
+    .encode()
+    .unwrap();
+
+    let recent_blockhash = ctx.banks_client.get_latest_blockhash().await.unwrap();
+    let result = ctx
+        .banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                ctx.program_id,
+                &ixn_data,
+                vec![
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new_readonly(ctx.cc.token, false),
+                    AccountMeta::new_readonly(ctx.cc.cc_state, false),
+                    AccountMeta::new_readonly(account_utils::SPL_NOOP_PROGRAM_ID, false),
+                    AccountMeta::new_readonly(ctx.mailbox_program_id, false),
+                    AccountMeta::new(ctx.mailbox_accounts.outbox, false),
+                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new(token_sender_pubkey, true),
+                    AccountMeta::new_readonly(unique_msg.pubkey(), true),
+                    AccountMeta::new(dispatched_msg_key, false),
+                    AccountMeta::new_readonly(fp, false),
+                    AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new(transient_pda, false),
+                    AccountMeta::new_readonly(specific_domain_standing_quote_pda, false),
+                    AccountMeta::new_readonly(default_domain_standing_quote_pda, false),
+                    AccountMeta::new_readonly(wildcard_standing_quote_pda, false),
+                    AccountMeta::new_readonly(cc_route_pda, false),
+                    AccountMeta::new_readonly(cc_default_route_pda, false),
+                    AccountMeta::new(fee_beneficiary_ata, false),
+                    AccountMeta::new_readonly(igp_program, false),
+                    AccountMeta::new(igp_program_data, false),
+                    AccountMeta::new(gas_payment_pda_key, false),
+                    AccountMeta::new_readonly(igp_overhead_igp, false),
+                    AccountMeta::new(igp_igp, false),
+                    AccountMeta::new_readonly(ctx.spl_token_program_id, false),
+                    AccountMeta::new(ctx.mint, false),
+                    AccountMeta::new(token_sender_ata, false),
+                    AccountMeta::new(ctx.cc.escrow, false),
+                ],
+            )],
+            Some(&token_sender_pubkey),
+            &[&token_sender, &unique_msg],
+            recent_blockhash,
+        ))
+        .await;
+
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(QuoteValidationError::TransientContextMismatch as u32),
+        ),
+    );
+
+    // Transient PDA must still exist — the failed consume must not autoclose.
+    let transient_account = ctx.banks_client.get_account(transient_pda).await.unwrap();
+    assert!(
+        transient_account.is_some_and(|a| !a.data.is_empty()),
+        "transient PDA must persist after rejected consume so the payer can close it"
+    );
+}
+
 // === Additional fee tests for parity with native ===
 
 #[tokio::test]


### PR DESCRIPTION
### Description

  Relaxes the `hyperlane-sealevel-fee` program to allow cross-collateral (CC) transient quotes signed with `ctx.target_router == DEFAULT_ROUTER` to be submitted and consumed when the on-chain routing cascade falls back to the default
  route. Previously the program rejected this shape up front as "unconsumable" because the consume-time `target_router` check did strict equality against the caller's `quote_fee.target_router` (which is always a real remote router, never
  the `DEFAULT_ROUTER` sentinel).

  The fix makes the consume-time `target_router` check scope-aware via a new `CcQuoteFeeValidation` enum:

  - `Specific` (the `(dest, quote_fee.target_router)` CC route PDA is initialized): require `ctx.target_router == quote_fee.target_router`. Unchanged behavior.
  - `Default` (specific route uninitialized; cascade falls back to `(dest, DEFAULT_ROUTER)`): require `ctx.target_router == DEFAULT_ROUTER`. New path.

  This mirrors EVM's `feeContracts[dest][target_router] ?? feeContracts[dest][DEFAULT_ROUTER]` fallback in `CrossCollateralRoutingFee.sol`: a signer authorized for the DEFAULT fee contract on EVM can quote a transfer whose specific route
  is unconfigured, and now the SVM analog supports the equivalent flow. The off-chain quoter SDK in `hyp-sol` already encodes this routing decision (`svmQuoteService.ts::pickLeaf`) and was previously hard-blocked from selecting the DEFAULT
   fallback for transient quotes; that guard can now be lifted in a follow-up PR.

  The `CcQuoteFeeValidation` enum wraps `&QuoteFee` inside its variants so the consume-time validate is a compile-time-exhaustive match on the scope — no separate boolean flag the caller might forget to thread through. `validate()` returns
   the validated `&QuoteFee` so the caller doesn't need a separate accessor.

  Scope isolation is enforced by a three-part lock and was verified independently by four security review agents (full diff vs spec, adversarial threat modeling, CPI safety, EVM parity):
  1. **Submit-time signer scoping** — the route PDA's signer set is loaded from `(dest, ctx.target_router)`, so a DEFAULT-route signer cannot produce a valid submit at a specific scope and vice versa.
  2. **Scope detection via PDA re-derivation** — `resolve_cc_routing` re-derives both CC route PDA keys with `find_program_address` and `cc_specific_route_active` cannot be spoofed.
  3. **Scope-bound consume** — `CcQuoteFeeValidation::unwrap_for_router` enforces strict scope-specific router equality at validation time.

  Removes the now-unused `DefaultRouterNotAllowedForTransientQuote` error variant and the matching simulation-side guard in `process_get_submit_quote_account_metas`.

  ### Drive-by changes

  - Hoists the `ctx.target_router == H256::zero()` rejection in `process_submit_quote` above the wildcard-domain branch so it applies symmetrically to both wildcard and exact-domain CC transient submissions. Zero-router transients are
  unconsumable at every scope; rejecting up front keeps the submit surface symmetric and prevents operators from stranding rent on dead transients.

  ### Related issues

  <!-- Fixes #[issue number here] -->

  ### Backward compatibility

  Yes. The fee program is not yet in production, so there are no in-flight signers, deployed callers, or persisted on-chain transients that would observe the change. The account-list layout is unchanged for both `SubmitQuote` and
  `QuoteFee` (the relaxation only affects which `target_router` values are accepted in the same existing slots).

  ### Testing

  Unit tests + token-program end-to-end tests.

  **Fee-program functional tests** (`tests/functional/transient.rs`, `tests/functional/helpers.rs`):

  - DEFAULT-signed transient consumed when only default route configured.
  - DEFAULT-signed transient rejected when specific route configured (race: specific route added between submit and consume); transient PDA persists and is closeable by the original payer.
  - Specific-router transient submit rejected when no specific route is configured (`RouteNotFound`).
  - Specific-router transient rejected after specific route removed between submit and consume.
  - Wildcard-domain DEFAULT-router transient consumed under default scope.
  - Wildcard-domain DEFAULT-router transient rejected when specific route is configured at the destination.
  - Wildcard-domain specific-router transient rejected under default scope (symmetric invariant).
  - Inverted `GetSubmitQuoteAccountMetas` simulation: layout is now emitted for the CC DEFAULT-router transient case instead of erroring up front.

  **Token-program end-to-end tests** (`hyperlane-sealevel-token-cross-collateral/tests/functional.rs`):

  - `TransferRemoteTo` consumes a DEFAULT-signed transient end-to-end when only the default route is configured. Fee comes from the transient quote, not the on-chain default rate (asserted with distinguishing values).
  - `TransferRemoteTo` with a DEFAULT-signed transient aborts the entire transaction with `QuoteValidationError::TransientContextMismatch` when a specific route is configured for the caller's `target_router`; the transient PDA persists for
   the payer to close manually.

  Full test counts: `hyperlane-sealevel-fee` 175 passed, `hyperlane-sealevel-token-cross-collateral` 61 passed. `cargo clippy --tests -- -D warnings` clean.
  
  Live test: https://solscan.io/tx/28KFVNg185ZnqSd7QUNPJ6JQFp2v2WLnwM3dEaFrxeuXwrSUDY7yKvPL4iej68dB4xXRbZtZsos4kYg9dNqtzeR8