### PR TITLE
fix(sealevel): HLSVM-2026Q2-010

### DIFF
--- a/rust/sealevel/libraries/account-utils/src/discriminator.rs
+++ b/rust/sealevel/libraries/account-utils/src/discriminator.rs
@@ -320,4 +320,11 @@ mod test {
             OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &bytes[..]).unwrap();
         assert_eq!(decoded, Some(Bar { a: 9 }));
     }
+
+    #[test]
+    fn test_optional_discriminated_data_matching_discriminator_truncated_payload_errors() {
+        let mut bytes = Bar::DISCRIMINATOR.to_vec();
+        bytes.extend_from_slice(&[0u8; 3]); // Bar needs a u64; only 3 bytes follow
+        assert!(OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &bytes[..]).is_err());
+    }
 }

--- a/rust/sealevel/libraries/account-utils/src/discriminator.rs
+++ b/rust/sealevel/libraries/account-utils/src/discriminator.rs
@@ -104,6 +104,95 @@ pub trait DiscriminatorData: Sized {
     const DISCRIMINATOR_SLICE: &'static [u8] = &Self::DISCRIMINATOR;
 }
 
+/// A trailing optional field that is self-describing on disk: serializes to
+/// nothing when absent, and to `[T::DISCRIMINATOR][value]` when present. On read
+/// it is `Some` only if the tail begins with `T::DISCRIMINATOR`; EOF, a short
+/// tail, or any non-matching tail (e.g. stale bytes in an over-allocated account)
+/// reads as `None`. A matching discriminator with an undecodable payload errors.
+///
+/// The absent-able counterpart of [`DiscriminatorPrefixed`]; place it LAST so the
+/// rest of the struct can derive Borsh, and decode via a reader path
+/// (`AccountData::fetch`), not `try_from_slice` (which rejects an over-allocated
+/// account's unread tail). Choose a `DISCRIMINATOR` that won't collide with the
+/// preceding field's bytes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OptionalDiscriminatedData<T>(pub Option<T>);
+
+impl<T> Default for OptionalDiscriminatedData<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<T> From<Option<T>> for OptionalDiscriminatedData<T> {
+    fn from(value: Option<T>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: PartialEq> PartialEq<Option<T>> for OptionalDiscriminatedData<T> {
+    fn eq(&self, other: &Option<T>) -> bool {
+        self.0 == *other
+    }
+}
+
+impl<T> Deref for OptionalDiscriminatedData<T> {
+    type Target = Option<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for OptionalDiscriminatedData<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> BorshSerialize for OptionalDiscriminatedData<T>
+where
+    T: DiscriminatorData + BorshSerialize,
+{
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        if let Some(value) = &self.0 {
+            T::DISCRIMINATOR.serialize(writer)?;
+            value.serialize(writer)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T> BorshDeserialize for OptionalDiscriminatedData<T>
+where
+    T: DiscriminatorData + BorshDeserialize,
+{
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut discriminator = [0u8; Discriminator::LENGTH];
+        match reader.read_exact(&mut discriminator) {
+            Ok(()) if discriminator == T::DISCRIMINATOR => {
+                Ok(Self(Some(T::deserialize_reader(reader)?)))
+            }
+            // A non-matching or too-short tail is stale/absent data, not an error.
+            Ok(()) => Ok(Self(None)),
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(Self(None)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl<T> SizedData for OptionalDiscriminatedData<T>
+where
+    T: DiscriminatorData + SizedData,
+{
+    fn size(&self) -> usize {
+        match &self.0 {
+            Some(value) => Discriminator::LENGTH + value.size(),
+            None => 0,
+        }
+    }
+}
+
 /// Encodes the given data with a discriminator prefix.
 pub trait DiscriminatorEncode: DiscriminatorData + borsh::BorshSerialize {
     fn encode(self) -> Result<Vec<u8>, ProgramError> {
@@ -160,5 +249,75 @@ mod test {
             serialized_prefixed_foo[0..Discriminator::LENGTH],
             Foo::DISCRIMINATOR
         );
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Clone, Default)]
+    struct Bar {
+        a: u64,
+    }
+
+    impl DiscriminatorData for Bar {
+        const DISCRIMINATOR: [u8; 8] = *b"BAR_____";
+    }
+
+    impl SizedData for Bar {
+        fn size(&self) -> usize {
+            8
+        }
+    }
+
+    #[test]
+    fn test_optional_discriminated_data_none_writes_nothing() {
+        let none = OptionalDiscriminatedData::<Bar>(None);
+        assert!(borsh::to_vec(&none).unwrap().is_empty());
+        assert_eq!(none.size(), 0);
+    }
+
+    #[test]
+    fn test_optional_discriminated_data_some_roundtrip() {
+        let some = OptionalDiscriminatedData(Some(Bar { a: 7 }));
+        let bytes = borsh::to_vec(&some).unwrap();
+        // [discriminator][payload]
+        assert_eq!(bytes[..Discriminator::LENGTH], Bar::DISCRIMINATOR);
+        assert_eq!(bytes.len(), some.size());
+
+        let decoded =
+            OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &bytes[..]).unwrap();
+        assert_eq!(decoded, some);
+    }
+
+    #[test]
+    fn test_optional_discriminated_data_eof_is_none() {
+        let decoded = OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &[][..]).unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn test_optional_discriminated_data_short_tail_is_none() {
+        // Fewer bytes than the discriminator can't be a present field.
+        let decoded =
+            OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &[0xAB, 0xCD][..]).unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn test_optional_discriminated_data_non_matching_tail_is_none() {
+        // A full-length tail that isn't the discriminator (e.g. stale bytes) is
+        // absent, not an error — this is the HLSVM-2026Q2-010 fix.
+        let stale = [0xFFu8; 64];
+        let decoded =
+            OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &stale[..]).unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn test_optional_discriminated_data_ignores_trailing_after_payload() {
+        // Discriminator + valid payload, then stale padding: still Some, padding
+        // ignored (deserialize_reader does not require full consumption).
+        let mut bytes = borsh::to_vec(&OptionalDiscriminatedData(Some(Bar { a: 9 }))).unwrap();
+        bytes.extend_from_slice(&[0xFF; 16]);
+        let decoded =
+            OptionalDiscriminatedData::<Bar>::deserialize_reader(&mut &bytes[..]).unwrap();
+        assert_eq!(decoded, Some(Bar { a: 9 }));
     }
 }

--- a/rust/sealevel/libraries/account-utils/src/lib.rs
+++ b/rust/sealevel/libraries/account-utils/src/lib.rs
@@ -17,28 +17,6 @@ pub mod error;
 pub use discriminator::*;
 pub use error::*;
 
-/// Reads an optional trailing field from a Borsh reader. Treats EOF as
-/// `None` so that accounts serialized before the field existed still
-/// deserialize correctly. All future trailing-optional fields must use
-/// this helper to preserve backward compatibility.
-pub fn read_optional_trailing<R: std::io::Read, V: BorshDeserialize>(
-    reader: &mut R,
-) -> std::io::Result<Option<V>> {
-    let mut tag = [0u8; 1];
-    match reader.read_exact(&mut tag) {
-        Ok(()) => match tag[0] {
-            0 => Ok(None),
-            1 => V::deserialize_reader(reader).map(Some),
-            v => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Invalid Option tag: {v}"),
-            )),
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(None),
-        Err(e) => Err(e),
-    }
-}
-
 /// Verifies that no additional accounts remain in the iterator.
 pub fn ensure_no_extraneous_accounts(
     accounts_iter: &mut std::slice::Iter<'_, AccountInfo<'_>>,

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/accounts.rs
@@ -1,7 +1,7 @@
 //! Accounts for the Hyperlane token program.
 
 use access_control::AccessControl;
-use account_utils::{read_optional_trailing, AccountData, SizedData};
+use account_utils::{AccountData, DiscriminatorData, OptionalDiscriminatedData, SizedData};
 use borsh::{BorshDeserialize, BorshSerialize};
 use hyperlane_core::{H256, U256};
 use hyperlane_sealevel_connection_client::{
@@ -28,12 +28,20 @@ pub struct FeeConfig {
     pub fee_account: Pubkey,
 }
 
+impl DiscriminatorData for FeeConfig {
+    const DISCRIMINATOR: [u8; 8] = *b"TOKFEEV1";
+}
+
+impl SizedData for FeeConfig {
+    fn size(&self) -> usize {
+        // fee_program + fee_account
+        32 + 32
+    }
+}
+
 /// A PDA account containing the data for a Hyperlane token
 /// and any plugin-specific data.
-///
-/// `BorshDeserialize` is implemented manually to support backward-compatible
-/// deserialization of accounts created before `fee_config` was added.
-#[derive(Debug, PartialEq, Default)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Default)]
 pub struct HyperlaneToken<T> {
     /// The bump seed for this PDA.
     pub bump: u8,
@@ -61,66 +69,7 @@ pub struct HyperlaneToken<T> {
     pub plugin_data: T,
     /// Optional warp fee configuration. Must be the last field for
     /// backward-compatible deserialization.
-    pub fee_config: Option<FeeConfig>,
-}
-
-impl<T: BorshDeserialize> BorshDeserialize for HyperlaneToken<T> {
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let bump = u8::deserialize_reader(reader)?;
-        let mailbox = Pubkey::deserialize_reader(reader)?;
-        let mailbox_process_authority = Pubkey::deserialize_reader(reader)?;
-        let dispatch_authority_bump = u8::deserialize_reader(reader)?;
-        let decimals = u8::deserialize_reader(reader)?;
-        let remote_decimals = u8::deserialize_reader(reader)?;
-        let owner = Option::<Pubkey>::deserialize_reader(reader)?;
-        let interchain_security_module = Option::<Pubkey>::deserialize_reader(reader)?;
-        let interchain_gas_paymaster =
-            Option::<(Pubkey, InterchainGasPaymasterType)>::deserialize_reader(reader)?;
-        let destination_gas = HashMap::<u32, u64>::deserialize_reader(reader)?;
-        let remote_routers = HashMap::<u32, H256>::deserialize_reader(reader)?;
-        let plugin_data = T::deserialize_reader(reader)?;
-        let fee_config = read_optional_trailing::<_, FeeConfig>(reader)?;
-
-        Ok(Self {
-            bump,
-            mailbox,
-            mailbox_process_authority,
-            dispatch_authority_bump,
-            decimals,
-            remote_decimals,
-            owner,
-            interchain_security_module,
-            interchain_gas_paymaster,
-            destination_gas,
-            remote_routers,
-            plugin_data,
-            fee_config,
-        })
-    }
-}
-
-impl<T: BorshSerialize> BorshSerialize for HyperlaneToken<T> {
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        self.bump.serialize(writer)?;
-        self.mailbox.serialize(writer)?;
-        self.mailbox_process_authority.serialize(writer)?;
-        self.dispatch_authority_bump.serialize(writer)?;
-        self.decimals.serialize(writer)?;
-        self.remote_decimals.serialize(writer)?;
-        self.owner.serialize(writer)?;
-        self.interchain_security_module.serialize(writer)?;
-        self.interchain_gas_paymaster.serialize(writer)?;
-        self.destination_gas.serialize(writer)?;
-        self.remote_routers.serialize(writer)?;
-        self.plugin_data.serialize(writer)?;
-        // Only write the Option tag + payload when Some; write nothing for None
-        // so the serialized size matches the pre-upgrade layout.
-        if let Some(cfg) = &self.fee_config {
-            1u8.serialize(writer)?;
-            cfg.serialize(writer)?;
-        }
-        Ok(())
-    }
+    pub fee_config: OptionalDiscriminatedData<FeeConfig>,
 }
 
 impl<T> HyperlaneToken<T>
@@ -198,11 +147,8 @@ where
         (self.remote_routers.len() * (std::mem::size_of::<u32>() + 32)) +
         // plugin_data
         self.plugin_data.size() +
-        // fee_config: Option<FeeConfig> — None: 0 (omitted), Some: 1 tag + 32 + 32
-        match &self.fee_config {
-            Some(_) => 1 + 64,
-            None => 0,
-        }
+        // fee_config: 0 when None, DISCRIMINATOR (8) + 32 + 32 when Some.
+        self.fee_config.size()
     }
 }
 
@@ -421,7 +367,7 @@ mod test {
             destination_gas: HashMap::from([(1000, 200000), (200, 400000)]),
             remote_routers: HashMap::from([(1000, H256::random()), (200, H256::random())]),
             plugin_data: Foo { bar: 69 },
-            fee_config: None,
+            fee_config: None.into(),
         };
         let serialized = borsh::to_vec(&hyperlane_token_foo).unwrap();
 
@@ -460,7 +406,8 @@ mod test {
             fee_config: Some(FeeConfig {
                 fee_program: Pubkey::new_unique(),
                 fee_account: Pubkey::new_unique(),
-            }),
+            })
+            .into(),
         };
         let serialized = borsh::to_vec(&token).unwrap();
         assert_eq!(serialized.len(), token.size());
@@ -469,13 +416,12 @@ mod test {
     #[test]
     fn test_backward_compat_deserialize_without_fee_config() {
         // Serializing with fee_config: None omits the trailing field entirely,
-        // producing the same layout as a pre-upgrade account. Verify that
-        // read_optional_trailing handles EOF → None correctly.
+        // producing the same layout as a pre-upgrade account. Verify EOF → None.
         let token = HyperlaneToken::<()> {
             bump: 1,
             decimals: 9,
             remote_decimals: 18,
-            fee_config: None,
+            fee_config: None.into(),
             ..HyperlaneToken::<()>::default()
         };
         let serialized = borsh::to_vec(&token).unwrap();
@@ -497,7 +443,8 @@ mod test {
             fee_config: Some(FeeConfig {
                 fee_program: Pubkey::new_unique(),
                 fee_account: Pubkey::new_unique(),
-            }),
+            })
+            .into(),
             ..HyperlaneToken::<()>::default()
         };
 
@@ -507,4 +454,172 @@ mod test {
 
         assert_eq!(deserialized, token);
     }
+
+    // HLSVM-2026Q2-010 regression guards. `overlay_shrunk` reproduces a pre-#8698
+    // store after a router removal (freed tail left non-zero). Tabled over the
+    // three real plugin sizes since plugin_data sits between the map and fee_config.
+
+    /// Fixed-size stand-in for a concrete plugin; N is a real plugin's size
+    /// (Native=1, Synthetic=34, Collateral=98).
+    #[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq)]
+    struct FixedPlugin<const N: usize> {
+        data: [u8; N],
+    }
+
+    impl<const N: usize> Default for FixedPlugin<N> {
+        fn default() -> Self {
+            Self { data: [0u8; N] }
+        }
+    }
+
+    impl<const N: usize> SizedData for FixedPlugin<N> {
+        fn size(&self) -> usize {
+            N
+        }
+    }
+
+    fn token_with<const N: usize>(
+        routers: &[(u32, H256)],
+        plugin_byte: u8,
+        fee_config: Option<FeeConfig>,
+    ) -> HyperlaneToken<FixedPlugin<N>> {
+        HyperlaneToken {
+            bump: 1,
+            decimals: 9,
+            remote_decimals: 18,
+            remote_routers: routers.iter().copied().collect(),
+            plugin_data: FixedPlugin {
+                data: [plugin_byte; N],
+            },
+            fee_config: fee_config.into(),
+            ..Default::default()
+        }
+    }
+
+    fn overlay_shrunk(before: Vec<u8>, keep: Vec<u8>) -> Vec<u8> {
+        assert!(keep.len() < before.len());
+        let mut buf = before;
+        buf[..keep.len()].copy_from_slice(&keep);
+        buf
+    }
+
+    // Removed router + plugin both filled with the sentinel, so the byte past
+    // plugin_data is the sentinel regardless of which field it lands in.
+
+    /// Stale 0x02 tail must not reject the account.
+    fn assert_stale_router_tail_rejects<const N: usize>() {
+        let keep = borsh::to_vec(&token_with::<N>(&[(0, H256::zero())], 0x02, None)).unwrap();
+        let before = borsh::to_vec(&token_with::<N>(
+            &[(0, H256::zero()), (0x0202_0202, H256::from([0x02; 32]))],
+            0x02,
+            None,
+        ))
+        .unwrap();
+        let boundary = keep.len();
+        let buf = overlay_shrunk(before, keep);
+        assert_eq!(
+            buf[boundary], 0x02,
+            "N={N}: trigger byte should be the stale 0x02"
+        );
+
+        let decoded = HyperlaneToken::<FixedPlugin<N>>::deserialize_reader(&mut &buf[..])
+            .unwrap_or_else(|e| {
+                panic!("N={N}: stale router tail must not make the token unreadable: {e}")
+            });
+        assert_eq!(
+            decoded.fee_config, None,
+            "N={N}: stale bytes must not be read as fee_config",
+        );
+    }
+
+    /// Stale 0x01 tail must not be misread as Some.
+    fn assert_stale_router_tail_not_misread<const N: usize>() {
+        let keep = borsh::to_vec(&token_with::<N>(&[(0, H256::zero())], 0x01, None)).unwrap();
+        let before = borsh::to_vec(&token_with::<N>(
+            &[
+                (0, H256::zero()),
+                (0x0101_0101, H256::from([0x01; 32])),
+                (0x0101_0102, H256::from([0x01; 32])),
+            ],
+            0x01,
+            None,
+        ))
+        .unwrap();
+        let boundary = keep.len();
+        let buf = overlay_shrunk(before, keep);
+        assert_eq!(
+            buf[boundary], 0x01,
+            "N={N}: trigger byte should be the stale 0x01"
+        );
+
+        let decoded = HyperlaneToken::<FixedPlugin<N>>::deserialize_reader(&mut &buf[..]).unwrap();
+        assert_eq!(
+            decoded.fee_config, None,
+            "N={N}: stale 0x01 tail must not be misread as Some(FeeConfig)",
+        );
+    }
+
+    /// A genuine fee_config must survive stale router bytes trailing it.
+    fn assert_real_fee_config_survives<const N: usize>() {
+        let fee_config = FeeConfig {
+            fee_program: Pubkey::new_unique(),
+            fee_account: Pubkey::new_unique(),
+        };
+        let keep = borsh::to_vec(&token_with::<N>(
+            &[(0, H256::zero())],
+            0,
+            Some(fee_config.clone()),
+        ))
+        .unwrap();
+        let before = borsh::to_vec(&token_with::<N>(
+            &[(0, H256::zero()), (1, H256::from([9u8; 32]))],
+            0,
+            Some(fee_config.clone()),
+        ))
+        .unwrap();
+        let buf = overlay_shrunk(before, keep);
+
+        let decoded = HyperlaneToken::<FixedPlugin<N>>::deserialize_reader(&mut &buf[..]).unwrap();
+        assert_eq!(
+            decoded.fee_config,
+            Some(fee_config),
+            "N={N}: real fee_config must survive a stale remote_routers tail",
+        );
+    }
+
+    // Per-size tests (Native=1, Synthetic=34, Collateral=98) so each plugin size
+    // is validated independently rather than short-circuiting at the first.
+    macro_rules! stale_tail_tests {
+        ($size:literal => $rejects:ident, $not_misread:ident, $survives:ident) => {
+            #[test]
+            fn $rejects() {
+                assert_stale_router_tail_rejects::<$size>();
+            }
+
+            #[test]
+            fn $not_misread() {
+                assert_stale_router_tail_not_misread::<$size>();
+            }
+
+            #[test]
+            fn $survives() {
+                assert_real_fee_config_survives::<$size>();
+            }
+        };
+    }
+
+    stale_tail_tests!(1 =>
+        test_token_stale_router_tail_rejects_native,
+        test_token_stale_router_tail_not_misread_native,
+        test_token_real_fee_config_survives_native);
+
+    stale_tail_tests!(34 =>
+        test_token_stale_router_tail_rejects_synthetic,
+        test_token_stale_router_tail_not_misread_synthetic,
+        test_token_real_fee_config_survives_synthetic);
+
+    stale_tail_tests!(98 =>
+        test_token_stale_router_tail_rejects_collateral,
+        test_token_stale_router_tail_not_misread_collateral,
+        test_token_real_fee_config_survives_collateral);
 }

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -255,7 +255,7 @@ where
             remote_decimals: init.remote_decimals,
             remote_routers: HashMap::new(),
             plugin_data,
-            fee_config: None,
+            fee_config: None.into(),
         };
         let token_account_data = HyperlaneTokenAccount::<T>::from(token);
 
