### PR TITLE
Add flash CCR rebalancer

### DIFF
--- a/solidity/contracts/rebalancing/FlashCcrRebalancer.sol
+++ b/solidity/contracts/rebalancing/FlashCcrRebalancer.sol
@@ -1,0 +1,708 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.24;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {Quote} from "../interfaces/ITokenBridge.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
+import {ReentrancyGuardTransient} from "../libs/ReentrancyGuardTransient.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+
+interface IFlashCcrRouter {
+    function localDomain() external view returns (uint32);
+
+    function token() external view returns (address);
+
+    function quoteTransferRemoteTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount,
+        bytes32 _targetRouter
+    ) external view returns (Quote[] memory);
+
+    function transferRemoteTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount,
+        bytes32 _targetRouter
+    ) external payable returns (bytes32);
+}
+
+interface IAaveV3FlashPool {
+    function flashLoanSimple(
+        address receiverAddress,
+        address asset,
+        uint256 amount,
+        bytes calldata params,
+        uint16 referralCode
+    ) external;
+}
+
+interface IUniswapV3FlashPool {
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function flash(
+        address recipient,
+        uint256 amount0,
+        uint256 amount1,
+        bytes calldata data
+    ) external;
+}
+
+/**
+ * @title FlashCcrRebalancer
+ * @notice Atomically rebalances same-chain CrossCollateralRouter pools using a
+ *         flashloan, a same-domain transferRemoteTo, and caller-supplied swap
+ *         calldata.
+ * @dev The contract is intentionally not a generic multicall surface. The only
+ *      arbitrary call is one allowlisted swap target with bounded token input
+ *      and an enforced output balance increase. It never receives approval from
+ *      warp route adapters; it only deposits the borrowed token through
+ *      transferRemoteTo and repays the flashloan before the transaction ends.
+ */
+contract FlashCcrRebalancer is
+    Ownable,
+    PackageVersioned,
+    ReentrancyGuardTransient
+{
+    using Address for address;
+    using SafeERC20 for IERC20;
+    using TypeCasts for address;
+    using TypeCasts for bytes32;
+
+    enum FlashLoanProvider {
+        AaveV3,
+        UniswapV3
+    }
+
+    struct FlashLoanParams {
+        FlashLoanProvider provider;
+        address providerAddress;
+        address token;
+        uint256 amount;
+    }
+
+    struct CcrParams {
+        address deficitRouter;
+        address surplusRouter;
+        bytes32 targetRouter;
+        uint32 localDomain;
+        uint256 amount;
+        uint256 maxDeficitTokenDebit;
+        uint256 minSurplusReceived;
+    }
+
+    struct SwapCall {
+        address target;
+        address allowanceTarget;
+        address tokenIn;
+        address tokenOut;
+        uint256 amountInMax;
+        uint256 minAmountOut;
+        uint256 value;
+        bytes data;
+    }
+
+    struct TopUpParams {
+        address payer;
+        uint256 maxSurplusTokenTopUp;
+        uint256 maxDeficitTokenTopUp;
+    }
+
+    struct RebalanceParams {
+        FlashLoanParams loan;
+        CcrParams ccr;
+        SwapCall swap;
+        TopUpParams topUp;
+        address refundTo;
+        uint256 deadline;
+    }
+
+    error UnauthorizedRebalancer(address caller);
+    error UnauthorizedFlashLoanProvider(
+        FlashLoanProvider provider,
+        address pool
+    );
+    error UnauthorizedSwapTarget(address target);
+    error UnauthorizedAllowanceTarget(address target);
+    error CallbackNotActive();
+    error CallbackAlreadyEntered();
+    error InvalidCallbackSender(address sender);
+    error InvalidAaveInitiator(address initiator);
+    error DeadlineExceeded(uint256 deadline);
+    error InvalidRefundRecipient();
+    error InvalidTopUpPayer();
+    error InvalidRouterToken(address router, address expected, address actual);
+    error InvalidLocalDomain(address router, uint32 expected, uint32 actual);
+    error InvalidTargetRouter(bytes32 expected, bytes32 actual);
+    error InvalidLoanAsset(address expected, address actual);
+    error InvalidLoanAmount(uint256 expected, uint256 actual);
+    error UnsupportedQuoteToken(address token, uint256 amount);
+    error CcrDebitExceedsMax(uint256 debit, uint256 maxDebit);
+    error InsufficientSurplusReceived(uint256 received, uint256 minimum);
+    error TopUpLimitExceeded(address token, uint256 required, uint256 max);
+    error InsufficientSwapOutput(uint256 received, uint256 minimum);
+    error InsufficientRepayment(uint256 balance, uint256 debt);
+
+    event RebalancerSet(address indexed rebalancer, bool allowed);
+    event FlashLoanProviderSet(
+        FlashLoanProvider indexed provider,
+        address indexed pool,
+        bool allowed
+    );
+    event SwapTargetSet(address indexed target, bool allowed);
+    event AllowanceTargetSet(address indexed target, bool allowed);
+    event FlashCcrRebalanceExecuted(
+        FlashLoanProvider indexed provider,
+        address indexed flashLoanProvider,
+        address indexed deficitRouter,
+        address surplusRouter,
+        address deficitToken,
+        address surplusToken,
+        uint256 ccrAmount,
+        uint256 flashDebt,
+        uint256 surplusReceived,
+        uint256 swapOutput
+    );
+
+    mapping(address rebalancer => bool allowed) public allowedRebalancers;
+    mapping(FlashLoanProvider provider => mapping(address pool => bool allowed))
+        public allowedFlashLoanProviders;
+    mapping(address target => bool allowed) public allowedSwapTargets;
+    mapping(address target => bool allowed) public allowedAllowanceTargets;
+
+    bytes32 private activeParamsHash;
+    FlashLoanProvider private activeProvider;
+    address private activeFlashLoanProvider;
+    bool private activeCallbackEntered;
+    bool private activeCallbackConsumed;
+    uint256 private activeSurplusTopUpPulled;
+
+    constructor(address _owner) Ownable() {
+        _transferOwnership(_owner);
+    }
+
+    receive() external payable {}
+
+    function setRebalancer(
+        address rebalancer,
+        bool allowed
+    ) external onlyOwner {
+        allowedRebalancers[rebalancer] = allowed;
+        emit RebalancerSet(rebalancer, allowed);
+    }
+
+    function setFlashLoanProvider(
+        FlashLoanProvider provider,
+        address pool,
+        bool allowed
+    ) external onlyOwner {
+        allowedFlashLoanProviders[provider][pool] = allowed;
+        emit FlashLoanProviderSet(provider, pool, allowed);
+    }
+
+    function setSwapTarget(address target, bool allowed) external onlyOwner {
+        allowedSwapTargets[target] = allowed;
+        emit SwapTargetSet(target, allowed);
+    }
+
+    function setAllowanceTarget(
+        address target,
+        bool allowed
+    ) external onlyOwner {
+        allowedAllowanceTargets[target] = allowed;
+        emit AllowanceTargetSet(target, allowed);
+    }
+
+    function rebalance(
+        RebalanceParams calldata params
+    ) external payable nonReentrant {
+        _validateEntry(params);
+        bytes memory callbackData = abi.encode(params);
+        _activate(params, callbackData);
+
+        if (params.loan.provider == FlashLoanProvider.AaveV3) {
+            IAaveV3FlashPool(params.loan.providerAddress).flashLoanSimple(
+                address(this),
+                params.loan.token,
+                params.loan.amount,
+                callbackData,
+                0
+            );
+        } else {
+            _startUniswapFlash(params, callbackData);
+        }
+
+        _clearAaveApproval(params);
+        _refundTopUp(
+            params.swap.tokenIn,
+            params.topUp.payer,
+            activeSurplusTopUpPulled
+        );
+        _clearActive();
+        _refund(params.loan.token, params.refundTo);
+        _refund(params.swap.tokenIn, params.refundTo);
+        _refund(address(0), params.refundTo);
+    }
+
+    function executeOperation(
+        address asset,
+        uint256 amount,
+        uint256 premium,
+        address initiator,
+        bytes calldata params
+    ) external returns (bool) {
+        if (initiator != address(this)) revert InvalidAaveInitiator(initiator);
+        RebalanceParams memory decoded = _validateCallback(
+            FlashLoanProvider.AaveV3,
+            asset,
+            amount,
+            params
+        );
+        uint256 debt = amount + premium;
+        _enterCallback();
+        _executeAfterBorrow(decoded, debt, false);
+        _exitCallback();
+        return true;
+    }
+
+    function uniswapV3FlashCallback(
+        uint256 fee0,
+        uint256 fee1,
+        bytes calldata params
+    ) external {
+        _validateRawCallback(FlashLoanProvider.UniswapV3, params);
+        RebalanceParams memory decoded = abi.decode(params, (RebalanceParams));
+        (address token0, address token1) = _uniswapPoolTokens(msg.sender);
+        (address borrowedToken, uint256 fee) = decoded.loan.token == token0
+            ? (token0, fee0)
+            : (token1, fee1);
+
+        _validateCallback(
+            FlashLoanProvider.UniswapV3,
+            borrowedToken,
+            decoded.loan.amount,
+            params
+        );
+        uint256 debt = decoded.loan.amount + fee;
+        _enterCallback();
+        _executeAfterBorrow(decoded, debt, true);
+        _exitCallback();
+    }
+
+    function _validateEntry(RebalanceParams calldata params) internal view {
+        if (!allowedRebalancers[msg.sender]) {
+            revert UnauthorizedRebalancer(msg.sender);
+        }
+        if (params.deadline < block.timestamp) {
+            revert DeadlineExceeded(params.deadline);
+        }
+        if (params.refundTo == address(0)) revert InvalidRefundRecipient();
+        if (
+            !allowedFlashLoanProviders[params.loan.provider][
+                params.loan.providerAddress
+            ]
+        ) {
+            revert UnauthorizedFlashLoanProvider(
+                params.loan.provider,
+                params.loan.providerAddress
+            );
+        }
+        if (!allowedSwapTargets[params.swap.target]) {
+            revert UnauthorizedSwapTarget(params.swap.target);
+        }
+        if (!allowedAllowanceTargets[params.swap.allowanceTarget]) {
+            revert UnauthorizedAllowanceTarget(params.swap.allowanceTarget);
+        }
+        if (
+            params.topUp.payer == address(0) &&
+            (params.topUp.maxSurplusTokenTopUp > 0 ||
+                params.topUp.maxDeficitTokenTopUp > 0)
+        ) {
+            revert InvalidTopUpPayer();
+        }
+    }
+
+    function _activate(
+        RebalanceParams calldata params,
+        bytes memory callbackData
+    ) internal {
+        activeParamsHash = keccak256(callbackData);
+        activeProvider = params.loan.provider;
+        activeFlashLoanProvider = params.loan.providerAddress;
+    }
+
+    function _clearActive() internal {
+        delete activeParamsHash;
+        delete activeProvider;
+        delete activeFlashLoanProvider;
+        delete activeCallbackEntered;
+        delete activeCallbackConsumed;
+        delete activeSurplusTopUpPulled;
+    }
+
+    function _startUniswapFlash(
+        RebalanceParams calldata params,
+        bytes memory callbackData
+    ) internal {
+        (address token0, address token1) = _uniswapPoolTokens(
+            params.loan.providerAddress
+        );
+        if (params.loan.token != token0 && params.loan.token != token1) {
+            revert InvalidLoanAsset(params.loan.token, address(0));
+        }
+        uint256 amount0 = params.loan.token == token0 ? params.loan.amount : 0;
+        uint256 amount1 = params.loan.token == token1 ? params.loan.amount : 0;
+        IUniswapV3FlashPool(params.loan.providerAddress).flash(
+            address(this),
+            amount0,
+            amount1,
+            callbackData
+        );
+    }
+
+    function _validateRawCallback(
+        FlashLoanProvider provider,
+        bytes calldata params
+    ) internal view {
+        if (activeParamsHash == bytes32(0)) revert CallbackNotActive();
+        if (provider != activeProvider) revert CallbackNotActive();
+        if (msg.sender != activeFlashLoanProvider) {
+            revert InvalidCallbackSender(msg.sender);
+        }
+        if (keccak256(params) != activeParamsHash) revert CallbackNotActive();
+    }
+
+    function _enterCallback() internal {
+        if (activeCallbackEntered || activeCallbackConsumed) {
+            revert CallbackAlreadyEntered();
+        }
+        activeCallbackEntered = true;
+        activeCallbackConsumed = true;
+    }
+
+    function _exitCallback() internal {
+        activeCallbackEntered = false;
+    }
+
+    function _validateCallback(
+        FlashLoanProvider provider,
+        address asset,
+        uint256 amount,
+        bytes calldata params
+    ) internal view returns (RebalanceParams memory decoded) {
+        _validateRawCallback(provider, params);
+
+        decoded = abi.decode(params, (RebalanceParams));
+        if (asset != decoded.loan.token) {
+            revert InvalidLoanAsset(decoded.loan.token, asset);
+        }
+        if (amount != decoded.loan.amount) {
+            revert InvalidLoanAmount(decoded.loan.amount, amount);
+        }
+    }
+
+    function _executeAfterBorrow(
+        RebalanceParams memory params,
+        uint256 debt,
+        bool repayByTransfer
+    ) internal {
+        address deficitToken = _validateCcr(params);
+        address surplusToken = IFlashCcrRouter(params.ccr.surplusRouter)
+            .token();
+
+        uint256 deficitTopUpUsed = _executeCcr(params, deficitToken);
+        (uint256 surplusReceived, uint256 swapOutput) = _executeSwap(
+            params,
+            surplusToken,
+            deficitToken
+        );
+        _repayOrApprove(
+            params,
+            debt,
+            deficitTopUpUsed,
+            repayByTransfer,
+            deficitToken
+        );
+
+        emit FlashCcrRebalanceExecuted(
+            params.loan.provider,
+            params.loan.providerAddress,
+            params.ccr.deficitRouter,
+            params.ccr.surplusRouter,
+            deficitToken,
+            surplusToken,
+            params.ccr.amount,
+            debt,
+            surplusReceived,
+            swapOutput
+        );
+    }
+
+    function _validateCcr(
+        RebalanceParams memory params
+    ) internal view returns (address deficitToken) {
+        IFlashCcrRouter deficitRouter = IFlashCcrRouter(
+            params.ccr.deficitRouter
+        );
+        IFlashCcrRouter surplusRouter = IFlashCcrRouter(
+            params.ccr.surplusRouter
+        );
+
+        deficitToken = deficitRouter.token();
+        if (deficitToken != params.loan.token) {
+            revert InvalidRouterToken(
+                params.ccr.deficitRouter,
+                params.loan.token,
+                deficitToken
+            );
+        }
+        address surplusToken = surplusRouter.token();
+        if (surplusToken != params.swap.tokenIn) {
+            revert InvalidRouterToken(
+                params.ccr.surplusRouter,
+                params.swap.tokenIn,
+                surplusToken
+            );
+        }
+        if (params.swap.tokenOut != deficitToken) {
+            revert InvalidLoanAsset(deficitToken, params.swap.tokenOut);
+        }
+
+        uint32 deficitDomain = deficitRouter.localDomain();
+        if (deficitDomain != params.ccr.localDomain) {
+            revert InvalidLocalDomain(
+                params.ccr.deficitRouter,
+                params.ccr.localDomain,
+                deficitDomain
+            );
+        }
+        uint32 surplusDomain = surplusRouter.localDomain();
+        if (surplusDomain != params.ccr.localDomain) {
+            revert InvalidLocalDomain(
+                params.ccr.surplusRouter,
+                params.ccr.localDomain,
+                surplusDomain
+            );
+        }
+
+        bytes32 expectedTarget = params.ccr.surplusRouter.addressToBytes32();
+        if (expectedTarget != params.ccr.targetRouter) {
+            revert InvalidTargetRouter(expectedTarget, params.ccr.targetRouter);
+        }
+    }
+
+    function _executeCcr(
+        RebalanceParams memory params,
+        address deficitToken
+    ) internal returns (uint256 deficitTopUpUsed) {
+        uint256 debit = _quoteDeficitTokenDebit(params, deficitToken);
+        if (debit > params.ccr.maxDeficitTokenDebit) {
+            revert CcrDebitExceedsMax(debit, params.ccr.maxDeficitTokenDebit);
+        }
+
+        deficitTopUpUsed = _pullDeficitTopUpIfNeeded(
+            params,
+            debit,
+            0,
+            deficitToken
+        );
+
+        IERC20(deficitToken).forceApprove(params.ccr.deficitRouter, debit);
+        uint256 surplusBefore = IERC20(params.swap.tokenIn).balanceOf(
+            address(this)
+        );
+        IFlashCcrRouter(params.ccr.deficitRouter).transferRemoteTo(
+            params.ccr.localDomain,
+            address(this).addressToBytes32(),
+            params.ccr.amount,
+            params.ccr.targetRouter
+        );
+        IERC20(deficitToken).forceApprove(params.ccr.deficitRouter, 0);
+
+        uint256 surplusReceived = IERC20(params.swap.tokenIn).balanceOf(
+            address(this)
+        ) - surplusBefore;
+        if (surplusReceived < params.ccr.minSurplusReceived) {
+            revert InsufficientSurplusReceived(
+                surplusReceived,
+                params.ccr.minSurplusReceived
+            );
+        }
+    }
+
+    function _quoteDeficitTokenDebit(
+        RebalanceParams memory params,
+        address deficitToken
+    ) internal view returns (uint256 debit) {
+        Quote[] memory quotes = IFlashCcrRouter(params.ccr.deficitRouter)
+            .quoteTransferRemoteTo(
+                params.ccr.localDomain,
+                address(this).addressToBytes32(),
+                params.ccr.amount,
+                params.ccr.targetRouter
+            );
+
+        for (uint256 i = 0; i < quotes.length; i++) {
+            if (quotes[i].amount == 0) continue;
+            if (quotes[i].token != deficitToken) {
+                revert UnsupportedQuoteToken(quotes[i].token, quotes[i].amount);
+            }
+            debit += quotes[i].amount;
+        }
+    }
+
+    function _executeSwap(
+        RebalanceParams memory params,
+        address surplusToken,
+        address deficitToken
+    ) internal returns (uint256 surplusReceived, uint256 swapOutput) {
+        surplusReceived = IERC20(surplusToken).balanceOf(address(this));
+        if (surplusReceived < params.swap.amountInMax) {
+            uint256 topUpAmount = params.swap.amountInMax - surplusReceived;
+            _pullTopUp(
+                surplusToken,
+                params.topUp.payer,
+                topUpAmount,
+                params.topUp.maxSurplusTokenTopUp
+            );
+            activeSurplusTopUpPulled += topUpAmount;
+        }
+
+        IERC20(surplusToken).forceApprove(
+            params.swap.allowanceTarget,
+            params.swap.amountInMax
+        );
+        uint256 deficitBefore = IERC20(deficitToken).balanceOf(address(this));
+        params.swap.target.functionCallWithValue(
+            params.swap.data,
+            params.swap.value
+        );
+        IERC20(surplusToken).forceApprove(params.swap.allowanceTarget, 0);
+
+        swapOutput =
+            IERC20(deficitToken).balanceOf(address(this)) -
+            deficitBefore;
+        if (swapOutput < params.swap.minAmountOut) {
+            revert InsufficientSwapOutput(swapOutput, params.swap.minAmountOut);
+        }
+    }
+
+    function _repayOrApprove(
+        RebalanceParams memory params,
+        uint256 debt,
+        uint256 deficitTopUpUsed,
+        bool repayByTransfer,
+        address deficitToken
+    ) internal {
+        uint256 balance = IERC20(deficitToken).balanceOf(address(this));
+        if (balance < debt) {
+            _pullDeficitTopUpIfNeeded(
+                params,
+                debt,
+                deficitTopUpUsed,
+                deficitToken
+            );
+            balance = IERC20(deficitToken).balanceOf(address(this));
+        }
+        if (balance < debt) revert InsufficientRepayment(balance, debt);
+
+        if (repayByTransfer) {
+            IERC20(deficitToken).safeTransfer(
+                params.loan.providerAddress,
+                debt
+            );
+        } else {
+            IERC20(deficitToken).forceApprove(
+                params.loan.providerAddress,
+                debt
+            );
+        }
+    }
+
+    function _pullDeficitTopUpIfNeeded(
+        RebalanceParams memory params,
+        uint256 requiredBalance,
+        uint256 alreadyUsed,
+        address deficitToken
+    ) internal returns (uint256 totalUsed) {
+        uint256 balance = IERC20(deficitToken).balanceOf(address(this));
+        totalUsed = alreadyUsed;
+        if (balance >= requiredBalance) return totalUsed;
+
+        uint256 needed = requiredBalance - balance;
+        uint256 remaining = params.topUp.maxDeficitTokenTopUp - alreadyUsed;
+        _pullTopUp(deficitToken, params.topUp.payer, needed, remaining);
+        totalUsed += needed;
+    }
+
+    function _pullTopUp(
+        address token,
+        address payer,
+        uint256 amount,
+        uint256 maxAmount
+    ) internal {
+        if (amount == 0) return;
+        if (amount > maxAmount)
+            revert TopUpLimitExceeded(token, amount, maxAmount);
+        if (payer == address(0)) revert InvalidTopUpPayer();
+        IERC20(token).safeTransferFrom(payer, address(this), amount);
+    }
+
+    function _clearAaveApproval(RebalanceParams calldata params) internal {
+        if (params.loan.provider == FlashLoanProvider.AaveV3) {
+            IERC20(params.loan.token).forceApprove(
+                params.loan.providerAddress,
+                0
+            );
+        }
+    }
+
+    function _refundTopUp(
+        address token,
+        address payer,
+        uint256 maxAmount
+    ) internal {
+        if (maxAmount == 0) return;
+        if (payer == address(0)) revert InvalidTopUpPayer();
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        uint256 refundAmount = balance < maxAmount ? balance : maxAmount;
+        if (refundAmount > 0) IERC20(token).safeTransfer(payer, refundAmount);
+    }
+
+    function _refund(address token, address recipient) internal {
+        if (token == address(0)) {
+            uint256 nativeBalance = address(this).balance;
+            if (nativeBalance > 0)
+                Address.sendValue(payable(recipient), nativeBalance);
+            return;
+        }
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance > 0) IERC20(token).safeTransfer(recipient, balance);
+    }
+
+    function _uniswapPoolTokens(
+        address pool
+    ) internal view returns (address token0, address token1) {
+        token0 = IUniswapV3FlashPool(pool).token0();
+        token1 = IUniswapV3FlashPool(pool).token1();
+    }
+}

