### PR TITLE
fix: deploy DefaultFallbackRoutingIsm with owner/domains set in constructor

### DIFF
--- a/.changeset/fallback-routing-ism-atomic-init.md
+++ b/.changeset/fallback-routing-ism-atomic-init.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/core': major
+'@hyperlane-xyz/sdk': patch
+---
+
+`DefaultFallbackRoutingIsm` deployment was changed to set the owner, domains, and submodules directly in the constructor instead of a separate follow-up call, simplifying the deploy path in `HyperlaneIsmFactory`.

--- a/solidity/contracts/isms/routing/DefaultFallbackRoutingIsm.sol
+++ b/solidity/contracts/isms/routing/DefaultFallbackRoutingIsm.sol
@@ -16,7 +16,19 @@ contract DefaultFallbackRoutingIsm is DomainRoutingIsm, MailboxClient {
     using Address for address;
     using TypeCasts for bytes32;
 
-    constructor(address _mailbox) MailboxClient(_mailbox) {}
+    constructor(
+        address _mailbox,
+        address _owner,
+        uint32[] memory _domains,
+        IInterchainSecurityModule[] memory _modules
+    ) MailboxClient(_mailbox) {
+        require(_domains.length == _modules.length, "length mismatch");
+        for (uint256 i = 0; i < _domains.length; i++) {
+            _set(_domains[i], address(_modules[i]));
+        }
+        _transferOwnership(_owner);
+        _disableInitializers();
+    }
 
     function module(
         uint32 origin

--- a/solidity/test/isms/DomainRoutingIsm.t.sol
+++ b/solidity/test/isms/DomainRoutingIsm.t.sol
@@ -189,13 +189,27 @@ contract DefaultFallbackRoutingIsmTest is DomainRoutingIsmTest {
             address(hook)
         );
 
-        ism = new DefaultFallbackRoutingIsm(address(mailbox));
-        ism.initialize(address(this));
+        ism = new DefaultFallbackRoutingIsm(
+            address(mailbox),
+            address(this),
+            new uint32[](0),
+            new IInterchainSecurityModule[](0)
+        );
     }
 
     function testConstructorReverts() public {
         vm.expectRevert("MailboxClient: invalid mailbox");
-        new DefaultFallbackRoutingIsm(address(0));
+        new DefaultFallbackRoutingIsm(
+            address(0),
+            address(this),
+            new uint32[](0),
+            new IInterchainSecurityModule[](0)
+        );
+    }
+
+    function testConstructorDisablesReinitialization() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        ism.initialize(address(this));
     }
 
     function testRemoveIsms(uint32 domain, uint8 count) public override {

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -634,23 +634,13 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
             'Mailbox address is required for deploying fallback routing ISM',
           );
         }
+
         logger.debug('Deploying fallback routing ISM ...');
         routingIsm = await this.multiProvider.handleDeploy(
           destination,
           new DefaultFallbackRoutingIsm__factory(),
-          [mailbox],
+          [mailbox, config.owner, safeConfigDomains, submoduleAddresses],
           await getZKSyncArtifactByContractName(config.type),
-        );
-        // TODO: Should verify contract here
-        logger.debug('Initialising fallback routing ISM ...');
-        receipt = await this.multiProvider.handleTx(
-          destination,
-          routingIsm['initialize(address,uint32[],address[])'](
-            config.owner,
-            safeConfigDomains,
-            submoduleAddresses,
-            overrides,
-          ),
         );
       } else {
         // deploying new domain routing ISM


### PR DESCRIPTION
## Summary
- `DefaultFallbackRoutingIsm` now sets owner, domains, and submodules directly in its constructor instead of via a separate `initialize()` call.
- Simplifies `HyperlaneIsmFactory`'s fallback-routing deploy path accordingly, removing the now-unnecessary post-deploy initialization step.

## Test plan
- [x] `forge test --match-contract DefaultFallbackRoutingIsmTest` passing
- [x] `HyperlaneIsmFactory.hardhat-test.ts` passing (37/37)
- [x] `EvmIsmModule.hardhat-test.ts` passing (47/47)
- [x] SDK `tsc` build clean