### PR TITLE
feat(infra): wire local rebalancing bridges into CROSS/moonpay-staging (Base)

### DIFF
--- a/solidity/test/token/AtomicLocalRebalancingBridge.fork.t.sol
+++ b/solidity/test/token/AtomicLocalRebalancingBridge.fork.t.sol
@@ -364,3 +364,214 @@ contract AtomicLocalRebalancingBridgeBaseForkTest is
         );
     }
 }
+
+interface IUniswapV3SwapRouter02 {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(
+        ExactInputSingleParams calldata params
+    ) external payable returns (uint256 amountOut);
+}
+
+contract AtomicLocalRebalancingBridgeBaseUniswapForwardForkTest is
+    AtomicLocalRebalancingBridgeForkTestBase
+{
+    address internal constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address internal constant USDT = 0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2;
+    address internal constant UNISWAP_V3_ROUTER =
+        0x2626664c2603336E57B271c5C0b26F421741e481;
+    uint32 internal constant LOCAL_DOMAIN = 8453;
+    uint256 internal constant FORK_BLOCK = 48_000_000;
+
+    function setUp() public {
+        _setUpFork(
+            "base",
+            FORK_BLOCK,
+            IERC20(USDC),
+            IERC20(USDT),
+            LOCAL_DOMAIN
+        );
+
+        deal(USDC, address(sourceRouter), 1_000e6);
+        deal(USDT, rebalancer, 1_000e6);
+        _approveOutputForBridge(IERC20(USDT));
+    }
+
+    function testFork_uniswapExactInputSingle_exactFunding() public {
+        uint256 amountIn = 100e6;
+        uint256 destinationBefore = IERC20(USDT).balanceOf(
+            address(destinationRouter)
+        );
+
+        vm.prank(rebalancer);
+        _localRebalance(amountIn, _uniswapCalls(amountIn, 0));
+
+        _assertExactFunding(
+            IERC20(USDT),
+            amountIn,
+            destinationBefore,
+            IERC20(USDT).balanceOf(rebalancer)
+        );
+    }
+
+    function testFork_uniswapExactInputSingle_surplusRefundedToRebalancer()
+        public
+    {
+        uint256 amountIn = 100e6;
+        uint256 destinationBefore = IERC20(USDT).balanceOf(
+            address(destinationRouter)
+        );
+        uint256 rebalancerBefore = IERC20(USDT).balanceOf(rebalancer);
+
+        vm.prank(rebalancer);
+        _localRebalance(amountIn, _uniswapCalls(amountIn, 0));
+
+        assertEq(
+            IERC20(USDT).balanceOf(address(destinationRouter)) -
+                destinationBefore,
+            amountIn
+        );
+        assertGt(IERC20(USDT).balanceOf(rebalancer), rebalancerBefore);
+        assertEq(IERC20(USDT).balanceOf(address(bridge)), 0);
+    }
+
+    function _uniswapCalls(
+        uint256 amountIn,
+        uint256 topUp
+    ) internal view returns (CallLib.Call[] memory calls) {
+        calls = new CallLib.Call[](topUp == 0 ? 2 : 3);
+        calls[0] = _approveInputCall(IERC20(USDC), UNISWAP_V3_ROUTER, amountIn);
+        calls[1] = _uniswapV3Call(USDC, USDT, amountIn);
+        if (topUp > 0) {
+            calls[2] = _topUpCall(IERC20(USDT), topUp);
+        }
+    }
+
+    function _uniswapV3Call(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) private view returns (CallLib.Call memory) {
+        return
+            _targetCall(
+                UNISWAP_V3_ROUTER,
+                abi.encodeCall(
+                    IUniswapV3SwapRouter02.exactInputSingle,
+                    (
+                        IUniswapV3SwapRouter02.ExactInputSingleParams({
+                            tokenIn: tokenIn,
+                            tokenOut: tokenOut,
+                            fee: 100,
+                            recipient: address(bridge),
+                            amountIn: amountIn,
+                            amountOutMinimum: 1,
+                            sqrtPriceLimitX96: 0
+                        })
+                    )
+                )
+            );
+    }
+}
+
+contract AtomicLocalRebalancingBridgeBaseUniswapReverseForkTest is
+    AtomicLocalRebalancingBridgeForkTestBase
+{
+    address internal constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address internal constant USDT = 0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2;
+    address internal constant UNISWAP_V3_ROUTER =
+        0x2626664c2603336E57B271c5C0b26F421741e481;
+    uint32 internal constant LOCAL_DOMAIN = 8453;
+    uint256 internal constant FORK_BLOCK = 48_000_000;
+
+    function setUp() public {
+        _setUpFork(
+            "base",
+            FORK_BLOCK,
+            IERC20(USDT),
+            IERC20(USDC),
+            LOCAL_DOMAIN
+        );
+
+        deal(USDT, address(sourceRouter), 1_000e6);
+        deal(USDC, rebalancer, 1_000e6);
+        _approveOutputForBridge(IERC20(USDC));
+    }
+
+    function testFork_uniswapExactInputSingle_shortfallCoveredByTopUp() public {
+        uint256 amountIn = 100e6;
+        uint256 destinationBefore = IERC20(USDC).balanceOf(
+            address(destinationRouter)
+        );
+        uint256 rebalancerBefore = IERC20(USDC).balanceOf(rebalancer);
+
+        vm.prank(rebalancer);
+        _localRebalance(amountIn, _uniswapCalls(amountIn, 20e6));
+
+        _assertExactFunding(
+            IERC20(USDC),
+            amountIn,
+            destinationBefore,
+            rebalancerBefore
+        );
+        assertLt(IERC20(USDC).balanceOf(rebalancer), rebalancerBefore);
+    }
+
+    function testFork_uniswapExactInputSingle_revertsWhenOutputBelowRequired()
+        public
+    {
+        uint256 amountIn = 100e6;
+
+        vm.prank(rebalancer);
+        vm.expectRevert(
+            AtomicLocalRebalancingBridge
+                .InsufficientOutputTokenProduced
+                .selector
+        );
+        _localRebalance(amountIn, _uniswapCalls(amountIn, 0));
+    }
+
+    function _uniswapCalls(
+        uint256 amountIn,
+        uint256 topUp
+    ) internal view returns (CallLib.Call[] memory calls) {
+        calls = new CallLib.Call[](topUp == 0 ? 2 : 3);
+        calls[0] = _approveInputCall(IERC20(USDT), UNISWAP_V3_ROUTER, amountIn);
+        calls[1] = _uniswapV3Call(USDT, USDC, amountIn);
+        if (topUp > 0) {
+            calls[2] = _topUpCall(IERC20(USDC), topUp);
+        }
+    }
+
+    function _uniswapV3Call(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) private view returns (CallLib.Call memory) {
+        return
+            _targetCall(
+                UNISWAP_V3_ROUTER,
+                abi.encodeCall(
+                    IUniswapV3SwapRouter02.exactInputSingle,
+                    (
+                        IUniswapV3SwapRouter02.ExactInputSingleParams({
+                            tokenIn: tokenIn,
+                            tokenOut: tokenOut,
+                            fee: 100,
+                            recipient: address(bridge),
+                            amountIn: amountIn,
+                            amountOutMinimum: 1,
+                            sqrtPriceLimitX96: 0
+                        })
+                    )
+                )
+            );
+    }
+}

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
@@ -1,0 +1,238 @@
+import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32, assert } from '@hyperlane-xyz/utils';
+
+import {
+  RouterConfigWithoutOwner,
+  tokens,
+} from '../../../../../src/config/warp.js';
+import { getDomainId, getRegistry } from '../../../../registry.js';
+import { DEPLOYER } from '../../owners.js';
+import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
+import { WarpRouteIds } from '../warpIds.js';
+import {
+  getRebalancingBridgesConfigFor,
+  getUSDCRebalancingBridgesConfigFor,
+  getWarpRouteAddressByChain,
+  mergeAllowedBridges,
+} from './utils.js';
+
+// Contract version to upgrade the base CCR to (the #8894 impl, needed for
+// isRebalanceTarget/addRebalanceTarget + local-domain addBridge). Matches the
+// pending audit-branch major release for @hyperlane-xyz/core.
+const REBALANCE_TARGET_CONTRACT_VERSION = '12.0.0';
+
+// Staging mimic of the production CROSS/moonpay USDC route (getUSDCCitreaMoonpayWarpConfig).
+// Deliberately simplified for a deployer-owned test route:
+//   - all routers owned by the deployer key (easy iteration, no Safe/ICA governance)
+//   - default ISM everywhere (omit interchainSecurityModule -> mailbox default ISM)
+//   - default hook on EVM (omit hook); Solana keeps its IGP hook (required)
+//   - zero warp fee (omit tokenFee) -> no offchain-quote / CCR fee surface
+// Rebalancing IS reproduced from prod: same allowedRebalancers (MCR signer) and the same
+// CCTP + Eclipse/Paradex/Igra/Radix + Iron (TBDA) bridge wiring per leg.
+// EXTRA_REBALANCER is additionally permitted on every EVM leg for staging (the Solana leg
+// has no rebalancer, matching prod).
+
+// Owned by the Hyperlane deployer key: EVM uses the shared DEPLOYER (owners.ts);
+// the Solana XO leg uses the mainnet3 sealevel deployer pubkey.
+const DEPLOYER_EVM = DEPLOYER;
+const DEPLOYER_SOLANA = '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf';
+
+const SOLANA_IGP_ADDRESS = 'BhNcatUDC2D5JTyeaqrdSukiVFsEHK7e3hVmKMztwefv';
+const SOLANA_XO_TOKEN_MINT = 'xoUSDq85Rjsb6SbUwJyreFgeWQvxdkT7R3c3g7s6p5Y';
+const SOLANA_XO_NAME = 'XO Cash';
+const SOLANA_XO_SYMBOL = 'XO';
+
+const REBALANCER = '0xa3948a15e1d0778a7d53268b651B2411AF198FE3';
+const EXTRA_REBALANCER = '0x2cB236403574301029c7bDDfda133c6e0338a857';
+const ALLOWED_REBALANCERS = [REBALANCER, EXTRA_REBALANCER];
+const EVM_CHAINS = ['arbitrum', 'base', 'ethereum', 'polygon'] as const;
+type EvmChain = (typeof EVM_CHAINS)[number];
+
+function getTBDAAddresses(): Record<
+  'arbitrum' | 'base' | 'ethereum' | 'citrea' | 'polygon',
+  string
+> {
+  const route = getRegistry().getWarpRoute(WarpRouteIds.USDCCitreaIronBridge);
+  assert(route, 'CROSS/ctusd-usdc-ironbridge route not found in registry');
+
+  const find = (chain: EvmChain | 'citrea') => {
+    const token = route.tokens.find((t) => t.chainName === chain);
+    assert(token?.addressOrDenom, `Missing TBDA address for ${chain}`);
+    return token.addressOrDenom;
+  };
+
+  return {
+    arbitrum: find('arbitrum'),
+    base: find('base'),
+    ethereum: find('ethereum'),
+    citrea: find('citrea'),
+    polygon: find('polygon'),
+  };
+}
+
+// Cross-collateral peers reference the sibling USDT staging route by deployed address.
+// On the first deploy that route does not exist yet, so return {} and wire the peers on a
+// second pass via `warp apply` once both routes are registered.
+function getSiblingCrossCollateralRouters(): Record<string, string[]> {
+  const route = getRegistry().getWarpRoute(
+    WarpRouteIds.USDTCitreaMoonpaySTAGING,
+  );
+  if (!route) return {};
+  return Object.fromEntries(
+    route.tokens.map(({ chainName, addressOrDenom }) => {
+      assert(addressOrDenom, `Missing USDT staging router for ${chainName}`);
+      return [
+        String(getDomainId(chainName)),
+        [addressToBytes32(addressOrDenom)],
+      ];
+    }),
+  );
+}
+
+export async function getUSDCCitreaMoonpayStagingWarpConfig(
+  routerConfig: ChainMap<RouterConfigWithoutOwner>,
+): Promise<ChainMap<HypTokenRouterConfig>> {
+  const crossCollateralRouters = getSiblingCrossCollateralRouters();
+
+  const cctpRebalancingConfigByChain = getUSDCRebalancingBridgesConfigFor(
+    ['arbitrum', 'base', 'ethereum', 'polygon'],
+    [WarpRouteIds.MainnetCCTPV2Standard, WarpRouteIds.MainnetCCTPV2Fast],
+  );
+
+  const additionalRebalancingConfigByChain = getRebalancingBridgesConfigFor(
+    ['arbitrum', 'base', 'bsc', 'ethereum', 'polygon'],
+    [
+      WarpRouteIds.EclipseUSDC,
+      WarpRouteIds.ParadexUSDC,
+      WarpRouteIds.IgraUSDC,
+      WarpRouteIds.RadixUSDC,
+    ],
+  );
+
+  const tbda = getTBDAAddresses();
+
+  assert(
+    additionalRebalancingConfigByChain.bsc,
+    'missing rebalancing config for bsc',
+  );
+
+  // Same-chain local rebalancing bridge (USDC-sourced) + its sibling USDT CCR
+  // rebalance target on Base — both resolved from the registry by warpId.
+  const localBridgeBase = getWarpRouteAddressByChain(
+    WarpRouteIds.CROSSMoonpayStagingLocalBridgeUSDC,
+    'base',
+  );
+  const usdtCcrBase = getWarpRouteAddressByChain(
+    WarpRouteIds.USDTCitreaMoonpaySTAGING,
+    'base',
+  );
+
+  return {
+    solanamainnet: {
+      type: TokenType.crossCollateral,
+      token: SOLANA_XO_TOKEN_MINT,
+      mailbox: routerConfig.solanamainnet.mailbox,
+      owner: DEPLOYER_SOLANA,
+      hook: SOLANA_IGP_ADDRESS,
+      gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+      name: SOLANA_XO_NAME,
+      symbol: SOLANA_XO_SYMBOL,
+      decimals: 6,
+      crossCollateralRouters,
+    },
+    arbitrum: {
+      type: TokenType.crossCollateral,
+      token: tokens.arbitrum.USDC,
+      mailbox: routerConfig.arbitrum.mailbox,
+      owner: DEPLOYER_EVM,
+      ...cctpRebalancingConfigByChain.arbitrum,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      allowedRebalancingBridges: mergeAllowedBridges(
+        cctpRebalancingConfigByChain.arbitrum.allowedRebalancingBridges,
+        additionalRebalancingConfigByChain.arbitrum?.allowedRebalancingBridges,
+        { [String(getDomainId('citrea'))]: [{ bridge: tbda.arbitrum }] },
+      ),
+      crossCollateralRouters,
+    },
+    base: {
+      type: TokenType.crossCollateral,
+      token: tokens.base.USDC,
+      mailbox: routerConfig.base.mailbox,
+      owner: DEPLOYER_EVM,
+      ...cctpRebalancingConfigByChain.base,
+      // Authorize the local rebalancing bridge as a rebalancer AND a bridge, and
+      // register its sibling USDT CCR as a same-chain rebalance target. Upgrade
+      // the CCR to the #8894 impl so these are supported on-chain.
+      contractVersion: REBALANCE_TARGET_CONTRACT_VERSION,
+      allowedRebalancers: [...ALLOWED_REBALANCERS, localBridgeBase],
+      allowedRebalancingBridges: mergeAllowedBridges(
+        cctpRebalancingConfigByChain.base.allowedRebalancingBridges,
+        additionalRebalancingConfigByChain.base?.allowedRebalancingBridges,
+        { [String(getDomainId('citrea'))]: [{ bridge: tbda.base }] },
+        { [String(getDomainId('base'))]: [{ bridge: localBridgeBase }] },
+      ),
+      rebalanceTargets: { [String(getDomainId('base'))]: [usdtCcrBase] },
+      crossCollateralRouters,
+    },
+    bsc: {
+      type: TokenType.crossCollateral,
+      token: tokens.bsc.USDC,
+      mailbox: routerConfig.bsc.mailbox,
+      owner: DEPLOYER_EVM,
+      ...additionalRebalancingConfigByChain.bsc,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      scale: { numerator: 1, denominator: 1_000_000_000_000 },
+      crossCollateralRouters,
+    },
+    citrea: {
+      type: TokenType.crossCollateral,
+      token: tokens.citrea.ctUSD,
+      mailbox: routerConfig.citrea.mailbox,
+      owner: DEPLOYER_EVM,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      allowedRebalancingBridges: Object.fromEntries(
+        EVM_CHAINS.map((dest) => [
+          String(getDomainId(dest)),
+          [{ bridge: tbda.citrea }],
+        ]),
+      ),
+      crossCollateralRouters,
+    },
+    ethereum: {
+      type: TokenType.crossCollateral,
+      token: tokens.ethereum.USDC,
+      mailbox: routerConfig.ethereum.mailbox,
+      owner: DEPLOYER_EVM,
+      ...cctpRebalancingConfigByChain.ethereum,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      allowedRebalancingBridges: mergeAllowedBridges(
+        cctpRebalancingConfigByChain.ethereum.allowedRebalancingBridges,
+        additionalRebalancingConfigByChain.ethereum?.allowedRebalancingBridges,
+        { [String(getDomainId('citrea'))]: [{ bridge: tbda.ethereum }] },
+      ),
+      crossCollateralRouters,
+    },
+    katana: {
+      type: TokenType.crossCollateral,
+      token: tokens.katana.USDC,
+      mailbox: routerConfig.katana.mailbox,
+      owner: DEPLOYER_EVM,
+      allowedRebalancers: [EXTRA_REBALANCER],
+      crossCollateralRouters,
+    },
+    polygon: {
+      type: TokenType.crossCollateral,
+      token: tokens.polygon.USDC,
+      mailbox: routerConfig.polygon.mailbox,
+      owner: DEPLOYER_EVM,
+      ...cctpRebalancingConfigByChain.polygon,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      allowedRebalancingBridges: mergeAllowedBridges(
+        cctpRebalancingConfigByChain.polygon.allowedRebalancingBridges,
+        additionalRebalancingConfigByChain.polygon?.allowedRebalancingBridges,
+        { [String(getDomainId('citrea'))]: [{ bridge: tbda.polygon }] },
+      ),
+      crossCollateralRouters,
+    },
+  };
+}

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
@@ -181,6 +181,13 @@ export async function getUSDCCitreaMoonpayStagingWarpConfig(
       owner: DEPLOYER_EVM,
       ...additionalRebalancingConfigByChain.bsc,
       allowedRebalancers: ALLOWED_REBALANCERS,
+      // bsc USDC is 18-decimal (vs 6 elsewhere); the 1e12 scale reconciles it.
+      // Declaring name/symbol/decimals makes this leg satisfy TokenMetadataSchema
+      // so `warp apply`'s metadata derivation preserves `scale` (otherwise the
+      // scale is dropped and cross-chain decimals fail verification).
+      name: 'USD Coin',
+      symbol: 'USDC',
+      decimals: 18,
       scale: { numerator: 1, denominator: 1_000_000_000_000 },
       crossCollateralRouters,
     },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.ts
