### PR TITLE
refactor(rebalancer): split strategy and movable execution

### DIFF
--- a/.changeset/rebalancer-strategy-movable-split.md
+++ b/.changeset/rebalancer-strategy-movable-split.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/rebalancer": patch
+---
+
+Split rebalancer strategy finalization and movable collateral execution into dedicated modules so route filtering, intent metrics, validation, transaction preparation, chain execution, and result recording can be tested and optimized independently.

--- a/typescript/rebalancer/docs/rebalancer-architecture-review.md
+++ b/typescript/rebalancer/docs/rebalancer-architecture-review.md
@@ -4,7 +4,7 @@ Date: 2026-06-12
 
 Scope: `typescript/rebalancer` package. Findings are from local code inspection plus three read-only subagent slices covering core runtime, strategy/config, and bridges/tracking/tests.
 
-Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice landed in PR #8880. The stacked follow-up PR implemented cycle context, shared planning/projection, and LiFi SDK isolation. The remaining work is deeper executor and test-fixture decomposition.
+Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice landed in PR #8880. The stacked follow-up PR implemented cycle context, shared planning/projection, and LiFi SDK isolation. The third stacked PR moved strategy finalization and movable execution into dedicated modules. The remaining work is inventory executor and test-fixture decomposition.
 
 ## Bottom Line
 
@@ -64,6 +64,24 @@ These slices improve modularity and remove performance blockers from hidden muta
 - Tests now use deterministic runner fakes for quote/status/execution behavior instead of mutating global fetch or relying on SDK internals.
 - Benefit: SDK global state is isolated behind a narrow seam, default execution avoids provider clobbering races, scoped runners can unlock safe source-chain concurrency, and bridge tests are faster and less brittle.
 
+## Implemented In PR3
+
+These slices finish the strategy planning boundary and split movable collateral execution into smaller execution modules.
+
+### Slice 7: StrategyPlanner Finalization
+
+- Added `StrategyPlanner` to own route filtering against actual balances and `bridgeMinAcceptedAmount`.
+- Moved intent-created metrics emission out of `BaseStrategy`.
+- `BaseStrategy` and `CollateralDeficitStrategy` now generate candidate routes, then delegate finalization to the planner.
+- Benefit: strategy evaluation no longer owns final side effects, making route filtering and metrics behavior unit-testable and reusable across strategy implementations.
+
+### Slice 8: Movable Collateral Execution Modules
+
+- Split movable collateral execution into `MovableRouteValidator`, `MovableTransactionPreparer`, `MovableChainTransactionExecutor`, and `MovableResultRecorder`.
+- Kept `Rebalancer` as the orchestration layer for intent creation, preparation, execution, result recording, metrics, and summary logging.
+- Added focused tests for the extracted modules while preserving existing `Rebalancer` behavior tests.
+- Benefit: validation, transaction preparation, chain execution, and action recording can now be tested and optimized independently without mocking the entire rebalancer monolith.
+
 ## Remaining Follow-Up TODOs
 
 Keep the north star performance, but use the larger module split to make future performance work safer.
@@ -73,8 +91,8 @@ Keep the north star performance, but use the larger module split to make future 
 - [x] Normalize config into a resolved route execution matrix so strategies do not perform bridge/execution config lookups.
 - [x] Move pending-transfer, pending-rebalance, and proposed-route projection into a shared `BalanceProjector`.
 - [x] Introduce shared route planning and centralize route materialization after strategy evaluation.
-- [ ] Move route filtering and metrics emission out of `BaseStrategy` into a dedicated `StrategyPlanner`.
-- [ ] Split movable collateral execution into route validation, transaction preparation, chain transaction execution, and result recording modules.
+- [x] Move route filtering and metrics emission out of `BaseStrategy` into a dedicated `StrategyPlanner`.
+- [x] Split movable collateral execution into route validation, transaction preparation, chain transaction execution, and result recording modules.
 - [ ] Split inventory execution into intent resolution, inventory planning, bridge capacity estimation, movement execution, and `transferRemote` execution modules.
 - [x] Wrap LiFi SDK/global state behind an injected client/runner and make execution locking follow the runner's provider-state scope.
 - [ ] Replace route-specific e2e deployment managers with a declarative fixture builder and shared deploy/enroll/seed helpers.
@@ -85,8 +103,8 @@ Keep the north star performance, but use the larger module split to make future 
 - `RebalancerService` owns lifecycle/setup and delegates daemon events to `RebalancerOrchestrator`.
 - `Monitor` polls confirmed block tags, bridged supply, and inventory balances into `MonitorEvent`.
 - `RebalancerOrchestrator` syncs tracking state, builds raw balances, asks a strategy for routes, and dispatches routes to rebalancers.
-- `BaseStrategy` handles balance reservation, pending/proposed rebalance simulation, surplus/deficit matching, route materialization, filtering, and metrics.
-- `Rebalancer` executes movable-collateral routes end to end.
+- `BaseStrategy` handles balance reservation, pending/proposed rebalance simulation, surplus/deficit matching, and route materialization, then delegates route finalization to `StrategyPlanner`.
+- `Rebalancer` orchestrates movable-collateral execution through route validation, transaction preparation, chain transaction execution, and result recording modules.
 - `InventoryRebalancer` executes inventory routes end to end, including active-intent continuation, bridge planning, external bridge execution, and `transferRemote`.
 - `ActionTracker` owns explorer recovery, delivery checks, TTL/staleness, external bridge status, stores, and projection into inflight context.
 

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -225,6 +225,10 @@ describe('Rebalancer', () => {
       const failureResults = results.filter((r) => !r.success);
       expect(successResults).to.have.lengthOf(1);
       expect(failureResults).to.have.lengthOf(1);
+      expect(successResults[0].route.origin).to.equal('ethereum');
+      expect(successResults[0].route.destination).to.equal('arbitrum');
+      expect(failureResults[0].route.origin).to.equal('optimism');
+      expect(failureResults[0].route.destination).to.equal('arbitrum');
     });
   });
 

