### PR TITLE
chore(infra): bump mainnet key-funder image to Tron funding fix

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -51,7 +51,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // monorepo services
   checkWarpDeploy: 'main',
   // standalone services
-  keyFunder: '3b17358-20260315-183126',
+  keyFunder: '5dc6aa4-20260714-184449',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
   feeQuoting: '12d899d-20260325-184337',


### PR DESCRIPTION
## Summary
- Bumps `mainnetDockerTags.keyFunder` to `5dc6aa4-20260714-184449`, the node-services image built from main after #9021 (Tron funding fix via `TronWallet`) merged.
- Rolls the key-funder Tron fix out to mainnet.

## Test plan
- [x] #9021 verified end-to-end on testnet4 (one-off Job COMPLETED exit 0, tronshasta IGP claim succeeded).
- [ ] Deploy key-funder to mainnet3 and confirm next scheduled run funds Tron chains (tron mainnet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)