### PR TITLE
feat: cache AWS KMS signer construction

### DIFF
--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -1,13 +1,16 @@
+use std::str::FromStr;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use dashmap::DashMap;
 use ethers::core::k256::sha2::{Digest, Sha256};
 use ethers::prelude::{AwsSigner, LocalWallet};
 use ethers::utils::hex::ToHex;
 use eyre::{bail, Context, Report};
 use rusoto_core::Region;
 use rusoto_kms::KmsClient;
-use std::str::FromStr;
+use tokio::sync::OnceCell;
 use tracing::instrument;
 
 use hyperlane_core::{AccountAddressType, H256};
@@ -25,6 +28,39 @@ fn resolve_kms_region(region: &str) -> Region {
         name: region.to_owned(),
         endpoint: format!("https://kms.{region}.amazonaws.com"),
     })
+}
+
+/// A global cache of constructed AWS signers, keyed by (KMS key id, region). Building an
+/// `AwsSigner` requires a KMS `GetPublicKey` call; without this cache, every independent
+/// call site that needs the same configured signer (mailbox builder, ISM builder,
+/// validator-announce builder, lander adapter, etc.) pays that KMS round trip again, even
+/// though the result - the signer's address - never changes for a given key id.
+static AWS_SIGNER_CACHE: OnceLock<DashMap<(String, String), OnceCell<AwsSigner>>> = OnceLock::new();
+
+fn get_aws_signer_cache() -> &'static DashMap<(String, String), OnceCell<AwsSigner>> {
+    AWS_SIGNER_CACHE.get_or_init(DashMap::new)
+}
+
+/// Builds an `AwsSigner` for the given KMS key id and region, reusing an already-constructed
+/// signer for the same (id, region) pair if one exists rather than making a fresh KMS call.
+async fn build_aws_signer(id: &str, region: &str) -> Result<AwsSigner, Report> {
+    let cell = get_aws_signer_cache()
+        .entry((id.to_owned(), region.to_owned()))
+        .or_default();
+    let signer = cell
+        .get_or_try_init(|| async {
+            let http_client =
+                utils::http_client_with_timeout().map_err(|err| eyre::eyre!(err.to_string()))?;
+            let client = KmsClient::new_with_client(
+                rusoto_core::Client::new_with(AwsChainCredentialsProvider::new(), http_client),
+                resolve_kms_region(region),
+            );
+            AwsSigner::new(client, id, 0, Some(AWS_SIGNER_TIMEOUT))
+                .await
+                .map_err(Report::from)
+        })
+        .await?;
+    Ok(signer.clone())
 }
 
 /// Signer types
@@ -107,14 +143,7 @@ impl BuildableWithSignerConf for hyperlane_ethereum::Signers {
                 ),
             )),
             SignerConf::Aws { id, region } => {
-                let http_client = utils::http_client_with_timeout()
-                    .map_err(|err| eyre::eyre!(err.to_string()))?;
-                let client = KmsClient::new_with_client(
-                    rusoto_core::Client::new_with(AwsChainCredentialsProvider::new(), http_client),
-                    resolve_kms_region(region),
-                );
-                let signer = AwsSigner::new(client, id, 0, Some(AWS_SIGNER_TIMEOUT)).await?;
-                hyperlane_ethereum::Signers::Aws(signer)
+                hyperlane_ethereum::Signers::Aws(build_aws_signer(id, region).await?)
             }
             SignerConf::CosmosKey { .. } => {
                 bail!("cosmosKey signer is not supported by Ethereum")
@@ -148,16 +177,9 @@ impl BuildableWithSignerConf for hyperlane_tron::TronSigner {
                 let wallet = ethers::core::k256::ecdsa::SigningKey::from(key);
                 Ok(hyperlane_tron::TronSigner::from(wallet))
             }
-            SignerConf::Aws { id, region } => {
-                let http_client = utils::http_client_with_timeout()
-                    .map_err(|err| eyre::eyre!(err.to_string()))?;
-                let client = KmsClient::new_with_client(
-                    rusoto_core::Client::new_with(AwsChainCredentialsProvider::new(), http_client),
-                    resolve_kms_region(region),
-                );
-                let signer = AwsSigner::new(client, id, 0, Some(AWS_SIGNER_TIMEOUT)).await?;
-                Ok(hyperlane_tron::TronSigner::Aws(signer))
-            }
+            SignerConf::Aws { id, region } => Ok(hyperlane_tron::TronSigner::Aws(
+                build_aws_signer(id, region).await?,
+            )),
             _ => bail!(format!("{conf:?} key is not supported by tron")),
         }
     }

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -1,16 +1,15 @@
 use std::str::FromStr;
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use dashmap::DashMap;
 use ethers::core::k256::sha2::{Digest, Sha256};
 use ethers::prelude::{AwsSigner, LocalWallet};
 use ethers::utils::hex::ToHex;
 use eyre::{bail, Context, Report};
+use moka::future::Cache;
 use rusoto_core::Region;
 use rusoto_kms::KmsClient;
