### PR TITLE
fix: avoid check-warp-deploy false-positive verification violations

### DIFF
--- a/.changeset/check-warp-deploy-verification-skip.md
+++ b/.changeset/check-warp-deploy-verification-skip.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+The warp route contract verification check now skips chains that have no Etherscan-API-compatible block explorer configured. Previously these chains (e.g. tronscan, zksync, keyless etherscan) produced an `Error` verification status that surfaced as a false-positive `ContractVerificationStatus` violation in `check-warp-deploy`; they are now reported as `Skipped`.

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCSTAGEWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCSTAGEWarpConfig.ts
@@ -1,10 +1,6 @@
 import { ChainMap, HypTokenRouterConfig } from '@hyperlane-xyz/sdk';
 
-import { AgentGCPKey } from '../../../../../src/agents/gcp.js';
-import { DeployEnvironment } from '../../../../../src/config/deploy-environment.js';
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
-import { Role } from '../../../../../src/roles.js';
-import { Contexts } from '../../../../contexts.js';
 import { DEPLOYER } from '../../owners.js';
 
 import {
@@ -99,22 +95,22 @@ const stagingOwnersByChain: Record<DeploymentChain, string> = {
   katana: DEPLOYER,
 };
 
+// EIP-712 quote signer for this route's OffchainQuotedLinearFee. Matches the
+// address of the hyperlane-mainnet3-key-quotesigner GCP secret. Hardcoded (the
+// config only needs the public address) so config load doesn't require GCP
+// secret access — otherwise check-warp-deploy aborts loading this route
+// in-cluster where the pod has no GCP identity.
+const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';
+
 export const getEclipseUSDCSTAGEWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const quoteSignerKey = new AgentGCPKey(
-    'mainnet3' as DeployEnvironment,
-    Contexts.Hyperlane,
-    Role.QuoteSigner,
-  );
-  await quoteSignerKey.fetch();
-
   return buildEclipseUSDCWarpConfig(routerConfig, {
     ownersByChain: stagingOwnersByChain,
     programIds: STAGING_PROGRAM_IDS,
     tokenMetadata: STAGING_TOKEN_METADATA,
     proxyAdmins: stagingProxyAdmins,
-    quoteSigners: [quoteSignerKey.address],
+    quoteSigners: [QUOTE_SIGNER],
   });
 };
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -35,6 +35,7 @@ import {
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   ContractVerifier,
+  ExplorerFamily,
   ExplorerLicenseType,
   HyperlaneContractsMap,
   RouterConfig,
@@ -775,6 +776,16 @@ describe('EvmWarpRouteReader', async () => {
       .stub(multiProvider, 'isLocalRpc')
       .returns(false);
 
+    // Stub tryGetEvmExplorerMetadata so the verifier path runs (the local test
+    // chain has no Etherscan-compatible explorer, which would otherwise cause
+    // the status to be reported as Skipped).
+    const tryGetEvmExplorerMetadataStub = sinon
+      .stub(multiProvider, 'tryGetEvmExplorerMetadata')
+      .returns({
+        apiUrl: 'https://example.com/api',
+        family: ExplorerFamily.Etherscan,
+      });
+
     // Stub getContractVerificationStatus
     const getContractVerificationStatus = sinon
       .stub(contractVerifier, 'getContractVerificationStatus')
@@ -794,6 +805,7 @@ describe('EvmWarpRouteReader', async () => {
 
     // Restore stub
     getContractVerificationStatus.restore();
+    tryGetEvmExplorerMetadataStub.restore();
     isLocalRpcStub.restore();
   });
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -534,6 +534,17 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       this.logger.debug('Skipping verification for local endpoints');
       return { [contractType]: ContractVerificationStatus.Skipped };
     }
+
+    // Skip chains with no Etherscan-API-compatible explorer configured. The
+    // verifier can't query them (e.g. tronscan, zksync, keyless etherscan), so
+    // a resulting `Error` status is a false-positive violation, not a real
+    // unverified contract.
+    if (!this.multiProvider.tryGetEvmExplorerMetadata(chain)) {
+      this.logger.debug(
+        `Skipping verification for ${chain}: no Etherscan-compatible explorer configured`,
+      );
+      return { [contractType]: ContractVerificationStatus.Skipped };
+    }
     const quietVerificationLogger = this.logger.child(
       { module: 'contract-verifier' },
       { level: 'silent' },


### PR DESCRIPTION
## Summary
- Skip warp-route contract verification for chains with no Etherscan-API-compatible explorer configured. `EvmWarpRouteReader.getContractVerificationStatus` now returns `Skipped` (instead of letting the explorer call throw and yield `Error`) when `tryGetEvmExplorerMetadata(chain)` is null — e.g. tronscan, zksync, keyless etherscan. This eliminates ~44 false-positive `ContractVerificationStatus` violations in the mainnet3 `check-warp-deploy` cronjob.
- Hardcode the USDCSTAGE/eclipse route's EIP-712 quote-signer public address instead of fetching the `hyperlane-mainnet3-key-quotesigner` GCP secret at config-load time. The in-cluster cronjob pod has no GCP identity, so the fetch aborted loading the route. The config only needs the public address; it matches the existing hardcoded value in `getUSDCCitreaMoonpayWarpConfig.ts`.

## Test plan
- [ ] `pnpm -C typescript/sdk build` / typecheck (verified locally with `tsc --noEmit`, exit 0)
- [ ] `pnpm -C typescript/infra` typecheck (verified locally with `tsc --noEmit`, exit 0)
- [ ] Redeploy `check-warp-deploy` to `:main` and confirm the run no longer emits the etherscan-incompatible verification violations nor aborts loading the USDCSTAGE route

🤖 Generated with [Claude Code](https://claude.com/claude-code)