### PR TITLE
feat(infra): fast-track Heimdall Safe indexing

### DIFF
--- a/typescript/infra/scripts/safes/propose-txs.ts
+++ b/typescript/infra/scripts/safes/propose-txs.ts
@@ -164,9 +164,11 @@ async function main() {
               rootLogger.info(
                 `[${chainName}] Requested Heimdall fast-track${canonicalUrl ? `: ${canonicalUrl}` : ''}`,
               );
-            } catch (error) {
+            } catch (error: unknown) {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error);
               rootLogger.warn(
-                `[${chainName}] Failed to request Heimdall fast-track for ${safeTxHash}; the Safe transaction was proposed successfully: ${String(error)}`,
+                `[${chainName}] Failed to request Heimdall fast-track for ${safeTxHash}; the Safe transaction was proposed successfully: ${errorMessage}`,
               );
             }
           }),

--- a/typescript/infra/scripts/safes/propose-txs.ts
+++ b/typescript/infra/scripts/safes/propose-txs.ts
@@ -9,6 +9,10 @@ import { readJson } from '@hyperlane-xyz/utils/fs';
 import { Contexts } from '../../config/contexts.js';
 import { SafeMultiSend } from '../../src/govern/multisend.js';
 import { Role } from '../../src/roles.js';
+import {
+  DEFAULT_HEIMDALL_URL,
+  requestHeimdallSafeTxRefresh,
+} from '../../src/utils/heimdall.js';
 import { withPropose } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
