### PR TITLE
chore: remove frozen Imperator validator from ink default ISM

### DIFF
--- a/.changeset/remove-imperator-default-ism.md
+++ b/.changeset/remove-imperator-default-ism.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Removed the acquired Imperator validator from the ink default multisig ISM config, where it has been frozen (checkpoint stuck at index 129000), and lowered the ink threshold from 4 to 3 to preserve the minimum majority (`floor(n/2) + 1`). Imperator remains in the other default ISMs pending a planned batch rotation.

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -774,17 +774,12 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   ink: {
-    threshold: 4,
+    threshold: 3,
     validators: [
       {
         address: '0xb533b8b104522958b984fb258e0684dec0f1a6a5',
         alias: AW_VALIDATOR_ALIAS,
       },
-      {
-        address: '0xd207a6dfd887d91648b672727ff1aef6223cb15a',
-        alias: 'Imperator',
-      },
-
       {
         address: '0xa40203b5301659f1e201848d92f5e81f64f206f5',
         alias: 'Enigma',


### PR DESCRIPTION
## Summary

Removes the acquired **Imperator** validator from the **ink** default multisig ISM only, where it is currently **down** — its S3 `checkpoint_latest_index.json` has been frozen at index **129000** for 24h+ while the ink chain advanced past 129472. The threshold is lowered from **4 → 3** to preserve the minimum majority (`floor(n/2) + 1`).

Scoped down from the earlier 12-chain removal per @nambrot: only remove Imperator where it is down right now; the full rotation off the remaining chains (mostly Superchain/OP-stack) is deferred to a planned batch once we have a Superchain plan.

### Validator status check (2026-07-22)

| Chain | Imperator observed index | Chain leader | Verdict |
|-------|--------------------------|--------------|---------|
| ink | 129000 (flat 24h+, S3-confirmed) | 129472+ | **DOWN — removed here** |
| fraxtal | 31388 (= AW & Enigma, low traffic) | 31388 | up — deferred |
| celo, ethereum, forma, lisk, metal, mode, optimism, soneium, superseed, unichain, worldchain | tracking leader (gap ≤1) | — | up — deferred |

ink after removal (5 validators, threshold 3): AW, Enigma, Luganodes, Tessellated, Zee Prime.

## Test plan

- [x] `multisigIsm.test.ts` invariant tests pass (threshold ≥ `floor(n/2)+1`, valid validator set)

Tracked in [AW-720](https://linear.app/hyperlane-xyz/issue/AW-720/validator-operator-removals).