### PR TITLE
fix(sealevel): address HLSVM-2026Q2-014 minor audit suggestions

### DIFF
--- a/rust/sealevel/libraries/account-utils/src/discriminator.rs
+++ b/rust/sealevel/libraries/account-utils/src/discriminator.rs
@@ -120,6 +120,9 @@ impl<T> DiscriminatorEncode for T where T: DiscriminatorData + borsh::BorshSeria
 /// Decodes the given data with a discriminator prefix.
 pub trait DiscriminatorDecode: DiscriminatorData + borsh::BorshDeserialize {
     fn decode(data: &[u8]) -> Result<Self, ProgramError> {
+        if data.len() < Discriminator::LENGTH {
+            return Err(ProgramError::InvalidInstructionData);
+        }
         let (discriminator, rest) = data.split_at(Discriminator::LENGTH);
         if discriminator != Self::DISCRIMINATOR_SLICE {
             return Err(ProgramError::InvalidInstructionData);
@@ -160,5 +163,26 @@ mod test {
             serialized_prefixed_foo[0..Discriminator::LENGTH],
             Foo::DISCRIMINATOR
         );
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize, Default, Debug)]
+    struct Bar {
+        a: u64,
+    }
+
+    impl DiscriminatorData for Bar {
+        const DISCRIMINATOR: [u8; 8] = [3, 3, 3, 3, 3, 3, 3, 3];
+    }
+
+    #[test]
+    fn test_decode_rejects_short_input() {
+        // Fewer than DISCRIMINATOR_LENGTH bytes must error, not panic in split_at.
+        for len in 0..Discriminator::LENGTH {
+            let short = vec![3u8; len];
+            assert_eq!(
+                Bar::decode(&short).unwrap_err(),
+                ProgramError::InvalidInstructionData,
+            );
+        }
     }
 }

--- a/rust/sealevel/libraries/ecdsa-signature/src/lib.rs
+++ b/rust/sealevel/libraries/ecdsa-signature/src/lib.rs
@@ -11,7 +11,18 @@ pub enum EcdsaSignatureError {
     InvalidLength,
     #[error("Invalid signature recovery ID")]
     InvalidRecoveryId,
+    #[error("Signature s value is in the upper half order (non-canonical)")]
+    HighS,
 }
+
+/// Half the secp256k1 curve order (n / 2), big-endian. A signature is canonical
+/// (low-S) only when `s <= n/2`; larger `s` values are rejected so each
+/// signature has a single valid encoding (otherwise `(r, n - s, v ^ 1)` is a
+/// second encoding of the same signature).
+const SECP256K1_HALF_ORDER: [u8; 32] = [
+    0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0x5D, 0x57, 0x6E, 0x73, 0x57, 0xA4, 0x50, 0x1D, 0xDF, 0xE9, 0x2F, 0x46, 0x68, 0x1B, 0x20, 0xA0,
+];
 
 /// An ECDSA signature with a recovery ID.
 /// Signature recovery functions expect a 64 byte serialized r & s value and a 1 byte recovery ID