--- a/typescript/rebalancer/src/core/Rebalancer.test.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.test.ts
@@ -89,7 +89,7 @@ describe('Rebalancer', () => {
 
       sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([
         {
-          id: '0x1111111111111111111111111111111111111111111111111111111111111111',
+          id: 'test-message-id-success',
         } as any,
       ]);
 
@@ -110,6 +110,49 @@ describe('Rebalancer', () => {
 
       expect(results).to.have.lengthOf(1);
       expect(results[0].success).to.be.true;
+    });
+
+    it('should record rebalance amount metrics for successful routes', async () => {
+      const ctx = createRebalancerTestContext();
+      const metrics = {
+        recordRebalanceAmount: Sinon.stub(),
+        recordActionAttempt: Sinon.stub(),
+      };
+
+      sandbox.stub(HyperlaneCore, 'getDispatchedMessages').returns([
+        {
+          id: 'test-message-id-success',
+        } as any,
+      ]);
+
+      const rebalancer = new Rebalancer(
+        ctx.warpCore,
+        ctx.chainMetadata,
+        ctx.tokensByChainName,
+        ctx.multiProvider as any,
+        createMockActionTracker(),
+        testLogger,
+        metrics as any,
+      );
+
+      const route = buildTestMovableCollateralRoute({
+        origin: 'ethereum',
+        destination: 'arbitrum',
+      });
+
+      await rebalancer.rebalance([route]);
+
+      expect(metrics.recordRebalanceAmount.calledOnce).to.be.true;
+      const [recordedRoute, originTokenAmount] =
+        metrics.recordRebalanceAmount.firstCall.args;
+      expect(recordedRoute).to.include({
+        origin: route.origin,
+        destination: route.destination,
+        amount: route.amount,
+        bridge: route.bridge,
+        executionType: route.executionType,
+      });
+      expect(originTokenAmount.amount).to.equal(route.amount);
     });
 
     it('should return failure results for routes that fail preparation', async () => {

--- a/typescript/rebalancer/src/core/Rebalancer.ts
+++ b/typescript/rebalancer/src/core/Rebalancer.ts
@@ -1,47 +1,38 @@
-import { type PopulatedTransaction, type providers } from 'ethers';
 import { type Logger } from 'pino';
 
 import {
   type ChainMap,
   type ChainMetadata,
-  type ChainName,
-  type EthJsonRpcBlockParameterTag,
-  EvmMovableCollateralAdapter,
-  HyperlaneCore,
-  type InterchainGasQuote,
   type MultiProvider,
   type Token,
   type WarpCore,
 } from '@hyperlane-xyz/sdk';
-import { eqAddress, isNullish, mapAllSettled } from '@hyperlane-xyz/utils';
 
 import type {
   IMovableCollateralRebalancer,
   MovableCollateralExecutionResult,
-  PreparedTransaction,
   RebalancerType,
 } from '../interfaces/IRebalancer.js';
 import { MovableCollateralRoute } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import type { RebalanceIntent } from '../tracking/types.js';
-import {
-  denormalizeToLocal,
-  normalizeToCanonical,
-} from '../utils/balanceUtils.js';
-
-// Internal types with intentId for tracking
-type InternalExecutionResult = MovableCollateralExecutionResult & {
-  intentId: string;
-  canonicalAmount?: bigint;
-  localAmount?: bigint;
-};
-
-type InternalRoute = MovableCollateralRoute & { intentId: string };
+import { denormalizeToLocal } from '../utils/balanceUtils.js';
+import { MovableChainTransactionExecutor } from './movable/ChainTransactionExecutor.js';
+import { MovableResultRecorder } from './movable/ResultRecorder.js';
+import { MovableRouteValidator } from './movable/RouteValidator.js';
+import { MovableTransactionPreparer } from './movable/TransactionPreparer.js';
+import type {
+  MovableInternalExecutionResult,
+  MovableInternalRoute,
+} from './movable/types.js';
 
 export class Rebalancer implements IMovableCollateralRebalancer {
   public readonly rebalancerType: RebalancerType = 'movableCollateral';
   private readonly logger: Logger;
+  private readonly transactionPreparer: MovableTransactionPreparer;
+  private readonly transactionExecutor: MovableChainTransactionExecutor;
+  private readonly resultRecorder: MovableResultRecorder;
 
   constructor(
     private readonly warpCore: WarpCore,
@@ -53,6 +44,32 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     private readonly metrics?: Metrics,
   ) {
     this.logger = logger.child({ class: Rebalancer.name });
+
+    const routeValidator = new MovableRouteValidator(
+      this.warpCore,
+      this.chainMetadata,
+      this.tokensByChainName,
+      this.multiProvider,
+      this.logger,
+    );
+    this.transactionPreparer = new MovableTransactionPreparer(
+      this.warpCore,
+      this.chainMetadata,
+      this.tokensByChainName,
+      routeValidator,
+      this.logger,
+    );
+    this.resultRecorder = new MovableResultRecorder(
+      this.multiProvider,
+      this.actionTracker,
+      this.logger,
+    );
+    this.transactionExecutor = new MovableChainTransactionExecutor(
+      this.multiProvider,
+      this.resultRecorder,
+      this.logger,
+      this.metrics,
+    );
   }
 
   async rebalance(
@@ -75,25 +92,27 @@ export class Rebalancer implements IMovableCollateralRebalancer {
         route: r,
         success: false,
         error: r.bridge ? undefined : 'Missing required bridge address',
-        messageId: '', // Required by MovableCollateralExecutionResult, empty for validation failures
+        messageId: '',
       }));
     }
 
     const intents = await this.createIntents(routes);
 
-    const internalRoutes: InternalRoute[] = routes.map((route, idx) => ({
+    const internalRoutes: MovableInternalRoute[] = routes.map((route, idx) => ({
       ...route,
-      bridge: route.bridge!,
       intentId: intents[idx].id,
     }));
 
     const { preparedTransactions, preparationFailureResults } =
-      await this.prepareTransactions(internalRoutes);
+      await this.transactionPreparer.prepareTransactions(internalRoutes);
 
-    let executionResults: InternalExecutionResult[] = [];
+    let executionResults: MovableInternalExecutionResult[] = [];
 
     if (preparedTransactions.length > 0) {
-      executionResults = await this.executeTransactions(preparedTransactions);
+      executionResults =
+        await this.transactionExecutor.executeTransactions(
+          preparedTransactions,
+        );
     }
 
     const allInternalResults = [
@@ -101,35 +120,11 @@ export class Rebalancer implements IMovableCollateralRebalancer {
       ...executionResults,
     ];
 
-    await this.processResults(allInternalResults);
+    await this.resultRecorder.recordResults(allInternalResults);
+    this.recordMetrics(allInternalResults);
+    this.logSummary(allInternalResults, routes.length);
 
-    const successfulResults = allInternalResults.filter((r) => r.success);
-    if (this.metrics && successfulResults.length > 0) {
-      for (const result of successfulResults) {
-        const token = this.tokensByChainName[result.route.origin];
-        if (token) {
-          this.metrics.recordRebalanceAmount(
-            result.route,
-            token.amount(
-              result.localAmount ??
-                denormalizeToLocal(result.route.amount, token),
-            ),
-          );
-        }
-      }
-    }
-
-    const failures = allInternalResults.filter((r) => !r.success);
-    if (failures.length > 0) {
-      this.logger.error(
-        { failureCount: failures.length, totalRoutes: routes.length },
-        'Some rebalance operations failed.',
-      );
-    } else {
-      this.logger.info('Rebalance successful');
-    }
-
-    return this.toPublicResults(allInternalResults);
+    return this.resultRecorder.toPublicResults(allInternalResults);
   }
 
   private async createIntents(
@@ -148,555 +143,38 @@ export class Rebalancer implements IMovableCollateralRebalancer {
     );
   }
 
-  private async processResults(
-    results: InternalExecutionResult[],
-  ): Promise<void> {
-    for (const result of results) {
-      const intentId = result.intentId;
+  private recordMetrics(results: MovableInternalExecutionResult[]): void {
+    const successfulResults = results.filter((r) => r.success);
+    if (!this.metrics || successfulResults.length === 0) {
+      return;
+    }
 
-      if (result.success && result.messageId) {
-        await this.actionTracker.createRebalanceAction({
-          intentId,
-          origin: this.multiProvider.getDomainId(result.route.origin),
-          destination: this.multiProvider.getDomainId(result.route.destination),
-          amount: result.canonicalAmount ?? result.route.amount,
-          type: 'rebalance_message',
-          messageId: result.messageId,
-          txHash: result.txHash,
-        });
-
-        this.logger.info(
-          {
-            intentId,
-            messageId: result.messageId,
-            txHash: result.txHash,
-            origin: result.route.origin,
-            destination: result.route.destination,
-          },
-          'Rebalance action created successfully',
-        );
-      } else {
-        await this.actionTracker.failRebalanceIntent(intentId);
-
-        this.logger.warn(
-          {
-            intentId,
-            success: result.success,
-            error: result.error,
-            origin: result.route.origin,
-            destination: result.route.destination,
-          },
-          'Rebalance intent marked as failed',
+    for (const result of successfulResults) {
+      const token = this.tokensByChainName[result.route.origin];
+      if (token) {
+        this.metrics.recordRebalanceAmount(
+          result.route,
+          token.amount(
+            result.localAmount ??
+              denormalizeToLocal(result.route.amount, token),
+          ),
         );
       }
     }
   }
 
-  private toPublicResults(
-    internalResults: InternalExecutionResult[],
-  ): MovableCollateralExecutionResult[] {
-    return internalResults.map((internal) => ({
-      route: internal.route,
-      success: internal.success,
-      error: internal.error,
-      messageId: internal.messageId || '', // Ensure messageId is always a string
-      txHash: internal.txHash,
-    }));
-  }
-
-  private async prepareTransactions(routes: InternalRoute[]): Promise<{
-    preparedTransactions: PreparedTransaction[];
-    preparationFailureResults: InternalExecutionResult[];
-  }> {
-    this.logger.info(
-      { numRoutes: routes.length },
-      'Preparing all rebalance transactions.',
-    );
-    const { fulfilled, rejected } = await mapAllSettled(
-      routes,
-      (route) => this.prepareTransaction(route),
-      (_, i) => i,
-    );
-
-    // Filter out null results (validation failures logged internally)
-    const preparedTransactions = Array.from(fulfilled.values()).filter(
-      (tx): tx is PreparedTransaction => !isNullish(tx),
-    );
-
-    // Create failure results for tracking
-    const preparationFailureResults: InternalExecutionResult[] = [];
-    for (const [i, error] of rejected) {
-      preparationFailureResults.push({
-        route: routes[i],
-        intentId: routes[i].intentId,
-        success: false,
-        error: String(error),
-        messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
-      });
-    }
-    // Also track null results (validation failures)
-    Array.from(fulfilled.entries()).forEach(([i, tx]) => {
-      if (isNullish(tx)) {
-        preparationFailureResults.push({
-          route: routes[i],
-          intentId: routes[i].intentId,
-          success: false,
-          error: 'Preparation returned null',
-          messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
-        });
-      }
-    });
-
-    return { preparedTransactions, preparationFailureResults };
-  }
-
-  private async prepareTransaction(
-    route: InternalRoute,
-  ): Promise<PreparedTransaction | null> {
-    const { origin, destination, amount } = route;
-
-    this.logger.info(
-      {
-        origin,
-        destination,
-        amount,
-      },
-      'Preparing transaction for route',
-    );
-
-    // 1. Adapter and permissions validation
-    if (!(await this.validateRoute(route))) {
-      // Errors logged in validateRoute
-      return null;
-    }
-
-    const originToken = this.tokensByChainName[origin];
-    const destinationToken = this.tokensByChainName[destination];
-    const destinationChainMeta = this.chainMetadata[destination];
-    const localAmount = denormalizeToLocal(amount, originToken);
-
-    const originTokenAmount = originToken.amount(localAmount);
-    const decimalFormattedAmount =
-      originTokenAmount.getDecimalFormattedAmount();
-    const originHypAdapter = originToken.getHypAdapter(
-      this.warpCore.multiProvider,
-    ) as EvmMovableCollateralAdapter;
-
-    const { bridge } = route;
-
-    // 2. Get quotes
-    let quotes: InterchainGasQuote[];
-    try {
-      quotes = await originHypAdapter.getRebalanceQuotes(
-        bridge,
-        destinationChainMeta.domainId,
-        destinationToken.addressOrDenom,
-        localAmount,
-      );
-    } catch (error) {
+  private logSummary(
+    results: MovableInternalExecutionResult[],
+    totalRoutes: number,
+  ): void {
+    const failures = results.filter((r) => !r.success);
+    if (failures.length > 0) {
       this.logger.error(
-        {
-          origin,
-          destination,
-          amount: decimalFormattedAmount,
-          tokenName: originToken.name,
-          error,
-        },
-        'Failed to get quotes for route.',
+        { failureCount: failures.length, totalRoutes },
+        'Some rebalance operations failed.',
       );
-      return null;
+    } else {
+      this.logger.info('Rebalance successful');
     }
-
-    // 3. Populate transaction
-    let populatedTx: PopulatedTransaction;
-    try {
-      populatedTx = await originHypAdapter.populateRebalanceTx(
-        destinationChainMeta.domainId,
-        localAmount,
-        bridge,
-        quotes,
-      );
-    } catch (error) {
-      this.logger.error(
-        {
-          origin,
-          destination,
-          amount: decimalFormattedAmount,
-          tokenName: originToken.name,
-          error,
-        },
-        'Failed to populate transaction for route.',
-      );
-      return null;
-    }
-
-    return { populatedTx, route, originTokenAmount };
-  }
-
-  private async validateRoute(route: InternalRoute): Promise<boolean> {
-    const { origin, destination, amount } = route;
-    const originToken = this.tokensByChainName[origin];
-    const destinationToken = this.tokensByChainName[destination];
-    const destinationDomain = this.chainMetadata[destination];
-
-    if (!originToken) {
-      this.logger.error(
-        { origin, destination, amount },
-        'Route validation failed: origin token not found.',
-      );
-      return false;
-    }
-
-    const localAmount = denormalizeToLocal(amount, originToken);
-    const originTokenAmount = originToken.amount(localAmount);
-    const decimalFormattedAmount =
-      originTokenAmount.getDecimalFormattedAmount();
-
-    if (!destinationToken) {
-      this.logger.error(
-        { origin, destination, amount: decimalFormattedAmount },
-        'Route validation failed: destination token not found.',
-      );
-      return false;
-    }
-
-    if (!destinationDomain) {
-      this.logger.error(
-        { origin, destination, amount: decimalFormattedAmount },
-        'Route validation failed: destination domain metadata not found.',
-      );
-      return false;
-    }
-
-    const originHypAdapter = originToken.getHypAdapter(
-      this.warpCore.multiProvider,
-    );
-    if (!(originHypAdapter instanceof EvmMovableCollateralAdapter)) {
-      this.logger.error(
-        {
-          origin,
-          destination,
-          amount: decimalFormattedAmount,
-          tokenName: originToken.name,
-        },
-        'Route validation failed: Origin TokenAdapter is not an EvmHypCollateralAdapter.',
-      );
-      return false;
-    }
-
-    const signer = this.multiProvider.getSigner(origin);
-    const signerAddress = await signer.getAddress();
-    if (!(await originHypAdapter.isRebalancer(signerAddress))) {
-      this.logger.error(
-        {
-          origin,
-          destination,
-          amount: decimalFormattedAmount,
-          tokenName: originToken.name,
-          tokenAddress: originToken.addressOrDenom,
-          signerAddress,
-        },
-        'Route validation failed: Signer is not a rebalancer.',
-      );
-      return false;
-    }
-
-    const allowedDestination = await originHypAdapter.getAllowedDestination(
-      destinationDomain.domainId,
-    );
-    if (!eqAddress(allowedDestination, destinationToken.addressOrDenom)) {
-      this.logger.error(
-        {
-          origin,
-          destination,
-          amount: decimalFormattedAmount,
-          tokenName: originToken.name,
-          tokenAddress: originToken.addressOrDenom,
-          destinationTokenAddress: destinationToken.addressOrDenom,
-          allowedDestinationTokenAddress: allowedDestination,
-        },
-        'Route validation failed: Destination is not allowed.',
-      );
-      return false;
-    }
-
-    const { bridge } = route;
-
-    if (
-      !(await originHypAdapter.isBridgeAllowed(
-        destinationDomain.domainId,
-        bridge,
-      ))
-    ) {
-      this.logger.error(
-        {
-          origin,
-          destination,
-          amount: decimalFormattedAmount,
-          tokenName: originToken.name,
-          tokenAddress: originToken.addressOrDenom,
-          bridgeAddress: bridge,
-        },
-        'Route validation failed: Bridge is not allowed.',
-      );
-      return false;
-    }
-
-    return true;
-  }
-
-  private async executeTransactions(
-    transactions: PreparedTransaction[],
-  ): Promise<InternalExecutionResult[]> {
-    this.logger.info(
-      { numTransactions: transactions.length },
-      'Estimating gas for all prepared transactions.',
-    );
-
-    const results: InternalExecutionResult[] = [];
-
-    // 1. Estimate gas for rebalance transactions
-    const gasEstimateResults = await Promise.allSettled(
-      transactions.map(async (transaction) => {
-        await this.multiProvider.estimateGas(
-          transaction.route.origin,
-          transaction.populatedTx,
-        );
-        return transaction;
-      }),
-    );
-
-    // 2. Filter out failed transactions and track failures
-    const validTransactions: PreparedTransaction[] = [];
-    gasEstimateResults.forEach((result, i) => {
-      if (result.status === 'fulfilled') {
-        validTransactions.push(result.value);
-      } else {
-        const failedTransaction = transactions[i];
-        this.logger.error(
-          {
-            origin: failedTransaction.route.origin,
-            destination: failedTransaction.route.destination,
-            amount:
-              failedTransaction.originTokenAmount.getDecimalFormattedAmount(),
-            tokenName: failedTransaction.originTokenAmount.token.name,
-            error: result.reason,
-          },
-          'Gas estimation failed for route.',
-        );
-        results.push({
-          route: failedTransaction.route,
-          intentId: failedTransaction.route.intentId,
-          success: false,
-          error: `Gas estimation failed: ${String(result.reason)}`,
-          messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
-        });
-      }
-    });
-
-    if (validTransactions.length === 0) {
-      this.logger.info('No transactions to execute after gas estimation.');
-      return results;
-    }
-
-    // 3. Group transactions by origin chain
-    const txsByOrigin = new Map<ChainName, PreparedTransaction[]>();
-    for (const tx of validTransactions) {
-      const origin = tx.route.origin;
-      if (!txsByOrigin.has(origin)) {
-        txsByOrigin.set(origin, []);
-      }
-      txsByOrigin.get(origin)!.push(tx);
-    }
-
-    // 4. Send transactions - parallel across chains, sequential within each chain
-    this.logger.info(
-      {
-        numChains: txsByOrigin.size,
-        numTransactions: validTransactions.length,
-      },
-      'Sending transactions (parallel across chains, sequential within chain).',
-    );
-
-    const chainSendResults = await Promise.allSettled(
-      Array.from(txsByOrigin.entries()).map(([origin, txs]) =>
-        this.sendTransactionsForChain(origin, txs),
-      ),
-    );
-
-    // 5. Collect successful sends and record send failures
-    const successfulSends: Array<{
-      transaction: PreparedTransaction;
-      receipt: providers.TransactionReceipt;
-    }> = [];
-
-    chainSendResults.forEach((chainResult) => {
-      if (chainResult.status === 'fulfilled') {
-        for (const txResult of chainResult.value) {
-          if ('receipt' in txResult) {
-            successfulSends.push(txResult);
-          } else {
-            results.push({
-              route: txResult.transaction.route,
-              intentId: txResult.transaction.route.intentId,
-              success: false,
-              error: `Transaction send failed: ${txResult.error}`,
-              messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
-            });
-            this.metrics?.recordActionAttempt(
-              txResult.transaction.route,
-              false,
-            );
-          }
-        }
-      } else {
-        // This shouldn't happen since sendTransactionsForChain catches errors internally,
-        // but handle it just in case
-        this.logger.error(
-          { error: chainResult.reason },
-          'Unexpected error during chain transaction sending.',
-        );
-      }
-    });
-
-    // 6. Build results from confirmed receipts
-    for (const { transaction, receipt } of successfulSends) {
-      const result = this.buildResult(transaction, receipt);
-      results.push(result);
-      this.metrics?.recordActionAttempt(result.route, result.success);
-    }
-
-    return results;
-  }
-
-  // === Parallel Transaction Sending Methods ===
-
-  /**
-   * Send all transactions for a single origin chain sequentially.
-   * Sequential sending is required to avoid nonce contention when using the same signing key.
-   */
-  private async sendTransactionsForChain(
-    origin: ChainName,
-    transactions: PreparedTransaction[],
-  ): Promise<
-    Array<
-      | {
-          transaction: PreparedTransaction;
-          receipt: providers.TransactionReceipt;
-        }
-      | { transaction: PreparedTransaction; error: string }
-    >
-  > {
-    const results: Array<
-      | {
-          transaction: PreparedTransaction;
-          receipt: providers.TransactionReceipt;
-        }
-      | { transaction: PreparedTransaction; error: string }
-    > = [];
-
-    // Send sequentially to avoid nonce contention
-    for (const transaction of transactions) {
-      try {
-        const decimalFormattedAmount =
-          transaction.originTokenAmount.getDecimalFormattedAmount();
-        const tokenName = transaction.originTokenAmount.token.name;
-
-        const reorgPeriod = this.getReorgPeriod(origin);
-
-        this.logger.info(
-          {
-            origin,
-            destination: transaction.route.destination,
-            amount: decimalFormattedAmount,
-            tokenName,
-            reorgPeriod,
-          },
-          'Sending rebalance transaction and waiting for reorgPeriod confirmations.',
-        );
-
-        const receipt = await this.multiProvider.sendTransaction(
-          origin,
-          transaction.populatedTx,
-          {
-            waitConfirmations: reorgPeriod as
-              | number
-              | EthJsonRpcBlockParameterTag,
-          },
-        );
-
-        this.logger.info(
-          {
-            origin,
-            destination: transaction.route.destination,
-            amount: decimalFormattedAmount,
-            tokenName,
-            txHash: receipt.transactionHash,
-          },
-          'Rebalance transaction confirmed at reorgPeriod depth.',
-        );
-
-        results.push({ transaction, receipt });
-      } catch (error) {
-        this.logger.error(
-          {
-            origin,
-            destination: transaction.route.destination,
-            amount: transaction.originTokenAmount.getDecimalFormattedAmount(),
-            tokenName: transaction.originTokenAmount.token.name,
-            error,
-          },
-          'Transaction send failed for route.',
-        );
-        results.push({ transaction, error: String(error) });
-      }
-    }
-
-    return results;
-  }
-
-  /**
-   * Build the execution result from a confirmed transaction receipt.
-   * Receipt is already confirmed at reorgPeriod depth from sendTransaction.
-   */
-  private buildResult(
-    transaction: PreparedTransaction,
-    receipt: providers.TransactionReceipt,
-  ): InternalExecutionResult {
-    const { origin, destination } = transaction.route;
-    const dispatchedMessages = HyperlaneCore.getDispatchedMessages(receipt);
-
-    if (dispatchedMessages.length === 0) {
-      this.logger.error(
-        { origin, destination, txHash: receipt.transactionHash },
-        'No Dispatch event found in confirmed rebalance receipt',
-      );
-      return {
-        route: transaction.route,
-        intentId: transaction.route.intentId,
-        success: false,
-        error: `Transaction confirmed but no Dispatch event found`,
-        messageId: '', // Required by MovableCollateralExecutionResult, empty for failures
-        txHash: receipt.transactionHash,
-      };
-    }
-
-    return {
-      route: transaction.route,
-      intentId: transaction.route.intentId,
-      success: true,
-      messageId: dispatchedMessages[0].id,
-      txHash: receipt.transactionHash,
-      canonicalAmount: normalizeToCanonical(
-        transaction.originTokenAmount.amount,
-        transaction.originTokenAmount.token,
-      ),
-      localAmount: transaction.originTokenAmount.amount,
-    };
-  }
-
-  private getReorgPeriod(chainName: string): number | string {
-    const metadata = this.multiProvider.getChainMetadata(chainName);
-    return metadata.blocks?.reorgPeriod ?? 32;
   }
 }

--- a/typescript/rebalancer/src/core/movable/ChainTransactionExecutor.ts
+++ b/typescript/rebalancer/src/core/movable/ChainTransactionExecutor.ts
@@ -1,0 +1,213 @@
+import { type providers } from 'ethers';
+import { type Logger } from 'pino';
+
+import {
+  type ChainName,
+  type EthJsonRpcBlockParameterTag,
+  type MultiProvider,
+} from '@hyperlane-xyz/sdk';
+
+import type { PreparedTransaction } from '../../interfaces/IRebalancer.js';
+import type { Metrics } from '../../metrics/Metrics.js';
+import { MovableResultRecorder } from './ResultRecorder.js';
+import type { MovableInternalExecutionResult } from './types.js';
+
+type ChainSendResult =
+  | {
+      transaction: PreparedTransaction;
+      receipt: providers.TransactionReceipt;
+    }
+  | { transaction: PreparedTransaction; error: string };
+
+export class MovableChainTransactionExecutor {
+  constructor(
+    private readonly multiProvider: MultiProvider,
+    private readonly resultRecorder: MovableResultRecorder,
+    private readonly logger: Logger,
+    private readonly metrics?: Metrics,
+  ) {}
+
+  async executeTransactions(
+    transactions: PreparedTransaction[],
+  ): Promise<MovableInternalExecutionResult[]> {
+    this.logger.info(
+      { numTransactions: transactions.length },
+      'Estimating gas for all prepared transactions.',
+    );
+
+    const results: MovableInternalExecutionResult[] = [];
+
+    const gasEstimateResults = await Promise.allSettled(
+      transactions.map(async (transaction) => {
+        await this.multiProvider.estimateGas(
+          transaction.route.origin,
+          transaction.populatedTx,
+        );
+        return transaction;
+      }),
+    );
+
+    const validTransactions: PreparedTransaction[] = [];
+    gasEstimateResults.forEach((result, i) => {
+      if (result.status === 'fulfilled') {
+        validTransactions.push(result.value);
+      } else {
+        const failedTransaction = transactions[i];
+        this.logger.error(
+          {
+            origin: failedTransaction.route.origin,
+            destination: failedTransaction.route.destination,
+            amount:
+              failedTransaction.originTokenAmount.getDecimalFormattedAmount(),
+            tokenName: failedTransaction.originTokenAmount.token.name,
+            error: result.reason,
+          },
+          'Gas estimation failed for route.',
+        );
+        results.push({
+          route: failedTransaction.route,
+          intentId: failedTransaction.route.intentId,
+          success: false,
+          error: `Gas estimation failed: ${String(result.reason)}`,
+          messageId: '',
+        });
+      }
+    });
+
+    if (validTransactions.length === 0) {
+      this.logger.info('No transactions to execute after gas estimation.');
+      return results;
+    }
+
+    const txsByOrigin = new Map<ChainName, PreparedTransaction[]>();
+    for (const tx of validTransactions) {
+      const origin = tx.route.origin;
+      const chainTransactions = txsByOrigin.get(origin) ?? [];
+      chainTransactions.push(tx);
+      txsByOrigin.set(origin, chainTransactions);
+    }
+
+    this.logger.info(
+      {
+        numChains: txsByOrigin.size,
+        numTransactions: validTransactions.length,
+      },
+      'Sending transactions (parallel across chains, sequential within chain).',
+    );
+
+    const chainSendResults = await Promise.allSettled(
+      Array.from(txsByOrigin.entries()).map(([origin, txs]) =>
+        this.sendTransactionsForChain(origin, txs),
+      ),
+    );
+
+    const successfulSends: Array<{
+      transaction: PreparedTransaction;
+      receipt: providers.TransactionReceipt;
+    }> = [];
+
+    chainSendResults.forEach((chainResult) => {
+      if (chainResult.status === 'fulfilled') {
+        for (const txResult of chainResult.value) {
+          if ('receipt' in txResult) {
+            successfulSends.push(txResult);
+          } else {
+            results.push({
+              route: txResult.transaction.route,
+              intentId: txResult.transaction.route.intentId,
+              success: false,
+              error: `Transaction send failed: ${txResult.error}`,
+              messageId: '',
+            });
+            this.metrics?.recordActionAttempt(
+              txResult.transaction.route,
+              false,
+            );
+          }
+        }
+      } else {
+        this.logger.error(
+          { error: chainResult.reason },
+          'Unexpected error during chain transaction sending.',
+        );
+      }
+    });
+
+    for (const { transaction, receipt } of successfulSends) {
+      const result = this.resultRecorder.buildResult(transaction, receipt);
+      results.push(result);
+      this.metrics?.recordActionAttempt(result.route, result.success);
+    }
+
+    return results;
+  }
+
+  async sendTransactionsForChain(
+    origin: ChainName,
+    transactions: PreparedTransaction[],
+  ): Promise<ChainSendResult[]> {
+    const results: ChainSendResult[] = [];
+
+    for (const transaction of transactions) {
+      try {
+        const decimalFormattedAmount =
+          transaction.originTokenAmount.getDecimalFormattedAmount();
+        const tokenName = transaction.originTokenAmount.token.name;
+        const reorgPeriod = this.getReorgPeriod(origin);
+
+        this.logger.info(
+          {
+            origin,
+            destination: transaction.route.destination,
+            amount: decimalFormattedAmount,
+            tokenName,
+            reorgPeriod,
+          },
+          'Sending rebalance transaction and waiting for reorgPeriod confirmations.',
+        );
+
+        const receipt = await this.multiProvider.sendTransaction(
+          origin,
+          transaction.populatedTx,
+          {
+            waitConfirmations: reorgPeriod as
+              | number
+              | EthJsonRpcBlockParameterTag,
+          },
+        );
+
+        this.logger.info(
+          {
+            origin,
+            destination: transaction.route.destination,
+            amount: decimalFormattedAmount,
+            tokenName,
+            txHash: receipt.transactionHash,
+          },
+          'Rebalance transaction confirmed at reorgPeriod depth.',
+        );
+
+        results.push({ transaction, receipt });
+      } catch (error) {
+        this.logger.error(
+          {
+            origin,
+            destination: transaction.route.destination,
+            amount: transaction.originTokenAmount.getDecimalFormattedAmount(),
+            tokenName: transaction.originTokenAmount.token.name,
+            error,
+          },
+          'Transaction send failed for route.',
+        );
+        results.push({ transaction, error: String(error) });
+      }
+    }
+
+    return results;
+  }
+
+  private getReorgPeriod(chainName: string): number | string {
+    const metadata = this.multiProvider.getChainMetadata(chainName);
+    return metadata.blocks?.reorgPeriod ?? 32;
+  }
+}

--- a/typescript/rebalancer/src/core/movable/MovableExecution.test.ts
+++ b/typescript/rebalancer/src/core/movable/MovableExecution.test.ts
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+import { type providers } from 'ethers';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import { HyperlaneCore, type MultiProvider } from '@hyperlane-xyz/sdk';
+
+import type { IActionTracker } from '../../tracking/IActionTracker.js';
+import {
+  buildTestMovableCollateralRoute,
+  buildTestPreparedTransaction,
+  createRebalancerTestContext,
+  TEST_ADDRESSES,
+} from '../../test/helpers.js';
+import { MovableChainTransactionExecutor } from './ChainTransactionExecutor.js';
+import { MovableResultRecorder } from './ResultRecorder.js';
+import { MovableRouteValidator } from './RouteValidator.js';
+import { MovableTransactionPreparer } from './TransactionPreparer.js';
+import type { MovableInternalRoute } from './types.js';
+
+const testLogger = pino({ level: 'silent' });
+
+function buildInternalRoute(
+  overrides: Partial<MovableInternalRoute> = {},
+): MovableInternalRoute {
+  return {
+    ...buildTestMovableCollateralRoute(),
+    intentId: 'intent-1',
+    ...overrides,
+  };
+}
+
+function createActionTrackerStub(): IActionTracker {
+  return {
+    createRebalanceAction: Sinon.stub().resolves(),
+    failRebalanceIntent: Sinon.stub().resolves(),
+  } as unknown as IActionTracker;
+}
+
+describe('movable collateral execution modules', () => {
+  let sandbox: Sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('validates route bridge permission against destination domain', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum'], {
+      ethereum: { isBridgeAllowed: false },
+    });
+    const validator = new MovableRouteValidator(
+      ctx.warpCore,
+      ctx.chainMetadata,
+      ctx.tokensByChainName,
+      ctx.multiProvider as unknown as MultiProvider,
+      testLogger,
+    );
+
+    const isValid = await validator.validate(buildInternalRoute());
+
+    expect(isValid).to.be.false;
+    expect(
+      ctx.adapters.ethereum.isBridgeAllowed.calledOnceWithExactly(
+        ctx.chainMetadata.arbitrum.domainId,
+        TEST_ADDRESSES.bridge,
+      ),
+    ).to.be.true;
+  });
+
+  it('prepares transactions using origin-local denormalized amounts', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+    ctx.tokensByChainName.ethereum.scale = {
+      numerator: 1,
+      denominator: 1_000_000_000_000,
+    };
+    const validator = new MovableRouteValidator(
+      ctx.warpCore,
+      ctx.chainMetadata,
+      ctx.tokensByChainName,
+      ctx.multiProvider as unknown as MultiProvider,
+      testLogger,
+    );
+    const preparer = new MovableTransactionPreparer(
+      ctx.warpCore,
+      ctx.chainMetadata,
+      ctx.tokensByChainName,
+      validator,
+      testLogger,
+    );
+
+    const { preparedTransactions, preparationFailureResults } =
+      await preparer.prepareTransactions([
+        buildInternalRoute({ amount: 1_000_000n }),
+      ]);
+
+    expect(preparationFailureResults).to.deep.equal([]);
+    expect(preparedTransactions).to.have.lengthOf(1);
+    expect(ctx.adapters.ethereum.getRebalanceQuotes.firstCall.args[3]).to.equal(
+      1_000_000_000_000_000_000n,
+    );
+    expect(
+      ctx.adapters.ethereum.populateRebalanceTx.firstCall.args[1],
+    ).to.equal(1_000_000_000_000_000_000n);
+  });
+
+  it('records gas-estimation failures without sending transactions', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+    ctx.multiProvider.estimateGas = Sinon.stub().rejects(
+      new Error('Gas estimation failed'),
+    );
+    const actionTracker = createActionTrackerStub();
+    const resultRecorder = new MovableResultRecorder(
+      ctx.multiProvider as unknown as MultiProvider,
+      actionTracker,
+      testLogger,
+    );
+    const executor = new MovableChainTransactionExecutor(
+      ctx.multiProvider as unknown as MultiProvider,
+      resultRecorder,
+      testLogger,
+    );
+
+    const results = await executor.executeTransactions([
+      buildTestPreparedTransaction(),
+    ]);
+
+    expect(results).to.have.lengthOf(1);
+    expect(results[0].success).to.be.false;
+    expect(results[0].error).to.include('Gas estimation failed');
+    expect((ctx.multiProvider.sendTransaction as Sinon.SinonStub).called).to.be
+      .false;
+  });
+
+  it('builds successful receipt results and records rebalance actions', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+    const actionTracker = createActionTrackerStub();
+    const resultRecorder = new MovableResultRecorder(
+      ctx.multiProvider as unknown as MultiProvider,
+      actionTracker,
+      testLogger,
+    );
+    const messageId = 'test-message-id-success';
+    sandbox
+      .stub(HyperlaneCore, 'getDispatchedMessages')
+      .returns([{ id: messageId }] as ReturnType<
+        typeof HyperlaneCore.getDispatchedMessages
+      >);
+
+    const result = resultRecorder.buildResult(buildTestPreparedTransaction(), {
+      transactionHash: 'test-tx-hash-success',
+    } as providers.TransactionReceipt);
+    await resultRecorder.recordResults([result]);
+
+    expect(result.success).to.be.true;
+    expect(result.messageId).to.equal(messageId);
+    expect((actionTracker.createRebalanceAction as Sinon.SinonStub).calledOnce)
+      .to.be.true;
+    expect(
+      (actionTracker.createRebalanceAction as Sinon.SinonStub).firstCall
+        .args[0],
+    ).to.include({
+      intentId: 'test-intent',
+      messageId,
+      type: 'rebalance_message',
+    });
+    expect((actionTracker.failRebalanceIntent as Sinon.SinonStub).called).to.be
+      .false;
+  });
+});

--- a/typescript/rebalancer/src/core/movable/MovableExecution.test.ts
+++ b/typescript/rebalancer/src/core/movable/MovableExecution.test.ts
@@ -16,7 +16,10 @@ import { MovableChainTransactionExecutor } from './ChainTransactionExecutor.js';
 import { MovableResultRecorder } from './ResultRecorder.js';
 import { MovableRouteValidator } from './RouteValidator.js';
 import { MovableTransactionPreparer } from './TransactionPreparer.js';
-import type { MovableInternalRoute } from './types.js';
+import type {
+  MovableInternalExecutionResult,
+  MovableInternalRoute,
+} from './types.js';
 
 const testLogger = pino({ level: 'silent' });
 
@@ -226,5 +229,68 @@ describe('movable collateral execution modules', () => {
     });
     expect((actionTracker.failRebalanceIntent as Sinon.SinonStub).called).to.be
       .false;
+  });
+
+  it('records route amount when successful results do not include canonical amount', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+    const actionTracker = createActionTrackerStub();
+    const resultRecorder = new MovableResultRecorder(
+      ctx.multiProvider as unknown as MultiProvider,
+      actionTracker,
+      testLogger,
+    );
+    const route = buildInternalRoute({ amount: 123n });
+    const result: MovableInternalExecutionResult = {
+      route,
+      intentId: route.intentId,
+      success: true,
+      messageId: 'test-message-id-success',
+      txHash: 'test-tx-hash-success',
+    };
+
+    await resultRecorder.recordResults([result]);
+
+    expect(
+      (actionTracker.createRebalanceAction as Sinon.SinonStub).calledOnce,
+    ).to.equal(true);
+    expect(
+      (actionTracker.createRebalanceAction as Sinon.SinonStub).firstCall
+        .args[0],
+    ).to.include({
+      amount: 123n,
+      intentId: route.intentId,
+      messageId: 'test-message-id-success',
+    });
+    expect((actionTracker.failRebalanceIntent as Sinon.SinonStub).called).to.be
+      .false;
+  });
+
+  it('fails intents when confirmed transactions do not dispatch messages', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+    const actionTracker = createActionTrackerStub();
+    const resultRecorder = new MovableResultRecorder(
+      ctx.multiProvider as unknown as MultiProvider,
+      actionTracker,
+      testLogger,
+    );
+    sandbox
+      .stub(HyperlaneCore, 'getDispatchedMessages')
+      .returns([] as ReturnType<typeof HyperlaneCore.getDispatchedMessages>);
+
+    const result = resultRecorder.buildResult(buildTestPreparedTransaction(), {
+      transactionHash: 'test-tx-hash-no-dispatch',
+    } as providers.TransactionReceipt);
+    await resultRecorder.recordResults([result]);
+
+    expect(result.success).to.equal(false);
+    expect(result.messageId).to.equal('');
+    expect(result.error).to.include('no Dispatch event');
+    expect((actionTracker.createRebalanceAction as Sinon.SinonStub).called).to
+      .be.false;
+    expect(
+      (actionTracker.failRebalanceIntent as Sinon.SinonStub).calledOnceWith(
+        'test-intent',
+      ),
+    ).to.equal(true);
   });
 });

