### PR TITLE
fix: assert expected owner on already-initialized routing ISM deploys

### DIFF
--- a/.changeset/ism-deploy-owner-guard.md
+++ b/.changeset/ism-deploy-owner-guard.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+`HyperlaneIsmFactory` now asserts the expected owner when a routing ISM deploy finds its target contract already initialized, instead of silently treating any existing initialization as success. This surfaces contention on a routing ISM's one-time `initialize()` call as a loud failure rather than a silent no-op.

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.hardhat-test.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.hardhat-test.ts
@@ -1,8 +1,13 @@
 /* eslint-disable no-console */
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import hre from 'hardhat';
 
-import { DomainRoutingIsm, TrustedRelayerIsm } from '@hyperlane-xyz/core';
+import {
+  DomainRoutingIsm,
+  DomainRoutingIsm__factory,
+  TrustedRelayerIsm,
+} from '@hyperlane-xyz/core';
 import { Address, WithAddress, randomInt } from '@hyperlane-xyz/utils';
 
 import { TestChainName, testChains } from '../consts/testChains.js';
@@ -17,7 +22,10 @@ import {
   randomMultisigIsmConfig,
 } from '../test/testUtils.js';
 
-import { HyperlaneIsmFactory } from './HyperlaneIsmFactory.js';
+import {
+  HyperlaneIsmFactory,
+  assertSubmodulesMatchExpected,
+} from './HyperlaneIsmFactory.js';
 import {
   DomainRoutingIsmConfig,
   IsmType,
@@ -27,6 +35,8 @@ import {
   TrustedRelayerIsmConfig,
 } from './types.js';
 import { moduleMatchesConfig } from './utils.js';
+
+chai.use(chaiAsPromised);
 
 describe('HyperlaneIsmFactory', async () => {
   let ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
@@ -490,5 +500,87 @@ describe('HyperlaneIsmFactory', async () => {
         newMailboxAddress,
       ));
     expect(matches).to.be.true;
+  });
+
+  // Guards the "resumed deploy / already initialized" branch in
+  // deployRoutingIsm: owner matching alone isn't enough to safely skip
+  // re-initialization — the configured submodules must match too, or a
+  // routing ISM correctly owned but wired to the wrong submodules would be
+  // silently accepted as if the deploy had succeeded.
+  describe('assertSubmodulesMatchExpected', () => {
+    let domainRoutingIsm: DomainRoutingIsm;
+    let domains: number[];
+    let modules: Address[];
+
+    before(async () => {
+      const config: DomainRoutingIsmConfig = {
+        type: IsmType.ROUTING,
+        owner: await multiProvider.getSignerAddress(chain),
+        domains: Object.fromEntries(
+          testChains
+            .filter(
+              (c) => c !== TestChainName.test1 && c !== TestChainName.test4,
+            )
+            .map((c) => [c, randomMultisigIsmConfig(3, 5)]),
+        ),
+      };
+      const ism = await ismFactory.deploy({ destination: chain, config });
+      domainRoutingIsm = DomainRoutingIsm__factory.connect(
+        ism.address,
+        multiProvider.getSigner(chain),
+      );
+      domains = (await domainRoutingIsm.domains()).map((d) => d.toNumber());
+      modules = await Promise.all(
+        domains.map((d) => domainRoutingIsm.module(d)),
+      );
+    });
+
+    it('does not throw when on-chain domains/modules match expected', async () => {
+      await expect(
+        assertSubmodulesMatchExpected(
+          domainRoutingIsm,
+          domains,
+          modules,
+          chain,
+        ),
+      ).to.not.be.rejected;
+    });
+
+    it('throws when a domain routes to a different module than expected', async () => {
+      const tamperedModules = [...modules];
+      tamperedModules[0] = randomAddress();
+      await expect(
+        assertSubmodulesMatchExpected(
+          domainRoutingIsm,
+          domains,
+          tamperedModules,
+          chain,
+        ),
+      ).to.be.rejectedWith('front-run');
+    });
+
+    it('throws when the expected domain count differs from what is configured on-chain', async () => {
+      await expect(
+        assertSubmodulesMatchExpected(
+          domainRoutingIsm,
+          domains.slice(1),
+          modules.slice(1),
+          chain,
+        ),
+      ).to.be.rejectedWith('front-run');
+    });
+
+    it('throws when an expected domain is not configured on-chain, even if the domain count matches', async () => {
+      const unconfiguredDomain = Math.max(...domains) + 1;
+      const tamperedDomains = [unconfiguredDomain, ...domains.slice(1)];
+      await expect(
+        assertSubmodulesMatchExpected(
+          domainRoutingIsm,
+          tamperedDomains,
+          modules,
+          chain,
+        ),
+      ).to.be.rejectedWith('front-run');
+    });
   });
 });

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -165,6 +165,42 @@ export function assertNoNestedCompositeIsm(
   }
 }
 
