### PR TITLE
fix: fund Tron chains in key-funder via TronWallet

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,6 +1622,9 @@ importers:
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@hyperlane-xyz/tron-sdk':
+        specifier: workspace:*
+        version: link:../tron-sdk
       '@hyperlane-xyz/utils':
         specifier: workspace:*
         version: link:../utils

--- a/typescript/keyfunder/package.json
+++ b/typescript/keyfunder/package.json
@@ -39,6 +39,7 @@
     "@hyperlane-xyz/metrics": "workspace:*",
     "@hyperlane-xyz/registry": "catalog:",
     "@hyperlane-xyz/sdk": "workspace:*",
+    "@hyperlane-xyz/tron-sdk": "workspace:*",
     "@hyperlane-xyz/utils": "workspace:*",
     "ethers": "catalog:",
     "pino": "catalog:",

--- a/typescript/keyfunder/src/service.ts
+++ b/typescript/keyfunder/src/service.ts
@@ -4,7 +4,9 @@ import { Wallet } from 'ethers';
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
 import { HyperlaneIgp, MultiProvider } from '@hyperlane-xyz/sdk';
+import { TronWallet } from '@hyperlane-xyz/tron-sdk';
 import {
+  ProtocolType,
   applyRpcUrlOverridesFromEnv,
   createServiceLogger,
   rootLogger,
@@ -68,9 +70,26 @@ async function main(): Promise<void> {
     );
 
     const multiProvider = new MultiProvider(chainMetadata);
-    const signer = new Wallet(privateKey);
-    multiProvider.setSharedSigner(signer);
-    logger.info('Initialized MultiProvider with signer');
+    // Tron's JSON-RPC rejects eth_sendRawTransaction, so Tron chains need a
+    // TronWallet (native HTTP wallet API) for the funding write path. Other
+    // chains use a standard ethers Wallet. setSharedSigner can't be mixed with
+    // per-chain signers, so wire every configured chain explicitly.
+    const evmSigner = new Wallet(privateKey);
+    const tronChains: string[] = [];
+    for (const chain of configuredChains) {
+      const metadata = chainMetadata[chain];
+      if (metadata.protocol === ProtocolType.Tron) {
+        const rpcUrl = metadata.rpcUrls[0].http;
+        multiProvider.setSigner(chain, new TronWallet(privateKey, rpcUrl));
+        tronChains.push(chain);
+      } else {
+        multiProvider.setSigner(chain, evmSigner);
+      }
+    }
+    logger.info(
+      { tronChains, totalChains: configuredChains.length },
+      'Initialized MultiProvider with per-chain signers',
+    );
 
     let igp: HyperlaneIgp | undefined;
     const igpEntries = Object.entries(config.chains)

--- a/typescript/keyfunder/src/service.ts
+++ b/typescript/keyfunder/src/service.ts
@@ -3,11 +3,12 @@ import { Wallet } from 'ethers';
 
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
-import { HyperlaneIgp, MultiProvider } from '@hyperlane-xyz/sdk';
+import { ChainMetadata, HyperlaneIgp, MultiProvider } from '@hyperlane-xyz/sdk';
 import { TronWallet } from '@hyperlane-xyz/tron-sdk';
 import {
   ProtocolType,
   applyRpcUrlOverridesFromEnv,
+  assert,
   createServiceLogger,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -77,8 +78,13 @@ async function main(): Promise<void> {
     const evmSigner = new Wallet(privateKey);
     const tronChains: string[] = [];
     for (const chain of configuredChains) {
-      const metadata = chainMetadata[chain];
+      const metadata: ChainMetadata | undefined = chainMetadata[chain];
+      assert(metadata, `Missing metadata for chain: ${chain}`);
       if (metadata.protocol === ProtocolType.Tron) {
+        assert(
+          metadata.rpcUrls.length,
+          `No RPC URLs configured for Tron chain: ${chain}`,
+        );
         const rpcUrl = metadata.rpcUrls[0].http;
         multiProvider.setSigner(chain, new TronWallet(privateKey, rpcUrl));
         tronChains.push(chain);


### PR DESCRIPTION
## Summary
- The key-funder set a single shared ethers `Wallet` for every chain (`setSharedSigner`). All funding transfers go through `multiProvider.sendTransaction` → `signer.sendTransaction` → ethers `eth_sendRawTransaction`, which Tron's JSON-RPC rejects. Result: `tron` and `tronshasta` fail every key-funder run (surfaced by the "Key Funder Pods Failing" alert).
- Wire per-chain signers instead of one shared signer. Tron-protocol chains get a `TronWallet` from `@hyperlane-xyz/tron-sdk` (native HTTP wallet API + `TronJsonRpcProvider`, handling Tron's network-detection/no-nonce/gas-estimation quirks); all other chains keep the standard ethers `Wallet`. This reuses the exact Tron submission path the Rust lander already uses on mainnet — no new Tron signing logic.
- Added `@hyperlane-xyz/tron-sdk` as a workspace dependency of `@hyperlane-xyz/keyfunder`.

`setSharedSigner` and per-chain `setSigner` can't be mixed, so every configured chain is wired explicitly. RPC env overrides still apply (the loop reads `rpcUrls` after `applyRpcUrlOverridesFromEnv`).

No changeset — `@hyperlane-xyz/keyfunder` is a private package.

## Test plan
- [x] `pnpm --filter @hyperlane-xyz/keyfunder build` (tsc, no errors)
- [x] `pnpm --filter @hyperlane-xyz/keyfunder lint` (0 errors)
- [x] `pnpm --filter @hyperlane-xyz/keyfunder test` (50/50 pass)
- [x] Ran the built image (`hyperlane-node-services:8695e37-20260714-180212`) as a one-off Job from the testnet4 `key-funder` CronJob. `tronshasta` IGP `claim()` was built + broadcast via `TronWallet` ("IGP claim completed"), job exited 0 ("KeyFunder completed successfully"). Previously every run exited 1 with `eth_sendRawTransaction does not exist` on tronshasta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)