### PR TITLE
chore(infra): skip mocachain in key-funder funding

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -91,6 +91,7 @@ export const keyFunderConfig: KeyFunderConfig<
     'litchain',
     'mantapacific',
     'miraclechain',
+    'mocachain',
     'molten',
     'neutron',
     'ontology',


### PR DESCRIPTION
## Summary
- Adds `mocachain` to the mainnet3 key-funder `chainsToSkip` so it is no longer funded.

## Context
Per Slack discussion — Nam asked to stop funding mocachain; Paul confirmed this is the intended path. mocachain was already alert-suppressed (`ADDITIONAL_NO_ALERT_CHAINS`) but still being funded; this stops the funding itself.

## Test plan
- [ ] Config-only change; key-funder will skip mocachain on next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)