### PR TITLE
chore: refuse humanity exploiter relaying

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -40,9 +40,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '81821ef-20260520-124638',
-  relayerRC: '81821ef-20260520-124638',
-  relayerFastPath: '81821ef-20260520-124638',
+  relayer: 'a38d060-20260604-084332',
+  relayerRC: 'a38d060-20260604-084332',
+  relayerFastPath: 'a38d060-20260604-084332',
   validator: '81821ef-20260520-124638',
   validatorRC: '81821ef-20260520-124638',
   scraper: 'da1cfb1-20260522-132959',

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -302,11 +302,23 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
       '0x00000000000000000000000235aE95896583818d',
     ];
 
+    const humanityExploiter = [
+      '0x36560d6ac2004e1bb483e77b791e905dd4f5e672',
+      '0xee4B6B8967Aa947ac3aEf540eE07ea6099C566F7',
+      '0x4dD6288307661BBf0B1785B531dbAd3fac8c909D',
+      '0x456Cb73b35022E4B524e5510807776453d984AeF',
+      '0xD1ea823D421E0c829ee11F772AF487fd352678EA',
+      '0x9e995952eF7665B243eeEF0693acD7FEd7150504',
+      '0x6Aa22CB8420E94Fc2119364b4c7885710aE753bB',
+      '0xAf2a4989922299EB14A29E332dad1012A8aaD3A0',
+    ];
+
     const uniqueAddresses = new Set(
       [
         ...sanctionedEthereumAddresses,
         ...radiantExploiter,
         ...flowAddresses,
+        ...humanityExploiter,
       ].map((address) => address.toLowerCase()),
     );
 


### PR DESCRIPTION
### Description

Refuses relaying for the Humanity exploiter

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
