### PR TITLE
fix(infra): accept on-chain USDC/subtensor rebalancing bridges

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getSubtensorUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getSubtensorUSDCWarpConfig.ts
@@ -9,7 +9,10 @@ import { usdcTokenAddresses } from '../cctp.js';
 import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
 import { WarpRouteIds } from '../warpIds.js';
 
-import { getUSDCRebalancingBridgesConfigFor } from './utils.js';
+import {
+  getUSDCRebalancingBridgesConfigFor,
+  mergeAllowedBridges,
+} from './utils.js';
 
 const deploymentChains = [
   'arbitrum',
@@ -24,6 +27,20 @@ const deploymentChains = [
 type DeploymentChain = (typeof deploymentChains)[number];
 
 const syntheticChain: DeploymentChain = 'subtensor';
+
+// getUSDCRebalancingBridgesConfigFor intersects with the CCTP V1 route chains,
+// which excludes subtensor (domain 964) and solanamainnet (domain 1399811149).
+// On-chain, each collateral leg also allows rebalancing to those two domains via
+// its own bridge, so hardcode them to accept the deployed state.
+const SUBTENSOR_DOMAIN = '964';
+const SOLANA_DOMAIN = '1399811149';
+const onchainRebalancingBridgeByChain: Record<string, string> = {
+  arbitrum: '0x8a82186ea618b91d13a2041fb7ac31bf01c02ad2',
+  base: '0x5c4afb7e23b1dc1b409dc1702f89c64527b25975',
+  ethereum: '0xedcbaa585fd0f80f20073f9958246476466205b8',
+  polygon: '0xa62f45662809f5f6535b58bae9a572a2ec4a1f84',
+  unichain: '0x296af86bff91b23cf980f6a443bc15a3a5d30682',
+};
 
 export const getSubtensorUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
@@ -81,6 +98,14 @@ export const getSubtensorUSDCWarpConfig = async (
         const { allowedRebalancers, allowedRebalancingBridges } =
           currentRebalancingConfig;
 
+        const onchainBridge = onchainRebalancingBridgeByChain[currentChain];
+        const mergedBridges = onchainBridge
+          ? mergeAllowedBridges(allowedRebalancingBridges, {
+              [SUBTENSOR_DOMAIN]: [{ bridge: onchainBridge }],
+              [SOLANA_DOMAIN]: [{ bridge: onchainBridge }],
+            })
+          : allowedRebalancingBridges;
+
         return [
           currentChain,
           {
@@ -89,7 +114,7 @@ export const getSubtensorUSDCWarpConfig = async (
             mailbox: routerConfig[currentChain].mailbox,
             owner,
             allowedRebalancers,
-            allowedRebalancingBridges,
+            allowedRebalancingBridges: mergedBridges,
             contractVersion: '8.1.1',
           },
         ];


### PR DESCRIPTION
## Summary
- `getSubtensorUSDCWarpConfig` builds `allowedRebalancingBridges` via `getUSDCRebalancingBridgesConfigFor`, which intersects the deployment chains with the CCTP V1 route. That intersection drops subtensor (domain `964`) and solanamainnet (domain `1399811149`).
- On-chain, every collateral leg (arbitrum, base, ethereum, polygon, unichain) additionally allows rebalancing to those two domains via that chain's own bridge.
- Hardcode the deployed bridge per collateral chain for domains `964` + `1399811149` via `mergeAllowedBridges`, so check-warp-deploy matches the on-chain state.

Clears 10 `hyperlane_check_violations` series (`USDC/subtensor`, `allowedRebalancingBridges.964` / `.1399811149`).

## Test plan
- [x] `pnpm exec tsc --noEmit` in `typescript/infra`
- [ ] check-warp-deploy shows USDC/subtensor clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)