### PR TITLE
fix(sdk,cli): xERC20 warp routes for proxied tokens & non-Etherscan explorers (Tron)

### DIFF
--- a/.changeset/tron-explorer-api-gate.md
+++ b/.changeset/tron-explorer-api-gate.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+`tryGetEvmExplorerMetadata` now restricts explorer-API usage to Etherscan-compatible families (Etherscan/Blockscout/Routescan/ZkSync) instead of only excluding `Other`, so non-Etherscan explorers such as TronScan are skipped cleanly instead of returning HTML that breaks JSON parsing during xERC20 bridge derivation (warp read / enrollment on Tron).

--- a/.changeset/xerc20-proxy-type-detection.md
+++ b/.changeset/xerc20-proxy-type-detection.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Fixed XERC20 type detection (deriveXERC20TokenType) for xERC20 tokens deployed behind a proxy: it now resolves the implementation address and inspects its bytecode for the Velodrome/Standard selectors, instead of only checking the (delegatecall-stub) proxy bytecode. This fixes "Unable to detect XERC20 type … does not implement Standard or Velodrome XERC20 interface" for proxied xERC20 warp routes.

--- a/.changeset/xerc20-read-normalize-bridges.md
+++ b/.changeset/xerc20-read-normalize-bridges.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/cli': patch
+---
+
+hyperlane xerc20 read now normalizes bridge addresses (via normalizeAddressEvm) before de-duplicating, so a bridge is no longer listed twice when on-chain and expected addresses differ only in EIP-55 casing (seen on Tron xERC20 routes).

--- a/typescript/cli/src/commands/xerc20.ts
+++ b/typescript/cli/src/commands/xerc20.ts
@@ -11,7 +11,12 @@ import {
   type XERC20ModuleConfig,
   isXERC20TokenConfig,
 } from '@hyperlane-xyz/sdk';
