### PR TITLE
fix(sealevel/composite-ism): disallow Pausable in domain PDAs (HLSVM-2026Q2-011)

### DIFF
--- a/rust/sealevel/programs/ism/composite-ism/README.md
+++ b/rust/sealevel/programs/ism/composite-ism/README.md
@@ -127,7 +127,19 @@ independent of the outer composite ISM's account space.
   `SetDomainIsm` rejects any ISM subtree that contains either variant
   (`RoutingInDomainIsm` / `FallbackRoutingInDomainIsm` error). Domain PDAs may
   contain `MultisigMessageId`, `Aggregation`, `AmountRouting`, `TrustedRelayer`,
-  `RateLimited`, `Pausable`, and `Test` nodes only.
+  `RateLimited`, and `Test` nodes only.
+
+- **`Pausable` is not allowed inside a domain PDA.**
+  `Pause` and `Unpause` traverse only the root storage PDA — all accounts a
+  Solana transaction touches must be declared upfront, so propagating pause
+  state to an unbounded number of domain PDAs would require enumerating every
+  domain and passing their accounts in one transaction. Solana's 1232-byte
+  packet limit (32 bytes per pubkey) makes this infeasible for deployments with
+  many domains, and splitting it across multiple transactions would mean the
+  pause is not atomic. `Pausable` is therefore restricted to the root tree where
+  it can be flipped in a single account, single transaction operation.
+  To freeze a specific domain route, call `SetDomainIsm` with
+  `Test { accept: false }` for that domain.
 
 - **`RateLimited` requires its containing PDA to be writable.** When the ISM
   tree (or a domain PDA) contains a `RateLimited` node, `VerifyAccountMetas`

--- a/rust/sealevel/programs/ism/composite-ism/README.md
+++ b/rust/sealevel/programs/ism/composite-ism/README.md
@@ -141,6 +141,12 @@ independent of the outer composite ISM's account space.
   To freeze a specific domain route, call `SetDomainIsm` with
   `Test { accept: false }` for that domain.
 
+  Additionally, `set_paused` does **not** affect the external `fallback_ism`
+  program referenced by a `FallbackRouting` node. The fallback ISM is an
+  independent program with its own state; pausing this composite ISM does not
+  pause it. To pause the fallback path, call the pause instruction on the
+  fallback ISM program directly.
+
 - **`RateLimited` requires its containing PDA to be writable.** When the ISM
   tree (or a domain PDA) contains a `RateLimited` node, `VerifyAccountMetas`
   marks the relevant PDA writable. Callers must pass that account as writable in

--- a/rust/sealevel/programs/ism/composite-ism/src/error.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/error.rs
@@ -58,6 +58,8 @@ pub enum Error {
     InvalidProcessAuthority = 26,
     #[error("Process authority must be a signer (Verify must be called via Mailbox.process)")]
     ProcessAuthorityNotSigner = 27,
+    #[error("Pausable ISM is not allowed inside a domain PDA (pause propagation does not reach domain PDAs)")]
+    PausableInDomainIsm = 28,
 }
 
 impl From<Error> for ProgramError {

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -604,20 +604,6 @@ fn validate_domain_ism(node: &IsmNode) -> ProgramResult {
             Ok(())
         }
         IsmNode::Test { .. } => Ok(()),
-        // Pausable is intentionally disallowed in domain PDAs.
-        //
-        // set_paused/flip_pausable only traverses the root storage tree (a single
-        // PDA account). Propagating pause state into domain PDAs would require the
-        // caller to enumerate every domain PDA and pass them all as writable
-        // accounts in the Pause/Unpause transaction. Solana's 1232-byte transaction
-        // size limit makes this infeasible for deployments with many domains (each
-        // pubkey is 32 bytes), and even if it fit, multiple transactions would be
-        // required — meaning the pause would not be atomic across all domains.
-        //
-        // In practice Pausable is used at the root or inside Aggregation at the
-        // root level, not inside per-domain routing ISMs, so this is not a
-        // functional restriction. To freeze a specific domain route an owner can
-        // call set_domain_ism with Test { accept: false } instead.
         IsmNode::Pausable { .. } => Err(Error::PausableInDomainIsm.into()),
     }
 }
