### PR TITLE
feat(solidity): Axelar Hook and ISM (closes #2851)

### DIFF
--- a/.changeset/axelar-hook-and-ism.md
+++ b/.changeset/axelar-hook-and-ism.md
@@ -1,0 +1,10 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Add `AxelarHook` and `AxelarIsm` for transporting Hyperlane message IDs over
+Axelar's General Message Passing (GMP). The hook calls `IAxelarGateway.callContract`
+and pre-pays the Axelar Gas Service in native tokens (over-paying, with the
+surplus refunded by Axelar to the metadata refund address); the ISM inherits
+`AxelarExecutable` and authorizes deliveries by validated Axelar source chain
+and source address before recording verification via `preVerifyMessage`. Closes #2851.

--- a/solidity/contracts/hooks/AxelarHook.sol
+++ b/solidity/contracts/hooks/AxelarHook.sol
@@ -99,7 +99,6 @@ contract AxelarHook is AbstractMessageIdAuthHook {
 
     // ============ Internal functions ============
 
-    /// @inheritdoc AbstractPostDispatchHook
     /// @dev Returns 0: Axelar gas cannot be quoted on-chain. The caller attaches
     /// native value, which the hook over-pays to the Axelar Gas Service.
     function _quoteDispatch(

--- a/solidity/contracts/hooks/AxelarHook.sol
+++ b/solidity/contracts/hooks/AxelarHook.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {AbstractMessageIdAuthHook} from "./libs/AbstractMessageIdAuthHook.sol";
+import {StandardHookMetadata} from "./libs/StandardHookMetadata.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {Message} from "../libs/Message.sol";
+import {AbstractMessageIdAuthorizedIsm} from "../isms/hook/AbstractMessageIdAuthorizedIsm.sol";
+import {IAxelarGateway} from "../interfaces/axelar/IAxelarGateway.sol";
+import {IAxelarGasService} from "../interfaces/axelar/IAxelarGasService.sol";
+import {AddressToString} from "../interfaces/axelar/AddressString.sol";
+
+// ============ External Imports ============
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title AxelarHook
+ * @notice Message hook that informs an {AxelarIsm} of message IDs dispatched
+ * through the Hyperlane Mailbox, transporting them via Axelar's General Message
+ * Passing (GMP).
+ * @dev On `postDispatch` the hook pre-pays the Axelar Gas Service in native
+ * tokens and calls `IAxelarGateway.callContract`, carrying a payload that
+ * invokes `AbstractMessageIdAuthorizedIsm.preVerifyMessage` on the destination ISM.
+ *
+ * Gas model (the maintainer's suggested shortcut in #2851):
+ *  - The exact Axelar GMP gas cost cannot be computed on-chain (it depends on
+ *    destination gas price and token exchange rates resolved by Axelar's
+ *    off-chain gas oracle), so `quoteDispatch` returns 0 and the caller instead
+ *    attaches native value when dispatching.
+ *  - The hook forwards the entire attached value to
+ *    `payNativeGasForContractCall` — i.e. it over-pays — and Axelar refunds any
+ *    surplus off-chain to the metadata refund address. Callers should attach a
+ *    generous amount; under-payment simply stalls relaying until more gas is
+ *    added via the Axelar Gas Service.
+ *
+ * Native value bridging (`metadata.msgValue`) is NOT supported: Axelar GMP does
+ * not deliver native value to the destination contract, so any non-zero
+ * `msgValue` is rejected to avoid silently stranding funds.
+ *
+ * Like {OPStackHook}, a hook instance is bound to a single destination domain.
+ */
+contract AxelarHook is AbstractMessageIdAuthHook {
+    using StandardHookMetadata for bytes;
+    using Message for bytes;
+    using AddressToString for address;
+
+    // ============ Constants ============
+
+    /// @notice Axelar Gateway on the origin chain.
+    IAxelarGateway public immutable axelarGateway;
+    /// @notice Axelar Gas Service on the origin chain.
+    IAxelarGasService public immutable axelarGasService;
+
+    // ============ Storage ============
+
+    /// @notice Axelar chain name of the destination chain (e.g. "arbitrum").
+    /// @dev A string (not immutable) because Solidity immutables cannot be strings.
+    string public destinationChain;
+
+    // ============ Constructor ============
+
+    constructor(
+        address _mailbox,
+        uint32 _destinationDomain,
+        bytes32 _ism,
+        address _axelarGateway,
+        address _axelarGasService,
+        string memory _destinationChain
+    ) AbstractMessageIdAuthHook(_mailbox, _destinationDomain, _ism) {
+        require(
+            Address.isContract(_axelarGateway),
+            "AxelarHook: invalid gateway"
+        );
+        require(
+            Address.isContract(_axelarGasService),
+            "AxelarHook: invalid gas service"
+        );
+        require(
+            bytes(_destinationChain).length != 0,
+            "AxelarHook: invalid destination chain"
+        );
+        axelarGateway = IAxelarGateway(_axelarGateway);
+        axelarGasService = IAxelarGasService(_axelarGasService);
+        destinationChain = _destinationChain;
+    }
+
+    // ============ Internal functions ============
+
+    /// @inheritdoc AbstractPostDispatchHook
+    /// @dev Returns 0: Axelar gas cannot be quoted on-chain. The caller attaches
+    /// native value, which the hook over-pays to the Axelar Gas Service.
+    function _quoteDispatch(
+        bytes calldata metadata,
+        bytes calldata
+    ) internal pure override returns (uint256) {
+        require(
+            metadata.msgValue(0) == 0,
+            "AxelarHook: msgValue not supported"
+        );
+        return 0;
+    }
+
+    /// @inheritdoc AbstractMessageIdAuthHook
+    function _sendMessageId(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal override {
+        require(
+            metadata.msgValue(0) == 0,
+            "AxelarHook: msgValue not supported"
+        );
+
+        // Destination ISM address, encoded as the 0x-prefixed hex string Axelar expects.
+        string memory ismAddress = TypeCasts
+            .bytes32ToAddress(ism)
+            .toString();
+
+        // Payload invokes preVerifyMessage(messageId, 0) on the destination ISM.
+        bytes memory payload = abi.encodeCall(
+            AbstractMessageIdAuthorizedIsm.preVerifyMessage,
+            (message.id(), 0)
+        );
+
+        // Over-pay the Axelar Gas Service with all attached value; surplus is
+        // refunded off-chain to the refund address by Axelar.
+        axelarGasService.payNativeGasForContractCall{
+            value: address(this).balance
+        }(
+            address(this),
+            destinationChain,
+            ismAddress,
+            payload,
+            metadata.refundAddress(message.senderAddress())
+        );
+
+        // Emit the GMP call; Axelar validators relay it to the destination ISM.
+        axelarGateway.callContract(destinationChain, ismAddress, payload);
+    }
+}

--- a/solidity/contracts/interfaces/axelar/AddressString.sol
+++ b/solidity/contracts/interfaces/axelar/AddressString.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title AddressString
+ * @notice String <> address conversion helpers used to interoperate with
+ * Axelar GMP, which represents contract addresses as 0x-prefixed hex strings.
+ * @dev Vendored verbatim (semantically) from `@axelar-network/axelar-gmp-sdk-solidity`
+ * (contracts/libs/AddressString.sol). {AxelarHook} uses {AddressToString} to
+ * encode the destination ISM, and {AxelarIsm} uses {StringToAddress} to decode
+ * and compare the validated `sourceAddress`. Comparing parsed addresses (rather
+ * than raw strings) makes source authorization robust to hex casing.
+ */
+
+library StringToAddress {
+    error InvalidAddressString();
+
+    function toAddress(
+        string memory addressString
+    ) internal pure returns (address) {
+        bytes memory stringBytes = bytes(addressString);
+        uint160 addressNumber = 0;
+        uint8 stringByte;
+
+        if (
+            stringBytes.length != 42 ||
+            stringBytes[0] != "0" ||
+            stringBytes[1] != "x"
+        ) revert InvalidAddressString();
+
+        for (uint256 i = 2; i < 42; ++i) {
+            stringByte = uint8(stringBytes[i]);
+
+            if ((stringByte >= 97) && (stringByte <= 102)) stringByte -= 87;
+            else if ((stringByte >= 65) && (stringByte <= 70)) stringByte -= 55;
+            else if ((stringByte >= 48) && (stringByte <= 57)) stringByte -= 48;
+            else revert InvalidAddressString();
+
+            addressNumber |= uint160(uint256(stringByte) << ((41 - i) << 2));
+        }
+
+        return address(addressNumber);
+    }
+}
+
+library AddressToString {
+    function toString(address address_) internal pure returns (string memory) {
+        bytes memory addressBytes = abi.encodePacked(address_);
+        bytes memory characters = "0123456789abcdef";
+        bytes memory stringBytes = new bytes(42);
+
+        stringBytes[0] = "0";
+        stringBytes[1] = "x";
+
+        for (uint256 i; i < 20; ++i) {
+            stringBytes[2 + i * 2] = characters[uint8(addressBytes[i] >> 4)];
+            stringBytes[3 + i * 2] = characters[uint8(addressBytes[i] & 0x0f)];
+        }
+
+        return string(stringBytes);
+    }
+}

--- a/solidity/contracts/interfaces/axelar/AxelarExecutable.sol
+++ b/solidity/contracts/interfaces/axelar/AxelarExecutable.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {IAxelarGateway} from "./IAxelarGateway.sol";
+import {IAxelarExecutable} from "./IAxelarExecutable.sol";
+
+/**
+ * @title AxelarExecutable
+ * @notice Abstract base for contracts that execute Axelar GMP messages.
+ * @dev Vendored verbatim (semantically) from `@axelar-network/axelar-gmp-sdk-solidity`
+ * (contracts/executable/AxelarExecutable.sol). Kept in-tree to avoid adding the
+ * full Axelar SDK as a build dependency, consistent with how this repo vendors
+ * other bridge interfaces (e.g. `interfaces/optimism`). Maintainers who prefer
+ * the upstream dependency can replace this file with an import from the SDK
+ * without changing {AxelarIsm}, since the surface is identical.
+ *
+ * `execute` is the untrusted entrypoint: it asks the gateway to validate that
+ * the Axelar network approved this exact (commandId, sourceChain, sourceAddress,
+ * payloadHash) tuple before dispatching to `_execute`. Authorization of the
+ * source is left to the child contract.
+ */
+abstract contract AxelarExecutable is IAxelarExecutable {
+    /// @dev Address of the Axelar Gateway contract.
+    address internal immutable gatewayAddress;
+
+    constructor(address gateway_) {
+        if (gateway_ == address(0)) revert InvalidAddress();
+        gatewayAddress = gateway_;
+    }
+
+    /// @inheritdoc IAxelarExecutable
+    function execute(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) external {
+        bytes32 payloadHash = keccak256(payload);
+
+        if (
+            !gateway().validateContractCall(
+                commandId,
+                sourceChain,
+                sourceAddress,
+                payloadHash
+            )
+        ) revert NotApprovedByGateway();
+
+        _execute(commandId, sourceChain, sourceAddress, payload);
+    }
+
+    /// @inheritdoc IAxelarExecutable
+    function gateway() public view returns (IAxelarGateway) {
+        return IAxelarGateway(gatewayAddress);
+    }
+
+    /**
+     * @dev Executes the gateway-validated command. Implemented by child contracts.
+     */
+    function _execute(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) internal virtual;
+}

--- a/solidity/contracts/interfaces/axelar/IAxelarExecutable.sol
+++ b/solidity/contracts/interfaces/axelar/IAxelarExecutable.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {IAxelarGateway} from "./IAxelarGateway.sol";
+
+/**
+ * @title IAxelarExecutable
+ * @notice Interface for a contract executable by the Axelar Gateway via GMP.
+ * @dev Vendored from `@axelar-network/axelar-gmp-sdk-solidity`
+ * (contracts/interfaces/IAxelarExecutable.sol).
+ */
+interface IAxelarExecutable {
+    /// @dev Thrown when a function is called with the zero address.
+    error InvalidAddress();
+
+    /// @dev Thrown when the call has not been approved by the Axelar Gateway.
+    error NotApprovedByGateway();
+
+    /// @notice Returns the Axelar Gateway associated with this executable.
+    function gateway() external view returns (IAxelarGateway);
+
+    /**
+     * @notice Executes a command delivered from another chain.
+     * @param commandId The Axelar command identifier of the delivery.
+     * @param sourceChain The Axelar name of the source chain.
+     * @param sourceAddress The source contract address (as a string).
+     * @param payload The payload to execute.
+     */
+    function execute(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) external;
+}

--- a/solidity/contracts/interfaces/axelar/IAxelarGasService.sol
+++ b/solidity/contracts/interfaces/axelar/IAxelarGasService.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title IAxelarGasService
+ * @notice Minimal interface for the Axelar Gas Service, restricted to native
+ * gas prepayment for a contract call.
+ * @dev Vendored from `@axelar-network/axelar-gmp-sdk-solidity`
+ * (contracts/interfaces/IAxelarGasService.sol). The `payNativeGasForContractCall`
+ * selector matches the deployed Axelar Gas Service exactly. Surplus gas paid via
+ * this method is refunded by Axelar to `refundAddress`, which is why
+ * {AxelarHook} can safely over-pay rather than compute an exact on-chain quote.
+ */
+interface IAxelarGasService {
+    /**
+     * @notice Pay for gas using native currency for a contract call on a
+     * destination chain. Called on the source chain before `callContract`.
+     * @param sender The address making the payment (the hook).
+     * @param destinationChain The Axelar name of the destination chain.
+     * @param destinationAddress The destination contract address (as a string).
+     * @param payload The payload passed to `callContract`.
+     * @param refundAddress The address that receives any gas over-payment refund.
+     */
+    function payNativeGasForContractCall(
+        address sender,
+        string calldata destinationChain,
+        string calldata destinationAddress,
+        bytes calldata payload,
+        address refundAddress
+    ) external payable;
+}

--- a/solidity/contracts/interfaces/axelar/IAxelarGateway.sol
+++ b/solidity/contracts/interfaces/axelar/IAxelarGateway.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title IAxelarGateway
+ * @notice Minimal interface for the Axelar Gateway, restricted to the General
+ * Message Passing (GMP) surface required by {AxelarHook} and {AxelarIsm}.
+ * @dev Vendored from `@axelar-network/axelar-gmp-sdk-solidity`
+ * (contracts/interfaces/IAxelarGateway.sol). Function selectors are identical
+ * to the deployed Axelar Gateway, so this interface is ABI-compatible with the
+ * canonical contracts on every supported chain. Only the methods used by this
+ * integration are declared to avoid pulling the full SDK dependency tree.
+ */
+interface IAxelarGateway {
+    /**
+     * @notice Emitted when a contract call is made through the gateway.
+     */
+    event ContractCall(
+        address indexed sender,
+        string destinationChain,
+        string destinationContractAddress,
+        bytes32 indexed payloadHash,
+        bytes payload
+    );
+
+    /**
+     * @notice Sends a contract call to another chain.
+     * @param destinationChain The Axelar name of the destination chain.
+     * @param contractAddress The address of the contract on the destination chain.
+     * @param payload The payload to be delivered to the destination contract.
+     */
+    function callContract(
+        string calldata destinationChain,
+        string calldata contractAddress,
+        bytes calldata payload
+    ) external;
+
+    /**
+     * @notice Validates and consumes a contract call approval.
+     * @dev Returns true exactly once for an approved (commandId, sourceChain,
+     * sourceAddress, msg.sender, payloadHash) tuple, then marks it executed.
+     * @return valid True if the contract call was approved by the Axelar network.
+     */
+    function validateContractCall(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes32 payloadHash
+    ) external returns (bool valid);
+
+    /**
+     * @notice Checks whether a contract call is currently approved.
+     */
+    function isContractCallApproved(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        address contractAddress,
+        bytes32 payloadHash
+    ) external view returns (bool);
+
+    /**
+     * @notice Checks whether a command has already been executed.
+     */
+    function isCommandExecuted(bytes32 commandId) external view returns (bool);
+}

--- a/solidity/contracts/isms/hook/AxelarIsm.sol
+++ b/solidity/contracts/isms/hook/AxelarIsm.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {AbstractMessageIdAuthorizedIsm} from "./AbstractMessageIdAuthorizedIsm.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
+import {AxelarExecutable} from "../../interfaces/axelar/AxelarExecutable.sol";
+import {StringToAddress} from "../../interfaces/axelar/AddressString.sol";
+
+// ============ External Imports ============
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ * @title AxelarIsm
+ * @notice Uses Axelar's General Message Passing to verify interchain messages.
+ * @dev Inherits {AxelarExecutable}: the Axelar Gateway-validated `execute`
+ * entrypoint dispatches to `_execute`, where the source is authorized and the
+ * Hyperlane message ID is recorded via `preVerifyMessage`.
+ *
+ * Trust model:
+ *  - {AxelarExecutable.execute} guarantees, via `gateway.validateContractCall`,
+ *    that the Axelar network approved this exact (sourceChain, sourceAddress,
+ *    payload) delivery.
+ *  - `_execute` then requires the delivery originated on the trusted origin
+ *    chain and from the authorized hook, before recording verification.
+ *
+ * Because authorization is established from Axelar's validated call arguments
+ * (not `msg.sender`), `preVerifyMessage` is reached through a self-call guarded
+ * by the transient `_verifying` flag, so it can only ever be set during a
+ * gateway-validated, source-authorized `execute`. Direct external calls to
+ * `preVerifyMessage` revert.
+ *
+ * Native value bridging is not supported (Axelar GMP carries no native value to
+ * the destination); the recorded `msgValue` is always 0.
+ */
+contract AxelarIsm is AxelarExecutable, AbstractMessageIdAuthorizedIsm {
+    using StringToAddress for string;
+    using Address for address;
+
+    // ============ Constants ============
+
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.NULL);
+
+    /// @notice keccak256 of the trusted Axelar source (origin) chain name.
+    bytes32 public immutable originChainHash;
+
+    // ============ Storage ============
+
+    /// @notice Human-readable Axelar origin chain name, retained for introspection.
+    string public originChain;
+
+    /// @dev True only for the duration of a gateway-validated, source-authorized
+    /// `execute`, gating the self-call into `preVerifyMessage`.
+    bool private _verifying;
+
+    // ============ Constructor ============
+
+    constructor(
+        address _axelarGateway,
+        string memory _originChain
+    ) AxelarExecutable(_axelarGateway) {
+        require(
+            bytes(_originChain).length != 0,
+            "AxelarIsm: invalid origin chain"
+        );
+        originChain = _originChain;
+        originChainHash = keccak256(bytes(_originChain));
+    }
+
+    // ============ Internal functions ============
+
+    /// @inheritdoc AbstractMessageIdAuthorizedIsm
+    function _isAuthorized() internal view override returns (bool) {
+        return _verifying && msg.sender == address(this);
+    }
+
+    /// @inheritdoc AxelarExecutable
+    function _execute(
+        bytes32,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes calldata payload
+    ) internal override {
+        require(
+            keccak256(bytes(sourceChain)) == originChainHash,
+            "AxelarIsm: untrusted source chain"
+        );
+        require(
+            sourceAddress.toAddress() ==
+                TypeCasts.bytes32ToAddress(authorizedHook),
+            "AxelarIsm: untrusted source address"
+        );
+        // Defense in depth: only the message-id verification call is ever forwarded.
+        require(
+            payload.length >= 4 &&
+                bytes4(payload[0:4]) ==
+                AbstractMessageIdAuthorizedIsm.preVerifyMessage.selector,
+            "AxelarIsm: invalid payload"
+        );
+
+        _verifying = true;
+        // Self-call records verification through preVerifyMessage, whose
+        // _isAuthorized() check passes only while `_verifying` is set.
+        address(this).functionCall(payload);
+        _verifying = false;
+    }
+}

--- a/solidity/contracts/mock/MockAxelar.sol
+++ b/solidity/contracts/mock/MockAxelar.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {IAxelarGateway} from "../interfaces/axelar/IAxelarGateway.sol";
+import {IAxelarGasService} from "../interfaces/axelar/IAxelarGasService.sol";
+
+/**
+ * @title MockAxelarGateway
+ * @notice Minimal test double for the Axelar Gateway.
+ * @dev Mirrors the real gateway's contract-call lifecycle closely enough to
+ * exercise {AxelarHook} and {AxelarIsm}:
+ *  - `callContract` is a no-op that emits `ContractCall` (asserted with vm.expectCall).
+ *  - `approveContractCall` (test-only) registers an approval, simulating the
+ *    Axelar network having approved a delivery.
+ *  - `validateContractCall` returns true once per approval (keyed on the calling
+ *    contract, i.e. the ISM) and then marks it executed, matching mainnet semantics.
+ */
+contract MockAxelarGateway is IAxelarGateway {
+    mapping(bytes32 => bool) public approvals;
+    mapping(bytes32 => bool) public executed;
+
+    function callContract(
+        string calldata destinationChain,
+        string calldata contractAddress,
+        bytes calldata payload
+    ) external override {
+        emit ContractCall(
+            msg.sender,
+            destinationChain,
+            contractAddress,
+            keccak256(payload),
+            payload
+        );
+    }
+
+    /// @notice Test helper: register an approval for a future `validateContractCall`.
+    function approveContractCall(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        address contractAddress,
+        bytes32 payloadHash
+    ) external {
+        approvals[
+            _key(
+                commandId,
+                sourceChain,
+                sourceAddress,
+                contractAddress,
+                payloadHash
+            )
+        ] = true;
+    }
+
+    function validateContractCall(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        bytes32 payloadHash
+    ) external override returns (bool) {
+        bytes32 key = _key(
+            commandId,
+            sourceChain,
+            sourceAddress,
+            msg.sender,
+            payloadHash
+        );
+        if (approvals[key]) {
+            approvals[key] = false;
+            executed[commandId] = true;
+            return true;
+        }
+        return false;
+    }
+
+    function isContractCallApproved(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        address contractAddress,
+        bytes32 payloadHash
+    ) external view override returns (bool) {
+        return
+            approvals[
+                _key(
+                    commandId,
+                    sourceChain,
+                    sourceAddress,
+                    contractAddress,
+                    payloadHash
+                )
+            ];
+    }
+
+    function isCommandExecuted(
+        bytes32 commandId
+    ) external view override returns (bool) {
+        return executed[commandId];
+    }
+
+    function _key(
+        bytes32 commandId,
+        string calldata sourceChain,
+        string calldata sourceAddress,
+        address contractAddress,
+        bytes32 payloadHash
+    ) private pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    commandId,
+                    sourceChain,
+                    sourceAddress,
+                    contractAddress,
+                    payloadHash
+                )
+            );
+    }
+}
+
+/**
+ * @title MockAxelarGasService
+ * @notice Minimal test double for the Axelar Gas Service.
+ * @dev Accepts and retains the native gas pre-payment (so the hook forwards its
+ * entire balance here, leaving nothing to refund on-chain) and emits an event
+ * for `vm.expectCall`/`vm.expectEmit` assertions.
+ */
+contract MockAxelarGasService is IAxelarGasService {
+    event NativeGasPaidForContractCall(
+        address indexed sender,
+        string destinationChain,
+        string destinationAddress,
+        bytes32 indexed payloadHash,
+        uint256 gasFeeAmount,
+        address refundAddress
+    );
+
+    function payNativeGasForContractCall(
+        address sender,
+        string calldata destinationChain,
+        string calldata destinationAddress,
+        bytes calldata payload,
+        address refundAddress
+    ) external payable override {
+        emit NativeGasPaidForContractCall(
+            sender,
+            destinationChain,
+            destinationAddress,
+            keccak256(payload),
+            msg.value,
+            refundAddress
+        );
+    }
+}

--- a/solidity/script/AxelarHookDeployer.s.sol
+++ b/solidity/script/AxelarHookDeployer.s.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {TypeCasts} from "../contracts/libs/TypeCasts.sol";
+import {AxelarHook} from "../contracts/hooks/AxelarHook.sol";
+import {AxelarIsm} from "../contracts/isms/hook/AxelarIsm.sol";
+
+/**
+ * @title AxelarHookDeployer
+ * @notice Helper deployment script for the Axelar Hook + ISM testnet demo.
+ * @dev Deployment is necessarily two-sided (ISM on the destination chain, hook
+ * on the origin chain), so each step is a separate entrypoint driven by env
+ * vars. See `RUNBOOK_testnet_demo.md` for the full walkthrough.
+ *
+ * Steps:
+ *  1. `deployIsm`            on the DESTINATION chain.
+ *  2. `deployHook`           on the ORIGIN chain (needs the ISM address).
+ *  3. `setAuthorizedHook`    on the DESTINATION chain (needs the hook address).
+ */
+contract AxelarHookDeployer is Script {
+    function deployIsm() external {
+        address axelarGateway = vm.envAddress("AXELAR_GATEWAY");
+        string memory originChain = vm.envString("AXELAR_ORIGIN_CHAIN");
+
+        vm.startBroadcast();
+        AxelarIsm ism = new AxelarIsm(axelarGateway, originChain);
+        vm.stopBroadcast();
+
+        console.log("AxelarIsm deployed at:", address(ism));
+    }
+
+    function deployHook() external {
+        address mailbox = vm.envAddress("HYP_MAILBOX");
+        uint32 destinationDomain = uint32(vm.envUint("HYP_DESTINATION_DOMAIN"));
+        address ism = vm.envAddress("AXELAR_ISM");
+        address axelarGateway = vm.envAddress("AXELAR_GATEWAY");
+        address axelarGasService = vm.envAddress("AXELAR_GAS_SERVICE");
+        string memory destinationChain = vm.envString(
+            "AXELAR_DESTINATION_CHAIN"
+        );
+
+        vm.startBroadcast();
+        AxelarHook hook = new AxelarHook(
+            mailbox,
+            destinationDomain,
+            TypeCasts.addressToBytes32(ism),
+            axelarGateway,
+            axelarGasService,
+            destinationChain
+        );
+        vm.stopBroadcast();
+
+        console.log("AxelarHook deployed at:", address(hook));
+    }
+
+    function setAuthorizedHook() external {
+        address ism = vm.envAddress("AXELAR_ISM");
+        address hook = vm.envAddress("AXELAR_HOOK");
+
+        vm.startBroadcast();
+        AxelarIsm(ism).setAuthorizedHook(TypeCasts.addressToBytes32(hook));
+        vm.stopBroadcast();
+
+        console.log("AxelarIsm authorized hook set to:", hook);
+    }
+}

--- a/solidity/test/isms/AxelarIsm.t.sol
+++ b/solidity/test/isms/AxelarIsm.t.sol
@@ -363,7 +363,7 @@ contract AxelarIsmTest is ExternalBridgeTest {
             axelarIsm.authorizedHook(),
             TypeCasts.addressToBytes32(address(hook))
         );
-        assertEq(uint256(axelarIsm.moduleType()), 0); // Types.NULL
+        assertEq(uint256(axelarIsm.moduleType()), 6); // Types.NULL
     }
 
     function test_ism_constructor_revertWhen_zeroGateway() public {
@@ -485,6 +485,16 @@ contract AxelarIsmTest is ExternalBridgeTest {
         // 42 chars, 0x-prefixed, but contains a non-hex character ('z' = 122)
         vm.expectRevert(StringToAddress.InvalidAddressString.selector);
         addrLib.toAddress("0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz");
+    }
+
+    function test_stringToAddress_acceptsUppercaseHex() public view {
+        // Axelar peers may emit checksummed/uppercase hex; parsing must be
+        // case-insensitive so source authorization is robust to casing.
+        address expected = 0xabCDeF0123456789AbcdEf0123456789aBCDEF01;
+        assertEq(
+            addrLib.toAddress("0xABCDEF0123456789ABCDEF0123456789ABCDEF01"),
+            expected
+        );
     }
 }
 

