### PR TITLE
fix(sdk): derive unrecognized NULL-module ISMs as UNKNOWN, not TEST_ISM

### DIFF
--- a/.changeset/ism-reader-unknown-null.md
+++ b/.changeset/ism-reader-unknown-null.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+EvmIsmReader no longer misclassifies unrecognized NULL-module ISMs as TEST_ISM. An Ownable NULL-type ISM that matches none of the known probes (e.g. a message-id blacklist ISM) is now derived as IsmType.UNKNOWN, since a genuine TestIsm is not Ownable; this avoids representing a real filtering module as a no-op accept-all ISM.

--- a/typescript/sdk/src/ism/EvmIsmReader.test.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.test.ts
@@ -20,6 +20,7 @@ import {
   InterchainAccountRouter__factory,
   OPStackIsm,
   OPStackIsm__factory,
+  Ownable,
   Ownable__factory,
   PausableIsm,
   PausableIsm__factory,
@@ -167,6 +168,9 @@ describe('EvmIsmReader', () => {
       .stub(RateLimitedIsm__factory, 'connect')
       .returns(mockContract as unknown as RateLimitedIsm);
     sandbox
+      .stub(Ownable__factory, 'connect')
+      .returns(mockContract as unknown as Ownable);
+    sandbox
       .stub(IInterchainSecurityModule__factory, 'connect')
       .returns(mockContract as unknown as IInterchainSecurityModule);
 
@@ -180,6 +184,55 @@ describe('EvmIsmReader', () => {
     expect(ismConfig).to.deep.equal(expectedConfig);
 
     // should get same result if we call the specific method for the ism type
+    const config = await evmIsmReader.deriveNullConfig(mockAddress);
+    expect(config).to.deep.equal(ismConfig);
+  });
+
+  it('should preserve an unrecognized Ownable NULL-type ISM as UNKNOWN, not TEST_ISM', async () => {
+    const mockAddress = randomAddress();
+    const mockOwner = randomAddress();
+
+    // A custom NULL-type ISM (e.g. a message-id blacklist ISM): all known probes miss,
+    // but it exposes owner(), so it must NOT be misclassified as a no-op TestIsm.
+    const mockContract = {
+      moduleType: sandbox.stub().resolves(ModuleType.NULL),
+      trustedRelayer: sandbox.stub().rejects(missingSelectorError()),
+      paused: sandbox.stub().rejects(missingSelectorError()),
+      ccipOrigin: sandbox.stub().rejects(missingSelectorError()),
+      VERIFIED_MASK_INDEX: sandbox.stub().rejects(missingSelectorError()),
+      recipient: sandbox.stub().rejects(missingSelectorError()),
+      owner: sandbox.stub().resolves(mockOwner),
+    };
+    sandbox
+      .stub(OPStackIsm__factory, 'connect')
+      .returns(mockContract as unknown as OPStackIsm);
+    sandbox
+      .stub(PausableIsm__factory, 'connect')
+      .returns(mockContract as unknown as PausableIsm);
+    sandbox
+      .stub(TrustedRelayerIsm__factory, 'connect')
+      .returns(mockContract as unknown as TrustedRelayerIsm);
+    sandbox
+      .stub(CCIPIsm__factory, 'connect')
+      .returns(mockContract as unknown as CCIPIsm);
+    sandbox
+      .stub(RateLimitedIsm__factory, 'connect')
+      .returns(mockContract as unknown as RateLimitedIsm);
+    sandbox
+      .stub(Ownable__factory, 'connect')
+      .returns(mockContract as unknown as Ownable);
+    sandbox
+      .stub(IInterchainSecurityModule__factory, 'connect')
+      .returns(mockContract as unknown as IInterchainSecurityModule);
+
+    const expectedConfig = {
+      address: mockAddress,
+      type: IsmType.UNKNOWN,
+    };
+
+    const ismConfig = await evmIsmReader.deriveIsmConfig(mockAddress);
+    expect(ismConfig).to.deep.equal(expectedConfig);
+
     const config = await evmIsmReader.deriveNullConfig(mockAddress);
     expect(config).to.deep.equal(ismConfig);
   });

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -55,6 +55,7 @@ import {
   NullIsmConfig,
   OffchainLookupIsmConfig,
   RoutingIsmConfig,
+  UnknownIsmConfig,
 } from './types.js';
 
 const INCREMENTAL_REVERT_STRING =
@@ -72,7 +73,9 @@ export interface IsmReader {
   deriveMultisigConfig(
     address: Address,
   ): Promise<WithAddress<MultisigIsmConfig>>;
-  deriveNullConfig(address: Address): Promise<WithAddress<NullIsmConfig>>;
+  deriveNullConfig(
+    address: Address,
+  ): Promise<WithAddress<NullIsmConfig | UnknownIsmConfig>>;
   deriveArbL2ToL1Config(
     address: Address,
   ): Promise<WithAddress<ArbL2ToL1IsmConfig>>;
@@ -553,7 +556,7 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
 
   async deriveNullConfig(
     address: Address,
-  ): Promise<WithAddress<NullIsmConfig>> {
+  ): Promise<WithAddress<NullIsmConfig | UnknownIsmConfig>> {
     const ism = IInterchainSecurityModule__factory.connect(
       address,
       this.provider,
@@ -677,7 +680,27 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
       );
     }
 
-    // no specific properties, must be Test ISM
+    // A genuine TestIsm is NOT Ownable (TestIsm.sol exposes only moduleType/verify/
+    // setVerify). If this NULL-type ISM has an owner() it is an unrecognized custom ISM
+    // (e.g. a message-id blacklist ISM), not a TestIsm. Falling through to TEST_ISM here
+    // would misrepresent a real filtering module as a no-op accept-all ISM, so preserve
+    // it as UNKNOWN instead.
+    const ownableIsm = Ownable__factory.connect(address, this.provider);
+    try {
+      await ownableIsm.owner();
+      this.logger.warn(
+        { address, chain: this.chain },
+        'Unrecognized Ownable NULL-type ISM; preserving as UNKNOWN instead of TEST_ISM',
+      );
+      return {
+        address,
+        type: IsmType.UNKNOWN,
+      };
+    } catch (error) {
+      throwIfNotMissingSelector(error);
+    }
+
+    // no owner and no recognized selectors --> genuine Test ISM
     return {
       address,
       type: IsmType.TEST_ISM,


### PR DESCRIPTION
## Summary

`EvmIsmReader.deriveNullConfig` ended with an unconditional `TEST_ISM` fallback. Any NULL-module ISM (`moduleType() == 6`) that matched none of the known probes (`trustedRelayer` / `pausable` / `ccip` / `opStack` / `rateLimited`) was labelled `IsmType.TEST_ISM` — a no-op, accept-all module. This **understates the security of real custom ISMs**.

Concretely: the `krown` warp routes (ETH/USDC/USDT) enroll a custom **message-ID blacklist ISM** in their krown-origin aggregation. On-chain it is `moduleType=6 (NULL)`, Ownable, built on Hyperlane core `11.3.1`, and exposes `verify(bytes,bytes)` + `blacklist(bytes32[])`. The reader derived it as `testIsm`, which is what surfaced in registry PR encoding these ISMs and triggered the "why is there a testIsm in prod?" discussion.

## Fix

A genuine `TestIsm` is **not** Ownable (`TestIsm.sol` exposes only `moduleType` / `verify` / `setVerify`). The fallback now probes `owner()`; if present, the ISM is an unrecognized custom NULL-type ISM and is preserved as `IsmType.UNKNOWN` (which the SDK already models) instead of `TEST_ISM`. Transient (non-missing-selector) errors still propagate via `throwIfNotMissingSelector`.

This is a faithful-representation fix only — `UNKNOWN` is already excluded from `DeployableIsmType`, so nothing changes about deployment behavior.

## Test plan

- [x] `EvmIsmReader.test.ts` — existing "derive test ISM" case still passes (non-Ownable → `TEST_ISM`)
- [x] New case: Ownable NULL-type ISM with all probes missing → `IsmType.UNKNOWN`
- [x] `tsc --noEmit` clean, `oxlint` clean
- [ ] Follow-up (separate): once the blacklist ISM contract lands in `@hyperlane-xyz/core`, add a first-class `deriveNullConfig` probe + `IsmType` so it derives as a typed config rather than `UNKNOWN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)