### PR TITLE
fix(sealevel): HLSVM-2026Q2-009

### DIFF
--- a/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
@@ -2892,6 +2892,47 @@ async fn test_submit_transient_quote() {
 }
 
 #[tokio::test]
+async fn test_submit_transient_quote_allows_fully_wildcarded() {
+    // Fully-wildcarded transient quotes are payer-scoped and consumed once, so allowed.
+    let (mut banks_client, payer) = setup_client().await;
+    let (igp_key, signing_key) = setup_igp_with_signer(&mut banks_client, &payer).await;
+
+    let exchange_rate = 2_000_000_000_000_000_000u128;
+    let gas_price = 50_000_000_000u128;
+    let token_decimals = 18u8;
+
+    let context = encode_igp_context(&Pubkey::default(), WILDCARD_DOMAIN, &WILDCARD_SENDER);
+    let data = encode_igp_data(exchange_rate, gas_price, token_decimals);
+
+    let (quote, quote_pda) = make_transient_igp_quote(
+        &signing_key,
+        &igp_key,
+        IGP_DOMAIN_ID,
+        &payer.pubkey(),
+        context,
+        data,
+        100,
+    );
+
+    let ix =
+        submit_igp_quote_instruction(igp_program_id(), payer.pubkey(), igp_key, quote_pda, quote)
+            .unwrap();
+    process_instruction(&mut banks_client, ix, &payer, &[&payer])
+        .await
+        .unwrap();
+
+    let account = banks_client.get_account(quote_pda).await.unwrap().unwrap();
+    let transient = fetch_transient_quote(&account.data);
+    assert_eq!(transient.payer, payer.pubkey());
+    assert_eq!(transient.destination_domain, WILDCARD_DOMAIN);
+    assert_eq!(transient.sender, WILDCARD_SENDER);
+    assert_eq!(transient.token_exchange_rate, exchange_rate);
+    assert_eq!(transient.gas_price, gas_price);
+    assert_eq!(transient.token_decimals, token_decimals);
+    assert_eq!(transient.expiry, 100);
+}
+
+#[tokio::test]
 async fn test_submit_transient_quote_rejects_reuse_by_different_payer() {
     let (mut banks_client, payer) = setup_client().await;
     let (igp_key, signing_key) = setup_igp_with_signer(&mut banks_client, &payer).await;

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -1165,11 +1165,6 @@ fn submit_igp_quote(
 
     // --- Business logic ---
 
-    // Reject fully-wildcarded.
-    if ctx.destination_domain == WILDCARD_DOMAIN && ctx.sender == WILDCARD_SENDER {
-        return Err(QuoteValidationError::FullyWildcardedQuote.into());
-    }
-
     ensure_no_extraneous_accounts(accounts_iter)?;
 
     if quote.is_transient() {
@@ -1222,6 +1217,13 @@ fn submit_igp_quote(
         }
     } else {
         // --- Standing path ---
+
+        // Reject fully-wildcarded standing quotes (shared across payers, would
+        // override the cascade). Transient quotes are payer-scoped, so allowed.
+        if ctx.destination_domain == WILDCARD_DOMAIN && ctx.sender == WILDCARD_SENDER {
+            return Err(QuoteValidationError::FullyWildcardedQuote.into());
+        }
+
         let dest_domain_le = ctx.destination_domain.to_le_bytes();
         let (expected_pda, pda_bump) = Pubkey::find_program_address(
             igp_standing_quote_pda_seeds!(

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
@@ -2955,8 +2955,12 @@ async fn test_transfer_remote_igp_new_flow_standing_native() {
 
 /// IGP new flow with transient quote on native token, no fees.
 /// Isolates whether the IGP transient autoclose works with native SOL transfers.
-#[tokio::test]
-async fn test_transfer_remote_igp_new_flow_transient_native() {
+/// Parameterized by the quote's context (domain, sender) so the same flow covers
+/// both an exact-match quote and a fully-wildcarded one.
+async fn run_transfer_remote_igp_new_flow_transient_native(
+    quote_context_domain: u32,
+    quote_context_sender: Pubkey,
+) {
     let program_id = hyperlane_sealevel_token_native_id();
     let mailbox_program_id = mailbox_id();
     let (mut banks_client, payer) = setup_client().await;
@@ -3009,7 +3013,11 @@ async fn test_transfer_remote_igp_new_flow_transient_native() {
 
     let igp_exchange_rate = 2 * TOKEN_EXCHANGE_RATE_SCALE;
     let igp_gas_price: u128 = 5;
-    let igp_context = encode_igp_context(&Pubkey::default(), REMOTE_DOMAIN, &program_id);
+    let igp_context = encode_igp_context(
+        &Pubkey::default(),
+        quote_context_domain,
+        &quote_context_sender,
+    );
     let igp_data_bytes = encode_igp_data(igp_exchange_rate, igp_gas_price, 9);
 
     let mut igp_quote = SvmSignedQuote {
@@ -3132,6 +3140,22 @@ async fn test_transfer_remote_igp_new_flow_transient_native() {
         igp_transient_account.is_none() || igp_transient_account.unwrap().data.is_empty(),
         "IGP transient PDA should be closed"
     );
+}
+
+#[tokio::test]
+async fn test_transfer_remote_igp_new_flow_transient_native() {
+    // Exact-match transient quote (context sender = the token program).
+    run_transfer_remote_igp_new_flow_transient_native(
+        REMOTE_DOMAIN,
+        hyperlane_sealevel_token_native_id(),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_transfer_remote_igp_new_flow_transient_native_fully_wildcarded() {
+    // Fully-wildcarded transient quote is resolved, priced, and autoclosed end-to-end.
+    run_transfer_remote_igp_new_flow_transient_native(IGP_WILDCARD_DOMAIN, WILDCARD_SENDER).await;
 }
 
 /// Fully transient: both fee program AND IGP use transient quotes on native.


### PR DESCRIPTION
### Description

Fixes audit finding **HLSVM-2026Q2-009**: `submit_igp_quote` rejected fully-wildcarded transient quotes, diverging from both the EVM `OffchainQuotedIGP` and the Sealevel fee program.

The fully-wildcarded rejection (`destination_domain == WILDCARD_DOMAIN && sender == WILDCARD_SENDER`) ran *before* the transient/standing dispatch, so it incorrectly applied to transient quotes too. The justification for rejecting fully-wildcarded quotes only holds for **standing** quotes — they are shared across all payers and reused until expiry, so a `(WILDCARD_DOMAIN, WILDCARD_SENDER)` standing quote would be a global catch-all overriding the cascade. **Transient** quotes are payer-scoped via the scoped salt and consumed once, so a fully-wildcarded transient affects only that payer's single gas payment.

This PR moves the rejection into the standing branch only, matching the Sealevel fee program (`hyperlane-sealevel-fee/src/processor/submit.rs`) and the EVM IGP.

### Drive-by changes

- Strengthened the IGP submission unit test to assert all stored transient fields (payer, exchange rate, gas price, decimals, expiry) instead of just domain/sender.
- Parameterized the existing native-token IGP transient E2E (`test_transfer_remote_igp_new_flow_transient_native`) by the quote's context `(domain, sender)` into a shared helper, and added a fully-wildcarded variant that drives the full `transfer_remote` → `PayForGas` CPI path to prove a wildcarded transient is resolved, priced from the quote, and autoclosed.

### Related issues

- Fixes [HLSVM-2026Q2-009](https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/12)

### Backward compatibility

Yes. The change only relaxes a restriction (no storage-layout or interface changes): previously-valid submissions remain valid, and fully-wildcarded **standing** quotes are still rejected. It only additionally accepts fully-wildcarded **transient** quotes that were previously rejected. Takes effect on the next IGP program upgrade.

### Testing

Unit Tests — full suites of the impacted packages pass (143 tests, 0 failures):
- `hyperlane-sealevel-igp` — 29
- `hyperlane-sealevel-igp-test` — 80 (incl. `test_submit_transient_quote_allows_fully_wildcarded`)
- `hyperlane-sealevel-token-native` — 34 (incl. new `test_transfer_remote_igp_new_flow_transient_native_fully_wildcarded`)
