### PR TITLE
feat(skills): add SVM warp fee management skills

### DIFF
--- a/.claude/skills/svm-warp-alt-manage/SKILL.md
+++ b/.claude/skills/svm-warp-alt-manage/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: svm-warp-alt-manage
+description: Create, check, and read on-chain Sealevel (SVM) Address Lookup Tables (ALTs) for a warp route. Use after deploying, extending, or upgrading an SVM warp route, when transfers fail with transaction-too-large errors, or when asked to inspect or verify a route's ALTs. Fee-enabled SVM transfers bundle 40+ accounts and require ALTs to fit under the 1232-byte tx limit.
+---
+
+# SVM Warp ALT Management
+
+Manage the on-chain Address Lookup Tables (ALTs) that a Sealevel warp route uses to compress its account list into a v0 `VersionedTransaction`. Fee-enabled SVM warp transfers reference 40+ accounts (core + fee + IGP + token plugin) and exceed Solana's 1232-byte transaction size limit without ALTs.
+
+Wraps the `hyperlane warp alt` command group (`typescript/cli/src/commands/warp-alt.ts`): `create`, `check`, `read`.
+
+## When to Use
+
+- Right **after** deploying a new SVM warp route (`/warp-deploy-init-route`), extending one, or upgrading an SVM program (`/svm-warp-program-upgrade`) — ALTs must be (re)created.
+- SVM transfers fail with transaction-too-large / too-many-accounts errors.
+- "check the ALTs for <route>" / "are the lookup tables up to date?" → `check`.
+- "show me the ALT contents for <route>" → `read`.
+
+## Model
+
+Each Sealevel chain in the route has, in the registry warp config under `options.sealevel.altAddresses.<chain>`:
+
+- `core` — one **chain-shared** ALT (mailbox/core accounts, reusable across routes on that chain).
+- `warpSpecific` — an array (min 1) of **route-specific** ALTs (this route's token/fee/IGP accounts).
+
+ALTs are created on-chain, populated, then **frozen**. Frozen tables are immutable and their rent **cannot be reclaimed** — you never "edit" an ALT, you create a fresh one and update the registry pointer. This is why `--force`/`--full-force` leak the old (frozen) tables: they create new ones and abandon the old, unrecoverable ones.
+
+## Commands
+
+All commands run from `typescript/cli` and require `--warp-route-id`. `--chain` is optional and scopes to a single chain (defaults to all Sealevel chains in the route). `create` needs write context (`--key.sealevel` + private RPC via HTTP registry); `check` and `read` are read-only.
+
+### create — build + persist ALTs
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp alt create \
+  --registry http://localhost:<port> \
+  --key.sealevel $<SEALEVEL_KEY_VAR> \
+  -w <WARP_ROUTE_ID> \
+  [--chain <chain>]
+```
+
+- Default (no flags): creates ALTs only where the registry has none. Existing entries are left as-is.
+- `--force` / `-f`: recreate the **warp-specific** ALTs for chains that already have registry entries; the chain-shared `core` ALT is reused. Old warp-specific frozen ALTs are leaked (unrecoverable).
+- `--full-force` / `-F`: recreate **all** ALTs including `core`. Implies `--force`. All old frozen ALTs leaked.
+- Writes the resulting ALT addresses back to the registry warp config (`options.sealevel.altAddresses`).
+
+Use plain `create` after a fresh deploy. Use `--force` after an upgrade/extend that changed the route-specific account set. Reserve `--full-force` for when the core ALT itself is wrong — it's the most wasteful (leaks the shared table too).
+
+### check — verify on-chain ALTs match expected
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp alt check \
+  --registry http://localhost:<port> \
+  -w <WARP_ROUTE_ID> \
+  [--chain <chain>]
+```
+
+Compares on-chain ALT contents against the expected account set for the route. **Exits non-zero on drift** — treat a non-zero exit as "ALTs are stale, recreate them" (usually `create --force`). Report the specific diff to the user.
+
+### read — dump ALT contents
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp alt read \
+  --registry http://localhost:<port> \
+  -w <WARP_ROUTE_ID> \
+  [--chain <chain>] \
+  [--out <file.yaml>]
+```
+
+Read-only. Prints (or writes) the current on-chain ALT addresses and their entries. No key needed.
+
+## Execution Flow
+
+1. **Start the HTTP registry** (needed for private Sealevel RPC; `--writeMode` for `create`):
+   ```bash
+   cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
+   ```
+   Run in background; wait for `Listening on http://localhost:<port>`; note port + task ID. (`/start-http-registry`.)
+2. **Run the requested subcommand** (`create` / `check` / `read`) against `--registry http://localhost:<port>`.
+3. For `create`: after success, confirm the registry warp config now has `options.sealevel.altAddresses.<chain>.{core,warpSpecific}` and follow with a `check` to prove no drift.
+4. **Stop the HTTP registry** background task, even on failure.
+5. If `create` mutated the registry, open a registry PR with the updated warp config (the `altAddresses` block) so the ALT pointers are canonical.
+
+## Caveats
+
+- **ALTs are frozen and unrecoverable.** Never assume you can reclaim rent or mutate a table. `--force`/`--full-force` intentionally abandon old frozen tables — only use them when the account set actually changed.
+- **Always create ALTs after any deploy/extend/upgrade** of an SVM route. Missing or stale ALTs are the usual cause of transaction-too-large failures on fee-enabled SVM transfers.
+- **`check` exit code is the signal** — non-zero = drift; don't ignore it. Recreate and re-check.
+- **Core vs warp-specific:** prefer `--force` (keeps the shared core ALT) over `--full-force` unless the core table itself is stale.
+- `create` needs write context and a funded `--key.sealevel`; `check`/`read` do not.

--- a/.claude/skills/svm-warp-program-upgrade/SKILL.md
+++ b/.claude/skills/svm-warp-program-upgrade/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: svm-warp-program-upgrade
+description: Upgrade a deployed Sealevel (SVM) warp-route token or IGP program to a newer contract version (e.g. to enable token/IGP fee support), driven by warp apply. Use when asked to upgrade, bump, or migrate an SVM warp/IGP program to a fee-enabled or newer version, or when a config diff reports a contractVersion mismatch on a Sealevel chain.
+---
+
+# SVM Warp Program Upgrade
+
+Upgrade a deployed Sealevel warp-route token program (collateral/synthetic/native/cross-collateral) or IGP program to a newer on-chain `contractVersion` — most commonly to move an existing route onto a fee-enabled program build.
+
+There is **no standalone `warp upgrade` CLI command.** The upgrade runs automatically as part of `hyperlane warp apply`: when the expected `contractVersion` in the compiled program config differs from the on-chain version AND program bytes are supplied, the SVM token module calls `prepareProgramUpgrade` (`typescript/svm-sdk/src/deploy/program-upgrade.ts`) before its config-update step.
+
+## When to Use
+
+- "upgrade the solanamainnet <TOKEN> warp program to the fee-enabled version"
+- "bump the SVM IGP program to vX"
+- "warp check says contractVersion mismatch on eclipsemainnet — upgrade it"
+- Any request to migrate a deployed Sealevel warp/IGP program to a newer program build
+
+## What the Upgrade Actually Does
+
+`prepareProgramUpgrade` (verify against source before relying on details):
+
+1. **Version compare.** Reads on-chain `contractVersion`, compares to expected. Equal → no-op (returns null). Expected older → **throws** (no downgrades). Expected newer → proceeds.
+2. **Immutable check.** Reads the program's upgrade authority. If the program has none (immutable), it **asserts/throws** — cannot upgrade.
+3. **Extend program-data if needed.** Computes `additionalBytes = newProgramBytes.length - currentMaxProgramLen`. If `> 0`, emits a single `ExtendProgramChecked` instruction (`getExtendProgramCheckedInstruction`, loader.ts) sized to exactly the deficit. The checked variant is required on Agave 3.0+ (`enable_extend_program_checked` gate). No fixed padding amount — it extends by exactly what the new binary needs.
+4. **Buffer create + write.** Creates a buffer account and writes the new program bytes using the **submitter/payer key** (executed immediately; no upgrade authority needed for this part).
+5. **Transfer buffer authority** to the upgrade authority if payer ≠ upgrade authority.
+6. **Emit the upgrade instruction** as an authority transaction — this and the extend require the **upgrade authority** to sign.
+
+So the run splits into two groups:
+
+- **Payer-executed immediately:** buffer create/write (+ optional buffer-authority transfer).
+- **Authority transactions (need the upgrade authority signature):** `ExtendProgramChecked` (if any) + the `Upgrade` instruction. These are surfaced as `AnnotatedSvmTransaction`s. If the upgrade authority == the submitter key, `warp apply` submits them; otherwise they are written for the authority to sign (e.g. via a `file` submitter / Squads).
+
+## Inputs
+
+- **Warp route ID** (e.g. `USDC/solana-...`) — required.
+- **Chain(s)** — which Sealevel chain(s) to upgrade.
+- **Submitter key** for the chain (`--key.sealevel`) — funds/writes the buffer.
+- **Upgrade authority** — who signs the extend + upgrade. If it is not the submitter key, expect a `file`/Squads submitter and plan to route the authority txs to the owner.
+- Confirmation that the compiled config carries the **new program bytes** and the **target `contractVersion`** (this is what the deploy/config pipeline resolves; a version bump without program bytes does nothing).
+
+If any of these is missing, ask before proceeding.
+
+## Execution Flow
+
+### Step 1 — Read current on-chain version
+
+Read the deployed program's config to capture the current `contractVersion` and confirm it is older than the target. Use `hyperlane warp read` (or `warp check`) against the route so you can show the user current vs expected version and the upgrade authority.
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp read \
+  --registry http://localhost:<port> \
+  -w <WARP_ROUTE_ID>
+```
+
+Confirm:
+
+- expected version **>** current version (equal = nothing to do; expected older = will throw)
+- the program has an upgrade authority (not immutable)
+- who the upgrade authority is (submitter vs external owner)
+
+### Step 2 — Start the HTTP registry
+
+The upgrade needs private RPC overrides for the Sealevel chain.
+
+```bash
+cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
+```
+
+Run in background; wait for `Listening on http://localhost:<port>`; note port + task ID. (`/start-http-registry` skill.)
+
+### Step 3 — Dry-run / preview
+
+Preview the apply so the user sees exactly which programs will be extended + upgraded and the version transitions, before spending SOL on buffer writes.
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp apply \
+  --registry http://localhost:<port> \
+  --key.sealevel $<SEALEVEL_KEY_VAR> \
+  -w <WARP_ROUTE_ID> \
+  --dry-run
+```
+
+Look for the annotations `Extend <label>: +N bytes` and `Upgrade <label>: <old> → <new>`. Show these to the user. If no upgrade annotation appears, the version already matches or no program bytes were supplied — stop and report that.
+
+### Step 4 — Run the upgrade
+
+Re-run without `--dry-run`. If the upgrade authority differs from the submitter key, supply a strategy with a `file` submitter for the Sealevel chain so the authority (extend + upgrade) transactions are written out for the owner to sign.
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp apply \
+  --registry http://localhost:<port> \
+  --key.sealevel $<SEALEVEL_KEY_VAR> \
+  [--strategy ~/.hyperlane/strategies/<owner>-strategy.yaml]  # if authority != submitter
+  --receipts-dir /tmp/<route>-svm-upgrade-txs \
+  -w <WARP_ROUTE_ID> \
+  --yes
+```
+
+Buffer create/write is executed immediately by the submitter key. The extend + upgrade either execute (authority == submitter) or land in the receipts dir for the owner to sign.
+
+### Step 5 — Verify
+
+Re-read the program and confirm on-chain `contractVersion` now equals the target. If the authority txs were written to a file, the version will only change **after** the owner executes them — say so explicitly.
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp read \
+  --registry http://localhost:<port> -w <WARP_ROUTE_ID>
+```
+
+### Step 6 — Recreate ALTs
+
+A program upgrade can change the account set for transfers. After any successful upgrade, **recreate the SVM Address Lookup Tables** for the route — run `/svm-warp-alt-manage` (`hyperlane warp alt create`). Then `hyperlane warp alt check` to confirm no drift.
+
+### Step 7 — Stop the HTTP registry
+
+Kill the background task from Step 2, even on failure.
+
+## Caveats
+
+- **No downgrades.** Expected version older than on-chain → hard error. Don't try to "roll back" via this path.
+- **Immutable programs can't be upgraded.** If there's no upgrade authority, stop and escalate.
+- **Two-key reality.** The submitter/payer key pays for and writes the buffer; the **upgrade authority** must sign the extend + upgrade. These are frequently different (owner = Squads multisig). Plan for a `file` submitter and owner execution.
+- **Version bump alone is inert.** If the config carries a new `contractVersion` but no program bytes, `prepareProgramUpgrade` never runs a binary upgrade — only the config-update path. Ensure the program build/bytes are wired in.
+- **Extend sizing is exact**, computed from the new binary vs current program-data capacity; it is not a fixed 10 KiB. If the binary shrank or fits, no extend instruction is emitted.
+- **Always follow with ALT recreation** (Step 6) — stale ALTs after an account-layout change cause transfer failures.

--- a/.claude/skills/warp-manage-offchain-quotes/SKILL.md
+++ b/.claude/skills/warp-manage-offchain-quotes/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: warp-manage-offchain-quotes
+description: Create and read offchain-signed standing warp fee quotes on a deployed warp route, on both EVM and SVM chains. Use when asked to set, submit, update, or inspect standing (reusable, on-chain-expiring) offchain fee quotes for a warp route via the hyperlane warp quote command. One secp256k1 signer key works across EVM and SVM.
+---
+
+# Manage Offchain-Signed Warp Fee Quotes
+
+Create and read **standing** offchain-signed fee quotes on a deployed warp route using `hyperlane warp quote` (`typescript/cli/src/commands/warp-quote.ts`). Works on both EVM and SVM chains — the quote signature is secp256k1 ECDSA (Ethereum-style, recovers to an H160), so a **single signer key** is valid across protocols.
+
+> This is the general-purpose quote tool. The `set-moonpay-standing-quotes` skill is a purpose-built wrapper for the CROSS/moonpay route specifically; use that one for MoonPay, this one for everything else.
+
+## Standing vs Transient
+
+- **Standing quote** (`--ttl > 0`): reusable across many senders/recipients until its on-chain expiry. This is the only kind this command can create — it's signed with wildcard recipient/amount and stored on-chain.
+- **Transient quote** (`ttl = 0`, one-shot at submission time): **NOT usable from this standalone command.** Its storage is scoped to the create tx (EIP-1153 transient storage on EVM, payer-scoped PDA on SVM), so it only exists inside the transfer tx that carries it. `--ttl` therefore must be `> 0` (the CLI demands it).
+
+## Two-Key Model (critical)
+
+There are two distinct keys, do not conflate them:
+
+| Key              | Flag / env                                                   | Role                                                                                                                                                                                                           |
+| ---------------- | ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Quote signer** | `--quote-signer-key` or `HYP_QUOTE_SIGNER_KEY`               | 0x-hex secp256k1 private key that **signs the quote**. Its derived address MUST be in the route's `quoteSigners` allowlist (`typescript/sdk/src/fee/types.ts`) or the on-chain verification rejects the quote. |
+| **Tx submitter** | `--key.<protocol>` (e.g. `--key.ethereum`, `--key.sealevel`) | Pays for and sends the on-chain submission transaction. Unrelated to signing.                                                                                                                                  |
+
+If the signer address is not in `quoteSigners`, the submission will revert — verify membership first.
+
+## Commands
+
+Run from `typescript/cli`. Both require `--warp-route-id`.
+
+### create — submit a standing quote
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp quote create \
+  --registry http://localhost:<port> \
+  --key.<protocol> $<SUBMITTER_KEY_VAR> \
+  --quote-signer-key $HYP_QUOTE_SIGNER_KEY \
+  -w <WARP_ROUTE_ID> \
+  --chain <origin-chain> \
+  --destination <remote-chain> \
+  --recipient <wildcard | native-address> \
+  --amount <wildcard | amount> \
+  --max-fee <wei-or-lamports> \
+  --half-amount <wei-or-lamports> \
+  --ttl <seconds, > 0> \
+  [--target-router <native-router-address>]
+```
+
+Flag notes:
+
+- `--chain` = origin chain the quote is submitted on; `--destination` = the remote chain the quote applies to.
+- `--recipient` / `--amount`: for a broadly reusable standing quote, use the wildcard sentinel (`WarpQuoteAmountKind.wildcard`) for both. Recipient, when concrete, is in the **destination chain's native format** (0x… EVM, base58 Solana).
+- `--max-fee` + `--half-amount`: the linear fee-curve parameters (in wei on EVM, lamports on SVM).
+- `--ttl`: seconds; on-chain expiry = now + ttl. Must be `> 0`.
+- `--target-router`: **cross-collateral only.** Submits against a specific router-keyed leaf, in the destination chain's native address format. Omit to let the CLI auto-resolve (specific router leaf if present, else the `DEFAULT` leaf). Don't set it for single-collateral routes.
+
+### read — inspect standing quotes
+
+```bash
+cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp quote read \
+  --registry http://localhost:<port> \
+  -w <WARP_ROUTE_ID> \
+  [--chain <chain>] \
+  [--recipients <native-addr> --recipients <native-addr> ...] \
+  [--out <file.yaml>]
+```
+
+- Read-only, no keys.
+- `--chain` scopes to one chain (defaults to all chains in the route).
+- `--recipients`: extra recipient addresses to **probe** on protocols whose standing-quote storage is **non-enumerable** (EVM — you must know the recipient to look it up). Ignored on protocols that enumerate on-chain (SVM lists them for you). Accepts native format per chain (0x… / base58); the CLI auto-detects protocol and converts to bytes32, skipping anything that isn't a valid address.
+
+## Execution Flow
+
+1. **Verify the signer is allowlisted.** Derive the address from the quote signer key and confirm it appears in the route's `quoteSigners`. If not, stop — the quote would be rejected on-chain.
+2. **Start the HTTP registry** (private RPC overrides; `--writeMode` for create):
+   ```bash
+   cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
+   ```
+   Background; wait for `Listening on http://localhost:<port>`; note port + task ID.
+3. **For create:** first `read` the current standing quotes for the lane so you can show old→new. Then run `create`. Summarize the lane (origin→destination, recipient/amount scope, maxFee/halfAmount, TTL) in plain language before the raw output.
+4. **For read:** run and show output directly (no confirmation — read-only). On EVM, remember concrete recipients must be supplied via `--recipients` to be visible.
+5. **Stop the HTTP registry** background task, even on failure.
+
+## Caveats
+
+- **One signer key, all protocols.** Because verification recovers an H160 from a secp256k1 signature, the same `--quote-signer-key` works for EVM and SVM. The address just has to be in `quoteSigners`.
+- **Signer ≠ submitter.** `--quote-signer-key` signs; `--key.<protocol>` pays. Supplying only one of them is a common mistake.
+- **`--ttl` must be > 0.** Transient (ttl=0) quotes cannot be created from this command — they only live inside a transfer tx.
+- **`--target-router` is cross-collateral only** and expects the destination chain's native router address; leave it off otherwise and rely on auto-resolution.
+- **EVM reads need `--recipients`** for concrete (non-wildcard) recipients since EVM storage isn't enumerable; SVM reads enumerate on-chain.
+- For the CROSS/moonpay route specifically, prefer `/set-moonpay-standing-quotes`.

--- a/.claude/skills/warp-manage-offchain-quotes/SKILL.md
+++ b/.claude/skills/warp-manage-offchain-quotes/SKILL.md
@@ -51,6 +51,7 @@ Flag notes:
 
 - `--chain` = origin chain the quote is submitted on; `--destination` = the remote chain the quote applies to.
 - `--recipient` / `--amount`: for a broadly reusable standing quote, use the wildcard sentinel (`WarpQuoteAmountKind.wildcard`) for both. Recipient, when concrete, is in the **destination chain's native format** (0x… EVM, base58 Solana).
+  - **When unsure which recipient to use, ask the user — do not silently default to `wildcard`.** A recipient is only valid in the destination chain's native format, so a value that worked for one destination (e.g. a Solana base58 key) is invalid when the destination is a different protocol (e.g. an EVM chain). If the user's requested recipient can't apply to this destination, or they said "same params" but the address format doesn't fit, stop and confirm the intended recipient (concrete address vs. `wildcard`) before submitting.
 - `--max-fee` + `--half-amount`: the linear fee-curve parameters (in wei on EVM, lamports on SVM).
 - `--ttl`: seconds; on-chain expiry = now + ttl. Must be `> 0`.
 - `--target-router`: **cross-collateral only.** Submits against a specific router-keyed leaf, in the destination chain's native address format. Omit to let the CLI auto-resolve (specific router leaf if present, else the `DEFAULT` leaf). Don't set it for single-collateral routes.
@@ -78,7 +79,7 @@ cd <MONOREPO_ROOT>/typescript/cli && pnpm hyperlane warp quote read \
    cd <MONOREPO_ROOT> && pnpm -C typescript/infra start:http-registry --writeMode
    ```
    Background; wait for `Listening on http://localhost:<port>`; note port + task ID.
-3. **For create:** first `read` the current standing quotes for the lane so you can show old→new. Then run `create`. Summarize the lane (origin→destination, recipient/amount scope, maxFee/halfAmount, TTL) in plain language before the raw output.
+3. **For create:** first `read` the current standing quotes for the lane so you can show old→new. **Confirm the recipient is valid for the destination protocol; if it's ambiguous or a format mismatch, ask the user before submitting rather than defaulting to `wildcard`.** Then run `create`. Summarize the lane (origin→destination, recipient/amount scope, maxFee/halfAmount, TTL) in plain language before the raw output.
 4. **For read:** run and show output directly (no confirmation — read-only). On EVM, remember concrete recipients must be supplied via `--recipients` to be visible.
 5. **Stop the HTTP registry** background task, even on failure.
 


### PR DESCRIPTION
## Summary

Adds three Claude Code skills to `.claude/skills/` for operating fee-enabled warp routes (SVM + EVM), derived from the recent SVM/EVM fee-support PR series. These are the skills #1, #2, and #4 from the proposed set; #3 (`warp-set-fee`) and #5 (`deploy-svm-fee-warp-route`) are intentionally omitted as they will be covered by the `xeno/haggis-automated-warp-deployments` work.

| Skill | Purpose |
| ----- | ------- |
| `svm-warp-program-upgrade` | Upgrade a deployed SVM warp/IGP program to a newer `contractVersion` (e.g. fee-enabled build). Runs via `warp apply` → `prepareProgramUpgrade`: version-compare, immutable check, exact-size program-data extend (`ExtendProgramChecked`), buffer write by payer, upgrade signed by the upgrade authority. |
| `svm-warp-alt-manage` | Create / check / read on-chain SVM Address Lookup Tables (`hyperlane warp alt`). Fee-enabled SVM transfers bundle 40+ accounts and need ALTs to fit under the 1232-byte tx limit. Covers the frozen/unrecoverable caveat, `--force`/`--full-force` leak semantics, and non-zero `check` exit on drift. |
| `warp-manage-offchain-quotes` | Create / read standing offchain-signed fee quotes (`hyperlane warp quote`) on EVM and SVM. Documents the two-key model (`--quote-signer-key`/`HYP_QUOTE_SIGNER_KEY` vs `--key.<protocol>`), standing-only (`--ttl > 0`), cross-collateral `--target-router` auto-resolution, and wildcard recipient/amount. |

Content was verified against the current CLI/SDK source (`typescript/cli/src/commands/{warp-alt,warp-quote}.ts`, `typescript/svm-sdk/src/deploy/program-upgrade.ts`, `typescript/sdk/src/{warp,fee}/types.ts`).

## Test plan

- [ ] Draft — skills to be exercised against a test SVM warp route (upgrade, ALT create/check, quote create/read).
- [ ] Confirm skill trigger descriptions surface for the intended natural-language requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)