### PR TITLE
feat: wire setTokenGasOracles for token-based IGP fees

### DIFF
--- a/.changeset/token-igp-fees-sdk.md
+++ b/.changeset/token-igp-fees-sdk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The IGP hook config gained an optional `tokenOracleConfig` (keyed by fee token then remote chain) that wires per-fee-token gas oracles via `setTokenGasOracles` for ERC20-denominated interchain gas payments. Each fee token is backed by its own `StorageGasOracle`, oracle addresses are resolved from the on-chain `tokenGasOracles` mapping (no off-chain bookkeeping), and the path is gated behind non-legacy IGPs at contract version >= 11.3.0. The wiring was added to both the module path (`EvmHookModule`) and the deployer path (`HyperlaneIgpDeployer`, also used by `HyperlaneHookDeployer`) so infra deployments pick it up.

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -4,6 +4,7 @@ import {
   InterchainGasPaymaster,
   ProxyAdmin,
   StorageGasOracle,
+  StorageGasOracle__factory,
 } from '@hyperlane-xyz/core';
 import {
   addBufferToGasLimit,
@@ -50,6 +51,12 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     assert(
       !config.quoteSigners?.length,
       `Legacy IGP on ${chain} does not support quoteSigners`,
+    );
+
+    assert(
+      !config.tokenOracleConfig ||
+        Object.keys(config.tokenOracleConfig).length === 0,
+      'Legacy IGP on ' + chain + ' does not support tokenOracleConfig',
     );
 
     const cachedAddresses = this.cachedAddresses[chain] ?? {};
@@ -152,6 +159,8 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
       }
     }
 
+    await this.configureTokenGasOracles(chain, igp, config);
+
     return igp;
   }
 
@@ -168,11 +177,32 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
       return gasOracle;
     }
 
+    await this.configureStorageGasOracle(
+      chain,
+      gasOracle,
+      config.oracleConfig,
+      config.overhead,
+    );
+
+    return gasOracle;
+  }
+
+  /**
+   * Reconciles the remote gas data stored on a StorageGasOracle against the
+   * desired config, submitting only the drifted entries. Shared by the native
+   * oracle and per-fee-token oracles.
+   */
+  protected async configureStorageGasOracle(
+    chain: ChainName,
+    gasOracle: StorageGasOracle,
+    oracleConfig: NonNullable<IgpConfig['oracleConfig']>,
+    overhead: IgpConfig['overhead'],
+  ): Promise<void> {
     this.logger.info(`Configuring gas oracle from ${chain}...`);
     const configsToSet: Array<StorageGasOracle.RemoteGasDataConfigStruct> = [];
 
     // For each remote, check if the gas oracle has the correct data
-    for (const [remote, desired] of Object.entries(config.oracleConfig)) {
+    for (const [remote, desired] of Object.entries(oracleConfig)) {
       // TODO: add back support for non-EVM remotes.
       // Previously would check core metadata for non EVMs and fallback to multiprovider for custom EVMs
       const remoteDomain = this.multiProvider.tryGetDomainId(remote);
@@ -204,7 +234,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
         });
       }
 
-      const exampleRemoteGas = (config.overhead[remote] ?? 200_000) + 50_000;
+      const exampleRemoteGas = (overhead[remote] ?? 200_000) + 50_000;
       const exampleRemoteGasCost = desiredData.tokenExchangeRate
         .mul(desiredData.gasPrice)
         .mul(exampleRemoteGas)
@@ -237,8 +267,127 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
         );
       });
     }
+  }
 