--- a/solidity/test/isms/AxelarIsm.t.sol
+++ b/solidity/test/isms/AxelarIsm.t.sol
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: MIT or Apache-2.0
+pragma solidity ^0.8.13;
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
+import {AbstractMessageIdAuthorizedIsm} from "../../contracts/isms/hook/AbstractMessageIdAuthorizedIsm.sol";
+import {AbstractMessageIdAuthHook} from "../../contracts/hooks/libs/AbstractMessageIdAuthHook.sol";
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {TestRecipient} from "../../contracts/test/TestRecipient.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+
+import {AxelarHook} from "../../contracts/hooks/AxelarHook.sol";
+import {AxelarIsm} from "../../contracts/isms/hook/AxelarIsm.sol";
+import {IAxelarGateway} from "../../contracts/interfaces/axelar/IAxelarGateway.sol";
+import {IAxelarGasService} from "../../contracts/interfaces/axelar/IAxelarGasService.sol";
+import {IAxelarExecutable} from "../../contracts/interfaces/axelar/IAxelarExecutable.sol";
+import {AddressToString, StringToAddress} from "../../contracts/interfaces/axelar/AddressString.sol";
+import {MockAxelarGateway, MockAxelarGasService} from "../../contracts/mock/MockAxelar.sol";
+
+import {ExternalBridgeTest} from "./ExternalBridgeTest.sol";
+import {MessageUtils} from "./IsmTestUtils.sol";
+
+/**
+ * @notice Test suite for {AxelarHook} + {AxelarIsm}.
+ * @dev Extends {ExternalBridgeTest} to inherit the shared hook/ISM behavioural
+ * suite, overriding the bridge-specific hooks for Axelar GMP semantics. Axelar
+ * does not deliver native value to the destination, so value-bridging tests are
+ * overridden to assert the unsupported-value behaviour. Axelar-specific branches
+ * (gateway approval, source authorization, payload validation, gas payment,
+ * string<>address conversion) are covered by dedicated tests below.
+ */
+contract AxelarIsmTest is ExternalBridgeTest {
+    using TypeCasts for address;
+    using MessageUtils for bytes;
+    using AddressToString for address;
+
+    string internal constant AXELAR_ORIGIN_CHAIN = "ethereum";
+    string internal constant AXELAR_DESTINATION_CHAIN = "arbitrum";
+
+    MockAxelarGateway internal gateway;
+    MockAxelarGasService internal gasService;
+
+    AxelarHook internal axelarHook;
+    AxelarIsm internal axelarIsm;
+    AddressStringHarness internal addrLib;
+
+    function setUp() public override {
+        // Axelar gas cannot be quoted on-chain; the hook returns a 0 quote and
+        // the caller attaches native value, so the shared harness runs with GAS_QUOTE = 0.
+        GAS_QUOTE = 0;
+
+        gateway = new MockAxelarGateway();
+        gasService = new MockAxelarGasService();
+        addrLib = new AddressStringHarness();
+
+        deployAll();
+        super.setUp();
+    }
+
+    /* ============ setup ============ */
+
+    function deployIsm() public {
+        axelarIsm = new AxelarIsm(address(gateway), AXELAR_ORIGIN_CHAIN);
+        ism = AbstractMessageIdAuthorizedIsm(address(axelarIsm));
+    }
+
+    function deployHook() public {
+        originMailbox = new TestMailbox(ORIGIN_DOMAIN);
+        axelarHook = new AxelarHook(
+            address(originMailbox),
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(ism)),
+            address(gateway),
+            address(gasService),
+            AXELAR_DESTINATION_CHAIN
+        );
+        hook = AbstractMessageIdAuthHook(address(axelarHook));
+    }
+
+    function deployAll() public {
+        deployIsm();
+        deployHook();
+        ism.setAuthorizedHook(TypeCasts.addressToBytes32(address(hook)));
+    }
+
+    /* ============ ExternalBridgeTest hooks ============ */
+
+    function _expectOriginExternalBridgeCall(
+        bytes memory _encodedHookData
+    ) internal override {
+        vm.expectCall(
+            address(gateway),
+            abi.encodeCall(
+                IAxelarGateway.callContract,
+                (
+                    AXELAR_DESTINATION_CHAIN,
+                    AddressToString.toString(address(ism)),
+                    _encodedHookData
+                )
+            )
+        );
+    }
+
+    /// @dev Simulates the Axelar network delivering the GMP message to the ISM.
+    /// Native value is never carried by Axelar GMP, so `_msgValue` is ignored.
+    function _externalBridgeDestinationCall(
+        bytes memory _encodedHookData,
+        uint256
+    ) internal override {
+        (bytes32 commandId, string memory source) = _approveDelivery(
+            _encodedHookData
+        );
+        axelarIsm.execute(
+            commandId,
+            AXELAR_ORIGIN_CHAIN,
+            source,
+            _encodedHookData
+        );
+    }
+
+    /// @dev Registers a gateway approval for a delivery from the authorized hook
+    /// on the trusted origin chain, returning the (commandId, source) so callers
+    /// can invoke `execute` as a separate statement. This lets `vm.expectRevert`
+    /// scope to the `execute` call rather than the (successful) approval.
+    function _approveDelivery(
+        bytes memory hookData
+    ) internal returns (bytes32 commandId, string memory source) {
+        source = AddressToString.toString(address(hook));
+        commandId = keccak256(hookData);
+        gateway.approveContractCall(
+            commandId,
+            AXELAR_ORIGIN_CHAIN,
+            source,
+            address(ism),
+            keccak256(hookData)
+        );
+    }
+
+    /// @dev Axelar verification is asynchronous (execute writes storage, then
+    /// `verify` reads it); there is no synchronous metadata-bearing verify path.
+    function _encodeExternalDestinationBridgeCall(
+        address,
+        address,
+        uint256,
+        bytes32
+    ) internal pure override returns (bytes memory) {
+        return new bytes(0);
+    }
+
+    /* ============ overrides: no synchronous external-bridge verify path ============ */
+
+    function test_preVerifyMessage_externalBridgeCall() public override {}
+
+    function test_verify_msgValue_externalBridgeCall() public override {}
+
+    function test_verify_revertsWhen_invalidIsm() public override {}
+
+    function test_verify_false_arbitraryCall() public override {}
+
+    function test_verify_revertWhen_invalidMetadata() public override {
+        // verify() never reverts on empty metadata; it simply reports unverified.
+        assertFalse(ism.verify(new bytes(0), encodedMessage));
+    }
+
+    /* ============ overrides: Axelar carries no native value ============ */
+
+    function test_verify_msgValue_asyncCall() public override {
+        // A delivery encoding a non-zero msgValue cannot be verified because the
+        // destination call carries zero native value.
+        bytes memory encodedHookData = _encodeHookData(messageId, MSG_VALUE);
+        (bytes32 commandId, string memory source) = _approveDelivery(
+            encodedHookData
+        );
+
+        vm.expectRevert("AbstractMessageIdAuthorizedIsm: invalid msg.value");
+        axelarIsm.execute(commandId, AXELAR_ORIGIN_CHAIN, source, encodedHookData);
+
+        assertFalse(ism.isVerified(encodedMessage));
+        assertEq(address(testRecipient).balance, 0);
+    }
+
+    function test_verify_override_msgValue() public override {
+        bytes memory encodedHookData = _encodeHookData(messageId, MSG_VALUE);
+        (bytes32 commandId, string memory source) = _approveDelivery(
+            encodedHookData
+        );
+
+        vm.expectRevert("AbstractMessageIdAuthorizedIsm: invalid msg.value");
+        axelarIsm.execute(commandId, AXELAR_ORIGIN_CHAIN, source, encodedHookData);
+
+        assertFalse(ism.isVerified(encodedMessage));
+    }
+
+    function test_verify_valueAlreadyClaimed(uint256) public override {
+        // Verification always records zero value; recipient never receives funds.
+        _externalBridgeDestinationCall(_encodeHookData(messageId, 0), 0);
+
+        bool verified = ism.verify(new bytes(0), encodedMessage);
+        assertTrue(verified);
+        assertEq(address(ism).balance, 0);
+        assertEq(address(testRecipient).balance, 0);
+
+        // A repeated verify remains true and is a no-op on balances.
+        verified = ism.verify(new bytes(0), encodedMessage);
+        assertTrue(verified);
+        assertEq(address(testRecipient).balance, 0);
+    }
+
+    /* ============ overrides: source authorization (Axelar-specific) ============ */
+
+    function test_verify_revertsWhen_notAuthorizedHook() public override {
+        string memory badSource = AddressToString.toString(address(this));
+        bytes memory payload = _encodeHookData(messageId, 0);
+        bytes32 commandId = keccak256(payload);
+        gateway.approveContractCall(
+            commandId,
+            AXELAR_ORIGIN_CHAIN,
+            badSource,
+            address(ism),
+            keccak256(payload)
+        );
+
+        vm.expectRevert("AxelarIsm: untrusted source address");
+        axelarIsm.execute(commandId, AXELAR_ORIGIN_CHAIN, badSource, payload);
+
+        assertFalse(ism.isVerified(encodedMessage));
+    }
+
+    function test_verify_revertsWhen_incorrectMessageId() public override {
+        bytes32 incorrectMessageId = keccak256("incorrect message id");
+        // The wrong id is verified, so the real message remains unverified.
+        _externalBridgeDestinationCall(
+            _encodeHookData(incorrectMessageId, 0),
+            0
+        );
+        assertFalse(ism.isVerified(testMessage));
+    }
+
+    /* ============ Axelar: hook configuration & construction ============ */
+
+    function test_hook_configuration() public view {
+        assertEq(address(axelarHook.axelarGateway()), address(gateway));
+        assertEq(address(axelarHook.axelarGasService()), address(gasService));
+        assertEq(axelarHook.destinationChain(), AXELAR_DESTINATION_CHAIN);
+        assertEq(axelarHook.destinationDomain(), DESTINATION_DOMAIN);
+        assertEq(axelarHook.ism(), TypeCasts.addressToBytes32(address(ism)));
+    }
+
+    function test_hook_constructor_revertWhen_invalidGateway() public {
+        vm.expectRevert("AxelarHook: invalid gateway");
+        new AxelarHook(
+            address(originMailbox),
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(ism)),
+            address(0xdead), // EOA, not a contract
+            address(gasService),
+            AXELAR_DESTINATION_CHAIN
+        );
+    }
+
+    function test_hook_constructor_revertWhen_invalidGasService() public {
+        vm.expectRevert("AxelarHook: invalid gas service");
+        new AxelarHook(
+            address(originMailbox),
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(ism)),
+            address(gateway),
+            address(0xdead),
+            AXELAR_DESTINATION_CHAIN
+        );
+    }
+
+    function test_hook_constructor_revertWhen_emptyDestinationChain() public {
+        vm.expectRevert("AxelarHook: invalid destination chain");
+        new AxelarHook(
+            address(originMailbox),
+            DESTINATION_DOMAIN,
+            TypeCasts.addressToBytes32(address(ism)),
+            address(gateway),
+            address(gasService),
+            ""
+        );
+    }
+
+    /* ============ Axelar: hook value semantics & gas payment ============ */
+
+    function test_quoteDispatch_revertWhen_msgValue() public {
+        bytes memory metadata = StandardHookMetadata.overrideMsgValue(
+            MSG_VALUE
+        );
+        vm.expectRevert("AxelarHook: msgValue not supported");
+        hook.quoteDispatch(metadata, encodedMessage);
+    }
+
+    function test_postDispatch_revertWhen_msgValue() public {
+        bytes memory metadata = StandardHookMetadata.overrideMsgValue(
+            MSG_VALUE
+        );
+        originMailbox.updateLatestDispatchedId(messageId);
+
+        vm.deal(address(this), MSG_VALUE);
+        vm.expectRevert("AxelarHook: msgValue not supported");
+        hook.postDispatch{value: MSG_VALUE}(metadata, encodedMessage);
+    }
+
+    function test_postDispatch_forwardsValueToGasService() public {
+        uint256 payment = 0.01 ether;
+        vm.deal(address(this), payment);
+
+        bytes memory encodedHookData = _encodeHookData(messageId, 0);
+        originMailbox.updateLatestDispatchedId(messageId);
+
+        vm.expectCall(
+            address(gasService),
+            payment,
+            abi.encodeCall(
+                IAxelarGasService.payNativeGasForContractCall,
+                (
+                    address(hook),
+                    AXELAR_DESTINATION_CHAIN,
+                    AddressToString.toString(address(ism)),
+                    encodedHookData,
+                    address(this) // refund address from testMetadata
+                )
+            )
+        );
+
+        hook.postDispatch{value: payment}(testMetadata, encodedMessage);
+
+        assertEq(address(gasService).balance, payment);
+        assertEq(address(hook).balance, 0);
+    }
+
+    /// @dev Overrides the shared refund test: Axelar uses an over-pay model, so
+    /// the entire attached value is forwarded to the Gas Service (refunded
+    /// off-chain by Axelar) rather than refunded on-chain.
+    function testFuzz_postDispatch_refundsExtraValue(
+        uint256 value
+    ) public override {
+        value = bound(value, 0, MAX_MSG_VALUE);
+        vm.deal(address(this), value);
+
+        bytes memory encodedHookData = _encodeHookData(messageId, 0);
+        originMailbox.updateLatestDispatchedId(messageId);
+        _expectOriginExternalBridgeCall(encodedHookData);
+
+        hook.postDispatch{value: value}(testMetadata, encodedMessage);
+
+        assertEq(address(gasService).balance, value);
+        assertEq(address(hook).balance, 0);
+    }
+
+    /* ============ Axelar: ISM construction ============ */
+
+    function test_ism_configuration() public view {
+        assertEq(address(axelarIsm.gateway()), address(gateway));
+        assertEq(axelarIsm.originChain(), AXELAR_ORIGIN_CHAIN);
+        assertEq(
+            axelarIsm.originChainHash(),
+            keccak256(bytes(AXELAR_ORIGIN_CHAIN))
+        );
+        assertEq(
+            axelarIsm.authorizedHook(),
+            TypeCasts.addressToBytes32(address(hook))
+        );
+        assertEq(uint256(axelarIsm.moduleType()), 0); // Types.NULL
+    }
+
+    function test_ism_constructor_revertWhen_zeroGateway() public {
+        vm.expectRevert(IAxelarExecutable.InvalidAddress.selector);
+        new AxelarIsm(address(0), AXELAR_ORIGIN_CHAIN);
+    }
+
+    function test_ism_constructor_revertWhen_emptyOriginChain() public {
+        vm.expectRevert("AxelarIsm: invalid origin chain");
+        new AxelarIsm(address(gateway), "");
+    }
+
+    /* ============ Axelar: execute() authorization branches ============ */
+
+    function test_execute_revertWhen_notApprovedByGateway() public {
+        bytes memory payload = _encodeHookData(messageId, 0);
+        string memory source = AddressToString.toString(address(hook));
+
+        vm.expectRevert(IAxelarExecutable.NotApprovedByGateway.selector);
+        axelarIsm.execute(
+            keccak256(payload),
+            AXELAR_ORIGIN_CHAIN,
+            source,
+            payload
+        );
+    }
+
+    function test_execute_revertWhen_untrustedSourceChain() public {
+        bytes memory payload = _encodeHookData(messageId, 0);
+        string memory source = AddressToString.toString(address(hook));
+        bytes32 commandId = keccak256(payload);
+        gateway.approveContractCall(
+            commandId,
+            "polygon",
+            source,
+            address(ism),
+            keccak256(payload)
+        );
+
+        vm.expectRevert("AxelarIsm: untrusted source chain");
+        axelarIsm.execute(commandId, "polygon", source, payload);
+    }
+
+    function test_execute_revertWhen_shortPayload() public {
+        bytes memory payload = hex"00112233"; // 4 bytes but wrong selector
+        string memory source = AddressToString.toString(address(hook));
+        bytes32 commandId = keccak256(payload);
+        gateway.approveContractCall(
+            commandId,
+            AXELAR_ORIGIN_CHAIN,
+            source,
+            address(ism),
+            keccak256(payload)
+        );
+
+        vm.expectRevert("AxelarIsm: invalid payload");
+        axelarIsm.execute(commandId, AXELAR_ORIGIN_CHAIN, source, payload);
+    }
+
+    function test_execute_revertWhen_payloadTooShort() public {
+        bytes memory payload = hex"0011"; // < 4 bytes
+        string memory source = AddressToString.toString(address(hook));
+        bytes32 commandId = keccak256(payload);
+        gateway.approveContractCall(
+            commandId,
+            AXELAR_ORIGIN_CHAIN,
+            source,
+            address(ism),
+            keccak256(payload)
+        );
+
+        vm.expectRevert("AxelarIsm: invalid payload");
+        axelarIsm.execute(commandId, AXELAR_ORIGIN_CHAIN, source, payload);
+    }
+
+    function test_execute_revertWhen_alreadyVerified() public {
+        bytes memory payload = _encodeHookData(messageId, 0);
+        _externalBridgeDestinationCall(payload, 0);
+        assertTrue(ism.isVerified(encodedMessage));
+
+        // Replaying the same message id is rejected by preVerifyMessage and the
+        // revert bubbles up through execute.
+        string memory source = AddressToString.toString(address(hook));
+        bytes32 commandId = keccak256(abi.encode("second", payload));
+        gateway.approveContractCall(
+            commandId,
+            AXELAR_ORIGIN_CHAIN,
+            source,
+            address(ism),
+            keccak256(payload)
+        );
+        vm.expectRevert("AbstractMessageIdAuthorizedIsm: message already verified");
+        axelarIsm.execute(commandId, AXELAR_ORIGIN_CHAIN, source, payload);
+    }
+
+    function test_preVerifyMessage_revertWhen_directCall() public {
+        vm.expectRevert("AbstractMessageIdAuthorizedIsm: sender is not the hook");
+        axelarIsm.preVerifyMessage(messageId, 0);
+    }
+
+    /* ============ Axelar: AddressString library ============ */
+
+    function testFuzz_addressString_roundtrip(address a) public view {
+        assertEq(addrLib.toAddress(addrLib.toString(a)), a);
+    }
+
+    function test_stringToAddress_revertWhen_wrongLength() public {
+        vm.expectRevert(StringToAddress.InvalidAddressString.selector);
+        addrLib.toAddress("0x1234");
+    }
+
+    function test_stringToAddress_revertWhen_missingPrefix() public {
+        // 42 chars but not 0x-prefixed
+        vm.expectRevert(StringToAddress.InvalidAddressString.selector);
+        addrLib.toAddress("0X00000000000000000000000000000000000000ab");
+    }
+
+    function test_stringToAddress_revertWhen_invalidChar() public {
+        // 42 chars, 0x-prefixed, but contains a non-hex character ('z' = 122)
+        vm.expectRevert(StringToAddress.InvalidAddressString.selector);
+        addrLib.toAddress("0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz");
+    }
+}
+
+/**
+ * @notice Exposes the internal AddressString libraries as external functions so
+ * their success and revert branches can be asserted directly.
+ */
+contract AddressStringHarness {
+    using StringToAddress for string;
+    using AddressToString for address;
+
+    function toAddress(string calldata s) external pure returns (address) {
+        return s.toAddress();
+    }
+
+    function toString(address a) external pure returns (string memory) {
+        return a.toString();
+    }
+}


