### PR TITLE
feat(keyfunder): fund stableswap inventory wallet (new role)

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredStableswapInventoryRebalancerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredStableswapInventoryRebalancerBalances.json
@@ -1,0 +1,9 @@
+{
+  "ethereum": 0.02,
+  "arbitrum": 0.02,
+  "base": 0.02,
+  "polygon": 40,
+  "bsc": 0.02,
+  "katana": 0.04,
+  "citrea": 0.001
+}

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -7,6 +7,7 @@ import { DockerImageRepos, mainnetDockerTags } from '../../docker.js';
 
 import desiredRebalancerBalances from './balances/desiredRebalancerBalances.json' with { type: 'json' };
 import desiredInventoryRebalancerBalances from './balances/desiredInventoryRebalancerBalances.json' with { type: 'json' };
+import desiredStableswapInventoryRebalancerBalances from './balances/desiredStableswapInventoryRebalancerBalances.json' with { type: 'json' };
 import desiredRelayerBalances from './balances/desiredRelayerBalances.json' with { type: 'json' };
 import lowUrgencyKeyFunderBalances from './balances/lowUrgencyKeyFunderBalance.json' with { type: 'json' };
 import { environment } from './chains.js';
@@ -32,6 +33,13 @@ const desiredInventoryRebalancerBalancePerChain = objMap(
   desiredInventoryRebalancerBalances,
   (_, balance) => balance.toString(),
 ) as Record<DesiredInventoryRebalancerBalanceChains, string>;
+
+type DesiredStableswapInventoryRebalancerBalanceChains =
+  keyof typeof desiredStableswapInventoryRebalancerBalances;
+const desiredStableswapInventoryRebalancerBalancePerChain = objMap(
+  desiredStableswapInventoryRebalancerBalances,
+  (_, balance) => balance.toString(),
+) as Record<DesiredStableswapInventoryRebalancerBalanceChains, string>;
 
 type LowUrgencyKeyFunderBalanceChains =
   keyof typeof lowUrgencyKeyFunderBalances;
@@ -60,6 +68,7 @@ export const keyFunderConfig: KeyFunderConfig<
       Role.Relayer,
       Role.Rebalancer,
       Role.InventoryRebalancer,
+      Role.StableswapInventoryRebalancer,
     ],
     [Contexts.ReleaseCandidate]: [Role.Relayer],
     [Contexts.FastPath]: [Role.Relayer],
@@ -71,6 +80,8 @@ export const keyFunderConfig: KeyFunderConfig<
   desiredRebalancerBalancePerChain,
   // desired inventory rebalancer balance config
   desiredInventoryRebalancerBalancePerChain,
