### PR TITLE
fix(validator): reuse validator key as Tron origin chain signer

### DIFF
--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -192,8 +192,12 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
         cfg_unwrap_all!(cwp, err: [base, origin_chain, validator, checkpoint_syncer]);
 
         let mut base: Settings = base;
-        // If the origin chain is an EVM chain, then we can use the validator as the signer if needed.
-        if origin_chain.domain_protocol() == HyperlaneDomainProtocol::Ethereum {
+        // Tron and Ethereum both use secp256k1 keys, so the validator attestation
+        // signer can double as the origin chain signer (used for self-announce txs).
+        if matches!(
+            origin_chain.domain_protocol(),
+            HyperlaneDomainProtocol::Ethereum | HyperlaneDomainProtocol::Tron
+        ) {
             if let Some(origin) = base.chains.get_mut(&origin_chain) {
                 origin.signer.get_or_insert_with(|| validator.clone());
             }


### PR DESCRIPTION
## Problem

A customer spinning up a **Tron validator** hit:

```
WARN validator::validator: Cannot announce validator without a signer;
make sure a signer is set for the origin chain, origin_chain: tron
```

The self-announce flow needs an **origin chain signer** to submit the announce transaction on-chain — this is separate from the validator attestation key (which signs checkpoints/announcements). On EVM origins the attestation key is auto-reused as the chain signer, so operators never set it explicitly. On Tron that fallback didn't fire, so the validator could sign checkpoints but never announce, making it functionally unusable.

## Root cause

The fallback in `validator/src/settings.rs` only triggered for the Ethereum protocol:

```rust
if origin_chain.domain_protocol() == HyperlaneDomainProtocol::Ethereum {
    origin.signer.get_or_insert_with(|| validator.clone());
}
```

Tron has its own `HyperlaneDomainProtocol::Tron`, so it was excluded — even though Tron uses secp256k1 keys and `TronSigner` builds from the same `SignerConf` variants (`HexKey` + `Aws`/KMS) as the Ethereum signer.

## Fix

Extend the fallback to also cover `Tron`. The validator attestation key (hex key **or AWS KMS**) now doubles as the Tron chain signer, matching EVM behavior.

## Verification

Traced the full path to confirm the reused key — including AWS KMS — works for the Tron self-announce tx:

- `settings.rs` — `validator: SignerConf` is cloned into `origin.signer` (same type).
- `signers.rs:143` — `BuildableWithSignerConf for TronSigner` builds `AwsSigner` from `SignerConf::Aws` → `TronSigner::Aws`.
- `hyperlane-tron/src/signer.rs` — `TronSigner::sign_hash` fully implements the `Aws` variant (secp256k1 recoverable sig via trial recovery); no `todo!`/`unimplemented!`.
- `validator_announce.rs` → `provider/tron.rs` `submit_tx` — uses the chain signer to sign and broadcast the announce tx; KMS path wired through.

`cargo check -p validator` passes.

The chain signer still needs TRX to pay for the announce tx; the validator logs the address and balance requirement on each loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
