### PR TITLE
feat(infra): enable Solana inventory rebalancing on USDC/radix, USDC/subtensor, USDC/aleo

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/aleo-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/aleo-config.yaml
@@ -1,5 +1,12 @@
 warpRouteId: USDC/aleo
 
+inventorySigners:
+  ethereum: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
+  sealevel: '4ZJoMHQPEMkeExtFQLbuh8nB21dxHj741dSo6oJ5BcMo'
+externalBridges:
+  lifi:
+    integrator: rebalancer
+
 strategy:
   rebalanceStrategy: weighted
   chains:
@@ -10,6 +17,11 @@ strategy:
       bridgeLockTime: 60
       bridgeMinAcceptedAmount: 3500
       bridge: '0xE086378F7f0afd5C3ff95E10B5e7806a0901b33f'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+          bridgeLockTime: 1800 # LiFi Solana hop, longer than EVM CCTP legs
 
     avalanche:
       weighted:
@@ -18,6 +30,11 @@ strategy:
       bridgeLockTime: 60
       bridgeMinAcceptedAmount: 3500
       bridge: '0xCB35d7730843F770625bE36A0E4228c17fDcBC09'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+          bridgeLockTime: 1800 # LiFi Solana hop, longer than EVM CCTP legs
 
     base:
       weighted:
@@ -26,14 +43,24 @@ strategy:
       bridgeLockTime: 60
       bridgeMinAcceptedAmount: 3500
       bridge: '0x31169ee5A8C0D680de74461d7B5394fFc7C3576B'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+          bridgeLockTime: 1800 # LiFi Solana hop, longer than EVM CCTP legs
 
     ethereum:
       weighted:
-        weight: 30
+        weight: 20
         tolerance: 5
       bridgeLockTime: 60
       bridgeMinAcceptedAmount: 3500
       bridge: '0x7A576Bb5291567cfDbB4585B1911CF7C9891ea07'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+          bridgeLockTime: 1800 # LiFi Solana hop, longer than EVM CCTP legs
 
     optimism:
       weighted:
@@ -42,6 +69,11 @@ strategy:
       bridgeLockTime: 60
       bridgeMinAcceptedAmount: 3500
       bridge: '0x4eFaacbf0D3d57b401Cb6B559e84b344448b0C30'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+          bridgeLockTime: 1800 # LiFi Solana hop, longer than EVM CCTP legs
 
     polygon:
       weighted:
@@ -50,3 +82,17 @@ strategy:
       bridgeLockTime: 60
       bridgeMinAcceptedAmount: 3500
       bridge: '0x07d89DE0F7E18c9bcAAE81F44aee9CA02EBeE872'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+          bridgeLockTime: 1800 # LiFi Solana hop, longer than EVM CCTP legs
+
+    solanamainnet:
+      weighted:
+        weight: 10
+        tolerance: 5
+      bridgeLockTime: 1800 # 30 mins in seconds
+      bridgeMinAcceptedAmount: 3500
+      executionType: inventory
+      externalBridge: lifi

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/radix-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/radix-config.yaml
@@ -1,5 +1,12 @@
 warpRouteId: USDC/radix
 
+inventorySigners:
+  ethereum: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
+  sealevel: '4ZJoMHQPEMkeExtFQLbuh8nB21dxHj741dSo6oJ5BcMo'
+externalBridges:
+  lifi:
+    integrator: rebalancer
+
 strategy:
   rebalanceStrategy: weighted
   chains:
@@ -10,6 +17,10 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 10000
       bridge: '0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
 
     base:
       weighted:
@@ -18,11 +29,28 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 10000
       bridge: '0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
 
     ethereum:
       weighted:
-        weight: 50
+        weight: 40
         tolerance: 10
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 10000
       bridge: '0xedCBAa585FD0F80f20073F9958246476466205b8'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+
+    solanamainnet:
+      weighted:
+        weight: 10
+        tolerance: 10
+      bridgeLockTime: 1800 # 30 mins in seconds
+      bridgeMinAcceptedAmount: 10000
+      executionType: inventory
+      externalBridge: lifi

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
@@ -1,4 +1,10 @@
 warpRouteId: USDC/subtensor
+inventorySigners:
+  ethereum: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
+  sealevel: '4ZJoMHQPEMkeExtFQLbuh8nB21dxHj741dSo6oJ5BcMo'
+externalBridges:
+  lifi:
+    integrator: rebalancer
 strategy:
   rebalanceStrategy: minAmount
   chains:
