### PR TITLE
fix: correct ink rebalancing bridge address in USDC/eclipsemainnet rebalancer config

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/eclipsemainnet-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/eclipsemainnet-config.yaml
@@ -104,7 +104,7 @@ strategy:
         tolerance: 3
       bridgeLockTime: 1800
       bridgeMinAcceptedAmount: 2500
-      bridge: '0x33e94B6D2ae697c16a750dB7c3d9443622C4405a'
+      bridge: '0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7'
       override:
         bsc:
           executionType: inventory


### PR DESCRIPTION
## Summary

The `USDC/eclipsemainnet` rebalancer config set the **ink** leg's `bridge` to `0x33e94B6D2ae697c16a750dB7c3d9443622C4405a`, which is the rebalancing-bridge address used on base/optimism/polygon/unichain — **not ink**. As a result every rebalance originating on ink failed `Rebalancer.validateRoute`'s on-chain `allowedBridges` / `isBridgeAllowed` check with `Route validation failed: Bridge is not allowed`, generating ~1 unhandled error per tick and firing the **"Rebalancer unhandled errors"** low-urgency alert (last 24h: ink→base 289x, ink→optimism 11x).

### Verification

- On-chain ink warp router `0x0DE665377A5B0D390469d0ea0FCae55e0c14f4c4` — `allowedBridges(domain)` returns `[0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7, 0x70CF23d09784fCA62be304c928BCA9F1801B1F21]` for every destination (base/optimism/arbitrum/polygon/unichain). `0x33e9...` is **not** in the allowlist.
- On-chain base warp router `0x37e637891A558B5b621723cbf8Fc771525f280C1` — `allowedBridges()` includes `0x33e9...`, confirming `0x33e9...` is the base/op bridge, not ink's.
- The `USDC/superseed` rebalancer config already uses `0x92dFEB6f...` for ink.

### Fix

Set ink's `bridge` to `0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7`, matching the on-chain allowlist and the superseed config. **No on-chain governance tx is needed** — the ink router already allows this bridge.

Impact of the bug was limited to automated rebalancing of ink's small leg (weight 5%); user message delivery was unaffected.

## Test plan

- [ ] Merge + redeploy the `USDC/eclipsemainnet` rebalancer
- [ ] Confirm `Route validation failed: Bridge is not allowed` errors stop in the rebalancer pod logs
- [ ] Confirm the "Rebalancer unhandled errors" alert clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)