### PR TITLE
feat(infra): lower fast-path relayer reorgPeriod for arbitrum/base/citrea

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -1105,7 +1105,7 @@ const fastPath: RootAgentConfig = {
     ],
     blacklist,
     gasPaymentEnforcement,
-    reorgPeriodOverrides: { ethereum: 1 },
+    reorgPeriodOverrides: { ethereum: 1, arbitrum: 1, base: 1, citrea: 1 },
     ismCacheConfigs,
     cache: {
       enabled: true,


### PR DESCRIPTION
## Summary
- Adds `arbitrum: 1, base: 1, citrea: 1` to the fast-path relayer's `reorgPeriodOverrides` in `mainnet3/agent.ts` (alongside the existing `ethereum: 1`).
- Speeds up trusted-relayer fast-path deliveries by removing the origin-chain default finality wait, which was the dominant latency component on these lanes.

## Context
Empirical latency measurements on katana lanes showed total latency ≈ ~10s relay floor + origin finality wait (reorgPeriod × origin block time) + ~1 destination block. The origin reorgPeriod was the dominant lever:
- base→katana was ~29s, driven almost entirely by base's default reorgPeriod (10) × ~2s block time ≈ 20s origin wait.
- arbitrum lanes were ~10s both ways (arbitrum reorgPeriod 5 × 0.25s ≈ 1.2s).

Registry defaults for reference: arbitrum 5, base 10, citrea 5, ethereum 15. polygon/bsc are `finalized` (no override). katana is already 1 (no override needed).

## Risk
Bounded: the fast path only serves sub-threshold (<1000 USDC) transfers via the TrustedRelayerIsm branch of the AmountRoutingIsm. Larger transfers continue to route through the validator multisig, which is gated by the separate validator reorgPeriod and is unaffected by this change.

Approved by Nam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)