### PR TITLE
perf(relayer): reduce quorum fetch latency

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
@@ -14,7 +14,12 @@ use hyperlane_core::{
 
 const FETCH_CHECKPOINT_METHOD: &str = "fetch_checkpoint";
 const LATEST_INDEX_METHOD: &str = "latest_index";
-const LATEST_INDEX_CACHE_TTL: Duration = Duration::from_secs(5);
+// Kept short so that on the merkle-root multisig path (where `latest_index`
+// gates the highest quorum index we search from) a freshly-advanced validator
+// is picked up within ~1 retry cycle, while still absorbing the bulk of
+// per-validator `latest_index` RPC/S3 load. The message-id multisig path only
+// uses `latest_index` for metrics, so it is unaffected by this TTL.
+const LATEST_INDEX_CACHE_TTL: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CachedLatestIndexKey {

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
@@ -1,15 +1,26 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, time::Duration};
 
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
-use hyperlane_base::{cache::FunctionCallCache, CheckpointSyncer};
+use hyperlane_base::{
+    cache::{ExpirationType, FunctionCallCache},
+    CheckpointSyncer,
+};
 use hyperlane_core::{
     ReorgEvent, ReorgEventResponse, SignedAnnouncement, SignedCheckpointWithMessageId, H256,
 };
 
 const FETCH_CHECKPOINT_METHOD: &str = "fetch_checkpoint";
+const LATEST_INDEX_METHOD: &str = "latest_index";
+const LATEST_INDEX_CACHE_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CachedLatestIndexKey {
+    validator: H256,
+    storage_location: String,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CachedCheckpointKey {
@@ -49,6 +60,13 @@ impl<C> CachedCheckpointSyncer<C> {
             validator: self.validator,
             storage_location: self.storage_location.clone(),
             index,
+        }
+    }
+
+    fn latest_index_cache_key(&self) -> CachedLatestIndexKey {
+        CachedLatestIndexKey {
+            validator: self.validator,
+            storage_location: self.storage_location.clone(),
         }
     }
 
@@ -97,7 +115,49 @@ where
     C: FunctionCallCache + Debug,
 {
     async fn latest_index(&self) -> Result<Option<u32>> {
-        self.inner.latest_index().await
+        let cache_key = self.latest_index_cache_key();
+        match self
+            .cache
+            .get_cached_call_result::<u32>(
+                &self.origin_domain_name,
+                LATEST_INDEX_METHOD,
+                &cache_key,
+            )
+            .await
+        {
+            Ok(Some(latest_index)) => return Ok(Some(latest_index)),
+            Ok(None) => {}
+            Err(err) => {
+                debug!(
+                    error = %err,
+                    validator = ?self.validator,
+                    "Failed to fetch latest checkpoint index from cache"
+                );
+            }
+        }
+
+        let result = self.inner.latest_index().await;
+        if let Ok(Some(latest_index)) = &result {
+            if let Err(err) = self
+                .cache
+                .cache_call_result_with_expiration(
+                    &self.origin_domain_name,
+                    LATEST_INDEX_METHOD,
+                    &cache_key,
+                    latest_index,
+                    ExpirationType::AfterDuration(LATEST_INDEX_CACHE_TTL),
+                )
+                .await
+            {
+                debug!(
+                    error = %err,
+                    validator = ?self.validator,
+                    latest_index,
+                    "Failed to cache latest checkpoint index"
+                );
+            }
+        }
+        result
     }
 
     async fn write_latest_index(&self, index: u32) -> Result<()> {
@@ -211,7 +271,9 @@ mod tests {
     #[derive(Debug)]
     struct CountingCheckpointSyncer {
         fetch_count: Arc<AtomicUsize>,
+        latest_index_count: Arc<AtomicUsize>,
         responses: Mutex<VecDeque<Result<Option<SignedCheckpointWithMessageId>>>>,
+        latest_index_responses: Mutex<VecDeque<Result<Option<u32>>>>,
     }
 
     impl CountingCheckpointSyncer {
@@ -219,12 +281,31 @@ mod tests {
             responses: Vec<Result<Option<SignedCheckpointWithMessageId>>>,
         ) -> (Self, Arc<AtomicUsize>) {
             let fetch_count = Arc::new(AtomicUsize::new(0));
+            let latest_index_count = Arc::new(AtomicUsize::new(0));
             (
                 Self {
                     fetch_count: fetch_count.clone(),
+                    latest_index_count,
                     responses: Mutex::new(responses.into()),
+                    latest_index_responses: Mutex::new(VecDeque::new()),
                 },
                 fetch_count,
+            )
+        }
+
+        fn new_with_latest_index_responses(
+            latest_index_responses: Vec<Result<Option<u32>>>,
+        ) -> (Self, Arc<AtomicUsize>) {
+            let fetch_count = Arc::new(AtomicUsize::new(0));
+            let latest_index_count = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    fetch_count,
+                    latest_index_count: latest_index_count.clone(),
+                    responses: Mutex::new(VecDeque::new()),
+                    latest_index_responses: Mutex::new(latest_index_responses.into()),
+                },
+                latest_index_count,
             )
         }
     }
@@ -232,7 +313,12 @@ mod tests {
     #[async_trait::async_trait]
     impl CheckpointSyncer for CountingCheckpointSyncer {
         async fn latest_index(&self) -> Result<Option<u32>> {
-            Ok(Some(0))
+            self.latest_index_count.fetch_add(1, Ordering::Relaxed);
+            self.latest_index_responses
+                .lock()
+                .map_err(|_| eyre::eyre!("Failed to lock latest index responses"))?
+                .pop_front()
+                .unwrap_or_else(|| bail!("No latest index response"))
         }
 
         async fn write_latest_index(&self, _index: u32) -> Result<()> {
@@ -488,5 +574,72 @@ mod tests {
         assert_eq!(second, Some(signed_checkpoint));
         assert_eq!(first_fetch_count.load(Ordering::Relaxed), 1);
         assert_eq!(second_fetch_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn caches_successful_latest_index_fetches() {
+        let signer = test_signer();
+        let (inner, latest_index_count) =
+            CountingCheckpointSyncer::new_with_latest_index_responses(vec![Ok(Some(10))]);
+        let syncer = CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        );
+
+        let first = syncer.latest_index().await.expect("first fetch");
+        let second = syncer.latest_index().await.expect("second fetch");
+
+        assert_eq!(first, Some(10));
+        assert_eq!(second, Some(10));
+        assert_eq!(latest_index_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_cache_missing_latest_index_fetches() {
+        let signer = test_signer();
+        let (inner, latest_index_count) =
+            CountingCheckpointSyncer::new_with_latest_index_responses(vec![Ok(None), Ok(Some(10))]);
+        let syncer = CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        );
+
+        let first = syncer.latest_index().await.expect("first fetch");
+        let second = syncer.latest_index().await.expect("second fetch");
+
+        assert_eq!(first, None);
+        assert_eq!(second, Some(10));
+        assert_eq!(latest_index_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn expires_cached_latest_index_fetches() {
+        let signer = test_signer();
+        let (inner, latest_index_count) =
+            CountingCheckpointSyncer::new_with_latest_index_responses(vec![
+                Ok(Some(10)),
+                Ok(Some(11)),
+            ]);
+        let syncer = CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        );
+
+        let first = syncer.latest_index().await.expect("first fetch");
+        tokio::time::sleep(LATEST_INDEX_CACHE_TTL + Duration::from_secs(1)).await;
+        let second = syncer.latest_index().await.expect("second fetch");
+
+        assert_eq!(first, Some(10));
+        assert_eq!(second, Some(11));
+        assert_eq!(latest_index_count.load(Ordering::Relaxed), 2);
     }
 }

--- a/rust/main/hyperlane-base/src/cache/metered_cache.rs
+++ b/rust/main/hyperlane-base/src/cache/metered_cache.rs
@@ -9,7 +9,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::cache::FunctionCallCache;
 
-use super::CacheResult;
+use super::{CacheResult, ExpirationType};
 
 /// Basic cache information.
 #[derive(Debug, Clone)]
@@ -69,6 +69,19 @@ where
     ) -> CacheResult<()> {
         self.inner
             .cache_call_result(domain_name, fn_key, fn_params, result)
+            .await
+    }
+
+    async fn cache_call_result_with_expiration(
+        &self,
+        domain_name: &str,
+        fn_key: &str,
+        fn_params: &(impl Serialize + Send + Sync),
+        result: &(impl Serialize + Send + Sync),
+        expiration: ExpirationType,
+    ) -> CacheResult<()> {
+        self.inner
+            .cache_call_result_with_expiration(domain_name, fn_key, fn_params, result, expiration)
             .await
     }
 

--- a/rust/main/hyperlane-base/src/cache/mod.rs
+++ b/rust/main/hyperlane-base/src/cache/mod.rs
@@ -11,7 +11,7 @@ pub use metered_cache::{
     MeteredCache, MeteredCacheConfig, MeteredCacheMetrics, MeteredCacheMetricsBuilder,
     HIT_COUNT_HELP, HIT_COUNT_LABELS, MISS_COUNT_HELP, MISS_COUNT_LABELS,
 };
-pub use moka::{CacheResult, Expiration, LocalCache};
+pub use moka::{CacheResult, Expiration, ExpirationType, LocalCache};
 pub use optional_cache::OptionalCache;
 
 /// Should be used as the `fn_params` when the function has no parameters
@@ -28,6 +28,16 @@ pub trait FunctionCallCache: Send + Sync {
         fn_key: &str,
         fn_params: &(impl Serialize + Send + Sync),
         result: &(impl Serialize + Send + Sync),
+    ) -> CacheResult<()>;
+
+    /// Cache a call result with the given parameters and expiration.
+    async fn cache_call_result_with_expiration(
+        &self,
+        domain_name: &str,
+        fn_key: &str,
+        fn_params: &(impl Serialize + Send + Sync),
+        result: &(impl Serialize + Send + Sync),
+        expiration: ExpirationType,
     ) -> CacheResult<()>;
 
     /// Get a cached call result with the given parameters

--- a/rust/main/hyperlane-base/src/cache/moka/local_cache.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/local_cache.rs
@@ -28,11 +28,26 @@ impl FunctionCallCache for LocalCache {
         fn_params: &(impl Serialize + Send + Sync),
         result: &(impl Serialize + Send + Sync),
     ) -> CacheResult<()> {
+        self.cache_call_result_with_expiration(
+            domain_name,
+            method,
+            fn_params,
+            result,
+            ExpirationType::Default,
+        )
+        .await
+    }
+
+    async fn cache_call_result_with_expiration(
+        &self,
+        domain_name: &str,
+        method: &str,
+        fn_params: &(impl Serialize + Send + Sync),
+        result: &(impl Serialize + Send + Sync),
+        expiration: ExpirationType,
+    ) -> CacheResult<()> {
         let key = (domain_name, method, fn_params);
-        self.0
-            .set(&key, result, ExpirationType::Default)
-            .await
-            .map(|_| ())
+        self.0.set(&key, result, expiration).await.map(|_| ())
     }
 
     /// Get a cached call result with the given parameters

--- a/rust/main/hyperlane-base/src/cache/optional_cache.rs
+++ b/rust/main/hyperlane-base/src/cache/optional_cache.rs
@@ -6,7 +6,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::cache::FunctionCallCache;
 
-use super::CacheResult;
+use super::{CacheResult, ExpirationType};
 
 /// A Cache wrapper that instruments the cache calls with metrics.
 #[derive(new, Debug, Clone)]
@@ -30,6 +30,28 @@ where
         if let Some(inner) = &self.inner {
             return inner
                 .cache_call_result(domain_name, fn_key, fn_params, result)
+                .await;
+        }
+        Ok(())
+    }
+
+    async fn cache_call_result_with_expiration(
+        &self,
+        domain_name: &str,
+        fn_key: &str,
+        fn_params: &(impl Serialize + Send + Sync),
+        result: &(impl Serialize + Send + Sync),
+        expiration: ExpirationType,
+    ) -> CacheResult<()> {
+        if let Some(inner) = &self.inner {
+            return inner
+                .cache_call_result_with_expiration(
+                    domain_name,
+                    fn_key,
+                    fn_params,
+                    result,
+                    expiration,
+                )
                 .await;
         }
         Ok(())

--- a/rust/main/hyperlane-base/src/types/multisig.rs
+++ b/rust/main/hyperlane-base/src/types/multisig.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use derive_new::new;
 use eyre::Result;
-use futures::StreamExt;
+use futures::{stream::FuturesUnordered, StreamExt};
 use tracing::{debug, instrument, warn};
 
 use hyperlane_core::{
@@ -176,8 +176,10 @@ impl MultisigCheckpointSyncer {
         // Keeps track of signed validator checkpoints for a particular root.
         // In practice, it's likely that validators will all sign the same root for a
         // particular index, but we'd like to be robust to this not being the case
-        let mut signed_checkpoints_per_root: HashMap<H256, Vec<SignedCheckpointWithMessageId>> =
-            HashMap::new();
+        let mut signed_checkpoints_per_root: HashMap<
+            H256,
+            Vec<(usize, SignedCheckpointWithMessageId)>,
+        > = HashMap::new();
 
         // we iterate in batches of N=threshold*1.5 to avoid waiting for all validators.
         // This reaches a quorum faster without having to fetch all the signatures.
@@ -186,28 +188,33 @@ impl MultisigCheckpointSyncer {
         let batch_size = (threshold as f64 * 1.5) as usize;
         let batch_size = batch_size.clamp(1, 10);
 
-        for batched_validators in validators.chunks(batch_size) {
+        let indexed_validators = validators.iter().enumerate().collect::<Vec<_>>();
+        for batched_validators in indexed_validators.chunks(batch_size) {
             // Go through each validator and get the checkpoint syncer.
             // Create a future for each validator that fetches its signed checkpoint
-            let futures = batched_validators
+            let mut futures = batched_validators
                 .iter()
-                .filter_map(|address| {
-                    if let Some(syncer) = self.checkpoint_syncers.get(&H160::from(*address)) {
-                        Some((address, syncer))
+                .filter_map(|(validator_index, address)| {
+                    if let Some(syncer) = self.checkpoint_syncers.get(&H160::from(**address)) {
+                        Some((*validator_index, **address, syncer))
                     } else {
                         debug!(validator=%address, "Checkpoint syncer not found");
                         None
                     }
                 })
-                .map(|(address, syncer)| {
+                .map(|(validator_index, address, syncer)| {
                     let checkpoint_syncer = syncer.clone();
-                    async move { (address, checkpoint_syncer.fetch_checkpoint(index).await) }
+                    async move {
+                        (
+                            validator_index,
+                            address,
+                            checkpoint_syncer.fetch_checkpoint(index).await,
+                        )
+                    }
                 })
-                .collect::<Vec<_>>();
+                .collect::<FuturesUnordered<_>>();
 
-            let checkpoints = futures::future::join_all(futures).await;
-
-            for (validator, checkpoint) in checkpoints {
+            while let Some((validator_index, validator, checkpoint)) = futures.next().await {
                 // Gracefully ignore an error fetching the checkpoint from a validator's
                 // checkpoint syncer, which can happen if the validator has not
                 // signed the checkpoint at `index`.
@@ -237,7 +244,7 @@ impl MultisigCheckpointSyncer {
                 // Ensure that the signature is actually by the validator
                 let signer = signed_checkpoint.recover()?;
 
-                if H256::from(signer) != *validator {
+                if H256::from(signer) != validator {
                     debug!(
                         validator = format!("{:#x}", validator),
                         index = index,
@@ -249,7 +256,7 @@ impl MultisigCheckpointSyncer {
                 // Push the signed checkpoint into the hashmap
                 let root = signed_checkpoint.value.root;
                 let signed_checkpoints = signed_checkpoints_per_root.entry(root).or_default();
-                signed_checkpoints.push(signed_checkpoint);
+                signed_checkpoints.push((validator_index, signed_checkpoint));
 
                 // Count the number of signatures for this signed checkpoint
                 let signature_count = signed_checkpoints.len();
@@ -263,12 +270,18 @@ impl MultisigCheckpointSyncer {
 
                 // If we've hit a quorum, create a MultisigSignedCheckpoint
                 if signature_count >= threshold {
-                    let mut checkpoint: MultisigSignedCheckpoint = signed_checkpoints.try_into()?;
+                    signed_checkpoints.sort_by_key(|(validator_index, _)| *validator_index);
+                    let mut ordered_signed_checkpoints = signed_checkpoints
+                        .iter()
+                        .map(|(_, signed_checkpoint)| signed_checkpoint.clone())
+                        .collect::<Vec<_>>();
+                    let mut checkpoint: MultisigSignedCheckpoint =
+                        (&mut ordered_signed_checkpoints).try_into()?;
 
                     // Ensure the signatures are in the correct order, padding with empty signatures if necessary
                     if destination.is_aleo_protocol() {
                         checkpoint.signatures =
-                            self.ensure_validator_ordering(validators, signed_checkpoints);
+                            self.ensure_validator_ordering(validators, &ordered_signed_checkpoints);
                     }
 
                     debug!(checkpoint=?checkpoint, "Fetched multisig checkpoint");
@@ -320,11 +333,12 @@ impl MultisigCheckpointSyncer {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr;
+    use std::{str::FromStr, time::Duration};
 
     use aws_config::Region;
     use hyperlane_core::{
-        Checkpoint, CheckpointWithMessageId, HyperlaneSignerExt, KnownHyperlaneDomain,
+        Checkpoint, CheckpointWithMessageId, HyperlaneSignerExt, KnownHyperlaneDomain, ReorgEvent,
+        ReorgEventResponse, SignedAnnouncement,
     };
     use hyperlane_ethereum::Signers;
 
@@ -369,6 +383,57 @@ mod test {
             syncers.insert(key, val);
         }
         syncers
+    }
+
+    #[derive(Debug)]
+    struct DelayedCheckpointSyncer {
+        delay: Duration,
+        latest_index: Option<u32>,
+        checkpoint: Option<SignedCheckpointWithMessageId>,
+    }
+
+    #[async_trait::async_trait]
+    impl CheckpointSyncer for DelayedCheckpointSyncer {
+        async fn latest_index(&self) -> Result<Option<u32>> {
+            Ok(self.latest_index)
+        }
+
+        async fn write_latest_index(&self, _: u32) -> Result<()> {
+            Ok(())
+        }
+
+        async fn fetch_checkpoint(&self, _: u32) -> Result<Option<SignedCheckpointWithMessageId>> {
+            tokio::time::sleep(self.delay).await;
+            Ok(self.checkpoint.clone())
+        }
+
+        async fn write_checkpoint(&self, _: &SignedCheckpointWithMessageId) -> Result<()> {
+            Ok(())
+        }
+
+        async fn write_metadata(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn write_announcement(&self, _: &SignedAnnouncement) -> Result<()> {
+            Ok(())
+        }
+
+        fn announcement_location(&self) -> String {
+            "test".to_string()
+        }
+
+        async fn write_reorg_status(&self, _: &ReorgEvent) -> Result<()> {
+            Ok(())
+        }
+
+        async fn reorg_status(&self) -> Result<ReorgEventResponse> {
+            Ok(ReorgEventResponse {
+                exists: false,
+                event: None,
+                content: None,
+            })
+        }
     }
 
     async fn generate_multisig_signed_checkpoint(
@@ -648,6 +713,77 @@ mod test {
             .expect("Failed to fetch checkpoint");
 
         let expected = Some(generate_multisig_signed_checkpoint(&validators, checkpoint).await);
+        assert_eq!(result, expected);
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn test_fetch_checkpoint_does_not_wait_for_slow_validator_after_quorum() {
+        let checkpoint = CheckpointWithMessageId {
+            checkpoint: Checkpoint {
+                mailbox_domain: 100,
+                merkle_tree_hook_address: H256::zero(),
+                root: H256::zero(),
+                index: 1000,
+            },
+            message_id: H256::zero(),
+        };
+
+        let mut validators: Vec<_> = dummy_validators().drain(..).take(3).collect();
+        for validator in &mut validators {
+            validator.latest_index = Some(1000);
+            validator.fetch_checkpoint = Some(checkpoint);
+        }
+
+        let mut syncers: HashMap<H160, Arc<dyn CheckpointSyncer + 'static>> = HashMap::new();
+        for (validator_index, validator) in validators.iter().enumerate() {
+            let signer: Signers = validator
+                .private_key
+                .parse::<ethers::signers::LocalWallet>()
+                .unwrap()
+                .into();
+            let delay = if validator_index == 0 {
+                Duration::from_secs(2)
+            } else {
+                Duration::ZERO
+            };
+            let signed_checkpoint = signer.sign(checkpoint).await.unwrap();
+            let syncer = DelayedCheckpointSyncer {
+                delay,
+                latest_index: validator.latest_index,
+                checkpoint: Some(signed_checkpoint),
+            };
+            let key = H160::from_str(&validator.public_key).unwrap();
+            syncers.insert(key, Arc::new(syncer) as Arc<dyn CheckpointSyncer>);
+        }
+
+        let validator_addresses = validators
+            .iter()
+            .map(|validator| {
+                let address: H256 = H160::from_str(&validator.public_key).unwrap().into();
+                address
+            })
+            .collect::<Vec<_>>();
+        let multisig_syncer = MultisigCheckpointSyncer::new(syncers, None);
+
+        let start = tokio::time::Instant::now();
+        let result = multisig_syncer
+            .fetch_checkpoint(
+                validator_addresses.as_slice(),
+                2,
+                1000,
+                &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+            )
+            .await
+            .expect("Failed to fetch checkpoint")
+            .expect("Expected checkpoint");
+
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "fetch_checkpoint should return after fast quorum"
+        );
+
+        let expected = generate_multisig_signed_checkpoint(&validators[1..], checkpoint).await;
         assert_eq!(result, expected);
     }
 


### PR DESCRIPTION
## Performance impact

- `latest_index()` remote reads are reduced by up to 100% for repeated metadata builds within the 5s TTL: cached successful validators are read from memory instead of S3/GCS/local storage.
- Batch checkpoint latency changes from waiting for the slowest validator in the active batch to waiting only until quorum for a root is available.
- The new timing test covers a threshold-2 batch with one 2s validator and two fast validators; `fetch_checkpoint` returns in under 1s instead of waiting roughly 2s for the slow validator.

## Summary

- Added explicit-expiration writes to `FunctionCallCache` so callers can use TTLs shorter than the default cache lifetime.
- Cached successful validator `latest_index()` reads for 5 seconds in the relayer checkpoint syncer decorator from #8865.
- Changed `MultisigCheckpointSyncer::fetch_checkpoint` to process a validator batch with `FuturesUnordered`, returning as soon as the batch has quorum instead of waiting for every in-flight validator in that batch.
- Preserved multisig metadata ordering by sorting collected quorum signatures by original validator index before constructing metadata.

## Why

The relayer already avoids fetching every validator by batching, but a slow validator in the active batch can still delay quorum even when other validators have already returned enough signatures. Also, `latest_index()` is fetched repeatedly during metadata attempts; a short success-only TTL avoids repeated remote storage reads without caching time-varying misses.

## Stacking

Stacked on #8865 because the short-TTL `latest_index()` cache naturally extends the `CachedCheckpointSyncer` introduced there.

## Validation

- `cargo fmt --package hyperlane-base --package relayer`
- `cargo test --package relayer cached_checkpoint_syncer --lib`
- `cargo test --package hyperlane-base test_fetch_checkpoint_does_not_wait_for_slow_validator_after_quorum --lib`
- `cargo test --package hyperlane-base types::multisig --lib`
- `cargo clippy --package hyperlane-base --lib -- -D warnings`
- `cargo clippy --package relayer --lib -- -D warnings`
