### PR TITLE
chore(infra): skip USDCSTAGE/eclipsemainnet in warp check

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -48,6 +48,9 @@ const ROUTES_TO_SKIP: string[] = [
   'GAME/base-form',
   // Skip until Paradex executes hyperevm upgrade on their side
   WarpRouteIds.ParadexUSDC,
+  // Staging route: not auto-skipped by isStagingOrTestRoute since the STAGE
+  // marker is in the symbol before the first `/`, not a chain segment.
+  WarpRouteIds.EclipseUSDCSTAGE,
 ];
 
 // Name segments that mark a warp route as a non-production (staging/test)


### PR DESCRIPTION
## Summary
- Adds `WarpRouteIds.EclipseUSDCSTAGE` (`USDCSTAGE/eclipsemainnet`) to `ROUTES_TO_SKIP` in `check-warp-deploy.ts` so the daily warp check no longer produces violations for this staging route.
- `isStagingOrTestRoute` does not auto-catch it: the `STAGE` marker is in the symbol (before the first `/`), not in a `-`/`/`-delimited chain segment, so it must be listed explicitly (matching the `ParadexUSDC` pattern).

## Context
`USDCSTAGE/eclipsemainnet` is a staging deployment. Its only genuine warp-check diff was a `tokenFee` mismatch caused by the registry `monad` leg being an under-specified collateral stub vs a full on-chain `RoutingFee` — i.e. registry drift on a staging route, not a production config issue. Rather than backfill the staging config, we exclude it from the monitor.

Existing `hyperlane_check_violations` series for this route will be cleared separately via `clear-warp-violation` as part of a Grafana ghost-cleanup pass.

## Test plan
- [ ] CI lint/typecheck passes
- [ ] Next `check-warp-deploy` run logs `USDCSTAGE/eclipsemainnet` under "Skipping the following warp routes" and emits no violations for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)