### PR TITLE
fix(sdk): skip altVM warp-check decimals diff when deploy config omits it

### DIFF
--- a/.changeset/warp-check-altvm-native-decimals-symmetry.md
+++ b/.changeset/warp-check-altvm-native-decimals-symmetry.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The altVM warp check no longer reports a false-positive `decimals` ConfigMismatch on native legs whose on-chain reader resolves a concrete decimals value (e.g. Sealevel/Solana native = 9). The expected side omits decimals for altVM native tokens, so `buildAltVmWarpRouteDiff` now skips the decimals comparison whenever the deploy config omits it, mirroring the existing ISM/hook/contractVersion handling.

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -608,6 +608,51 @@ describe('buildAltVmWarpRouteDiff', () => {
     });
   });
 
+  it('does not flag a decimals drift when the deploy config omits decimals (altVM native)', () => {
+    // expandedDeployConfigToAltVmCheckConfig omits decimals for altVM native
+    // tokens, but the Sealevel reader resolves a concrete value (SOL = 9).
+    // Comparing 9 against an omitted expected would report a false-positive
+    // decimals mismatch on every Sealevel native leg.
+    const diff = buildAltVmWarpRouteDiff(
+      {
+        [testSealevelChain.name]: {
+          ...baseConfig,
+          type: TokenType.native,
+          decimals: 9,
+        },
+      },
+      {
+        [testSealevelChain.name]: {
+          ...baseConfig,
+          type: TokenType.native,
+        },
+      },
+    );
+
+    expect(diff).to.deep.equal({});
+  });
+
+  it('flags a decimals mismatch when the deploy config opts in', () => {
+    const diff = buildAltVmWarpRouteDiff(
+      {
+        [testSealevelChain.name]: {
+          ...baseConfig,
+          decimals: 9,
+        },
+      },
+      {
+        [testSealevelChain.name]: {
+          ...baseConfig,
+          decimals: 6,
+        },
+      },
+    );
+
+    expect(diff[testSealevelChain.name]).to.deep.include({
+      decimals: { actual: 9, expected: 6 },
+    });
+  });
+
   it('flags a crossCollateralRouters enrollment drift', () => {
     const diff = buildAltVmWarpRouteDiff(
       {

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -543,6 +543,12 @@ export function buildAltVmWarpRouteDiff(
     // EVM path (buildWarpRouteDiff) and only compare when both sides opt in.
     // contractVersion is excluded the same way (mirrors buildWarpRouteDiff): it's
     // rarely set explicitly, so only compare when the deploy config opts in.
+    // decimals is excluded the same way: the expected side omits it for altVM
+    // native tokens (expandedDeployConfigToAltVmCheckConfig), but the derived
+    // side resolves a concrete value for some protocols (e.g. Sealevel native =
+    // 9) and omits it for others (e.g. Aleo native). Only compare when the
+    // deploy config opts in, otherwise every Sealevel native leg reports a
+    // false-positive decimals mismatch.
     // scale is excluded entirely here -- it needs an exact rational comparison
     // (see altVmScaleMismatch) rather than the plain `number` diffObjMerge does.
     const { actual: normalizedActualGas, expected: normalizedExpectedGas } =
@@ -561,6 +567,7 @@ export function buildAltVmWarpRouteDiff(
       contractVersion: isNullish(expected.contractVersion)
         ? undefined
         : actual.contractVersion,
+      decimals: isNullish(expected.decimals) ? undefined : actual.decimals,
       scale: undefined,
       destinationGas: normalizedActualGas,
     };


### PR DESCRIPTION
## Summary

- Fixes a false-positive `decimals` ConfigMismatch that #9096 introduced for altVM **native** legs. #9096 dropped `decimals` from the expected/deploy side for all altVM native tokens (correct for Aleo, whose reader omits decimals), but Sealevel/Solana native still resolves `decimals=9` on the derived/actual side. The resulting asymmetry (`expected: omitted` vs `actual: 9`) flagged every Solana native leg at once.
- `buildAltVmWarpRouteDiff` now skips the decimals comparison whenever the deploy config omits decimals, mirroring the existing `interchainSecurityModule`/`hook`/`contractVersion` reconciliation. This keeps Aleo green (both sides omit) and clears Sealevel (expected omits → actual ignored), while still flagging real drift when the deploy config opts into decimals.

## Impact

Clears the daily `check-warp-deploy-mainnet3` ConfigMismatch alerts on the 5 SOL native routes that started firing after #9096 deployed: SOL/aleo, SOL/apechain-solanamainnet, SOL/hyperevm-solanamainnet, SOL/igra, SOL/radix. No real on-chain drift — `decimals: 9` is correct for SOL native.

## Test plan

- [x] `pnpm -C typescript/sdk build`
- [x] `warpCheck.test.ts` (55 passing), incl. two new `buildAltVmWarpRouteDiff` cases:
  - does not flag a decimals drift when the deploy config omits decimals (altVM native)
  - flags a decimals mismatch when the deploy config opts in

🤖 Generated with [Claude Code](https://claude.com/claude-code)