### PR TITLE
feat: per-destination-token fee granularity for CROSS/moonpay warp route

### DIFF
--- a/.changeset/moonpay-per-destination-fees.md
+++ b/.changeset/moonpay-per-destination-fees.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/infra': patch
+---
+
+The CROSS/moonpay USDC and USDT warp route fee configs were given per-destination-token granularity by emitting a CrossCollateralRoutingFee leaf for each enrolled destination router (alongside the existing default-router fallback), allowing distinct fees per destination token.

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayWarpConfig.ts
@@ -26,6 +26,7 @@ import { getDomainId, getRegistry } from '../../../../registry.js';
 import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
 import { WarpRouteIds } from '../warpIds.js';
 import {
+  getCrossCollateralTargetRoutersByChain,
   getRebalancingBridgesConfigFor,
   getUSDCRebalancingBridgesConfigFor,
   mergeAllowedBridges,
@@ -279,25 +280,41 @@ function buildHook(local: (typeof ROUTE_CHAINS)[number], owner: string) {
   return buildFastRouteHook(local, owner);
 }
 
+// Target routers (destination tokens) priced per destination, keyed by chain.
+// Union of both Moonpay routes so USDC/USDT/ctUSD/XO can each be priced distinctly.
+const TARGET_ROUTERS_BY_CHAIN = getCrossCollateralTargetRoutersByChain([
+  WarpRouteIds.USDCCitreaMoonpay,
+  WarpRouteIds.USDTCitreaMoonpay,
+]);
+
 function buildCrossCollateralRoutingFee(
   owner: string,
   destinations: readonly ChainName[],
 ): TokenFeeConfigInput {
+  const offchainFee = (): TokenFeeConfigInput => ({
+    type: TokenFeeType.OffchainQuotedLinearFee,
+    owner,
+    bps: 3,
+    quoteSigners: QUOTE_SIGNERS,
+  });
+
   return {
     type: TokenFeeType.CrossCollateralRoutingFee,
     owner,
     feeContracts: Object.fromEntries(
-      destinations.map((dest) => [
-        dest,
-        {
-          [DEFAULT_ROUTER_KEY]: {
-            type: TokenFeeType.OffchainQuotedLinearFee,
-            owner,
-            bps: 3,
-            quoteSigners: QUOTE_SIGNERS,
+      destinations.map((dest) => {
+        const targetRouters = TARGET_ROUTERS_BY_CHAIN[dest] ?? [];
+        return [
+          dest,
+          {
+            // Per-destination-token fee slots, plus a default fallback.
+            ...Object.fromEntries(
+              targetRouters.map((routerKey) => [routerKey, offchainFee()]),
+            ),
+            [DEFAULT_ROUTER_KEY]: offchainFee(),
           },
-        },
-      ]),
+        ];
+      }),
     ),
   };
 }

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayWarpConfig.ts
@@ -24,7 +24,10 @@ import {
 } from '../../../../../src/config/warp.js';
 import { getDomainId, getRegistry } from '../../../../registry.js';
 import { WarpRouteIds } from '../warpIds.js';
-import { getRebalancingBridgesConfigFor } from './utils.js';
+import {
+  getCrossCollateralTargetRoutersByChain,
+  getRebalancingBridgesConfigFor,
+} from './utils.js';
 
 const FAST_PATH_RELAYER = relayerAddresses.mainnet3.fastpath;
 // Threshold in message units (6-decimal normalized via scale); BSC's 18-dec token is
@@ -98,25 +101,41 @@ function getUsdcCrossCollateralRouters(): Record<string, string[]> {
   );
 }
 
+// Target routers (destination tokens) priced per destination, keyed by chain.
+// Union of both Moonpay routes so USDC/USDT/ctUSD/XO can each be priced distinctly.
+const TARGET_ROUTERS_BY_CHAIN = getCrossCollateralTargetRoutersByChain([
+  WarpRouteIds.USDCCitreaMoonpay,
+  WarpRouteIds.USDTCitreaMoonpay,
+]);
+
 function buildCrossCollateralRoutingFee(
   owner: string,
   destinations: readonly ChainName[],
 ): TokenFeeConfigInput {
+  const offchainFee = (): TokenFeeConfigInput => ({
+    type: TokenFeeType.OffchainQuotedLinearFee,
+    owner,
+    bps: 3,
+    quoteSigners: QUOTE_SIGNERS,
+  });
+
   return {
     type: TokenFeeType.CrossCollateralRoutingFee,
     owner,
     feeContracts: Object.fromEntries(
-      destinations.map((dest) => [
-        dest,
-        {
-          [DEFAULT_ROUTER_KEY]: {
-            type: TokenFeeType.OffchainQuotedLinearFee,
-            owner,
-            bps: 3,
-            quoteSigners: QUOTE_SIGNERS,
+      destinations.map((dest) => {
+        const targetRouters = TARGET_ROUTERS_BY_CHAIN[dest] ?? [];
+        return [
+          dest,
+          {
+            // Per-destination-token fee slots, plus a default fallback.
+            ...Object.fromEntries(
+              targetRouters.map((routerKey) => [routerKey, offchainFee()]),
+            ),
+            [DEFAULT_ROUTER_KEY]: offchainFee(),
           },
-        },
-      ]),
+        ];
+      }),
     ),
   };
 }

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -10,6 +10,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
+  addressToBytes32,
   arrayToObject,
   assert,
   intersection,
@@ -185,6 +186,40 @@ export function getRebalancingBridgesConfigFor(
       };
     },
   );
