### PR TITLE
fix: retry on stale dispatch_event_index lookup for Aleo warp send

### DIFF
--- a/.changeset/popular-horses-sort.md
+++ b/.changeset/popular-horses-sort.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/aleo-sdk": patch
+---
+
+Fixed aleo warp send with retries

--- a/typescript/aleo-sdk/src/clients/base.ts
+++ b/typescript/aleo-sdk/src/clients/base.ts
@@ -149,11 +149,26 @@ export class AleoBase {
     programId: string,
     mappingName: string,
     key: string,
+    { retryOnNull = false }: { retryOnNull?: boolean } = {},
   ): Promise<any | undefined> {
     try {
       const result = await retryAsync(
-        () =>
-          this.aleoClient.getProgramMappingValue(programId, mappingName, key),
+        async () => {
+          const r = await this.aleoClient.getProgramMappingValue(
+            programId,
+            mappingName,
+            key,
+          );
+          // Freshly-finalized state can briefly lag behind the
+          // confirmed-transaction endpoint, so give callers that just
+          // confirmed a tx the option to retry until the mapping catches up.
+          if (r === null && retryOnNull) {
+            throw new Error(
+              `mapping value for ${programId}/${mappingName}/${key} not yet indexed`,
+            );
+          }
+          return r;
+        },
         RETRY_ATTEMPTS,
         RETRY_DELAY_MS,
       );

--- a/typescript/aleo-sdk/src/clients/provider.ts
+++ b/typescript/aleo-sdk/src/clients/provider.ts
@@ -405,12 +405,18 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
     const blockHash = await this.findBlockHashByTxId(txId);
     const block = await this.aleoClient.getBlockByHash(blockHash);
     const blockHeight = Number(block.header.metadata.height);
-    const nonce = await this.queryMappingValue(
-      programId,
-      'dispatch_event_index',
-      `${blockHeight}u32`,
-    );
-    return nonce != null ? (nonce as number) : null;
+    try {
+      const nonce = await this.queryMappingValue(
+        programId,
+        'dispatch_event_index',
+        `${blockHeight}u32`,
+        { retryOnNull: true },
+      );
+      return nonce != null ? (nonce as number) : null;
+    } catch {
+      // Retries exhausted; genuinely no dispatch event for this block.
+      return null;
+    }
   }
 
   async getDispatchedMessageId(


### PR DESCRIPTION
## Summary
- `AleoProvider.getDispatchNonceForTx` treated a `null` mapping lookup as "no dispatch happened" instead of "not indexed yet on Aleo's public API", causing false-negative failures on `hyperlane warp send` from Aleo even when the transfer succeeded on-chain.
- Added an opt-in `retryOnNull` option to the shared `queryMappingValue` helper (reusing the existing retryAsync/RETRY_ATTEMPTS/RETRY_DELAY_MS backoff pattern already used elsewhere in the SDK), and `getDispatchNonceForTx` now opts into it, only falling back to `null` after retries are exhausted.

## Test plan
- Built typescript/aleo-sdk
- Verified against a real mainnet tx that had previously hit this exact false-negative