### PR TITLE
fix(sealevel): HLSVM-2026Q2-013

### DIFF
--- a/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp-test/src/functional.rs
@@ -2883,6 +2883,7 @@ async fn test_submit_transient_quote() {
     let account = banks_client.get_account(quote_pda).await.unwrap().unwrap();
     let transient = fetch_transient_quote(&account.data);
     assert_eq!(transient.payer, payer.pubkey());
+    assert_eq!(transient.fee_token_mint, Pubkey::default());
     assert_eq!(transient.destination_domain, dest_domain);
     assert_eq!(transient.sender, sender);
     assert_eq!(transient.token_exchange_rate, exchange_rate);

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/accounts.rs
@@ -606,6 +606,8 @@ pub struct IgpTransientQuote {
     pub payer: Pubkey,
     /// Scoped salt: keccak256(payer || client_salt).
     pub scoped_salt: H256,
+    /// Fee token mint from the quote context (Pubkey::default() for SOL).
+    pub fee_token_mint: Pubkey,
     /// Destination domain from the quote context.
     pub destination_domain: u32,
     /// Sender (warp route program ID) from the quote context.
@@ -625,6 +627,7 @@ impl SizedData for IgpTransientQuote {
         std::mem::size_of::<u8>()       // bump_seed
             + PUBKEY_SIZE               // payer
             + H256_SIZE                 // scoped_salt
+            + PUBKEY_SIZE               // fee_token_mint
             + std::mem::size_of::<u32>() // destination_domain
             + PUBKEY_SIZE               // sender
             + std::mem::size_of::<u128>() // token_exchange_rate
@@ -780,6 +783,7 @@ mod test {
             bump_seed: 2,
             payer: Pubkey::new_unique(),
             scoped_salt: H256::random(),
+            fee_token_mint: Pubkey::new_unique(),
             destination_domain: 42,
             sender: Pubkey::new_unique(),
             token_exchange_rate: 1_000_000_000_000_000_000,
@@ -798,6 +802,7 @@ mod test {
             bump_seed: 2,
             payer: Pubkey::new_unique(),
             scoped_salt: H256::random(),
+            fee_token_mint: Pubkey::new_unique(),
             destination_domain: 42,
             sender: Pubkey::new_unique(),
             token_exchange_rate: 1_000_000_000_000_000_000,

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -447,7 +447,9 @@ fn pay_for_gas(program_id: &Pubkey, accounts: &[AccountInfo], payment: PayForGas
                 return Err(ProgramError::NotEnoughAccountKeys);
             }
 
-            let fee_token_mint = Pubkey::default();
+            // Fee token used for payment. Only lamports (default mint) today; will be
+            // derived from the payment token account once SPL fee tokens are supported.
+            let expected_fee_token_mint = Pubkey::default();
             let clock = Clock::get()?;
 
             // Require fee_config for new flow — prevents stale quotes after config removal.
@@ -470,6 +472,7 @@ fn pay_for_gas(program_id: &Pubkey, accounts: &[AccountInfo], payment: PayForGas
                     transient_info,
                     igp_info.key,
                     payer_info.key,
+                    &expected_fee_token_mint,
                     payment.destination_domain,
                     quoted_sender,
                     min_issued_at,
@@ -489,7 +492,7 @@ fn pay_for_gas(program_id: &Pubkey, accounts: &[AccountInfo], payment: PayForGas
                     program_id,
                     accounts_iter,
                     igp_info.key,
-                    &fee_token_mint,
+                    &expected_fee_token_mint,
                     cascade_levels,
                     min_issued_at,
                     &clock,
@@ -643,7 +646,9 @@ fn quote_gas_payment(
                 return Err(ProgramError::NotEnoughAccountKeys);
             }
 
-            let fee_token_mint = Pubkey::default();
+            // Fee token used for payment. Only lamports (default mint) today; will be
+            // derived from the payment token account once SPL fee tokens are supported.
+            let expected_fee_token_mint = Pubkey::default();
             let clock = Clock::get()?;
 
             // Require fee_config for new flow — prevents stale quotes after config removal.
@@ -661,7 +666,7 @@ fn quote_gas_payment(
                 program_id,
                 accounts_iter,
                 igp_info.key,
-                &fee_token_mint,
+                &expected_fee_token_mint,
                 cascade_levels,
                 min_issued_at,
                 &clock,
@@ -1365,6 +1370,7 @@ fn try_resolve_transient_quote(
     account_info: &AccountInfo,
     igp_key: &Pubkey,
     payer: &Pubkey,
+    expected_fee_token_mint: &Pubkey,
     dest_domain: u32,
     sender: &Pubkey,
     min_issued_at: i64,
@@ -1385,6 +1391,11 @@ fn try_resolve_transient_quote(
     // Verify payer binding — prevents another payer from using this quote.
     if transient.data.payer != *payer {
         return Err(QuoteValidationError::TransientPayerMismatch.into());
+    }
+
+    // Bind the quoted fee token to the token used for payment.
+    if transient.data.fee_token_mint != *expected_fee_token_mint {
+        return Err(QuoteValidationError::TransientContextMismatch.into());
     }
 
     // Verify stored context matches expected values. Wildcard fields match any value,
@@ -1662,4 +1673,97 @@ fn get_igp_quote_account_metas(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use hyperlane_core::H256;
+
+    /// Serializes a transient quote into the on-chain account byte layout.
+    fn transient_account_bytes(quote: &IgpTransientQuote) -> Vec<u8> {
+        let account = IgpTransientQuoteAccount::new(quote.clone().into());
+        let mut buf = vec![0u8; account.size()];
+        account.store_in_slice(&mut buf).unwrap();
+        buf
+    }
+
+    /// `try_resolve_transient_quote` must reject a quote whose stored fee_token_mint
+    /// differs from the mint used for payment, and accept any exact match (not just
+    /// the default mint). Guards HLSVM-2026Q2-013 for future SPL fee-token support.
+    #[test]
+    fn test_try_resolve_transient_quote_validates_fee_token_mint() {
+        let program_id = Pubkey::new_unique();
+        let igp_key = Pubkey::new_unique();
+        let payer = Pubkey::new_unique();
+        let sender = Pubkey::new_unique();
+        let dest_domain = 137u32;
+        let scoped_salt = H256::from_low_u64_be(42);
+        let non_default = Pubkey::new_unique();
+
+        let (pda_key, bump) = Pubkey::find_program_address(
+            igp_transient_quote_pda_seeds!(&igp_key, scoped_salt),
+            &program_id,
+        );
+
+        // (stored_mint, expected_mint, should_resolve)
+        let cases = [
+            (Pubkey::default(), Pubkey::default(), true),
+            (non_default, non_default, true),
+            (non_default, Pubkey::default(), false),
+            (Pubkey::default(), non_default, false),
+        ];
+
+        for (stored_mint, expected_mint, should_resolve) in cases {
+            let quote = IgpTransientQuote {
+                bump_seed: bump,
+                payer,
+                scoped_salt,
+                fee_token_mint: stored_mint,
+                destination_domain: dest_domain,
+                sender,
+                token_exchange_rate: 2_000_000_000_000_000_000,
+                gas_price: 1_000_000_000,
+                token_decimals: 9,
+                expiry: 1_000,
+            };
+            let mut data = transient_account_bytes(&quote);
+            let mut lamports = 1_000_000u64;
+            let account_info = AccountInfo::new(
+                &pda_key,
+                false,
+                true,
+                &mut lamports,
+                &mut data,
+                &program_id,
+                false,
+            );
+            let clock = Clock {
+                unix_timestamp: 500,
+                ..Default::default()
+            };
+
+            let result = try_resolve_transient_quote(
+                &program_id,
+                &account_info,
+                &igp_key,
+                &payer,
+                &expected_mint,
+                dest_domain,
+                &sender,
+                0,
+                &clock,
+            );
+
+            if should_resolve {
+                let resolved = result.expect("quote with matching mint should resolve");
+                assert_eq!(resolved.token_exchange_rate, 2_000_000_000_000_000_000);
+            } else {
+                assert_eq!(
+                    result.unwrap_err(),
+                    QuoteValidationError::TransientContextMismatch.into(),
+                );
+            }
+        }
+    }
 }

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -1190,6 +1190,7 @@ fn submit_igp_quote(
                     bump_seed: pda_bump,
                     payer: *payer_info.key,
                     scoped_salt,
+                    fee_token_mint: ctx.fee_token_mint,
                     destination_domain: ctx.destination_domain,
                     sender: ctx.sender,
                     token_exchange_rate: data.token_exchange_rate,


### PR DESCRIPTION
### Description

Resolves the `fee_token_mint` handling inconsistency between IGP standing and transient quotes (HLSVM-2026Q2-013).

`IgpStandingQuote` keys its PDA on and stores `fee_token_mint`, while `IgpTransientQuote` stored neither — even though the field is part of the signed quote context. This PR adds `fee_token_mint: Pubkey` to `IgpTransientQuote` (and its `SizedData`), populated from the signature-bound `ctx.fee_token_mint` at submit, so both quote types persist the mint consistently.

The submit-time `NonDefaultFeeTokenMint` guard is unchanged, so there is **no behavioral change** today — every stored quote still has `fee_token_mint == Pubkey::default()`. This is groundwork for consume-time mint validation under future any-token gas payment; that validation and the payment machinery are intentionally out of scope here.

### Drive-by changes

None.

### Related issues

- Fixes [HLSVM-2026Q2-013](https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/16)

### Backward compatibility

Yes. Transient quotes are created, consumed, and closed within a single transaction, so no persisted account is affected by the struct layout change. No PDA seeds change, the standing path is untouched, and no new validation paths are introduced.

### Testing

Unit Tests. `IgpTransientQuote` Borsh-roundtrip + sized-data unit tests carry the new field; `test_submit_transient_quote` asserts the stored mint. 29 lib tests + 4 transient functional tests pass; clippy `-D warnings` clean.
