### PR TITLE
fix(tron-sdk): honor provided RPC host for tx broadcasting

### DIFF
--- a/.changeset/tron-wallet-respect-rpc.md
+++ b/.changeset/tron-wallet-respect-rpc.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/tron-sdk': patch
+---
+
+TronWallet now uses the provided RPC URL's host for building, signing and broadcasting transactions instead of silently redirecting non-TronGrid/localhost hosts to the public https://api.trongrid.io endpoint. This fixes private/custom Tron RPCs being ignored for broadcasting (which caused rate-limiting/429s and leaked transactions to a third party). API keys via `custom_rpc_header` continue to work. As an intended behavior change, an RPC that serves eth JSON-RPC but not the Tron HTTP API (`/wallet/*`) will now fail loudly instead of silently succeeding by routing broadcasts through public TronGrid; such setups should point the RPC at a full Tron HTTP API host (or TronGrid with an API key via `custom_rpc_header`).

--- a/typescript/tron-sdk/src/ethers/TronWallet.ts
+++ b/typescript/tron-sdk/src/ethers/TronWallet.ts
@@ -9,7 +9,7 @@ import {
   TronJsonRpcProvider,
 } from './TronJsonRpcProvider.js';
 import { TransactionRequest } from '@ethersproject/providers';
-import { stripCustomRpcHeaders } from './urlUtils.js';
+import { stripCustomRpcHeaders, toHttpApiUrl } from './urlUtils.js';
 
 /** Union of possible TronWeb transaction types */
 export type TronTransaction =