@@ -673,11 +659,8 @@ fn flip_pausable(node: &mut IsmNode, paused: bool) {
 
 /// Sets every `Pausable` node in the ISM tree to `paused`. Owner-gated.
 ///
-/// Only `Pausable` nodes stored inline in the root storage PDA are updated.
-/// `Pausable` nodes are intentionally disallowed inside domain PDAs (see
-/// `validate_domain_ism`) because propagating pause state across an unbounded
-/// number of separate domain PDA accounts cannot be done atomically within
-/// Solana's transaction size and account-list constraints.
+/// Only nodes in the root storage PDA are updated; `Pausable` is disallowed
+/// in domain PDAs — see README § Limitations.
 ///
 /// Accounts:
 /// 0. `[signer]`   The owner.

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -603,7 +603,22 @@ fn validate_domain_ism(node: &IsmNode) -> ProgramResult {
             }
             Ok(())
         }
-        IsmNode::Test { .. } | IsmNode::Pausable { .. } => Ok(()),
+        IsmNode::Test { .. } => Ok(()),
+        // Pausable is intentionally disallowed in domain PDAs.
+        //
+        // set_paused/flip_pausable only traverses the root storage tree (a single
+        // PDA account). Propagating pause state into domain PDAs would require the
+        // caller to enumerate every domain PDA and pass them all as writable
+        // accounts in the Pause/Unpause transaction. Solana's 1232-byte transaction
+        // size limit makes this infeasible for deployments with many domains (each
+        // pubkey is 32 bytes), and even if it fit, multiple transactions would be
+        // required — meaning the pause would not be atomic across all domains.
+        //
+        // In practice Pausable is used at the root or inside Aggregation at the
+        // root level, not inside per-domain routing ISMs, so this is not a
+        // functional restriction. To freeze a specific domain route an owner can
+        // call set_domain_ism with Test { accept: false } instead.
+        IsmNode::Pausable { .. } => Err(Error::PausableInDomainIsm.into()),
     }
 }
 
@@ -657,6 +672,12 @@ fn flip_pausable(node: &mut IsmNode, paused: bool) {
 }
 
 /// Sets every `Pausable` node in the ISM tree to `paused`. Owner-gated.
+///
+/// Only `Pausable` nodes stored inline in the root storage PDA are updated.
+/// `Pausable` nodes are intentionally disallowed inside domain PDAs (see
+/// `validate_domain_ism`) because propagating pause state across an unbounded
+/// number of separate domain PDA accounts cannot be done atomically within
+/// Solana's transaction size and account-list constraints.
 ///
 /// Accounts:
 /// 0. `[signer]`   The owner.
@@ -987,6 +1008,27 @@ mod test {
             ],
         };
         assert!(validate_config(&Pubkey::new_unique(), &node).is_ok());
+    }
+
+    #[test]
+    fn test_validate_domain_ism_rejects_pausable() {
+        let node = IsmNode::Pausable { paused: false };
+        assert_eq!(
+            validate_domain_ism(&node).unwrap_err(),
+            Error::PausableInDomainIsm.into()
+        );
+    }
+
+    #[test]
+    fn test_validate_domain_ism_rejects_pausable_nested_in_aggregation() {
+        let node = IsmNode::Aggregation {
+            threshold: 1,
+            sub_isms: vec![IsmNode::Pausable { paused: true }],
+        };
+        assert_eq!(
+            validate_domain_ism(&node).unwrap_err(),
+            Error::PausableInDomainIsm.into()
+        );
     }
 
     #[test]

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_big_isms.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_big_isms.rs
@@ -10,7 +10,7 @@
 //! (run from `rust/sealevel/`)
 //!
 //! TESTS:
-//! - 200 domains, each Routing → Aggregation(2-of-2)[Pausable, MultisigMessageId(7v,3)]
+//! - 200 domains, each Routing → Aggregation(2-of-2)[Test, MultisigMessageId(7v,3)]
 //! - 16 levels of nested single-child Aggregation (call-depth + stack)
 //! - UpdateConfig realloc: grow storage PDA from Test to Aggregation(50-of-50)
 //! - Wide Aggregation: 50-of-50 Test sub-ISMs (heap + compute scaling with fan-out)
