### PR TITLE
chore(infra): bump mainnet3 agent image + enable fastpath external-secrets

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -41,13 +41,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '9502df3-20260612-173246',
-  relayerRC: '9502df3-20260612-173246',
-  relayerFastPath: '9502df3-20260612-173246',
-  validator: '9502df3-20260612-173246',
-  validatorRC: '9502df3-20260612-173246',
-  validatorFastPath: '9502df3-20260612-173246',
-  scraper: '9502df3-20260612-173246',
+  relayer: '557df49-20260615-165434',
+  relayerRC: '557df49-20260615-165434',
+  relayerFastPath: '557df49-20260615-165434',
+  validator: '557df49-20260615-165434',
+  validatorRC: '557df49-20260615-165434',
+  validatorFastPath: '557df49-20260615-165434',
+  scraper: '557df49-20260615-165434',
   // monorepo services
   checkWarpDeploy: 'main',
   // standalone services

--- a/typescript/infra/config/environments/mainnet3/infrastructure.ts
+++ b/typescript/infra/config/environments/mainnet3/infrastructure.ts
@@ -41,6 +41,7 @@ export const infrastructure: InfrastructureConfig = {
       'hyperlane-mainnet3-',
       'rc-mainnet3-',
       'neutron-mainnet3-',
+      'fastpath-mainnet3-',
       'mainnet3-',
     ],
   },


### PR DESCRIPTION
## Summary

Two changes to enable the mainnet3 fastpath validator rollout (#8848):

1. Bumps all mainnet3 rust agent image tags to `557df49-20260615-165434`, built off `main` at `557df49` (includes the fastpath validators merge). Tags updated: `relayer`, `relayerRC`, `relayerFastPath`, `validator`, `validatorRC`, `validatorFastPath`, `scraper`.
2. Adds the `fastpath-mainnet3-` prefix to `accessibleGCPSecretPrefixes` so the external-secrets service account's IAM condition permits the new fastpath context's GCP secrets. Without this, the validator `*-agent-validator-secret` ExternalSecrets fail with `PermissionDenied` on `secretmanager.versions.access` and the validator pods are stuck `ContainerCreating`.

> Applying (2) requires re-running `scripts/deploy-infra-external-secrets.ts -e mainnet3` to update the IAM condition.

## Image

- `ghcr.io/hyperlane-xyz/hyperlane-agent:557df49-20260615-165434` ([build run](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/27562241592))

🤖 Generated with [Claude Code](https://claude.com/claude-code)