### PR TITLE
chore: signer rotations

### DIFF
--- a/typescript/infra/.gitignore
+++ b/typescript/infra/.gitignore
@@ -9,3 +9,4 @@ test/outputs
 config/environments/test/core/
 config/environments/test/igp/
 config/environments/test/ism/
+safe-tx-output/

--- a/typescript/infra/config/environments/mainnet3/governance/proxy-admin/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/proxy-admin/aw.ts
@@ -1,27 +1,37 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
-import { awSafes } from '../safe/aw.js';
-import { awIcas } from '../ica/aw.js';
 import { Address } from '@hyperlane-xyz/utils';
+
+import { chainOwners } from '../../owners.js';
+import { awIcas } from '../ica/aw.js';
+import { awSafes } from '../safe/aw.js';
+
+// Fall back to the chain's governance owner when an AW safe entry has been
+// removed (e.g. a deprecated/unused safe commented out of awSafes), so a missing
+// entry never yields an undefined proxy-admin owner.
+const ownerOrFallback = (
+  safe: Address | undefined,
+  fallback: Address,
+): Address => safe ?? fallback;
 
 export const awProxyAdmins: ChainMap<{ address: Address; owner: Address }> = {
   ethereum: {
     address: '0x692e50577fAaBF10F824Dc8Ce581e3Af93785175',
-    owner: awSafes.ethereum,
+    owner: ownerOrFallback(awSafes.ethereum, chainOwners.ethereum.owner),
   },
   arbitrum: {
     address: '0x33465314CbD880976B7A9f86062d615DE5E4Fa8A',
-    owner: awSafes.arbitrum,
+    owner: ownerOrFallback(awSafes.arbitrum, chainOwners.arbitrum.owner),
   },
   bsc: {
     address: '0x9C5a42CBA06D818945df8D798C98F41EA1d88BDA',
-    owner: awSafes.bsc,
+    owner: ownerOrFallback(awSafes.bsc, chainOwners.bsc.owner),
   },
   plasma: {
     address: '0x0587E4E093Cd820eda59EcF0FD73544cE65B4775',
-    owner: awSafes.plasma,
+    owner: ownerOrFallback(awSafes.plasma, chainOwners.plasma.owner),
   },
   tron: {
     address: '0x0d558DbF548fB9df2b62740b8a4C79A7160971DB',
     owner: awIcas.tron, // owned by Ethereum Safe
   },
-} as const;
+};

