### PR TITLE
fix(sdk): skip decimals diff for AltVM native tokens in warp check

### DIFF
--- a/.changeset/warp-check-altvm-native-decimals-skip.md
+++ b/.changeset/warp-check-altvm-native-decimals-skip.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The warp check no longer emits a spurious `decimals` ConfigMismatch for AltVM native tokens (e.g. Aleo `AleoHypNative`). The derived actual side has no decimals field for native tokens (`DerivedNativeWarpConfig` omits it), while the deploy-config-derived expected side carries decimals from the warp core config, so the field is now excluded from the diff on the expected side for AltVM native token types to keep both sides symmetric.

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -458,6 +458,43 @@ describe('expandedDeployConfigToAltVmCheckConfig', () => {
 
     expect(result).to.not.have.property('token');
   });
+
+  it('drops decimals for AltVM native tokens, whose reader side never carries decimals', () => {
+    // DerivedNativeWarpConfig has no decimals field, so the actual side omits it
+    // for AltVM native tokens (e.g. Aleo AleoHypNative). The expected side must
+    // omit it too even when the core config specifies decimals, otherwise it
+    // emits a permanent false-positive `decimals` ConfigMismatch.
+    const result = expandedDeployConfigToAltVmCheckConfig(
+      testSealevelChain.name,
+      {
+        decimals: 6,
+        destinationGas: {},
+        mailbox: MAILBOX,
+        owner: OWNER,
+        type: TokenType.native,
+      },
+      buildMultiProvider(),
+    );
+
+    expect(result).to.not.have.property('decimals');
+  });
+
+  it('retains decimals for AltVM collateral tokens, which do carry on-chain decimals', () => {
+    const result = expandedDeployConfigToAltVmCheckConfig(
+      testSealevelChain.name,
+      {
+        decimals: 6,
+        destinationGas: {},
+        mailbox: MAILBOX,
+        owner: OWNER,
+        token: TOKEN_A,
+        type: TokenType.collateral,
+      },
+      buildMultiProvider(),
+    );
+
+    expect(result.decimals).to.equal(6);
+  });
 });
 
 describe('normalizeAltVmExpectedTokenType', () => {

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -380,7 +380,14 @@ export function expandedDeployConfigToAltVmCheckConfig(
   // positives from unresolved metadata on the expected side. Cosmos SDK's
   // decimals=0 placeholder is excluded on the actual side (see
   // derivedWarpConfigToCheckConfig), so it's excluded here too for symmetry.
-  if (protocol !== ProtocolType.CosmosNative && !isNullish(config.decimals)) {
+  // AltVM native tokens (e.g. Aleo AleoHypNative) never carry decimals on the
+  // actual side -- DerivedNativeWarpConfig has no decimals field -- so their
+  // core-config decimals is excluded here to keep both sides symmetric.
+  if (
+    protocol !== ProtocolType.CosmosNative &&
+    normalizeAltVmExpectedTokenType(config.type) !== TokenType.native &&
+    !isNullish(config.decimals)
+  ) {
     result.decimals = config.decimals;
   }
 


### PR DESCRIPTION
## Summary
- `hyperlane warp check` emitted a spurious `decimals` ConfigMismatch for AltVM native tokens (e.g. Aleo `AleoHypNative` on the ALEO/aleo route).
- Root cause: an asymmetry in the AltVM checker. The derived **actual** side (`derivedWarpConfigToCheckConfig`) has no decimals for native tokens because `DerivedNativeWarpConfig` omits the field, while the **expected** side (`expandedDeployConfigToAltVmCheckConfig`) carries decimals from the warp core config.
- Fix: exclude decimals on the expected side for native token types, mirroring the existing synthetic-`token` exclusion pattern so both sides stay symmetric.

## Verification
- `hyperlane warp check --id ALEO/aleo` returns "No violations found" with this change (was previously reporting `decimals ACTUAL "" / EXPECTED 6`).

cc @troykessler