-    return gasOracle;
+  /**
+   * Wires per-fee-token gas oracles on the IGP for ERC20-denominated gas
+   * payments. Target-driven and idempotent: each fee token's oracle is resolved
+   * from the on-chain tokenGasOracles mapping (no off-chain bookkeeping), or a
+   * dedicated StorageGasOracle is deployed if none is wired yet. Must run while
+   * the deployer still owns the IGP (setTokenGasOracles is onlyOwner) and after
+   * the native gas params, since the IGP requires a destination's native oracle
+   * to exist before a token oracle can be set for it.
+   */
+  protected async configureTokenGasOracles(
+    chain: ChainName,
+    igp: InterchainGasPaymaster,
+    config: IgpConfig,
+  ): Promise<void> {
+    if (!config.tokenOracleConfig) return;
+    this.assertLegacyIgpConfig(chain, config);
+
+    for (const [feeToken, oracleConfig] of Object.entries(
+      config.tokenOracleConfig,
+    )) {
+      const remotes = Object.keys(oracleConfig)
+        .map((remote) => ({
+          remote,
+          remoteDomain: this.multiProvider.tryGetDomainId(remote),
+        }))
+        .filter(
+          (r): r is { remote: string; remoteDomain: number } =>
+            r.remoteDomain !== null,
+        );
+
+      if (remotes.length === 0) {
+        this.logger.warn(
+          `Skipping token gas oracle for ${feeToken} on ${chain}: no configured remotes in MultiProvider`,
+        );
+        continue;
+      }
+
+      // Reuse the oracle already wired for this fee token (across any of its
+      // destinations), otherwise deploy a dedicated one.
+      let gasOracle: StorageGasOracle | undefined;
+      for (const { remoteDomain } of remotes) {
+        const existing = await igp.tokenGasOracles(feeToken, remoteDomain);
+        if (!eqAddress(existing, ethers.constants.AddressZero)) {
+          gasOracle = StorageGasOracle__factory.connect(
+            existing,
+            this.multiProvider.getSigner(chain),
+          );
+          break;
+        }
+      }
+
+      if (!gasOracle) {
+        // shouldRecover=false so we don't read back the native 'storageGasOracle'
+        // cache entry; idempotency comes from the on-chain mapping check above.
+        gasOracle = await this.deployContractFromFactory(
+          chain,
+          new StorageGasOracle__factory(),
+          'storageGasOracle',
+          [],
+          undefined,
+          false,
+        );
+      }
+
+      await this.configureStorageGasOracle(
+        chain,
+        gasOracle,
+        oracleConfig,
+        config.overhead,
+      );
+
+      // Transfer the token oracle to the configured oracle key, matching the
+      // native oracle's ownership.
+      await this.runIfOwner(chain, gasOracle, async () => {
+        const oracle = gasOracle!;
+        if (!eqAddress(await oracle.owner(), config.oracleKey)) {
+          await this.multiProvider.handleTx(
+            chain,
+            oracle.transferOwnership(
+              config.oracleKey,
+              this.multiProvider.getTransactionOverrides(chain),
+            ),
+          );
+        }
+      });
+
+      // Point any destinations not yet mapped to this oracle at it.
+      const tokenOracleParams: InterchainGasPaymaster.TokenGasOracleConfigStruct[] =
+        [];
+      for (const { remoteDomain } of remotes) {
+        const current = await igp.tokenGasOracles(feeToken, remoteDomain);
+        if (!eqAddress(current, gasOracle.address)) {
+          tokenOracleParams.push({
+            feeToken,
+            remoteDomain,
+            gasOracle: gasOracle.address,
+          });
+        }
+      }
+
+      if (tokenOracleParams.length > 0) {
+        await this.runIfOwner(chain, igp, async () => {
+          this.logger.info(
+            `Setting token gas oracles for ${feeToken} on ${chain} (domains ${tokenOracleParams
+              .map((p) => p.remoteDomain)
+              .join(', ')})`,
+          );
+          const estimatedGas =
+            await igp.estimateGas.setTokenGasOracles(tokenOracleParams);
+          await this.multiProvider.handleTx(
+            chain,
+            igp.setTokenGasOracles(tokenOracleParams, {
+              gasLimit: addBufferToGasLimit(estimatedGas),
+              ...this.multiProvider.getTransactionOverrides(chain),
+            }),
+          );
+        });
+      }
+    }
   }
 
   async deployContracts(

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -342,12 +342,15 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
       // Transfer the token oracle to the configured oracle key, matching the
       // native oracle's ownership.
+      assert(
+        gasOracle,
+        `Expected token gas oracle for ${feeToken} on ${chain}`,
+      );
       await this.runIfOwner(chain, gasOracle, async () => {
-        const oracle = gasOracle!;
-        if (!eqAddress(await oracle.owner(), config.oracleKey)) {
+        if (!eqAddress(await gasOracle.owner(), config.oracleKey)) {
           await this.multiProvider.handleTx(
             chain,
-            oracle.transferOwnership(
+            gasOracle.transferOwnership(
               config.oracleKey,
               this.multiProvider.getTransactionOverrides(chain),
             ),

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -18,7 +18,7 @@ import { HyperlaneContracts } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { submitBatched } from '../deploy/utils.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
-import { IgpVersion } from '../hook/types.js';
+import { IgpVersion, OFFCHAIN_QUOTED_IGP_VERSION } from '../hook/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -27,7 +27,11 @@ import {
   oracleConfigToOracleData,
   serializeDifference,
 } from './oracle/types.js';
-import { IgpConfig } from './types.js';
+import {
+  IgpConfig,
+  assertTokenOracleConfigHasNativeRemotes,
+  igpSupportsOffchainFeeQuoting,
+} from './types.js';
 
 export class HyperlaneIgpDeployer extends HyperlaneDeployer<
   IgpConfig,
@@ -56,7 +60,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     assert(
       !config.tokenOracleConfig ||
         Object.keys(config.tokenOracleConfig).length === 0,
-      'Legacy IGP on ' + chain + ' does not support tokenOracleConfig',
+      `Legacy IGP on ${chain} does not support tokenOracleConfig`,
     );
 
     const cachedAddresses = this.cachedAddresses[chain] ?? {};
@@ -285,6 +289,24 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
   ): Promise<void> {
     if (!config.tokenOracleConfig) return;
     this.assertLegacyIgpConfig(chain, config);
+    assertTokenOracleConfigHasNativeRemotes(chain, config);
+
+    let contractVersion: string;
+    try {
+      contractVersion = await igp.PACKAGE_VERSION();
+    } catch (error) {
+      throw new Error(
+        `IGP tokenOracleConfig on ${chain} requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+        { cause: error },
+      );
+    }
+    assert(
+      igpSupportsOffchainFeeQuoting({
+        igpVersion: config.igpVersion,
+        contractVersion,
+      }),
+      `IGP tokenOracleConfig on ${chain} requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+    );
 
     for (const [feeToken, oracleConfig] of Object.entries(
       config.tokenOracleConfig,

--- a/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
+++ b/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
@@ -1,12 +1,16 @@
 import { expect } from 'chai';
-import { utils } from 'ethers';
+import { constants, utils } from 'ethers';
 import hre from 'hardhat';
 
-import { InterchainGasPaymaster } from '@hyperlane-xyz/core';
+import {
+  InterchainGasPaymaster,
+  StorageGasOracle__factory,
+} from '@hyperlane-xyz/core';
+import { eqAddress } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
-import { testIgpConfig } from '../../test/testUtils.js';
+import { randomAddress, testIgpConfig } from '../../test/testUtils.js';
 import { ChainMap } from '../../types.js';
 import { HyperlaneIgpDeployer } from '../HyperlaneIgpDeployer.js';
 import { IgpConfig } from '../types.js';
@@ -79,5 +83,45 @@ describe('HyperlaneIgpDeployer', () => {
       modifiedConfig.tokenExchangeRate.eq(expected.tokenExchangeRate),
       `tokenExchangeRate mismatch: expected ${expected.tokenExchangeRate.toString()}, got ${modifiedConfig.tokenExchangeRate.toString()}`,
     ).to.be.true;
+  });
+
+  it('should wire a per-fee-token gas oracle via setTokenGasOracles', async () => {
+    const feeToken = randomAddress();
+    const tokenOracle = {
+      tokenExchangeRate: utils.parseUnits('5', 'gwei').toString(),
+      gasPrice: utils.parseUnits('7', 'gwei').toString(),
+      tokenDecimals: 18,
+    };
+    testConfig[local].tokenOracleConfig = {
+      [feeToken]: { [remote]: tokenOracle },
+    };
+
+    const localContracts = await deployer.deployContracts(
+      local,
+      testConfig[local],
+    );
+    igp = localContracts.interchainGasPaymaster;
+
+    // A dedicated oracle is wired for the fee token, distinct from the native one.
+    const oracleAddress = await igp.tokenGasOracles(feeToken, remoteId);
+    expect(eqAddress(oracleAddress, constants.AddressZero)).to.be.false;
+    const nativeOracle = (await igp.destinationGasConfigs(remoteId)).gasOracle;
+    expect(eqAddress(oracleAddress, nativeOracle)).to.be.false;
+
+    // The oracle returns the configured token rates.
+    const oracle = StorageGasOracle__factory.connect(
+      oracleAddress,
+      multiProvider.getProvider(local),
+    );
+    const data = await oracle.getExchangeRateAndGasPrice(remoteId);
+    const expected = oracleConfigToOracleData(tokenOracle);
+    expect(data.gasPrice.eq(expected.gasPrice)).to.be.true;
+    expect(data.tokenExchangeRate.eq(expected.tokenExchangeRate)).to.be.true;
+
+    // Re-deploying with the same config is idempotent (oracle resolved on-chain).
+    const oracleBefore = oracleAddress;
+    await deployer.deployContracts(local, testConfig[local]);
+    const oracleAfter = await igp.tokenGasOracles(feeToken, remoteId);
+    expect(eqAddress(oracleAfter, oracleBefore)).to.be.true;
   });
 });

--- a/typescript/sdk/src/gas/types.ts
+++ b/typescript/sdk/src/gas/types.ts
@@ -2,13 +2,58 @@ import { BigNumber } from 'ethers';
 import { z } from 'zod';
 
 import { InterchainGasPaymaster } from '@hyperlane-xyz/core';
+import { assert } from '@hyperlane-xyz/utils';
+import { compareVersions } from 'compare-versions';
 import type { Address } from '@hyperlane-xyz/utils';
 
 import type { CheckerViolation } from '../deploy/types.js';
-import { IgpSchema } from '../hook/types.js';
-import { ChainMap } from '../types.js';
+import {
+  IgpSchema,
+  IgpVersion,
+  OFFCHAIN_QUOTED_IGP_VERSION,
+} from '../hook/types.js';
+import { ChainMap, ChainName } from '../types.js';
 
 export type IgpConfig = z.infer<typeof IgpSchema>;
+
+export function igpSupportsOffchainFeeQuoting({
+  igpVersion,
+  contractVersion,
+  quoteSigners,
+}: {
+  igpVersion?: IgpVersion;
+  contractVersion?: string;
+  quoteSigners?: string[];
+}): boolean {
+  return (
+    igpVersion !== IgpVersion.Legacy &&
+    (quoteSigners !== undefined ||
+      (contractVersion !== undefined &&
+        compareVersions(contractVersion, OFFCHAIN_QUOTED_IGP_VERSION) >= 0))
+  );
+}
+
+export function assertTokenOracleConfigHasNativeRemotes(
+  chain: ChainName,
+  config: Pick<IgpConfig, 'overhead' | 'tokenOracleConfig'>,
+): void {
+  if (!config.tokenOracleConfig) return;
+
+  const configuredNativeRemotes = new Set(Object.keys(config.overhead));
+  for (const [feeToken, oracleConfig] of Object.entries(
+    config.tokenOracleConfig,
+  )) {
+    const missingNativeRemotes = Object.keys(oracleConfig).filter(
+      (remote) => !configuredNativeRemotes.has(remote),
+    );
+    assert(
+      missingNativeRemotes.length === 0,
+      `Token gas oracle config for ${feeToken} on ${chain} includes remotes without native gas oracle config: ${missingNativeRemotes.join(
+        ', ',
+      )}`,
+    );
+  }
+}
 
 export enum IgpViolationType {
   Beneficiary = 'Beneficiary',

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -859,6 +859,29 @@ describe('EvmHookModule', async () => {
       await expectTxsAndUpdate(hook, config, 0);
     });
 
+    it('should reject token gas oracle remotes without native gas config', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      config.contractVersion = CONTRACTS_PACKAGE_VERSION;
+      const { hook } = await createHook(config);
+
+      const target = deepCopy(config);
+      const [remoteWithoutNativeConfig] = testChains;
+      delete target.overhead[remoteWithoutNativeConfig];
+      target.tokenOracleConfig = {
+        [randomAddress()]: randomTokenOracleConfig(),
+      };
+
+      try {
+        await hook.update(target);
+        throw new Error('Expected token oracle remote validation to fail');
+      } catch (error: unknown) {
+        assert(error instanceof Error, 'Expected Error');
+        expect(error.message).to.include(
+          `includes remotes without native gas oracle config: ${remoteWithoutNativeConfig}`,
+        );
+      }
+    });
+
     it('should reject token gas oracles for legacy IGP configs', async () => {
       const config = await createDeployerOwnedIgpHookConfig();
       const { hook } = await createHook(config);

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -797,7 +797,7 @@ describe('EvmHookModule', async () => {
       }
     });
 
-    const randomTokenOracleConfig = () =>
+    const randomTokenOracleConfig = (withTypicalCost = false) =>
       Object.fromEntries(
         testChains.map((c) => [
           c,
@@ -805,6 +805,15 @@ describe('EvmHookModule', async () => {
             tokenExchangeRate: randomInt(1234567891234).toString(),
             gasPrice: randomInt(1234567891234).toString(),
             tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+            ...(withTypicalCost
+              ? {
+                  typicalCost: {
+                    handleGasAmount: 50_000,
+                    totalGasAmount: 200_000,
+                    totalUsdCost: 1,
+                  },
+                }
+              : {}),
           },
         ]),
       );
@@ -842,7 +851,7 @@ describe('EvmHookModule', async () => {
       // add a token oracle config; oracle is deployed eagerly, leaving a single
       // setTokenGasOracles tx to wire the mapping.
       config.tokenOracleConfig = {
-        [randomAddress()]: randomTokenOracleConfig(),
+        [randomAddress()]: randomTokenOracleConfig(true),
       };
       await expectTxsAndUpdate(hook, config, 1);
 

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
-import { Signer } from 'ethers';
+import { Signer, ethers } from 'ethers';
 import hre from 'hardhat';
 
-import { CONTRACTS_PACKAGE_VERSION } from '@hyperlane-xyz/core';
+import {
+  CONTRACTS_PACKAGE_VERSION,
+  InterchainGasPaymaster__factory,
+} from '@hyperlane-xyz/core';
 import {
   Address,
   WithAddress,
@@ -790,6 +793,79 @@ describe('EvmHookModule', async () => {
         assert(error instanceof Error, 'Expected Error');
         expect(error.message).to.include(
           'IGP quoteSigners require contract version >= 11.3.0',
+        );
+      }
+    });
+
+    const randomTokenOracleConfig = () =>
+      Object.fromEntries(
+        testChains.map((c) => [
+          c,
+          {
+            tokenExchangeRate: randomInt(1234567891234).toString(),
+            gasPrice: randomInt(1234567891234).toString(),
+            tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+          },
+        ]),
+      );
+
+    it('should deploy IGP with token gas oracles and wire them on-chain', async () => {
+      const feeToken = randomAddress();
+      const config = await createDeployerOwnedIgpHookConfig();
+      config.tokenOracleConfig = { [feeToken]: randomTokenOracleConfig() };
+
+      const { hook } = await createHook(config);
+
+      // The token oracle mapping is read back from chain (not derivable via the
+      // reader), so assert it directly: a dedicated oracle is wired per remote.
+      const igp = InterchainGasPaymaster__factory.connect(
+        hook.serialize().deployedHook,
+        multiProvider.getProvider(chain),
+      );
+      const oracles = await Promise.all(
+        testChains.map((c) =>
+          igp.tokenGasOracles(feeToken, multiProvider.getDomainId(c)),
+        ),
+      );
+      for (const oracle of oracles) {
+        expect(eqAddress(oracle, ethers.constants.AddressZero)).to.be.false;
+      }
+      // All destinations of a fee token share a single oracle instance.
+      expect(oracles.every((o) => eqAddress(o, oracles[0]))).to.be.true;
+    });
+
+    it('should set token gas oracles on update', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      config.contractVersion = CONTRACTS_PACKAGE_VERSION;
+      const { hook } = await createHook(config);
+
+      // add a token oracle config; oracle is deployed eagerly, leaving a single
+      // setTokenGasOracles tx to wire the mapping.
+      config.tokenOracleConfig = {
+        [randomAddress()]: randomTokenOracleConfig(),
+      };
+      await expectTxsAndUpdate(hook, config, 1);
+
+      // re-applying the same config is a no-op (mapping already wired on-chain)
+      await expectTxsAndUpdate(hook, config, 0);
+    });
+
+    it('should reject token gas oracles for legacy IGP configs', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      const { hook } = await createHook(config);
+      const legacyTarget = {
+        ...config,
+        igpVersion: IgpVersion.Legacy,
+        tokenOracleConfig: { [randomAddress()]: randomTokenOracleConfig() },
+      };
+
+      try {
+        await hook.update(legacyTarget);
+        throw new Error('Expected legacy IGP token oracle update to fail');
+      } catch (error: unknown) {
+        assert(error instanceof Error, 'Expected Error');
+        expect(error.message).to.include(
+          'IGP tokenOracleConfig requires contract version >= 11.3.0',
         );
       }
     });

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -60,7 +60,11 @@ import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { isProxy, proxyAdmin } from '../deploy/proxy.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
-import { IgpConfig } from '../gas/types.js';
+import {
+  IgpConfig,
+  assertTokenOracleConfigHasNativeRemotes,
+  igpSupportsOffchainFeeQuoting,
+} from '../gas/types.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { ArbL2ToL1IsmConfig, IsmType, OpStackIsmConfig } from '../ism/types.js';
@@ -568,17 +572,16 @@ export class EvmHookModule extends HyperlaneModule<
 
     // update quote signers only if explicitly specified in target config
     // and IGP supports them (detected from on-chain read or version upgrade)
-    const quoteSignerVersion =
+    const offchainFeeQuotingVersion =
       targetConfig.contractVersion ?? currentVersion ?? undefined;
-    const supportsQuoteSigners =
-      targetConfig.igpVersion !== IgpVersion.Legacy &&
-      (currentConfig.quoteSigners !== undefined ||
-        (quoteSignerVersion !== undefined &&
-          compareVersions(quoteSignerVersion, OFFCHAIN_QUOTED_IGP_VERSION) >=
-            0));
+    const supportsOffchainFeeQuoting = igpSupportsOffchainFeeQuoting({
+      igpVersion: targetConfig.igpVersion,
+      contractVersion: offchainFeeQuotingVersion,
+      quoteSigners: currentConfig.quoteSigners,
+    });
     if (targetConfig.quoteSigners !== undefined) {
       assert(
-        supportsQuoteSigners,
+        supportsOffchainFeeQuoting,
         `IGP quoteSigners require contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
       );
       updateTxs.push(
@@ -594,7 +597,7 @@ export class EvmHookModule extends HyperlaneModule<
     // mapping and setTokenGasOracles only exist on the new (non-legacy) IGP.
     if (targetConfig.tokenOracleConfig !== undefined) {
       assert(
-        supportsQuoteSigners,
+        supportsOffchainFeeQuoting,
         `IGP tokenOracleConfig requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
       );
       updateTxs.push(
@@ -612,8 +615,11 @@ export class EvmHookModule extends HyperlaneModule<
   /**
    * Diffs and applies per-fee-token gas oracles on the IGP. Target-driven: the
    * configured fee tokens are the only enumeration source (the on-chain
-   * tokenGasOracles mapping is not enumerable), and each token's current oracle
-   * is read back from chain, so no off-chain address bookkeeping is needed.
+   * tokenGasOracles mapping is not enumerable), so removals are intentionally
+   * unsupported and old fee-token mappings remain live until cleared by a
+   * dedicated teardown flow. Each configured token's current oracle is read back
+   * from chain, so no off-chain address bookkeeping is needed for additions and
+   * updates.
    *
    * For each fee token: resolve the oracle already wired on chain (reused across
    * that token's destinations), or deploy a fresh StorageGasOracle if none is
@@ -635,6 +641,7 @@ export class EvmHookModule extends HyperlaneModule<
       interchainGasPaymaster,
       this.multiProvider.getProvider(this.domainId),
     );
+    assertTokenOracleConfigHasNativeRemotes(this.chain, config);
 
     for (const [feeToken, oracleConfig] of Object.entries(
       targetTokenOracleConfig,

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -589,6 +589,149 @@ export class EvmHookModule extends HyperlaneModule<
       );
     }
 
+    // update token gas oracles only if explicitly specified in target config.
+    // Gated behind the same support check as quoteSigners: the tokenGasOracles
+    // mapping and setTokenGasOracles only exist on the new (non-legacy) IGP.
+    if (targetConfig.tokenOracleConfig !== undefined) {
+      assert(
+        supportsQuoteSigners,
+        `IGP tokenOracleConfig requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+      );
+      updateTxs.push(
+        ...(await this.updateIgpTokenGasOracles({
+          interchainGasPaymaster: this.args.addresses.deployedHook,
+          targetTokenOracleConfig: targetConfig.tokenOracleConfig,
+          config: targetConfig,
+        })),
+      );
+    }
+
+    return updateTxs;
+  }
+
+  /**
+   * Diffs and applies per-fee-token gas oracles on the IGP. Target-driven: the
+   * configured fee tokens are the only enumeration source (the on-chain
+   * tokenGasOracles mapping is not enumerable), and each token's current oracle
+   * is read back from chain, so no off-chain address bookkeeping is needed.
+   *
+   * For each fee token: resolve the oracle already wired on chain (reused across
+   * that token's destinations), or deploy a fresh StorageGasOracle if none is
+   * set yet; reconcile the oracle's remote gas data; then point any unmapped
+   * destinations at it via setTokenGasOracles.
+   */
+  protected async updateIgpTokenGasOracles({
+    interchainGasPaymaster,
+    targetTokenOracleConfig,
+    config,
+  }: {
+    interchainGasPaymaster: Address;
+    targetTokenOracleConfig: NonNullable<IgpConfig['tokenOracleConfig']>;
+    config: IgpConfig;
+  }): Promise<AnnotatedEV5Transaction[]> {
+    const updateTxs: AnnotatedEV5Transaction[] = [];
+    const igpInterface = InterchainGasPaymaster__factory.createInterface();
+    const igp = InterchainGasPaymaster__factory.connect(
+      interchainGasPaymaster,
+      this.multiProvider.getProvider(this.domainId),
+    );
+
+    for (const [feeToken, oracleConfig] of Object.entries(
+      targetTokenOracleConfig,
+    )) {
+      // Resolve the in-MultiProvider remote domains for this fee token.
+      const remotes = Object.keys(oracleConfig)
+        .map((remote) => ({
+          remote,
+          domainId: this.multiProvider.tryGetDomainId(remote),
+        }))
+        .filter(
+          (r): r is { remote: string; domainId: number } => r.domainId !== null,
+        );
+
+      if (remotes.length === 0) {
+        this.logger.warn(
+          `Skipping token gas oracle for ${feeToken} on ${this.chain}: no configured remotes in MultiProvider`,
+        );
+        continue;
+      }
+
+      // Find an oracle already wired for this fee token on any configured
+      // destination; reuse it across destinations.
+      let gasOracle: Address | undefined;
+      for (const { domainId } of remotes) {
+        const existing = await igp.tokenGasOracles(feeToken, domainId);
+        if (!eqAddress(existing, ethers.constants.AddressZero)) {
+          gasOracle = existing;
+          break;
+        }
+      }
+
+      // No oracle wired yet -> deploy a dedicated one for this fee token,
+      // seeded with its oracle config.
+      if (!gasOracle) {
+        const newOracle = await this.deployStorageGasOracle({
+          config,
+          oracleConfig,
+        });
+        gasOracle = newOracle.address;
+      } else {
+        // Reconcile remote gas data on the existing oracle. updateStorageGasOracle
+        // diffs against a supplied current config, so read it back from chain
+        // first (tokenDecimals isn't stored on-chain, so carry it from target to
+        // avoid a spurious diff).
+        const oracleContract = StorageGasOracle__factory.connect(
+          gasOracle,
+          this.multiProvider.getProvider(this.domainId),
+        );
+        const currentOracleConfig: IgpConfig['oracleConfig'] = {};
+        for (const { remote, domainId } of remotes) {
+          const data = await oracleContract.remoteGasData(domainId);
+          currentOracleConfig[remote] = {
+            tokenExchangeRate: data.tokenExchangeRate.toString(),
+            gasPrice: data.gasPrice.toString(),
+            tokenDecimals: oracleConfig[remote]?.tokenDecimals,
+          };
+        }
+
+        updateTxs.push(
+          ...(await this.updateStorageGasOracle({
+            gasOracle,
+            currentOracleConfig,
+            targetOracleConfig: oracleConfig,
+            targetOverhead: config.overhead,
+          })),
+        );
+      }
+
+      // Point any destinations not yet mapped to this oracle at it.
+      const tokenOracleParams: InterchainGasPaymaster.TokenGasOracleConfigStruct[] =
+        [];
+      for (const { domainId } of remotes) {
+        const current = await igp.tokenGasOracles(feeToken, domainId);
+        if (!eqAddress(current, gasOracle)) {
+          tokenOracleParams.push({
+            feeToken,
+            remoteDomain: domainId,
+            gasOracle,
+          });
+        }
+      }
+
+      if (tokenOracleParams.length > 0) {
+        updateTxs.push({
+          annotation: `Setting token gas oracles for ${feeToken} on ${this.chain} (domains ${tokenOracleParams
+            .map((p) => p.remoteDomain)
+            .join(', ')})`,
+          chainId: this.chainId,
+          to: interchainGasPaymaster,
+          data: igpInterface.encodeFunctionData('setTokenGasOracles', [
+            tokenOracleParams,
+          ]),
+        });
+      }
+    }
+
     return updateTxs;
   }
 
@@ -1327,6 +1470,21 @@ export class EvmHookModule extends HyperlaneModule<
       }
     }
 
+    // Wire per-fee-token gas oracles if configured. Must run while the deployer
+    // still owns the IGP (setTokenGasOracles is onlyOwner) and after the native
+    // gas params above, since the IGP requires a destination's native oracle to
+    // exist before a non-native token oracle can be set for it.
+    if (config.tokenOracleConfig !== undefined) {
+      const tokenOracleTxs = await this.updateIgpTokenGasOracles({
+        interchainGasPaymaster: igp.address,
+        targetTokenOracleConfig: config.tokenOracleConfig,
+        config,
+      });
+      for (const tx of tokenOracleTxs) {
+        await this.multiProvider.sendTransaction(this.chain, tx);
+      }
+    }
+
     // Transfer igp to the configured owner
     await this.multiProvider.handleTx(
       this.chain,
@@ -1361,8 +1519,12 @@ export class EvmHookModule extends HyperlaneModule<
 
   protected async deployStorageGasOracle({
     config,
+    oracleConfig = config.oracleConfig,
   }: {
     config: IgpConfig;
+    // Oracle data to seed the deployed oracle with. Defaults to the native
+    // oracleConfig; token gas oracles pass their per-fee-token config instead.
+    oracleConfig?: IgpConfig['oracleConfig'];
   }): Promise<StorageGasOracle> {
     // Deploy the StorageGasOracle, by default msg.sender is the owner
     const gasOracle = await this.deployer.deployContractFromFactory(
@@ -1375,7 +1537,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Obtain the transactions to set the gas params for each remote
     const configureTxs = await this.updateStorageGasOracle({
       gasOracle: gasOracle.address,
-      targetOracleConfig: config.oracleConfig,
+      targetOracleConfig: oracleConfig,
       targetOverhead: config.overhead,
     });
 

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -855,7 +855,12 @@ export class EvmHookModule extends HyperlaneModule<
       }
 
       // only update if the oracle config has changed
-      if (!current || !deepEquals(current, target)) {
+      const comparableTarget = {
+        gasPrice: target.gasPrice,
+        tokenExchangeRate: target.tokenExchangeRate,
+        tokenDecimals: target.tokenDecimals,
+      };
+      if (!current || !deepEquals(current, comparableTarget)) {
         configsToSet.push({ remoteDomain, ...target });
 
         // Log an example remote gas cost

--- a/typescript/sdk/src/hook/types.test.ts
+++ b/typescript/sdk/src/hook/types.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+
+import { HookConfigSchema, HookType } from './types.js';
+
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const igpConfig = (feeToken: string, remote = 'test1') => ({
+  type: HookType.INTERCHAIN_GAS_PAYMASTER,
+  owner: ADDRESS,
+  beneficiary: ADDRESS,
+  oracleKey: ADDRESS,
+  overhead: {},
+  oracleConfig: {},
+  tokenOracleConfig: {
+    [feeToken]: {
+      [remote]: {
+        tokenExchangeRate: '1',
+        gasPrice: '1',
+      },
+    },
+  },
+});
+
+describe('IgpSchema tokenOracleConfig', () => {
+  it('allows non-zero EVM fee-token keys and chain-name remote keys', () => {
+    expect(HookConfigSchema.safeParse(igpConfig(ADDRESS)).success).to.be.true;
+  });
+
+  it('rejects zero-address fee-token keys', () => {
+    expect(HookConfigSchema.safeParse(igpConfig(ZERO_ADDRESS)).success).to.be
+      .false;
+  });
+
+  it('rejects non-address fee-token keys', () => {
+    expect(HookConfigSchema.safeParse(igpConfig('NATIVE_TOKEN')).success).to.be
+      .false;
+  });
+
+  it('rejects invalid remote chain keys', () => {
+    expect(
+      HookConfigSchema.safeParse(igpConfig(ADDRESS, 'not-a-chain')).success,
+    ).to.be.false;
+  });
+});

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -217,6 +217,15 @@ export const IgpSchema = OwnableSchema.extend({
   igpVersion: z.nativeEnum(IgpVersion).optional(),
   quoteSigners: z.array(z.string()).optional(),
   contractVersion: z.string().optional(),
+  // Per-fee-token gas oracles for ERC20-denominated interchain gas payments.
+  // Keyed by fee token address -> remote chain -> oracle config. Each fee token
+  // gets its own StorageGasOracle (the IGasOracle interface is keyed only by
+  // destination, so distinct exchange rates require distinct oracle instances).
+  // Optional and off by default; only wired when present and the IGP supports
+  // tokenGasOracles (>= OFFCHAIN_QUOTED_IGP_VERSION, non-legacy).
+  tokenOracleConfig: z
+    .record(z.record(ProtocolAgnositicGasOracleConfigWithTypicalCostSchema))
+    .optional(),
 });
 
 export const DomainRoutingHookConfigSchema: z.ZodSchema<DomainRoutingHookConfig> =

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -3,12 +3,14 @@ import { z } from 'zod';
 import {
   Address,
   WithAddress,
+  isAddressEvm,
   isNullish,
+  isZeroishAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { ProtocolAgnositicGasOracleConfigWithTypicalCostSchema } from '../gas/oracle/types.js';
-import { ZHash } from '../metadata/customZodTypes.js';
+import { ZChainName, ZHash } from '../metadata/customZodTypes.js';
 import {
   ChainMap,
   OwnableConfig,
@@ -147,6 +149,15 @@ export enum IgpVersion {
 
 export const OFFCHAIN_QUOTED_IGP_VERSION = '11.3.0';
 
+const FeeTokenAddressSchema = z
+  .string()
+  .refine((feeToken) => isAddressEvm(feeToken), {
+    message: 'fee token must be an EVM address',
+  })
+  .refine((feeToken) => !isZeroishAddress(feeToken), {
+    message: 'fee token must not be the zero address',
+  });
+
 // Hook types that can be updated in-place
 export const MUTABLE_HOOK_TYPE: HookType[] = [
   HookType.INTERCHAIN_GAS_PAYMASTER,
@@ -224,7 +235,13 @@ export const IgpSchema = OwnableSchema.extend({
   // Optional and off by default; only wired when present and the IGP supports
   // tokenGasOracles (>= OFFCHAIN_QUOTED_IGP_VERSION, non-legacy).
   tokenOracleConfig: z
-    .record(z.record(ProtocolAgnositicGasOracleConfigWithTypicalCostSchema))
+    .record(
+      FeeTokenAddressSchema,
+      z.record(
+        ZChainName,
+        ProtocolAgnositicGasOracleConfigWithTypicalCostSchema,
+      ),
+    )
     .optional(),
 });
 


### PR DESCRIPTION
## Summary
Stack 3/4 of #8741. **Base: #8908.**

Wires `setTokenGasOracles` through the IGP hook config: an optional `tokenOracleConfig` (keyed by fee token → remote chain) deploys a per-fee-token `StorageGasOracle` and points the IGP's `tokenGasOracles[feeToken][destination]` mapping at it, enabling ERC20-denominated interchain gas payments.

- Off by default; gated behind non-legacy IGPs at `>= 11.3.0` (same support check as `quoteSigners`).
- Each distinct fee token gets its own `StorageGasOracle` (the `IGasOracle` interface is keyed only by destination).
- Target-driven and idempotent: configured fee tokens are the enumeration source; oracle addresses resolved from the on-chain `tokenGasOracles` mapping (no off-chain bookkeeping).
- Wired in both the module path (`EvmHookModule`) and the deployer path (`HyperlaneIgpDeployer`, also used by `HyperlaneHookDeployer`).

The meatiest review of the stack — isolated here.

## Stack
1. #8907 — exchange-rate rebalance
2. #8908 — legacy IGP support
3. **this** — token-denominated IGP fees (SDK)
4. token-denominated IGP fees (infra + agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)