### PR TITLE
perf(rebalancer): split planning execution seams

### DIFF
--- a/.changeset/rebalancer-planner-execution-split.md
+++ b/.changeset/rebalancer-planner-execution-split.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/rebalancer": patch
 ---
 
-Improved rebalancer planning and execution isolation by passing explicit cycle context to executors, centralizing balance projection and route materialization, resolving route execution config once, and wrapping LiFi SDK calls behind an injected runner with provider-scope execution locks.
+Improved rebalancer planning and execution isolation by passing explicit cycle context to executors, centralizing balance projection and route materialization, resolving route execution config once, and wrapping LiFi SDK calls behind an injected runner with provider-scope execution locks. Also normalized route execution configs so stale fields are dropped when overrides change execution type, and made collateral-deficit strategies account for proposed rebalances from earlier composite strategies.

--- a/.changeset/rebalancer-planner-execution-split.md
+++ b/.changeset/rebalancer-planner-execution-split.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/rebalancer": patch
+---
+
+Improved rebalancer planning and execution isolation by passing explicit cycle context to executors, centralizing balance projection and route materialization, resolving route execution config once, and wrapping LiFi SDK calls behind an injected runner with provider-scope execution locks.

--- a/typescript/rebalancer/docs/rebalancer-architecture-review.md
+++ b/typescript/rebalancer/docs/rebalancer-architecture-review.md
@@ -4,7 +4,7 @@ Date: 2026-06-12
 
 Scope: `typescript/rebalancer` package. Findings are from local code inspection plus three read-only subagent slices covering core runtime, strategy/config, and bridges/tracking/tests.
 
-Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice was completed in this PR; larger planner/executor decomposition remains future work.
+Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice landed in PR #8880. The stacked follow-up PR implemented cycle context, shared planning/projection, and LiFi SDK isolation. The remaining work is deeper executor and test-fixture decomposition.
 
 ## Bottom Line
 
@@ -14,7 +14,7 @@ The main issue is that important runtime state and side effects are hidden behin
 
 Recommended direction: rearchitect around explicit cycle snapshots, pure-ish planning, typed execution plans, query-oriented tracking state, and small executor modules.
 
-## Implemented In This PR
+## Implemented In PR #8880
 
 These slices directly target cycle latency and failure visibility without changing external config shape.
 
@@ -39,20 +39,46 @@ These slices directly target cycle latency and failure visibility without changi
 - Executor throws now return failed route results for attempted routes rather than silently producing an empty result set.
 - Benefit: slow metrics work and partial tracker-source failures do not stall the whole cycle, and failed execution paths are visible in cycle accounting.
 
-## Follow-Up Stacked Draft PR TODOs
+## Implemented In This Stacked PR
 
-Use this as the TODO list for the next draft PR on top of this one. Keep the north star performance, but use the larger module split to make future performance work safer.
+These slices improve modularity and remove performance blockers from hidden mutable state and global SDK constraints.
 
-- [ ] Add explicit `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`.
-- [ ] Remove inventory state injection through `InventoryRebalancer.setInventoryBalances()` by passing cycle context into executors.
-- [ ] Normalize config into a resolved route execution matrix so strategies do not perform bridge/execution config lookups.
-- [ ] Move pending-transfer, pending-rebalance, and proposed-route projection into a shared `BalanceProjector`.
-- [ ] Introduce `StrategyPlanner` and centralize route materialization/filtering after strategy evaluation.
+### Slice 4: Explicit Cycle Context And Execution Status
+
+- Added `RebalanceCycleContext` for balances, inventory balances, and confirmed block tags.
+- Added `ExecutionSummary` and `CycleResult.status` so route failures and executor-level errors are surfaced as `success`, `partial`, or `failed`.
+- The orchestrator now passes cycle context into rebalancers and no longer imports/casts to `InventoryRebalancer` to inject inventory balances.
+- Benefit: execution accounting is explicit and testable, and inventory execution no longer depends on an orchestrator side channel.
+
+### Slice 5: Shared Balance Projection And Route Planning
+
+- Added `BalanceProjector` for pending transfers, pending rebalances, and proposed route projection.
+- Added `RoutePlanner` helpers to centralize route materialization from surplus/deficit deltas and the resolved route execution matrix.
+- Normalized bridge config into `RouteExecutionMatrix` so route execution config is resolved once instead of repeatedly merged with late non-null assertions.
+- Benefit: strategy evaluation does less repeated config work, planning behavior is easier to unit test, and future strategy changes can target deltas instead of executable route construction.
+
+### Slice 6: LiFi SDK Runner And Provider-Scope Locks
+
+- Wrapped LiFi SDK calls and REST fetch behind an injected `LiFiSdkRunner`.
+- Made execution locking follow the runner's provider scope: the default global LiFi SDK runner remains globally serialized, while injected scoped runners can serialize by source protocol and source chain.
+- Tests now use deterministic runner fakes for quote/status/execution behavior instead of mutating global fetch or relying on SDK internals.
+- Benefit: SDK global state is isolated behind a narrow seam, default execution avoids provider clobbering races, scoped runners can unlock safe source-chain concurrency, and bridge tests are faster and less brittle.
+
+## Remaining Follow-Up TODOs
+
+Keep the north star performance, but use the larger module split to make future performance work safer.
+
+- [x] Add explicit `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`.
+- [x] Remove inventory state injection through `InventoryRebalancer.setInventoryBalances()` by passing cycle context into executors.
+- [x] Normalize config into a resolved route execution matrix so strategies do not perform bridge/execution config lookups.
+- [x] Move pending-transfer, pending-rebalance, and proposed-route projection into a shared `BalanceProjector`.
+- [x] Introduce shared route planning and centralize route materialization after strategy evaluation.
+- [ ] Move route filtering and metrics emission out of `BaseStrategy` into a dedicated `StrategyPlanner`.
 - [ ] Split movable collateral execution into route validation, transaction preparation, chain transaction execution, and result recording modules.
 - [ ] Split inventory execution into intent resolution, inventory planning, bridge capacity estimation, movement execution, and `transferRemote` execution modules.
-- [ ] Wrap LiFi SDK/global state behind an injected client/runner and narrow the execution lock to the actual signer/source-chain constraint.
+- [x] Wrap LiFi SDK/global state behind an injected client/runner and make execution locking follow the runner's provider-state scope.
 - [ ] Replace route-specific e2e deployment managers with a declarative fixture builder and shared deploy/enroll/seed helpers.
-- [ ] Add deterministic unit fakes for external bridges separate from local integration bridge adapters.
+- [x] Add deterministic unit fakes for LiFi execution/status behavior separate from local integration bridge adapters.
 
 ## Current Shape
 

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { pino } from 'pino';
 
