### PR TITLE
feat(infra): per-series push for warp check violations

### DIFF
--- a/.changeset/warp-violation-per-series-push.md
+++ b/.changeset/warp-violation-per-series-push.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+Push gateway submission gained an optional `groupings` parameter and a new `deleteMetrics` helper, letting each metric be pushed under its own group and cleared independently via DELETE.

--- a/typescript/infra/scripts/check/check-utils.ts
+++ b/typescript/infra/scripts/check/check-utils.ts
@@ -332,3 +332,33 @@ export function getCheckerViolationsGaugeObj(metricsRegister: Registry) {
     ],
   };
 }
+
+// Every warp violation is pushed to PushGateway under its own group, keyed by
+// (warp_route_id, chain, contract_name, type). This makes each alert an
+// independently addressable series that can be cleared on its own (push 0 /
+// DELETE) without touching any other violation. The grouping value must be a
+// single URL-path-safe segment: warp_route_id contains "/" and contract_name
+// can be empty, both of which break PushGateway's path grouping, so we encode
+// the composite as base64url and expose it as a single `alert_key` label. A NUL
+// separator is used so values containing spaces (e.g. some violation types)
+// cannot collide across different composites.
+export function warpViolationAlertKey(
+  warpRouteId: string,
+  chain: string,
+  contractName: string,
+  type: string,
+): string {
+  const composite = [warpRouteId, chain, contractName, type].join('\u0000');
+  return Buffer.from(composite, 'utf8').toString('base64url');
+}
+
+export function warpViolationGroupings(
+  warpRouteId: string,
+  chain: string,
+  contractName: string,
+  type: string,
+): Record<string, string> {
+  return {
+    alert_key: warpViolationAlertKey(warpRouteId, chain, contractName, type),
+  };
+}

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -30,6 +30,7 @@ import { getEnvironmentConfig } from '../core-utils.js';
 import {
   getCheckWarpDeployArgs,
   getCheckerViolationsGaugeObj,
+  warpViolationGroupings,
 } from './check-utils.js';
 
 const ROUTES_TO_SKIP: string[] = [
@@ -52,12 +53,6 @@ const ROUTES_TO_SKIP: string[] = [
 async function main() {
   const { environment, chains, pushMetrics } =
     await getCheckWarpDeployArgs().argv;
-
-  const metricsRegister = new Registry();
-  const checkerViolationsGauge = new Gauge(
-    getCheckerViolationsGaugeObj(metricsRegister),
-  );
-  metricsRegister.registerMetric(checkerViolationsGauge);
 
   const failedWarpRoutesChecks: string[] = [];
 
@@ -156,24 +151,10 @@ async function main() {
       if (result.violations.length > 0) {
         logWarpRouteCheckResult(result);
         if (pushMetrics) {
-          pushWarpViolationsMetrics(
-            checkerViolationsGauge,
-            result,
-            warpRouteId,
-          );
+          await pushWarpViolationsMetrics(result, warpRouteId, environment);
         }
       } else {
         console.info(chalk.green(`warp checker found no violations`));
-      }
-
-      if (pushMetrics) {
-        await submitMetrics(
-          metricsRegister,
-          `check-warp-deploy-${environment}`,
-          {
-            overwriteAllMetrics: true,
-          },
-        );
       }
     } catch (e) {
       console.error(
@@ -549,13 +530,23 @@ async function isTestnetRoute(
   return false;
 }
 
-function pushWarpViolationsMetrics(
-  checkerViolationsGauge: Gauge<string>,
+// Each violation is pushed to PushGateway under its own group, keyed by an
+// alert_key grouping label. This makes every violation an independently
+// addressable series that can be cleared on its own (DELETE / push 0) without
+// touching any other violation. We do NOT overwrite the whole job group: a run
+// that does not observe a given violation must leave that series untouched, so
+// stale RPCs or a partial run can never silently auto-clear a real alert.
+// Clearing is exclusively the human-confirmed action (see clear-warp-violation).
+async function pushWarpViolationsMetrics(
   result: WarpRouteCheckResult,
   warpRouteId: string,
+  environment: string,
 ) {
   for (const violation of result.violations) {
-    checkerViolationsGauge
+    const register = new Registry();
+    const gauge = new Gauge(getCheckerViolationsGaugeObj(register));
+    register.registerMetric(gauge);
+    gauge
       .labels({
         actual: violation.actual,
         chain: violation.chain,
@@ -568,6 +559,20 @@ function pushWarpViolationsMetrics(
         warp_route_id: warpRouteId,
       })
       .set(1);
+
+    const groupings = warpViolationGroupings(
+      warpRouteId,
+      violation.chain,
+      violation.name,
+      violation.type,
+    );
+
+    // PUT (overwriteAllMetrics) is safe here because this group holds exactly
+    // one series; it keeps the single-series group clean across refreshes.
+    await submitMetrics(register, `check-warp-deploy-${environment}`, {
+      groupings,
+      overwriteAllMetrics: true,
+    });
     console.log(
       `Violation: ${violation.name} on ${violation.chain} with ${violation.actual} ${violation.type} ${violation.expected} pushed to metrics`,
     );

--- a/typescript/infra/scripts/check/clear-warp-violation.ts
+++ b/typescript/infra/scripts/check/clear-warp-violation.ts
@@ -1,0 +1,81 @@
+import chalk from 'chalk';
+import { Registry } from 'prom-client';
+
+import { deleteMetrics } from '@hyperlane-xyz/metrics';
+
+import { checkWarpDeployConfig } from '../../config/environments/mainnet3/warp/checkWarpDeploy.js';
+import { getArgs } from '../agent-utils.js';
+
+import { warpViolationGroupings } from './check-utils.js';
+
+// Human-confirmed clearing of a single hyperlane_check_violations alert.
+//
+// The daily checker never auto-clears a violation: it only ever pushes/refreshes
+// series it actually observes, each under its own PushGateway group. This script
+// is the only way a series is removed, and it is meant to be invoked explicitly
+// (e.g. by Haggis) once a human confirms the underlying config/registry drift is
+// resolved. It DELETEs exactly the one group identified by the labels, leaving
+// every other violation untouched.
+async function main() {
+  const {
+    environment,
+    warpRouteId,
+    chain,
+    contractName,
+    violationType,
+    pushGateway,
+  } = await getArgs()
+    .describe('warpRouteId', 'Warp route id of the violation, e.g. USDC/...')
+    .string('warpRouteId')
+    .demandOption('warpRouteId')
+    .describe('chain', 'Chain of the violation')
+    .string('chain')
+    .demandOption('chain')
+    .describe('contractName', 'Contract name of the violation (may be empty)')
+    .string('contractName')
+    .default('contractName', '')
+    .describe('violationType', 'Violation type, e.g. Owner')
+    .string('violationType')
+    .demandOption('violationType')
+    .describe(
+      'pushGateway',
+      'PushGateway address; defaults to PROMETHEUS_PUSH_GATEWAY or the env config',
+    )
+    .string('pushGateway').argv;
+
+  const gatewayAddr =
+    pushGateway ??
+    process.env['PROMETHEUS_PUSH_GATEWAY'] ??
+    checkWarpDeployConfig.prometheusPushGateway;
+  process.env['PROMETHEUS_PUSH_GATEWAY'] = gatewayAddr;
+
+  const groupings = warpViolationGroupings(
+    warpRouteId,
+    chain,
+    contractName,
+    violationType,
+  );
+
+  console.log(
+    chalk.yellow(
+      `Clearing violation ${violationType} for ${warpRouteId} on ${chain} (contract "${contractName}")`,
+    ),
+  );
+  console.log(chalk.yellow(`Grouping: ${JSON.stringify(groupings)}`));
+
+  // Registry is only used to resolve the gateway; no metrics are pushed.
+  await deleteMetrics(
+    new Registry(),
+    `check-warp-deploy-${environment}`,
+    groupings,
+  );
+
+  console.log(chalk.green('Delete request sent to PushGateway'));
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/check/clear-warp-violation.ts
+++ b/typescript/infra/scripts/check/clear-warp-violation.ts
@@ -14,7 +14,7 @@ import { warpViolationGroupings } from './check-utils.js';
 // series it actually observes, each under its own PushGateway group. This script
 // is the only way a series is removed, and it is meant to be invoked explicitly
 // (e.g. by Haggis) once a human confirms the underlying config/registry drift is
-// resolved. It DELETEs exactly the one group identified by the labels, leaving
+// resolved. It deletes exactly the one group identified by the labels, leaving
 // every other violation untouched.
 async function main() {
   const {

--- a/typescript/metrics/src/index.ts
+++ b/typescript/metrics/src/index.ts
@@ -50,4 +50,4 @@ export { formatBigInt } from './utils.js';
 export { startMetricsServer } from './server.js';
 
 // Push Gateway
-export { getPushGateway, submitMetrics } from './pushgateway.js';
+export { deleteMetrics, getPushGateway, submitMetrics } from './pushgateway.js';

--- a/typescript/metrics/src/pushgateway.ts
+++ b/typescript/metrics/src/pushgateway.ts
@@ -33,25 +33,35 @@ export function getPushGateway(
  * @param register - The Prometheus registry to submit
  * @param jobName - The job name for the metrics
  * @param options - Optional configuration
- * @param options.overwriteAllMetrics - If true, overwrites all metrics instead of adding
+ * @param options.overwriteAllMetrics - If true, overwrites the whole group (PUT)
+ *   instead of only replacing same-named metrics (POST). Only meaningful for a
+ *   single-series-per-group layout; do not use it to clear unobserved series.
+ * @param options.groupings - Extra grouping labels appended to the PushGateway
+ *   group key. When each series is pushed under its own grouping, it can be
+ *   cleared independently via deleteMetrics without touching other series.
  * @param logger - Optional logger instance
  */
 export async function submitMetrics(
   register: Registry,
   jobName: string,
-  options?: { overwriteAllMetrics?: boolean },
+  options?: {
+    overwriteAllMetrics?: boolean;
+    groupings?: Record<string, string>;
+  },
   logger?: Logger,
 ): Promise<void> {
   const log = logger ?? rootLogger.child({ module: 'metrics' });
   const gateway = getPushGateway(register, log);
   if (!gateway) return;
 
+  const params = { jobName, groupings: options?.groupings };
+
   let resp;
   try {
     if (options?.overwriteAllMetrics) {
-      resp = (await gateway.push({ jobName })).resp;
+      resp = (await gateway.push(params)).resp;
     } else {
-      resp = (await gateway.pushAdd({ jobName })).resp;
+      resp = (await gateway.pushAdd(params)).resp;
     }
   } catch (e) {
     log.error('Error when pushing metrics', { error: format(e) });
@@ -63,4 +73,44 @@ export async function submitMetrics(
       ? (resp as any).statusCode
       : 'unknown';
   log.info('Prometheus metrics pushed to PushGateway', { statusCode });
+}
+
+/**
+ * Deletes a metric group from the Prometheus push gateway (DELETE). This is the
+ * only way to clear a series: PushGateway retains the last pushed sample until
+ * its group is explicitly deleted. Pass the same groupings used when the series
+ * was pushed so exactly that group is removed and no other series is affected.
+ *
+ * @param register - The Prometheus registry (used only to resolve the gateway)
+ * @param jobName - The job name the metrics were pushed under
+ * @param groupings - Grouping labels identifying the group to delete
+ * @param logger - Optional logger instance
+ */
+export async function deleteMetrics(
+  register: Registry,
+  jobName: string,
+  groupings?: Record<string, string>,
+  logger?: Logger,
+): Promise<void> {
+  const log = logger ?? rootLogger.child({ module: 'metrics' });
+  const gateway = getPushGateway(register, log);
+  if (!gateway) return;
+
+  let resp;
+  try {
+    resp = (await gateway.delete({ jobName, groupings })).resp;
+  } catch (e) {
+    log.error('Error when deleting metrics', { error: format(e) });
+    return;
+  }
+
+  const statusCode =
+    typeof resp == 'object' && resp != null && 'statusCode' in resp
+      ? (resp as any).statusCode
+      : 'unknown';
+  log.info('Prometheus metrics deleted from PushGateway', {
+    jobName,
+    groupings,
+    statusCode,
+  });
 }


### PR DESCRIPTION
## Summary

- Each `hyperlane_check_violations` series is now pushed to its **own** PushGateway group, keyed by a base64url `alert_key` grouping label composed of `warp_route_id \0 chain \0 contract_name \0 type` (NUL-separated; base64url so the `/` in `warp_route_id` and empty `contract_name` stay URL-path-safe).
- **Removed the run-wide `overwriteAllMetrics` PUT.** A checker run that does not observe a given violation now leaves that series untouched — stale RPCs or a partial/aborted run can no longer silently auto-clear a real alert.
- Clearing a violation is now an explicit, human-confirmed action: new `typescript/infra/scripts/check/clear-warp-violation.ts` DELETEs exactly one group. Backed by a new `deleteMetrics` helper + optional `groupings` param on `submitMetrics` in `@hyperlane-xyz/metrics`.

This implements the manual-resolution loop: PD fires → Haggis triages → human confirms fix → Haggis explicitly clears the alert. Ghost/stale series can no longer clear or resurrect on their own.

### Rollout note
After deploy, the legacy job-only PushGateway group (holds all series accumulated under the old single-group PUT) must be DELETEd **once** — the intentional one-time backlog clear. New pushes land under the per-series `alert_key` groups.

## Test plan

- [ ] `pnpm -C typescript/metrics build` (done, clean)
- [ ] `oxlint` on `typescript/metrics/src` + `typescript/infra/scripts/check` (done, 0/0)
- [ ] infra `tsc --noEmit` (done, clean)
- [ ] Dry-run the checker against a route with a known violation; confirm each violation appears as its own `{job, alert_key}` group on PushGateway
- [ ] Run `clear-warp-violation.ts` for one violation; confirm only that group is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)