### PR TITLE
feat(sdk): rebalanceTargets support for CrossCollateralRouter

### DIFF
--- a/.changeset/rebalance-recipients-sdk.md
+++ b/.changeset/rebalance-recipients-sdk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added `rebalanceRecipients` support for `CrossCollateralRouter` warp configs, including apply transactions for `setRecipient` and `removeRecipient` and reader round-tripping through `allowedRecipient`.

--- a/.changeset/rebalance-targets-sdk.md
+++ b/.changeset/rebalance-targets-sdk.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Add first-class `rebalanceTargets` support for `CrossCollateralRouter` warp configs (completing the SDK surface for #8894's `IRebalanceTargets`). The `crossCollateral` token config gains an optional `rebalanceTargets` map (domain/chain → target router addresses); `EvmWarpModule` diffs it and emits `addRebalanceTarget(uint32,bytes32)` / `removeRebalanceTarget(uint32,bytes32)` during `warp apply`, and `EvmWarpRouteReader` reads it back (across all domains including the local domain), so it round-trips idempotently.

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -85,6 +85,7 @@ import { resolveTokenFeeAddress } from './configUtils.js';
 import { hypERC20contracts } from './contracts.js';
 import { HypERC20Deployer } from './deploy.js';
 import {
+  CrossCollateralTokenConfig,
   DerivedTokenRouterConfig,
   EverclearCollateralTokenConfig,
   HypTokenRouterConfig,
@@ -141,6 +142,17 @@ const getAllowedRebalancingBridgesByDomain = (
         ),
       );
     },
+  );
+};
+
+const getRebalanceTargetsByDomain = (
+  rebalanceTargetsByDomain: NonNullable<
+    CrossCollateralTokenConfig['rebalanceTargets']
+  >,
+): Record<string, Set<Address>> => {
+  return objMap(
+    rebalanceTargetsByDomain,
+    (_domainId, targets) => new Set(targets.map(normalizeAddressEvm)),
   );
 };
 export class EvmWarpModule extends HyperlaneModule<
@@ -289,6 +301,8 @@ export class EvmWarpModule extends HyperlaneModule<
         expectedConfig,
       )),
       ...this.createRemoveBridgesTxs(actualConfig, expectedConfig),
+      ...this.createAddRebalanceTargetsUpdateTxs(actualConfig, expectedConfig),
+      ...this.createRemoveRebalanceTargetsTxs(actualConfig, expectedConfig),
       ...(await this.createRevokeStaleBridgeAllowancesTxs(
         actualConfig,
         expectedConfig,
@@ -837,6 +851,99 @@ export class EvmWarpModule extends HyperlaneModule<
           };
         });
       },
+    );
+  }
+
+  createAddRebalanceTargetsUpdateTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (
+      !isCrossCollateralTokenConfig(expectedConfig) ||
+      !isCrossCollateralTokenConfig(actualConfig)
+    ) {
+      return [];
+    }
+
+    if (!expectedConfig.rebalanceTargets) {
+      return [];
+    }
+
+    const actualTargets = getRebalanceTargetsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        actualConfig.rebalanceTargets ?? {},
+      ),
+    );
+    const expectedTargets = getRebalanceTargetsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        expectedConfig.rebalanceTargets,
+      ),
+    );
+
+    const targetsToAddByDomain = objMap(expectedTargets, (domain, targets) => {
+      const actual = actualTargets[domain] ?? new Set();
+      return Array.from(difference(targets, actual));
+    });
+
+    return Object.entries(targetsToAddByDomain).flatMap(([domain, toAdd]) =>
+      toAdd.map((target) => ({
+        chainId: this.chainId,
+        annotation: `Adding rebalance target "${target}" for domain ${domain} on token "${this.args.addresses.deployedTokenRoute}" on chain "${this.chainName}"`,
+        to: this.args.addresses.deployedTokenRoute,
+        data: CrossCollateralRouter__factory.createInterface().encodeFunctionData(
+          'addRebalanceTarget(uint32,bytes32)',
+          [domain, addressToBytes32(target)],
+        ),
+      })),
+    );
+  }
+
+  createRemoveRebalanceTargetsTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (
+      !isCrossCollateralTokenConfig(expectedConfig) ||
+      !isCrossCollateralTokenConfig(actualConfig)
+    ) {
+      return [];
+    }
+
+    if (!expectedConfig.rebalanceTargets) {
+      return [];
+    }
+
+    const actualTargets = getRebalanceTargetsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        actualConfig.rebalanceTargets ?? {},
+      ),
+    );
+    const expectedTargets = getRebalanceTargetsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        expectedConfig.rebalanceTargets,
+      ),
+    );
+
+    const targetsToRemoveByDomain = objMap(actualTargets, (domain, targets) => {
+      const expected = expectedTargets[domain] ?? new Set();
+      return Array.from(difference(targets, expected));
+    });
+
+    return Object.entries(targetsToRemoveByDomain).flatMap(
+      ([domain, toRemove]) =>
+        toRemove.map((target) => ({
+          chainId: this.chainId,
+          annotation: `Removing rebalance target "${target}" for domain ${domain} on token "${this.args.addresses.deployedTokenRoute}" on chain "${this.chainName}"`,
+          to: this.args.addresses.deployedTokenRoute,
+          data: CrossCollateralRouter__factory.createInterface().encodeFunctionData(
+            'removeRebalanceTarget(uint32,bytes32)',
+            [domain, addressToBytes32(target)],
+          ),
+        })),
     );
   }
 

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -155,6 +155,16 @@ const getRebalanceTargetsByDomain = (
     (_domainId, targets) => new Set(targets.map(normalizeAddressEvm)),
   );
 };
