### PR TITLE
fix(scraper): retry dispatches on partial enrichment

### DIFF
--- a/rust/main/agents/scraper/README.md
+++ b/rust/main/agents/scraper/README.md
@@ -17,6 +17,17 @@ To init the database, run from `rust` dir
 cargo run --package migration --bin init-db
 ```
 
+## Database migrations
+
+Deploy scraper database migrations before deploying a scraper binary that
+references newly-added columns. The raw message dispatch reconciler depends on
+`raw_message_dispatch.msg_body`; deploying that binary before migration makes
+raw dispatch inserts fail closed and stalls the message cursor until the column
+exists.
+
+For rollback, stop or roll back scraper binaries that reference a new column
+before dropping that column.
+
 To re-create the database, run from `rust` dir
 
 ```bash

--- a/rust/main/agents/scraper/README.md
+++ b/rust/main/agents/scraper/README.md
@@ -25,6 +25,16 @@ references newly-added columns. The raw message dispatch reconciler depends on
 raw dispatch inserts fail closed and stalls the message cursor until the column
 exists.
 
+After running migrations and before deploying the scraper binary, create the
+reconciliation index concurrently:
+
+```
+cargo run --package migration --bin create-raw-dispatch-reconciliation-index
+```
+
+Then run `EXPLAIN` on the reconciliation query and confirm it uses
+`raw_message_dispatch_reconciliation_idx`.
+
 For rollback, stop or roll back scraper binaries that reference a new column
 before dropping that column.
 

--- a/rust/main/agents/scraper/migration/Cargo.toml
+++ b/rust/main/agents/scraper/migration/Cargo.toml
@@ -48,5 +48,9 @@ path = "bin/recreate_db.rs"
 name = "generate-entities"
 path = "bin/generate_entities.rs"
 
+[[bin]]
+name = "create-raw-dispatch-reconciliation-index"
+path = "bin/create_raw_dispatch_reconciliation_index.rs"
+
 [features]
 default = []

--- a/rust/main/agents/scraper/migration/bin/common.rs
+++ b/rust/main/agents/scraper/migration/bin/common.rs
@@ -1,6 +1,7 @@
 use std::{env, time::Duration};
 
 use migration::sea_orm::{Database, DatabaseConnection};
+#[allow(unused_imports)]
 pub use migration::{DbErr, Migrator, MigratorTrait as _};
 use sea_orm::ConnectOptions;
 

--- a/rust/main/agents/scraper/migration/bin/create_raw_dispatch_reconciliation_index.rs
+++ b/rust/main/agents/scraper/migration/bin/create_raw_dispatch_reconciliation_index.rs
@@ -1,0 +1,23 @@
+//! Create the raw dispatch reconciliation index outside the SeaORM migration
+//! transaction so Postgres can build it concurrently.
+
+use common::{init, DbErr};
+use migration::sea_orm::ConnectionTrait;
+
+mod common;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), DbErr> {
+    let db = init().await?;
+
+    db.execute_unprepared(
+        r#"
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS raw_message_dispatch_reconciliation_idx
+        ON raw_message_dispatch (origin_domain, origin_mailbox, id)
+        WHERE msg_body IS NOT NULL
+        "#,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/rust/main/agents/scraper/migration/src/lib.rs
+++ b/rust/main/agents/scraper/migration/src/lib.rs
@@ -15,6 +15,7 @@ mod m20230309_000004_create_table_gas_payment;
 mod m20230309_000005_create_table_message;
 mod m20250224_000006_create_table_raw_message_dispatch;
 mod m20250521_000007_add_cursor_event_type;
+mod m20260613_000008_add_msg_body_to_raw_message_dispatch;
 
 pub struct Migrator;
 
@@ -34,6 +35,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230309_000005_create_table_message::Migration),
             Box::new(m20250224_000006_create_table_raw_message_dispatch::Migration),
             Box::new(m20250521_000007_add_cursor_event_type::Migration),
+            Box::new(m20260613_000008_add_msg_body_to_raw_message_dispatch::Migration),
         ]
     }
 }

--- a/rust/main/agents/scraper/migration/src/m20260613_000008_add_msg_body_to_raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/migration/src/m20260613_000008_add_msg_body_to_raw_message_dispatch.rs
@@ -3,6 +3,9 @@ use sea_orm_migration::prelude::*;
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
+/// Add `msg_body` to raw dispatches so the scraper can reconcile raw rows into
+/// complete message rows without re-reading historical logs. Also adds the
+/// index used by the reconciliation anti-join scan.
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -13,10 +16,32 @@ impl MigrationTrait for Migration {
                     .add_column(ColumnDef::new(RawMessageDispatch::MsgBody).binary())
                     .to_owned(),
             )
-            .await
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE INDEX raw_message_dispatch_reconciliation_idx
+                ON raw_message_dispatch (origin_domain, origin_mailbox, id)
+                WHERE msg_body IS NOT NULL
+                "#,
+            )
+            .await?;
+
+        Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(RawMessageDispatch::Table)
+                    .name("raw_message_dispatch_reconciliation_idx")
+                    .to_owned(),
+            )
+            .await?;
+
         manager
             .alter_table(
                 Table::alter()

--- a/rust/main/agents/scraper/migration/src/m20260613_000008_add_msg_body_to_raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/migration/src/m20260613_000008_add_msg_body_to_raw_message_dispatch.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RawMessageDispatch::Table)
+                    .add_column(ColumnDef::new(RawMessageDispatch::MsgBody).binary())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RawMessageDispatch::Table)
+                    .drop_column(RawMessageDispatch::MsgBody)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum RawMessageDispatch {
+    Table,
+    MsgBody,
+}

--- a/rust/main/agents/scraper/migration/src/m20260613_000008_add_msg_body_to_raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/migration/src/m20260613_000008_add_msg_body_to_raw_message_dispatch.rs
@@ -4,8 +4,12 @@ use sea_orm_migration::prelude::*;
 pub struct Migration;
 
 /// Add `msg_body` to raw dispatches so the scraper can reconcile raw rows into
-/// complete message rows without re-reading historical logs. Also adds the
-/// index used by the reconciliation anti-join scan.
+/// complete message rows without re-reading historical logs.
+///
+/// The reconciliation index is created by the
+/// `create-raw-dispatch-reconciliation-index` bin because Postgres requires
+/// `CREATE INDEX CONCURRENTLY` to run outside a transaction, while SeaORM wraps
+/// Postgres migrations in one transaction.
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -18,28 +22,13 @@ impl MigrationTrait for Migration {
             )
             .await?;
 
-        manager
-            .get_connection()
-            .execute_unprepared(
-                r#"
-                CREATE INDEX raw_message_dispatch_reconciliation_idx
-                ON raw_message_dispatch (origin_domain, origin_mailbox, id)
-                WHERE msg_body IS NOT NULL
-                "#,
-            )
-            .await?;
-
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_index(
-                Index::drop()
-                    .table(RawMessageDispatch::Table)
-                    .name("raw_message_dispatch_reconciliation_idx")
-                    .to_owned(),
-            )
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS raw_message_dispatch_reconciliation_idx")
             .await?;
 
         manager

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -12,6 +12,7 @@ use hyperlane_core::{
     rpc_clients::RPC_RETRY_SLEEP_DURATION, Delivery, HyperlaneDomain, HyperlaneLogStore,
     HyperlaneMessage, InterchainGasPayment, SameChainCcrSwap, H512,
 };
+use prometheus::IntGaugeVec;
 use tokio::{sync::mpsc::Receiver as MpscReceiver, task::JoinHandle, time::sleep};
 use tracing::{info, info_span, instrument, trace, warn, Instrument};
 
@@ -21,7 +22,11 @@ use hyperlane_base::{
     CoreMetrics, HyperlaneAgentCore, RuntimeMetrics, SyncOptions,
 };
 
-use crate::{db::ScraperDb, settings::ScraperSettings, store::HyperlaneDbStore};
+use crate::{
+    db::ScraperDb,
+    settings::ScraperSettings,
+    store::{HyperlaneDbStore, RawDispatchRetryBackoff},
+};
 
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
 const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
@@ -41,6 +46,7 @@ pub struct Scraper {
     agent_metrics: AgentMetrics,
     chain_metrics: ChainMetrics,
     runtime_metrics: RuntimeMetrics,
+    raw_dispatch_unenriched_max_age: IntGaugeVec,
 }
 
 #[derive(Debug)]
@@ -72,6 +78,13 @@ impl BaseAgent for Scraper {
         let core = settings.build_hyperlane_core(metrics.clone());
 
         let contract_sync_metrics = Arc::new(ContractSyncMetrics::new(&metrics));
+        let raw_dispatch_unenriched_max_age = metrics
+            .new_int_gauge(
+                "raw_message_dispatch_unenriched_max_age_seconds",
+                "Maximum age in seconds of raw message dispatches pending reconciliation",
+                &["chain"],
+            )
+            .expect("failed to register raw dispatch reconciliation age metric");
 
         let scrapers = Self::build_chain_scrapers(
             &settings,
@@ -93,6 +106,7 @@ impl BaseAgent for Scraper {
             agent_metrics,
             chain_metrics,
             runtime_metrics,
+            raw_dispatch_unenriched_max_age,
         })
     }
 
