### PR TITLE
feat: enumerate OffchainQuotedLinearFee standing quotes

### DIFF
--- a/.changeset/offchain-quoted-linear-fee-enumeration.md
+++ b/.changeset/offchain-quoted-linear-fee-enumeration.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+`OffchainQuotedLinearFee` exposed its standing-quote mapping for offchain enumeration. The `quotes` keys are now tracked in enumerable sets as standing quotes are stored, and two views were added: `quoteDomains()` returns the domain ids with at least one standing quote, and `getQuotesForDomain(domainId)` returns every quote stored under that exact domain key as `QuoteEntry[]` (recipient plus the `StoredQuote`). Entries are never removed, so enumeration includes the wildcard recipient and logically-expired quotes; recipient-only quotes are stored under the `WILDCARD_DEST` key and apply to every destination, so callers computing effective fees also query that key.

--- a/solidity/contracts/token/fees/OffchainQuotedLinearFee.sol
+++ b/solidity/contracts/token/fees/OffchainQuotedLinearFee.sol
@@ -20,6 +20,8 @@ import {Quote} from "../../interfaces/ITokenBridge.sol";
 import {LinearFee} from "./LinearFee.sol";
 import {FeeType} from "./BaseFee.sol";
 
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 /**
  * @dev Fee quote context layout (packed, 68 bytes):
  *
@@ -95,6 +97,8 @@ library FeeQuoteData {
  */
 contract OffchainQuotedLinearFee is AbstractOffchainQuoter, LinearFee {
     using TransientStorage for bytes32;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
 
     // ============ Constants ============
 
@@ -124,10 +128,26 @@ contract OffchainQuotedLinearFee is AbstractOffchainQuoter, LinearFee {
         uint48 expiry;
     }
 
+    /// @dev A standing quote together with its recipient key, as returned by
+    /// `getQuotesForDomain(domainId)` for offchain enumeration within a domain.
+    struct QuoteEntry {
+        bytes32 recipient;
+        StoredQuote quote;
+    }
+
     // ============ Storage ============
 
     mapping(uint32 destination => mapping(bytes32 recipient => StoredQuote))
         public quotes;
+
+    /// @dev Enumerable key set for `quotes`: the domain ids with at least one
+    /// standing quote, and the recipients stored under each. Tracks keys only;
+    /// the quote data stays in `quotes`. Entries are never removed (standing
+    /// quotes expire logically but are never deleted), so enumeration may
+    /// include expired quotes.
+    EnumerableSet.UintSet private _domainIds;
+    mapping(uint32 domainId => EnumerableSet.Bytes32Set recipients)
+        private _recipients;
 
     // ============ Constructor ============
 
@@ -283,6 +303,46 @@ contract OffchainQuotedLinearFee is AbstractOffchainQuoter, LinearFee {
             sq.issuedAt,
             sq.expiry
         );
+        // Track the key for offchain enumeration (idempotent on overwrite).
+        _domainIds.add(dest);
+        _recipients[dest].add(recipient);
         return true;
+    }
+
+    /// @notice Returns the domain ids that have at least one standing quote, for
+    /// use with `getQuotesForDomain`. Includes `WILDCARD_DEST` when recipient-only quotes
+    /// exist. Unbounded and never pruned; order is unspecified.
+    function quoteDomains() external view returns (uint32[] memory domainIds) {
+        uint256 len = _domainIds.length();
+        domainIds = new uint32[](len);
+        for (uint256 i = 0; i < len; i++) {
+            domainIds[i] = uint32(_domainIds.at(i));
+        }
+    }
+
+    /// @notice Returns every standing quote stored under the exact `domainId`
+    /// key, each with its recipient key, for offchain enumeration of the raw
+    /// `quotes` mapping. Use `quoteDomains()` to discover domain ids.
+    /// @dev Returns raw exact-key storage, NOT the effective quotes for a
+    /// destination: recipient-only quotes live under the `WILDCARD_DEST`
+    /// (`type(uint32).max`) key and apply to every destination, so also query
+    /// `getQuotesForDomain(WILDCARD_DEST)` when computing effective fees. Likewise
+    /// includes the wildcard recipient and logically-expired entries (never
+    /// removed) — filter by `quote.expiry`. Returned order is unspecified and is
+    /// not resolution priority. Unbounded: a domain with many signed quotes may
+    /// exceed RPC gas/return limits.
+    function getQuotesForDomain(
+        uint32 domainId
+    ) external view returns (QuoteEntry[] memory entries) {
+        EnumerableSet.Bytes32Set storage recipients = _recipients[domainId];
+        uint256 recipientLen = recipients.length();
+        entries = new QuoteEntry[](recipientLen);
+        for (uint256 i = 0; i < recipientLen; i++) {
+            bytes32 recipient = recipients.at(i);
+            entries[i] = QuoteEntry({
+                recipient: recipient,
+                quote: quotes[domainId][recipient]
+            });
+        }
     }
 }

