### PR TITLE
fix(infra): harden IGP upgrade rollout

### DIFF
--- a/.changeset/honest-igps-report.md
+++ b/.changeset/honest-igps-report.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Legacy IGP upgrades were fixed to recognize missing `PACKAGE_VERSION` selectors after aggregate providers wrap empty responses.

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -14,6 +14,7 @@ import {
   ChainMap,
   ChainName,
   ChainNameOrId,
+  ContractVerificationInput,
   EV5GnosisSafeTxBuilder,
   EvmHookModule,
   HookType,
@@ -39,6 +40,7 @@ import {
   isEVMLike,
   rootLogger,
 } from '@hyperlane-xyz/utils';
+import { readJson } from '@hyperlane-xyz/utils/fs';
 import { BigNumber, ethers } from 'ethers';
 
 import { Contexts } from '../../config/contexts.js';
@@ -47,7 +49,10 @@ import {
   getGovernanceSafes,
   getLegacyGovernanceIcas,
 } from '../../config/environments/mainnet3/governance/utils.js';
-import { DEPLOYER } from '../../config/environments/mainnet3/owners.js';
+import {
+  DEPLOYER,
+  upgradeTimelocks,
+} from '../../config/environments/mainnet3/owners.js';
 import { getEnvAddresses } from '../../config/registry.js';
 import { chainsToSkip, legacyIgpChains } from '../../src/config/chain.js';
 import { determineGovernanceType, Owner } from '../../src/governance.js';
@@ -60,6 +65,8 @@ import { getTimelockLogBlockRange } from '../../src/utils/timelock.js';
 import { writeAndFormatJsonAtPath } from '../../src/utils/utils.js';
 import {
   getArgs,
+  getModuleDirectory,
+  Modules,
   withChains,
   withContext,
   withOutputFile,
@@ -70,6 +77,10 @@ import { getEnvironmentConfig } from '../core-utils.js';
 const ETHEREUM_CHAIN: ChainName = 'ethereum';
 const OUTPUT_ROOT = 'igp-upgrade-output';
 const CANCUN_PROBE_INIT_CODE = '0x5f5f5d5f5c5f5260205ff3';
+const localSafeUpgradeTimelockGovernance: ChainMap<GovernanceType | undefined> =
+  {
+    arbitrum: GovernanceType.AbacusWorks,
+  };
 // Timelock upgrade idempotency needs log scanning because CREATE deployments
 // change the implementation address in the scheduled calldata across reruns.
 // The per-query block range comes from the same conservative timelock helper
@@ -131,6 +142,18 @@ type SimulatedDeployment = {
   address: Address;
   nonce: number;
 };
+
+type UpgradeGovernanceRoute = {
+  ownerType: Owner | null;
+  governanceType: GovernanceType;
+  timelockProposer?: 'ica' | 'safe';
+};
+
+class VerificationAwareEvmHookModule extends EvmHookModule {
+  get verificationInputs(): ChainMap<ContractVerificationInput[]> {
+    return this.deployer.verificationInputs;
+  }
+}
 
 class DryRunDeployMultiProvider extends MultiProvider {
   readonly simulatedDeployments: SimulatedDeployment[] = [];
@@ -203,6 +226,74 @@ class DryRunDeployMultiProvider extends MultiProvider {
 
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export async function determineUpgradeGovernanceRoute(
+  chain: ChainName,
+  ownerAddress: Address,
+): Promise<UpgradeGovernanceRoute> {
+  const upgradeTimelock = upgradeTimelocks[chain];
+  const localSafeGovernanceType = localSafeUpgradeTimelockGovernance[chain];
+  if (
+    upgradeTimelock &&
+    localSafeGovernanceType &&
+    eqAddress(upgradeTimelock, ownerAddress)
+  ) {
+    return {
+      ownerType: Owner.TIMELOCK,
+      governanceType: localSafeGovernanceType,
+      timelockProposer: 'safe',
+    };
+  }
+
+  return determineGovernanceType(chain, ownerAddress);
+}
+
+export function mergeVerificationInputs(
+  existingInputs: ChainMap<ContractVerificationInput[]>,
+  newInputs: ChainMap<ContractVerificationInput[]>,
+): ChainMap<ContractVerificationInput[]> {
+  const mergedInputs: ChainMap<ContractVerificationInput[]> =
+    deepCopy(existingInputs);
+  for (const [chain, inputs] of Object.entries(newInputs)) {
+    const chainInputs = (mergedInputs[chain] ??= []);
+    for (const input of inputs) {
+      if (
+        chainInputs.some(
+          (existing) =>
+            existing.name === input.name &&
+            eqAddress(existing.address, input.address) &&
+            existing.constructorArguments === input.constructorArguments &&
+            existing.isProxy === input.isProxy,
+        )
+      ) {
+        continue;
+      }
+      chainInputs.push(input);
+    }
+  }
+  return mergedInputs;
+}
+
+async function writeVerificationInputs(
+  environment: 'mainnet3',
+  newInputs: ChainMap<ContractVerificationInput[]>,
+) {
+  if (Object.keys(newInputs).length === 0) return;
+
+  const verificationPath = join(
+    getModuleDirectory(environment, Modules.INTERCHAIN_GAS_PAYMASTER),
+    'verification.json',
+  );
+  const existingInputs =
+    readJson<ChainMap<ContractVerificationInput[]>>(verificationPath);
+  await writeAndFormatJsonAtPath(
+    verificationPath,
+    mergeVerificationInputs(existingInputs, newInputs),
+  );
+  rootLogger.info(
+    `Wrote deployment verification inputs to ${verificationPath}`,
+  );
 }
 
 export function isMissingPackageVersionError(error: unknown): boolean {
@@ -569,11 +660,13 @@ async function buildHookUpdateTransactions({
   config,
   addresses,
   multiProvider,
+  onVerificationInputs,
 }: {
   chain: ChainName;
   config: IgpConfig;
   addresses: ChainMap<Address>;
   multiProvider: MultiProvider;
+  onVerificationInputs?: (inputs: ContractVerificationInput[]) => void;
 }): Promise<AnnotatedEV5Transaction[]> {
   assert(addresses.mailbox, `[${chain}] missing mailbox address`);
   assert(addresses.proxyAdmin, `[${chain}] missing proxyAdmin address`);
@@ -583,7 +676,7 @@ async function buildHookUpdateTransactions({
   );
 
   const targetConfig = getTargetIgpConfig(chain, config);
-  const module = new EvmHookModule(multiProvider, {
+  const module = new VerificationAwareEvmHookModule(multiProvider, {
     chain,
     config: targetConfig,
     addresses: {
@@ -594,7 +687,11 @@ async function buildHookUpdateTransactions({
     },
   });
 
-  return module.update(deepCopy(targetConfig));
+  try {
+    return await module.update(deepCopy(targetConfig));
+  } finally {
+    onVerificationInputs?.(module.verificationInputs[chain] ?? []);
+  }
 }
 
 export function getUpgradeTargetImplementation({
@@ -631,6 +728,39 @@ export function getUpgradeTargetImplementation({
   return undefined;
 }
 
+export async function executeDeployerOwnedCall({
+  chain,
+  call,
+  multiProvider,
+}: {
+  chain: ChainName;
+  call: UpgradeCall;
+  multiProvider: MultiProvider;
+}): Promise<{
+  status: 'error' | 'executed';
+  detail: string;
+}> {
+  try {
+    rootLogger.info(
+      `[${chain}] executing deployer-key upgrade: ${call.description}`,
+    );
+    await multiProvider.sendTransaction(chain, {
+      to: call.to,
+      data: call.data,
+      value: call.value,
+    });
+    return {
+      status: 'executed',
+      detail: `executed deployer-key upgrade: ${call.description}`,
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      detail: `deployer-key upgrade failed: ${formatError(error)}`,
+    };
+  }
+}
+
 async function routeGovernedCall({
   groups,
   icaGroups,
@@ -657,16 +787,15 @@ async function routeGovernedCall({
     | 'timelock queued'
     | 'scheduled'
     | 'done'
+    | 'error'
     | 'manual'
     | 'executed';
   detail: string;
   ownerType: Owner | null;
   governanceType: GovernanceType;
 }> {
-  const { ownerType, governanceType } = await determineGovernanceType(
-    chain,
-    ownerAddress,
-  );
+  const { ownerType, governanceType, timelockProposer } =
+    await determineUpgradeGovernanceRoute(chain, ownerAddress);
 
   switch (ownerType) {
     case Owner.SAFE:
@@ -710,6 +839,7 @@ async function routeGovernedCall({
           timelockAddress: ownerAddress,
           innerCall: call,
           idempotency: timelockIdempotency,
+          proposerType: timelockProposer,
         })),
         ownerType,
         governanceType,
@@ -724,29 +854,11 @@ async function routeGovernedCall({
           governanceType,
         };
       }
-      try {
-        rootLogger.info(
-          `[${chain}] executing deployer-key upgrade: ${call.description}`,
-        );
-        await multiProvider.sendTransaction(chain, {
-          to: call.to,
-          data: call.data,
-          value: call.value,
-        });
-        return {
-          status: 'executed',
-          detail: `executed deployer-key upgrade: ${call.description}`,
-          ownerType,
-          governanceType,
-        };
-      } catch (error) {
-        return {
-          status: 'manual',
-          detail: `deployer-key upgrade failed: ${error instanceof Error ? error.message : String(error)}`,
-          ownerType,
-          governanceType,
-        };
-      }
+      return {
+        ...(await executeDeployerOwnedCall({ chain, call, multiProvider })),
+        ownerType,
+        governanceType,
+      };
     default:
       return {
         status: 'manual',
@@ -901,6 +1013,7 @@ async function routeTimelockCall({
   timelockAddress,
   innerCall,
   idempotency,
+  proposerType,
 }: {
   groups: Map<string, SafeCallGroup>;
   ica: InterchainAccount;
@@ -909,6 +1022,7 @@ async function routeTimelockCall({
   timelockAddress: Address;
   innerCall: UpgradeCall;
   idempotency?: TimelockIdempotency;
+  proposerType?: 'ica' | 'safe';
 }): Promise<{
   status: 'timelock queued' | 'scheduled' | 'done';
   detail: string;
@@ -967,10 +1081,10 @@ async function routeTimelockCall({
     description: `Schedule timelock operation ${operationId}: ${innerCall.description}`,
   };
 
-  const proposer =
-    chain === ETHEREUM_CHAIN
-      ? getGovernanceSafes(governanceType)[ETHEREUM_CHAIN]
-      : getGovernanceIcaAddress(chain, governanceType);
+  const proposeViaSafe = chain === ETHEREUM_CHAIN || proposerType === 'safe';
+  const proposer = proposeViaSafe
+    ? getGovernanceSafes(governanceType)[chain]
+    : getGovernanceIcaAddress(chain, governanceType);
   assert(
     proposer,
     `[${chain}] no ${governanceType} proposer address available for timelock ${timelockAddress}`,
@@ -980,8 +1094,8 @@ async function routeTimelockCall({
     `[${chain}] ${proposer} does not have PROPOSER_ROLE on timelock ${timelockAddress}`,
   );
 
-  if (chain === ETHEREUM_CHAIN) {
-    addSafeCall(groups, ETHEREUM_CHAIN, governanceType, scheduleCall);
+  if (proposeViaSafe) {
+    addSafeCall(groups, chain, governanceType, scheduleCall);
   } else {
     await addIcaSafeCall({
       groups,
@@ -1272,6 +1386,7 @@ async function main() {
   const safeGroups = new Map<string, SafeCallGroup>();
   const icaGroups = new Map<string, IcaCallGroup>();
   const plans: ChainPlan[] = [];
+  const verificationInputs: ChainMap<ContractVerificationInput[]> = {};
   const targetChainIndexes = new Map(
     targetChains.map((chain, index) => [chain, index]),
   );
@@ -1335,10 +1450,8 @@ async function main() {
           currentVersion,
         });
       if (implementationUpgradeRequired) {
-        const { ownerType, governanceType } = await determineGovernanceType(
-          chain,
-          proxyAdminOwner,
-        );
+        const { ownerType, governanceType } =
+          await determineUpgradeGovernanceRoute(chain, proxyAdminOwner);
         const legacyIcaOwner = getLegacyGovernanceIcas(governanceType)[chain];
         const isUnroutable =
           ownerType === Owner.UNKNOWN ||
@@ -1380,6 +1493,11 @@ async function main() {
         config,
         addresses,
         multiProvider,
+        onVerificationInputs: propose
+          ? (inputs) => {
+              if (inputs.length > 0) verificationInputs[chain] = inputs;
+            }
+          : undefined,
       });
       const simulatedDeployments =
         multiProvider instanceof DryRunDeployMultiProvider
@@ -1508,6 +1626,10 @@ async function main() {
       (targetChainIndexes.get(a.chain) ?? Number.MAX_SAFE_INTEGER) -
       (targetChainIndexes.get(b.chain) ?? Number.MAX_SAFE_INTEGER),
   );
+
+  if (propose) {
+    await writeVerificationInputs(environment, verificationInputs);
+  }
 
   await flushIcaCallGroups({
     safeGroups,

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -1,13 +1,19 @@
 import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
+import { ContractVerificationInput, MultiProvider } from '@hyperlane-xyz/sdk';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
+import sinon from 'sinon';
 
+import { Owner } from '../src/governance.js';
 import { GovernanceType } from '../src/governanceTypes.js';
 import { getTimelockLogBlockRange } from '../src/utils/timelock.js';
 import {
   callMatchesTimelockIdempotency,
+  determineUpgradeGovernanceRoute,
+  executeDeployerOwnedCall,
   getUpgradeTargetImplementation,
   isMissingPackageVersionError,
+  mergeVerificationInputs,
   splitProposableGroups,
 } from '../scripts/igp/upgrade-compatible-igps.js';
 
@@ -52,6 +58,63 @@ describe('upgrade-compatible-igps', () => {
         }),
       ).to.equal(false);
     });
+  });
+
+  it('routes the Arbitrum upgrade timelock through the local AW Safe', async () => {
+    expect(
+      await determineUpgradeGovernanceRoute(
+        'arbitrum',
+        '0xAC98b0cD1B64EA4fe133C6D2EDaf842cE5cF4b01',
+      ),
+    ).to.deep.equal({
+      ownerType: Owner.TIMELOCK,
+      governanceType: GovernanceType.AbacusWorks,
+      timelockProposer: 'safe',
+    });
+  });
+
+  it('merges real deployment verification inputs without duplicates', () => {
+    const existingInput: ContractVerificationInput = {
+      name: 'InterchainGasPaymaster',
+      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      constructorArguments: '',
+      isProxy: false,
+    };
+    const newInput: ContractVerificationInput = {
+      ...existingInput,
+      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    };
+    const duplicateInput = {
+      ...existingInput,
+      address: existingInput.address.toUpperCase().replace('0X', '0x'),
+    };
+
+    expect(
+      mergeVerificationInputs(
+        { arbitrum: [existingInput] },
+        { arbitrum: [duplicateInput, newInput] },
+      ),
+    ).to.deep.equal({ arbitrum: [existingInput, newInput] });
+  });
+
+  it('reports failed deployer-owned execution as an error', async () => {
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    sinon
+      .stub(multiProvider, 'sendTransaction')
+      .rejects(new Error('submission failed'));
+    const result = await executeDeployerOwnedCall({
+      chain: 'test1',
+      call: {
+        to: '0x1111111111111111111111111111111111111111',
+        data: '0x1234',
+        value: BigNumber.from(0),
+        description: 'upgrade',
+      },
+      multiProvider,
+    });
+
+    expect(result.status).to.equal('error');
+    expect(result.detail).to.include('submission failed');
   });
 
   it('uses conservative timelock log block ranges', () => {

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -19,7 +19,6 @@ import {
   OPStackHook,
   OPStackIsm__factory,
   Ownable__factory,
-  PackageVersioned__factory,
   PausableHook,
   PausableHook__factory,
   ProxyAdmin__factory,
@@ -72,7 +71,7 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
 import { ChainName, ChainNameOrId } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
-import { isMissingSelectorRevert } from '../utils/contract.js';
+import { fetchPackageVersion } from '../utils/contract.js';
 
 import {
   VERSION_ERROR_MESSAGE,
@@ -487,20 +486,11 @@ export class EvmHookModule extends HyperlaneModule<
     const igpAddress = this.args.addresses.deployedHook;
     const igpInterface = InterchainGasPaymaster__factory.createInterface();
     const provider = this.multiProvider.getProvider(this.domainId);
-    let currentVersion: string | undefined;
-    try {
-      currentVersion = await PackageVersioned__factory.connect(
-        igpAddress,
-        provider,
-      ).PACKAGE_VERSION();
-    } catch (error) {
-      if (!isMissingSelectorRevert(error)) {
-        throw error;
-      }
-      this.logger.debug(
-        `IGP ${igpAddress} on ${this.chain} does not expose PACKAGE_VERSION`,
-      );
-    }
+    const currentVersion = await fetchPackageVersion(
+      provider,
+      igpAddress,
+      this.logger,
+    );
 
     // Upgrade IGP proxy implementation only if contractVersion is specified in config
     if (targetConfig.contractVersion && (await isProxy(provider, igpAddress))) {
@@ -509,12 +499,9 @@ export class EvmHookModule extends HyperlaneModule<
         VERSION_ERROR_MESSAGE,
       );
 
-      if (
-        !currentVersion ||
-        compareVersions(targetConfig.contractVersion, currentVersion) > 0
-      ) {
+      if (compareVersions(targetConfig.contractVersion, currentVersion) > 0) {
         this.logger.info(
-          `Upgrading IGP implementation from ${currentVersion ?? 'unknown'} to ${targetConfig.contractVersion}`,
+          `Upgrading IGP implementation from ${currentVersion} to ${targetConfig.contractVersion}`,
         );
         const newImpl = await this.deployer.deployContractFromFactory(
           this.chain,
@@ -597,7 +584,7 @@ export class EvmHookModule extends HyperlaneModule<
     // update quote signers only if explicitly specified in target config
     // and IGP supports them (detected from on-chain read or version upgrade)
     const offchainFeeQuotingVersion =
-      targetConfig.contractVersion ?? currentVersion ?? undefined;
+      targetConfig.contractVersion ?? currentVersion;
     const supportsOffchainFeeQuoting = igpSupportsOffchainFeeQuoting({
       igpVersion: targetConfig.igpVersion,
       contractVersion: offchainFeeQuotingVersion,


### PR DESCRIPTION
### Description

Hardens the token IGP upgrade rollout path before production batches:

- recognizes legacy IGP `PACKAGE_VERSION` calls after SmartProvider wraps empty responses, while continuing to propagate genuine RPC failures;
- routes Arbitrum's upgrade timelock schedule call through the local Abacus Works Safe and verifies its proposer role;
- persists the hook deployer's real verification inputs to `mainnet3/igp/verification.json` during `--propose` runs, including deployments made before a later planning error; dry-run artifacts remain excluded;
- reports failed deployer-owned execution as an error so the script exits nonzero.

The root causes were split between the SDK module using the narrower missing-selector matcher, the rollout script assuming every non-Ethereum timelock proposer was an ICA, and the upgrade path bypassing the standard deploy flow that writes verification inputs.

### Drive-by changes

None. Nibiru handling is intentionally unchanged here; it was disabled in mainnet3 agent operations by #9089 while its RPC is unhealthy.

### Related issues

Follow-up to #8443.

### Backward compatibility

Yes. Existing governance routes are unchanged. The only special route is the configured Arbitrum upgrade timelock. The SDK now uses the existing legacy-version helper for the same version read.

### Testing

- `pnpm -C typescript/sdk check`
- `pnpm -C typescript/infra check`
- SDK contract utility tests: 9 passing
- IGP rollout tests: 8 passing
- focused `EvmHookModule` Hardhat tests: 2 passing
- targeted oxlint and oxfmt checks
- live Arbitrum dry run: produced one `timelock queued` plan for ProxyAdmin `0x80Cebd56A65e46c474a1A101e89E76C4c51D179c`, scheduled by local AW Safe `0x03fD5BE9DF85F0017dC7F4DC3068dDF64fffF25e`; no verification JSON changes in dry-run mode

No `--propose` run was performed.
