### PR TITLE
fix(infra): add per-route timeout to check-warp-deploy

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -63,6 +63,33 @@ function isStagingOrTestRoute(warpRouteId: string): boolean {
   return segments.some((segment) => STAGING_ROUTE_MARKERS.includes(segment));
 }
 
+// Upper bound on how long a single warp route check may run before it is
+// abandoned. A hung/unresponsive RPC leg on one route would otherwise stall the
+// entire cron run indefinitely, starving every subsequent route of a check.
+const DEFAULT_PER_ROUTE_TIMEOUT_MS = 5 * 60 * 1000;
+const perRouteTimeoutMs = Number(
+  process.env.WARP_CHECK_PER_ROUTE_TIMEOUT_MS ?? DEFAULT_PER_ROUTE_TIMEOUT_MS,
+);
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onTimeoutMessage: string,
+): Promise<T> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error(onTimeoutMessage)),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
 async function main() {
   const { environment, chains, pushMetrics } =
     await getCheckWarpDeployArgs().argv;
@@ -151,15 +178,19 @@ async function main() {
 
     try {
       const warpDeployConfig = warpDeployConfigMap[warpRouteId];
-      const result = await runWarpRouteCheckFromRegistry({
-        chains,
-        multiProvider,
-        registry,
-        registryUris: registries,
-        warpRouteId,
-        warpCoreConfig: warpCoreConfigMap[warpRouteId],
-        warpDeployConfig,
-      });
+      const result = await withTimeout(
+        runWarpRouteCheckFromRegistry({
+          chains,
+          multiProvider,
+          registry,
+          registryUris: registries,
+          warpRouteId,
+          warpCoreConfig: warpCoreConfigMap[warpRouteId],
+          warpDeployConfig,
+        }),
+        perRouteTimeoutMs,
+        `Timed out checking warp route ${warpRouteId} after ${perRouteTimeoutMs}ms`,
+      );
 
       if (result.violations.length > 0) {
         logWarpRouteCheckResult(result);


### PR DESCRIPTION
## Summary
- The `check-warp-deploy` cron iterates warp routes sequentially with `await runWarpRouteCheckFromRegistry(...)` and **no per-route timeout**. A single hung/unresponsive RPC leg could block the loop indefinitely, so every route after it never gets checked (observed as monitor hangs).
- Wraps each per-route check in `withTimeout` (default **5m**, overridable via `WARP_CHECK_PER_ROUTE_TIMEOUT_MS`). The timer is cleared on completion so it never keeps the event loop alive.
- A timed-out route is pushed to `failedWarpRoutesChecks` exactly like any other thrown error: it does **not** emit stale violation metrics, and the run still `process.exit(1)`s to surface the failure.

## Follow-on (not in this PR)
Per-route timeout bounds the blast radius but still fails the whole route when one of its chains is unreachable. A deeper fix is per-chain resilience — skip only the unreachable chain leg (or mark it degraded) rather than failing the entire route — so a single bad RPC does not mask violations on the route's healthy chains. Filing separately.

## Test plan
- [x] `oxlint` clean.
- [ ] Dry-run the monitor (`--environment mainnet3`, no `--pushMetrics`) and confirm a route that exceeds the timeout is logged as failed and the run continues to subsequent routes.