@@ -172,6 +172,10 @@ export async function getUSDCCitreaMoonpayStagingWarpConfig(
         { [String(getDomainId('base'))]: [{ bridge: localBridgeBase }] },
       ),
       rebalanceTargets: { [String(getDomainId('base'))]: [usdtCcrBase] },
+      // Local-domain rebalance recipient: setRecipient(base, USDT-CCR) so the
+      // ALRB escrow's source.rebalance(localDomain,…) can resolve _recipient
+      // (rebalanceTargets only satisfies isRebalanceTarget, not _recipient).
+      rebalanceRecipients: { [String(getDomainId('base'))]: usdtCcrBase },
       crossCollateralRouters,
     },
     bsc: {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
@@ -98,6 +98,10 @@ export async function getUSDTCitreaMoonpayStagingWarpConfig(
         [String(getDomainId('base'))]: [{ bridge: localBridgeBase }],
       },
       rebalanceTargets: { [String(getDomainId('base'))]: [usdcCcrBase] },
+      // Local-domain rebalance recipient: setRecipient(base, USDC-CCR) so the
+      // ALRB escrow's source.rebalance(localDomain,…) can resolve _recipient
+      // (rebalanceTargets only satisfies isRebalanceTarget, not _recipient).
+      rebalanceRecipients: { [String(getDomainId('base'))]: usdcCcrBase },
       crossCollateralRouters,
     },
     bsc: {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
@@ -1,0 +1,140 @@
+import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32, assert } from '@hyperlane-xyz/utils';
+
+import {
+  RouterConfigWithoutOwner,
+  tokens,
+} from '../../../../../src/config/warp.js';
+import { getDomainId, getRegistry } from '../../../../registry.js';
+import { DEPLOYER } from '../../owners.js';
+import { WarpRouteIds } from '../warpIds.js';
+import {
+  getRebalancingBridgesConfigFor,
+  getWarpRouteAddressByChain,
+} from './utils.js';
+
+// Upgrade the base CCR to the #8894 impl (needed for isRebalanceTarget/
+// addRebalanceTarget + local-domain addBridge). Matches the pending core major.
+const REBALANCE_TARGET_CONTRACT_VERSION = '12.0.0';
+
+// Staging mimic of the production CROSS/moonpay USDT route (getUSDTCitreaMoonpayWarpConfig).
+// Same simplifications as the USDC staging getter: deployer-owned, default ISM, default hook,
+// zero fee. 6 EVM chains (no Solana XO leg, no Citrea ctUSD leg — those live
+// on the USDC route, same as prod).
+// Rebalancing IS reproduced from prod: same allowedRebalancers (MCR signer) and the same
+// OFT + Eclipse USDT bridge wiring (arbitrum/bsc/ethereum/polygon; base + katana have none).
+// EXTRA_REBALANCER is additionally permitted on every leg for staging.
+
+// Owned by the shared Hyperlane deployer key (owners.ts DEPLOYER).
+const DEPLOYER_EVM = DEPLOYER;
+
+const REBALANCER = '0xa3948a15e1d0778a7d53268b651B2411AF198FE3';
+const EXTRA_REBALANCER = '0x2cB236403574301029c7bDDfda133c6e0338a857';
+const ALLOWED_REBALANCERS = [REBALANCER, EXTRA_REBALANCER];
+
+const EVM_CHAINS = ['arbitrum', 'base', 'ethereum', 'polygon'] as const;
+
+// Cross-collateral peers reference the sibling USDC staging route by deployed address.
+// Returns {} until that route is registered; wire on a second pass via `warp apply`.
+function getSiblingCrossCollateralRouters(): Record<string, string[]> {
+  const route = getRegistry().getWarpRoute(
+    WarpRouteIds.USDCCitreaMoonpaySTAGING,
+  );
+  if (!route) return {};
+  return Object.fromEntries(
+    route.tokens.map(({ chainName, addressOrDenom }) => {
+      assert(addressOrDenom, `Missing USDC staging router for ${chainName}`);
+      return [
+        String(getDomainId(chainName)),
+        [addressToBytes32(addressOrDenom)],
+      ];
+    }),
+  );
+}
+
+export async function getUSDTCitreaMoonpayStagingWarpConfig(
+  routerConfig: ChainMap<RouterConfigWithoutOwner>,
+): Promise<ChainMap<HypTokenRouterConfig>> {
+  const crossCollateralRouters = getSiblingCrossCollateralRouters();
+
+  const oftRebalancingConfigByChain = getRebalancingBridgesConfigFor(
+    [...EVM_CHAINS, 'bsc'],
+    [WarpRouteIds.USDTOft, WarpRouteIds.EclipseUSDT],
+  );
+
+  assert(oftRebalancingConfigByChain.bsc, 'missing rebalancing config for bsc');
+
+  // Same-chain local rebalancing bridge (USDT-sourced) + its sibling USDC CCR
+  // rebalance target on Base — both resolved from the registry by warpId.
+  const localBridgeBase = getWarpRouteAddressByChain(
+    WarpRouteIds.CROSSMoonpayStagingLocalBridgeUSDT,
+    'base',
+  );
+  const usdcCcrBase = getWarpRouteAddressByChain(
+    WarpRouteIds.USDCCitreaMoonpaySTAGING,
+    'base',
+  );
+
+  return {
+    arbitrum: {
+      type: TokenType.crossCollateral,
+      token: tokens.arbitrum.USDT,
+      mailbox: routerConfig.arbitrum.mailbox,
+      owner: DEPLOYER_EVM,
+      ...oftRebalancingConfigByChain.arbitrum,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      crossCollateralRouters,
+    },
+    base: {
+      type: TokenType.crossCollateral,
+      token: tokens.base.USDT,
+      mailbox: routerConfig.base.mailbox,
+      owner: DEPLOYER_EVM,
+      // Authorize the local rebalancing bridge as a rebalancer AND a bridge, and
+      // register its sibling USDC CCR as a same-chain rebalance target.
+      contractVersion: REBALANCE_TARGET_CONTRACT_VERSION,
+      allowedRebalancers: [EXTRA_REBALANCER, localBridgeBase],
+      allowedRebalancingBridges: {
+        [String(getDomainId('base'))]: [{ bridge: localBridgeBase }],
+      },
+      rebalanceTargets: { [String(getDomainId('base'))]: [usdcCcrBase] },
+      crossCollateralRouters,
+    },
+    bsc: {
+      type: TokenType.crossCollateral,
+      token: tokens.bsc.USDT,
+      mailbox: routerConfig.bsc.mailbox,
+      owner: DEPLOYER_EVM,
+      ...oftRebalancingConfigByChain.bsc,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      scale: { numerator: 1, denominator: 1_000_000_000_000 },
+      crossCollateralRouters,
+    },
+    ethereum: {
+      type: TokenType.crossCollateral,
+      token: tokens.ethereum.USDT,
+      mailbox: routerConfig.ethereum.mailbox,
+      owner: DEPLOYER_EVM,
+      ...oftRebalancingConfigByChain.ethereum,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      crossCollateralRouters,
+    },
+    katana: {
+      type: TokenType.crossCollateral,
+      token: tokens.katana.USDT,
+      mailbox: routerConfig.katana.mailbox,
+      owner: DEPLOYER_EVM,
+      allowedRebalancers: [EXTRA_REBALANCER],
+      crossCollateralRouters,
+    },
+    polygon: {
+      type: TokenType.crossCollateral,
+      token: tokens.polygon.USDT,
+      mailbox: routerConfig.polygon.mailbox,
+      owner: DEPLOYER_EVM,
+      ...oftRebalancingConfigByChain.polygon,
+      allowedRebalancers: ALLOWED_REBALANCERS,
+      crossCollateralRouters,
+    },
+  };
+}

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
@@ -107,6 +107,13 @@ export async function getUSDTCitreaMoonpayStagingWarpConfig(
       owner: DEPLOYER_EVM,
       ...oftRebalancingConfigByChain.bsc,
       allowedRebalancers: ALLOWED_REBALANCERS,
+      // bsc USDT is 18-decimal (vs 6 elsewhere); the 1e12 scale reconciles it.
+      // Declaring name/symbol/decimals makes this leg satisfy TokenMetadataSchema
+      // so `warp apply`'s metadata derivation preserves `scale` (otherwise the
+      // scale is dropped and cross-chain decimals fail verification).
+      name: 'Tether USD',
+      symbol: 'USDT',
+      decimals: 18,
       scale: { numerator: 1, denominator: 1_000_000_000_000 },
       crossCollateralRouters,
     },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
