### PR TITLE
fix(sealevel): HLSVM-2026Q2-008

### DIFF
--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -18,6 +18,7 @@ use hyperlane_sealevel_fee::{
 };
 use hyperlane_sealevel_igp::{
     accounts::{igp_quote_mode, IgpQuoteMode, InterchainGasPaymasterType},
+    igp_quote_authority_pda_seeds,
     instruction::{Instruction as IgpInstruction, PayForGas as IgpPayForGas},
 };
 use hyperlane_sealevel_mailbox::{
@@ -49,10 +50,12 @@ enum IgpPaymentAccounts<'b> {
         account_metas: Vec<AccountMeta>,
         account_infos: Vec<AccountInfo<'b>>,
     },
-    /// New flow: offchain quote pricing, `invoke_signed` with dispatch_authority PDA.
+    /// New flow: offchain quote pricing, `invoke_signed` with the IGP quote authority PDA.
     Quoted {
         account_metas: Vec<AccountMeta>,
         account_infos: Vec<AccountInfo<'b>>,
+        /// Canonical bump for the route's IGP quote authority, reused at the CPI.
+        igp_quote_authority_bump: u8,
     },
 }
 
@@ -561,10 +564,31 @@ where
 
             // Determine quoting mode from the IGP account's on-chain state.
             let quote_mode = igp_quote_mode(&igp_account_info.data.borrow())?;
-            match quote_mode {
+            let is_overhead_igp =
+                matches!(igp_account_type, InterchainGasPaymasterType::OverheadIgp(_));
+
+            // Account [N+3]: OverheadIgp appends the configured IGP again at the end.
+            let append_overhead_igp =
+                |metas: &mut Vec<AccountMeta>, infos: &mut Vec<AccountInfo<'b>>| {
+                    if is_overhead_igp {
+                        metas.push(AccountMeta::new_readonly(
+                            *configured_igp_account.key,
+                            false,
+                        ));
+                        infos.push(configured_igp_account.clone());
+                    }
+                };
+
+            Some(match quote_mode {
                 IgpQuoteMode::Quoted => {
-                    // Account [5]: sender_authority (dispatch_authority PDA, signed via invoke_signed).
+                    // Account [5]: sender_authority — must be this route's IGP quote authority.
+                    // Derive once here; the bump is reused to sign the PayForGas CPI.
+                    let (igp_quote_authority_key, igp_quote_authority_bump) =
+                        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), program_id);
                     if let Some(sender_authority) = pre_igp_accounts.get_mut(0) {
+                        if *sender_authority.0.key != igp_quote_authority_key {
+                            return Err(ProgramError::InvalidArgument);
+                        }
                         sender_authority.1 =
                             AccountMeta::new_readonly(*sender_authority.0.key, true);
                     } else {
@@ -586,33 +610,34 @@ where
                         igp_payment_account_infos.push(info);
                         igp_payment_account_metas.push(meta);
                     }
+
+                    append_overhead_igp(
+                        &mut igp_payment_account_metas,
+                        &mut igp_payment_account_infos,
+                    );
+
+                    IgpPaymentAccounts::Quoted {
+                        account_metas: igp_payment_account_metas,
+                        account_infos: igp_payment_account_infos,
+                        igp_quote_authority_bump,
+                    }
                 }
                 IgpQuoteMode::Legacy => {
                     // Legacy: no pre-IGP accounts expected.
                     if !pre_igp_accounts.is_empty() {
                         return Err(ProgramError::InvalidArgument);
                     }
+
+                    append_overhead_igp(
+                        &mut igp_payment_account_metas,
+                        &mut igp_payment_account_infos,
+                    );
+
+                    IgpPaymentAccounts::Legacy {
+                        account_metas: igp_payment_account_metas,
+                        account_infos: igp_payment_account_infos,
+                    }
                 }
-            }
-
-            // Account [N+3]: OverheadIgp appended at end (OverheadIgp only).
-            if matches!(igp_account_type, InterchainGasPaymasterType::OverheadIgp(_)) {
-                igp_payment_account_metas.push(AccountMeta::new_readonly(
-                    *configured_igp_account.key,
-                    false,
-                ));
-                igp_payment_account_infos.push(configured_igp_account.clone());
-            }
-
-            Some(match quote_mode {
-                IgpQuoteMode::Quoted => IgpPaymentAccounts::Quoted {
-                    account_metas: igp_payment_account_metas,
-                    account_infos: igp_payment_account_infos,
-                },
-                IgpQuoteMode::Legacy => IgpPaymentAccounts::Legacy {
-                    account_metas: igp_payment_account_metas,
-                    account_infos: igp_payment_account_infos,
-                },
             })
         } else {
             None
@@ -713,6 +738,7 @@ where
                 IgpPaymentAccounts::Quoted {
                     account_metas,
                     account_infos,
+                    igp_quote_authority_bump,
                 } => {
                     let igp_ixn = Instruction::new_with_borsh(
                         *igp_program_id,
@@ -724,7 +750,11 @@ where
                         account_metas,
                     );
 
-                    invoke_signed(&igp_ixn, &account_infos, &[dispatch_authority_seeds])?;
+                    // Sign with the IGP quote authority, not the dispatch authority.
+                    let igp_quote_authority_seeds: &[&[u8]] =
+                        igp_quote_authority_pda_seeds!(igp_quote_authority_bump);
+
+                    invoke_signed(&igp_ixn, &account_infos, &[igp_quote_authority_seeds])?;
                 }
             }
         }

--- a/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
@@ -31,7 +31,7 @@ use hyperlane_sealevel_igp::{
     },
     error::Error as IgpError,
     igp_gas_payment_pda_seeds, igp_pda_seeds, igp_program_data_pda_seeds,
