### PR TITLE
feat(core): decimal-aware TVL rate limiting

### DIFF
--- a/.changeset/rate-limit-decimal-aware.md
+++ b/.changeset/rate-limit-decimal-aware.md
@@ -1,0 +1,6 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+- TVL rate limiters now meter cross-chain transfers in local token units. `NetFlowRateLimitedHookIsm` and `DelayedFlowRouter` convert the message (wire) amount to local units via `TvlRateLimited._toLocalAmount` — mirroring `TokenRouter._inboundAmount` (`mulDiv`, round down) — before consuming or crediting the bucket.
+- This makes limiters correct for routes whose local decimals differ from the wire format (`scaleNumerator != scaleDenominator`); the amount metered now matches the collateral the router actually moves. `DelayedFlowRouter` carries the wire amount cross-chain and converts on each side, so origin and destination meter with their own router's scale.

--- a/solidity/contracts/hooks/warp-route/NetFlowRateLimitedHookIsm.sol
+++ b/solidity/contracts/hooks/warp-route/NetFlowRateLimitedHookIsm.sol
@@ -26,7 +26,7 @@ import {TokenRouter} from "../../token/libs/TokenRouter.sol";
  * consume on deliver).
  *
  * @dev Use only for routes where `token()`'s balance at the router is the live
- * TVL AND the wire<->local conversion is `TokenRouter`'s fixed `scale` fraction
+ * TVL AND the message<->local conversion is `TokenRouter`'s fixed `scale`
  * (what `_toLocalAmount` reproduces to meter the message amount in local
  * units): HypERC20, HypERC20Collateral, HypNative. Do NOT use for:
  *   - HypXERC20 / HypXERC20Lockbox / HypFiatToken / HypERC4626Collateral —

--- a/solidity/contracts/hooks/warp-route/NetFlowRateLimitedHookIsm.sol
+++ b/solidity/contracts/hooks/warp-route/NetFlowRateLimitedHookIsm.sol
@@ -25,13 +25,18 @@ import {TokenRouter} from "../../token/libs/TokenRouter.sol";
  * on dispatch); otherwise it is collateral (outbound moves balance out →
  * consume on deliver).
  *
- * @dev Use for routes where `_message.body().amount()` is denominated in the
- * same units as `localCollateral()` AND `token()`'s balance at the router is
- * the live TVL: HypERC20, HypERC20Collateral, HypNative. Do NOT use for
- * HypXERC20 / HypXERC20Lockbox / HypFiatToken (they mint/burn an external
- * token) or HypERC4626Collateral (it deposits collateral into a vault and
- * holds shares) — in all of these `token()`'s `balanceOf(router) == 0`, so
- * capacity collapses to zero and the route bricks.
+ * @dev Use only for routes where `token()`'s balance at the router is the live
+ * TVL AND the wire<->local conversion is `TokenRouter`'s fixed `scale` fraction
+ * (what `_toLocalAmount` reproduces to meter the message amount in local
+ * units): HypERC20, HypERC20Collateral, HypNative. Do NOT use for:
+ *   - HypXERC20 / HypXERC20Lockbox / HypFiatToken / HypERC4626Collateral —
+ *     `token()`'s `balanceOf(router) == 0` (they mint/burn an external token or
+ *     hold vault shares), so capacity collapses to zero and the route bricks.
+ *   - HypERC4626 (synthetic, rebasing) — `token() == router` gives a *nonzero*
+ *     capacity (so the zero-capacity check above does NOT catch it), but it
+ *     scales by exchange rate rather than the fixed `scale` fraction, so
+ *     `_toLocalAmount` meters the wrong units (message shares vs
+ *     asset-denominated TVL).
  *
  * @dev This contract authenticates flow only, NOT message authenticity
  * (`moduleType()` is NULL). Deployers MUST compose it under an authenticating
@@ -152,7 +157,7 @@ contract NetFlowRateLimitedHookIsm is
             revert InvalidDeliveredMessage(_message.id());
         }
 
-        uint256 amount = _message.body().amount();
+        uint256 amount = _toLocalAmount(_message.body().amount());
         if (outboundFlow == FlowDirection.CREDIT) {
             _validateAndConsumeFilledLevel(amount);
         } else {
@@ -180,7 +185,7 @@ contract NetFlowRateLimitedHookIsm is
             revert InvalidDispatchedMessage(messageId);
         }
 