@@ -1325,7 +1325,7 @@ where
 
         ensure_no_extraneous_accounts(accounts_iter)?;
 
-        token.fee_config = fee_config;
+        token.fee_config = fee_config.into();
 
         // Store with realloc since fee_config may change the account size.
         HyperlaneTokenAccount::<T>::from(token).store_with_rent_exempt_realloc(

--- a/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
@@ -24,10 +24,11 @@ use access_control::AccessControl;
 use account_utils::{AccountData, DiscriminatorPrefixed, DiscriminatorPrefixedData};
 use hyperlane_sealevel_igp::{
     accounts::{
-        compute_gas_fee, GasOracle, GasPaymentAccount, GasPaymentData, Igp, IgpAccount,
-        IgpFeeConfig, IgpStandingQuote, IgpStandingQuoteAccount, IgpTransientQuote,
-        IgpTransientQuoteAccount, OverheadIgp, OverheadIgpAccount, ProgramData, ProgramDataAccount,
-        RemoteGasData, SOL_DECIMALS, TOKEN_EXCHANGE_RATE_SCALE, WILDCARD_DOMAIN, WILDCARD_SENDER,
+        compute_gas_fee, igp_quote_mode, GasOracle, GasPaymentAccount, GasPaymentData, Igp,
+        IgpAccount, IgpFeeConfig, IgpQuoteMode, IgpStandingQuote, IgpStandingQuoteAccount,
+        IgpTransientQuote, IgpTransientQuoteAccount, OverheadIgp, OverheadIgpAccount, ProgramData,
+        ProgramDataAccount, RemoteGasData, SOL_DECIMALS, TOKEN_EXCHANGE_RATE_SCALE,
+        WILDCARD_DOMAIN, WILDCARD_SENDER,
     },
     error::Error as IgpError,
     igp_gas_payment_pda_seeds, igp_pda_seeds, igp_program_data_pda_seeds,
@@ -318,7 +319,7 @@ async fn test_initialize_igp() {
                 owner,
                 beneficiary,
                 gas_oracles: HashMap::new(),
-                fee_config: None,
+                fee_config: None.into(),
             }
             .into()
         ),
@@ -524,6 +525,13 @@ async fn test_set_gas_oracle_configs() {
             remaining_config.domain,
             remaining_config.gas_oracle.unwrap(),
         )]),
