### PR TITLE
fix: warp check derives all CCR fee router keys

### DIFF
--- a/.changeset/warp-check-ccr-fee-router-keys.md
+++ b/.changeset/warp-check-ccr-fee-router-keys.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+The EVM warp route check now derives cross-collateral-routing (CCR) fee entries for every enrolled router key, not just the multi-collateral-enrolled subset. Previously `EvmWarpRouteReader` only seeded fee-mapping keys from on-chain `crossCollateralRouters` plus the default router key, so any `feeContracts` entry keyed under a normal `remoteRouters` address — including the local domain's own router for same-chain swaps — was never read, producing perpetual false-positive `tokenFee` violations in `check-warp-deploy`. The reader now unions `crossCollateralRouters`, `remoteRouters`, and the local router's own address when probing fee contracts.

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -32,6 +32,7 @@ import {
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   Address,
+  addressToBytes32,
   arrayToObject,
   assert,
   eqAddress,
@@ -54,12 +55,16 @@ import {
   DerivedTokenFeeConfig,
   EvmTokenFeeReader,
 } from '../fee/EvmTokenFeeReader.js';
+import {
+  CrossCollateralRoutersByDomain,
+  mergeCrossCollateralRouters,
+} from '../fee/crossCollateralUtils.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { DerivedHookConfig, HookType, OnchainHookType } from '../hook/types.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmRouterReader } from '../router/EvmRouterReader.js';
-import { DestinationGas } from '../router/types.js';
+import { DestinationGas, RemoteRouters } from '../router/types.js';
 import { ChainName, ChainNameOrId, DeployedOwnableConfig } from '../types.js';
 import {
   fetchPackageVersion as fetchContractPackageVersion,
@@ -323,12 +328,24 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     const feeDestinations = [
       ...new Set([...(domains ?? []), ...ccrEnrolledDomains]),
     ];
+    // CCR feeContracts are keyed by each destination's enrolled router address.
+    // Those keys are the normal remoteRouters, not just the MC-enrolled
+    // crossCollateralRouters, so union both — otherwise the reader misses every
+    // fee entry keyed under a normal router and reports false-positive diffs.
+    // remoteRouters omits the local domain, so add this router's own address as
+    // the key for self-domain (same-chain CCR swap) fee entries.
+    const selfDomainId = this.multiProvider.getDomainId(this.chain);
+    const feeRouterKeys = isCrossCollateralTokenConfig(tokenConfig)
+      ? mergeCrossCollateralRouters(
+          tokenConfig.crossCollateralRouters,
+          this.remoteRoutersToRouterKeys(routerConfig.remoteRouters),
+          { [selfDomainId]: [addressToBytes32(warpRouteAddress)] },
+        )
+      : undefined;
     const tokenFee = await this.fetchTokenFee(
       warpRouteAddress,
       feeDestinations.length ? feeDestinations : undefined,
-      isCrossCollateralTokenConfig(tokenConfig)
-        ? tokenConfig.crossCollateralRouters
-        : undefined,
+      feeRouterKeys,
     );
 
     // Read feeHook (IGP address for ERC20 gas payments)
@@ -455,10 +472,20 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     return undefined;
   }
 
+  private remoteRoutersToRouterKeys(
+    remoteRouters: RemoteRouters | undefined,
+  ): CrossCollateralRoutersByDomain {
+    const routerKeys: CrossCollateralRoutersByDomain = {};
+    for (const [domain, { address }] of Object.entries(remoteRouters ?? {})) {
+      routerKeys[Number(domain)] = [address];
+    }
+    return routerKeys;
+  }
+
   public async fetchTokenFee(
     routerAddress: Address,
     destinations?: number[],
-    crossCollateralRouters?: Record<string, string[]>,
+    crossCollateralRouters?: CrossCollateralRoutersByDomain,
   ): Promise<DerivedTokenFeeConfig | undefined> {
     const TokenRouter = TokenRouter__factory.connect(
       routerAddress,
@@ -505,18 +532,10 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         return undefined;
       }));
 
-    const normalizedCrossCollateralRouters = crossCollateralRouters
-      ? Object.fromEntries(
-          Object.entries(crossCollateralRouters).map(([domain, routers]) => [
-            Number(domain),
-            routers,
-          ]),
-        )
-      : undefined;
     return this.evmTokenFeeReader.deriveTokenFeeConfig({
       address: tokenFee,
       routingDestinations,
-      crossCollateralRouters: normalizedCrossCollateralRouters,
+      crossCollateralRouters,
     });
   }
 


### PR DESCRIPTION
## Summary
- Fixes perpetual false-positive `tokenFee` violations in `check-warp-deploy` for cross-collateral-routing (CCR) warp routes (surfaced on the CROSS/moonpay USDC + USDT routes).
- Root cause: `EvmWarpRouteReader` only seeded CCR fee-mapping keys from on-chain `crossCollateralRouters` + the default router key. But `feeContracts(dest, targetRouter)` is keyed by each destination's *enrolled router address* — i.e. the normal `remoteRouters`, not just the MC-enrolled subset. Every fee entry keyed under a normal router (and the local domain's own router for same-chain swaps) was never probed, so all those actuals came back empty and diffed against config.
- Fix: union three key sources per destination when reading fees — on-chain `crossCollateralRouters`, `remoteRouters` (converted to router-key map), and the local router's own address at the local domain. `EvmTokenFeeReader` skips `AddressZero`, so the extra keys add no new false positives.

## Verification
- Reproduced the check end-to-end against arbitrum/base/etc. on private RPCs: moonpay violations went 63 → 6 with `tokenFee=0` after the fix (remaining 6 are unrelated to fees — a nested solana-route ISM ownership drift tracked separately).
- On-chain confirmed the self-domain fee entry is real (`feeContracts(42161, arbRouter)` returns a live `OffchainQuotedLinearFee`), which the old reader missed.
- `pnpm -C typescript/sdk build` clean; existing `EvmWarpRouteReader.hardhat-test.ts` unaffected (it only asserts destinations, not fee keys).

## Test plan
- [ ] CI green
- [ ] Confirm `check-warp-deploy` on CROSS/moonpay no longer reports `tokenFee` diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)