### PR TITLE
feat: rebalance gas oracle exchange rate for low-decimal fee tokens

### DIFF
--- a/.changeset/token-igp-exchange-rate-rebalance.md
+++ b/.changeset/token-igp-exchange-rate-rebalance.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The gas oracle exchange-rate computation in `getLocalStorageGasOracleConfig` was generalized to handle low-decimal fee tokens. When the fee token has fewer decimals than the remote native token (e.g. a 6-decimal ERC20 fee token paying for an 18-decimal native chain), the scaled exchange rate could fall below 1 and floor to a coarse integer, badly mispricing the quote. The existing precision-loss adjustment now also rebalances in this direction, shifting magnitude from the gas price into the exchange rate (their product, and thus the quote, is preserved) so the on-chain exchange rate keeps its precision. Same-decimal native pairs are unaffected.

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -10,6 +10,7 @@ import {
 // Fee quote the IGP computes for a message, in the local (fee-token) base unit:
 //   quote = gasAmount * gasPrice * tokenExchangeRate / 1e10
 const EXCHANGE_RATE_SCALE = 1e10;
+const MAX_REBALANCED_QUOTE_ROUNDING_ERROR = 1 / 1000;
 function quote(
   config: { gasPrice: string; tokenExchangeRate: string },
   gasAmount: number,
@@ -69,40 +70,39 @@ describe('getLocalStorageGasOracleConfig', () => {
       exchangeRateMarginPct: 0,
     }).remote;
 
-    // Exchange rate must stay well above the floor (not collapse to 1).
-    expect(Number(config.tokenExchangeRate)).to.be.greaterThan(1);
+    // Exchange rate must be representable before integer rounding.
+    expect(Number(config.tokenExchangeRate)).to.be.at.least(1);
 
     // The quote (gasPrice * exchangeRate product) must match the intended value:
     // intended per-gas = 5e10 * 0.1 / 1e10 = 0.5 base units per unit gas.
     const gasAmount = 200_000;
     expect(quote(config, gasAmount)).to.be.approximately(
       0.5 * gasAmount,
-      0.5 * gasAmount * 0.001, // within 0.1% (ceil rounding on the gas price)
+      0.5 * gasAmount * MAX_REBALANCED_QUOTE_ROUNDING_ERROR,
     );
   });
 
-  it('falls back to the floor when the gas price is too small to rebalance', () => {
-    // gasPrice in wei (100) is below MIN_REBALANCED_GAS_PRICE, so there is no
-    // magnitude to shift; the exchange rate floors to 1 rather than throwing.
+  it('throws when a sub-unit exchange rate has no gas price headroom to rebalance', () => {
+    // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
+    // magnitude into the exchange rate would exceed the rounding-error bound.
     const gasOracleParams: Record<string, ChainGasOracleParams> = {
       feeToken: {
         gasPrice: { amount: '1', decimals: 9 },
         nativeToken: { price: '1', decimals: 6 },
       },
       remote: {
-        gasPrice: { amount: '100', decimals: 0 }, // 100 wei
+        gasPrice: { amount: '5', decimals: 0 }, // <10 wei
         nativeToken: { price: '10', decimals: 18 },
       },
     };
 
-    const config = getLocalStorageGasOracleConfig({
-      local: 'feeToken',
-      localProtocolType: ProtocolType.Ethereum,
-      gasOracleParams,
-      exchangeRateMarginPct: 0,
-    }).remote;
-
-    expect(config.tokenExchangeRate).to.equal('1');
-    expect(config.gasPrice).to.equal('100');
+    expect(() =>
+      getLocalStorageGasOracleConfig({
+        local: 'feeToken',
+        localProtocolType: ProtocolType.Ethereum,
+        gasOracleParams,
+        exchangeRateMarginPct: 0,
+      }),
+    ).to.throw('Token exchange rate must be at least 1');
   });
 });

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -82,7 +82,7 @@ describe('getLocalStorageGasOracleConfig', () => {
     );
   });
 
