### PR TITLE
fix(rust): reduce agent log volume by demoting hot logs to TRACE

### DIFF
--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -4,7 +4,7 @@ use derive_new::new;
 use hyperlane_core::{PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason};
 use prometheus::{IntGauge, IntGaugeVec};
 use tokio::sync::{broadcast::Receiver, Mutex};
-use tracing::{debug, instrument};
+use tracing::{instrument, trace};
 
 use crate::server::operations::message_retry::{MessageRetryQueueResponse, MessageRetryRequest};
 use crate::settings::matching_list::MatchingListExt;
@@ -57,11 +57,24 @@ impl OpQueue {
         }
 
         // This function is called very often by the message processor tasks, so only log when there are operations to pop
-        // to avoid spamming the logs
+        // to avoid spamming the logs. Emit a compact per-op summary at TRACE; the full Debug dump of every
+        // operation was a dominant share of log volume in production.
         if !popped.is_empty() {
-            debug!(
+            let operations = popped
+                .iter()
+                .map(|op| {
+                    format!(
+                        "{:?} nonce={} dest={} status={:?}",
+                        op.id(),
+                        op.priority(),
+                        op.destination_domain(),
+                        op.status()
+                    )
+                })
+                .collect::<Vec<_>>();
+            trace!(
                 queue_label = %self.queue_metrics_label,
-                operations = ?popped,
+                ?operations,
                 "Popped OpQueue operations"
             );
         }

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -227,7 +227,7 @@ where
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
                 }
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     provider_host = provider_host.as_str(),

--- a/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
@@ -100,7 +100,7 @@ impl JsonRpcTransport for FallbackHttpTransport {
                 // Create log span
                 let provider = &self.inner.providers[priority.index];
 
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     "fallback_request"


### PR DESCRIPTION
## Summary
Cuts production agent log volume (and the associated GCP Cloud Logging bill) by demoting the two chattiest DEBUG log lines to TRACE and slimming one of them.

- `fallback_request` (fires on **every** fallback-provider RPC request) → `trace!` in both `hyperlane-ethereum` and `hyperlane-starknet` fallback providers.
- `Popped OpQueue operations` (fires on every non-empty queue pop, up to 32 ops/tick) → `trace!`, and the full `Debug` dump of every `PendingOperation` is replaced with a compact `{id, nonce, dest, status}` summary.

Agents run at the `debug` default (`rust/main/helm/hyperlane-agent/values.yaml`), so these lines were emitted continuously in prod. Sampling of live logs showed `fallback_request` (~569 B/line) and `Popped OpQueue operations` (~1540 B/line) were the dominant contributors to log volume.

This complements the Cloud Logging sink exclusions already applied (fallback sampled to 10%, testnet4 DEBUG dropped) by cutting the volume at the source across all environments.

## Test plan
- [x] `cargo check -p relayer -p hyperlane-ethereum -p hyperlane-starknet` passes
- [x] `cargo fmt` (pre-commit hook) clean
- [ ] Reviewer: confirm TRACE is the desired level (still visible when `HYP_LOG_LEVEL=trace` for targeted debugging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)