### PR TITLE
feat: support legacy IGP config

### DIFF
--- a/.changeset/legacy-igp-config.md
+++ b/.changeset/legacy-igp-config.md
@@ -3,3 +3,5 @@
 ---
 
 The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments. An `igpVersion` switch (`legacy`/`latest`) was added to the IGP hook config and a `deployQuotedCalls` switch to the core config; legacy IGP deploy paths are kept recover-only by requiring cached `proxyAdmin`, `storageGasOracle`, and `interchainGasPaymaster` addresses. `CoreConfigSchema` now rejects configs that pair a legacy IGP (`igpVersion: legacy`) with `deployQuotedCalls` left enabled, since QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient storage and must ship together on the same chains.
+
+Legacy IGP configs that include `quoteSigners` now fail fast instead of silently skipping signer updates, because legacy IGP contracts do not expose the offchain-quoting signer interface.

--- a/.changeset/legacy-igp-config.md
+++ b/.changeset/legacy-igp-config.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments.
+The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments. An `igpVersion` switch (`legacy`/`latest`) was added to the IGP hook config and a `deployQuotedCalls` switch to the core config; legacy IGP deploy paths are kept recover-only by requiring cached `proxyAdmin`, `storageGasOracle`, and `interchainGasPaymaster` addresses. `CoreConfigSchema` now rejects configs that pair a legacy IGP (`igpVersion: legacy`) with `deployQuotedCalls` left enabled, since QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient storage and must ship together on the same chains.

--- a/.changeset/legacy-igp-config.md
+++ b/.changeset/legacy-igp-config.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments.

