### PR TITLE
feat(infra): token-based IGP config, reclaim, relayer guard

### DIFF
--- a/.changeset/gold-feetoken-igp.md
+++ b/.changeset/gold-feetoken-igp.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The relayer agent config schema was updated to recognize `feeToken` gas payment enforcement config and reject non-native exact-token enforcement until token-aware IGP indexing is available. ERC20 IGP payments can still satisfy token-agnostic `onChainFeeQuoting` checks through the indexed destination gas amount.

--- a/.changeset/legacy-igp-config.md
+++ b/.changeset/legacy-igp-config.md
@@ -3,3 +3,5 @@
 ---
 
 The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments. An `igpVersion` switch (`legacy`/`latest`) was added to the IGP hook config and a `deployQuotedCalls` switch to the core config; legacy IGP deploy paths are kept recover-only by requiring cached `proxyAdmin`, `storageGasOracle`, and `interchainGasPaymaster` addresses. `CoreConfigSchema` now rejects configs that pair a legacy IGP (`igpVersion: legacy`) with `deployQuotedCalls` left enabled, since QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient storage and must ship together on the same chains.
+
+Legacy IGP configs that include `quoteSigners` now fail fast instead of silently skipping signer updates, because legacy IGP contracts do not expose the offchain-quoting signer interface.

--- a/.changeset/legacy-igp-config.md
+++ b/.changeset/legacy-igp-config.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments.
+The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments. An `igpVersion` switch (`legacy`/`latest`) was added to the IGP hook config and a `deployQuotedCalls` switch to the core config; legacy IGP deploy paths are kept recover-only by requiring cached `proxyAdmin`, `storageGasOracle`, and `interchainGasPaymaster` addresses. `CoreConfigSchema` now rejects configs that pair a legacy IGP (`igpVersion: legacy`) with `deployQuotedCalls` left enabled, since QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient storage and must ship together on the same chains.

--- a/.changeset/legacy-igp-config.md
+++ b/.changeset/legacy-igp-config.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The SDK core and IGP deployers were updated to support recover-only legacy IGP configurations and opt out of QuotedCalls deployments.

--- a/.changeset/token-igp-exchange-rate-rebalance.md
+++ b/.changeset/token-igp-exchange-rate-rebalance.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The gas oracle exchange-rate computation in `getLocalStorageGasOracleConfig` was generalized to handle low-decimal fee tokens. When the fee token has fewer decimals than the remote native token (e.g. a 6-decimal ERC20 fee token paying for an 18-decimal native chain), the scaled exchange rate could fall below 1 and floor to a coarse integer, badly mispricing the quote. The existing precision-loss adjustment now also rebalances in this direction, shifting magnitude from the gas price into the exchange rate (their product, and thus the quote, is preserved) so the on-chain exchange rate keeps its precision. Same-decimal native pairs are unaffected.

--- a/.changeset/token-igp-fees-sdk.md
+++ b/.changeset/token-igp-fees-sdk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The IGP hook config gained an optional `tokenOracleConfig` (keyed by fee token then remote chain) that wires per-fee-token gas oracles via `setTokenGasOracles` for ERC20-denominated interchain gas payments. Each fee token is backed by its own `StorageGasOracle`, oracle addresses are resolved from the on-chain `tokenGasOracles` mapping (no off-chain bookkeeping), and the path is gated behind non-legacy IGPs at contract version >= 11.3.0. The wiring was added to both the module path (`EvmHookModule`) and the deployer path (`HyperlaneIgpDeployer`, also used by `HyperlaneHookDeployer`) so infra deployments pick it up.

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -16,7 +16,7 @@ use hyperlane_base::{
         Settings,
     },
 };
-use hyperlane_core::{cfg_unwrap_all, config::*, HyperlaneDomain, U256};
+use hyperlane_core::{cfg_unwrap_all, config::*, HyperlaneDomain, H160, U256};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -222,6 +222,19 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
                 let minimum_is_defined = matches!(policy.get_opt_key("minimum"), Ok(Some(_)));
 
                 let matching_list = policy.chain(&mut err).get_opt_key("matchingList").and_then(parse_matching_list).unwrap_or_default();
