### PR TITLE
feat(infra): add RebalancerStaging and InventoryRebalancerStaging key roles

### DIFF
--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -165,6 +165,32 @@ function getRoleKeyMapPerChain(
     }
   };
 
+  const setRebalancerStagingKeys = () => {
+    const rebalancerStagingKey = getRebalancerStagingKey(agentConfig);
+    // Assign the single staging rebalancer key to all chains that have a relayer configured
+    for (const chainName of agentConfig.contextChainNames.relayer) {
+      keysPerChain[chainName] = {
+        ...keysPerChain[chainName],
+        [Role.RebalancerStaging]: {
+          [rebalancerStagingKey.identifier]: rebalancerStagingKey,
+        },
+      };
+    }
+  };
+
+  const setInventoryRebalancerStagingKeys = () => {
+    const inventoryStagingKey = getInventoryRebalancerStagingKey(agentConfig);
+    // Assign the single staging inventory rebalancer key to all chains that have a relayer configured
+    for (const chainName of agentConfig.contextChainNames.relayer) {
+      keysPerChain[chainName] = {
+        ...keysPerChain[chainName],
+        [Role.InventoryRebalancerStaging]: {
+          [inventoryStagingKey.identifier]: inventoryStagingKey,
+        },
+      };
+    }
+  };
+
   const setQuoteSignerKeys = () => {
     const quoteSignerKey = getQuoteSignerKey(agentConfig);
     for (const chainName of agentConfig.contextChainNames.relayer) {
@@ -193,6 +219,12 @@ function getRoleKeyMapPerChain(
         break;
       case Role.InventoryRebalancer:
         setInventoryRebalancerKeys();
+        break;
+      case Role.RebalancerStaging:
+        setRebalancerStagingKeys();
+        break;
+      case Role.InventoryRebalancerStaging:
+        setInventoryRebalancerStagingKeys();
         break;
       case Role.QuoteSigner:
         setQuoteSignerKeys();
@@ -263,6 +295,10 @@ export function getCloudAgentKey(
       return getRebalancerKey(agentConfig);
     case Role.InventoryRebalancer:
       return getInventoryRebalancerKey(agentConfig);
+    case Role.RebalancerStaging:
+      return getRebalancerStagingKey(agentConfig);
+    case Role.InventoryRebalancerStaging:
+      return getInventoryRebalancerStagingKey(agentConfig);
     case Role.QuoteSigner:
       return getQuoteSignerKey(agentConfig);
     default:
@@ -332,6 +368,32 @@ export function getInventoryRebalancerKey(
     agentConfig.runEnv,
     Contexts.Hyperlane,
     Role.InventoryRebalancer,
+  );
+}
+
+// Returns the staging rebalancer key. This is always a GCP key, not chain specific
+// and in the Hyperlane context
+export function getRebalancerStagingKey(
+  agentConfig: AgentContextConfig,
+): CloudAgentKey {
+  logger.debug('Retrieving staging rebalancer key');
+  return new AgentGCPKey(
+    agentConfig.runEnv,
+    Contexts.Hyperlane,
+    Role.RebalancerStaging,
+  );
+}
+
+// Returns the staging inventory rebalancer key. This is always a GCP key, not chain specific
+// and in the Hyperlane context
+export function getInventoryRebalancerStagingKey(
+  agentConfig: AgentContextConfig,
+): CloudAgentKey {
+  logger.debug('Retrieving staging inventory rebalancer key');
+  return new AgentGCPKey(
+    agentConfig.runEnv,
+    Contexts.Hyperlane,
+    Role.InventoryRebalancerStaging,
   );
 }
 

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -5,6 +5,8 @@ export enum Role {
   Deployer = 'deployer',
   Rebalancer = 'rebalancer',
   InventoryRebalancer = 'inventoryrebalancer',
+  RebalancerStaging = 'rebalancerstaging',
+  InventoryRebalancerStaging = 'inventoryrebalancerstaging',
   QuoteSigner = 'quotesigner',
   // Funding-only role: the stableswap rebalancer's EVM inventory
   // signer. Has no managed agent key — keyfunder only needs the address to
@@ -24,6 +26,8 @@ export const ALL_KEY_ROLES = [
   Role.Deployer,
   Role.Rebalancer,
   Role.InventoryRebalancer,
+  Role.RebalancerStaging,
+  Role.InventoryRebalancerStaging,
   Role.QuoteSigner,
 ];
 


### PR DESCRIPTION
## Summary
- Adds two new managed GCP key roles, `RebalancerStaging` and `InventoryRebalancerStaging`, so staging rebalancer keys can be created for `mainnet3` using the existing `scripts/keys/create-keys.ts` tooling.
- Wires both roles into `ALL_KEY_ROLES`, adds their GCP key getters (`getRebalancerStagingKey`, `getInventoryRebalancerStagingKey`), per-chain key setters, and the `getCloudAgentKey` switch.
- Keyfunder is intentionally **not** touched — these roles are not added to `FundableRole`, so this PR only enables key *creation*, not automated funding.

Resulting GCP secret names (Hyperlane context, mainnet3):
- `hyperlane-mainnet3-key-rebalancerstaging`
- `hyperlane-mainnet3-key-inventoryrebalancerstaging`

## How to create the keys after merge
```bash
cd typescript/infra
tsx scripts/keys/create-keys.ts -e mainnet3
```
The script prompts before creating and only creates keys that don't already exist. It also updates the combined `hyperlane-mainnet3-key-addresses` GCP secret with the derived addresses.

## Notes
- `@hyperlane-xyz/infra` is a private package, so no changeset is required.
- Enabling funding later would additionally require adding the roles to `FundableRole` (`src/roles.ts`), handling them in `assertFundableRole` (`src/utils/utils.ts`), and wiring address JSON + desired-balance config into `key-funder.ts`.

## Test plan
- [x] `pnpm exec tsc --noEmit` passes for `typescript/infra`
- [x] Dry-run `create-keys -e mainnet3` in an authorized GCP environment and confirm the two new secrets are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)