### PR TITLE
chore(infra): bump testnet4 key-funder image to Tron funding fix

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -67,5 +67,5 @@ export const testnetDockerTags: BaseDockerTags = {
   validatorFastPath: '8b6fdf8-20260605-090142',
   scraper: '8b6fdf8-20260605-090142',
   // standalone services
-  keyFunder: '87f0933-20260605-085727',
+  keyFunder: '5dc6aa4-20260714-184449',
 };


### PR DESCRIPTION
## Summary
- Bumps `testnetDockerTags.keyFunder` from `87f0933-20260605-085727` (June 5, pre-fix) to `5dc6aa4-20260714-184449` — the same image mainnet has run since #9024.

## Why
The deployed testnet4 key-funder CronJob was still on the June 5 image, which funds Tron chains via `eth_sendRawTransaction`. On the hourly `tronshasta` IGP fee-claim it gets `-32601 the method eth_sendRawTransaction does not exist/is not available` from `api.shasta.trongrid.io/jsonrpc`, so the job exits non-zero (`1/13 chains failed to fund: tronshasta`) and fires the "Key Funder Pods Failing" alert (48 firings in the last ~24h). Dust on the tronshasta IGP (~9h ago) flipped the job from Completed to Error, since `desiredBalance:'0'` -> `claimThreshold:0.0` means any dust triggers the claim.

PR #9021 (`5dc6aa4`) rewrote the key-funder to fund Tron via the native `TronWallet` HTTP wallet API; #9024 bumped mainnet. This brings testnet4 to the same fixed image.

## Test plan
- [ ] Merge, then redeploy the testnet4 key-funder CronJob to the new image
- [ ] Confirm next hourly run reaches "KeyFunder completed successfully" and logs tronChains: ["tronshasta"]
- [ ] Confirm "Key Funder Pods Failing" (testnet4) stops firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)