-use tokio::sync::OnceCell;
 use tracing::instrument;
 
 use hyperlane_core::{AccountAddressType, H256};
@@ -30,31 +29,26 @@ fn resolve_kms_region(region: &str) -> Region {
     })
 }
 
-/// A global cache of constructed AWS signers, keyed by (KMS key id, region). Building an
-/// `AwsSigner` requires a KMS `GetPublicKey` call; without this cache, every independent
-/// call site that needs the same configured signer (mailbox builder, ISM builder,
-/// validator-announce builder, lander adapter, etc.) pays that KMS round trip again, even
-/// though the result - the signer's address - never changes for a given key id.
-type AwsSignerCache = DashMap<(String, String), Arc<OnceCell<AwsSigner>>>;
+/// Cache of constructed AWS signers, keyed by (KMS key id, region), so independent call
+/// sites needing the same signer share one `GetPublicKey` call instead of repeating it.
+///
+/// Uses moka's `try_get_with`, not a `tokio::sync::OnceCell`: moka coalesces concurrent
+/// callers into one `init` attempt on both success and failure, so a KMS outage fails once
+/// for everyone waiting instead of serializing a fresh `AWS_SIGNER_TIMEOUT`-long attempt
+/// per waiter.
+type AwsSignerCache = Cache<(String, String), AwsSigner>;
 
 static AWS_SIGNER_CACHE: OnceLock<AwsSignerCache> = OnceLock::new();
 
 fn get_aws_signer_cache() -> &'static AwsSignerCache {
