### PR TITLE
chore(infra): temporarily disable taiko validator and relayer

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -182,7 +182,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     superseed: true,
     swell: true,
     tac: true,
-    taiko: true,
+    taiko: false, // temporarily disabled out of caution (Taiko network incident)
     tea: true,
     tron: true,
     unichain: true,
@@ -314,7 +314,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     superseed: true,
     swell: true,
     tac: true,
-    taiko: true,
+    taiko: false, // temporarily disabled out of caution (Taiko network incident)
     tea: true,
     tron: true,
     unichain: true,


### PR DESCRIPTION
Temporarily disables `taiko` under Role.Validator and Role.Relayer in the mainnet3 agent config, out of caution. Scraper left enabled.

Mirrors live kubectl edits already applied (validator scaled to 0, taiko removed from relayer `HYP_RELAYCHAINS`); this makes them durable across deploys. Revert to re-enable.

Context: https://x.com/taikoxyz/status/2068858818352865626