-    igp_standing_quote_pda_seeds, igp_transient_quote_pda_seeds,
+    igp_quote_authority_pda_seeds, igp_standing_quote_pda_seeds, igp_transient_quote_pda_seeds,
     instruction::{
         close_igp_standing_quote_instruction, close_igp_transient_quote_instruction,
         get_igp_quote_account_metas_instruction, set_igp_min_issued_at_instruction,
@@ -3916,7 +3916,7 @@ async fn test_pay_for_gas_new_flow_rejects_sender_authority_not_signer() {
 
     let quoted_sender = Pubkey::new_unique();
     let (sender_authority, _) = Pubkey::find_program_address(
-        &[b"hyperlane_dispatcher", b"-", b"dispatch_authority"],
+        &[b"hyperlane_dispatcher", b"-", b"igp_quote_authority"],
         &quoted_sender,
     );
 
@@ -4530,6 +4530,18 @@ async fn test_get_igp_quote_account_metas_roundtrip_with_quote() {
 
     // sender_authority is a signer (signed via invoke_signed).
     assert!(metas[6].is_signer);
+
+    // sender_authority is the dedicated IGP quote authority PDA, and must differ
+    // from the mailbox dispatch authority so a malicious configured IGP cannot
+    // replay the forwarded signer into a Mailbox dispatch.
+    let (expected_quote_authority, _) =
+        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), &quoted_sender);
+    assert_eq!(metas[6].pubkey, expected_quote_authority);
+    let (mailbox_dispatch_authority, _) = Pubkey::find_program_address(
+        &[b"hyperlane_dispatcher", b"-", b"dispatch_authority"],
+        &quoted_sender,
+    );
+    assert_ne!(metas[6].pubkey, mailbox_dispatch_authority);
 
     // Cascade PDAs match expected derivation.
     let exact_pda =

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/pda_seeds.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/pda_seeds.rs
@@ -124,6 +124,28 @@ macro_rules! igp_transient_quote_pda_seeds {
     }};
 }
 
+/// Gets the PDA seeds for the IGP quote authority.
+///
+/// Derived under the warp route program id and used to authorize quoted IGP
+/// gas payments. Distinct from the mailbox dispatch authority
+/// (`["hyperlane_dispatcher", "-", "dispatch_authority"]`) so a malicious
+/// configured IGP cannot replay the forwarded signer into a Mailbox dispatch.
+#[macro_export]
+macro_rules! igp_quote_authority_pda_seeds {
+    () => {{
+        &[b"hyperlane_dispatcher", b"-", b"igp_quote_authority"]
+    }};
+
+    ($bump_seed:expr) => {{
+        &[
+            b"hyperlane_dispatcher",
+            b"-",
+            b"igp_quote_authority",
+            &[$bump_seed],
+        ]
+    }};
+}
+
 /// Gets the PDA seeds for an IGP gas payment account that's based upon
 /// the pubkey of a unique message account for uniqueness.
 #[macro_export]

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     error::Error as IgpError,
     igp_gas_payment_pda_seeds, igp_pda_seeds, igp_program_data_pda_seeds,
