### PR TITLE
fix(sdk): read Starknet balances at latest block instead of pending

### DIFF
--- a/.changeset/starknet-balances-latest-block.md
+++ b/.changeset/starknet-balances-latest-block.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+The default Starknet provider builder now reads at the `latest` block instead of starknet.js's `pending` default, so balance and view calls no longer fail on RPC providers that reject `block_id: "pending"`.

--- a/typescript/sdk/src/providers/builders/starknet.ts
+++ b/typescript/sdk/src/providers/builders/starknet.ts
@@ -1,4 +1,4 @@
-import { RpcProvider as StarknetRpcProvider } from 'starknet';
+import { BlockTag, RpcProvider as StarknetRpcProvider } from 'starknet';
 
 import { assert } from '@hyperlane-xyz/utils';
 
@@ -17,6 +17,11 @@ export const defaultStarknetJsProviderBuilder: ProviderBuilderFn<
   const provider = new StarknetRpcProvider({
     nodeUrl: url,
     headers,
+    // Default reads to the latest accepted block instead of starknet.js's
+    // `pending` default. Some RPC providers reject `block_id: "pending"`
+    // (-32602 Invalid block id), and reading already-finalized state at
+    // `latest` is both universally supported and semantically correct.
+    blockIdentifier: BlockTag.LATEST,
   });
   return { provider, type: ProviderType.Starknet };
 };


### PR DESCRIPTION
## Summary
- `warp balances` (and other view reads) failed on Starknet with `-32602 Invalid Params: "unknown block tag 'pending'"` because the default Starknet provider builder constructed the `RpcProvider` without a `blockIdentifier`, so starknet.js fell back to its `block_id: "pending"` default. RPC providers that don't accept the `pending` tag reject the call, so `balance_of()` / `total_supply()` error out.
- Mirrors the existing fix in `typescript/starknet-sdk/src/clients/provider.ts` (which already passes `blockIdentifier: BlockTag.LATEST`) into the SDK's `defaultStarknetJsProviderBuilder`, used by `MultiProtocolProvider.getStarknetProvider`.
- Reading already-finalized state at `latest` is universally supported and semantically correct for balance/supply reads.
- Added a patch changeset for `@hyperlane-xyz/sdk`.

## Repro (before)
```
pnpm hyperlane warp balances -r <registry> -w Fartcoin/solanamainnet-starknet
# starknet row -> 'Error', status INCONCLUSIVE
# Could not fetch balance for Fartcoin on starknet: ... "unknown block tag 'pending'"
```

## Test plan
- [x] `pnpm -C typescript/sdk build` (exit 0)
- [x] Rebuild SDK + CLI and re-run `warp balances` for `Fartcoin/solanamainnet-starknet`; starknet row shows the synthetic supply and status resolves to a real collateral-vs-supply comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)