### PR TITLE
fix(infra): expect customer timelocks as MITO proxyAdmin owners

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getMitosisMITOWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getMitosisMITOWarpConfig.ts
@@ -10,7 +10,9 @@ import {
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
 
-// TODO: update with new owners once they are updated
+// Mitosis (customer) EOA. Still owns the ISMs; the proxyAdmins on both chains
+// were handed off to the customer governance timelocks on 2025-09-23, so
+// proxyAdmin ownership is expected to be the per-chain timelock, not this EOA.
 const mitosisOwner = '0x8f51e8e0Ce90CC1B6E60a3E434c7E63DeaD13612';
 const mitosisTimelockOwner = '0x1248163200964459971c7cC9631909132AD28C27';
 const bscTimelockOwner = '0x1248163214D9A0D6F02932A245370D3fD9613A82';
@@ -23,7 +25,7 @@ export const getMitosisMITOWarpConfig = async (
     owner: mitosisTimelockOwner,
     type: TokenType.native,
     ownerOverrides: {
-      proxyAdmin: mitosisOwner,
+      proxyAdmin: mitosisTimelockOwner,
     },
     hook: {
       type: HookType.AGGREGATION,
@@ -60,7 +62,7 @@ export const getMitosisMITOWarpConfig = async (
     ...routerConfig.bsc,
     owner: bscTimelockOwner,
     ownerOverrides: {
-      proxyAdmin: mitosisOwner,
+      proxyAdmin: bscTimelockOwner,
     },
     type: TokenType.synthetic,
     symbol: 'MITO',


### PR DESCRIPTION
## Summary

The MITO/mitosis warp route proxyAdmins were handed off from the Mitosis (customer) EOA (`0x8f51e8e0…13612`) to the customer's governance timelocks on **2025-09-23** via self-signed `transferOwnership` txs:

- **bsc** proxyAdmin `0xb80d5c3D…db66` → `0x1248163214…3A82` (tx `0x55ce24f9…bbfd7`)
- **mitosis** proxyAdmin `0x8452…89ca` → `0x1248163200…28C27` (tx `0xe7d84eb2…db33d`)

The warp checker still expected that EOA (via `ownerOverrides.proxyAdmin`), producing a spurious `proxyAdmin` Owner violation (`WarpRoute-ConfigMismatch`). This points the expected proxyAdmin owner at the per-chain customer timelock (the same address as the route `owner`), matching verified on-chain state.

Verified on-chain:
- `cast call <bsc proxyAdmin> owner()` → `0x1248163214D9A0D6F02932A245370D3fD9613A82`
- `cast call <mitosis proxyAdmin> owner()` → `0x1248163200964459971c7cC9631909132AD28C27`

ISM owners (FALLBACK_ROUTING, PAUSABLE) are intentionally left as the Mitosis customer EOA `0x8f51e8e0` — those were not part of the handoff and still match on-chain.

Paired with the registry update to `deployments/warp_routes/MITO/mitosis-deploy.yaml` (separate PR in hyperlane-registry).

## Test plan

- [ ] `pnpm -C typescript/infra tsx scripts/check/check-warp-deploy.ts -e mainnet3 --warpRouteId MITO/... ` shows no proxyAdmin Owner violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)