### PR TITLE
fix(keyfunder): scale wallet balance metrics by chain native token decimals

### DIFF
--- a/typescript/keyfunder/src/core/KeyFunder.test.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.test.ts
@@ -1,16 +1,68 @@
 import { expect } from 'chai';
+import { BigNumber } from 'ethers';
 import type { Logger } from 'pino';
 import sinon from 'sinon';
 
 import { MultiProvider } from '@hyperlane-xyz/sdk';
 
 import type { KeyFunderConfig } from '../config/types.js';
+import type { KeyFunderMetrics } from '../metrics/Metrics.js';
 
 import { KeyFunder } from './KeyFunder.js';
 
 describe('KeyFunder', () => {
   afterEach(() => {
     sinon.restore();
+  });
+
+  it('scales the funder balance metric by the chain native token decimals', async () => {
+    const logger = {
+      child: () => logger,
+      debug: () => undefined,
+      error: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+    } as unknown as Logger;
+
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    // 1152 TRX at 6 decimals = 1_152_000_000 sun.
+    multiProvider.getSigner.returns({
+      getAddress: async () => '0x2222222222222222222222222222222222222222',
+      getBalance: async () => BigNumber.from('1152000000'),
+    } as never);
+    multiProvider.getChainMetadata.returns({
+      nativeToken: { name: 'TRON', symbol: 'TRX', decimals: 6 },
+    } as never);
+
+    const recordUnifiedWalletBalance = sinon.spy();
+    const metrics = {
+      recordUnifiedWalletBalance,
+    } as unknown as KeyFunderMetrics;
+
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {},
+      chains: { tron: {} },
+    };
+
+    const keyFunder = new KeyFunder(multiProvider, config, {
+      logger,
+      metrics,
+    });
+
+    await (
+      keyFunder as unknown as {
+        recordFunderBalance: (chain: string) => Promise<void>;
+      }
+    ).recordFunderBalance('tron');
+
+    sinon.assert.calledOnceWithExactly(
+      recordUnifiedWalletBalance,
+      'tron',
+      '0x2222222222222222222222222222222222222222',
+      'key-funder',
+      1152,
+    );
   });
 
   it('should continue funding when recordFunderBalance fails', async () => {

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -118,16 +118,24 @@ export class KeyFunder {
     logger.info({ durationSeconds }, 'Chain funding completed');
   }
 
+  private getNativeDecimals(chain: string): number {
+    return (
+      this.multiProvider.getChainMetadata(chain).nativeToken?.decimals ?? 18
+    );
+  }
+
   private async recordFunderBalance(chain: string): Promise<void> {
     const signer = this.multiProvider.getSigner(chain);
     const funderAddress = await signer.getAddress();
     const funderBalance = await signer.getBalance();
-    const balanceInEther = parseFloat(ethers.utils.formatEther(funderBalance));
+    const balance = parseFloat(
+      ethers.utils.formatUnits(funderBalance, this.getNativeDecimals(chain)),
+    );
     this.options.metrics?.recordUnifiedWalletBalance(
       chain,
       funderAddress,
       'key-funder',
-      balanceInEther,
+      balance,
     );
   }
 
@@ -180,7 +188,9 @@ export class KeyFunder {
 
     this.options.metrics?.recordIgpBalance(
       chain,
-      parseFloat(ethers.utils.formatEther(igpBalance)),
+      parseFloat(
+        ethers.utils.formatUnits(igpBalance, this.getNativeDecimals(chain)),
+      ),
     );
 
     logger.info(
@@ -232,7 +242,9 @@ export class KeyFunder {
       chain,
       key.address,
       key.role,
-      parseFloat(ethers.utils.formatEther(currentBalance)),
+      parseFloat(
+        ethers.utils.formatUnits(currentBalance, this.getNativeDecimals(chain)),
+      ),
     );
 
     if (fundingAmount.eq(0)) {


### PR DESCRIPTION
## Summary
- The key-funder emitted `hyperlane_wallet_balance` (and IGP/wallet balance metrics) by formatting every raw balance with `ethers.utils.formatEther`, which hardcodes 18 decimals.
- On chains whose native token uses fewer decimals — e.g. Tron/TRX at 6 — balances were underreported by ~1e12, so healthy wallets read as ~0 and tripped low-balance alerts.
- Balance-read metric emissions now scale by the chain's native-token decimals from chain metadata (`getChainMetadata(chain).nativeToken?.decimals ?? 18`) via a `getNativeDecimals` helper. Applied to `recordFunderBalance`, `recordIgpBalance`, and `recordWalletBalance`.

## Context
- Triggered by PagerDuty incident Q3Q0SJEPGTRRTR: "tron key-funder ... balance is low" on `0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba`. On-chain balance was ~2,747 TRX (healthy); the metric read ~2.7e-9. False positive, not a funding shortfall.
- Root-cause group: 01KQ7F5HHAZMM8KHWBFK7MZFPA.
- The analogous Rust agent path was already fixed in #9017 (`u256_as_scaled_f64_with_decimals(balance, native_token.decimals)`); this brings the TypeScript key-funder in line.

## Out of scope / follow-up
- The funding math itself (`parseEther(desiredBalance)` in `fundKey`) still assumes 18 decimals for non-EVM-decimal chains. That path only mutates funds when a wallet is genuinely below threshold and is a separate, riskier change — flagged for a follow-up rather than bundled here.

## Test plan
- [x] Added `KeyFunder.test.ts` case asserting a 6-decimal TRX balance (1_152_000_000 sun) reports as 1152.
- [x] `pnpm -C typescript/keyfunder build`
- [x] `pnpm -C typescript/keyfunder test` (51 passing)
- [x] `pnpm -C typescript/keyfunder lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)