### PR TITLE
perf(relayer): wake database loader after indexing

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -14,9 +14,9 @@ use hyperlane_base::{
     db::{HyperlaneDb, HyperlaneRocksDB},
     CoreMetrics,
 };
-use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation};
+use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H512};
 use prometheus::IntGauge;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{error::TryRecvError, Receiver, UnboundedSender};
 use tracing::{debug, instrument, trace};
 
 use super::{blacklist::AddressBlacklist, metadata::AppContextClassifier, pending_message::*};
@@ -41,6 +41,7 @@ pub struct MessageDbLoader {
     metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
     nonce_iterator: ForwardBackwardIterator,
     max_retries: u32,
+    index_notifications: Option<Receiver<H512>>,
 }
 
 #[derive(Debug)]
@@ -249,6 +250,8 @@ impl DbLoaderExt for MessageDbLoader {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
+        self.drain_index_notifications();
+
         // Forever, scan HyperlaneRocksDB looking for new messages to send. When criteria are
         // satisfied or the message is disqualified, push the message onto
         // self.tx_msg and then continue the scan at the next highest
@@ -319,7 +322,7 @@ impl DbLoaderExt for MessageDbLoader {
                 self.send_channels[&destination].send(Box::new(pending_msg) as QueueOperation)?;
             }
         } else {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            self.wait_for_index_notification().await;
         }
         Ok(())
     }
