### PR TITLE
docs(sealevel): document domain PDA lifecycle for Routing and update_config (HLSVM-2026Q2-012)

### DIFF
--- a/rust/sealevel/programs/ism/composite-ism/src/accounts.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/accounts.rs
@@ -98,6 +98,11 @@ pub enum IsmNode {
     ///
     /// Returns `NoRouteForDomain` if no domain PDA is configured for the origin.
     ///
+    /// **Lifecycle note**: domain PDAs are global to the program and survive
+    /// `update_config` calls that change the root to a non-routing type.  They
+    /// become active again if the root is later set back to a routing-type node.
+    /// Operators should call `remove_domain_ism` for every configured domain
+    /// before switching away from a routing root.
     Routing,
 
     /// Routes to a per-domain PDA first (like `Routing`), then falls back to a

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -262,6 +262,15 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], mut root: IsmNode) 
 
 /// Replaces the full ISM config tree. Owner-gated.
 ///
+/// **Domain PDA lifecycle**: per-domain ISM accounts created by [`set_domain_ism`] are
+/// stored at seeds `[DOMAIN_ISM_SEED, domain]` and are not tied to any particular root
+/// config. They are NOT closed by this instruction. Domain PDAs set under a previous
+/// `Routing` or `FallbackRouting` root remain on-chain and become active again if a
+/// later `update_config` call restores a routing-type root. Operators must call
+/// [`remove_domain_ism`] for every configured domain before switching away from a
+/// routing root, and should audit existing domain PDAs (via off-chain
+/// `getProgramAccounts`) before enabling routing.
+///
 /// Accounts:
 /// 0. `[signer]`     The owner (also payer for any rent top-up).
 /// 1. `[writable]`   The storage PDA account.


### PR DESCRIPTION
## Summary

Addresses HLSVM-2026Q2-012 from the ChainLight Q2 2026 SVM audit ([issue #15](https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/15)).

No code change — this is a documentation-only fix. The finding is correctly rated Informational and the auditors themselves recommend documenting the lifecycle rather than changing the architecture:

> "The issue is primarily operational. Document this lifecycle explicitly."

**Why no code fix:** `update_config` cannot enumerate domain PDAs on-chain (Solana programs only see accounts passed into the instruction). Requiring callers to close all domain PDAs before `update_config` would be a breaking interface change with no bounded account count. The pre-staging use-case (setting domain PDAs before the root is a routing node) is intentional.

## Changes

- `accounts.rs` — lifecycle note on the `Routing` node variant: domain PDAs survive `update_config` and are reactivated by any future routing root; operators must call `remove_domain_ism` before switching away
- `processor.rs` — expanded `update_config` doc comment with the same guidance and a pointer to `getProgramAccounts` for off-chain enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)