### PR TITLE
feat(infra): add compatible igp upgrade script

### DIFF
--- a/.changeset/neat-igp-upgrades.md
+++ b/.changeset/neat-igp-upgrades.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The compare-versions dependency was moved to the workspace catalog, and contract-version utility helpers were exported for infra reuse.
+The compare-versions dependency was moved to the workspace catalog.

--- a/.changeset/neat-igp-upgrades.md
+++ b/.changeset/neat-igp-upgrades.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The compare-versions dependency was moved to the workspace catalog.

--- a/.changeset/neat-igp-upgrades.md
+++ b/.changeset/neat-igp-upgrades.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The compare-versions dependency was moved to the workspace catalog.
+The compare-versions dependency was moved to the workspace catalog, and contract-version utility helpers were exported for infra reuse.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1471,6 +1471,9 @@ importers:
       chalk:
         specifier: 'catalog:'
         version: 5.6.2
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ catalogs:
     chalk:
       specifier: ^5.3.0
       version: 5.6.2
+    compare-versions:
+      specifier: ^6.1.1
+      version: 6.1.1
     cosmjs-types:
       specifier: ^0.9.0
       version: 0.9.0
@@ -1472,7 +1475,7 @@ importers:
         specifier: 'catalog:'
         version: 5.6.2
       compare-versions:
-        specifier: ^6.1.1
+        specifier: 'catalog:'
         version: 6.1.1
       deep-object-diff:
         specifier: ^1.1.9
@@ -2248,7 +2251,7 @@ importers:
         specifier: 'catalog:'
         version: 0.7.0
       compare-versions:
-        specifier: ^6.1.1
+        specifier: 'catalog:'
         version: 6.1.1
       cosmjs-types:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ catalog:
   yaml: 2.4.5
   lodash-es: ^4.17.21
   borsh: ^0.7.0
+  compare-versions: ^6.1.1
   dotenv: ^10.0.0
   asn1.js: ^5.4.1
   uuid: ^10.0.0

--- a/typescript/infra/.gitignore
+++ b/typescript/infra/.gitignore
@@ -7,6 +7,7 @@ deployment-plan.yaml
 deployment-plans/
 test/outputs
 safe-tx-output/
+igp-upgrade-output/
 config/environments/test/core/
 config/environments/test/igp/
 config/environments/test/ism/

--- a/typescript/infra/.gitignore
+++ b/typescript/infra/.gitignore
@@ -11,6 +11,5 @@ igp-upgrade-output/
 config/environments/test/core/
 config/environments/test/igp/
 config/environments/test/ism/
-safe-tx-output/
 safe-tx-parse-results*
 squads-tx-parse-results*

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -80,7 +80,7 @@
     "borsh": "catalog:",
     "bs58": "^6.0.0",
     "chalk": "catalog:",
-    "compare-versions": "^6.1.1",
+    "compare-versions": "catalog:",
     "deep-object-diff": "^1.1.9",
     "dotenv": "catalog:",
     "json-stable-stringify": "^1.1.1",

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -80,6 +80,7 @@
     "borsh": "catalog:",
     "bs58": "^6.0.0",
     "chalk": "catalog:",
+    "compare-versions": "^6.1.1",
     "deep-object-diff": "^1.1.9",
     "dotenv": "catalog:",
     "json-stable-stringify": "^1.1.1",

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -51,10 +51,11 @@ import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
-import { GOVERNOR_MAX_BATCH_SIZE } from '../../src/govern/HyperlaneAppGovernor.js';
+import { GOVERNOR_MAX_BATCH_SIZE } from '../../src/govern/constants.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
 import { Role } from '../../src/roles.js';
 import { logTable } from '../../src/utils/log.js';
+import { getTimelockLogBlockRange } from '../../src/utils/timelock.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
   getArgs,
@@ -70,10 +71,9 @@ const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
 // Timelock upgrade idempotency needs log scanning because CREATE deployments
 // change the implementation address in the scheduled calldata across reruns.
-// Keep chunks below common provider log limits; widen manually if an older
-// still-pending operation must be detected.
+// The per-query block range comes from the same conservative timelock helper
+// used by the pending-timelock scripts.
 const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
