### PR TITLE
chore(infra): bump mainnet3 keyFunder image to decimals-fix build

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -51,7 +51,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // monorepo services
   checkWarpDeploy: 'main',
   // standalone services
-  keyFunder: '5dc6aa4-20260714-184449',
+  keyFunder: '950782c-20260723-201236',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
   feeQuoting: '12d899d-20260325-184337',


### PR DESCRIPTION
## Summary
- Rolls the mainnet3 key-funder onto node-services image `950782c-20260723-201236`, built from main after #9101 merged.
- #9101 scales the key-funder wallet balance metrics (`recordFunderBalance`, `recordIgpBalance`, `recordWalletBalance`) by each chain's native-token decimals instead of hardcoded `formatEther` (18). This corrects the underscaled Tron (TRX = 6 decimals) balance that tripped a false-positive low-balance alert.

## Context
- PagerDuty Q3Q0SJEPGTRRTR (false positive; on-chain balance ~2,747 TRX, healthy).
- Root-cause group 01KQ7F5HHAZMM8KHWBFK7MZFPA.
- After merge + `deploy-key-funder.ts -e mainnet3`, the hourly CronJob will emit corrected balances and the alert clears, letting the Grafana silence be lifted so PD auto-resolves.

## Test plan
- [x] Image `950782c-20260723-201236` built successfully from main (run 30041109605).
- [ ] Deploy to mainnet3, confirm `hyperlane_wallet_balance{chain="tron"}` reads ~2,747 TRX after next CronJob run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)