### PR TITLE
chore: igra gas prices

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -138,8 +138,8 @@
     },
     "igra": {
       "oracleConfig": {
-        "tokenExchangeRate": "1280789843859896",
-        "gasPrice": "101276819069391",
+        "tokenExchangeRate": "6233980165986777",
+        "gasPrice": "20807624956885",
         "tokenDecimals": 18
       },
       "overhead": 166887

--- a/typescript/infra/config/environments/mainnet3/tokenPrices.json
+++ b/typescript/infra/config/environments/mainnet3/tokenPrices.json
@@ -45,7 +45,7 @@
   "hashkey": "0.089604",
   "hemi": "1745.03",
   "hyperevm": "71.48",
-  "igra": "0.00607009",
+  "igra": "0.02954491",
   "immutablezkevmmainnet": "0.142352",
   "incentiv": "0.003",
   "ink": "1745.03",


### PR DESCRIPTION
### Description

Updated IGRA (iKAS token) gas oracle prices to reflect current market prices:
- iKAS price updated from `$0.00607009` to `$0.02954491` in `tokenPrices.json`
- Solana gas oracle configs updated in `gas-oracle-configs.json` to reflect the new exchange rate

EVM oracle prices were updated on-chain directly via `deploy.ts -m igp` on all chains with active IGRA warp routes (arbitrum, avalanche, base, ethereum, igra, optimism, polygon). Solana oracle was updated via `update-gas-oracles.ts --apply`.

### Drive-by changes

None

### Related issues

N/A

### Backward compatibility

Yes

### Testing

On-chain oracle values verified post-deploy using `cast call` on the StorageGasOracle contracts.