### PR TITLE
feat(infra): transfer moonpay-staging route ownership to deployer key

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
@@ -6,6 +6,7 @@ import {
   tokens,
 } from '../../../../../src/config/warp.js';
 import { getDomainId, getRegistry } from '../../../../registry.js';
+import { DEPLOYER } from '../../owners.js';
 import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
 import { WarpRouteIds } from '../warpIds.js';
 import {
@@ -23,9 +24,10 @@ import {
 // Rebalancing IS reproduced from prod: same allowedRebalancers (MCR signer) and the same
 // CCTP + Eclipse/Paradex/Igra/Radix + Iron (TBDA) bridge wiring per leg.
 
-// Troy's personal deployer keys for staging; to be transferred to the AW deployer later.
-const DEPLOYER_EVM = '0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E';
-const DEPLOYER_SOLANA = 'D4jZ2sNktKgTrhWVMnjZb5BXP7MMh9N3y5ZLwkyKfozb';
+// Owned by the Hyperlane deployer key: EVM uses the shared DEPLOYER (owners.ts);
+// the Solana XO leg uses the mainnet3 sealevel deployer pubkey.
+const DEPLOYER_EVM = DEPLOYER;
+const DEPLOYER_SOLANA = '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf';
 
 const SOLANA_IGP_ADDRESS = 'BhNcatUDC2D5JTyeaqrdSukiVFsEHK7e3hVmKMztwefv';
 const SOLANA_XO_TOKEN_MINT = 'xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y';

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
@@ -6,6 +6,7 @@ import {
   tokens,
 } from '../../../../../src/config/warp.js';
 import { getDomainId, getRegistry } from '../../../../registry.js';
+import { DEPLOYER } from '../../owners.js';
 import { WarpRouteIds } from '../warpIds.js';
 import { getRebalancingBridgesConfigFor } from './utils.js';
 
@@ -16,8 +17,8 @@ import { getRebalancingBridgesConfigFor } from './utils.js';
 // Rebalancing IS reproduced from prod: same allowedRebalancers (MCR signer) and the same
 // OFT + Eclipse USDT bridge wiring (arbitrum/bsc/ethereum/polygon; base + katana have none).
 
-// Troy's personal deployer key for staging; to be transferred to the AW deployer later.
-const DEPLOYER_EVM = '0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E';
+// Owned by the shared Hyperlane deployer key (owners.ts DEPLOYER).
+const DEPLOYER_EVM = DEPLOYER;
 
 const EVM_CHAINS = ['arbitrum', 'base', 'ethereum', 'polygon'] as const;
 


### PR DESCRIPTION
## Summary
Transfers ownership of the `USDC/moonpay-staging` and `USDT/moonpay-staging` routes from the personal deployer keys to the standard Hyperlane deployer key, so the route can be configured via the shared deployer.

- EVM legs (13) → `0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba` (owners.ts `DEPLOYER`)
- Solana leg → `9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf` (mainnet3 sealevel deployer)

Owner-only change; no rebalancing/ISM/fee changes. Companion registry PR regenerates the deploy YAMLs for `warp apply`.

## Test plan
- [x] `tsc --noEmit` clean on `typescript/infra`
- [x] Regenerated deploy YAMLs; registry diff is owner-only (14 legs)
- [ ] `warp apply` to push new owners on-chain