### PR TITLE
perf(validator): remove final checkpoint pacing delay

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -17335,6 +17335,7 @@ dependencies = [
  "k256 0.13.4",
  "mockall",
  "prometheus",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "rusoto_core",
  "serde",

--- a/rust/main/agents/validator/Cargo.toml
+++ b/rust/main/agents/validator/Cargo.toml
@@ -44,7 +44,9 @@ rusoto_core = '*'
 [dev-dependencies]
 http-body-util.workspace = true
 mockall.workspace = true
+rand.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tokio-test.workspace = true
 tower.workspace = true
 tracing-test.workspace = true

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -332,7 +332,7 @@ impl ValidatorSubmitter {
     async fn sign_and_submit_checkpoint(
         &self,
         checkpoint: CheckpointWithMessageId,
-    ) -> ChainResult<()> {
+    ) -> ChainResult<bool> {
         let start = Instant::now();
         let existing = self
             .checkpoint_syncer
@@ -348,7 +348,7 @@ impl ValidatorSubmitter {
             let signer = self.signer.eth_address();
             if existing_signer == signer && existing.value == checkpoint {
                 debug!(index = checkpoint.index, "Checkpoint already submitted");
-                return Ok(());
+                return Ok(false);
             } else {
                 warn!(
                     index = checkpoint.index,
@@ -377,7 +377,7 @@ impl ValidatorSubmitter {
             "Stored checkpoint",
         );
 
-        Ok(())
+        Ok(true)
     }
 
     /// Signs and submits any previously unsubmitted checkpoints.
@@ -420,18 +420,20 @@ impl ValidatorSubmitter {
                     Box::pin(async move {
                         let start = Instant::now();
                         let checkpoint_index = checkpoint.index;
-                        self_clone.sign_and_submit_checkpoint(checkpoint).await?;
+                        let wrote_checkpoint =
+                            self_clone.sign_and_submit_checkpoint(checkpoint).await?;
                         tracing::info!(
                             index = checkpoint_index,
+                            wrote_checkpoint,
                             elapsed=?start.elapsed(),
-                            "Signed and submitted checkpoint",
+                            "Processed checkpoint",
                         );
-                        Ok(())
+                        Ok(wrote_checkpoint)
                     })
                 })
             });
 
-            join_all(futures).await;
+            let wrote_checkpoint = join_all(futures).await.into_iter().any(|wrote| wrote);
 
             tracing::info!(
                 elapsed=?start.elapsed(),
@@ -462,8 +464,8 @@ impl ValidatorSubmitter {
             }
 
             // Pace storage/signing bursts between chunks without delaying the latest-index
-            // update or adding an unnecessary tail after the final chunk.
-            if !checkpoints.is_empty() {
+            // update, throttling all-existing backfills, or adding a final-chunk tail.
+            if wrote_checkpoint && !checkpoints.is_empty() {
                 sleep(CHECKPOINT_SUBMISSION_CHUNK_INTERVAL).await;
             }
         }

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -22,6 +22,8 @@ use hyperlane_ethereum::{Signers, SingletonSignerHandle};
 
 use crate::reorg_reporter::ReorgReporter;
 
+const CHECKPOINT_SUBMISSION_CHUNK_INTERVAL: Duration = Duration::from_millis(100);
+
 #[derive(Clone)]
 pub(crate) struct ValidatorSubmitter {
     interval: Duration,
@@ -375,9 +377,6 @@ impl ValidatorSubmitter {
             "Stored checkpoint",
         );
 
-        // TODO: move these into S3 implementations
-        // small sleep before signing next checkpoint to avoid rate limiting
-        sleep(Duration::from_millis(100)).await;
         Ok(())
     }
 
@@ -460,6 +459,12 @@ impl ValidatorSubmitter {
                 })
                 .await;
                 first_chunk = false;
+            }
+
+            // Pace storage/signing bursts between chunks without delaying the latest-index
+            // update or adding an unnecessary tail after the final chunk.
+            if !checkpoints.is_empty() {
+                sleep(CHECKPOINT_SUBMISSION_CHUNK_INTERVAL).await;
             }
         }
     }

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -88,6 +88,63 @@ fn dummy_singleton_handle() -> SingletonSignerHandle {
     SingletonSignerHandle::new(H160::from_low_u64_be(0), mpsc::unbounded_channel().0)
 }
 
