### PR TITLE
chore(infra): bump mainnet3 Rust agent image

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -41,13 +41,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'ba9a263-20260714-170949',
-  relayerRC: 'ba9a263-20260714-170949',
-  relayerFastPath: 'ba9a263-20260714-170949',
-  validator: '955281d-20260714-112301',
-  validatorRC: '955281d-20260714-112301',
-  validatorFastPath: '955281d-20260714-112301',
-  scraper: '955281d-20260714-112301',
+  relayer: 'e22be4b-20260715-194756',
+  relayerRC: 'e22be4b-20260715-194756',
+  relayerFastPath: 'e22be4b-20260715-194756',
+  validator: 'e22be4b-20260715-194756',
+  validatorRC: 'e22be4b-20260715-194756',
+  validatorFastPath: 'e22be4b-20260715-194756',
+  scraper: 'e22be4b-20260715-194756',
   // monorepo services
   checkWarpDeploy: 'main',
   // standalone services


### PR DESCRIPTION
## Summary

- bumps every mainnet3 Rust-agent tag to the immutable `e22be4b-20260715-194756` image
- covers Hyperlane, RC, and FastPath relayers/validators plus the scraper
- includes the Rust-agent optimizations merged in #8989, #9029, #9030, #9031, #9032, #9033, and #9034

Build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/29445848753

## Rollout

The main Hyperlane relayer has already been rolled out and verified in `mainnet3`:

- Helm release `omniscient-relayer`, revision 576
- image digest `sha256:6bdc655421f2939024c907007e27987135dff6bab5aefb514fd0276e98cef04d`
- agent and cloudflared containers ready with zero restarts
- all 94 critical-error metric series at zero
- confirmed-message counters active after startup
- no panic, fatal, or critical errors; observed ERROR logs are expected per-message states such as awaiting validator signatures, nonce replacement, and already-delivered handling

Validator, scraper, RC, and FastPath rollouts are intentionally deferred.

## Validation

- `pnpm -C typescript/infra check`
- `git diff --check`
- exact image exercised sequentially in RC before the production relayer rollout