+    );
+
+    // HLSVM-2026Q2-010: a real gas-oracle removal must leave fee_config absent.
+    assert_eq!(igp.fee_config, None);
+    assert_eq!(
+        igp_quote_mode(&igp_account.data).unwrap(),
+        IgpQuoteMode::Legacy,
     );
 }
 
@@ -1845,7 +1853,7 @@ async fn test_set_igp_quote_config_rejects_lower_min_issued_at() {
     .unwrap();
 
     let igp = fetch_igp(&mut banks_client, igp_key).await;
-    assert_eq!(igp.fee_config.unwrap().min_issued_at, 2000);
+    assert_eq!(igp.fee_config.as_ref().unwrap().min_issued_at, 2000);
 }
 
 #[tokio::test]
@@ -2019,7 +2027,7 @@ async fn test_add_igp_quote_signer() {
         .unwrap();
 
     let igp = fetch_igp(&mut banks_client, igp_key).await;
-    let signers = &igp.fee_config.unwrap().signers;
+    let signers = &igp.fee_config.as_ref().unwrap().signers;
     assert!(signers.contains(&signer_addr));
     assert_eq!(signers.len(), 1);
 }
@@ -2218,7 +2226,7 @@ async fn test_set_igp_min_issued_at() {
         .unwrap();
 
     let igp = fetch_igp(&mut banks_client, igp_key).await;
-    assert_eq!(igp.fee_config.unwrap().min_issued_at, 500);
+    assert_eq!(igp.fee_config.as_ref().unwrap().min_issued_at, 500);
 
     // Increase is allowed.
     let ix =
@@ -2228,7 +2236,7 @@ async fn test_set_igp_min_issued_at() {
         .unwrap();
 
     let igp = fetch_igp(&mut banks_client, igp_key).await;
-    assert_eq!(igp.fee_config.unwrap().min_issued_at, 1000);
+    assert_eq!(igp.fee_config.as_ref().unwrap().min_issued_at, 1000);
 }
 
 #[tokio::test]
@@ -2250,7 +2258,7 @@ async fn test_set_igp_min_issued_at_equal_allowed() {
         .unwrap();
 
     let igp = fetch_igp(&mut banks_client, igp_key).await;
-    assert_eq!(igp.fee_config.unwrap().min_issued_at, 500);
+    assert_eq!(igp.fee_config.as_ref().unwrap().min_issued_at, 500);
 }
 
 #[tokio::test]

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs
@@ -7,7 +7,7 @@ use std::{
 
 use access_control::AccessControl;
 use account_utils::{
-    read_optional_trailing, AccountData, DiscriminatorData, DiscriminatorPrefixed, SizedData,
+    AccountData, DiscriminatorData, DiscriminatorPrefixed, OptionalDiscriminatedData, SizedData,
     BORSH_LEN_PREFIX, H160_SIZE, H256_SIZE, PUBKEY_SIZE,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -172,11 +172,7 @@ impl DiscriminatorData for Igp {
 }
 
 /// IGP account data.
-/// `BorshSerialize` and `BorshDeserialize` are implemented manually to support
-/// backward-compatible (de)serialization of accounts created before `fee_config`
-/// was added. When `fee_config` is `None`, no trailing bytes are written so the
-/// serialized size matches the pre-upgrade layout exactly.
-#[derive(Debug, PartialEq, Default)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, PartialEq, Default)]
 pub struct Igp {
     /// The bump seed for the IGP PDA.
     pub bump_seed: u8,
@@ -190,43 +186,7 @@ pub struct Igp {
     pub gas_oracles: HashMap<u32, GasOracle>,
     /// Offchain quoting configuration. None = quoting disabled (oracle-only).
     /// Managed via SetIgpQuoteConfig. Trailing field for backward compat.
-    pub fee_config: Option<IgpFeeConfig>,
-}
-
-impl BorshSerialize for Igp {
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        self.bump_seed.serialize(writer)?;
-        self.salt.serialize(writer)?;
-        self.owner.serialize(writer)?;
-        self.beneficiary.serialize(writer)?;
-        self.gas_oracles.serialize(writer)?;
-        // Only write the Option tag + payload when Some; write nothing for None
-        // so the serialized size matches the pre-upgrade layout.
-        if let Some(cfg) = &self.fee_config {
-            1u8.serialize(writer)?;
-            cfg.serialize(writer)?;
-        }
-        Ok(())
-    }
-}
-
-impl BorshDeserialize for Igp {
-    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let bump_seed = u8::deserialize_reader(reader)?;
-        let salt = H256::deserialize_reader(reader)?;
-        let owner = Option::<Pubkey>::deserialize_reader(reader)?;
-        let beneficiary = Pubkey::deserialize_reader(reader)?;
-        let gas_oracles = HashMap::<u32, GasOracle>::deserialize_reader(reader)?;
-        let fee_config = read_optional_trailing::<_, IgpFeeConfig>(reader)?;
-        Ok(Self {
-            bump_seed,
-            salt,
-            owner,
-            beneficiary,
-            gas_oracles,
-            fee_config,
-        })
-    }
+    pub fee_config: OptionalDiscriminatedData<IgpFeeConfig>,
 }
 
 impl SizedData for Igp {
@@ -242,10 +202,8 @@ impl SizedData for Igp {
             + 32
             + 4
             + (self.gas_oracles.len() * (4 + 1 + 33))
-            + match &self.fee_config {
-                Some(cfg) => 1 + cfg.size(),
-                None => 0,
-            }
+            // fee_config: 0 when None, DISCRIMINATOR (8) + payload when Some.
+            + self.fee_config.size()
     }
 }
 
@@ -335,29 +293,21 @@ pub fn igp_quote_mode(data: &[u8]) -> Result<IgpQuoteMode, ProgramError> {
     }
     reader = &reader[skip..];
 
-    // No trailing bytes → fee_config is absent (pre-upgrade account).
-    if reader.is_empty() {
+    // Present only if the tail begins with the discriminator; any other tail
+    // (incl. stale pre-zero-fill bytes) is Legacy, never an error. Mirrors
+    // OptionalDiscriminatedData.
+    let discriminator_len = IgpFeeConfig::DISCRIMINATOR_LENGTH;
+    if reader.len() < discriminator_len
+        || reader[..discriminator_len] != IgpFeeConfig::DISCRIMINATOR
+    {
         return Ok(IgpQuoteMode::Legacy);
     }
 
-    // None tag (0) → fee_config explicitly set to None.
-    if reader[0] == 0 {
-        return Ok(IgpQuoteMode::Legacy);
-    }
-
-    // Some tag (1) → fee_config must deserialize successfully.
-    // Use deserialize_reader (not try_from_slice / try_from_reader) so any
-    // trailing bytes after a valid IgpFeeConfig — e.g. stale padding from a
-    // future shrink path — don't make this probe spuriously reject and block
-    // dispatch.
-    if reader[0] == 1 {
-        IgpFeeConfig::deserialize_reader(&mut &reader[1..])
-            .map_err(|_| ProgramError::InvalidAccountData)?;
-        return Ok(IgpQuoteMode::Quoted);
-    }
-
-    // Unexpected tag byte.
-    Err(ProgramError::InvalidAccountData)
+    // deserialize_reader (not try_from_slice) tolerates trailing bytes after a
+    // valid config, matching the full Igp read path.
+    IgpFeeConfig::deserialize_reader(&mut &reader[discriminator_len..])
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+    Ok(IgpQuoteMode::Quoted)
 }
 
 /// Remote gas data.
@@ -528,6 +478,10 @@ impl SizedData for IgpFeeConfig {
             + std::mem::size_of::<u32>()  // domain_id
             + std::mem::size_of::<i64>() // min_issued_at
     }
+}
+
+impl DiscriminatorData for IgpFeeConfig {
+    const DISCRIMINATOR: [u8; 8] = *b"IGPFEEV1";
 }
 
 // --- Standing quote PDA ---
@@ -822,7 +776,8 @@ mod test {
                 signers: BTreeSet::from([H160::random()]),
                 domain_id: 42,
                 min_issued_at: 1000,
-            }),
+            })
+            .into(),
         };
         let encoded = borsh::to_vec(&igp).unwrap();
         let decoded: Igp = borsh::from_slice(&encoded).unwrap();
