### PR TITLE
fix(infra): pin CARR solanamainnet scale to on-chain value

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainCARRWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCarrchainCARRWarpConfig.ts
@@ -76,6 +76,7 @@ export const getCarrChainCARRWarpConfig = async (
     token: tokens.solanamainnet,
     foreignDeployment: SOLANA_FOREIGN_DEPLOYMENT,
     gas: SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+    scale: 1000000000000,
   };
 
   return {


### PR DESCRIPTION
## Summary
- CARR solanamainnet leg has 6 decimals vs 18-decimal EVM counterparts, so the missing `scale` was treated as identity (1) and tripped check-warp-deploy scale drift.
- Pin `scale: 1000000000000` (10^12) in the CARR getter to match the on-chain value.

This is the getter-driven counterpart to registry PR #1603 (which pins the 7 non-getter SVM scale-gap routes directly). CARR has a monorepo getter, so the fix must live here — after merge, export-warp-configs will backfill the registry.

## Test plan
- [ ] check-warp-deploy (CARR) goes green