@@ -54,21 +54,14 @@ export class TronWallet extends Wallet {
   private txBuilder: TronTransactionBuilder;
 
   constructor(privateKey: string, tronUrl: string) {
-    // tronUrl should be the JSON-RPC endpoint (e.g. http://host:port/jsonrpc
-    // for TronGrid/TRE, or the root URL for third-party providers like Alchemy).
-    // TronWeb needs the base HTTP API URL — strip /jsonrpc path if present, and
-    // fall back to public TronGrid for third-party providers that only serve JSON-RPC.
-    // Extract custom headers before stripping path, as they may contain API keys.
-    const { url: cleanTronUrl, headers } = stripCustomRpcHeaders(tronUrl);
-    const parsed = new URL(cleanTronUrl);
-    if (parsed.pathname.endsWith('/jsonrpc')) {
-      parsed.pathname = parsed.pathname.slice(0, -8);
-    }
-    const baseUrl = parsed.toString();
-    const tronWebUrl =
-      /^https?:\/\/(localhost|127\.0\.0\.1|[^/]*trongrid)/.test(baseUrl)
-        ? baseUrl
-        : 'https://api.trongrid.io';
+    // `tronUrl` is the chain's HTTP RPC endpoint (root URL or a .../jsonrpc URL).
+    // TronWeb needs the Tron HTTP API base host; use the caller-provided host
+    // directly (matching the AltVM TronProvider) so a private/custom RPC is
+    // honored for building, signing and broadcasting instead of being silently
+    // redirected to the public TronGrid endpoint. Custom headers (e.g. API keys)
+    // are preserved via `custom_rpc_header`.
+    const { headers } = stripCustomRpcHeaders(tronUrl);
+    const tronWebUrl = toHttpApiUrl(tronUrl);
     super(privateKey, new TronJsonRpcProvider(tronUrl));
     this.originalTronUrl = tronUrl;
 

--- a/typescript/tron-sdk/src/ethers/urlUtils.test.ts
+++ b/typescript/tron-sdk/src/ethers/urlUtils.test.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 
-import { parseCustomHeaders, stripCustomRpcHeaders } from './urlUtils.js';
+import {
+  parseCustomHeaders,
+  stripCustomRpcHeaders,
+  toHttpApiUrl,
+} from './urlUtils.js';
 
 describe('parseCustomHeaders', () => {
   it('extracts a single custom_rpc_header', () => {
@@ -79,5 +83,72 @@ describe('stripCustomRpcHeaders', () => {
     const result = stripCustomRpcHeaders(url);
     expect(result.url).to.equal('https://host/jsonrpc');
     expect(result.headers).to.deep.equal({});
+  });
+});
+
+describe('toHttpApiUrl', () => {
+  it('strips a trailing /jsonrpc path', () => {
+    expect(toHttpApiUrl('https://node.example.com:8090/jsonrpc')).to.equal(
+      'https://node.example.com:8090/',
+    );
+  });
+
+  it('strips custom_rpc_header query params', () => {
+    expect(
+      toHttpApiUrl(
+        'https://node.example.com/jsonrpc?custom_rpc_header=x-api-key:abc',
+      ),
+    ).to.equal('https://node.example.com/');
+  });
+
+  it('preserves a private/custom host', () => {
+    const result = toHttpApiUrl('https://my-tron-node.example.com/jsonrpc');
+    expect(result).to.contain('my-tron-node.example.com');
+    expect(result).to.not.contain('trongrid');
+  });
+
+  it('leaves a plain host without /jsonrpc unchanged', () => {
+    expect(toHttpApiUrl('https://node.example.com')).to.equal(
+      'https://node.example.com/',
+    );
+  });
+
+  it('returns a trongrid host as its own host', () => {
+    const result = toHttpApiUrl('https://api.trongrid.io/jsonrpc');
+    expect(result).to.contain('trongrid');
+  });
+
+  it('preserves non-custom_rpc_header query params', () => {
+    expect(
+      toHttpApiUrl(
+        'https://host.example.com/jsonrpc?custom_rpc_header=x-api-key:abc&foo=bar',
+      ),
+    ).to.equal('https://host.example.com/?foo=bar');
+  });
+
+  it('leaves a non-trailing /jsonrpc path segment intact', () => {
+    expect(toHttpApiUrl('https://host.example.com/jsonrpc/v1')).to.equal(
+      'https://host.example.com/jsonrpc/v1',
+    );
+  });
+
+  it('throws on invalid (non-URL) input', () => {
+    expect(() => toHttpApiUrl('not-a-url')).to.throw();
+  });
+
+  // Provider-style URLs that carry the API key in the path (e.g. Alchemy:
+  // https://tron-mainnet.g.alchemy.com/v2/<key>) must keep the host and path
+  // verbatim, since the provider serves both eth JSON-RPC and the Tron HTTP API
+  // under that base. A generic host is used here to avoid secret scanners.
+  it('preserves a provider base URL with an api-key path segment (no /jsonrpc)', () => {
+    expect(toHttpApiUrl('https://tron-rpc.example.com/v2/API_KEY')).to.equal(
+      'https://tron-rpc.example.com/v2/API_KEY',
+    );
+  });
+
+  it('strips only a trailing /jsonrpc from such a provider URL', () => {
+    expect(
+      toHttpApiUrl('https://tron-rpc.example.com/v2/API_KEY/jsonrpc'),
+    ).to.equal('https://tron-rpc.example.com/v2/API_KEY');
   });
 });

--- a/typescript/tron-sdk/src/ethers/urlUtils.ts
+++ b/typescript/tron-sdk/src/ethers/urlUtils.ts
@@ -46,3 +46,23 @@ export function stripCustomRpcHeaders(url: string): {
   parsed.searchParams.delete('custom_rpc_header');
   return { url: parsed.toString(), headers };
 }
+
+/**
+ * Derive the Tron HTTP API base host from an RPC URL.
+ *
+ * TronWeb needs the base HTTP API host (serving `/wallet/*`), which differs
+ * from the ethers JSON-RPC endpoint. This strips any `custom_rpc_header` query
+ * params (they are auth headers, not part of the host) and a trailing
+ * `/jsonrpc` path segment.
+ *
+ * e.g. "https://node.example.com/jsonrpc?custom_rpc_header=x-api-key:abc"
+ * returns "https://node.example.com/"
+ */
+export function toHttpApiUrl(url: string): string {
+  const { url: clean } = stripCustomRpcHeaders(url);
+  const parsed = new URL(clean);
+  if (parsed.pathname.endsWith('/jsonrpc')) {
+    parsed.pathname = parsed.pathname.slice(0, -'/jsonrpc'.length);
+  }
+  return parsed.toString();
+}


### PR DESCRIPTION
## Problem

`TronWallet` splits work between an ethers `TronJsonRpcProvider` (reads) and an internal `TronWeb` client used to **build, sign and broadcast** transactions. The TronWeb host was chosen by a regex that forced any host that isn't `localhost`/`127.0.0.1` or `*trongrid*` to the public `https://api.trongrid.io`:

```ts
const tronWebUrl =
  /^https?:\/\/(localhost|127\.0\.0\.1|[^/]*trongrid)/.test(baseUrl)
    ? baseUrl
    : 'https://api.trongrid.io';
```

So a private/custom RPC (e.g. Alchemy `https://tron-mainnet.g.alchemy.com/v2/<key>`) was used for reads but **silently ignored for broadcasting** — transactions were sent to the public TronGrid endpoint instead, causing HTTP 429 rate-limiting and leaking signed transactions to a third party.

## Fix

- Add a unit-tested `toHttpApiUrl(url)` helper in `urlUtils.ts` that derives the Tron HTTP API base host (strips `custom_rpc_header` params and a trailing `/jsonrpc`).
- `TronWallet` now uses the caller-provided host for its TronWeb client, matching the sibling AltVM `TronProvider` (`src/clients/provider.ts`). No silent public-TronGrid fallback.
- Backward compatible: constructor signature and `connect()` are unchanged; API keys via `custom_rpc_header` are preserved.
- Behavior change (documented in the changeset): an endpoint that serves eth JSON-RPC but **not** the Tron HTTP API (`/wallet/*`) now fails loudly instead of silently succeeding by routing broadcasts through public TronGrid.

## Testing

- `urlUtils` unit tests: **21 passing** (incl. api-key-in-path and `/jsonrpc`-stripping cases).
- **Live Alchemy mainnet** (read-only): the wallet's TronWeb host is the Alchemy endpoint (not TronGrid); both eth JSON-RPC (`eth_blockNumber`) and the Tron HTTP API (`/wallet/getnowblock`) succeed at that host and agree on the same block.
- CLI Tron e2e (`TEST_STACK=tron`, local TRE node): `core-deploy` **7 passing**, `warp-deploy-1` **14 passing**. (On `127.0.0.1` the old and new code resolve to the same host, so behavior on the test node is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)