### PR TITLE
chore(infra): disable swell and miraclechain agents

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -180,7 +180,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     stride: false,
     subtensor: true,
     superseed: true,
-    swell: true,
+    swell: false, // disabled — Swell network sunset 2026-06-30
     tac: true,
     taiko: false, // temporarily disabled out of caution (Taiko network incident)
     tea: true,
@@ -312,7 +312,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     stride: true,
     subtensor: true,
     superseed: true,
-    swell: true,
+    swell: false, // disabled — Swell network sunset 2026-06-30
     tac: true,
     taiko: false, // temporarily disabled out of caution (Taiko network incident)
     tea: true,
@@ -444,7 +444,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     stride: true,
     subtensor: true,
     superseed: true,
-    swell: true,
+    swell: false, // disabled — Swell network sunset 2026-06-30
     tac: true,
     taiko: true,
     tea: true,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -136,7 +136,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     megaeth: true,
     metal: true,
     metis: true,
-    miraclechain: true,
+    miraclechain: false, // temporarily disabled
     mitosis: true,
     mocachain: true,
     mode: true,
@@ -268,7 +268,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     megaeth: true,
     metal: true,
     metis: true,
-    miraclechain: true,
+    miraclechain: false, // temporarily disabled
     mitosis: true,
     mocachain: true,
     mode: true,
@@ -400,7 +400,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     megaeth: true,
     metal: true,
     metis: true,
-    miraclechain: true,
+    miraclechain: false, // temporarily disabled
     mitosis: true,
     mocachain: true,
     mode: true,

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -136,7 +136,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     megaeth: true,
     metal: true,
     metis: true,
-    miraclechain: false, // temporarily disabled
+    miraclechain: false, // disabled — Miraclechain network sunset 2026-06-30
     mitosis: true,
     mocachain: true,
     mode: true,
@@ -268,7 +268,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     megaeth: true,
     metal: true,
     metis: true,
-    miraclechain: false, // temporarily disabled
+    miraclechain: false, // disabled — Miraclechain network sunset 2026-06-30
     mitosis: true,
     mocachain: true,
     mode: true,
@@ -400,7 +400,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     megaeth: true,
     metal: true,
     metis: true,
-    miraclechain: false, // temporarily disabled
+    miraclechain: false, // disabled — Miraclechain network sunset 2026-06-30
     mitosis: true,
     mocachain: true,
     mode: true,

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -73,7 +73,7 @@ export const keyFunderConfig: KeyFunderConfig<
     [Contexts.ReleaseCandidate]: [Role.Relayer],
     [Contexts.FastPath]: [Role.Relayer],
   },
-  chainsToSkip: ['litchain', 'artela', 'molten'],
+  chainsToSkip: ['litchain', 'artela', 'molten', 'swell'],
   // desired balance config, must be set for each chain
   desiredBalancePerChain: desiredRelayerBalancePerChain,
   // desired rebalancer balance config

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -73,7 +73,7 @@ export const keyFunderConfig: KeyFunderConfig<
     [Contexts.ReleaseCandidate]: [Role.Relayer],
     [Contexts.FastPath]: [Role.Relayer],
   },
-  chainsToSkip: ['litchain', 'artela', 'molten', 'swell'],
+  chainsToSkip: ['litchain', 'artela', 'molten', 'swell', 'miraclechain'],
   // desired balance config, must be set for each chain
   desiredBalancePerChain: desiredRelayerBalancePerChain,
   // desired rebalancer balance config

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -103,6 +103,10 @@ export const chainsToSkip: ChainName[] = [
   'abstract',
   'sophon',
 
+  // Swell network sunset 2026-06-30 (registry marks it disabled; kept explicit
+  // until the pinned .registryrc is bumped past the disable commit).
+  'swell',
+
   ...getDisabledChains(),
 ];
 

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -107,6 +107,10 @@ export const chainsToSkip: ChainName[] = [
   // until the pinned .registryrc is bumped past the disable commit).
   'swell',
 
+  // Miraclechain network sunset 2026-06-30. Not yet marked disabled in the
+  // pinned registry, so kept explicit here.
+  'miraclechain',
+
   ...getDisabledChains(),
 ];
 


### PR DESCRIPTION
## Summary
- Disable **swell** agents (validator + relayer + scraper) — Swell network sunset 2026-06-30. Added to keyFunder `chainsToSkip` and infra `chainsToSkip`.
- Disable **miraclechain** agents (validator + relayer + scraper) — Miraclechain network sunset 2026-06-30. Added to keyFunder `chainsToSkip` and infra `chainsToSkip`.

## Notes
- swell warp routes are all synthetic legs backed by ethereum collateral; owners (Renzo, Aero) are aware. No collateral on swell to rescue.
- Neither chain is yet marked `availability: disabled` in the pinned registry, so both are listed explicitly in `chainsToSkip` (see below for why that list matters).
- Prod already updated manually (validators scaled to 0; swell+miraclechain removed from relayer `HYP_RELAYCHAINS` and scraper `HYP_CHAINSTOSCRAPE`). Merging this makes it durable across the next helm deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)