### PR TITLE
fix(infra): pin CCTP v2 and LUMIA warp owners to on-chain values

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWarpConfig.ts
@@ -50,7 +50,7 @@ export const getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWa
       type: TokenType.synthetic,
       proxyAdmin: {
         address: '0x54bB5b12c67095eB3dabCD11FA74AAcfE46E7767',
-        owner: '0x8bBA07Ddc72455b55530C17e6f6223EF6E156863',
+        owner: '0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39',
       },
     };
 
@@ -61,7 +61,7 @@ export const getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWa
       token: '0xD9343a049D5DBd89CD19DC6BcA8c48fB3a0a42a7',
       proxyAdmin: {
         address: '0xdaB976ae358D4D2d25050b5A25f71520983C46c9',
-        owner: '0x8bBA07Ddc72455b55530C17e6f6223EF6E156863',
+        owner: '0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39',
       },
     };
 
@@ -71,7 +71,7 @@ export const getArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIAWa
       type: TokenType.native,
       proxyAdmin: {
         address: '0xBC53dACd8c0ac0d2bAC461479EAaf5519eCC8853',
-        owner: '0x8bBA07Ddc72455b55530C17e6f6223EF6E156863',
+        owner: '0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39',
       },
     };
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCCTPConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCCTPConfig.ts
@@ -96,6 +96,10 @@ export const getCCTPV1WarpConfig = async (
   );
 };
 
+// These V2 routes remain owned by the AW Safe on-chain (ICA migration pending),
+// so pin the config to the actual on-chain owner rather than the ICA.
+const v2SafeOwnedChains = new Set(['arbitrum', 'base']);
+
 const getCCTPV2WarpConfig = (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   _abacusWorksEnvOwnerConfig: ChainMap<OwnableConfig>,
@@ -117,8 +121,13 @@ const getCCTPV2WarpConfig = (
     const minFinalityThreshold =
       mode === 'fast' ? FAST_FINALITY_THRESHOLD : STANDARD_FINALITY_THRESHOLD;
 
+    const owner = v2SafeOwnedChains.has(chain)
+      ? (awSafes[chain] ?? config.owner)
+      : config.owner;
+
     return {
       ...config,
+      owner,
       contractVersion:
         mode === 'fast' ? CONTRACT_VERSION_FAST : CONTRACT_VERSION_STANDARD,
       maxFeeBps,


### PR DESCRIPTION
## Summary

Aligns the configured warp owners with the actual on-chain owners for two routes flagged by `check-warp-deploy` owner mismatches. On-chain is treated as source of truth (to be verified manually before merge).

### CCTP v2 (fast + standard), arbitrum & base
- On-chain owner (and proxyAdmin owner) is the **AW Safe**, not the AW ICA the config derived via `awIcas[chain] ?? awSafes[chain]`.
  - arbitrum: `0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e` (Safe) vs configured `0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45` (ICA)
  - base: `0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF` (Safe) vs configured `0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7` (ICA)
- Pins these two V2 chains to `awSafes[chain]`. ICA migration is still pending (see existing TODOs in the getter); other V2 chains already match and are unchanged.

### LUMIA, bsc / ethereum / lumiaprism
- On-chain `proxyAdmin.owner` is `0xa86C4AF592ddAa676f53De278dE9cfCD52Ae6B39` (the Lumia team address, same as the token owner), not the configured `0x8bBA07Ddc72455b55530C17e6f6223EF6E156863`.

## Test plan
- [ ] Manually verify on-chain owners match the new configured values before merge
- [ ] `check-warp-deploy` no longer emits owner ConfigMismatch for USDC/mainnet-cctp-v2-fast, USDC/mainnet-cctp-v2-standard (arbitrum, base) and LUMIA proxyAdmin owner (bsc, ethereum, lumiaprism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)