+/**
+ * Asserts that every domain -> submodule mapping already configured on a
+ * routing ISM found already-initialized matches what this deploy expected to
+ * configure. Owner matching alone isn't sufficient: a resumed deploy whose
+ * nested submodules landed on different addresses than this attempt (e.g. a
+ * raw-CREATE nested routing ISM re-deployed with a new nonce-based address),
+ * or someone else's initialize() call, can leave a routing ISM correctly
+ * owned but wired to the wrong submodules.
+ */
+async function assertSubmodulesMatchExpected(
+  routingIsm:
+    | DomainRoutingIsm
+    | IncrementalDomainRoutingIsm
+    | DefaultFallbackRoutingIsm,
+  expectedDomains: number[],
+  expectedModules: Address[],
+  destination: ChainName,
+): Promise<void> {
+  const existingDomains = (await routingIsm.domains()).map((domain) =>
+    domain.toNumber(),
+  );
+  assert(
+    existingDomains.length === expectedDomains.length,
+    `Routing ISM at ${routingIsm.address} on ${destination} was front-run: it has ${existingDomains.length} domains configured, expected ${expectedDomains.length} — refusing to proceed`,
+  );
+  for (let i = 0; i < expectedDomains.length; i++) {
+    const domain = expectedDomains[i];
+    const expectedModule = expectedModules[i];
+    const actualModule = await routingIsm.module(domain);
+    assert(
+      eqAddress(actualModule, expectedModule),
+      `Routing ISM at ${routingIsm.address} on ${destination} was front-run: domain ${domain} routes to ${actualModule}, expected ${expectedModule} — refusing to proceed`,
+    );
+  }
+}
+
 class IsmDeployer extends HyperlaneDeployer<{}, typeof ismFactories> {
   protected readonly cachingEnabled = false;
 
@@ -724,8 +760,14 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
             eqAddress(existingOwner, config.owner),
             `Fallback routing ISM at ${routingIsm.address} on ${destination} was front-run: address ${existingOwner} initialized it before this deploy could, and now owns it instead of the expected owner ${config.owner} — refusing to proceed`,
           );