@@ -20,7 +24,7 @@ type TxFile = {
 };
 
 async function main() {
-  const { directory, file, safeAddress, propose } = await withPropose(
+  const argv = await withPropose(
     yargs(process.argv.slice(2))
       .option('directory', {
         type: 'string',
@@ -39,6 +43,16 @@ async function main() {
         demandOption: true,
         alias: 's',
       })
+      .option('notify-heimdall', {
+        type: 'boolean',
+        describe: 'Ask Heimdall to index and parse proposed transactions',
+        default: true,
+      })
+      .option('heimdall-url', {
+        type: 'string',
+        describe: 'Heimdall base URL',
+        default: process.env.HEIMDALL_BASE_URL ?? DEFAULT_HEIMDALL_URL,
+      })
       .check((argv) => {
         if (!argv.directory && !argv.file) {
           throw new Error('Must provide either --directory or --file');
@@ -49,6 +63,8 @@ async function main() {
         return true;
       }),
   ).argv;
+  const { directory, file, safeAddress, propose, notifyHeimdall, heimdallUrl } =
+    argv;
 
   let filePaths: string[];
   if (file) {
@@ -134,6 +150,27 @@ async function main() {
       rootLogger.info(`[${chainName}] Successfully proposed transactions`);
       for (const hash of hashes) {
         rootLogger.info(`[${chainName}] safeTxHash: ${hash}`);
+      }
+      if (notifyHeimdall) {
+        await Promise.all(
+          hashes.map(async (safeTxHash) => {
+            try {
+              const canonicalUrl = await requestHeimdallSafeTxRefresh({
+                baseUrl: heimdallUrl,
+                chainName,
+                safeAddress,
+                safeTxHash,
+              });
+              rootLogger.info(
+                `[${chainName}] Requested Heimdall fast-track${canonicalUrl ? `: ${canonicalUrl}` : ''}`,
+              );
+            } catch (error) {
+              rootLogger.warn(
+                `[${chainName}] Failed to request Heimdall fast-track for ${safeTxHash}; the Safe transaction was proposed successfully: ${String(error)}`,
+              );
+            }
+          }),
+        );
       }
     } catch (error) {
       rootLogger.error(

--- a/typescript/infra/src/utils/heimdall.ts
+++ b/typescript/infra/src/utils/heimdall.ts
@@ -1,0 +1,66 @@
+export const DEFAULT_HEIMDALL_URL = 'https://heimdall.tailb0554c.ts.net';
+
+const HEIMDALL_REQUEST_TIMEOUT_MS = 10_000;
+const HEIMDALL_REQUEST_ATTEMPTS = 3;
+const HEIMDALL_RETRY_BASE_MS = 250;
+const RETRYABLE_HEIMDALL_STATUSES = new Set([404, 429, 503]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function requestHeimdallSafeTxRefresh({
+  baseUrl,
+  chainName,
+  safeAddress,
+  safeTxHash,
+  fetchFn = fetch,
+  sleepFn = sleep,
+}: {
+  baseUrl: string;
+  chainName: string;
+  safeAddress: string;
+  safeTxHash: string;
+  fetchFn?: typeof fetch;
+  sleepFn?: (ms: number) => Promise<void>;
+}): Promise<string | undefined> {
+  const origin = new URL(baseUrl).origin;
+  const refreshUrl = new URL(
+    `/api/v1/multisigs/${encodeURIComponent(chainName)}/${encodeURIComponent(safeAddress)}/txs/${encodeURIComponent(safeTxHash)}/refresh`,
+    origin,
+  );
+  for (let attempt = 1; attempt <= HEIMDALL_REQUEST_ATTEMPTS; attempt += 1) {
+    const response = await fetchFn(refreshUrl, {
+      method: 'POST',
+      headers: {
+        Origin: origin,
+        'X-Heimdall-CSRF': '1',
+      },
+      signal: AbortSignal.timeout(HEIMDALL_REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      if (
+        attempt < HEIMDALL_REQUEST_ATTEMPTS &&
+        RETRYABLE_HEIMDALL_STATUSES.has(response.status)
+      ) {
+        await sleepFn(HEIMDALL_RETRY_BASE_MS * 2 ** (attempt - 1));
+        continue;
+      }
+      throw new Error(`Heimdall returned HTTP ${response.status}`);
+    }
+
+    const body: unknown = await response.json();
+    if (
+      typeof body === 'object' &&
+      body !== null &&
+      'canonicalUrl' in body &&
+      typeof body.canonicalUrl === 'string'
+    ) {
+      return new URL(body.canonicalUrl, origin).toString();
+    }
+    return undefined;
+  }
+
+  throw new Error('Heimdall refresh exhausted without a response');
+}

--- a/typescript/infra/test/heimdall.test.ts
+++ b/typescript/infra/test/heimdall.test.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+
+import { requestHeimdallSafeTxRefresh } from '../src/utils/heimdall.js';
+
+describe('Heimdall utils', () => {
+  it('requests an exact Safe transaction refresh with CSRF headers', async () => {
+    let requestedUrl: string | undefined;
+    let requestedInit: RequestInit | undefined;
+    const fetchFn = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requestedUrl =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      requestedInit = init;
+      return new Response(
+        JSON.stringify({
+          canonicalUrl: '/txs/safe/ethereum/0xhash',
+        }),
+        {
+          status: 202,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    };
+
+    const canonicalUrl = await requestHeimdallSafeTxRefresh({
+      baseUrl: 'https://heimdall.example/path',
+      chainName: 'ethereum mainnet',
+      safeAddress: '0xSafe',
+      safeTxHash: '0xHash/with/slashes',
+      fetchFn,
+    });
+
+    expect(requestedUrl).to.equal(
+      'https://heimdall.example/api/v1/multisigs/ethereum%20mainnet/0xSafe/txs/0xHash%2Fwith%2Fslashes/refresh',
+    );
+    expect(requestedInit?.method).to.equal('POST');
+    expect(new Headers(requestedInit?.headers).get('Origin')).to.equal(
+      'https://heimdall.example',
+    );
+    expect(new Headers(requestedInit?.headers).get('X-Heimdall-CSRF')).to.equal(
+      '1',
+    );
+    expect(requestedInit?.signal).to.be.instanceOf(AbortSignal);
+    expect(canonicalUrl).to.equal(
+      'https://heimdall.example/txs/safe/ethereum/0xhash',
+    );
+  });
+
+  it('retries a transaction that is not yet visible before succeeding', async () => {
+    let attempts = 0;
+    const retryDelays: number[] = [];
+    const fetchFn = async (): Promise<Response> => {
+      attempts += 1;
+      return attempts === 1
+        ? new Response(null, { status: 404 })
+        : new Response(
+            JSON.stringify({ canonicalUrl: '/txs/safe/ethereum/0xhash' }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            },
+          );
+    };
+
+    const canonicalUrl = await requestHeimdallSafeTxRefresh({
+      baseUrl: 'https://heimdall.example',
+      chainName: 'ethereum',
+      safeAddress: '0xSafe',
+      safeTxHash: '0xHash',
+      fetchFn,
+      sleepFn: async (ms) => {
+        retryDelays.push(ms);
+      },
+    });
+
+    expect(attempts).to.equal(2);
+    expect(retryDelays).to.deep.equal([250]);
+    expect(canonicalUrl).to.equal(
+      'https://heimdall.example/txs/safe/ethereum/0xhash',
+    );
+  });
+
+  it('rejects unsuccessful refresh requests after bounded retries', async () => {
+    let attempts = 0;
+    const fetchFn = async (): Promise<Response> => {
+      attempts += 1;
+      return new Response(null, { status: 503 });
+    };
+
+    try {
+      await requestHeimdallSafeTxRefresh({
+        baseUrl: 'https://heimdall.example',
+        chainName: 'ethereum',
+        safeAddress: '0xSafe',
+        safeTxHash: '0xHash',
+        fetchFn,
+        sleepFn: async () => {},
+      });
+      throw new Error('Expected refresh request to reject');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      if (error instanceof Error) {
+        expect(error.message).to.equal('Heimdall returned HTTP 503');
+      }
+    }
+    expect(attempts).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Summary

- notify Heimdall immediately after `propose-txs.ts` successfully submits each Safe transaction
- call the exact Safe transaction refresh endpoint with the required CSRF/origin headers
- retry the brief transaction-service visibility race and keep Heimdall failures warning-only
- allow operators to disable the hook or override the Heimdall base URL

## Why

The scheduled Heimdall Safe sync can leave operators waiting several minutes before a newly proposed transaction is indexed and parsed. The exact refresh hook makes the transaction available as soon as the Safe transaction service exposes it without changing proposal success semantics.

## Validation

- `pnpm --dir typescript/infra exec mocha --config ../sdk/.mocharc.json --timeout 10000 test/heimdall.test.ts`
- `pnpm exec oxlint --type-aware typescript/infra/src/utils/heimdall.ts typescript/infra/test/heimdall.test.ts`
- commit-time gitleaks, oxlint, and oxfmt hooks
- `git diff --check`

The clean-worktree package-wide TypeScript dependency build is currently blocked before infra checking by the existing Solidity build error `HH411` for the missing `dependencies` library imported by `AttributeCheckpointFraud.sol`.