-const TIMELOCK_LOG_CHUNK_BLOCKS = 50_000;
 
 type UpgradeCall = {
   to: Address;
@@ -106,6 +106,13 @@ type SafeCallGroup = {
   calls: UpgradeCall[];
   batchIndex?: number;
   batchCount?: number;
+};
+
+type IcaCallGroup = {
+  destination: ChainName;
+  governanceType: GovernanceType;
+  owner: Address;
+  calls: UpgradeCall[];
 };
 
 type ProposalResult = {
@@ -343,12 +350,14 @@ export function callMatchesTimelockIdempotency({
 }
 
 async function getExistingTimelockOperation({
+  chain,
   provider,
   timelock,
   call,
   idempotency,
   currentOperationId,
 }: {
+  chain: ChainName;
   provider: ethers.providers.Provider;
   timelock: ReturnType<typeof TimelockController__factory.connect>;
   call: UpgradeCall;
@@ -369,15 +378,13 @@ async function getExistingTimelockOperation({
   const latestBlock = await provider.getBlockNumber();
   const fromBlock = Math.max(0, latestBlock - TIMELOCK_LOOKBACK_BLOCKS);
   const eventFilter = timelock.filters.CallScheduled();
+  const logBlockRange = getTimelockLogBlockRange(chain);
   for (
     let startBlock = fromBlock;
     startBlock <= latestBlock;
-    startBlock += TIMELOCK_LOG_CHUNK_BLOCKS + 1
+    startBlock += logBlockRange + 1
   ) {
-    const endBlock = Math.min(
-      latestBlock,
-      startBlock + TIMELOCK_LOG_CHUNK_BLOCKS,
-    );
+    const endBlock = Math.min(latestBlock, startBlock + logBlockRange);
     const logs = await timelock.queryFilter(eventFilter, startBlock, endBlock);
     for (const log of logs) {
       const { id, target, value, data } = log.args;
@@ -459,6 +466,67 @@ function addSafeCall(
     safeAddress,
     calls: [call],
   });
+}
+
+function getIcaCallGroupKey({
+  destination,
+  governanceType,
+  owner,
+}: {
+  destination: ChainName;
+  governanceType: GovernanceType;
+  owner: Address;
+}) {
+  return `${destination}:${governanceType}:${owner}`;
+}
+
+function addIcaCall(
+  groups: Map<string, IcaCallGroup>,
+  destination: ChainName,
+  governanceType: GovernanceType,
+  owner: Address,
+  call: UpgradeCall,
+) {
+  const key = getIcaCallGroupKey({ destination, governanceType, owner });
+  const existing = groups.get(key);
+  if (existing) {
+    existing.calls.push(call);
+    return;
+  }
+
+  groups.set(key, {
+    destination,
+    governanceType,
+    owner,
+    calls: [call],
+  });
+}
+
+async function assertIcaOwner({
+  ica,
+  destination,
+  governanceType,
+  ownerAddress,
+}: {
+  ica: InterchainAccount;
+  destination: ChainName;
+  governanceType: GovernanceType;
+  ownerAddress: Address;
+}) {
+  const owner = getGovernanceSafes(governanceType)[ETHEREUM_CHAIN];
+  assert(
+    owner,
+    `No ${governanceType} Safe configured on ${ETHEREUM_CHAIN}; cannot propose ICA call for ${destination}`,
+  );
+
+  const expectedIca = await ica.getAccount(destination, {
+    origin: ETHEREUM_CHAIN,
+    owner,
+  });
+  assert(
+    eqAddress(expectedIca, ownerAddress),
+    `[${destination}] expected ${governanceType} ICA ${expectedIca}, but owner is ${ownerAddress}`,
+  );
 }
 
 function toUpgradeCall(
@@ -549,6 +617,7 @@ export function getUpgradeTargetImplementation({
       return decodedImplementation;
     }
   } catch {
+    // Not a ProxyAdmin.upgrade call; callers use undefined as a non-match.
     return undefined;
   }
 
@@ -597,6 +666,7 @@ async function getGovernedCallOwner({
 
 async function routeGovernedCall({
   groups,
+  icaGroups,
   ica,
   chain,
   call,
@@ -604,6 +674,7 @@ async function routeGovernedCall({
   timelockIdempotency,
 }: {
   groups: Map<string, SafeCallGroup>;
+  icaGroups: Map<string, IcaCallGroup>;
   ica: InterchainAccount;
   chain: ChainName;
   call: UpgradeCall;
@@ -639,17 +710,16 @@ async function routeGovernedCall({
           governanceType,
         };
       }
-      await addIcaSafeCall({
-        groups,
+      await assertIcaOwner({
         ica,
         destination: chain,
         governanceType,
-        innerCall: call,
-        expectedRemoteOwner: ownerAddress,
+        ownerAddress,
       });
+      addIcaCall(icaGroups, chain, governanceType, ownerAddress, call);
       return {
         status: 'queued',
-        detail: `queued ${governanceType} ICA tx from ethereum: ${call.description}`,
+        detail: `queued ${governanceType} ICA inner tx from ethereum: ${call.description}`,
         ownerType,
         governanceType,
       };
@@ -761,6 +831,66 @@ async function addIcaSafeCall({
   });
 }
 
+async function flushIcaCallGroups({
+  safeGroups,
+  icaGroups,
+  ica,
+}: {
+  safeGroups: Map<string, SafeCallGroup>;
+  icaGroups: Map<string, IcaCallGroup>;
+  ica: InterchainAccount;
+}) {
+  for (const group of icaGroups.values()) {
+    const safes = getGovernanceSafes(group.governanceType);
+    const owner = safes[ETHEREUM_CHAIN];
+    assert(
+      owner,
+      `No ${group.governanceType} Safe configured on ${ETHEREUM_CHAIN}; cannot propose ICA call for ${group.destination}`,
+    );
+
+    const accountConfig = {
+      origin: ETHEREUM_CHAIN,
+      owner,
+    };
+    const innerCalls = group.calls.map((call) => ({
+      to: call.to,
+      data: call.data,
+      value: call.value.toString(),
+    }));
+    const gasLimit = await ica.estimateIcaHandleGas({
+      origin: ETHEREUM_CHAIN,
+      destination: group.destination,
+      innerCalls,
+      config: accountConfig,
+    });
+    const hookMetadata = formatStandardHookMetadata({
+      gasLimit: gasLimit.toBigInt(),
+      refundAddress: accountConfig.owner,
+    });
+    const callRemote = await ica.getCallRemote({
+      chain: ETHEREUM_CHAIN,
+      destination: group.destination,
+      innerCalls,
+      config: accountConfig,
+      hookMetadata,
+    });
+
+    assert(
+      callRemote.to && callRemote.data,
+      `[${group.destination}] could not build ICA callRemote transaction`,
+    );
+
+    addSafeCall(safeGroups, ETHEREUM_CHAIN, group.governanceType, {
+      to: callRemote.to,
+      data: callRemote.data,
+      value: callRemote.value ?? BigNumber.from(0),
+      description: `ICA ${group.destination}: ${group.calls.length} ordered tx(s): ${group.calls
+        .map((call) => call.description)
+        .join('; ')}`,
+    });
+  }
+}
+
 async function routeTimelockCall({
   groups,
   ica,
@@ -801,6 +931,7 @@ async function routeTimelockCall({
   );
 
   const existingOperation = await getExistingTimelockOperation({
+    chain,
     provider,
     timelock,
     call: innerCall,
@@ -1130,6 +1261,7 @@ async function main() {
   );
   const ica = InterchainAccount.fromAddressesMap(icaAddresses, multiProvider);
   const safeGroups = new Map<string, SafeCallGroup>();
+  const icaGroups = new Map<string, IcaCallGroup>();
   const plans: ChainPlan[] = [];
 
   for (const chain of targetChains) {
@@ -1288,6 +1420,7 @@ async function main() {
         );
         const route = await routeGovernedCall({
           groups: safeGroups,
+          icaGroups,
           ica,
           chain,
           call: upgradeCall,
@@ -1369,6 +1502,7 @@ async function main() {
         });
         const route = await routeGovernedCall({
           groups: safeGroups,
+          icaGroups,
           ica,
           chain,
           call,
@@ -1427,6 +1561,12 @@ async function main() {
       });
     }
   }
+
+  await flushIcaCallGroups({
+    safeGroups,
+    icaGroups,
+    ica,
+  });
 
   const groups = splitSafeCallGroups([...safeGroups.values()]);
   const runDir = join(

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -21,7 +21,6 @@ import {
 import {
   Address,
   assert,
-  bytes32ToAddress,
   eqAddress,
   formatStandardHookMetadata,
   isEVMLike,
@@ -29,23 +28,23 @@ import {
 } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 import { BigNumber, ethers } from 'ethers';
+import { compareVersions } from 'compare-versions';
 
 import { Contexts } from '../../config/contexts.js';
 import {
   getGovernanceIcas,
   getGovernanceSafes,
-  getGovernanceTimelocks,
 } from '../../config/environments/mainnet3/governance/utils.js';
 import { getEnvAddresses } from '../../config/registry.js';
 import {
-  legacyEthIcaRouter,
-  legacyIcaChainRouters,
+  chainsToSkip,
+  legacyIcaChains,
   legacyIgpChains,
 } from '../../src/config/chain.js';
+import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
-import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { getEnvironmentDirectory } from '../../src/paths.js';
 import { logTable } from '../../src/utils/log.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
@@ -91,6 +90,15 @@ type SafeCallGroup = {
   calls: UpgradeCall[];
 };
 
+type ProposalResult = {
+  chain: ChainName;
+  governanceType: GovernanceType;
+  safeAddress: Address;
+  status: 'proposed' | 'error' | 'skipped';
+  detail: string;
+  hashes?: string[];
+};
+
 type VerificationArtifact = {
   name: string;
   address: Address;
@@ -102,22 +110,8 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function compareSemver(a: string, b: string): number {
-  const aParts = a.split('.').map((part) => parseInt(part, 10));
-  const bParts = b.split('.').map((part) => parseInt(part, 10));
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aPart = aParts[i] ?? 0;
-    const bPart = bParts[i] ?? 0;
-    if (aPart !== bPart) return aPart > bPart ? 1 : -1;
-  }
-  return 0;
-}
-
-function getImplementationAddress(
-  chain: ChainName,
-  implementations: ChainMap<Address>,
-): Address | undefined {
-  return implementations[chain];
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function getImplementationAddressesFromVerificationArtifacts(
@@ -154,6 +148,34 @@ function getImplementationAddressesFromVerificationArtifacts(
   return implementations;
 }
 
+function getImplementationAddressOverrides(
+  filepath: string,
+  supportedChains: Set<ChainName>,
+): ChainMap<Address> {
+  const rawOverrides = readJson<unknown>(filepath);
+  assert(isRecord(rawOverrides), `${filepath} must contain a JSON object`);
+
+  const overrides: ChainMap<Address> = {};
+  for (const [chain, value] of Object.entries(rawOverrides)) {
+    assert(
+      supportedChains.has(chain),
+      `${filepath} contains unsupported chain ${chain}`,
+    );
+    assert(typeof value === 'string', `${filepath} ${chain} must be a string`);
+    assert(
+      ethers.utils.isAddress(value),
+      `${filepath} ${chain} is not an EVM address: ${value}`,
+    );
+    assert(
+      !eqAddress(value, ethers.constants.AddressZero),
+      `${filepath} ${chain} implementation is zero address`,
+    );
+    overrides[chain] = value;
+  }
+
+  return overrides;
+}
+
 async function getCurrentVersion(
   chain: ChainName,
   provider: ethers.providers.Provider,
@@ -170,6 +192,40 @@ async function getCurrentVersion(
     );
     return undefined;
   }
+}
+
+async function assertTargetImplementation({
+  chain,
+  provider,
+  targetImplementation,
+}: {
+  chain: ChainName;
+  provider: ethers.providers.Provider;
+  targetImplementation: Address;
+}): Promise<void> {
+  assert(
+    ethers.utils.isAddress(targetImplementation),
+    `[${chain}] target implementation is not an EVM address: ${targetImplementation}`,
+  );
+  assert(
+    !eqAddress(targetImplementation, ethers.constants.AddressZero),
+    `[${chain}] target implementation is zero address`,
+  );
+
+  const code = await provider.getCode(targetImplementation);
+  assert(
+    code !== '0x',
+    `[${chain}] target implementation ${targetImplementation} has no deployed code`,
+  );
+
+  const targetVersion = await PackageVersioned__factory.connect(
+    targetImplementation,
+    provider,
+  ).PACKAGE_VERSION();
+  assert(
+    targetVersion === CONTRACTS_PACKAGE_VERSION,
+    `[${chain}] target implementation ${targetImplementation} exposes PACKAGE_VERSION ${targetVersion}, expected ${CONTRACTS_PACKAGE_VERSION}`,
+  );
 }
 
 async function assertCancunCompatible(
@@ -272,13 +328,6 @@ async function addIcaSafeCall({
   const accountConfig = {
     origin: ETHEREUM_CHAIN,
     owner,
-    ...(legacyIcaChainRouters[destination]
-      ? {
-          localRouter: legacyEthIcaRouter,
-          routerOverride:
-            legacyIcaChainRouters[destination].interchainAccountRouter,
-        }
-      : {}),
   };
   const expectedIca = await ica.getAccount(destination, accountConfig);
   const ownerAddress =
@@ -305,10 +354,9 @@ async function addIcaSafeCall({
     innerCalls,
     config: accountConfig,
   });
-  const refundAddress = bytes32ToAddress(accountConfig.owner);
   const hookMetadata = formatStandardHookMetadata({
     gasLimit: gasLimit.toBigInt(),
-    refundAddress,
+    refundAddress: accountConfig.owner,
   });
   const callRemote = await ica.getCallRemote({
     chain: ETHEREUM_CHAIN,
@@ -431,7 +479,8 @@ async function writeSafeBatchFiles({
   groups: SafeCallGroup[];
   multiProvider: Parameters<typeof EV5GnosisSafeTxBuilder.create>[0];
   runDir: string;
-}) {
+}): Promise<Set<string>> {
+  const rawFallbackGroupKeys = new Set<string>();
   for (const group of groups) {
     let builder: EV5GnosisSafeTxBuilder;
     try {
@@ -441,6 +490,9 @@ async function writeSafeBatchFiles({
         safeAddress: group.safeAddress,
       });
     } catch (error) {
+      rawFallbackGroupKeys.add(
+        getSafeGroupKey(group.chain, group.governanceType),
+      );
       const filepath = join(
         runDir,
         `${group.chain}-${group.governanceType}.raw.json`,
@@ -448,6 +500,7 @@ async function writeSafeBatchFiles({
       mkdirSync(dirname(filepath), { recursive: true });
       await writeAndFormatJsonAtPath(filepath, {
         chain: group.chain,
+        chainId: multiProvider.getEvmChainId(group.chain),
         safeAddress: group.safeAddress,
         governanceType: group.governanceType,
         note: 'Raw calldata. NOT a Safe Transaction Builder file (no usable tx service for this chain); submit manually.',
@@ -483,6 +536,7 @@ async function writeSafeBatchFiles({
       `[${group.chain}] wrote ${group.governanceType} Safe batch ${filepath}`,
     );
   }
+  return rawFallbackGroupKeys;
 }
 
 async function proposeSafeGroups({
@@ -491,24 +545,48 @@ async function proposeSafeGroups({
 }: {
   groups: SafeCallGroup[];
   multiProvider: Parameters<typeof SafeMultiSend.initialize>[0];
-}) {
+}): Promise<ProposalResult[]> {
+  const results: ProposalResult[] = [];
   for (const group of groups) {
-    const safeMultiSend = await SafeMultiSend.initialize(
-      multiProvider,
-      group.chain,
-      group.safeAddress,
-    );
-    const hashes = await safeMultiSend.sendTransactions(
-      group.calls.map((call) => ({
-        to: call.to,
-        data: call.data,
-        value: call.value,
-      })),
-    );
-    rootLogger.info(
-      `[${group.chain}] proposed ${group.calls.length} ${group.governanceType} tx(s): ${hashes.join(', ')}`,
-    );
+    try {
+      const safeMultiSend = await SafeMultiSend.initialize(
+        multiProvider,
+        group.chain,
+        group.safeAddress,
+      );
+      const hashes = await safeMultiSend.sendTransactions(
+        group.calls.map((call) => ({
+          to: call.to,
+          data: call.data,
+          value: call.value,
+        })),
+      );
+      results.push({
+        chain: group.chain,
+        governanceType: group.governanceType,
+        safeAddress: group.safeAddress,
+        status: 'proposed',
+        detail: `proposed ${group.calls.length} tx(s)`,
+        hashes,
+      });
+      rootLogger.info(
+        `[${group.chain}] proposed ${group.calls.length} ${group.governanceType} tx(s): ${hashes.join(', ')}`,
+      );
+    } catch (error) {
+      const detail = formatError(error);
+      results.push({
+        chain: group.chain,
+        governanceType: group.governanceType,
+        safeAddress: group.safeAddress,
+        status: 'error',
+        detail,
+      });
+      rootLogger.error(
+        `[${group.chain}] failed to propose ${group.governanceType} Safe tx(s): ${detail}`,
+      );
+    }
   }
+  return results;
 }
 
 async function main() {
@@ -551,8 +629,13 @@ async function main() {
     !propose || chains?.length || all,
     'Refusing to propose for all compatible chains without --all. Pass --chains or --all.',
   );
+  assert(
+    environment === 'mainnet3',
+    'This script only supports mainnet3 because governance Safe, ICA, and timelock config is imported from mainnet3.',
+  );
 
   const envConfig = getEnvironmentConfig(environment);
+  const supportedChains = new Set(envConfig.supportedChainNames);
   const chainAddresses = getEnvAddresses(environment);
   const implementationAddresses = {
     ...getImplementationAddressesFromVerificationArtifacts(
@@ -560,21 +643,43 @@ async function main() {
       chainAddresses,
     ),
     ...(implementationAddressesFile
-      ? readJson<ChainMap<Address>>(implementationAddressesFile)
+      ? getImplementationAddressOverrides(
+          implementationAddressesFile,
+          supportedChains,
+        )
       : {}),
   };
   const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
+
+  if (requested) {
+    for (const chain of requested) {
+      if (!supportedChains.has(chain)) {
+        rootLogger.warn(
+          `[${chain}] requested but not supported in ${environment}; skipping`,
+        );
+      } else if (legacyIgpChains.includes(chain)) {
+        rootLogger.warn(
+          `[${chain}] requested but in legacyIgpChains; skipping`,
+        );
+      } else if (chainsToSkip.includes(chain)) {
+        rootLogger.warn(`[${chain}] requested but in chainsToSkip; skipping`);
+      }
+    }
+  }
+
   const targetChains = envConfig.supportedChainNames.filter((chain) => {
     if (requested && !requested.has(chain)) return false;
     if (legacyIgpChains.includes(chain)) return false;
+    if (chainsToSkip.includes(chain)) return false;
     return true;
   });
+  const providerChains = Array.from(new Set([...targetChains, ETHEREUM_CHAIN]));
 
   const multiProvider = await envConfig.getMultiProvider(
     context,
     undefined,
     true,
-    targetChains,
+    providerChains,
   );
   const icaAddresses = Object.fromEntries(
     Object.entries(chainAddresses).filter(
@@ -610,10 +715,7 @@ async function main() {
     }
 
     const provider = multiProvider.getProvider(chain);
-    const targetImplementation = getImplementationAddress(
-      chain,
-      implementationAddresses,
-    );
+    const targetImplementation = implementationAddresses[chain];
     try {
       if (!skipEvmPreflight) {
         await assertCancunCompatible(chain, provider);
@@ -633,26 +735,8 @@ async function main() {
         interchainGasPaymaster,
       );
       if (
-        targetImplementation &&
-        eqAddress(currentImplementation, targetImplementation)
-      ) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          targetImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'no change',
-          detail: 'proxy already points at target implementation',
-        });
-        continue;
-      }
-
-      if (
         currentVersion &&
-        compareSemver(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
+        compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
       ) {
         plans.push({
           chain,
@@ -682,6 +766,27 @@ async function main() {
         continue;
       }
 
+      await assertTargetImplementation({
+        chain,
+        provider,
+        targetImplementation,
+      });
+
+      if (eqAddress(currentImplementation, targetImplementation)) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'no change',
+          detail: 'proxy already points at target implementation',
+        });
+        continue;
+      }
+
       const proxyAdminOwner = await Ownable__factory.connect(
         actualProxyAdmin,
         provider,
@@ -707,6 +812,24 @@ async function main() {
           detail = `queued ${governanceType} Safe proposal`;
           break;
         case Owner.ICA:
+          if (legacyIcaChains.includes(chain)) {
+            plans.push({
+              chain,
+              interchainGasPaymaster,
+              currentImplementation,
+              targetImplementation,
+              currentVersion,
+              targetVersion: CONTRACTS_PACKAGE_VERSION,
+              proxyAdmin: actualProxyAdmin,
+              proxyAdminOwner,
+              ownerType,
+              governanceType,
+              status: 'manual',
+              detail:
+                'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls',
+            });
+            continue;
+          }
           await addIcaSafeCall({
             groups: safeGroups,
             ica,
@@ -803,10 +926,45 @@ async function main() {
     OUTPUT_ROOT,
     new Date().toISOString().replace(/[:.]/g, '-'),
   );
-  await writeSafeBatchFiles({ groups, multiProvider, runDir });
+  const rawFallbackGroupKeys = await writeSafeBatchFiles({
+    groups,
+    multiProvider,
+    runDir,
+  });
 
+  const proposalResults: ProposalResult[] = [];
   if (propose) {
-    await proposeSafeGroups({ groups, multiProvider });
+    for (const group of groups) {
+      if (
+        !rawFallbackGroupKeys.has(
+          getSafeGroupKey(group.chain, group.governanceType),
+        )
+      ) {
+        continue;
+      }
+      const detail =
+        'skipped propose because only raw fallback calldata was written; submit manually';
+      proposalResults.push({
+        chain: group.chain,
+        governanceType: group.governanceType,
+        safeAddress: group.safeAddress,
+        status: 'skipped',
+        detail,
+      });
+      rootLogger.warn(`[${group.chain}] ${detail}`);
+    }
+
+    proposalResults.push(
+      ...(await proposeSafeGroups({
+        groups: groups.filter(
+          (group) =>
+            !rawFallbackGroupKeys.has(
+              getSafeGroupKey(group.chain, group.governanceType),
+            ),
+        ),
+        multiProvider,
+      })),
+    );
   }
 
   const output = {
@@ -816,6 +974,7 @@ async function main() {
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
     ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
+    ...(proposalResults.length > 0 ? { proposalResults } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
       governanceType: group.governanceType,
@@ -842,7 +1001,10 @@ async function main() {
       ].join('\n'),
     );
   }
-  if (plans.some((plan) => plan.status === 'error')) {
+  if (
+    plans.some((plan) => plan.status === 'error') ||
+    proposalResults.some((result) => result.status === 'error')
+  ) {
     process.exitCode = 1;
   }
 }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -202,6 +202,24 @@ function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
   return `${chain}:${governanceType}`;
 }
 
+function getPostUpgradeConfigCommand({
+  environment,
+  context,
+  chains,
+}: {
+  environment: string;
+  context: string;
+  chains: ChainName[];
+}) {
+  return [
+    'pnpm --dir typescript/infra exec tsx scripts/deploy.ts',
+    `--environment ${environment}`,
+    `--context ${context}`,
+    '--module igp',
+    `--chains ${chains.join(' ')}`,
+  ].join(' ');
+}
+
 function addSafeCall(
   groups: Map<string, SafeCallGroup>,
   chain: ChainName,
@@ -770,6 +788,17 @@ async function main() {
   }
 
   const groups = [...safeGroups.values()];
+  const queuedUpgradeChains = plans
+    .filter((plan) => plan.status === 'queued')
+    .map((plan) => plan.chain);
+  const postUpgradeConfigCommand =
+    queuedUpgradeChains.length > 0
+      ? getPostUpgradeConfigCommand({
+          environment,
+          context,
+          chains: queuedUpgradeChains,
+        })
+      : undefined;
   const runDir = join(
     OUTPUT_ROOT,
     new Date().toISOString().replace(/[:.]/g, '-'),
@@ -786,6 +815,7 @@ async function main() {
     targetVersion: CONTRACTS_PACKAGE_VERSION,
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
+    ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
       governanceType: group.governanceType,
@@ -802,6 +832,15 @@ async function main() {
 
   if (!propose) {
     rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
+  }
+  if (postUpgradeConfigCommand) {
+    rootLogger.warn(
+      [
+        'After the upgrade transactions execute and any ICA messages relay, immediately apply IGP config.',
+        'The upgraded IGP reads native gas params from new storage slots; until config is applied, native gas payments may be underquoted or zero.',
+        postUpgradeConfigCommand,
+      ].join('\n'),
+    );
   }
   if (plans.some((plan) => plan.status === 'error')) {
     process.exitCode = 1;

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -35,13 +35,10 @@ import { Contexts } from '../../config/contexts.js';
 import {
   getGovernanceIcas,
   getGovernanceSafes,
+  getLegacyGovernanceIcas,
 } from '../../config/environments/mainnet3/governance/utils.js';
 import { getEnvAddresses } from '../../config/registry.js';
-import {
-  chainsToSkip,
-  legacyIcaChains,
-  legacyIgpChains,
-} from '../../src/config/chain.js';
+import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
@@ -883,7 +880,8 @@ async function main() {
           detail = `queued ${governanceType} Safe proposal`;
           break;
         case Owner.ICA:
-          if (legacyIcaChains.includes(chain)) {
+          const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
+          if (legacyIcaOwner && eqAddress(legacyIcaOwner, proxyAdminOwner)) {
             plans.push({
               chain,
               interchainGasPaymaster,

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -68,6 +68,10 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+// Timelock upgrade idempotency needs log scanning because CREATE deployments
+// change the implementation address in the scheduled calldata across reruns.
+// Keep chunks below common provider log limits; widen manually if an older
+// still-pending operation must be detected.
 const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
 const TIMELOCK_LOG_CHUNK_BLOCKS = 50_000;
 
@@ -387,9 +391,6 @@ async function getExistingTimelockOperation({
         })
       ) {
         continue;
-      }
-      if (await timelock.isOperationDone(id)) {
-        return { id, status: 'done' };
       }
       if (
         (await timelock.isOperationPending(id)) ||
@@ -1296,7 +1297,7 @@ async function main() {
             proxyAddress: interchainGasPaymaster,
           },
         });
-        status = route.status === 'done' ? 'error' : route.status;
+        status = route.status === 'done' ? 'skipped' : route.status;
         ownerType = route.ownerType;
         governanceType = route.governanceType;
         routeDetails.push(route.detail);
@@ -1324,7 +1325,7 @@ async function main() {
             status,
             detail:
               route.status === 'done'
-                ? route.detail
+                ? `${route.detail}; upgrade already executed`
                 : `${route.detail}; ${transactions.length - 1} config tx(s) deferred until the timelock upgrade executes`,
             ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
           });

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,10 +1,9 @@
-import { existsSync, mkdirSync } from 'fs';
+import { mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { pathToFileURL } from 'url';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
-  InterchainGasPaymaster__factory,
   Ownable__factory,
   PackageVersioned__factory,
   ProxyAdmin__factory,
@@ -14,21 +13,27 @@ import {
   AnnotatedEV5Transaction,
   ChainMap,
   ChainName,
+  ChainNameOrId,
   EV5GnosisSafeTxBuilder,
+  EvmHookModule,
+  HookType,
+  IgpConfig,
   InterchainAccount,
+  MultiProvider,
   PROPOSER_ROLE,
+  extractIsmAndHookFactoryAddresses,
   proxyAdmin,
   proxyImplementation,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
   assert,
+  deepCopy,
   eqAddress,
   formatStandardHookMetadata,
   isEVMLike,
   rootLogger,
 } from '@hyperlane-xyz/utils';
-import { readJson } from '@hyperlane-xyz/utils/fs';
 import { BigNumber, ethers } from 'ethers';
 import { compareVersions } from 'compare-versions';
 
@@ -38,13 +43,13 @@ import {
   getGovernanceSafes,
   getLegacyGovernanceIcas,
 } from '../../config/environments/mainnet3/governance/utils.js';
+import { DEPLOYER } from '../../config/environments/mainnet3/owners.js';
 import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
-import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
-import { getEnvironmentDirectory } from '../../src/paths.js';
+import { Role } from '../../src/roles.js';
 import { logTable } from '../../src/utils/log.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
@@ -60,7 +65,6 @@ const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
 const MAX_SAFE_BATCH_SIZE = 120;
-const IGP_ARTIFACT_NAME = 'InterchainGasPaymaster';
 
 type UpgradeCall = {
   to: Address;
@@ -80,6 +84,8 @@ type ChainPlan = {
   proxyAdminOwner?: Address;
   ownerType?: Owner | null;
   governanceType?: GovernanceType;
+  transactionCount?: number;
+  simulatedDeployments?: SimulatedDeployment[];
   status: string;
   detail: string;
 };
@@ -102,12 +108,81 @@ type ProposalResult = {
   hashes?: string[];
 };
 
-type VerificationArtifact = {
-  name: string;
+type SimulatedDeployment = {
+  chain: ChainName;
+  contractName: string;
   address: Address;
-  isProxy?: boolean;
-  expectedimplementation?: Address;
+  nonce: number;
 };
+
+class DryRunDeployMultiProvider extends MultiProvider {
+  readonly simulatedDeployments: SimulatedDeployment[] = [];
+  private readonly nextNonces: ChainMap<number> = {};
+
+  constructor(
+    base: MultiProvider,
+    private readonly deployerAddress: Address,
+  ) {
+    super(base.metadata, {
+      ...base.options,
+      providers: base.providers,
+      signers: base.signers,
+    });
+  }
+
+  override async getSignerAddress(_chainNameOrId: ChainNameOrId) {
+    return this.deployerAddress;
+  }
+
+  override async handleDeploy<
+    F extends Parameters<MultiProvider['handleDeploy']>[1],
+  >(
+    chainNameOrId: ChainNameOrId,
+    factory: F,
+    params: Parameters<F['deploy']>,
+  ): Promise<Awaited<ReturnType<F['deploy']>>> {
+    assert(
+      'attach' in factory && typeof factory.attach === 'function',
+      `[${chainNameOrId}] dry-run deployment simulation only supports ethers factories`,
+    );
+
+    const chain = this.getChainName(chainNameOrId);
+    const nonce =
+      this.nextNonces[chain] ??
+      (await this.getProvider(chain).getTransactionCount(this.deployerAddress));
+    this.nextNonces[chain] = nonce + 1;
+
+    const address = ethers.utils.getContractAddress({
+      from: this.deployerAddress,
+      nonce,
+    });
+    const contractName = factory.constructor.name.replace(/__factory$/, '');
+    this.simulatedDeployments.push({
+      chain,
+      contractName,
+      address,
+      nonce,
+    });
+
+    rootLogger.info(
+      `[${chain}] dry-run simulated ${contractName} deployment at ${address} from ${this.deployerAddress} nonce ${nonce}`,
+    );
+
+    const contract = factory.attach(address);
+    Object.defineProperty(contract, 'deployTransaction', {
+      value: factory.getDeployTransaction(...params),
+    });
+    return contract as Awaited<ReturnType<F['deploy']>>;
+  }
+
+  override async handleTx(): Promise<never> {
+    throw new Error('Dry-run deployment simulation attempted to send a tx');
+  }
+
+  override async sendTransaction(): Promise<never> {
+    throw new Error('Dry-run deployment simulation attempted to send a tx');
+  }
+}
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -136,131 +211,6 @@ export function isMissingPackageVersionError(error: unknown): boolean {
     typeof error.message === 'string' &&
     error.message.includes('data="0x"')
   );
-}
-
-function getImplementationAddressesFromVerificationModule({
-  environment,
-  module,
-  chainAddresses,
-}: {
-  environment: DeployEnvironment;
-  module: 'igp' | 'core';
-  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>;
-}): ChainMap<Address> {
-  const filepath = join(
-    getEnvironmentDirectory(environment),
-    module,
-    'verification.json',
-  );
-  if (!existsSync(filepath)) return {};
-
-  const implementations: ChainMap<Address> = {};
-  const artifactsByChain = readJson<ChainMap<VerificationArtifact[]>>(filepath);
-  for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
-    const interchainGasPaymaster =
-      chainAddresses[chain]?.interchainGasPaymaster;
-    if (!interchainGasPaymaster) continue;
-
-    const proxyArtifact = artifacts.find(
-      (artifact) =>
-        artifact.isProxy &&
-        artifact.expectedimplementation &&
-        eqAddress(artifact.address, interchainGasPaymaster),
-    );
-    if (!proxyArtifact?.expectedimplementation) continue;
-    const expectedImplementation = proxyArtifact.expectedimplementation;
-
-    const implementationArtifact = artifacts.find(
-      (artifact) =>
-        artifact.name === IGP_ARTIFACT_NAME &&
-        eqAddress(artifact.address, expectedImplementation),
-    );
-    if (!implementationArtifact) {
-      rootLogger.warn(
-        `[${chain}] ${module}/verification.json proxy target ${expectedImplementation} has no ${IGP_ARTIFACT_NAME} artifact entry; ignoring`,
-      );
-      continue;
-    }
-
-    implementations[chain] = expectedImplementation;
-  }
-
-  return implementations;
-}
-
-export function mergeImplementationAddresses({
-  igpImplementations,
-  coreImplementations,
-}: {
-  igpImplementations: ChainMap<Address>;
-  coreImplementations: ChainMap<Address>;
-}): ChainMap<Address> {
-  const implementations: ChainMap<Address> = { ...igpImplementations };
-
-  for (const [chain, coreImplementation] of Object.entries(
-    coreImplementations,
-  )) {
-    const igpImplementation = igpImplementations[chain];
-    if (!igpImplementation) {
-      implementations[chain] = coreImplementation;
-      continue;
-    }
-    if (!eqAddress(igpImplementation, coreImplementation)) {
-      rootLogger.warn(
-        `[${chain}] igp/core verification implementation mismatch; using igp ${igpImplementation} over core ${coreImplementation}`,
-      );
-    }
-  }
-
-  return implementations;
-}
-
-function getImplementationAddressesFromVerificationArtifacts(
-  environment: DeployEnvironment,
-  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
-): ChainMap<Address> {
-  const igpImplementations = getImplementationAddressesFromVerificationModule({
-    environment,
-    module: 'igp',
-    chainAddresses,
-  });
-  const coreImplementations = getImplementationAddressesFromVerificationModule({
-    environment,
-    module: 'core',
-    chainAddresses,
-  });
-  return mergeImplementationAddresses({
-    igpImplementations,
-    coreImplementations,
-  });
-}
-
-export function getImplementationAddressOverrides(
-  filepath: string,
-  supportedChains: Set<ChainName>,
-): ChainMap<Address> {
-  const rawOverrides = readJson<unknown>(filepath);
-  assert(isRecord(rawOverrides), `${filepath} must contain a JSON object`);
-
-  const overrides: ChainMap<Address> = {};
-  for (const [chain, value] of Object.entries(rawOverrides)) {
-    assert(
-      supportedChains.has(chain),
-      `${filepath} contains unsupported chain ${chain}`,
-    );
-    assert(typeof value === 'string', `${filepath} ${chain} must be a string`);
-    assert(
-      ethers.utils.isAddress(value),
-      `${filepath} ${chain} is not an EVM address: ${value}`,
-    );
-    assert(
-      !eqAddress(value, ethers.constants.AddressZero),
-      `${filepath} ${chain} implementation is zero address`,
-    );
-    overrides[chain] = value;
-  }
-
-  return overrides;
 }
 
 async function getCurrentVersion(
@@ -297,52 +247,6 @@ function isVersionAtLeastTarget({
       { cause: error },
     );
   }
-}
-
-async function assertTargetImplementation({
-  chain,
-  provider,
-  targetImplementation,
-}: {
-  chain: ChainName;
-  provider: ethers.providers.Provider;
-  targetImplementation: Address;
-}): Promise<void> {
-  assert(
-    ethers.utils.isAddress(targetImplementation),
-    `[${chain}] target implementation is not an EVM address: ${targetImplementation}`,
-  );
-  assert(
-    !eqAddress(targetImplementation, ethers.constants.AddressZero),
-    `[${chain}] target implementation is zero address`,
-  );
-
-  const code = await provider.getCode(targetImplementation);
-  assert(
-    code !== '0x',
-    `[${chain}] target implementation ${targetImplementation} has no deployed code`,
-  );
-  const igpInterface = InterchainGasPaymaster__factory.createInterface();
-  for (const signature of [
-    'quoteGasPayment(uint32,uint256)',
-    'payForGas(bytes32,uint32,uint256,address)',
-    'setDestinationGasConfigs',
-  ]) {
-    const selector = igpInterface.getSighash(signature);
-    assert(
-      code.toLowerCase().includes(selector.slice(2).toLowerCase()),
-      `[${chain}] target implementation ${targetImplementation} is missing IGP selector ${signature}`,
-    );
-  }
-
-  const targetVersion = await PackageVersioned__factory.connect(
-    targetImplementation,
-    provider,
-  ).PACKAGE_VERSION();
-  assert(
-    targetVersion === CONTRACTS_PACKAGE_VERSION,
-    `[${chain}] target implementation ${targetImplementation} exposes PACKAGE_VERSION ${targetVersion}, expected ${CONTRACTS_PACKAGE_VERSION}`,
-  );
 }
 
 async function assertProxyAdmin({
@@ -417,41 +321,6 @@ function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
   return `${chain}:${governanceType}`;
 }
 
-export function getPostUpgradeConfigCommand({
-  environment,
-  context,
-  chains,
-}: {
-  environment: string;
-  context: string;
-  chains: ChainName[];
-}) {
-  return [
-    'pnpm --dir typescript/infra exec tsx scripts/deploy.ts',
-    `--environment ${environment}`,
-    `--context ${context}`,
-    '--module igp',
-    `--chains ${chains.join(' ')}`,
-  ].join(' ');
-}
-
-export function getPostUpgradeConfigChains(plans: ChainPlan[]): ChainName[] {
-  return plans
-    .filter((plan) => plan.status === 'queued')
-    .map((plan) => plan.chain);
-}
-
-export function getTimelockPostExecutionConfigChains(
-  plans: ChainPlan[],
-): ChainName[] {
-  return plans
-    .filter(
-      (plan) =>
-        plan.status === 'timelock queued' || plan.status === 'scheduled',
-    )
-    .map((plan) => plan.chain);
-}
-
 function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
   const splitGroups: SafeCallGroup[] = [];
 
@@ -503,6 +372,227 @@ function addSafeCall(
     safeAddress,
     calls: [call],
   });
+}
+
+function toUpgradeCall(
+  tx: AnnotatedEV5Transaction,
+  defaultDescription: string,
+): UpgradeCall {
+  assert(tx.to, `${defaultDescription} is missing a target address`);
+  assert(tx.data, `${defaultDescription} is missing calldata`);
+
+  return {
+    to: tx.to,
+    data: tx.data,
+    value: tx.value ? BigNumber.from(tx.value) : BigNumber.from(0),
+    description: tx.annotation ?? defaultDescription,
+  };
+}
+
+function getTargetIgpConfig(chain: ChainName, config: IgpConfig): IgpConfig {
+  assert(
+    config.type === HookType.INTERCHAIN_GAS_PAYMASTER,
+    `[${chain}] expected InterchainGasPaymaster config, got ${config.type}`,
+  );
+
+  return {
+    ...deepCopy(config),
+    contractVersion: CONTRACTS_PACKAGE_VERSION,
+    owner: config.ownerOverrides?.interchainGasPaymaster ?? config.owner,
+  };
+}
+
+async function buildHookUpdateTransactions({
+  chain,
+  config,
+  addresses,
+  multiProvider,
+}: {
+  chain: ChainName;
+  config: IgpConfig;
+  addresses: ChainMap<Address>;
+  multiProvider: MultiProvider;
+}): Promise<AnnotatedEV5Transaction[]> {
+  assert(addresses.mailbox, `[${chain}] missing mailbox address`);
+  assert(addresses.proxyAdmin, `[${chain}] missing proxyAdmin address`);
+  assert(
+    addresses.interchainGasPaymaster,
+    `[${chain}] missing interchainGasPaymaster address`,
+  );
+
+  const targetConfig = getTargetIgpConfig(chain, config);
+  const module = new EvmHookModule(multiProvider, {
+    chain,
+    config: targetConfig,
+    addresses: {
+      ...extractIsmAndHookFactoryAddresses(addresses),
+      mailbox: addresses.mailbox,
+      proxyAdmin: addresses.proxyAdmin,
+      deployedHook: addresses.interchainGasPaymaster,
+    },
+  });
+
+  return module.update(deepCopy(targetConfig));
+}
+
+export function getUpgradeTargetImplementation({
+  tx,
+  proxyAdminAddress,
+  proxyAddress,
+}: {
+  tx: AnnotatedEV5Transaction;
+  proxyAdminAddress: Address;
+  proxyAddress: Address;
+}): Address | undefined {
+  if (!tx.to || !tx.data || !eqAddress(tx.to, proxyAdminAddress)) {
+    return undefined;
+  }
+
+  try {
+    const decoded = ProxyAdmin__factory.createInterface().decodeFunctionData(
+      'upgrade',
+      tx.data,
+    );
+    const [decodedProxy, decodedImplementation] = decoded;
+    if (
+      typeof decodedProxy === 'string' &&
+      typeof decodedImplementation === 'string' &&
+      eqAddress(decodedProxy, proxyAddress)
+    ) {
+      return decodedImplementation;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function getDeferredTimelockConfigChains(
+  plans: Pick<ChainPlan, 'chain' | 'status' | 'detail'>[],
+): ChainName[] {
+  return plans
+    .filter(
+      (plan) =>
+        (plan.status === 'timelock queued' || plan.status === 'scheduled') &&
+        plan.detail.includes('config tx(s) deferred'),
+    )
+    .map((plan) => plan.chain);
+}
+
+async function getGovernedCallOwner({
+  chain,
+  provider,
+  call,
+  proxyAdminAddress,
+  proxyAddress,
+  currentImplementation,
+}: {
+  chain: ChainName;
+  provider: ethers.providers.Provider;
+  call: UpgradeCall;
+  proxyAdminAddress: Address;
+  proxyAddress: Address;
+  currentImplementation: Address;
+}): Promise<Address> {
+  if (eqAddress(call.to, proxyAdminAddress)) {
+    return assertProxyAdmin({
+      chain,
+      provider,
+      proxyAdminAddress,
+      proxyAddress,
+      expectedImplementation: currentImplementation,
+    });
+  }
+
+  return Ownable__factory.connect(call.to, provider).owner();
+}
+
+async function routeGovernedCall({
+  groups,
+  ica,
+  chain,
+  call,
+  ownerAddress,
+}: {
+  groups: Map<string, SafeCallGroup>;
+  ica: InterchainAccount;
+  chain: ChainName;
+  call: UpgradeCall;
+  ownerAddress: Address;
+}): Promise<{
+  status: 'queued' | 'timelock queued' | 'scheduled' | 'done' | 'manual';
+  detail: string;
+  ownerType: Owner | null;
+  governanceType: GovernanceType;
+}> {
+  const { ownerType, governanceType } = await determineGovernanceType(
+    chain,
+    ownerAddress,
+  );
+
+  switch (ownerType) {
+    case Owner.SAFE:
+      addSafeCall(groups, chain, governanceType, call);
+      return {
+        status: 'queued',
+        detail: `queued ${governanceType} Safe tx: ${call.description}`,
+        ownerType,
+        governanceType,
+      };
+    case Owner.ICA:
+      const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
+      if (legacyIcaOwner && eqAddress(legacyIcaOwner, ownerAddress)) {
+        return {
+          status: 'manual',
+          detail: 'owned by a legacy V1 ICA; script only builds V2 ICA calls',
+          ownerType,
+          governanceType,
+        };
+      }
+      await addIcaSafeCall({
+        groups,
+        ica,
+        destination: chain,
+        governanceType,
+        innerCall: call,
+        expectedRemoteOwner: ownerAddress,
+      });
+      return {
+        status: 'queued',
+        detail: `queued ${governanceType} ICA tx from ethereum: ${call.description}`,
+        ownerType,
+        governanceType,
+      };
+    case Owner.TIMELOCK:
+      return {
+        ...(await routeTimelockCall({
+          groups,
+          ica,
+          chain,
+          governanceType,
+          timelockAddress: ownerAddress,
+          innerCall: call,
+        })),
+        ownerType,
+        governanceType,
+      };
+    case Owner.DEPLOYER:
+      return {
+        status: 'manual',
+        detail:
+          'owned by deployer; script does not execute deployer-key governed calls',
+        ownerType,
+        governanceType,
+      };
+    default:
+      return {
+        status: 'manual',
+        detail: `unknown owner ${ownerAddress}`,
+        ownerType,
+        governanceType,
+      };
+  }
 }
 
 async function addIcaSafeCall({
@@ -860,18 +950,12 @@ async function main() {
     outFile,
     propose,
     all,
-    implementationAddressesFile,
     skipEvmPreflight,
   } = await withOutputFile(
     withChains(
       withContext(
         withPropose(
           getArgs()
-            .option('implementationAddressesFile', {
-              type: 'string',
-              describe:
-                'Optional JSON map of chain name to already deployed InterchainGasPaymaster implementation address. Overrides verification artifacts.',
-            })
             .option('all', {
               type: 'boolean',
               default: false,
@@ -904,18 +988,6 @@ async function main() {
   const envConfig = getEnvironmentConfig(environment);
   const supportedChains = new Set(envConfig.supportedChainNames);
   const chainAddresses = getEnvAddresses(environment);
-  const implementationAddresses = {
-    ...getImplementationAddressesFromVerificationArtifacts(
-      environment,
-      chainAddresses,
-    ),
-    ...(implementationAddressesFile
-      ? getImplementationAddressOverrides(
-          implementationAddressesFile,
-          supportedChains,
-        )
-      : {}),
-  };
   const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
 
   if (requested) {
@@ -948,12 +1020,15 @@ async function main() {
   );
   const providerChains = Array.from(new Set([...targetChains, ETHEREUM_CHAIN]));
 
-  const multiProvider = await envConfig.getMultiProvider(
+  const baseMultiProvider = await envConfig.getMultiProvider(
     context,
-    undefined,
+    propose ? Role.Deployer : undefined,
     true,
     providerChains,
   );
+  const multiProvider = propose
+    ? baseMultiProvider
+    : new DryRunDeployMultiProvider(baseMultiProvider, DEPLOYER);
   const icaAddresses = Object.fromEntries(
     Object.entries(chainAddresses).filter(
       ([, addresses]) => !!addresses.interchainAccountRouter,
@@ -988,11 +1063,12 @@ async function main() {
     }
 
     const provider = multiProvider.getProvider(chain);
-    const targetImplementation = implementationAddresses[chain];
+    const config = envConfig.igp[chain];
     try {
       if (!skipEvmPreflight) {
         await assertCancunCompatible(chain, provider);
       }
+      assert(config, `[${chain}] missing IGP config`);
 
       const currentImplementation = await proxyImplementation(
         provider,
@@ -1007,62 +1083,6 @@ async function main() {
         provider,
         interchainGasPaymaster,
       );
-      if (
-        currentVersion &&
-        isVersionAtLeastTarget({
-          chain,
-          currentVersion,
-        })
-      ) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          targetImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'skipped',
-          detail: 'current contract version is already >= target version',
-        });
-        continue;
-      }
-
-      if (!targetImplementation) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'error',
-          detail: 'missing implementation address',
-        });
-        continue;
-      }
-
-      await assertTargetImplementation({
-        chain,
-        provider,
-        targetImplementation,
-      });
-
-      if (eqAddress(currentImplementation, targetImplementation)) {
-        plans.push({
-          chain,
-          interchainGasPaymaster,
-          currentImplementation,
-          targetImplementation,
-          currentVersion,
-          targetVersion: CONTRACTS_PACKAGE_VERSION,
-          proxyAdmin: actualProxyAdmin,
-          status: 'no change',
-          detail: 'proxy already points at target implementation',
-        });
-        continue;
-      }
-
       const proxyAdminOwner = await assertProxyAdmin({
         chain,
         provider,
@@ -1070,108 +1090,30 @@ async function main() {
         proxyAddress: interchainGasPaymaster,
         expectedImplementation: currentImplementation,
       });
-      const { ownerType, governanceType } = await determineGovernanceType(
-        chain,
-        proxyAdminOwner,
-      );
-      const upgradeCall: UpgradeCall = {
-        to: actualProxyAdmin,
-        data: ProxyAdmin__factory.createInterface().encodeFunctionData(
-          'upgrade',
-          [interchainGasPaymaster, targetImplementation],
-        ),
-        value: BigNumber.from(0),
-        description: `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION} implementation ${targetImplementation}`,
-      };
 
-      let detail: string;
-      let status = 'queued';
-      switch (ownerType) {
-        case Owner.SAFE:
-          addSafeCall(safeGroups, chain, governanceType, upgradeCall);
-          detail = `queued ${governanceType} Safe proposal`;
-          break;
-        case Owner.ICA:
-          const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
-          if (legacyIcaOwner && eqAddress(legacyIcaOwner, proxyAdminOwner)) {
-            plans.push({
-              chain,
-              interchainGasPaymaster,
-              currentImplementation,
-              targetImplementation,
-              currentVersion,
-              targetVersion: CONTRACTS_PACKAGE_VERSION,
-              proxyAdmin: actualProxyAdmin,
-              proxyAdminOwner,
-              ownerType,
-              governanceType,
-              status: 'manual',
-              detail:
-                'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls',
-            });
-            continue;
-          }
-          await addIcaSafeCall({
-            groups: safeGroups,
-            ica,
-            destination: chain,
-            governanceType,
-            innerCall: upgradeCall,
-          });
-          detail = `queued ${governanceType} ICA proposal from ethereum`;
-          break;
-        case Owner.TIMELOCK:
-          const timelockRoute = await routeTimelockCall({
-            groups: safeGroups,
-            ica,
-            chain,
-            governanceType,
-            timelockAddress: proxyAdminOwner,
-            innerCall: upgradeCall,
-          });
-          if (timelockRoute.status === 'scheduled') {
-            plans.push({
-              chain,
-              interchainGasPaymaster,
-              currentImplementation,
-              targetImplementation,
-              currentVersion,
-              targetVersion: CONTRACTS_PACKAGE_VERSION,
-              proxyAdmin: actualProxyAdmin,
-              proxyAdminOwner,
-              ownerType,
-              governanceType,
-              status: 'scheduled',
-              detail: timelockRoute.detail,
-            });
-            continue;
-          }
-          if (timelockRoute.status === 'done') {
-            plans.push({
-              chain,
-              interchainGasPaymaster,
-              currentImplementation,
-              targetImplementation,
-              currentVersion,
-              targetVersion: CONTRACTS_PACKAGE_VERSION,
-              proxyAdmin: actualProxyAdmin,
-              proxyAdminOwner,
-              ownerType,
-              governanceType,
-              status: 'error',
-              detail: timelockRoute.detail,
-            });
-            continue;
-          }
-          detail = timelockRoute.detail;
-          status = timelockRoute.status;
-          break;
-        case Owner.DEPLOYER:
+      const implementationUpgradeRequired =
+        !currentVersion ||
+        !isVersionAtLeastTarget({
+          chain,
+          currentVersion,
+        });
+      if (implementationUpgradeRequired) {
+        const { ownerType, governanceType } = await determineGovernanceType(
+          chain,
+          proxyAdminOwner,
+        );
+        const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
+        if (
+          ownerType === Owner.DEPLOYER ||
+          !ownerType ||
+          (ownerType === Owner.ICA &&
+            legacyIcaOwner &&
+            eqAddress(legacyIcaOwner, proxyAdminOwner))
+        ) {
           plans.push({
             chain,
             interchainGasPaymaster,
             currentImplementation,
-            targetImplementation,
             currentVersion,
             targetVersion: CONTRACTS_PACKAGE_VERSION,
             proxyAdmin: actualProxyAdmin,
@@ -1180,10 +1122,89 @@ async function main() {
             governanceType,
             status: 'manual',
             detail:
-              'ProxyAdmin is deployer-owned; script does not execute deployer-key upgrades',
+              ownerType === Owner.ICA
+                ? 'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls'
+                : `ProxyAdmin owner ${proxyAdminOwner} is not routeable`,
           });
           continue;
-        default:
+        }
+      }
+
+      const deploymentsBefore =
+        multiProvider instanceof DryRunDeployMultiProvider
+          ? multiProvider.simulatedDeployments.length
+          : 0;
+      const transactions = await buildHookUpdateTransactions({
+        chain,
+        config,
+        addresses,
+        multiProvider,
+      });
+      const simulatedDeployments =
+        multiProvider instanceof DryRunDeployMultiProvider
+          ? multiProvider.simulatedDeployments.slice(deploymentsBefore)
+          : undefined;
+
+      if (transactions.length === 0) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          proxyAdminOwner,
+          status: 'no change',
+          detail: 'hook module produced no update transactions',
+          ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
+        });
+        continue;
+      }
+
+      const upgradeIndex = transactions.findIndex(
+        (tx) =>
+          !!getUpgradeTargetImplementation({
+            tx,
+            proxyAdminAddress: actualProxyAdmin,
+            proxyAddress: interchainGasPaymaster,
+          }),
+      );
+      const targetImplementation =
+        upgradeIndex >= 0
+          ? getUpgradeTargetImplementation({
+              tx: transactions[upgradeIndex],
+              proxyAdminAddress: actualProxyAdmin,
+              proxyAddress: interchainGasPaymaster,
+            })
+          : undefined;
+
+      const routeDetails: string[] = [];
+      let status = 'queued';
+      let ownerType: Owner | null | undefined;
+      let governanceType: GovernanceType | undefined;
+
+      if (upgradeIndex >= 0) {
+        const upgradeCall = toUpgradeCall(
+          transactions[upgradeIndex],
+          `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION}`,
+        );
+        const route = await routeGovernedCall({
+          groups: safeGroups,
+          ica,
+          chain,
+          call: upgradeCall,
+          ownerAddress: proxyAdminOwner,
+        });
+        status = route.status === 'done' ? 'error' : route.status;
+        ownerType = route.ownerType;
+        governanceType = route.governanceType;
+        routeDetails.push(route.detail);
+
+        if (
+          route.status === 'timelock queued' ||
+          route.status === 'scheduled' ||
+          route.status === 'done'
+        ) {
           plans.push({
             chain,
             interchainGasPaymaster,
@@ -1195,10 +1216,72 @@ async function main() {
             proxyAdminOwner,
             ownerType,
             governanceType,
-            status: 'manual',
-            detail: `unknown ProxyAdmin owner ${proxyAdminOwner}`,
+            transactionCount: 1,
+            status,
+            detail:
+              route.status === 'done'
+                ? route.detail
+                : `${route.detail}; ${transactions.length - 1} config tx(s) deferred until the timelock upgrade executes`,
+            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
           });
           continue;
+        }
+
+        if (route.status === 'manual') {
+          plans.push({
+            chain,
+            interchainGasPaymaster,
+            currentImplementation,
+            targetImplementation,
+            currentVersion,
+            targetVersion: CONTRACTS_PACKAGE_VERSION,
+            proxyAdmin: actualProxyAdmin,
+            proxyAdminOwner,
+            ownerType,
+            governanceType,
+            transactionCount: 1,
+            status,
+            detail: route.detail,
+            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
+          });
+          continue;
+        }
+      }
+
+      for (const [index, transaction] of transactions.entries()) {
+        if (index === upgradeIndex) continue;
+        const call = toUpgradeCall(
+          transaction,
+          `IGP update tx ${index + 1} for ${chain}`,
+        );
+        const ownerAddress = await getGovernedCallOwner({
+          chain,
+          provider,
+          call,
+          proxyAdminAddress: actualProxyAdmin,
+          proxyAddress: interchainGasPaymaster,
+          currentImplementation,
+        });
+        const route = await routeGovernedCall({
+          groups: safeGroups,
+          ica,
+          chain,
+          call,
+          ownerAddress,
+        });
+        ownerType ??= route.ownerType;
+        governanceType ??= route.governanceType;
+        routeDetails.push(route.detail);
+        if (route.status === 'manual' || route.status === 'done') {
+          status = route.status === 'done' ? 'error' : route.status;
+          break;
+        }
+        if (
+          route.status === 'timelock queued' ||
+          route.status === 'scheduled'
+        ) {
+          status = route.status;
+        }
       }
 
       plans.push({
@@ -1212,14 +1295,15 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
+        transactionCount: transactions.length,
         status,
-        detail,
+        detail: routeDetails.join('; '),
+        ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
       });
     } catch (error) {
       plans.push({
         chain,
         interchainGasPaymaster,
-        targetImplementation,
         targetVersion: CONTRACTS_PACKAGE_VERSION,
         status: 'error',
         detail: formatError(error),
@@ -1228,25 +1312,6 @@ async function main() {
   }
 
   const groups = splitSafeCallGroups([...safeGroups.values()]);
-  const queuedUpgradeChains = getPostUpgradeConfigChains(plans);
-  const timelockPostExecutionChains =
-    getTimelockPostExecutionConfigChains(plans);
-  const postUpgradeConfigCommand =
-    queuedUpgradeChains.length > 0
-      ? getPostUpgradeConfigCommand({
-          environment,
-          context,
-          chains: queuedUpgradeChains,
-        })
-      : undefined;
-  const timelockPostExecutionConfigCommand =
-    timelockPostExecutionChains.length > 0
-      ? getPostUpgradeConfigCommand({
-          environment,
-          context,
-          chains: timelockPostExecutionChains,
-        })
-      : undefined;
   const runDir = join(
     OUTPUT_ROOT,
     new Date().toISOString().replace(/[:.]/g, '-'),
@@ -1282,10 +1347,6 @@ async function main() {
     targetVersion: CONTRACTS_PACKAGE_VERSION,
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
-    ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
-    ...(timelockPostExecutionConfigCommand
-      ? { timelockPostExecutionConfigCommand }
-      : {}),
     ...(proposalResults.length > 0 ? { proposalResults } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
@@ -1307,21 +1368,12 @@ async function main() {
   if (!propose) {
     rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
   }
-  if (postUpgradeConfigCommand) {
+  const deferredTimelockChains = getDeferredTimelockConfigChains(plans);
+  if (deferredTimelockChains.length > 0) {
     rootLogger.warn(
       [
-        'After the upgrade transactions execute and any ICA messages relay, immediately apply IGP config.',
-        'The upgraded IGP reads native gas params from new storage slots; until config is applied, native gas payments may be underquoted or zero.',
-        postUpgradeConfigCommand,
-      ].join('\n'),
-    );
-  }
-  if (timelockPostExecutionConfigCommand) {
-    rootLogger.warn(
-      [
-        'After the timelock upgrade operation executes, immediately apply IGP config on these chains.',
-        'Do not run this command after only scheduling the timelock operation.',
-        timelockPostExecutionConfigCommand,
+        `Config txs were deferred for timelock-owned upgrade chain(s): ${deferredTimelockChains.join(', ')}`,
+        'Execute the timelock upgrade first, then rerun this script for those chains to propose the hook-module config txs.',
       ].join('\n'),
     );
   }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,6 +1,5 @@
-import { mkdirSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
-import yargs from 'yargs';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
@@ -46,6 +45,8 @@ import {
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
+import type { DeployEnvironment } from '../../src/config/deploy-environment.js';
+import { getEnvironmentDirectory } from '../../src/paths.js';
 import { logTable } from '../../src/utils/log.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
@@ -90,6 +91,13 @@ type SafeCallGroup = {
   calls: UpgradeCall[];
 };
 
+type VerificationArtifact = {
+  name: string;
+  address: Address;
+  isProxy?: boolean;
+  expectedimplementation?: Address;
+};
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -110,6 +118,40 @@ function getImplementationAddress(
   implementations: ChainMap<Address>,
 ): Address | undefined {
   return implementations[chain];
+}
+
+function getImplementationAddressesFromVerificationArtifacts(
+  environment: DeployEnvironment,
+  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
+): ChainMap<Address> {
+  const implementations: ChainMap<Address> = {};
+  for (const module of ['igp', 'core']) {
+    const filepath = join(
+      getEnvironmentDirectory(environment),
+      module,
+      'verification.json',
+    );
+    if (!existsSync(filepath)) continue;
+
+    const artifactsByChain =
+      readJson<ChainMap<VerificationArtifact[]>>(filepath);
+    for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
+      const interchainGasPaymaster =
+        chainAddresses[chain]?.interchainGasPaymaster;
+      if (!interchainGasPaymaster) continue;
+
+      const proxyArtifact = artifacts.find(
+        (artifact) =>
+          artifact.isProxy &&
+          artifact.expectedimplementation &&
+          eqAddress(artifact.address, interchainGasPaymaster),
+      );
+      if (proxyArtifact?.expectedimplementation) {
+        implementations[chain] = proxyArtifact.expectedimplementation;
+      }
+    }
+  }
+  return implementations;
 }
 
 async function getCurrentVersion(
@@ -469,8 +511,7 @@ async function main() {
             .option('implementationAddressesFile', {
               type: 'string',
               describe:
-                'JSON map of chain name to already deployed InterchainGasPaymaster implementation address',
-              demandOption: true,
+                'Optional JSON map of chain name to already deployed InterchainGasPaymaster implementation address. Overrides verification artifacts.',
             })
             .option('all', {
               type: 'boolean',
@@ -493,10 +534,17 @@ async function main() {
     'Refusing to propose for all compatible chains without --all. Pass --chains or --all.',
   );
 
-  const implementationAddresses = readJson<ChainMap<Address>>(
-    implementationAddressesFile,
-  );
   const envConfig = getEnvironmentConfig(environment);
+  const chainAddresses = getEnvAddresses(environment);
+  const implementationAddresses = {
+    ...getImplementationAddressesFromVerificationArtifacts(
+      environment,
+      chainAddresses,
+    ),
+    ...(implementationAddressesFile
+      ? readJson<ChainMap<Address>>(implementationAddressesFile)
+      : {}),
+  };
   const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
   const targetChains = envConfig.supportedChainNames.filter((chain) => {
     if (requested && !requested.has(chain)) return false;
@@ -510,7 +558,6 @@ async function main() {
     true,
     targetChains,
   );
-  const chainAddresses = getEnvAddresses(environment);
   const icaAddresses = Object.fromEntries(
     Object.entries(chainAddresses).filter(
       ([, addresses]) => !!addresses.interchainAccountRouter,

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
+import { pathToFileURL } from 'url';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
@@ -114,6 +115,27 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function getNestedRecord(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  return isRecord(value[key]) ? value[key] : undefined;
+}
+
+export function isMissingPackageVersionError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+
+  const nestedError = getNestedRecord(error, 'error');
+  const data = typeof error.data === 'string' ? error.data : nestedError?.data;
+  if (error.code === 'CALL_EXCEPTION' && data === '0x') return true;
+
+  return (
+    error.code === 'CALL_EXCEPTION' &&
+    typeof error.message === 'string' &&
+    error.message.includes('data="0x"')
+  );
+}
+
 function getImplementationAddressesFromVerificationArtifacts(
   environment: DeployEnvironment,
   chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
@@ -148,7 +170,7 @@ function getImplementationAddressesFromVerificationArtifacts(
   return implementations;
 }
 
-function getImplementationAddressOverrides(
+export function getImplementationAddressOverrides(
   filepath: string,
   supportedChains: Set<ChainName>,
 ): ChainMap<Address> {
@@ -187,6 +209,7 @@ async function getCurrentVersion(
       provider,
     ).PACKAGE_VERSION();
   } catch (error) {
+    if (!isMissingPackageVersionError(error)) throw error;
     rootLogger.info(
       `[${chain}] IGP does not expose PACKAGE_VERSION: ${formatError(error)}`,
     );
@@ -258,7 +281,7 @@ function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
   return `${chain}:${governanceType}`;
 }
 
-function getPostUpgradeConfigCommand({
+export function getPostUpgradeConfigCommand({
   environment,
   context,
   chains,
@@ -274,6 +297,12 @@ function getPostUpgradeConfigCommand({
     '--module igp',
     `--chains ${chains.join(' ')}`,
   ].join(' ');
+}
+
+export function getPostUpgradeConfigChains(plans: ChainPlan[]): ChainName[] {
+  return plans
+    .filter((plan) => plan.status === 'queued')
+    .map((plan) => plan.chain);
 }
 
 function addSafeCall(
@@ -393,7 +422,7 @@ async function routeTimelockCall({
   governanceType: GovernanceType;
   timelockAddress: Address;
   innerCall: UpgradeCall;
-}): Promise<string> {
+}): Promise<{ status: 'queued' | 'scheduled'; detail: string }> {
   const provider = ica.multiProvider.getProvider(chain);
   const timelock = TimelockController__factory.connect(
     timelockAddress,
@@ -418,7 +447,10 @@ async function routeTimelockCall({
     (await timelock.isOperationReady(operationId)) ||
     (await timelock.isOperationDone(operationId));
   if (isScheduled) {
-    return `timelock operation already scheduled/done: ${operationId}`;
+    return {
+      status: 'scheduled',
+      detail: `timelock operation already scheduled/done: ${operationId}`,
+    };
   }
 
   const scheduleCall: UpgradeCall = {
@@ -461,7 +493,10 @@ async function routeTimelockCall({
     });
   }
 
-  return `timelock operation queued for scheduling: ${operationId}`;
+  return {
+    status: 'queued',
+    detail: `timelock operation queued for scheduling: ${operationId}`,
+  };
 }
 
 function getGovernanceIcaAddress(
@@ -587,6 +622,42 @@ async function proposeSafeGroups({
     }
   }
   return results;
+}
+
+export function splitProposableGroups({
+  groups,
+  rawFallbackGroupKeys,
+}: {
+  groups: SafeCallGroup[];
+  rawFallbackGroupKeys: Set<string>;
+}): {
+  proposableGroups: SafeCallGroup[];
+  skippedProposalResults: ProposalResult[];
+} {
+  const proposableGroups: SafeCallGroup[] = [];
+  const skippedProposalResults: ProposalResult[] = [];
+
+  for (const group of groups) {
+    if (
+      !rawFallbackGroupKeys.has(
+        getSafeGroupKey(group.chain, group.governanceType),
+      )
+    ) {
+      proposableGroups.push(group);
+      continue;
+    }
+
+    skippedProposalResults.push({
+      chain: group.chain,
+      governanceType: group.governanceType,
+      safeAddress: group.safeAddress,
+      status: 'skipped',
+      detail:
+        'skipped propose because only raw fallback calldata was written; submit manually',
+    });
+  }
+
+  return { proposableGroups, skippedProposalResults };
 }
 
 async function main() {
@@ -840,7 +911,7 @@ async function main() {
           detail = `queued ${governanceType} ICA proposal from ethereum`;
           break;
         case Owner.TIMELOCK:
-          detail = await routeTimelockCall({
+          const timelockRoute = await routeTimelockCall({
             groups: safeGroups,
             ica,
             chain,
@@ -848,6 +919,24 @@ async function main() {
             timelockAddress: proxyAdminOwner,
             innerCall: upgradeCall,
           });
+          if (timelockRoute.status === 'scheduled') {
+            plans.push({
+              chain,
+              interchainGasPaymaster,
+              currentImplementation,
+              targetImplementation,
+              currentVersion,
+              targetVersion: CONTRACTS_PACKAGE_VERSION,
+              proxyAdmin: actualProxyAdmin,
+              proxyAdminOwner,
+              ownerType,
+              governanceType,
+              status: 'scheduled',
+              detail: timelockRoute.detail,
+            });
+            continue;
+          }
+          detail = timelockRoute.detail;
           break;
         case Owner.DEPLOYER:
           plans.push({
@@ -911,9 +1000,7 @@ async function main() {
   }
 
   const groups = [...safeGroups.values()];
-  const queuedUpgradeChains = plans
-    .filter((plan) => plan.status === 'queued')
-    .map((plan) => plan.chain);
+  const queuedUpgradeChains = getPostUpgradeConfigChains(plans);
   const postUpgradeConfigCommand =
     queuedUpgradeChains.length > 0
       ? getPostUpgradeConfigCommand({
@@ -934,34 +1021,18 @@ async function main() {
 
   const proposalResults: ProposalResult[] = [];
   if (propose) {
-    for (const group of groups) {
-      if (
-        !rawFallbackGroupKeys.has(
-          getSafeGroupKey(group.chain, group.governanceType),
-        )
-      ) {
-        continue;
-      }
-      const detail =
-        'skipped propose because only raw fallback calldata was written; submit manually';
-      proposalResults.push({
-        chain: group.chain,
-        governanceType: group.governanceType,
-        safeAddress: group.safeAddress,
-        status: 'skipped',
-        detail,
-      });
-      rootLogger.warn(`[${group.chain}] ${detail}`);
+    const { proposableGroups, skippedProposalResults } = splitProposableGroups({
+      groups,
+      rawFallbackGroupKeys,
+    });
+    proposalResults.push(...skippedProposalResults);
+    for (const result of skippedProposalResults) {
+      rootLogger.warn(`[${result.chain}] ${result.detail}`);
     }
 
     proposalResults.push(
       ...(await proposeSafeGroups({
-        groups: groups.filter(
-          (group) =>
-            !rawFallbackGroupKeys.has(
-              getSafeGroupKey(group.chain, group.governanceType),
-            ),
-        ),
+        groups: proposableGroups,
         multiProvider,
       })),
     );
@@ -1009,7 +1080,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  rootLogger.error(error);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    rootLogger.error(error);
+    process.exit(1);
+  });
+}

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'url';
 
 import {
   CONTRACTS_PACKAGE_VERSION,
+  InterchainGasPaymaster__factory,
   Ownable__factory,
   PackageVersioned__factory,
   ProxyAdmin__factory,
@@ -58,6 +59,8 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+const MAX_SAFE_BATCH_SIZE = 120;
+const IGP_ARTIFACT_NAME = 'InterchainGasPaymaster';
 
 type UpgradeCall = {
   to: Address;
@@ -86,6 +89,8 @@ type SafeCallGroup = {
   governanceType: GovernanceType;
   safeAddress: Address;
   calls: UpgradeCall[];
+  batchIndex?: number;
+  batchCount?: number;
 };
 
 type ProposalResult = {
@@ -109,7 +114,7 @@ function formatError(error: unknown): string {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function getNestedRecord(
@@ -133,38 +138,101 @@ export function isMissingPackageVersionError(error: unknown): boolean {
   );
 }
 
+function getImplementationAddressesFromVerificationModule({
+  environment,
+  module,
+  chainAddresses,
+}: {
+  environment: DeployEnvironment;
+  module: 'igp' | 'core';
+  chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>;
+}): ChainMap<Address> {
+  const filepath = join(
+    getEnvironmentDirectory(environment),
+    module,
+    'verification.json',
+  );
+  if (!existsSync(filepath)) return {};
+
+  const implementations: ChainMap<Address> = {};
+  const artifactsByChain = readJson<ChainMap<VerificationArtifact[]>>(filepath);
+  for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
+    const interchainGasPaymaster =
+      chainAddresses[chain]?.interchainGasPaymaster;
+    if (!interchainGasPaymaster) continue;
+
+    const proxyArtifact = artifacts.find(
+      (artifact) =>
+        artifact.isProxy &&
+        artifact.expectedimplementation &&
+        eqAddress(artifact.address, interchainGasPaymaster),
+    );
+    if (!proxyArtifact?.expectedimplementation) continue;
+    const expectedImplementation = proxyArtifact.expectedimplementation;
+
+    const implementationArtifact = artifacts.find(
+      (artifact) =>
+        artifact.name === IGP_ARTIFACT_NAME &&
+        eqAddress(artifact.address, expectedImplementation),
+    );
+    if (!implementationArtifact) {
+      rootLogger.warn(
+        `[${chain}] ${module}/verification.json proxy target ${expectedImplementation} has no ${IGP_ARTIFACT_NAME} artifact entry; ignoring`,
+      );
+      continue;
+    }
+
+    implementations[chain] = expectedImplementation;
+  }
+
+  return implementations;
+}
+
+export function mergeImplementationAddresses({
+  igpImplementations,
+  coreImplementations,
+}: {
+  igpImplementations: ChainMap<Address>;
+  coreImplementations: ChainMap<Address>;
+}): ChainMap<Address> {
+  const implementations: ChainMap<Address> = { ...igpImplementations };
+
+  for (const [chain, coreImplementation] of Object.entries(
+    coreImplementations,
+  )) {
+    const igpImplementation = igpImplementations[chain];
+    if (!igpImplementation) {
+      implementations[chain] = coreImplementation;
+      continue;
+    }
+    if (!eqAddress(igpImplementation, coreImplementation)) {
+      rootLogger.warn(
+        `[${chain}] igp/core verification implementation mismatch; using igp ${igpImplementation} over core ${coreImplementation}`,
+      );
+    }
+  }
+
+  return implementations;
+}
+
 function getImplementationAddressesFromVerificationArtifacts(
   environment: DeployEnvironment,
   chainAddresses: ChainMap<{ interchainGasPaymaster?: Address }>,
 ): ChainMap<Address> {
-  const implementations: ChainMap<Address> = {};
-  for (const module of ['igp', 'core']) {
-    const filepath = join(
-      getEnvironmentDirectory(environment),
-      module,
-      'verification.json',
-    );
-    if (!existsSync(filepath)) continue;
-
-    const artifactsByChain =
-      readJson<ChainMap<VerificationArtifact[]>>(filepath);
-    for (const [chain, artifacts] of Object.entries(artifactsByChain)) {
-      const interchainGasPaymaster =
-        chainAddresses[chain]?.interchainGasPaymaster;
-      if (!interchainGasPaymaster) continue;
-
-      const proxyArtifact = artifacts.find(
-        (artifact) =>
-          artifact.isProxy &&
-          artifact.expectedimplementation &&
-          eqAddress(artifact.address, interchainGasPaymaster),
-      );
-      if (proxyArtifact?.expectedimplementation) {
-        implementations[chain] = proxyArtifact.expectedimplementation;
-      }
-    }
-  }
-  return implementations;
+  const igpImplementations = getImplementationAddressesFromVerificationModule({
+    environment,
+    module: 'igp',
+    chainAddresses,
+  });
+  const coreImplementations = getImplementationAddressesFromVerificationModule({
+    environment,
+    module: 'core',
+    chainAddresses,
+  });
+  return mergeImplementationAddresses({
+    igpImplementations,
+    coreImplementations,
+  });
 }
 
 export function getImplementationAddressOverrides(
@@ -214,6 +282,23 @@ async function getCurrentVersion(
   }
 }
 
+function isVersionAtLeastTarget({
+  chain,
+  currentVersion,
+}: {
+  chain: ChainName;
+  currentVersion: string;
+}): boolean {
+  try {
+    return compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0;
+  } catch (error) {
+    throw new Error(
+      `[${chain}] current PACKAGE_VERSION ${currentVersion} is not valid semver`,
+      { cause: error },
+    );
+  }
+}
+
 async function assertTargetImplementation({
   chain,
   provider,
@@ -237,6 +322,18 @@ async function assertTargetImplementation({
     code !== '0x',
     `[${chain}] target implementation ${targetImplementation} has no deployed code`,
   );
+  const igpInterface = InterchainGasPaymaster__factory.createInterface();
+  for (const signature of [
+    'quoteGasPayment(uint32,uint256)',
+    'payForGas(bytes32,uint32,uint256,address)',
+    'setDestinationGasConfigs',
+  ]) {
+    const selector = igpInterface.getSighash(signature);
+    assert(
+      code.toLowerCase().includes(selector.slice(2).toLowerCase()),
+      `[${chain}] target implementation ${targetImplementation} is missing IGP selector ${signature}`,
+    );
+  }
 
   const targetVersion = await PackageVersioned__factory.connect(
     targetImplementation,
@@ -246,6 +343,48 @@ async function assertTargetImplementation({
     targetVersion === CONTRACTS_PACKAGE_VERSION,
     `[${chain}] target implementation ${targetImplementation} exposes PACKAGE_VERSION ${targetVersion}, expected ${CONTRACTS_PACKAGE_VERSION}`,
   );
+}
+
+async function assertProxyAdmin({
+  chain,
+  provider,
+  proxyAdminAddress,
+  proxyAddress,
+  expectedImplementation,
+}: {
+  chain: ChainName;
+  provider: ethers.providers.Provider;
+  proxyAdminAddress: Address;
+  proxyAddress: Address;
+  expectedImplementation: Address;
+}): Promise<Address> {
+  const code = await provider.getCode(proxyAdminAddress);
+  assert(
+    code !== '0x',
+    `[${chain}] ProxyAdmin ${proxyAdminAddress} has no deployed code`,
+  );
+
+  const proxyAdminInterface = ProxyAdmin__factory.createInterface();
+  const implementationResult = await provider.call({
+    to: proxyAdminAddress,
+    data: proxyAdminInterface.encodeFunctionData('getProxyImplementation', [
+      proxyAddress,
+    ]),
+  });
+  const [proxyAdminImplementation] = proxyAdminInterface.decodeFunctionResult(
+    'getProxyImplementation',
+    implementationResult,
+  );
+  assert(
+    typeof proxyAdminImplementation === 'string',
+    `[${chain}] ProxyAdmin ${proxyAdminAddress} returned invalid implementation for ${proxyAddress}`,
+  );
+  assert(
+    eqAddress(proxyAdminImplementation, expectedImplementation),
+    `[${chain}] ProxyAdmin ${proxyAdminAddress} reports implementation ${proxyAdminImplementation}, expected ${expectedImplementation}`,
+  );
+
+  return Ownable__factory.connect(proxyAdminAddress, provider).owner();
 }
 
 async function assertCancunCompatible(
@@ -300,6 +439,43 @@ export function getPostUpgradeConfigChains(plans: ChainPlan[]): ChainName[] {
   return plans
     .filter((plan) => plan.status === 'queued')
     .map((plan) => plan.chain);
+}
+
+export function getTimelockPostExecutionConfigChains(
+  plans: ChainPlan[],
+): ChainName[] {
+  return plans
+    .filter(
+      (plan) =>
+        plan.status === 'timelock queued' || plan.status === 'scheduled',
+    )
+    .map((plan) => plan.chain);
+}
+
+function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
+  const splitGroups: SafeCallGroup[] = [];
+
+  for (const group of groups) {
+    if (group.calls.length <= MAX_SAFE_BATCH_SIZE) {
+      splitGroups.push(group);
+      continue;
+    }
+
+    const batchCount = Math.ceil(group.calls.length / MAX_SAFE_BATCH_SIZE);
+    for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+      splitGroups.push({
+        ...group,
+        calls: group.calls.slice(
+          batchIndex * MAX_SAFE_BATCH_SIZE,
+          (batchIndex + 1) * MAX_SAFE_BATCH_SIZE,
+        ),
+        batchIndex: batchIndex + 1,
+        batchCount,
+      });
+    }
+  }
+
+  return splitGroups;
 }
 
 function addSafeCall(
@@ -419,7 +595,10 @@ async function routeTimelockCall({
   governanceType: GovernanceType;
   timelockAddress: Address;
   innerCall: UpgradeCall;
-}): Promise<{ status: 'queued' | 'scheduled'; detail: string }> {
+}): Promise<{
+  status: 'timelock queued' | 'scheduled' | 'done';
+  detail: string;
+}> {
   const provider = ica.multiProvider.getProvider(chain);
   const timelock = TimelockController__factory.connect(
     timelockAddress,
@@ -439,10 +618,17 @@ async function routeTimelockCall({
     salt,
   );
 
+  const isDone = await timelock.isOperationDone(operationId);
+  if (isDone) {
+    return {
+      status: 'done',
+      detail: `timelock operation already executed but proxy still points at the old implementation: ${operationId}`,
+    };
+  }
+
   const isScheduled =
     (await timelock.isOperationPending(operationId)) ||
-    (await timelock.isOperationReady(operationId)) ||
-    (await timelock.isOperationDone(operationId));
+    (await timelock.isOperationReady(operationId));
   if (isScheduled) {
     return {
       status: 'scheduled',
@@ -491,7 +677,7 @@ async function routeTimelockCall({
   }
 
   return {
-    status: 'queued',
+    status: 'timelock queued',
     detail: `timelock operation queued for scheduling: ${operationId}`,
   };
 }
@@ -525,9 +711,12 @@ async function writeSafeBatchFiles({
       rawFallbackGroupKeys.add(
         getSafeGroupKey(group.chain, group.governanceType),
       );
+      const batchSuffix = group.batchCount
+        ? `-${group.batchIndex}-of-${group.batchCount}`
+        : '';
       const filepath = join(
         runDir,
-        `${group.chain}-${group.governanceType}.raw.json`,
+        `${group.chain}-${group.governanceType}${batchSuffix}.raw.json`,
       );
       mkdirSync(dirname(filepath), { recursive: true });
       await writeAndFormatJsonAtPath(filepath, {
@@ -535,6 +724,9 @@ async function writeSafeBatchFiles({
         chainId: multiProvider.getEvmChainId(group.chain),
         safeAddress: group.safeAddress,
         governanceType: group.governanceType,
+        ...(group.batchIndex && group.batchCount
+          ? { batchIndex: group.batchIndex, batchCount: group.batchCount }
+          : {}),
         note: 'Raw calldata. NOT a Safe Transaction Builder file (no usable tx service for this chain); submit manually.',
         error: formatError(error),
         transactions: group.calls.map((call) => ({
@@ -558,9 +750,12 @@ async function writeSafeBatchFiles({
       chainId,
     }));
     const batch = await builder.submit(...txs);
+    const batchSuffix = group.batchCount
+      ? `-${group.batchIndex}-of-${group.batchCount}`
+      : '';
     const filepath = join(
       runDir,
-      `${group.chain}-${group.governanceType}.json`,
+      `${group.chain}-${group.governanceType}${batchSuffix}.json`,
     );
     mkdirSync(dirname(filepath), { recursive: true });
     await writeAndFormatJsonAtPath(filepath, batch);
@@ -701,6 +896,10 @@ async function main() {
     environment === 'mainnet3',
     'This script only supports mainnet3 because governance Safe, ICA, and timelock config is imported from mainnet3.',
   );
+  assert(
+    !skipEvmPreflight,
+    'mainnet3 IGP upgrades require the Cancun/PUSH0 preflight; remove --skipEvmPreflight.',
+  );
 
   const envConfig = getEnvironmentConfig(environment);
   const supportedChains = new Set(envConfig.supportedChainNames);
@@ -741,6 +940,12 @@ async function main() {
     if (chainsToSkip.includes(chain)) return false;
     return true;
   });
+  assert(
+    targetChains.length > 0,
+    requested
+      ? 'No requested chains remain after supported/legacy/skip filtering.'
+      : 'No compatible chains remain after legacy/skip filtering.',
+  );
   const providerChains = Array.from(new Set([...targetChains, ETHEREUM_CHAIN]));
 
   const multiProvider = await envConfig.getMultiProvider(
@@ -804,7 +1009,10 @@ async function main() {
       );
       if (
         currentVersion &&
-        compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
+        isVersionAtLeastTarget({
+          chain,
+          currentVersion,
+        })
       ) {
         plans.push({
           chain,
@@ -855,10 +1063,13 @@ async function main() {
         continue;
       }
 
-      const proxyAdminOwner = await Ownable__factory.connect(
-        actualProxyAdmin,
+      const proxyAdminOwner = await assertProxyAdmin({
+        chain,
         provider,
-      ).owner();
+        proxyAdminAddress: actualProxyAdmin,
+        proxyAddress: interchainGasPaymaster,
+        expectedImplementation: currentImplementation,
+      });
       const { ownerType, governanceType } = await determineGovernanceType(
         chain,
         proxyAdminOwner,
@@ -874,6 +1085,7 @@ async function main() {
       };
 
       let detail: string;
+      let status = 'queued';
       switch (ownerType) {
         case Owner.SAFE:
           addSafeCall(safeGroups, chain, governanceType, upgradeCall);
@@ -934,7 +1146,25 @@ async function main() {
             });
             continue;
           }
+          if (timelockRoute.status === 'done') {
+            plans.push({
+              chain,
+              interchainGasPaymaster,
+              currentImplementation,
+              targetImplementation,
+              currentVersion,
+              targetVersion: CONTRACTS_PACKAGE_VERSION,
+              proxyAdmin: actualProxyAdmin,
+              proxyAdminOwner,
+              ownerType,
+              governanceType,
+              status: 'error',
+              detail: timelockRoute.detail,
+            });
+            continue;
+          }
           detail = timelockRoute.detail;
+          status = timelockRoute.status;
           break;
         case Owner.DEPLOYER:
           plans.push({
@@ -982,7 +1212,7 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
-        status: 'queued',
+        status,
         detail,
       });
     } catch (error) {
@@ -997,14 +1227,24 @@ async function main() {
     }
   }
 
-  const groups = [...safeGroups.values()];
+  const groups = splitSafeCallGroups([...safeGroups.values()]);
   const queuedUpgradeChains = getPostUpgradeConfigChains(plans);
+  const timelockPostExecutionChains =
+    getTimelockPostExecutionConfigChains(plans);
   const postUpgradeConfigCommand =
     queuedUpgradeChains.length > 0
       ? getPostUpgradeConfigCommand({
           environment,
           context,
           chains: queuedUpgradeChains,
+        })
+      : undefined;
+  const timelockPostExecutionConfigCommand =
+    timelockPostExecutionChains.length > 0
+      ? getPostUpgradeConfigCommand({
+          environment,
+          context,
+          chains: timelockPostExecutionChains,
         })
       : undefined;
   const runDir = join(
@@ -1043,12 +1283,18 @@ async function main() {
     mode: propose ? 'propose' : 'dry-run',
     legacyIgpChains,
     ...(postUpgradeConfigCommand ? { postUpgradeConfigCommand } : {}),
+    ...(timelockPostExecutionConfigCommand
+      ? { timelockPostExecutionConfigCommand }
+      : {}),
     ...(proposalResults.length > 0 ? { proposalResults } : {}),
     safeGroups: groups.map((group) => ({
       chain: group.chain,
       governanceType: group.governanceType,
       safeAddress: group.safeAddress,
       transactionCount: group.calls.length,
+      ...(group.batchIndex && group.batchCount
+        ? { batchIndex: group.batchIndex, batchCount: group.batchCount }
+        : {}),
     })),
     plans,
   };
@@ -1070,9 +1316,19 @@ async function main() {
       ].join('\n'),
     );
   }
+  if (timelockPostExecutionConfigCommand) {
+    rootLogger.warn(
+      [
+        'After the timelock upgrade operation executes, immediately apply IGP config on these chains.',
+        'Do not run this command after only scheduling the timelock operation.',
+        timelockPostExecutionConfigCommand,
+      ].join('\n'),
+    );
+  }
   if (
     plans.some((plan) => plan.status === 'error') ||
-    proposalResults.some((result) => result.status === 'error')
+    proposalResults.some((result) => result.status === 'error') ||
+    (propose && rawFallbackGroupKeys.size > 0)
   ) {
     process.exitCode = 1;
   }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -26,6 +26,10 @@ import {
   proxyImplementation,
 } from '@hyperlane-xyz/sdk';
 import {
+  isMissingSelectorCallException,
+  isValidContractVersion,
+} from '@hyperlane-xyz/sdk/utils/contract';
+import {
   Address,
   assert,
   deepCopy,
@@ -35,7 +39,6 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 import { BigNumber, ethers } from 'ethers';
-import { compareVersions } from 'compare-versions';
 
 import { Contexts } from '../../config/contexts.js';
 import {
@@ -48,6 +51,7 @@ import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
+import { GOVERNOR_MAX_BATCH_SIZE } from '../../src/govern/HyperlaneAppGovernor.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
 import { Role } from '../../src/roles.js';
 import { logTable } from '../../src/utils/log.js';
@@ -64,7 +68,8 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
-const MAX_SAFE_BATCH_SIZE = 120;
+const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
+const TIMELOCK_LOG_CHUNK_BLOCKS = 50_000;
 
 type UpgradeCall = {
   to: Address;
@@ -188,29 +193,8 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function getNestedRecord(
-  value: Record<string, unknown>,
-  key: string,
-): Record<string, unknown> | undefined {
-  return isRecord(value[key]) ? value[key] : undefined;
-}
-
 export function isMissingPackageVersionError(error: unknown): boolean {
-  if (!isRecord(error)) return false;
-
-  const nestedError = getNestedRecord(error, 'error');
-  const data = typeof error.data === 'string' ? error.data : nestedError?.data;
-  if (error.code === 'CALL_EXCEPTION' && data === '0x') return true;
-
-  return (
-    error.code === 'CALL_EXCEPTION' &&
-    typeof error.message === 'string' &&
-    error.message.includes('data="0x"')
-  );
+  return isMissingSelectorCallException(error);
 }
 
 async function getCurrentVersion(
@@ -233,20 +217,11 @@ async function getCurrentVersion(
 }
 
 function isVersionAtLeastTarget({
-  chain,
   currentVersion,
 }: {
-  chain: ChainName;
   currentVersion: string;
 }): boolean {
-  try {
-    return compareVersions(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0;
-  } catch (error) {
-    throw new Error(
-      `[${chain}] current PACKAGE_VERSION ${currentVersion} is not valid semver`,
-      { cause: error },
-    );
-  }
+  return isValidContractVersion(currentVersion, CONTRACTS_PACKAGE_VERSION);
 }
 
 async function assertProxyAdmin({
@@ -309,12 +284,123 @@ async function assertCancunCompatible(
   }
 }
 
-function timelockSalt(chain: ChainName, callData: string): string {
+type TimelockOperationMatch = {
+  id: string;
+  status: 'scheduled' | 'done';
+};
+
+type TimelockIdempotency = {
+  type: 'proxyAdminUpgrade';
+  proxyAddress: Address;
+};
+
+function timelockSalt(chain: ChainName, description: string): string {
   return ethers.utils.keccak256(
     ethers.utils.toUtf8Bytes(
-      `hyperlane-igp-upgrade:${chain}:${CONTRACTS_PACKAGE_VERSION}:${callData}`,
+      `hyperlane-igp-upgrade:${chain}:${CONTRACTS_PACKAGE_VERSION}:${description}`,
     ),
   );
+}
+
+export function callMatchesTimelockIdempotency({
+  call,
+  scheduledTarget,
+  scheduledValue,
+  scheduledData,
+  idempotency,
+}: {
+  call: UpgradeCall;
+  scheduledTarget: Address;
+  scheduledValue: BigNumber;
+  scheduledData: string;
+  idempotency?: TimelockIdempotency;
+}): boolean {
+  if (!eqAddress(scheduledTarget, call.to)) return false;
+  if (!scheduledValue.eq(call.value)) return false;
+
+  if (!idempotency) {
+    return scheduledData === call.data;
+  }
+
+  if (idempotency.type === 'proxyAdminUpgrade') {
+    return (
+      getUpgradeTargetImplementation({
+        tx: {
+          to: scheduledTarget,
+          data: scheduledData,
+        },
+        proxyAdminAddress: call.to,
+        proxyAddress: idempotency.proxyAddress,
+      }) !== undefined
+    );
+  }
+
+  return false;
+}
+
+async function getExistingTimelockOperation({
+  provider,
+  timelock,
+  call,
+  idempotency,
+  currentOperationId,
+}: {
+  provider: ethers.providers.Provider;
+  timelock: ReturnType<typeof TimelockController__factory.connect>;
+  call: UpgradeCall;
+  idempotency?: TimelockIdempotency;
+  currentOperationId: string;
+}): Promise<TimelockOperationMatch | undefined> {
+  if (await timelock.isOperationDone(currentOperationId)) {
+    return { id: currentOperationId, status: 'done' };
+  }
+  if (
+    (await timelock.isOperationPending(currentOperationId)) ||
+    (await timelock.isOperationReady(currentOperationId))
+  ) {
+    return { id: currentOperationId, status: 'scheduled' };
+  }
+  if (!idempotency) return undefined;
+
+  const latestBlock = await provider.getBlockNumber();
+  const fromBlock = Math.max(0, latestBlock - TIMELOCK_LOOKBACK_BLOCKS);
+  const eventFilter = timelock.filters.CallScheduled();
+  for (
+    let startBlock = fromBlock;
+    startBlock <= latestBlock;
+    startBlock += TIMELOCK_LOG_CHUNK_BLOCKS + 1
+  ) {
+    const endBlock = Math.min(
+      latestBlock,
+      startBlock + TIMELOCK_LOG_CHUNK_BLOCKS,
+    );
+    const logs = await timelock.queryFilter(eventFilter, startBlock, endBlock);
+    for (const log of logs) {
+      const { id, target, value, data } = log.args;
+      if (
+        !callMatchesTimelockIdempotency({
+          call,
+          scheduledTarget: target,
+          scheduledValue: value,
+          scheduledData: data,
+          idempotency,
+        })
+      ) {
+        continue;
+      }
+      if (await timelock.isOperationDone(id)) {
+        return { id, status: 'done' };
+      }
+      if (
+        (await timelock.isOperationPending(id)) ||
+        (await timelock.isOperationReady(id))
+      ) {
+        return { id, status: 'scheduled' };
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
@@ -325,18 +411,18 @@ function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
   const splitGroups: SafeCallGroup[] = [];
 
   for (const group of groups) {
-    if (group.calls.length <= MAX_SAFE_BATCH_SIZE) {
+    if (group.calls.length <= GOVERNOR_MAX_BATCH_SIZE) {
       splitGroups.push(group);
       continue;
     }
 
-    const batchCount = Math.ceil(group.calls.length / MAX_SAFE_BATCH_SIZE);
+    const batchCount = Math.ceil(group.calls.length / GOVERNOR_MAX_BATCH_SIZE);
     for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
       splitGroups.push({
         ...group,
         calls: group.calls.slice(
-          batchIndex * MAX_SAFE_BATCH_SIZE,
-          (batchIndex + 1) * MAX_SAFE_BATCH_SIZE,
+          batchIndex * GOVERNOR_MAX_BATCH_SIZE,
+          (batchIndex + 1) * GOVERNOR_MAX_BATCH_SIZE,
         ),
         batchIndex: batchIndex + 1,
         batchCount,
@@ -514,12 +600,14 @@ async function routeGovernedCall({
   chain,
   call,
   ownerAddress,
+  timelockIdempotency,
 }: {
   groups: Map<string, SafeCallGroup>;
   ica: InterchainAccount;
   chain: ChainName;
   call: UpgradeCall;
   ownerAddress: Address;
+  timelockIdempotency?: TimelockIdempotency;
 }): Promise<{
   status: 'queued' | 'timelock queued' | 'scheduled' | 'done' | 'manual';
   detail: string;
@@ -573,6 +661,7 @@ async function routeGovernedCall({
           governanceType,
           timelockAddress: ownerAddress,
           innerCall: call,
+          idempotency: timelockIdempotency,
         })),
         ownerType,
         governanceType,
@@ -678,6 +767,7 @@ async function routeTimelockCall({
   governanceType,
   timelockAddress,
   innerCall,
+  idempotency,
 }: {
   groups: Map<string, SafeCallGroup>;
   ica: InterchainAccount;
@@ -685,6 +775,7 @@ async function routeTimelockCall({
   governanceType: GovernanceType;
   timelockAddress: Address;
   innerCall: UpgradeCall;
+  idempotency?: TimelockIdempotency;
 }): Promise<{
   status: 'timelock queued' | 'scheduled' | 'done';
   detail: string;
@@ -695,7 +786,7 @@ async function routeTimelockCall({
     provider,
   );
   const delay = await timelock.getMinDelay();
-  const salt = timelockSalt(chain, innerCall.data);
+  const salt = timelockSalt(chain, innerCall.description);
   const predecessor = ethers.constants.HashZero;
   const targets = [innerCall.to];
   const values = [innerCall.value];
@@ -708,21 +799,23 @@ async function routeTimelockCall({
     salt,
   );
 
-  const isDone = await timelock.isOperationDone(operationId);
-  if (isDone) {
+  const existingOperation = await getExistingTimelockOperation({
+    provider,
+    timelock,
+    call: innerCall,
+    idempotency,
+    currentOperationId: operationId,
+  });
+  if (existingOperation?.status === 'done') {
     return {
       status: 'done',
-      detail: `timelock operation already executed but proxy still points at the old implementation: ${operationId}`,
+      detail: `timelock operation already executed: ${existingOperation.id}`,
     };
   }
-
-  const isScheduled =
-    (await timelock.isOperationPending(operationId)) ||
-    (await timelock.isOperationReady(operationId));
-  if (isScheduled) {
+  if (existingOperation?.status === 'scheduled') {
     return {
       status: 'scheduled',
-      detail: `timelock operation already scheduled/done: ${operationId}`,
+      detail: `timelock operation already scheduled: ${existingOperation.id}`,
     };
   }
 
@@ -1094,7 +1187,6 @@ async function main() {
       const implementationUpgradeRequired =
         !currentVersion ||
         !isVersionAtLeastTarget({
-          chain,
           currentVersion,
         });
       if (implementationUpgradeRequired) {
@@ -1105,7 +1197,7 @@ async function main() {
         const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
         if (
           ownerType === Owner.DEPLOYER ||
-          !ownerType ||
+          ownerType === Owner.UNKNOWN ||
           (ownerType === Owner.ICA &&
             legacyIcaOwner &&
             eqAddress(legacyIcaOwner, proxyAdminOwner))
@@ -1182,6 +1274,11 @@ async function main() {
       let status = 'queued';
       let ownerType: Owner | null | undefined;
       let governanceType: GovernanceType | undefined;
+      let routedTransactionCount = 0;
+      let manualTransactionCount = 0;
+      let doneTransactionCount = 0;
+      let hasTimelockQueued = false;
+      let hasScheduled = false;
 
       if (upgradeIndex >= 0) {
         const upgradeCall = toUpgradeCall(
@@ -1194,11 +1291,18 @@ async function main() {
           chain,
           call: upgradeCall,
           ownerAddress: proxyAdminOwner,
+          timelockIdempotency: {
+            type: 'proxyAdminUpgrade',
+            proxyAddress: interchainGasPaymaster,
+          },
         });
         status = route.status === 'done' ? 'error' : route.status;
         ownerType = route.ownerType;
         governanceType = route.governanceType;
         routeDetails.push(route.detail);
+        if (route.status !== 'done') {
+          routedTransactionCount += 1;
+        }
 
         if (
           route.status === 'timelock queued' ||
@@ -1216,7 +1320,7 @@ async function main() {
             proxyAdminOwner,
             ownerType,
             governanceType,
-            transactionCount: 1,
+            transactionCount: routedTransactionCount,
             status,
             detail:
               route.status === 'done'
@@ -1239,7 +1343,7 @@ async function main() {
             proxyAdminOwner,
             ownerType,
             governanceType,
-            transactionCount: 1,
+            transactionCount: routedTransactionCount,
             status,
             detail: route.detail,
             ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
@@ -1272,16 +1376,28 @@ async function main() {
         ownerType ??= route.ownerType;
         governanceType ??= route.governanceType;
         routeDetails.push(route.detail);
-        if (route.status === 'manual' || route.status === 'done') {
-          status = route.status === 'done' ? 'error' : route.status;
-          break;
+        if (route.status === 'manual') {
+          manualTransactionCount += 1;
+          continue;
         }
-        if (
-          route.status === 'timelock queued' ||
-          route.status === 'scheduled'
-        ) {
-          status = route.status;
+        if (route.status === 'done') {
+          doneTransactionCount += 1;
+          continue;
         }
+
+        routedTransactionCount += 1;
+        hasTimelockQueued ||= route.status === 'timelock queued';
+        hasScheduled ||= route.status === 'scheduled';
+      }
+
+      if (manualTransactionCount > 0) {
+        status = routedTransactionCount > 0 ? 'partial' : 'manual';
+      } else if (hasTimelockQueued) {
+        status = 'timelock queued';
+      } else if (hasScheduled) {
+        status = 'scheduled';
+      } else if (routedTransactionCount === 0 && doneTransactionCount > 0) {
+        status = 'skipped';
       }
 
       plans.push({
@@ -1295,7 +1411,7 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
-        transactionCount: transactions.length,
+        transactionCount: routedTransactionCount,
         status,
         detail: routeDetails.join('; '),
         ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -32,6 +32,7 @@ import {
 import {
   Address,
   assert,
+  concurrentMap,
   deepCopy,
   eqAddress,
   formatStandardHookMetadata,
@@ -624,46 +625,6 @@ export function getUpgradeTargetImplementation({
   return undefined;
 }
 
-export function getDeferredTimelockConfigChains(
-  plans: Pick<ChainPlan, 'chain' | 'status' | 'detail'>[],
-): ChainName[] {
-  return plans
-    .filter(
-      (plan) =>
-        (plan.status === 'timelock queued' || plan.status === 'scheduled') &&
-        plan.detail.includes('config tx(s) deferred'),
-    )
-    .map((plan) => plan.chain);
-}
-
-async function getGovernedCallOwner({
-  chain,
-  provider,
-  call,
-  proxyAdminAddress,
-  proxyAddress,
-  currentImplementation,
-}: {
-  chain: ChainName;
-  provider: ethers.providers.Provider;
-  call: UpgradeCall;
-  proxyAdminAddress: Address;
-  proxyAddress: Address;
-  currentImplementation: Address;
-}): Promise<Address> {
-  if (eqAddress(call.to, proxyAdminAddress)) {
-    return assertProxyAdmin({
-      chain,
-      provider,
-      proxyAdminAddress,
-      proxyAddress,
-      expectedImplementation: currentImplementation,
-    });
-  }
-
-  return Ownable__factory.connect(call.to, provider).owner();
-}
-
 async function routeGovernedCall({
   groups,
   icaGroups,
@@ -1176,6 +1137,7 @@ async function main() {
     propose,
     all,
     skipEvmPreflight,
+    concurrency: chainConcurrency,
   } = await withOutputFile(
     withChains(
       withContext(
@@ -1191,6 +1153,11 @@ async function main() {
               type: 'boolean',
               default: false,
               describe: 'Skip Cancun/PUSH0 eth_call preflight',
+            })
+            .option('concurrency', {
+              type: 'number',
+              default: 8,
+              describe: 'Number of chains to plan concurrently',
             }),
         ),
       ),
@@ -1209,6 +1176,7 @@ async function main() {
     !skipEvmPreflight,
     'mainnet3 IGP upgrades require the Cancun/PUSH0 preflight; remove --skipEvmPreflight.',
   );
+  assert(chainConcurrency > 0, '--concurrency must be greater than 0');
 
   const envConfig = getEnvironmentConfig(environment);
   const supportedChains = new Set(envConfig.supportedChainNames);
@@ -1263,8 +1231,11 @@ async function main() {
   const safeGroups = new Map<string, SafeCallGroup>();
   const icaGroups = new Map<string, IcaCallGroup>();
   const plans: ChainPlan[] = [];
+  const targetChainIndexes = new Map(
+    targetChains.map((chain, index) => [chain, index]),
+  );
 
-  for (const chain of targetChains) {
+  await concurrentMap(chainConcurrency, targetChains, async (chain) => {
     const metadata = multiProvider.getChainMetadata(chain);
     if (!isEVMLike(metadata.protocol)) {
       plans.push({
@@ -1273,7 +1244,7 @@ async function main() {
         status: 'skipped',
         detail: `non-EVM protocol ${metadata.protocol}`,
       });
-      continue;
+      return;
     }
 
     const addresses = chainAddresses[chain];
@@ -1285,7 +1256,7 @@ async function main() {
         status: 'skipped',
         detail: 'missing interchainGasPaymaster in registry',
       });
-      continue;
+      return;
     }
 
     const provider = multiProvider.getProvider(chain);
@@ -1351,13 +1322,15 @@ async function main() {
                 ? 'ProxyAdmin is owned by a legacy V1 ICA; script only builds V2 ICA calls'
                 : `ProxyAdmin owner ${proxyAdminOwner} is not routeable`,
           });
-          continue;
+          return;
         }
       }
 
       const deploymentsBefore =
         multiProvider instanceof DryRunDeployMultiProvider
-          ? multiProvider.simulatedDeployments.length
+          ? multiProvider.simulatedDeployments.filter(
+              (deployment) => deployment.chain === chain,
+            ).length
           : 0;
       const transactions = await buildHookUpdateTransactions({
         chain,
@@ -1367,7 +1340,9 @@ async function main() {
       });
       const simulatedDeployments =
         multiProvider instanceof DryRunDeployMultiProvider
-          ? multiProvider.simulatedDeployments.slice(deploymentsBefore)
+          ? multiProvider.simulatedDeployments
+              .filter((deployment) => deployment.chain === chain)
+              .slice(deploymentsBefore)
           : undefined;
 
       if (transactions.length === 0) {
@@ -1383,7 +1358,7 @@ async function main() {
           detail: 'hook module produced no update transactions',
           ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
         });
-        continue;
+        return;
       }
 
       const upgradeIndex = transactions.findIndex(
@@ -1403,15 +1378,9 @@ async function main() {
             })
           : undefined;
 
-      const routeDetails: string[] = [];
-      let status = 'queued';
       let ownerType: Owner | null | undefined;
       let governanceType: GovernanceType | undefined;
       let routedTransactionCount = 0;
-      let manualTransactionCount = 0;
-      let doneTransactionCount = 0;
-      let hasTimelockQueued = false;
-      let hasScheduled = false;
 
       if (upgradeIndex >= 0) {
         const upgradeCall = toUpgradeCall(
@@ -1430,109 +1399,37 @@ async function main() {
             proxyAddress: interchainGasPaymaster,
           },
         });
-        status = route.status === 'done' ? 'skipped' : route.status;
+        const status = route.status === 'done' ? 'skipped' : route.status;
         ownerType = route.ownerType;
         governanceType = route.governanceType;
-        routeDetails.push(route.detail);
-        if (route.status !== 'done') {
+        if (route.status === 'queued' || route.status === 'timelock queued') {
           routedTransactionCount += 1;
         }
-
-        if (
-          route.status === 'timelock queued' ||
-          route.status === 'scheduled' ||
-          route.status === 'done'
-        ) {
-          plans.push({
-            chain,
-            interchainGasPaymaster,
-            currentImplementation,
-            targetImplementation,
-            currentVersion,
-            targetVersion: CONTRACTS_PACKAGE_VERSION,
-            proxyAdmin: actualProxyAdmin,
-            proxyAdminOwner,
-            ownerType,
-            governanceType,
-            transactionCount: routedTransactionCount,
-            status,
-            detail:
-              route.status === 'done'
-                ? `${route.detail}; upgrade already executed`
-                : `${route.detail}; ${transactions.length - 1} config tx(s) deferred until the timelock upgrade executes`,
-            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
-          });
-          continue;
-        }
-
-        if (route.status === 'manual') {
-          plans.push({
-            chain,
-            interchainGasPaymaster,
-            currentImplementation,
-            targetImplementation,
-            currentVersion,
-            targetVersion: CONTRACTS_PACKAGE_VERSION,
-            proxyAdmin: actualProxyAdmin,
-            proxyAdminOwner,
-            ownerType,
-            governanceType,
-            transactionCount: routedTransactionCount,
-            status,
-            detail: route.detail,
-            ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
-          });
-          continue;
-        }
-      }
-
-      for (const [index, transaction] of transactions.entries()) {
-        if (index === upgradeIndex) continue;
-        const call = toUpgradeCall(
-          transaction,
-          `IGP update tx ${index + 1} for ${chain}`,
-        );
-        const ownerAddress = await getGovernedCallOwner({
+        const configTxCount = transactions.length - 1;
+        plans.push({
           chain,
-          provider,
-          call,
-          proxyAdminAddress: actualProxyAdmin,
-          proxyAddress: interchainGasPaymaster,
+          interchainGasPaymaster,
           currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          proxyAdminOwner,
+          ownerType,
+          governanceType,
+          transactionCount: routedTransactionCount,
+          status,
+          detail: [
+            route.status === 'done'
+              ? `${route.detail}; upgrade already executed`
+              : route.detail,
+            configTxCount > 0
+              ? `${configTxCount} hook-module config tx(s) intentionally not proposed; run deploy.ts -m igp after upgrade execution`
+              : 'run deploy.ts -m igp after upgrade execution to apply/confirm config',
+          ].join('; '),
+          ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
         });
-        const route = await routeGovernedCall({
-          groups: safeGroups,
-          icaGroups,
-          ica,
-          chain,
-          call,
-          ownerAddress,
-        });
-        ownerType ??= route.ownerType;
-        governanceType ??= route.governanceType;
-        routeDetails.push(route.detail);
-        if (route.status === 'manual') {
-          manualTransactionCount += 1;
-          continue;
-        }
-        if (route.status === 'done') {
-          doneTransactionCount += 1;
-          continue;
-        }
-
-        routedTransactionCount += 1;
-        hasTimelockQueued ||= route.status === 'timelock queued';
-        hasScheduled ||= route.status === 'scheduled';
-      }
-
-      if (manualTransactionCount > 0) {
-        status = routedTransactionCount > 0 ? 'partial' : 'manual';
-      } else if (hasTimelockQueued) {
-        status = 'timelock queued';
-      } else if (hasScheduled) {
-        status = 'scheduled';
-      } else if (routedTransactionCount === 0 && doneTransactionCount > 0) {
-        status = 'skipped';
+        return;
       }
 
       plans.push({
@@ -1546,9 +1443,9 @@ async function main() {
         proxyAdminOwner,
         ownerType,
         governanceType,
-        transactionCount: routedTransactionCount,
-        status,
-        detail: routeDetails.join('; '),
+        transactionCount: 0,
+        status: 'no upgrade',
+        detail: `${transactions.length} hook-module config tx(s) intentionally not proposed; run deploy.ts -m igp to apply config`,
         ...(simulatedDeployments?.length ? { simulatedDeployments } : {}),
       });
     } catch (error) {
@@ -1560,7 +1457,12 @@ async function main() {
         detail: formatError(error),
       });
     }
-  }
+  });
+  plans.sort(
+    (a, b) =>
+      (targetChainIndexes.get(a.chain) ?? Number.MAX_SAFE_INTEGER) -
+      (targetChainIndexes.get(b.chain) ?? Number.MAX_SAFE_INTEGER),
+  );
 
   await flushIcaCallGroups({
     safeGroups,
@@ -1625,12 +1527,20 @@ async function main() {
   if (!propose) {
     rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
   }
-  const deferredTimelockChains = getDeferredTimelockConfigChains(plans);
-  if (deferredTimelockChains.length > 0) {
+  const upgradeChains = plans
+    .filter(
+      (plan) =>
+        !!plan.targetImplementation &&
+        ['queued', 'timelock queued', 'scheduled', 'skipped'].includes(
+          plan.status,
+        ),
+    )
+    .map((plan) => plan.chain);
+  if (upgradeChains.length > 0) {
     rootLogger.warn(
       [
-        `Config txs were deferred for timelock-owned upgrade chain(s): ${deferredTimelockChains.join(', ')}`,
-        'Execute the timelock upgrade first, then rerun this script for those chains to propose the hook-module config txs.',
+        `Upgrade-only mode: apply IGP config after upgrade execution for chain(s): ${upgradeChains.join(', ')}`,
+        `pnpm -C typescript/infra exec tsx scripts/deploy.ts -e ${environment} -x ${context} -m igp --chains ${upgradeChains.join(' ')}`,
       ].join('\n'),
     );
   }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -1,0 +1,767 @@
+import { mkdirSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import yargs from 'yargs';
+
+import {
+  CONTRACTS_PACKAGE_VERSION,
+  Ownable__factory,
+  PackageVersioned__factory,
+  ProxyAdmin__factory,
+  TimelockController__factory,
+} from '@hyperlane-xyz/core';
+import {
+  AnnotatedEV5Transaction,
+  ChainMap,
+  ChainName,
+  EV5GnosisSafeTxBuilder,
+  InterchainAccount,
+  PROPOSER_ROLE,
+  proxyAdmin,
+  proxyImplementation,
+} from '@hyperlane-xyz/sdk';
+import {
+  Address,
+  assert,
+  bytes32ToAddress,
+  eqAddress,
+  formatStandardHookMetadata,
+  isEVMLike,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
+import { BigNumber, ethers } from 'ethers';
+
+import { Contexts } from '../../config/contexts.js';
+import {
+  getGovernanceIcas,
+  getGovernanceSafes,
+  getGovernanceTimelocks,
+} from '../../config/environments/mainnet3/governance/utils.js';
+import { getEnvAddresses } from '../../config/registry.js';
+import {
+  legacyEthIcaRouter,
+  legacyIcaChainRouters,
+  legacyIgpChains,
+} from '../../src/config/chain.js';
+import { determineGovernanceType, Owner } from '../../src/governance.js';
+import { GovernanceType } from '../../src/governanceTypes.js';
+import { SafeMultiSend } from '../../src/govern/multisend.js';
+import { logTable } from '../../src/utils/log.js';
+import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
+import {
+  getArgs,
+  withChains,
+  withContext,
+  withOutputFile,
+  withPropose,
+} from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+const ETHEREUM_CHAIN: ChainName = 'ethereum';
+const OUTPUT_ROOT = 'igp-upgrade-output';
+const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+
+type UpgradeCall = {
+  to: Address;
+  data: string;
+  value: BigNumber;
+  description: string;
+};
+
+type ChainPlan = {
+  chain: ChainName;
+  interchainGasPaymaster?: Address;
+  currentImplementation?: Address;
+  targetImplementation?: Address;
+  currentVersion?: string;
+  targetVersion: string;
+  proxyAdmin?: Address;
+  proxyAdminOwner?: Address;
+  ownerType?: Owner | null;
+  governanceType?: GovernanceType;
+  status: string;
+  detail: string;
+};
+
+type SafeCallGroup = {
+  chain: ChainName;
+  governanceType: GovernanceType;
+  safeAddress: Address;
+  calls: UpgradeCall[];
+};
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function compareSemver(a: string, b: string): number {
+  const aParts = a.split('.').map((part) => parseInt(part, 10));
+  const bParts = b.split('.').map((part) => parseInt(part, 10));
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const aPart = aParts[i] ?? 0;
+    const bPart = bParts[i] ?? 0;
+    if (aPart !== bPart) return aPart > bPart ? 1 : -1;
+  }
+  return 0;
+}
+
+function getImplementationAddress(
+  chain: ChainName,
+  implementations: ChainMap<Address>,
+): Address | undefined {
+  return implementations[chain];
+}
+
+async function getCurrentVersion(
+  chain: ChainName,
+  provider: ethers.providers.Provider,
+  igpAddress: Address,
+): Promise<string | undefined> {
+  try {
+    return await PackageVersioned__factory.connect(
+      igpAddress,
+      provider,
+    ).PACKAGE_VERSION();
+  } catch (error) {
+    rootLogger.info(
+      `[${chain}] IGP does not expose PACKAGE_VERSION: ${formatError(error)}`,
+    );
+    return undefined;
+  }
+}
+
+async function assertCancunCompatible(
+  chain: ChainName,
+  provider: ethers.providers.Provider,
+) {
+  try {
+    const result = await provider.call({ data: CANCUN_PROBE_INIT_CODE });
+    assert(
+      result === ethers.constants.HashZero,
+      `[${chain}] Cancun probe returned unexpected data: ${result}`,
+    );
+  } catch (error) {
+    throw new Error(
+      `[${chain}] Cancun/PUSH0 preflight failed; keep this chain in legacyIgpChains or override only after manual verification`,
+      { cause: error },
+    );
+  }
+}
+
+function timelockSalt(chain: ChainName, callData: string): string {
+  return ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes(
+      `hyperlane-igp-upgrade:${chain}:${CONTRACTS_PACKAGE_VERSION}:${callData}`,
+    ),
+  );
+}
+
+function getSafeGroupKey(chain: ChainName, governanceType: GovernanceType) {
+  return `${chain}:${governanceType}`;
+}
+
+function addSafeCall(
+  groups: Map<string, SafeCallGroup>,
+  chain: ChainName,
+  governanceType: GovernanceType,
+  call: UpgradeCall,
+) {
+  const safeAddress = getGovernanceSafes(governanceType)[chain];
+  assert(
+    safeAddress,
+    `No ${governanceType} Safe configured on ${chain}; cannot propose ${call.description}`,
+  );
+
+  const key = getSafeGroupKey(chain, governanceType);
+  const existing = groups.get(key);
+  if (existing) {
+    existing.calls.push(call);
+    return;
+  }
+
+  groups.set(key, {
+    chain,
+    governanceType,
+    safeAddress,
+    calls: [call],
+  });
+}
+
+async function addIcaSafeCall({
+  groups,
+  ica,
+  destination,
+  governanceType,
+  innerCall,
+  expectedRemoteOwner,
+}: {
+  groups: Map<string, SafeCallGroup>;
+  ica: InterchainAccount;
+  destination: ChainName;
+  governanceType: GovernanceType;
+  innerCall: UpgradeCall;
+  expectedRemoteOwner?: Address;
+}) {
+  const safes = getGovernanceSafes(governanceType);
+  const owner = safes[ETHEREUM_CHAIN];
+  assert(
+    owner,
+    `No ${governanceType} Safe configured on ${ETHEREUM_CHAIN}; cannot propose ICA call for ${destination}`,
+  );
+
+  const accountConfig = {
+    origin: ETHEREUM_CHAIN,
+    owner,
+    ...(legacyIcaChainRouters[destination]
+      ? {
+          localRouter: legacyEthIcaRouter,
+          routerOverride:
+            legacyIcaChainRouters[destination].interchainAccountRouter,
+        }
+      : {}),
+  };
+  const expectedIca = await ica.getAccount(destination, accountConfig);
+  const ownerAddress =
+    expectedRemoteOwner ??
+    (await Ownable__factory.connect(
+      innerCall.to,
+      ica.multiProvider.getProvider(destination),
+    ).owner());
+  assert(
+    eqAddress(expectedIca, ownerAddress),
+    `[${destination}] expected ${governanceType} ICA ${expectedIca}, but ${innerCall.to} owner is ${ownerAddress}`,
+  );
+
+  const innerCalls = [
+    {
+      to: innerCall.to,
+      data: innerCall.data,
+      value: innerCall.value.toString(),
+    },
+  ];
+  const gasLimit = await ica.estimateIcaHandleGas({
+    origin: ETHEREUM_CHAIN,
+    destination,
+    innerCalls,
+    config: accountConfig,
+  });
+  const refundAddress = bytes32ToAddress(accountConfig.owner);
+  const hookMetadata = formatStandardHookMetadata({
+    gasLimit: gasLimit.toBigInt(),
+    refundAddress,
+  });
+  const callRemote = await ica.getCallRemote({
+    chain: ETHEREUM_CHAIN,
+    destination,
+    innerCalls,
+    config: accountConfig,
+    hookMetadata,
+  });
+
+  assert(
+    callRemote.to && callRemote.data,
+    `[${destination}] could not build ICA callRemote transaction`,
+  );
+
+  addSafeCall(groups, ETHEREUM_CHAIN, governanceType, {
+    to: callRemote.to,
+    data: callRemote.data,
+    value: callRemote.value ?? BigNumber.from(0),
+    description: `ICA ${destination}: ${innerCall.description}`,
+  });
+}
+
+async function routeTimelockCall({
+  groups,
+  ica,
+  chain,
+  governanceType,
+  timelockAddress,
+  innerCall,
+}: {
+  groups: Map<string, SafeCallGroup>;
+  ica: InterchainAccount;
+  chain: ChainName;
+  governanceType: GovernanceType;
+  timelockAddress: Address;
+  innerCall: UpgradeCall;
+}): Promise<string> {
+  const provider = ica.multiProvider.getProvider(chain);
+  const timelock = TimelockController__factory.connect(
+    timelockAddress,
+    provider,
+  );
+  const delay = await timelock.getMinDelay();
+  const salt = timelockSalt(chain, innerCall.data);
+  const predecessor = ethers.constants.HashZero;
+  const targets = [innerCall.to];
+  const values = [innerCall.value];
+  const payloads = [innerCall.data];
+  const operationId = await timelock.hashOperationBatch(
+    targets,
+    values,
+    payloads,
+    predecessor,
+    salt,
+  );
+
+  const isScheduled =
+    (await timelock.isOperationPending(operationId)) ||
+    (await timelock.isOperationReady(operationId)) ||
+    (await timelock.isOperationDone(operationId));
+  if (isScheduled) {
+    return `timelock operation already scheduled/done: ${operationId}`;
+  }
+
+  const scheduleCall: UpgradeCall = {
+    to: timelockAddress,
+    data: timelock.interface.encodeFunctionData('scheduleBatch', [
+      targets,
+      values,
+      payloads,
+      predecessor,
+      salt,
+      delay,
+    ]),
+    value: BigNumber.from(0),
+    description: `Schedule timelock operation ${operationId}: ${innerCall.description}`,
+  };
+
+  const proposer =
+    chain === ETHEREUM_CHAIN
+      ? getGovernanceSafes(governanceType)[ETHEREUM_CHAIN]
+      : getGovernanceIcaAddress(chain, governanceType);
+  assert(
+    proposer,
+    `[${chain}] no ${governanceType} proposer address available for timelock ${timelockAddress}`,
+  );
+  assert(
+    await timelock.hasRole(PROPOSER_ROLE, proposer),
+    `[${chain}] ${proposer} does not have PROPOSER_ROLE on timelock ${timelockAddress}`,
+  );
+
+  if (chain === ETHEREUM_CHAIN) {
+    addSafeCall(groups, ETHEREUM_CHAIN, governanceType, scheduleCall);
+  } else {
+    await addIcaSafeCall({
+      groups,
+      ica,
+      destination: chain,
+      governanceType,
+      innerCall: scheduleCall,
+      expectedRemoteOwner: proposer,
+    });
+  }
+
+  return `timelock operation queued for scheduling: ${operationId}`;
+}
+
+function getGovernanceIcaAddress(
+  chain: ChainName,
+  governanceType: GovernanceType,
+): Address | undefined {
+  return getGovernanceIcas(governanceType)[chain];
+}
+
+async function writeSafeBatchFiles({
+  groups,
+  multiProvider,
+  runDir,
+}: {
+  groups: SafeCallGroup[];
+  multiProvider: Parameters<typeof EV5GnosisSafeTxBuilder.create>[0];
+  runDir: string;
+}) {
+  for (const group of groups) {
+    let builder: EV5GnosisSafeTxBuilder;
+    try {
+      builder = await EV5GnosisSafeTxBuilder.create(multiProvider, {
+        version: '1.0',
+        chain: group.chain,
+        safeAddress: group.safeAddress,
+      });
+    } catch (error) {
+      const filepath = join(
+        runDir,
+        `${group.chain}-${group.governanceType}.raw.json`,
+      );
+      mkdirSync(dirname(filepath), { recursive: true });
+      await writeAndFormatJsonAtPath(filepath, {
+        chain: group.chain,
+        safeAddress: group.safeAddress,
+        governanceType: group.governanceType,
+        note: 'Raw calldata. NOT a Safe Transaction Builder file (no usable tx service for this chain); submit manually.',
+        error: formatError(error),
+        transactions: group.calls.map((call) => ({
+          to: call.to,
+          value: call.value.toString(),
+          data: call.data,
+          description: call.description,
+        })),
+      });
+      rootLogger.warn(
+        `[${group.chain}] wrote raw ${group.governanceType} payload ${basename(filepath)}`,
+      );
+      continue;
+    }
+
+    const chainId = multiProvider.getEvmChainId(group.chain);
+    const txs: AnnotatedEV5Transaction[] = group.calls.map((call) => ({
+      to: call.to,
+      data: call.data,
+      value: call.value,
+      chainId,
+    }));
+    const batch = await builder.submit(...txs);
+    const filepath = join(
+      runDir,
+      `${group.chain}-${group.governanceType}.json`,
+    );
+    mkdirSync(dirname(filepath), { recursive: true });
+    await writeAndFormatJsonAtPath(filepath, batch);
+    rootLogger.info(
+      `[${group.chain}] wrote ${group.governanceType} Safe batch ${filepath}`,
+    );
+  }
+}
+
+async function proposeSafeGroups({
+  groups,
+  multiProvider,
+}: {
+  groups: SafeCallGroup[];
+  multiProvider: Parameters<typeof SafeMultiSend.initialize>[0];
+}) {
+  for (const group of groups) {
+    const safeMultiSend = await SafeMultiSend.initialize(
+      multiProvider,
+      group.chain,
+      group.safeAddress,
+    );
+    const hashes = await safeMultiSend.sendTransactions(
+      group.calls.map((call) => ({
+        to: call.to,
+        data: call.data,
+        value: call.value,
+      })),
+    );
+    rootLogger.info(
+      `[${group.chain}] proposed ${group.calls.length} ${group.governanceType} tx(s): ${hashes.join(', ')}`,
+    );
+  }
+}
+
+async function main() {
+  const {
+    environment,
+    context = Contexts.Hyperlane,
+    chains,
+    outFile,
+    propose,
+    all,
+    implementationAddressesFile,
+    skipEvmPreflight,
+  } = await withOutputFile(
+    withChains(
+      withContext(
+        withPropose(
+          getArgs()
+            .option('implementationAddressesFile', {
+              type: 'string',
+              describe:
+                'JSON map of chain name to already deployed InterchainGasPaymaster implementation address',
+              demandOption: true,
+            })
+            .option('all', {
+              type: 'boolean',
+              default: false,
+              describe:
+                'Confirm proposing for every compatible chain when --chains is omitted',
+            })
+            .option('skipEvmPreflight', {
+              type: 'boolean',
+              default: false,
+              describe: 'Skip Cancun/PUSH0 eth_call preflight',
+            }),
+        ),
+      ),
+    ),
+  ).argv;
+
+  assert(
+    !propose || chains?.length || all,
+    'Refusing to propose for all compatible chains without --all. Pass --chains or --all.',
+  );
+
+  const implementationAddresses = readJson<ChainMap<Address>>(
+    implementationAddressesFile,
+  );
+  const envConfig = getEnvironmentConfig(environment);
+  const requested = chains && chains.length > 0 ? new Set(chains) : undefined;
+  const targetChains = envConfig.supportedChainNames.filter((chain) => {
+    if (requested && !requested.has(chain)) return false;
+    if (legacyIgpChains.includes(chain)) return false;
+    return true;
+  });
+
+  const multiProvider = await envConfig.getMultiProvider(
+    context,
+    undefined,
+    true,
+    targetChains,
+  );
+  const chainAddresses = getEnvAddresses(environment);
+  const icaAddresses = Object.fromEntries(
+    Object.entries(chainAddresses).filter(
+      ([, addresses]) => !!addresses.interchainAccountRouter,
+    ),
+  );
+  const ica = InterchainAccount.fromAddressesMap(icaAddresses, multiProvider);
+  const safeGroups = new Map<string, SafeCallGroup>();
+  const plans: ChainPlan[] = [];
+
+  for (const chain of targetChains) {
+    const metadata = multiProvider.getChainMetadata(chain);
+    if (!isEVMLike(metadata.protocol)) {
+      plans.push({
+        chain,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        status: 'skipped',
+        detail: `non-EVM protocol ${metadata.protocol}`,
+      });
+      continue;
+    }
+
+    const addresses = chainAddresses[chain];
+    const interchainGasPaymaster = addresses?.interchainGasPaymaster;
+    if (!interchainGasPaymaster) {
+      plans.push({
+        chain,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        status: 'skipped',
+        detail: 'missing interchainGasPaymaster in registry',
+      });
+      continue;
+    }
+
+    const provider = multiProvider.getProvider(chain);
+    const targetImplementation = getImplementationAddress(
+      chain,
+      implementationAddresses,
+    );
+    try {
+      if (!skipEvmPreflight) {
+        await assertCancunCompatible(chain, provider);
+      }
+
+      const currentImplementation = await proxyImplementation(
+        provider,
+        interchainGasPaymaster,
+      );
+      const currentVersion = await getCurrentVersion(
+        chain,
+        provider,
+        interchainGasPaymaster,
+      );
+      const actualProxyAdmin = await proxyAdmin(
+        provider,
+        interchainGasPaymaster,
+      );
+      if (
+        targetImplementation &&
+        eqAddress(currentImplementation, targetImplementation)
+      ) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'no change',
+          detail: 'proxy already points at target implementation',
+        });
+        continue;
+      }
+
+      if (
+        currentVersion &&
+        compareSemver(currentVersion, CONTRACTS_PACKAGE_VERSION) >= 0
+      ) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          targetImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'skipped',
+          detail: 'current contract version is already >= target version',
+        });
+        continue;
+      }
+
+      if (!targetImplementation) {
+        plans.push({
+          chain,
+          interchainGasPaymaster,
+          currentImplementation,
+          currentVersion,
+          targetVersion: CONTRACTS_PACKAGE_VERSION,
+          proxyAdmin: actualProxyAdmin,
+          status: 'error',
+          detail: 'missing implementation address',
+        });
+        continue;
+      }
+
+      const proxyAdminOwner = await Ownable__factory.connect(
+        actualProxyAdmin,
+        provider,
+      ).owner();
+      const { ownerType, governanceType } = await determineGovernanceType(
+        chain,
+        proxyAdminOwner,
+      );
+      const upgradeCall: UpgradeCall = {
+        to: actualProxyAdmin,
+        data: ProxyAdmin__factory.createInterface().encodeFunctionData(
+          'upgrade',
+          [interchainGasPaymaster, targetImplementation],
+        ),
+        value: BigNumber.from(0),
+        description: `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION} implementation ${targetImplementation}`,
+      };
+
+      let detail: string;
+      switch (ownerType) {
+        case Owner.SAFE:
+          addSafeCall(safeGroups, chain, governanceType, upgradeCall);
+          detail = `queued ${governanceType} Safe proposal`;
+          break;
+        case Owner.ICA:
+          await addIcaSafeCall({
+            groups: safeGroups,
+            ica,
+            destination: chain,
+            governanceType,
+            innerCall: upgradeCall,
+          });
+          detail = `queued ${governanceType} ICA proposal from ethereum`;
+          break;
+        case Owner.TIMELOCK:
+          detail = await routeTimelockCall({
+            groups: safeGroups,
+            ica,
+            chain,
+            governanceType,
+            timelockAddress: proxyAdminOwner,
+            innerCall: upgradeCall,
+          });
+          break;
+        case Owner.DEPLOYER:
+          plans.push({
+            chain,
+            interchainGasPaymaster,
+            currentImplementation,
+            targetImplementation,
+            currentVersion,
+            targetVersion: CONTRACTS_PACKAGE_VERSION,
+            proxyAdmin: actualProxyAdmin,
+            proxyAdminOwner,
+            ownerType,
+            governanceType,
+            status: 'manual',
+            detail:
+              'ProxyAdmin is deployer-owned; script does not execute deployer-key upgrades',
+          });
+          continue;
+        default:
+          plans.push({
+            chain,
+            interchainGasPaymaster,
+            currentImplementation,
+            targetImplementation,
+            currentVersion,
+            targetVersion: CONTRACTS_PACKAGE_VERSION,
+            proxyAdmin: actualProxyAdmin,
+            proxyAdminOwner,
+            ownerType,
+            governanceType,
+            status: 'manual',
+            detail: `unknown ProxyAdmin owner ${proxyAdminOwner}`,
+          });
+          continue;
+      }
+
+      plans.push({
+        chain,
+        interchainGasPaymaster,
+        currentImplementation,
+        targetImplementation,
+        currentVersion,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        proxyAdmin: actualProxyAdmin,
+        proxyAdminOwner,
+        ownerType,
+        governanceType,
+        status: 'queued',
+        detail,
+      });
+    } catch (error) {
+      plans.push({
+        chain,
+        interchainGasPaymaster,
+        targetImplementation,
+        targetVersion: CONTRACTS_PACKAGE_VERSION,
+        status: 'error',
+        detail: formatError(error),
+      });
+    }
+  }
+
+  const groups = [...safeGroups.values()];
+  const runDir = join(
+    OUTPUT_ROOT,
+    new Date().toISOString().replace(/[:.]/g, '-'),
+  );
+  await writeSafeBatchFiles({ groups, multiProvider, runDir });
+
+  if (propose) {
+    await proposeSafeGroups({ groups, multiProvider });
+  }
+
+  const output = {
+    environment,
+    context,
+    targetVersion: CONTRACTS_PACKAGE_VERSION,
+    mode: propose ? 'propose' : 'dry-run',
+    legacyIgpChains,
+    safeGroups: groups.map((group) => ({
+      chain: group.chain,
+      governanceType: group.governanceType,
+      safeAddress: group.safeAddress,
+      transactionCount: group.calls.length,
+    })),
+    plans,
+  };
+
+  if (outFile) {
+    await writeAndFormatJsonAtPath(outFile, output);
+  }
+  logTable(plans, ['chain', 'status', 'ownerType', 'governanceType', 'detail']);
+
+  if (!propose) {
+    rootLogger.info(`Dry run: Safe batch files written under ${runDir}`);
+  }
+  if (plans.some((plan) => plan.status === 'error')) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  rootLogger.error(error);
+  process.exit(1);
+});

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -73,6 +73,9 @@ export const legacyIgpChains: ChainName[] = Array.from(
     'incentiv',
     'metis',
     'ontology',
+    'taiko',
+    'torus',
+
     // Keep chains with repeatedly unreliable deployment/proposal execution on
     // legacy IGP for now.
     'astar',
@@ -80,8 +83,6 @@ export const legacyIgpChains: ChainName[] = Array.from(
     'prom',
     'pulsechain',
     'sei',
-    'taiko',
-    'torus',
     'viction',
     'xrplevm',
     ...getDisabledChains(),

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -73,11 +73,17 @@ export const legacyIgpChains: ChainName[] = Array.from(
     'incentiv',
     'metis',
     'ontology',
+    // Keep chains with repeatedly unreliable deployment/proposal execution on
+    // legacy IGP for now.
+    'astar',
+    'krown',
     'prom',
     'pulsechain',
+    'sei',
     'taiko',
     'torus',
     'viction',
+    'xrplevm',
     ...getDisabledChains(),
   ]),
 );

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -40,10 +40,9 @@ import {
   SafeMultiSend,
   SignerMultiSend,
 } from './multisend.js';
+import { GOVERNOR_MAX_BATCH_SIZE } from './constants.js';
 import type { AnnotatedCallData, InferredCall } from './types.js';
 import { SubmissionType } from './types.js';
-
-export const GOVERNOR_MAX_BATCH_SIZE = 120;
 
 export abstract class HyperlaneAppGovernor<
   App extends HyperlaneApp<any>,

--- a/typescript/infra/src/govern/HyperlaneAppGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneAppGovernor.ts
@@ -43,6 +43,8 @@ import {
 import type { AnnotatedCallData, InferredCall } from './types.js';
 import { SubmissionType } from './types.js';
 
+export const GOVERNOR_MAX_BATCH_SIZE = 120;
+
 export abstract class HyperlaneAppGovernor<
   App extends HyperlaneApp<any>,
   Config extends OwnableConfig,
@@ -178,13 +180,15 @@ export abstract class HyperlaneAppGovernor<
           );
           try {
             // Process calls in batches up to max size of 120
-            const maxBatchSize = 120;
             for (
               let i = 0;
               i < callsForSubmissionType.length;
-              i += maxBatchSize
+              i += GOVERNOR_MAX_BATCH_SIZE
             ) {
-              const batch = callsForSubmissionType.slice(i, i + maxBatchSize);
+              const batch = callsForSubmissionType.slice(
+                i,
+                i + GOVERNOR_MAX_BATCH_SIZE,
+              );
               const sendBatch = () =>
                 multiSend.sendTransactions(
                   batch.map((call) => ({

--- a/typescript/infra/src/govern/constants.ts
+++ b/typescript/infra/src/govern/constants.ts
@@ -1,0 +1,1 @@
+export const GOVERNOR_MAX_BATCH_SIZE = 120;

--- a/typescript/infra/src/utils/timelock.ts
+++ b/typescript/infra/src/utils/timelock.ts
@@ -137,16 +137,24 @@ export async function timelockConfigMatches({
   return { matches: issues.length === 0, issues };
 }
 
-const rpcBlockRangesByChain: ChainMap<number> = {
+export const DEFAULT_TIMELOCK_LOG_BLOCK_RANGE = 999;
+
+export const timelockLogBlockRangeByChain: ChainMap<number> = {
   // The rpc limits to a max of 1024 blocks
   moonbeam: 1024,
   // The rpc limits to a max of 5000 blocks
   merlin: 5000,
   // The rpc limits to a max of 1000 blocks
   xlayer: 1000,
-  // The rpc limits to a max of 1000 blocks
+  // The rpc limits to a max of 5000 blocks
   dogechain: 5000,
 };
+
+export function getTimelockLogBlockRange(chain: ChainName): number {
+  return (
+    timelockLogBlockRangeByChain[chain] ?? DEFAULT_TIMELOCK_LOG_BLOCK_RANGE
+  );
+}
 
 export function getTimelockConfigs({
   chains,
@@ -201,7 +209,7 @@ async function getPendingTimelockTxsOnChain(
     chain,
     multiProvider,
     timelockAddress,
-    paginationBlockRange: rpcBlockRangesByChain[chain] ?? 10_000,
+    paginationBlockRange: getTimelockLogBlockRange(chain),
   });
 
   let scheduledTxs: Awaited<

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+
+import { GovernanceType } from '../src/governanceTypes.js';
+import {
+  getImplementationAddressOverrides,
+  getPostUpgradeConfigChains,
+  isMissingPackageVersionError,
+  splitProposableGroups,
+} from '../scripts/igp/upgrade-compatible-igps.js';
+
+describe('upgrade-compatible-igps', () => {
+  describe('isMissingPackageVersionError', () => {
+    it('only treats missing selector call exceptions as missing package version', () => {
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          data: '0x',
+        }),
+      ).to.equal(true);
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          error: { data: '0x' },
+        }),
+      ).to.equal(true);
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          message: 'call reverted with data="0x"',
+        }),
+      ).to.equal(true);
+
+      expect(
+        isMissingPackageVersionError({
+          code: 'SERVER_ERROR',
+          message: 'Invalid response from provider',
+        }),
+      ).to.equal(false);
+      expect(
+        isMissingPackageVersionError({
+          code: 'CALL_EXCEPTION',
+          data: '0x1234',
+        }),
+      ).to.equal(false);
+    });
+  });
+
+  describe('getImplementationAddressOverrides', () => {
+    const supportedChains = new Set(['ethereum', 'arbitrum']);
+    let dir: string;
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'igp-upgrade-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    function writeOverrides(value: unknown) {
+      const filepath = join(dir, 'overrides.json');
+      writeFileSync(filepath, JSON.stringify(value));
+      return filepath;
+    }
+
+    it('loads valid chain implementation overrides', () => {
+      const implementation = '0x1111111111111111111111111111111111111111';
+      const filepath = writeOverrides({ ethereum: implementation });
+
+      expect(
+        getImplementationAddressOverrides(filepath, supportedChains),
+      ).to.deep.equal({
+        ethereum: implementation,
+      });
+    });
+
+    it('rejects unsupported chains and invalid addresses', () => {
+      expect(() =>
+        getImplementationAddressOverrides(
+          writeOverrides({
+            unknown: '0x1111111111111111111111111111111111111111',
+          }),
+          supportedChains,
+        ),
+      ).to.throw('unsupported chain unknown');
+
+      expect(() =>
+        getImplementationAddressOverrides(
+          writeOverrides({
+            ethereum: '0x0000000000000000000000000000000000000000',
+          }),
+          supportedChains,
+        ),
+      ).to.throw('implementation is zero address');
+
+      expect(() =>
+        getImplementationAddressOverrides(
+          writeOverrides({ ethereum: 'not-an-address' }),
+          supportedChains,
+        ),
+      ).to.throw('is not an EVM address');
+    });
+  });
+
+  it('only includes newly queued upgrades in the post-upgrade config command', () => {
+    expect(
+      getPostUpgradeConfigChains([
+        {
+          chain: 'ethereum',
+          targetVersion: '1.0.0',
+          status: 'queued',
+          detail: 'new safe proposal',
+        },
+        {
+          chain: 'arbitrum',
+          targetVersion: '1.0.0',
+          status: 'scheduled',
+          detail: 'timelock operation already scheduled/done',
+        },
+      ]),
+    ).to.deep.equal(['ethereum']);
+  });
+
+  it('splits raw fallback Safe groups out of propose mode', () => {
+    const safeGroup = {
+      chain: 'ethereum',
+      governanceType: GovernanceType.AbacusWorks,
+      safeAddress: '0x1111111111111111111111111111111111111111',
+      calls: [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          data: '0x',
+          value: BigNumber.from(0),
+          description: 'upgrade',
+        },
+      ],
+    };
+    const rawFallbackGroup = {
+      ...safeGroup,
+      chain: 'arbitrum',
+    };
+
+    const result = splitProposableGroups({
+      groups: [safeGroup, rawFallbackGroup],
+      rawFallbackGroupKeys: new Set([
+        `${rawFallbackGroup.chain}:${rawFallbackGroup.governanceType}`,
+      ]),
+    });
+
+    expect(result.proposableGroups).to.deep.equal([safeGroup]);
+    expect(result.skippedProposalResults).to.deep.include({
+      chain: 'arbitrum',
+      governanceType: GovernanceType.AbacusWorks,
+      safeAddress: rawFallbackGroup.safeAddress,
+      status: 'skipped',
+      detail:
+        'skipped propose because only raw fallback calldata was written; submit manually',
+    });
+  });
+});

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -133,6 +133,99 @@ describe('upgrade-compatible-igps', () => {
         },
       }),
     ).to.equal(true);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: '0x5555555555555555555555555555555555555555',
+        scheduledValue: BigNumber.from(0),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          proxy,
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(1),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          proxy,
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(0),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          '0x6666666666666666666666666666666666666666',
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(0),
+        scheduledData: '0x1234',
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(false);
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -6,7 +6,6 @@ import { GovernanceType } from '../src/governanceTypes.js';
 import { getTimelockLogBlockRange } from '../src/utils/timelock.js';
 import {
   callMatchesTimelockIdempotency,
-  getDeferredTimelockConfigChains,
   getUpgradeTargetImplementation,
   isMissingPackageVersionError,
   splitProposableGroups,
@@ -53,34 +52,6 @@ describe('upgrade-compatible-igps', () => {
         }),
       ).to.equal(false);
     });
-  });
-
-  it('detects timelock chains with deferred config txs', () => {
-    const plans = [
-      {
-        chain: 'ethereum',
-        targetVersion: '1.0.0',
-        status: 'queued',
-        detail: 'new safe proposal',
-      },
-      {
-        chain: 'arbitrum',
-        targetVersion: '1.0.0',
-        status: 'timelock queued',
-        detail: 'timelock schedule proposal; 2 config tx(s) deferred',
-      },
-      {
-        chain: 'optimism',
-        targetVersion: '1.0.0',
-        status: 'scheduled',
-        detail: 'timelock operation already scheduled; 1 config tx(s) deferred',
-      },
-    ];
-
-    expect(getDeferredTimelockConfigChains(plans)).to.deep.equal([
-      'arbitrum',
-      'optimism',
-    ]);
   });
 
   it('uses conservative timelock log block ranges', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -4,6 +4,7 @@ import { BigNumber } from 'ethers';
 
 import { GovernanceType } from '../src/governanceTypes.js';
 import {
+  callMatchesTimelockIdempotency,
   getDeferredTimelockConfigChains,
   getUpgradeTargetImplementation,
   isMissingPackageVersionError,
@@ -36,6 +37,12 @@ describe('upgrade-compatible-igps', () => {
         isMissingPackageVersionError({
           code: 'SERVER_ERROR',
           message: 'Invalid response from provider',
+        }),
+      ).to.equal(true);
+      expect(
+        isMissingPackageVersionError({
+          code: 'SERVER_ERROR',
+          message: 'rate limited',
         }),
       ).to.equal(false);
       expect(
@@ -94,6 +101,38 @@ describe('upgrade-compatible-igps', () => {
         proxyAddress: proxy,
       }),
     ).to.equal(implementation);
+  });
+
+  it('matches timelock IGP upgrade operations across different implementations', () => {
+    const proxyAdmin = '0x1111111111111111111111111111111111111111';
+    const proxy = '0x2222222222222222222222222222222222222222';
+    const firstImplementation = '0x3333333333333333333333333333333333333333';
+    const secondImplementation = '0x4444444444444444444444444444444444444444';
+    const iface = ProxyAdmin__factory.createInterface();
+
+    expect(
+      callMatchesTimelockIdempotency({
+        call: {
+          to: proxyAdmin,
+          value: BigNumber.from(0),
+          data: iface.encodeFunctionData('upgrade', [
+            proxy,
+            firstImplementation,
+          ]),
+          description: 'upgrade',
+        },
+        scheduledTarget: proxyAdmin,
+        scheduledValue: BigNumber.from(0),
+        scheduledData: iface.encodeFunctionData('upgrade', [
+          proxy,
+          secondImplementation,
+        ]),
+        idempotency: {
+          type: 'proxyAdminUpgrade',
+          proxyAddress: proxy,
+        },
+      }),
+    ).to.equal(true);
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -9,7 +9,9 @@ import { GovernanceType } from '../src/governanceTypes.js';
 import {
   getImplementationAddressOverrides,
   getPostUpgradeConfigChains,
+  getTimelockPostExecutionConfigChains,
   isMissingPackageVersionError,
+  mergeImplementationAddresses,
   splitProposableGroups,
 } from '../scripts/igp/upgrade-compatible-igps.js';
 
@@ -82,6 +84,13 @@ describe('upgrade-compatible-igps', () => {
     it('rejects unsupported chains and invalid addresses', () => {
       expect(() =>
         getImplementationAddressOverrides(
+          writeOverrides(['0x1111111111111111111111111111111111111111']),
+          supportedChains,
+        ),
+      ).to.throw('must contain a JSON object');
+
+      expect(() =>
+        getImplementationAddressOverrides(
           writeOverrides({
             unknown: '0x1111111111111111111111111111111111111111',
           }),
@@ -107,23 +116,50 @@ describe('upgrade-compatible-igps', () => {
     });
   });
 
-  it('only includes newly queued upgrades in the post-upgrade config command', () => {
+  it('splits immediate and timelock post-upgrade config chains', () => {
+    const plans = [
+      {
+        chain: 'ethereum',
+        targetVersion: '1.0.0',
+        status: 'queued',
+        detail: 'new safe proposal',
+      },
+      {
+        chain: 'arbitrum',
+        targetVersion: '1.0.0',
+        status: 'timelock queued',
+        detail: 'timelock schedule proposal',
+      },
+      {
+        chain: 'optimism',
+        targetVersion: '1.0.0',
+        status: 'scheduled',
+        detail: 'timelock operation already scheduled',
+      },
+    ];
+
+    expect(getPostUpgradeConfigChains(plans)).to.deep.equal(['ethereum']);
+    expect(getTimelockPostExecutionConfigChains(plans)).to.deep.equal([
+      'arbitrum',
+      'optimism',
+    ]);
+  });
+
+  it('prefers igp verification implementations over core fallback', () => {
     expect(
-      getPostUpgradeConfigChains([
-        {
-          chain: 'ethereum',
-          targetVersion: '1.0.0',
-          status: 'queued',
-          detail: 'new safe proposal',
+      mergeImplementationAddresses({
+        igpImplementations: {
+          ethereum: '0x1111111111111111111111111111111111111111',
         },
-        {
-          chain: 'arbitrum',
-          targetVersion: '1.0.0',
-          status: 'scheduled',
-          detail: 'timelock operation already scheduled/done',
+        coreImplementations: {
+          ethereum: '0x2222222222222222222222222222222222222222',
+          arbitrum: '0x3333333333333333333333333333333333333333',
         },
-      ]),
-    ).to.deep.equal(['ethereum']);
+      }),
+    ).to.deep.equal({
+      ethereum: '0x1111111111111111111111111111111111111111',
+      arbitrum: '0x3333333333333333333333333333333333333333',
+    });
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 
 import { GovernanceType } from '../src/governanceTypes.js';
+import { getTimelockLogBlockRange } from '../src/utils/timelock.js';
 import {
   callMatchesTimelockIdempotency,
   getDeferredTimelockConfigChains,
@@ -80,6 +81,11 @@ describe('upgrade-compatible-igps', () => {
       'arbitrum',
       'optimism',
     ]);
+  });
+
+  it('uses conservative timelock log block ranges', () => {
+    expect(getTimelockLogBlockRange('ethereum')).to.equal(999);
+    expect(getTimelockLogBlockRange('xlayer')).to.equal(1000);
   });
 
   it('extracts target implementation from ProxyAdmin upgrade calldata', () => {

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -1,17 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-
+import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 
 import { GovernanceType } from '../src/governanceTypes.js';
 import {
-  getImplementationAddressOverrides,
-  getPostUpgradeConfigChains,
-  getTimelockPostExecutionConfigChains,
+  getDeferredTimelockConfigChains,
+  getUpgradeTargetImplementation,
   isMissingPackageVersionError,
-  mergeImplementationAddresses,
   splitProposableGroups,
 } from '../scripts/igp/upgrade-compatible-igps.js';
 
@@ -52,71 +47,7 @@ describe('upgrade-compatible-igps', () => {
     });
   });
 
-  describe('getImplementationAddressOverrides', () => {
-    const supportedChains = new Set(['ethereum', 'arbitrum']);
-    let dir: string;
-
-    beforeEach(() => {
-      dir = mkdtempSync(join(tmpdir(), 'igp-upgrade-test-'));
-    });
-
-    afterEach(() => {
-      rmSync(dir, { recursive: true, force: true });
-    });
-
-    function writeOverrides(value: unknown) {
-      const filepath = join(dir, 'overrides.json');
-      writeFileSync(filepath, JSON.stringify(value));
-      return filepath;
-    }
-
-    it('loads valid chain implementation overrides', () => {
-      const implementation = '0x1111111111111111111111111111111111111111';
-      const filepath = writeOverrides({ ethereum: implementation });
-
-      expect(
-        getImplementationAddressOverrides(filepath, supportedChains),
-      ).to.deep.equal({
-        ethereum: implementation,
-      });
-    });
-
-    it('rejects unsupported chains and invalid addresses', () => {
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides(['0x1111111111111111111111111111111111111111']),
-          supportedChains,
-        ),
-      ).to.throw('must contain a JSON object');
-
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides({
-            unknown: '0x1111111111111111111111111111111111111111',
-          }),
-          supportedChains,
-        ),
-      ).to.throw('unsupported chain unknown');
-
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides({
-            ethereum: '0x0000000000000000000000000000000000000000',
-          }),
-          supportedChains,
-        ),
-      ).to.throw('implementation is zero address');
-
-      expect(() =>
-        getImplementationAddressOverrides(
-          writeOverrides({ ethereum: 'not-an-address' }),
-          supportedChains,
-        ),
-      ).to.throw('is not an EVM address');
-    });
-  });
-
-  it('splits immediate and timelock post-upgrade config chains', () => {
+  it('detects timelock chains with deferred config txs', () => {
     const plans = [
       {
         chain: 'ethereum',
@@ -128,38 +59,41 @@ describe('upgrade-compatible-igps', () => {
         chain: 'arbitrum',
         targetVersion: '1.0.0',
         status: 'timelock queued',
-        detail: 'timelock schedule proposal',
+        detail: 'timelock schedule proposal; 2 config tx(s) deferred',
       },
       {
         chain: 'optimism',
         targetVersion: '1.0.0',
         status: 'scheduled',
-        detail: 'timelock operation already scheduled',
+        detail: 'timelock operation already scheduled; 1 config tx(s) deferred',
       },
     ];
 
-    expect(getPostUpgradeConfigChains(plans)).to.deep.equal(['ethereum']);
-    expect(getTimelockPostExecutionConfigChains(plans)).to.deep.equal([
+    expect(getDeferredTimelockConfigChains(plans)).to.deep.equal([
       'arbitrum',
       'optimism',
     ]);
   });
 
-  it('prefers igp verification implementations over core fallback', () => {
+  it('extracts target implementation from ProxyAdmin upgrade calldata', () => {
+    const proxyAdmin = '0x1111111111111111111111111111111111111111';
+    const proxy = '0x2222222222222222222222222222222222222222';
+    const implementation = '0x3333333333333333333333333333333333333333';
+    const data = ProxyAdmin__factory.createInterface().encodeFunctionData(
+      'upgrade',
+      [proxy, implementation],
+    );
+
     expect(
-      mergeImplementationAddresses({
-        igpImplementations: {
-          ethereum: '0x1111111111111111111111111111111111111111',
+      getUpgradeTargetImplementation({
+        tx: {
+          to: proxyAdmin,
+          data,
         },
-        coreImplementations: {
-          ethereum: '0x2222222222222222222222222222222222222222',
-          arbitrum: '0x3333333333333333333333333333333333333333',
-        },
+        proxyAdminAddress: proxyAdmin,
+        proxyAddress: proxy,
       }),
-    ).to.deep.equal({
-      ethereum: '0x1111111111111111111111111111111111111111',
-      arbitrum: '0x3333333333333333333333333333333333333333',
-    });
+    ).to.equal(implementation);
   });
 
   it('splits raw fallback Safe groups out of propose mode', () => {

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -177,7 +177,7 @@
     "@turnkey/solana": "catalog:",
     "bignumber.js": "catalog:",
     "borsh": "catalog:",
-    "compare-versions": "^6.1.1",
+    "compare-versions": "catalog:",
     "cosmjs-types": "catalog:",
     "cross-fetch": "^3.1.5",
     "ethers": "catalog:",

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -50,13 +50,6 @@ export {
   isContractAddress,
   assertIsContractAddress,
 } from './contracts/contracts.js';
-export {
-  isMissingSelectorCallException,
-  isMissingSelectorRevert,
-  isValidContractVersion,
-  throwIfNotMissingSelector,
-  throwIfNotMissingSelectorRevert,
-} from './utils/contract.js';
 export { MUTABLE_HOOK_TYPE, OnchainHookType } from './hook/types.js';
 export { MUTABLE_ISM_TYPE } from './ism/types.js';
 

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -50,6 +50,13 @@ export {
   isContractAddress,
   assertIsContractAddress,
 } from './contracts/contracts.js';
+export {
+  isMissingSelectorCallException,
+  isMissingSelectorRevert,
+  isValidContractVersion,
+  throwIfNotMissingSelector,
+  throwIfNotMissingSelectorRevert,
+} from './utils/contract.js';
 export { MUTABLE_HOOK_TYPE, OnchainHookType } from './hook/types.js';
 export { MUTABLE_ISM_TYPE } from './ism/types.js';
 

--- a/typescript/sdk/src/utils/contract.ts
+++ b/typescript/sdk/src/utils/contract.ts
@@ -3,6 +3,10 @@ import { providers } from 'ethers';
 
 import { Address, chunk, isNullish, strip0x } from '@hyperlane-xyz/utils';
 
+/**
+ * Returns true when the deployed contract version is already at or above the
+ * target version.
+ */
 export function isValidContractVersion(
   currentVersion: string,
   targetVersion: string,


### PR DESCRIPTION
## Summary
Adds `scripts/igp/upgrade-compatible-igps.ts` to plan or propose mainnet3 IGP implementation upgrades for compatible chains.

The script uses `EvmHookModule.update()` to construct the IGP upgrade transaction, but proposal mode intentionally routes only the ProxyAdmin upgrade. Hook-module config/setter transactions are not proposed by this script; operators should run the normal `deploy.ts -m igp` path after the upgrade has executed.

In dry-run mode the script simulates the new IGP implementation deployment address from the deployer nonce. Chain planning is bounded-parallel via `--concurrency` (default 8), then output is sorted back into target-chain order.

Routing supports Safe, Ethereum Safe -> ICA, timelock scheduling, and manual reporting for deployer/unknown/legacy V1 ICA ownership. ICA-owned upgrades are buffered per destination/governance and emitted as ordered `callRemote` Safe txs. Timelock duplicate-schedule detection scans pending/ready `CallScheduled` operations for the same ProxyAdmin + IGP proxy, using the shared conservative timelock log range helper (`999` default plus per-chain overrides).

Also updates `legacyIgpChains` from #8921 and intentionally leaves unreliable deployment/proposal chains on legacy IGP for now: astar, krown, prom, pulsechain, sei, viction, xrplevm.

Operator runbook gist: https://gist.github.com/paulbalaji/8ba10f6144aca9eb1433a076b47a3436

## Operator Notes
- No target implementation artifact or override file is required.
- Dry-run output includes simulated implementation deployments and Safe batch files under `igp-upgrade-output/`.
- Proposals are upgrade-only. After each upgrade actually executes, run:
  - `pnpm -C typescript/infra exec tsx scripts/deploy.ts -e mainnet3 -x hyperlane -m igp --chains <executed chains>`
- For timelock-owned upgrades, run `deploy.ts -m igp` only after the timelock operation has executed.
- Between upgrade execution and the post-upgrade `deploy.ts -m igp` config apply, destination gas configs read as zero; keep that window short.

## Validation
- `pnpm -C typescript/infra format`
- `pnpm -C typescript/infra check`
- `pnpm -C typescript/sdk check`
- `pnpm -C typescript/infra exec mocha --config ../sdk/.mocharc.json test/igp-upgrade-compatible-igps.test.ts`
- `pnpm -C typescript/infra exec tsx scripts/igp/upgrade-compatible-igps.ts --help`
- `pnpm -C typescript/infra exec tsx scripts/igp/upgrade-compatible-igps.ts -e mainnet3 -x hyperlane --chains adichain --outFile /tmp/igp-upgrade-adichain-upgrade-only.json`
- `pnpm -C typescript/infra exec tsx scripts/igp/upgrade-compatible-igps.ts -e mainnet3 -x hyperlane --chains ethereum arbitrum --concurrency 2 --outFile /tmp/igp-upgrade-two-chain-upgrade-only.json`
- Expected fail-fast checks:
  - `pnpm -C typescript/infra exec tsx scripts/igp/upgrade-compatible-igps.ts -e mainnet3 --all --skipEvmPreflight`
  - `pnpm -C typescript/infra exec tsx scripts/igp/upgrade-compatible-igps.ts -e mainnet3 --chains viction`
- `pnpm changeset status --since=d288e7ba674db69e46c1638fc7cb594da2aacc37`
- `git diff --check`
