### PR TITLE
feat: rebalancer fleet mode — one process for all Solana-leg USDC rebalancers

### DIFF
--- a/.changeset/rebalancer-fleet-mode.md
+++ b/.changeset/rebalancer-fleet-mode.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': minor
+---
+
+Added fleet mode (`REBALANCER_CONFIG_FILES`) that runs multiple warp-route rebalancers in one process with a shared execution lock, fresh inventory-balance refetch before inventory execution, an injectable inventory view seam, and a start-once metrics server.

--- a/typescript/infra/config/environments/mainnet3/rebalancer/fleets.ts
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/fleets.ts
@@ -1,0 +1,28 @@
+import { assert } from '@hyperlane-xyz/utils';
+
+export interface RebalancerFleetDefinition {
+  name: string;
+  warpRouteIds: string[];
+}
+
+export const rebalancerFleets: RebalancerFleetDefinition[] = [
+  {
+    name: 'usdc-sol-fleet',
+    warpRouteIds: [
+      'USDC/eclipsemainnet',
+      'USDC/radix',
+      'USDC/subtensor',
+      'USDC/aleo',
+      'USDC/paradex',
+      'USDC/superseed',
+    ],
+  },
+];
+
+export function getRebalancerFleet(
+  name: string,
+): RebalancerFleetDefinition {
+  const fleet = rebalancerFleets.find((candidate) => candidate.name === name);
+  assert(fleet, `Rebalancer fleet not found: ${name}`);
+  return fleet;
+}

--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -76,7 +76,10 @@ The rebalancer container
     value: json
   - name: LOG_LEVEL
     value: info
-  {{- if .Values.warpRouteId }}
+  {{- if .Values.hyperlane.rebalancerConfigFiles }}
+  - name: WARP_ROUTE_IDS
+    value: {{ join "," .Values.hyperlane.warpRouteIds | quote }}
+  {{- else if .Values.warpRouteId }}
   - name: WARP_ROUTE_ID
     value: {{ .Values.warpRouteId | quote }}
   {{- end }}
@@ -96,8 +99,13 @@ The rebalancer container
   {{- end }}
   - name: COINGECKO_API_KEY
     value: $(COINGECKO_API_KEY)
+  {{- if .Values.hyperlane.rebalancerConfigFiles }}
+  - name: REBALANCER_CONFIG_FILES
+    value: "{{ range $index, $config := .Values.hyperlane.rebalancerConfigFiles }}{{ if $index }},{{ end }}/config/{{ $config.name }}{{ end }}"
+  {{- else }}
   - name: REBALANCER_CONFIG_FILE
     value: "/config/rebalancer-config.yaml"
+  {{- end }}
   - name: CHECK_FREQUENCY
     value: "60000"
   - name: WITH_METRICS

--- a/typescript/infra/helm/rebalancer/templates/configmap.yaml
+++ b/typescript/infra/helm/rebalancer/templates/configmap.yaml
@@ -5,5 +5,11 @@ metadata:
   labels:
     {{- include "hyperlane.labels" . | nindent 4 }}
 data:
+{{- if .Values.hyperlane.rebalancerConfig }}
   rebalancer-config.yaml: |
 {{ .Values.hyperlane.rebalancerConfig | indent 4 }}
+{{- end }}
+{{- range .Values.hyperlane.rebalancerConfigFiles }}
+  {{ .name }}: |
+{{ .content | indent 4 }}
+{{- end }}

--- a/typescript/infra/helm/rebalancer/values.yaml
+++ b/typescript/infra/helm/rebalancer/values.yaml
@@ -8,6 +8,8 @@ hyperlane:
   context: hyperlane
   registryUri: ''
   rebalancerConfig: ''
+  rebalancerConfigFiles: []
+  warpRouteIds: []
   withMetrics: true
   # Used for fetching private RPC secrets
   chains: []

--- a/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
+++ b/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
@@ -1,21 +1,33 @@
 import { checkbox, input } from '@inquirer/prompts';
-import path from 'path';
 
 import {
   LogFormat,
   LogLevel,
   configureRootLogger,
   rootLogger,
+  sleep,
 } from '@hyperlane-xyz/utils';
 
+import {
+  getRebalancerFleet,
+  rebalancerFleets,
+} from '../../config/environments/mainnet3/rebalancer/fleets.js';
 import { DeployEnvironment } from '../../src/config/deploy-environment.js';
 import {
+  RebalancerFleetHelmManager,
   RebalancerHelmManager,
   getDeployedRebalancerWarpRouteIds,
+  getRebalancerConfigPath,
 } from '../../src/rebalancer/helm.js';
 import { REBALANCER_HELM_RELEASE_PREFIX } from '../../src/utils/consts.js';
 import { validateRegistryCommit } from '../../src/utils/git.js';
