### PR TITLE
feat(sdk): deploy AtomicLocalRebalancingBridge via the warp-deploy path

### DIFF
--- a/.changeset/atomic-local-rebalancing-bridge-deploy.md
+++ b/.changeset/atomic-local-rebalancing-bridge-deploy.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": minor
+---
+
+Add `AtomicLocalRebalancingBridge` as a deployable warp token type (`TokenType.atomicLocalRebalancing`). Like `TokenBridgeOft` and `TokenBridgeDepositAddress`, it is a bare `ITokenBridge` adapter deployed unproxied via the direct-deploy path (no proxy, no `initialize`, no remote enrollment or mailbox-client configuration). Its config schema carries the immutable `sourceRouter` the bridge binds to; the deployer supplies the constructor arguments `(localDomain, sourceRouter, owner)`, with `localDomain` derived from the chain. The type is registered in the token contract/factory maps and included in the warp-route "not synthetic-only" validation.

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -76,6 +76,8 @@ const TYPE_DESCRIPTIONS: Record<DeployableTokenType, string> = {
   [TokenType.nativeScaled]: '',
   [TokenType.collateralOft]:
     'A collateral token that bridges via LayerZero OFT',
+  [TokenType.atomicLocalRebalancing]:
+    'A same-chain atomic local rebalancing bridge bound to a source collateral router',
   [TokenType.crossCollateral]:
     'A collateral token that can route to multiple routers across chains',
 };
@@ -85,6 +87,8 @@ const YAML_ONLY_TYPES: TokenType[] = [
   TokenType.collateralOft,
   TokenType.collateralCctp,
   TokenType.collateralDepositAddress,
+  // Needs a sourceRouter arg the interactive prompt can't gather; YAML-only.
+  TokenType.atomicLocalRebalancing,
 ];
 
 const TYPE_CHOICES = Object.values(TokenType)

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCrossMoonpayStagingLocalBridgeWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCrossMoonpayStagingLocalBridgeWarpConfig.ts
@@ -1,52 +1,80 @@
 import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
+import { getRegistry } from '../../../../registry.js';
+import { DEPLOYER } from '../../owners.js';
+import { WarpRouteIds } from '../warpIds.js';
 
-// Deployment scope: the EVM legs of CROSS/moonpay-staging that hold both a
-// USDC-side and USDT-side CrossCollateralRouter (mutually cross-enrolled), so a
-// same-chain USDC->USDT local rebalance is possible.
-const deploymentChains = [
-  'ethereum',
-  'base',
-  'arbitrum',
-  'polygon',
-  'bsc',
-] as const;
+// Owner of the deployed bridges. Matches the current CROSS/moonpay-staging router
+// owner (the AW deployer, after the ownership transfer in registry #1590) so the
+// same key can wire each bridge onto its source router (addRebalancer / addBridge
+// / addRebalanceTarget).
+const OWNER = DEPLOYER;
 
-export type DeploymentChain = (typeof deploymentChains)[number];
+// Narrowed to Base for the initial deployment. Expand this list (per direction)
+// once the mechanism is proven and the target CCRs are on the #8894 impl.
+const deploymentChains = ['base'] as const;
 
