### PR TITLE
chore: remove stalled Luganodes validators from default and Renzo ISMs

### DIFF
--- a/.changeset/remove-luganodes-stalled-validators.md
+++ b/.changeset/remove-luganodes-stalled-validators.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Removed the stalled Luganodes validator from the default multisig ISM configs for unichain and fraxtal, lowering each chain's threshold from 4 to 3 to preserve the minimum majority (`floor(n/2) + 1`) over the remaining 5 validators.

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -233,10 +233,6 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   fraxtal: {
     threshold: 1,
     validators: [
-      {
-        address: '0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91',
-        alias: 'Luganodes',
-      },
       { address: '0xe986f457965227a05dcf984c8d0c29e01253c44d', alias: 'Renzo' },
     ],
   },
@@ -283,10 +279,6 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   unichain: {
     threshold: 1,
     validators: [
-      {
-        address: '0xa9d517776fe8beba7d67c21cac1e805bd609c08e',
-        alias: 'Luganodes',
-      },
       { address: '0xfe318024ca6197f2157905209149067a11e6982c', alias: 'Renzo' },
     ],
   },
@@ -313,30 +305,18 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   plasma: {
     threshold: 1,
     validators: [
-      {
-        address: '0x8516146068f7de5df6d65a54a631c968121df782',
-        alias: 'Luganodes',
-      },
       { address: '0x9A336232b3cc7399b500D09821AB14Caed008b7e', alias: 'Renzo' },
     ],
   },
   ink: {
     threshold: 1,
     validators: [
-      {
-        address: '0x4d3d970a2468c25d4b5c6af860d11b48223ca94b',
-        alias: 'Luganodes',
-      },
       { address: '0xe42562c4b4d72f28a11e6d02e5a641706f5815b3', alias: 'Renzo' },
     ],
   },
   monad: {
     threshold: 1,
     validators: [
-      {
-        address: '0x552d5a478d78a558eb473d844e4524de36d79cd9',
-        alias: 'Luganodes',
-      },
       { address: '0x59f6f0beb754f74a6d6b95d37f70066a474f2de7', alias: 'Renzo' },
     ],
   },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -295,10 +295,6 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   worldchain: {
     threshold: 1,
     validators: [
-      {
-        address: '0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19',
-        alias: 'Luganodes',
-      },
       { address: '0x650a1bcb489BE2079d82602c10837780ef6dADA8', alias: 'Renzo' },
     ],
   },

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -762,7 +762,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   fraxtal: {
-    threshold: 4,
+    threshold: 3,
     validators: [
       {
         address: '0x4bce180dac6da60d0f3a2bdf036ffe9004f944c1',
@@ -776,10 +776,6 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
       {
         address: '0x573e960e07ad74ea2c5f1e3c31b2055994b12797',
         alias: 'Imperator',
-      },
-      {
-        address: '0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91',
-        alias: 'Luganodes',
       },
       DEFAULT_ZEE_PRIME_VALIDATOR,
     ],
@@ -2126,7 +2122,7 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   unichain: {
-    threshold: 4,
+    threshold: 3,
     validators: [
       {
         address: '0x9773a382342ebf604a2e5de0a1f462fb499e28b1',
@@ -2136,14 +2132,9 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
         address: '0xa2549be30fb852c210c2fe8e7639039dca779936',
         alias: 'Imperator',
       },
-
       {
         address: '0xbcbed4d11e946844162cd92c6d09d1cf146b4006',
         alias: 'Enigma',
-      },
-      {
-        address: '0xa9d517776fe8beba7d67c21cac1e805bd609c08e',
-        alias: 'Luganodes',
       },
       DEFAULT_TESSELLATED_VALIDATOR,
       DEFAULT_ZEE_PRIME_VALIDATOR,


### PR DESCRIPTION
## Summary

Luganodes suspended operations and their validators have stalled (frozen since 2026-06-24, confirmed via `hyperlane_observed_validator_latest_index` flatlining while the rest of the validator pack advances, plus S3 checkpoint Last-Modified for the Renzo routes). This PR removes Luganodes from the ISMs where its validator is genuinely dead.

### Default multisig ISM (`typescript/sdk/src/consts/multisigIsm.ts`)
- **unichain**: removed Luganodes (`0xa9d5177...`), threshold `4 -> 3`
- **fraxtal**: removed Luganodes (`0x25b3a88...`), threshold `4 -> 3`

Each chain drops from 6 to 5 validators; `4 -> 3` keeps a strict majority (`floor(5/2)+1 = 3`), verified by `multisigIsm.test.ts`.

### Renzo EZETH ISM (`getRenzoEZETHWarpConfig.ts`)
Removed Luganodes from the `ezEthValidators` entries for **fraxtal, unichain, plasma, ink, monad**. These were 2-validator, threshold-1 sets `[Luganodes, Renzo]`; each now leaves **Renzo as the sole threshold-1 validator**.

> ⚠️ Consequence: on those 5 Renzo routes the ISM is now effectively 1-of-1 on Renzo — no validator redundancy until a replacement is enrolled. Quorum/delivery is unaffected today (Luganodes was already contributing nothing), but this reduces fault tolerance and should be followed up by enrolling a replacement validator.

### Scope notes
- Luganodes remains **healthy and untouched** on all other chains where it is actively signing (arbitrum, base, bsc, optimism, ethereum, celo, linea, etc.) and on the **ink default ISM** (`0xff9c1e7...`, still healthy).
- No delivery impact from this change — quorum was intact everywhere; this is a redundancy/hygiene cleanup.

## Test plan
- [x] `pnpm -C typescript/sdk mocha src/consts/multisigIsm.test.ts` — threshold/majority checks pass
- [ ] CI green