-import { type Address, assert, objFilter } from '@hyperlane-xyz/utils';
+import {
+  type Address,
+  assert,
+  normalizeAddressEvm,
+  objFilter,
+} from '@hyperlane-xyz/utils';
 
 import { runSubmit } from '../config/submit.js';
 import {
@@ -182,7 +187,9 @@ const read: CommandModuleWithContext<
         const onChainBridges = Object.keys(onChainConfig.limits);
         const expectedBridges = Object.keys(config.limits);
         const allBridges = [
-          ...new Set([...onChainBridges, ...expectedBridges]),
+          ...new Set(
+            [...onChainBridges, ...expectedBridges].map(normalizeAddressEvm),
+          ),
         ];
 
         const { xERC20 } = module.serialize();

--- a/typescript/sdk/src/block-explorer/utils.ts
+++ b/typescript/sdk/src/block-explorer/utils.ts
@@ -1,10 +1,10 @@
 import type { BlockExplorer } from '../metadata/chainMetadataTypes.js';
 import { ExplorerFamily } from '../metadata/chainMetadataTypes.js';
 
-export function isEvmBlockExplorerAndNotEtherscan(
-  blockExplorer: BlockExplorer,
+function isEvmBlockExplorerFamilyAndNotEtherscan(
+  family?: ExplorerFamily,
 ): boolean {
-  if (!blockExplorer.family) {
+  if (!family) {
     return false;
   }
 
@@ -20,5 +20,26 @@ export function isEvmBlockExplorerAndNotEtherscan(
     [ExplorerFamily.Unknown]: false,
   };
 
-  return byFamily[blockExplorer.family] ?? false;
+  return byFamily[family] ?? false;
+}
+
+export function isEvmBlockExplorerAndNotEtherscan(
+  blockExplorer: BlockExplorer,
+): boolean {
+  return isEvmBlockExplorerFamilyAndNotEtherscan(blockExplorer.family);
+}
+
+/**
+ * Whether the given explorer family exposes an Etherscan-compatible logs/API
+ * surface (Etherscan itself plus Blockscout/Routescan/ZkSync). Families such as
+ * TronScan, Voyager, RadixDashboard, Other and Unknown are not compatible and
+ * must not be queried with the Etherscan-style API.
+ */
+export function isEtherscanApiCompatibleFamily(
+  family?: ExplorerFamily,
+): boolean {
+  return (
+    family === ExplorerFamily.Etherscan ||
+    isEvmBlockExplorerFamilyAndNotEtherscan(family)
+  );
 }

--- a/typescript/sdk/src/metadata/ChainMetadataManager.test.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.test.ts
@@ -5,7 +5,11 @@ import { ProtocolType } from '@hyperlane-xyz/utils';
 import { ChainNameOrId } from '../types.js';
 
 import { ChainMetadataManager } from './ChainMetadataManager.js';
-import { ChainMetadata } from './chainMetadataTypes.js';
+import {
+  BlockExplorer,
+  ChainMetadata,
+  ExplorerFamily,
+} from './chainMetadataTypes.js';
 
 describe(ChainMetadataManager.name, () => {
   let manager: ChainMetadataManager;
@@ -140,4 +144,89 @@ describe(ChainMetadataManager.name, () => {
       });
     });
   });
+
+  describe(
+    ChainMetadataManager.prototype.tryGetEvmExplorerMetadata.name,
+    () => {
+      const etherscanExplorer: BlockExplorer = {
+        name: 'Etherscan',
+        url: 'https://etherscan.example.com',
+        apiUrl: 'https://api.etherscan.example.com/api',
+        apiKey: 'test-key',
+        family: ExplorerFamily.Etherscan,
+      };
+      const etherscanNoKeyExplorer: BlockExplorer = {
+        name: 'Etherscan',
+        url: 'https://etherscan.example.com',
+        apiUrl: 'https://api.etherscan.example.com/api',
+        family: ExplorerFamily.Etherscan,
+      };
+      const blockscoutExplorer: BlockExplorer = {
+        name: 'Blockscout',
+        url: 'https://blockscout.example.com',
+        apiUrl: 'https://blockscout.example.com/api',
+        family: ExplorerFamily.Blockscout,
+      };
+      const tronScanExplorer: BlockExplorer = {
+        name: 'TronScan',
+        url: 'https://tronscan.example.com',
+        apiUrl: 'https://tronscan.example.com/#/api',
+        family: ExplorerFamily.TronScan,
+      };
+
+      interface Case {
+        description: string;
+        blockExplorers: BlockExplorer[];
+        expectedFamily: ExplorerFamily | null;
+      }
+
+      const cases: Case[] = [
+        {
+          description:
+            'TronScan default with no compatible fallback returns null',
+          blockExplorers: [tronScanExplorer],
+          expectedFamily: null,
+        },
+        {
+          description: 'Etherscan with an api key returns the explorer',
+          blockExplorers: [etherscanExplorer],
+          expectedFamily: ExplorerFamily.Etherscan,
+        },
+        {
+          description: 'Blockscout returns the explorer',
+          blockExplorers: [blockscoutExplorer],
+          expectedFamily: ExplorerFamily.Blockscout,
+        },
+        {
+          description:
+            'Etherscan without an api key falls back to Blockscout when present',
+          blockExplorers: [etherscanNoKeyExplorer, blockscoutExplorer],
+          expectedFamily: ExplorerFamily.Blockscout,
+        },
+      ];
+
+      for (const c of cases) {
+        it(c.description, () => {
+          const chainManager = new ChainMetadataManager({
+            testchain: {
+              chainId: 12345,
+              domainId: 12345,
+              name: 'testchain',
+              protocol: ProtocolType.Ethereum,
+              rpcUrls: [{ http: 'https://testchain.example.com' }],
+              blockExplorers: c.blockExplorers,
+            },
+          });
+
+          const result = chainManager.tryGetEvmExplorerMetadata('testchain');
+
+          if (c.expectedFamily === null) {
+            expect(result).to.equal(null);
+          } else {
+            expect(result?.family).to.equal(c.expectedFamily);
+          }
+        });
+      }
+    },
+  );
 });

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -10,7 +10,10 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { isEvmBlockExplorerAndNotEtherscan } from '../block-explorer/utils.js';
+import {
+  isEtherscanApiCompatibleFamily,
+  isEvmBlockExplorerAndNotEtherscan,
+} from '../block-explorer/utils.js';
 import { ChainMap, ChainName, ChainNameOrId } from '../types.js';
 
 import {
@@ -438,7 +441,7 @@ export class ChainMetadataManager<MetaExt = {}> {
         ? !!defaultExplorer.apiKey
         : true;
     const canUseExplorerApi =
-      defaultExplorer.family !== ExplorerFamily.Other &&
+      isEtherscanApiCompatibleFamily(defaultExplorer.family) &&
       isExplorerConfiguredCorrectly;
 
     const explorer = canUseExplorerApi ? defaultExplorer : fallBackExplorer;

--- a/typescript/sdk/src/token/xerc20.test.ts
+++ b/typescript/sdk/src/token/xerc20.test.ts
@@ -1,0 +1,174 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import sinon from 'sinon';
+
+import { TestChainName } from '../consts/testChains.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { XERC20Type } from './types.js';
+import { deriveXERC20TokenType } from './xerc20.js';
+
+const PROXY_ADDRESS = '0x1111111111111111111111111111111111111111';
+const IMPLEMENTATION_ADDRESS = '0x2222222222222222222222222222222222222222';
+const PROXY_ADMIN_ADDRESS = '0x3333333333333333333333333333333333333333';
+
+const setBufferCapSelector = ethers.utils
+  .id('setBufferCap(address,uint256)')
+  .slice(2, 10)
+  .toLowerCase();
+const setLimitsSelector = ethers.utils
+  .id('setLimits(address,uint256,uint256)')
+  .slice(2, 10)
+  .toLowerCase();
+
+// EIP-1967 admin slot read by proxyAdmin() / isProxy().
+const ADMIN_SLOT =
+  '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+// EIP-1967 implementation slot read by proxyImplementation().
+const IMPLEMENTATION_SLOT =
+  '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
+
+function storageAddress(address: string): string {
+  return ethers.utils.hexZeroPad(address, 32);
+}
+
+interface Case {
+  name: string;
+  // Bytecode returned by provider.getCode() keyed by address.
+  code: Record<string, string>;
+  // Storage values returned by provider.getStorageAt() keyed by slot. When a
+  // slot is omitted the stub throws, proving the derivation never reads it.
+  storage: Record<string, string>;
+  expected: { type: XERC20Type } | { errorIncludes: string };
+}
+
+const cases: Case[] = [
+  {
+    // The address bytecode already carries the Velodrome selector, so the
+    // proxy path must never be consulted. Reading the admin slot would throw.
+    name: 'returns Velo from the address bytecode without inspecting the proxy',
+    code: { [PROXY_ADDRESS]: `0x${setBufferCapSelector}` },
+    storage: {},
+    expected: { type: XERC20Type.Velo },
+  },
+  {
+    // The address bytecode carries the Standard selector; short-circuits too.
+    name: 'returns Standard from the address bytecode without inspecting the proxy',
+    code: { [PROXY_ADDRESS]: `0x${setLimitsSelector}` },
+    storage: {},
+    expected: { type: XERC20Type.Standard },
+  },
+  {
+    // Proxy bytecode is a delegatecall stub lacking the selectors; the
+    // implementation bytecode carries the Velodrome selector.
+    name: 'inspects the implementation bytecode when the Velo token is behind a proxy',
+    code: {
+      [PROXY_ADDRESS]: '0xdead',
+      [IMPLEMENTATION_ADDRESS]: `0x${setBufferCapSelector}`,
+    },
+    storage: {
+      [ADMIN_SLOT]: storageAddress(PROXY_ADMIN_ADDRESS),
+      [IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+    },
+    expected: { type: XERC20Type.Velo },
+  },
+  {
+    // Same proxy path but the implementation carries the Standard selector.
+    name: 'inspects the implementation bytecode when the Standard token is behind a proxy',
+    code: {
+      [PROXY_ADDRESS]: '0xdead',
+      [IMPLEMENTATION_ADDRESS]: `0x${setLimitsSelector}`,
+    },
+    storage: {
+      [ADMIN_SLOT]: storageAddress(PROXY_ADMIN_ADDRESS),
+      [IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+    },
+    expected: { type: XERC20Type.Standard },
+  },
+  {
+    // Proxy resolves to an implementation that still lacks both selectors.
+    name: 'throws when neither the proxy nor its implementation implements a known interface',
+    code: {
+      [PROXY_ADDRESS]: '0xdead',
+      [IMPLEMENTATION_ADDRESS]: '0xbeef',
+    },
+    storage: {
+      [ADMIN_SLOT]: storageAddress(PROXY_ADMIN_ADDRESS),
+      [IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+    },
+    expected: {
+      errorIncludes:
+        'does not implement Standard or Velodrome XERC20 interface',
+    },
+  },
+  {
+    // No bytecode at the address at all.
+    name: 'throws when the address has no bytecode',
+    code: { [PROXY_ADDRESS]: '0x' },
+    storage: {},
+    expected: { errorIncludes: 'Contract has no bytecode' },
+  },
+];
+
+describe('deriveXERC20TokenType', () => {
+  let sandbox: sinon.SinonSandbox;
+  let multiProvider: MultiProvider;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    multiProvider = MultiProvider.createTestMultiProvider();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  for (const c of cases) {
+    it(c.name, async () => {
+      const provider = multiProvider.getProvider(TestChainName.test1);
+
+      sandbox.stub(provider, 'getCode').callsFake(async (addressOrName) => {
+        const target = await addressOrName;
+        const code = c.code[target];
+        if (code === undefined) {
+          throw new Error(`Unexpected getCode call for ${target}`);
+        }
+        return code;
+      });
+      sandbox
+        .stub(provider, 'getStorageAt')
+        .callsFake(async (_addressOrName, position) => {
+          const slot = await position;
+          const value = typeof slot === 'string' ? c.storage[slot] : undefined;
+          if (value === undefined) {
+            throw new Error(`Unexpected getStorageAt call for slot ${slot}`);
+          }
+          return value;
+        });
+
+      if ('type' in c.expected) {
+        const type = await deriveXERC20TokenType(
+          multiProvider,
+          TestChainName.test1,
+          PROXY_ADDRESS,
+        );
+        expect(type).to.equal(c.expected.type);
+      } else {
+        let error: Error | undefined;
+        try {
+          await deriveXERC20TokenType(
+            multiProvider,
+            TestChainName.test1,
+            PROXY_ADDRESS,
+          );
+        } catch (e) {
+          if (e instanceof Error) {
+            error = e;
+          }
+        }
+        expect(error).to.be.instanceOf(Error);
+        expect(error?.message).to.include(c.expected.errorIncludes);
+      }
+    });
+  }
+});

--- a/typescript/sdk/src/token/xerc20.ts
+++ b/typescript/sdk/src/token/xerc20.ts
@@ -13,6 +13,7 @@ import {
   getLogsFromEtherscanLikeExplorerAPI,
 } from '../block-explorer/etherscan.js';
 import { isContractAddress } from '../contracts/contracts.js';
+import { isProxy, proxyImplementation } from '../deploy/proxy.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { GetEventLogsResponse } from '../rpc/evm/types.js';
 import { viemLogFromGetEventLogsResponse } from '../rpc/evm/utils.js';
@@ -454,8 +455,7 @@ export async function deriveXERC20TokenType(
   }
 
   const provider = multiProvider.getProvider(chain);
-  const code = await provider.getCode(address);
-  const normalizedCode = code.toLowerCase();
+  let normalizedCode = (await provider.getCode(address)).toLowerCase();
   const setBufferCapSelector = ethers.utils
     .id('setBufferCap(address,uint256)')
     .slice(2, 10)
@@ -464,6 +464,17 @@ export async function deriveXERC20TokenType(
     .id('setLimits(address,uint256,uint256)')
     .slice(2, 10)
     .toLowerCase();
+
+  // xERC20 tokens are commonly deployed behind a proxy whose bytecode does not
+  // embed the implementation's selectors; inspect the implementation in that case.
+  if (
+    !normalizedCode.includes(setBufferCapSelector) &&
+    !normalizedCode.includes(setLimitsSelector) &&
+    (await isProxy(provider, address))
+  ) {
+    const implementation = await proxyImplementation(provider, address);
+    normalizedCode = (await provider.getCode(implementation)).toLowerCase();
+  }
 
   // Prefer Velodrome if both selectors are present.
   if (normalizedCode.includes(setBufferCapSelector)) {


### PR DESCRIPTION
## Summary

Three related fixes that unblock xERC20 warp routes for **proxied xERC20 tokens** and **non-Etherscan chains** (surfaced while deploying/reading an Arbitrum↔Tron oUSDT route). All validated end-to-end on live **Arbitrum↔Tron mainnet**: `warp read` and `warp apply` both succeed (routers enrolled + bridge limits set on both chains).

### 1. `fix(sdk)`: detect XERC20 type behind a proxy
`deriveXERC20TokenType` only grep'd the address's own bytecode for the `setBufferCap`/`setLimits` selectors. Every oUSDT-style xERC20 is deployed behind a `TransparentUpgradeableProxy` whose runtime bytecode is a delegatecall stub with none of the implementation's selectors, so detection always threw *"does not implement Standard or Velodrome XERC20 interface"*. It now resolves the EIP-1967 implementation (via `isProxy`/`proxyImplementation`) and inspects the implementation bytecode when the proxy's own lacks the selectors. `isProxy` is only consulted when detection would otherwise fail, and non-proxy behavior + error messages are unchanged.

### 2. `fix(sdk)`: gate EVM explorer API to Etherscan-compatible families
`tryGetEvmExplorerMetadata` only excluded `ExplorerFamily.Other`, so non-Etherscan explorers (e.g. `TronScan`) passed the gate. The xERC20 bridge-log fetch (`getExtraLockBoxConfigs`) then hit the Tronscan UI URL and got HTML back → `Unexpected token '<', "<!DOCTYPE"... is not valid JSON`, breaking **both** `warp read` and enrollment on Tron. It now gates positively to Etherscan-compatible families (Etherscan/Blockscout/Routescan/ZkSync) via a new `isEtherscanApiCompatibleFamily` helper; incompatible explorers fall back to a compatible one or return `null` (callers already handle `null` by skipping derivation).

### 3. `fix(cli)`: normalize `xerc20 read` bridge addresses before dedupe
`xerc20 read` unioned on-chain and expected bridge addresses through a `Set` without normalizing casing, so a bridge whose forms differed only in EIP-55 casing was listed twice (observed on Tron). Addresses are now mapped through `normalizeAddressEvm` before de-duplication.

## Testing
- **Unit:** table-driven `deriveXERC20TokenType` (non-proxy Velo/Standard, proxy Velo/Standard, unsupported→throw, no-bytecode→throw); `tryGetEvmExplorerMetadata` (TronScan→null, Etherscan+key, Blockscout, Etherscan-no-key→Blockscout fallback).
- **Live mainnet:** Arbitrum↔Tron `warp read` reads both chains cleanly; `warp apply` enrolls routers both ways and sets router+lockbox limits.

## Follow-up (not in this PR)
`EvmXERC20Module.detectDriftFromConfigs` (the `warp apply` path) has a similar address-casing hazard. It has a partial mitigation (normalized-then-raw lookup) and worked correctly in the live run, so it's left as a follow-up to normalize both sides at the boundary consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)