@@ -837,7 +792,7 @@ mod test {
             owner: Some(Pubkey::new_unique()),
             beneficiary: Pubkey::new_unique(),
             gas_oracles: HashMap::new(),
-            fee_config: None,
+            fee_config: None.into(),
         };
         let encoded = borsh::to_vec(&igp).unwrap();
         let decoded: Igp = borsh::from_slice(&encoded).unwrap();
@@ -846,15 +801,15 @@ mod test {
 
     #[test]
     fn test_igp_backward_compat_deserialize_without_fee_config() {
-        // Custom BorshSerialize writes nothing for fee_config: None,
-        // producing the same byte layout as pre-upgrade accounts.
+        // fee_config: None writes no trailing bytes, producing the same byte
+        // layout as pre-upgrade accounts.
         let igp = Igp {
             bump_seed: 1,
             salt: H256::random(),
             owner: Some(Pubkey::new_unique()),
             beneficiary: Pubkey::new_unique(),
             gas_oracles: HashMap::new(),
-            fee_config: None,
+            fee_config: None.into(),
         };
         let encoded = borsh::to_vec(&igp).unwrap();
         // No trailing Option tag — matches old format exactly.
@@ -877,7 +832,8 @@ mod test {
                 signers: BTreeSet::from([H160::random(), H160::random()]),
                 domain_id: 42,
                 min_issued_at: 1000,
-            }),
+            })
+            .into(),
         };
         assert_eq!(igp.size(), borsh::to_vec(&igp).unwrap().len());
     }
