### PR TITLE
fix(sealevel): HLSVM-2026Q2-001

### DIFF
--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/error.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/error.rs
@@ -17,6 +17,11 @@ pub enum Error {
     /// The CC dispatch authority PDA is invalid.
     #[error("Invalid dispatch authority")]
     InvalidDispatchAuthority = 1001,
+
+    /// A mailbox-delivered message claims the local domain as its origin.
+    /// fnv1a("Error::SameDomainViaMailbox")
+    #[error("Same-domain delivery via mailbox not allowed")]
+    SameDomainViaMailbox = 3618916391,
 }
 
 impl From<Error> for ProgramError {

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
@@ -732,6 +732,11 @@ fn transfer_from_remote_cc(
     // Verify mailbox process authority is a valid signer
     hyperlane_token.ensure_mailbox_process_authority_signer(process_authority_account)?;
 
+    // Same-domain releases must use the same-chain CPI path, not the mailbox.
+    if xfer.origin == cc_state.local_domain {
+        return Err(CcError::SameDomainViaMailbox.into());
+    }
+
     // Dual-router validation: check both CC enrolled routers and base remote routers
     if !cc_state.is_authorized_router(xfer.origin, &xfer.sender, &hyperlane_token.remote_routers) {
         return Err(CcError::UnauthorizedRouter.into());
@@ -884,8 +889,8 @@ fn handle_local(
     // unvalidated sender field (which would allow spoofing).
     let sender = H256::from(handle.sender_program_id.to_bytes());
 
-    // Validate sender is an authorized router (CC enrolled or base remote routers)
-    if !cc_state.is_authorized_router(cc_state.local_domain, &sender, &token.remote_routers) {
+    // Same-chain release is restricted to CC-enrolled routers.
+    if !cc_state.is_enrolled_router(cc_state.local_domain, &sender) {
         return Err(CcError::UnauthorizedRouter.into());
     }
 

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
@@ -2029,6 +2029,57 @@ mod handle_instruction {
             TransactionError::InstructionError(0, InstructionError::Custom(1000)),
         );
     }
+
+    #[tokio::test]
+    async fn test_handle_from_mailbox_rejects_local_origin() {
+        let mut ctx = TestContext::new(false).await;
+        let escrow = ctx.cc.escrow;
+        let ata_payer = ctx.cc.ata_payer;
+        ctx.fund_escrow_and_ata_payer(escrow, ata_payer, 100 * 10u64.pow(LOCAL_DECIMALS_U32))
+            .await;
+
+        // Enroll the sender as a CC router for the local domain, so the only
+        // thing rejecting the message is the same-domain guard.
+        let cc_router = H256::random();
+        set_cc_routers(
+            &mut ctx.banks_client,
+            &ctx.program_id,
+            &ctx.payer,
+            vec![CrossCollateralRouterUpdate::Add {
+                domain: LOCAL_DOMAIN,
+                router: cc_router,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let recipient_pubkey = Pubkey::new_unique();
+        let recipient: H256 = recipient_pubkey.to_bytes().into();
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce: 0,
+            origin: LOCAL_DOMAIN,
+            sender: cc_router,
+            destination: LOCAL_DOMAIN,
+            recipient: ctx.program_id.to_bytes().into(),
+            body: TokenMessage::new(recipient, 1000u64.into(), vec![]).to_vec(),
+        };
+
+        let result = process(
+            &mut ctx.banks_client,
+            &ctx.payer,
+            &ctx.mailbox_accounts,
+            vec![],
+            &message,
+        )
+        .await;
+
+        // Custom(3618916391) = CcError::SameDomainViaMailbox
+        assert_transaction_error(
+            result,
+            TransactionError::InstructionError(0, InstructionError::Custom(3618916391)),
+        );
+    }
 }
 
 mod handle_local_instruction {
@@ -2253,9 +2304,9 @@ mod handle_local_instruction {
     }
 
     #[tokio::test]
-    async fn test_handle_local_accepts_base_remote_router() {
-        // Base remote router enrollment also authorizes HandleLocal via
-        // is_authorized_router (checks both CC enrolled and base routers).
+    async fn test_handle_local_rejects_base_remote_router() {
+        // Same-chain HandleLocal authorizes CC-enrolled routers only; a base
+        // remote router enrolled for the local domain is rejected.
         let mut ctx = TestContext::new(false).await;
         let program_b = second_cc_program_id();
         let cc_b = ctx.init_second_cc_token().await;
@@ -2353,8 +2404,10 @@ mod handle_local_instruction {
         );
         let result = ctx.banks_client.process_transaction(transaction).await;
 
-        // Should succeed — is_authorized_router accepts base remote routers too
-        result.unwrap();
+        assert_transaction_error(
+            result,
+            TransactionError::InstructionError(0, InstructionError::Custom(1000)),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

Restricts cross-collateral same-domain collateral release to CC-enrolled routers, aligning the Sealevel CC token program with the EVM `CrossCollateralRouter`. Previously both receive paths authorized via `is_authorized_router`, which accepts CC-enrolled routers **or** base remote routers — a broader authorized set than EVM, which gates same-domain release to CC-enrolled routers only.

- `handle_local` now authorizes via `is_enrolled_router(local_domain, &sender)` instead of `is_authorized_router`, dropping the base remote-router branch on the same-chain CPI path (mirrors EVM's CC-enrolled-only same-chain branch).
- `transfer_from_remote_cc` now rejects `xfer.origin == cc_state.local_domain` before authorization (mirrors EVM's `"CCR: same-domain via mailbox not allowed"` guard).
- New error `Error::SameDomainViaMailbox = 3618916391` (`fnv1a("Error::SameDomainViaMailbox")`, following the codebase's hash-discriminant convention).

Router *enrollment* stays permissive, matching EVM: base `_enrollRemoteRouter` (Router.sol) and `enrollCrossCollateralRouters` (CrossCollateralRouter.sol) both allow local-domain entries, so no enrollment-side guard was added. The divergence is closed only at the authorization sites, exactly where EVM enforces it.

### Drive-by changes

None.

### Related issues

- Fixes [HLSVM-2026Q2-001](https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/2) (Chainlight SVM audit, Q2 2026)

### Backward compatibility

Yes. No storage layout, instruction format, or account-layout changes; the error enum only gains a variant (existing `1000`/`1001` discriminants untouched). Both edits strictly tighten authorization — legitimate same-chain CC transfers already enroll the local CC router, and genuine cross-chain messages have `origin != local_domain`, so no valid flow is affected.

### Testing

Unit Tests — `cargo test -p hyperlane-sealevel-token-cross-collateral` (62 passed). Flipped `test_handle_local_accepts_base_remote_router` → `test_handle_local_rejects_base_remote_router` (asserts `UnauthorizedRouter`), and added `test_handle_from_mailbox_rejects_local_origin` (enrolls the sender as a CC router for the local domain so only the new same-domain guard rejects it). `cargo clippy --all-targets` and `cargo fmt` clean.
