### PR TITLE
chore: blacklist USDC/eclipsemainnet message to Circle-blacklisted recipient

### DIFF
--- a/typescript/infra/config/environments/mainnet3/customBlacklist.ts
+++ b/typescript/infra/config/environments/mainnet3/customBlacklist.ts
@@ -239,6 +239,8 @@ export const blacklistedMessageIds = [
   '0x4190cf8c0419cd966fc96fcb9050be3d941cb06974667bd768f22e90abcec6a6',
   // USDC/paradex user transfer to USDC contract address (blacklisted by Circle) [2026-04-27]
   '0xeece23565b9bf5a344516b92a8bf857644f5ef29e49fd0b525c8f752452cf113',
+  // USDC/eclipsemainnet polygon->ethereum transfer to ethereum USDC contract itself (Circle-blacklisted recipient) [2026-06-22]
+  '0x15f8ed49d2c10c8bf1f255b91a0f38540dd6bd35de490c24befda7c554c7e872',
 
   // krown -> ethereum
   '0x4d745f718590f89ce261f2fea8dbbc251bb612f424d9bb1c06a89abaf75b680f',


### PR DESCRIPTION
## Summary
- Adds message `0x15f8ed49d2c10c8bf1f255b91a0f38540dd6bd35de490c24befda7c554c7e872` to the mainnet3 relayer denylist (`customBlacklist.ts`).
- This is a USDC/eclipsemainnet **polygon → ethereum** warp transfer (nonce 431553, 15 USDC) whose **recipient is the ethereum USDC token contract itself** (`0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`), which Circle blacklists as a recipient.
- `Mailbox.process()` → `handle()` → `USDC.transfer()` reverts permanently with `Blacklistable: account is blacklisted`. The relayer's `eth_estimateGas` dry-run therefore fails forever (`Retry(ErrorEstimatingGas)`), the message sits in the submit queue, and it trips the **Rebalancing Warp Route Relayer Queue Length > 0 for 60m** alert (PD `Q190Y5GPIP2S57`).

## Context
- Same failure mode and same fix as the existing entries:
  - `// USDC/eclipsemainnet warp transfer to USDC contract itself [2026-01-30]`
  - `// USDC/paradex user transfer to USDC contract address (blacklisted by Circle) [2026-04-27]`
- Origin tx was a direct `transferRemote` call to the polygon warp router by an EOA, with the destination-chain USDC token contract pasted as the recipient — an unrecoverable user/UI error, not a protocol fault.

## Test plan
- [ ] CI typecheck/lint on `typescript/infra`.
- [ ] Confirm relayer picks up the denylist (live `HYP_BLACKLIST` patched separately to avoid a full deploy) and the message is skipped, draining the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)