@@ -235,6 +249,7 @@ impl Scraper {
         tasks.push(self.build_raw_dispatch_reconciler(
             domain.clone(),
             self.contract_sync_metrics.clone(),
+            self.raw_dispatch_unenriched_max_age.clone(),
             store.clone(),
         ));
 
@@ -372,6 +387,7 @@ impl Scraper {
         &self,
         domain: HyperlaneDomain,
         contract_sync_metrics: Arc<ContractSyncMetrics>,
+        raw_dispatch_unenriched_max_age: IntGaugeVec,
         store: HyperlaneDbStore,
     ) -> JoinHandle<()> {
         let domain_name = domain.name().to_owned();
@@ -386,7 +402,11 @@ impl Scraper {
                     &domain_name,
                     "reconcile_task",
                 ]);
+                let max_age_metric =
+                    raw_dispatch_unenriched_max_age.with_label_values(&[&domain_name]);
                 let mut next_after_id = 0;
+                let mut retry_backoff = RawDispatchRetryBackoff::default();
+                let mut max_age_seen_this_scan = 0_u64;
 
                 loop {
                     liveness_metric.set(
@@ -399,6 +419,7 @@ impl Scraper {
                     let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
                         next_after_id,
                         RAW_DISPATCH_RECONCILIATION_BATCH_SIZE,
+                        &mut retry_backoff,
                     ))
                     .catch_unwind()
                     .await;
@@ -406,18 +427,28 @@ impl Scraper {
                     match result {
                         Ok(Ok(result)) if result.candidate_count == 0 && next_after_id > 0 => {
                             next_after_id = 0;
+                            max_age_seen_this_scan = 0;
                             sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
                         }
                         Ok(Ok(result)) if result.candidate_count == 0 => {
+                            max_age_metric.set(0);
+                            max_age_seen_this_scan = 0;
                             sleep(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await;
                         }
                         Ok(Ok(result)) => {
                             next_after_id = result.next_after_id;
+                            max_age_seen_this_scan =
+                                max_age_seen_this_scan.max(result.max_unenriched_age_seconds);
+                            max_age_metric
+                                .set(max_age_seen_this_scan.try_into().unwrap_or(i64::MAX));
                             stored_events_metric.inc_by(result.stored_count.into());
                             info!(
                                 candidates = result.candidate_count,
+                                attempted = result.attempted_count,
+                                skipped_backoff = result.skipped_backoff_count,
                                 stored = result.stored_count,
                                 next_after_id,
+                                max_unenriched_age_seconds = max_age_seen_this_scan,
                                 domain = domain_name,
                                 "Reconciled raw message dispatches"
                             );

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use async_trait::async_trait;
 use derive_more::AsRef;
@@ -19,6 +23,9 @@ use hyperlane_base::{
 use crate::{db::ScraperDb, settings::ScraperSettings, store::HyperlaneDbStore};
 
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
+const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
+const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(60);
+const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
 
 /// A message explorer scraper agent
 #[derive(Debug, AsRef)]
@@ -224,6 +231,12 @@ impl Scraper {
             .await?;
         tasks.push(gas_payment_indexer);
 
+        tasks.push(self.build_raw_dispatch_reconciler(
+            domain.clone(),
+            self.contract_sync_metrics.clone(),
+            store.clone(),
+        ));
+
         if let Some(ccr_task) = self
             .build_ccr_indexer(
                 domain,
@@ -352,6 +365,62 @@ impl Scraper {
                 .instrument(info_span!("ChainContractSync", chain=%domain.name(), event=label)),
         );
         Ok((task, maybe_broadcaser))
+    }
+
+    fn build_raw_dispatch_reconciler(
+        &self,
+        domain: HyperlaneDomain,
+        contract_sync_metrics: Arc<ContractSyncMetrics>,
+        store: HyperlaneDbStore,
+    ) -> JoinHandle<()> {
+        let domain_name = domain.name().to_owned();
+        let span_domain_name = domain_name.clone();
+        tokio::spawn(
+            async move {
+                let stored_events_metric = contract_sync_metrics
+                    .stored_events
+                    .with_label_values(&["message_dispatch_reconciled", &domain_name]);
+                let liveness_metric = contract_sync_metrics.liveness_metrics.with_label_values(&[
+                    "raw_message_dispatch_reconciliation",
+                    &domain_name,
+                    "reconcile_task",
+                ]);
+
+                loop {
+                    liveness_metric.set(
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .map(|duration| duration.as_secs() as i64)
+                            .unwrap_or_default(),
+                    );
+
+                    match store
+                        .reconcile_raw_message_dispatches(RAW_DISPATCH_RECONCILIATION_BATCH_SIZE)
+                        .await
+                    {
+                        Ok(0) => sleep(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await,
+                        Ok(stored) => {
+                            stored_events_metric.inc_by(stored.into());
+                            info!(
+                                stored,
+                                domain = domain_name,
+                                "Reconciled raw message dispatches"
+                            );
+                            sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
+                        }
+                        Err(err) => {
+                            warn!(
+                                ?err,
+                                domain = domain_name,
+                                "Failed to reconcile raw message dispatches"
+                            );
+                            sleep(RPC_RETRY_SLEEP_DURATION).await;
+                        }
+                    }
+                }
+            }
+            .instrument(info_span!("RawDispatchReconciliation", chain=%span_domain_name)),
+        )
     }
 
     async fn build_delivery_indexer(

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -1,12 +1,13 @@
 use std::{
     collections::HashMap,
+    panic::AssertUnwindSafe,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
 use derive_more::AsRef;
-use futures::future::try_join_all;
+use futures::{future::try_join_all, FutureExt};
 use hyperlane_core::{
     rpc_clients::RPC_RETRY_SLEEP_DURATION, Delivery, HyperlaneDomain, HyperlaneLogStore,
     HyperlaneMessage, InterchainGasPayment, SameChainCcrSwap, H512,
@@ -385,6 +386,7 @@ impl Scraper {
                     &domain_name,
                     "reconcile_task",
                 ]);
+                let mut next_after_id = 0;
 
                 loop {
                     liveness_metric.set(
@@ -394,25 +396,45 @@ impl Scraper {
                             .unwrap_or_default(),
                     );
 
-                    match store
-                        .reconcile_raw_message_dispatches(RAW_DISPATCH_RECONCILIATION_BATCH_SIZE)
-                        .await
-                    {
-                        Ok(0) => sleep(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await,
-                        Ok(stored) => {
-                            stored_events_metric.inc_by(stored.into());
+                    let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
+                        next_after_id,
+                        RAW_DISPATCH_RECONCILIATION_BATCH_SIZE,
+                    ))
+                    .catch_unwind()
+                    .await;
+
+                    match result {
+                        Ok(Ok(result)) if result.candidate_count == 0 && next_after_id > 0 => {
+                            next_after_id = 0;
+                            sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
+                        }
+                        Ok(Ok(result)) if result.candidate_count == 0 => {
+                            sleep(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await;
+                        }
+                        Ok(Ok(result)) => {
+                            next_after_id = result.next_after_id;
+                            stored_events_metric.inc_by(result.stored_count.into());
                             info!(
-                                stored,
+                                candidates = result.candidate_count,
+                                stored = result.stored_count,
+                                next_after_id,
                                 domain = domain_name,
                                 "Reconciled raw message dispatches"
                             );
                             sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
                         }
-                        Err(err) => {
+                        Ok(Err(err)) => {
                             warn!(
                                 ?err,
                                 domain = domain_name,
                                 "Failed to reconcile raw message dispatches"
+                            );
+                            sleep(RPC_RETRY_SLEEP_DURATION).await;
+                        }
+                        Err(_) => {
+                            warn!(
+                                domain = domain_name,
+                                "Raw message dispatch reconciliation panicked; retrying"
                             );
                             sleep(RPC_RETRY_SLEEP_DURATION).await;
                         }

--- a/rust/main/agents/scraper/src/db/generated/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/generated/raw_message_dispatch.rs
@@ -82,7 +82,7 @@ impl ColumnTrait for Column {
             Self::Sender => ColumnType::VarBinary(StringLen::None).def(),
             Self::Recipient => ColumnType::VarBinary(StringLen::None).def(),
             Self::OriginMailbox => ColumnType::VarBinary(StringLen::None).def(),
-            Self::MsgBody => ColumnType::VarBinary(StringLen::None).def(),
+            Self::MsgBody => ColumnType::VarBinary(StringLen::None).def().null(),
         }
     }
 }

--- a/rust/main/agents/scraper/src/db/generated/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/generated/raw_message_dispatch.rs
@@ -26,6 +26,7 @@ pub struct Model {
     pub sender: Vec<u8>,
     pub recipient: Vec<u8>,
     pub origin_mailbox: Vec<u8>,
+    pub msg_body: Option<Vec<u8>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -43,6 +44,7 @@ pub enum Column {
     Sender,
     Recipient,
     OriginMailbox,
+    MsgBody,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -80,6 +82,7 @@ impl ColumnTrait for Column {
             Self::Sender => ColumnType::VarBinary(StringLen::None).def(),
             Self::Recipient => ColumnType::VarBinary(StringLen::None).def(),
             Self::OriginMailbox => ColumnType::VarBinary(StringLen::None).def(),
+            Self::MsgBody => ColumnType::VarBinary(StringLen::None).def(),
         }
     }
 }

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -26,6 +26,7 @@ pub struct StorableRawMessageDispatch<'a> {
 
 #[derive(Debug, Clone)]
 pub struct RawDispatchForEnrichment {
+    pub raw_id: i64,
     pub msg_id: H256,
     pub msg: HyperlaneMessage,
     pub meta: LogMeta,
@@ -178,6 +179,7 @@ impl ScraperDb {
         &self,
         origin_domain: u32,
         origin_mailbox: &H256,
+        after_id: i64,
         limit: u64,
     ) -> Result<Vec<RawDispatchForEnrichment>> {
         let origin_mailbox = address_to_bytes(origin_mailbox);
@@ -195,12 +197,14 @@ impl ScraperDb {
                   AND raw_message_dispatch.origin_mailbox = $2
                   AND raw_message_dispatch.msg_body IS NOT NULL
                   AND "message".id IS NULL
-                ORDER BY raw_message_dispatch.nonce ASC
-                LIMIT $3
+                  AND raw_message_dispatch.id > $3
+                ORDER BY raw_message_dispatch.id ASC
+                LIMIT $4
                 "#,
                 [
                     (origin_domain as i32).into(),
                     origin_mailbox.into(),
+                    after_id.into(),
                     (limit as i64).into(),
                 ],
             ))
@@ -235,6 +239,7 @@ fn raw_dispatch_to_candidate(raw: raw_message_dispatch::Model) -> Result<RawDisp
     let origin_mailbox = bytes_to_address(raw.origin_mailbox)?;
 
     Ok(RawDispatchForEnrichment {
+        raw_id: raw.id,
         msg_id: H256::from_slice(&raw.msg_id),
         msg: HyperlaneMessage {
             version: 3,
@@ -268,11 +273,12 @@ mod tests {
     use time::PrimitiveDateTime;
 
     use hyperlane_core::{
-        address_to_bytes, h256_to_bytes, h512_to_bytes, HyperlaneMessage, LogMeta, H256, H512, U256,
+        address_to_bytes, h256_to_bytes, h512_to_bytes, BlockInfo, HyperlaneMessage, LogMeta,
+        TxnInfo, TxnReceiptInfo, H256, H512, U256,
     };
 
     use crate::db::generated::raw_message_dispatch;
-    use crate::db::ScraperDb;
+    use crate::db::{ScraperDb, StorableMessage, StorableTxn};
 
     use super::{raw_dispatch_to_candidate, StorableRawMessageDispatch};
 
@@ -406,6 +412,7 @@ mod tests {
         let storable = candidate.storable_message(7);
 
         assert_eq!(candidate.msg_id, msg_id);
+        assert_eq!(candidate.raw_id, 1);
         assert_eq!(candidate.msg, msg);
         assert_eq!(candidate.meta.address, mailbox);
         assert_eq!(candidate.meta.block_number, 100);
@@ -664,7 +671,87 @@ mod tests {
             .expect("Last message should exist");
         assert_eq!(last_result.nonce, (MESSAGE_COUNT - 1) as i32);
 
-        // Test 4: Duplicate handling (same message ID should update, not fail)
+        // Test 4: raw dispatches with matching message rows are excluded from
+        // the reconciliation candidate query.
+        scraper_db
+            .store_blocks(
+                1,
+                [BlockInfo {
+                    hash: metas[1].block_hash,
+                    timestamp: 1,
+                    number: metas[1].block_number,
+                }]
+                .into_iter(),
+            )
+            .await?;
+        let block = scraper_db
+            .get_block_basic([&metas[1].block_hash].into_iter())
+            .await?
+            .pop()
+            .expect("block should exist");
+        scraper_db
+            .store_txns(
+                [StorableTxn {
+                    info: TxnInfo {
+                        hash: metas[1].transaction_id,
+                        gas_limit: U256::one(),
+                        max_priority_fee_per_gas: None,
+                        max_fee_per_gas: None,
+                        gas_price: None,
+                        nonce: 1,
+                        sender: H256::from_low_u64_be(1),
+                        recipient: Some(H256::from_low_u64_be(2)),
+                        receipt: Some(TxnReceiptInfo {
+                            gas_used: U256::one(),
+                            cumulative_gas_used: U256::one(),
+                            effective_gas_price: None,
+                        }),
+                        raw_input_data: None,
+                    },
+                    block_id: block.id,
+                }]
+                .into_iter(),
+            )
+            .await?;
+        let txn_id = scraper_db
+            .get_txn_ids([&metas[1].transaction_id].into_iter())
+            .await?
+            .get(&metas[1].transaction_id)
+            .copied()
+            .expect("txn should exist");
+        scraper_db
+            .store_dispatched_messages(
+                1,
+                &H256::from_low_u64_be(999),
+                [StorableMessage {
+                    msg: messages[1].clone(),
+                    meta: &metas[1],
+                    txn_id,
+                    id_override: None,
+                }]
+                .into_iter(),
+            )
+            .await?;
+
+        let candidates = scraper_db
+            .retrieve_unenriched_raw_dispatches(1, &H256::from_low_u64_be(999), 0, 100)
+            .await?;
+        assert_eq!(candidates.len(), MESSAGE_COUNT - 1);
+        assert!(candidates.iter().any(|candidate| candidate.msg.nonce == 0));
+        assert!(candidates.iter().all(|candidate| candidate.msg.nonce != 1));
+
+        let paged_candidates = scraper_db
+            .retrieve_unenriched_raw_dispatches(
+                1,
+                &H256::from_low_u64_be(999),
+                candidates[0].raw_id,
+                1,
+            )
+            .await?;
+        assert_eq!(paged_candidates.len(), 1);
+        assert!(paged_candidates[0].raw_id > candidates[0].raw_id);
+
+        // Test 5: Duplicate handling (same message ID should update, not fail)
         let storables_dup: Vec<StorableRawMessageDispatch> = messages
             .iter()
             .take(10)

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -27,6 +27,7 @@ pub struct StorableRawMessageDispatch<'a> {
 #[derive(Debug, Clone)]
 pub struct RawDispatchForEnrichment {
     pub raw_id: i64,
+    pub time_created: TimeDateTime,
     pub msg_id: H256,
     pub msg: HyperlaneMessage,
     pub meta: LogMeta,
@@ -240,6 +241,7 @@ fn raw_dispatch_to_candidate(raw: raw_message_dispatch::Model) -> Result<RawDisp
 
     Ok(RawDispatchForEnrichment {
         raw_id: raw.id,
+        time_created: raw.time_created,
         msg_id: H256::from_slice(&raw.msg_id),
         msg: HyperlaneMessage {
             version: 3,

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -1,17 +1,20 @@
 use eyre::Result;
 use itertools::Itertools;
-use sea_orm::{prelude::*, ActiveValue::*, Insert, QuerySelect, TransactionTrait};
+use sea_orm::{
+    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, Statement, TransactionTrait,
+};
 use tracing::{debug, instrument, trace};
 
 use hyperlane_core::{
-    address_to_bytes, h256_to_bytes, h512_to_bytes, HyperlaneMessage, LogMeta, H256,
+    address_to_bytes, bytes_to_address, bytes_to_h512, h256_to_bytes, h512_to_bytes,
+    HyperlaneMessage, LogMeta, H256, U256,
 };
 use migration::OnConflict;
 
 use crate::date_time;
 use crate::db::ScraperDb;
 
-use super::generated::raw_message_dispatch;
+use super::{generated::raw_message_dispatch, StorableMessage};
 
 /// Struct representing a raw message dispatch that can be stored in the database.
 /// This contains all data available from the dispatch event log without requiring RPC calls.
@@ -21,14 +24,32 @@ pub struct StorableRawMessageDispatch<'a> {
     pub meta: &'a LogMeta,
 }
 
+#[derive(Debug, Clone)]
+pub struct RawDispatchForEnrichment {
+    pub msg_id: H256,
+    pub msg: HyperlaneMessage,
+    pub meta: LogMeta,
+}
+
+impl RawDispatchForEnrichment {
+    pub fn storable_message(&self, txn_id: i64) -> StorableMessage<'_> {
+        StorableMessage {
+            msg: self.msg.clone(),
+            meta: &self.meta,
+            txn_id,
+            id_override: Some(self.msg_id),
+        }
+    }
+}
+
 impl ScraperDb {
     /// Used for store_raw_message_dispatches().
-    /// raw_message_dispatch::ActiveModel has 12 fields, on conflict has 1 column,
-    /// update has 7 columns. So there should be about a maximum of 20 sql
+    /// raw_message_dispatch::ActiveModel has 13 fields, on conflict has 1 column,
+    /// update has 8 columns. So there should be about a maximum of 22 sql
     /// parameters per ActiveModel.
     /// u16::MAX (65_535u16) is the maximum amount of parameters we can
-    /// have for Postgres. So 65000 / 20 = 3250
-    const STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE: usize = 3250;
+    /// have for Postgres. So 65000 / 22 = 2954
+    const STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE: usize = 2954;
 
     /// Get the latest raw message dispatch ID for a specific domain and mailbox.
     async fn latest_raw_dispatch_id(
@@ -96,6 +117,7 @@ impl ScraperDb {
                 sender: Set(address_to_bytes(&storable.msg.sender)),
                 recipient: Set(address_to_bytes(&storable.msg.recipient)),
                 origin_mailbox: Unchanged(origin_mailbox.clone()),
+                msg_body: Set(Some(storable.msg.body.clone())),
             })
             .collect_vec();
 
@@ -128,6 +150,7 @@ impl ScraperDb {
                                         raw_message_dispatch::Column::DestinationDomain,
                                         raw_message_dispatch::Column::Sender,
                                         raw_message_dispatch::Column::Recipient,
+                                        raw_message_dispatch::Column::MsgBody,
                                     ])
                                     .to_owned(),
                             )
@@ -150,6 +173,46 @@ impl ScraperDb {
         Ok(new_dispatch_count)
     }
 
+    #[instrument(skip(self))]
+    pub async fn retrieve_unenriched_raw_dispatches(
+        &self,
+        origin_domain: u32,
+        origin_mailbox: &H256,
+        limit: u64,
+    ) -> Result<Vec<RawDispatchForEnrichment>> {
+        let origin_mailbox = address_to_bytes(origin_mailbox);
+        let raw_dispatches = raw_message_dispatch::Entity::find()
+            .from_raw_sql(Statement::from_sql_and_values(
+                self.0.get_database_backend(),
+                r#"
+                SELECT raw_message_dispatch.*
+                FROM raw_message_dispatch
+                LEFT JOIN "message"
+                  ON "message".origin = raw_message_dispatch.origin_domain
+                 AND "message".origin_mailbox = raw_message_dispatch.origin_mailbox
+                 AND "message".nonce = raw_message_dispatch.nonce
+                WHERE raw_message_dispatch.origin_domain = $1
+                  AND raw_message_dispatch.origin_mailbox = $2
+                  AND raw_message_dispatch.msg_body IS NOT NULL
+                  AND "message".id IS NULL
+                ORDER BY raw_message_dispatch.nonce ASC
+                LIMIT $3
+                "#,
+                [
+                    (origin_domain as i32).into(),
+                    origin_mailbox.into(),
+                    (limit as i64).into(),
+                ],
+            ))
+            .all(&self.0)
+            .await?;
+
+        raw_dispatches
+            .into_iter()
+            .map(raw_dispatch_to_candidate)
+            .collect()
+    }
+
     /// Get the raw message dispatch by message ID.
     #[instrument(skip(self))]
     #[cfg(test)]
@@ -163,6 +226,34 @@ impl ScraperDb {
             .one(&self.0)
             .await?)
     }
+}
+
+fn raw_dispatch_to_candidate(raw: raw_message_dispatch::Model) -> Result<RawDispatchForEnrichment> {
+    let body = raw
+        .msg_body
+        .ok_or_else(|| eyre::eyre!("raw message dispatch missing msg_body"))?;
+    let origin_mailbox = bytes_to_address(raw.origin_mailbox)?;
+
+    Ok(RawDispatchForEnrichment {
+        msg_id: H256::from_slice(&raw.msg_id),
+        msg: HyperlaneMessage {
+            version: 3,
+            nonce: raw.nonce as u32,
+            origin: raw.origin_domain as u32,
+            destination: raw.destination_domain as u32,
+            sender: bytes_to_address(raw.sender)?,
+            recipient: bytes_to_address(raw.recipient)?,
+            body,
+        },
+        meta: LogMeta {
+            address: origin_mailbox,
+            block_number: raw.origin_block_height as u64,
+            block_hash: H256::from_slice(&raw.origin_block_hash),
+            transaction_id: bytes_to_h512(&raw.origin_tx_hash),
+            transaction_index: 0,
+            log_index: U256::zero(),
+        },
+    })
 }
 
 #[cfg(test)]
@@ -183,7 +274,7 @@ mod tests {
     use crate::db::generated::raw_message_dispatch;
     use crate::db::ScraperDb;
 
-    use super::StorableRawMessageDispatch;
+    use super::{raw_dispatch_to_candidate, StorableRawMessageDispatch};
 
     /// Helper to create a test message with specific values
     fn create_test_message(nonce: u32, origin: u32, destination: u32) -> HyperlaneMessage {
@@ -283,7 +374,45 @@ mod tests {
             sender: vec![0u8; 32],
             recipient: vec![0u8; 32],
             origin_mailbox: vec![0u8; 32],
+            msg_body: Some(vec![1, 2, 3, 4]),
         }
+    }
+
+    #[test]
+    fn test_raw_dispatch_to_candidate_preserves_body_and_msg_id() {
+        let msg = create_test_message(42, 1, 2);
+        let msg_id = msg.id();
+        let tx_hash = H512::from_low_u64_be(5);
+        let block_hash = H256::from_low_u64_be(100);
+        let mailbox = H256::from_low_u64_be(999);
+        let raw = raw_message_dispatch::Model {
+            id: 1,
+            time_created: PrimitiveDateTime::new(date!(2024 - 01 - 01), time!(0:00)),
+            time_updated: PrimitiveDateTime::new(date!(2024 - 01 - 01), time!(0:00)),
+            msg_id: h256_to_bytes(&msg_id),
+            origin_tx_hash: h512_to_bytes(&tx_hash),
+            origin_block_hash: h256_to_bytes(&block_hash),
+            origin_block_height: 100,
+            nonce: msg.nonce as i32,
+            origin_domain: msg.origin as i32,
+            destination_domain: msg.destination as i32,
+            sender: address_to_bytes(&msg.sender),
+            recipient: address_to_bytes(&msg.recipient),
+            origin_mailbox: address_to_bytes(&mailbox),
+            msg_body: Some(msg.body.clone()),
+        };
+
+        let candidate = raw_dispatch_to_candidate(raw).unwrap();
+        let storable = candidate.storable_message(7);
+
+        assert_eq!(candidate.msg_id, msg_id);
+        assert_eq!(candidate.msg, msg);
+        assert_eq!(candidate.meta.address, mailbox);
+        assert_eq!(candidate.meta.block_number, 100);
+        assert_eq!(candidate.meta.block_hash, block_hash);
+        assert_eq!(candidate.meta.transaction_id, tx_hash);
+        assert_eq!(storable.id_override, Some(msg_id));
+        assert_eq!(storable.txn_id, 7);
     }
 
     #[tokio::test]
@@ -411,6 +540,7 @@ mod tests {
             sender: address_to_bytes(&msg.sender),
             recipient: address_to_bytes(&msg.recipient),
             origin_mailbox: vec![0u8; 32],
+            msg_body: Some(msg.body.clone()),
         };
 
         let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -682,6 +812,7 @@ mod tests {
             sender: address_to_bytes(&msg.sender),
             recipient: address_to_bytes(&msg.recipient),
             origin_mailbox: vec![0u8; 32],
+            msg_body: Some(msg.body.clone()),
         };
 
         let mock_db = MockDatabase::new(DatabaseBackend::Postgres)

--- a/rust/main/agents/scraper/src/store.rs
+++ b/rust/main/agents/scraper/src/store.rs
@@ -2,6 +2,7 @@ pub use storage::HyperlaneDbStore;
 
 mod deliveries;
 mod dispatches;
+pub(crate) use dispatches::RawDispatchRetryBackoff;
 mod payments;
 mod same_chain_ccr_swaps;
 mod storage;

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -14,6 +14,13 @@ use crate::store::storage::{HyperlaneDbStore, TxnWithId};
 /// Label for raw message dispatch metrics
 const RAW_MESSAGE_DISPATCH_LABEL: &str = "raw_message_dispatch";
 
+#[derive(Debug, Default)]
+pub(crate) struct RawDispatchReconciliationResult {
+    pub candidate_count: usize,
+    pub stored_count: u32,
+    pub next_after_id: i64,
+}
+
 #[async_trait]
 impl HyperlaneLogStore<HyperlaneMessage> for HyperlaneDbStore {
     /// Store dispatched messages from the origin mailbox into the database.
@@ -92,14 +99,31 @@ impl HyperlaneDbStore {
         Ok(stored as u32)
     }
 
-    pub(crate) async fn reconcile_raw_message_dispatches(&self, limit: u64) -> Result<u32> {
+    pub(crate) async fn reconcile_raw_message_dispatches(
+        &self,
+        after_id: i64,
+        limit: u64,
+    ) -> Result<RawDispatchReconciliationResult> {
         let raw_dispatches = self
             .db
-            .retrieve_unenriched_raw_dispatches(self.domain.id(), &self.mailbox_address, limit)
+            .retrieve_unenriched_raw_dispatches(
+                self.domain.id(),
+                &self.mailbox_address,
+                after_id,
+                limit,
+            )
             .await?;
         if raw_dispatches.is_empty() {
-            return Ok(0);
+            return Ok(RawDispatchReconciliationResult {
+                next_after_id: after_id,
+                ..Default::default()
+            });
         }
+        let next_after_id = raw_dispatches
+            .iter()
+            .map(|raw_dispatch| raw_dispatch.raw_id)
+            .max()
+            .unwrap_or(after_id);
 
         let txns: HashMap<H512, TxnWithId> = self
             .ensure_blocks_and_txns(raw_dispatches.iter().map(|r| &r.meta))
@@ -142,7 +166,11 @@ impl HyperlaneDbStore {
             );
         }
 
-        Ok(stored as u32)
+        Ok(RawDispatchReconciliationResult {
+            candidate_count: raw_dispatches.len(),
+            stored_count: stored as u32,
+            next_after_id,
+        })
     }
 }
 

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -6,6 +6,7 @@ use hyperlane_core::{
     unwrap_or_none_result, HyperlaneLogStore, HyperlaneMessage,
     HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
 };
+use time::OffsetDateTime;
 use tracing::warn;
 
 use crate::db::{StorableMessage, StorableRawMessageDispatch};
@@ -13,12 +14,56 @@ use crate::store::storage::{HyperlaneDbStore, TxnWithId};
 
 /// Label for raw message dispatch metrics
 const RAW_MESSAGE_DISPATCH_LABEL: &str = "raw_message_dispatch";
+const RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS: i64 = 60;
+const RAW_DISPATCH_RETRY_MAX_BACKOFF_SECONDS: i64 = 15 * 60;
 
 #[derive(Debug, Default)]
 pub(crate) struct RawDispatchReconciliationResult {
     pub candidate_count: usize,
+    pub attempted_count: usize,
+    pub skipped_backoff_count: usize,
     pub stored_count: u32,
     pub next_after_id: i64,
+    pub max_unenriched_age_seconds: u64,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RawDispatchRetryBackoff {
+    rows: HashMap<i64, RawDispatchRetry>,
+}
+
+#[derive(Debug)]
+struct RawDispatchRetry {
+    attempts: u32,
+    next_retry_at: OffsetDateTime,
+}
+
+impl RawDispatchRetryBackoff {
+    fn should_attempt(&self, raw_id: i64, now: OffsetDateTime) -> bool {
+        match self.rows.get(&raw_id) {
+            Some(retry) => retry.next_retry_at <= now,
+            None => true,
+        }
+    }
+
+    fn record_missing(&mut self, raw_id: i64, now: OffsetDateTime) -> u32 {
+        let retry = self.rows.entry(raw_id).or_insert(RawDispatchRetry {
+            attempts: 0,
+            next_retry_at: now,
+        });
+        retry.attempts = retry.attempts.saturating_add(1);
+
+        let multiplier = 2_i64.pow(retry.attempts.saturating_sub(1).min(4));
+        let backoff_seconds = RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS
+            .saturating_mul(multiplier)
+            .min(RAW_DISPATCH_RETRY_MAX_BACKOFF_SECONDS);
+        retry.next_retry_at = offset_by_seconds(now, backoff_seconds);
+        retry.attempts
+    }
+
+    fn record_success(&mut self, raw_id: i64) {
+        self.rows.remove(&raw_id);
+    }
 }
 
 #[async_trait]
@@ -103,6 +148,7 @@ impl HyperlaneDbStore {
         &self,
         after_id: i64,
         limit: u64,
+        retry_backoff: &mut RawDispatchRetryBackoff,
     ) -> Result<RawDispatchReconciliationResult> {
         let raw_dispatches = self
             .db
@@ -113,9 +159,16 @@ impl HyperlaneDbStore {
                 limit,
             )
             .await?;
+        let now = OffsetDateTime::now_utc();
+        let max_unenriched_age_seconds = raw_dispatches
+            .iter()
+            .map(|raw_dispatch| raw_dispatch_age_seconds(raw_dispatch.time_created, now))
+            .max()
+            .unwrap_or_default();
         if raw_dispatches.is_empty() {
             return Ok(RawDispatchReconciliationResult {
                 next_after_id: after_id,
+                max_unenriched_age_seconds,
                 ..Default::default()
             });
         }
@@ -124,24 +177,52 @@ impl HyperlaneDbStore {
             .map(|raw_dispatch| raw_dispatch.raw_id)
             .max()
             .unwrap_or(after_id);
+        let skipped_backoff_count = raw_dispatches
+            .iter()
+            .filter(|raw_dispatch| !retry_backoff.should_attempt(raw_dispatch.raw_id, now))
+            .count();
+        let raw_dispatches_to_attempt = raw_dispatches
+            .iter()
+            .filter(|raw_dispatch| retry_backoff.should_attempt(raw_dispatch.raw_id, now))
+            .collect::<Vec<_>>();
+
+        if raw_dispatches_to_attempt.is_empty() {
+            return Ok(RawDispatchReconciliationResult {
+                candidate_count: raw_dispatches.len(),
+                skipped_backoff_count,
+                next_after_id,
+                max_unenriched_age_seconds,
+                ..Default::default()
+            });
+        }
 
         let txns: HashMap<H512, TxnWithId> = self
-            .ensure_blocks_and_txns(raw_dispatches.iter().map(|r| &r.meta))
+            .ensure_blocks_and_txns(raw_dispatches_to_attempt.iter().map(|r| &r.meta))
             .await?
             .map(|t| (t.hash, t))
             .collect();
 
         let mut missing_tx_hashes = Vec::new();
         let mut unique_missing_tx_hashes = HashSet::new();
-        let storable = raw_dispatches
+        let mut stored_raw_ids = Vec::new();
+        let storable = raw_dispatches_to_attempt
             .iter()
             .filter_map(
                 |raw_dispatch| match txns.get(&raw_dispatch.meta.transaction_id) {
-                    Some(txn) => Some(raw_dispatch.storable_message(txn.id)),
+                    Some(txn) => {
+                        stored_raw_ids.push(raw_dispatch.raw_id);
+                        Some(raw_dispatch.storable_message(txn.id))
+                    }
                     None => {
+                        let attempts = retry_backoff.record_missing(raw_dispatch.raw_id, now);
                         if unique_missing_tx_hashes.insert(raw_dispatch.meta.transaction_id) {
                             missing_tx_hashes.push(raw_dispatch.meta.transaction_id);
                         }
+                        warn!(
+                            raw_id = raw_dispatch.raw_id,
+                            attempts,
+                            "Raw message dispatch transaction remains unavailable; backing off reconciliation"
+                        );
                         None
                     }
                 },
@@ -156,10 +237,15 @@ impl HyperlaneDbStore {
                 storable.into_iter(),
             )
             .await?;
+        for raw_id in stored_raw_ids {
+            retry_backoff.record_success(raw_id);
+        }
 
         if !missing_tx_hashes.is_empty() {
             warn!(
                 candidate_count = raw_dispatches.len(),
+                attempted = raw_dispatches_to_attempt.len(),
+                skipped_backoff = skipped_backoff_count,
                 stored,
                 missing_tx_hashes = ?missing_tx_hashes,
                 "Raw message dispatch reconciliation skipped rows whose transactions are not enriched yet"
@@ -168,10 +254,27 @@ impl HyperlaneDbStore {
 
         Ok(RawDispatchReconciliationResult {
             candidate_count: raw_dispatches.len(),
+            attempted_count: raw_dispatches_to_attempt.len(),
+            skipped_backoff_count,
             stored_count: stored as u32,
             next_after_id,
+            max_unenriched_age_seconds,
         })
     }
+}
+
+fn raw_dispatch_age_seconds(
+    time_created: sea_orm::prelude::TimeDateTime,
+    now: OffsetDateTime,
+) -> u64 {
+    now.unix_timestamp()
+        .saturating_sub(time_created.assume_utc().unix_timestamp())
+        .max(0) as u64
+}
+
+fn offset_by_seconds(now: OffsetDateTime, seconds: i64) -> OffsetDateTime {
+    now.checked_add(time::Duration::seconds(seconds))
+        .unwrap_or(now)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -349,5 +452,40 @@ mod tests {
 
         assert!(storable.is_empty());
         assert!(missing_txns.is_none());
+    }
+
+    #[test]
+    fn raw_dispatch_retry_backoff_delays_repeated_attempts() {
+        let now = OffsetDateTime::now_utc();
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        assert!(backoff.should_attempt(raw_id, now));
+        assert_eq!(backoff.record_missing(raw_id, now), 1);
+        assert!(!backoff.should_attempt(raw_id, now));
+        assert!(!backoff.should_attempt(
+            raw_id,
+            offset_by_seconds(
+                now,
+                RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS.saturating_sub(1)
+            )
+        ));
+        assert!(backoff.should_attempt(
+            raw_id,
+            offset_by_seconds(now, RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS)
+        ));
+    }
+
+    #[test]
+    fn raw_dispatch_retry_backoff_clears_after_success() {
+        let now = OffsetDateTime::now_utc();
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.record_missing(raw_id, now);
+        assert!(!backoff.should_attempt(raw_id, now));
+
+        backoff.record_success(raw_id);
+        assert!(backoff.should_attempt(raw_id, now));
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -75,24 +75,53 @@ impl HyperlaneDbStore {
             .await?
             .map(|t| (t.hash, t))
             .collect();
-        let storable = messages
-            .iter()
-            .filter_map(|(message, meta)| {
-                txns.get(&meta.transaction_id)
-                    .map(|t| (message.inner().clone(), meta, t.id))
-            })
-            .map(|(msg, meta, txn_id)| StorableMessage {
-                msg,
-                meta,
-                txn_id,
-                id_override: None,
-            });
+        let storable = storable_messages_for_txns(messages, &txns)?;
         let stored = self
             .db
-            .store_dispatched_messages(self.domain.id(), &self.mailbox_address, storable)
+            .store_dispatched_messages(
+                self.domain.id(),
+                &self.mailbox_address,
+                storable.into_iter(),
+            )
             .await?;
         Ok(stored as u32)
     }
+}
+
+fn storable_messages_for_txns<'a>(
+    messages: &'a [(Indexed<HyperlaneMessage>, LogMeta)],
+    txns: &HashMap<H512, TxnWithId>,
+) -> Result<Vec<StorableMessage<'a>>, Report> {
+    let mut missing_dispatch_tx_hashes = Vec::new();
+    let mut missing_tx_hashes = Vec::new();
+    let mut storable = Vec::with_capacity(messages.len());
+
+    for (message, meta) in messages {
+        let Some(txn) = txns.get(&meta.transaction_id) else {
+            missing_dispatch_tx_hashes.push(meta.transaction_id);
+            if !missing_tx_hashes.contains(&meta.transaction_id) {
+                missing_tx_hashes.push(meta.transaction_id);
+            }
+            continue;
+        };
+
+        storable.push(StorableMessage {
+            msg: message.inner().clone(),
+            meta,
+            txn_id: txn.id,
+            id_override: None,
+        });
+    }
+
+    if !missing_tx_hashes.is_empty() {
+        let missing_dispatches = missing_dispatch_tx_hashes.len();
+        eyre::bail!(
+            "failed to enrich {missing_dispatches} of {} message dispatches; missing transaction ids: {missing_tx_hashes:?}",
+            messages.len(),
+        );
+    }
+
+    Ok(storable)
 }
 
 #[async_trait]
@@ -115,5 +144,71 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneDbS
         );
         let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
         Ok(self.db.retrieve_block_number(block_id).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn indexed_message(nonce: u32) -> Indexed<HyperlaneMessage> {
+        Indexed::new(HyperlaneMessage {
+            nonce,
+            ..Default::default()
+        })
+    }
+
+    fn log_meta(transaction_id: H512) -> LogMeta {
+        LogMeta {
+            transaction_id,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn storable_messages_for_txns_allows_multiple_messages_per_txn() {
+        let txn_hash = H512::from_low_u64_be(1);
+        let messages = vec![
+            (indexed_message(0), log_meta(txn_hash)),
+            (indexed_message(1), log_meta(txn_hash)),
+        ];
+        let txns = HashMap::from([(
+            txn_hash,
+            TxnWithId {
+                hash: txn_hash,
+                id: 7,
+            },
+        )]);
+
+        let storable = storable_messages_for_txns(&messages, &txns)
+            .expect("all messages should have transaction ids");
+
+        assert_eq!(storable.len(), messages.len());
+        assert!(storable.iter().all(|message| message.txn_id == 7));
+    }
+
+    #[test]
+    fn storable_messages_for_txns_errors_on_missing_enrichment_txn() {
+        let found_txn_hash = H512::from_low_u64_be(1);
+        let missing_txn_hash = H512::from_low_u64_be(2);
+        let messages = vec![
+            (indexed_message(0), log_meta(found_txn_hash)),
+            (indexed_message(1), log_meta(missing_txn_hash)),
+            (indexed_message(2), log_meta(missing_txn_hash)),
+        ];
+        let txns = HashMap::from([(
+            found_txn_hash,
+            TxnWithId {
+                hash: found_txn_hash,
+                id: 7,
+            },
+        )]);
+
+        let err = storable_messages_for_txns(&messages, &txns)
+            .err()
+            .expect("expected missing transaction id error");
+
+        assert!(err.to_string().contains("failed to enrich 2 of 3"));
+        assert!(err.to_string().contains(&format!("{missing_txn_hash:?}")));
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use eyre::{Report, Result};
@@ -75,7 +75,7 @@ impl HyperlaneDbStore {
             .await?
             .map(|t| (t.hash, t))
             .collect();
-        let storable = storable_messages_for_txns(messages, &txns)?;
+        let (storable, missing_txns) = storable_message_prefix_for_txns(messages, &txns);
         let stored = self
             .db
             .store_dispatched_messages(
@@ -84,26 +84,49 @@ impl HyperlaneDbStore {
                 storable.into_iter(),
             )
             .await?;
+
+        if let Some(missing_txns) = missing_txns {
+            eyre::bail!(
+                "stored {stored} contiguous enriched message dispatches before first missing transaction; failed to enrich {} of {} message dispatches; missing transaction ids: {:?}",
+                missing_txns.missing_dispatches,
+                messages.len(),
+                missing_txns.missing_tx_hashes,
+            );
+        }
+
         Ok(stored as u32)
     }
 }
 
-fn storable_messages_for_txns<'a>(
+#[derive(Debug, PartialEq, Eq)]
+struct MissingDispatchTxns {
+    missing_dispatches: usize,
+    missing_tx_hashes: Vec<H512>,
+}
+
+fn storable_message_prefix_for_txns<'a>(
     messages: &'a [(Indexed<HyperlaneMessage>, LogMeta)],
     txns: &HashMap<H512, TxnWithId>,
-) -> Result<Vec<StorableMessage<'a>>, Report> {
-    let mut missing_dispatch_tx_hashes = Vec::new();
+) -> (Vec<StorableMessage<'a>>, Option<MissingDispatchTxns>) {
+    let mut missing_dispatches: usize = 0;
     let mut missing_tx_hashes = Vec::new();
+    let mut unique_missing_tx_hashes = HashSet::new();
     let mut storable = Vec::with_capacity(messages.len());
+    let mut found_first_gap = false;
 
     for (message, meta) in messages {
         let Some(txn) = txns.get(&meta.transaction_id) else {
-            missing_dispatch_tx_hashes.push(meta.transaction_id);
-            if !missing_tx_hashes.contains(&meta.transaction_id) {
+            found_first_gap = true;
+            missing_dispatches = missing_dispatches.saturating_add(1);
+            if unique_missing_tx_hashes.insert(meta.transaction_id) {
                 missing_tx_hashes.push(meta.transaction_id);
             }
             continue;
         };
+
+        if found_first_gap {
+            continue;
+        }
 
         storable.push(StorableMessage {
             msg: message.inner().clone(),
@@ -113,15 +136,11 @@ fn storable_messages_for_txns<'a>(
         });
     }
 
-    if !missing_tx_hashes.is_empty() {
-        let missing_dispatches = missing_dispatch_tx_hashes.len();
-        eyre::bail!(
-            "failed to enrich {missing_dispatches} of {} message dispatches; missing transaction ids: {missing_tx_hashes:?}",
-            messages.len(),
-        );
-    }
-
-    Ok(storable)
+    let missing_txns = (missing_dispatches > 0).then_some(MissingDispatchTxns {
+        missing_dispatches,
+        missing_tx_hashes,
+    });
+    (storable, missing_txns)
 }
 
 #[async_trait]
@@ -166,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    fn storable_messages_for_txns_allows_multiple_messages_per_txn() {
+    fn storable_message_prefix_for_txns_allows_multiple_messages_per_txn() {
         let txn_hash = H512::from_low_u64_be(1);
         let messages = vec![
             (indexed_message(0), log_meta(txn_hash)),
@@ -180,35 +199,83 @@ mod tests {
             },
         )]);
 
-        let storable = storable_messages_for_txns(&messages, &txns)
-            .expect("all messages should have transaction ids");
+        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
 
+        assert!(missing_txns.is_none());
         assert_eq!(storable.len(), messages.len());
         assert!(storable.iter().all(|message| message.txn_id == 7));
     }
 
     #[test]
-    fn storable_messages_for_txns_errors_on_missing_enrichment_txn() {
+    fn storable_message_prefix_for_txns_stores_prefix_before_first_missing_txn() {
         let found_txn_hash = H512::from_low_u64_be(1);
         let missing_txn_hash = H512::from_low_u64_be(2);
+        let later_found_txn_hash = H512::from_low_u64_be(3);
         let messages = vec![
             (indexed_message(0), log_meta(found_txn_hash)),
             (indexed_message(1), log_meta(missing_txn_hash)),
-            (indexed_message(2), log_meta(missing_txn_hash)),
+            (indexed_message(2), log_meta(later_found_txn_hash)),
         ];
-        let txns = HashMap::from([(
-            found_txn_hash,
-            TxnWithId {
-                hash: found_txn_hash,
-                id: 7,
-            },
-        )]);
+        let txns = HashMap::from([
+            (
+                found_txn_hash,
+                TxnWithId {
+                    hash: found_txn_hash,
+                    id: 7,
+                },
+            ),
+            (
+                later_found_txn_hash,
+                TxnWithId {
+                    hash: later_found_txn_hash,
+                    id: 8,
+                },
+            ),
+        ]);
 
-        let err = storable_messages_for_txns(&messages, &txns)
-            .err()
-            .expect("expected missing transaction id error");
+        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
 
-        assert!(err.to_string().contains("failed to enrich 2 of 3"));
-        assert!(err.to_string().contains(&format!("{missing_txn_hash:?}")));
+        assert_eq!(storable.len(), 1);
+        assert_eq!(storable[0].msg.nonce, 0);
+        assert_eq!(storable[0].txn_id, 7);
+        assert_eq!(
+            missing_txns,
+            Some(MissingDispatchTxns {
+                missing_dispatches: 1,
+                missing_tx_hashes: vec![missing_txn_hash],
+            })
+        );
+    }
+
+    #[test]
+    fn storable_message_prefix_for_txns_all_missing_returns_empty_prefix() {
+        let missing_txn_hash = H512::from_low_u64_be(2);
+        let messages = vec![
+            (indexed_message(0), log_meta(missing_txn_hash)),
+            (indexed_message(1), log_meta(missing_txn_hash)),
+        ];
+        let txns = HashMap::new();
+
+        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
+
+        assert!(storable.is_empty());
+        assert_eq!(
+            missing_txns,
+            Some(MissingDispatchTxns {
+                missing_dispatches: 2,
+                missing_tx_hashes: vec![missing_txn_hash],
+            })
+        );
+    }
+
+    #[test]
+    fn storable_message_prefix_for_txns_empty_input_returns_empty_prefix() {
+        let messages = vec![];
+        let txns = HashMap::new();
+
+        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
+
+        assert!(storable.is_empty());
+        assert!(missing_txns.is_none());
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
-use eyre::{Report, Result};
+use eyre::Result;
 use hyperlane_core::{
     unwrap_or_none_result, HyperlaneLogStore, HyperlaneMessage,
     HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
@@ -26,7 +26,7 @@ impl HyperlaneLogStore<HyperlaneMessage> for HyperlaneDbStore {
 
         // STEP 1: Store a raw message dispatches FIRST (zero RPC dependencies)
         // This ensures Offchain Lookup Server can query transaction hashes even if RPC providers fail
-        self.store_raw_message_dispatches(messages).await;
+        self.store_raw_message_dispatches(messages).await?;
 
         // STEP 2: Store full messages (requires RPC calls for block/transaction data)
         // If RPC fails here, raw messages are already stored and Offchain Lookup Server can still
@@ -39,7 +39,7 @@ impl HyperlaneDbStore {
     async fn store_raw_message_dispatches(
         &self,
         messages: &[(Indexed<HyperlaneMessage>, LogMeta)],
-    ) {
+    ) -> Result<()> {
         let raw_messages = messages
             .iter()
             .map(|(message, meta)| StorableRawMessageDispatch {
@@ -49,14 +49,7 @@ impl HyperlaneDbStore {
         let raw_stored = self
             .db
             .store_raw_message_dispatches(self.domain.id(), &self.mailbox_address, raw_messages)
-            .await
-            .unwrap_or_else(|e| {
-                warn!(
-                    ?e,
-                    "Failed to store raw message dispatches, continuing with enriched storage"
-                );
-                0
-            });
+            .await?;
 
         // Track raw message dispatches in metrics for E2E verification
         if let Some(metric) = self.stored_events_metric() {
@@ -64,18 +57,19 @@ impl HyperlaneDbStore {
                 .with_label_values(&[RAW_MESSAGE_DISPATCH_LABEL, self.domain.name()])
                 .inc_by(raw_stored);
         }
+        Ok(())
     }
 
-    async fn store_enriched_message_dispatches(
+    pub(crate) async fn store_enriched_message_dispatches(
         &self,
         messages: &[(Indexed<HyperlaneMessage>, LogMeta)],
-    ) -> Result<u32, Report> {
+    ) -> Result<u32> {
         let txns: HashMap<H512, TxnWithId> = self
             .ensure_blocks_and_txns(messages.iter().map(|r| &r.1))
             .await?
             .map(|t| (t.hash, t))
             .collect();
-        let (storable, missing_txns) = storable_message_prefix_for_txns(messages, &txns);
+        let (storable, missing_txns) = storable_messages_for_available_txns(messages, &txns);
         let stored = self
             .db
             .store_dispatched_messages(
@@ -86,11 +80,65 @@ impl HyperlaneDbStore {
             .await?;
 
         if let Some(missing_txns) = missing_txns {
-            eyre::bail!(
-                "stored {stored} contiguous enriched message dispatches before first missing transaction; failed to enrich {} of {} message dispatches; missing transaction ids: {:?}",
-                missing_txns.missing_dispatches,
-                messages.len(),
-                missing_txns.missing_tx_hashes,
+            warn!(
+                stored,
+                missing_dispatches = missing_txns.missing_dispatches,
+                total_dispatches = messages.len(),
+                missing_tx_hashes = ?missing_txns.missing_tx_hashes,
+                "Stored available enriched message dispatches; raw rows remain pending for reconciliation"
+            );
+        }
+
+        Ok(stored as u32)
+    }
+
+    pub(crate) async fn reconcile_raw_message_dispatches(&self, limit: u64) -> Result<u32> {
+        let raw_dispatches = self
+            .db
+            .retrieve_unenriched_raw_dispatches(self.domain.id(), &self.mailbox_address, limit)
+            .await?;
+        if raw_dispatches.is_empty() {
+            return Ok(0);
+        }
+
+        let txns: HashMap<H512, TxnWithId> = self
+            .ensure_blocks_and_txns(raw_dispatches.iter().map(|r| &r.meta))
+            .await?
+            .map(|t| (t.hash, t))
+            .collect();
+
+        let mut missing_tx_hashes = Vec::new();
+        let mut unique_missing_tx_hashes = HashSet::new();
+        let storable = raw_dispatches
+            .iter()
+            .filter_map(
+                |raw_dispatch| match txns.get(&raw_dispatch.meta.transaction_id) {
+                    Some(txn) => Some(raw_dispatch.storable_message(txn.id)),
+                    None => {
+                        if unique_missing_tx_hashes.insert(raw_dispatch.meta.transaction_id) {
+                            missing_tx_hashes.push(raw_dispatch.meta.transaction_id);
+                        }
+                        None
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
+
+        let stored = self
+            .db
+            .store_dispatched_messages(
+                self.domain.id(),
+                &self.mailbox_address,
+                storable.into_iter(),
+            )
+            .await?;
+
+        if !missing_tx_hashes.is_empty() {
+            warn!(
+                candidate_count = raw_dispatches.len(),
+                stored,
+                missing_tx_hashes = ?missing_tx_hashes,
+                "Raw message dispatch reconciliation skipped rows whose transactions are not enriched yet"
             );
         }
 
@@ -104,7 +152,7 @@ struct MissingDispatchTxns {
     missing_tx_hashes: Vec<H512>,
 }
 
-fn storable_message_prefix_for_txns<'a>(
+fn storable_messages_for_available_txns<'a>(
     messages: &'a [(Indexed<HyperlaneMessage>, LogMeta)],
     txns: &HashMap<H512, TxnWithId>,
 ) -> (Vec<StorableMessage<'a>>, Option<MissingDispatchTxns>) {
@@ -112,21 +160,15 @@ fn storable_message_prefix_for_txns<'a>(
     let mut missing_tx_hashes = Vec::new();
     let mut unique_missing_tx_hashes = HashSet::new();
     let mut storable = Vec::with_capacity(messages.len());
-    let mut found_first_gap = false;
 
     for (message, meta) in messages {
         let Some(txn) = txns.get(&meta.transaction_id) else {
-            found_first_gap = true;
             missing_dispatches = missing_dispatches.saturating_add(1);
             if unique_missing_tx_hashes.insert(meta.transaction_id) {
                 missing_tx_hashes.push(meta.transaction_id);
             }
             continue;
         };
-
-        if found_first_gap {
-            continue;
-        }
 
         storable.push(StorableMessage {
             msg: message.inner().clone(),
@@ -185,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn storable_message_prefix_for_txns_allows_multiple_messages_per_txn() {
+    fn storable_messages_for_available_txns_allows_multiple_messages_per_txn() {
         let txn_hash = H512::from_low_u64_be(1);
         let messages = vec![
             (indexed_message(0), log_meta(txn_hash)),
@@ -199,7 +241,7 @@ mod tests {
             },
         )]);
 
-        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
+        let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 
         assert!(missing_txns.is_none());
         assert_eq!(storable.len(), messages.len());
@@ -207,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn storable_message_prefix_for_txns_stores_prefix_before_first_missing_txn() {
+    fn storable_messages_for_available_txns_stores_later_rows_after_missing_txn() {
         let found_txn_hash = H512::from_low_u64_be(1);
         let missing_txn_hash = H512::from_low_u64_be(2);
         let later_found_txn_hash = H512::from_low_u64_be(3);
@@ -233,11 +275,13 @@ mod tests {
             ),
         ]);
 
-        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
+        let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 
-        assert_eq!(storable.len(), 1);
+        assert_eq!(storable.len(), 2);
         assert_eq!(storable[0].msg.nonce, 0);
         assert_eq!(storable[0].txn_id, 7);
+        assert_eq!(storable[1].msg.nonce, 2);
+        assert_eq!(storable[1].txn_id, 8);
         assert_eq!(
             missing_txns,
             Some(MissingDispatchTxns {
@@ -248,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn storable_message_prefix_for_txns_all_missing_returns_empty_prefix() {
+    fn storable_messages_for_available_txns_all_missing_returns_empty() {
         let missing_txn_hash = H512::from_low_u64_be(2);
         let messages = vec![
             (indexed_message(0), log_meta(missing_txn_hash)),
@@ -256,7 +300,7 @@ mod tests {
         ];
         let txns = HashMap::new();
 
-        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
+        let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 
         assert!(storable.is_empty());
         assert_eq!(
@@ -269,11 +313,11 @@ mod tests {
     }
 
     #[test]
-    fn storable_message_prefix_for_txns_empty_input_returns_empty_prefix() {
+    fn storable_messages_for_available_txns_empty_input_returns_empty() {
         let messages = vec![];
         let txns = HashMap::new();
 
-        let (storable, missing_txns) = storable_message_prefix_for_txns(&messages, &txns);
+        let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 
         assert!(storable.is_empty());
         assert!(missing_txns.is_none());

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -223,7 +223,14 @@ where
 
             let logs = {
                 let store = store.lock().await;
-                Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
+                match Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
+                {
+                    Ok(logs) => logs,
+                    Err(err) => {
+                        warn!(?err, ?tx_id, "Error storing logs in db");
+                        continue;
+                    }
+                }
             };
             let num_logs = logs.len() as u64;
             info!(
@@ -286,7 +293,19 @@ where
 
             let logs = {
                 let store = store.lock().await;
-                Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
+                match Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
+                {
+                    Ok(logs) => logs,
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            ?range,
+                            "Skipping cursor update because logs failed to store"
+                        );
+                        sleep(SLEEP_DURATION).await;
+                        continue;
+                    }
+                }
             };
             let logs_found = logs.len() as u64;
             info!(
@@ -323,18 +342,12 @@ where
         store: &S,
         logs: Vec<(Indexed<T>, LogMeta)>,
         stored_logs_metric: &GenericCounter<AtomicU64>,
-    ) -> Vec<(Indexed<T>, LogMeta)> {
+    ) -> Result<Vec<(Indexed<T>, LogMeta)>> {
         let deduped_logs = HashSet::<_>::from_iter(logs);
         let logs = Vec::from_iter(deduped_logs);
 
         // Store deliveries
-        let stored = match store.store_logs(&logs).await {
-            Ok(stored) => stored,
-            Err(err) => {
-                warn!(?err, "Error storing logs in db");
-                Default::default()
-            }
-        };
+        let stored = store.store_logs(&logs).await?;
         if stored > 0 {
             debug!(
                 domain = domain.name(),
@@ -345,7 +358,115 @@ where
         }
         // Report amount of deliveries stored into db
         stored_logs_metric.inc_by(stored as u64);
-        logs
+        Ok(logs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::RangeInclusive;
+
+    use async_trait::async_trait;
+    use prometheus::IntCounter;
+
+    use hyperlane_core::{
+        ChainCommunicationError, ChainResult, HyperlaneMessage, Indexer, KnownHyperlaneDomain,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct MockIndexer;
+
+    #[async_trait]
+    impl Indexer<HyperlaneMessage> for MockIndexer {
+        async fn fetch_logs_in_range(
+            &self,
+            _range: RangeInclusive<u32>,
+        ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
+            Err(ChainCommunicationError::from_other_str(
+                "mock indexer does not fetch logs",
+            ))
+        }
+
+        async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+            Err(ChainCommunicationError::from_other_str(
+                "mock indexer does not fetch finalized blocks",
+            ))
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct StoreResult {
+        stored: u32,
+        error: Option<&'static str>,
+    }
+
+    #[async_trait]
+    impl HyperlaneLogStore<HyperlaneMessage> for StoreResult {
+        async fn store_logs(&self, _logs: &[(Indexed<HyperlaneMessage>, LogMeta)]) -> Result<u32> {
+            match self.error {
+                Some(err) => Err(eyre::eyre!(err)),
+                None => Ok(self.stored),
+            }
+        }
+    }
+
+    fn test_domain() -> HyperlaneDomain {
+        HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum)
+    }
+
+    fn stored_logs_metric() -> IntCounter {
+        IntCounter::new("test_stored_events", "test stored events")
+            .expect("test counter should be valid")
+    }
+
+    fn test_logs() -> Vec<(Indexed<HyperlaneMessage>, LogMeta)> {
+        vec![(
+            Indexed::new(HyperlaneMessage::default()).with_sequence(0),
+            LogMeta::default(),
+        )]
+    }
+
+    #[tokio::test]
+    async fn dedupe_and_store_logs_returns_logs_and_updates_metric_on_success() {
+        let metric = stored_logs_metric();
+
+        let logs =
+            ContractSync::<HyperlaneMessage, StoreResult, MockIndexer>::dedupe_and_store_logs(
+                &test_domain(),
+                &StoreResult {
+                    stored: 1,
+                    error: None,
+                },
+                test_logs(),
+                &metric,
+            )
+            .await
+            .expect("store logs should succeed");
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(metric.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn dedupe_and_store_logs_returns_error_without_updating_metric() {
+        let metric = stored_logs_metric();
+
+        let result =
+            ContractSync::<HyperlaneMessage, StoreResult, MockIndexer>::dedupe_and_store_logs(
+                &test_domain(),
+                &StoreResult {
+                    stored: 0,
+                    error: Some("db unavailable"),
+                },
+                test_logs(),
+                &metric,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(metric.get(), 0);
     }
 }
 

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -223,13 +223,18 @@ where
 
             let logs = {
                 let store = store.lock().await;
-                match Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
-                {
-                    Ok(logs) => logs,
-                    Err(err) => {
-                        warn!(?err, ?tx_id, "Error storing logs in db");
-                        continue;
-                    }
+                Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
+            };
+            let logs = match logs {
+                Ok(logs) => logs,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        ?tx_id,
+                        "Error storing logs in db; tx-id task will rely on cursor retry"
+                    );
+                    sleep(SLEEP_DURATION).await;
+                    continue;
                 }
             };
             let num_logs = logs.len() as u64;
@@ -293,18 +298,18 @@ where
 
             let logs = {
                 let store = store.lock().await;
-                match Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
-                {
-                    Ok(logs) => logs,
-                    Err(err) => {
-                        warn!(
-                            ?err,
-                            ?range,
-                            "Skipping cursor update because logs failed to store"
-                        );
-                        sleep(SLEEP_DURATION).await;
-                        continue;
-                    }
+                Self::dedupe_and_store_logs(&domain, &store, logs, &stored_logs_metric).await
+            };
+            let logs = match logs {
+                Ok(logs) => logs,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        ?range,
+                        "Skipping cursor update because logs failed to store"
+                    );
+                    sleep(SLEEP_DURATION).await;
+                    continue;
                 }
             };
             let logs_found = logs.len() as u64;
@@ -364,10 +369,16 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::ops::RangeInclusive;
+    use std::{
+        ops::RangeInclusive,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc as StdArc,
+        },
+    };
 
     use async_trait::async_trait;
-    use prometheus::IntCounter;
+    use prometheus::{IntCounter, IntGauge};
 
     use hyperlane_core::{
         ChainCommunicationError, ChainResult, HyperlaneMessage, Indexer, KnownHyperlaneDomain,
@@ -375,8 +386,10 @@ mod tests {
 
     use super::*;
 
-    #[derive(Clone, Debug)]
-    struct MockIndexer;
+    #[derive(Clone, Debug, Default)]
+    struct MockIndexer {
+        logs: Vec<(Indexed<HyperlaneMessage>, LogMeta)>,
+    }
 
     #[async_trait]
     impl Indexer<HyperlaneMessage> for MockIndexer {
@@ -384,9 +397,7 @@ mod tests {
             &self,
             _range: RangeInclusive<u32>,
         ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
-            Err(ChainCommunicationError::from_other_str(
-                "mock indexer does not fetch logs",
-            ))
+            Ok(self.logs.clone())
         }
 
         async fn get_finalized_block_number(&self) -> ChainResult<u32> {
@@ -400,11 +411,15 @@ mod tests {
     struct StoreResult {
         stored: u32,
         error: Option<&'static str>,
+        calls: Option<StdArc<AtomicUsize>>,
     }
 
     #[async_trait]
     impl HyperlaneLogStore<HyperlaneMessage> for StoreResult {
         async fn store_logs(&self, _logs: &[(Indexed<HyperlaneMessage>, LogMeta)]) -> Result<u32> {
+            if let Some(calls) = &self.calls {
+                calls.fetch_add(1, Ordering::SeqCst);
+            }
             match self.error {
                 Some(err) => Err(eyre::eyre!(err)),
                 None => Ok(self.stored),
@@ -419,6 +434,15 @@ mod tests {
     fn stored_logs_metric() -> IntCounter {
         IntCounter::new("test_stored_events", "test stored events")
             .expect("test counter should be valid")
+    }
+
+    fn indexed_height_metric() -> IntGauge {
+        IntGauge::new("test_indexed_height", "test indexed height")
+            .expect("test gauge should be valid")
+    }
+
+    fn liveness_metric() -> IntGauge {
+        IntGauge::new("test_liveness", "test liveness").expect("test gauge should be valid")
     }
 
     fn test_logs() -> Vec<(Indexed<HyperlaneMessage>, LogMeta)> {
@@ -438,6 +462,7 @@ mod tests {
                 &StoreResult {
                     stored: 1,
                     error: None,
+                    calls: None,
                 },
                 test_logs(),
                 &metric,
@@ -459,6 +484,7 @@ mod tests {
                 &StoreResult {
                     stored: 0,
                     error: Some("db unavailable"),
+                    calls: None,
                 },
                 test_logs(),
                 &metric,
@@ -467,6 +493,71 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(metric.get(), 0);
+    }
+
+    #[derive(Debug)]
+    struct MockCursor {
+        updates: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ContractSyncCursor<HyperlaneMessage> for MockCursor {
+        async fn next_action(&mut self) -> Result<(CursorAction, Duration)> {
+            Ok((CursorAction::Query(0..=0), Duration::default()))
+        }
+
+        fn latest_queried_block(&self) -> u32 {
+            0
+        }
+
+        async fn update(
+            &mut self,
+            _logs: Vec<(Indexed<HyperlaneMessage>, LogMeta)>,
+            _range: RangeInclusive<u32>,
+        ) -> Result<()> {
+            self.updates.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_indexer_task_skips_cursor_update_when_store_errors() {
+        let store_calls = StdArc::new(AtomicUsize::new(0));
+        let cursor_updates = StdArc::new(AtomicUsize::new(0));
+        let store = StoreResult {
+            stored: 0,
+            error: Some("db unavailable"),
+            calls: Some(store_calls.clone()),
+        };
+        let cursor = MockCursor {
+            updates: cursor_updates.clone(),
+        };
+
+        let task = tokio::spawn(
+            ContractSync::<HyperlaneMessage, StoreResult, MockIndexer>::cursor_indexer_task(
+                test_domain(),
+                MockIndexer { logs: test_logs() },
+                Arc::new(Mutex::new(store)),
+                Box::new(cursor),
+                None,
+                stored_logs_metric(),
+                indexed_height_metric(),
+                liveness_metric(),
+            ),
+        );
+
+        for _ in 0..50 {
+            if store_calls.load(Ordering::SeqCst) > 0 {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(store_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(cursor_updates.load(Ordering::SeqCst), 0);
+
+        task.abort();
+        let _ = task.await;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #8890.

- Persist raw message dispatches as the durable source of truth before enrichment, including the message body needed to reconstruct complete `message` rows.
- Store every dispatch whose block/transaction enrichment is currently available instead of failing the whole range or only a contiguous prefix. Missing txns are left as raw rows for reconciliation.
- Added a scraper-local raw-dispatch reconciler that periodically finds raw dispatches without matching `message` rows and re-attempts block/transaction enrichment without blocking later nonces.
- Hardened reconciliation so permanently stuck raw rows do not starve later gaps: the task scans by raw dispatch `id`, advances a rotating in-memory cursor even when rows cannot enrich, and wraps back to the start after reaching the end.
- Kept true DB write failures fail-closed: if raw dispatch persistence fails, `store_logs` returns `Err` and the cursor does not advance.
- Preserved the shared `ContractSync` store-error behavior from the prior commit: real `store_logs` errors still prevent cursor advancement.

## Migration

This PR adds scraper DB migration `m20260613_000008_add_msg_body_to_raw_message_dispatch`, which adds a nullable column:

```sql
ALTER TABLE raw_message_dispatch ADD COLUMN msg_body BYTEA NULL;
```

The reconciliation scan index is intentionally created outside the SeaORM migration transaction so Postgres can build it concurrently:

```bash
cargo run --package migration --bin create-raw-dispatch-reconciliation-index
```

That helper runs:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS raw_message_dispatch_reconciliation_idx
ON raw_message_dispatch (origin_domain, origin_mailbox, id)
WHERE msg_body IS NOT NULL;
```

Deployment order:

1. Run scraper DB migrations while the old scraper image is still running.
2. Run `create-raw-dispatch-reconciliation-index`.
3. Run `EXPLAIN` on the reconciliation query and confirm the plan uses `raw_message_dispatch_reconciliation_idx` rather than a sequential scan.
4. Deploy the new scraper binary.

New binaries must not deploy before the column migration, because new raw-dispatch writes and reconciliation reads reference `raw_message_dispatch.msg_body`. This ordering requirement is also documented in `rust/main/agents/scraper/README.md`.

Rollback detail: stop or roll back scraper binaries that reference `raw_message_dispatch.msg_body` before dropping the column.

Backfill detail: no manual backfill is required for new operation. Existing pre-migration raw rows have `msg_body = NULL` and are intentionally ignored by the DB-only reconciler because they cannot produce complete `message` rows without refetching the original logs. The known BSC -> Eni nonces 393531/393532 were checked in prod and already have enriched `message` rows, `msg_body`, parent `transaction` rows, and parent `block` rows, so no targeted backfill remains for those two.

## Operational Status

Good to merge once CI is green.

- Confirmed mainnet3 and testnet4 scraper secrets point to the same `explorer4` DB, so this is a single shared migration.
- Applied `m20260613_000008_add_msg_body_to_raw_message_dispatch` on prod DB with the `postgres` owner connection.
- Created `raw_message_dispatch_reconciliation_idx` with `CREATE INDEX CONCURRENTLY IF NOT EXISTS`.
- Ran `EXPLAIN (ANALYZE, BUFFERS)` on prod-sized BSC raw dispatch data; the plan uses `Bitmap Index Scan on raw_message_dispatch_reconciliation_idx` and `message_origin_origin_mailbox_nonce_key` for the join side.
- Verified BSC -> Eni nonces 393531/393532 already have complete enriched rows; no targeted backfill remains for those two.
- New scraper image has not been rolled yet.

## Validation

- `cargo fmt --all --check`
- `cargo test -p scraper storable_messages_for_available_txns`
- `cargo test -p scraper raw_message_dispatch::tests -- --skip test_raw_message_dispatch_real_postgres --skip test_upsert_preserves_time_created_updates_time_updated`
- `cargo test -p scraper -- --skip db::block::tests::test_store_blocks_real_postgres --skip db::raw_message_dispatch::tests::test_raw_message_dispatch_real_postgres --skip db::raw_message_dispatch::tests::test_upsert_preserves_time_created_updates_time_updated`
- `cargo test -p hyperlane-base contract_sync::tests --lib`
- `cargo clippy -p scraper --bin scraper -- -D warnings`
- `cargo clippy -p hyperlane-base --lib -- -D warnings`
- `cargo fmt --package migration --check`
- `RUSTFLAGS='-D warnings' cargo check -p migration --bin create-raw-dispatch-reconciliation-index`

## Local Caveat

The full unfiltered `cargo test -p scraper` cannot pass in this local environment because Docker is unavailable at `/var/run/docker.sock`; the skipped tests above are existing Docker-backed Postgres tests. The load-bearing anti-join assertion was added to `test_raw_message_dispatch_real_postgres`, so it compiles locally and runs in Docker-enabled environments.
