### PR TITLE
fix(sealevel): bind mailbox process authority to ISM program ID (HLSVM-2026Q2-002)

### DIFF
--- a/rust/sealevel/programs/ism/composite-ism/README.md
+++ b/rust/sealevel/programs/ism/composite-ism/README.md
@@ -136,6 +136,14 @@ independent of the outer composite ISM's account space.
   configured address is checked on every `Verify` call — messages to any other
   recipient are rejected with `RecipientMismatch`.
 
+- **`RateLimited` must live in the root ISM tree, not inside a fallback ISM.**
+  Capacity mutation is gated on the process authority PDA derived per ISM program
+  (`derive_process_authority(mailbox, program_id)`). The mailbox signs only the
+  authority of the ISM it invokes directly (the root composite ISM), never a
+  nested fallback ISM reached by CPI, so a `RateLimited` node inside a fallback
+  ISM demands a signer that can never be produced and its messages are
+  undeliverable.
+
 - **`RateLimited` requires its containing PDA to be writable.** When the ISM
   tree (or a domain PDA) contains a `RateLimited` node, `VerifyAccountMetas`
   marks the relevant PDA writable. Callers must pass that account as writable in

--- a/rust/sealevel/programs/ism/composite-ism/README.md
+++ b/rust/sealevel/programs/ism/composite-ism/README.md
@@ -129,6 +129,13 @@ independent of the outer composite ISM's account space.
   contain `MultisigMessageId`, `Aggregation`, `AmountRouting`, `TrustedRelayer`,
   `RateLimited`, `Pausable`, and `Test` nodes only.
 
+- **`RateLimited` requires a specific warp-route recipient.** The node parses a
+  token amount from a fixed offset in the TokenMessage body, so it only makes
+  sense when bound to a known warp-route contract. Config validation rejects
+  `recipient: None` and `recipient: H256::zero()` (`InvalidConfig` error). The
+  configured address is checked on every `Verify` call — messages to any other
+  recipient are rejected with `RecipientMismatch`.
+
 - **`RateLimited` requires its containing PDA to be writable.** When the ISM
   tree (or a domain PDA) contains a `RateLimited` node, `VerifyAccountMetas`
   marks the relevant PDA writable. Callers must pass that account as writable in

--- a/rust/sealevel/programs/ism/composite-ism/src/account_metas.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/account_metas.rs
@@ -318,7 +318,7 @@ pub fn required_accounts_for_node(
         // The process authority PDA (derived from the mailbox program ID) must be
         // passed as a signer so that only `Mailbox.process` can drain the bucket.
         IsmNode::RateLimited { mailbox, .. } => {
-            let (process_authority, _) = derive_process_authority(mailbox);
+            let (process_authority, _) = derive_process_authority(mailbox, program_id);
             Ok(vec![
                 AccountMeta::new_readonly(process_authority, true).into()
             ])
@@ -495,7 +495,7 @@ mod test {
             last_updated: 0,
             mailbox,
         };
-        let (expected_pda, _) = derive_process_authority(&mailbox);
+        let (expected_pda, _) = derive_process_authority(&mailbox, &program_id);
         let msg = dummy_message(ORIGIN);
         let accounts =
             required_accounts_for_node(&node, &[], &msg, &program_id, &no_extra()).unwrap();
@@ -662,7 +662,7 @@ mod test {
             last_updated: 0,
             mailbox,
         };
-        let (expected_process_authority, _) = derive_process_authority(&mailbox);
+        let (expected_process_authority, _) = derive_process_authority(&mailbox, &program_id);
         let msg = dummy_message(ORIGIN);
         let accounts =
             all_verify_account_metas(&vam_pda, &node, &[], &msg, &program_id, &[]).unwrap();

--- a/rust/sealevel/programs/ism/composite-ism/src/accounts.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/accounts.rs
@@ -179,14 +179,13 @@ pub fn derive_domain_pda(program_id: &Pubkey, domain: u32) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[DOMAIN_ISM_SEED, &domain_bytes], program_id)
 }
 
