### PR TITLE
feat: rotate DSRV into solanamainnet default ISM (replace Zee Prime)

### DIFF
--- a/.changeset/rotate-dsrv-solanamainnet-ism.md
+++ b/.changeset/rotate-dsrv-solanamainnet-ism.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Rotated the DSRV validator back into the solanamainnet default multisig ISM in place of the Zee Prime validator, which is shutting down. The threshold remains 3 of 5.

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -1786,7 +1786,10 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
         alias: 'Eclipse',
       },
       DEFAULT_MITOSIS_VALIDATOR,
-      DEFAULT_ZEE_PRIME_VALIDATOR,
+      {
+        address: '0xd90ea26ff731d967c5ea660851f7d63cb04ab820',
+        alias: 'DSRV',
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary
- Zee Prime is shutting down their solanamainnet validator. This rotates the still-running DSRV validator (`0xd90ea26ff731d967c5ea660851f7d63cb04ab820`) back into the `solanamainnet` default multisig ISM in its place.
- Threshold stays **3 of 5** — retains a comfortable margin.
- `DEFAULT_ZEE_PRIME_VALIDATOR` constant is left intact (still used by other chains); only the solanamainnet validator list changes.

## Context
- DSRV was previously part of the solanamainnet set (added in #4467, removed in #6945 as part of a bulk operator-deal rotation). Its solanamainnet validator was never spun down — it's still signing at tip (verified on-chain: bucket `s3://dsrv-hyperlane-v3-validator-signatures-validator10-solana/eu-central-1`, latest checkpoint index matching AW's), because SVM rotations were never completed and it still backs the solaxy/svmbnb warp ISMs.
- With Zee Prime leaving, swapping DSRV back in keeps the set at 5 validators / 3 threshold.

## Test plan
- [ ] CI (lint, build, config validation)
- [ ] Confirm `check-validator-announce` passes for solanamainnet (DSRV already announced on-chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)