### PR TITLE
feat(sdk): export quoted calls and predicate subpaths

### DIFF
--- a/.changeset/sdk-quoted-calls-predicate-subpaths.md
+++ b/.changeset/sdk-quoted-calls-predicate-subpaths.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Added narrow SDK subpath exports for quoted calls and the Predicate API client.

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/middleware/account/*.d.ts",
       "default": "./dist/middleware/account/*.js"
     },
+    "./predicate/PredicateApiClient": {
+      "types": "./dist/predicate/PredicateApiClient.d.ts",
+      "default": "./dist/predicate/PredicateApiClient.js"
+    },
     "./providers/builders/*": {
       "types": "./dist/providers/builders/*.d.ts",
       "default": "./dist/providers/builders/*.js"
@@ -112,6 +116,18 @@
     "./providers/SmartProvider/types": {
       "types": "./dist/providers/SmartProvider/types.d.ts",
       "default": "./dist/providers/SmartProvider/types.js"
+    },
+    "./quoted-calls/client": {
+      "types": "./dist/quoted-calls/client.d.ts",
+      "default": "./dist/quoted-calls/client.js"
+    },
+    "./quoted-calls/codec": {
+      "types": "./dist/quoted-calls/codec.d.ts",
+      "default": "./dist/quoted-calls/codec.js"
+    },
+    "./quoted-calls/types": {
+      "types": "./dist/quoted-calls/types.d.ts",
+      "default": "./dist/quoted-calls/types.js"
     },
     "./token/*": {
       "types": "./dist/token/*.d.ts",


### PR DESCRIPTION
## Summary

- export narrow SDK entrypoints for quoted-calls client, codec, and types
- export the Predicate API client entrypoint
- add an SDK patch changeset

## Why

Consumer applications can avoid the SDK root barrel for these modules. This is a non-blocking follow-up to [Warp UI #1161](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/1161); the Warp UI change remains compatible with the currently published SDK.

## Validation

- `pnpm turbo run build --filter=@hyperlane-xyz/sdk...` (15/15 tasks)
- `pnpm -C typescript/sdk check`
- focused quoted-calls codec and Predicate API client tests (24 passing)
- Node import resolution for all four new package subpaths
- `pnpm changeset status`

## Existing issue

- `pnpm -C typescript/sdk lint` still reports 97 pre-existing SDK findings; this PR changes only JSON and Markdown.