-// Owner of the deployed bridges. Matches the CROSS/moonpay-staging router owner
-// (Troy's staging deployer key) so the same key can wire the bridge onto the
-// source routers (addRebalancer / addBridge / addRebalanceTarget).
-const OWNER = '0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E';
-
-// USDC-side CrossCollateralRouter per chain — the immutable source router each
-// bridge binds to. Read from the deployed CROSS/moonpay-staging registry config.
-const sourceRoutersByChain: Record<DeploymentChain, string> = {
-  ethereum: '0xB58C85C143f2032A77e2C2B08603453ebA6C12aF',
-  base: '0x146Fb3Fcc2C9F547Ee4f85A5b0497274cBD380D0',
-  arbitrum: '0x9fb176528AdF0Bb7524CE752B2345C80eD24243F',
-  polygon: '0xa539EF6eF471c2D00d258540AB0bc38eD0B1F2ab',
-  bsc: '0x3382D9253eE54d49A90cBA41Cfc7b2704e713cEf',
+// Each AtomicLocalRebalancingBridge binds ONE immutable source router, so the two
+// same-chain rebalance directions are two separate warp routes. The source router
+// per chain is read from the deployed CROSS/moonpay-staging leg for that direction;
+// the sibling leg is the runtime `destinationRecipient` (not a deploy input).
+const SOURCE_WARP_ROUTE_ID_BY_DIRECTION: Record<string, string> = {
+  [WarpRouteIds.CROSSMoonpayStagingLocalBridgeUSDC]: 'USDC/moonpay-staging',
+  [WarpRouteIds.CROSSMoonpayStagingLocalBridgeUSDT]: 'USDT/moonpay-staging',
 };
 
+// Reads chain -> router address for a deployed warp route from the registry,
+// mirroring the sibling-router lookups in the prod moonpay getters.
+function getSourceRoutersByChain(sourceWarpRouteId: string): ChainMap<string> {
+  const route = getRegistry().getWarpRoute(sourceWarpRouteId);
+  assert(route, `Source warp route ${sourceWarpRouteId} not found in registry`);
+  return Object.fromEntries(
+    route.tokens.map(({ chainName, addressOrDenom }): [string, string] => {
+      assert(
+        addressOrDenom,
+        `Expected source router address for ${sourceWarpRouteId} on ${chainName}`,
+      );
+      return [chainName, addressOrDenom];
+    }),
+  );
+}
+
 // AtomicLocalRebalancingBridge is a bare ITokenBridge adapter that resolves the
-// source/destination tokens dynamically at call time, so the token metadata
-// below is cosmetic (only used to satisfy the warp-deploy metadata pipeline).
+// source/destination tokens dynamically at call time, so the token metadata below
+// is cosmetic (only used to satisfy the warp-deploy metadata pipeline).
 export const getCrossMoonpayStagingLocalBridgeWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
-): Promise<ChainMap<HypTokenRouterConfig>> =>
-  Object.fromEntries(
-    deploymentChains.map((chain) => [
-      chain,
-      {
-        ...routerConfig[chain],
-        owner: OWNER,
-        type: TokenType.atomicLocalRebalancing,
-        sourceRouter: sourceRoutersByChain[chain],
-        decimals: 6,
-        name: 'Moonpay Staging Local Rebalancing Bridge (USDC)',
-        symbol: 'mpsALRB',
-      },
-    ]),
+  _abacusWorksEnvOwnerConfig: unknown,
+  warpRouteId: string,
+): Promise<ChainMap<HypTokenRouterConfig>> => {
+  const sourceWarpRouteId = SOURCE_WARP_ROUTE_ID_BY_DIRECTION[warpRouteId];
+  assert(
+    sourceWarpRouteId,
+    `No local rebalancing bridge direction registered for ${warpRouteId}`,
   );
+  const sourceRoutersByChain = getSourceRoutersByChain(sourceWarpRouteId);
+
+  return Object.fromEntries(
+    deploymentChains.map((chain) => {
+      const sourceRouter = sourceRoutersByChain[chain];
+      assert(
+        sourceRouter,
+        `No ${sourceWarpRouteId} source router deployed on ${chain}`,
+      );
+      return [
+        chain,
+        {
+          ...routerConfig[chain],
+          owner: OWNER,
+          type: TokenType.atomicLocalRebalancing,
+          sourceRouter,
+          decimals: 6,
+          name: 'Moonpay Staging Local Rebalancing Bridge',
+          symbol: 'mpsALRB',
+        },
+      ];
+    }),
+  );
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCrossMoonpayStagingLocalBridgeWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCrossMoonpayStagingLocalBridgeWarpConfig.ts
@@ -1,0 +1,52 @@
+import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
+
+import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
+
+// Deployment scope: the EVM legs of CROSS/moonpay-staging that hold both a
+// USDC-side and USDT-side CrossCollateralRouter (mutually cross-enrolled), so a
+// same-chain USDC->USDT local rebalance is possible.
+const deploymentChains = [
+  'ethereum',
+  'base',
+  'arbitrum',
+  'polygon',
+  'bsc',
+] as const;
+
+export type DeploymentChain = (typeof deploymentChains)[number];
+
+// Owner of the deployed bridges. Matches the CROSS/moonpay-staging router owner
+// (Troy's staging deployer key) so the same key can wire the bridge onto the
+// source routers (addRebalancer / addBridge / addRebalanceTarget).
+const OWNER = '0x1cFd6A81e98de59e3eeB3AE35c3cb13FCb586E1E';
+
+// USDC-side CrossCollateralRouter per chain — the immutable source router each
+// bridge binds to. Read from the deployed CROSS/moonpay-staging registry config.
+const sourceRoutersByChain: Record<DeploymentChain, string> = {
+  ethereum: '0xB58C85C143f2032A77e2C2B08603453ebA6C12aF',
+  base: '0x146Fb3Fcc2C9F547Ee4f85A5b0497274cBD380D0',
+  arbitrum: '0x9fb176528AdF0Bb7524CE752B2345C80eD24243F',
+  polygon: '0xa539EF6eF471c2D00d258540AB0bc38eD0B1F2ab',
+  bsc: '0x3382D9253eE54d49A90cBA41Cfc7b2704e713cEf',
+};
+
+// AtomicLocalRebalancingBridge is a bare ITokenBridge adapter that resolves the
+// source/destination tokens dynamically at call time, so the token metadata
+// below is cosmetic (only used to satisfy the warp-deploy metadata pipeline).
+export const getCrossMoonpayStagingLocalBridgeWarpConfig = async (
+  routerConfig: ChainMap<RouterConfigWithoutOwner>,
+): Promise<ChainMap<HypTokenRouterConfig>> =>
+  Object.fromEntries(
+    deploymentChains.map((chain) => [
+      chain,
+      {
+        ...routerConfig[chain],
+        owner: OWNER,
+        type: TokenType.atomicLocalRebalancing,
+        sourceRouter: sourceRoutersByChain[chain],
+        decimals: 6,
+        name: 'Moonpay Staging Local Rebalancing Bridge (USDC)',
+        symbol: 'mpsALRB',
+      },
+    ]),
+  );

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -151,8 +151,10 @@ export enum WarpRouteIds {
   USDCCitreaMoonpay = 'USDC/moonpay',
   USDCCitreaIronBridge = 'CROSS/ctusd-usdc-ironbridge',
   USDTCitreaMoonpay = 'USDT/moonpay',
-  // AtomicLocalRebalancingBridge (USDC-sourced) for the CROSS/moonpay-staging route
-  CROSSMoonpayStagingLocalBridge = 'CROSS/moonpay-staging-localbridge-usdc',
+  // AtomicLocalRebalancingBridge routes for CROSS/moonpay-staging (one per source
+  // direction; each bridge binds one immutable source router).
+  CROSSMoonpayStagingLocalBridgeUSDC = 'CROSS/moonpay-staging-localbridge-usdc',
+  CROSSMoonpayStagingLocalBridgeUSDT = 'CROSS/moonpay-staging-localbridge-usdt',
 
   // TODO: uncomment when USDTOft warp routes are in the registry
   // USDT OFT

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -151,6 +151,8 @@ export enum WarpRouteIds {
   USDCCitreaMoonpay = 'USDC/moonpay',
   USDCCitreaIronBridge = 'CROSS/ctusd-usdc-ironbridge',
   USDTCitreaMoonpay = 'USDT/moonpay',
+  // AtomicLocalRebalancingBridge (USDC-sourced) for the CROSS/moonpay-staging route
+  CROSSMoonpayStagingLocalBridge = 'CROSS/moonpay-staging-localbridge-usdc',
 
   // TODO: uncomment when USDTOft warp routes are in the registry
   // USDT OFT

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -235,7 +235,9 @@ export const warpConfigGetterMap: Record<string, WarpConfigGetter> = {
   [WarpRouteIds.USDCCitreaIronBridge]: getUSDCCitreaIronBridgeWarpConfig,
   [WarpRouteIds.USDCCitreaMoonpay]: getUSDCCitreaMoonpayWarpConfig,
   [WarpRouteIds.USDTCitreaMoonpay]: getUSDTCitreaMoonpayWarpConfig,
-  [WarpRouteIds.CROSSMoonpayStagingLocalBridge]:
+  [WarpRouteIds.CROSSMoonpayStagingLocalBridgeUSDC]:
+    getCrossMoonpayStagingLocalBridgeWarpConfig,
+  [WarpRouteIds.CROSSMoonpayStagingLocalBridgeUSDT]:
     getCrossMoonpayStagingLocalBridgeWarpConfig,
 };
 

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -138,6 +138,7 @@ import { WarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
 import { getCCTPWarpConfig as getTestnetCCTPWarpConfig } from './environments/testnet4/warp/getCCTPConfig.js';
 import { DEFAULT_REGISTRY_URI } from './registry.js';
 import { getUSDCCitreaIronBridgeWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDCCitreaIronBridgeWarpConfig.js';
+import { getCrossMoonpayStagingLocalBridgeWarpConfig } from './environments/mainnet3/warp/configGetters/getCrossMoonpayStagingLocalBridgeWarpConfig.js';
 import { getUSDCCitreaMoonpayWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayWarpConfig.js';
 import { getUSDTCitreaMoonpayWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayWarpConfig.js';
 import { getUSDTOftWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.js';
@@ -234,6 +235,8 @@ export const warpConfigGetterMap: Record<string, WarpConfigGetter> = {
   [WarpRouteIds.USDCCitreaIronBridge]: getUSDCCitreaIronBridgeWarpConfig,
   [WarpRouteIds.USDCCitreaMoonpay]: getUSDCCitreaMoonpayWarpConfig,
   [WarpRouteIds.USDTCitreaMoonpay]: getUSDTCitreaMoonpayWarpConfig,
+  [WarpRouteIds.CROSSMoonpayStagingLocalBridge]:
+    getCrossMoonpayStagingLocalBridgeWarpConfig,
 };
 
 type StrategyConfigGetter = () => ChainSubmissionStrategy;

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -766,7 +766,10 @@ export async function enrollCrossChainRouters(
       resolvedConfigMap,
       (_, config: any): config is any =>
         !config.foreignDeployment &&
-        config.type !== TokenType.collateralDepositAddress,
+        config.type !== TokenType.collateralDepositAddress &&
+        // Bare same-chain ITokenBridge adapter: not a cross-chain router, has no
+        // on-chain warp config to derive, so it is never enrolled (like deposit-address).
+        config.type !== TokenType.atomicLocalRebalancing,
     ),
   );
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -184,6 +184,8 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         this.deriveHypCollateralDepositAddressTokenConfig.bind(this),
       [TokenType.collateralOft]:
         this.deriveHypCollateralOftTokenConfig.bind(this),
+      // Bare adapter with no derivable on-chain warp config; deploy-only.
+      [TokenType.atomicLocalRebalancing]: null,
       [TokenType.crossCollateral]:
         this.deriveCrossCollateralTokenConfig.bind(this),
     };

--- a/typescript/sdk/src/token/TokenStandard.ts
+++ b/typescript/sdk/src/token/TokenStandard.ts
@@ -451,6 +451,7 @@ export const EVM_TOKEN_TYPE_TO_STANDARD: Record<
   [TokenType.collateralEverclear]: TokenStandard.EvmHypEverclearCollateral,
   [TokenType.collateralDepositAddress]: TokenStandard.EvmHypCollateral,
   [TokenType.collateralOft]: TokenStandard.EvmHypCollateral,
+  [TokenType.atomicLocalRebalancing]: TokenStandard.EvmHypCollateral,
   [TokenType.crossCollateral]: TokenStandard.EvmHypCrossCollateralRouter,
 };
 
@@ -566,6 +567,7 @@ export const TRON_TOKEN_TYPE_TO_STANDARD: Record<
   [TokenType.collateralEverclear]: TokenStandard.TronHypEverclearCollateral,
   [TokenType.collateralDepositAddress]: TokenStandard.TronHypCollateral,
   [TokenType.collateralOft]: TokenStandard.TronHypCollateral,
+  [TokenType.atomicLocalRebalancing]: TokenStandard.TronHypCollateral,
   [TokenType.crossCollateral]: TokenStandard.TronHypCrossCollateralRouter,
 };
 

--- a/typescript/sdk/src/token/config.ts
+++ b/typescript/sdk/src/token/config.ts
@@ -13,6 +13,8 @@ export const TokenType = {
   collateralEverclear: 'collateralEverclear',
   collateralDepositAddress: 'collateralDepositAddress',
   collateralOft: 'collateralOft',
+  // Same-chain atomic local rebalancing bridge (bare ITokenBridge adapter)
+  atomicLocalRebalancing: 'atomicLocalRebalancing',
   native: 'native',
   nativeOpL2: 'nativeOpL2',
   nativeOpL1: 'nativeOpL1',
@@ -50,6 +52,8 @@ const isMovableCollateralTokenTypeMap = {
   [TokenType.collateralEverclear]: false,
   [TokenType.collateralDepositAddress]: false,
   [TokenType.collateralOft]: false,
+  // Bare ITokenBridge adapter, not a MovableCollateralRouter subclass
+  [TokenType.atomicLocalRebalancing]: false,
   [TokenType.crossCollateral]: true, // CrossCollateralRouter extends HypERC20Collateral
   [TokenType.unknown]: false,
 } as const;

--- a/typescript/sdk/src/token/contracts.ts
+++ b/typescript/sdk/src/token/contracts.ts
@@ -1,6 +1,7 @@
 import { ContractFactory } from 'ethers';
 
 import {
+  AtomicLocalRebalancingBridge__factory,
   CrossCollateralRouter__factory,
   EverclearEthBridge__factory,
   EverclearTokenBridge__factory,
@@ -48,6 +49,7 @@ export const hypERC20contracts = {
   [TokenType.collateralEverclear]: 'EverclearTokenBridge',
   [TokenType.collateralDepositAddress]: 'TokenBridgeDepositAddress',
   [TokenType.collateralOft]: 'TokenBridgeOft',
+  [TokenType.atomicLocalRebalancing]: 'AtomicLocalRebalancingBridge',
   [TokenType.crossCollateral]: 'CrossCollateralRouter',
 } as const satisfies Record<DeployableTokenType, string>;
 export type HypERC20contracts = typeof hypERC20contracts;
@@ -79,6 +81,8 @@ export const hypERC20factories = {
   [TokenType.collateralDepositAddress]:
     new TokenBridgeDepositAddress__factory(),
   [TokenType.collateralOft]: new TokenBridgeOft__factory(),
+  [TokenType.atomicLocalRebalancing]:
+    new AtomicLocalRebalancingBridge__factory(),
   [TokenType.crossCollateral]: new CrossCollateralRouter__factory(),
 } as const satisfies Record<HypERC20TokenType, ContractFactory>;
 export type HypERC20Factories = typeof hypERC20factories;

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -72,6 +72,7 @@ import {
   PredicateWrapperConfig,
   OftTokenConfig,
   WarpRouteDeployConfig,
+  isAtomicLocalRebalancingBridgeTokenConfig,
   isCctpTokenConfig,
   isCollateralTokenConfig,
   isEverclearCollateralTokenConfig,
@@ -161,7 +162,7 @@ abstract class TokenDeployer<
   }
 
   async constructorArgs(
-    _: ChainName,
+    chain: ChainName,
     config: HypTokenRouterConfig,
   ): Promise<any> {
     // TODO: derive as specified in https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/5296
@@ -211,6 +212,13 @@ abstract class TokenDeployer<
       return [config.oft, config.owner];
     } else if (isDepositAddressTokenConfig(config)) {
       return [config.token, config.owner];
+    } else if (isAtomicLocalRebalancingBridgeTokenConfig(config)) {
+      // constructor(uint32 _localDomain, address _sourceRouter, address _owner)
+      return [
+        this.multiProvider.getDomainId(chain),
+        config.sourceRouter,
+        config.owner,
+      ];
     } else if (isCctpTokenConfig(config)) {
       switch (config.cctpVersion) {
         case 'V1':
@@ -269,6 +277,9 @@ abstract class TokenDeployer<
       throw new Error('OFT does not use initialize');
     } else if (isDepositAddressTokenConfig(config)) {
       throw new Error('Direct bridge adapters do not use initialize');
+    } else if (isAtomicLocalRebalancingBridgeTokenConfig(config)) {
+      // Deployed unproxied — owner is set in constructor, no initialize
+      throw new Error('AtomicLocalRebalancingBridge does not use initialize');
     } else if (
       isCollateralTokenConfig(config) ||
       isXERC20TokenConfig(config) ||
@@ -912,6 +923,21 @@ abstract class TokenDeployer<
           chain,
           contractKey,
           this.routerContractName(config),
+          constructorArgs,
+        );
+        directBridgeContracts[chain] = { [contractKey]: contract };
+        delete resolvedConfigMap[chain];
+        continue;
+      }
+      if (isAtomicLocalRebalancingBridgeTokenConfig(config)) {
+        // Bare ITokenBridge adapter: constructor-configured, unproxied.
+        // Skip the router pipeline (no proxy/initialize/enrollRemoteRouters/
+        // mailbox-client config) exactly like OFT/DepositAddress.
+        const contractKey = this.routerContractKey(config);
+        const constructorArgs = await this.constructorArgs(chain, config);
+        const contract = await this.deployContract(
+          chain,
+          contractKey,
           constructorArgs,
         );
         directBridgeContracts[chain] = { [contractKey]: contract };

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -330,6 +330,29 @@ export const OftTokenConfigSchema = TokenMetadataSchema.partial().extend({
 export type OftTokenConfig = z.infer<typeof OftTokenConfigSchema>;
 export const isOftTokenConfig = isCompliant(OftTokenConfigSchema);
 
+/**
+ * Configuration for AtomicLocalRebalancingBridge — a bare ITokenBridge adapter
+ * (no mailbox, no proxy/initialize) that performs same-chain rebalances by
+ * pulling collateral from an immutable source router, running swap calls, and
+ * funding a validated destination router. Deployed unproxied like OFT/DepositAddress.
+ */
+export const AtomicLocalRebalancingBridgeTokenConfigSchema =
+  TokenMetadataSchema.partial().extend({
+    type: z.literal(TokenType.atomicLocalRebalancing),
+    sourceRouter: z
+      .string()
+      .describe(
+        'Source collateral router the bridge is immutably bound to (rebalances pull collateral from it)',
+      ),
+    predicateWrapper: PredicateWrapperConfigSchema.optional(),
+  });
+export type AtomicLocalRebalancingBridgeTokenConfig = z.infer<
+  typeof AtomicLocalRebalancingBridgeTokenConfigSchema
+>;
+export const isAtomicLocalRebalancingBridgeTokenConfig = isCompliant(
+  AtomicLocalRebalancingBridgeTokenConfigSchema,
+);
+
 export const CollateralRebaseTokenConfigSchema =
   TokenMetadataSchema.partial().extend({
     type: z.literal(TokenType.collateralVaultRebase),
@@ -472,6 +495,7 @@ const AllHypTokenConfigSchema = z.discriminatedUnion('type', [
   EverclearCollateralTokenConfigSchema,
   EverclearEthBridgeTokenConfigSchema,
   DepositAddressTokenConfigSchema,
+  AtomicLocalRebalancingBridgeTokenConfigSchema,
   CrossCollateralTokenConfigSchema,
   UnknownTokenConfigSchema,
 ]);
@@ -598,6 +622,7 @@ export const WarpRouteDeployConfigSchema = z
           isEverclearTokenBridgeConfig(config) ||
           isDepositAddressTokenConfig(config) ||
           isCrossCollateralTokenConfig(config) ||
+          isAtomicLocalRebalancingBridgeTokenConfig(config) ||
           isOftTokenConfig(config),
       ) || entries.every(([_, config]) => isTokenMetadata(config))
     );


### PR DESCRIPTION
## Summary

Makes the `AtomicLocalRebalancingBridge` (added in #8894) **deployable through the standard TypeScript warp-deploy path**, so we can deploy and (later) exercise the same-chain local rebalancing bridge on `CROSS/moonpay-staging` without a bespoke script.

`AtomicLocalRebalancingBridge` is structurally a bare `ITokenBridge` adapter — constructor-only, `Ownable`, no Mailbox, no proxy/`initialize` — i.e. the same family as `TokenBridgeOft` / `TokenBridgeDepositAddress`. It is wired into the existing **direct-deploy interception** in `TokenDeployer.deploy()` (no proxy, no `initialize`, no remote enrollment or mailbox-client config).

### SDK (`@hyperlane-xyz/sdk`: minor)
- `token/config.ts` — new `TokenType.atomicLocalRebalancing` (+ `isMovableCollateralTokenTypeMap` = false).
- `token/contracts.ts` — factory/name maps → `AtomicLocalRebalancingBridge__factory`.
- `token/types.ts` — `AtomicLocalRebalancingBridgeTokenConfigSchema` (immutable `sourceRouter` + metadata) in the discriminated union; included in the `NO_SYNTHETIC_ONLY` refine.
- `token/deploy.ts` — `constructorArgs` → `[localDomain, sourceRouter, owner]` (localDomain from the chain); `initializeArgs` throw; direct-deploy interception branch.
- Exhaustive-map coverage: `EvmWarpRouteReader.ts` (null — deploy-only, no on-chain reader) and `TokenStandard.ts` (EVM + Tron).

### CLI
- `cli/src/config/warp.ts` — add the type to the exhaustive `TYPE_DESCRIPTIONS` map and to `YAML_ONLY_TYPES` (it needs a `sourceRouter` the interactive prompt can't gather).

### Infra
- `getCrossMoonpayStagingLocalBridgeWarpConfig.ts` — a single **registry-driven, direction-parameterized** builder registered under **two** `WarpRouteId`s:
  - `CROSS/moonpay-staging-localbridge-usdc` (source = USDC leg → rebalances USDC→USDT)
  - `CROSS/moonpay-staging-localbridge-usdt` (source = USDT leg → rebalances USDT→USDC)
  Each bridge binds one immutable source router; the per-chain source address is read from the deployed `CROSS/moonpay-staging` leg via the registry (like the prod sibling-router lookups), and the owner is derived from the AW `DEPLOYER` constant. **Deployment is scoped to Base** for the initial rollout (expand per direction later).

## Base branch
Targets **`audit-q3-2026`** because `AtomicLocalRebalancingBridge` and its typechain factory only exist there (not yet on `main`). Rides along when the audit branch merges to `main`.

## Deploy (per direction)
```
yarn tsx typescript/infra/scripts/warp-routes/generate-warp-config.ts -e mainnet3 \
  --warpRouteId CROSS/moonpay-staging-localbridge-usdc -o <registry>/.../deploy-config.yaml
hyperlane warp deploy --warp-route-id CROSS/moonpay-staging-localbridge-usdc --key <funded-key>
```
(`REGISTRY_URI` must point at a registry that has the `CROSS/moonpay-staging` routes.)

## ⚠️ Prerequisites
1. **CCR impl.** The deployed `CROSS/moonpay-staging` CrossCollateralRouters **predate #8894** — `isRebalanceTarget`/`rebalanceTargets` revert. The bridge deploys fine, but its `rebalance()` (and the `addRebalanceTarget` wiring) require the source router to implement `IRebalanceTargets`, so the **CCR proxies must be upgraded to the #8894 implementation first**.
2. **Owner.** After registry #1590 the staging routers + their ProxyAdmins are owned by the **AW deployer** `0xa7ECcdb9…` (Solana `9bRSUP…`), not the earlier personal key. So the CCR upgrade + bridge wiring go through the AW deployer key. (Confirm the *on-chain* `owner()` before wiring — the transfer tx may lag the registry.)

## Validation
- Full monorepo `turbo run build` passes (29/29), incl. CLI + infra.
- `WarpRouteDeployConfigSchema` accepts the bridge-only route; the builder emits a valid Base config for **both** directions (source = USDC-CCR / USDT-CCR respectively, owner = AW deployer), reading addresses from the registry.
- Base fork (anvil, built core factory): bridge deploys with the correct immutables against the real staging USDC-CCR; after upgrading the CCR proxy to the #8894 impl, `addRebalancer`+`addBridge`+`addRebalanceTarget` make `isRebalanceTarget`/`isAllowedRebalancer` return true.

## Not included (deferred)
- Live mainnet broadcast; expanding beyond Base; the `rebalance()` swap test; private-agents rebalancer integration.
- `addRebalanceTarget` has no `warp apply` support yet (`addBridge`/`addRebalancer` already work via `allowedRebalancingBridges`/`allowedRebalancers`) — needed to fully drive wiring from config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)