### PR TITLE
chore(infra): skip staging routes with STAGE/STAGING symbol suffix

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -57,8 +57,18 @@ const ROUTES_TO_SKIP: string[] = [
 // violations on mainnet.
 const STAGING_ROUTE_MARKERS = ['staging', 'test'];
 
+// Token-symbol suffixes that mark a route as staging, e.g. `USDCSTAGE`,
+// `HYPERSTAGE`, `REZSTAGING`. The staging marker is fused onto the symbol
+// (before the first `/`) rather than living in its own chain segment, so it is
+// not caught by STAGING_ROUTE_MARKERS above.
+const STAGING_SYMBOL_SUFFIXES = ['stage', 'staging'];
+
 function isStagingOrTestRoute(warpRouteId: string): boolean {
-  const [, ...rest] = warpRouteId.split('/');
+  const [symbol = '', ...rest] = warpRouteId.split('/');
+  const lowerSymbol = symbol.toLowerCase();
+  if (STAGING_SYMBOL_SUFFIXES.some((suffix) => lowerSymbol.endsWith(suffix))) {
+    return true;
+  }
   const segments = rest.join('/').toLowerCase().split(/[-/]/);
   return segments.some((segment) => STAGING_ROUTE_MARKERS.includes(segment));
 }


### PR DESCRIPTION
## Summary
- `check-warp-deploy` excludes staging/test routes via `isStagingOrTestRoute`, but the filter only matched `staging`/`test` **chain segments** (post-`/`).
- Staging routes whose marker is fused onto the **token symbol** (before the first `/`) slipped through and produced spurious mainnet warp-check violations:
  - `USDCSTAGE/eclipsemainnet`, `USDCSTAGE/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed`
  - `USDTSTAGE/mode`
  - `HYPERSTAGE/…`, `stHYPERSTAGE/bsc-ethereum`, `PZETHSTAGE/…`, `ETHSTAGE/stage`, `EZETHSTAGE/renzo-stage`, `REZSTAGING/base-ethereum-unichain`
- Adds a symbol-suffix check (`stage`/`staging`) so these are auto-skipped, replacing the need for one-off `ROUTES_TO_SKIP` entries.
- `test` is intentionally **not** a symbol suffix marker to avoid false positives on production symbols like `CONTEST`/`LATEST`; testnet routes remain handled by the separate testnet filter and chain-segment markers are unchanged.

## Test plan
- [x] Verified against all current registry routes: the 8 `*STAGE`/`*STAGING` symbol routes + existing `moonpay-staging`/`oUSDT/staging` segment routes are skipped; production routes (incl. `CONTEST`/`LATEST`) are kept.
- [x] `oxlint` clean.