### PR TITLE
feat(cli): log delivery time for warp send and send message

### DIFF
--- a/.changeset/nervous-mirrors-promise.md
+++ b/.changeset/nervous-mirrors-promise.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/cli": minor
 ---
 
-Added transfer time for warp send transfers
+Delivery time logging was added to `hyperlane warp send` and `hyperlane send message`, displaying elapsed seconds between dispatch and delivery for EVM chains.

--- a/.changeset/nervous-mirrors-promise.md
+++ b/.changeset/nervous-mirrors-promise.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/cli": minor
+---
+
+Added transfer time for warp send transfers

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -1,8 +1,13 @@
 import { stringify as yamlStringify } from 'yaml';
 
+import { Mailbox__factory } from '@hyperlane-xyz/core';
 import { GasAction } from '@hyperlane-xyz/provider-sdk';
 import { HyperlaneRelayer } from '@hyperlane-xyz/relayer';
-import { type ChainName, HyperlaneCore } from '@hyperlane-xyz/sdk';
+import {
+  type ChainName,
+  HyperlaneCore,
+  type MultiProvider,
+} from '@hyperlane-xyz/sdk';
 import { addressToBytes32, isEVMLike, timeout } from '@hyperlane-xyz/utils';
 
 import { EXPLORER_URL } from '../consts.js';
