### PR TITLE
feat(rust): signed eth_estimateGas for Seismic relayer (handoff)

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -4028,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -4053,7 +4053,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -4095,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -4155,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -4242,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?branch=pb%2Fseismic-sign-raw-transaction#2c3ae23707b48fbdd99d3e1c1fe2eedcc0afc573"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -270,30 +270,33 @@ tag = "2025-08-07"
 git = "https://github.com/hyperlane-xyz/cometbft-rs"
 tag = "2025-08-07"
 
+# NOTE: temporarily pinned to the pb/seismic-sign-raw-transaction branch for the
+# Middleware::sign_raw_transaction passthrough (hyperlane-xyz/ethers-rs#48).
+# Repin to a tag once that PR merges and a new ethers-rs tag is cut.
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+branch = "pb/seismic-sign-raw-transaction"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+branch = "pb/seismic-sign-raw-transaction"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+branch = "pb/seismic-sign-raw-transaction"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+branch = "pb/seismic-sign-raw-transaction"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+branch = "pb/seismic-sign-raw-transaction"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -134,6 +134,10 @@ where
     // either use the pre-estimated gas limit or estimate it
     let mut estimated_gas_limit: U256 = match tx.tx.gas() {
         Some(&estimate) => estimate.into(),
+        // Seismic zeroes `from` on unsigned eth_estimateGas, so msg.sender-gated
+        // calls (e.g. a TrustedRelayerIsm) would estimate against sender 0x0.
+        // Use a signed estimate so the node recovers the relayer's address.
+        None if domain.is_seismic_stack() => seismic_estimate_gas(&tx.tx, provider.clone()).await?,
         None => tx.estimate_gas().await?.into(),
     };
 
@@ -369,6 +373,54 @@ where
         .await?;
     tracing::debug!(?result, ?tx, "Successfully fetched zkSync fee estimate");
     Ok(result)
+}
+
+/// Gas cap used when signing the throwaway tx handed to `eth_estimateGas` on
+/// Seismic. Mirrors seismic-viem's DEFAULT_SIGNED_ESTIMATE_GAS_LIMIT.
+const SEISMIC_SIGNED_ESTIMATE_GAS_CAP: u32 = 30_000_000;
+
+/// Estimate gas on a Seismic chain via a signed `eth_estimateGas`.
+///
+/// Seismic zeroes the `from` field on unsigned `eth_call`/`eth_estimateGas` (to
+/// protect access-controlled shielded state), so msg.sender-gated calls
+/// estimate as if sent from `0x0`. Instead, Seismic's `eth_estimateGas` accepts
+/// a *signed* transaction and recovers `msg.sender` from the signature. We sign
+/// the call's transaction (via the middleware stack's signer, exposed by
+/// `Middleware::sign_raw_transaction`) and submit the raw bytes.
+///
+/// NOTE: not yet exercised end-to-end — no current Seismic chain uses a
+/// msg.sender-gated ISM (the multisig default ISM estimates fine unsigned). This
+/// path is needed only if a TrustedRelayerIsm is deployed on a Seismic chain,
+/// and should be validated against one before relying on it (in particular the
+/// nonce/fee fields the node expects on the signed estimate tx).
+async fn seismic_estimate_gas<M>(tx: &TypedTransaction, provider: Arc<M>) -> ChainResult<U256>
+where
+    M: Middleware + 'static,
+{
+    let mut tx = tx.clone();
+    // Ensure `from` is set so the node recovers the right sender.
+    if tx.from().is_none() {
+        if let Some(sender) = provider.default_sender() {
+            tx.set_from(sender);
+        }
+    }
+    // Cap the gas so the signed tx serializes with a sane estimation ceiling
+    // (the real submission sets the actual gas limit downstream).
+    tx.set_gas(EthersU256::from(SEISMIC_SIGNED_ESTIMATE_GAS_CAP));
+
+    // Sign through the middleware stack (requires the `sign_raw_transaction`
+    // passthrough added to hyperlane-xyz/ethers-rs).
+    let signed = provider
+        .sign_raw_transaction(&tx)
+        .await
+        .map_err(ChainCommunicationError::from_other)?;
+
+    let gas: EthersU256 = provider
+        .provider()
+        .request("eth_estimateGas", [signed])
+        .await
+        .map_err(ChainCommunicationError::from_other)?;
+    Ok(gas.into())
 }
 
 // From

--- a/rust/main/hyperlane-core/src/chain.rs
+++ b/rust/main/hyperlane-core/src/chain.rs
@@ -401,6 +401,7 @@ pub enum HyperlaneDomainTechnicalStack {
     OpStack,
     PolygonCDK,
     PolkadotSubstrate,
+    Seismic,
     ZkSync,
     #[default]
     Other,
@@ -686,6 +687,13 @@ impl HyperlaneDomain {
         matches!(
             self.domain_technical_stack(),
             HyperlaneDomainTechnicalStack::ZkSync
+        )
+    }
+
+    pub const fn is_seismic_stack(&self) -> bool {
+        matches!(
+            self.domain_technical_stack(),
+            HyperlaneDomainTechnicalStack::Seismic
         )
     }
 


### PR DESCRIPTION
## What

Adds a signed `eth_estimateGas` path for Seismic chains in the Rust agents:
- `HyperlaneDomainTechnicalStack::Seismic` + `is_seismic_stack()` (hyperlane-core)
- `seismic_estimate_gas` in `fill_tx_gas_params` (hyperlane-ethereum): signs the tx via `Middleware::sign_raw_transaction` and calls `eth_estimateGas` with the raw signed tx, so Seismic recovers `msg.sender`.

Depends on hyperlane-xyz/ethers-rs#48 (the `sign_raw_transaction` passthrough); Cargo is temporarily pinned to that branch.

## Why

Seismic zeroes `from` on unsigned `eth_call`/`eth_estimateGas`. For msg.sender-gated ISMs (e.g. `TrustedRelayerIsm`) the relayer's `process` gas estimate would simulate against `0x0` and revert. A signed estimate fixes that.

## Status — handoff / NOT YET NEEDED

- **No current Seismic chain needs this.** seismictestnet uses the multisig/aggregation default ISM, which doesn't read `msg.sender`, so unsigned estimation already works. This path only matters once a `TrustedRelayerIsm` is placed on a Seismic chain.
- **Not exercised end-to-end** (nothing to validate against yet). In particular the nonce/fee fields the node expects on the signed estimate tx should be validated against a real sender-gated Seismic chain before relying on it.
- The bare `Seismic` enum variant (forward-compat for agent-config parsing) ships separately in the seismictestnet deploy PR (#8852), so agents don't break when `technicalStack: "seismic"` enters the agent config. This branch should be rebased on `main` after that lands.

## Before merge
- [ ] hyperlane-xyz/ethers-rs#48 merged + new ethers-rs tag cut
- [ ] Repin `rust/main/Cargo.toml` ethers-rs deps from the branch to that tag
- [ ] Validate against a Seismic chain with a sender-gated ISM

🤖 Generated with [Claude Code](https://claude.com/claude-code)