### PR TITLE
feat(infra): register CROSS/moonpay as relayer metric app context

### DIFF
--- a/rust/main/app-contexts/mainnet_config.json
+++ b/rust/main/app-contexts/mainnet_config.json
@@ -41646,6 +41646,211 @@
       ]
     },
     {
+      "name": "CROSS/moonpay",
+      "matchingList": [
+        {
+          "originDomain": 42161,
+          "senderAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ],
+          "destinationDomain": 8453,
+          "recipientAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ]
+        },
+        {
+          "originDomain": 42161,
+          "senderAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ],
+          "destinationDomain": 4114,
+          "recipientAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ]
+        },
+        {
+          "originDomain": 42161,
+          "senderAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ],
+          "destinationDomain": 1,
+          "recipientAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ]
+        },
+        {
+          "originDomain": 42161,
+          "senderAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ],
+          "destinationDomain": 1399811149,
+          "recipientAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ]
+        },
+        {
+          "originDomain": 8453,
+          "senderAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ],
+          "destinationDomain": 42161,
+          "recipientAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ]
+        },
+        {
+          "originDomain": 8453,
+          "senderAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ],
+          "destinationDomain": 4114,
+          "recipientAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ]
+        },
+        {
+          "originDomain": 8453,
+          "senderAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ],
+          "destinationDomain": 1,
+          "recipientAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ]
+        },
+        {
+          "originDomain": 8453,
+          "senderAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ],
+          "destinationDomain": 1399811149,
+          "recipientAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ]
+        },
+        {
+          "originDomain": 4114,
+          "senderAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ],
+          "destinationDomain": 42161,
+          "recipientAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ]
+        },
+        {
+          "originDomain": 4114,
+          "senderAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ],
+          "destinationDomain": 8453,
+          "recipientAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ]
+        },
+        {
+          "originDomain": 4114,
+          "senderAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ],
+          "destinationDomain": 1,
+          "recipientAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ]
+        },
+        {
+          "originDomain": 4114,
+          "senderAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ],
+          "destinationDomain": 1399811149,
+          "recipientAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ]
+        },
+        {
+          "originDomain": 1,
+          "senderAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ],
+          "destinationDomain": 42161,
+          "recipientAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ]
+        },
+        {
+          "originDomain": 1,
+          "senderAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ],
+          "destinationDomain": 8453,
+          "recipientAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ]
+        },
+        {
+          "originDomain": 1,
+          "senderAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ],
+          "destinationDomain": 4114,
+          "recipientAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ]
+        },
+        {
+          "originDomain": 1,
+          "senderAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ],
+          "destinationDomain": 1399811149,
+          "recipientAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ]
+        },
+        {
+          "originDomain": 1399811149,
+          "senderAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ],
+          "destinationDomain": 42161,
+          "recipientAddress": [
+            "0x00000000000000000000000075a9297db5f0349fd1d6f4030953fe17175e06d4"
+          ]
+        },
+        {
+          "originDomain": 1399811149,
+          "senderAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ],
+          "destinationDomain": 8453,
+          "recipientAddress": [
+            "0x0000000000000000000000007abbb4ea8a5895127500cf0c15830c9eb9f61f96"
+          ]
+        },
+        {
+          "originDomain": 1399811149,
+          "senderAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ],
+          "destinationDomain": 4114,
+          "recipientAddress": [
+            "0x0000000000000000000000002bef59e84615371304bd731601f6344f5f304504"
+          ]
+        },
+        {
+          "originDomain": 1399811149,
+          "senderAddress": [
+            "0xf5324d5c5be7eb842fb738d13de87ee39cb9b6629ea6566c14241cd27a9b788b"
+          ],
+          "destinationDomain": 1,
+          "recipientAddress": [
+            "0x000000000000000000000000eb1b48b238e15a62e1858a601b6bffdf41163ae3"
+          ]
+        }
+      ]
+    },
+    {
       "name": "USDT/oft",
       "matchingList": [
         {

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -155,6 +155,7 @@ export enum WarpRouteIds {
   USDCCitreaMoonpay = 'USDC/moonpay',
   USDCCitreaIronBridge = 'CROSS/ctusd-usdc-ironbridge',
   USDTCitreaMoonpay = 'USDT/moonpay',
+  CROSSCitreaMoonpay = 'CROSS/moonpay',
 
   // TODO: uncomment when USDTOft warp routes are in the registry
   // USDT OFT


### PR DESCRIPTION
## Summary
- `CROSS/moonpay` is a cross-collateral (stableswap-style) router. Its **cross-token** transfers (e.g. the customer's ethereum-USDT → solana-XO leg) currently fall through to the `Unknown` relayer app context.
- The per-token sub-routes (`USDC/moonpay`, `USDT/moonpay`) cannot capture these: `multiAddressChainMapMatchingList` requires **both** endpoints (sender+origin AND recipient+destination) to match the same warp config, so a cross-token transfer matches neither sub-route.
- Registers `CROSS/moonpay` in `WarpRouteIds` (placed **after** `USDC`/`USDT` so same-token messages keep their existing labels via first-match-wins) and regenerates `rust/main/app-contexts/mainnet_config.json` via `pnpm update-agent-config:mainnet3`.
- This brings CROSS/moonpay traffic under the existing generic Grafana alert "Prepare queue has been increasing on a known app context" (`adgxrgyii9s00f`) automatically — no new alert rule needed.

## Test plan
- [ ] Confirm the generated `CROSS/moonpay` matching list covers all legs (arbitrum/base/citrea/ethereum/solanamainnet) — diff shows the full cross-product including the eth-USDT → solana-XO entry.
- [ ] Verify same-token transfers still classify as `USDC/moonpay` / `USDT/moonpay` (first-match-wins ordering preserved).
- [ ] After deploy, confirm CROSS/moonpay appears as an app_context label in relayer metrics and the alert covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)