+  // desired stableswap inventory rebalancer balance config
+  desiredStableswapInventoryRebalancerBalancePerChain,
   // if not set, keyfunder defaults to using desired balance * 0.2 as the threshold
   igpClaimThresholdPerChain: {
     ancient8: '0.1',

--- a/typescript/infra/config/stableswapInventoryRebalancer.json
+++ b/typescript/infra/config/stableswapInventoryRebalancer.json
@@ -1,0 +1,5 @@
+{
+  "mainnet3": {
+    "hyperlane": "0x93240AD82ca750da33de564F8dcE8EBEB5885822"
+  }
+}

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -39,6 +39,7 @@ export interface KeyFunderConfig<
   desiredBalancePerChain: Record<SupportedChains[number], string>;
   desiredRebalancerBalancePerChain: ChainMap<string>;
   desiredInventoryRebalancerBalancePerChain?: ChainMap<string>;
+  desiredStableswapInventoryRebalancerBalancePerChain?: ChainMap<string>;
   igpClaimThresholdPerChain: ChainMap<string>;
   chainsToSkip: ChainName[];
   // Per-chain overrides for automatic sweep of excess funds to Safes

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -11,6 +11,7 @@ import { DockerImageRepos } from '../../config/docker.js';
 import { NODE_SERVICE_NAMES } from '../utils/consts.js';
 import rebalancerAddresses from '../../config/rebalancer.json' with { type: 'json' };
 import inventoryRebalancerAddresses from '../../config/inventoryRebalancer.json' with { type: 'json' };
+import stableswapInventoryRebalancerAddresses from '../../config/stableswapInventoryRebalancer.json' with { type: 'json' };
 import { getEnvAddresses } from '../../config/registry.js';
 import { getAgentConfig } from '../../scripts/agent-utils.js';
 import { getEnvironmentConfig } from '../../scripts/core-utils.js';
@@ -300,6 +301,11 @@ export class KeyFunderHelmManager extends HelmManager {
           DeployEnvironment,
           Record<Contexts, string>
         >;
+      case Role.StableswapInventoryRebalancer:
+        return stableswapInventoryRebalancerAddresses as Record<
+          DeployEnvironment,
+          Record<Contexts, string>
+        >;
       default:
         return undefined;
     }
@@ -316,6 +322,9 @@ export class KeyFunderHelmManager extends HelmManager {
         return this.config.desiredRebalancerBalancePerChain?.[chain];
       case Role.InventoryRebalancer:
         return this.config.desiredInventoryRebalancerBalancePerChain?.[chain];
+      case Role.StableswapInventoryRebalancer:
+        return this.config
+          .desiredStableswapInventoryRebalancerBalancePerChain?.[chain];
       default:
         return undefined;
     }

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -6,12 +6,17 @@ export enum Role {
   Rebalancer = 'rebalancer',
   InventoryRebalancer = 'inventoryrebalancer',
   QuoteSigner = 'quotesigner',
+  // Funding-only role: the stableswap rebalancer's EVM inventory
+  // signer. Has no managed agent key — keyfunder only needs the address to
+  // send gas to it. Do NOT add to ALL_KEY_ROLES / ALL_AGENT_ROLES / rolesWithKeys.
+  StableswapInventoryRebalancer = 'stableswapinventoryrebalancer',
 }
 
 export type FundableRole =
   | Role.Relayer
   | Role.Rebalancer
-  | Role.InventoryRebalancer;
+  | Role.InventoryRebalancer
+  | Role.StableswapInventoryRebalancer;
 
 export const ALL_KEY_ROLES = [
   Role.Validator,

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -222,7 +222,12 @@ export function assertRole(roleStr: string) {
 
 export function assertFundableRole(roleStr: string): FundableRole {
   const role = roleStr as Role;
-  if (role !== Role.Relayer && role !== Role.Rebalancer) {
+  if (
+    role !== Role.Relayer &&
+    role !== Role.Rebalancer &&
+    role !== Role.InventoryRebalancer &&
+    role !== Role.StableswapInventoryRebalancer
+  ) {
     throw Error(`Invalid fundable role ${role}`);
   }
   return role;


### PR DESCRIPTION
## Problem

The stableswap rebalancer (the `typescript/stableswap-rebalancer` package deployed from `private-agents`) signs with three wallets. Its **EVM inventory signer `0x93240AD82ca750da33de564F8dcE8EBEB5885822`** (`HYP_INVENTORY_KEY_ETHEREUM`) keeps **running out of gas** — it is registered in **no funder**:

- keyfunder funds the *unrelated* `InventoryRebalancer` address `0x6056…FdA9`, not this wallet.
- It is in no `rebalancer.json` / `inventoryRebalancer.json` / balance file, and `private-agents` has no funding wiring of its own.

(The MCR signer `0xa3948a15…198FE3` is already funded via `Role.Rebalancer` and is unchanged.)

## Change

Add a **funding-only** `Role.StableswapInventoryRebalancer` and enroll it under the `Hyperlane` context so keyfunder tops up `0x93240AD8…5822` on the chains this rebalancer actually transacts on.

- **Commit 1 — plumbing:** new `Role` + `FundableRole` member, optional `desiredStableswapInventoryRebalancerBalancePerChain` config field, address resolution + desired-balance lookup in `key-funder.ts`, the `stableswapInventoryRebalancer.json` address file, and `assertFundableRole` widened. The role is deliberately **excluded** from `ALL_KEY_ROLES` / `ALL_AGENT_ROLES` / any `rolesWithKeys` — it has no managed key; keyfunder only needs the address to send gas to.
- **Commit 2 — mainnet3 enablement:** wire the role into `contextsAndRolesToFund[Hyperlane]` and add the desired-balance file.

Targets (`desiredStableswapInventoryRebalancerBalances.json`):

| chain | target | native |
|---|---|---|
| ethereum / arbitrum / base | 0.02 | ETH |
| polygon | 40 | POL |
| bsc | 0.02 | BNB |
| katana | 0.04 | ETH |
| citrea | 0.001 | CBTC (BTC-pegged → kept small) |

No keyfunder Docker rebuild needed — the infra side generates the YAML at deploy time and the image reads roles/chains generically.

## Out of scope
- **Sealevel signer `4ZJo…BcMo`** — keyfunder is EVM-only; SOL must be funded separately.
- MCR signer — already funded, untouched.

## Verify / deploy
- `pnpm turbo run build --filter=@hyperlane-xyz/infra` + `pnpm lint`.
- Render the generated keyfunder YAML and confirm role `hyperlane-stableswapinventoryrebalancer` → `0x93240AD8…5822` with exactly the 7 chains/amounts (Zod-validated in `generateKeyfunderYaml`).
- Deploy: `pnpm tsx typescript/infra/scripts/funding/deploy-key-funder.ts -e mainnet3`.
- Pre-deploy: confirm the keyfunder **funder/deployer wallet** itself holds gas on **katana (ETH)** and **citrea (CBTC)**, or those chains silently fail to fund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)