### PR TITLE
fix(ci): stabilize Tron test runtime

### DIFF
--- a/.changeset/stable-tron-test-runtime.md
+++ b/.changeset/stable-tron-test-runtime.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/tron-sdk': patch
+---
+
+The Tron test runtime was pinned to TRE 2.0.0 and now uses its HTTP health check with an explicit Tron HD path.

--- a/rust/main/utils/run-locally/src/tron/mod.rs
+++ b/rust/main/utils/run-locally/src/tron/mod.rs
@@ -30,13 +30,17 @@ use crate::{
     SCRAPER_METRICS_PORT,
 };
 
+/// Immutable multi-platform digest for tronbox/tre 2.0.0.
+const TRE_IMAGE: &str =
+    "tronbox/tre@sha256:f4332e11df12a9f360639a4546fd046593909630fda48af00b30410c144342f0";
+
 /// BIP-44 m/44'/195'/0'/0/0 derived from the "abandon" mnemonic.
-/// This is the default funded account in tronbox/tre:dev.
 const TRON_PRIVATE_KEY: &str = "0xb5a4cea271ff424d7c31dc12a3e43e401df7a40d7412a15750f3f0b6b5449a28";
 
 /// Mnemonic passed to TRE to ensure deterministic accounts.
 const TRE_MNEMONIC: &str =
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const TRE_HD_PATH: &str = "m/44'/195'/0'/0/";
 
 const TRON_RPC_URL: &str = "http://127.0.0.1:9090/jsonrpc";
 const TRON_WALLET_URL: &str = "http://127.0.0.1:9090/wallet";
@@ -266,8 +270,9 @@ fn run_locally() {
         .arg("env", "block=allowTvmCompatibleEvm:1")
         .arg("env", "preapprove=allowTvmCompatibleEvm:1")
         .arg("env", format!("mnemonic={}", TRE_MNEMONIC))
+        .arg("env", format!("hdPath={}", TRE_HD_PATH))
         .arg("env", "defaultBalance=1000000")
-        .cmd("tronbox/tre:dev")
+        .cmd(TRE_IMAGE)
         .filter_logs(|_| false)
         .spawn("TRN", None);
 

--- a/typescript/tron-sdk/compose.yaml
+++ b/typescript/tron-sdk/compose.yaml
@@ -1,6 +1,6 @@
 services:
   devnode:
-    image: tronbox/tre
+    image: tronbox/tre@sha256:f4332e11df12a9f360639a4546fd046593909630fda48af00b30410c144342f0
     container_name: tron
     ports:
       - '9090:9090'

--- a/typescript/tron-sdk/src/testing/node.ts
+++ b/typescript/tron-sdk/src/testing/node.ts
@@ -21,12 +21,19 @@ export interface TronTestChainMetadata {
 const TRE_CONTAINER_PORT = 9090;
 
 /**
+ * Immutable multi-platform digest for tronbox/tre 2.0.0.
+ */
+const TRE_IMAGE =
+  'tronbox/tre@sha256:f4332e11df12a9f360639a4546fd046593909630fda48af00b30410c144342f0';
+
+/**
  * Fixed mnemonic passed to tronbox/tre so accounts are deterministic.
  * The derived account 0 private key must match TEST_TRON_PRIVATE_KEY
  * in constants.ts.
  */
 const TRE_MNEMONIC =
   'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const TRE_HD_PATH = "m/44'/195'/0'/0/";
 
 /**
  * Result of starting a Tron node, including the container and funded keys.
@@ -53,10 +60,11 @@ export async function runTronNode(
 
   const container = await retryAsync(
     () => {
-      return new GenericContainer('tronbox/tre:dev')
+      return new GenericContainer(TRE_IMAGE)
         .withEnvironment({
           preapprove: 'allowTvmCompatibleEvm:1',
           mnemonic: TRE_MNEMONIC,
+          hdPath: TRE_HD_PATH,
           defaultBalance: '1000000',
         })
         .withExposedPorts({
@@ -65,9 +73,11 @@ export async function runTronNode(
         })
         .withStartupTimeout(120_000)
         .withWaitStrategy(
-          Wait.forLogMessage(/TRE now listening on/).withStartupTimeout(
-            120_000,
-          ),
+          Wait.forHttp('/healthcheck', TRE_CONTAINER_PORT, {
+            abortOnContainerExit: true,
+          })
+            .forStatusCode(200)
+            .withStartupTimeout(120_000),
         )
         .start();
     },


### PR DESCRIPTION
## Summary

- pin every active TRE test runtime reference to the immutable `tronbox/tre:2.0.0` multi-platform digest
- wait for TRE's `/healthcheck` endpoint instead of the removed `TRE now listening on` log message
- explicitly derive deterministic accounts with the Tron BIP-44 path in both TypeScript and Rust test runners

## Root cause

`tronbox/tre:dev` was republished as TRE 2.0.0. The new unified runtime no longer emits the log line used by the Testcontainers readiness check and defaults to the Ethereum HD path. Coverage and all three Tron CLI E2E shards consequently timed out before running tests.

## Validation

- `pnpm -C typescript/tron-sdk build`
- focused `oxlint` and `oxfmt` on `src/testing/node.ts`
- `rustfmt --check rust/main/utils/run-locally/src/tron/mod.rs`
- `docker compose -f typescript/tron-sdk/compose.yaml config --images`
- `pnpm version:check`

Full local container execution was unavailable because the Docker daemon was not running; GitHub CI exercises the pinned Linux image.