### PR TITLE
fix(infra): simplify validator checkpoint monitor to raw reads

### DIFF
--- a/typescript/infra/scripts/validators/monitor-checkpoints.ts
+++ b/typescript/infra/scripts/validators/monitor-checkpoints.ts
@@ -1,16 +1,18 @@
 /**
  * Validator checkpoint liveness monitor.
  *
- * Polls each whitelisted validator's latest signed checkpoint directly from its
- * checkpoint syncer (S3/GCS) and compares it against ground truth:
- *   - the on-chain MerkleTreeHook leaf count (absolute lag), and
- *   - the furthest-ahead peer in the same validator set on the same chain
- *     (relative/peer lag).
+ * Polls each whitelisted validator's latest signed checkpoint index directly
+ * from its checkpoint syncer (S3/GCS) and reports it alongside two reference
+ * points for lag:
+ *   - the on-chain MerkleTreeHook leaf count (absolute head), and
+ *   - the furthest-ahead peer in the same validator set on the same chain.
  *
- * Unlike the relayer-observed `hyperlane_observed_validator_latest_index`
- * metric, this reads the syncer directly, so a stalled validator produces a
- * monotonically growing lag that only clears when the validator resumes
- * signing. That makes it a clean, non-flapping basis for a downtime alert.
+ * The job is deliberately dumb: it reports the latest read and the derived lags
+ * as plain gauges and does no thresholding of its own. All tolerance lives in
+ * the alert, which should only fire when a validator has been many messages
+ * behind the on-chain head while its peers keep progressing, sustained over
+ * hours. That keeps a healthy validator momentarily a leaf or two behind (or
+ * even briefly ahead of our once-per-run on-chain snapshot) from ever flapping.
  *
  * Usage (all sets, push to prometheus):
  *   pnpm tsx scripts/validators/monitor-checkpoints.ts -e mainnet3 --pushMetrics
@@ -31,12 +33,9 @@ import {
   getValidatorFromStorageLocation,
 } from '@hyperlane-xyz/sdk';
 import {
-  BaseValidator,
   LogFormat,
   LogLevel,
-  bytes32ToAddress,
   configureRootLogger,
-  eqAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
@@ -54,46 +53,21 @@ import {
 } from '../agent-utils.js';
 import { getEnvironmentConfig } from '../core-utils.js';
 
-// A reachable validator whose signed checkpoint trails the furthest-ahead peer
-// in its set on the same chain by at least this many leaves is treated as
-// stalled relative to its peers. Peer lag is volume-independent: it only grows
-// when peers keep signing while this validator does not.
-const PEER_LAG_STALL_THRESHOLD = 5;
-
-// Backstop for validators with no live peer to diff against (e.g. single-signer
-// chains): treat a validator trailing the on-chain merkle count by at least this
-// many leaves as stalled. Set generously above normal catch-up jitter (observed
-// 0-2 leaves) so a healthy validator briefly behind during a dispatch burst is
-// never flagged.
-const ONCHAIN_LAG_STALL_THRESHOLD = 50;
-
 function getArgs() {
   return withChains(withPushMetrics(getRootArgs()))
     .describe('set', 'only monitor a single validator set')
     .choices('set', Object.values(ValidatorSetName)).argv;
 }
 
-// Outcome of resolving + reading + verifying a validator's latest checkpoint.
-//   ok          - a signed checkpoint at `index` was fetched and its signature,
-//                 signer, domain, hook and index all check out.
-//   none        - the validator resolved but has not signed any checkpoint yet.
-//   unreachable - the storage location could not be resolved or read.
-//   unverified  - a latest-index pointer was read but the backing checkpoint is
-//                 missing or fails verification (wrong signer, wrong domain/hook,
-//                 or an index ahead of the on-chain merkle tree). Treated as not
-//                 live and, crucially, excluded from peerMax so a forged pointer
-//                 cannot make honest peers look stalled.
-type CheckpointStatus = 'ok' | 'none' | 'unreachable' | 'unverified';
-
-type CheckpointRead = { status: CheckpointStatus; index: number };
-
 type ValidatorReading = {
   set: ValidatorSetName;
   chain: string;
   address: string;
   alias: string;
-  status: CheckpointStatus;
-  // Latest verified checkpoint index (-1 unless status is 'ok').
+  // Whether the announced syncer could be resolved and read.
+  reachable: boolean;
+  // Latest checkpoint index read from the syncer, or -1 if unreachable or the
+  // validator has not signed any checkpoint yet.
   index: number;
 };
 
@@ -101,26 +75,22 @@ type ValidatorRow = ValidatorReading & {
   onchainCount: number | undefined;
   lagOnchain: number | undefined;
   lagPeer: number | undefined;
-  down: boolean;
 };
 
-// Resolve a validator's announced storage location, read its latest-index
-// pointer, then fetch and cryptographically verify the checkpoint it points at.
-// A bare latest-index pointer is untrusted: it is unsigned, and the announced
-// bucket identity is not authenticated on-chain, so a validator could announce
-// a healthy peer's bucket or publish an arbitrary future index. We therefore
-// only accept an index once the signed checkpoint at that index recovers to the
-// expected signer for this chain's mailbox domain and merkle tree hook.
-async function readAndVerifyCheckpoint(
+// Resolve a validator's announced storage location and read the latest
+// checkpoint index it advertises. This is intentionally the raw latest read: no
+// signature/domain/hook verification and no rejection of indices ahead of our
+// on-chain snapshot. A stalled validator simply stops advancing this index, so
+// its lag grows monotonically and the alert catches it.
+async function readLatestCheckpointIndex(
   chain: string,
   address: string,
   multiProvider: MultiProvider,
-  addresses: Record<string, string>,
-  onchainCount: number | undefined,
-): Promise<CheckpointRead> {
+  validatorAnnounceAddress: string,
+): Promise<{ reachable: boolean; index: number }> {
   try {
     const validatorAnnounce = ValidatorAnnounce__factory.connect(
-      addresses.validatorAnnounce,
+      validatorAnnounceAddress,
       multiProvider.getProvider(chain),
     );
     const [locations] = await validatorAnnounce.getAnnouncedStorageLocations([
@@ -128,57 +98,15 @@ async function readAndVerifyCheckpoint(
     ]);
     const location = locations?.[locations.length - 1];
     if (!location) {
-      return { status: 'unreachable', index: -1 };
+      return { reachable: false, index: -1 };
     }
 
     const validator = await getValidatorFromStorageLocation(location);
-    const latestIndex = await validator.getLatestCheckpointIndex();
-    if (latestIndex < 0) {
-      return { status: 'none', index: -1 };
-    }
-
-    // No honest checkpoint can exist ahead of the on-chain merkle tree, so an
-    // index beyond count-1 is a forged/ahead pointer. Reject it rather than let
-    // it poison peerMax.
-    if (onchainCount !== undefined && latestIndex > onchainCount - 1) {
-      rootLogger.warn(
-        `[${chain}] ${address} latest index ${latestIndex} exceeds on-chain count ${onchainCount}; rejecting`,
-      );
-      return { status: 'unverified', index: -1 };
-    }
-
-    const signed = await validator.getCheckpoint(latestIndex);
-    if (!signed) {
-      rootLogger.warn(
-        `[${chain}] ${address} advertised index ${latestIndex} but no signed checkpoint is present`,
-      );
-      return { status: 'unverified', index: -1 };
-    }
-
-    const recovered = BaseValidator.recoverAddress(signed);
-    const { checkpoint } = signed.value;
-    const domainId = multiProvider.getDomainId(chain);
-    if (
-      !eqAddress(recovered, address) ||
-      checkpoint.index !== latestIndex ||
-      checkpoint.mailbox_domain !== domainId ||
-      !eqAddress(
-        bytes32ToAddress(checkpoint.merkle_tree_hook_address),
-        addresses.merkleTreeHook,
-      )
-    ) {
-      rootLogger.warn(
-        `[${chain}] ${address} checkpoint failed verification ` +
-          `(signer ${recovered}, domain ${checkpoint.mailbox_domain} vs ${domainId}, ` +
-          `hook ${checkpoint.merkle_tree_hook_address}, index ${checkpoint.index} vs ${latestIndex})`,
-      );
-      return { status: 'unverified', index: -1 };
-    }
-
-    return { status: 'ok', index: latestIndex };
+    const index = await validator.getLatestCheckpointIndex();
+    return { reachable: true, index };
   } catch (error) {
     rootLogger.debug(`[${chain}] ${address} unreachable: ${error}`);
-    return { status: 'unreachable', index: -1 };
+    return { reachable: false, index: -1 };
   }
 }
 
@@ -222,9 +150,9 @@ async function main() {
   });
   const chainAddresses = getChainAddresses();
 
-  // On-chain merkle leaf count per chain (absolute ground truth). undefined if
-  // the read fails, in which case we still report reachability but omit the
-  // on-chain lag so a chain-wide RPC hiccup can't masquerade as "resolved".
+  // On-chain merkle leaf count per chain (absolute head). undefined if the read
+  // fails, in which case we still report reachability but omit the on-chain lag
+  // so a chain-wide RPC hiccup can't masquerade as "caught up".
   const onchainCounts: Record<string, number | undefined> = {};
   await Promise.all(
     targetChains.map(async (chain) => {
@@ -243,22 +171,21 @@ async function main() {
     }),
   );
 
-  // Resolve, read, and VERIFY each validator's latest checkpoint once per
+  // Resolve and read each validator's latest checkpoint index once per
   // (chain, address); a validator may appear in more than one set.
-  const readingCache = new Map<string, Promise<CheckpointRead>>();
-  const readCheckpoint = (
-    chain: string,
-    address: string,
-  ): Promise<CheckpointRead> => {
+  const readingCache = new Map<
+    string,
+    Promise<{ reachable: boolean; index: number }>
+  >();
+  const readIndex = (chain: string, address: string) => {
     const key = `${chain}:${address.toLowerCase()}`;
     let cached = readingCache.get(key);
     if (!cached) {
-      cached = readAndVerifyCheckpoint(
+      cached = readLatestCheckpointIndex(
         chain,
         address,
         multiProvider,
-        chainAddresses[chain],
-        onchainCounts[chain],
+        chainAddresses[chain].validatorAnnounce,
       );
       readingCache.set(key, cached);
     }
@@ -272,7 +199,7 @@ async function main() {
         .filter((chain) => s.validators[chain]?.length)
         .flatMap((chain) =>
           s.validators[chain].map(async (validator: MonitoredValidator) => {
-            const { status, index } = await readCheckpoint(
+            const { reachable, index } = await readIndex(
               chain,
               validator.address,
             );
@@ -281,7 +208,7 @@ async function main() {
               chain,
               address: validator.address,
               alias: validator.alias,
-              status,
+              reachable,
               index,
             });
           }),
@@ -289,32 +216,27 @@ async function main() {
     ),
   );
 
-  // Furthest-ahead VERIFIED peer per (set, chain) for the relative diff. Only
-  // 'ok' readings feed peerMax, so a forged or unverifiable pointer can never
-  // inflate the peer bar and make honest validators look stalled.
+  // Furthest-ahead reachable peer per (set, chain) for the relative diff.
   const peerMax = new Map<string, number>();
   for (const r of readings) {
-    if (r.status !== 'ok') continue;
+    if (!r.reachable || r.index < 0) continue;
     const key = `${r.set}:${r.chain}`;
     peerMax.set(key, Math.max(peerMax.get(key) ?? -1, r.index));
   }
 
   const rows: ValidatorRow[] = readings.map((r) => {
     const onchainCount = onchainCounts[r.chain];
-    const live = r.status === 'ok';
-    // On-chain latest leaf index is count - 1.
+    const hasIndex = r.reachable && r.index >= 0;
+    // On-chain latest leaf index is count - 1. Clamp at 0 so a validator briefly
+    // ahead of our once-per-run snapshot reports 0 lag rather than a negative.
     const lagOnchain =
-      live && onchainCount !== undefined
+      hasIndex && onchainCount !== undefined
         ? Math.max(0, onchainCount - 1 - r.index)
         : undefined;
     const peer = peerMax.get(`${r.set}:${r.chain}`);
     const lagPeer =
-      live && peer !== undefined ? Math.max(0, peer - r.index) : undefined;
-    const down =
-      !live ||
-      (lagPeer !== undefined && lagPeer >= PEER_LAG_STALL_THRESHOLD) ||
-      (lagOnchain !== undefined && lagOnchain >= ONCHAIN_LAG_STALL_THRESHOLD);
-    return { ...r, onchainCount, lagOnchain, lagPeer, down };
+      hasIndex && peer !== undefined ? Math.max(0, peer - r.index) : undefined;
+    return { ...r, onchainCount, lagOnchain, lagPeer };
   });
 
   printReport(rows);
@@ -350,34 +272,20 @@ function printReport(rows: ValidatorRow[]) {
         onchain: r.onchainCount ?? '?',
         lag_onchain: r.lagOnchain ?? '?',
         lag_peer: r.lagPeer ?? '?',
-        status: r.down ? '❌ DOWN' : '✅',
+        reachable: r.reachable ? '✅' : '❌',
       }));
     // eslint-disable-next-line no-console
     console.table(table);
   }
 
-  const down = rows.filter((r) => r.down);
-  if (down.length === 0) {
-    rootLogger.info(chalk.green('\nAll monitored validators are live.'));
-  } else {
+  const unreachable = rows.filter((r) => !r.reachable);
+  if (unreachable.length > 0) {
     rootLogger.warn(
-      chalk.yellow(`\n${down.length} validator(s) flagged as down:`),
+      chalk.yellow(`\n${unreachable.length} validator(s) unreachable:`),
     );
-    for (const r of down) {
-      const reason =
-        r.status === 'unreachable'
-          ? 'unreachable / no storage location'
-          : r.status === 'none'
-            ? 'no checkpoints signed yet'
-            : r.status === 'unverified'
-              ? 'checkpoint failed verification (signer/domain/hook/index)'
-              : r.lagPeer !== undefined && r.lagPeer >= PEER_LAG_STALL_THRESHOLD
-                ? `peer lag ${r.lagPeer} (onchain lag ${r.lagOnchain})`
-                : `onchain lag ${r.lagOnchain} (no live peer)`;
+    for (const r of unreachable) {
       rootLogger.warn(
-        chalk.yellow(
-          `  - [${r.chain}] ${r.set}/${r.alias} ${r.address}: ${reason}`,
-        ),
+        chalk.yellow(`  - [${r.chain}] ${r.set}/${r.alias} ${r.address}`),
       );
     }
   }
@@ -398,7 +306,7 @@ async function pushValidatorMetrics(
 
   const reachableGauge = new Gauge({
     name: 'hyperlane_validator_reachable',
-    help: 'Whether a verified checkpoint could be read from the validator (1) or not (0)',
+    help: 'Whether the validator syncer could be resolved and read (1) or not (0)',
     registers: [register],
     labelNames,
   });
@@ -430,7 +338,7 @@ async function pushValidatorMetrics(
   // is PUT-overwritten each run, a chain whose merkle-count read failed drops
   // its lag_onchain series entirely — which would silently clear a lag alert.
   // This gauge lets alerts fail CLOSED: treat lag_onchain as unknown (not
-  // resolved) whenever onchain_read_success == 0 for a chain.
+  // caught up) whenever onchain_read_success == 0 for a chain.
   const onchainReadSuccessGauge = new Gauge({
     name: 'hyperlane_validator_monitor_onchain_read_success',
     help: 'Whether the on-chain MerkleTreeHook count read succeeded (1) or not (0)',
@@ -452,9 +360,8 @@ async function pushValidatorMetrics(
       alias: row.alias,
       validator_set: row.set,
     };
-    const live = row.status === 'ok';
-    reachableGauge.labels(labels).set(live ? 1 : 0);
-    if (live) {
+    reachableGauge.labels(labels).set(row.reachable ? 1 : 0);
+    if (row.reachable && row.index >= 0) {
       indexGauge.labels(labels).set(row.index);
     }
     if (row.lagOnchain !== undefined) {


### PR DESCRIPTION
## Summary
Follow-up to #9108. The checkpoint monitor rejected any validator whose latest signed index was ahead of the **once-per-run** on-chain merkle count snapshot. On busy chains (e.g. bsc) the tree grows between the single `count()` read and the slower per-validator syncer reads, so healthy validators are momentarily a leaf ahead of the snapshot — and were **all falsely marked down** (observed: every bsc validator across all 3 sets).

Per review feedback, the fix is to stop being clever in code and move all tolerance to the alert.

- Reports the **raw latest read** (`getLatestCheckpointIndex()`). Removed the signed-checkpoint fetch + signer/domain/hook verification, the `unverified` state, the ahead-of-count rejection, index clamping, and the in-code `down` flag with `PEER_LAG_STALL_THRESHOLD` / `ONCHAIN_LAG_STALL_THRESHOLD`.
- Emits plain gauges: `checkpoint_index` (raw), `onchain_merkle_count` (head), `checkpoint_lag_onchain`, `checkpoint_lag_peer` (both `max(0, …)` so a validator briefly ahead of the snapshot reads 0, not negative), plus `reachable` and `onchain_read_success`. **Same metric names → no dashboard churn.**
- No code threshold decides "down". The alert fires only when a validator is many messages behind the on-chain head **and** peers are progressing, sustained over hours.

Net: one file, +59 / −152.

## Test plan
- [x] `oxlint` clean
- [x] `tsc --noEmit` clean
- [x] Ran against bsc (`-e mainnet3 --chains bsc`): all validators reachable, lag_onchain / lag_peer 0, no false positives
- [ ] After merge: rebuild + re-pin image, redeploy to mainnet3, then build the liveness alert to these metrics and observe

🤖 Generated with [Claude Code](https://claude.com/claude-code)