### PR TITLE
refactor(rebalancer): split inventory and e2e fixtures

### DIFF
--- a/.changeset/rebalancer-inventory-e2e-split.md
+++ b/.changeset/rebalancer-inventory-e2e-split.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/rebalancer": patch
+---
+
+Split inventory execution and e2e route fixture setup into dedicated modules so intent resolution, inventory planning, bridge capacity estimation, inventory movement, transferRemote execution, and local fixture deploy/enroll/seed behavior can be tested and evolved independently.

--- a/typescript/rebalancer/docs/rebalancer-architecture-review.md
+++ b/typescript/rebalancer/docs/rebalancer-architecture-review.md
@@ -4,7 +4,7 @@ Date: 2026-06-12
 
 Scope: `typescript/rebalancer` package. Findings are from local code inspection plus three read-only subagent slices covering core runtime, strategy/config, and bridges/tracking/tests.
 
-Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice landed in PR #8880. The stacked follow-up PR implemented cycle context, shared planning/projection, and LiFi SDK isolation. The third stacked PR moved strategy finalization and movable execution into dedicated modules. The remaining work is inventory executor and test-fixture decomposition.
+Status: this document now doubles as the refactor plan and implementation log. The first performance-oriented implementation slice landed in PR #8880. The stacked follow-up PR implemented cycle context, shared planning/projection, and LiFi SDK isolation. The third stacked PR moved strategy finalization and movable execution into dedicated modules. The final stacked PR split inventory execution and consolidated the e2e route fixture harness.
 
 ## Bottom Line
 
@@ -82,20 +82,38 @@ These slices finish the strategy planning boundary and split movable collateral 
 - Added focused tests for the extracted modules while preserving existing `Rebalancer` behavior tests.
 - Benefit: validation, transaction preparation, chain execution, and action recording can now be tested and optimized independently without mocking the entire rebalancer monolith.
 
+## Implemented In PR4
+
+These slices finish the requested executor and e2e harness decomposition while preserving runtime behavior.
+
+### Slice 9: Inventory Execution Modules
+
+- Split inventory execution into `InventoryIntentResolver`, `InventoryPlanner`, `BridgeCapacityEstimator`, `InventoryMovementExecutor`, and `TransferRemoteExecutor`.
+- Kept `InventoryRebalancer` as the orchestration and protocol-adapter layer for token lookup, signer construction, typed transaction sending, and message-id extraction.
+- Added focused planner tests while preserving the existing `InventoryRebalancer` behavior suite.
+- Benefit: active-intent continuation, transfer planning, bridge capacity checks, external bridge execution, and `transferRemote` recording can now be reasoned about and tested independently.
+
+### Slice 10: Declarative E2E Route Fixtures
+
+- Added `RouteFixtureBuilder` for declarative ERC20/native route deployment across local chains.
+- Centralized remote-router enrollment, rebalancer enrollment, monitored-route bridge registration, ERC20/native route seeding, recipient seeding, and route address-map construction.
+- Refactored the ERC20, native, inventory, and mixed deployment managers to declare fixture shape instead of each manager hand-rolling deploy/enroll/seed loops.
+- Benefit: e2e fixture changes now have one deploy/enroll/seed implementation to test, reducing route-specific drift and making new fixture topologies cheaper to add.
+
 ## Remaining Follow-Up TODOs
 
-Keep the north star performance, but use the larger module split to make future performance work safer.
+The requested stacked implementation slices are complete. Keep the north star performance, but use the larger module split to make future performance work safer.
 
 - [x] Add explicit `RebalanceCycleContext`, `ExecutionSummary`, and `CycleResult.status`.
-- [x] Remove inventory state injection through `InventoryRebalancer.setInventoryBalances()` by passing cycle context into executors.
+- [x] Remove runtime inventory state injection through `InventoryRebalancer.setInventoryBalances()` by passing cycle context into executors.
 - [x] Normalize config into a resolved route execution matrix so strategies do not perform bridge/execution config lookups.
 - [x] Move pending-transfer, pending-rebalance, and proposed-route projection into a shared `BalanceProjector`.
 - [x] Introduce shared route planning and centralize route materialization after strategy evaluation.
 - [x] Move route filtering and metrics emission out of `BaseStrategy` into a dedicated `StrategyPlanner`.
 - [x] Split movable collateral execution into route validation, transaction preparation, chain transaction execution, and result recording modules.
-- [ ] Split inventory execution into intent resolution, inventory planning, bridge capacity estimation, movement execution, and `transferRemote` execution modules.
+- [x] Split inventory execution into intent resolution, inventory planning, bridge capacity estimation, movement execution, and `transferRemote` execution modules.
 - [x] Wrap LiFi SDK/global state behind an injected client/runner and make execution locking follow the runner's provider-state scope.
-- [ ] Replace route-specific e2e deployment managers with a declarative fixture builder and shared deploy/enroll/seed helpers.
+- [x] Replace route-specific e2e deployment managers with a declarative fixture builder and shared deploy/enroll/seed helpers.
 - [x] Add deterministic unit fakes for LiFi execution/status behavior separate from local integration bridge adapters.
 
 ## Current Shape
@@ -105,7 +123,8 @@ Keep the north star performance, but use the larger module split to make future 
 - `RebalancerOrchestrator` syncs tracking state, builds raw balances, asks a strategy for routes, and dispatches routes to rebalancers.
 - `BaseStrategy` handles balance reservation, pending/proposed rebalance simulation, surplus/deficit matching, and route materialization, then delegates route finalization to `StrategyPlanner`.
 - `Rebalancer` orchestrates movable-collateral execution through route validation, transaction preparation, chain transaction execution, and result recording modules.
-- `InventoryRebalancer` executes inventory routes end to end, including active-intent continuation, bridge planning, external bridge execution, and `transferRemote`.
+- `InventoryRebalancer` orchestrates inventory execution through intent resolution, inventory planning, bridge capacity estimation, external bridge movement execution, and `transferRemote` execution modules.
+- E2E local deployment managers declare route fixture shape through `RouteFixtureBuilder`, then reuse shared deploy/enroll/seed helpers.
 - `ActionTracker` owns explorer recovery, delivery checks, TTL/staleness, external bridge status, stores, and projection into inflight context.
 
 ## Highest Priority Problems