@@ -45,6 +56,12 @@ impl EcdsaSignature {
         // Recovery ID must be 0 or 1
         if recovery_id > 1 {
             return Err(EcdsaSignatureError::InvalidRecoveryId);
+        }
+
+        // Enforce low-S: reject s > n/2 so the signature has a single canonical
+        // encoding. This covers every caller of the shared library.
+        if serialized_rs[32..] > SECP256K1_HALF_ORDER[..] {
+            return Err(EcdsaSignatureError::HighS);
         }
 
         Ok(Self {
@@ -119,6 +136,9 @@ mod test {
             let mut rs = [0u8; 64];
             rs[..32].copy_from_slice(&H256::random()[..]);
             rs[32..].copy_from_slice(&H256::random()[..]);
+            // Force s into the lower half order so the low-S check accepts it;
+            // this test only exercises recovery-id decoding.
+            rs[32] = 0;
 
             let mut bytes = [0u8; 65];
             bytes[..64].copy_from_slice(&rs[..]);
@@ -145,5 +165,65 @@ mod test {
                 }
             }
         }
+    }
+
+    /// The full secp256k1 curve order (n), big-endian.
+    const SECP256K1_ORDER: [u8; 32] = [
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36,
+        0x41, 0x41,
+    ];
+
+    /// Builds a 65-byte signature with an arbitrary `r`, the given `s`, and `v = 0`.
+    fn signature_with_s(s: &[u8; 32]) -> [u8; 65] {
+        let mut bytes = [0u8; 65];
+        bytes[..32].copy_from_slice(&[0x11u8; 32]); // arbitrary r
+        bytes[32..64].copy_from_slice(s);
+        bytes[64] = 0;
+        bytes
+    }
+
+    /// Big-endian `a - b`, assuming `a >= b`.
+    fn be_sub(a: [u8; 32], b: &[u8; 32]) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        let mut borrow = 0i16;
+        for i in (0..32).rev() {
+            let diff = a[i] as i16 - b[i] as i16 - borrow;
+            if diff < 0 {
+                out[i] = (diff + 256) as u8;
+                borrow = 1;
+            } else {
+                out[i] = diff as u8;
+                borrow = 0;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_rejects_high_s_signatures() {
+        // s == n/2 is the largest canonical value: accepted.
+        assert!(EcdsaSignature::from_bytes(&signature_with_s(&SECP256K1_HALF_ORDER)).is_ok());
+
+        // s == n/2 + 1 is the smallest non-canonical value: rejected.
+        let mut just_above = SECP256K1_HALF_ORDER;
+        just_above[31] += 1;
+        assert_eq!(
+            EcdsaSignature::from_bytes(&signature_with_s(&just_above)).unwrap_err(),
+            EcdsaSignatureError::HighS
+        );
+
+        // A low-S signature is accepted, but its malleable twin (r, n - s) is
+        // high-S and must be rejected — so a single signature cannot have two
+        // valid encodings.
+        let mut low_s = [0u8; 32];
+        low_s[31] = 1;
+        assert!(EcdsaSignature::from_bytes(&signature_with_s(&low_s)).is_ok());
+
+        let malleable_s = be_sub(SECP256K1_ORDER, &low_s);
+        assert_eq!(
+            EcdsaSignature::from_bytes(&signature_with_s(&malleable_s)).unwrap_err(),
+            EcdsaSignatureError::HighS
+        );
     }
 }

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/error.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/error.rs
@@ -34,6 +34,10 @@ pub enum Error {
     /// IGP has offchain quoting configured but caller used legacy (oracle-only) flow.
     #[error("IGP requires new quoting flow")]
     IgpNewFlowRequired = 7,
+
+    /// Fee account domain does not match the token mailbox local domain.
+    #[error("Fee account domain mismatch")]
+    InvalidFeeAccountDomain = 8,
 }
 
 impl From<Error> for ProgramError {

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/instruction.rs
@@ -14,7 +14,9 @@ use solana_program::{
 };
 use solana_system_interface::program as system_program;
 
-use hyperlane_sealevel_mailbox::mailbox_message_dispatch_authority_pda_seeds;
+use hyperlane_sealevel_mailbox::{
+    mailbox_message_dispatch_authority_pda_seeds, mailbox_outbox_pda_seeds,
+};
 
 use crate::{accounts::FeeConfig, hyperlane_token_pda_seeds};
 
@@ -237,6 +239,7 @@ pub fn set_interchain_security_module_instruction(
 pub fn set_fee_config_instruction(
     program_id: Pubkey,
     owner_payer: Pubkey,
+    mailbox: Pubkey,
     fee_config: Option<FeeConfig>,
 ) -> Result<SolanaInstruction, ProgramError> {
     let (token_key, _token_bump) =
@@ -250,14 +253,19 @@ pub fn set_fee_config_instruction(
     // When fee_config is Some:
     // 3. `[executable]` The fee program.
     // 4. `[]` The fee account (owned by fee program).
+    // 5. `[]` The mailbox outbox PDA account.
     let mut accounts = vec![
         AccountMeta::new_readonly(system_program::ID, false),
         AccountMeta::new(token_key, false),
         AccountMeta::new(owner_payer, true),
     ];
     if let Some(ref cfg) = fee_config {
+        let (mailbox_outbox_key, _mailbox_outbox_bump) =
+            Pubkey::try_find_program_address(mailbox_outbox_pda_seeds!(), &mailbox)
+                .ok_or(ProgramError::InvalidSeeds)?;
         accounts.push(AccountMeta::new_readonly(cfg.fee_program, false));
         accounts.push(AccountMeta::new_readonly(cfg.fee_account, false));
+        accounts.push(AccountMeta::new_readonly(mailbox_outbox_key, false));
     }
 
     let ixn = Instruction::SetFeeConfig(fee_config);

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -1325,7 +1325,8 @@ where
 
         ensure_no_extraneous_accounts(accounts_iter)?;
 
-        token.fee_config = fee_config;
+        let previous_fee_config = token.fee_config.clone();
+        token.fee_config = fee_config.clone();
 
         // Store with realloc since fee_config may change the account size.
         HyperlaneTokenAccount::<T>::from(token).store_with_rent_exempt_realloc(
@@ -1335,6 +1336,11 @@ where
             system_program,
         )?;
 
+        msg!(
+            "Set fee config: {:?} -> {:?}",
+            previous_fee_config,
+            fee_config
+        );
         Ok(())
     }
 }

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/src/processor.rs
@@ -21,6 +21,7 @@ use hyperlane_sealevel_igp::{
     instruction::{Instruction as IgpInstruction, PayForGas as IgpPayForGas},
 };
 use hyperlane_sealevel_mailbox::{
+    accounts::Outbox,
     instruction::{Instruction as MailboxInstruction, OutboxDispatch as MailboxOutboxDispatch},
     mailbox_message_dispatch_authority_pda_seeds, mailbox_process_authority_pda_seeds,
 };
@@ -1283,6 +1284,7 @@ where
     ///
     /// 3. `[executable]` The fee program.
     /// 4. `[]` The fee account (owned by fee program).
+    /// 5. `[]` The mailbox outbox PDA account (to read local_domain).
     pub fn set_fee_config(
         program_id: &Pubkey,
         accounts: &[AccountInfo],
@@ -1320,7 +1322,15 @@ where
             {
                 return Err(ProgramError::InvalidArgument);
             }
-            FeeAccountPrefix::parse_from(&fee_account_info.data.borrow())?;
+            let fee_account_prefix = FeeAccountPrefix::parse_from(&fee_account_info.data.borrow())?;
+
+            // Account 5: Mailbox outbox PDA - read local_domain from mailbox.
+            let mailbox_outbox_account = next_account_info(accounts_iter)?;
+            let outbox =
+                Outbox::verify_account_and_fetch_inner(&token.mailbox, mailbox_outbox_account)?;
+            if fee_account_prefix.domain_id != outbox.local_domain {
+                return Err(Error::InvalidFeeAccountDomain.into());
+            }
         }
 
         ensure_no_extraneous_accounts(accounts_iter)?;

--- a/rust/sealevel/libraries/multisig-ism/src/multisig.rs
+++ b/rust/sealevel/libraries/multisig-ism/src/multisig.rs
@@ -32,6 +32,10 @@ impl<T: Signable> MultisigIsm<T> {
     /// ordering.
     /// Returns an error if the threshold is not met or if any of the signatures are invalid.
     pub fn verify(&self) -> Result<(), MultisigIsmError> {
+        if self.signatures.len() < self.threshold as usize {
+            return Err(MultisigIsmError::ThresholdNotMet);
+        }
+
         let signed_digest = self.signed_data.eth_signed_message_hash();
         let signed_digest_bytes = signed_digest.as_bytes();
 
@@ -177,6 +181,30 @@ mod test {
             TestSignedPayload(),
             // Sigs out of order
             vec![signature_1, signature_0],
+            vec![validator_0, validator_1],
+            2,
+        );
+
+        assert_eq!(
+            multisig_ism.verify().unwrap_err(),
+            MultisigIsmError::ThresholdNotMet
+        );
+    }
+
+    #[test]
+    fn test_multisig_ism_verify_fewer_signatures_than_threshold() {
+        let validator_0 = H160::from_str("0xfdB65576568b99A8a00a292577b8fc51abB115bD").unwrap();
+        let signature_0 = EcdsaSignature::from_bytes(
+            &hex::decode("4e561dcd350b7a271c7247843f7731a8a9810037c13784f5b3a9616788ca536976c5ff70b1865c4568e273a375851a5304dc7a1ac54f0783f3dde38d345313a91c").unwrap()[..]
+        ).unwrap();
+
+        let validator_1 = H160::from_str("0x5090cEd8BC5A7D3c2FbE2b2702eE4a8e7b227181").unwrap();
+
+        // Threshold of 2 but only one signature provided: must error, not panic
+        // when indexing signatures[1].
+        let multisig_ism = MultisigIsm::new(
+            TestSignedPayload(),
+            vec![signature_0],
             vec![validator_0, validator_1],
             2,
         );

--- a/rust/sealevel/libraries/quote-verifier/src/lib.rs
+++ b/rust/sealevel/libraries/quote-verifier/src/lib.rs
@@ -212,6 +212,14 @@ pub trait ValidatableQuote {
 
     /// Validates that the quote is still usable given the clock and min_issued_at threshold.
     /// Used at consumption time (cascade resolution).
+    ///
+    /// Deliberately does not require `now >= issued_at`. The on-chain
+    /// `Clock::unix_timestamp` drifts and can lag the signer's real clock, and
+    /// submission already bounds forward-dating to
+    /// `MAX_QUOTE_ISSUED_AT_FUTURE_SKEW_SECS`. A strict consume-time `now >= issued_at`
+    /// check would reject legitimate quotes whenever the on-chain clock trails
+    /// `issued_at` — most notably transient quotes submitted and consumed in the
+    /// same slot with a forward-skewed `issued_at`.
     fn validate_quote(
         &self,
         min_issued_at: i64,

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/accounts.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/accounts.rs
@@ -188,12 +188,12 @@ pub struct FeeAccount {
     pub owner: Option<Pubkey>,
     /// Beneficiary who receives collected token fees.
     pub beneficiary: Pubkey,
-    /// Fee resolution strategy with variant-specific signer configuration.
-    pub fee_data: FeeData,
     /// Hyperlane domain ID of the local chain (used in quote signature verification).
     pub domain_id: u32,
     /// Emergency revocation threshold: standing quotes with issued_at < min_issued_at are rejected.
     pub min_issued_at: i64,
+    /// Fee resolution strategy with variant-specific signer configuration.
+    pub fee_data: FeeData,
 }
 
 impl AccessControl for FeeAccount {
@@ -212,13 +212,15 @@ impl AccessControl for FeeAccount {
 pub struct FeeAccountPrefix {
     /// Beneficiary who receives collected fees.
     pub beneficiary: Pubkey,
+    /// Hyperlane domain ID of the local chain.
+    pub domain_id: u32,
 }
 
 impl FeeAccountPrefix {
-    /// Parses the beneficiary from raw fee account data by reading fields
-    /// sequentially with Borsh — no fixed offsets.
+    /// Parses the prefix fields from raw fee account data by reading fields
+    /// sequentially with Borsh - no fixed offsets.
     ///
-    /// On-disk layout: `[initialized (1)][discriminator (8)][bump (1)][owner (Option<Pubkey>)][beneficiary (Pubkey)]...`
+    /// On-disk layout: `[initialized (1)][discriminator (8)][bump (1)][owner (Option<Pubkey>)][beneficiary (Pubkey)][domain_id (u32)]...`
     pub fn parse_from(data: &[u8]) -> Result<Self, ProgramError> {
         // Verify initialized flag + discriminator, then skip past them.
         let prefix_len = 1 + FeeAccount::DISCRIMINATOR.len();
@@ -241,8 +243,13 @@ impl FeeAccountPrefix {
             .map_err(|_| ProgramError::InvalidAccountData)?;
         let beneficiary = Pubkey::deserialize_reader(&mut reader)
             .map_err(|_| ProgramError::InvalidAccountData)?;
+        let domain_id =
+            u32::deserialize_reader(&mut reader).map_err(|_| ProgramError::InvalidAccountData)?;
 
-        Ok(Self { beneficiary })
+        Ok(Self {
+            beneficiary,
+            domain_id,
+        })
     }
 }
 
@@ -260,9 +267,9 @@ impl SizedData for FeeAccount {
         std::mem::size_of::<u8>()                                                                   // bump
         + option_pubkey_size(&self.owner)                                                           // owner
         + PUBKEY_SIZE                                                                               // beneficiary
-        + SizedData::size(&self.fee_data)                                                           // fee_data
         + std::mem::size_of::<u32>()                                                                // domain_id
-        + std::mem::size_of::<i64>() // min_issued_at
+        + std::mem::size_of::<i64>()                                                                // min_issued_at
+        + SizedData::size(&self.fee_data) // fee_data
     }
 }
 

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/admin.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/admin.rs
@@ -109,6 +109,10 @@ pub(super) fn process_update_fee_params(
 
 /// Set the minimum issued_at threshold for standing quote validation (owner-only).
 ///
+/// This is the revocation control for signed quotes: advancing `min_issued_at`
+/// invalidates every quote issued at or before it. Quote expiry has no upper
+/// bound, so prefer short expiries to keep revocation windows bounded.
+///
 /// Accounts:
 /// 0. `[writable]` Fee account.
 /// 1. `[signer]` Owner.

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/init.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/src/processor/init.rs
@@ -65,9 +65,9 @@ pub(super) fn process_init_fee(
             bump_seed: fee_account_bump,
             owner: Some(*payer_info.key),
             beneficiary: data.beneficiary,
-            fee_data: data.fee_data,
             domain_id: data.domain_id,
             min_issued_at: 0,
+            fee_data: data.fee_data,
         }
         .into(),
     );

--- a/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-fee/tests/functional.rs
@@ -855,6 +855,7 @@ mod init_fee {
         let account = banks_client.get_account(fee_key).await.unwrap().unwrap();
         let prefix = FeeAccountPrefix::parse_from(&account.data).unwrap();
         assert_eq!(prefix.beneficiary, beneficiary);
+        assert_eq!(prefix.domain_id, LOCAL_DOMAIN);
     }
 
     #[tokio::test]

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/instruction.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/instruction.rs
@@ -83,6 +83,24 @@ pub enum SetIgpQuoteSignerOperation {
     Remove(H160),
 }
 
+impl SetIgpQuoteSignerOperation {
+    /// Static label for the operation, for config-change logs.
+    pub fn action_to_str(&self) -> &'static str {
+        match self {
+            SetIgpQuoteSignerOperation::Add(_) => "Added",
+            SetIgpQuoteSignerOperation::Remove(_) => "Removed",
+        }
+    }
+
+    /// The signer this operation adds or removes.
+    pub fn signer(&self) -> &H160 {
+        match self {
+            SetIgpQuoteSignerOperation::Add(signer)
+            | SetIgpQuoteSignerOperation::Remove(signer) => signer,
+        }
+    }
+}
+
 impl Instruction {
     /// Deserializes an instruction from a slice.
     pub fn from_instruction_data(data: &[u8]) -> Result<Self, ProgramError> {

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -942,6 +942,12 @@ fn set_gas_oracle_configs(
 
 /// Sets or removes the IGP quote configuration.
 ///
+/// `min_issued_at` is only guaranteed monotonic while the config stays present:
+/// clearing the config (Some -> None) and re-adding it (None -> Some) resets the
+/// revocation floor to the new config's `min_issued_at`, which may be lower than
+/// a previously-set floor. To revoke quotes, advance `min_issued_at` via
+/// SetIgpMinIssuedAt rather than removing and re-adding the config.
+///
 /// Accounts:
 /// 0. `[executable]` The system program.
 /// 1. `[writeable]` The IGP account.
@@ -1052,6 +1058,10 @@ fn set_igp_quote_signer(
 
 /// Sets the min_issued_at threshold on the IGP.
 /// Monotonic: new value must be >= current value.
+///
+/// This is the revocation control for IGP quotes: advancing `min_issued_at`
+/// invalidates every quote issued at or before it. Quote expiry has no upper
+/// bound, so prefer short expiries to keep revocation windows bounded.
 ///
 /// Accounts:
 /// 0. `[executable]` The system program.

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/src/processor.rs
@@ -974,6 +974,7 @@ fn set_igp_quote_config(
         }
     }
 
+    let new_min_issued_at = config.as_ref().map(|c| c.min_issued_at);
     igp.fee_config = config;
 
     let igp_account = IgpAccount::new(igp.into());
@@ -984,6 +985,10 @@ fn set_igp_quote_config(
         system_program_info,
     )?;
 
+    match new_min_issued_at {
+        Some(min) => msg!("Set IGP quote config (min_issued_at {})", min),
+        None => msg!("Cleared IGP quote config"),
+    }
     Ok(())
 }
 
@@ -1018,12 +1023,12 @@ fn set_igp_quote_signer(
         .as_mut()
         .ok_or(ProgramError::InvalidArgument)?;
 
-    match operation {
+    match &operation {
         SetIgpQuoteSignerOperation::Add(signer) => {
-            fee_config.signers.insert(signer);
+            fee_config.signers.insert(*signer);
         }
         SetIgpQuoteSignerOperation::Remove(signer) => {
-            if !fee_config.signers.remove(&signer) {
+            if !fee_config.signers.remove(signer) {
                 return Err(ProgramError::InvalidArgument);
             }
         }
@@ -1037,6 +1042,11 @@ fn set_igp_quote_signer(
         system_program_info,
     )?;
 
+    msg!(
+        "{} IGP quote signer: {:?}",
+        operation.action_to_str(),
+        operation.signer()
+    );
     Ok(())
 }
 
@@ -1086,6 +1096,7 @@ fn set_igp_min_issued_at(
         system_program_info,
     )?;
 
+    msg!("Set IGP min_issued_at: {}", min_issued_at);
     Ok(())
 }
 

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/tests/functional.rs
@@ -39,7 +39,7 @@ use hyperlane_sealevel_igp::{
 use hyperlane_sealevel_mailbox::{
     accounts::{DispatchedMessage, DispatchedMessageAccount},
     mailbox_dispatched_message_pda_seeds, mailbox_message_dispatch_authority_pda_seeds,
-    mailbox_process_authority_pda_seeds,
+    mailbox_outbox_pda_seeds, mailbox_process_authority_pda_seeds,
     protocol_fee::ProtocolFee,
 };
 use hyperlane_sealevel_message_recipient_interface::{
@@ -147,6 +147,10 @@ async fn setup_client() -> (BanksClient, Keypair) {
 
 fn fee_program_id() -> Pubkey {
     pubkey!("Fee1111111111111111111111111111111111111111")
+}
+
+fn mailbox_outbox() -> Pubkey {
+    Pubkey::find_program_address(mailbox_outbox_pda_seeds!(), &mailbox_id()).0
 }
 
 async fn initialize_mint(
@@ -1957,6 +1961,7 @@ async fn test_transfer_remote_with_fee_collateral() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -2229,6 +2234,7 @@ async fn test_transfer_remote_with_fee_routing_mode() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -2353,8 +2359,20 @@ async fn test_transfer_remote_with_fee_routing_mode() {
 #[tokio::test]
 async fn test_set_fee_config() {
     let program_id = hyperlane_sealevel_token_collateral_id();
+    let mailbox_program_id = mailbox_id();
     let spl_token_program_id = spl_token_2022::id();
     let (mut banks_client, payer) = setup_client().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &mailbox_program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        ONE_SOL_IN_LAMPORTS,
+        ProtocolFee::default(),
+    )
+    .await
+    .unwrap();
 
     let (mint, _mint_authority) = initialize_mint(
         &mut banks_client,
@@ -2438,6 +2456,7 @@ async fn test_set_fee_config() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_config.fee_program, false),
                     AccountMeta::new_readonly(fee_config.fee_account, false),
+                    AccountMeta::new_readonly(mailbox_accounts.outbox, false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -2776,6 +2795,7 @@ async fn setup_collateral_fee_test_context() -> CollateralFeeTestContext {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),

--- a/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-cross-collateral/tests/functional.rs
@@ -37,7 +37,7 @@ use hyperlane_sealevel_igp::{
 use hyperlane_sealevel_mailbox::{
     accounts::{DispatchedMessage, DispatchedMessageAccount},
     mailbox_dispatched_message_pda_seeds, mailbox_message_dispatch_authority_pda_seeds,
-    mailbox_process_authority_pda_seeds,
+    mailbox_outbox_pda_seeds, mailbox_process_authority_pda_seeds,
     protocol_fee::ProtocolFee,
 };
 use hyperlane_sealevel_message_recipient_interface::{
@@ -100,6 +100,10 @@ fn second_cc_program_id() -> Pubkey {
 
 fn fee_program_id() -> Pubkey {
     pubkey!("Fee1111111111111111111111111111111111111111")
+}
+
+fn mailbox_outbox() -> Pubkey {
+    Pubkey::find_program_address(mailbox_outbox_pda_seeds!(), &mailbox_id()).0
 }
 
 async fn setup_client() -> (BanksClient, Keypair) {
@@ -3486,6 +3490,7 @@ async fn test_cc_remote_transfer_with_fee() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -3729,6 +3734,7 @@ async fn test_cc_local_transfer_with_fee() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -3962,6 +3968,7 @@ async fn test_cc_remote_transfer_with_fee_routing_mode() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -4177,6 +4184,7 @@ async fn test_cc_remote_transfer_with_fee_cc_routing_mode() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -4449,6 +4457,7 @@ async fn test_cc_remote_transfer_with_default_router_transient_quote() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -4798,6 +4807,7 @@ async fn test_cc_remote_transfer_with_default_router_transient_rejected_when_spe
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -5079,6 +5089,7 @@ async fn test_set_fee_config() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_config.fee_program, false),
                     AccountMeta::new_readonly(fee_config.fee_account, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -5314,6 +5325,7 @@ async fn setup_cc_fee_test_context() -> CcFeeTestContext {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),
@@ -6685,6 +6697,7 @@ async fn test_cc_remote_transfer_igp_new_flow_with_fee() {
                     AccountMeta::new(ctx.payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&ctx.payer.pubkey()),

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/tests/functional.rs
@@ -43,7 +43,7 @@ use hyperlane_sealevel_igp::{
 use hyperlane_sealevel_mailbox::{
     accounts::{DispatchedMessage, DispatchedMessageAccount},
     mailbox_dispatched_message_pda_seeds, mailbox_message_dispatch_authority_pda_seeds,
-    mailbox_process_authority_pda_seeds,
+    mailbox_outbox_pda_seeds, mailbox_process_authority_pda_seeds,
     protocol_fee::ProtocolFee,
 };
 use hyperlane_sealevel_message_recipient_interface::{
@@ -142,6 +142,10 @@ async fn setup_client() -> (BanksClient, Keypair) {
 
 fn fee_program_id() -> Pubkey {
     pubkey!("Fee1111111111111111111111111111111111111111")
+}
+
+fn mailbox_outbox() -> Pubkey {
+    Pubkey::find_program_address(mailbox_outbox_pda_seeds!(), &mailbox_id()).0
 }
 
 struct HyperlaneTokenAccounts {
@@ -1378,7 +1382,19 @@ const FEE_HALF_AMOUNT: u64 = 500_000_000;
 #[tokio::test]
 async fn test_set_fee_config() {
     let program_id = hyperlane_sealevel_token_native_id();
+    let mailbox_program_id = mailbox_id();
     let (mut banks_client, payer) = setup_client().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &mailbox_program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        ONE_SOL_IN_LAMPORTS,
+        ProtocolFee::default(),
+    )
+    .await
+    .unwrap();
 
     let hyperlane_token_accounts =
         initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
@@ -1449,6 +1465,7 @@ async fn test_set_fee_config() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_config.fee_program, false),
                     AccountMeta::new_readonly(fee_config.fee_account, false),
+                    AccountMeta::new_readonly(mailbox_accounts.outbox, false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -1599,6 +1616,7 @@ async fn test_transfer_remote_with_fee_native() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -1867,6 +1885,7 @@ async fn test_transfer_remote_with_transient_quote_native() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -2190,6 +2209,7 @@ async fn setup_fee_test_context() -> FeeTestContext {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -2641,6 +2661,7 @@ async fn test_transfer_remote_with_fee_routing_mode() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -3267,6 +3288,7 @@ async fn test_transfer_remote_fully_transient_fee_and_igp_native() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),

--- a/rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/src/plugin.rs
@@ -351,7 +351,7 @@ impl HyperlaneSealevelTokenPlugin for SyntheticPlugin {
 
         // After potentially paying for the ATA creation, we need to make sure
         // the ATA payer still meets the rent-exemption requirements.
-        verify_rent_exempt(recipient_ata, &Rent::get()?)?;
+        verify_rent_exempt(ata_payer_account, &Rent::get()?)?;
 
         let mint_ixn = mint_to_checked(
             &spl_token_2022::id(),

--- a/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/tests/functional.rs
@@ -30,7 +30,7 @@ use hyperlane_sealevel_igp::{
 use hyperlane_sealevel_mailbox::{
     accounts::{DispatchedMessage, DispatchedMessageAccount},
     mailbox_dispatched_message_pda_seeds, mailbox_message_dispatch_authority_pda_seeds,
-    mailbox_process_authority_pda_seeds,
+    mailbox_outbox_pda_seeds, mailbox_process_authority_pda_seeds,
     protocol_fee::ProtocolFee,
 };
 use hyperlane_sealevel_message_recipient_interface::{
@@ -42,6 +42,7 @@ use hyperlane_sealevel_token::{
 };
 use hyperlane_sealevel_token_lib::{
     accounts::{convert_decimals, FeeConfig, HyperlaneToken, HyperlaneTokenAccount},
+    error::Error as TokenError,
     hyperlane_token_pda_seeds,
     instruction::{Init, Instruction as HyperlaneTokenInstruction, TransferRemote},
 };
@@ -146,6 +147,10 @@ async fn setup_client() -> (BanksClient, Keypair) {
 
 fn fee_program_id() -> Pubkey {
     pubkey!("Fee1111111111111111111111111111111111111111")
+}
+
+fn mailbox_outbox() -> Pubkey {
+    Pubkey::find_program_address(mailbox_outbox_pda_seeds!(), &mailbox_id()).0
 }
 
 struct HyperlaneTokenAccounts {
@@ -1515,6 +1520,7 @@ async fn test_transfer_remote_with_fee_synthetic() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -1781,6 +1787,7 @@ async fn test_transfer_remote_with_fee_routing_mode() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fp, false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -1910,7 +1917,19 @@ async fn test_transfer_remote_with_fee_routing_mode() {
 #[tokio::test]
 async fn test_set_fee_config() {
     let program_id = hyperlane_sealevel_token_id();
+    let mailbox_program_id = mailbox_id();
     let (mut banks_client, payer) = setup_client().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &mailbox_program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        ONE_SOL_IN_LAMPORTS,
+        ProtocolFee::default(),
+    )
+    .await
+    .unwrap();
 
     let hyperlane_token_accounts =
         initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
@@ -1980,6 +1999,7 @@ async fn test_set_fee_config() {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_config.fee_program, false),
                     AccountMeta::new_readonly(fee_config.fee_account, false),
+                    AccountMeta::new_readonly(mailbox_accounts.outbox, false),
                 ],
             )],
             Some(&payer.pubkey()),
@@ -2153,6 +2173,96 @@ async fn test_set_fee_config_wrong_fee_account_owner() {
     );
 }
 
+#[tokio::test]
+async fn test_set_fee_config_wrong_fee_account_domain_fails() {
+    let program_id = hyperlane_sealevel_token_id();
+    let mailbox_program_id = mailbox_id();
+    let (mut banks_client, payer) = setup_client().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &mailbox_program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        ONE_SOL_IN_LAMPORTS,
+        ProtocolFee::default(),
+    )
+    .await
+    .unwrap();
+
+    let hyperlane_token_accounts =
+        initialize_hyperlane_token(&program_id, &mut banks_client, &payer, None)
+            .await
+            .unwrap();
+
+    let fee_salt = H256::zero();
+    let fee_account_key = {
+        let fp = fee_program_id();
+        let (fee_account, _) = Pubkey::find_program_address(fee_account_pda_seeds!(fee_salt), &fp);
+        let ix = fee_instruction::init_fee_instruction(
+            fp,
+            payer.pubkey(),
+            fee_salt,
+            Pubkey::new_unique(),
+            FeeData::Leaf(LeafFeeConfig {
+                strategy: FeeDataStrategy::Linear(FeeParams {
+                    max_fee: FEE_MAX,
+                    half_amount: FEE_HALF_AMOUNT,
+                }),
+                signers: None,
+            }),
+            REMOTE_DOMAIN,
+        )
+        .unwrap();
+        let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+        banks_client
+            .process_transaction(Transaction::new_signed_with_payer(
+                &[ix],
+                Some(&payer.pubkey()),
+                &[&payer],
+                recent_blockhash,
+            ))
+            .await
+            .unwrap();
+        fee_account
+    };
+
+    let fee_config = FeeConfig {
+        fee_program: fee_program_id(),
+        fee_account: fee_account_key,
+    };
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let result = banks_client
+        .process_transaction(Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                program_id,
+                &HyperlaneTokenInstruction::SetFeeConfig(Some(fee_config.clone()))
+                    .encode()
+                    .unwrap(),
+                vec![
+                    AccountMeta::new_readonly(system_program::ID, false),
+                    AccountMeta::new(hyperlane_token_accounts.token, false),
+                    AccountMeta::new(payer.pubkey(), true),
+                    AccountMeta::new_readonly(fee_config.fee_program, false),
+                    AccountMeta::new_readonly(fee_config.fee_account, false),
+                    AccountMeta::new_readonly(mailbox_accounts.outbox, false),
+                ],
+            )],
+            Some(&payer.pubkey()),
+            &[&payer],
+            recent_blockhash,
+        ))
+        .await;
+
+    assert_transaction_error(
+        result,
+        TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(TokenError::InvalidFeeAccountDomain as u32),
+        ),
+    );
+}
+
 /// Shared setup for synthetic negative fee tests.
 struct SyntheticFeeTestContext {
     banks_client: BanksClient,
@@ -2268,6 +2378,7 @@ async fn setup_synthetic_fee_test_context() -> SyntheticFeeTestContext {
                     AccountMeta::new(payer.pubkey(), true),
                     AccountMeta::new_readonly(fee_program_id(), false),
                     AccountMeta::new_readonly(fee_account_key, false),
+                    AccountMeta::new_readonly(mailbox_outbox(), false),
                 ],
             )],
             Some(&payer.pubkey()),

--- a/rust/sealevel/programs/ism/composite-ism/src/accounts.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/accounts.rs
@@ -123,6 +123,23 @@ pub enum IsmNode {
     },
 }
 
+impl IsmNode {
+    /// Static label for the node variant, for concise config-change logs.
+    pub fn kind_to_str(&self) -> &'static str {
+        match self {
+            IsmNode::TrustedRelayer { .. } => "TrustedRelayer",
+            IsmNode::MultisigMessageId { .. } => "MultisigMessageId",
+            IsmNode::Aggregation { .. } => "Aggregation",
+            IsmNode::Test { .. } => "Test",
+            IsmNode::Pausable { .. } => "Pausable",
+            IsmNode::AmountRouting { .. } => "AmountRouting",
+            IsmNode::RateLimited { .. } => "RateLimited",
+            IsmNode::Routing => "Routing",
+            IsmNode::FallbackRouting { .. } => "FallbackRouting",
+        }
+    }
+}
+
 /// Data stored in the VAM PDA account (VERIFY_ACCOUNT_METAS_PDA_SEEDS).
 /// Contains the complete ISM config tree.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Default, PartialEq)]

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -134,7 +134,14 @@ fn verify(
         if !storage_info.is_writable {
             return Err(Error::DomainPdaNotWritable.into());
         }
-        CompositeIsmAccount::from(storage).store(storage_info, true)?;
+        // Realloc is disallowed here because `verify` has no payer account to
+        // fund a rent-exempt growth; an unfunded resize would fail closed with
+        // InsufficientFundsForRent (HLSVM-2026Q2-014). This is safe today because
+        // the only verify-time mutation is `RateLimited`, which updates
+        // fixed-size fields in place and never changes the serialized length.
+        // Any future growing mutation must instead route through
+        // `store_with_rent_exempt_realloc` with a payer.
+        CompositeIsmAccount::from(storage).store(storage_info, false)?;
     }
     Ok(())
 }

--- a/rust/sealevel/programs/ism/composite-ism/src/processor.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/processor.rs
@@ -13,6 +13,7 @@ use serializable_account_meta::SimulationReturnData;
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
+    msg,
     program::set_return_data,
     program_error::ProgramError,
     pubkey::Pubkey,
@@ -293,6 +294,7 @@ fn update_config(
 
     let mut storage = load_and_verify_storage(program_id, storage_pda_account)?;
     storage.ensure_owner_signer(owner_account)?;
+    msg!("Updated ISM root config: {}", root.kind_to_str());
     storage.root = Some(root);
 
     CompositeIsmAccount::from(*storage).store_with_rent_exempt_realloc(
@@ -342,6 +344,7 @@ fn set_domain_ism(
         return Err(Error::InvalidSystemProgram.into());
     }
 
+    msg!("Set domain {} ISM: {}", domain, ism.kind_to_str());
     let domain_storage = DomainIsmAccount::from(DomainIsmStorage {
         bump_seed: bump,
         domain,
@@ -403,6 +406,7 @@ fn remove_domain_ism(program_id: &Pubkey, accounts: &[AccountInfo], domain: u32)
 
     domain_pda_account.close_account(owner_account)?;
 
+    msg!("Removed domain {} ISM", domain);
     Ok(())
 }
 
@@ -427,9 +431,15 @@ fn transfer_ownership(
     let storage_pda_account = next_account_info(accounts_iter)?;
 
     let mut storage = load_and_verify_storage(program_id, storage_pda_account)?;
+    let old_owner = storage.owner;
     storage.transfer_ownership(owner_account, new_owner)?;
     CompositeIsmAccount::from(*storage).store(storage_pda_account, false)?;
 
+    msg!(
+        "Transferred ownership from {:?} to {:?}",
+        old_owner,
+        new_owner
+    );
     Ok(())
 }
 
@@ -681,6 +691,8 @@ fn set_paused(program_id: &Pubkey, accounts: &[AccountInfo], paused: bool) -> Pr
     }
 
     CompositeIsmAccount::from(*storage).store(storage_pda_account, false)?;
+
+    msg!("Set paused: {}", paused);
     Ok(())
 }
 

--- a/rust/sealevel/programs/ism/composite-ism/src/verify.rs
+++ b/rust/sealevel/programs/ism/composite-ism/src/verify.rs
@@ -46,16 +46,23 @@ where
             if contains_rate_limited(&ism) && !domain_pda_info.is_writable {
                 return Err(Error::DomainPdaNotWritable.into());
             }
-            let mut _did_mutate = false;
+            let mut did_mutate = false;
             verify_node(
                 &mut ism,
                 metadata,
                 message,
                 accounts_iter,
                 program_id,
-                &mut _did_mutate,
+                &mut did_mutate,
             )?;
-            if domain_pda_info.is_writable {
+            // Only rewrite the PDA when a node actually mutated state (i.e.
+            // `RateLimited`); this avoids a wasted re-serialize and account
+            // write on non-mutating verifies. A mutation requires a writable
+            // account, so error explicitly when it is missing.
+            if did_mutate {
+                if !domain_pda_info.is_writable {
+                    return Err(Error::DomainPdaNotWritable.into());
+                }
                 storage.ism = Some(ism);
                 DomainIsmAccount::from(storage).store(domain_pda_info, false)?;
             }

--- a/rust/sealevel/programs/mailbox-test/src/functional.rs
+++ b/rust/sealevel/programs/mailbox-test/src/functional.rs
@@ -1465,3 +1465,83 @@ async fn test_get_program_version() {
         .expect("failed to deserialize");
     assert_eq!(result.return_data, package_versioned::PACKAGE_VERSION);
 }
+
+#[tokio::test]
+async fn test_outbox_get_latest_checkpoint() {
+    use serializable_account_meta::SimulationReturnData;
+
+    let program_id = mailbox_id();
+    let (mut banks_client, payer, _, _) = setup_client().await;
+
+    let mailbox_accounts = initialize_mailbox(
+        &mut banks_client,
+        &program_id,
+        &payer,
+        LOCAL_DOMAIN,
+        MAX_PROTOCOL_FEE,
+        test_protocol_fee_config(),
+    )
+    .await
+    .unwrap();
+
+    // Dispatch a message so the outbox tree holds a real, non-default root.
+    let recipient = H256::random();
+    let message_body = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    dispatch_from_payer(
+        &mut banks_client,
+        &payer,
+        &mailbox_accounts,
+        OutboxDispatch {
+            sender: payer.pubkey(),
+            destination_domain: REMOTE_DOMAIN,
+            recipient,
+            message_body: message_body.clone(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let dispatched_message = HyperlaneMessage {
+        version: 3,
+        nonce: 0,
+        origin: LOCAL_DOMAIN,
+        sender: payer.pubkey().to_bytes().into(),
+        destination: REMOTE_DOMAIN,
+        recipient,
+        body: message_body,
+    };
+    let mut expected_tree = MerkleTree::default();
+    expected_tree.ingest(dispatched_message.id());
+
+    let ix = Instruction::new_with_borsh(
+        program_id,
+        &MailboxInstruction::OutboxGetLatestCheckpoint,
+        vec![AccountMeta::new_readonly(mailbox_accounts.outbox, false)],
+    );
+
+    let recent_blockhash = banks_client.get_latest_blockhash().await.unwrap();
+    let simulation = banks_client
+        .simulate_transaction(Transaction::new_unsigned(Message::new_with_blockhash(
+            &[ix],
+            Some(&payer.pubkey()),
+            &recent_blockhash,
+        )))
+        .await
+        .unwrap();
+
+    // Regression: the getter copied the 32-byte root into a 31-byte slice,
+    // panicking before any return data was set.
+    assert!(simulation.result.unwrap().is_ok());
+
+    let return_data = simulation
+        .simulation_details
+        .unwrap()
+        .return_data
+        .expect("no return data");
+    let result = SimulationReturnData::<Vec<u8>>::try_from_slice(&return_data.data)
+        .expect("failed to deserialize");
+
+    assert_eq!(result.return_data.len(), 36);
+    assert_eq!(&result.return_data[0..32], expected_tree.root().as_ref());
+    assert_eq!(&result.return_data[32..36], &1u32.to_le_bytes());
+}

--- a/rust/sealevel/programs/mailbox/src/processor.rs
+++ b/rust/sealevel/programs/mailbox/src/processor.rs
@@ -804,7 +804,7 @@ fn outbox_get_latest_checkpoint(program_id: &Pubkey, accounts: &[AccountInfo]) -
         .expect("Too many messages in outbox tree");
 
     let mut ret_buf = [0; 36];
-    ret_buf[0..31].copy_from_slice(root.as_ref());
+    ret_buf[0..32].copy_from_slice(root.as_ref());
     ret_buf[32..].copy_from_slice(&count.to_le_bytes());
 
     // Wrap it in the SimulationReturnData because serialized ret_buf


### PR DESCRIPTION
### Description

Addresses the minor suggestions from Chainlight audit finding **HLSVM-2026Q2-014** ("Minor Suggestions", Informational), plus the `set_fee_config` domain-binding fix. Each suggestion is its own commit.

**Panics / input guards**
- Correct `outbox_get_latest_checkpoint` root slice (`ret_buf[0..31]` → `[0..32]`) — a latent panic in the on-chain getter; adds a getter test.
- Reject `< 8` byte input in `DiscriminatorDecode::decode` before `split_at` (was a panic).
- Guard `MultisigIsm::verify` against fewer signatures than threshold (was an index-out-of-bounds panic in the standalone verifier).
- Rent-check the `ata_payer` PDA (not the freshly-created recipient ATA) in the synthetic `transfer_out`, matching the collateral plugin.

**Composite-ISM**
- Persist the ISM tree at verify time with `store(false)` — no unfunded realloc / `InsufficientFundsForRent` DoS.
- Gate the domain-ISM write-back on `did_mutate` instead of `is_writable`, avoiding a wasteful re-serialize on non-mutating verifies.

**Missing events**
- Log composite-ISM owner config changes (root/domain/pause/ownership).
- Log IGP quote config, signer, and `min_issued_at` updates.
- Log `set_fee_config` old → new fee config.

**Signature hardening**
- Enforce low-S in `EcdsaSignature::from_bytes` (reject `s > n/2`), eliminating the malleable `(r, n − s, v ^ 1)` second encoding for every caller of the shared library.

**Fee-account domain binding**
- `set_fee_config` now verifies the adopted fee account's `domain_id` equals the token's `local_domain` (read from the mailbox Outbox, itself verified against the trusted `token.mailbox`), closing a cross-chain quote-replay path since `domain_id` is part of the quote signature hash.

**Docs-only** (behavioral guards were unsafe or need persisted state under SVM constraints)
- Documented why `validate_quote` intentionally omits a consume-time `now >= issued_at` check (SVM `Clock` drift; submission already bounds forward-dating).
- Documented `SetMinIssuedAt` / `SetIgpMinIssuedAt` as the revocation control and the `None → Some` IGP re-add floor-reset caveat.

### Drive-by changes

- `FeeAccount` moves the variable-length `fee_data` to the last field so `FeeAccountPrefix` can read `domain_id` without deserializing `fee_data`. **This is a storage-layout change**, safe only while the fee program is unreleased (see Backward compatibility).
- Added `IsmNode::kind_to_str` and `SetIgpQuoteSignerOperation::{action_to_str, signer}` helpers for concise, correct config-change logs.

### Related issues

- Addresses Chainlight audit **HLSVM-2026Q2-014**: https://github.com/chainlight-io/2026-q2-hyperlane-svm-issues/issues/11

Deliberately **excluded** (owned by dedicated audit-issue PRs or deferred):
- CC remote-release local-origin (HLSVM-001, #8948), stale trailing-byte tolerance (HLSVM-010, #8946), IGP dispatch-authority (HLSVM-008, #8952).
- Quoted-IGP PayForGas sender-binding (#10) — the dedicated `igp_quote_authority` seeds in #8952 already block the unbacked-message vector; residual not worth an interface change here.
- Beneficiary-ATA idempotent creation — handled by off-chain tooling.
- `Test` `IsmNode` variant removal — acknowledged owner-gated informational residual risk.

### Backward compatibility

**Yes for released code; one unreleased-only storage change.**
- The `FeeAccount` field reorder is a breaking on-chain storage-layout change, but the fee program is **unreleased** (no `declare_id`, no mainnet config, no off-chain decoder) so there are no persisted accounts to migrate. Must not land after any fee account is deployed.
- The low-S check tightens signature acceptance, but every production signer emits canonical low-S (`LocalWallet` k256 RFC6979, `AwsSigner` `normalize_s`), so no live signature is rejected.
- Follow-up before merge: regenerate `typescript/svm-sdk/src/hyperlane/program-bytes.ts` from the rebuilt fee/token `.so` (CI-gated by `SEALEVEL_SOURCE_HASH`).

### Testing

Unit + functional tests per affected crate (mailbox, account-utils, multisig-ism, ecdsa-signature, composite-ism, IGP, fee, all four token programs); each fix-with-test commit was red/green verified by temporarily reverting the fix. Full `cargo build`/`clippy` on the sealevel workspace is clean. A multi-agent security review of the diff (crypto/constants, behavioral changes, cross-language decoders, test correctness) found no new issues.
