### PR TITLE
perf(rebalancer): improve cycle hot paths

### DIFF
--- a/.changeset/rebalancer-cycle-performance.md
+++ b/.changeset/rebalancer-cycle-performance.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/rebalancer": patch
+---
+
+Improved rebalancer cycle performance by parallelizing monitor reads, batching tracked-action lookups, bounding delivery-status sync concurrency, and making token metrics processing best-effort.

--- a/typescript/rebalancer-sim/src/runners/MockActionTracker.ts
+++ b/typescript/rebalancer-sim/src/runners/MockActionTracker.ts
@@ -70,6 +70,39 @@ export class MockActionTracker implements IActionTracker {
     );
   }
 
+  async getActionsForIntents(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>> {
+    const actionsByIntent = new Map<string, RebalanceAction[]>(
+      intentIds.map((intentId) => [intentId, []]),
+    );
+
+    for (const action of this.actions.values()) {
+      actionsByIntent.get(action.intentId)?.push(action);
+    }
+
+    return actionsByIntent;
+  }
+
+  async getActionsByMessageIds(
+    messageIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction>> {
+    const requestedMessageIds = new Set(messageIds);
+    const actionsByMessageId = new Map<string, RebalanceAction>();
+
+    for (const action of this.actions.values()) {
+      if (
+        action.messageId &&
+        requestedMessageIds.has(action.messageId) &&
+        !actionsByMessageId.has(action.messageId)
+      ) {
+        actionsByMessageId.set(action.messageId, action);
+      }
+    }
+
+    return actionsByMessageId;
+  }
+
   async getInflightInventoryMovements(_origin: Domain): Promise<bigint> {
     // No inventory movements in simulation
     return 0n;

--- a/typescript/rebalancer/docs/rebalancer-architecture-review.md
+++ b/typescript/rebalancer/docs/rebalancer-architecture-review.md
@@ -1,0 +1,444 @@
+# Rebalancer Architecture Review
+
+Date: 2026-06-12
+
+Scope: `typescript/rebalancer` package. Findings are from local code inspection plus three read-only subagent slices covering core runtime, strategy/config, and bridges/tracking/tests.
+
+Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice was completed in this PR; larger planner/executor decomposition remains future work.
+
+## Bottom Line
+
+The package is functional and has useful high-level separation (`core`, `strategy`, `tracking`, `bridges`, `monitor`), but it is not the most optimal setup for performance, modularity, or testability.
+
+The main issue is that important runtime state and side effects are hidden behind thin interfaces. `rebalance(routes)` can create intents, mutate inventory state, continue old work, ignore new routes, make RPC calls, send transactions, poll bridge APIs, record metrics, and swallow errors. This makes correctness hard to reason about and forces tests to mock large objects instead of asserting pure planning and state transitions.
+
+Recommended direction: rearchitect around explicit cycle snapshots, pure-ish planning, typed execution plans, query-oriented tracking state, and small executor modules.
+
+## Implemented In This PR
+
+These slices directly target cycle latency and failure visibility without changing external config shape.
+
+### Slice 1: Monitor Snapshot Parallelism
+
+- Confirmed block tags are fetched concurrently for the unique warp-route chains in each monitor cycle.
+- Bridged supply reads are fetched concurrently per token while preserving `tokensInfo` order and event shape.
+- Benefit: monitor cycle duration is no longer the sum of every chain/token RPC read. The slowest read now dominates instead of all reads serially accumulating.
+
+### Slice 2: Tracking Hot-Path Batching
+
+- `InMemoryStore` now maintains lazy indexes and exposes indexed field lookups.
+- `ActionTracker` can fetch actions by intent IDs and message IDs in batches.
+- `InflightContextAdapter` fetches inventory intent actions in one grouped call instead of one action scan per intent.
+- Delivery checks use bounded concurrency and destination block-tag caching.
+- Benefit: tracker sync and inflight-context projection scale with indexed lookups and bounded IO rather than repeated full-store scans and serial RPCs.
+
+### Slice 3: Orchestrator Non-Gating Side Effects
+
+- Token metrics processing is best-effort and no longer blocks rebalancing cycles.
+- Action-tracker sync runs each source independently and logs freshness by source instead of treating sync as one all-or-nothing operation.
+- Executor throws now return failed route results for attempted routes rather than silently producing an empty result set.
+- Benefit: slow metrics work and partial tracker-source failures do not stall the whole cycle, and failed execution paths are visible in cycle accounting.
+
+## Follow-Up Stacked Draft PR TODOs
+
+Use this as the TODO list for the next draft PR on top of this one. Keep the north star performance, but use the larger module split to make future performance work safer.
+
+- [ ] Add explicit `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`.
+- [ ] Remove inventory state injection through `InventoryRebalancer.setInventoryBalances()` by passing cycle context into executors.
+- [ ] Normalize config into a resolved route execution matrix so strategies do not perform bridge/execution config lookups.
+- [ ] Move pending-transfer, pending-rebalance, and proposed-route projection into a shared `BalanceProjector`.
+- [ ] Introduce `StrategyPlanner` and centralize route materialization/filtering after strategy evaluation.
+- [ ] Split movable collateral execution into route validation, transaction preparation, chain transaction execution, and result recording modules.
+- [ ] Split inventory execution into intent resolution, inventory planning, bridge capacity estimation, movement execution, and `transferRemote` execution modules.
+- [ ] Wrap LiFi SDK/global state behind an injected client/runner and narrow the execution lock to the actual signer/source-chain constraint.
+- [ ] Replace route-specific e2e deployment managers with a declarative fixture builder and shared deploy/enroll/seed helpers.
+- [ ] Add deterministic unit fakes for external bridges separate from local integration bridge adapters.
+
+## Current Shape
+
+- `RebalancerService` owns lifecycle/setup and delegates daemon events to `RebalancerOrchestrator`.
+- `Monitor` polls confirmed block tags, bridged supply, and inventory balances into `MonitorEvent`.
+- `RebalancerOrchestrator` syncs tracking state, builds raw balances, asks a strategy for routes, and dispatches routes to rebalancers.
+- `BaseStrategy` handles balance reservation, pending/proposed rebalance simulation, surplus/deficit matching, route materialization, filtering, and metrics.
+- `Rebalancer` executes movable-collateral routes end to end.
+- `InventoryRebalancer` executes inventory routes end to end, including active-intent continuation, bridge planning, external bridge execution, and `transferRemote`.
+- `ActionTracker` owns explorer recovery, delivery checks, TTL/staleness, external bridge status, stores, and projection into inflight context.
+
+## Highest Priority Problems
+
+### 1. Hidden Runtime State And Lossy Results
+
+Evidence:
+
+- `RebalancerOrchestrator.executeRoutes()` casts `IRebalancer` to `InventoryRebalancer` and mutates inventory balances before calling `rebalance()`: `src/core/RebalancerOrchestrator.ts`.
+- `InventoryRebalancer.rebalance()` ignores new routes when an active inventory intent exists, only takes the first route when no active intent exists, and keeps mutable `inventoryBalances` / `consumedInventory`: `src/core/InventoryRebalancer.ts`.
+- `RebalancerOrchestrator.executeRoutes()` catches thrown executor errors and returns `[]`, so `executeWithTracking()` can report `0` failures for a failed executor path: `src/core/RebalancerOrchestrator.ts`.
+
+Impact:
+
+- Cycle result counts are not trustworthy for system-level failures.
+- Interface says "rebalance these routes", but inventory execution may continue unrelated prior work.
+- Tests must know concrete implementation details.
+
+Recommendation:
+
+- Add `RebalanceCycleContext` and pass it into executors:
+
+```ts
+type RebalanceCycleContext = {
+  cycleId: string;
+  balances: RawBalances;
+  inventoryBalances?: ChainMap<bigint>;
+  confirmedBlockTags?: ConfirmedBlockTags;
+  trackerSnapshot: TrackerSnapshot;
+};
+
+interface RouteExecutor<R extends StrategyRoute> {
+  executionType: R['executionType'];
+  execute(
+    routes: R[],
+    context: RebalanceCycleContext,
+  ): Promise<ExecutionSummary<R>>;
+}
+```
+
+- Replace `ExecutionResult[]` as the only return shape with `ExecutionSummary`, including `status: 'success' | 'partial' | 'failed'`, per-route results, and system errors.
+- Remove `InventoryRebalancer.setInventoryBalances()` and concrete casts from the orchestrator.
+
+### 2. Polling And Tracking Are Serial / Full-Scan Heavy
+
+Evidence:
+
+- `Monitor.computeConfirmedBlockTags()` loops chains serially; token bridged supply reads also run serially.
+- `ActionTracker.syncTransfers()` checks in-progress transfers one by one.
+- `ActionTracker.syncRebalanceActions()` checks delivery one action at a time.
+- `ActionTracker.syncInventoryMovementActions()` polls external bridge status serially.
+- Store abstractions only expose broad scans like `getAll()`, `getByStatus()`, `getByDestination()`, forcing repeated filters and per-intent action lookups.
+
+Impact:
+
+- Cycle duration scales poorly with chain count, in-flight transfers, and active actions.
+- Slow or flaky RPC/API calls extend or poison the whole cycle.
+- Strategy runs on implicitly stale state after sync failure.
+
+Recommendation:
+
+- Create `StateSyncer` that returns an explicit `TrackerSnapshot` using `Promise.allSettled` and bounded concurrency.
+- Group delivery checks by destination and compute confirmed block tag once per destination.
+- Add query-oriented store APIs:
+
+```ts
+getActionsByIntentIds(intentIds: string[]): Promise<Map<string, RebalanceAction[]>>;
+getCompletedAmountsByIntent(intentIds: string[]): Promise<Map<string, bigint>>;
+getActiveIntentsWithActions(): Promise<Array<{ intent: RebalanceIntent; actions: RebalanceAction[] }>>;
+getByMessageIds(messageIds: string[]): Promise<Map<string, RebalanceAction>>;
+```
+
+- Track freshness in the snapshot:
+
+```ts
+type TrackerSnapshot = {
+  pendingTransfers: RouteWithContext[];
+  pendingRebalances: RouteWithContext[];
+  freshness: 'fresh' | 'partial' | 'stale';
+  syncFailures: Array<{ source: string; error: string }>;
+};
+```
+
+### 3. Strategy Planning Is Coupled To Execution Config
+
+Evidence:
+
+- `BaseStrategy.getRebalancingRoutes()` performs reservation, simulation, surplus/deficit matching, route materialization, filtering, and metrics.
+- `WeightedStrategy`, `MinAmountStrategy`, and `CollateralDeficitStrategy` each repeat pending/proposed simulation before categorization.
+- `CompositeStrategy` passes accumulated routes as `proposedRebalances`, requiring every strategy to understand composition internals.
+- Config allows composite strategies with per-strategy chain subsets, but runtime builds raw balances from the union while `BaseStrategy.validateRawBalances()` rejects extra chains.
+- Bridge execution config is normalized late with non-null assertions and casts in `StrategyFactory` / `bridgeUtils`.
+
+Impact:
+
+- Adding a strategy requires touching schema, factory, simulation behavior, and route materialization.
+- Strategy tests cover too much orchestration behavior.
+- Config validity is split between Zod and constructors.
+
+Recommendation:
+
+- Normalize config once into `StrategyPlanConfig`:
+
+```ts
+type StrategyPlanConfig = {
+  chainSet: ChainName[];
+  strategies: StrategyDescriptorInstance[];
+  routeExecution: Record<ChainName, Record<ChainName, RouteExecutionConfig>>;
+};
+
+type RouteExecutionConfig =
+  | {
+      executionType: 'movableCollateral';
+      bridge: Address;
+      minAcceptedAmount: bigint;
+    }
+  | {
+      executionType: 'inventory';
+      externalBridge: ExternalBridgeType;
+      minAcceptedAmount: bigint;
+    };
+```
+
+- Move reservation and pending/proposed projection into `BalanceProjector`.
+- Make strategies return desired deltas/targets, not executable routes:
+
+```ts
+interface StrategyEvaluator {
+  evaluate(context: StrategyContext): DeltaPlan;
+}
+```
+
+- Centralize route materialization/filtering after strategy evaluation.
+- Either enforce identical chain sets for composite strategies at config load, or explicitly support subsets by passing each strategy only its configured balances.
+
+### 4. Movable And Inventory Executors Are Monoliths
+
+Evidence:
+
+- `Rebalancer.rebalance()` creates intents, validates routes, gets quotes, populates txs, estimates gas, sends txs, parses receipts, records actions, and emits metrics.
+- `validateRoute()` repeats signer/permission/destination/bridge checks per route.
+- `InventoryRebalancer.executeRoute()` handles cost probes, fee-aware max transfer, source selection, bridge capacity, bridge execution, partial fulfillment, and `transferRemote`.
+
+Impact:
+
+- Hard to unit test without broad mocks.
+- Repeated RPC validation wastes time within a cycle.
+- Inventory behavior is a state machine encoded as imperative branches.
+
+Recommendation:
+
+- Split movable-collateral execution:
+  - `MovableRouteValidator`
+  - `MovableTxPreparer`
+  - `ChainTxExecutor`
+  - `RebalanceResultRecorder`
+- Add per-cycle validation cache keyed by `origin:destination:bridge:token`.
+- Split inventory execution into a state machine:
+  - `InventoryIntentResolver`
+  - `InventoryPlanner`
+  - `BridgeCapacityEstimator`
+  - `InventoryMovementExecutor`
+  - `TransferRemoteExecutor`
+- Model inventory steps explicitly:
+
+```ts
+type InventoryStep =
+  | { kind: 'wait_for_deposit'; intentId: string }
+  | { kind: 'transfer_remote'; route: InventoryRoute; amount: bigint }
+  | { kind: 'bridge_inventory'; movements: InventoryMovementPlan[] }
+  | { kind: 'complete_with_acceptable_loss'; intentId: string };
+```
+
+### 5. Metrics And External IO Can Gate Core Work
+
+Evidence:
+
+- `RebalancerOrchestrator.executeCycle()` awaits `Promise.all(metrics.processToken(...))` before tracker sync and strategy evaluation.
+- `syncActionTracker()` wraps several sync operations in one catch and then continues with stale data without surfacing freshness to the planner.
+- `ExplorerClient` has repeated fetch/error code, fixed `limit = 100`, no pagination, no request policy, and `any` response normalization.
+
+Impact:
+
+- Price/metrics failures can block rebalancing.
+- Explorer/API/RPC failure policy is not explicit.
+- Missing pagination risks invisible in-flight work above the limit.
+
+Recommendation:
+
+- Make metrics best-effort via `allSettled`, timeout, or async sink.
+- Build a shared GraphQL requester with timeout, retry policy, typed response schemas, and pagination.
+- Pass tracker freshness into strategy/execution. Decide policy explicitly:
+  - `fresh`: execute normally.
+  - `partial`: allow safe no-op or limited execution.
+  - `stale`: skip execution unless manual override.
+
+### 6. Bootstrap And Process Lifecycle Are Hard To Test
+
+Evidence:
+
+- `src/service.ts` mixes env parsing, key derivation, registry/provider construction, config merge, service start, and process exit.
+- `RebalancerService.gracefulShutdown()` removes all process listeners and calls `process.exit(0)`.
+- Tests monkeypatch static factory construction and fake orchestrator behavior.
+
+Impact:
+
+- Runtime assembly is difficult to test without process/global side effects.
+- Signal handling can remove listeners not owned by this service.
+
+Recommendation:
+
+- Extract pure setup functions:
+  - `loadRuntimeConfig(env)`
+  - `deriveInventorySigners(env, config)`
+  - `buildProviders(runtimeConfig)`
+  - `buildRebalancerService(deps)`
+- Keep `process.exit` only in the CLI entrypoint.
+- Track and remove only signal handlers owned by this service.
+- Inject factory, clock, and signal manager interfaces.
+
+### 7. LiFi Adapter And Test Harness Limit Parallelism
+
+Evidence:
+
+- `LiFiBridge` uses process-global LiFi SDK config/provider mutation and serializes all executions behind `_executeLock`.
+- LiFi tests mutate `globalThis.fetch`.
+- E2E deployment managers duplicate topology/deploy/enroll/seed loops.
+- `MockExternalBridge` is an integration bridge, not a lightweight fake: it estimates gas, sends real route txs, and instantiates a relayer in status checks.
+
+Impact:
+
+- Hard to test bridge behavior deterministically.
+- Parallel bridge execution is globally limited even when independent.
+- E2E suite setup is slower and drifts across route variants.
+
+Recommendation:
+
+- Introduce `LiFiClient` / `LiFiSdkRunner` with injected HTTP client and provider context.
+- Replace global execution lock with per-source-chain or per-signer guard where needed.
+- Split test bridge types:
+  - `FakeExternalBridge` for deterministic unit tests.
+  - `LocalWarpBridgeAdapter` for integration/e2e.
+- Replace route-specific deployment managers with declarative fixture builder:
+
+```ts
+type RebalancerFixtureSpec = {
+  topology: ChainName[];
+  routeKind: 'erc20' | 'native' | 'mixed' | 'inventory';
+  strategies: StrategyConfig[];
+  seedBalances: Array<{ chain: ChainName; account: string; amount: bigint }>;
+};
+```
+
+## Target Architecture
+
+Proposed module boundaries:
+
+```text
+src/runtime/
+  service.ts              # lifecycle only
+  CycleRunner.ts          # singleflight, timeout, cycle ids, error boundary
+  StateSyncer.ts          # monitor event + tracker sync -> CycleSnapshot
+
+src/planning/
+  StrategyPlanner.ts      # strategy order, projection, route materialization
+  BalanceProjector.ts     # pending transfers/rebalances/proposed routes
+  RouteMaterializer.ts    # deltas -> executable StrategyRoute[]
+  RouteExecutionMatrix.ts # resolved origin/destination execution config
+
+src/execution/
+  ExecutionEngine.ts
+  movable/
+    RouteValidator.ts
+    TxPreparer.ts
+    ChainTxExecutor.ts
+  inventory/
+    InventoryPlanner.ts
+    InventoryIntentResolver.ts
+    BridgeCapacityEstimator.ts
+    InventoryMovementExecutor.ts
+    TransferRemoteExecutor.ts
+
+src/tracking/
+  ActionTracker.ts        # facade/coordinator
+  ExplorerRecovery.ts
+  DeliveryStatusSyncer.ts
+  InventoryMovementStatusSyncer.ts
+  IntentProjector.ts
+  store/
+    IndexedInMemoryStore.ts
+
+src/config/
+  schema.ts
+  normalize.ts
+  strategyRegistry.ts
+  bridgeRegistry.ts
+```
+
+Cycle flow:
+
+```text
+Monitor event
+  -> CycleRunner
+  -> StateSyncer builds CycleSnapshot
+  -> StrategyPlanner builds ExecutionPlan
+  -> ExecutionEngine dispatches by executionType
+  -> ResultRecorder updates tracker/metrics
+  -> CycleResult includes status, failures, freshness, timings
+```
+
+## Implementation Plan
+
+### Phase 0: Guardrails And Characterization
+
+- Add tests for current lossy behavior before refactor:
+  - executor throws -> cycle result reports failure
+  - inventory active intent ignores new routes intentionally
+  - composite chain subset config either fails early or works intentionally
+- Add cycle timing logs/metrics around monitor polling, tracker sync, planning, execution.
+- No behavior change except test coverage and observability.
+
+### Phase 1: Explicit Cycle Context And Results
+
+- Introduce `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`.
+- Change `IRebalancer.rebalance(routes)` to `execute(routes, context)` or add a parallel interface and migrate callers.
+- Remove `InventoryRebalancer.setInventoryBalances()`.
+- Make thrown executor errors count as failed cycle/system errors.
+
+### Phase 2: Config Normalization And Strategy Planner
+
+- Push static numeric checks into Zod.
+- Add second validation pass for token/registry-dependent checks.
+- Normalize route execution config into a per-origin/per-destination matrix.
+- Decide and enforce composite chain-set policy.
+- Move balance projection and route materialization out of strategy subclasses.
+
+### Phase 3: Tracking Performance Refactor
+
+- Add indexed store methods by intent, status, destination, and message id.
+- Split `ActionTracker` into syncers/projectors with pure transition tests.
+- Use bounded concurrency and grouped destination block tags for delivery checks.
+- Return explicit `TrackerSnapshot` freshness/failures.
+
+### Phase 4: Executor Split
+
+- Split movable executor pipeline and add per-cycle route validation cache.
+- Convert inventory execution into planner + step executors.
+- Keep public behavior stable while making each step unit-testable.
+
+### Phase 5: Bridge And Harness Cleanup
+
+- Wrap LiFi SDK/global state behind injected client/runner.
+- Replace global execution lock with narrower guard.
+- Add deterministic `FakeExternalBridge`.
+- Consolidate e2e harness into declarative fixture builder and shared deploy/enroll/seed helpers.
+
+## Suggested Tests After Refactor
+
+- Unit:
+  - `BalanceProjector` pending transfer/rebalance cases.
+  - `RouteMaterializer` min amount and execution config selection.
+  - `TrackerSnapshot` projection from intents/actions/transfers.
+  - `InventoryPlanner` branches: wait, direct transfer, partial transfer, bridge, acceptable loss.
+  - `MovableRouteValidator` cache hits/misses.
+- Integration:
+  - `RebalancerService + CycleRunner + Orchestrator` with real planner and fake executors.
+  - `ActionTracker` syncers with fake explorer/core/bridge clients.
+  - LiFi adapter with injected fake SDK runner.
+- E2E:
+  - One movable-collateral route.
+  - One inventory route with active partial intent continuation.
+  - One composite strategy route proving chain-set policy and proposed-route projection.
+
+## Pickup Notes
+
+- Preserve current external config shape initially. Add normalized internal types behind `RebalancerConfig.load()`.
+- Avoid compatibility shims inside strategy code; compatibility belongs at config normalization boundaries.
+- Do not make metrics or Explorer availability a hard gate unless a freshness policy explicitly says execution is unsafe.
+- Keep route execution idempotency tied to tracker state, not executor instance fields.
+- Changes under this published package likely need a changeset once implementation changes behavior or public types.

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -46,6 +46,8 @@ function createMockActionTracker(): IActionTracker {
     getPartiallyFulfilledInventoryIntents: Sinon.stub().resolves([]),
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
+    getActionsForIntents: Sinon.stub().resolves(new Map()),
+    getActionsByMessageIds: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
 }

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -32,17 +32,12 @@ function createMockLogger(): Logger & {
   warn: Sinon.SinonStub;
   error: Sinon.SinonStub;
 } {
-  return {
-    info: Sinon.stub(),
-    warn: Sinon.stub(),
-    error: Sinon.stub(),
-    debug: Sinon.stub(),
-    child: Sinon.stub().returnsThis(),
-  } as unknown as Logger & {
-    info: Sinon.SinonStub;
-    warn: Sinon.SinonStub;
-    error: Sinon.SinonStub;
-  };
+  const logger = pino({ level: 'silent' });
+  return Object.assign(logger, {
+    info: Sinon.stub(logger, 'info'),
+    warn: Sinon.stub(logger, 'warn'),
+    error: Sinon.stub(logger, 'error'),
+  });
 }
 
 function createMockRebalancerConfig(): RebalancerConfig {
@@ -1011,6 +1006,36 @@ describe('RebalancerOrchestrator', () => {
 
       expect(result.proposedRoutes).to.have.lengthOf(0);
       expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
+    });
+
+    it('should skip token metrics already in flight from a prior cycle', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([]);
+
+      const actionTracker = createMockActionTracker();
+      const inflightAdapter = createMockInflightContextAdapter();
+      const metrics = createMockMetrics();
+      (metrics.processToken as Sinon.SinonStub).returns(
+        new Promise(() => undefined),
+      );
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        rebalancers: [],
+        metrics,
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+      const event = createMonitorEvent();
+
+      await orchestrator.executeCycle(event);
+      await orchestrator.executeCycle(event);
+
+      expect((metrics.processToken as Sinon.SinonStub).calledTwice).to.be.true;
     });
 
     it('should warn when detached token metrics processing fails', async () => {

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -118,7 +118,6 @@ function createMockActionTracker(): IActionTracker {
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
     getActionsForIntents: Sinon.stub().resolves(new Map()),
-    getActionByMessageId: Sinon.stub().resolves(undefined),
     getActionsByMessageIds: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
@@ -800,7 +799,10 @@ describe('RebalancerOrchestrator', () => {
       ).to.be.true;
       expect(
         logger.warn.calledWithMatch(
-          Sinon.match.has('source', 'transfers'),
+          Sinon.match({
+            source: 'transfers',
+            error: 'Transfer sync failed',
+          }),
           'ActionTracker sync source failed, using stale data',
         ),
       ).to.be.true;
@@ -1009,6 +1011,45 @@ describe('RebalancerOrchestrator', () => {
 
       expect(result.proposedRoutes).to.have.lengthOf(0);
       expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
+    });
+
+    it('should warn when detached token metrics processing fails', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([]);
+
+      const actionTracker = createMockActionTracker();
+      const inflightAdapter = createMockInflightContextAdapter();
+      const metrics = createMockMetrics();
+      (metrics.processToken as Sinon.SinonStub).rejects(
+        new Error('metrics failed'),
+      );
+      const logger = createMockLogger();
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger,
+        rebalancers: [],
+        metrics,
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+      const event = createMonitorEvent();
+
+      await orchestrator.executeCycle(event);
+      await Promise.resolve();
+
+      expect(
+        logger.warn.calledWithMatch(
+          Sinon.match({
+            count: 2,
+            errors: ['metrics failed', 'metrics failed'],
+          }),
+          'Metrics token processing failed',
+        ),
+      ).to.be.true;
     });
   });
 });

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { pino } from 'pino';
+import { type Logger, pino } from 'pino';
 import Sinon from 'sinon';
 
 import type { RebalancerConfig } from '../config/RebalancerConfig.js';
@@ -26,6 +26,24 @@ import {
 chai.use(chaiAsPromised);
 
 const testLogger = pino({ level: 'silent' });
+
+function createMockLogger(): Logger & {
+  info: Sinon.SinonStub;
+  warn: Sinon.SinonStub;
+  error: Sinon.SinonStub;
+} {
+  return {
+    info: Sinon.stub(),
+    warn: Sinon.stub(),
+    error: Sinon.stub(),
+    debug: Sinon.stub(),
+    child: Sinon.stub().returnsThis(),
+  } as unknown as Logger & {
+    info: Sinon.SinonStub;
+    warn: Sinon.SinonStub;
+    error: Sinon.SinonStub;
+  };
+}
 
 function createMockRebalancerConfig(): RebalancerConfig {
   return {
@@ -99,6 +117,9 @@ function createMockActionTracker(): IActionTracker {
     getPartiallyFulfilledInventoryIntents: Sinon.stub().resolves([]),
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
+    getActionsForIntents: Sinon.stub().resolves(new Map()),
+    getActionByMessageId: Sinon.stub().resolves(undefined),
+    getActionsByMessageIds: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
 }
@@ -352,6 +373,46 @@ describe('RebalancerOrchestrator', () => {
       expect(result.proposedRoutes).to.have.lengthOf(1);
       expect(result.executedCount).to.equal(0);
       expect(result.failedCount).to.equal(1);
+    });
+
+    it('should count thrown movable collateral executor errors as route failures', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([
+        {
+          origin: 'ethereum',
+          destination: 'arbitrum',
+          amount: 1000n,
+          bridge: TEST_ADDRESSES.bridge,
+          executionType: 'movableCollateral',
+        },
+      ]);
+
+      const rebalancer = createMockRebalancer();
+      rebalancer.rebalance.rejects(new Error('Executor failed'));
+
+      const actionTracker = createMockActionTracker();
+      const inflightAdapter = createMockInflightContextAdapter();
+      const metrics = createMockMetrics();
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        rebalancers: [rebalancer],
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        metrics,
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+      const event = createMonitorEvent();
+
+      const result = await orchestrator.executeCycle(event);
+
+      expect(result.executedCount).to.equal(0);
+      expect(result.failedCount).to.equal(1);
+      expect((metrics.recordRebalancerFailure as Sinon.SinonStub).calledOnce).to
+        .be.true;
     });
   });
 
@@ -667,6 +728,8 @@ describe('RebalancerOrchestrator', () => {
 
       // Verifies executeCycle completes without error when rebalancers is empty
       await orchestrator.executeCycle(event);
+
+      expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
     });
   });
 
