### PR TITLE
fix(sdk): retry assertCodeExists to tolerate RPC lag

### DIFF
--- a/.changeset/proxy-assert-code-retry.md
+++ b/.changeset/proxy-assert-code-retry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+assertCodeExists now retries getCode with backoff to tolerate RPC lag where a just-confirmed contract is not yet visible across all nodes in a load-balanced pool.

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import { Provider as ZKSyncProvider } from 'zksync-ethers';
 
 import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
-import { Address, ChainId, eqAddress } from '@hyperlane-xyz/utils';
+import { Address, ChainId, eqAddress, retryAsync } from '@hyperlane-xyz/utils';
 
 import { transferOwnershipTransactions } from '../contracts/contracts.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
@@ -36,10 +36,18 @@ async function assertCodeExists(
   provider: EthersLikeProvider,
   contract: Address,
 ): Promise<void> {
-  const code = await provider.getCode(contract);
-  if (code === '0x') {
-    throw new Error(`Contract at ${contract} has no code`);
-  }
+  // Retry to handle RPC lag where a just-confirmed tx isn't yet visible on
+  // all nodes in a load-balanced pool.
+  await retryAsync(
+    async () => {
+      const code = await provider.getCode(contract);
+      if (code === '0x') {
+        throw new Error(`Contract at ${contract} has no code`);
+      }
+    },
+    5,
+    2000,
+  );
 }
 
 export async function proxyImplementation(


### PR DESCRIPTION
## Summary
- Wrap the `getCode` check in `assertCodeExists` (`typescript/sdk/src/deploy/proxy.ts`) with `retryAsync` (5 attempts, 2000ms base backoff) so a just-confirmed contract that isn't yet visible on every node in a load-balanced RPC pool doesn't produce a spurious "has no code" failure.
- Added a changeset (`@hyperlane-xyz/sdk` patch).

## Test plan
- [ ] CI lint/format/build passes
- [ ] Existing proxy.ts consumers (`proxyImplementation`, `isInitialized`, `proxyAdmin`) behave unchanged on healthy RPCs