### PR TITLE
fix(infra): re-enable Forma relayer and scraper

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -99,7 +99,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     ethereum: true,
     fluent: true,
     flowmainnet: true,
-    forma: false, // disabled — RPC unavailable
+    forma: false, // relayer + scraper only
     fraxtal: true,
     galactica: true,
     gnosis: true,
@@ -200,7 +200,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     ethereum: true,
     fluent: true,
     flowmainnet: true,
-    forma: false, // disabled — RPC unavailable
+    forma: true,
     fraxtal: true,
     galactica: true,
     gnosis: true,
@@ -301,7 +301,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     ethereum: true,
     fluent: true,
     flowmainnet: true,
-    forma: false, // disabled — RPC unavailable
+    forma: true,
     fraxtal: true,
     galactica: true,
     gnosis: true,


### PR DESCRIPTION
## Summary

- Re-enabled Forma for the mainnet3 relayer and scraper.
- Kept the Forma validator disabled and clarified the intended role scope.

## Validation

- `pnpm -C typescript/infra check`
- Deployed mainnet3 relayer revision 578 and scraper revision 302; both pods are ready with zero restarts and Forma indexing active.
