### PR TITLE
feat: transfer with memo

### DIFF
--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
@@ -37,6 +37,8 @@ pub enum Instruction {
     SetInterchainGasPaymaster(Option<(Pubkey, InterchainGasPaymasterType)>),
     /// Transfer ownership of the program. Only owner.
     TransferOwnership(Option<Pubkey>),
+    /// Transfer tokens to a remote recipient with a memo.
+    TransferRemoteWithMemo(TransferRemoteWithMemo),
 }
 
 impl DiscriminatorData for Instruction {
@@ -67,6 +69,15 @@ pub struct TransferRemote {
     pub recipient: H256,
     /// The amount or ID of the token to transfer.
     pub amount_or_id: U256,
+}
+
+/// Instruction data for transferring `amount_or_id` token to `recipient` on `destination` domain including a memo.
+#[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq)]
+pub struct TransferRemoteWithMemo {
+    /// The parameters for the remote transfer.
+    pub xfer: TransferRemote,
+    /// A memo to include in the message.
+    pub memo: Vec<u8>,
 }
 
 /// Gets an instruction to initialize the program. This provides only the

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -278,10 +278,7 @@ where
         accounts: &[AccountInfo],
         transfer: TransferRemoteWithMemo,
     ) -> ProgramResult {
-	let TransferRemoteWithMemo {
-	    xfer,
-	    memo
-	} = transfer;
+        let TransferRemoteWithMemo { xfer, memo } = transfer;
         let accounts_iter = &mut accounts.iter();
 
         // Account 0: System program.

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 use crate::{
     accounts::{HyperlaneToken, HyperlaneTokenAccount},
     error::Error,
-    instruction::{Init, TransferRemote},
+    instruction::{Init, TransferRemoteWithMemo},
 };
 
 /// Seeds relating to the PDA account with information about this warp route.
@@ -273,11 +273,15 @@ where
     /// - 13: `[writeable]` The IGP account.
     ///   ---- End if ----
     /// - 14..N: `[??..??]` Plugin-specific accounts.
-    pub fn transfer_remote(
+    pub fn transfer_remote_with_memo(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
-        xfer: TransferRemote,
+        transfer: TransferRemoteWithMemo,
     ) -> ProgramResult {
+	let TransferRemoteWithMemo {
+	    xfer,
+	    memo
+	} = transfer;
         let accounts_iter = &mut accounts.iter();
 
         // Account 0: System program.
@@ -454,7 +458,7 @@ where
 
         // The token message body, which specifies the remote_amount.
         let token_transfer_message =
-            TokenMessage::new(xfer.recipient, remote_amount, vec![]).to_vec();
+            TokenMessage::new(xfer.recipient, remote_amount, memo).to_vec();
 
         if let Some((igp_payment_account_metas, igp_payment_account_infos)) = igp_payment_accounts {
             // Dispatch the message and pay for gas.

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/processor.rs
@@ -62,8 +62,14 @@ pub fn process_instruction(
     // Otherwise, try decoding a "normal" token instruction
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
-        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![] }),
-        TokenIxn::TransferRemoteWithMemo(xfer) => transfer_remote_with_memo(program_id, accounts, xfer),
+        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(
+            program_id,
+            accounts,
+            TransferRemoteWithMemo { xfer, memo: vec![] },
+        ),
+        TokenIxn::TransferRemoteWithMemo(xfer) => {
+            transfer_remote_with_memo(program_id, accounts, xfer)
+        }
         TokenIxn::EnrollRemoteRouter(config) => enroll_remote_router(program_id, accounts, config),
         TokenIxn::EnrollRemoteRouters(configs) => {
             enroll_remote_routers(program_id, accounts, configs)
@@ -133,7 +139,9 @@ fn transfer_remote_with_memo(
     accounts: &[AccountInfo],
     transfer: TransferRemoteWithMemo,
 ) -> ProgramResult {
-    HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
+    HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(
+        program_id, accounts, transfer,
+    )
 }
 
 // Accounts:

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/src/processor.rs
@@ -9,7 +9,7 @@ use hyperlane_sealevel_message_recipient_interface::{
     HandleInstruction, MessageRecipientInstruction,
 };
 use hyperlane_sealevel_token_lib::{
-    instruction::{Init, Instruction as TokenIxn, TransferRemote},
+    instruction::{Init, Instruction as TokenIxn, TransferRemoteWithMemo},
     processor::HyperlaneSealevelToken,
 };
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey};
@@ -62,7 +62,8 @@ pub fn process_instruction(
     // Otherwise, try decoding a "normal" token instruction
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
-        TokenIxn::TransferRemote(xfer) => transfer_remote(program_id, accounts, xfer),
+        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![] }),
+        TokenIxn::TransferRemoteWithMemo(xfer) => transfer_remote_with_memo(program_id, accounts, xfer),
         TokenIxn::EnrollRemoteRouter(config) => enroll_remote_router(program_id, accounts, config),
         TokenIxn::EnrollRemoteRouters(configs) => {
             enroll_remote_routers(program_id, accounts, configs)
@@ -127,12 +128,12 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], init: Init) -> Prog
 /// 15.  `[writeable]` The mint.
 /// 16.  `[writeable]` The token sender's associated token account, from which tokens will be sent.
 /// 17.  `[writeable]` The escrow PDA account.
-fn transfer_remote(
+fn transfer_remote_with_memo(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    transfer: TransferRemote,
+    transfer: TransferRemoteWithMemo,
 ) -> ProgramResult {
-    HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote(program_id, accounts, transfer)
+    HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
 }
 
 // Accounts:

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
@@ -25,7 +25,7 @@ use hyperlane_sealevel_message_recipient_interface::{
 };
 use hyperlane_sealevel_token_lib::{
     accounts::{HyperlaneToken, HyperlaneTokenAccount},
-    instruction::{Init, Instruction as TokenIxn},
+    instruction::{Init, Instruction as TokenIxn, TransferRemoteWithMemo},
     processor::{HyperlaneSealevelToken, HyperlaneSealevelTokenPlugin},
 };
 use hyperlane_warp_route::TokenMessage;
@@ -125,7 +125,10 @@ pub fn process_instruction(
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
         TokenIxn::TransferRemote(xfer) => {
-            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote(program_id, accounts, xfer)
+            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![]})
+        }
+        TokenIxn::TransferRemoteWithMemo(transfer) => {
+            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
         }
         TokenIxn::EnrollRemoteRouter(config) => {
             HyperlaneSealevelToken::<CollateralPlugin>::enroll_remote_router(

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/src/processor.rs
@@ -125,10 +125,16 @@ pub fn process_instruction(
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
         TokenIxn::TransferRemote(xfer) => {
-            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![]})
+            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(
+                program_id,
+                accounts,
+                TransferRemoteWithMemo { xfer, memo: vec![] },
+            )
         }
         TokenIxn::TransferRemoteWithMemo(transfer) => {
-            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
+            HyperlaneSealevelToken::<CollateralPlugin>::transfer_remote_with_memo(
+                program_id, accounts, transfer,
+            )
         }
         TokenIxn::EnrollRemoteRouter(config) => {
             HyperlaneSealevelToken::<CollateralPlugin>::enroll_remote_router(

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
@@ -9,7 +9,7 @@ use hyperlane_sealevel_message_recipient_interface::{
     HandleInstruction, MessageRecipientInstruction,
 };
 use hyperlane_sealevel_token_lib::{
-    instruction::{Init, Instruction as TokenIxn, TransferRemote},
+    instruction::{Init, Instruction as TokenIxn, TransferRemoteWithMemo},
     processor::HyperlaneSealevelToken,
 };
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey};
@@ -62,7 +62,8 @@ pub fn process_instruction(
     // Otherwise, try decoding a "normal" token instruction
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
-        TokenIxn::TransferRemote(xfer) => transfer_remote(program_id, accounts, xfer),
+        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![]}),
+        TokenIxn::TransferRemoteWithMemo(transfer) => transfer_remote_with_memo(program_id, accounts, transfer),
         TokenIxn::EnrollRemoteRouter(config) => enroll_remote_router(program_id, accounts, config),
         TokenIxn::EnrollRemoteRouters(configs) => {
             enroll_remote_routers(program_id, accounts, configs)
@@ -121,12 +122,12 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], init: Init) -> Prog
 ///      ---- End if ----
 /// 14.  `[executable]` The system program.
 /// 15.  `[writeable]` The native token collateral PDA account.
-fn transfer_remote(
+fn transfer_remote_with_memo(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    transfer: TransferRemote,
+    transfer: TransferRemoteWithMemo,
 ) -> ProgramResult {
-    HyperlaneSealevelToken::<NativePlugin>::transfer_remote(program_id, accounts, transfer)
+    HyperlaneSealevelToken::<NativePlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
 }
 
 /// Accounts:

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/src/processor.rs
@@ -62,8 +62,14 @@ pub fn process_instruction(
     // Otherwise, try decoding a "normal" token instruction
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
-        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![]}),
-        TokenIxn::TransferRemoteWithMemo(transfer) => transfer_remote_with_memo(program_id, accounts, transfer),
+        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(
+            program_id,
+            accounts,
+            TransferRemoteWithMemo { xfer, memo: vec![] },
+        ),
+        TokenIxn::TransferRemoteWithMemo(transfer) => {
+            transfer_remote_with_memo(program_id, accounts, transfer)
+        }
         TokenIxn::EnrollRemoteRouter(config) => enroll_remote_router(program_id, accounts, config),
         TokenIxn::EnrollRemoteRouters(configs) => {
             enroll_remote_routers(program_id, accounts, configs)
@@ -127,7 +133,9 @@ fn transfer_remote_with_memo(
     accounts: &[AccountInfo],
     transfer: TransferRemoteWithMemo,
 ) -> ProgramResult {
-    HyperlaneSealevelToken::<NativePlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
+    HyperlaneSealevelToken::<NativePlugin>::transfer_remote_with_memo(
+        program_id, accounts, transfer,
+    )
 }
 
 /// Accounts:

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
@@ -9,7 +9,7 @@ use hyperlane_sealevel_message_recipient_interface::{
     HandleInstruction, MessageRecipientInstruction,
 };
 use hyperlane_sealevel_token_lib::{
-    instruction::{Init, Instruction as TokenIxn, TransferRemote},
+    instruction::{Init, Instruction as TokenIxn, TransferRemoteWithMemo},
     processor::HyperlaneSealevelToken,
 };
 use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey};
@@ -62,7 +62,8 @@ pub fn process_instruction(
     // Otherwise, try decoding a "normal" token instruction
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
-        TokenIxn::TransferRemote(xfer) => transfer_remote(program_id, accounts, xfer),
+        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![]}),
+        TokenIxn::TransferRemoteWithMemo(transfer) => transfer_remote_with_memo(program_id, accounts, transfer),
         TokenIxn::EnrollRemoteRouter(config) => enroll_remote_router(program_id, accounts, config),
         TokenIxn::EnrollRemoteRouters(configs) => {
             enroll_remote_routers(program_id, accounts, configs)
@@ -123,12 +124,12 @@ fn initialize(program_id: &Pubkey, accounts: &[AccountInfo], init: Init) -> Prog
 /// 14. `[executable]` The spl_token_2022 program.
 /// 15. `[writeable]` The mint / mint authority PDA account.
 /// 16. `[writeable]` The token sender's associated token account, from which tokens will be burned.
-fn transfer_remote(
+fn transfer_remote_with_memo(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    transfer: TransferRemote,
+    transfer: TransferRemoteWithMemo,
 ) -> ProgramResult {
-    HyperlaneSealevelToken::<SyntheticPlugin>::transfer_remote(program_id, accounts, transfer)
+    HyperlaneSealevelToken::<SyntheticPlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
 }
 
 // Accounts:

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/processor.rs
@@ -62,8 +62,14 @@ pub fn process_instruction(
     // Otherwise, try decoding a "normal" token instruction
     match TokenIxn::decode(instruction_data)? {
         TokenIxn::Init(init) => initialize(program_id, accounts, init),
-        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(program_id, accounts, TransferRemoteWithMemo { xfer, memo: vec![]}),
-        TokenIxn::TransferRemoteWithMemo(transfer) => transfer_remote_with_memo(program_id, accounts, transfer),
+        TokenIxn::TransferRemote(xfer) => transfer_remote_with_memo(
+            program_id,
+            accounts,
+            TransferRemoteWithMemo { xfer, memo: vec![] },
+        ),
+        TokenIxn::TransferRemoteWithMemo(transfer) => {
+            transfer_remote_with_memo(program_id, accounts, transfer)
+        }
         TokenIxn::EnrollRemoteRouter(config) => enroll_remote_router(program_id, accounts, config),
         TokenIxn::EnrollRemoteRouters(configs) => {
             enroll_remote_routers(program_id, accounts, configs)
@@ -129,7 +135,9 @@ fn transfer_remote_with_memo(
     accounts: &[AccountInfo],
     transfer: TransferRemoteWithMemo,
 ) -> ProgramResult {
-    HyperlaneSealevelToken::<SyntheticPlugin>::transfer_remote_with_memo(program_id, accounts, transfer)
+    HyperlaneSealevelToken::<SyntheticPlugin>::transfer_remote_with_memo(
+        program_id, accounts, transfer,
+    )
 }
 
 // Accounts:


### PR DESCRIPTION
### Description

Adds a new instruction to the token programs for transferring `amount_or_id` token to `recipient` on `destination` domain including a memo.

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