@@ -10,6 +16,10 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
       bridge: '0x5C4aFb7e23B1Dc1B409dc1702f89C64527b25975'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
 
     ethereum:
       minAmount:
@@ -19,6 +29,10 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
       bridge: '0xedCBAa585FD0F80f20073F9958246476466205b8'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
 
     polygon:
       minAmount:
@@ -28,6 +42,10 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
       bridge: '0xa62F45662809f5F6535b58bae9A572a2EC4A1f84'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
 
     arbitrum:
       minAmount:
@@ -37,6 +55,10 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
       bridge: '0x8a82186EA618b91D13A2041fb7aC31Bf01C02aD2'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
 
     unichain:
       minAmount:
@@ -46,3 +68,17 @@ strategy:
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
       bridge: '0x296aF86bff91b23cF980f6a443bc15A3A5d30682'
+      override:
+        solanamainnet:
+          executionType: inventory
+          externalBridge: lifi
+
+    solanamainnet:
+      minAmount:
+        min: 5000
+        target: 15000
+        type: 'absolute'
+      bridgeLockTime: 1800 # 30 mins in seconds
+      bridgeMinAcceptedAmount: 3000
+      executionType: inventory
+      externalBridge: lifi


### PR DESCRIPTION
## Summary

Enables `solanamainnet` as an **inventory-rebalanced** leg on the `USDC/radix`, `USDC/subtensor`, and `USDC/aleo` rebalancers, mirroring the pattern already live on `USDC/eclipsemainnet`.

Config-only change to the rebalancer strategy YAMLs. Per chain:
- Added `inventorySigners` (evm + sealevel) and `externalBridges.lifi`.
- Added a `solanamainnet` strategy entry with `executionType: inventory`, `externalBridge: lifi`.
- Added an `override` on each existing EVM chain routing the Solana leg through LiFi.

**No warp-config or onchain router changes.** Inventory rebalancing does not use the MovableCollateralRouter `rebalance()` / `allowedRebalancers` path, so the Solana leg stays as plain `foreignDeployment` collateral in the warp getters — exactly as `USDC/eclipsemainnet` already runs it. All three routes already have a deployed Solana collateral leg.

Per-route weights/targets:
- **radix** (`weighted`): added `solanamainnet` weight 10; reduced `ethereum` 50→40 (total stays 100).
- **subtensor** (`minAmount`): added `solanamainnet` with `min 5000 / target 15000 / absolute` (matching the other spokes).
- **aleo** (`weighted`): added `solanamainnet` weight 10; reduced `ethereum` 30→20 (total stays 100). The Solana leg + its inbound overrides use `bridgeLockTime: 1800` because aleo's EVM legs use `60s`, too short for a LiFi hop.

## Please confirm before merge @mo

1. **Inventory signers** — I reused the `USDC/eclipsemainnet` signers (`ethereum: 0x6056…FdA9`, `sealevel: 4ZJo…BcMo`) on all three routes. Confirm they should share that inventory wallet vs. use dedicated signers, and that both are/will be **funded** (USDC inventory on Solana + gas on the evm signer). This funding is the real gating item, not the YAML.
2. **radix / aleo Solana weights** — the 10 splits (and ethereum reductions) are placeholders; set the real target liquidity split.
3. **subtensor: minAmount + inventory** — schema allows it (both strategies extend the same base config, validation passed), but no existing inventory config uses `minAmount` (all are `weighted`). Please confirm the minAmount strategy engine issues inventory routes correctly at runtime before we ship the subtensor half. radix + aleo (`weighted`) are the exact eclipse pattern and lower-risk — could merge those first, hold subtensor.
4. **aleo bridgeLockTime** — I set `1800s` on the Solana leg/overrides vs the `60s` EVM legs. Confirm that's the right in-flight window for a LiFi Solana rebalance.
5. **LiFi Solana lane** — confirm LiFi supports the USDC Solana lane for these routes.

## Test plan

- [x] All three YAMLs parse and match the eclipse inventory structure (validated).
- [ ] Rebalancer config Zod schema validation in CI.
- [ ] @mo confirms signers/funding, weights, LiFi lane, minAmount+inventory runtime behavior, and aleo lock time.

Generated with Haggis for @Nam Chu Hoai; requested review from @Mo Hussan.