### PR TITLE
feat: emit fee-token gas payment events

### DIFF
--- a/.changeset/gold-feetoken-igp.md
+++ b/.changeset/gold-feetoken-igp.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+The InterchainGasPaymaster emitted token-aware gas payment events while preserving the legacy GasPayment event for existing indexers.

--- a/rust/main/chains/hyperlane-ethereum/abis/IInterchainGasPaymaster.abi.json
+++ b/rust/main/chains/hyperlane-ethereum/abis/IInterchainGasPaymaster.abi.json
@@ -31,6 +31,43 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "messageId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feeToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "gasAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "payment",
+        "type": "uint256"
+      }
+    ],
+    "name": "GasPaymentWithFeeToken",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/rust/main/chains/hyperlane-tron/abis/IInterchainGasPaymaster.abi.json
+++ b/rust/main/chains/hyperlane-tron/abis/IInterchainGasPaymaster.abi.json
@@ -31,6 +31,43 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "messageId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "destinationDomain",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feeToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "gasAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "payment",
+        "type": "uint256"
+      }
+    ],
+    "name": "GasPaymentWithFeeToken",
+    "type": "event"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/solidity/contracts/hooks/igp/InterchainGasPaymaster.sol
+++ b/solidity/contracts/hooks/igp/InterchainGasPaymaster.sol
@@ -491,6 +491,13 @@ contract InterchainGasPaymaster is
         }
 
         emit GasPayment(_messageId, _destinationDomain, _gasLimit, _payment);
+        emit GasPaymentWithFeeToken(
+            _messageId,
+            _destinationDomain,
+            _feeToken,
+            _gasLimit,
+            _payment
+        );
     }
 
     /// @inheritdoc AbstractPostDispatchHook

--- a/solidity/contracts/interfaces/IInterchainGasPaymaster.sol
+++ b/solidity/contracts/interfaces/IInterchainGasPaymaster.sol
@@ -24,6 +24,22 @@ interface IInterchainGasPaymaster {
     );
 
     /**
+     * @notice Emitted when a payment is made for a message's gas costs.
+     * @param messageId The ID of the message to pay for.
+     * @param destinationDomain The domain of the destination chain.
+     * @param feeToken The token used to pay gas fees, or address(0) for native token payments.
+     * @param gasAmount The amount of destination gas paid for.
+     * @param payment The amount of tokens paid.
+     */
+    event GasPaymentWithFeeToken(
+        bytes32 indexed messageId,
+        uint32 indexed destinationDomain,
+        address indexed feeToken,
+        uint256 gasAmount,
+        uint256 payment
+    );
+
+    /**
      * @notice Emitted when a token gas oracle is set.
      * @param feeToken The fee token address.
      * @param remoteDomain The remote domain.

--- a/solidity/test/igps/InterchainGasPaymaster.t.sol
+++ b/solidity/test/igps/InterchainGasPaymaster.t.sol
@@ -46,6 +46,13 @@ contract InterchainGasPaymasterTest is Test {
         uint256 gasLimit,
         uint256 payment
     );
+    event GasPaymentWithFeeToken(
+        bytes32 indexed messageId,
+        uint32 indexed destinationDomain,
+        address indexed feeToken,
+        uint256 gasLimit,
+        uint256 payment
+    );
     event BeneficiarySet(address beneficiary);
     event DestinationGasConfigSet(
         uint32 remoteDomain,
@@ -730,6 +737,15 @@ contract InterchainGasPaymasterTest is Test {
         bytes32 messageId = keccak256(testEncodedMessage);
         vm.expectEmit(true, true, false, true);
         emit GasPayment(messageId, testDestinationDomain, totalGas, quote);
+
+        vm.expectEmit(true, true, true, true);
+        emit GasPaymentWithFeeToken(
+            messageId,
+            testDestinationDomain,
+            address(feeToken),
+            totalGas,
+            quote
+        );
 
         igp.postDispatch{value: 0}(metadata, testEncodedMessage);
 

--- a/solidity/test/igps/InterchainGasPaymaster.t.sol
+++ b/solidity/test/igps/InterchainGasPaymaster.t.sol
@@ -340,6 +340,14 @@ contract InterchainGasPaymasterTest is Test {
             testGasLimit,
             _quote
         );
+        vm.expectEmit(true, true, true, true);
+        emit GasPaymentWithFeeToken(
+            testMessageId,
+            testDestinationDomain,
+            address(0),
+            testGasLimit,
+            _quote
+        );
         igp.payForGas{value: _quote + _overpayment}(
             testMessageId,
             testDestinationDomain,
@@ -457,6 +465,22 @@ contract InterchainGasPaymasterTest is Test {
         uint256 _refundAddressBalanceBefore = address(this).balance;
         uint256 _quote = igp.quoteDispatch("", testEncodedMessage);
         uint256 _overpayment = 21000;
+
+        bytes32 messageId = keccak256(testEncodedMessage);
+        uint256 totalGas = igp.destinationGasLimit(
+            testDestinationDomain,
+            DEFAULT_GAS_USAGE
+        );
+        vm.expectEmit(true, true, false, true);
+        emit GasPayment(messageId, testDestinationDomain, totalGas, _quote);
+        vm.expectEmit(true, true, true, true);
+        emit GasPaymentWithFeeToken(
+            messageId,
+            testDestinationDomain,
+            address(0),
+            totalGas,
+            _quote
+        );
 
         igp.postDispatch{value: _quote + _overpayment}("", testEncodedMessage);
 


### PR DESCRIPTION
## Summary

Adds token-aware IGP gas payment event emission while preserving the legacy `GasPayment` event for existing indexers.

Changes:
- adds `GasPaymentWithFeeToken` to the IGP interface and generated agent ABIs
- emits both `GasPayment` and `GasPaymentWithFeeToken` from the IGP payment path
- updates the token-fee Forge test to assert both events
- adds a core changeset for the bytecode/event behavior change

## Stack

First PR in the fee-token IGP agent support stack. The follow-up Rust agent PR will index this event and enforce exact non-native fee-token policies.

## Validation

- `pnpm -C solidity fixtures`
- `cd solidity && forge test -vvv --decode-internal --match-contract InterchainGasPaymasterTest --match-test testPostDispatch_withTokenFee`
- `git diff --check`