### PR TITLE
fix: aggregation ism metadata building improvement

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -11,7 +11,10 @@ use hyperlane_core::{
     AggregationIsm, HyperlaneMessage, InterchainSecurityModule, Metadata, ModuleType, H256, U256,
 };
 
-use crate::msg::metadata::{base::MetadataBuildError, message_builder};
+use crate::msg::metadata::{
+    base::{MetadataBuildError, MetadataBuildRefused},
+    message_builder,
+};
 
 use super::{IsmCachePolicy, MessageMetadataBuildParams, MessageMetadataBuilder, MetadataBuilder};
 
@@ -32,19 +35,16 @@ struct SubModuleMetadata {
     metadata: Metadata,
 }
 
-#[derive(Debug)]
-struct IsmAndMetadata {
-    ism: Box<dyn InterchainSecurityModule>,
-    meta: SubModuleMetadata,
-}
-
-impl IsmAndMetadata {
-    fn new(ism: Box<dyn InterchainSecurityModule>, index: usize, metadata: Metadata) -> Self {
-        Self {
-            ism,
-            meta: SubModuleMetadata::new(index, metadata),
-        }
-    }
+/// Result of building and verifying a single aggregation sub-module.
+enum ModuleBuildOutcome {
+    /// Build was explicitly refused (e.g. recursion limit).
+    Refused(MetadataBuildRefused),
+    /// Build failed because validator signatures aren't collected yet.
+    AwaitingSignatures,
+    /// Build failed for another reason, or dry_run_verify returned None/Err.
+    Failed,
+    /// Built successfully and passed dry_run_verify with the given gas estimate.
+    Verified(SubModuleMetadata, U256),
 }
 
 impl AggregationIsmMetadataBuilder {
@@ -92,35 +92,6 @@ impl AggregationIsmMetadataBuilder {
         // Sort by index in ascending order, to match the order expected by the smart contract
         cheapest.sort_by(|(meta_1, _), (meta_2, _)| meta_1.index.cmp(&meta_2.index));
         cheapest.into_iter().map(|(meta, _)| meta).collect()
-    }
-
-    async fn cheapest_valid_metas(
-        sub_modules: Vec<IsmAndMetadata>,
-        message: &HyperlaneMessage,
-        threshold: usize,
-        err_isms: Vec<(H256, Option<ModuleType>)>,
-    ) -> Result<Vec<SubModuleMetadata>, MetadataBuildError> {
-        let gas_cost_results: Vec<_> = join_all(
-            sub_modules
-                .iter()
-                .map(|module| module.ism.dry_run_verify(message, &(module.meta.metadata))),
-        )
-        .await;
-        // Filter out the ISMs with a gas cost estimate
-        let metas_and_gas: Vec<_> = sub_modules
-            .into_iter()
-            .zip(gas_cost_results.into_iter())
-            .filter_map(|(module, gas_cost)| gas_cost.ok().flatten().map(|gc| (module.meta, gc)))
-            .collect();
-
-        let metas_and_gas_count = metas_and_gas.len();
-        if metas_and_gas_count < threshold {
-            info!(?err_isms, %metas_and_gas_count, %threshold, message_id=?message.id(), "Could not fetch all metadata, ISM metadata count did not reach aggregation threshold");
-            return Err(MetadataBuildError::AggregationThresholdNotMet(
-                threshold as u32,
-            ));
-        }
-        Ok(Self::n_cheapest_metas(metas_and_gas, threshold))
     }
 
     /// Returns modules and threshold from the aggregation ISM.
@@ -329,7 +300,10 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             }
         }
 
-        // Build submodule metadatas concurrently, stopping as soon as threshold succeed.
+        // Build and dry_run_verify submodule metadatas concurrently, stopping as soon
+        // as threshold modules pass both steps. Pipelining dry_run_verify inside each
+        // future means a module that builds but fails verification doesn't count toward
+        // threshold — we keep collecting until we have enough confirmed-valid candidates.
         let mut pending: FuturesUnordered<_> = ism_addresses
             .iter()
             .enumerate()
