### PR TITLE
chore(monitoring): add mainnet3 prepare-queue delivery-stall alert export

### DIFF
--- a/tools/grafana/alerts/README.md
+++ b/tools/grafana/alerts/README.md
@@ -1,0 +1,20 @@
+# Grafana Alert Rules
+
+NOTE: these alert rule exports are **not** provisioned automatically. Grafana Cloud
+remains the live source of truth; the JSON here is a manually-synced, version-controlled
+reference (same convention as the dashboards one directory up). Update the file whenever
+the corresponding rule changes in Grafana.
+
+Each `*.json` is the export of a single Grafana managed alert rule.
+
+## Rules
+
+| File | Rule | Notes |
+| ---- | ---- | ----- |
+| `mainnet3-prepare-queue-anomalous-growth.json` | mainnet3 prepare queue anomalous growth with zero deliveries [critical] | Fires when a destination's relayer `prepare_queue` is >3x its own trailing 7d baseline AND >30 messages AND deliveries have gone to zero for 45m+. Catches per-destination delivery stalls (dead/hung lander task) that the level/`deriv`-based alerts miss, while staying quiet on chains with chronic upstream backlogs (flat vs baseline). |
+
+## Syncing to Grafana
+
+Rules are managed via the Grafana alerting API (or the UI). To re-import an exported rule,
+`POST`/`PUT` the JSON to `/api/v1/provisioning/alert-rules` (adjust `uid`/`folderUID` as
+needed), or paste the query/condition into a new rule in the UI.

--- a/tools/grafana/alerts/mainnet3-prepare-queue-anomalous-growth.json
+++ b/tools/grafana/alerts/mainnet3-prepare-queue-anomalous-growth.json
@@ -1,0 +1,85 @@
+{
+  "uid": "ffs73w46d7668c",
+  "title": "mainnet3 prepare queue anomalous growth with zero deliveries [critical]",
+  "folderUID": "zGKXxzD4z",
+  "ruleGroup": "mainnet3",
+  "orgID": 1,
+  "condition": "C",
+  "for": "45m",
+  "isPaused": true,
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "labels": {
+    "severity": "error",
+    "deployment": "mainnet3",
+    "remote": "{{ $labels.remote }}"
+  },
+  "annotations": {
+    "summary": "Prepare queue for {{ $labels.remote }} is >3x its own trailing 7d baseline AND >30 messages AND zero deliveries (messages_processed rate==0) for 45m+. Indicates a real per-destination delivery stall (e.g. a dead/hung lander task), distinct from chronic upstream backlogs which sit flat vs baseline. Restarting the relayer should fix short-term; ping backend to investigate.",
+    "runbook_url": "https://www.notion.so/hyperlanexyz/Runbook-83c755f2652943289cf98cd1309487a8?source=copy_link"
+  },
+  "notification_settings": {
+    "receiver": "Pagerduty - Error",
+    "group_by": ["grafana_folder", "alertname", "remote"]
+  },
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-prom",
+      "relativeTimeRange": { "from": 600, "to": 0 },
+      "model": {
+        "refId": "A",
+        "editorMode": "code",
+        "expr": "( (sum by(remote)(hyperlane_submitter_queue_length{queue_name=\"prepare_queue\", hyperlane_deployment=\"mainnet3\"}) > bool (3 * avg_over_time(sum by(remote)(hyperlane_submitter_queue_length{queue_name=\"prepare_queue\", hyperlane_deployment=\"mainnet3\"})[7d:1h]))) * (sum by(remote)(hyperlane_submitter_queue_length{queue_name=\"prepare_queue\", hyperlane_deployment=\"mainnet3\"}) > bool 30) * (sum by(remote)(rate(hyperlane_messages_processed_count{hyperlane_deployment=\"mainnet3\"}[15m])) == bool 0) )",
+        "instant": true,
+        "range": false,
+        "intervalMs": 1000,
+        "maxDataPoints": 43200,
+        "legendFormat": "__auto"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "model": {
+        "refId": "B",
+        "type": "reduce",
+        "expression": "A",
+        "reducer": "last",
+        "datasource": { "type": "__expr__", "uid": "__expr__" },
+        "conditions": [
+          {
+            "evaluator": { "params": [], "type": "gt" },
+            "operator": { "type": "and" },
+            "query": { "params": ["B"] },
+            "reducer": { "params": [], "type": "last" },
+            "type": "query"
+          }
+        ],
+        "intervalMs": 1000,
+        "maxDataPoints": 43200
+      }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "model": {
+        "refId": "C",
+        "type": "math",
+        "expression": "$B > 0",
+        "datasource": { "name": "Expression", "type": "__expr__", "uid": "__expr__" },
+        "conditions": [
+          {
+            "evaluator": { "params": [0, 0], "type": "gt" },
+            "operator": { "type": "and" },
+            "query": { "params": [] },
+            "reducer": { "params": [], "type": "avg" },
+            "type": "query"
+          }
+        ],
+        "intervalMs": 1000,
+        "maxDataPoints": 43200
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a version-controlled export of a new Grafana alert: **mainnet3 prepare queue anomalous growth with zero deliveries [critical]** (uid `ffs73w46d7668c`).
- Alert fires when a destination's relayer `prepare_queue` is **>3x its own trailing 7d baseline** AND **>30 messages** AND **deliveries have gone to zero** (`rate(messages_processed[15m]) == 0`) for **45m+**.
- Catches per-destination delivery stalls (dead/hung lander task) that the existing level/`deriv` alerts miss, while staying quiet on chains with chronic upstream backlogs (which sit flat vs their own baseline).

## Context
Motivated by the Base delivery incident (~13.6h of a fully-stalled lander task) where no existing alert fired. The existing `deriv`-based "Prepare Queue is increasing" alert stayed Normal (for=3h + `avg by(remote)` dilution + noisy slope), and the lander liveness alert only watches polling stages that always tick.

14-day backtest across all mainnet3 chains (baseline-relative growth AND zero-deliveries, sustained 45m):
- `base` = 31 buckets (~7.75h — the incident, the only true positive)
- `ink` = 3 (~45m, one minor episode)
- everything else (incl. `linea`, `celestia`, all chronic-backlog chains) = **0**

The baseline-relative framing eliminates the `linea` structural false positive (chronic ~73 queue is its own baseline → ratio ≈1), and the zero-deliveries gate removes benign high-traffic bursts that still deliver.

## Notes
- Grafana Cloud remains the live source of truth; this JSON is a manually-synced reference (same convention as `tools/grafana/*.json` dashboards). Added `tools/grafana/alerts/README.md` describing the convention.
- The rule is currently created **paused** (`is_paused: true`) in Grafana pending a go-live check-in.

## Test plan
- [ ] Confirm backtest stays FP-clean over the trailing 24h before unpausing
- [ ] Unpause the Grafana rule to go live

🤖 Generated with [Claude Code](https://claude.com/claude-code)