### PR TITLE
fix(relayer): skip non-CCTP V2 messages in relay API instead of erroring

### DIFF
--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -550,11 +550,9 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         // returns false and no non-EVM indexer overrides it. Extending the relay API
         // to non-EVM chains requires a chain-specific is_cctp_v2 implementation.
         if !extracted.is_cctp_v2 {
-            warn!(message_id = ?extracted.message_id, "Rejecting non-CCTP V2 message");
+            warn!(message_id = ?extracted.message_id, "Skipping non-CCTP V2 message");
             state.record_failure("not_cctp_v2");
-            return Err(ServerError::InvalidRequest(
-                "Only EVM CCTP V2 messages are supported via the relay API".to_string(),
-            ));
+            continue;
         }
 
         // Get message context for (origin, destination)

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -407,7 +407,7 @@ async fn test_extraction_timeout() {
 }
 
 #[tokio::test]
-async fn test_non_cctp_message_rejected() {
+async fn test_non_cctp_message_skipped() {
     let msg = test_msg(ORIGIN_ID, DEST_ID, 1);
     let TestHarness {
         state,
@@ -417,7 +417,7 @@ async fn test_non_cctp_message_rejected() {
 
     let status = send_relay(state.router(), TX_HASH).await;
 
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::OK);
     assert!(
         rx.is_closed() || rx.len() == 0,
         "nothing should be enqueued"


### PR DESCRIPTION
## Summary

- Non-CCTP V2 messages submitted to the relay API are now silently skipped instead of returning a 400 error
- Response is `200 OK` with an empty `messages` array when no eligible messages are found
- Whitelist, blacklist, and other validation errors still return errors as before

## Test plan

- Updated `test_non_cctp_message_rejected` → `test_non_cctp_message_skipped` to assert `200 OK` and empty queue
- All 12 relay API unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)