### PR TITLE
chore(infra): skip staging/test warp routes in check-warp-deploy

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -50,6 +50,19 @@ const ROUTES_TO_SKIP: string[] = [
   WarpRouteIds.ParadexUSDC,
 ];
 
+// Name segments that mark a warp route as a non-production (staging/test)
+// deployment. Matched against the `-`/`/`-delimited segments of the route
+// name so `USDC/moonpay-staging` is skipped but names like `attestation` are
+// not. These routes are excluded from check-warp-deploy so they don't produce
+// violations on mainnet.
+const STAGING_ROUTE_MARKERS = ['staging', 'test'];
+
+function isStagingOrTestRoute(warpRouteId: string): boolean {
+  const [, ...rest] = warpRouteId.split('/');
+  const segments = rest.join('/').toLowerCase().split(/[-/]/);
+  return segments.some((segment) => STAGING_ROUTE_MARKERS.includes(segment));
+}
+
 async function main() {
   const { environment, chains, pushMetrics } =
     await getCheckWarpDeployArgs().argv;
@@ -352,7 +365,11 @@ async function getWarpIdsToCheck({
         (environment === 'mainnet3' && !isTestnet) ||
         (environment === 'testnet4' && isTestnet);
 
-      if (!shouldCheck || ROUTES_TO_SKIP.includes(warpRouteId)) {
+      if (
+        !shouldCheck ||
+        ROUTES_TO_SKIP.includes(warpRouteId) ||
+        isStagingOrTestRoute(warpRouteId)
+      ) {
         return false;
       }
 


### PR DESCRIPTION
## Summary
- `check-warp-deploy` (mainnet3 CronJob) was flagging perpetual violations on staging/test warp routes (e.g. `USDC/moonpay-staging`, `USDT/moonpay-staging`, `CROSS/moonpay-staging`). These are deployed with unreleased contract versions (`@hyperlane-xyz/core@12.0.0`, which has no git tag), so their source can't be reproduced for verification and they always report as unverified.
- Adds `isStagingOrTestRoute()` which skips any route whose name segment is `staging` or `test`, applied alongside the existing `ROUTES_TO_SKIP` explicit list.
- Segment-based matching (split on `-`/`/`) avoids false positives like `attestation`.

## Test plan
- [x] `tsc --noEmit` clean for `check-warp-deploy.ts`
- [ ] Dry-run `check-warp-deploy -e mainnet3` and confirm the moonpay-staging routes appear in the skipped set and no longer produce violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)