### PR TITLE
fix: flakiness in svm pk detection which caused tests to randomly fail

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -117,7 +117,9 @@ tags = ["private key", "svm"]
 [[rules]]
 id = "svm-base58-private-key"
 description = "Solana wallet private key"
-regex = '''\b[1-9A-HJ-NP-Za-km-z]{87,88}\b'''
+# A 64-byte Solana keypair base58-encodes to 86-88 chars; leading zero seed
+# bytes shorten it (85 at 8 such bytes). 85-88 covers any RNG-generated key.
+regex = '''\b[1-9A-HJ-NP-Za-km-z]{85,88}\b'''
 tags = ["private key", "svm"]
 
 # Not testing evm, starknet or cosmos private key as

--- a/typescript/infra/test/gitleaks.test.ts
+++ b/typescript/infra/test/gitleaks.test.ts
@@ -606,7 +606,8 @@ describe('GitLeaks CLI Integration Tests', function () {
       failureTestCases: [
         {
           name: 'should not detect Base58 key too short',
-          content: `const invalidKey = "${generateSvmPrivateKey().slice(0, -2)}";`,
+          // 84 chars: one below the rule's 85-char lower bound.
+          content: `const invalidKey = "${generateSvmPrivateKey().slice(0, 84)}";`,
         },
         {
           name: 'should not detect Base58 key too long',


### PR DESCRIPTION
### Description

Fixes a flaky test when checking for svm pks in the project

### Drive-by changes

### Related issues

### Backward compatibility

- yes

### Testing

- Manual