-/// Derives the process authority PDA for a given mailbox program ID.
-///
-/// The mailbox signs with this PDA via `invoke_signed` when it calls
-/// `Verify` on behalf of a message delivery.  By requiring this account to be
-/// a signer, the `RateLimited` node ensures only the mailbox can drain the
-/// rate-limit bucket.
-pub fn derive_process_authority(mailbox: &Pubkey) -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[PROCESS_AUTHORITY_SEED], mailbox)
+/// Derives the per-ISM process authority PDA. The mailbox signs with this PDA
+/// via `invoke_signed` when calling `Verify`; `RateLimited` requires it as a
+/// signer so only the mailbox can drain the bucket. `ism_program_id` is
+/// included in the seeds so each ISM gets a distinct PDA, preventing a
+/// malicious ISM from forwarding the signer to a victim ISM via a nested CPI.
+pub fn derive_process_authority(mailbox: &Pubkey, ism_program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[PROCESS_AUTHORITY_SEED, ism_program_id.as_ref()], mailbox)
 }
 
 /// Loads and validates a domain ISM account, returning the full storage.

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -524,7 +524,7 @@ fn validate_config_inner(
             // Require a specific warp-route address: RateLimited parses a token
             // amount from a fixed offset in the TokenMessage body, so applying it
             // without a recipient would misinterpret arbitrary message bodies.
-            if recipient.map_or(true, |r| r == H256::zero()) {
+            if recipient.is_none_or(|r| r == H256::zero()) {
                 return Err(Error::InvalidConfig.into());
             }
             Ok(())
@@ -570,7 +570,7 @@ fn validate_domain_ism(node: &IsmNode) -> ProgramResult {
             if *max_capacity == 0 || *mailbox == Pubkey::default() {
                 return Err(Error::InvalidConfig.into());
             }
-            if recipient.map_or(true, |r| r == H256::zero()) {
+            if recipient.is_none_or(|r| r == H256::zero()) {
                 return Err(Error::InvalidConfig.into());
             }
             Ok(())

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -5,7 +5,7 @@ use account_utils::{
     create_pda_account, verify_account_uninitialized, AccountInfoExt, DiscriminatorDecode,
     SizedData,
 };
-use hyperlane_core::{Decode, HyperlaneMessage, ModuleType};
+use hyperlane_core::{Decode, HyperlaneMessage, ModuleType, H256};
 use hyperlane_sealevel_interchain_security_module_interface::{
     InterchainSecurityModuleInstruction, MetadataSpecResult, VERIFY_ACCOUNT_METAS_PDA_SEEDS,
 };
@@ -514,10 +514,17 @@ fn validate_config_inner(
         }
         IsmNode::RateLimited {
             max_capacity,
+            recipient,
             mailbox,
             ..
         } => {
             if *max_capacity == 0 || *mailbox == Pubkey::default() {
+                return Err(Error::InvalidConfig.into());
+            }
+            // Require a specific warp-route address: RateLimited parses a token
+            // amount from a fixed offset in the TokenMessage body, so applying it
+            // without a recipient would misinterpret arbitrary message bodies.
+            if recipient.map_or(true, |r| r == H256::zero()) {
                 return Err(Error::InvalidConfig.into());
             }
             Ok(())
@@ -556,10 +563,14 @@ fn validate_domain_ism(node: &IsmNode) -> ProgramResult {
     match node {
         IsmNode::RateLimited {
             max_capacity,
+            recipient,
             mailbox,
             ..
         } => {
             if *max_capacity == 0 || *mailbox == Pubkey::default() {
+                return Err(Error::InvalidConfig.into());
+            }
+            if recipient.map_or(true, |r| r == H256::zero()) {
                 return Err(Error::InvalidConfig.into());
             }
             Ok(())
@@ -873,7 +884,7 @@ mod test {
     fn test_validate_config_rate_limited_zero_capacity() {
         let node = IsmNode::RateLimited {
             max_capacity: 0,
-            recipient: None,
+            recipient: Some(H256::from([1u8; 32])),
             filled_level: 0,
             last_updated: 0,
             mailbox: Pubkey::new_unique(),
@@ -888,10 +899,40 @@ mod test {
     fn test_validate_config_rate_limited_default_mailbox_rejected() {
         let node = IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(H256::from([1u8; 32])),
             filled_level: 0,
             last_updated: 0,
             mailbox: Pubkey::default(),
+        };
+        assert_eq!(
+            validate_config(&Pubkey::new_unique(), &node).unwrap_err(),
+            Error::InvalidConfig.into()
+        );
+    }
+
+    #[test]
+    fn test_validate_config_rate_limited_no_recipient_rejected() {
+        let node = IsmNode::RateLimited {
+            max_capacity: 1_000,
+            recipient: None,
+            filled_level: 0,
+            last_updated: 0,
+            mailbox: Pubkey::new_unique(),
+        };
+        assert_eq!(
+            validate_config(&Pubkey::new_unique(), &node).unwrap_err(),
+            Error::InvalidConfig.into()
+        );
+    }
+
+    #[test]
+    fn test_validate_config_rate_limited_zero_recipient_rejected() {
+        let node = IsmNode::RateLimited {
+            max_capacity: 1_000,
+            recipient: Some(H256::zero()),
+            filled_level: 0,
+            last_updated: 0,
+            mailbox: Pubkey::new_unique(),
         };
         assert_eq!(
             validate_config(&Pubkey::new_unique(), &node).unwrap_err(),
@@ -1014,7 +1055,7 @@ mod test {
     fn test_validate_domain_ism_rate_limited_ok() {
         let node = IsmNode::RateLimited {
             max_capacity: 100,
-            recipient: None,
+            recipient: Some(H256::from([1u8; 32])),
             filled_level: 100,
             last_updated: 0,
             mailbox: Pubkey::new_unique(),
@@ -1023,10 +1064,40 @@ mod test {
     }
 
     #[test]
+    fn test_validate_domain_ism_rate_limited_no_recipient_rejected() {
+        let node = IsmNode::RateLimited {
+            max_capacity: 100,
+            recipient: None,
+            filled_level: 0,
+            last_updated: 0,
+            mailbox: Pubkey::new_unique(),
+        };
+        assert_eq!(
+            validate_domain_ism(&node).unwrap_err(),
+            Error::InvalidConfig.into()
+        );
+    }
+
+    #[test]
+    fn test_validate_domain_ism_rate_limited_zero_recipient_rejected() {
+        let node = IsmNode::RateLimited {
+            max_capacity: 100,
+            recipient: Some(H256::zero()),
+            filled_level: 0,
+            last_updated: 0,
+            mailbox: Pubkey::new_unique(),
+        };
+        assert_eq!(
+            validate_domain_ism(&node).unwrap_err(),
+            Error::InvalidConfig.into()
+        );
+    }
+
+    #[test]
     fn test_validate_domain_ism_rate_limited_zero_capacity() {
         let node = IsmNode::RateLimited {
             max_capacity: 0,
-            recipient: None,
+            recipient: Some(H256::from([1u8; 32])),
             filled_level: 0,
             last_updated: 0,
             mailbox: Pubkey::new_unique(),
@@ -1040,9 +1111,10 @@ mod test {
     #[test]
     fn test_normalize_node_rate_limited() {
         let mailbox = Pubkey::new_unique();
+        let recipient = Some(H256::from([1u8; 32]));
         let mut node = IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient,
             filled_level: 0,
             last_updated: 999,
             mailbox,
@@ -1052,7 +1124,7 @@ mod test {
             node,
             IsmNode::RateLimited {
                 max_capacity: 1_000,
-                recipient: None,
+                recipient,
                 filled_level: 1_000,
                 last_updated: 0,
                 mailbox,
@@ -1063,11 +1135,12 @@ mod test {
     #[test]
     fn test_normalize_node_nested_in_aggregation() {
         let mailbox = Pubkey::new_unique();
+        let recipient = Some(H256::from([1u8; 32]));
         let mut node = IsmNode::Aggregation {
             threshold: 1,
             sub_isms: vec![IsmNode::RateLimited {
                 max_capacity: 500,
-                recipient: None,
+                recipient,
                 filled_level: 0,
                 last_updated: 42,
                 mailbox,
@@ -1079,7 +1152,7 @@ mod test {
                 sub_isms[0],
                 IsmNode::RateLimited {
                     max_capacity: 500,
-                    recipient: None,
+                    recipient,
                     filled_level: 500,
                     last_updated: 0,
                     mailbox,

--- a/rust/sealevel/programs/ism/composite-ism/src/verify.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/verify.rs
@@ -870,15 +870,17 @@ mod test {
         let mailbox = Pubkey::new_unique();
         let victim_program_id = Pubkey::new_unique();
         let attacker_program_id = Pubkey::new_unique();
+        let warp_route = H256::from([0xAAu8; 32]);
         let mut node = IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(warp_route),
             filled_level: 1_000,
             last_updated: 0,
             mailbox,
         };
 
         let mut msg = dummy_message(ORIGIN_DOMAIN);
+        msg.recipient = warp_route;
         msg.body = rate_limited_token_body(100);
 
         // Attacker has the authority for their own ISM (mailbox signed for them).
@@ -911,15 +913,17 @@ mod test {
     #[test]
     fn test_rate_limited_wrong_authority_rejected() {
         let mailbox = Pubkey::new_unique();
+        let warp_route = H256::from([0xAAu8; 32]);
         let mut node = IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(warp_route),
             filled_level: 1_000,
             last_updated: 0,
             mailbox,
         };
 
         let mut msg = dummy_message(ORIGIN_DOMAIN);
+        msg.recipient = warp_route;
         msg.body = rate_limited_token_body(100);
 
         // Provide the WRONG authority (some random key, not the derived PDA).
@@ -949,15 +953,17 @@ mod test {
     #[test]
     fn test_rate_limited_authority_not_signer_rejected() {
         let mailbox = Pubkey::new_unique();
+        let warp_route = H256::from([0xAAu8; 32]);
         let mut node = IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(warp_route),
             filled_level: 1_000,
             last_updated: 0,
             mailbox,
         };
 
         let mut msg = dummy_message(ORIGIN_DOMAIN);
+        msg.recipient = warp_route;
         msg.body = rate_limited_token_body(100);
 
         let program_id = no_program_id();

--- a/rust/sealevel/programs/ism/composite-ism/src/verify.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/verify.rs
@@ -281,7 +281,7 @@ where
             // calls Verify during message delivery.  Direct calls (not through the
             // mailbox) cannot produce a valid signer for this PDA, so attackers
             // cannot drain the rate-limit bucket without delivering a real message.
-            let (expected_authority, _) = derive_process_authority(mailbox);
+            let (expected_authority, _) = derive_process_authority(mailbox, program_id);
             let authority_info = next_account_info(accounts_iter)?;
             if authority_info.key != &expected_authority {
                 return Err(Error::InvalidProcessAuthority.into());
@@ -860,6 +860,53 @@ mod test {
         body
     }
 
+    /// `RateLimited` rejects an authority derived for a different ISM program.
+    ///
+    /// This is the core security property: a malicious ISM that received the
+    /// mailbox's `invoke_signed` authority cannot forward it to a victim ISM
+    /// because the PDA is bound to the calling ISM's program ID.
+    #[test]
+    fn test_rate_limited_cross_ism_authority_rejected() {
+        let mailbox = Pubkey::new_unique();
+        let victim_program_id = Pubkey::new_unique();
+        let attacker_program_id = Pubkey::new_unique();
+        let mut node = IsmNode::RateLimited {
+            max_capacity: 1_000,
+            recipient: None,
+            filled_level: 1_000,
+            last_updated: 0,
+            mailbox,
+        };
+
+        let mut msg = dummy_message(ORIGIN_DOMAIN);
+        msg.body = rate_limited_token_body(100);
+
+        // Attacker has the authority for their own ISM (mailbox signed for them).
+        let (attacker_authority, _) = derive_process_authority(&mailbox, &attacker_program_id);
+        let owner = Pubkey::default();
+        let mut lamports = 0u64;
+        let mut data = vec![];
+        // Signer = true, simulating the forwarded is_signer flag from a nested CPI.
+        let attacker_acc =
+            make_fake_account_info(&attacker_authority, true, &mut lamports, &mut data, &owner);
+
+        let accounts = vec![attacker_acc];
+        let mut iter = accounts.iter();
+        // Victim ISM uses victim_program_id — derived PDA differs → rejected.
+        assert_eq!(
+            verify_node(
+                &mut node,
+                &[],
+                &msg,
+                &mut iter,
+                &victim_program_id,
+                &mut false,
+            )
+            .unwrap_err(),
+            Error::InvalidProcessAuthority.into()
+        );
+    }
+
     /// `RateLimited` rejects when the process authority key is wrong.
     #[test]
     fn test_rate_limited_wrong_authority_rejected() {
@@ -913,7 +960,8 @@ mod test {
         let mut msg = dummy_message(ORIGIN_DOMAIN);
         msg.body = rate_limited_token_body(100);
 
-        let (authority_key, _) = derive_process_authority(&mailbox);
+        let program_id = no_program_id();
+        let (authority_key, _) = derive_process_authority(&mailbox, &program_id);
         let owner = Pubkey::default();
         let mut lamports = 0u64;
         let mut data = vec![];
@@ -924,15 +972,7 @@ mod test {
         let accounts = vec![authority_acc];
         let mut iter = accounts.iter();
         assert_eq!(
-            verify_node(
-                &mut node,
-                &[],
-                &msg,
-                &mut iter,
-                &no_program_id(),
-                &mut false,
-            )
-            .unwrap_err(),
+            verify_node(&mut node, &[], &msg, &mut iter, &program_id, &mut false,).unwrap_err(),
             Error::ProcessAuthorityNotSigner.into()
         );
     }

--- a/rust/sealevel/programs/ism/composite-ism/tests/common/mod.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/common/mod.rs
@@ -190,6 +190,13 @@ pub fn dummy_message() -> HyperlaneMessage {
     }
 }
 
+/// Non-zero warp-route recipient shared by the RateLimited tests. RateLimited
+/// requires a specific recipient, and the verified message's recipient must
+/// equal it (see `validate_domain_ism` / `verify_node`).
+pub fn rate_limited_recipient() -> H256 {
+    H256::from([0xAAu8; 32])
+}
+
 /// Builds a TokenMessage body with a given amount (big-endian u256 at bytes 32..64).
 pub fn token_message_body(amount: u64) -> Vec<u8> {
     let mut body = vec![0u8; 64];

--- a/rust/sealevel/programs/ism/composite-ism/tests/common/mod.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/common/mod.rs
@@ -42,7 +42,7 @@ pub fn mock_mailbox_id() -> Pubkey {
 
 /// The process authority PDA for the mock mailbox.
 pub fn mock_mailbox_process_authority() -> Pubkey {
-    derive_process_authority(&mock_mailbox_id()).0
+    derive_process_authority(&mock_mailbox_id(), &composite_ism_id()).0
 }
 
 /// In-process mock mailbox that forwards `Verify` / `VerifyAccountMetas` calls
@@ -57,8 +57,11 @@ fn mock_mailbox_process_instruction(
         program::invoke_signed,
     };
 
-    let (process_authority, bump) =
-        solana_program::pubkey::Pubkey::find_program_address(&[b"process_authority"], program_id);
+    let ism_id = composite_ism_id();
+    let (process_authority, bump) = solana_program::pubkey::Pubkey::find_program_address(
+        &[b"process_authority", ism_id.as_ref()],
+        program_id,
+    );
 
     // When forwarding accounts to the composite ISM via invoke_signed, we must
     // set is_signer: true for the process authority PDA in the CPI account metas.
@@ -76,7 +79,11 @@ fn mock_mailbox_process_instruction(
 
     let ix = SolInstruction::new_with_bytes(composite_ism_id(), data, account_metas);
 
-    invoke_signed(&ix, accounts, &[&[b"process_authority", &[bump]]])
+    invoke_signed(
+        &ix,
+        accounts,
+        &[&[b"process_authority", ism_id.as_ref(), &[bump]]],
+    )
 }
 
 pub fn program_test() -> ProgramTest {

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_fallback_routing.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_fallback_routing.rs
@@ -24,7 +24,7 @@ mod common;
 
 use hyperlane_core::Encode;
 use hyperlane_sealevel_composite_ism::{
-    accounts::{derive_domain_pda, CompositeIsmAccount, IsmNode},
+    accounts::{derive_domain_pda, derive_process_authority, CompositeIsmAccount, IsmNode},
     error::Error,
     instruction::{initialize_instruction, set_domain_ism_instruction},
     processor::process_instruction,
@@ -43,9 +43,9 @@ use solana_sdk::{
 };
 
 use common::{
-    assert_simulation_error, assert_simulation_ok, domain_pda_key, dummy_message,
+    assert_simulation_error, assert_simulation_ok, composite_ism_id, domain_pda_key, dummy_message,
     get_all_verify_account_metas, get_metadata_spec, get_verify_account_metas, initialize,
-    mock_mailbox_id, process_verify_via_mailbox, program_test, remove_domain_ism, set_domain_ism,
+    mock_mailbox_id, program_test, rate_limited_recipient, remove_domain_ism, set_domain_ism,
     simulate_verify, storage_pda_key, token_message_body,
 };
 
@@ -939,18 +939,17 @@ async fn test_verify_fallback_with_inner_routing_and_trusted_relayer_accepts() {
     );
 }
 
-// ── Regression: FallbackRouting → RateLimited fallback preserves writable flag ──
+// ── RateLimited is unsupported inside a fallback ISM ───────────────────────────
 //
-// When the fallback ISM contains a RateLimited node, its all_verify_account_metas
-// returns the storage PDA as writable (it must be written during Verify to update
-// filled_level/last_updated).  The old dedup silently dropped the writable copy and
-// kept only the read-only sentinel, causing DomainPdaNotWritable at Verify time.
-//
-// The fix: merge is_writable/is_signer from the inner ISM's first element into the
-// retained sentinel instead of discarding it.
-
+// RateLimited gates capacity mutation on a per-ISM-program process authority PDA
+// (`derive_process_authority(mailbox, program_id)` in verify.rs, where program_id
+// is the executing program). The mailbox only signs the authority of the ISM it
+// invokes directly — the root composite ISM — never a nested fallback ISM, which
+// is a separate program reached by CPI. A RateLimited node inside a fallback ISM
+// therefore demands a signer the mailbox can never produce, so such messages are
+// undeliverable; RateLimited must live in the root tree.
 #[tokio::test]
-async fn test_vam_fallback_with_rate_limited_storage_is_writable() {
+async fn test_rate_limited_in_fallback_ism_requires_unsignable_authority() {
     let mut context = program_test_with_fallback().start_with_context().await;
     let payer = context.payer.insecure_clone();
     let recent_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
@@ -961,7 +960,7 @@ async fn test_vam_fallback_with_rate_limited_storage_is_writable() {
         recent_blockhash,
         IsmNode::RateLimited {
             max_capacity: 1_000_000,
-            recipient: None,
+            recipient: Some(rate_limited_recipient()),
             filled_level: 0,
             last_updated: 0,
             mailbox: mock_mailbox_id(),
@@ -983,6 +982,7 @@ async fn test_vam_fallback_with_rate_limited_storage_is_writable() {
 
     let mut msg = dummy_message();
     msg.origin = ORIGIN;
+    msg.recipient = rate_limited_recipient();
     msg.body = token_message_body(100);
     let verify_ixn = VerifyInstruction {
         metadata: vec![],
@@ -998,72 +998,21 @@ async fn test_vam_fallback_with_rate_limited_storage_is_writable() {
     )
     .await;
 
-    // [storage_pda, domain_pda, fallback_storage_pda (writable), process_authority (signer), fallback_ism]
-    // The sentinel for fallback_storage_pda must be writable because RateLimited writes
-    // filled_level/last_updated to the storage PDA during Verify.
-    assert_eq!(metas.len(), 5);
-    assert_eq!(metas[0].pubkey, storage_pda_key());
-    assert_eq!(metas[1].pubkey, domain_pda_key(ORIGIN));
-    assert_eq!(metas[2].pubkey, fallback_storage_pda_key());
+    // The RateLimited node in the fallback ISM demands the fallback ISM's OWN
+    // process authority as a signer — derived for `fallback_ism_id()`, not the root
+    // composite ISM. The mailbox only ever signs the root ISM's authority, so this
+    // required signer can never be satisfied and the message is undeliverable.
+    let fallback_authority = derive_process_authority(&mock_mailbox_id(), &fallback_ism_id()).0;
+    let root_authority = derive_process_authority(&mock_mailbox_id(), &composite_ism_id()).0;
+
     assert!(
-        metas[2].is_writable,
-        "fallback storage must be writable for RateLimited"
+        metas
+            .iter()
+            .any(|m| m.pubkey == fallback_authority && m.is_signer),
+        "RateLimited in a fallback ISM must demand the fallback ISM's own (unsignable) process authority as signer"
     );
-    assert!(metas[3].is_signer, "process authority must be signer");
-    assert_eq!(metas[4].pubkey, fallback_ism_id());
-}
-
-#[tokio::test]
-async fn test_verify_fallback_with_rate_limited_accepts_within_capacity() {
-    let mut context = program_test_with_fallback().start_with_context().await;
-    let payer = context.payer.insecure_clone();
-    let recent_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
-
-    setup_fallback_ism(
-        &mut context.banks_client,
-        &payer,
-        recent_blockhash,
-        IsmNode::RateLimited {
-            max_capacity: 1_000_000,
-            recipient: None,
-            filled_level: 0,
-            last_updated: 0,
-            mailbox: mock_mailbox_id(),
-        },
-    )
-    .await;
-
-    let recent_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
-    initialize(
-        &mut context.banks_client,
-        &payer,
-        recent_blockhash,
-        IsmNode::FallbackRouting {
-            fallback_ism: fallback_ism_id(),
-        },
-    )
-    .await
-    .unwrap();
-
-    let mut msg = dummy_message();
-    msg.origin = ORIGIN;
-    msg.body = token_message_body(100);
-    let verify_ixn = VerifyInstruction {
-        metadata: vec![],
-        message: msg.to_vec(),
-    };
-
-    let recent_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
-    let metas = get_all_verify_account_metas(
-        &mut context.banks_client,
-        &payer,
-        recent_blockhash,
-        verify_ixn.clone(),
-    )
-    .await;
-
-    let recent_blockhash = context.banks_client.get_latest_blockhash().await.unwrap();
-    process_verify_via_mailbox(&mut context.banks_client, &payer, verify_ixn, metas)
-        .await
-        .unwrap();
+    assert!(
+        !metas.iter().any(|m| m.pubkey == root_authority),
+        "the root authority — the only process-authority PDA the mailbox can sign — must be absent, proving the demanded signer is unsignable"
+    );
 }

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
@@ -39,8 +39,8 @@ use std::str::FromStr;
 use common::{
     assert_simulation_error, assert_simulation_ok, composite_ism_id, domain_pda_key, dummy_message,
     encode_aggregation_metadata, get_all_verify_account_metas, initialize, mock_mailbox_id,
-    process_verify_via_mailbox, program_test, set_domain_ism, simulate_verify, storage_pda_key,
-    token_message_body,
+    process_verify_via_mailbox, program_test, rate_limited_recipient, set_domain_ism,
+    simulate_verify, storage_pda_key, token_message_body,
 };
 
 const ORIGIN: u32 = 1234;
@@ -637,13 +637,6 @@ async fn process_verify_domain(
     account_metas: Vec<AccountMeta>,
 ) -> Result<(), solana_program_test::BanksClientError> {
     process_verify_via_mailbox(banks_client, payer, verify_ixn, account_metas).await
-}
-
-/// Non-zero warp-route recipient shared by the RateLimited domain-PDA tests.
-/// RateLimited requires a specific recipient, and the verified message's
-/// recipient must equal it (see `validate_domain_ism` / `verify_node`).
-fn rate_limited_recipient() -> H256 {
-    H256::from([0xAAu8; 32])
 }
 
 #[tokio::test]

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
@@ -705,7 +705,8 @@ async fn test_rate_limited_in_domain_pda_domain_pda_is_writable() {
         get_all_verify_account_metas(&mut banks_client, &payer, recent_blockhash, verify_ixn).await;
 
     use hyperlane_sealevel_composite_ism::accounts::derive_process_authority;
-    let expected_process_authority = derive_process_authority(&mock_mailbox_id()).0;
+    let expected_process_authority =
+        derive_process_authority(&mock_mailbox_id(), &composite_ism_id()).0;
 
     assert_eq!(account_metas.len(), 3);
     assert_eq!(account_metas[0].pubkey, storage_pda_key());

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_nested.rs
@@ -639,6 +639,13 @@ async fn process_verify_domain(
     process_verify_via_mailbox(banks_client, payer, verify_ixn, account_metas).await
 }
 
+/// Non-zero warp-route recipient shared by the RateLimited domain-PDA tests.
+/// RateLimited requires a specific recipient, and the verified message's
+/// recipient must equal it (see `validate_domain_ism` / `verify_node`).
+fn rate_limited_recipient() -> H256 {
+    H256::from([0xAAu8; 32])
+}
+
 #[tokio::test]
 async fn test_rate_limited_in_domain_pda_initializes_full() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
@@ -654,7 +661,7 @@ async fn test_rate_limited_in_domain_pda_initializes_full() {
         ORIGIN,
         IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(rate_limited_recipient()),
             filled_level: 0, // normalized to max_capacity by SetDomainIsm
             last_updated: 0,
             mailbox: mock_mailbox_id(),
@@ -683,7 +690,7 @@ async fn test_rate_limited_in_domain_pda_domain_pda_is_writable() {
         ORIGIN,
         IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(rate_limited_recipient()),
             filled_level: 0,
             last_updated: 0,
             mailbox: mock_mailbox_id(),
@@ -694,6 +701,7 @@ async fn test_rate_limited_in_domain_pda_domain_pda_is_writable() {
 
     let mut msg = dummy_message();
     msg.origin = ORIGIN;
+    msg.recipient = rate_limited_recipient();
     msg.body = token_message_body(100);
     let verify_ixn = VerifyInstruction {
         metadata: vec![],
@@ -731,7 +739,7 @@ async fn test_rate_limited_in_domain_pda_enforces_limit() {
         ORIGIN,
         IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(rate_limited_recipient()),
             filled_level: 0,
             last_updated: 0,
             mailbox: mock_mailbox_id(),
@@ -743,6 +751,7 @@ async fn test_rate_limited_in_domain_pda_enforces_limit() {
     let build_verify = |amount: u64| {
         let mut msg = dummy_message();
         msg.origin = ORIGIN;
+        msg.recipient = rate_limited_recipient();
         msg.body = token_message_body(amount);
         VerifyInstruction {
             metadata: vec![],
@@ -806,7 +815,7 @@ async fn test_rate_limited_in_domain_pda_readonly_bypass_rejected() {
         ORIGIN,
         IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(rate_limited_recipient()),
             filled_level: 0,
             last_updated: 0,
             mailbox: mock_mailbox_id(),
@@ -817,6 +826,7 @@ async fn test_rate_limited_in_domain_pda_readonly_bypass_rejected() {
 
     let mut msg = dummy_message();
     msg.origin = ORIGIN;
+    msg.recipient = rate_limited_recipient();
     msg.body = token_message_body(500);
     let verify_ixn = VerifyInstruction {
         metadata: vec![],
@@ -878,7 +888,7 @@ async fn test_rate_limited_domain_pda_writable_bit_requires_fixpoint() {
         ORIGIN,
         IsmNode::RateLimited {
             max_capacity: 1_000,
-            recipient: None,
+            recipient: Some(rate_limited_recipient()),
             filled_level: 0,
             last_updated: 0,
             mailbox: mock_mailbox_id(),
@@ -889,6 +899,7 @@ async fn test_rate_limited_domain_pda_writable_bit_requires_fixpoint() {
 
     let mut msg = dummy_message();
     msg.origin = ORIGIN;
+    msg.recipient = rate_limited_recipient();
     msg.body = token_message_body(500);
     let verify_ixn = VerifyInstruction {
         metadata: vec![],

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_rate_limited.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_rate_limited.rs
@@ -591,7 +591,8 @@ async fn test_verify_account_metas_writable_pda() {
         get_verify_account_metas(&mut banks_client, &payer, recent_blockhash, ixn).await;
 
     use hyperlane_sealevel_composite_ism::accounts::derive_process_authority;
-    let expected_process_authority = derive_process_authority(&mock_mailbox_id()).0;
+    let expected_process_authority =
+        derive_process_authority(&mock_mailbox_id(), &composite_ism_id()).0;
 
     // Storage PDA must be writable so the rate limit state can be written back on Verify.
     // Process authority PDA must also be present as a signer.

--- a/rust/sealevel/programs/ism/composite-ism/tests/functional_rate_limited.rs
+++ b/rust/sealevel/programs/ism/composite-ism/tests/functional_rate_limited.rs
@@ -14,7 +14,7 @@
 //! - After a partial time elapsed, partial refill allows additional transfers
 //! - After a full 24-hour window, capacity is fully restored
 //! - Verify fails with RecipientMismatch when recipient does not match the configured one
-//! - Verify succeeds for any recipient when no recipient is configured
+//! - Initialize fails when recipient is None (RateLimited requires a warp-route address)
 //! - Verify fails with InvalidMessageBody when message body is shorter than 64 bytes
 //! - Verify fails with RateLimitExceeded when message amount overflows u64 (high bytes non-zero)
 //! - VerifyAccountMetas returns the storage PDA as writable (state is mutated on Verify)
@@ -40,17 +40,19 @@ use solana_sdk::{
 };
 
 use common::{
-    assert_simulation_error, assert_simulation_ok, composite_ism_id, dummy_message,
-    get_verify_account_metas, initialize, mock_mailbox_id, process_verify_via_mailbox,
-    program_test, simulate_verify, storage_pda_key, token_message_body,
+    assert_simulation_error, composite_ism_id, dummy_message, get_verify_account_metas, initialize,
+    mock_mailbox_id, process_verify_via_mailbox, program_test, simulate_verify, storage_pda_key,
+    token_message_body,
 };
 
 const MAX_CAPACITY: u64 = 1_000;
+// A fixed warp-route contract address used as the configured recipient in tests.
+const WARP_ROUTE: H256 = H256([0x11u8; 32]);
 
 fn rate_limited_node(max_capacity: u64) -> IsmNode {
     IsmNode::RateLimited {
         max_capacity,
-        recipient: None,
+        recipient: Some(WARP_ROUTE),
         filled_level: 0, // normalized to max_capacity on initialize
         last_updated: 0,
         mailbox: mock_mailbox_id(),
@@ -59,6 +61,7 @@ fn rate_limited_node(max_capacity: u64) -> IsmNode {
 
 fn verify_ixn(amount: u64) -> VerifyInstruction {
     let mut msg = dummy_message();
+    msg.recipient = WARP_ROUTE;
     msg.body = token_message_body(amount);
     VerifyInstruction {
         metadata: vec![],
@@ -459,37 +462,39 @@ async fn test_verify_wrong_recipient() {
 }
 
 #[tokio::test]
-async fn test_verify_any_recipient_when_none() {
+async fn test_initialize_no_recipient_rejected() {
     let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
 
-    initialize(
-        &mut banks_client,
-        &payer,
-        recent_blockhash,
-        rate_limited_node(MAX_CAPACITY), // recipient: None
-    )
-    .await
-    .unwrap();
-
-    let mut msg = dummy_message();
-    msg.body = token_message_body(1);
-    msg.recipient = H256::from([0xAB; 32]); // arbitrary recipient
-    let ixn = VerifyInstruction {
-        metadata: vec![],
-        message: msg.to_vec(),
+    let node = IsmNode::RateLimited {
+        max_capacity: MAX_CAPACITY,
+        recipient: None,
+        filled_level: 0,
+        last_updated: 0,
+        mailbox: mock_mailbox_id(),
     };
-    let account_metas =
-        get_verify_account_metas(&mut banks_client, &payer, recent_blockhash, ixn.clone()).await;
-    let result = simulate_verify(
-        &mut banks_client,
-        &payer,
-        recent_blockhash,
-        ixn,
-        account_metas,
-    )
-    .await;
+    let result = initialize(&mut banks_client, &payer, recent_blockhash, node).await;
+    assert!(
+        result.is_err(),
+        "Initialize with recipient: None should be rejected"
+    );
+}
 
-    assert_simulation_ok(&result);
+#[tokio::test]
+async fn test_initialize_zero_recipient_rejected() {
+    let (mut banks_client, payer, recent_blockhash) = program_test().start().await;
+
+    let node = IsmNode::RateLimited {
+        max_capacity: MAX_CAPACITY,
+        recipient: Some(H256::zero()),
+        filled_level: 0,
+        last_updated: 0,
+        mailbox: mock_mailbox_id(),
+    };
+    let result = initialize(&mut banks_client, &payer, recent_blockhash, node).await;
+    assert!(
+        result.is_err(),
+        "Initialize with recipient: Some(zero) should be rejected"
+    );
 }
 
 #[tokio::test]
@@ -506,7 +511,8 @@ async fn test_verify_body_too_short() {
     .unwrap();
 
     // dummy_message has body = vec![] (len 0 < 64)
-    let msg = dummy_message();
+    let mut msg = dummy_message();
+    msg.recipient = WARP_ROUTE;
     let ixn = VerifyInstruction {
         metadata: vec![],
         message: msg.to_vec(),
@@ -548,6 +554,7 @@ async fn test_verify_amount_overflow() {
     let mut body = vec![0u8; 64];
     body[32] = 1; // high byte of the 32-byte amount field
     let mut msg = dummy_message();
+    msg.recipient = WARP_ROUTE;
     msg.body = body;
     let ixn = VerifyInstruction {
         metadata: vec![],

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -359,15 +359,16 @@ fn inbox_process(
         });
     }
 
-    // Derive the global process-authority PDA so that ISMs that require the
+    // Derive a per-ISM process-authority PDA so that ISMs that require the
     // Mailbox to co-sign (e.g. RateLimited) receive a proper signer account.
-    // The PDA is derived under the Mailbox's own program ID with a single
-    // well-known seed so any ISM configured with this mailbox can verify it.
+    // Including the ISM program ID in the seeds binds this authority to the
+    // specific ISM being called, preventing a malicious recipient-selected ISM
+    // from forwarding the signer to a victim ISM via a nested CPI.
     let (process_authority_key, process_authority_bump) =
-        Pubkey::find_program_address(&[b"process_authority"], program_id);
+        Pubkey::find_program_address(&[b"process_authority", ism.as_ref()], program_id);
 
-    // If the ISM requested the global process-authority PDA, mark it as a
-    // signer in the CPI so that invoke_signed can grant signing authority.
+    // If the ISM requested its process-authority PDA, mark it as a signer in
+    // the CPI so that invoke_signed can grant signing authority.
     for meta in &mut ism_verify_account_metas {
         if meta.pubkey == process_authority_key {
             meta.is_signer = true;
@@ -384,7 +385,11 @@ fn inbox_process(
     invoke_signed(
         &verify,
         &ism_verify_infos,
-        &[&[b"process_authority", &[process_authority_bump]]],
+        &[&[
+            b"process_authority",
+            ism.as_ref(),
+            &[process_authority_bump],
+        ]],
     )?;
 
     // Mark the message as delivered by creating the processed message account.


### PR DESCRIPTION
## Summary

Fixes HLSVM-2026Q2-002 (chainlight-io/2026-q2-hyperlane-svm-issues#3).

The process authority PDA was previously seeded only with `b"process_authority"` under the mailbox program ID, making it a single global signer. A malicious recipient-controlled ISM could accept the PDA from the mailbox during its own `Verify` call and forward it — with `is_signer=true` preserved through Solana's CPI privilege propagation — to a victim composite ISM's `Verify` call via a nested `invoke`. The victim's `RateLimited` node would accept the forwarded signer and drain its capacity without authorisation.

**Fix:** add `ism_program_id` to the PDA seeds in both the mailbox signing path and the composite ISM derivation:

```
seeds: [b"process_authority", ism_program_id]  // one PDA per ISM program
```

Each ISM now receives a distinct process authority PDA. A signer derived for ISM A cannot satisfy the check in ISM B.

## Changes

- `mailbox/processor.rs`: seed `[b"process_authority", ism]` + matching `invoke_signed`
- `composite-ism/accounts.rs`: `derive_process_authority(mailbox, ism_program_id)`
- `composite-ism/verify.rs`: pass `program_id` to `derive_process_authority`; add `test_rate_limited_cross_ism_authority_rejected`
- `composite-ism/account_metas.rs`: pass `program_id` to `derive_process_authority`

## Test plan

- [x] `cargo test --lib` in `rust/sealevel/programs/ism/composite-ism` — all unit tests pass including new cross-ISM rejection test
- [x] `cargo test --lib` in `rust/sealevel/programs/mailbox`
- [x] `cargo clippy` — no warnings

Closes chainlight-io/2026-q2-hyperlane-svm-issues#3