### PR TITLE
feat(infra): add validator checkpoint liveness monitor

### DIFF
--- a/.changeset/metrics-submit-throw-on-error.md
+++ b/.changeset/metrics-submit-throw-on-error.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+An opt-in `throwOnError` option was added to `submitMetrics` so batch/CronJob callers can fail loudly when a PushGateway push errors or returns a non-2xx status instead of silently recording a successful run.

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -34,6 +34,7 @@ interface BaseDockerTags extends AgentDockerTags {
 
 interface MainnetDockerTags extends BaseDockerTags {
   checkWarpDeploy: string;
+  validatorMonitor: string;
   warpMonitor: string;
   rebalancer: string;
   feeQuoting: string;
@@ -50,6 +51,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   scraper: 'e22be4b-20260715-194756',
   // monorepo services
   checkWarpDeploy: 'main',
+  validatorMonitor: 'main',
   // standalone services
   keyFunder: '5dc6aa4-20260714-184449',
   warpMonitor: '744b3bb-20260521-215958',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -51,7 +51,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   scraper: 'e22be4b-20260715-194756',
   // monorepo services
   checkWarpDeploy: 'main',
-  validatorMonitor: 'main',
+  validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
   keyFunder: '5dc6aa4-20260714-184449',
   warpMonitor: '744b3bb-20260521-215958',

--- a/typescript/infra/config/environments/mainnet3/index.ts
+++ b/typescript/infra/config/environments/mainnet3/index.ts
@@ -17,6 +17,7 @@ import { getIgp } from './igp.js';
 import { infrastructure } from './infrastructure.js';
 import { chainOwners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
+import { validatorMonitorConfig } from './validatorMonitor.js';
 import { checkWarpDeployConfig } from './warp/checkWarpDeploy.js';
 
 export const environment: EnvironmentConfig = {
@@ -59,4 +60,5 @@ export const environment: EnvironmentConfig = {
   infra: infrastructure,
   keyFunderConfig,
   checkWarpDeployConfig,
+  validatorMonitorConfig,
 };

--- a/typescript/infra/config/environments/mainnet3/validatorMonitor.ts
+++ b/typescript/infra/config/environments/mainnet3/validatorMonitor.ts
@@ -1,0 +1,16 @@
+import { ValidatorMonitorConfig } from '../../../src/config/funding.js';
+import { DockerImageRepos, mainnetDockerTags } from '../../docker.js';
+
+import { environment } from './chains.js';
+
+export const validatorMonitorConfig: ValidatorMonitorConfig = {
+  docker: {
+    repo: DockerImageRepos.MONOREPO,
+    tag: mainnetDockerTags.validatorMonitor,
+  },
+  namespace: environment,
+  cronSchedule: '*/30 * * * *', // every 30 minutes
+  prometheusPushGateway:
+    'http://prometheus-prometheus-pushgateway.monitoring.svc.cluster.local:9091',
+  registryCommit: 'main', // always use the latest version from the main branch
+};

--- a/typescript/infra/helm/validator-monitor/Chart.yaml
+++ b/typescript/infra/helm/validator-monitor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: validator-monitor
+description: Validator checkpoint liveness monitor
+type: application
+version: 0.1.0
+appVersion: '1.16.0'

--- a/typescript/infra/helm/validator-monitor/templates/_helpers.tpl
+++ b/typescript/infra/helm/validator-monitor/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hyperlane.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hyperlane.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hyperlane.labels" -}}
+helm.sh/chart: {{ include "hyperlane.chart" . }}
+hyperlane/deployment: {{ .Values.hyperlane.runEnv | quote }}
+hyperlane/context: "hyperlane"
+{{ include "hyperlane.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hyperlane.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hyperlane.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The name of the ClusterSecretStore
+*/}}
+{{- define "hyperlane.cluster-secret-store.name" -}}
+{{- default "external-secrets-gcp-cluster-secret-store" .Values.externalSecrets.clusterSecretStore }}
+{{- end }}

--- a/typescript/infra/helm/validator-monitor/templates/cron-job.yaml
+++ b/typescript/infra/helm/validator-monitor/templates/cron-job.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: validator-monitor
+spec:
+  schedule: "{{ .Values.cronjob.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: validator-monitor
+            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+            imagePullPolicy: Always
+            # Use `args` instead of `command` to preserve the Docker ENTRYPOINT.
+            # The entrypoint script (docker-entrypoint.sh) handles REGISTRY_COMMIT checkout.
+            # Using `command` would bypass the entrypoint and break registry version pinning.
+            args:
+            - pnpm
+            - exec
+            - tsx
+            - ./typescript/infra/scripts/validators/monitor-checkpoints.ts
+            - -e
+            - {{ .Values.hyperlane.runEnv }}
+            - --pushMetrics
+            env:
+            - name: PROMETHEUS_PUSH_GATEWAY
+              value: {{ .Values.infra.prometheusPushGateway }}
+            {{- if .Values.hyperlane.registryCommit }}
+            - name: REGISTRY_COMMIT
+              value: {{ .Values.hyperlane.registryCommit }}
+            {{- end }}
+            envFrom:
+            - secretRef:
+                name: validator-monitor-env-var-secret

--- a/typescript/infra/helm/validator-monitor/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/validator-monitor/templates/env-var-external-secret.yaml
@@ -1,0 +1,45 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: validator-monitor-env-var-external-secret
+  labels:
+    {{- include "hyperlane.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ include "hyperlane.cluster-secret-store.name" . }}
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  # The secret that will be created
+  target:
+    name: validator-monitor-env-var-secret
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          {{- include "hyperlane.labels" . | nindent 10 }}
+        annotations:
+          update-on-redeploy: "{{ now }}"
+      data:
+        GCP_SECRET_OVERRIDES_ENABLED: "true"
+        GCP_SECRET_OVERRIDE_HYPERLANE_{{ .Values.hyperlane.runEnv | upper }}_KEY_DEPLOYER: {{ print "'{{ .deployer_key | toString }}'" }}
+{{/*
+   * For each network, create an environment variable with the RPC endpoint.
+   * The templating of external-secrets will use the data section below to know how
+   * to replace the correct value in the created secret.
+   */}}
+        {{- range .Values.hyperlane.chains }}
+        GCP_SECRET_OVERRIDE_{{ $.Values.hyperlane.runEnv | upper }}_RPC_ENDPOINTS_{{ . | upper }}: {{ printf "'{{ .%s_rpcs | toString }}'" . }}
+        {{- end }}
+  data:
+  - secretKey: deployer_key
+    remoteRef:
+      key: {{ printf "hyperlane-%s-key-deployer" .Values.hyperlane.runEnv }}
+{{/*
+   * For each network, load the secret in GCP secret manager with the form: environment-rpc-endpoint-network,
+   * and associate it with the secret key networkname_rpc.
+   */}}
+  {{- range .Values.hyperlane.chains }}
+  - secretKey: {{ printf "%s_rpcs" . }}
+    remoteRef:
+      key: {{ printf "%s-rpc-endpoints-%s" $.Values.hyperlane.runEnv . }}
+  {{- end }}

--- a/typescript/infra/helm/validator-monitor/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/validator-monitor/templates/env-var-external-secret.yaml
@@ -21,7 +21,6 @@ spec:
           update-on-redeploy: "{{ now }}"
       data:
         GCP_SECRET_OVERRIDES_ENABLED: "true"
-        GCP_SECRET_OVERRIDE_HYPERLANE_{{ .Values.hyperlane.runEnv | upper }}_KEY_DEPLOYER: {{ print "'{{ .deployer_key | toString }}'" }}
 {{/*
    * For each network, create an environment variable with the RPC endpoint.
    * The templating of external-secrets will use the data section below to know how
@@ -31,9 +30,6 @@ spec:
         GCP_SECRET_OVERRIDE_{{ $.Values.hyperlane.runEnv | upper }}_RPC_ENDPOINTS_{{ . | upper }}: {{ printf "'{{ .%s_rpcs | toString }}'" . }}
         {{- end }}
   data:
-  - secretKey: deployer_key
-    remoteRef:
-      key: {{ printf "hyperlane-%s-key-deployer" .Values.hyperlane.runEnv }}
 {{/*
    * For each network, load the secret in GCP secret manager with the form: environment-rpc-endpoint-network,
    * and associate it with the secret key networkname_rpc.

--- a/typescript/infra/helm/validator-monitor/values.yaml
+++ b/typescript/infra/helm/validator-monitor/values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: ghcr.io/hyperlane-xyz/hyperlane-monorepo
+  tag:
+hyperlane:
+  runEnv: mainnet3
+  chains: []
+  registryCommit: '' # Registry commit to use
+cronjob:
+  schedule: '*/30 * * * *'
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+externalSecrets:
+  clusterSecretStore:

--- a/typescript/infra/scripts/validators/deploy-validator-monitor.ts
+++ b/typescript/infra/scripts/validators/deploy-validator-monitor.ts
@@ -1,0 +1,26 @@
+import { Contexts } from '../../config/contexts.js';
+import { HelmCommand } from '../../src/utils/helm.js';
+import { ValidatorMonitorHelmManager } from '../../src/validator-monitor/helm.js';
+import { assertCorrectKubeContext } from '../agent-utils.js';
+import { getConfigsBasedOnArgs } from '../core-utils.js';
+
+async function main() {
+  const { agentConfig, envConfig, environment } = await getConfigsBasedOnArgs();
+  if (agentConfig.context != Contexts.Hyperlane)
+    throw new Error(
+      `Invalid context ${agentConfig.context}, must be ${Contexts.Hyperlane}`,
+    );
+
+  await assertCorrectKubeContext(envConfig);
+
+  const manager = ValidatorMonitorHelmManager.forEnvironment(environment);
+  if (!manager) {
+    throw new Error('No validatorMonitorConfig found');
+  }
+
+  await manager.runHelmCommand(HelmCommand.InstallOrUpgrade);
+}
+
+main()
+  .then(() => console.log('Deploy successful!'))
+  .catch(console.error);

--- a/typescript/infra/scripts/validators/deploy-validator-monitor.ts
+++ b/typescript/infra/scripts/validators/deploy-validator-monitor.ts
@@ -23,4 +23,7 @@ async function main() {
 
 main()
   .then(() => console.log('Deploy successful!'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/typescript/infra/scripts/validators/monitor-checkpoints.ts
+++ b/typescript/infra/scripts/validators/monitor-checkpoints.ts
@@ -1,0 +1,369 @@
+/**
+ * Validator checkpoint liveness monitor.
+ *
+ * Polls each whitelisted validator's latest signed checkpoint directly from its
+ * checkpoint syncer (S3/GCS) and compares it against ground truth:
+ *   - the on-chain MerkleTreeHook leaf count (absolute lag), and
+ *   - the furthest-ahead peer in the same validator set on the same chain
+ *     (relative/peer lag).
+ *
+ * Unlike the relayer-observed `hyperlane_observed_validator_latest_index`
+ * metric, this reads the syncer directly, so a stalled validator produces a
+ * monotonically growing lag that only clears when the validator resumes
+ * signing. That makes it a clean, non-flapping basis for a downtime alert.
+ *
+ * Usage (all sets, push to prometheus):
+ *   pnpm tsx scripts/validators/monitor-checkpoints.ts -e mainnet3 --pushMetrics
+ *
+ * Usage (local inspection, one set, no push):
+ *   pnpm tsx scripts/validators/monitor-checkpoints.ts -e mainnet3 --set renzo
+ */
+import chalk from 'chalk';
+import { Gauge, Registry } from 'prom-client';
+
+import {
+  MerkleTreeHook__factory,
+  ValidatorAnnounce__factory,
+} from '@hyperlane-xyz/core';
+import { submitMetrics } from '@hyperlane-xyz/metrics';
+import { getValidatorFromStorageLocation } from '@hyperlane-xyz/sdk';
+import {
+  LogFormat,
+  LogLevel,
+  configureRootLogger,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+
+import { Contexts } from '../../config/contexts.js';
+import { getChainAddresses } from '../../config/registry.js';
+import { Role } from '../../src/roles.js';
+import { isEthereumProtocolChain } from '../../src/utils/utils.js';
+import {
+  MonitoredValidator,
+  ValidatorSetName,
+  getMonitoredValidatorSets,
+} from '../../src/validators/monitorConfig.js';
+import {
+  getArgs as getRootArgs,
+  withChains,
+  withPushMetrics,
+} from '../agent-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
+
+// A reachable validator whose signed checkpoint trails the furthest-ahead peer
+// in its set on the same chain by at least this many leaves is treated as
+// stalled relative to its peers. Peer lag is volume-independent: it only grows
+// when peers keep signing while this validator does not.
+const PEER_LAG_STALL_THRESHOLD = 5;
+
+// Backstop for validators with no live peer to diff against (e.g. single-signer
+// chains): treat a validator trailing the on-chain merkle count by at least this
+// many leaves as stalled. Set generously above normal catch-up jitter (observed
+// 0-2 leaves) so a healthy validator briefly behind during a dispatch burst is
+// never flagged.
+const ONCHAIN_LAG_STALL_THRESHOLD = 50;
+
+function getArgs() {
+  return withChains(withPushMetrics(getRootArgs()))
+    .describe('set', 'only monitor a single validator set')
+    .choices('set', Object.values(ValidatorSetName)).argv;
+}
+
+type ValidatorReading = {
+  set: ValidatorSetName;
+  chain: string;
+  address: string;
+  alias: string;
+  // Latest checkpoint index signed by the validator (-1 if none / unreachable).
+  index: number;
+  reachable: boolean;
+};
+
+type ValidatorRow = ValidatorReading & {
+  onchainCount: number | undefined;
+  lagOnchain: number | undefined;
+  lagPeer: number | undefined;
+  down: boolean;
+};
+
+async function main() {
+  configureRootLogger(LogFormat.Pretty, LogLevel.Info);
+  const {
+    environment,
+    pushMetrics,
+    chains: chainFilter,
+    set: setFilter,
+  } = await getArgs();
+
+  const sets = getMonitoredValidatorSets(environment).filter(
+    (s) => !setFilter || s.name === setFilter,
+  );
+
+  const envConfig = getEnvironmentConfig(environment);
+
+  // Union of chains across the selected sets, restricted to EVM chains this
+  // environment supports (so we have RPC/secrets and a MerkleTreeHook to read),
+  // and to the optional --chains filter.
+  const targetChains = Array.from(
+    new Set(sets.flatMap((s) => Object.keys(s.validators))),
+  )
+    .filter((c) => envConfig.supportedChainNames.includes(c))
+    .filter(isEthereumProtocolChain)
+    .filter((c) => !chainFilter?.length || chainFilter.includes(c));
+
+  if (targetChains.length === 0) {
+    rootLogger.error('No target chains after filtering');
+    process.exit(1);
+  }
+
+  const multiProvider = await envConfig.getMultiProvider(
+    Contexts.Hyperlane,
+    Role.Deployer,
+    true,
+    targetChains,
+  );
+  const chainAddresses = getChainAddresses();
+
+  // On-chain merkle leaf count per chain (absolute ground truth). undefined if
+  // the read fails, in which case we still report reachability but omit the
+  // on-chain lag so a chain-wide RPC hiccup can't masquerade as "resolved".
+  const onchainCounts: Record<string, number | undefined> = {};
+  await Promise.all(
+    targetChains.map(async (chain) => {
+      try {
+        const merkleTreeHook = MerkleTreeHook__factory.connect(
+          chainAddresses[chain].merkleTreeHook,
+          multiProvider.getProvider(chain),
+        );
+        onchainCounts[chain] = await merkleTreeHook.count();
+      } catch (error) {
+        rootLogger.error(
+          `[${chain}] Failed to read on-chain merkle count: ${error}`,
+        );
+        onchainCounts[chain] = undefined;
+      }
+    }),
+  );
+
+  // Resolve + read each validator's latest checkpoint index once per
+  // (chain, address); a validator may appear in more than one set.
+  const readingCache = new Map<string, Promise<number>>();
+  const readIndex = (chain: string, address: string): Promise<number> => {
+    const key = `${chain}:${address.toLowerCase()}`;
+    let cached = readingCache.get(key);
+    if (!cached) {
+      cached = (async () => {
+        const validatorAnnounce = ValidatorAnnounce__factory.connect(
+          chainAddresses[chain].validatorAnnounce,
+          multiProvider.getProvider(chain),
+        );
+        const [locations] =
+          await validatorAnnounce.getAnnouncedStorageLocations([address]);
+        const location = locations?.[locations.length - 1];
+        if (!location) {
+          throw new Error('no announced storage location');
+        }
+        const validator = await getValidatorFromStorageLocation(location);
+        return validator.getLatestCheckpointIndex();
+      })();
+      readingCache.set(key, cached);
+    }
+    return cached;
+  };
+
+  const readings: ValidatorReading[] = [];
+  await Promise.all(
+    sets.flatMap((s) =>
+      targetChains
+        .filter((chain) => s.validators[chain]?.length)
+        .flatMap((chain) =>
+          s.validators[chain].map(async (validator: MonitoredValidator) => {
+            try {
+              const index = await readIndex(chain, validator.address);
+              readings.push({
+                set: s.name,
+                chain,
+                address: validator.address,
+                alias: validator.alias,
+                index,
+                reachable: index >= 0,
+              });
+            } catch (error) {
+              rootLogger.debug(
+                `[${chain}] ${s.name}/${validator.alias} (${validator.address}) unreachable: ${error}`,
+              );
+              readings.push({
+                set: s.name,
+                chain,
+                address: validator.address,
+                alias: validator.alias,
+                index: -1,
+                reachable: false,
+              });
+            }
+          }),
+        ),
+    ),
+  );
+
+  // Furthest-ahead reachable peer per (set, chain) for the relative diff.
+  const peerMax = new Map<string, number>();
+  for (const r of readings) {
+    if (!r.reachable) continue;
+    const key = `${r.set}:${r.chain}`;
+    peerMax.set(key, Math.max(peerMax.get(key) ?? -1, r.index));
+  }
+
+  const rows: ValidatorRow[] = readings.map((r) => {
+    const onchainCount = onchainCounts[r.chain];
+    // On-chain latest leaf index is count - 1.
+    const lagOnchain =
+      r.reachable && onchainCount !== undefined
+        ? Math.max(0, onchainCount - 1 - r.index)
+        : undefined;
+    const peer = peerMax.get(`${r.set}:${r.chain}`);
+    const lagPeer =
+      r.reachable && peer !== undefined
+        ? Math.max(0, peer - r.index)
+        : undefined;
+    const down =
+      !r.reachable ||
+      (lagPeer !== undefined && lagPeer >= PEER_LAG_STALL_THRESHOLD) ||
+      (lagOnchain !== undefined && lagOnchain >= ONCHAIN_LAG_STALL_THRESHOLD);
+    return { ...r, onchainCount, lagOnchain, lagPeer, down };
+  });
+
+  printReport(rows);
+
+  if (pushMetrics) {
+    await pushValidatorMetrics(rows, environment);
+  }
+
+  process.exit(0);
+}
+
+function printReport(rows: ValidatorRow[]) {
+  const bySet = new Map<ValidatorSetName, ValidatorRow[]>();
+  for (const row of rows) {
+    const existing = bySet.get(row.set) ?? [];
+    existing.push(row);
+    bySet.set(row.set, existing);
+  }
+
+  for (const [set, setRows] of bySet) {
+    rootLogger.info(`\n${set} validators:`);
+    const table = setRows
+      .slice()
+      .sort(
+        (a, b) =>
+          a.chain.localeCompare(b.chain) ||
+          (b.lagPeer ?? -1) - (a.lagPeer ?? -1),
+      )
+      .map((r) => ({
+        chain: r.chain,
+        alias: r.alias,
+        index: r.index,
+        onchain: r.onchainCount ?? '?',
+        lag_onchain: r.lagOnchain ?? '?',
+        lag_peer: r.lagPeer ?? '?',
+        status: r.down ? '❌ DOWN' : '✅',
+      }));
+    // eslint-disable-next-line no-console
+    console.table(table);
+  }
+
+  const down = rows.filter((r) => r.down);
+  if (down.length === 0) {
+    rootLogger.info(chalk.green('\nAll monitored validators are live.'));
+  } else {
+    rootLogger.warn(
+      chalk.yellow(`\n${down.length} validator(s) flagged as down:`),
+    );
+    for (const r of down) {
+      const reason = !r.reachable
+        ? 'unreachable / no checkpoints'
+        : r.lagPeer !== undefined && r.lagPeer >= PEER_LAG_STALL_THRESHOLD
+          ? `peer lag ${r.lagPeer} (onchain lag ${r.lagOnchain})`
+          : `onchain lag ${r.lagOnchain} (no live peer)`;
+      rootLogger.warn(
+        chalk.yellow(
+          `  - [${r.chain}] ${r.set}/${r.alias} ${r.address}: ${reason}`,
+        ),
+      );
+    }
+  }
+}
+
+// The whole job group is overwritten (PUT) on every run so the published metrics
+// are a full snapshot: a validator removed from config, or a set no longer
+// monitored, disappears cleanly instead of lingering as a ghost series. Every
+// monitored validator is always represented (reachable 0/1), so a validator we
+// failed to read shows as unreachable rather than vanishing.
+async function pushValidatorMetrics(rows: ValidatorRow[], environment: string) {
+  const register = new Registry();
+  const labelNames = ['chain', 'validator', 'alias', 'validator_set'];
+
+  const reachableGauge = new Gauge({
+    name: 'hyperlane_validator_reachable',
+    help: 'Whether the validator checkpoint syncer could be read (1) or not (0)',
+    registers: [register],
+    labelNames,
+  });
+  const indexGauge = new Gauge({
+    name: 'hyperlane_validator_checkpoint_index',
+    help: 'Latest checkpoint index signed by the validator (from its syncer)',
+    registers: [register],
+    labelNames,
+  });
+  const lagOnchainGauge = new Gauge({
+    name: 'hyperlane_validator_checkpoint_lag_onchain',
+    help: 'Leaves behind the on-chain merkle tree count (absolute lag)',
+    registers: [register],
+    labelNames,
+  });
+  const lagPeerGauge = new Gauge({
+    name: 'hyperlane_validator_checkpoint_lag_peer',
+    help: 'Leaves behind the furthest-ahead peer in the same set on the same chain',
+    registers: [register],
+    labelNames,
+  });
+  const onchainCountGauge = new Gauge({
+    name: 'hyperlane_validator_onchain_merkle_count',
+    help: 'On-chain MerkleTreeHook leaf count',
+    registers: [register],
+    labelNames: ['chain'],
+  });
+
+  const seenChains = new Set<string>();
+  for (const row of rows) {
+    const labels = {
+      chain: row.chain,
+      validator: row.address,
+      alias: row.alias,
+      validator_set: row.set,
+    };
+    reachableGauge.labels(labels).set(row.reachable ? 1 : 0);
+    if (row.reachable) {
+      indexGauge.labels(labels).set(row.index);
+    }
+    if (row.lagOnchain !== undefined) {
+      lagOnchainGauge.labels(labels).set(row.lagOnchain);
+    }
+    if (row.lagPeer !== undefined) {
+      lagPeerGauge.labels(labels).set(row.lagPeer);
+    }
+    if (row.onchainCount !== undefined && !seenChains.has(row.chain)) {
+      seenChains.add(row.chain);
+      onchainCountGauge.labels({ chain: row.chain }).set(row.onchainCount);
+    }
+  }
+
+  await submitMetrics(register, `validator-monitor-${environment}`, {
+    overwriteAllMetrics: true,
+  });
+}
+
+main().catch((err) => {
+  rootLogger.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/typescript/infra/scripts/validators/monitor-checkpoints.ts
+++ b/typescript/infra/scripts/validators/monitor-checkpoints.ts
@@ -26,17 +26,21 @@ import {
   ValidatorAnnounce__factory,
 } from '@hyperlane-xyz/core';
 import { submitMetrics } from '@hyperlane-xyz/metrics';
-import { getValidatorFromStorageLocation } from '@hyperlane-xyz/sdk';
 import {
+  MultiProvider,
+  getValidatorFromStorageLocation,
+} from '@hyperlane-xyz/sdk';
+import {
+  BaseValidator,
   LogFormat,
   LogLevel,
+  bytes32ToAddress,
   configureRootLogger,
+  eqAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { Contexts } from '../../config/contexts.js';
 import { getChainAddresses } from '../../config/registry.js';
-import { Role } from '../../src/roles.js';
 import { isEthereumProtocolChain } from '../../src/utils/utils.js';
 import {
   MonitoredValidator,
@@ -69,14 +73,28 @@ function getArgs() {
     .choices('set', Object.values(ValidatorSetName)).argv;
 }
 
+// Outcome of resolving + reading + verifying a validator's latest checkpoint.
+//   ok          - a signed checkpoint at `index` was fetched and its signature,
+//                 signer, domain, hook and index all check out.
+//   none        - the validator resolved but has not signed any checkpoint yet.
+//   unreachable - the storage location could not be resolved or read.
+//   unverified  - a latest-index pointer was read but the backing checkpoint is
+//                 missing or fails verification (wrong signer, wrong domain/hook,
+//                 or an index ahead of the on-chain merkle tree). Treated as not
+//                 live and, crucially, excluded from peerMax so a forged pointer
+//                 cannot make honest peers look stalled.
+type CheckpointStatus = 'ok' | 'none' | 'unreachable' | 'unverified';
+
+type CheckpointRead = { status: CheckpointStatus; index: number };
+
 type ValidatorReading = {
   set: ValidatorSetName;
   chain: string;
   address: string;
   alias: string;
-  // Latest checkpoint index signed by the validator (-1 if none / unreachable).
+  status: CheckpointStatus;
+  // Latest verified checkpoint index (-1 unless status is 'ok').
   index: number;
-  reachable: boolean;
 };
 
 type ValidatorRow = ValidatorReading & {
@@ -85,6 +103,84 @@ type ValidatorRow = ValidatorReading & {
   lagPeer: number | undefined;
   down: boolean;
 };
+
+// Resolve a validator's announced storage location, read its latest-index
+// pointer, then fetch and cryptographically verify the checkpoint it points at.
+// A bare latest-index pointer is untrusted: it is unsigned, and the announced
+// bucket identity is not authenticated on-chain, so a validator could announce
+// a healthy peer's bucket or publish an arbitrary future index. We therefore
+// only accept an index once the signed checkpoint at that index recovers to the
+// expected signer for this chain's mailbox domain and merkle tree hook.
+async function readAndVerifyCheckpoint(
+  chain: string,
+  address: string,
+  multiProvider: MultiProvider,
+  addresses: Record<string, string>,
+  onchainCount: number | undefined,
+): Promise<CheckpointRead> {
+  try {
+    const validatorAnnounce = ValidatorAnnounce__factory.connect(
+      addresses.validatorAnnounce,
+      multiProvider.getProvider(chain),
+    );
+    const [locations] = await validatorAnnounce.getAnnouncedStorageLocations([
+      address,
+    ]);
+    const location = locations?.[locations.length - 1];
+    if (!location) {
+      return { status: 'unreachable', index: -1 };
+    }
+
+    const validator = await getValidatorFromStorageLocation(location);
+    const latestIndex = await validator.getLatestCheckpointIndex();
+    if (latestIndex < 0) {
+      return { status: 'none', index: -1 };
+    }
+
+    // No honest checkpoint can exist ahead of the on-chain merkle tree, so an
+    // index beyond count-1 is a forged/ahead pointer. Reject it rather than let
+    // it poison peerMax.
+    if (onchainCount !== undefined && latestIndex > onchainCount - 1) {
+      rootLogger.warn(
+        `[${chain}] ${address} latest index ${latestIndex} exceeds on-chain count ${onchainCount}; rejecting`,
+      );
+      return { status: 'unverified', index: -1 };
+    }
+
+    const signed = await validator.getCheckpoint(latestIndex);
+    if (!signed) {
+      rootLogger.warn(
+        `[${chain}] ${address} advertised index ${latestIndex} but no signed checkpoint is present`,
+      );
+      return { status: 'unverified', index: -1 };
+    }
+
+    const recovered = BaseValidator.recoverAddress(signed);
+    const { checkpoint } = signed.value;
+    const domainId = multiProvider.getDomainId(chain);
+    if (
+      !eqAddress(recovered, address) ||
+      checkpoint.index !== latestIndex ||
+      checkpoint.mailbox_domain !== domainId ||
+      !eqAddress(
+        bytes32ToAddress(checkpoint.merkle_tree_hook_address),
+        addresses.merkleTreeHook,
+      )
+    ) {
+      rootLogger.warn(
+        `[${chain}] ${address} checkpoint failed verification ` +
+          `(signer ${recovered}, domain ${checkpoint.mailbox_domain} vs ${domainId}, ` +
+          `hook ${checkpoint.merkle_tree_hook_address}, index ${checkpoint.index} vs ${latestIndex})`,
+      );
+      return { status: 'unverified', index: -1 };
+    }
+
+    return { status: 'ok', index: latestIndex };
+  } catch (error) {
+    rootLogger.debug(`[${chain}] ${address} unreachable: ${error}`);
+    return { status: 'unreachable', index: -1 };
+  }
+}
 
 async function main() {
   configureRootLogger(LogFormat.Pretty, LogLevel.Info);
@@ -116,12 +212,14 @@ async function main() {
     process.exit(1);
   }
 
-  const multiProvider = await envConfig.getMultiProvider(
-    Contexts.Hyperlane,
-    Role.Deployer,
-    true,
-    targetChains,
-  );
+  // Read-only workload: build an unsigned MultiProvider straight from the
+  // secret-backed registry RPC metadata. We never sign anything here, so we do
+  // NOT ask for Role.Deployer (which would eagerly install the mainnet deployer
+  // key on every EVM provider — unnecessary privileged-key exposure).
+  const registry = await envConfig.getRegistry(true, targetChains);
+  const multiProvider = new MultiProvider(await registry.getMetadata(), {
+    minConfirmationTimeoutMs: 300_000,
+  });
   const chainAddresses = getChainAddresses();
 
   // On-chain merkle leaf count per chain (absolute ground truth). undefined if
@@ -145,27 +243,23 @@ async function main() {
     }),
   );
 
-  // Resolve + read each validator's latest checkpoint index once per
+  // Resolve, read, and VERIFY each validator's latest checkpoint once per
   // (chain, address); a validator may appear in more than one set.
-  const readingCache = new Map<string, Promise<number>>();
-  const readIndex = (chain: string, address: string): Promise<number> => {
+  const readingCache = new Map<string, Promise<CheckpointRead>>();
+  const readCheckpoint = (
+    chain: string,
+    address: string,
+  ): Promise<CheckpointRead> => {
     const key = `${chain}:${address.toLowerCase()}`;
     let cached = readingCache.get(key);
     if (!cached) {
-      cached = (async () => {
-        const validatorAnnounce = ValidatorAnnounce__factory.connect(
-          chainAddresses[chain].validatorAnnounce,
-          multiProvider.getProvider(chain),
-        );
-        const [locations] =
-          await validatorAnnounce.getAnnouncedStorageLocations([address]);
-        const location = locations?.[locations.length - 1];
-        if (!location) {
-          throw new Error('no announced storage location');
-        }
-        const validator = await getValidatorFromStorageLocation(location);
-        return validator.getLatestCheckpointIndex();
-      })();
+      cached = readAndVerifyCheckpoint(
+        chain,
+        address,
+        multiProvider,
+        chainAddresses[chain],
+        onchainCounts[chain],
+      );
       readingCache.set(key, cached);
     }
     return cached;
@@ -178,56 +272,46 @@ async function main() {
         .filter((chain) => s.validators[chain]?.length)
         .flatMap((chain) =>
           s.validators[chain].map(async (validator: MonitoredValidator) => {
-            try {
-              const index = await readIndex(chain, validator.address);
-              readings.push({
-                set: s.name,
-                chain,
-                address: validator.address,
-                alias: validator.alias,
-                index,
-                reachable: index >= 0,
-              });
-            } catch (error) {
-              rootLogger.debug(
-                `[${chain}] ${s.name}/${validator.alias} (${validator.address}) unreachable: ${error}`,
-              );
-              readings.push({
-                set: s.name,
-                chain,
-                address: validator.address,
-                alias: validator.alias,
-                index: -1,
-                reachable: false,
-              });
-            }
+            const { status, index } = await readCheckpoint(
+              chain,
+              validator.address,
+            );
+            readings.push({
+              set: s.name,
+              chain,
+              address: validator.address,
+              alias: validator.alias,
+              status,
+              index,
+            });
           }),
         ),
     ),
   );
 
-  // Furthest-ahead reachable peer per (set, chain) for the relative diff.
+  // Furthest-ahead VERIFIED peer per (set, chain) for the relative diff. Only
+  // 'ok' readings feed peerMax, so a forged or unverifiable pointer can never
+  // inflate the peer bar and make honest validators look stalled.
   const peerMax = new Map<string, number>();
   for (const r of readings) {
-    if (!r.reachable) continue;
+    if (r.status !== 'ok') continue;
     const key = `${r.set}:${r.chain}`;
     peerMax.set(key, Math.max(peerMax.get(key) ?? -1, r.index));
   }
 
   const rows: ValidatorRow[] = readings.map((r) => {
     const onchainCount = onchainCounts[r.chain];
+    const live = r.status === 'ok';
     // On-chain latest leaf index is count - 1.
     const lagOnchain =
-      r.reachable && onchainCount !== undefined
+      live && onchainCount !== undefined
         ? Math.max(0, onchainCount - 1 - r.index)
         : undefined;
     const peer = peerMax.get(`${r.set}:${r.chain}`);
     const lagPeer =
-      r.reachable && peer !== undefined
-        ? Math.max(0, peer - r.index)
-        : undefined;
+      live && peer !== undefined ? Math.max(0, peer - r.index) : undefined;
     const down =
-      !r.reachable ||
+      !live ||
       (lagPeer !== undefined && lagPeer >= PEER_LAG_STALL_THRESHOLD) ||
       (lagOnchain !== undefined && lagOnchain >= ONCHAIN_LAG_STALL_THRESHOLD);
     return { ...r, onchainCount, lagOnchain, lagPeer, down };
@@ -236,7 +320,7 @@ async function main() {
   printReport(rows);
 
   if (pushMetrics) {
-    await pushValidatorMetrics(rows, environment);
+    await pushValidatorMetrics(rows, onchainCounts, environment);
   }
 
   process.exit(0);
@@ -280,11 +364,16 @@ function printReport(rows: ValidatorRow[]) {
       chalk.yellow(`\n${down.length} validator(s) flagged as down:`),
     );
     for (const r of down) {
-      const reason = !r.reachable
-        ? 'unreachable / no checkpoints'
-        : r.lagPeer !== undefined && r.lagPeer >= PEER_LAG_STALL_THRESHOLD
-          ? `peer lag ${r.lagPeer} (onchain lag ${r.lagOnchain})`
-          : `onchain lag ${r.lagOnchain} (no live peer)`;
+      const reason =
+        r.status === 'unreachable'
+          ? 'unreachable / no storage location'
+          : r.status === 'none'
+            ? 'no checkpoints signed yet'
+            : r.status === 'unverified'
+              ? 'checkpoint failed verification (signer/domain/hook/index)'
+              : r.lagPeer !== undefined && r.lagPeer >= PEER_LAG_STALL_THRESHOLD
+                ? `peer lag ${r.lagPeer} (onchain lag ${r.lagOnchain})`
+                : `onchain lag ${r.lagOnchain} (no live peer)`;
       rootLogger.warn(
         chalk.yellow(
           `  - [${r.chain}] ${r.set}/${r.alias} ${r.address}: ${reason}`,
@@ -299,13 +388,17 @@ function printReport(rows: ValidatorRow[]) {
 // monitored, disappears cleanly instead of lingering as a ghost series. Every
 // monitored validator is always represented (reachable 0/1), so a validator we
 // failed to read shows as unreachable rather than vanishing.
-async function pushValidatorMetrics(rows: ValidatorRow[], environment: string) {
+async function pushValidatorMetrics(
+  rows: ValidatorRow[],
+  onchainCounts: Record<string, number | undefined>,
+  environment: string,
+) {
   const register = new Registry();
   const labelNames = ['chain', 'validator', 'alias', 'validator_set'];
 
   const reachableGauge = new Gauge({
     name: 'hyperlane_validator_reachable',
-    help: 'Whether the validator checkpoint syncer could be read (1) or not (0)',
+    help: 'Whether a verified checkpoint could be read from the validator (1) or not (0)',
     registers: [register],
     labelNames,
   });
@@ -333,8 +426,25 @@ async function pushValidatorMetrics(rows: ValidatorRow[], environment: string) {
     registers: [register],
     labelNames: ['chain'],
   });
+  // Explicit per-chain success signal for the on-chain read. Because the group
+  // is PUT-overwritten each run, a chain whose merkle-count read failed drops
+  // its lag_onchain series entirely — which would silently clear a lag alert.
+  // This gauge lets alerts fail CLOSED: treat lag_onchain as unknown (not
+  // resolved) whenever onchain_read_success == 0 for a chain.
+  const onchainReadSuccessGauge = new Gauge({
+    name: 'hyperlane_validator_monitor_onchain_read_success',
+    help: 'Whether the on-chain MerkleTreeHook count read succeeded (1) or not (0)',
+    registers: [register],
+    labelNames: ['chain'],
+  });
 
-  const seenChains = new Set<string>();
+  for (const [chain, count] of Object.entries(onchainCounts)) {
+    onchainReadSuccessGauge.labels({ chain }).set(count !== undefined ? 1 : 0);
+    if (count !== undefined) {
+      onchainCountGauge.labels({ chain }).set(count);
+    }
+  }
+
   for (const row of rows) {
     const labels = {
       chain: row.chain,
@@ -342,8 +452,9 @@ async function pushValidatorMetrics(rows: ValidatorRow[], environment: string) {
       alias: row.alias,
       validator_set: row.set,
     };
-    reachableGauge.labels(labels).set(row.reachable ? 1 : 0);
-    if (row.reachable) {
+    const live = row.status === 'ok';
+    reachableGauge.labels(labels).set(live ? 1 : 0);
+    if (live) {
       indexGauge.labels(labels).set(row.index);
     }
     if (row.lagOnchain !== undefined) {
@@ -352,14 +463,14 @@ async function pushValidatorMetrics(rows: ValidatorRow[], environment: string) {
     if (row.lagPeer !== undefined) {
       lagPeerGauge.labels(labels).set(row.lagPeer);
     }
-    if (row.onchainCount !== undefined && !seenChains.has(row.chain)) {
-      seenChains.add(row.chain);
-      onchainCountGauge.labels({ chain: row.chain }).set(row.onchainCount);
-    }
   }
 
+  // Propagate push failure: if the PushGateway is unreachable, the CronJob must
+  // fail so Kubernetes does not record a successful run while the previous
+  // snapshot silently goes stale. Alert on snapshot freshness as a backstop.
   await submitMetrics(register, `validator-monitor-${environment}`, {
     overwriteAllMetrics: true,
+    throwOnError: true,
   });
 }
 

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -15,7 +15,11 @@ import { Role } from '../roles.js';
 
 import { RootAgentConfig } from './agent/agent.js';
 import type { DeployEnvironment } from './deploy-environment.js';
-import { CheckWarpDeployConfig, KeyFunderConfig } from './funding.js';
+import {
+  CheckWarpDeployConfig,
+  KeyFunderConfig,
+  ValidatorMonitorConfig,
+} from './funding.js';
 import { InfrastructureConfig } from './infrastructure.js';
 
 export type EnvironmentConfig = {
@@ -46,6 +50,7 @@ export type EnvironmentConfig = {
   ) => Promise<ChainMap<CloudAgentKey>>;
   keyFunderConfig?: KeyFunderConfig<string[]>;
   checkWarpDeployConfig?: CheckWarpDeployConfig;
+  validatorMonitorConfig?: ValidatorMonitorConfig;
 };
 
 export function getOwnerConfigForAddress(owner: string): OwnableConfig {

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -53,6 +53,10 @@ export interface CheckWarpDeployConfig extends CronJobConfig {
   registryCommit?: string;
 }
 
+export interface ValidatorMonitorConfig extends CronJobConfig {
+  registryCommit?: string;
+}
+
 // Zod validation schema for sweep override configuration
 export type SweepOverrideConfig = z.infer<typeof SweepOverrideConfigSchema>;
 

--- a/typescript/infra/src/validator-monitor/helm.ts
+++ b/typescript/infra/src/validator-monitor/helm.ts
@@ -1,0 +1,63 @@
+import { join } from 'path';
+
+import { Contexts } from '../../config/contexts.js';
+import { getAgentConfig } from '../../scripts/agent-utils.js';
+import { getEnvironmentConfig } from '../../scripts/core-utils.js';
+import { AgentContextConfig } from '../config/agent/agent.js';
+import { DeployEnvironment } from '../config/deploy-environment.js';
+import { ValidatorMonitorConfig } from '../config/funding.js';
+import { HelmManager } from '../utils/helm.js';
+import { getInfraPath } from '../utils/utils.js';
+
+export class ValidatorMonitorHelmManager extends HelmManager {
+  readonly helmReleaseName: string = 'validator-monitor';
+  readonly helmChartPath: string = join(
+    getInfraPath(),
+    './helm/validator-monitor/',
+  );
+
+  constructor(
+    readonly config: ValidatorMonitorConfig,
+    readonly agentConfig: AgentContextConfig,
+  ) {
+    super();
+  }
+
+  static forEnvironment(
+    environment: DeployEnvironment,
+  ): ValidatorMonitorHelmManager | undefined {
+    const envConfig = getEnvironmentConfig(environment);
+    if (!envConfig.validatorMonitorConfig) {
+      return undefined;
+    }
+    const agentConfig = getAgentConfig(Contexts.Hyperlane, environment);
+    return new ValidatorMonitorHelmManager(
+      envConfig.validatorMonitorConfig,
+      agentConfig,
+    );
+  }
+
+  get namespace() {
+    return this.config.namespace;
+  }
+
+  async helmValues() {
+    return {
+      cronjob: {
+        schedule: this.config.cronSchedule,
+      },
+      hyperlane: {
+        runEnv: this.agentConfig.runEnv,
+        chains: this.agentConfig.environmentChainNames,
+        registryCommit: this.config.registryCommit,
+      },
+      infra: {
+        prometheusPushGateway: this.config.prometheusPushGateway,
+      },
+      image: {
+        repository: this.config.docker.repo,
+        tag: this.config.docker.tag,
+      },
+    };
+  }
+}

--- a/typescript/infra/src/validators/monitorConfig.ts
+++ b/typescript/infra/src/validators/monitorConfig.ts
@@ -1,0 +1,94 @@
+import { ChainMap, defaultMultisigConfigs } from '@hyperlane-xyz/sdk';
+import { Address, objMap } from '@hyperlane-xyz/utils';
+
+import { Contexts } from '../../config/contexts.js';
+import { ezEthValidators } from '../../config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.js';
+import { getAgentConfig } from '../../scripts/agent-utils.js';
+import { CheckpointSyncerType } from '../config/agent/validator.js';
+import { DeployEnvironment } from '../config/deploy-environment.js';
+
+// Named, whitelisted validator sets that the checkpoint liveness monitor tracks.
+// Each set is checked independently so a validator's lag can be compared against
+// its own peer group (the "relative diff") in addition to the on-chain merkle
+// count (the "absolute" ground truth).
+export enum ValidatorSetName {
+  DefaultIsm = 'default-ism',
+  Renzo = 'renzo',
+  FastPath = 'fastpath',
+}
+
+export interface MonitoredValidator {
+  address: Address;
+  alias: string;
+}
+
+export interface MonitoredValidatorSet {
+  name: ValidatorSetName;
+  validators: ChainMap<MonitoredValidator[]>;
+}
+
+// External fastpath validators that sign to their own S3 buckets. They announce
+// their storage locations on-chain (see announce-fastpath-validators.ts), so the
+// monitor resolves their location via ValidatorAnnounce like every other set.
+const EXTERNAL_FASTPATH_VALIDATORS: MonitoredValidator[] = [
+  { address: '0x93911a19cd8914220f6287d515187e7751817683', alias: 'Enigma' },
+  { address: '0xf9c6519dbd9a42bc6a60ea8daec3fa3830f40241', alias: 'Luganodes' },
+];
+
+function getDefaultIsmValidatorSet(): ChainMap<MonitoredValidator[]> {
+  return objMap(defaultMultisigConfigs, (_chain, config) =>
+    config.validators.map((v) => ({ address: v.address, alias: v.alias })),
+  );
+}
+
+function getRenzoValidatorSet(): ChainMap<MonitoredValidator[]> {
+  return objMap(ezEthValidators, (_chain, config) =>
+    config.validators.map((v) => ({ address: v.address, alias: v.alias })),
+  );
+}
+
+function getFastPathValidatorSet(
+  environment: DeployEnvironment,
+): ChainMap<MonitoredValidator[]> {
+  const agentConfig = getAgentConfig(Contexts.FastPath, environment);
+  const fastpathChains = agentConfig.contextChainNames.validator;
+  const result: ChainMap<MonitoredValidator[]> = {};
+
+  // In-house (AW) fastpath validators, read from the fastpath agent config.
+  if (agentConfig.validators) {
+    for (const [chain, chainConfig] of Object.entries(
+      agentConfig.validators.chains,
+    )) {
+      if (!fastpathChains.includes(chain)) continue;
+      for (const v of chainConfig.validators) {
+        if (v.checkpointSyncer.type !== CheckpointSyncerType.S3) continue;
+        (result[chain] ??= []).push({ address: v.address, alias: v.name });
+      }
+    }
+  }
+
+  // External fastpath validators run across the same fastpath chains.
+  for (const chain of fastpathChains) {
+    for (const external of EXTERNAL_FASTPATH_VALIDATORS) {
+      (result[chain] ??= []).push(external);
+    }
+  }
+
+  return result;
+}
+
+export function getMonitoredValidatorSets(
+  environment: DeployEnvironment,
+): MonitoredValidatorSet[] {
+  return [
+    {
+      name: ValidatorSetName.DefaultIsm,
+      validators: getDefaultIsmValidatorSet(),
+    },
+    { name: ValidatorSetName.Renzo, validators: getRenzoValidatorSet() },
+    {
+      name: ValidatorSetName.FastPath,
+      validators: getFastPathValidatorSet(environment),
+    },
+  ];
+}

--- a/typescript/metrics/src/pushgateway.ts
+++ b/typescript/metrics/src/pushgateway.ts
@@ -39,6 +39,10 @@ export function getPushGateway(
  * @param options.groupings - Extra grouping labels appended to the PushGateway
  *   group key. When each series is pushed under its own grouping, it can be
  *   cleared independently via deleteMetrics without touching other series.
+ * @param options.throwOnError - If true, a failed push (network error or a
+ *   non-2xx response) is rethrown instead of swallowed, so a caller running as
+ *   a batch/CronJob can fail loudly rather than record a false success while the
+ *   previous snapshot goes stale. Defaults to false for backwards compatibility.
  * @param logger - Optional logger instance
  */
 export async function submitMetrics(
@@ -47,6 +51,7 @@ export async function submitMetrics(
   options?: {
     overwriteAllMetrics?: boolean;
     groupings?: Record<string, string>;
+    throwOnError?: boolean;
   },
   logger?: Logger,
 ): Promise<void> {
@@ -65,6 +70,7 @@ export async function submitMetrics(
     }
   } catch (e) {
     log.error('Error when pushing metrics', { error: format(e) });
+    if (options?.throwOnError) throw e;
     return;
   }
 
@@ -72,6 +78,15 @@ export async function submitMetrics(
     typeof resp == 'object' && resp != null && 'statusCode' in resp
       ? (resp as any).statusCode
       : 'unknown';
+  if (
+    options?.throwOnError &&
+    typeof statusCode === 'number' &&
+    statusCode >= 400
+  ) {
+    throw new Error(
+      `PushGateway returned status ${statusCode} for job ${jobName}`,
+    );
+  }
   log.info('Prometheus metrics pushed to PushGateway', { statusCode });
 }
 


### PR DESCRIPTION
## Summary
- Adds a mainnet3 cron job (`monitor-checkpoints.ts`) that polls each whitelisted validator's latest signed checkpoint **directly from its syncer (S3/GCS)** and compares it against two ground-truth references:
  - **on-chain lag** — leaves behind the `MerkleTreeHook.count()` (absolute, volume-independent, monotonic while a validator is frozen)
  - **peer lag** — leaves behind the furthest-ahead reachable peer in the same set on the same chain
- Validator sets are defined **as config in the monorepo** (`src/validators/monitorConfig.ts`): `default-ism`, `renzo`, `fastpath` — extensible, multiple sets whitelisted.
- Publishes a full metric snapshot each run to the Prometheus push gateway (`hyperlane_validator_reachable`, `_checkpoint_index`, `_checkpoint_lag_onchain`, `_checkpoint_lag_peer`, `_onchain_merkle_count`) under job `validator-monitor-<env>` with `overwriteAllMetrics`, so decommissioned validators disappear cleanly instead of lingering as ghost series.
- Standalone `validator-monitor` Helm chart + `ValidatorMonitorHelmManager` + `deploy-validator-monitor.ts`, modeled on `check-warp-deploy`. 30-minute cadence; private RPCs pulled from GCP Secret Manager via `envFrom` external secret.

## Why
The existing checkpoint-inconsistency alert is built on the relayer-observed, lazily-sampled `hyperlane_observed_validator_latest_index` metric, which flaps. Reading the syncer directly produces a clean, non-flapping lag that only clears when a validator resumes signing — a much better basis for a downtime alert.

## Down detection
A validator is flagged **down** when any of:
- unreachable / no checkpoints
- `lag_peer >= 5` (stalled relative to live peers)
- `lag_onchain >= 50` (backstop for single-signer chains with no peer to diff against; set well above normal 0–2 leaf catch-up jitter)

## Verification (mainnet3, live)
Ran all three sets against mainnet3. Reporting matched ground truth with no false positives across ~300 healthy validators:
- **default-ism**: correctly flagged unreachable validators (nibiru, forma/Everstake, lukso, adichain, peaq, robinhood) and peer-lag stalls (blast/Everclear 180, forma/Stakecito 193, viction/BlockPI 7); everyone caught up to on-chain count stayed green.
- **renzo**: flagged Luganodes stalled across fraxtal/plasma/unichain/ink/monad/worldchain and Everclear on blast, peers caught up.
- **fastpath**: flagged citrea/Enigma unreachable, AW + Luganodes caught up.

## Test plan
- [x] `tsc --noEmit` clean on `@hyperlane-xyz/infra`
- [x] `oxlint` clean on new/changed files
- [x] `helm template` renders valid manifests
- [x] Live run against mainnet3 for all three sets — down list matches ground truth, no false positives
- [ ] Deploy the cron job and stand up a Grafana alert on `hyperlane_validator_checkpoint_lag_onchain` / reachability, run in parallel with the existing rule, then retire the old one

🤖 Generated with [Claude Code](https://claude.com/claude-code)