### PR DESCRIPTION
# feat(solidity): Axelar Hook and ISM (closes #2851)

## Summary

Adds a message **Hook** and **Interchain Security Module** that transport a
Hyperlane message ID over **Axelar's General Message Passing (GMP)**.

- **`AxelarHook`** (origin chain) — on `postDispatch`, pre-pays the Axelar Gas
  Service in native tokens and calls `IAxelarGateway.callContract`, carrying a
  payload that invokes `preVerifyMessage(messageId, 0)` on the destination ISM.
- **`AxelarIsm`** (destination chain) — inherits `AxelarExecutable`; the
  gateway-validated `execute` entrypoint authorizes the delivery by Axelar
  source chain + source address, then records verification.

This mirrors the existing `OPStackHook` / `OPStackIsm` pair, reusing
`AbstractMessageIdAuthHook` and `AbstractMessageIdAuthorizedIsm` so it slots
into the standard hook/ISM machinery with no Mailbox changes.

## Before / After

**Condition — before this PR:** Hyperlane had no way to transport a message ID
over Axelar GMP. A route that wanted Axelar-secured verification could not be
expressed: there was no Axelar hook to emit the cross-chain call on the origin,
and no Axelar ISM to attest the message on the destination. (Bridge hook/ISM
pairs existed for OP Stack, CCIP, etc. — but not Axelar.)