@@ -890,7 +846,7 @@ mod test {
             owner: Some(Pubkey::new_unique()),
             beneficiary: Pubkey::new_unique(),
             gas_oracles: HashMap::new(),
-            fee_config: None,
+            fee_config: None.into(),
         };
         assert_eq!(igp.size(), borsh::to_vec(&igp).unwrap().len());
     }
@@ -906,7 +862,7 @@ mod test {
             owner: Some(Pubkey::new_unique()),
             beneficiary: Pubkey::new_unique(),
             gas_oracles,
-            fee_config: None,
+            fee_config: None.into(),
         };
         assert_eq!(igp.size(), borsh::to_vec(&igp).unwrap().len());
     }
@@ -1073,7 +1029,7 @@ mod test {
             owner: Some(Pubkey::new_unique()),
             beneficiary: Pubkey::new_unique(),
             gas_oracles: HashMap::new(),
-            fee_config,
+            fee_config: fee_config.into(),
         }
     }
 
@@ -1122,7 +1078,8 @@ mod test {
                 signers: BTreeSet::from([H160::random()]),
                 domain_id: 42,
                 min_issued_at: 1000,
-            }),
+            })
+            .into(),
         };
         let data = make_igp_account_data(igp);
         assert_eq!(igp_quote_mode(&data).unwrap(), IgpQuoteMode::Quoted);
