### PR TITLE
refactor(warp-check): move governance-ICA ownerStatus resolution from SDK to infra

### DIFF
--- a/.changeset/ica-owner-status-resolution.md
+++ b/.changeset/ica-owner-status-resolution.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The warp-route `ownerStatus` check no longer bakes governance-ICA knowledge into the SDK. `expandWarpDeployConfig` is now deterministic (an Inactive owner is normalized to Active), and `checkWarpRouteDeployConfig` accepts an optional `acceptedInactiveOwners` list of `{ chain, owner }` verdicts. An observed Inactive owner is treated as acceptable only when the exact `{ chain, owner }` pair is present in that list, letting the caller (infra) own the governance decision of deriving and verifying the ICA while the SDK stays governance-agnostic.
+The warp-route `ownerStatus` check no longer baked governance-ICA knowledge into the SDK. `expandWarpDeployConfig` became deterministic (an Inactive owner is normalized to Active), and `checkWarpRouteDeployConfig` gained an optional `acceptedInactiveOwners` list of `{ chain, owner }` verdicts. An observed Inactive owner was treated as acceptable only when the exact `{ chain, owner }` pair was present in that list, letting the caller (infra) own the governance decision of deriving and verifying the ICA while the SDK stayed governance-agnostic.

--- a/.changeset/ica-owner-status-resolution.md
+++ b/.changeset/ica-owner-status-resolution.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The warp-route `ownerStatus` check no longer reports an Inactive false positive for governance ICA owners on nonce-less / lazily-deployed chains (Tron and other AltVM). `expandWarpDeployConfig` and `checkWarpRouteDeployConfig` now accept an optional `interchainAccount`; when supplied, an Inactive owner is resolved by deriving the leaf-chain ICA from the route's Ethereum-leg owner and is treated as acceptable only when that derivation matches the on-chain owner and the origin owner is a Safe with threshold > 1, preserving the anti-1-of-1 signal.
+The warp-route `ownerStatus` check no longer bakes governance-ICA knowledge into the SDK. `expandWarpDeployConfig` is now deterministic (an Inactive owner is normalized to Active), and `checkWarpRouteDeployConfig` accepts an optional `acceptedInactiveOwners` list of `{ chain, owner }` verdicts. An observed Inactive owner is treated as acceptable only when the exact `{ chain, owner }` pair is present in that list, letting the caller (infra) own the governance decision of deriving and verifying the ICA while the SDK stays governance-agnostic.

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -308,11 +308,14 @@ async function runWarpRouteCheckFromRegistry({
   // state. The declaration is the source of intent; derivation/Safe checks are
   // fail-closed (see governance-ica-owners.ts). Without an ICA app we can't
   // derive, so nothing is accepted and the ownerStatus check runs unchanged.
+  // Scope resolution to the (possibly --chains-filtered) destinations so an
+  // excluded leaf chain's ICA derivation + Safe RPC are never attempted.
   const acceptedInactiveOwners = interchainAccount
     ? await resolveAcceptedInactiveOwners({
         warpRouteId,
         interchainAccount,
         multiProvider,
+        destinations: Object.keys(filteredConfigs.warpDeployConfig),
       })
     : undefined;
 

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -34,6 +34,7 @@ import {
   warpViolationGroupings,
 } from './check-utils.js';
 import { isContractVerificationViolation } from './contract-verification-skip.js';
+import { resolveAcceptedInactiveOwners } from './governance-ica-owners.js';
 import { isSkippedOwnerStatusViolation } from './owner-status-skip.js';
 
 const ROUTES_TO_SKIP: string[] = [
@@ -303,11 +304,23 @@ async function runWarpRouteCheckFromRegistry({
     warpDeployConfig: loadedConfigs.warpDeployConfig,
   });
 
+  // Derive + verify the governance ICA owners this route accepts in an Inactive
+  // state. The declaration is the source of intent; derivation/Safe checks are
+  // fail-closed (see governance-ica-owners.ts). Without an ICA app we can't
+  // derive, so nothing is accepted and the ownerStatus check runs unchanged.
+  const acceptedInactiveOwners = interchainAccount
+    ? await resolveAcceptedInactiveOwners({
+        warpRouteId,
+        interchainAccount,
+        multiProvider,
+      })
+    : undefined;
+
   return checkWarpRouteDeployConfig({
     multiProvider,
     warpCoreConfig: filteredConfigs.warpCoreConfig,
     warpDeployConfig: filteredConfigs.warpDeployConfig,
-    interchainAccount,
+    acceptedInactiveOwners,
   });
 }
 

--- a/typescript/infra/scripts/check/governance-ica-owners.ts
+++ b/typescript/infra/scripts/check/governance-ica-owners.ts
@@ -126,17 +126,27 @@ export async function verifyGovernanceIcaOwner({
 // governance ICA declarations. Fail-closed: any uncertainty drops the owner
 // from the result so the ownerStatus violation still fires. A missing
 // declaration simply yields no accepted owners.
+//
+// When `destinations` is provided (e.g. a --chains-filtered check), only
+// declarations whose destination is in that set are resolved, so an excluded
+// leaf chain's ICA derivation and Safe RPC are never attempted.
 export async function resolveAcceptedInactiveOwners({
   warpRouteId,
   interchainAccount,
   multiProvider,
+  destinations,
 }: {
   warpRouteId: string;
   interchainAccount: InterchainAccount;
   multiProvider: MultiProvider;
+  destinations?: readonly ChainName[];
 }): Promise<AcceptedInactiveOwner[]> {
+  const allowedDestinations = destinations && new Set(destinations);
   const declarations = GOVERNANCE_ICA_OWNERS.filter(
-    (declaration) => declaration.warpRouteId === warpRouteId,
+    (declaration) =>
+      declaration.warpRouteId === warpRouteId &&
+      (!allowedDestinations ||
+        allowedDestinations.has(declaration.destination)),
   );
 
   const verdicts = await Promise.all(

--- a/typescript/infra/scripts/check/governance-ica-owners.ts
+++ b/typescript/infra/scripts/check/governance-ica-owners.ts
@@ -1,0 +1,155 @@
+import chalk from 'chalk';
+
+import { ISafe__factory } from '@hyperlane-xyz/core';
+import {
+  type AccountConfig,
+  type AcceptedInactiveOwner,
+  type ChainName,
+  InterchainAccount,
+  type MultiProvider,
+} from '@hyperlane-xyz/sdk';
+import { type Address, eqAddress } from '@hyperlane-xyz/utils';
+
+// A nonce-less / lazily-deployed governance ICA (Tron and other AltVM) has no
+// contract code and no nonce, so the ownerStatus virtual check derives it as
+// Inactive and forces expected=Active — a permanent, unresolvable false
+// positive even though the owner is a perfectly good multisig-controlled ICA.
+//
+// The SDK checker no longer knows anything about ICAs: it only passes an
+// Inactive owner through as acceptable when infra hands it an explicit
+// { chain, owner } verdict (see checkWarpRouteDeployConfig's
+// `acceptedInactiveOwners`). This file owns the governance decision: it
+// DECLARES the intended ICA per route and DERIVES + VERIFIES it at runtime.
+//
+// A declaration is the source of intent — we never reconstruct the AccountConfig
+// by assuming Ethereum or inferring it from the route. For each declaration we:
+//   1. derive the leaf-chain ICA from the declared origin owner via
+//      InterchainAccount.getAccount,
+//   2. require the derived ICA to equal the declared ICA,
+//   3. require the declared origin owner to be a Safe with threshold > 1.
+// Only then do we emit { chain: destination, owner: derivedIca } as accepted.
+// The SDK matches that owner against the observed on-chain owner, which supplies
+// the final derivedIca == onChainOwner check, so we don't re-read the route.
+//
+// Everything uncertain FAILS CLOSED (owner not accepted → violation still
+// fires): a missing declaration, a derivation mismatch or error, a Safe RPC
+// failure, or a threshold <= 1. This preserves the anti-1-of-1 signal the
+// ownerStatus check exists for.
+export interface GovernanceIcaOwnerDeclaration {
+  warpRouteId: string;
+  // Leaf chain whose on-chain owner is the (Inactive) governance ICA.
+  destination: ChainName;
+  // The ICA we expect to derive; cross-checked against the derivation so a
+  // stale/incorrect declaration fails closed rather than silently accepting a
+  // different owner.
+  declaredIca: Address;
+  // Explicit origin chain + owner (and optional ICA routing overrides). This is
+  // the source of intent — NOT inferred from the route.
+  accountConfig: AccountConfig;
+}
+
+export const GOVERNANCE_ICA_OWNERS: GovernanceIcaOwnerDeclaration[] = [
+  {
+    warpRouteId: 'USDT/eclipsemainnet',
+    destination: 'tron',
+    declaredIca: '0xB960616C7E2ee0F2a296A4b2B9D0b3308E23A69D',
+    accountConfig: {
+      origin: 'ethereum',
+      owner: '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6',
+    },
+  },
+];
+
+// Derives + verifies a single governance ICA declaration. Returns the accepted
+// verdict, or undefined if anything is uncertain (fail-closed): a derivation
+// mismatch or error, a Safe RPC failure, or a threshold <= 1.
+export async function verifyGovernanceIcaOwner({
+  declaration,
+  interchainAccount,
+  multiProvider,
+}: {
+  declaration: GovernanceIcaOwnerDeclaration;
+  interchainAccount: InterchainAccount;
+  multiProvider: MultiProvider;
+}): Promise<AcceptedInactiveOwner | undefined> {
+  const { warpRouteId, destination, declaredIca, accountConfig } = declaration;
+  const label = `${warpRouteId} ${destination} ICA ${declaredIca}`;
+
+  // 1. Derive the leaf-chain ICA from the declared origin owner.
+  let derivedIca: Address;
+  try {
+    derivedIca = await interchainAccount.getAccount(destination, accountConfig);
+  } catch (e) {
+    console.warn(
+      chalk.yellow(`Skipping ${label}: ICA derivation failed: ${e}`),
+    );
+    return undefined;
+  }
+
+  // 2. Require the derivation to match the declared ICA.
+  if (!eqAddress(derivedIca, declaredIca)) {
+    console.warn(
+      chalk.yellow(
+        `Skipping ${label}: derived ICA ${derivedIca} != declared ${declaredIca}`,
+      ),
+    );
+    return undefined;
+  }
+
+  // 3. Anti-1-of-1: require the origin owner to be a Safe with threshold > 1.
+  // A non-Safe origin owner (getThreshold reverts) or a 1-of-1 Safe fails.
+  try {
+    const safe = ISafe__factory.connect(
+      accountConfig.owner,
+      multiProvider.getProvider(accountConfig.origin),
+    );
+    const threshold = await safe.getThreshold();
+    if (!threshold.gt(1)) {
+      console.warn(
+        chalk.yellow(
+          `Skipping ${label}: origin Safe threshold ${threshold.toString()} <= 1`,
+        ),
+      );
+      return undefined;
+    }
+  } catch (e) {
+    console.warn(
+      chalk.yellow(`Skipping ${label}: origin Safe check failed: ${e}`),
+    );
+    return undefined;
+  }
+
+  return { chain: destination, owner: derivedIca };
+}
+
+// Resolves the accepted Inactive owners for a route by deriving + verifying its
+// governance ICA declarations. Fail-closed: any uncertainty drops the owner
+// from the result so the ownerStatus violation still fires. A missing
+// declaration simply yields no accepted owners.
+export async function resolveAcceptedInactiveOwners({
+  warpRouteId,
+  interchainAccount,
+  multiProvider,
+}: {
+  warpRouteId: string;
+  interchainAccount: InterchainAccount;
+  multiProvider: MultiProvider;
+}): Promise<AcceptedInactiveOwner[]> {
+  const declarations = GOVERNANCE_ICA_OWNERS.filter(
+    (declaration) => declaration.warpRouteId === warpRouteId,
+  );
+
+  const verdicts = await Promise.all(
+    declarations.map((declaration) =>
+      verifyGovernanceIcaOwner({
+        declaration,
+        interchainAccount,
+        multiProvider,
+      }),
+    ),
+  );
+
+  return verdicts.filter(
+    (verdict): verdict is AcceptedInactiveOwner => verdict !== undefined,
+  );
+}

--- a/typescript/infra/test/governance-ica-owners.test.ts
+++ b/typescript/infra/test/governance-ica-owners.test.ts
@@ -32,11 +32,14 @@ describe('verifyGovernanceIcaOwner', () => {
     return { getAccount } as unknown as InterchainAccount;
   }
 
-  // Minimal MultiProvider double: its provider is passed straight into the
-  // stubbed ISafe__factory.connect, so its value is irrelevant here.
-  function buildMultiProvider(): MultiProvider {
+  // Minimal MultiProvider double whose getProvider can be stubbed so a test can
+  // assert which chain's provider is fetched (it's passed into
+  // ISafe__factory.connect).
+  function buildMultiProvider(
+    getProvider: (chain: string) => unknown = () => ({}),
+  ): MultiProvider {
     // CAST: test double exercising only getProvider.
-    return { getProvider: () => ({}) } as unknown as MultiProvider;
+    return { getProvider } as unknown as MultiProvider;
   }
 
   function stubSafeThreshold(threshold: number) {
@@ -62,6 +65,9 @@ describe('verifyGovernanceIcaOwner', () => {
   it('accepts a matching ICA whose non-ethereum origin owner is a Safe with threshold > 1', async () => {
     const connectStub = stubSafeThreshold(3);
     const getAccountStub = sinon.stub().resolves(DECLARED_ICA);
+    // Sentinel provider so we can assert it flows origin -> getProvider -> connect.
+    const originProvider = { sentinel: 'arbitrum-provider' };
+    const getProviderStub = sinon.stub().returns(originProvider);
     // Origin is arbitrum, NOT ethereum — proves the origin comes from the
     // declaration and is never assumed to be ethereum.
     const accountConfig: AccountConfig = {
@@ -72,7 +78,7 @@ describe('verifyGovernanceIcaOwner', () => {
     const result = await verifyGovernanceIcaOwner({
       declaration: declaration(accountConfig),
       interchainAccount: buildIca(getAccountStub),
-      multiProvider: buildMultiProvider(),
+      multiProvider: buildMultiProvider(getProviderStub),
     });
 
     expect(result).to.deep.equal({ chain: DESTINATION, owner: DECLARED_ICA });
@@ -80,8 +86,12 @@ describe('verifyGovernanceIcaOwner', () => {
     expect(getAccountStub.calledOnceWith(DESTINATION, accountConfig)).to.equal(
       true,
     );
-    // Safe threshold was read against the declared origin owner.
-    expect(connectStub.calledOnceWith(ORIGIN_OWNER)).to.equal(true);
+    // The Safe RPC used the declared origin's provider: a reintroduced Ethereum
+    // hardcode (getProvider('ethereum')) would fail these assertions.
+    expect(getProviderStub.calledOnceWithExactly('arbitrum')).to.equal(true);
+    expect(connectStub.calledOnce).to.equal(true);
+    expect(connectStub.firstCall.args[0]).to.equal(ORIGIN_OWNER);
+    expect(connectStub.firstCall.args[1]).to.equal(originProvider);
   });
 
   it('fails closed for a matching ICA whose origin owner is a 1-of-1 Safe', async () => {
@@ -197,5 +207,41 @@ describe('resolveAcceptedInactiveOwners', () => {
     });
 
     expect(result).to.deep.equal([]);
+  });
+
+  it('skips resolution entirely when the declaration destination is outside the scoped chains', async () => {
+    const getAccountStub = sinon.stub().resolves(DECLARED_ICA);
+    const connectStub = sinon.stub(ISafe__factory, 'connect');
+
+    const result = await resolveAcceptedInactiveOwners({
+      warpRouteId: 'USDT/eclipsemainnet',
+      interchainAccount: buildIca(getAccountStub),
+      multiProvider: buildMultiProvider(),
+      // A --chains ethereum check of a route whose only declaration targets tron:
+      // the excluded leaf must never trigger derivation or the Safe RPC.
+      destinations: ['ethereum'],
+    });
+
+    expect(result).to.deep.equal([]);
+    expect(getAccountStub.notCalled).to.equal(true);
+    expect(connectStub.notCalled).to.equal(true);
+  });
+
+  it('resolves the declaration when its destination is within the scoped chains', async () => {
+    sinon.stub(ISafe__factory, 'connect').returns(
+      // CAST: only getThreshold() is read from the connected Safe.
+      {
+        getThreshold: async () => BigNumber.from(3),
+      } as ReturnType<typeof ISafe__factory.connect>,
+    );
+
+    const result = await resolveAcceptedInactiveOwners({
+      warpRouteId: 'USDT/eclipsemainnet',
+      interchainAccount: buildIca(async () => DECLARED_ICA),
+      multiProvider: buildMultiProvider(),
+      destinations: ['ethereum', 'tron'],
+    });
+
+    expect(result).to.deep.equal([{ chain: 'tron', owner: DECLARED_ICA }]);
   });
 });

--- a/typescript/infra/test/governance-ica-owners.test.ts
+++ b/typescript/infra/test/governance-ica-owners.test.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import sinon from 'sinon';
+
+import { ISafe__factory } from '@hyperlane-xyz/core';
+import {
+  type AccountConfig,
+  type InterchainAccount,
+  type MultiProvider,
+} from '@hyperlane-xyz/sdk';
+
+import {
+  type GovernanceIcaOwnerDeclaration,
+  resolveAcceptedInactiveOwners,
+  verifyGovernanceIcaOwner,
+} from '../scripts/check/governance-ica-owners.js';
+
+describe('verifyGovernanceIcaOwner', () => {
+  const DESTINATION = 'tron';
+  const DECLARED_ICA = '0xB960616C7E2ee0F2a296A4b2B9D0b3308E23A69D';
+  const ORIGIN_OWNER = '0x3965AC3D295641E452E0ea896a086A9cD7C6C5b6';
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // Minimal InterchainAccount double: the resolver only calls getAccount.
+  function buildIca(
+    getAccount: (chain: string, config: AccountConfig) => Promise<string>,
+  ): InterchainAccount {
+    // CAST: test double exercising only the one member the resolver reads.
+    return { getAccount } as unknown as InterchainAccount;
+  }
+
+  // Minimal MultiProvider double: its provider is passed straight into the
+  // stubbed ISafe__factory.connect, so its value is irrelevant here.
+  function buildMultiProvider(): MultiProvider {
+    // CAST: test double exercising only getProvider.
+    return { getProvider: () => ({}) } as unknown as MultiProvider;
+  }
+
+  function stubSafeThreshold(threshold: number) {
+    return sinon.stub(ISafe__factory, 'connect').returns(
+      // CAST: only getThreshold() is read from the connected Safe.
+      {
+        getThreshold: async () => BigNumber.from(threshold),
+      } as ReturnType<typeof ISafe__factory.connect>,
+    );
+  }
+
+  function declaration(
+    accountConfig: AccountConfig,
+  ): GovernanceIcaOwnerDeclaration {
+    return {
+      warpRouteId: 'USDT/eclipsemainnet',
+      destination: DESTINATION,
+      declaredIca: DECLARED_ICA,
+      accountConfig,
+    };
+  }
+
+  it('accepts a matching ICA whose non-ethereum origin owner is a Safe with threshold > 1', async () => {
+    const connectStub = stubSafeThreshold(3);
+    const getAccountStub = sinon.stub().resolves(DECLARED_ICA);
+    // Origin is arbitrum, NOT ethereum — proves the origin comes from the
+    // declaration and is never assumed to be ethereum.
+    const accountConfig: AccountConfig = {
+      origin: 'arbitrum',
+      owner: ORIGIN_OWNER,
+    };
+
+    const result = await verifyGovernanceIcaOwner({
+      declaration: declaration(accountConfig),
+      interchainAccount: buildIca(getAccountStub),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.deep.equal({ chain: DESTINATION, owner: DECLARED_ICA });
+    // Derivation used the declared destination + accountConfig verbatim.
+    expect(getAccountStub.calledOnceWith(DESTINATION, accountConfig)).to.equal(
+      true,
+    );
+    // Safe threshold was read against the declared origin owner.
+    expect(connectStub.calledOnceWith(ORIGIN_OWNER)).to.equal(true);
+  });
+
+  it('fails closed for a matching ICA whose origin owner is a 1-of-1 Safe', async () => {
+    stubSafeThreshold(1);
+    const result = await verifyGovernanceIcaOwner({
+      declaration: declaration({ origin: 'ethereum', owner: ORIGIN_OWNER }),
+      interchainAccount: buildIca(async () => DECLARED_ICA),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.equal(undefined);
+  });
+
+  it('fails closed when the derived ICA does not match the declared ICA', async () => {
+    const connectStub = stubSafeThreshold(3);
+    const result = await verifyGovernanceIcaOwner({
+      declaration: declaration({ origin: 'ethereum', owner: ORIGIN_OWNER }),
+      interchainAccount: buildIca(
+        async () => '0x3333333333333333333333333333333333333333',
+      ),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.equal(undefined);
+    // A derivation mismatch fails before the Safe threshold is ever read.
+    expect(connectStub.notCalled).to.equal(true);
+  });
+
+  it('fails closed when ICA derivation throws', async () => {
+    const result = await verifyGovernanceIcaOwner({
+      declaration: declaration({ origin: 'ethereum', owner: ORIGIN_OWNER }),
+      interchainAccount: buildIca(async () => {
+        throw new Error('derivation failed');
+      }),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.equal(undefined);
+  });
+
+  it('fails closed when the origin Safe check reverts (RPC failure / non-Safe owner)', async () => {
+    sinon.stub(ISafe__factory, 'connect').returns(
+      // CAST: simulate a non-Safe owner / RPC failure where getThreshold reverts.
+      {
+        getThreshold: async (): Promise<BigNumber> => {
+          throw new Error('not a safe');
+        },
+      } as ReturnType<typeof ISafe__factory.connect>,
+    );
+    const result = await verifyGovernanceIcaOwner({
+      declaration: declaration({ origin: 'ethereum', owner: ORIGIN_OWNER }),
+      interchainAccount: buildIca(async () => DECLARED_ICA),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.equal(undefined);
+  });
+});
+
+describe('resolveAcceptedInactiveOwners', () => {
+  const DECLARED_ICA = '0xB960616C7E2ee0F2a296A4b2B9D0b3308E23A69D';
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function buildIca(
+    getAccount: (chain: string, config: AccountConfig) => Promise<string>,
+  ): InterchainAccount {
+    // CAST: test double exercising only getAccount.
+    return { getAccount } as unknown as InterchainAccount;
+  }
+
+  function buildMultiProvider(): MultiProvider {
+    // CAST: test double exercising only getProvider.
+    return { getProvider: () => ({}) } as unknown as MultiProvider;
+  }
+
+  it('returns an empty list when there is no declaration for the route', async () => {
+    const result = await resolveAcceptedInactiveOwners({
+      warpRouteId: 'UNKNOWN/route',
+      interchainAccount: buildIca(async () => DECLARED_ICA),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it('resolves the declared route to its accepted verdict when derivation + Safe check pass', async () => {
+    sinon.stub(ISafe__factory, 'connect').returns(
+      // CAST: only getThreshold() is read from the connected Safe.
+      {
+        getThreshold: async () => BigNumber.from(3),
+      } as ReturnType<typeof ISafe__factory.connect>,
+    );
+
+    const result = await resolveAcceptedInactiveOwners({
+      warpRouteId: 'USDT/eclipsemainnet',
+      interchainAccount: buildIca(async () => DECLARED_ICA),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.deep.equal([{ chain: 'tron', owner: DECLARED_ICA }]);
+  });
+
+  it('drops the verdict (fail closed) when the declared route derivation mismatches', async () => {
+    const result = await resolveAcceptedInactiveOwners({
+      warpRouteId: 'USDT/eclipsemainnet',
+      interchainAccount: buildIca(
+        async () => '0x3333333333333333333333333333333333333333',
+      ),
+      multiProvider: buildMultiProvider(),
+    });
+
+    expect(result).to.deep.equal([]);
+  });
+});

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -849,7 +849,6 @@ export { EvmWarpRouteReader } from './token/EvmWarpRouteReader.js';
 export {
   WARP_ROUTE_CHECK_SCALE_TYPE,
   WARP_ROUTE_CHECK_TYPE,
-  applyAcceptedInactiveOwnerStatus,
   checkWarpRouteDeployConfig,
 } from './token/warpCheck.js';
 export type {

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -849,9 +849,11 @@ export { EvmWarpRouteReader } from './token/EvmWarpRouteReader.js';
 export {
   WARP_ROUTE_CHECK_SCALE_TYPE,
   WARP_ROUTE_CHECK_TYPE,
+  applyAcceptedInactiveOwnerStatus,
   checkWarpRouteDeployConfig,
 } from './token/warpCheck.js';
 export type {
+  AcceptedInactiveOwner,
   WarpRouteCheckResult,
   WarpRouteCheckViolation,
 } from './token/warpCheck.js';

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -1,8 +1,5 @@
 import { expect } from 'chai';
-import { BigNumber, constants } from 'ethers';
-import sinon from 'sinon';
-
-import { ISafe__factory } from '@hyperlane-xyz/core';
+import { constants } from 'ethers';
 
 import {
   DEFAULT_ROUTER_KEY,
@@ -13,7 +10,6 @@ import {
 } from '../fee/types.js';
 import { HookType } from '../hook/types.js';
 import { IsmType } from '../ism/types.js';
-import { InterchainAccount } from '../middleware/account/InterchainAccount.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { test1, test2 } from '../consts/testChains.js';
 import type { WarpCoreConfig } from '../warp/types.js';
@@ -22,7 +18,6 @@ import { TokenType } from './config.js';
 import {
   filterWarpCoreConfigMapByChains,
   getChainsFromWarpCoreConfig,
-  isGovernanceIcaOwner,
   normalizeWarpDeployConfigForCheck,
   resolveTokenFeeAddress,
   transformConfigToCheck,
@@ -859,158 +854,6 @@ describe('configUtils', () => {
     it('should return all routes for empty chains array', () => {
       const result = filterWarpCoreConfigMapByChains(configMap, []);
       expect(Object.keys(result)).to.have.lengthOf(3);
-    });
-  });
-
-  describe('isGovernanceIcaOwner', () => {
-    const LEAF_CHAIN = 'tron';
-    const ORIGIN_OWNER = '0x1111111111111111111111111111111111111111';
-    // The on-chain leaf owner that a correct ICA derivation reproduces.
-    const LEAF_OWNER = '0x2222222222222222222222222222222222222222';
-    const MAILBOX = '0x000000000000000000000000000000000000b001';
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    // Minimal InterchainAccount double: the resolver only touches getAccount and
-    // multiProvider.getProvider (whose return is passed straight into the stubbed
-    // ISafe__factory.connect, so its value is irrelevant here).
-    function buildIca(
-      getAccount: (
-        chain: string,
-        config: { origin: string; owner: string },
-      ) => Promise<string>,
-    ): InterchainAccount {
-      // CAST: test double exercising only the two members the resolver reads.
-      return {
-        multiProvider: { getProvider: () => ({}) },
-        getAccount,
-      } as unknown as InterchainAccount;
-    }
-
-    function stubSafeThreshold(threshold: number) {
-      return sinon.stub(ISafe__factory, 'connect').returns(
-        // CAST: only getThreshold() is read from the connected Safe.
-        {
-          getThreshold: async () => BigNumber.from(threshold),
-        } as ReturnType<typeof ISafe__factory.connect>,
-      );
-    }
-
-    function warpDeployConfig(
-      withEthereumOwner: boolean,
-    ): WarpRouteDeployConfigMailboxRequired {
-      const config: WarpRouteDeployConfigMailboxRequired = {
-        [LEAF_CHAIN]: {
-          mailbox: MAILBOX,
-          owner: LEAF_OWNER,
-          type: TokenType.collateral,
-          token: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        },
-      };
-      if (withEthereumOwner) {
-        config['ethereum'] = {
-          mailbox: MAILBOX,
-          owner: ORIGIN_OWNER,
-          type: TokenType.collateral,
-          token: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-        };
-      }
-      return config;
-    }
-
-    it('returns false for the origin chain itself (it is not a leaf ICA)', async () => {
-      const connectStub = stubSafeThreshold(3);
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(async () => LEAF_OWNER),
-        warpDeployConfig: warpDeployConfig(true),
-        chain: 'ethereum',
-        owner: ORIGIN_OWNER,
-      });
-
-      expect(result).to.equal(false);
-      expect(connectStub.notCalled).to.equal(true);
-    });
-
-    it('returns false when the route has no Ethereum-leg owner to derive from', async () => {
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(async () => LEAF_OWNER),
-        warpDeployConfig: warpDeployConfig(false),
-        chain: LEAF_CHAIN,
-        owner: LEAF_OWNER,
-      });
-
-      expect(result).to.equal(false);
-    });
-
-    it('returns false when ICA derivation throws', async () => {
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(async () => {
-          throw new Error('derivation failed');
-        }),
-        warpDeployConfig: warpDeployConfig(true),
-        chain: LEAF_CHAIN,
-        owner: LEAF_OWNER,
-      });
-
-      expect(result).to.equal(false);
-    });
-
-    it('returns false when the derived ICA does not match the on-chain owner', async () => {
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(
-          async () => '0x3333333333333333333333333333333333333333',
-        ),
-        warpDeployConfig: warpDeployConfig(true),
-        chain: LEAF_CHAIN,
-        owner: LEAF_OWNER,
-      });
-
-      expect(result).to.equal(false);
-    });
-
-    it('returns false for a matching ICA whose origin owner is a 1-of-1 Safe (preserves anti-1-of-1 signal)', async () => {
-      stubSafeThreshold(1);
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(async () => LEAF_OWNER),
-        warpDeployConfig: warpDeployConfig(true),
-        chain: LEAF_CHAIN,
-        owner: LEAF_OWNER,
-      });
-
-      expect(result).to.equal(false);
-    });
-
-    it('returns false for a matching ICA whose origin owner is not a Safe (getThreshold reverts)', async () => {
-      sinon.stub(ISafe__factory, 'connect').returns(
-        // CAST: simulate a non-Safe owner where getThreshold reverts.
-        {
-          getThreshold: async (): Promise<BigNumber> => {
-            throw new Error('not a safe');
-          },
-        } as ReturnType<typeof ISafe__factory.connect>,
-      );
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(async () => LEAF_OWNER),
-        warpDeployConfig: warpDeployConfig(true),
-        chain: LEAF_CHAIN,
-        owner: LEAF_OWNER,
-      });
-
-      expect(result).to.equal(false);
-    });
-
-    it('returns true for a matching ICA whose origin owner is a Safe with threshold > 1', async () => {
-      stubSafeThreshold(3);
-      const result = await isGovernanceIcaOwner({
-        interchainAccount: buildIca(async () => LEAF_OWNER),
-        warpDeployConfig: warpDeployConfig(true),
-        chain: LEAF_CHAIN,
-        owner: LEAF_OWNER,
-      });
-
-      expect(result).to.equal(true);
     });
   });
 });

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -1,7 +1,6 @@
 import { constants } from 'ethers';
 import { zeroAddress } from 'viem';
 
-import { ISafe__factory } from '@hyperlane-xyz/core';
 import { ProtocolType } from '@hyperlane-xyz/provider-sdk';
 import {
   Address,
@@ -9,7 +8,6 @@ import {
   addressToBytes32,
   assert,
   deepCopy,
-  eqAddress,
   intersection,
   isAddressEvm,
   isCosmosIbcDenomAddress,
@@ -30,14 +28,13 @@ import {
 } from '../fee/types.js';
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
-import { InterchainAccount } from '../middleware/account/InterchainAccount.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import {
   DestinationGas,
   RemoteRouters,
   resolveRouterMapConfig,
 } from '../router/types.js';
-import { ChainMap, ChainName } from '../types.js';
+import { ChainMap } from '../types.js';
 import { normalizeScale } from '../utils/decimals.js';
 import { WarpCoreConfig } from '../warp/types.js';
 
@@ -182,75 +179,6 @@ export function filterWarpCoreConfigMapByChains<T extends WarpCoreConfig>(
   );
 }
 
-// The ownerStatus check is not just an owner-match check: it exists to catch
-// single-point-of-failure (1-of-1) ownership. On nonce-less / lazily-deployed
-// chains (Tron and other AltVM) a governance ICA owner has no contract code and
-// no nonce, so it derives as Inactive. Forcing expected=Active for it would be
-// an unresolvable false positive even though the owner is a perfectly good
-// multisig-controlled ICA.
-//
-// Rather than allowlisting each such owner (which silences the anti-1-of-1
-// signal), we resolve it: assume Ethereum is the ICA origin, take the route's
-// Ethereum-leg owner as the single candidate origin owner, derive the leaf ICA
-// from it, and treat the Inactive status as acceptable only if that derivation
-// matches the on-chain leaf owner AND the origin owner is a Safe with
-// threshold > 1. A 1-of-1 origin Safe (or a non-Safe origin owner) still fires.
-const ICA_ORIGIN_CHAIN = 'ethereum';
-
-export async function isGovernanceIcaOwner(params: {
-  interchainAccount: InterchainAccount;
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
-  chain: ChainName;
-  owner: Address;
-}): Promise<boolean> {
-  const { interchainAccount, warpDeployConfig, chain, owner } = params;
-
-  // The heuristic resolves leaf-chain ICAs against the Ethereum origin; the
-  // origin chain itself is not a leaf and is checked normally.
-  if (chain === ICA_ORIGIN_CHAIN) {
-    return false;
-  }
-
-  // Assume Ethereum as the ICA origin and take the Ethereum-leg owner as the
-  // single candidate origin owner. Routes without an Ethereum leg can't use
-  // this heuristic.
-  const originOwner = warpDeployConfig[ICA_ORIGIN_CHAIN]?.owner;
-  if (!originOwner) {
-    return false;
-  }
-
-  const multiProvider = interchainAccount.multiProvider;
-
-  // Derive the leaf-chain ICA from the origin owner. If it matches the leaf's
-  // on-chain owner, that owner is the governance ICA of the origin owner.
-  let derivedIca: Address;
-  try {
-    derivedIca = await interchainAccount.getAccount(chain, {
-      origin: ICA_ORIGIN_CHAIN,
-      owner: originOwner,
-    });
-  } catch {
-    return false;
-  }
-
-  if (!eqAddress(derivedIca, owner)) {
-    return false;
-  }
-
-  // Anti-1-of-1: only clear if the origin owner is a Safe with threshold > 1.
-  // A non-Safe origin owner (getThreshold reverts) or a 1-of-1 Safe still fires.
-  try {
-    const safe = ISafe__factory.connect(
-      originOwner,
-      multiProvider.getProvider(ICA_ORIGIN_CHAIN),
-    );
-    const threshold = await safe.getThreshold();
-    return threshold.gt(1);
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Expands a Warp deploy config with additional data
  *
@@ -266,7 +194,6 @@ export async function expandWarpDeployConfig(params: {
   deployedRoutersAddresses: ChainMap<Address>;
   expandedOnChainWarpConfig?: WarpRouteDeployConfigMailboxRequired;
   validateScale?: boolean;
-  interchainAccount?: InterchainAccount;
 }): Promise<WarpRouteDeployConfigMailboxRequired> {
   const {
     multiProvider,
@@ -274,7 +201,6 @@ export async function expandWarpDeployConfig(params: {
     deployedRoutersAddresses,
     expandedOnChainWarpConfig,
     validateScale = true,
-    interchainAccount,
   } = params;
 
   const derivedTokenMetadata: TokenMetadataMap = await deriveTokenMetadata(
@@ -417,40 +343,24 @@ export async function expandWarpDeployConfig(params: {
 
       if (isEVMChain && expandedOnChainWarpConfig?.[chain]?.ownerStatus) {
         // For 'active' or 'gnosis-safe', we set their actual state as the control because they are both acceptable.
-        // For other cases, we expect 'active'
-        chainConfig.ownerStatus = await promiseObjAll(
-          objMap(
-            expandedOnChainWarpConfig[chain].ownerStatus ?? {},
-            async (ownerAddress, status) => {
-              switch (status) {
-                // Skipped for local e2e testing
-                case OwnerStatus.Skipped:
-                case OwnerStatus.Active:
-                case OwnerStatus.GnosisSafe:
-                  return status; // Pass through the status so diffs will be shown
-                case OwnerStatus.Error:
-                  return OwnerStatus.Active;
-                case OwnerStatus.Inactive:
-                  // A nonce-less governance ICA (Tron/AltVM) derives as Inactive
-                  // but is a legitimate multisig-controlled owner. Treat its
-                  // Inactive status as the acceptable control (expected==actual,
-                  // no violation) rather than forcing Active. Genuine inactive
-                  // EOAs, 1-of-1 origin Safes, and non-ICA owners still fire.
-                  if (
-                    interchainAccount &&
-                    (await isGovernanceIcaOwner({
-                      interchainAccount,
-                      warpDeployConfig,
-                      chain,
-                      owner: ownerAddress,
-                    }))
-                  ) {
-                    return OwnerStatus.Inactive;
-                  }
-                  return OwnerStatus.Active;
-              }
-            },
-          ),
+        // For other cases, we expect 'active'. Accepting an Inactive owner (e.g.
+        // a nonce-less governance ICA on Tron/AltVM) is a governance decision
+        // handled by the caller via `acceptedInactiveOwners` in
+        // `checkWarpRouteDeployConfig`, not here.
+        chainConfig.ownerStatus = objMap(
+          expandedOnChainWarpConfig[chain].ownerStatus ?? {},
+          (_ownerAddress, status) => {
+            switch (status) {
+              // Skipped for local e2e testing
+              case OwnerStatus.Skipped:
+              case OwnerStatus.Active:
+              case OwnerStatus.GnosisSafe:
+                return status; // Pass through the status so diffs will be shown
+              case OwnerStatus.Error:
+              case OwnerStatus.Inactive:
+                return OwnerStatus.Active;
+            }
+          },
         );
       }
 

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -17,12 +17,14 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 
 import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { TokenType } from './config.js';
-import type {
-  DerivedWarpRouteDeployConfig,
-  WarpRouteDeployConfigMailboxRequired,
+import {
+  type DerivedWarpRouteDeployConfig,
+  OwnerStatus,
+  type WarpRouteDeployConfigMailboxRequired,
 } from './types.js';
 import {
   altVmScaleMismatch,
+  applyAcceptedInactiveOwnerStatus,
   buildAltVmWarpRouteDiff,
   buildWarpRouteDiff,
   derivedWarpConfigToCheckConfig,
@@ -799,5 +801,137 @@ describe('buildWarpRouteDiff', () => {
     });
 
     expect(diff[CHAIN]).to.have.nested.property('hook.actual');
+  });
+});
+
+describe('applyAcceptedInactiveOwnerStatus', () => {
+  const CHAIN = 'tron';
+  const OWNER_A = '0xAAAAaaAAAAaAaaAAAaAAAAaaaAAAaaAAAAaAaAaA';
+  const OWNER_B = '0xBbBBBbbBBBbBBBBbbBbBbbBbbbBBbbBBbBBBbBBB';
+
+  // The expander maps every observed ownerStatus to an expected Active, so the
+  // expected side starts fully Active; accepting re-sets specific entries back
+  // to Inactive.
+  function expandedConfig(
+    ownerStatus: Record<string, OwnerStatus>,
+  ): WarpRouteDeployConfigMailboxRequired {
+    return {
+      [CHAIN]: {
+        mailbox: MAILBOX,
+        owner: OWNER_A,
+        token: TOKEN_A,
+        type: TokenType.collateral,
+        ownerStatus,
+      },
+    };
+  }
+
+  it('accepts multiple Inactive owners on the same chain', () => {
+    const expanded = expandedConfig({
+      [OWNER_A]: OwnerStatus.Active,
+      [OWNER_B]: OwnerStatus.Active,
+    });
+
+    applyAcceptedInactiveOwnerStatus({
+      expandedWarpDeployConfig: expanded,
+      onChainWarpConfig: {
+        [CHAIN]: {
+          ownerStatus: {
+            [OWNER_A]: OwnerStatus.Inactive,
+            [OWNER_B]: OwnerStatus.Inactive,
+          },
+        },
+      },
+      acceptedInactiveOwners: [
+        { chain: CHAIN, owner: OWNER_A },
+        { chain: CHAIN, owner: OWNER_B },
+      ],
+    });
+
+    expect(expanded[CHAIN].ownerStatus).to.deep.equal({
+      [OWNER_A]: OwnerStatus.Inactive,
+      [OWNER_B]: OwnerStatus.Inactive,
+    });
+  });
+
+  it('does not accept an owner declared on a different chain or with a different address', () => {
+    const expanded = expandedConfig({
+      [OWNER_A]: OwnerStatus.Active,
+    });
+
+    applyAcceptedInactiveOwnerStatus({
+      expandedWarpDeployConfig: expanded,
+      onChainWarpConfig: {
+        [CHAIN]: { ownerStatus: { [OWNER_A]: OwnerStatus.Inactive } },
+      },
+      acceptedInactiveOwners: [
+        // Wrong chain.
+        { chain: 'ethereum', owner: OWNER_A },
+        // Wrong address on the right chain.
+        { chain: CHAIN, owner: OWNER_B },
+      ],
+    });
+
+    expect(expanded[CHAIN].ownerStatus?.[OWNER_A]).to.equal(OwnerStatus.Active);
+  });
+
+  it('does not override non-Inactive observed statuses even when accepted', () => {
+    const expanded = expandedConfig({
+      [OWNER_A]: OwnerStatus.Active,
+      [OWNER_B]: OwnerStatus.GnosisSafe,
+    });
+
+    applyAcceptedInactiveOwnerStatus({
+      expandedWarpDeployConfig: expanded,
+      onChainWarpConfig: {
+        [CHAIN]: {
+          ownerStatus: {
+            [OWNER_A]: OwnerStatus.Active,
+            [OWNER_B]: OwnerStatus.GnosisSafe,
+          },
+        },
+      },
+      acceptedInactiveOwners: [
+        { chain: CHAIN, owner: OWNER_A },
+        { chain: CHAIN, owner: OWNER_B },
+      ],
+    });
+
+    expect(expanded[CHAIN].ownerStatus).to.deep.equal({
+      [OWNER_A]: OwnerStatus.Active,
+      [OWNER_B]: OwnerStatus.GnosisSafe,
+    });
+  });
+
+  it('matches owner addresses case-insensitively', () => {
+    const expanded = expandedConfig({
+      [OWNER_A]: OwnerStatus.Active,
+    });
+
+    applyAcceptedInactiveOwnerStatus({
+      expandedWarpDeployConfig: expanded,
+      onChainWarpConfig: {
+        [CHAIN]: { ownerStatus: { [OWNER_A]: OwnerStatus.Inactive } },
+      },
+      acceptedInactiveOwners: [{ chain: CHAIN, owner: OWNER_A.toLowerCase() }],
+    });
+
+    expect(expanded[CHAIN].ownerStatus?.[OWNER_A]).to.equal(
+      OwnerStatus.Inactive,
+    );
+  });
+
+  it('is a no-op when no accepted owners are provided', () => {
+    const expanded = expandedConfig({ [OWNER_A]: OwnerStatus.Active });
+
+    applyAcceptedInactiveOwnerStatus({
+      expandedWarpDeployConfig: expanded,
+      onChainWarpConfig: {
+        [CHAIN]: { ownerStatus: { [OWNER_A]: OwnerStatus.Inactive } },
+      },
+      acceptedInactiveOwners: [],
+    });
+
+    expect(expanded[CHAIN].ownerStatus?.[OWNER_A]).to.equal(OwnerStatus.Active);
   });
 });

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -37,7 +37,6 @@ import {
 
 import { isProxy, proxyAdmin } from '../deploy/proxy.js';
 import { altVmChainLookup } from '../metadata/ChainMetadataManager.js';
-import { InterchainAccount } from '../middleware/account/InterchainAccount.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { resolveRouterMapConfig } from '../router/types.js';
 import { ChainName } from '../types.js';
@@ -60,6 +59,7 @@ import {
 import {
   DerivedWarpRouteDeployConfig,
   HypTokenRouterVirtualConfig,
+  OwnerStatus,
   TokenMetadata,
   WarpRouteDeployConfigMailboxRequired,
   derivedHookAddress,
@@ -642,18 +642,76 @@ export function altVmScaleMismatch(
   };
 }
 
+// An owner the caller vetted and decided to accept in an Inactive on-chain
+// state. `chain`/`owner` identify the exact ownerStatus entry to accept; a
+// chain may appear more than once with different owners.
+export interface AcceptedInactiveOwner {
+  chain: ChainName;
+  owner: Address;
+}
+
+// Re-accepts caller-vetted Inactive owners by overriding the expected
+// ownerStatus back to Inactive, but ONLY where the owner is Inactive on-chain.
+// Mutates `expandedWarpDeployConfig` in place. Exported for unit testing.
+export function applyAcceptedInactiveOwnerStatus({
+  expandedWarpDeployConfig,
+  onChainWarpConfig,
+  acceptedInactiveOwners,
+}: {
+  expandedWarpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  onChainWarpConfig: Record<
+    string,
+    { ownerStatus?: Record<string, OwnerStatus> }
+  >;
+  acceptedInactiveOwners?: readonly AcceptedInactiveOwner[];
+}): void {
+  if (!acceptedInactiveOwners?.length) {
+    return;
+  }
+
+  // Group accepted owners per chain into lowercased sets for case-insensitive
+  // address matching.
+  const acceptedByChain = new Map<ChainName, Set<string>>();
+  for (const { chain, owner } of acceptedInactiveOwners) {
+    const owners = acceptedByChain.get(chain) ?? new Set<string>();
+    owners.add(owner.toLowerCase());
+    acceptedByChain.set(chain, owners);
+  }
+
+  for (const [chain, acceptedOwners] of acceptedByChain) {
+    const observedOwnerStatus = onChainWarpConfig[chain]?.ownerStatus;
+    const expectedOwnerStatus = expandedWarpDeployConfig[chain]?.ownerStatus;
+    if (!observedOwnerStatus || !expectedOwnerStatus) {
+      continue;
+    }
+
+    for (const [owner, status] of Object.entries(observedOwnerStatus)) {
+      if (
+        status === OwnerStatus.Inactive &&
+        acceptedOwners.has(owner.toLowerCase())
+      ) {
+        expectedOwnerStatus[owner] = OwnerStatus.Inactive;
+      }
+    }
+  }
+}
+
 export async function checkWarpRouteDeployConfig({
   multiProvider,
   warpCoreConfig,
   warpDeployConfig,
-  interchainAccount,
+  acceptedInactiveOwners,
 }: {
   multiProvider: MultiProvider;
   warpCoreConfig: WarpCoreConfig;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
-  // Optional ICA app used to resolve Inactive ownerStatus false positives for
-  // nonce-less governance ICA owners (Tron/AltVM). Omitted -> no resolution.
-  interchainAccount?: InterchainAccount;
+  // Owners the caller has decided to accept in an Inactive on-chain state
+  // (e.g. a nonce-less governance ICA on Tron/AltVM that a multisig controls).
+  // The caller owns the decision — including deriving and verifying the ICA and
+  // its origin Safe threshold. Here we only pass Inactive through as the
+  // expected control when the observed status is Inactive AND the exact
+  // {chain, owner} pair is present. A chain may list multiple accepted owners.
+  acceptedInactiveOwners?: readonly AcceptedInactiveOwner[];
 }): Promise<WarpRouteCheckResult> {
   const knownWarpCoreTokens = warpCoreConfig.tokens.filter(
     (token) => multiProvider.tryGetProtocol(token.chainName) !== null,
@@ -762,8 +820,18 @@ export async function checkWarpRouteDeployConfig({
     deployedRoutersAddresses,
     expandedOnChainWarpConfig,
     validateScale: false,
-    interchainAccount,
   });
+
+  // expandWarpDeployConfig deterministically maps every Inactive owner to an
+  // expected Active (a violation). Re-accept the specific owners the caller
+  // vetted, but only where the owner is actually Inactive on-chain, so a
+  // stale/incorrect accept entry can never mask a real status change.
+  applyAcceptedInactiveOwnerStatus({
+    expandedWarpDeployConfig,
+    onChainWarpConfig: expandedOnChainWarpConfig,
+    acceptedInactiveOwners,
+  });
+
   const normalizedWarpDeployConfig = normalizeWarpDeployConfigForCheck({
     multiProvider,
     warpDeployConfig: expandedWarpDeployConfig,


### PR DESCRIPTION
## Summary
- Removes all governance-ICA / Safe knowledge from the SDK warp-check. `expandWarpDeployConfig` is now deterministic (an Inactive owner always maps to expected Active), and `checkWarpRouteDeployConfig` accepts an optional `acceptedInactiveOwners: { chain, owner }[]` list. An observed Inactive owner is passed through as the expected control **only** when the exact `{ chain, owner }` pair is present.
- Moves the governance decision into infra (`typescript/infra/scripts/check/governance-ica-owners.ts`): each route declares `{ destination, declaredIca, accountConfig }` (explicit origin chain + owner — never inferred from the route). At runtime it derives the leaf ICA via `InterchainAccount.getAccount`, requires `derivedIca == declaredIca` and an origin Safe `threshold > 1`, then emits `{ destination, derivedIca }` as the accepted verdict.
- **Fail-closed everywhere**: a missing declaration, derivation mismatch/error, Safe RPC failure, or `threshold <= 1` all drop the owner from the accepted set, so the ownerStatus violation still fires and the anti-1-of-1 signal is preserved. The SDK's match against the observed on-chain owner supplies the final `derivedIca == onChainOwner` check.

## Why
The old SDK-side heuristic assumed Ethereum as the ICA origin and inferred the owner from the route — coupling the deterministic SDK checker to a governance-specific policy. This inverts that: the SDK stays governance-agnostic; infra declares intent and verifies it.

## Test plan
- [x] SDK: `applyAcceptedInactiveOwnerStatus` unit tests — multiple accepted owners on one chain, chain/address mismatch, non-Inactive statuses not overridden, case-insensitive match, empty-list no-op.
- [x] Infra: `verifyGovernanceIcaOwner` / `resolveAcceptedInactiveOwners` tests — non-ethereum declared origin success, threshold 1 fail-closed, derivation mismatch fail-closed, derivation throw fail-closed, Safe RPC revert fail-closed, missing declaration → empty.
- [x] `pnpm --filter @hyperlane-xyz/sdk build`, SDK + infra typecheck, `oxlint`, all affected tests green.

cc <@U08GTGH9ULA> <@U06RL49CZQD>

🤖 Generated with [Claude Code](https://claude.com/claude-code)