### PR TITLE
fix(starknet-sdk): default reads to latest block to avoid pending-block RPC errors

### DIFF
--- a/.changeset/starknet-read-latest-block.md
+++ b/.changeset/starknet-read-latest-block.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/starknet-sdk': patch
+---
+
+Starknet read calls defaulted to the latest accepted block instead of the pending block, so warp token reads no longer fail against RPC providers that reject `block_id: "pending"`.

--- a/typescript/starknet-sdk/src/clients/provider.ts
+++ b/typescript/starknet-sdk/src/clients/provider.ts
@@ -1,5 +1,6 @@
 import {
   AccountInterface,
+  BlockTag,
   CairoOption,
   CairoOptionVariant,
   Contract,
@@ -99,6 +100,11 @@ export class StarknetProvider implements AltVM.IProvider<StarknetAnnotatedTx> {
     const provider = new RpcProvider({
       nodeUrl: rpcUrls[0],
       transactionRetryIntervalFallback,
+      // Default reads to the latest accepted block instead of starknet.js's
+      // `pending` default. Some RPC providers reject `block_id: "pending"`
+      // (-32602 Invalid block id), and reading already-finalized state at
+      // `latest` is both universally supported and semantically correct.
+      blockIdentifier: BlockTag.LATEST,
     });
     return new StarknetProvider(provider, metadata, rpcUrls);
   }


### PR DESCRIPTION
## What

Starknet SDK read calls relied on starknet.js's default `block_id: "pending"`. Some RPC providers (e.g. `rpc.starknet.lava.build`) reject `pending` with `-32602 Invalid params: {"reason":"Invalid block id"}`, causing `StarknetProvider.determineTokenType` → `getClassHashAt` (and subsequent `callContract` reads) to fail.

This sets the read provider's default `blockIdentifier` to `BlockTag.LATEST`. Reading already-finalized state at `latest` is universally supported across RPCs and semantically correct for warp token reads.

## Why this surfaced as a flaky release-PR failure

The `read-warp-token` Starknet SDK e2e shard failed on the changesets release PR (#8835) but passes on `main`. The `typescript/starknet-sdk/src` tree is byte-identical between the two — the difference was purely which RPC node served the request, not code. This makes the read path robust regardless of provider.

## Testing

`STARKNET_SDK_E2E_TEST=read-warp-token pnpm -C typescript/starknet-sdk test:e2e` — both the Starknet (lava.build) and Paradex legs pass:

```
  Starknet Warp Token read E2E Tests
    ✔ should read collateral token on starknet ...
    ✔ should read collateral token on paradex ...
  2 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)