### PR TITLE
feat: add Hyperliquid core primitives

### DIFF
--- a/.changeset/hyperliquid-core-primitives.md
+++ b/.changeset/hyperliquid-core-primitives.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": patch
+---
+
+Added Hyperliquid CoreWriter and CoreDepositWallet interfaces plus CoreWriter action encoding helpers for HyperEVM integrations.

--- a/docs/hyperliquid-core-integration.md
+++ b/docs/hyperliquid-core-integration.md
@@ -1,0 +1,20 @@
+# Hyperliquid Core integration primitives
+
+HyperEVM is already a Hyperlane domain, but HyperCore balances are not directly controlled by Hyperlane messages. The useful primitives for a Nexus/warp integration live at the HyperCore <> HyperEVM boundary.
+
+## Transfer boundary
+
+- Read precompiles expose Core state and do not move funds.
+- CoreWriter is the HyperEVM -> HyperCore action path. A contract calling CoreWriter acts for that contract's own HyperCore account.
+- HyperCore -> HyperEVM credits linked assets through protocol transfers. It does not execute arbitrary calldata against HyperEVM contracts.
+- Generic linked spot assets use token system addresses. Recipient-aware Core deposits are asset-specific; Circle's USDC `CoreDepositWallet.depositFor` is the clean first target.
+
+## Contract primitives in this repo
+
+- `ICoreWriter` exposes `sendRawAction(bytes)`.
+- `HyperliquidCoreWriter` encodes the action headers and ABI payloads for:
+  - action `6`, spot send
+  - action `13`, send asset
+- `ICoreDepositWallet` exposes Circle's USDC deposit entry points used to credit HyperCore users from HyperEVM.
+
+These are intentionally lower-level than a full adapter. A production adapter still needs intent storage for any asynchronous Core -> EVM -> warp flow and should only claim direct user credit for assets whose HyperEVM -> Core path supports an explicit recipient.

--- a/solidity/contracts/interfaces/hyperliquid/ICoreDepositWallet.sol
+++ b/solidity/contracts/interfaces/hyperliquid/ICoreDepositWallet.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+interface ICoreDepositWallet {
+    function deposit(uint256 amount, uint32 destinationDex) external;
+
+    function depositFor(
+        address recipient,
+        uint256 amount,
+        uint32 destinationDex
+    ) external;
+
+    function depositWithAuth(
+        address from,
+        address recipient,
+        uint256 amount,
+        uint32 destinationDex,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes calldata signature
+    ) external;
+}

--- a/solidity/contracts/interfaces/hyperliquid/ICoreWriter.sol
+++ b/solidity/contracts/interfaces/hyperliquid/ICoreWriter.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+interface ICoreWriter {
+    function sendRawAction(bytes calldata data) external;
+}

--- a/solidity/contracts/libs/HyperliquidCoreWriter.sol
+++ b/solidity/contracts/libs/HyperliquidCoreWriter.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0;
+
+library HyperliquidCoreWriter {
+    address internal constant CORE_WRITER =
+        0x3333333333333333333333333333333333333333;
+
+    uint8 internal constant ACTION_VERSION = 1;
+
+    uint24 internal constant SPOT_SEND_ACTION_ID = 6;
+    uint24 internal constant SEND_ASSET_ACTION_ID = 13;
+
+    uint32 internal constant CORE_PERPS_DEX_ID = 0;
+    uint32 internal constant CORE_SPOT_DEX_ID = type(uint32).max;
+
+    function formatSpotSend(
+        address destination,
+        uint64 token,
+        uint64 amount
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                ACTION_VERSION,
+                _formatActionId(SPOT_SEND_ACTION_ID),
+                abi.encode(destination, token, amount)
+            );
+    }
+
+    function formatSendAsset(
+        address destination,
+        address subAccount,
+        uint32 sourceDex,
+        uint32 destinationDex,
+        uint64 token,
+        uint64 amount
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                ACTION_VERSION,
+                _formatActionId(SEND_ASSET_ACTION_ID),
+                abi.encode(
+                    destination,
+                    subAccount,
+                    sourceDex,
+                    destinationDex,
+                    token,
+                    amount
+                )
+            );
+    }
+
+    function _formatActionId(uint24 actionId) private pure returns (bytes3) {
+        return bytes3(actionId);
+    }
+}

--- a/solidity/test/libs/HyperliquidCoreWriter.t.sol
+++ b/solidity/test/libs/HyperliquidCoreWriter.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {HyperliquidCoreWriter} from "../../contracts/libs/HyperliquidCoreWriter.sol";
+
+contract HyperliquidCoreWriterTest is Test {
+    address constant DESTINATION =
+        address(0x2000000000000000000000000000000000000000);
+    address constant SUB_ACCOUNT = address(0x1234);
+    uint64 constant TOKEN = 0;
+    uint64 constant AMOUNT = 1_000_000;
+
+    function test_formatSpotSend() public pure {
+        bytes memory encoded = HyperliquidCoreWriter.formatSpotSend(
+            DESTINATION,
+            TOKEN,
+            AMOUNT
+        );
+
+        assertEq(
+            encoded,
+            abi.encodePacked(
+                hex"01000006",
+                abi.encode(DESTINATION, TOKEN, AMOUNT)
+            )
+        );
+    }
+
+    function test_formatSendAsset() public pure {
+        bytes memory encoded = HyperliquidCoreWriter.formatSendAsset(
+            DESTINATION,
+            SUB_ACCOUNT,
+            type(uint32).max,
+            0,
+            TOKEN,
+            AMOUNT
+        );
+
+        assertEq(
+            encoded,
+            abi.encodePacked(
+                hex"0100000d",
+                abi.encode(
+                    DESTINATION,
+                    SUB_ACCOUNT,
+                    uint32(type(uint32).max),
+                    uint32(0),
+                    TOKEN,
+                    AMOUNT
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Added Hyperliquid CoreWriter and Circle CoreDepositWallet interfaces for HyperEVM integrations.
- Added CoreWriter action encoding helpers for spot-send and send-asset payloads.
- Documented the HyperCore <> HyperEVM boundary and why these are primitives rather than a full adapter.

## Validation

- forge test --match-contract HyperliquidCoreWriterTest -vvv
- pnpm -C solidity lint
- git diff --check

## Follow-up

- Build production adapters separately once the UX and asset target are fixed.
- Only claim one-click user Core credit for assets with an explicit recipient-aware deposit path, currently modeled around USDC depositFor.