### PR TITLE
fix: include solana rpc indexing

### DIFF
--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -74,10 +74,15 @@ export class RebalancerHelmManager extends HelmManager {
       throw new Error('No chains configured');
     }
 
-    // Store chains for helm values (used for private RPC secrets)
-    // Warp core config includes all strategy chains
+    // Store chains for helm values (used for private RPC secrets).
+    // Merge warp token chains and strategy chains — some strategy chains
+    // (e.g. solanamainnet used as a LiFi bridge target) are not warp tokens
+    // and would otherwise fall back to the public registry RPC.
     this.rebalancerChains = [
-      ...new Set(warpCoreConfig.tokens.map((t) => t.chainName)),
+      ...new Set([
+        ...warpCoreConfig.tokens.map((t) => t.chainName),
+        ...chainNames,
+      ]),
     ];
 
     // Store the config file content for helm values


### PR DESCRIPTION
### Description

`rebalancerChains` (used to populate `RPC_URL_*` env vars via ExternalSecret) was built solely from `warpCoreConfig.tokens` — the warp token chains. Strategy-only chains like `solanamainnet` (used as a LiFi bridge target in USDC/eclipsemainnet) were never included, so `RPC_URL_SOLANAMAINNET` was never injected and the rebalancer fell back to the public registry RPC (`https://api.mainnet-beta.solana.com`).

Under load this causes 429s that wedge the rebalancer's Solana balance monitor, preventing it from detecting and rebalancing a collateral deficit — which in turn blocks arbitrum→solanamainnet transfers from being relayed (gas estimation fails with SPL InsufficientFunds).

Fix: merge strategy chain names into `rebalancerChains` so all chains the rebalancer interacts with (not just warp token chains) get private RPC URLs injected.

### Drive-by changes

None.

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

Yes. Additive only — existing rebalancers already have `mainnet3-rpc-endpoints-<chain>` GCP secrets for their warp token chains; this only adds secrets lookups for chains that were previously missing.

### Testing

Manual — redeployed `hyperlane-rebalancer-usdc-eclipsemainnet` and confirmed `RPC_URL_SOLANAMAINNET` is now set to the private Alchemy endpoint in the pod.