@@ -1131,10 +1088,10 @@ mod test {
     #[test]
     fn test_igp_quote_mode_garbage_trailing_bytes() {
         let mut data = make_igp_account_data(default_igp(None));
-        // Append garbage with Some tag — should error, not return Legacy.
-        data.push(1); // Some tag
-        data.extend_from_slice(&[0xFF; 5]); // invalid IgpFeeConfig
-        assert!(igp_quote_mode(&data).is_err());
+        // Trailing bytes that don't begin with IgpFeeConfig::DISCRIMINATOR are
+        // stale/absent, not a present config: classified Legacy, never an error.
+        data.extend_from_slice(&[0xFF; 16]);
+        assert_eq!(igp_quote_mode(&data).unwrap(), IgpQuoteMode::Legacy);
     }
 
     #[test]
@@ -1156,5 +1113,127 @@ mod test {
     fn test_igp_quote_mode_truncated_data() {
         assert!(igp_quote_mode(&[]).is_err());
         assert!(igp_quote_mode(&[0u8; 50]).is_err());
+    }
+
+    // HLSVM-2026Q2-010 regression guards: a stale gas_oracles tail must not create
+    // a false fee_config (`*_stale_oracle_tail_*`), and a genuine fee_config must
+    // survive stale trailing bytes (`*_real_fee_config_*`).
+
+    fn igp_with(domains: &[u32], fee_config: Option<IgpFeeConfig>) -> Igp {
+        let mut gas_oracles = HashMap::new();
+        for &domain in domains {
+            gas_oracles.insert(
+                domain,
+                GasOracle::RemoteGasData(RemoteGasData {
+                    token_exchange_rate: 1_000_000_000,
+                    gas_price: 50_000_000_000,
+                    token_decimals: 18,
+                }),
+            );
+        }
+        Igp {
+            bump_seed: 1,
+            salt: H256::zero(),
+            owner: Some(Pubkey::new_from_array([7u8; 32])),
+            beneficiary: Pubkey::new_from_array([9u8; 32]),
+            gas_oracles,
+            fee_config: fee_config.into(),
+        }
+    }
+
+    // Overlays `keep` (post-shrink) onto `before` (pre-shrink) — a pre-#8698 store
+    // that left the removed entry's bytes as a stale tail. borsh sorts the map by
+    // key, so a removed domain > 0 lands at the tail boundary.
+    fn overlay_shrunk(before: Vec<u8>, keep: Vec<u8>) -> Vec<u8> {
+        assert!(keep.len() < before.len());
+        let mut buf = before;
+        buf[..keep.len()].copy_from_slice(&keep);
+        buf
+    }
+
+    /// Stale 0x02 tail must not reject the account.
+    #[test]
+    fn test_igp_stale_oracle_tail_does_not_reject_account() {
+        let buf = overlay_shrunk(
+            borsh::to_vec(&igp_with(&[0, 0xFF02], None)).unwrap(),
+            borsh::to_vec(&igp_with(&[0], None)).unwrap(),
+        );
+        let decoded = Igp::deserialize_reader(&mut &buf[..])
+            .expect("stale removed-oracle tail must not make a legacy IGP unreadable");
+        assert_eq!(
+            decoded.fee_config, None,
+            "stale bytes must not be read as fee_config",
+        );
+    }
+
+    /// Stale 0x01 tail that decodes as a plausible IgpFeeConfig must not be read
+    /// as Some.
+    #[test]
+    fn test_igp_stale_oracle_tail_not_misread_as_fee_config() {
+        let buf = overlay_shrunk(
+            borsh::to_vec(&igp_with(&[0, 1], None)).unwrap(),
+            borsh::to_vec(&igp_with(&[0], None)).unwrap(),
+        );
+        let decoded = Igp::deserialize_reader(&mut &buf[..]).unwrap();
+        assert_eq!(
+            decoded.fee_config, None,
+            "stale tail starting with 0x01 must not be misread as Some(IgpFeeConfig)",
+        );
+    }
+
+    /// Dispatch-path probe must not reject on a 0x02 stale tail.
+    #[test]
+    fn test_igp_quote_mode_stale_oracle_tail_stays_legacy() {
+        let data = overlay_shrunk(
+            make_igp_account_data(igp_with(&[0, 0xFF02], None)),
+            make_igp_account_data(igp_with(&[0], None)),
+        );
+        assert_eq!(igp_quote_mode(&data).unwrap(), IgpQuoteMode::Legacy);
+    }
+
+    /// Dispatch-path probe must not classify a legacy IGP as Quoted on a 0x01
+    /// stale tail.
+    #[test]
+    fn test_igp_quote_mode_stale_oracle_tail_not_false_quoted() {
+        let data = overlay_shrunk(
+            make_igp_account_data(igp_with(&[0, 1], None)),
+            make_igp_account_data(igp_with(&[0], None)),
+        );
+        assert_eq!(igp_quote_mode(&data).unwrap(), IgpQuoteMode::Legacy);
+    }
+
+    /// A genuine fee_config must survive stale oracle bytes trailing after it.
+    #[test]
+    fn test_igp_real_fee_config_survives_stale_map_tail() {
+        let fee_config = IgpFeeConfig {
+            signers: BTreeSet::from([H160::random()]),
+            domain_id: 42,
+            min_issued_at: 1000,
+        };
+        let buf = overlay_shrunk(
+            borsh::to_vec(&igp_with(&[0, 0xFF02], Some(fee_config.clone()))).unwrap(),
+            borsh::to_vec(&igp_with(&[0], Some(fee_config.clone()))).unwrap(),
+        );
+        let decoded = Igp::deserialize_reader(&mut &buf[..]).unwrap();
+        assert_eq!(
+            decoded.fee_config,
+            Some(fee_config),
+            "real quote settings must survive a stale gas_oracles tail",
+        );
+    }
+
+    /// Dispatch-path probe reports Quoted for a genuine fee_config behind a tail.
+    #[test]
+    fn test_igp_quote_mode_real_fee_config_with_stale_map_tail() {
+        let fee_config = IgpFeeConfig {
+            signers: BTreeSet::from([H160::random()]),
+            domain_id: 42,
+            min_issued_at: 1000,
+        };
+        let data = overlay_shrunk(
+            make_igp_account_data(igp_with(&[0, 0xFF02], Some(fee_config.clone()))),
+            make_igp_account_data(igp_with(&[0], Some(fee_config))),
+        );
+        assert_eq!(igp_quote_mode(&data).unwrap(), IgpQuoteMode::Quoted);
     }
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -199,7 +199,7 @@ fn init_igp(program_id: &Pubkey, accounts: &[AccountInfo], data: InitIgp) -> Pro
                 owner: data.owner,
                 beneficiary: data.beneficiary,
                 gas_oracles: HashMap::new(),
-                fee_config: None,
+                fee_config: None.into(),
             }
             .into()
         },