-    igp_standing_quote_pda_seeds, igp_transient_quote_pda_seeds,
+    igp_quote_authority_pda_seeds, igp_standing_quote_pda_seeds, igp_transient_quote_pda_seeds,
     instruction::{
         GasOracleConfig, GasOverheadConfig, GetIgpQuoteAccountMetas, InitIgp, InitOverheadIgp,
         Instruction as IgpInstruction, PayForGas, QuoteGasPayment, SetIgpQuoteSignerOperation,
@@ -294,9 +294,8 @@ fn init_igp_variant<T: account_utils::DiscriminatorPrefixedData + SizedData>(
     Ok(*igp_info.key)
 }
 
-/// Dispatch authority PDA seeds for sender_authority verification.
-/// Same seeds as mailbox uses: ["hyperlane_dispatcher", "-", "dispatch_authority"].
-const DISPATCH_AUTHORITY_SEEDS: &[&[u8]] = &[b"hyperlane_dispatcher", b"-", b"dispatch_authority"];
+/// IGP quote authority PDA seeds for sender_authority verification.
+const IGP_QUOTE_AUTHORITY_SEEDS: &[&[u8]] = igp_quote_authority_pda_seeds!();
 
 /// Pay for gas.
 ///
@@ -317,7 +316,7 @@ const DISPATCH_AUTHORITY_SEEDS: &[&[u8]] = &[b"hyperlane_dispatcher", b"-", b"di
 /// 3. `[signer]` Unique gas payment account.
 /// 4. `[writeable]` Gas payment PDA.
 /// 5. `[writeable]` The IGP account (same position as old flow).
-/// 6. `[signer]` sender_authority (dispatch_authority PDA — must be signer).
+/// 6. `[signer]` sender_authority (IGP quote authority PDA — must be signer).
 /// 7. `[]` quoted_sender (warp route program ID).
 /// 8. `[]` Standing quote PDA (exact).
 /// 9. `[]` Standing quote PDA (wildcard-sender).
@@ -434,10 +433,10 @@ fn pay_for_gas(program_id: &Pubkey, accounts: &[AccountInfo], payment: PayForGas
             let quoted_sender_info = next_account_info(accounts_iter)?;
             let quoted_sender = quoted_sender_info.key;
 
-            // Verify sender_authority is the dispatch authority PDA for quoted_sender.
+            // Verify sender_authority is the IGP quote authority PDA for quoted_sender.
             // This binds the authority to the actual message sender program.
             let (expected_authority, _) =
-                Pubkey::find_program_address(DISPATCH_AUTHORITY_SEEDS, quoted_sender);
+                Pubkey::find_program_address(IGP_QUOTE_AUTHORITY_SEEDS, quoted_sender);
             if *sender_authority_info.key != expected_authority {
                 return Err(ProgramError::InvalidSeeds);
             }
@@ -1596,9 +1595,9 @@ fn get_igp_quote_account_metas(
         });
 
         let (sender_authority, _) =
-            Pubkey::find_program_address(DISPATCH_AUTHORITY_SEEDS, &data.sender);
+            Pubkey::find_program_address(IGP_QUOTE_AUTHORITY_SEEDS, &data.sender);
 
-        // [6] sender_authority (dispatch_authority PDA, signed via invoke_signed).
+        // [6] sender_authority (IGP quote authority PDA, signed via invoke_signed).
         metas.push(SerializableAccountMeta {
             pubkey: sender_authority,
             is_signer: true,

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
@@ -30,7 +30,7 @@ use hyperlane_sealevel_igp::{
         GasPaymentAccount, GasPaymentData, IgpFeeConfig, InterchainGasPaymasterType,
         TOKEN_EXCHANGE_RATE_SCALE,
     },
-    igp_gas_payment_pda_seeds, igp_standing_quote_pda_seeds,
+    igp_gas_payment_pda_seeds, igp_quote_authority_pda_seeds, igp_standing_quote_pda_seeds,
     instruction::{
         set_igp_quote_config_instruction, set_igp_quote_signer_instruction,
         submit_igp_quote_instruction, SetIgpQuoteSignerOperation,
@@ -276,6 +276,7 @@ struct HyperlaneTokenAccounts {
     mailbox_process_authority: Pubkey,
     dispatch_authority: Pubkey,
     dispatch_authority_bump: u8,
+    igp_quote_authority: Pubkey,
     escrow: Pubkey,
     escrow_bump: u8,
     ata_payer: Pubkey,
@@ -301,6 +302,9 @@ async fn initialize_hyperlane_token(
 
     let (dispatch_authority_key, dispatch_authority_seed) =
         Pubkey::find_program_address(mailbox_message_dispatch_authority_pda_seeds!(), program_id);
+
+    let (igp_quote_authority_key, _) =
+        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), program_id);
 
     let (escrow_account_key, escrow_account_bump_seed) =
         Pubkey::find_program_address(hyperlane_token_escrow_pda_seeds!(), program_id);
@@ -370,6 +374,7 @@ async fn initialize_hyperlane_token(
         mailbox_process_authority: mailbox_process_authority_key,
         dispatch_authority: dispatch_authority_key,
         dispatch_authority_bump: dispatch_authority_seed,
+        igp_quote_authority: igp_quote_authority_key,
         escrow: escrow_account_key,
         escrow_bump: escrow_account_bump_seed,
         ata_payer: ata_payer_account_key,
@@ -3388,7 +3393,7 @@ async fn test_transfer_remote_igp_new_flow_standing_collateral() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -3590,7 +3595,7 @@ async fn test_transfer_remote_igp_new_flow_transient_collateral() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new(igp_transient_pda, false),
                     AccountMeta::new_readonly(igp_accounts.overhead_igp, false),
@@ -3756,7 +3761,7 @@ async fn test_transfer_remote_igp_new_flow_cascade_oracle_fallback_collateral() 
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -3884,7 +3889,7 @@ async fn test_transfer_remote_igp_new_flow_with_fee_collateral() {
                     AccountMeta::new(ctx.igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
                     AccountMeta::new_readonly(
-                        ctx.hyperlane_token_accounts.dispatch_authority,
+                        ctx.hyperlane_token_accounts.igp_quote_authority,
                         false,
                     ),
                     AccountMeta::new_readonly(program_id, false),
@@ -4062,7 +4067,7 @@ async fn test_transfer_remote_igp_new_flow_cascade_wildcard_sender_collateral() 
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -4231,7 +4236,7 @@ async fn test_transfer_remote_igp_new_flow_cascade_wildcard_domain_collateral() 
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -4424,7 +4429,7 @@ async fn test_transfer_remote_igp_new_flow_with_overhead_collateral() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
@@ -28,7 +28,8 @@ use hyperlane_sealevel_igp::{
     accounts::{
         GasPaymentAccount, IgpFeeConfig, InterchainGasPaymasterType, TOKEN_EXCHANGE_RATE_SCALE,
     },
-    igp_gas_payment_pda_seeds, igp_standing_quote_pda_seeds, igp_transient_quote_pda_seeds,
+    igp_gas_payment_pda_seeds, igp_quote_authority_pda_seeds, igp_standing_quote_pda_seeds,
+    igp_transient_quote_pda_seeds,
     instruction::{
         set_igp_quote_config_instruction, set_igp_quote_signer_instruction,
         submit_igp_quote_instruction, SetIgpQuoteSignerOperation,
@@ -284,6 +285,7 @@ struct CcTokenAccounts {
     mailbox_process_authority: Pubkey,
     dispatch_authority: Pubkey,
     dispatch_authority_bump: u8,
+    igp_quote_authority: Pubkey,
     escrow: Pubkey,
     escrow_bump: u8,
     ata_payer: Pubkey,
@@ -312,6 +314,9 @@ async fn initialize_cc_token(
 
     let (dispatch_authority_key, dispatch_authority_bump) =
         Pubkey::find_program_address(mailbox_message_dispatch_authority_pda_seeds!(), program_id);
+
+    let (igp_quote_authority_key, _) =
+        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), program_id);
 
     let (escrow_account_key, escrow_account_bump_seed) =
         Pubkey::find_program_address(hyperlane_token_escrow_pda_seeds!(), program_id);
@@ -368,6 +373,7 @@ async fn initialize_cc_token(
         mailbox_process_authority: mailbox_process_authority_key,
         dispatch_authority: dispatch_authority_key,
         dispatch_authority_bump,
+        igp_quote_authority: igp_quote_authority_key,
         escrow: escrow_account_key,
         escrow_bump: escrow_account_bump_seed,
         ata_payer: ata_payer_account_key,
@@ -5876,7 +5882,7 @@ async fn test_cc_remote_transfer_igp_new_flow_standing() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -6030,7 +6036,7 @@ async fn test_cc_remote_transfer_igp_new_flow_transient() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new(igp_transient_pda, false),
                     AccountMeta::new_readonly(igp_overhead_igp, false),
@@ -6155,7 +6161,7 @@ async fn test_cc_remote_transfer_igp_new_flow_cascade_oracle_fallback() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -6287,7 +6293,7 @@ async fn test_cc_remote_transfer_igp_new_flow_cascade_wildcard_sender() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -6419,7 +6425,7 @@ async fn test_cc_remote_transfer_igp_new_flow_cascade_wildcard_domain() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -6576,7 +6582,7 @@ async fn test_cc_remote_transfer_igp_new_flow_with_overhead() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -6824,7 +6830,7 @@ async fn test_cc_remote_transfer_igp_new_flow_with_fee() {
                     AccountMeta::new_readonly(igp_program, false),
                     AccountMeta::new(igp_program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(ctx.cc.dispatch_authority, false),
+                    AccountMeta::new_readonly(ctx.cc.igp_quote_authority, false),
                     AccountMeta::new_readonly(ctx.program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
@@ -33,7 +33,8 @@ use hyperlane_sealevel_igp::{
         GasPaymentAccount, GasPaymentData, IgpFeeConfig, InterchainGasPaymasterType,
         TOKEN_EXCHANGE_RATE_SCALE, WILDCARD_DOMAIN as IGP_WILDCARD_DOMAIN, WILDCARD_SENDER,
     },
-    igp_gas_payment_pda_seeds, igp_standing_quote_pda_seeds, igp_transient_quote_pda_seeds,
+    igp_gas_payment_pda_seeds, igp_quote_authority_pda_seeds, igp_standing_quote_pda_seeds,
+    igp_transient_quote_pda_seeds,
     instruction::{
         set_igp_quote_config_instruction, set_igp_quote_signer_instruction,
         submit_igp_quote_instruction, GasOverheadConfig, Instruction as IgpProgramInstruction,
@@ -150,6 +151,7 @@ struct HyperlaneTokenAccounts {
     mailbox_process_authority: Pubkey,
     dispatch_authority: Pubkey,
     dispatch_authority_bump: u8,
+    igp_quote_authority: Pubkey,
     native_collateral: Pubkey,
     native_collateral_bump: u8,
 }
@@ -171,6 +173,9 @@ async fn initialize_hyperlane_token(
 
     let (dispatch_authority_key, dispatch_authority_seed) =
         Pubkey::find_program_address(mailbox_message_dispatch_authority_pda_seeds!(), program_id);
+
+    let (igp_quote_authority_key, _) =
+        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), program_id);
 
     let (native_collateral_account_key, native_collateral_account_bump_seed) =
         Pubkey::find_program_address(hyperlane_token_native_collateral_pda_seeds!(), program_id);
@@ -229,6 +234,7 @@ async fn initialize_hyperlane_token(
         mailbox_process_authority: mailbox_process_authority_key,
         dispatch_authority: dispatch_authority_key,
         dispatch_authority_bump: dispatch_authority_seed,
+        igp_quote_authority: igp_quote_authority_key,
         native_collateral: native_collateral_account_key,
         native_collateral_bump: native_collateral_account_bump_seed,
     })
@@ -2899,7 +2905,7 @@ async fn test_transfer_remote_igp_new_flow_standing_native() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_standing_pda, false),
                     AccountMeta::new_readonly(ws_standing_pda, false),
@@ -2950,6 +2956,147 @@ async fn test_transfer_remote_igp_new_flow_standing_native() {
             .unwrap()
             .is_some(),
         "dispatched message should exist"
+    );
+}
+
+/// A quoted IGP transfer that passes the mailbox dispatch authority (the
+/// pre-fix account) at the IGP sender_authority slot must be rejected: the
+/// route only forwards its dedicated IGP quote authority PDA, so a malicious
+/// configured IGP can never receive a Mailbox-capable signer.
+#[tokio::test]
+async fn test_transfer_remote_igp_new_flow_rejects_non_quote_authority_native() {
+    let program_id = hyperlane_sealevel_token_native_id();
+    let mailbox_program_id = mailbox_id();
+
+    let (mut banks_client, payer) = setup_client().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &mailbox_program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        ONE_SOL_IN_LAMPORTS,
+        ProtocolFee::default(),
+    )
+    .await
+    .unwrap();
+
+    let igp_accounts =
+        initialize_igp_accounts(&mut banks_client, &igp_program_id(), &payer, REMOTE_DOMAIN)
+            .await
+            .unwrap();
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, Some(&igp_accounts))
+            .await
+            .unwrap();
+
+    enroll_remote_router(
+        &mut banks_client,
+        &program_id,
+        &payer,
+        &hyperlane_token_accounts.token,
+        REMOTE_DOMAIN,
+        H256::random(),
+    )
+    .await
+    .unwrap();
+
+    let igp_signing_key = setup_igp_new_flow(&mut banks_client, &payer, &igp_accounts.igp).await;
+    submit_standing_igp_quote(
+        &mut banks_client,
+        &payer,
+        &igp_accounts.igp,
+        &igp_signing_key,
+        REMOTE_DOMAIN,
+        &program_id,
+        2 * TOKEN_EXCHANGE_RATE_SCALE,
+        5,
+        9,
+    )
+    .await;
+
+    let exact_standing_pda = derive_igp_standing_quote_pda(
+        &igp_accounts.igp,
+        &Pubkey::default(),
+        REMOTE_DOMAIN,
+        &program_id,
+    );
+    let ws_standing_pda = derive_igp_standing_quote_pda(
+        &igp_accounts.igp,
+        &Pubkey::default(),
+        REMOTE_DOMAIN,
+        &WILDCARD_SENDER,
+    );
+    let wd_standing_pda = derive_igp_standing_quote_pda(
+        &igp_accounts.igp,
+        &Pubkey::default(),
+        IGP_WILDCARD_DOMAIN,
+        &program_id,
+    );
+
+    let token_sender =
+        new_funded_keypair(&mut banks_client, &payer, 100 * ONE_SOL_IN_LAMPORTS).await;
+    let token_sender_pubkey = token_sender.pubkey();
+    let unique_message_account_keypair = Keypair::new();
+    let (dispatched_message_key, _) = Pubkey::find_program_address(
+        mailbox_dispatched_message_pda_seeds!(&unique_message_account_keypair.pubkey()),
+        &mailbox_program_id,
+    );
+    let (gas_payment_pda_key, _) = Pubkey::find_program_address(
+        igp_gas_payment_pda_seeds!(&unique_message_account_keypair.pubkey()),
+        &igp_program_id(),
+    );
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let result = banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                program_id,
+                &HyperlaneTokenInstruction::TransferRemote(TransferRemote {
+                    destination_domain: REMOTE_DOMAIN,
+                    recipient: H256::random(),
+                    amount_or_id: (10 * ONE_SOL_IN_LAMPORTS).into(),
+                })
+                .encode()
+                .unwrap(),
+                vec![
+                    // Core (0-8)
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new_readonly(account_utils::SPL_NOOP_PROGRAM_ID, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.token, false),
+                    AccountMeta::new_readonly(mailbox_accounts.program, false),
+                    AccountMeta::new(mailbox_accounts.outbox, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(token_sender_pubkey, true),
+                    AccountMeta::new_readonly(unique_message_account_keypair.pubkey(), true),
+                    AccountMeta::new(dispatched_message_key, false),
+                    // IGP new flow — WRONG sender_authority: the mailbox dispatch
+                    // authority instead of the IGP quote authority PDA.
+                    AccountMeta::new_readonly(igp_accounts.program, false),
+                    AccountMeta::new(igp_accounts.program_data, false),
+                    AccountMeta::new(gas_payment_pda_key, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(program_id, false),
+                    AccountMeta::new_readonly(exact_standing_pda, false),
+                    AccountMeta::new_readonly(ws_standing_pda, false),
+                    AccountMeta::new_readonly(wd_standing_pda, false),
+                    AccountMeta::new_readonly(igp_accounts.overhead_igp, false), // TERMINAL
+                    AccountMeta::new(igp_accounts.igp, false),
+                    // Plugin (native)
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new(hyperlane_token_accounts.native_collateral, false),
+                ],
+            )],
+            Some(&token_sender_pubkey),
+            &[&token_sender, &unique_message_account_keypair],
+            recent_blockhash,
+        ))
+        .await;
+
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(0, InstructionError::InvalidArgument),
     );
 }
 
@@ -3088,7 +3235,7 @@ async fn test_transfer_remote_igp_new_flow_transient_native() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new(igp_transient_pda, false),
                     AccountMeta::new_readonly(igp_accounts.overhead_igp, false), // TERMINAL
@@ -3424,7 +3571,7 @@ async fn test_transfer_remote_fully_transient_fee_and_igp_native() {
             AccountMeta::new_readonly(igp_accounts.program, false),
             AccountMeta::new(igp_accounts.program_data, false),
             AccountMeta::new(gas_payment_pda_key, false),
-            AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+            AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
             AccountMeta::new_readonly(program_id, false),
             AccountMeta::new(igp_transient_pda, false),
             AccountMeta::new_readonly(igp_accounts.overhead_igp, false), // TERMINAL
@@ -3840,7 +3987,7 @@ async fn test_transfer_remote_igp_new_flow_cascade_wildcard_sender_native() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -3965,7 +4112,7 @@ async fn test_transfer_remote_igp_new_flow_cascade_oracle_fallback_native() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -4128,7 +4275,7 @@ async fn test_transfer_remote_igp_new_flow_with_overhead_native() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -4270,7 +4417,7 @@ async fn test_transfer_remote_igp_new_flow_cascade_wildcard_domain_native() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gp, false),
-                    AccountMeta::new_readonly(hta.dispatch_authority, false),
+                    AccountMeta::new_readonly(hta.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new_readonly(exact_pda, false),
                     AccountMeta::new_readonly(ws_pda, false),
@@ -4300,4 +4447,348 @@ async fn test_transfer_remote_igp_new_flow_cascade_wildcard_domain_native() {
         ep,
     )
     .await;
+}
+
+// ========================================================================
+// HLSVM-2026Q2-008 regression: a malicious configured IGP cannot replay the
+// forwarded quoted-payment signer into a nested Mailbox::OutboxDispatch.
+//
+// Pre-fix the route forwarded its *mailbox dispatch authority* PDA to the
+// (owner-chosen, untrusted) IGP program's `PayForGas`. A malicious IGP could
+// re-invoke `Mailbox::OutboxDispatch` with that signer and `sender = route
+// program id` to emit an unbacked message as the route. The fix forwards a
+// dedicated `igp_quote_authority` PDA whose seeds do NOT satisfy Mailbox's
+// dispatch-authority check, so the nested dispatch is rejected with
+// `MissingRequiredSignature`.
+// ========================================================================
+
+/// Mock malicious IGP program id (replaces the real IGP that the route CPIs).
+const MALICIOUS_IGP_ID: Pubkey = pubkey!("US517G5965aydkZ46HS38QLi7UQiSojurfbQfKCELFx");
+
+/// Mock malicious IGP. From the token's `PayForGas` CPI accounts it takes the
+/// forwarded signer (`[6]`) and route id (`[7]=quoted_sender`), plus a full
+/// nested-dispatch set smuggled through the cascade
+/// (`[8]=mailbox [9]=outbox [10]=noop [11]=unique(signer) [12]=dispatched PDA`),
+/// and attempts a complete `OutboxDispatch` as the route. The full account set
+/// is deliberate: only Mailbox's signer check can stop the replay, so a success
+/// here means a Mailbox-capable signer was forwarded.
+fn malicious_igp_process(
+    _program_id: &Pubkey,
+    accounts: &[solana_program::account_info::AccountInfo],
+    _instruction_data: &[u8],
+) -> solana_program::entrypoint::ProgramResult {
+    let system_info = &accounts[0];
+    let payer_info = &accounts[1];
+    let sender_authority_info = &accounts[6];
+    let quoted_sender_info = &accounts[7];
+    let mailbox_program_info = &accounts[8];
+    let outbox_info = &accounts[9];
+    let noop_info = &accounts[10];
+    let unique_info = &accounts[11];
+    let dispatched_info = &accounts[12];
+
+    solana_program::msg!(
+        "malicious igp attempting nested mailbox dispatch as sender {}",
+        quoted_sender_info.key
+    );
+
+    let dispatch = hyperlane_sealevel_mailbox::instruction::OutboxDispatch {
+        sender: *quoted_sender_info.key,
+        destination_domain: REMOTE_DOMAIN,
+        recipient: H256::zero(),
+        message_body: vec![],
+    };
+
+    let ix = Instruction::new_with_borsh(
+        *mailbox_program_info.key,
+        &hyperlane_sealevel_mailbox::instruction::Instruction::OutboxDispatch(dispatch),
+        vec![
+            AccountMeta::new(*outbox_info.key, false),
+            AccountMeta::new_readonly(*sender_authority_info.key, true),
+            AccountMeta::new_readonly(*system_info.key, false),
+            AccountMeta::new_readonly(*noop_info.key, false),
+            AccountMeta::new(*payer_info.key, true),
+            AccountMeta::new_readonly(*unique_info.key, true),
+            AccountMeta::new(*dispatched_info.key, false),
+        ],
+    );
+
+    // Swallow the result: a stealthy IGP doesn't break the route. The caller
+    // asserts the invariant via the attacker dispatched-message PDA, not an error.
+    match solana_program::program::invoke(
+        &ix,
+        &[
+            outbox_info.clone(),
+            sender_authority_info.clone(),
+            system_info.clone(),
+            noop_info.clone(),
+            payer_info.clone(),
+            unique_info.clone(),
+            dispatched_info.clone(),
+            mailbox_program_info.clone(),
+        ],
+    ) {
+        Ok(()) => {
+            solana_program::msg!(
+                "malicious nested mailbox dispatch SUCCEEDED: unbacked message emitted"
+            )
+        }
+        Err(e) => {
+            solana_program::msg!("malicious nested mailbox dispatch rejected: {:?}", e)
+        }
+    }
+
+    Ok(())
+}
+
+/// Like `setup_client`, but also registers the mock malicious IGP program.
+async fn setup_client_with_malicious_igp() -> (BanksClient, Keypair) {
+    let program_id = hyperlane_sealevel_token_native_id();
+    let mut program_test = ProgramTest::new(
+        "hyperlane_sealevel_token_native",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    fn noop_processor(
+        _program_id: &Pubkey,
+        _accounts: &[solana_program::account_info::AccountInfo],
+        _instruction_data: &[u8],
+    ) -> solana_program::entrypoint::ProgramResult {
+        Ok(())
+    }
+    program_test.add_program(
+        "spl_noop",
+        account_utils::SPL_NOOP_PROGRAM_ID,
+        processor!(noop_processor),
+    );
+
+    let mailbox_program_id = mailbox_id();
+    program_test.add_program(
+        "hyperlane_sealevel_mailbox",
+        mailbox_program_id,
+        processor!(hyperlane_sealevel_mailbox::processor::process_instruction),
+    );
+
+    program_test.add_program(
+        "hyperlane_sealevel_igp",
+        igp_program_id(),
+        processor!(hyperlane_sealevel_igp::processor::process_instruction),
+    );
+
+    program_test.add_program(
+        "hyperlane_sealevel_test_ism",
+        hyperlane_sealevel_test_ism::id(),
+        processor!(hyperlane_sealevel_test_ism::program::process_instruction),
+    );
+
+    program_test.add_program(
+        "hyperlane_sealevel_fee",
+        fee_program_id(),
+        processor!(fee_process_instruction),
+    );
+
+    program_test.add_program(
+        "malicious_igp",
+        MALICIOUS_IGP_ID,
+        processor!(malicious_igp_process),
+    );
+
+    let (banks_client, payer, _recent_blockhash) = program_test.start().await;
+
+    (banks_client, payer)
+}
+
+/// HLSVM-2026Q2-008: a route configured to use a malicious IGP forwards only
+/// its dedicated `igp_quote_authority` PDA. When the malicious IGP replays that
+/// signer into a nested `Mailbox::OutboxDispatch` (sender = route program id),
+/// Mailbox rejects it with `MissingRequiredSignature` because the forwarded PDA
+/// is not the route's mailbox dispatch authority.
+#[tokio::test]
+async fn test_transfer_remote_quoted_igp_malicious_igp_cannot_replay_signer_native() {
+    let program_id = hyperlane_sealevel_token_native_id();
+    let mailbox_program_id = mailbox_id();
+
+    let (mut banks_client, payer) = setup_client_with_malicious_igp().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &mailbox_program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        ONE_SOL_IN_LAMPORTS,
+        ProtocolFee::default(),
+    )
+    .await
+    .unwrap();
+
+    let igp_accounts =
+        initialize_igp_accounts(&mut banks_client, &igp_program_id(), &payer, REMOTE_DOMAIN)
+            .await
+            .unwrap();
+
+    // Initialize the route pointed at the real IGP, then repoint it at the
+    // malicious IGP program (keeping the Quoted IGP account as the configured
+    // account so quote-mode is read correctly).
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, Some(&igp_accounts))
+            .await
+            .unwrap();
+
+    enroll_remote_router(
+        &mut banks_client,
+        &program_id,
+        &payer,
+        &hyperlane_token_accounts.token,
+        REMOTE_DOMAIN,
+        H256::random(),
+    )
+    .await
+    .unwrap();
+
+    // Configure the IGP account to Quoted mode and submit a standing quote.
+    let igp_signing_key = setup_igp_new_flow(&mut banks_client, &payer, &igp_accounts.igp).await;
+    submit_standing_igp_quote(
+        &mut banks_client,
+        &payer,
+        &igp_accounts.igp,
+        &igp_signing_key,
+        REMOTE_DOMAIN,
+        &program_id,
+        2 * TOKEN_EXCHANGE_RATE_SCALE,
+        5,
+        9,
+    )
+    .await;
+
+    // Repoint the route's IGP program at the malicious program, keeping the
+    // Quoted IGP account as the configured account.
+    let set_igp_ix = hyperlane_sealevel_token_lib::instruction::set_igp_instruction(
+        program_id,
+        payer.pubkey(),
+        Some((
+            MALICIOUS_IGP_ID,
+            InterchainGasPaymasterType::Igp(igp_accounts.igp),
+        )),
+    )
+    .unwrap();
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[set_igp_ix],
+            Some(&payer.pubkey()),
+            &[&payer],
+            recent_blockhash,
+        ))
+        .await
+        .unwrap();
+
+    // The route's dedicated IGP quote authority PDA — the only signer the route
+    // forwards to the configured IGP.
+    let (igp_quote_authority, _) =
+        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), &program_id);
+
+    let token_sender =
+        new_funded_keypair(&mut banks_client, &payer, 100 * ONE_SOL_IN_LAMPORTS).await;
+    let token_sender_pubkey = token_sender.pubkey();
+
+    // The route's own (backed) dispatch accounts.
+    let legit_unique_message = Keypair::new();
+    let (legit_dispatched_message_pda, _) = Pubkey::find_program_address(
+        mailbox_dispatched_message_pda_seeds!(&legit_unique_message.pubkey()),
+        &mailbox_program_id,
+    );
+    // gas_payment_pda is a PDA of the REAL IGP program; the malicious mock
+    // ignores it, so its derivation under the real IGP is fine.
+    let (gas_payment_pda_key, _) = Pubkey::find_program_address(
+        igp_gas_payment_pda_seeds!(&legit_unique_message.pubkey()),
+        &igp_program_id(),
+    );
+
+    // The attacker's dispatch accounts, smuggled through the cascade. If this
+    // PDA exists after the transfer, an unbacked message was emitted.
+    let attacker_unique_message = Keypair::new();
+    let (attacker_dispatched_message_pda, _) = Pubkey::find_program_address(
+        mailbox_dispatched_message_pda_seeds!(&attacker_unique_message.pubkey()),
+        &mailbox_program_id,
+    );
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let result = banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                program_id,
+                &HyperlaneTokenInstruction::TransferRemote(TransferRemote {
+                    destination_domain: REMOTE_DOMAIN,
+                    recipient: H256::random(),
+                    amount_or_id: (10 * ONE_SOL_IN_LAMPORTS).into(),
+                })
+                .encode()
+                .unwrap(),
+                vec![
+                    // Core (0-8)
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new_readonly(account_utils::SPL_NOOP_PROGRAM_ID, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.token, false),
+                    AccountMeta::new_readonly(mailbox_accounts.program, false),
+                    AccountMeta::new(mailbox_accounts.outbox, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(token_sender_pubkey, true),
+                    AccountMeta::new_readonly(legit_unique_message.pubkey(), true),
+                    AccountMeta::new(legit_dispatched_message_pda, false),
+                    // IGP section: program points at the MALICIOUS IGP.
+                    AccountMeta::new_readonly(MALICIOUS_IGP_ID, false),
+                    AccountMeta::new(igp_accounts.program_data, false),
+                    AccountMeta::new(gas_payment_pda_key, false),
+                    // Quoted pass-through: igp_quote_authority, route id, then the
+                    // cascade slots abused to smuggle a full nested-dispatch set
+                    // (mailbox, outbox, noop, attacker unique(signer), dispatched PDA).
+                    AccountMeta::new_readonly(igp_quote_authority, false),
+                    AccountMeta::new_readonly(program_id, false),
+                    AccountMeta::new_readonly(mailbox_accounts.program, false),
+                    AccountMeta::new(mailbox_accounts.outbox, false),
+                    AccountMeta::new_readonly(account_utils::SPL_NOOP_PROGRAM_ID, false),
+                    AccountMeta::new_readonly(attacker_unique_message.pubkey(), true),
+                    AccountMeta::new(attacker_dispatched_message_pda, false),
+                    // Terminal: configured IGP (Quoted account).
+                    AccountMeta::new(igp_accounts.igp, false),
+                    // Plugin (native)
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new(hyperlane_token_accounts.native_collateral, false),
+                ],
+            )],
+            Some(&token_sender_pubkey),
+            &[
+                &token_sender,
+                &legit_unique_message,
+                &attacker_unique_message,
+            ],
+            recent_blockhash,
+        ))
+        .await;
+
+    // The IGP swallowed its failed replay, so the transfer completes normally.
+    result.expect("transfer_remote should succeed; the malicious IGP swallows its failed replay");
+
+    // The route's own, backed message was dispatched.
+    assert!(
+        banks_client
+            .get_account(legit_dispatched_message_pda)
+            .await
+            .unwrap()
+            .is_some(),
+        "the route's own (backed) message should have been dispatched",
+    );
+
+    // Security invariant: the forwarded igp_quote_authority is not the route's
+    // mailbox dispatch authority, so the replay is rejected and no unbacked
+    // message exists. Regression here means a Mailbox-capable signer was forwarded.
+    assert!(
+        banks_client
+            .get_account(attacker_dispatched_message_pda)
+            .await
+            .unwrap()
+            .is_none(),
+        "an unbacked message was emitted: the malicious IGP replayed the forwarded signer",
+    );
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
@@ -20,7 +20,7 @@ use hyperlane_sealevel_igp::{
         GasPaymentAccount, GasPaymentData, IgpFeeConfig, InterchainGasPaymasterType,
         TOKEN_EXCHANGE_RATE_SCALE, WILDCARD_DOMAIN as IGP_WILDCARD_DOMAIN, WILDCARD_SENDER,
     },
