### PR TITLE
fix(sdk): stop counting bridged amount as native fee in quoteTransferRemoteGas

### DIFF
--- a/.changeset/native-warp-route-quote-fix.md
+++ b/.changeset/native-warp-route-quote-fix.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fixed EvmHypSyntheticAdapter.quoteTransferRemoteGas miscounting the bridged amount as a native fee for native warp routes (token() == address(0)), which inflated the IGP quote and caused downstream consumers (e.g. the rebalancer) to over-reserve costs. The transfer amount is now subtracted from the internal-fee quote before quotes are classified as native or ERC20.

--- a/typescript/sdk/src/token/adapters/EvmHypSyntheticAdapter.test.ts
+++ b/typescript/sdk/src/token/adapters/EvmHypSyntheticAdapter.test.ts
@@ -21,14 +21,12 @@ describe('EvmHypSyntheticAdapter.quoteTransferRemoteGas', () => {
   //   [0] gas payment, [1] transfer amount + internal fee, [2] external fee.
   function stubRawQuotes(quotes: Array<[string, bigint]>) {
     sandbox.stub(adapter, 'getContractPackageVersion').resolves('10.0.0');
-    const quoteFn = sandbox
-      .stub()
-      .resolves(
-        quotes.map(([token, amount]) => ({
-          0: token,
-          1: BigNumber.from(amount),
-        })),
-      );
+    const quoteFn = sandbox.stub().resolves(
+      quotes.map(([token, amount]) => ({
+        0: token,
+        1: BigNumber.from(amount),
+      })),
+    );
     // @ts-ignore inject a minimal contract stub for the unit test
     adapter.contract = {
       'quoteTransferRemote(uint32,bytes32,uint256)': quoteFn,

--- a/typescript/sdk/src/token/adapters/EvmHypSyntheticAdapter.test.ts
+++ b/typescript/sdk/src/token/adapters/EvmHypSyntheticAdapter.test.ts
@@ -1,0 +1,119 @@
+import { expect } from 'chai';
+import { BigNumber, constants } from 'ethers';
+import sinon from 'sinon';
+
+import { test1, test2 } from '../../consts/testChains.js';
+import { MultiProtocolProvider } from '../../providers/MultiProtocolProvider.js';
+
+import { EvmHypSyntheticAdapter } from './EvmTokenAdapter.js';
+
+describe('EvmHypSyntheticAdapter.quoteTransferRemoteGas', () => {
+  const TOKEN_ADDRESS = '0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b';
+  const RECIPIENT = '0x1111111111111111111111111111111111111111';
+  const DESTINATION_DOMAIN = test2.domainId!;
+  const AMOUNT = 100n;
+
+  let adapter: EvmHypSyntheticAdapter;
+  let sandbox: sinon.SinonSandbox;
+
+  // Stubs the versioned quoteTransferRemote(uint32,bytes32,uint256) call to return
+  // the provided [token, amount] tuples, mirroring TokenRouter.quoteTransferRemote:
+  //   [0] gas payment, [1] transfer amount + internal fee, [2] external fee.
+  function stubRawQuotes(quotes: Array<[string, bigint]>) {
+    sandbox.stub(adapter, 'getContractPackageVersion').resolves('10.0.0');
+    const quoteFn = sandbox
+      .stub()
+      .resolves(
+        quotes.map(([token, amount]) => ({
+          0: token,
+          1: BigNumber.from(amount),
+        })),
+      );
+    // @ts-ignore inject a minimal contract stub for the unit test
+    adapter.contract = {
+      'quoteTransferRemote(uint32,bytes32,uint256)': quoteFn,
+    };
+  }
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const multiProvider =
+      MultiProtocolProvider.createTestMultiProtocolProvider();
+    adapter = new EvmHypSyntheticAdapter(test1.name, multiProvider, {
+      token: TOKEN_ADDRESS,
+    });
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('does not count the bridged amount as a native fee for native routes', async () => {
+    // Native route: token() == address(0), so every quote is denominated in address(0).
+    // Regression guard: index 1 (amount + fee) must not be summed into the IGP quote.
+    stubRawQuotes([
+      [constants.AddressZero, 5n],
+      [constants.AddressZero, AMOUNT],
+      [constants.AddressZero, 0n],
+    ]);
+
+    const result = await adapter.quoteTransferRemoteGas({
+      destination: DESTINATION_DOMAIN,
+      recipient: RECIPIENT,
+      amount: AMOUNT,
+    });
+
+    expect(result.igpQuote.amount).to.equal(5n);
+    expect(result.tokenFeeQuote).to.equal(undefined);
+  });
+
+  it('sums native fees for native routes with internal and external fees', async () => {
+    stubRawQuotes([
+      [constants.AddressZero, 5n],
+      [constants.AddressZero, AMOUNT + 7n],
+      [constants.AddressZero, 3n],
+    ]);
+
+    const result = await adapter.quoteTransferRemoteGas({
+      destination: DESTINATION_DOMAIN,
+      recipient: RECIPIENT,
+      amount: AMOUNT,
+    });
+
+    expect(result.igpQuote.amount).to.equal(15n);
+    expect(result.tokenFeeQuote).to.equal(undefined);
+  });
+
+  it('returns only the native gas payment for ERC20 routes without fees', async () => {
+    stubRawQuotes([
+      [constants.AddressZero, 5n],
+      [TOKEN_ADDRESS, AMOUNT],
+      [TOKEN_ADDRESS, 0n],
+    ]);
+
+    const result = await adapter.quoteTransferRemoteGas({
+      destination: DESTINATION_DOMAIN,
+      recipient: RECIPIENT,
+      amount: AMOUNT,
+    });
+
+    expect(result.igpQuote.amount).to.equal(5n);
+    expect(result.tokenFeeQuote).to.equal(undefined);
+  });
+
+  it('collects ERC20 gas and fees into the tokenFeeQuote', async () => {
+    stubRawQuotes([
+      [TOKEN_ADDRESS, 5n],
+      [TOKEN_ADDRESS, AMOUNT + 7n],
+      [TOKEN_ADDRESS, 3n],
+    ]);
+
+    const result = await adapter.quoteTransferRemoteGas({
+      destination: DESTINATION_DOMAIN,
+      recipient: RECIPIENT,
+      amount: AMOUNT,
+    });
+
+    expect(result.igpQuote.amount).to.equal(0n);
+    expect(result.tokenFeeQuote?.addressOrDenom).to.equal(TOKEN_ADDRESS);
+    expect(result.tokenFeeQuote?.amount).to.equal(15n);
+  });
+});

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -492,7 +492,7 @@ export class EvmHypSyntheticAdapter
     // (token()==address(0)) index 1 is denominated in address(0), so leaving the
     // bridged amount in would miscount it as a native fee and inflate the IGP quote.
     const feeQuotes = rawQuotes.map((q, i) => ({
-      addressOrDenom: q[0] as Address,
+      addressOrDenom: q[0],
       amount: BigInt(q[1].toString()) - (i === 1 ? amount : 0n),
     }));
 

--- a/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/EvmTokenAdapter.ts
@@ -483,20 +483,26 @@ export class EvmHypSyntheticAdapter
       'quoteTransferRemote(uint32,bytes32,uint256)'
     ](destination, recipBytes32, amount.toString());
 
-    const allQuotes = rawQuotes.map((q) => ({
+    // Per the TokenRouter.quoteTransferRemote convention the contract returns:
+    //   [0] gas payment (native when feeToken()==address(0), else token())
+    //   [1] transfer amount + internal warp route fee (denominated in token())
+    //   [2] external bridging fee (denominated in token())
+    // Subtract the transfer amount from index 1 so only the fee portion remains.
+    // This must happen before classifying quotes by denom: for native routes
+    // (token()==address(0)) index 1 is denominated in address(0), so leaving the
+    // bridged amount in would miscount it as a native fee and inflate the IGP quote.
+    const feeQuotes = rawQuotes.map((q, i) => ({
       addressOrDenom: q[0] as Address,
-      amount: BigInt(q[1].toString()),
+      amount: BigInt(q[1].toString()) - (i === 1 ? amount : 0n),
     }));
 
-    // Native quotes (token == address(0)) → msg.value sent with transferRemote
-    const nativeAmount = allQuotes
+    // Native fees (denom == address(0)) → msg.value sent with transferRemote.
+    const nativeAmount = feeQuotes
       .filter((q) => isZeroishAddress(q.addressOrDenom))
       .reduce((sum, q) => sum + q.amount, 0n);
 
-    // ERC20 quotes → must be approved before transferRemote.
-    // quotes[1] always has token = token() with amount = transfer_amount + feeAmount.
-    // Subtract transfer_amount from index 1 only, so we get just the fee portion.
-    const erc20Quotes = allQuotes.filter(
+    // ERC20 fees → must be approved before transferRemote.
+    const erc20Quotes = feeQuotes.filter(
       (q) => !isZeroishAddress(q.addressOrDenom),
     );
     const erc20Denoms = new Set(
@@ -506,10 +512,7 @@ export class EvmHypSyntheticAdapter
       erc20Denoms.size <= 1,
       `Unexpected multi-token ERC20 fee quotes: ${[...erc20Denoms].join(', ')}`,
     );
-    const tokenFeeAmount = allQuotes.reduce((sum, q, i) => {
-      if (isZeroishAddress(q.addressOrDenom)) return sum;
-      return sum + q.amount - (i === 1 ? amount : 0n);
-    }, 0n);
+    const tokenFeeAmount = erc20Quotes.reduce((sum, q) => sum + q.amount, 0n);
     const tokenFeeQuote: Quote | undefined =
       tokenFeeAmount > 0n
         ? {


### PR DESCRIPTION
## Summary
- Fixes a regression introduced in #8443 that broke `Rebalancer E2E Tests` on `main` (12 failing: `InventoryMinAmountStrategy` + `Inventory WeightedStrategy`).
- For **native** warp routes (`token() == address(0)`), every entry returned by `TokenRouter.quoteTransferRemote` is denominated in `address(0)`. The #8443 rewrite of `EvmHypSyntheticAdapter.quoteTransferRemoteGas` summed the index-1 entry (`transfer amount + internal fee`) into the native/IGP quote, inflating `igpQuote.amount` by the full transfer amount.
- Downstream, the rebalancer's `calculateTransferCosts` over-reserved costs → `maxTransferable` collapsed to `0` → no transfer/intent was created (`expected +0 to equal 1`). ERC20 routes were unaffected because their index-1 denom is non-zero and already subtracted `amount`.

## Fix
- Subtract the transfer `amount` from the index-1 quote **before** classifying quotes as native vs ERC20, so the bridged amount is never miscounted as a fee. Preserves #8443's ERC20 feeHook support.

## Root cause / bisection
- Last green `rebalancer-e2e` on main: `019201ac` (06-25). First red: `9cd76063` (06-29) = the #8443 merge.

## Test plan
- [x] New unit test `EvmHypSyntheticAdapter.test.ts` (native no-fee, native with fees, ERC20 no-fee, ERC20 with fees) — all passing.
- [x] `Rebalancer E2E Tests` workflow run against this branch is **green** (12 → 0 failing): https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/28533488959
- [x] `pnpm -C typescript/sdk build`, oxlint clean, changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)