### PR TITLE
fix(agents): scale wallet balance metric by configured native token decimals

### DIFF
--- a/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use eyre::Result;
 use hyperlane_core::metrics::agent::decimals_by_protocol;
 use hyperlane_core::metrics::agent::u256_as_scaled_f64;
+use hyperlane_core::metrics::agent::u256_as_scaled_f64_with_decimals;
 use hyperlane_core::metrics::agent::METRICS_SCRAPE_INTERVAL;
 use hyperlane_core::HyperlaneDomain;
 use hyperlane_core::HyperlaneProvider;
@@ -367,7 +368,8 @@ impl ChainSpecificMetricsUpdater {
 
         match self.provider.get_balance(wallet_addr.clone()).await {
             Ok(balance) => {
-                let balance = u256_as_scaled_f64(balance, self.conf.domain.domain_protocol());
+                let balance =
+                    u256_as_scaled_f64_with_decimals(balance, self.conf.native_token.decimals);
                 trace!("Wallet {agent_name} ({wallet_addr}) on chain {chain} balance is {balance} of the native currency");
                 wallet_balance_metric
                 .with(&hashmap! {

--- a/rust/main/hyperlane-core/src/metrics/agent.rs
+++ b/rust/main/hyperlane-core/src/metrics/agent.rs
@@ -13,11 +13,18 @@ const ALEO_DECIMALS: u8 = 6;
 /// This should be whatever the prometheus scrape interval is
 pub const METRICS_SCRAPE_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Convert a u256 scaled integer value into the corresponding f64 value.
+/// Convert a u256 scaled integer value into the corresponding f64 value, using
+/// the protocol's default number of native token decimals.
 #[cfg(feature = "float")]
 pub fn u256_as_scaled_f64(value: U256, domain: HyperlaneDomainProtocol) -> f64 {
-    let decimals = decimals_by_protocol(domain);
-    value.to_f64_lossy() / (10u64.pow(decimals as u32) as f64)
+    u256_as_scaled_f64_with_decimals(value, decimals_by_protocol(domain) as u32)
+}
+
+/// Convert a u256 scaled integer value into the corresponding f64 value, using
+/// the provided number of decimals.
+#[cfg(feature = "float")]
+pub fn u256_as_scaled_f64_with_decimals(value: U256, decimals: u32) -> f64 {
+    value.to_f64_lossy() / 10f64.powi(decimals as i32)
 }
 
 /// Get the decimals each protocol typically uses for its lowest denomination
@@ -28,5 +35,21 @@ pub fn decimals_by_protocol(protocol: HyperlaneDomainProtocol) -> u8 {
         HyperlaneDomainProtocol::Sealevel => SOLANA_DECIMALS,
         HyperlaneDomainProtocol::Aleo => ALEO_DECIMALS,
         _ => ETHEREUM_DECIMALS,
+    }
+}
+
+#[cfg(all(test, feature = "float"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scales_by_configured_decimals() {
+        // 1152 TRX at 6 decimals (Tron) = 1_152_000_000 SUN.
+        let tron_balance = U256::from(1_152_000_000u64);
+        assert!((u256_as_scaled_f64_with_decimals(tron_balance, 6) - 1152.0).abs() < 1e-9);
+
+        // 1.5 ETH at 18 decimals.
+        let eth_balance = U256::from(1_500_000_000_000_000_000u64);
+        assert!((u256_as_scaled_f64_with_decimals(eth_balance, 18) - 1.5).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
## Summary
- The `hyperlane_wallet_balance` metric scaled native balances by the **protocol default** decimals (`decimals_by_protocol` → 18 for any non-Cosmos/Sealevel/Aleo chain) instead of the chain's **configured** `native_token.decimals`.
- For Tron (TRX = 6 decimals) this under-reported the balance by `1e12`, so the metric read ~`1.15e-9` instead of ~1,152 TRX. That permanently tripped the mainnet3 "relayer/ata-payer balance critically low" alert (threshold 21 TRX) even though the wallet was healthy (~14x the desired balance).
- Fix: scale the wallet balance by `conf.native_token.decimals` via a new `u256_as_scaled_f64_with_decimals(value, decimals)` helper. `u256_as_scaled_f64(value, protocol)` now delegates to it, so existing protocol-default behavior (e.g. gas price) is unchanged.
- `native_token.decimals` is already parsed from registry metadata per-chain (defaulting to 18), and is the same value exported by the `chain_config_native_token_decimals` gauge — so any non-EVM chain whose native decimals differ from its protocol default is now reported correctly.
- Same class of fix as the earlier Aleo decimals correction (#8097).

## Test plan
- [x] `cargo test -p hyperlane-core --features float scales_by_configured_decimals` — added unit test covering Tron (6 decimals) and ETH (18 decimals) scaling.
- [x] `cargo build -p hyperlane-base` compiles.
- [ ] Confirm on a canary/agent that `hyperlane_wallet_balance{chain="tron"}` reports ~1,152 after rollout.

Discovered while triaging the Tron relayer low-balance page (PagerDuty Q0RK6667KAC09O).