### PR TITLE
chore(infra): pin check-warp-deploy to latest monorepo image

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -49,7 +49,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   validatorFastPath: 'e22be4b-20260715-194756',
   scraper: 'e22be4b-20260715-194756',
   // monorepo services
-  checkWarpDeploy: 'main',
+  checkWarpDeploy: '197b1e0-20260720-085052',
   // standalone services
   keyFunder: '5dc6aa4-20260714-184449',
   warpMonitor: '744b3bb-20260521-215958',


### PR DESCRIPTION
## Summary
- Pins the `check-warp-deploy-mainnet3` cronjob image from the floating `main` tag to `197b1e0-20260720-085052`.
- This build includes the recent warp-check fixes: #9066 (CCR fee router keys), #9050 (skip USDCSTAGE/eclipsemainnet), #9019 (avoid false-positive verification violations), #9008 (skip explorer API key GCP fetch in k8s), #8995 (per-series push).
- Pinning to a dated SHA tag guarantees the fixes are deployed and forces a fresh image pull (the floating tag can be cached on the node).

## Test plan
- [ ] Deploy the cronjob (`deploy-check-warp-deploy.ts`) to mainnet3.
- [ ] Trigger a manual run and confirm the real remaining violation set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)