--- a/typescript/rebalancer/src/core/movable/MovableExecution.test.ts
+++ b/typescript/rebalancer/src/core/movable/MovableExecution.test.ts
@@ -135,6 +135,63 @@ describe('movable collateral execution modules', () => {
       .false;
   });
 
+  it('records action attempt metrics for successful and failed sends', async () => {
+    const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
+    const actionTracker = createActionTrackerStub();
+    const metrics = {
+      recordActionAttempt: Sinon.stub(),
+    };
+    const resultRecorder = new MovableResultRecorder(
+      ctx.multiProvider as unknown as MultiProvider,
+      actionTracker,
+      testLogger,
+    );
+    const executor = new MovableChainTransactionExecutor(
+      ctx.multiProvider as unknown as MultiProvider,
+      resultRecorder,
+      testLogger,
+      metrics as any,
+    );
+    const messageId = 'test-message-id-success';
+    sandbox
+      .stub(HyperlaneCore, 'getDispatchedMessages')
+      .returns([{ id: messageId }] as ReturnType<
+        typeof HyperlaneCore.getDispatchedMessages
+      >);
+
+    const failedTransaction = buildTestPreparedTransaction();
+    const successfulTransaction = buildTestPreparedTransaction({
+      route: buildInternalRoute({ intentId: 'intent-2' }),
+    });
+    (ctx.multiProvider.sendTransaction as Sinon.SinonStub)
+      .onFirstCall()
+      .rejects(new Error('Send failed'))
+      .onSecondCall()
+      .resolves({
+        transactionHash: 'test-tx-hash-success',
+      } as providers.TransactionReceipt);
+
+    const results = await executor.executeTransactions([
+      failedTransaction,
+      successfulTransaction,
+    ]);
+
+    expect(results).to.have.lengthOf(2);
+    expect(metrics.recordActionAttempt.calledTwice).to.be.true;
+    expect(
+      metrics.recordActionAttempt.firstCall.calledWithExactly(
+        failedTransaction.route,
+        false,
+      ),
+    ).to.be.true;
+    expect(
+      metrics.recordActionAttempt.secondCall.calledWithExactly(
+        successfulTransaction.route,
+        true,
+      ),
+    ).to.be.true;
+  });
+
   it('builds successful receipt results and records rebalance actions', async () => {
     const ctx = createRebalancerTestContext(['ethereum', 'arbitrum']);
     const actionTracker = createActionTrackerStub();

--- a/typescript/rebalancer/src/core/movable/ResultRecorder.ts
+++ b/typescript/rebalancer/src/core/movable/ResultRecorder.ts
@@ -1,0 +1,112 @@
+import { type providers } from 'ethers';
+import { type Logger } from 'pino';
+
+import { HyperlaneCore, type MultiProvider } from '@hyperlane-xyz/sdk';
+
+import type {
+  MovableCollateralExecutionResult,
+  PreparedTransaction,
+} from '../../interfaces/IRebalancer.js';
+import type { IActionTracker } from '../../tracking/IActionTracker.js';
+import { normalizeToCanonical } from '../../utils/balanceUtils.js';
+import type { MovableInternalExecutionResult } from './types.js';
+
+export class MovableResultRecorder {
+  constructor(
+    private readonly multiProvider: MultiProvider,
+    private readonly actionTracker: IActionTracker,
+    private readonly logger: Logger,
+  ) {}
+
+  async recordResults(
+    results: MovableInternalExecutionResult[],
+  ): Promise<void> {
+    for (const result of results) {
+      const intentId = result.intentId;
+
+      if (result.success && result.messageId) {
+        await this.actionTracker.createRebalanceAction({
+          intentId,
+          origin: this.multiProvider.getDomainId(result.route.origin),
+          destination: this.multiProvider.getDomainId(result.route.destination),
+          amount: result.canonicalAmount ?? result.route.amount,
+          type: 'rebalance_message',
+          messageId: result.messageId,
+          txHash: result.txHash,
+        });
+
+        this.logger.info(
+          {
+            intentId,
+            messageId: result.messageId,
+            txHash: result.txHash,
+            origin: result.route.origin,
+            destination: result.route.destination,
+          },
+          'Rebalance action created successfully',
+        );
+      } else {
+        await this.actionTracker.failRebalanceIntent(intentId);
+
+        this.logger.warn(
+          {
+            intentId,
+            success: result.success,
+            error: result.error,
+            origin: result.route.origin,
+            destination: result.route.destination,
+          },
+          'Rebalance intent marked as failed',
+        );
+      }
+    }
+  }
+
+  toPublicResults(
+    internalResults: MovableInternalExecutionResult[],
+  ): MovableCollateralExecutionResult[] {
+    return internalResults.map((internal) => ({
+      route: internal.route,
+      success: internal.success,
+      error: internal.error,
+      messageId: internal.messageId || '',
+      txHash: internal.txHash,
+    }));
+  }
+
+  buildResult(
+    transaction: PreparedTransaction,
+    receipt: providers.TransactionReceipt,
+  ): MovableInternalExecutionResult {
+    const { origin, destination } = transaction.route;
+    const dispatchedMessages = HyperlaneCore.getDispatchedMessages(receipt);
+
+    if (dispatchedMessages.length === 0) {
+      this.logger.error(
+        { origin, destination, txHash: receipt.transactionHash },
+        'No Dispatch event found in confirmed rebalance receipt',
+      );
+      return {
+        route: transaction.route,
+        intentId: transaction.route.intentId,
+        success: false,
+        error: `Transaction confirmed but no Dispatch event found`,
+        messageId: '',
+        txHash: receipt.transactionHash,
+      };
+    }
+
+    return {
+      route: transaction.route,
+      intentId: transaction.route.intentId,
+      success: true,
+      messageId: dispatchedMessages[0].id,
+      txHash: receipt.transactionHash,
+      canonicalAmount: normalizeToCanonical(
+        transaction.originTokenAmount.amount,
+        transaction.originTokenAmount.token,
+      ),
+      localAmount: transaction.originTokenAmount.amount,
+    };
+  }
+}

--- a/typescript/rebalancer/src/core/movable/RouteValidator.ts
+++ b/typescript/rebalancer/src/core/movable/RouteValidator.ts
@@ -1,0 +1,134 @@
+import { type Logger } from 'pino';
+
+import {
+  type ChainMap,
+  type ChainMetadata,
+  EvmMovableCollateralAdapter,
+  type MultiProvider,
+  type Token,
+  type WarpCore,
+} from '@hyperlane-xyz/sdk';
+import { eqAddress } from '@hyperlane-xyz/utils';
+
+import { denormalizeToLocal } from '../../utils/balanceUtils.js';
+import type { MovableInternalRoute } from './types.js';
+
+export class MovableRouteValidator {
+  constructor(
+    private readonly warpCore: WarpCore,
+    private readonly chainMetadata: ChainMap<ChainMetadata>,
+    private readonly tokensByChainName: ChainMap<Token>,
+    private readonly multiProvider: MultiProvider,
+    private readonly logger: Logger,
+  ) {}
+
+  async validate(route: MovableInternalRoute): Promise<boolean> {
+    const { origin, destination, amount } = route;
+    const originToken = this.tokensByChainName[origin];
+    const destinationToken = this.tokensByChainName[destination];
+    const destinationDomain = this.chainMetadata[destination];
+
+    if (!originToken) {
+      this.logger.error(
+        { origin, destination, amount },
+        'Route validation failed: origin token not found.',
+      );
+      return false;
+    }
+
+    const localAmount = denormalizeToLocal(amount, originToken);
+    const originTokenAmount = originToken.amount(localAmount);
+    const decimalFormattedAmount =
+      originTokenAmount.getDecimalFormattedAmount();
+
+    if (!destinationToken) {
+      this.logger.error(
+        { origin, destination, amount: decimalFormattedAmount },
+        'Route validation failed: destination token not found.',
+      );
+      return false;
+    }
+
+    if (!destinationDomain) {
+      this.logger.error(
+        { origin, destination, amount: decimalFormattedAmount },
+        'Route validation failed: destination domain metadata not found.',
+      );
+      return false;
+    }
+
+    const originHypAdapter = originToken.getHypAdapter(
+      this.warpCore.multiProvider,
+    );
+    if (!(originHypAdapter instanceof EvmMovableCollateralAdapter)) {
+      this.logger.error(
+        {
+          origin,
+          destination,
+          amount: decimalFormattedAmount,
+          tokenName: originToken.name,
+        },
+        'Route validation failed: Origin TokenAdapter is not an EvmHypCollateralAdapter.',
+      );
+      return false;
+    }
+
+    const signer = this.multiProvider.getSigner(origin);
+    const signerAddress = await signer.getAddress();
+    if (!(await originHypAdapter.isRebalancer(signerAddress))) {
+      this.logger.error(
+        {
+          origin,
+          destination,
+          amount: decimalFormattedAmount,
+          tokenName: originToken.name,
+          tokenAddress: originToken.addressOrDenom,
+          signerAddress,
+        },
+        'Route validation failed: Signer is not a rebalancer.',
+      );
+      return false;
+    }
+
+    const allowedDestination = await originHypAdapter.getAllowedDestination(
+      destinationDomain.domainId,
+    );
+    if (!eqAddress(allowedDestination, destinationToken.addressOrDenom)) {
+      this.logger.error(
+        {
+          origin,
+          destination,
+          amount: decimalFormattedAmount,
+          tokenName: originToken.name,
+          tokenAddress: originToken.addressOrDenom,
+          destinationTokenAddress: destinationToken.addressOrDenom,
+          allowedDestinationTokenAddress: allowedDestination,
+        },
+        'Route validation failed: Destination is not allowed.',
+      );
+      return false;
+    }
+
+    if (
+      !(await originHypAdapter.isBridgeAllowed(
+        destinationDomain.domainId,
+        route.bridge,
+      ))
+    ) {
+      this.logger.error(
+        {
+          origin,
+          destination,
+          amount: decimalFormattedAmount,
+          tokenName: originToken.name,
+          tokenAddress: originToken.addressOrDenom,
+          bridgeAddress: route.bridge,
+        },
+        'Route validation failed: Bridge is not allowed.',
+      );
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/typescript/rebalancer/src/core/movable/TransactionPreparer.ts
+++ b/typescript/rebalancer/src/core/movable/TransactionPreparer.ts
@@ -1,0 +1,151 @@
+import { type PopulatedTransaction } from 'ethers';
+import { type Logger } from 'pino';
+
+import {
+  type ChainMap,
+  type ChainMetadata,
+  EvmMovableCollateralAdapter,
+  type InterchainGasQuote,
+  type Token,
+  type WarpCore,
+} from '@hyperlane-xyz/sdk';
+import { isNullish, mapAllSettled } from '@hyperlane-xyz/utils';
+
+import type { PreparedTransaction } from '../../interfaces/IRebalancer.js';
+import { denormalizeToLocal } from '../../utils/balanceUtils.js';
+import { MovableRouteValidator } from './RouteValidator.js';
+import type {
+  MovableInternalExecutionResult,
+  MovableInternalRoute,
+} from './types.js';
+
+export class MovableTransactionPreparer {
+  constructor(
+    private readonly warpCore: WarpCore,
+    private readonly chainMetadata: ChainMap<ChainMetadata>,
+    private readonly tokensByChainName: ChainMap<Token>,
+    private readonly routeValidator: MovableRouteValidator,
+    private readonly logger: Logger,
+  ) {}
+
+  async prepareTransactions(routes: MovableInternalRoute[]): Promise<{
+    preparedTransactions: PreparedTransaction[];
+    preparationFailureResults: MovableInternalExecutionResult[];
+  }> {
+    this.logger.info(
+      { numRoutes: routes.length },
+      'Preparing all rebalance transactions.',
+    );
+    const { fulfilled, rejected } = await mapAllSettled(
+      routes,
+      (route) => this.prepareTransaction(route),
+      (_, i) => i,
+    );
+
+    const preparedTransactions = Array.from(fulfilled.values()).filter(
+      (tx): tx is PreparedTransaction => !isNullish(tx),
+    );
+
+    const preparationFailureResults: MovableInternalExecutionResult[] = [];
+    for (const [i, error] of rejected) {
+      preparationFailureResults.push({
+        route: routes[i],
+        intentId: routes[i].intentId,
+        success: false,
+        error: String(error),
+        messageId: '',
+      });
+    }
+
+    Array.from(fulfilled.entries()).forEach(([i, tx]) => {
+      if (isNullish(tx)) {
+        preparationFailureResults.push({
+          route: routes[i],
+          intentId: routes[i].intentId,
+          success: false,
+          error: 'Preparation returned null',
+          messageId: '',
+        });
+      }
+    });
+
+    return { preparedTransactions, preparationFailureResults };
+  }
+
+  async prepareTransaction(
+    route: MovableInternalRoute,
+  ): Promise<PreparedTransaction | null> {
+    const { origin, destination, amount } = route;
+
+    this.logger.info(
+      {
+        origin,
+        destination,
+        amount,
+      },
+      'Preparing transaction for route',
+    );
+
+    if (!(await this.routeValidator.validate(route))) {
+      return null;
+    }
+
+    const originToken = this.tokensByChainName[origin];
+    const destinationToken = this.tokensByChainName[destination];
+    const destinationChainMeta = this.chainMetadata[destination];
+    const localAmount = denormalizeToLocal(amount, originToken);
+
+    const originTokenAmount = originToken.amount(localAmount);
+    const decimalFormattedAmount =
+      originTokenAmount.getDecimalFormattedAmount();
+    const originHypAdapter = originToken.getHypAdapter(
+      this.warpCore.multiProvider,
+    ) as EvmMovableCollateralAdapter;
+
+    let quotes: InterchainGasQuote[];
+    try {
+      quotes = await originHypAdapter.getRebalanceQuotes(
+        route.bridge,
+        destinationChainMeta.domainId,
+        destinationToken.addressOrDenom,
+        localAmount,
+      );
+    } catch (error) {
+      this.logger.error(
+        {
+          origin,
+          destination,
+          amount: decimalFormattedAmount,
+          tokenName: originToken.name,
+          error,
+        },
+        'Failed to get quotes for route.',
+      );
+      return null;
+    }
+
+    let populatedTx: PopulatedTransaction;
+    try {
+      populatedTx = await originHypAdapter.populateRebalanceTx(
+        destinationChainMeta.domainId,
+        localAmount,
+        route.bridge,
+        quotes,
+      );
+    } catch (error) {
+      this.logger.error(
+        {
+          origin,
+          destination,
+          amount: decimalFormattedAmount,
+          tokenName: originToken.name,
+          error,
+        },
+        'Failed to populate transaction for route.',
+      );
+      return null;
+    }
+
+    return { populatedTx, route, originTokenAmount };
+  }
+}

--- a/typescript/rebalancer/src/core/movable/TransactionPreparer.ts
+++ b/typescript/rebalancer/src/core/movable/TransactionPreparer.ts
@@ -9,7 +9,7 @@ import {
   type Token,
   type WarpCore,
 } from '@hyperlane-xyz/sdk';
-import { isNullish, mapAllSettled } from '@hyperlane-xyz/utils';
+import { mapAllSettled } from '@hyperlane-xyz/utils';
 
 import type { PreparedTransaction } from '../../interfaces/IRebalancer.js';
 import { denormalizeToLocal } from '../../utils/balanceUtils.js';
@@ -42,32 +42,34 @@ export class MovableTransactionPreparer {
       (_, i) => i,
     );
 
-    const preparedTransactions = Array.from(fulfilled.values()).filter(
-      (tx): tx is PreparedTransaction => !isNullish(tx),
-    );
-
+    const preparedTransactions: PreparedTransaction[] = [];
     const preparationFailureResults: MovableInternalExecutionResult[] = [];
-    for (const [i, error] of rejected) {
-      preparationFailureResults.push({
-        route: routes[i],
-        intentId: routes[i].intentId,
-        success: false,
-        error: String(error),
-        messageId: '',
-      });
-    }
 
-    Array.from(fulfilled.entries()).forEach(([i, tx]) => {
-      if (isNullish(tx)) {
+    for (const [i, tx] of fulfilled) {
+      const route = routes[i];
+      if (tx) {
+        preparedTransactions.push(tx);
+      } else {
         preparationFailureResults.push({
-          route: routes[i],
-          intentId: routes[i].intentId,
+          route,
+          intentId: route.intentId,
           success: false,
           error: 'Preparation returned null',
           messageId: '',
         });
       }
-    });
+    }
+
+    for (const [i, error] of rejected) {
+      const route = routes[i];
+      preparationFailureResults.push({
+        route,
+        intentId: route.intentId,
+        success: false,
+        error: String(error),
+        messageId: '',
+      });
+    }
 
     return { preparedTransactions, preparationFailureResults };
   }

--- a/typescript/rebalancer/src/core/movable/types.ts
+++ b/typescript/rebalancer/src/core/movable/types.ts
@@ -1,0 +1,13 @@
+import type { MovableCollateralExecutionResult } from '../../interfaces/IRebalancer.js';
+import type { MovableCollateralRoute } from '../../interfaces/IStrategy.js';
+
+export type MovableInternalExecutionResult =
+  MovableCollateralExecutionResult & {
+    intentId: string;
+    canonicalAmount?: bigint;
+    localAmount?: bigint;
+  };
+
+export type MovableInternalRoute = MovableCollateralRoute & {
+  intentId: string;
+};

--- a/typescript/rebalancer/src/planning/StrategyPlanner.test.ts
+++ b/typescript/rebalancer/src/planning/StrategyPlanner.test.ts
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import type { ChainMap, Token } from '@hyperlane-xyz/sdk';
+
+import type { RawBalances, StrategyRoute } from '../interfaces/IStrategy.js';
+import type { Metrics } from '../metrics/Metrics.js';
+import { TEST_ADDRESSES } from '../test/helpers.js';
+import type { RouteExecutionMatrix } from '../utils/bridgeUtils.js';
+
+import { StrategyPlanner } from './StrategyPlanner.js';
+
+const testLogger = pino({ level: 'silent' });
+
+describe('StrategyPlanner', () => {
+  function createMockToken(chainName: string, decimals = 18): Token {
+    return {
+      chainName,
+      decimals,
+      addressOrDenom: TEST_ADDRESSES.token,
+    } as unknown as Token;
+  }
+
+  const routeExecutionMatrix: RouteExecutionMatrix = {
+    ethereum: {
+      arbitrum: {
+        executionType: 'movableCollateral',
+        bridge: TEST_ADDRESSES.bridge,
+        bridgeMinAcceptedAmount: '100',
+      },
+    },
+    arbitrum: {
+      ethereum: {
+        executionType: 'movableCollateral',
+        bridge: TEST_ADDRESSES.bridge,
+      },
+    },
+    optimism: {
+      ethereum: {
+        executionType: 'movableCollateral',
+        bridge: TEST_ADDRESSES.bridge,
+      },
+    },
+  };
+
+  const tokensByChainName: ChainMap<Token> = {
+    ethereum: createMockToken('ethereum'),
+    arbitrum: createMockToken('arbitrum'),
+    optimism: createMockToken('optimism'),
+  };
+
+  it('filters routes by actual origin balance and bridgeMinAcceptedAmount', () => {
+    const planner = new StrategyPlanner(
+      routeExecutionMatrix,
+      testLogger,
+      undefined,
+      tokensByChainName,
+    );
+    const routes: StrategyRoute[] = [
+      {
+        origin: 'arbitrum',
+        destination: 'ethereum',
+        amount: 10n,
+        executionType: 'movableCollateral',
+        bridge: TEST_ADDRESSES.bridge,
+      },
+      {
+        origin: 'ethereum',
+        destination: 'arbitrum',
+        amount: ethers.utils.parseEther('50').toBigInt(),
+        executionType: 'movableCollateral',
+        bridge: TEST_ADDRESSES.bridge,
+      },
+      {
+        origin: 'optimism',
+        destination: 'ethereum',
+        amount: 25n,
+        executionType: 'movableCollateral',
+        bridge: TEST_ADDRESSES.bridge,
+      },
+    ];
+    const actualBalances: RawBalances = {
+      ethereum: ethers.utils.parseEther('1000').toBigInt(),
+      arbitrum: 5n,
+      optimism: 25n,
+    };
+
+    const filteredRoutes = planner.finalizeRoutes(
+      routes,
+      actualBalances,
+      'weighted',
+      'TestStrategy',
+    );
+
+    expect(filteredRoutes).to.deep.equal([routes[2]]);
+  });
+
+  it('records intent metrics only for routes kept after filtering', () => {
+    const recordIntentCreated = Sinon.stub();
+    const metrics = {
+      recordIntentCreated,
+    } as unknown as Metrics;
+    const planner = new StrategyPlanner(
+      routeExecutionMatrix,
+      testLogger,
+      metrics,
+      tokensByChainName,
+    );
+    const keptRoute: StrategyRoute = {
+      origin: 'optimism',
+      destination: 'ethereum',
+      amount: 25n,
+      executionType: 'movableCollateral',
+      bridge: TEST_ADDRESSES.bridge,
+    };
+    const droppedRoute: StrategyRoute = {
+      origin: 'arbitrum',
+      destination: 'ethereum',
+      amount: 10n,
+      executionType: 'movableCollateral',
+      bridge: TEST_ADDRESSES.bridge,
+    };
+
+    planner.finalizeRoutes(
+      [droppedRoute, keptRoute],
+      {
+        ethereum: 100n,
+        arbitrum: 5n,
+        optimism: 25n,
+      },
+      'weighted',
+      'TestStrategy',
+    );
+
+    Sinon.assert.calledOnceWithExactly(
+      recordIntentCreated,
+      keptRoute,
+      'weighted',
+    );
+  });
+
+  it('keeps routes at the min amount boundary and when token metadata is unavailable', () => {
+    const routeAtMinAmount: StrategyRoute = {
+      origin: 'ethereum',
+      destination: 'arbitrum',
+      amount: ethers.utils.parseEther('100').toBigInt(),
+      executionType: 'movableCollateral',
+      bridge: TEST_ADDRESSES.bridge,
+    };
+    const routeWithoutToken: StrategyRoute = {
+      origin: 'optimism',
+      destination: 'ethereum',
+      amount: 25n,
+      executionType: 'movableCollateral',
+      bridge: TEST_ADDRESSES.bridge,
+    };
+    const planner = new StrategyPlanner(routeExecutionMatrix, testLogger);
+
+    const filteredRoutes = planner.finalizeRoutes(
+      [routeAtMinAmount, routeWithoutToken],
+      {
+        ethereum: routeAtMinAmount.amount,
+        optimism: routeWithoutToken.amount,
+      },
+      'weighted',
+      'TestStrategy',
+    );
+
+    expect(filteredRoutes).to.deep.equal([routeAtMinAmount, routeWithoutToken]);
+  });
+});

--- a/typescript/rebalancer/src/planning/StrategyPlanner.ts
+++ b/typescript/rebalancer/src/planning/StrategyPlanner.ts
@@ -1,0 +1,99 @@
+import type { Logger } from 'pino';
+
+import type { ChainMap, Token } from '@hyperlane-xyz/sdk';
+
+import type { RawBalances, StrategyRoute } from '../interfaces/IStrategy.js';
+import type { Metrics } from '../metrics/Metrics.js';
+import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
+import {
+  getRouteExecutionConfig,
+  type RouteExecutionMatrix,
+} from '../utils/bridgeUtils.js';
+
+type PlannerLogger = Pick<Logger, 'debug' | 'info' | 'warn'>;
+
+export class StrategyPlanner {
+  constructor(
+    private readonly routeExecutionMatrix: RouteExecutionMatrix,
+    private readonly logger: PlannerLogger,
+    private readonly metrics?: Metrics,
+    private readonly tokensByChainName?: ChainMap<Token>,
+  ) {}
+
+  finalizeRoutes(
+    routes: StrategyRoute[],
+    actualBalances: RawBalances,
+    strategyName: string,
+    context: string,
+  ): StrategyRoute[] {
+    const filteredRoutes = this.filterRoutes(routes, actualBalances, context);
+
+    this.logger.debug(
+      {
+        context,
+        filteredRoutesCount: filteredRoutes.length,
+        droppedCount: routes.length - filteredRoutes.length,
+      },
+      'Filtered rebalancing routes',
+    );
+
+    for (const route of filteredRoutes) {
+      this.metrics?.recordIntentCreated(route, strategyName);
+    }
+
+    return filteredRoutes;
+  }
+
+  private filterRoutes(
+    routes: StrategyRoute[],
+    actualBalances: RawBalances,
+    context: string,
+  ): StrategyRoute[] {
+    return routes.filter((route) => {
+      const balance = actualBalances[route.origin] ?? 0n;
+      if (balance < route.amount) {
+        this.logger.warn(
+          {
+            context,
+            origin: route.origin,
+            destination: route.destination,
+            required: route.amount.toString(),
+            available: balance.toString(),
+          },
+          'Dropping route due to insufficient balance',
+        );
+        return false;
+      }
+
+      const token = this.tokensByChainName?.[route.origin];
+      if (token) {
+        const bridgeConfig = getRouteExecutionConfig(
+          this.routeExecutionMatrix,
+          route.origin,
+          route.destination,
+        );
+        if (bridgeConfig.bridgeMinAcceptedAmount != null) {
+          const minAmount = normalizeConfiguredAmount(
+            bridgeConfig.bridgeMinAcceptedAmount,
+            token,
+          );
+          if (route.amount < minAmount) {
+            this.logger.info(
+              {
+                context,
+                origin: route.origin,
+                destination: route.destination,
+                amount: route.amount.toString(),
+                minAmount: minAmount.toString(),
+              },
+              'Dropping route below bridgeMinAcceptedAmount',
+            );
+            return false;
+          }
+        }
+      }
+
+      return true;
+    });
+  }
+}

--- a/typescript/rebalancer/src/planning/index.ts
+++ b/typescript/rebalancer/src/planning/index.ts
@@ -1,3 +1,4 @@
 export { BalanceProjector } from './BalanceProjector.js';
 export { materializeStrategyRoute, planRoutes } from './RoutePlanner.js';
+export { StrategyPlanner } from './StrategyPlanner.js';
 export type { BalanceDelta } from './types.js';

--- a/typescript/rebalancer/src/strategy/BaseStrategy.ts
+++ b/typescript/rebalancer/src/strategy/BaseStrategy.ts
@@ -11,7 +11,11 @@ import type {
   StrategyRoute,
 } from '../interfaces/IStrategy.js';
 import { type Metrics } from '../metrics/Metrics.js';
-import { BalanceProjector, planRoutes } from '../planning/index.js';
+import {
+  BalanceProjector,
+  planRoutes,
+  StrategyPlanner,
+} from '../planning/index.js';
 import type { BalanceDelta } from '../planning/types.js';
 import {
   type BridgeConfig,
@@ -20,7 +24,6 @@ import {
   normalizeRouteExecutionMatrix,
   type RouteExecutionMatrix,
 } from '../utils/bridgeUtils.js';
-import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
 
 export type Delta = BalanceDelta;
 
@@ -33,6 +36,7 @@ export abstract class BaseStrategy implements IStrategy {
   protected readonly metrics?: Metrics;
   protected readonly logger: Logger;
   protected readonly routeExecutionMatrix: RouteExecutionMatrix;
+  protected readonly strategyPlanner: StrategyPlanner;
   protected readonly tokensByChainName?: ChainMap<Token>;
 
   constructor(
@@ -52,6 +56,12 @@ export abstract class BaseStrategy implements IStrategy {
       normalizeRouteExecutionMatrix(routeExecutionConfig);
     this.metrics = metrics;
     this.tokensByChainName = tokensByChainName;
+    this.strategyPlanner = new StrategyPlanner(
+      this.routeExecutionMatrix,
+      this.logger,
+      metrics,
+      tokensByChainName,
+    );
   }
 
   protected getBridgeConfigForRoute(
@@ -201,23 +211,12 @@ export abstract class BaseStrategy implements IStrategy {
       'Found rebalancing routes',
     );
 
-    const filteredRoutes = this.filterRoutes(routes, actualBalances);
-
-    this.logger.debug(
-      {
-        context: this.constructor.name,
-        filteredRoutesCount: filteredRoutes.length,
-        droppedCount: routes.length - filteredRoutes.length,
-      },
-      'Filtered rebalancing routes',
+    return this.strategyPlanner.finalizeRoutes(
+      routes,
+      actualBalances,
+      this.name,
+      this.constructor.name,
     );
-
-    // Record metrics for each intent that passed filtering
-    for (const route of filteredRoutes) {
-      this.metrics?.recordIntentCreated(route, this.name);
-    }
-
-    return filteredRoutes;
   }
 
   /**
@@ -333,58 +332,5 @@ export abstract class BaseStrategy implements IStrategy {
       this.logger,
       this.constructor.name,
     );
-  }
-
-  protected filterRoutes(
-    routes: StrategyRoute[],
-    actualBalances: RawBalances,
-  ): StrategyRoute[] {
-    return routes.filter((route) => {
-      const balance = actualBalances[route.origin] ?? 0n;
-      if (balance < route.amount) {
-        this.logger.warn(
-          {
-            context: this.constructor.name,
-            origin: route.origin,
-            destination: route.destination,
-            required: route.amount.toString(),
-            available: balance.toString(),
-          },
-          'Dropping route due to insufficient balance',
-        );
-        return false;
-      }
-
-      if (this.tokensByChainName) {
-        const token = this.tokensByChainName[route.origin];
-        if (token) {
-          const bridgeConfig = this.getBridgeConfigForRoute(
-            route.origin,
-            route.destination,
-          );
-          if (bridgeConfig.bridgeMinAcceptedAmount != null) {
-            const minAmount = normalizeConfiguredAmount(
-              bridgeConfig.bridgeMinAcceptedAmount,
-              token,
-            );
-            if (route.amount < minAmount) {
-              this.logger.info(
-                {
-                  context: this.constructor.name,
-                  origin: route.origin,
-                  destination: route.destination,
-                  amount: route.amount.toString(),
-                  minAmount: minAmount.toString(),
-                },
-                'Dropping route below bridgeMinAcceptedAmount',
-              );
-              return false;
-            }
-          }
-        }
-      }
-
-      return true;
-    });
   }
 }

--- a/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
+++ b/typescript/rebalancer/src/strategy/CollateralDeficitStrategy.ts
@@ -255,23 +255,12 @@ export class CollateralDeficitStrategy extends BaseStrategy {
       'Found rebalancing routes',
     );
 
-    const filteredRoutes = this.filterRoutes(routes, actualBalances);
-
-    // Record metrics for each intent created
-    for (const route of filteredRoutes) {
-      this.metrics?.recordIntentCreated(route, this.name);
-    }
-
-    this.logger.debug(
-      {
-        context: this.constructor.name,
-        filteredRoutesCount: filteredRoutes.length,
-        droppedCount: routes.length - filteredRoutes.length,
-      },
-      'Filtered rebalancing routes',
+    return this.strategyPlanner.finalizeRoutes(
+      routes,
+      actualBalances,
+      this.name,
+      this.constructor.name,
     );
-
-    return filteredRoutes;
   }
 
   /**


### PR DESCRIPTION
## Summary

Stacked on #8881, which is stacked on #8880. This is PR3 for `typescript/rebalancer/docs/rebalancer-architecture-review.md` and handles the strategy finalization + movable collateral executor decomposition slices.

## Slices and Benefits

1. StrategyPlanner finalization
- Added `StrategyPlanner` for final route filtering and intent-created metrics emission.
- `BaseStrategy` and `CollateralDeficitStrategy` now generate candidate routes and delegate filtering/metrics side effects to the planner.
- Benefit: strategy evaluation is closer to pure planning, while filter/metrics behavior is separately testable and reusable across strategies.

2. Movable collateral execution modules
- Split `Rebalancer` movable execution into:
  - `MovableRouteValidator`
  - `MovableTransactionPreparer`
  - `MovableChainTransactionExecutor`
  - `MovableResultRecorder`
- Kept `Rebalancer` as the orchestration layer for intent creation, preparation, execution, result recording, metrics, and summary logging.
- Benefit: route validation, transaction preparation, chain execution, and action recording can now be tested and optimized independently without carrying the whole monolithic rebalancer setup.

3. Documentation/checklist
- Updated `docs/rebalancer-architecture-review.md` to mark the StrategyPlanner and movable executor decomposition slices complete.
- Added a rebalancer changeset.

## Review Notes

- Used subagents for both implementation slices.
- Ran Claude read-only reviews for the strategy slice and movable execution slice.
- Addressed Claude nits by removing a redundant route spread override, replacing a carried-over non-null map access, and adding extra StrategyPlanner boundary coverage.

## Checks

- `pnpm -C typescript/rebalancer build`
- `pnpm -C typescript/rebalancer test` (`411 passing`)
- `pnpm -C typescript/rebalancer exec oxlint -c ../../oxlint.json <touched ts files>`
- `pnpm exec prettier --check <touched docs/changeset/ts files>`
- `git diff --check`
- commit hooks ran successfully