--- a/solidity/test/rebalancing/FlashCcrRebalancer.t.sol
+++ b/solidity/test/rebalancing/FlashCcrRebalancer.t.sol
@@ -1,0 +1,1179 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
+import {ERC20Test} from "../../contracts/test/ERC20Test.sol";
+import {ITokenFee, Quote} from "../../contracts/interfaces/ITokenBridge.sol";
+import {ICrossCollateralFee} from "../../contracts/token/interfaces/ICrossCollateralFee.sol";
+import {CrossCollateralRouter} from "../../contracts/token/CrossCollateralRouter.sol";
+import {FlashCcrRebalancer} from "../../contracts/rebalancing/FlashCcrRebalancer.sol";
+
+interface IAaveFlashReceiver {
+    function executeOperation(
+        address asset,
+        uint256 amount,
+        uint256 premium,
+        address initiator,
+        bytes calldata params
+    ) external returns (bool);
+}
+
+interface IUniswapFlashReceiver {
+    function uniswapV3FlashCallback(
+        uint256 fee0,
+        uint256 fee1,
+        bytes calldata params
+    ) external;
+}
+
+contract MockDepositFee is ITokenFee, ICrossCollateralFee {
+    address public immutable token;
+    uint256 public immutable feeBps;
+
+    constructor(address _token, uint256 _feeBps) {
+        token = _token;
+        feeBps = _feeBps;
+    }
+
+    function quoteTransferRemote(
+        uint32,
+        bytes32,
+        uint256 amount
+    ) external view returns (Quote[] memory quotes) {
+        quotes = new Quote[](1);
+        quotes[0] = Quote(token, (amount * feeBps) / 10_000);
+    }
+
+    function quoteTransferRemoteTo(
+        uint32,
+        bytes32,
+        uint256 amount,
+        bytes32
+    ) external view returns (Quote[] memory quotes) {
+        quotes = new Quote[](1);
+        quotes[0] = Quote(token, (amount * feeBps) / 10_000);
+    }
+}
+
+contract MockQuoteRouter {
+    address public immutable token;
+    uint32 public immutable localDomain;
+    address public immutable quoteToken;
+    uint256 public immutable quoteAmount;
+
+    constructor(
+        address _token,
+        uint32 _localDomain,
+        address _quoteToken,
+        uint256 _quoteAmount
+    ) {
+        token = _token;
+        localDomain = _localDomain;
+        quoteToken = _quoteToken;
+        quoteAmount = _quoteAmount;
+    }
+
+    function quoteTransferRemoteTo(
+        uint32,
+        bytes32,
+        uint256,
+        bytes32
+    ) external view returns (Quote[] memory quotes) {
+        quotes = new Quote[](1);
+        quotes[0] = Quote(quoteToken, quoteAmount);
+    }
+
+    function transferRemoteTo(
+        uint32,
+        bytes32,
+        uint256,
+        bytes32
+    ) external pure returns (bytes32) {
+        revert("UNEXPECTED_TRANSFER");
+    }
+}
+
+contract MockAaveV3Pool {
+    using SafeERC20 for IERC20;
+
+    uint256 public premiumBps;
+
+    constructor(uint256 _premiumBps) {
+        premiumBps = _premiumBps;
+    }
+
+    function flashLoanSimple(
+        address receiver,
+        address asset,
+        uint256 amount,
+        bytes calldata params,
+        uint16
+    ) external {
+        uint256 balanceBefore = IERC20(asset).balanceOf(address(this));
+        uint256 premium = (amount * premiumBps) / 10_000;
+        IERC20(asset).safeTransfer(receiver, amount);
+        require(
+            IAaveFlashReceiver(receiver).executeOperation(
+                asset,
+                amount,
+                premium,
+                receiver,
+                params
+            ),
+            "AAVE_CALLBACK_FALSE"
+        );
+        IERC20(asset).safeTransferFrom(
+            receiver,
+            address(this),
+            amount + premium
+        );
+        require(
+            IERC20(asset).balanceOf(address(this)) >= balanceBefore + premium,
+            "AAVE_NOT_REPAID"
+        );
+    }
+}
+
+contract MockUniswapV3FlashPool {
+    using SafeERC20 for IERC20;
+
+    address public immutable token0;
+    address public immutable token1;
+    uint256 public immutable feeBps;
+
+    constructor(address _token0, address _token1, uint256 _feeBps) {
+        token0 = _token0;
+        token1 = _token1;
+        feeBps = _feeBps;
+    }
+
+    function flash(
+        address recipient,
+        uint256 amount0,
+        uint256 amount1,
+        bytes calldata data
+    ) external {
+        uint256 token0Before = IERC20(token0).balanceOf(address(this));
+        uint256 token1Before = IERC20(token1).balanceOf(address(this));
+        uint256 fee0 = (amount0 * feeBps) / 10_000;
+        uint256 fee1 = (amount1 * feeBps) / 10_000;
+
+        if (amount0 > 0) IERC20(token0).safeTransfer(recipient, amount0);
+        if (amount1 > 0) IERC20(token1).safeTransfer(recipient, amount1);
+
+        IUniswapFlashReceiver(recipient).uniswapV3FlashCallback(
+            fee0,
+            fee1,
+            data
+        );
+
+        require(
+            IERC20(token0).balanceOf(address(this)) >= token0Before + fee0,
+            "UNI_TOKEN0_NOT_REPAID"
+        );
+        require(
+            IERC20(token1).balanceOf(address(this)) >= token1Before + fee1,
+            "UNI_TOKEN1_NOT_REPAID"
+        );
+    }
+}
+
+contract MockAllowanceTarget {
+    using SafeERC20 for IERC20;
+
+    function pull(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) external {
+        IERC20(token).safeTransferFrom(from, to, amount);
+    }
+}
+
+contract MockSwapTarget {
+    using SafeERC20 for IERC20;
+
+    bool public stealBeyondAllowance;
+    address public reenterTarget;
+    bytes public reenterData;
+
+    function setStealBeyondAllowance(bool value) external {
+        stealBeyondAllowance = value;
+    }
+
+    function setReenter(address target, bytes calldata data) external {
+        reenterTarget = target;
+        reenterData = data;
+    }
+
+    function swapExactOutput(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountInUsed,
+        uint256 amountOut
+    ) external payable {
+        if (reenterTarget != address(0)) {
+            (bool success, bytes memory returndata) = reenterTarget.call(
+                reenterData
+            );
+            if (!success) {
+                assembly {
+                    revert(add(returndata, 32), mload(returndata))
+                }
+            }
+        }
+
+        uint256 pullAmount = stealBeyondAllowance
+            ? amountInUsed + 1
+            : amountInUsed;
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), pullAmount);
+        IERC20(tokenOut).safeTransfer(msg.sender, amountOut);
+    }
+}
+
+contract MockRoutedSwapTarget {
+    using SafeERC20 for IERC20;
+
+    function swapViaAllowanceTarget(
+        address allowanceTarget,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountInUsed,
+        uint256 amountOut
+    ) external payable {
+        MockAllowanceTarget(allowanceTarget).pull(
+            tokenIn,
+            msg.sender,
+            address(this),
+            amountInUsed
+        );
+        IERC20(tokenOut).safeTransfer(msg.sender, amountOut);
+    }
+}
+
+contract FlashCcrRebalancerTest is Test {
+    using TypeCasts for address;
+
+    struct BuildParams {
+        FlashCcrRebalancer.FlashLoanProvider provider;
+        address providerAddress;
+        address loanToken;
+        uint256 loanAmount;
+        address deficitRouter;
+        address surplusRouter;
+        address surplusToken;
+        address deficitToken;
+        uint256 maxDebit;
+        uint256 ccrAmount;
+        uint256 amountInUsed;
+        uint256 swapOutput;
+        uint256 amountInMax;
+        uint256 surplusTopUp;
+        uint256 deficitTopUp;
+    }
+
+    uint32 internal constant LOCAL_DOMAIN = 1;
+    uint256 internal constant USDC_SCALE_NUM = 1e12;
+    uint256 internal constant USDC_SCALE_DEN = 1;
+    uint256 internal constant USDT_SCALE_NUM = 1;
+    uint256 internal constant USDT_SCALE_DEN = 1;
+
+    address internal constant OWNER = address(0xA11CE);
+    address internal constant REBALANCER = address(0xB0B);
+    address internal constant TOP_UP = address(0xCAFE);
+    address internal constant REFUND_TO = address(0xFEE);
+    address internal constant UNAUTHORIZED = address(0xBAD);
+
+    MockMailbox internal mailbox;
+    ERC20Test internal usdc;
+    ERC20Test internal usdt;
+    CrossCollateralRouter internal usdcRouter;
+    CrossCollateralRouter internal usdtRouter;
+    MockAaveV3Pool internal aavePool;
+    MockUniswapV3FlashPool internal uniPool;
+    MockSwapTarget internal swapTarget;
+    FlashCcrRebalancer internal helper;
+
+    function setUp() public {
+        mailbox = new MockMailbox(LOCAL_DOMAIN);
+        usdc = new ERC20Test("USD Coin", "USDC", 0, 6);
+        usdt = new ERC20Test("Tether USD", "USDT", 0, 18);
+
+        usdcRouter = _deployRouter(
+            address(usdc),
+            USDC_SCALE_NUM,
+            USDC_SCALE_DEN
+        );
+        usdtRouter = _deployRouter(
+            address(usdt),
+            USDT_SCALE_NUM,
+            USDT_SCALE_DEN
+        );
+        _enrollSameChain(usdcRouter, usdtRouter);
+        _enrollSameChain(usdtRouter, usdcRouter);
+
+        usdc.mintTo(address(usdcRouter), 1_000_000e6);
+        usdt.mintTo(address(usdtRouter), 1_000_000e18);
+
+        aavePool = new MockAaveV3Pool(5);
+        uniPool = new MockUniswapV3FlashPool(address(usdc), address(usdt), 1);
+        swapTarget = new MockSwapTarget();
+        helper = new FlashCcrRebalancer(OWNER);
+
+        usdc.mintTo(address(aavePool), 10_000_000e6);
+        usdc.mintTo(address(uniPool), 10_000_000e6);
+        usdt.mintTo(address(uniPool), 10_000_000e18);
+        usdc.mintTo(address(swapTarget), 10_000_000e6);
+        usdt.mintTo(address(swapTarget), 10_000_000e18);
+        usdc.mintTo(TOP_UP, 100_000e6);
+        usdt.mintTo(TOP_UP, 100_000e18);
+
+        vm.startPrank(OWNER);
+        helper.setRebalancer(REBALANCER, true);
+        helper.setFlashLoanProvider(
+            FlashCcrRebalancer.FlashLoanProvider.AaveV3,
+            address(aavePool),
+            true
+        );
+        helper.setFlashLoanProvider(
+            FlashCcrRebalancer.FlashLoanProvider.UniswapV3,
+            address(uniPool),
+            true
+        );
+        helper.setSwapTarget(address(swapTarget), true);
+        helper.setAllowanceTarget(address(swapTarget), true);
+        vm.stopPrank();
+
+        vm.startPrank(TOP_UP);
+        usdc.approve(address(helper), type(uint256).max);
+        usdt.approve(address(helper), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    function test_aaveHappyPath_usdcDeficit_usdtSurplus() public {
+        uint256 amount = 1000e6;
+        uint256 debt = amount + 500000; // 5 bps Aave premium.
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            debt,
+            1000e18,
+            0,
+            0
+        );
+
+        uint256 usdcRouterBefore = usdc.balanceOf(address(usdcRouter));
+        uint256 usdtRouterBefore = usdt.balanceOf(address(usdtRouter));
+        uint256 poolBefore = usdc.balanceOf(address(aavePool));
+
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(
+            usdc.balanceOf(address(usdcRouter)),
+            usdcRouterBefore + amount
+        );
+        assertEq(
+            usdt.balanceOf(address(usdtRouter)),
+            usdtRouterBefore - 1000e18
+        );
+        assertEq(usdc.balanceOf(address(aavePool)), poolBefore + 500000);
+        assertEq(usdc.balanceOf(address(helper)), 0);
+        assertEq(usdt.balanceOf(address(helper)), 0);
+        assertEq(usdt.balanceOf(REFUND_TO), 0);
+        assertEq(usdt.allowance(address(helper), address(swapTarget)), 0);
+        assertEq(usdc.allowance(address(helper), address(usdcRouter)), 0);
+    }
+
+    function test_uniswapHappyPath_usdcDeficit_usdtSurplus() public {
+        uint256 amount = 1000e6;
+        uint256 debt = amount + 100000; // 1 bp Uniswap flash fee.
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsUniswap(
+            amount,
+            amount,
+            1000e18,
+            debt,
+            1000e18,
+            0,
+            0
+        );
+        uint256 poolBefore = usdc.balanceOf(address(uniPool));
+
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(address(uniPool)), poolBefore + 100000);
+        assertEq(usdc.balanceOf(address(helper)), 0);
+        assertEq(usdt.balanceOf(address(helper)), 0);
+    }
+
+    function test_aaveHappyPath_withSeparateSwapAllowanceTarget() public {
+        MockAllowanceTarget allowanceTarget = new MockAllowanceTarget();
+        MockRoutedSwapTarget routedSwapTarget = new MockRoutedSwapTarget();
+        usdc.mintTo(address(routedSwapTarget), 10_000_000e6);
+
+        vm.startPrank(OWNER);
+        helper.setSwapTarget(address(routedSwapTarget), true);
+        helper.setAllowanceTarget(address(allowanceTarget), true);
+        vm.stopPrank();
+
+        uint256 amount = 1000e6;
+        uint256 debt = amount + 500000;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            debt,
+            1000e18,
+            0,
+            0
+        );
+        params.swap.target = address(routedSwapTarget);
+        params.swap.allowanceTarget = address(allowanceTarget);
+        params.swap.data = abi.encodeCall(
+            MockRoutedSwapTarget.swapViaAllowanceTarget,
+            (
+                address(allowanceTarget),
+                address(usdt),
+                address(usdc),
+                1000e18,
+                debt
+            )
+        );
+
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(address(helper)), 0);
+        assertEq(usdt.balanceOf(address(helper)), 0);
+        assertEq(usdt.allowance(address(helper), address(allowanceTarget)), 0);
+        assertEq(usdt.allowance(address(helper), address(routedSwapTarget)), 0);
+    }
+
+    function test_aaveHappyPath_usdtDeficit_usdcSurplus() public {
+        uint256 amount = 1000e18;
+        uint256 debt = amount + 0.5e18;
+        FlashCcrRebalancer.RebalanceParams
+            memory params = _baseReverseParamsAave(
+                amount,
+                amount,
+                1000e6,
+                debt,
+                1000e6,
+                0,
+                0
+            );
+        usdt.mintTo(address(aavePool), 10_000_000e18);
+        usdt.mintTo(address(swapTarget), 10_000_000e18);
+
+        uint256 usdtRouterBefore = usdt.balanceOf(address(usdtRouter));
+        uint256 usdcRouterBefore = usdc.balanceOf(address(usdcRouter));
+
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(
+            usdt.balanceOf(address(usdtRouter)),
+            usdtRouterBefore + amount
+        );
+        assertEq(
+            usdc.balanceOf(address(usdcRouter)),
+            usdcRouterBefore - 1000e6
+        );
+        assertEq(usdt.balanceOf(address(helper)), 0);
+        assertEq(usdc.balanceOf(address(helper)), 0);
+    }
+
+    function test_surplusTokenTopUpUsedAndUnusedRefundedToPayer() public {
+        uint256 amount = 1000e6;
+        uint256 debt = amount + 500000;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1001e18,
+            debt,
+            1002e18,
+            2e18,
+            0
+        );
+        params.ccr.minSurplusReceived = 1000e18;
+
+        uint256 topUpBefore = usdt.balanceOf(TOP_UP);
+        uint256 refundBefore = usdt.balanceOf(REFUND_TO);
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(usdt.balanceOf(TOP_UP), topUpBefore - 1e18);
+        assertEq(usdt.balanceOf(REFUND_TO), refundBefore);
+        assertEq(usdt.balanceOf(address(helper)), 0);
+    }
+
+    function test_surplusRouteResidueRefundedToRefundRecipient() public {
+        uint256 amount = 1000e6;
+        uint256 debt = amount + 500000;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            999e18,
+            debt,
+            1000e18,
+            0,
+            0
+        );
+        params.ccr.minSurplusReceived = 1000e18;
+
+        uint256 refundBefore = usdt.balanceOf(REFUND_TO);
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(usdt.balanceOf(REFUND_TO), refundBefore + 1e18);
+        assertEq(usdt.balanceOf(address(helper)), 0);
+    }
+
+    function test_deficitTokenTopUpCoversRepaymentShortfall() public {
+        uint256 amount = 1000e6;
+        uint256 debt = amount + 500000;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount,
+            1000e18,
+            0,
+            500000
+        );
+
+        uint256 topUpBefore = usdc.balanceOf(TOP_UP);
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(TOP_UP), topUpBefore - 500000);
+        assertEq(usdc.balanceOf(address(helper)), 0);
+    }
+
+    function test_deficitTokenTopUpCoversCcrFeeAndRepaymentShortfall() public {
+        MockDepositFee fee = new MockDepositFee(address(usdc), 5);
+        usdcRouter.setFeeRecipient(address(fee));
+
+        uint256 amount = 1000e6;
+        uint256 ccrFee = 500000;
+        uint256 debt = amount + 500000;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount + ccrFee,
+            1000e18,
+            amount,
+            1000e18,
+            0,
+            ccrFee + 500000
+        );
+
+        uint256 topUpBefore = usdc.balanceOf(TOP_UP);
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(TOP_UP), topUpBefore - ccrFee - 500000);
+        assertEq(usdc.balanceOf(address(fee)), ccrFee);
+        assertEq(usdc.balanceOf(address(aavePool)), 10_000_000e6 + 500000);
+        assertEq(usdc.balanceOf(address(helper)), 0);
+    }
+
+    function test_revert_ifSwapOutputBelowMinimum_rollsBackCcr() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount,
+            1000e18,
+            0,
+            500000
+        );
+        params.swap.minAmountOut = amount + 1;
+
+        uint256 usdcRouterBefore = usdc.balanceOf(address(usdcRouter));
+        uint256 usdtRouterBefore = usdt.balanceOf(address(usdtRouter));
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.InsufficientSwapOutput.selector,
+                amount,
+                amount + 1
+            )
+        );
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(address(usdcRouter)), usdcRouterBefore);
+        assertEq(usdt.balanceOf(address(usdtRouter)), usdtRouterBefore);
+    }
+
+    function test_revert_ifRepaymentShortfall_rollsBackCcr() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount,
+            1000e18,
+            0,
+            0
+        );
+
+        uint256 usdcRouterBefore = usdc.balanceOf(address(usdcRouter));
+        uint256 usdtRouterBefore = usdt.balanceOf(address(usdtRouter));
+
+        vm.prank(REBALANCER);
+        vm.expectRevert();
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(address(usdcRouter)), usdcRouterBefore);
+        assertEq(usdt.balanceOf(address(usdtRouter)), usdtRouterBefore);
+    }
+
+    function test_revert_unauthorizedCaller() public {
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1000e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            0
+        );
+        vm.prank(UNAUTHORIZED);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.UnauthorizedRebalancer.selector,
+                UNAUTHORIZED
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_unallowlistedFlashProvider() public {
+        MockAaveV3Pool otherPool = new MockAaveV3Pool(5);
+        usdc.mintTo(address(otherPool), 10_000_000e6);
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1000e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            0
+        );
+        params.loan.providerAddress = address(otherPool);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.UnauthorizedFlashLoanProvider.selector,
+                FlashCcrRebalancer.FlashLoanProvider.AaveV3,
+                address(otherPool)
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_unallowlistedSwapTarget() public {
+        MockSwapTarget otherSwap = new MockSwapTarget();
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1000e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            0
+        );
+        params.swap.target = address(otherSwap);
+        params.swap.allowanceTarget = address(otherSwap);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.UnauthorizedSwapTarget.selector,
+                address(otherSwap)
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_unallowlistedAllowanceTarget() public {
+        MockSwapTarget otherSwap = new MockSwapTarget();
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1000e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            0
+        );
+        params.swap.allowanceTarget = address(otherSwap);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.UnauthorizedAllowanceTarget.selector,
+                address(otherSwap)
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_deadlineExceeded() public {
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1000e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            0
+        );
+        params.deadline = block.timestamp - 1;
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.DeadlineExceeded.selector,
+                params.deadline
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_ccrDebitExceedsMax() public {
+        MockDepositFee fee = new MockDepositFee(address(usdc), 5);
+        usdcRouter.setFeeRecipient(address(fee));
+
+        uint256 amount = 1000e6;
+        uint256 ccrFee = 500000;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount + ccrFee - 1,
+            1000e18,
+            amount,
+            1000e18,
+            0,
+            ccrFee
+        );
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.CcrDebitExceedsMax.selector,
+                amount + ccrFee,
+                amount + ccrFee - 1
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_unsupportedFeeQuoteToken() public {
+        MockQuoteRouter quoteRouter = new MockQuoteRouter(
+            address(usdc),
+            LOCAL_DOMAIN,
+            address(usdt),
+            500000
+        );
+
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1001e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            1e6
+        );
+        params.ccr.deficitRouter = address(quoteRouter);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.UnsupportedQuoteToken.selector,
+                address(usdt),
+                500000
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_surplusTopUpLimitExceeded() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1001e18,
+            amount + 500000,
+            1001e18,
+            1e18 - 1,
+            0
+        );
+        params.ccr.minSurplusReceived = 1000e18;
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.TopUpLimitExceeded.selector,
+                address(usdt),
+                1e18,
+                1e18 - 1
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_deficitTopUpLimitExceeded() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount,
+            1000e18,
+            0,
+            500000 - 1
+        );
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FlashCcrRebalancer.TopUpLimitExceeded.selector,
+                address(usdc),
+                500000,
+                500000 - 1
+            )
+        );
+        helper.rebalance(params);
+    }
+
+    function test_revert_maliciousSwapCannotStealBeyondAllowance() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount + 500000,
+            1000e18,
+            0,
+            0
+        );
+        swapTarget.setStealBeyondAllowance(true);
+
+        uint256 usdcRouterBefore = usdc.balanceOf(address(usdcRouter));
+        uint256 usdtRouterBefore = usdt.balanceOf(address(usdtRouter));
+
+        vm.prank(REBALANCER);
+        vm.expectRevert();
+        helper.rebalance(params);
+
+        assertEq(usdc.balanceOf(address(usdcRouter)), usdcRouterBefore);
+        assertEq(usdt.balanceOf(address(usdtRouter)), usdtRouterBefore);
+    }
+
+    function test_revert_callbackSpoofing() public {
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            1000e6,
+            1000e6,
+            1000e18,
+            1000e6,
+            1000e18,
+            0,
+            0
+        );
+
+        vm.expectRevert(FlashCcrRebalancer.CallbackNotActive.selector);
+        helper.executeOperation(
+            address(usdc),
+            1000e6,
+            0,
+            address(helper),
+            abi.encode(params)
+        );
+
+        vm.expectRevert(FlashCcrRebalancer.CallbackNotActive.selector);
+        helper.uniswapV3FlashCallback(0, 0, abi.encode(params));
+    }
+
+    function test_revert_reentrancyFromSwapTarget() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount + 500000,
+            1000e18,
+            0,
+            0
+        );
+        bytes memory reenterData = abi.encodeCall(
+            FlashCcrRebalancer.rebalance,
+            (params)
+        );
+        swapTarget.setReenter(address(helper), reenterData);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert();
+        helper.rebalance(params);
+    }
+
+    function test_revert_nestedAaveCallbackFromSwapTarget() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            1000e18,
+            amount + 500000,
+            1000e18,
+            0,
+            0
+        );
+        bytes memory callbackData = abi.encode(params);
+        bytes memory reenterData = abi.encodeCall(
+            MockAaveV3Pool.flashLoanSimple,
+            (address(helper), address(usdc), amount, callbackData, 0)
+        );
+        swapTarget.setReenter(address(aavePool), reenterData);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(FlashCcrRebalancer.CallbackAlreadyEntered.selector);
+        helper.rebalance(params);
+    }
+
+    function test_revert_nestedUniswapCallbackFromSwapTarget() public {
+        uint256 amount = 1000e6;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsUniswap(
+            amount,
+            amount,
+            1000e18,
+            amount + 100000,
+            1000e18,
+            0,
+            0
+        );
+        bytes memory callbackData = abi.encode(params);
+        bytes memory reenterData = abi.encodeCall(
+            MockUniswapV3FlashPool.flash,
+            (address(helper), amount, 0, callbackData)
+        );
+        swapTarget.setReenter(address(uniPool), reenterData);
+
+        vm.prank(REBALANCER);
+        vm.expectRevert(FlashCcrRebalancer.CallbackAlreadyEntered.selector);
+        helper.rebalance(params);
+    }
+
+    function testFuzz_aaveAmounts(uint96 rawAmount, uint16 premiumBps) public {
+        uint256 amount = bound(uint256(rawAmount), 1e6, 50_000e6);
+        premiumBps = uint16(bound(uint256(premiumBps), 0, 50));
+        MockAaveV3Pool fuzzPool = new MockAaveV3Pool(premiumBps);
+        usdc.mintTo(address(fuzzPool), 100_000_000e6);
+        vm.prank(OWNER);
+        helper.setFlashLoanProvider(
+            FlashCcrRebalancer.FlashLoanProvider.AaveV3,
+            address(fuzzPool),
+            true
+        );
+
+        uint256 premium = (amount * premiumBps) / 10_000;
+        uint256 surplus = amount * 1e12;
+        FlashCcrRebalancer.RebalanceParams memory params = _baseParamsAave(
+            amount,
+            amount,
+            surplus,
+            amount + premium,
+            surplus,
+            0,
+            premium
+        );
+        params.loan.providerAddress = address(fuzzPool);
+
+        uint256 usdcRouterBefore = usdc.balanceOf(address(usdcRouter));
+        uint256 usdtRouterBefore = usdt.balanceOf(address(usdtRouter));
+        vm.prank(REBALANCER);
+        helper.rebalance(params);
+
+        assertEq(
+            usdc.balanceOf(address(usdcRouter)),
+            usdcRouterBefore + amount
+        );
+        assertEq(
+            usdt.balanceOf(address(usdtRouter)),
+            usdtRouterBefore - surplus
+        );
+        assertEq(usdc.balanceOf(address(helper)), 0);
+        assertEq(usdt.balanceOf(address(helper)), 0);
+    }
+
+    function _deployRouter(
+        address token,
+        uint256 scaleNum,
+        uint256 scaleDen
+    ) internal returns (CrossCollateralRouter router) {
+        router = new CrossCollateralRouter(
+            token,
+            scaleNum,
+            scaleDen,
+            address(mailbox)
+        );
+        router.initialize(address(0), address(0), address(this));
+    }
+
+    function _enrollSameChain(
+        CrossCollateralRouter source,
+        CrossCollateralRouter target
+    ) internal {
+        uint32[] memory domains = new uint32[](1);
+        bytes32[] memory routers = new bytes32[](1);
+        domains[0] = LOCAL_DOMAIN;
+        routers[0] = address(target).addressToBytes32();
+        source.enrollCrossCollateralRouters(domains, routers);
+    }
+
+    function _baseParamsAave(
+        uint256 loanAmount,
+        uint256 maxDebit,
+        uint256 amountInUsed,
+        uint256 swapOutput,
+        uint256 amountInMax,
+        uint256 surplusTopUp,
+        uint256 deficitTopUp
+    ) internal view returns (FlashCcrRebalancer.RebalanceParams memory params) {
+        params = _baseParams(
+            BuildParams({
+                provider: FlashCcrRebalancer.FlashLoanProvider.AaveV3,
+                providerAddress: address(aavePool),
+                loanToken: address(usdc),
+                loanAmount: loanAmount,
+                deficitRouter: address(usdcRouter),
+                surplusRouter: address(usdtRouter),
+                surplusToken: address(usdt),
+                deficitToken: address(usdc),
+                maxDebit: maxDebit,
+                ccrAmount: loanAmount,
+                amountInUsed: amountInUsed,
+                swapOutput: swapOutput,
+                amountInMax: amountInMax,
+                surplusTopUp: surplusTopUp,
+                deficitTopUp: deficitTopUp
+            })
+        );
+    }
+
+    function _baseParamsUniswap(
+        uint256 loanAmount,
+        uint256 maxDebit,
+        uint256 amountInUsed,
+        uint256 swapOutput,
+        uint256 amountInMax,
+        uint256 surplusTopUp,
+        uint256 deficitTopUp
+    ) internal view returns (FlashCcrRebalancer.RebalanceParams memory params) {
+        params = _baseParams(
+            BuildParams({
+                provider: FlashCcrRebalancer.FlashLoanProvider.UniswapV3,
+                providerAddress: address(uniPool),
+                loanToken: address(usdc),
+                loanAmount: loanAmount,
+                deficitRouter: address(usdcRouter),
+                surplusRouter: address(usdtRouter),
+                surplusToken: address(usdt),
+                deficitToken: address(usdc),
+                maxDebit: maxDebit,
+                ccrAmount: loanAmount,
+                amountInUsed: amountInUsed,
+                swapOutput: swapOutput,
+                amountInMax: amountInMax,
+                surplusTopUp: surplusTopUp,
+                deficitTopUp: deficitTopUp
+            })
+        );
+    }
+
+    function _baseReverseParamsAave(
+        uint256 loanAmount,
+        uint256 maxDebit,
+        uint256 amountInUsed,
+        uint256 swapOutput,
+        uint256 amountInMax,
+        uint256 surplusTopUp,
+        uint256 deficitTopUp
+    ) internal view returns (FlashCcrRebalancer.RebalanceParams memory params) {
+        params = _baseParams(
+            BuildParams({
+                provider: FlashCcrRebalancer.FlashLoanProvider.AaveV3,
+                providerAddress: address(aavePool),
+                loanToken: address(usdt),
+                loanAmount: loanAmount,
+                deficitRouter: address(usdtRouter),
+                surplusRouter: address(usdcRouter),
+                surplusToken: address(usdc),
+                deficitToken: address(usdt),
+                maxDebit: maxDebit,
+                ccrAmount: loanAmount,
+                amountInUsed: amountInUsed,
+                swapOutput: swapOutput,
+                amountInMax: amountInMax,
+                surplusTopUp: surplusTopUp,
+                deficitTopUp: deficitTopUp
+            })
+        );
+    }
+
+    function _baseParams(
+        BuildParams memory build
+    ) internal view returns (FlashCcrRebalancer.RebalanceParams memory params) {
+        params.loan = FlashCcrRebalancer.FlashLoanParams({
+            provider: build.provider,
+            providerAddress: build.providerAddress,
+            token: build.loanToken,
+            amount: build.loanAmount
+        });
+        params.ccr = FlashCcrRebalancer.CcrParams({
+            deficitRouter: build.deficitRouter,
+            surplusRouter: build.surplusRouter,
+            targetRouter: build.surplusRouter.addressToBytes32(),
+            localDomain: LOCAL_DOMAIN,
+            amount: build.ccrAmount,
+            maxDeficitTokenDebit: build.maxDebit,
+            minSurplusReceived: build.amountInUsed
+        });
+        params.swap = FlashCcrRebalancer.SwapCall({
+            target: address(swapTarget),
+            allowanceTarget: address(swapTarget),
+            tokenIn: build.surplusToken,
+            tokenOut: build.deficitToken,
+            amountInMax: build.amountInMax,
+            minAmountOut: build.swapOutput,
+            value: 0,
+            data: abi.encodeCall(
+                MockSwapTarget.swapExactOutput,
+                (
+                    build.surplusToken,
+                    build.deficitToken,
+                    build.amountInUsed,
+                    build.swapOutput
+                )
+            )
+        });
+        params.topUp = FlashCcrRebalancer.TopUpParams({
+            payer: TOP_UP,
+            maxSurplusTokenTopUp: build.surplusTopUp,
+            maxDeficitTokenTopUp: build.deficitTopUp
+        });
+        params.refundTo = REFUND_TO;
+        params.deadline = block.timestamp + 1 hours;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `FlashCcrRebalancer`, a helper contract for atomically rebalancing same-chain CrossCollateralRouter collateral pools with a flashloan and caller-supplied swap calldata.

The intended use case is CROSS/moonpay-style inventory balancing where one asset, e.g. USDC, is deficient on a chain and the paired same-chain asset, e.g. USDT, is surplus. The helper borrows the deficient token, sends it through same-chain CCR `transferRemoteTo`, receives the surplus token, swaps back into the borrowed token, tops up bounded shortfalls if needed, and repays the flashloan in the same transaction.

## Design Diagram

```mermaid
flowchart LR
    Operator[Allowlisted rebalancer]
    Helper[FlashCcrRebalancer]
    Flash{Flashloan provider}
    Aave[Aave V3 flashLoanSimple]
    Uni[Uniswap V3 pool flash]
    Deficit[Deficit CCR router]
    Surplus[Surplus CCR router]
    Swap[Allowlisted swap target]
    Spender[Allowlisted allowance target]
    TopUp[Top-up payer]
    Refund[Refund recipient]

    Operator -->|rebalance params| Helper
    Helper -->|borrow deficit token| Flash
    Flash --> Aave
    Flash --> Uni
    Aave -->|callback + borrowed token| Helper
    Uni -->|callback + borrowed token| Helper

    Helper -->|approve exact CCR debit| Deficit
    Deficit -->|transferRemoteTo localDomain, recipient=helper, target=surplus router| Surplus
    Surplus -->|surplus token| Helper

    TopUp -.->|optional surplus top-up before swap| Helper
    Helper -->|bounded approval amountInMax| Spender
    Helper -->|call supplied calldata/value| Swap
    Spender -->|pull surplus token if route requires| Helper
    Swap -->|deficit token output| Helper

    TopUp -.->|optional deficit top-up for CCR fee or repayment shortfall| Helper
    Helper -->|repay amount + fee/premium| Flash
    Helper -->|unused top-up / route residue| Refund
```

## Motivation

The design reduces the amount of route inventory that needs to be held by, approved to, or moved out of adapter contracts during a rebalance. Instead of staging assets in an executor or adapter and relying on a multi-step operational flow, the whole rebalance is one atomic transaction:

- if the swap is bad, the CCR leg reverts
- if repayment cannot be made, the flashloan reverts
- if any allowlist, debit, top-up, or output bound is violated, the transaction reverts

This gives us the useful flashloan property discussed in the design thread: the repayment requirement narrows the asset-loss surface because the borrowed asset, CCR transfer, swap, top-up, and repayment must all succeed together.

## High-Level Flow

1. An allowlisted rebalancer calls `rebalance` with flashloan, CCR, swap, top-up, refund, and deadline params.
2. The helper starts either:
   - Aave V3 `flashLoanSimple`, or
   - Uniswap V3 pool `flash`.
3. The flashloan callback validates:
   - active callback state exists
   - callback provider type matches the requested provider
   - `msg.sender` is the allowlisted active provider
   - callback params hash matches the active rebalance params
   - borrowed asset and amount match the request
   - the callback has not already been consumed or reentered
4. The helper validates the CCR leg:
   - deficit router token equals the flashloan token
   - surplus router token equals swap input token
   - swap output token equals deficit token
   - both routers are on the expected local domain
   - target router is exactly the surplus router
5. The helper quotes `transferRemoteTo` and sums only deficit-token quote amounts.
6. If the CCR debit exceeds the borrowed balance, the helper pulls bounded deficit-token top-up before CCR execution.
7. The helper approves the deficit router for the exact quoted debit and calls same-domain `transferRemoteTo(localDomain, helper, amount, surplusRouter)`.
8. The helper verifies the surplus-token balance delta is at least `minSurplusReceived`.
9. If the surplus balance is below `swap.amountInMax`, the helper pulls bounded surplus-token top-up from the configured payer.
10. The helper approves the configured `allowanceTarget` for at most `amountInMax`, calls the configured swap `target` with calldata/value, then clears the approval.
11. The helper verifies the deficit-token balance delta is at least `minAmountOut`.
12. If the deficit-token balance is still below flashloan debt, the helper pulls bounded deficit-token top-up.
13. The helper repays the flashloan:
   - Aave path: approves the pool for `amount + premium`, letting Aave pull repayment
   - Uniswap path: transfers `amount + fee` back to the pool during callback
14. After callback completion, the helper clears transient allowances/state and refunds:
   - unused surplus-token top-up back to `topUp.payer`
   - remaining route residue/native value to `refundTo`

## Provider Configuration

The contract is intentionally configurable but bounded by owner-managed allowlists:

- `allowedRebalancers[caller]`
- `allowedFlashLoanProviders[provider][pool]`
- `allowedSwapTargets[target]`
- `allowedAllowanceTargets[spender]`

Supported flashloan providers in this PR:

- Aave V3 `flashLoanSimple`
- Uniswap V3 pool `flash`

The provider enum keeps callback semantics explicit because Aave and Uniswap repay differently.

## swaps.xyz / Swap Calldata Design

The helper does not integrate directly with swaps.xyz onchain. Instead, swaps.xyz remains an offchain quote/calldata provider.

The expected integration shape is:

1. Offchain executor asks swaps.xyz for an exact-output route sized to repay the flash debt.
2. The request should use the helper as sender, and generally the helper as recipient.
3. The executor passes the returned transaction fields into `SwapCall`:
   - `target`: returned `tx.to`
   - `allowanceTarget`: returned approval/spender address, which may differ from `tx.to`
   - `tokenIn`: surplus token received from CCR
   - `tokenOut`: borrowed/deficit token
   - `amountInMax`: maximum surplus token the helper may approve/spend
   - `minAmountOut`: minimum deficit-token balance increase required
   - `value`: returned native value, if any
   - `data`: returned calldata

The contract does not decode or trust the route internals. It enforces the local invariants around that calldata:

- target must be allowlisted
- allowance target must be allowlisted
- token input approval is capped at `amountInMax`
- approval is cleared after the call
- output is measured by token balance delta
- swap must produce at least `minAmountOut`
- the whole flow reverts if flashloan repayment cannot be made

This supports both simple Uniswap-style call targets and aggregator-style flows where `tx.to` and ERC20 spender are separate addresses.

## Top-Up Model

The helper supports both top-up directions discussed in the design thread:

- **Surplus-token top-up before swap:** if CCR returns less surplus token than the swap may need, the helper can pull up to `maxSurplusTokenTopUp` from `topUp.payer`.
- **Deficit-token top-up before CCR / before repayment:** if CCR fees or flashloan repayment require more deficit token than the borrowed/swap output balance, the helper can pull up to `maxDeficitTokenTopUp`.

Unused surplus-token top-up is refunded to `topUp.payer` before any generic residue sweep. Residue that came from the route itself is swept to `refundTo`.

## Safety Properties

Important invariants enforced by the implementation:

- only allowlisted rebalancers can start a rebalance
- deadline must not be expired
- flashloan callback params are bound to the active rebalance by hash
- callback sender must be the active allowlisted provider
- callback asset and amount must match the request
- only one flash callback can be consumed per rebalance
- nested callback execution is rejected
- CCR target router must be the configured same-chain surplus router
- quote tokens must be the deficit token
- CCR debit must be below `maxDeficitTokenDebit`
- swap target and allowance target must be allowlisted
- swap input approval is bounded and cleared
- swap output is checked by balance delta
- top-ups are capped by user-supplied maximums
- all helper-held relevant token balances are swept/refunded after a successful rebalance

## Tests

Adds focused Solidity coverage for:

- Aave V3 happy path with USDC deficit / USDT surplus
- Uniswap V3 happy path with USDC deficit / USDT surplus
- reverse USDT deficit / USDC surplus direction
- separate swap target and allowance target, matching aggregator/swaps.xyz-style calldata
- surplus-token top-up with unused amount refunded to payer
- route residue refunded to `refundTo`
- deficit-token top-up for repayment shortfall
- deficit-token top-up for CCR fee plus repayment shortfall
- swap output shortfall rolling back the CCR leg
- repayment shortfall rolling back the CCR leg
- unauthorized caller rejection
- unallowlisted flash provider rejection
- unallowlisted swap target rejection
- unallowlisted allowance target rejection
- deadline expiry
- CCR debit max bound
- unsupported quote token rejection
- surplus and deficit top-up limits
- malicious swap attempting to steal beyond allowance
- direct callback spoofing
- nested Aave callback from swap target
- nested Uniswap callback from swap target
- entrypoint reentrancy from swap target
- fuzzed Aave amounts and premiums

## Verification

- `forge test --match-path test/rebalancing/FlashCcrRebalancer.t.sol`
  - 25 passed
- `forge build --skip test --contracts contracts/rebalancing/FlashCcrRebalancer.sol`
  - passed

## Follow-Up / Rollout Notes

This PR adds the contract and focused unit coverage. Before production use, the next steps should be:

- deploy with conservative owner-controlled allowlists
- fork-test against real Aave/Uniswap pools on target chains
- fork-test real swaps.xyz calldata for exact-output USDC/USDT routes
- wire executor config to produce `RebalanceParams` from route imbalance analysis
- set operational policies for max debit, max top-up, slippage, deadline, and refund recipient
