### PR TITLE
feat: enable OffchainQuotedLinearFee on eclipse USDC/USDT FPWRs

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -361,6 +361,13 @@ const awProxyAdmins: ChainMap<{ address: string; owner: string }> = objMap(
   },
 );
 
+// Reuse the CROSS/moonpay quote signers so the stableswap-moonpay rebalancer
+// can be exempted from the eclipse FPWR fee via standing zero-quotes.
+const QUOTE_SIGNERS = [
+  '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d',
+  '0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867',
+];
+
 export const getEclipseUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> =>
@@ -372,6 +379,7 @@ export const getEclipseUSDCWarpConfig = async (
       name: 'USD Coin',
       symbol: 'USDC',
     },
+    quoteSigners: QUOTE_SIGNERS,
   });
 
 // Strategies

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -128,11 +128,13 @@ export interface EclipseUSDTWarpConfigOptions {
     solanamainnet: string;
   };
   proxyAdmins: ChainMap<{ address?: string; owner: string }>;
+  quoteSigners?: string[];
 }
 
 const getBaseEvmConfig = (
   chain: DeploymentChain,
   proxyAdmins: ChainMap<{ address?: string; owner: string }>,
+  quoteSigners?: string[],
 ) => {
   const proxyAdmin = proxyAdmins[chain];
   assert(proxyAdmin, `Missing proxyAdmin for chain ${chain}`);
@@ -150,6 +152,8 @@ const getBaseEvmConfig = (
       getWarpFeeOwner(chain),
       destinations,
       destinationFeeBps,
+      undefined,
+      quoteSigners,
     ),
     ...scaleDownConfig(decimals, MESSAGE_DECIMALS),
   };
@@ -159,7 +163,7 @@ export const buildEclipseUSDTWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   options: EclipseUSDTWarpConfigOptions,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const { ownersByChain, programIds, proxyAdmins } = options;
+  const { ownersByChain, programIds, proxyAdmins, quoteSigners } = options;
 
   const rebalancingConfigByChain = getRebalancingBridgesConfigFor(
     rebalanceableCollateralChains,
@@ -180,7 +184,7 @@ export const buildEclipseUSDTWarpConfig = async (
     );
     configs.push([
       chain,
-      { ...baseConfig, ...getBaseEvmConfig(chain, proxyAdmins) },
+      { ...baseConfig, ...getBaseEvmConfig(chain, proxyAdmins, quoteSigners) },
     ]);
   }
 
@@ -192,7 +196,7 @@ export const buildEclipseUSDTWarpConfig = async (
     configs.push([
       chain,
       {
-        ...getBaseEvmConfig(chain, proxyAdmins),
+        ...getBaseEvmConfig(chain, proxyAdmins, quoteSigners),
         type: TokenType.collateral,
         token: usdtToken,
         owner: ownersByChain[chain],
@@ -234,6 +238,13 @@ export const buildEclipseUSDTWarpConfig = async (
   return Object.fromEntries(configs);
 };
 
+// Reuse the CROSS/moonpay quote signers so the stableswap-moonpay rebalancer
+// can be exempted from the eclipse FPWR fee via standing zero-quotes.
+const QUOTE_SIGNERS = [
+  '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d',
+  '0x6bb7818bbE8d88094Cf3620e58BC6BbEd542B867',
+];
+
 export const getEclipseUSDTWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> =>
@@ -241,6 +252,7 @@ export const getEclipseUSDTWarpConfig = async (
     ownersByChain: productionOwnersByChain,
     programIds: PRODUCTION_PROGRAM_IDS,
     proxyAdmins: awProxyAdmins,
+    quoteSigners: QUOTE_SIGNERS,
   });
 
 // Strategies


### PR DESCRIPTION
## Summary
- Threads `quoteSigners` into the eclipse **USDC** and **USDT** warp config getters so each per-destination leaf fee contract deploys as `OffchainQuotedLinearFee` instead of plain `LinearFee`.
- Reuses the existing CROSS/moonpay quote signers (same pair already used by the Citrea/moonpay getters).
- **No economic change on its own**: the existing bps stays as the immutable `LinearFee` fallback for normal users; this only adds the EIP-712 quote-signing capability.

## Why
Enables exempting the CROSS/moonpay stableswap rebalancer from the eclipse FPWR fee. With `OffchainQuotedLinearFee` in place, we can later submit offchain **standing zero-quotes** keyed on `(destDomain, moonpayDestRouter)` so the rebalancer's `MovableCollateralRouter` transfers resolve to a 0 fee, while everyone else falls through to the bps fallback (resolution cascade step 2: `quotes[dest][recipient]`).

## Scope / rollout
- `warp apply` will redeploy the leaf fee contract for **every EVM fee destination** on both routes and rewire `RoutingFee.setFeeContract(...)` via the WarpFees Safe (ethereum) / ICA (other chains) — same governance pattern as the moonpay Citrea routes.
- The actual zero-fee exemption is a **separate offchain EIP-712 standing-quote step** performed after these contracts exist; it is not part of this PR.

## Test plan
- [x] `tsc --noEmit` passes for `typescript/infra`
- [x] pre-commit (oxlint + oxfmt) clean
- [ ] `warp apply` dry-run preview on USDC/eclipsemainnet + USDT/eclipsemainnet to confirm only fee-contract deploys + setFeeContract rewires are proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)