@@ -968,13 +968,13 @@ fn set_igp_quote_config(
 
     // min_issued_at must not move backward when overwriting an existing config,
     // mirroring the SetIgpMinIssuedAt monotonic guarantee.
-    if let (Some(existing), Some(new_config)) = (&igp.fee_config, &config) {
+    if let (Some(existing), Some(new_config)) = (igp.fee_config.as_ref(), config.as_ref()) {
         if new_config.min_issued_at < existing.min_issued_at {
             return Err(ProgramError::InvalidArgument);
         }
     }
 
-    igp.fee_config = config;
+    igp.fee_config = config.into();
 
     let igp_account = IgpAccount::new(igp.into());
     igp_account.store_with_rent_exempt_realloc(

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
@@ -522,7 +522,7 @@ async fn test_initialize() {
                 escrow_bump: hyperlane_token_accounts.escrow_bump,
                 ata_payer_bump: hyperlane_token_accounts.ata_payer_bump,
             },
-            fee_config: None,
+            fee_config: None.into(),
         }),
     );
 

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
@@ -288,7 +288,7 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], init: Init) -> Prog
         remote_decimals: init.remote_decimals,
         remote_routers: HashMap::new(),
         plugin_data,
-        fee_config: None,
+        fee_config: None.into(),
     };
     let hyperlane_token_account_data =
         HyperlaneTokenAccount::<CollateralPlugin>::from(hyperlane_token);

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
@@ -685,7 +685,7 @@ mod init_instruction {
                     escrow_bump: ctx.cc.escrow_bump,
                     ata_payer_bump: ctx.cc.ata_payer_bump,
                 },