+          await assertSubmodulesMatchExpected(
+            routingIsm,
+            safeConfigDomains,
+            submoduleAddresses,
+            destination,
+          );
           logger.debug(
-            `Skipping initialization of fallback routing ISM at ${routingIsm.address} — already initialized with the expected owner`,
+            `Skipping initialization of fallback routing ISM at ${routingIsm.address} — already initialized with the expected owner and submodules`,
           );
         }
       } else {
@@ -774,6 +816,12 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
             assert(
               eqAddress(existingOwner, owner),
               `Routing ISM at ${routingIsm.address} on ${destination} was front-run: address ${existingOwner} initialized it before this deploy could, and now owns it instead of the expected owner ${owner} — refusing to proceed`,
+            );
+            await assertSubmodulesMatchExpected(
+              routingIsm,
+              safeConfigDomains,
+              submoduleAddresses,
+              destination,
             );
           }
           return routingIsm;

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -174,7 +174,7 @@ export function assertNoNestedCompositeIsm(
  * or someone else's initialize() call, can leave a routing ISM correctly
  * owned but wired to the wrong submodules.
  */
-async function assertSubmodulesMatchExpected(
+export async function assertSubmodulesMatchExpected(
   routingIsm:
     | DomainRoutingIsm
     | IncrementalDomainRoutingIsm
@@ -190,9 +190,20 @@ async function assertSubmodulesMatchExpected(
     existingDomains.length === expectedDomains.length,
     `Routing ISM at ${routingIsm.address} on ${destination} was front-run: it has ${existingDomains.length} domains configured, expected ${expectedDomains.length} — refusing to proceed`,
   );
+  // Combined with the length check above, confirming every expected domain is
+  // present on-chain proves the two domain sets are exactly equal.
+  const existingDomainSet = new Set(existingDomains);
   for (let i = 0; i < expectedDomains.length; i++) {
     const domain = expectedDomains[i];
     const expectedModule = expectedModules[i];
+    // module() reverts with a raw "No ISM found for origin" string for a
+    // domain that isn't configured (or, on DefaultFallbackRoutingIsm, silently
+    // falls back to the mailbox default ISM instead) — check set membership
+    // first so a missing domain always surfaces as this clear message.
+    assert(
+      existingDomainSet.has(domain),
+      `Routing ISM at ${routingIsm.address} on ${destination} was front-run: expected domain ${domain} is not configured on-chain — refusing to proceed`,
+    );
     const actualModule = await routingIsm.module(domain);
     assert(
       eqAddress(actualModule, expectedModule),

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -697,8 +697,6 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
           await getZKSyncArtifactByContractName(config.type),
         );
         // TODO: Should verify contract here
-        // Defensive double-init guard (fresh CREATE address, so this never
-        // fires in practice; kept for safety).
         if (
           !(await isInitialized(
             this.multiProvider.getProvider(destination),
@@ -716,8 +714,18 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
             ),
           );
         } else {
+          // Already initialized by the time we got here — either a resumed
+          // deploy, or someone else won the race on this ISM's permissionless
+          // one-time initialize(). Refuse to proceed silently if it's the
+          // latter: a hijacked owner here would otherwise be treated as a
+          // successful deploy.
+          const existingOwner = await routingIsm.owner();
+          assert(
+            eqAddress(existingOwner, config.owner),
+            `Fallback routing ISM at ${routingIsm.address} on ${destination} was front-run: address ${existingOwner} initialized it before this deploy could, and now owns it instead of the expected owner ${config.owner} — refusing to proceed`,
+          );
           logger.debug(
-            `Skipping initialization of fallback routing ISM at ${routingIsm.address} — already initialized`,
+            `Skipping initialization of fallback routing ISM at ${routingIsm.address} — already initialized with the expected owner`,
           );
         }
       } else {
@@ -756,6 +764,16 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
               safeConfigDomains,
               submoduleAddresses,
               overrides,
+            );
+          } else {
+            // Already initialized — either a resumed deploy landing on the
+            // same deterministic address, or someone else won the race on
+            // this ISM's permissionless one-time initialize(). Refuse to
+            // proceed silently if it's the latter.
+            const existingOwner = await routingIsm.owner();
+            assert(
+              eqAddress(existingOwner, owner),
+              `Routing ISM at ${routingIsm.address} on ${destination} was front-run: address ${existingOwner} initialized it before this deploy could, and now owns it instead of the expected owner ${owner} — refusing to proceed`,
             );
           }
           return routingIsm;


### PR DESCRIPTION
## Summary
- `HyperlaneIsmFactory` now asserts the expected owner when a routing ISM deploy finds its target contract already initialized, instead of silently treating any existing initialization as success.
- Applies to both the `defaultFallbackRoutingIsm` deploy path and the zkSync `domainRoutingIsm`/`incrementalDomainRoutingIsm` path, which share the same "deploy then initialize" shape.
- If the owner doesn't match, the deploy now throws with a clear message identifying the address that front-ran the initialization, instead of quietly logging a debug line and returning as if the deploy succeeded.

## Test plan
- [x] `HyperlaneIsmFactory.hardhat-test.ts` + `EvmIsmModule.hardhat-test.ts` passing (84/84)
- [x] SDK `tsc` build clean
- [x] `oxlint` clean