--- a/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.test.ts
@@ -271,6 +271,7 @@ describe('InventoryRebalancer E2E', () => {
       destination: SOLANA_DOMAIN,
       amount: 10000000000n,
       executionMethod: 'inventory',
+      externalBridge: ExternalBridgeType.LiFi,
       createdAt: now,
       updatedAt: now,
       ...overrides,

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -8,10 +8,8 @@ import {
   ProviderType,
   SealevelCoreAdapter,
   TOKEN_COLLATERALIZED_STANDARDS,
-  type Token,
   type WarpTypedTransaction,
   type WarpCore,
-  WarpTxCategory,
   getSignerForChain,
   type TypedTransactionReceipt,
 } from '@hyperlane-xyz/sdk';
@@ -19,7 +17,6 @@ import {
   ProtocolType,
   assert,
   ensure0x,
-  fromWei,
   isEVMLike,
 } from '@hyperlane-xyz/utils';
 
@@ -36,125 +33,18 @@ import type {
 } from '../interfaces/IRebalancer.js';
 import type { InventoryRoute } from '../interfaces/IStrategy.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
-import type {
-  PartialInventoryIntent,
-  RebalanceIntent,
-} from '../tracking/types.js';
-import {
-  MIN_VIABLE_COST_MULTIPLIER,
-  calculateTransferCosts,
-} from '../utils/gasEstimation.js';
-import {
-  getExternalBridgeTokenAddress,
-  isNativeTokenStandard,
-} from '../utils/tokenUtils.js';
+import type { RebalanceIntent } from '../tracking/types.js';
 import { parseSolanaPrivateKey } from '../utils/solanaKeyParser.js';
 import { toProtocolTransaction } from '../utils/transactionUtils.js';
-import {
-  alignLocalToCanonical,
-  denormalizeToLocal,
-  normalizeToCanonical,
-} from '../utils/balanceUtils.js';
-
-/**
- * Buffer percentage to add when bridging inventory.
- * Bridges (amount * (100 + BRIDGE_BUFFER_PERCENT)) / 100 to account for slippage.
- */
-const BRIDGE_BUFFER_PERCENT = 5n;
-
-/**
- * Multiplier applied to LiFi's quoted gas costs.
- * LiFi consistently underestimates gas, and gas prices can spike significantly
- * between quote and execution. Using 20x provides headroom for volatility
- * (historically LiFi underestimates by ~14x).
- */
-const GAS_COST_MULTIPLIER = 20n;
-
-/**
- * Maximum percentage of inventory that gas costs can consume for a bridge to be viable.
- * If gas exceeds this threshold, the bridge is not economically worthwhile.
- */
-const MAX_GAS_PERCENT_THRESHOLD = 10n;
-
-type BridgeCapacity = {
-  maxSourceInput: bigint;
-  maxTargetOutput: bigint;
-};
-
-type BridgeQuoteMode = 'forward' | 'reverse';
-
-type InventoryMovementExecutionResult =
-  | {
-      success: true;
-      txHash: string;
-      inputRequired: bigint;
-      quotedOutput: bigint;
-      quotedOutputMin: bigint;
-      quoteModeUsed: BridgeQuoteMode;
-    }
-  | {
-      success: false;
-      error: string;
-    };
-const RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES = [
-  'balance may be insufficient',
-  'transfer amount exceeds balance',
-  'insufficient balance',
-];
-
-function hasRecoverableMaxTransferErrorMessage(message: string): boolean {
-  const normalized = message.toLowerCase();
-  return (
-    normalized.includes('unpredictable_gas_limit') ||
-    RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES.some((pattern) =>
-      normalized.includes(pattern),
-    )
-  );
-}
-
-function isRecoverableMaxTransferProbeError(error: unknown): boolean {
-  const seen = new Set<unknown>();
-  const stack: unknown[] = [error];
-
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (current == null) continue;
-
-    if (typeof current === 'string') {
-      if (hasRecoverableMaxTransferErrorMessage(current)) return true;
-      continue;
-    }
-
-    if (typeof current !== 'object') continue;
-    if (seen.has(current)) continue;
-    seen.add(current);
-
-    const candidate = current as {
-      code?: unknown;
-      message?: unknown;
-      cause?: unknown;
-      error?: unknown;
-    };
-
-    if (
-      typeof candidate.code === 'string' &&
-      candidate.code.toUpperCase() === 'UNPREDICTABLE_GAS_LIMIT'
-    ) {
-      return true;
-    }
-
-    if (
-      typeof candidate.message === 'string' &&
-      hasRecoverableMaxTransferErrorMessage(candidate.message)
-    ) {
-      return true;
-    }
-
-    stack.push(candidate.cause, candidate.error);
-  }
-
-  return false;
-}
+import { BridgeCapacityEstimator } from './inventory/BridgeCapacityEstimator.js';
+import { InventoryIntentResolver } from './inventory/IntentResolver.js';
+import { InventoryMovementExecutor } from './inventory/InventoryMovementExecutor.js';
+import { InventoryPlanner } from './inventory/InventoryPlanner.js';
+import { TransferRemoteExecutor } from './inventory/TransferRemoteExecutor.js';
+import type {
+  BridgeQuoteMode,
+  InventoryMovementExecutionResult,
+} from './inventory/types.js';
 
 /**
  * Configuration for the InventoryRebalancer.
@@ -199,6 +89,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   private readonly externalBridgeRegistry: Partial<ExternalBridgeRegistry>;
   private readonly warpCore: WarpCore;
   private readonly multiProvider: MultiProvider;
+  private readonly inventoryPlanner: InventoryPlanner;
+  private readonly intentResolver: InventoryIntentResolver;
+  private readonly bridgeCapacityEstimator: BridgeCapacityEstimator;
+  private readonly movementExecutor: InventoryMovementExecutor;
+  private readonly transferRemoteExecutor: TransferRemoteExecutor;
 
   /**
    * Internal balance storage for inventory tracking.
@@ -227,6 +122,53 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     this.warpCore = warpCore;
     this.multiProvider = multiProvider;
     this.logger = logger;
+
+    this.inventoryPlanner = new InventoryPlanner(
+      () => this.inventoryBalances,
+      () => this.consumedInventory,
+      this.multiProvider,
+      this.warpCore,
+      this.getTokenForChain.bind(this),
+      this.getInventorySignerAddress.bind(this),
+      this.logger,
+    );
+    this.bridgeCapacityEstimator = new BridgeCapacityEstimator(
+      this.multiProvider,
+      this.getExternalBridge.bind(this),
+      this.getNativeTokenAddress.bind(this),
+      this.getTokenForChain.bind(this),
+      this.getInventorySignerAddress.bind(this),
+      this.logger,
+    );
+    this.movementExecutor = new InventoryMovementExecutor(
+      this.config,
+      this.actionTracker,
+      () => this.consumedInventory,
+      this.multiProvider,
+      this.getExternalBridge.bind(this),
+      this.getNativeTokenAddress.bind(this),
+      this.getTokenForChain.bind(this),
+      this.getProtocolForChain.bind(this),
+      this.getInventorySignerAddress.bind(this),
+      this.logger,
+    );
+    this.transferRemoteExecutor = new TransferRemoteExecutor(
+      this.actionTracker,
+      this.warpCore,
+      this.multiProvider,
+      this.getTokenForChain.bind(this),
+      this.getInventorySignerAddress.bind(this),
+      (chain, typedTx) => this.sendAndConfirmInventoryTx(chain, typedTx),
+      (origin, txHash) => this.extractDispatchedMessageId(origin, txHash),
+      this.logger,
+    );
+    this.intentResolver = new InventoryIntentResolver(
+      this.actionTracker,
+      this.multiProvider,
+      this.executeRoute.bind(this),
+      this.consumeSuccessfulRoute.bind(this),
+      this.logger,
+    );
 
     // Validate that all tokens are collateral-backed
     // Synthetic tokens cannot be used with inventory rebalancing because:
@@ -344,68 +286,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   }
 
   /**
-   * Get available inventory for a chain.
-   * Returns 0n for unknown chains.
-   */
-  private getAvailableInventory(chain: ChainName): bigint {
-    return this.inventoryBalances.get(chain) ?? 0n;
-  }
-
-  /**
-   * Get all inventory balances.
-   */
-  private getBalances(): Map<ChainName, bigint> {
-    return this.inventoryBalances;
-  }
-
-  /**
-   * Calculate total inventory across all chains, excluding specified chains.
-   */
-  private getTotalInventory(excludeChains: ChainName[]): bigint {
-    const excludeSet = new Set(excludeChains);
-    let total = 0n;
-    for (const [chain, balance] of this.inventoryBalances) {
-      if (!excludeSet.has(chain)) {
-        total += balance;
-      }
-    }
-    return total;
-  }
-
-  private formatLocalAmount(amount: bigint, token: Token): string {
-    return fromWei(amount.toString(), token.decimals);
-  }
-
-  /**
-   * Get the effective available inventory for a chain, accounting for
-   * inventory already consumed during this execution cycle.
-   *
-   * This prevents over-execution when multiple routes withdraw from the same chain.
-   *
-   * @param chain - The chain to check inventory for
-   * @returns Effective available inventory (cached - consumed)
-   */
-  private getEffectiveAvailableInventory(chain: ChainName): bigint {
-    const cached = this.getAvailableInventory(chain);
-    const consumed = this.consumedInventory.get(chain) ?? 0n;
-    const effective = cached > consumed ? cached - consumed : 0n;
-
-    if (consumed > 0n) {
-      this.logger.debug(
-        {
-          chain,
-          cachedInventory: cached.toString(),
-          consumedThisCycle: consumed.toString(),
-          effectiveInventory: effective.toString(),
-        },
-        'Calculated effective inventory after prior executions',
-      );
-    }
-
-    return effective;
-  }
-
-  /**
    * Execute inventory-based rebalances for the given routes.
    *
    * Single-intent architecture:
@@ -422,181 +302,19 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     }
 
     this.consumedInventory.clear();
-
-    // 1. Check for existing in_progress intent
-    const activeIntent = await this.getActiveInventoryIntent();
-
-    if (activeIntent) {
-      if (activeIntent.hasInflightDeposit) {
-        this.logger.info(
-          {
-            intentId: activeIntent.intent.id,
-            remaining: activeIntent.remaining.toString(),
-          },
-          'Active intent has in-flight deposit, waiting for delivery before continuing',
-        );
-        return [];
-      }
-      // Continue existing intent, ignore new routes
-      this.logger.info(
-        {
-          intentId: activeIntent.intent.id,
-          remaining: activeIntent.remaining.toString(),
-          newRoutesIgnored: routes.length,
-        },
-        'Continuing existing intent, ignoring new routes',
-      );
-      return this.continueIntent(activeIntent);
-    }
-
-    // 2. No existing intent - take first route only
-    if (routes.length === 0) return [];
-
-    const route = routes[0];
-    if (routes.length > 1) {
-      this.logger.info(
-        {
-          selectedRoute: `${route.origin} → ${route.destination}`,
-          discardedCount: routes.length - 1,
-        },
-        'Taking first route only, discarding others',
-      );
-    }
-
-    // 3. Create intent and execute
-    const intent = await this.actionTracker.createRebalanceIntent({
-      origin: this.multiProvider.getDomainId(route.origin),
-      destination: this.multiProvider.getDomainId(route.destination),
-      amount: route.amount,
-      executionMethod: 'inventory',
-      externalBridge: route.externalBridge,
-    });
-
-    this.logger.debug(
-      {
-        intentId: intent.id,
-        origin: route.origin,
-        destination: route.destination,
-        amount: route.amount.toString(),
-      },
-      'Created new inventory rebalance intent',
-    );
-
-    try {
-      const result = await this.executeRoute(route, intent);
-
-      // Update consumed inventory on success
-      if (result.success && result.amountSent) {
-        const current = this.consumedInventory.get(route.destination) ?? 0n;
-        this.consumedInventory.set(
-          route.destination,
-          current + result.amountSent,
-        );
-      }
-
-      return [result];
-    } catch (error) {
-      this.logger.error(
-        {
-          route,
-          intentId: intent.id,
-          error: (error as Error).message,
-        },
-        'Failed to execute inventory route',
-      );
-
-      return [
-        {
-          route,
-          success: false,
-          error: (error as Error).message,
-        },
-      ];
-    }
+    return this.intentResolver.rebalance(routes);
   }
 
-  /**
-   * Get the single active inventory intent (if any).
-   * Returns null if no in_progress inventory intent exists.
-   */
-  private async getActiveInventoryIntent(): Promise<PartialInventoryIntent | null> {
-    const partialIntents =
-      await this.actionTracker.getPartiallyFulfilledInventoryIntents();
-    return partialIntents.length > 0 ? partialIntents[0] : null;
-  }
-
-  /**
-   * Continue execution of an existing partial intent.
-   * Uses the pre-computed remaining amount from PartialInventoryIntent.
-   */
-  private async continueIntent(
-    partial: PartialInventoryIntent,
-  ): Promise<InventoryExecutionResult[]> {
-    const { intent, remaining } = partial;
-
-    const route: InventoryRoute = {
-      origin: this.multiProvider.getChainName(intent.origin),
-      destination: this.multiProvider.getChainName(intent.destination),
-      amount: remaining,
-      executionType: 'inventory',
-      externalBridge: intent.externalBridge!,
-    };
-
-    this.logger.info(
-      {
-        intentId: intent.id,
-        origin: route.origin,
-        destination: route.destination,
-        remaining: remaining.toString(),
-        completed: partial.completedAmount.toString(),
-        total: intent.amount.toString(),
-      },
-      'Continuing partial inventory intent',
-    );
-
-    // Warn if intent never started - indicates previous execution attempt failed
-    // without creating any actions (e.g., all bridges failed viability check)
-    if (intent.status === 'not_started') {
-      this.logger.warn(
-        {
-          intentId: intent.id,
-          origin: route.origin,
-          destination: route.destination,
-        },
-        'Retrying intent that never started - previous execution attempt failed without creating any actions',
+  private consumeSuccessfulRoute(
+    route: InventoryRoute,
+    result: InventoryExecutionResult,
+  ): void {
+    if (result.success && result.amountSent) {
+      const current = this.consumedInventory.get(route.destination) ?? 0n;
+      this.consumedInventory.set(
+        route.destination,
+        current + result.amountSent,
       );
-    }
-
-    try {
-      const result = await this.executeRoute(route, intent);
-
-      // Update consumed inventory on success
-      if (result.success && result.amountSent) {
-        const current = this.consumedInventory.get(route.destination) ?? 0n;
-        this.consumedInventory.set(
-          route.destination,
-          current + result.amountSent,
-        );
-      }
-
-      return [result];
-    } catch (error) {
-      this.logger.error(
-        {
-          route,
-          intentId: intent.id,
-          error: (error as Error).message,
-        },
-        'Failed to continue partial inventory intent',
-      );
-
-      return [
-        {
-          route,
-          success: false,
-          error: (error as Error).message,
-        },
-      ];
     }
   }
 
@@ -632,136 +350,15 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       'Executing inventory route',
     );
 
-    const sourceToken = this.getTokenForChain(destination);
-    assert(sourceToken, `No token found for source chain: ${destination}`);
-    const requestedLocalAmount = denormalizeToLocal(amount, sourceToken);
-    const executionSender = this.getInventorySignerAddress(destination);
-    const executionRecipient = this.getInventorySignerAddress(origin);
-
-    // Check available inventory on the DESTINATION (deficit) chain
-    // We need inventory here because transferRemote is called FROM this chain
-    const availableInventory = this.getEffectiveAvailableInventory(destination);
-
-    this.logger.info(
-      {
-        checkingChain: destination,
-        availableInventory: availableInventory.toString(),
-        availableInventoryFormatted: this.formatLocalAmount(
-          availableInventory,
-          sourceToken,
-        ),
-        requiredAmount: requestedLocalAmount.toString(),
-        requiredAmountFormatted: this.formatLocalAmount(
-          requestedLocalAmount,
-          sourceToken,
-        ),
-      },
-      'Checking effective inventory on destination (deficit) chain',
-    );
-
-    // Calculate transfer costs including max transferable and min viable amounts
-    // transferRemote is called FROM destination TO origin (swapped direction)
-    const costs = await calculateTransferCosts(
-      destination, // FROM chain (where transferRemote is called)
-      origin, // TO chain (where Hyperlane message goes)
-      availableInventory,
+    const plan = await this.inventoryPlanner.buildTransferPlan(route, intent);
+    const {
+      sourceToken,
       requestedLocalAmount,
-      this.multiProvider,
-      this.warpCore.multiProvider,
-      this.getTokenForChain.bind(this),
-      executionSender,
-      isNativeTokenStandard,
-      this.logger,
-    );
-    const { minViableTransfer } = costs;
-    let maxTransferable = costs.maxTransferable;
-
-    if (!isNativeTokenStandard(sourceToken.standard)) {
-      if (availableInventory === 0n) {
-        maxTransferable = 0n;
-        this.logger.debug(
-          {
-            fromChain: destination,
-            toChain: origin,
-            requestedAmount: requestedLocalAmount.toString(),
-          },
-          'Skipping fee-aware max transferable probe because destination inventory is zero',
-        );
-      } else {
-        try {
-          const feeAwareMaxTransfer = await this.warpCore.getMaxTransferAmount({
-            balance: sourceToken.amount(availableInventory),
-            destination: origin,
-            sender: executionSender,
-            recipient: executionRecipient,
-          });
-
-          maxTransferable =
-            feeAwareMaxTransfer.amount < requestedLocalAmount
-              ? feeAwareMaxTransfer.amount
-              : requestedLocalAmount;
-
-          this.logger.debug(
-            {
-              fromChain: destination,
-              toChain: origin,
-              availableInventory: availableInventory.toString(),
-              requestedAmount: requestedLocalAmount.toString(),
-              feeAwareMaxTransferable: maxTransferable.toString(),
-            },
-            'Calculated fee-aware max transferable amount for non-native route',
-          );
-        } catch (error) {
-          if (!isRecoverableMaxTransferProbeError(error)) {
-            throw error;
-          }
-
-          maxTransferable = 0n;
-          this.logger.warn(
-            {
-              fromChain: destination,
-              toChain: origin,
-              availableInventory: availableInventory.toString(),
-              requestedAmount: requestedLocalAmount.toString(),
-              error: error instanceof Error ? error.message : String(error),
-              intentId: intent.id,
-            },
-            'Fee-aware max transferable probe failed due to insufficient balance, falling back to external bridge',
-          );
-        }
-      }
-    }
-
-    // Calculate total inventory across all chains
-    // Note: consumedInventory tracking is handled separately within this cycle
-    const totalInventory = this.getTotalInventory([]);
-
-    this.logger.info(
-      {
-        fromChain: destination,
-        toChain: origin,
-        availableInventoryFormatted: this.formatLocalAmount(
-          availableInventory,
-          sourceToken,
-        ),
-        requestedAmountFormatted: this.formatLocalAmount(
-          requestedLocalAmount,
-          sourceToken,
-        ),
-        maxTransferableFormatted: this.formatLocalAmount(
-          maxTransferable,
-          sourceToken,
-        ),
-        minViableTransferFormatted: this.formatLocalAmount(
-          minViableTransfer,
-          sourceToken,
-        ),
-        canFullyFulfill: maxTransferable >= requestedLocalAmount,
-        canPartialFulfill: maxTransferable >= minViableTransfer,
-        totalInventory: totalInventory.toString(),
-      },
-      'Calculated max transferable amount with cost-based threshold',
-    );
+      availableInventory,
+      maxTransferable,
+      minViableTransfer,
+      totalCost,
+    } = plan;
 
     // Early exit: If remaining amount is below minViableTransfer, complete the intent
     // This prevents infinite loops when the remaining amount is too small to economically bridge
@@ -786,16 +383,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
     // Swap the route for executeTransferRemote: destination → origin
     // This ensures transferRemote is called FROM destination, ADDING collateral there
-    const swappedRoute: InventoryRoute = {
-      ...route,
-      origin: destination, // transferRemote called FROM here
-      destination: origin, // Hyperlane message goes TO here
-      amount: requestedLocalAmount,
-    };
+    const swappedRoute = this.inventoryPlanner.buildSwappedRoute(
+      route,
+      requestedLocalAmount,
+    );
 
     if (maxTransferable >= requestedLocalAmount) {
       // Sufficient inventory on destination - execute transferRemote directly
-      const fulfilledCanonicalAmount = normalizeToCanonical(
+      const fulfilledCanonicalAmount = this.inventoryPlanner.canonicalAmount(
         requestedLocalAmount,
         sourceToken,
       );
@@ -808,7 +403,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       return { ...result, route };
     } else if (maxTransferable > 0n && maxTransferable >= minViableTransfer) {
       // Partial transfer: Transfer available inventory when economically viable
-      const alignedExecution = alignLocalToCanonical(
+      const alignedExecution = this.inventoryPlanner.alignLocalToCanonical(
         maxTransferable,
         sourceToken,
       );
@@ -857,14 +452,16 @@ export class InventoryRebalancer implements IInventoryRebalancer {
         targetChain: destination,
         maxTransferable: maxTransferable.toString(),
         minViableTransfer: minViableTransfer.toString(),
-        costMultiplier: MIN_VIABLE_COST_MULTIPLIER.toString(),
+        costMultiplier: this.inventoryPlanner
+          .minViableCostMultiplier()
+          .toString(),
         intentId: intent.id,
       },
       'Inventory below cost-based threshold on destination, triggering LiFi movement',
     );
 
     // Get all available source chains with raw inventory
-    const allSources = this.selectAllSourceChains(destination);
+    const allSources = this.inventoryPlanner.selectAllSourceChains(destination);
 
     if (allSources.length === 0) {
       this.logger.warn(
@@ -892,12 +489,13 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     }> = [];
 
     for (const source of allSources) {
-      const capacity = await this.calculateBridgeCapacity(
-        source.chain,
-        destination,
-        source.availableAmount,
-        route.externalBridge,
-      );
+      const capacity =
+        await this.bridgeCapacityEstimator.calculateBridgeCapacity(
+          source.chain,
+          destination,
+          source.availableAmount,
+          route.externalBridge,
+        );
 
       if (capacity.maxTargetOutput > 0n) {
         viableSources.push({ chain: source.chain, ...capacity });
@@ -926,40 +524,13 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       };
     }
 
-    // Create bridge plans using destination-local output amounts.
-    const shortfall =
-      requestedLocalAmount > availableInventory
-        ? requestedLocalAmount - availableInventory
-        : 0n;
-    const targetWithBuffer =
-      ((shortfall + costs.totalCost) * (100n + BRIDGE_BUFFER_PERCENT)) / 100n;
-    const bridgePlans: Array<{
-      chain: ChainName;
-      maxSourceInput: bigint;
-      targetOutput: bigint;
-      quoteMode: BridgeQuoteMode;
-    }> = [];
-    let totalPlanned = 0n;
-
-    for (const source of viableSources) {
-      if (totalPlanned >= targetWithBuffer) break;
-
-      const remaining = targetWithBuffer - totalPlanned;
-      const targetOutput =
-        source.maxTargetOutput >= remaining
-          ? remaining
-          : source.maxTargetOutput;
-      const quoteMode: BridgeQuoteMode =
-        source.maxTargetOutput > remaining ? 'reverse' : 'forward';
-
-      bridgePlans.push({
-        chain: source.chain,
-        maxSourceInput: source.maxSourceInput,
-        targetOutput,
-        quoteMode,
-      });
-      totalPlanned += targetOutput;
-    }
+    const { bridgePlans, shortfall, targetWithBuffer, totalPlanned } =
+      this.inventoryPlanner.buildBridgePlans(
+        viableSources,
+        requestedLocalAmount,
+        availableInventory,
+        totalCost,
+      );
 
     this.logger.info(
       {
@@ -1096,96 +667,11 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     intent: RebalanceIntent,
     fulfilledCanonicalAmount: bigint,
   ): Promise<InventoryExecutionResult> {
-    const { origin, destination, amount } = route;
-
-    const originToken = this.getTokenForChain(origin);
-    if (!originToken) {
-      throw new Error(`No token found for origin chain: ${origin}`);
-    }
-
-    const destinationDomain = this.multiProvider.getDomainId(destination);
-
-    this.logger.debug(
-      { origin, destination, amount: amount.toString() },
-      'Building transferRemote transactions for exact execution amount',
-    );
-
-    const originTokenAmount = originToken.amount(amount);
-    const transferTxs = await this.warpCore.getTransferRemoteTxs({
-      originTokenAmount,
-      destination,
-      sender: this.getInventorySignerAddress(origin),
-      recipient: this.getInventorySignerAddress(destination),
-    });
-    assert(
-      transferTxs.length > 0,
-      'Expected at least one transaction from WarpCore',
-    );
-
-    this.logger.info(
-      {
-        origin,
-        destination,
-        amount: amount.toString(),
-        transactionCount: transferTxs.length,
-        intentId: intent.id,
-      },
-      'Sending transferRemote transactions',
-    );
-
-    let transferTxHash: string | undefined;
-    for (const tx of transferTxs) {
-      const { txHash } = await this.sendAndConfirmInventoryTx(origin, tx);
-      if (tx.category === WarpTxCategory.Transfer) {
-        transferTxHash = txHash;
-      }
-    }
-
-    const messageId = transferTxHash
-      ? await this.extractDispatchedMessageId(origin, transferTxHash)
-      : undefined;
-
-    assert(transferTxHash, 'No transfer transaction hash found');
-
-    if (!messageId) {
-      this.logger.warn(
-        {
-          origin,
-          destination,
-          txHash: transferTxHash,
-          intentId: intent.id,
-        },
-        'TransferRemote transaction sent but no messageId found in logs',
-      );
-    }
-
-    this.logger.info(
-      {
-        origin,
-        destination,
-        txHash: transferTxHash,
-        messageId,
-        intentId: intent.id,
-      },
-      'TransferRemote transaction confirmed',
-    );
-
-    // Create the inventory_deposit action with messageId for tracking
-    await this.actionTracker.createRebalanceAction({
-      intentId: intent.id,
-      origin: this.multiProvider.getDomainId(origin),
-      destination: destinationDomain,
-      amount: fulfilledCanonicalAmount,
-      type: 'inventory_deposit',
-      txHash: transferTxHash,
-      messageId,
-    });
-
-    return {
+    return this.transferRemoteExecutor.executeTransferRemote(
       route,
-      success: true,
-      amountSent: amount,
-    };
+      intent,
+      fulfilledCanonicalAmount,
+    );
   }
 
   private async sendAndConfirmInventoryTx(
@@ -1301,147 +787,6 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   }
 
   /**
-   * Select all source chains with available inventory for bridging.
-   * Returns sources sorted by available amount (highest first).
-   */
-  private selectAllSourceChains(
-    targetChain: ChainName,
-  ): Array<{ chain: ChainName; availableAmount: bigint }> {
-    const balances = this.getBalances();
-    const sources: Array<{ chain: ChainName; availableAmount: bigint }> = [];
-
-    for (const [chainName, balance] of balances) {
-      if (chainName === targetChain) continue;
-
-      const consumed = this.consumedInventory.get(chainName) ?? 0n;
-      const effectiveAvailable = balance > consumed ? balance - consumed : 0n;
-
-      if (effectiveAvailable > 0n) {
-        sources.push({
-          chain: chainName,
-          availableAmount: effectiveAvailable,
-        });
-      }
-    }
-
-    // Sort by available amount descending (bridge from largest sources first)
-    return sources.sort((a, b) =>
-      a.availableAmount > b.availableAmount ? -1 : 1,
-    );
-  }
-
-  /**
-   * Calculate the bridge capacity from a source chain in destination-local units.
-   * Uses LiFi quotes to conservatively estimate the destination output available
-   * from the source chain's current local inventory.
-   *
-   * For native-token sources, gas is reserved from the source inventory and the
-   * output capacity is re-quoted from the remaining source input.
-   */
-  private async calculateBridgeCapacity(
-    sourceChain: ChainName,
-    targetChain: ChainName,
-    rawInventory: bigint,
-    externalBridgeType: ExternalBridgeType,
-  ): Promise<BridgeCapacity> {
-    const sourceToken = this.getTokenForChain(sourceChain);
-    const targetToken = this.getTokenForChain(targetChain);
-    assert(sourceToken, `No token found for source chain: ${sourceChain}`);
-    assert(targetToken, `No token found for target chain: ${targetChain}`);
-
-    // Convert HypNative token addresses to the external bridge's native token representation
-    const fromTokenAddress = getExternalBridgeTokenAddress(
-      sourceToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-    const toTokenAddress = getExternalBridgeTokenAddress(
-      targetToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-
-    const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
-    const targetChainId = Number(this.multiProvider.getChainId(targetChain));
-
-    try {
-      const externalBridge = this.getExternalBridge(externalBridgeType);
-      const initialQuote = await externalBridge.quote({
-        fromChain: sourceChainId,
-        toChain: targetChainId,
-        fromToken: fromTokenAddress,
-        toToken: toTokenAddress,
-        fromAmount: rawInventory,
-        fromAddress: this.getInventorySignerAddress(sourceChain),
-        toAddress: this.getInventorySignerAddress(targetChain),
-      });
-
-      let maxSourceInput = rawInventory;
-      let outputQuote = initialQuote;
-
-      if (isNativeTokenStandard(sourceToken.standard)) {
-        const estimatedGas = initialQuote.gasCosts * GAS_COST_MULTIPLIER;
-        const maxGasThreshold = rawInventory / MAX_GAS_PERCENT_THRESHOLD;
-        if (estimatedGas > maxGasThreshold) {
-          this.logger.info(
-            {
-              sourceChain,
-              targetChain,
-              rawInventory: rawInventory.toString(),
-              quotedGas: initialQuote.gasCosts.toString(),
-              estimatedGas: estimatedGas.toString(),
-              maxGasThreshold: maxGasThreshold.toString(),
-            },
-            'Bridge not viable - gas cost exceeds 10% of inventory',
-          );
-          return { maxSourceInput: 0n, maxTargetOutput: 0n };
-        }
-
-        maxSourceInput = rawInventory - estimatedGas;
-        if (maxSourceInput <= 0n) {
-          return { maxSourceInput: 0n, maxTargetOutput: 0n };
-        }
-
-        outputQuote = await externalBridge.quote({
-          fromChain: sourceChainId,
-          toChain: targetChainId,
-          fromToken: fromTokenAddress,
-          toToken: toTokenAddress,
-          fromAmount: maxSourceInput,
-          fromAddress: this.getInventorySignerAddress(sourceChain),
-          toAddress: this.getInventorySignerAddress(targetChain),
-        });
-      }
-
-      this.logger.info(
-        {
-          sourceChain,
-          targetChain,
-          rawInventory: rawInventory.toString(),
-          maxSourceInput: maxSourceInput.toString(),
-          maxTargetOutput: outputQuote.toAmountMin.toString(),
-        },
-        'Calculated bridge capacity',
-      );
-
-      return {
-        maxSourceInput,
-        maxTargetOutput: outputQuote.toAmountMin,
-      };
-    } catch (error) {
-      this.logger.warn(
-        {
-          sourceChain,
-          targetChain,
-          error: (error as Error).message,
-        },
-        'Failed to calculate bridge capacity, skipping chain',
-      );
-      return { maxSourceInput: 0n, maxTargetOutput: 0n };
-    }
-  }
-
-  /**
    * Execute inventory movement from source chain to target chain via LiFi bridge.
    *
    * Quote mode is chosen during planning:
@@ -1466,227 +811,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     intent: RebalanceIntent,
     externalBridgeType: ExternalBridgeType,
   ): Promise<InventoryMovementExecutionResult> {
-    const sourceToken = this.getTokenForChain(sourceChain);
-    if (!sourceToken) {
-      return {
-        success: false,
-        error: `No token found for source chain: ${sourceChain}`,
-      };
-    }
-
-    const targetToken = this.getTokenForChain(targetChain);
-    if (!targetToken) {
-      return {
-        success: false,
-        error: `No token found for target chain: ${targetChain}`,
-      };
-    }
-
-    // Get chain IDs for the external bridge (not domain IDs)
-    // Convert to number since getChainId can return string | number
-    const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
-    const targetChainId = Number(this.multiProvider.getChainId(targetChain));
-
-    // Convert HypNative token addresses to the external bridge's native token representation
-    // For HypNative tokens, addressOrDenom is the warp route contract, not the native token
-    const fromTokenAddress = getExternalBridgeTokenAddress(
-      sourceToken,
+    return this.movementExecutor.executeInventoryMovement(
+      sourceChain,
+      targetChain,
+      targetOutputAmount,
+      maxSourceInput,
+      quoteMode,
+      intent,
       externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
     );
-
-    const toTokenAddress = getExternalBridgeTokenAddress(
-      targetToken,
-      externalBridgeType,
-      this.getNativeTokenAddress.bind(this),
-    );
-
-    this.logger.debug(
-      {
-        sourceTokenStandard: sourceToken.standard,
-        targetTokenStandard: targetToken.standard,
-        fromTokenAddress,
-        toTokenAddress,
-      },
-      'Resolved token addresses for LiFi bridge',
-    );
-
-    try {
-      const externalBridge = this.getExternalBridge(externalBridgeType);
-      const fromAddress = this.getInventorySignerAddress(sourceChain);
-      const toAddress = this.getInventorySignerAddress(targetChain);
-      const quoteWithMode = async (mode: BridgeQuoteMode) =>
-        externalBridge.quote({
-          fromChain: sourceChainId,
-          toChain: targetChainId,
-          fromToken: fromTokenAddress,
-          toToken: toTokenAddress,
-          ...(mode === 'forward'
-            ? { fromAmount: maxSourceInput }
-            : { toAmount: targetOutputAmount }),
-          fromAddress,
-          toAddress,
-        });
-
-      let quoteModeUsed = quoteMode;
-      let quote = await quoteWithMode(quoteModeUsed);
-
-      if (quoteModeUsed === 'reverse' && quote.fromAmount > maxSourceInput) {
-        this.logger.warn(
-          {
-            sourceChain,
-            targetChain,
-            plannedQuoteMode: quoteMode,
-            requestedTargetOutput: targetOutputAmount.toString(),
-            quotedInput: quote.fromAmount.toString(),
-            maxSourceInput: maxSourceInput.toString(),
-            intentId: intent.id,
-          },
-          'Reverse bridge quote exceeded source capacity, retrying with forward quote',
-        );
-
-        // Spend the full source cap on fallback; minor output drift is acceptable
-        // and will be reconciled by later cycles rather than risking livelock.
-        quoteModeUsed = 'forward';
-        quote = await quoteWithMode(quoteModeUsed);
-      }
-
-      const inputRequired = quote.fromAmount;
-      if (inputRequired > maxSourceInput) {
-        return {
-          success: false,
-          error: `Bridge input ${inputRequired} exceeded planned source capacity ${maxSourceInput}`,
-        };
-      }
-
-      this.logger.info(
-        {
-          sourceChain,
-          targetChain,
-          sourceChainId,
-          targetChainId,
-          requestedTargetOutput: targetOutputAmount.toString(),
-          requestedTargetOutputFormatted: this.formatLocalAmount(
-            targetOutputAmount,
-            targetToken,
-          ),
-          quoteModePlanned: quoteMode,
-          quoteModeUsed,
-          retriedAsForward:
-            quoteMode === 'reverse' && quoteModeUsed === 'forward',
-          inputRequired: inputRequired.toString(),
-          inputRequiredFormatted: this.formatLocalAmount(
-            inputRequired,
-            sourceToken,
-          ),
-          quotedOutput: quote.toAmount.toString(),
-          quotedOutputMin: quote.toAmountMin.toString(),
-          quotedOutputFormatted: this.formatLocalAmount(
-            quote.toAmount,
-            targetToken,
-          ),
-          quotedOutputMinFormatted: this.formatLocalAmount(
-            quote.toAmountMin,
-            targetToken,
-          ),
-          gasCosts: quote.gasCosts.toString(),
-          feeCosts: quote.feeCosts.toString(),
-          intentId: intent.id,
-        },
-        'Executing inventory movement via bridge quote',
-      );
-
-      this.logger.debug(
-        {
-          quoteId: quote.id,
-          tool: quote.tool,
-          fromAmount: quote.fromAmount.toString(),
-          toAmount: quote.toAmount.toString(),
-          toAmountMin: quote.toAmountMin.toString(),
-          executionDuration: quote.executionDuration,
-          gasCosts: quote.gasCosts.toString(),
-          feeCosts: quote.feeCosts.toString(),
-        },
-        'Received LiFi quote for inventory movement',
-      );
-
-      // Build private keys map from all available inventory signers
-      const privateKeys: Partial<Record<ProtocolType, string>> = {};
-      for (const [protocol, cfg] of Object.entries(
-        this.config.inventorySigners,
-      )) {
-        if (cfg?.key) {
-          privateKeys[protocol as ProtocolType] = cfg.key;
-        }
-      }
-      const sourceProtocol = this.getProtocolForChain(sourceChain);
-      assert(
-        privateKeys[sourceProtocol],
-        `Missing inventory signer key for protocol ${sourceProtocol} (chain ${sourceChain})`,
-      );
-      const result = await externalBridge.execute(quote, privateKeys);
-
-      this.logger.info(
-        {
-          sourceChain,
-          targetChain,
-          txHash: result.txHash,
-          intentId: intent.id,
-        },
-        'Inventory movement transaction executed',
-      );
-
-      // Keep bridge consumption in source-local units; intent fulfillment only
-      // advances from canonical inventory_deposit amounts after transferRemote.
-      await this.actionTracker.createRebalanceAction({
-        intentId: intent.id,
-        origin: this.multiProvider.getDomainId(sourceChain),
-        destination: this.multiProvider.getDomainId(targetChain),
-        amount: inputRequired,
-        type: 'inventory_movement',
-        txHash: result.txHash,
-        externalBridgeId: externalBridgeType,
-      });
-
-      // Track consumed inventory on source chain for this cycle
-      const currentConsumed = this.consumedInventory.get(sourceChain) ?? 0n;
-      this.consumedInventory.set(sourceChain, currentConsumed + inputRequired);
-
-      this.logger.debug(
-        {
-          sourceChain,
-          amountConsumed: inputRequired.toString(),
-          totalConsumed: (currentConsumed + inputRequired).toString(),
-        },
-        'Updated consumed inventory after LiFi bridge',
-      );
-
-      return {
-        success: true,
-        txHash: result.txHash,
-        inputRequired,
-        quotedOutput: quote.toAmount,
-        quotedOutputMin: quote.toAmountMin,
-        quoteModeUsed,
-      };
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      this.logger.error(
-        {
-          sourceChain,
-          targetChain,
-          amount: targetOutputAmount.toString(),
-          intentId: intent.id,
-          error: errorMessage,
-        },
-        'Failed to execute inventory movement',
-      );
-
-      return {
-        success: false,
-        error: errorMessage,
-      };
-    }
   }
 }

--- a/typescript/rebalancer/src/core/inventory/BridgeCapacityEstimator.test.ts
+++ b/typescript/rebalancer/src/core/inventory/BridgeCapacityEstimator.test.ts
@@ -1,0 +1,161 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+
+import type { ChainName, MultiProvider, Token } from '@hyperlane-xyz/sdk';
+import { TokenStandard } from '@hyperlane-xyz/sdk';
+
+import { ExternalBridgeType } from '../../config/types.js';
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../../interfaces/IExternalBridge.js';
+import { BridgeCapacityEstimator } from './BridgeCapacityEstimator.js';
+
+const logger = pino({ level: 'silent' });
+
+function quoteFrom(
+  params: BridgeQuoteParams,
+  overrides: Partial<BridgeQuote> = {},
+): BridgeQuote {
+  return {
+    id: 'quote',
+    tool: 'test',
+    fromAmount: params.fromAmount ?? 0n,
+    toAmount: params.fromAmount ?? 0n,
+    toAmountMin: params.fromAmount ?? 0n,
+    executionDuration: 1,
+    gasCosts: 0n,
+    feeCosts: 0n,
+    route: undefined,
+    requestParams: params,
+    ...overrides,
+  };
+}
+
+function token(standard: TokenStandard): Token {
+  return {
+    addressOrDenom: '0x1111111111111111111111111111111111111111',
+    collateralAddressOrDenom: '0x2222222222222222222222222222222222222222',
+    decimals: 18,
+    standard,
+  } as unknown as Token;
+}
+
+function bridgeWithQuote(
+  quote: (params: BridgeQuoteParams) => Promise<BridgeQuote>,
+): IExternalBridge {
+  return {
+    externalBridgeId: 'test',
+    logger,
+    quote,
+    execute: async (): Promise<BridgeTransferResult> => ({
+      txHash: '0x0',
+      fromChain: 1,
+      toChain: 2,
+    }),
+    getStatus: async (): Promise<BridgeTransferStatus> => ({
+      status: 'pending',
+    }),
+  };
+}
+
+describe('BridgeCapacityEstimator', () => {
+  const arbitrum = 'arbitrum' as ChainName;
+  const base = 'base' as ChainName;
+  const multiProvider = {
+    getChainId: (chain: ChainName) => (chain === arbitrum ? 42161 : 8453),
+  } as unknown as MultiProvider;
+
+  it('rejects native bridge capacity when gas exceeds threshold', async () => {
+    const quoteCalls: BridgeQuoteParams[] = [];
+    const estimator = new BridgeCapacityEstimator(
+      multiProvider,
+      () =>
+        bridgeWithQuote(async (params) => {
+          quoteCalls.push(params);
+          return quoteFrom(params, { gasCosts: 6n, toAmountMin: 100n });
+        }),
+      () => '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      () => token(TokenStandard.EvmHypNative),
+      () => '0x0000000000000000000000000000000000000001',
+      logger,
+    );
+
+    const capacity = await estimator.calculateBridgeCapacity(
+      arbitrum,
+      base,
+      1000n,
+      ExternalBridgeType.LiFi,
+    );
+
+    expect(capacity).to.deep.equal({
+      maxSourceInput: 0n,
+      maxTargetOutput: 0n,
+    });
+    expect(quoteCalls).to.have.length(1);
+  });
+
+  it('subtracts estimated gas and requotes viable native capacity', async () => {
+    const quoteCalls: BridgeQuoteParams[] = [];
+    const estimator = new BridgeCapacityEstimator(
+      multiProvider,
+      () =>
+        bridgeWithQuote(async (params) => {
+          quoteCalls.push(params);
+          return quoteFrom(params, {
+            gasCosts: 4n,
+            toAmountMin: params.fromAmount === 920n ? 900n : 1000n,
+          });
+        }),
+      () => '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      () => token(TokenStandard.EvmHypNative),
+      () => '0x0000000000000000000000000000000000000001',
+      logger,
+    );
+
+    const capacity = await estimator.calculateBridgeCapacity(
+      arbitrum,
+      base,
+      1000n,
+      ExternalBridgeType.LiFi,
+    );
+
+    expect(capacity).to.deep.equal({
+      maxSourceInput: 920n,
+      maxTargetOutput: 900n,
+    });
+    expect(quoteCalls.map((params) => params.fromAmount)).to.deep.equal([
+      1000n,
+      920n,
+    ]);
+  });
+
+  it('returns zero capacity when bridge quote throws', async () => {
+    const estimator = new BridgeCapacityEstimator(
+      multiProvider,
+      () =>
+        bridgeWithQuote(async () => {
+          throw new Error('quote unavailable');
+        }),
+      () => '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      () => token(TokenStandard.EvmHypCollateral),
+      () => '0x0000000000000000000000000000000000000001',
+      logger,
+    );
+
+    const capacity = await estimator.calculateBridgeCapacity(
+      arbitrum,
+      base,
+      1000n,
+      ExternalBridgeType.LiFi,
+    );
+
+    expect(capacity).to.deep.equal({
+      maxSourceInput: 0n,
+      maxTargetOutput: 0n,
+    });
+  });
+});

--- a/typescript/rebalancer/src/core/inventory/BridgeCapacityEstimator.ts
+++ b/typescript/rebalancer/src/core/inventory/BridgeCapacityEstimator.ts
@@ -1,0 +1,136 @@
+import type { Logger } from 'pino';
+
+import {
+  type ChainName,
+  type MultiProvider,
+  type Token,
+} from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import type { ExternalBridgeType } from '../../config/types.js';
+import type { IExternalBridge } from '../../interfaces/IExternalBridge.js';
+import {
+  getExternalBridgeTokenAddress,
+  isNativeTokenStandard,
+} from '../../utils/tokenUtils.js';
+import type { BridgeCapacity } from './types.js';
+
+const GAS_COST_MULTIPLIER = 20n;
+const MAX_GAS_PERCENT_THRESHOLD = 10n;
+
+export class BridgeCapacityEstimator {
+  constructor(
+    private readonly multiProvider: MultiProvider,
+    private readonly getExternalBridge: (
+      type: ExternalBridgeType,
+    ) => IExternalBridge,
+    private readonly getNativeTokenAddress: (
+      bridgeType: ExternalBridgeType,
+    ) => string,
+    private readonly getTokenForChain: (chain: ChainName) => Token | undefined,
+    private readonly getInventorySignerAddress: (chain: ChainName) => string,
+    private readonly logger: Logger,
+  ) {}
+
+  async calculateBridgeCapacity(
+    sourceChain: ChainName,
+    targetChain: ChainName,
+    rawInventory: bigint,
+    externalBridgeType: ExternalBridgeType,
+  ): Promise<BridgeCapacity> {
+    const sourceToken = this.getTokenForChain(sourceChain);
+    const targetToken = this.getTokenForChain(targetChain);
+    assert(sourceToken, `No token found for source chain: ${sourceChain}`);
+    assert(targetToken, `No token found for target chain: ${targetChain}`);
+
+    const fromTokenAddress = getExternalBridgeTokenAddress(
+      sourceToken,
+      externalBridgeType,
+      this.getNativeTokenAddress,
+    );
+    const toTokenAddress = getExternalBridgeTokenAddress(
+      targetToken,
+      externalBridgeType,
+      this.getNativeTokenAddress,
+    );
+
+    const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
+    const targetChainId = Number(this.multiProvider.getChainId(targetChain));
+
+    try {
+      const externalBridge = this.getExternalBridge(externalBridgeType);
+      const initialQuote = await externalBridge.quote({
+        fromChain: sourceChainId,
+        toChain: targetChainId,
+        fromToken: fromTokenAddress,
+        toToken: toTokenAddress,
+        fromAmount: rawInventory,
+        fromAddress: this.getInventorySignerAddress(sourceChain),
+        toAddress: this.getInventorySignerAddress(targetChain),
+      });
+
+      let maxSourceInput = rawInventory;
+      let outputQuote = initialQuote;
+
+      if (isNativeTokenStandard(sourceToken.standard)) {
+        const estimatedGas = initialQuote.gasCosts * GAS_COST_MULTIPLIER;
+        const maxGasThreshold = rawInventory / MAX_GAS_PERCENT_THRESHOLD;
+        if (estimatedGas > maxGasThreshold) {
+          this.logger.info(
+            {
+              sourceChain,
+              targetChain,
+              rawInventory: rawInventory.toString(),
+              quotedGas: initialQuote.gasCosts.toString(),
+              estimatedGas: estimatedGas.toString(),
+              maxGasThreshold: maxGasThreshold.toString(),
+            },
+            'Bridge not viable - gas cost exceeds 10% of inventory',
+          );
+          return { maxSourceInput: 0n, maxTargetOutput: 0n };
+        }
+
+        maxSourceInput = rawInventory - estimatedGas;
+        if (maxSourceInput <= 0n) {
+          return { maxSourceInput: 0n, maxTargetOutput: 0n };
+        }
+
+        outputQuote = await externalBridge.quote({
+          fromChain: sourceChainId,
+          toChain: targetChainId,
+          fromToken: fromTokenAddress,
+          toToken: toTokenAddress,
+          fromAmount: maxSourceInput,
+          fromAddress: this.getInventorySignerAddress(sourceChain),
+          toAddress: this.getInventorySignerAddress(targetChain),
+        });
+      }
+
+      this.logger.info(
+        {
+          sourceChain,
+          targetChain,
+          rawInventory: rawInventory.toString(),
+          maxSourceInput: maxSourceInput.toString(),
+          maxTargetOutput: outputQuote.toAmountMin.toString(),
+        },
+        'Calculated bridge capacity',
+      );
+
+      return {
+        maxSourceInput,
+        maxTargetOutput: outputQuote.toAmountMin,
+      };
+    } catch (error) {
+      this.logger.warn(
+        {
+          sourceChain,
+          targetChain,
+          error: (error as Error).message,
+        },
+        'Failed to calculate bridge capacity, skipping chain',
+      );
+      return { maxSourceInput: 0n, maxTargetOutput: 0n };
+    }
+  }
+}

--- a/typescript/rebalancer/src/core/inventory/IntentResolver.test.ts
+++ b/typescript/rebalancer/src/core/inventory/IntentResolver.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+
+import type { MultiProvider } from '@hyperlane-xyz/sdk';
+
+import type { InventoryExecutionResult } from '../../interfaces/IRebalancer.js';
+import type { InventoryRoute } from '../../interfaces/IStrategy.js';
+import type { IActionTracker } from '../../tracking/IActionTracker.js';
+import type { PartialInventoryIntent } from '../../tracking/types.js';
+import { InventoryIntentResolver } from './IntentResolver.js';
+
+const logger = pino({ level: 'silent' });
+
+describe('InventoryIntentResolver', () => {
+  it('fails clearly when continuing an inventory intent without an external bridge', async () => {
+    const partialIntent: PartialInventoryIntent = {
+      intent: {
+        id: 'intent-1',
+        origin: 1,
+        destination: 2,
+        amount: 100n,
+        status: 'in_progress',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      completedAmount: 0n,
+      remaining: 100n,
+      hasInflightDeposit: false,
+    };
+    const actionTracker = {
+      getPartiallyFulfilledInventoryIntents: async () => [partialIntent],
+    } as unknown as IActionTracker;
+    const resolver = new InventoryIntentResolver(
+      actionTracker,
+      {} as MultiProvider,
+      async (): Promise<InventoryExecutionResult> => {
+        throw new Error('executeRoute should not be called');
+      },
+      () => {
+        throw new Error('consumeSuccessfulRoute should not be called');
+      },
+      logger,
+    );
+
+    try {
+      await resolver.rebalance([] as InventoryRoute[]);
+      expect.fail('Expected resolver to reject');
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        'Inventory intent intent-1 is missing externalBridge',
+      );
+    }
+  });
+});

--- a/typescript/rebalancer/src/core/inventory/IntentResolver.ts
+++ b/typescript/rebalancer/src/core/inventory/IntentResolver.ts
@@ -1,0 +1,180 @@
+import type { Logger } from 'pino';
+
+import type { MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import type { InventoryExecutionResult } from '../../interfaces/IRebalancer.js';
+import type { InventoryRoute } from '../../interfaces/IStrategy.js';
+import type { IActionTracker } from '../../tracking/IActionTracker.js';
+import type {
+  PartialInventoryIntent,
+  RebalanceIntent,
+} from '../../tracking/types.js';
+
+export class InventoryIntentResolver {
+  constructor(
+    private readonly actionTracker: IActionTracker,
+    private readonly multiProvider: MultiProvider,
+    private readonly executeRoute: (
+      route: InventoryRoute,
+      intent: RebalanceIntent,
+    ) => Promise<InventoryExecutionResult>,
+    private readonly consumeSuccessfulRoute: (
+      route: InventoryRoute,
+      result: InventoryExecutionResult,
+    ) => void,
+    private readonly logger: Logger,
+  ) {}
+
+  async rebalance(
+    routes: InventoryRoute[],
+  ): Promise<InventoryExecutionResult[]> {
+    const activeIntent = await this.getActiveInventoryIntent();
+
+    if (activeIntent) {
+      if (activeIntent.hasInflightDeposit) {
+        this.logger.info(
+          {
+            intentId: activeIntent.intent.id,
+            remaining: activeIntent.remaining.toString(),
+          },
+          'Active intent has in-flight deposit, waiting for delivery before continuing',
+        );
+        return [];
+      }
+      this.logger.info(
+        {
+          intentId: activeIntent.intent.id,
+          remaining: activeIntent.remaining.toString(),
+          newRoutesIgnored: routes.length,
+        },
+        'Continuing existing intent, ignoring new routes',
+      );
+      return this.continueIntent(activeIntent);
+    }
+
+    if (routes.length === 0) return [];
+
+    const route = routes[0];
+    if (routes.length > 1) {
+      this.logger.info(
+        {
+          selectedRoute: `${route.origin} → ${route.destination}`,
+          discardedCount: routes.length - 1,
+        },
+        'Taking first route only, discarding others',
+      );
+    }
+
+    const intent = await this.actionTracker.createRebalanceIntent({
+      origin: this.multiProvider.getDomainId(route.origin),
+      destination: this.multiProvider.getDomainId(route.destination),
+      amount: route.amount,
+      executionMethod: 'inventory',
+      externalBridge: route.externalBridge,
+    });
+
+    this.logger.debug(
+      {
+        intentId: intent.id,
+        origin: route.origin,
+        destination: route.destination,
+        amount: route.amount.toString(),
+      },
+      'Created new inventory rebalance intent',
+    );
+
+    try {
+      const result = await this.executeRoute(route, intent);
+      this.consumeSuccessfulRoute(route, result);
+      return [result];
+    } catch (error) {
+      this.logger.error(
+        {
+          route,
+          intentId: intent.id,
+          error: (error as Error).message,
+        },
+        'Failed to execute inventory route',
+      );
+
+      return [
+        {
+          route,
+          success: false,
+          error: (error as Error).message,
+        },
+      ];
+    }
+  }
+
+  private async getActiveInventoryIntent(): Promise<PartialInventoryIntent | null> {
+    const partialIntents =
+      await this.actionTracker.getPartiallyFulfilledInventoryIntents();
+    return partialIntents.length > 0 ? partialIntents[0] : null;
+  }
+
+  private async continueIntent(
+    partial: PartialInventoryIntent,
+  ): Promise<InventoryExecutionResult[]> {
+    const { intent, remaining } = partial;
+    assert(
+      intent.externalBridge,
+      `Inventory intent ${intent.id} is missing externalBridge`,
+    );
+
+    const route: InventoryRoute = {
+      origin: this.multiProvider.getChainName(intent.origin),
+      destination: this.multiProvider.getChainName(intent.destination),
+      amount: remaining,
+      executionType: 'inventory',
+      externalBridge: intent.externalBridge,
+    };
+
+    this.logger.info(
+      {
+        intentId: intent.id,
+        origin: route.origin,
+        destination: route.destination,
+        remaining: remaining.toString(),
+        completed: partial.completedAmount.toString(),
+        total: intent.amount.toString(),
+      },
+      'Continuing partial inventory intent',
+    );
+
+    if (intent.status === 'not_started') {
+      this.logger.warn(
+        {
+          intentId: intent.id,
+          origin: route.origin,
+          destination: route.destination,
+        },
+        'Retrying intent that never started - previous execution attempt failed without creating any actions',
+      );
+    }
+
+    try {
+      const result = await this.executeRoute(route, intent);
+      this.consumeSuccessfulRoute(route, result);
+      return [result];
+    } catch (error) {
+      this.logger.error(
+        {
+          route,
+          intentId: intent.id,
+          error: (error as Error).message,
+        },
+        'Failed to continue partial inventory intent',
+      );
+
+      return [
+        {
+          route,
+          success: false,
+          error: (error as Error).message,
+        },
+      ];
+    }
+  }
+}

--- a/typescript/rebalancer/src/core/inventory/InventoryMovementExecutor.test.ts
+++ b/typescript/rebalancer/src/core/inventory/InventoryMovementExecutor.test.ts
@@ -1,0 +1,247 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+
+import type { ChainName, MultiProvider, Token } from '@hyperlane-xyz/sdk';
+import { TokenStandard } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { ExternalBridgeType } from '../../config/types.js';
+import type { InventoryRebalancerConfig } from '../InventoryRebalancer.js';
+import type {
+  BridgeQuote,
+  BridgeQuoteParams,
+  BridgeTransferResult,
+  BridgeTransferStatus,
+  IExternalBridge,
+} from '../../interfaces/IExternalBridge.js';
+import type {
+  CreateRebalanceActionParams,
+  IActionTracker,
+} from '../../tracking/IActionTracker.js';
+import type { RebalanceIntent } from '../../tracking/types.js';
+import { InventoryMovementExecutor } from './InventoryMovementExecutor.js';
+
+const logger = pino({ level: 'silent' });
+
+function token(): Token {
+  return {
+    addressOrDenom: '0x1111111111111111111111111111111111111111',
+    collateralAddressOrDenom: '0x2222222222222222222222222222222222222222',
+    decimals: 18,
+    standard: TokenStandard.EvmHypCollateral,
+  } as unknown as Token;
+}
+
+function quoteFrom(
+  params: BridgeQuoteParams,
+  overrides: Partial<BridgeQuote> = {},
+): BridgeQuote {
+  return {
+    id: 'quote',
+    tool: 'test',
+    fromAmount: params.fromAmount ?? params.toAmount ?? 0n,
+    toAmount: params.toAmount ?? params.fromAmount ?? 0n,
+    toAmountMin: params.toAmount ?? params.fromAmount ?? 0n,
+    executionDuration: 1,
+    gasCosts: 0n,
+    feeCosts: 0n,
+    route: undefined,
+    requestParams: params,
+    ...overrides,
+  };
+}
+
+type BridgeFake = IExternalBridge & {
+  quoteCalls: BridgeQuoteParams[];
+  executedQuotes: BridgeQuote[];
+};
+
+function bridgeWithQuotes(
+  quote: (params: BridgeQuoteParams) => Promise<BridgeQuote>,
+): BridgeFake {
+  const quoteCalls: BridgeQuoteParams[] = [];
+  const executedQuotes: BridgeQuote[] = [];
+
+  return {
+    externalBridgeId: 'test',
+    logger,
+    quoteCalls,
+    executedQuotes,
+    quote: async (params) => {
+      quoteCalls.push(params);
+      return quote(params);
+    },
+    execute: async (quoteToExecute): Promise<BridgeTransferResult> => {
+      executedQuotes.push(quoteToExecute);
+      return {
+        txHash: '0xabc',
+        fromChain: quoteToExecute.requestParams.fromChain,
+        toChain: quoteToExecute.requestParams.toChain,
+      };
+    },
+    getStatus: async (): Promise<BridgeTransferStatus> => ({
+      status: 'pending',
+    }),
+  };
+}
+
+function actionTracker(
+  createdActions: CreateRebalanceActionParams[],
+): IActionTracker {
+  return {
+    createRebalanceAction: async (params: CreateRebalanceActionParams) => {
+      createdActions.push(params);
+      return {
+        id: 'action',
+        status: 'in_progress',
+        createdAt: 1,
+        updatedAt: 1,
+        ...params,
+      };
+    },
+  } as unknown as IActionTracker;
+}
+
+function executor(
+  bridge: IExternalBridge,
+  consumed: Map<ChainName, bigint>,
+  createdActions: CreateRebalanceActionParams[],
+): InventoryMovementExecutor {
+  const config: InventoryRebalancerConfig = {
+    inventorySigners: {
+      [ProtocolType.Ethereum]: {
+        address: '0x0000000000000000000000000000000000000001',
+        key: '0xinventory',
+      },
+    },
+    inventoryChains: [],
+  };
+  const multiProvider = {
+    getChainId: (chain: ChainName) => (chain === arbitrum ? 42161 : 8453),
+    getDomainId: (chain: ChainName) => (chain === arbitrum ? 42161 : 8453),
+  } as unknown as MultiProvider;
+
+  return new InventoryMovementExecutor(
+    config,
+    actionTracker(createdActions),
+    () => consumed,
+    multiProvider,
+    () => bridge,
+    () => '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    () => token(),
+    () => ProtocolType.Ethereum,
+    () => '0x0000000000000000000000000000000000000001',
+    logger,
+  );
+}
+
+const arbitrum = 'arbitrum' as ChainName;
+const base = 'base' as ChainName;
+const intent: RebalanceIntent = {
+  id: 'intent',
+  origin: 42161,
+  destination: 8453,
+  amount: 100n,
+  status: 'in_progress',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+describe('InventoryMovementExecutor', () => {
+  it('falls back from over-cap reverse quote to forward quote and books consumed inventory', async () => {
+    const bridge = bridgeWithQuotes(async (params) => {
+      if (params.toAmount !== undefined) {
+        return quoteFrom(params, {
+          fromAmount: 120n,
+          toAmount: params.toAmount,
+          toAmountMin: params.toAmount,
+        });
+      }
+
+      return quoteFrom(params, {
+        fromAmount: 100n,
+        toAmount: 95n,
+        toAmountMin: 90n,
+      });
+    });
+    const consumed = new Map<ChainName, bigint>([[arbitrum, 7n]]);
+    const createdActions: CreateRebalanceActionParams[] = [];
+
+    const result = await executor(
+      bridge,
+      consumed,
+      createdActions,
+    ).executeInventoryMovement(
+      arbitrum,
+      base,
+      95n,
+      100n,
+      'reverse',
+      intent,
+      ExternalBridgeType.LiFi,
+    );
+
+    expect(result).to.deep.equal({
+      success: true,
+      txHash: '0xabc',
+      inputRequired: 100n,
+      quotedOutput: 95n,
+      quotedOutputMin: 90n,
+      quoteModeUsed: 'forward',
+    });
+    expect(
+      bridge.quoteCalls.map((params) => ({
+        fromAmount: params.fromAmount,
+        toAmount: params.toAmount,
+      })),
+    ).to.deep.equal([
+      { fromAmount: undefined, toAmount: 95n },
+      { fromAmount: 100n, toAmount: undefined },
+    ]);
+    expect(bridge.executedQuotes).to.have.length(1);
+    expect(consumed.get(arbitrum)).to.equal(107n);
+    expect(createdActions).to.deep.include({
+      intentId: 'intent',
+      origin: 42161,
+      destination: 8453,
+      amount: 100n,
+      type: 'inventory_movement',
+      txHash: '0xabc',
+      externalBridgeId: ExternalBridgeType.LiFi,
+    });
+  });
+
+  it('does not execute or consume inventory when forward quote exceeds planned capacity', async () => {
+    const bridge = bridgeWithQuotes(async (params) =>
+      quoteFrom(params, {
+        fromAmount: 101n,
+        toAmount: 95n,
+        toAmountMin: 90n,
+      }),
+    );
+    const consumed = new Map<ChainName, bigint>();
+    const createdActions: CreateRebalanceActionParams[] = [];
+
+    const result = await executor(
+      bridge,
+      consumed,
+      createdActions,
+    ).executeInventoryMovement(
+      arbitrum,
+      base,
+      95n,
+      100n,
+      'forward',
+      intent,
+      ExternalBridgeType.LiFi,
+    );
+
+    expect(result).to.deep.equal({
+      success: false,
+      error: 'Bridge input 101 exceeded planned source capacity 100',
+    });
+    expect(bridge.executedQuotes).to.deep.equal([]);
+    expect(consumed.get(arbitrum)).to.equal(undefined);
+    expect(createdActions).to.deep.equal([]);
+  });
+});

--- a/typescript/rebalancer/src/core/inventory/InventoryMovementExecutor.ts
+++ b/typescript/rebalancer/src/core/inventory/InventoryMovementExecutor.ts
@@ -1,0 +1,266 @@
+import type { Logger } from 'pino';
+
+import {
+  type ChainName,
+  type MultiProvider,
+  type Token,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType, assert, fromWei } from '@hyperlane-xyz/utils';
+
+import type { ExternalBridgeType } from '../../config/types.js';
+import type { InventoryRebalancerConfig } from '../InventoryRebalancer.js';
+import type { IExternalBridge } from '../../interfaces/IExternalBridge.js';
+import type { IActionTracker } from '../../tracking/IActionTracker.js';
+import type { RebalanceIntent } from '../../tracking/types.js';
+import { getExternalBridgeTokenAddress } from '../../utils/tokenUtils.js';
+import type {
+  BridgeQuoteMode,
+  InventoryMovementExecutionResult,
+} from './types.js';
+
+export class InventoryMovementExecutor {
+  constructor(
+    private readonly config: InventoryRebalancerConfig,
+    private readonly actionTracker: IActionTracker,
+    private readonly consumedInventory: () => Map<ChainName, bigint>,
+    private readonly multiProvider: MultiProvider,
+    private readonly getExternalBridge: (
+      type: ExternalBridgeType,
+    ) => IExternalBridge,
+    private readonly getNativeTokenAddress: (
+      bridgeType: ExternalBridgeType,
+    ) => string,
+    private readonly getTokenForChain: (chain: ChainName) => Token | undefined,
+    private readonly getProtocolForChain: (chain: ChainName) => ProtocolType,
+    private readonly getInventorySignerAddress: (chain: ChainName) => string,
+    private readonly logger: Logger,
+  ) {}
+
+  async executeInventoryMovement(
+    sourceChain: ChainName,
+    targetChain: ChainName,
+    targetOutputAmount: bigint,
+    maxSourceInput: bigint,
+    quoteMode: BridgeQuoteMode,
+    intent: RebalanceIntent,
+    externalBridgeType: ExternalBridgeType,
+  ): Promise<InventoryMovementExecutionResult> {
+    const sourceToken = this.getTokenForChain(sourceChain);
+    if (!sourceToken) {
+      return {
+        success: false,
+        error: `No token found for source chain: ${sourceChain}`,
+      };
+    }
+
+    const targetToken = this.getTokenForChain(targetChain);
+    if (!targetToken) {
+      return {
+        success: false,
+        error: `No token found for target chain: ${targetChain}`,
+      };
+    }
+
+    const sourceChainId = Number(this.multiProvider.getChainId(sourceChain));
+    const targetChainId = Number(this.multiProvider.getChainId(targetChain));
+    const fromTokenAddress = getExternalBridgeTokenAddress(
+      sourceToken,
+      externalBridgeType,
+      this.getNativeTokenAddress,
+    );
+    const toTokenAddress = getExternalBridgeTokenAddress(
+      targetToken,
+      externalBridgeType,
+      this.getNativeTokenAddress,
+    );
+
+    this.logger.debug(
+      {
+        sourceTokenStandard: sourceToken.standard,
+        targetTokenStandard: targetToken.standard,
+        fromTokenAddress,
+        toTokenAddress,
+      },
+      'Resolved token addresses for LiFi bridge',
+    );
+
+    try {
+      const externalBridge = this.getExternalBridge(externalBridgeType);
+      const fromAddress = this.getInventorySignerAddress(sourceChain);
+      const toAddress = this.getInventorySignerAddress(targetChain);
+      const quoteWithMode = async (mode: BridgeQuoteMode) =>
+        externalBridge.quote({
+          fromChain: sourceChainId,
+          toChain: targetChainId,
+          fromToken: fromTokenAddress,
+          toToken: toTokenAddress,
+          ...(mode === 'forward'
+            ? { fromAmount: maxSourceInput }
+            : { toAmount: targetOutputAmount }),
+          fromAddress,
+          toAddress,
+        });
+
+      let quoteModeUsed = quoteMode;
+      let quote = await quoteWithMode(quoteModeUsed);
+
+      if (quoteModeUsed === 'reverse' && quote.fromAmount > maxSourceInput) {
+        this.logger.warn(
+          {
+            sourceChain,
+            targetChain,
+            plannedQuoteMode: quoteMode,
+            requestedTargetOutput: targetOutputAmount.toString(),
+            quotedInput: quote.fromAmount.toString(),
+            maxSourceInput: maxSourceInput.toString(),
+            intentId: intent.id,
+          },
+          'Reverse bridge quote exceeded source capacity, retrying with forward quote',
+        );
+
+        quoteModeUsed = 'forward';
+        quote = await quoteWithMode(quoteModeUsed);
+      }
+
+      const inputRequired = quote.fromAmount;
+      if (inputRequired > maxSourceInput) {
+        return {
+          success: false,
+          error: `Bridge input ${inputRequired} exceeded planned source capacity ${maxSourceInput}`,
+        };
+      }
+
+      this.logger.info(
+        {
+          sourceChain,
+          targetChain,
+          sourceChainId,
+          targetChainId,
+          requestedTargetOutput: targetOutputAmount.toString(),
+          requestedTargetOutputFormatted: this.formatLocalAmount(
+            targetOutputAmount,
+            targetToken,
+          ),
+          quoteModePlanned: quoteMode,
+          quoteModeUsed,
+          retriedAsForward:
+            quoteMode === 'reverse' && quoteModeUsed === 'forward',
+          inputRequired: inputRequired.toString(),
+          inputRequiredFormatted: this.formatLocalAmount(
+            inputRequired,
+            sourceToken,
+          ),
+          quotedOutput: quote.toAmount.toString(),
+          quotedOutputMin: quote.toAmountMin.toString(),
+          quotedOutputFormatted: this.formatLocalAmount(
+            quote.toAmount,
+            targetToken,
+          ),
+          quotedOutputMinFormatted: this.formatLocalAmount(
+            quote.toAmountMin,
+            targetToken,
+          ),
+          gasCosts: quote.gasCosts.toString(),
+          feeCosts: quote.feeCosts.toString(),
+          intentId: intent.id,
+        },
+        'Executing inventory movement via bridge quote',
+      );
+
+      this.logger.debug(
+        {
+          quoteId: quote.id,
+          tool: quote.tool,
+          fromAmount: quote.fromAmount.toString(),
+          toAmount: quote.toAmount.toString(),
+          toAmountMin: quote.toAmountMin.toString(),
+          executionDuration: quote.executionDuration,
+          gasCosts: quote.gasCosts.toString(),
+          feeCosts: quote.feeCosts.toString(),
+        },
+        'Received LiFi quote for inventory movement',
+      );
+
+      const privateKeys: Partial<Record<ProtocolType, string>> = {};
+      for (const [protocol, cfg] of Object.entries(
+        this.config.inventorySigners,
+      )) {
+        if (cfg?.key) {
+          privateKeys[protocol as ProtocolType] = cfg.key;
+        }
+      }
+      const sourceProtocol = this.getProtocolForChain(sourceChain);
+      assert(
+        privateKeys[sourceProtocol],
+        `Missing inventory signer key for protocol ${sourceProtocol} (chain ${sourceChain})`,
+      );
+      const result = await externalBridge.execute(quote, privateKeys);
+
+      this.logger.info(
+        {
+          sourceChain,
+          targetChain,
+          txHash: result.txHash,
+          intentId: intent.id,
+        },
+        'Inventory movement transaction executed',
+      );
+
+      await this.actionTracker.createRebalanceAction({
+        intentId: intent.id,
+        origin: this.multiProvider.getDomainId(sourceChain),
+        destination: this.multiProvider.getDomainId(targetChain),
+        amount: inputRequired,
+        type: 'inventory_movement',
+        txHash: result.txHash,
+        externalBridgeId: externalBridgeType,
+      });
+
+      const currentConsumed = this.consumedInventory().get(sourceChain) ?? 0n;
+      this.consumedInventory().set(
+        sourceChain,
+        currentConsumed + inputRequired,
+      );
+
+      this.logger.debug(
+        {
+          sourceChain,
+          amountConsumed: inputRequired.toString(),
+          totalConsumed: (currentConsumed + inputRequired).toString(),
+        },
+        'Updated consumed inventory after LiFi bridge',
+      );
+
+      return {
+        success: true,
+        txHash: result.txHash,
+        inputRequired,
+        quotedOutput: quote.toAmount,
+        quotedOutputMin: quote.toAmountMin,
+        quoteModeUsed,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        {
+          sourceChain,
+          targetChain,
+          amount: targetOutputAmount.toString(),
+          intentId: intent.id,
+          error: errorMessage,
+        },
+        'Failed to execute inventory movement',
+      );
+
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  private formatLocalAmount(amount: bigint, token: Token): string {
+    return fromWei(amount.toString(), token.decimals);
+  }
+}

--- a/typescript/rebalancer/src/core/inventory/InventoryPlanner.test.ts
+++ b/typescript/rebalancer/src/core/inventory/InventoryPlanner.test.ts
@@ -81,6 +81,28 @@ describe('InventoryPlanner', () => {
     ]);
   });
 
+  it('includes transfer costs before applying the bridge buffer', () => {
+    const { bridgePlans, shortfall, targetWithBuffer, totalPlanned } =
+      planner.buildBridgePlans(
+        [{ chain: arbitrum, maxSourceInput: 200n, maxTargetOutput: 200n }],
+        100n,
+        40n,
+        20n,
+      );
+
+    expect(shortfall).to.equal(60n);
+    expect(targetWithBuffer).to.equal(84n);
+    expect(totalPlanned).to.equal(84n);
+    expect(bridgePlans).to.deep.equal([
+      {
+        chain: arbitrum,
+        maxSourceInput: 200n,
+        targetOutput: 84n,
+        quoteMode: 'reverse',
+      },
+    ]);
+  });
+
   it('aligns local inventory amounts to canonical progress', () => {
     const token = {
       scale: { numerator: 1n, denominator: 1_000n },

--- a/typescript/rebalancer/src/core/inventory/InventoryPlanner.test.ts
+++ b/typescript/rebalancer/src/core/inventory/InventoryPlanner.test.ts
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+
+import type {
+  ChainName,
+  MultiProvider,
+  Token,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+
+import {
+  InventoryPlanner,
+  isRecoverableMaxTransferProbeError,
+} from './InventoryPlanner.js';
+
+const logger = pino({ level: 'silent' });
+
+describe('InventoryPlanner', () => {
+  const arbitrum = 'arbitrum' as ChainName;
+  const base = 'base' as ChainName;
+  const solana = 'solanamainnet' as ChainName;
+  let balances: Map<ChainName, bigint>;
+  let consumed: Map<ChainName, bigint>;
+  let planner: InventoryPlanner;
+
+  beforeEach(() => {
+    balances = new Map<ChainName, bigint>([
+      [arbitrum, 100n],
+      [base, 60n],
+      [solana, 30n],
+    ]);
+    consumed = new Map<ChainName, bigint>([[arbitrum, 25n]]);
+    planner = new InventoryPlanner(
+      () => balances,
+      () => consumed,
+      {} as MultiProvider,
+      {} as WarpCore,
+      () => undefined,
+      () => '0x0000000000000000000000000000000000000000',
+      logger,
+    );
+  });
+
+  it('accounts for consumed inventory when selecting bridge sources', () => {
+    const sources = planner.selectAllSourceChains(solana);
+
+    expect(sources).to.deep.equal([
+      { chain: arbitrum, availableAmount: 75n },
+      { chain: base, availableAmount: 60n },
+    ]);
+  });
+
+  it('builds buffered bridge plans without inflating each split', () => {
+    const { bridgePlans, shortfall, targetWithBuffer, totalPlanned } =
+      planner.buildBridgePlans(
+        [
+          { chain: arbitrum, maxSourceInput: 100n, maxTargetOutput: 60n },
+          { chain: base, maxSourceInput: 100n, maxTargetOutput: 60n },
+        ],
+        100n,
+        0n,
+        0n,
+      );
+
+    expect(shortfall).to.equal(100n);
+    expect(targetWithBuffer).to.equal(105n);
+    expect(totalPlanned).to.equal(105n);
+    expect(bridgePlans).to.deep.equal([
+      {
+        chain: arbitrum,
+        maxSourceInput: 100n,
+        targetOutput: 60n,
+        quoteMode: 'forward',
+      },
+      {
+        chain: base,
+        maxSourceInput: 100n,
+        targetOutput: 45n,
+        quoteMode: 'reverse',
+      },
+    ]);
+  });
+
+  it('aligns local inventory amounts to canonical progress', () => {
+    const token = {
+      scale: { numerator: 1n, denominator: 1_000n },
+    } as Token;
+
+    const aligned = planner.alignLocalToCanonical(1_999n, token);
+
+    expect(aligned).to.deep.equal({
+      localAmount: 1_000n,
+      messageAmount: 1n,
+    });
+  });
+
+  it('detects nested recoverable max-transfer probe errors', () => {
+    const error = new Error('outer') as Error & { cause?: unknown };
+    error.cause = {
+      code: 'UNPREDICTABLE_GAS_LIMIT',
+      error: {
+        message: 'ERC20: transfer amount exceeds balance',
+      },
+    };
+
+    expect(isRecoverableMaxTransferProbeError(error)).to.equal(true);
+    expect(isRecoverableMaxTransferProbeError(new Error('RPC down'))).to.equal(
+      false,
+    );
+  });
+});

--- a/typescript/rebalancer/src/core/inventory/InventoryPlanner.ts
+++ b/typescript/rebalancer/src/core/inventory/InventoryPlanner.ts
@@ -1,0 +1,370 @@
+import type { Logger } from 'pino';
+
+import {
+  type ChainName,
+  type MultiProvider,
+  type Token,
+  type WarpCore,
+} from '@hyperlane-xyz/sdk';
+import { assert, fromWei } from '@hyperlane-xyz/utils';
+
+import type { InventoryRoute } from '../../interfaces/IStrategy.js';
+import type { RebalanceIntent } from '../../tracking/types.js';
+import {
+  alignLocalToCanonical,
+  denormalizeToLocal,
+  normalizeToCanonical,
+} from '../../utils/balanceUtils.js';
+import {
+  MIN_VIABLE_COST_MULTIPLIER,
+  calculateTransferCosts,
+} from '../../utils/gasEstimation.js';
+import { isNativeTokenStandard } from '../../utils/tokenUtils.js';
+import type {
+  BridgeCapacity,
+  BridgePlan,
+  InventorySource,
+  InventoryTransferPlan,
+} from './types.js';
+
+const BRIDGE_BUFFER_PERCENT = 5n;
+
+const RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES = [
+  'balance may be insufficient',
+  'transfer amount exceeds balance',
+  'insufficient balance',
+];
+
+function hasRecoverableMaxTransferErrorMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('unpredictable_gas_limit') ||
+    RECOVERABLE_MAX_TRANSFER_ERROR_MESSAGES.some((pattern) =>
+      normalized.includes(pattern),
+    )
+  );
+}
+
+export function isRecoverableMaxTransferProbeError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  const stack: unknown[] = [error];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current == null) continue;
+
+    if (typeof current === 'string') {
+      if (hasRecoverableMaxTransferErrorMessage(current)) return true;
+      continue;
+    }
+
+    if (typeof current !== 'object') continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    const candidate = current as {
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+      error?: unknown;
+    };
+
+    if (
+      typeof candidate.code === 'string' &&
+      candidate.code.toUpperCase() === 'UNPREDICTABLE_GAS_LIMIT'
+    ) {
+      return true;
+    }
+
+    if (
+      typeof candidate.message === 'string' &&
+      hasRecoverableMaxTransferErrorMessage(candidate.message)
+    ) {
+      return true;
+    }
+
+    stack.push(candidate.cause, candidate.error);
+  }
+
+  return false;
+}
+
+export class InventoryPlanner {
+  constructor(
+    private readonly inventoryBalances: () => Map<ChainName, bigint>,
+    private readonly consumedInventory: () => Map<ChainName, bigint>,
+    private readonly multiProvider: MultiProvider,
+    private readonly warpCore: WarpCore,
+    private readonly getTokenForChain: (chain: ChainName) => Token | undefined,
+    private readonly getInventorySignerAddress: (chain: ChainName) => string,
+    private readonly logger: Logger,
+  ) {}
+
+  getAvailableInventory(chain: ChainName): bigint {
+    return this.inventoryBalances().get(chain) ?? 0n;
+  }
+
+  getTotalInventory(excludeChains: ChainName[]): bigint {
+    const excludeSet = new Set(excludeChains);
+    let total = 0n;
+    for (const [chain, balance] of this.inventoryBalances()) {
+      if (!excludeSet.has(chain)) {
+        total += balance;
+      }
+    }
+    return total;
+  }
+
+  getEffectiveAvailableInventory(chain: ChainName): bigint {
+    const cached = this.getAvailableInventory(chain);
+    const consumed = this.consumedInventory().get(chain) ?? 0n;
+    const effective = cached > consumed ? cached - consumed : 0n;
+
+    if (consumed > 0n) {
+      this.logger.debug(
+        {
+          chain,
+          cachedInventory: cached.toString(),
+          consumedThisCycle: consumed.toString(),
+          effectiveInventory: effective.toString(),
+        },
+        'Calculated effective inventory after prior executions',
+      );
+    }
+
+    return effective;
+  }
+
+  selectAllSourceChains(targetChain: ChainName): InventorySource[] {
+    const sources: InventorySource[] = [];
+
+    for (const [chainName, balance] of this.inventoryBalances()) {
+      if (chainName === targetChain) continue;
+
+      const consumed = this.consumedInventory().get(chainName) ?? 0n;
+      const effectiveAvailable = balance > consumed ? balance - consumed : 0n;
+
+      if (effectiveAvailable > 0n) {
+        sources.push({
+          chain: chainName,
+          availableAmount: effectiveAvailable,
+        });
+      }
+    }
+
+    return sources.sort((a, b) =>
+      a.availableAmount > b.availableAmount ? -1 : 1,
+    );
+  }
+
+  async buildTransferPlan(
+    route: InventoryRoute,
+    intent: RebalanceIntent,
+  ): Promise<InventoryTransferPlan> {
+    const { origin, destination, amount } = route;
+    const sourceToken = this.getTokenForChain(destination);
+    assert(sourceToken, `No token found for source chain: ${destination}`);
+    const requestedLocalAmount = denormalizeToLocal(amount, sourceToken);
+    const executionSender = this.getInventorySignerAddress(destination);
+    const executionRecipient = this.getInventorySignerAddress(origin);
+    const availableInventory = this.getEffectiveAvailableInventory(destination);
+
+    this.logger.info(
+      {
+        checkingChain: destination,
+        availableInventory: availableInventory.toString(),
+        availableInventoryFormatted: this.formatLocalAmount(
+          availableInventory,
+          sourceToken,
+        ),
+        requiredAmount: requestedLocalAmount.toString(),
+        requiredAmountFormatted: this.formatLocalAmount(
+          requestedLocalAmount,
+          sourceToken,
+        ),
+      },
+      'Checking effective inventory on destination (deficit) chain',
+    );
+
+    const costs = await calculateTransferCosts(
+      destination,
+      origin,
+      availableInventory,
+      requestedLocalAmount,
+      this.multiProvider,
+      this.warpCore.multiProvider,
+      this.getTokenForChain,
+      executionSender,
+      isNativeTokenStandard,
+      this.logger,
+    );
+    const { minViableTransfer } = costs;
+    let maxTransferable = costs.maxTransferable;
+
+    if (!isNativeTokenStandard(sourceToken.standard)) {
+      if (availableInventory === 0n) {
+        maxTransferable = 0n;
+        this.logger.debug(
+          {
+            fromChain: destination,
+            toChain: origin,
+            requestedAmount: requestedLocalAmount.toString(),
+          },
+          'Skipping fee-aware max transferable probe because destination inventory is zero',
+        );
+      } else {
+        try {
+          const feeAwareMaxTransfer = await this.warpCore.getMaxTransferAmount({
+            balance: sourceToken.amount(availableInventory),
+            destination: origin,
+            sender: executionSender,
+            recipient: executionRecipient,
+          });
+
+          maxTransferable =
+            feeAwareMaxTransfer.amount < requestedLocalAmount
+              ? feeAwareMaxTransfer.amount
+              : requestedLocalAmount;
+
+          this.logger.debug(
+            {
+              fromChain: destination,
+              toChain: origin,
+              availableInventory: availableInventory.toString(),
+              requestedAmount: requestedLocalAmount.toString(),
+              feeAwareMaxTransferable: maxTransferable.toString(),
+            },
+            'Calculated fee-aware max transferable amount for non-native route',
+          );
+        } catch (error) {
+          if (!isRecoverableMaxTransferProbeError(error)) {
+            throw error;
+          }
+
+          maxTransferable = 0n;
+          this.logger.warn(
+            {
+              fromChain: destination,
+              toChain: origin,
+              availableInventory: availableInventory.toString(),
+              requestedAmount: requestedLocalAmount.toString(),
+              error: error instanceof Error ? error.message : String(error),
+              intentId: intent.id,
+            },
+            'Fee-aware max transferable probe failed due to insufficient balance, falling back to external bridge',
+          );
+        }
+      }
+    }
+
+    const totalInventory = this.getTotalInventory([]);
+
+    this.logger.info(
+      {
+        fromChain: destination,
+        toChain: origin,
+        availableInventoryFormatted: this.formatLocalAmount(
+          availableInventory,
+          sourceToken,
+        ),
+        requestedAmountFormatted: this.formatLocalAmount(
+          requestedLocalAmount,
+          sourceToken,
+        ),
+        maxTransferableFormatted: this.formatLocalAmount(
+          maxTransferable,
+          sourceToken,
+        ),
+        minViableTransferFormatted: this.formatLocalAmount(
+          minViableTransfer,
+          sourceToken,
+        ),
+        canFullyFulfill: maxTransferable >= requestedLocalAmount,
+        canPartialFulfill: maxTransferable >= minViableTransfer,
+        totalInventory: totalInventory.toString(),
+      },
+      'Calculated max transferable amount with cost-based threshold',
+    );
+
+    return {
+      sourceToken,
+      requestedLocalAmount,
+      availableInventory,
+      maxTransferable,
+      minViableTransfer,
+      totalCost: costs.totalCost,
+      totalInventory,
+    };
+  }
+
+  buildSwappedRoute(
+    route: InventoryRoute,
+    requestedLocalAmount: bigint,
+  ): InventoryRoute {
+    return {
+      ...route,
+      origin: route.destination,
+      destination: route.origin,
+      amount: requestedLocalAmount,
+    };
+  }
+
+  canonicalAmount(localAmount: bigint, token: Token): bigint {
+    return normalizeToCanonical(localAmount, token);
+  }
+
+  alignLocalToCanonical(localAmount: bigint, token: Token) {
+    return alignLocalToCanonical(localAmount, token);
+  }
+
+  buildBridgePlans(
+    capacities: Array<{ chain: ChainName } & BridgeCapacity>,
+    requestedLocalAmount: bigint,
+    availableInventory: bigint,
+    totalCost: bigint,
+  ): {
+    bridgePlans: BridgePlan[];
+    shortfall: bigint;
+    targetWithBuffer: bigint;
+    totalPlanned: bigint;
+  } {
+    const shortfall =
+      requestedLocalAmount > availableInventory
+        ? requestedLocalAmount - availableInventory
+        : 0n;
+    const targetWithBuffer =
+      ((shortfall + totalCost) * (100n + BRIDGE_BUFFER_PERCENT)) / 100n;
+    const bridgePlans: BridgePlan[] = [];
+    let totalPlanned = 0n;
+
+    for (const source of capacities) {
+      if (totalPlanned >= targetWithBuffer) break;
+
+      const remaining = targetWithBuffer - totalPlanned;
+      const targetOutput =
+        source.maxTargetOutput >= remaining
+          ? remaining
+          : source.maxTargetOutput;
+      const quoteMode =
+        source.maxTargetOutput > remaining ? 'reverse' : 'forward';
+
+      bridgePlans.push({
+        chain: source.chain,
+        maxSourceInput: source.maxSourceInput,
+        targetOutput,
+        quoteMode,
+      });
+      totalPlanned += targetOutput;
+    }
+
+    return { bridgePlans, shortfall, targetWithBuffer, totalPlanned };
+  }
+
+  minViableCostMultiplier(): bigint {
+    return MIN_VIABLE_COST_MULTIPLIER;
+  }
+
+  private formatLocalAmount(amount: bigint, token: Token): string {
+    return fromWei(amount.toString(), token.decimals);
+  }
+}

--- a/typescript/rebalancer/src/core/inventory/TransferRemoteExecutor.ts
+++ b/typescript/rebalancer/src/core/inventory/TransferRemoteExecutor.ts
@@ -1,0 +1,131 @@
+import type { Logger } from 'pino';
+
+import {
+  type ChainName,
+  type MultiProvider,
+  type Token,
+  type WarpTypedTransaction,
+  type WarpCore,
+  WarpTxCategory,
+} from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import type { InventoryExecutionResult } from '../../interfaces/IRebalancer.js';
+import type { InventoryRoute } from '../../interfaces/IStrategy.js';
+import type { IActionTracker } from '../../tracking/IActionTracker.js';
+import type { RebalanceIntent } from '../../tracking/types.js';
+
+export class TransferRemoteExecutor {
+  constructor(
+    private readonly actionTracker: IActionTracker,
+    private readonly warpCore: WarpCore,
+    private readonly multiProvider: MultiProvider,
+    private readonly getTokenForChain: (chain: ChainName) => Token | undefined,
+    private readonly getInventorySignerAddress: (chain: ChainName) => string,
+    private readonly sendAndConfirmInventoryTx: (
+      chain: ChainName,
+      typedTx: WarpTypedTransaction,
+    ) => Promise<{ txHash: string }>,
+    private readonly extractDispatchedMessageId: (
+      origin: ChainName,
+      txHash: string,
+    ) => Promise<string | undefined>,
+    private readonly logger: Logger,
+  ) {}
+
+  async executeTransferRemote(
+    route: InventoryRoute,
+    intent: RebalanceIntent,
+    fulfilledCanonicalAmount: bigint,
+  ): Promise<InventoryExecutionResult> {
+    const { origin, destination, amount } = route;
+
+    const originToken = this.getTokenForChain(origin);
+    if (!originToken) {
+      throw new Error(`No token found for origin chain: ${origin}`);
+    }
+
+    const destinationDomain = this.multiProvider.getDomainId(destination);
+
+    this.logger.debug(
+      { origin, destination, amount: amount.toString() },
+      'Building transferRemote transactions for exact execution amount',
+    );
+
+    const originTokenAmount = originToken.amount(amount);
+    const transferTxs = await this.warpCore.getTransferRemoteTxs({
+      originTokenAmount,
+      destination,
+      sender: this.getInventorySignerAddress(origin),
+      recipient: this.getInventorySignerAddress(destination),
+    });
+    assert(
+      transferTxs.length > 0,
+      'Expected at least one transaction from WarpCore',
+    );
+
+    this.logger.info(
+      {
+        origin,
+        destination,
+        amount: amount.toString(),
+        transactionCount: transferTxs.length,
+        intentId: intent.id,
+      },
+      'Sending transferRemote transactions',
+    );
+
+    let transferTxHash: string | undefined;
+    for (const tx of transferTxs) {
+      const { txHash } = await this.sendAndConfirmInventoryTx(origin, tx);
+      if (tx.category === WarpTxCategory.Transfer) {
+        transferTxHash = txHash;
+      }
+    }
+
+    const messageId = transferTxHash
+      ? await this.extractDispatchedMessageId(origin, transferTxHash)
+      : undefined;
+
+    assert(transferTxHash, 'No transfer transaction hash found');
+
+    if (!messageId) {
+      this.logger.warn(
+        {
+          origin,
+          destination,
+          txHash: transferTxHash,
+          intentId: intent.id,
+        },
+        'TransferRemote transaction sent but no messageId found in logs',
+      );
+    }
+
+    this.logger.info(
+      {
+        origin,
+        destination,
+        txHash: transferTxHash,
+        messageId,
+        intentId: intent.id,
+      },
+      'TransferRemote transaction confirmed',
+    );
+
+    await this.actionTracker.createRebalanceAction({
+      intentId: intent.id,
+      origin: this.multiProvider.getDomainId(origin),
+      destination: destinationDomain,
+      amount: fulfilledCanonicalAmount,
+      type: 'inventory_deposit',
+      txHash: transferTxHash,
+      messageId,
+    });
+
+    return {
+      route,
+      success: true,
+      amountSent: amount,
+    };
+  }
+}

--- a/typescript/rebalancer/src/core/inventory/types.ts
+++ b/typescript/rebalancer/src/core/inventory/types.ts
@@ -1,0 +1,44 @@
+import type { ChainName, Token } from '@hyperlane-xyz/sdk';
+
+export type BridgeCapacity = {
+  maxSourceInput: bigint;
+  maxTargetOutput: bigint;
+};
+
+export type BridgeQuoteMode = 'forward' | 'reverse';
+
+export type InventoryMovementExecutionResult =
+  | {
+      success: true;
+      txHash: string;
+      inputRequired: bigint;
+      quotedOutput: bigint;
+      quotedOutputMin: bigint;
+      quoteModeUsed: BridgeQuoteMode;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export type InventorySource = {
+  chain: ChainName;
+  availableAmount: bigint;
+};
+
+export type BridgePlan = {
+  chain: ChainName;
+  maxSourceInput: bigint;
+  targetOutput: bigint;
+  quoteMode: BridgeQuoteMode;
+};
+
+export type InventoryTransferPlan = {
+  sourceToken: Token;
+  requestedLocalAmount: bigint;
+  availableInventory: bigint;
+  maxTransferable: bigint;
+  minViableTransfer: bigint;
+  totalCost: bigint;
+  totalInventory: bigint;
+};

--- a/typescript/rebalancer/src/e2e/harness/Erc20InventoryLocalDeploymentManager.ts
+++ b/typescript/rebalancer/src/e2e/harness/Erc20InventoryLocalDeploymentManager.ts
@@ -1,11 +1,6 @@
 import { ethers, providers } from 'ethers';
 
 import {
-  ERC20Test__factory,
-  HypERC20Collateral__factory,
-} from '@hyperlane-xyz/core';
-
-import {
   type Erc20InventoryChainDeployment,
   type Erc20InventoryDeployedAddresses,
   TEST_CHAIN_CONFIGS,
@@ -13,6 +8,15 @@ import {
 } from '../fixtures/routes.js';
 
 import { BaseLocalDeploymentManager } from './BaseLocalDeploymentManager.js';
+import {
+  addBridgesToMonitoredRoutes,
+  addRebalancersToRouteGroups,
+  enrollRouteGroups,
+  routeAddresses,
+  RouteFixtureBuilder,
+  seedErc20Recipient,
+  seedErc20RouteGroups,
+} from './RouteFixtureBuilder.js';
 
 const TOKEN_SCALE = ethers.BigNumber.from(1);
 const USDC_INITIAL_SUPPLY = '100000000000000';
@@ -39,145 +43,82 @@ export class Erc20InventoryLocalDeploymentManager extends BaseLocalDeploymentMan
       TestChain,
       Erc20InventoryChainDeployment
     >;
-    const monitoredRouters = {} as Record<TestChain, ethers.Contract>;
-    const bridgeRouters = {} as Record<TestChain, ethers.Contract>;
-    const tokens = {} as Record<TestChain, ethers.Contract>;
+    const fixture = await new RouteFixtureBuilder({
+      deployerWallet,
+      providersByChain,
+      chainInfra,
+      ownerAddress: deployerAddress,
+    })
+      .withNativeBalance(
+        this.inventorySignerAddress,
+        ethers.BigNumber.from(INVENTORY_INITIAL_ETH_BALANCE),
+      )
+      .withErc20Token({
+        id: 'usdc',
+        name: 'USDC',
+        symbol: 'USDC',
+        initialSupply: USDC_INITIAL_SUPPLY,
+        decimals: USDC_DECIMALS,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'monitored',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE,
+        scaleDenominator: TOKEN_SCALE,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'bridge',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE,
+        scaleDenominator: TOKEN_SCALE,
+      })
+      .deploy();
+
+    const tokens = fixture.tokens.usdc;
+    const monitoredRouters = fixture.routeGroups.monitored;
+    const bridgeRouters = fixture.routeGroups.bridge;
 
     for (const config of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(config.name)!;
-      await provider.send('anvil_setBalance', [
-        this.inventorySignerAddress,
-        ethers.utils.hexValue(
-          ethers.BigNumber.from(INVENTORY_INITIAL_ETH_BALANCE),
-        ),
-      ]);
-
-      const deployer = deployerWallet.connect(provider);
-
-      const token = await new ERC20Test__factory(deployer).deploy(
-        'USDC',
-        'USDC',
-        USDC_INITIAL_SUPPLY,
-        USDC_DECIMALS,
-      );
-      await token.deployed();
-
-      const monitoredRoute = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE,
-        TOKEN_SCALE,
-        chainInfra[config.name].mailbox,
-      );
-      await monitoredRoute.deployed();
-      await monitoredRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
-      const bridgeRoute = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE,
-        TOKEN_SCALE,
-        chainInfra[config.name].mailbox,
-      );
-      await bridgeRoute.deployed();
-      await bridgeRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
       chainDeployments[config.name] = {
         mailbox: chainInfra[config.name].mailbox,
         ism: chainInfra[config.name].ism,
-        monitoredRouter: monitoredRoute.address,
-        bridgeRouter: bridgeRoute.address,
-        token: token.address,
+        monitoredRouter: monitoredRouters[config.name].address,
+        bridgeRouter: bridgeRouters[config.name].address,
+        token: tokens[config.name].address,
       };
-
-      tokens[config.name] = token;
-      monitoredRouters[config.name] = monitoredRoute;
-      bridgeRouters[config.name] = bridgeRoute;
     }
 
-    const routeGroups = [monitoredRouters, bridgeRouters];
-    for (const routeMap of routeGroups) {
-      for (const chain of TEST_CHAIN_CONFIGS) {
-        const localRoute = routeMap[chain.name];
-        const remoteDomains: number[] = [];
-        const remoteRouters: string[] = [];
-
-        for (const remote of TEST_CHAIN_CONFIGS) {
-          if (remote.name === chain.name) continue;
-          remoteDomains.push(remote.domainId);
-          remoteRouters.push(
-            ethers.utils.hexZeroPad(routeMap[remote.name].address, 32),
-          );
-        }
-
-        await localRoute.enrollRemoteRouters(remoteDomains, remoteRouters);
-      }
-    }
-
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const monitoredRoute = monitoredRouters[chain.name];
-      await monitoredRoute.addRebalancer(deployerAddress);
-      await monitoredRoute.addRebalancer(this.inventorySignerAddress);
-
-      for (const destination of TEST_CHAIN_CONFIGS) {
-        if (destination.name === chain.name) continue;
-        await monitoredRoute.addBridge(
-          destination.domainId,
-          bridgeRouters[chain.name].address,
-        );
-      }
-    }
+    await enrollRouteGroups([monitoredRouters, bridgeRouters]);
+    await addRebalancersToRouteGroups([monitoredRouters], () => [
+      deployerAddress,
+      this.inventorySignerAddress,
+    ]);
+    await addBridgesToMonitoredRoutes(monitoredRouters, [bridgeRouters]);
 
     const bridgeSeedAmount = ethers.BigNumber.from(INVENTORY_ERC20_BRIDGE_SEED);
     const signerErc20Amount = ethers.BigNumber.from(
       INVENTORY_INITIAL_ERC20_BALANCE,
     );
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(chain.name)!;
-      const deployer = deployerWallet.connect(provider);
-      const token = ERC20Test__factory.connect(
-        tokens[chain.name].address,
-        deployer,
-      );
-      const tx1 = await token.transfer(
-        bridgeRouters[chain.name].address,
-        bridgeSeedAmount,
-      );
-      await tx1.wait();
-      const tx2 = await token.transfer(
-        this.inventorySignerAddress,
-        signerErc20Amount,
-      );
-      await tx2.wait();
-    }
+    await seedErc20RouteGroups({
+      deployerWallet,
+      providersByChain,
+      tokens,
+      routeGroups: [bridgeRouters],
+      amount: bridgeSeedAmount,
+    });
+    await seedErc20Recipient({
+      deployerWallet,
+      providersByChain,
+      tokens,
+      recipient: this.inventorySignerAddress,
+      amount: signerErc20Amount,
+    });
 
     return {
       chains: chainDeployments,
-      monitoredRoute: {
-        anvil1: monitoredRouters.anvil1.address,
-        anvil2: monitoredRouters.anvil2.address,
-        anvil3: monitoredRouters.anvil3.address,
-      },
-      bridgeRoute: {
-        anvil1: bridgeRouters.anvil1.address,
-        anvil2: bridgeRouters.anvil2.address,
-        anvil3: bridgeRouters.anvil3.address,
-      },
-      tokens: {
-        anvil1: tokens.anvil1.address,
-        anvil2: tokens.anvil2.address,
-        anvil3: tokens.anvil3.address,
-      },
+      monitoredRoute: routeAddresses(monitoredRouters),
+      bridgeRoute: routeAddresses(bridgeRouters),
+      tokens: routeAddresses(tokens),
     };
   }
 }

--- a/typescript/rebalancer/src/e2e/harness/Erc20LocalDeploymentManager.ts
+++ b/typescript/rebalancer/src/e2e/harness/Erc20LocalDeploymentManager.ts
@@ -1,11 +1,6 @@
 import { ethers, providers } from 'ethers';
 
 import {
-  ERC20Test__factory,
-  HypERC20Collateral__factory,
-} from '@hyperlane-xyz/core';
-
-import {
   type ChainDeployment,
   type DeployedAddresses,
   TEST_CHAIN_CONFIGS,
@@ -13,6 +8,14 @@ import {
 } from '../fixtures/routes.js';
 
 import { BaseLocalDeploymentManager } from './BaseLocalDeploymentManager.js';
+import {
+  addBridgesToMonitoredRoutes,
+  addRebalancersToRouteGroups,
+  enrollRouteGroups,
+  routeAddresses,
+  RouteFixtureBuilder,
+  seedErc20RouteGroups,
+} from './RouteFixtureBuilder.js';
 
 const USDC_INITIAL_SUPPLY = '100000000000000';
 const USDC_DECIMALS = 6;
@@ -30,161 +33,78 @@ export class Erc20LocalDeploymentManager extends BaseLocalDeploymentManager<Depl
   ): Promise<DeployedAddresses> {
     const deployerAddress = deployerWallet.address;
     const chainDeployments = {} as Record<TestChain, ChainDeployment>;
-    const monitoredRouters = {} as Record<TestChain, ethers.Contract>;
-    const bridgeRouters1 = {} as Record<TestChain, ethers.Contract>;
-    const bridgeRouters2 = {} as Record<TestChain, ethers.Contract>;
-    const tokens = {} as Record<TestChain, ethers.Contract>;
+    const fixture = await new RouteFixtureBuilder({
+      deployerWallet,
+      providersByChain,
+      chainInfra,
+      ownerAddress: deployerAddress,
+    })
+      .withErc20Token({
+        id: 'usdc',
+        name: 'USDC',
+        symbol: 'USDC',
+        initialSupply: USDC_INITIAL_SUPPLY,
+        decimals: USDC_DECIMALS,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'monitored',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE_NUMERATOR,
+        scaleDenominator: TOKEN_SCALE_DENOMINATOR,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'bridge1',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE_NUMERATOR,
+        scaleDenominator: TOKEN_SCALE_DENOMINATOR,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'bridge2',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE_NUMERATOR,
+        scaleDenominator: TOKEN_SCALE_DENOMINATOR,
+      })
+      .deploy();
 
-    for (let i = 0; i < TEST_CHAIN_CONFIGS.length; i++) {
-      const config = TEST_CHAIN_CONFIGS[i];
-      const provider = providersByChain.get(config.name)!;
-      const deployer = deployerWallet.connect(provider);
+    const tokens = fixture.tokens.usdc;
+    const monitoredRouters = fixture.routeGroups.monitored;
+    const bridgeRouters1 = fixture.routeGroups.bridge1;
+    const bridgeRouters2 = fixture.routeGroups.bridge2;
 
-      const token = await new ERC20Test__factory(deployer).deploy(
-        'USDC',
-        'USDC',
-        USDC_INITIAL_SUPPLY,
-        USDC_DECIMALS,
-      );
-      await token.deployed();
-
-      const monitoredRoute = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE_NUMERATOR,
-        TOKEN_SCALE_DENOMINATOR,
-        chainInfra[config.name].mailbox,
-      );
-      await monitoredRoute.deployed();
-      await monitoredRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
-      const bridgeRoute1 = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE_NUMERATOR,
-        TOKEN_SCALE_DENOMINATOR,
-        chainInfra[config.name].mailbox,
-      );
-      await bridgeRoute1.deployed();
-      await bridgeRoute1.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
-      const bridgeRoute2 = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE_NUMERATOR,
-        TOKEN_SCALE_DENOMINATOR,
-        chainInfra[config.name].mailbox,
-      );
-      await bridgeRoute2.deployed();
-      await bridgeRoute2.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
+    for (const config of TEST_CHAIN_CONFIGS) {
       chainDeployments[config.name] = {
         mailbox: chainInfra[config.name].mailbox,
         ism: chainInfra[config.name].ism,
-        token: token.address,
-        monitoredRouter: monitoredRoute.address,
-        bridgeRouter1: bridgeRoute1.address,
-        bridgeRouter2: bridgeRoute2.address,
+        token: tokens[config.name].address,
+        monitoredRouter: monitoredRouters[config.name].address,
+        bridgeRouter1: bridgeRouters1[config.name].address,
+        bridgeRouter2: bridgeRouters2[config.name].address,
       };
-
-      tokens[config.name] = token;
-      monitoredRouters[config.name] = monitoredRoute;
-      bridgeRouters1[config.name] = bridgeRoute1;
-      bridgeRouters2[config.name] = bridgeRoute2;
     }
 
     const routeGroups = [monitoredRouters, bridgeRouters1, bridgeRouters2];
-    for (const routeMap of routeGroups) {
-      for (const chain of TEST_CHAIN_CONFIGS) {
-        const localRoute = routeMap[chain.name];
-        const remoteDomains: number[] = [];
-        const remoteRouters: string[] = [];
-
-        for (const remote of TEST_CHAIN_CONFIGS) {
-          if (remote.name === chain.name) continue;
-          remoteDomains.push(remote.domainId);
-          remoteRouters.push(
-            ethers.utils.hexZeroPad(routeMap[remote.name].address, 32),
-          );
-        }
-
-        await localRoute.enrollRemoteRouters(remoteDomains, remoteRouters);
-        await localRoute.addRebalancer(deployerAddress);
-      }
-    }
-
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const monitoredRoute = monitoredRouters[chain.name];
-      for (const destination of TEST_CHAIN_CONFIGS) {
-        if (destination.name === chain.name) continue;
-        await monitoredRoute.addBridge(
-          destination.domainId,
-          bridgeRouters1[chain.name].address,
-        );
-        await monitoredRoute.addBridge(
-          destination.domainId,
-          bridgeRouters2[chain.name].address,
-        );
-      }
-    }
+    await enrollRouteGroups(routeGroups);
+    await addRebalancersToRouteGroups(routeGroups, () => [deployerAddress]);
+    await addBridgesToMonitoredRoutes(monitoredRouters, [
+      bridgeRouters1,
+      bridgeRouters2,
+    ]);
 
     const bridgeSeedAmount = ethers.BigNumber.from(USDC_INITIAL_SUPPLY).div(10);
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(chain.name)!;
-      const deployer = deployerWallet.connect(provider);
-      const token = ERC20Test__factory.connect(
-        tokens[chain.name].address,
-        deployer,
-      );
-      const tx1 = await token.transfer(
-        bridgeRouters1[chain.name].address,
-        bridgeSeedAmount,
-      );
-      await tx1.wait();
-      const tx2 = await token.transfer(
-        bridgeRouters2[chain.name].address,
-        bridgeSeedAmount,
-      );
-      await tx2.wait();
-    }
+    await seedErc20RouteGroups({
+      deployerWallet,
+      providersByChain,
+      tokens,
+      routeGroups: [bridgeRouters1, bridgeRouters2],
+      amount: bridgeSeedAmount,
+    });
 
     return {
       chains: chainDeployments,
-      monitoredRoute: {
-        anvil1: monitoredRouters.anvil1.address,
-        anvil2: monitoredRouters.anvil2.address,
-        anvil3: monitoredRouters.anvil3.address,
-      },
-      bridgeRoute1: {
-        anvil1: bridgeRouters1.anvil1.address,
-        anvil2: bridgeRouters1.anvil2.address,
-        anvil3: bridgeRouters1.anvil3.address,
-      },
-      bridgeRoute2: {
-        anvil1: bridgeRouters2.anvil1.address,
-        anvil2: bridgeRouters2.anvil2.address,
-        anvil3: bridgeRouters2.anvil3.address,
-      },
-      tokens: {
-        anvil1: tokens.anvil1.address,
-        anvil2: tokens.anvil2.address,
-        anvil3: tokens.anvil3.address,
-      },
+      monitoredRoute: routeAddresses(monitoredRouters),
+      bridgeRoute1: routeAddresses(bridgeRouters1),
+      bridgeRoute2: routeAddresses(bridgeRouters2),
+      tokens: routeAddresses(tokens),
     };
   }
 }

--- a/typescript/rebalancer/src/e2e/harness/MixedLocalDeploymentManager.ts
+++ b/typescript/rebalancer/src/e2e/harness/MixedLocalDeploymentManager.ts
@@ -1,10 +1,5 @@
 import { ethers, providers } from 'ethers';
 
-import {
-  ERC20Test__factory,
-  HypERC20Collateral__factory,
-} from '@hyperlane-xyz/core';
-
 import { ExecutionType, ExternalBridgeType } from '../../config/types.js';
 import {
   type Erc20InventoryChainDeployment,
@@ -14,6 +9,15 @@ import {
 } from '../fixtures/routes.js';
 
 import { BaseLocalDeploymentManager } from './BaseLocalDeploymentManager.js';
+import {
+  addBridgesToMonitoredRoutes,
+  addRebalancersToRouteGroups,
+  enrollRouteGroups,
+  routeAddresses,
+  RouteFixtureBuilder,
+  seedErc20Recipient,
+  seedErc20RouteGroups,
+} from './RouteFixtureBuilder.js';
 
 const TOKEN_SCALE = ethers.BigNumber.from(1);
 const USDC_INITIAL_SUPPLY = '100000000000000';
@@ -48,147 +52,83 @@ export class MixedLocalDeploymentManager extends BaseLocalDeploymentManager<Erc2
       TestChain,
       Erc20InventoryChainDeployment
     >;
-    const monitoredRouters = {} as Record<TestChain, ethers.Contract>;
-    const bridgeRouters = {} as Record<TestChain, ethers.Contract>;
-    const tokens = {} as Record<TestChain, ethers.Contract>;
+    const fixture = await new RouteFixtureBuilder({
+      deployerWallet,
+      providersByChain,
+      chainInfra,
+      ownerAddress: deployerAddress,
+    })
+      .withNativeBalance(
+        this.inventorySignerAddress,
+        ethers.BigNumber.from(INVENTORY_INITIAL_ETH_BALANCE),
+      )
+      .withErc20Token({
+        id: 'usdc',
+        name: 'USDC',
+        symbol: 'USDC',
+        initialSupply: USDC_INITIAL_SUPPLY,
+        decimals: USDC_DECIMALS,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'monitored',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE,
+        scaleDenominator: TOKEN_SCALE,
+      })
+      .withErc20CollateralRouteGroup({
+        id: 'bridge',
+        tokenId: 'usdc',
+        scaleNumerator: TOKEN_SCALE,
+        scaleDenominator: TOKEN_SCALE,
+      })
+      .deploy();
+
+    const tokens = fixture.tokens.usdc;
+    const monitoredRouters = fixture.routeGroups.monitored;
+    const bridgeRouters = fixture.routeGroups.bridge;
 
     for (const config of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(config.name)!;
-      await provider.send('anvil_setBalance', [
-        this.inventorySignerAddress,
-        ethers.utils.hexValue(
-          ethers.BigNumber.from(INVENTORY_INITIAL_ETH_BALANCE),
-        ),
-      ]);
-
-      const deployer = deployerWallet.connect(provider);
-
-      const token = await new ERC20Test__factory(deployer).deploy(
-        'USDC',
-        'USDC',
-        USDC_INITIAL_SUPPLY,
-        USDC_DECIMALS,
-      );
-      await token.deployed();
-
-      const monitoredRoute = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE,
-        TOKEN_SCALE,
-        chainInfra[config.name].mailbox,
-      );
-      await monitoredRoute.deployed();
-      await monitoredRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
-      const bridgeRoute = await new HypERC20Collateral__factory(
-        deployer,
-      ).deploy(
-        token.address,
-        TOKEN_SCALE,
-        TOKEN_SCALE,
-        chainInfra[config.name].mailbox,
-      );
-      await bridgeRoute.deployed();
-      await bridgeRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
       chainDeployments[config.name] = {
         mailbox: chainInfra[config.name].mailbox,
         ism: chainInfra[config.name].ism,
-        monitoredRouter: monitoredRoute.address,
-        bridgeRouter: bridgeRoute.address,
-        token: token.address,
+        monitoredRouter: monitoredRouters[config.name].address,
+        bridgeRouter: bridgeRouters[config.name].address,
+        token: tokens[config.name].address,
       };
-
-      tokens[config.name] = token;
-      monitoredRouters[config.name] = monitoredRoute;
-      bridgeRouters[config.name] = bridgeRoute;
     }
 
-    const routeGroups = [monitoredRouters, bridgeRouters];
-    for (const routeMap of routeGroups) {
-      for (const chain of TEST_CHAIN_CONFIGS) {
-        const localRoute = routeMap[chain.name];
-        const remoteDomains: number[] = [];
-        const remoteRouters: string[] = [];
-
-        for (const remote of TEST_CHAIN_CONFIGS) {
-          if (remote.name === chain.name) continue;
-          remoteDomains.push(remote.domainId);
-          remoteRouters.push(
-            ethers.utils.hexZeroPad(routeMap[remote.name].address, 32),
-          );
-        }
-
-        await localRoute.enrollRemoteRouters(remoteDomains, remoteRouters);
-      }
-    }
-
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const monitoredRoute = monitoredRouters[chain.name];
-      await monitoredRoute.addRebalancer(deployerAddress);
-      if (chain.name === MIXED_INVENTORY_CHAIN) {
-        await monitoredRoute.addRebalancer(this.inventorySignerAddress);
-      }
-
-      for (const destination of TEST_CHAIN_CONFIGS) {
-        if (destination.name === chain.name) continue;
-        await monitoredRoute.addBridge(
-          destination.domainId,
-          bridgeRouters[chain.name].address,
-        );
-      }
-    }
+    await enrollRouteGroups([monitoredRouters, bridgeRouters]);
+    await addRebalancersToRouteGroups([monitoredRouters], (chain) =>
+      chain === MIXED_INVENTORY_CHAIN
+        ? [deployerAddress, this.inventorySignerAddress]
+        : [deployerAddress],
+    );
+    await addBridgesToMonitoredRoutes(monitoredRouters, [bridgeRouters]);
 
     const bridgeSeedAmount = ethers.BigNumber.from(INVENTORY_ERC20_BRIDGE_SEED);
     const signerErc20Amount = ethers.BigNumber.from(
       INVENTORY_INITIAL_ERC20_BALANCE,
     );
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(chain.name)!;
-      const deployer = deployerWallet.connect(provider);
-      const token = ERC20Test__factory.connect(
-        tokens[chain.name].address,
-        deployer,
-      );
-      const tx1 = await token.transfer(
-        bridgeRouters[chain.name].address,
-        bridgeSeedAmount,
-      );
-      await tx1.wait();
-      const tx2 = await token.transfer(
-        this.inventorySignerAddress,
-        signerErc20Amount,
-      );
-      await tx2.wait();
-    }
+    await seedErc20RouteGroups({
+      deployerWallet,
+      providersByChain,
+      tokens,
+      routeGroups: [bridgeRouters],
+      amount: bridgeSeedAmount,
+    });
+    await seedErc20Recipient({
+      deployerWallet,
+      providersByChain,
+      tokens,
+      recipient: this.inventorySignerAddress,
+      amount: signerErc20Amount,
+    });
 
     return {
       chains: chainDeployments,
-      monitoredRoute: {
-        anvil1: monitoredRouters.anvil1.address,
-        anvil2: monitoredRouters.anvil2.address,
-        anvil3: monitoredRouters.anvil3.address,
-      },
-      bridgeRoute: {
-        anvil1: bridgeRouters.anvil1.address,
-        anvil2: bridgeRouters.anvil2.address,
-        anvil3: bridgeRouters.anvil3.address,
-      },
-      tokens: {
-        anvil1: tokens.anvil1.address,
-        anvil2: tokens.anvil2.address,
-        anvil3: tokens.anvil3.address,
-      },
+      monitoredRoute: routeAddresses(monitoredRouters),
+      bridgeRoute: routeAddresses(bridgeRouters),
+      tokens: routeAddresses(tokens),
     };
   }
 }

--- a/typescript/rebalancer/src/e2e/harness/NativeLocalDeploymentManager.ts
+++ b/typescript/rebalancer/src/e2e/harness/NativeLocalDeploymentManager.ts
@@ -1,7 +1,5 @@
 import { ethers, providers } from 'ethers';
 
-import { HypNative__factory } from '@hyperlane-xyz/core';
-
 import {
   type NativeChainDeployment,
   type NativeDeployedAddresses,
@@ -10,6 +8,14 @@ import {
 } from '../fixtures/routes.js';
 
 import { BaseLocalDeploymentManager } from './BaseLocalDeploymentManager.js';
+import {
+  addBridgesToMonitoredRoutes,
+  addRebalancersToRouteGroups,
+  enrollRouteGroups,
+  routeAddresses,
+  RouteFixtureBuilder,
+  seedNativeRouteGroup,
+} from './RouteFixtureBuilder.js';
 
 const TOKEN_SCALE_NUMERATOR = ethers.BigNumber.from(1);
 const TOKEN_SCALE_DENOMINATOR = ethers.BigNumber.from(1);
@@ -31,108 +37,59 @@ export class NativeLocalDeploymentManager extends BaseLocalDeploymentManager<Nat
   ): Promise<NativeDeployedAddresses> {
     const deployerAddress = deployerWallet.address;
     const chainDeployments = {} as Record<TestChain, NativeChainDeployment>;
-    const monitoredRouters = {} as Record<TestChain, ethers.Contract>;
-    const bridgeRouters = {} as Record<TestChain, ethers.Contract>;
+    const fixture = await new RouteFixtureBuilder({
+      deployerWallet,
+      providersByChain,
+      chainInfra,
+      ownerAddress: deployerAddress,
+    })
+      .withNativeBalance(
+        this.inventorySignerAddress,
+        ethers.BigNumber.from(INVENTORY_INITIAL_BALANCE),
+      )
+      .withNativeRouteGroup({
+        id: 'monitored',
+        scaleNumerator: TOKEN_SCALE_NUMERATOR,
+        scaleDenominator: TOKEN_SCALE_DENOMINATOR,
+      })
+      .withNativeRouteGroup({
+        id: 'bridge',
+        scaleNumerator: TOKEN_SCALE_NUMERATOR,
+        scaleDenominator: TOKEN_SCALE_DENOMINATOR,
+      })
+      .deploy();
+
+    const monitoredRouters = fixture.routeGroups.monitored;
+    const bridgeRouters = fixture.routeGroups.bridge;
 
     for (const config of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(config.name)!;
-      await provider.send('anvil_setBalance', [
-        this.inventorySignerAddress,
-        ethers.utils.hexValue(ethers.BigNumber.from(INVENTORY_INITIAL_BALANCE)),
-      ]);
-
-      const deployer = deployerWallet.connect(provider);
-
-      const monitoredRoute = await new HypNative__factory(deployer).deploy(
-        TOKEN_SCALE_NUMERATOR,
-        TOKEN_SCALE_DENOMINATOR,
-        chainInfra[config.name].mailbox,
-      );
-      await monitoredRoute.deployed();
-      await monitoredRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
-      const bridgeRoute = await new HypNative__factory(deployer).deploy(
-        TOKEN_SCALE_NUMERATOR,
-        TOKEN_SCALE_DENOMINATOR,
-        chainInfra[config.name].mailbox,
-      );
-      await bridgeRoute.deployed();
-      await bridgeRoute.initialize(
-        ethers.constants.AddressZero,
-        chainInfra[config.name].ism,
-        deployerAddress,
-      );
-
       chainDeployments[config.name] = {
         mailbox: chainInfra[config.name].mailbox,
         ism: chainInfra[config.name].ism,
-        monitoredRouter: monitoredRoute.address,
-        bridgeRouter: bridgeRoute.address,
+        monitoredRouter: monitoredRouters[config.name].address,
+        bridgeRouter: bridgeRouters[config.name].address,
       };
-
-      monitoredRouters[config.name] = monitoredRoute;
-      bridgeRouters[config.name] = bridgeRoute;
     }
 
-    const routeGroups = [monitoredRouters, bridgeRouters];
-    for (const routeMap of routeGroups) {
-      for (const chain of TEST_CHAIN_CONFIGS) {
-        const localRoute = routeMap[chain.name];
-        const remoteDomains: number[] = [];
-        const remoteRouters: string[] = [];
-
-        for (const remote of TEST_CHAIN_CONFIGS) {
-          if (remote.name === chain.name) continue;
-          remoteDomains.push(remote.domainId);
-          remoteRouters.push(
-            ethers.utils.hexZeroPad(routeMap[remote.name].address, 32),
-          );
-        }
-
-        await localRoute.enrollRemoteRouters(remoteDomains, remoteRouters);
-      }
-    }
-
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const monitoredRoute = monitoredRouters[chain.name];
-      await monitoredRoute.addRebalancer(deployerAddress);
-      await monitoredRoute.addRebalancer(this.inventorySignerAddress);
-
-      for (const destination of TEST_CHAIN_CONFIGS) {
-        if (destination.name === chain.name) continue;
-        await monitoredRoute.addBridge(
-          destination.domainId,
-          bridgeRouters[chain.name].address,
-        );
-      }
-    }
+    await enrollRouteGroups([monitoredRouters, bridgeRouters]);
+    await addRebalancersToRouteGroups([monitoredRouters], () => [
+      deployerAddress,
+      this.inventorySignerAddress,
+    ]);
+    await addBridgesToMonitoredRoutes(monitoredRouters, [bridgeRouters]);
 
     const bridgeSeedAmount = ethers.BigNumber.from(INVENTORY_BRIDGE_SEED);
-    for (const chain of TEST_CHAIN_CONFIGS) {
-      const provider = providersByChain.get(chain.name)!;
-      const deployer = deployerWallet.connect(provider);
-      await deployer.sendTransaction({
-        to: bridgeRouters[chain.name].address,
-        value: bridgeSeedAmount,
-      });
-    }
+    await seedNativeRouteGroup({
+      deployerWallet,
+      providersByChain,
+      routeGroup: bridgeRouters,
+      amount: bridgeSeedAmount,
+    });
 
     return {
       chains: chainDeployments,
-      monitoredRoute: {
-        anvil1: monitoredRouters.anvil1.address,
-        anvil2: monitoredRouters.anvil2.address,
-        anvil3: monitoredRouters.anvil3.address,
-      },
-      bridgeRoute: {
-        anvil1: bridgeRouters.anvil1.address,
-        anvil2: bridgeRouters.anvil2.address,
-        anvil3: bridgeRouters.anvil3.address,
-      },
+      monitoredRoute: routeAddresses(monitoredRouters),
+      bridgeRoute: routeAddresses(bridgeRouters),
     };
   }
 }

--- a/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.test.ts
+++ b/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.test.ts
@@ -1,0 +1,170 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import {
+  addBridgesToMonitoredRoutes,
+  addRebalancersToRouteGroups,
+  buildRemoteRouterEnrollment,
+  routeAddresses,
+} from './RouteFixtureBuilder.js';
+
+describe('RouteFixtureBuilder helpers', () => {
+  const routeGroup = {
+    anvil1: { address: '0x0000000000000000000000000000000000000001' },
+    anvil2: { address: '0x0000000000000000000000000000000000000002' },
+    anvil3: { address: '0x0000000000000000000000000000000000000003' },
+  };
+
+  it('builds remote enrollment domains and padded routers', () => {
+    const enrollment = buildRemoteRouterEnrollment(routeGroup, 'anvil1');
+
+    expect(enrollment.remoteDomains).to.deep.equal([31338, 31339]);
+    expect(enrollment.remoteRouters).to.deep.equal([
+      ethers.utils.hexZeroPad(routeGroup.anvil2.address, 32),
+      ethers.utils.hexZeroPad(routeGroup.anvil3.address, 32),
+    ]);
+  });
+
+  it('builds chain address maps from route groups', () => {
+    expect(routeAddresses(routeGroup)).to.deep.equal({
+      anvil1: routeGroup.anvil1.address,
+      anvil2: routeGroup.anvil2.address,
+      anvil3: routeGroup.anvil3.address,
+    });
+  });
+
+  it('adds per-chain rebalancers to every route group', async () => {
+    const calls: Array<{ chain: string; rebalancer: string }> = [];
+    const routeGroups = [
+      Object.fromEntries(
+        Object.keys(routeGroup).map((chain) => [
+          chain,
+          {
+            address: routeGroup[chain as keyof typeof routeGroup].address,
+            addRebalancer: async (rebalancer: string) => {
+              calls.push({ chain, rebalancer });
+            },
+          },
+        ]),
+      ),
+    ];
+
+    await addRebalancersToRouteGroups(
+      routeGroups as unknown as Parameters<
+        typeof addRebalancersToRouteGroups
+      >[0],
+      (chain) =>
+        chain === 'anvil3' ? ['deployer', 'inventory'] : ['deployer'],
+    );
+
+    expect(calls).to.deep.equal([
+      { chain: 'anvil1', rebalancer: 'deployer' },
+      { chain: 'anvil2', rebalancer: 'deployer' },
+      { chain: 'anvil3', rebalancer: 'deployer' },
+      { chain: 'anvil3', rebalancer: 'inventory' },
+    ]);
+  });
+
+  it('adds local-chain bridge addresses for every remote destination', async () => {
+    const calls: Array<{
+      chain: string;
+      destinationDomain: number;
+      bridge: string;
+    }> = [];
+    const monitoredRouters = Object.fromEntries(
+      Object.keys(routeGroup).map((chain) => [
+        chain,
+        {
+          address: routeGroup[chain as keyof typeof routeGroup].address,
+          addBridge: async (destinationDomain: number, bridge: string) => {
+            calls.push({ chain, destinationDomain, bridge });
+          },
+        },
+      ]),
+    );
+    const bridgeRouteGroups = [
+      {
+        anvil1: { address: '0x0000000000000000000000000000000000000011' },
+        anvil2: { address: '0x0000000000000000000000000000000000000012' },
+        anvil3: { address: '0x0000000000000000000000000000000000000013' },
+      },
+      {
+        anvil1: { address: '0x0000000000000000000000000000000000000021' },
+        anvil2: { address: '0x0000000000000000000000000000000000000022' },
+        anvil3: { address: '0x0000000000000000000000000000000000000023' },
+      },
+    ];
+
+    await addBridgesToMonitoredRoutes(
+      monitoredRouters as unknown as Parameters<
+        typeof addBridgesToMonitoredRoutes
+      >[0],
+      bridgeRouteGroups as unknown as Parameters<
+        typeof addBridgesToMonitoredRoutes
+      >[1],
+    );
+
+    expect(calls).to.deep.equal([
+      {
+        chain: 'anvil1',
+        destinationDomain: 31338,
+        bridge: bridgeRouteGroups[0].anvil1.address,
+      },
+      {
+        chain: 'anvil1',
+        destinationDomain: 31338,
+        bridge: bridgeRouteGroups[1].anvil1.address,
+      },
+      {
+        chain: 'anvil1',
+        destinationDomain: 31339,
+        bridge: bridgeRouteGroups[0].anvil1.address,
+      },
+      {
+        chain: 'anvil1',
+        destinationDomain: 31339,
+        bridge: bridgeRouteGroups[1].anvil1.address,
+      },
+      {
+        chain: 'anvil2',
+        destinationDomain: 31337,
+        bridge: bridgeRouteGroups[0].anvil2.address,
+      },
+      {
+        chain: 'anvil2',
+        destinationDomain: 31337,
+        bridge: bridgeRouteGroups[1].anvil2.address,
+      },
+      {
+        chain: 'anvil2',
+        destinationDomain: 31339,
+        bridge: bridgeRouteGroups[0].anvil2.address,
+      },
+      {
+        chain: 'anvil2',
+        destinationDomain: 31339,
+        bridge: bridgeRouteGroups[1].anvil2.address,
+      },
+      {
+        chain: 'anvil3',
+        destinationDomain: 31337,
+        bridge: bridgeRouteGroups[0].anvil3.address,
+      },
+      {
+        chain: 'anvil3',
+        destinationDomain: 31337,
+        bridge: bridgeRouteGroups[1].anvil3.address,
+      },
+      {
+        chain: 'anvil3',
+        destinationDomain: 31338,
+        bridge: bridgeRouteGroups[0].anvil3.address,
+      },
+      {
+        chain: 'anvil3',
+        destinationDomain: 31338,
+        bridge: bridgeRouteGroups[1].anvil3.address,
+      },
+    ]);
+  });
+});

--- a/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.test.ts
+++ b/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.test.ts
@@ -7,13 +7,37 @@ import {
   buildRemoteRouterEnrollment,
   routeAddresses,
 } from './RouteFixtureBuilder.js';
+import type { TestChain } from '../fixtures/routes.js';
+
+type TestRouteGroup = Record<TestChain, { address: string }>;
+
+type TestRebalancerRouteGroup = Record<
+  TestChain,
+  { address: string; addRebalancer: (rebalancer: string) => Promise<void> }
+>;
+
+type TestBridgeRouteGroup = Record<
+  TestChain,
+  {
+    address: string;
+    addBridge: (destinationDomain: number, bridge: string) => Promise<void>;
+  }
+>;
+
+const routeGroupEntries = <T extends TestRouteGroup>(
+  group: T,
+): Array<[TestChain, T[TestChain]]> => [
+  ['anvil1', group.anvil1],
+  ['anvil2', group.anvil2],
+  ['anvil3', group.anvil3],
+];
 
 describe('RouteFixtureBuilder helpers', () => {
   const routeGroup = {
     anvil1: { address: '0x0000000000000000000000000000000000000001' },
     anvil2: { address: '0x0000000000000000000000000000000000000002' },
     anvil3: { address: '0x0000000000000000000000000000000000000003' },
-  };
+  } satisfies TestRouteGroup;
 
   it('builds remote enrollment domains and padded routers', () => {
     const enrollment = buildRemoteRouterEnrollment(routeGroup, 'anvil1');
@@ -26,35 +50,43 @@ describe('RouteFixtureBuilder helpers', () => {
   });
 
   it('builds chain address maps from route groups', () => {
-    expect(routeAddresses(routeGroup)).to.deep.equal({
-      anvil1: routeGroup.anvil1.address,
-      anvil2: routeGroup.anvil2.address,
-      anvil3: routeGroup.anvil3.address,
-    });
+    expect(routeAddresses(routeGroup)).to.deep.equal(
+      Object.fromEntries(
+        routeGroupEntries(routeGroup).map(([chain, route]) => [
+          chain,
+          route.address,
+        ]),
+      ),
+    );
   });
 
   it('adds per-chain rebalancers to every route group', async () => {
     const calls: Array<{ chain: string; rebalancer: string }> = [];
-    const routeGroups = [
-      Object.fromEntries(
-        Object.keys(routeGroup).map((chain) => [
-          chain,
-          {
-            address: routeGroup[chain as keyof typeof routeGroup].address,
-            addRebalancer: async (rebalancer: string) => {
-              calls.push({ chain, rebalancer });
-            },
+    const routeGroups: TestRebalancerRouteGroup[] = [
+      {
+        anvil1: {
+          address: routeGroup.anvil1.address,
+          addRebalancer: async (rebalancer) => {
+            calls.push({ chain: 'anvil1', rebalancer });
           },
-        ]),
-      ),
+        },
+        anvil2: {
+          address: routeGroup.anvil2.address,
+          addRebalancer: async (rebalancer) => {
+            calls.push({ chain: 'anvil2', rebalancer });
+          },
+        },
+        anvil3: {
+          address: routeGroup.anvil3.address,
+          addRebalancer: async (rebalancer) => {
+            calls.push({ chain: 'anvil3', rebalancer });
+          },
+        },
+      },
     ];
 
-    await addRebalancersToRouteGroups(
-      routeGroups as unknown as Parameters<
-        typeof addRebalancersToRouteGroups
-      >[0],
-      (chain) =>
-        chain === 'anvil3' ? ['deployer', 'inventory'] : ['deployer'],
+    await addRebalancersToRouteGroups(routeGroups, (chain) =>
+      chain === 'anvil3' ? ['deployer', 'inventory'] : ['deployer'],
     );
 
     expect(calls).to.deep.equal([
@@ -71,17 +103,26 @@ describe('RouteFixtureBuilder helpers', () => {
       destinationDomain: number;
       bridge: string;
     }> = [];
-    const monitoredRouters = Object.fromEntries(
-      Object.keys(routeGroup).map((chain) => [
-        chain,
-        {
-          address: routeGroup[chain as keyof typeof routeGroup].address,
-          addBridge: async (destinationDomain: number, bridge: string) => {
-            calls.push({ chain, destinationDomain, bridge });
-          },
+    const monitoredRouters: TestBridgeRouteGroup = {
+      anvil1: {
+        address: routeGroup.anvil1.address,
+        addBridge: async (destinationDomain, bridge) => {
+          calls.push({ chain: 'anvil1', destinationDomain, bridge });
         },
-      ]),
-    );
+      },
+      anvil2: {
+        address: routeGroup.anvil2.address,
+        addBridge: async (destinationDomain, bridge) => {
+          calls.push({ chain: 'anvil2', destinationDomain, bridge });
+        },
+      },
+      anvil3: {
+        address: routeGroup.anvil3.address,
+        addBridge: async (destinationDomain, bridge) => {
+          calls.push({ chain: 'anvil3', destinationDomain, bridge });
+        },
+      },
+    };
     const bridgeRouteGroups = [
       {
         anvil1: { address: '0x0000000000000000000000000000000000000011' },
@@ -93,16 +134,9 @@ describe('RouteFixtureBuilder helpers', () => {
         anvil2: { address: '0x0000000000000000000000000000000000000022' },
         anvil3: { address: '0x0000000000000000000000000000000000000023' },
       },
-    ];
+    ] satisfies TestRouteGroup[];
 
-    await addBridgesToMonitoredRoutes(
-      monitoredRouters as unknown as Parameters<
-        typeof addBridgesToMonitoredRoutes
-      >[0],
-      bridgeRouteGroups as unknown as Parameters<
-        typeof addBridgesToMonitoredRoutes
-      >[1],
-    );
+    await addBridgesToMonitoredRoutes(monitoredRouters, bridgeRouteGroups);
 
     expect(calls).to.deep.equal([
       {

--- a/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.ts
+++ b/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.ts
@@ -1,0 +1,348 @@
+import { ethers, providers } from 'ethers';
+
+import {
+  ERC20Test__factory,
+  HypERC20Collateral__factory,
+  HypNative__factory,
+} from '@hyperlane-xyz/core';
+
+import { TEST_CHAIN_CONFIGS, type TestChain } from '../fixtures/routes.js';
+
+export type ChainInfra = Record<
+  string,
+  { mailbox: string; ism: string; merkleHook: string }
+>;
+
+export type RouteGroupMap = Record<TestChain, ethers.Contract>;
+export type TokenMap = Record<TestChain, ethers.Contract>;
+
+export interface DeployedRouteFixture {
+  routeGroups: Record<string, RouteGroupMap>;
+  tokens: Record<string, TokenMap>;
+}
+
+interface RouteFixtureBuilderParams {
+  deployerWallet: ethers.Wallet;
+  providersByChain: Map<string, providers.JsonRpcProvider>;
+  chainInfra: ChainInfra;
+  ownerAddress: string;
+}
+
+interface Erc20TokenSpec {
+  id: string;
+  name: string;
+  symbol: string;
+  initialSupply: string;
+  decimals: number;
+}
+
+interface BaseRouteGroupSpec {
+  id: string;
+  scaleNumerator: ethers.BigNumberish;
+  scaleDenominator: ethers.BigNumberish;
+}
+
+interface Erc20CollateralRouteGroupSpec extends BaseRouteGroupSpec {
+  kind: 'erc20Collateral';
+  tokenId: string;
+}
+
+interface NativeRouteGroupSpec extends BaseRouteGroupSpec {
+  kind: 'native';
+}
+
+type RouteGroupSpec = Erc20CollateralRouteGroupSpec | NativeRouteGroupSpec;
+
+interface NativeBalanceSeed {
+  address: string;
+  amount: ethers.BigNumberish;
+}
+
+export class RouteFixtureBuilder {
+  private readonly tokenSpecs: Erc20TokenSpec[] = [];
+  private readonly routeGroupSpecs: RouteGroupSpec[] = [];
+  private readonly nativeBalanceSeeds: NativeBalanceSeed[] = [];
+
+  constructor(private readonly params: RouteFixtureBuilderParams) {}
+
+  withNativeBalance(
+    address: string,
+    amount: ethers.BigNumberish,
+  ): RouteFixtureBuilder {
+    this.nativeBalanceSeeds.push({ address, amount });
+    return this;
+  }
+
+  withErc20Token(spec: Erc20TokenSpec): RouteFixtureBuilder {
+    this.tokenSpecs.push(spec);
+    return this;
+  }
+
+  withErc20CollateralRouteGroup(
+    spec: Omit<Erc20CollateralRouteGroupSpec, 'kind'>,
+  ): RouteFixtureBuilder {
+    this.routeGroupSpecs.push({ ...spec, kind: 'erc20Collateral' });
+    return this;
+  }
+
+  withNativeRouteGroup(
+    spec: Omit<NativeRouteGroupSpec, 'kind'>,
+  ): RouteFixtureBuilder {
+    this.routeGroupSpecs.push({ ...spec, kind: 'native' });
+    return this;
+  }
+
+  async deploy(): Promise<DeployedRouteFixture> {
+    const tokens: Record<string, TokenMap> = {};
+    const routeGroups: Record<string, RouteGroupMap> = {};
+
+    for (const tokenSpec of this.tokenSpecs) {
+      tokens[tokenSpec.id] = {} as TokenMap;
+    }
+
+    for (const routeGroupSpec of this.routeGroupSpecs) {
+      routeGroups[routeGroupSpec.id] = {} as RouteGroupMap;
+    }
+
+    for (const chain of TEST_CHAIN_CONFIGS) {
+      const provider = this.params.providersByChain.get(chain.name);
+      if (!provider) {
+        throw new Error(`Missing provider for chain ${chain.name}`);
+      }
+
+      for (const seed of this.nativeBalanceSeeds) {
+        await provider.send('anvil_setBalance', [
+          seed.address,
+          ethers.utils.hexValue(seed.amount),
+        ]);
+      }
+
+      const deployer = this.params.deployerWallet.connect(provider);
+
+      for (const tokenSpec of this.tokenSpecs) {
+        const token = await new ERC20Test__factory(deployer).deploy(
+          tokenSpec.name,
+          tokenSpec.symbol,
+          tokenSpec.initialSupply,
+          tokenSpec.decimals,
+        );
+        await token.deployed();
+        tokens[tokenSpec.id][chain.name] = token;
+      }
+
+      for (const routeGroupSpec of this.routeGroupSpecs) {
+        const route =
+          routeGroupSpec.kind === 'erc20Collateral'
+            ? await this.deployErc20CollateralRoute(
+                routeGroupSpec,
+                tokens,
+                chain.name,
+                deployer,
+              )
+            : await this.deployNativeRoute(
+                routeGroupSpec,
+                chain.name,
+                deployer,
+              );
+
+        routeGroups[routeGroupSpec.id][chain.name] = route;
+      }
+    }
+
+    return { routeGroups, tokens };
+  }
+
+  private async deployErc20CollateralRoute(
+    spec: Erc20CollateralRouteGroupSpec,
+    tokens: Record<string, TokenMap>,
+    chain: TestChain,
+    deployer: ethers.Wallet,
+  ): Promise<ethers.Contract> {
+    const token = tokens[spec.tokenId]?.[chain];
+    if (!token) {
+      throw new Error(`Missing ERC20 token ${spec.tokenId} for chain ${chain}`);
+    }
+
+    const route = await new HypERC20Collateral__factory(deployer).deploy(
+      token.address,
+      spec.scaleNumerator,
+      spec.scaleDenominator,
+      this.params.chainInfra[chain].mailbox,
+    );
+    await route.deployed();
+    await route.initialize(
+      ethers.constants.AddressZero,
+      this.params.chainInfra[chain].ism,
+      this.params.ownerAddress,
+    );
+    return route;
+  }
+
+  private async deployNativeRoute(
+    spec: NativeRouteGroupSpec,
+    chain: TestChain,
+    deployer: ethers.Wallet,
+  ): Promise<ethers.Contract> {
+    const route = await new HypNative__factory(deployer).deploy(
+      spec.scaleNumerator,
+      spec.scaleDenominator,
+      this.params.chainInfra[chain].mailbox,
+    );
+    await route.deployed();
+    await route.initialize(
+      ethers.constants.AddressZero,
+      this.params.chainInfra[chain].ism,
+      this.params.ownerAddress,
+    );
+    return route;
+  }
+}
+
+export function buildRemoteRouterEnrollment(
+  routeMap: Record<TestChain, { address: string }>,
+  localChain: TestChain,
+): { remoteDomains: number[]; remoteRouters: string[] } {
+  const remoteDomains: number[] = [];
+  const remoteRouters: string[] = [];
+
+  for (const remote of TEST_CHAIN_CONFIGS) {
+    if (remote.name === localChain) continue;
+    remoteDomains.push(remote.domainId);
+    remoteRouters.push(
+      ethers.utils.hexZeroPad(routeMap[remote.name].address, 32),
+    );
+  }
+
+  return { remoteDomains, remoteRouters };
+}
+
+export async function enrollRouteGroups(
+  routeGroups: readonly RouteGroupMap[],
+): Promise<void> {
+  for (const routeGroup of routeGroups) {
+    for (const chain of TEST_CHAIN_CONFIGS) {
+      const { remoteDomains, remoteRouters } = buildRemoteRouterEnrollment(
+        routeGroup,
+        chain.name,
+      );
+      await routeGroup[chain.name].enrollRemoteRouters(
+        remoteDomains,
+        remoteRouters,
+      );
+    }
+  }
+}
+
+export async function addRebalancersToRouteGroups(
+  routeGroups: readonly RouteGroupMap[],
+  rebalancersForChain: (chain: TestChain) => readonly string[],
+): Promise<void> {
+  for (const routeGroup of routeGroups) {
+    for (const chain of TEST_CHAIN_CONFIGS) {
+      for (const rebalancer of rebalancersForChain(chain.name)) {
+        await routeGroup[chain.name].addRebalancer(rebalancer);
+      }
+    }
+  }
+}
+
+export async function addBridgesToMonitoredRoutes(
+  monitoredRouters: RouteGroupMap,
+  bridgeRouteGroups: readonly RouteGroupMap[],
+): Promise<void> {
+  for (const chain of TEST_CHAIN_CONFIGS) {
+    for (const destination of TEST_CHAIN_CONFIGS) {
+      if (destination.name === chain.name) continue;
+      for (const bridgeRouteGroup of bridgeRouteGroups) {
+        await monitoredRouters[chain.name].addBridge(
+          destination.domainId,
+          bridgeRouteGroup[chain.name].address,
+        );
+      }
+    }
+  }
+}
+
+export async function seedErc20RouteGroups(params: {
+  deployerWallet: ethers.Wallet;
+  providersByChain: Map<string, providers.JsonRpcProvider>;
+  tokens: TokenMap;
+  routeGroups: readonly RouteGroupMap[];
+  amount: ethers.BigNumberish;
+}): Promise<void> {
+  for (const chain of TEST_CHAIN_CONFIGS) {
+    const token = erc20TokenForChain(params, chain.name);
+    for (const routeGroup of params.routeGroups) {
+      const tx = await token.transfer(
+        routeGroup[chain.name].address,
+        params.amount,
+      );
+      await tx.wait();
+    }
+  }
+}
+
+export async function seedErc20Recipient(params: {
+  deployerWallet: ethers.Wallet;
+  providersByChain: Map<string, providers.JsonRpcProvider>;
+  tokens: TokenMap;
+  recipient: string;
+  amount: ethers.BigNumberish;
+}): Promise<void> {
+  for (const chain of TEST_CHAIN_CONFIGS) {
+    const token = erc20TokenForChain(params, chain.name);
+    const tx = await token.transfer(params.recipient, params.amount);
+    await tx.wait();
+  }
+}
+
+export async function seedNativeRouteGroup(params: {
+  deployerWallet: ethers.Wallet;
+  providersByChain: Map<string, providers.JsonRpcProvider>;
+  routeGroup: RouteGroupMap;
+  amount: ethers.BigNumberish;
+}): Promise<void> {
+  for (const chain of TEST_CHAIN_CONFIGS) {
+    const provider = params.providersByChain.get(chain.name);
+    if (!provider) {
+      throw new Error(`Missing provider for chain ${chain.name}`);
+    }
+
+    const deployer = params.deployerWallet.connect(provider);
+    const tx = await deployer.sendTransaction({
+      to: params.routeGroup[chain.name].address,
+      value: params.amount,
+    });
+    await tx.wait();
+  }
+}
+
+export function routeAddresses(
+  routeGroup: Record<TestChain, { address: string }>,
+): Record<TestChain, string> {
+  return Object.fromEntries(
+    TEST_CHAIN_CONFIGS.map((chain) => [
+      chain.name,
+      routeGroup[chain.name].address,
+    ]),
+  ) as Record<TestChain, string>;
+}
+
+function erc20TokenForChain(
+  params: {
+    deployerWallet: ethers.Wallet;
+    providersByChain: Map<string, providers.JsonRpcProvider>;
+    tokens: TokenMap;
+  },
+  chain: TestChain,
+): ethers.Contract {
+  const provider = params.providersByChain.get(chain);
+  if (!provider) {
+    throw new Error(`Missing provider for chain ${chain}`);
+  }
+
+  return ERC20Test__factory.connect(
+    params.tokens[chain].address,
+    params.deployerWallet.connect(provider),
+  );
+}

--- a/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.ts
+++ b/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.ts
@@ -2,7 +2,9 @@ import { ethers, providers } from 'ethers';
 
 import {
   ERC20Test__factory,
+  type HypERC20Collateral,
   HypERC20Collateral__factory,
+  type HypNative,
   HypNative__factory,
 } from '@hyperlane-xyz/core';
 
@@ -13,7 +15,9 @@ export type ChainInfra = Record<
   { mailbox: string; ism: string; merkleHook: string }
 >;
 
-export type RouteGroupMap = Record<TestChain, ethers.Contract>;
+type DeployedRoute = HypERC20Collateral | HypNative;
+
+export type RouteGroupMap = Record<TestChain, DeployedRoute>;
 export type TokenMap = Record<TestChain, ethers.Contract>;
 type RouteAddressMap = Record<TestChain, { address: string }>;
 type RebalancerRouteWithMethod = {
@@ -23,10 +27,8 @@ type BridgeRouteWithMethod = {
   address: string;
   addBridge: (destinationDomain: number, bridge: string) => Promise<unknown>;
 };
-type RebalancerRoute = ethers.Contract | RebalancerRouteWithMethod;
-type BridgeRoute = ethers.Contract | BridgeRouteWithMethod;
-type RebalancerRouteMap = Record<TestChain, RebalancerRoute>;
-type BridgeRouteMap = Record<TestChain, BridgeRoute>;
+type RebalancerRouteMap = Record<TestChain, RebalancerRouteWithMethod>;
+type BridgeRouteMap = Record<TestChain, BridgeRouteWithMethod>;
 
 export interface DeployedRouteFixture {
   routeGroups: Record<string, RouteGroupMap>;
@@ -169,7 +171,7 @@ export class RouteFixtureBuilder {
     tokens: Record<string, TokenMap>,
     chain: TestChain,
     deployer: ethers.Wallet,
-  ): Promise<ethers.Contract> {
+  ): Promise<HypERC20Collateral> {
     const token = tokens[spec.tokenId]?.[chain];
     if (!token) {
       throw new Error(`Missing ERC20 token ${spec.tokenId} for chain ${chain}`);
@@ -194,7 +196,7 @@ export class RouteFixtureBuilder {
     spec: NativeRouteGroupSpec,
     chain: TestChain,
     deployer: ethers.Wallet,
-  ): Promise<ethers.Contract> {
+  ): Promise<HypNative> {
     const route = await new HypNative__factory(deployer).deploy(
       spec.scaleNumerator,
       spec.scaleDenominator,
@@ -252,7 +254,7 @@ export async function addRebalancersToRouteGroups(
   for (const routeGroup of routeGroups) {
     for (const chain of TEST_CHAIN_CONFIGS) {
       for (const rebalancer of rebalancersForChain(chain.name)) {
-        await addRebalancer(routeGroup[chain.name], rebalancer);
+        await routeGroup[chain.name].addRebalancer(rebalancer);
       }
     }
   }
@@ -266,8 +268,7 @@ export async function addBridgesToMonitoredRoutes(
     for (const destination of TEST_CHAIN_CONFIGS) {
       if (destination.name === chain.name) continue;
       for (const bridgeRouteGroup of bridgeRouteGroups) {
-        await addBridge(
-          monitoredRouters[chain.name],
+        await monitoredRouters[chain.name].addBridge(
           destination.domainId,
           bridgeRouteGroup[chain.name].address,
         );
@@ -338,23 +339,6 @@ export function routeAddresses(
     anvil2: routeGroup.anvil2.address,
     anvil3: routeGroup.anvil3.address,
   };
-}
-
-function addRebalancer(
-  route: RebalancerRoute,
-  rebalancer: string,
-): Promise<unknown> {
-  const withMethod = route as RebalancerRouteWithMethod;
-  return withMethod.addRebalancer(rebalancer);
-}
-
-function addBridge(
-  route: BridgeRoute,
-  destinationDomain: number,
-  bridge: string,
-): Promise<unknown> {
-  const withMethod = route as BridgeRouteWithMethod;
-  return withMethod.addBridge(destinationDomain, bridge);
 }
 
 function erc20TokenForChain(

--- a/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.ts
+++ b/typescript/rebalancer/src/e2e/harness/RouteFixtureBuilder.ts
@@ -15,6 +15,18 @@ export type ChainInfra = Record<
 
 export type RouteGroupMap = Record<TestChain, ethers.Contract>;
 export type TokenMap = Record<TestChain, ethers.Contract>;
+type RouteAddressMap = Record<TestChain, { address: string }>;
+type RebalancerRouteWithMethod = {
+  addRebalancer: (rebalancer: string) => Promise<unknown>;
+};
+type BridgeRouteWithMethod = {
+  address: string;
+  addBridge: (destinationDomain: number, bridge: string) => Promise<unknown>;
+};
+type RebalancerRoute = ethers.Contract | RebalancerRouteWithMethod;
+type BridgeRoute = ethers.Contract | BridgeRouteWithMethod;
+type RebalancerRouteMap = Record<TestChain, RebalancerRoute>;
+type BridgeRouteMap = Record<TestChain, BridgeRoute>;
 
 export interface DeployedRouteFixture {
   routeGroups: Record<string, RouteGroupMap>;
@@ -199,7 +211,7 @@ export class RouteFixtureBuilder {
 }
 
 export function buildRemoteRouterEnrollment(
-  routeMap: Record<TestChain, { address: string }>,
+  routeMap: RouteAddressMap,
   localChain: TestChain,
 ): { remoteDomains: number[]; remoteRouters: string[] } {
   const remoteDomains: number[] = [];
@@ -234,27 +246,28 @@ export async function enrollRouteGroups(
 }
 
 export async function addRebalancersToRouteGroups(
-  routeGroups: readonly RouteGroupMap[],
+  routeGroups: readonly RebalancerRouteMap[],
   rebalancersForChain: (chain: TestChain) => readonly string[],
 ): Promise<void> {
   for (const routeGroup of routeGroups) {
     for (const chain of TEST_CHAIN_CONFIGS) {
       for (const rebalancer of rebalancersForChain(chain.name)) {
-        await routeGroup[chain.name].addRebalancer(rebalancer);
+        await addRebalancer(routeGroup[chain.name], rebalancer);
       }
     }
   }
 }
 
 export async function addBridgesToMonitoredRoutes(
-  monitoredRouters: RouteGroupMap,
-  bridgeRouteGroups: readonly RouteGroupMap[],
+  monitoredRouters: BridgeRouteMap,
+  bridgeRouteGroups: readonly RouteAddressMap[],
 ): Promise<void> {
   for (const chain of TEST_CHAIN_CONFIGS) {
     for (const destination of TEST_CHAIN_CONFIGS) {
       if (destination.name === chain.name) continue;
       for (const bridgeRouteGroup of bridgeRouteGroups) {
-        await monitoredRouters[chain.name].addBridge(
+        await addBridge(
+          monitoredRouters[chain.name],
           destination.domainId,
           bridgeRouteGroup[chain.name].address,
         );
@@ -318,14 +331,30 @@ export async function seedNativeRouteGroup(params: {
 }
 
 export function routeAddresses(
-  routeGroup: Record<TestChain, { address: string }>,
+  routeGroup: RouteAddressMap,
 ): Record<TestChain, string> {
-  return Object.fromEntries(
-    TEST_CHAIN_CONFIGS.map((chain) => [
-      chain.name,
-      routeGroup[chain.name].address,
-    ]),
-  ) as Record<TestChain, string>;
+  return {
+    anvil1: routeGroup.anvil1.address,
+    anvil2: routeGroup.anvil2.address,
+    anvil3: routeGroup.anvil3.address,
+  };
+}
+
+function addRebalancer(
+  route: RebalancerRoute,
+  rebalancer: string,
+): Promise<unknown> {
+  const withMethod = route as RebalancerRouteWithMethod;
+  return withMethod.addRebalancer(rebalancer);
+}
+
+function addBridge(
+  route: BridgeRoute,
+  destinationDomain: number,
+  bridge: string,
+): Promise<unknown> {
+  const withMethod = route as BridgeRouteWithMethod;
+  return withMethod.addBridge(destinationDomain, bridge);
 }
 
 function erc20TokenForChain(


### PR DESCRIPTION
## Summary

Final stacked rebalancer architecture slice on top of #8882.

- Split inventory execution out of `InventoryRebalancer` into focused modules:
  - `InventoryIntentResolver`
  - `InventoryPlanner`
  - `BridgeCapacityEstimator`
  - `InventoryMovementExecutor`
  - `TransferRemoteExecutor`
- Replace route-specific local e2e deployment loops with `RouteFixtureBuilder` and shared deploy/enroll/seed/address helpers.
- Update `docs/rebalancer-architecture-review.md` and the changeset to mark the final follow-up slices complete.

## Slice Benefits

- Inventory intent resolution: isolates single-intent continuation and in-flight-deposit waiting so active-intent behavior is testable without the bridge/transaction path.
- Inventory planning: keeps cost probes, effective inventory, mixed-decimal alignment, source selection, and bridge-plan construction in a focused planning module.
- Bridge capacity estimation: separates quote/gas viability checks from execution so source viability can be optimized independently.
- Inventory movement execution: isolates external bridge quote/execute/action-recording behavior, including reverse-to-forward quote fallback and consumed-inventory bookkeeping.
- `transferRemote` execution: separates WarpCore transaction creation/sending/action recording from bridge movement logic.
- Declarative e2e fixtures: local route managers now declare fixture topology and reuse shared deployment, router enrollment, rebalancer enrollment, bridge registration, token/native seeding, and address-map helpers, reducing route-specific drift.

## Review Notes

- Used subagent implementation slices for inventory execution and e2e fixture extraction.
- Claude e2e harness review found no actionable correctness issues; I added direct helper tests for the low coverage gap it identified.
- Claude inventory review flagged `intent.externalBridge!`; replaced it with an explicit assert and added a seam test for the missing-bridge continuation path.

## Verification

- `pnpm -C typescript/rebalancer build`
- `pnpm -C typescript/rebalancer test` (`420 passing`)
- `pnpm exec oxlint -c ../../oxlint.json ...` on touched PR4 TS files
- `pnpm exec prettier --check ...` on touched PR4 files/docs/changeset
- `git diff --check`

Not run: heavyweight testcontainer e2e suites.
