### PR TITLE
fix(infra): pin EclipseUSDC AW proxyAdmin owners for chains dropped from awSafes

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -147,12 +147,16 @@ const awProxyAdminOwners: Record<EvmChain, string> = {
   base: awSafes.base,
   ethereum: awSafes.ethereum,
   optimism: awSafes.optimism,
-  polygon: awSafes.polygon,
-  unichain: awSafes.unichain,
+  // polygon/unichain/linea/monad/ink AW safes were commented out of awSafes in
+  // #8874 (inactive elsewhere) but still own these EclipseUSDC proxyAdmins
+  // on-chain. Pin the literal addresses so the declared owner keeps matching
+  // on-chain state instead of silently falling through to the regular ICA.
+  polygon: '0xf9cFD440CfBCfAB8473cc156485B7eE753b2913E',
+  unichain: '0x028C71E99e23fD393DE4207486D1aF7FA2b26b33',
   avalanche: awSafes.avalanche,
-  linea: awSafes.linea,
-  monad: awSafes.monad,
-  ink: awSafes.ink,
+  linea: '0xaCD1865B262C89Fb0b50dcc8fB095330ae8F35b5',
+  monad: '0x930f79e486B869EC7B5BF4e83121aDfcca198f42',
+  ink: '0x8DEe31BF7da558ee3224D22E224e172783CA8d70',
   worldchain: awSafes.worldchain,
   hyperevm: awSafes.hyperevm,
   bsc: awSafes.bsc,


### PR DESCRIPTION
## Problem

#8874 commented `polygon`, `unichain`, `linea`, `monad`, and `ink` out of `awSafes` (they're inactive elsewhere). But `getEclipseUSDCWarpConfig.ts` still references `awSafes.<chain>` in `awProxyAdminOwners`. Those now resolve to `undefined` and fall through:

```ts
const proxyAdminOwner = awProxyAdminOwners[chain] ?? chainOwners[chain].owner;
```

…to the **regular ICA**. This silently changes the *declared* proxyAdmin owner on 5 live chains, so `hyperlane warp check` on EclipseUSDC would flag mismatches and `govern` could propose transferring proxyAdmin ownership AW-safe → regular-ICA — not intended by #8874.

## Fix

Pin the literal AW safe addresses for the 5 affected chains so the declared owner keeps matching on-chain state. (`avalanche`/`worldchain`/etc. stay on `awSafes.X` — still active in the set.)

## On-chain verification

Queried `owner()` on each route's proxyAdmin; all match the pinned addresses:

| chain | proxyAdmin | on-chain owner | pinned |
|---|---|---|---|
| polygon | `0xD65217cA…` | `0xf9cFD440…` | ✅ |
| unichain | `0xe175575c…` | `0x028C71E9…` | ✅ |
| linea | `0x71644C72…` | `0xaCD1865B…` | ✅ |
| monad | `0x8F8FEf4A…` | `0x930f79e4…` | ✅ |
| ink | `0x3Ee33a0F…` | `0x8DEe31BF…` | ✅ |

`katana` was checked too — its proxyAdmin is genuinely owned by the regular ICA (`0x53dE35b7…`), and `katana: awSafes.katana` (always `undefined`) falls through to that same regular ICA, so it's correct and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)