### PR TITLE
chore: revert Luganodes removal from Renzo ezETH ISM

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -233,6 +233,10 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   fraxtal: {
     threshold: 1,
     validators: [
+      {
+        address: '0x25b3a88f7cfd3c9f7d7e32b295673a16a6ddbd91',
+        alias: 'Luganodes',
+      },
       { address: '0xe986f457965227a05dcf984c8d0c29e01253c44d', alias: 'Renzo' },
     ],
   },
@@ -279,6 +283,10 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   unichain: {
     threshold: 1,
     validators: [
+      {
+        address: '0xa9d517776fe8beba7d67c21cac1e805bd609c08e',
+        alias: 'Luganodes',
+      },
       { address: '0xfe318024ca6197f2157905209149067a11e6982c', alias: 'Renzo' },
     ],
   },
@@ -295,24 +303,40 @@ export const ezEthValidators: ChainMap<MultisigConfig> = {
   worldchain: {
     threshold: 1,
     validators: [
+      {
+        address: '0x15c6aaf2d982651ea5ae5f080d0ddfe7d6545f19',
+        alias: 'Luganodes',
+      },
       { address: '0x650a1bcb489BE2079d82602c10837780ef6dADA8', alias: 'Renzo' },
     ],
   },
   plasma: {
     threshold: 1,
     validators: [
+      {
+        address: '0x8516146068f7de5df6d65a54a631c968121df782',
+        alias: 'Luganodes',
+      },
       { address: '0x9A336232b3cc7399b500D09821AB14Caed008b7e', alias: 'Renzo' },
     ],
   },
   ink: {
     threshold: 1,
     validators: [
+      {
+        address: '0x4d3d970a2468c25d4b5c6af860d11b48223ca94b',
+        alias: 'Luganodes',
+      },
       { address: '0xe42562c4b4d72f28a11e6d02e5a641706f5815b3', alias: 'Renzo' },
     ],
   },
   monad: {
     threshold: 1,
     validators: [
+      {
+        address: '0x552d5a478d78a558eb473d844e4524de36d79cd9',
+        alias: 'Luganodes',
+      },
       { address: '0x59f6f0beb754f74a6d6b95d37f70066a474f2de7', alias: 'Renzo' },
     ],
   },


### PR DESCRIPTION
## Summary

Reverts the `ezEthValidators` (Renzo ezETH route) changes from #9018 for fraxtal, unichain, plasma, ink, monad, and worldchain. Re-adds Luganodes to each of those threshold-1 sets.

**Why:** The EZETH/renzo-prod warp check reads `getRenzoEZETHWarpConfig` (`warpConfigGetterMap[RenzoEZETH]`) as its expected config. The route ISM is inline `AGGREGATION(t=2)[ROUTING(per-origin multisig from ezEthValidators), FALLBACK_ROUTING]`. Removing Luganodes changes the expected per-origin multisig, but the on-chain ROUTING + multisig ISMs are owned by **Renzo's Safes** (`ezEthOwners`), so we cannot reconcile on-chain unilaterally — it needs a `hyperlane warp apply` executed by Renzo. Landing the config change alone just produces a standing WarpRoute-ConfigMismatch we can't clear.

Delivery was never affected either way (threshold-1, Renzo co-validator still signs). The Luganodes-on-Renzo removal will be redone alongside a coordinated Renzo-executed apply.

**Kept from #9018:** the default-ISM removal (unichain + fraxtal in `multisigIsm.ts`, threshold 4→3) — those are AbacusWorks-owned and applied via our own governance. Not touched here.

## Test plan
- [x] Only `getRenzoEZETHWarpConfig.ts` changed; re-adds 6 Luganodes entries (24 insertions), restoring pre-#9018 state
- [ ] CI green