--- a/solidity/test/token/OffchainQuotedLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedLinearFee.t.sol
@@ -763,6 +763,200 @@ contract OffchainQuotedLinearFeeTest is Test {
             _computeFee(IMMUTABLE_MAX_FEE, IMMUTABLE_HALF_AMOUNT, AMOUNT)
         );
     }
+
+    // ============ Quote Enumeration ============
+
+    function test_getQuotesForDomain_emptyWhenNoStandingQuotes() public view {
+        assertEq(quotedFee.quoteDomains().length, 0);
+        assertEq(quotedFee.getQuotesForDomain(DEST).length, 0);
+    }
+
+    function test_getQuotesForDomain_returnsStoredEntriesForDomain() public {
+        bytes32 recipientA = bytes32(uint256(0xA));
+        bytes32 recipientB = bytes32(uint256(0xB));
+        _submitStanding(
+            DEST,
+            recipientA,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+        _submitStanding(
+            DEST,
+            recipientB,
+            WILDCARD_AMOUNT,
+            MAX_FEE * 2,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+
+        uint32[] memory domains = quotedFee.quoteDomains();
+        assertEq(domains.length, 1);
+        assertEq(domains[0], DEST);
+
+        OffchainQuotedLinearFee.QuoteEntry[] memory entries = quotedFee
+            .getQuotesForDomain(DEST);
+        assertEq(entries.length, 2);
+        // Order is unspecified; assert by recipient, not index.
+        OffchainQuotedLinearFee.StoredQuote memory a = _findQuote(
+            entries,
+            recipientA
+        );
+        assertEq(a.maxFee, MAX_FEE);
+        assertEq(a.halfAmount, HALF_AMOUNT);
+        assertEq(a.issuedAt, 1);
+        assertEq(a.expiry, 1001);
+        OffchainQuotedLinearFee.StoredQuote memory b = _findQuote(
+            entries,
+            recipientB
+        );
+        assertEq(b.maxFee, MAX_FEE * 2);
+    }
+
+    function test_getQuotesForDomain_separatesByDomain() public {
+        uint32 destB = DEST + 1;
+        _submitStanding(
+            DEST,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+        _submitStanding(
+            destB,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+
+        uint32[] memory domains = quotedFee.quoteDomains();
+        assertEq(domains.length, 2);
+        // Order is unspecified; assert membership, not index.
+        assertTrue(_containsDomain(domains, DEST));
+        assertTrue(_containsDomain(domains, destB));
+
+        assertEq(quotedFee.getQuotesForDomain(DEST).length, 1);
+        assertEq(quotedFee.getQuotesForDomain(destB).length, 1);
+        // A domain with no quotes returns an empty array.
+        assertEq(quotedFee.getQuotesForDomain(DEST + 99).length, 0);
+    }
+
+    function test_getQuotesForDomain_overwriteDoesNotDuplicate() public {
+        _submitStanding(
+            DEST,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+        // A newer issuedAt overwrites the entry in place.
+        _submitStanding(
+            DEST,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE * 3,
+            HALF_AMOUNT,
+            2,
+            1001
+        );
+
+        assertEq(quotedFee.quoteDomains().length, 1);
+        OffchainQuotedLinearFee.QuoteEntry[] memory entries = quotedFee
+            .getQuotesForDomain(DEST);
+        assertEq(entries.length, 1);
+        assertEq(entries[0].quote.maxFee, MAX_FEE * 3);
+        assertEq(entries[0].quote.issuedAt, 2);
+    }
+
+    function test_getQuotesForDomain_excludesTransientQuotes() public {
+        // Transient quotes never touch the mapping, so they are not enumerated.
+        _submitTransient(DEST, RECIPIENT, AMOUNT, MAX_FEE, HALF_AMOUNT);
+
+        assertEq(quotedFee.quoteDomains().length, 0);
+        assertEq(quotedFee.getQuotesForDomain(DEST).length, 0);
+    }
+
+    function test_getQuotesForDomain_includesWildcardRecipient() public {
+        bytes32 wildcardRecipient = bytes32(type(uint256).max);
+        _submitStanding(
+            DEST,
+            wildcardRecipient,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+
+        OffchainQuotedLinearFee.QuoteEntry[] memory entries = quotedFee
+            .getQuotesForDomain(DEST);
+        assertEq(entries.length, 1);
+        assertEq(entries[0].recipient, wildcardRecipient);
+    }
+
+    function test_getQuotesForDomain_wildcardDestinationEnumeratedUnderItsOwnKey()
+        public
+    {
+        uint32 wildcardDest = type(uint32).max;
+        // A recipient-only quote applies to every destination and is stored
+        // under the WILDCARD_DEST key, not under any specific destination.
+        _submitStanding(
+            wildcardDest,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            1,
+            1001
+        );
+
+        // Not surfaced under a specific destination key...
+        assertEq(quotedFee.getQuotesForDomain(DEST).length, 0);
+
+        // ...but enumerable under the WILDCARD_DEST key.
+        OffchainQuotedLinearFee.QuoteEntry[] memory entries = quotedFee
+            .getQuotesForDomain(wildcardDest);
+        assertEq(entries.length, 1);
+        assertEq(entries[0].recipient, RECIPIENT);
+
+        uint32[] memory domains = quotedFee.quoteDomains();
+        assertEq(domains.length, 1);
+        assertEq(domains[0], wildcardDest);
+    }
+
+    function _findQuote(
+        OffchainQuotedLinearFee.QuoteEntry[] memory entries,
+        bytes32 recipient
+    ) internal pure returns (OffchainQuotedLinearFee.StoredQuote memory) {
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].recipient == recipient) {
+                return entries[i].quote;
+            }
+        }
+        revert("recipient not found");
+    }
+
+    function _containsDomain(
+        uint32[] memory domains,
+        uint32 domain
+    ) internal pure returns (bool) {
+        for (uint256 i = 0; i < domains.length; i++) {
+            if (domains[i] == domain) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 
 // ============ FeeQuoteContext / FeeQuoteData Codec Tests ============


### PR DESCRIPTION
### Description

Exposes `OffchainQuotedLinearFee`'s standing-quote mapping for offchain enumeration.

The `quotes` mapping (`destination => recipient => StoredQuote`) is write-only from the chain's perspective — there was no way to enumerate which standing quotes exist. This adds enumerable key-tracking and two views:

- `quoteDomains()` — returns the domain ids that have at least one standing quote.
- `getQuotesForDomain(domainId)` — returns every quote stored under that exact domain key as `QuoteEntry[]` (recipient key + `StoredQuote`).

Implementation:
- Added a new `QuoteEntry { bytes32 recipient; StoredQuote quote; }` struct.
- Added an `EnumerableSet.UintSet` of domain ids and a per-domain `EnumerableSet.Bytes32Set` of recipients. Keys are tracked (idempotently) whenever a standing quote is stored; the quote data itself stays in the existing `quotes` mapping.
- Entries are never removed: standing quotes expire logically but are never deleted, so enumeration includes logically-expired quotes and the wildcard recipient. Callers filter by `quote.expiry`.
- Recipient-only quotes are stored under the `WILDCARD_DEST` (`type(uint32).max`) key and apply to every destination, so callers computing effective fees must also query `getQuotesForDomain(WILDCARD_DEST)`. This is documented on the view and covered by a dedicated test.
- Transient quotes never touch the mapping and are therefore not enumerated.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. Additive only — two new view functions, a new struct, and two private storage sets appended after existing storage. No changes to existing function signatures, the `quotes` mapping, or fee resolution behavior.

### Testing

Unit Tests (Forge). Added a "Quote Enumeration" suite to `OffchainQuotedLinearFee.t.sol` covering:
- empty state (no standing quotes)
- stored entries returned per domain (order-independent, asserted by recipient)
- separation across domains
- in-place overwrite does not duplicate keys
- transient quotes excluded
- wildcard recipient included
- wildcard destination enumerated under its own `WILDCARD_DEST` key, not under specific destinations