@@ -337,6 +340,7 @@ impl MessageDbLoader {
         destination_ctxs: HashMap<u32, Arc<MessageContext>>,
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,
+        index_notifications: Option<Receiver<H512>>,
     ) -> Self {
         Self {
             message_whitelist,
@@ -348,6 +352,49 @@ impl MessageDbLoader {
             metric_app_contexts,
             nonce_iterator: ForwardBackwardIterator::new(Arc::new(db) as Arc<dyn HyperlaneDb>),
             max_retries,
+            index_notifications,
+        }
+    }
+
+    /// Discard already-observed index notifications so this receiver cannot
+    /// backpressure the message indexer while the loader is processing a backlog.
+    fn drain_index_notifications(&mut self) {
+        let mut disconnected = false;
+        if let Some(receiver) = self.index_notifications.as_mut() {
+            loop {
+                match receiver.try_recv() {
+                    Ok(_) => {}
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if disconnected {
+            self.index_notifications = None;
+        }
+    }
+
+    /// Wake as soon as the message indexer stores new logs, retaining the
+    /// periodic poll as a safety fallback for missed or unavailable notifications.
+    async fn wait_for_index_notification(&mut self) {
+        const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+        let Some(receiver) = self.index_notifications.as_mut() else {
+            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
+            return;
+        };
+
+        let disconnected = tokio::select! {
+            notification = receiver.recv() => notification.is_none(),
+            _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => false,
+        };
+
+        if disconnected {
+            self.index_notifications = None;
+            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -394,7 +394,6 @@ impl MessageDbLoader {
 
         if disconnected {
             self.index_notifications = None;
-            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -221,6 +221,39 @@ async fn test_idle_tick_returns_on_mid_wait_disconnect() {
     .await;
 }
 
+#[tokio::test]
+async fn test_drain_index_notifications_clears_backlog() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(3);
+        for txid in 0..3 {
+            notification_sender
+                .try_send(H512::from_low_u64_be(txid))
+                .expect("notification channel should have capacity");
+        }
+        let (mut loader, _) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+
+        loader.drain_index_notifications();
+
+        assert_eq!(
+            loader.index_notifications.as_ref().map(Receiver::len),
+            Some(0)
+        );
+        notification_sender
+            .try_send(H512::from_low_u64_be(3))
+            .expect("draining should free channel capacity");
+    })
+    .await;
+}
+
 /// Only adds database entries to the pending message prefix if the message's
 /// retry count is greater than zero
 fn persist_retried_messages(

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -2,8 +2,8 @@ use std::time::Instant;
 
 use prometheus::IntCounterVec;
 use tokio::{
-    sync::mpsc::{self, UnboundedReceiver},
-    time::sleep,
+    sync::mpsc::{self, Receiver, UnboundedReceiver},
+    time::{sleep, timeout},
 };
 use tokio_metrics::TaskMonitor;
 use tracing::info_span;
@@ -69,6 +69,16 @@ fn dummy_message_loader(
     db: &HyperlaneRocksDB,
     cache: OptionalCache<MeteredCache<LocalCache>>,
 ) -> (MessageDbLoader, UnboundedReceiver<QueueOperation>) {
+    dummy_message_loader_with_notifications(origin_domain, destination_domain, db, cache, None)
+}
+
+fn dummy_message_loader_with_notifications(
+    origin_domain: &HyperlaneDomain,
+    destination_domain: &HyperlaneDomain,
+    db: &HyperlaneRocksDB,
+    cache: OptionalCache<MeteredCache<LocalCache>>,
+    index_notifications: Option<Receiver<H512>>,
+) -> (MessageDbLoader, UnboundedReceiver<QueueOperation>) {
     let base_metadata_builder =
         dummy_metadata_builder(origin_domain, destination_domain, db, cache.clone());
     let message_context = Arc::new(dummy_message_context(
@@ -89,6 +99,7 @@ fn dummy_message_loader(
             HashMap::from([(destination_domain.id(), message_context)]),
             vec![].into(),
             DEFAULT_MAX_MESSAGE_RETRIES,
+            index_notifications,
         ),
         receive_channel,
     )
@@ -113,6 +124,67 @@ fn add_db_entry(db: &HyperlaneRocksDB, msg: &HyperlaneMessage, retry_count: u32)
         db.store_pending_message_retry_count_by_message_id(&msg.id(), &retry_count)
             .unwrap();
     }
+}
+
+#[tokio::test]
+async fn test_idle_tick_wakes_on_index_notification() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, _) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+
+        let notify = async move {
+            sleep(Duration::from_millis(20)).await;
+            notification_sender
+                .send(H512::zero())
+                .await
+                .expect("notification receiver should remain open");
+        };
+
+        timeout(Duration::from_millis(750), async {
+            let (tick_result, _) = tokio::join!(loader.tick(), notify);
+            tick_result.expect("idle loader tick should succeed");
+        })
+        .await
+        .expect("index notification should wake the idle loader promptly");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_idle_tick_retains_polling_fallback() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (_notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, _) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+
+        let start = Instant::now();
+        timeout(Duration::from_millis(1_500), loader.tick())
+            .await
+            .expect("fallback poll should complete")
+            .expect("idle loader tick should succeed");
+        assert!(
+            start.elapsed() >= Duration::from_millis(900),
+            "idle loader woke before its fallback poll interval"
+        );
+    })
+    .await;
 }
 
 /// Only adds database entries to the pending message prefix if the message's

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -187,6 +187,40 @@ async fn test_idle_tick_retains_polling_fallback() {
     .await;
 }
 
+#[tokio::test]
+async fn test_idle_tick_returns_on_mid_wait_disconnect() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, _) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+
+        let disconnect = async move {
+            sleep(Duration::from_millis(20)).await;
+            drop(notification_sender);
+        };
+
+        timeout(Duration::from_millis(750), async {
+            let (tick_result, _) = tokio::join!(loader.tick(), disconnect);
+            tick_result.expect("idle loader tick should succeed");
+        })
+        .await
+        .expect("receiver disconnect should wake the idle loader promptly");
+        assert!(
+            loader.index_notifications.is_none(),
+            "disconnected receiver should be cleared"
+        );
+    })
+    .await;
+}
+
 /// Only adds database entries to the pending message prefix if the message's
 /// retry count is greater than zero
 fn persist_retried_messages(

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -504,6 +504,7 @@ impl BaseAgent for Relayer {
             let message_db_loader = match self.run_message_db_loader(
                 origin,
                 send_channels.clone(),
+                BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
                 task_monitor.clone(),
             ) {
                 Ok(task) => task,
@@ -915,6 +916,7 @@ impl Relayer {
         &self,
         origin: &Origin,
         send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
+        index_notifications: Option<MpscReceiver<H512>>,
         task_monitor: TaskMonitor,
     ) -> eyre::Result<JoinHandle<()>> {
         let metrics = MessageDbLoaderMetrics::new(&self.core.metrics, &origin.domain);
@@ -959,6 +961,7 @@ impl Relayer {
             destination_ctxs,
             self.metric_app_contexts.clone(),
             self.max_retries,
+            index_notifications,
         );
 
         let span = info_span!("MessageDbLoader", origin=%message_db_loader.domain());

--- a/rust/main/hyperlane-base/src/contract_sync/broadcast.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/broadcast.rs
@@ -26,9 +26,16 @@ impl BroadcastMpscSender<H512> {
     /// Send a message to all the receiving channels.
     // This will block if at least one of the receiving channels is full
     pub async fn send(&self, txid: H512) -> Result<()> {
-        let senders = self.sender.lock().await;
-        for sender in &*senders {
-            sender.send(txid).await?
+        let mut senders = self.sender.lock().await;
+        let mut index = 0;
+        while index < senders.len() {
+            if senders[index].send(txid).await.is_ok() {
+                index = index.saturating_add(1);
+            } else {
+                // A closed receiver must not prevent later subscribers from
+                // receiving this or future messages.
+                senders.remove(index);
+            }
         }
         Ok(())
     }
@@ -48,5 +55,28 @@ impl BroadcastMpscSender<H512> {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn disconnected_subscriber_does_not_block_later_subscribers() {
+        let broadcaster = BroadcastMpscSender::new(1);
+        let disconnected_receiver = broadcaster.get_receiver().await;
+        let mut live_receiver = broadcaster.get_receiver().await;
+        drop(disconnected_receiver);
+
+        let txid = H512::from_low_u64_be(1);
+        broadcaster.send(txid).await.unwrap();
+
+        assert_eq!(live_receiver.recv().await, Some(txid));
+        assert_eq!(broadcaster.sender.lock().await.len(), 1);
+
+        let next_txid = H512::from_low_u64_be(2);
+        broadcaster.send(next_txid).await.unwrap();
+        assert_eq!(live_receiver.recv().await, Some(next_txid));
     }
 }

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -591,28 +591,22 @@ fn relayer_restart_invariants_met() -> eyre::Result<bool> {
     let log_file_path = AGENT_LOGGING_DIR.join("RLY-output.log");
     let relayer_logfile = File::open(log_file_path).unwrap();
 
-    let line_filters = vec![RETRIEVED_MESSAGE_LOG, "CouldNotFetchMetadata"];
+    let no_metadata_message_count = restored_unavailable_metadata_count(&relayer_logfile);
 
     log!("Checking message statuses were retrieved from logs...");
-    let matched_logs = get_matching_lines(&relayer_logfile, vec![line_filters.clone()]);
-
-    let no_metadata_message_count = *matched_logs
-        .get(&line_filters)
-        .ok_or_else(|| eyre::eyre!("No logs matched line filters"))?;
-
     log!(
-        "CouldNotFetchMetadata log count found {}, expected {}",
+        "Unavailable metadata log count found {}, expected {}",
         no_metadata_message_count,
         ZERO_MERKLE_INSERTION_KATHY_MESSAGES
     );
     // These messages are never inserted into the merkle tree.
     // So these messages will never be deliverable and will always
-    // be in a CouldNotFetchMetadata state.
+    // have an unavailable metadata state.
     // When the relayer restarts, these messages' statuses should be
-    // retrieved from the database with CouldNotFetchMetadata status.
+    // retrieved from the database with an unavailable metadata status.
     if no_metadata_message_count < ZERO_MERKLE_INSERTION_KATHY_MESSAGES {
         log!(
-            "No metadata message count is {}, expected {}",
+            "Unavailable metadata message count is {}, expected {}",
             no_metadata_message_count,
             ZERO_MERKLE_INSERTION_KATHY_MESSAGES
         );
@@ -624,6 +618,57 @@ fn relayer_restart_invariants_met() -> eyre::Result<bool> {
     // Causing this invariant to be higher than expected
     assert!(no_metadata_message_count >= ZERO_MERKLE_INSERTION_KATHY_MESSAGES);
     Ok(true)
+}
+
+fn restored_unavailable_metadata_count(relayer_logfile: &File) -> u32 {
+    let could_not_fetch_filters = vec![RETRIEVED_MESSAGE_LOG, "CouldNotFetchMetadata"];
+    let metadata_refused_filters = vec![RETRIEVED_MESSAGE_LOG, "MessageMetadataRefused"];
+
+    let matched_logs = get_matching_lines(
+        relayer_logfile,
+        vec![
+            could_not_fetch_filters.clone(),
+            metadata_refused_filters.clone(),
+        ],
+    );
+
+    // Once the reorg flag is set, zero-merkle-insertion messages can move from
+    // CouldNotFetchMetadata to MessageMetadataRefused before the relayer restarts.
+    // Both states prove the message status was restored from the database.
+    matched_logs
+        .get(&could_not_fetch_filters)
+        .copied()
+        .unwrap_or_default()
+        + matched_logs
+            .get(&metadata_refused_filters)
+            .copied()
+            .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, SeekFrom};
+
+    use super::*;
+
+    #[test]
+    fn counts_all_restored_unavailable_metadata_states() {
+        let mut log_file = tempfile::tempfile().unwrap();
+        writeln!(
+            log_file,
+            r#"status=Retry(CouldNotFetchMetadata) {RETRIEVED_MESSAGE_LOG}"#
+        )
+        .unwrap();
+        writeln!(
+            log_file,
+            r#"status=Retry(MessageMetadataRefused) {RETRIEVED_MESSAGE_LOG}"#
+        )
+        .unwrap();
+        writeln!(log_file, "CouldNotFetchMetadata without retrieval").unwrap();
+        log_file.seek(SeekFrom::Start(0)).unwrap();
+
+        assert_eq!(restored_unavailable_metadata_count(&log_file), 2);
+    }
 }
 
 /// Check relayer reused already built metadata


### PR DESCRIPTION
## Performance impact

Removes the idle message-loader's residual 0–1s polling delay when txid broadcasting is enabled.

Seven recent `omniscient-relayer-fastpath` messages showed 35–901ms between indexing and submitter pickup (597ms mean). Expected improvement is roughly 0.5–0.6s per idle-path message on average, with up to ~1s at the tail. The 1s poll remains as a correctness fallback.

No material CPU increase is expected: the loader waits on the existing bounded origin broadcaster instead of polling more frequently.

## Summary

- register the database loader with the origin txid broadcaster
- wake an idle loader as soon as message indexing stores a transaction
- drain queued notifications while processing to limit broadcaster backpressure
- retain current polling behavior when notifications are absent or disconnected
- add prompt-wake and fallback tests

## Context

This targets the residual loader delay visible after the faster polling work in #8989. The latency-timeline workflow from #8982 was used to isolate the indexing-to-submitter gap.

## Testing

- `cargo test --package relayer msg::db_loader::tests --lib`
- `cargo clippy --package relayer --lib -- -D warnings`
- `cargo fmt --package relayer -- --check`
- `git diff --check`

The broader `--tests` clippy target remains blocked by existing unrelated test lints.