### PR TITLE
fix(infra): correct stale seismictestnet gas price

### DIFF
--- a/typescript/infra/config/environments/testnet4/gasPrices.json
+++ b/typescript/infra/config/environments/testnet4/gasPrices.json
@@ -64,7 +64,7 @@
     "decimals": 6
   },
   "seismictestnet": {
-    "amount": "46.566129041",
+    "amount": "1.2",
     "decimals": 9
   },
   "sepolia": {


### PR DESCRIPTION
## Summary

Corrects the stale `seismictestnet` gas price in `typescript/infra/config/environments/testnet4/gasPrices.json` from `46.566129041` gwei to `1.2` gwei (decimals unchanged at 9).

## Details

- seismictestnet's configured gas price was `46.566129041` gwei, which was stale/wrong — confirmed by directly querying `testnet-1.seismictest.net/rpc`'s `eth_gasPrice`, which returned ~1.2 gwei live.
- That stale value had already been pushed to the on-chain StorageGasOracle (`0x71775B071F77F1ce52Ece810ce084451a3045FFe` on sepolia, domain 5124), causing interchain gas quotes for sepolia → seismictestnet transfers to be ~38x too high (was quoting ~0.0251 ETH / ~$30 for a simple USDC transfer).
- Comparable L2 testnets in the same file (arbitrumsepolia, basesepolia, optimismsepolia) are all configured sub-1-gwei, making seismictestnet's old 46.57 gwei value a clear outlier.
- Validated the new value of `1.2` against a dry run of `typescript/infra/scripts/print-gas-prices.ts -e testnet4`, which independently recomputed seismictestnet's live gas price as exactly 1.2 gwei.
- The corrected value has already been deployed on-chain via `pnpm tsx scripts/deploy.ts -e testnet4 -m igp --chains sepolia` (sepolia's own StorageGasOracle now reports `gasPrice=1200000000`, i.e. 1.2 gwei, for the seismictestnet remote domain) — this PR just lands the matching config-file change so the repo's source of truth reflects the on-chain state.

## Test plan

- [ ] No other chain entries in `gasPrices.json` are modified