+                let fee_token = policy.chain(&mut err)
+                    .get_opt_key("feeToken")
+                    .parse_from_str::<H160>("Expected feeToken to be an EVM address")
+                    .end()
+                    .unwrap_or_else(H160::zero);
+                if fee_token != H160::zero() {
+                    err.push(
+                        (&policy.cwp).add("fee_token"),
+                        eyre!(
+                            "`feeToken` gas payment enforcement is not supported without token-aware IGP indexing; use onChainFeeQuoting with the native token field unset"
+                        ),
+                    );
+                }
 
                 let parse_minimum = |p| GasPaymentEnforcementPolicy::Minimum { payment: p };
                 match policy_type {
@@ -514,6 +527,38 @@ fn parse_address_list(
 mod test {
     use super::*;
     use hyperlane_core::H160;
+    use serde_json::json;
+
+    fn chain_config(name: &str, domain_id: u32) -> Value {
+        json!({
+            "name": name,
+            "domainid": domain_id,
+            "chainid": domain_id,
+            "protocol": "ethereum",
+            "rpcurls": [{ "http": "http://localhost:8545" }],
+            "mailbox": "0x0000000000000000000000000000000000000001",
+            "interchaingaspaymaster": "0x0000000000000000000000000000000000000002",
+            "validatorannounce": "0x0000000000000000000000000000000000000003",
+            "merkletreehook": "0x0000000000000000000000000000000000000004",
+        })
+    }
+
+    fn parse_settings(raw: Value) -> ConfigResult<RelayerSettings> {
+        RelayerSettings::from_config_filtered(
+            RawRelayerSettings(raw),
+            &ConfigPath::default(),
+            (),
+            "relayer",
+        )
+    }
+
+    fn assert_fee_token_error(error: ConfigParsingError) {
+        let error = error.to_string();
+        assert!(
+            error.contains("`feeToken` gas payment enforcement is not supported"),
+            "unexpected error: {error}",
+        );
+    }
 
     #[test]
     fn test_parse_address_blacklist() {
@@ -571,5 +616,51 @@ mod test {
         let p = ValueParser::new(ConfigPath::default(), &value);
         let configs = parse_ism_cache_configs(p).expect("Failed to parse ism cache config");
         assert_eq!(configs.len(), 2);
+    }
+
+    #[test]
+    fn fee_token_policy_rejects_non_zero_fee_token() {
+        let settings = parse_settings(json!({
+            "relaychains": "legacy",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+            "gaspaymentenforcement": [{
+                "type": "minimum",
+                "payment": "1",
+                "feetoken": "0x0000000000000000000000000000000000000005",
+            }],
+        }));
+
+        assert_fee_token_error(settings.expect_err("non-zero feeToken policy must reject"));
+    }
+
+    #[test]
+    fn fee_token_policy_allows_unset_fee_token() {
+        parse_settings(json!({
+            "relaychains": "legacy",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+            "gaspaymentenforcement": [{
+                "type": "onChainFeeQuoting",
+            }],
+        }))
+        .expect("unset feeToken should parse");
+    }
+
+    #[test]
+    fn fee_token_policy_allows_zero_fee_token() {
+        parse_settings(json!({
+            "relaychains": "legacy",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+            "gaspaymentenforcement": [{
+                "type": "onChainFeeQuoting",
+                "feetoken": "0x0000000000000000000000000000000000000000",
+            }],
+        }))
+        .expect("zero feeToken should parse");
     }
 }

--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -23,6 +23,7 @@ import {
 import { Address, objMap } from '@hyperlane-xyz/utils';
 
 import { getChain } from '../../registry.js';
+import { legacyIgpChains } from '../../../src/config/chain.js';
 
 import { getEdenCoreConfig } from './eden.js';
 import { getTronCoreConfig } from './tron.js';
@@ -172,6 +173,7 @@ export const core: ChainMap<CoreConfig> = objMap(
       defaultIsm,
       defaultHook,
       requiredHook,
+      ...(legacyIgpChains.includes(local) ? { deployQuotedCalls: false } : {}),
       ...owner,
     };
   },

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -19,6 +19,7 @@ import { getTronIgpConfig } from './tron.js';
 import gasPrices from './gasPrices.json' with { type: 'json' };
 import { DEPLOYER, chainOwners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
+import { tokenGasOracleConfigs } from './tokenGasOracles.js';
 import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
@@ -86,6 +87,11 @@ export const igp: ChainMap<IgpConfig> = objMap(
         ]),
       ),
       oracleConfig: getOracleConfigWithOverrides(local),
+      // Per-fee-token gas oracles for token-denominated IGP fees; configured in
+      // tokenGasOracles.ts (empty by default).
+      ...(tokenGasOracleConfigs[local]
+        ? { tokenOracleConfig: tokenGasOracleConfigs[local] }
+        : {}),
     };
   },
 );

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,5 +1,10 @@
-import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
-import type { IgpVersion } from '@hyperlane-xyz/sdk';
+import {
+  ChainMap,
+  ChainName,
+  HookType,
+  IgpConfig,
+  IgpVersion,
+} from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 
 import {
@@ -18,7 +23,6 @@ import { tokenGasOracleConfigs } from './tokenGasOracles.js';
 import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
-const LEGACY_IGP_VERSION = 'legacy' as IgpVersion;
 
 function getOracleConfigWithOverrides(origin: ChainName) {
   const oracleConfig = storageGasOracleConfig[origin];
@@ -73,7 +77,7 @@ export const igp: ChainMap<IgpConfig> = objMap(
     return {
       type: HookType.INTERCHAIN_GAS_PAYMASTER,
       ...(legacyIgpChains.includes(local)
-        ? { igpVersion: LEGACY_IGP_VERSION }
+        ? { igpVersion: IgpVersion.Legacy }
         : {}),
       ...owner,
       ownerOverrides: {

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,4 +1,10 @@
-import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
+import {
+  ChainMap,
+  ChainName,
+  HookType,
+  IgpConfig,
+  IgpVersion,
+} from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 
 import {
@@ -6,6 +12,7 @@ import {
   getAllStorageGasOracleConfigs,
   getOverheadWithOverrides,
 } from '../../../src/config/gas-oracle.js';
+import { legacyIgpChains } from '../../../src/config/chain.js';
 
 import { getEdenIgpConfig } from './eden.js';
 import { getTronIgpConfig } from './tron.js';
@@ -61,6 +68,9 @@ export const igp: ChainMap<IgpConfig> = objMap(
 
     return {
       type: HookType.INTERCHAIN_GAS_PAYMASTER,
+      ...(legacyIgpChains.includes(local)
+        ? { igpVersion: IgpVersion.Legacy }
+        : {}),
       ...owner,
       ownerOverrides: {
         ...owner.ownerOverrides,

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -1,10 +1,5 @@
-import {
-  ChainMap,
-  ChainName,
-  HookType,
-  IgpConfig,
-  IgpVersion,
-} from '@hyperlane-xyz/sdk';
+import { ChainMap, ChainName, HookType, IgpConfig } from '@hyperlane-xyz/sdk';
+import type { IgpVersion } from '@hyperlane-xyz/sdk';
 import { exclude, objMap } from '@hyperlane-xyz/utils';
 
 import {
@@ -23,6 +18,7 @@ import { tokenGasOracleConfigs } from './tokenGasOracles.js';
 import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
+const LEGACY_IGP_VERSION = 'legacy' as IgpVersion;
 
 function getOracleConfigWithOverrides(origin: ChainName) {
   const oracleConfig = storageGasOracleConfig[origin];
@@ -59,18 +55,25 @@ const storageGasOracleConfig: AllStorageGasOracleConfigs =
 export const igp: ChainMap<IgpConfig> = objMap(
   chainOwners,
   (local, owner): IgpConfig => {
+    const tokenOracleConfig = tokenGasOracleConfigs[local];
     if (local === 'eden') {
-      return getEdenIgpConfig(owner, storageGasOracleConfig);
+      return {
+        ...getEdenIgpConfig(owner, storageGasOracleConfig),
+        ...(tokenOracleConfig ? { tokenOracleConfig } : {}),
+      };
     }
 
     if (local === 'tron') {
-      return getTronIgpConfig(owner, storageGasOracleConfig);
+      return {
+        ...getTronIgpConfig(owner, storageGasOracleConfig),
+        ...(tokenOracleConfig ? { tokenOracleConfig } : {}),
+      };
     }
 
     return {
       type: HookType.INTERCHAIN_GAS_PAYMASTER,
       ...(legacyIgpChains.includes(local)
-        ? { igpVersion: IgpVersion.Legacy }
+        ? { igpVersion: LEGACY_IGP_VERSION }
         : {}),
       ...owner,
       ownerOverrides: {
@@ -89,9 +92,7 @@ export const igp: ChainMap<IgpConfig> = objMap(
       oracleConfig: getOracleConfigWithOverrides(local),
       // Per-fee-token gas oracles for token-denominated IGP fees; configured in
       // tokenGasOracles.ts (empty by default).
-      ...(tokenGasOracleConfigs[local]
-        ? { tokenOracleConfig: tokenGasOracleConfigs[local] }
-        : {}),
+      ...(tokenOracleConfig ? { tokenOracleConfig } : {}),
     };
   },
 );

--- a/typescript/infra/config/environments/mainnet3/tokenGasOracles.ts
+++ b/typescript/infra/config/environments/mainnet3/tokenGasOracles.ts
@@ -1,0 +1,21 @@
+import { ChainMap, IgpConfig } from '@hyperlane-xyz/sdk';
+
+/**
+ * Per-fee-token IGP gas oracle configs for ERC20-denominated interchain gas
+ * payments, keyed by:
+ *
+ *   local chain -> fee token address -> remote chain -> oracle config
+ *
+ * The wiring in `igp.ts` merges the entry for each local chain into that
+ * chain's `IgpConfig.tokenOracleConfig`, which the SDK turns into per-fee-token
+ * `StorageGasOracle` deployments + `setTokenGasOracles` calls on the IGP.
+ *
+ * Empty by default — keeping all token-IGP rollout changes contained to this
+ * file. To enable a token on a chain, add an entry here. Only applies to
+ * non-legacy IGPs (>= 11.3.0, EIP-1153 transient storage); legacy chains reject
+ * it. The exchange rate is denominated in the fee token (price of the remote
+ * native token quoted in the fee token), not the local native token.
+ */
+export const tokenGasOracleConfigs: ChainMap<
+  NonNullable<IgpConfig['tokenOracleConfig']>
+> = {};

--- a/typescript/infra/config/environments/testnet4/igp.ts
+++ b/typescript/infra/config/environments/testnet4/igp.ts
@@ -10,6 +10,7 @@ import {
 import gasPrices from './gasPrices.json' with { type: 'json' };
 import { owners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
+import { tokenGasOracleConfigs } from './tokenGasOracles.js';
 import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
 
 const tokenPrices: ChainMap<string> = rawTokenPrices;
@@ -54,6 +55,11 @@ export const igp: ChainMap<IgpConfig> = objMap(
           getOverheadWithOverrides(chain, remote),
         ]),
       ),
+      // Per-fee-token gas oracles for token-denominated IGP fees; configured in
+      // tokenGasOracles.ts (empty by default).
+      ...(tokenGasOracleConfigs[chain]
+        ? { tokenOracleConfig: tokenGasOracleConfigs[chain] }
+        : {}),
     };
   },
 );

--- a/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
+++ b/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
@@ -57,8 +57,9 @@ const SEISMIC_SUSDC_PRICE = '1';
 function seismicSusdcOracleConfigs(): ChainMap<ProtocolAgnositicGasOracleConfigWithTypicalCost> {
   const remotes = supportedChainNames.filter((chain) => chain !== SEISMIC);
 
-  const gasOracleParams = [SEISMIC, ...remotes].reduce((agg, chain) => {
-    agg[chain] = {
+  const gasOracleParams: ChainMap<ChainGasOracleParams> = {};
+  for (const chain of [SEISMIC, ...remotes]) {
+    gasOracleParams[chain] = {
       gasPrice: gasPrices[chain],
       nativeToken: {
         price: chain === SEISMIC ? SEISMIC_SUSDC_PRICE : tokenPrices[chain],
@@ -68,8 +69,7 @@ function seismicSusdcOracleConfigs(): ChainMap<ProtocolAgnositicGasOracleConfigW
             : mustGetChainNativeToken(chain).decimals,
       },
     };
-    return agg;
-  }, {} as ChainMap<ChainGasOracleParams>);
+  }
 
   return getLocalStorageGasOracleConfig({
     local: SEISMIC,

--- a/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
+++ b/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
@@ -1,0 +1,21 @@
+import { ChainMap, IgpConfig } from '@hyperlane-xyz/sdk';
+
+/**
+ * Per-fee-token IGP gas oracle configs for ERC20-denominated interchain gas
+ * payments, keyed by:
+ *
+ *   local chain -> fee token address -> remote chain -> oracle config
+ *
+ * The wiring in `igp.ts` merges the entry for each local chain into that
+ * chain's `IgpConfig.tokenOracleConfig`, which the SDK turns into per-fee-token
+ * `StorageGasOracle` deployments + `setTokenGasOracles` calls on the IGP.
+ *
+ * Empty by default — keeping all token-IGP rollout changes contained to this
+ * file. To enable a token on a chain, add an entry here. Only applies to
+ * non-legacy IGPs (>= 11.3.0, EIP-1153 transient storage); legacy chains reject
+ * it. The exchange rate is denominated in the fee token (price of the remote
+ * native token quoted in the fee token), not the local native token.
+ */
+export const tokenGasOracleConfigs: ChainMap<
+  NonNullable<IgpConfig['tokenOracleConfig']>
+> = {};

--- a/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
+++ b/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
@@ -43,7 +43,9 @@ const SEISMIC: ChainName = 'seismictestnet';
 const SEISMIC_SUSDC = '0x790701048922e265105fd6a4467a2901c2201c43';
 const SEISMIC_SUSDC_DECIMALS = 6;
 // sUSDC is USD-pegged, so priced at $1: quotes then land at the same USD value
-// as the native SIZE quote, just denominated in sUSDC.
+// as the native SIZE quote, just denominated in sUSDC. This testnet-only
+// constant has no depeg or staleness guard; replace it with a live/staleness-
+// checked price source before any mainnet reuse.
 const SEISMIC_SUSDC_PRICE = '1';
 
 /**

--- a/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
+++ b/typescript/infra/config/environments/testnet4/tokenGasOracles.ts
@@ -1,4 +1,23 @@
-import { ChainMap, IgpConfig } from '@hyperlane-xyz/sdk';
+import {
+  ChainGasOracleParams,
+  ChainMap,
+  ChainName,
+  GasPriceConfig,
+  IgpConfig,
+  ProtocolAgnositicGasOracleConfigWithTypicalCost,
+  getLocalStorageGasOracleConfig,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { EXCHANGE_RATE_MARGIN_PCT } from '../../../src/config/gas-oracle.js';
+import { mustGetChainNativeToken } from '../../../src/utils/utils.js';
+
+import rawGasPrices from './gasPrices.json' with { type: 'json' };
+import { supportedChainNames } from './supportedChainNames.js';
+import rawTokenPrices from './tokenPrices.json' with { type: 'json' };
+
+const tokenPrices: ChainMap<string> = rawTokenPrices;
+const gasPrices: ChainMap<GasPriceConfig> = rawGasPrices;
 
 /**
  * Per-fee-token IGP gas oracle configs for ERC20-denominated interchain gas
@@ -10,12 +29,58 @@ import { ChainMap, IgpConfig } from '@hyperlane-xyz/sdk';
  * chain's `IgpConfig.tokenOracleConfig`, which the SDK turns into per-fee-token
  * `StorageGasOracle` deployments + `setTokenGasOracles` calls on the IGP.
  *
- * Empty by default — keeping all token-IGP rollout changes contained to this
- * file. To enable a token on a chain, add an entry here. Only applies to
- * non-legacy IGPs (>= 11.3.0, EIP-1153 transient storage); legacy chains reject
- * it. The exchange rate is denominated in the fee token (price of the remote
- * native token quoted in the fee token), not the local native token.
+ * Token-IGP rollout changes stay contained to this file. To enable a token on
+ * a chain, add an entry here. Only applies to non-legacy IGPs (>= 11.3.0,
+ * EIP-1153 transient storage); legacy chains reject it. The exchange rate is
+ * denominated in the fee token (price of the remote native token quoted in the
+ * fee token), not the local native token.
  */
+
+// Seismic is moving to sUSDC-only for gas; SIZE is not a user-facing asset, so
+// outbound dispatches pay the IGP fee in sUSDC instead of native SIZE.
+// https://seismic-testnet.socialscan.io/src20token/0x790701048922e265105fd6a4467a2901c2201c43
+const SEISMIC: ChainName = 'seismictestnet';
+const SEISMIC_SUSDC = '0x790701048922e265105fd6a4467a2901c2201c43';
+const SEISMIC_SUSDC_DECIMALS = 6;
+// sUSDC is USD-pegged, so priced at $1: quotes then land at the same USD value
+// as the native SIZE quote, just denominated in sUSDC.
+const SEISMIC_SUSDC_PRICE = '1';
+
+/**
+ * Builds the sUSDC-denominated oracle config for each Seismic remote by reusing
+ * the native gas-oracle machinery with sUSDC substituted as Seismic's local fee
+ * token (its price and decimals). This makes the exchange rate resolve to the
+ * remote native token priced in sUSDC, adjusted for sUSDC's 6 decimals.
+ */
+function seismicSusdcOracleConfigs(): ChainMap<ProtocolAgnositicGasOracleConfigWithTypicalCost> {
+  const remotes = supportedChainNames.filter((chain) => chain !== SEISMIC);
+
+  const gasOracleParams = [SEISMIC, ...remotes].reduce((agg, chain) => {
+    agg[chain] = {
+      gasPrice: gasPrices[chain],
+      nativeToken: {
+        price: chain === SEISMIC ? SEISMIC_SUSDC_PRICE : tokenPrices[chain],
+        decimals:
+          chain === SEISMIC
+            ? SEISMIC_SUSDC_DECIMALS
+            : mustGetChainNativeToken(chain).decimals,
+      },
+    };
+    return agg;
+  }, {} as ChainMap<ChainGasOracleParams>);
+
+  return getLocalStorageGasOracleConfig({
+    local: SEISMIC,
+    localProtocolType: ProtocolType.Ethereum,
+    gasOracleParams,
+    exchangeRateMarginPct: EXCHANGE_RATE_MARGIN_PCT,
+  });
+}
+
 export const tokenGasOracleConfigs: ChainMap<
   NonNullable<IgpConfig['tokenOracleConfig']>
-> = {};
+> = {
+  [SEISMIC]: {
+    [SEISMIC_SUSDC]: seismicSusdcOracleConfigs(),
+  },
+};

--- a/typescript/infra/scripts/funding/reclaim-from-igp.ts
+++ b/typescript/infra/scripts/funding/reclaim-from-igp.ts
@@ -310,7 +310,9 @@ async function main() {
   ).length;
 
   rootLogger.info(
-    chalk.green(`\nSuccessfully executed ${successCount} claim(s)`),
+    chalk.green(
+      `\n${dryRun ? 'Would have executed' : 'Successfully executed'} ${successCount} claim(s)`,
+    ),
   );
   if (errorCount > 0) {
     rootLogger.error(

--- a/typescript/infra/scripts/funding/reclaim-from-igp.ts
+++ b/typescript/infra/scripts/funding/reclaim-from-igp.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
-import { formatEther, parseEther } from 'ethers/lib/utils.js';
+import { formatEther, formatUnits, parseEther } from 'ethers/lib/utils.js';
 
+import { ERC20__factory } from '@hyperlane-xyz/core';
 import { HyperlaneIgp } from '@hyperlane-xyz/sdk';
 import {
   isZeroishAddress,
@@ -38,6 +39,8 @@ type ReclaimStatus = (typeof ReclaimStatus)[keyof typeof ReclaimStatus];
 
 interface ReclaimResult {
   chain: string;
+  // 'native' for the native-balance claim, or a fee-token label for claimToken.
+  token: string;
   balance: string;
   threshold: string;
   status: ReclaimStatus;
@@ -61,6 +64,10 @@ async function main() {
   const keyFunderConfig = getKeyFunderConfig(environmentConfig);
   const igpClaimThresholds = keyFunderConfig.igpClaimThresholdPerChain;
   const desiredBalances = keyFunderConfig.desiredBalancePerChain;
+
+  // Per-chain IGP hook configs; tokenOracleConfig (keyed by fee token address)
+  // is the source of truth for which ERC20 fee tokens to claim via claimToken.
+  const igpConfigs = environmentConfig.igp;
 
   // Filter chains if provided
   const chainsToProcess = chains?.length
@@ -106,10 +113,13 @@ async function main() {
 
   const reclaimResults = await promiseObjAll(
     objMap(filteredPaymasters, async (chain, paymaster) => {
-      if (!paymaster) return null;
+      if (!paymaster) return [];
 
+      const provider = multiProvider.getProvider(chain);
+      const chainResults: ReclaimResult[] = [];
+
+      // ---- Native claim ----
       try {
-        const provider = multiProvider.getProvider(chain);
         const balance = await provider.getBalance(paymaster.address);
         const formattedBalance = formatEther(balance);
 
@@ -140,122 +150,143 @@ async function main() {
           }
         }
 
-        // Skip if balance is zero (even with --force)
-        if (balance.isZero()) {
-          return {
-            chain,
-            balance: formatTo5SF(formattedBalance),
-            threshold: formatTo5SF(formatEther(threshold)),
-            status: ReclaimStatus.BELOW_THRESHOLD,
-          };
-        }
-
-        // Only reclaim when greater than the reclaim threshold (unless --force is used)
-        if (!force && balance.lt(threshold)) {
-          return {
-            chain,
-            balance: formatTo5SF(formattedBalance),
-            threshold: formatTo5SF(formatEther(threshold)),
-            status: ReclaimStatus.BELOW_THRESHOLD,
-          };
-        }
-
-        // Estimate the gas cost for the claim transaction
-        const gasEstimate = await paymaster.estimateGas.claim();
-        const feeData = await provider.getFeeData();
-
-        // Calculate total cost: gas * (gasPrice or maxFeePerGas)
-        const gasPrice = feeData.maxFeePerGas || feeData.gasPrice;
-        if (!gasPrice) {
-          return {
-            chain,
-            balance: formatTo5SF(formattedBalance),
-            threshold: formatTo5SF(thresholdStr),
-            status: ReclaimStatus.NO_GAS_PRICE,
-          };
-        }
-
-        const estimatedCost = gasEstimate.mul(gasPrice);
-        const costThreshold = estimatedCost.mul(2); // 2x the cost
-
-        // Only proceed if balance > 2x the estimated cost (unless --force is used)
-        if (!force && balance.lte(costThreshold)) {
-          return {
-            chain,
-            balance: formatTo5SF(formattedBalance),
-            threshold: formatTo5SF(formatEther(threshold)),
-            status: ReclaimStatus.INSUFFICIENT_FOR_GAS,
-          };
-        }
-
-        rootLogger.debug(`Claiming from IGP on ${chain}...`);
-        let tx;
-        let explorerUrl;
-        if (dryRun) {
-          rootLogger.info(`[DRY RUN] Would claim from IGP on ${chain}`);
+        let status: ReclaimStatus;
+        if (balance.isZero() || (!force && balance.lt(threshold))) {
+          // Skip if balance is zero (even with --force) or below threshold
+          status = ReclaimStatus.BELOW_THRESHOLD;
         } else {
-          tx = await paymaster.claim();
-          explorerUrl = multiProvider.tryGetExplorerTxUrl(chain, tx);
-          rootLogger.info(
-            `Claimed from IGP on ${chain}: ${explorerUrl || tx.hash}`,
-          );
-        }
+          // Estimate the gas cost for the claim transaction
+          const gasEstimate = await paymaster.estimateGas.claim();
+          const feeData = await provider.getFeeData();
 
-        return {
-          chain,
-          balance: formatTo5SF(formattedBalance),
-          threshold: formatTo5SF(formatEther(threshold)),
-          status: ReclaimStatus.SUCCESS,
-        };
-      } catch (error) {
-        const provider = multiProvider.getProvider(chain);
-        let balance = 'N/A';
-        let thresholdDisplay = '0.1';
-        try {
-          const bal = await provider.getBalance(paymaster.address);
-          balance = formatTo5SF(formatEther(bal));
-        } catch {
-          // Balance fetch failed, leave as N/A
-        }
+          // Calculate total cost: gas * (gasPrice or maxFeePerGas)
+          const gasPrice = feeData.maxFeePerGas || feeData.gasPrice;
+          if (!gasPrice) {
+            status = ReclaimStatus.NO_GAS_PRICE;
+          } else {
+            const estimatedCost = gasEstimate.mul(gasPrice);
+            const costThreshold = estimatedCost.mul(2); // 2x the cost
 
-        // Calculate threshold for display
-        const thresholdStr = igpClaimThresholds[chain];
-        if (thresholdStr) {
-          thresholdDisplay = thresholdStr;
-        } else {
-          const desired = desiredBalances[chain];
-          if (desired) {
-            thresholdDisplay = formatEther(parseEther(desired).div(5));
+            // Only proceed if balance > 2x the estimated cost (unless --force is used)
+            if (!force && balance.lte(costThreshold)) {
+              status = ReclaimStatus.INSUFFICIENT_FOR_GAS;
+            } else if (dryRun) {
+              rootLogger.info(`[DRY RUN] Would claim from IGP on ${chain}`);
+              status = ReclaimStatus.SUCCESS;
+            } else {
+              rootLogger.debug(`Claiming from IGP on ${chain}...`);
+              const tx = await paymaster.claim();
+              const explorerUrl = multiProvider.tryGetExplorerTxUrl(chain, tx);
+              rootLogger.info(
+                `Claimed from IGP on ${chain}: ${explorerUrl || tx.hash}`,
+              );
+              status = ReclaimStatus.SUCCESS;
+            }
           }
         }
 
+        chainResults.push({
+          chain,
+          token: 'native',
+          balance: formatTo5SF(formattedBalance),
+          threshold: formatTo5SF(formatEther(threshold)),
+          status,
+        });
+      } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
-        // Extract just the key error info, not the full stack
         const shortError = errorMsg.split('\n')[0];
         rootLogger.error(
           chalk.red(`Error claiming from IGP on ${chain}: ${shortError}`),
         );
-        return {
+        chainResults.push({
           chain,
-          balance,
-          threshold: formatTo5SF(thresholdDisplay),
+          token: 'native',
+          balance: 'N/A',
+          threshold: 'N/A',
           status: ReclaimStatus.ERROR,
-        };
+        });
       }
+
+      // ---- Fee-token claims ----
+      // Fee tokens are enumerated from the IGP's tokenOracleConfig (the same set
+      // configured via setTokenGasOracles). Empty on legacy IGPs / chains with no
+      // token-denominated fees, so this is a no-op there. The manual script claims
+      // any non-zero configured fee-token balance; gas is paid by the signer in the
+      // native token, so the native 2x-gas guard above does not apply here.
+      const feeTokens = Object.keys(igpConfigs[chain]?.tokenOracleConfig ?? {});
+      for (const tokenAddr of feeTokens) {
+        let label = tokenAddr;
+        try {
+          const erc20 = ERC20__factory.connect(tokenAddr, provider);
+          const [tokenBalance, decimals, symbol] = await Promise.all([
+            erc20.balanceOf(paymaster.address),
+            erc20.decimals(),
+            erc20.symbol(),
+          ]);
+          label = `${symbol} (${tokenAddr.slice(0, 8)}…)`;
+          const formattedTokenBalance = formatUnits(tokenBalance, decimals);
+
+          if (tokenBalance.isZero()) {
+            chainResults.push({
+              chain,
+              token: label,
+              balance: formatTo5SF(formattedTokenBalance),
+              threshold: '0',
+              status: ReclaimStatus.BELOW_THRESHOLD,
+            });
+            continue;
+          }
+
+          if (dryRun) {
+            rootLogger.info(
+              `[DRY RUN] Would claim ${label} from IGP on ${chain}`,
+            );
+          } else {
+            const tx = await paymaster.claimToken(tokenAddr);
+            const explorerUrl = multiProvider.tryGetExplorerTxUrl(chain, tx);
+            rootLogger.info(
+              `Claimed ${label} from IGP on ${chain}: ${explorerUrl || tx.hash}`,
+            );
+          }
+
+          chainResults.push({
+            chain,
+            token: label,
+            balance: formatTo5SF(formattedTokenBalance),
+            threshold: '0',
+            status: ReclaimStatus.SUCCESS,
+          });
+        } catch (error) {
+          const errorMsg =
+            error instanceof Error ? error.message : String(error);
+          const shortError = errorMsg.split('\n')[0];
+          rootLogger.error(
+            chalk.red(
+              `Error claiming token ${label} from IGP on ${chain}: ${shortError}`,
+            ),
+          );
+          chainResults.push({
+            chain,
+            token: label,
+            balance: 'N/A',
+            threshold: 'N/A',
+            status: ReclaimStatus.ERROR,
+          });
+        }
+      }
+
+      return chainResults;
     }),
   );
 
-  // Convert to array and filter out nulls
-  const filteredResults = Object.values(reclaimResults).filter(
-    (result): result is ReclaimResult =>
-      result !== null && result !== undefined,
-  );
-  results.push(...filteredResults);
+  // Flatten per-chain result arrays
+  results.push(...Object.values(reclaimResults).flat());
 
   // Show all chains in the table
   if (results.length > 0) {
     const tableData = results.map((r) => ({
       chain: r.chain,
+      token: r.token,
       balance: r.balance,
       threshold: r.threshold,
       status: r.status,
@@ -274,7 +305,7 @@ async function main() {
   ).length;
 
   rootLogger.info(
-    chalk.green(`\nSuccessfully claimed from ${successCount} chain(s)`),
+    chalk.green(`\nSuccessfully executed ${successCount} claim(s)`),
   );
   if (errorCount > 0) {
     rootLogger.error(

--- a/typescript/infra/scripts/funding/reclaim-from-igp.ts
+++ b/typescript/infra/scripts/funding/reclaim-from-igp.ts
@@ -208,11 +208,14 @@ async function main() {
       }
 
       // ---- Fee-token claims ----
-      // Fee tokens are enumerated from the IGP's tokenOracleConfig (the same set
-      // configured via setTokenGasOracles). Empty on legacy IGPs / chains with no
-      // token-denominated fees, so this is a no-op there. The manual script claims
-      // any non-zero configured fee-token balance; gas is paid by the signer in the
-      // native token, so the native 2x-gas guard above does not apply here.
+      // Fee tokens are enumerated from the append-only IGP tokenOracleConfig.
+      // The on-chain tokenGasOracles mapping is not enumerable, so tokens removed
+      // from config are not discoverable here. Keep token entries in config until
+      // any stranded IGP balance has been reclaimed. Empty on legacy IGPs / chains
+      // with no token-denominated fees, so this is a no-op there. The manual
+      // script claims any non-zero configured fee-token balance; gas is paid by
+      // the signer in the native token, so the native 2x-gas guard above does not
+      // apply here.
       const feeTokens = Object.keys(igpConfigs[chain]?.tokenOracleConfig ?? {});
       for (const tokenAddr of feeTokens) {
         let label = tokenAddr;
@@ -236,6 +239,8 @@ async function main() {
             });
             continue;
           }
+
+          await paymaster.estimateGas.claimToken(tokenAddr);
 
           if (dryRun) {
             rootLogger.info(

--- a/typescript/infra/scripts/igp/legacy-igp-config.ts
+++ b/typescript/infra/scripts/igp/legacy-igp-config.ts
@@ -5,9 +5,9 @@ import {
   EvmHookModule,
   HookType,
   IgpConfig,
-  IgpVersion,
   extractIsmAndHookFactoryAddresses,
 } from '@hyperlane-xyz/sdk';
+import type { IgpVersion } from '@hyperlane-xyz/sdk';
 import { assert, deepCopy } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
@@ -21,6 +21,8 @@ import {
   withOutputFile,
 } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
+
+const LEGACY_IGP_VERSION = 'legacy' as IgpVersion;
 
 function serializeTx(tx: Awaited<ReturnType<EvmHookModule['update']>>[number]) {
   return {
@@ -50,7 +52,7 @@ async function main() {
   const configuredLegacyChains = legacyIgpChains.filter(
     (chain) =>
       envConfig.supportedChainNames.includes(chain) &&
-      igpConfigs[chain]?.igpVersion === IgpVersion.Legacy,
+      igpConfigs[chain]?.igpVersion === LEGACY_IGP_VERSION,
   );
   const targetChains =
     requestedChains && requestedChains.length > 0
@@ -60,7 +62,7 @@ async function main() {
   assert(targetChains.length > 0, 'No legacy IGP chains selected');
 
   const nonLegacyChains = targetChains.filter(
-    (chain) => igpConfigs[chain]?.igpVersion !== IgpVersion.Legacy,
+    (chain) => igpConfigs[chain]?.igpVersion !== LEGACY_IGP_VERSION,
   );
   assert(
     nonLegacyChains.length === 0,

--- a/typescript/infra/scripts/igp/legacy-igp-config.ts
+++ b/typescript/infra/scripts/igp/legacy-igp-config.ts
@@ -46,7 +46,17 @@ async function main() {
 
   const envConfig = getEnvironmentConfig(environment);
   const igpConfigs = envConfig.igp;
-  const requestedChains = chains as ChainName[] | undefined;
+  const supportedChains = new Set<string>(envConfig.supportedChainNames);
+  const requestedChains =
+    chains && chains.length > 0
+      ? chains.filter((chain): chain is ChainName => supportedChains.has(chain))
+      : undefined;
+  assert(
+    !chains || requestedChains?.length === chains.length,
+    `Unknown chain(s) requested: ${chains
+      ?.filter((chain) => !supportedChains.has(chain))
+      .join(', ')}`,
+  );
   const configuredLegacyChains = legacyIgpChains.filter(
     (chain) =>
       envConfig.supportedChainNames.includes(chain) &&

--- a/typescript/infra/scripts/igp/legacy-igp-config.ts
+++ b/typescript/infra/scripts/igp/legacy-igp-config.ts
@@ -1,0 +1,155 @@
+import { writeFile } from 'fs/promises';
+
+import {
+  ChainName,
+  EvmHookModule,
+  HookType,
+  IgpConfig,
+  IgpVersion,
+  extractIsmAndHookFactoryAddresses,
+} from '@hyperlane-xyz/sdk';
+import { assert, deepCopy } from '@hyperlane-xyz/utils';
+
+import { Contexts } from '../../config/contexts.js';
+import { getEnvAddresses } from '../../config/registry.js';
+import { legacyIgpChains } from '../../src/config/chain.js';
+import { Role } from '../../src/roles.js';
+import {
+  getArgs,
+  withChains,
+  withContext,
+  withOutputFile,
+} from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+function serializeTx(tx: Awaited<ReturnType<EvmHookModule['update']>>[number]) {
+  return {
+    annotation: tx.annotation,
+    chainId: tx.chainId,
+    to: tx.to,
+    data: tx.data,
+    ...(tx.value ? { value: tx.value.toString() } : {}),
+  };
+}
+
+async function main() {
+  const {
+    environment,
+    context = Contexts.Hyperlane,
+    chains,
+    execute,
+    outFile,
+  } = await withOutputFile(withChains(withContext(getArgs())))
+    .describe('execute', 'Send transactions instead of only printing calldata')
+    .boolean('execute')
+    .default('execute', false).argv;
+
+  const envConfig = getEnvironmentConfig(environment);
+  const igpConfigs = envConfig.igp;
+  const requestedChains = chains as ChainName[] | undefined;
+  const configuredLegacyChains = legacyIgpChains.filter(
+    (chain) =>
+      envConfig.supportedChainNames.includes(chain) &&
+      igpConfigs[chain]?.igpVersion === IgpVersion.Legacy,
+  );
+  const targetChains =
+    requestedChains && requestedChains.length > 0
+      ? requestedChains
+      : configuredLegacyChains;
+
+  assert(targetChains.length > 0, 'No legacy IGP chains selected');
+
+  const nonLegacyChains = targetChains.filter(
+    (chain) => igpConfigs[chain]?.igpVersion !== IgpVersion.Legacy,
+  );
+  assert(
+    nonLegacyChains.length === 0,
+    `Chains are not configured for legacy IGP: ${nonLegacyChains.join(', ')}`,
+  );
+
+  const multiProvider = await envConfig.getMultiProvider(
+    context,
+    execute ? Role.Deployer : undefined,
+    true,
+    targetChains,
+  );
+  const addresses = getEnvAddresses(environment);
+  const plans = [];
+
+  for (const chain of targetChains) {
+    const chainAddresses = addresses[chain];
+    const config = igpConfigs[chain];
+
+    assert(chainAddresses, `Missing registry addresses for ${chain}`);
+    assert(config, `Missing IGP config for ${chain}`);
+    assert(
+      config.type === HookType.INTERCHAIN_GAS_PAYMASTER,
+      `Expected IGP hook config for ${chain}`,
+    );
+    assert(
+      chainAddresses.interchainGasPaymaster,
+      `Missing interchainGasPaymaster address for ${chain}`,
+    );
+    assert(chainAddresses.mailbox, `Missing mailbox address for ${chain}`);
+    assert(
+      chainAddresses.proxyAdmin,
+      `Missing proxyAdmin address for ${chain}`,
+    );
+
+    const targetConfig: IgpConfig = {
+      ...config,
+      owner: config.ownerOverrides?.interchainGasPaymaster ?? config.owner,
+    };
+    const module = new EvmHookModule(multiProvider, {
+      chain,
+      config: targetConfig,
+      addresses: {
+        ...extractIsmAndHookFactoryAddresses(chainAddresses),
+        mailbox: chainAddresses.mailbox,
+        proxyAdmin: chainAddresses.proxyAdmin,
+        deployedHook: chainAddresses.interchainGasPaymaster,
+      },
+    });
+    const transactions = await module.update(deepCopy(targetConfig));
+    const executed = [];
+
+    if (execute) {
+      for (const transaction of transactions) {
+        const receipt = await multiProvider.sendTransaction(chain, transaction);
+        executed.push(receipt.transactionHash);
+      }
+    }
+
+    plans.push({
+      chain,
+      interchainGasPaymaster: chainAddresses.interchainGasPaymaster,
+      transactionCount: transactions.length,
+      transactions: transactions.map(serializeTx),
+      ...(execute ? { executed } : {}),
+    });
+  }
+
+  const output = JSON.stringify(
+    {
+      environment,
+      context,
+      mode: execute ? 'execute' : 'dry-run',
+      plans,
+    },
+    null,
+    2,
+  );
+
+  if (outFile) {
+    await writeFile(outFile, output);
+  }
+
+  console.info(output);
+}
+
+main()
+  .then()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/igp/legacy-igp-config.ts
+++ b/typescript/infra/scripts/igp/legacy-igp-config.ts
@@ -5,9 +5,9 @@ import {
   EvmHookModule,
   HookType,
   IgpConfig,
+  IgpVersion,
   extractIsmAndHookFactoryAddresses,
 } from '@hyperlane-xyz/sdk';
-import type { IgpVersion } from '@hyperlane-xyz/sdk';
 import { assert, deepCopy } from '@hyperlane-xyz/utils';
 
 import { Contexts } from '../../config/contexts.js';
@@ -21,8 +21,6 @@ import {
   withOutputFile,
 } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
-
-const LEGACY_IGP_VERSION = 'legacy' as IgpVersion;
 
 function serializeTx(tx: Awaited<ReturnType<EvmHookModule['update']>>[number]) {
   return {
@@ -52,7 +50,7 @@ async function main() {
   const configuredLegacyChains = legacyIgpChains.filter(
     (chain) =>
       envConfig.supportedChainNames.includes(chain) &&
-      igpConfigs[chain]?.igpVersion === LEGACY_IGP_VERSION,
+      igpConfigs[chain]?.igpVersion === IgpVersion.Legacy,
   );
   const targetChains =
     requestedChains && requestedChains.length > 0
@@ -62,7 +60,7 @@ async function main() {
   assert(targetChains.length > 0, 'No legacy IGP chains selected');
 
   const nonLegacyChains = targetChains.filter(
-    (chain) => igpConfigs[chain]?.igpVersion !== LEGACY_IGP_VERSION,
+    (chain) => igpConfigs[chain]?.igpVersion !== IgpVersion.Legacy,
   );
   assert(
     nonLegacyChains.length === 0,

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -62,6 +62,8 @@ export function getDisabledChains(): ChainName[] {
 
 // Chains that should keep the legacy IGP path. Deploy flows should recover
 // existing IGP deployments and skip latest-only contracts on these chains.
+// Disabled chains are included so operations never try to auto-heal them from
+// legacy recover-only deployments to latest IGP deployments while disabled.
 export const legacyIgpChains: ChainName[] = Array.from(
   new Set([
     'chilizmainnet',

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -60,6 +60,24 @@ export function getDisabledChains(): ChainName[] {
     .map(([name]) => name);
 }
 
+// Chains that should keep the legacy IGP path. Deploy flows should recover
+// existing IGP deployments and skip latest-only contracts on these chains.
+export const legacyIgpChains: ChainName[] = Array.from(
+  new Set([
+    'chilizmainnet',
+    'coti',
+    'electroneum',
+    'incentiv',
+    'metis',
+    'prom',
+    'pulsechain',
+    'taiko',
+    'torus',
+    'viction',
+    ...getDisabledChains(),
+  ]),
+);
+
 // A list of chains to skip during deploy, check-deploy and ICA operations.
 // Used by scripts like check-owner-ica.ts to exclude chains that are temporarily
 // unsupported (e.g. zksync, zeronetwork) or have known issues

--- a/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.hardhat-test.ts
@@ -190,6 +190,16 @@ describe('EvmCoreModule', async () => {
       expect(eqAddress(await qc.PERMIT2(), customPermit2)).to.be.true;
     });
 
+    it('should skip quotedCalls when disabled', async () => {
+      const module = await EvmCoreModule.create({
+        chain: CHAIN,
+        config: { ...config, deployQuotedCalls: false },
+        multiProvider,
+      });
+
+      expect(module.serialize().quotedCalls).to.be.undefined;
+    });
+
     it('should deploy testRecipient', async () => {
       expect(evmCoreModule.serialize().testRecipient).to.exist;
       expect(await testRecipientContract.owner()).to.equal(signer.address);
@@ -255,6 +265,24 @@ describe('EvmCoreModule', async () => {
       const updateTxs = await evmCoreModuleInstance.update(existingConfig);
 
       expect(updateTxs.length).to.equal(0);
+    });
+
+    it('should not auto-deploy missing quotedCalls when disabled', async () => {
+      const { quotedCalls: _, ...addresses } = evmCoreModule.serialize();
+      const evmCoreModuleInstance = new EvmCoreModule(multiProvider, {
+        chain: CHAIN,
+        config: { ...config, deployQuotedCalls: false },
+        addresses,
+      });
+
+      const existingConfig: CoreConfig = await evmCoreModuleInstance.read();
+      const updateTxs = await evmCoreModuleInstance.update({
+        ...existingConfig,
+        deployQuotedCalls: false,
+      });
+
+      expect(updateTxs.length).to.equal(0);
+      expect(evmCoreModuleInstance.serialize().quotedCalls).to.be.undefined;
     });
 
     it('should update a mutable Ism', async () => {

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -493,7 +493,7 @@ export class EvmCoreModule extends HyperlaneModule<
       mailbox: mailbox.address,
       interchainAccountRouter,
       validatorAnnounce,
-      ...(quotedCalls ? { quotedCalls } : {}),
+      quotedCalls,
       timelockController,
       testRecipient,
       merkleTreeHook,

--- a/typescript/sdk/src/core/EvmCoreModule.ts
+++ b/typescript/sdk/src/core/EvmCoreModule.ts
@@ -27,6 +27,7 @@ import {
   CoreConfigSchema,
   DeployedCoreAddresses,
   DerivedCoreConfig,
+  shouldDeployQuotedCalls,
 } from '../core/types.js';
 import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
 import {
@@ -116,8 +117,11 @@ export class EvmCoreModule extends HyperlaneModule<
   ): Promise<AnnotatedEV5Transaction[]> {
     CoreConfigSchema.parse(expectedConfig);
 
-    // Deploy QuotedCalls if not yet present
-    if (!this.args.addresses.quotedCalls) {
+    // Deploy QuotedCalls if not yet present and enabled for this chain.
+    if (
+      shouldDeployQuotedCalls(expectedConfig) &&
+      !this.args.addresses.quotedCalls
+    ) {
       const ismFactory = new HyperlaneIsmFactory(
         attachContractsMap(
           { [this.chainName]: this.args.addresses },
@@ -435,10 +439,10 @@ export class EvmCoreModule extends HyperlaneModule<
       await coreDeployer.deployValidatorAnnounce(chainName, mailbox.address)
     ).address;
 
-    // Deploy QuotedCalls
-    const quotedCalls = (
-      await coreDeployer.deployQuotedCalls(chainName, config.permit2)
-    ).address;
+    const quotedCalls = shouldDeployQuotedCalls(config)
+      ? (await coreDeployer.deployQuotedCalls(chainName, config.permit2))
+          .address
+      : undefined;
 
     // Deploy timelock controller if config.upgrade is set
     let timelockController;
@@ -489,7 +493,7 @@ export class EvmCoreModule extends HyperlaneModule<
       mailbox: mailbox.address,
       interchainAccountRouter,
       validatorAnnounce,
-      quotedCalls,
+      ...(quotedCalls ? { quotedCalls } : {}),
       timelockController,
       testRecipient,
       merkleTreeHook,

--- a/typescript/sdk/src/core/EvmCoreReader.ts
+++ b/typescript/sdk/src/core/EvmCoreReader.ts
@@ -1,12 +1,7 @@
 import { providers } from 'ethers';
 
 import { Mailbox__factory, ProxyAdmin__factory } from '@hyperlane-xyz/core';
-import {
-  Address,
-  objMap,
-  promiseObjAll,
-  rootLogger,
-} from '@hyperlane-xyz/utils';
+import { Address, assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { proxyAdmin } from '../deploy/proxy.js';
@@ -69,34 +64,63 @@ export class EvmCoreReader implements CoreReader {
         proxyAdmin(this.provider, mailboxInstance.address),
       ]);
 
+    const readConfig = async <T>(
+      readerCall: Promise<T> | undefined,
+    ): Promise<T | undefined> => {
+      try {
+        return await readerCall;
+      } catch (e) {
+        this.logger.error(
+          `EvmCoreReader: readerCall failed for ${mailbox}:`,
+          e,
+        );
+        return;
+      }
+    };
+
     // Parallelize each configuration request
-    const results = await promiseObjAll(
-      objMap(
-        {
-          owner: mailboxInstance.owner(),
-          defaultIsm: this.evmIsmReader.deriveIsmConfig(defaultIsm),
-          defaultHook: this.evmHookReader.deriveHookConfig(defaultHook),
-          requiredHook: this.evmHookReader.deriveHookConfig(requiredHook),
-          interchainAccountRouter: interchainAccountRouter
-            ? this.evmIcaRouterReader.deriveConfig(interchainAccountRouter)
-            : undefined,
-          proxyAdmin: this.getProxyAdminConfig(mailboxProxyAdmin),
-        },
-        async (_, readerCall) => {
-          try {
-            return readerCall;
-          } catch (e) {
-            this.logger.error(
-              `EvmCoreReader: readerCall failed for ${mailbox}:`,
-              e,
-            );
-            return;
-          }
-        },
+    const [
+      owner,
+      derivedDefaultIsm,
+      derivedDefaultHook,
+      derivedRequiredHook,
+      derivedIcaRouterConfig,
+      proxyAdminConfig,
+    ] = await Promise.all([
+      readConfig(mailboxInstance.owner()),
+      readConfig(this.evmIsmReader.deriveIsmConfig(defaultIsm)),
+      readConfig(this.evmHookReader.deriveHookConfig(defaultHook)),
+      readConfig(this.evmHookReader.deriveHookConfig(requiredHook)),
+      readConfig(
+        interchainAccountRouter
+          ? this.evmIcaRouterReader.deriveConfig(interchainAccountRouter)
+          : undefined,
       ),
+      readConfig(this.getProxyAdminConfig(mailboxProxyAdmin)),
+    ]);
+
+    assert(owner, `EvmCoreReader: owner read failed for ${mailbox}`);
+    assert(
+      derivedDefaultIsm,
+      `EvmCoreReader: defaultIsm read failed for ${mailbox}`,
+    );
+    assert(
+      derivedDefaultHook,
+      `EvmCoreReader: defaultHook read failed for ${mailbox}`,
+    );
+    assert(
+      derivedRequiredHook,
+      `EvmCoreReader: requiredHook read failed for ${mailbox}`,
     );
 
-    const derivedConfig = results as DerivedCoreConfig;
+    const derivedConfig: DerivedCoreConfig = {
+      owner,
+      defaultIsm: derivedDefaultIsm,
+      defaultHook: derivedDefaultHook,
+      requiredHook: derivedRequiredHook,
+      interchainAccountRouter: derivedIcaRouterConfig,
+      proxyAdmin: proxyAdminConfig,
+    };
     const hasLegacyIgp =
       hookTreeContainsLegacyIgp(derivedConfig.defaultHook) ||
       hookTreeContainsLegacyIgp(derivedConfig.requiredHook);

--- a/typescript/sdk/src/core/EvmCoreReader.ts
+++ b/typescript/sdk/src/core/EvmCoreReader.ts
@@ -11,6 +11,7 @@ import {
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { proxyAdmin } from '../deploy/proxy.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
+import { hookTreeContainsLegacyIgp } from '../hook/utils.js';
 import { EvmIcaRouterReader } from '../ica/EvmIcaReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -95,7 +96,15 @@ export class EvmCoreReader implements CoreReader {
       ),
     );
 
-    return results as DerivedCoreConfig;
+    const derivedConfig = results as DerivedCoreConfig;
+    const hasLegacyIgp =
+      hookTreeContainsLegacyIgp(derivedConfig.defaultHook) ||
+      hookTreeContainsLegacyIgp(derivedConfig.requiredHook);
+
+    return {
+      ...derivedConfig,
+      ...(hasLegacyIgp ? { deployQuotedCalls: false } : {}),
+    };
   }
 
   private async getProxyAdminConfig(

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -332,7 +332,7 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
 
     return {
       ...ownableContracts,
-      ...(quotedCalls ? { quotedCalls } : {}),
+      quotedCalls,
     };
   }
 }

--- a/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
+++ b/typescript/sdk/src/core/HyperlaneCoreDeployer.ts
@@ -3,6 +3,7 @@ import {
   IPostDispatchHook__factory,
   Mailbox,
   QuotedCalls,
+  QuotedCalls__factory,
   TestRecipient,
   ValidatorAnnounce,
 } from '@hyperlane-xyz/core';
@@ -32,7 +33,7 @@ import {
   PERMIT2_ADDRESS,
   coreFactories,
 } from './contracts.js';
-import { CoreConfig } from './types.js';
+import { CoreConfig, shouldDeployQuotedCalls } from './types.js';
 
 export class HyperlaneCoreDeployer extends HyperlaneDeployer<
   CoreConfig,
@@ -259,9 +260,16 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
     chain: ChainName,
     permit2?: Address,
   ): Promise<QuotedCalls> {
-    return this.deployContract(chain, 'quotedCalls', [
-      permit2 ?? PERMIT2_ADDRESS,
-    ]);
+    const quotedCalls = await this.deployContractFromFactory(
+      chain,
+      new QuotedCalls__factory(),
+      'quotedCalls',
+      [permit2 ?? PERMIT2_ADDRESS],
+      undefined,
+      true,
+    );
+    this.writeCache(chain, 'quotedCalls', quotedCalls.address);
+    return quotedCalls;
   }
 
   async deployTestRecipient(
@@ -293,7 +301,9 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
       mailbox.address,
     );
 
-    const quotedCalls = await this.deployQuotedCalls(chain, config.permit2);
+    const quotedCalls = shouldDeployQuotedCalls(config)
+      ? await this.deployQuotedCalls(chain, config.permit2)
+      : undefined;
 
     if (config.upgrade) {
       const timelockController = await this.deployTimelock(
@@ -322,7 +332,7 @@ export class HyperlaneCoreDeployer extends HyperlaneDeployer<
 
     return {
       ...ownableContracts,
-      quotedCalls,
+      ...(quotedCalls ? { quotedCalls } : {}),
     };
   }
 }

--- a/typescript/sdk/src/core/contracts.ts
+++ b/typescript/sdk/src/core/contracts.ts
@@ -10,10 +10,16 @@ import { HyperlaneAddresses } from '../contracts/types.js';
 // Canonical Permit2 deployment address (same on all EVM chains)
 export const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3';
 
-export const coreFactories = {
+const requiredCoreFactories = {
   validatorAnnounce: new ValidatorAnnounce__factory(),
   proxyAdmin: new ProxyAdmin__factory(),
   mailbox: new Mailbox__factory(),
+};
+
+export const coreFactories: typeof requiredCoreFactories & {
+  quotedCalls?: QuotedCalls__factory;
+} = {
+  ...requiredCoreFactories,
   quotedCalls: new QuotedCalls__factory(),
 };
 

--- a/typescript/sdk/src/core/types.test.ts
+++ b/typescript/sdk/src/core/types.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+
+import { HookType, IgpVersion } from '../hook/types.js';
+
+import { CoreConfigSchema } from './types.js';
+
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+
+const igpHook = (igpVersion?: IgpVersion) => ({
+  type: HookType.INTERCHAIN_GAS_PAYMASTER,
+  owner: ADDRESS,
+  beneficiary: ADDRESS,
+  oracleKey: ADDRESS,
+  overhead: {},
+  oracleConfig: {},
+  ...(igpVersion ? { igpVersion } : {}),
+});
+
+const baseConfig = (overrides: Record<string, unknown>) => ({
+  owner: ADDRESS,
+  defaultIsm: ADDRESS,
+  defaultHook: ADDRESS,
+  requiredHook: ADDRESS,
+  ...overrides,
+});
+
+describe('CoreConfigSchema legacy IGP / QuotedCalls guard', () => {
+  it('rejects a legacy IGP hook when deployQuotedCalls is not false', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({ defaultHook: igpHook(IgpVersion.Legacy) }),
+    );
+    expect(result.success).to.be.false;
+    if (!result.success) {
+      expect(result.error.issues[0].path).to.deep.equal(['deployQuotedCalls']);
+    }
+  });
+
+  it('allows a legacy IGP hook when deployQuotedCalls is false', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({
+        defaultHook: igpHook(IgpVersion.Legacy),
+        deployQuotedCalls: false,
+      }),
+    );
+    expect(result.success).to.be.true;
+  });
+
+  it('allows a latest IGP hook with QuotedCalls deploying', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({ defaultHook: igpHook(IgpVersion.Latest) }),
+    );
+    expect(result.success).to.be.true;
+  });
+
+  it('detects a legacy IGP nested inside an aggregation hook', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({
+        requiredHook: {
+          type: HookType.AGGREGATION,
+          hooks: [{ type: HookType.MERKLE_TREE }, igpHook(IgpVersion.Legacy)],
+        },
+      }),
+    );
+    expect(result.success).to.be.false;
+  });
+});

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -27,6 +27,8 @@ const CoreConfigBaseSchema = OwnableSchema.extend({
   interchainAccountRouter: IcaRouterConfigSchema.optional(),
   // Override canonical Permit2 address for QuotedCalls deployment
   permit2: z.string().optional(),
+  // Set false for chains that should keep legacy core artifacts only.
+  deployQuotedCalls: z.boolean().optional(),
 });
 
 const rejectRateLimitedDefaultIsm = (
@@ -71,6 +73,12 @@ export type CoreConfig = z.infer<typeof CoreConfigSchema> & {
   remove?: boolean;
   upgrade?: UpgradeConfig;
 };
+
+export function shouldDeployQuotedCalls(
+  config: Pick<CoreConfig, 'deployQuotedCalls'>,
+): boolean {
+  return config.deployQuotedCalls !== false;
+}
 
 export type CoreConfigHookFieldKey = keyof Pick<
   CoreConfig,

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -6,7 +6,12 @@ import type { Address, ParsedMessage } from '@hyperlane-xyz/utils';
 import type { UpgradeConfig } from '../deploy/proxy.js';
 import type { CheckerViolation } from '../deploy/types.js';
 import { ProxyFactoryFactoriesSchema } from '../deploy/types.js';
-import { DerivedHookConfig, HookConfigSchema } from '../hook/types.js';
+import {
+  DerivedHookConfig,
+  HookConfigSchema,
+  HookType,
+  IgpVersion,
+} from '../hook/types.js';
 import {
   DerivedIcaRouterConfigSchema,
   IcaRouterConfigSchema,
@@ -44,15 +49,75 @@ const rejectRateLimitedDefaultIsm = (
   }
 };
 
-export const CoreConfigSchema = CoreConfigBaseSchema.superRefine(
-  rejectRateLimitedDefaultIsm,
-);
+// Recursively checks a hook config tree for a legacy IGP (igpVersion: legacy).
+function hookTreeContainsLegacyIgp(hook: unknown): boolean {
+  if (typeof hook !== 'object' || hook === null) return false;
+  const node = hook as Record<string, unknown>;
+  if (
+    node.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
+    node.igpVersion === IgpVersion.Legacy
+  ) {
+    return true;
+  }
+  if (Array.isArray(node.hooks) && node.hooks.some(hookTreeContainsLegacyIgp)) {
+    return true;
+  }
+  if (
+    node.domains !== null &&
+    typeof node.domains === 'object' &&
+    Object.values(node.domains as Record<string, unknown>).some(
+      hookTreeContainsLegacyIgp,
+    )
+  ) {
+    return true;
+  }
+  return (
+    hookTreeContainsLegacyIgp(node.fallback) ||
+    hookTreeContainsLegacyIgp(node.lowerHook) ||
+    hookTreeContainsLegacyIgp(node.upperHook) ||
+    hookTreeContainsLegacyIgp(node.childHook)
+  );
+}
+
+// QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient
+// storage, so they ship together on the same (non-legacy) chains. Reject the
+// mismatch where a legacy IGP is configured but QuotedCalls is still set to
+// deploy (deployQuotedCalls !== false).
+const rejectQuotedCallsWithLegacyIgp = (
+  val: {
+    defaultHook: unknown;
+    requiredHook: unknown;
+    deployQuotedCalls?: boolean;
+  },
+  ctx: z.RefinementCtx,
+) => {
+  if (val.deployQuotedCalls === false) return;
+  if (
+    hookTreeContainsLegacyIgp(val.defaultHook) ||
+    hookTreeContainsLegacyIgp(val.requiredHook)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'deployQuotedCalls must be false when a legacy IGP (igpVersion: legacy) is configured: QuotedCalls requires EIP-1153 transient storage and pairs with the new offchain-quoting IGP.',
+      path: ['deployQuotedCalls'],
+    });
+  }
+};
+
+export const CoreConfigSchema = CoreConfigBaseSchema.superRefine((val, ctx) => {
+  rejectRateLimitedDefaultIsm(val, ctx);
+  rejectQuotedCallsWithLegacyIgp(val, ctx);
+});
 
 export const DerivedCoreConfigSchema = CoreConfigBaseSchema.merge(
   z.object({
     interchainAccountRouter: DerivedIcaRouterConfigSchema.optional(),
   }),
-).superRefine(rejectRateLimitedDefaultIsm);
+).superRefine((val, ctx) => {
+  rejectRateLimitedDefaultIsm(val, ctx);
+  rejectQuotedCallsWithLegacyIgp(val, ctx);
+});
 
 export const DeployedCoreAddressesSchema = ProxyFactoryFactoriesSchema.extend({
   mailbox: z.string(),

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -6,11 +6,8 @@ import type { Address, ParsedMessage } from '@hyperlane-xyz/utils';
 import type { UpgradeConfig } from '../deploy/proxy.js';
 import type { CheckerViolation } from '../deploy/types.js';
 import { ProxyFactoryFactoriesSchema } from '../deploy/types.js';
-import {
-  DerivedHookConfig,
-  HookConfig,
-  HookConfigSchema,
-} from '../hook/types.js';
+import type { DerivedHookConfig, HookConfig } from '../hook/types.js';
+import { HookConfigSchema } from '../hook/types.js';
 import { hookTreeContainsLegacyIgp } from '../hook/utils.js';
 import {
   DerivedIcaRouterConfigSchema,
@@ -55,16 +52,16 @@ const rejectRateLimitedDefaultIsm = (
 // deploy (deployQuotedCalls !== false).
 const rejectQuotedCallsWithLegacyIgp = (
   val: {
-    defaultHook: unknown;
-    requiredHook: unknown;
+    defaultHook: HookConfig;
+    requiredHook: HookConfig;
     deployQuotedCalls?: boolean;
   },
   ctx: z.RefinementCtx,
 ) => {
   if (val.deployQuotedCalls === false) return;
   if (
-    hookTreeContainsLegacyIgp(val.defaultHook as HookConfig) ||
-    hookTreeContainsLegacyIgp(val.requiredHook as HookConfig)
+    hookTreeContainsLegacyIgp(val.defaultHook) ||
+    hookTreeContainsLegacyIgp(val.requiredHook)
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -8,10 +8,10 @@ import type { CheckerViolation } from '../deploy/types.js';
 import { ProxyFactoryFactoriesSchema } from '../deploy/types.js';
 import {
   DerivedHookConfig,
+  HookConfig,
   HookConfigSchema,
-  HookType,
-  IgpVersion,
 } from '../hook/types.js';
+import { hookTreeContainsLegacyIgp } from '../hook/utils.js';
 import {
   DerivedIcaRouterConfigSchema,
   IcaRouterConfigSchema,
@@ -49,36 +49,6 @@ const rejectRateLimitedDefaultIsm = (
   }
 };
 
-// Recursively checks a hook config tree for a legacy IGP (igpVersion: legacy).
-function hookTreeContainsLegacyIgp(hook: unknown): boolean {
-  if (typeof hook !== 'object' || hook === null) return false;
-  const node = hook as Record<string, unknown>;
-  if (
-    node.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
-    node.igpVersion === IgpVersion.Legacy
-  ) {
-    return true;
-  }
-  if (Array.isArray(node.hooks) && node.hooks.some(hookTreeContainsLegacyIgp)) {
-    return true;
-  }
-  if (
-    node.domains !== null &&
-    typeof node.domains === 'object' &&
-    Object.values(node.domains as Record<string, unknown>).some(
-      hookTreeContainsLegacyIgp,
-    )
-  ) {
-    return true;
-  }
-  return (
-    hookTreeContainsLegacyIgp(node.fallback) ||
-    hookTreeContainsLegacyIgp(node.lowerHook) ||
-    hookTreeContainsLegacyIgp(node.upperHook) ||
-    hookTreeContainsLegacyIgp(node.childHook)
-  );
-}
-
 // QuotedCalls and the offchain-quoting IGP both require EIP-1153 transient
 // storage, so they ship together on the same (non-legacy) chains. Reject the
 // mismatch where a legacy IGP is configured but QuotedCalls is still set to
@@ -93,8 +63,8 @@ const rejectQuotedCallsWithLegacyIgp = (
 ) => {
   if (val.deployQuotedCalls === false) return;
   if (
-    hookTreeContainsLegacyIgp(val.defaultHook) ||
-    hookTreeContainsLegacyIgp(val.requiredHook)
+    hookTreeContainsLegacyIgp(val.defaultHook as HookConfig) ||
+    hookTreeContainsLegacyIgp(val.requiredHook as HookConfig)
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -4,6 +4,7 @@ import {
   InterchainGasPaymaster,
   ProxyAdmin,
   StorageGasOracle,
+  StorageGasOracle__factory,
 } from '@hyperlane-xyz/core';
 import {
   addBufferToGasLimit,
@@ -50,6 +51,12 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     assert(
       !config.quoteSigners?.length,
       `Legacy IGP on ${chain} does not support quoteSigners`,
+    );
+
+    assert(
+      !config.tokenOracleConfig ||
+        Object.keys(config.tokenOracleConfig).length === 0,
+      'Legacy IGP on ' + chain + ' does not support tokenOracleConfig',
     );
 
     const cachedAddresses = this.cachedAddresses[chain] ?? {};
@@ -152,6 +159,8 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
       }
     }
 
+    await this.configureTokenGasOracles(chain, igp, config);
+
     return igp;
   }
 
@@ -168,11 +177,32 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
       return gasOracle;
     }
 
+    await this.configureStorageGasOracle(
+      chain,
+      gasOracle,
+      config.oracleConfig,
+      config.overhead,
+    );
+
+    return gasOracle;
+  }
+
+  /**
+   * Reconciles the remote gas data stored on a StorageGasOracle against the
+   * desired config, submitting only the drifted entries. Shared by the native
+   * oracle and per-fee-token oracles.
+   */
+  protected async configureStorageGasOracle(
+    chain: ChainName,
+    gasOracle: StorageGasOracle,
+    oracleConfig: NonNullable<IgpConfig['oracleConfig']>,
+    overhead: IgpConfig['overhead'],
+  ): Promise<void> {
     this.logger.info(`Configuring gas oracle from ${chain}...`);
     const configsToSet: Array<StorageGasOracle.RemoteGasDataConfigStruct> = [];
 
     // For each remote, check if the gas oracle has the correct data
-    for (const [remote, desired] of Object.entries(config.oracleConfig)) {
+    for (const [remote, desired] of Object.entries(oracleConfig)) {
       // TODO: add back support for non-EVM remotes.
       // Previously would check core metadata for non EVMs and fallback to multiprovider for custom EVMs
       const remoteDomain = this.multiProvider.tryGetDomainId(remote);
@@ -204,7 +234,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
         });
       }
 
-      const exampleRemoteGas = (config.overhead[remote] ?? 200_000) + 50_000;
+      const exampleRemoteGas = (overhead[remote] ?? 200_000) + 50_000;
       const exampleRemoteGasCost = desiredData.tokenExchangeRate
         .mul(desiredData.gasPrice)
         .mul(exampleRemoteGas)
@@ -237,8 +267,127 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
         );
       });
     }
+  }
 
-    return gasOracle;
+  /**
+   * Wires per-fee-token gas oracles on the IGP for ERC20-denominated gas
+   * payments. Target-driven and idempotent: each fee token's oracle is resolved
+   * from the on-chain tokenGasOracles mapping (no off-chain bookkeeping), or a
+   * dedicated StorageGasOracle is deployed if none is wired yet. Must run while
+   * the deployer still owns the IGP (setTokenGasOracles is onlyOwner) and after
+   * the native gas params, since the IGP requires a destination's native oracle
+   * to exist before a token oracle can be set for it.
+   */
+  protected async configureTokenGasOracles(
+    chain: ChainName,
+    igp: InterchainGasPaymaster,
+    config: IgpConfig,
+  ): Promise<void> {
+    if (!config.tokenOracleConfig) return;
+    this.assertLegacyIgpConfig(chain, config);
+
+    for (const [feeToken, oracleConfig] of Object.entries(
+      config.tokenOracleConfig,
+    )) {
+      const remotes = Object.keys(oracleConfig)
+        .map((remote) => ({
+          remote,
+          remoteDomain: this.multiProvider.tryGetDomainId(remote),
+        }))
+        .filter(
+          (r): r is { remote: string; remoteDomain: number } =>
+            r.remoteDomain !== null,
+        );
+
+      if (remotes.length === 0) {
+        this.logger.warn(
+          `Skipping token gas oracle for ${feeToken} on ${chain}: no configured remotes in MultiProvider`,
+        );
+        continue;
+      }
+
+      // Reuse the oracle already wired for this fee token (across any of its
+      // destinations), otherwise deploy a dedicated one.
+      let gasOracle: StorageGasOracle | undefined;
+      for (const { remoteDomain } of remotes) {
+        const existing = await igp.tokenGasOracles(feeToken, remoteDomain);
+        if (!eqAddress(existing, ethers.constants.AddressZero)) {
+          gasOracle = StorageGasOracle__factory.connect(
+            existing,
+            this.multiProvider.getSigner(chain),
+          );
+          break;
+        }
+      }
+
+      if (!gasOracle) {
+        // shouldRecover=false so we don't read back the native 'storageGasOracle'
+        // cache entry; idempotency comes from the on-chain mapping check above.
+        gasOracle = await this.deployContractFromFactory(
+          chain,
+          new StorageGasOracle__factory(),
+          'storageGasOracle',
+          [],
+          undefined,
+          false,
+        );
+      }
+
+      await this.configureStorageGasOracle(
+        chain,
+        gasOracle,
+        oracleConfig,
+        config.overhead,
+      );
+
+      // Transfer the token oracle to the configured oracle key, matching the
+      // native oracle's ownership.
+      await this.runIfOwner(chain, gasOracle, async () => {
+        const oracle = gasOracle!;
+        if (!eqAddress(await oracle.owner(), config.oracleKey)) {
+          await this.multiProvider.handleTx(
+            chain,
+            oracle.transferOwnership(
+              config.oracleKey,
+              this.multiProvider.getTransactionOverrides(chain),
+            ),
+          );
+        }
+      });
+
+      // Point any destinations not yet mapped to this oracle at it.
+      const tokenOracleParams: InterchainGasPaymaster.TokenGasOracleConfigStruct[] =
+        [];
+      for (const { remoteDomain } of remotes) {
+        const current = await igp.tokenGasOracles(feeToken, remoteDomain);
+        if (!eqAddress(current, gasOracle.address)) {
+          tokenOracleParams.push({
+            feeToken,
+            remoteDomain,
+            gasOracle: gasOracle.address,
+          });
+        }
+      }
+
+      if (tokenOracleParams.length > 0) {
+        await this.runIfOwner(chain, igp, async () => {
+          this.logger.info(
+            `Setting token gas oracles for ${feeToken} on ${chain} (domains ${tokenOracleParams
+              .map((p) => p.remoteDomain)
+              .join(', ')})`,
+          );
+          const estimatedGas =
+            await igp.estimateGas.setTokenGasOracles(tokenOracleParams);
+          await this.multiProvider.handleTx(
+            chain,
+            igp.setTokenGasOracles(tokenOracleParams, {
+              gasLimit: addBufferToGasLimit(estimatedGas),
+              ...this.multiProvider.getTransactionOverrides(chain),
+            }),
+          );
+        });
+      }
+    }
   }
 
   async deployContracts(

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -342,12 +342,15 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
       // Transfer the token oracle to the configured oracle key, matching the
       // native oracle's ownership.
+      assert(
+        gasOracle,
+        `Expected token gas oracle for ${feeToken} on ${chain}`,
+      );
       await this.runIfOwner(chain, gasOracle, async () => {
-        const oracle = gasOracle!;
-        if (!eqAddress(await oracle.owner(), config.oracleKey)) {
+        if (!eqAddress(await gasOracle.owner(), config.oracleKey)) {
           await this.multiProvider.handleTx(
             chain,
-            oracle.transferOwnership(
+            gasOracle.transferOwnership(
               config.oracleKey,
               this.multiProvider.getTransactionOverrides(chain),
             ),

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -287,7 +287,12 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     igp: InterchainGasPaymaster,
     config: IgpConfig,
   ): Promise<void> {
-    if (!config.tokenOracleConfig) return;
+    if (
+      !config.tokenOracleConfig ||
+      Object.keys(config.tokenOracleConfig).length === 0
+    ) {
+      return;
+    }
     this.assertLegacyIgpConfig(chain, config);
     assertTokenOracleConfigHasNativeRemotes(chain, config);
 

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -18,7 +18,7 @@ import { HyperlaneContracts } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { submitBatched } from '../deploy/utils.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
-import { IgpVersion } from '../hook/types.js';
+import { IgpVersion, OFFCHAIN_QUOTED_IGP_VERSION } from '../hook/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -27,7 +27,11 @@ import {
   oracleConfigToOracleData,
   serializeDifference,
 } from './oracle/types.js';
-import { IgpConfig } from './types.js';
+import {
+  IgpConfig,
+  assertTokenOracleConfigHasNativeRemotes,
+  igpSupportsOffchainFeeQuoting,
+} from './types.js';
 
 export class HyperlaneIgpDeployer extends HyperlaneDeployer<
   IgpConfig,
@@ -56,7 +60,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     assert(
       !config.tokenOracleConfig ||
         Object.keys(config.tokenOracleConfig).length === 0,
-      'Legacy IGP on ' + chain + ' does not support tokenOracleConfig',
+      `Legacy IGP on ${chain} does not support tokenOracleConfig`,
     );
 
     const cachedAddresses = this.cachedAddresses[chain] ?? {};
@@ -285,6 +289,24 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
   ): Promise<void> {
     if (!config.tokenOracleConfig) return;
     this.assertLegacyIgpConfig(chain, config);
+    assertTokenOracleConfigHasNativeRemotes(chain, config);
+
+    let contractVersion: string;
+    try {
+      contractVersion = await igp.PACKAGE_VERSION();
+    } catch (error) {
+      throw new Error(
+        `IGP tokenOracleConfig on ${chain} requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+        { cause: error },
+      );
+    }
+    assert(
+      igpSupportsOffchainFeeQuoting({
+        igpVersion: config.igpVersion,
+        contractVersion,
+      }),
+      `IGP tokenOracleConfig on ${chain} requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+    );
 
     for (const [feeToken, oracleConfig] of Object.entries(
       config.tokenOracleConfig,

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -7,6 +7,7 @@ import {
 } from '@hyperlane-xyz/core';
 import {
   addBufferToGasLimit,
+  assert,
   eqAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -16,6 +17,7 @@ import { HyperlaneContracts } from '../contracts/types.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { submitBatched } from '../deploy/utils.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
+import { IgpVersion } from '../hook/types.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainName } from '../types.js';
 
@@ -42,12 +44,41 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     });
   }
 
+  protected assertLegacyIgpConfig(chain: ChainName, config: IgpConfig): void {
+    if (config.igpVersion !== IgpVersion.Legacy) return;
+
+    assert(
+      !config.quoteSigners?.length,
+      'Legacy IGP on ' + chain + ' does not support quoteSigners',
+    );
+
+    const cachedAddresses = this.cachedAddresses[chain] ?? {};
+    const requiredCachedContracts: Array<keyof IgpFactories> = [
+      'interchainGasPaymaster',
+      'proxyAdmin',
+      'storageGasOracle',
+    ];
+    const missing = requiredCachedContracts.filter(
+      (contractName) => !cachedAddresses[contractName],
+    );
+
+    assert(
+      missing.length === 0,
+      'Legacy IGP on ' +
+        chain +
+        ' requires existing cached addresses for ' +
+        missing.join(', '),
+    );
+  }
+
   async deployInterchainGasPaymaster(
     chain: ChainName,
     proxyAdmin: ProxyAdmin,
     storageGasOracle: StorageGasOracle,
     config: IgpConfig,
   ): Promise<InterchainGasPaymaster> {
+    this.assertLegacyIgpConfig(chain, config);
+
     const igp = await this.deployProxiedContract(
       chain,
       'interchainGasPaymaster',
@@ -129,6 +160,8 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     chain: ChainName,
     config: IgpConfig,
   ): Promise<StorageGasOracle> {
+    this.assertLegacyIgpConfig(chain, config);
+
     const gasOracle = await this.deployContract(chain, 'storageGasOracle', []);
 
     if (!config.oracleConfig) {
@@ -213,6 +246,8 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
     chain: ChainName,
     config: IgpConfig,
   ): Promise<HyperlaneContracts<IgpFactories>> {
+    this.assertLegacyIgpConfig(chain, config);
+
     // NB: To share ProxyAdmins with HyperlaneCore, ensure the ProxyAdmin
     // is loaded into the contract cache.
     const proxyAdmin = await this.deployContract(chain, 'proxyAdmin', []);

--- a/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
+++ b/typescript/sdk/src/gas/HyperlaneIgpDeployer.ts
@@ -49,7 +49,7 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
     assert(
       !config.quoteSigners?.length,
-      'Legacy IGP on ' + chain + ' does not support quoteSigners',
+      `Legacy IGP on ${chain} does not support quoteSigners`,
     );
 
     const cachedAddresses = this.cachedAddresses[chain] ?? {};
@@ -64,10 +64,9 @@ export class HyperlaneIgpDeployer extends HyperlaneDeployer<
 
     assert(
       missing.length === 0,
-      'Legacy IGP on ' +
-        chain +
-        ' requires existing cached addresses for ' +
-        missing.join(', '),
+      `Legacy IGP on ${chain} requires existing cached addresses for ${missing.join(
+        ', ',
+      )}`,
     );
   }
 

--- a/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
+++ b/typescript/sdk/src/gas/oracle/configure-gas-oracles.hardhat-test.ts
@@ -1,12 +1,16 @@
 import { expect } from 'chai';
-import { utils } from 'ethers';
+import { constants, utils } from 'ethers';
 import hre from 'hardhat';
 
-import { InterchainGasPaymaster } from '@hyperlane-xyz/core';
+import {
+  InterchainGasPaymaster,
+  StorageGasOracle__factory,
+} from '@hyperlane-xyz/core';
+import { eqAddress } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
-import { testIgpConfig } from '../../test/testUtils.js';
+import { randomAddress, testIgpConfig } from '../../test/testUtils.js';
 import { ChainMap } from '../../types.js';
 import { HyperlaneIgpDeployer } from '../HyperlaneIgpDeployer.js';
 import { IgpConfig } from '../types.js';
@@ -79,5 +83,45 @@ describe('HyperlaneIgpDeployer', () => {
       modifiedConfig.tokenExchangeRate.eq(expected.tokenExchangeRate),
       `tokenExchangeRate mismatch: expected ${expected.tokenExchangeRate.toString()}, got ${modifiedConfig.tokenExchangeRate.toString()}`,
     ).to.be.true;
+  });
+
+  it('should wire a per-fee-token gas oracle via setTokenGasOracles', async () => {
+    const feeToken = randomAddress();
+    const tokenOracle = {
+      tokenExchangeRate: utils.parseUnits('5', 'gwei').toString(),
+      gasPrice: utils.parseUnits('7', 'gwei').toString(),
+      tokenDecimals: 18,
+    };
+    testConfig[local].tokenOracleConfig = {
+      [feeToken]: { [remote]: tokenOracle },
+    };
+
+    const localContracts = await deployer.deployContracts(
+      local,
+      testConfig[local],
+    );
+    igp = localContracts.interchainGasPaymaster;
+
+    // A dedicated oracle is wired for the fee token, distinct from the native one.
+    const oracleAddress = await igp.tokenGasOracles(feeToken, remoteId);
+    expect(eqAddress(oracleAddress, constants.AddressZero)).to.be.false;
+    const nativeOracle = (await igp.destinationGasConfigs(remoteId)).gasOracle;
+    expect(eqAddress(oracleAddress, nativeOracle)).to.be.false;
+
+    // The oracle returns the configured token rates.
+    const oracle = StorageGasOracle__factory.connect(
+      oracleAddress,
+      multiProvider.getProvider(local),
+    );
+    const data = await oracle.getExchangeRateAndGasPrice(remoteId);
+    const expected = oracleConfigToOracleData(tokenOracle);
+    expect(data.gasPrice.eq(expected.gasPrice)).to.be.true;
+    expect(data.tokenExchangeRate.eq(expected.tokenExchangeRate)).to.be.true;
+
+    // Re-deploying with the same config is idempotent (oracle resolved on-chain).
+    const oracleBefore = oracleAddress;
+    await deployer.deployContracts(local, testConfig[local]);
+    const oracleAfter = await igp.tokenGasOracles(feeToken, remoteId);
+    expect(eqAddress(oracleAfter, oracleBefore)).to.be.true;
   });
 });

--- a/typescript/sdk/src/gas/types.ts
+++ b/typescript/sdk/src/gas/types.ts
@@ -2,13 +2,58 @@ import { BigNumber } from 'ethers';
 import { z } from 'zod';
 
 import { InterchainGasPaymaster } from '@hyperlane-xyz/core';
+import { assert } from '@hyperlane-xyz/utils';
+import { compareVersions } from 'compare-versions';
 import type { Address } from '@hyperlane-xyz/utils';
 
 import type { CheckerViolation } from '../deploy/types.js';
-import { IgpSchema } from '../hook/types.js';
-import { ChainMap } from '../types.js';
+import {
+  IgpSchema,
+  IgpVersion,
+  OFFCHAIN_QUOTED_IGP_VERSION,
+} from '../hook/types.js';
+import { ChainMap, ChainName } from '../types.js';
 
 export type IgpConfig = z.infer<typeof IgpSchema>;
+
+export function igpSupportsOffchainFeeQuoting({
+  igpVersion,
+  contractVersion,
+  quoteSigners,
+}: {
+  igpVersion?: IgpVersion;
+  contractVersion?: string;
+  quoteSigners?: string[];
+}): boolean {
+  return (
+    igpVersion !== IgpVersion.Legacy &&
+    (quoteSigners !== undefined ||
+      (contractVersion !== undefined &&
+        compareVersions(contractVersion, OFFCHAIN_QUOTED_IGP_VERSION) >= 0))
+  );
+}
+
+export function assertTokenOracleConfigHasNativeRemotes(
+  chain: ChainName,
+  config: Pick<IgpConfig, 'overhead' | 'tokenOracleConfig'>,
+): void {
+  if (!config.tokenOracleConfig) return;
+
+  const configuredNativeRemotes = new Set(Object.keys(config.overhead));
+  for (const [feeToken, oracleConfig] of Object.entries(
+    config.tokenOracleConfig,
+  )) {
+    const missingNativeRemotes = Object.keys(oracleConfig).filter(
+      (remote) => !configuredNativeRemotes.has(remote),
+    );
+    assert(
+      missingNativeRemotes.length === 0,
+      `Token gas oracle config for ${feeToken} on ${chain} includes remotes without native gas oracle config: ${missingNativeRemotes.join(
+        ', ',
+      )}`,
+    );
+  }
+}
 
 export enum IgpViolationType {
   Beneficiary = 'Beneficiary',

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -10,6 +10,7 @@ import {
 // Fee quote the IGP computes for a message, in the local (fee-token) base unit:
 //   quote = gasAmount * gasPrice * tokenExchangeRate / 1e10
 const EXCHANGE_RATE_SCALE = 1e10;
+const MAX_REBALANCED_QUOTE_ROUNDING_ERROR = 1 / 1000;
 function quote(
   config: { gasPrice: string; tokenExchangeRate: string },
   gasAmount: number,
@@ -69,40 +70,39 @@ describe('getLocalStorageGasOracleConfig', () => {
       exchangeRateMarginPct: 0,
     }).remote;
 
-    // Exchange rate must stay well above the floor (not collapse to 1).
-    expect(Number(config.tokenExchangeRate)).to.be.greaterThan(1);
+    // Exchange rate must be representable before integer rounding.
+    expect(Number(config.tokenExchangeRate)).to.be.at.least(1);
 
     // The quote (gasPrice * exchangeRate product) must match the intended value:
     // intended per-gas = 5e10 * 0.1 / 1e10 = 0.5 base units per unit gas.
     const gasAmount = 200_000;
     expect(quote(config, gasAmount)).to.be.approximately(
       0.5 * gasAmount,
-      0.5 * gasAmount * 0.001, // within 0.1% (ceil rounding on the gas price)
+      0.5 * gasAmount * MAX_REBALANCED_QUOTE_ROUNDING_ERROR,
     );
   });
 
-  it('falls back to the floor when the gas price is too small to rebalance', () => {
-    // gasPrice in wei (100) is below MIN_REBALANCED_GAS_PRICE, so there is no
-    // magnitude to shift; the exchange rate floors to 1 rather than throwing.
+  it('throws when a sub-unit exchange rate has no gas price headroom to rebalance', () => {
+    // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
+    // magnitude into the exchange rate would exceed the rounding-error bound.
     const gasOracleParams: Record<string, ChainGasOracleParams> = {
       feeToken: {
         gasPrice: { amount: '1', decimals: 9 },
         nativeToken: { price: '1', decimals: 6 },
       },
       remote: {
-        gasPrice: { amount: '100', decimals: 0 }, // 100 wei
+        gasPrice: { amount: '5', decimals: 0 }, // <10 wei
         nativeToken: { price: '10', decimals: 18 },
       },
     };
 
-    const config = getLocalStorageGasOracleConfig({
-      local: 'feeToken',
-      localProtocolType: ProtocolType.Ethereum,
-      gasOracleParams,
-      exchangeRateMarginPct: 0,
-    }).remote;
-
-    expect(config.tokenExchangeRate).to.equal('1');
-    expect(config.gasPrice).to.equal('100');
+    expect(() =>
+      getLocalStorageGasOracleConfig({
+        local: 'feeToken',
+        localProtocolType: ProtocolType.Ethereum,
+        gasOracleParams,
+        exchangeRateMarginPct: 0,
+      }),
+    ).to.throw('Token exchange rate must be at least 1');
   });
 });

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -138,4 +138,27 @@ describe('getLocalStorageGasOracleConfig', () => {
     expect(config.tokenExchangeRate).to.equal('1');
     expect(config.gasPrice).to.equal('5');
   });
+
+  it('uses a smaller gas price scale when the exchange rate would floor to zero', () => {
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      local: {
+        gasPrice: { amount: '1', decimals: 0 },
+        nativeToken: { price: '1', decimals: 18 },
+      },
+      remote: {
+        gasPrice: { amount: '0.5', decimals: 0 },
+        nativeToken: { price: '0.0000001', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'local',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    expect(config.tokenExchangeRate).to.equal('1');
+    expect(config.gasPrice).to.equal('500');
+  });
 });

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -82,7 +82,7 @@ describe('getLocalStorageGasOracleConfig', () => {
     );
   });
 
-  it('throws when a sub-unit exchange rate has no gas price headroom to rebalance', () => {
+  it('falls back to the floor when there is no gas price headroom to rebalance', () => {
     // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
     // magnitude into the exchange rate would exceed the rounding-error bound.
     const gasOracleParams: Record<string, ChainGasOracleParams> = {
@@ -96,13 +96,14 @@ describe('getLocalStorageGasOracleConfig', () => {
       },
     };
 
-    expect(() =>
-      getLocalStorageGasOracleConfig({
-        local: 'feeToken',
-        localProtocolType: ProtocolType.Ethereum,
-        gasOracleParams,
-        exchangeRateMarginPct: 0,
-      }),
-    ).to.throw('Token exchange rate must be at least 1');
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    expect(config.tokenExchangeRate).to.equal('1');
+    expect(config.gasPrice).to.equal('5');
   });
 });

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -85,6 +85,8 @@ describe('getLocalStorageGasOracleConfig', () => {
   it('falls back to the floor when there is no gas price headroom to rebalance', () => {
     // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
     // magnitude into the exchange rate would exceed the rounding-error bound.
+    // This documents the known fallback limitation: the quote is overpriced by
+    // the sub-1 exchange rate factor rather than preserving precision.
     const gasOracleParams: Record<string, ChainGasOracleParams> = {
       feeToken: {
         gasPrice: { amount: '1', decimals: 9 },

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -82,6 +82,36 @@ describe('getLocalStorageGasOracleConfig', () => {
     );
   });
 
+  it('preserves precision for non-power-of-ten exchange rates', () => {
+    // 6-decimal fee token paying for an 18-decimal remote, remote worth 15x.
+    // Naively the scaled exchange rate is 0.15. Shifting only one digit makes
+    // this 1.5, which floors to 1 and underquotes by 33%; using all safe
+    // gas-price headroom keeps the floor rounding error negligible.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      feeToken: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 6 },
+      },
+      remote: {
+        gasPrice: { amount: '50', decimals: 9 }, // 50 gwei = 5e10 wei
+        nativeToken: { price: '15', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    const gasAmount = 200_000;
+    expect(quote(config, gasAmount)).to.be.approximately(
+      0.75 * gasAmount,
+      0.75 * gasAmount * MAX_REBALANCED_QUOTE_ROUNDING_ERROR,
+    );
+  });
+
   it('falls back to the floor when there is no gas price headroom to rebalance', () => {
     // gasPrice in wei (5) is below MIN_REBALANCED_GAS_PRICE, so shifting any
     // magnitude into the exchange rate would exceed the rounding-error bound.

--- a/typescript/sdk/src/gas/utils.test.ts
+++ b/typescript/sdk/src/gas/utils.test.ts
@@ -1,0 +1,108 @@
+import { expect } from 'chai';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import {
+  ChainGasOracleParams,
+  getLocalStorageGasOracleConfig,
+} from './utils.js';
+
+// Fee quote the IGP computes for a message, in the local (fee-token) base unit:
+//   quote = gasAmount * gasPrice * tokenExchangeRate / 1e10
+const EXCHANGE_RATE_SCALE = 1e10;
+function quote(
+  config: { gasPrice: string; tokenExchangeRate: string },
+  gasAmount: number,
+): number {
+  return (
+    (gasAmount * Number(config.gasPrice) * Number(config.tokenExchangeRate)) /
+    EXCHANGE_RATE_SCALE
+  );
+}
+
+describe('getLocalStorageGasOracleConfig', () => {
+  it('leaves same-decimal native pairs unchanged (no rebalance)', () => {
+    // local + remote both 18-decimal native tokens; remote worth 2x local.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      local: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 18 },
+      },
+      remote: {
+        gasPrice: { amount: '1', decimals: 9 }, // 1 gwei = 1e9 wei
+        nativeToken: { price: '2', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'local',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    });
+
+    // exchangeRate = (2/1) * 1e10 ; gasPrice = 1e9 ; both pass through as-is.
+    expect(config.remote.tokenExchangeRate).to.equal('20000000000');
+    expect(config.remote.gasPrice).to.equal('1000000000');
+  });
+
+  it('rebalances a sub-unit exchange rate for a low-decimal fee token', () => {
+    // 6-decimal fee token paying for an 18-decimal remote, remote worth 10x.
+    // Naively the scaled exchange rate is (10) * 10^(6-18) * 1e10 = 0.1, which
+    // would floor to 1 and overprice the quote 10x. The rebalance must keep it
+    // representable while preserving the quote.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      feeToken: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 6 },
+      },
+      remote: {
+        gasPrice: { amount: '50', decimals: 9 }, // 50 gwei = 5e10 wei
+        nativeToken: { price: '10', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    // Exchange rate must stay well above the floor (not collapse to 1).
+    expect(Number(config.tokenExchangeRate)).to.be.greaterThan(1);
+
+    // The quote (gasPrice * exchangeRate product) must match the intended value:
+    // intended per-gas = 5e10 * 0.1 / 1e10 = 0.5 base units per unit gas.
+    const gasAmount = 200_000;
+    expect(quote(config, gasAmount)).to.be.approximately(
+      0.5 * gasAmount,
+      0.5 * gasAmount * 0.001, // within 0.1% (ceil rounding on the gas price)
+    );
+  });
+
+  it('falls back to the floor when the gas price is too small to rebalance', () => {
+    // gasPrice in wei (100) is below MIN_REBALANCED_GAS_PRICE, so there is no
+    // magnitude to shift; the exchange rate floors to 1 rather than throwing.
+    const gasOracleParams: Record<string, ChainGasOracleParams> = {
+      feeToken: {
+        gasPrice: { amount: '1', decimals: 9 },
+        nativeToken: { price: '1', decimals: 6 },
+      },
+      remote: {
+        gasPrice: { amount: '100', decimals: 0 }, // 100 wei
+        nativeToken: { price: '10', decimals: 18 },
+      },
+    };
+
+    const config = getLocalStorageGasOracleConfig({
+      local: 'feeToken',
+      localProtocolType: ProtocolType.Ethereum,
+      gasOracleParams,
+      exchangeRateMarginPct: 0,
+    }).remote;
+
+    expect(config.tokenExchangeRate).to.equal('1');
+    expect(config.gasPrice).to.equal('100');
+  });
+});

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -329,6 +329,11 @@ function adjustForPrecisionLoss(
     }
 
     if (newExchangeRate.lt(1)) {
+      // Known limitation: gas prices below 10 * MIN_REBALANCED_GAS_PRICE do
+      // not have a full decimal digit of headroom to shift while preserving the
+      // final ceil rounding-error bound. In that no-headroom band, keep the
+      // original gas price and fall back to the minimum representable exchange
+      // rate instead of introducing a larger ceil error.
       rootLogger.warn(
         `Token exchange rate remains below 1 after precision rebalance; falling back to minimum on-chain exchange rate. Original gas price: ${new BigNumberJs(
           gasPrice,

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -7,6 +7,7 @@ import {
   assert,
   convertDecimals,
   objMap,
+  rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { getProtocolExchangeRateDecimals } from '../consts/igp.js';
@@ -327,12 +328,13 @@ function adjustForPrecisionLoss(
       newGasPrice = newGasPrice.div(factor);
     }
 
-    assert(
-      newExchangeRate.gte(1),
-      `Token exchange rate must be at least 1 after precision rebalance. Original gas price: ${new BigNumberJs(
-        gasPrice,
-      ).toString()}, original exchange rate: ${exchangeRate.toString()}`,
-    );
+    if (newExchangeRate.lt(1)) {
+      rootLogger.warn(
+        `Token exchange rate remains below 1 after precision rebalance; falling back to minimum on-chain exchange rate. Original gas price: ${new BigNumberJs(
+          gasPrice,
+        ).toString()}, original exchange rate: ${exchangeRate.toString()}`,
+      );
+    }
   }
 
   // We may have very little precision, and ultimately need an integer value for

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -310,18 +310,10 @@ function adjustForPrecisionLoss(
   // preserved while the on-chain exchange rate keeps its precision. No-op for
   // same-decimal native pairs, where the scaled rate is already >> 1.
   if (newExchangeRate.lt(1)) {
-    const headroom = decimalMagnitude(
+    const shiftMagnitude = decimalMagnitude(
       newGasPrice.div(MIN_REBALANCED_GAS_PRICE),
     );
-    let digitsNeeded = 0;
-    while (
-      digitsNeeded < headroom &&
-      newExchangeRate.times(new BigNumberJs(10).pow(digitsNeeded)).lt(1)
-    ) {
-      digitsNeeded += 1;
-    }
 
-    const shiftMagnitude = Math.min(headroom, digitsNeeded);
     if (shiftMagnitude > 0) {
       const factor = new BigNumberJs(10).pow(shiftMagnitude);
       newExchangeRate = newExchangeRate.times(factor);

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -1,6 +1,6 @@
 import { Provider } from '@ethersproject/providers';
 import { BigNumber as BigNumberJs } from 'bignumber.js';
-import { BigNumber, ethers } from 'ethers';
+import { ethers } from 'ethers';
 
 import {
   ProtocolType,
@@ -160,20 +160,17 @@ function getTokenExchangeRate({
   return exchangeRate;
 }
 
-function getProtocolExchangeRate(
+// Scales the (decimal-adjusted) exchange rate by the protocol's fixed-point
+// multiplier. Returns a float that may be < 1 (e.g. for a low-decimal fee token
+// paying for a high-decimal native chain); rounding to an integer and any
+// precision rebalancing against the gas price happen later in
+// adjustForPrecisionLoss.
+function scaleProtocolExchangeRate(
   localProtocolType: ProtocolType,
   exchangeRate: InstanceType<typeof BigNumberJs>,
-): BigNumber {
+): InstanceType<typeof BigNumberJs> {
   const multiplierDecimals = getProtocolExchangeRateDecimals(localProtocolType);
-  const multiplier = new BigNumberJs(10).pow(multiplierDecimals);
-  const integer = exchangeRate
-    .times(multiplier)
-    .integerValue(BigNumberJs.ROUND_FLOOR)
-    .toString(10);
-  const result = BigNumber.from(integer);
-
-  // Ensure exchange rate is at least 1
-  return result.lt(1) ? BigNumber.from(1) : result;
+  return exchangeRate.times(new BigNumberJs(10).pow(multiplierDecimals));
 }
 
 // Gets the StorageGasOracleConfig for each remote chain for a particular local chain.
@@ -236,8 +233,10 @@ export function getLocalStorageGasOracleConfig({
       );
     }
 
-    // Make the exchange rate an integer by scaling it up by the appropriate factor for the protocol.
-    const exchangeRate = getProtocolExchangeRate(
+    // Scale the exchange rate by the protocol's fixed-point factor. Kept as a
+    // float here; adjustForPrecisionLoss does the final integer rounding (and
+    // rebalances against the gas price if it would otherwise underflow).
+    const scaledExchangeRate = scaleProtocolExchangeRate(
       localProtocolType,
       exchangeRateFloat,
     );
@@ -257,14 +256,14 @@ export function getLocalStorageGasOracleConfig({
     // Get a prospective gasOracleConfig, adjusting the gas price and exchange rate
     // as needed to account for precision loss (e.g. if the gas price is super small).
     let gasOracleConfig: ProtocolAgnositicGasOracleConfigWithTypicalCost =
-      adjustForPrecisionLoss(gasPrice, exchangeRate, remoteDecimals);
+      adjustForPrecisionLoss(gasPrice, scaledExchangeRate, remoteDecimals);
 
     // Apply the modifier if provided.
     if (gasPriceModifier) {
       // Once again adjust for precision loss after applying the modifier.
       gasOracleConfig = adjustForPrecisionLoss(
         gasPriceModifier(local, remote, gasOracleConfig),
-        BigNumber.from(gasOracleConfig.tokenExchangeRate),
+        new BigNumberJs(gasOracleConfig.tokenExchangeRate),
         remoteDecimals,
       );
     }
@@ -283,13 +282,37 @@ export function getLocalStorageGasOracleConfig({
   }, {} as ChainMap<ProtocolAgnositicGasOracleConfig>);
 }
 
+// Floor for the gas price after rebalancing a sub-unit exchange rate. The gas
+// price is divided when shifting magnitude into the exchange rate; keeping it
+// above this bound caps the rounding error from the final ceil.
+const MIN_REBALANCED_GAS_PRICE = 1000;
+
 function adjustForPrecisionLoss(
   gasPrice: Parameters<typeof BigNumberJs>[0],
-  exchangeRate: BigNumber,
+  exchangeRate: InstanceType<typeof BigNumberJs>,
   remoteDecimals: number,
 ): ProtocolAgnositicGasOracleConfig {
   let newGasPrice = new BigNumberJs(gasPrice);
   let newExchangeRate = exchangeRate;
+
+  // When the fee token has fewer decimals than the remote native token (e.g. a
+  // 6-decimal ERC20 fee token paying for an 18-decimal native chain), decimal
+  // conversion can push the scaled exchange rate below 1, where rounding to an
+  // integer would badly misprice (or zero out) the quote. The quote is the
+  // product gasPrice * exchangeRate, so shift magnitude from the gas price into
+  // the exchange rate by a power of ten: the product (and thus the quote) is
+  // preserved while the on-chain exchange rate keeps its precision. No-op for
+  // same-decimal native pairs, where the scaled rate is already >> 1.
+  if (newExchangeRate.lt(1) && newGasPrice.gt(MIN_REBALANCED_GAS_PRICE)) {
+    const headroom = Math.floor(
+      Math.log10(newGasPrice.div(MIN_REBALANCED_GAS_PRICE).toNumber()),
+    );
+    if (headroom >= 1) {
+      const factor = new BigNumberJs(10).pow(headroom);
+      newExchangeRate = newExchangeRate.times(factor);
+      newGasPrice = newGasPrice.div(factor);
+    }
+  }
 
   // We may have very little precision, and ultimately need an integer value for
   // the gas price that will be set on-chain. If this is the case, we scale up the
@@ -301,11 +324,11 @@ function adjustForPrecisionLoss(
     // Check that there's no significant underflow when applying
     // this to the exchange rate:
     const adjustedExchangeRate = newExchangeRate.div(gasPriceScalingFactor);
-    const recoveredExchangeRate = adjustedExchangeRate.mul(
+    const recoveredExchangeRate = adjustedExchangeRate.times(
       gasPriceScalingFactor,
     );
     // Ensure we recover at least 99% of the original exchange rate
-    if (recoveredExchangeRate.mul(100).div(newExchangeRate).gte(99)) {
+    if (recoveredExchangeRate.times(100).div(newExchangeRate).gte(99)) {
       newGasPrice = newGasPrice.times(gasPriceScalingFactor);
       newExchangeRate = adjustedExchangeRate;
     }
@@ -317,14 +340,22 @@ function adjustForPrecisionLoss(
     'Gas price must be greater than 0, possible loss of precision',
   );
 
+  // Round the (possibly rebalanced) exchange rate to an integer, keeping a
+  // floor of 1 so a tiny-but-nonzero rate never collapses to 0.
+  let newExchangeRateInteger = newExchangeRate.integerValue(
+    BigNumberJs.ROUND_FLOOR,
+  );
+  if (newExchangeRateInteger.lt(1)) {
+    newExchangeRateInteger = new BigNumberJs(1);
+  }
   assert(
-    newExchangeRate.gt(0),
+    newExchangeRateInteger.gt(0),
     `Token exchange rate must be greater than 0, possible loss of precision. Original exchange rate: ${exchangeRate.toString()}`,
   );
 
   return {
-    tokenExchangeRate: newExchangeRate.toString(),
-    gasPrice: newGasPriceInteger.toString(),
+    tokenExchangeRate: newExchangeRateInteger.toFixed(0),
+    gasPrice: newGasPriceInteger.toFixed(0),
     tokenDecimals: remoteDecimals,
   };
 }

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -338,19 +338,29 @@ function adjustForPrecisionLoss(
   // the gas price that will be set on-chain. If this is the case, we scale up the
   // gas price and scale down the exchange rate by the same factor.
   if (newGasPrice.lt(10) && !newGasPrice.mod(1).isZero()) {
-    // Scale up the gas price by 1e4 (arbitrary choice)
-    const gasPriceScalingFactor = 1e4;
+    // Use the largest decimal scale that preserves the integer exchange rate
+    // that will actually be set on-chain.
+    for (let scalingMagnitude = 4; scalingMagnitude > 0; scalingMagnitude--) {
+      const gasPriceScalingFactor = new BigNumberJs(10).pow(scalingMagnitude);
+      const adjustedExchangeRate = newExchangeRate.div(gasPriceScalingFactor);
+      const adjustedExchangeRateInteger = adjustedExchangeRate.integerValue(
+        BigNumberJs.ROUND_FLOOR,
+      );
+      const recoveredExchangeRate = adjustedExchangeRateInteger.times(
+        gasPriceScalingFactor,
+      );
 
-    // Check that there's no significant underflow when applying
-    // this to the exchange rate:
-    const adjustedExchangeRate = newExchangeRate.div(gasPriceScalingFactor);
-    const recoveredExchangeRate = adjustedExchangeRate.times(
-      gasPriceScalingFactor,
-    );
-    // Ensure we recover at least 99% of the original exchange rate
-    if (recoveredExchangeRate.times(100).div(newExchangeRate).gte(99)) {
-      newGasPrice = newGasPrice.times(gasPriceScalingFactor);
-      newExchangeRate = adjustedExchangeRate;
+      // Ensure the integer value recovers at least 99% of the original
+      // exchange rate. If it floors to zero, the final floor-to-one clamp would
+      // overquote, so try a smaller scale.
+      if (
+        adjustedExchangeRateInteger.gt(0) &&
+        recoveredExchangeRate.times(100).div(newExchangeRate).gte(99)
+      ) {
+        newGasPrice = newGasPrice.times(gasPriceScalingFactor);
+        newExchangeRate = adjustedExchangeRate;
+        break;
+      }
     }
   }
 

--- a/typescript/sdk/src/gas/utils.ts
+++ b/typescript/sdk/src/gas/utils.ts
@@ -282,10 +282,15 @@ export function getLocalStorageGasOracleConfig({
   }, {} as ChainMap<ProtocolAgnositicGasOracleConfig>);
 }
 
-// Floor for the gas price after rebalancing a sub-unit exchange rate. The gas
-// price is divided when shifting magnitude into the exchange rate; keeping it
-// above this bound caps the rounding error from the final ceil.
+// Floor for the gas price after rebalancing a sub-unit exchange rate. Because
+// the final gas price is ceiled, keeping the rebalanced value at least 1000
+// bounds the relative quote error from that ceil to < 1 / 1000 = 0.1%.
 const MIN_REBALANCED_GAS_PRICE = 1000;
+
+function decimalMagnitude(value: InstanceType<typeof BigNumberJs>): number {
+  if (value.lt(1)) return 0;
+  return value.integerValue(BigNumberJs.ROUND_FLOOR).toFixed(0).length - 1;
+}
 
 function adjustForPrecisionLoss(
   gasPrice: Parameters<typeof BigNumberJs>[0],
@@ -303,21 +308,37 @@ function adjustForPrecisionLoss(
   // the exchange rate by a power of ten: the product (and thus the quote) is
   // preserved while the on-chain exchange rate keeps its precision. No-op for
   // same-decimal native pairs, where the scaled rate is already >> 1.
-  if (newExchangeRate.lt(1) && newGasPrice.gt(MIN_REBALANCED_GAS_PRICE)) {
-    const headroom = Math.floor(
-      Math.log10(newGasPrice.div(MIN_REBALANCED_GAS_PRICE).toNumber()),
+  if (newExchangeRate.lt(1)) {
+    const headroom = decimalMagnitude(
+      newGasPrice.div(MIN_REBALANCED_GAS_PRICE),
     );
-    if (headroom >= 1) {
-      const factor = new BigNumberJs(10).pow(headroom);
+    let digitsNeeded = 0;
+    while (
+      digitsNeeded < headroom &&
+      newExchangeRate.times(new BigNumberJs(10).pow(digitsNeeded)).lt(1)
+    ) {
+      digitsNeeded += 1;
+    }
+
+    const shiftMagnitude = Math.min(headroom, digitsNeeded);
+    if (shiftMagnitude > 0) {
+      const factor = new BigNumberJs(10).pow(shiftMagnitude);
       newExchangeRate = newExchangeRate.times(factor);
       newGasPrice = newGasPrice.div(factor);
     }
+
+    assert(
+      newExchangeRate.gte(1),
+      `Token exchange rate must be at least 1 after precision rebalance. Original gas price: ${new BigNumberJs(
+        gasPrice,
+      ).toString()}, original exchange rate: ${exchangeRate.toString()}`,
+    );
   }
 
   // We may have very little precision, and ultimately need an integer value for
   // the gas price that will be set on-chain. If this is the case, we scale up the
   // gas price and scale down the exchange rate by the same factor.
-  if (newGasPrice.lt(10) && newGasPrice.mod(1) !== new BigNumberJs(0)) {
+  if (newGasPrice.lt(10) && !newGasPrice.mod(1).isZero()) {
     // Scale up the gas price by 1e4 (arbitrary choice)
     const gasPriceScalingFactor = 1e4;
 

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -39,6 +39,7 @@ import {
   HookConfig,
   HookType,
   IgpHookConfig,
+  IgpVersion,
   MUTABLE_HOOK_TYPE,
   PausableHookConfig,
   ProtocolFeeHookConfig,
@@ -670,6 +671,40 @@ describe('EvmHookModule', async () => {
       await expectTxsAndUpdate(hook, config, 1);
     });
 
+    it('should not update IGP only because igpVersion is legacy', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      const { hook } = await createHook(config);
+
+      await expectTxsAndUpdate(
+        hook,
+        { ...config, igpVersion: IgpVersion.Legacy },
+        0,
+      );
+    });
+
+    it('should not update routing hooks only because nested IGP is legacy', async () => {
+      const igpConfig = await createDeployerOwnedIgpHookConfig();
+      const config: FallbackRoutingHookConfig = {
+        owner: await multiProvider.getSignerAddress(chain),
+        domains: {
+          [TestChainName.test1]: {
+            type: HookType.AGGREGATION,
+            hooks: [{ type: HookType.MERKLE_TREE }, igpConfig],
+          },
+        },
+        type: HookType.FALLBACK_ROUTING,
+        fallback: { type: HookType.MERKLE_TREE },
+      };
+      const { hook } = await createHook(config);
+      const legacyConfig = deepCopy(config);
+      (
+        (legacyConfig.domains[TestChainName.test1] as AggregationHookConfig)
+          .hooks[1] as IgpHookConfig
+      ).igpVersion = IgpVersion.Legacy;
+
+      await expectTxsAndUpdate(hook, legacyConfig, 0);
+    });
+
     it('should add quote signers to IGP', async () => {
       const config = await createDeployerOwnedIgpHookConfig();
       config.contractVersion = CONTRACTS_PACKAGE_VERSION;
@@ -737,6 +772,26 @@ describe('EvmHookModule', async () => {
 
       // expect 0 txs since omitting quoteSigners means "don't change"
       await expectTxsAndUpdate(hook, config, 0);
+    });
+
+    it('should reject quote signers for legacy IGP configs', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      const { hook } = await createHook(config);
+      const legacyTarget = {
+        ...config,
+        igpVersion: IgpVersion.Legacy,
+        quoteSigners: [randomAddress()],
+      };
+
+      try {
+        await hook.update(legacyTarget);
+        throw new Error('Expected legacy IGP quote signer update to fail');
+      } catch (error: unknown) {
+        assert(error instanceof Error, 'Expected Error');
+        expect(error.message).to.include(
+          'IGP quoteSigners require contract version >= 11.3.0',
+        );
+      }
     });
 
     it('should not upgrade IGP when contractVersion is not in config', async () => {

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -859,6 +859,29 @@ describe('EvmHookModule', async () => {
       await expectTxsAndUpdate(hook, config, 0);
     });
 
+    it('should reject token gas oracle remotes without native gas config', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      config.contractVersion = CONTRACTS_PACKAGE_VERSION;
+      const { hook } = await createHook(config);
+
+      const target = deepCopy(config);
+      const [remoteWithoutNativeConfig] = testChains;
+      delete target.overhead[remoteWithoutNativeConfig];
+      target.tokenOracleConfig = {
+        [randomAddress()]: randomTokenOracleConfig(),
+      };
+
+      try {
+        await hook.update(target);
+        throw new Error('Expected token oracle remote validation to fail');
+      } catch (error: unknown) {
+        assert(error instanceof Error, 'Expected Error');
+        expect(error.message).to.include(
+          `includes remotes without native gas oracle config: ${remoteWithoutNativeConfig}`,
+        );
+      }
+    });
+
     it('should reject token gas oracles for legacy IGP configs', async () => {
       const config = await createDeployerOwnedIgpHookConfig();
       const { hook } = await createHook(config);

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -797,7 +797,7 @@ describe('EvmHookModule', async () => {
       }
     });
 
-    const randomTokenOracleConfig = () =>
+    const randomTokenOracleConfig = (withTypicalCost = false) =>
       Object.fromEntries(
         testChains.map((c) => [
           c,
@@ -805,6 +805,15 @@ describe('EvmHookModule', async () => {
             tokenExchangeRate: randomInt(1234567891234).toString(),
             gasPrice: randomInt(1234567891234).toString(),
             tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+            ...(withTypicalCost
+              ? {
+                  typicalCost: {
+                    handleGasAmount: 50_000,
+                    totalGasAmount: 200_000,
+                    totalUsdCost: 1,
+                  },
+                }
+              : {}),
           },
         ]),
       );
@@ -842,7 +851,7 @@ describe('EvmHookModule', async () => {
       // add a token oracle config; oracle is deployed eagerly, leaving a single
       // setTokenGasOracles tx to wire the mapping.
       config.tokenOracleConfig = {
-        [randomAddress()]: randomTokenOracleConfig(),
+        [randomAddress()]: randomTokenOracleConfig(true),
       };
       await expectTxsAndUpdate(hook, config, 1);
 

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
-import { Signer } from 'ethers';
+import { Signer, ethers } from 'ethers';
 import hre from 'hardhat';
 
-import { CONTRACTS_PACKAGE_VERSION } from '@hyperlane-xyz/core';
+import {
+  CONTRACTS_PACKAGE_VERSION,
+  InterchainGasPaymaster__factory,
+} from '@hyperlane-xyz/core';
 import {
   Address,
   WithAddress,
@@ -790,6 +793,79 @@ describe('EvmHookModule', async () => {
         assert(error instanceof Error, 'Expected Error');
         expect(error.message).to.include(
           'IGP quoteSigners require contract version >= 11.3.0',
+        );
+      }
+    });
+
+    const randomTokenOracleConfig = () =>
+      Object.fromEntries(
+        testChains.map((c) => [
+          c,
+          {
+            tokenExchangeRate: randomInt(1234567891234).toString(),
+            gasPrice: randomInt(1234567891234).toString(),
+            tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+          },
+        ]),
+      );
+
+    it('should deploy IGP with token gas oracles and wire them on-chain', async () => {
+      const feeToken = randomAddress();
+      const config = await createDeployerOwnedIgpHookConfig();
+      config.tokenOracleConfig = { [feeToken]: randomTokenOracleConfig() };
+
+      const { hook } = await createHook(config);
+
+      // The token oracle mapping is read back from chain (not derivable via the
+      // reader), so assert it directly: a dedicated oracle is wired per remote.
+      const igp = InterchainGasPaymaster__factory.connect(
+        hook.serialize().deployedHook,
+        multiProvider.getProvider(chain),
+      );
+      const oracles = await Promise.all(
+        testChains.map((c) =>
+          igp.tokenGasOracles(feeToken, multiProvider.getDomainId(c)),
+        ),
+      );
+      for (const oracle of oracles) {
+        expect(eqAddress(oracle, ethers.constants.AddressZero)).to.be.false;
+      }
+      // All destinations of a fee token share a single oracle instance.
+      expect(oracles.every((o) => eqAddress(o, oracles[0]))).to.be.true;
+    });
+
+    it('should set token gas oracles on update', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      config.contractVersion = CONTRACTS_PACKAGE_VERSION;
+      const { hook } = await createHook(config);
+
+      // add a token oracle config; oracle is deployed eagerly, leaving a single
+      // setTokenGasOracles tx to wire the mapping.
+      config.tokenOracleConfig = {
+        [randomAddress()]: randomTokenOracleConfig(),
+      };
+      await expectTxsAndUpdate(hook, config, 1);
+
+      // re-applying the same config is a no-op (mapping already wired on-chain)
+      await expectTxsAndUpdate(hook, config, 0);
+    });
+
+    it('should reject token gas oracles for legacy IGP configs', async () => {
+      const config = await createDeployerOwnedIgpHookConfig();
+      const { hook } = await createHook(config);
+      const legacyTarget = {
+        ...config,
+        igpVersion: IgpVersion.Legacy,
+        tokenOracleConfig: { [randomAddress()]: randomTokenOracleConfig() },
+      };
+
+      try {
+        await hook.update(legacyTarget);
+        throw new Error('Expected legacy IGP token oracle update to fail');
+      } catch (error: unknown) {
+        assert(error instanceof Error, 'Expected Error');
+        expect(error.message).to.include(
+          'IGP tokenOracleConfig requires contract version >= 11.3.0',
         );
       }
     });

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -72,6 +72,7 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
+import { isMissingSelectorRevert } from '../utils/contract.js';
 
 import {
   VERSION_ERROR_MESSAGE,
@@ -471,12 +472,20 @@ export class EvmHookModule extends HyperlaneModule<
     const igpAddress = this.args.addresses.deployedHook;
     const igpInterface = InterchainGasPaymaster__factory.createInterface();
     const provider = this.multiProvider.getProvider(this.domainId);
-    const currentVersion = await PackageVersioned__factory.connect(
-      igpAddress,
-      provider,
-    )
-      .PACKAGE_VERSION()
-      .catch(() => undefined);
+    let currentVersion: string | undefined;
+    try {
+      currentVersion = await PackageVersioned__factory.connect(
+        igpAddress,
+        provider,
+      ).PACKAGE_VERSION();
+    } catch (error) {
+      if (!isMissingSelectorRevert(error)) {
+        throw error;
+      }
+      this.logger.debug(
+        `IGP ${igpAddress} on ${this.chain} does not expose PACKAGE_VERSION`,
+      );
+    }
 
     // Upgrade IGP proxy implementation only if contractVersion is specified in config
     if (targetConfig.contractVersion && (await isProxy(provider, igpAddress))) {
@@ -595,7 +604,11 @@ export class EvmHookModule extends HyperlaneModule<
     // update token gas oracles only if explicitly specified in target config.
     // Gated behind the same support check as quoteSigners: the tokenGasOracles
     // mapping and setTokenGasOracles only exist on the new (non-legacy) IGP.
-    if (targetConfig.tokenOracleConfig !== undefined) {
+    const targetTokenOracleConfig = targetConfig.tokenOracleConfig;
+    if (
+      targetTokenOracleConfig &&
+      Object.keys(targetTokenOracleConfig).length > 0
+    ) {
       assert(
         supportsOffchainFeeQuoting,
         `IGP tokenOracleConfig requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
@@ -603,7 +616,7 @@ export class EvmHookModule extends HyperlaneModule<
       updateTxs.push(
         ...(await this.updateIgpTokenGasOracles({
           interchainGasPaymaster: this.args.addresses.deployedHook,
-          targetTokenOracleConfig: targetConfig.tokenOracleConfig,
+          targetTokenOracleConfig,
           config: targetConfig,
         })),
       );

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -60,7 +60,11 @@ import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import { isProxy, proxyAdmin } from '../deploy/proxy.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
-import { IgpConfig } from '../gas/types.js';
+import {
+  IgpConfig,
+  assertTokenOracleConfigHasNativeRemotes,
+  igpSupportsOffchainFeeQuoting,
+} from '../gas/types.js';
 import { EvmIsmModule } from '../ism/EvmIsmModule.js';
 import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
 import { ArbL2ToL1IsmConfig, IsmType, OpStackIsmConfig } from '../ism/types.js';
@@ -568,17 +572,16 @@ export class EvmHookModule extends HyperlaneModule<
 
     // update quote signers only if explicitly specified in target config
     // and IGP supports them (detected from on-chain read or version upgrade)
-    const quoteSignerVersion =
+    const offchainFeeQuotingVersion =
       targetConfig.contractVersion ?? currentVersion ?? undefined;
-    const supportsQuoteSigners =
-      targetConfig.igpVersion !== IgpVersion.Legacy &&
-      (currentConfig.quoteSigners !== undefined ||
-        (quoteSignerVersion !== undefined &&
-          compareVersions(quoteSignerVersion, OFFCHAIN_QUOTED_IGP_VERSION) >=
-            0));
+    const supportsOffchainFeeQuoting = igpSupportsOffchainFeeQuoting({
+      igpVersion: targetConfig.igpVersion,
+      contractVersion: offchainFeeQuotingVersion,
+      quoteSigners: currentConfig.quoteSigners,
+    });
     if (targetConfig.quoteSigners !== undefined) {
       assert(
-        supportsQuoteSigners,
+        supportsOffchainFeeQuoting,
         `IGP quoteSigners require contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
       );
       updateTxs.push(
@@ -594,7 +597,7 @@ export class EvmHookModule extends HyperlaneModule<
     // mapping and setTokenGasOracles only exist on the new (non-legacy) IGP.
     if (targetConfig.tokenOracleConfig !== undefined) {
       assert(
-        supportsQuoteSigners,
+        supportsOffchainFeeQuoting,
         `IGP tokenOracleConfig requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
       );
       updateTxs.push(
@@ -612,8 +615,11 @@ export class EvmHookModule extends HyperlaneModule<
   /**
    * Diffs and applies per-fee-token gas oracles on the IGP. Target-driven: the
    * configured fee tokens are the only enumeration source (the on-chain
-   * tokenGasOracles mapping is not enumerable), and each token's current oracle
-   * is read back from chain, so no off-chain address bookkeeping is needed.
+   * tokenGasOracles mapping is not enumerable), so removals are intentionally
+   * unsupported and old fee-token mappings remain live until cleared by a
+   * dedicated teardown flow. Each configured token's current oracle is read back
+   * from chain, so no off-chain address bookkeeping is needed for additions and
+   * updates.
    *
    * For each fee token: resolve the oracle already wired on chain (reused across
    * that token's destinations), or deploy a fresh StorageGasOracle if none is
@@ -635,6 +641,7 @@ export class EvmHookModule extends HyperlaneModule<
       interchainGasPaymaster,
       this.multiProvider.getProvider(this.domainId),
     );
+    assertTokenOracleConfigHasNativeRemotes(this.chain, config);
 
     for (const [feeToken, oracleConfig] of Object.entries(
       targetTokenOracleConfig,

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -589,6 +589,149 @@ export class EvmHookModule extends HyperlaneModule<
       );
     }
 
+    // update token gas oracles only if explicitly specified in target config.
+    // Gated behind the same support check as quoteSigners: the tokenGasOracles
+    // mapping and setTokenGasOracles only exist on the new (non-legacy) IGP.
+    if (targetConfig.tokenOracleConfig !== undefined) {
+      assert(
+        supportsQuoteSigners,
+        `IGP tokenOracleConfig requires contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+      );
+      updateTxs.push(
+        ...(await this.updateIgpTokenGasOracles({
+          interchainGasPaymaster: this.args.addresses.deployedHook,
+          targetTokenOracleConfig: targetConfig.tokenOracleConfig,
+          config: targetConfig,
+        })),
+      );
+    }
+
+    return updateTxs;
+  }
+
+  /**
+   * Diffs and applies per-fee-token gas oracles on the IGP. Target-driven: the
+   * configured fee tokens are the only enumeration source (the on-chain
+   * tokenGasOracles mapping is not enumerable), and each token's current oracle
+   * is read back from chain, so no off-chain address bookkeeping is needed.
+   *
+   * For each fee token: resolve the oracle already wired on chain (reused across
+   * that token's destinations), or deploy a fresh StorageGasOracle if none is
+   * set yet; reconcile the oracle's remote gas data; then point any unmapped
+   * destinations at it via setTokenGasOracles.
+   */
+  protected async updateIgpTokenGasOracles({
+    interchainGasPaymaster,
+    targetTokenOracleConfig,
+    config,
+  }: {
+    interchainGasPaymaster: Address;
+    targetTokenOracleConfig: NonNullable<IgpConfig['tokenOracleConfig']>;
+    config: IgpConfig;
+  }): Promise<AnnotatedEV5Transaction[]> {
+    const updateTxs: AnnotatedEV5Transaction[] = [];
+    const igpInterface = InterchainGasPaymaster__factory.createInterface();
+    const igp = InterchainGasPaymaster__factory.connect(
+      interchainGasPaymaster,
+      this.multiProvider.getProvider(this.domainId),
+    );
+
+    for (const [feeToken, oracleConfig] of Object.entries(
+      targetTokenOracleConfig,
+    )) {
+      // Resolve the in-MultiProvider remote domains for this fee token.
+      const remotes = Object.keys(oracleConfig)
+        .map((remote) => ({
+          remote,
+          domainId: this.multiProvider.tryGetDomainId(remote),
+        }))
+        .filter(
+          (r): r is { remote: string; domainId: number } => r.domainId !== null,
+        );
+
+      if (remotes.length === 0) {
+        this.logger.warn(
+          `Skipping token gas oracle for ${feeToken} on ${this.chain}: no configured remotes in MultiProvider`,
+        );
+        continue;
+      }
+
+      // Find an oracle already wired for this fee token on any configured
+      // destination; reuse it across destinations.
+      let gasOracle: Address | undefined;
+      for (const { domainId } of remotes) {
+        const existing = await igp.tokenGasOracles(feeToken, domainId);
+        if (!eqAddress(existing, ethers.constants.AddressZero)) {
+          gasOracle = existing;
+          break;
+        }
+      }
+
+      // No oracle wired yet -> deploy a dedicated one for this fee token,
+      // seeded with its oracle config.
+      if (!gasOracle) {
+        const newOracle = await this.deployStorageGasOracle({
+          config,
+          oracleConfig,
+        });
+        gasOracle = newOracle.address;
+      } else {
+        // Reconcile remote gas data on the existing oracle. updateStorageGasOracle
+        // diffs against a supplied current config, so read it back from chain
+        // first (tokenDecimals isn't stored on-chain, so carry it from target to
+        // avoid a spurious diff).
+        const oracleContract = StorageGasOracle__factory.connect(
+          gasOracle,
+          this.multiProvider.getProvider(this.domainId),
+        );
+        const currentOracleConfig: IgpConfig['oracleConfig'] = {};
+        for (const { remote, domainId } of remotes) {
+          const data = await oracleContract.remoteGasData(domainId);
+          currentOracleConfig[remote] = {
+            tokenExchangeRate: data.tokenExchangeRate.toString(),
+            gasPrice: data.gasPrice.toString(),
+            tokenDecimals: oracleConfig[remote]?.tokenDecimals,
+          };
+        }
+
+        updateTxs.push(
+          ...(await this.updateStorageGasOracle({
+            gasOracle,
+            currentOracleConfig,
+            targetOracleConfig: oracleConfig,
+            targetOverhead: config.overhead,
+          })),
+        );
+      }
+
+      // Point any destinations not yet mapped to this oracle at it.
+      const tokenOracleParams: InterchainGasPaymaster.TokenGasOracleConfigStruct[] =
+        [];
+      for (const { domainId } of remotes) {
+        const current = await igp.tokenGasOracles(feeToken, domainId);
+        if (!eqAddress(current, gasOracle)) {
+          tokenOracleParams.push({
+            feeToken,
+            remoteDomain: domainId,
+            gasOracle,
+          });
+        }
+      }
+
+      if (tokenOracleParams.length > 0) {
+        updateTxs.push({
+          annotation: `Setting token gas oracles for ${feeToken} on ${this.chain} (domains ${tokenOracleParams
+            .map((p) => p.remoteDomain)
+            .join(', ')})`,
+          chainId: this.chainId,
+          to: interchainGasPaymaster,
+          data: igpInterface.encodeFunctionData('setTokenGasOracles', [
+            tokenOracleParams,
+          ]),
+        });
+      }
+    }
+
     return updateTxs;
   }
 
@@ -1327,6 +1470,21 @@ export class EvmHookModule extends HyperlaneModule<
       }
     }
 
+    // Wire per-fee-token gas oracles if configured. Must run while the deployer
+    // still owns the IGP (setTokenGasOracles is onlyOwner) and after the native
+    // gas params above, since the IGP requires a destination's native oracle to
+    // exist before a non-native token oracle can be set for it.
+    if (config.tokenOracleConfig !== undefined) {
+      const tokenOracleTxs = await this.updateIgpTokenGasOracles({
+        interchainGasPaymaster: igp.address,
+        targetTokenOracleConfig: config.tokenOracleConfig,
+        config,
+      });
+      for (const tx of tokenOracleTxs) {
+        await this.multiProvider.sendTransaction(this.chain, tx);
+      }
+    }
+
     // Transfer igp to the configured owner
     await this.multiProvider.handleTx(
       this.chain,
@@ -1361,8 +1519,12 @@ export class EvmHookModule extends HyperlaneModule<
 
   protected async deployStorageGasOracle({
     config,
+    oracleConfig = config.oracleConfig,
   }: {
     config: IgpConfig;
+    // Oracle data to seed the deployed oracle with. Defaults to the native
+    // oracleConfig; token gas oracles pass their per-fee-token config instead.
+    oracleConfig?: IgpConfig['oracleConfig'];
   }): Promise<StorageGasOracle> {
     // Deploy the StorageGasOracle, by default msg.sender is the owner
     const gasOracle = await this.deployer.deployContractFromFactory(
@@ -1375,7 +1537,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Obtain the transactions to set the gas params for each remote
     const configureTxs = await this.updateStorageGasOracle({
       gasOracle: gasOracle.address,
-      targetOracleConfig: config.oracleConfig,
+      targetOracleConfig: oracleConfig,
       targetOverhead: config.overhead,
     });
 

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -855,7 +855,12 @@ export class EvmHookModule extends HyperlaneModule<
       }
 
       // only update if the oracle config has changed
-      if (!current || !deepEquals(current, target)) {
+      const comparableTarget = {
+        gasPrice: target.gasPrice,
+        tokenExchangeRate: target.tokenExchangeRate,
+        tokenDecimals: target.tokenDecimals,
+      };
+      if (!current || !deepEquals(current, comparableTarget)) {
         configsToSet.push({ remoteDomain, ...target });
 
         // Log an example remote gas cost

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -89,7 +89,9 @@ import {
   HookType,
   HookTypeToContractNameMap,
   IgpHookConfig,
+  IgpVersion,
   MUTABLE_HOOK_TYPE,
+  OFFCHAIN_QUOTED_IGP_VERSION,
   OpStackHookConfig,
   PausableHookConfig,
   ProtocolFeeHookConfig,
@@ -110,6 +112,28 @@ class HookDeployer extends HyperlaneDeployer<{}, HookFactories> {
   deployContracts(_chain: ChainName, _config: {}): Promise<any> {
     throw new Error('Method not implemented.');
   }
+}
+
+function stripIgpVersion(config: unknown): unknown {
+  if (Array.isArray(config)) {
+    return config.map(stripIgpVersion);
+  }
+
+  if (config !== null && typeof config === 'object') {
+    const stripped: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      if (key !== 'igpVersion') {
+        stripped[key] = stripIgpVersion(value);
+      }
+    }
+    return stripped;
+  }
+
+  return config;
+}
+
+function hookConfigsEqual(a: unknown, b: unknown): boolean {
+  return deepEquals(stripIgpVersion(a), stripIgpVersion(b));
 }
 
 export class EvmHookModule extends HyperlaneModule<
@@ -183,7 +207,7 @@ export class EvmHookModule extends HyperlaneModule<
     );
 
     // If configs match, no updates needed
-    if (deepEquals(normalizedCurrentConfig, normalizedTargetConfig)) {
+    if (hookConfigsEqual(normalizedCurrentConfig, normalizedTargetConfig)) {
       return [];
     }
 
@@ -282,7 +306,7 @@ export class EvmHookModule extends HyperlaneModule<
 
       // If the domain is not in the current config or the config has changed, deploy a new hook
       // TODO: in-place updates per domain as a future optimization
-      if (!deepEquals(currentDomains[dest], targetDomainConfig)) {
+      if (!hookConfigsEqual(currentDomains[dest], targetDomainConfig)) {
         const domainHook = await this.deploy({
           config: targetDomainConfig,
         });
@@ -443,6 +467,12 @@ export class EvmHookModule extends HyperlaneModule<
     const igpAddress = this.args.addresses.deployedHook;
     const igpInterface = InterchainGasPaymaster__factory.createInterface();
     const provider = this.multiProvider.getProvider(this.domainId);
+    const currentVersion = await PackageVersioned__factory.connect(
+      igpAddress,
+      provider,
+    )
+      .PACKAGE_VERSION()
+      .catch(() => undefined);
 
     // Upgrade IGP proxy implementation only if contractVersion is specified in config
     if (targetConfig.contractVersion && (await isProxy(provider, igpAddress))) {
@@ -451,12 +481,6 @@ export class EvmHookModule extends HyperlaneModule<
         VERSION_ERROR_MESSAGE,
       );
 
-      const currentVersion = await PackageVersioned__factory.connect(
-        igpAddress,
-        provider,
-      )
-        .PACKAGE_VERSION()
-        .catch(() => undefined);
       if (
         !currentVersion ||
         compareVersions(targetConfig.contractVersion, currentVersion) > 0
@@ -520,6 +544,11 @@ export class EvmHookModule extends HyperlaneModule<
         })),
       );
     } else {
+      assert(
+        targetConfig.igpVersion !== IgpVersion.Legacy,
+        'Legacy IGP updates require an existing gas oracle configuration',
+      );
+
       const newGasOracle = await this.deployStorageGasOracle({
         config: targetConfig,
       });
@@ -539,10 +568,19 @@ export class EvmHookModule extends HyperlaneModule<
 
     // update quote signers only if explicitly specified in target config
     // and IGP supports them (detected from on-chain read or version upgrade)
+    const quoteSignerVersion =
+      targetConfig.contractVersion ?? currentVersion ?? undefined;
     const supportsQuoteSigners =
-      currentConfig.quoteSigners !== undefined ||
-      targetConfig.contractVersion != null;
-    if (targetConfig.quoteSigners !== undefined && supportsQuoteSigners) {
+      targetConfig.igpVersion !== IgpVersion.Legacy &&
+      (currentConfig.quoteSigners !== undefined ||
+        (quoteSignerVersion !== undefined &&
+          compareVersions(quoteSignerVersion, OFFCHAIN_QUOTED_IGP_VERSION) >=
+            0));
+    if (targetConfig.quoteSigners !== undefined) {
+      assert(
+        supportsQuoteSigners,
+        `IGP quoteSigners require contract version >= ${OFFCHAIN_QUOTED_IGP_VERSION}`,
+      );
       updateTxs.push(
         ...this.updateIgpQuoteSigners({
           currentSigners: currentConfig.quoteSigners ?? [],
@@ -770,7 +808,7 @@ export class EvmHookModule extends HyperlaneModule<
     // Deploy a new fallback hook if the fallback config has changed
     if (
       targetConfig.type === HookType.FALLBACK_ROUTING &&
-      !deepEquals(
+      !hookConfigsEqual(
         targetConfig.fallback,
         (currentConfig as FallbackRoutingHookConfig).fallback,
       )
@@ -1224,6 +1262,11 @@ export class EvmHookModule extends HyperlaneModule<
   }: {
     config: IgpHookConfig;
   }): Promise<InterchainGasPaymaster> {
+    assert(
+      config.igpVersion !== IgpVersion.Legacy,
+      'Legacy IGP configs require an existing deployment and cannot deploy a new IGP',
+    );
+
     this.logger.debug('Deploying IGP as hook...');
 
     // Deploy the StorageGasOracle

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -301,6 +301,29 @@ describe('EvmHookReader', () => {
     expect(thrown).to.equal(transientError);
   });
 
+  it('should not stamp IGP as legacy on empty provider responses', async () => {
+    const mockAddress = randomAddress();
+    const emptyProviderResponse = new Error('Invalid response from provider');
+
+    sandbox.stub(InterchainGasPaymaster__factory, 'connect').returns({
+      hookType: sandbox
+        .stub()
+        .resolves(OnchainHookType.INTERCHAIN_GAS_PAYMASTER),
+      owner: sandbox.stub().resolves(randomAddress()),
+      beneficiary: sandbox.stub().resolves(randomAddress()),
+      quoteSigners: sandbox.stub().rejects(emptyProviderResponse),
+    } as unknown as InterchainGasPaymaster);
+
+    let thrown: unknown;
+    try {
+      await evmHookReader.deriveIgpConfig(mockAddress);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(emptyProviderResponse);
+  });
+
   it('should still derive IGP config when a domain is unsupported', async () => {
     const mockAddress = randomAddress();
     const owner = randomAddress();

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -34,6 +34,7 @@ import { EvmHookReader } from './EvmHookReader.js';
 import {
   CCIPHookConfig,
   HookType,
+  IgpVersion,
   MailboxDefaultHookConfig,
   MerkleTreeHookConfig,
   OnchainHookType,
@@ -328,6 +329,7 @@ describe('EvmHookReader', () => {
       address: mockAddress,
       type: HookType.INTERCHAIN_GAS_PAYMASTER,
       beneficiary,
+      igpVersion: IgpVersion.Legacy,
       oracleKey: owner,
       overhead: {},
       oracleConfig: {},

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -40,6 +40,7 @@ import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 import {
   isMissingSelectorCallException,
   throwIfNotMissingSelector,
+  throwIfNotMissingSelectorRevert,
 } from '../utils/contract.js';
 
 import {
@@ -484,7 +485,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           .quoteSigners()
           .then((quoteSigners) => ({ quoteSigners, igpVersion: undefined }))
           .catch((error) => {
-            throwIfNotMissingSelector(error);
+            throwIfNotMissingSelectorRevert(error);
             this.logger.debug(
               'quoteSigners() not available on this IGP version, skipping',
             );

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -474,26 +474,28 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       this.provider,
     );
 
+    const getQuoteSignersResult = async (): Promise<{
+      quoteSigners: string[];
+      igpVersion?: IgpVersion;
+    }> => {
+      try {
+        return { quoteSigners: await hook.quoteSigners() };
+      } catch (error) {
+        throwIfNotMissingSelectorRevert(error);
+        this.logger.debug(
+          'quoteSigners() not available on this IGP version, skipping',
+        );
+        return { quoteSigners: [], igpVersion: IgpVersion.Legacy };
+      }
+    };
+
     // Parallelize initial RPC calls
     const [hookType, owner, beneficiary, quoteSignersResult] =
       await Promise.all([
         hook.hookType(),
         hook.owner(),
         hook.beneficiary(),
-        // quoteSigners() not available on IGP versions before offchain fee quoting
-        hook
-          .quoteSigners()
-          .then((quoteSigners) => ({ quoteSigners, igpVersion: undefined }))
-          .catch((error) => {
-            throwIfNotMissingSelectorRevert(error);
-            this.logger.debug(
-              'quoteSigners() not available on this IGP version, skipping',
-            );
-            return {
-              quoteSigners: [] as string[],
-              igpVersion: IgpVersion.Legacy,
-            };
-          }),
+        getQuoteSignersResult(),
       ]);
 
     this.assertHookType(hookType, OnchainHookType.INTERCHAIN_GAS_PAYMASTER);

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -52,6 +52,7 @@ import {
   FallbackRoutingHookConfig,
   HookConfig,
   HookType,
+  IgpVersion,
   IgpHookConfig,
   MailboxDefaultHookConfig,
   MerkleTreeHookConfig,
@@ -473,19 +474,26 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
     );
 
     // Parallelize initial RPC calls
-    const [hookType, owner, beneficiary, quoteSigners] = await Promise.all([
-      hook.hookType(),
-      hook.owner(),
-      hook.beneficiary(),
-      // quoteSigners() not available on IGP versions before offchain fee quoting
-      hook.quoteSigners().catch((error) => {
-        throwIfNotMissingSelector(error);
-        this.logger.debug(
-          'quoteSigners() not available on this IGP version, skipping',
-        );
-        return [] as string[];
-      }),
-    ]);
+    const [hookType, owner, beneficiary, quoteSignersResult] =
+      await Promise.all([
+        hook.hookType(),
+        hook.owner(),
+        hook.beneficiary(),
+        // quoteSigners() not available on IGP versions before offchain fee quoting
+        hook
+          .quoteSigners()
+          .then((quoteSigners) => ({ quoteSigners, igpVersion: undefined }))
+          .catch((error) => {
+            throwIfNotMissingSelector(error);
+            this.logger.debug(
+              'quoteSigners() not available on this IGP version, skipping',
+            );
+            return {
+              quoteSigners: [] as string[],
+              igpVersion: IgpVersion.Legacy,
+            };
+          }),
+      ]);
 
     this.assertHookType(hookType, OnchainHookType.INTERCHAIN_GAS_PAYMASTER);
 
@@ -550,7 +558,12 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       oracleKey: oracleKey ?? owner,
       overhead,
       oracleConfig,
-      ...(quoteSigners.length > 0 ? { quoteSigners: [...quoteSigners] } : {}),
+      ...(quoteSignersResult.igpVersion
+        ? { igpVersion: quoteSignersResult.igpVersion }
+        : {}),
+      ...(quoteSignersResult.quoteSigners.length > 0
+        ? { quoteSigners: [...quoteSignersResult.quoteSigners] }
+        : {}),
     };
 
     this._cache.set(address, config);

--- a/typescript/sdk/src/hook/types.test.ts
+++ b/typescript/sdk/src/hook/types.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+
+import { HookConfigSchema, HookType } from './types.js';
+
+const ADDRESS = '0x0000000000000000000000000000000000000001';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const igpConfig = (feeToken: string, remote = 'test1') => ({
+  type: HookType.INTERCHAIN_GAS_PAYMASTER,
+  owner: ADDRESS,
+  beneficiary: ADDRESS,
+  oracleKey: ADDRESS,
+  overhead: {},
+  oracleConfig: {},
+  tokenOracleConfig: {
+    [feeToken]: {
+      [remote]: {
+        tokenExchangeRate: '1',
+        gasPrice: '1',
+      },
+    },
+  },
+});
+
+describe('IgpSchema tokenOracleConfig', () => {
+  it('allows non-zero EVM fee-token keys and chain-name remote keys', () => {
+    expect(HookConfigSchema.safeParse(igpConfig(ADDRESS)).success).to.be.true;
+  });
+
+  it('rejects zero-address fee-token keys', () => {
+    expect(HookConfigSchema.safeParse(igpConfig(ZERO_ADDRESS)).success).to.be
+      .false;
+  });
+
+  it('rejects non-address fee-token keys', () => {
+    expect(HookConfigSchema.safeParse(igpConfig('NATIVE_TOKEN')).success).to.be
+      .false;
+  });
+
+  it('rejects invalid remote chain keys', () => {
+    expect(
+      HookConfigSchema.safeParse(igpConfig(ADDRESS, 'not-a-chain')).success,
+    ).to.be.false;
+  });
+});

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -103,7 +103,13 @@ export type IgpHookConfig = z.infer<typeof IgpSchema>;
 export type ProtocolFeeHookConfig = z.infer<typeof ProtocolFeeSchema>;
 export type PausableHookConfig = z.infer<typeof PausableHookSchema>;
 export type OpStackHookConfig = z.infer<typeof OpStackHookSchema>;
-export type ArbL2ToL1HookConfig = z.infer<typeof ArbL2ToL1HookSchema>;
+export type ArbL2ToL1HookConfig = {
+  type: typeof HookType.ARB_L2_TO_L1;
+  arbSys: string;
+  bridge?: string;
+  destinationChain: string;
+  childHook: HookConfig;
+};
 export type MailboxDefaultHookConfig = z.infer<typeof MailboxDefaultHookSchema>;
 export type RateLimitedHookConfig = z.infer<typeof RateLimitedHookSchema>;
 
@@ -182,22 +188,25 @@ export const OpStackHookSchema = OwnableSchema.extend({
   destinationChain: z.string(),
 });
 
-export const ArbL2ToL1HookSchema = z.object({
-  type: z.literal(HookType.ARB_L2_TO_L1),
-  arbSys: z
-    .string()
-    .describe(
-      'precompile for sending messages to L1, interface here: https://github.com/OffchainLabs/nitro-contracts/blob/90037b996509312ef1addb3f9352457b8a99d6a6/src/precompiles/ArbSys.sol#L12',
-    ),
-  bridge: z
-    .string()
-    .optional()
-    .describe(
-      'address of the bridge contract on L1, optional only needed for non @arbitrum/sdk chains',
-    ),
-  destinationChain: z.string(),
-  childHook: z.lazy((): z.ZodSchema => HookConfigSchema),
-});
+export const ArbL2ToL1HookSchema: z.ZodSchema<ArbL2ToL1HookConfig> = z.lazy(
+  () =>
+    z.object({
+      type: z.literal(HookType.ARB_L2_TO_L1),
+      arbSys: z
+        .string()
+        .describe(
+          'precompile for sending messages to L1, interface here: https://github.com/OffchainLabs/nitro-contracts/blob/90037b996509312ef1addb3f9352457b8a99d6a6/src/precompiles/ArbSys.sol#L12',
+        ),
+      bridge: z
+        .string()
+        .optional()
+        .describe(
+          'address of the bridge contract on L1, optional only needed for non @arbitrum/sdk chains',
+        ),
+      destinationChain: z.string(),
+      childHook: HookConfigSchema,
+    }),
+);
 
 export const IgpSchema = OwnableSchema.extend({
   type: z.literal(HookType.INTERCHAIN_GAS_PAYMASTER),

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -217,6 +217,15 @@ export const IgpSchema = OwnableSchema.extend({
   igpVersion: z.nativeEnum(IgpVersion).optional(),
   quoteSigners: z.array(z.string()).optional(),
   contractVersion: z.string().optional(),
+  // Per-fee-token gas oracles for ERC20-denominated interchain gas payments.
+  // Keyed by fee token address -> remote chain -> oracle config. Each fee token
+  // gets its own StorageGasOracle (the IGasOracle interface is keyed only by
+  // destination, so distinct exchange rates require distinct oracle instances).
+  // Optional and off by default; only wired when present and the IGP supports
+  // tokenGasOracles (>= OFFCHAIN_QUOTED_IGP_VERSION, non-legacy).
+  tokenOracleConfig: z
+    .record(z.record(ProtocolAgnositicGasOracleConfigWithTypicalCostSchema))
+    .optional(),
 });
 
 export const DomainRoutingHookConfigSchema: z.ZodSchema<DomainRoutingHookConfig> =

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -134,6 +134,13 @@ export type HookConfig = z.infer<typeof HookConfigSchema>;
 
 export type DerivedHookConfig = WithAddress<Exclude<HookConfig, Address>>;
 
+export enum IgpVersion {
+  Legacy = 'legacy',
+  Latest = 'latest',
+}
+
+export const OFFCHAIN_QUOTED_IGP_VERSION = '11.3.0';
+
 // Hook types that can be updated in-place
 export const MUTABLE_HOOK_TYPE: HookType[] = [
   HookType.INTERCHAIN_GAS_PAYMASTER,
@@ -198,6 +205,7 @@ export const IgpSchema = OwnableSchema.extend({
   oracleKey: z.string(),
   overhead: z.record(z.number()),
   oracleConfig: z.record(ProtocolAgnositicGasOracleConfigWithTypicalCostSchema),
+  igpVersion: z.nativeEnum(IgpVersion).optional(),
   quoteSigners: z.array(z.string()).optional(),
   contractVersion: z.string().optional(),
 });

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -3,12 +3,14 @@ import { z } from 'zod';
 import {
   Address,
   WithAddress,
+  isAddressEvm,
   isNullish,
+  isZeroishAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { ProtocolAgnositicGasOracleConfigWithTypicalCostSchema } from '../gas/oracle/types.js';
-import { ZHash } from '../metadata/customZodTypes.js';
+import { ZChainName, ZHash } from '../metadata/customZodTypes.js';
 import {
   ChainMap,
   OwnableConfig,
@@ -147,6 +149,15 @@ export enum IgpVersion {
 
 export const OFFCHAIN_QUOTED_IGP_VERSION = '11.3.0';
 
+const FeeTokenAddressSchema = z
+  .string()
+  .refine((feeToken) => isAddressEvm(feeToken), {
+    message: 'fee token must be an EVM address',
+  })
+  .refine((feeToken) => !isZeroishAddress(feeToken), {
+    message: 'fee token must not be the zero address',
+  });
+
 // Hook types that can be updated in-place
 export const MUTABLE_HOOK_TYPE: HookType[] = [
   HookType.INTERCHAIN_GAS_PAYMASTER,
@@ -224,7 +235,13 @@ export const IgpSchema = OwnableSchema.extend({
   // Optional and off by default; only wired when present and the IGP supports
   // tokenGasOracles (>= OFFCHAIN_QUOTED_IGP_VERSION, non-legacy).
   tokenOracleConfig: z
-    .record(z.record(ProtocolAgnositicGasOracleConfigWithTypicalCostSchema))
+    .record(
+      FeeTokenAddressSchema,
+      z.record(
+        ZChainName,
+        ProtocolAgnositicGasOracleConfigWithTypicalCostSchema,
+      ),
+    )
     .optional(),
 });
 

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -60,7 +60,7 @@ function hookTreeContains(
     );
   }
   if (hook.type === HookType.ARB_L2_TO_L1) {
-    return hookTreeContains(hook.childHook as HookConfig, predicate);
+    return hookTreeContains(hook.childHook, predicate);
   }
   return false;
 }

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -5,6 +5,7 @@ import {
   DerivedHookConfig,
   HookConfig,
   HookType,
+  IgpVersion,
 } from './types.js';
 
 /**
@@ -31,33 +32,54 @@ export function stripPredicateSubHook(
   return hook;
 }
 
-export function hookTreeContainsRateLimited(
+function hookTreeContains(
   hook: HookConfig | undefined,
+  predicate: (hook: Exclude<HookConfig, string>) => boolean,
 ): boolean {
   if (!hook || typeof hook === 'string') return false;
-  if (hook.type === HookType.RATE_LIMITED) return true;
+  if (predicate(hook)) return true;
   if (hook.type === HookType.AGGREGATION) {
-    return hook.hooks.some(hookTreeContainsRateLimited);
+    return hook.hooks.some((child) => hookTreeContains(child, predicate));
   }
   if (hook.type === HookType.ROUTING) {
-    return Object.values(hook.domains).some(hookTreeContainsRateLimited);
+    return Object.values(hook.domains).some((child) =>
+      hookTreeContains(child, predicate),
+    );
   }
   if (hook.type === HookType.FALLBACK_ROUTING) {
     return (
-      Object.values(hook.domains).some(hookTreeContainsRateLimited) ||
-      hookTreeContainsRateLimited(hook.fallback)
+      Object.values(hook.domains).some((child) =>
+        hookTreeContains(child, predicate),
+      ) || hookTreeContains(hook.fallback, predicate)
     );
   }
   if (hook.type === HookType.AMOUNT_ROUTING) {
     return (
-      hookTreeContainsRateLimited(hook.lowerHook) ||
-      hookTreeContainsRateLimited(hook.upperHook)
+      hookTreeContains(hook.lowerHook, predicate) ||
+      hookTreeContains(hook.upperHook, predicate)
     );
   }
   if (hook.type === HookType.ARB_L2_TO_L1) {
-    return hookTreeContainsRateLimited(hook.childHook as HookConfig);
+    return hookTreeContains(hook.childHook as HookConfig, predicate);
   }
   return false;
+}
+
+export function hookTreeContainsRateLimited(
+  hook: HookConfig | undefined,
+): boolean {
+  return hookTreeContains(hook, (node) => node.type === HookType.RATE_LIMITED);
+}
+
+export function hookTreeContainsLegacyIgp(
+  hook: HookConfig | undefined,
+): boolean {
+  return hookTreeContains(
+    hook,
+    (node) =>
+      node.type === HookType.INTERCHAIN_GAS_PAYMASTER &&
+      node.igpVersion === IgpVersion.Legacy,
+  );
 }
 
 export const isHookCompatible = ({

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -147,6 +147,7 @@ export {
   MailboxMultisigIsmViolation,
   MailboxViolation,
   MailboxViolationType,
+  shouldDeployQuotedCalls,
   ValidatorAnnounceViolation,
 } from './core/types.js';
 export { HyperlaneAppChecker } from './deploy/HyperlaneAppChecker.js';
@@ -250,9 +251,11 @@ export {
   HookType,
   IgpHookConfig,
   IgpSchema,
+  IgpVersion,
   MerkleTreeHookConfig,
   MerkleTreeSchema,
   normalizeUnknownHookTypes,
+  OFFCHAIN_QUOTED_IGP_VERSION,
   OpStackHookConfig,
   OpStackHookSchema,
   PausableHookConfig,

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -53,6 +53,21 @@ describe('RelayerAgentConfigSchema feeToken gate', () => {
     expect(result.success).to.be.false;
   });
 
+  it('rejects malformed stringified gas payment enforcement', () => {
+    const result = RelayerAgentConfigSchema.safeParse(
+      config({
+        gasPaymentEnforcement: '[{"type":"minimum"',
+      }),
+    );
+
+    expect(result.success).to.be.false;
+    if (!result.success) {
+      expect(result.error.issues[0].message).to.equal(
+        'Invalid gasPaymentEnforcement JSON payload',
+      );
+    }
+  });
+
   it('allows unset feeToken', () => {
     const result = RelayerAgentConfigSchema.safeParse(
       config({

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -1,9 +1,71 @@
 import { expect } from 'chai';
 
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 
-import { buildAgentConfig } from './agentConfig.js';
+import { RelayerAgentConfigSchema, buildAgentConfig } from './agentConfig.js';
+
+describe('RelayerAgentConfigSchema feeToken gate', () => {
+  const FEE_TOKEN = '0x0000000000000000000000000000000000000005';
+
+  // Minimal chain metadata satisfying AgentChainMetadataSchema.
+  const chainMetadata = (name: string, domainId: number) => ({
+    name,
+    domainId,
+    chainId: domainId,
+    protocol: ProtocolType.Ethereum,
+    rpcUrls: [{ http: 'http://localhost:8545' }],
+    mailbox: '0x0000000000000000000000000000000000000001',
+    interchainGasPaymaster: '0x0000000000000000000000000000000000000002',
+    validatorAnnounce: '0x0000000000000000000000000000000000000003',
+    merkleTreeHook: '0x0000000000000000000000000000000000000004',
+  });
+
+  const config = (overrides: Record<string, unknown>) => ({
+    relayChains: 'legacy',
+    chains: { legacy: chainMetadata('legacy', 1000) },
+    gasPaymentEnforcement: [
+      { type: 'minimum', payment: '1', feeToken: FEE_TOKEN },
+    ],
+    ...overrides,
+  });
+
+  it('rejects non-zero feeToken policy', () => {
+    const result = RelayerAgentConfigSchema.safeParse(config({}));
+    expect(result.success).to.be.false;
+    if (!result.success) {
+      expect(result.error.issues[0].message).to.contain(
+        '`feeToken` gas payment enforcement is not supported',
+      );
+    }
+  });
+
+  it('allows unset feeToken', () => {
+    const result = RelayerAgentConfigSchema.safeParse(
+      config({
+        gasPaymentEnforcement: [{ type: 'onChainFeeQuoting' }],
+      }),
+    );
+    expect(result.success).to.be.true;
+  });
+
+  it('allows native (zero) feeToken', () => {
+    const result = RelayerAgentConfigSchema.safeParse(
+      config({
+        gasPaymentEnforcement: [
+          {
+            type: 'minimum',
+            payment: '1',
+            feeToken: '0x0000000000000000000000000000000000000000',
+          },
+        ],
+      }),
+    );
+    expect(result.success).to.be.true;
+  });
+});
 
 describe('Agent config', () => {
   const args: Parameters<typeof buildAgentConfig> = [

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -42,6 +42,17 @@ describe('RelayerAgentConfigSchema feeToken gate', () => {
     }
   });
 
+  it('rejects non-zero feeToken policy in stringified config', () => {
+    const result = RelayerAgentConfigSchema.safeParse(
+      config({
+        gasPaymentEnforcement: JSON.stringify([
+          { type: 'minimum', payment: '1', feeToken: FEE_TOKEN },
+        ]),
+      }),
+    );
+    expect(result.success).to.be.false;
+  });
+
   it('allows unset feeToken', () => {
     const result = RelayerAgentConfigSchema.safeParse(
       config({

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 
 import { ModuleType } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { ProtocolType, isEmptyAddress } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainMap, ChainName } from '../types.js';
@@ -370,7 +370,28 @@ const GasPaymentEnforcementSchema = z.union([
 export type GasPaymentEnforcement = z.infer<typeof GasPaymentEnforcementSchema>;
 
 function feeTokenIsNonZero(feeToken?: string): boolean {
-  return feeToken != null && /[1-9a-f]/i.test(feeToken.replace(/^0x/i, ''));
+  return !isEmptyAddress(feeToken);
+}
+
+function gasPaymentEnforcementPolicies(
+  gasPaymentEnforcement: unknown,
+): GasPaymentEnforcement[] | undefined {
+  if (Array.isArray(gasPaymentEnforcement)) {
+    return gasPaymentEnforcement;
+  }
+
+  if (typeof gasPaymentEnforcement !== 'string') {
+    return undefined;
+  }
+
+  try {
+    const result = z
+      .array(GasPaymentEnforcementSchema)
+      .safeParse(JSON.parse(gasPaymentEnforcement));
+    return result.success ? result.data : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 const MetricAppContextSchema = z.object({
@@ -530,11 +551,11 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
 }).superRefine((config, ctx) => {
   // Mirror the Rust relayer gate: the current IGP event does not expose the
   // token address, so exact non-native `feeToken` enforcement is rejected.
-  const { gasPaymentEnforcement } = config;
-  if (!Array.isArray(gasPaymentEnforcement)) {
+  const policies = gasPaymentEnforcementPolicies(config.gasPaymentEnforcement);
+  if (!policies) {
     return;
   }
-  gasPaymentEnforcement.forEach((policy, policyIndex) => {
+  policies.forEach((policy, policyIndex) => {
     if (!feeTokenIsNonZero(policy.feeToken)) {
       return;
     }

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -347,6 +347,9 @@ const GasPaymentEnforcementBaseSchema = z.object({
   matchingList: MatchingListSchema.optional().describe(
     'An optional matching list, any message that matches will use this policy. By default all messages will match.',
   ),
+  feeToken: ZHash.optional().describe(
+    'The origin fee token that must have paid the IGP. The zero address, or unset, represents native tokens.',
+  ),
 });
 const GasPaymentEnforcementSchema = z.union([
   GasPaymentEnforcementBaseSchema.extend({
@@ -365,6 +368,10 @@ const GasPaymentEnforcementSchema = z.union([
   }),
 ]);
 export type GasPaymentEnforcement = z.infer<typeof GasPaymentEnforcementSchema>;
+
+function feeTokenIsNonZero(feeToken?: string): boolean {
+  return feeToken != null && /[1-9a-f]/i.test(feeToken.replace(/^0x/i, ''));
+}
 
 const MetricAppContextSchema = z.object({
   name: z.string().min(1),
@@ -520,6 +527,24 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
     .describe(
       'Relay API allowed CORS origins, comma-separated. Defaults to https://nexus.hyperlane.xyz.',
     ),
+}).superRefine((config, ctx) => {
+  // Mirror the Rust relayer gate: the current IGP event does not expose the
+  // token address, so exact non-native `feeToken` enforcement is rejected.
+  const { gasPaymentEnforcement } = config;
+  if (!Array.isArray(gasPaymentEnforcement)) {
+    return;
+  }
+  gasPaymentEnforcement.forEach((policy, policyIndex) => {
+    if (!feeTokenIsNonZero(policy.feeToken)) {
+      return;
+    }
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['gasPaymentEnforcement', policyIndex, 'feeToken'],
+      message:
+        '`feeToken` gas payment enforcement is not supported without token-aware IGP indexing; leave it unset and use onChainFeeQuoting for ERC20 IGP gas-amount sufficiency.',
+    });
+  });
 });
 
 export type RelayerConfig = z.infer<typeof RelayerAgentConfigSchema>;

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -373,24 +373,30 @@ function feeTokenIsNonZero(feeToken?: string): boolean {
   return !isEmptyAddress(feeToken);
 }
 
+type GasPaymentEnforcementParseResult =
+  | { policies: GasPaymentEnforcement[] | undefined; parseError: false }
+  | { policies: undefined; parseError: true };
+
 function gasPaymentEnforcementPolicies(
   gasPaymentEnforcement: unknown,
-): GasPaymentEnforcement[] | undefined {
+): GasPaymentEnforcementParseResult {
   if (Array.isArray(gasPaymentEnforcement)) {
-    return gasPaymentEnforcement;
+    return { policies: gasPaymentEnforcement, parseError: false };
   }
 
   if (typeof gasPaymentEnforcement !== 'string') {
-    return undefined;
+    return { policies: undefined, parseError: false };
   }
 
   try {
     const result = z
       .array(GasPaymentEnforcementSchema)
       .safeParse(JSON.parse(gasPaymentEnforcement));
-    return result.success ? result.data : undefined;
+    return result.success
+      ? { policies: result.data, parseError: false }
+      : { policies: undefined, parseError: true };
   } catch {
-    return undefined;
+    return { policies: undefined, parseError: true };
   }
 }
 
@@ -551,7 +557,17 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
 }).superRefine((config, ctx) => {
   // Mirror the Rust relayer gate: the current IGP event does not expose the
   // token address, so exact non-native `feeToken` enforcement is rejected.
-  const policies = gasPaymentEnforcementPolicies(config.gasPaymentEnforcement);
+  const { policies, parseError } = gasPaymentEnforcementPolicies(
+    config.gasPaymentEnforcement,
+  );
+  if (parseError) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['gasPaymentEnforcement'],
+      message: 'Invalid gasPaymentEnforcement JSON payload',
+    });
+    return;
+  }
   if (!policies) {
     return;
   }

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -240,6 +240,9 @@ export function randomHookConfig(
         arbSys: randomAddress(),
         bridge: randomAddress(),
         destinationChain: 'testChain',
+        childHook: {
+          type: HookType.MERKLE_TREE,
+        },
       };
 
     case HookType.ROUTING:

--- a/typescript/sdk/src/utils/contract.test.ts
+++ b/typescript/sdk/src/utils/contract.test.ts
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 
 import { missingSelectorError, wrappedError } from '../test/errors.js';
 
-import { isMissingSelectorCallException } from './contract.js';
+import {
+  isMissingSelectorCallException,
+  isMissingSelectorRevert,
+} from './contract.js';
 
 describe('contract utils', () => {
   describe('isMissingSelectorCallException', () => {
@@ -32,6 +35,9 @@ describe('contract utils', () => {
           new Error('Invalid response from provider'),
         ),
       ).to.equal(true);
+      expect(
+        isMissingSelectorRevert(new Error('Invalid response from provider')),
+      ).to.equal(false);
     });
 
     it('matches SmartProvider-wrapped empty provider responses', () => {

--- a/typescript/sdk/src/utils/contract.ts
+++ b/typescript/sdk/src/utils/contract.ts
@@ -51,6 +51,10 @@ export function isMissingSelectorCallException(error: unknown): boolean {
   if (!isRecord(error)) return false;
   if (isEmptyProviderResponse(error)) return true;
 
+  return isMissingSelectorRevert(error);
+}
+
+export function isMissingSelectorRevert(error: unknown): boolean {
   const callException = findCallException(error);
   if (!callException) return false;
 
@@ -73,6 +77,10 @@ export function isMissingSelectorCallException(error: unknown): boolean {
 
 export function throwIfNotMissingSelector(error: unknown): void {
   if (!isMissingSelectorCallException(error)) throw error;
+}
+
+export function throwIfNotMissingSelectorRevert(error: unknown): void {
+  if (!isMissingSelectorRevert(error)) throw error;
 }
 
 export async function contractHasString(


### PR DESCRIPTION
## Summary
Stack 4/4 of #8741. **Base: #8909.**

Infra + agent wiring for token-denominated IGP fees:
- Piped empty `tokenGasOracles` config into mainnet3 and testnet4 token IGPs.
- `reclaim-from-igp` now claims ERC20 fee tokens alongside the native claim (no-op on legacy IGPs / chains without token fees).
- **seismictestnet sUSDC**: configures the sUSDC fee token (`0x790701048922e265105fd6a4467a2901c2201c43`, 6 decimals); per-remote oracle configs reuse the native gas-oracle machinery with sUSDC substituted as the local fee token (price $1), so quotes resolve to the same USD value as native SIZE. (relies on the low-decimal rebalance from #8907.)
- Relayer agent config schema recognizes `feeToken` gas payment enforcement and rejects non-native exact-token enforcement until token-aware IGP indexing exists.

The relayer guard (`rust/` + `agentConfig`) is the one cross-cutting bit here — flag for a separate split if a Rust reviewer prefers.

## Stack
1. #8907 — exchange-rate rebalance
2. #8908 — legacy IGP support
3. #8909 — token-denominated IGP fees (SDK)
4. **this** — token-denominated IGP fees (infra + agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)