**Condition — after this PR:** Dispatching through `AxelarHook` pays Axelar gas
and emits `gateway.callContract`; Axelar relays it; `AxelarIsm.execute` verifies
the message on the destination, after which the Mailbox can `process` it. Axelar
becomes a usable transport for the standard message-ID auth hook/ISM flow.

| Metric | Before | After |
|---|---:|---:|
| Axelar GMP transport for Hyperlane | not available | `AxelarHook` + `AxelarIsm` |
| New production contracts | 0 | 2 |
| New external/npm dependencies | — | 0 (Axelar surface vendored in-tree) |
| New Solidity files (contracts + vendored + mock) | 0 | 8 |
| Test cases exercising the pair | 0 | ~39 (shared `ExternalBridgeTest` suite + Axelar-specific) |
| Target coverage on the 2 new contracts | n/a | 100% line + branch |
| Mailbox / SDK / registry changes | — | 0 (strictly in scope of #2851) |
| Native value bridged to destination | n/a | 0 by design (Axelar GMP carries none; non-zero `msgValue` rejected) |

**Acceptance conditions (definition of done):**

- [ ] `forge build` compiles on `main` toolchain (solc 0.8.33 / cancun)
- [ ] `forge test --match-contract AxelarIsmTest` all green
- [ ] `forge coverage` shows 100% line + branch on `AxelarHook` and `AxelarIsm`
- [ ] Testnet demo tx hashes attached (see Demo section)

## Design

### Gas accounting (per the maintainer's suggestion in #2851)
The exact Axelar GMP gas cost cannot be computed on-chain — it depends on
destination gas price and token exchange rates resolved by Axelar's off-chain
gas oracle. Following the maintainer's "over-pay and let Axelar refund" hint,
`quoteDispatch` returns `0` and the caller instead attaches native value when
dispatching. The hook forwards the entire attached value to
`payNativeGasForContractCall` (an over-payment), and Axelar refunds the surplus
off-chain to the metadata refund address. Under-payment does not lose funds — it
simply stalls relaying until more gas is added via the Axelar Gas Service. A
`0` quote also keeps the hook compatible with the shared `ExternalBridgeTest`
harness (which, like `OPStackHook`, assumes a zero protocol-charged quote).

### Authorization / trust model
`AxelarExecutable.execute` asks the gateway (`validateContractCall`) to confirm
the Axelar network approved this exact `(commandId, sourceChain, sourceAddress,
payloadHash)` delivery. `AxelarIsm._execute` then enforces:

1. `sourceChain` equals the configured trusted origin chain (`originChainHash`);
2. the parsed `sourceAddress` equals the configured `authorizedHook`;
3. the payload is a `preVerifyMessage` call (selector check, defense-in-depth).

Because authorization comes from Axelar's *validated call arguments* rather than
`msg.sender`, `preVerifyMessage` is reached via a self-call guarded by a
transient `_verifying` flag, so its `_isAuthorized()` check can only pass inside
a gateway-validated, source-authorized `execute`. Direct external calls to
`preVerifyMessage` revert. Source addresses are compared as parsed `address`
values (not raw strings), making authorization robust to hex casing.

### No native-value bridging
Axelar GMP does not deliver native value to the destination contract. To avoid
silently stranding funds, the hook rejects any non-zero `metadata.msgValue`, and
the ISM always records `msgValue == 0`.

### Dependencies
Minimal Axelar interfaces (`IAxelarGateway`, `IAxelarGasService`,
`IAxelarExecutable`), a small `AxelarExecutable` base, and the `AddressString`
library are **vendored** under `contracts/interfaces/axelar/`, consistent with
how this repo vendors other bridge interfaces (e.g. `interfaces/optimism`).
Function selectors are identical to the canonical
`@axelar-network/axelar-gmp-sdk-solidity`, so the contracts are ABI-compatible
with the deployed Axelar contracts. If maintainers prefer the upstream
dependency, the vendored files can be swapped for SDK imports with no change to
`AxelarHook` / `AxelarIsm`.

## Files

| File | Purpose |
|---|---|
| `contracts/hooks/AxelarHook.sol` | origin-chain hook |
| `contracts/isms/hook/AxelarIsm.sol` | destination-chain ISM |
| `contracts/interfaces/axelar/*` | vendored minimal Axelar surface |
| `contracts/mock/MockAxelar.sol` | gateway + gas service test doubles |
| `test/isms/AxelarIsm.t.sol` | full test suite (extends `ExternalBridgeTest`) |
| `script/AxelarHookDeployer.s.sol` | testnet deploy helper |
| `.changeset/axelar-hook-and-ism.md` | changeset |

## Testing

```bash
cd solidity
forge build
forge test  --match-contract AxelarIsmTest -vvv
forge coverage --match-contract AxelarIsmTest \
  --no-match-coverage "(test|mock|script)/"
```

The suite extends `ExternalBridgeTest` (the shared hook/ISM harness used by
`OPStackIsm`) and adds Axelar-specific tests covering: constructor validation
(hook + ISM), `quoteDispatch`/`postDispatch` value rejection, gas-service
pre-payment, gateway-not-approved, untrusted source chain/address, payload
validation (short payload + wrong selector), replay rejection, direct
`preVerifyMessage` rejection, and the `AddressString` round-trip + revert paths.
Target: 100% line/branch coverage on the new contracts.

## Demo (testnet)

> Filled in after running `RUNBOOK_testnet_demo.md`.

- Origin dispatch tx: `<hash>`
- AxelarScan GMP: `<link>`
- Destination `execute` tx: `<hash>`

## Checklist

- [x] Mirrors existing `OPStack` hook/ISM conventions
- [x] No changes outside the scope of #2851
- [x] Changeset added (`@hyperlane-xyz/core`)
- [x] NatSpec on all public/external members
- [ ] `forge test` + `forge coverage` green locally
- [ ] Testnet demo tx hashes added above

---

## Test results ✅

Toolchain: `forge` (Foundry) + solc 0.8.33 / evm cancun (per `solidity/foundry.toml`).

```
forge test --match-contract AxelarIsmTest
Suite result: ok. 44 passed; 0 failed; 0 skipped (44 total tests)
```

Coverage (`FOUNDRY_PROFILE=coverage forge coverage --match-contract AxelarIsmTest --no-match-coverage "(test|mock|script)/"`):

| File | % Lines | % Statements | % Branches | % Funcs |
|------|---------|--------------|------------|---------|
| contracts/hooks/AxelarHook.sol | 100.00% (16/16) | 100.00% (15/15) | 100.00% (10/10) | 100.00% (3/3) |
| contracts/isms/hook/AxelarIsm.sol | 100.00% (13/13) | 100.00% (12/12) | 100.00% (8/8) | 100.00% (3/3) |
| contracts/interfaces/axelar/AxelarExecutable.sol | 100.00% (10/10) | 100.00% (10/10) | 100.00% (2/2) | 100.00% (3/3) |
| contracts/interfaces/axelar/AddressString.sol | 100.00% (26/26) | 100.00% (35/35) | 100.00% (7/7) | 100.00% (2/2) |

All new contracts are at 100% line/statement/branch/function coverage.

## Demo (testnet tx hashes) — TODO

Issue #2851 requests a testnet/mainnet demo with tx hashes. These will be
captured via `RUNBOOK_testnet_demo.md` (needs funded testnet keys + RPC URLs)
and added here before the PR is marked ready for review.
