### PR TITLE
fix(sdk): read remote router and self-router fee contracts in warp check

### DIFF
--- a/.changeset/chatty-humans-reply.md
+++ b/.changeset/chatty-humans-reply.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Fixed warp read and check for remote router cross collateral fees

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -33,6 +33,7 @@ import {
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   Address,
+  addressToBytes32,
   arrayToObject,
   assert,
   eqAddress,
@@ -55,12 +56,20 @@ import {
   DerivedTokenFeeConfig,
   EvmTokenFeeReader,
 } from '../fee/EvmTokenFeeReader.js';
+import {
+  CrossCollateralRoutersByDomain,
+  mergeCrossCollateralRouters,
+} from '../fee/crossCollateralUtils.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { DerivedHookConfig, HookType, OnchainHookType } from '../hook/types.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmRouterReader } from '../router/EvmRouterReader.js';
-import { DestinationGas } from '../router/types.js';
+import {
+  DestinationGas,
+  RemoteRouters,
+  resolveRouterMapConfig,
+} from '../router/types.js';
 import { ChainName, ChainNameOrId, DeployedOwnableConfig } from '../types.js';
 import {
   isMissingSelectorCallException,
@@ -329,6 +338,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       isCrossCollateralTokenConfig(tokenConfig)
         ? tokenConfig.crossCollateralRouters
         : undefined,
+      routerConfig.remoteRouters,
     );
 
     // Read feeHook (IGP address for ERC20 gas payments)
@@ -459,6 +469,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     routerAddress: Address,
     destinations?: number[],
     crossCollateralRouters?: Record<string, string[]>,
+    remoteRouters?: RemoteRouters,
   ): Promise<DerivedTokenFeeConfig | undefined> {
     const TokenRouter = TokenRouter__factory.connect(
       routerAddress,
@@ -505,7 +516,9 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         return undefined;
       }));
 
-    const normalizedCrossCollateralRouters = crossCollateralRouters
+    const normalizedCrossCollateralRouters:
+      | CrossCollateralRoutersByDomain
+      | undefined = crossCollateralRouters
       ? Object.fromEntries(
           Object.entries(crossCollateralRouters).map(([domain, routers]) => [
             Number(domain),
@@ -513,10 +526,31 @@ export class EvmWarpRouteReader extends EvmRouterReader {
           ]),
         )
       : undefined;
+
+    const remoteRoutersByDomain: CrossCollateralRoutersByDomain | undefined =
+      remoteRouters && Object.keys(remoteRouters).length > 0
+        ? Object.fromEntries(
+            Object.entries(
+              resolveRouterMapConfig(this.multiProvider, remoteRouters),
+            ).map(([domain, { address }]) => [Number(domain), [address]]),
+          )
+        : undefined;
+
+    // Also probe the warp token's own address (as bytes32) for the local domain,
+    // since fee contracts may be keyed by the token's self-address for same-chain swaps.
+    const localDomain = this.multiProvider.getDomainId(this.chain);
+    const selfRouterByDomain: CrossCollateralRoutersByDomain = {
+      [localDomain]: [addressToBytes32(routerAddress)],
+    };
+
     return this.evmTokenFeeReader.deriveTokenFeeConfig({
       address: tokenFee,
       routingDestinations,
-      crossCollateralRouters: normalizedCrossCollateralRouters,
+      crossCollateralRouters: mergeCrossCollateralRouters(
+        normalizedCrossCollateralRouters,
+        remoteRoutersByDomain,
+        selfRouterByDomain,
+      ),
     });
   }
 


### PR DESCRIPTION
## Summary

- The `CrossCollateralRoutingFee` reader in `EvmWarpRouteReader.fetchTokenFee` only probed `DEFAULT_ROUTER_KEY` and explicitly enrolled cross-collateral router addresses when querying `feeContracts(destination, router)` onchain
- Fee contracts keyed by **remote router addresses** (warp token addresses on other chains) and by the **token's own address** (for same-chain/self-domain swaps) were never discovered, causing false violations in warp check
- Fixed by merging two additional key sets into the probed router keys per destination:
  1. `remoteRouters` from `routerConfig` — bytes32-encoded warp token addresses on each remote chain
  2. `addressToBytes32(routerAddress)` for the local domain — covers self-keyed fee contracts

## Test plan

- [x] Existing 614 SDK unit tests pass
- [x] Run `hyperlane warp check` on USDT/moonpay route and confirm fee contract violations are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)