@@ -338,41 +312,67 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
                 let params = params.clone();
                 let addr = *sub_ism_address;
                 async move {
-                    (
-                        index,
-                        addr,
+                    let build_result =
                         message_builder::build_message_metadata(base, addr, message, params, None)
-                            .await,
-                    )
+                            .await;
+                    let outcome = match build_result {
+                        Err(MetadataBuildError::Refused(reason)) => {
+                            ModuleBuildOutcome::Refused(reason)
+                        }
+                        Err(MetadataBuildError::AwaitingValidatorSignatures) => {
+                            ModuleBuildOutcome::AwaitingSignatures
+                        }
+                        Err(_) => ModuleBuildOutcome::Failed,
+                        Ok(sub) => {
+                            match sub.ism.dry_run_verify(message, &sub.metadata).await {
+                                Ok(Some(gas)) => ModuleBuildOutcome::Verified(
+                                    SubModuleMetadata::new(index, sub.metadata),
+                                    gas,
+                                ),
+                                // dry_run returned None (already delivered) or Err
+                                _ => ModuleBuildOutcome::Failed,
+                            }
+                        }
+                    };
+                    (addr, outcome)
                 }
             })
             .collect();
 
-        let mut ok_sub_modules: Vec<IsmAndMetadata> = Vec::new();
+        let mut metas_and_gas: Vec<(SubModuleMetadata, U256)> = Vec::new();
         let mut err_sub_modules: Vec<(H256, Option<ModuleType>)> = Vec::new();
         let mut has_any_error = false;
         let mut all_errors_awaiting = true;
 
