### PR TITLE
feat: add new commitment endpoint

### DIFF
--- a/.changeset/itchy-wasps-develop.md
+++ b/.changeset/itchy-wasps-develop.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/ccip-server": minor
+---
+
+Added new public commitments endpoint to check whether calls are present or not

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -165,7 +165,7 @@ export class CallCommitmentsService extends BaseService {
     }
 
     logger.info(data, 'Commitment processing completed successfully');
-    return res.sendStatus(200);
+    return res.status(200).json({ commitment });
   }
 
   public async handleFetchCommitment(

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -27,6 +27,7 @@ import {
 import {
   addressToBytes32,
   bytes32ToAddress,
+  assert,
   eqAddress,
   parseMessage,
 } from '@hyperlane-xyz/utils';
@@ -389,12 +390,31 @@ export class CallCommitmentsService extends BaseService {
    * Used by the router status service to detect call_lost without a time threshold.
    */
   public async handleCheckCommitment(req: Request, res: Response) {
+    const logger = this.addLoggerServiceContext(req.log);
     const { commitment } = req.params;
-    const record = await prisma.commitment.findUnique({
-      where: { commitment },
-      select: { commitment: true },
-    });
-    return res.json({ exists: record !== null });
+    assert(commitment, 'Route parameter :commitment must be present');
+    try {
+      const record = await prisma.commitment.findUnique({
+        where: { commitment },
+        select: { commitment: true },
+      });
+      return res.json({ exists: record !== null });
+    } catch (error: any) {
+      logger.error(
+        {
+          commitment,
+          error: error.message,
+          stack: error.stack,
+          error_reason: UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
+        },
+        'Database error during commitment existence check',
+      );
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
+      );
+      return res.status(500).json({ error: 'Internal server error' });
+    }
   }
 
   /**
@@ -417,7 +437,11 @@ export class CallCommitmentsService extends BaseService {
       commitmentRateLimit,
       this.handleCommitment.bind(this),
     );
-    router.get('/calls/:commitment', this.handleCheckCommitment.bind(this));
+    router.get(
+      '/calls/:commitment',
+      commitmentRateLimit,
+      this.handleCheckCommitment.bind(this),
+    );
     router.post(
       '/getCallsFromRevealMessage',
       createAbiHandler(

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -385,6 +385,19 @@ export class CallCommitmentsService extends BaseService {
   }
 
   /**
+   * GET /calls/:commitment — returns { exists: boolean }.
+   * Used by the router status service to detect call_lost without a time threshold.
+   */
+  public async handleCheckCommitment(req: Request, res: Response) {
+    const { commitment } = req.params;
+    const record = await prisma.commitment.findUnique({
+      where: { commitment },
+      select: { commitment: true },
+    });
+    return res.json({ exists: record !== null });
+  }
+
+  /**
    * Register routes onto an Express Router or app.
    */
   private registerRoutes(router: Router, baseUrl: string): void {
@@ -404,6 +417,7 @@ export class CallCommitmentsService extends BaseService {
       commitmentRateLimit,
       this.handleCommitment.bind(this),
     );
+    router.get('/calls/:commitment', this.handleCheckCommitment.bind(this));
     router.post(
       '/getCallsFromRevealMessage',
       createAbiHandler(

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -135,7 +135,8 @@ describe('CallCommitmentsService.handleCommitment', () => {
     await service.handleCommitment(req, res);
 
     expect(icaApp.getAccount.called).to.be.true;
-    expect(res.sendStatus.calledWith(200)).to.be.true;
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.json.calledWithMatch(sinon.match.has('commitment'))).to.be.true;
   });
 
   it('routes legacy payload to deriveIcaFromDispatchTx', async () => {


### PR DESCRIPTION
…er calls are present or not

### Description

Added new public commitments endpoint to check whether calls are available or not. Needed for proper error tracking in the engine to decide whether to recover a failed swap or not

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
