### PR TITLE
fix(ccip-server): regenerate Prisma client during builds

### DIFF
--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -12,8 +12,9 @@
   "type": "module",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "postinstall": "prisma generate",
-    "build": "tsc -p tsconfig.json",
+    "prisma:generate": "rm -rf ./src/generated/prisma && prisma generate",
+    "postinstall": "pnpm prisma:generate",
+    "build": "pnpm prisma:generate && tsc -p tsconfig.json",
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",


### PR DESCRIPTION
## Summary

- adds one `prisma:generate` script that clears incomplete generated output before regeneration
- runs it from both `postinstall` and `build`
- keeps the two-install `version:prepare` ordering introduced in #9071

## Why

#9071 removed Prisma generation from `build` after fixing the release-time race, but that made incremental workspaces fragile. When `pnpm install` is already up to date, it does not rerun `postinstall`; a missing or partially generated ignored client then makes the root build fail with `TS2307`.

Cleaning the generated directory before generation also makes the next run recover from an interrupted Prisma write instead of rejecting the non-empty partial directory.

## Impact

`pnpm build` now hydrates the CCIP server Prisma client independently of whether install lifecycle scripts ran. Release ordering remains unchanged, so installs do not overlap the Turbo version-update phase.

## Validation

- `pnpm -C typescript/ccip-server build`
- `pnpm build` (29/29 tasks passed)
- commit hooks, including gitleaks and formatting