### PR TITLE
fix: exclude CrossCollateralRoutingFee feeContracts from warp check

### DIFF
--- a/.changeset/warp-check-ccrf-fee-contracts.md
+++ b/.changeset/warp-check-ccrf-fee-contracts.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+The warp check no longer diffs `CrossCollateralRoutingFee` `feeContracts`. These are the OffchainQuotedLinearFee standing-quote contracts wired dynamically per-recipient via submitQuote, so the static registry snapshot always drifted from on-chain state and emitted a perpetual violation every run.

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -383,7 +383,7 @@ describe('configUtils', () => {
       });
     });
 
-    it('normalizes CCRF router-keyed fee contracts recursively', () => {
+    it('excludes CCRF feeContracts (standing quotes) from the check', () => {
       const ROUTER_KEY =
         '0x1111111111111111111111111111111111111111111111111111111111111111';
       const transformedObj = transformConfigToCheck({
@@ -422,63 +422,7 @@ describe('configUtils', () => {
         tokenFee: {
           type: TokenFeeType.CrossCollateralRoutingFee,
           owner: ADDRESS,
-          feeContracts: {
-            ethereum: {
-              [DEFAULT_ROUTER_KEY]: {
-                type: TokenFeeType.LinearFee,
-                owner: ADDRESS,
-                token: ADDRESS,
-                bps: 200n,
-              },
-              [ROUTER_KEY]: {
-                type: TokenFeeType.LinearFee,
-                owner: ADDRESS,
-                token: ADDRESS,
-                bps: 300n,
-              },
-            },
-          },
-        },
-      });
-    });
-
-    it('keeps only populated CCRF router entries during normalization', () => {
-      const transformedObj = transformConfigToCheck({
-        type: TokenType.collateral,
-        token: ADDRESS,
-        tokenFee: {
-          type: TokenFeeType.CrossCollateralRoutingFee,
-          owner: ADDRESS,
-          feeContracts: {
-            ethereum: {
-              [DEFAULT_ROUTER_KEY]: {
-                type: TokenFeeType.LinearFee,
-                owner: ADDRESS,
-                token: ADDRESS,
-                bps: 200n,
-              },
-            },
-          },
-        },
-      } as any);
-
-      expect(transformedObj).to.eql({
-        type: TokenType.collateral,
-        token: ADDRESS,
-        scale: { numerator: 1n, denominator: 1n },
-        tokenFee: {
-          type: TokenFeeType.CrossCollateralRoutingFee,
-          owner: ADDRESS,
-          feeContracts: {
-            ethereum: {
-              [DEFAULT_ROUTER_KEY]: {
-                type: TokenFeeType.LinearFee,
-                owner: ADDRESS,
-                token: ADDRESS,
-                bps: 200n,
-              },
-            },
-          },
+          feeContracts: {},
         },
       });
     });

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -625,17 +625,6 @@ const FIELDS_TO_IGNORE = new Set<keyof HypTokenRouterConfig>([
   'name',
 ]);
 
-function normalizeCrossCollateralFeeContractsForCheck(
-  destinationConfig: Record<string, TokenFeeConfigInput>,
-) {
-  return Object.fromEntries(
-    Object.entries(destinationConfig).map(([router, nestedFee]) => [
-      router,
-      normalizeTokenFeeForCheck(nestedFee),
-    ]),
-  );
-}
-
 function normalizeTokenFeeForCheck(
   feeConfig: TokenFeeConfigInput | undefined,
 ): TokenFeeConfigInput | undefined {
@@ -661,18 +650,15 @@ function normalizeTokenFeeForCheck(
   }
 
   if (feeConfig.type === TokenFeeType.CrossCollateralRoutingFee) {
-    const normalizedFeeContracts = Object.fromEntries(
-      Object.keys(feeConfig.feeContracts).map((chain) => [
-        chain,
-        normalizeCrossCollateralFeeContractsForCheck(
-          feeConfig.feeContracts[chain],
-        ),
-      ]),
-    );
+    // feeContracts here are the OffchainQuotedLinearFee "standing quote" contracts,
+    // wired dynamically per-recipient via submitQuote. The registry deploy config only
+    // holds a static snapshot, so this map always drifts from on-chain state and would
+    // otherwise emit a perpetual violation every check run. Collapse both sides to an
+    // empty map so it is excluded from the diff.
     return {
       type: TokenFeeType.CrossCollateralRoutingFee,
       owner: feeConfig.owner,
-      feeContracts: normalizedFeeContracts,
+      feeContracts: {},
     };
   }
 


### PR DESCRIPTION
## Summary
- The warp checker was emitting a perpetual violation every run for every Moonpay (and other CCRF) route's `tokenFee.feeContracts.*` entries.
- Those entries are the `OffchainQuotedLinearFee` **standing-quote** contracts, wired dynamically per-recipient via `submitQuote`. The registry deploy config only holds a static snapshot, so on-chain state always drifts from it — nothing actionable, pure noise.
- `normalizeTokenFeeForCheck` now collapses `CrossCollateralRoutingFee.feeContracts` to an empty map on both sides of the diff, so the map is excluded from the check. The CCRF `owner` is still checked.

## Changes
- `typescript/sdk/src/token/configUtils.ts`: drop `feeContracts` in the CCRF branch of `normalizeTokenFeeForCheck`; remove the now-unused `normalizeCrossCollateralFeeContractsForCheck` helper.
- `typescript/sdk/src/token/configUtils.test.ts`: replace the two CCRF recursive-normalization cases with one asserting `feeContracts` is excluded.
- Changeset (patch, `@hyperlane-xyz/sdk`).

## Test plan
- [x] `pnpm -C typescript/sdk build`
- [x] `pnpm -C typescript/sdk mocha src/token/configUtils.test.ts` (31 passing)
- [x] oxlint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)