### PR TITLE
feat(sdk): add seismic technical stack

### DIFF
--- a/.changeset/seismic-technical-stack.md
+++ b/.changeset/seismic-technical-stack.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Added a new `Seismic` value to the `ChainTechnicalStack` enum.

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -40,6 +40,7 @@ export enum ChainTechnicalStack {
   OpStack = 'opstack',
   PolygonCDK = 'polygoncdk',
   PolkadotSubstrate = 'polkadotsubstrate',
+  Seismic = 'seismic',
   ZkSync = 'zksync',
   Other = 'other',
   Unknown = 'unknown',


### PR DESCRIPTION
## Description

Adds a new `Seismic` value to the `ChainTechnicalStack` enum in the SDK chain metadata types. Placed in alphabetical order (above `ZkSync`).

No special-case handling is wired up for this stack yet; it behaves like a standard EVM stack.

## Changeset

Minor changeset added for `@hyperlane-xyz/sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)