--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -23,6 +23,7 @@ import {
 import { Address, objMap } from '@hyperlane-xyz/utils';
 
 import { getChain } from '../../registry.js';
+import { legacyIgpChains } from '../../../src/config/chain.js';
 
 import { getEdenCoreConfig } from './eden.js';
 import { getTronCoreConfig } from './tron.js';
@@ -172,6 +173,7 @@ export const core: ChainMap<CoreConfig> = objMap(
       defaultIsm,
       defaultHook,
       requiredHook,
+      ...(legacyIgpChains.includes(local) ? { deployQuotedCalls: false } : {}),
       ...owner,
     };
   },

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,4 +1,10 @@
-import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
+import {
+  ChainMap,
+  ChainName,
+  HookType,
+  IgpConfig,
+  IgpVersion,
+} from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 
 import {
@@ -6,6 +12,7 @@ import {
   getAllStorageGasOracleConfigs,
   getOverheadWithOverrides,
 } from '../../../src/config/gas-oracle.js';
+import { legacyIgpChains } from '../../../src/config/chain.js';
 
 import { getEdenIgpConfig } from './eden.js';
 import { getTronIgpConfig } from './tron.js';
@@ -61,6 +68,9 @@ export const igp: ChainMap<IgpConfig> = objMap(
 
     return {
       type: HookType.INTERCHAIN_GAS_PAYMASTER,
+      ...(legacyIgpChains.includes(local)
+        ? { igpVersion: IgpVersion.Legacy }
+        : {}),
       ...owner,
       ownerOverrides: {
         ...owner.ownerOverrides,

--- a/typescript/infra/scripts/igp/legacy-igp-config.ts
+++ b/typescript/infra/scripts/igp/legacy-igp-config.ts
@@ -1,0 +1,155 @@
+import { writeFile } from 'fs/promises';
+
+import {
+  ChainName,
+  EvmHookModule,
+  HookType,
+  IgpConfig,
+  IgpVersion,
+  extractIsmAndHookFactoryAddresses,
+} from '@hyperlane-xyz/sdk';
+import { assert, deepCopy } from '@hyperlane-xyz/utils';
+
+import { Contexts } from '../../config/contexts.js';
+import { getEnvAddresses } from '../../config/registry.js';
+import { legacyIgpChains } from '../../src/config/chain.js';
+import { Role } from '../../src/roles.js';
+import {
+  getArgs,
+  withChains,
+  withContext,
+  withOutputFile,
+} from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+function serializeTx(tx: Awaited<ReturnType<EvmHookModule['update']>>[number]) {
+  return {
+    annotation: tx.annotation,
+    chainId: tx.chainId,
+    to: tx.to,
+    data: tx.data,
+    ...(tx.value ? { value: tx.value.toString() } : {}),
+  };
+}
+
+async function main() {
+  const {
+    environment,
+    context = Contexts.Hyperlane,
+    chains,
+    execute,
+    outFile,
+  } = await withOutputFile(withChains(withContext(getArgs())))
+    .describe('execute', 'Send transactions instead of only printing calldata')
+    .boolean('execute')
+    .default('execute', false).argv;
+
+  const envConfig = getEnvironmentConfig(environment);
+  const igpConfigs = envConfig.igp;
+  const requestedChains = chains as ChainName[] | undefined;
+  const configuredLegacyChains = legacyIgpChains.filter(
+    (chain) =>
+      envConfig.supportedChainNames.includes(chain) &&
+      igpConfigs[chain]?.igpVersion === IgpVersion.Legacy,
+  );
+  const targetChains =
+    requestedChains && requestedChains.length > 0
+      ? requestedChains
+      : configuredLegacyChains;
+
+  assert(targetChains.length > 0, 'No legacy IGP chains selected');
+
+  const nonLegacyChains = targetChains.filter(
+    (chain) => igpConfigs[chain]?.igpVersion !== IgpVersion.Legacy,
+  );
+  assert(
+    nonLegacyChains.length === 0,
+    `Chains are not configured for legacy IGP: ${nonLegacyChains.join(', ')}`,
+  );
+
+  const multiProvider = await envConfig.getMultiProvider(
+    context,
+    execute ? Role.Deployer : undefined,
+    true,
+    targetChains,
+  );
+  const addresses = getEnvAddresses(environment);
+  const plans = [];
+
+  for (const chain of targetChains) {
+    const chainAddresses = addresses[chain];
+    const config = igpConfigs[chain];
+
+    assert(chainAddresses, `Missing registry addresses for ${chain}`);
+    assert(config, `Missing IGP config for ${chain}`);
+    assert(
+      config.type === HookType.INTERCHAIN_GAS_PAYMASTER,
+      `Expected IGP hook config for ${chain}`,
+    );
+    assert(
+      chainAddresses.interchainGasPaymaster,
+      `Missing interchainGasPaymaster address for ${chain}`,
+    );
+    assert(chainAddresses.mailbox, `Missing mailbox address for ${chain}`);
+    assert(
+      chainAddresses.proxyAdmin,
+      `Missing proxyAdmin address for ${chain}`,
+    );
+
+    const targetConfig: IgpConfig = {
+      ...config,
+      owner: config.ownerOverrides?.interchainGasPaymaster ?? config.owner,
+    };
+    const module = new EvmHookModule(multiProvider, {
+      chain,
+      config: targetConfig,
+      addresses: {
+        ...extractIsmAndHookFactoryAddresses(chainAddresses),
+        mailbox: chainAddresses.mailbox,
+        proxyAdmin: chainAddresses.proxyAdmin,
+        deployedHook: chainAddresses.interchainGasPaymaster,
+      },
+    });
+    const transactions = await module.update(deepCopy(targetConfig));
+    const executed = [];
+
+    if (execute) {
+      for (const transaction of transactions) {
+        const receipt = await multiProvider.sendTransaction(chain, transaction);
+        executed.push(receipt.transactionHash);
+      }
+    }
+
+    plans.push({
+      chain,
+      interchainGasPaymaster: chainAddresses.interchainGasPaymaster,
+      transactionCount: transactions.length,
+      transactions: transactions.map(serializeTx),
+      ...(execute ? { executed } : {}),
+    });
+  }
+
+  const output = JSON.stringify(
+    {
+      environment,
+      context,
+      mode: execute ? 'execute' : 'dry-run',
+      plans,
+    },
+    null,
+    2,
+  );
+
+  if (outFile) {
+    await writeFile(outFile, output);
+  }
+
+  console.info(output);
+}
+
+main()
+  .then()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -62,6 +62,8 @@ export function getDisabledChains(): ChainName[] {
 
 // Chains that should keep the legacy IGP path. Deploy flows should recover
 // existing IGP deployments and skip latest-only contracts on these chains.
+// Disabled chains are included so operations never try to auto-heal them from
+// legacy recover-only deployments to latest IGP deployments while disabled.
 export const legacyIgpChains: ChainName[] = Array.from(
   new Set([
     'chilizmainnet',

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -60,6 +60,24 @@ export function getDisabledChains(): ChainName[] {
     .map(([name]) => name);
 }
 
+// Chains that should keep the legacy IGP path. Deploy flows should recover
+// existing IGP deployments and skip latest-only contracts on these chains.
+export const legacyIgpChains: ChainName[] = Array.from(
+  new Set([
+    'chilizmainnet',
+    'coti',
+    'electroneum',
+    'incentiv',
+    'metis',
+    'prom',
+    'pulsechain',
+    'taiko',
+    'torus',
+    'viction',
+    ...getDisabledChains(),
+  ]),
+);
+
 // A list of chains to skip during deploy, check-deploy and ICA operations.
 // Used by scripts like check-owner-ica.ts to exclude chains that are temporarily
 // unsupported (e.g. zksync, zeronetwork) or have known issues

--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -190,6 +190,16 @@ describe('EvmCoreModule', async () => {
       expect(eqAddress(await qc.PERMIT2(), customPermit2)).to.be.true;
     });
 
+    it('should skip quotedCalls when disabled', async () => {
+      const module = await EvmCoreModule.create({
+        chain: CHAIN,
+        config: { ...config, deployQuotedCalls: false },
+        multiProvider,
+      });
+
+      expect(module.serialize().quotedCalls).to.be.undefined;
+    });
+
     it('should deploy testRecipient', async () => {
       expect(evmCoreModule.serialize().testRecipient).to.exist;
       expect(await testRecipientContract.owner()).to.equal(signer.address);
@@ -255,6 +265,24 @@ describe('EvmCoreModule', async () => {
       const updateTxs = await evmCoreModuleInstance.update(existingConfig);
 
       expect(updateTxs.length).to.equal(0);
+    });
+
+    it('should not auto-deploy missing quotedCalls when disabled', async () => {
+      const { quotedCalls: _, ...addresses } = evmCoreModule.serialize();
+      const evmCoreModuleInstance = new EvmCoreModule(multiProvider, {
+        chain: CHAIN,
+        config: { ...config, deployQuotedCalls: false },
+        addresses,
+      });
+
+      const existingConfig: CoreConfig = await evmCoreModuleInstance.read();
+      const updateTxs = await evmCoreModuleInstance.update({
+        ...existingConfig,
+        deployQuotedCalls: false,
+      });
+
+      expect(updateTxs.length).to.equal(0);
+      expect(evmCoreModuleInstance.serialize().quotedCalls).to.be.undefined;
     });
 
     it('should update a mutable Ism', async () => {

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -493,7 +493,7 @@ export class EvmCoreModule extends HyperlaneModule<
       mailbox: mailbox.address,
       interchainAccountRouter,
       validatorAnnounce,
-      ...(quotedCalls ? { quotedCalls } : {}),
+      quotedCalls,
       timelockController,
       testRecipient,
       merkleTreeHook,

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -27,6 +27,7 @@ import {
   CoreConfigSchema,
   DeployedCoreAddresses,
   DerivedCoreConfig,
+  shouldDeployQuotedCalls,
 } from '../core/types.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import {
@@ -116,8 +117,11 @@ export class EvmCoreModule extends HyperlaneModule<
   ): Promise<AnnotatedEV5Transaction[]> {
     CoreConfigSchema.parse(expectedConfig);
 
-    // Deploy QuotedCalls if not yet present
-    if (!this.args.addresses.quotedCalls) {
+    // Deploy QuotedCalls if not yet present and enabled for this chain.
+    if (
+      shouldDeployQuotedCalls(expectedConfig) &&
+      !this.args.addresses.quotedCalls
+    ) {
       const ismFactory = new HyperlaneIsmFactory(
         attachContractsMap(
           { [this.chainName]: this.args.addresses },
@@ -435,10 +439,10 @@ export class EvmCoreModule extends HyperlaneModule<
       await coreDeployer.deployValidatorAnnounce(chainName, mailbox.address)
     ).address;
 
-    // Deploy QuotedCalls
-    const quotedCalls = (
-      await coreDeployer.deployQuotedCalls(chainName, config.permit2)
-    ).address;
+    const quotedCalls = shouldDeployQuotedCalls(config)
+      ? (await coreDeployer.deployQuotedCalls(chainName, config.permit2))
+          .address
+      : undefined;
 
     // Deploy timelock controller if config.upgrade is set
     let timelockController;
@@ -489,7 +493,7 @@ export class EvmCoreModule extends HyperlaneModule<
       mailbox: mailbox.address,
       interchainAccountRouter,
       validatorAnnounce,
-      quotedCalls,
+      ...(quotedCalls ? { quotedCalls } : {}),
       timelockController,
       testRecipient,
       merkleTreeHook,

--- a/typescript/sdk/src/core/EvmCoreReader.ts
+++ b/typescript/sdk/src/core/EvmCoreReader.ts
@@ -11,6 +11,7 @@ import {
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { proxyAdmin } from '../deploy/proxy.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
+import { hookTreeContainsLegacyIgp } from '../hook/utils.js';
 import { EvmIcaRouterReader } from '../ica/EvmIcaReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -95,7 +96,15 @@ export class EvmCoreReader implements CoreReader {
       ),
     );
 
-    return results as DerivedCoreConfig;
+    const derivedConfig = results as DerivedCoreConfig;
+    const hasLegacyIgp =
+      hookTreeContainsLegacyIgp(derivedConfig.defaultHook) ||
+      hookTreeContainsLegacyIgp(derivedConfig.requiredHook);
+
+    return {
+      ...derivedConfig,
+      ...(hasLegacyIgp ? { deployQuotedCalls: false } : {}),
+    };
   }
 
   private async getProxyAdminConfig(

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -332,7 +332,7 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
 
     return {
       ...ownableContracts,
-      ...(quotedCalls ? { quotedCalls } : {}),
+      quotedCalls,
     };
   }
 }

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -3,6 +3,7 @@ import {
   IPostDispatchHook__factory,
   Mailbox,
   QuotedCalls,
+  QuotedCalls__factory,
   TestRecipient,
   ValidatorAnnounce,
 } from '@hyperlane-xyz/core';
@@ -32,7 +33,7 @@ import {
   PERMIT2_ADDRESS,
   coreFactories,
 } from './contracts.js';
-import { CoreConfig } from './types.js';
+import { CoreConfig, shouldDeployQuotedCalls } from './types.js';
 
 export class HyperlaneCoreDeployer extends HyperlaneDeployer<
   CoreConfig,
@@ -259,9 +260,16 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
     chain: ChainName,
     permit2?: Address,
   ): Promise<QuotedCalls> {
-    return this.deployContract(chain, 'quotedCalls', [
-      permit2 ?? PERMIT2_ADDRESS,
-    ]);
+    const quotedCalls = await this.deployContractFromFactory(
+      chain,
+      new QuotedCalls__factory(),
+      'quotedCalls',
+      [permit2 ?? PERMIT2_ADDRESS],
+      undefined,
+      true,
+    );
+    this.writeCache(chain, 'quotedCalls', quotedCalls.address);
+    return quotedCalls;
   }
 
   async deployTestRecipient(
@@ -293,7 +301,9 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox.address,
     );
 
-    const quotedCalls = await this.deployQuotedCalls(chain, config.permit2);
+    const quotedCalls = shouldDeployQuotedCalls(config)
+      ? await this.deployQuotedCalls(chain, config.permit2)
+      : undefined;
 
     if (config.upgrade) {
       const timelockController = await this.deployTimelock(
@@ -322,7 +332,7 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
 
     return {
       ...ownableContracts,
-      quotedCalls,
+      ...(quotedCalls ? { quotedCalls } : {}),
     };
   }
 }

--- a/typescript/sdk/src/core/contracts.ts
+++ b/typescript/sdk/src/core/contracts.ts
@@ -10,10 +10,16 @@ import { HyperlaneAddresses } from '../contracts/types.js';
 // Canonical Permit2 deployment address (same on all EVM chains)
 export const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
 
-export const coreFactories = {
+const requiredCoreFactories = {
   validatorAnnounce: new ValidatorAnnounce__factory(),
   proxyAdmin: new ProxyAdmin__factory(),
   mailbox: new Mailbox__factory(),
+};
+
+export const coreFactories: typeof requiredCoreFactories & {
+  quotedCalls?: QuotedCalls__factory;
+} = {
+  ...requiredCoreFactories,
   quotedCalls: new QuotedCalls__factory(),
 };
 

--- a/typescript/sdk/src/core/types.test.ts
+++ b/typescript/sdk/src/core/types.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+
+import { HookType, IgpVersion } from '../hook/types.js';
+
+import { CoreConfigSchema } from './types.js';
+
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+
+const igpHook = (igpVersion?: IgpVersion) => ({
+  type: HookType.INTERCHAIN_GAS_PAYMASTER,
+  owner: ADDRESS,
+  beneficiary: ADDRESS,
+  oracleKey: ADDRESS,
+  overhead: {},
+  oracleConfig: {},
+  ...(igpVersion ? { igpVersion } : {}),
+});
+
+const baseConfig = (overrides: Record<string, unknown>) => ({
+  owner: ADDRESS,
+  defaultIsm: ADDRESS,
+  defaultHook: ADDRESS,
+  requiredHook: ADDRESS,
+  ...overrides,
+});
+
+describe('CoreConfigSchema legacy IGP / QuotedCalls guard', () => {
+  it('rejects a legacy IGP hook when deployQuotedCalls is not false', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({ defaultHook: igpHook(IgpVersion.Legacy) }),
+    );
+    expect(result.success).to.be.false;
+    if (!result.success) {
+      expect(result.error.issues[0].path).to.deep.equal(['deployQuotedCalls']);
+    }
+  });
+
+  it('allows a legacy IGP hook when deployQuotedCalls is false', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({
+        defaultHook: igpHook(IgpVersion.Legacy),
+        deployQuotedCalls: false,
+      }),
+    );
+    expect(result.success).to.be.true;
+  });
+
+  it('allows a latest IGP hook with QuotedCalls deploying', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({ defaultHook: igpHook(IgpVersion.Latest) }),
+    );
+    expect(result.success).to.be.true;
+  });
+
+  it('detects a legacy IGP nested inside an aggregation hook', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({
+        requiredHook: {
+          type: HookType.AGGREGATION,
+          hooks: [{ type: HookType.MERKLE_TREE }, igpHook(IgpVersion.Legacy)],
+        },
+      }),
+    );
+    expect(result.success).to.be.false;
+  });
+});

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -27,6 +27,8 @@ const CoreConfigBaseSchema = OwnableSchema.extend({
   interchainAccountRouter: IcaRouterConfigSchema.optional(),
   // Override canonical Permit2 address for QuotedCalls deployment
   permit2: z.string().optional(),
+  // Set false for chains that should keep legacy core artifacts only.
+  deployQuotedCalls: z.boolean().optional(),
 });
 
 const rejectRateLimitedDefaultIsm = (
@@ -71,6 +73,12 @@ export type CoreConfig = z.infer<typeof CoreConfigSchema> & {
   remove?: boolean;
   upgrade?: UpgradeConfig;
 };
+
+export function shouldDeployQuotedCalls(
+  config: Pick<CoreConfig, 'deployQuotedCalls'>,
+): boolean {
+  return config.deployQuotedCalls !== false;
+}
 
 export type CoreConfigHookFieldKey = keyof Pick<
   CoreConfig,

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -6,7 +6,12 @@ import type { Address, ParsedMessage } from '@hyperlane-xyz/utils';
 import type { UpgradeConfig } from '../deploy/proxy.js';
 import type { CheckerViolation } from '../deploy/types.js';
 import { ProxyFactoryFactoriesSchema } from '../deploy/types.js';
-import { DerivedHookConfig, HookConfigSchema } from '../hook/types.js';
+import {
+  DerivedHookConfig,
+  HookConfigSchema,
+  HookType,
+  IgpVersion,
+} from '../hook/types.js';
 import {
   DerivedIcaRouterConfigSchema,
   IcaRouterConfigSchema,
@@ -44,15 +49,75 @@ const rejectRateLimitedDefaultIsm = (
   }
 };
 
-export const CoreConfigSchema = CoreConfigBaseSchema.superRefine(
-  rejectRateLimitedDefaultIsm,
-);
+// Recursively checks a hook config tree for a legacy IGP (igpVersion: legacy).
+function hookTreeContainsLegacyIgp(hook: unknown): boolean {
+  if (typeof hook !== 'object' || hook === null) return false;
+  const node = hook as Record<string, unknown>;
+  if (
+    node.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
+    node.igpVersion === IgpVersion.Legacy
+  ) {
+    return true;
+  }
+  if (Array.isArray(node.hooks) && node.hooks.some(hookTreeContainsLegacyIgp)) {
+    return true;
+  }
+  if (
+    node.domains !== null &&
+    typeof node.domains === 'object' &&
+    Object.values(node.domains as Record<string, unknown>).some(
+      hookTreeContainsLegacyIgp,
+    )
+  ) {
+    return true;
+  }
+  return (
+    hookTreeContainsLegacyIgp(node.fallback) ||
+    hookTreeContainsLegacyIgp(node.lowerHook) ||
+    hookTreeContainsLegacyIgp(node.upperHook) ||
+    hookTreeContainsLegacyIgp(node.childHook)
+  );
+}
+
+// QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient
+// storage, so they ship together on the same (non-legacy) chains. Reject the
+// mismatch where a legacy IGP is configured but QuotedCalls is still set to
+// deploy (deployQuotedCalls !== false).
+const rejectQuotedCallsWithLegacyIgp = (
+  val: {
+    defaultHook: unknown;
+    requiredHook: unknown;
+    deployQuotedCalls?: boolean;
+  },
+  ctx: z.RefinementCtx,
+) => {
+  if (val.deployQuotedCalls === false) return;
+  if (
+    hookTreeContainsLegacyIgp(val.defaultHook) ||
+    hookTreeContainsLegacyIgp(val.requiredHook)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'deployQuotedCalls must be false when a legacy IGP (igpVersion: legacy) is configured: QuotedCalls requires EIP-1153 transient storage and pairs with the new offchain-quoting IGP.',
+      path: ['deployQuotedCalls'],
+    });
+  }
+};
+
+export const CoreConfigSchema = CoreConfigBaseSchema.superRefine((val, ctx) => {
+  rejectRateLimitedDefaultIsm(val, ctx);
+  rejectQuotedCallsWithLegacyIgp(val, ctx);
+});
 
 export const DerivedCoreConfigSchema = CoreConfigBaseSchema.merge(
   z.object({
     interchainAccountRouter: DerivedIcaRouterConfigSchema.optional(),
   }),
-).superRefine(rejectRateLimitedDefaultIsm);
+).superRefine((val, ctx) => {
+  rejectRateLimitedDefaultIsm(val, ctx);
+  rejectQuotedCallsWithLegacyIgp(val, ctx);
+});
 
 export const DeployedCoreAddressesSchema = ProxyFactoryFactoriesSchema.extend({
   mailbox: z.string(),

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -6,11 +6,8 @@ import type { Address, ParsedMessage } from '@hyperlane-xyz/utils';
 import type { UpgradeConfig } from '../deploy/proxy.js';
 import type { CheckerViolation } from '../deploy/types.js';
 import { ProxyFactoryFactoriesSchema } from '../deploy/types.js';
-import {
-  DerivedHookConfig,
-  HookConfig,
-  HookConfigSchema,
-} from '../hook/types.js';
+import type { DerivedHookConfig, HookConfig } from '../hook/types.js';
+import { HookConfigSchema } from '../hook/types.js';
 import { hookTreeContainsLegacyIgp } from '../hook/utils.js';
 import {
   DerivedIcaRouterConfigSchema,
@@ -55,16 +52,16 @@ const rejectRateLimitedDefaultIsm = (
 // deploy (deployQuotedCalls !== false).
 const rejectQuotedCallsWithLegacyIgp = (
   val: {
-    defaultHook: unknown;
-    requiredHook: unknown;
+    defaultHook: HookConfig;
+    requiredHook: HookConfig;
     deployQuotedCalls?: boolean;
   },
   ctx: z.RefinementCtx,
 ) => {
   if (val.deployQuotedCalls === false) return;
   if (
-    hookTreeContainsLegacyIgp(val.defaultHook as HookConfig) ||
-    hookTreeContainsLegacyIgp(val.requiredHook as HookConfig)
+    hookTreeContainsLegacyIgp(val.defaultHook) ||
+    hookTreeContainsLegacyIgp(val.requiredHook)
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -8,10 +8,10 @@ import type { CheckerViolation } from '../deploy/types.js';
 import { ProxyFactoryFactoriesSchema } from '../deploy/types.js';
 import {
   DerivedHookConfig,
+  HookConfig,
   HookConfigSchema,
-  HookType,
-  IgpVersion,
 } from '../hook/types.js';
+import { hookTreeContainsLegacyIgp } from '../hook/utils.js';
 import {
   DerivedIcaRouterConfigSchema,
   IcaRouterConfigSchema,
@@ -49,36 +49,6 @@ const rejectRateLimitedDefaultIsm = (
   }
 };
 
-// Recursively checks a hook config tree for a legacy IGP (igpVersion: legacy).
-function hookTreeContainsLegacyIgp(hook: unknown): boolean {
-  if (typeof hook !== 'object' || hook === null) return false;
-  const node = hook as Record<string, unknown>;
-  if (
-    node.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
-    node.igpVersion === IgpVersion.Legacy
-  ) {
-    return true;
-  }
-  if (Array.isArray(node.hooks) && node.hooks.some(hookTreeContainsLegacyIgp)) {
-    return true;
-  }
-  if (
-    node.domains !== null &&
-    typeof node.domains === 'object' &&
-    Object.values(node.domains as Record<string, unknown>).some(
-      hookTreeContainsLegacyIgp,
-    )
-  ) {
-    return true;
-  }
-  return (
-    hookTreeContainsLegacyIgp(node.fallback) ||
-    hookTreeContainsLegacyIgp(node.lowerHook) ||
-    hookTreeContainsLegacyIgp(node.upperHook) ||
-    hookTreeContainsLegacyIgp(node.childHook)
-  );
-}
-
 // QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient
 // storage, so they ship together on the same (non-legacy) chains. Reject the
 // mismatch where a legacy IGP is configured but QuotedCalls is still set to
@@ -93,8 +63,8 @@ const rejectQuotedCallsWithLegacyIgp = (
 ) => {
   if (val.deployQuotedCalls === false) return;
   if (
-    hookTreeContainsLegacyIgp(val.defaultHook) ||
-    hookTreeContainsLegacyIgp(val.requiredHook)
+    hookTreeContainsLegacyIgp(val.defaultHook as HookConfig) ||
+    hookTreeContainsLegacyIgp(val.requiredHook as HookConfig)
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -7,6 +7,7 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   addBufferToGasLimit,
+  assert,
   eqAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -16,6 +17,7 @@ import { HyperlaneContracts } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { submitBatched } from '../deploy/utils.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
+import { IgpVersion } from '../hook/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -42,12 +44,41 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     });
   }
 
+  protected assertLegacyIgpConfig(chain: ChainName, config: IgpConfig): void {
+    if (config.igpVersion !== IgpVersion.Legacy) return;
+
+    assert(
+      !config.quoteSigners?.length,
+      'Legacy IGP on ' + chain + ' does not support quoteSigners',
+    );
+
+    const cachedAddresses = this.cachedAddresses[chain] ?? {};
+    const requiredCachedContracts: Array<keyof IgpFactories> = [
+      'interchainGasPaymaster',
+      'proxyAdmin',
+      'storageGasOracle',
+    ];
+    const missing = requiredCachedContracts.filter(
+      (contractName) => !cachedAddresses[contractName],
+    );
+
+    assert(
+      missing.length === 0,
+      'Legacy IGP on ' +
+        chain +
+        ' requires existing cached addresses for ' +
+        missing.join(', '),
+    );
+  }
+
   async deployInterchainGasPaymaster(
     chain: ChainName,
     proxyAdmin: ProxyAdmin,
     storageGasOracle: StorageGasOracle,
     config: IgpConfig,
   ): Promise<InterchainGasPaymaster> {
+    this.assertLegacyIgpConfig(chain, config);
+
     const igp = await this.deployProxiedContract(
       chain,
       'interchainGasPaymaster',
@@ -129,6 +160,8 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     chain: ChainName,
     config: IgpConfig,
   ): Promise<StorageGasOracle> {
+    this.assertLegacyIgpConfig(chain, config);
+
     const gasOracle = await this.deployContract(chain, 'storageGasOracle', []);
 
     if (!config.oracleConfig) {
@@ -213,6 +246,8 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     chain: ChainName,
     config: IgpConfig,
   ): Promise<HyperlaneContracts<IgpFactories>> {
+    this.assertLegacyIgpConfig(chain, config);
+
     // NB: To share ProxyAdmins with HyperlaneCore, ensure the ProxyAdmin
     // is loaded into the contract cache.
     const proxyAdmin = await this.deployContract(chain, 'proxyAdmin', []);

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -49,7 +49,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
     assert(
       !config.quoteSigners?.length,
-      'Legacy IGP on ' + chain + ' does not support quoteSigners',
+      `Legacy IGP on ${chain} does not support quoteSigners`,
     );
 
     const cachedAddresses = this.cachedAddresses[chain] ?? {};
@@ -64,10 +64,9 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
     assert(
       missing.length === 0,
-      'Legacy IGP on ' +
-        chain +
-        ' requires existing cached addresses for ' +
-        missing.join(', '),
+      `Legacy IGP on ${chain} requires existing cached addresses for ${missing.join(
+        ', ',
+      )}`,
     );
   }
 

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -39,6 +39,7 @@ import {
   HookConfig,
   HookType,
   IgpHookConfig,
+  IgpVersion,
   MUTABLE_HOOK_TYPE,
   PausableHookConfig,
   ProtocolFeeHookConfig,
@@ -670,6 +671,40 @@ describe('EvmHookModule', async () => {
       await expectTxsAndUpdate(hook, config, 1);
     });
 
+    it('should not update IGP only because igpVersion is legacy', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      const { hook } = await createHook(config);
+
+      await expectTxsAndUpdate(
+        hook,
+        { ...config, igpVersion: IgpVersion.Legacy },
+        0,
+      );
+    });
+
+    it('should not update routing hooks only because nested IGP is legacy', async () => {
+      const igpConfig = await createDeployerOwnedIgpHookConfig();
+      const config: FallbackRoutingHookConfig = {
+        owner: await multiProvider.getSignerAddress(chain),
+        domains: {
+          [TestChainName.test1]: {
+            type: HookType.AGGREGATION,
+            hooks: [{ type: HookType.MERKLE_TREE }, igpConfig],
+          },
+        },
+        type: HookType.FALLBACK_ROUTING,
+        fallback: { type: HookType.MERKLE_TREE },
+      };
+      const { hook } = await createHook(config);
+      const legacyConfig = deepCopy(config);
+      (
+        (legacyConfig.domains[TestChainName.test1] as AggregationHookConfig)
+          .hooks[1] as IgpHookConfig
+      ).igpVersion = IgpVersion.Legacy;
+
+      await expectTxsAndUpdate(hook, legacyConfig, 0);
+    });
+
     it('should add quote signers to IGP', async () => {
       const config = await createDeployerOwnedIgpHookConfig();
       config.contractVersion = CONTRACTS_PACKAGE_VERSION;
@@ -737,6 +772,26 @@ describe('EvmHookModule', async () => {
 
       // expect 0 txs since omitting quoteSigners means "don't change"
       await expectTxsAndUpdate(hook, config, 0);
+    });
+
+    it('should reject quote signers for legacy IGP configs', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      const { hook } = await createHook(config);
+      const legacyTarget = {
+        ...config,
+        igpVersion: IgpVersion.Legacy,
+        quoteSigners: [randomAddress()],
+      };
+
+      try {
+        await hook.update(legacyTarget);
+        throw new Error('Expected legacy IGP quote signer update to fail');
+      } catch (error: unknown) {
+        assert(error instanceof Error, 'Expected Error');
+        expect(error.message).to.include(
+          'IGP quoteSigners require contract version >= 11.3.0',
+        );
+      }
     });
 
     it('should not upgrade IGP when contractVersion is not in config', async () => {

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -89,7 +89,9 @@ import {
   HookType,
   HookTypeToContractNameMap,
   IgpHookConfig,
+  IgpVersion,
   MUTABLE_HOOK_TYPE,
+  OFFCHAIN_QUOTED_IGP_VERSION,
   OpStackHookConfig,
   PausableHookConfig,
   ProtocolFeeHookConfig,
@@ -110,6 +112,28 @@ class HookDeployer extends HyperlaneDeployer<{}, HookFactories> {
   deployContracts(_chain: ChainName, _config: {}): Promise<any> {
     throw new Error('Method not implemented.');
   }
+}
+
+function stripIgpVersion(config: unknown): unknown {
+  if (Array.isArray(config)) {
+    return config.map(stripIgpVersion);
+  }
+
+  if (config !== null && typeof config === 'object') {
+    const stripped: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      if (key !== 'igpVersion') {
+        stripped[key] = stripIgpVersion(value);
+      }
+    }
+    return stripped;
+  }
+
+  return config;
+}
+
+function hookConfigsEqual(a: unknown, b: unknown): boolean {
+  return deepEquals(stripIgpVersion(a), stripIgpVersion(b));
 }
 
 export class EvmHookModule extends HyperlaneModule<
@@ -183,7 +207,7 @@ export class EvmHookModule extends HyperlaneModule<
     );
 
     // If configs match, no updates needed
-    if (deepEquals(normalizedCurrentConfig, normalizedTargetConfig)) {
+    if (hookConfigsEqual(normalizedCurrentConfig, normalizedTargetConfig)) {
       return [];
     }
 
@@ -282,7 +306,7 @@ export class EvmHookModule extends HyperlaneModule<
 
       // If the domain is not in the current config or the config has changed, deploy a new hook
       // TODO: in-place updates per domain as a future optimization
-      if (!deepEquals(currentDomains[dest], targetDomainConfig)) {
+      if (!hookConfigsEqual(currentDomains[dest], targetDomainConfig)) {
         const domainHook = await this.deploy({
           config: targetDomainConfig,
         });
@@ -443,6 +467,12 @@ export class EvmHookModule extends HyperlaneModule<
     const igpAddress = this.args.addresses.deployedHook;
     const igpInterface = InterchainGasPaymaster__factory.createInterface();
     const provider = this.multiProvider.getProvider(this.domainId);
+    const currentVersion = await PackageVersioned__factory.connect(
+      igpAddress,
+      provider,
+    )
+      .PACKAGE_VERSION()
+      .catch(() => undefined);
 
     // Upgrade IGP proxy implementation only if contractVersion is specified in config
     if (targetConfig.contractVersion && (await isProxy(provider, igpAddress))) {
@@ -451,12 +481,6 @@ export class EvmHookModule extends HyperlaneModule<
         VERSION_ERROR_MESSAGE,
       );
 
-      const currentVersion = await PackageVersioned__factory.connect(
-        igpAddress,
-        provider,
-      )
-        .PACKAGE_VERSION()
-        .catch(() => undefined);
       if (
         !currentVersion ||
         compareVersions(targetConfig.contractVersion, currentVersion) > 0
@@ -520,6 +544,11 @@ export class EvmHookModule extends HyperlaneModule<
         })),
       );
     } else {
+      assert(
+        targetConfig.igpVersion !== IgpVersion.Legacy,
+        'Legacy IGP updates require an existing gas oracle configuration',
+      );
+
       const newGasOracle = await this.deployStorageGasOracle({
         config: targetConfig,
       });
@@ -539,10 +568,19 @@ export class EvmHookModule extends HyperlaneModule<
 
     // update quote signers only if explicitly specified in target config
     // and IGP supports them (detected from on-chain read or version upgrade)
+    const quoteSignerVersion =
+      targetConfig.contractVersion ?? currentVersion ?? undefined;
     const supportsQuoteSigners =
-      currentConfig.quoteSigners !== undefined ||
-      targetConfig.contractVersion != null;
-    if (targetConfig.quoteSigners !== undefined && supportsQuoteSigners) {
+      targetConfig.igpVersion !== IgpVersion.Legacy &&
+      (currentConfig.quoteSigners !== undefined ||
+        (quoteSignerVersion !== undefined &&
+          compareVersions(quoteSignerVersion, OFFCHAIN_QUOTED_IGP_VERSION) >=
+            0));
+    if (targetConfig.quoteSigners !== undefined) {
+      assert(
+        supportsQuoteSigners,
+        `IGP quoteSigners require contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+      );
       updateTxs.push(
         ...this.updateIgpQuoteSigners({
           currentSigners: currentConfig.quoteSigners ?? [],
@@ -770,7 +808,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Deploy a new fallback hook if the fallback config has changed
     if (
       targetConfig.type === HookType.FALLBACK_ROUTING &&
-      !deepEquals(
+      !hookConfigsEqual(
         targetConfig.fallback,
         (currentConfig as FallbackRoutingHookConfig).fallback,
       )
@@ -1224,6 +1262,11 @@ export class EvmHookModule extends HyperlaneModule<
   }: {
     config: IgpHookConfig;
   }): Promise<InterchainGasPaymaster> {
+    assert(
+      config.igpVersion !== IgpVersion.Legacy,
+      'Legacy IGP configs require an existing deployment and cannot deploy a new IGP',
+    );
+
     this.logger.debug('Deploying IGP as hook...');
 
     // Deploy the StorageGasOracle

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -301,6 +301,29 @@ describe('EvmHookReader', () => {
     expect(thrown).to.equal(transientError);
   });
 
+  it('should not stamp IGP as legacy on empty provider responses', async () => {
+    const mockAddress = randomAddress();
+    const emptyProviderResponse = new Error('Invalid response from provider');
+
+    sandbox.stub(InterchainGasPaymaster__factory, 'connect').returns({
+      hookType: sandbox
+        .stub()
+        .resolves(OnchainHookType.INTERCHAIN_GAS_PAYMASTER),
+      owner: sandbox.stub().resolves(randomAddress()),
+      beneficiary: sandbox.stub().resolves(randomAddress()),
+      quoteSigners: sandbox.stub().rejects(emptyProviderResponse),
+    } as unknown as InterchainGasPaymaster);
+
+    let thrown: unknown;
+    try {
+      await evmHookReader.deriveIgpConfig(mockAddress);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(emptyProviderResponse);
+  });
+
   it('should still derive IGP config when a domain is unsupported', async () => {
     const mockAddress = randomAddress();
     const owner = randomAddress();

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -34,6 +34,7 @@ import { EvmHookReader } from './EvmHookReader.js';
 import {
   CCIPHookConfig,
   HookType,
+  IgpVersion,
   MailboxDefaultHookConfig,
   MerkleTreeHookConfig,
   OnchainHookType,
@@ -328,6 +329,7 @@ describe('EvmHookReader', () => {
       address: mockAddress,
       type: HookType.INTERCHAIN_GAS_PAYMASTER,
       beneficiary,
+      igpVersion: IgpVersion.Legacy,
       oracleKey: owner,
       overhead: {},
       oracleConfig: {},

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -40,6 +40,7 @@ import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 import {
   isMissingSelectorCallException,
   throwIfNotMissingSelector,
+  throwIfNotMissingSelectorRevert,
 } from '../utils/contract.js';
 
 import {
@@ -484,7 +485,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           .quoteSigners()
           .then((quoteSigners) => ({ quoteSigners, igpVersion: undefined }))
           .catch((error) => {
-            throwIfNotMissingSelector(error);
+            throwIfNotMissingSelectorRevert(error);
             this.logger.debug(
               'quoteSigners() not available on this IGP version, skipping',
             );

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -52,6 +52,7 @@ import {
   FallbackRoutingHookConfig,
   HookConfig,
   HookType,
+  IgpVersion,
   IgpHookConfig,
   MailboxDefaultHookConfig,
   MerkleTreeHookConfig,
@@ -473,19 +474,26 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
     );
 
     // Parallelize initial RPC calls
-    const [hookType, owner, beneficiary, quoteSigners] = await Promise.all([
-      hook.hookType(),
-      hook.owner(),
-      hook.beneficiary(),
-      // quoteSigners() not available on IGP versions before offchain fee quoting
-      hook.quoteSigners().catch((error) => {
-        throwIfNotMissingSelector(error);
-        this.logger.debug(
-          'quoteSigners() not available on this IGP version, skipping',
-        );
-        return [] as string[];
-      }),
-    ]);
+    const [hookType, owner, beneficiary, quoteSignersResult] =
+      await Promise.all([
+        hook.hookType(),
+        hook.owner(),
+        hook.beneficiary(),
+        // quoteSigners() not available on IGP versions before offchain fee quoting
+        hook
+          .quoteSigners()
+          .then((quoteSigners) => ({ quoteSigners, igpVersion: undefined }))
+          .catch((error) => {
+            throwIfNotMissingSelector(error);
+            this.logger.debug(
+              'quoteSigners() not available on this IGP version, skipping',
+            );
+            return {
+              quoteSigners: [] as string[],
+              igpVersion: IgpVersion.Legacy,
+            };
+          }),
+      ]);
 
     this.assertHookType(hookType, OnchainHookType.INTERCHAIN_GAS_PAYMASTER);
 
@@ -550,7 +558,12 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       oracleKey: oracleKey ?? owner,
       overhead,
       oracleConfig,
-      ...(quoteSigners.length > 0 ? { quoteSigners: [...quoteSigners] } : {}),
+      ...(quoteSignersResult.igpVersion
+        ? { igpVersion: quoteSignersResult.igpVersion }
+        : {}),
+      ...(quoteSignersResult.quoteSigners.length > 0
+        ? { quoteSigners: [...quoteSignersResult.quoteSigners] }
+        : {}),
     };
 
     this._cache.set(address, config);

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -103,7 +103,13 @@ export type IgpHookConfig = z.infer<typeof IgpSchema>;
 export type ProtocolFeeHookConfig = z.infer<typeof ProtocolFeeSchema>;
 export type PausableHookConfig = z.infer<typeof PausableHookSchema>;
 export type OpStackHookConfig = z.infer<typeof OpStackHookSchema>;
-export type ArbL2ToL1HookConfig = z.infer<typeof ArbL2ToL1HookSchema>;
+export type ArbL2ToL1HookConfig = {
+  type: typeof HookType.ARB_L2_TO_L1;
+  arbSys: string;
+  bridge?: string;
+  destinationChain: string;
+  childHook: HookConfig;
+};
 export type MailboxDefaultHookConfig = z.infer<typeof MailboxDefaultHookSchema>;
 export type RateLimitedHookConfig = z.infer<typeof RateLimitedHookSchema>;
 
@@ -182,22 +188,25 @@ export const OpStackHookSchema = OwnableSchema.extend({
   destinationChain: z.string(),
 });
 
-export const ArbL2ToL1HookSchema = z.object({
-  type: z.literal(HookType.ARB_L2_TO_L1),
-  arbSys: z
-    .string()
-    .describe(
-      'precompile for sending messages to L1, interface here: https://github.com/OffchainLabs/nitro-contracts/blob/90037b996509312ef1addb3f9352457b8a99d6a6/src/precompiles/ArbSys.sol#L12',
-    ),
-  bridge: z
-    .string()
-    .optional()
-    .describe(
-      'address of the bridge contract on L1, optional only needed for non @arbitrum/sdk chains',
-    ),
-  destinationChain: z.string(),
-  childHook: z.lazy((): z.ZodSchema => HookConfigSchema),
-});
+export const ArbL2ToL1HookSchema: z.ZodSchema<ArbL2ToL1HookConfig> = z.lazy(
+  () =>
+    z.object({
+      type: z.literal(HookType.ARB_L2_TO_L1),
+      arbSys: z
+        .string()
+        .describe(
+          'precompile for sending messages to L1, interface here: https://github.com/OffchainLabs/nitro-contracts/blob/90037b996509312ef1addb3f9352457b8a99d6a6/src/precompiles/ArbSys.sol#L12',
+        ),
+      bridge: z
+        .string()
+        .optional()
+        .describe(
+          'address of the bridge contract on L1, optional only needed for non @arbitrum/sdk chains',
+        ),
+      destinationChain: z.string(),
+      childHook: HookConfigSchema,
+    }),
+);
 
 export const IgpSchema = OwnableSchema.extend({
   type: z.literal(HookType.INTERCHAIN_GAS_PAYMASTER),

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -134,6 +134,13 @@ export type HookConfig = z.infer<typeof HookConfigSchema>;
 
 export type DerivedHookConfig = WithAddress<Exclude<HookConfig, Address>>;
 
+export enum IgpVersion {
+  Legacy = 'legacy',
+  Latest = 'latest',
+}
+
+export const OFFCHAIN_QUOTED_IGP_VERSION = '11.3.0';
+
 // Hook types that can be updated in-place
 export const MUTABLE_HOOK_TYPE: HookType[] = [
   HookType.INTERCHAIN_GAS_PAYMASTER,
@@ -198,6 +205,7 @@ export const IgpSchema = OwnableSchema.extend({
   oracleKey: z.string(),
   overhead: z.record(z.number()),
   oracleConfig: z.record(ProtocolAgnositicGasOracleConfigWithTypicalCostSchema),
+  igpVersion: z.nativeEnum(IgpVersion).optional(),
   quoteSigners: z.array(z.string()).optional(),
   contractVersion: z.string().optional(),
 });

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -60,7 +60,7 @@ function hookTreeContains(
     );
   }
   if (hook.type === HookType.ARB_L2_TO_L1) {
-    return hookTreeContains(hook.childHook as HookConfig, predicate);
+    return hookTreeContains(hook.childHook, predicate);
   }
   return false;
 }

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -5,6 +5,7 @@ import {
   DerivedHookConfig,
   HookConfig,
   HookType,
+  IgpVersion,
 } from './types.js';
 
 /**
@@ -31,33 +32,54 @@ export function stripPredicateSubHook(
   return hook;
 }
 
-export function hookTreeContainsRateLimited(
+function hookTreeContains(
   hook: HookConfig | undefined,
+  predicate: (hook: Exclude<HookConfig, string>) => boolean,
 ): boolean {
   if (!hook || typeof hook === 'string') return false;
-  if (hook.type === HookType.RATE_LIMITED) return true;
+  if (predicate(hook)) return true;
   if (hook.type === HookType.AGGREGATION) {
-    return hook.hooks.some(hookTreeContainsRateLimited);
+    return hook.hooks.some((child) => hookTreeContains(child, predicate));
   }
   if (hook.type === HookType.ROUTING) {
-    return Object.values(hook.domains).some(hookTreeContainsRateLimited);
+    return Object.values(hook.domains).some((child) =>
+      hookTreeContains(child, predicate),
+    );
   }
   if (hook.type === HookType.FALLBACK_ROUTING) {
     return (
-      Object.values(hook.domains).some(hookTreeContainsRateLimited) ||
-      hookTreeContainsRateLimited(hook.fallback)
+      Object.values(hook.domains).some((child) =>
+        hookTreeContains(child, predicate),
+      ) || hookTreeContains(hook.fallback, predicate)
     );
   }
   if (hook.type === HookType.AMOUNT_ROUTING) {
     return (
-      hookTreeContainsRateLimited(hook.lowerHook) ||
-      hookTreeContainsRateLimited(hook.upperHook)
+      hookTreeContains(hook.lowerHook, predicate) ||
+      hookTreeContains(hook.upperHook, predicate)
     );
   }
   if (hook.type === HookType.ARB_L2_TO_L1) {
-    return hookTreeContainsRateLimited(hook.childHook as HookConfig);
+    return hookTreeContains(hook.childHook as HookConfig, predicate);
   }
   return false;
+}
+
+export function hookTreeContainsRateLimited(
+  hook: HookConfig | undefined,
+): boolean {
+  return hookTreeContains(hook, (node) => node.type === HookType.RATE_LIMITED);
+}
+
+export function hookTreeContainsLegacyIgp(
+  hook: HookConfig | undefined,
+): boolean {
+  return hookTreeContains(
+    hook,
+    (node) =>
+      node.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
+      node.igpVersion === IgpVersion.Legacy,
+  );
 }
 
 export const isHookCompatible = ({

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -147,6 +147,7 @@ export {
   MailboxMultisigIsmViolation,
   MailboxViolation,
   MailboxViolationType,
+  shouldDeployQuotedCalls,
   ValidatorAnnounceViolation,
 } from './core/types.js';
 export { HyperlaneAppChecker } from './deploy/HyperlaneAppChecker.js';
@@ -250,9 +251,11 @@ export {
   HookType,
   IgpHookConfig,
   IgpSchema,
+  IgpVersion,
   MerkleTreeHookConfig,
   MerkleTreeSchema,
   normalizeUnknownHookTypes,
+  OFFCHAIN_QUOTED_IGP_VERSION,
   OpStackHookConfig,
   OpStackHookSchema,
   PausableHookConfig,

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -240,6 +240,9 @@ export function randomHookConfig(
         arbSys: randomAddress(),
         bridge: randomAddress(),
         destinationChain: 'testChain',
+        childHook: {
+          type: HookType.MERKLE_TREE,
+        },
       };
 
     case HookType.ROUTING:

--- a/typescript/sdk/src/utils/contract.test.ts
+++ b/typescript/sdk/src/utils/contract.test.ts
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 
 import { missingSelectorError, wrappedError } from '../test/errors.js';
 
-import { isMissingSelectorCallException } from './contract.js';
+import {
+  isMissingSelectorCallException,
+  isMissingSelectorRevert,
+} from './contract.js';
 
 describe('contract utils', () => {
   describe('isMissingSelectorCallException', () => {
@@ -32,6 +35,9 @@ describe('contract utils', () => {
           new Error('Invalid response from provider'),
         ),
       ).to.equal(true);
+      expect(
+        isMissingSelectorRevert(new Error('Invalid response from provider')),
+      ).to.equal(false);
     });
 
     it('matches SmartProvider-wrapped empty provider responses', () => {

--- a/typescript/sdk/src/utils/contract.ts
+++ b/typescript/sdk/src/utils/contract.ts
@@ -51,6 +51,10 @@ export function isMissingSelectorCallException(error: unknown): boolean {
   if (!isRecord(error)) return false;
   if (isEmptyProviderResponse(error)) return true;
 
+  return isMissingSelectorRevert(error);
+}
+
+export function isMissingSelectorRevert(error: unknown): boolean {
   const callException = findCallException(error);
   if (!callException) return false;
 
@@ -73,6 +77,10 @@ export function isMissingSelectorCallException(error: unknown): boolean {
 
 export function throwIfNotMissingSelector(error: unknown): void {
   if (!isMissingSelectorCallException(error)) throw error;
+}
+
+export function throwIfNotMissingSelectorRevert(error: unknown): void {
+  if (!isMissingSelectorRevert(error)) throw error;
 }
 
 export async function contractHasString(


### PR DESCRIPTION
## Summary
Stack 2/4 of #8741. **Base: #8907.**

- Added `IgpVersion` (`legacy`/`latest`) to the IGP hook config and a `deployQuotedCalls` switch to the core config.
- Kept legacy IGP deploy paths recover-only by requiring cached `proxyAdmin`, `storageGasOracle`, and `interchainGasPaymaster` addresses.
- Gated QuotedCalls deployment/auto-healing in `EvmCoreModule`/`HyperlaneCoreDeployer`.
- Marked mainnet3 long-tail legacy IGP chains; `legacy-igp-config.ts` infra helper for dry-run/execute update calldata.
- `CoreConfigSchema` rejects pairing a legacy IGP with `deployQuotedCalls` left enabled (both need EIP-1153 transient storage, must ship together).

Carries the shared `IgpVersion` / `OFFCHAIN_QUOTED_IGP_VERSION` types the upper PRs import.

## Stack
1. #8907 — exchange-rate rebalance
2. **this** — legacy IGP support
3. token-denominated IGP fees (SDK)
4. token-denominated IGP fees (infra + agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)