### PR TITLE
chore: upgrade relayers to a38d060-20260604-084332

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -40,9 +40,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '81821ef-20260520-124638',
-  relayerRC: '81821ef-20260520-124638',
-  relayerFastPath: '81821ef-20260520-124638',
+  relayer: 'a38d060-20260604-084332',
+  relayerRC: 'a38d060-20260604-084332',
+  relayerFastPath: 'a38d060-20260604-084332',
   validator: '81821ef-20260520-124638',
   validatorRC: '81821ef-20260520-124638',
   scraper: 'da1cfb1-20260522-132959',

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -945,7 +945,8 @@ const hyperlane: RootAgentConfig = {
       port: 8900,
       rateLimitMaxRequests: 100,
       rateLimitWindowSecs: 60,
-      corsOrigins: 'https://nexus.hyperlane.xyz',
+      corsOrigins:
+        'https://nexus.hyperlane.xyz,https://hyperlane-warp-template-git-xaroz-swap-form-abacus-works.vercel.app',
     },
     resources: relayerResources,
   },


### PR DESCRIPTION
### Description

Upgrade relayers to latest version

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