@@ -131,7 +131,7 @@ fn scale_message() -> hyperlane_core::HyperlaneMessage {
     }
 }
 
-/// Builds aggregation metadata for [Pausable (empty), MultisigMessageId (3 sigs)].
+/// Builds aggregation metadata for [Test (empty), MultisigMessageId (3 sigs)].
 fn build_aggregation_metadata(message: &hyperlane_core::HyperlaneMessage) -> Vec<u8> {
     let checkpoint = CheckpointWithMessageId {
         checkpoint: Checkpoint {
@@ -160,7 +160,7 @@ fn build_aggregation_metadata(message: &hyperlane_core::HyperlaneMessage) -> Vec
     }
     .to_vec();
 
-    // sub-ISM 0 = Pausable (empty metadata), sub-ISM 1 = MultisigMessageId
+    // sub-ISM 0 = Test (empty metadata), sub-ISM 1 = MultisigMessageId
     encode_aggregation_metadata(&[Some(&[]), Some(&multisig_meta)])
 }
 
@@ -195,12 +195,12 @@ fn multisig_meta_for_scale_message() -> Vec<u8> {
     .to_vec()
 }
 
-/// The per-domain ISM node: 2-of-2 Aggregation[Pausable, MultisigMessageId(7v, 3-of-7)].
+/// The per-domain ISM node: 2-of-2 Aggregation[Test, MultisigMessageId(7v, 3-of-7)].
 fn domain_ism() -> IsmNode {
     IsmNode::Aggregation {
         threshold: 2,
         sub_isms: vec![
-            IsmNode::Pausable { paused: false },
+            IsmNode::Test { accept: true },
             IsmNode::MultisigMessageId {
                 validators: seven_validators(),
                 threshold: 3,
@@ -210,7 +210,7 @@ fn domain_ism() -> IsmNode {
 }
 
 // ===========================================================================
-// Test 1: 200 domains — Routing → Aggregation(2-of-2)[Pausable, Multisig(7v,3)]
+// Test 1: 200 domains — Routing → Aggregation(2-of-2)[Test, Multisig(7v,3)]
 // ===========================================================================
 //
 // Configures 200 domain PDAs under a single Routing root, then verifies a
@@ -223,7 +223,7 @@ fn domain_ism() -> IsmNode {
 //   - Compute budget (3 secp256k1 recoveries + routing/aggregation overhead)
 
 #[tokio::test]
-async fn test_scale_200_domains_aggregation_pausable_multisig() {
+async fn test_scale_200_domains_aggregation_multisig() {
     let (mut banks_client, payer, _) = bpf_program_test().start().await;
 
     // ── 1. Initialize with a bare Routing root ────────────────────────────
@@ -234,7 +234,7 @@ async fn test_scale_200_domains_aggregation_pausable_multisig() {
 
     // ── 2. Register 200 domain PDAs ───────────────────────────────────────
     // domains 1..=199 + VERIFY_DOMAIN (1234) = 200 total.
-    // Each gets: Aggregation(2-of-2)[Pausable, MultisigMessageId(7v, 3-of-7)].
+    // Each gets: Aggregation(2-of-2)[Test, MultisigMessageId(7v, 3-of-7)].
     let domains: Vec<u32> = (1u32..=199).chain(std::iter::once(VERIFY_DOMAIN)).collect();
     assert_eq!(domains.len(), TOTAL_DOMAINS);
 

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
@@ -25,6 +25,7 @@ use hyperlane_sealevel_composite_ism::{
 use hyperlane_sealevel_interchain_security_module_interface::{
     InterchainSecurityModuleInstruction, VerifyInstruction,
 };
+use hyperlane_test_utils::assert_transaction_error;
 use multisig_ism::MultisigIsmMessageIdMetadata;
 use solana_program::instruction::AccountMeta;
 use solana_sdk::{
@@ -533,33 +534,20 @@ async fn test_pausable_in_domain_pda_unpaused_accepts() {
     initialize(&mut banks_client, &payer, recent_blockhash, routing_root())
         .await
         .unwrap();
-    set_domain_ism(
+    let result = set_domain_ism(
         &mut banks_client,
         &payer,
         recent_blockhash,
         ORIGIN,
         IsmNode::Pausable { paused: false },
     )
-    .await
-    .unwrap();
-
-    let verify_ixn = verify_ixn_empty(ORIGIN);
-    let account_metas = get_all_verify_account_metas(
-        &mut banks_client,
-        &payer,
-        recent_blockhash,
-        verify_ixn.clone(),
-    )
     .await;
-    assert_simulation_ok(
-        &simulate_verify(
-            &mut banks_client,
-            &payer,
-            recent_blockhash,
-            verify_ixn,
-            account_metas,
-        )
-        .await,
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(Error::PausableInDomainIsm as u32),
+        ),
     );
 }
 
@@ -570,36 +558,19 @@ async fn test_pausable_in_domain_pda_paused_rejects() {
     initialize(&mut banks_client, &payer, recent_blockhash, routing_root())
         .await
         .unwrap();
-    set_domain_ism(
+    let result = set_domain_ism(
         &mut banks_client,
         &payer,
         recent_blockhash,
         ORIGIN,
         IsmNode::Pausable { paused: true },
     )
-    .await
-    .unwrap();
-
-    let verify_ixn = verify_ixn_empty(ORIGIN);
-    let account_metas = get_all_verify_account_metas(
-        &mut banks_client,
-        &payer,
-        recent_blockhash,
-        verify_ixn.clone(),
-    )
     .await;
-    assert_simulation_error(
-        &simulate_verify(
-            &mut banks_client,
-            &payer,
-            recent_blockhash,
-            verify_ixn,
-            account_metas,
-        )
-        .await,
+    assert_transaction_error(
+        result,
         TransactionError::InstructionError(
             0,
-            InstructionError::Custom(Error::VerifyRejected as u32),
+            InstructionError::Custom(Error::PausableInDomainIsm as u32),
         ),
     );
 }


### PR DESCRIPTION
## Summary

Fixes incomplete pause propagation in the Composite ISM reported in chainlight-io/2026-q2-hyperlane-svm-issues#14.

- `Pausable` nodes stored in domain PDAs were never updated by `Pause`/`Unpause` — `flip_pausable` only traverses the root storage tree and treats `Routing`/`FallbackRouting` as no-ops
- Rather than extending `Pause`/`Unpause` to accept domain PDA accounts (Option 2 from the audit recommendation), `Pausable` is now rejected by `validate_domain_ism` (Option 1)

**Why Option 1 (restrict to root tree):**
Propagating pause state into domain PDAs would require the caller to enumerate every domain PDA and pass them all as writable accounts upfront. Solana's 1232-byte transaction size limit makes this infeasible for deployments with many domains (each pubkey is 32 bytes), and even if it fit in one tx, larger deployments would need multiple transactions — meaning the pause would not be atomic across all domains.

In practice `Pausable` is used at the root or inside root-level `Aggregation` nodes, not inside per-domain routing ISMs. Owners who need to freeze a specific domain route can call `set_domain_ism` with `Test { accept: false }`.

## Changes

- `error.rs`: Add `PausableInDomainIsm = 28` error variant
- `processor.rs`: `validate_domain_ism` now returns `Err(PausableInDomainIsm)` for `Pausable` nodes; added doc comments on `set_paused` and the rejection arm explaining the constraint
- `processor.rs`: Two new unit tests — `test_validate_domain_ism_rejects_pausable` and `test_validate_domain_ism_rejects_pausable_nested_in_aggregation`
- `functional_big_isms.rs`: Updated scale test that previously used `Pausable` inside domain ISMs — replaced with `Test { accept: true }` (same empty metadata, same scale coverage)

## Test plan

- [x] `cargo test --lib` in `rust/sealevel/programs/ism/composite-ism` — 78 unit tests pass
- [x] `cargo clippy` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)