### PR TITLE
chore(rust): bump `starknet` and `cainome` to drop abandoned `size-of` dep

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "cainome"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd7cc8b7674f2285ea36cdf883c14f7c6bfedf12a9643d77dd618e43d34345"
+checksum = "f296568cda6f1f4934270a321151f9f51afa737450f67ef13a8534f2bd9afdac"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1846,7 +1846,7 @@ dependencies = [
  "convert_case 0.8.0",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet",
  "starknet-types-core",
  "thiserror 2.0.18",
  "tracing",
@@ -1856,14 +1856,14 @@ dependencies = [
 
 [[package]]
 name = "cainome-cairo-serde"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da490d99e84c141e9f5646965de176d6fbfcc7a525f17b6b08e208cd65e6fe35"
+checksum = "95ae2d4c21db23c7730a85187c2e9d73fe00c123171839185fb13f31550f3240"
 dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "serde_with",
- "starknet 0.15.1",
+ "starknet",
  "thiserror 2.0.18",
 ]
 
@@ -1881,23 +1881,23 @@ dependencies = [
 
 [[package]]
 name = "cainome-parser"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaf4e3cba66ccc85bca9726e09ffd69d3b1be37f1305ed59e1b1d5a6e86fabc"
+checksum = "4ffdbc6abfba9c7e91beb87fe7561f097d9f7bbda45c6ff74be3a9ff3f1a0124"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case 0.8.0",
  "quote 1.0.42",
  "serde_json",
- "starknet 0.14.0",
+ "starknet",
  "syn 2.0.109",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cainome-rs"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24e87fcf544b3112f70e36eb560c78c0f7e18ca5d6a1483fdf7b05e7e8302e9"
+checksum = "93aa5c33e66b58ff6723d3e43e60fe163ac20719ea89fce921096e654b15bcd6"
 dependencies = [
  "anyhow",
  "cainome-cairo-serde",
@@ -1907,16 +1907,16 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "serde_json",
- "starknet 0.15.1",
+ "starknet",
  "syn 2.0.109",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cainome-rs-macro"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919354b1142e3ca398313b842a5f95b081b0261270164a8fcdf13c8c633193fd"
+checksum = "9d679cd9a88b9d412ed4ed30264b80f1bec6c1aa9656e238f06be560ddebb652"
 dependencies = [
  "anyhow",
  "cainome-cairo-serde",
@@ -1926,9 +1926,9 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.42",
  "serde_json",
- "starknet 0.14.0",
+ "starknet",
  "syn 2.0.109",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4333,7 +4333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27cea6e7f512d43b098939ff4d5a5d6fe3db07971e1d05176fe26c642d33f5b8"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.1",
+ "rand 0.9.4",
  "siphasher 1.0.2",
  "wide",
 ]
@@ -5895,7 +5895,7 @@ dependencies = [
  "hyperlane-starknet",
  "hyperlane-test",
  "hyperlane-tron",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "maplit",
  "mockall",
  "moka",
@@ -5951,7 +5951,7 @@ dependencies = [
  "getrandom 0.2.15",
  "hex 0.4.3",
  "hyperlane-application",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "num 0.4.3",
  "num-derive",
  "num-traits",
@@ -5983,7 +5983,7 @@ dependencies = [
  "cometbft",
  "cometbft-rpc",
  "cosmrs",
- "cosmwasm-std 1.5.7",
+ "cosmwasm-std 2.1.3",
  "crypto",
  "derive-new",
  "futures",
@@ -6000,7 +6000,7 @@ dependencies = [
  "ibc-proto",
  "injective-protobuf",
  "injective-std",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "once_cell",
  "pin-project",
  "protobuf 2.28.0",
@@ -6013,7 +6013,7 @@ dependencies = [
  "time",
  "tokio",
  "tonic 0.12.3",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "tracing-futures",
  "url",
@@ -6075,7 +6075,7 @@ dependencies = [
  "hyperlane-metric",
  "hyperlane-operation-verifier",
  "hyperlane-warp-route",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "num 0.4.3",
  "num-traits",
  "reqwest 0.11.27",
@@ -6349,7 +6349,7 @@ dependencies = [
  "reqwest-utils",
  "serde",
  "serde_json",
- "starknet 0.15.1",
+ "starknet",
  "thiserror 1.0.63",
  "tokio",
  "tracing",
@@ -6389,7 +6389,7 @@ dependencies = [
  "hyperlane-metric",
  "hyperlane-operation-verifier",
  "hyperlane-warp-route",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "num 0.4.3",
  "num-traits",
  "prost 0.13.4",
@@ -7005,11 +7005,13 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
+checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
 dependencies = [
  "lambdaworks-math",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "sha2 0.10.8",
  "sha3",
@@ -7017,10 +7019,14 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
+checksum = "018a95aa873eb49896a858dee0d925c33f3978d073c64b08dd4f2c9b35a017c6"
 dependencies = [
+ "getrandom 0.2.15",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "rand 0.8.5",
  "serde",
  "serde_json",
 ]
@@ -7046,7 +7052,7 @@ dependencies = [
  "hyperlane-radix",
  "hyperlane-sealevel",
  "hyperlane-tron",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "mockall",
  "prometheus",
  "radix-common",
@@ -8807,7 +8813,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.4",
  "ring 0.17.8",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
@@ -9026,9 +9032,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -9276,7 +9282,7 @@ dependencies = [
  "hyperlane-metric",
  "hyperlane-operation-verifier",
  "hyperlane-test",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "lander",
  "maplit",
  "mockall",
@@ -9298,7 +9304,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
  "tracing-futures",
@@ -9662,7 +9668,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "starknet 0.15.1",
+ "starknet",
  "tempfile",
  "tokio",
  "toml_edit 0.19.15",
@@ -10190,7 +10196,7 @@ dependencies = [
  "hyperlane-core",
  "hyperlane-ethereum",
  "hyperlane-test",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "migration",
  "num-bigint 0.4.6",
  "num-traits",
@@ -10909,12 +10915,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "size-of"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e36eca171fddeda53901b0a436573b3f2391eaa9189d439b2bd8ea8cebd7e3"
 
 [[package]]
 name = "slab"
@@ -15104,124 +15104,55 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e2e53e7705c9a9aad7f118a4bac7386afeb8db272b3eb445a464ca4c3dfee5"
+checksum = "f5ed01c14136e56dcdf21385d20c4a6fdd3509947cb56cca45fc765ef5809add"
 dependencies = [
- "starknet-accounts 0.13.0",
- "starknet-contract 0.13.0",
- "starknet-core 0.13.0",
+ "starknet-accounts",
+ "starknet-contract",
+ "starknet-core",
  "starknet-core-derive",
  "starknet-crypto",
  "starknet-macros",
- "starknet-providers 0.13.0",
- "starknet-signers 0.11.0",
-]
-
-[[package]]
-name = "starknet"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ec983c56ce05b2d7679fa860b37b2ade21004c343ff49374a591b40ee8ee1d"
-dependencies = [
- "starknet-accounts 0.14.0",
- "starknet-contract 0.14.0",
- "starknet-core 0.14.0",
- "starknet-core-derive",
- "starknet-crypto",
- "starknet-macros",
- "starknet-providers 0.14.1",
- "starknet-signers 0.12.0",
+ "starknet-providers",
+ "starknet-signers",
 ]
 
 [[package]]
 name = "starknet-accounts"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca52534db01eda3bf3250f398bd4597aed3856d0d17d84070efbc7919abad71"
+checksum = "4f7c118729bcdcfa1610844047cbdb23090fb1d4172a36bb97a663be8d022d1a"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
- "starknet-core 0.13.0",
+ "starknet-core",
  "starknet-crypto",
- "starknet-providers 0.13.0",
- "starknet-signers 0.11.0",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7adf55fa08ffed413614df3171632e45dcba72cc53706b147ba08e5b7b4e4fb"
-dependencies = [
- "async-trait",
- "auto_impl 1.2.0",
- "starknet-core 0.14.0",
- "starknet-crypto",
- "starknet-providers 0.14.1",
- "starknet-signers 0.12.0",
+ "starknet-providers",
+ "starknet-signers",
  "thiserror 1.0.63",
 ]
 
 [[package]]
 name = "starknet-contract"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d8d5a5306527eedcb4bd70afecfc6824add631a08eac8fd1cf9c2bdfd21e77"
+checksum = "ccb64331b72caf51c0d8b684b62012f9a771015b4cf5e52cba9bf61be8384ad3"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.13.0",
- "starknet-core 0.13.0",
- "starknet-providers 0.13.0",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72746fa496e352ef16b4a8fd11e415ada6b7b5a9107fc6e845eeb921b8bb2a69"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "starknet-accounts 0.14.0",
- "starknet-core 0.14.0",
- "starknet-providers 0.14.1",
+ "starknet-accounts",
+ "starknet-core",
+ "starknet-providers",
  "thiserror 1.0.63",
 ]
 
 [[package]]
 name = "starknet-core"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a16799e4a75173839d868a1a48ff5d3e10456febd4dec91b04ba6521741d5"
-dependencies = [
- "base64 0.21.7",
- "crypto-bigint 0.5.5",
- "flate2",
- "foldhash 0.1.5",
- "hex 0.4.3",
- "indexmap 2.12.0",
- "num-traits",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3",
- "starknet-core-derive",
- "starknet-crypto",
- "starknet-types-core",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2091a08ebfc65c5a6b8bd2c66e32780739854b813af0b4348b6dbf3a887865"
+checksum = "efb7212226769766c1c7d79b70f9242ffbd213290a41604ecc7e78faa0ed0deb"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint 0.5.5",
@@ -15253,9 +15184,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039a3bad70806b494c9e6b21c5238a6c8a373d66a26071859deb0ccca6f93634"
+checksum = "1004a16c25dc6113c19d4f9d0c19ff97d85804829894bba22c0d0e9e7b249812"
 dependencies = [
  "crypto-bigint 0.5.5",
  "hex 0.4.3",
@@ -15272,49 +15203,28 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
+checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dd27bb42d53bd7948a32d4a88c04e799bfcc011b87448756bb0643e6ec0e6d"
+checksum = "6d59e1eb22f4366385b132ba7016faa5a6457f1f23f896f737a06da626455e7b"
 dependencies = [
- "starknet-core 0.14.0",
+ "starknet-core",
  "syn 2.0.109",
 ]
 
 [[package]]
 name = "starknet-providers"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74c3850a661fa1ffd3c3e2cb9db6e28c94ab9aaaa0496503014a814f09cd455"
-dependencies = [
- "async-trait",
- "auto_impl 1.2.0",
- "ethereum-types 0.14.1",
- "flate2",
- "getrandom 0.2.15",
- "log",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_with",
- "starknet-core 0.13.0",
- "thiserror 1.0.63",
- "url",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce77bf215b70673264bc875d59c45fb7da500e7e6f71d2608ad25a1f7280671"
+checksum = "15fc3d94cc008cea64e291b261e8349065424ee7491e5dd0fa9bd688818bece1"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -15326,16 +15236,16 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.14.0",
+ "starknet-core",
  "thiserror 1.0.63",
  "url",
 ]
 
 [[package]]
 name = "starknet-signers"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aeca13b8c61165b69d4775880d74ff9bbb9bafa36a297899e0f160619631b3"
+checksum = "d839b06d899ef3a0de11b1e9a91a14c118b1ed36830ec8e59d9fbc9a1e51976b"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -15343,41 +15253,26 @@ dependencies = [
  "eth-keystore",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "starknet-core 0.13.0",
- "starknet-crypto",
- "thiserror 1.0.63",
-]
-
-[[package]]
-name = "starknet-signers"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd831176f8a217694895fd69be17f985e5e28f00bc8044eb54b55656f3a7f1"
-dependencies = [
- "async-trait",
- "auto_impl 1.2.0",
- "crypto-bigint 0.5.5",
- "eth-keystore",
- "getrandom 0.2.15",
- "rand 0.8.5",
- "starknet-core 0.14.0",
+ "starknet-core",
  "starknet-crypto",
  "thiserror 1.0.63",
 ]
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.8"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4037bcb26ce7c508448d221e570d075196fd4f6912ae6380981098937af9522a"
+checksum = "90d23b1bc014ee4cce40056ab3114bcbcdc2dbc1e845bbfb1f8bd0bab63507d4"
 dependencies = [
+ "blake2",
+ "digest 0.10.7",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
+ "rand 0.9.4",
  "serde",
- "size-of",
  "zeroize",
 ]
 
@@ -16864,7 +16759,7 @@ dependencies = [
  "hyperlane-cosmos",
  "hyperlane-ethereum",
  "hyperlane-test",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "k256 0.13.4",
  "mockall",
  "prometheus",
@@ -16876,7 +16771,7 @@ dependencies = [
  "thiserror 1.0.63",
  "tokio",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "tracing-futures",
  "tracing-test",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -61,7 +61,7 @@ borsh = { version = "1.5", features = ["derive"] }
 bs58 = "0.5.0"
 bytes = "1"
 byteorder = "1.5.0"
-cainome = { version = "0.8.0", features = ["abigen-rs"] }
+cainome = { version = "0.10.1", features = ["abigen-rs"] }
 clap = "4"
 chrono = "*"
 color-eyre = "0.6"
@@ -169,7 +169,7 @@ solana-stake-interface = "1.2"
 solana-system-interface = { version = "2.0", features = ["bincode"] }
 solana-transaction-status = "3.0"
 solana-vote-interface = "3.0"
-starknet = "0.15.0"
+starknet = "0.17.0"
 static_assertions = "1.1"
 strum = "0.26.2"
 strum_macros = "0.26.2"

--- a/rust/main/chains/hyperlane-starknet/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/client.rs
@@ -7,7 +7,7 @@ use hyperlane_core::{
 };
 use hyperlane_metric::prometheus_metric::{ChainInfo, PrometheusClientMetrics};
 use starknet::core::types::{
-    BlockId, BlockTag, Felt, FunctionCall, InvokeTransaction, MaybePendingBlockWithTxHashes,
+    BlockId, BlockTag, Felt, FunctionCall, InvokeTransaction, MaybePreConfirmedBlockWithTxHashes,
     Transaction, TransactionReceipt,
 };
 use starknet::macros::selector;
@@ -78,13 +78,13 @@ impl HyperlaneChain for StarknetProvider {
 impl HyperlaneProvider for StarknetProvider {
     #[instrument(err, skip(self))]
     async fn get_block_by_height(&self, height: u64) -> ChainResult<BlockInfo> {
-        let block: MaybePendingBlockWithTxHashes = self
+        let block: MaybePreConfirmedBlockWithTxHashes = self
             .rpc_client()
             .get_block_with_tx_hashes(BlockId::Number(height))
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;
         match block {
-            MaybePendingBlockWithTxHashes::Block(b) => Ok(BlockInfo {
+            MaybePreConfirmedBlockWithTxHashes::Block(b) => Ok(BlockInfo {
                 hash: H256::from_slice(b.block_hash.to_bytes_be().as_slice()),
                 timestamp: b.timestamp,
                 number: b.block_number,

--- a/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
@@ -84,7 +84,7 @@ impl JsonRpcTransport for FallbackHttpTransport {
     ) -> Result<JsonRpcResponse<R>, Self::Error>
     where
         P: Serialize + Send,
-        R: DeserializeOwned,
+        R: DeserializeOwned + Send,
     {
         let params_json = serde_json::to_value(params).map_err(Self::Error::Json)?;
         let mut errors = vec![];

--- a/rust/main/chains/hyperlane-starknet/src/provider/metric.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/metric.rs
@@ -91,7 +91,7 @@ impl JsonRpcTransport for MetricProvider {
     ) -> Result<JsonRpcResponse<R>, Self::Error>
     where
         P: Serialize + Send,
-        R: DeserializeOwned,
+        R: DeserializeOwned + Send,
     {
         let start = Instant::now();
         let params_json = serde_json::to_value(params).map_err(Self::Error::Json)?;

--- a/rust/main/chains/hyperlane-starknet/src/utils.rs
+++ b/rust/main/chains/hyperlane-starknet/src/utils.rs
@@ -8,7 +8,6 @@ use hyperlane_core::{
     ChainCommunicationError, ChainResult, HyperlaneMessage, ModuleType, ReorgPeriod, TxOutcome,
 };
 use starknet::accounts::ExecutionV3;
-use starknet::core::types::ReceiptBlock;
 use starknet::{
     accounts::SingleOwnerAccount,
     core::{
@@ -52,7 +51,7 @@ pub async fn get_transaction_receipt(
                     .await
                     .map_err(HyperlaneStarknetError::from)?;
 
-                if tx.block == ReceiptBlock::Pending {
+                if tx.block.is_pre_confirmed() {
                     return Err(HyperlaneStarknetError::PendingBlock.into());
                 }
 

--- a/rust/main/rust-toolchain
+++ b/rust/main/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.91.0"
 profile = "default"


### PR DESCRIPTION
### Description

The Rust dependency tree currently contains the `size-of` crate. It is an abandoned crate, and critically doesn't suppose rust >=1.90. `size-of` is exclusively consumed by two Starknet-related crates (`starknet`, `cainome`). Bumping these two to their latest versions which no longer depend on `size-of`. 

### Drive-by changes

- bump `starknet` 0.15 -> 0.17 and `cainome` 0.8 -> 0.10.1
- bump `rust-toolchain` to 1.91
- other minor fixes to make everything compile and tests pass

### Related issues

None

### Backward compatibility

Yes

### Testing

N/A