+}
+
+/**
+ * Returns the set of cross-collateral target routers (as bytes32), keyed by chain,
+ * unioned across the given warp routes and deduplicated.
+ *
+ * Used to key per-destination-token fee contracts in a CrossCollateralRoutingFee:
+ * the inner fee map is keyed by the destination router's bytes32 (the target token),
+ * matching the on-chain lookup `feeContracts[destination][targetRouter]`.
+ */
+export function getCrossCollateralTargetRoutersByChain(
+  warpRouteIds: readonly WarpRouteIds[],
+): ChainMap<string[]> {
+  const registry = getRegistry();
+  const routersByChain: ChainMap<string[]> = {};
+
+  for (const warpRouteId of warpRouteIds) {
+    const route = registry.getWarpRoute(warpRouteId);
+    assert(route, `Warp route ${warpRouteId} not found`);
+
+    for (const { chainName, addressOrDenom } of route.tokens) {
+      assert(
+        addressOrDenom,
+        `Missing router address for ${warpRouteId} on ${chainName}`,
+      );
+      const routerKey = addressToBytes32(addressOrDenom);
+      const existing = (routersByChain[chainName] ??= []);
+      if (!existing.includes(routerKey)) {
+        existing.push(routerKey);
+      }
+    }
+  }
+
+  return routersByChain;
 }
 
 export const getRebalancingUSDTConfigForChain = (


### PR DESCRIPTION
## Summary

Moonpay's CROSS/moonpay stableswap can currently only price fees per (source token, destination chain) — e.g. ctUSD must charge one fee for transfers to *both* Eth USDC and Eth USDT, and USDT→X cannot be priced per destination token. The on-chain `CrossCollateralRoutingFee` already supports per-target-router pricing (`feeContracts[destination][targetRouter]`, with `DEFAULT_ROUTER` as fallback) and `CrossCollateralRouter.transferRemoteTo` already plumbs the target router into the fee lookup. The gap was purely in the infra config getters, which only populated the `DEFAULT_ROUTER` slot.

This wires per-destination-token fee slots into the config for both Moonpay legs:

- New shared helper `getCrossCollateralTargetRoutersByChain` in `configGetters/utils.ts` unions the token (router) addresses of the USDC/moonpay and USDT/moonpay registry routes, keyed by chain and deduped, returning each as bytes32 (the `targetRouter` key).
- `buildCrossCollateralRoutingFee` in both `getUSDCCitreaMoonpayWarpConfig.ts` and `getUSDTCitreaMoonpayWarpConfig.ts` now emits one `OffchainQuotedLinearFee` per destination target router (USDC / USDT / ctUSD / XO) in addition to the `DEFAULT_ROUTER_KEY` fallback.

Each sub-fee is a distinct deployment (`EvmTokenFeeDeployer` has `cachingEnabled = false`), so the per-router contracts get independent standing quotes. `bps: 3` is kept as the fallback for every slot; Moonpay can attach distinct signed standing quotes per (destination, target token) without further config changes.

## Notes / tradeoffs

- This multiplies the number of deployed fee contracts: each destination now gets ~`(#target routers at that chain) + 1` `OffchainQuotedLinearFee` deployments (e.g. EVM dests: USDC + USDT + default = 3) instead of 1. That is inherent to the granularity feature.
- Owner is unchanged: the WarpFees governance owner (ethereum `warpFeesSafes` + ICAs on other chains via `warpFeesIcas`), separate from the router owners.
- Behavior is unchanged until distinct standing quotes are attached — all slots default to bps 3.

## Test plan

- [x] `tsc --noEmit` passes for `typescript/infra`
- [x] oxlint + oxfmt pass (pre-commit)
- [ ] `warp check` / dry-run diff against the deployed CROSS/moonpay routes to review the generated governance txs (new fee deployments + `setCrossCollateralRouterFeeContracts`)
- [ ] Confirm with Moonpay the intended per-(destination, target token) quotes before applying

cc @Troy for a sanity check on the deploy/governance surface.