-                fee_config: None,
+                fee_config: None.into(),
             }),
         );
 

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
@@ -360,7 +360,7 @@ async fn test_initialize() {
             plugin_data: NativePlugin {
                 native_collateral_bump: hyperlane_token_accounts.native_collateral_bump,
             },
-            fee_config: None,
+            fee_config: None.into(),
         }),
     );
 

--- a/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
@@ -394,7 +394,7 @@ async fn test_initialize() {
                 mint_bump: hyperlane_token_accounts.mint_bump,
                 ata_payer_bump: hyperlane_token_accounts.ata_payer_bump,
             },
-            fee_config: None,
+            fee_config: None.into(),
         }),
     );
 
@@ -935,6 +935,67 @@ async fn test_enroll_remote_router() {
         token.remote_routers,
         vec![(REMOTE_DOMAIN, remote_router)].into_iter().collect(),
     );
+}
+
+#[tokio::test]
+async fn test_remote_router_removal_keeps_fee_config_absent() {
+    // HLSVM-2026Q2-010: a real remote-router removal must leave fee_config absent.
+    let program_id = hyperlane_sealevel_token_id();
+    let (mut banks_client, payer) = setup_client().await;
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
+            .await
+            .unwrap();
+
+    // Enroll two routers, then unenroll one (router: None) — the real shrink path.
+    for domain in [REMOTE_DOMAIN, REMOTE_DOMAIN + 1] {
+        enroll_remote_router(
+            &mut banks_client,
+            &program_id,
+            &payer,
+            &hyperlane_token_accounts.token,
+            domain,
+            H256::random(),
+        )
+        .await
+        .unwrap();
+    }
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let transaction = Transaction::new_signed_with_payer(
+        &[Instruction::new_with_bytes(
+            program_id,
+            &HyperlaneTokenInstruction::EnrollRemoteRouter(RemoteRouterConfig {
+                domain: REMOTE_DOMAIN + 1,
+                router: None,
+            })
+            .encode()
+            .unwrap(),
+            vec![
+                AccountMeta::new_readonly(system_program::ID, false),
+                AccountMeta::new(hyperlane_token_accounts.token, false),
+                AccountMeta::new_readonly(payer.pubkey(), true),
+            ],
+        )],
+        Some(&payer.pubkey()),
+        &[&payer],
+        recent_blockhash,
+    );
+    banks_client.process_transaction(transaction).await.unwrap();
+
+    let token_account_data = banks_client
+        .get_account(hyperlane_token_accounts.token)
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    let token = HyperlaneTokenAccount::<SyntheticPlugin>::fetch(&mut &token_account_data[..])
+        .unwrap()
+        .into_inner();
+    assert_eq!(token.remote_routers.len(), 1);
+    assert!(token.remote_routers.contains_key(&REMOTE_DOMAIN));
+    assert_eq!(token.fee_config, None);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Description

Fixes **HLSVM-2026Q2-010**: a stale-trailing-byte misread on the optional `fee_config` field of the `Igp` and `HyperlaneToken` accounts.

The trailing `fee_config` was serialized as a bare single-byte `Option` tag. When an account had been over-allocated and later shrunk (e.g. a pre-zero-fill gas-oracle/router resize), stale bytes left in the tail could be misread as a present `fee_config` — either rejecting the account (liveness break) or fabricating a bogus config.

The fix replaces the single-byte `Option` tag with `OptionalDiscriminatedData<T>`, a reusable `account-utils` wrapper (sibling of `DiscriminatorPrefixed<T>`, built on the existing `DiscriminatorData` trait). A present value is prefixed with the type's 8-byte `DISCRIMINATOR`; any non-matching, short, or EOF tail is read as `None`. This makes the field self-describing, so stale bytes can no longer be mistaken for a valid config.

Changed:
- `account-utils`: new `OptionalDiscriminatedData<T>` wrapper + unit tests (`discriminator.rs`).
- `hyperlane-sealevel-igp` and `hyperlane-sealevel-token`: trailing `fee_config` now uses the wrapper (`accounts.rs`, `processor.rs`).

### Drive-by changes

- Minor signature/touch-ups in the token-variant processors and functional tests to match the new accessor.

### Related issues

Fixes [HLSVM-2026Q2-010](https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/13) (Q2 2026 Chainlight SVM audit).

### Backward compatibility

Wire format of the trailing `fee_config` field changes (8-byte discriminator prefix instead of a 1-byte `Option` tag). This is safe within the audited SVM feature set — the `fee_config` field itself is new on this branch and not yet deployed — but any account already written with the old single-byte tag would need migration. No impact on existing released accounts, since the field did not exist before.

### Testing

Unit + functional tests:
- Wrapper unit tests for `OptionalDiscriminatedData<T>`.
- IGP/token byte-overlay regression tests across all plugin sizes (stale-tail → `None`).
- Real-shrink functional tests reproducing the over-allocated-then-shrunk account scenario.
