### PR TITLE
perf(relayer): reuse CCIP-read HTTP connections

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -44,6 +44,13 @@ fn ccip_signature_cache() -> &'static CcipSignatureCache {
     CCIP_SIGNATURE_CACHE.get_or_init(|| Cache::builder().max_capacity(10_000).build())
 }
 
+/// Process-wide client so requests to CCIP-read servers can reuse pooled connections.
+static CCIP_HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+
+fn ccip_http_client() -> &'static Client {
+    CCIP_HTTP_CLIENT.get_or_init(Client::new)
+}
+
 #[derive(Clone, Debug, Serialize)]
 struct OffchainLookupRequestBody {
     pub data: String,
@@ -420,7 +427,7 @@ async fn fetch_offchain_data(
             ?message_id,
             "Sending POST request to offchain lookup server"
         );
-        Client::new()
+        ccip_http_client()
             .request(Method::POST, interpolated_url)
             .header(CONTENT_TYPE, "application/json")
             .timeout(Duration::from_secs(DEFAULT_TIMEOUT))
@@ -433,7 +440,7 @@ async fn fetch_offchain_data(
                 MetadataBuildError::FailedToBuild(msg)
             })?
     } else {
-        Client::new()
+        ccip_http_client()
             .request(Method::GET, interpolated_url)
             .timeout(Duration::from_secs(DEFAULT_TIMEOUT))
             .send()
@@ -514,12 +521,14 @@ fn create_ccip_url_regex() -> RegexSet {
 #[cfg(test)]
 mod test {
     use std::{
+        net::SocketAddr,
         str::FromStr,
         sync::atomic::{AtomicUsize, Ordering},
         time::Duration,
         vec,
     };
 
+    use axum::{extract::ConnectInfo, routing::get, Router};
     use ethers::types::H160 as EthersH160;
     use futures::future::join_all;
     use hyperlane_core::{HyperlaneSignerError, Signature as HyperlaneSignature, SignedType, U256};
@@ -606,6 +615,32 @@ mod test {
             callback_function: [0, 0, 0, 0],
             extra_data: vec![].into(),
         }
+    }
+
+    #[tokio::test]
+    async fn test_ccip_http_client_reuses_connections() -> eyre::Result<()> {
+        async fn peer_port(ConnectInfo(address): ConnectInfo<SocketAddr>) -> String {
+            address.port().to_string()
+        }
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let router = Router::new().route("/", get(peer_port));
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+        });
+
+        let url = format!("http://{address}");
+        let first_peer_port = ccip_http_client().get(&url).send().await?.text().await?;
+        let second_peer_port = ccip_http_client().get(&url).send().await?.text().await?;
+
+        server.abort();
+        assert_eq!(first_peer_port, second_peer_port);
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- reuse one process-wide `reqwest::Client` for CCIP-read GET and POST requests
- preserve existing request construction, timeout, and response handling
- verify sequential requests reuse the same TCP connection

## Root cause

`fetch_offchain_data` created a new `reqwest::Client` for every request, including retries. Each client owns its own connection pool, so dropping it prevented DNS/TCP/TLS and keep-alive reuse.

## Expected performance delta

In a one-hour live sample, the primary CCIP host received 70 production and 78 RC requests. Grouping requests by reqwest's default 90-second idle-pool timeout indicates that approximately 76-78% of fresh connections could have been avoided.

Successful requests to that host had a 290 ms median and 813 ms p95 over 24 hours. This change saves only the DNS/TCP/TLS/connection-establishment portion; server processing time is unchanged, so no unsupported end-to-end latency delta is claimed.

## Validation

- stacked CCIP module suite: `cargo test -p relayer msg::metadata::ccip_read::test --lib` (9 passed)
- `cargo clippy -p relayer --lib -- -D warnings`
- `cargo fmt --package relayer -- --check`
- `git diff --check`
- normal pre-commit hooks

The focused test starts an Axum keep-alive server and confirms two sequential requests arrive from the same peer TCP port.

## Stack

- base: #9045