-        uint256 amount = _message.body().amount();
+        uint256 amount = _toLocalAmount(_message.body().amount());
         if (outboundFlow == FlowDirection.CONSUME) {
             _validateAndConsumeFilledLevel(amount);
         } else {

--- a/solidity/contracts/isms/warp-route/DelayedFlowRouter.sol
+++ b/solidity/contracts/isms/warp-route/DelayedFlowRouter.sol
@@ -114,16 +114,19 @@ contract DelayedFlowRouter is TimelockRouter, TvlRateLimited {
         // `TokenMessage` slices `body[32:64]` for `amount`. Safe here: the
         // parent asserted `_isLatestDispatched` before invoking this hook, and
         // the sender binding above only passes for messages formatted by
-        // `warpRouter`, which only ever formats valid token messages.
-        uint256 amount = message.body().amount();
+        // `warpRouter`, which only ever formats valid token messages. Metered
+        // in this router's local units (the message carries the wire amount).
+        uint256 amount = _toLocalAmount(message.body().amount());
         _credit(amount);
         emit NetFlowCredited(message.id(), messageNonce, amount);
     }
 
-    /// @dev Carries `(id, amount)` so the destination can size the delay
-    /// against its current bucket. Shared by `postDispatch` and
-    /// `quoteDispatch` via the parent, so the quote can never drift from the
-    /// dispatched payload.
+    /// @dev Carries `(id, wireAmount)` so the destination can size the delay
+    /// against its current bucket. The wire (message) amount is carried as-is
+    /// and converted to local units on each side (`_toLocalAmount`), so origin
+    /// and destination each meter using their own router's scale. Shared by
+    /// `postDispatch` and `quoteDispatch` via the parent, so the quote can
+    /// never drift from the dispatched payload.
     function _encodePayload(
         bytes calldata message
     ) internal view override returns (bytes memory) {
@@ -153,8 +156,11 @@ contract DelayedFlowRouter is TimelockRouter, TvlRateLimited {
         bytes32 /*_sender*/,
         bytes calldata payload
     ) internal override {
-        (bytes32 id, uint256 amount) = abi.decode(payload, (bytes32, uint256));
-        uint256 deficitSecs = _consume(amount);
+        (bytes32 id, uint256 wireAmount) = abi.decode(
+            payload,
+            (bytes32, uint256)
+        );
+        uint256 deficitSecs = _consume(_toLocalAmount(wireAmount));
         uint48 wait = deficitSecs > maxDelay ? maxDelay : uint48(deficitSecs);
         _TimelockRouter_commitReadyAt(id, wait);
     }

--- a/solidity/contracts/isms/warp-route/DelayedFlowRouter.sol
+++ b/solidity/contracts/isms/warp-route/DelayedFlowRouter.sol
@@ -115,15 +115,15 @@ contract DelayedFlowRouter is TimelockRouter, TvlRateLimited {
         // parent asserted `_isLatestDispatched` before invoking this hook, and
         // the sender binding above only passes for messages formatted by
         // `warpRouter`, which only ever formats valid token messages. Metered
-        // in this router's local units (the message carries the wire amount).
+        // in this router's local units (converted from the message amount).
         uint256 amount = _toLocalAmount(message.body().amount());
         _credit(amount);
         emit NetFlowCredited(message.id(), messageNonce, amount);
     }
 
-    /// @dev Carries `(id, wireAmount)` so the destination can size the delay
-    /// against its current bucket. The wire (message) amount is carried as-is
-    /// and converted to local units on each side (`_toLocalAmount`), so origin
+    /// @dev Carries `(id, messageAmount)` so the destination can size the delay
+    /// against its current bucket. The message amount is carried as-is and
+    /// converted to local units on each side (`_toLocalAmount`), so origin
     /// and destination each meter using their own router's scale. Shared by
     /// `postDispatch` and `quoteDispatch` via the parent, so the quote can
     /// never drift from the dispatched payload.
@@ -156,11 +156,11 @@ contract DelayedFlowRouter is TimelockRouter, TvlRateLimited {
         bytes32 /*_sender*/,
         bytes calldata payload
     ) internal override {
-        (bytes32 id, uint256 wireAmount) = abi.decode(
+        (bytes32 id, uint256 messageAmount) = abi.decode(
             payload,
             (bytes32, uint256)
         );
-        uint256 deficitSecs = _consume(_toLocalAmount(wireAmount));
+        uint256 deficitSecs = _consume(_toLocalAmount(messageAmount));
         uint48 wait = deficitSecs > maxDelay ? maxDelay : uint48(deficitSecs);
         _TimelockRouter_commitReadyAt(id, wait);
     }

--- a/solidity/contracts/isms/warp-route/DelayedFlowRouter.sol
+++ b/solidity/contracts/isms/warp-route/DelayedFlowRouter.sol
@@ -117,8 +117,9 @@ contract DelayedFlowRouter is TimelockRouter, TvlRateLimited {
         // `warpRouter`, which only ever formats valid token messages. Metered
         // in this router's local units (converted from the message amount).
         uint256 amount = _toLocalAmount(message.body().amount());
+        bytes32 messageId = message.id();
         _credit(amount);
-        emit NetFlowCredited(message.id(), messageNonce, amount);
+        emit NetFlowCredited(messageId, messageNonce, amount);
     }
 
     /// @dev Carries `(id, messageAmount)` so the destination can size the delay

--- a/solidity/contracts/libs/RateLimited.sol
+++ b/solidity/contracts/libs/RateLimited.sol
@@ -15,6 +15,7 @@ pragma solidity >=0.8.0;
 
 // ============ External Imports ============
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title RateLimited
@@ -184,7 +185,7 @@ contract RateLimited is OwnableUpgradeable {
             filledLevel = 0;
             deficitSecs = cap == 0
                 ? type(uint256).max
-                : ((_amount - level) * DURATION) / cap;
+                : Math.mulDiv(_amount - level, DURATION, cap);
         }
         lastUpdated = block.timestamp;
         _RateLimited_initialize();

--- a/solidity/contracts/libs/TvlRateLimited.sol
+++ b/solidity/contracts/libs/TvlRateLimited.sol
@@ -16,6 +16,7 @@ pragma solidity >=0.8.0;
 // ============ External Imports ============
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 // ============ Internal Imports ============
 import {RateLimited} from "./RateLimited.sol";
@@ -45,6 +46,7 @@ import {TokenRouter} from "../token/libs/TokenRouter.sol";
  */
 abstract contract TvlRateLimited is RateLimited {
     using StorageSlot for bytes32;
+    using Math for uint256;
 
     // ============ Errors ============
     error InvalidRouter();
@@ -121,6 +123,24 @@ abstract contract TvlRateLimited is RateLimited {
     /// derives the refill rate from this, so no additional override is needed.
     function maxCapacity() public view override returns (uint256) {
         return (localCollateral() * thresholdBps) / BPS_DENOMINATOR;
+    }
+
+    /// @notice Converts a message (wire) amount to local token units so it is
+    /// commensurate with the bucket, which is denominated in `localCollateral()`
+    /// units.
+    /// @dev Mirrors `TokenRouter._inboundAmount` for fixed-scale routes (the
+    /// only supported ones) — same `mulDiv` and rounding — so the metered
+    /// amount matches the collateral the router actually moves.
+    function _toLocalAmount(
+        uint256 _wireAmount
+    ) internal view returns (uint256) {
+        TokenRouter router = TokenRouter(warpRouter);
+        return
+            _wireAmount.mulDiv(
+                router.scaleDenominator(),
+                router.scaleNumerator(),
+                Math.Rounding.Down
+            );
     }
 
     /// @inheritdoc RateLimited

--- a/solidity/contracts/libs/TvlRateLimited.sol
+++ b/solidity/contracts/libs/TvlRateLimited.sol
@@ -125,18 +125,18 @@ abstract contract TvlRateLimited is RateLimited {
         return (localCollateral() * thresholdBps) / BPS_DENOMINATOR;
     }
 
-    /// @notice Converts a message (wire) amount to local token units so it is
+    /// @notice Converts a message amount to local token units so it is
     /// commensurate with the bucket, which is denominated in `localCollateral()`
     /// units.
     /// @dev Mirrors `TokenRouter._inboundAmount` for fixed-scale routes (the
     /// only supported ones) — same `mulDiv` and rounding — so the metered
     /// amount matches the collateral the router actually moves.
     function _toLocalAmount(
-        uint256 _wireAmount
+        uint256 _messageAmount
     ) internal view returns (uint256) {
         TokenRouter router = TokenRouter(warpRouter);
         return
-            _wireAmount.mulDiv(
+            _messageAmount.mulDiv(
                 router.scaleDenominator(),
                 router.scaleNumerator(),
                 Math.Rounding.Down

--- a/solidity/test/hooks/NetFlowRateLimitedHookIsm.t.sol
+++ b/solidity/test/hooks/NetFlowRateLimitedHookIsm.t.sol
@@ -380,15 +380,15 @@ contract NetFlowRateLimitedHookIsmTest is Test {
         assertEq(vaultNetFlow.maxCapacity(), 0);
     }
 
-    /// @dev The bucket is denominated in local units but the message carries a
-    /// wire amount. For any scale, NetFlow must meter — and the route must move
-    /// — the local equivalent (`wire * scaleDenominator / scaleNumerator`), not
-    /// the raw wire amount. Asserts the bucket consumption equals the collateral
-    /// the router actually releases.
+    /// @dev The bucket meters in the token's local units, but a message amount
+    /// is in the route's scaled units. NetFlow must convert by the router's
+    /// scale before metering (a no-op only when scaleNumerator ==
+    /// scaleDenominator). Asserts the bucket consumption equals the collateral
+    /// the router releases.
     function testFuzz_metersLocalUnits_forAnyScale(
         uint256 scaleNumerator,
         uint256 scaleDenominator,
-        uint256 wireAmount
+        uint256 messageAmount
     ) external {
         scaleNumerator = bound(scaleNumerator, 1, 1e12);
         scaleDenominator = bound(scaleDenominator, 1, 1e12);
@@ -421,16 +421,20 @@ contract NetFlowRateLimitedHookIsmTest is Test {
         // revert (over-capacity is covered elsewhere). Bounds guarantee no
         // intermediate overflow, so raw arithmetic matches the contract's
         // mulDiv(Rounding.Down).
-        uint256 maxWire = (cap * scaleNumerator) / scaleDenominator;
-        wireAmount = bound(wireAmount, 0, maxWire);
-        uint256 expectedLocal = (wireAmount * scaleDenominator) /
+        uint256 maxMessage = (cap * scaleNumerator) / scaleDenominator;
+        messageAmount = bound(messageAmount, 0, maxMessage);
+        uint256 expectedLocal = (messageAmount * scaleDenominator) /
             scaleNumerator;
 
         bytes memory message = localMailbox.buildInboundMessage(
             ORIGIN,
             address(scaledRouter).addressToBytes32(),
             address(remoteRouter).addressToBytes32(),
-            TokenMessage.format(BOB.addressToBytes32(), wireAmount, bytes(""))
+            TokenMessage.format(
+                BOB.addressToBytes32(),
+                messageAmount,
+                bytes("")
+            )
         );
         localMailbox.process(bytes(""), message);
 
@@ -446,7 +450,7 @@ contract NetFlowRateLimitedHookIsmTest is Test {
     function testFuzz_outboundMetersLocalUnits_forAnyScale(
         uint256 scaleNumerator,
         uint256 scaleDenominator,
-        uint256 wireAmount
+        uint256 messageAmount
     ) external {
         scaleNumerator = bound(scaleNumerator, 1, 1e12);
         scaleDenominator = bound(scaleDenominator, 1, 1e12);
@@ -472,8 +476,8 @@ contract NetFlowRateLimitedHookIsmTest is Test {
         );
 
         uint256 cap = scaledNetFlow.maxCapacity(); // 10% of supply
-        wireAmount = bound(
-            wireAmount,
+        messageAmount = bound(
+            messageAmount,
             0,
             (cap * scaleNumerator) / scaleDenominator
         );
@@ -485,7 +489,7 @@ contract NetFlowRateLimitedHookIsmTest is Test {
                 address(remoteRouter).addressToBytes32(),
                 TokenMessage.format(
                     BOB.addressToBytes32(),
-                    wireAmount,
+                    messageAmount,
                     bytes("")
                 )
             );
@@ -496,7 +500,7 @@ contract NetFlowRateLimitedHookIsmTest is Test {
         // Synthetic route → outbound consumes; metered in local units.
         assertEq(
             cap - scaledNetFlow.calculateCurrentLevel(),
-            (wireAmount * scaleDenominator) / scaleNumerator
+            (messageAmount * scaleDenominator) / scaleNumerator
         );
     }
 

--- a/solidity/test/hooks/NetFlowRateLimitedHookIsm.t.sol
+++ b/solidity/test/hooks/NetFlowRateLimitedHookIsm.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT or Apache-2.0
 pragma solidity ^0.8.13;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, StdStorage, stdStorage} from "forge-std/Test.sol";
 
 import {ERC20Test} from "contracts/test/ERC20Test.sol";
 import {HypERC20Collateral} from "contracts/token/HypERC20Collateral.sol";
 import {HypERC20} from "contracts/token/HypERC20.sol";
 import {HypNative} from "contracts/token/HypNative.sol";
 import {HypERC4626Collateral} from "contracts/token/extensions/HypERC4626Collateral.sol";
+import {HypERC4626} from "contracts/token/extensions/HypERC4626.sol";
 import {ERC4626Test} from "contracts/test/ERC4626/ERC4626Test.sol";
 import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {NetFlowRateLimitedHookIsm} from "contracts/hooks/warp-route/NetFlowRateLimitedHookIsm.sol";
@@ -23,6 +24,7 @@ import {TypeCasts} from "contracts/libs/TypeCasts.sol";
 contract NetFlowRateLimitedHookIsmTest is Test {
     using TypeCasts for address;
     using Message for bytes;
+    using stdStorage for StdStorage;
 
     uint32 constant ORIGIN = 11;
     uint32 constant DESTINATION = 12;
@@ -376,6 +378,156 @@ contract NetFlowRateLimitedHookIsmTest is Test {
         assertEq(token.balanceOf(address(vaultRouter)), 0);
         assertEq(vaultNetFlow.localCollateral(), 0);
         assertEq(vaultNetFlow.maxCapacity(), 0);
+    }
+
+    /// @dev The bucket is denominated in local units but the message carries a
+    /// wire amount. For any scale, NetFlow must meter — and the route must move
+    /// — the local equivalent (`wire * scaleDenominator / scaleNumerator`), not
+    /// the raw wire amount. Asserts the bucket consumption equals the collateral
+    /// the router actually releases.
+    function testFuzz_metersLocalUnits_forAnyScale(
+        uint256 scaleNumerator,
+        uint256 scaleDenominator,
+        uint256 wireAmount
+    ) external {
+        scaleNumerator = bound(scaleNumerator, 1, 1e12);
+        scaleDenominator = bound(scaleDenominator, 1, 1e12);
+
+        HypERC20Collateral scaledRouter = new HypERC20Collateral(
+            address(token),
+            scaleNumerator,
+            scaleDenominator,
+            address(localMailbox)
+        );
+        NetFlowRateLimitedHookIsm scaledNetFlow = new NetFlowRateLimitedHookIsm(
+            address(localMailbox),
+            address(scaledRouter),
+            MAX_FLOW_BPS
+        );
+        scaledRouter.initialize(
+            address(scaledNetFlow),
+            address(scaledNetFlow),
+            address(this)
+        );
+        scaledRouter.enrollRemoteRouter(
+            ORIGIN,
+            address(remoteRouter).addressToBytes32()
+        );
+        token.mintTo(address(scaledRouter), INITIAL_COLLATERAL);
+
+        uint256 cap = scaledNetFlow.maxCapacity(); // 10% of local TVL
+
+        // Keep the local equivalent within capacity so the consume doesn't
+        // revert (over-capacity is covered elsewhere). Bounds guarantee no
+        // intermediate overflow, so raw arithmetic matches the contract's
+        // mulDiv(Rounding.Down).
+        uint256 maxWire = (cap * scaleNumerator) / scaleDenominator;
+        wireAmount = bound(wireAmount, 0, maxWire);
+        uint256 expectedLocal = (wireAmount * scaleDenominator) /
+            scaleNumerator;
+
+        bytes memory message = localMailbox.buildInboundMessage(
+            ORIGIN,
+            address(scaledRouter).addressToBytes32(),
+            address(remoteRouter).addressToBytes32(),
+            TokenMessage.format(BOB.addressToBytes32(), wireAmount, bytes(""))
+        );
+        localMailbox.process(bytes(""), message);
+
+        // Metered exactly the local amount the router released.
+        assertEq(token.balanceOf(BOB), expectedLocal);
+        assertEq(cap - scaledNetFlow.calculateCurrentLevel(), expectedLocal);
+    }
+
+    /// @dev The outbound path (`_postDispatch`) must also meter local units.
+    /// Uses a scaled synthetic route (outbound consumes) driven via a direct
+    /// postDispatch, so TVL/capacity stay fixed and the consumption is
+    /// observable from a full bucket.
+    function testFuzz_outboundMetersLocalUnits_forAnyScale(
+        uint256 scaleNumerator,
+        uint256 scaleDenominator,
+        uint256 wireAmount
+    ) external {
+        scaleNumerator = bound(scaleNumerator, 1, 1e12);
+        scaleDenominator = bound(scaleDenominator, 1, 1e12);
+
+        HypERC20 scaledRouter = new HypERC20(
+            DECIMALS,
+            scaleNumerator,
+            scaleDenominator,
+            address(localMailbox)
+        );
+        NetFlowRateLimitedHookIsm scaledNetFlow = new NetFlowRateLimitedHookIsm(
+            address(localMailbox),
+            address(scaledRouter),
+            MAX_FLOW_BPS
+        );
+        scaledRouter.initialize(
+            INITIAL_COLLATERAL,
+            "S",
+            "S",
+            address(scaledNetFlow),
+            address(scaledNetFlow),
+            address(this)
+        );
+
+        uint256 cap = scaledNetFlow.maxCapacity(); // 10% of supply
+        wireAmount = bound(
+            wireAmount,
+            0,
+            (cap * scaleNumerator) / scaleDenominator
+        );
+
+        {
+            vm.prank(address(scaledRouter));
+            bytes memory message = localMailbox.buildOutboundMessage(
+                ORIGIN,
+                address(remoteRouter).addressToBytes32(),
+                TokenMessage.format(
+                    BOB.addressToBytes32(),
+                    wireAmount,
+                    bytes("")
+                )
+            );
+            localMailbox.updateLatestDispatchedId(message.id());
+            scaledNetFlow.postDispatch(bytes(""), message);
+        }
+
+        // Synthetic route → outbound consumes; metered in local units.
+        assertEq(
+            cap - scaledNetFlow.calculateCurrentLevel(),
+            (wireAmount * scaleDenominator) / scaleNumerator
+        );
+    }
+
+    /// @dev HypERC4626 (synthetic, rebasing) is `token() == router`, so it has
+    /// nonzero capacity and is NOT caught by the zero-capacity exclusion — yet
+    /// it scales by exchange rate, which `_toLocalAmount`'s fixed scale ignores.
+    /// Documents why it is unsupported.
+    function test_hypERC4626Synthetic_scalesByExchangeRate() external {
+        HypERC4626 rebasing = new HypERC4626(
+            DECIMALS,
+            SCALE,
+            SCALE,
+            address(localMailbox),
+            ORIGIN
+        );
+        stdstore.target(address(rebasing)).sig("exchangeRate()").checked_write(
+            uint256(2e10) // 1 share == 2 assets
+        );
+
+        NetFlowRateLimitedHookIsm rebasingNetFlow = new NetFlowRateLimitedHookIsm(
+                address(localMailbox),
+                address(rebasing),
+                MAX_FLOW_BPS
+            );
+
+        // Synthetic (nonzero capacity) → zero-capacity exclusion misses it.
+        assertEq(rebasingNetFlow.capacityToken(), address(rebasing));
+
+        // Messages meter shares while TVL (totalSupply) is in assets; the fixed
+        // scale in `_toLocalAmount` cannot reconcile the exchange rate.
+        assertEq(rebasing.sharesToAssets(1e18), 2e18);
     }
 
     function _processInbound(uint256 amount) internal {

--- a/solidity/test/isms/DelayedFlowRouter.t.sol
+++ b/solidity/test/isms/DelayedFlowRouter.t.sol
@@ -246,6 +246,155 @@ contract DelayedFlowRouterTest is Test {
         );
     }
 
+    /// @dev A raw `(amount - level) * DURATION` would overflow for a huge
+    /// amount; `_consume` uses `mulDiv`, so it stays overflow-safe and the
+    /// result clamps to `MAX_DELAY`.
+    function test_hugeAmount_clampsToMaxDelayWithoutOverflow() public {
+        bytes32 id = keccak256("huge");
+        _simulateWithdrawal(id, type(uint256).max / 2);
+        assertEq(
+            destinationDelay.readyAt(id),
+            uint48(block.timestamp + MAX_DELAY)
+        );
+    }
+
+    /// @dev The payload carries a wire amount; the destination bucket is in
+    /// local units. For any scale, the delay must be sized against the local
+    /// equivalent (`wire * scaleDenominator / scaleNumerator`), not the raw
+    /// wire amount. Uses a fresh scaled collateral route + DFR.
+    function testFuzz_delaySizedInLocalUnits_forAnyScale(
+        uint256 scaleNumerator,
+        uint256 scaleDenominator,
+        uint256 wireAmount
+    ) public {
+        scaleNumerator = bound(scaleNumerator, 1, 1e12);
+        scaleDenominator = bound(scaleDenominator, 1, 1e12);
+
+        HypERC20Collateral scaledRouter = new HypERC20Collateral(
+            address(underlying),
+            scaleNumerator,
+            scaleDenominator,
+            address(destinationMailbox)
+        );
+        underlying.mintTo(address(scaledRouter), INITIAL_COLLATERAL);
+        DelayedFlowRouter scaledDelay = new DelayedFlowRouter(
+            TokenRouter(payable(address(scaledRouter))),
+            THRESHOLD_BPS,
+            MAX_DELAY
+        );
+        scaledDelay.enrollRemoteRouter(
+            ORIGIN_DOMAIN,
+            address(originDelay).addressToBytes32()
+        );
+
+        uint256 cap = scaledDelay.maxCapacity(); // local units
+
+        // Cover both under- and over-capacity (up to ~3x cap local). Bounds
+        // keep raw arithmetic equal to the contract's mulDiv(Rounding.Down).
+        uint256 maxWire = ((cap * 3) * scaleNumerator) / scaleDenominator;
+        wireAmount = bound(wireAmount, 0, maxWire);
+        uint256 localAmount = (wireAmount * scaleDenominator) / scaleNumerator;
+
+        bytes32 id = keccak256(abi.encode(wireAmount, cap));
+        vm.prank(address(destinationMailbox));
+        scaledDelay.handle(
+            ORIGIN_DOMAIN,
+            address(originDelay).addressToBytes32(),
+            abi.encode(id, wireAmount)
+        );
+
+        // Expected delay derived from the LOCAL amount (mirrors _consume).
+        uint256 expectedWait;
+        if (localAmount > cap) {
+            expectedWait = ((localAmount - cap) * scaledDelay.DURATION()) / cap;
+            if (expectedWait > MAX_DELAY) expectedWait = MAX_DELAY;
+        }
+        assertEq(
+            scaledDelay.readyAt(id),
+            uint48(block.timestamp + expectedWait)
+        );
+    }
+
+    /// @dev The origin credit path (`_TimelockRouter_onDispatch`) must also
+    /// meter local units. Drains a scaled route to zero via a consume, then
+    /// credits via a direct postDispatch and asserts the bucket rose by the
+    /// local equivalent of the wire amount.
+    function testFuzz_creditMetersLocalUnits_forAnyScale(
+        uint256 scaleNumerator,
+        uint256 scaleDenominator,
+        uint256 creditWire
+    ) public {
+        scaleNumerator = bound(scaleNumerator, 1, 1e12);
+        scaleDenominator = bound(scaleDenominator, 1, 1e12);
+
+        HypERC20Collateral scaledRouter = new HypERC20Collateral(
+            address(underlying),
+            scaleNumerator,
+            scaleDenominator,
+            address(destinationMailbox)
+        );
+        underlying.mintTo(address(scaledRouter), INITIAL_COLLATERAL);
+        DelayedFlowRouter scaledDelay = new DelayedFlowRouter(
+            TokenRouter(payable(address(scaledRouter))),
+            THRESHOLD_BPS,
+            MAX_DELAY
+        );
+        scaledDelay.enrollRemoteRouter(
+            ORIGIN_DOMAIN,
+            address(originDelay).addressToBytes32()
+        );
+
+        uint256 cap = scaledDelay.maxCapacity();
+
+        // Over-drain (>capacity) so `_consume` clamps the level to zero
+        // regardless of scale rounding.
+        vm.prank(address(destinationMailbox));
+        scaledDelay.handle(
+            ORIGIN_DOMAIN,
+            address(originDelay).addressToBytes32(),
+            abi.encode(
+                keccak256("drain"),
+                (cap * 2 * scaleNumerator) / scaleDenominator
+            )
+        );
+        assertEq(scaledDelay.calculateCurrentLevel(), 0);
+
+        // Credit a local amount within capacity (no clamp) so the delta is
+        // exact.
+        creditWire = bound(
+            creditWire,
+            0,
+            (cap * scaleNumerator) / scaleDenominator
+        );
+
+        {
+            bytes memory message = MessageUtils.formatMessage(
+                3,
+                1, // nonce > lastCreditedNonce (0)
+                DESTINATION_DOMAIN,
+                address(scaledRouter).addressToBytes32(),
+                ORIGIN_DOMAIN,
+                address(originDelay).addressToBytes32(),
+                TokenMessage.format(
+                    user.addressToBytes32(),
+                    creditWire,
+                    bytes("")
+                )
+            );
+            vm.mockCall(
+                address(destinationMailbox),
+                abi.encodeWithSignature("latestDispatchedId()"),
+                abi.encode(keccak256(message))
+            );
+            scaledDelay.postDispatch(bytes(""), message);
+        }
+
+        assertEq(
+            scaledDelay.calculateCurrentLevel(),
+            (creditWire * scaleDenominator) / scaleNumerator
+        );
+    }
+
     // ============ Deposit replenishment ============
 
     function test_depositCreditsBucket() public {

--- a/solidity/test/isms/DelayedFlowRouter.t.sol
+++ b/solidity/test/isms/DelayedFlowRouter.t.sol
@@ -258,14 +258,14 @@ contract DelayedFlowRouterTest is Test {
         );
     }
 
-    /// @dev The payload carries a wire amount; the destination bucket is in
-    /// local units. For any scale, the delay must be sized against the local
-    /// equivalent (`wire * scaleDenominator / scaleNumerator`), not the raw
-    /// wire amount. Uses a fresh scaled collateral route + DFR.
+    /// @dev The bucket is in the destination token's local units, but the
+    /// payload amount is in the route's scaled units. For any scale, the delay
+    /// must be sized against the amount converted to local units by the
+    /// router's scale. Uses a fresh scaled collateral route + DFR.
     function testFuzz_delaySizedInLocalUnits_forAnyScale(
         uint256 scaleNumerator,
         uint256 scaleDenominator,
-        uint256 wireAmount
+        uint256 messageAmount
     ) public {
         scaleNumerator = bound(scaleNumerator, 1, 1e12);
         scaleDenominator = bound(scaleDenominator, 1, 1e12);
@@ -291,16 +291,17 @@ contract DelayedFlowRouterTest is Test {
 
         // Cover both under- and over-capacity (up to ~3x cap local). Bounds
         // keep raw arithmetic equal to the contract's mulDiv(Rounding.Down).
-        uint256 maxWire = ((cap * 3) * scaleNumerator) / scaleDenominator;
-        wireAmount = bound(wireAmount, 0, maxWire);
-        uint256 localAmount = (wireAmount * scaleDenominator) / scaleNumerator;
+        uint256 maxMessage = ((cap * 3) * scaleNumerator) / scaleDenominator;
+        messageAmount = bound(messageAmount, 0, maxMessage);
+        uint256 localAmount = (messageAmount * scaleDenominator) /
+            scaleNumerator;
 
-        bytes32 id = keccak256(abi.encode(wireAmount, cap));
+        bytes32 id = keccak256(abi.encode(messageAmount, cap));
         vm.prank(address(destinationMailbox));
         scaledDelay.handle(
             ORIGIN_DOMAIN,
             address(originDelay).addressToBytes32(),
-            abi.encode(id, wireAmount)
+            abi.encode(id, messageAmount)
         );
 
         // Expected delay derived from the LOCAL amount (mirrors _consume).
@@ -318,11 +319,11 @@ contract DelayedFlowRouterTest is Test {
     /// @dev The origin credit path (`_TimelockRouter_onDispatch`) must also
     /// meter local units. Drains a scaled route to zero via a consume, then
     /// credits via a direct postDispatch and asserts the bucket rose by the
-    /// local equivalent of the wire amount.
+    /// message amount converted to local units.
     function testFuzz_creditMetersLocalUnits_forAnyScale(
         uint256 scaleNumerator,
         uint256 scaleDenominator,
-        uint256 creditWire
+        uint256 creditMessage
     ) public {
         scaleNumerator = bound(scaleNumerator, 1, 1e12);
         scaleDenominator = bound(scaleDenominator, 1, 1e12);
@@ -361,8 +362,8 @@ contract DelayedFlowRouterTest is Test {
 
         // Credit a local amount within capacity (no clamp) so the delta is
         // exact.
-        creditWire = bound(
-            creditWire,
+        creditMessage = bound(
+            creditMessage,
             0,
             (cap * scaleNumerator) / scaleDenominator
         );
@@ -377,7 +378,7 @@ contract DelayedFlowRouterTest is Test {
                 address(originDelay).addressToBytes32(),
                 TokenMessage.format(
                     user.addressToBytes32(),
-                    creditWire,
+                    creditMessage,
                     bytes("")
                 )
             );
@@ -391,7 +392,7 @@ contract DelayedFlowRouterTest is Test {
 
         assertEq(
             scaledDelay.calculateCurrentLevel(),
-            (creditWire * scaleDenominator) / scaleNumerator
+            (creditMessage * scaleDenominator) / scaleNumerator
         );
     }
 


### PR DESCRIPTION
### Description

Makes the TVL-based rate limiters (`NetFlowRateLimitedHookIsm`, `DelayedFlowRouter`) **decimal-aware**.

The rate-limit bucket is denominated in the warp router's **local** token units, but Hyperlane messages carry a **wire (scaled)** amount. Previously both contracts metered the raw wire amount against a local-unit bucket, so any route whose local decimals differ from the wire format (`scaleNumerator != scaleDenominator`) was over- or under-metered.

This PR adds `TvlRateLimited._toLocalAmount`, which converts a wire amount to local units using the router's scale — mirroring `TokenRouter._inboundAmount` (`mulDiv`, round down) — and applies it at every metering point:

- **NetFlow**: `verify` (inbound) and `_postDispatch` (outbound).
- **DelayedFlowRouter**: origin credit (`_TimelockRouter_onDispatch`) and destination consume (`_handle`). The cross-chain payload keeps the wire amount, so origin and destination each convert with their own router's scale.

Stacked on `net-flow-rate-limit-ism`.

### Drive-by changes

Surfaced while reviewing this change:

- Excluded exchange-rate / rebasing routes (the HypERC4626 family) from NetFlow's supported set. The synthetic `HypERC4626` variant is `token() == router`, so it has nonzero capacity and is **not** caught by the existing zero-capacity exclusion, yet it scales by exchange rate rather than the fixed `scale` fraction — now documented and tested.
- Made `RateLimited._consume`'s deficit computation overflow-safe with `mulDiv` (preserves the by-design floor where small overages pay zero wait).

### Related issues

N/A

### Backward compatibility

Yes. No storage-layout changes. The modified contracts (`TvlRateLimited`, `NetFlowRateLimitedHookIsm`, `DelayedFlowRouter`) are new/unreleased on the `net-flow-rate-limit-ism` line; the `RateLimited._consume` change is floor-preserving and adds no state.

### Testing

Unit + fuzz:

- Inbound and outbound scaling fuzz tests for NetFlow and DelayedFlowRouter — the amount metered equals the collateral the router actually moves, across arbitrary scales.
- HypERC4626-synthetic exclusion test.
- Huge-amount overflow regression test.

`forge test` — affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