@@ -159,6 +164,14 @@ async function executeDelivery({
       log('Attempting self-relay of message');
       await relayer.relayMessage(dispatchTx);
       logGreen('Message was self-relayed!');
+      await logMessageDeliveryTime(
+        origin,
+        destination,
+        dispatchTx.blockNumber,
+        message.id,
+        chainAddresses,
+        multiProvider,
+      );
     } else {
       if (skipWaitForDelivery) {
         return;
@@ -168,11 +181,56 @@ async function executeDelivery({
       // Max wait 10 minutes
       await core.waitForMessageProcessed(dispatchTx, 10000, 60);
       logGreen('Message was delivered!');
+      await logMessageDeliveryTime(
+        origin,
+        destination,
+        dispatchTx.blockNumber,
+        message.id,
+        chainAddresses,
+        multiProvider,
+      );
     }
   } catch (e) {
     errorRed(
       `Encountered error sending message from ${origin} to ${destination}`,
     );
     throw e;
+  }
+}
+
+async function logMessageDeliveryTime(
+  origin: ChainName,
+  destination: ChainName,
+  dispatchBlockNumber: number,
+  messageId: string,
+  chainAddresses: Record<string, Record<string, string>>,
+  multiProvider: MultiProvider,
+): Promise<void> {
+  if (
+    !isEVMLike(multiProvider.getProtocol(origin)) ||
+    !isEVMLike(multiProvider.getProtocol(destination))
+  ) {
+    return;
+  }
+  try {
+    const mailboxAddress = chainAddresses[destination]?.mailbox;
+    if (!mailboxAddress) return;
+
+    const mailbox = Mailbox__factory.connect(
+      mailboxAddress,
+      multiProvider.getProvider(destination),
+    );
+    const processedBlockNum = await mailbox.processedAt(messageId);
+    const [dispatchBlock, processedBlock] = await Promise.all([
+      multiProvider.getProvider(origin).getBlock(dispatchBlockNumber),
+      multiProvider.getProvider(destination).getBlock(processedBlockNum),
+    ]);
+    if (dispatchBlock && processedBlock) {
+      logGreen(
+        `Delivery time: ${processedBlock.timestamp - dispatchBlock.timestamp}s`,
+      );
+    }
+  } catch {
+    // Non-fatal: delivery time is informational only
   }
 }

--- a/typescript/cli/src/send/message.ts
+++ b/typescript/cli/src/send/message.ts
@@ -1,13 +1,8 @@
 import { stringify as yamlStringify } from 'yaml';
 
-import { Mailbox__factory } from '@hyperlane-xyz/core';
 import { GasAction } from '@hyperlane-xyz/provider-sdk';
 import { HyperlaneRelayer } from '@hyperlane-xyz/relayer';
-import {
-  type ChainName,
-  HyperlaneCore,
-  type MultiProvider,
-} from '@hyperlane-xyz/sdk';
+import { type ChainName, HyperlaneCore } from '@hyperlane-xyz/sdk';
 import { addressToBytes32, isEVMLike, timeout } from '@hyperlane-xyz/utils';
 
 import { EXPLORER_URL } from '../consts.js';
@@ -23,7 +18,7 @@ import {
   runSingleChainSelectionStep,
 } from '../utils/chains.js';
 import { indentYamlOrJson } from '../utils/files.js';
-import { stubMerkleTreeConfig } from '../utils/relay.js';
+import { logDeliveryTime, stubMerkleTreeConfig } from '../utils/relay.js';
 
 export async function sendTestMessage({
   context,
@@ -164,7 +159,7 @@ async function executeDelivery({
       log('Attempting self-relay of message');
       await relayer.relayMessage(dispatchTx);
       logGreen('Message was self-relayed!');
-      await logMessageDeliveryTime(
+      await logDeliveryTime(
         origin,
         destination,
         dispatchTx.blockNumber,
@@ -181,7 +176,7 @@ async function executeDelivery({
       // Max wait 10 minutes
       await core.waitForMessageProcessed(dispatchTx, 10000, 60);
       logGreen('Message was delivered!');
-      await logMessageDeliveryTime(
+      await logDeliveryTime(
         origin,
         destination,
         dispatchTx.blockNumber,
@@ -195,42 +190,5 @@ async function executeDelivery({
       `Encountered error sending message from ${origin} to ${destination}`,
     );
     throw e;
-  }
-}
-
-async function logMessageDeliveryTime(
-  origin: ChainName,
-  destination: ChainName,
-  dispatchBlockNumber: number,
-  messageId: string,
-  chainAddresses: Record<string, Record<string, string>>,
-  multiProvider: MultiProvider,
-): Promise<void> {
-  if (
-    !isEVMLike(multiProvider.getProtocol(origin)) ||
-    !isEVMLike(multiProvider.getProtocol(destination))
-  ) {
-    return;
-  }
-  try {
-    const mailboxAddress = chainAddresses[destination]?.mailbox;
-    if (!mailboxAddress) return;
-
-    const mailbox = Mailbox__factory.connect(
-      mailboxAddress,
-      multiProvider.getProvider(destination),
-    );
-    const processedBlockNum = await mailbox.processedAt(messageId);
-    const [dispatchBlock, processedBlock] = await Promise.all([
-      multiProvider.getProvider(origin).getBlock(dispatchBlockNumber),
-      multiProvider.getProvider(destination).getBlock(processedBlockNum),
-    ]);
-    if (dispatchBlock && processedBlock) {
-      logGreen(
-        `Delivery time: ${processedBlock.timestamp - dispatchBlock.timestamp}s`,
-      );
-    }
-  } catch {
-    // Non-fatal: delivery time is informational only
   }
 }

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -6,7 +6,6 @@ import { type Address, type Hex } from 'viem';
 
 import {
   CrossCollateralRouter__factory,
-  Mailbox__factory,
   TokenRouter__factory,
 } from '@hyperlane-xyz/core';
 import { GasAction } from '@hyperlane-xyz/provider-sdk';
@@ -23,7 +22,6 @@ import {
   HyperlaneCore,
   MultiProtocolCore,
   MultiProtocolProvider,
-  type MultiProvider,
   PredicateApiClient,
   type PredicateAttestation,
   PredicateAttestationSchema,
@@ -59,7 +57,7 @@ import { type WriteCommandContext } from '../context/types.js';
 import { runPreflightChecksForChains } from '../deploy/utils.js';
 import { log, logBlue, logGreen, logRed, warnYellow } from '../logger.js';
 import { indentYamlOrJson } from '../utils/files.js';
-import { runSelfRelay } from '../utils/relay.js';
+import { logDeliveryTime, runSelfRelay } from '../utils/relay.js';
 import { runTokenSelectionStep } from '../utils/tokens.js';
 
 export const WarpSendLogs = {
@@ -814,43 +812,6 @@ async function executeDelivery({
     }
   }
   logGreen(`Transfer sent to ${destination} chain!`);
-}
-
-async function logDeliveryTime(
-  origin: ChainName,
-  destination: ChainName,
-  dispatchBlockNumber: number,
-  messageId: string,
-  chainAddresses: ChainMap<Record<string, string>>,
-  multiProvider: MultiProvider,
-): Promise<void> {
-  if (
-    !isEVMLike(multiProvider.getProtocol(origin)) ||
-    !isEVMLike(multiProvider.getProtocol(destination))
-  ) {
-    return;
-  }
-  try {
-    const mailboxAddress = chainAddresses[destination]?.mailbox;
-    if (!mailboxAddress) return;
-
-    const mailbox = Mailbox__factory.connect(
-      mailboxAddress,
-      multiProvider.getProvider(destination),
-    );
-    const processedBlockNum = await mailbox.processedAt(messageId);
-    const [dispatchBlock, processedBlock] = await Promise.all([
-      multiProvider.getProvider(origin).getBlock(dispatchBlockNumber),
-      multiProvider.getProvider(destination).getBlock(processedBlockNum),
-    ]);
-    if (dispatchBlock && processedBlock) {
-      logGreen(
-        `Delivery time: ${processedBlock.timestamp - dispatchBlock.timestamp}s`,
-      );
-    }
-  } catch {
-    // Non-fatal: delivery time is informational only
-  }
 }
 
 async function waitForExplorerDelivery(

--- a/typescript/cli/src/send/transfer.ts
+++ b/typescript/cli/src/send/transfer.ts
@@ -6,6 +6,7 @@ import { type Address, type Hex } from 'viem';
 
 import {
   CrossCollateralRouter__factory,
+  Mailbox__factory,
   TokenRouter__factory,
 } from '@hyperlane-xyz/core';
 import { GasAction } from '@hyperlane-xyz/provider-sdk';
@@ -22,6 +23,7 @@ import {
   HyperlaneCore,
   MultiProtocolCore,
   MultiProtocolProvider,
+  type MultiProvider,
   PredicateApiClient,
   type PredicateAttestation,
   PredicateAttestationSchema,
@@ -725,12 +727,21 @@ async function executeDelivery({
     if (!evmTransferReceipt) {
       throw new Error('Missing EVM transfer receipt required for self-relay');
     }
-    return runSelfRelay({
+    await runSelfRelay({
       txReceipt: evmTransferReceipt,
       multiProvider: multiProvider,
       registry: registry,
       successMessage: WarpSendLogs.SUCCESS,
     });
+    await logDeliveryTime(
+      origin,
+      destination,
+      evmTransferReceipt.blockNumber,
+      messageId,
+      chainAddresses,
+      multiProvider,
+    );
+    return;
   }
 
   if (skipWaitForDelivery) return;
@@ -746,6 +757,16 @@ async function executeDelivery({
       delayMs,
       maxAttempts,
     );
+    if (evmTransferReceipt) {
+      await logDeliveryTime(
+        origin,
+        destination,
+        evmTransferReceipt.blockNumber,
+        messageId,
+        chainAddresses,
+        multiProvider,
+      );
+    }
   } else {
     try {
       await waitForExplorerDelivery(messageId, timeoutMs);
@@ -793,6 +814,43 @@ async function executeDelivery({
     }
   }
   logGreen(`Transfer sent to ${destination} chain!`);
+}
+
+async function logDeliveryTime(
+  origin: ChainName,
+  destination: ChainName,
+  dispatchBlockNumber: number,
+  messageId: string,
+  chainAddresses: ChainMap<Record<string, string>>,
+  multiProvider: MultiProvider,
+): Promise<void> {
+  if (
+    !isEVMLike(multiProvider.getProtocol(origin)) ||
+    !isEVMLike(multiProvider.getProtocol(destination))
+  ) {
+    return;
+  }
+  try {
+    const mailboxAddress = chainAddresses[destination]?.mailbox;
+    if (!mailboxAddress) return;
+
+    const mailbox = Mailbox__factory.connect(
+      mailboxAddress,
+      multiProvider.getProvider(destination),
+    );
+    const processedBlockNum = await mailbox.processedAt(messageId);
+    const [dispatchBlock, processedBlock] = await Promise.all([
+      multiProvider.getProvider(origin).getBlock(dispatchBlockNumber),
+      multiProvider.getProvider(destination).getBlock(processedBlockNum),
+    ]);
+    if (dispatchBlock && processedBlock) {
+      logGreen(
+        `Delivery time: ${processedBlock.timestamp - dispatchBlock.timestamp}s`,
+      );
+    }
+  } catch {
+    // Non-fatal: delivery time is informational only
+  }
 }
 
 async function waitForExplorerDelivery(

--- a/typescript/cli/src/utils/relay.ts
+++ b/typescript/cli/src/utils/relay.ts
@@ -1,8 +1,11 @@
 import { type TransactionReceipt } from '@ethersproject/providers';
 
+import { Mailbox__factory } from '@hyperlane-xyz/core';
 import { type IRegistry } from '@hyperlane-xyz/registry';
 import { HyperlaneRelayer } from '@hyperlane-xyz/relayer';
 import {
+  type ChainMap,
+  type ChainName,
   type DispatchedMessage,
   HookType,
   HyperlaneCore,
@@ -10,9 +13,9 @@ import {
   type TxSubmitterBuilder,
   TxSubmitterType,
 } from '@hyperlane-xyz/sdk';
-import { type ProtocolType } from '@hyperlane-xyz/utils';
+import { type ProtocolType, isEVMLike } from '@hyperlane-xyz/utils';
 
-import { log, logGreen } from '../logger.js';
+import { log, logDebug, logGreen } from '../logger.js';
 import { type ExtendedSubmissionStrategy } from '../submitters/types.js';
 
 /**
@@ -100,6 +103,45 @@ export type RunSelfRelayOptions = {
   txReceipt: TransactionReceipt;
   successMessage?: string;
 };
+
+export async function logDeliveryTime(
+  origin: ChainName,
+  destination: ChainName,
+  dispatchBlockNumber: number,
+  messageId: string,
+  chainAddresses: ChainMap<Record<string, string>>,
+  multiProvider: MultiProvider,
+): Promise<void> {
+  if (
+    !isEVMLike(multiProvider.getProtocol(origin)) ||
+    !isEVMLike(multiProvider.getProtocol(destination))
+  ) {
+    return;
+  }
+  try {
+    const mailboxAddress = chainAddresses[destination]?.mailbox;
+    if (!mailboxAddress) return;
+
+    const mailbox = Mailbox__factory.connect(
+      mailboxAddress,
+      multiProvider.getProvider(destination),
+    );
+    const processedBlockNum = await mailbox.processedAt(messageId);
+    const [dispatchBlock, processedBlock] = await Promise.all([
+      multiProvider.getProvider(origin).getBlock(dispatchBlockNumber),
+      multiProvider.getProvider(destination).getBlock(processedBlockNum),
+    ]);
+    if (dispatchBlock && processedBlock) {
+      logGreen(
+        `Delivery time: ${processedBlock.timestamp - dispatchBlock.timestamp}s`,
+      );
+    }
+  } catch (error: unknown) {
+    logDebug(
+      `Failed to log delivery time for ${origin}→${destination} message ${messageId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
 
 export async function runSelfRelay({
   registry,


### PR DESCRIPTION
## Summary

- Added `logMessageDeliveryTime` to `hyperlane send message` — logs elapsed seconds between dispatch block and process block after delivery (both self-relay and relayer paths)
- Added `logDeliveryTime` to `hyperlane warp send` — same block-timestamp approach, fires after self-relay and after relayer delivery (EVM path only)
- Both functions are non-fatal: wrapped in try/catch, skip silently on non-EVM chains

## Test plan

- [x] Run `hyperlane send message` between two EVM chains and confirm `Delivery time: Xs` appears after `Message was delivered!`
- [x] Run `hyperlane warp send` and confirm `Delivery time: Xs` appears after transfer success
- [x] Run with `--self-relay` flag and confirm timing is logged for both commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)