### PR TITLE
feat: add moonpay quote update scripts

### DIFF
--- a/.claude/skills/set-moonpay-standing-quotes/SKILL.md
+++ b/.claude/skills/set-moonpay-standing-quotes/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: set-moonpay-standing-quotes
+description: Update standing fee quotes for the CROSS/moonpay warp route. Use when asked to set, update, or change fees/bps for specific chains, tokens, or directions in the MoonPay route. Also use when asked to show or read current standing quotes.
+---
+
+# Set MoonPay Standing Quotes Skill
+
+## When to Use
+
+- "update fees from arbitrum USDC to all USDT destinations to 5bps"
+- "set moonpay fee for katana → base DEFAULT slot to 3bps"
+- "change all fees to 4bps"
+- Any request to modify standing quote bps for the CROSS/moonpay warp route
+- "show current moonpay fees" / "what are the current standing quotes?" → run `print-quotes.ts` (see below)
+
+## Route Reference
+
+**CROSS/moonpay** — EVM origin chains and source token labels:
+
+| Chain    | Source tokens |
+| -------- | ------------- |
+| arbitrum | USDC, USDT    |
+| base     | USDC, USDT    |
+| bsc      | USDC, USDT    |
+| citrea   | ctUSD         |
+| ethereum | USDC, USDT    |
+| katana   | USDC, USDT    |
+| polygon  | USDC, USDT    |
+
+Destinations include all the above chains plus `solanamainnet`.
+
+**Targets** — destination router slot labels:
+
+- `DEFAULT` — fallback slot covering any router with no specific override
+- `USDC` — per-router slot for the USDC router on the destination
+- `USDT` — per-router slot for the USDT router on the destination
+- `ctUSD` — per-router slot for the citrea router
+- `XO` — per-router slot for the solanamainnet router
+
+## Parsing Natural Language → CLI Flags
+
+| Concept in request           | Flag              | Value                               |
+| ---------------------------- | ----------------- | ----------------------------------- |
+| origin chain(s)              | `--origins`       | comma-separated names or `all`      |
+| source token(s) on origin    | `--source-tokens` | `USDC`, `USDT`, `ctUSD`, or `all`   |
+| destination chain(s)         | `--destinations`  | comma-separated names or `all`      |
+| destination router target(s) | `--targets`       | `DEFAULT`, `USDC`, `USDT`, or `all` |
+| fee amount                   | `--bps`           | number (e.g. `3`, `5`, `0.5`)       |
+| quote lifetime               | `--ttl`           | seconds (86400 = 24h, 604800 = 7d)  |
+
+**Heuristics:**
+
+- "from X" → `--origins X`
+- "USDC/USDT" before "→" or "to" → `--source-tokens`
+- "to X" / "→ X" as destination chain → `--destinations X`
+- "USDT destinations" / "USDC targets" → `--targets USDT/USDC`
+- target not mentioned → `--targets DEFAULT`
+- "all ..." → `all`
+- TTL not mentioned → `--ttl 86400` (24h)
+
+**Examples:**
+
+```
+"update all fees from arbitrum usdc to all usdt destinations to 5bps"
+→ --origins arbitrum --source-tokens USDC --destinations all --targets USDT --bps 5 --ttl 86400
+
+"set katana to arbitrum default fee to 3bps"
+→ --origins katana --source-tokens all --destinations arbitrum --targets DEFAULT --bps 3 --ttl 86400
+
+"update all moonpay fees to 3bps"
+→ --origins all --source-tokens all --destinations all --targets all --bps 3 --ttl 86400
+
+"set ethereum USDT → base and polygon DEFAULT to 4.5bps with 7d TTL"
+→ --origins ethereum --source-tokens USDT --destinations base,polygon --targets DEFAULT --bps 4.5 --ttl 604800
+```
+
+## Ambiguity
+
+Ask ONE clarifying question before proceeding if any dimension is unclear:
+
+- Target not specified → ask whether they mean `DEFAULT` only or all per-router slots too
+- "all fees" with no further detail → confirm ALL origins × ALL tokens × ALL destinations × ALL targets
+- Destination sounds like a token name (e.g. "to USDT") → clarify if it's a target or a destination chain
+
+## Execution Flow
+
+**Step 1 — Derive flags** from the request.
+
+**Step 2 — Enumerate affected lanes** from the route topology above (do NOT run any script yet).
+Cross-product the selected origins × source-tokens × destinations × targets and list them in a compact table:
+
+```
+origin      src    → dest        target    new bps
+arbitrum    USDC   → base        DEFAULT   5.00
+arbitrum    USDC   → bsc         DEFAULT   5.00
+...
+```
+
+Include the total count. Show TTL.
+
+**Step 3 — Ask the user to confirm** before running anything:
+
+> "This will update N lanes to X bps (TTL Yh). Proceed?"
+
+Wait for the user to reply. Do NOT run the script yet.
+
+**Step 4 — On confirmation**, run the script with `--yes`, the HTTP registry, and no explicit signer/submitter keys (GCP defaults are used automatically):
+
+```bash
+cd <monorepo-root> && pnpm tsx typescript/infra/scripts/moonpay/set-quotes.ts \
+  -r http://localhost:3333 \
+  --origins <origins> \
+  --source-tokens <source-tokens> \
+  --destinations <destinations> \
+  --targets <targets> \
+  --bps <bps> \
+  --ttl <seconds> \
+  --yes
+```
+
+Find the monorepo root with `git rev-parse --show-toplevel` if needed.
+
+The HTTP registry (`-r http://localhost:3333`) provides private RPC URL overrides. If it is not running, start it first using the `/start-http-registry` skill.
+
+**Step 5** — Show the script output so the user can verify submissions. Surface any errors clearly without retrying silently.
+
+## Reading Current Standing Quotes
+
+When the user asks to see current fees or standing quotes (e.g. "show me the current moonpay fees", "what bps are we charging?"), run `print-quotes.ts` instead:
+
+```bash
+cd <monorepo-root> && pnpm tsx typescript/infra/scripts/moonpay/print-quotes.ts \
+  -r http://localhost:3333
+```
+
+Show the output directly. No confirmation needed — this is read-only.

--- a/.claude/skills/set-moonpay-standing-quotes/SKILL.md
+++ b/.claude/skills/set-moonpay-standing-quotes/SKILL.md
@@ -39,14 +39,14 @@ Destinations include all the above chains plus `solanamainnet`.
 
 ## Parsing Natural Language → CLI Flags
 
-| Concept in request           | Flag              | Value                               |
-| ---------------------------- | ----------------- | ----------------------------------- |
-| origin chain(s)              | `--origins`       | comma-separated names or `all`      |
-| source token(s) on origin    | `--source-tokens` | `USDC`, `USDT`, `ctUSD`, or `all`   |
-| destination chain(s)         | `--destinations`  | comma-separated names or `all`      |
-| destination router target(s) | `--targets`       | `DEFAULT`, `USDC`, `USDT`, or `all` |
-| fee amount                   | `--bps`           | number (e.g. `3`, `5`, `0.5`)       |
-| quote lifetime               | `--ttl`           | seconds (86400 = 24h, 604800 = 7d)  |
+| Concept in request           | Flag              | Value                                             |
+| ---------------------------- | ----------------- | ------------------------------------------------- |
+| origin chain(s)              | `--origins`       | comma-separated names or `all`                    |
+| source token(s) on origin    | `--source-tokens` | `USDC`, `USDT`, `ctUSD`, or `all`                 |
+| destination chain(s)         | `--destinations`  | comma-separated names or `all`                    |
+| destination router target(s) | `--targets`       | `DEFAULT`, `USDC`, `USDT`, or `all`               |
+| fee amount                   | `--bps`           | number (e.g. `3`, `5`, `0.5`)                     |
+| quote lifetime               | `--ttl`           | duration with unit suffix (`24h`, `2d`, `86400s`) |
 
 **Heuristics:**
 
@@ -56,22 +56,22 @@ Destinations include all the above chains plus `solanamainnet`.
 - "USDT destinations" / "USDC targets" → `--targets USDT/USDC`
 - target not mentioned → `--targets DEFAULT`
 - "all ..." → `all`
-- TTL not mentioned → `--ttl 86400` (24h)
+- TTL not mentioned → `--ttl 24h`
 
 **Examples:**
 
-```
+```test
 "update all fees from arbitrum usdc to all usdt destinations to 5bps"
-→ --origins arbitrum --source-tokens USDC --destinations all --targets USDT --bps 5 --ttl 86400
+→ --origins arbitrum --source-tokens USDC --destinations all --targets USDT --bps 5 --ttl 24h
 
 "set katana to arbitrum default fee to 3bps"
-→ --origins katana --source-tokens all --destinations arbitrum --targets DEFAULT --bps 3 --ttl 86400
+→ --origins katana --source-tokens all --destinations arbitrum --targets DEFAULT --bps 3 --ttl 24h
 
 "update all moonpay fees to 3bps"
-→ --origins all --source-tokens all --destinations all --targets all --bps 3 --ttl 86400
+→ --origins all --source-tokens all --destinations all --targets all --bps 3 --ttl 24h
 
 "set ethereum USDT → base and polygon DEFAULT to 4.5bps with 7d TTL"
-→ --origins ethereum --source-tokens USDT --destinations base,polygon --targets DEFAULT --bps 4.5 --ttl 604800
+→ --origins ethereum --source-tokens USDT --destinations base,polygon --targets DEFAULT --bps 4.5 --ttl 7d
 ```
 
 ## Ambiguity
@@ -86,25 +86,7 @@ Ask ONE clarifying question before proceeding if any dimension is unclear:
 
 **Step 1 — Derive flags** from the request.
 
-**Step 2 — Enumerate affected lanes** from the route topology above (do NOT run any script yet).
-Cross-product the selected origins × source-tokens × destinations × targets and list them in a compact table:
-
-```
-origin      src    → dest        target    new bps
-arbitrum    USDC   → base        DEFAULT   5.00
-arbitrum    USDC   → bsc         DEFAULT   5.00
-...
-```
-
-Include the total count. Show TTL.
-
-**Step 3 — Ask the user to confirm** before running anything:
-
-> "This will update N lanes to X bps (TTL Yh). Proceed?"
-
-Wait for the user to reply. Do NOT run the script yet.
-
-**Step 4 — On confirmation**, run the script with `--yes`, the HTTP registry, and no explicit signer/submitter keys (GCP defaults are used automatically):
+**Step 2 — Preview with `--dry-run`** to confirm the exact lanes and current→new bps against live on-chain state (no signer/submitter keys are needed for this):
 
 ```bash
 cd <monorepo-root> && pnpm tsx typescript/infra/scripts/moonpay/set-quotes.ts \
@@ -114,15 +96,38 @@ cd <monorepo-root> && pnpm tsx typescript/infra/scripts/moonpay/set-quotes.ts \
   --destinations <destinations> \
   --targets <targets> \
   --bps <bps> \
-  --ttl <seconds> \
+  --ttl <duration, e.g. 24h> \
+  --dry-run
+```
+
+Find the monorepo root with `git rev-parse --show-toplevel` if needed. The HTTP registry (`-r http://localhost:3333`) provides private RPC URL overrides — start it first with `/start-http-registry` if it isn't running.
+
+**Step 3 — Run it for real**, immediately and without asking for approval: re-run the same command with `--dry-run` swapped for `--yes` (GCP defaults are used automatically for signer/submitter keys):
+
+```bash
+cd <monorepo-root> && pnpm tsx typescript/infra/scripts/moonpay/set-quotes.ts \
+  -r http://localhost:3333 \
+  --origins <origins> \
+  --source-tokens <source-tokens> \
+  --destinations <destinations> \
+  --targets <targets> \
+  --bps <bps> \
+  --ttl <duration, e.g. 24h> \
   --yes
 ```
 
-Find the monorepo root with `git rev-parse --show-toplevel` if needed.
+**Step 4 — Summarize the result** in plain language, grouped by lane, before showing raw output. For each lane report old→new bps, or `(unchanged, was already correct)` when the current value already matched the target — plus the TTL used:
 
-The HTTP registry (`-r http://localhost:3333`) provides private RPC URL overrides. If it is not running, start it first using the `/start-http-registry` skill.
+```test
+Done. Katana↔katana quotes now:
 
-**Step 5** — Show the script output so the user can verify submissions. Surface any errors clearly without retrying silently.
+- USDC→USDC: 3bps (unchanged, was already correct)
+- USDT→USDT: 3bps (unchanged, was already correct)
+- USDC→USDT: 3→30bps, 7-day TTL
+- USDT→USDC: 18→30bps, 7-day TTL
+```
+
+Then show the script's raw output below the summary so the user can verify the actual submissions. Surface any errors clearly without retrying silently.
 
 ## Reading Current Standing Quotes
 