-  it('throws when a sub-unit exchange rate has no gas price headroom to rebalance', () => {
+  it('falls back to the floor when there is no gas price headroom to rebalance', () => {
     // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
     // magnitude into the exchange rate would exceed the rounding-error bound.
     const gasOracleParams: Record<string, ChainGasOracleParams> = {
@@ -96,13 +96,14 @@ describe('getLocalStorageGasOracleConfig', () => {
       },
     };
 
-    expect(() =>
-      getLocalStorageGasOracleConfig({
-        local: 'feeToken',
-        localProtocolType: ProtocolType.Ethereum,
-        gasOracleParams,
-        exchangeRateMarginPct: 0,
-      }),
-    ).to.throw('Token exchange rate must be at least 1');
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    expect(config.tokenExchangeRate).to.equal('1');
+    expect(config.gasPrice).to.equal('5');
   });
 });

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -85,6 +85,8 @@ describe('getLocalStorageGasOracleConfig', () => {
   it('falls back to the floor when there is no gas price headroom to rebalance', () => {
     // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
     // magnitude into the exchange rate would exceed the rounding-error bound.
+    // This documents the known fallback limitation: the quote is overpriced by
+    // the sub-1 exchange rate factor rather than preserving precision.
     const gasOracleParams: Record<string, ChainGasOracleParams> = {
       feeToken: {
         gasPrice: { amount: '1', decimals: 9 },

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -82,6 +82,36 @@ describe('getLocalStorageGasOracleConfig', () => {
     );
   });
 
+  it('preserves precision for non-power-of-ten exchange rates', () => {
+    // 6-decimal fee token paying for an 18-decimal remote, remote worth 15x.
+    // Naively the scaled exchange rate is 0.15. Shifting only one digit makes
+    // this 1.5, which floors to 1 and underquotes by 33%; using all safe
+    // gas-price headroom keeps the floor rounding error negligible.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      feeToken: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 6 },
+      },
+      remote: {
+        gasPrice: { amount: '50', decimals: 9 }, // 50 gwei = 5e10 wei
+        nativeToken: { price: '15', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    const gasAmount = 200_000;
+    expect(quote(config, gasAmount)).to.be.approximately(
+      0.75 * gasAmount,
+      0.75 * gasAmount * MAX_REBALANCED_QUOTE_ROUNDING_ERROR,
+    );
+  });
+
   it('falls back to the floor when there is no gas price headroom to rebalance', () => {
     // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
     // magnitude into the exchange rate would exceed the rounding-error bound.

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -1,0 +1,108 @@
+import { expect } from 'chai';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import {
+  ChainGasOracleParams,
+  getLocalStorageGasOracleConfig,
+} from './utils.js';
+
+// Fee quote the IGP computes for a message, in the local (fee-token) base unit:
+//   quote = gasAmount * gasPrice * tokenExchangeRate / 1e10
+const EXCHANGE_RATE_SCALE = 1e10;
+function quote(
+  config: { gasPrice: string; tokenExchangeRate: string },
+  gasAmount: number,
+): number {
+  return (
+    (gasAmount * Number(config.gasPrice) * Number(config.tokenExchangeRate)) /
+    EXCHANGE_RATE_SCALE
+  );
+}
+
+describe('getLocalStorageGasOracleConfig', () => {
+  it('leaves same-decimal native pairs unchanged (no rebalance)', () => {
+    // local + remote both 18-decimal native tokens; remote worth 2x local.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      local: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 18 },
+      },
+      remote: {
+        gasPrice: { amount: '1', decimals: 9 }, // 1 gwei = 1e9 wei
+        nativeToken: { price: '2', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'local',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    });
+
+    // exchangeRate = (2/1) * 1e10 ; gasPrice = 1e9 ; both pass through as-is.
+    expect(config.remote.tokenExchangeRate).to.equal('20000000000');
+    expect(config.remote.gasPrice).to.equal('1000000000');
+  });
+
+  it('rebalances a sub-unit exchange rate for a low-decimal fee token', () => {
+    // 6-decimal fee token paying for an 18-decimal remote, remote worth 10x.
+    // Naively the scaled exchange rate is (10) * 10^(6-18) * 1e10 = 0.1, which
+    // would floor to 1 and overprice the quote 10x. The rebalance must keep it
+    // representable while preserving the quote.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      feeToken: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 6 },
+      },
+      remote: {
+        gasPrice: { amount: '50', decimals: 9 }, // 50 gwei = 5e10 wei
+        nativeToken: { price: '10', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    // Exchange rate must stay well above the floor (not collapse to 1).
+    expect(Number(config.tokenExchangeRate)).to.be.greaterThan(1);
+
+    // The quote (gasPrice * exchangeRate product) must match the intended value:
+    // intended per-gas = 5e10 * 0.1 / 1e10 = 0.5 base units per unit gas.
+    const gasAmount = 200_000;
+    expect(quote(config, gasAmount)).to.be.approximately(
+      0.5 * gasAmount,
+      0.5 * gasAmount * 0.001, // within 0.1% (ceil rounding on the gas price)
+    );
+  });
+
+  it('falls back to the floor when the gas price is too small to rebalance', () => {
+    // gasPrice in wei (100) is below MIN_REBALANCED_GAS_PRICE, so there is no
+    // magnitude to shift; the exchange rate floors to 1 rather than throwing.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      feeToken: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 6 },
+      },
+      remote: {
+        gasPrice: { amount: '100', decimals: 0 }, // 100 wei
+        nativeToken: { price: '10', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    expect(config.tokenExchangeRate).to.equal('1');
+    expect(config.gasPrice).to.equal('100');
+  });
+});

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -329,6 +329,11 @@ function adjustForPrecisionLoss(
     }
 
     if (newExchangeRate.lt(1)) {
+      // Known limitation: gas prices below 10 * MIN_REBALANCED_GAS_PRICE do
+      // not have a full decimal digit of headroom to shift while preserving the
+      // final ceil rounding-error bound. In that no-headroom band, keep the
+      // original gas price and fall back to the minimum representable exchange
+      // rate instead of introducing a larger ceil error.
       rootLogger.warn(
         `Token exchange rate remains below 1 after precision rebalance; falling back to minimum on-chain exchange rate. Original gas price: ${new BigNumberJs(
           gasPrice,

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -7,6 +7,7 @@ import {
   assert,
   convertDecimals,
   objMap,
+  rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { getProtocolExchangeRateDecimals } from '../consts/igp.js';
@@ -327,12 +328,13 @@ function adjustForPrecisionLoss(
       newGasPrice = newGasPrice.div(factor);
     }
 
-    assert(
-      newExchangeRate.gte(1),
-      `Token exchange rate must be at least 1 after precision rebalance. Original gas price: ${new BigNumberJs(
-        gasPrice,
-      ).toString()}, original exchange rate: ${exchangeRate.toString()}`,
-    );
+    if (newExchangeRate.lt(1)) {
+      rootLogger.warn(
+        `Token exchange rate remains below 1 after precision rebalance; falling back to minimum on-chain exchange rate. Original gas price: ${new BigNumberJs(
+          gasPrice,
+        ).toString()}, original exchange rate: ${exchangeRate.toString()}`,
+      );
+    }
   }
 
   // We may have very little precision, and ultimately need an integer value for

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -310,18 +310,10 @@ function adjustForPrecisionLoss(
   // preserved while the on-chain exchange rate keeps its precision. No-op for
   // same-decimal native pairs, where the scaled rate is already >> 1.
   if (newExchangeRate.lt(1)) {
-    const headroom = decimalMagnitude(
+    const shiftMagnitude = decimalMagnitude(
       newGasPrice.div(MIN_REBALANCED_GAS_PRICE),
     );
-    let digitsNeeded = 0;
-    while (
-      digitsNeeded < headroom &&
-      newExchangeRate.times(new BigNumberJs(10).pow(digitsNeeded)).lt(1)
-    ) {
-      digitsNeeded += 1;
-    }
 
-    const shiftMagnitude = Math.min(headroom, digitsNeeded);
     if (shiftMagnitude > 0) {
       const factor = new BigNumberJs(10).pow(shiftMagnitude);
       newExchangeRate = newExchangeRate.times(factor);

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@ethersproject/providers';
 import { BigNumber as BigNumberJs } from 'bignumber.js';
-import { BigNumber, ethers } from 'ethers';
+import { ethers } from 'ethers';
 
 import {
   ProtocolType,
@@ -160,20 +160,17 @@ function getTokenExchangeRate({
   return exchangeRate;
 }
 
-function getProtocolExchangeRate(
+// Scales the (decimal-adjusted) exchange rate by the protocol's fixed-point
+// multiplier. Returns a float that may be < 1 (e.g. for a low-decimal fee token
+// paying for a high-decimal native chain); rounding to an integer and any
+// precision rebalancing against the gas price happen later in
+// adjustForPrecisionLoss.
+function scaleProtocolExchangeRate(
   localProtocolType: ProtocolType,
   exchangeRate: InstanceType<typeof BigNumberJs>,
-): BigNumber {
+): InstanceType<typeof BigNumberJs> {
   const multiplierDecimals = getProtocolExchangeRateDecimals(localProtocolType);
-  const multiplier = new BigNumberJs(10).pow(multiplierDecimals);
-  const integer = exchangeRate
-    .times(multiplier)
-    .integerValue(BigNumberJs.ROUND_FLOOR)
-    .toString(10);
-  const result = BigNumber.from(integer);
-
-  // Ensure exchange rate is at least 1
-  return result.lt(1) ? BigNumber.from(1) : result;
+  return exchangeRate.times(new BigNumberJs(10).pow(multiplierDecimals));
 }
 
 // Gets the StorageGasOracleConfig for each remote chain for a particular local chain.
@@ -236,8 +233,10 @@ export function getLocalStorageGasOracleConfig({
       );
     }
 
-    // Make the exchange rate an integer by scaling it up by the appropriate factor for the protocol.
-    const exchangeRate = getProtocolExchangeRate(
+    // Scale the exchange rate by the protocol's fixed-point factor. Kept as a
+    // float here; adjustForPrecisionLoss does the final integer rounding (and
+    // rebalances against the gas price if it would otherwise underflow).
+    const scaledExchangeRate = scaleProtocolExchangeRate(
       localProtocolType,
       exchangeRateFloat,
     );
@@ -257,14 +256,14 @@ export function getLocalStorageGasOracleConfig({
     // Get a prospective gasOracleConfig, adjusting the gas price and exchange rate
     // as needed to account for precision loss (e.g. if the gas price is super small).
     let gasOracleConfig: ProtocolAgnositicGasOracleConfigWithTypicalCost =
-      adjustForPrecisionLoss(gasPrice, exchangeRate, remoteDecimals);
+      adjustForPrecisionLoss(gasPrice, scaledExchangeRate, remoteDecimals);
 
     // Apply the modifier if provided.
     if (gasPriceModifier) {
       // Once again adjust for precision loss after applying the modifier.
       gasOracleConfig = adjustForPrecisionLoss(
         gasPriceModifier(local, remote, gasOracleConfig),
-        BigNumber.from(gasOracleConfig.tokenExchangeRate),
+        new BigNumberJs(gasOracleConfig.tokenExchangeRate),
         remoteDecimals,
       );
     }
@@ -283,13 +282,37 @@ export function getLocalStorageGasOracleConfig({
   }, {} as ChainMap<ProtocolAgnositicGasOracleConfig>);
 }
 
+// Floor for the gas price after rebalancing a sub-unit exchange rate. The gas
+// price is divided when shifting magnitude into the exchange rate; keeping it
+// above this bound caps the rounding error from the final ceil.
+const MIN_REBALANCED_GAS_PRICE = 1000;
+
 function adjustForPrecisionLoss(
   gasPrice: Parameters<typeof BigNumberJs>[0],
-  exchangeRate: BigNumber,
+  exchangeRate: InstanceType<typeof BigNumberJs>,
   remoteDecimals: number,
 ): ProtocolAgnositicGasOracleConfig {
   let newGasPrice = new BigNumberJs(gasPrice);
   let newExchangeRate = exchangeRate;
+
+  // When the fee token has fewer decimals than the remote native token (e.g. a
+  // 6-decimal ERC20 fee token paying for an 18-decimal native chain), decimal
+  // conversion can push the scaled exchange rate below 1, where rounding to an
+  // integer would badly misprice (or zero out) the quote. The quote is the
+  // product gasPrice * exchangeRate, so shift magnitude from the gas price into
+  // the exchange rate by a power of ten: the product (and thus the quote) is
+  // preserved while the on-chain exchange rate keeps its precision. No-op for
+  // same-decimal native pairs, where the scaled rate is already >> 1.
+  if (newExchangeRate.lt(1) && newGasPrice.gt(MIN_REBALANCED_GAS_PRICE)) {
+    const headroom = Math.floor(
+      Math.log10(newGasPrice.div(MIN_REBALANCED_GAS_PRICE).toNumber()),
+    );
+    if (headroom >= 1) {
+      const factor = new BigNumberJs(10).pow(headroom);
+      newExchangeRate = newExchangeRate.times(factor);
+      newGasPrice = newGasPrice.div(factor);
+    }
+  }
 
   // We may have very little precision, and ultimately need an integer value for
   // the gas price that will be set on-chain. If this is the case, we scale up the
@@ -301,11 +324,11 @@ function adjustForPrecisionLoss(
     // Check that there's no significant underflow when applying
     // this to the exchange rate:
     const adjustedExchangeRate = newExchangeRate.div(gasPriceScalingFactor);
-    const recoveredExchangeRate = adjustedExchangeRate.mul(
+    const recoveredExchangeRate = adjustedExchangeRate.times(
       gasPriceScalingFactor,
     );
     // Ensure we recover at least 99% of the original exchange rate
-    if (recoveredExchangeRate.mul(100).div(newExchangeRate).gte(99)) {
+    if (recoveredExchangeRate.times(100).div(newExchangeRate).gte(99)) {
       newGasPrice = newGasPrice.times(gasPriceScalingFactor);
       newExchangeRate = adjustedExchangeRate;
     }
@@ -317,14 +340,22 @@ function adjustForPrecisionLoss(
     'Gas price must be greater than 0, possible loss of precision',
   );
 
+  // Round the (possibly rebalanced) exchange rate to an integer, keeping a
+  // floor of 1 so a tiny-but-nonzero rate never collapses to 0.
+  let newExchangeRateInteger = newExchangeRate.integerValue(
+    BigNumberJs.ROUND_FLOOR,
+  );
+  if (newExchangeRateInteger.lt(1)) {
+    newExchangeRateInteger = new BigNumberJs(1);
+  }
   assert(
-    newExchangeRate.gt(0),
+    newExchangeRateInteger.gt(0),
     `Token exchange rate must be greater than 0, possible loss of precision. Original exchange rate: ${exchangeRate.toString()}`,
   );
 
   return {
-    tokenExchangeRate: newExchangeRate.toString(),
-    gasPrice: newGasPriceInteger.toString(),
+    tokenExchangeRate: newExchangeRateInteger.toFixed(0),
+    gasPrice: newGasPriceInteger.toFixed(0),
     tokenDecimals: remoteDecimals,
   };
 }

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -282,10 +282,15 @@ export function getLocalStorageGasOracleConfig({
   }, {} as ChainMap<ProtocolAgnositicGasOracleConfig>);
 }
 
-// Floor for the gas price after rebalancing a sub-unit exchange rate. The gas
-// price is divided when shifting magnitude into the exchange rate; keeping it
-// above this bound caps the rounding error from the final ceil.
+// Floor for the gas price after rebalancing a sub-unit exchange rate. Because
+// the final gas price is ceiled, keeping the rebalanced value at least 1000
+// bounds the relative quote error from that ceil to < 1 / 1000 = 0.1%.
 const MIN_REBALANCED_GAS_PRICE = 1000;
+
+function decimalMagnitude(value: InstanceType<typeof BigNumberJs>): number {
+  if (value.lt(1)) return 0;
+  return value.integerValue(BigNumberJs.ROUND_FLOOR).toFixed(0).length - 1;
+}
 
 function adjustForPrecisionLoss(
   gasPrice: Parameters<typeof BigNumberJs>[0],
@@ -303,21 +308,37 @@ function adjustForPrecisionLoss(
   // the exchange rate by a power of ten: the product (and thus the quote) is
   // preserved while the on-chain exchange rate keeps its precision. No-op for
   // same-decimal native pairs, where the scaled rate is already >> 1.
-  if (newExchangeRate.lt(1) && newGasPrice.gt(MIN_REBALANCED_GAS_PRICE)) {
-    const headroom = Math.floor(
-      Math.log10(newGasPrice.div(MIN_REBALANCED_GAS_PRICE).toNumber()),
+  if (newExchangeRate.lt(1)) {
+    const headroom = decimalMagnitude(
+      newGasPrice.div(MIN_REBALANCED_GAS_PRICE),
     );
-    if (headroom >= 1) {
-      const factor = new BigNumberJs(10).pow(headroom);
+    let digitsNeeded = 0;
+    while (
+      digitsNeeded < headroom &&
+      newExchangeRate.times(new BigNumberJs(10).pow(digitsNeeded)).lt(1)
+    ) {
+      digitsNeeded += 1;
+    }
+
+    const shiftMagnitude = Math.min(headroom, digitsNeeded);
+    if (shiftMagnitude > 0) {
+      const factor = new BigNumberJs(10).pow(shiftMagnitude);
       newExchangeRate = newExchangeRate.times(factor);
       newGasPrice = newGasPrice.div(factor);
     }
+
+    assert(
+      newExchangeRate.gte(1),
+      `Token exchange rate must be at least 1 after precision rebalance. Original gas price: ${new BigNumberJs(
+        gasPrice,
+      ).toString()}, original exchange rate: ${exchangeRate.toString()}`,
+    );
   }
 
   // We may have very little precision, and ultimately need an integer value for
   // the gas price that will be set on-chain. If this is the case, we scale up the
   // gas price and scale down the exchange rate by the same factor.
-  if (newGasPrice.lt(10) && newGasPrice.mod(1) !== new BigNumberJs(0)) {
+  if (newGasPrice.lt(10) && !newGasPrice.mod(1).isZero()) {
     // Scale up the gas price by 1e4 (arbitrary choice)
     const gasPriceScalingFactor = 1e4;
 


### PR DESCRIPTION
## Summary
Stack 1/4 of #8741.

Generalizes `adjustForPrecisionLoss` (`gas/utils.ts`) so a fee token with fewer decimals than the remote native token (e.g. a 6-decimal ERC20 paying an 18-decimal chain) no longer underflows the scaled exchange rate to the floor of 1. Magnitude is shifted from the gas price into the exchange rate, preserving their product (and thus the quote). Same-decimal native pairs are unaffected.

Fully standalone — no dependency on the rest of the stack.

## Stack
1. **this** — exchange-rate rebalance
2. legacy IGP support
3. token-denominated IGP fees (SDK)
4. token-denominated IGP fees (infra + agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)