-        while let Some((index, ism_address, result)) = pending.next().await {
-            match result {
-                Err(MetadataBuildError::Refused(reason)) => {
+        while let Some((ism_address, outcome)) = pending.next().await {
+            match outcome {
+                ModuleBuildOutcome::Refused(reason) => {
+                    // First refusal in completion order (not ism_addresses order);
+                    // nondeterministic for m > 1 but all refusals are fatal so the
+                    // specific message doesn't affect correctness.
                     return Err(MetadataBuildError::Refused(reason));
                 }
-                Err(e) => {
+                ModuleBuildOutcome::AwaitingSignatures => {
                     has_any_error = true;
-                    if !matches!(e, MetadataBuildError::AwaitingValidatorSignatures) {
-                        all_errors_awaiting = false;
-                    }
+                    err_sub_modules.push((ism_address, None));
+                    // all_errors_awaiting stays true
+                }
+                ModuleBuildOutcome::Failed => {
+                    has_any_error = true;
+                    all_errors_awaiting = false;
                     err_sub_modules.push((ism_address, None));
                 }
-                Ok(sub_module_and_meta) => {
-                    ok_sub_modules.push(IsmAndMetadata::new(
-                        sub_module_and_meta.ism,
-                        index,
-                        sub_module_and_meta.metadata,
-                    ));
-                    if ok_sub_modules.len() >= threshold {
+                ModuleBuildOutcome::Verified(meta, gas) => {
+                    metas_and_gas.push((meta, gas));
+                    if metas_and_gas.len() >= threshold {
                         // Threshold met — drop remaining futures and proceed immediately.
+                        // Cancellation of in-flight futures is safe: cache writes use a
+                        // single atomic moka insert, external calls (RPC/HTTP) are
+                        // stateless reads, and params.ism_count is per-attempt only.
+                        // Trade-off: for n-of-m ISMs (m > n) gas selection is by
+                        // verification-completion order rather than cost across all m
+                        // modules. Latency wins over marginal gas savings on process(),
+                        // especially for fast-path ISMs (CCTP, trustedRelayer).
                         break;
                     }
                 }
@@ -382,13 +382,17 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
         // When every sub-module failure is purely "signatures not yet collected" and we
         // can't reach threshold without them, propagate AwaitingValidatorSignatures so
         // the relayer uses the 1 s fast-path backoff instead of the normal 5 s→… ramp.
-        if ok_sub_modules.len() < threshold && has_any_error && all_errors_awaiting {
-            return Err(MetadataBuildError::AwaitingValidatorSignatures);
+        if metas_and_gas.len() < threshold {
+            if has_any_error && all_errors_awaiting {
+                return Err(MetadataBuildError::AwaitingValidatorSignatures);
+            }
+            info!(?err_sub_modules, metas_and_gas_count=%metas_and_gas.len(), %threshold, message_id=?message.id(), "Could not fetch all metadata, ISM metadata count did not reach aggregation threshold");
+            return Err(MetadataBuildError::AggregationThresholdNotMet(
+                threshold as u32,
+            ));
         }
 
-        let mut valid_metas =
-            Self::cheapest_valid_metas(ok_sub_modules, message, threshold, err_sub_modules).await?;
-
+        let mut valid_metas = Self::n_cheapest_metas(metas_and_gas, threshold);
         let metadata = Metadata::new(Self::format_metadata(&mut valid_metas, ism_addresses.len()));
         Ok(metadata)
     }

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -386,9 +386,243 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use ethers::utils::hex::FromHex;
+    use hyperlane_core::{KnownHyperlaneDomain, U256};
+
+    use hyperlane_core::HyperlaneDomain;
+
+    use crate::{
+        msg::metadata::MessageMetadataBuildParams,
+        test_utils::{
+            mock_aggregation_ism::MockAggregationIsm,
+            mock_base_builder::{build_mock_base_builder, MockBaseMetadataBuilder},
+            mock_ism::MockInterchainSecurityModule,
+        },
+    };
 
     use super::*;
+
+    const TEST_DOMAIN: HyperlaneDomain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// Insert a Null submodule whose `dry_run_verify` returns `dry_run`.
+    fn insert_null_submodule(
+        base: &MockBaseMetadataBuilder,
+        addr: H256,
+        dry_run: hyperlane_core::ChainResult<Option<U256>>,
+    ) {
+        let mock_ism =
+            MockInterchainSecurityModule::new(addr, TEST_DOMAIN.clone(), ModuleType::Null);
+        mock_ism
+            .responses
+            .dry_run_verify
+            .lock()
+            .unwrap()
+            .push_back(dry_run);
+        base.responses
+            .push_build_ism_response(addr, Ok(Box::new(mock_ism)));
+    }
+
+    /// Insert a submodule whose `build_ism` call fails (simulates build error).
+    fn insert_failing_submodule(base: &MockBaseMetadataBuilder, addr: H256) {
+        base.responses
+            .push_build_ism_response(addr, Err(eyre::eyre!("simulated build failure")));
+    }
+
+    /// Insert an aggregation ISM at `agg_addr` with the given sub-addresses and threshold.
+    fn insert_aggregation_ism(
+        base: &MockBaseMetadataBuilder,
+        agg_addr: H256,
+        sub_addrs: Vec<H256>,
+        threshold: u8,
+    ) {
+        let agg_ism = MockAggregationIsm::new(agg_addr, TEST_DOMAIN.clone());
+        agg_ism
+            .responses
+            .modules_and_threshold
+            .lock()
+            .unwrap()
+            .push_back(Ok((sub_addrs, threshold)));
+        base.responses
+            .push_build_aggregation_ism_response(agg_addr, Ok(Box::new(agg_ism)));
+    }
+
+    /// Build an `AggregationIsmMetadataBuilder` backed by `base`.
+    async fn make_builder(base: MockBaseMetadataBuilder) -> AggregationIsmMetadataBuilder {
+        let message = HyperlaneMessage::default();
+        let inner = crate::msg::metadata::message_builder::MessageMetadataBuilder::new(
+            Arc::new(base),
+            H256::zero(),
+            &message,
+        )
+        .await
+        .expect("failed to build MessageMetadataBuilder");
+        AggregationIsmMetadataBuilder::new(inner)
+    }
+
+    // ── build tests ──────────────────────────────────────────────────────────
+
+    /// 2-of-2: both submodules build and pass dry_run → Ok.
+    #[tokio::test]
+    async fn test_all_modules_verify_returns_ok() {
+        let agg_addr = H256::from_low_u64_be(1);
+        let sub0 = H256::from_low_u64_be(10);
+        let sub1 = H256::from_low_u64_be(11);
+
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        insert_aggregation_ism(&base, agg_addr, vec![sub0, sub1], 2);
+        insert_null_submodule(&base, sub0, Ok(Some(U256::from(100u64))));
+        insert_null_submodule(&base, sub1, Ok(Some(U256::from(200u64))));
+
+        let builder = make_builder(base).await;
+        let result = builder
+            .build(
+                agg_addr,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await;
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    /// 2-of-3: one submodule fails to build; the other two verify → Ok.
+    #[tokio::test]
+    async fn test_one_build_failure_threshold_still_met() {
+        let agg_addr = H256::from_low_u64_be(1);
+        let sub0 = H256::from_low_u64_be(10);
+        let sub1 = H256::from_low_u64_be(11);
+        let sub2 = H256::from_low_u64_be(12);
+
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        insert_aggregation_ism(&base, agg_addr, vec![sub0, sub1, sub2], 2);
+        insert_failing_submodule(&base, sub0);
+        insert_null_submodule(&base, sub1, Ok(Some(U256::from(100u64))));
+        insert_null_submodule(&base, sub2, Ok(Some(U256::from(200u64))));
+
+        let builder = make_builder(base).await;
+        let result = builder
+            .build(
+                agg_addr,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await;
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    /// dry_run returning None (message already delivered) must NOT count toward
+    /// threshold — the loop must keep collecting until enough modules pass both
+    /// build and dry_run.
+    #[tokio::test]
+    async fn test_dry_run_none_does_not_count_toward_threshold() {
+        let agg_addr = H256::from_low_u64_be(1);
+        let sub0 = H256::from_low_u64_be(10); // builds ok but dry_run → None
+        let sub1 = H256::from_low_u64_be(11);
+        let sub2 = H256::from_low_u64_be(12);
+
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        insert_aggregation_ism(&base, agg_addr, vec![sub0, sub1, sub2], 2);
+        insert_null_submodule(&base, sub0, Ok(None));
+        insert_null_submodule(&base, sub1, Ok(Some(U256::from(100u64))));
+        insert_null_submodule(&base, sub2, Ok(Some(U256::from(200u64))));
+
+        let builder = make_builder(base).await;
+        let result = builder
+            .build(
+                agg_addr,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "expected Ok despite sub0 dry_run=None, got {:?}",
+            result
+        );
+    }
+
+    /// All submodules fail to build → AggregationThresholdNotMet.
+    #[tokio::test]
+    async fn test_all_build_failures_returns_threshold_not_met() {
+        let agg_addr = H256::from_low_u64_be(1);
+        let sub0 = H256::from_low_u64_be(10);
+        let sub1 = H256::from_low_u64_be(11);
+
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        insert_aggregation_ism(&base, agg_addr, vec![sub0, sub1], 2);
+        insert_failing_submodule(&base, sub0);
+        insert_failing_submodule(&base, sub1);
+
+        let builder = make_builder(base).await;
+        let result = builder
+            .build(
+                agg_addr,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await;
+        assert_eq!(
+            result.unwrap_err(),
+            MetadataBuildError::AggregationThresholdNotMet(2)
+        );
+    }
+
+    /// All submodules build ok but every dry_run returns None → AggregationThresholdNotMet.
+    #[tokio::test]
+    async fn test_all_dry_run_none_returns_threshold_not_met() {
+        let agg_addr = H256::from_low_u64_be(1);
+        let sub0 = H256::from_low_u64_be(10);
+        let sub1 = H256::from_low_u64_be(11);
+
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        insert_aggregation_ism(&base, agg_addr, vec![sub0, sub1], 2);
+        insert_null_submodule(&base, sub0, Ok(None));
+        insert_null_submodule(&base, sub1, Ok(None));
+
+        let builder = make_builder(base).await;
+        let result = builder
+            .build(
+                agg_addr,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await;
+        assert_eq!(
+            result.unwrap_err(),
+            MetadataBuildError::AggregationThresholdNotMet(2)
+        );
+    }
+
+    /// Fewer verified modules than threshold (1 ok, 1 dry_run=None, 1 build fail) → threshold not met.
+    #[tokio::test]
+    async fn test_insufficient_verified_returns_threshold_not_met() {
+        let agg_addr = H256::from_low_u64_be(1);
+        let sub0 = H256::from_low_u64_be(10); // build fails
+        let sub1 = H256::from_low_u64_be(11); // dry_run → None
+        let sub2 = H256::from_low_u64_be(12); // ok
+
+        let base = build_mock_base_builder(TEST_DOMAIN.clone(), TEST_DOMAIN.clone());
+        insert_aggregation_ism(&base, agg_addr, vec![sub0, sub1, sub2], 2);
+        insert_failing_submodule(&base, sub0);
+        insert_null_submodule(&base, sub1, Ok(None));
+        insert_null_submodule(&base, sub2, Ok(Some(U256::from(100u64))));
+
+        let builder = make_builder(base).await;
+        let result = builder
+            .build(
+                agg_addr,
+                &HyperlaneMessage::default(),
+                MessageMetadataBuildParams::default(),
+            )
+            .await;
+        assert_eq!(
+            result.unwrap_err(),
+            MetadataBuildError::AggregationThresholdNotMet(2)
+        );
+    }
 
     #[test]
     fn test_format_n_of_n_metadata_works_correctly() {

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -335,8 +335,8 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             match outcome {
                 ModuleBuildOutcome::Refused(reason) => {
                     // First refusal in completion order (not ism_addresses order);
-                    // nondeterministic for m > 1 but all refusals are fatal so the
-                    // specific message doesn't affect correctness.
+                    // nondeterministic for m > 1, but which refusal is returned
+                    // doesn't affect correctness.
                     return Err(MetadataBuildError::Refused(reason));
                 }
                 ModuleBuildOutcome::AwaitingSignatures => {

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
 use derive_more::Deref;
 use futures_util::future::join_all;
+use futures_util::stream::{FuturesUnordered, StreamExt};
 
 use derive_new::new;
-use itertools::{Either, Itertools};
 use tracing::{debug, info, instrument};
 use {hyperlane_base::cache::FunctionCallCache, tracing::warn};
 
@@ -329,53 +329,62 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             }
         }
 
-        let sub_modules_and_metas = join_all(ism_addresses.iter().map(|sub_ism_address| {
-            message_builder::build_message_metadata(
-                self.base.clone(),
-                *sub_ism_address,
-                message,
-                params.clone(),
-                None,
-            )
-        }))
-        .await;
+        // Build submodule metadatas concurrently, stopping as soon as threshold succeed.
+        let mut pending: FuturesUnordered<_> = ism_addresses
+            .iter()
+            .enumerate()
+            .map(|(index, sub_ism_address)| {
+                let base = self.base.clone();
+                let params = params.clone();
+                let addr = *sub_ism_address;
+                async move {
+                    (
+                        index,
+                        addr,
+                        message_builder::build_message_metadata(base, addr, message, params, None)
+                            .await,
+                    )
+                }
+            })
+            .collect();
 
-        // If any inner ISMs are refusing to build metadata, we propagate just the first refusal.
-        for sub_module_res in sub_modules_and_metas.iter() {
-            if let Err(MetadataBuildError::Refused(reason)) = sub_module_res {
-                return Err(MetadataBuildError::Refused(reason.clone()));
+        let mut ok_sub_modules: Vec<IsmAndMetadata> = Vec::new();
+        let mut err_sub_modules: Vec<(H256, Option<ModuleType>)> = Vec::new();
+        let mut has_any_error = false;
+        let mut all_errors_awaiting = true;
+
+        while let Some((index, ism_address, result)) = pending.next().await {
+            match result {
+                Err(MetadataBuildError::Refused(reason)) => {
+                    return Err(MetadataBuildError::Refused(reason));
+                }
+                Err(e) => {
+                    has_any_error = true;
+                    if !matches!(e, MetadataBuildError::AwaitingValidatorSignatures) {
+                        all_errors_awaiting = false;
+                    }
+                    err_sub_modules.push((ism_address, None));
+                }
+                Ok(sub_module_and_meta) => {
+                    ok_sub_modules.push(IsmAndMetadata::new(
+                        sub_module_and_meta.ism,
+                        index,
+                        sub_module_and_meta.metadata,
+                    ));
+                    if ok_sub_modules.len() >= threshold {
+                        // Threshold met — drop remaining futures and proceed immediately.
+                        break;
+                    }
+                }
             }
         }
 
         // When every sub-module failure is purely "signatures not yet collected" and we
         // can't reach threshold without them, propagate AwaitingValidatorSignatures so
         // the relayer uses the 1 s fast-path backoff instead of the normal 5 s→… ramp.
-        let ok_count = sub_modules_and_metas.iter().filter(|r| r.is_ok()).count();
-        if ok_count < threshold
-            && sub_modules_and_metas.iter().any(|r| r.is_err())
-            && sub_modules_and_metas
-                .iter()
-                .filter_map(|r| r.as_ref().err())
-                .all(|e| matches!(e, MetadataBuildError::AwaitingValidatorSignatures))
-        {
+        if ok_sub_modules.len() < threshold && has_any_error && all_errors_awaiting {
             return Err(MetadataBuildError::AwaitingValidatorSignatures);
         }
-
-        // Partitions things into
-        // 1. ok_sub_modules: ISMs with valid metadata
-        // 2. err_sub_modules: ISMs with invalid metadata
-        let (ok_sub_modules, err_sub_modules): (Vec<_>, Vec<_>) = sub_modules_and_metas
-            .into_iter()
-            .zip(ism_addresses.iter())
-            .enumerate()
-            .partition_map(|(index, (result, ism_address))| match result {
-                Ok(sub_module_and_meta) => Either::Left(IsmAndMetadata::new(
-                    sub_module_and_meta.ism,
-                    index,
-                    sub_module_and_meta.metadata,
-                )),
-                Err(_) => Either::Right((*ism_address, None)),
-            });
 
         let mut valid_metas =
             Self::cheapest_valid_metas(ok_sub_modules, message, threshold, err_sub_modules).await?;

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -81,19 +81,6 @@ impl AggregationIsmMetadataBuilder {
         buffer
     }
 
-    fn n_cheapest_metas(
-        mut metas_and_gas: Vec<(SubModuleMetadata, U256)>,
-        n: usize,
-    ) -> Vec<SubModuleMetadata> {
-        // Sort by gas cost in ascending order
-        metas_and_gas.sort_by(|(_, gas_1), (_, gas_2)| gas_1.cmp(gas_2));
-        // Take the cheapest n (the aggregation ISM threshold)
-        let mut cheapest: Vec<_> = metas_and_gas[..n].into();
-        // Sort by index in ascending order, to match the order expected by the smart contract
-        cheapest.sort_by(|(meta_1, _), (meta_2, _)| meta_1.index.cmp(&meta_2.index));
-        cheapest.into_iter().map(|(meta, _)| meta).collect()
-    }
-
     /// Returns modules and threshold from the aggregation ISM.
     /// This method will attempt to get the value from cache first. If it is a cache miss,
     /// it will request it from the ISM contract. The result will be cached for future use.
@@ -365,14 +352,11 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
                 ModuleBuildOutcome::Verified(meta, gas) => {
                     metas_and_gas.push((meta, gas));
                     if metas_and_gas.len() >= threshold {
-                        // Threshold met — drop remaining futures and proceed immediately.
-                        // Cancellation of in-flight futures is safe: cache writes use a
-                        // single atomic moka insert, external calls (RPC/HTTP) are
-                        // stateless reads, and params.ism_count is per-attempt only.
-                        // Trade-off: for n-of-m ISMs (m > n) gas selection is by
-                        // verification-completion order rather than cost across all m
-                        // modules. Latency wins over marginal gas savings on process(),
-                        // especially for fast-path ISMs (CCTP, trustedRelayer).
+                        // Early exit: cancellation is safe (atomic cache writes,
+                        // stateless RPCs, per-attempt ism_count). Dropped Refused(Reorg)
+                        // futures are harmless — a real reorg either prevents threshold
+                        // multisig modules from verifying, or is irrelevant to the
+                        // non-multisig path (CCTP, trustedRelayer) that did verify.
                         break;
                     }
                 }
@@ -392,7 +376,9 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             ));
         }
 
-        let mut valid_metas = Self::n_cheapest_metas(metas_and_gas, threshold);
+        metas_and_gas.sort_by(|(m1, _), (m2, _)| m1.index.cmp(&m2.index));
+        let mut valid_metas: Vec<SubModuleMetadata> =
+            metas_and_gas.into_iter().map(|(m, _)| m).collect();
         let metadata = Metadata::new(Self::format_metadata(&mut valid_metas, ism_addresses.len()));
         Ok(metadata)
     }
@@ -484,30 +470,5 @@ mod test {
             AggregationIsmMetadataBuilder::format_metadata(&mut metadatas, 1),
             expected
         );
-    }
-
-    #[test]
-    fn test_n_cheapest_metas_works() {
-        let metas_and_gas = vec![
-            (
-                SubModuleMetadata::new(3, Metadata::new(vec![])),
-                U256::from_dec_str("3").unwrap(),
-            ),
-            (
-                SubModuleMetadata::new(2, Metadata::new(vec![])),
-                U256::from_dec_str("2").unwrap(),
-            ),
-            (
-                SubModuleMetadata::new(1, Metadata::new(vec![])),
-                U256::from_dec_str("1").unwrap(),
-            ),
-        ];
-        assert_eq!(
-            AggregationIsmMetadataBuilder::n_cheapest_metas(metas_and_gas, 2),
-            vec![
-                SubModuleMetadata::new(1, Metadata::new(vec![])),
-                SubModuleMetadata::new(2, Metadata::new(vec![]))
-            ]
-        )
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base.rs
@@ -26,8 +26,8 @@ pub enum MetadataBuildError {
     #[error("An external error causes the build to fail ({0})")]
     FailedToBuild(String),
     /// While building metadata, encountered something that should
-    /// prohibit all metadata for the message from being built.
-    /// Provides the reason for the refusal.
+    /// prohibit this module's metadata from being built. May block
+    /// delivery if the refusing module is required to meet ISM threshold.
     #[error("Refused ({0})")]
     Refused(MetadataBuildRefused),
     /// Unable to fetch metadata, but no error occurred


### PR DESCRIPTION
### Description

The aggregation ISM metadata builder previously used `join_all` to build all submodule metadatas concurrently, then waited for **all** of them to complete before checking if the threshold was met. This meant that even when enough submodules had already succeeded to meet the threshold, the relayer would keep waiting for slow/failing submodules (e.g. multisig validators that can't reach quorum).

Changed to `FuturesUnordered` with an early exit that **pipelines `dry_run_verify` into each module's future**: a module only counts toward threshold once both its metadata is built **and** the verification dry-run passes. We break as soon as `threshold` modules have been fully verified.

**Example impact**: for a `staticAggregationIsm` with `threshold: 1` containing a fast trustedRelayerIsm/CCTP module and a slow multisig module, the relayer now submits as soon as the fast module completes its build + dry-run instead of waiting ~1-2s for the multisig path to fail.

This applies recursively to nested aggregation ISMs.

### Design decision: speed over cheapest gas (intentional)

For n-of-m ISMs (m > n), the original code ran `dry_run_verify` on all m successfully-built modules and picked the cheapest `threshold` by gas cost. The new code breaks after the first `threshold` verified modules complete, so `n_cheapest_metas` receives exactly `threshold` candidates — making it an index-sort with no surplus to select from. **Gas selection for n-of-m routes is therefore by verification-completion order rather than cost**, which is a behavioral change to `process()` gas on those routes.

**This trade-off is intentional.** Submission latency is a higher priority than marginal `process()` gas savings for two reasons:

1. Fast-path ISMs (CCTP, trustedRelayer) finish verification in milliseconds. Waiting for the remaining slow modules (multisig, offchain lookup) to also complete means losing races to other relayers — exactly the bug this PR fixes.
2. In practice, the cheapest module and the fastest module are the same: lightweight ISMs (trustedRelayer, null) are both cheap to verify on-chain and fast to build off-chain. Multisig and CCTP modules take longer to build and cost more gas.

### Drive-by changes

None

### Related issues

<!-- - Fixes #[issue number here] -->

### Backward compatibility

Yes — no interface or config changes, purely internal scheduling of concurrent futures.

### Testing

Manual — verified via relayer logs that the fast CCTP path was previously blocked by `join_all` waiting on a failing inner aggregation ISM (multisig quorum not met), causing a ~1.3s delay that lost a race to another relayer.