### PR TITLE
fix(infra): allowlist USDT/eclipsemainnet tron ownerStatus violation

### DIFF
--- a/typescript/infra/scripts/check/owner-status-skip.ts
+++ b/typescript/infra/scripts/check/owner-status-skip.ts
@@ -42,6 +42,15 @@ export const OWNER_STATUS_SKIP: OwnerStatusSkip[] = [
     chain: 'coti',
     owner: '0xdF2E2886d23ba57F996C203D2Ccd9dCa6373590C',
   },
+  // Tron has no nonces, so TronJsonRpcProvider.getTransactionCount always
+  // returns 0; any Tron EOA owner (no contract code) therefore derives as
+  // Inactive and gets forced to expected=Active. This owner is the intended
+  // on-chain owner, so allowlist the ownerStatus violation.
+  {
+    warpRouteId: 'USDT/eclipsemainnet',
+    chain: 'tron',
+    owner: '0x74E009ed8f6d7BBEce015c8A1E7076084e8aEBA6',
+  },
 ];
 
 // ownerStatus virtual-config violations carry a field path of the form


### PR DESCRIPTION
## Summary
- The `USDT/eclipsemainnet` warp check emits a permanent `ownerStatus` `ConfigMismatch` on the tron leg (`0x74E009ed…6`: EXPECTED active / ACTUAL inactive).
- Root cause: Tron has no nonces, so `TronJsonRpcProvider.getTransactionCount()` is hardcoded to return `0`. `isAddressActive()` treats an address as active only if it has contract code **or** nonce > 0. A Tron EOA owner (no code) therefore always derives as `Inactive`, and `expandWarpDeployConfig` forces the expected side to `Active` — an unresolvable false positive for any Tron EOA owner.
- The owner is the intended on-chain owner (there is no registry value to change), so this allowlists only that specific `{route, chain, owner}` ownerStatus violation, matching the existing legacy inactive-EOA entries (BEST, GNET, USDC/WBTC-coti). Every other check on the route still runs, and a future owner change on this route+chain will still surface.

## Note
The already-firing PushGateway series for this violation won't clear on merge alone — it needs the one-time `clear-skipped-owner-status.ts` rollout clear (separate, gated step).

cc @troykessler