--- a/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
@@ -1,76 +1,64 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
-// 2026-06-16: Commented-out entries are AW safes that own no warp routes and are
-// not referenced as an owner by any monorepo config getter. They are retained
-// (commented) for historical reference. With the proxy-admin / warp-router
-// fallbacks, a missing entry resolves to the chain's governance owner / deployer
-// rather than an unmaintained safe.
+// Active AbacusWorks safes: own warp routes and/or are referenced as an owner by
+// monorepo config (proxy-admin / warp-router config). Verified against on-chain
+// proxy-admin owner() where applicable.
+//
+// Inactive safes (own no warp routes and not referenced as an owner anywhere) are
+// commented out at the bottom — see the dated note there.
 export const awSafes: ChainMap<Address> = {
-  mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have a UI
+  arbitrum: '0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e',
+  avalanche: '0x5bE94B17112B8F18eA9Ac8e559377B467556a3c3',
+  base: '0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF',
+  bsc: '0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170',
   celo: '0x879038d6Fc9F6D5e2BA73188bd078486d77e1156',
   ethereum: '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6',
-  avalanche: '0x5bE94B17112B8F18eA9Ac8e559377B467556a3c3',
-  // polygon: '0xf9cFD440CfBCfAB8473cc156485B7eE753b2913E',
-  bsc: '0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170',
-  arbitrum: '0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e',
-  optimism: '0xbd7db3821806bc72D223F0AE521Bf82FcBd6Ef4d',
-  // gnosis: '0x0Ac72fBc82c9c39F81242229631dfC38aA13031B',
-  base: '0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF',
-  // solana: 'EzppBFV2taxWw8kEjxNYvby6q7W1biJEqwP3iC7YgRe3',
-  // blast: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  // linea: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  mode: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  // ancient8: '0xD2BFA0F0654E3f2139b8cDC56c32eeC54D32b133',
-  // taiko: '0xa4864301d3fa2a3e68256309F9F0F570270a1BD0',
-  // fraxtal: '0x66e9f52800E9F89F0569fddc594Acd5EE609f762',
-  // sei: '0xCed197FBc360C26C19889745Cf73511b71D03d5D',
-  // mantle: '0x8aFE6EECc6CcB02aA20DA8Fff7d29aadEBbc2DCd',
-  // bob: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
-  // zetachain: '0x9d399876522Fc5C044D048594de399A2349d6026',
-  // fusemainnet: '0x29a526227CB864C90Cf078d03872da913B473139',
-  // endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  // zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
-  // swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-
-  // Q5, 2024 batch
-  // berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-
-  // HyperEVM
   hyperevm: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-
-  // zksync chains
-  zeronetwork: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
-  // abstract: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
-  // zksync: '0x9C81aA0cC233e9BddeA426F5d395Ab5B65135450',
-  // sophon: '0x3D1baf8cA4935f416671640B1Aa9E17E005986eE',
-
-  // ousdt extension
-  worldchain: '0x95b1634566663117322999ce42cDEaEF18c089Be',
-  // unichain: '0x028C71E99e23fD393DE4207486D1aF7FA2b26b33',
-  // ink: '0x8DEe31BF7da558ee3224D22E224e172783CA8d70',
-  // soneium: '0xD97F1bc0d49f994137Acf36baE2aEd9b2E4F239a',
-  // superseed: '0x2915Ff7B025bc65bBFfD1621F6B3d4E4295dB4F6',
-  // lisk: '0x831d0b06DF466263c06FFcD467cf91c6FA57c62C',
-  // sonic: '0x7f56412491D8E77331Ff0300d3C8E42A6D233FdC',
-  // bitlayer: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-  // ronin: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-  // metis: '0xf6B817Cf8b4440F38951851cf1160969039966A2',
-  // metal: '0x41A4e3425c7FeE8711D1C1b2c2acc1879F849b45',
-
-  // Jan 29, 2026 - Migrating Viction to Safes
-  // ----------------------------------------------------------
-  viction: '0x18165B1cb2969B79D2a0f67AECe0bf7bb44a7CaD',
-
-  // Feb 4, 2026 - FPWR ProxyAdmin on Safes
-  // ----------------------------------------------------------
-  // monad: '0x930f79e486B869EC7B5BF4e83121aDfcca198f42',
-
-  // Mar 12, 2026 - Igra Chain Deployment
-  // ----------------------------------------------------------
-  // igra: '0x0c205894f0cA786AB1693f232F4e19a60Af5c72B',
-
-  // Mar 24, 2026
-  // ----------------------------------------------------------
+  mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have a UI
+  mode: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  optimism: '0xbd7db3821806bc72D223F0AE521Bf82FcBd6Ef4d',
   plasma: '0xCcf5e9862D486e71aA47B87Cb3a7eEB1e1f2F624',
+  viction: '0x18165B1cb2969B79D2a0f67AECe0bf7bb44a7CaD',
+  worldchain: '0x95b1634566663117322999ce42cDEaEF18c089Be',
+  zeronetwork: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
+
+  // ---------------------------------------------------------------------------
+  // 2026-06-16: Inactive — own no warp routes and are not referenced as an owner
+  // by any monorepo config getter. Retained for historical reference; a missing
+  // entry resolves (via proxy-admin / warp-router fallbacks) to the chain's
+  // governance owner rather than an unmaintained safe.
+  // ---------------------------------------------------------------------------
+  // abstract: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
+  // ancient8: '0xD2BFA0F0654E3f2139b8cDC56c32eeC54D32b133',
+  // berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // bitlayer: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // blast: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  // bob: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
+  // endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  // fraxtal: '0x66e9f52800E9F89F0569fddc594Acd5EE609f762',
+  // fusemainnet: '0x29a526227CB864C90Cf078d03872da913B473139',
+  // gnosis: '0x0Ac72fBc82c9c39F81242229631dfC38aA13031B',
+  // igra: '0x0c205894f0cA786AB1693f232F4e19a60Af5c72B',
+  // ink: '0x8DEe31BF7da558ee3224D22E224e172783CA8d70',
+  // linea: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  // lisk: '0x831d0b06DF466263c06FFcD467cf91c6FA57c62C',
+  // mantle: '0x8aFE6EECc6CcB02aA20DA8Fff7d29aadEBbc2DCd',
+  // metal: '0x41A4e3425c7FeE8711D1C1b2c2acc1879F849b45',
+  // metis: '0xf6B817Cf8b4440F38951851cf1160969039966A2',
+  // monad: '0x930f79e486B869EC7B5BF4e83121aDfcca198f42',
+  // polygon: '0xf9cFD440CfBCfAB8473cc156485B7eE753b2913E',
+  // ronin: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // sei: '0xCed197FBc360C26C19889745Cf73511b71D03d5D',
+  // solana: 'EzppBFV2taxWw8kEjxNYvby6q7W1biJEqwP3iC7YgRe3',
+  // soneium: '0xD97F1bc0d49f994137Acf36baE2aEd9b2E4F239a',
+  // sonic: '0x7f56412491D8E77331Ff0300d3C8E42A6D233FdC',
+  // sophon: '0x3D1baf8cA4935f416671640B1Aa9E17E005986eE',
+  // superseed: '0x2915Ff7B025bc65bBFfD1621F6B3d4E4295dB4F6',
+  // swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // taiko: '0xa4864301d3fa2a3e68256309F9F0F570270a1BD0',
+  // unichain: '0x028C71E99e23fD393DE4207486D1aF7FA2b26b33',
+  // zetachain: '0x9d399876522Fc5C044D048594de399A2349d6026',
+  // zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
+  // zksync: '0x9C81aA0cC233e9BddeA426F5d395Ab5B65135450',
 };