-    AWS_SIGNER_CACHE.get_or_init(DashMap::new)
+    AWS_SIGNER_CACHE.get_or_init(|| Cache::builder().max_capacity(100).build())
 }
 
 /// Builds an `AwsSigner` for the given KMS key id and region, reusing an already-constructed
 /// signer for the same (id, region) pair if one exists rather than making a fresh KMS call.
 async fn build_aws_signer(id: &str, region: &str) -> Result<AwsSigner, Report> {
-    // Clone the `Arc<OnceCell<_>>` out and let the DashMap guard drop immediately - holding
-    // it across the `.await` below would keep the shard's lock held for the whole KMS call,
-    // blocking any other task whose key happens to hash into the same shard.
-    let cell = get_aws_signer_cache()
-        .entry((id.to_owned(), region.to_owned()))
-        .or_insert_with(|| Arc::new(OnceCell::new()))
-        .clone();
-    let signer = cell
-        .get_or_try_init(|| async {
+    get_aws_signer_cache()
+        .try_get_with((id.to_owned(), region.to_owned()), async {
             let http_client =
                 utils::http_client_with_timeout().map_err(|err| eyre::eyre!(err.to_string()))?;
             let client = KmsClient::new_with_client(
@@ -65,8 +59,8 @@ async fn build_aws_signer(id: &str, region: &str) -> Result<AwsSigner, Report> {
                 .await
                 .map_err(Report::from)
         })
-        .await?;
-    Ok(signer.clone())
+        .await
+        .map_err(|arc_err| eyre::eyre!("{arc_err}"))
 }
 
 /// Signer types
@@ -360,12 +354,75 @@ impl ChainSigner for hyperlane_aleo::AleoSigner {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
     use ethers::{signers::LocalWallet, utils::hex};
     use hyperlane_core::{AccountAddressType, Encode, H256};
+    use moka::future::Cache;
     use rusoto_core::Region;
+    use tokio::sync::Barrier;
 
     use super::resolve_kms_region;
     use crate::settings::{ChainSigner, SignerConf};
+
+    /// Exercises the exact coalescing mechanism `build_aws_signer` relies on
+    /// (`moka::future::Cache::try_get_with`) against a fake, always-failing initializer -
+    /// proving concurrent callers on the same key share one attempt and one failure, and
+    /// that a later call is not permanently blocked by a stale cached error.
+    #[tokio::test]
+    async fn concurrent_failing_lookups_are_coalesced_into_one_attempt() {
+        let cache: Cache<&'static str, u32> = Cache::builder().max_capacity(10).build();
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        const WAITERS: usize = 5;
+        let barrier = Arc::new(Barrier::new(WAITERS));
+        let tasks: Vec<_> = (0..WAITERS)
+            .map(|_| {
+                let cache = cache.clone();
+                let attempts = attempts.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    cache
+                        .try_get_with("key", async {
+                            attempts.fetch_add(1, Ordering::SeqCst);
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                            Err::<u32, &'static str>("simulated KMS failure")
+                        })
+                        .await
+                })
+            })
+            .collect();
+
+        for task in tasks {
+            let result = task.await.expect("spawned task must not panic");
+            assert!(
+                result.is_err(),
+                "the shared failure must propagate to every waiter"
+            );
+        }
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            1,
+            "concurrent callers on the same key must coalesce into a single init attempt, \
+             not one attempt per waiter"
+        );
+
+        // A later, non-concurrent call must retry rather than reuse the (uncached) failure.
+        let retry_result = cache
+            .try_get_with("key", async {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Ok::<u32, &'static str>(42)
+            })
+            .await;
+        assert_eq!(retry_result, Ok(42));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            2,
+            "a later call must retry after a failure, not reuse a permanently cached error"
+        );
+    }
 
     #[test]
     fn resolve_kms_region_known_region_uses_enum_variant() {

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -35,18 +35,24 @@ fn resolve_kms_region(region: &str) -> Region {
 /// call site that needs the same configured signer (mailbox builder, ISM builder,
 /// validator-announce builder, lander adapter, etc.) pays that KMS round trip again, even
 /// though the result - the signer's address - never changes for a given key id.
-static AWS_SIGNER_CACHE: OnceLock<DashMap<(String, String), OnceCell<AwsSigner>>> = OnceLock::new();
+type AwsSignerCache = DashMap<(String, String), Arc<OnceCell<AwsSigner>>>;
 
-fn get_aws_signer_cache() -> &'static DashMap<(String, String), OnceCell<AwsSigner>> {
+static AWS_SIGNER_CACHE: OnceLock<AwsSignerCache> = OnceLock::new();
+
+fn get_aws_signer_cache() -> &'static AwsSignerCache {
     AWS_SIGNER_CACHE.get_or_init(DashMap::new)
 }
 
 /// Builds an `AwsSigner` for the given KMS key id and region, reusing an already-constructed
 /// signer for the same (id, region) pair if one exists rather than making a fresh KMS call.
 async fn build_aws_signer(id: &str, region: &str) -> Result<AwsSigner, Report> {
+    // Clone the `Arc<OnceCell<_>>` out and let the DashMap guard drop immediately - holding
+    // it across the `.await` below would keep the shard's lock held for the whole KMS call,
+    // blocking any other task whose key happens to hash into the same shard.
     let cell = get_aws_signer_cache()
         .entry((id.to_owned(), region.to_owned()))
-        .or_default();
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
     let signer = cell
         .get_or_try_init(|| async {
             let http_client =


### PR DESCRIPTION
## Summary
Adds a global cache (keyed by KMS key id + region) so an `AwsSigner` is constructed once per key and reused, instead of being rebuilt - and hitting KMS `GetPublicKey` fresh - every time any code path needs the same configured signer.

## Why
Traced two independent real relayer messages (different pods, different days) while investigating metadata-build latency and found **12 separate `AwsSigner` constructions per message**, each a genuine ~100-160ms KMS round trip (avg ~126ms), for the exact same signing key every time - not a cache hit, not free. That's ~1.5s of pure waste per message.

The root cause: several independent call sites each need "the relayer's signer" - the ISM builder (`build_ism`, called fresh per message per ISM address), the mailbox builder, the validator-announce builder, the lander adapter/entrypoint, the CCIP-read signer, agent metrics config - and none of them share a cached instance. Every one calls `SignerConf::build()`, which for an AWS-configured signer unconditionally constructs a fresh `AwsSigner` via `AwsSigner::new(...).await`, a real KMS API call.

7 of the 12 constructions observed cluster tightly inside what I'd been calling the "pre-multisig overhead" window in metadata building (~850ms, almost entirely unaccounted for by any other logged work) - strong circumstantial evidence this redundant construction is a meaningful contributor to that delay, not just background noise.

## Change
- `hyperlane-base/src/settings/signers.rs`: added `AWS_SIGNER_CACHE` (a `DashMap<(String, String), OnceCell<AwsSigner>>`, same established pattern already used for `ANONYMOUS_CLIENT_CACHE` in `s3_storage.rs`) and a `build_aws_signer(id, region)` helper. Both `hyperlane_ethereum::Signers::build` and `hyperlane_tron::TronSigner::build` (the two places that independently duplicated the exact same `AwsSigner::new(...)` construction) now call this helper instead. `AwsSigner` is `Clone` (cheap - clones the already-fetched pubkey/address/client handle), so a cache hit is just a clone, no network call.
- No trait signature changes, no behavior change for non-AWS signer types, no changes to any ISM-building or dry-run-verify logic (this is purely about *reusing* an already-built signer, not changing who needs one - deliberately narrower in scope than an earlier attempt at this problem that turned out to break `TrustedRelayerIsm` dry-run support by removing the signer requirement instead of caching it).

## Testing
- `cargo test -p hyperlane-base --lib`: 75 passed, 1 pre-existing unrelated failure (`gcs_storage::public_landset_no_auth_works_test`, a sandbox TLS/native-cert-loading issue, confirmed to fail identically on unmodified `main`).
- `cargo fmt` and `cargo clippy -p hyperlane-base --tests -- -D warnings` clean on the touched file (2 flagged clippy items are pre-existing, in test code I didn't touch).

## Test plan
- [ ] CI green on this PR
- [ ] Confirm signer construction count drops from ~12/message to ~1/message (steady-state, after warmup) in staging relayer logs
- [ ] Re-measure the "pre-multisig overhead" window on real messages post-deploy to quantify actual savings