### PR TITLE
chore: remove Cosmostation validators from default multisig configs

### DIFF
--- a/.changeset/remove-cosmostation-validators.md
+++ b/.changeset/remove-cosmostation-validators.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/sdk": patch
 ---
 
-Removed Cosmostation validators from the default multisig ISM configs for celestia, eden, forma, mantapacific, neutron, and stride, and lowered each chain's threshold by one.
+Removed Cosmostation validators from the default multisig ISM configs for celestia, eden, forma, mantapacific, neutron, and stride, and set each chain's threshold to the minimum majority value (`floor(n/2) + 1`) enforced by `multisigIsm.test.ts`.

--- a/.changeset/remove-cosmostation-validators.md
+++ b/.changeset/remove-cosmostation-validators.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Removed Cosmostation validators from the default multisig ISM configs for celestia, eden, forma, mantapacific, neutron, and stride, and lowered each chain's threshold by one.

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -419,7 +419,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   celestia: {
-    threshold: 2,
+    threshold: 3,
     validators: [
       {
         address: '0x6dbc192c06907784fb0af0c0c2d8809ea50ba675',
@@ -599,7 +599,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   eden: {
-    threshold: 2,
+    threshold: 3,
     validators: [
       {
         address: '0x1c61e6379443e2842d3e9db28e962b6c717fdab1',
@@ -1124,7 +1124,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   mantapacific: {
-    threshold: 2,
+    threshold: 3,
     validators: [
       {
         address: '0x8e668c97ad76d0e28375275c41ece4972ab8a5bc',
@@ -1370,7 +1370,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   neutron: {
-    threshold: 2,
+    threshold: 3,
     validators: [
       {
         address: '0xa9b8c1f4998f781f958c63cfcd1708d02f004ff0',
@@ -1965,7 +1965,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   stride: {
-    threshold: 6,
+    threshold: 5,
     validators: [
       {
         address: '0x38c7a4ca1273ead2e867d096adbcdd0e2acb21d8',

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -419,7 +419,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   celestia: {
-    threshold: 3,
+    threshold: 2,
     validators: [
       {
         address: '0x6dbc192c06907784fb0af0c0c2d8809ea50ba675',
@@ -430,10 +430,6 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
       {
         address: '0x21e93a81920b73c0e98aed8e6b058dae409e4909',
         alias: 'Binary Builders',
-      },
-      {
-        address: '0x7b8606d61bc990165d1e5977037ddcf7f2de74d6',
-        alias: 'Cosmostation',
       },
     ],
   },
@@ -603,7 +599,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   eden: {
-    threshold: 3,
+    threshold: 2,
     validators: [
       {
         address: '0x1c61e6379443e2842d3e9db28e962b6c717fdab1',
@@ -613,10 +609,6 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
       {
         address: '0xE95a08Ef009be3Fbc7FDfa4739AB2428910C285f',
         alias: 'Substance Labs',
-      },
-      {
-        address: '0x359042Ade900d465e96C9c7A9BF975b061c1e8f7',
-        alias: 'Cosmostation',
       },
       {
         address: '0xa3f19CDFa6B684b44da3cF1e2D19d5Cb916cA0EF',
@@ -740,12 +732,8 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   forma: {
-    threshold: 5,
+    threshold: 4,
     validators: [
-      {
-        address: '0x5B19F64F04f495D3958804Ec416c165F00f74898',
-        alias: 'Cosmostation',
-      },
       {
         address: '0x3f869C36110F00D10dC74cca3ac1FB133cf019ad',
         alias: 'Polkachu',
@@ -1136,15 +1124,11 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   mantapacific: {
-    threshold: 3,
+    threshold: 2,
     validators: [
       {
         address: '0x8e668c97ad76d0e28375275c41ece4972ab8a5bc',
         alias: AW_VALIDATOR_ALIAS,
-      },
-      {
-        address: '0x521a3e6bf8d24809fde1c1fd3494a859a16f132c',
-        alias: 'Cosmostation',
       },
       {
         address: '0x25b9a0961c51e74fd83295293bc029131bf1e05a',
@@ -1386,15 +1370,11 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   neutron: {
-    threshold: 3,
+    threshold: 2,
     validators: [
       {
         address: '0xa9b8c1f4998f781f958c63cfcd1708d02f004ff0',
         alias: AW_VALIDATOR_ALIAS,
-      },
-      {
-        address: '0xb65438a014fb05fbadcfe35bc6e25d372b6ba460',
-        alias: 'Cosmostation',
       },
       {
         address: '0xc79503a3e3011535a9c60f6d21f76f59823a38bd',
@@ -1985,15 +1965,11 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   stride: {
-    threshold: 7,
+    threshold: 6,
     validators: [
       {
         address: '0x38c7a4ca1273ead2e867d096adbcdd0e2acb21d8',
         alias: 'Everstake',
-      },
-      {
-        address: '0x88f0E5528131b10e3463C4c68108217Dd33462ac',
-        alias: 'Cosmostation',
       },
       { address: '0xa3eaa1216827ad63dd9db43f6168258a89177990', alias: 'DSRV' },
       {


### PR DESCRIPTION
## Summary

Removes Cosmostation validator entries from the default multisig ISM configs in `typescript/sdk/src/consts/multisigIsm.ts` for:

- `celestia`
- `eden`
- `forma`
- `mantapacific`
- `neutron`
- `stride`

Thresholds are set to the minimum majority value enforced by `multisigIsm.test.ts` (`floor(n/2) + 1`) rather than blindly lowering by one.

| Chain | Before | After | Minimum majority after removal |
|-------|--------|-------|-------------------------------|
| celestia | 3 of 5 | 3 of 4 | 3 of 4 |
| eden | 3 of 5 | 3 of 4 | 3 of 4 |
| forma | 5 of 7 | 4 of 6 | 4 of 6 |
| mantapacific | 3 of 5 | 3 of 4 | 3 of 4 |
| neutron | 3 of 5 | 3 of 4 | 3 of 4 |
| stride | 7 of 10 | 5 of 9 | 5 of 9 |

## Scope

Only the TypeScript SDK consts are updated per request; generated SVM multisig config files are intentionally left unchanged.

## Validation

`pnpm -C typescript/sdk test -- --grep "MultisigIsm"` passes.

## Changeset

Includes a patch changeset for `@hyperlane-xyz/sdk`.