--- a/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
@@ -1,57 +1,62 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
+// 2026-06-16: Commented-out entries are AW safes that own no warp routes and are
+// not referenced as an owner by any monorepo config getter. They are retained
+// (commented) for historical reference. With the proxy-admin / warp-router
+// fallbacks, a missing entry resolves to the chain's governance owner / deployer
+// rather than an unmaintained safe.
 export const awSafes: ChainMap<Address> = {
   mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have a UI
   celo: '0x879038d6Fc9F6D5e2BA73188bd078486d77e1156',
   ethereum: '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6',
   avalanche: '0x5bE94B17112B8F18eA9Ac8e559377B467556a3c3',
-  polygon: '0xf9cFD440CfBCfAB8473cc156485B7eE753b2913E',
+  // polygon: '0xf9cFD440CfBCfAB8473cc156485B7eE753b2913E',
   bsc: '0x7bB2ADeDdC342ffb611dDC073095cc4B8C547170',
   arbitrum: '0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e',
   optimism: '0xbd7db3821806bc72D223F0AE521Bf82FcBd6Ef4d',
-  gnosis: '0x0Ac72fBc82c9c39F81242229631dfC38aA13031B',
+  // gnosis: '0x0Ac72fBc82c9c39F81242229631dfC38aA13031B',
   base: '0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF',
   // solana: 'EzppBFV2taxWw8kEjxNYvby6q7W1biJEqwP3iC7YgRe3',
-  blast: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  linea: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  // blast: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  // linea: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
   mode: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  ancient8: '0xD2BFA0F0654E3f2139b8cDC56c32eeC54D32b133',
-  taiko: '0xa4864301d3fa2a3e68256309F9F0F570270a1BD0',
-  fraxtal: '0x66e9f52800E9F89F0569fddc594Acd5EE609f762',
-  sei: '0xCed197FBc360C26C19889745Cf73511b71D03d5D',
-  mantle: '0x8aFE6EECc6CcB02aA20DA8Fff7d29aadEBbc2DCd',
-  bob: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
-  zetachain: '0x9d399876522Fc5C044D048594de399A2349d6026',
-  fusemainnet: '0x29a526227CB864C90Cf078d03872da913B473139',
-  endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
-  zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
-  swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // ancient8: '0xD2BFA0F0654E3f2139b8cDC56c32eeC54D32b133',
+  // taiko: '0xa4864301d3fa2a3e68256309F9F0F570270a1BD0',
+  // fraxtal: '0x66e9f52800E9F89F0569fddc594Acd5EE609f762',
+  // sei: '0xCed197FBc360C26C19889745Cf73511b71D03d5D',
+  // mantle: '0x8aFE6EECc6CcB02aA20DA8Fff7d29aadEBbc2DCd',
+  // bob: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
+  // zetachain: '0x9d399876522Fc5C044D048594de399A2349d6026',
+  // fusemainnet: '0x29a526227CB864C90Cf078d03872da913B473139',
+  // endurance: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  // zircuit: '0x9e2fe7723b018d02cDE4f5cC1A9bC9C65b922Fc8',
+  // swell: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // Q5, 2024 batch
-  berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // berachain: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // HyperEVM
   hyperevm: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
 
   // zksync chains
   zeronetwork: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
-  abstract: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
-  zksync: '0x9C81aA0cC233e9BddeA426F5d395Ab5B65135450',
-  sophon: '0x3D1baf8cA4935f416671640B1Aa9E17E005986eE',
+  // abstract: '0xCB21F61A3c8139F18e635d45aD1e62A4A61d2c3D',
+  // zksync: '0x9C81aA0cC233e9BddeA426F5d395Ab5B65135450',
+  // sophon: '0x3D1baf8cA4935f416671640B1Aa9E17E005986eE',
 
   // ousdt extension
   worldchain: '0x95b1634566663117322999ce42cDEaEF18c089Be',
-  unichain: '0x028C71E99e23fD393DE4207486D1aF7FA2b26b33',
-  ink: '0x8DEe31BF7da558ee3224D22E224e172783CA8d70',
-  soneium: '0xD97F1bc0d49f994137Acf36baE2aEd9b2E4F239a',
-  superseed: '0x2915Ff7B025bc65bBFfD1621F6B3d4E4295dB4F6',
-  lisk: '0x831d0b06DF466263c06FFcD467cf91c6FA57c62C',
-  sonic: '0x7f56412491D8E77331Ff0300d3C8E42A6D233FdC',
-  bitlayer: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-  ronin: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-  metis: '0xf6B817Cf8b4440F38951851cf1160969039966A2',
-  metal: '0x41A4e3425c7FeE8711D1C1b2c2acc1879F849b45',
+  // unichain: '0x028C71E99e23fD393DE4207486D1aF7FA2b26b33',
+  // ink: '0x8DEe31BF7da558ee3224D22E224e172783CA8d70',
+  // soneium: '0xD97F1bc0d49f994137Acf36baE2aEd9b2E4F239a',
+  // superseed: '0x2915Ff7B025bc65bBFfD1621F6B3d4E4295dB4F6',
+  // lisk: '0x831d0b06DF466263c06FFcD467cf91c6FA57c62C',
+  // sonic: '0x7f56412491D8E77331Ff0300d3C8E42A6D233FdC',
+  // bitlayer: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // ronin: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
+  // metis: '0xf6B817Cf8b4440F38951851cf1160969039966A2',
+  // metal: '0x41A4e3425c7FeE8711D1C1b2c2acc1879F849b45',
 
   // Jan 29, 2026 - Migrating Viction to Safes
   // ----------------------------------------------------------
@@ -59,7 +64,7 @@ export const awSafes: ChainMap<Address> = {
 
   // Feb 4, 2026 - FPWR ProxyAdmin on Safes
   // ----------------------------------------------------------
-  monad: '0x930f79e486B869EC7B5BF4e83121aDfcca198f42',
+  // monad: '0x930f79e486B869EC7B5BF4e83121aDfcca198f42',
 
   // Mar 12, 2026 - Igra Chain Deployment
   // ----------------------------------------------------------

--- a/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/aw.ts
@@ -15,7 +15,7 @@ export const awSafes: ChainMap<Address> = {
   celo: '0x879038d6Fc9F6D5e2BA73188bd078486d77e1156',
   ethereum: '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6',
   hyperevm: '0x5F7771EA40546e2932754C263455Cb0023a55ca7',
-  mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have a UI
+  mantapacific: '0x03ed2D65f2742193CeD99D48EbF1F1D6F12345B6', // does not have safe API > 5.18.0
   mode: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
   optimism: '0xbd7db3821806bc72D223F0AE521Bf82FcBd6Ef4d',
   plasma: '0xCcf5e9862D486e71aA47B87Cb3a7eEB1e1f2F624',

--- a/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
@@ -3,13 +3,23 @@ import { Address } from '@hyperlane-xyz/utils';
 export const awSigners: Address[] = [
   '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba', // 1
   '0xc3E966E79eF1aA4751221F55fB8A36589C24C0cA', // 2
-  '0x3f6D8219Cf0eEECd470150B20DAa018fCfe0714B', // 3
-  '0x478be6076f31E9666123B9721D0B6631baD944AF', // 4
-  '0x003DDD9eEAb62013b7332Ab4CC6B10077a8ca961', // 5
-  '0x0f37358c518475Aad722c666a3f60Ac2cbA526F7', // 6
-  '0xD7C3cc05e4311286e8E837EF6a8add9A54488B1e', // 7
-  '0x5b73A98165778BCCE72979B4EE3faCdb31728b8E', // 8
-  '0x47Bbac4147c330c8FAD542d1A52f1bB97716826b', // 9
+  '0x003DDD9eEAb62013b7332Ab4CC6B10077a8ca961', // 3
+  '0xD7C3cc05e4311286e8E837EF6a8add9A54488B1e', // 4
+  '0x5b73A98165778BCCE72979B4EE3faCdb31728b8E', // 5
+  '0x47Bbac4147c330c8FAD542d1A52f1bB97716826b', // 6
+  '0x852d3D5dc1B8C8cFf3bebD033025e54fA366fA94', // 7
 ];
 
-export const awThreshold = 4;
+export const awThreshold = 3;
+
+export const awSvmSigners: Address[] = [
+  'A8goWfZ7a6smK9pdDgoDWyAq9p7jtvyERJN6VLd8zrx2', // 1
+  '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf', // 2
+  'A4voX3UC3TGLsKyEsDGWAvrjT3mpnA67Fx9cccdoPKqm', // 3
+  'B32qTbw8iDcVdagMAMBfDFCef88N1KtfRG5QoPVzbj5K', // 4
+  '8GjwFNTn2giBwEGo3qMrfNydEjXiQHUNf79rwAkTNmDy', // 5
+  'E7cD9kcNXUC6f7CFDUoqjWaWaPxY9WNpNxjhbh5HwMiE', // 6
+  '8U1cahSHqugrpPmEUm4ZNokJhoCDVGVjCB33EP1k2eFT', // 7
+];
+
+export const awSvmThreshold = 3;

--- a/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
@@ -20,6 +20,7 @@ export const awSvmSigners: Address[] = [
   '8GjwFNTn2giBwEGo3qMrfNydEjXiQHUNf79rwAkTNmDy', // 5
   'E7cD9kcNXUC6f7CFDUoqjWaWaPxY9WNpNxjhbh5HwMiE', // 6
   '8U1cahSHqugrpPmEUm4ZNokJhoCDVGVjCB33EP1k2eFT', // 7
+  'AHWkCm6fuLCBqkSt5ZDNYWc8PTbWDLjrZDcLpcGQnSui', // 8
 ];
 
 export const awSvmThreshold = 3;

--- a/typescript/infra/config/environments/mainnet3/governance/signers/regular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/regular.ts
@@ -16,16 +16,17 @@ export const regularSigners: Address[] = [
 export const regularThreshold = 6;
 
 export const regularSvmSigners: Address[] = [
-  '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf', // 1
-  '3c5oFeqTRDXUkTcaxCMS2jsHWAkvUi4treoMBCP1aUPo', // 2
-  '4ocDADfUkH6qSMBGV977rPJEvmFxiG1MSmBbKwMUX9Ya', // 3
-  'FwHF7jDNvuwCuYhBCZZPY1VBoBVSHPsVBqu7UCp7dnA3', // 4
-  '8V5Uu7xMQhaUcD6pzNReVzrSe89KMCXoGk7ErbkXik2b', // 5
-  'A4voX3UC3TGLsKyEsDGWAvrjT3mpnA67Fx9cccdoPKqm', // 6
-  'Cstnx15y98NCnjXddxEcgpJrW44TFYq9QSXYcdmfW4HR', // 7
-  'DqGAc8YvHUPnpA5cuausLhkCp1cUvEQFYjpWVHJTPiNM', // 8
-  'EpaKfP4sd2xhEQvnYS3EgCXj7rkg7jTCasTByFj8kuLg', // 9
-  'AkG81cTMBD2Kh1gmDF66mAeRosDQjvATJyDWN48BSh85', // 10
+  'A8goWfZ7a6smK9pdDgoDWyAq9p7jtvyERJN6VLd8zrx2', // 1
+  '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf', // 2
+  '3c5oFeqTRDXUkTcaxCMS2jsHWAkvUi4treoMBCP1aUPo', // 3
+  '4ocDADfUkH6qSMBGV977rPJEvmFxiG1MSmBbKwMUX9Ya', // 4
+  'FwHF7jDNvuwCuYhBCZZPY1VBoBVSHPsVBqu7UCp7dnA3', // 5
+  '8V5Uu7xMQhaUcD6pzNReVzrSe89KMCXoGk7ErbkXik2b', // 6
+  'A4voX3UC3TGLsKyEsDGWAvrjT3mpnA67Fx9cccdoPKqm', // 7
+  'Cstnx15y98NCnjXddxEcgpJrW44TFYq9QSXYcdmfW4HR', // 8
+  'DqGAc8YvHUPnpA5cuausLhkCp1cUvEQFYjpWVHJTPiNM', // 9
+  'EpaKfP4sd2xhEQvnYS3EgCXj7rkg7jTCasTByFj8kuLg', // 10
+  'AkG81cTMBD2Kh1gmDF66mAeRosDQjvATJyDWN48BSh85', // 11
 ];
 
 export const regularSvmThreshold = 6;

--- a/typescript/infra/config/environments/mainnet3/governance/signers/warpFees.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/warpFees.ts
@@ -1,4 +1,4 @@
-import { awSigners, awThreshold } from './aw.js';
+import { awSigners } from './aw.js';
 
 export const warpFeesSigners = awSigners;
-export const warpFeesThreshold = awThreshold;
+export const warpFeesThreshold = 2;


### PR DESCRIPTION
## Summary

Rotates the AbacusWorks and WarpFees governance signer configs, syncs the SVM (Squads) signer configs, and tidies the AW safe map. Config-only — no code changes.

> **Stacked PR (1 of 2).** The code changes — asymmetric Safe owner-update tooling and the Safe SDK upgrade — live in #8895, stacked on this branch. **Merge this first.**

## Signer rotation
- **aw EVM** (`signers/aw.ts`): removed 3 signers, added 1; threshold `4 → 3`
- **warpFees EVM** (`signers/warpFees.ts`): threshold decoupled from aw → `2` (signers still re-exported from aw)
- **aw SVM / Squads** (`signers/aw.ts`): `awSvmSigners` (8 keys, incl. the JK key) + `awSvmThreshold = 3`
- **regular SVM / Squads** (`signers/regular.ts`): added the Turnkey deployer key (now 11 members) to match the on-chain multisig; threshold unchanged at `6`

## AW safe map tidy-up (`safe/aw.ts`, `proxy-admin/aw.ts`)
- Commented out **30** AW safes that own no warp routes and aren't referenced as an owner by any monorepo config getter; kept **14** active (the warp-route owners + plasma). Retained commented for historical reference.
- **Verified on-chain**: `ethereum/arbitrum/bsc/plasma` ProxyAdmin `owner()` all equal their AW safe — so **plasma is kept** (its ProxyAdmin is safe-owned on-chain) despite owning no warp routes.
- Guarded `proxy-admin/aw.ts` owner resolution to fall back to the chain's governance owner if a safe entry is removed (a missing entry never yields an `undefined` proxy-admin owner / a stale safe).
- Regrouped `safe/aw.ts`: active safes grouped at the top, inactive block below the dated note (pure reorder — verified no address/membership change).

## Notes
- `infra` is private → no changeset.
- **Core ownership is unaffected** — Regular governance owns core on every chain; the AW safe never wins the `owners.ts` resolution.
- Config only. Proposing/signing the on-chain owner-update txs is a separate operational step (tooling in #8895).

🤖 Generated with [Claude Code](https://claude.com/claude-code)