### PR TITLE
fix(infra): temporarily disable keyfunder sweeping

### DIFF
--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -175,7 +175,8 @@ export class KeyFunderHelmManager extends HelmManager {
 
         const override = this.config.sweepOverrides?.[chain];
         chainConfig.sweep = {
-          enabled: true,
+          // Temporarily disabled; re-enable once sweep destination is confirmed.
+          enabled: false,
           address: override?.sweepAddress ?? DEFAULT_SWEEP_ADDRESS,
           threshold: sweepThreshold,
           targetMultiplier: override?.targetMultiplier ?? 1.5,


### PR DESCRIPTION
## Description

Temporarily disables automatic keyfunder sweeping by setting `sweep.enabled: false` in the generated keyfunder config.

The hardcoded `DEFAULT_SWEEP_ADDRESS` is left unchanged (`0x478be6076f31E9666123B9721D0B6631baD944AF`), so sweeping can be re-enabled by flipping `enabled` back to `true` once the sweep destination is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)