### PR TITLE
fix(warp): treat paradex collateralDex annotation as collateral in altVM check

### DIFF
--- a/.changeset/warp-check-collateraldex-alias.md
+++ b/.changeset/warp-check-collateraldex-alias.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Updated the altVM warp route check to treat the paradex-only `collateralDex` registry annotation as equivalent to `collateral`. `collateralDex` has no matching SDK `TokenType`, and on-chain the leg is a standard collateral router, so the deriver reported `collateral` and the generic altVM diff produced a perpetual false-positive `type` ConfigMismatch in `check-warp-deploy` for the ETH/paradex and DIME/paradex routes.

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -27,6 +27,7 @@ import {
   derivedWarpConfigToCheckConfig,
   expandedDeployConfigToAltVmCheckConfig,
   getScaleViolations,
+  normalizeAltVmExpectedTokenType,
 } from './warpCheck.js';
 
 const MAILBOX = '0x000000000000000000000000000000000000b001';
@@ -407,6 +408,29 @@ describe('expandedDeployConfigToAltVmCheckConfig', () => {
 
     expect(result.hook).to.equal(undefined);
     expect(result.interchainSecurityModule).to.equal(undefined);
+  });
+});
+
+describe('normalizeAltVmExpectedTokenType', () => {
+  it("maps the paradex-only 'collateralDex' annotation to collateral", () => {
+    // collateralDex is a registry-only annotation with no SDK TokenType; the leg
+    // is a standard collateral router on-chain, so the checker must treat the two
+    // as equivalent instead of false-flagging a `type` ConfigMismatch.
+    expect(normalizeAltVmExpectedTokenType('collateralDex')).to.equal(
+      TokenType.collateral,
+    );
+  });
+
+  it('leaves known token types unchanged', () => {
+    expect(normalizeAltVmExpectedTokenType(TokenType.collateral)).to.equal(
+      TokenType.collateral,
+    );
+    expect(normalizeAltVmExpectedTokenType(TokenType.synthetic)).to.equal(
+      TokenType.synthetic,
+    );
+    expect(normalizeAltVmExpectedTokenType(TokenType.native)).to.equal(
+      TokenType.native,
+    );
   });
 });
 

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -274,6 +274,16 @@ function normalizeCrossCollateralRouters(
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
+// `collateralDex` is a paradex-only registry annotation for a collateral route
+// that performs a DEX conversion (see registry ETH/paradex & DIME/paradex). It has
+// no matching SDK TokenType, and on-chain the leg is a standard collateral router,
+// so the deriver reports `collateral`. Treat the annotation as its underlying
+// collateral type so the generic altVM diff doesn't false-flag a `type` mismatch.
+const COLLATERAL_DEX_TYPE_ALIAS = 'collateralDex';
+export function normalizeAltVmExpectedTokenType(type: string): string {
+  return type === COLLATERAL_DEX_TYPE_ALIAS ? TokenType.collateral : type;
+}
+
 export function expandedDeployConfigToAltVmCheckConfig(
   chain: ChainName,
   config: WarpRouteDeployConfigMailboxRequired[string],
@@ -331,7 +341,7 @@ export function expandedDeployConfigToAltVmCheckConfig(
   // altVmScaleMismatch (exact bigint fraction compare against the raw expected
   // config.scale), not through this generic diff. See checkWarpRouteDeployConfig.
   const result: AltVmCheckConfig = {
-    type: config.type,
+    type: normalizeAltVmExpectedTokenType(config.type),
     owner: normalizeAddress(config.owner, protocol),
     mailbox: normalizeAddress(config.mailbox, protocol),
     interchainSecurityModule: ismAddress,


### PR DESCRIPTION
## Summary

The `check-warp-deploy` job perpetually false-flagged a `type` ConfigMismatch for the ETH/paradex and DIME/paradex warp routes:

- `collateralDex` is a **paradex-only registry annotation** for a collateral route that performs a DEX conversion. It has no matching SDK `TokenType`.
- On-chain the leg is a standard collateral router, so the deriver reports `collateral`.
- The altVM expected-config path (`expandedDeployConfigToAltVmCheckConfig`) reads the raw registry `type` string, so `collateralDex` survived to the generic diff and never matched the derived `collateral`. (Confirmed via live Prometheus: `expected=collateralDex`, `actual=collateral`.)

This teaches the checker to normalize the `collateralDex` annotation to its underlying `collateral` type on the expected side only, so the diff no longer false-flags. A genuinely different on-chain type still surfaces as a violation.

## Changes

- Added exported `normalizeAltVmExpectedTokenType(type)` helper in `warpCheck.ts` and applied it to the expected-side `AltVmCheckConfig.type`.
- Unit tests for the mapping (collateralDex → collateral) and passthrough of known types.

## Test plan

- [x] `pnpm -C typescript/sdk build` (tsc clean)
- [x] `npx mocha ... warpCheck.test.ts` — 9 passing incl. 2 new