### PR TITLE
feat: sealevel metaswaps reveals

### DIFF
--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -642,6 +642,7 @@ async fn submit_via_lander(
         prepare_op(op, prepare_queue, e, msg, reason).await;
         return;
     }
+    op.on_submitted();
 
     if let Err(e) = db.store_payload_uuids_by_message_id(&message_id, vec![payload.details.uuid]) {
         let reason = ReprepareReason::ErrorStoringPayloadUuidsByMessageId;

--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -642,8 +642,6 @@ async fn submit_via_lander(
         prepare_op(op, prepare_queue, e, msg, reason).await;
         return;
     }
-    op.on_submitted();
-
     if let Err(e) = db.store_payload_uuids_by_message_id(&message_id, vec![payload.details.uuid]) {
         let reason = ReprepareReason::ErrorStoringPayloadUuidsByMessageId;
         let msg = "Error storing mapping from message id to payload uuids";

--- a/rust/main/agents/relayer/src/msg/message_processor/stage/submit.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/stage/submit.rs
@@ -70,7 +70,9 @@ pub(crate) async fn filter_operations_for_submit(
                 submit_queue.push(op, Some(ReadyToSubmit)).await;
             }
             PostSubmitSuccess => {
-                // PostSubmitSuccess is sent to Confirm stage.
+                // Tx is confirmed on-chain at this point (Included/Finalized).
+                // Fire the reveal hook now, before the 10-min confirm delay.
+                op.on_submitted_success();
                 confirm_op(op, confirm_queue, metrics).await;
             }
             PostSubmitFailure => {

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -70,16 +70,6 @@ fn is_ica_invalid_reveal(err: &impl std::fmt::Display) -> bool {
     err.to_string().contains(ICA_INVALID_REVEAL)
 }
 
-/// Detects Custom(10) = CommitmentAlreadySet from the Solana Universal Router program.
-/// This error occurs in `process_estimate_costs` simulation when the UR program's
-/// `pending_swap` PDA already exists from a prior (possibly other-relayer) delivery.
-/// It signals that the COMMIT message was already processed; our `delivered()` check
-/// may be returning false due to RPC lag on the processed-message PDA.
-fn is_ur_commitment_already_set(err: &impl std::fmt::Display) -> bool {
-    // Simulation error format: "Error in simulation result: Some(UiTransactionError(InstructionError(N, Custom(10))))"
-    err.to_string().contains("Custom(10)")
-}
-
 /// The outcome of a gas payment requirement check.
 enum GasPaymentRequirementOutcome {
     MeetsRequirement(U256),
@@ -162,19 +152,6 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ica_reveal_attempts: u32,
-    /// Set when simulation fails with CommitmentAlreadySet (Custom(10)) from the
-    /// Solana UR program. Means another relayer already processed the COMMIT;
-    /// our processed-message PDA is temporarily invisible at 'processed' commitment.
-    /// Guards `on_delivered` from firing more than once and skips the `delivered()`
-    /// check in `confirm()`.
-    #[new(default)]
-    #[serde(skip_serializing)]
-    ur_commitment_already_set: bool,
-    /// Set after the reveal task has been spawned for a COMMIT message so that
-    /// repeated `prepare()` calls don't spawn duplicate tasks.
-    #[new(default)]
-    #[serde(skip_serializing)]
-    reveal_spawned: bool,
 }
 
 impl Debug for PendingMessage {
@@ -290,15 +267,6 @@ impl PendingOperation for PendingMessage {
             return PendingOperationResult::NotReady;
         }
 
-        // Proactively spawn a reveal task the first time we see a COMMIT message
-        // (96-byte body). The task waits for the pending_swap PDA to appear before
-        // building the reveal tx, so it is safe to fire before the commit lands.
-        // This ensures reveals happen even when another relayer delivers the commit.
-        if !self.reveal_spawned && self.message.body.len() == 96 {
-            self.ctx.destination_mailbox.on_delivered(&self.message);
-            self.reveal_spawned = true;
-        }
-
         // If the message has already been processed, e.g. due to another relayer having
         // already processed, then mark it as already-processed, and move on to
         // the next tick.
@@ -315,7 +283,6 @@ impl PendingOperation for PendingMessage {
         };
         if is_already_delivered {
             debug!("Message has already been delivered, marking as submitted.");
-            self.ctx.destination_mailbox.on_delivered(&self.message);
             self.submitted = true;
             self.set_next_attempt_after(CONFIRM_DELAY);
             return PendingOperationResult::Confirm(ConfirmReason::AlreadySubmitted);
@@ -430,27 +397,6 @@ impl PendingOperation for PendingMessage {
                         // permanently-failing reveal doesn't re-enter the fast-poll burst.
                         if !is_ica_invalid_reveal(&e) {
                             self.ica_reveal_attempts = 0;
-                        }
-                        // CommitmentAlreadySet (Custom(10)) from the Solana UR program means
-                        // the pending_swap PDA already exists — the COMMIT was already
-                        // delivered (possibly by another relayer) and our processed-message
-                        // PDA is just not visible yet at 'processed' commitment. Skip the
-                        // delivered() re-check (which would return false) and go straight to
-                        // confirm, firing on_delivered exactly once.
-                        if is_ur_commitment_already_set(&e) && !self.ur_commitment_already_set {
-                            warn!(
-                                message_id = ?self.message.id(),
-                                "Simulation failed with CommitmentAlreadySet (Custom(10)); \
-                                 COMMIT was already delivered. Firing on_delivered and \
-                                 moving to confirm."
-                            );
-                            self.ur_commitment_already_set = true;
-                            self.ctx.destination_mailbox.on_delivered(&self.message);
-                            self.submitted = true;
-                            self.set_next_attempt_after(CONFIRM_DELAY);
-                            return PendingOperationResult::Confirm(
-                                ConfirmReason::AlreadySubmitted,
-                            );
                         }
                         warn!(
                             message_id = ?self.message.id(),
@@ -573,22 +519,6 @@ impl PendingOperation for PendingMessage {
             return PendingOperationResult::NotReady;
         }
 
-        // CommitmentAlreadySet path: the COMMIT was already delivered by another relayer.
-        // Our processed-message PDA may be invisible at 'processed' commitment; skip
-        // the delivered() check to avoid a reprepare loop. on_delivered was already
-        // fired in prepare() when the flag was first set.
-        if self.ur_commitment_already_set {
-            if let Err(err) = self.record_message_process_success() {
-                return self
-                    .on_reconfirm(Some(err), "Error when recording message process success");
-            }
-            info!(
-                message_id = ?self.message.id(),
-                "Message confirmed via CommitmentAlreadySet path (another relayer delivered)"
-            );
-            return PendingOperationResult::Success;
-        }
-
         let is_delivered = match self
             .ctx
             .destination_mailbox
@@ -610,7 +540,6 @@ impl PendingOperation for PendingMessage {
                 submission=?self.submission_outcome,
                 "Message successfully processed"
             );
-            self.ctx.destination_mailbox.on_delivered(&self.message);
             PendingOperationResult::Success
         } else {
             warn!(message_id = ?self.message.id(), tx_outcome=?self.submission_outcome, "Transaction attempting to process message either reverted or was reorged");

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -267,6 +267,8 @@ impl PendingOperation for PendingMessage {
             return PendingOperationResult::NotReady;
         }
 
+        self.ctx.destination_mailbox.on_delivered(&self.message);
+
         // If the message has already been processed, e.g. due to another relayer having
         // already processed, then mark it as already-processed, and move on to
         // the next tick.

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -170,6 +170,11 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ur_commitment_already_set: bool,
+    /// Set after the reveal task has been spawned for a COMMIT message so that
+    /// repeated `prepare()` calls don't spawn duplicate tasks.
+    #[new(default)]
+    #[serde(skip_serializing)]
+    reveal_spawned: bool,
 }
 
 impl Debug for PendingMessage {
@@ -283,6 +288,15 @@ impl PendingOperation for PendingMessage {
         if !self.is_ready() {
             trace!("Message is not ready to be submitted yet");
             return PendingOperationResult::NotReady;
+        }
+
+        // Proactively spawn a reveal task the first time we see a COMMIT message
+        // (96-byte body). The task waits for the pending_swap PDA to appear before
+        // building the reveal tx, so it is safe to fire before the commit lands.
+        // This ensures reveals happen even when another relayer delivers the commit.
+        if !self.reveal_spawned && self.message.body.len() == 96 {
+            self.ctx.destination_mailbox.on_delivered(&self.message);
+            self.reveal_spawned = true;
         }
 
         // If the message has already been processed, e.g. due to another relayer having

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -70,6 +70,16 @@ fn is_ica_invalid_reveal(err: &impl std::fmt::Display) -> bool {
     err.to_string().contains(ICA_INVALID_REVEAL)
 }
 
+/// Detects Custom(10) = CommitmentAlreadySet from the Solana Universal Router program.
+/// This error occurs in `process_estimate_costs` simulation when the UR program's
+/// `pending_swap` PDA already exists from a prior (possibly other-relayer) delivery.
+/// It signals that the COMMIT message was already processed; our `delivered()` check
+/// may be returning false due to RPC lag on the processed-message PDA.
+fn is_ur_commitment_already_set(err: &impl std::fmt::Display) -> bool {
+    // Simulation error format: "Error in simulation result: Some(UiTransactionError(InstructionError(N, Custom(10))))"
+    err.to_string().contains("Custom(10)")
+}
+
 /// The outcome of a gas payment requirement check.
 enum GasPaymentRequirementOutcome {
     MeetsRequirement(U256),
@@ -152,6 +162,14 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ica_reveal_attempts: u32,
+    /// Set when simulation fails with CommitmentAlreadySet (Custom(10)) from the
+    /// Solana UR program. Means another relayer already processed the COMMIT;
+    /// our processed-message PDA is temporarily invisible at 'processed' commitment.
+    /// Guards `on_delivered` from firing more than once and skips the `delivered()`
+    /// check in `confirm()`.
+    #[new(default)]
+    #[serde(skip_serializing)]
+    ur_commitment_already_set: bool,
 }
 
 impl Debug for PendingMessage {
@@ -283,6 +301,7 @@ impl PendingOperation for PendingMessage {
         };
         if is_already_delivered {
             debug!("Message has already been delivered, marking as submitted.");
+            self.ctx.destination_mailbox.on_delivered(&self.message);
             self.submitted = true;
             self.set_next_attempt_after(CONFIRM_DELAY);
             return PendingOperationResult::Confirm(ConfirmReason::AlreadySubmitted);
@@ -397,6 +416,44 @@ impl PendingOperation for PendingMessage {
                         // permanently-failing reveal doesn't re-enter the fast-poll burst.
                         if !is_ica_invalid_reveal(&e) {
                             self.ica_reveal_attempts = 0;
+                        }
+                        // CommitmentAlreadySet (Custom(10)) from the Solana UR program means
+                        // the pending_swap PDA already exists — the COMMIT was already
+                        // delivered (possibly by another relayer) and our processed-message
+                        // PDA is just not visible yet at 'processed' commitment. Skip the
+                        // delivered() re-check (which would return false) and go straight to
+                        // confirm, firing on_delivered exactly once.
+                        if is_ur_commitment_already_set(&e) && !self.ur_commitment_already_set {
+                            warn!(
+                                message_id = ?self.message.id(),
+                                "Simulation failed with CommitmentAlreadySet (Custom(10)); \
+                                 COMMIT was already delivered. Firing on_delivered and \
+                                 moving to confirm."
+                            );
+                            self.ur_commitment_already_set = true;
+                            self.ctx.destination_mailbox.on_delivered(&self.message);
+                            self.submitted = true;
+                            self.set_next_attempt_after(CONFIRM_DELAY);
+                            return PendingOperationResult::Confirm(
+                                ConfirmReason::AlreadySubmitted,
+                            );
+                        }
+                        // Re-check delivered(): simulation and the earlier delivered() call may
+                        // have hit different RPC nodes at slightly different states.  If the
+                        // message is now delivered, skip the reprepare loop and fire on_delivered.
+                        if let Ok(true) = self
+                            .ctx
+                            .destination_mailbox
+                            .delivered(self.message.id())
+                            .await
+                        {
+                            debug!("Message delivered (detected after simulation failure), marking as submitted.");
+                            self.ctx.destination_mailbox.on_delivered(&self.message);
+                            self.submitted = true;
+                            self.set_next_attempt_after(CONFIRM_DELAY);
+                            return PendingOperationResult::Confirm(
+                                ConfirmReason::AlreadySubmitted,
+                            );
                         }
                         warn!(
                             message_id = ?self.message.id(),
@@ -519,6 +576,22 @@ impl PendingOperation for PendingMessage {
             return PendingOperationResult::NotReady;
         }
 
+        // CommitmentAlreadySet path: the COMMIT was already delivered by another relayer.
+        // Our processed-message PDA may be invisible at 'processed' commitment; skip
+        // the delivered() check to avoid a reprepare loop. on_delivered was already
+        // fired in prepare() when the flag was first set.
+        if self.ur_commitment_already_set {
+            if let Err(err) = self.record_message_process_success() {
+                return self
+                    .on_reconfirm(Some(err), "Error when recording message process success");
+            }
+            info!(
+                message_id = ?self.message.id(),
+                "Message confirmed via CommitmentAlreadySet path (another relayer delivered)"
+            );
+            return PendingOperationResult::Success;
+        }
+
         let is_delivered = match self
             .ctx
             .destination_mailbox
@@ -540,6 +613,7 @@ impl PendingOperation for PendingMessage {
                 submission=?self.submission_outcome,
                 "Message successfully processed"
             );
+            self.ctx.destination_mailbox.on_delivered(&self.message);
             PendingOperationResult::Success
         } else {
             warn!(message_id = ?self.message.id(), tx_outcome=?self.submission_outcome, "Transaction attempting to process message either reverted or was reorged");

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -267,8 +267,6 @@ impl PendingOperation for PendingMessage {
             return PendingOperationResult::NotReady;
         }
 
-        self.ctx.destination_mailbox.on_delivered(&self.message);
-
         // If the message has already been processed, e.g. due to another relayer having
         // already processed, then mark it as already-processed, and move on to
         // the next tick.
@@ -285,6 +283,7 @@ impl PendingOperation for PendingMessage {
         };
         if is_already_delivered {
             debug!("Message has already been delivered, marking as submitted.");
+            self.ctx.destination_mailbox.on_delivered(&self.message);
             self.submitted = true;
             self.set_next_attempt_after(CONFIRM_DELAY);
             return PendingOperationResult::Confirm(ConfirmReason::AlreadySubmitted);
@@ -538,6 +537,7 @@ impl PendingOperation for PendingMessage {
                 return self
                     .on_reconfirm(Some(err), "Error when recording message process success");
             }
+            self.ctx.destination_mailbox.on_delivered(&self.message);
             info!(
                 submission=?self.submission_outcome,
                 "Message successfully processed"

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -497,7 +497,9 @@ impl PendingOperation for PendingMessage {
         match tx_outcome {
             Ok(outcome) => {
                 self.set_operation_outcome(outcome, state.gas_limit).await;
-                self.ctx.destination_mailbox.on_submitted(&self.message);
+                self.ctx
+                    .destination_mailbox
+                    .on_submitted_success(&self.message);
                 PendingOperationResult::Confirm(ConfirmReason::SubmittedBySelf)
             }
             Err(e) => {
@@ -627,8 +629,10 @@ impl PendingOperation for PendingMessage {
         Some(self.ctx.destination_mailbox.clone())
     }
 
-    fn on_submitted(&self) {
-        self.ctx.destination_mailbox.on_submitted(&self.message);
+    fn on_submitted_success(&self) {
+        self.ctx
+            .destination_mailbox
+            .on_submitted_success(&self.message);
     }
 
     fn get_metric(&self) -> Option<Arc<IntGauge>> {

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -627,6 +627,10 @@ impl PendingOperation for PendingMessage {
         Some(self.ctx.destination_mailbox.clone())
     }
 
+    fn on_submitted(&self) {
+        self.ctx.destination_mailbox.on_submitted(&self.message);
+    }
+
     fn get_metric(&self) -> Option<Arc<IntGauge>> {
         self.metric.clone()
     }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -497,6 +497,7 @@ impl PendingOperation for PendingMessage {
         match tx_outcome {
             Ok(outcome) => {
                 self.set_operation_outcome(outcome, state.gas_limit).await;
+                self.ctx.destination_mailbox.on_submitted(&self.message);
                 PendingOperationResult::Confirm(ConfirmReason::SubmittedBySelf)
             }
             Err(e) => {

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -438,23 +438,6 @@ impl PendingOperation for PendingMessage {
                                 ConfirmReason::AlreadySubmitted,
                             );
                         }
-                        // Re-check delivered(): simulation and the earlier delivered() call may
-                        // have hit different RPC nodes at slightly different states.  If the
-                        // message is now delivered, skip the reprepare loop and fire on_delivered.
-                        if let Ok(true) = self
-                            .ctx
-                            .destination_mailbox
-                            .delivered(self.message.id())
-                            .await
-                        {
-                            debug!("Message delivered (detected after simulation failure), marking as submitted.");
-                            self.ctx.destination_mailbox.on_delivered(&self.message);
-                            self.submitted = true;
-                            self.set_next_attempt_after(CONFIRM_DELAY);
-                            return PendingOperationResult::Confirm(
-                                ConfirmReason::AlreadySubmitted,
-                            );
-                        }
                         warn!(
                             message_id = ?self.message.id(),
                             error = %e,

--- a/rust/main/chains/hyperlane-sealevel/Cargo.toml
+++ b/rust/main/chains/hyperlane-sealevel/Cargo.toml
@@ -34,6 +34,7 @@ solana-stake-interface.workspace = true
 solana-system-interface.workspace = true
 solana-transaction-status.workspace = true
 solana-vote-interface.workspace = true
+hex.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing-futures.workspace = true

--- a/rust/main/chains/hyperlane-sealevel/src/keypair.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/keypair.rs
@@ -27,6 +27,13 @@ impl Deref for SealevelKeypair {
     }
 }
 
+impl Clone for SealevelKeypair {
+    fn clone(&self) -> Self {
+        #[allow(clippy::unwrap_used)]
+        Self(Keypair::try_from(self.0.to_bytes().as_slice()).unwrap())
+    }
+}
+
 impl std::fmt::Debug for SealevelKeypair {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.pubkey())

--- a/rust/main/chains/hyperlane-sealevel/src/keypair.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/keypair.rs
@@ -29,8 +29,10 @@ impl Deref for SealevelKeypair {
 
 impl Clone for SealevelKeypair {
     fn clone(&self) -> Self {
-        #[allow(clippy::unwrap_used)]
-        Self(Keypair::try_from(self.0.to_bytes().as_slice()).unwrap())
+        Self(
+            Keypair::try_from(self.0.to_bytes().as_slice())
+                .expect("bytes from a valid Keypair are always valid"),
+        )
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/lib.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/lib.rs
@@ -21,6 +21,7 @@ pub use solana_sdk::signer::keypair::Keypair;
 pub use trait_builder::*;
 pub use tx_submitter::*;
 pub use tx_type::*;
+pub use universal_router_reveal::UniversalRouterRevealConfig;
 pub use validator_announce::*;
 
 mod account;
@@ -45,5 +46,6 @@ mod signer;
 mod trait_builder;
 mod tx_submitter;
 mod tx_type;
+mod universal_router_reveal;
 mod utils;
 mod validator_announce;

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -437,7 +437,10 @@ impl SealevelMailbox {
         let account = self
             .provider
             .rpc_client()
-            .get_account_option_with_finalized_commitment(processed_message_account_key)
+            .get_account_option_with_commitment(
+                processed_message_account_key,
+                CommitmentConfig::processed(),
+            )
             .await?;
         Ok(account)
     }
@@ -558,18 +561,6 @@ impl Mailbox for SealevelMailbox {
             .unwrap_or(false);
         let txid = signature.into();
 
-        if let Some(reveal_config) = &self.ur_reveal {
-            if let Ok(payer) = self.get_payer() {
-                maybe_spawn_reveal(
-                    message,
-                    reveal_config,
-                    self.provider.rpc_client().clone(),
-                    self.priority_fee_oracle.clone(),
-                    payer.clone(),
-                );
-            }
-        }
-
         Ok(TxOutcome {
             transaction_id: txid,
             executed,
@@ -627,6 +618,25 @@ impl Mailbox for SealevelMailbox {
     fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>> {
         let account = self.processed_message_account(message_id);
         serde_json::to_vec(&account).map(Some).map_err(Into::into)
+    }
+
+    fn on_delivered(&self, message: &HyperlaneMessage) {
+        if let Some(reveal_config) = &self.ur_reveal {
+            match self.get_payer() {
+                Ok(payer) => maybe_spawn_reveal(
+                    message,
+                    reveal_config,
+                    self.provider.rpc_client().clone(),
+                    self.priority_fee_oracle.clone(),
+                    payer.clone(),
+                ),
+                Err(e) => {
+                    tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
+                }
+            }
+        } else {
+            tracing::info!("[REVEAL] Not configured for this mailbox; skipping");
+        }
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -657,6 +657,34 @@ impl Mailbox for SealevelMailbox {
         let account = self.processed_message_account(message_id);
         serde_json::to_vec(&account).map(Some).map_err(Into::into)
     }
+
+    fn on_delivered(&self, message: &HyperlaneMessage) {
+        if let Some(ref cfg) = self.ur_reveal {
+            if message.body.len() == 96 {
+                #[allow(clippy::unwrap_used)]
+                let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
+                let is_new = self
+                    .seen_reveal_commitments
+                    .lock()
+                    .unwrap()
+                    .insert(commitment);
+                if is_new {
+                    match self.get_payer() {
+                        Ok(payer) => maybe_spawn_reveal(
+                            message,
+                            cfg,
+                            self.provider.rpc_client().clone(),
+                            self.priority_fee_oracle.clone(),
+                            payer.clone(),
+                        ),
+                        Err(e) => {
+                            tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Resolve which ALT to use for a given message.

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -635,35 +635,34 @@ impl Mailbox for SealevelMailbox {
             if message.body.len() == 96 {
                 #[allow(clippy::unwrap_used)]
                 let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
-                // Check before acquiring payer so a transient get_payer() failure
-                // doesn't permanently mark the commitment as seen.
-                let already_seen = self
-                    .seen_reveal_commitments
-                    .lock()
-                    .unwrap()
-                    .contains(&commitment);
-                if !already_seen {
-                    match self.get_payer() {
-                        Ok(payer) => {
-                            let mut set = self.seen_reveal_commitments.lock().unwrap();
-                            // Evict oldest half when the set grows large to bound memory.
-                            if set.len() >= SEEN_REVEAL_MAX {
-                                let keep: std::collections::HashSet<_> =
-                                    set.iter().cloned().skip(set.len() / 2).collect();
-                                *set = keep;
+                match self.seen_reveal_commitments.lock() {
+                    Err(e) => {
+                        tracing::warn!(error = ?e, "[REVEAL] seen_reveal_commitments mutex poisoned; skipping reveal");
+                    }
+                    Ok(mut set) => {
+                        if !set.contains(&commitment) {
+                            match self.get_payer() {
+                                Ok(payer) => {
+                                    // Evict oldest half when the set grows large to bound memory.
+                                    if set.len() >= SEEN_REVEAL_MAX {
+                                        let keep: std::collections::HashSet<_> =
+                                            set.iter().cloned().skip(set.len() / 2).collect();
+                                        *set = keep;
+                                    }
+                                    set.insert(commitment);
+                                    drop(set);
+                                    maybe_spawn_reveal(
+                                        message,
+                                        cfg,
+                                        self.provider.rpc_client().clone(),
+                                        self.priority_fee_oracle.clone(),
+                                        payer.clone(),
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
+                                }
                             }
-                            set.insert(commitment);
-                            drop(set);
-                            maybe_spawn_reveal(
-                                message,
-                                cfg,
-                                self.provider.rpc_client().clone(),
-                                self.priority_fee_oracle.clone(),
-                                payer.clone(),
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
                         }
                     }
                 }

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -37,6 +37,7 @@ use hyperlane_core::{
 
 use crate::priority_fee::PriorityFeeOracle;
 use crate::tx_submitter::TransactionSubmitter;
+use crate::universal_router_reveal::{maybe_spawn_reveal, UniversalRouterRevealConfig};
 use crate::utils::sanitize_dynamic_accounts;
 use crate::{
     ConnectionConf, ProcessAltOverride, SealevelKeypair, SealevelProvider,
@@ -95,6 +96,7 @@ pub struct SealevelMailbox {
 
     system_program: Pubkey,
     spl_noop: Pubkey,
+    ur_reveal: Option<UniversalRouterRevealConfig>,
 }
 
 impl SealevelMailbox {
@@ -131,9 +133,9 @@ impl SealevelMailbox {
             mailbox_process_alt: conf.mailbox_process_alt,
             process_alt_overrides: conf.process_alt_overrides.clone(),
             provider,
-
             system_program,
             spl_noop,
+            ur_reveal: conf.ur_reveal.clone(),
         })
     }
 
@@ -555,6 +557,18 @@ impl Mailbox for SealevelMailbox {
             .map_err(|err| warn!("Failed to confirm inbox process transaction: {}", err))
             .unwrap_or(false);
         let txid = signature.into();
+
+        if let Some(reveal_config) = &self.ur_reveal {
+            if let Ok(payer) = self.get_payer() {
+                maybe_spawn_reveal(
+                    message,
+                    reveal_config,
+                    self.provider.rpc_client().clone(),
+                    self.priority_fee_oracle.clone(),
+                    payer.clone(),
+                );
+            }
+        }
 
         Ok(TxOutcome {
             transaction_id: txid,

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -634,8 +634,6 @@ impl Mailbox for SealevelMailbox {
                     tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
                 }
             }
-        } else {
-            tracing::info!("[REVEAL] Not configured for this mailbox; skipping");
         }
     }
 }

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -1,7 +1,11 @@
 // Silence a clippy bug https://github.com/rust-lang/rust-clippy/issues/12281
 #![allow(clippy::blocks_in_conditions)]
 
-use std::{collections::HashMap, str::FromStr as _, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr as _,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -97,6 +101,9 @@ pub struct SealevelMailbox {
     system_program: Pubkey,
     spl_noop: Pubkey,
     ur_reveal: Option<UniversalRouterRevealConfig>,
+    /// Tracks commitments for which a reveal task has already been spawned,
+    /// preventing duplicate tasks across repeated `process_estimate_costs` calls.
+    seen_reveal_commitments: Arc<Mutex<HashSet<[u8; 32]>>>,
 }
 
 impl SealevelMailbox {
@@ -136,6 +143,7 @@ impl SealevelMailbox {
             system_program,
             spl_noop,
             ur_reveal: conf.ur_reveal.clone(),
+            seen_reveal_commitments: Arc::new(Mutex::new(HashSet::new())),
         })
     }
 
@@ -576,6 +584,36 @@ impl Mailbox for SealevelMailbox {
         message: &HyperlaneMessage,
         metadata: &Metadata,
     ) -> ChainResult<TxCostEstimate> {
+        // Spawn the reveal task before simulation runs so it fires even when
+        // CommitmentAlreadySet causes the simulation to fail (meaning another
+        // relayer already delivered). The task polls internally for the
+        // pending_swap PDA, so it is safe to fire before the commit lands.
+        if let Some(ref cfg) = self.ur_reveal {
+            if message.body.len() == 96 {
+                #[allow(clippy::unwrap_used)]
+                let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
+                let is_new = self
+                    .seen_reveal_commitments
+                    .lock()
+                    .unwrap()
+                    .insert(commitment);
+                if is_new {
+                    match self.get_payer() {
+                        Ok(payer) => maybe_spawn_reveal(
+                            message,
+                            cfg,
+                            self.provider.rpc_client().clone(),
+                            self.priority_fee_oracle.clone(),
+                            payer.clone(),
+                        ),
+                        Err(e) => {
+                            tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
+                        }
+                    }
+                }
+            }
+        }
+
         // Getting a process payload in Sealevel is a pretty expensive operation
         // that involves some view calls. Consider reusing the payload with subsequent
         // calls to `process` to avoid this cost.
@@ -618,23 +656,6 @@ impl Mailbox for SealevelMailbox {
     fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>> {
         let account = self.processed_message_account(message_id);
         serde_json::to_vec(&account).map(Some).map_err(Into::into)
-    }
-
-    fn on_delivered(&self, message: &HyperlaneMessage) {
-        if let Some(reveal_config) = &self.ur_reveal {
-            match self.get_payer() {
-                Ok(payer) => maybe_spawn_reveal(
-                    message,
-                    reveal_config,
-                    self.provider.rpc_client().clone(),
-                    self.priority_fee_oracle.clone(),
-                    payer.clone(),
-                ),
-                Err(e) => {
-                    tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
-                }
-            }
-        }
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -447,10 +447,7 @@ impl SealevelMailbox {
         let account = self
             .provider
             .rpc_client()
-            .get_account_option_with_commitment(
-                processed_message_account_key,
-                CommitmentConfig::processed(),
-            )
+            .get_account_option_with_finalized_commitment(processed_message_account_key)
             .await?;
         Ok(account)
     }
@@ -632,36 +629,57 @@ impl Mailbox for SealevelMailbox {
 
     fn on_delivered(&self, message: &HyperlaneMessage) {
         if let Some(ref cfg) = self.ur_reveal {
-            if message.body.len() == 96 {
-                #[allow(clippy::unwrap_used)]
-                let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
-                match self.seen_reveal_commitments.lock() {
-                    Err(e) => {
-                        tracing::warn!(error = ?e, "[REVEAL] seen_reveal_commitments mutex poisoned; skipping reveal");
-                    }
-                    Ok(mut set) => {
-                        if !set.contains(&commitment) {
-                            match self.get_payer() {
-                                Ok(payer) => {
-                                    // Evict oldest half when the set grows large to bound memory.
-                                    if set.len() >= SEEN_REVEAL_MAX {
-                                        let keep: std::collections::HashSet<_> =
-                                            set.iter().cloned().skip(set.len() / 2).collect();
-                                        *set = keep;
-                                    }
-                                    set.insert(commitment);
-                                    drop(set);
-                                    maybe_spawn_reveal(
-                                        message,
-                                        cfg,
-                                        self.provider.rpc_client().clone(),
-                                        self.priority_fee_oracle.clone(),
-                                        payer.clone(),
-                                    );
+            if message.body.len() != 96 {
+                return;
+            }
+            // Gate on recipient == UR program before touching seen_reveal_commitments,
+            // so a non-UR 96-byte message can't poison a slot for a real commitment.
+            let program_id = match Pubkey::from_str(&cfg.program_id) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(error = ?e, "Invalid UR program ID in config; skipping reveal");
+                    return;
+                }
+            };
+            let message_recipient = Pubkey::new_from_array(message.recipient.0);
+            if message_recipient != program_id {
+                return;
+            }
+
+            let commitment: [u8; 32] = message.body[0..32]
+                .try_into()
+                .expect("body is exactly 96 bytes");
+            match self.seen_reveal_commitments.lock() {
+                Err(e) => {
+                    tracing::warn!(error = ?e, "seen_reveal_commitments mutex poisoned; skipping reveal");
+                }
+                Ok(mut set) => {
+                    if !set.contains(&commitment) {
+                        match self.get_payer() {
+                            Ok(payer) => {
+                                // Evict oldest half when the set grows large to bound memory.
+                                if set.len() >= SEEN_REVEAL_MAX {
+                                    let keep: std::collections::HashSet<_> =
+                                        set.iter().cloned().skip(set.len() / 2).collect();
+                                    *set = keep;
                                 }
-                                Err(e) => {
-                                    tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
-                                }
+                                // Insert here — after recipient validation — so only genuine UR
+                                // COMMIT messages occupy a slot. If the reveal task times out or
+                                // fails, this commitment stays seen for the process lifetime
+                                // (until the 1000-entry eviction). A relayer restart will re-fire
+                                // it via the is_already_delivered → on_delivered path.
+                                set.insert(commitment);
+                                drop(set);
+                                maybe_spawn_reveal(
+                                    message,
+                                    cfg,
+                                    self.provider.rpc_client().clone(),
+                                    self.priority_fee_oracle.clone(),
+                                    payer.clone(),
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = ?e, "get_payer failed; skipping reveal");
                             }
                         }
                     }

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -50,6 +50,8 @@ use crate::{
 
 const SYSTEM_PROGRAM: &str = "11111111111111111111111111111111";
 const SPL_NOOP: &str = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV";
+// Maximum entries in seen_reveal_commitments before evicting the oldest half.
+const SEEN_REVEAL_MAX: usize = 1_000;
 
 // Earlier versions of collateral warp routes were deployed off a version where the mint
 // was requested as a writeable account for handle instruction. This is not necessary,
@@ -584,36 +586,6 @@ impl Mailbox for SealevelMailbox {
         message: &HyperlaneMessage,
         metadata: &Metadata,
     ) -> ChainResult<TxCostEstimate> {
-        // Spawn the reveal task before simulation runs so it fires even when
-        // CommitmentAlreadySet causes the simulation to fail (meaning another
-        // relayer already delivered). The task polls internally for the
-        // pending_swap PDA, so it is safe to fire before the commit lands.
-        if let Some(ref cfg) = self.ur_reveal {
-            if message.body.len() == 96 {
-                #[allow(clippy::unwrap_used)]
-                let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
-                let is_new = self
-                    .seen_reveal_commitments
-                    .lock()
-                    .unwrap()
-                    .insert(commitment);
-                if is_new {
-                    match self.get_payer() {
-                        Ok(payer) => maybe_spawn_reveal(
-                            message,
-                            cfg,
-                            self.provider.rpc_client().clone(),
-                            self.priority_fee_oracle.clone(),
-                            payer.clone(),
-                        ),
-                        Err(e) => {
-                            tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
-                        }
-                    }
-                }
-            }
-        }
-
         // Getting a process payload in Sealevel is a pretty expensive operation
         // that involves some view calls. Consider reusing the payload with subsequent
         // calls to `process` to avoid this cost.
@@ -663,20 +635,33 @@ impl Mailbox for SealevelMailbox {
             if message.body.len() == 96 {
                 #[allow(clippy::unwrap_used)]
                 let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
-                let is_new = self
+                // Check before acquiring payer so a transient get_payer() failure
+                // doesn't permanently mark the commitment as seen.
+                let already_seen = self
                     .seen_reveal_commitments
                     .lock()
                     .unwrap()
-                    .insert(commitment);
-                if is_new {
+                    .contains(&commitment);
+                if !already_seen {
                     match self.get_payer() {
-                        Ok(payer) => maybe_spawn_reveal(
-                            message,
-                            cfg,
-                            self.provider.rpc_client().clone(),
-                            self.priority_fee_oracle.clone(),
-                            payer.clone(),
-                        ),
+                        Ok(payer) => {
+                            let mut set = self.seen_reveal_commitments.lock().unwrap();
+                            // Evict oldest half when the set grows large to bound memory.
+                            if set.len() >= SEEN_REVEAL_MAX {
+                                let keep: std::collections::HashSet<_> =
+                                    set.iter().cloned().skip(set.len() / 2).collect();
+                                *set = keep;
+                            }
+                            set.insert(commitment);
+                            drop(set);
+                            maybe_spawn_reveal(
+                                message,
+                                cfg,
+                                self.provider.rpc_client().clone(),
+                                self.priority_fee_oracle.clone(),
+                                payer.clone(),
+                            );
+                        }
                         Err(e) => {
                             tracing::warn!(error = ?e, "[REVEAL] get_payer failed; skipping reveal");
                         }

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -52,6 +52,8 @@ const SYSTEM_PROGRAM: &str = "11111111111111111111111111111111";
 const SPL_NOOP: &str = "noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV";
 // Maximum entries in seen_reveal_commitments before evicting the oldest half.
 const SEEN_REVEAL_MAX: usize = 1_000;
+/// Expected byte length of a Universal Router COMMIT message body.
+const COMMIT_BODY_LEN: usize = 96;
 
 // Earlier versions of collateral warp routes were deployed off a version where the mint
 // was requested as a writeable account for handle instruction. This is not necessary,
@@ -642,7 +644,7 @@ impl Mailbox for SealevelMailbox {
 impl SealevelMailbox {
     fn maybe_spawn_reveal_for_message(&self, message: &HyperlaneMessage) {
         if let Some(ref cfg) = self.ur_reveal {
-            if message.body.len() != 96 {
+            if message.body.len() != COMMIT_BODY_LEN {
                 return;
             }
             // Gate on recipient == UR program before touching seen_reveal_commitments,
@@ -661,7 +663,7 @@ impl SealevelMailbox {
 
             let commitment: [u8; 32] = message.body[0..32]
                 .try_into()
-                .expect("body is exactly 96 bytes");
+                .expect("body is exactly COMMIT_BODY_LEN bytes");
             match self.seen_reveal_commitments.lock() {
                 Err(e) => {
                     tracing::warn!(error = ?e, "seen_reveal_commitments mutex poisoned; skipping reveal");
@@ -682,6 +684,8 @@ impl SealevelMailbox {
                                 // (until the 1000-entry eviction). A relayer restart will re-fire
                                 // it via the is_already_delivered → on_delivered path.
                                 set.insert(commitment);
+                                // Release the lock before spawning so on_delivered callbacks
+                                // can acquire the mutex immediately without blocking on the spawn.
                                 drop(set);
                                 maybe_spawn_reveal(
                                     message,

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -627,7 +627,20 @@ impl Mailbox for SealevelMailbox {
         serde_json::to_vec(&account).map(Some).map_err(Into::into)
     }
 
+    fn on_submitted(&self, message: &HyperlaneMessage) {
+        self.maybe_spawn_reveal_for_message(message);
+    }
+
+    /// Restart-recovery path: fires when the relayer detects a message was already
+    /// delivered on a previous run.  Deduplication via `seen_reveal_commitments`
+    /// prevents double-spawning if `on_submitted` already ran this session.
     fn on_delivered(&self, message: &HyperlaneMessage) {
+        self.maybe_spawn_reveal_for_message(message);
+    }
+}
+
+impl SealevelMailbox {
+    fn maybe_spawn_reveal_for_message(&self, message: &HyperlaneMessage) {
         if let Some(ref cfg) = self.ur_reveal {
             if message.body.len() != 96 {
                 return;

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox.rs
@@ -627,13 +627,13 @@ impl Mailbox for SealevelMailbox {
         serde_json::to_vec(&account).map(Some).map_err(Into::into)
     }
 
-    fn on_submitted(&self, message: &HyperlaneMessage) {
+    fn on_submitted_success(&self, message: &HyperlaneMessage) {
         self.maybe_spawn_reveal_for_message(message);
     }
 
     /// Restart-recovery path: fires when the relayer detects a message was already
     /// delivered on a previous run.  Deduplication via `seen_reveal_commitments`
-    /// prevents double-spawning if `on_submitted` already ran this session.
+    /// prevents double-spawning if `on_submitted_success` already ran this session.
     fn on_delivered(&self, message: &HyperlaneMessage) {
         self.maybe_spawn_reveal_for_message(message);
     }

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -2,12 +2,14 @@ use std::sync::Arc;
 
 use solana_client::{
     nonblocking::rpc_client::RpcClient,
-    rpc_client::SerializableTransaction,
+    rpc_client::{GetConfirmedSignaturesForAddress2Config, SerializableTransaction},
     rpc_config::{
         RpcBlockConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig,
         RpcSimulateTransactionConfig, RpcTransactionConfig,
     },
-    rpc_response::{Response, RpcSimulateTransactionResult},
+    rpc_response::{
+        Response, RpcConfirmedTransactionStatusWithSignature, RpcSimulateTransactionResult,
+    },
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_program::clock::Slot;
@@ -190,6 +192,23 @@ impl SealevelRpcClient {
     ) -> ChainResult<Vec<(Pubkey, Account)>> {
         self.0
             .get_program_accounts_with_config(pubkey, config)
+            .await
+            .map_err(ChainCommunicationError::from_other)
+    }
+
+    /// Returns up to `limit` transaction signatures that reference `address`,
+    /// ordered newest-first. Returns an empty vec if the address has no history.
+    pub async fn get_signatures_for_address_with_limit(
+        &self,
+        address: &Pubkey,
+        limit: usize,
+    ) -> ChainResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        let config = GetConfirmedSignaturesForAddress2Config {
+            limit: Some(limit),
+            ..Default::default()
+        };
+        self.0
+            .get_signatures_for_address_with_config(address, config)
             .await
             .map_err(ChainCommunicationError::from_other)
     }

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
@@ -3,7 +3,9 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use derive_new::new;
 use solana_client::rpc_config::RpcProgramAccountsConfig;
-use solana_client::rpc_response::{Response, RpcSimulateTransactionResult};
+use solana_client::rpc_response::{
+    Response, RpcConfirmedTransactionStatusWithSignature, RpcSimulateTransactionResult,
+};
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
@@ -398,6 +400,24 @@ impl SealevelFallbackRpcClient {
             SealevelTxType::Legacy(t) => self.simulate_transaction(t).await,
             SealevelTxType::Versioned(t) => self.simulate_versioned_transaction(t).await,
         }
+    }
+
+    /// Returns up to `limit` transaction signatures that reference `address`.
+    pub async fn get_signatures_for_address_with_limit(
+        &self,
+        address: Pubkey,
+        limit: usize,
+    ) -> ChainResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        self.fallback_provider
+            .call(move |client| {
+                let future = async move {
+                    client
+                        .get_signatures_for_address_with_limit(&address, limit)
+                        .await
+                };
+                Box::pin(future)
+            })
+            .await
     }
 
     /// get statuses based on signatures

--- a/rust/main/chains/hyperlane-sealevel/src/trait_builder.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/trait_builder.rs
@@ -10,6 +10,7 @@ use url::Url;
 use crate::{
     priority_fee::{ConstantPriorityFeeOracle, HeliusPriorityFeeOracle, PriorityFeeOracle},
     tx_submitter::config::TransactionSubmitterConfig,
+    universal_router_reveal::UniversalRouterRevealConfig,
 };
 
 /// An ALT override: if message matches matching_list, use alt_address.
@@ -41,6 +42,9 @@ pub struct ConnectionConf {
     /// Per-message ALT overrides. First matching entry wins.
     /// Falls back to `mailbox_process_alt` if no match.
     pub process_alt_overrides: Vec<ProcessAltOverride>,
+    /// When set, the relayer automatically submits `RouterInstruction::Reveal`
+    /// after confirming delivery of a UR COMMIT message to this chain.
+    pub ur_reveal: Option<UniversalRouterRevealConfig>,
 }
 
 /// An error type when parsing a connection configuration.

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -286,10 +286,13 @@ pub fn maybe_spawn_reveal(
     let sender = message.sender.0;
     let commitment_hex = hex::encode(commitment);
 
+    let pending_swap_pda =
+        derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
     info!(
         commitment = %commitment_hex,
         origin,
         sender = %hex::encode(sender),
+        %pending_swap_pda,
         ccs_url = %config.ccs_url,
         program_id = %config.program_id,
         fee_payer = %fee_payer.pubkey(),
@@ -316,9 +319,6 @@ pub fn maybe_spawn_reveal(
             fee_payer: &fee_payer,
             http_client,
         };
-        let pending_swap_pda =
-            derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
-
         // Phase 1: confirm the pending_swap PDA is visible at confirmed commitment.
         // The task is spawned from on_delivered, so the commit is already confirmed —
         // the PDA should exist immediately. A short retry window handles RPC propagation

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -104,18 +104,18 @@ fn parse_clmm_pool_state(data: &[u8]) -> Result<ClmmPoolState> {
     }
     let read_pubkey = |offset: usize| {
         Pubkey::new_from_array(
-            data[offset..offset + 32]
+            data[offset..offset.saturating_add(32)]
                 .try_into()
                 .expect("slice is exactly 32 bytes"),
         )
     };
     let tick_spacing = i16::from_le_bytes(
-        data[POOL_TICK_SPACING_OFFSET..POOL_TICK_SPACING_OFFSET + 2]
+        data[POOL_TICK_SPACING_OFFSET..POOL_TICK_SPACING_OFFSET.saturating_add(2)]
             .try_into()
             .expect("slice is exactly 2 bytes"),
     );
     let tick_current = i32::from_le_bytes(
-        data[POOL_TICK_CURRENT_OFFSET..POOL_TICK_CURRENT_OFFSET + 4]
+        data[POOL_TICK_CURRENT_OFFSET..POOL_TICK_CURRENT_OFFSET.saturating_add(4)]
             .try_into()
             .expect("slice is exactly 4 bytes"),
     );
@@ -145,14 +145,16 @@ async fn fetch_clmm_pool_state(
 
 // Mirrors reveal.mjs `getTickArrayStartIndex`.  Uses truncation-towards-zero integer
 // division (Rust default), with an explicit floor correction for negative ticks.
+// Division is safe: tick_spacing is guarded > 0, so ticks_in_array > 0 and i32::MIN/-1 is unreachable.
+#[allow(clippy::arithmetic_side_effects)]
 fn get_tick_array_start_index(tick_current: i32, tick_spacing: i16) -> Result<i32> {
     if tick_spacing <= 0 {
         bail!("invalid tick_spacing: {tick_spacing}");
     }
-    let ticks_in_array = 60i32 * tick_spacing as i32;
-    let mut start = (tick_current / ticks_in_array) * ticks_in_array;
+    let ticks_in_array = 60i32.saturating_mul(tick_spacing as i32);
+    let mut start = (tick_current / ticks_in_array).saturating_mul(ticks_in_array);
     if tick_current < 0 && tick_current % ticks_in_array != 0 {
-        start -= ticks_in_array;
+        start = start.saturating_sub(ticks_in_array);
     }
     Ok(start)
 }
@@ -346,7 +348,7 @@ pub fn maybe_spawn_reveal(
                             tracing::debug!(error = ?e, "Could not check PDA history");
                         }
                     }
-                    pda_wait_iters += 1;
+                    pda_wait_iters = pda_wait_iters.saturating_add(1);
                     if pda_wait_iters >= PDA_WAIT_MAX_ITERS {
                         warn!(%pending_swap_pda, "PDA not visible after {}s post-confirmation; stopping", PDA_WAIT_MAX_ITERS * 5);
                         return;
@@ -431,7 +433,7 @@ pub fn maybe_spawn_reveal(
                 }
             }
 
-            token_wait_iters += 1;
+            token_wait_iters = token_wait_iters.saturating_add(1);
             if token_wait_iters >= TOKEN_WAIT_MAX_ITERS {
                 error!(%pending_swap_pda, "Warp tokens never arrived after {}s; inbound transfer may be stuck; stopping", TOKEN_WAIT_MAX_ITERS * 5);
                 return;
@@ -476,7 +478,7 @@ pub fn maybe_spawn_reveal(
                         warn!(retry_in_secs = delay_secs, error = ?e, "Transient failure; will retry");
                     }
                     tokio::time::sleep(Duration::from_secs(delay_secs)).await;
-                    delay_secs = (delay_secs * 2).min(REVEAL_MAX_RETRY_DELAY_SECS);
+                    delay_secs = delay_secs.saturating_mul(2).min(REVEAL_MAX_RETRY_DELAY_SECS);
                 }
             }
         }
@@ -810,12 +812,12 @@ async fn build_instruction(
                     "account[11] (observationState)",
                 );
 
-                let ticks_in_array = 60i32 * pool_state.tick_spacing as i32;
+                let ticks_in_array = 60i32.saturating_mul(pool_state.tick_spacing as i32);
                 let ta0_start =
                     get_tick_array_start_index(pool_state.tick_current, pool_state.tick_spacing)?;
                 // Forward progression matches UI's buildClmmAccounts formula.
-                let ta1_start = ta0_start + ticks_in_array;
-                let ta2_start = ta0_start + 2 * ticks_in_array;
+                let ta1_start = ta0_start.saturating_add(ticks_in_array);
+                let ta2_start = ta0_start.saturating_add(2i32.saturating_mul(ticks_in_array));
                 let live_ta0 = compute_tick_array_address(&pool_pubkey, ta0_start);
                 let live_ta1 = compute_tick_array_address(&pool_pubkey, ta1_start);
                 let live_ta2 = compute_tick_array_address(&pool_pubkey, ta2_start);

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -306,11 +306,11 @@ pub fn maybe_spawn_reveal(
         let pending_swap_pda =
             derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
 
-        // Phase 1: wait for the pending_swap PDA to appear on-chain.
-        // The reveal task may be spawned before the commit tx is confirmed
-        // (e.g. when another relayer delivers it), so we poll rather than
-        // aborting immediately on None.  Give up after ~10 min (120 × 5 s).
-        const PDA_WAIT_MAX_ITERS: u32 = 120;
+        // Phase 1: confirm the pending_swap PDA is visible at confirmed commitment.
+        // The task is spawned from on_delivered, so the commit is already confirmed —
+        // the PDA should exist immediately. A short retry window handles RPC propagation
+        // lag. If the PDA has tx history but is gone, it was already revealed; stop.
+        const PDA_WAIT_MAX_ITERS: u32 = 5; // 5 × 5s = 25s propagation grace
         let mut pda_wait_iters: u32 = 0;
         loop {
             match rpc_client
@@ -318,14 +318,10 @@ pub fn maybe_spawn_reveal(
                 .await
             {
                 Ok(Some(_)) => {
-                    info!(commitment = %commitment_hex, %pending_swap_pda, "[REVEAL] PDA appeared; proceeding to token wait");
+                    info!(commitment = %commitment_hex, %pending_swap_pda, "[REVEAL] PDA confirmed; proceeding to token wait");
                     break;
                 }
                 Ok(None) => {
-                    // Check if this PDA ever existed. If there's any transaction
-                    // history it was created and then consumed by a successful reveal —
-                    // either by us on a prior run or by another relayer. Stop immediately
-                    // rather than waiting the full 10-min timeout.
                     match rpc_client
                         .get_signatures_for_address_with_limit(pending_swap_pda, 1)
                         .await
@@ -334,21 +330,21 @@ pub fn maybe_spawn_reveal(
                             info!(
                                 commitment = %commitment_hex,
                                 %pending_swap_pda,
-                                "[REVEAL] PDA is gone and has transaction history — reveal already completed; stopping"
+                                "[REVEAL] PDA gone with tx history — already revealed; stopping"
                             );
                             return;
                         }
-                        Ok(_) => {} // no history yet, commit hasn't landed
+                        Ok(_) => {}
                         Err(e) => {
-                            warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA history; assuming not yet created");
+                            warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA history");
                         }
                     }
                     pda_wait_iters += 1;
                     if pda_wait_iters >= PDA_WAIT_MAX_ITERS {
-                        info!(
+                        warn!(
                             commitment = %commitment_hex,
                             %pending_swap_pda,
-                            "[REVEAL] PDA never appeared after {}s; commit may not have landed; stopping",
+                            "[REVEAL] PDA not visible after {}s post-confirmation; stopping",
                             PDA_WAIT_MAX_ITERS * 5
                         );
                         return;
@@ -357,7 +353,7 @@ pub fn maybe_spawn_reveal(
                         commitment = %commitment_hex,
                         %pending_swap_pda,
                         wait_iters = pda_wait_iters,
-                        "[REVEAL] PDA not yet visible; waiting 5s for commit to land"
+                        "[REVEAL] PDA not yet visible; retrying in 5s"
                     );
                 }
                 Err(e) => {
@@ -370,6 +366,10 @@ pub fn maybe_spawn_reveal(
         // Phase 2: fetch CCS to learn the pda_input_ata address (accounts[1]) and
         // poll for a non-zero token balance.  We must not build the full reveal tx
         // (pool state RPC, tick arrays, etc.) until the warp tokens have landed.
+        // Bail after 30 min (360 × 5s) to surface stuck swaps — the warp transfer
+        // should arrive in seconds; anything longer indicates a failed inbound leg.
+        const TOKEN_WAIT_MAX_ITERS: u32 = 360;
+        let mut token_wait_iters: u32 = 0;
         loop {
             // Bail early if PDA is already gone.
             match rpc_client
@@ -451,6 +451,16 @@ pub fn maybe_spawn_reveal(
                 }
             }
 
+            token_wait_iters += 1;
+            if token_wait_iters >= TOKEN_WAIT_MAX_ITERS {
+                error!(
+                    commitment = %commitment_hex,
+                    %pending_swap_pda,
+                    "[REVEAL] Warp tokens never arrived after {}s; inbound transfer may be stuck; stopping",
+                    TOKEN_WAIT_MAX_ITERS * 5
+                );
+                return;
+            }
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
 

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -319,10 +319,11 @@ pub fn maybe_spawn_reveal(
             fee_payer: &fee_payer,
             http_client,
         };
-        // Phase 1: confirm the pending_swap PDA is visible at confirmed commitment.
-        // The task is spawned from on_delivered, so the commit is already confirmed —
-        // the PDA should exist immediately. A short retry window handles RPC propagation
-        // lag. If the PDA has tx history but is gone, it was already revealed; stop.
+        // Phase 1: wait for the pending_swap PDA to appear at confirmed commitment.
+        // The task is spawned after the commit tx is confirmed on-chain (on_submitted_success
+        // polls delivered() before calling this; on_delivered fires post-confirmation),
+        // so the PDA should exist immediately.  A short retry window handles RPC
+        // propagation lag.  If the PDA has tx history but is gone, already revealed; stop.
         const PDA_WAIT_MAX_ITERS: u32 = 5; // 5 × 5s = 25s propagation grace
         let mut pda_wait_iters: u32 = 0;
         loop {

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -42,8 +42,13 @@ use crate::{
 const REVEAL_COMPUTE_UNITS: u32 = 600_000;
 const CCS_MAX_RETRIES: u32 = 10;
 const CCS_RETRY_DELAY_SECS: u64 = 5;
-const CONFIRM_MAX_POLLS: u32 = 60;
+// Outer send attempts (each gets a fresh blockhash): 3 × ~60s = ~3 min total.
+const SEND_RETRY_MAX: u32 = 3;
+// Inner polls per blockhash window (~150 slots ≈ 60 s on mainnet).
+const CONFIRM_POLLS_PER_BLOCKHASH: u32 = 30;
 const CONFIRM_POLL_DELAY_MS: u64 = 2_000;
+// Resend the signed tx every N inner polls to keep it in the leader queue.
+const RESEND_INTERVAL_POLLS: u32 = 10;
 
 // Raydium CLMM program on mainnet.
 const RAYDIUM_CLMM_PROGRAM: Pubkey =
@@ -51,6 +56,14 @@ const RAYDIUM_CLMM_PROGRAM: Pubkey =
 
 // SPL Associated Token Account program.
 const ATA_PROGRAM: Pubkey = solana_program::pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+
+// wSOL mint. When the output mint is wSOL, the reveal sweeps PDA wSOL ATA →
+// fee_payer's wSOL ATA, then closes it → native SOL to recipient.
+const WSOL_MINT: Pubkey = solana_program::pubkey!("So11111111111111111111111111111111111111112");
+
+// SPL Token (legacy) program. Used for the CloseAccount instruction on wSOL ATAs.
+const SPL_TOKEN_PROGRAM: Pubkey =
+    solana_program::pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
 // Byte offsets within a Raydium CLMM PoolState account (includes 8-byte Anchor discriminant).
 // Verified against `reveal.mjs` fetchClmmPoolState offsets.
@@ -174,6 +187,25 @@ fn make_ata_ix(
     }
 }
 
+// SPL Token CloseAccount instruction (discriminant = 9).
+// Transfers all lamports from `wsol_ata` to `lamport_dest` and closes the account,
+// unwrapping wSOL to native SOL. `authority` must sign the transaction.
+fn make_close_account_ix(
+    wsol_ata: &Pubkey,
+    lamport_dest: &Pubkey,
+    authority: &Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id: SPL_TOKEN_PROGRAM,
+        accounts: vec![
+            AccountMeta::new(*wsol_ata, false),
+            AccountMeta::new(*lamport_dest, false),
+            AccountMeta::new_readonly(*authority, true),
+        ],
+        data: vec![9u8],
+    }
+}
+
 /// Configuration for automated UR reveal submission on a Sealevel destination.
 #[derive(Debug, Clone)]
 pub struct UniversalRouterRevealConfig {
@@ -254,6 +286,7 @@ pub fn maybe_spawn_reveal(
             }
         };
         info!(commitment = %commitment_hex, %program_id, "[REVEAL] Task started");
+        let http_client = Client::new();
         let ctx = RevealContext {
             ccs_url: &ccs_url,
             program_id,
@@ -265,6 +298,7 @@ pub fn maybe_spawn_reveal(
             rpc_client: &rpc_client,
             priority_fee_oracle,
             fee_payer: &fee_payer,
+            http_client,
         };
         match submit_reveal(ctx).await {
             Err(e) => error!(commitment = %commitment_hex, error = ?e, "[REVEAL] Failed"),
@@ -284,14 +318,14 @@ struct RevealContext<'a> {
     rpc_client: &'a SealevelFallbackRpcClient,
     priority_fee_oracle: Arc<dyn PriorityFeeOracle>,
     fee_payer: &'a SealevelKeypair,
+    http_client: reqwest::Client,
 }
 
 async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
     let commitment_hex = hex::encode(ctx.commitment);
 
     info!(commitment = %commitment_hex, ccs_url = ctx.ccs_url, "[REVEAL] Fetching calldata from CCS");
-    let http = Client::new();
-    let ccs = fetch_from_ccs(&http, ctx.ccs_url, &ctx.commitment).await?;
+    let ccs = fetch_from_ccs(&ctx.http_client, ctx.ccs_url, &ctx.commitment).await?;
     info!(
         commitment = %commitment_hex,
         data_len = ccs.data.len(),
@@ -301,7 +335,7 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
     );
 
     info!(commitment = %commitment_hex, "[REVEAL] Building RouterInstruction::Reveal");
-    let mut built = build_instruction(&ctx, ctx.fee_payer.pubkey(), &ccs).await?;
+    let built = build_instruction(&ctx, &ccs).await?;
     info!(
         commitment = %commitment_hex,
         instruction_count = built.len(),
@@ -324,66 +358,107 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
         "[REVEAL] Priority fee determined"
     );
 
-    let mut instructions = vec![
-        ComputeBudgetInstruction::set_compute_unit_limit(REVEAL_COMPUTE_UNITS),
-        ComputeBudgetInstruction::set_compute_unit_price(priority_fee),
-    ];
-    instructions.append(&mut built);
+    // Outer loop: each attempt fetches a fresh blockhash and rebuilds the tx.
+    // On mainnet, a tx sent once is often silently dropped by congested leaders;
+    // the inner loop resends periodically within the ~150-slot (~60 s) validity
+    // window, and the outer loop retries after the window expires.
+    for send_attempt in 1..=SEND_RETRY_MAX {
+        // Fresh blockhash each attempt so the tx is valid for a new ~150-slot window.
+        info!(commitment = %commitment_hex, send_attempt, "[REVEAL] Fetching latest blockhash");
+        let blockhash = ctx
+            .rpc_client
+            .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
+            .await
+            .map_err(|e| eyre!("get_latest_blockhash: {e}"))?;
+        info!(commitment = %commitment_hex, blockhash = %blockhash, "[REVEAL] Got blockhash");
 
-    // Use `confirmed` commitment for the blockhash so the tx has a full ~150-slot validity window.
-    info!(commitment = %commitment_hex, "[REVEAL] Fetching latest blockhash");
-    let blockhash = ctx
-        .rpc_client
-        .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
-        .await
-        .map_err(|e| eyre!("get_latest_blockhash: {e}"))?;
-    info!(commitment = %commitment_hex, blockhash = %blockhash, "[REVEAL] Got blockhash");
+        let mut instructions = vec![
+            ComputeBudgetInstruction::set_compute_unit_limit(REVEAL_COMPUTE_UNITS),
+            ComputeBudgetInstruction::set_compute_unit_price(priority_fee),
+        ];
+        instructions.extend(built.iter().cloned());
 
-    let message = Message::new(&instructions, Some(&ctx.fee_payer.pubkey()));
-    let tx = Transaction::new(&[ctx.fee_payer.keypair()], message, blockhash);
+        let message = Message::new(&instructions, Some(&ctx.fee_payer.pubkey()));
+        let tx = Transaction::new(&[ctx.fee_payer.keypair()], message, blockhash);
 
-    info!(commitment = %commitment_hex, fee_payer = %ctx.fee_payer.pubkey(), "[REVEAL] Sending transaction");
-    let signature = ctx
-        .rpc_client
-        .send_transaction(&tx, true)
-        .await
-        .map_err(|e| eyre!("send_transaction: {e}"))?;
+        info!(
+            commitment = %commitment_hex,
+            fee_payer = %ctx.fee_payer.pubkey(),
+            send_attempt,
+            "[REVEAL] Sending transaction"
+        );
+        let signature = ctx
+            .rpc_client
+            .send_transaction(&tx, true)
+            .await
+            .map_err(|e| eyre!("send_transaction (attempt {send_attempt}): {e}"))?;
 
-    let max_confirm_secs = CONFIRM_MAX_POLLS.saturating_mul((CONFIRM_POLL_DELAY_MS / 1000) as u32);
-    info!(commitment = %commitment_hex, %signature, max_confirm_secs, "[REVEAL] Tx sent; polling for confirmation");
+        info!(
+            commitment = %commitment_hex,
+            %signature,
+            send_attempt,
+            "[REVEAL] Tx sent; polling for confirmation"
+        );
 
-    for attempt in 1..=CONFIRM_MAX_POLLS {
-        tokio::time::sleep(Duration::from_millis(CONFIRM_POLL_DELAY_MS)).await;
-        info!(commitment = %commitment_hex, %signature, attempt, max_attempts = CONFIRM_MAX_POLLS, "[REVEAL] Polling confirmation");
-        match ctx.rpc_client.get_signature_statuses(&[signature]).await {
-            Ok(response) => {
-                match response.value.into_iter().next().flatten() {
+        let mut confirmed = false;
+        for poll in 1..=CONFIRM_POLLS_PER_BLOCKHASH {
+            tokio::time::sleep(Duration::from_millis(CONFIRM_POLL_DELAY_MS)).await;
+
+            // Resend periodically to keep the tx in the leader queue within the validity window.
+            if poll % RESEND_INTERVAL_POLLS == 0 {
+                if let Err(e) = ctx.rpc_client.send_transaction(&tx, true).await {
+                    warn!(commitment = %commitment_hex, %signature, poll, error = ?e, "[REVEAL] Resend error (non-fatal)");
+                }
+            }
+
+            info!(
+                commitment = %commitment_hex,
+                %signature,
+                send_attempt,
+                poll,
+                max_polls = CONFIRM_POLLS_PER_BLOCKHASH,
+                "[REVEAL] Polling confirmation"
+            );
+            match ctx.rpc_client.get_signature_statuses(&[signature]).await {
+                Ok(response) => match response.value.into_iter().next().flatten() {
                     None => {
-                        // Tx not yet seen by RPC; keep polling.
-                        info!(commitment = %commitment_hex, %signature, attempt, "[REVEAL] Tx not yet confirmed; continuing to poll");
+                        info!(commitment = %commitment_hex, %signature, poll, "[REVEAL] Tx not yet seen; continuing to poll");
                     }
                     Some(TransactionStatus { err: Some(e), .. }) => {
                         bail!("Reveal tx failed on-chain: {e:?}");
                     }
                     Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
-                        info!(commitment = %commitment_hex, %signature, attempt, "[REVEAL] Tx confirmed");
-                        return Ok(());
+                        info!(commitment = %commitment_hex, %signature, send_attempt, poll, "[REVEAL] Tx confirmed");
+                        confirmed = true;
+                        break;
                     }
                     Some(_) => {
-                        // Landed but not yet at confirmed commitment; keep polling.
-                        info!(commitment = %commitment_hex, %signature, attempt, "[REVEAL] Tx processed but not yet confirmed; continuing to poll");
+                        info!(commitment = %commitment_hex, %signature, poll, "[REVEAL] Tx processed but not yet confirmed; continuing to poll");
                     }
+                },
+                Err(e) => {
+                    warn!(commitment = %commitment_hex, %signature, error = ?e, poll, "[REVEAL] Error polling confirmation");
                 }
             }
-            Err(e) => {
-                warn!(commitment = %commitment_hex, %signature, error = ?e, attempt, "[REVEAL] Error polling confirmation");
-            }
         }
-        if attempt == CONFIRM_MAX_POLLS {
-            bail!("Reveal tx not confirmed after {} polls", CONFIRM_MAX_POLLS);
+
+        if confirmed {
+            return Ok(());
+        }
+
+        if send_attempt < SEND_RETRY_MAX {
+            warn!(
+                commitment = %commitment_hex,
+                %signature,
+                send_attempt,
+                "[REVEAL] Tx not confirmed within blockhash window; retrying with fresh blockhash"
+            );
         }
     }
-    bail!("Reveal tx confirmation timed out")
+    bail!(
+        "Reveal tx not confirmed after {} send attempts",
+        SEND_RETRY_MAX
+    )
 }
 
 async fn fetch_from_ccs(
@@ -462,7 +537,6 @@ fn derive_pending_swap_pda(
 /// precede the reveal instruction so the CLMM output account and recipient ATA exist.
 async fn build_instruction(
     ctx: &RevealContext<'_>,
-    fee_payer_pubkey: Pubkey,
     ccs: &CcsGetResponse,
 ) -> Result<Vec<Instruction>> {
     let program_id = ctx.program_id;
@@ -477,7 +551,7 @@ async fn build_instruction(
 
     // Verify CCS data is consistent with the commitment from the message body.
     let ccs_commitment =
-        solana_program::keccak::hash(&[message.as_slice(), salt.as_ref()].concat()).to_bytes();
+        solana_program::keccak::hashv(&[message.as_slice(), salt.as_ref()]).to_bytes();
     if ccs_commitment != commitment {
         warn!(
             expected = %hex::encode(commitment),
@@ -592,15 +666,25 @@ async fn build_instruction(
                     "[REVEAL] Fetched live CLMM pool state"
                 );
 
-                let live_amm_config = pool_state.amm_config;
-                if accounts[5].pubkey != live_amm_config {
-                    warn!(
-                        ccs = %accounts[5].pubkey,
-                        live = %live_amm_config,
-                        "[REVEAL] account[5] (ammConfig) mismatch — using live pool state"
-                    );
-                    accounts[5].pubkey = live_amm_config;
-                }
+                let override_acct =
+                    |accounts: &mut Vec<AccountMeta>, idx: usize, live: Pubkey, label: &str| {
+                        if accounts[idx].pubkey != live {
+                            warn!(
+                                ccs = %accounts[idx].pubkey,
+                                live = %live,
+                                "[REVEAL] {} mismatch — using live pool state",
+                                label
+                            );
+                            accounts[idx].pubkey = live;
+                        }
+                    };
+
+                override_acct(
+                    &mut accounts,
+                    5,
+                    pool_state.amm_config,
+                    "account[5] (ammConfig)",
+                );
 
                 // Determine swap direction from the input_mint (account[15]) vs pool mint0.
                 // zero_for_one = inputMint == mint0 → inputVault=vault0, outputVault=vault1
@@ -622,34 +706,24 @@ async fn build_instruction(
                 } else {
                     (pool_state.vault1, pool_state.vault0)
                 };
-                if accounts[9].pubkey != live_input_vault {
-                    warn!(
-                        ccs = %accounts[9].pubkey,
-                        live = %live_input_vault,
-                        zero_for_one,
-                        "[REVEAL] account[9] (inputVault) mismatch — using live pool state"
-                    );
-                    accounts[9].pubkey = live_input_vault;
-                }
-                if accounts[10].pubkey != live_output_vault {
-                    warn!(
-                        ccs = %accounts[10].pubkey,
-                        live = %live_output_vault,
-                        zero_for_one,
-                        "[REVEAL] account[10] (outputVault) mismatch — using live pool state"
-                    );
-                    accounts[10].pubkey = live_output_vault;
-                }
-
-                let live_obs = pool_state.observation_state;
-                if accounts[11].pubkey != live_obs {
-                    warn!(
-                        ccs = %accounts[11].pubkey,
-                        live = %live_obs,
-                        "[REVEAL] account[11] (observationState) mismatch — using live pool state"
-                    );
-                    accounts[11].pubkey = live_obs;
-                }
+                override_acct(
+                    &mut accounts,
+                    9,
+                    live_input_vault,
+                    "account[9] (inputVault)",
+                );
+                override_acct(
+                    &mut accounts,
+                    10,
+                    live_output_vault,
+                    "account[10] (outputVault)",
+                );
+                override_acct(
+                    &mut accounts,
+                    11,
+                    pool_state.observation_state,
+                    "account[11] (observationState)",
+                );
 
                 let ticks_in_array = 60i32 * pool_state.tick_spacing as i32;
                 let ta0_start =
@@ -684,17 +758,19 @@ async fn build_instruction(
                 } else {
                     pool_state.mint0
                 };
-                if accounts[15].pubkey != live_input_mint {
-                    warn!(ccs=%accounts[15].pubkey, live=%live_input_mint, "[REVEAL] account[15] (inputMint) mismatch");
-                    accounts[15].pubkey = live_input_mint;
-                }
-                if accounts[16].pubkey != live_output_mint {
-                    warn!(ccs=%accounts[16].pubkey, live=%live_output_mint, "[REVEAL] account[16] (outputMint) mismatch");
-                    accounts[16].pubkey = live_output_mint;
-                }
-                if accounts[23].pubkey != live_output_mint {
-                    accounts[23].pubkey = live_output_mint;
-                }
+                override_acct(
+                    &mut accounts,
+                    15,
+                    live_input_mint,
+                    "account[15] (inputMint)",
+                );
+                override_acct(
+                    &mut accounts,
+                    16,
+                    live_output_mint,
+                    "account[16] (outputMint)",
+                );
+                accounts[23].pubkey = live_output_mint;
 
                 // Derive ATA accounts from locally-known authoritative values so stale CCS
                 // entries can't cause address constraint failures.
@@ -712,27 +788,70 @@ async fn build_instruction(
                 let live_recipient_output_ata =
                     derive_ata(&recipient_pubkey, &live_output_mint, &output_token_prog);
 
-                if accounts[1].pubkey != live_pda_input_ata {
-                    warn!(ccs=%accounts[1].pubkey, live=%live_pda_input_ata, "[REVEAL] account[1] (pda_input_ata) mismatch");
-                    accounts[1].pubkey = live_pda_input_ata;
-                }
-                if accounts[7].pubkey != live_pda_input_ata {
-                    accounts[7].pubkey = live_pda_input_ata;
-                }
-                if accounts[8].pubkey != live_pda_output_ata {
-                    warn!(ccs=%accounts[8].pubkey, live=%live_pda_output_ata, "[REVEAL] account[8] (pda_output_ata) mismatch");
-                    accounts[8].pubkey = live_pda_output_ata;
-                }
-                if accounts[21].pubkey != live_pda_output_ata {
-                    accounts[21].pubkey = live_pda_output_ata;
-                }
-                if accounts[22].pubkey != live_recipient_output_ata {
-                    warn!(ccs=%accounts[22].pubkey, live=%live_recipient_output_ata, "[REVEAL] account[22] (recipient_output_ata) mismatch");
-                    accounts[22].pubkey = live_recipient_output_ata;
-                }
+                override_acct(
+                    &mut accounts,
+                    1,
+                    live_pda_input_ata,
+                    "account[1] (pda_input_ata)",
+                );
+                accounts[7].pubkey = live_pda_input_ata;
+                override_acct(
+                    &mut accounts,
+                    8,
+                    live_pda_output_ata,
+                    "account[8] (pda_output_ata)",
+                );
+                accounts[21].pubkey = live_pda_output_ata;
+                let fee_payer_pubkey = ctx.fee_payer.pubkey();
+                let output_is_native_sol = live_output_mint == WSOL_MINT;
 
-                // Build idempotent ATA creates: CLMM output ATA and recipient output ATA
-                // must exist before the reveal instruction executes.
+                // For native SOL output: account[22] must be the fee_payer's wSOL ATA
+                // (not the recipient's). The UR SWEEP moves PDA wSOL → fee_payer wSOL ATA,
+                // then a CloseAccount ix below unwraps it → native SOL to recipient.
+                let (ata_second, maybe_close_ix) = if output_is_native_sol {
+                    let fee_payer_wsol_ata =
+                        derive_ata(&fee_payer_pubkey, &WSOL_MINT, &SPL_TOKEN_PROGRAM);
+                    override_acct(
+                        &mut accounts,
+                        22,
+                        fee_payer_wsol_ata,
+                        "account[22] (fee_payer_wsol_ata for SOL output)",
+                    );
+                    let ata_ix = make_ata_ix(
+                        &fee_payer_pubkey,
+                        &fee_payer_wsol_ata,
+                        &fee_payer_pubkey,
+                        &WSOL_MINT,
+                        &SPL_TOKEN_PROGRAM,
+                    );
+                    let close_ix = make_close_account_ix(
+                        &fee_payer_wsol_ata,
+                        &recipient_pubkey,
+                        &fee_payer_pubkey,
+                    );
+                    info!(
+                        fee_payer_wsol_ata = %fee_payer_wsol_ata,
+                        recipient = %recipient_pubkey,
+                        "[REVEAL] SOL output: fee_payer wSOL ATA will be closed → native SOL to recipient"
+                    );
+                    (ata_ix, Some(close_ix))
+                } else {
+                    override_acct(
+                        &mut accounts,
+                        22,
+                        live_recipient_output_ata,
+                        "account[22] (recipient_output_ata)",
+                    );
+                    let ata_ix = make_ata_ix(
+                        &fee_payer_pubkey,
+                        &live_recipient_output_ata,
+                        &recipient_pubkey,
+                        &live_output_mint,
+                        &output_token_prog,
+                    );
+                    (ata_ix, None)
+                };
+
                 let ata_pda_output = make_ata_ix(
                     &fee_payer_pubkey,
                     &live_pda_output_ata,
@@ -740,17 +859,10 @@ async fn build_instruction(
                     &live_output_mint,
                     &output_token_prog,
                 );
-                let ata_recipient = make_ata_ix(
-                    &fee_payer_pubkey,
-                    &live_recipient_output_ata,
-                    &recipient_pubkey,
-                    &live_output_mint,
-                    &output_token_prog,
-                );
 
                 info!(
                     pda_output_ata = %live_pda_output_ata,
-                    recipient_output_ata = %live_recipient_output_ata,
+                    output_is_native_sol,
                     "[REVEAL] ATA creation instructions prepared"
                 );
 
@@ -759,7 +871,11 @@ async fn build_instruction(
                     accounts,
                     data,
                 };
-                return Ok(vec![ata_pda_output, ata_recipient, reveal_ix]);
+                let mut ixs = vec![ata_pda_output, ata_second, reveal_ix];
+                if let Some(close_ix) = maybe_close_ix {
+                    ixs.push(close_ix);
+                }
+                return Ok(ixs);
             }
             Err(e) => {
                 warn!(

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -322,6 +322,27 @@ pub fn maybe_spawn_reveal(
                     break;
                 }
                 Ok(None) => {
+                    // Check if this PDA ever existed. If there's any transaction
+                    // history it was created and then consumed by a successful reveal —
+                    // either by us on a prior run or by another relayer. Stop immediately
+                    // rather than waiting the full 10-min timeout.
+                    match rpc_client
+                        .get_signatures_for_address_with_limit(pending_swap_pda, 1)
+                        .await
+                    {
+                        Ok(sigs) if !sigs.is_empty() => {
+                            info!(
+                                commitment = %commitment_hex,
+                                %pending_swap_pda,
+                                "[REVEAL] PDA is gone and has transaction history — reveal already completed; stopping"
+                            );
+                            return;
+                        }
+                        Ok(_) => {} // no history yet, commit hasn't landed
+                        Err(e) => {
+                            warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA history; assuming not yet created");
+                        }
+                    }
                     pda_wait_iters += 1;
                     if pda_wait_iters >= PDA_WAIT_MAX_ITERS {
                         info!(

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -31,6 +31,7 @@ use solana_sdk::{
     signature::Signer,
     transaction::Transaction,
 };
+use solana_transaction_status::TransactionStatus;
 use tracing::{error, info, warn};
 
 use crate::{
@@ -43,6 +44,135 @@ const CCS_MAX_RETRIES: u32 = 10;
 const CCS_RETRY_DELAY_SECS: u64 = 5;
 const CONFIRM_MAX_POLLS: u32 = 60;
 const CONFIRM_POLL_DELAY_MS: u64 = 2_000;
+
+// Raydium CLMM program on mainnet.
+const RAYDIUM_CLMM_PROGRAM: Pubkey =
+    solana_program::pubkey!("CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK");
+
+// SPL Associated Token Account program.
+const ATA_PROGRAM: Pubkey = solana_program::pubkey!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+
+// Byte offsets within a Raydium CLMM PoolState account (includes 8-byte Anchor discriminant).
+// Verified against `reveal.mjs` fetchClmmPoolState offsets.
+const POOL_AMM_CONFIG_OFFSET: usize = 9; // Pubkey (32 bytes)
+const POOL_MINT0_OFFSET: usize = 73; // Pubkey (32 bytes)
+const POOL_MINT1_OFFSET: usize = 105; // Pubkey (32 bytes)
+const POOL_VAULT0_OFFSET: usize = 137; // Pubkey (32 bytes)
+const POOL_VAULT1_OFFSET: usize = 169; // Pubkey (32 bytes)
+const POOL_OBS_STATE_OFFSET: usize = 201; // Pubkey (32 bytes)
+const POOL_TICK_SPACING_OFFSET: usize = 235; // i16 LE
+const POOL_TICK_CURRENT_OFFSET: usize = 269; // i32 LE
+
+struct ClmmPoolState {
+    amm_config: Pubkey,
+    mint0: Pubkey,
+    #[allow(dead_code)]
+    mint1: Pubkey,
+    vault0: Pubkey,
+    vault1: Pubkey,
+    observation_state: Pubkey,
+    tick_spacing: i16,
+    tick_current: i32,
+}
+
+fn parse_clmm_pool_state(data: &[u8]) -> Result<ClmmPoolState> {
+    let min_len = POOL_TICK_CURRENT_OFFSET + 4;
+    if data.len() < min_len {
+        bail!(
+            "pool account data too short: {} bytes (need {})",
+            data.len(),
+            min_len
+        );
+    }
+    #[allow(clippy::unwrap_used)]
+    let read_pubkey =
+        |offset: usize| Pubkey::new_from_array(data[offset..offset + 32].try_into().unwrap());
+    #[allow(clippy::unwrap_used)]
+    let tick_spacing = i16::from_le_bytes(
+        data[POOL_TICK_SPACING_OFFSET..POOL_TICK_SPACING_OFFSET + 2]
+            .try_into()
+            .unwrap(),
+    );
+    #[allow(clippy::unwrap_used)]
+    let tick_current = i32::from_le_bytes(
+        data[POOL_TICK_CURRENT_OFFSET..POOL_TICK_CURRENT_OFFSET + 4]
+            .try_into()
+            .unwrap(),
+    );
+    Ok(ClmmPoolState {
+        amm_config: read_pubkey(POOL_AMM_CONFIG_OFFSET),
+        mint0: read_pubkey(POOL_MINT0_OFFSET),
+        mint1: read_pubkey(POOL_MINT1_OFFSET),
+        vault0: read_pubkey(POOL_VAULT0_OFFSET),
+        vault1: read_pubkey(POOL_VAULT1_OFFSET),
+        observation_state: read_pubkey(POOL_OBS_STATE_OFFSET),
+        tick_spacing,
+        tick_current,
+    })
+}
+
+async fn fetch_clmm_pool_state(
+    pool_pubkey: Pubkey,
+    rpc_client: &SealevelFallbackRpcClient,
+) -> Result<ClmmPoolState> {
+    let account = rpc_client
+        .get_account_option_with_commitment(pool_pubkey, CommitmentConfig::processed())
+        .await
+        .map_err(|e| eyre!("fetch pool account {pool_pubkey}: {e}"))?
+        .ok_or_else(|| eyre!("pool account {pool_pubkey} not found on chain"))?;
+    parse_clmm_pool_state(&account.data)
+}
+
+// Mirrors reveal.mjs `getTickArrayStartIndex`.  Uses truncation-towards-zero integer
+// division (Rust default), with an explicit floor correction for negative ticks.
+fn get_tick_array_start_index(tick_current: i32, tick_spacing: i16) -> i32 {
+    let ticks_in_array = 60i32 * tick_spacing as i32;
+    let mut start = (tick_current / ticks_in_array) * ticks_in_array;
+    if tick_current < 0 && tick_current % ticks_in_array != 0 {
+        start -= ticks_in_array;
+    }
+    start
+}
+
+// Seeds: [b"tick_array", pool_id (32 bytes), start_index (i32 big-endian)]
+fn compute_tick_array_address(pool_id: &Pubkey, start_index: i32) -> Pubkey {
+    Pubkey::find_program_address(
+        &[b"tick_array", pool_id.as_ref(), &start_index.to_be_bytes()],
+        &RAYDIUM_CLMM_PROGRAM,
+    )
+    .0
+}
+
+// Seeds for ATA: [owner, token_program, mint] under ATA_PROGRAM
+fn derive_ata(owner: &Pubkey, mint: &Pubkey, token_program: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(
+        &[owner.as_ref(), token_program.as_ref(), mint.as_ref()],
+        &ATA_PROGRAM,
+    )
+    .0
+}
+
+// Idempotent ATA create instruction (discriminant = 1).
+fn make_ata_ix(
+    payer: &Pubkey,
+    ata: &Pubkey,
+    owner: &Pubkey,
+    mint: &Pubkey,
+    token_program: &Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id: ATA_PROGRAM,
+        accounts: vec![
+            AccountMeta::new(*payer, true),
+            AccountMeta::new(*ata, false),
+            AccountMeta::new_readonly(*owner, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(solana_system_interface::program::id(), false),
+            AccountMeta::new_readonly(*token_program, false),
+        ],
+        data: vec![1u8],
+    }
+}
 
 /// Configuration for automated UR reveal submission on a Sealevel destination.
 #[derive(Debug, Clone)]
@@ -84,7 +214,7 @@ pub fn maybe_spawn_reveal(
         info!(
             body_len,
             origin = message.origin,
-            "Skipping UR reveal: body is not 96 bytes (not a COMMIT message)"
+            "[REVEAL] Skipping: body is not 96 bytes (not a COMMIT message)"
         );
         return;
     }
@@ -93,6 +223,8 @@ pub fn maybe_spawn_reveal(
     let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
     #[allow(clippy::unwrap_used)]
     let user_salt: [u8; 32] = message.body[32..64].try_into().unwrap();
+    #[allow(clippy::unwrap_used)]
+    let recipient: [u8; 32] = message.body[64..96].try_into().unwrap();
     let origin = message.origin;
     let sender = message.sender.0;
     let commitment_hex = hex::encode(commitment);
@@ -107,7 +239,7 @@ pub fn maybe_spawn_reveal(
         ccs_url = %config.ccs_url,
         program_id = %config.program_id,
         fee_payer = %fee_payer.pubkey(),
-        "Spawning UR reveal task"
+        "[REVEAL] Spawning reveal task"
     );
 
     let ccs_url = config.ccs_url.trim_end_matches('/').to_owned();
@@ -117,11 +249,11 @@ pub fn maybe_spawn_reveal(
         let program_id = match Pubkey::from_str(&program_id_str) {
             Ok(p) => p,
             Err(e) => {
-                error!(commitment = %commitment_hex, error = ?e, "Invalid UR program ID; aborting reveal");
+                error!(commitment = %commitment_hex, error = ?e, "[REVEAL] Invalid program ID; aborting");
                 return;
             }
         };
-        info!(commitment = %commitment_hex, %program_id, "UR reveal task started");
+        info!(commitment = %commitment_hex, %program_id, "[REVEAL] Task started");
         let ctx = RevealContext {
             ccs_url: &ccs_url,
             program_id,
@@ -129,13 +261,14 @@ pub fn maybe_spawn_reveal(
             origin,
             sender,
             user_salt,
+            recipient,
             rpc_client: &rpc_client,
             priority_fee_oracle,
             fee_payer: &fee_payer,
         };
         match submit_reveal(ctx).await {
-            Err(e) => error!(commitment = %commitment_hex, error = ?e, "UR reveal failed"),
-            Ok(()) => info!(commitment = %commitment_hex, "UR reveal confirmed successfully"),
+            Err(e) => error!(commitment = %commitment_hex, error = ?e, "[REVEAL] Failed"),
+            Ok(()) => info!(commitment = %commitment_hex, "[REVEAL] Confirmed successfully"),
         }
     });
 }
@@ -147,50 +280,40 @@ struct RevealContext<'a> {
     origin: u32,
     sender: [u8; 32],
     user_salt: [u8; 32],
+    recipient: [u8; 32],
     rpc_client: &'a SealevelFallbackRpcClient,
     priority_fee_oracle: Arc<dyn PriorityFeeOracle>,
     fee_payer: &'a SealevelKeypair,
 }
 
 async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
-    let RevealContext {
-        ccs_url,
-        program_id,
-        commitment,
-        origin,
-        sender,
-        user_salt,
-        rpc_client,
-        priority_fee_oracle,
-        fee_payer,
-    } = ctx;
-    let commitment_hex = hex::encode(commitment);
+    let commitment_hex = hex::encode(ctx.commitment);
 
-    info!(commitment = %commitment_hex, ccs_url, "Fetching reveal data from CCS");
+    info!(commitment = %commitment_hex, ccs_url = ctx.ccs_url, "[REVEAL] Fetching calldata from CCS");
     let http = Client::new();
-    let ccs = fetch_from_ccs(&http, ccs_url, &commitment).await?;
+    let ccs = fetch_from_ccs(&http, ctx.ccs_url, &ctx.commitment).await?;
     info!(
         commitment = %commitment_hex,
         data_len = ccs.data.len(),
         salt = %ccs.salt,
         reveal_accounts_count = ccs.reveal_accounts.as_ref().map(|a| a.len()).unwrap_or(0),
-        "CCS fetch succeeded"
+        "[REVEAL] CCS fetch succeeded"
     );
 
-    info!(commitment = %commitment_hex, "Building RouterInstruction::Reveal");
-    let instruction = build_instruction(program_id, origin, sender, user_salt, &ccs)?;
+    info!(commitment = %commitment_hex, "[REVEAL] Building RouterInstruction::Reveal");
+    let mut built = build_instruction(&ctx, ctx.fee_payer.pubkey(), &ccs).await?;
     info!(
         commitment = %commitment_hex,
-        accounts_count = instruction.accounts.len(),
-        data_len = instruction.data.len(),
-        "Reveal instruction built"
+        instruction_count = built.len(),
+        "[REVEAL] Instructions built"
     );
 
     let dummy = SealevelTxType::Legacy(Transaction::new_unsigned(Message::new(
         &[],
-        Some(&fee_payer.pubkey()),
+        Some(&ctx.fee_payer.pubkey()),
     )));
-    let priority_fee = priority_fee_oracle
+    let priority_fee = ctx
+        .priority_fee_oracle
         .get_priority_fee(&dummy)
         .await
         .unwrap_or(0);
@@ -198,54 +321,66 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
         commitment = %commitment_hex,
         priority_fee,
         compute_units = REVEAL_COMPUTE_UNITS,
-        "Priority fee determined"
+        "[REVEAL] Priority fee determined"
     );
 
-    let instructions = vec![
+    let mut instructions = vec![
         ComputeBudgetInstruction::set_compute_unit_limit(REVEAL_COMPUTE_UNITS),
         ComputeBudgetInstruction::set_compute_unit_price(priority_fee),
-        instruction,
     ];
+    instructions.append(&mut built);
 
-    info!(commitment = %commitment_hex, "Fetching latest blockhash");
-    let blockhash = rpc_client
-        .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
+    // Use `confirmed` commitment for the blockhash so the tx has a full ~150-slot validity window.
+    info!(commitment = %commitment_hex, "[REVEAL] Fetching latest blockhash");
+    let blockhash = ctx
+        .rpc_client
+        .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
         .await
         .map_err(|e| eyre!("get_latest_blockhash: {e}"))?;
-    info!(commitment = %commitment_hex, blockhash = %blockhash, "Got blockhash");
+    info!(commitment = %commitment_hex, blockhash = %blockhash, "[REVEAL] Got blockhash");
 
-    let message = Message::new(&instructions, Some(&fee_payer.pubkey()));
-    let tx = Transaction::new(&[fee_payer.keypair()], message, blockhash);
+    let message = Message::new(&instructions, Some(&ctx.fee_payer.pubkey()));
+    let tx = Transaction::new(&[ctx.fee_payer.keypair()], message, blockhash);
 
-    info!(commitment = %commitment_hex, fee_payer = %fee_payer.pubkey(), "Sending reveal transaction");
-    let signature = rpc_client
+    info!(commitment = %commitment_hex, fee_payer = %ctx.fee_payer.pubkey(), "[REVEAL] Sending transaction");
+    let signature = ctx
+        .rpc_client
         .send_transaction(&tx, true)
         .await
         .map_err(|e| eyre!("send_transaction: {e}"))?;
 
     let max_confirm_secs = CONFIRM_MAX_POLLS.saturating_mul((CONFIRM_POLL_DELAY_MS / 1000) as u32);
-    info!(commitment = %commitment_hex, %signature, max_confirm_secs, "Reveal tx sent; polling for confirmation");
+    info!(commitment = %commitment_hex, %signature, max_confirm_secs, "[REVEAL] Tx sent; polling for confirmation");
 
     for attempt in 1..=CONFIRM_MAX_POLLS {
         tokio::time::sleep(Duration::from_millis(CONFIRM_POLL_DELAY_MS)).await;
-        info!(commitment = %commitment_hex, %signature, attempt, max_attempts = CONFIRM_MAX_POLLS, "Polling reveal tx confirmation");
-        match rpc_client
-            .confirm_transaction_with_commitment(signature, CommitmentConfig::confirmed())
-            .await
-        {
-            Ok(true) => {
-                info!(commitment = %commitment_hex, %signature, attempt, "Reveal tx confirmed");
-                return Ok(());
-            }
-            Ok(false) => {
-                if attempt == CONFIRM_MAX_POLLS {
-                    bail!("Reveal tx not confirmed after {} polls", CONFIRM_MAX_POLLS);
+        info!(commitment = %commitment_hex, %signature, attempt, max_attempts = CONFIRM_MAX_POLLS, "[REVEAL] Polling confirmation");
+        match ctx.rpc_client.get_signature_statuses(&[signature]).await {
+            Ok(response) => {
+                match response.value.into_iter().next().flatten() {
+                    None => {
+                        // Tx not yet seen by RPC; keep polling.
+                        info!(commitment = %commitment_hex, %signature, attempt, "[REVEAL] Tx not yet confirmed; continuing to poll");
+                    }
+                    Some(TransactionStatus { err: Some(e), .. }) => {
+                        bail!("Reveal tx failed on-chain: {e:?}");
+                    }
+                    Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
+                        info!(commitment = %commitment_hex, %signature, attempt, "[REVEAL] Tx confirmed");
+                        return Ok(());
+                    }
+                    Some(_) => {
+                        // Landed but not yet at confirmed commitment; keep polling.
+                        info!(commitment = %commitment_hex, %signature, attempt, "[REVEAL] Tx processed but not yet confirmed; continuing to poll");
+                    }
                 }
-                info!(commitment = %commitment_hex, %signature, attempt, "Reveal tx not yet confirmed; continuing to poll");
             }
             Err(e) => {
-                warn!(commitment = %commitment_hex, %signature, error = ?e, attempt, "Error polling reveal tx confirmation")
+                warn!(commitment = %commitment_hex, %signature, error = ?e, attempt, "[REVEAL] Error polling confirmation");
             }
+        }
+        if attempt == CONFIRM_MAX_POLLS {
+            bail!("Reveal tx not confirmed after {} polls", CONFIRM_MAX_POLLS);
         }
     }
     bail!("Reveal tx confirmation timed out")
@@ -258,12 +393,12 @@ async fn fetch_from_ccs(
 ) -> Result<CcsGetResponse> {
     let commitment_hex = hex::encode(commitment);
     let url = format!("{ccs_url}/calldata/0x{commitment_hex}");
-    info!(commitment = %commitment_hex, url, "GET CCS calldata");
+    info!(commitment = %commitment_hex, url, "[REVEAL] GET CCS calldata");
     for attempt in 1..=CCS_MAX_RETRIES {
-        info!(commitment = %commitment_hex, attempt, max_retries = CCS_MAX_RETRIES, url, "CCS fetch attempt");
+        info!(commitment = %commitment_hex, attempt, max_retries = CCS_MAX_RETRIES, url, "[REVEAL] CCS fetch attempt");
         let resp = http.get(&url).send().await?;
         let status = resp.status();
-        info!(commitment = %commitment_hex, attempt, %status, "CCS response received");
+        info!(commitment = %commitment_hex, attempt, %status, "[REVEAL] CCS response received");
         match status {
             s if s.is_success() => {
                 let ccs = resp.json::<CcsGetResponse>().await?;
@@ -271,7 +406,7 @@ async fn fetch_from_ccs(
                     commitment = %commitment_hex,
                     attempt,
                     has_reveal_accounts = ccs.reveal_accounts.is_some(),
-                    "CCS calldata parsed successfully"
+                    "[REVEAL] CCS calldata parsed successfully"
                 );
                 return Ok(ccs);
             }
@@ -282,11 +417,11 @@ async fn fetch_from_ccs(
                         attempt,
                         max_retries = CCS_MAX_RETRIES,
                         retry_delay_secs = CCS_RETRY_DELAY_SECS,
-                        "CCS 404 — calldata not yet stored; retrying"
+                        "[REVEAL] CCS 404 — calldata not yet stored; retrying"
                     );
                     tokio::time::sleep(Duration::from_secs(CCS_RETRY_DELAY_SECS)).await;
                 } else {
-                    warn!(commitment = %commitment_hex, attempt, "CCS 404 on final attempt");
+                    warn!(commitment = %commitment_hex, attempt, "[REVEAL] CCS 404 on final attempt");
                 }
             }
             _ => bail!(
@@ -299,15 +434,57 @@ async fn fetch_from_ccs(
     bail!("CCS returned 404 after {} retries", CCS_MAX_RETRIES)
 }
 
-fn build_instruction(
-    program_id: Pubkey,
+fn derive_fee_payer_pda(program_id: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[b"hyperlane_fee_payer"], program_id).0
+}
+
+fn derive_pending_swap_pda(
+    program_id: &Pubkey,
     origin: u32,
-    sender: [u8; 32],
-    user_salt: [u8; 32],
+    sender: &[u8; 32],
+    user_salt: &[u8; 32],
+    commitment: &[u8; 32],
+) -> Pubkey {
+    Pubkey::find_program_address(
+        &[
+            b"pending_swap",
+            &origin.to_le_bytes(),
+            sender.as_ref(),
+            user_salt.as_ref(),
+            commitment.as_ref(),
+        ],
+        program_id,
+    )
+    .0
+}
+
+/// Returns [ata_create_0, ata_create_1, reveal_ix] — the two idempotent ATA creates must
+/// precede the reveal instruction so the CLMM output account and recipient ATA exist.
+async fn build_instruction(
+    ctx: &RevealContext<'_>,
+    fee_payer_pubkey: Pubkey,
     ccs: &CcsGetResponse,
-) -> Result<Instruction> {
+) -> Result<Vec<Instruction>> {
+    let program_id = ctx.program_id;
+    let origin = ctx.origin;
+    let sender = ctx.sender;
+    let user_salt = ctx.user_salt;
+    let recipient = ctx.recipient;
+    let commitment = ctx.commitment;
+    let rpc_client = ctx.rpc_client;
     let message = hex_decode_bytes(&ccs.data)?;
     let salt = hex_decode_fixed32(&ccs.salt)?;
+
+    // Verify CCS data is consistent with the commitment from the message body.
+    let ccs_commitment =
+        solana_program::keccak::hash(&[message.as_slice(), salt.as_ref()].concat()).to_bytes();
+    if ccs_commitment != commitment {
+        warn!(
+            expected = %hex::encode(commitment),
+            from_ccs = %hex::encode(ccs_commitment),
+            "[REVEAL] CCS keccak(calldata||salt) does not match message body commitment — CCS data may be stale or wrong"
+        );
+    }
 
     let msg_len = message.len() as u32;
     info!(
@@ -316,7 +493,7 @@ fn build_instruction(
         user_salt = %hex::encode(user_salt),
         message_len = msg_len,
         salt = %ccs.salt,
-        "Building reveal instruction data"
+        "[REVEAL] Building instruction data"
     );
 
     // 1 (variant) + 4 (origin) + 32 (sender) + 32 (user_salt) + 4 (msg_len) + message + 32 (salt)
@@ -335,23 +512,62 @@ fn build_instruction(
         .as_deref()
         .ok_or_else(|| eyre!("CCS response missing revealAccounts"))?;
 
+    // Derive both critical PDAs locally to verify (and override) what CCS stored.
+    // Use commitment from message body — the authoritative PDA seed.
+    let expected_pending_swap =
+        derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
+    let expected_fee_payer_pda = derive_fee_payer_pda(&program_id);
+    info!(
+        expected_pending_swap = %expected_pending_swap,
+        expected_fee_payer_pda = %expected_fee_payer_pda,
+        "[REVEAL] Locally-derived PDAs"
+    );
+
     info!(
         account_count = reveal_accounts.len(),
-        "Building account metas from revealAccounts"
+        "[REVEAL] Building account metas"
     );
-    let accounts: Vec<AccountMeta> = reveal_accounts
+    let mut accounts: Vec<AccountMeta> = reveal_accounts
         .iter()
         .enumerate()
         .map(|(i, a)| {
-            info!(
-                index = i,
-                pubkey = %a.pubkey,
-                is_writable = a.is_writable,
-                is_signer = a.is_signer,
-                "Reveal account"
-            );
             let pubkey = Pubkey::from_str(&a.pubkey)
                 .map_err(|e| eyre!("invalid pubkey {}: {}", a.pubkey, e))?;
+
+            // Override accounts[0] (pending_swap), accounts[2] (fee_payer_pda), and
+            // accounts[4] (CLMM payer = pending_swap PDA) with locally-derived values.
+            let pubkey = match i {
+                0 | 4 => {
+                    if pubkey != expected_pending_swap {
+                        warn!(
+                            index = i,
+                            ccs_pubkey = %pubkey,
+                            expected = %expected_pending_swap,
+                            "[REVEAL] account (pending_swap PDA) mismatch — using locally-derived PDA"
+                        );
+                    }
+                    expected_pending_swap
+                }
+                2 => {
+                    if pubkey != expected_fee_payer_pda {
+                        warn!(
+                            ccs_pubkey = %pubkey,
+                            expected = %expected_fee_payer_pda,
+                            "[REVEAL] account[2] (fee_payer_pda) mismatch — using locally-derived PDA"
+                        );
+                    }
+                    expected_fee_payer_pda
+                }
+                _ => pubkey,
+            };
+
+            info!(
+                index = i,
+                pubkey = %pubkey,
+                is_writable = a.is_writable,
+                is_signer = a.is_signer,
+                "[REVEAL] Account"
+            );
             Ok(match (a.is_writable, a.is_signer) {
                 (true, _) => AccountMeta::new(pubkey, a.is_signer),
                 (false, _) => AccountMeta::new_readonly(pubkey, a.is_signer),
@@ -359,17 +575,218 @@ fn build_instruction(
         })
         .collect::<Result<_>>()?;
 
+    // Fetch live CLMM pool state and override accounts[5] (ammConfig),
+    // accounts[11] (observationState), and accounts[17..=19] (tick arrays).
+    // The engine may store stale values (e.g. observationState falls back to poolId
+    // when hop.observationState is undefined at quote time → ConstraintAddress error).
+    if accounts.len() > 24 {
+        let pool_pubkey = accounts[6].pubkey;
+        match fetch_clmm_pool_state(pool_pubkey, rpc_client).await {
+            Ok(pool_state) => {
+                info!(
+                    pool = %pool_pubkey,
+                    amm_config = %pool_state.amm_config,
+                    observation_state = %pool_state.observation_state,
+                    tick_current = pool_state.tick_current,
+                    tick_spacing = pool_state.tick_spacing,
+                    "[REVEAL] Fetched live CLMM pool state"
+                );
+
+                let live_amm_config = pool_state.amm_config;
+                if accounts[5].pubkey != live_amm_config {
+                    warn!(
+                        ccs = %accounts[5].pubkey,
+                        live = %live_amm_config,
+                        "[REVEAL] account[5] (ammConfig) mismatch — using live pool state"
+                    );
+                    accounts[5].pubkey = live_amm_config;
+                }
+
+                // Determine swap direction from the input_mint (account[15]) vs pool mint0.
+                // zero_for_one = inputMint == mint0 → inputVault=vault0, outputVault=vault1
+                // If accounts[15] matches neither pool mint, CCS is corrupt — bail rather than
+                // silently using the wrong vaults and ATAs.
+                let input_mint = accounts[15].pubkey;
+                let zero_for_one = if input_mint == pool_state.mint0 {
+                    true
+                } else if input_mint == pool_state.mint1 {
+                    false
+                } else {
+                    bail!(
+                        "accounts[15] (inputMint {}) matches neither pool mint0 ({}) nor mint1 ({}) — CCS route data is corrupt",
+                        input_mint, pool_state.mint0, pool_state.mint1
+                    );
+                };
+                let (live_input_vault, live_output_vault) = if zero_for_one {
+                    (pool_state.vault0, pool_state.vault1)
+                } else {
+                    (pool_state.vault1, pool_state.vault0)
+                };
+                if accounts[9].pubkey != live_input_vault {
+                    warn!(
+                        ccs = %accounts[9].pubkey,
+                        live = %live_input_vault,
+                        zero_for_one,
+                        "[REVEAL] account[9] (inputVault) mismatch — using live pool state"
+                    );
+                    accounts[9].pubkey = live_input_vault;
+                }
+                if accounts[10].pubkey != live_output_vault {
+                    warn!(
+                        ccs = %accounts[10].pubkey,
+                        live = %live_output_vault,
+                        zero_for_one,
+                        "[REVEAL] account[10] (outputVault) mismatch — using live pool state"
+                    );
+                    accounts[10].pubkey = live_output_vault;
+                }
+
+                let live_obs = pool_state.observation_state;
+                if accounts[11].pubkey != live_obs {
+                    warn!(
+                        ccs = %accounts[11].pubkey,
+                        live = %live_obs,
+                        "[REVEAL] account[11] (observationState) mismatch — using live pool state"
+                    );
+                    accounts[11].pubkey = live_obs;
+                }
+
+                let ticks_in_array = 60i32 * pool_state.tick_spacing as i32;
+                let ta0_start =
+                    get_tick_array_start_index(pool_state.tick_current, pool_state.tick_spacing);
+                // Forward progression matches UI's buildClmmAccounts formula.
+                let ta1_start = ta0_start + ticks_in_array;
+                let ta2_start = ta0_start + 2 * ticks_in_array;
+                let live_ta0 = compute_tick_array_address(&pool_pubkey, ta0_start);
+                let live_ta1 = compute_tick_array_address(&pool_pubkey, ta1_start);
+                let live_ta2 = compute_tick_array_address(&pool_pubkey, ta2_start);
+                info!(
+                    ta0 = %live_ta0,
+                    ta1 = %live_ta1,
+                    ta2 = %live_ta2,
+                    ta0_start,
+                    ta1_start,
+                    ta2_start,
+                    "[REVEAL] Recomputed tick arrays from live pool state"
+                );
+                accounts[17].pubkey = live_ta0;
+                accounts[18].pubkey = live_ta1;
+                accounts[19].pubkey = live_ta2;
+
+                // Override mints from pool state so they're guaranteed correct.
+                let live_input_mint = if zero_for_one {
+                    pool_state.mint0
+                } else {
+                    pool_state.mint1
+                };
+                let live_output_mint = if zero_for_one {
+                    pool_state.mint1
+                } else {
+                    pool_state.mint0
+                };
+                if accounts[15].pubkey != live_input_mint {
+                    warn!(ccs=%accounts[15].pubkey, live=%live_input_mint, "[REVEAL] account[15] (inputMint) mismatch");
+                    accounts[15].pubkey = live_input_mint;
+                }
+                if accounts[16].pubkey != live_output_mint {
+                    warn!(ccs=%accounts[16].pubkey, live=%live_output_mint, "[REVEAL] account[16] (outputMint) mismatch");
+                    accounts[16].pubkey = live_output_mint;
+                }
+                if accounts[23].pubkey != live_output_mint {
+                    accounts[23].pubkey = live_output_mint;
+                }
+
+                // Derive ATA accounts from locally-known authoritative values so stale CCS
+                // entries can't cause address constraint failures.
+                let input_token_prog = accounts[12].pubkey;
+                let output_token_prog = accounts[24].pubkey;
+
+                let live_pda_input_ata =
+                    derive_ata(&expected_pending_swap, &live_input_mint, &input_token_prog);
+                let live_pda_output_ata = derive_ata(
+                    &expected_pending_swap,
+                    &live_output_mint,
+                    &output_token_prog,
+                );
+                let recipient_pubkey = Pubkey::new_from_array(recipient);
+                let live_recipient_output_ata =
+                    derive_ata(&recipient_pubkey, &live_output_mint, &output_token_prog);
+
+                if accounts[1].pubkey != live_pda_input_ata {
+                    warn!(ccs=%accounts[1].pubkey, live=%live_pda_input_ata, "[REVEAL] account[1] (pda_input_ata) mismatch");
+                    accounts[1].pubkey = live_pda_input_ata;
+                }
+                if accounts[7].pubkey != live_pda_input_ata {
+                    accounts[7].pubkey = live_pda_input_ata;
+                }
+                if accounts[8].pubkey != live_pda_output_ata {
+                    warn!(ccs=%accounts[8].pubkey, live=%live_pda_output_ata, "[REVEAL] account[8] (pda_output_ata) mismatch");
+                    accounts[8].pubkey = live_pda_output_ata;
+                }
+                if accounts[21].pubkey != live_pda_output_ata {
+                    accounts[21].pubkey = live_pda_output_ata;
+                }
+                if accounts[22].pubkey != live_recipient_output_ata {
+                    warn!(ccs=%accounts[22].pubkey, live=%live_recipient_output_ata, "[REVEAL] account[22] (recipient_output_ata) mismatch");
+                    accounts[22].pubkey = live_recipient_output_ata;
+                }
+
+                // Build idempotent ATA creates: CLMM output ATA and recipient output ATA
+                // must exist before the reveal instruction executes.
+                let ata_pda_output = make_ata_ix(
+                    &fee_payer_pubkey,
+                    &live_pda_output_ata,
+                    &expected_pending_swap,
+                    &live_output_mint,
+                    &output_token_prog,
+                );
+                let ata_recipient = make_ata_ix(
+                    &fee_payer_pubkey,
+                    &live_recipient_output_ata,
+                    &recipient_pubkey,
+                    &live_output_mint,
+                    &output_token_prog,
+                );
+
+                info!(
+                    pda_output_ata = %live_pda_output_ata,
+                    recipient_output_ata = %live_recipient_output_ata,
+                    "[REVEAL] ATA creation instructions prepared"
+                );
+
+                let reveal_ix = Instruction {
+                    program_id,
+                    accounts,
+                    data,
+                };
+                return Ok(vec![ata_pda_output, ata_recipient, reveal_ix]);
+            }
+            Err(e) => {
+                warn!(
+                    pool = %pool_pubkey,
+                    error = ?e,
+                    "[REVEAL] Could not fetch CLMM pool state; submitting without ATA pre-creation"
+                );
+            }
+        }
+    } else {
+        warn!(
+            account_count = accounts.len(),
+            "[REVEAL] Expected 25 accounts for CLMM reveal — skipping live pool state override"
+        );
+    }
+
     info!(
         total_data_len = data.len(),
         total_accounts = accounts.len(),
-        "Reveal instruction assembled"
+        "[REVEAL] Instruction assembled (no pool state override)"
     );
 
-    Ok(Instruction {
+    Ok(vec![Instruction {
         program_id,
         accounts,
         data,
-    })
+    }])
 }
 
 fn hex_decode_bytes(hex_str: &str) -> Result<Vec<u8>> {

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -32,7 +32,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::TransactionStatus;
-use tracing::{error, info, warn, Instrument};
+use tracing::{debug, error, info, warn, Instrument};
 
 use crate::{
     priority_fee::PriorityFeeOracle, rpc::fallback::SealevelFallbackRpcClient, SealevelKeypair,
@@ -331,7 +331,7 @@ pub fn maybe_spawn_reveal(
                 .await
             {
                 Ok(Some(_)) => {
-                    tracing::debug!("PDA confirmed; proceeding");
+                    debug!("PDA confirmed; proceeding");
                     break;
                 }
                 Ok(None) => {
@@ -345,7 +345,7 @@ pub fn maybe_spawn_reveal(
                         }
                         Ok(_) => {}
                         Err(e) => {
-                            tracing::debug!(error = ?e, "Could not check PDA history");
+                            debug!(error = ?e, "Could not check PDA history");
                         }
                     }
                     pda_wait_iters = pda_wait_iters.saturating_add(1);
@@ -355,7 +355,7 @@ pub fn maybe_spawn_reveal(
                     }
                 }
                 Err(e) => {
-                    tracing::debug!(error = ?e, "Could not check PDA; retrying in 5s");
+                    debug!(error = ?e, "Could not check PDA; retrying in 5s");
                 }
             }
             tokio::time::sleep(Duration::from_secs(5)).await;
@@ -379,7 +379,7 @@ pub fn maybe_spawn_reveal(
                     return;
                 }
                 Err(e) => {
-                    tracing::debug!(error = ?e, "Could not check PDA while waiting for tokens");
+                    debug!(error = ?e, "Could not check PDA while waiting for tokens");
                 }
                 Ok(Some(_)) => {}
             }
@@ -425,13 +425,13 @@ pub fn maybe_spawn_reveal(
                                             acct.data[64..72].try_into().unwrap_or([0u8; 8]),
                                         );
                                         if balance > 0 {
-                                            tracing::debug!(%ata_pubkey, balance, "PDA input ATA funded; proceeding to build tx");
+                                            debug!(%ata_pubkey, balance, "PDA input ATA funded; proceeding to build tx");
                                             break;
                                         }
                                     }
                                     Ok(None) => {}
                                     Ok(Some(_)) => {
-                                        tracing::debug!("PDA input ATA has unexpected data length; waiting 5s");
+                                        debug!("PDA input ATA has unexpected data length; waiting 5s");
                                     }
                                     Err(e) => {
                                         warn!(error = ?e, "Could not check PDA input ATA balance; waiting 5s");
@@ -485,7 +485,7 @@ pub fn maybe_spawn_reveal(
                                 warn!(retry_in_secs = delay_secs, error = ?e, "On-chain rejection but PDA still exists; retrying with fresh pool state");
                             }
                             Err(check_err) => {
-                                tracing::debug!(error = ?check_err, "Could not check PDA existence after on-chain error; will retry");
+                                debug!(error = ?check_err, "Could not check PDA existence after on-chain error; will retry");
                             }
                         }
                     } else {
@@ -563,7 +563,7 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
             // Resend periodically to keep the tx in the leader queue within the validity window.
             if poll % RESEND_INTERVAL_POLLS == 0 {
                 if let Err(e) = ctx.rpc_client.send_transaction(&tx, true).await {
-                    tracing::debug!(%signature, error = ?e, "Resend error (non-fatal)");
+                    debug!(%signature, error = ?e, "Resend error (non-fatal)");
                 }
             }
 
@@ -581,7 +581,7 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
                     Some(_) => {}
                 },
                 Err(e) => {
-                    tracing::debug!(%signature, error = ?e, "Error polling confirmation");
+                    debug!(%signature, error = ?e, "Error polling confirmation");
                 }
             }
         }
@@ -607,7 +607,7 @@ async fn fetch_from_ccs(
 ) -> Result<CcsGetResponse> {
     let commitment_hex = hex::encode(commitment);
     let url = format!("{ccs_url}/calldata/0x{commitment_hex}");
-    tracing::debug!(url, "GET CCS calldata");
+    debug!(url, "GET CCS calldata");
     for attempt in 1..=CCS_MAX_RETRIES {
         let resp = http.get(&url).send().await?;
         let status = resp.status();
@@ -618,7 +618,7 @@ async fn fetch_from_ccs(
             }
             reqwest::StatusCode::NOT_FOUND => {
                 if attempt < CCS_MAX_RETRIES {
-                    tracing::debug!(attempt, "CCS 404 — calldata not yet stored; retrying");
+                    debug!(attempt, "CCS 404 — calldata not yet stored; retrying");
                     tokio::time::sleep(Duration::from_secs(CCS_RETRY_DELAY_SECS)).await;
                 } else {
                     warn!("CCS 404 on final attempt");
@@ -758,7 +758,7 @@ async fn build_instruction(
         let pool_pubkey = accounts[6].pubkey;
         match fetch_clmm_pool_state(pool_pubkey, rpc_client).await {
             Ok(pool_state) => {
-                tracing::debug!(
+                debug!(
                     pool = %pool_pubkey,
                     amm_config = %pool_state.amm_config,
                     observation_state = %pool_state.observation_state,
@@ -839,7 +839,7 @@ async fn build_instruction(
                 let live_ta0 = compute_tick_array_address(&pool_pubkey, ta0_start);
                 let live_ta1 = compute_tick_array_address(&pool_pubkey, ta1_start);
                 let live_ta2 = compute_tick_array_address(&pool_pubkey, ta2_start);
-                tracing::debug!(ta0 = %live_ta0, ta1 = %live_ta1, ta2 = %live_ta2, "Recomputed tick arrays from live pool state");
+                debug!(ta0 = %live_ta0, ta1 = %live_ta1, ta2 = %live_ta2, "Recomputed tick arrays from live pool state");
                 accounts[17].pubkey = live_ta0;
                 accounts[18].pubkey = live_ta1;
                 accounts[19].pubkey = live_ta2;
@@ -929,7 +929,7 @@ async fn build_instruction(
                         &recipient_pubkey,
                         &fee_payer_pubkey,
                     );
-                    tracing::debug!(fee_payer_wsol_ata = %fee_payer_wsol_ata, "SOL output: closing wSOL ATA → native SOL to recipient");
+                    debug!(fee_payer_wsol_ata = %fee_payer_wsol_ata, "SOL output: closing wSOL ATA → native SOL to recipient");
                     (ata_ix, Some(close_ix))
                 } else {
                     override_acct(

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -1,0 +1,271 @@
+//! Automated reveal submission for EVM→Solana CLMM swap commit-reveal pattern.
+//!
+//! After the Hyperlane mailbox delivers a COMMIT message to the Solana UR program,
+//! `maybe_spawn_reveal` is called with the message. If the body is 96 bytes
+//! (`commitment(32)|userSalt(32)|recipient(32)`) and `ur_reveal` is configured, a
+//! `RouterInstruction::Reveal` (variant 2) is submitted in a spawned tokio task.
+//!
+//! Instruction data layout:
+//!   [0]       u8        variant = 2
+//!   [1..5]    u32 LE    origin domain
+//!   [5..37]   [u8;32]   sender  (EVM UR address as bytes32)
+//!   [37..69]  [u8;32]   user_salt (TypeCasts.addressToBytes32(msgSender()))
+//!   [69..73]  u32 LE    message length
+//!   [73..N]   u8[]      message (borsh CCS calldata)
+//!   [N..N+32] [u8;32]   salt (random revealSalt)
+
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use eyre::{bail, eyre, Result};
+use hyperlane_core::HyperlaneMessage;
+use reqwest::Client;
+use serde::Deserialize;
+use solana_commitment_config::CommitmentConfig;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    message::Message,
+    pubkey::Pubkey,
+    signature::Signer,
+    transaction::Transaction,
+};
+use tracing::{error, info, warn};
+
+use crate::{
+    priority_fee::PriorityFeeOracle, rpc::fallback::SealevelFallbackRpcClient, SealevelKeypair,
+    SealevelTxType,
+};
+
+const REVEAL_COMPUTE_UNITS: u32 = 600_000;
+const CCS_MAX_RETRIES: u32 = 10;
+const CCS_RETRY_DELAY_SECS: u64 = 5;
+const CONFIRM_MAX_POLLS: u32 = 60;
+const CONFIRM_POLL_DELAY_MS: u64 = 2_000;
+
+/// Configuration for automated UR reveal submission on a Sealevel destination.
+#[derive(Debug, Clone)]
+pub struct UniversalRouterRevealConfig {
+    /// Base URL of the CCS, e.g. "https://ccs.example.com".
+    pub ccs_url: String,
+    /// Solana UR program ID (base58).
+    pub program_id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct CcsGetResponse {
+    data: String,
+    salt: String,
+    #[serde(rename = "revealAccounts")]
+    reveal_accounts: Option<Vec<CcsRevealAccount>>,
+}
+
+#[derive(Deserialize, Debug)]
+struct CcsRevealAccount {
+    pubkey: String,
+    #[serde(rename = "isWritable")]
+    is_writable: bool,
+    #[serde(rename = "isSigner")]
+    is_signer: bool,
+}
+
+/// If `message` looks like a UR COMMIT (96-byte body) and config is present, spawns a
+/// tokio task to fetch from CCS and submit `RouterInstruction::Reveal`.
+pub fn maybe_spawn_reveal(
+    message: &HyperlaneMessage,
+    config: &UniversalRouterRevealConfig,
+    rpc_client: SealevelFallbackRpcClient,
+    priority_fee_oracle: Arc<dyn PriorityFeeOracle>,
+    fee_payer: SealevelKeypair,
+) {
+    if message.body.len() != 96 {
+        return;
+    }
+    // COMMIT body: commitment(32) | userSalt(32) | recipient(32)
+    #[allow(clippy::unwrap_used)]
+    let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
+    #[allow(clippy::unwrap_used)]
+    let user_salt: [u8; 32] = message.body[32..64].try_into().unwrap();
+    let origin = message.origin;
+    let sender = message.sender.0;
+
+    let ccs_url = config.ccs_url.trim_end_matches('/').to_owned();
+    let program_id_str = config.program_id.clone();
+
+    tokio::spawn(async move {
+        let hex = hex::encode(commitment);
+        info!(commitment = %hex, "Submitting UR reveal");
+        let program_id = match Pubkey::from_str(&program_id_str) {
+            Ok(p) => p,
+            Err(e) => {
+                error!(commitment = %hex, error = ?e, "Invalid UR program ID");
+                return;
+            }
+        };
+        if let Err(e) = submit_reveal(
+            &ccs_url,
+            program_id,
+            commitment,
+            origin,
+            sender,
+            user_salt,
+            &rpc_client,
+            priority_fee_oracle,
+            &fee_payer,
+        )
+        .await
+        {
+            error!(commitment = %hex, error = ?e, "UR reveal failed");
+        } else {
+            info!(commitment = %hex, "UR reveal submitted successfully");
+        }
+    });
+}
+
+async fn submit_reveal(
+    ccs_url: &str,
+    program_id: Pubkey,
+    commitment: [u8; 32],
+    origin: u32,
+    sender: [u8; 32],
+    user_salt: [u8; 32],
+    rpc_client: &SealevelFallbackRpcClient,
+    priority_fee_oracle: Arc<dyn PriorityFeeOracle>,
+    fee_payer: &SealevelKeypair,
+) -> Result<()> {
+    let http = Client::new();
+    let ccs = fetch_from_ccs(&http, ccs_url, &commitment).await?;
+    let instruction = build_instruction(program_id, origin, sender, user_salt, &ccs)?;
+
+    let dummy = SealevelTxType::Legacy(Transaction::new_unsigned(Message::new(
+        &[],
+        Some(&fee_payer.pubkey()),
+    )));
+    let priority_fee = priority_fee_oracle
+        .get_priority_fee(&dummy)
+        .await
+        .unwrap_or(0);
+
+    let instructions = vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(REVEAL_COMPUTE_UNITS),
+        ComputeBudgetInstruction::set_compute_unit_price(priority_fee),
+        instruction,
+    ];
+
+    let blockhash = rpc_client
+        .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
+        .await
+        .map_err(|e| eyre!("get_latest_blockhash: {e}"))?;
+
+    let message = Message::new(&instructions, Some(&fee_payer.pubkey()));
+    let tx = Transaction::new(&[fee_payer.keypair()], message, blockhash);
+
+    let signature = rpc_client
+        .send_transaction(&tx, true)
+        .await
+        .map_err(|e| eyre!("send_transaction: {e}"))?;
+
+    info!(%signature, "Reveal tx sent, awaiting confirmation");
+
+    for attempt in 1..=CONFIRM_MAX_POLLS {
+        tokio::time::sleep(Duration::from_millis(CONFIRM_POLL_DELAY_MS)).await;
+        match rpc_client
+            .confirm_transaction_with_commitment(signature, CommitmentConfig::confirmed())
+            .await
+        {
+            Ok(true) => return Ok(()),
+            Ok(false) => {
+                if attempt == CONFIRM_MAX_POLLS {
+                    bail!("Reveal tx not confirmed after {} polls", CONFIRM_MAX_POLLS);
+                }
+            }
+            Err(e) => warn!(%signature, error = ?e, "Error polling reveal tx confirmation"),
+        }
+    }
+    bail!("Reveal tx confirmation timed out")
+}
+
+async fn fetch_from_ccs(
+    http: &Client,
+    ccs_url: &str,
+    commitment: &[u8; 32],
+) -> Result<CcsGetResponse> {
+    let url = format!("{}/calldata/0x{}", ccs_url, hex::encode(commitment));
+    for attempt in 1..=CCS_MAX_RETRIES {
+        let resp = http.get(&url).send().await?;
+        match resp.status() {
+            s if s.is_success() => return Ok(resp.json::<CcsGetResponse>().await?),
+            reqwest::StatusCode::NOT_FOUND => {
+                if attempt < CCS_MAX_RETRIES {
+                    warn!(
+                        attempt,
+                        "CCS 404 for commitment; retrying in {}s", CCS_RETRY_DELAY_SECS
+                    );
+                    tokio::time::sleep(Duration::from_secs(CCS_RETRY_DELAY_SECS)).await;
+                }
+            }
+            status => bail!(
+                "CCS GET failed: {} {}",
+                status,
+                resp.text().await.unwrap_or_default()
+            ),
+        }
+    }
+    bail!("CCS returned 404 after {} retries", CCS_MAX_RETRIES)
+}
+
+fn build_instruction(
+    program_id: Pubkey,
+    origin: u32,
+    sender: [u8; 32],
+    user_salt: [u8; 32],
+    ccs: &CcsGetResponse,
+) -> Result<Instruction> {
+    let message = hex_decode_bytes(&ccs.data)?;
+    let salt = hex_decode_fixed32(&ccs.salt)?;
+
+    let msg_len = message.len() as u32;
+    let mut data = Vec::with_capacity(1 + 4 + 32 + 32 + 4 + message.len() + 32);
+    data.push(2u8); // RouterInstruction::Reveal variant
+    data.extend_from_slice(&origin.to_le_bytes());
+    data.extend_from_slice(&sender);
+    data.extend_from_slice(&user_salt);
+    data.extend_from_slice(&msg_len.to_le_bytes());
+    data.extend_from_slice(&message);
+    data.extend_from_slice(&salt);
+
+    let reveal_accounts = ccs
+        .reveal_accounts
+        .as_deref()
+        .ok_or_else(|| eyre!("CCS response missing revealAccounts"))?;
+
+    let accounts: Vec<AccountMeta> = reveal_accounts
+        .iter()
+        .map(|a| {
+            let pubkey = Pubkey::from_str(&a.pubkey)
+                .map_err(|e| eyre!("invalid pubkey {}: {}", a.pubkey, e))?;
+            Ok(match (a.is_writable, a.is_signer) {
+                (true, _) => AccountMeta::new(pubkey, a.is_signer),
+                (false, _) => AccountMeta::new_readonly(pubkey, a.is_signer),
+            })
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(Instruction {
+        program_id,
+        accounts,
+        data,
+    })
+}
+
+fn hex_decode_bytes(hex_str: &str) -> Result<Vec<u8>> {
+    let s = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    hex::decode(s).map_err(|e| eyre!("hex decode: {e}"))
+}
+
+fn hex_decode_fixed32(hex_str: &str) -> Result<[u8; 32]> {
+    hex_decode_bytes(hex_str)?
+        .try_into()
+        .map_err(|_| eyre!("expected 32 bytes from '{hex_str}'"))
+}

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -885,6 +885,10 @@ async fn build_instruction(
                 let recipient_pubkey = Pubkey::new_from_array(recipient);
                 let live_recipient_output_ata =
                     derive_ata(&recipient_pubkey, &live_output_mint, &output_token_prog);
+                // Recipient's input-token ATA: used by the reveal fallback path when the
+                // destination swap fails — tokens are transferred here instead of swapped.
+                let live_recipient_input_ata =
+                    derive_ata(&recipient_pubkey, &live_input_mint, &input_token_prog);
 
                 override_acct(
                     &mut accounts,
@@ -956,13 +960,36 @@ async fn build_instruction(
                     &live_output_mint,
                     &output_token_prog,
                 );
+                // Pre-create the recipient's input-token ATA so the fallback transfer
+                // (swap failure → tokens sent directly to recipient) succeeds on-chain.
+                let ata_recipient_input = make_ata_ix(
+                    &fee_payer_pubkey,
+                    &live_recipient_input_ata,
+                    &recipient_pubkey,
+                    &live_input_mint,
+                    &input_token_prog,
+                );
+
+                // Insert 4 new fixed accounts at position [3] before the CLMM swap accounts.
+                // New reveal layout: [0] pending_swap, [1] pda_ata, [2] fee_payer,
+                //   [3] recipient_ata, [4] token_program, [5] mint, [6] system_program,
+                //   [7..] swap command accounts (CCS-provided, shifted from old [3..]).
+                accounts.splice(
+                    3..3,
+                    [
+                        AccountMeta::new(live_recipient_input_ata, false),
+                        AccountMeta::new_readonly(input_token_prog, false),
+                        AccountMeta::new_readonly(live_input_mint, false),
+                        AccountMeta::new_readonly(solana_system_interface::program::id(), false),
+                    ],
+                );
 
                 let reveal_ix = Instruction {
                     program_id,
                     accounts,
                     data,
                 };
-                let mut ixs = vec![ata_pda_output, ata_second, reveal_ix];
+                let mut ixs = vec![ata_pda_output, ata_second, ata_recipient_input, reveal_ix];
                 if let Some(close_ix) = maybe_close_ix {
                     ixs.push(close_ix);
                 }
@@ -972,7 +999,23 @@ async fn build_instruction(
                 warn!(
                     pool = %pool_pubkey,
                     error = ?e,
-                    "Could not fetch CLMM pool state; submitting without ATA pre-creation"
+                    "Could not fetch CLMM pool state; submitting with CCS accounts and new layout"
+                );
+                // Still insert the 4 new fixed accounts using CCS-provided mint/token_program
+                // so the instruction has the correct layout even without pool-state overrides.
+                let input_token_prog = accounts[12].pubkey;
+                let input_mint = accounts[15].pubkey;
+                let recipient_pubkey = Pubkey::new_from_array(recipient);
+                let recipient_input_ata =
+                    derive_ata(&recipient_pubkey, &input_mint, &input_token_prog);
+                accounts.splice(
+                    3..3,
+                    [
+                        AccountMeta::new(recipient_input_ata, false),
+                        AccountMeta::new_readonly(input_token_prog, false),
+                        AccountMeta::new_readonly(input_mint, false),
+                        AccountMeta::new_readonly(solana_system_interface::program::id(), false),
+                    ],
                 );
             }
         }

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -44,7 +44,10 @@ const CCS_MAX_RETRIES: u32 = 10;
 const CCS_RETRY_DELAY_SECS: u64 = 5;
 // Outer send attempts (each gets a fresh blockhash): 3 × ~60s = ~3 min total.
 const SEND_RETRY_MAX: u32 = 3;
-// Inner polls per blockhash window (~150 slots ≈ 60 s on mainnet).
+// Reveal task retry backoff on transient failures (RPC errors, tx not confirmed, fee payer low).
+const REVEAL_INITIAL_RETRY_DELAY_SECS: u64 = 30;
+const REVEAL_MAX_RETRY_DELAY_SECS: u64 = 600; // 10 min
+                                              // Inner polls per blockhash window (~150 slots ≈ 60 s on mainnet).
 const CONFIRM_POLLS_PER_BLOCKHASH: u32 = 30;
 const CONFIRM_POLL_DELAY_MS: u64 = 2_000;
 // Resend the signed tx every N inner polls to keep it in the leader queue.
@@ -232,8 +235,9 @@ struct CcsRevealAccount {
     is_signer: bool,
 }
 
-/// If `message` looks like a UR COMMIT (96-byte body) and config is present, spawns a
-/// tokio task to fetch from CCS and submit `RouterInstruction::Reveal`.
+/// If `message` looks like a UR COMMIT (96-byte body, recipient == UR program) and
+/// config is present, spawns a tokio task to fetch from CCS and submit
+/// `RouterInstruction::Reveal`.
 pub fn maybe_spawn_reveal(
     message: &HyperlaneMessage,
     config: &UniversalRouterRevealConfig,
@@ -243,11 +247,20 @@ pub fn maybe_spawn_reveal(
 ) {
     let body_len = message.body.len();
     if body_len != 96 {
-        info!(
-            body_len,
-            origin = message.origin,
-            "[REVEAL] Skipping: body is not 96 bytes (not a COMMIT message)"
-        );
+        return;
+    }
+
+    // Verify the message is addressed to this UR program, not some other
+    // Sealevel program that happens to send 96-byte messages.
+    let program_id = match Pubkey::from_str(&config.program_id) {
+        Ok(p) => p,
+        Err(e) => {
+            error!("[REVEAL] Invalid program ID in config: {e}");
+            return;
+        }
+    };
+    let message_recipient = Pubkey::new_from_array(message.recipient.0);
+    if message_recipient != program_id {
         return;
     }
     // COMMIT body: commitment(32) | userSalt(32) | recipient(32)
@@ -260,14 +273,12 @@ pub fn maybe_spawn_reveal(
     let origin = message.origin;
     let sender = message.sender.0;
     let commitment_hex = hex::encode(commitment);
-    let sender_hex = hex::encode(sender);
-    let user_salt_hex = hex::encode(user_salt);
 
     info!(
         commitment = %commitment_hex,
         origin,
-        sender = %sender_hex,
-        user_salt = %user_salt_hex,
+        sender = %hex::encode(sender),
+        user_salt = %hex::encode(user_salt),
         ccs_url = %config.ccs_url,
         program_id = %config.program_id,
         fee_payer = %fee_payer.pubkey(),
@@ -275,16 +286,8 @@ pub fn maybe_spawn_reveal(
     );
 
     let ccs_url = config.ccs_url.trim_end_matches('/').to_owned();
-    let program_id_str = config.program_id.clone();
 
     tokio::spawn(async move {
-        let program_id = match Pubkey::from_str(&program_id_str) {
-            Ok(p) => p,
-            Err(e) => {
-                error!(commitment = %commitment_hex, error = ?e, "[REVEAL] Invalid program ID; aborting");
-                return;
-            }
-        };
         info!(commitment = %commitment_hex, %program_id, "[REVEAL] Task started");
         let http_client = Client::new();
         let ctx = RevealContext {
@@ -300,9 +303,194 @@ pub fn maybe_spawn_reveal(
             fee_payer: &fee_payer,
             http_client,
         };
-        match submit_reveal(ctx).await {
-            Err(e) => error!(commitment = %commitment_hex, error = ?e, "[REVEAL] Failed"),
-            Ok(()) => info!(commitment = %commitment_hex, "[REVEAL] Confirmed successfully"),
+        let pending_swap_pda =
+            derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
+
+        // Phase 1: wait for the pending_swap PDA to appear on-chain.
+        // The reveal task may be spawned before the commit tx is confirmed
+        // (e.g. when another relayer delivers it), so we poll rather than
+        // aborting immediately on None.  Give up after ~10 min (120 × 5 s).
+        const PDA_WAIT_MAX_ITERS: u32 = 120;
+        let mut pda_wait_iters: u32 = 0;
+        loop {
+            match rpc_client
+                .get_account_option_with_commitment(pending_swap_pda, CommitmentConfig::confirmed())
+                .await
+            {
+                Ok(Some(_)) => {
+                    info!(commitment = %commitment_hex, %pending_swap_pda, "[REVEAL] PDA appeared; proceeding to token wait");
+                    break;
+                }
+                Ok(None) => {
+                    pda_wait_iters += 1;
+                    if pda_wait_iters >= PDA_WAIT_MAX_ITERS {
+                        info!(
+                            commitment = %commitment_hex,
+                            %pending_swap_pda,
+                            "[REVEAL] PDA never appeared after {}s; commit may not have landed; stopping",
+                            PDA_WAIT_MAX_ITERS * 5
+                        );
+                        return;
+                    }
+                    info!(
+                        commitment = %commitment_hex,
+                        %pending_swap_pda,
+                        wait_iters = pda_wait_iters,
+                        "[REVEAL] PDA not yet visible; waiting 5s for commit to land"
+                    );
+                }
+                Err(e) => {
+                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA; retrying in 5s");
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+
+        // Phase 2: fetch CCS to learn the pda_input_ata address (accounts[1]) and
+        // poll for a non-zero token balance.  We must not build the full reveal tx
+        // (pool state RPC, tick arrays, etc.) until the warp tokens have landed.
+        loop {
+            // Bail early if PDA is already gone.
+            match rpc_client
+                .get_account_option_with_commitment(pending_swap_pda, CommitmentConfig::confirmed())
+                .await
+            {
+                Ok(None) => {
+                    info!(commitment = %commitment_hex, "[REVEAL] PDA gone before tokens arrived; stopping");
+                    return;
+                }
+                Err(e) => {
+                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA while waiting for tokens");
+                }
+                Ok(Some(_)) => {}
+            }
+
+            // Fetch CCS to discover the pda_input_ata address.
+            let ccs_opt = match fetch_from_ccs(&ctx.http_client, &ccs_url, &commitment).await {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] CCS fetch failed while waiting for tokens; retrying in 5s");
+                    None
+                }
+            };
+
+            if let Some(ccs) = ccs_opt {
+                if let Some(accounts) = ccs.reveal_accounts.as_deref() {
+                    if accounts.len() > 1 {
+                        if let Ok(ata_pubkey) = Pubkey::from_str(&accounts[1].pubkey) {
+                            // Check the ATA balance.
+                            match rpc_client
+                                .get_account_option_with_commitment(
+                                    ata_pubkey,
+                                    CommitmentConfig::confirmed(),
+                                )
+                                .await
+                            {
+                                Ok(Some(acct)) if acct.data.len() >= 72 => {
+                                    let balance = u64::from_le_bytes(
+                                        acct.data[64..72].try_into().unwrap_or([0u8; 8]),
+                                    );
+                                    if balance > 0 {
+                                        info!(
+                                            commitment = %commitment_hex,
+                                            %ata_pubkey,
+                                            balance,
+                                            "[REVEAL] PDA input ATA has tokens; proceeding to build tx"
+                                        );
+                                        break;
+                                    }
+                                    info!(
+                                        commitment = %commitment_hex,
+                                        %ata_pubkey,
+                                        "[REVEAL] PDA input ATA exists but balance is zero; waiting 5s"
+                                    );
+                                }
+                                Ok(None) => {
+                                    info!(
+                                        commitment = %commitment_hex,
+                                        %ata_pubkey,
+                                        "[REVEAL] PDA input ATA not yet created; waiting 5s"
+                                    );
+                                }
+                                Ok(Some(_)) => {
+                                    warn!(commitment = %commitment_hex, "[REVEAL] PDA input ATA has unexpected data length; waiting 5s");
+                                }
+                                Err(e) => {
+                                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA input ATA balance; waiting 5s");
+                                }
+                            }
+                        } else {
+                            warn!(commitment = %commitment_hex, "[REVEAL] Could not parse accounts[1] pubkey from CCS; retrying in 5s");
+                        }
+                    } else {
+                        warn!(commitment = %commitment_hex, "[REVEAL] CCS revealAccounts has <2 entries; retrying in 5s");
+                    }
+                } else {
+                    warn!(commitment = %commitment_hex, "[REVEAL] CCS response missing revealAccounts; retrying in 5s");
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+
+        let mut delay_secs = REVEAL_INITIAL_RETRY_DELAY_SECS;
+        loop {
+            match submit_reveal(&ctx).await {
+                Ok(()) => {
+                    info!(commitment = %commitment_hex, "[REVEAL] Confirmed successfully");
+                    break;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if msg.contains("Reveal tx failed on-chain") {
+                        // On-chain rejection — two possible causes:
+                        // 1. PDA is gone: another relayer already revealed → we're done.
+                        // 2. PDA still exists: our params were rejected (stale pool state,
+                        //    wrong vaults, etc.) → retry; build_instruction fetches fresh
+                        //    pool state on each call so the next attempt should self-correct.
+                        match rpc_client
+                            .get_account_option_with_commitment(
+                                pending_swap_pda,
+                                CommitmentConfig::confirmed(),
+                            )
+                            .await
+                        {
+                            Ok(None) => {
+                                info!(
+                                    commitment = %commitment_hex,
+                                    %pending_swap_pda,
+                                    "[REVEAL] pending_swap PDA is gone — reveal completed by another relayer; stopping"
+                                );
+                                break;
+                            }
+                            Ok(Some(_)) => {
+                                warn!(
+                                    commitment = %commitment_hex,
+                                    retry_in_secs = delay_secs,
+                                    error = ?e,
+                                    "[REVEAL] On-chain rejection but PDA still exists; retrying with fresh pool state"
+                                );
+                            }
+                            Err(check_err) => {
+                                warn!(
+                                    commitment = %commitment_hex,
+                                    error = ?check_err,
+                                    "[REVEAL] Could not check PDA existence after on-chain error; will retry"
+                                );
+                            }
+                        }
+                    } else {
+                        warn!(
+                            commitment = %commitment_hex,
+                            retry_in_secs = delay_secs,
+                            error = ?e,
+                            "[REVEAL] Transient failure; will retry"
+                        );
+                    }
+                    tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+                    delay_secs = (delay_secs * 2).min(REVEAL_MAX_RETRY_DELAY_SECS);
+                }
+            }
         }
     });
 }
@@ -321,7 +509,7 @@ struct RevealContext<'a> {
     http_client: reqwest::Client,
 }
 
-async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
+async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
     let commitment_hex = hex::encode(ctx.commitment);
 
     info!(commitment = %commitment_hex, ccs_url = ctx.ccs_url, "[REVEAL] Fetching calldata from CCS");
@@ -335,7 +523,7 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
     );
 
     info!(commitment = %commitment_hex, "[REVEAL] Building RouterInstruction::Reveal");
-    let built = build_instruction(&ctx, &ccs).await?;
+    let built = build_instruction(ctx, &ccs).await?;
     info!(
         commitment = %commitment_hex,
         instruction_count = built.len(),
@@ -513,6 +701,8 @@ fn derive_fee_payer_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(&[b"hyperlane_fee_payer"], program_id).0
 }
 
+// Seeds: [b"pending_swap", origin_le, sender, user_salt, commitment]
+// commitment = keccak256(calldata || revealSalt), same value stored in PDA and in the COMMIT body.
 fn derive_pending_swap_pda(
     program_id: &Pubkey,
     origin: u32,
@@ -587,7 +777,6 @@ async fn build_instruction(
         .ok_or_else(|| eyre!("CCS response missing revealAccounts"))?;
 
     // Derive both critical PDAs locally to verify (and override) what CCS stored.
-    // Use commitment from message body — the authoritative PDA seed.
     let expected_pending_swap =
         derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
     let expected_fee_payer_pda = derive_fee_payer_pda(&program_id);
@@ -608,16 +797,15 @@ async fn build_instruction(
             let pubkey = Pubkey::from_str(&a.pubkey)
                 .map_err(|e| eyre!("invalid pubkey {}: {}", a.pubkey, e))?;
 
-            // Override accounts[0] (pending_swap), accounts[2] (fee_payer_pda), and
-            // accounts[4] (CLMM payer = pending_swap PDA) with locally-derived values.
+            // Override accounts[0] (pending_swap) and accounts[2] (fee_payer_pda)
+            // with locally-derived values.
             let pubkey = match i {
-                0 | 4 => {
+                0 => {
                     if pubkey != expected_pending_swap {
                         warn!(
-                            index = i,
                             ccs_pubkey = %pubkey,
                             expected = %expected_pending_swap,
-                            "[REVEAL] account (pending_swap PDA) mismatch — using locally-derived PDA"
+                            "[REVEAL] account[0] (pending_swap PDA) mismatch — using locally-derived PDA"
                         );
                     }
                     expected_pending_swap

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -395,38 +395,52 @@ pub fn maybe_spawn_reveal(
 
             if let Some(ccs) = ccs_opt {
                 if let Some(accounts) = ccs.reveal_accounts.as_deref() {
-                    if accounts.len() > 1 {
-                        if let Ok(ata_pubkey) = Pubkey::from_str(&accounts[1].pubkey) {
-                            // Check the ATA balance.
-                            match rpc_client
-                                .get_account_option_with_commitment(
-                                    ata_pubkey,
-                                    CommitmentConfig::confirmed(),
-                                )
-                                .await
-                            {
-                                Ok(Some(acct)) if acct.data.len() >= 72 => {
-                                    let balance = u64::from_le_bytes(
-                                        acct.data[64..72].try_into().unwrap_or([0u8; 8]),
-                                    );
-                                    if balance > 0 {
-                                        tracing::debug!(%ata_pubkey, balance, "PDA input ATA funded; proceeding to build tx");
-                                        break;
+                    // Require at least accounts[0..=15] so we can derive the ATA locally.
+                    if accounts.len() > 15 {
+                        // Derive the input ATA from first-principles (same logic as
+                        // build_instruction) rather than trusting accounts[1] from CCS, which
+                        // could be stale. accounts[12] = inputTokenProgram, accounts[15] =
+                        // inputMint; pending_swap_pda is the ATA owner.
+                        let maybe_ata_pubkey = Pubkey::from_str(&accounts[12].pubkey)
+                            .ok()
+                            .zip(Pubkey::from_str(&accounts[15].pubkey).ok())
+                            .map(|(token_prog, input_mint)| {
+                                derive_ata(&pending_swap_pda, &input_mint, &token_prog)
+                            });
+                        match maybe_ata_pubkey {
+                            None => {
+                                warn!("Could not parse accounts[12] or accounts[15] pubkey from CCS; retrying in 5s");
+                            }
+                            Some(ata_pubkey) => {
+                                // Check the ATA balance.
+                                match rpc_client
+                                    .get_account_option_with_commitment(
+                                        ata_pubkey,
+                                        CommitmentConfig::confirmed(),
+                                    )
+                                    .await
+                                {
+                                    Ok(Some(acct)) if acct.data.len() >= 72 => {
+                                        let balance = u64::from_le_bytes(
+                                            acct.data[64..72].try_into().unwrap_or([0u8; 8]),
+                                        );
+                                        if balance > 0 {
+                                            tracing::debug!(%ata_pubkey, balance, "PDA input ATA funded; proceeding to build tx");
+                                            break;
+                                        }
+                                    }
+                                    Ok(None) => {}
+                                    Ok(Some(_)) => {
+                                        tracing::debug!("PDA input ATA has unexpected data length; waiting 5s");
+                                    }
+                                    Err(e) => {
+                                        warn!(error = ?e, "Could not check PDA input ATA balance; waiting 5s");
                                     }
                                 }
-                                Ok(None) => {}
-                                Ok(Some(_)) => {
-                                    tracing::debug!("PDA input ATA has unexpected data length; waiting 5s");
-                                }
-                                Err(e) => {
-                                    warn!(error = ?e, "Could not check PDA input ATA balance; waiting 5s");
-                                }
                             }
-                        } else {
-                            warn!("Could not parse accounts[1] pubkey from CCS; retrying in 5s");
                         }
                     } else {
-                        warn!("CCS revealAccounts has <2 entries; retrying in 5s");
+                        warn!("CCS revealAccounts has <16 entries; retrying in 5s");
                     }
                 } else {
                     warn!("CCS response missing revealAccounts; retrying in 5s");
@@ -815,7 +829,11 @@ async fn build_instruction(
                 let ticks_in_array = 60i32.saturating_mul(pool_state.tick_spacing as i32);
                 let ta0_start =
                     get_tick_array_start_index(pool_state.tick_current, pool_state.tick_spacing)?;
-                // Forward progression matches UI's buildClmmAccounts formula.
+                // Forward progression matches the UI's buildClmmAccounts formula.
+                // The UR COMMIT currently only supports one_for_zero swaps (price moves
+                // up, tick increases), so forward tick arrays are always correct.  If
+                // zero_for_one support is added in future, this must become conditional
+                // on `zero_for_one` (subtract `ticks_in_array` for backward arrays).
                 let ta1_start = ta0_start.saturating_add(ticks_in_array);
                 let ta2_start = ta0_start.saturating_add(2i32.saturating_mul(ticks_in_array));
                 let live_ta0 = compute_tick_array_address(&pool_pubkey, ta0_start);

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -549,6 +549,7 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
         let message = Message::new(&instructions, Some(&ctx.fee_payer.pubkey()));
         let tx = Transaction::new(&[ctx.fee_payer.keypair()], message, blockhash);
 
+        // skip_preflight=true to avoid BlockhashNotFound race on multi-RPC setups.
         let signature = ctx
             .rpc_client
             .send_transaction(&tx, true)
@@ -640,7 +641,7 @@ fn derive_fee_payer_pda(program_id: &Pubkey) -> Pubkey {
 }
 
 // Seeds: [b"pending_swap", origin_le, sender, user_salt, commitment]
-// commitment = keccak256(calldata || revealSalt), same value stored in PDA and in the COMMIT body.
+// commitment = keccak256(revealSalt || calldata), same value stored in PDA and in the COMMIT body.
 fn derive_pending_swap_pda(
     program_id: &Pubkey,
     origin: u32,
@@ -679,10 +680,10 @@ async fn build_instruction(
 
     // Verify CCS data is consistent with the commitment from the message body.
     let ccs_commitment =
-        solana_program::keccak::hashv(&[message.as_slice(), salt.as_ref()]).to_bytes();
+        solana_program::keccak::hashv(&[salt.as_ref(), message.as_slice()]).to_bytes();
     if ccs_commitment != commitment {
         bail!(
-            "CCS keccak(calldata||salt) {} does not match message body commitment {} — CCS data is stale or wrong",
+            "CCS keccak(salt||calldata) {} does not match message body commitment {} — CCS data is stale or wrong",
             hex::encode(ccs_commitment),
             hex::encode(commitment),
         );
@@ -970,12 +971,13 @@ async fn build_instruction(
                     &input_token_prog,
                 );
 
-                // Insert 4 new fixed accounts at position [3] before the CLMM swap accounts.
+                // Replace CCS[3] (old system_program fixed account) with 4 new fixed accounts.
+                // Old reveal layout: [0] pending_swap, [1] pda_ata, [2] fee_payer, [3] system_program, [4..] swap accounts
                 // New reveal layout: [0] pending_swap, [1] pda_ata, [2] fee_payer,
                 //   [3] recipient_ata, [4] token_program, [5] mint, [6] system_program,
-                //   [7..] swap command accounts (CCS-provided, shifted from old [3..]).
+                //   [7..] swap command accounts (CCS[4..], same as old [4..]).
                 accounts.splice(
-                    3..3,
+                    3..4,
                     [
                         AccountMeta::new(live_recipient_input_ata, false),
                         AccountMeta::new_readonly(input_token_prog, false),
@@ -1001,15 +1003,15 @@ async fn build_instruction(
                     error = ?e,
                     "Could not fetch CLMM pool state; submitting with CCS accounts and new layout"
                 );
-                // Still insert the 4 new fixed accounts using CCS-provided mint/token_program
-                // so the instruction has the correct layout even without pool-state overrides.
+                // Still replace CCS[3] with the 4 new fixed accounts using CCS-provided
+                // mint/token_program so the instruction has the correct layout.
                 let input_token_prog = accounts[12].pubkey;
                 let input_mint = accounts[15].pubkey;
                 let recipient_pubkey = Pubkey::new_from_array(recipient);
                 let recipient_input_ata =
                     derive_ata(&recipient_pubkey, &input_mint, &input_token_prog);
                 accounts.splice(
-                    3..3,
+                    3..4,
                     [
                         AccountMeta::new(recipient_input_ata, false),
                         AccountMeta::new_readonly(input_token_prog, false),

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -103,19 +103,18 @@ pub fn maybe_spawn_reveal(
                 return;
             }
         };
-        if let Err(e) = submit_reveal(
-            &ccs_url,
+        let ctx = RevealContext {
+            ccs_url: &ccs_url,
             program_id,
             commitment,
             origin,
             sender,
             user_salt,
-            &rpc_client,
+            rpc_client: &rpc_client,
             priority_fee_oracle,
-            &fee_payer,
-        )
-        .await
-        {
+            fee_payer: &fee_payer,
+        };
+        if let Err(e) = submit_reveal(ctx).await {
             error!(commitment = %hex, error = ?e, "UR reveal failed");
         } else {
             info!(commitment = %hex, "UR reveal submitted successfully");
@@ -123,17 +122,30 @@ pub fn maybe_spawn_reveal(
     });
 }
 
-async fn submit_reveal(
-    ccs_url: &str,
+struct RevealContext<'a> {
+    ccs_url: &'a str,
     program_id: Pubkey,
     commitment: [u8; 32],
     origin: u32,
     sender: [u8; 32],
     user_salt: [u8; 32],
-    rpc_client: &SealevelFallbackRpcClient,
+    rpc_client: &'a SealevelFallbackRpcClient,
     priority_fee_oracle: Arc<dyn PriorityFeeOracle>,
-    fee_payer: &SealevelKeypair,
-) -> Result<()> {
+    fee_payer: &'a SealevelKeypair,
+}
+
+async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
+    let RevealContext {
+        ccs_url,
+        program_id,
+        commitment,
+        origin,
+        sender,
+        user_salt,
+        rpc_client,
+        priority_fee_oracle,
+        fee_payer,
+    } = ctx;
     let http = Client::new();
     let ccs = fetch_from_ccs(&http, ccs_url, &commitment).await?;
     let instruction = build_instruction(program_id, origin, sender, user_salt, &ccs)?;
@@ -226,7 +238,9 @@ fn build_instruction(
     let salt = hex_decode_fixed32(&ccs.salt)?;
 
     let msg_len = message.len() as u32;
-    let mut data = Vec::with_capacity(1 + 4 + 32 + 32 + 4 + message.len() + 32);
+    // 1 (variant) + 4 (origin) + 32 (sender) + 32 (user_salt) + 4 (msg_len) + message + 32 (salt)
+    let fixed_overhead: usize = 105;
+    let mut data = Vec::with_capacity(fixed_overhead.saturating_add(message.len()));
     data.push(2u8); // RouterInstruction::Reveal variant
     data.extend_from_slice(&origin.to_le_bytes());
     data.extend_from_slice(&sender);

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -44,6 +44,8 @@ const CCS_MAX_RETRIES: u32 = 10;
 const CCS_RETRY_DELAY_SECS: u64 = 5;
 // Outer send attempts (each gets a fresh blockhash): 3 × ~60s = ~3 min total.
 const SEND_RETRY_MAX: u32 = 3;
+// Per-request timeout for CCS HTTP calls so a slow-responding CCS can't block the task forever.
+const CCS_REQUEST_TIMEOUT_SECS: u64 = 30;
 // Reveal task retry backoff on transient failures (RPC errors, tx not confirmed, fee payer low).
 const REVEAL_INITIAL_RETRY_DELAY_SECS: u64 = 30;
 const REVEAL_MAX_RETRY_DELAY_SECS: u64 = 600; // 10 min
@@ -141,13 +143,16 @@ async fn fetch_clmm_pool_state(
 
 // Mirrors reveal.mjs `getTickArrayStartIndex`.  Uses truncation-towards-zero integer
 // division (Rust default), with an explicit floor correction for negative ticks.
-fn get_tick_array_start_index(tick_current: i32, tick_spacing: i16) -> i32 {
+fn get_tick_array_start_index(tick_current: i32, tick_spacing: i16) -> Result<i32> {
+    if tick_spacing <= 0 {
+        bail!("invalid tick_spacing: {tick_spacing}");
+    }
     let ticks_in_array = 60i32 * tick_spacing as i32;
     let mut start = (tick_current / ticks_in_array) * ticks_in_array;
     if tick_current < 0 && tick_current % ticks_in_array != 0 {
         start -= ticks_in_array;
     }
-    start
+    Ok(start)
 }
 
 // Seeds: [b"tick_array", pool_id (32 bytes), start_index (i32 big-endian)]
@@ -289,7 +294,10 @@ pub fn maybe_spawn_reveal(
 
     tokio::spawn(async move {
         info!(commitment = %commitment_hex, %program_id, "[REVEAL] Task started");
-        let http_client = Client::new();
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(CCS_REQUEST_TIMEOUT_SECS))
+            .build()
+            .expect("HTTP client build failed — invalid configuration");
         let ctx = RevealContext {
             ccs_url: &ccs_url,
             program_id,
@@ -774,10 +782,10 @@ async fn build_instruction(
     let ccs_commitment =
         solana_program::keccak::hashv(&[message.as_slice(), salt.as_ref()]).to_bytes();
     if ccs_commitment != commitment {
-        warn!(
-            expected = %hex::encode(commitment),
-            from_ccs = %hex::encode(ccs_commitment),
-            "[REVEAL] CCS keccak(calldata||salt) does not match message body commitment — CCS data may be stale or wrong"
+        bail!(
+            "CCS keccak(calldata||salt) {} does not match message body commitment {} — CCS data is stale or wrong",
+            hex::encode(ccs_commitment),
+            hex::encode(commitment),
         );
     }
 
@@ -946,7 +954,7 @@ async fn build_instruction(
 
                 let ticks_in_array = 60i32 * pool_state.tick_spacing as i32;
                 let ta0_start =
-                    get_tick_array_start_index(pool_state.tick_current, pool_state.tick_spacing);
+                    get_tick_array_start_index(pool_state.tick_current, pool_state.tick_spacing)?;
                 // Forward progression matches UI's buildClmmAccounts formula.
                 let ta1_start = ta0_start + ticks_in_array;
                 let ta2_start = ta0_start + 2 * ticks_in_array;
@@ -1036,6 +1044,9 @@ async fn build_instruction(
                         fee_payer_wsol_ata,
                         "account[22] (fee_payer_wsol_ata for SOL output)",
                     );
+                    // The ATA is closed atomically in the same tx (step 3 below), so it is
+                    // always empty or non-existent at the start of each reveal — no pre-existing
+                    // balance can accumulate from the reveal flow itself.
                     let ata_ix = make_ata_ix(
                         &fee_payer_pubkey,
                         &fee_payer_wsol_ata,

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -79,7 +79,13 @@ pub fn maybe_spawn_reveal(
     priority_fee_oracle: Arc<dyn PriorityFeeOracle>,
     fee_payer: SealevelKeypair,
 ) {
-    if message.body.len() != 96 {
+    let body_len = message.body.len();
+    if body_len != 96 {
+        info!(
+            body_len,
+            origin = message.origin,
+            "Skipping UR reveal: body is not 96 bytes (not a COMMIT message)"
+        );
         return;
     }
     // COMMIT body: commitment(32) | userSalt(32) | recipient(32)
@@ -89,20 +95,33 @@ pub fn maybe_spawn_reveal(
     let user_salt: [u8; 32] = message.body[32..64].try_into().unwrap();
     let origin = message.origin;
     let sender = message.sender.0;
+    let commitment_hex = hex::encode(commitment);
+    let sender_hex = hex::encode(sender);
+    let user_salt_hex = hex::encode(user_salt);
+
+    info!(
+        commitment = %commitment_hex,
+        origin,
+        sender = %sender_hex,
+        user_salt = %user_salt_hex,
+        ccs_url = %config.ccs_url,
+        program_id = %config.program_id,
+        fee_payer = %fee_payer.pubkey(),
+        "Spawning UR reveal task"
+    );
 
     let ccs_url = config.ccs_url.trim_end_matches('/').to_owned();
     let program_id_str = config.program_id.clone();
 
     tokio::spawn(async move {
-        let hex = hex::encode(commitment);
-        info!(commitment = %hex, "Submitting UR reveal");
         let program_id = match Pubkey::from_str(&program_id_str) {
             Ok(p) => p,
             Err(e) => {
-                error!(commitment = %hex, error = ?e, "Invalid UR program ID");
+                error!(commitment = %commitment_hex, error = ?e, "Invalid UR program ID; aborting reveal");
                 return;
             }
         };
+        info!(commitment = %commitment_hex, %program_id, "UR reveal task started");
         let ctx = RevealContext {
             ccs_url: &ccs_url,
             program_id,
@@ -114,10 +133,9 @@ pub fn maybe_spawn_reveal(
             priority_fee_oracle,
             fee_payer: &fee_payer,
         };
-        if let Err(e) = submit_reveal(ctx).await {
-            error!(commitment = %hex, error = ?e, "UR reveal failed");
-        } else {
-            info!(commitment = %hex, "UR reveal submitted successfully");
+        match submit_reveal(ctx).await {
+            Err(e) => error!(commitment = %commitment_hex, error = ?e, "UR reveal failed"),
+            Ok(()) => info!(commitment = %commitment_hex, "UR reveal confirmed successfully"),
         }
     });
 }
@@ -146,9 +164,27 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
         priority_fee_oracle,
         fee_payer,
     } = ctx;
+    let commitment_hex = hex::encode(commitment);
+
+    info!(commitment = %commitment_hex, ccs_url, "Fetching reveal data from CCS");
     let http = Client::new();
     let ccs = fetch_from_ccs(&http, ccs_url, &commitment).await?;
+    info!(
+        commitment = %commitment_hex,
+        data_len = ccs.data.len(),
+        salt = %ccs.salt,
+        reveal_accounts_count = ccs.reveal_accounts.as_ref().map(|a| a.len()).unwrap_or(0),
+        "CCS fetch succeeded"
+    );
+
+    info!(commitment = %commitment_hex, "Building RouterInstruction::Reveal");
     let instruction = build_instruction(program_id, origin, sender, user_salt, &ccs)?;
+    info!(
+        commitment = %commitment_hex,
+        accounts_count = instruction.accounts.len(),
+        data_len = instruction.data.len(),
+        "Reveal instruction built"
+    );
 
     let dummy = SealevelTxType::Legacy(Transaction::new_unsigned(Message::new(
         &[],
@@ -158,6 +194,12 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
         .get_priority_fee(&dummy)
         .await
         .unwrap_or(0);
+    info!(
+        commitment = %commitment_hex,
+        priority_fee,
+        compute_units = REVEAL_COMPUTE_UNITS,
+        "Priority fee determined"
+    );
 
     let instructions = vec![
         ComputeBudgetInstruction::set_compute_unit_limit(REVEAL_COMPUTE_UNITS),
@@ -165,34 +207,45 @@ async fn submit_reveal(ctx: RevealContext<'_>) -> Result<()> {
         instruction,
     ];
 
+    info!(commitment = %commitment_hex, "Fetching latest blockhash");
     let blockhash = rpc_client
         .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
         .await
         .map_err(|e| eyre!("get_latest_blockhash: {e}"))?;
+    info!(commitment = %commitment_hex, blockhash = %blockhash, "Got blockhash");
 
     let message = Message::new(&instructions, Some(&fee_payer.pubkey()));
     let tx = Transaction::new(&[fee_payer.keypair()], message, blockhash);
 
+    info!(commitment = %commitment_hex, fee_payer = %fee_payer.pubkey(), "Sending reveal transaction");
     let signature = rpc_client
         .send_transaction(&tx, true)
         .await
         .map_err(|e| eyre!("send_transaction: {e}"))?;
 
-    info!(%signature, "Reveal tx sent, awaiting confirmation");
+    let max_confirm_secs = CONFIRM_MAX_POLLS.saturating_mul((CONFIRM_POLL_DELAY_MS / 1000) as u32);
+    info!(commitment = %commitment_hex, %signature, max_confirm_secs, "Reveal tx sent; polling for confirmation");
 
     for attempt in 1..=CONFIRM_MAX_POLLS {
         tokio::time::sleep(Duration::from_millis(CONFIRM_POLL_DELAY_MS)).await;
+        info!(commitment = %commitment_hex, %signature, attempt, max_attempts = CONFIRM_MAX_POLLS, "Polling reveal tx confirmation");
         match rpc_client
             .confirm_transaction_with_commitment(signature, CommitmentConfig::confirmed())
             .await
         {
-            Ok(true) => return Ok(()),
+            Ok(true) => {
+                info!(commitment = %commitment_hex, %signature, attempt, "Reveal tx confirmed");
+                return Ok(());
+            }
             Ok(false) => {
                 if attempt == CONFIRM_MAX_POLLS {
                     bail!("Reveal tx not confirmed after {} polls", CONFIRM_MAX_POLLS);
                 }
+                info!(commitment = %commitment_hex, %signature, attempt, "Reveal tx not yet confirmed; continuing to poll");
             }
-            Err(e) => warn!(%signature, error = ?e, "Error polling reveal tx confirmation"),
+            Err(e) => {
+                warn!(commitment = %commitment_hex, %signature, error = ?e, attempt, "Error polling reveal tx confirmation")
+            }
         }
     }
     bail!("Reveal tx confirmation timed out")
@@ -203,21 +256,40 @@ async fn fetch_from_ccs(
     ccs_url: &str,
     commitment: &[u8; 32],
 ) -> Result<CcsGetResponse> {
-    let url = format!("{}/calldata/0x{}", ccs_url, hex::encode(commitment));
+    let commitment_hex = hex::encode(commitment);
+    let url = format!("{ccs_url}/calldata/0x{commitment_hex}");
+    info!(commitment = %commitment_hex, url, "GET CCS calldata");
     for attempt in 1..=CCS_MAX_RETRIES {
+        info!(commitment = %commitment_hex, attempt, max_retries = CCS_MAX_RETRIES, url, "CCS fetch attempt");
         let resp = http.get(&url).send().await?;
-        match resp.status() {
-            s if s.is_success() => return Ok(resp.json::<CcsGetResponse>().await?),
+        let status = resp.status();
+        info!(commitment = %commitment_hex, attempt, %status, "CCS response received");
+        match status {
+            s if s.is_success() => {
+                let ccs = resp.json::<CcsGetResponse>().await?;
+                info!(
+                    commitment = %commitment_hex,
+                    attempt,
+                    has_reveal_accounts = ccs.reveal_accounts.is_some(),
+                    "CCS calldata parsed successfully"
+                );
+                return Ok(ccs);
+            }
             reqwest::StatusCode::NOT_FOUND => {
                 if attempt < CCS_MAX_RETRIES {
                     warn!(
+                        commitment = %commitment_hex,
                         attempt,
-                        "CCS 404 for commitment; retrying in {}s", CCS_RETRY_DELAY_SECS
+                        max_retries = CCS_MAX_RETRIES,
+                        retry_delay_secs = CCS_RETRY_DELAY_SECS,
+                        "CCS 404 — calldata not yet stored; retrying"
                     );
                     tokio::time::sleep(Duration::from_secs(CCS_RETRY_DELAY_SECS)).await;
+                } else {
+                    warn!(commitment = %commitment_hex, attempt, "CCS 404 on final attempt");
                 }
             }
-            status => bail!(
+            _ => bail!(
                 "CCS GET failed: {} {}",
                 status,
                 resp.text().await.unwrap_or_default()
@@ -238,6 +310,15 @@ fn build_instruction(
     let salt = hex_decode_fixed32(&ccs.salt)?;
 
     let msg_len = message.len() as u32;
+    info!(
+        origin,
+        sender = %hex::encode(sender),
+        user_salt = %hex::encode(user_salt),
+        message_len = msg_len,
+        salt = %ccs.salt,
+        "Building reveal instruction data"
+    );
+
     // 1 (variant) + 4 (origin) + 32 (sender) + 32 (user_salt) + 4 (msg_len) + message + 32 (salt)
     let fixed_overhead: usize = 105;
     let mut data = Vec::with_capacity(fixed_overhead.saturating_add(message.len()));
@@ -254,9 +335,21 @@ fn build_instruction(
         .as_deref()
         .ok_or_else(|| eyre!("CCS response missing revealAccounts"))?;
 
+    info!(
+        account_count = reveal_accounts.len(),
+        "Building account metas from revealAccounts"
+    );
     let accounts: Vec<AccountMeta> = reveal_accounts
         .iter()
-        .map(|a| {
+        .enumerate()
+        .map(|(i, a)| {
+            info!(
+                index = i,
+                pubkey = %a.pubkey,
+                is_writable = a.is_writable,
+                is_signer = a.is_signer,
+                "Reveal account"
+            );
             let pubkey = Pubkey::from_str(&a.pubkey)
                 .map_err(|e| eyre!("invalid pubkey {}: {}", a.pubkey, e))?;
             Ok(match (a.is_writable, a.is_signer) {
@@ -265,6 +358,12 @@ fn build_instruction(
             })
         })
         .collect::<Result<_>>()?;
+
+    info!(
+        total_data_len = data.len(),
+        total_accounts = accounts.len(),
+        "Reveal instruction assembled"
+    );
 
     Ok(Instruction {
         program_id,

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -32,7 +32,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::TransactionStatus;
-use tracing::{error, info, warn};
+use tracing::{error, info, warn, Instrument};
 
 use crate::{
     priority_fee::PriorityFeeOracle, rpc::fallback::SealevelFallbackRpcClient, SealevelKeypair,
@@ -262,7 +262,7 @@ pub fn maybe_spawn_reveal(
     let program_id = match Pubkey::from_str(&config.program_id) {
         Ok(p) => p,
         Err(e) => {
-            error!("[REVEAL] Invalid program ID in config: {e}");
+            error!("Invalid program ID in config: {e}");
             return;
         }
     };
@@ -288,17 +288,15 @@ pub fn maybe_spawn_reveal(
         commitment = %commitment_hex,
         origin,
         sender = %hex::encode(sender),
-        user_salt = %hex::encode(user_salt),
         ccs_url = %config.ccs_url,
         program_id = %config.program_id,
         fee_payer = %fee_payer.pubkey(),
-        "[REVEAL] Spawning reveal task"
+        "Spawning reveal task"
     );
 
     let ccs_url = config.ccs_url.trim_end_matches('/').to_owned();
 
     tokio::spawn(async move {
-        info!(commitment = %commitment_hex, %program_id, "[REVEAL] Task started");
         let http_client = Client::builder()
             .timeout(Duration::from_secs(CCS_REQUEST_TIMEOUT_SECS))
             .build()
@@ -331,7 +329,7 @@ pub fn maybe_spawn_reveal(
                 .await
             {
                 Ok(Some(_)) => {
-                    info!(commitment = %commitment_hex, %pending_swap_pda, "[REVEAL] PDA confirmed; proceeding to token wait");
+                    tracing::debug!("PDA confirmed; proceeding");
                     break;
                 }
                 Ok(None) => {
@@ -340,37 +338,22 @@ pub fn maybe_spawn_reveal(
                         .await
                     {
                         Ok(sigs) if !sigs.is_empty() => {
-                            info!(
-                                commitment = %commitment_hex,
-                                %pending_swap_pda,
-                                "[REVEAL] PDA gone with tx history — already revealed; stopping"
-                            );
+                            info!(%pending_swap_pda, "PDA gone with tx history — already revealed; stopping");
                             return;
                         }
                         Ok(_) => {}
                         Err(e) => {
-                            warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA history");
+                            tracing::debug!(error = ?e, "Could not check PDA history");
                         }
                     }
                     pda_wait_iters += 1;
                     if pda_wait_iters >= PDA_WAIT_MAX_ITERS {
-                        warn!(
-                            commitment = %commitment_hex,
-                            %pending_swap_pda,
-                            "[REVEAL] PDA not visible after {}s post-confirmation; stopping",
-                            PDA_WAIT_MAX_ITERS * 5
-                        );
+                        warn!(%pending_swap_pda, "PDA not visible after {}s post-confirmation; stopping", PDA_WAIT_MAX_ITERS * 5);
                         return;
                     }
-                    info!(
-                        commitment = %commitment_hex,
-                        %pending_swap_pda,
-                        wait_iters = pda_wait_iters,
-                        "[REVEAL] PDA not yet visible; retrying in 5s"
-                    );
                 }
                 Err(e) => {
-                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA; retrying in 5s");
+                    tracing::debug!(error = ?e, "Could not check PDA; retrying in 5s");
                 }
             }
             tokio::time::sleep(Duration::from_secs(5)).await;
@@ -390,11 +373,11 @@ pub fn maybe_spawn_reveal(
                 .await
             {
                 Ok(None) => {
-                    info!(commitment = %commitment_hex, "[REVEAL] PDA gone before tokens arrived; stopping");
+                    info!("PDA gone before tokens arrived; stopping");
                     return;
                 }
                 Err(e) => {
-                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA while waiting for tokens");
+                    tracing::debug!(error = ?e, "Could not check PDA while waiting for tokens");
                 }
                 Ok(Some(_)) => {}
             }
@@ -403,7 +386,7 @@ pub fn maybe_spawn_reveal(
             let ccs_opt = match fetch_from_ccs(&ctx.http_client, &ccs_url, &commitment).await {
                 Ok(c) => Some(c),
                 Err(e) => {
-                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] CCS fetch failed while waiting for tokens; retrying in 5s");
+                    warn!(error = ?e, "CCS fetch failed while waiting for tokens; retrying in 5s");
                     None
                 }
             };
@@ -425,53 +408,32 @@ pub fn maybe_spawn_reveal(
                                         acct.data[64..72].try_into().unwrap_or([0u8; 8]),
                                     );
                                     if balance > 0 {
-                                        info!(
-                                            commitment = %commitment_hex,
-                                            %ata_pubkey,
-                                            balance,
-                                            "[REVEAL] PDA input ATA has tokens; proceeding to build tx"
-                                        );
+                                        tracing::debug!(%ata_pubkey, balance, "PDA input ATA funded; proceeding to build tx");
                                         break;
                                     }
-                                    info!(
-                                        commitment = %commitment_hex,
-                                        %ata_pubkey,
-                                        "[REVEAL] PDA input ATA exists but balance is zero; waiting 5s"
-                                    );
                                 }
-                                Ok(None) => {
-                                    info!(
-                                        commitment = %commitment_hex,
-                                        %ata_pubkey,
-                                        "[REVEAL] PDA input ATA not yet created; waiting 5s"
-                                    );
-                                }
+                                Ok(None) => {}
                                 Ok(Some(_)) => {
-                                    warn!(commitment = %commitment_hex, "[REVEAL] PDA input ATA has unexpected data length; waiting 5s");
+                                    tracing::debug!("PDA input ATA has unexpected data length; waiting 5s");
                                 }
                                 Err(e) => {
-                                    warn!(commitment = %commitment_hex, error = ?e, "[REVEAL] Could not check PDA input ATA balance; waiting 5s");
+                                    warn!(error = ?e, "Could not check PDA input ATA balance; waiting 5s");
                                 }
                             }
                         } else {
-                            warn!(commitment = %commitment_hex, "[REVEAL] Could not parse accounts[1] pubkey from CCS; retrying in 5s");
+                            warn!("Could not parse accounts[1] pubkey from CCS; retrying in 5s");
                         }
                     } else {
-                        warn!(commitment = %commitment_hex, "[REVEAL] CCS revealAccounts has <2 entries; retrying in 5s");
+                        warn!("CCS revealAccounts has <2 entries; retrying in 5s");
                     }
                 } else {
-                    warn!(commitment = %commitment_hex, "[REVEAL] CCS response missing revealAccounts; retrying in 5s");
+                    warn!("CCS response missing revealAccounts; retrying in 5s");
                 }
             }
 
             token_wait_iters += 1;
             if token_wait_iters >= TOKEN_WAIT_MAX_ITERS {
-                error!(
-                    commitment = %commitment_hex,
-                    %pending_swap_pda,
-                    "[REVEAL] Warp tokens never arrived after {}s; inbound transfer may be stuck; stopping",
-                    TOKEN_WAIT_MAX_ITERS * 5
-                );
+                error!(%pending_swap_pda, "Warp tokens never arrived after {}s; inbound transfer may be stuck; stopping", TOKEN_WAIT_MAX_ITERS * 5);
                 return;
             }
             tokio::time::sleep(Duration::from_secs(5)).await;
@@ -481,7 +443,7 @@ pub fn maybe_spawn_reveal(
         loop {
             match submit_reveal(&ctx).await {
                 Ok(()) => {
-                    info!(commitment = %commitment_hex, "[REVEAL] Confirmed successfully");
+                    info!("Confirmed successfully");
                     break;
                 }
                 Err(e) => {
@@ -500,43 +462,25 @@ pub fn maybe_spawn_reveal(
                             .await
                         {
                             Ok(None) => {
-                                info!(
-                                    commitment = %commitment_hex,
-                                    %pending_swap_pda,
-                                    "[REVEAL] pending_swap PDA is gone — reveal completed by another relayer; stopping"
-                                );
+                                info!(%pending_swap_pda, "pending_swap PDA is gone — reveal completed by another relayer; stopping");
                                 break;
                             }
                             Ok(Some(_)) => {
-                                warn!(
-                                    commitment = %commitment_hex,
-                                    retry_in_secs = delay_secs,
-                                    error = ?e,
-                                    "[REVEAL] On-chain rejection but PDA still exists; retrying with fresh pool state"
-                                );
+                                warn!(retry_in_secs = delay_secs, error = ?e, "On-chain rejection but PDA still exists; retrying with fresh pool state");
                             }
                             Err(check_err) => {
-                                warn!(
-                                    commitment = %commitment_hex,
-                                    error = ?check_err,
-                                    "[REVEAL] Could not check PDA existence after on-chain error; will retry"
-                                );
+                                tracing::debug!(error = ?check_err, "Could not check PDA existence after on-chain error; will retry");
                             }
                         }
                     } else {
-                        warn!(
-                            commitment = %commitment_hex,
-                            retry_in_secs = delay_secs,
-                            error = ?e,
-                            "[REVEAL] Transient failure; will retry"
-                        );
+                        warn!(retry_in_secs = delay_secs, error = ?e, "Transient failure; will retry");
                     }
                     tokio::time::sleep(Duration::from_secs(delay_secs)).await;
                     delay_secs = (delay_secs * 2).min(REVEAL_MAX_RETRY_DELAY_SECS);
                 }
             }
         }
-    });
+    }.instrument(tracing::info_span!("reveal", commitment = %commitment_hex)));
 }
 
 struct RevealContext<'a> {
@@ -554,25 +498,8 @@ struct RevealContext<'a> {
 }
 
 async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
-    let commitment_hex = hex::encode(ctx.commitment);
-
-    info!(commitment = %commitment_hex, ccs_url = ctx.ccs_url, "[REVEAL] Fetching calldata from CCS");
     let ccs = fetch_from_ccs(&ctx.http_client, ctx.ccs_url, &ctx.commitment).await?;
-    info!(
-        commitment = %commitment_hex,
-        data_len = ccs.data.len(),
-        salt = %ccs.salt,
-        reveal_accounts_count = ccs.reveal_accounts.as_ref().map(|a| a.len()).unwrap_or(0),
-        "[REVEAL] CCS fetch succeeded"
-    );
-
-    info!(commitment = %commitment_hex, "[REVEAL] Building RouterInstruction::Reveal");
     let built = build_instruction(ctx, &ccs).await?;
-    info!(
-        commitment = %commitment_hex,
-        instruction_count = built.len(),
-        "[REVEAL] Instructions built"
-    );
 
     let dummy = SealevelTxType::Legacy(Transaction::new_unsigned(Message::new(
         &[],
@@ -583,12 +510,6 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
         .get_priority_fee(&dummy)
         .await
         .unwrap_or(0);
-    info!(
-        commitment = %commitment_hex,
-        priority_fee,
-        compute_units = REVEAL_COMPUTE_UNITS,
-        "[REVEAL] Priority fee determined"
-    );
 
     // Outer loop: each attempt fetches a fresh blockhash and rebuilds the tx.
     // On mainnet, a tx sent once is often silently dropped by congested leaders;
@@ -596,13 +517,11 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
     // window, and the outer loop retries after the window expires.
     for send_attempt in 1..=SEND_RETRY_MAX {
         // Fresh blockhash each attempt so the tx is valid for a new ~150-slot window.
-        info!(commitment = %commitment_hex, send_attempt, "[REVEAL] Fetching latest blockhash");
         let blockhash = ctx
             .rpc_client
             .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
             .await
             .map_err(|e| eyre!("get_latest_blockhash: {e}"))?;
-        info!(commitment = %commitment_hex, blockhash = %blockhash, "[REVEAL] Got blockhash");
 
         let mut instructions = vec![
             ComputeBudgetInstruction::set_compute_unit_limit(REVEAL_COMPUTE_UNITS),
@@ -613,24 +532,13 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
         let message = Message::new(&instructions, Some(&ctx.fee_payer.pubkey()));
         let tx = Transaction::new(&[ctx.fee_payer.keypair()], message, blockhash);
 
-        info!(
-            commitment = %commitment_hex,
-            fee_payer = %ctx.fee_payer.pubkey(),
-            send_attempt,
-            "[REVEAL] Sending transaction"
-        );
         let signature = ctx
             .rpc_client
             .send_transaction(&tx, true)
             .await
             .map_err(|e| eyre!("send_transaction (attempt {send_attempt}): {e}"))?;
 
-        info!(
-            commitment = %commitment_hex,
-            %signature,
-            send_attempt,
-            "[REVEAL] Tx sent; polling for confirmation"
-        );
+        info!(%signature, send_attempt, "Tx sent");
 
         let mut confirmed = false;
         for poll in 1..=CONFIRM_POLLS_PER_BLOCKHASH {
@@ -639,37 +547,25 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
             // Resend periodically to keep the tx in the leader queue within the validity window.
             if poll % RESEND_INTERVAL_POLLS == 0 {
                 if let Err(e) = ctx.rpc_client.send_transaction(&tx, true).await {
-                    warn!(commitment = %commitment_hex, %signature, poll, error = ?e, "[REVEAL] Resend error (non-fatal)");
+                    tracing::debug!(%signature, error = ?e, "Resend error (non-fatal)");
                 }
             }
 
-            info!(
-                commitment = %commitment_hex,
-                %signature,
-                send_attempt,
-                poll,
-                max_polls = CONFIRM_POLLS_PER_BLOCKHASH,
-                "[REVEAL] Polling confirmation"
-            );
             match ctx.rpc_client.get_signature_statuses(&[signature]).await {
                 Ok(response) => match response.value.into_iter().next().flatten() {
-                    None => {
-                        info!(commitment = %commitment_hex, %signature, poll, "[REVEAL] Tx not yet seen; continuing to poll");
-                    }
+                    None => {}
                     Some(TransactionStatus { err: Some(e), .. }) => {
                         bail!("Reveal tx failed on-chain: {e:?}");
                     }
                     Some(status) if status.satisfies_commitment(CommitmentConfig::confirmed()) => {
-                        info!(commitment = %commitment_hex, %signature, send_attempt, poll, "[REVEAL] Tx confirmed");
+                        info!(%signature, "Tx confirmed");
                         confirmed = true;
                         break;
                     }
-                    Some(_) => {
-                        info!(commitment = %commitment_hex, %signature, poll, "[REVEAL] Tx processed but not yet confirmed; continuing to poll");
-                    }
+                    Some(_) => {}
                 },
                 Err(e) => {
-                    warn!(commitment = %commitment_hex, %signature, error = ?e, poll, "[REVEAL] Error polling confirmation");
+                    tracing::debug!(%signature, error = ?e, "Error polling confirmation");
                 }
             }
         }
@@ -679,12 +575,7 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
         }
 
         if send_attempt < SEND_RETRY_MAX {
-            warn!(
-                commitment = %commitment_hex,
-                %signature,
-                send_attempt,
-                "[REVEAL] Tx not confirmed within blockhash window; retrying with fresh blockhash"
-            );
+            warn!(%signature, send_attempt, "Tx not confirmed within blockhash window; retrying with fresh blockhash");
         }
     }
     bail!(
@@ -700,35 +591,21 @@ async fn fetch_from_ccs(
 ) -> Result<CcsGetResponse> {
     let commitment_hex = hex::encode(commitment);
     let url = format!("{ccs_url}/calldata/0x{commitment_hex}");
-    info!(commitment = %commitment_hex, url, "[REVEAL] GET CCS calldata");
+    tracing::debug!(url, "GET CCS calldata");
     for attempt in 1..=CCS_MAX_RETRIES {
-        info!(commitment = %commitment_hex, attempt, max_retries = CCS_MAX_RETRIES, url, "[REVEAL] CCS fetch attempt");
         let resp = http.get(&url).send().await?;
         let status = resp.status();
-        info!(commitment = %commitment_hex, attempt, %status, "[REVEAL] CCS response received");
         match status {
             s if s.is_success() => {
                 let ccs = resp.json::<CcsGetResponse>().await?;
-                info!(
-                    commitment = %commitment_hex,
-                    attempt,
-                    has_reveal_accounts = ccs.reveal_accounts.is_some(),
-                    "[REVEAL] CCS calldata parsed successfully"
-                );
                 return Ok(ccs);
             }
             reqwest::StatusCode::NOT_FOUND => {
                 if attempt < CCS_MAX_RETRIES {
-                    warn!(
-                        commitment = %commitment_hex,
-                        attempt,
-                        max_retries = CCS_MAX_RETRIES,
-                        retry_delay_secs = CCS_RETRY_DELAY_SECS,
-                        "[REVEAL] CCS 404 — calldata not yet stored; retrying"
-                    );
+                    tracing::debug!(attempt, "CCS 404 — calldata not yet stored; retrying");
                     tokio::time::sleep(Duration::from_secs(CCS_RETRY_DELAY_SECS)).await;
                 } else {
-                    warn!(commitment = %commitment_hex, attempt, "[REVEAL] CCS 404 on final attempt");
+                    warn!("CCS 404 on final attempt");
                 }
             }
             _ => bail!(
@@ -795,14 +672,6 @@ async fn build_instruction(
     }
 
     let msg_len = message.len() as u32;
-    info!(
-        origin,
-        sender = %hex::encode(sender),
-        user_salt = %hex::encode(user_salt),
-        message_len = msg_len,
-        salt = %ccs.salt,
-        "[REVEAL] Building instruction data"
-    );
 
     // 1 (variant) + 4 (origin) + 32 (sender) + 32 (user_salt) + 4 (msg_len) + message + 32 (salt)
     let fixed_overhead: usize = 105;
@@ -824,16 +693,7 @@ async fn build_instruction(
     let expected_pending_swap =
         derive_pending_swap_pda(&program_id, origin, &sender, &user_salt, &commitment);
     let expected_fee_payer_pda = derive_fee_payer_pda(&program_id);
-    info!(
-        expected_pending_swap = %expected_pending_swap,
-        expected_fee_payer_pda = %expected_fee_payer_pda,
-        "[REVEAL] Locally-derived PDAs"
-    );
 
-    info!(
-        account_count = reveal_accounts.len(),
-        "[REVEAL] Building account metas"
-    );
     let mut accounts: Vec<AccountMeta> = reveal_accounts
         .iter()
         .enumerate()
@@ -849,7 +709,7 @@ async fn build_instruction(
                         warn!(
                             ccs_pubkey = %pubkey,
                             expected = %expected_pending_swap,
-                            "[REVEAL] account[0] (pending_swap PDA) mismatch — using locally-derived PDA"
+                            "account[0] (pending_swap PDA) mismatch — using locally-derived PDA"
                         );
                     }
                     expected_pending_swap
@@ -859,7 +719,7 @@ async fn build_instruction(
                         warn!(
                             ccs_pubkey = %pubkey,
                             expected = %expected_fee_payer_pda,
-                            "[REVEAL] account[2] (fee_payer_pda) mismatch — using locally-derived PDA"
+                            "account[2] (fee_payer_pda) mismatch — using locally-derived PDA"
                         );
                     }
                     expected_fee_payer_pda
@@ -867,13 +727,6 @@ async fn build_instruction(
                 _ => pubkey,
             };
 
-            info!(
-                index = i,
-                pubkey = %pubkey,
-                is_writable = a.is_writable,
-                is_signer = a.is_signer,
-                "[REVEAL] Account"
-            );
             Ok(match (a.is_writable, a.is_signer) {
                 (true, _) => AccountMeta::new(pubkey, a.is_signer),
                 (false, _) => AccountMeta::new_readonly(pubkey, a.is_signer),
@@ -889,13 +742,13 @@ async fn build_instruction(
         let pool_pubkey = accounts[6].pubkey;
         match fetch_clmm_pool_state(pool_pubkey, rpc_client).await {
             Ok(pool_state) => {
-                info!(
+                tracing::debug!(
                     pool = %pool_pubkey,
                     amm_config = %pool_state.amm_config,
                     observation_state = %pool_state.observation_state,
                     tick_current = pool_state.tick_current,
                     tick_spacing = pool_state.tick_spacing,
-                    "[REVEAL] Fetched live CLMM pool state"
+                    "Fetched live CLMM pool state"
                 );
 
                 let override_acct =
@@ -904,7 +757,7 @@ async fn build_instruction(
                             warn!(
                                 ccs = %accounts[idx].pubkey,
                                 live = %live,
-                                "[REVEAL] {} mismatch — using live pool state",
+                                "{} mismatch — using live pool state",
                                 label
                             );
                             accounts[idx].pubkey = live;
@@ -966,15 +819,7 @@ async fn build_instruction(
                 let live_ta0 = compute_tick_array_address(&pool_pubkey, ta0_start);
                 let live_ta1 = compute_tick_array_address(&pool_pubkey, ta1_start);
                 let live_ta2 = compute_tick_array_address(&pool_pubkey, ta2_start);
-                info!(
-                    ta0 = %live_ta0,
-                    ta1 = %live_ta1,
-                    ta2 = %live_ta2,
-                    ta0_start,
-                    ta1_start,
-                    ta2_start,
-                    "[REVEAL] Recomputed tick arrays from live pool state"
-                );
+                tracing::debug!(ta0 = %live_ta0, ta1 = %live_ta1, ta2 = %live_ta2, "Recomputed tick arrays from live pool state");
                 accounts[17].pubkey = live_ta0;
                 accounts[18].pubkey = live_ta1;
                 accounts[19].pubkey = live_ta2;
@@ -1064,11 +909,7 @@ async fn build_instruction(
                         &recipient_pubkey,
                         &fee_payer_pubkey,
                     );
-                    info!(
-                        fee_payer_wsol_ata = %fee_payer_wsol_ata,
-                        recipient = %recipient_pubkey,
-                        "[REVEAL] SOL output: fee_payer wSOL ATA will be closed → native SOL to recipient"
-                    );
+                    tracing::debug!(fee_payer_wsol_ata = %fee_payer_wsol_ata, "SOL output: closing wSOL ATA → native SOL to recipient");
                     (ata_ix, Some(close_ix))
                 } else {
                     override_acct(
@@ -1095,12 +936,6 @@ async fn build_instruction(
                     &output_token_prog,
                 );
 
-                info!(
-                    pda_output_ata = %live_pda_output_ata,
-                    output_is_native_sol,
-                    "[REVEAL] ATA creation instructions prepared"
-                );
-
                 let reveal_ix = Instruction {
                     program_id,
                     accounts,
@@ -1116,22 +951,16 @@ async fn build_instruction(
                 warn!(
                     pool = %pool_pubkey,
                     error = ?e,
-                    "[REVEAL] Could not fetch CLMM pool state; submitting without ATA pre-creation"
+                    "Could not fetch CLMM pool state; submitting without ATA pre-creation"
                 );
             }
         }
     } else {
         warn!(
             account_count = accounts.len(),
-            "[REVEAL] Expected 25 accounts for CLMM reveal — skipping live pool state override"
+            "Expected 25 accounts for CLMM reveal — skipping live pool state override"
         );
     }
-
-    info!(
-        total_data_len = data.len(),
-        total_accounts = accounts.len(),
-        "[REVEAL] Instruction assembled (no pool state override)"
-    );
 
     Ok(vec![Instruction {
         program_id,

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -518,13 +518,15 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
     let ccs = fetch_from_ccs(&ctx.http_client, ctx.ccs_url, &ctx.commitment).await?;
     let built = build_instruction(ctx, &ccs).await?;
 
-    let dummy = SealevelTxType::Legacy(Transaction::new_unsigned(Message::new(
-        &[],
+    // Build a probe tx from the real instructions so the oracle can price based
+    // on the actual hot accounts (pool, vaults, tick arrays) rather than a global estimate.
+    let probe = SealevelTxType::Legacy(Transaction::new_unsigned(Message::new(
+        &built,
         Some(&ctx.fee_payer.pubkey()),
     )));
     let priority_fee = ctx
         .priority_fee_oracle
-        .get_priority_fee(&dummy)
+        .get_priority_fee(&probe)
         .await
         .unwrap_or(0);
 
@@ -998,27 +1000,11 @@ async fn build_instruction(
                 return Ok(ixs);
             }
             Err(e) => {
-                warn!(
-                    pool = %pool_pubkey,
-                    error = ?e,
-                    "Could not fetch CLMM pool state; submitting with CCS accounts and new layout"
-                );
-                // Still replace CCS[3] with the 4 new fixed accounts using CCS-provided
-                // mint/token_program so the instruction has the correct layout.
-                let input_token_prog = accounts[12].pubkey;
-                let input_mint = accounts[15].pubkey;
-                let recipient_pubkey = Pubkey::new_from_array(recipient);
-                let recipient_input_ata =
-                    derive_ata(&recipient_pubkey, &input_mint, &input_token_prog);
-                accounts.splice(
-                    3..4,
-                    [
-                        AccountMeta::new(recipient_input_ata, false),
-                        AccountMeta::new_readonly(input_token_prog, false),
-                        AccountMeta::new_readonly(input_mint, false),
-                        AccountMeta::new_readonly(solana_system_interface::program::id(), false),
-                    ],
-                );
+                // Bail so the outer retry loop re-fetches pool state on the next attempt.
+                // Submitting with stale CCS accounts would produce a ConstraintAddress failure
+                // on-chain and, for SOL-output reveals, would silently omit the wSOL close
+                // instruction — burning fees without unwrapping the token.
+                bail!("Could not fetch live CLMM pool state: {e}");
             }
         }
     } else {

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -102,20 +102,22 @@ fn parse_clmm_pool_state(data: &[u8]) -> Result<ClmmPoolState> {
             min_len
         );
     }
-    #[allow(clippy::unwrap_used)]
-    let read_pubkey =
-        |offset: usize| Pubkey::new_from_array(data[offset..offset + 32].try_into().unwrap());
-    #[allow(clippy::unwrap_used)]
+    let read_pubkey = |offset: usize| {
+        Pubkey::new_from_array(
+            data[offset..offset + 32]
+                .try_into()
+                .expect("slice is exactly 32 bytes"),
+        )
+    };
     let tick_spacing = i16::from_le_bytes(
         data[POOL_TICK_SPACING_OFFSET..POOL_TICK_SPACING_OFFSET + 2]
             .try_into()
-            .unwrap(),
+            .expect("slice is exactly 2 bytes"),
     );
-    #[allow(clippy::unwrap_used)]
     let tick_current = i32::from_le_bytes(
         data[POOL_TICK_CURRENT_OFFSET..POOL_TICK_CURRENT_OFFSET + 4]
             .try_into()
-            .unwrap(),
+            .expect("slice is exactly 4 bytes"),
     );
     Ok(ClmmPoolState {
         amm_config: read_pubkey(POOL_AMM_CONFIG_OFFSET),
@@ -269,12 +271,15 @@ pub fn maybe_spawn_reveal(
         return;
     }
     // COMMIT body: commitment(32) | userSalt(32) | recipient(32)
-    #[allow(clippy::unwrap_used)]
-    let commitment: [u8; 32] = message.body[0..32].try_into().unwrap();
-    #[allow(clippy::unwrap_used)]
-    let user_salt: [u8; 32] = message.body[32..64].try_into().unwrap();
-    #[allow(clippy::unwrap_used)]
-    let recipient: [u8; 32] = message.body[64..96].try_into().unwrap();
+    let commitment: [u8; 32] = message.body[0..32]
+        .try_into()
+        .expect("body is exactly 96 bytes");
+    let user_salt: [u8; 32] = message.body[32..64]
+        .try_into()
+        .expect("body is exactly 96 bytes");
+    let recipient: [u8; 32] = message.body[64..96]
+        .try_into()
+        .expect("body is exactly 96 bytes");
     let origin = message.origin;
     let sender = message.sender.0;
     let commitment_hex = hex::encode(commitment);

--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -1903,7 +1903,11 @@
       "validatorAnnounce": "pRgs5vN4Pj7WvFbxf6QDHizo2njq2uksqEUbaSghVA8",
       "interchainSecurityModule": "LwNfVYMDzAe5dCJgA5CipTZcT34Eyf74zLr81K91jxk",
       "technicalStack": "other",
-      "mailboxProcessAlt": "5iPyGCTQ2xHaCxv9A8GDJzt2tHWL8t9FK8UwG3KoQsYo"
+      "mailboxProcessAlt": "5iPyGCTQ2xHaCxv9A8GDJzt2tHWL8t9FK8UwG3KoQsYo",
+      "urReveal": {
+        "ccsUrl": "https://offchain-lookup.services.hyperlane.xyz/callCommitments",
+        "programId": "2CttnaLkYbNHbaFDFnQ8PMCnzUwTGrKnskBxPM4TRWGp"
+      }
     },
     "taiko": {
       "aggregationHook": "0xeD3990D594ceA77b3b9b23378d8527534b6B3779",

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -364,10 +364,27 @@ fn parse_sealevel_ur_reveal(
         .map(|s| s.to_owned());
 
     match (ccs_url, program_id) {
-        (Some(ccs_url), Some(program_id)) => Some(UniversalRouterRevealConfig {
-            ccs_url,
-            program_id,
-        }),
+        (Some(ccs_url), Some(program_id)) => {
+            // Validate at startup so misconfiguration fails fast rather than at first reveal.
+            if Url::parse(&ccs_url).is_err() {
+                err.push(
+                    (&chain.cwp).add("urReveal").add("ccsUrl"),
+                    eyre!("urReveal.ccsUrl is not a valid URL: {ccs_url}"),
+                );
+                return None;
+            }
+            if Pubkey::from_str(&program_id).is_err() {
+                err.push(
+                    (&chain.cwp).add("urReveal").add("programId"),
+                    eyre!("urReveal.programId is not a valid Solana pubkey: {program_id}"),
+                );
+                return None;
+            }
+            Some(UniversalRouterRevealConfig {
+                ccs_url,
+                program_id,
+            })
+        }
         (None, None) => None,
         _ => {
             err.push(

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -312,6 +312,7 @@ fn build_sealevel_connection_conf(
         transaction_submitter,
         mailbox_process_alt,
         process_alt_overrides,
+        ur_reveal: None,
     }))
 }
 

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -3,7 +3,7 @@ use std::{ops::Add, str::FromStr};
 use eyre::eyre;
 use hyperlane_sealevel::{
     HeliusPriorityFeeLevel, HeliusPriorityFeeOracleConfig, PriorityFeeOracleConfig,
-    ProcessAltOverride,
+    ProcessAltOverride, UniversalRouterRevealConfig,
 };
 use solana_sdk::pubkey::Pubkey;
 use url::Url;
@@ -296,6 +296,7 @@ fn build_sealevel_connection_conf(
     let transaction_submitter = parse_transaction_submitter_config(chain, &mut local_err);
     let mailbox_process_alt = parse_sealevel_mailbox_process_alt(chain, &mut local_err);
     let process_alt_overrides = parse_sealevel_process_alt_overrides(chain, &mut local_err);
+    let ur_reveal = parse_sealevel_ur_reveal(chain, &mut local_err);
 
     if !local_err.is_ok() {
         err.merge(local_err);
@@ -312,7 +313,7 @@ fn build_sealevel_connection_conf(
         transaction_submitter,
         mailbox_process_alt,
         process_alt_overrides,
-        ur_reveal: None,
+        ur_reveal,
     }))
 }
 
@@ -339,6 +340,42 @@ fn parse_sealevel_mailbox_process_alt(
         }
     } else {
         None
+    }
+}
+
+fn parse_sealevel_ur_reveal(
+    chain: &ValueParser,
+    err: &mut ConfigParsingError,
+) -> Option<UniversalRouterRevealConfig> {
+    let ccs_url = chain
+        .chain(err)
+        .get_opt_key("urReveal")
+        .get_opt_key("ccsUrl")
+        .parse_string()
+        .end()
+        .map(|s| s.to_owned());
+
+    let program_id = chain
+        .chain(err)
+        .get_opt_key("urReveal")
+        .get_opt_key("programId")
+        .parse_string()
+        .end()
+        .map(|s| s.to_owned());
+
+    match (ccs_url, program_id) {
+        (Some(ccs_url), Some(program_id)) => Some(UniversalRouterRevealConfig {
+            ccs_url,
+            program_id,
+        }),
+        (None, None) => None,
+        _ => {
+            err.push(
+                (&chain.cwp).add("urReveal"),
+                eyre!("urReveal requires both ccsUrl and programId"),
+            );
+            None
+        }
     }
 }
 

--- a/rust/main/hyperlane-core/src/traits/mailbox.rs
+++ b/rust/main/hyperlane-core/src/traits/mailbox.rs
@@ -75,7 +75,11 @@ pub trait Mailbox: HyperlaneContract + Send + Sync + Debug {
     /// Get the calldata for a call which allows to check if a particular messages was delivered
     fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>>;
 
-    /// Called when the relayer sees a message that may need chain-specific follow-up work.
+    /// Called immediately after the relayer successfully submits a process tx for a message.
+    /// Fires before the confirm delay; use for latency-sensitive follow-up work.
+    fn on_submitted(&self, _message: &HyperlaneMessage) {}
+
+    /// Called when the relayer confirms a message was already delivered (restart recovery path).
     fn on_delivered(&self, _message: &HyperlaneMessage) {}
 }
 

--- a/rust/main/hyperlane-core/src/traits/mailbox.rs
+++ b/rust/main/hyperlane-core/src/traits/mailbox.rs
@@ -74,6 +74,11 @@ pub trait Mailbox: HyperlaneContract + Send + Sync + Debug {
 
     /// Get the calldata for a call which allows to check if a particular messages was delivered
     fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>>;
+
+    /// Called once after a message is confirmed as delivered on-chain.
+    /// Default is a no-op; chain implementations may override to perform
+    /// post-delivery actions (e.g. submitting a reveal transaction).
+    fn on_delivered(&self, _message: &HyperlaneMessage) {}
 }
 
 /// The result of processing a batch of messages

--- a/rust/main/hyperlane-core/src/traits/mailbox.rs
+++ b/rust/main/hyperlane-core/src/traits/mailbox.rs
@@ -74,11 +74,6 @@ pub trait Mailbox: HyperlaneContract + Send + Sync + Debug {
 
     /// Get the calldata for a call which allows to check if a particular messages was delivered
     fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>>;
-
-    /// Called once after a message is confirmed as delivered on-chain.
-    /// Default is a no-op; chain implementations may override to perform
-    /// post-delivery actions (e.g. submitting a reveal transaction).
-    fn on_delivered(&self, _message: &HyperlaneMessage) {}
 }
 
 /// The result of processing a batch of messages

--- a/rust/main/hyperlane-core/src/traits/mailbox.rs
+++ b/rust/main/hyperlane-core/src/traits/mailbox.rs
@@ -74,6 +74,9 @@ pub trait Mailbox: HyperlaneContract + Send + Sync + Debug {
 
     /// Get the calldata for a call which allows to check if a particular messages was delivered
     fn delivered_calldata(&self, message_id: H256) -> ChainResult<Option<Vec<u8>>>;
+
+    /// Called when the relayer sees a message that may need chain-specific follow-up work.
+    fn on_delivered(&self, _message: &HyperlaneMessage) {}
 }
 
 /// The result of processing a batch of messages

--- a/rust/main/hyperlane-core/src/traits/mailbox.rs
+++ b/rust/main/hyperlane-core/src/traits/mailbox.rs
@@ -77,7 +77,7 @@ pub trait Mailbox: HyperlaneContract + Send + Sync + Debug {
 
     /// Called immediately after the relayer successfully submits a process tx for a message.
     /// Fires before the confirm delay; use for latency-sensitive follow-up work.
-    fn on_submitted(&self, _message: &HyperlaneMessage) {}
+    fn on_submitted_success(&self, _message: &HyperlaneMessage) {}
 
     /// Called when the relayer confirms a message was already delivered (restart recovery path).
     fn on_delivered(&self, _message: &HyperlaneMessage) {}

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -179,7 +179,7 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
 
     /// Called immediately after the process tx for this operation is successfully submitted.
     /// Default no-op; override for latency-sensitive follow-up work (e.g. UR reveal).
-    fn on_submitted(&self) {}
+    fn on_submitted_success(&self) {}
 
     /// Creates payload for the operation
     async fn payload(&self) -> ChainResult<Vec<u8>>;

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -177,6 +177,10 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
         None
     }
 
+    /// Called immediately after the process tx for this operation is successfully submitted.
+    /// Default no-op; override for latency-sensitive follow-up work (e.g. UR reveal).
+    fn on_submitted(&self) {}
+
     /// Creates payload for the operation
     async fn payload(&self) -> ChainResult<Vec<u8>>;
 

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_config.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_config.rs
@@ -37,6 +37,7 @@ fn test_configuration_fields() {
             transaction_submitter: Default::default(),
             mailbox_process_alt: None,
             process_alt_overrides: vec![],
+            ur_reveal: None,
         }),
         metrics_conf: Default::default(),
         index: Default::default(),

--- a/typescript/ccip-server/prisma/migrations/20260617154917_add_calldata/migration.sql
+++ b/typescript/ccip-server/prisma/migrations/20260617154917_add_calldata/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "Calldata" (
+    "commitment" TEXT NOT NULL,
+    "chainId" INTEGER NOT NULL,
+    "data" TEXT NOT NULL,
+    "salt" TEXT NOT NULL,
+    "relayers" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Calldata_pkey" PRIMARY KEY ("commitment")
+);

--- a/typescript/ccip-server/prisma/migrations/20260617200000_add_calldata_user_salt/migration.sql
+++ b/typescript/ccip-server/prisma/migrations/20260617200000_add_calldata_user_salt/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Calldata" ADD COLUMN "userSalt" TEXT;

--- a/typescript/ccip-server/prisma/migrations/20260617210000_rename_calldata_columns/migration.sql
+++ b/typescript/ccip-server/prisma/migrations/20260617210000_rename_calldata_columns/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "Calldata" RENAME COLUMN "chainId" TO "originDomain";
+ALTER TABLE "Calldata" RENAME COLUMN "userSalt" TO "destinationAccount";
+UPDATE "Calldata" SET "destinationAccount" = '' WHERE "destinationAccount" IS NULL;
+ALTER TABLE "Calldata" ALTER COLUMN "destinationAccount" SET NOT NULL;

--- a/typescript/ccip-server/prisma/migrations/20260622000000_add_calldata_reveal_accounts/migration.sql
+++ b/typescript/ccip-server/prisma/migrations/20260622000000_add_calldata_reveal_accounts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Calldata" ADD COLUMN "revealAccounts" JSONB;

--- a/typescript/ccip-server/prisma/schema.prisma
+++ b/typescript/ccip-server/prisma/schema.prisma
@@ -29,5 +29,6 @@ model Calldata {
   salt               String
   relayers           Json
   destinationAccount String
+  revealAccounts     Json?
   createdAt          DateTime @default(now())
 }

--- a/typescript/ccip-server/prisma/schema.prisma
+++ b/typescript/ccip-server/prisma/schema.prisma
@@ -23,10 +23,11 @@ model Commitment {
 }
 
 model Calldata {
-  commitment String   @id
-  chainId    Int
-  data       String
-  salt       String
-  relayers   Json
-  createdAt  DateTime @default(now())
+  commitment         String   @id
+  originDomain       Int
+  data               String
+  salt               String
+  relayers           Json
+  destinationAccount String
+  createdAt          DateTime @default(now())
 }

--- a/typescript/ccip-server/prisma/schema.prisma
+++ b/typescript/ccip-server/prisma/schema.prisma
@@ -21,3 +21,12 @@ model Commitment {
   originDomain Int
   createdAt    DateTime @default(now())
 }
+
+model Calldata {
+  commitment String   @id
+  chainId    Int
+  data       String
+  salt       String
+  relayers   Json
+  createdAt  DateTime @default(now())
+}

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -1,4 +1,5 @@
 import type { Log } from '@ethersproject/providers';
+import { utils } from 'ethers';
 import { Request, Response, Router } from 'express';
 import rateLimit from 'express-rate-limit';
 import { Logger } from 'pino';
@@ -426,7 +427,7 @@ export class CallCommitmentsService extends BaseService {
         /^0x[0-9a-fA-F]{64}$/,
         'commitment must be a 32-byte 0x hex string',
       ),
-    chainId: z.number().int().positive(),
+    originDomain: z.number().int().positive(),
     data: z
       .string()
       .regex(/^0x[0-9a-fA-F]+$/, 'data must be a non-empty 0x hex string'),
@@ -434,6 +435,12 @@ export class CallCommitmentsService extends BaseService {
       .string()
       .regex(/^0x[0-9a-fA-F]{64}$/, 'salt must be a 32-byte 0x hex string'),
     relayers: z.array(z.string().regex(/^0x[0-9a-fA-F]{64}$/)).default([]),
+    destinationAccount: z
+      .string()
+      .regex(
+        /^0x[0-9a-fA-F]{64}$/,
+        'destinationAccount must be a 32-byte 0x hex string',
+      ),
   });
 
   public async handleCalldataPost(req: Request, res: Response) {
@@ -444,14 +451,62 @@ export class CallCommitmentsService extends BaseService {
     if (!result.success) {
       return res.status(400).json({ errors: result.error.format() });
     }
-    const { commitment, chainId, data, salt, relayers } = result.data;
-    logger.info({ chainId, commitment }, 'Storing calldata');
+    const {
+      commitment,
+      originDomain,
+      data,
+      salt,
+      relayers,
+      destinationAccount,
+    } = result.data;
+    logger.info({ originDomain, commitment }, 'Storing calldata');
     try {
       await prisma.calldata.upsert({
         where: { commitment },
         update: {},
-        create: { commitment, chainId, data, salt, relayers },
+        create: {
+          commitment,
+          originDomain,
+          data,
+          salt,
+          relayers,
+          destinationAccount,
+        },
       });
+
+      // Dual-write to Commitment table for EVM destinations so the existing
+      // getCallsFromRevealMessage CCIP-Read endpoint keeps working.
+      // destinationAccount is bytes32; if upper 12 bytes are zero, it's a padded EVM address.
+      if (/^0x0{24}[0-9a-fA-F]{40}$/.test(destinationAccount)) {
+        const icaAddress = bytes32ToAddress(destinationAccount);
+        const [decodedCalls] = utils.defaultAbiCoder.decode(
+          ['tuple(bytes32 to, uint256 value, bytes data)[]'],
+          data,
+        ) as [
+          Array<{ to: string; value: { toString(): string }; data: string }>,
+        ];
+        const calls = decodedCalls.map((c) => ({
+          to: c.to,
+          value: c.value.toString(),
+          data: c.data,
+        }));
+        await prisma.commitment.upsert({
+          where: { commitment },
+          update: {},
+          create: {
+            commitment,
+            calls,
+            relayers,
+            salt,
+            ica: icaAddress,
+            originDomain,
+          },
+        });
+        logger.info(
+          { commitment, icaAddress, originDomain },
+          'Dual-wrote to Commitment table',
+        );
+      }
     } catch (error: any) {
       logger.error(
         {
@@ -474,10 +529,11 @@ export class CallCommitmentsService extends BaseService {
     const { commitment } = req.params;
 
     let record: {
-      chainId: number;
+      originDomain: number;
       data: string;
       salt: string;
       relayers: unknown;
+      destinationAccount: string | null;
     } | null;
     try {
       record = await prisma.calldata.findUnique({ where: { commitment } });
@@ -491,9 +547,12 @@ export class CallCommitmentsService extends BaseService {
     if (!record) return res.status(404).json({ error: 'Not found' });
 
     return res.status(200).json({
-      chainId: record.chainId,
+      originDomain: record.originDomain,
       data: record.data,
       salt: record.salt,
+      ...(record.destinationAccount != null && {
+        destinationAccount: record.destinationAccount,
+      }),
     });
   }
 

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -420,6 +420,12 @@ export class CallCommitmentsService extends BaseService {
 
   // ── /calldata endpoints ─────────────────────────────────────────────────────
 
+  private static readonly RevealAccountSchema = z.object({
+    pubkey: z.string().min(32).max(44),
+    isWritable: z.boolean(),
+    isSigner: z.boolean(),
+  });
+
   private static readonly CalldataPostSchema = z.object({
     commitment: z
       .string()
@@ -441,6 +447,9 @@ export class CallCommitmentsService extends BaseService {
         /^0x[0-9a-fA-F]{64}$/,
         'destinationAccount must be a 32-byte 0x hex string',
       ),
+    revealAccounts: z
+      .array(CallCommitmentsService.RevealAccountSchema)
+      .optional(),
   });
 
   public async handleCalldataPost(req: Request, res: Response) {
@@ -458,6 +467,7 @@ export class CallCommitmentsService extends BaseService {
       salt,
       relayers,
       destinationAccount,
+      revealAccounts,
     } = result.data;
     logger.info({ originDomain, commitment }, 'Storing calldata');
     try {
@@ -471,6 +481,7 @@ export class CallCommitmentsService extends BaseService {
           salt,
           relayers,
           destinationAccount,
+          ...(revealAccounts != null && { revealAccounts }),
         },
       });
 
@@ -541,6 +552,7 @@ export class CallCommitmentsService extends BaseService {
       salt: string;
       relayers: unknown;
       destinationAccount: string | null;
+      revealAccounts: unknown;
     } | null;
     try {
       record = await prisma.calldata.findUnique({ where: { commitment } });
@@ -559,6 +571,9 @@ export class CallCommitmentsService extends BaseService {
       salt: record.salt,
       ...(record.destinationAccount != null && {
         destinationAccount: record.destinationAccount,
+      }),
+      ...(record.revealAccounts != null && {
+        revealAccounts: record.revealAccounts,
       }),
     });
   }

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -436,7 +436,10 @@ export class CallCommitmentsService extends BaseService {
     originDomain: z.number().int().positive(),
     data: z
       .string()
-      .regex(/^0x[0-9a-fA-F]+$/, 'data must be a non-empty 0x hex string'),
+      .regex(
+        /^0x(?:[0-9a-fA-F]{2})+$/,
+        'data must be a non-empty byte-aligned 0x hex string',
+      ),
     salt: z
       .string()
       .regex(/^0x[0-9a-fA-F]{64}$/, 'salt must be a 32-byte 0x hex string'),
@@ -489,25 +492,38 @@ export class CallCommitmentsService extends BaseService {
       // CCIP-Read endpoint keeps working. Only EVM-destination routes carry
       // ABI-encoded ICA calls — borsh (Solana) data will fail to decode and
       // skip the dual-write automatically.
+      let decodedCalls: Array<{
+        to: string;
+        value: string;
+        data: string;
+      }> | null = null;
       try {
-        const icaAddress = bytes32ToAddress(destinationAccount);
-        const [decodedCalls] = utils.defaultAbiCoder.decode(
+        const [raw] = utils.defaultAbiCoder.decode(
           ['tuple(bytes32 to, uint256 value, bytes data)[]'],
           data,
         ) as [
           Array<{ to: string; value: { toString(): string }; data: string }>,
         ];
-        const calls = decodedCalls.map((c) => ({
+        decodedCalls = raw.map((c) => ({
           to: c.to,
           value: c.value.toString(),
           data: c.data,
         }));
+      } catch {
+        // Solana-destination routes carry borsh data that fails ABI decode — not an error.
+        logger.debug(
+          { commitment },
+          'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
+        );
+      }
+      if (decodedCalls != null) {
+        const icaAddress = bytes32ToAddress(destinationAccount);
         await prisma.commitment.upsert({
           where: { commitment },
           update: {},
           create: {
             commitment,
-            calls,
+            calls: decodedCalls,
             relayers,
             salt,
             ica: icaAddress,
@@ -517,12 +533,6 @@ export class CallCommitmentsService extends BaseService {
         logger.info(
           { commitment, icaAddress, originDomain },
           'Dual-wrote to Commitment table',
-        );
-      } catch (dualWriteError: any) {
-        // Solana-destination routes carry borsh data that fails ABI decode — not an error.
-        logger.debug(
-          { commitment, error: dualWriteError.message },
-          'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
         );
       }
     } catch (error: any) {

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -608,7 +608,11 @@ export class CallCommitmentsService extends BaseService {
       commitmentRateLimit,
       this.handleCalldataPost.bind(this),
     );
-    router.get('/calldata/:commitment', this.handleCalldataGet.bind(this));
+    router.get(
+      '/calldata/:commitment',
+      commitmentRateLimit,
+      this.handleCalldataGet.bind(this),
+    );
     router.post(
       '/getCallsFromRevealMessage',
       createAbiHandler(

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -474,38 +474,47 @@ export class CallCommitmentsService extends BaseService {
         },
       });
 
-      // Dual-write to Commitment table for EVM destinations so the existing
-      // getCallsFromRevealMessage CCIP-Read endpoint keeps working.
-      // destinationAccount is bytes32; if upper 12 bytes are zero, it's a padded EVM address.
-      if (/^0x0{24}[0-9a-fA-F]{40}$/.test(destinationAccount)) {
-        const icaAddress = bytes32ToAddress(destinationAccount);
-        const [decodedCalls] = utils.defaultAbiCoder.decode(
-          ['tuple(bytes32 to, uint256 value, bytes data)[]'],
-          data,
-        ) as [
-          Array<{ to: string; value: { toString(): string }; data: string }>,
-        ];
-        const calls = decodedCalls.map((c) => ({
-          to: c.to,
-          value: c.value.toString(),
-          data: c.data,
-        }));
-        await prisma.commitment.upsert({
-          where: { commitment },
-          update: {},
-          create: {
-            commitment,
-            calls,
-            relayers,
-            salt,
-            ica: icaAddress,
-            originDomain,
-          },
-        });
-        logger.info(
-          { commitment, icaAddress, originDomain },
-          'Dual-wrote to Commitment table',
-        );
+      // Dual-write to Commitment table so the existing getCallsFromRevealMessage
+      // CCIP-Read endpoint keeps working. Only EVM-destination routes carry
+      // ABI-encoded ICA calls — borsh (Solana) data will fail to decode and
+      // skip the dual-write automatically.
+      {
+        try {
+          const icaAddress = bytes32ToAddress(destinationAccount);
+          const [decodedCalls] = utils.defaultAbiCoder.decode(
+            ['tuple(bytes32 to, uint256 value, bytes data)[]'],
+            data,
+          ) as [
+            Array<{ to: string; value: { toString(): string }; data: string }>,
+          ];
+          const calls = decodedCalls.map((c) => ({
+            to: c.to,
+            value: c.value.toString(),
+            data: c.data,
+          }));
+          await prisma.commitment.upsert({
+            where: { commitment },
+            update: {},
+            create: {
+              commitment,
+              calls,
+              relayers,
+              salt,
+              ica: icaAddress,
+              originDomain,
+            },
+          });
+          logger.info(
+            { commitment, icaAddress, originDomain },
+            'Dual-wrote to Commitment table',
+          );
+        } catch (dualWriteError: any) {
+          // Solana-destination routes carry borsh data that fails ABI decode — not an error.
+          logger.debug(
+            { commitment, error: dualWriteError.message },
+            'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
+          );
+        }
       }
     } catch (error: any) {
       logger.error(

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -421,7 +421,12 @@ export class CallCommitmentsService extends BaseService {
   // ── /calldata endpoints ─────────────────────────────────────────────────────
 
   private static readonly RevealAccountSchema = z.object({
-    pubkey: z.string().min(32).max(44),
+    pubkey: z
+      .string()
+      .regex(
+        /^[1-9A-HJ-NP-Za-km-z]{32,44}$/,
+        'pubkey must be a base58 Solana address',
+      ),
     isWritable: z.boolean(),
     isSigner: z.boolean(),
   });
@@ -443,7 +448,16 @@ export class CallCommitmentsService extends BaseService {
     salt: z
       .string()
       .regex(/^0x[0-9a-fA-F]{64}$/, 'salt must be a 32-byte 0x hex string'),
-    relayers: z.array(z.string().regex(/^0x[0-9a-fA-F]{64}$/)).default([]),
+    relayers: z
+      .array(
+        z
+          .string()
+          .regex(
+            /^0x[0-9a-fA-F]{40}$/,
+            'relayer must be a 20-byte EVM address',
+          ),
+      )
+      .default([]),
     destinationAccount: z
       .string()
       .regex(
@@ -472,6 +486,17 @@ export class CallCommitmentsService extends BaseService {
       destinationAccount,
       revealAccounts,
     } = result.data;
+    // Verify commitment = keccak256(salt || data) before persisting.
+    // This prevents a client from poisoning a commitment slot with arbitrary data.
+    const expectedCommitment = utils.keccak256(
+      utils.concat([utils.arrayify(salt), utils.arrayify(data)]),
+    );
+    if (expectedCommitment.toLowerCase() !== commitment.toLowerCase()) {
+      return res
+        .status(400)
+        .json({ error: 'commitment does not match keccak256(salt || data)' });
+    }
+
     logger.info({ originDomain, commitment }, 'Storing calldata');
     try {
       await prisma.calldata.upsert({

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -417,6 +417,86 @@ export class CallCommitmentsService extends BaseService {
     }
   }
 
+  // ── /calldata endpoints ─────────────────────────────────────────────────────
+
+  private static readonly CalldataPostSchema = z.object({
+    commitment: z
+      .string()
+      .regex(
+        /^0x[0-9a-fA-F]{64}$/,
+        'commitment must be a 32-byte 0x hex string',
+      ),
+    chainId: z.number().int().positive(),
+    data: z
+      .string()
+      .regex(/^0x[0-9a-fA-F]+$/, 'data must be a non-empty 0x hex string'),
+    salt: z
+      .string()
+      .regex(/^0x[0-9a-fA-F]{64}$/, 'salt must be a 32-byte 0x hex string'),
+    relayers: z.array(z.string().regex(/^0x[0-9a-fA-F]{64}$/)).default([]),
+  });
+
+  public async handleCalldataPost(req: Request, res: Response) {
+    const logger = this.addLoggerServiceContext(req.log);
+    const result = CallCommitmentsService.CalldataPostSchema.safeParse(
+      req.body,
+    );
+    if (!result.success) {
+      return res.status(400).json({ errors: result.error.format() });
+    }
+    const { commitment, chainId, data, salt, relayers } = result.data;
+    logger.info({ chainId, commitment }, 'Storing calldata');
+    try {
+      await prisma.calldata.upsert({
+        where: { commitment },
+        update: {},
+        create: { commitment, chainId, data, salt, relayers },
+      });
+    } catch (error: any) {
+      logger.error(
+        {
+          error: error.message,
+          error_reason: UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
+        },
+        'Database error storing calldata',
+      );
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
+      );
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+    return res.status(200).json({ commitment });
+  }
+
+  public async handleCalldataGet(req: Request, res: Response) {
+    const logger = this.addLoggerServiceContext(req.log);
+    const { commitment } = req.params;
+
+    let record: {
+      chainId: number;
+      data: string;
+      salt: string;
+      relayers: unknown;
+    } | null;
+    try {
+      record = await prisma.calldata.findUnique({ where: { commitment } });
+    } catch (error: any) {
+      logger.error(
+        { commitment, error: error.message },
+        'Database error fetching calldata',
+      );
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+    if (!record) return res.status(404).json({ error: 'Not found' });
+
+    return res.status(200).json({
+      chainId: record.chainId,
+      data: record.data,
+      salt: record.salt,
+    });
+  }
+
   /**
    * Register routes onto an Express Router or app.
    */
@@ -442,6 +522,12 @@ export class CallCommitmentsService extends BaseService {
       commitmentRateLimit,
       this.handleCheckCommitment.bind(this),
     );
+    router.post(
+      '/calldata',
+      commitmentRateLimit,
+      this.handleCalldataPost.bind(this),
+    );
+    router.get('/calldata/:commitment', this.handleCalldataGet.bind(this));
     router.post(
       '/getCallsFromRevealMessage',
       createAbiHandler(

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -478,43 +478,41 @@ export class CallCommitmentsService extends BaseService {
       // CCIP-Read endpoint keeps working. Only EVM-destination routes carry
       // ABI-encoded ICA calls — borsh (Solana) data will fail to decode and
       // skip the dual-write automatically.
-      {
-        try {
-          const icaAddress = bytes32ToAddress(destinationAccount);
-          const [decodedCalls] = utils.defaultAbiCoder.decode(
-            ['tuple(bytes32 to, uint256 value, bytes data)[]'],
-            data,
-          ) as [
-            Array<{ to: string; value: { toString(): string }; data: string }>,
-          ];
-          const calls = decodedCalls.map((c) => ({
-            to: c.to,
-            value: c.value.toString(),
-            data: c.data,
-          }));
-          await prisma.commitment.upsert({
-            where: { commitment },
-            update: {},
-            create: {
-              commitment,
-              calls,
-              relayers,
-              salt,
-              ica: icaAddress,
-              originDomain,
-            },
-          });
-          logger.info(
-            { commitment, icaAddress, originDomain },
-            'Dual-wrote to Commitment table',
-          );
-        } catch (dualWriteError: any) {
-          // Solana-destination routes carry borsh data that fails ABI decode — not an error.
-          logger.debug(
-            { commitment, error: dualWriteError.message },
-            'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
-          );
-        }
+      try {
+        const icaAddress = bytes32ToAddress(destinationAccount);
+        const [decodedCalls] = utils.defaultAbiCoder.decode(
+          ['tuple(bytes32 to, uint256 value, bytes data)[]'],
+          data,
+        ) as [
+          Array<{ to: string; value: { toString(): string }; data: string }>,
+        ];
+        const calls = decodedCalls.map((c) => ({
+          to: c.to,
+          value: c.value.toString(),
+          data: c.data,
+        }));
+        await prisma.commitment.upsert({
+          where: { commitment },
+          update: {},
+          create: {
+            commitment,
+            calls,
+            relayers,
+            salt,
+            ica: icaAddress,
+            originDomain,
+          },
+        });
+        logger.info(
+          { commitment, icaAddress, originDomain },
+          'Dual-wrote to Commitment table',
+        );
+      } catch (dualWriteError: any) {
+        // Solana-destination routes carry borsh data that fails ABI decode — not an error.
+        logger.debug(
+          { commitment, error: dualWriteError.message },
+          'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
+        );
       }
     } catch (error: any) {
       logger.error(

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -535,10 +535,10 @@ export class CallCommitmentsService extends BaseService {
           'Dual-wrote to Commitment table',
         );
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       logger.error(
         {
-          error: error.message,
+          error: error instanceof Error ? error.message : String(error),
           error_reason: UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
         },
         'Database error storing calldata',
@@ -566,9 +566,12 @@ export class CallCommitmentsService extends BaseService {
     } | null;
     try {
       record = await prisma.calldata.findUnique({ where: { commitment } });
-    } catch (error: any) {
+    } catch (error: unknown) {
       logger.error(
-        { commitment, error: error.message },
+        {
+          commitment,
+          error: error instanceof Error ? error.message : String(error),
+        },
         'Database error fetching calldata',
       );
       return res.status(500).json({ error: 'Internal server error' });

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -42,7 +42,7 @@ interface MainnetDockerTags extends BaseDockerTags {
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
   relayer: '557df49-20260615-165434',
-  relayerRC: '557df49-20260615-165434',
+  relayerRC: '0650757-20260623-093746',
   relayerFastPath: '557df49-20260615-165434',
   validator: '557df49-20260615-165434',
   validatorRC: '557df49-20260615-165434',

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -4,6 +4,7 @@ import {
   AgentSealevelPriorityFeeOracleType,
   AgentSealevelTransactionSubmitter,
   AgentSealevelTransactionSubmitterType,
+  AgentSealevelUrReveal,
   ChainMap,
   ChainName,
   GasPaymentEnforcement,
@@ -525,6 +526,18 @@ const sealevelTransactionSubmitterConfigGetter = (
   };
 };
 
+const sealevelUrRevealConfigGetter = (
+  chain: ChainName,
+): AgentSealevelUrReveal => {
+  if (chain === 'solanamainnet') {
+    return {
+      ccsUrl: 'https://offchain-lookup.services.hyperlane.xyz/callCommitments',
+      programId: '2CttnaLkYbNHbaFDFnQ8PMCnzUwTGrKnskBxPM4TRWGp',
+    };
+  }
+  return undefined;
+};
+
 const contextBase = {
   namespace: environment,
   runEnv: environment,
@@ -535,6 +548,7 @@ const contextBase = {
   sealevel: {
     priorityFeeOracleConfigGetter: sealevelPriorityFeeOracleConfigGetter,
     transactionSubmitterConfigGetter: sealevelTransactionSubmitterConfigGetter,
+    urRevealConfigGetter: sealevelUrRevealConfigGetter,
   },
 } as const;
 

--- a/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/rc.json
@@ -1,7 +1,4 @@
 {
-  "zksync": {
-    "validators": []
-  },
   "ancient8": {
     "validators": ["0xaae4d879a04e3d8b956eb4ffbefd57fdbed09cae"]
   },

--- a/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
+++ b/typescript/infra/helm/offchain-lookup-server/values-mainnet.yaml
@@ -6,7 +6,7 @@ image:
   # Modify this tag to deploy a new revision.
   # Images can be found here:
   # https://github.com/orgs/hyperlane-xyz/packages/container/package/hyperlane-node-services
-  tag: d1b6f0a-20260603-124857
+  tag: 19a71a3-20260622-142404
 
 # In Google Cloud Secret Manager, all secrets need to have a certain prefix in order to be accessible by
 # the Cluster Secret Store. For testnet this prefix is "hyperlane-testnet4"

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import {
   AgentSealevelPriorityFeeOracle,
   AgentSealevelTransactionSubmitter,
+  AgentSealevelUrReveal,
   ChainName,
   RelayerConfig,
   RpcConsensusType,
@@ -118,6 +119,12 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
               );
           }
 
+          let urReveal: AgentSealevelUrReveal | undefined;
+          if (getChain(chain).protocol === ProtocolType.Sealevel) {
+            urReveal =
+              this.config.rawConfig.sealevel?.urRevealConfigGetter?.(chain);
+          }
+
           const batchConfig = this.batchConfig(chain);
 
           return {
@@ -134,6 +141,7 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
               : {}),
             priorityFeeOracle,
             transactionSubmitter,
+            urReveal,
           };
         }),
       },

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -2,6 +2,7 @@ import {
   AgentChainMetadata,
   AgentSealevelPriorityFeeOracle,
   AgentSealevelTransactionSubmitter,
+  AgentSealevelUrReveal,
   AgentSignerAwsKey,
   AgentSignerKeyType,
   ChainName,
@@ -96,6 +97,7 @@ export interface SealevelAgentConfig {
   transactionSubmitterConfigGetter?: (
     chain: ChainName,
   ) => AgentSealevelTransactionSubmitter;
+  urRevealConfigGetter?: (chain: ChainName) => AgentSealevelUrReveal;
 }
 
 // An ugly way to mark a URL as a the secret Helius URL when Helm templating

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -356,6 +356,7 @@ export {
   AgentSealevelPriorityFeeOracleType,
   AgentSealevelTransactionSubmitter,
   AgentSealevelTransactionSubmitterType,
+  AgentSealevelUrReveal,
   AgentSigner,
   AgentSignerAwsKey,
   AgentSignerHexKey,

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -2,6 +2,7 @@
  * The types defined here are the source of truth for chain metadata.
  * ANY CHANGES HERE NEED TO BE REFLECTED IN HYPERLANE-BASE CONFIG PARSING.
  */
+import { PublicKey } from '@solana/web3.js';
 import { z } from 'zod';
 
 import { ModuleType } from '@hyperlane-xyz/sdk';
@@ -190,7 +191,17 @@ const AgentSealevelChainMetadataSchema = z.object({
   urReveal: z
     .object({
       ccsUrl: z.string().url().describe('CCS endpoint for calldata lookup'),
-      programId: z.string().describe('Universal Router program ID (base58)'),
+      programId: z
+        .string()
+        .refine((val) => {
+          try {
+            new PublicKey(val);
+            return true;
+          } catch {
+            return false;
+          }
+        }, 'Must be a valid Solana public key (base58)')
+        .describe('Universal Router program ID (base58)'),
     })
     .optional()
     .describe(

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -187,6 +187,15 @@ const AgentSealevelChainMetadataSchema = z.object({
     .describe(
       'Per-message ALT overrides. Array of {matchingList, addressLookupTable} or JSON string.',
     ),
+  urReveal: z
+    .object({
+      ccsUrl: z.string().url().describe('CCS endpoint for calldata lookup'),
+      programId: z.string().describe('Universal Router program ID (base58)'),
+    })
+    .optional()
+    .describe(
+      'When set, the relayer automatically submits RouterInstruction::Reveal after confirming delivery of a UR COMMIT message.',
+    ),
 });
 
 export type AgentSealevelChainMetadata = z.infer<
@@ -198,6 +207,8 @@ export type AgentSealevelPriorityFeeOracle =
 
 export type AgentSealevelTransactionSubmitter =
   AgentSealevelChainMetadata['transactionSubmitter'];
+
+export type AgentSealevelUrReveal = AgentSealevelChainMetadata['urReveal'];
 
 export const AgentChainMetadataSchema = ChainMetadataSchemaObject.merge(
   HyperlaneDeploymentArtifactsSchema,


### PR DESCRIPTION
### Description

Adds end-to-end automated reveal submission for EVM→Solana CLMM commit-reveal metaswaps.

**Rust relayer (`hyperlane-sealevel`)**

- New `universal_router_reveal.rs` module: when a UR COMMIT message (96-byte body, recipient == UR program ID) is confirmed on Solana, a background tokio task is spawned that:
  1. Polls for the `pending_swap` PDA to appear (up to 10 min) — handles the case where another relayer delivers the commit
  2. Polls the PDA's input ATA until the warp token transfer lands (balance > 0)
  3. Fetches calldata + `revealAccounts` from CCS, overrides stale pool/vault/tick-array addresses with live Raydium CLMM pool state, and submits `RouterInstruction::Reveal`
  4. Handles native SOL output by sweeping the fee-payer's wSOL ATA and closing it
- Reveal is triggered from both `process_estimate_costs` (before simulation, so `CommitmentAlreadySet` from another relayer still fires the task) and `on_delivered` (after confirmation), deduplicated per-commitment via a `seen_reveal_commitments` `HashSet`
- `pending_message.rs`: calls `on_delivered` at the start of every `prepare()` so reveal is spawned even for messages that were already delivered before this relayer started
- Added `get_signatures_for_address_with_limit` to `SealevelRpcClient` / `SealevelFallbackRpcClient`
- `SealevelKeypair` derives `Clone`
- `ConnectionConf` gets a new optional `ur_reveal: Option<UniversalRouterRevealConfig>` (CCS URL + UR program ID); wired through `connection_parser.rs`
- `mainnet_config.json` adds the Solana UR reveal config

**TypeScript CCS (`ccip-server`)**

- New `Calldata` Prisma model with columns: `commitment`, `originDomain`, `data` (hex calldata), `salt`, `relayers`, `destinationAccount`, `revealAccounts` (JSON array of Solana account metas)
- New `/calldata` POST endpoint (`handleCalldataPost`) that stores the model; dual-writes to the existing `Commitment` table for EVM destinations (ABI-decode falls back silently for Borsh/Solana payloads)
- New `/calldata/:commitment` GET endpoint (`handleCalldataGet`) that returns `{ data, salt, revealAccounts }`
- Zod schemas validate all inputs; `revealAccounts` is an optional array of `{ pubkey, isWritable, isSigner }`

### Drive-by changes

- Removed stale RC validator entries from `aw-validators/rc.json`
- Bumped offchain-lookup-server Helm values

### Related issues

<!-- - Fixes #[issue number here] -->

### Backward compatibility

Yes — the CCS dual-write is additive; the existing CCIP-Read endpoint is unchanged. The `ur_reveal` relayer config is optional and defaults to no-op.

### Testing

Manual — end-to-end EVM→Solana CLMM swap successfully relayed and revealed on mainnet.