### PR TITLE
fix(infra): pin warp getter destinationGas config to on-chain values

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAleoUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAleoUSDCWarpConfig.ts
@@ -129,6 +129,16 @@ export const getAleoUSDCWarpConfig = async (
     token: tokens.solanamainnet.USDC,
     foreignDeployment: 'EiUymjh3vJ2486ozY24s1A1YWXoH6QnSGjWuP95ph35G',
     gas: 300_000,
+    destinationGas: {
+      '1634493807': '64000', // aleo
+      '42161': '68000', // arbitrum
+      '43114': '68000', // avalanche
+      '8453': '68000', // base
+      '56': '68000', // bsc
+      '1': '68000', // ethereum
+      '10': '68000', // optimism
+      '137': '68000', // polygon
+    },
   };
 
   return {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.ts
@@ -22,6 +22,10 @@ export const getEclipseEthereumESWarpConfig = async (
       type: TokenType.synthetic,
       foreignDeployment: '2JvSu7PzquY2b8NDZbnupFZ1jezqMBtNUhi7TuU3GQJD',
       gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+      destinationGas: {
+        '1399811149': '64000', // solanamainnet
+        '1': '68000', // ethereum
+      },
     },
     solanamainnet: {
       foreignDeployment: '9Cu9VqDPPzntFZMar4gCdw6EGL3RbofLEqyh6WKSZKGm',
@@ -29,6 +33,10 @@ export const getEclipseEthereumESWarpConfig = async (
       gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
       owner: eclipseTeamMultiSigs.solanamainnet,
       type: TokenType.synthetic,
+      destinationGas: {
+        '1408864445': '64000', // eclipsemainnet
+        '1': '68000', // ethereum
+      },
     },
     ethereum: {
       mailbox: routerConfig.ethereum.mailbox,

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getSuperseedUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getSuperseedUSDCWarpConfig.ts
@@ -92,6 +92,14 @@ export const getSuperseedUSDCWarpConfig = async (
     type: TokenType.collateral,
     token: tokens.solanamainnet.USDC,
     foreignDeployment: '7aM3itqXToHXhdR97EwJjZc7fay6uBszhUs1rzJm3tto',
+    destinationGas: {
+      '5330': '64000', // superseed
+      '1': '68000', // ethereum
+      '42161': '68000', // arbitrum
+      '8453': '68000', // base
+      '10': '68000', // optimism
+      '57073': '68000', // ink
+    },
   };
 
   return {


### PR DESCRIPTION
## Summary
Clears `check-warp-deploy` **destinationGas** drift for warp routes whose expected config comes from `warpConfigGetterMap` (monorepo getters), not registry `*-deploy.yaml`. Pins expected config to observed on-chain values per the resolve-then-rebump policy.

All three drifts are on the **solanamainnet source leg** and each route is multi-remote, so a global per-chain `gas` bump would break other source→dest pairs. Fix uses an explicit per-source `destinationGas` map (domain-id keyed) on solanamainnet — matching the pattern in registry PR #1598.

| Route | Getter | Drift pinned |
|-------|--------|--------------|
| ES/eclipse | `getEclipseEthereumESWarpConfig` | eclipse↔solana 300000 → 64000 (maps added on both solana and eclipse legs; ethereum leg stays 68000) |
| USDC/aleo | `getAleoUSDCWarpConfig` | solana→aleo 60000 → 64000 (other solana remotes pinned at existing 68000) |
| USDC/superseed | `getSuperseedUSDCWarpConfig` | solana→superseed 68000 → 64000 (other solana remotes pinned at existing 68000) |

## Notes for reviewer
- **USDC/aleo**: registry PR #1598 added a `destinationGas` map to registry `USDC/aleo-deploy.yaml`, but the checker uses this **getter** for `USDC/aleo` (it's in `warpConfigGetterMap`), so that registry edit did not clear the check — this getter edit is the effective fix. The stale registry map is harmless but could be cleaned up separately.
- **USDC/superseed**: `getSuperseedUSDCWarpConfig` is reused by `getEthereumSuperseedUSDCSTAGEWarpConfig` via a `...solanamainnet` spread, so the new map is inherited by the STAGE route too. STAGE routes are skipped by `check-warp-deploy` (#9023), so no check impact; flagging in case an explicit STAGE override is preferred.
- Companion registry PR (2-chain gas bumps + registry-sourced routes): hyperlane-xyz/hyperlane-registry#1602

## Test plan
- [ ] Re-run `check-warp-deploy -e mainnet3` and confirm ES/eclipse, USDC/aleo, USDC/superseed no longer report destinationGas violations