### PR TITLE
fix: remove redundant prisma generate from ccip-server build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "turbo run test --continue",
     "test:ci": "turbo run test:ci",
     "coverage": "turbo run coverage",
-    "version:prepare": "pnpm changeset version && turbo run version:update && pnpm install",
+    "version:prepare": "pnpm changeset version && pnpm install && turbo run version:update && pnpm install",
     "version:check": "pnpm changeset status",
     "release": "pnpm build && pnpm build:zk && pnpm changeset publish",
     "spellcheck": "typos --config .spellcheck/typos.toml",

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -13,7 +13,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "postinstall": "prisma generate",
-    "build": "prisma generate && tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json",
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",


### PR DESCRIPTION
## Summary

`typescript/ccip-server/package.json` ran `prisma generate` in both `postinstall` and `build`. During the release workflow, `build` runs (via `pnpm release` → `pnpm build`) after `pnpm install` has already fired `postinstall` — two `prisma generate` invocations end up racing on the same output directory (`src/generated/prisma`). Prisma's generate isn't atomic (each output entry is `rm -rf`'d then rewritten), so one process can catch the directory mid-teardown from the other and bail out with:

```
../ccip-server postinstall: Error:
../ccip-server postinstall: .../typescript/ccip-server/src/generated/prisma exists and is not empty
but doesn't look like a generated Prisma Client. Please check your output path and remove the existing
directory if you indeed want to generate the Prisma Client in that location.
```

This failed the `publish-release` job here: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/29729247061/job/88310189485

`postinstall` is the one that's actually load-bearing — `dev`/`start` never run `build`, and `typescript/Dockerfile` explicitly depends on `postinstall` generating the client before the rest of the service source is even copied in. `build`'s copy is a defensive pattern from Prisma's own docs (guarding against platforms like Vercel that cache `node_modules` and skip `postinstall`), which doesn't apply to this repo — CI never caches `node_modules`, so `pnpm install` always runs `postinstall` fresh. Removing it from `build` leaves a single generator and eliminates the race.

Verified locally: `build` still compiles clean against the client `postinstall` generates (`tsc` fails immediately if the client is missing, confirming the dependency; with it present, `pnpm run postinstall && pnpm run build` succeeds).

## Test plan

- [x] `pnpm --filter @hyperlane-xyz/ccip-server run postinstall && pnpm --filter @hyperlane-xyz/ccip-server run build` succeeds locally
- [x] Confirmed `tsc` alone fails without a prior `prisma generate` (proves `postinstall` is required, not incidental)
- [ ] Next `Release` CI run on `main` completes `publish-release` without the prisma race