### PR TITLE
fix: skip explorer API key GCP fetch in k8s for warp check

### DIFF
--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -276,7 +276,13 @@ async function fetchSecretMetadataOverrides(
   // verification checks (e.g. warp check) use authenticated requests.
   // These overrides live only in the PartialRegistry layer and are never
   // persisted back to the on-disk registry.
-  const explorerApiKeys = await fetchExplorerApiKeys();
+  // Only fetch from GCP when running locally (not in k8s), mirroring the Safe
+  // API key handling above: the pod has no GCP identity, and the registry
+  // already provides explorer API keys inline, so the fetch is unnecessary
+  // (and previously fatal) in-cluster.
+  const explorerApiKeys: ChainMap<string> = !inKubernetes()
+    ? await fetchExplorerApiKeys()
+    : {};
   for (const chain of chains) {
     const apiKey = explorerApiKeys[chain];
     if (!apiKey) continue;


### PR DESCRIPTION
## Summary
- The `check-warp-deploy` cronjob pod runs as KSA `default` with **no GCP identity** (no Workload Identity binding, no `serviceAccountName`). The unconditional `fetchExplorerApiKeys()` call at `chain.ts:279` hard-throws on GCP `PERMISSION_DENIED` and aborts the entire warp check before any violations are computed.
- Explorer API keys are **already provided inline by the registry** (added in registry [#832](https://github.com/hyperlane-xyz/hyperlane-registry/pull/832); 30 chains carry `blockExplorers[].apiKey`). The GCP `explorer-api-keys` fetch is now redundant legacy code that merges on top of what the registry already supplies.
- Guard the fetch with `!inKubernetes()`, mirroring the existing Safe API key handling 16 lines above (`chain.ts:263`). Locally, behavior is unchanged (still fetches from GCP). In k8s, the check skips the fetch and uses the registry-supplied authenticated keys — **no degradation, no new secret plumbed into the pod, no IAM change**.

## Context
This surfaced after redeploying `check-warp-deploy` to the GHCR image (the release had been frozen on a 4-month-stale GCR image). The redeploy fixed the stale getters (e.g. the MITO false `proxyAdmin` violation), but the current code then hit this unconditional explorer-key fetch, which the old frozen image never exercised. This unblocks the daily job so we can get an authoritative remaining-violations list.

## Test plan
- [x] `tsc --noEmit` passes for `@hyperlane-xyz/infra`
- [x] Pre-commit hooks (oxlint, oxfmt, gitleaks) pass
- [ ] Redeploy `check-warp-deploy` to mainnet3 and confirm the cronjob completes a full run without the `explorer-api-keys` abort
- [ ] Spot-check that explorer verification requests still use registry-supplied API keys in-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)