-import type { LiFiStep } from '@lifi/sdk';
+import type { LiFiStep, Route, RouteExtended, StatusResponse } from '@lifi/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
 import type {
@@ -9,7 +9,7 @@ import type {
   BridgeQuoteParams,
   ExternalBridgeConfig,
 } from '../interfaces/IExternalBridge.js';
-import { LiFiBridge } from './LiFiBridge.js';
+import { LiFiBridge, type LiFiSdkRunner } from './LiFiBridge.js';
 
 const testLogger = pino({ level: 'silent' });
 
@@ -226,6 +226,55 @@ const VALIDATION_PATTERNS = [
 
 function isValidationError(msg: string): boolean {
   return VALIDATION_PATTERNS.some((pattern) => pattern.test(msg));
+}
+
+const NOT_FOUND_STATUS = {
+  status: 'NOT_FOUND',
+  tool: 'across',
+  sending: {},
+  receiving: {},
+} as StatusResponse;
+
+function createTestRunner(
+  overrides: Partial<LiFiSdkRunner> = {},
+): LiFiSdkRunner {
+  return {
+    providerScope: 'global',
+    createConfig: () => undefined,
+    setProviders: () => undefined,
+    getQuote: async () => createLiFiStep(),
+    convertQuoteToRoute: (quote: LiFiStep) =>
+      ({
+        id: quote.id,
+        fromChainId: quote.action.fromChainId,
+        toChainId: quote.action.toChainId,
+        fromToken: quote.action.fromToken,
+        toToken: quote.action.toToken,
+        fromAddress: quote.action.fromAddress,
+        toAddress: quote.action.toAddress,
+        fromAmount: quote.action.fromAmount,
+        toAmount: quote.estimate.toAmount,
+        steps: [quote],
+      }) as Route,
+    executeRoute: async (route: Route) =>
+      ({
+        steps: [
+          {
+            execution: {
+              process: [{ txHash: `0x${route.fromChainId.toString(16)}` }],
+            },
+          },
+        ],
+      }) as RouteExtended,
+    getStatus: async () => NOT_FOUND_STATUS,
+    fetch: async () =>
+      ({
+        ok: true,
+        json: async () => createLiFiStep(),
+        text: async () => '',
+      }) as Response,
+    ...overrides,
+  };
 }
 
 describe('LiFiBridge.execute() route validation', function () {
@@ -618,38 +667,39 @@ describe('LiFiBridge.quote() routing policy', function () {
   });
 
   it('should use RECOMMENDED order for reverse toAmount quotes', async () => {
-    const originalFetch = globalThis.fetch;
     let requestUrl = '';
 
-    globalThis.fetch = (async (input: URL | RequestInfo) => {
-      requestUrl = String(input);
-      return {
-        ok: true,
-        json: async () =>
-          createLiFiStep({
-            toChainId: 1151111081099710,
-            toAmount: '5000000000',
-          }),
-      } as Response;
-    }) as typeof fetch;
+    bridge = new LiFiBridge(
+      BRIDGE_CONFIG,
+      testLogger,
+      createTestRunner({
+        fetch: async (input: string) => {
+          requestUrl = input;
+          return {
+            ok: true,
+            json: async () =>
+              createLiFiStep({
+                toChainId: 1151111081099710,
+                toAmount: '5000000000',
+              }),
+          } as Response;
+        },
+      }),
+    );
 
-    try {
-      const quote = await bridge.quote({
-        fromChain: 42161,
-        toChain: 1151111081099710,
-        fromToken: TOKEN_ADDR,
-        toToken: TOKEN_ADDR,
-        fromAddress: SENDER_ADDR,
-        toAddress: SENDER_ADDR,
-        toAmount: 5000000000n,
-      });
-      const params = new URL(requestUrl).searchParams;
+    const quote = await bridge.quote({
+      fromChain: 42161,
+      toChain: 1151111081099710,
+      fromToken: TOKEN_ADDR,
+      toToken: TOKEN_ADDR,
+      fromAddress: SENDER_ADDR,
+      toAddress: SENDER_ADDR,
+      toAmount: 5000000000n,
+    });
+    const params = new URL(requestUrl).searchParams;
 
-      expect(params.get('order')).to.equal('RECOMMENDED');
-      expect(quote.requestParams.toAmount).to.equal(5000000000n);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(params.get('order')).to.equal('RECOMMENDED');
+    expect(quote.requestParams.toAmount).to.equal(5000000000n);
   });
 });
 
@@ -661,27 +711,23 @@ describe('LiFiBridge.getStatus()', function () {
   });
 
   it('should translate Hyperlane domain IDs to LiFi chain IDs before SDK status lookup', async () => {
-    const originalFetch = globalThis.fetch;
-    let requestUrl = '';
+    let statusParams: Parameters<LiFiSdkRunner['getStatus']>[0] | undefined;
+    bridge = new LiFiBridge(
+      BRIDGE_CONFIG,
+      testLogger,
+      createTestRunner({
+        getStatus: async (params) => {
+          statusParams = params;
+          return NOT_FOUND_STATUS;
+        },
+      }),
+    );
 
-    globalThis.fetch = (async (input: URL | RequestInfo) => {
-      requestUrl = String(input);
-      return {
-        ok: true,
-        json: async () => ({ status: 'NOT_FOUND' }),
-      } as Response;
-    }) as typeof fetch;
+    const result = await bridge.getStatus('0x1234', 1399811149, 1399811149);
 
-    try {
-      const result = await bridge.getStatus('0x1234', 1399811149, 1399811149);
-      const params = new URL(requestUrl).searchParams;
-
-      expect(result.status).to.equal('not_found');
-      expect(params.get('fromChain')).to.equal('1151111081099710');
-      expect(params.get('toChain')).to.equal('1151111081099710');
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(result.status).to.equal('not_found');
+    expect(statusParams?.fromChain).to.equal(1151111081099710);
+    expect(statusParams?.toChain).to.equal(1151111081099710);
   });
 });
 
@@ -800,6 +846,121 @@ describe('LiFiBridge source protocol handling', function () {
       const msg = (error as Error).message;
       expect(msg).to.equal('expected downstream error');
     }
+  });
+
+  it('serializes all executions for a global provider runner', async () => {
+    const activeByChain = new Map<number, number>();
+    let differentChainRanWhileArbitrumActive = false;
+
+    const bridge = new LiFiBridge(
+      BRIDGE_CONFIG,
+      testLogger,
+      createTestRunner({
+        executeRoute: async (route: Route) => {
+          if (route.fromChainId === 10 && (activeByChain.get(42161) ?? 0) > 0) {
+            differentChainRanWhileArbitrumActive = true;
+          }
+
+          activeByChain.set(
+            route.fromChainId,
+            (activeByChain.get(route.fromChainId) ?? 0) + 1,
+          );
+          await new Promise((resolve) =>
+            setTimeout(resolve, route.fromChainId === 42161 ? 20 : 0),
+          );
+          activeByChain.set(
+            route.fromChainId,
+            (activeByChain.get(route.fromChainId) ?? 1) - 1,
+          );
+
+          return {
+            steps: [
+              {
+                execution: {
+                  process: [{ txHash: `0x${route.fromChainId.toString(16)}` }],
+                },
+              },
+            ],
+          } as RouteExtended;
+        },
+      }),
+    );
+    const arbitrumQuote = createTestQuote();
+    const optimismQuote = createTestQuote(
+      { fromChainId: 10 },
+      { fromChain: 10 },
+    );
+
+    await Promise.all([
+      bridge.execute(arbitrumQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+      bridge.execute(optimismQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    ]);
+
+    expect(differentChainRanWhileArbitrumActive).to.equal(false);
+  });
+
+  it('serializes same-source executions without blocking other source chains for scoped runners', async () => {
+    const activeByChain = new Map<number, number>();
+    let sameChainOverlap = false;
+    let differentChainRanWhileArbitrumActive = false;
+
+    const bridge = new LiFiBridge(
+      BRIDGE_CONFIG,
+      testLogger,
+      createTestRunner({
+        providerScope: 'scoped',
+        executeRoute: async (route: Route) => {
+          const currentActive = activeByChain.get(route.fromChainId) ?? 0;
+          if (currentActive > 0) {
+            sameChainOverlap = true;
+          }
+          if (route.fromChainId === 10 && (activeByChain.get(42161) ?? 0) > 0) {
+            differentChainRanWhileArbitrumActive = true;
+          }
+
+          activeByChain.set(route.fromChainId, currentActive + 1);
+          await new Promise((resolve) =>
+            setTimeout(resolve, route.fromChainId === 42161 ? 20 : 0),
+          );
+          activeByChain.set(route.fromChainId, currentActive);
+
+          return {
+            steps: [
+              {
+                execution: {
+                  process: [{ txHash: `0x${route.fromChainId.toString(16)}` }],
+                },
+              },
+            ],
+          } as RouteExtended;
+        },
+      }),
+    );
+    const firstArbitrumQuote = createTestQuote();
+    const secondArbitrumQuote = createTestQuote();
+    const optimismQuote = createTestQuote(
+      { fromChainId: 10 },
+      { fromChain: 10 },
+    );
+
+    await Promise.all([
+      bridge.execute(firstArbitrumQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+      bridge.execute(secondArbitrumQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+      bridge.execute(optimismQuote, {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      }),
+    ]);
+
+    expect(sameChainOverlap).to.equal(false);
+    expect(differentChainRanWhileArbitrumActive).to.equal(true);
   });
 
   it('addressesEqual keeps Sealevel base58 comparison case-sensitive', () => {

--- a/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.test.ts
@@ -277,6 +277,20 @@ function createTestRunner(
   };
 }
 
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('LiFiBridge.execute() route validation', function () {
   // Allow extra time for tests that pass validation and reach SDK execution
   this.timeout(15000);
@@ -907,6 +921,11 @@ describe('LiFiBridge source protocol handling', function () {
     const activeByChain = new Map<number, number>();
     let sameChainOverlap = false;
     let differentChainRanWhileArbitrumActive = false;
+    let arbitrumExecutionCount = 0;
+    let firstArbitrumReleased = false;
+    const firstArbitrumEntered = deferred();
+    const releaseFirstArbitrum = deferred();
+    const optimismRan = deferred();
 
     const bridge = new LiFiBridge(
       BRIDGE_CONFIG,
@@ -923,9 +942,19 @@ describe('LiFiBridge source protocol handling', function () {
           }
 
           activeByChain.set(route.fromChainId, currentActive + 1);
-          await new Promise((resolve) =>
-            setTimeout(resolve, route.fromChainId === 42161 ? 20 : 0),
-          );
+          if (route.fromChainId === 42161) {
+            arbitrumExecutionCount++;
+            if (arbitrumExecutionCount === 1) {
+              firstArbitrumEntered.resolve();
+              await releaseFirstArbitrum.promise;
+              firstArbitrumReleased = true;
+            } else {
+              expect(firstArbitrumReleased).to.equal(true);
+            }
+          } else {
+            await firstArbitrumEntered.promise;
+            optimismRan.resolve();
+          }
           activeByChain.set(route.fromChainId, currentActive);
 
           return {
@@ -947,7 +976,7 @@ describe('LiFiBridge source protocol handling', function () {
       { fromChain: 10 },
     );
 
-    await Promise.all([
+    const executions = Promise.all([
       bridge.execute(firstArbitrumQuote, {
         [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
       }),
@@ -959,8 +988,54 @@ describe('LiFiBridge source protocol handling', function () {
       }),
     ]);
 
+    await optimismRan.promise;
+    releaseFirstArbitrum.resolve();
+    await executions;
+
     expect(sameChainOverlap).to.equal(false);
     expect(differentChainRanWhileArbitrumActive).to.equal(true);
+  });
+
+  it('releases scoped execution locks after executeRoute rejects', async () => {
+    let attempts = 0;
+    const bridge = new LiFiBridge(
+      BRIDGE_CONFIG,
+      testLogger,
+      createTestRunner({
+        providerScope: 'scoped',
+        executeRoute: async (route: Route) => {
+          attempts++;
+          if (attempts === 1) {
+            throw new Error('route execution failed');
+          }
+          return {
+            steps: [
+              {
+                execution: {
+                  process: [{ txHash: `0x${route.fromChainId.toString(16)}` }],
+                },
+              },
+            ],
+          } as RouteExtended;
+        },
+      }),
+    );
+
+    try {
+      await bridge.execute(createTestQuote(), {
+        [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+      });
+      expect.fail('Expected execute to throw');
+    } catch (error: unknown) {
+      expect((error as Error).message).to.equal('route execution failed');
+    }
+
+    const result = await bridge.execute(createTestQuote(), {
+      [ProtocolType.Ethereum]: TEST_PRIVATE_KEY,
+    });
+
+    expect(result.txHash).to.equal('0xa4b1');
+    expect(attempts).to.equal(2);
   });
 
   it('addressesEqual keeps Sealevel base58 comparison case-sensitive', () => {

--- a/typescript/rebalancer/src/bridges/LiFiBridge.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.ts
@@ -69,6 +69,11 @@ type LiFiProviders = Parameters<typeof lifiConfig.setProviders>[0];
 type LiFiExecuteRouteOptions = Parameters<typeof executeRoute>[1];
 
 export interface LiFiSdkRunner {
+  /**
+   * `scoped` runners must isolate provider state per execution scope before
+   * allowing source-chain concurrency. The default SDK runner mutates global
+   * LiFi provider state and therefore remains globally serialized.
+   */
   providerScope: 'global' | 'scoped';
   createConfig(config: Parameters<typeof createConfig>[0]): void;
   setProviders(providers: LiFiProviders): void;
@@ -86,12 +91,7 @@ const DEFAULT_LIFI_SDK_RUNNER: LiFiSdkRunner = {
   providerScope: 'global',
   createConfig,
   setProviders: (providers) => lifiConfig.setProviders(providers),
-  getQuote: (params) => {
-    if ('toAmount' in params) {
-      return getQuote(params);
-    }
-    return getQuote(params);
-  },
+  getQuote,
   convertQuoteToRoute,
   executeRoute,
   getStatus: (params) => getStatus(params),

--- a/typescript/rebalancer/src/bridges/LiFiBridge.ts
+++ b/typescript/rebalancer/src/bridges/LiFiBridge.ts
@@ -3,8 +3,10 @@ import {
   KeypairWalletAdapter,
   Solana,
   type LiFiStep,
+  type QuoteRequest,
   type Route,
   type RouteExtended,
+  type StatusResponse,
   convertQuoteToRoute,
   createConfig,
   executeRoute,
@@ -61,6 +63,39 @@ const VIEM_CHAINS: Record<number, Chain> = {
  */
 const HYPERLANE_TO_LIFI_CHAIN_IDS: Record<number, number> = {
   1399811149: 1151111081099710, // Solana: Hyperlane domain → LiFi chain ID
+};
+
+type LiFiProviders = Parameters<typeof lifiConfig.setProviders>[0];
+type LiFiExecuteRouteOptions = Parameters<typeof executeRoute>[1];
+
+export interface LiFiSdkRunner {
+  providerScope: 'global' | 'scoped';
+  createConfig(config: Parameters<typeof createConfig>[0]): void;
+  setProviders(providers: LiFiProviders): void;
+  getQuote(params: QuoteRequest): Promise<LiFiStep>;
+  convertQuoteToRoute(quote: LiFiStep): Route;
+  executeRoute(
+    route: Route,
+    options: LiFiExecuteRouteOptions,
+  ): Promise<RouteExtended>;
+  getStatus(params: Parameters<typeof getStatus>[0]): Promise<StatusResponse>;
+  fetch(input: string): Promise<Response>;
+}
+
+const DEFAULT_LIFI_SDK_RUNNER: LiFiSdkRunner = {
+  providerScope: 'global',
+  createConfig,
+  setProviders: (providers) => lifiConfig.setProviders(providers),
+  getQuote: (params) => {
+    if ('toAmount' in params) {
+      return getQuote(params);
+    }
+    return getQuote(params);
+  },
+  convertQuoteToRoute,
+  executeRoute,
+  getStatus: (params) => getStatus(params),
+  fetch: async (input) => fetch(input),
 };
 
 /**
@@ -131,13 +166,19 @@ export class LiFiBridge implements IExternalBridge {
   }
   readonly logger: Logger;
   private initialized = false;
-  private _executeLock: Promise<void> = Promise.resolve();
+  private readonly executeLocks = new Map<string, Promise<void>>();
   private readonly config: ExternalBridgeConfig;
   private readonly chainMetadataByChainId: Map<number, ChainMetadata>;
+  private readonly lifiRunner: LiFiSdkRunner;
 
-  constructor(config: ExternalBridgeConfig, logger: Logger) {
+  constructor(
+    config: ExternalBridgeConfig,
+    logger: Logger,
+    lifiRunner: LiFiSdkRunner = DEFAULT_LIFI_SDK_RUNNER,
+  ) {
     this.config = config;
     this.logger = logger;
+    this.lifiRunner = lifiRunner;
     // Build LiFi chainId -> metadata map for O(1) lookups.
     // Numeric chainIds are only unique for EVM chains; non-EVM chains can
     // legitimately collide (e.g. radix and ethereum both use 1), so index
@@ -171,7 +212,7 @@ export class LiFiBridge implements IExternalBridge {
   private initialize(): void {
     if (this.initialized) return;
 
-    createConfig({
+    this.lifiRunner.createConfig({
       integrator: this.config.integrator,
       apiKey: this.config.apiKey,
     });
@@ -226,7 +267,7 @@ export class LiFiBridge implements IExternalBridge {
     fromChain: number,
     fromRpcUrl: string | undefined,
   ): void {
-    const providers: Parameters<typeof lifiConfig.setProviders>[0] = [];
+    const providers: LiFiProviders = [];
     switch (protocol) {
       case ProtocolType.Ethereum: {
         const account = privateKeyToAccount(ensure0x(key) as `0x${string}`);
@@ -267,7 +308,7 @@ export class LiFiBridge implements IExternalBridge {
         );
     }
 
-    lifiConfig.setProviders(providers);
+    this.lifiRunner.setProviders(providers);
 
     this.logger.debug(
       {
@@ -328,7 +369,7 @@ export class LiFiBridge implements IExternalBridge {
     const lifiFromChain = LiFiBridge.toLiFiChainId(params.fromChain);
     const lifiToChain = LiFiBridge.toLiFiChainId(params.toChain);
 
-    const quote = await getQuote({
+    const quote = await this.lifiRunner.getQuote({
       fromChain: lifiFromChain,
       toChain: lifiToChain,
       fromToken: params.fromToken,
@@ -412,7 +453,7 @@ export class LiFiBridge implements IExternalBridge {
       'Fetching LiFi toAmount quote',
     );
 
-    const response = await fetch(url);
+    const response = await this.lifiRunner.fetch(url);
     if (!response.ok) {
       const errorBody = await response.text();
       throw new Error(
@@ -501,7 +542,7 @@ export class LiFiBridge implements IExternalBridge {
     this.initialize();
 
     // Convert quote to route for execution
-    const route = convertQuoteToRoute(quote.route);
+    const route = this.lifiRunner.convertQuoteToRoute(quote.route);
 
     this.validateRouteAgainstRequest(route, quote.requestParams);
 
@@ -526,51 +567,45 @@ export class LiFiBridge implements IExternalBridge {
     );
 
     const fromRpcUrl = this.getRpcUrlForChainId(fromChain);
-
-    let release!: () => void;
-    const acquired = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const prev = this._executeLock;
-    this._executeLock = acquired;
-    await prev;
+    const signerKey = privateKeys[sourceProtocol];
+    const executeLockKey = this.getExecutionLockKey(sourceProtocol, fromChain);
 
     let txHash: string | undefined;
-    let executedRoute!: RouteExtended;
 
-    try {
-      this.configureLiFiProvider(
-        sourceProtocol,
-        privateKeys[sourceProtocol]!,
-        fromChain,
-        fromRpcUrl,
-      );
+    const executedRoute = await this.withExecutionLock(
+      executeLockKey,
+      async () => {
+        this.configureLiFiProvider(
+          sourceProtocol,
+          signerKey,
+          fromChain,
+          fromRpcUrl,
+        );
 
-      // Execute route with update callbacks
-      executedRoute = await executeRoute(route, {
-        // Update callback for route progress
-        updateRouteHook: (updatedRoute: RouteExtended) => {
-          this.logger.debug(
-            { step: updatedRoute.steps[0]?.id },
-            'Route step updated',
-          );
+        // Execute route with update callbacks
+        return this.lifiRunner.executeRoute(route, {
+          // Update callback for route progress
+          updateRouteHook: (updatedRoute: RouteExtended) => {
+            this.logger.debug(
+              { step: updatedRoute.steps[0]?.id },
+              'Route step updated',
+            );
 
-          // Extract txHash from execution if available (RouteExtended has LiFiStepExtended with execution)
-          const execution = updatedRoute.steps[0]?.execution;
-          if (execution?.process) {
-            for (const process of execution.process) {
-              if (process.txHash) {
-                txHash = process.txHash;
+            // Extract txHash from execution if available (RouteExtended has LiFiStepExtended with execution)
+            const execution = updatedRoute.steps[0]?.execution;
+            if (execution?.process) {
+              for (const process of execution.process) {
+                if (process.txHash) {
+                  txHash = process.txHash;
+                }
               }
             }
-          }
-        },
-        // Auto-accept rate updates for rebalancing
-        acceptExchangeRateUpdateHook: async () => true,
-      });
-    } finally {
-      release();
-    }
+          },
+          // Auto-accept rate updates for rebalancing
+          acceptExchangeRateUpdateHook: async () => true,
+        });
+      },
+    );
 
     // Extract txHash from executed route if not captured in callbacks
     if (!txHash) {
@@ -613,6 +648,39 @@ export class LiFiBridge implements IExternalBridge {
       toChain,
       transferId,
     };
+  }
+
+  private getExecutionLockKey(
+    protocol: ProtocolType,
+    fromChain: number,
+  ): string {
+    if (this.lifiRunner.providerScope === 'global') {
+      return 'global';
+    }
+    return `${protocol}:${fromChain}`;
+  }
+
+  private async withExecutionLock<T>(
+    key: string,
+    execute: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.executeLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    this.executeLocks.set(key, current);
+    await previous;
+
+    try {
+      return await execute();
+    } finally {
+      release();
+      if (this.executeLocks.get(key) === current) {
+        this.executeLocks.delete(key);
+      }
+    }
   }
 
   /**
@@ -698,7 +766,7 @@ export class LiFiBridge implements IExternalBridge {
     this.initialize();
 
     try {
-      const status = await getStatus({
+      const status = await this.lifiRunner.getStatus({
         txHash,
         fromChain: LiFiBridge.toLiFiChainId(fromChain),
         toChain: LiFiBridge.toLiFiChainId(toChain),

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -342,6 +342,40 @@ describe('InventoryRebalancer E2E', () => {
       expect(actionParams.txHash).to.equal('0xTransferRemoteTxHash');
     });
 
+    it('uses inventory balances from cycle context without prior balance setup', async () => {
+      const route = createTestRoute();
+      createTestIntent();
+
+      const localRebalancer = new InventoryRebalancer(
+        config,
+        actionTracker as unknown as IActionTracker,
+        { lifi: bridge as unknown as IExternalBridge },
+        warpCore as unknown as WarpCore,
+        multiProvider as unknown as MultiProvider,
+        testLogger,
+      );
+
+      const results = await localRebalancer.rebalance([route], {
+        balances: {},
+        inventoryBalances: {
+          [SOLANA_CHAIN]: 10000000000n,
+          [ARBITRUM_CHAIN]: 0n,
+        },
+      });
+
+      expect(results).to.have.lengthOf(1);
+      expect(results[0].success).to.be.true;
+      expect(multiProvider.sendTransaction.calledOnce).to.be.true;
+
+      const [chainArg] = multiProvider.sendTransaction.firstCall.args;
+      expect(chainArg).to.equal(SOLANA_CHAIN);
+
+      const actionParams =
+        actionTracker.createRebalanceAction.firstCall.args[0];
+      expect(actionParams.type).to.equal('inventory_deposit');
+      expect(actionParams.amount).to.equal(10000000000n);
+    });
+
     it('executes transferRemote with correct parameters (swapped direction)', async () => {
       const route = createTestRoute({ amount: 5000000000n }); // 5k USDC
       createTestIntent({ amount: 5000000000n });

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -31,6 +31,7 @@ import type {
 import type {
   IInventoryRebalancer,
   InventoryExecutionResult,
+  RebalanceCycleContext,
   RebalancerType,
 } from '../interfaces/IRebalancer.js';
 import type { InventoryRoute } from '../interfaces/IStrategy.js';
@@ -414,7 +415,12 @@ export class InventoryRebalancer implements IInventoryRebalancer {
    */
   async rebalance(
     routes: InventoryRoute[],
+    context?: RebalanceCycleContext,
   ): Promise<InventoryExecutionResult[]> {
+    if (context?.inventoryBalances) {
+      this.setInventoryBalances(context.inventoryBalances);
+    }
+
     this.consumedInventory.clear();
 
     // 1. Check for existing in_progress intent

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -230,6 +230,7 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(0);
       expect(result.executedCount).to.equal(0);
       expect(result.failedCount).to.equal(0);
@@ -289,10 +290,8 @@ describe('RebalancerOrchestrator', () => {
             bridge: TEST_ADDRESSES.bridge,
           },
           success: true,
-          messageId:
-            '0x1111111111111111111111111111111111111111111111111111111111111111',
-          txHash:
-            '0x2222222222222222222222222222222222222222222222222222222222222222',
+          messageId: 'test-message-id-success',
+          txHash: 'test-tx-hash-success',
         },
       ]);
 
@@ -314,6 +313,7 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(1);
       expect(result.executedCount).to.equal(1);
       expect(result.failedCount).to.equal(0);
@@ -364,8 +364,69 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('failed');
       expect(result.proposedRoutes).to.have.lengthOf(1);
       expect(result.executedCount).to.equal(0);
+      expect(result.failedCount).to.equal(1);
+    });
+
+    it('should report partial status for mixed movable collateral results', async () => {
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([
+        {
+          origin: 'ethereum',
+          destination: 'arbitrum',
+          amount: 1000n,
+          bridge: TEST_ADDRESSES.bridge,
+          executionType: 'movableCollateral',
+        },
+        {
+          origin: 'arbitrum',
+          destination: 'ethereum',
+          amount: 500n,
+          bridge: TEST_ADDRESSES.bridge,
+          executionType: 'movableCollateral',
+        },
+      ]);
+
+      const rebalancer = createMockRebalancer();
+      rebalancer.rebalance.resolves([
+        {
+          route: {
+            origin: 'ethereum',
+            destination: 'arbitrum',
+            amount: 1000n,
+            bridge: TEST_ADDRESSES.bridge,
+          },
+          success: true,
+          messageId: 'test-message-id-success',
+          txHash: 'test-tx-hash-success',
+        },
+        {
+          route: {
+            origin: 'arbitrum',
+            destination: 'ethereum',
+            amount: 500n,
+            bridge: TEST_ADDRESSES.bridge,
+          },
+          success: false,
+          error: 'Gas estimation failed',
+        },
+      ]);
+
+      const orchestrator = new RebalancerOrchestrator({
+        strategy,
+        rebalancers: [rebalancer],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+      });
+
+      const result = await orchestrator.executeCycle(createMonitorEvent());
+
+      expect(result.status).to.equal('partial');
+      expect(result.executedCount).to.equal(1);
       expect(result.failedCount).to.equal(1);
     });
 
@@ -403,6 +464,7 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('failed');
       expect(result.executedCount).to.equal(0);
       expect(result.failedCount).to.equal(1);
       expect((metrics.recordRebalancerFailure as Sinon.SinonStub).calledOnce).to
@@ -471,12 +533,22 @@ describe('RebalancerOrchestrator', () => {
       };
 
       const orchestrator = new RebalancerOrchestrator(deps);
-      const event = createMonitorEvent();
+      const inventoryBalances = {
+        ethereum: 2000n,
+        arbitrum: 1000n,
+      };
+      const event = createMonitorEvent({ inventoryBalances });
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(1);
       expect(inventoryRebalancer.rebalance.calledOnce).to.be.true;
+      expect(inventoryRebalancer.setInventoryBalances.called).to.be.false;
+      expect(inventoryRebalancer.rebalance.firstCall.args[1]).to.deep.include({
+        inventoryBalances,
+        confirmedBlockTags: event.confirmedBlockTags,
+      });
     });
   });
 
@@ -573,6 +645,7 @@ describe('RebalancerOrchestrator', () => {
 
       const result = await orchestrator.executeCycle(event);
 
+      expect(result.status).to.equal('success');
       expect(result.proposedRoutes).to.have.lengthOf(2);
       expect(result.executedCount).to.equal(1);
       expect(result.failedCount).to.equal(0);
@@ -625,12 +698,21 @@ describe('RebalancerOrchestrator', () => {
       };
 
       const orchestrator = new RebalancerOrchestrator(deps);
-      const event = createMonitorEvent();
+      const inventoryBalances = {
+        ethereum: 2000n,
+        arbitrum: 1000n,
+      };
+      const event = createMonitorEvent({ inventoryBalances });
 
       await orchestrator.executeCycle(event);
 
       expect(inventoryRebalancer.rebalance.calledOnce).to.be.true;
       expect(inventoryRebalancer.rebalance.calledWith([])).to.be.true;
+      expect(inventoryRebalancer.setInventoryBalances.called).to.be.false;
+      expect(inventoryRebalancer.rebalance.firstCall.args[1]).to.deep.include({
+        inventoryBalances,
+        confirmedBlockTags: event.confirmedBlockTags,
+      });
     });
 
     it('should NOT call inventoryRebalancer.rebalance([]) when routes are proposed', async () => {

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -11,7 +11,11 @@ import {
 } from '../config/types.js';
 import type { IExternalBridge } from '../interfaces/IExternalBridge.js';
 import { MonitorEventType } from '../interfaces/IMonitor.js';
-import type { IRebalancer } from '../interfaces/IRebalancer.js';
+import type {
+  ExecutionResult,
+  ExecutionSummary,
+  IRebalancer,
+} from '../interfaces/IRebalancer.js';
 import type { IStrategy } from '../interfaces/IStrategy.js';
 import { Metrics } from '../metrics/Metrics.js';
 import { TEST_ADDRESSES, getTestAddress } from '../test/helpers.js';
@@ -151,6 +155,14 @@ function createMockBridge(): IExternalBridge {
   } as unknown as IExternalBridge;
 }
 
+type ExecutionSummaryTester = {
+  createExecutionSummary(
+    results: ExecutionResult[],
+    systemErrors?: string[],
+  ): ExecutionSummary;
+  mergeExecutionSummaries(summaries: ExecutionSummary[]): ExecutionSummary;
+};
+
 function createMockMetrics(): Metrics {
   return {
     recordRebalancerSuccess: Sinon.stub(),
@@ -206,6 +218,66 @@ describe('RebalancerOrchestrator', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('execution summary status', () => {
+    function createSummaryTester(): ExecutionSummaryTester {
+      const deps: RebalancerOrchestratorDeps = {
+        strategy: createMockStrategy(),
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        rebalancers: [],
+      };
+      return new RebalancerOrchestrator(
+        deps,
+      ) as unknown as ExecutionSummaryTester;
+    }
+
+    const successfulResult: ExecutionResult = {
+      route: {
+        origin: 'ethereum',
+        destination: 'arbitrum',
+        amount: 1000n,
+      },
+      success: true,
+    };
+    const failedResult: ExecutionResult = {
+      ...successfulResult,
+      success: false,
+      error: 'failed',
+    };
+
+    it('should fail empty summaries with system errors', () => {
+      const summary = createSummaryTester().createExecutionSummary(
+        [],
+        ['executor failed'],
+      );
+
+      expect(summary.status).to.equal('failed');
+      expect(summary.systemErrors).to.deep.equal(['executor failed']);
+    });
+
+    it('should mark successful results with system errors as partial', () => {
+      const summary = createSummaryTester().createExecutionSummary(
+        [successfulResult],
+        ['inventory failed'],
+      );
+
+      expect(summary.status).to.equal('partial');
+    });
+
+    it('should merge success and failure summaries as partial', () => {
+      const tester = createSummaryTester();
+      const summary = tester.mergeExecutionSummaries([
+        tester.createExecutionSummary([successfulResult]),
+        tester.createExecutionSummary([failedResult]),
+      ]);
+
+      expect(summary.status).to.equal('partial');
+      expect(summary.results).to.deep.equal([successfulResult, failedResult]);
+    });
   });
 
   describe('executeCycle() - No Routes', () => {

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -550,6 +550,66 @@ describe('RebalancerOrchestrator', () => {
         confirmedBlockTags: event.confirmedBlockTags,
       });
     });
+
+    it('should report failed status when inventory executor throws', async () => {
+      const config: RebalancerConfig = {
+        warpRouteId: 'TEST/route',
+        strategyConfig: [
+          {
+            rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+            chains: {
+              ethereum: {
+                bridge: TEST_ADDRESSES.bridge,
+                bridgeMinAcceptedAmount: 0,
+                weighted: { weight: 50n, tolerance: 10n },
+                executionType: ExecutionType.Inventory,
+              },
+              arbitrum: {
+                bridge: TEST_ADDRESSES.bridge,
+                bridgeMinAcceptedAmount: 0,
+                weighted: { weight: 50n, tolerance: 10n },
+              },
+            },
+          },
+        ],
+        intentTTL: DEFAULT_INTENT_TTL_MS,
+      } as RebalancerConfig;
+
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([
+        {
+          origin: 'ethereum',
+          destination: 'arbitrum',
+          amount: 1000n,
+          externalBridge: 'lifi',
+          executionType: 'inventory',
+        },
+      ]);
+
+      const inventoryRebalancer = createMockInventoryRebalancer();
+      inventoryRebalancer.rebalance.rejects(new Error('Inventory failed'));
+
+      const actionTracker = createMockActionTracker();
+      const inflightAdapter = createMockInflightContextAdapter();
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        rebalancers: [inventoryRebalancer],
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: config,
+        logger: testLogger,
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+
+      const result = await orchestrator.executeCycle(createMonitorEvent());
+
+      expect(result.status).to.equal('failed');
+      expect(result.proposedRoutes).to.have.lengthOf(1);
+      expect(result.executedCount).to.equal(0);
+      expect(result.failedCount).to.equal(0);
+    });
   });
 
   describe('executeCycle() - Mixed Routes', () => {
@@ -651,6 +711,93 @@ describe('RebalancerOrchestrator', () => {
       expect(result.failedCount).to.equal(0);
       expect(rebalancer.rebalance.calledOnce).to.be.true;
       expect(inventoryRebalancer.rebalance.calledOnce).to.be.true;
+    });
+
+    it('should report partial status when movable succeeds and inventory throws', async () => {
+      const config: RebalancerConfig = {
+        warpRouteId: 'TEST/route',
+        strategyConfig: [
+          {
+            rebalanceStrategy: RebalancerStrategyOptions.Weighted,
+            chains: {
+              ethereum: {
+                bridge: TEST_ADDRESSES.bridge,
+                bridgeMinAcceptedAmount: 0,
+                weighted: { weight: 33n, tolerance: 10n },
+              },
+              arbitrum: {
+                bridge: TEST_ADDRESSES.bridge,
+                bridgeMinAcceptedAmount: 0,
+                weighted: { weight: 33n, tolerance: 10n },
+                executionType: ExecutionType.Inventory,
+              },
+              optimism: {
+                bridge: TEST_ADDRESSES.bridge,
+                bridgeMinAcceptedAmount: 0,
+                weighted: { weight: 34n, tolerance: 10n },
+              },
+            },
+          },
+        ],
+        intentTTL: DEFAULT_INTENT_TTL_MS,
+      } as RebalancerConfig;
+
+      const strategy = createMockStrategy();
+      strategy.getRebalancingRoutes.returns([
+        {
+          origin: 'ethereum',
+          destination: 'optimism',
+          amount: 1000n,
+          bridge: TEST_ADDRESSES.bridge,
+          executionType: 'movableCollateral',
+        },
+        {
+          origin: 'arbitrum',
+          destination: 'ethereum',
+          amount: 500n,
+          externalBridge: 'lifi',
+          executionType: 'inventory',
+        },
+      ]);
+
+      const rebalancer = createMockRebalancer();
+      rebalancer.rebalance.resolves([
+        {
+          route: {
+            origin: 'ethereum',
+            destination: 'optimism',
+            amount: 1000n,
+            bridge: TEST_ADDRESSES.bridge,
+          },
+          success: true,
+          messageId: '0x1111',
+          txHash: '0x2222',
+        },
+      ]);
+
+      const inventoryRebalancer = createMockInventoryRebalancer();
+      inventoryRebalancer.rebalance.rejects(new Error('Inventory failed'));
+
+      const actionTracker = createMockActionTracker();
+      const inflightAdapter = createMockInflightContextAdapter();
+
+      const deps: RebalancerOrchestratorDeps = {
+        strategy,
+        rebalancers: [rebalancer, inventoryRebalancer],
+        actionTracker,
+        inflightContextAdapter: inflightAdapter,
+        rebalancerConfig: config,
+        logger: testLogger,
+      };
+
+      const orchestrator = new RebalancerOrchestrator(deps);
+
+      const result = await orchestrator.executeCycle(createMonitorEvent());
+
+      expect(result.status).to.equal('partial');
+      expect(result.proposedRoutes).to.have.lengthOf(2);
+      expect(result.executedCount).to.equal(1);
+      expect(result.failedCount).to.equal(0);
     });
   });
 

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -8,8 +8,11 @@ import {
   type MonitorEvent,
 } from '../interfaces/IMonitor.js';
 import type {
+  ExecutionSummary,
+  ExecutionStatus,
   ExecutionResult,
   IRebalancer,
+  RebalanceCycleContext,
   RebalancerType,
 } from '../interfaces/IRebalancer.js';
 import type { IStrategy, StrategyRoute } from '../interfaces/IStrategy.js';
@@ -21,8 +24,6 @@ import { Metrics } from '../metrics/Metrics.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import { InflightContextAdapter } from '../tracking/InflightContextAdapter.js';
 import { getRawBalances } from '../utils/balanceUtils.js';
-
-import { InventoryRebalancer } from './InventoryRebalancer.js';
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -40,6 +41,8 @@ const METRICS_PROCESS_TOKEN_TIMEOUT_MS = 30_000;
  * executedCount/failedCount: Counts from movable_collateral execution ONLY
  */
 export interface CycleResult {
+  /** Holistic status across all executor summaries. Counts below track movable collateral only. */
+  status: ExecutionStatus;
   balances: Record<string, bigint>;
   proposedRoutes: StrategyRoute[];
   executedCount: number;
@@ -99,6 +102,11 @@ export class RebalancerOrchestrator {
       event,
       this.logger,
     );
+    const context: RebalanceCycleContext = {
+      balances: rawBalances,
+      inventoryBalances: event.inventoryBalances,
+      confirmedBlockTags: event.confirmedBlockTags,
+    };
 
     this.logger.info(
       {
@@ -120,6 +128,7 @@ export class RebalancerOrchestrator {
 
     let executedCount = 0;
     let failedCount = 0;
+    let executionSummary = this.createExecutionSummary([]);
 
     if (strategyRoutes.length > 0) {
       this.logger.info(
@@ -133,21 +142,26 @@ export class RebalancerOrchestrator {
         'Routes proposed',
       );
 
-      const results = await this.executeWithTracking(strategyRoutes, event);
-      executedCount = results.executedCount;
-      failedCount = results.failedCount;
+      const execution = await this.executeWithTracking(strategyRoutes, context);
+      executionSummary = execution.summary;
+      executedCount = execution.executedCount;
+      failedCount = execution.failedCount;
     } else {
       this.logger.info('No rebalancing needed');
     }
 
     const inventoryRebalancer = this.rebalancersByType.get('inventory');
     if (inventoryRebalancer && strategyRoutes.length === 0) {
-      await this.executeRoutes([], inventoryRebalancer, event);
+      executionSummary = this.mergeExecutionSummaries([
+        executionSummary,
+        await this.executeRoutes([], inventoryRebalancer, context),
+      ]);
     }
 
     this.logger.info('Polling cycle completed');
 
     return {
+      status: executionSummary.status,
       balances: rawBalances,
       proposedRoutes: strategyRoutes,
       executedCount,
@@ -306,47 +320,53 @@ export class RebalancerOrchestrator {
 
   private async executeWithTracking(
     routes: StrategyRoute[],
-    event: MonitorEvent,
-  ): Promise<{ executedCount: number; failedCount: number }> {
+    context: RebalanceCycleContext,
+  ): Promise<{
+    summary: ExecutionSummary;
+    executedCount: number;
+    failedCount: number;
+  }> {
     const movableCollateral = routes.filter(isMovableCollateralRoute);
     const inventory = routes.filter(isInventoryRoute);
 
     let executedCount = 0;
     let failedCount = 0;
+    const summaries: ExecutionSummary[] = [];
 
     const movableCollateralRebalancer =
       this.rebalancersByType.get('movableCollateral');
     if (movableCollateral.length > 0 && movableCollateralRebalancer) {
-      const results = await this.executeRoutes(
+      const summary = await this.executeRoutes(
         movableCollateral,
         movableCollateralRebalancer,
-        event,
+        context,
       );
-      executedCount = results.filter((r) => r.success).length;
-      failedCount = results.filter((r) => !r.success).length;
+      summaries.push(summary);
+      executedCount = summary.results.filter((r) => r.success).length;
+      failedCount = summary.results.filter((r) => !r.success).length;
     }
 
     const inventoryRebalancer = this.rebalancersByType.get('inventory');
     if (inventory.length > 0 && inventoryRebalancer) {
-      await this.executeRoutes(inventory, inventoryRebalancer, event);
+      summaries.push(
+        await this.executeRoutes(inventory, inventoryRebalancer, context),
+      );
     }
 
-    return { executedCount, failedCount };
+    return {
+      summary: this.mergeExecutionSummaries(summaries),
+      executedCount,
+      failedCount,
+    };
   }
 
   private async executeRoutes(
     routes: StrategyRoute[],
     rebalancer: IRebalancer,
-    event: MonitorEvent,
-  ): Promise<ExecutionResult[]> {
-    if (rebalancer.rebalancerType === 'inventory' && event.inventoryBalances) {
-      (rebalancer as InventoryRebalancer).setInventoryBalances(
-        event.inventoryBalances,
-      );
-    }
-
+    context: RebalanceCycleContext,
+  ): Promise<ExecutionSummary> {
     try {
-      const results = await rebalancer.rebalance(routes);
+      const results = await rebalancer.rebalance(routes, context);
 
       const successful = results.filter((r) => r.success);
       const failed = results.filter((r) => !r.success);
@@ -378,7 +398,7 @@ export class RebalancerOrchestrator {
         );
       }
 
-      return results;
+      return this.createExecutionSummary(results);
     } catch (error: unknown) {
       if (rebalancer.rebalancerType === 'movableCollateral') {
         this.metrics?.recordRebalancerFailure();
@@ -388,12 +408,36 @@ export class RebalancerOrchestrator {
         { error, type: rebalancer.rebalancerType },
         'Error while executing routes',
       );
-      return routes.map((route) => ({
+      const results = routes.map((route) => ({
         route,
         success: false,
         error: errorMessageString,
         reason: 'executor_error',
       }));
+      return this.createExecutionSummary(results, [errorMessageString]);
     }
+  }
+
+  private createExecutionSummary(
+    results: ExecutionResult[],
+    systemErrors: string[] = [],
+  ): ExecutionSummary {
+    const successfulCount = results.filter((r) => r.success).length;
+    const failedCount = results.filter((r) => !r.success).length;
+    let status: ExecutionStatus = 'success';
+
+    if (failedCount > 0 || systemErrors.length > 0) {
+      status = successfulCount > 0 ? 'partial' : 'failed';
+    }
+
+    return { status, results, systemErrors };
+  }
+
+  private mergeExecutionSummaries(
+    summaries: ExecutionSummary[],
+  ): ExecutionSummary {
+    const results = summaries.flatMap((summary) => summary.results);
+    const systemErrors = summaries.flatMap((summary) => summary.systemErrors);
+    return this.createExecutionSummary(results, systemErrors);
   }
 }

--- a/typescript/rebalancer/src/interfaces/IRebalancer.ts
+++ b/typescript/rebalancer/src/interfaces/IRebalancer.ts
@@ -1,16 +1,26 @@
 import {
+  type ChainMap,
   type EvmMovableCollateralAdapter,
   type IToken,
   type TokenAmount,
 } from '@hyperlane-xyz/sdk';
 
+import type { ConfirmedBlockTags } from './IMonitor.js';
 import {
   type InventoryRoute,
   type MovableCollateralRoute,
+  type RawBalances,
   type Route,
 } from './IStrategy.js';
 
 export type RebalancerType = 'movableCollateral' | 'inventory';
+export type ExecutionStatus = 'success' | 'partial' | 'failed';
+
+export interface RebalanceCycleContext {
+  balances: RawBalances;
+  inventoryBalances?: ChainMap<bigint>;
+  confirmedBlockTags?: ConfirmedBlockTags;
+}
 
 export interface ExecutionResult<R extends Route = Route> {
   route: R;
@@ -31,12 +41,21 @@ export interface InventoryExecutionResult extends ExecutionResult<InventoryRoute
   amountSent?: bigint;
 }
 
+export interface ExecutionSummary<
+  R extends Route = Route,
+  E extends ExecutionResult<R> = ExecutionResult<R>,
+> {
+  status: ExecutionStatus;
+  results: E[];
+  systemErrors: string[];
+}
+
 export interface IRebalancer<
   R extends Route = Route,
   E extends ExecutionResult<R> = ExecutionResult<R>,
 > {
   readonly rebalancerType: RebalancerType;
-  rebalance(routes: R[]): Promise<E[]>;
+  rebalance(routes: R[], context?: RebalanceCycleContext): Promise<E[]>;
 }
 
 export type IMovableCollateralRebalancer = IRebalancer<

--- a/typescript/rebalancer/src/planning/BalanceProjector.test.ts
+++ b/typescript/rebalancer/src/planning/BalanceProjector.test.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+
+import { BalanceProjector } from './BalanceProjector.js';
+
+describe('BalanceProjector', () => {
+  it('reserves destination collateral for pending transfers', () => {
+    const balances = {
+      ethereum: 100n,
+      arbitrum: 50n,
+    };
+
+    const projected = BalanceProjector.reserveCollateral(balances, [
+      { origin: 'ethereum', destination: 'arbitrum', amount: 70n },
+    ]);
+
+    expect(projected).to.deep.equal({
+      ethereum: 100n,
+      arbitrum: -20n,
+    });
+    expect(projected).to.not.equal(balances);
+  });
+
+  it('returns original balances when there is nothing to reserve', () => {
+    const balances = { ethereum: 100n };
+
+    expect(BalanceProjector.reserveCollateral(balances, [])).to.equal(balances);
+  });
+
+  it('simulates movable collateral pending rebalances by adding destination only', () => {
+    const projected = BalanceProjector.simulatePendingRebalances(
+      {
+        ethereum: 100n,
+        arbitrum: 50n,
+      },
+      [{ origin: 'ethereum', destination: 'arbitrum', amount: 25n }],
+    );
+
+    expect(projected).to.deep.equal({
+      ethereum: 100n,
+      arbitrum: 75n,
+    });
+  });
+
+  it('simulates inventory pending rebalances using delivered and awaiting amounts', () => {
+    const projected = BalanceProjector.simulatePendingRebalances(
+      {
+        ethereum: 100n,
+        arbitrum: 50n,
+      },
+      [
+        {
+          origin: 'ethereum',
+          destination: 'arbitrum',
+          amount: 80n,
+          executionMethod: 'inventory',
+          deliveredAmount: 30n,
+          awaitingDeliveryAmount: 20n,
+        },
+      ],
+    );
+
+    expect(projected).to.deep.equal({
+      ethereum: 50n,
+      arbitrum: 80n,
+    });
+  });
+
+  it('does not adjust inventory destination when delivery and awaiting amounts cover the route', () => {
+    const projected = BalanceProjector.simulatePendingRebalances(
+      {
+        ethereum: 100n,
+        arbitrum: 50n,
+      },
+      [
+        {
+          origin: 'ethereum',
+          destination: 'arbitrum',
+          amount: 80n,
+          executionMethod: 'inventory',
+          deliveredAmount: 30n,
+          awaitingDeliveryAmount: 50n,
+        },
+      ],
+    );
+
+    expect(projected).to.deep.equal({
+      ethereum: 50n,
+      arbitrum: 50n,
+    });
+  });
+
+  it('simulates proposed rebalances on origin and destination', () => {
+    const projected = BalanceProjector.simulateProposedRebalances(
+      {
+        ethereum: 100n,
+        arbitrum: 50n,
+      },
+      [{ origin: 'ethereum', destination: 'arbitrum', amount: 25n }],
+    );
+
+    expect(projected).to.deep.equal({
+      ethereum: 75n,
+      arbitrum: 75n,
+    });
+  });
+});

--- a/typescript/rebalancer/src/planning/BalanceProjector.ts
+++ b/typescript/rebalancer/src/planning/BalanceProjector.ts
@@ -1,0 +1,173 @@
+import type { Logger } from 'pino';
+
+import type {
+  RawBalances,
+  Route,
+  RouteWithContext,
+} from '../interfaces/IStrategy.js';
+
+type ProjectionLogger = Pick<Logger, 'debug' | 'info'>;
+
+export class BalanceProjector {
+  static reserveCollateral(
+    rawBalances: RawBalances,
+    pendingTransfers: Route[],
+    logger?: ProjectionLogger,
+    context?: string,
+  ): RawBalances {
+    if (pendingTransfers.length === 0) {
+      return rawBalances;
+    }
+
+    const reserved = { ...rawBalances };
+
+    for (const transfer of pendingTransfers) {
+      const destBalance = reserved[transfer.destination] ?? 0n;
+      reserved[transfer.destination] = destBalance - transfer.amount;
+
+      logger?.debug(
+        {
+          context,
+          destination: transfer.destination,
+          amount: transfer.amount.toString(),
+          newBalance: reserved[transfer.destination].toString(),
+        },
+        'Reserved collateral for pending transfer',
+      );
+    }
+
+    logger?.info(
+      {
+        reservations: pendingTransfers.map((t) => ({
+          destination: t.destination,
+          amount: t.amount.toString(),
+        })),
+      },
+      'Collateral reserved for pending transfers',
+    );
+
+    return reserved;
+  }
+
+  static simulatePendingRebalances(
+    rawBalances: RawBalances,
+    pendingRebalances: RouteWithContext[],
+    logger?: ProjectionLogger,
+    context?: string,
+  ): RawBalances {
+    if (pendingRebalances.length === 0) {
+      return rawBalances;
+    }
+
+    const simulated = { ...rawBalances };
+
+    for (const rebalance of pendingRebalances) {
+      if (rebalance.executionMethod === 'inventory') {
+        const total = rebalance.amount;
+        const delivered = rebalance.deliveredAmount ?? 0n;
+        const awaiting = rebalance.awaitingDeliveryAmount ?? 0n;
+        const destinationAdjustment = total - delivered - awaiting;
+
+        if (destinationAdjustment > 0n) {
+          simulated[rebalance.destination] =
+            (simulated[rebalance.destination] ?? 0n) + destinationAdjustment;
+
+          logger?.debug(
+            {
+              context,
+              destination: rebalance.destination,
+              destinationAdjustment: destinationAdjustment.toString(),
+            },
+            'Simulated inventory rebalance (destination increase for unfulfilled)',
+          );
+        }
+
+        const originAdjustment = total - delivered;
+        if (originAdjustment > 0n) {
+          simulated[rebalance.origin] =
+            (simulated[rebalance.origin] ?? 0n) - originAdjustment;
+
+          logger?.debug(
+            {
+              context,
+              origin: rebalance.origin,
+              originAdjustment: originAdjustment.toString(),
+            },
+            'Simulated inventory rebalance (origin decrease for pending)',
+          );
+        }
+      } else {
+        simulated[rebalance.destination] =
+          (simulated[rebalance.destination] ?? 0n) + rebalance.amount;
+
+        logger?.debug(
+          {
+            context,
+            destination: rebalance.destination,
+            amount: rebalance.amount.toString(),
+          },
+          'Simulated movable collateral rebalance (destination increase)',
+        );
+      }
+    }
+
+    logger?.info(
+      {
+        simulations: pendingRebalances.map((r) => ({
+          from: r.origin,
+          to: r.destination,
+          amount: r.amount.toString(),
+          executionMethod: r.executionMethod ?? 'movable_collateral',
+          deliveredAmount: r.deliveredAmount?.toString() ?? '0',
+          awaitingDeliveryAmount: r.awaitingDeliveryAmount?.toString() ?? '0',
+        })),
+      },
+      'Simulated pending rebalances',
+    );
+
+    return simulated;
+  }
+
+  static simulateProposedRebalances(
+    rawBalances: RawBalances,
+    proposedRebalances: Route[],
+    logger?: ProjectionLogger,
+    context?: string,
+  ): RawBalances {
+    if (proposedRebalances.length === 0) {
+      return rawBalances;
+    }
+
+    const simulated = { ...rawBalances };
+
+    for (const rebalance of proposedRebalances) {
+      simulated[rebalance.origin] =
+        (simulated[rebalance.origin] ?? 0n) - rebalance.amount;
+      simulated[rebalance.destination] =
+        (simulated[rebalance.destination] ?? 0n) + rebalance.amount;
+
+      logger?.debug(
+        {
+          context,
+          origin: rebalance.origin,
+          destination: rebalance.destination,
+          amount: rebalance.amount.toString(),
+        },
+        'Simulated proposed rebalance (origin decrease, destination increase)',
+      );
+    }
+
+    logger?.info(
+      {
+        simulations: proposedRebalances.map((r) => ({
+          from: r.origin,
+          to: r.destination,
+          amount: r.amount.toString(),
+        })),
+      },
+      'Simulated proposed rebalances',
+    );
+
+    return simulated;
+  }
+}

--- a/typescript/rebalancer/src/planning/RoutePlanner.test.ts
+++ b/typescript/rebalancer/src/planning/RoutePlanner.test.ts
@@ -1,0 +1,127 @@
+import { expect } from 'chai';
+
+import { ExternalBridgeType } from '../config/types.js';
+import type { RouteExecutionMatrix } from '../utils/bridgeUtils.js';
+
+import { materializeStrategyRoute, planRoutes } from './RoutePlanner.js';
+
+describe('RoutePlanner', () => {
+  const routeExecutionMatrix: RouteExecutionMatrix = {
+    ethereum: {
+      arbitrum: {
+        executionType: 'movableCollateral',
+        bridge: '0x1111111111111111111111111111111111111111',
+      },
+      optimism: {
+        executionType: 'inventory',
+        externalBridge: ExternalBridgeType.LiFi,
+      },
+    },
+    arbitrum: {
+      ethereum: {
+        executionType: 'movableCollateral',
+        bridge: '0x2222222222222222222222222222222222222222',
+      },
+      optimism: {
+        executionType: 'movableCollateral',
+        bridge: '0x3333333333333333333333333333333333333333',
+      },
+    },
+    optimism: {
+      ethereum: {
+        executionType: 'movableCollateral',
+        bridge: '0x4444444444444444444444444444444444444444',
+      },
+      arbitrum: {
+        executionType: 'movableCollateral',
+        bridge: '0x5555555555555555555555555555555555555555',
+      },
+    },
+  };
+
+  it('materializes movable collateral routes from the matrix', () => {
+    const route = materializeStrategyRoute(
+      routeExecutionMatrix,
+      'ethereum',
+      'arbitrum',
+      10n,
+    );
+
+    expect(route).to.deep.equal({
+      origin: 'ethereum',
+      destination: 'arbitrum',
+      amount: 10n,
+      executionType: 'movableCollateral',
+      bridge: '0x1111111111111111111111111111111111111111',
+    });
+  });
+
+  it('materializes inventory routes from the matrix', () => {
+    const route = materializeStrategyRoute(
+      routeExecutionMatrix,
+      'ethereum',
+      'optimism',
+      10n,
+    );
+
+    expect(route).to.deep.equal({
+      origin: 'ethereum',
+      destination: 'optimism',
+      amount: 10n,
+      executionType: 'inventory',
+      externalBridge: ExternalBridgeType.LiFi,
+    });
+  });
+
+  it('matches surpluses to deficits in order', () => {
+    const routes = planRoutes(
+      [
+        { chain: 'ethereum', amount: 100n },
+        { chain: 'arbitrum', amount: 50n },
+      ],
+      [{ chain: 'optimism', amount: 120n }],
+      routeExecutionMatrix,
+    );
+
+    expect(routes).to.deep.equal([
+      {
+        origin: 'ethereum',
+        destination: 'optimism',
+        amount: 100n,
+        executionType: 'inventory',
+        externalBridge: ExternalBridgeType.LiFi,
+      },
+      {
+        origin: 'arbitrum',
+        destination: 'optimism',
+        amount: 20n,
+        executionType: 'movableCollateral',
+        bridge: '0x3333333333333333333333333333333333333333',
+      },
+    ]);
+  });
+
+  it('skips zero-amount routes while draining exhausted deltas', () => {
+    const routes = planRoutes(
+      [
+        { chain: 'ethereum', amount: 0n },
+        { chain: 'arbitrum', amount: 50n },
+      ],
+      [
+        { chain: 'optimism', amount: 0n },
+        { chain: 'ethereum', amount: 30n },
+      ],
+      routeExecutionMatrix,
+    );
+
+    expect(routes).to.deep.equal([
+      {
+        origin: 'arbitrum',
+        destination: 'ethereum',
+        amount: 30n,
+        executionType: 'movableCollateral',
+        bridge: '0x2222222222222222222222222222222222222222',
+      },
+    ]);
+  });
+});

--- a/typescript/rebalancer/src/planning/RoutePlanner.ts
+++ b/typescript/rebalancer/src/planning/RoutePlanner.ts
@@ -1,0 +1,63 @@
+import type { ChainName } from '@hyperlane-xyz/sdk';
+
+import type { StrategyRoute } from '../interfaces/IStrategy.js';
+import {
+  createStrategyRoute,
+  getRouteExecutionConfig,
+  type RouteExecutionMatrix,
+} from '../utils/bridgeUtils.js';
+
+import type { BalanceDelta } from './types.js';
+
+export function materializeStrategyRoute(
+  routeExecutionMatrix: RouteExecutionMatrix,
+  origin: ChainName,
+  destination: ChainName,
+  amount: bigint,
+): StrategyRoute {
+  return createStrategyRoute(
+    getRouteExecutionConfig(routeExecutionMatrix, origin, destination),
+    origin,
+    destination,
+    amount,
+  );
+}
+
+export function planRoutes(
+  surpluses: BalanceDelta[],
+  deficits: BalanceDelta[],
+  routeExecutionMatrix: RouteExecutionMatrix,
+): StrategyRoute[] {
+  const routes: StrategyRoute[] = [];
+
+  while (deficits.length > 0 && surpluses.length > 0) {
+    const surplus = surpluses[0];
+    const deficit = deficits[0];
+    const transferAmount =
+      surplus.amount > deficit.amount ? deficit.amount : surplus.amount;
+
+    if (transferAmount > 0n) {
+      routes.push(
+        materializeStrategyRoute(
+          routeExecutionMatrix,
+          surplus.chain,
+          deficit.chain,
+          transferAmount,
+        ),
+      );
+    }
+
+    deficit.amount -= transferAmount;
+    surplus.amount -= transferAmount;
+
+    if (deficit.amount <= 0n) {
+      deficits.shift();
+    }
+
+    if (surplus.amount <= 0n) {
+      surpluses.shift();
+    }
+  }
+
+  return routes;
+}

--- a/typescript/rebalancer/src/planning/index.ts
+++ b/typescript/rebalancer/src/planning/index.ts
@@ -1,0 +1,3 @@
+export { BalanceProjector } from './BalanceProjector.js';
+export { materializeStrategyRoute, planRoutes } from './RoutePlanner.js';
+export type { BalanceDelta } from './types.js';

--- a/typescript/rebalancer/src/planning/types.ts
+++ b/typescript/rebalancer/src/planning/types.ts
@@ -1,0 +1,6 @@
+import type { ChainName } from '@hyperlane-xyz/sdk';
+
+export type BalanceDelta = {
+  chain: ChainName;
+  amount: bigint;
+};

--- a/typescript/rebalancer/src/strategy/BaseStrategy.ts
+++ b/typescript/rebalancer/src/strategy/BaseStrategy.ts
@@ -15,9 +15,9 @@ import { BalanceProjector, planRoutes } from '../planning/index.js';
 import type { BalanceDelta } from '../planning/types.js';
 import {
   type BridgeConfig,
+  type BridgeConfigWithOverride,
   getRouteExecutionConfig,
   normalizeRouteExecutionMatrix,
-  type RouteExecutionConfigSource,
   type RouteExecutionMatrix,
 } from '../utils/bridgeUtils.js';
 import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
@@ -38,7 +38,7 @@ export abstract class BaseStrategy implements IStrategy {
   constructor(
     chains: ChainName[],
     logger: Logger,
-    routeExecutionConfig: RouteExecutionConfigSource,
+    routeExecutionConfig: ChainMap<BridgeConfigWithOverride>,
     metrics?: Metrics,
     tokensByChainName?: ChainMap<Token>,
   ) {

--- a/typescript/rebalancer/src/strategy/BaseStrategy.ts
+++ b/typescript/rebalancer/src/strategy/BaseStrategy.ts
@@ -11,15 +11,18 @@ import type {
   StrategyRoute,
 } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
+import { BalanceProjector, planRoutes } from '../planning/index.js';
+import type { BalanceDelta } from '../planning/types.js';
 import {
   type BridgeConfig,
-  type BridgeConfigWithOverride,
-  createStrategyRoute,
-  getBridgeConfig,
+  getRouteExecutionConfig,
+  normalizeRouteExecutionMatrix,
+  type RouteExecutionConfigSource,
+  type RouteExecutionMatrix,
 } from '../utils/bridgeUtils.js';
 import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
 
-export type Delta = { chain: ChainName; amount: bigint };
+export type Delta = BalanceDelta;
 
 /**
  * Base abstract class for rebalancing strategies
@@ -29,13 +32,13 @@ export abstract class BaseStrategy implements IStrategy {
   protected readonly chains: ChainName[];
   protected readonly metrics?: Metrics;
   protected readonly logger: Logger;
-  protected readonly bridgeConfigs: ChainMap<BridgeConfigWithOverride>;
+  protected readonly routeExecutionMatrix: RouteExecutionMatrix;
   protected readonly tokensByChainName?: ChainMap<Token>;
 
   constructor(
     chains: ChainName[],
     logger: Logger,
-    bridgeConfigs: ChainMap<BridgeConfigWithOverride>,
+    routeExecutionConfig: RouteExecutionConfigSource,
     metrics?: Metrics,
     tokensByChainName?: ChainMap<Token>,
   ) {
@@ -45,7 +48,8 @@ export abstract class BaseStrategy implements IStrategy {
     }
     this.chains = chains;
     this.logger = logger;
-    this.bridgeConfigs = bridgeConfigs;
+    this.routeExecutionMatrix =
+      normalizeRouteExecutionMatrix(routeExecutionConfig);
     this.metrics = metrics;
     this.tokensByChainName = tokensByChainName;
   }
@@ -54,7 +58,11 @@ export abstract class BaseStrategy implements IStrategy {
     origin: ChainName,
     destination: ChainName,
   ): BridgeConfig {
-    return getBridgeConfig(this.bridgeConfigs, origin, destination);
+    return getRouteExecutionConfig(
+      this.routeExecutionMatrix,
+      origin,
+      destination,
+    );
   }
 
   /**
@@ -176,50 +184,7 @@ export abstract class BaseStrategy implements IStrategy {
     surpluses.sort((a, b) => (a.amount > b.amount ? -1 : 1));
     deficits.sort((a, b) => (a.amount > b.amount ? -1 : 1));
 
-    const routes: StrategyRoute[] = [];
-
-    // Transfer from surplus to deficit until all deficits are balanced.
-    while (deficits.length > 0 && surpluses.length > 0) {
-      const surplus = surpluses[0];
-      const deficit = deficits[0];
-
-      // Transfers the whole surplus or just the amount to balance the deficit
-      const transferAmount =
-        surplus.amount > deficit.amount ? deficit.amount : surplus.amount;
-
-      // Skip zero-amount routes (can occur after scaling when surpluses < deficits)
-      if (transferAmount > 0n) {
-        // Get bridge config for this route (with destination-specific overrides)
-        const bridgeConfig = this.getBridgeConfigForRoute(
-          surplus.chain,
-          deficit.chain,
-        );
-
-        // Create appropriate route type based on execution type
-        routes.push(
-          createStrategyRoute(
-            bridgeConfig,
-            surplus.chain,
-            deficit.chain,
-            transferAmount,
-          ),
-        );
-      }
-
-      // Decreases the amounts for the following iterations
-      deficit.amount -= transferAmount;
-      surplus.amount -= transferAmount;
-
-      // Removes the deficit if it is fully balanced (including scaled-to-zero)
-      if (deficit.amount <= 0n) {
-        deficits.shift();
-      }
-
-      // Removes the surplus if it has been drained
-      if (surplus.amount <= 0n) {
-        surpluses.shift();
-      }
-    }
+    const routes = planRoutes(surpluses, deficits, this.routeExecutionMatrix);
 
     this.logger.debug(
       {
@@ -309,40 +274,12 @@ export abstract class BaseStrategy implements IStrategy {
     rawBalances: RawBalances,
     pendingTransfers: Route[],
   ): RawBalances {
-    if (pendingTransfers.length === 0) {
-      return rawBalances;
-    }
-
-    const reserved = { ...rawBalances };
-
-    for (const transfer of pendingTransfers) {
-      const destBalance = reserved[transfer.destination] ?? 0n;
-      // Reserve the transfer amount from destination
-      // Allow negative values to indicate collateral deficits
-      reserved[transfer.destination] = destBalance - transfer.amount;
-
-      this.logger.debug(
-        {
-          context: this.constructor.name,
-          destination: transfer.destination,
-          amount: transfer.amount.toString(),
-          newBalance: reserved[transfer.destination].toString(),
-        },
-        'Reserved collateral for pending transfer',
-      );
-    }
-
-    this.logger.info(
-      {
-        reservations: pendingTransfers.map((t) => ({
-          destination: t.destination,
-          amount: t.amount.toString(),
-        })),
-      },
-      'Collateral reserved for pending transfers',
+    return BalanceProjector.reserveCollateral(
+      rawBalances,
+      pendingTransfers,
+      this.logger,
+      this.constructor.name,
     );
-
-    return reserved;
   }
 
   /**
@@ -366,83 +303,12 @@ export abstract class BaseStrategy implements IStrategy {
     rawBalances: RawBalances,
     pendingRebalances: RouteWithContext[],
   ): RawBalances {
-    if (pendingRebalances.length === 0) {
-      return rawBalances;
-    }
-
-    const simulated = { ...rawBalances };
-
-    for (const rebalance of pendingRebalances) {
-      if (rebalance.executionMethod === 'inventory') {
-        // Inventory: simulate eventual final state
-        const total = rebalance.amount;
-        const delivered = rebalance.deliveredAmount ?? 0n;
-        const awaiting = rebalance.awaitingDeliveryAmount ?? 0n;
-
-        // Destination: add unfulfilled amount (total - delivered - awaiting)
-        // This is what's NOT yet reflected in on-chain balance
-        const destinationAdjustment = total - delivered - awaiting;
-        if (destinationAdjustment > 0n) {
-          simulated[rebalance.destination] =
-            (simulated[rebalance.destination] ?? 0n) + destinationAdjustment;
-
-          this.logger.debug(
-            {
-              context: this.constructor.name,
-              destination: rebalance.destination,
-              destinationAdjustment: destinationAdjustment.toString(),
-            },
-            'Simulated inventory rebalance (destination increase for unfulfilled)',
-          );
-        }
-
-        // Origin: subtract pending amount (total - delivered)
-        // This is what WILL decrease when all messages deliver
-        const originAdjustment = total - delivered;
-        if (originAdjustment > 0n) {
-          simulated[rebalance.origin] =
-            (simulated[rebalance.origin] ?? 0n) - originAdjustment;
-
-          this.logger.debug(
-            {
-              context: this.constructor.name,
-              origin: rebalance.origin,
-              originAdjustment: originAdjustment.toString(),
-            },
-            'Simulated inventory rebalance (origin decrease for pending)',
-          );
-        }
-      } else {
-        // Movable collateral: origin already deducted on-chain, add to destination
-        simulated[rebalance.destination] =
-          (simulated[rebalance.destination] ?? 0n) + rebalance.amount;
-
-        this.logger.debug(
-          {
-            context: this.constructor.name,
-            destination: rebalance.destination,
-            amount: rebalance.amount.toString(),
-          },
-          'Simulated movable collateral rebalance (destination increase)',
-        );
-      }
-    }
-
-    this.logger.info(
-      {
-        simulations: pendingRebalances.map((r) => ({
-          from: r.origin,
-          to: r.destination,
-          amount: r.amount.toString(),
-          executionMethod: r.executionMethod ?? 'movable_collateral',
-          deliveredAmount: r.deliveredAmount?.toString() ?? '0',
-          awaitingDeliveryAmount: r.awaitingDeliveryAmount?.toString() ?? '0',
-        })),
-      },
-      'Simulated pending rebalances',
+    return BalanceProjector.simulatePendingRebalances(
+      rawBalances,
+      pendingRebalances,
+      this.logger,
+      this.constructor.name,
     );
-
-    return simulated;
   }
 
   /**
@@ -461,44 +327,12 @@ export abstract class BaseStrategy implements IStrategy {
     rawBalances: RawBalances,
     proposedRebalances: Route[],
   ): RawBalances {
-    if (proposedRebalances.length === 0) {
-      return rawBalances;
-    }
-
-    const simulated = { ...rawBalances };
-
-    for (const rebalance of proposedRebalances) {
-      // Subtract from origin (not yet deducted on-chain)
-      simulated[rebalance.origin] =
-        (simulated[rebalance.origin] ?? 0n) - rebalance.amount;
-
-      // Add to destination
-      simulated[rebalance.destination] =
-        (simulated[rebalance.destination] ?? 0n) + rebalance.amount;
-
-      this.logger.debug(
-        {
-          context: this.constructor.name,
-          origin: rebalance.origin,
-          destination: rebalance.destination,
-          amount: rebalance.amount.toString(),
-        },
-        'Simulated proposed rebalance (origin decrease, destination increase)',
-      );
-    }
-
-    this.logger.info(
-      {
-        simulations: proposedRebalances.map((r) => ({
-          from: r.origin,
-          to: r.destination,
-          amount: r.amount.toString(),
-        })),
-      },
-      'Simulated proposed rebalances',
+    return BalanceProjector.simulateProposedRebalances(
+      rawBalances,
+      proposedRebalances,
+      this.logger,
+      this.constructor.name,
     );
-
-    return simulated;
   }
 
   protected filterRoutes(

--- a/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.test.ts
+++ b/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.test.ts
@@ -291,6 +291,47 @@ describe('CollateralDeficitStrategy', () => {
       expect(result.surpluses).to.have.lengthOf(2); // Both chains have surplus
     });
 
+    it('should simulate proposed rebalances by subtracting origin and adding destination', () => {
+      const config = {
+        [chain1]: { bridge: BRIDGE1, buffer: '1000' },
+        [chain2]: { bridge: BRIDGE2, buffer: '500' },
+      };
+      const bridgeConfigs = extractBridgeConfigs(config);
+
+      const strategy = new CollateralDeficitStrategy(
+        config,
+        tokensByChainName,
+        testLogger,
+        bridgeConfigs,
+      );
+
+      const rawBalances: RawBalances = {
+        [chain1]: -10_000_000n,
+        [chain2]: 20_000_000n,
+      };
+      const proposedRebalances: StrategyRoute[] = [
+        {
+          origin: chain2,
+          destination: chain1,
+          amount: 15_000_000n,
+          executionType: 'movableCollateral',
+          bridge: BRIDGE2,
+        },
+      ];
+
+      const result = strategy['getCategorizedBalances'](
+        rawBalances,
+        [],
+        proposedRebalances,
+      );
+
+      expect(result.deficits).to.have.lengthOf(0);
+      expect(result.surpluses).to.deep.equal([
+        { chain: chain1, amount: 5_000_000n },
+        { chain: chain2, amount: 5_000_000n },
+      ]);
+    });
+
     it('should handle multiple chains with mixed balances', () => {
       const strategy = new CollateralDeficitStrategy(
         {
@@ -440,6 +481,48 @@ describe('CollateralDeficitStrategy', () => {
         expect([chain2, chain3]).to.include(route.origin);
         expect(route.destination).to.equal(chain1);
       });
+    });
+
+    it('should avoid routes already covered by proposed rebalances', () => {
+      const config = {
+        [chain1]: { bridge: BRIDGE1, buffer: '0' },
+        [chain2]: { bridge: BRIDGE2, buffer: '0' },
+      };
+      const bridgeConfigs = extractBridgeConfigs(config);
+      const strategy = new CollateralDeficitStrategy(
+        config,
+        tokensByChainName,
+        testLogger,
+        bridgeConfigs,
+      );
+
+      const routes = strategy.getRebalancingRoutes(
+        {
+          [chain1]: 0n,
+          [chain2]: 10_000_000n,
+        },
+        {
+          pendingTransfers: [
+            {
+              origin: chain2,
+              destination: chain1,
+              amount: 10_000_000n,
+            },
+          ],
+          pendingRebalances: [],
+          proposedRebalances: [
+            {
+              origin: chain2,
+              destination: chain1,
+              amount: 10_000_000n,
+              executionType: 'movableCollateral',
+              bridge: BRIDGE2,
+            },
+          ],
+        },
+      );
+
+      expect(routes).to.deep.equal([]);
     });
   });
 

--- a/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
+++ b/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
@@ -13,9 +13,9 @@ import type {
   StrategyRoute,
 } from '../interfaces/IStrategy.js';
 import { Metrics } from '../metrics/Metrics.js';
+import { planRoutes } from '../planning/index.js';
 import {
   type BridgeConfigWithOverride,
-  createStrategyRoute,
   isInventoryConfig,
   isMovableCollateralConfig,
 } from '../utils/bridgeUtils.js';
@@ -158,6 +158,7 @@ export class CollateralDeficitStrategy extends BaseStrategy {
   ): StrategyRoute[] {
     const pendingRebalances = inflightContext?.pendingRebalances ?? [];
     const pendingTransfers = inflightContext?.pendingTransfers ?? [];
+    const proposedRebalances = inflightContext?.proposedRebalances ?? [];
 
     this.logger.info(
       {
@@ -168,6 +169,7 @@ export class CollateralDeficitStrategy extends BaseStrategy {
         })),
         pendingRebalances: pendingRebalances.length,
         pendingTransfers: pendingTransfers.length,
+        proposedRebalances: proposedRebalances.length,
       },
       'Strategy evaluating',
     );
@@ -185,6 +187,7 @@ export class CollateralDeficitStrategy extends BaseStrategy {
     const { surpluses, deficits } = this.getCategorizedBalances(
       effectiveBalances,
       pendingRebalances,
+      proposedRebalances,
     );
 
     this.logger.debug(
@@ -241,36 +244,7 @@ export class CollateralDeficitStrategy extends BaseStrategy {
     // Sort deficits by amount (largest first)
     deficits.sort((a, b) => (a.amount > b.amount ? -1 : 1));
 
-    const routes: StrategyRoute[] = [];
-
-    // Match surpluses to deficits
-    while (deficits.length > 0 && surpluses.length > 0) {
-      const surplus = surpluses[0];
-      const deficit = deficits[0];
-      const transferAmount =
-        surplus.amount > deficit.amount ? deficit.amount : surplus.amount;
-
-      if (transferAmount > 0n) {
-        const bridgeConfig = this.getBridgeConfigForRoute(
-          surplus.chain,
-          deficit.chain,
-        );
-        routes.push(
-          createStrategyRoute(
-            bridgeConfig,
-            surplus.chain,
-            deficit.chain,
-            transferAmount,
-          ),
-        );
-      }
-
-      deficit.amount -= transferAmount;
-      surplus.amount -= transferAmount;
-
-      if (deficit.amount <= 0n) deficits.shift();
-      if (surplus.amount <= 0n) surpluses.shift();
-    }
+    const routes = planRoutes(surpluses, deficits, this.routeExecutionMatrix);
 
     this.logger.debug(
       { context: this.constructor.name, routes },

--- a/typescript/rebalancer/src/strategy/StrategyFactory.ts
+++ b/typescript/rebalancer/src/strategy/StrategyFactory.ts
@@ -3,16 +3,14 @@ import { type Logger } from 'pino';
 import { type ChainMap, type Token } from '@hyperlane-xyz/sdk';
 
 import {
-  ExecutionType,
   RebalancerStrategyOptions,
   type StrategyConfig,
 } from '../config/types.js';
 import { type IStrategy } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
-import type {
-  BridgeConfigWithOverride,
-  InventoryBridgeConfig,
-  MovableCollateralBridgeConfig,
+import {
+  buildBridgeConfigMapFromConfig,
+  type BridgeConfigWithOverride,
 } from '../utils/bridgeUtils.js';
 
 import { CollateralDeficitStrategy } from './CollateralDeficitStrategy.js';
@@ -123,35 +121,6 @@ export class StrategyFactory {
   private static extractBridgeConfigs(
     strategyConfig: StrategyConfig,
   ): ChainMap<BridgeConfigWithOverride> {
-    const bridgeConfigs: ChainMap<BridgeConfigWithOverride> = {};
-
-    for (const [chain, config] of Object.entries(strategyConfig.chains)) {
-      const baseConfig = {
-        bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount ?? 0,
-      };
-
-      const executionType =
-        config.executionType ?? ExecutionType.MovableCollateral;
-
-      if (executionType === ExecutionType.Inventory) {
-        bridgeConfigs[chain] = {
-          ...baseConfig,
-          executionType: 'inventory',
-          externalBridge: config.externalBridge!, // Validated by config schema
-          override: config.override as ChainMap<Partial<InventoryBridgeConfig>>,
-        };
-      } else {
-        bridgeConfigs[chain] = {
-          ...baseConfig,
-          executionType: 'movableCollateral',
-          bridge: config.bridge!, // Validated by config schema
-          override: config.override as ChainMap<
-            Partial<MovableCollateralBridgeConfig>
-          >,
-        };
-      }
-    }
-
-    return bridgeConfigs;
+    return buildBridgeConfigMapFromConfig(strategyConfig.chains);
   }
 }

--- a/typescript/rebalancer/src/utils/bridgeUtils.test.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.test.ts
@@ -146,6 +146,7 @@ describe('bridgeConfig', () => {
     expect(result.executionType).to.equal(ExecutionType.Inventory);
     assert(isInventoryConfig(result));
     expect(result.externalBridge).to.equal(ExternalBridgeType.LiFi);
+    expect(result.bridgeMinAcceptedAmount).to.equal(0);
   });
 
   it('should allow override to change executionType from movableCollateral to inventory', () => {
@@ -252,7 +253,7 @@ describe('bridgeConfig', () => {
     expect(getRouteExecutionConfig(matrix, 'chain2', 'chain1')).to.deep.equal({
       executionType: 'movableCollateral',
       bridge: '0x0987654321098765432109876543210987654321',
-      bridgeMinAcceptedAmount: undefined,
+      bridgeMinAcceptedAmount: 0,
     });
   });
 
@@ -277,7 +278,7 @@ describe('bridgeConfig', () => {
     expect(getBridgeConfig(configs, 'chain1', 'chain2')).to.deep.equal({
       executionType: 'inventory',
       externalBridge: ExternalBridgeType.LiFi,
-      bridgeMinAcceptedAmount: undefined,
+      bridgeMinAcceptedAmount: 0,
     });
   });
 });

--- a/typescript/rebalancer/src/utils/bridgeUtils.test.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.test.ts
@@ -7,7 +7,7 @@ import { type ChainMap } from '@hyperlane-xyz/sdk';
 import { ExecutionType, ExternalBridgeType } from '../config/types.js';
 import {
   buildBridgeConfigMapFromConfig,
-  buildRouteExecutionMatrixFromConfig,
+  buildRouteExecutionMatrix,
   type BridgeConfigWithOverride,
   getBridgeConfig,
   getRouteExecutionConfig,
@@ -225,7 +225,7 @@ describe('bridgeConfig', () => {
   });
 
   it('should build resolved per-origin/per-destination execution matrix', () => {
-    const matrix = buildRouteExecutionMatrixFromConfig({
+    const configs = buildBridgeConfigMapFromConfig({
       chain1: {
         executionType: ExecutionType.MovableCollateral,
         bridge: '0x1234567890123456789012345678901234567890',
@@ -242,6 +242,7 @@ describe('bridgeConfig', () => {
         bridge: '0x0987654321098765432109876543210987654321',
       },
     });
+    const matrix = buildRouteExecutionMatrix(configs);
 
     expect(getRouteExecutionConfig(matrix, 'chain1', 'chain2')).to.deep.equal({
       executionType: 'inventory',

--- a/typescript/rebalancer/src/utils/bridgeUtils.test.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.test.ts
@@ -6,10 +6,14 @@ import { type ChainMap } from '@hyperlane-xyz/sdk';
 
 import { ExecutionType, ExternalBridgeType } from '../config/types.js';
 import {
+  buildBridgeConfigMapFromConfig,
+  buildRouteExecutionMatrixFromConfig,
   type BridgeConfigWithOverride,
   getBridgeConfig,
+  getRouteExecutionConfig,
   isInventoryConfig,
   isMovableCollateralConfig,
+  resolveRouteExecutionConfig,
 } from './bridgeUtils.js';
 
 describe('bridgeConfig', () => {
@@ -189,5 +193,90 @@ describe('bridgeConfig', () => {
     expect(result.bridge).to.equal(
       '0x1234567890123456789012345678901234567890',
     );
+  });
+
+  it('should resolve movable collateral config without non-null assertions', () => {
+    const result = resolveRouteExecutionConfig({
+      executionType: ExecutionType.MovableCollateral,
+      bridge: '0x1234567890123456789012345678901234567890',
+      bridgeMinAcceptedAmount: 1000,
+    });
+
+    expect(result).to.deep.equal({
+      executionType: 'movableCollateral',
+      bridge: '0x1234567890123456789012345678901234567890',
+      bridgeMinAcceptedAmount: 1000,
+    });
+  });
+
+  it('should resolve inventory config without preserving stale bridge fields', () => {
+    const result = resolveRouteExecutionConfig({
+      executionType: ExecutionType.Inventory,
+      bridge: '0x1234567890123456789012345678901234567890',
+      externalBridge: ExternalBridgeType.LiFi,
+      bridgeMinAcceptedAmount: 1000,
+    });
+
+    expect(result).to.deep.equal({
+      executionType: 'inventory',
+      externalBridge: ExternalBridgeType.LiFi,
+      bridgeMinAcceptedAmount: 1000,
+    });
+  });
+
+  it('should build resolved per-origin/per-destination execution matrix', () => {
+    const matrix = buildRouteExecutionMatrixFromConfig({
+      chain1: {
+        executionType: ExecutionType.MovableCollateral,
+        bridge: '0x1234567890123456789012345678901234567890',
+        bridgeMinAcceptedAmount: 1000,
+        override: {
+          chain2: {
+            executionType: ExecutionType.Inventory,
+            externalBridge: ExternalBridgeType.LiFi,
+          },
+        },
+      },
+      chain2: {
+        executionType: ExecutionType.MovableCollateral,
+        bridge: '0x0987654321098765432109876543210987654321',
+      },
+    });
+
+    expect(getRouteExecutionConfig(matrix, 'chain1', 'chain2')).to.deep.equal({
+      executionType: 'inventory',
+      externalBridge: ExternalBridgeType.LiFi,
+      bridgeMinAcceptedAmount: 1000,
+    });
+    expect(getRouteExecutionConfig(matrix, 'chain2', 'chain1')).to.deep.equal({
+      executionType: 'movableCollateral',
+      bridge: '0x0987654321098765432109876543210987654321',
+      bridgeMinAcceptedAmount: undefined,
+    });
+  });
+
+  it('should build resolved bridge config maps for strategy constructors', () => {
+    const configs = buildBridgeConfigMapFromConfig({
+      chain1: {
+        executionType: ExecutionType.MovableCollateral,
+        bridge: '0x1234567890123456789012345678901234567890',
+        override: {
+          chain2: {
+            executionType: ExecutionType.Inventory,
+            externalBridge: ExternalBridgeType.LiFi,
+          },
+        },
+      },
+      chain2: {
+        executionType: ExecutionType.MovableCollateral,
+        bridge: '0x0987654321098765432109876543210987654321',
+      },
+    });
+
+    expect(getBridgeConfig(configs, 'chain1', 'chain2')).to.deep.equal({
+      executionType: 'inventory',
+      externalBridge: ExternalBridgeType.LiFi,
+      bridgeMinAcceptedAmount: undefined,
+    });
   });
 });

--- a/typescript/rebalancer/src/utils/bridgeUtils.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.ts
@@ -62,7 +62,7 @@ export function resolveRouteExecutionConfig(
     return {
       executionType: 'inventory',
       externalBridge: config.externalBridge,
-      bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount,
+      bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount ?? 0,
     };
   }
 
@@ -70,7 +70,7 @@ export function resolveRouteExecutionConfig(
   return {
     executionType: 'movableCollateral',
     bridge: config.bridge,
-    bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount,
+    bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount ?? 0,
   };
 }
 

--- a/typescript/rebalancer/src/utils/bridgeUtils.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.ts
@@ -1,7 +1,7 @@
 import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
-import type { Address } from '@hyperlane-xyz/utils';
+import { assert, type Address } from '@hyperlane-xyz/utils';
 
-import type { ExternalBridgeType } from '../config/types.js';
+import { ExecutionType, type ExternalBridgeType } from '../config/types.js';
 import type { StrategyRoute } from '../interfaces/IStrategy.js';
 
 type BaseBridgeConfig = {
@@ -38,6 +38,158 @@ export type BridgeConfigWithOverride = BridgeConfig & {
   override?: ChainMap<Partial<BridgeConfig>>;
 };
 
+export type RouteExecutionMatrix = ChainMap<ChainMap<BridgeConfig>>;
+
+export type RouteExecutionConfigInput = BaseBridgeConfig & {
+  executionType?: ExecutionType | BridgeConfig['executionType'];
+  bridge?: Address;
+  externalBridge?: ExternalBridgeType;
+  override?: ChainMap<Partial<RouteExecutionConfigInput>>;
+};
+
+export type RouteExecutionConfigInputMap = ChainMap<RouteExecutionConfigInput>;
+
+export type RouteExecutionConfigSource =
+  | ChainMap<BridgeConfigWithOverride>
+  | RouteExecutionMatrix;
+
+export function isRouteExecutionMatrix(
+  config: RouteExecutionConfigSource,
+): config is RouteExecutionMatrix {
+  const firstValue = Object.values(config)[0];
+  return firstValue !== undefined && !('executionType' in firstValue);
+}
+
+export function resolveRouteExecutionConfig(
+  config: RouteExecutionConfigInput,
+): BridgeConfig {
+  const executionType = config.executionType ?? ExecutionType.MovableCollateral;
+
+  if (executionType === ExecutionType.Inventory) {
+    assert(
+      config.externalBridge,
+      'externalBridge is required for inventory execution',
+    );
+    return {
+      executionType: 'inventory',
+      externalBridge: config.externalBridge,
+      bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount,
+    };
+  }
+
+  assert(config.bridge, 'bridge is required for movableCollateral execution');
+  return {
+    executionType: 'movableCollateral',
+    bridge: config.bridge,
+    bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount,
+  };
+}
+
+export function buildRouteExecutionMatrixFromConfig(
+  chainConfigs: RouteExecutionConfigInputMap,
+): RouteExecutionMatrix {
+  const matrix: RouteExecutionMatrix = {};
+  const chains = Object.keys(chainConfigs);
+
+  for (const origin of chains) {
+    const originConfig = chainConfigs[origin];
+    matrix[origin] = {};
+
+    for (const destination of chains) {
+      if (origin === destination) {
+        continue;
+      }
+
+      const override = originConfig.override?.[destination];
+      matrix[origin][destination] = resolveRouteExecutionConfig({
+        ...originConfig,
+        ...override,
+      });
+    }
+  }
+
+  return matrix;
+}
+
+export function buildBridgeConfigMapFromConfig(
+  chainConfigs: RouteExecutionConfigInputMap,
+): ChainMap<BridgeConfigWithOverride> {
+  const bridgeConfigs: ChainMap<BridgeConfigWithOverride> = {};
+
+  for (const [origin, originConfig] of Object.entries(chainConfigs)) {
+    const override: ChainMap<Partial<BridgeConfig>> = {};
+
+    for (const [destination, destinationOverride] of Object.entries(
+      originConfig.override ?? {},
+    )) {
+      override[destination] = resolveRouteExecutionConfig({
+        ...originConfig,
+        ...destinationOverride,
+      });
+    }
+
+    const resolved = resolveRouteExecutionConfig(originConfig);
+    bridgeConfigs[origin] = {
+      ...resolved,
+      override: Object.keys(override).length > 0 ? override : undefined,
+    };
+  }
+
+  return bridgeConfigs;
+}
+
+export function buildRouteExecutionMatrix(
+  bridges: ChainMap<BridgeConfigWithOverride>,
+  chains = Object.keys(bridges),
+): RouteExecutionMatrix {
+  const matrix: RouteExecutionMatrix = {};
+
+  for (const origin of chains) {
+    const originConfig = bridges[origin];
+    assert(originConfig, `Missing bridge config for chain ${origin}`);
+    matrix[origin] = {};
+
+    for (const destination of chains) {
+      if (origin === destination) {
+        continue;
+      }
+
+      matrix[origin][destination] = getBridgeConfig(
+        bridges,
+        origin,
+        destination,
+      );
+    }
+  }
+
+  return matrix;
+}
+
+export function normalizeRouteExecutionMatrix(
+  config: RouteExecutionConfigSource,
+): RouteExecutionMatrix {
+  if (isRouteExecutionMatrix(config)) {
+    return config;
+  }
+
+  return buildRouteExecutionMatrix(config);
+}
+
+export function getRouteExecutionConfig(
+  matrix: RouteExecutionMatrix,
+  origin: ChainName,
+  destination: ChainName,
+): BridgeConfig {
+  const originMatrix = matrix[origin];
+  assert(originMatrix, `Missing route execution config for origin ${origin}`);
+  const routeConfig = originMatrix[destination];
+  assert(
+    routeConfig,
+    `Missing route execution config for ${origin} -> ${destination}`,
+  );
+  return routeConfig;
+}
+
 /**
  * Gets the bridge configuration for a specific chain pair, applying any overrides
  * @param bridges The map of bridge configurations by chain
@@ -51,13 +203,15 @@ export function getBridgeConfig(
   toChain: ChainName,
 ): BridgeConfig {
   const fromConfig = bridges[fromChain];
+  assert(fromConfig, `Missing bridge config for chain ${fromChain}`);
   const routeSpecificOverrides = fromConfig.override?.[toChain];
 
-  // Create a new object with the properties from bridgeConfig, excluding the overrides property
   const { override: _, ...baseConfig } = fromConfig;
 
-  // Return a new object with the base config and any overrides
-  return { ...baseConfig, ...routeSpecificOverrides } as BridgeConfig;
+  return resolveRouteExecutionConfig({
+    ...baseConfig,
+    ...routeSpecificOverrides,
+  });
 }
 
 /**

--- a/typescript/rebalancer/src/utils/bridgeUtils.ts
+++ b/typescript/rebalancer/src/utils/bridgeUtils.ts
@@ -49,17 +49,6 @@ export type RouteExecutionConfigInput = BaseBridgeConfig & {
 
 export type RouteExecutionConfigInputMap = ChainMap<RouteExecutionConfigInput>;
 
-export type RouteExecutionConfigSource =
-  | ChainMap<BridgeConfigWithOverride>
-  | RouteExecutionMatrix;
-
-export function isRouteExecutionMatrix(
-  config: RouteExecutionConfigSource,
-): config is RouteExecutionMatrix {
-  const firstValue = Object.values(config)[0];
-  return firstValue !== undefined && !('executionType' in firstValue);
-}
-
 export function resolveRouteExecutionConfig(
   config: RouteExecutionConfigInput,
 ): BridgeConfig {
@@ -83,32 +72,6 @@ export function resolveRouteExecutionConfig(
     bridge: config.bridge,
     bridgeMinAcceptedAmount: config.bridgeMinAcceptedAmount,
   };
-}
-
-export function buildRouteExecutionMatrixFromConfig(
-  chainConfigs: RouteExecutionConfigInputMap,
-): RouteExecutionMatrix {
-  const matrix: RouteExecutionMatrix = {};
-  const chains = Object.keys(chainConfigs);
-
-  for (const origin of chains) {
-    const originConfig = chainConfigs[origin];
-    matrix[origin] = {};
-
-    for (const destination of chains) {
-      if (origin === destination) {
-        continue;
-      }
-
-      const override = originConfig.override?.[destination];
-      matrix[origin][destination] = resolveRouteExecutionConfig({
-        ...originConfig,
-        ...override,
-      });
-    }
-  }
-
-  return matrix;
 }
 
 export function buildBridgeConfigMapFromConfig(
@@ -166,12 +129,8 @@ export function buildRouteExecutionMatrix(
 }
 
 export function normalizeRouteExecutionMatrix(
-  config: RouteExecutionConfigSource,
+  config: ChainMap<BridgeConfigWithOverride>,
 ): RouteExecutionMatrix {
-  if (isRouteExecutionMatrix(config)) {
-    return config;
-  }
-
   return buildRouteExecutionMatrix(config);
 }
 


### PR DESCRIPTION
## Summary

Stacked on #8880. This is the second/final implementation PR for `typescript/rebalancer/docs/rebalancer-architecture-review.md`, focused on performance-enabling architecture seams without changing external config shape.

## Slices and Benefits

1. Explicit cycle context and execution status
- Added `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`.
- Passed balances, inventory balances, and confirmed block tags into rebalancers directly.
- Removed the orchestrator's concrete `InventoryRebalancer` cast / `setInventoryBalances` side channel.
- Benefit: cycle execution accounting is explicit, executor failures are visible as `success` / `partial` / `failed`, and inventory execution state is easier to test without hidden orchestrator mutation.

2. Shared balance projection and route planning
- Added `BalanceProjector` for pending transfer, pending rebalance, and proposed-route projection.
- Added route planning/materialization helpers over a resolved `RouteExecutionMatrix`.
- Resolved bridge execution config once instead of repeatedly merging overrides and relying on non-null assertions in strategy setup.
- Benefit: strategy hot paths do less repeated config work, planning behavior has focused unit tests, and future strategy additions can reuse projection/materialization instead of duplicating it.

3. LiFi SDK runner isolation and provider-scope locking
- Wrapped LiFi SDK calls and direct REST fetch behind an injected `LiFiSdkRunner`.
- Kept the default LiFi SDK runner globally serialized because its provider config is global.
- Allowed injected scoped runners to serialize by source protocol/source chain when provider state is not global.
- Benefit: default execution avoids SDK provider clobbering races, tests no longer mutate global fetch/SDK state, and a future truly scoped runner can safely unlock more source-chain concurrency.

4. Documentation/checklist update
- Updated `docs/rebalancer-architecture-review.md` to separate #8880 work, this stacked PR, and remaining executor/test-fixture decomposition TODOs.
- Added a changeset for the rebalancer package.

## Review Notes

- Used subagents for cycle-context and planning/config slices.
- Ran Claude read-only reviews for cycle context, planning/config, and LiFi isolation.
- Addressed Claude's LiFi global-provider race finding by keeping the default SDK runner globally locked and making scoped locking opt-in via runner provider scope.

## Checks

- `pnpm -C typescript/rebalancer build`
- `pnpm -C typescript/rebalancer test` (`404 passing`)
- `pnpm -C typescript/rebalancer exec oxlint -c ../../oxlint.json <touched ts files>`
- `pnpm exec prettier --check <touched docs/changeset/ts files>`
- `git diff --check`
- commit hooks ran successfully