--- a/typescript/infra/scripts/moonpay/oqlf-lib.ts
+++ b/typescript/infra/scripts/moonpay/oqlf-lib.ts
@@ -1,0 +1,481 @@
+/**
+ * Shared discovery, formatting, and submission logic for the moonpay
+ * standing-quote scripts (print-quotes.ts, set-quotes.ts, propagate-quotes.ts).
+ */
+
+import { Wallet, constants, ethers } from 'ethers';
+
+import {
+  BaseFee__factory,
+  CrossCollateralRoutingFee__factory,
+  OffchainQuotedLinearFee__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import {
+  EvmTokenFeeReader,
+  MultiProvider,
+  OnchainTokenFeeType,
+  convertToBps,
+} from '@hyperlane-xyz/sdk';
+import { addressToBytes32, assert, rootLogger } from '@hyperlane-xyz/utils';
+
+import { getDomainId, getWarpCoreConfig } from '../../config/registry.js';
+import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
+import { fetchGCPSecret } from '../../src/utils/gcloud.js';
+
+const logger = rootLogger.child({ module: 'moonpay-quotes' });
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const GCP_SIGNER_SECRET = 'hyperlane-mainnet3-key-quotesigner';
+export const GCP_DEPLOYER_SECRET = 'hyperlane-mainnet3-key-deployer';
+
+export const WILDCARD_DEST = 0xffffffff;
+export const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32);
+export const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
+
+// EIP-712: matches AbstractOffchainQuoter.sol name/version
+export const EIP712_NAME = 'OffchainQuoter';
+export const EIP712_VERSION = '1';
+export const SIGNED_QUOTE_TYPES = {
+  SignedQuote: [
+    { name: 'context', type: 'bytes' },
+    { name: 'data', type: 'bytes' },
+    { name: 'issuedAt', type: 'uint48' },
+    { name: 'expiry', type: 'uint48' },
+    { name: 'salt', type: 'bytes32' },
+    { name: 'submitter', type: 'address' },
+  ],
+};
+
+// Matches the contract's MAX_BPS (10_000 = 100%) — a sane hard upper bound
+// so a fat-fingered --bps value can't lock in an absurd fee.
+const MAX_SANE_BPS = 10_000;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface OqlfSlot {
+  origin: string;
+  sourceToken: string; // normalised group label of the origin token (USDC / USDT / …)
+  destination: string;
+  destDomain: number;
+  target: string; // "DEFAULT" or normalised group label of the destination token
+  isDefault: boolean;
+  oqlfAddress: string;
+  onchainMaxFee: bigint;
+  onchainHalfAmount: bigint;
+  effectiveMaxFee: bigint;
+  effectiveHalfAmount: bigint;
+  effectiveSource: 'standing' | 'fallback';
+  standingExpiry: number; // 0 when effectiveSource === 'fallback'
+}
+
+export interface GcpKeySecret {
+  privateKey: string;
+  address: string;
+}
+
+// ── Formatting ────────────────────────────────────────────────────────────────
+
+/** Display bps as "W.FF". */
+export function fmtBps(maxFee: bigint, halfAmount: bigint): string {
+  if (halfAmount === 0n) return '?.??';
+  return convertToBps(maxFee, halfAmount).toFixed(2);
+}
+
+export function formatExpiry(ts: number): string {
+  if (ts === 0) return '—';
+  const remaining = ts - Math.floor(Date.now() / 1000);
+  const abs = new Date(ts * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .replace('.000Z', 'Z');
+  if (remaining <= 0) return `${abs} (expired)`;
+  const h = Math.round(remaining / 3600);
+  return `${abs} (${h}h)`;
+}
+
+// ── bps <-> (maxFee, halfAmount) ────────────────────────────────────────────
+
+/**
+ * Convert a numeric bps value to canonical (maxFee, halfAmount), delegating
+ * to the SDK's EvmTokenFeeReader so deployed contracts stay consistent with
+ * the rest of the fee tooling (and inherit its bps>0 / precision guards).
+ */
+export function bpsToParams(
+  multiProvider: MultiProvider,
+  chain: string,
+  bps: number,
+): { maxFee: bigint; halfAmount: bigint } {
+  assert(
+    Number.isFinite(bps) && bps > 0 && bps <= MAX_SANE_BPS,
+    `bps must be a positive number no greater than ${MAX_SANE_BPS}, got ${bps}`,
+  );
+  return new EvmTokenFeeReader(multiProvider, chain).convertFromBps(bps);
+}
+
+// ── GCP secret handling ───────────────────────────────────────────────────────
+
+export function isGcpKeySecret(secret: unknown): secret is GcpKeySecret {
+  if (typeof secret !== 'object' || secret === null) return false;
+  const record = secret as Record<string, unknown>;
+  return (
+    typeof record.privateKey === 'string' && typeof record.address === 'string'
+  );
+}
+
+export async function resolveGcpKey(secretName: string): Promise<GcpKeySecret> {
+  const secret = await fetchGCPSecret(secretName);
+  assert(
+    isGcpKeySecret(secret),
+    `Malformed GCP secret payload for ${secretName}: expected {privateKey, address}`,
+  );
+  return secret;
+}
+
+// ── Address / router label maps ────────────────────────────────────────────
+
+export interface AddrMaps {
+  addrToLabel: Map<string, string>; // normalized addr → label
+  routersByChain: Map<string, string[]>; // chain → [addr]
+}
+
+/**
+ * Builds address→label and chain→routers maps in a single pass over every
+ * route's tokens. usd-coin→"USDC", tether→"USDT", else symbol.
+ * EVM addresses are lowercased; non-EVM (e.g. Solana base58) are kept as-is.
+ */
+export function buildAddrMaps(routeIds: string[]): AddrMaps {
+  const addrToLabel = new Map<string, string>();
+  const routersByChain = new Map<string, string[]>();
+  for (const routeId of routeIds) {
+    const warpConfig = getWarpCoreConfig(routeId);
+    for (const t of warpConfig.tokens) {
+      if (!t.addressOrDenom) continue;
+      const key = t.addressOrDenom.startsWith('0x')
+        ? t.addressOrDenom.toLowerCase()
+        : t.addressOrDenom;
+      const label =
+        t.coinGeckoId === 'usd-coin'
+          ? 'USDC'
+          : t.coinGeckoId === 'tether'
+            ? 'USDT'
+            : (t.symbol ?? t.chainName ?? key.slice(0, 10));
+      addrToLabel.set(key, label);
+      if (t.chainName) {
+        const list = routersByChain.get(t.chainName) ?? [];
+        if (!list.includes(key)) list.push(key);
+        routersByChain.set(t.chainName, list);
+      }
+    }
+  }
+  return { addrToLabel, routersByChain };
+}
+
+// ── Slot discovery ────────────────────────────────────────────────────────────
+
+/**
+ * Discovers every OQLF slot (DEFAULT + per-router) across all origin/dest
+ * pairs for the given routes, resolving the standing-quote → fallback
+ * cascade the same way the on-chain contract does.
+ */
+export async function discoverOqlfSlots(
+  multiProvider: MultiProvider,
+  routeIds: string[] = ROUTE_IDS,
+): Promise<OqlfSlot[]> {
+  const { addrToLabel, routersByChain } = buildAddrMaps(routeIds);
+  const now = Math.floor(Date.now() / 1000);
+  const seenSlots = new Set<string>();
+  const allSlots: OqlfSlot[] = [];
+
+  await Promise.all(
+    routeIds.flatMap((routeId) => {
+      const warpConfig = getWarpCoreConfig(routeId);
+      const seenOriginAddrs = new Set<string>();
+      const evmTokens = warpConfig.tokens.filter((t) => {
+        if (
+          !t.addressOrDenom ||
+          !t.chainName ||
+          !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
+        )
+          return false;
+        const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
+        if (seenOriginAddrs.has(key)) return false;
+        seenOriginAddrs.add(key);
+        return true;
+      });
+
+      return evmTokens.map(async (originToken) => {
+        const { chainName: origin, addressOrDenom: routerAddr } = originToken;
+        if (!routerAddr || !origin) return;
+        const normalizedOriginAddr = routerAddr.toLowerCase();
+        const sourceToken =
+          addrToLabel.get(normalizedOriginAddr) ?? originToken.symbol ?? origin;
+        const provider = multiProvider.getProvider(origin);
+
+        let ccrAddress: string;
+        try {
+          ccrAddress = await TokenRouter__factory.connect(
+            routerAddr,
+            provider,
+          ).feeRecipient();
+        } catch (error) {
+          logger.warn(
+            { origin, routerAddr, error },
+            'Failed to read feeRecipient; skipping origin token',
+          );
+          return;
+        }
+        if (!ccrAddress || ccrAddress === constants.AddressZero) return;
+
+        let feeTypeNum: number;
+        try {
+          feeTypeNum = await BaseFee__factory.connect(
+            ccrAddress,
+            provider,
+          ).feeType();
+        } catch (error) {
+          logger.warn(
+            { origin, ccrAddress, error },
+            'Failed to read feeType; skipping origin token',
+          );
+          return;
+        }
+        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
+          return;
+
+        const ccr = CrossCollateralRoutingFee__factory.connect(
+          ccrAddress,
+          provider,
+        );
+
+        let defaultRouterKey: string;
+        try {
+          defaultRouterKey = await ccr.DEFAULT_ROUTER();
+        } catch (error) {
+          logger.warn(
+            { origin, ccrAddress, error },
+            'Failed to read DEFAULT_ROUTER; skipping origin token',
+          );
+          return;
+        }
+
+        const seenDestChains = new Set<string>();
+        const destTokens = warpConfig.tokens.filter((t) => {
+          if (!t.chainName) return false;
+          if (seenDestChains.has(t.chainName)) return false;
+          seenDestChains.add(t.chainName);
+          return true;
+        });
+
+        await Promise.all(
+          destTokens.map(async (destToken) => {
+            const { chainName: destination } = destToken;
+            if (!destination) return;
+            let destDomain: number;
+            try {
+              destDomain = getDomainId(destination);
+            } catch (error) {
+              logger.warn(
+                { destination, error },
+                'Failed to resolve domain id; skipping destination',
+              );
+              return;
+            }
+
+            const destRouters = routersByChain.get(destination) ?? [];
+            const targetKeys: Array<{
+              key: string;
+              label: string;
+              isDefault: boolean;
+            }> = [
+              { key: defaultRouterKey, label: 'DEFAULT', isDefault: true },
+              ...destRouters.map((addr) => ({
+                key: addressToBytes32(addr),
+                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
+                isDefault: false,
+              })),
+            ];
+
+            await Promise.all(
+              targetKeys.map(async ({ key, label, isDefault }) => {
+                let oqlfAddress: string;
+                try {
+                  oqlfAddress = await ccr.feeContracts(destDomain, key);
+                } catch (error) {
+                  logger.warn(
+                    { origin, destination, target: label, error },
+                    'Failed to read feeContracts slot; skipping',
+                  );
+                  return;
+                }
+                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
+                  return;
+
+                // Dedup key includes the target label: a per-router slot can
+                // legitimately point at the same OQLF instance as DEFAULT,
+                // and both logical targets must still surface separately so
+                // --targets filtering (set-quotes.ts) sees every alias.
+                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${origin}:${sourceToken}:${label}`;
+                if (seenSlots.has(slotId)) return;
+                seenSlots.add(slotId);
+
+                const oqlf = OffchainQuotedLinearFee__factory.connect(
+                  oqlfAddress,
+                  provider,
+                );
+                const [onchainMaxFee, onchainHalfAmount] = await Promise.all([
+                  oqlf.maxFee(),
+                  oqlf.halfAmount(),
+                ]);
+
+                let effectiveMaxFee = onchainMaxFee.toBigInt();
+                let effectiveHalfAmount = onchainHalfAmount.toBigInt();
+                let effectiveSource: 'standing' | 'fallback' = 'fallback';
+                let standingExpiry = 0;
+
+                for (const { dest, recip } of [
+                  { dest: destDomain, recip: WILDCARD_RECIPIENT },
+                  { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT },
+                ]) {
+                  const sq = await oqlf.quotes(dest, recip);
+                  const expiry = Number(sq.expiry);
+                  if (expiry > 0 && expiry >= now) {
+                    effectiveMaxFee = sq.maxFee.toBigInt();
+                    effectiveHalfAmount = sq.halfAmount.toBigInt();
+                    effectiveSource = 'standing';
+                    standingExpiry = expiry;
+                    break;
+                  }
+                }
+
+                allSlots.push({
+                  origin,
+                  sourceToken,
+                  destination,
+                  destDomain,
+                  target: label,
+                  isDefault,
+                  oqlfAddress,
+                  onchainMaxFee: onchainMaxFee.toBigInt(),
+                  onchainHalfAmount: onchainHalfAmount.toBigInt(),
+                  effectiveMaxFee,
+                  effectiveHalfAmount,
+                  effectiveSource,
+                  standingExpiry,
+                });
+              }),
+            );
+          }),
+        );
+      });
+    }),
+  );
+
+  // Concurrent discovery races RPC calls, so push order is nondeterministic
+  // across runs — sort for stable, reproducible output. Origin → sourceToken
+  // → destination, then DEFAULT first followed by alpha-sorted targets.
+  allSlots.sort((a, b) => {
+    const cmp =
+      a.origin.localeCompare(b.origin) ||
+      a.sourceToken.localeCompare(b.sourceToken) ||
+      a.destination.localeCompare(b.destination);
+    if (cmp !== 0) return cmp;
+    if (a.target === 'DEFAULT') return -1;
+    if (b.target === 'DEFAULT') return 1;
+    return a.target.localeCompare(b.target);
+  });
+
+  return allSlots;
+}
+
+// ── Sign + submit ─────────────────────────────────────────────────────────────
+
+export interface QuoteSubmission {
+  slot: OqlfSlot;
+  maxFee: bigint;
+  halfAmount: bigint;
+  bpsLabel: string;
+}
+
+/**
+ * Signs and submits a single standing quote, regenerating timestamps/salt on
+ * each attempt so the signature stays fresh across retries.
+ */
+export async function submitQuoteWithRetry(
+  multiProvider: MultiProvider,
+  signerKey: string,
+  submitterWallet: Wallet,
+  submission: QuoteSubmission,
+  ttlSeconds: number,
+  maxAttempts = 3,
+): Promise<void> {
+  const { slot, maxFee, halfAmount, bpsLabel } = submission;
+  const provider = multiProvider.getProvider(slot.origin);
+  const signerWallet = new Wallet(signerKey, provider);
+  const submitter = submitterWallet.connect(provider);
+  const { chainId } = await provider.getNetwork();
+
+  const context = ethers.utils.solidityPack(
+    ['uint32', 'bytes32', 'uint256'],
+    [slot.destDomain, WILDCARD_RECIPIENT, constants.MaxUint256],
+  );
+  const data = ethers.utils.solidityPack(
+    ['uint256', 'uint256'],
+    [maxFee, halfAmount],
+  );
+  const domain = {
+    name: EIP712_NAME,
+    version: EIP712_VERSION,
+    chainId,
+    verifyingContract: slot.oqlfAddress,
+  };
+  const oqlf = OffchainQuotedLinearFee__factory.connect(
+    slot.oqlfAddress,
+    submitter,
+  );
+  const txOverrides = multiProvider.getTransactionOverrides(slot.origin);
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const issuedAt = Math.floor(Date.now() / 1000);
+      const expiry = issuedAt + ttlSeconds;
+      const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+      const submitterAddr = constants.AddressZero;
+      const message = {
+        context,
+        data,
+        issuedAt,
+        expiry,
+        salt,
+        submitter: submitterAddr,
+      };
+      const signature = await signerWallet._signTypedData(
+        domain,
+        SIGNED_QUOTE_TYPES,
+        message,
+      );
+
+      const attemptSuffix = attempt > 1 ? ` (attempt ${attempt})` : '';
+      process.stdout.write(
+        `Submitting ${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${bpsLabel} bps)${attemptSuffix}... `,
+      );
+      const tx = await oqlf.submitQuote(message, signature, txOverrides);
+      process.stdout.write(`${tx.hash.slice(0, 14)}… `);
+      await tx.wait(1);
+      console.log('confirmed.');
+      return;
+    } catch (err) {
+      lastErr = err;
+      const msg =
+        err instanceof Error ? err.message.slice(0, 120) : String(err);
+      if (attempt < maxAttempts) {
+        console.warn(`\n  attempt ${attempt} failed: ${msg} — retrying...`);
+      } else {
+        console.error(`\n  failed after ${maxAttempts} attempts: ${msg}`);
+      }
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}

--- a/typescript/infra/scripts/moonpay/oqlf-lib.ts
+++ b/typescript/infra/scripts/moonpay/oqlf-lib.ts
@@ -25,6 +25,14 @@ import { fetchGCPSecret } from '../../src/utils/gcloud.js';
 
 const logger = rootLogger.child({ module: 'moonpay-quotes' });
 
+// Provider/RPC errors can embed the full request (including RPC URLs, which
+// often carry API keys in the path/query) — log a truncated message only,
+// never the raw error object.
+function errMsg(error: unknown): string {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.slice(0, 200);
+}
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 export const GCP_SIGNER_SECRET = 'hyperlane-mainnet3-key-quotesigner';
@@ -117,10 +125,13 @@ export function bpsToParams(
 // ── GCP secret handling ───────────────────────────────────────────────────────
 
 export function isGcpKeySecret(secret: unknown): secret is GcpKeySecret {
-  if (typeof secret !== 'object' || secret === null) return false;
-  const record = secret as Record<string, unknown>;
   return (
-    typeof record.privateKey === 'string' && typeof record.address === 'string'
+    typeof secret === 'object' &&
+    secret !== null &&
+    'privateKey' in secret &&
+    'address' in secret &&
+    typeof secret.privateKey === 'string' &&
+    typeof secret.address === 'string'
   );
 }
 
@@ -129,6 +140,11 @@ export async function resolveGcpKey(secretName: string): Promise<GcpKeySecret> {
   assert(
     isGcpKeySecret(secret),
     `Malformed GCP secret payload for ${secretName}: expected {privateKey, address}`,
+  );
+  const walletAddress = new Wallet(secret.privateKey).address;
+  assert(
+    walletAddress.toLowerCase() === secret.address.toLowerCase(),
+    `Malformed GCP secret payload for ${secretName}: address does not match privateKey`,
   );
   return secret;
 }
@@ -221,7 +237,7 @@ export async function discoverOqlfSlots(
           ).feeRecipient();
         } catch (error) {
           logger.warn(
-            { origin, routerAddr, error },
+            { origin, routerAddr, error: errMsg(error) },
             'Failed to read feeRecipient; skipping origin token',
           );
           return;
@@ -236,7 +252,7 @@ export async function discoverOqlfSlots(
           ).feeType();
         } catch (error) {
           logger.warn(
-            { origin, ccrAddress, error },
+            { origin, ccrAddress, error: errMsg(error) },
             'Failed to read feeType; skipping origin token',
           );
           return;
@@ -254,7 +270,7 @@ export async function discoverOqlfSlots(
           defaultRouterKey = await ccr.DEFAULT_ROUTER();
         } catch (error) {
           logger.warn(
-            { origin, ccrAddress, error },
+            { origin, ccrAddress, error: errMsg(error) },
             'Failed to read DEFAULT_ROUTER; skipping origin token',
           );
           return;
@@ -277,7 +293,7 @@ export async function discoverOqlfSlots(
               destDomain = getDomainId(destination);
             } catch (error) {
               logger.warn(
-                { destination, error },
+                { destination, error: errMsg(error) },
                 'Failed to resolve domain id; skipping destination',
               );
               return;
@@ -304,7 +320,12 @@ export async function discoverOqlfSlots(
                   oqlfAddress = await ccr.feeContracts(destDomain, key);
                 } catch (error) {
                   logger.warn(
-                    { origin, destination, target: label, error },
+                    {
+                      origin,
+                      destination,
+                      target: label,
+                      error: errMsg(error),
+                    },
                     'Failed to read feeContracts slot; skipping',
                   );
                   return;
@@ -312,11 +333,14 @@ export async function discoverOqlfSlots(
                 if (!oqlfAddress || oqlfAddress === constants.AddressZero)
                   return;
 
-                // Dedup key includes the target label: a per-router slot can
-                // legitimately point at the same OQLF instance as DEFAULT,
-                // and both logical targets must still surface separately so
-                // --targets filtering (set-quotes.ts) sees every alias.
-                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${origin}:${sourceToken}:${label}`;
+                // Dedup key includes the target's on-chain identity (key, not
+                // the display label): a per-router slot can legitimately
+                // point at the same OQLF instance as DEFAULT, and both
+                // logical targets must still surface separately so --targets
+                // filtering (set-quotes.ts) sees every alias. Using the raw
+                // key instead of label avoids any (extremely unlikely) label
+                // collision between distinct target identities.
+                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${origin}:${sourceToken}:${key}`;
                 if (seenSlots.has(slotId)) return;
                 seenSlots.add(slotId);
 
@@ -389,6 +413,71 @@ export async function discoverOqlfSlots(
   return allSlots;
 }
 
+// ── Signer authorization ──────────────────────────────────────────────────────
+
+/**
+ * Verifies the signer is an authorized quote signer on every unique
+ * (origin, OQLF contract) pair among the given slots, exiting the process
+ * with a clear error if any are unauthorized. Keyed by (origin, oqlfAddress)
+ * rather than just oqlfAddress, since deterministic (CREATE2) deployments can
+ * put the same OQLF address on multiple chains with different authorized
+ * signer sets.
+ */
+export async function verifySignerAuthorization(
+  multiProvider: MultiProvider,
+  signerKey: string,
+  slots: OqlfSlot[],
+): Promise<void> {
+  const signerAddress = new Wallet(signerKey).address;
+  const uniqueOqlfs = new Map<
+    string,
+    { oqlfAddress: string; origin: string }
+  >();
+  for (const slot of slots) {
+    uniqueOqlfs.set(`${slot.origin}:${slot.oqlfAddress.toLowerCase()}`, {
+      oqlfAddress: slot.oqlfAddress,
+      origin: slot.origin,
+    });
+  }
+
+  const unauthorized = (
+    await Promise.all(
+      [...uniqueOqlfs.values()].map(async ({ oqlfAddress, origin }) => {
+        const provider = multiProvider.getProvider(origin);
+        const oqlf = OffchainQuotedLinearFee__factory.connect(
+          oqlfAddress,
+          provider,
+        );
+        const authorized = await oqlf.isQuoteSigner(signerAddress);
+        return authorized ? null : { oqlfAddress, origin };
+      }),
+    )
+  ).filter((r): r is { oqlfAddress: string; origin: string } => r !== null);
+
+  if (unauthorized.length > 0) {
+    for (const { oqlfAddress, origin } of unauthorized) {
+      const provider = multiProvider.getProvider(origin);
+      const oqlf = OffchainQuotedLinearFee__factory.connect(
+        oqlfAddress,
+        provider,
+      );
+      const authorizedSigners = await oqlf.quoteSigners();
+      console.error(
+        `\nError: signer ${signerAddress} is NOT authorized on OQLF ${oqlfAddress} (origin ${origin}).`,
+      );
+      console.error(
+        authorizedSigners.length === 0
+          ? 'No authorized signers found — contract may not be configured.'
+          : `Authorized signers: ${authorizedSigners.join(', ')}`,
+      );
+    }
+    process.exit(1);
+  }
+  console.log(
+    `Signer ${signerAddress} is authorized on all ${uniqueOqlfs.size} OQLF contract(s). Proceeding.\n`,
+  );
+}
+
 // ── Sign + submit ─────────────────────────────────────────────────────────────
 
 export interface QuoteSubmission {
@@ -410,6 +499,12 @@ export async function submitQuoteWithRetry(
   ttlSeconds: number,
   maxAttempts = 3,
 ): Promise<void> {
+  assert(
+    Number.isFinite(ttlSeconds) && ttlSeconds > 0,
+    `ttlSeconds must be a positive number, got ${ttlSeconds}`,
+  );
+  assert(maxAttempts > 0, `maxAttempts must be positive, got ${maxAttempts}`);
+
   const { slot, maxFee, halfAmount, bpsLabel } = submission;
   const provider = multiProvider.getProvider(slot.origin);
   const signerWallet = new Wallet(signerKey, provider);

--- a/typescript/infra/scripts/moonpay/print-quotes.ts
+++ b/typescript/infra/scripts/moonpay/print-quotes.ts
@@ -7,8 +7,9 @@
  * Output columns:
  *   origin → dest  target  bps  source  expires
  *
- *   target  – DEFAULT (standard transfer) or symbol of the specific
- *             destination token router (cross-collateral path)
+ *   path    – "standard" = DEFAULT slot, used for generic transfers
+ *             "targeted" = per-router slot, OVERRIDES DEFAULT for that token
+ *   target  – DEFAULT or symbol of the destination token router
  *   bps     – effective fee rate: standing quote if active, else fallback
  *   source  – "standing" | "fallback"
  *   expires – expiry of the standing quote, or "—" for fallback
@@ -64,6 +65,9 @@ interface EffectiveQuote {
 interface Row {
   origin: string;
   destination: string;
+  // "standard" = DEFAULT CCR slot (generic transfers)
+  // "targeted" = per-router CCR slot (overrides DEFAULT for this specific token)
+  path: 'standard' | 'targeted';
   target: string; // DEFAULT or token symbol
   oqlf: string;
   quote: EffectiveQuote;
@@ -291,6 +295,7 @@ async function main(): Promise<void> {
                 return {
                   origin,
                   destination,
+                  path: label === 'DEFAULT' ? 'standard' : 'targeted',
                   target: label,
                   oqlf: oqlfAddress,
                   quote,
@@ -316,6 +321,7 @@ async function main(): Promise<void> {
     const W = {
       origin: Math.max(6, ...rows.map((r) => r.origin.length)),
       dest: Math.max(4, ...rows.map((r) => r.destination.length)),
+      path: 8, // "standard" | "targeted"
       target: Math.max(6, ...rows.map((r) => r.target.length)),
       bps: 6,
       source: 8,
@@ -325,13 +331,15 @@ async function main(): Promise<void> {
       '   ' +
       pad('dest', W.dest) +
       '   ' +
+      pad('path', W.path) +
+      '   ' +
       pad('target', W.target) +
       '   ' +
       pad('bps', W.bps) +
       '   ' +
       pad('source', W.source) +
       '   expires';
-    const divider = [W.origin, W.dest, W.target, W.bps, W.source, 30]
+    const divider = [W.origin, W.dest, W.path, W.target, W.bps, W.source, 30]
       .map((w) => '─'.repeat(w))
       .join('   ');
 
@@ -340,10 +348,14 @@ async function main(): Promise<void> {
 
     for (const r of rows) {
       const bpsDisplay = pad(r.quote.bps + ' bps', W.bps + 4);
+      // "targeted" rows override DEFAULT: mark them so the active fee is obvious.
+      const pathDisplay = r.path === 'targeted' ? '► ' + r.path : '  ' + r.path;
       console.log(
         pad(r.origin, W.origin) +
           ' → ' +
           pad(r.destination, W.dest) +
+          '   ' +
+          pad(pathDisplay, W.path + 2) +
           '   ' +
           pad(r.target, W.target) +
           '   ' +
@@ -354,6 +366,9 @@ async function main(): Promise<void> {
           formatExpiry(r.quote.expiry),
       );
     }
+    console.log(
+      '\n  ► targeted = per-router OQLF; overrides DEFAULT when user targets that token',
+    );
   }
 
   console.log('\nDone.');

--- a/typescript/infra/scripts/moonpay/print-quotes.ts
+++ b/typescript/infra/scripts/moonpay/print-quotes.ts
@@ -203,12 +203,19 @@ async function main(): Promise<void> {
     console.log('═'.repeat(78));
 
     const warpConfig = getWarpCoreConfig(routeId);
-    const evmTokens = warpConfig.tokens.filter(
-      (t) =>
-        t.addressOrDenom &&
-        t.chainName &&
-        /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom),
-    );
+    const seenOriginAddrs = new Set<string>();
+    const evmTokens = warpConfig.tokens.filter((t) => {
+      if (
+        !t.addressOrDenom ||
+        !t.chainName ||
+        !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
+      )
+        return false;
+      const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
+      if (seenOriginAddrs.has(key)) return false;
+      seenOriginAddrs.add(key);
+      return true;
+    });
 
     // Process all origins concurrently.
     const originRows = await Promise.all(
@@ -251,9 +258,14 @@ async function main(): Promise<void> {
           provider,
         );
 
-        // Process all destinations concurrently, including same-chain
-        // (e.g. arbitrum USDC → arbitrum USDT cross-collateral swap).
-        const destTokens = warpConfig.tokens.filter((t) => !!t.chainName);
+        // One entry per unique destination chain (routers already deduped in routersByChain).
+        const seenDestChains = new Set<string>();
+        const destTokens = warpConfig.tokens.filter((t) => {
+          if (!t.chainName) return false;
+          if (seenDestChains.has(t.chainName)) return false;
+          seenDestChains.add(t.chainName);
+          return true;
+        });
 
         const destRows = await Promise.all(
           destTokens.map(async (destToken): Promise<Row[]> => {
@@ -328,6 +340,7 @@ async function main(): Promise<void> {
       target: Math.max(6, ...rows.map((r) => r.target.length)),
       bps: Math.max(3, ...rows.map((r) => (r.quote.bps + ' bps').length)),
       source: 8,
+      oqlf: 42, // "0x" + 40 hex chars
     };
     const header =
       pad('origin', W.origin) +
@@ -341,8 +354,19 @@ async function main(): Promise<void> {
       pad('bps', W.bps) +
       '   ' +
       pad('source', W.source) +
+      '   ' +
+      pad('fee contract', W.oqlf) +
       '   expires';
-    const divider = [W.origin, W.src, W.dest, W.target, W.bps, W.source, 30]
+    const divider = [
+      W.origin,
+      W.src,
+      W.dest,
+      W.target,
+      W.bps,
+      W.source,
+      W.oqlf,
+      30,
+    ]
       .map((w) => '─'.repeat(w))
       .join('   ');
 
@@ -362,6 +386,8 @@ async function main(): Promise<void> {
           pad(r.quote.bps + ' bps', W.bps) +
           '   ' +
           pad(r.quote.source, W.source) +
+          '   ' +
+          pad(r.oqlf, W.oqlf) +
           '   ' +
           formatExpiry(r.quote.expiry),
       );

--- a/typescript/infra/scripts/moonpay/print-quotes.ts
+++ b/typescript/infra/scripts/moonpay/print-quotes.ts
@@ -61,11 +61,9 @@ interface EffectiveQuote {
 
 interface Row {
   origin: string;
+  sourceToken: string; // normalised group label: USDC / USDT / …
   destination: string;
-  // "standard" = DEFAULT CCR slot (generic transfers)
-  // "targeted" = per-router CCR slot (overrides DEFAULT for this specific token)
-  path: 'standard' | 'targeted';
-  target: string; // DEFAULT or token symbol
+  target: string; // DEFAULT or normalised group label of the destination token
   oqlf: string;
   quote: EffectiveQuote;
 }
@@ -161,8 +159,8 @@ async function main(): Promise<void> {
   const multiProvider = new MultiProvider(chainMetadata);
   const now = Math.floor(Date.now() / 1000);
 
-  // Build address→label map for all token routers across all routes,
-  // so per-router CCR keys can be labelled as e.g. "USDT" instead of "0x1234".
+  // Build address→label map for all token routers across all routes.
+  // usd-coin→"USDC", tether→"USDT", else symbol.
   // EVM addresses are lowercased; non-EVM (e.g. Solana base58) are kept as-is.
   const addrToLabel = new Map<string, string>(); // normalized addr → label
   for (const routeId of ROUTE_IDS) {
@@ -172,7 +170,13 @@ async function main(): Promise<void> {
         const key = t.addressOrDenom.startsWith('0x')
           ? t.addressOrDenom.toLowerCase()
           : t.addressOrDenom;
-        addrToLabel.set(key, t.symbol ?? t.chainName);
+        const label =
+          t.coinGeckoId === 'usd-coin'
+            ? 'USDC'
+            : t.coinGeckoId === 'tether'
+              ? 'USDT'
+              : (t.symbol ?? t.chainName);
+        addrToLabel.set(key, label);
       }
     }
   }
@@ -212,6 +216,9 @@ async function main(): Promise<void> {
         const { chainName: origin, addressOrDenom: routerAddress } =
           originToken;
         if (!routerAddress || !origin) return [];
+        const normalizedOriginAddr = routerAddress.toLowerCase();
+        const sourceToken =
+          addrToLabel.get(normalizedOriginAddr) ?? originToken.symbol ?? origin;
 
         const provider = multiProvider.getProvider(origin);
 
@@ -290,8 +297,8 @@ async function main(): Promise<void> {
                 );
                 return {
                   origin,
+                  sourceToken,
                   destination,
-                  path: label === 'DEFAULT' ? 'standard' : 'targeted',
                   target: label,
                   oqlf: oqlfAddress,
                   quote,
@@ -316,18 +323,18 @@ async function main(): Promise<void> {
 
     const W = {
       origin: Math.max(6, ...rows.map((r) => r.origin.length)),
+      src: Math.max(3, ...rows.map((r) => r.sourceToken.length)),
       dest: Math.max(4, ...rows.map((r) => r.destination.length)),
-      path: 8, // "standard" | "targeted"
       target: Math.max(6, ...rows.map((r) => r.target.length)),
-      bps: 6,
+      bps: Math.max(3, ...rows.map((r) => (r.quote.bps + ' bps').length)),
       source: 8,
     };
     const header =
       pad('origin', W.origin) +
       '   ' +
-      pad('dest', W.dest) +
+      pad('src', W.src) +
       '   ' +
-      pad('path', W.path) +
+      pad('dest', W.dest) +
       '   ' +
       pad('target', W.target) +
       '   ' +
@@ -335,7 +342,7 @@ async function main(): Promise<void> {
       '   ' +
       pad('source', W.source) +
       '   expires';
-    const divider = [W.origin, W.dest, W.path, W.target, W.bps, W.source, 30]
+    const divider = [W.origin, W.src, W.dest, W.target, W.bps, W.source, 30]
       .map((w) => '─'.repeat(w))
       .join('   ');
 
@@ -343,28 +350,22 @@ async function main(): Promise<void> {
     console.log(divider);
 
     for (const r of rows) {
-      const bpsDisplay = pad(r.quote.bps + ' bps', W.bps + 4);
-      // "targeted" rows override DEFAULT: mark them so the active fee is obvious.
-      const pathDisplay = r.path === 'targeted' ? '► ' + r.path : '  ' + r.path;
       console.log(
         pad(r.origin, W.origin) +
+          '   ' +
+          pad(r.sourceToken, W.src) +
           ' → ' +
           pad(r.destination, W.dest) +
           '   ' +
-          pad(pathDisplay, W.path + 2) +
-          '   ' +
           pad(r.target, W.target) +
           '   ' +
-          bpsDisplay +
+          pad(r.quote.bps + ' bps', W.bps) +
           '   ' +
           pad(r.quote.source, W.source) +
           '   ' +
           formatExpiry(r.quote.expiry),
       );
     }
-    console.log(
-      '\n  ► targeted = per-router OQLF; overrides DEFAULT when user targets that token',
-    );
   }
 
   console.log('\nDone.');

--- a/typescript/infra/scripts/moonpay/print-quotes.ts
+++ b/typescript/infra/scripts/moonpay/print-quotes.ts
@@ -48,10 +48,7 @@ const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32); // bytes32 max
 const DEFAULT_ROUTER_KEY =
   '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
 
-const ROUTE_IDS = [
-  WarpRouteIds.USDCCitreaMoonpay,
-  WarpRouteIds.USDTCitreaMoonpay,
-];
+const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -164,34 +161,33 @@ async function main(): Promise<void> {
   const multiProvider = new MultiProvider(chainMetadata);
   const now = Math.floor(Date.now() / 1000);
 
-  // Build address→label map for all token routers across both routes,
+  // Build address→label map for all token routers across all routes,
   // so per-router CCR keys can be labelled as e.g. "USDT" instead of "0x1234".
-  const addrToLabel = new Map<string, string>(); // lowercase addr → label
+  // EVM addresses are lowercased; non-EVM (e.g. Solana base58) are kept as-is.
+  const addrToLabel = new Map<string, string>(); // normalized addr → label
   for (const routeId of ROUTE_IDS) {
     const warpConfig = getWarpCoreConfig(routeId);
     for (const t of warpConfig.tokens) {
-      if (t.addressOrDenom && /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)) {
-        addrToLabel.set(
-          t.addressOrDenom.toLowerCase(),
-          t.symbol ?? t.chainName,
-        );
+      if (t.addressOrDenom) {
+        const key = t.addressOrDenom.startsWith('0x')
+          ? t.addressOrDenom.toLowerCase()
+          : t.addressOrDenom;
+        addrToLabel.set(key, t.symbol ?? t.chainName);
       }
     }
   }
 
-  // Collect all EVM router addresses per chain (both routes combined).
+  // Collect all router addresses per chain (both EVM and non-EVM, all routes combined).
   const routersByChain = new Map<string, string[]>(); // chain → [addr]
   for (const routeId of ROUTE_IDS) {
     const warpConfig = getWarpCoreConfig(routeId);
     for (const t of warpConfig.tokens) {
-      if (
-        t.addressOrDenom &&
-        t.chainName &&
-        /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
-      ) {
+      if (t.addressOrDenom && t.chainName) {
+        const normalizedAddr = t.addressOrDenom.startsWith('0x')
+          ? t.addressOrDenom.toLowerCase()
+          : t.addressOrDenom;
         const list = routersByChain.get(t.chainName) ?? [];
-        if (!list.includes(t.addressOrDenom.toLowerCase()))
-          list.push(t.addressOrDenom.toLowerCase());
+        if (!list.includes(normalizedAddr)) list.push(normalizedAddr);
         routersByChain.set(t.chainName, list);
       }
     }
@@ -264,11 +260,11 @@ async function main(): Promise<void> {
               return [];
             }
 
-            // Build targetRouter keys: DEFAULT + per-token EVM routers on dest chain.
-            const destEVMRouters = routersByChain.get(destination) ?? [];
+            // Build targetRouter keys: DEFAULT + all routers on dest chain (EVM and non-EVM).
+            const destRouters = routersByChain.get(destination) ?? [];
             const targetKeys: Array<{ key: string; label: string }> = [
               { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT' },
-              ...destEVMRouters.map((addr) => ({
+              ...destRouters.map((addr) => ({
                 key: addressToBytes32(addr),
                 label: addrToLabel.get(addr) ?? addr.slice(0, 10),
               })),
@@ -374,7 +370,9 @@ async function main(): Promise<void> {
   console.log('\nDone.');
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/moonpay/print-quotes.ts
+++ b/typescript/infra/scripts/moonpay/print-quotes.ts
@@ -1,0 +1,365 @@
+#!/usr/bin/env tsx
+/**
+ * Shows the effective fee bps a user pays right now for every direction in
+ * the CROSS/moonpay warp routes, resolving the standing-quote → fallback
+ * cascade the same way the on-chain contract does.
+ *
+ * Output columns:
+ *   origin → dest  target  bps  source  expires
+ *
+ *   target  – DEFAULT (standard transfer) or symbol of the specific
+ *             destination token router (cross-collateral path)
+ *   bps     – effective fee rate: standing quote if active, else fallback
+ *   source  – "standing" | "fallback"
+ *   expires – expiry of the standing quote, or "—" for fallback
+ *
+ * Usage (from typescript/infra/):
+ *   pnpm tsx scripts/moonpay/print-quotes.ts
+ *   pnpm tsx scripts/moonpay/print-quotes.ts -r http://localhost:3000
+ */
+
+import yargs from 'yargs';
+import { constants } from 'ethers';
+
+import {
+  BaseFee__factory,
+  CrossCollateralRoutingFee__factory,
+  OffchainQuotedLinearFee__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
+import { MultiProvider, OnchainTokenFeeType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+
+import {
+  getDomainId,
+  getRegistry,
+  getWarpCoreConfig,
+} from '../../config/registry.js';
+import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const WILDCARD_DEST = 0xffffffff; // uint32 max
+const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32); // bytes32 max
+
+// keccak256("RoutingFee.DEFAULT_ROUTER")
+const DEFAULT_ROUTER_KEY =
+  '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
+
+const ROUTE_IDS = [
+  WarpRouteIds.USDCCitreaMoonpay,
+  WarpRouteIds.USDTCitreaMoonpay,
+];
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface EffectiveQuote {
+  bps: string;
+  source: 'standing' | 'fallback';
+  expiry: number; // 0 = fallback (no expiry)
+  quoteKey: string; // which standing key was active, e.g. "(8453,*)"
+}
+
+interface Row {
+  origin: string;
+  destination: string;
+  target: string; // DEFAULT or token symbol
+  oqlf: string;
+  quote: EffectiveQuote;
+}
+
+// ── Formatting ────────────────────────────────────────────────────────────────
+
+function toBps(maxFee: bigint, halfAmount: bigint): string {
+  if (halfAmount === 0n) return '?.??';
+  // bps = maxFee * 10000 / (halfAmount * 2)
+  const denom = halfAmount * 2n;
+  const whole = (maxFee * 10000n) / denom;
+  const frac = (maxFee * 1_000_000n) / denom - whole * 100n;
+  return `${whole}.${String(frac).padStart(2, '0')}`;
+}
+
+function formatExpiry(ts: number): string {
+  if (ts === 0) return '—';
+  const remaining = ts - Math.floor(Date.now() / 1000);
+  const abs = new Date(ts * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .replace('.000Z', 'Z');
+  if (remaining <= 0) return `${abs} (expired)`;
+  const h = Math.round(remaining / 3600);
+  return `${abs} (${h}h)`;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+// ── Core logic ────────────────────────────────────────────────────────────────
+
+async function resolveEffective(
+  oqlfAddress: string,
+  destDomain: number,
+  provider: ReturnType<MultiProvider['getProvider']>,
+  now: number,
+): Promise<EffectiveQuote> {
+  const oqlf = OffchainQuotedLinearFee__factory.connect(oqlfAddress, provider);
+
+  // Probe standing quotes: resolution order matches the contract cascade.
+  // (dest, *) is more specific than (*, *), so check it first.
+  const keysToProbe = [
+    { dest: destDomain, recip: WILDCARD_RECIPIENT, label: `(${destDomain},*)` },
+    { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT, label: '(*,*)' },
+  ];
+
+  for (const { dest, recip, label } of keysToProbe) {
+    const sq = await oqlf.quotes(dest, recip);
+    const expiry = Number(sq.expiry);
+    if (expiry > 0 && expiry >= now) {
+      return {
+        bps: toBps(sq.maxFee.toBigInt(), sq.halfAmount.toBigInt()),
+        source: 'standing',
+        expiry,
+        quoteKey: label,
+      };
+    }
+  }
+
+  // No active standing quote — use immutable fallback.
+  const [maxFee, halfAmount] = await Promise.all([
+    oqlf.maxFee(),
+    oqlf.halfAmount(),
+  ]);
+  return {
+    bps: toBps(maxFee.toBigInt(), halfAmount.toBigInt()),
+    source: 'fallback',
+    expiry: 0,
+    quoteKey: '—',
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const { registry: registryUri } = await yargs(process.argv.slice(2))
+    .option('registry', {
+      alias: 'r',
+      type: 'string',
+      describe: 'Registry URI (filesystem path or http://…)',
+    })
+    .parseAsync();
+
+  // For chain metadata (and thus RPC URLs), use the HTTP registry when -r is
+  // provided — it overlays private RPC URLs without replacing the filesystem
+  // registry that getWarpCoreConfig / getDomainId rely on.
+  const rpcRegistry = registryUri
+    ? getMergedRegistry({ registryUris: [registryUri], enableProxy: true })
+    : getRegistry();
+  const chainMetadata = await rpcRegistry.getMetadata();
+  const multiProvider = new MultiProvider(chainMetadata);
+  const now = Math.floor(Date.now() / 1000);
+
+  // Build address→label map for all token routers across both routes,
+  // so per-router CCR keys can be labelled as e.g. "USDT" instead of "0x1234".
+  const addrToLabel = new Map<string, string>(); // lowercase addr → label
+  for (const routeId of ROUTE_IDS) {
+    const warpConfig = getWarpCoreConfig(routeId);
+    for (const t of warpConfig.tokens) {
+      if (t.addressOrDenom && /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)) {
+        addrToLabel.set(
+          t.addressOrDenom.toLowerCase(),
+          t.symbol ?? t.chainName,
+        );
+      }
+    }
+  }
+
+  // Collect all EVM router addresses per chain (both routes combined).
+  const routersByChain = new Map<string, string[]>(); // chain → [addr]
+  for (const routeId of ROUTE_IDS) {
+    const warpConfig = getWarpCoreConfig(routeId);
+    for (const t of warpConfig.tokens) {
+      if (
+        t.addressOrDenom &&
+        t.chainName &&
+        /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
+      ) {
+        const list = routersByChain.get(t.chainName) ?? [];
+        if (!list.includes(t.addressOrDenom.toLowerCase()))
+          list.push(t.addressOrDenom.toLowerCase());
+        routersByChain.set(t.chainName, list);
+      }
+    }
+  }
+
+  for (const routeId of ROUTE_IDS) {
+    console.log(`\n${'═'.repeat(78)}`);
+    console.log(routeId);
+    console.log('═'.repeat(78));
+
+    const warpConfig = getWarpCoreConfig(routeId);
+    const evmTokens = warpConfig.tokens.filter(
+      (t) =>
+        t.addressOrDenom &&
+        t.chainName &&
+        /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom),
+    );
+
+    // Process all origins concurrently.
+    const originRows = await Promise.all(
+      evmTokens.map(async (originToken): Promise<Row[]> => {
+        const { chainName: origin, addressOrDenom: routerAddress } =
+          originToken;
+        if (!routerAddress || !origin) return [];
+
+        const provider = multiProvider.getProvider(origin);
+
+        // Get feeRecipient → must be a CrossCollateralRoutingFee.
+        let ccrAddress: string;
+        try {
+          ccrAddress = await TokenRouter__factory.connect(
+            routerAddress,
+            provider,
+          ).feeRecipient();
+        } catch {
+          return [];
+        }
+        if (!ccrAddress || ccrAddress === constants.AddressZero) return [];
+
+        let feeTypeNum: number;
+        try {
+          feeTypeNum = await BaseFee__factory.connect(
+            ccrAddress,
+            provider,
+          ).feeType();
+        } catch {
+          return [];
+        }
+        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
+          return [];
+
+        const ccr = CrossCollateralRoutingFee__factory.connect(
+          ccrAddress,
+          provider,
+        );
+
+        // Process all destinations concurrently, including same-chain
+        // (e.g. arbitrum USDC → arbitrum USDT cross-collateral swap).
+        const destTokens = warpConfig.tokens.filter((t) => !!t.chainName);
+
+        const destRows = await Promise.all(
+          destTokens.map(async (destToken): Promise<Row[]> => {
+            const { chainName: destination } = destToken;
+            if (!destination) return [];
+
+            let destDomain: number;
+            try {
+              destDomain = getDomainId(destination);
+            } catch {
+              return [];
+            }
+
+            // Build targetRouter keys: DEFAULT + per-token EVM routers on dest chain.
+            const destEVMRouters = routersByChain.get(destination) ?? [];
+            const targetKeys: Array<{ key: string; label: string }> = [
+              { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT' },
+              ...destEVMRouters.map((addr) => ({
+                key: addressToBytes32(addr),
+                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
+              })),
+            ];
+
+            // Resolve all targetRouter slots concurrently.
+            const keyRows = await Promise.all(
+              targetKeys.map(async ({ key, label }): Promise<Row | null> => {
+                let oqlfAddress: string;
+                try {
+                  oqlfAddress = await ccr.feeContracts(destDomain, key);
+                } catch {
+                  return null;
+                }
+                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
+                  return null;
+
+                const quote = await resolveEffective(
+                  oqlfAddress,
+                  destDomain,
+                  provider,
+                  now,
+                );
+                return {
+                  origin,
+                  destination,
+                  target: label,
+                  oqlf: oqlfAddress,
+                  quote,
+                };
+              }),
+            );
+
+            return keyRows.filter((r): r is Row => r !== null);
+          }),
+        );
+
+        return destRows.flat();
+      }),
+    );
+
+    // Print table.
+    const rows = originRows.flat();
+    if (rows.length === 0) {
+      console.log('  (no rows)');
+      continue;
+    }
+
+    const W = {
+      origin: Math.max(6, ...rows.map((r) => r.origin.length)),
+      dest: Math.max(4, ...rows.map((r) => r.destination.length)),
+      target: Math.max(6, ...rows.map((r) => r.target.length)),
+      bps: 6,
+      source: 8,
+    };
+    const header =
+      pad('origin', W.origin) +
+      '   ' +
+      pad('dest', W.dest) +
+      '   ' +
+      pad('target', W.target) +
+      '   ' +
+      pad('bps', W.bps) +
+      '   ' +
+      pad('source', W.source) +
+      '   expires';
+    const divider = [W.origin, W.dest, W.target, W.bps, W.source, 30]
+      .map((w) => '─'.repeat(w))
+      .join('   ');
+
+    console.log('\n' + header);
+    console.log(divider);
+
+    for (const r of rows) {
+      const bpsDisplay = pad(r.quote.bps + ' bps', W.bps + 4);
+      console.log(
+        pad(r.origin, W.origin) +
+          ' → ' +
+          pad(r.destination, W.dest) +
+          '   ' +
+          pad(r.target, W.target) +
+          '   ' +
+          bpsDisplay +
+          '   ' +
+          pad(r.quote.source, W.source) +
+          '   ' +
+          formatExpiry(r.quote.expiry),
+      );
+    }
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/typescript/infra/scripts/moonpay/print-quotes.ts
+++ b/typescript/infra/scripts/moonpay/print-quotes.ts
@@ -5,14 +5,14 @@
  * cascade the same way the on-chain contract does.
  *
  * Output columns:
- *   origin → dest  target  bps  source  expires
+ *   origin → dest  target  bps  source  fee contract  expires
  *
- *   path    – "standard" = DEFAULT slot, used for generic transfers
- *             "targeted" = per-router slot, OVERRIDES DEFAULT for that token
- *   target  – DEFAULT or symbol of the destination token router
- *   bps     – effective fee rate: standing quote if active, else fallback
- *   source  – "standing" | "fallback"
- *   expires – expiry of the standing quote, or "—" for fallback
+ *   src          – source token label (USDC / USDT / …)
+ *   target       – DEFAULT or symbol of the destination token router
+ *   bps          – effective fee rate: standing quote if active, else fallback
+ *   source       – "standing" | "fallback"
+ *   fee contract – OQLF address for this (destination, target) slot
+ *   expires      – expiry of the standing quote, or "—" for fallback
  *
  * Usage (from typescript/infra/):
  *   pnpm tsx scripts/moonpay/print-quotes.ts
@@ -20,125 +20,22 @@
  */
 
 import yargs from 'yargs';
-import { constants } from 'ethers';
 
-import {
-  BaseFee__factory,
-  CrossCollateralRoutingFee__factory,
-  OffchainQuotedLinearFee__factory,
-  TokenRouter__factory,
-} from '@hyperlane-xyz/core';
 import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
-import { MultiProvider, OnchainTokenFeeType } from '@hyperlane-xyz/sdk';
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+
+import { getRegistry } from '../../config/registry.js';
 
 import {
-  getDomainId,
-  getRegistry,
-  getWarpCoreConfig,
-} from '../../config/registry.js';
-import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
-
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const WILDCARD_DEST = 0xffffffff; // uint32 max
-const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32); // bytes32 max
-
-// keccak256("RoutingFee.DEFAULT_ROUTER")
-const DEFAULT_ROUTER_KEY =
-  '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
-
-const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-interface EffectiveQuote {
-  bps: string;
-  source: 'standing' | 'fallback';
-  expiry: number; // 0 = fallback (no expiry)
-  quoteKey: string; // which standing key was active, e.g. "(8453,*)"
-}
-
-interface Row {
-  origin: string;
-  sourceToken: string; // normalised group label: USDC / USDT / …
-  destination: string;
-  target: string; // DEFAULT or normalised group label of the destination token
-  oqlf: string;
-  quote: EffectiveQuote;
-}
-
-// ── Formatting ────────────────────────────────────────────────────────────────
-
-function toBps(maxFee: bigint, halfAmount: bigint): string {
-  if (halfAmount === 0n) return '?.??';
-  // bps = maxFee * 10000 / (halfAmount * 2)
-  const denom = halfAmount * 2n;
-  const whole = (maxFee * 10000n) / denom;
-  const frac = (maxFee * 1_000_000n) / denom - whole * 100n;
-  return `${whole}.${String(frac).padStart(2, '0')}`;
-}
-
-function formatExpiry(ts: number): string {
-  if (ts === 0) return '—';
-  const remaining = ts - Math.floor(Date.now() / 1000);
-  const abs = new Date(ts * 1000)
-    .toISOString()
-    .replace('T', ' ')
-    .replace('.000Z', 'Z');
-  if (remaining <= 0) return `${abs} (expired)`;
-  const h = Math.round(remaining / 3600);
-  return `${abs} (${h}h)`;
-}
+  ROUTE_IDS,
+  discoverOqlfSlots,
+  fmtBps,
+  formatExpiry,
+} from './oqlf-lib.js';
 
 function pad(s: string, n: number): string {
   return s.length >= n ? s : s + ' '.repeat(n - s.length);
 }
-
-// ── Core logic ────────────────────────────────────────────────────────────────
-
-async function resolveEffective(
-  oqlfAddress: string,
-  destDomain: number,
-  provider: ReturnType<MultiProvider['getProvider']>,
-  now: number,
-): Promise<EffectiveQuote> {
-  const oqlf = OffchainQuotedLinearFee__factory.connect(oqlfAddress, provider);
-
-  // Probe standing quotes: resolution order matches the contract cascade.
-  // (dest, *) is more specific than (*, *), so check it first.
-  const keysToProbe = [
-    { dest: destDomain, recip: WILDCARD_RECIPIENT, label: `(${destDomain},*)` },
-    { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT, label: '(*,*)' },
-  ];
-
-  for (const { dest, recip, label } of keysToProbe) {
-    const sq = await oqlf.quotes(dest, recip);
-    const expiry = Number(sq.expiry);
-    if (expiry > 0 && expiry >= now) {
-      return {
-        bps: toBps(sq.maxFee.toBigInt(), sq.halfAmount.toBigInt()),
-        source: 'standing',
-        expiry,
-        quoteKey: label,
-      };
-    }
-  }
-
-  // No active standing quote — use immutable fallback.
-  const [maxFee, halfAmount] = await Promise.all([
-    oqlf.maxFee(),
-    oqlf.halfAmount(),
-  ]);
-  return {
-    bps: toBps(maxFee.toBigInt(), halfAmount.toBigInt()),
-    source: 'fallback',
-    expiry: 0,
-    quoteKey: '—',
-  };
-}
-
-// ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const { registry: registryUri } = await yargs(process.argv.slice(2))
@@ -157,188 +54,35 @@ async function main(): Promise<void> {
     : getRegistry();
   const chainMetadata = await rpcRegistry.getMetadata();
   const multiProvider = new MultiProvider(chainMetadata);
-  const now = Math.floor(Date.now() / 1000);
-
-  // Build address→label map for all token routers across all routes.
-  // usd-coin→"USDC", tether→"USDT", else symbol.
-  // EVM addresses are lowercased; non-EVM (e.g. Solana base58) are kept as-is.
-  const addrToLabel = new Map<string, string>(); // normalized addr → label
-  for (const routeId of ROUTE_IDS) {
-    const warpConfig = getWarpCoreConfig(routeId);
-    for (const t of warpConfig.tokens) {
-      if (t.addressOrDenom) {
-        const key = t.addressOrDenom.startsWith('0x')
-          ? t.addressOrDenom.toLowerCase()
-          : t.addressOrDenom;
-        const label =
-          t.coinGeckoId === 'usd-coin'
-            ? 'USDC'
-            : t.coinGeckoId === 'tether'
-              ? 'USDT'
-              : (t.symbol ?? t.chainName);
-        addrToLabel.set(key, label);
-      }
-    }
-  }
-
-  // Collect all router addresses per chain (both EVM and non-EVM, all routes combined).
-  const routersByChain = new Map<string, string[]>(); // chain → [addr]
-  for (const routeId of ROUTE_IDS) {
-    const warpConfig = getWarpCoreConfig(routeId);
-    for (const t of warpConfig.tokens) {
-      if (t.addressOrDenom && t.chainName) {
-        const normalizedAddr = t.addressOrDenom.startsWith('0x')
-          ? t.addressOrDenom.toLowerCase()
-          : t.addressOrDenom;
-        const list = routersByChain.get(t.chainName) ?? [];
-        if (!list.includes(normalizedAddr)) list.push(normalizedAddr);
-        routersByChain.set(t.chainName, list);
-      }
-    }
-  }
 
   for (const routeId of ROUTE_IDS) {
     console.log(`\n${'═'.repeat(78)}`);
     console.log(routeId);
     console.log('═'.repeat(78));
 
-    const warpConfig = getWarpCoreConfig(routeId);
-    const seenOriginAddrs = new Set<string>();
-    const evmTokens = warpConfig.tokens.filter((t) => {
-      if (
-        !t.addressOrDenom ||
-        !t.chainName ||
-        !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
-      )
-        return false;
-      const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
-      if (seenOriginAddrs.has(key)) return false;
-      seenOriginAddrs.add(key);
-      return true;
-    });
-
-    // Process all origins concurrently.
-    const originRows = await Promise.all(
-      evmTokens.map(async (originToken): Promise<Row[]> => {
-        const { chainName: origin, addressOrDenom: routerAddress } =
-          originToken;
-        if (!routerAddress || !origin) return [];
-        const normalizedOriginAddr = routerAddress.toLowerCase();
-        const sourceToken =
-          addrToLabel.get(normalizedOriginAddr) ?? originToken.symbol ?? origin;
-
-        const provider = multiProvider.getProvider(origin);
-
-        // Get feeRecipient → must be a CrossCollateralRoutingFee.
-        let ccrAddress: string;
-        try {
-          ccrAddress = await TokenRouter__factory.connect(
-            routerAddress,
-            provider,
-          ).feeRecipient();
-        } catch {
-          return [];
-        }
-        if (!ccrAddress || ccrAddress === constants.AddressZero) return [];
-
-        let feeTypeNum: number;
-        try {
-          feeTypeNum = await BaseFee__factory.connect(
-            ccrAddress,
-            provider,
-          ).feeType();
-        } catch {
-          return [];
-        }
-        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
-          return [];
-
-        const ccr = CrossCollateralRoutingFee__factory.connect(
-          ccrAddress,
-          provider,
-        );
-
-        // One entry per unique destination chain (routers already deduped in routersByChain).
-        const seenDestChains = new Set<string>();
-        const destTokens = warpConfig.tokens.filter((t) => {
-          if (!t.chainName) return false;
-          if (seenDestChains.has(t.chainName)) return false;
-          seenDestChains.add(t.chainName);
-          return true;
-        });
-
-        const destRows = await Promise.all(
-          destTokens.map(async (destToken): Promise<Row[]> => {
-            const { chainName: destination } = destToken;
-            if (!destination) return [];
-
-            let destDomain: number;
-            try {
-              destDomain = getDomainId(destination);
-            } catch {
-              return [];
-            }
-
-            // Build targetRouter keys: DEFAULT + all routers on dest chain (EVM and non-EVM).
-            const destRouters = routersByChain.get(destination) ?? [];
-            const targetKeys: Array<{ key: string; label: string }> = [
-              { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT' },
-              ...destRouters.map((addr) => ({
-                key: addressToBytes32(addr),
-                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
-              })),
-            ];
-
-            // Resolve all targetRouter slots concurrently.
-            const keyRows = await Promise.all(
-              targetKeys.map(async ({ key, label }): Promise<Row | null> => {
-                let oqlfAddress: string;
-                try {
-                  oqlfAddress = await ccr.feeContracts(destDomain, key);
-                } catch {
-                  return null;
-                }
-                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
-                  return null;
-
-                const quote = await resolveEffective(
-                  oqlfAddress,
-                  destDomain,
-                  provider,
-                  now,
-                );
-                return {
-                  origin,
-                  sourceToken,
-                  destination,
-                  target: label,
-                  oqlf: oqlfAddress,
-                  quote,
-                };
-              }),
-            );
-
-            return keyRows.filter((r): r is Row => r !== null);
-          }),
-        );
-
-        return destRows.flat();
-      }),
-    );
-
-    // Print table.
-    const rows = originRows.flat();
-    if (rows.length === 0) {
+    const slots = await discoverOqlfSlots(multiProvider, [routeId]);
+    if (slots.length === 0) {
       console.log('  (no rows)');
       continue;
     }
+
+    const rows = slots.map((s) => ({
+      origin: s.origin,
+      sourceToken: s.sourceToken,
+      destination: s.destination,
+      target: s.target,
+      oqlf: s.oqlfAddress,
+      bps: fmtBps(s.effectiveMaxFee, s.effectiveHalfAmount),
+      source: s.effectiveSource,
+      expires: formatExpiry(s.standingExpiry),
+    }));
 
     const W = {
       origin: Math.max(6, ...rows.map((r) => r.origin.length)),
       src: Math.max(3, ...rows.map((r) => r.sourceToken.length)),
       dest: Math.max(4, ...rows.map((r) => r.destination.length)),
       target: Math.max(6, ...rows.map((r) => r.target.length)),
-      bps: Math.max(3, ...rows.map((r) => (r.quote.bps + ' bps').length)),
+      bps: Math.max(3, ...rows.map((r) => (r.bps + ' bps').length)),
       source: 8,
       oqlf: 42, // "0x" + 40 hex chars
     };
@@ -383,13 +127,13 @@ async function main(): Promise<void> {
           '   ' +
           pad(r.target, W.target) +
           '   ' +
-          pad(r.quote.bps + ' bps', W.bps) +
+          pad(r.bps + ' bps', W.bps) +
           '   ' +
-          pad(r.quote.source, W.source) +
+          pad(r.source, W.source) +
           '   ' +
           pad(r.oqlf, W.oqlf) +
           '   ' +
-          formatExpiry(r.quote.expiry),
+          r.expires,
       );
     }
   }

--- a/typescript/infra/scripts/moonpay/propagate-quotes.ts
+++ b/typescript/infra/scripts/moonpay/propagate-quotes.ts
@@ -207,12 +207,19 @@ async function main(): Promise<void> {
   await Promise.all(
     ROUTE_IDS.flatMap((routeId) => {
       const warpConfig = getWarpCoreConfig(routeId);
-      const evmTokens = warpConfig.tokens.filter(
-        (t) =>
-          t.addressOrDenom &&
-          t.chainName &&
-          /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom),
-      );
+      const seenOriginAddrs = new Set<string>();
+      const evmTokens = warpConfig.tokens.filter((t) => {
+        if (
+          !t.addressOrDenom ||
+          !t.chainName ||
+          !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
+        )
+          return false;
+        const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
+        if (seenOriginAddrs.has(key)) return false;
+        seenOriginAddrs.add(key);
+        return true;
+      });
       return evmTokens.map(async (originToken) => {
         const { chainName: origin, addressOrDenom: routerAddr } = originToken;
         if (!routerAddr || !origin) return;
@@ -248,7 +255,13 @@ async function main(): Promise<void> {
           ccrAddress,
           provider,
         );
-        const destTokens = warpConfig.tokens.filter((t) => !!t.chainName);
+        const seenDestChains = new Set<string>();
+        const destTokens = warpConfig.tokens.filter((t) => {
+          if (!t.chainName) return false;
+          if (seenDestChains.has(t.chainName)) return false;
+          seenDestChains.add(t.chainName);
+          return true;
+        });
 
         await Promise.all(
           destTokens.map(async (destToken) => {
@@ -286,7 +299,7 @@ async function main(): Promise<void> {
                 if (!oqlfAddress || oqlfAddress === constants.AddressZero)
                   return;
 
-                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${sourceToken}`;
+                const slotId = `${ccrAddress.toLowerCase()}:${destDomain}:${key}:${sourceToken}`;
                 if (seen.has(slotId)) return;
                 seen.add(slotId);
 

--- a/typescript/infra/scripts/moonpay/propagate-quotes.ts
+++ b/typescript/infra/scripts/moonpay/propagate-quotes.ts
@@ -7,92 +7,43 @@
  *   2. Submits that value as a new 7-day standing quote to every non-DEFAULT
  *      (per-router) slot whose current effective value DIFFERS from DEFAULT's.
  *
- * Dry-run is the default. Pass --propose to actually submit transactions.
+ * Dry-run is the default (or pass --dry-run explicitly). Pass --propose to
+ * actually submit transactions. In dry-run mode no signer/submitter keys are
+ * fetched — the plan is derived from public on-chain reads only.
  *
  * The signer key (GCP quotesigner) signs the EIP-712 data; the gas-paying
  * submitter key defaults to the GCP mainnet3 deployer key when -k is omitted.
  *
  * Usage (from typescript/infra/):
  *   pnpm tsx scripts/moonpay/propagate-quotes.ts
+ *   pnpm tsx scripts/moonpay/propagate-quotes.ts --dry-run
  *   pnpm tsx scripts/moonpay/propagate-quotes.ts --propose
  *   pnpm tsx scripts/moonpay/propagate-quotes.ts --propose -k 0x<key>
  */
 
-import { Wallet, constants, ethers } from 'ethers';
+import { Wallet } from 'ethers';
 import yargs from 'yargs';
 
-import {
-  BaseFee__factory,
-  CrossCollateralRoutingFee__factory,
-  OffchainQuotedLinearFee__factory,
-  TokenRouter__factory,
-} from '@hyperlane-xyz/core';
+import { confirm } from '@inquirer/prompts';
+
 import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
-import { MultiProvider, OnchainTokenFeeType } from '@hyperlane-xyz/sdk';
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import { getRegistry } from '../../config/registry.js';
 
 import {
-  getDomainId,
-  getRegistry,
-  getWarpCoreConfig,
-} from '../../config/registry.js';
-import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
-import { fetchGCPSecret } from '../../src/utils/gcloud.js';
+  GCP_DEPLOYER_SECRET,
+  GCP_SIGNER_SECRET,
+  OqlfSlot,
+  QuoteSubmission,
+  discoverOqlfSlots,
+  fmtBps,
+  resolveGcpKey,
+  submitQuoteWithRetry,
+} from './oqlf-lib.js';
 
-const GCP_SIGNER_SECRET = 'hyperlane-mainnet3-key-quotesigner';
-const GCP_DEPLOYER_SECRET = 'hyperlane-mainnet3-key-deployer';
-
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32);
-const WILDCARD_DEST = 0xffffffff;
-const DEFAULT_ROUTER_KEY =
-  '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
-const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
 const TTL_7D = 7 * 86_400;
-
-const EIP712_NAME = 'OffchainQuoter';
-const EIP712_VERSION = '1';
-const SIGNED_QUOTE_TYPES = {
-  SignedQuote: [
-    { name: 'context', type: 'bytes' },
-    { name: 'data', type: 'bytes' },
-    { name: 'issuedAt', type: 'uint48' },
-    { name: 'expiry', type: 'uint48' },
-    { name: 'salt', type: 'bytes32' },
-    { name: 'submitter', type: 'address' },
-  ],
-};
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-interface Slot {
-  origin: string;
-  sourceToken: string;
-  destination: string;
-  destDomain: number;
-  /** 'DEFAULT' or normalised token label */
-  target: string;
-  isDefault: boolean;
-  oqlfAddress: string;
-  /** Current effective maxFee (standing or fallback) */
-  effectiveMaxFee: bigint;
-  /** Current effective halfAmount */
-  effectiveHalfAmount: bigint;
-  hasActiveStanding: boolean;
-}
-
-// ── Utilities ─────────────────────────────────────────────────────────────────
-
-function fmtBps(maxFee: bigint, halfAmount: bigint): string {
-  if (halfAmount === 0n) return '?.??';
-  const denom = halfAmount * 2n;
-  const whole = (maxFee * 10_000n) / denom;
-  const frac = (maxFee * 1_000_000n) / denom - whole * 100n;
-  return `${whole}.${String(frac).padStart(2, '0')}`;
-}
-
-// ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const {
@@ -100,6 +51,7 @@ async function main(): Promise<void> {
     signerKey: signerKeyArg,
     submitterKey: submitterKeyArg,
     propose,
+    dryRun: dryRunArg,
   } = await yargs(process.argv.slice(2))
     .option('registry', {
       alias: 'r',
@@ -125,37 +77,41 @@ async function main(): Promise<void> {
       default: false,
       describe: 'Submit transactions on-chain (default: dry run only).',
     })
+    .option('dry-run', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Explicitly force a dry run (this is also the default when ' +
+        '--propose is omitted). No signer/submitter keys are fetched.',
+    })
     .parseAsync();
 
-  // Signing key: custom if provided, else GCP secret. No ETH needed — only signs EIP-712.
-  let signerKey: string;
-  if (signerKeyArg) {
-    signerKey = signerKeyArg.startsWith('0x')
-      ? signerKeyArg
-      : `0x${signerKeyArg}`;
-    console.log(`Signer:    ${new Wallet(signerKey).address}`);
-  } else {
-    const signerSecret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
-      privateKey: string;
-      address: string;
-    };
-    signerKey = signerSecret.privateKey;
-    console.log(`Signer:    ${signerSecret.address}`);
-  }
+  // --propose is the only thing that can turn off dry-run; --dry-run always wins.
+  const effectiveDryRun = dryRunArg || !propose;
 
-  let submitterWallet: Wallet | null = null;
-  if (propose) {
-    const submitterKeyRaw =
-      submitterKeyArg ??
-      process.env.PRIVATE_KEY ??
-      (await (async () => {
-        const deployerSecret = (await fetchGCPSecret(GCP_DEPLOYER_SECRET)) as {
-          privateKey: string;
-          address: string;
-        };
-        console.log(`Submitter: ${deployerSecret.address} (mainnet3 deployer)`);
-        return deployerSecret.privateKey;
-      })());
+  // Signing/submitter keys are only needed to sign and submit — skip fetching
+  // them entirely for a dry run so a preview never requires GCP credentials.
+  let signerKey: string | undefined;
+  let submitterWallet: Wallet | undefined;
+  if (!effectiveDryRun) {
+    // Signing key: custom if provided, else GCP secret. No ETH needed — only signs EIP-712.
+    if (signerKeyArg) {
+      signerKey = signerKeyArg.startsWith('0x')
+        ? signerKeyArg
+        : `0x${signerKeyArg}`;
+      console.log(`Signer:    ${new Wallet(signerKey).address}`);
+    } else {
+      const signerSecret = await resolveGcpKey(GCP_SIGNER_SECRET);
+      signerKey = signerSecret.privateKey;
+      console.log(`Signer:    ${signerSecret.address}`);
+    }
+
+    let submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;
+    if (!submitterKeyRaw) {
+      const deployerSecret = await resolveGcpKey(GCP_DEPLOYER_SECRET);
+      submitterKeyRaw = deployerSecret.privateKey;
+      console.log(`Submitter: ${deployerSecret.address} (mainnet3 deployer)`);
+    }
     const k = submitterKeyRaw.startsWith('0x')
       ? submitterKeyRaw
       : `0x${submitterKeyRaw}`;
@@ -167,195 +123,26 @@ async function main(): Promise<void> {
     console.log('Mode:      DRY RUN (pass --propose to submit transactions)');
   }
 
+  // For chain metadata (and thus RPC URLs), use the HTTP registry when -r is
+  // provided — it overlays private RPC URLs without replacing the filesystem
+  // registry that getWarpCoreConfig / getDomainId rely on (same as
+  // print-quotes.ts / set-quotes.ts).
   const rpcRegistry = registryUri
     ? getMergedRegistry({ registryUris: [registryUri], enableProxy: true })
     : getRegistry();
   const chainMetadata = await rpcRegistry.getMetadata();
   const multiProvider = new MultiProvider(chainMetadata);
 
-  const addrToLabel = new Map<string, string>();
-  const routersByChain = new Map<string, string[]>();
-  for (const routeId of ROUTE_IDS) {
-    const warpConfig = getWarpCoreConfig(routeId);
-    for (const t of warpConfig.tokens) {
-      if (t.addressOrDenom) {
-        const addr = t.addressOrDenom.startsWith('0x')
-          ? t.addressOrDenom.toLowerCase()
-          : t.addressOrDenom;
-        const label =
-          t.coinGeckoId === 'usd-coin'
-            ? 'USDC'
-            : t.coinGeckoId === 'tether'
-              ? 'USDT'
-              : (t.symbol ?? t.chainName ?? addr.slice(0, 10));
-        addrToLabel.set(addr, label);
-        if (t.chainName) {
-          const list = routersByChain.get(t.chainName) ?? [];
-          if (!list.includes(addr)) list.push(addr);
-          routersByChain.set(t.chainName, list);
-        }
-      }
-    }
-  }
-
   // ── Scan slots ────────────────────────────────────────────────────────────
   console.log('\nScanning OQLF slots...\n');
-  const now = Math.floor(Date.now() / 1000);
-  const seen = new Set<string>();
-  const allSlots: Slot[] = [];
-
-  await Promise.all(
-    ROUTE_IDS.flatMap((routeId) => {
-      const warpConfig = getWarpCoreConfig(routeId);
-      const seenOriginAddrs = new Set<string>();
-      const evmTokens = warpConfig.tokens.filter((t) => {
-        if (
-          !t.addressOrDenom ||
-          !t.chainName ||
-          !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
-        )
-          return false;
-        const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
-        if (seenOriginAddrs.has(key)) return false;
-        seenOriginAddrs.add(key);
-        return true;
-      });
-      return evmTokens.map(async (originToken) => {
-        const { chainName: origin, addressOrDenom: routerAddr } = originToken;
-        if (!routerAddr || !origin) return;
-        const normalizedAddr = routerAddr.toLowerCase();
-        const sourceToken =
-          addrToLabel.get(normalizedAddr) ?? originToken.symbol ?? origin;
-        const provider = multiProvider.getProvider(origin);
-
-        let ccrAddress: string;
-        try {
-          ccrAddress = await TokenRouter__factory.connect(
-            routerAddr,
-            provider,
-          ).feeRecipient();
-        } catch {
-          return;
-        }
-        if (!ccrAddress || ccrAddress === constants.AddressZero) return;
-
-        let feeTypeNum: number;
-        try {
-          feeTypeNum = await BaseFee__factory.connect(
-            ccrAddress,
-            provider,
-          ).feeType();
-        } catch {
-          return;
-        }
-        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
-          return;
-
-        const ccr = CrossCollateralRoutingFee__factory.connect(
-          ccrAddress,
-          provider,
-        );
-        const seenDestChains = new Set<string>();
-        const destTokens = warpConfig.tokens.filter((t) => {
-          if (!t.chainName) return false;
-          if (seenDestChains.has(t.chainName)) return false;
-          seenDestChains.add(t.chainName);
-          return true;
-        });
-
-        await Promise.all(
-          destTokens.map(async (destToken) => {
-            const { chainName: destination } = destToken;
-            if (!destination) return;
-            let destDomain: number;
-            try {
-              destDomain = getDomainId(destination);
-            } catch {
-              return;
-            }
-
-            const destRouters = routersByChain.get(destination) ?? [];
-            const targetKeys: Array<{
-              key: string;
-              label: string;
-              isDefault: boolean;
-            }> = [
-              { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT', isDefault: true },
-              ...destRouters.map((addr) => ({
-                key: addressToBytes32(addr),
-                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
-                isDefault: false,
-              })),
-            ];
-
-            await Promise.all(
-              targetKeys.map(async ({ key, label, isDefault }) => {
-                let oqlfAddress: string;
-                try {
-                  oqlfAddress = await ccr.feeContracts(destDomain, key);
-                } catch {
-                  return;
-                }
-                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
-                  return;
-
-                const slotId = `${ccrAddress.toLowerCase()}:${destDomain}:${key}:${sourceToken}`;
-                if (seen.has(slotId)) return;
-                seen.add(slotId);
-
-                const oqlf = OffchainQuotedLinearFee__factory.connect(
-                  oqlfAddress,
-                  provider,
-                );
-                const [onchainMaxFee, onchainHalfAmount] = await Promise.all([
-                  oqlf.maxFee(),
-                  oqlf.halfAmount(),
-                ]);
-
-                let effectiveMaxFee = onchainMaxFee.toBigInt();
-                let effectiveHalfAmount = onchainHalfAmount.toBigInt();
-                let hasActiveStanding = false;
-
-                for (const { dest, recip } of [
-                  { dest: destDomain, recip: WILDCARD_RECIPIENT },
-                  { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT },
-                ]) {
-                  const sq = await oqlf.quotes(dest, recip);
-                  const expiry = Number(sq.expiry);
-                  if (expiry > 0 && expiry >= now) {
-                    effectiveMaxFee = sq.maxFee.toBigInt();
-                    effectiveHalfAmount = sq.halfAmount.toBigInt();
-                    hasActiveStanding = true;
-                    break;
-                  }
-                }
-
-                allSlots.push({
-                  origin,
-                  sourceToken,
-                  destination,
-                  destDomain,
-                  target: label,
-                  isDefault,
-                  oqlfAddress,
-                  effectiveMaxFee,
-                  effectiveHalfAmount,
-                  hasActiveStanding,
-                });
-              }),
-            );
-          }),
-        );
-      });
-    }),
-  );
+  const allSlots: OqlfSlot[] = await discoverOqlfSlots(multiProvider);
 
   // ── Build propagation plan ─────────────────────────────────────────────────
 
   // Group by (origin, sourceToken, destination) to pair DEFAULT with per-router slots.
   const groups = new Map<
     string,
-    { defaultSlot: Slot | null; perRouterSlots: Slot[] }
+    { defaultSlot: OqlfSlot | null; perRouterSlots: OqlfSlot[] }
   >();
   for (const slot of allSlots) {
     const key = `${slot.origin}:${slot.sourceToken}:${slot.destination}`;
@@ -368,31 +155,37 @@ async function main(): Promise<void> {
     groups.set(key, g);
   }
 
-  // Collect slots to update: per-router slots whose effective bps differs from
-  // the DEFAULT slot's active standing quote value.
+  // Collect slots to update: per-router slots whose effective value differs
+  // from the DEFAULT slot's active standing quote value. Compare the raw
+  // maxFee/halfAmount values, not the display-rounded bps string, so a real
+  // (sub-display-precision) difference isn't skipped.
   const toSubmit: Array<{
-    slot: Slot;
-    maxFee: bigint;
-    halfAmount: bigint;
+    submission: QuoteSubmission;
     sourceBps: string;
     currentBps: string;
   }> = [];
 
   for (const [, { defaultSlot, perRouterSlots }] of groups) {
     // Only propagate when DEFAULT has an active standing quote.
-    if (!defaultSlot?.hasActiveStanding) continue;
+    if (!defaultSlot || defaultSlot.effectiveSource !== 'standing') continue;
     const sourceBps = fmtBps(
       defaultSlot.effectiveMaxFee,
       defaultSlot.effectiveHalfAmount,
     );
     for (const slot of perRouterSlots) {
+      if (
+        slot.effectiveMaxFee === defaultSlot.effectiveMaxFee &&
+        slot.effectiveHalfAmount === defaultSlot.effectiveHalfAmount
+      )
+        continue;
       const currentBps = fmtBps(slot.effectiveMaxFee, slot.effectiveHalfAmount);
-      // Skip if per-router slot already shows the same effective value.
-      if (currentBps === sourceBps) continue;
       toSubmit.push({
-        slot,
-        maxFee: defaultSlot.effectiveMaxFee,
-        halfAmount: defaultSlot.effectiveHalfAmount,
+        submission: {
+          slot,
+          maxFee: defaultSlot.effectiveMaxFee,
+          halfAmount: defaultSlot.effectiveHalfAmount,
+          bpsLabel: sourceBps,
+        },
         sourceBps,
         currentBps,
       });
@@ -401,10 +194,14 @@ async function main(): Promise<void> {
 
   toSubmit.sort((a, b) => {
     return (
-      a.slot.origin.localeCompare(b.slot.origin) ||
-      a.slot.sourceToken.localeCompare(b.slot.sourceToken) ||
-      a.slot.destination.localeCompare(b.slot.destination) ||
-      a.slot.target.localeCompare(b.slot.target)
+      a.submission.slot.origin.localeCompare(b.submission.slot.origin) ||
+      a.submission.slot.sourceToken.localeCompare(
+        b.submission.slot.sourceToken,
+      ) ||
+      a.submission.slot.destination.localeCompare(
+        b.submission.slot.destination,
+      ) ||
+      a.submission.slot.target.localeCompare(b.submission.slot.target)
     );
   });
 
@@ -418,10 +215,22 @@ async function main(): Promise<void> {
   // ── Print plan ────────────────────────────────────────────────────────────
   console.log(`${toSubmit.length} per-router slot(s) to propagate (TTL 7d):\n`);
   const W = {
-    origin: Math.max(6, ...toSubmit.map((r) => r.slot.origin.length)),
-    src: Math.max(3, ...toSubmit.map((r) => r.slot.sourceToken.length)),
-    dest: Math.max(4, ...toSubmit.map((r) => r.slot.destination.length)),
-    target: Math.max(6, ...toSubmit.map((r) => r.slot.target.length)),
+    origin: Math.max(
+      6,
+      ...toSubmit.map((r) => r.submission.slot.origin.length),
+    ),
+    src: Math.max(
+      3,
+      ...toSubmit.map((r) => r.submission.slot.sourceToken.length),
+    ),
+    dest: Math.max(
+      4,
+      ...toSubmit.map((r) => r.submission.slot.destination.length),
+    ),
+    target: Math.max(
+      6,
+      ...toSubmit.map((r) => r.submission.slot.target.length),
+    ),
     cur: Math.max(7, ...toSubmit.map((r) => r.currentBps.length)),
   };
   const pad = (s: string, n: number) =>
@@ -434,74 +243,69 @@ async function main(): Promise<void> {
       .map((w) => '─'.repeat(w))
       .join('   '),
   );
-  for (const { slot, sourceBps, currentBps } of toSubmit) {
+  for (const { submission, sourceBps, currentBps } of toSubmit) {
+    const { slot } = submission;
     console.log(
       `${pad(slot.origin, W.origin)}   ${pad(slot.sourceToken, W.src)} → ${pad(slot.destination, W.dest)}   ${pad(slot.target, W.target)}   ${pad(currentBps, W.cur)}   ${sourceBps}`,
     );
   }
   console.log();
 
-  if (!propose) {
+  if (effectiveDryRun) {
     console.log('Dry run complete. Pass --propose to submit transactions.');
+    return;
+  }
+
+  assert(
+    signerKey !== undefined && submitterWallet !== undefined,
+    'signer/submitter keys are required when --propose is set',
+  );
+
+  const confirmed = await confirm({
+    message: `Submit ${toSubmit.length} quote(s)?`,
+    default: false,
+  });
+  if (!confirmed) {
+    console.log('Aborted.');
     return;
   }
 
   // ── Sign and submit ────────────────────────────────────────────────────────
 
-  for (const { slot, maxFee, halfAmount, sourceBps } of toSubmit) {
-    const provider = multiProvider.getProvider(slot.origin);
-    const signerWallet = new Wallet(signerKey, provider);
-    const submitter = submitterWallet!.connect(provider);
-    const { chainId } = await provider.getNetwork();
-
-    const issuedAt = Math.floor(Date.now() / 1000);
-    const expiry = issuedAt + TTL_7D;
-    const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-    const submitterAddr = constants.AddressZero;
-
-    const context = ethers.utils.solidityPack(
-      ['uint32', 'bytes32', 'uint256'],
-      [slot.destDomain, WILDCARD_RECIPIENT, constants.MaxUint256],
-    );
-    const data = ethers.utils.solidityPack(
-      ['uint256', 'uint256'],
-      [maxFee, halfAmount],
-    );
-
-    const signature = await signerWallet._signTypedData(
-      {
-        name: EIP712_NAME,
-        version: EIP712_VERSION,
-        chainId,
-        verifyingContract: slot.oqlfAddress,
-      },
-      SIGNED_QUOTE_TYPES,
-      { context, data, issuedAt, expiry, salt, submitter: submitterAddr },
-    );
-
-    process.stdout.write(
-      `${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${sourceBps} bps)... `,
-    );
-    const oqlf = OffchainQuotedLinearFee__factory.connect(
-      slot.oqlfAddress,
-      submitter,
-    );
-    const txOverrides = multiProvider.getTransactionOverrides(slot.origin);
-    const tx = await oqlf.submitQuote(
-      { context, data, issuedAt, expiry, salt, submitter: submitterAddr },
-      signature,
-      txOverrides,
-    );
-    process.stdout.write(`${tx.hash.slice(0, 14)}… `);
-    await tx.wait(1);
-    console.log('confirmed.');
+  const results: Array<{ submission: QuoteSubmission; error?: unknown }> = [];
+  for (const { submission } of toSubmit) {
+    try {
+      await submitQuoteWithRetry(
+        multiProvider,
+        signerKey,
+        submitterWallet,
+        submission,
+        TTL_7D,
+      );
+      results.push({ submission });
+    } catch (error) {
+      results.push({ submission, error });
+    }
   }
 
-  console.log('\nAll quotes propagated.');
+  const failed = results.filter((r) => r.error !== undefined);
+  console.log(
+    `\n${results.length - failed.length}/${results.length} quote(s) propagated successfully.`,
+  );
+  if (failed.length > 0) {
+    console.error('\nFailed submissions (state to reconcile manually):');
+    for (const { submission, error } of failed) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(
+        `  ${submission.slot.origin} (${submission.slot.sourceToken}) → ${submission.slot.destination} / ${submission.slot.target}: ${msg}`,
+      );
+    }
+    process.exitCode = 1;
+  }
 }
 
 main()
-  .then(() => process.exit(0))
+  .then(() => process.exit(process.exitCode ?? 0))
   .catch((err) => {
     console.error(err instanceof Error ? err.message : err);
     process.exit(1);

--- a/typescript/infra/scripts/moonpay/propagate-quotes.ts
+++ b/typescript/infra/scripts/moonpay/propagate-quotes.ts
@@ -1,0 +1,479 @@
+#!/usr/bin/env tsx
+/**
+ * Propagates standing quotes from DEFAULT target slots to per-router target slots.
+ *
+ * For each (origin, sourceToken, destination) group in the CROSS/moonpay route:
+ *   1. Reads the DEFAULT OQLF slot's active standing quote value.
+ *   2. Submits that value as a new 7-day standing quote to every non-DEFAULT
+ *      (per-router) slot whose current effective value DIFFERS from DEFAULT's.
+ *
+ * Dry-run is the default. Pass --propose to actually submit transactions.
+ *
+ * The signer key (GCP quotesigner) signs the EIP-712 data; the gas-paying
+ * submitter key defaults to the GCP mainnet3 deployer key when -k is omitted.
+ *
+ * Usage (from typescript/infra/):
+ *   pnpm tsx scripts/moonpay/propagate-quotes.ts
+ *   pnpm tsx scripts/moonpay/propagate-quotes.ts --propose
+ *   pnpm tsx scripts/moonpay/propagate-quotes.ts --propose -k 0x<key>
+ */
+
+import { Wallet, constants, ethers } from 'ethers';
+import yargs from 'yargs';
+
+import {
+  BaseFee__factory,
+  CrossCollateralRoutingFee__factory,
+  OffchainQuotedLinearFee__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
+import { MultiProvider, OnchainTokenFeeType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+
+import {
+  getDomainId,
+  getRegistry,
+  getWarpCoreConfig,
+} from '../../config/registry.js';
+import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
+import { fetchGCPSecret } from '../../src/utils/gcloud.js';
+
+const GCP_SIGNER_SECRET = 'hyperlane-mainnet3-key-quotesigner';
+const GCP_DEPLOYER_SECRET = 'hyperlane-mainnet3-key-deployer';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32);
+const WILDCARD_DEST = 0xffffffff;
+const DEFAULT_ROUTER_KEY =
+  '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
+const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
+const TTL_7D = 7 * 86_400;
+
+const EIP712_NAME = 'OffchainQuoter';
+const EIP712_VERSION = '1';
+const SIGNED_QUOTE_TYPES = {
+  SignedQuote: [
+    { name: 'context', type: 'bytes' },
+    { name: 'data', type: 'bytes' },
+    { name: 'issuedAt', type: 'uint48' },
+    { name: 'expiry', type: 'uint48' },
+    { name: 'salt', type: 'bytes32' },
+    { name: 'submitter', type: 'address' },
+  ],
+};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface Slot {
+  origin: string;
+  sourceToken: string;
+  destination: string;
+  destDomain: number;
+  /** 'DEFAULT' or normalised token label */
+  target: string;
+  isDefault: boolean;
+  oqlfAddress: string;
+  /** Current effective maxFee (standing or fallback) */
+  effectiveMaxFee: bigint;
+  /** Current effective halfAmount */
+  effectiveHalfAmount: bigint;
+  hasActiveStanding: boolean;
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+function fmtBps(maxFee: bigint, halfAmount: bigint): string {
+  if (halfAmount === 0n) return '?.??';
+  const denom = halfAmount * 2n;
+  const whole = (maxFee * 10_000n) / denom;
+  const frac = (maxFee * 1_000_000n) / denom - whole * 100n;
+  return `${whole}.${String(frac).padStart(2, '0')}`;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const {
+    registry: registryUri,
+    submitterKey: submitterKeyArg,
+    propose,
+  } = await yargs(process.argv.slice(2))
+    .option('registry', {
+      alias: 'r',
+      type: 'string',
+      describe: 'Registry URI (local path or http://…)',
+    })
+    .option('submitter-key', {
+      alias: 'k',
+      type: 'string',
+      describe:
+        'Private key (0x…) of the gas-paying submitter. ' +
+        'Defaults to GCP mainnet3 deployer key when omitted.',
+    })
+    .option('propose', {
+      type: 'boolean',
+      default: false,
+      describe: 'Submit transactions on-chain (default: dry run only).',
+    })
+    .parseAsync();
+
+  // Signing key: GCP secret, signs EIP-712 data (no ETH needed).
+  const signerSecret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
+    privateKey: string;
+    address: string;
+  };
+  const signerKey = signerSecret.privateKey;
+  console.log(`Signer:    ${signerSecret.address}`);
+
+  let submitterWallet: Wallet | null = null;
+  if (propose) {
+    const submitterKeyRaw =
+      submitterKeyArg ??
+      process.env.PRIVATE_KEY ??
+      (await (async () => {
+        const deployerSecret = (await fetchGCPSecret(GCP_DEPLOYER_SECRET)) as {
+          privateKey: string;
+          address: string;
+        };
+        console.log(`Submitter: ${deployerSecret.address} (mainnet3 deployer)`);
+        return deployerSecret.privateKey;
+      })());
+    const k = submitterKeyRaw.startsWith('0x')
+      ? submitterKeyRaw
+      : `0x${submitterKeyRaw}`;
+    submitterWallet = new Wallet(k);
+    if (submitterKeyArg || process.env.PRIVATE_KEY) {
+      console.log(`Submitter: ${submitterWallet.address}`);
+    }
+  } else {
+    console.log('Mode:      DRY RUN (pass --propose to submit transactions)');
+  }
+
+  const rpcRegistry = registryUri
+    ? getMergedRegistry({ registryUris: [registryUri], enableProxy: true })
+    : getRegistry();
+  const chainMetadata = await rpcRegistry.getMetadata();
+  const multiProvider = new MultiProvider(chainMetadata);
+
+  const addrToLabel = new Map<string, string>();
+  const routersByChain = new Map<string, string[]>();
+  for (const routeId of ROUTE_IDS) {
+    const warpConfig = getWarpCoreConfig(routeId);
+    for (const t of warpConfig.tokens) {
+      if (t.addressOrDenom) {
+        const addr = t.addressOrDenom.startsWith('0x')
+          ? t.addressOrDenom.toLowerCase()
+          : t.addressOrDenom;
+        const label =
+          t.coinGeckoId === 'usd-coin'
+            ? 'USDC'
+            : t.coinGeckoId === 'tether'
+              ? 'USDT'
+              : (t.symbol ?? t.chainName ?? addr.slice(0, 10));
+        addrToLabel.set(addr, label);
+        if (t.chainName) {
+          const list = routersByChain.get(t.chainName) ?? [];
+          if (!list.includes(addr)) list.push(addr);
+          routersByChain.set(t.chainName, list);
+        }
+      }
+    }
+  }
+
+  // ── Scan slots ────────────────────────────────────────────────────────────
+  console.log('\nScanning OQLF slots...\n');
+  const now = Math.floor(Date.now() / 1000);
+  const seen = new Set<string>();
+  const allSlots: Slot[] = [];
+
+  await Promise.all(
+    ROUTE_IDS.flatMap((routeId) => {
+      const warpConfig = getWarpCoreConfig(routeId);
+      const evmTokens = warpConfig.tokens.filter(
+        (t) =>
+          t.addressOrDenom &&
+          t.chainName &&
+          /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom),
+      );
+      return evmTokens.map(async (originToken) => {
+        const { chainName: origin, addressOrDenom: routerAddr } = originToken;
+        if (!routerAddr || !origin) return;
+        const normalizedAddr = routerAddr.toLowerCase();
+        const sourceToken =
+          addrToLabel.get(normalizedAddr) ?? originToken.symbol ?? origin;
+        const provider = multiProvider.getProvider(origin);
+
+        let ccrAddress: string;
+        try {
+          ccrAddress = await TokenRouter__factory.connect(
+            routerAddr,
+            provider,
+          ).feeRecipient();
+        } catch {
+          return;
+        }
+        if (!ccrAddress || ccrAddress === constants.AddressZero) return;
+
+        let feeTypeNum: number;
+        try {
+          feeTypeNum = await BaseFee__factory.connect(
+            ccrAddress,
+            provider,
+          ).feeType();
+        } catch {
+          return;
+        }
+        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
+          return;
+
+        const ccr = CrossCollateralRoutingFee__factory.connect(
+          ccrAddress,
+          provider,
+        );
+        const destTokens = warpConfig.tokens.filter((t) => !!t.chainName);
+
+        await Promise.all(
+          destTokens.map(async (destToken) => {
+            const { chainName: destination } = destToken;
+            if (!destination) return;
+            let destDomain: number;
+            try {
+              destDomain = getDomainId(destination);
+            } catch {
+              return;
+            }
+
+            const destRouters = routersByChain.get(destination) ?? [];
+            const targetKeys: Array<{
+              key: string;
+              label: string;
+              isDefault: boolean;
+            }> = [
+              { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT', isDefault: true },
+              ...destRouters.map((addr) => ({
+                key: addressToBytes32(addr),
+                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
+                isDefault: false,
+              })),
+            ];
+
+            await Promise.all(
+              targetKeys.map(async ({ key, label, isDefault }) => {
+                let oqlfAddress: string;
+                try {
+                  oqlfAddress = await ccr.feeContracts(destDomain, key);
+                } catch {
+                  return;
+                }
+                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
+                  return;
+
+                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${sourceToken}`;
+                if (seen.has(slotId)) return;
+                seen.add(slotId);
+
+                const oqlf = OffchainQuotedLinearFee__factory.connect(
+                  oqlfAddress,
+                  provider,
+                );
+                const [onchainMaxFee, onchainHalfAmount] = await Promise.all([
+                  oqlf.maxFee(),
+                  oqlf.halfAmount(),
+                ]);
+
+                let effectiveMaxFee = onchainMaxFee.toBigInt();
+                let effectiveHalfAmount = onchainHalfAmount.toBigInt();
+                let hasActiveStanding = false;
+
+                for (const { dest, recip } of [
+                  { dest: destDomain, recip: WILDCARD_RECIPIENT },
+                  { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT },
+                ]) {
+                  const sq = await oqlf.quotes(dest, recip);
+                  const expiry = Number(sq.expiry);
+                  if (expiry > 0 && expiry >= now) {
+                    effectiveMaxFee = sq.maxFee.toBigInt();
+                    effectiveHalfAmount = sq.halfAmount.toBigInt();
+                    hasActiveStanding = true;
+                    break;
+                  }
+                }
+
+                allSlots.push({
+                  origin,
+                  sourceToken,
+                  destination,
+                  destDomain,
+                  target: label,
+                  isDefault,
+                  oqlfAddress,
+                  effectiveMaxFee,
+                  effectiveHalfAmount,
+                  hasActiveStanding,
+                });
+              }),
+            );
+          }),
+        );
+      });
+    }),
+  );
+
+  // ── Build propagation plan ─────────────────────────────────────────────────
+
+  // Group by (origin, sourceToken, destination) to pair DEFAULT with per-router slots.
+  const groups = new Map<
+    string,
+    { defaultSlot: Slot | null; perRouterSlots: Slot[] }
+  >();
+  for (const slot of allSlots) {
+    const key = `${slot.origin}:${slot.sourceToken}:${slot.destination}`;
+    const g = groups.get(key) ?? { defaultSlot: null, perRouterSlots: [] };
+    if (slot.isDefault) {
+      g.defaultSlot = slot;
+    } else {
+      g.perRouterSlots.push(slot);
+    }
+    groups.set(key, g);
+  }
+
+  // Collect slots to update: per-router slots whose effective bps differs from
+  // the DEFAULT slot's active standing quote value.
+  const toSubmit: Array<{
+    slot: Slot;
+    maxFee: bigint;
+    halfAmount: bigint;
+    sourceBps: string;
+    currentBps: string;
+  }> = [];
+
+  for (const [, { defaultSlot, perRouterSlots }] of groups) {
+    // Only propagate when DEFAULT has an active standing quote.
+    if (!defaultSlot?.hasActiveStanding) continue;
+    const sourceBps = fmtBps(
+      defaultSlot.effectiveMaxFee,
+      defaultSlot.effectiveHalfAmount,
+    );
+    for (const slot of perRouterSlots) {
+      const currentBps = fmtBps(slot.effectiveMaxFee, slot.effectiveHalfAmount);
+      // Skip if per-router slot already shows the same effective value.
+      if (currentBps === sourceBps) continue;
+      toSubmit.push({
+        slot,
+        maxFee: defaultSlot.effectiveMaxFee,
+        halfAmount: defaultSlot.effectiveHalfAmount,
+        sourceBps,
+        currentBps,
+      });
+    }
+  }
+
+  toSubmit.sort((a, b) => {
+    return (
+      a.slot.origin.localeCompare(b.slot.origin) ||
+      a.slot.sourceToken.localeCompare(b.slot.sourceToken) ||
+      a.slot.destination.localeCompare(b.slot.destination) ||
+      a.slot.target.localeCompare(b.slot.target)
+    );
+  });
+
+  if (toSubmit.length === 0) {
+    console.log(
+      'No per-router slots need updating (all match their DEFAULT standing quote).',
+    );
+    return;
+  }
+
+  // ── Print plan ────────────────────────────────────────────────────────────
+  console.log(`${toSubmit.length} per-router slot(s) to propagate (TTL 7d):\n`);
+  const W = {
+    origin: Math.max(6, ...toSubmit.map((r) => r.slot.origin.length)),
+    src: Math.max(3, ...toSubmit.map((r) => r.slot.sourceToken.length)),
+    dest: Math.max(4, ...toSubmit.map((r) => r.slot.destination.length)),
+    target: Math.max(6, ...toSubmit.map((r) => r.slot.target.length)),
+    cur: Math.max(7, ...toSubmit.map((r) => r.currentBps.length)),
+  };
+  const pad = (s: string, n: number) =>
+    s.length >= n ? s : s + ' '.repeat(n - s.length);
+  console.log(
+    `${pad('origin', W.origin)}   ${pad('src', W.src)} → ${pad('dest', W.dest)}   ${pad('target', W.target)}   ${pad('current', W.cur)}   new`,
+  );
+  console.log(
+    [W.origin, W.src, W.dest, W.target, W.cur, 8]
+      .map((w) => '─'.repeat(w))
+      .join('   '),
+  );
+  for (const { slot, sourceBps, currentBps } of toSubmit) {
+    console.log(
+      `${pad(slot.origin, W.origin)}   ${pad(slot.sourceToken, W.src)} → ${pad(slot.destination, W.dest)}   ${pad(slot.target, W.target)}   ${pad(currentBps, W.cur)}   ${sourceBps}`,
+    );
+  }
+  console.log();
+
+  if (!propose) {
+    console.log('Dry run complete. Pass --propose to submit transactions.');
+    return;
+  }
+
+  // ── Sign and submit ────────────────────────────────────────────────────────
+
+  for (const { slot, maxFee, halfAmount, sourceBps } of toSubmit) {
+    const provider = multiProvider.getProvider(slot.origin);
+    const signerWallet = new Wallet(signerKey, provider);
+    const submitter = submitterWallet!.connect(provider);
+    const { chainId } = await provider.getNetwork();
+
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const expiry = issuedAt + TTL_7D;
+    const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+    const submitterAddr = constants.AddressZero;
+
+    const context = ethers.utils.solidityPack(
+      ['uint32', 'bytes32', 'uint256'],
+      [slot.destDomain, WILDCARD_RECIPIENT, constants.MaxUint256],
+    );
+    const data = ethers.utils.solidityPack(
+      ['uint256', 'uint256'],
+      [maxFee, halfAmount],
+    );
+
+    const signature = await signerWallet._signTypedData(
+      {
+        name: EIP712_NAME,
+        version: EIP712_VERSION,
+        chainId,
+        verifyingContract: slot.oqlfAddress,
+      },
+      SIGNED_QUOTE_TYPES,
+      { context, data, issuedAt, expiry, salt, submitter: submitterAddr },
+    );
+
+    process.stdout.write(
+      `${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${sourceBps} bps)... `,
+    );
+    const oqlf = OffchainQuotedLinearFee__factory.connect(
+      slot.oqlfAddress,
+      submitter,
+    );
+    const txOverrides = multiProvider.getTransactionOverrides(slot.origin);
+    const tx = await oqlf.submitQuote(
+      { context, data, issuedAt, expiry, salt, submitter: submitterAddr },
+      signature,
+      txOverrides,
+    );
+    process.stdout.write(`${tx.hash.slice(0, 14)}… `);
+    await tx.wait(1);
+    console.log('confirmed.');
+  }
+
+  console.log('\nAll quotes propagated.');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/moonpay/propagate-quotes.ts
+++ b/typescript/infra/scripts/moonpay/propagate-quotes.ts
@@ -97,6 +97,7 @@ function fmtBps(maxFee: bigint, halfAmount: bigint): string {
 async function main(): Promise<void> {
   const {
     registry: registryUri,
+    signerKey: signerKeyArg,
     submitterKey: submitterKeyArg,
     propose,
   } = await yargs(process.argv.slice(2))
@@ -104,6 +105,13 @@ async function main(): Promise<void> {
       alias: 'r',
       type: 'string',
       describe: 'Registry URI (local path or http://…)',
+    })
+    .option('signer-key', {
+      alias: 's',
+      type: 'string',
+      describe:
+        'Private key (0x…) of the EIP-712 quote signer. ' +
+        'Defaults to GCP secret hyperlane-mainnet3-key-quotesigner.',
     })
     .option('submitter-key', {
       alias: 'k',
@@ -119,13 +127,21 @@ async function main(): Promise<void> {
     })
     .parseAsync();
 
-  // Signing key: GCP secret, signs EIP-712 data (no ETH needed).
-  const signerSecret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
-    privateKey: string;
-    address: string;
-  };
-  const signerKey = signerSecret.privateKey;
-  console.log(`Signer:    ${signerSecret.address}`);
+  // Signing key: custom if provided, else GCP secret. No ETH needed — only signs EIP-712.
+  let signerKey: string;
+  if (signerKeyArg) {
+    signerKey = signerKeyArg.startsWith('0x')
+      ? signerKeyArg
+      : `0x${signerKeyArg}`;
+    console.log(`Signer:    ${new Wallet(signerKey).address}`);
+  } else {
+    const signerSecret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
+      privateKey: string;
+      address: string;
+    };
+    signerKey = signerSecret.privateKey;
+    console.log(`Signer:    ${signerSecret.address}`);
+  }
 
   let submitterWallet: Wallet | null = null;
   if (propose) {

--- a/typescript/infra/scripts/moonpay/propagate-quotes.ts
+++ b/typescript/infra/scripts/moonpay/propagate-quotes.ts
@@ -41,6 +41,7 @@ import {
   fmtBps,
   resolveGcpKey,
   submitQuoteWithRetry,
+  verifySignerAuthorization,
 } from './oqlf-lib.js';
 
 const TTL_7D = 7 * 86_400;
@@ -259,6 +260,12 @@ async function main(): Promise<void> {
   assert(
     signerKey !== undefined && submitterWallet !== undefined,
     'signer/submitter keys are required when --propose is set',
+  );
+
+  await verifySignerAuthorization(
+    multiProvider,
+    signerKey,
+    toSubmit.map((t) => t.submission.slot),
   );
 
   const confirmed = await confirm({

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -111,6 +111,7 @@ async function main(): Promise<void> {
   const {
     registry: registryUri,
     ttl,
+    signerKey: signerKeyArg,
     submitterKey: submitterKeyArg,
   } = await yargs(process.argv.slice(2))
     .option('registry', {
@@ -123,23 +124,38 @@ async function main(): Promise<void> {
       default: DEFAULT_TTL,
       describe: 'Standing quote TTL in seconds (default 24 h)',
     })
+    .option('signer-key', {
+      alias: 's',
+      type: 'string',
+      describe:
+        'Private key (0x…) of the EIP-712 quote signer. ' +
+        'Defaults to GCP secret hyperlane-mainnet3-key-quotesigner.',
+    })
     .option('submitter-key', {
       alias: 'k',
       type: 'string',
       describe:
         'Private key (0x…) of the gas-paying submitter account. ' +
         'Defaults to PRIVATE_KEY env var. ' +
-        'The quote signer (GCP secret) signs; this account pays gas.',
+        'The quote signer signs; this account pays gas.',
     })
     .parseAsync();
 
-  // Signing key: GCP secret, no ETH needed — only signs the EIP-712 data.
-  const secret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
-    privateKey: string;
-    address: string;
-  };
-  const signerKey = secret.privateKey;
-  console.log(`Signer:    ${secret.address}`);
+  // Signing key: custom if provided, else GCP secret. No ETH needed — only signs EIP-712.
+  let signerKey: string;
+  if (signerKeyArg) {
+    signerKey = signerKeyArg.startsWith('0x')
+      ? signerKeyArg
+      : `0x${signerKeyArg}`;
+    console.log(`Signer:    ${new Wallet(signerKey).address}`);
+  } else {
+    const secret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
+      privateKey: string;
+      address: string;
+    };
+    signerKey = secret.privateKey;
+    console.log(`Signer:    ${secret.address}`);
+  }
 
   // Submitter key: pays gas for submitQuote(). Anyone may submit since submitter=address(0).
   const submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -261,12 +261,19 @@ async function main(): Promise<void> {
   await Promise.all(
     ROUTE_IDS.flatMap((routeId) => {
       const warpConfig = getWarpCoreConfig(routeId);
-      const evmTokens = warpConfig.tokens.filter(
-        (t) =>
-          t.addressOrDenom &&
-          t.chainName &&
-          /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom),
-      );
+      const seenOriginAddrs = new Set<string>();
+      const evmTokens = warpConfig.tokens.filter((t) => {
+        if (
+          !t.addressOrDenom ||
+          !t.chainName ||
+          !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
+        )
+          return false;
+        const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
+        if (seenOriginAddrs.has(key)) return false;
+        seenOriginAddrs.add(key);
+        return true;
+      });
       return evmTokens.map(async (originToken) => {
         const { chainName: origin, addressOrDenom: routerAddr } = originToken;
         if (!routerAddr || !origin) return;
@@ -302,7 +309,13 @@ async function main(): Promise<void> {
           ccrAddress,
           provider,
         );
-        const destTokens = warpConfig.tokens.filter((t) => !!t.chainName);
+        const seenDestChains = new Set<string>();
+        const destTokens = warpConfig.tokens.filter((t) => {
+          if (!t.chainName) return false;
+          if (seenDestChains.has(t.chainName)) return false;
+          seenDestChains.add(t.chainName);
+          return true;
+        });
 
         await Promise.all(
           destTokens.map(async (destToken) => {

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -1,0 +1,588 @@
+#!/usr/bin/env tsx
+/**
+ * Interactively sets standing quotes for CROSS/MoonPay warp routes.
+ * Signs EIP-712 quotes and submits them on-chain via OQLF.submitQuote().
+ *
+ * Standing quotes are stored in OQLF.quotes[destDomain][WILDCARD_RECIPIENT]
+ * and expire after --ttl seconds (default 24 h). Any address may submit
+ * since submitter = address(0).
+ *
+ * Usage (from typescript/infra/):
+ *   pnpm tsx scripts/moonpay/set-quotes.ts
+ *   pnpm tsx scripts/moonpay/set-quotes.ts -r http://localhost:3000
+ */
+
+import { Wallet, constants, ethers } from 'ethers';
+import yargs from 'yargs';
+
+import { checkbox, confirm, input } from '@inquirer/prompts';
+
+import {
+  BaseFee__factory,
+  CrossCollateralRoutingFee__factory,
+  OffchainQuotedLinearFee__factory,
+  TokenRouter__factory,
+} from '@hyperlane-xyz/core';
+import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
+import { MultiProvider, OnchainTokenFeeType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+
+import {
+  getDomainId,
+  getRegistry,
+  getWarpCoreConfig,
+} from '../../config/registry.js';
+import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
+import { fetchGCPSecret } from '../../src/utils/gcloud.js';
+
+const GCP_SIGNER_SECRET = 'hyperlane-mainnet3-key-quotesigner';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const WILDCARD_DEST = 0xffffffff;
+const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32);
+// keccak256("RoutingFee.DEFAULT_ROUTER")
+const DEFAULT_ROUTER_KEY =
+  '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
+const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
+const DEFAULT_TTL = 86_400; // 24 hours
+
+// EIP-712: matches AbstractOffchainQuoter.sol name/version
+const EIP712_NAME = 'OffchainQuoter';
+const EIP712_VERSION = '1';
+const SIGNED_QUOTE_TYPES = {
+  SignedQuote: [
+    { name: 'context', type: 'bytes' },
+    { name: 'data', type: 'bytes' },
+    { name: 'issuedAt', type: 'uint48' },
+    { name: 'expiry', type: 'uint48' },
+    { name: 'salt', type: 'bytes32' },
+    { name: 'submitter', type: 'address' },
+  ],
+};
+
+// Matches EvmTokenFeeReader.convertFromBps — used to derive canonical (maxFee, halfAmount)
+// from a bps value without needing an on-chain read.
+const ASSUMED_MAX_AMOUNT = 10n ** 36n; // 10^36 — prevents overflow in LinearFee contract
+const MAX_BPS = 10_000n;
+const BPS_PRECISION = 10_000n; // supports up to 4 decimal places on bps
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface OqlfSlot {
+  origin: string;
+  sourceToken: string; // normalised group label of the origin token (USDC / USDT)
+  destination: string;
+  destDomain: number;
+  target: string; // "DEFAULT" or normalised group label of the destination token
+  oqlfAddress: string;
+  currentBpsStr: string;
+  currentSource: 'standing' | 'fallback';
+  onchainMaxFee: bigint;
+  onchainHalfAmount: bigint;
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+/** Display bps as "W.FF" — same formula as print-quotes. */
+function fmtBps(maxFee: bigint, halfAmount: bigint): string {
+  if (halfAmount === 0n) return '?.??';
+  const denom = halfAmount * 2n;
+  const whole = (maxFee * 10_000n) / denom;
+  const frac = (maxFee * 1_000_000n) / denom - whole * 100n;
+  return `${whole}.${String(frac).padStart(2, '0')}`;
+}
+
+/**
+ * Convert a numeric bps value to canonical (maxFee, halfAmount).
+ * Mirrors EvmTokenFeeReader.convertFromBps exactly so deployed contracts
+ * are consistent with the standing quote parameters.
+ */
+function bpsToParams(bps: number): { maxFee: bigint; halfAmount: bigint } {
+  const maxFee = BigInt(constants.MaxUint256.toString()) / ASSUMED_MAX_AMOUNT;
+  const scaledBps = BigInt(Math.round(bps * Number(BPS_PRECISION)));
+  const halfAmount = ((maxFee / 2n) * MAX_BPS * BPS_PRECISION) / scaledBps;
+  return { maxFee, halfAmount };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const {
+    registry: registryUri,
+    ttl,
+    submitterKey: submitterKeyArg,
+  } = await yargs(process.argv.slice(2))
+    .option('registry', {
+      alias: 'r',
+      type: 'string',
+      describe: 'Registry URI (local path or http://…)',
+    })
+    .option('ttl', {
+      type: 'number',
+      default: DEFAULT_TTL,
+      describe: 'Standing quote TTL in seconds (default 24 h)',
+    })
+    .option('submitter-key', {
+      alias: 'k',
+      type: 'string',
+      describe:
+        'Private key (0x…) of the gas-paying submitter account. ' +
+        'Defaults to PRIVATE_KEY env var. ' +
+        'The quote signer (GCP secret) signs; this account pays gas.',
+    })
+    .parseAsync();
+
+  // Signing key: GCP secret, no ETH needed — only signs the EIP-712 data.
+  const secret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
+    privateKey: string;
+    address: string;
+  };
+  const signerKey = secret.privateKey;
+  console.log(`Signer:    ${secret.address}`);
+
+  // Submitter key: pays gas for submitQuote(). Anyone may submit since submitter=address(0).
+  const submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;
+  if (!submitterKeyRaw) {
+    console.error(
+      'Error: provide a gas-paying key via --submitter-key or PRIVATE_KEY env var.',
+    );
+    process.exit(1);
+  }
+  const submitterKey = submitterKeyRaw.startsWith('0x')
+    ? submitterKeyRaw
+    : `0x${submitterKeyRaw}`;
+  const submitterWallet = new Wallet(submitterKey);
+  console.log(`Submitter: ${submitterWallet.address}`);
+
+  // HTTP registry overlays private RPC URLs; filesystem registry handles warp configs.
+  const rpcRegistry = registryUri
+    ? getMergedRegistry({ registryUris: [registryUri], enableProxy: true })
+    : getRegistry();
+  const chainMetadata = await rpcRegistry.getMetadata();
+  const multiProvider = new MultiProvider(chainMetadata);
+
+  // address → normalised group label: usd-coin→"USDC", tether→"USDT", else symbol.
+  // EVM addresses are lowercased; non-EVM (e.g. Solana base58) are kept as-is.
+  const addrToLabel = new Map<string, string>();
+  const routersByChain = new Map<string, string[]>();
+  for (const routeId of ROUTE_IDS) {
+    const warpConfig = getWarpCoreConfig(routeId);
+    for (const t of warpConfig.tokens) {
+      if (t.addressOrDenom) {
+        const addr = t.addressOrDenom.startsWith('0x')
+          ? t.addressOrDenom.toLowerCase()
+          : t.addressOrDenom;
+        const label =
+          t.coinGeckoId === 'usd-coin'
+            ? 'USDC'
+            : t.coinGeckoId === 'tether'
+              ? 'USDT'
+              : (t.symbol ?? t.chainName ?? addr.slice(0, 10));
+        addrToLabel.set(addr, label);
+        if (t.chainName) {
+          const list = routersByChain.get(t.chainName) ?? [];
+          if (!list.includes(addr)) list.push(addr);
+          routersByChain.set(t.chainName, list);
+        }
+      }
+    }
+  }
+
+  // ── Discover all OQLF slots ────────────────────────────────────────────────
+  console.log('\nDiscovering OQLF slots (one-time RPC scan)...\n');
+  const now = Math.floor(Date.now() / 1000);
+  // dedup: one standing-quote storage slot per (oqlfAddress, destDomain)
+  const seenSlots = new Set<string>();
+  const allSlots: OqlfSlot[] = [];
+
+  await Promise.all(
+    ROUTE_IDS.flatMap((routeId) => {
+      const warpConfig = getWarpCoreConfig(routeId);
+      const evmTokens = warpConfig.tokens.filter(
+        (t) =>
+          t.addressOrDenom &&
+          t.chainName &&
+          /^0x[0-9a-f]{40}$/i.test(t.addressOrDenom),
+      );
+      return evmTokens.map(async (originToken) => {
+        const { chainName: origin, addressOrDenom: routerAddr } = originToken;
+        if (!routerAddr || !origin) return;
+        const normalizedOriginAddr = routerAddr.toLowerCase();
+        const sourceToken =
+          addrToLabel.get(normalizedOriginAddr) ?? originToken.symbol ?? origin;
+        const provider = multiProvider.getProvider(origin);
+
+        let ccrAddress: string;
+        try {
+          ccrAddress = await TokenRouter__factory.connect(
+            routerAddr,
+            provider,
+          ).feeRecipient();
+        } catch {
+          return;
+        }
+        if (!ccrAddress || ccrAddress === constants.AddressZero) return;
+
+        let feeTypeNum: number;
+        try {
+          feeTypeNum = await BaseFee__factory.connect(
+            ccrAddress,
+            provider,
+          ).feeType();
+        } catch {
+          return;
+        }
+        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
+          return;
+
+        const ccr = CrossCollateralRoutingFee__factory.connect(
+          ccrAddress,
+          provider,
+        );
+        const destTokens = warpConfig.tokens.filter((t) => !!t.chainName);
+
+        await Promise.all(
+          destTokens.map(async (destToken) => {
+            const { chainName: destination } = destToken;
+            if (!destination) return;
+            let destDomain: number;
+            try {
+              destDomain = getDomainId(destination);
+            } catch {
+              return;
+            }
+
+            const destRouters = routersByChain.get(destination) ?? [];
+            const targetKeys: Array<{ key: string; label: string }> = [
+              { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT' },
+              ...destRouters.map((addr) => ({
+                key: addressToBytes32(addr),
+                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
+              })),
+            ];
+
+            await Promise.all(
+              targetKeys.map(async ({ key, label }) => {
+                let oqlfAddress: string;
+                try {
+                  oqlfAddress = await ccr.feeContracts(destDomain, key);
+                } catch {
+                  return;
+                }
+                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
+                  return;
+
+                // Each (oqlfAddress, destDomain) is a unique on-chain storage slot.
+                // Include sourceToken in the key because two CCRs on the same chain
+                // (one USDC, one USDT) each own separate OQLF instances.
+                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${sourceToken}`;
+                if (seenSlots.has(slotId)) return;
+                seenSlots.add(slotId);
+
+                const oqlf = OffchainQuotedLinearFee__factory.connect(
+                  oqlfAddress,
+                  provider,
+                );
+                const [onchainMaxFee, onchainHalfAmount] = await Promise.all([
+                  oqlf.maxFee(),
+                  oqlf.halfAmount(),
+                ]);
+
+                // Resolve current standing quote (dest-specific wins over wildcard).
+                let currentMaxFee = onchainMaxFee.toBigInt();
+                let currentHalfAmount = onchainHalfAmount.toBigInt();
+                let currentSource: 'standing' | 'fallback' = 'fallback';
+
+                for (const { dest, recip } of [
+                  { dest: destDomain, recip: WILDCARD_RECIPIENT },
+                  { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT },
+                ]) {
+                  const sq = await oqlf.quotes(dest, recip);
+                  const expiry = Number(sq.expiry);
+                  if (expiry > 0 && expiry >= now) {
+                    currentMaxFee = sq.maxFee.toBigInt();
+                    currentHalfAmount = sq.halfAmount.toBigInt();
+                    currentSource = 'standing';
+                    break;
+                  }
+                }
+
+                allSlots.push({
+                  origin,
+                  sourceToken,
+                  destination,
+                  destDomain,
+                  target: label,
+                  oqlfAddress,
+                  currentBpsStr: fmtBps(currentMaxFee, currentHalfAmount),
+                  currentSource,
+                  onchainMaxFee: onchainMaxFee.toBigInt(),
+                  onchainHalfAmount: onchainHalfAmount.toBigInt(),
+                });
+              }),
+            );
+          }),
+        );
+      });
+    }),
+  );
+
+  // Consistent ordering: origin → sourceToken → dest → DEFAULT first, then alpha by target.
+  allSlots.sort((a, b) => {
+    const cmp =
+      a.origin.localeCompare(b.origin) ||
+      a.sourceToken.localeCompare(b.sourceToken) ||
+      a.destination.localeCompare(b.destination);
+    if (cmp !== 0) return cmp;
+    if (a.target === 'DEFAULT') return -1;
+    if (b.target === 'DEFAULT') return 1;
+    return a.target.localeCompare(b.target);
+  });
+
+  console.log(`Found ${allSlots.length} OQLF slots.\n`);
+
+  // ── Verify signer authorization ────────────────────────────────────────────
+  const signerAddress = secret.address;
+  const sampleSlot = allSlots[0];
+  if (sampleSlot) {
+    const provider = multiProvider.getProvider(sampleSlot.origin);
+    const oqlf = OffchainQuotedLinearFee__factory.connect(
+      sampleSlot.oqlfAddress,
+      provider,
+    );
+    const authorized = await oqlf.isQuoteSigner(signerAddress);
+    if (!authorized) {
+      const authorizedSigners = await oqlf.quoteSigners();
+      console.error(
+        `\nError: signer ${signerAddress} is NOT authorized on OQLF ${sampleSlot.oqlfAddress}.`,
+      );
+      console.error(
+        authorizedSigners.length === 0
+          ? 'No authorized signers found — contract may not be configured.'
+          : `Authorized signers: ${authorizedSigners.join(', ')}`,
+      );
+      process.exit(1);
+    }
+    console.log(`Signer ${signerAddress} is authorized. Proceeding.\n`);
+  }
+
+  // ── Interactive selection ──────────────────────────────────────────────────
+
+  const parseTtl = (v: string): number | null => {
+    const t = v.trim().toLowerCase();
+    const m = t.match(/^(\d+(?:\.\d+)?)(h|d)?$/);
+    if (!m) return null;
+    const n = parseFloat(m[1]);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return m[2] === 'd' ? n * 86_400 : n * 3600;
+  };
+
+  const defaultTtlStr =
+    ttl % 86_400 === 0 ? `${ttl / 86_400}d` : `${ttl / 3600}h`;
+  const ttlRaw = await input({
+    message: 'Standing quote TTL (e.g. 24h or 2d)',
+    default: defaultTtlStr,
+    validate: (v) => parseTtl(v) !== null || 'Enter a duration like 24h or 2d.',
+  });
+  const effectiveTtl = parseTtl(ttlRaw)!;
+
+  const availableOrigins = [...new Set(allSlots.map((s) => s.origin))].sort();
+  const selectedChains = await checkbox({
+    message: 'Select origin chains',
+    choices: availableOrigins.map((c) => ({ value: c })),
+    pageSize: 20,
+    required: true,
+  });
+
+  const availableSourceTokens = [
+    ...new Set(allSlots.map((s) => s.sourceToken)),
+  ].sort();
+  const selectedSourceTokens = await checkbox({
+    message: 'Select source token groups',
+    choices: availableSourceTokens.map((t) => ({ value: t })),
+    pageSize: 20,
+    required: true,
+  });
+
+  const availableDestinations = [
+    ...new Set(allSlots.map((s) => s.destination)),
+  ].sort();
+  const selectedDestinations = await checkbox({
+    message: 'Select destination chains',
+    choices: availableDestinations.map((c) => ({ value: c })),
+    pageSize: 20,
+    required: true,
+  });
+
+  const availableTargets = [...new Set(allSlots.map((s) => s.target))].sort(
+    (a, b) => {
+      if (a === 'DEFAULT') return -1;
+      if (b === 'DEFAULT') return 1;
+      return a.localeCompare(b);
+    },
+  );
+  const selectedTargets = await checkbox({
+    message: 'Select target token groups',
+    choices: availableTargets.map((t) => ({ value: t })),
+    pageSize: 20,
+    required: true,
+  });
+
+  const filteredSlots = allSlots.filter(
+    (s) =>
+      selectedChains.includes(s.origin) &&
+      selectedSourceTokens.includes(s.sourceToken) &&
+      selectedDestinations.includes(s.destination) &&
+      selectedTargets.includes(s.target),
+  );
+
+  console.log(
+    `\n${filteredSlots.length} combination(s) to review.\n` +
+      'For each: enter bps, ↵ skip, "d" for on-chain default.\n',
+  );
+
+  // ── Per-slot prompts ───────────────────────────────────────────────────────
+
+  const toSubmit: Array<{
+    slot: OqlfSlot;
+    maxFee: bigint;
+    halfAmount: bigint;
+    newBpsStr: string;
+  }> = [];
+
+  for (const slot of filteredSlots) {
+    const fallbackBpsStr = fmtBps(slot.onchainMaxFee, slot.onchainHalfAmount);
+    const effectiveLine =
+      slot.currentSource === 'standing'
+        ? `  effective : ${slot.currentBpsStr} bps (standing quote — overrides fallback)`
+        : `  effective : ${slot.currentBpsStr} bps (no standing quote, using fallback)`;
+    console.log(
+      `\n${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}\n` +
+        effectiveLine +
+        `\n  fallback  : ${fallbackBpsStr} bps`,
+    );
+
+    const raw = await input({
+      message: 'new bps [↵=skip, d=reset to fallback]',
+      default: '',
+      validate: (v) => {
+        const t = v.trim();
+        if (t === '' || t === 'd') return true;
+        const n = parseFloat(t);
+        if (Number.isFinite(n) && n > 0) return true;
+        return 'Enter a positive number, ↵ to skip, or "d" for on-chain default.';
+      },
+    });
+
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      console.log('  → skipped.');
+      continue;
+    }
+
+    let maxFee: bigint;
+    let halfAmount: bigint;
+    let newBpsStr: string;
+
+    if (trimmed === 'd') {
+      maxFee = slot.onchainMaxFee;
+      halfAmount = slot.onchainHalfAmount;
+      newBpsStr = fallbackBpsStr;
+    } else {
+      ({ maxFee, halfAmount } = bpsToParams(parseFloat(trimmed)));
+      newBpsStr = fmtBps(maxFee, halfAmount);
+    }
+
+    console.log(`  → queued: ${newBpsStr} bps`);
+    toSubmit.push({ slot, maxFee, halfAmount, newBpsStr });
+  }
+
+  if (toSubmit.length === 0) {
+    console.log('\nNothing to submit.');
+    return;
+  }
+
+  // ── Confirm ────────────────────────────────────────────────────────────────
+
+  const ttlHours = (effectiveTtl / 3600).toFixed(1);
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log(`${toSubmit.length} quote(s) to submit (TTL ${ttlHours} h):`);
+  for (const { slot, newBpsStr } of toSubmit) {
+    console.log(
+      `  ${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}  →  ${newBpsStr} bps`,
+    );
+  }
+  console.log('═'.repeat(60));
+
+  const confirmed = await confirm({ message: 'Submit?', default: false });
+  if (!confirmed) {
+    console.log('Aborted.');
+    return;
+  }
+
+  // ── Sign and submit ────────────────────────────────────────────────────────
+
+  for (const { slot, maxFee, halfAmount, newBpsStr } of toSubmit) {
+    const provider = multiProvider.getProvider(slot.origin);
+    // signerWallet: signs the EIP-712 data (no gas needed).
+    const signerWallet = new Wallet(signerKey, provider);
+    // submitter: connected to provider so it can pay gas.
+    const submitter_wallet = submitterWallet.connect(provider);
+    const { chainId } = await provider.getNetwork();
+
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const expiry = issuedAt + effectiveTtl;
+    const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+    const submitter = constants.AddressZero; // unrestricted for standing quotes
+
+    // FeeQuoteContext.encode(destDomain, WILDCARD_RECIPIENT, WILDCARD_AMOUNT)
+    const context = ethers.utils.solidityPack(
+      ['uint32', 'bytes32', 'uint256'],
+      [slot.destDomain, WILDCARD_RECIPIENT, constants.MaxUint256],
+    );
+    // FeeQuoteData.encode(maxFee, halfAmount)
+    const data = ethers.utils.solidityPack(
+      ['uint256', 'uint256'],
+      [maxFee, halfAmount],
+    );
+
+    const domain = {
+      name: EIP712_NAME,
+      version: EIP712_VERSION,
+      chainId,
+      verifyingContract: slot.oqlfAddress,
+    };
+    const message = { context, data, issuedAt, expiry, salt, submitter };
+    const signature = await signerWallet._signTypedData(
+      domain,
+      SIGNED_QUOTE_TYPES,
+      message,
+    );
+
+    process.stdout.write(
+      `Submitting ${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${newBpsStr} bps)... `,
+    );
+    // Submitter wallet pays gas; anyone may submit since submitter field = address(0).
+    const oqlf = OffchainQuotedLinearFee__factory.connect(
+      slot.oqlfAddress,
+      submitter_wallet,
+    );
+    const tx = await oqlf.submitQuote(
+      { context, data, issuedAt, expiry, salt, submitter },
+      signature,
+    );
+    process.stdout.write(`${tx.hash.slice(0, 14)}… `);
+    await tx.wait(1);
+    console.log('confirmed.');
+  }
+
+  console.log('\nAll quotes submitted.');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -348,10 +348,9 @@ async function main(): Promise<void> {
                 if (!oqlfAddress || oqlfAddress === constants.AddressZero)
                   return;
 
-                // Each (oqlfAddress, destDomain) is a unique on-chain storage slot.
-                // Include sourceToken in the key because two CCRs on the same chain
-                // (one USDC, one USDT) each own separate OQLF instances.
-                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${sourceToken}`;
+                // Dedup key: include origin so that multiple origin-chain CCRs that
+                // share the same OQLF instance don't suppress each other's slots.
+                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${origin}:${sourceToken}`;
                 if (seenSlots.has(slotId)) return;
                 seenSlots.add(slotId);
 

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -113,6 +113,12 @@ async function main(): Promise<void> {
     ttl,
     signerKey: signerKeyArg,
     submitterKey: submitterKeyArg,
+    origins: originsArg,
+    sourceTokens: sourceTokensArg,
+    destinations: destinationsArg,
+    targets: targetsArg,
+    bps: bpsArg,
+    yes: autoConfirm,
   } = await yargs(process.argv.slice(2))
     .option('registry', {
       alias: 'r',
@@ -121,8 +127,9 @@ async function main(): Promise<void> {
     })
     .option('ttl', {
       type: 'number',
-      default: DEFAULT_TTL,
-      describe: 'Standing quote TTL in seconds (default 24 h)',
+      describe:
+        'Standing quote TTL in seconds. Skips the TTL prompt when provided. ' +
+        'Accepts raw seconds; use --ttl=86400 for 24h.',
     })
     .option('signer-key', {
       alias: 's',
@@ -138,6 +145,42 @@ async function main(): Promise<void> {
         'Private key (0x…) of the gas-paying submitter account. ' +
         'Defaults to PRIVATE_KEY env var. ' +
         'The quote signer signs; this account pays gas.',
+    })
+    .option('origins', {
+      alias: 'o',
+      type: 'string',
+      describe:
+        'Comma-separated origin chain names, or "all". Skips the origin prompt.',
+    })
+    .option('source-tokens', {
+      type: 'string',
+      describe:
+        'Comma-separated source token groups (e.g. "USDC,USDT"), or "all". ' +
+        'Skips the source token prompt.',
+    })
+    .option('destinations', {
+      alias: 'd',
+      type: 'string',
+      describe:
+        'Comma-separated destination chain names, or "all". Skips the destination prompt.',
+    })
+    .option('targets', {
+      alias: 't',
+      type: 'string',
+      describe:
+        'Comma-separated target groups (e.g. "DEFAULT,USDC"), or "all". ' +
+        'Skips the target prompt.',
+    })
+    .option('bps', {
+      type: 'number',
+      describe:
+        'Fee in bps to apply to all selected slots. Skips per-slot prompts.',
+    })
+    .option('yes', {
+      alias: 'y',
+      type: 'boolean',
+      default: false,
+      describe: 'Skip the confirmation prompt.',
     })
     .parseAsync();
 
@@ -157,19 +200,22 @@ async function main(): Promise<void> {
     console.log(`Signer:    ${secret.address}`);
   }
 
-  // Submitter key: pays gas for submitQuote(). Anyone may submit since submitter=address(0).
-  const submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;
+  // Submitter key: pays gas for submitQuote(). Defaults to GCP mainnet3 deployer key.
+  let submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;
   if (!submitterKeyRaw) {
-    console.error(
-      'Error: provide a gas-paying key via --submitter-key or PRIVATE_KEY env var.',
-    );
-    process.exit(1);
+    const deployerSecret = (await fetchGCPSecret(
+      'hyperlane-mainnet3-key-deployer',
+    )) as { privateKey: string; address: string };
+    submitterKeyRaw = deployerSecret.privateKey;
+    console.log(`Submitter: ${deployerSecret.address} (mainnet3 deployer)`);
   }
   const submitterKey = submitterKeyRaw.startsWith('0x')
     ? submitterKeyRaw
     : `0x${submitterKeyRaw}`;
   const submitterWallet = new Wallet(submitterKey);
-  console.log(`Submitter: ${submitterWallet.address}`);
+  if (submitterKeyArg || process.env.PRIVATE_KEY) {
+    console.log(`Submitter: ${submitterWallet.address}`);
+  }
 
   // HTTP registry overlays private RPC URLs; filesystem registry handles warp configs.
   const rpcRegistry = registryUri
@@ -359,7 +405,7 @@ async function main(): Promise<void> {
   console.log(`Found ${allSlots.length} OQLF slots.\n`);
 
   // ── Verify signer authorization ────────────────────────────────────────────
-  const signerAddress = secret.address;
+  const signerAddress = new Wallet(signerKey).address;
   const sampleSlot = allSlots[0];
   if (sampleSlot) {
     const provider = multiProvider.getProvider(sampleSlot.origin);
@@ -383,7 +429,7 @@ async function main(): Promise<void> {
     console.log(`Signer ${signerAddress} is authorized. Proceeding.\n`);
   }
 
-  // ── Interactive selection ──────────────────────────────────────────────────
+  // ── Selection helpers ──────────────────────────────────────────────────────
 
   const parseTtl = (v: string): number | null => {
     const t = v.trim().toLowerCase();
@@ -394,42 +440,76 @@ async function main(): Promise<void> {
     return m[2] === 'd' ? n * 86_400 : n * 3600;
   };
 
-  const defaultTtlStr =
-    ttl % 86_400 === 0 ? `${ttl / 86_400}d` : `${ttl / 3600}h`;
-  const ttlRaw = await input({
-    message: 'Standing quote TTL (e.g. 24h or 2d)',
-    default: defaultTtlStr,
-    validate: (v) => parseTtl(v) !== null || 'Enter a duration like 24h or 2d.',
-  });
-  const effectiveTtl = parseTtl(ttlRaw)!;
+  // Resolve a comma-separated flag value ("all" = every available item).
+  // Returns null when the flag was not provided → caller should prompt.
+  const resolveFlag = (
+    flag: string | undefined,
+    available: string[],
+  ): string[] | null => {
+    if (flag === undefined) return null;
+    if (flag.toLowerCase() === 'all') return [...available];
+    return flag
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  };
+
+  // ── TTL ───────────────────────────────────────────────────────────────────
+
+  let effectiveTtl: number;
+  if (ttl !== undefined) {
+    effectiveTtl = ttl;
+    const h = (effectiveTtl / 3600).toFixed(1);
+    console.log(`TTL: ${h} h`);
+  } else {
+    const defaultTtlStr =
+      DEFAULT_TTL % 86_400 === 0
+        ? `${DEFAULT_TTL / 86_400}d`
+        : `${DEFAULT_TTL / 3600}h`;
+    const ttlRaw = await input({
+      message: 'Standing quote TTL (e.g. 24h or 2d)',
+      default: defaultTtlStr,
+      validate: (v) =>
+        parseTtl(v) !== null || 'Enter a duration like 24h or 2d.',
+    });
+    effectiveTtl = parseTtl(ttlRaw)!;
+  }
+
+  // ── Filter selections ─────────────────────────────────────────────────────
 
   const availableOrigins = [...new Set(allSlots.map((s) => s.origin))].sort();
-  const selectedChains = await checkbox({
-    message: 'Select origin chains',
-    choices: availableOrigins.map((c) => ({ value: c })),
-    pageSize: 20,
-    required: true,
-  });
+  const selectedChains =
+    resolveFlag(originsArg, availableOrigins) ??
+    (await checkbox({
+      message: 'Select origin chains',
+      choices: availableOrigins.map((c) => ({ value: c })),
+      pageSize: 20,
+      required: true,
+    }));
 
   const availableSourceTokens = [
     ...new Set(allSlots.map((s) => s.sourceToken)),
   ].sort();
-  const selectedSourceTokens = await checkbox({
-    message: 'Select source token groups',
-    choices: availableSourceTokens.map((t) => ({ value: t })),
-    pageSize: 20,
-    required: true,
-  });
+  const selectedSourceTokens =
+    resolveFlag(sourceTokensArg, availableSourceTokens) ??
+    (await checkbox({
+      message: 'Select source token groups',
+      choices: availableSourceTokens.map((t) => ({ value: t })),
+      pageSize: 20,
+      required: true,
+    }));
 
   const availableDestinations = [
     ...new Set(allSlots.map((s) => s.destination)),
   ].sort();
-  const selectedDestinations = await checkbox({
-    message: 'Select destination chains',
-    choices: availableDestinations.map((c) => ({ value: c })),
-    pageSize: 20,
-    required: true,
-  });
+  const selectedDestinations =
+    resolveFlag(destinationsArg, availableDestinations) ??
+    (await checkbox({
+      message: 'Select destination chains',
+      choices: availableDestinations.map((c) => ({ value: c })),
+      pageSize: 20,
+      required: true,
+    }));
 
   const availableTargets = [...new Set(allSlots.map((s) => s.target))].sort(
     (a, b) => {
@@ -438,12 +518,14 @@ async function main(): Promise<void> {
       return a.localeCompare(b);
     },
   );
-  const selectedTargets = await checkbox({
-    message: 'Select target token groups',
-    choices: availableTargets.map((t) => ({ value: t })),
-    pageSize: 20,
-    required: true,
-  });
+  const selectedTargets =
+    resolveFlag(targetsArg, availableTargets) ??
+    (await checkbox({
+      message: 'Select target token groups',
+      choices: availableTargets.map((t) => ({ value: t })),
+      pageSize: 20,
+      required: true,
+    }));
 
   const filteredSlots = allSlots.filter(
     (s) =>
@@ -453,12 +535,12 @@ async function main(): Promise<void> {
       selectedTargets.includes(s.target),
   );
 
-  console.log(
-    `\n${filteredSlots.length} combination(s) to review.\n` +
-      'For each: enter bps, ↵ skip, "d" for on-chain default.\n',
-  );
+  if (filteredSlots.length === 0) {
+    console.log('\nNo slots match the selected filters.');
+    return;
+  }
 
-  // ── Per-slot prompts ───────────────────────────────────────────────────────
+  // ── Build submission queue ─────────────────────────────────────────────────
 
   const toSubmit: Array<{
     slot: OqlfSlot;
@@ -467,51 +549,89 @@ async function main(): Promise<void> {
     newBpsStr: string;
   }> = [];
 
-  for (const slot of filteredSlots) {
-    const fallbackBpsStr = fmtBps(slot.onchainMaxFee, slot.onchainHalfAmount);
-    const effectiveLine =
-      slot.currentSource === 'standing'
-        ? `  effective : ${slot.currentBpsStr} bps (standing quote — overrides fallback)`
-        : `  effective : ${slot.currentBpsStr} bps (no standing quote, using fallback)`;
+  if (bpsArg !== undefined) {
+    // Non-interactive: apply the same bps to all filtered slots.
+    const { maxFee, halfAmount } = bpsToParams(bpsArg);
+    const newBpsStr = fmtBps(maxFee, halfAmount);
+    const W = {
+      origin: Math.max(6, ...filteredSlots.map((s) => s.origin.length)),
+      src: Math.max(3, ...filteredSlots.map((s) => s.sourceToken.length)),
+      dest: Math.max(4, ...filteredSlots.map((s) => s.destination.length)),
+      target: Math.max(6, ...filteredSlots.map((s) => s.target.length)),
+      cur: Math.max(7, ...filteredSlots.map((s) => s.currentBpsStr.length)),
+    };
+    const pad = (s: string, n: number) =>
+      s.length >= n ? s : s + ' '.repeat(n - s.length);
     console.log(
-      `\n${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}\n` +
-        effectiveLine +
-        `\n  fallback  : ${fallbackBpsStr} bps`,
+      `\n${filteredSlots.length} slot(s) → ${newBpsStr} bps (TTL ${(effectiveTtl / 3600).toFixed(1)} h):\n`,
     );
-
-    const raw = await input({
-      message: 'new bps [↵=skip, d=reset to fallback]',
-      default: '',
-      validate: (v) => {
-        const t = v.trim();
-        if (t === '' || t === 'd') return true;
-        const n = parseFloat(t);
-        if (Number.isFinite(n) && n > 0) return true;
-        return 'Enter a positive number, ↵ to skip, or "d" for on-chain default.';
-      },
-    });
-
-    const trimmed = raw.trim();
-    if (trimmed === '') {
-      console.log('  → skipped.');
-      continue;
+    console.log(
+      `${pad('origin', W.origin)}   ${pad('src', W.src)} → ${pad('dest', W.dest)}   ${pad('target', W.target)}   ${pad('current', W.cur)}   new`,
+    );
+    console.log(
+      [W.origin, W.src, W.dest, W.target, W.cur, 8]
+        .map((w) => '─'.repeat(w))
+        .join('   '),
+    );
+    for (const slot of filteredSlots) {
+      console.log(
+        `${pad(slot.origin, W.origin)}   ${pad(slot.sourceToken, W.src)} → ${pad(slot.destination, W.dest)}   ${pad(slot.target, W.target)}   ${pad(slot.currentBpsStr, W.cur)}   ${newBpsStr}`,
+      );
+      toSubmit.push({ slot, maxFee, halfAmount, newBpsStr });
     }
+    console.log();
+  } else {
+    // Interactive: prompt bps per slot.
+    console.log(
+      `\n${filteredSlots.length} combination(s) to review.\n` +
+        'For each: enter bps, ↵ skip, "d" for on-chain default.\n',
+    );
+    for (const slot of filteredSlots) {
+      const fallbackBpsStr = fmtBps(slot.onchainMaxFee, slot.onchainHalfAmount);
+      const effectiveLine =
+        slot.currentSource === 'standing'
+          ? `  effective : ${slot.currentBpsStr} bps (standing quote — overrides fallback)`
+          : `  effective : ${slot.currentBpsStr} bps (no standing quote, using fallback)`;
+      console.log(
+        `\n${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}\n` +
+          effectiveLine +
+          `\n  fallback  : ${fallbackBpsStr} bps`,
+      );
 
-    let maxFee: bigint;
-    let halfAmount: bigint;
-    let newBpsStr: string;
+      const raw = await input({
+        message: 'new bps [↵=skip, d=reset to fallback]',
+        default: '',
+        validate: (v) => {
+          const t = v.trim();
+          if (t === '' || t === 'd') return true;
+          const n = parseFloat(t);
+          if (Number.isFinite(n) && n > 0) return true;
+          return 'Enter a positive number, ↵ to skip, or "d" for on-chain default.';
+        },
+      });
 
-    if (trimmed === 'd') {
-      maxFee = slot.onchainMaxFee;
-      halfAmount = slot.onchainHalfAmount;
-      newBpsStr = fallbackBpsStr;
-    } else {
-      ({ maxFee, halfAmount } = bpsToParams(parseFloat(trimmed)));
-      newBpsStr = fmtBps(maxFee, halfAmount);
+      const trimmed = raw.trim();
+      if (trimmed === '') {
+        console.log('  → skipped.');
+        continue;
+      }
+
+      let maxFee: bigint;
+      let halfAmount: bigint;
+      let newBpsStr: string;
+
+      if (trimmed === 'd') {
+        maxFee = slot.onchainMaxFee;
+        halfAmount = slot.onchainHalfAmount;
+        newBpsStr = fallbackBpsStr;
+      } else {
+        ({ maxFee, halfAmount } = bpsToParams(parseFloat(trimmed)));
+        newBpsStr = fmtBps(maxFee, halfAmount);
+      }
+
+      console.log(`  → queued: ${newBpsStr} bps`);
+      toSubmit.push({ slot, maxFee, halfAmount, newBpsStr });
     }
-
-    console.log(`  → queued: ${newBpsStr} bps`);
-    toSubmit.push({ slot, maxFee, halfAmount, newBpsStr });
   }
 
   if (toSubmit.length === 0) {
@@ -521,20 +641,21 @@ async function main(): Promise<void> {
 
   // ── Confirm ────────────────────────────────────────────────────────────────
 
-  const ttlHours = (effectiveTtl / 3600).toFixed(1);
-  console.log(`\n${'═'.repeat(60)}`);
-  console.log(`${toSubmit.length} quote(s) to submit (TTL ${ttlHours} h):`);
-  for (const { slot, newBpsStr } of toSubmit) {
-    console.log(
-      `  ${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}  →  ${newBpsStr} bps`,
-    );
-  }
-  console.log('═'.repeat(60));
-
-  const confirmed = await confirm({ message: 'Submit?', default: false });
-  if (!confirmed) {
-    console.log('Aborted.');
-    return;
+  if (!autoConfirm) {
+    const ttlHours = (effectiveTtl / 3600).toFixed(1);
+    console.log(`\n${'═'.repeat(60)}`);
+    console.log(`${toSubmit.length} quote(s) to submit (TTL ${ttlHours} h):`);
+    for (const { slot, newBpsStr } of toSubmit) {
+      console.log(
+        `  ${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}  →  ${newBpsStr} bps`,
+      );
+    }
+    console.log('═'.repeat(60));
+    const confirmed = await confirm({ message: 'Submit?', default: false });
+    if (!confirmed) {
+      console.log('Aborted.');
+      return;
+    }
   }
 
   // ── Sign and submit ────────────────────────────────────────────────────────

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -10,99 +10,64 @@
  * Usage (from typescript/infra/):
  *   pnpm tsx scripts/moonpay/set-quotes.ts
  *   pnpm tsx scripts/moonpay/set-quotes.ts -r http://localhost:3000
+ *   pnpm tsx scripts/moonpay/set-quotes.ts --dry-run --origins arbitrum --bps 5 ...
  */
 
-import { Wallet, constants, ethers } from 'ethers';
+import { Wallet } from 'ethers';
 import yargs from 'yargs';
 
 import { checkbox, confirm, input } from '@inquirer/prompts';
 
-import {
-  BaseFee__factory,
-  CrossCollateralRoutingFee__factory,
-  OffchainQuotedLinearFee__factory,
-  TokenRouter__factory,
-} from '@hyperlane-xyz/core';
+import { OffchainQuotedLinearFee__factory } from '@hyperlane-xyz/core';
 import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
-import { MultiProvider, OnchainTokenFeeType } from '@hyperlane-xyz/sdk';
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import { getRegistry } from '../../config/registry.js';
 
 import {
-  getDomainId,
-  getRegistry,
-  getWarpCoreConfig,
-} from '../../config/registry.js';
-import { WarpRouteIds } from '../../config/environments/mainnet3/warp/warpIds.js';
-import { fetchGCPSecret } from '../../src/utils/gcloud.js';
+  GCP_DEPLOYER_SECRET,
+  GCP_SIGNER_SECRET,
+  OqlfSlot,
+  QuoteSubmission,
+  bpsToParams,
+  discoverOqlfSlots,
+  fmtBps,
+  resolveGcpKey,
+  submitQuoteWithRetry,
+} from './oqlf-lib.js';
 
-const GCP_SIGNER_SECRET = 'hyperlane-mainnet3-key-quotesigner';
-
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const WILDCARD_DEST = 0xffffffff;
-const WILDCARD_RECIPIENT = '0x' + 'ff'.repeat(32);
-// keccak256("RoutingFee.DEFAULT_ROUTER")
-const DEFAULT_ROUTER_KEY =
-  '0x6e086cd647d6eb8b516856666e2c1465fb8a6a58d3a75938362acc674eacaf47';
-const ROUTE_IDS = [WarpRouteIds.CROSSCitreaMoonpay];
 const DEFAULT_TTL = 86_400; // 24 hours
-
-// EIP-712: matches AbstractOffchainQuoter.sol name/version
-const EIP712_NAME = 'OffchainQuoter';
-const EIP712_VERSION = '1';
-const SIGNED_QUOTE_TYPES = {
-  SignedQuote: [
-    { name: 'context', type: 'bytes' },
-    { name: 'data', type: 'bytes' },
-    { name: 'issuedAt', type: 'uint48' },
-    { name: 'expiry', type: 'uint48' },
-    { name: 'salt', type: 'bytes32' },
-    { name: 'submitter', type: 'address' },
-  ],
-};
-
-// Matches EvmTokenFeeReader.convertFromBps — used to derive canonical (maxFee, halfAmount)
-// from a bps value without needing an on-chain read.
-const ASSUMED_MAX_AMOUNT = 10n ** 36n; // 10^36 — prevents overflow in LinearFee contract
-const MAX_BPS = 10_000n;
-const BPS_PRECISION = 10_000n; // supports up to 4 decimal places on bps
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-interface OqlfSlot {
-  origin: string;
-  sourceToken: string; // normalised group label of the origin token (USDC / USDT)
-  destination: string;
-  destDomain: number;
-  target: string; // "DEFAULT" or normalised group label of the destination token
-  oqlfAddress: string;
-  currentBpsStr: string;
-  currentSource: 'standing' | 'fallback';
-  onchainMaxFee: bigint;
-  onchainHalfAmount: bigint;
-}
 
 // ── Utilities ─────────────────────────────────────────────────────────────────
 
-/** Display bps as "W.FF" — same formula as print-quotes. */
-function fmtBps(maxFee: bigint, halfAmount: bigint): string {
-  if (halfAmount === 0n) return '?.??';
-  const denom = halfAmount * 2n;
-  const whole = (maxFee * 10_000n) / denom;
-  const frac = (maxFee * 1_000_000n) / denom - whole * 100n;
-  return `${whole}.${String(frac).padStart(2, '0')}`;
+/**
+ * Parses a TTL string with a mandatory unit suffix (s/h/d) — a bare number
+ * is rejected so the same input can never be interpreted as seconds in one
+ * code path and hours in another.
+ */
+function parseTtl(v: string): number | null {
+  const t = v.trim().toLowerCase();
+  const m = t.match(/^(\d+(?:\.\d+)?)(s|h|d)$/);
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const multiplier = { s: 1, h: 3600, d: 86_400 }[m[2] as 's' | 'h' | 'd'];
+  return n * multiplier;
 }
 
-/**
- * Convert a numeric bps value to canonical (maxFee, halfAmount).
- * Mirrors EvmTokenFeeReader.convertFromBps exactly so deployed contracts
- * are consistent with the standing quote parameters.
- */
-function bpsToParams(bps: number): { maxFee: bigint; halfAmount: bigint } {
-  const maxFee = BigInt(constants.MaxUint256.toString()) / ASSUMED_MAX_AMOUNT;
-  const scaledBps = BigInt(Math.round(bps * Number(BPS_PRECISION)));
-  const halfAmount = ((maxFee / 2n) * MAX_BPS * BPS_PRECISION) / scaledBps;
-  return { maxFee, halfAmount };
+// Resolve a comma-separated flag value ("all" = every available item).
+// Returns null when the flag was not provided → caller should prompt.
+function resolveFlag(
+  flag: string | undefined,
+  available: string[],
+): string[] | null {
+  if (flag === undefined) return null;
+  if (flag.toLowerCase() === 'all') return [...available];
+  return flag
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -110,7 +75,7 @@ function bpsToParams(bps: number): { maxFee: bigint; halfAmount: bigint } {
 async function main(): Promise<void> {
   const {
     registry: registryUri,
-    ttl,
+    ttl: ttlRawArg,
     signerKey: signerKeyArg,
     submitterKey: submitterKeyArg,
     origins: originsArg,
@@ -119,6 +84,7 @@ async function main(): Promise<void> {
     targets: targetsArg,
     bps: bpsArg,
     yes: autoConfirm,
+    dryRun,
   } = await yargs(process.argv.slice(2))
     .option('registry', {
       alias: 'r',
@@ -126,10 +92,10 @@ async function main(): Promise<void> {
       describe: 'Registry URI (local path or http://…)',
     })
     .option('ttl', {
-      type: 'number',
+      type: 'string',
       describe:
-        'Standing quote TTL in seconds. Skips the TTL prompt when provided. ' +
-        'Accepts raw seconds; use --ttl=86400 for 24h.',
+        'Standing quote TTL with a unit suffix (e.g. 24h, 2d, 86400s). ' +
+        'Skips the TTL prompt when provided.',
     })
     .option('signer-key', {
       alias: 's',
@@ -182,39 +148,46 @@ async function main(): Promise<void> {
       default: false,
       describe: 'Skip the confirmation prompt.',
     })
+    .option('dry-run', {
+      type: 'boolean',
+      default: false,
+      describe:
+        'Print the lanes that would be updated and to what bps, without ' +
+        'signing or submitting anything. No signer/submitter keys required.',
+    })
     .parseAsync();
 
-  // Signing key: custom if provided, else GCP secret. No ETH needed — only signs EIP-712.
-  let signerKey: string;
-  if (signerKeyArg) {
-    signerKey = signerKeyArg.startsWith('0x')
-      ? signerKeyArg
-      : `0x${signerKeyArg}`;
-    console.log(`Signer:    ${new Wallet(signerKey).address}`);
-  } else {
-    const secret = (await fetchGCPSecret(GCP_SIGNER_SECRET)) as {
-      privateKey: string;
-      address: string;
-    };
-    signerKey = secret.privateKey;
-    console.log(`Signer:    ${secret.address}`);
-  }
+  // Signing/submitter keys are only needed to sign and submit — skip fetching
+  // them entirely for --dry-run so a preview never requires GCP credentials.
+  let signerKey: string | undefined;
+  let submitterWallet: Wallet | undefined;
+  if (!dryRun) {
+    // Signing key: custom if provided, else GCP secret. No ETH needed — only signs EIP-712.
+    if (signerKeyArg) {
+      signerKey = signerKeyArg.startsWith('0x')
+        ? signerKeyArg
+        : `0x${signerKeyArg}`;
+      console.log(`Signer:    ${new Wallet(signerKey).address}`);
+    } else {
+      const secret = await resolveGcpKey(GCP_SIGNER_SECRET);
+      signerKey = secret.privateKey;
+      console.log(`Signer:    ${secret.address}`);
+    }
 
-  // Submitter key: pays gas for submitQuote(). Defaults to GCP mainnet3 deployer key.
-  let submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;
-  if (!submitterKeyRaw) {
-    const deployerSecret = (await fetchGCPSecret(
-      'hyperlane-mainnet3-key-deployer',
-    )) as { privateKey: string; address: string };
-    submitterKeyRaw = deployerSecret.privateKey;
-    console.log(`Submitter: ${deployerSecret.address} (mainnet3 deployer)`);
-  }
-  const submitterKey = submitterKeyRaw.startsWith('0x')
-    ? submitterKeyRaw
-    : `0x${submitterKeyRaw}`;
-  const submitterWallet = new Wallet(submitterKey);
-  if (submitterKeyArg || process.env.PRIVATE_KEY) {
-    console.log(`Submitter: ${submitterWallet.address}`);
+    // Submitter key: pays gas for submitQuote(). Defaults to GCP mainnet3 deployer key.
+    let submitterKeyRaw = submitterKeyArg ?? process.env.PRIVATE_KEY;
+    if (!submitterKeyRaw) {
+      const deployerSecret = await resolveGcpKey(GCP_DEPLOYER_SECRET);
+      submitterKeyRaw = deployerSecret.privateKey;
+      console.log(`Submitter: ${deployerSecret.address} (mainnet3 deployer)`);
+    }
+    const submitterKey = submitterKeyRaw.startsWith('0x')
+      ? submitterKeyRaw
+      : `0x${submitterKeyRaw}`;
+    submitterWallet = new Wallet(submitterKey);
+    if (submitterKeyArg || process.env.PRIVATE_KEY) {
+      console.log(`Submitter: ${submitterWallet.address}`);
+    }
   }
 
   // HTTP registry overlays private RPC URLs; filesystem registry handles warp configs.
@@ -224,267 +197,86 @@ async function main(): Promise<void> {
   const chainMetadata = await rpcRegistry.getMetadata();
   const multiProvider = new MultiProvider(chainMetadata);
 
-  // address → normalised group label: usd-coin→"USDC", tether→"USDT", else symbol.
-  // EVM addresses are lowercased; non-EVM (e.g. Solana base58) are kept as-is.
-  const addrToLabel = new Map<string, string>();
-  const routersByChain = new Map<string, string[]>();
-  for (const routeId of ROUTE_IDS) {
-    const warpConfig = getWarpCoreConfig(routeId);
-    for (const t of warpConfig.tokens) {
-      if (t.addressOrDenom) {
-        const addr = t.addressOrDenom.startsWith('0x')
-          ? t.addressOrDenom.toLowerCase()
-          : t.addressOrDenom;
-        const label =
-          t.coinGeckoId === 'usd-coin'
-            ? 'USDC'
-            : t.coinGeckoId === 'tether'
-              ? 'USDT'
-              : (t.symbol ?? t.chainName ?? addr.slice(0, 10));
-        addrToLabel.set(addr, label);
-        if (t.chainName) {
-          const list = routersByChain.get(t.chainName) ?? [];
-          if (!list.includes(addr)) list.push(addr);
-          routersByChain.set(t.chainName, list);
-        }
-      }
-    }
-  }
-
   // ── Discover all OQLF slots ────────────────────────────────────────────────
   console.log('\nDiscovering OQLF slots (one-time RPC scan)...\n');
-  const now = Math.floor(Date.now() / 1000);
-  // dedup: one standing-quote storage slot per (oqlfAddress, destDomain)
-  const seenSlots = new Set<string>();
-  const allSlots: OqlfSlot[] = [];
-
-  await Promise.all(
-    ROUTE_IDS.flatMap((routeId) => {
-      const warpConfig = getWarpCoreConfig(routeId);
-      const seenOriginAddrs = new Set<string>();
-      const evmTokens = warpConfig.tokens.filter((t) => {
-        if (
-          !t.addressOrDenom ||
-          !t.chainName ||
-          !/^0x[0-9a-f]{40}$/i.test(t.addressOrDenom)
-        )
-          return false;
-        const key = `${t.chainName}:${t.addressOrDenom.toLowerCase()}`;
-        if (seenOriginAddrs.has(key)) return false;
-        seenOriginAddrs.add(key);
-        return true;
-      });
-      return evmTokens.map(async (originToken) => {
-        const { chainName: origin, addressOrDenom: routerAddr } = originToken;
-        if (!routerAddr || !origin) return;
-        const normalizedOriginAddr = routerAddr.toLowerCase();
-        const sourceToken =
-          addrToLabel.get(normalizedOriginAddr) ?? originToken.symbol ?? origin;
-        const provider = multiProvider.getProvider(origin);
-
-        let ccrAddress: string;
-        try {
-          ccrAddress = await TokenRouter__factory.connect(
-            routerAddr,
-            provider,
-          ).feeRecipient();
-        } catch {
-          return;
-        }
-        if (!ccrAddress || ccrAddress === constants.AddressZero) return;
-
-        let feeTypeNum: number;
-        try {
-          feeTypeNum = await BaseFee__factory.connect(
-            ccrAddress,
-            provider,
-          ).feeType();
-        } catch {
-          return;
-        }
-        if (feeTypeNum !== OnchainTokenFeeType.CrossCollateralRoutingFee)
-          return;
-
-        const ccr = CrossCollateralRoutingFee__factory.connect(
-          ccrAddress,
-          provider,
-        );
-        const seenDestChains = new Set<string>();
-        const destTokens = warpConfig.tokens.filter((t) => {
-          if (!t.chainName) return false;
-          if (seenDestChains.has(t.chainName)) return false;
-          seenDestChains.add(t.chainName);
-          return true;
-        });
-
-        await Promise.all(
-          destTokens.map(async (destToken) => {
-            const { chainName: destination } = destToken;
-            if (!destination) return;
-            let destDomain: number;
-            try {
-              destDomain = getDomainId(destination);
-            } catch {
-              return;
-            }
-
-            const destRouters = routersByChain.get(destination) ?? [];
-            const targetKeys: Array<{ key: string; label: string }> = [
-              { key: DEFAULT_ROUTER_KEY, label: 'DEFAULT' },
-              ...destRouters.map((addr) => ({
-                key: addressToBytes32(addr),
-                label: addrToLabel.get(addr) ?? addr.slice(0, 10),
-              })),
-            ];
-
-            await Promise.all(
-              targetKeys.map(async ({ key, label }) => {
-                let oqlfAddress: string;
-                try {
-                  oqlfAddress = await ccr.feeContracts(destDomain, key);
-                } catch {
-                  return;
-                }
-                if (!oqlfAddress || oqlfAddress === constants.AddressZero)
-                  return;
-
-                // Dedup key: include origin so that multiple origin-chain CCRs that
-                // share the same OQLF instance don't suppress each other's slots.
-                const slotId = `${oqlfAddress.toLowerCase()}:${destDomain}:${origin}:${sourceToken}`;
-                if (seenSlots.has(slotId)) return;
-                seenSlots.add(slotId);
-
-                const oqlf = OffchainQuotedLinearFee__factory.connect(
-                  oqlfAddress,
-                  provider,
-                );
-                const [onchainMaxFee, onchainHalfAmount] = await Promise.all([
-                  oqlf.maxFee(),
-                  oqlf.halfAmount(),
-                ]);
-
-                // Resolve current standing quote (dest-specific wins over wildcard).
-                let currentMaxFee = onchainMaxFee.toBigInt();
-                let currentHalfAmount = onchainHalfAmount.toBigInt();
-                let currentSource: 'standing' | 'fallback' = 'fallback';
-
-                for (const { dest, recip } of [
-                  { dest: destDomain, recip: WILDCARD_RECIPIENT },
-                  { dest: WILDCARD_DEST, recip: WILDCARD_RECIPIENT },
-                ]) {
-                  const sq = await oqlf.quotes(dest, recip);
-                  const expiry = Number(sq.expiry);
-                  if (expiry > 0 && expiry >= now) {
-                    currentMaxFee = sq.maxFee.toBigInt();
-                    currentHalfAmount = sq.halfAmount.toBigInt();
-                    currentSource = 'standing';
-                    break;
-                  }
-                }
-
-                allSlots.push({
-                  origin,
-                  sourceToken,
-                  destination,
-                  destDomain,
-                  target: label,
-                  oqlfAddress,
-                  currentBpsStr: fmtBps(currentMaxFee, currentHalfAmount),
-                  currentSource,
-                  onchainMaxFee: onchainMaxFee.toBigInt(),
-                  onchainHalfAmount: onchainHalfAmount.toBigInt(),
-                });
-              }),
-            );
-          }),
-        );
-      });
-    }),
-  );
-
-  // Consistent ordering: origin → sourceToken → dest → DEFAULT first, then alpha by target.
-  allSlots.sort((a, b) => {
-    const cmp =
-      a.origin.localeCompare(b.origin) ||
-      a.sourceToken.localeCompare(b.sourceToken) ||
-      a.destination.localeCompare(b.destination);
-    if (cmp !== 0) return cmp;
-    if (a.target === 'DEFAULT') return -1;
-    if (b.target === 'DEFAULT') return 1;
-    return a.target.localeCompare(b.target);
-  });
+  const allSlots: OqlfSlot[] = await discoverOqlfSlots(multiProvider);
 
   console.log(`Found ${allSlots.length} OQLF slots.\n`);
 
-  // ── Verify signer authorization ────────────────────────────────────────────
-  const signerAddress = new Wallet(signerKey).address;
-  const sampleSlot = allSlots[0];
-  if (sampleSlot) {
-    const provider = multiProvider.getProvider(sampleSlot.origin);
-    const oqlf = OffchainQuotedLinearFee__factory.connect(
-      sampleSlot.oqlfAddress,
-      provider,
+  // ── Verify signer authorization on every unique OQLF contract ──────────────
+  if (!dryRun) {
+    assert(
+      signerKey !== undefined,
+      'signer key is required when not --dry-run',
     );
-    const authorized = await oqlf.isQuoteSigner(signerAddress);
-    if (!authorized) {
-      const authorizedSigners = await oqlf.quoteSigners();
-      console.error(
-        `\nError: signer ${signerAddress} is NOT authorized on OQLF ${sampleSlot.oqlfAddress}.`,
-      );
-      console.error(
-        authorizedSigners.length === 0
-          ? 'No authorized signers found — contract may not be configured.'
-          : `Authorized signers: ${authorizedSigners.join(', ')}`,
-      );
+    const signerAddress = new Wallet(signerKey).address;
+    const uniqueOqlfOrigins = new Map<string, string>(); // oqlfAddress(lower) → origin
+    for (const slot of allSlots) {
+      uniqueOqlfOrigins.set(slot.oqlfAddress.toLowerCase(), slot.origin);
+    }
+    const unauthorized = (
+      await Promise.all(
+        [...uniqueOqlfOrigins].map(async ([oqlfAddress, origin]) => {
+          const provider = multiProvider.getProvider(origin);
+          const oqlf = OffchainQuotedLinearFee__factory.connect(
+            oqlfAddress,
+            provider,
+          );
+          const authorized = await oqlf.isQuoteSigner(signerAddress);
+          return authorized ? null : { oqlfAddress, origin };
+        }),
+      )
+    ).filter((r): r is { oqlfAddress: string; origin: string } => r !== null);
+
+    if (unauthorized.length > 0) {
+      for (const { oqlfAddress, origin } of unauthorized) {
+        const provider = multiProvider.getProvider(origin);
+        const oqlf = OffchainQuotedLinearFee__factory.connect(
+          oqlfAddress,
+          provider,
+        );
+        const authorizedSigners = await oqlf.quoteSigners();
+        console.error(
+          `\nError: signer ${signerAddress} is NOT authorized on OQLF ${oqlfAddress} (origin ${origin}).`,
+        );
+        console.error(
+          authorizedSigners.length === 0
+            ? 'No authorized signers found — contract may not be configured.'
+            : `Authorized signers: ${authorizedSigners.join(', ')}`,
+        );
+      }
       process.exit(1);
     }
-    console.log(`Signer ${signerAddress} is authorized. Proceeding.\n`);
+    console.log(
+      `Signer ${signerAddress} is authorized on all ${uniqueOqlfOrigins.size} OQLF contract(s). Proceeding.\n`,
+    );
   }
-
-  // ── Selection helpers ──────────────────────────────────────────────────────
-
-  const parseTtl = (v: string): number | null => {
-    const t = v.trim().toLowerCase();
-    const m = t.match(/^(\d+(?:\.\d+)?)(h|d)?$/);
-    if (!m) return null;
-    const n = parseFloat(m[1]);
-    if (!Number.isFinite(n) || n <= 0) return null;
-    return m[2] === 'd' ? n * 86_400 : n * 3600;
-  };
-
-  // Resolve a comma-separated flag value ("all" = every available item).
-  // Returns null when the flag was not provided → caller should prompt.
-  const resolveFlag = (
-    flag: string | undefined,
-    available: string[],
-  ): string[] | null => {
-    if (flag === undefined) return null;
-    if (flag.toLowerCase() === 'all') return [...available];
-    return flag
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-  };
 
   // ── TTL ───────────────────────────────────────────────────────────────────
 
   let effectiveTtl: number;
-  if (ttl !== undefined) {
-    effectiveTtl = ttl;
-    const h = (effectiveTtl / 3600).toFixed(1);
-    console.log(`TTL: ${h} h`);
+  if (ttlRawArg !== undefined) {
+    const parsed = parseTtl(ttlRawArg);
+    assert(
+      parsed !== null,
+      `Invalid --ttl "${ttlRawArg}"; use a duration like 24h, 2d, or 86400s.`,
+    );
+    effectiveTtl = parsed;
+    console.log(`TTL: ${(effectiveTtl / 3600).toFixed(1)} h`);
   } else {
     const defaultTtlStr =
       DEFAULT_TTL % 86_400 === 0
         ? `${DEFAULT_TTL / 86_400}d`
         : `${DEFAULT_TTL / 3600}h`;
-    const ttlRaw = await input({
-      message: 'Standing quote TTL (e.g. 24h or 2d)',
+    const ttlInput = await input({
+      message: 'Standing quote TTL (e.g. 24h, 2d, or 86400s)',
       default: defaultTtlStr,
       validate: (v) =>
-        parseTtl(v) !== null || 'Enter a duration like 24h or 2d.',
+        parseTtl(v) !== null || 'Enter a duration like 24h, 2d, or 86400s.',
     });
-    effectiveTtl = parseTtl(ttlRaw)!;
+    const parsed = parseTtl(ttlInput);
+    assert(parsed !== null, `Invalid TTL "${ttlInput}"`);
+    effectiveTtl = parsed;
   }
 
   // ── Filter selections ─────────────────────────────────────────────────────
@@ -554,28 +346,27 @@ async function main(): Promise<void> {
 
   // ── Build submission queue ─────────────────────────────────────────────────
 
-  const toSubmit: Array<{
-    slot: OqlfSlot;
-    maxFee: bigint;
-    halfAmount: bigint;
-    newBpsStr: string;
-  }> = [];
+  const toSubmit: QuoteSubmission[] = [];
 
   if (bpsArg !== undefined) {
     // Non-interactive: apply the same bps to all filtered slots.
-    const { maxFee, halfAmount } = bpsToParams(bpsArg);
-    const newBpsStr = fmtBps(maxFee, halfAmount);
     const W = {
       origin: Math.max(6, ...filteredSlots.map((s) => s.origin.length)),
       src: Math.max(3, ...filteredSlots.map((s) => s.sourceToken.length)),
       dest: Math.max(4, ...filteredSlots.map((s) => s.destination.length)),
       target: Math.max(6, ...filteredSlots.map((s) => s.target.length)),
-      cur: Math.max(7, ...filteredSlots.map((s) => s.currentBpsStr.length)),
+      cur: Math.max(
+        7,
+        ...filteredSlots.map(
+          (s) => fmtBps(s.effectiveMaxFee, s.effectiveHalfAmount).length,
+        ),
+      ),
     };
     const pad = (s: string, n: number) =>
       s.length >= n ? s : s + ' '.repeat(n - s.length);
+    let newBpsStr = '';
     console.log(
-      `\n${filteredSlots.length} slot(s) → ${newBpsStr} bps (TTL ${(effectiveTtl / 3600).toFixed(1)} h):\n`,
+      `\n${filteredSlots.length} slot(s) → ${bpsArg} bps (TTL ${(effectiveTtl / 3600).toFixed(1)} h):\n`,
     );
     console.log(
       `${pad('origin', W.origin)}   ${pad('src', W.src)} → ${pad('dest', W.dest)}   ${pad('target', W.target)}   ${pad('current', W.cur)}   new`,
@@ -586,10 +377,20 @@ async function main(): Promise<void> {
         .join('   '),
     );
     for (const slot of filteredSlots) {
-      console.log(
-        `${pad(slot.origin, W.origin)}   ${pad(slot.sourceToken, W.src)} → ${pad(slot.destination, W.dest)}   ${pad(slot.target, W.target)}   ${pad(slot.currentBpsStr, W.cur)}   ${newBpsStr}`,
+      const { maxFee, halfAmount } = bpsToParams(
+        multiProvider,
+        slot.origin,
+        bpsArg,
       );
-      toSubmit.push({ slot, maxFee, halfAmount, newBpsStr });
+      newBpsStr = fmtBps(maxFee, halfAmount);
+      const currentBpsStr = fmtBps(
+        slot.effectiveMaxFee,
+        slot.effectiveHalfAmount,
+      );
+      console.log(
+        `${pad(slot.origin, W.origin)}   ${pad(slot.sourceToken, W.src)} → ${pad(slot.destination, W.dest)}   ${pad(slot.target, W.target)}   ${pad(currentBpsStr, W.cur)}   ${newBpsStr}`,
+      );
+      toSubmit.push({ slot, maxFee, halfAmount, bpsLabel: newBpsStr });
     }
     console.log();
   } else {
@@ -599,11 +400,15 @@ async function main(): Promise<void> {
         'For each: enter bps, ↵ skip, "d" for on-chain default.\n',
     );
     for (const slot of filteredSlots) {
+      const currentBpsStr = fmtBps(
+        slot.effectiveMaxFee,
+        slot.effectiveHalfAmount,
+      );
       const fallbackBpsStr = fmtBps(slot.onchainMaxFee, slot.onchainHalfAmount);
       const effectiveLine =
-        slot.currentSource === 'standing'
-          ? `  effective : ${slot.currentBpsStr} bps (standing quote — overrides fallback)`
-          : `  effective : ${slot.currentBpsStr} bps (no standing quote, using fallback)`;
+        slot.effectiveSource === 'standing'
+          ? `  effective : ${currentBpsStr} bps (standing quote — overrides fallback)`
+          : `  effective : ${currentBpsStr} bps (no standing quote, using fallback)`;
       console.log(
         `\n${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}\n` +
           effectiveLine +
@@ -637,12 +442,16 @@ async function main(): Promise<void> {
         halfAmount = slot.onchainHalfAmount;
         newBpsStr = fallbackBpsStr;
       } else {
-        ({ maxFee, halfAmount } = bpsToParams(parseFloat(trimmed)));
+        ({ maxFee, halfAmount } = bpsToParams(
+          multiProvider,
+          slot.origin,
+          parseFloat(trimmed),
+        ));
         newBpsStr = fmtBps(maxFee, halfAmount);
       }
 
       console.log(`  → queued: ${newBpsStr} bps`);
-      toSubmit.push({ slot, maxFee, halfAmount, newBpsStr });
+      toSubmit.push({ slot, maxFee, halfAmount, bpsLabel: newBpsStr });
     }
   }
 
@@ -651,15 +460,25 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (dryRun) {
+    console.log('Dry run complete. No quotes were submitted.');
+    return;
+  }
+
+  assert(
+    signerKey !== undefined && submitterWallet !== undefined,
+    'signer/submitter keys are required when not --dry-run',
+  );
+
   // ── Confirm ────────────────────────────────────────────────────────────────
 
   if (!autoConfirm) {
     const ttlHours = (effectiveTtl / 3600).toFixed(1);
     console.log(`\n${'═'.repeat(60)}`);
     console.log(`${toSubmit.length} quote(s) to submit (TTL ${ttlHours} h):`);
-    for (const { slot, newBpsStr } of toSubmit) {
+    for (const { slot, bpsLabel } of toSubmit) {
       console.log(
-        `  ${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}  →  ${newBpsStr} bps`,
+        `  ${slot.origin} (${slot.sourceToken}) → ${slot.destination}  /  ${slot.target}  →  ${bpsLabel} bps`,
       );
     }
     console.log('═'.repeat(60));
@@ -672,86 +491,40 @@ async function main(): Promise<void> {
 
   // ── Sign and submit ────────────────────────────────────────────────────────
 
-  const MAX_ATTEMPTS = 3;
-
-  for (const { slot, maxFee, halfAmount, newBpsStr } of toSubmit) {
-    const provider = multiProvider.getProvider(slot.origin);
-    const signerWallet = new Wallet(signerKey, provider);
-    const submitter_wallet = submitterWallet.connect(provider);
-    const { chainId } = await provider.getNetwork();
-
-    const context = ethers.utils.solidityPack(
-      ['uint32', 'bytes32', 'uint256'],
-      [slot.destDomain, WILDCARD_RECIPIENT, constants.MaxUint256],
-    );
-    const data = ethers.utils.solidityPack(
-      ['uint256', 'uint256'],
-      [maxFee, halfAmount],
-    );
-    const domain = {
-      name: EIP712_NAME,
-      version: EIP712_VERSION,
-      chainId,
-      verifyingContract: slot.oqlfAddress,
-    };
-    const oqlf = OffchainQuotedLinearFee__factory.connect(
-      slot.oqlfAddress,
-      submitter_wallet,
-    );
-    const txOverrides = multiProvider.getTransactionOverrides(slot.origin);
-
-    let lastErr: unknown;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
-        // Regenerate timestamps and salt on each attempt so the signature is fresh.
-        const issuedAt = Math.floor(Date.now() / 1000);
-        const expiry = issuedAt + effectiveTtl;
-        const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-        const submitter = constants.AddressZero;
-
-        const message = { context, data, issuedAt, expiry, salt, submitter };
-        const signature = await signerWallet._signTypedData(
-          domain,
-          SIGNED_QUOTE_TYPES,
-          message,
-        );
-
-        const attemptSuffix = attempt > 1 ? ` (attempt ${attempt})` : '';
-        process.stdout.write(
-          `Submitting ${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${newBpsStr} bps)${attemptSuffix}... `,
-        );
-
-        const tx = await oqlf.submitQuote(
-          { context, data, issuedAt, expiry, salt, submitter },
-          signature,
-          txOverrides,
-        );
-        process.stdout.write(`${tx.hash.slice(0, 14)}… `);
-        await tx.wait(1);
-        console.log('confirmed.');
-        lastErr = undefined;
-        break;
-      } catch (err) {
-        lastErr = err;
-        const msg =
-          err instanceof Error ? err.message.slice(0, 120) : String(err);
-        if (attempt < MAX_ATTEMPTS) {
-          console.warn(`\n  attempt ${attempt} failed: ${msg} — retrying...`);
-        } else {
-          console.error(`\n  failed after ${MAX_ATTEMPTS} attempts: ${msg}`);
-        }
-      }
+  const results: Array<{ submission: QuoteSubmission; error?: unknown }> = [];
+  for (const submission of toSubmit) {
+    try {
+      await submitQuoteWithRetry(
+        multiProvider,
+        signerKey,
+        submitterWallet,
+        submission,
+        effectiveTtl,
+      );
+      results.push({ submission });
+    } catch (error) {
+      results.push({ submission, error });
     }
-
-    if (lastErr !== undefined)
-      throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
   }
 
-  console.log('\nAll quotes submitted.');
+  const failed = results.filter((r) => r.error !== undefined);
+  console.log(
+    `\n${results.length - failed.length}/${results.length} quote(s) submitted successfully.`,
+  );
+  if (failed.length > 0) {
+    console.error('\nFailed submissions (state to reconcile manually):');
+    for (const { submission, error } of failed) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(
+        `  ${submission.slot.origin} (${submission.slot.sourceToken}) → ${submission.slot.destination} / ${submission.slot.target}: ${msg}`,
+      );
+    }
+    process.exitCode = 1;
+  }
 }
 
 main()
-  .then(() => process.exit(0))
+  .then(() => process.exit(process.exitCode ?? 0))
   .catch((err) => {
     console.error(err instanceof Error ? err.message : err);
     process.exit(1);

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -673,60 +673,79 @@ async function main(): Promise<void> {
 
   // ── Sign and submit ────────────────────────────────────────────────────────
 
+  const MAX_ATTEMPTS = 3;
+
   for (const { slot, maxFee, halfAmount, newBpsStr } of toSubmit) {
     const provider = multiProvider.getProvider(slot.origin);
-    // signerWallet: signs the EIP-712 data (no gas needed).
     const signerWallet = new Wallet(signerKey, provider);
-    // submitter: connected to provider so it can pay gas.
     const submitter_wallet = submitterWallet.connect(provider);
     const { chainId } = await provider.getNetwork();
 
-    const issuedAt = Math.floor(Date.now() / 1000);
-    const expiry = issuedAt + effectiveTtl;
-    const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-    const submitter = constants.AddressZero; // unrestricted for standing quotes
-
-    // FeeQuoteContext.encode(destDomain, WILDCARD_RECIPIENT, WILDCARD_AMOUNT)
     const context = ethers.utils.solidityPack(
       ['uint32', 'bytes32', 'uint256'],
       [slot.destDomain, WILDCARD_RECIPIENT, constants.MaxUint256],
     );
-    // FeeQuoteData.encode(maxFee, halfAmount)
     const data = ethers.utils.solidityPack(
       ['uint256', 'uint256'],
       [maxFee, halfAmount],
     );
-
     const domain = {
       name: EIP712_NAME,
       version: EIP712_VERSION,
       chainId,
       verifyingContract: slot.oqlfAddress,
     };
-    const message = { context, data, issuedAt, expiry, salt, submitter };
-    const signature = await signerWallet._signTypedData(
-      domain,
-      SIGNED_QUOTE_TYPES,
-      message,
-    );
-
-    process.stdout.write(
-      `Submitting ${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${newBpsStr} bps)... `,
-    );
-    // Submitter wallet pays gas; anyone may submit since submitter field = address(0).
     const oqlf = OffchainQuotedLinearFee__factory.connect(
       slot.oqlfAddress,
       submitter_wallet,
     );
     const txOverrides = multiProvider.getTransactionOverrides(slot.origin);
-    const tx = await oqlf.submitQuote(
-      { context, data, issuedAt, expiry, salt, submitter },
-      signature,
-      txOverrides,
-    );
-    process.stdout.write(`${tx.hash.slice(0, 14)}… `);
-    await tx.wait(1);
-    console.log('confirmed.');
+
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        // Regenerate timestamps and salt on each attempt so the signature is fresh.
+        const issuedAt = Math.floor(Date.now() / 1000);
+        const expiry = issuedAt + effectiveTtl;
+        const salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+        const submitter = constants.AddressZero;
+
+        const message = { context, data, issuedAt, expiry, salt, submitter };
+        const signature = await signerWallet._signTypedData(
+          domain,
+          SIGNED_QUOTE_TYPES,
+          message,
+        );
+
+        const attemptSuffix = attempt > 1 ? ` (attempt ${attempt})` : '';
+        process.stdout.write(
+          `Submitting ${slot.origin} (${slot.sourceToken}) → ${slot.destination} / ${slot.target} (${newBpsStr} bps)${attemptSuffix}... `,
+        );
+
+        const tx = await oqlf.submitQuote(
+          { context, data, issuedAt, expiry, salt, submitter },
+          signature,
+          txOverrides,
+        );
+        process.stdout.write(`${tx.hash.slice(0, 14)}… `);
+        await tx.wait(1);
+        console.log('confirmed.');
+        lastErr = undefined;
+        break;
+      } catch (err) {
+        lastErr = err;
+        const msg =
+          err instanceof Error ? err.message.slice(0, 120) : String(err);
+        if (attempt < MAX_ATTEMPTS) {
+          console.warn(`\n  attempt ${attempt} failed: ${msg} — retrying...`);
+        } else {
+          console.error(`\n  failed after ${MAX_ATTEMPTS} attempts: ${msg}`);
+        }
+      }
+    }
+
+    if (lastErr !== undefined)
+      throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
   }
 
   console.log('\nAll quotes submitted.');

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -568,9 +568,11 @@ async function main(): Promise<void> {
       slot.oqlfAddress,
       submitter_wallet,
     );
+    const txOverrides = multiProvider.getTransactionOverrides(slot.origin);
     const tx = await oqlf.submitQuote(
       { context, data, issuedAt, expiry, salt, submitter },
       signature,
+      txOverrides,
     );
     process.stdout.write(`${tx.hash.slice(0, 14)}… `);
     await tx.wait(1);

--- a/typescript/infra/scripts/moonpay/set-quotes.ts
+++ b/typescript/infra/scripts/moonpay/set-quotes.ts
@@ -18,7 +18,6 @@ import yargs from 'yargs';
 
 import { checkbox, confirm, input } from '@inquirer/prompts';
 
-import { OffchainQuotedLinearFee__factory } from '@hyperlane-xyz/core';
 import { getRegistry as getMergedRegistry } from '@hyperlane-xyz/registry/fs';
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
@@ -35,6 +34,7 @@ import {
   fmtBps,
   resolveGcpKey,
   submitQuoteWithRetry,
+  verifySignerAuthorization,
 } from './oqlf-lib.js';
 
 const DEFAULT_TTL = 86_400; // 24 hours
@@ -44,7 +44,8 @@ const DEFAULT_TTL = 86_400; // 24 hours
 /**
  * Parses a TTL string with a mandatory unit suffix (s/h/d) — a bare number
  * is rejected so the same input can never be interpreted as seconds in one
- * code path and hours in another.
+ * code path and hours in another. Only whole seconds are accepted since the
+ * on-chain expiry is a uint48 of seconds.
  */
 function parseTtl(v: string): number | null {
   const t = v.trim().toLowerCase();
@@ -52,8 +53,10 @@ function parseTtl(v: string): number | null {
   if (!m) return null;
   const n = parseFloat(m[1]);
   if (!Number.isFinite(n) || n <= 0) return null;
-  const multiplier = { s: 1, h: 3600, d: 86_400 }[m[2] as 's' | 'h' | 'd'];
-  return n * multiplier;
+  const unit = m[2];
+  const multiplier = unit === 's' ? 1 : unit === 'h' ? 3600 : 86_400;
+  const seconds = n * multiplier;
+  return Number.isInteger(seconds) ? seconds : null;
 }
 
 // Resolve a comma-separated flag value ("all" = every available item).
@@ -203,53 +206,13 @@ async function main(): Promise<void> {
 
   console.log(`Found ${allSlots.length} OQLF slots.\n`);
 
-  // ── Verify signer authorization on every unique OQLF contract ──────────────
+  // ── Verify signer authorization on every unique (origin, OQLF) pair ────────
   if (!dryRun) {
     assert(
       signerKey !== undefined,
       'signer key is required when not --dry-run',
     );
-    const signerAddress = new Wallet(signerKey).address;
-    const uniqueOqlfOrigins = new Map<string, string>(); // oqlfAddress(lower) → origin
-    for (const slot of allSlots) {
-      uniqueOqlfOrigins.set(slot.oqlfAddress.toLowerCase(), slot.origin);
-    }
-    const unauthorized = (
-      await Promise.all(
-        [...uniqueOqlfOrigins].map(async ([oqlfAddress, origin]) => {
-          const provider = multiProvider.getProvider(origin);
-          const oqlf = OffchainQuotedLinearFee__factory.connect(
-            oqlfAddress,
-            provider,
-          );
-          const authorized = await oqlf.isQuoteSigner(signerAddress);
-          return authorized ? null : { oqlfAddress, origin };
-        }),
-      )
-    ).filter((r): r is { oqlfAddress: string; origin: string } => r !== null);
-
-    if (unauthorized.length > 0) {
-      for (const { oqlfAddress, origin } of unauthorized) {
-        const provider = multiProvider.getProvider(origin);
-        const oqlf = OffchainQuotedLinearFee__factory.connect(
-          oqlfAddress,
-          provider,
-        );
-        const authorizedSigners = await oqlf.quoteSigners();
-        console.error(
-          `\nError: signer ${signerAddress} is NOT authorized on OQLF ${oqlfAddress} (origin ${origin}).`,
-        );
-        console.error(
-          authorizedSigners.length === 0
-            ? 'No authorized signers found — contract may not be configured.'
-            : `Authorized signers: ${authorizedSigners.join(', ')}`,
-        );
-      }
-      process.exit(1);
-    }
-    console.log(
-      `Signer ${signerAddress} is authorized on all ${uniqueOqlfOrigins.size} OQLF contract(s). Proceeding.\n`,
-    );
+    await verifySignerAuthorization(multiProvider, signerKey, allSlots);
   }
 
   // ── TTL ───────────────────────────────────────────────────────────────────
@@ -421,7 +384,7 @@ async function main(): Promise<void> {
         validate: (v) => {
           const t = v.trim();
           if (t === '' || t === 'd') return true;
-          const n = parseFloat(t);
+          const n = Number(t);
           if (Number.isFinite(n) && n > 0) return true;
           return 'Enter a positive number, ↵ to skip, or "d" for on-chain default.';
         },
@@ -445,7 +408,7 @@ async function main(): Promise<void> {
         ({ maxFee, halfAmount } = bpsToParams(
           multiProvider,
           slot.origin,
-          parseFloat(trimmed),
+          Number(trimmed),
         ));
         newBpsStr = fmtBps(maxFee, halfAmount);
       }


### PR DESCRIPTION
### Description

Adds operational tooling for managing standing fee quotes on the CROSS/MoonPay warp route's Offchain Quoted Linear Fee (OQLF) contracts.

**`scripts/moonpay/set-quotes.ts`** — Sets standing quotes on OQLF contracts. Signs EIP-712 quotes with the GCP quote-signer key and submits them on-chain via \`OQLF.submitQuote()\`. Supports full non-interactive mode via CLI flags (\`--origins\`, \`--source-tokens\`, \`--destinations\`, \`--targets\`, \`--bps\`, \`--ttl\`, \`--yes\`). Key design decisions:
- Signer key (EIP-712 only, no gas) and submitter key (gas payer) are separate, both defaulting to GCP secrets
- Discovers all OQLF slots via a one-time RPC scan across all origin CCRs, destination domains, and target router keys (DEFAULT + per-token)
- Dedup key includes origin chain to handle the case where multiple origin-chain CCRs share the same OQLF instance — without this, slots were silently dropped non-deterministically depending on which origin's RPC responded first
- Retries each submission up to 3 times with fresh EIP-712 timestamps/salt on each attempt, to handle nonce races and transient RPC errors

**`scripts/moonpay/print-quotes.ts`** — Read-only view of effective fee bps for every lane. Resolves the standing-quote → fallback cascade the same way the on-chain contract does, and shows OQLF address, source (standing/fallback), and expiry for each row.

**`scripts/moonpay/propagate-quotes.ts`** — Propagates quotes across the route topology.

**`.claude/skills/set-moonpay-standing-quotes/SKILL.md`** — Claude Code skill for invoking \`set-quotes.ts\` via natural language (e.g. "set all USDC→USDC lanes to 3bps for 7 days").

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes — new scripts only, no changes to existing code.

### Testing

Manual — scripts run against mainnet OQLF contracts.