### PR TITLE
fix(sdk): stop ownerStatus check recursing into implementation owner

### DIFF
--- a/.changeset/warp-ownerstatus-skip-impl-owner.md
+++ b/.changeset/warp-ownerstatus-skip-impl-owner.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The warp route `ownerStatus` virtual check no longer recurses into the implementation contract's owner. Under the transparent-proxy pattern the implementation is inert (upgrade authority lives in the ProxyAdmin, not the implementation) and its owner is never a configured value, so a stale deployer EOA there produced false-positive owner-inactive drift. The check still recurses into the ProxyAdmin owner, which holds upgrade authority and is a managed owner.

--- a/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.hardhat-test.ts
@@ -809,7 +809,7 @@ describe('EvmWarpRouteReader', async () => {
     isLocalRpcStub.restore();
   });
 
-  it('should return the ownerStatus virtual config for the proxy, implementation, and proxy admin, if they are different', async () => {
+  it('should return the ownerStatus virtual config for the proxy and proxy admin (never the implementation) owners, if they are different', async () => {
     const provider = multiProvider.getProvider(chain);
     const otherChain = TestChainName.test3;
     const config: WarpRouteDeployConfigMailboxRequired = {
@@ -834,7 +834,10 @@ describe('EvmWarpRouteReader', async () => {
       .stub(multiProvider, 'isLocalRpc')
       .returns(false);
 
-    // Derive config and transfer the proxy, implementation, and proxyAdmin over
+    // Transfer the proxyAdmin owner to the router and the implementation owner
+    // to the mailbox, so all three owners are distinct. The implementation
+    // owner (mailbox) must NOT appear in the result: getOwnerStatus recurses
+    // into the proxyAdmin owner but deliberately not the implementation owner.
     const warpRouteAddress = warpRoute[chain].collateral.address;
     const proxyAdminAddress = await proxyAdmin(provider, warpRouteAddress);
     await new ProxyAdmin__factory()
@@ -859,7 +862,6 @@ describe('EvmWarpRouteReader', async () => {
     expect(derivedConfig.ownerStatus).to.deep.equal({
       [signer.address]: OwnerStatus.Active,
       [warpRouteAddress]: OwnerStatus.Active,
-      [mailbox.address]: OwnerStatus.Active,
     });
 
     // Restore stub

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -624,22 +624,21 @@ export class EvmWarpRouteReader extends EvmRouterReader {
       this.logger.debug(`${owner} may not be a safe`);
     }
 
-    // Check Proxy admin and implementation recursively
-    const contractType = (await isProxy(this.provider, address))
-      ? VerifyContractTypes.Proxy
-      : VerifyContractTypes.Implementation;
-    if (contractType === VerifyContractTypes.Proxy) {
-      const [proxyStatus, implementationStatus] = await Promise.all([
-        this.getOwnerStatus(chain, await proxyAdmin(provider, address)),
-        this.getOwnerStatus(
-          chain,
-          await proxyImplementation(this.provider, address),
-        ),
-      ]);
+    // Recurse into the proxyAdmin owner only. The proxyAdmin holds upgrade
+    // authority and is an owner we actually manage, so a dead owner there is a
+    // real concern. We deliberately do NOT recurse into the implementation
+    // contract's owner: under the transparent-proxy pattern the impl is inert
+    // (upgrade authority lives in the proxyAdmin, not the impl), we never
+    // configure the impl owner, and the ownerStatus check has no expected value
+    // for it — so a spent deployer EOA there is pure false-positive drift.
+    if (await isProxy(this.provider, address)) {
+      const proxyAdminStatus = await this.getOwnerStatus(
+        chain,
+        await proxyAdmin(provider, address),
+      );
       ownerStatus = {
         ...ownerStatus,
-        ...proxyStatus,
-        ...implementationStatus,
+        ...proxyAdminStatus,
       };
     }
 


### PR DESCRIPTION
## Summary

The warp route `ownerStatus` virtual check (`EvmWarpRouteReader.getOwnerStatus`) recursed into **both** the ProxyAdmin owner and the **implementation contract's** owner, merging every discovered owner into one liveness map. The implementation branch is the source of a permanent false-positive:

- Under the transparent-proxy pattern the implementation is **inert** — upgrade authority lives in the **ProxyAdmin**, not the impl. The impl is never called directly, holds no funds, and controls no upgrades.
- The impl owner is **never a configured value**. The expected side (`configUtils.ts` `expandWarpDeployConfig`) is *derived from the actual on-chain owner set* by flipping `Inactive`/`Error` → `Active`; there is no config that says what the impl owner should be. So the check only asserts liveness on an owner we don't manage.
- When a deployer EOA that owns the impl is inactive on a given chain (no code, nonce 0), the check emits a permanent `ConfigMismatch` that cannot be resolved. Concrete case: **USDT/eclipsemainnet on tron**, where the impl owner `0x74E0…EBA6` is a spent deployer EOA while the router and ProxyAdmin are both correctly owned by the active ICA `0xB960…A69D`.

This drops the implementation-owner recursion and keeps the **ProxyAdmin** recursion — the ProxyAdmin holds upgrade authority and is a managed owner, so a dead owner there is a real concern worth flagging.

This fixes the whole false-positive class rather than allowlisting instances one at a time.

## Allowlist audit

Verified on-chain that all 5 existing `OWNER_STATUS_SKIP` entries are **router-owner** cases (allowlisted address == `router.owner()`), not impl-owner — so none become dead and the allowlist is left unchanged:

- BEST/ethereum (bsc, ethereum) → `0x081Ec7…` is `router.owner()` on both
- GNET/galactica → `0xFe758b…` is `router.owner()`
- USDC/coti, WBTC/coti → `0xdF2E28…` is `router.owner()`

## Test plan

- [x] `tsc --noEmit` on `@hyperlane-xyz/sdk` passes
- [x] Updated `EvmWarpRouteReader.hardhat-test.ts` — the "proxy/impl/proxyAdmin different owners" case now asserts the impl owner (transferred to the mailbox) is **not** in the result, while router + ProxyAdmin owners are
- [ ] CI hardhat tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)