### PR TITLE
fix(infra): catch token-name staging markers in check-warp-deploy blacklist

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -50,17 +50,24 @@ const ROUTES_TO_SKIP: string[] = [
   WarpRouteIds.ParadexUSDC,
 ];
 
-// Name segments that mark a warp route as a non-production (staging/test)
-// deployment. Matched against the `-`/`/`-delimited segments of the route
-// name so `USDC/moonpay-staging` is skipped but names like `attestation` are
-// not. These routes are excluded from check-warp-deploy so they don't produce
-// violations on mainnet.
-const STAGING_ROUTE_MARKERS = ['staging', 'test'];
+// Markers that identify a non-production (staging/test) warp route. Matched
+// against every `-`/`/`-delimited segment of the FULL route id, INCLUDING the
+// token symbol, so both delimited markers (`USDC/moonpay-staging`,
+// `EZETHSTAGE/renzo-stage`) and markers glommed onto the token symbol
+// (`USDCSTAGE/...`, `REZSTAGING/...`, `ETHSTAGE/...`) are caught. Whole-segment
+// equality plus a staging-suffix check keeps names like `attestation` from
+// false-matching (`test` as a substring), while still catching the suffixed
+// staging tokens.
+const STAGING_ROUTE_MARKERS = ['staging', 'stage', 'test', 'testnet'];
+const STAGING_SUFFIX_MARKERS = ['staging', 'stage'];
 
 function isStagingOrTestRoute(warpRouteId: string): boolean {
-  const [, ...rest] = warpRouteId.split('/');
-  const segments = rest.join('/').toLowerCase().split(/[-/]/);
-  return segments.some((segment) => STAGING_ROUTE_MARKERS.includes(segment));
+  const segments = warpRouteId.toLowerCase().split(/[-/]/);
+  return segments.some(
+    (segment) =>
+      STAGING_ROUTE_MARKERS.includes(segment) ||
+      STAGING_SUFFIX_MARKERS.some((marker) => segment.endsWith(marker)),
+  );
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- The `check-warp-deploy` staging/test route blacklist (added in #9023) dropped the token-symbol segment (`const [, ...rest] = warpRouteId.split('/')`) and only did whole-segment equality matching. Routes whose staging marker lives in the **token symbol** — `USDCSTAGE/eclipsemainnet`, `REZSTAGING/base-ethereum-unichain`, `EZETHSTAGE/renzo-stage`, `PZETHSTAGE/...`, `USDTSTAGE/mode`, `ETHSTAGE/stage` — slipped through and produced spurious contract-verification violations on the daily mainnet cron.
- Fix: match against **every** `-`/`/`-delimited segment of the full route id (including the token symbol), add `stage`/`testnet` markers, and treat `staging`/`stage` as segment **suffixes** so markers glommed onto a token symbol are caught. Whole-segment equality is retained so `test` cannot substring-match names like `attestation`.

## Verification
Ran all 149 mainnet `warpIds.ts` route ids through the new predicate. Exactly the 10 staging/test routes match; **zero production routes false-positive**:

```
EZETHSTAGE/renzo-stage
USDCSTAGE/eclipsemainnet
ETHSTAGE/stage
PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit
REZSTAGING/base-ethereum-unichain
oUSDT/staging
USDC/testnet-cctp
USDTSTAGE/mode
USDC/moonpay-staging
USDT/moonpay-staging
```

## Test plan
- [x] oxlint + oxfmt pass (pre-commit hooks)
- [x] Predicate unit-checked against staging IDs (all match) and production IDs (none match)
- [ ] `check-warp-deploy` mainnet cron run shows the STAGE/STAGING token routes no longer flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)