@@ -93,7 +93,10 @@ export async function getUSDTCitreaMoonpayStagingWarpConfig(
       // Authorize the local rebalancing bridge as a rebalancer AND a bridge, and
       // register its sibling USDC CCR as a same-chain rebalance target.
       contractVersion: REBALANCE_TARGET_CONTRACT_VERSION,
-      allowedRebalancers: [EXTRA_REBALANCER, localBridgeBase],
+      // Include the MCR signer (REBALANCER) so it can drive the reverse
+      // USDT->USDC ALRB rebalance — matches the USDC leg's ALLOWED_REBALANCERS
+      // (the same signer must be authorized on both base CCRs).
+      allowedRebalancers: [...ALLOWED_REBALANCERS, localBridgeBase],
       allowedRebalancingBridges: {
         [String(getDomainId('base'))]: [{ bridge: localBridgeBase }],
       },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -90,6 +90,36 @@ export function getUSDCRebalancingBridgesConfigFor(
   );
 }
 
+// Resolves the deployed router/bridge address for a chain from a registry warp
+// route, by warpId (no hardcoding). Mirrors getTBDAAddresses / getUsdtCrossCollateralRouters.
+export function getWarpRouteAddressByChain(
+  warpRouteId: WarpRouteIds,
+  chain: ChainName,
+): string {
+  const route = getRegistry().getWarpRoute(warpRouteId);
+  assert(route, `Warp route ${warpRouteId} not found in registry`);
+  const token = route.tokens.find((t) => t.chainName === chain);
+  assert(token?.addressOrDenom, `Missing ${warpRouteId} address for ${chain}`);
+  return token.addressOrDenom;
+}
+
+export function mergeAllowedBridges(
+  ...configs: (
+    | NonNullable<MovableTokenConfig['allowedRebalancingBridges']>
+    | undefined
+  )[]
+): NonNullable<MovableTokenConfig['allowedRebalancingBridges']> {
+  const result: NonNullable<MovableTokenConfig['allowedRebalancingBridges']> =
+    {};
+  for (const config of configs) {
+    if (!config) continue;
+    for (const [domain, bridges] of Object.entries(config)) {
+      result[domain] = [...(result[domain] ?? []), ...bridges];
+    }
+  }
+  return result;
+}
+
 export const getRebalancingUSDCConfigForChain = (
   currentChain: keyof typeof usdcTokenAddresses,
   routerConfigByChain: ChainMap<RouterConfigWithoutOwner>,

--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -151,6 +151,11 @@ export enum WarpRouteIds {
   USDCCitreaMoonpay = 'USDC/moonpay',
   USDCCitreaIronBridge = 'CROSS/ctusd-usdc-ironbridge',
   USDTCitreaMoonpay = 'USDT/moonpay',
+  USDCCitreaMoonpaySTAGING = 'USDC/moonpay-staging',
+  USDTCitreaMoonpaySTAGING = 'USDT/moonpay-staging',
+  // Deployed AtomicLocalRebalancingBridge routes (registry PR #1592)
+  CROSSMoonpayStagingLocalBridgeUSDC = 'CROSS/moonpay-staging-localbridge-usdc',
+  CROSSMoonpayStagingLocalBridgeUSDT = 'CROSS/moonpay-staging-localbridge-usdt',
 
   // TODO: uncomment when USDTOft warp routes are in the registry
   // USDT OFT

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -138,7 +138,9 @@ import { WarpRouteIds } from './environments/mainnet3/warp/warpIds.js';
 import { getCCTPWarpConfig as getTestnetCCTPWarpConfig } from './environments/testnet4/warp/getCCTPConfig.js';
 import { DEFAULT_REGISTRY_URI } from './registry.js';
 import { getUSDCCitreaIronBridgeWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDCCitreaIronBridgeWarpConfig.js';
+import { getUSDCCitreaMoonpayStagingWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayStagingWarpConfig.js';
 import { getUSDCCitreaMoonpayWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDCCitreaMoonpayWarpConfig.js';
+import { getUSDTCitreaMoonpayStagingWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.js';
 import { getUSDTCitreaMoonpayWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayWarpConfig.js';
 import { getUSDTOftWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTOftWarpConfig.js';
 import { getUSDTOftLegacyWarpConfig } from './environments/mainnet3/warp/configGetters/getUSDTOftLegacyWarpConfig.js';
@@ -234,6 +236,10 @@ export const warpConfigGetterMap: Record<string, WarpConfigGetter> = {
   [WarpRouteIds.USDCCitreaIronBridge]: getUSDCCitreaIronBridgeWarpConfig,
   [WarpRouteIds.USDCCitreaMoonpay]: getUSDCCitreaMoonpayWarpConfig,
   [WarpRouteIds.USDTCitreaMoonpay]: getUSDTCitreaMoonpayWarpConfig,
+  [WarpRouteIds.USDCCitreaMoonpaySTAGING]:
+    getUSDCCitreaMoonpayStagingWarpConfig,
+  [WarpRouteIds.USDTCitreaMoonpaySTAGING]:
+    getUSDTCitreaMoonpayStagingWarpConfig,
 };
 
 type StrategyConfigGetter = () => ChainSubmissionStrategy;

--- a/typescript/infra/src/config/warp.ts
+++ b/typescript/infra/src/config/warp.ts
@@ -85,6 +85,10 @@ export const tokens = {
     USDCe: '0xF1815bd50389c46847f0Bda824eC8da914045D14',
     USDC: '0x2D270e6886d130D724215A266106e6832161EAEd',
   },
+  katana: {
+    USDC: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+    USDT: '0x2DCa96907fde857dd3D816880A0df407eeB2D2F2',
+  },
   solanamainnet: {
     USDC: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
     USDT: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',


### PR DESCRIPTION
## Summary
Authorizes the deployed `AtomicLocalRebalancingBridge`s (registry PR hyperlane-xyz/hyperlane-registry#1592) on the **base** legs of `CROSS/moonpay-staging`, config-driven and registry-resolved:
- `allowedRebalancers` += the bridge, `allowedRebalancingBridges[base]` += the bridge, and `rebalanceTargets[base]` = the sibling CCR — all resolved from the registry by warpId (`getWarpRouteAddressByChain`), no hardcoding.
- `contractVersion: '12.0.0'` on the base CCRs so `warp apply` upgrades them to the #8894 impl (needed for `isRebalanceTarget`/`addRebalanceTarget` + local-domain `addBridge`).
- Brings the two `moonpay-staging` getters onto the audit line + adds `mergeAllowedBridges` / `getWarpRouteAddressByChain`, the staging + localbridge `WarpRouteIds`, and the `katana` token entry.

**Stacked on** #<rebalance-targets PR> (base `mo/alrb-rebalance-targets`).

## Verified
- `tsc` clean (sdk + infra); `generate-warp-config` for both staging routes shows the base leg with the bridge in `allowedRebalancers` + `allowedRebalancingBridges[8453]`, sibling in `rebalanceTargets[8453]`, `contractVersion 12.0.0`.
- Fork test (Base) of the upgrade + wiring: pending (Phase F).

## Note
Temporary audit-line branch; reconciles to `main` when #8988 lands (where the moonpay-staging getters already exist and core is really 12.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)