+
+const getRebalanceRecipientsByDomain = (
+  rebalanceRecipientsByDomain: NonNullable<
+    CrossCollateralTokenConfig['rebalanceRecipients']
+  >,
+): Record<string, Address> => {
+  return objMap(rebalanceRecipientsByDomain, (_domainId, recipient) =>
+    normalizeAddressEvm(recipient),
+  );
+};
 export class EvmWarpModule extends HyperlaneModule<
   ProtocolType.Ethereum,
   HypTokenRouterConfig,
@@ -303,6 +313,8 @@ export class EvmWarpModule extends HyperlaneModule<
       ...this.createRemoveBridgesTxs(actualConfig, expectedConfig),
       ...this.createAddRebalanceTargetsUpdateTxs(actualConfig, expectedConfig),
       ...this.createRemoveRebalanceTargetsTxs(actualConfig, expectedConfig),
+      ...this.createSetRecipientsUpdateTxs(actualConfig, expectedConfig),
+      ...this.createRemoveRecipientsTxs(actualConfig, expectedConfig),
       ...(await this.createRevokeStaleBridgeAllowancesTxs(
         actualConfig,
         expectedConfig,
@@ -945,6 +957,98 @@ export class EvmWarpModule extends HyperlaneModule<
           ),
         })),
     );