+#[tokio::test(start_paused = true)]
+async fn single_checkpoint_chunk_has_no_throttle_tail() {
+    let checkpoint = CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index: 7,
+        },
+        message_id: H256::zero(),
+    };
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .once()
+        .returning(|_| Ok(None));
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .once()
+        .returning(|_| Ok(()));
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(checkpoint.index))
+        .once()
+        .returning(|_| Ok(()));
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(vec![checkpoint])
+            .await;
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(99)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        task.is_finished(),
+        "a final checkpoint chunk must not wait for the 100ms inter-chunk throttle"
+    );
+    task.await.unwrap();
+}
+
 fn reorg_event_is_correct(
     reorg_event: &ReorgEvent,
     expected_local_merkle_tree: &IncrementalMerkle,

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -146,6 +146,71 @@ async fn single_checkpoint_chunk_has_no_throttle_tail() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn two_written_chunks_have_one_inter_chunk_throttle() {
+    let checkpoints = [7, 8].map(|index| CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index,
+        },
+        message_id: H256::zero(),
+    });
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(checkpoints.len())
+        .returning(|_| Ok(None));
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .times(checkpoints.len())
+        .returning(|_| Ok(()));
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(checkpoints[1].index))
+        .once()
+        .returning(|_| Ok(()));
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(checkpoints.to_vec())
+            .await;
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(99)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        !task.is_finished(),
+        "two written chunks must wait for the 100ms inter-chunk throttle"
+    );
+
+    tokio::time::advance(Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        task.is_finished(),
+        "the final written chunk must not add another throttle delay"
+    );
+    task.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
 async fn all_existing_chunks_skip_inter_chunk_throttle() {
     let checkpoints = [7, 8].map(|index| CheckpointWithMessageId {
         checkpoint: Checkpoint {

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -145,6 +145,68 @@ async fn single_checkpoint_chunk_has_no_throttle_tail() {
     task.await.unwrap();
 }
 
+#[tokio::test(start_paused = true)]
+async fn all_existing_chunks_skip_inter_chunk_throttle() {
+    let checkpoints = [7, 8].map(|index| CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index,
+        },
+        message_id: H256::zero(),
+    });
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let signed_checkpoints = [
+        signer.sign(checkpoints[0]).await.unwrap(),
+        signer.sign(checkpoints[1]).await.unwrap(),
+    ];
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(checkpoints.len())
+        .returning(move |index| {
+            Ok(signed_checkpoints
+                .iter()
+                .find(|signed| signed.value.index == index)
+                .cloned())
+        });
+    checkpoint_syncer.expect_write_checkpoint().never();
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(checkpoints[1].index))
+        .once()
+        .returning(|_| Ok(()));
+
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(checkpoints.to_vec())
+            .await;
+    });
+    tokio::task::yield_now().await;
+
+    assert!(
+        task.is_finished(),
+        "all-existing chunks must not wait for the inter-chunk throttle"
+    );
+    task.await.unwrap();
+}
+
 fn reorg_event_is_correct(
     reorg_event: &ReorgEvent,
     expected_local_merkle_tree: &IncrementalMerkle,


### PR DESCRIPTION
## Performance impact

Publishes the validator's latest index exactly 100ms earlier after the first checkpoint chunk and removes the unnecessary 100ms tail after the final chunk.

For `N` checkpoint chunks, pacing sleeps change from `N` to `N - 1`. A normal single-chunk submission is therefore 100ms faster end to end, while multi-chunk storage/signing bursts remain separated by the existing 100ms throttle.

## Summary

- move checkpoint submission pacing from each completed chunk's work into the boundary between chunks
- update the latest index before any inter-chunk throttle
- avoid sleeping after the final chunk
- add a paused-time regression test for the single-chunk path

## Context

This reduces validator publication latency that contributes to the `AwaitingValidatorSignatures` stage highlighted by #8989.

## Testing

- `cargo test --package validator single_checkpoint_chunk_has_no_throttle_tail`
- `cargo clippy --package validator -- -D warnings`
- `cargo fmt --package validator -- --check`
- `git diff --check`