### PR TITLE
chore(infra): bump mainnet3 relayer image to native-decimals metric fix

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -41,9 +41,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '955281d-20260714-112301',
-  relayerRC: '955281d-20260714-112301',
-  relayerFastPath: '955281d-20260714-112301',
+  relayer: 'ba9a263-20260714-170949',
+  relayerRC: 'ba9a263-20260714-170949',
+  relayerFastPath: 'ba9a263-20260714-170949',
   validator: '955281d-20260714-112301',
   validatorRC: '955281d-20260714-112301',
   validatorFastPath: '955281d-20260714-112301',


### PR DESCRIPTION
## Summary
- Bumps the mainnet3 `relayer`, `relayerRC`, and `relayerFastPath` image tags to `ba9a263-20260714-170949`, built from `main` (commit `ba9a263`, includes #9017).
- #9017 scales the `hyperlane_wallet_balance` metric by the chain's configured `native_token.decimals` instead of the protocol default, fixing the false-positive Tron relayer/ata-payer low-balance alert (metric read ~1e-9 instead of ~1,152 TRX).
- Validator and scraper tags are intentionally left on the prior tag (`955281d-20260714-112301`); they can be bumped in a follow-up.

## Deploy plan
- After merge, deploy the mainnet3 relayers with the new image.
- Post-deploy: confirm `hyperlane_wallet_balance{chain="tron"}` reports ~1,152 and the "Mainnet3 relayer/ata-payer balance critically low" alert clears.

Context: triaged from PagerDuty Q0RK6667KAC09O (Tron relayer low balance false positive).