### PR TITLE
chore(infra): stop balance alerts for mocachain (no active route)

### DIFF
--- a/typescript/infra/src/funding/alerts.ts
+++ b/typescript/infra/src/funding/alerts.ts
@@ -18,6 +18,8 @@ const ADDITIONAL_NO_ALERT_CHAINS: ChainName[] = [
   // downtime
   'artela',
   'molten',
+  // no active warp route yet
+  'mocachain',
 ];
 
 export function getNoAlertChains(): Set<ChainName> {


### PR DESCRIPTION
## Summary
- mocachain is deployed but has no active warp route yet, so the recurring key-funder / relayer low-balance PagerDuty pages (e.g. PD `Q17I0DLM9WJY32`, "Eng mainnet token balance low … mocachain") are noise.
- Adds `mocachain` to `ADDITIONAL_NO_ALERT_CHAINS` in `typescript/infra/src/funding/alerts.ts`. Via `getNoAlertChains()` → `filterAlertChains`, this strips mocachain from all three regenerated balance alert queries (`lowUrgencyEngKeyFunderBalance`, `lowUrgencyKeyFunderBalance`, `highUrgencyRelayerBalance`) and exempts it from the missing-chain regression guard.
- Threshold JSONs are intentionally left intact — same pattern as the existing `artela` / `molten` entries — so funding thresholds are preserved if alerting is re-enabled later.

## Activation
The running Grafana alert rules only change when `scripts/funding/write-alert.ts` is next run (port-forwards Prometheus + hits the Grafana API). Until then the alert can be muted via the Silence URL in the PD payload.

## Test plan
- [x] `tsc --noEmit` clean for `typescript/infra`
- [x] Pre-commit hooks pass
- [ ] On next `write-alert.ts` run, confirm mocachain is dropped from all three balance alert queries and no regression abort fires