### PR TITLE
fix: install explicit rustls CryptoProvider to fix TLS backend regression

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6116,6 +6116,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_kms",
  "rusoto_sts",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "solana-sdk",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -135,6 +135,7 @@ ripemd = "0.1.3"
 rlp = "=0.5.2"
 rocksdb = "0.24.0"
 rstest = "0.25.0"
+rustls = { version = "0.23.36", default-features = false, features = ["aws_lc_rs", "logging", "std", "tls12"] }
 sea-orm = { version = "1.1.10", features = [
   "sqlx-postgres",
   "runtime-tokio-native-tls",

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -32,6 +32,7 @@ mockall.workspace = true
 paste.workspace = true
 prometheus.workspace = true
 rocksdb.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 solana-sdk.workspace = true

--- a/rust/main/hyperlane-base/src/agent.rs
+++ b/rust/main/hyperlane-base/src/agent.rs
@@ -72,6 +72,13 @@ pub trait BaseAgent: Send + Sync + Debug {
 /// initialize the metrics server and tracing as well.
 #[allow(unexpected_cfgs)] // TODO: `rustc` 1.80.1 clippy issue
 pub async fn agent_main<A: BaseAgent>() -> Result<()> {
+    // Some dependencies (e.g. snarkvm's reqwest/quinn stack) pull in the `aws-lc-rs`
+    // rustls backend alongside the `ring` backend already used by tonic/gRPC, so rustls
+    // can no longer auto-select a default CryptoProvider. Install one explicitly before
+    // any TLS connection (e.g. cosmos-native gRPC) is established. `install_default`
+    // errors only if a provider is already installed, which is harmless here.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     if env::var("ONELINE_BACKTRACES")
         .map(|v| v.to_lowercase())
         .as_deref()


### PR DESCRIPTION
## Summary
- A transitive dependency (snarkvm's reqwest/quinn stack) pulls in the `aws-lc-rs` rustls backend alongside the `ring` backend already used by tonic/gRPC. With both backends compiled in, rustls can no longer auto-select a default `CryptoProvider`, which breaks TLS connection setup (e.g. cosmos-native gRPC).
- Install the `aws-lc-rs` provider explicitly at the top of `agent_main` before any TLS connection is established. `install_default` only errors if a provider is already installed, so the call is harmless/idempotent.
- Pin `rustls` in the workspace `Cargo.toml` (`0.23.36`, `default-features = false` with `aws_lc_rs`, `logging`, `std`, `tls12`) and add it as a dependency of `hyperlane-base`.

## Test plan
- [ ] `cd rust/main && cargo build`
- [ ] `cd rust/main && cargo clippy --features aleo,integration_test -- -D warnings`
- [ ] Run an agent that opens a TLS/gRPC connection (e.g. cosmos-native) and confirm the connection succeeds without the "no process-level CryptoProvider available" panic.