-    igp_gas_payment_pda_seeds, igp_standing_quote_pda_seeds,
+    igp_gas_payment_pda_seeds, igp_quote_authority_pda_seeds, igp_standing_quote_pda_seeds,
     instruction::{
         set_igp_quote_config_instruction, set_igp_quote_signer_instruction,
         submit_igp_quote_instruction, GasOverheadConfig, Instruction as IgpProgramInstruction,
@@ -154,6 +154,7 @@ struct HyperlaneTokenAccounts {
     mailbox_process_authority: Pubkey,
     dispatch_authority: Pubkey,
     dispatch_authority_bump: u8,
+    igp_quote_authority: Pubkey,
     mint: Pubkey,
     mint_bump: u8,
     ata_payer: Pubkey,
@@ -177,6 +178,9 @@ async fn initialize_hyperlane_token(
 
     let (dispatch_authority_key, dispatch_authority_seed) =
         Pubkey::find_program_address(mailbox_message_dispatch_authority_pda_seeds!(), program_id);
+
+    let (igp_quote_authority_key, _) =
+        Pubkey::find_program_address(igp_quote_authority_pda_seeds!(), program_id);
 
     let (mint_account_key, mint_account_bump_seed) =
         Pubkey::find_program_address(hyperlane_token_mint_pda_seeds!(), program_id);
@@ -259,6 +263,7 @@ async fn initialize_hyperlane_token(
         mailbox_process_authority: mailbox_process_authority_key,
         dispatch_authority: dispatch_authority_key,
         dispatch_authority_bump: dispatch_authority_seed,
+        igp_quote_authority: igp_quote_authority_key,
         mint: mint_account_key,
         mint_bump: mint_account_bump_seed,
         ata_payer: ata_payer_account_key,
@@ -2903,8 +2908,8 @@ async fn test_transfer_remote_igp_new_flow_standing_exact() {
                 AccountMeta::new_readonly(igp_accounts.program, false),
                 AccountMeta::new(igp_accounts.program_data, false),
                 AccountMeta::new(gas_payment_pda_key, false),
-                // sender_authority = dispatch_authority
-                AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                // sender_authority = igp_quote_authority
+                AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                 // quoted_sender = program_id
                 AccountMeta::new_readonly(program_id, false),
                 // variable: all 3 cascade standing quote PDAs
@@ -3150,7 +3155,7 @@ async fn test_transfer_remote_igp_new_flow_transient_synthetic() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new(igp_transient_pda, false),
                     AccountMeta::new_readonly(igp_accounts.overhead_igp, false), // TERMINAL
@@ -3339,7 +3344,7 @@ async fn test_transfer_remote_igp_new_flow_transient_wildcard_domain() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new(igp_transient_pda, false),
                     AccountMeta::new_readonly(igp_accounts.overhead_igp, false), // TERMINAL
@@ -3526,7 +3531,7 @@ async fn test_transfer_remote_igp_new_flow_transient_wildcard_sender() {
                     AccountMeta::new_readonly(igp_accounts.program, false),
                     AccountMeta::new(igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
-                    AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+                    AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
                     AccountMeta::new_readonly(program_id, false),
                     AccountMeta::new(igp_transient_pda, false),
                     AccountMeta::new_readonly(igp_accounts.overhead_igp, false), // TERMINAL
@@ -3602,7 +3607,7 @@ fn build_igp_new_flow_transfer_remote_accounts(
         AccountMeta::new_readonly(igp_accounts.program, false),
         AccountMeta::new(igp_accounts.program_data, false),
         AccountMeta::new(*gas_payment_pda_key, false),
-        AccountMeta::new_readonly(hyperlane_token_accounts.dispatch_authority, false),
+        AccountMeta::new_readonly(hyperlane_token_accounts.igp_quote_authority, false),
         AccountMeta::new_readonly(*program_id, false),
     ];
     // Variable quote PDAs
@@ -4339,7 +4344,7 @@ async fn test_transfer_remote_igp_new_flow_with_fee() {
                     AccountMeta::new(ctx.igp_accounts.program_data, false),
                     AccountMeta::new(gas_payment_pda_key, false),
                     AccountMeta::new_readonly(
-                        ctx.hyperlane_token_accounts.dispatch_authority,
+                        ctx.hyperlane_token_accounts.igp_quote_authority,
                         false,
                     ),
                     AccountMeta::new_readonly(program_id, false),


### PR DESCRIPTION
### Description

Fixes **HLSVM-2026Q2-008** (Chainlight SVM audit, Q2 2026): *Mailbox dispatch-authority forwarding in the quoted IGP CPI leading to unbacked route messages*.

In quoted-IGP mode the warp route paid for gas by `invoke_signed`-ing the configured IGP's `PayForGas` while forwarding the **Mailbox dispatch-authority PDA** as the signer. Because the IGP program is owner-configured (not pinned), a malicious IGP could reuse that forwarded signer — via Solana's signer-privilege extension — in a nested `Mailbox::OutboxDispatch`, emitting a message attributed to the route with no matching local lock/burn (an unbacked message; remote mint/release if a remote router has it enrolled).

The fix introduces a dedicated **IGP quote authority PDA**, derived under the warp-route program id but with seeds (`["hyperlane_dispatcher", "-", "igp_quote_authority"]`) that **cannot** satisfy Mailbox's dispatch-authority check. The route now signs the quoted `PayForGas` CPI with this PDA instead of the dispatch authority; the Mailbox dispatch CPI keeps using the dispatch authority. Applied in lockstep across the three coordinated sites so quoted payments still resolve:

- New `igp_quote_authority_pda_seeds!` macro in the IGP program.
- IGP `PayForGas` (new/quoted flow) validates `sender_authority` against the new seeds.
- IGP `GetIgpQuoteAccountMetas` emits the new PDA at the `sender_authority` slot.
- Token-lib `transfer_remote_to` signs the IGP CPI with the new seeds (bump derived at runtime — no token-account storage change), and now also validates that the forwarded `sender_authority` equals the route's `igp_quote_authority` PDA (fails fast with `InvalidArgument`).

Cross-collateral is covered automatically — its remote path delegates to the shared `transfer_remote_to`. Legacy and overhead IGP flows are untouched.

### Drive-by changes

None.

### Related issues

- Fixes [HLSVM-2026Q2-008](https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/9) (Chainlight SVM audit Q2 2026).

### Backward compatibility

Yes.

- The quoted IGP flow is unreleased; legacy and overhead IGP flows do not derive this PDA and are unchanged.
- No storage-layout change: the new bump is derived at runtime via `find_program_address`, so existing `HyperlaneToken` accounts are unaffected (no migration).
- Off-chain callers read the quoted account list dynamically from `GetIgpQuoteAccountMetas`, so they pick up the new `sender_authority` PDA automatically; the producer and on-chain consumer use the same seeds and account order.

### Testing

Unit Tests.

- New behavioral regression test reproducing the attack end-to-end: a real native warp route is repointed to a mock malicious IGP, which attempts a full nested `Mailbox::OutboxDispatch` reusing the forwarded signer. Asserts the security invariant — the transfer succeeds, the route's own (backed) message is dispatched, and **no unbacked message** is emitted. Validated in both directions via a seed-collision check (colliding the quote-authority seeds with the dispatch authority makes the unbacked message appear and the test fail).
- Negative test: a non-quote-authority account at the `sender_authority` slot is rejected with `InvalidArgument`.
- IGP unit test asserts `GetIgpQuoteAccountMetas` emits the dedicated quote authority PDA and that it dtch authority.
- Updated all existing quoted-flow functional tests (native, collateral, synthetic, cross-collateral) to the new PDA.
- Full `rust/sealevel` workspace suite green (801 tests); `cargo fmt` + `clippy` clean.
