### PR TITLE
feat(infra): add eni to tron connected chains

### DIFF
--- a/typescript/infra/config/environments/mainnet3/tron.ts
+++ b/typescript/infra/config/environments/mainnet3/tron.ts
@@ -44,6 +44,7 @@ export const TRON_CONNECTED_CHAINS = [
   'hyperevm',
   'mantle',
   'blast',
+  'eni',
 ];
 
 export function getTronIgpConfig(


### PR DESCRIPTION
## Summary
- Adds `eni` (domain 173) to `TRON_CONNECTED_CHAINS` in mainnet3 tron config.
- This drives the Tron core default ISM routing module and the Tron IGP to include an eni entry.

## Context
Tron was extended without enrolling eni in the Tron default ISM. The eni→tron USDT message `0x1f7321fbb2bb7aa72bba7eded18b4941fd833b915b3c3fb0eaead9a4613a9d4e` was stuck: the Tron default ISM is a 2-of-2 aggregation over [pausable/NULL, routing], and the routing sub-module had no eni route, so the relayer hit `AggregationThresholdNotMet(2)`. The governance tx enrolling eni is being posted separately via `check-deploy --govern`; this PR aligns the source config so the diff closes.

## Test plan
- [x] CI config checks pass
- [ ] `check-deploy --module core --chains tron --govern` shows no remaining eni diff after governance tx executes