### PR TITLE
fix(sdk): remove inactive Polkachu validator from forma default_ism

### DIFF
--- a/.changeset/forma-remove-polkachu-validator.md
+++ b/.changeset/forma-remove-polkachu-validator.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Removed the long-inactive Polkachu validator from the forma default multisig ISM config. Polkachu's forma validator has not signed a checkpoint since Feb 2026 (~5 months) as the chain winds down; this drops it from the source-of-truth validator set. The threshold is left unchanged pending a separate on-chain ISM update.

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -618,10 +618,6 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
     threshold: 4,
     validators: [
       {
-        address: '0x3f869C36110F00D10dC74cca3ac1FB133cf019ad',
-        alias: 'Polkachu',
-      },
-      {
         address: '0xE74c7632aF1De54D208f1b9e18B22988dDc8C4CE',
         alias: 'Imperator',
       },


### PR DESCRIPTION
## Summary
- Removes the long-inactive **Polkachu** validator from the forma `default_ism` validator set in `typescript/sdk/src/consts/multisigIsm.ts`.
- Polkachu's forma validator last signed a checkpoint on **19 Feb 2026** (~5 months ago) as forma deprecates (ENG-3897).
- **Threshold left unchanged (4)** per @Nam Chu Hoai — the on-chain ISM change is deliberately deferred.

## Context / important caveat
This is a **source-of-truth config change only**. The running relayer reads the validator set + threshold **live from the on-chain ISM** (`multisig_ism.validators_and_threshold()` in `rust/main/agents/relayer/src/msg/metadata/multisig/base.rs`), **not** from `multisigIsm.ts`. So this edit does **not** change relayer runtime behavior and does **not** deliver the 6 stuck forma→celestia TIA withdrawals (nonces 116282–116287) on its own — those remain blocked on the on-chain 4-of-N quorum until a separate on-chain ISM update lands (threshold 4→3 + removal of dead validators) or a 4th validator resyncs.

Incident: forma withdrawals stalled (KI-003, group 01KK5JPK77570TPF80B1VDMKMV).

## Test plan
- [ ] CI (lint / build / changeset check) green