### PR TITLE
chore(infra): disable paradexsepolia in testnet4 agent operations

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -56,7 +56,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     kyvetestnet: false,
     modetestnet: true,
     optimismsepolia: true,
-    paradexsepolia: true,
+    paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
     radixtestnet: false,
     seismictestnet: true,
@@ -82,7 +82,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     kyvetestnet: false,
     modetestnet: true,
     optimismsepolia: true,
-    paradexsepolia: true,
+    paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
     radixtestnet: false,
     seismictestnet: true,
@@ -108,7 +108,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     kyvetestnet: false,
     modetestnet: true,
     optimismsepolia: true,
-    paradexsepolia: true,
+    paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
     radixtestnet: false,
     // disabled temporarily until timestamps change from ms to secs (soon)


### PR DESCRIPTION
## Summary
- Disables `paradexsepolia` across validator/relayer/scraper in the testnet4 `hyperlaneContextAgentChainConfig`.
- Paradex Sepolia testnet was reset/decommissioned: contract-sync block height froze at **921055 ~27 days ago**, the head metric went stale, and the sole RPC (`pathfinder.api.testnet.paradex.trade`) now returns **503**.
- Agents kept retrying the dead endpoint, which is what fires the "RPC usage > 300% higher than 1 week ago" alert (PD Q0G46W0AOFZW8A).

Mirrors the nibiru removal (#9089).

## Test plan
- [ ] CI lint/build passes
- [ ] After merge + agent redeploy, confirm paradexsepolia RPC-usage alert clears and no new paradexsepolia agent errors