@@ -698,6 +761,57 @@ describe('RebalancerOrchestrator', () => {
 
       expect(result.proposedRoutes).to.have.lengthOf(0);
       expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
+    });
+
+    it('should sync remaining tracker sources and log freshness when one source fails', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([]);
+
+      const actionTracker = createMockActionTracker();
+      (actionTracker.syncTransfers as Sinon.SinonStub).rejects(
+        new Error('Transfer sync failed'),
+      );
+      const inflightAdapter = createMockInflightContextAdapter();
+      const bridge = createMockBridge();
+      const logger = createMockLogger();
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger,
+        rebalancers: [],
+        externalBridgeRegistry: { lifi: bridge },
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+      const event = createMonitorEvent();
+
+      await orchestrator.executeCycle(event);
+
+      expect((actionTracker.syncRebalanceIntents as Sinon.SinonStub).calledOnce)
+        .to.be.true;
+      expect((actionTracker.syncRebalanceActions as Sinon.SinonStub).calledOnce)
+        .to.be.true;
+      expect(
+        (actionTracker.syncInventoryMovementActions as Sinon.SinonStub)
+          .calledOnce,
+      ).to.be.true;
+      expect(
+        logger.warn.calledWithMatch(
+          Sinon.match.has('source', 'transfers'),
+          'ActionTracker sync source failed, using stale data',
+        ),
+      ).to.be.true;
+      expect(
+        logger.info.calledWithMatch(
+          Sinon.match({
+            staleSources: ['transfers'],
+          }),
+          'ActionTracker sync freshness',
+        ),
+      ).to.be.true;
     });
 
     it('should sync inventory movement actions when bridge is provided', async () => {
@@ -865,6 +979,36 @@ describe('RebalancerOrchestrator', () => {
       await orchestrator.executeCycle(event);
 
       expect((metrics.processToken as Sinon.SinonStub).calledTwice).to.be.true;
+    });
+
+    it('should not gate cycle completion on token metrics processing', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([]);
+
+      const actionTracker = createMockActionTracker();
+      const inflightAdapter = createMockInflightContextAdapter();
+      const metrics = createMockMetrics();
+      (metrics.processToken as Sinon.SinonStub).returns(
+        new Promise(() => undefined),
+      );
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        rebalancers: [],
+        metrics,
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+      const event = createMonitorEvent();
+
+      const result = await orchestrator.executeCycle(event);
+
+      expect(result.proposedRoutes).to.have.lengthOf(0);
+      expect(strategy.getRebalancingRoutes.calledOnce).to.be.true;
     });
   });
 });

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -68,6 +68,7 @@ export class RebalancerOrchestrator {
   private readonly rebalancersByType: Map<RebalancerType, IRebalancer>;
   private readonly externalBridgeRegistry?: Partial<ExternalBridgeRegistry>;
   private readonly metrics?: Metrics;
+  private readonly inFlightMetricTokens = new Set<string>();
 
   constructor(deps: RebalancerOrchestratorDeps) {
     this.strategy = deps.strategy;
@@ -158,11 +159,30 @@ export class RebalancerOrchestrator {
     const { metrics } = this;
     if (!metrics) return;
 
+    const tokenInfosToProcess = event.tokensInfo.filter((tokenInfo) => {
+      const metricKey = this.metricTokenKey(tokenInfo.token);
+      if (this.inFlightMetricTokens.has(metricKey)) {
+        this.logger.debug(
+          { metricKey },
+          'Skipping token metrics processing already in flight',
+        );
+        return false;
+      }
+      this.inFlightMetricTokens.add(metricKey);
+      return true;
+    });
+
+    // Best-effort metrics are intentionally detached from the polling cycle.
+    // They may be dropped on process shutdown, but they cannot gate rebalancing.
     void Promise.allSettled(
-      event.tokensInfo.map((tokenInfo) =>
+      tokenInfosToProcess.map((tokenInfo) =>
         this.processTokenMetricsWithTimeout(() =>
           metrics.processToken(tokenInfo),
-        ),
+        ).finally(() => {
+          this.inFlightMetricTokens.delete(
+            this.metricTokenKey(tokenInfo.token),
+          );
+        }),
       ),
     ).then((results) => {
       const failed = results.filter((result) => result.status === 'rejected');
@@ -203,6 +223,10 @@ export class RebalancerOrchestrator {
         clearTimeout(timeout);
       }
     }
+  }
+
+  private metricTokenKey(token: MonitorEvent['tokensInfo'][number]['token']) {
+    return `${token.chainName}:${token.addressOrDenom}`;
   }
 
   /**

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -24,7 +24,7 @@ import { getRawBalances } from '../utils/balanceUtils.js';
 
 import { InventoryRebalancer } from './InventoryRebalancer.js';
 
-function errorToString(error: unknown): string {
+function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
@@ -171,7 +171,7 @@ export class RebalancerOrchestrator {
       this.logger.warn(
         {
           count: failed.length,
-          errors: failed.map((result) => errorToString(result.reason)),
+          errors: failed.map((result) => errorMessage(result.reason)),
         },
         'Metrics token processing failed',
       );
@@ -253,7 +253,7 @@ export class RebalancerOrchestrator {
 
       staleSources.push(name);
       this.logger.warn(
-        { source: name, error: result.reason },
+        { source: name, error: errorMessage(result.reason) },
         'ActionTracker sync source failed, using stale data',
       );
     });
@@ -359,7 +359,7 @@ export class RebalancerOrchestrator {
       if (rebalancer.rebalancerType === 'movableCollateral') {
         this.metrics?.recordRebalancerFailure();
       }
-      const errorMessage = errorToString(error);
+      const errorMessageString = errorMessage(error);
       this.logger.error(
         { error, type: rebalancer.rebalancerType },
         'Error while executing routes',
@@ -367,7 +367,7 @@ export class RebalancerOrchestrator {
       return routes.map((route) => ({
         route,
         success: false,
-        error: errorMessage,
+        error: errorMessageString,
         reason: 'executor_error',
       }));
     }

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -24,6 +24,17 @@ import { getRawBalances } from '../utils/balanceUtils.js';
 
 import { InventoryRebalancer } from './InventoryRebalancer.js';
 
+function errorToString(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+type ActionTrackerSyncStep = {
+  name: string;
+  run: () => Promise<unknown>;
+};
+
+const METRICS_PROCESS_TOKEN_TIMEOUT_MS = 30_000;
+
 /**
  * Result of a rebalancing cycle.
  * executedCount/failedCount: Counts from movable_collateral execution ONLY
@@ -78,12 +89,7 @@ export class RebalancerOrchestrator {
   async executeCycle(event: MonitorEvent): Promise<CycleResult> {
     this.logger.info('Polling cycle started');
 
-    const { metrics } = this;
-    if (metrics) {
-      await Promise.all(
-        event.tokensInfo.map((tokenInfo) => metrics.processToken(tokenInfo)),
-      );
-    }
+    this.processMetricsBestEffort(event);
 
     await this.syncActionTracker(event.confirmedBlockTags);
 
@@ -148,26 +154,116 @@ export class RebalancerOrchestrator {
     };
   }
 
+  private processMetricsBestEffort(event: MonitorEvent): void {
+    const { metrics } = this;
+    if (!metrics) return;
+
+    void Promise.allSettled(
+      event.tokensInfo.map((tokenInfo) =>
+        this.processTokenMetricsWithTimeout(() =>
+          metrics.processToken(tokenInfo),
+        ),
+      ),
+    ).then((results) => {
+      const failed = results.filter((result) => result.status === 'rejected');
+      if (failed.length === 0) return;
+
+      this.logger.warn(
+        {
+          count: failed.length,
+          errors: failed.map((result) => errorToString(result.reason)),
+        },
+        'Metrics token processing failed',
+      );
+    });
+  }
+
+  private async processTokenMetricsWithTimeout(
+    processToken: () => Promise<void>,
+  ): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        processToken(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `Metrics token processing timed out after ${METRICS_PROCESS_TOKEN_TIMEOUT_MS}ms`,
+                ),
+              ),
+            METRICS_PROCESS_TOKEN_TIMEOUT_MS,
+          );
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  }
+
   /**
    * Sync action tracker with current chain state.
    */
   private async syncActionTracker(
     confirmedBlockTags?: ConfirmedBlockTags,
   ): Promise<void> {
-    try {
-      await Promise.all([
-        this.actionTracker.syncTransfers(confirmedBlockTags),
-        this.actionTracker.syncRebalanceIntents(),
-        this.actionTracker.syncRebalanceActions(confirmedBlockTags),
-      ]);
+    const syncSteps: ActionTrackerSyncStep[] = [
+      {
+        name: 'transfers',
+        run: () => this.actionTracker.syncTransfers(confirmedBlockTags),
+      },
+      {
+        name: 'rebalanceIntents',
+        run: () => this.actionTracker.syncRebalanceIntents(),
+      },
+      {
+        name: 'rebalanceActions',
+        run: () => this.actionTracker.syncRebalanceActions(confirmedBlockTags),
+      },
+    ];
 
-      // Sync inventory movement actions via external bridge API
-      if (this.externalBridgeRegistry) {
-        await this.actionTracker.syncInventoryMovementActions(
-          this.externalBridgeRegistry,
-        );
+    const externalBridgeRegistry = this.externalBridgeRegistry;
+    if (externalBridgeRegistry) {
+      syncSteps.push({
+        name: 'inventoryMovementActions',
+        run: () =>
+          this.actionTracker.syncInventoryMovementActions(
+            externalBridgeRegistry,
+          ),
+      });
+    }
+
+    const results = await Promise.allSettled(
+      syncSteps.map((step) => Promise.resolve().then(() => step.run())),
+    );
+
+    const freshSources: string[] = [];
+    const staleSources: string[] = [];
+
+    results.forEach((result, index) => {
+      const { name } = syncSteps[index];
+      if (result.status === 'fulfilled') {
+        freshSources.push(name);
+        return;
       }
 
+      staleSources.push(name);
+      this.logger.warn(
+        { source: name, error: result.reason },
+        'ActionTracker sync source failed, using stale data',
+      );
+    });
+
+    this.logger.info(
+      { freshSources, staleSources },
+      'ActionTracker sync freshness',
+    );
+
+    try {
       await this.actionTracker.logStoreContents();
     } catch (error) {
       this.logger.warn(
@@ -259,15 +355,21 @@ export class RebalancerOrchestrator {
       }
 
       return results;
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (rebalancer.rebalancerType === 'movableCollateral') {
         this.metrics?.recordRebalancerFailure();
       }
+      const errorMessage = errorToString(error);
       this.logger.error(
         { error, type: rebalancer.rebalancerType },
         'Error while executing routes',
       );
-      return [];
+      return routes.map((route) => ({
+        route,
+        success: false,
+        error: errorMessage,
+        reason: 'executor_error',
+      }));
     }
   }
 }

--- a/typescript/rebalancer/src/core/RebalancerService.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.test.ts
@@ -136,6 +136,8 @@ function createMockActionTracker(): IActionTracker {
     getPartiallyFulfilledInventoryIntents: Sinon.stub().resolves([]),
     getActionsByType: Sinon.stub().resolves([]),
     getActionsForIntent: Sinon.stub().resolves([]),
+    getActionsForIntents: Sinon.stub().resolves(new Map()),
+    getActionsByMessageIds: Sinon.stub().resolves(new Map()),
     getInflightInventoryMovements: Sinon.stub().resolves(0n),
   };
 }

--- a/typescript/rebalancer/src/monitor/Monitor.test.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.test.ts
@@ -24,6 +24,7 @@ function createToken(chainName: ChainName, symbol: string): TestToken {
     isHypToken: () => true,
     getHypAdapter: () => ({ getBridgedSupply }),
     bridgedSupplyStub: getBridgedSupply,
+    // CAST: Monitor only touches this Token subset in this unit test.
   } as unknown as TestToken;
 }
 
@@ -52,6 +53,7 @@ describe('Monitor', () => {
     const warpCore = {
       tokens: [ethereumToken, arbitrumToken, secondEthereumToken],
       multiProvider,
+      // CAST: Monitor only reads tokens and multiProvider in this unit test.
     } as unknown as WarpCore;
     const monitor = new Monitor(0, warpCore, logger);
 

--- a/typescript/rebalancer/src/monitor/Monitor.test.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.test.ts
@@ -1,0 +1,102 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import type { ChainName, Token, WarpCore } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { MonitorEventType } from '../interfaces/IMonitor.js';
+import { Monitor } from './Monitor.js';
+
+const logger = pino({ level: 'silent' });
+
+type TestToken = Token & { bridgedSupplyStub: Sinon.SinonStub };
+
+function createToken(chainName: ChainName, symbol: string): TestToken {
+  const getBridgedSupply = Sinon.stub();
+  return {
+    chainName,
+    symbol,
+    name: symbol,
+    decimals: 18,
+    addressOrDenom: `0x${symbol.padEnd(40, '0')}`,
+    protocol: ProtocolType.Ethereum,
+    isHypToken: () => true,
+    getHypAdapter: () => ({ getBridgedSupply }),
+    bridgedSupplyStub: getBridgedSupply,
+  } as unknown as TestToken;
+}
+
+describe('Monitor', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('preserves token order and uses confirmed block tags per token chain', async () => {
+    const ethereumToken = createToken('ethereum' as ChainName, 'ETH');
+    const arbitrumToken = createToken('arbitrum' as ChainName, 'ARB');
+    const secondEthereumToken = createToken('ethereum' as ChainName, 'ETH2');
+    ethereumToken.bridgedSupplyStub.resolves(100n);
+    arbitrumToken.bridgedSupplyStub.resolves(200n);
+    secondEthereumToken.bridgedSupplyStub.resolves(300n);
+
+    const multiProvider = {
+      getChainMetadata: (chain: ChainName) => ({
+        protocol: ProtocolType.Ethereum,
+        blocks: { reorgPeriod: chain === 'ethereum' ? 10 : 20 },
+      }),
+      getEthersV5Provider: (chain: ChainName) => ({
+        getBlockNumber: async () => (chain === 'ethereum' ? 100 : 200),
+      }),
+    };
+    const warpCore = {
+      tokens: [ethereumToken, arbitrumToken, secondEthereumToken],
+      multiProvider,
+    } as unknown as WarpCore;
+    const monitor = new Monitor(0, warpCore, logger);
+
+    const eventPromise = new Promise<unknown>((resolve) => {
+      monitor.on(MonitorEventType.TokenInfo, async (event) => {
+        resolve(event);
+        void monitor.stop();
+      });
+    });
+
+    await monitor.start();
+    const event = (await eventPromise) as {
+      tokensInfo: Array<{ token: Token; bridgedSupply: bigint }>;
+      confirmedBlockTags: Record<string, number>;
+    };
+
+    expect(event.tokensInfo.map(({ token }) => token.symbol)).to.deep.equal([
+      'ETH',
+      'ARB',
+      'ETH2',
+    ]);
+    expect(
+      event.tokensInfo.map(({ token, bridgedSupply }) => ({
+        token: token.symbol,
+        bridgedSupply,
+      })),
+    ).to.deep.equal([
+      { token: 'ETH', bridgedSupply: 100n },
+      { token: 'ARB', bridgedSupply: 200n },
+      { token: 'ETH2', bridgedSupply: 300n },
+    ]);
+    expect(event.confirmedBlockTags).to.deep.equal({
+      ethereum: 90,
+      arbitrum: 180,
+    });
+    expect(
+      ethereumToken.bridgedSupplyStub.calledWithExactly({ blockTag: 90 }),
+    ).to.equal(true);
+    expect(
+      arbitrumToken.bridgedSupplyStub.calledWithExactly({ blockTag: 180 }),
+    ).to.equal(true);
+    expect(
+      secondEthereumToken.bridgedSupplyStub.calledWithExactly({
+        blockTag: 90,
+      }),
+    ).to.equal(true);
+  });
+});

--- a/typescript/rebalancer/src/monitor/Monitor.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.ts
@@ -51,14 +51,22 @@ export class Monitor implements IMonitor {
 
   private async computeConfirmedBlockTags(): Promise<ConfirmedBlockTags> {
     const blockTags: ConfirmedBlockTags = {};
-    const chains = new Set(this.warpCore.tokens.map((t) => t.chainName));
-
-    for (const chain of chains) {
-      blockTags[chain] = await getConfirmedBlockTag(
-        this.warpCore.multiProvider,
+    const chains = Array.from(
+      new Set(this.warpCore.tokens.map((t) => t.chainName)),
+    );
+    const results = await Promise.all(
+      chains.map(async (chain) => ({
         chain,
-        this.logger,
-      );
+        blockTag: await getConfirmedBlockTag(
+          this.warpCore.multiProvider,
+          chain,
+          this.logger,
+        ),
+      })),
+    );
+
+    for (const { chain, blockTag } of results) {
+      blockTags[chain] = blockTag;
     }
 
     return blockTags;
@@ -112,30 +120,30 @@ export class Monitor implements IMonitor {
           const confirmedBlockTags = await this.computeConfirmedBlockTags();
 
           const event: MonitorEvent = {
-            tokensInfo: [],
+            tokensInfo: await Promise.all(
+              this.warpCore.tokens.map(async (token) => {
+                this.logger.debug(
+                  {
+                    chain: token.chainName,
+                    tokenSymbol: token.symbol,
+                    tokenAddress: token.addressOrDenom,
+                  },
+                  'Checking token',
+                );
+                const blockTag = confirmedBlockTags[token.chainName];
+                const bridgedSupply = await this.getTokenBridgedSupply(
+                  token,
+                  blockTag,
+                );
+
+                return {
+                  token,
+                  bridgedSupply,
+                };
+              }),
+            ),
             confirmedBlockTags,
           };
-
-          for (const token of this.warpCore.tokens) {
-            this.logger.debug(
-              {
-                chain: token.chainName,
-                tokenSymbol: token.symbol,
-                tokenAddress: token.addressOrDenom,
-              },
-              'Checking token',
-            );
-            const blockTag = confirmedBlockTags[token.chainName];
-            const bridgedSupply = await this.getTokenBridgedSupply(
-              token,
-              blockTag,
-            );
-
-            event.tokensInfo.push({
-              token,
-              bridgedSupply,
-            });
-          }
 
           const inventoryBalances = await this.fetchInventoryBalances();
           if (Object.keys(inventoryBalances).length > 0) {
@@ -143,11 +151,7 @@ export class Monitor implements IMonitor {
             const tokensByChain = new Map(
               this.warpCore.tokens.map((token) => [token.chainName, token]),
             );
-            // CAST: inventoryBalances keys come from configured monitor chains,
-            // but Object.entries widens them to string.
-            const inventoryBalanceEntries = Object.entries(
-              inventoryBalances,
-            ) as [ChainName, bigint][];
+            const inventoryBalanceEntries = Object.entries(inventoryBalances);
             this.logger.info(
               {
                 chainsMonitored: Object.keys(inventoryBalances).length,

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -4,6 +4,7 @@ import { pino } from 'pino';
 import Sinon from 'sinon';
 
 import { EthJsonRpcBlockParameterTag } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import {
   DEFAULT_INTENT_TTL_MS,
@@ -1463,6 +1464,37 @@ describe('ActionTracker', () => {
     });
   });
 
+  describe('rebalance action queries', () => {
+    it('should keep the first action for duplicate message id lookups', async () => {
+      const firstAction: RebalanceAction = {
+        id: 'action-1',
+        type: 'rebalance_message',
+        status: 'in_progress',
+        intentId: 'intent-1',
+        messageId: '0xmsg1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      const secondAction: RebalanceAction = {
+        ...firstAction,
+        id: 'action-2',
+        intentId: 'intent-2',
+      };
+
+      await rebalanceActionStore.save(firstAction);
+      await rebalanceActionStore.save(secondAction);
+
+      const actionsByMessageId = await tracker.getActionsByMessageIds([
+        '0xmsg1',
+      ]);
+
+      expect(actionsByMessageId.get('0xmsg1')).to.deep.equal(firstAction);
+    });
+  });
+
   describe('delivery check synchronization', () => {
     it('should check delivery status in syncTransfers using adapter', async () => {
       await transferStore.save({
@@ -1575,6 +1607,86 @@ describe('ActionTracker', () => {
       await tracker.syncTransfers();
 
       expect(mailboxStub.isDelivered.calledOnce).to.be.true;
+    });
+
+    it('should preserve delivery pairing and cache block tags per destination', async () => {
+      const transfers: Transfer[] = [
+        {
+          id: '0xmsg1',
+          status: 'in_progress',
+          messageId: '0xmsg1',
+          origin: 1,
+          destination: 2,
+          amount: 100n,
+          sender: '0xuser1',
+          recipient: '0xuser2',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        {
+          id: '0xmsg2',
+          status: 'in_progress',
+          messageId: '0xmsg2',
+          origin: 1,
+          destination: 2,
+          amount: 200n,
+          sender: '0xuser1',
+          recipient: '0xuser2',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        {
+          id: '0xmsg3',
+          status: 'in_progress',
+          messageId: '0xmsg3',
+          origin: 1,
+          destination: 3,
+          amount: 300n,
+          sender: '0xuser1',
+          recipient: '0xuser2',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+
+      for (const transfer of transfers) {
+        await transferStore.save(transfer);
+      }
+
+      explorerClient.getInflightUserTransfers.resolves([]);
+      core.multiProvider.getChainMetadata = Sinon.stub().callsFake(
+        (chain: string) => ({
+          name: chain,
+          protocol: ProtocolType.Ethereum,
+          blocks: { reorgPeriod: 10 },
+        }),
+      );
+      core.multiProvider.getEthersV5Provider = Sinon.stub().returns({
+        getBlockNumber: Sinon.stub().resolves(1000),
+      });
+      mailboxStub.isDelivered.callsFake((messageId: string) =>
+        Promise.resolve(messageId !== '0xmsg2'),
+      );
+
+      await tracker.syncTransfers();
+
+      expect(mailboxStub.isDelivered.callCount).to.equal(3);
+      expect(
+        mailboxStub.isDelivered
+          .getCalls()
+          .map((call: Sinon.SinonSpyCall) => call.args),
+      ).to.deep.equal([
+        ['0xmsg1', 990],
+        ['0xmsg2', 990],
+        ['0xmsg3', 990],
+      ]);
+      expect(core.multiProvider.getEthersV5Provider.callCount).to.equal(2);
+
+      expect((await transferStore.get('0xmsg1'))?.status).to.equal('complete');
+      expect((await transferStore.get('0xmsg2'))?.status).to.equal(
+        'in_progress',
+      );
+      expect((await transferStore.get('0xmsg3'))?.status).to.equal('complete');
     });
 
     it('should pass blockTag when checking delivery in syncTransfers', async () => {

--- a/typescript/rebalancer/src/tracking/ActionTracker.test.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.test.ts
@@ -83,8 +83,8 @@ describe('ActionTracker', () => {
       transferStore,
       rebalanceIntentStore,
       rebalanceActionStore,
-      explorerClient as any,
-      core as any,
+      explorerClient,
+      core,
       config,
       testLogger,
     );

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -740,7 +740,7 @@ export class ActionTracker implements IActionTracker {
     const actionsByMessageId = new Map<string, RebalanceAction>();
 
     for (const action of actions) {
-      if (action.messageId) {
+      if (action.messageId && !actionsByMessageId.has(action.messageId)) {
         actionsByMessageId.set(action.messageId, action);
       }
     }

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -730,12 +730,6 @@ export class ActionTracker implements IActionTracker {
     return this.groupActionsByIntent(intentIds, actions);
   }
 
-  async getActionByMessageId(
-    messageId: string,
-  ): Promise<RebalanceAction | undefined> {
-    return this.rebalanceActionStore.getOneByField('messageId', messageId);
-  }
-
   async getActionsByMessageIds(
     messageIds: readonly string[],
   ): Promise<Map<string, RebalanceAction>> {

--- a/typescript/rebalancer/src/tracking/ActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/ActionTracker.ts
@@ -30,6 +30,34 @@ import type {
   Transfer,
 } from './types.js';
 
+const DELIVERY_CHECK_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = Array<R>(items.length);
+  let nextIndex = 0;
+
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex++;
+
+      if (index >= items.length) {
+        return;
+      }
+
+      results[index] = await mapper(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
 export interface ActionTrackerConfig {
   routersByDomain: Record<number, string>; // Domain ID → router address (source of truth for routers and domains)
   bridges: Address[]; // Bridge contract addresses for rebalance action queries
@@ -180,18 +208,24 @@ export class ActionTracker implements IActionTracker {
       }
     }
 
+    const getBlockTag = this.getConfirmedBlockTagLoader(confirmedBlockTags);
     const existingTransfers = await this.getInProgressTransfers();
-    for (const transfer of existingTransfers) {
-      const blockTag = await this.getConfirmedBlockTag(
-        transfer.destination,
-        confirmedBlockTags,
-      );
-      const delivered = await this.isMessageDelivered(
-        transfer.messageId,
-        transfer.destination,
-        blockTag,
-      );
+    const transferDeliveries = await mapWithConcurrency(
+      existingTransfers,
+      DELIVERY_CHECK_CONCURRENCY,
+      async (transfer) => {
+        const blockTag = await getBlockTag(transfer.destination);
+        const delivered = await this.isMessageDelivered(
+          transfer.messageId,
+          transfer.destination,
+          blockTag,
+        );
 
+        return { transfer, delivered };
+      },
+    );
+
+    for (const { transfer, delivered } of transferDeliveries) {
       if (delivered) {
         await this.transferStore.update(transfer.id, { status: 'complete' });
         completedTransfers++;
@@ -216,11 +250,13 @@ export class ActionTracker implements IActionTracker {
     // Check in_progress intents for completion or TTL expiry
     const inProgressIntents =
       await this.rebalanceIntentStore.getByStatus('in_progress');
-    const allInProgressActions =
-      await this.rebalanceActionStore.getByStatus('in_progress');
+    const actionsByIntent = await this.getActionsForIntents(
+      inProgressIntents.map((intent) => intent.id),
+    );
     const now = Date.now();
     for (const intent of inProgressIntents) {
-      const completedAmount = await this.getCompletedAmountForIntent(intent.id);
+      const actions = actionsByIntent.get(intent.id) ?? [];
+      const completedAmount = this.getCompletedAmount(actions);
       if (completedAmount >= intent.amount) {
         await this.rebalanceIntentStore.update(intent.id, {
           status: 'complete',
@@ -232,8 +268,8 @@ export class ActionTracker implements IActionTracker {
         });
 
         // Fail any in-progress actions associated with the expired intent
-        for (const action of allInProgressActions) {
-          if (action.intentId === intent.id) {
+        for (const action of actions) {
+          if (action.status === 'in_progress') {
             await this.rebalanceActionStore.update(action.id, {
               status: 'failed',
             });
@@ -289,10 +325,12 @@ export class ActionTracker implements IActionTracker {
       'Found inflight rebalance actions from Explorer',
     );
 
-    const allActions = await this.rebalanceActionStore.getAll();
+    const existingActionsByMessageId = await this.getActionsByMessageIds(
+      inflightMessages.map((msg) => msg.msg_id),
+    );
 
     for (const msg of inflightMessages) {
-      const existingAction = allActions.find((a) => a.messageId === msg.msg_id);
+      const existingAction = existingActionsByMessageId.get(msg.msg_id);
 
       if (!existingAction) {
         this.logger.info(
@@ -313,22 +351,27 @@ export class ActionTracker implements IActionTracker {
     // inventory_movement actions are synced separately via LiFi status API
     const inProgressActions =
       await this.rebalanceActionStore.getByStatus('in_progress');
-    for (const action of inProgressActions) {
-      // Skip actions without messageId (e.g., inventory_movement)
-      if (!action.messageId) {
-        continue;
-      }
+    const deliverableActions = inProgressActions.filter(
+      (action) => action.messageId,
+    );
+    const getBlockTag = this.getConfirmedBlockTagLoader(confirmedBlockTags);
+    const actionDeliveries = await mapWithConcurrency(
+      deliverableActions,
+      DELIVERY_CHECK_CONCURRENCY,
+      async (action) => {
+        assert(action.messageId, `Missing messageId for action ${action.id}`);
+        const blockTag = await getBlockTag(action.destination);
+        const delivered = await this.isMessageDelivered(
+          action.messageId,
+          action.destination,
+          blockTag,
+        );
 
-      const blockTag = await this.getConfirmedBlockTag(
-        action.destination,
-        confirmedBlockTags,
-      );
-      const delivered = await this.isMessageDelivered(
-        action.messageId,
-        action.destination,
-        blockTag,
-      );
+        return { action, delivered };
+      },
+    );
 
+    for (const { action, delivered } of actionDeliveries) {
       if (delivered) {
         await this.completeRebalanceAction(action.id);
         completedActions++;
@@ -525,6 +568,10 @@ export class ActionTracker implements IActionTracker {
    */
   private async getCompletedAmountForIntent(intentId: string): Promise<bigint> {
     const actions = await this.getActionsForIntent(intentId);
+    return this.getCompletedAmount(actions);
+  }
+
+  private getCompletedAmount(actions: readonly RebalanceAction[]): bigint {
     return actions
       .filter(
         (a) =>
@@ -542,17 +589,14 @@ export class ActionTracker implements IActionTracker {
   // === RebalanceAction Queries ===
 
   async getActionsByType(type: ActionType): Promise<RebalanceAction[]> {
-    const allActions = await this.rebalanceActionStore.getAll();
-    return allActions.filter((action) => action.type === type);
+    return this.rebalanceActionStore.getByField('type', type);
   }
 
   async getInflightInventoryMovements(origin: Domain): Promise<bigint> {
-    const allActions = await this.rebalanceActionStore.getAll();
-    const inflightMovements = allActions.filter(
-      (action) =>
-        action.type === 'inventory_movement' &&
-        action.status === 'in_progress' &&
-        action.origin === origin,
+    const inventoryMovements =
+      await this.getActionsByType('inventory_movement');
+    const inflightMovements = inventoryMovements.filter(
+      (action) => action.status === 'in_progress' && action.origin === origin,
     );
 
     return inflightMovements.reduce(
@@ -582,12 +626,16 @@ export class ActionTracker implements IActionTracker {
 
     const allActiveIntents = [...inProgressIntents, ...notStartedIntents];
     const partialIntents: PartialInventoryIntent[] = [];
+    const inventoryIntentIds = allActiveIntents
+      .filter((intent) => intent.executionMethod === 'inventory')
+      .map((intent) => intent.id);
+    const actionsByIntent = await this.getActionsForIntents(inventoryIntentIds);
 
     for (const intent of allActiveIntents) {
       // Only inventory execution method
       if (intent.executionMethod !== 'inventory') continue;
 
-      const actions = await this.getActionsForIntent(intent.id);
+      const actions = actionsByIntent.get(intent.id) ?? [];
 
       // Check for in-flight inventory_movement actions
       // Skip intents with active bridge movement(s). Movements still `pending` on
@@ -669,8 +717,41 @@ export class ActionTracker implements IActionTracker {
    * Get all actions associated with a specific intent.
    */
   async getActionsForIntent(intentId: string): Promise<RebalanceAction[]> {
-    const allActions = await this.rebalanceActionStore.getAll();
-    return allActions.filter((a) => a.intentId === intentId);
+    return this.rebalanceActionStore.getByField('intentId', intentId);
+  }
+
+  async getActionsForIntents(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>> {
+    const actions = await this.rebalanceActionStore.getByFieldValues(
+      'intentId',
+      intentIds,
+    );
+    return this.groupActionsByIntent(intentIds, actions);
+  }
+
+  async getActionByMessageId(
+    messageId: string,
+  ): Promise<RebalanceAction | undefined> {
+    return this.rebalanceActionStore.getOneByField('messageId', messageId);
+  }
+
+  async getActionsByMessageIds(
+    messageIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction>> {
+    const actions = await this.rebalanceActionStore.getByFieldValues(
+      'messageId',
+      messageIds,
+    );
+    const actionsByMessageId = new Map<string, RebalanceAction>();
+
+    for (const action of actions) {
+      if (action.messageId) {
+        actionsByMessageId.set(action.messageId, action);
+      }
+    }
+
+    return actionsByMessageId;
   }
 
   async syncInventoryMovementActions(
@@ -682,11 +763,9 @@ export class ActionTracker implements IActionTracker {
     let failed = 0;
 
     // Get all in-progress inventory_movement actions
-    const inProgressActions =
-      await this.rebalanceActionStore.getByStatus('in_progress');
-    const inventoryMovements = inProgressActions.filter(
-      (a) => a.type === 'inventory_movement',
-    );
+    const inventoryMovements = (
+      await this.getActionsByType('inventory_movement')
+    ).filter((action) => action.status === 'in_progress');
 
     this.logger.debug(
       { count: inventoryMovements.length },
@@ -879,6 +958,46 @@ export class ActionTracker implements IActionTracker {
   }
 
   // === Private Helpers ===
+
+  private groupActionsByIntent(
+    intentIds: readonly string[],
+    actions: readonly RebalanceAction[],
+  ): Map<string, RebalanceAction[]> {
+    const actionsByIntent = new Map<string, RebalanceAction[]>();
+
+    for (const intentId of intentIds) {
+      actionsByIntent.set(intentId, []);
+    }
+
+    for (const action of actions) {
+      const intentActions = actionsByIntent.get(action.intentId);
+      if (intentActions) {
+        intentActions.push(action);
+      }
+    }
+
+    return actionsByIntent;
+  }
+
+  private getConfirmedBlockTagLoader(
+    confirmedBlockTags?: ConfirmedBlockTags,
+  ): (destination: Domain) => Promise<string | number | undefined> {
+    const cache = new Map<Domain, Promise<string | number | undefined>>();
+
+    return (destination: Domain) => {
+      const cached = cache.get(destination);
+      if (cached) {
+        return cached;
+      }
+
+      const blockTag = this.getConfirmedBlockTag(
+        destination,
+        confirmedBlockTags,
+      );
+      cache.set(destination, blockTag);
+      return blockTag;
+    };
+  }
 
   /**
    * Get the confirmed block tag for delivery checks.

--- a/typescript/rebalancer/src/tracking/IActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/IActionTracker.ts
@@ -171,23 +171,15 @@ export interface IActionTracker {
    * Get actions grouped by intent ID.
    * @param intentIds - IDs of the intents
    */
-  getActionsForIntents?(
+  getActionsForIntents(
     intentIds: readonly string[],
   ): Promise<Map<string, RebalanceAction[]>>;
-
-  /**
-   * Get an action by Hyperlane message ID.
-   * @param messageId - Message ID associated with the action
-   */
-  getActionByMessageId?(
-    messageId: string,
-  ): Promise<RebalanceAction | undefined>;
 
   /**
    * Get actions keyed by Hyperlane message ID.
    * @param messageIds - Message IDs associated with actions
    */
-  getActionsByMessageIds?(
+  getActionsByMessageIds(
     messageIds: readonly string[],
   ): Promise<Map<string, RebalanceAction>>;
 

--- a/typescript/rebalancer/src/tracking/IActionTracker.ts
+++ b/typescript/rebalancer/src/tracking/IActionTracker.ts
@@ -168,6 +168,30 @@ export interface IActionTracker {
   getActionsForIntent(intentId: string): Promise<RebalanceAction[]>;
 
   /**
+   * Get actions grouped by intent ID.
+   * @param intentIds - IDs of the intents
+   */
+  getActionsForIntents?(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>>;
+
+  /**
+   * Get an action by Hyperlane message ID.
+   * @param messageId - Message ID associated with the action
+   */
+  getActionByMessageId?(
+    messageId: string,
+  ): Promise<RebalanceAction | undefined>;
+
+  /**
+   * Get actions keyed by Hyperlane message ID.
+   * @param messageIds - Message IDs associated with actions
+   */
+  getActionsByMessageIds?(
+    messageIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction>>;
+
+  /**
    * Get total inflight inventory movement amount from a specific chain.
    * Returns the sum of amounts for all in_progress inventory_movement actions
    * that originate from the specified domain.

--- a/typescript/rebalancer/src/tracking/InflightContextAdapter.test.ts
+++ b/typescript/rebalancer/src/tracking/InflightContextAdapter.test.ts
@@ -261,16 +261,16 @@ describe('InflightContextAdapter', () => {
 
       actionTracker.getActiveRebalanceIntents.resolves(mockIntents);
       actionTracker.getInProgressTransfers.resolves([]);
-      actionTracker.getActionsForIntents!.resolves(actionsByIntent);
+      actionTracker.getActionsForIntents.resolves(actionsByIntent);
       multiProvider.getChainName.withArgs(1).returns('ethereum');
       multiProvider.getChainName.withArgs(2).returns('arbitrum');
       multiProvider.getChainName.withArgs(3).returns('optimism');
 
       const result = await adapter.getInflightContext();
 
-      expect(actionTracker.getActionsForIntents!.calledOnce).to.be.true;
+      expect(actionTracker.getActionsForIntents.calledOnce).to.be.true;
       expect(
-        actionTracker.getActionsForIntents!.firstCall.args[0],
+        actionTracker.getActionsForIntents.firstCall.args[0],
       ).to.deep.equal(['inventory-intent-1', 'inventory-intent-2']);
       expect(actionTracker.getActionsForIntent.notCalled).to.be.true;
       expect(result.pendingRebalances[0].deliveredAmount).to.equal(300n);

--- a/typescript/rebalancer/src/tracking/InflightContextAdapter.test.ts
+++ b/typescript/rebalancer/src/tracking/InflightContextAdapter.test.ts
@@ -5,7 +5,7 @@ import type { MultiProvider } from '@hyperlane-xyz/sdk';
 
 import type { IActionTracker } from './IActionTracker.js';
 import { InflightContextAdapter } from './InflightContextAdapter.js';
-import type { RebalanceIntent, Transfer } from './types.js';
+import type { RebalanceAction, RebalanceIntent, Transfer } from './types.js';
 
 describe('InflightContextAdapter', () => {
   let actionTracker: Sinon.SinonStubbedInstance<IActionTracker>;
@@ -17,6 +17,7 @@ describe('InflightContextAdapter', () => {
       getActiveRebalanceIntents: Sinon.stub(),
       getInProgressTransfers: Sinon.stub(),
       getActionsForIntent: Sinon.stub(),
+      getActionsForIntents: Sinon.stub(),
     } as any;
 
     multiProvider = {
@@ -201,6 +202,81 @@ describe('InflightContextAdapter', () => {
 
       expect(result.pendingRebalances).to.have.lengthOf(2);
       expect(result.pendingTransfers).to.have.lengthOf(2);
+    });
+
+    it('should fetch inventory intent actions in one batch', async () => {
+      const mockIntents: RebalanceIntent[] = [
+        {
+          id: 'inventory-intent-1',
+          origin: 1,
+          destination: 2,
+          amount: 1000n,
+          status: 'in_progress',
+          executionMethod: 'inventory',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        {
+          id: 'inventory-intent-2',
+          origin: 2,
+          destination: 3,
+          amount: 2000n,
+          status: 'in_progress',
+          executionMethod: 'inventory',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+
+      const actionsByIntent = new Map<string, RebalanceAction[]>([
+        [
+          'inventory-intent-1',
+          [
+            {
+              id: 'action-complete',
+              type: 'inventory_deposit',
+              status: 'complete',
+              intentId: 'inventory-intent-1',
+              origin: 1,
+              destination: 2,
+              amount: 300n,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+            {
+              id: 'action-in-progress',
+              type: 'inventory_deposit',
+              status: 'in_progress',
+              intentId: 'inventory-intent-1',
+              origin: 1,
+              destination: 2,
+              amount: 200n,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          ],
+        ],
+        ['inventory-intent-2', []],
+      ]);
+
+      actionTracker.getActiveRebalanceIntents.resolves(mockIntents);
+      actionTracker.getInProgressTransfers.resolves([]);
+      actionTracker.getActionsForIntents!.resolves(actionsByIntent);
+      multiProvider.getChainName.withArgs(1).returns('ethereum');
+      multiProvider.getChainName.withArgs(2).returns('arbitrum');
+      multiProvider.getChainName.withArgs(3).returns('optimism');
+
+      const result = await adapter.getInflightContext();
+
+      expect(actionTracker.getActionsForIntents!.calledOnce).to.be.true;
+      expect(
+        actionTracker.getActionsForIntents!.firstCall.args[0],
+      ).to.deep.equal(['inventory-intent-1', 'inventory-intent-2']);
+      expect(actionTracker.getActionsForIntent.notCalled).to.be.true;
+      expect(result.pendingRebalances[0].deliveredAmount).to.equal(300n);
+      expect(result.pendingRebalances[0].awaitingDeliveryAmount).to.equal(200n);
+      expect(result.pendingRebalances[1].deliveredAmount).to.equal(0n);
+      expect(result.pendingRebalances[1].awaitingDeliveryAmount).to.equal(0n);
     });
   });
 });

--- a/typescript/rebalancer/src/tracking/InflightContextAdapter.ts
+++ b/typescript/rebalancer/src/tracking/InflightContextAdapter.ts
@@ -6,6 +6,7 @@ import type {
 } from '../interfaces/IStrategy.js';
 
 import type { IActionTracker } from './IActionTracker.js';
+import type { RebalanceAction } from './types.js';
 
 /**
  * Adapter that converts ActionTracker data to strategy-consumable InflightContext.
@@ -24,6 +25,13 @@ export class InflightContextAdapter {
   async getInflightContext(): Promise<InflightContext> {
     const intents = await this.actionTracker.getActiveRebalanceIntents();
     const transfers = await this.actionTracker.getInProgressTransfers();
+    const inventoryIntentIds = intents
+      .filter((intent) => intent.executionMethod === 'inventory')
+      .map((intent) => intent.id);
+    const actionsByIntent =
+      inventoryIntentIds.length > 0
+        ? await this.getActionsForIntents(inventoryIntentIds)
+        : new Map<string, RebalanceAction[]>();
 
     const pendingRebalances: RouteWithContext[] = await Promise.all(
       intents.map(async (intent) => {
@@ -32,9 +40,7 @@ export class InflightContextAdapter {
 
         // For inventory intents, compute delivered and awaiting amounts from actions
         if (intent.executionMethod === 'inventory') {
-          const actions = await this.actionTracker.getActionsForIntent(
-            intent.id,
-          );
+          const actions = actionsByIntent.get(intent.id) ?? [];
 
           // Sum of complete inventory_deposit actions (message delivered)
           deliveredAmount = actions
@@ -71,5 +77,25 @@ export class InflightContextAdapter {
     }));
 
     return { pendingRebalances, pendingTransfers };
+  }
+
+  private async getActionsForIntents(
+    intentIds: readonly string[],
+  ): Promise<Map<string, RebalanceAction[]>> {
+    if (this.actionTracker.getActionsForIntents) {
+      return this.actionTracker.getActionsForIntents(intentIds);
+    }
+
+    const actionsByIntent = new Map<string, RebalanceAction[]>();
+    await Promise.all(
+      intentIds.map(async (intentId) => {
+        actionsByIntent.set(
+          intentId,
+          await this.actionTracker.getActionsForIntent(intentId),
+        );
+      }),
+    );
+
+    return actionsByIntent;
   }
 }

--- a/typescript/rebalancer/src/tracking/InflightContextAdapter.ts
+++ b/typescript/rebalancer/src/tracking/InflightContextAdapter.ts
@@ -82,20 +82,6 @@ export class InflightContextAdapter {
   private async getActionsForIntents(
     intentIds: readonly string[],
   ): Promise<Map<string, RebalanceAction[]>> {
-    if (this.actionTracker.getActionsForIntents) {
-      return this.actionTracker.getActionsForIntents(intentIds);
-    }
-
-    const actionsByIntent = new Map<string, RebalanceAction[]>();
-    await Promise.all(
-      intentIds.map(async (intentId) => {
-        actionsByIntent.set(
-          intentId,
-          await this.actionTracker.getActionsForIntent(intentId),
-        );
-      }),
-    );
-
-    return actionsByIntent;
+    return this.actionTracker.getActionsForIntents(intentIds);
   }
 }

--- a/typescript/rebalancer/src/tracking/store/IStore.ts
+++ b/typescript/rebalancer/src/tracking/store/IStore.ts
@@ -45,4 +45,25 @@ export interface IStore<T extends TrackedActionBase, Status extends string> {
    * Query entities by destination domain.
    */
   getByDestination(destination: Domain): Promise<T[]>;
+
+  /**
+   * Query entities by an indexed field.
+   */
+  getByField<K extends keyof T>(field: K, value: T[K]): Promise<T[]>;
+
+  /**
+   * Query entities matching any value for an indexed field.
+   */
+  getByFieldValues<K extends keyof T>(
+    field: K,
+    values: readonly T[K][],
+  ): Promise<T[]>;
+
+  /**
+   * Retrieve the first entity matching an indexed field.
+   */
+  getOneByField<K extends keyof T>(
+    field: K,
+    value: T[K],
+  ): Promise<T | undefined>;
 }

--- a/typescript/rebalancer/src/tracking/store/IStore.ts
+++ b/typescript/rebalancer/src/tracking/store/IStore.ts
@@ -48,11 +48,13 @@ export interface IStore<T extends TrackedActionBase, Status extends string> {
 
   /**
    * Query entities by an indexed field.
+   * Result ordering is implementation-defined for index-backed queries.
    */
   getByField<K extends keyof T>(field: K, value: T[K]): Promise<T[]>;
 
   /**
    * Query entities matching any value for an indexed field.
+   * Result ordering is implementation-defined for index-backed queries.
    */
   getByFieldValues<K extends keyof T>(
     field: K,

--- a/typescript/rebalancer/src/tracking/store/InMemoryStore.test.ts
+++ b/typescript/rebalancer/src/tracking/store/InMemoryStore.test.ts
@@ -273,6 +273,31 @@ describe('InMemoryStore', () => {
       expect(complete).to.have.lengthOf(1);
       expect(complete).to.deep.include(transfer2);
     });
+
+    it('should update status indexes when entities change', async () => {
+      const transfer: Transfer = {
+        id: 'transfer-1',
+        status: 'in_progress',
+        messageId: 'msg-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        sender: '0xsender',
+        recipient: '0xrecipient',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await store.save(transfer);
+      expect(await store.getByStatus('in_progress')).to.have.lengthOf(1);
+
+      await store.update('transfer-1', { status: 'complete' });
+
+      expect(await store.getByStatus('in_progress')).to.be.empty;
+      const complete = await store.getByStatus('complete');
+      expect(complete).to.have.lengthOf(1);
+      expect(complete[0].id).to.equal('transfer-1');
+    });
   });
 
   describe('getByDestination', () => {
@@ -333,6 +358,90 @@ describe('InMemoryStore', () => {
       const toDomain3 = await store.getByDestination(3);
       expect(toDomain3).to.have.lengthOf(1);
       expect(toDomain3).to.deep.include(transfer2);
+    });
+
+    it('should remove deleted entities from indexes', async () => {
+      const transfer: Transfer = {
+        id: 'transfer-1',
+        status: 'in_progress',
+        messageId: 'msg-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        sender: '0xsender',
+        recipient: '0xrecipient',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await store.save(transfer);
+      expect(await store.getByDestination(2)).to.have.lengthOf(1);
+
+      await store.delete('transfer-1');
+
+      expect(await store.getByDestination(2)).to.be.empty;
+    });
+  });
+
+  describe('getByFieldValues', () => {
+    it('should return entities for any requested field value', async () => {
+      const transfer1: Transfer = {
+        id: 'transfer-1',
+        status: 'in_progress',
+        messageId: 'msg-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        sender: '0xsender1',
+        recipient: '0xrecipient1',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      const transfer2: Transfer = {
+        id: 'transfer-2',
+        status: 'complete',
+        messageId: 'msg-2',
+        origin: 2,
+        destination: 3,
+        amount: 200n,
+        sender: '0xsender2',
+        recipient: '0xrecipient2',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await store.save(transfer1);
+      await store.save(transfer2);
+
+      const result = await store.getByFieldValues('messageId', [
+        'msg-2',
+        'missing',
+      ]);
+
+      expect(result).to.deep.equal([transfer2]);
+    });
+
+    it('should return one entity by field', async () => {
+      const transfer: Transfer = {
+        id: 'transfer-1',
+        status: 'in_progress',
+        messageId: 'msg-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        sender: '0xsender',
+        recipient: '0xrecipient',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await store.save(transfer);
+
+      expect(await store.getOneByField('messageId', 'msg-1')).to.deep.equal(
+        transfer,
+      );
+      expect(await store.getOneByField('messageId', 'missing')).to.be.undefined;
     });
   });
 });

--- a/typescript/rebalancer/src/tracking/store/InMemoryStore.test.ts
+++ b/typescript/rebalancer/src/tracking/store/InMemoryStore.test.ts
@@ -422,6 +422,31 @@ describe('InMemoryStore', () => {
       expect(result).to.deep.equal([transfer2]);
     });
 
+    it('should update a lazily-created non-status index after later saves', async () => {
+      expect(
+        await store.getByFieldValues('messageId', ['msg-1']),
+      ).to.deep.equal([]);
+
+      const transfer: Transfer = {
+        id: 'transfer-1',
+        status: 'in_progress',
+        messageId: 'msg-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        sender: '0xsender',
+        recipient: '0xrecipient',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      await store.save(transfer);
+
+      expect(
+        await store.getByFieldValues('messageId', ['msg-1']),
+      ).to.deep.equal([transfer]);
+    });
+
     it('should return one entity by field', async () => {
       const transfer: Transfer = {
         id: 'transfer-1',

--- a/typescript/rebalancer/src/tracking/store/InMemoryStore.ts
+++ b/typescript/rebalancer/src/tracking/store/InMemoryStore.ts
@@ -76,6 +76,10 @@ export class InMemoryStore<
     return this.getEntities(index.get(value));
   }
 
+  /**
+   * Index-backed queries return index bucket order, not global insertion order.
+   * Updating an entity can move it to the end of its indexed value bucket.
+   */
   async getByFieldValues<K extends keyof T>(
     field: K,
     values: readonly T[K][],

--- a/typescript/rebalancer/src/tracking/store/InMemoryStore.ts
+++ b/typescript/rebalancer/src/tracking/store/InMemoryStore.ts
@@ -7,6 +7,8 @@ import type { IStore } from './IStore.js';
 /**
  * In-memory implementation of the IStore interface.
  * Uses a Map for fast lookups and keeps all data in memory.
+ * Returned entities are live references; mutate stored entities only through
+ * save/update/delete so indexes stay consistent.
  *
  * @template T - The entity type extending TrackedActionBase
  * @template Status - The status enum type for this entity
@@ -16,9 +18,16 @@ export class InMemoryStore<
   Status extends string,
 > implements IStore<T, Status> {
   protected data: Map<string, T> = new Map();
+  private readonly indexes = new Map<keyof T, Map<unknown, Set<string>>>();
 
   async save(entity: T): Promise<void> {
+    const existing = this.data.get(entity.id);
+    if (existing) {
+      this.removeFromIndexes(existing);
+    }
+
     this.data.set(entity.id, entity);
+    this.addToIndexes(entity);
   }
 
   async get(id: string): Promise<T | undefined> {
@@ -34,26 +43,119 @@ export class InMemoryStore<
     if (!existing) {
       throw new Error(`Entity ${id} not found`);
     }
-    this.data.set(id, {
+
+    const updated = {
       ...existing,
       ...updates,
       updatedAt: Date.now(),
-    } as T);
+    } as T;
+
+    this.removeFromIndexes(existing);
+    this.data.set(id, updated);
+    this.addToIndexes(updated);
   }
 
   async delete(id: string): Promise<void> {
-    this.data.delete(id);
+    const existing = this.data.get(id);
+    if (existing) {
+      this.removeFromIndexes(existing);
+      this.data.delete(id);
+    }
   }
 
   async getByStatus(status: Status): Promise<T[]> {
-    return Array.from(this.data.values()).filter(
-      (entity) => entity.status === status,
-    );
+    return this.getByField('status', status);
   }
 
   async getByDestination(destination: Domain): Promise<T[]> {
-    return Array.from(this.data.values()).filter(
-      (entity) => entity.destination === destination,
-    );
+    return this.getByField('destination', destination);
+  }
+
+  async getByField<K extends keyof T>(field: K, value: T[K]): Promise<T[]> {
+    const index = this.getIndex(field);
+    return this.getEntities(index.get(value));
+  }
+
+  async getByFieldValues<K extends keyof T>(
+    field: K,
+    values: readonly T[K][],
+  ): Promise<T[]> {
+    const index = this.getIndex(field);
+    const ids = new Set<string>();
+
+    for (const value of values) {
+      for (const id of index.get(value) ?? []) {
+        ids.add(id);
+      }
+    }
+
+    return this.getEntities(ids);
+  }
+
+  async getOneByField<K extends keyof T>(
+    field: K,
+    value: T[K],
+  ): Promise<T | undefined> {
+    const matches = await this.getByField(field, value);
+    return matches[0];
+  }
+
+  private getIndex<K extends keyof T>(field: K): Map<unknown, Set<string>> {
+    let index = this.indexes.get(field);
+    if (!index) {
+      index = new Map<unknown, Set<string>>();
+      for (const entity of this.data.values()) {
+        this.addToIndex(index, entity[field], entity.id);
+      }
+      this.indexes.set(field, index);
+    }
+
+    return index;
+  }
+
+  private addToIndexes(entity: T): void {
+    for (const [field, index] of this.indexes) {
+      this.addToIndex(index, entity[field], entity.id);
+    }
+  }
+
+  private removeFromIndexes(entity: T): void {
+    for (const [field, index] of this.indexes) {
+      const ids = index.get(entity[field]);
+      if (!ids) {
+        continue;
+      }
+
+      ids.delete(entity.id);
+      if (ids.size === 0) {
+        index.delete(entity[field]);
+      }
+    }
+  }
+
+  private addToIndex(
+    index: Map<unknown, Set<string>>,
+    value: unknown,
+    id: string,
+  ): void {
+    const ids = index.get(value) ?? new Set<string>();
+    ids.add(id);
+    index.set(value, ids);
+  }
+
+  private getEntities(ids: Set<string> | undefined): T[] {
+    if (!ids) {
+      return [];
+    }
+
+    const entities: T[] = [];
+    for (const id of ids) {
+      const entity = this.data.get(id);
+      if (entity) {
+        entities.push(entity);
+      }
+    }
+
+    return entities;
   }
 }


### PR DESCRIPTION
## Summary

Improves the rebalancer cycle hot paths without changing external config shape. The north star is cycle performance: reduce serial polling/sync work, avoid non-critical side effects blocking execution, and make failure accounting more visible.

## Slice Benefits

### 1. Monitor snapshot parallelism

- Parallelizes confirmed block tag reads across unique warp-route chains.
- Parallelizes bridged supply reads across tokens while preserving `tokensInfo` order and event shape.
- Benefit: monitor cycles are bounded closer to the slowest chain/token read instead of the sum of all reads.

### 2. Tracking hot-path batching

- Adds lazy indexes to `InMemoryStore` plus indexed field and batch lookup helpers.
- Adds batched action lookups by intent IDs and message IDs.
- Uses the batched action lookup in `InflightContextAdapter` so inventory intent projection no longer scans actions per intent.
- Bounds delivery status checks with per-destination confirmed-block-tag caching.
- Benefit: tracker sync and inflight-context projection scale with indexed lookups and bounded IO instead of repeated full scans and serial delivery checks.

### 3. Orchestrator non-gating side effects

- Makes token metrics processing best-effort, timeout-bounded, and non-gating.
- Runs tracker sync sources independently with freshness logging rather than one all-or-nothing `Promise.all` failure path.
- Maps executor throws to failed route results for attempted routes instead of silently returning an empty result set.
- Benefit: slow metrics work and partial sync-source failures no longer stall the whole cycle, and execution failures are visible in cycle accounting.

### 4. Architecture handoff + follow-up TODOs

- Adds `typescript/rebalancer/docs/rebalancer-architecture-review.md` with the package assessment, target architecture, implemented slices, and a follow-up stacked draft PR TODO list.
- Benefit: keeps the larger planner/executor decomposition scoped as follow-up work while documenting the rationale and pickup path.

## Follow-up stacked draft PR TODOs

The doc includes the detailed TODO list. The next draft PR should focus on the larger module split:

- explicit `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`
- removing inventory state injection through `setInventoryBalances()`
- config normalization into a route execution matrix
- shared balance projection and `StrategyPlanner`
- movable/inventory executor decomposition
- LiFi client isolation and e2e fixture cleanup

## Review Notes

Used subagents for independent implementation slices:

- monitor parallelism
- tracking/store batching and bounded sync
- orchestrator side-effect/failure handling

Used Claude read-only reviews for each slice. No blocking findings. Follow-ups from review were addressed by adding a metrics timeout and documenting the indexed-store mutation invariant.

## Validation

- `pnpm build`
- `pnpm test` (`387 passing`)
- `pnpm exec mocha --config .mocharc.json './src/core/RebalancerOrchestrator.test.ts' './src/tracking/**/*.test.ts' --exit`
- `pnpm exec oxlint -c ../../oxlint.json src/core/RebalancerOrchestrator.ts src/core/RebalancerOrchestrator.test.ts src/monitor/Monitor.ts src/tracking`
- `pnpm exec oxfmt --check src/core/RebalancerOrchestrator.ts src/tracking/store/InMemoryStore.ts`
- `pnpm -s exec prettier --check typescript/rebalancer/docs/rebalancer-architecture-review.md .changeset/rebalancer-cycle-performance.md`
- `git diff --check`

Note: package-wide `pnpm lint` still reports pre-existing lint issues in untouched files, so validation used touched-file oxlint plus full package build/test.
