### PR TITLE
fix(infra): pin WBTC/eclipse & USDC/ancient8 proxyAdmin owner via ownerOverrides

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
@@ -36,6 +36,13 @@ export const getAncient8EthereumUSDCWarpConfig = async (
     // for the hook module. The hook configuration is the Ethereum
     // default hook for the Ancient8 remote (no routing).
     hook: '0x19b2cF952b70b217c90FC408714Fbc1acD29A6A8',
+    // The ProxyAdmin is owned by the legacy Safe, not the standard AW owner.
+    // Set ownerOverrides.proxyAdmin (not just proxyAdmin.owner) since config
+    // expansion gives ownerOverrides.proxyAdmin precedence.
+    ownerOverrides: {
+      ...abacusWorksEnvOwnerConfig.ethereum.ownerOverrides,
+      proxyAdmin: regularSafes.ethereum,
+    },
     proxyAdmin: {
       owner: regularSafes.ethereum,
     },
@@ -47,6 +54,10 @@ export const getAncient8EthereumUSDCWarpConfig = async (
     type: TokenType.synthetic,
     // Uses the default ISM
     interchainSecurityModule: ethers.constants.AddressZero,
+    ownerOverrides: {
+      ...abacusWorksEnvOwnerConfig.ancient8.ownerOverrides,
+      proxyAdmin: regularIcas.ancient8,
+    },
     proxyAdmin: {
       owner: regularIcas.ancient8,
     },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAncient8EthereumUSDCWarpConfig.ts
@@ -13,8 +13,11 @@ import {
   RouterConfigWithoutOwner,
   tokens,
 } from '../../../../../src/config/warp.js';
-import { regularIcas } from '../../governance/ica/regular.js';
 import { regularSafes } from '../../governance/safe/regular.js';
+
+// Legacy ProxyAdmin owner for the Ancient8 synthetic leg, as recorded in the
+// registry deploy config. regularIcas has no ancient8 entry.
+const ANCIENT8_PROXY_ADMIN_OWNER = '0x72Ba22a1a8B8c2b7B1795a35a1E05c058217E9a7';
 
 export const getAncient8EthereumUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
@@ -54,12 +57,15 @@ export const getAncient8EthereumUSDCWarpConfig = async (
     type: TokenType.synthetic,
     // Uses the default ISM
     interchainSecurityModule: ethers.constants.AddressZero,
+    // regularIcas has no ancient8 entry, so pin the legacy ProxyAdmin owner
+    // (recorded in the registry deploy config) directly. Set
+    // ownerOverrides.proxyAdmin since config expansion gives it precedence.
     ownerOverrides: {
       ...abacusWorksEnvOwnerConfig.ancient8.ownerOverrides,
-      proxyAdmin: regularIcas.ancient8,
+      proxyAdmin: ANCIENT8_PROXY_ADMIN_OWNER,
     },
     proxyAdmin: {
-      owner: regularIcas.ancient8,
+      owner: ANCIENT8_PROXY_ADMIN_OWNER,
     },
   };
 

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.ts
@@ -33,6 +33,13 @@ export const getEclipseEthereumWBTCWarpConfig = async (
     type: TokenType.collateral,
     token: tokens.ethereum.WBTC,
     interchainSecurityModule: ethers.constants.AddressZero,
+    // The ProxyAdmin is owned by the legacy Safe, not the standard AW owner.
+    // Set ownerOverrides.proxyAdmin (not just proxyAdmin.owner) since config
+    // expansion gives ownerOverrides.proxyAdmin precedence.
+    ownerOverrides: {
+      ...abacusWorksEnvOwnerConfig.ethereum.ownerOverrides,
+      proxyAdmin: regularSafes.ethereum,
+    },
     proxyAdmin: {
       owner: regularSafes.ethereum,
     },


### PR DESCRIPTION
## Summary

Fixes the persistent `check-warp-deploy` drift on the **WBTC/eclipse** ethereum leg (`proxyAdmin.owner` expected `0x3965AC…` vs on-chain `0x562Dfaac…`), and the same latent bug in the **USDC/ancient8** getter.

### Root cause
The eclipse WBTC and ancient8 USDC config getters set `proxyAdmin.owner` (to the legacy Safe / ICA), but config expansion (`typescript/sdk` `configUtils.ts` `expandWarpDeployConfig`) gives `ownerOverrides.proxyAdmin` **precedence** over `proxyAdmin.owner`:

```ts
owner:
  config.ownerOverrides?.proxyAdmin ??
  chainConfig.proxyAdmin.owner ??
  config.owner;
```

`getRouterConfigsForAllVms` (`scripts/core-utils.ts`) injects `ownerOverrides.proxyAdmin = upgradeTimelocks[chain] ?? owner` for **every** chain. For ethereum there is no upgrade timelock, so the override resolves to the standard AW owner (`0x3965AC…`). That override silently beats the getter's explicit `proxyAdmin.owner = regularSafes.ethereum` (`0x562Dfaac…`), so the check expected the wrong owner and drift never cleared regardless of registry pins.

### Fix
Set `ownerOverrides.proxyAdmin` (merged over the injected overrides) in both getters so the intended ProxyAdmin owner is what expansion honors:
- WBTC/eclipse ethereum leg → `regularSafes.ethereum` (legacy Safe `0x562Dfaac…`)
- USDC/ancient8 ethereum leg → `regularSafes.ethereum`
- USDC/ancient8 ancient8 leg → `regularIcas.ancient8`

## Test plan
- [x] `tsc --noEmit` in `typescript/infra` passes
- [ ] `check-warp-deploy` k8s job shows WBTC/eclipse ethereum `proxyAdmin.owner` no longer drifting