-import { HelmCommand } from '../../src/utils/helm.js';
+import {
+  HelmCommand,
+  HelmManager,
+  getHelmReleaseName,
+  removeHelmRelease,
+} from '../../src/utils/helm.js';
+import { execCmd } from '../../src/utils/utils.js';
 import {
   assertCorrectKubeContext,
   filterOrphanedWarpRouteIds,
@@ -27,8 +39,37 @@ import {
 } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
-function getRebalancerConfigPathPrefix(environment: DeployEnvironment) {
-  return `config/environments/${environment}/rebalancer`;
+async function waitForReleasePodsToTerminate(
+  releaseName: string,
+  namespace: DeployEnvironment,
+): Promise<void> {
+  const selector = `app.kubernetes.io/instance=${releaseName}`;
+  const timeout = Date.now() + 120_000;
+
+  rootLogger.info(`Waiting for pods from ${releaseName} to terminate`);
+  while (Date.now() < timeout) {
+    const [pods] = await execCmd([
+      'kubectl',
+      'get',
+      'pods',
+      '--namespace',
+      namespace,
+      '--selector',
+      selector,
+      '-o',
+      'name',
+    ]);
+
+    if (pods.trim().length === 0) {
+      return;
+    }
+
+    await sleep(1000);
+  }
+
+  throw new Error(
+    `Timed out waiting for pods from ${releaseName} to terminate`,
+  );
 }
 
 async function main() {
@@ -39,11 +80,76 @@ async function main() {
     metrics,
     registryCommit: registryCommitArg,
     yes: skipConfirmation,
-  } = await withYes(
-    withMetrics(withRegistryCommit(withWarpRouteId(getArgs()))),
-  ).parse();
+    fleet: fleetName,
+  } = await withYes(withMetrics(withRegistryCommit(withWarpRouteId(getArgs()))))
+    .describe('fleet', 'rebalancer fleet name')
+    .string('fleet')
+    .conflicts('fleet', 'warpRouteId')
+    .parse();
+
+  if (fleetName && environment !== 'mainnet3') {
+    throw new Error(
+      `Rebalancer fleets are only defined for mainnet3; received ${environment}`,
+    );
+  }
+
+  const fleet = fleetName ? getRebalancerFleet(fleetName) : undefined;
 
   await assertCorrectKubeContext(getEnvironmentConfig(environment));
+
+  if (fleet) {
+    let registryCommit: string;
+    if (registryCommitArg) {
+      registryCommit = registryCommitArg;
+    } else {
+      const defaultRegistryCommit =
+        await RebalancerFleetHelmManager.getDeployedRegistryCommit(
+          fleet.name,
+          environment,
+        );
+
+      if (skipConfirmation) {
+        registryCommit = defaultRegistryCommit ?? 'main';
+      } else {
+        registryCommit = await input({
+          message: `[fleet ${fleet.name}] Enter registry version (commit, branch or tag):`,
+          default: defaultRegistryCommit,
+        });
+      }
+    }
+
+    await validateRegistryCommit(registryCommit);
+
+    const helmManager = new RebalancerFleetHelmManager(
+      fleet,
+      environment,
+      registryCommit,
+      metrics,
+    );
+    await helmManager.runPreflightChecks();
+
+    rootLogger.warn(
+      '⚠️  CUTOVER: pod-name-based Grafana alerts referencing hyperlane-rebalancer-usdc-* release names must be updated. Metric-level warp_route_id alerts are unaffected.',
+    );
+
+    for (const memberWarpRouteId of fleet.warpRouteIds) {
+      const releaseName = getHelmReleaseName(
+        memberWarpRouteId,
+        REBALANCER_HELM_RELEASE_PREFIX,
+      );
+      if (!(await HelmManager.doesHelmReleaseExist(releaseName, environment))) {
+        continue;
+      }
+
+      rootLogger.info(`Uninstalling per-route rebalancer: ${releaseName}`);
+      await removeHelmRelease(releaseName, environment);
+      await waitForReleasePodsToTerminate(releaseName, environment);
+      rootLogger.info(`Per-route rebalancer terminated: ${releaseName}`);
+    }
+
+    await helmManager.runHelmCommand(HelmCommand.InstallOrUpgrade);
+    return;
+  }
 
   let warpRouteIds: string[];
   if (warpRouteId) {
@@ -54,11 +160,7 @@ async function main() {
       REBALANCER_HELM_RELEASE_PREFIX,
     );
     const deployedIds = [
-      ...new Set(
-        deployedPods
-          .map((p) => p.warpRouteId)
-          .filter((id): id is string => !!id),
-      ),
+      ...new Set(deployedPods.map((pod) => pod.warpRouteId)),
     ].sort();
 
     if (deployedIds.length === 0) {
@@ -77,6 +179,19 @@ async function main() {
     if (warpRouteIds.length === 0) {
       rootLogger.info('No rebalancers selected');
       process.exit(0);
+    }
+  }
+
+  if (environment === 'mainnet3') {
+    for (const selectedWarpRouteId of warpRouteIds) {
+      const owningFleet = rebalancerFleets.find((candidate) =>
+        candidate.warpRouteIds.includes(selectedWarpRouteId),
+      );
+      if (owningFleet) {
+        throw new Error(
+          `Warp route ${selectedWarpRouteId} is managed by fleet ${owningFleet.name}. Deploy it with --fleet ${owningFleet.name}.`,
+        );
+      }
     }
   }
 
@@ -135,10 +250,9 @@ async function main() {
     }
 
     // Build path for config file - relative for local checks
-    const configFileName = `${warpRouteId}-config.yaml`;
-    const relativeConfigPath = path.join(
-      getRebalancerConfigPathPrefix(environment),
-      configFileName,
+    const relativeConfigPath = getRebalancerConfigPath(
+      environment,
+      warpRouteId,
     );
 
     const containerConfigPath = `/hyperlane-monorepo/typescript/infra/${relativeConfigPath}`;

--- a/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
+++ b/typescript/infra/scripts/rebalancer/deploy-rebalancer.ts
@@ -159,9 +159,22 @@ async function main() {
       environment,
       REBALANCER_HELM_RELEASE_PREFIX,
     );
-    const deployedIds = [
-      ...new Set(deployedPods.map((pod) => pod.warpRouteId)),
-    ].sort();
+    // Fleet-managed routes are redeployed via --fleet, not per-route;
+    // exclude them from the checkbox so selecting one can't abort the batch.
+    const fleetManagedIds = new Set(
+      rebalancerFleets.flatMap((candidate) => candidate.warpRouteIds),
+    );
+    const deployedIds = [...new Set(deployedPods.map((pod) => pod.warpRouteId))]
+      .filter((id) => {
+        if (environment === 'mainnet3' && fleetManagedIds.has(id)) {
+          rootLogger.info(
+            `Excluding fleet-managed route ${id} (redeploy it with --fleet)`,
+          );
+          return false;
+        }
+        return true;
+      })
+      .sort();
 
     if (deployedIds.length === 0) {
       rootLogger.error(

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -315,8 +315,40 @@ export class RebalancerFleetHelmManager extends HelmManager {
       );
     }
 
+    // Collect all existing warp monitors first and confirm ONCE before
+    // uninstalling any, so declining can never leave earlier members with
+    // their monitor removed but no fleet installed.
+    const existingMonitors: { warpRouteId: string; releaseName: string }[] = [];
     for (const warpRouteId of this.fleet.warpRouteIds) {
-      await checkAndHandleExistingMonitor(warpRouteId, this.namespace);
+      const releaseName = getHelmReleaseName(
+        warpRouteId,
+        WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX,
+      );
+      if (await HelmManager.doesHelmReleaseExist(releaseName, this.namespace)) {
+        existingMonitors.push({ warpRouteId, releaseName });
+      }
+    }
+
+    if (existingMonitors.length > 0) {
+      const monitorIds = existingMonitors
+        .map(({ warpRouteId }) => warpRouteId)
+        .join(', ');
+      const shouldReplace = await confirm({
+        message: `Warp route monitors exist for fleet members: ${monitorIds}. The rebalancer includes monitoring functionality. Replace ALL of them with the fleet rebalancer?`,
+      });
+      if (!shouldReplace) {
+        throw new Error(
+          `Deployment aborted: User chose not to replace existing monitors for fleet ${this.fleet.name}.`,
+        );
+      }
+
+      for (const { releaseName } of existingMonitors) {
+        rootLogger.info(`Uninstalling existing warp monitor: ${releaseName}`);
+        await removeHelmRelease(releaseName, this.namespace);
+        rootLogger.info(
+          `Successfully uninstalled warp monitor: ${releaseName}`,
+        );
+      }
     }
 
     this.rebalancerConfigFiles = configFiles;

--- a/typescript/infra/src/rebalancer/helm.ts
+++ b/typescript/infra/src/rebalancer/helm.ts
@@ -13,6 +13,7 @@ import { rootLogger } from '@hyperlane-xyz/utils';
 import { readYaml } from '@hyperlane-xyz/utils/fs';
 
 import { DockerImageRepos, mainnetDockerTags } from '../../config/docker.js';
+import type { RebalancerFleetDefinition } from '../../config/environments/mainnet3/rebalancer/fleets.js';
 import { getWarpCoreConfig } from '../../config/registry.js';
 import { DeployEnvironment } from '../config/deploy-environment.js';
 import {
@@ -26,6 +27,91 @@ import {
   removeHelmRelease,
 } from '../utils/helm.js';
 import { execCmdAndParseJson, getInfraPath } from '../utils/utils.js';
+
+interface RebalancerConfigDetails {
+  content: string;
+  chains: string[];
+  inventorySignerProtocols: string[];
+}
+
+interface RebalancerConfigFile {
+  name: string;
+  content: string;
+}
+
+export function getRebalancerConfigPath(
+  environment: DeployEnvironment,
+  warpRouteId: string,
+): string {
+  return path.join(
+    'config/environments',
+    environment,
+    'rebalancer',
+    `${warpRouteId}-config.yaml`,
+  );
+}
+
+export function getRebalancerFleetConfigFileName(warpRouteId: string): string {
+  return `${warpRouteId.toLowerCase().replaceAll('/', '-')}-config.yaml`;
+}
+
+function readRebalancerConfig(
+  warpRouteId: string,
+  rebalancerConfigFile: string,
+): RebalancerConfigDetails {
+  const warpCoreConfig = getWarpCoreConfig(warpRouteId);
+
+  const config: RebalancerConfigFileInput = readYaml(rebalancerConfigFile);
+  const validationResult = RebalancerConfigSchema.safeParse(config);
+  if (!validationResult.success) {
+    throw new Error(fromZodError(validationResult.error).message);
+  }
+
+  const chainNames = getStrategyChainNames(validationResult.data.strategy);
+  if (chainNames.length === 0) {
+    throw new Error('No chains configured');
+  }
+
+  return {
+    content: fs.readFileSync(rebalancerConfigFile, 'utf8'),
+    chains: [...new Set(warpCoreConfig.tokens.map((token) => token.chainName))],
+    inventorySignerProtocols: Object.keys(
+      validationResult.data.inventorySigners ?? {},
+    ),
+  };
+}
+
+async function checkAndHandleExistingMonitor(
+  warpRouteId: string,
+  namespace: string,
+): Promise<void> {
+  const monitorReleaseName = getHelmReleaseName(
+    warpRouteId,
+    WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX,
+  );
+
+  if (
+    !(await HelmManager.doesHelmReleaseExist(monitorReleaseName, namespace))
+  ) {
+    return;
+  }
+
+  const shouldReplace = await confirm({
+    message: `A warp route monitor exists for ${warpRouteId}. The rebalancer includes monitoring functionality. Would you like to replace the monitor with the rebalancer?`,
+  });
+
+  if (!shouldReplace) {
+    throw new Error(
+      `Deployment aborted: User chose not to replace existing monitor for ${warpRouteId}.`,
+    );
+  }
+
+  rootLogger.info(`Uninstalling existing warp monitor: ${monitorReleaseName}`);
+  await removeHelmRelease(monitorReleaseName, namespace);
+  rootLogger.info(
+    `Successfully uninstalled warp monitor: ${monitorReleaseName}`,
+  );
+}
 
 export class RebalancerHelmManager extends HelmManager {
   static helmReleasePrefix: string = 'hyperlane-rebalancer';
@@ -51,43 +137,17 @@ export class RebalancerHelmManager extends HelmManager {
   }
 
   async runPreflightChecks(localConfigPath: string) {
-    await this.checkAndHandleExistingMonitor();
-
-    const warpCoreConfig = getWarpCoreConfig(this.warpRouteId);
-    if (!warpCoreConfig) {
-      throw new Error(
-        `Warp Route ID not found in registry: ${this.warpRouteId}`,
-      );
-    }
+    await checkAndHandleExistingMonitor(this.warpRouteId, this.namespace);
 
     const rebalancerConfigFile = path.join(getInfraPath(), localConfigPath);
-
-    // Validate the rebalancer config file
-    const config: RebalancerConfigFileInput = readYaml(rebalancerConfigFile);
-    const validationResult = RebalancerConfigSchema.safeParse(config);
-    if (!validationResult.success) {
-      throw new Error(fromZodError(validationResult.error).message);
-    }
-
-    const chainNames = getStrategyChainNames(validationResult.data.strategy);
-    if (chainNames.length === 0) {
-      throw new Error('No chains configured');
-    }
-
-    // Store chains for helm values (used for private RPC secrets)
-    // Warp core config includes all strategy chains
-    this.rebalancerChains = [
-      ...new Set(warpCoreConfig.tokens.map((t) => t.chainName)),
-    ];
-
-    // Store the config file content for helm values
-    this.rebalancerConfigContent = fs.readFileSync(
+    const configDetails = readRebalancerConfig(
+      this.warpRouteId,
       rebalancerConfigFile,
-      'utf8',
     );
-    this.inventorySignerProtocols = Object.keys(
-      validationResult.data.inventorySigners ?? {},
-    );
+
+    this.rebalancerChains = configDetails.chains;
+    this.rebalancerConfigContent = configDetails.content;
+    this.inventorySignerProtocols = configDetails.inventorySignerProtocols;
   }
 
   get namespace() {
@@ -125,35 +185,6 @@ export class RebalancerHelmManager extends HelmManager {
     );
   }
 
-  private async checkAndHandleExistingMonitor(): Promise<void> {
-    const monitorReleaseName = getHelmReleaseName(
-      this.warpRouteId,
-      WARP_ROUTE_MONITOR_HELM_RELEASE_PREFIX,
-    );
-
-    if (
-      await HelmManager.doesHelmReleaseExist(monitorReleaseName, this.namespace)
-    ) {
-      const shouldReplace = await confirm({
-        message: `A warp route monitor exists for ${this.warpRouteId}. The rebalancer includes monitoring functionality. Would you like to replace the monitor with the rebalancer?`,
-      });
-
-      if (!shouldReplace) {
-        throw new Error(
-          `Deployment aborted: User chose not to replace existing monitor for ${this.warpRouteId}.`,
-        );
-      }
-
-      rootLogger.info(
-        `Uninstalling existing warp monitor: ${monitorReleaseName}`,
-      );
-      await removeHelmRelease(monitorReleaseName, this.namespace);
-      rootLogger.info(
-        `Successfully uninstalled warp monitor: ${monitorReleaseName}`,
-      );
-    }
-  }
-
   /**
    * Get all deployed rebalancers that include the given chain.
    * Used by RPC rotation to refresh rebalancer pods when RPCs change.
@@ -168,8 +199,13 @@ export class RebalancerHelmManager extends HelmManager {
     );
 
     const helmManagers: RebalancerHelmManager[] = [];
+    const matchedFleetReleases = new Set<string>();
 
-    for (const { warpRouteId } of deployedRebalancers) {
+    for (const {
+      warpRouteId,
+      helmReleaseName,
+      isFleet,
+    } of deployedRebalancers) {
       let warpCoreConfig;
       try {
         warpCoreConfig = getWarpCoreConfig(warpRouteId);
@@ -182,10 +218,20 @@ export class RebalancerHelmManager extends HelmManager {
         continue;
       }
 
+      if (isFleet && matchedFleetReleases.has(helmReleaseName)) {
+        continue;
+      }
+
+      const minimalManagerId = isFleet
+        ? helmReleaseName.slice(
+            `${RebalancerHelmManager.helmReleasePrefix}-`.length,
+          )
+        : warpRouteId;
+
       // Create a minimal manager for RPC rotation (only needs helmReleaseName and namespace)
       helmManagers.push(
         new RebalancerHelmManager(
-          warpRouteId,
+          minimalManagerId,
           environment,
           '', // registryCommit not needed for refresh
           '', // rebalancerConfigFile not needed for refresh
@@ -193,6 +239,10 @@ export class RebalancerHelmManager extends HelmManager {
           false, // withMetrics not needed for refresh
         ),
       );
+
+      if (isFleet) {
+        matchedFleetReleases.add(helmReleaseName);
+      }
     }
 
     return helmManagers;
@@ -212,9 +262,115 @@ export class RebalancerHelmManager extends HelmManager {
   }
 }
 
+export class RebalancerFleetHelmManager extends HelmManager {
+  readonly helmChartPath: string = path.join(
+    getInfraPath(),
+    './helm/rebalancer',
+  );
+
+  private readonly releaseName: string;
+  private rebalancerConfigFiles: RebalancerConfigFile[] = [];
+  private rebalancerChains: string[] = [];
+  private inventorySignerProtocols: string[] = [];
+
+  constructor(
+    readonly fleet: RebalancerFleetDefinition,
+    readonly environment: DeployEnvironment,
+    readonly registryCommit: string,
+    readonly withMetrics: boolean,
+  ) {
+    super();
+
+    this.releaseName = getHelmReleaseName(
+      fleet.name,
+      RebalancerHelmManager.helmReleasePrefix,
+    );
+    const untruncatedReleaseName = `${RebalancerHelmManager.helmReleasePrefix}-${fleet.name.toLowerCase().replaceAll('/', '-')}`;
+    if (this.releaseName !== untruncatedReleaseName) {
+      throw new Error(
+        `Rebalancer fleet Helm release name exceeds the 52-character limit: ${untruncatedReleaseName}`,
+      );
+    }
+  }
+
+  async runPreflightChecks(): Promise<void> {
+    const configFiles: RebalancerConfigFile[] = [];
+    const chains = new Set<string>();
+    const inventorySignerProtocols = new Set<string>();
+
+    for (const warpRouteId of this.fleet.warpRouteIds) {
+      const configFile = path.join(
+        getInfraPath(),
+        getRebalancerConfigPath(this.environment, warpRouteId),
+      );
+      const configDetails = readRebalancerConfig(warpRouteId, configFile);
+
+      configFiles.push({
+        name: getRebalancerFleetConfigFileName(warpRouteId),
+        content: configDetails.content,
+      });
+      configDetails.chains.forEach((chain) => chains.add(chain));
+      configDetails.inventorySignerProtocols.forEach((protocol) =>
+        inventorySignerProtocols.add(protocol),
+      );
+    }
+
+    for (const warpRouteId of this.fleet.warpRouteIds) {
+      await checkAndHandleExistingMonitor(warpRouteId, this.namespace);
+    }
+
+    this.rebalancerConfigFiles = configFiles;
+    this.rebalancerChains = [...chains];
+    this.inventorySignerProtocols = [...inventorySignerProtocols];
+  }
+
+  get namespace() {
+    return this.environment;
+  }
+
+  get helmReleaseName() {
+    return this.releaseName;
+  }
+
+  async helmValues() {
+    const registryUri = `${DEFAULT_GITHUB_REGISTRY}/tree/${this.registryCommit}`;
+
+    return {
+      image: {
+        repository: DockerImageRepos.NODE_SERVICES,
+        tag: mainnetDockerTags.rebalancer,
+      },
+      serviceName: NODE_SERVICE_NAMES.REBALANCER,
+      withMetrics: this.withMetrics,
+      fullnameOverride: this.helmReleaseName,
+      hyperlane: {
+        runEnv: this.environment,
+        registryUri,
+        rebalancerConfigFiles: this.rebalancerConfigFiles,
+        warpRouteIds: this.fleet.warpRouteIds,
+        withMetrics: this.withMetrics,
+        chains: this.rebalancerChains,
+        inventorySignerProtocols: this.inventorySignerProtocols,
+      },
+    };
+  }
+
+  static getDeployedRegistryCommit(
+    fleetName: string,
+    environment: DeployEnvironment,
+  ): Promise<string | undefined> {
+    return getDeployedRegistryCommit(
+      fleetName,
+      environment,
+      RebalancerHelmManager.helmReleasePrefix,
+    );
+  }
+}
+
 export interface RebalancerPodInfo {
   helmReleaseName: string;
   warpRouteId: string;
+  isFleet: boolean;
 }
 
 /**
@@ -238,15 +394,29 @@ export async function getDeployedRebalancerWarpRouteIds(
       continue;
     }
 
-    let warpRouteId: string | undefined;
+    let warpRouteIds: string[] = [];
+    let isFleet = false;
 
     for (const container of pod.spec?.containers || []) {
+      const warpRouteIdsEnv = (container.env || []).find(
+        (env: { name: string; value?: string }) =>
+          env.name === 'WARP_ROUTE_IDS',
+      );
+      if (warpRouteIdsEnv?.value) {
+        warpRouteIds = warpRouteIdsEnv.value
+          .split(',')
+          .map((warpRouteId: string) => warpRouteId.trim())
+          .filter(Boolean);
+        isFleet = true;
+        break;
+      }
+
       // Check WARP_ROUTE_ID env var
       const warpRouteIdEnv = (container.env || []).find(
         (e: { name: string; value?: string }) => e.name === 'WARP_ROUTE_ID',
       );
       if (warpRouteIdEnv?.value) {
-        warpRouteId = warpRouteIdEnv.value;
+        warpRouteIds = [warpRouteIdEnv.value];
         break;
       }
 
@@ -257,13 +427,13 @@ export async function getDeployedRebalancerWarpRouteIds(
       ];
       const warpRouteIdArgIndex = allArgs.indexOf('--warpRouteId');
       if (warpRouteIdArgIndex !== -1 && allArgs[warpRouteIdArgIndex + 1]) {
-        warpRouteId = allArgs[warpRouteIdArgIndex + 1];
+        warpRouteIds = [allArgs[warpRouteIdArgIndex + 1]];
         break;
       }
     }
 
     // Fallback: parse warpRouteId from configmap (for existing deployments without env var)
-    if (!warpRouteId) {
+    if (warpRouteIds.length === 0) {
       try {
         const configMapName = `${helmReleaseName}-config`;
         const cm = await execCmdAndParseJson(
@@ -272,17 +442,22 @@ export async function getDeployedRebalancerWarpRouteIds(
         const configYaml = cm.data?.['rebalancer-config.yaml'];
         if (configYaml) {
           const match = configYaml.match(/^warpRouteId:\s*(.+)$/m);
-          warpRouteId = match?.[1]?.trim();
+          const warpRouteId = match?.[1]?.trim();
+          if (warpRouteId) {
+            warpRouteIds = [warpRouteId];
+          }
         }
-      } catch (e) {
-        rootLogger.debug(
-          `Failed to read configmap for ${helmReleaseName}: ${e}`,
-        );
+      } catch (error) {
+        rootLogger.debug(`Failed to read configmap for ${helmReleaseName}`, {
+          error,
+        });
       }
     }
 
-    if (warpRouteId) {
-      rebalancerPods.push({ helmReleaseName, warpRouteId });
+    if (warpRouteIds.length > 0) {
+      for (const warpRouteId of warpRouteIds) {
+        rebalancerPods.push({ helmReleaseName, warpRouteId, isFleet });
+      }
     } else {
       rootLogger.warn(
         `Could not extract warp route ID from rebalancer pod with helm release: ${helmReleaseName}. Skipping.`,

--- a/typescript/rebalancer/src/core/InventoryRebalancer.ts
+++ b/typescript/rebalancer/src/core/InventoryRebalancer.ts
@@ -55,6 +55,8 @@ import {
   normalizeToCanonical,
 } from '../utils/balanceUtils.js';
 
+import { type IInventoryView, LocalInventoryView } from './InventoryView.js';
+
 /**
  * Buffer percentage to add when bridging inventory.
  * Bridges (amount * (100 + BRIDGE_BUFFER_PERCENT)) / 100 to account for slippage.
@@ -198,19 +200,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   private readonly externalBridgeRegistry: Partial<ExternalBridgeRegistry>;
   private readonly warpCore: WarpCore;
   private readonly multiProvider: MultiProvider;
-
-  /**
-   * Internal balance storage for inventory tracking.
-   * Updated via setInventoryBalances() before each rebalance cycle.
-   */
-  private inventoryBalances: Map<ChainName, bigint> = new Map();
-
-  /**
-   * Tracks inventory consumed during the current execution cycle.
-   * Cleared at the start of each execute() call.
-   * Used to prevent over-execution when multiple routes withdraw from the same chain.
-   */
-  private consumedInventory: Map<ChainName, bigint> = new Map();
+  private readonly view: IInventoryView;
 
   constructor(
     config: InventoryRebalancerConfig,
@@ -219,6 +209,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     warpCore: WarpCore,
     multiProvider: MultiProvider,
     logger: Logger,
+    inventoryView: IInventoryView = new LocalInventoryView(),
   ) {
     this.config = config;
     this.actionTracker = actionTracker;
@@ -226,6 +217,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     this.warpCore = warpCore;
     this.multiProvider = multiProvider;
     this.logger = logger;
+    this.view = inventoryView;
 
     // Validate that all tokens are collateral-backed
     // Synthetic tokens cannot be used with inventory rebalancing because:
@@ -328,14 +320,13 @@ export class InventoryRebalancer implements IInventoryRebalancer {
    * Called before each rebalance cycle to update internal state.
    */
   setInventoryBalances(balances: Record<ChainName, bigint>): void {
-    this.inventoryBalances = new Map(Object.entries(balances));
+    this.view.setBalances(balances);
+    const entries = Array.from(this.view.entries());
     this.logger.debug(
       {
-        chains: Array.from(this.inventoryBalances.keys()),
+        chains: entries.map(([chain]) => chain),
         balances: Object.fromEntries(
-          Array.from(this.inventoryBalances.entries()).map(
-            ([chain, balance]) => [chain, balance.toString()],
-          ),
+          entries.map(([chain, balance]) => [chain, balance.toString()]),
         ),
       },
       'Updated inventory balances',
@@ -347,28 +338,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
    * Returns 0n for unknown chains.
    */
   private getAvailableInventory(chain: ChainName): bigint {
-    return this.inventoryBalances.get(chain) ?? 0n;
-  }
-
-  /**
-   * Get all inventory balances.
-   */
-  private getBalances(): Map<ChainName, bigint> {
-    return this.inventoryBalances;
+    return this.view.getBalance(chain);
   }
 
   /**
    * Calculate total inventory across all chains, excluding specified chains.
    */
   private getTotalInventory(excludeChains: ChainName[]): bigint {
-    const excludeSet = new Set(excludeChains);
-    let total = 0n;
-    for (const [chain, balance] of this.inventoryBalances) {
-      if (!excludeSet.has(chain)) {
-        total += balance;
-      }
-    }
-    return total;
+    return this.view.getTotal(excludeChains);
   }
 
   private formatLocalAmount(amount: bigint, token: Token): string {
@@ -386,8 +363,8 @@ export class InventoryRebalancer implements IInventoryRebalancer {
    */
   private getEffectiveAvailableInventory(chain: ChainName): bigint {
     const cached = this.getAvailableInventory(chain);
-    const consumed = this.consumedInventory.get(chain) ?? 0n;
-    const effective = cached > consumed ? cached - consumed : 0n;
+    const consumed = this.view.getConsumed(chain);
+    const effective = this.view.getEffectiveBalance(chain);
 
     if (consumed > 0n) {
       this.logger.debug(
@@ -415,7 +392,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   async rebalance(
     routes: InventoryRoute[],
   ): Promise<InventoryExecutionResult[]> {
-    this.consumedInventory.clear();
+    this.view.beginCycle();
 
     // 1. Check for existing in_progress intent
     const activeIntent = await this.getActiveInventoryIntent();
@@ -481,11 +458,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
       // Update consumed inventory on success
       if (result.success && result.amountSent) {
-        const current = this.consumedInventory.get(route.destination) ?? 0n;
-        this.consumedInventory.set(
-          route.destination,
-          current + result.amountSent,
-        );
+        this.view.consume(route.destination, result.amountSent);
       }
 
       return [result];
@@ -566,11 +539,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
 
       // Update consumed inventory on success
       if (result.success && result.amountSent) {
-        const current = this.consumedInventory.get(route.destination) ?? 0n;
-        this.consumedInventory.set(
-          route.destination,
-          current + result.amountSent,
-        );
+        this.view.consume(route.destination, result.amountSent);
       }
 
       return [result];
@@ -727,7 +696,7 @@ export class InventoryRebalancer implements IInventoryRebalancer {
     }
 
     // Calculate total inventory across all chains
-    // Note: consumedInventory tracking is handled separately within this cycle
+    // Note: consumed inventory tracking is handled separately within this cycle
     const totalInventory = this.getTotalInventory([]);
 
     this.logger.info(
@@ -1301,14 +1270,12 @@ export class InventoryRebalancer implements IInventoryRebalancer {
   private selectAllSourceChains(
     targetChain: ChainName,
   ): Array<{ chain: ChainName; availableAmount: bigint }> {
-    const balances = this.getBalances();
     const sources: Array<{ chain: ChainName; availableAmount: bigint }> = [];
 
-    for (const [chainName, balance] of balances) {
+    for (const [chainName] of this.view.entries()) {
       if (chainName === targetChain) continue;
 
-      const consumed = this.consumedInventory.get(chainName) ?? 0n;
-      const effectiveAvailable = balance > consumed ? balance - consumed : 0n;
+      const effectiveAvailable = this.view.getEffectiveBalance(chainName);
 
       if (effectiveAvailable > 0n) {
         sources.push({
@@ -1643,14 +1610,14 @@ export class InventoryRebalancer implements IInventoryRebalancer {
       });
 
       // Track consumed inventory on source chain for this cycle
-      const currentConsumed = this.consumedInventory.get(sourceChain) ?? 0n;
-      this.consumedInventory.set(sourceChain, currentConsumed + inputRequired);
+      this.view.consume(sourceChain, inputRequired);
+      const totalConsumed = this.view.getConsumed(sourceChain);
 
       this.logger.debug(
         {
           sourceChain,
           amountConsumed: inputRequired.toString(),
-          totalConsumed: (currentConsumed + inputRequired).toString(),
+          totalConsumed: totalConsumed.toString(),
         },
         'Updated consumed inventory after LiFi bridge',
       );

--- a/typescript/rebalancer/src/core/InventoryView.test.ts
+++ b/typescript/rebalancer/src/core/InventoryView.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+
+import { LocalInventoryView } from './InventoryView.js';
+
+describe('LocalInventoryView', () => {
+  let view: LocalInventoryView;
+
+  beforeEach(() => {
+    view = new LocalInventoryView();
+  });
+
+  it('defaults unknown balances to zero', () => {
+    expect(view.getBalance('unknown')).to.equal(0n);
+  });
+
+  it('replaces balances instead of merging them', () => {
+    view.setBalances({ ethereum: 10n, arbitrum: 20n });
+    view.setBalances({ ethereum: 30n });
+
+    expect(view.getBalance('ethereum')).to.equal(30n);
+    expect(view.getBalance('arbitrum')).to.equal(0n);
+  });
+
+  it('sums balances and excludes specified chains', () => {
+    view.setBalances({ ethereum: 10n, arbitrum: 20n, optimism: 30n });
+
+    expect(view.getTotal([])).to.equal(60n);
+    expect(view.getTotal(['arbitrum', 'optimism'])).to.equal(10n);
+  });
+
+  it('accumulates consumption', () => {
+    view.consume('ethereum', 3n);
+    view.consume('ethereum', 4n);
+
+    expect(view.getConsumed('ethereum')).to.equal(7n);
+    expect(view.getConsumed('arbitrum')).to.equal(0n);
+  });
+
+  it('clamps effective balances to zero', () => {
+    view.setBalances({ ethereum: 10n });
+    view.consume('ethereum', 11n);
+
+    expect(view.getEffectiveBalance('ethereum')).to.equal(0n);
+  });
+
+  it('clears consumption without clearing balances at cycle start', () => {
+    view.setBalances({ ethereum: 10n });
+    view.consume('ethereum', 4n);
+
+    view.beginCycle();
+
+    expect(view.getBalance('ethereum')).to.equal(10n);
+    expect(view.getConsumed('ethereum')).to.equal(0n);
+    expect(view.getEffectiveBalance('ethereum')).to.equal(10n);
+  });
+
+  it('returns raw balance entries', () => {
+    view.setBalances({ ethereum: 10n, arbitrum: 20n });
+    view.consume('ethereum', 4n);
+
+    expect(Array.from(view.entries())).to.deep.equal([
+      ['ethereum', 10n],
+      ['arbitrum', 20n],
+    ]);
+  });
+});

--- a/typescript/rebalancer/src/core/InventoryView.ts
+++ b/typescript/rebalancer/src/core/InventoryView.ts
@@ -1,0 +1,59 @@
+import type { ChainName } from '@hyperlane-xyz/sdk';
+
+export interface IInventoryView {
+  setBalances(balances: Record<ChainName, bigint>): void;
+  getBalance(chain: ChainName): bigint;
+  entries(): Iterable<[ChainName, bigint]>;
+  getTotal(excludeChains: ChainName[]): bigint;
+  beginCycle(): void;
+  consume(chain: ChainName, amount: bigint): void;
+  getConsumed(chain: ChainName): bigint;
+  getEffectiveBalance(chain: ChainName): bigint;
+}
+
+export class LocalInventoryView implements IInventoryView {
+  private inventoryBalances: Map<ChainName, bigint> = new Map();
+  private consumedInventory: Map<ChainName, bigint> = new Map();
+
+  setBalances(balances: Record<ChainName, bigint>): void {
+    this.inventoryBalances = new Map(Object.entries(balances));
+  }
+
+  getBalance(chain: ChainName): bigint {
+    return this.inventoryBalances.get(chain) ?? 0n;
+  }
+
+  entries(): Iterable<[ChainName, bigint]> {
+    return this.inventoryBalances.entries();
+  }
+
+  getTotal(excludeChains: ChainName[]): bigint {
+    const excludeSet = new Set(excludeChains);
+    let total = 0n;
+    for (const [chain, balance] of this.inventoryBalances) {
+      if (!excludeSet.has(chain)) {
+        total += balance;
+      }
+    }
+    return total;
+  }
+
+  beginCycle(): void {
+    this.consumedInventory.clear();
+  }
+
+  consume(chain: ChainName, amount: bigint): void {
+    const current = this.consumedInventory.get(chain) ?? 0n;
+    this.consumedInventory.set(chain, current + amount);
+  }
+
+  getConsumed(chain: ChainName): bigint {
+    return this.consumedInventory.get(chain) ?? 0n;
+  }
+
+  getEffectiveBalance(chain: ChainName): bigint {
+    const balance = this.getBalance(chain);
+    const consumed = this.getConsumed(chain);
+    return balance > consumed ? balance - consumed : 0n;
+  }
+}

--- a/typescript/rebalancer/src/core/RebalancerFleet.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerFleet.test.ts
@@ -1,0 +1,252 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
+import { getRegistry } from '@hyperlane-xyz/registry/fs';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+
+import { RebalancerConfig } from '../config/RebalancerConfig.js';
+import { Mutex } from '../utils/mutex.js';
+
+import {
+  type FleetMember,
+  RebalancerFleet,
+  type RebalancerFleetOptions,
+} from './RebalancerFleet.js';
+import { type RebalancerServiceConfig } from './RebalancerService.js';
+
+const testLogger = pino({ level: 'silent' });
+
+function pending(): Promise<void> {
+  return new Promise(() => undefined);
+}
+
+class ControlledService {
+  readonly start: Sinon.SinonStub<[], Promise<void>>;
+  readonly gracefulShutdown: Sinon.SinonStub<[], Promise<void>> = Sinon.stub<
+    [],
+    Promise<void>
+  >().resolves();
+
+  constructor(startBehavior: () => Promise<void>) {
+    this.start = Sinon.stub<[], Promise<void>>().callsFake(startBehavior);
+  }
+}
+
+interface TestFleetHarness {
+  fleet: RebalancerFleet;
+  serviceConfigs: RebalancerServiceConfig[];
+  services: Map<string, ControlledService[]>;
+}
+
+function createFleetHarness(
+  warpRouteIds: string[],
+  buildService: (
+    warpRouteId: string,
+    instanceIndex: number,
+  ) => ControlledService = () => new ControlledService(pending),
+  options: Partial<RebalancerFleetOptions> = {},
+): TestFleetHarness {
+  const serviceConfigs: RebalancerServiceConfig[] = [];
+  const services = new Map<string, ControlledService[]>();
+
+  class TestRebalancerFleet extends RebalancerFleet {
+    protected override createService(
+      member: FleetMember,
+      serviceConfig: RebalancerServiceConfig,
+    ): ControlledService {
+      serviceConfigs.push(serviceConfig);
+      const warpRouteId = member.rebalancerConfig.warpRouteId;
+      const routeServices = services.get(warpRouteId) ?? [];
+      const service = buildService(warpRouteId, routeServices.length);
+      routeServices.push(service);
+      services.set(warpRouteId, routeServices);
+      return service;
+    }
+  }
+
+  const members = warpRouteIds.map((warpRouteId) => ({
+    rebalancerConfig: new RebalancerConfig(warpRouteId, [], 60_000),
+  }));
+  const registry = getRegistry({
+    registryUris: [DEFAULT_GITHUB_REGISTRY],
+    enableProxy: false,
+  });
+  const fleet = new TestRebalancerFleet(
+    new MultiProvider({}),
+    registry,
+    members,
+    {
+      checkFrequency: 60_000,
+      monitorOnly: false,
+      withMetrics: false,
+      ...options,
+    },
+    testLogger,
+  );
+
+  return { fleet, serviceConfigs, services };
+}
+
+function getServices(
+  harness: TestFleetHarness,
+  warpRouteId: string,
+): ControlledService[] {
+  return harness.services.get(warpRouteId) ?? [];
+}
+
+describe('RebalancerFleet', () => {
+  let sandbox: Sinon.SinonSandbox;
+  let activeFleets: RebalancerFleet[];
+
+  beforeEach(() => {
+    sandbox = Sinon.createSandbox();
+    activeFleets = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(activeFleets.map((fleet) => fleet.stop()));
+    sandbox.restore();
+  });
+
+  it('rejects duplicate warpRouteIds', () => {
+    expect(() => createFleetHarness(['USDC/route', 'USDC/route'])).to.throw(
+      'warpRouteIds must be unique',
+    );
+  });
+
+  it('passes one execution lock and ownsProcess false to all members', () => {
+    const harness = createFleetHarness(['USDC/one', 'USDC/two']);
+    activeFleets.push(harness.fleet);
+
+    expect(harness.serviceConfigs).to.have.lengthOf(2);
+    expect(harness.serviceConfigs[0]?.ownsProcess).to.equal(false);
+    expect(harness.serviceConfigs[1]?.ownsProcess).to.equal(false);
+    expect(harness.serviceConfigs[0]?.executionLock).to.be.instanceOf(Mutex);
+    expect(harness.serviceConfigs[0]?.executionLock).to.equal(
+      harness.serviceConfigs[1]?.executionLock,
+    );
+  });
+
+  it('staggers member starts', async () => {
+    const clock = sandbox.useFakeTimers();
+    const harness = createFleetHarness(['USDC/one', 'USDC/two'], undefined, {
+      staggerMs: 5_000,
+    });
+    activeFleets.push(harness.fleet);
+
+    const startPromise = harness.fleet.start();
+    await clock.tickAsync(0);
+
+    expect(getServices(harness, 'USDC/one')[0]?.start.calledOnce).to.equal(
+      true,
+    );
+    expect(getServices(harness, 'USDC/two')[0]?.start.called).to.equal(false);
+
+    await clock.tickAsync(4_999);
+    expect(getServices(harness, 'USDC/two')[0]?.start.called).to.equal(false);
+
+    await clock.tickAsync(1);
+    expect(getServices(harness, 'USDC/two')[0]?.start.calledOnce).to.equal(
+      true,
+    );
+
+    await harness.fleet.stop();
+    await startPromise;
+  });
+
+  it('recreates failed members with capped exponential backoff', async () => {
+    const clock = sandbox.useFakeTimers();
+    const harness = createFleetHarness(
+      ['USDC/failing', 'USDC/healthy'],
+      (warpRouteId, instanceIndex) =>
+        new ControlledService(
+          warpRouteId === 'USDC/failing' && instanceIndex < 7
+            ? () => Promise.reject(new Error(`failure ${instanceIndex}`))
+            : pending,
+        ),
+      { staggerMs: 0 },
+    );
+    activeFleets.push(harness.fleet);
+
+    const startPromise = harness.fleet.start();
+    await clock.tickAsync(0);
+
+    expect(getServices(harness, 'USDC/failing')).to.have.lengthOf(1);
+    expect(getServices(harness, 'USDC/healthy')).to.have.lengthOf(1);
+    expect(getServices(harness, 'USDC/healthy')[0]?.start.calledOnce).to.equal(
+      true,
+    );
+
+    const backoffs = [
+      30_000, 60_000, 120_000, 240_000, 480_000, 900_000, 900_000,
+    ];
+    for (const [index, delayMs] of backoffs.entries()) {
+      await clock.tickAsync(delayMs - 1);
+      expect(getServices(harness, 'USDC/failing')).to.have.lengthOf(index + 1);
+      await clock.tickAsync(1);
+      expect(getServices(harness, 'USDC/failing')).to.have.lengthOf(index + 2);
+    }
+
+    expect(getServices(harness, 'USDC/healthy')).to.have.lengthOf(1);
+    expect(getServices(harness, 'USDC/healthy')[0]?.start.calledOnce).to.equal(
+      true,
+    );
+
+    await harness.fleet.stop();
+    await startPromise;
+  });
+
+  it('does not restart after stop during backoff', async () => {
+    const clock = sandbox.useFakeTimers();
+    const exitStub = sandbox.stub(process, 'exit');
+    const harness = createFleetHarness(
+      ['USDC/failing', 'USDC/healthy'],
+      (warpRouteId) =>
+        new ControlledService(
+          warpRouteId === 'USDC/failing'
+            ? () => Promise.reject(new Error('failure'))
+            : pending,
+        ),
+      { staggerMs: 0 },
+    );
+    activeFleets.push(harness.fleet);
+
+    const startPromise = harness.fleet.start();
+    await clock.tickAsync(0);
+    await harness.fleet.stop();
+    await startPromise;
+
+    for (const services of harness.services.values()) {
+      expect(services).to.have.lengthOf(1);
+      expect(services[0]?.gracefulShutdown.calledOnce).to.equal(true);
+    }
+
+    await clock.tickAsync(30_000);
+    expect(getServices(harness, 'USDC/failing')).to.have.lengthOf(1);
+    expect(exitStub.called).to.equal(false);
+  });
+
+  it('registers only fleet-level signal handlers', async () => {
+    const clock = sandbox.useFakeTimers();
+    const sigintListeners = process.listenerCount('SIGINT');
+    const sigtermListeners = process.listenerCount('SIGTERM');
+    const harness = createFleetHarness(['USDC/one', 'USDC/two', 'USDC/three']);
+    activeFleets.push(harness.fleet);
+
+    const startPromise = harness.fleet.start();
+    await clock.tickAsync(0);
+
+    expect(process.listenerCount('SIGINT')).to.equal(sigintListeners + 1);
+    expect(process.listenerCount('SIGTERM')).to.equal(sigtermListeners + 1);
+    expect(
+      harness.serviceConfigs.every(({ ownsProcess }) => !ownsProcess),
+    ).to.equal(true);
+
+    await harness.fleet.stop();
+    await startPromise;
+    expect(process.listenerCount('SIGINT')).to.equal(sigintListeners);
+    expect(process.listenerCount('SIGTERM')).to.equal(sigtermListeners);
+  });
+});

--- a/typescript/rebalancer/src/core/RebalancerFleet.ts
+++ b/typescript/rebalancer/src/core/RebalancerFleet.ts
@@ -1,0 +1,263 @@
+import { type Logger } from 'pino';
+
+import { type IRegistry } from '@hyperlane-xyz/registry';
+import { type MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert, sleep } from '@hyperlane-xyz/utils';
+
+import { type RebalancerConfig } from '../config/RebalancerConfig.js';
+import { Mutex } from '../utils/mutex.js';
+
+import {
+  RebalancerService,
+  type RebalancerServiceConfig,
+} from './RebalancerService.js';
+
+const HEALTHY_RUN_MS = 30 * 60_000;
+const INITIAL_BACKOFF_MS = 30_000;
+const MAX_BACKOFF_MS = 15 * 60_000;
+
+type ManagedService = Pick<RebalancerService, 'start' | 'gracefulShutdown'>;
+
+export interface FleetMember {
+  rebalancerConfig: RebalancerConfig;
+}
+
+export interface RebalancerFleetOptions {
+  checkFrequency: number;
+  monitorOnly: boolean;
+  withMetrics: boolean;
+  coingeckoApiKey?: string;
+  version?: string;
+  /** Delay between member starts. Default: floor(checkFrequency / memberCount). */
+  staggerMs?: number;
+}
+
+interface MemberState {
+  member: FleetMember;
+  serviceConfig: RebalancerServiceConfig;
+  service: ManagedService;
+  firstAttemptFailed: boolean;
+}
+
+export class RebalancerFleet {
+  private readonly executionLock = new Mutex();
+  private readonly memberStates: MemberState[];
+  private readonly staggerMs: number;
+  private readonly stopped: Promise<void>;
+  private resolveStopped: () => void = () => undefined;
+  private started = false;
+  private shuttingDown = false;
+  private signalHandlersRegistered = false;
+  private hasEverRunHealthy = false;
+  private fatalStartupTriggered = false;
+  private stopOperation?: Promise<void>;
+
+  constructor(
+    private readonly multiProvider: MultiProvider,
+    private readonly registry: IRegistry,
+    members: FleetMember[],
+    options: RebalancerFleetOptions,
+    private readonly logger: Logger,
+  ) {
+    assert(members.length > 0, 'Rebalancer fleet requires at least one member');
+
+    const warpRouteIds = members.map(
+      ({ rebalancerConfig }) => rebalancerConfig.warpRouteId,
+    );
+    assert(
+      new Set(warpRouteIds).size === warpRouteIds.length,
+      'Rebalancer fleet warpRouteIds must be unique',
+    );
+
+    this.staggerMs =
+      options.staggerMs ?? Math.floor(options.checkFrequency / members.length);
+    this.stopped = new Promise((resolve) => {
+      this.resolveStopped = resolve;
+    });
+    this.memberStates = members.map((member) => {
+      const { warpRouteId } = member.rebalancerConfig;
+      const serviceConfig: RebalancerServiceConfig = {
+        mode: 'daemon',
+        checkFrequency: options.checkFrequency,
+        monitorOnly: options.monitorOnly,
+        withMetrics: options.withMetrics,
+        coingeckoApiKey: options.coingeckoApiKey,
+        version: options.version,
+        logger: logger.child({ warpRouteId }),
+        ownsProcess: false,
+        executionLock: this.executionLock,
+      };
+      return {
+        member,
+        serviceConfig,
+        service: this.createService(member, serviceConfig),
+        firstAttemptFailed: false,
+      };
+    });
+  }
+
+  protected createService(
+    member: FleetMember,
+    serviceConfig: RebalancerServiceConfig,
+  ): ManagedService {
+    return new RebalancerService(
+      this.multiProvider,
+      undefined,
+      this.registry,
+      member.rebalancerConfig,
+      serviceConfig,
+    );
+  }
+
+  async start(): Promise<void> {
+    if (!this.started && !this.shuttingDown) {
+      this.started = true;
+      this.registerSignalHandlers();
+      for (const [index, state] of this.memberStates.entries()) {
+        void this.superviseMember(state, index * this.staggerMs);
+      }
+    }
+
+    await this.stopped;
+  }
+
+  async stop(): Promise<void> {
+    this.stopOperation ??= this.stopServices();
+    await this.stopOperation;
+  }
+
+  private registerSignalHandlers(): void {
+    if (this.signalHandlersRegistered) return;
+
+    process.on('SIGINT', this.handleSignal);
+    process.on('SIGTERM', this.handleSignal);
+    this.signalHandlersRegistered = true;
+  }
+
+  private unregisterSignalHandlers(): void {
+    if (!this.signalHandlersRegistered) return;
+
+    process.off('SIGINT', this.handleSignal);
+    process.off('SIGTERM', this.handleSignal);
+    this.signalHandlersRegistered = false;
+  }
+
+  private readonly handleSignal = async (): Promise<void> => {
+    await this.stop();
+    process.exit(0);
+  };
+
+  private async superviseMember(
+    state: MemberState,
+    initialDelayMs: number,
+  ): Promise<void> {
+    if (!(await this.waitForRestart(initialDelayMs))) return;
+
+    let consecutiveFailures = 0;
+    let firstAttempt = true;
+
+    while (!this.shuttingDown) {
+      const startedAt = Date.now();
+      let error: unknown;
+
+      try {
+        await state.service.start();
+      } catch (startError) {
+        error = startError;
+      }
+
+      if (this.shuttingDown) return;
+
+      const runDurationMs = Date.now() - startedAt;
+      if (runDurationMs >= HEALTHY_RUN_MS) {
+        consecutiveFailures = 0;
+        this.hasEverRunHealthy = true;
+      }
+
+      if (firstAttempt) {
+        firstAttempt = false;
+        state.firstAttemptFailed = true;
+        if (this.shouldExitAfterFatalStartup()) return;
+      }
+
+      const delayMs = Math.min(
+        INITIAL_BACKOFF_MS * 2 ** consecutiveFailures,
+        MAX_BACKOFF_MS,
+      );
+      this.logger.error(
+        {
+          warpRouteId: state.member.rebalancerConfig.warpRouteId,
+          consecutiveFailures,
+          delayMs,
+          error,
+        },
+        error
+          ? 'Rebalancer fleet member failed; scheduling restart'
+          : 'Rebalancer fleet member stopped unexpectedly; scheduling restart',
+      );
+      consecutiveFailures += 1;
+
+      if (!(await this.waitForRestart(delayMs))) return;
+
+      state.service = this.createService(state.member, state.serviceConfig);
+    }
+  }
+
+  private shouldExitAfterFatalStartup(): boolean {
+    if (
+      this.hasEverRunHealthy ||
+      this.fatalStartupTriggered ||
+      !this.memberStates.every(({ firstAttemptFailed }) => firstAttemptFailed)
+    ) {
+      return false;
+    }
+
+    this.fatalStartupTriggered = true;
+    this.shuttingDown = true;
+    this.logger.fatal(
+      {
+        warpRouteIds: this.memberStates.map(
+          ({ member }) => member.rebalancerConfig.warpRouteId,
+        ),
+      },
+      'Every rebalancer fleet member failed during initial startup',
+    );
+    process.exit(1);
+  }
+
+  private async waitForRestart(delayMs: number): Promise<boolean> {
+    if (this.shuttingDown) return false;
+    if (delayMs === 0) return true;
+
+    await Promise.race([sleep(delayMs), this.stopped]);
+    return !this.shuttingDown;
+  }
+
+  private async stopServices(): Promise<void> {
+    this.shuttingDown = true;
+    this.unregisterSignalHandlers();
+
+    const results = await Promise.allSettled(
+      this.memberStates.map(({ service }) => service.gracefulShutdown()),
+    );
+    for (const [index, result] of results.entries()) {
+      const state = this.memberStates[index];
+      if (!state) continue;
+
+      const warpRouteId = state.member.rebalancerConfig.warpRouteId;
+      if (result.status === 'fulfilled') {
+        this.logger.info(
+          { warpRouteId },
+          'Rebalancer fleet member shutdown complete',
+        );
+      } else {
+        this.logger.error(
+          { warpRouteId, error: result.reason },
+          'Rebalancer fleet member shutdown failed',
+        );
+      }
+    }
+
+    this.resolveStopped();
+  }
+}

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.test.ts
@@ -17,6 +17,8 @@ import { Metrics } from '../metrics/Metrics.js';
 import { TEST_ADDRESSES, getTestAddress } from '../test/helpers.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import { InflightContextAdapter } from '../tracking/InflightContextAdapter.js';
+import { InventoryBalanceFetcher } from '../monitor/InventoryBalanceFetcher.js';
+import { Mutex } from '../utils/mutex.js';
 
 import {
   RebalancerOrchestrator,
@@ -865,6 +867,150 @@ describe('RebalancerOrchestrator', () => {
       await orchestrator.executeCycle(event);
 
       expect((metrics.processToken as Sinon.SinonStub).calledTwice).to.be.true;
+    });
+  });
+
+  describe('Execution Lock', () => {
+    it('should serialize execution across orchestrators sharing a lock', async () => {
+      const sharedLock = new Mutex();
+      const firstStrategy = createMockStrategy();
+      const secondStrategy = createMockStrategy();
+      const route = {
+        origin: 'ethereum',
+        destination: 'arbitrum',
+        amount: 1000n,
+        bridge: TEST_ADDRESSES.bridge,
+        executionType: 'movableCollateral',
+      };
+      firstStrategy.getRebalancingRoutes.returns([route]);
+      secondStrategy.getRebalancingRoutes.returns([route]);
+
+      let executing = false;
+      const executionOrder: string[] = [];
+      let signalFirstStarted: () => void = () => undefined;
+      const firstStarted = new Promise<void>((resolve) => {
+        signalFirstStarted = resolve;
+      });
+
+      const firstRebalancer = createMockRebalancer();
+      firstRebalancer.rebalance.callsFake(async () => {
+        expect(executing).to.be.false;
+        executing = true;
+        executionOrder.push('first-started');
+        signalFirstStarted();
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        executing = false;
+        executionOrder.push('first-finished');
+        return [];
+      });
+
+      const secondRebalancer = createMockRebalancer();
+      secondRebalancer.rebalance.callsFake(async () => {
+        expect(executing).to.be.false;
+        executing = true;
+        executionOrder.push('second-started');
+        executing = false;
+        executionOrder.push('second-finished');
+        return [];
+      });
+
+      const firstOrchestrator = new RebalancerOrchestrator({
+        strategy: firstStrategy,
+        rebalancers: [firstRebalancer],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        executionLock: sharedLock,
+      });
+      const secondOrchestrator = new RebalancerOrchestrator({
+        strategy: secondStrategy,
+        rebalancers: [secondRebalancer],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        executionLock: sharedLock,
+      });
+
+      const firstCycle = firstOrchestrator.executeCycle(createMonitorEvent());
+      await firstStarted;
+      const secondCycle = secondOrchestrator.executeCycle(createMonitorEvent());
+
+      await Promise.all([firstCycle, secondCycle]);
+
+      expect(executionOrder).to.deep.equal([
+        'first-started',
+        'first-finished',
+        'second-started',
+        'second-finished',
+      ]);
+    });
+  });
+
+  describe('Inventory Balance Refetch', () => {
+    it('should use fresh inventory balances at execution time', async () => {
+      const inventoryBalanceFetcher = sandbox.createStubInstance(
+        InventoryBalanceFetcher,
+      );
+      const freshBalances = { ethereum: 100n, arbitrum: 200n };
+      const snapshotBalances = { ethereum: 10n, arbitrum: 20n };
+      inventoryBalanceFetcher.fetchInventoryBalances.resolves(freshBalances);
+      const inventoryRebalancer = createMockInventoryRebalancer();
+      const orchestrator = new RebalancerOrchestrator({
+        strategy: createMockStrategy(),
+        rebalancers: [inventoryRebalancer],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        inventoryBalanceFetcher,
+      });
+
+      await orchestrator.executeCycle(
+        createMonitorEvent({ inventoryBalances: snapshotBalances }),
+      );
+
+      expect(
+        inventoryRebalancer.setInventoryBalances.calledOnceWithExactly(
+          freshBalances,
+        ),
+      ).to.be.true;
+      expect(
+        inventoryRebalancer.setInventoryBalances.calledWith(snapshotBalances),
+      ).to.be.false;
+    });
+
+    it('should use monitor balances and warn when fresh fetch fails', async () => {
+      const inventoryBalanceFetcher = sandbox.createStubInstance(
+        InventoryBalanceFetcher,
+      );
+      const snapshotBalances = { ethereum: 10n, arbitrum: 20n };
+      inventoryBalanceFetcher.fetchInventoryBalances.rejects(
+        new Error('RPC unavailable'),
+      );
+      const inventoryRebalancer = createMockInventoryRebalancer();
+      const warnSpy = sandbox.spy(testLogger, 'warn');
+      const orchestrator = new RebalancerOrchestrator({
+        strategy: createMockStrategy(),
+        rebalancers: [inventoryRebalancer],
+        actionTracker: createMockActionTracker(),
+        inflightContextAdapter: createMockInflightContextAdapter(),
+        rebalancerConfig: createMockRebalancerConfig(),
+        logger: testLogger,
+        inventoryBalanceFetcher,
+      });
+
+      await orchestrator.executeCycle(
+        createMonitorEvent({ inventoryBalances: snapshotBalances }),
+      );
+
+      expect(
+        inventoryRebalancer.setInventoryBalances.calledOnceWithExactly(
+          snapshotBalances,
+        ),
+      ).to.be.true;
+      expect(warnSpy.calledOnce).to.be.true;
     });
   });
 });

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -246,28 +246,27 @@ export class RebalancerOrchestrator {
     event: MonitorEvent,
   ): Promise<ExecutionResult[]> {
     if (rebalancer.rebalancerType === 'inventory') {
+      // Prefer balances re-fetched at execution time (under the execution
+      // lock); fall back to the monitor-time snapshot if the strict fetch
+      // fails on any chain.
+      let balances = event.inventoryBalances;
       if (this.inventoryBalanceFetcher) {
         try {
-          const freshBalances =
-            await this.inventoryBalanceFetcher.fetchInventoryBalances();
-          (rebalancer as InventoryRebalancer).setInventoryBalances(
-            freshBalances,
-          );
+          balances = await this.inventoryBalanceFetcher.fetchInventoryBalances({
+            strict: true,
+          });
         } catch (error) {
           this.logger.warn(
-            { error },
+            {
+              error,
+              hasMonitorSnapshot: event.inventoryBalances !== undefined,
+            },
             'Fresh inventory balance fetch failed, using monitor snapshot',
           );
-          if (event.inventoryBalances) {
-            (rebalancer as InventoryRebalancer).setInventoryBalances(
-              event.inventoryBalances,
-            );
-          }
         }
-      } else if (event.inventoryBalances) {
-        (rebalancer as InventoryRebalancer).setInventoryBalances(
-          event.inventoryBalances,
-        );
+      }
+      if (balances) {
+        (rebalancer as InventoryRebalancer).setInventoryBalances(balances);
       }
     }
 

--- a/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
+++ b/typescript/rebalancer/src/core/RebalancerOrchestrator.ts
@@ -21,8 +21,10 @@ import { Metrics } from '../metrics/Metrics.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import { InflightContextAdapter } from '../tracking/InflightContextAdapter.js';
 import { getRawBalances } from '../utils/balanceUtils.js';
+import { type IMutex, Mutex } from '../utils/mutex.js';
 
 import { InventoryRebalancer } from './InventoryRebalancer.js';
+import type { InventoryBalanceFetcher } from '../monitor/InventoryBalanceFetcher.js';
 
 /**
  * Result of a rebalancing cycle.
@@ -46,6 +48,10 @@ export interface RebalancerOrchestratorDeps {
 
   externalBridgeRegistry?: Partial<ExternalBridgeRegistry>;
   metrics?: Metrics;
+  /** Serializes the execution phase across orchestrators sharing signing keys (fleet mode). Defaults to a private per-instance mutex. */
+  executionLock?: IMutex;
+  /** When set, inventory balances are re-fetched fresh (under the execution lock) instead of trusting the monitor-time snapshot. */
+  inventoryBalanceFetcher?: InventoryBalanceFetcher;
 }
 
 export class RebalancerOrchestrator {
@@ -57,6 +63,8 @@ export class RebalancerOrchestrator {
   private readonly rebalancersByType: Map<RebalancerType, IRebalancer>;
   private readonly externalBridgeRegistry?: Partial<ExternalBridgeRegistry>;
   private readonly metrics?: Metrics;
+  private readonly executionLock: IMutex;
+  private readonly inventoryBalanceFetcher?: InventoryBalanceFetcher;
 
   constructor(deps: RebalancerOrchestratorDeps) {
     this.strategy = deps.strategy;
@@ -69,6 +77,8 @@ export class RebalancerOrchestrator {
     );
     this.externalBridgeRegistry = deps.externalBridgeRegistry;
     this.metrics = deps.metrics;
+    this.executionLock = deps.executionLock ?? new Mutex();
+    this.inventoryBalanceFetcher = deps.inventoryBalanceFetcher;
   }
 
   /**
@@ -114,29 +124,45 @@ export class RebalancerOrchestrator {
     let executedCount = 0;
     let failedCount = 0;
 
-    if (strategyRoutes.length > 0) {
-      this.logger.info(
-        {
-          routes: strategyRoutes.map((r) => ({
-            from: r.origin,
-            to: r.destination,
-            amount: r.amount.toString(),
-          })),
-        },
-        'Routes proposed',
-      );
+    const lockRequestedAt = Date.now();
+    await this.executionLock.runExclusive(async () => {
+      const lockWaitMs = Date.now() - lockRequestedAt;
+      if (lockWaitMs > 60_000) {
+        this.logger.warn(
+          { lockWaitMs },
+          'Execution lock wait exceeded threshold',
+        );
+      } else {
+        this.logger.debug(
+          { lockWaitMs },
+          'Execution lock wait below threshold',
+        );
+      }
 
-      const results = await this.executeWithTracking(strategyRoutes, event);
-      executedCount = results.executedCount;
-      failedCount = results.failedCount;
-    } else {
-      this.logger.info('No rebalancing needed');
-    }
+      if (strategyRoutes.length > 0) {
+        this.logger.info(
+          {
+            routes: strategyRoutes.map((r) => ({
+              from: r.origin,
+              to: r.destination,
+              amount: r.amount.toString(),
+            })),
+          },
+          'Routes proposed',
+        );
 
-    const inventoryRebalancer = this.rebalancersByType.get('inventory');
-    if (inventoryRebalancer && strategyRoutes.length === 0) {
-      await this.executeRoutes([], inventoryRebalancer, event);
-    }
+        const results = await this.executeWithTracking(strategyRoutes, event);
+        executedCount = results.executedCount;
+        failedCount = results.failedCount;
+      } else {
+        this.logger.info('No rebalancing needed');
+      }
+
+      const inventoryRebalancer = this.rebalancersByType.get('inventory');
+      if (inventoryRebalancer && strategyRoutes.length === 0) {
+        await this.executeRoutes([], inventoryRebalancer, event);
+      }
+    });
 
     this.logger.info('Polling cycle completed');
 
@@ -219,10 +245,30 @@ export class RebalancerOrchestrator {
     rebalancer: IRebalancer,
     event: MonitorEvent,
   ): Promise<ExecutionResult[]> {
-    if (rebalancer.rebalancerType === 'inventory' && event.inventoryBalances) {
-      (rebalancer as InventoryRebalancer).setInventoryBalances(
-        event.inventoryBalances,
-      );
+    if (rebalancer.rebalancerType === 'inventory') {
+      if (this.inventoryBalanceFetcher) {
+        try {
+          const freshBalances =
+            await this.inventoryBalanceFetcher.fetchInventoryBalances();
+          (rebalancer as InventoryRebalancer).setInventoryBalances(
+            freshBalances,
+          );
+        } catch (error) {
+          this.logger.warn(
+            { error },
+            'Fresh inventory balance fetch failed, using monitor snapshot',
+          );
+          if (event.inventoryBalances) {
+            (rebalancer as InventoryRebalancer).setInventoryBalances(
+              event.inventoryBalances,
+            );
+          }
+        }
+      } else if (event.inventoryBalances) {
+        (rebalancer as InventoryRebalancer).setInventoryBalances(
+          event.inventoryBalances,
+        );
+      }
     }
 
     try {

--- a/typescript/rebalancer/src/core/RebalancerService.test.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.test.ts
@@ -16,10 +16,11 @@ import { MonitorEventType } from '../interfaces/IMonitor.js';
 import type { IRebalancer } from '../interfaces/IRebalancer.js';
 import type { IStrategy } from '../interfaces/IStrategy.js';
 import { Metrics } from '../metrics/Metrics.js';
-import { Monitor } from '../monitor/Monitor.js';
+import { type InventoryMonitorConfig, Monitor } from '../monitor/Monitor.js';
 import { TEST_ADDRESSES, getTestAddress } from '../test/helpers.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import { InflightContextAdapter } from '../tracking/InflightContextAdapter.js';
+import type { IMutex } from '../utils/mutex.js';
 
 import {
   RebalancerService,
@@ -162,6 +163,7 @@ function createMockContextFactory(
     inflightAdapter?: InflightContextAdapter;
     monitor?: Monitor;
     metrics?: Metrics;
+    inventoryConfig?: InventoryMonitorConfig;
   } = {},
 ): RebalancerContextFactory {
   const warpCore = overrides.warpCore ?? createMockWarpCore();
@@ -186,7 +188,7 @@ function createMockContextFactory(
     createRebalancers: async (_actionTracker: IActionTracker) => ({
       rebalancers: [rebalancer],
       externalBridgeRegistry: {},
-      inventoryConfig: undefined,
+      inventoryConfig: overrides.inventoryConfig,
     }),
     createStrategy: async () => strategy,
     createMonitor: () => monitor,
@@ -202,6 +204,8 @@ function createMockContextFactory(
       rebalancers: IRebalancer[];
       externalBridgeRegistry: Partial<ExternalBridgeRegistry>;
       metrics?: Metrics;
+      executionLock?: IMutex;
+      inventoryConfig?: InventoryMonitorConfig;
     }) => ({
       executeCycle: Sinon.stub().callsFake(async (_event: any) => {
         // Simulate orchestrator behavior: call strategy, then rebalancer, then record metrics
@@ -229,6 +233,8 @@ interface DaemonTestSetup {
   actionTracker: IActionTracker;
   rebalancer: IRebalancer & { rebalance: Sinon.SinonStub };
   strategy: IStrategy & { getRebalancingRoutes: Sinon.SinonStub };
+  service: RebalancerService;
+  createOrchestratorSpy: Sinon.SinonSpy;
   triggerCycle: () => Promise<void>;
 }
 
@@ -253,6 +259,8 @@ async function setupDaemonTest(
       amount: bigint;
       bridge: string;
     }>;
+    serviceConfig?: Omit<RebalancerServiceConfig, 'mode' | 'logger'>;
+    inventoryConfig?: InventoryMonitorConfig;
   },
 ): Promise<DaemonTestSetup> {
   const actionTracker = createMockActionTracker();
@@ -283,7 +291,12 @@ async function setupDaemonTest(
     actionTracker,
     inflightAdapter,
     monitor,
+    inventoryConfig: options.inventoryConfig,
   });
+  const createOrchestratorSpy = sandbox.spy(
+    contextFactory,
+    'createOrchestrator',
+  );
   sandbox.stub(RebalancerContextFactory, 'create').resolves(contextFactory);
 
   const service = new RebalancerService(
@@ -291,7 +304,12 @@ async function setupDaemonTest(
     undefined,
     {} as any,
     createMockRebalancerConfig(),
-    { mode: 'daemon', checkFrequency: 60000, logger: testLogger },
+    {
+      mode: 'daemon',
+      checkFrequency: 60000,
+      logger: testLogger,
+      ...options.serviceConfig,
+    },
   );
 
   await service.start();
@@ -300,6 +318,8 @@ async function setupDaemonTest(
     actionTracker,
     rebalancer,
     strategy,
+    service,
+    createOrchestratorSpy,
     triggerCycle: async () => {
       expect(tokenInfoHandler).to.not.be.undefined;
       await tokenInfoHandler!({
@@ -641,6 +661,30 @@ describe('RebalancerService', () => {
       expect((monitor.on as Sinon.SinonStub).called).to.be.true;
       expect((monitor.start as Sinon.SinonStub).calledOnce).to.be.true;
     });
+
+    it('should not register signal handlers when the service does not own the process', async () => {
+      const processOnStub = sandbox.stub(process, 'on');
+
+      await setupDaemonTest(sandbox, {
+        rebalanceResults: [],
+        strategyRoutes: [],
+        serviceConfig: { ownsProcess: false },
+      });
+
+      expect(processOnStub.called).to.be.false;
+    });
+
+    it('should register signal handlers by default', async () => {
+      const processOnStub = sandbox.stub(process, 'on');
+
+      await setupDaemonTest(sandbox, {
+        rebalanceResults: [],
+        strategyRoutes: [],
+      });
+
+      expect(processOnStub.calledWith('SIGINT')).to.be.true;
+      expect(processOnStub.calledWith('SIGTERM')).to.be.true;
+    });
   });
 
   describe('stop()', () => {
@@ -672,6 +716,21 @@ describe('RebalancerService', () => {
       await service.stop();
 
       expect((monitor.stop as Sinon.SinonStub).calledOnce).to.be.true;
+    });
+
+    it('should stop without exiting when the service does not own the process', async () => {
+      const processExitStub = sandbox.stub(process, 'exit');
+      const { service } = await setupDaemonTest(sandbox, {
+        rebalanceResults: [],
+        strategyRoutes: [],
+        serviceConfig: { ownsProcess: false },
+      });
+      const stopSpy = sandbox.spy(service, 'stop');
+
+      await service.gracefulShutdown();
+
+      expect(stopSpy.calledOnce).to.be.true;
+      expect(processExitStub.called).to.be.false;
     });
   });
 
@@ -1060,6 +1119,33 @@ describe('RebalancerService', () => {
   });
 
   describe('initialization', () => {
+    it('should forward the execution lock and inventory config to the orchestrator', async () => {
+      const executionLock: IMutex = {
+        async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+          return fn();
+        },
+      };
+      const inventoryConfig: InventoryMonitorConfig = {
+        inventoryAddresses: {},
+        chains: ['ethereum'],
+      };
+
+      const { createOrchestratorSpy } = await setupDaemonTest(sandbox, {
+        rebalanceResults: [],
+        strategyRoutes: [],
+        serviceConfig: { ownsProcess: false, executionLock },
+        inventoryConfig,
+      });
+
+      expect(createOrchestratorSpy.calledOnce).to.be.true;
+      expect(createOrchestratorSpy.firstCall.args[0].executionLock).to.equal(
+        executionLock,
+      );
+      expect(createOrchestratorSpy.firstCall.args[0].inventoryConfig).to.equal(
+        inventoryConfig,
+      );
+    });
+
     it('should initialize only once', async () => {
       const contextFactory = createMockContextFactory();
       const createStub = sandbox

--- a/typescript/rebalancer/src/core/RebalancerService.ts
+++ b/typescript/rebalancer/src/core/RebalancerService.ts
@@ -31,6 +31,7 @@ import { type InventoryMonitorConfig, Monitor } from '../monitor/Monitor.js';
 import type { IActionTracker } from '../tracking/IActionTracker.js';
 import { InflightContextAdapter } from '../tracking/InflightContextAdapter.js';
 import { normalizeConfiguredAmount } from '../utils/balanceUtils.js';
+import type { IMutex } from '../utils/mutex.js';
 
 import type { RebalancerOrchestrator } from './RebalancerOrchestrator.js';
 
@@ -55,6 +56,12 @@ export interface RebalancerServiceConfig {
 
   /** Service version for logging */
   version?: string;
+
+  /** When false, the service registers no signal handlers and never exits the process (embedded/fleet mode). Default true. */
+  ownsProcess?: boolean;
+
+  /** Optional shared execution lock, forwarded to the orchestrator (fleet mode). */
+  executionLock?: IMutex;
 
   /**
    * Optional pre-configured ActionTracker.
@@ -233,6 +240,8 @@ export class RebalancerService {
       rebalancers,
       externalBridgeRegistry: externalBridgeRegistry,
       metrics: this.metrics,
+      executionLock: this.config.executionLock,
+      inventoryConfig,
     });
 
     this.logger.info(
@@ -333,9 +342,11 @@ export class RebalancerService {
       .on(MonitorEventType.Error, this.onMonitorError.bind(this))
       .on(MonitorEventType.Start, this.onMonitorStart.bind(this));
 
-    // Set up signal handlers for graceful shutdown
-    process.on('SIGINT', () => this.gracefulShutdown());
-    process.on('SIGTERM', () => this.gracefulShutdown());
+    if (this.config.ownsProcess !== false) {
+      // Set up signal handlers for graceful shutdown
+      process.on('SIGINT', () => this.gracefulShutdown());
+      process.on('SIGTERM', () => this.gracefulShutdown());
+    }
 
     try {
       await this.monitor.start();
@@ -365,6 +376,11 @@ export class RebalancerService {
 
     this.logger.info('Gracefully shutting down rebalancer...');
     await this.stop();
+
+    if (this.config.ownsProcess === false) {
+      this.logger.info('Rebalancer shutdown complete');
+      return;
+    }
 
     // Unregister listeners to prevent them from being called again during shutdown
     process.removeAllListeners('SIGINT');

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -42,6 +42,7 @@ import type { IRebalancer } from '../interfaces/IRebalancer.js';
 import type { IStrategy } from '../interfaces/IStrategy.js';
 import { Metrics } from '../metrics/Metrics.js';
 import { PriceGetter } from '../metrics/PriceGetter.js';
+import { InventoryBalanceFetcher } from '../monitor/InventoryBalanceFetcher.js';
 import { type InventoryMonitorConfig, Monitor } from '../monitor/Monitor.js';
 import { StrategyFactory } from '../strategy/StrategyFactory.js';
 import {
@@ -67,6 +68,7 @@ import {
   normalizeConfiguredAmount,
   normalizeToCanonical,
 } from '../utils/balanceUtils.js';
+import type { IMutex } from '../utils/mutex.js';
 import { isCollateralizedTokenEligibleForRebalancing } from '../utils/tokenUtils.js';
 
 const DEFAULT_EXPLORER_URL =
@@ -714,11 +716,21 @@ export class RebalancerContextFactory {
     rebalancers: IRebalancer[];
     externalBridgeRegistry: Partial<ExternalBridgeRegistry>;
     metrics?: Metrics;
+    executionLock?: IMutex;
+    inventoryConfig?: InventoryMonitorConfig;
   }): RebalancerOrchestrator {
     this.logger.debug(
       { warpRouteId: this.config.warpRouteId },
       'Creating RebalancerOrchestrator',
     );
+
+    const inventoryBalanceFetcher = options.inventoryConfig
+      ? new InventoryBalanceFetcher(
+          this.warpCore,
+          options.inventoryConfig,
+          this.logger,
+        )
+      : undefined;
 
     return new RebalancerOrchestrator({
       strategy: options.strategy,
@@ -729,6 +741,8 @@ export class RebalancerContextFactory {
       rebalancers: options.rebalancers,
       externalBridgeRegistry: options.externalBridgeRegistry,
       metrics: options.metrics,
+      executionLock: options.executionLock,
+      inventoryBalanceFetcher,
     });
   }
 

--- a/typescript/rebalancer/src/index.ts
+++ b/typescript/rebalancer/src/index.ts
@@ -13,9 +13,16 @@ export type {
   RebalancerServiceConfig,
   ManualRebalanceRequest,
 } from './core/RebalancerService.js';
+export { RebalancerFleet } from './core/RebalancerFleet.js';
+export type {
+  FleetMember,
+  RebalancerFleetOptions,
+} from './core/RebalancerFleet.js';
 
 // Core rebalancing logic
 export { Rebalancer } from './core/Rebalancer.js';
+export { LocalInventoryView } from './core/InventoryView.js';
+export type { IInventoryView } from './core/InventoryView.js';
 
 // Configuration
 export { RebalancerConfig } from './config/RebalancerConfig.js';
@@ -52,6 +59,7 @@ export { StrategyFactory } from './strategy/StrategyFactory.js';
 
 // Monitor
 export { Monitor } from './monitor/Monitor.js';
+export { InventoryBalanceFetcher } from './monitor/InventoryBalanceFetcher.js';
 
 // Metrics
 export { Metrics } from './metrics/Metrics.js';
@@ -105,6 +113,8 @@ export type {
 export { getRawBalances } from './utils/balanceUtils.js';
 export { isCollateralizedTokenEligibleForRebalancing } from './utils/tokenUtils.js';
 export { ExplorerClient } from './utils/ExplorerClient.js';
+export { Mutex } from './utils/mutex.js';
+export type { IMutex } from './utils/mutex.js';
 
 // Tracking
 export { InflightContextAdapter } from './tracking/InflightContextAdapter.js';

--- a/typescript/rebalancer/src/metrics/Metrics.ts
+++ b/typescript/rebalancer/src/metrics/Metrics.ts
@@ -8,7 +8,6 @@ import {
   getSealevelAtaPayerBalance,
   getTokenBridgedBalance,
   getXERC20Info,
-  startMetricsServer,
 } from '@hyperlane-xyz/metrics';
 import {
   Token,
@@ -26,7 +25,7 @@ import { type StrategyRoute } from '../interfaces/IStrategy.js';
 
 import { type PriceGetter } from './PriceGetter.js';
 import {
-  metricsRegister,
+  ensureMetricsServerStarted,
   rebalancerActionsCreatedTotal,
   rebalancerExecutionAmount,
   rebalancerExecutionTotal,
@@ -50,7 +49,7 @@ export class Metrics implements IMetrics {
     logger: Logger,
   ) {
     this.logger = logger.child({ class: Metrics.name });
-    startMetricsServer(metricsRegister);
+    ensureMetricsServerStarted();
 
     // Wrap PriceGetter to match TokenPriceGetter interface
     this.priceGetter = {

--- a/typescript/rebalancer/src/metrics/scripts/metrics.ts
+++ b/typescript/rebalancer/src/metrics/scripts/metrics.ts
@@ -7,6 +7,7 @@ import {
   type WarpRouteBalance,
   type XERC20Limit,
   createWarpMetricsGauges,
+  startMetricsServer,
   updateManagedLockboxBalanceMetrics as sharedUpdateManagedLockboxBalanceMetrics,
   updateNativeWalletBalanceMetrics as sharedUpdateNativeWalletBalanceMetrics,
   updateTokenBalanceMetrics as sharedUpdateTokenBalanceMetrics,
@@ -16,6 +17,14 @@ import { type ChainName, type Token, type WarpCore } from '@hyperlane-xyz/sdk';
 import { type Address } from '@hyperlane-xyz/utils';
 
 export const metricsRegister = new Registry();
+
+let metricsServerStarted = false;
+
+export function ensureMetricsServerStarted(): void {
+  if (metricsServerStarted) return;
+  metricsServerStarted = true;
+  startMetricsServer(metricsRegister);
+}
 
 // Create shared warp metrics gauges
 const gauges: WarpMetricsGauges = createWarpMetricsGauges(metricsRegister);

--- a/typescript/rebalancer/src/monitor/InventoryBalanceFetcher.ts
+++ b/typescript/rebalancer/src/monitor/InventoryBalanceFetcher.ts
@@ -11,7 +11,18 @@ export class InventoryBalanceFetcher {
     private readonly logger: Logger,
   ) {}
 
-  async fetchInventoryBalances(): Promise<ChainMap<bigint>> {
+  /**
+   * Read the inventory wallet balance on every configured chain.
+   *
+   * Read failures are handled per `strict`:
+   * - lenient (default, monitor polling): log and report 0n for the failed
+   *   chain so a single bad RPC doesn't stall the polling loop.
+   * - strict (execution time): rethrow so the caller can fall back to a
+   *   known-good snapshot instead of silently treating the chain as empty.
+   */
+  async fetchInventoryBalances(
+    options: { strict?: boolean } = {},
+  ): Promise<ChainMap<bigint>> {
     const balances: ChainMap<bigint> = {};
 
     const readPromises = this.inventoryConfig.chains.map(async (chainName) => {
@@ -49,6 +60,9 @@ export class InventoryBalanceFetcher {
           { chain: chainName, error: (error as Error).message },
           'Failed to read inventory balance',
         );
+        if (options.strict) {
+          throw error;
+        }
         return { chainName, balance: 0n };
       }
     });

--- a/typescript/rebalancer/src/monitor/InventoryBalanceFetcher.ts
+++ b/typescript/rebalancer/src/monitor/InventoryBalanceFetcher.ts
@@ -1,0 +1,64 @@
+import { type Logger } from 'pino';
+
+import { type ChainMap, type WarpCore } from '@hyperlane-xyz/sdk';
+
+import { type InventoryMonitorConfig } from './Monitor.js';
+
+export class InventoryBalanceFetcher {
+  constructor(
+    private readonly warpCore: WarpCore,
+    private readonly inventoryConfig: InventoryMonitorConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  async fetchInventoryBalances(): Promise<ChainMap<bigint>> {
+    const balances: ChainMap<bigint> = {};
+
+    const readPromises = this.inventoryConfig.chains.map(async (chainName) => {
+      const token = this.warpCore.tokens.find((t) => t.chainName === chainName);
+      if (!token) {
+        this.logger.warn(
+          { chain: chainName },
+          'No token found for inventory chain',
+        );
+        return { chainName, balance: 0n };
+      }
+
+      try {
+        const address = this.inventoryConfig.inventoryAddresses[token.protocol];
+        if (!address) {
+          this.logger.warn(
+            { chain: chainName, protocol: token.protocol },
+            'No inventory address for chain protocol, skipping',
+          );
+          return { chainName, balance: 0n };
+        }
+        const adapter = token.getAdapter(this.warpCore.multiProvider);
+        const balance = await adapter.getBalance(address);
+        this.logger.debug(
+          {
+            chain: chainName,
+            token: token.addressOrDenom,
+            balance: balance.toString(),
+          },
+          'Read inventory balance',
+        );
+        return { chainName, balance };
+      } catch (error) {
+        this.logger.error(
+          { chain: chainName, error: (error as Error).message },
+          'Failed to read inventory balance',
+        );
+        return { chainName, balance: 0n };
+      }
+    });
+
+    const results = await Promise.all(readPromises);
+
+    for (const { chainName, balance } of results) {
+      balances[chainName] = balance;
+    }
+
+    return balances;
+  }
+}

--- a/typescript/rebalancer/src/monitor/Monitor.ts
+++ b/typescript/rebalancer/src/monitor/Monitor.ts
@@ -1,11 +1,6 @@
 import { type Logger } from 'pino';
 
-import {
-  type ChainMap,
-  type ChainName,
-  type Token,
-  type WarpCore,
-} from '@hyperlane-xyz/sdk';
+import { type ChainName, type Token, type WarpCore } from '@hyperlane-xyz/sdk';
 import { Address, ProtocolType, fromWei, sleep } from '@hyperlane-xyz/utils';
 
 import {
@@ -18,6 +13,8 @@ import {
   MonitorStartError,
 } from '../interfaces/IMonitor.js';
 import { getConfirmedBlockTag } from '../utils/blockTag.js';
+
+import { InventoryBalanceFetcher } from './InventoryBalanceFetcher.js';
 
 /**
  * Configuration for the Monitor's inventory tracking.
@@ -38,6 +35,7 @@ export class Monitor implements IMonitor {
   private isMonitorRunning = false;
   private resolveStop: (() => void) | null = null;
   private stopPromise: Promise<void> | null = null;
+  private readonly inventoryBalanceFetcher?: InventoryBalanceFetcher;
 
   /**
    * @param checkFrequency - The frequency to poll balances in ms.
@@ -46,8 +44,12 @@ export class Monitor implements IMonitor {
     private readonly checkFrequency: number,
     private readonly warpCore: WarpCore,
     private readonly logger: Logger,
-    private readonly inventoryConfig?: InventoryMonitorConfig,
-  ) {}
+    inventoryConfig?: InventoryMonitorConfig,
+  ) {
+    this.inventoryBalanceFetcher = inventoryConfig
+      ? new InventoryBalanceFetcher(warpCore, inventoryConfig, logger)
+      : undefined;
+  }
 
   private async computeConfirmedBlockTags(): Promise<ConfirmedBlockTags> {
     const blockTags: ConfirmedBlockTags = {};
@@ -137,7 +139,9 @@ export class Monitor implements IMonitor {
             });
           }
 
-          const inventoryBalances = await this.fetchInventoryBalances();
+          const inventoryBalances = this.inventoryBalanceFetcher
+            ? await this.inventoryBalanceFetcher.fetchInventoryBalances()
+            : {};
           if (Object.keys(inventoryBalances).length > 0) {
             event.inventoryBalances = inventoryBalances;
             const tokensByChain = new Map(
@@ -261,60 +265,6 @@ export class Monitor implements IMonitor {
     }
 
     return bridgedSupply;
-  }
-
-  private async fetchInventoryBalances(): Promise<ChainMap<bigint>> {
-    if (!this.inventoryConfig) return {};
-
-    const balances: ChainMap<bigint> = {};
-
-    const readPromises = this.inventoryConfig.chains.map(async (chainName) => {
-      const token = this.warpCore.tokens.find((t) => t.chainName === chainName);
-      if (!token) {
-        this.logger.warn(
-          { chain: chainName },
-          'No token found for inventory chain',
-        );
-        return { chainName, balance: 0n };
-      }
-
-      try {
-        const address =
-          this.inventoryConfig!.inventoryAddresses[token.protocol];
-        if (!address) {
-          this.logger.warn(
-            { chain: chainName, protocol: token.protocol },
-            'No inventory address for chain protocol, skipping',
-          );
-          return { chainName, balance: 0n };
-        }
-        const adapter = token.getAdapter(this.warpCore.multiProvider);
-        const balance = await adapter.getBalance(address);
-        this.logger.debug(
-          {
-            chain: chainName,
-            token: token.addressOrDenom,
-            balance: balance.toString(),
-          },
-          'Read inventory balance',
-        );
-        return { chainName, balance };
-      } catch (error) {
-        this.logger.error(
-          { chain: chainName, error: (error as Error).message },
-          'Failed to read inventory balance',
-        );
-        return { chainName, balance: 0n };
-      }
-    });
-
-    const results = await Promise.all(readPromises);
-
-    for (const { chainName, balance } of results) {
-      balances[chainName] = balance;
-    }
-
-    return balances;
   }
 
   stop(): Promise<void> {

--- a/typescript/rebalancer/src/service.ts
+++ b/typescript/rebalancer/src/service.ts
@@ -7,7 +7,8 @@
  * environment variables and files, then starts the rebalancer in daemon mode.
  *
  * Environment Variables:
- * - REBALANCER_CONFIG_FILE: Path to the rebalancer configuration YAML file (required)
+ * - REBALANCER_CONFIG_FILE: Path to one rebalancer configuration YAML file
+ * - REBALANCER_CONFIG_FILES: Comma-separated rebalancer configuration YAML files for fleet mode (mutually exclusive with REBALANCER_CONFIG_FILE)
  * - HYP_REBALANCER_KEY: Private key for movable collateral rebalancing operations (preferred)
  * - HYP_KEY: Fallback private key for HYP_REBALANCER_KEY (optional)
  * - HYP_INVENTORY_KEY_<PROTOCOL>: Private key for inventory operations per protocol (e.g., HYP_INVENTORY_KEY_ETHEREUM, HYP_INVENTORY_KEY_SEALEVEL)
@@ -25,6 +26,7 @@
  *   REBALANCER_CONFIG_FILE=/config/rebalancer.yaml HYP_REBALANCER_KEY=0x... HYP_INVENTORY_KEY=0x... node dist/service.js
  */
 import { Wallet } from 'ethers';
+import { type Logger } from 'pino';
 import { Keypair } from '@solana/web3.js';
 
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
@@ -39,17 +41,160 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { RebalancerConfig } from './config/RebalancerConfig.js';
+import { type InventorySignerConfig } from './core/InventoryRebalancer.js';
+import { RebalancerFleet } from './core/RebalancerFleet.js';
 import { RebalancerService } from './core/RebalancerService.js';
 import { parseSolanaPrivateKey } from './utils/solanaKeyParser.js';
-import type { InventorySignerConfig } from './core/InventoryRebalancer.js';
+
+async function loadMergedRebalancerConfig(
+  configFile: string,
+  inventoryPrivateKeys: Partial<Record<ProtocolType, string>>,
+  monitorOnly: boolean,
+  logger: Logger,
+): Promise<RebalancerConfig> {
+  const rebalancerConfig = RebalancerConfig.load(configFile);
+  logger.info('✅ Loaded rebalancer configuration');
+
+  // Build consolidated inventory signers with keys embedded
+  const inventorySigners: Partial<Record<ProtocolType, InventorySignerConfig>> =
+    {};
+
+  for (const protocol of Object.values(ProtocolType)) {
+    const privateKey = inventoryPrivateKeys[protocol];
+    if (!privateKey) continue;
+
+    let derivedAddress: string;
+
+    if (isEVMLike(protocol)) {
+      // Tron uses same hex private key format as Ethereum.
+      // Derive 0x-prefixed hex address via ethers Wallet (TronWallet extends Wallet).
+      derivedAddress = new Wallet(privateKey).address;
+    } else if (protocol === ProtocolType.Sealevel) {
+      const keyBytes = parseSolanaPrivateKey(privateKey);
+      const keypair = Keypair.fromSecretKey(keyBytes);
+      derivedAddress = keypair.publicKey.toBase58();
+    } else {
+      logger.warn(
+        { protocol },
+        `Unsupported protocol for inventory signer derivation, skipping`,
+      );
+      continue;
+    }
+
+    // Validate against config if present
+    const configuredAddress =
+      rebalancerConfig.inventorySigners?.[protocol]?.address;
+    if (configuredAddress) {
+      const mismatch = isEVMLike(protocol)
+        ? configuredAddress.toLowerCase() !== derivedAddress.toLowerCase()
+        : configuredAddress !== derivedAddress;
+      if (mismatch) {
+        throw new Error(
+          `inventorySigners.${protocol} mismatch: config has ${configuredAddress} but HYP_INVENTORY_KEY_${protocol.toUpperCase()} derives to ${derivedAddress}`,
+        );
+      }
+    }
+
+    inventorySigners[protocol] = {
+      address: derivedAddress,
+      key: privateKey,
+    };
+    logger.info(
+      { protocol, address: derivedAddress },
+      `✅ ${protocol} inventory signer configured`,
+    );
+  }
+
+  // Fail fast if config references protocol-specific inventory signer but key is missing
+  if (!monitorOnly) {
+    for (const protocol of Object.values(ProtocolType)) {
+      if (
+        rebalancerConfig.inventorySigners?.[protocol] &&
+        !inventoryPrivateKeys[protocol]
+      ) {
+        const envKey = `HYP_INVENTORY_KEY_${protocol.toUpperCase()}`;
+        const hint =
+          protocol === ProtocolType.Ethereum
+            ? `${envKey} (or fallback HYP_INVENTORY_KEY)`
+            : envKey;
+        logger.error(
+          {
+            inventorySigner:
+              rebalancerConfig.inventorySigners[protocol]?.address,
+          },
+          `Config specifies inventorySigners.${protocol} but ${hint} is not set.`,
+        );
+        process.exit(1);
+      }
+    }
+  }
+
+  // Merge runtime keys into config — start from YAML config as base, overlay runtime keys per-protocol.
+  // This preserves YAML-only signer addresses (e.g., monitor-only configs) while adding runtime keys.
+  const mergedInventorySigners: Partial<
+    Record<ProtocolType, InventorySignerConfig>
+  > = { ...rebalancerConfig.inventorySigners };
+  for (const protocol of Object.values(ProtocolType)) {
+    const runtimeSigner = inventorySigners[protocol];
+    if (runtimeSigner) {
+      mergedInventorySigners[protocol] = {
+        ...mergedInventorySigners[protocol],
+        ...runtimeSigner,
+      };
+    }
+  }
+
+  return Object.keys(mergedInventorySigners).length > 0
+    ? new RebalancerConfig(
+        rebalancerConfig.warpRouteId,
+        rebalancerConfig.strategyConfig,
+        rebalancerConfig.intentTTL,
+        mergedInventorySigners,
+        rebalancerConfig.externalBridges,
+      )
+    : rebalancerConfig;
+}
+
+function errorDetails(error: unknown): { error: string; stack?: string } {
+  if (error instanceof Error) {
+    return { error: error.message, stack: error.stack };
+  }
+  return { error: String(error) };
+}
 
 async function main(): Promise<void> {
   const VERSION = process.env.SERVICE_VERSION || 'dev';
   // Validate required environment variables
   const configFile = process.env.REBALANCER_CONFIG_FILE;
-  if (!configFile) {
-    rootLogger.error('REBALANCER_CONFIG_FILE environment variable is required');
+  const configFilesValue = process.env.REBALANCER_CONFIG_FILES;
+  if (configFile !== undefined && configFilesValue !== undefined) {
+    rootLogger.error(
+      'REBALANCER_CONFIG_FILE and REBALANCER_CONFIG_FILES are mutually exclusive',
+    );
     process.exit(1);
+  }
+
+  const fleetMode = configFilesValue !== undefined;
+  let configFiles: string[];
+  if (fleetMode) {
+    configFiles = configFilesValue
+      .split(',')
+      .map((file) => file.trim())
+      .filter(Boolean);
+    if (configFiles.length === 0) {
+      rootLogger.error(
+        'REBALANCER_CONFIG_FILES must contain at least one configuration file',
+      );
+      process.exit(1);
+    }
+  } else {
+    if (!configFile) {
+      rootLogger.error(
+        'REBALANCER_CONFIG_FILE environment variable is required',
+      );
+      process.exit(1);
+    }
+    configFiles = [configFile];
   }
 
   const rebalancerPrivateKey =
@@ -106,7 +251,7 @@ async function main(): Promise<void> {
   logger.info(
     {
       version: VERSION,
-      configFile,
+      ...(fleetMode ? { configFiles } : { configFile }),
       checkFrequency,
       withMetrics,
       monitorOnly,
@@ -115,9 +260,17 @@ async function main(): Promise<void> {
   );
 
   try {
-    // Load rebalancer configuration
-    const rebalancerConfig = RebalancerConfig.load(configFile);
-    logger.info('✅ Loaded rebalancer configuration');
+    const mergedRebalancerConfigs: RebalancerConfig[] = [];
+    for (const file of configFiles) {
+      mergedRebalancerConfigs.push(
+        await loadMergedRebalancerConfig(
+          file,
+          inventoryPrivateKeys,
+          monitorOnly,
+          logger,
+        ),
+      );
+    }
 
     // Initialize registry (uses env var or defaults to GitHub registry)
     // For GitHub registries, REGISTRY_URI can include /tree/{commit} to pin to a specific version
@@ -147,106 +300,30 @@ async function main(): Promise<void> {
       '✅ Initialized MultiProvider with rebalancer signer',
     );
 
-    // Build consolidated inventory signers with keys embedded
-    const inventorySigners: Partial<
-      Record<ProtocolType, InventorySignerConfig>
-    > = {};
-
-    for (const protocol of Object.values(ProtocolType)) {
-      const privateKey = inventoryPrivateKeys[protocol];
-      if (!privateKey) continue;
-
-      let derivedAddress: string;
-
-      if (isEVMLike(protocol)) {
-        // Tron uses same hex private key format as Ethereum.
-        // Derive 0x-prefixed hex address via ethers Wallet (TronWallet extends Wallet).
-        derivedAddress = new Wallet(privateKey).address;
-      } else if (protocol === ProtocolType.Sealevel) {
-        const keyBytes = parseSolanaPrivateKey(privateKey);
-        const keypair = Keypair.fromSecretKey(keyBytes);
-        derivedAddress = keypair.publicKey.toBase58();
-      } else {
-        logger.warn(
-          { protocol },
-          `Unsupported protocol for inventory signer derivation, skipping`,
-        );
-        continue;
-      }
-
-      // Validate against config if present
-      const configuredAddress =
-        rebalancerConfig.inventorySigners?.[protocol]?.address;
-      if (configuredAddress) {
-        const mismatch = isEVMLike(protocol)
-          ? configuredAddress.toLowerCase() !== derivedAddress.toLowerCase()
-          : configuredAddress !== derivedAddress;
-        if (mismatch) {
-          throw new Error(
-            `inventorySigners.${protocol} mismatch: config has ${configuredAddress} but HYP_INVENTORY_KEY_${protocol.toUpperCase()} derives to ${derivedAddress}`,
-          );
-        }
-      }
-
-      inventorySigners[protocol] = {
-        address: derivedAddress,
-        key: privateKey,
-      };
-      logger.info(
-        { protocol, address: derivedAddress },
-        `✅ ${protocol} inventory signer configured`,
+    if (fleetMode) {
+      const fleet = new RebalancerFleet(
+        multiProvider,
+        registry,
+        mergedRebalancerConfigs.map((rebalancerConfig) => ({
+          rebalancerConfig,
+        })),
+        {
+          checkFrequency,
+          monitorOnly,
+          withMetrics,
+          coingeckoApiKey,
+          version: VERSION,
+        },
+        logger,
       );
+      await fleet.start();
+      return;
     }
 
-    // Fail fast if config references protocol-specific inventory signer but key is missing
-    if (!monitorOnly) {
-      for (const protocol of Object.values(ProtocolType)) {
-        if (
-          rebalancerConfig.inventorySigners?.[protocol] &&
-          !inventoryPrivateKeys[protocol]
-        ) {
-          const envKey = `HYP_INVENTORY_KEY_${protocol.toUpperCase()}`;
-          const hint =
-            protocol === ProtocolType.Ethereum
-              ? `${envKey} (or fallback HYP_INVENTORY_KEY)`
-              : envKey;
-          logger.error(
-            {
-              inventorySigner:
-                rebalancerConfig.inventorySigners[protocol]?.address,
-            },
-            `Config specifies inventorySigners.${protocol} but ${hint} is not set.`,
-          );
-          process.exit(1);
-        }
-      }
+    const mergedRebalancerConfig = mergedRebalancerConfigs[0];
+    if (!mergedRebalancerConfig) {
+      throw new Error('Rebalancer configuration was not loaded');
     }
-
-    // Merge runtime keys into config — start from YAML config as base, overlay runtime keys per-protocol.
-    // This preserves YAML-only signer addresses (e.g., monitor-only configs) while adding runtime keys.
-    const mergedInventorySigners: Partial<
-      Record<ProtocolType, InventorySignerConfig>
-    > = { ...rebalancerConfig.inventorySigners };
-    for (const protocol of Object.values(ProtocolType)) {
-      const runtimeSigner = inventorySigners[protocol];
-      if (runtimeSigner) {
-        mergedInventorySigners[protocol] = {
-          ...mergedInventorySigners[protocol],
-          ...runtimeSigner,
-        };
-      }
-    }
-
-    const mergedRebalancerConfig =
-      Object.keys(mergedInventorySigners).length > 0
-        ? new RebalancerConfig(
-            rebalancerConfig.warpRouteId,
-            rebalancerConfig.strategyConfig,
-            rebalancerConfig.intentTTL,
-            mergedInventorySigners,
-            rebalancerConfig.externalBridges,
-          )
-        : rebalancerConfig;
 
     // MultiProtocolProvider will be derived from multiProvider in factory
     const multiProtocolProvider = undefined;
@@ -271,18 +348,13 @@ async function main(): Promise<void> {
     // Start the service
     await service.start();
   } catch (error) {
-    const err = error as Error;
-    logger.error(
-      { error: err.message, stack: err.stack },
-      'Failed to start rebalancer service',
-    );
+    logger.error(errorDetails(error), 'Failed to start rebalancer service');
     process.exit(1);
   }
 }
 
 // Run the service
 main().catch((error) => {
-  const err = error as Error;
-  rootLogger.error({ error: err.message, stack: err.stack }, 'Fatal error');
+  rootLogger.error(errorDetails(error), 'Fatal error');
   process.exit(1);
 });

--- a/typescript/rebalancer/src/utils/mutex.test.ts
+++ b/typescript/rebalancer/src/utils/mutex.test.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+
+import { Mutex } from './mutex.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((resolver) => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
+
+describe('Mutex', () => {
+  it('prevents concurrent critical sections from interleaving', async () => {
+    const mutex = new Mutex();
+    const entered = deferred();
+    const release = deferred();
+    let inside = false;
+
+    const first = mutex.runExclusive(async () => {
+      expect(inside).to.be.false;
+      inside = true;
+      entered.resolve();
+      await release.promise;
+      inside = false;
+    });
+
+    await entered.promise;
+    const second = mutex.runExclusive(async () => {
+      expect(inside).to.be.false;
+      inside = true;
+      inside = false;
+    });
+
+    await Promise.resolve();
+    expect(inside).to.be.true;
+    release.resolve();
+    await Promise.all([first, second]);
+  });
+
+  it('runs waiters in FIFO order', async () => {
+    const mutex = new Mutex();
+    const entered = deferred();
+    const release = deferred();
+    const order: string[] = [];
+
+    const first = mutex.runExclusive(async () => {
+      order.push('first:start');
+      entered.resolve();
+      await release.promise;
+      order.push('first:end');
+    });
+    await entered.promise;
+
+    const second = mutex.runExclusive(async () => {
+      order.push('second');
+    });
+    const third = mutex.runExclusive(async () => {
+      order.push('third');
+    });
+
+    release.resolve();
+    await Promise.all([first, second, third]);
+
+    expect(order).to.deep.equal([
+      'first:start',
+      'first:end',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('propagates rejection without poisoning the lock', async () => {
+    const mutex = new Mutex();
+    const expectedError = new Error('critical section failed');
+    let caughtError: unknown;
+
+    try {
+      await mutex.runExclusive(async () => {
+        throw expectedError;
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).to.equal(expectedError);
+    expect(await mutex.runExclusive(async () => 'recovered')).to.equal(
+      'recovered',
+    );
+  });
+
+  it('propagates return values', async () => {
+    const mutex = new Mutex();
+
+    expect(await mutex.runExclusive(async () => 42)).to.equal(42);
+  });
+});

--- a/typescript/rebalancer/src/utils/mutex.ts
+++ b/typescript/rebalancer/src/utils/mutex.ts
@@ -1,0 +1,16 @@
+export interface IMutex {
+  runExclusive<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+export class Mutex implements IMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(fn);
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary

Adds **fleet mode** to `@hyperlane-xyz/rebalancer`: one process hosting N per-route rebalancers with in-process coordination, replacing the per-route pods for the six USDC routes that have a `solanamainnet` collateral leg (`usdc-sol-fleet`: eclipsemainnet, radix, subtensor, aleo, paradex, superseed).

**Why:** every rebalancer pod signs from the same inventory EOA (`0x6056…FdA9` / `4ZJo…BcMo`) and movable-collateral EOA — a single shared GCP key by design (`key-utils.ts`). The per-instance guards in `InventoryRebalancer` (single-active-intent, `consumedInventory`) are in-memory and don't span pods, so once #9025 enables Solana inventory on more routes, concurrent pods would race nonces and double-count the shared wallet. Fleet mode makes that interference impossible by construction: one shared execution mutex serializes all signing, and inventory balances are re-fetched fresh under the lock at execution time.

## What changed

**`@hyperlane-xyz/rebalancer`** (changeset: minor)
- `Mutex` (promise-chain) + `IInventoryView` seam extracted from `InventoryRebalancer` (`LocalInventoryView` default preserves exact behavior) — the seam is where a future shared cross-route reservation ledger (L1) drops in.
- `RebalancerOrchestrator`: execution phase runs inside an injectable `executionLock` (default: private mutex → single-route behavior unchanged); when an `InventoryBalanceFetcher` is wired, inventory wallet balances are re-fetched **strictly** under the lock, falling back to the monitor snapshot on failure.
- `RebalancerService`: `ownsProcess: false` mode (no signal handlers, no `process.exit`) so services embed in a fleet; metrics HTTP server starts once per process.
- `RebalancerFleet`: supervisor — staggered member starts, per-member restart with capped exponential backoff (30s→15min, reset after 30min healthy), fleet-owned signals, fatal exit(1) only if every member fails initial startup.
- `service.ts`: `REBALANCER_CONFIG_FILES` (comma-separated) starts a fleet; `REBALANCER_CONFIG_FILE` single-route mode unchanged; both set → error. Same Docker image/`SERVICE_NAME`.

**`typescript/infra`**
- Helm chart renders both modes (multi-config configmap, `REBALANCER_CONFIG_FILES`/`WARP_ROUTE_IDS` envs).
- `fleets.ts` defines `usdc-sol-fleet`; `RebalancerFleetHelmManager` validates every member config before touching any release; chains/protocols unions dedupe RPC secrets.
- `deploy-rebalancer --fleet <name>`: cutover = uninstall each per-route release → wait for pod termination → install fleet (never both running). Per-route path excludes/refuses fleet-managed ids. Fleet pods stay visible to RPC rotation via `WARP_ROUTE_IDS` discovery.

## Verification

- 403 mocha tests passing (incl. new: mutex FIFO/poisoning, view parity, cross-orchestrator serialization with interleaving assertion, fresh-refetch + fallback, fleet supervision/backoff/shutdown). `InventoryRebalancer.test.ts` passes **unmodified** (seam regression gate). tsc + build clean; lint parity with main (zero new findings).
- `helm template` renders verified for both single and fleet values.
- **Live smoke**: 2-route fleet (eclipse + radix, `MONITOR_ONLY=true`) against mainnet RPCs — staggered starts, per-route cycles, one metrics server (no EADDRINUSE), SIGTERM → graceful shutdown of both members → clean exit.
- Self-review (8-angle + verify): 3 confirmed issues found and fixed in the final commit (dead fetch-failure fallback / silent 0n; fleet preflight partial monitor uninstall on abort; interactive redeploy aborting on fleet-managed selection).

## Known limitations / follow-ups (deliberate L0 scope)

- **In-flight inbound blindness (L1 gap):** members can't see each other's in-flight LiFi transfers, so a member may redundantly bridge toward a destination another member is already funding (efficiency, not safety — source debits are mined before the lock releases). The `IInventoryView` seam exists so a shared reservation ledger can fix this without touching `InventoryRebalancer`.
- **Lock starvation:** a hung bridge execution holds the global lock (executions only; polling unaffected). `lockWaitMs` warn fires >60s; per-operation timeouts are the right future mitigation.
- **Universal refetch:** single-route inventory rebalancers also refetch at execution time now (fresher balances, ~1 extra balance read per chain per cycle). Monitor-time inventory fetch becomes fallback-only; consolidating fetches is a follow-up optimization.
- `helmValues` duplication between the two helm managers; name-sanitization repeated in 3 places; `firstAttemptFailed` naming — cleanup follow-ups.
- **Grafana**: pod-name-based alerts referencing `hyperlane-rebalancer-usdc-*` release names need updating at cutover (metric-level `warp_route_id` alerts unaffected). The deploy script warns.

## Rollout

1. Merge → build node-services image → bump `mainnetDockerTags.rebalancer`.
2. Canary: fleet manifest with eclipse only (sole inventory user pre-#9025); watch one cycle.
3. Full cutover: all 6 members via `deploy-rebalancer --fleet usdc-sol-fleet`.
4. Rollback: uninstall fleet release, redeploy per-route (configs untouched; image rollback unnecessary).
5. Then merge #9025 — its configs land inside the fleet; the shared-key race never exists in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
