### PR TITLE
fix(infra): lower USDC/subtensor rebalancer ethereum target to 45000

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -53,7 +53,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // standalone services
   keyFunder: '3b17358-20260315-183126',
   warpMonitor: '744b3bb-20260521-215958',
-  rebalancer: '9474574-20260612-104459',
+  rebalancer: 'da26d9a-20260703-122943',
   feeQuoting: '12d899d-20260325-184337',
 };
 

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
@@ -14,7 +14,7 @@ strategy:
     ethereum:
       minAmount:
         min: 45000
-        target: 55000
+        target: 45000
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000


### PR DESCRIPTION
## Summary
Two changes to unstall + redeploy the USDC/subtensor rebalancer.

1. **Config fix** — `hyperlane-rebalancer-usdc-subtensor-0` has been crash-looping since ~2026-07-03 10:58Z (PD [Q1607K1LBIOR1G](https://abacus-network.pagerduty.com/incidents/Q1607K1LBIOR1G)). Root cause: `MinAmountStrategy.validateAmounts` rejects startup because the sum of per-chain targets (base 15k + ethereum 55k + polygon 15k + arbitrum 15k + unichain 15k = **115,000 USDC**) exceeds total route collateral (**~113,105 USDC**). Lowering the ethereum target from 55,000 → **45,000** brings the target sum to **105,000 USDC**, below current collateral. Target now equals ethereum's `min` (45,000), which `validateAmounts` permits (`target >= min`). Same fix pattern as prior subtensor PR #8171 and the recurring USDC/superseed crash-loops.
2. **Image bump** — bump the mainnet3 `rebalancer` Docker tag to `da26d9a-20260703-122943`, built from the config fix on this branch.

## Test plan
- [ ] Verify target sum (105,000) < live route collateral before merge
- [ ] After merge + rebalancer redeploy, confirm `hyperlane-rebalancer-usdc-subtensor-0` boots (no `MinAmountStrategy.validateAmounts` error) and completes a polling cycle
- [ ] Confirm PD Q1607K1LBIOR1G auto-resolves once restarts age out of the 1h window