### PR TITLE
fix(infra): pin CCTP v2 arbitrum/base warp owners to on-chain Safe

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getCCTPConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getCCTPConfig.ts
@@ -96,6 +96,10 @@ export const getCCTPV1WarpConfig = async (
   );
 };
 
+// These V2 routes remain owned by the AW Safe on-chain (ICA migration pending),
+// so pin the config to the actual on-chain owner rather than the ICA.
+const v2SafeOwnedChains = new Set(['arbitrum', 'base']);
+
 const getCCTPV2WarpConfig = (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   _abacusWorksEnvOwnerConfig: ChainMap<OwnableConfig>,
@@ -117,8 +121,13 @@ const getCCTPV2WarpConfig = (
     const minFinalityThreshold =
       mode === 'fast' ? FAST_FINALITY_THRESHOLD : STANDARD_FINALITY_THRESHOLD;
 
+    const owner = v2SafeOwnedChains.has(chain)
+      ? (awSafes[chain] ?? config.owner)
+      : config.owner;
+
     return {
       ...config,
+      owner,
       contractVersion:
         mode === 'fast' ? CONTRACT_VERSION_FAST : CONTRACT_VERSION_STANDARD,
       maxFeeBps,


### PR DESCRIPTION
## Summary

Aligns the configured CCTP v2 warp owners with the actual on-chain owners for the arbitrum and base legs flagged by `check-warp-deploy` owner mismatches. On-chain is treated as source of truth (to be verified manually before merge).

### CCTP v2 (fast + standard), arbitrum & base
- On-chain owner (and proxyAdmin owner) is the **AW Safe**, not the AW ICA the config derived via `awIcas[chain] ?? awSafes[chain]`.
  - arbitrum: `0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e` (Safe) vs configured `0xD2757Bbc28C80789Ed679f22Ac65597Cacf51A45` (ICA)
  - base: `0x3949eD0CD036D9FF662d97BD7aC1686051c4aeBF` (Safe) vs configured `0x61756c4beBC1BaaC09d89729E2cbaD8BD30c62B7` (ICA)
- Pins these two V2 chains to `awSafes[chain]`. ICA migration is still pending (see existing TODOs in the getter); other V2 chains already match and are unchanged.

## Test plan
- [ ] Manually verify on-chain owners match the new configured values before merge
- [ ] `check-warp-deploy` no longer emits owner ConfigMismatch for USDC/mainnet-cctp-v2-fast, USDC/mainnet-cctp-v2-standard (arbitrum, base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)