### PR TITLE
chore: raise kyve relayer balance override to 500

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalanceOverrides.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalanceOverrides.json
@@ -13,7 +13,7 @@
   "flare": 1280,
   "forma": 5,
   "incentiv": 3000,
-  "kyve": 5,
+  "kyve": 500,
   "litchain": 0.05,
   "miraclechain": 0.05,
   "mocachain": 727,

--- a/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
@@ -53,7 +53,7 @@
   "katana": 0.0108,
   "kiichain": 25,
   "krown": 16600,
-  "kyve": 5,
+  "kyve": 500,
   "lazai": 7.12,
   "linea": 0.612,
   "lisk": 0.0832,

--- a/typescript/infra/config/environments/mainnet3/balances/highUrgencyRelayerBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/highUrgencyRelayerBalance.json
@@ -53,7 +53,7 @@
   "katana": 0.0027,
   "kiichain": 6.26,
   "krown": 4160,
-  "kyve": 1.25,
+  "kyve": 125,
   "lazai": 1.78,
   "linea": 0.153,
   "lisk": 0.0208,

--- a/typescript/infra/config/environments/mainnet3/balances/lowUrgencyEngKeyFunderBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/lowUrgencyEngKeyFunderBalance.json
@@ -53,7 +53,7 @@
   "katana": 0.0081,
   "kiichain": 18.8,
   "krown": 12500,
-  "kyve": 3.75,
+  "kyve": 375,
   "lazai": 5.34,
   "linea": 0.459,
   "lisk": 0.0624,

--- a/typescript/infra/config/environments/mainnet3/balances/lowUrgencyKeyFunderBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/lowUrgencyKeyFunderBalance.json
@@ -53,7 +53,7 @@
   "katana": 0.0162,
   "kiichain": 37.6,
   "krown": 25000,
-  "kyve": 7.5,
+  "kyve": 750,
   "lazai": 10.7,
   "linea": 0.918,
   "lisk": 0.2,


### PR DESCRIPTION
## Summary

The kyve mainnet3 relayer wallet (`kyve1txlawhefw0qrnk7t38w4chf4adcpkja0ela46f`) was paged for critically low balance (PD `Q029XJVXT9DH0O`) after a single `MsgProcessMessage` delivery drained it to zero.

**Root cause:** Every kyve delivery costs a flat **40.95 KYVE** (650k `gas_limit` × 63 ukyve/gas — the gas price is correct/intended, confirmed across 100 recent deliveries). But `desiredRelayerBalanceOverrides[kyve]` was **5 KYVE**, i.e. 8× *below* the cost of a single transaction. The key-funder target sat far under one tx cost, so it could never keep the wallet able to afford even one delivery. The 40.95 KYVE the wallet held was stale legacy funding that one delivery zeroed.

**Fix:** Raise the single source of truth `desiredRelayerBalanceOverrides[kyve]` from 5 → **500**, and regenerate all four tiers via `update-balance-thresholds.ts --skipReview`. The override is treated as `desired = burn × 8`, so `burn = 500/8 = 62.5 KYVE`:

| Tier | Multiple | KYVE | ≈ deliveries |
|---|---|---|---|
| high-urgency (page) | burn×2 | 125 | ~3 txs |
| low-urgency-eng | burn×6 | 375 | ~9 txs |
| desired (funder target) | burn×8 | 500 | ~12 txs |
| low-urgency-key-funder | burn×12 | 750 | ~18 txs |

KYVE ≈ $0.00133, so the 500-KYVE target is ≈ $0.66 — negligible USD exposure for ~12 deliveries of runway. The page now fires with ~3 deliveries still affordable instead of after the wallet is already drained.

## Test plan

- [x] `desiredRelayerBalanceOverrides[kyve]` set to 500
- [x] `update-balance-thresholds.ts --skipReview` regenerated all 4 balance files (kyve: high-urgency 125, low-eng 375, desired 500, low-key-funder 750)
- [x] Diff confirmed to touch only kyve lines across the 5 files
- [ ] Human review + merge; key-funder picks up new targets on next run