### PR TITLE
chore(infra): disable nibiru in mainnet3 agent operations

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -131,7 +131,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     morph: true,
     nesa: true,
     nexus: true,
-    nibiru: true,
+    nibiru: false, // disabled — sole RPC (evm-rpc.nibiru.fi) down, removed from agent ops (AW-721)
     noble: true,
     oortmainnet: true,
     optimism: true,
@@ -232,7 +232,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     morph: true,
     nesa: true,
     nexus: true,
-    nibiru: true,
+    nibiru: false, // disabled — sole RPC (evm-rpc.nibiru.fi) down, removed from agent ops (AW-721)
     noble: true,
     oortmainnet: true,
     optimism: true,
@@ -333,7 +333,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     morph: true,
     nesa: true,
     nexus: true,
-    nibiru: true,
+    nibiru: false, // disabled — sole RPC (evm-rpc.nibiru.fi) down, removed from agent ops (AW-721)
     noble: true,
     oortmainnet: true,
     optimism: true,


### PR DESCRIPTION
## Summary

Disables **nibiru** for the relayer, validator, and scraper in `hyperlaneContextAgentChainConfig` (`typescript/infra/config/environments/mainnet3/agent.ts`).

Nibiru's sole configured RPC (`evm-rpc.nibiru.fi`, no fallback, chain-team operated) is **100% erroring** (verified 2026-07-22, 1h error rate = 1.0), so agents cannot index/relay/validate it. This trips four low-urgency nibiru alerts continuously (No new blocks, RPC error >60%, scraper sync behind, Validator RPC Quorum Risk).

Follows the existing `soon: false` / `taiko: false` disable pattern. Reverses cleanly once a working/fallback RPC is available.

Decision by @nambrot (2026-07-22): silence + remove from agent operations.

## Remaining (tracked in AW-721)

- [ ] Scale the running nibiru validator StatefulSet to 0 (do not uninstall).
- [ ] Deploy relayer/scraper with this config so nibiru drops from operations.

Tracked: https://linear.app/hyperlane-xyz/issue/AW-721/nibiru-remove-from-agent-operations-sole-rpc-down

## Test plan

- [ ] CI (agent-configs mainnet3/testnet4, infra-test) green