+  }
+
+  createSetRecipientsUpdateTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (
+      !isCrossCollateralTokenConfig(expectedConfig) ||
+      !isCrossCollateralTokenConfig(actualConfig)
+    ) {
+      return [];
+    }
+
+    if (!expectedConfig.rebalanceRecipients) {
+      return [];
+    }
+
+    const actualRecipients = getRebalanceRecipientsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        actualConfig.rebalanceRecipients ?? {},
+      ),
+    );
+    const expectedRecipients = getRebalanceRecipientsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        expectedConfig.rebalanceRecipients,
+      ),
+    );
+
+    const recipientsToSetByDomain = objDiff(
+      expectedRecipients,
+      actualRecipients,
+    );
+
+    return Object.entries(recipientsToSetByDomain).map(
+      ([domain, recipient]) => ({
+        chainId: this.chainId,
+        annotation: `Setting rebalance recipient "${recipient}" for domain ${domain} on token "${this.args.addresses.deployedTokenRoute}" on chain "${this.chainName}"`,
+        to: this.args.addresses.deployedTokenRoute,
+        data: CrossCollateralRouter__factory.createInterface().encodeFunctionData(
+          'setRecipient(uint32,bytes32)',
+          [domain, addressToBytes32(recipient)],
+        ),
+      }),
+    );
+  }
+
+  createRemoveRecipientsTxs(
+    actualConfig: DerivedTokenRouterConfig,
+    expectedConfig: HypTokenRouterConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (
+      !isCrossCollateralTokenConfig(expectedConfig) ||
+      !isCrossCollateralTokenConfig(actualConfig)
+    ) {
+      return [];
+    }
+
+    if (!expectedConfig.rebalanceRecipients) {
+      return [];
+    }
+
+    const actualRecipients = getRebalanceRecipientsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        actualConfig.rebalanceRecipients ?? {},
+      ),
+    );
+    const expectedRecipients = getRebalanceRecipientsByDomain(
+      resolveRouterMapConfig(
+        this.multiProvider,
+        expectedConfig.rebalanceRecipients,
+      ),
+    );
+
+    const recipientDomainsToRemove = Array.from(
+      difference(
+        new Set(Object.keys(actualRecipients)),
+        new Set(Object.keys(expectedRecipients)),
+      ),
+    );
+
+    return recipientDomainsToRemove.map((domain) => ({
+      chainId: this.chainId,
+      annotation: `Removing rebalance recipient for domain ${domain} on token "${this.args.addresses.deployedTokenRoute}" on chain "${this.chainName}"`,
+      to: this.args.addresses.deployedTokenRoute,
+      data: CrossCollateralRouter__factory.createInterface().encodeFunctionData(
+        'removeRecipient(uint32)',
+        [domain],
+      ),
+    }));
   }
 
   /**

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -35,10 +35,12 @@ import {
   Address,
   arrayToObject,
   assert,
+  bytes32ToAddress,
   eqAddress,
   getLogLevel,
   isZeroish,
   isZeroishAddress,
+  normalizeAddressEvm,
   objFilter,
   objMap,
   promiseObjAll,
@@ -1439,13 +1441,23 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       ]),
     ];
     const crossCollateralRouters: Record<string, string[]> = {};
+    const rebalanceTargets: Record<string, string[]> = {};
 
     await Promise.all(
       allDomains.map(async (domain) => {
-        const routers =
-          await crossCollateralRouter.getCrossCollateralRouters(domain);
+        const [routers, targets] = await Promise.all([
+          crossCollateralRouter.getCrossCollateralRouters(domain),
+          crossCollateralRouter.rebalanceTargets(domain),
+        ]);
         if (routers.length > 0) {
           crossCollateralRouters[domain.toString()] = [...routers];
+        }
+        if (targets.length > 0) {
+          // rebalanceTargets stores addresses (as bytes32); the config keeps
+          // plain addresses, so normalize for a clean apply/read round-trip.
+          rebalanceTargets[domain.toString()] = targets.map((t) =>
+            normalizeAddressEvm(bytes32ToAddress(t)),
+          );
         }
       }),
     );
@@ -1459,6 +1471,8 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         Object.keys(crossCollateralRouters).length > 0
           ? crossCollateralRouters
           : undefined,
+      rebalanceTargets:
+        Object.keys(rebalanceTargets).length > 0 ? rebalanceTargets : undefined,
     };
   }
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -1442,6 +1442,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     ];
     const crossCollateralRouters: Record<string, string[]> = {};
     const rebalanceTargets: Record<string, string[]> = {};
+    const rebalanceRecipients: Record<string, string> = {};
 
     await Promise.all(
       allDomains.map(async (domain) => {
@@ -1479,6 +1480,29 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       );
     }
 
+    // `allowedRecipient()` may not exist on older deployed implementations.
+    // Probe once so deriving a pre-upgrade router does not fail.
+    let supportsRebalanceRecipients = true;
+    try {
+      await crossCollateralRouter.allowedRecipient(localDomain);
+    } catch {
+      supportsRebalanceRecipients = false;
+    }
+
+    if (supportsRebalanceRecipients) {
+      await Promise.all(
+        allDomains.map(async (domain) => {
+          const recipient =
+            await crossCollateralRouter.allowedRecipient(domain);
+          if (!isZeroishAddress(recipient)) {
+            rebalanceRecipients[domain.toString()] = normalizeAddressEvm(
+              bytes32ToAddress(recipient),
+            );
+          }
+        }),
+      );
+    }
+
     return {
       ...erc20TokenMetadata,
       type: TokenType.crossCollateral,
@@ -1490,6 +1514,10 @@ export class EvmWarpRouteReader extends EvmRouterReader {
           : undefined,
       rebalanceTargets:
         Object.keys(rebalanceTargets).length > 0 ? rebalanceTargets : undefined,
+      rebalanceRecipients:
+        Object.keys(rebalanceRecipients).length > 0
+          ? rebalanceRecipients
+          : undefined,
     };
   }
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -1445,22 +1445,39 @@ export class EvmWarpRouteReader extends EvmRouterReader {
 
     await Promise.all(
       allDomains.map(async (domain) => {
-        const [routers, targets] = await Promise.all([
-          crossCollateralRouter.getCrossCollateralRouters(domain),
-          crossCollateralRouter.rebalanceTargets(domain),
-        ]);
+        const routers =
+          await crossCollateralRouter.getCrossCollateralRouters(domain);
         if (routers.length > 0) {
           crossCollateralRouters[domain.toString()] = [...routers];
         }
-        if (targets.length > 0) {
-          // rebalanceTargets stores addresses (as bytes32); the config keeps
-          // plain addresses, so normalize for a clean apply/read round-trip.
-          rebalanceTargets[domain.toString()] = targets.map((t) =>
-            normalizeAddressEvm(bytes32ToAddress(t)),
-          );
-        }
       }),
     );
+
+    // `rebalanceTargets()` only exists on the #8894+ CrossCollateralRouter;
+    // older deployed impls revert. Probe once so a pre-upgrade router is derived
+    // without failing (e.g. when the same `warp apply` both upgrades the impl
+    // and adds targets), and skip the per-domain reads if unsupported.
+    let supportsRebalanceTargets = true;
+    try {
+      await crossCollateralRouter.rebalanceTargets(localDomain);
+    } catch {
+      supportsRebalanceTargets = false;
+    }
+
+    if (supportsRebalanceTargets) {
+      await Promise.all(
+        allDomains.map(async (domain) => {
+          const targets = await crossCollateralRouter.rebalanceTargets(domain);
+          if (targets.length > 0) {
+            // rebalanceTargets stores addresses (as bytes32); the config keeps
+            // plain addresses, so normalize for a clean apply/read round-trip.
+            rebalanceTargets[domain.toString()] = targets.map((t) =>
+              normalizeAddressEvm(bytes32ToAddress(t)),
+            );
+          }
+        }),
+      );
+    }
 
     return {
       ...erc20TokenMetadata,

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -372,6 +372,14 @@ export const CrossCollateralTokenConfigSchema =
     crossCollateralRouters: z
       .record(RemoteRouterDomainOrChainNameSchema, z.array(ZHash))
       .optional(),
+    /**
+     * Map of domain → rebalance target router addresses (beyond the enrolled
+     * remote router), authorized via `addRebalanceTarget`. Used e.g. to let a
+     * same-chain AtomicLocalRebalancingBridge fund a sibling collateral router.
+     */
+    rebalanceTargets: z
+      .record(RemoteRouterDomainOrChainNameSchema, z.array(ZHash))
+      .optional(),
     ...BaseMovableTokenConfigSchema.shape,
     predicateWrapper: PredicateWrapperConfigSchema.optional(),
   });

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -380,6 +380,14 @@ export const CrossCollateralTokenConfigSchema =
     rebalanceTargets: z
       .record(RemoteRouterDomainOrChainNameSchema, z.array(ZHash))
       .optional(),
+    /**
+     * Map of domain → the rebalance recipient router address applied via
+     * `setRecipient()`; e.g. the same-chain sibling CrossCollateralRouter for an
+     * AtomicLocalRebalancingBridge escrow.
+     */
+    rebalanceRecipients: z
+      .record(RemoteRouterDomainOrChainNameSchema, ZHash)
+      .optional(),
     ...BaseMovableTokenConfigSchema.shape,
     predicateWrapper: PredicateWrapperConfigSchema.optional(),
   });


### PR DESCRIPTION
## Summary
Completes the SDK surface for #8894's `IRebalanceTargets`, so `CrossCollateralRouter` rebalance targets can be set in config and applied via `hyperlane warp apply` (no manual `cast`).

- `token/types.ts` — optional `rebalanceTargets` map (domain/chain → target router addresses) on `CrossCollateralTokenConfigSchema`.
- `token/EvmWarpModule.ts` — `createAddRebalanceTargetsUpdateTxs` / `createRemoveRebalanceTargetsTxs` diff the config and emit `CrossCollateralRouter.addRebalanceTarget(uint32,bytes32)` / `removeRebalanceTarget`; wired into `createUpdateTxs` after the bridge txs.
- `token/EvmWarpRouteReader.ts` — reads `rebalanceTargets(domain)` across all domains (incl. the local domain, which is readable), so the field round-trips **idempotently**.

Mirrors the existing `allowedRebalancingBridges` add/remove/read machinery.

## Base
Targets `audit-q3-2026` because `addRebalanceTarget` only exists on #8894's `CrossCollateralRouter` (that branch). Rides #8988 to `main`.

## Follow-up
A hardhat apply/read unit test (mirroring the `allowedRebalancingBridges` tests) is TODO; behavior is validated end-to-end on a Base fork by the stacked wiring branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)