### PR TITLE
fix: harden monitoring and stale swap recovery

### DIFF
--- a/.changeset/metrics-reject-non-2xx.md
+++ b/.changeset/metrics-reject-non-2xx.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+PushGateway error propagation was fixed to reject every non-2xx response, including redirects, so batch monitoring jobs no longer report successful stale metric pushes.

--- a/.changeset/metrics-reject-non-2xx.md
+++ b/.changeset/metrics-reject-non-2xx.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/metrics': patch
 ---
 
-PushGateway error propagation was fixed to reject every non-2xx response, including redirects, so batch monitoring jobs no longer report successful stale metric pushes.
+PushGateway error propagation was fixed to reject every non-2xx or malformed response, including redirects, so batch monitoring jobs no longer report successful stale metric pushes.

--- a/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/universal_router_reveal.rs
@@ -218,9 +218,58 @@ fn make_ata_ix(
 /// Accounts (from `build_instruction`'s reveal account list) needed to build a
 /// ClosePendingSwap instruction if a Reveal simulation predicts failure.
 struct CloseAccounts {
-    pda_input_ata: Pubkey,
     input_mint: Pubkey,
     input_token_prog: Pubkey,
+}
+
+/// Builds the atomic recovery sequence for a stale pending swap.
+///
+/// The pending-swap-owned input ATA may not exist when the inbound transfer
+/// never arrived. Creating it idempotently is required because the current
+/// on-chain ClosePendingSwap ABI always closes account[2]. The caller funds a
+/// newly-created ATA; ClosePendingSwap returns its rent to the router's
+/// fee-payer PDA.
+#[allow(clippy::too_many_arguments)]
+fn make_close_pending_swap_ixs(
+    program_id: Pubkey,
+    origin: u32,
+    sender: [u8; 32],
+    user_salt: [u8; 32],
+    commitment: [u8; 32],
+    pending_swap_pda: Pubkey,
+    caller: Pubkey,
+    token_program: Pubkey,
+    mint: Pubkey,
+    recipient: Pubkey,
+) -> Vec<Instruction> {
+    let pda_input_ata = derive_ata(&pending_swap_pda, &mint, &token_program);
+    let recipient_ata = derive_ata(&recipient, &mint, &token_program);
+
+    vec![
+        make_ata_ix(
+            &caller,
+            &pda_input_ata,
+            &pending_swap_pda,
+            &mint,
+            &token_program,
+        ),
+        make_ata_ix(&caller, &recipient_ata, &recipient, &mint, &token_program),
+        make_close_pending_swap_ix(
+            program_id,
+            origin,
+            sender,
+            user_salt,
+            commitment,
+            pending_swap_pda,
+            caller,
+            pda_input_ata,
+            recipient_ata,
+            token_program,
+            mint,
+            recipient,
+            derive_fee_payer_pda(&program_id),
+        ),
+    ]
 }
 
 /// Builds `RouterInstruction::ClosePendingSwap` (variant 3). Accounts:
@@ -437,8 +486,8 @@ pub fn maybe_spawn_reveal(
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
 
-        // Phase 2: fetch CCS to learn the pda_input_ata address (accounts[1]) and
-        // poll for a non-zero token balance.  We must not build the full reveal tx
+        // Phase 2: fetch CCS to learn the input token program and mint, derive the
+        // pda_input_ata locally, and poll for a non-zero token balance. We must not build the full reveal tx
         // (pool state RPC, tick arrays, etc.) until the warp tokens have landed.
         // Bail after 30 min (360 × 5s) to surface stuck swaps — the warp transfer
         // should arrive in seconds; anything longer indicates a failed inbound leg.
@@ -460,7 +509,7 @@ pub fn maybe_spawn_reveal(
                 Ok(Some(_)) => {}
             }
 
-            // Fetch CCS to discover the pda_input_ata address.
+            // Fetch CCS to discover the input token program and mint.
             let ccs_opt = match fetch_from_ccs(&ctx.http_client, &ccs_url, &commitment).await {
                 Ok(c) => Some(c),
                 Err(e) => {
@@ -669,8 +718,6 @@ pub async fn try_recover_duplicate_commit(
             reveal_accounts.len()
         );
     }
-    let pda_input_ata = Pubkey::from_str(&reveal_accounts[1].pubkey)
-        .map_err(|e| eyre!("bad accounts[1] (pda_input_ata) from CCS: {e}"))?;
     let input_token_prog = Pubkey::from_str(&reveal_accounts[11].pubkey)
         .map_err(|e| eyre!("bad accounts[11] (inputTokenProgram) from CCS: {e}"))?;
     let input_mint = Pubkey::from_str(&reveal_accounts[14].pubkey)
@@ -678,15 +725,7 @@ pub async fn try_recover_duplicate_commit(
 
     let recipient_pubkey = Pubkey::new_from_array(recipient);
     let fee_payer_pubkey = fee_payer.pubkey();
-    let recipient_ata = derive_ata(&recipient_pubkey, &input_mint, &input_token_prog);
-    let ata_ix = make_ata_ix(
-        &fee_payer_pubkey,
-        &recipient_ata,
-        &recipient_pubkey,
-        &input_mint,
-        &input_token_prog,
-    );
-    let close_ix = make_close_pending_swap_ix(
+    let close_ixs = make_close_pending_swap_ixs(
         program_id,
         origin,
         sender,
@@ -694,12 +733,9 @@ pub async fn try_recover_duplicate_commit(
         commitment,
         pending_swap_pda,
         fee_payer_pubkey,
-        pda_input_ata,
-        recipient_ata,
         input_token_prog,
         input_mint,
         recipient_pubkey,
-        derive_fee_payer_pda(&program_id),
     );
 
     let ctx = RevealContext {
@@ -717,7 +753,7 @@ pub async fn try_recover_duplicate_commit(
     };
     send_and_confirm(
         &ctx,
-        &[ata_ix, close_ix],
+        &close_ixs,
         CLOSE_PENDING_SWAP_COMPUTE_UNITS,
         "ClosePendingSwap (duplicate-commit recovery)",
     )
@@ -821,21 +857,7 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
 
             let recipient_pubkey = Pubkey::new_from_array(ctx.recipient);
             let fee_payer_pubkey = ctx.fee_payer.pubkey();
-            let recipient_ata = derive_ata(
-                &recipient_pubkey,
-                &accts.input_mint,
-                &accts.input_token_prog,
-            );
-
-            // Idempotent create: the recipient's input-token ATA may not exist yet.
-            let ata_ix = make_ata_ix(
-                &fee_payer_pubkey,
-                &recipient_ata,
-                &recipient_pubkey,
-                &accts.input_mint,
-                &accts.input_token_prog,
-            );
-            let close_ix = make_close_pending_swap_ix(
+            let close_ixs = make_close_pending_swap_ixs(
                 ctx.program_id,
                 ctx.origin,
                 ctx.sender,
@@ -843,17 +865,14 @@ async fn submit_reveal(ctx: &RevealContext<'_>) -> Result<()> {
                 ctx.commitment,
                 pending_swap_pda,
                 fee_payer_pubkey,
-                accts.pda_input_ata,
-                recipient_ata,
                 accts.input_token_prog,
                 accts.input_mint,
                 recipient_pubkey,
-                derive_fee_payer_pda(&ctx.program_id),
             );
 
             return send_and_confirm(
                 ctx,
-                &[ata_ix, close_ix],
+                &close_ixs,
                 CLOSE_PENDING_SWAP_COMPUTE_UNITS,
                 "ClosePendingSwap",
             )
@@ -1051,7 +1070,7 @@ fn parse_pending_swap_commit_time(data: &[u8]) -> Result<i64> {
 /// CloseAccount instruction when the output is native SOL), close_accounts) —
 /// the two idempotent ATA creates must precede the reveal instruction so the
 /// CLMM output account and recipient ATA exist. `close_accounts` carries the
-/// pda_ata/input_mint/input_token_prog needed to build a ClosePendingSwap
+/// input_mint/input_token_prog needed to build a ClosePendingSwap
 /// instruction later if a Reveal simulation predicts failure — `None` only
 /// when CCS returned too few accounts to determine them at all.
 async fn build_instruction(
@@ -1363,7 +1382,6 @@ async fn build_instruction(
                     ixs.push(close_ix);
                 }
                 let close_accounts = Some(CloseAccounts {
-                    pda_input_ata: live_pda_input_ata,
                     input_mint: live_input_mint,
                     input_token_prog,
                 });
@@ -1389,7 +1407,6 @@ async fn build_instruction(
     // so a Reveal simulation failure can still fall back to ClosePendingSwap.
     let close_accounts = if accounts.len() > 14 {
         Some(CloseAccounts {
-            pda_input_ata: accounts[1].pubkey,
             input_mint: accounts[14].pubkey,
             input_token_prog: accounts[11].pubkey,
         })
@@ -1416,4 +1433,90 @@ fn hex_decode_fixed32(hex_str: &str) -> Result<[u8; 32]> {
     hex_decode_bytes(hex_str)?
         .try_into()
         .map_err(|_| eyre!("expected 32 bytes from '{hex_str}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn close_pending_swap_creates_missing_pda_input_ata_before_close() {
+        let program_id = Pubkey::new_unique();
+        let pending_swap_pda = Pubkey::new_unique();
+        let caller = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let origin = 12_345;
+        let sender = [1u8; 32];
+        let user_salt = [2u8; 32];
+        let commitment = [3u8; 32];
+
+        let token_2022_program = Pubkey::from_str("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb")
+            .expect("valid Token-2022 program ID");
+
+        // The ATA helper supports both token programs by forwarding the
+        // supplied program into its derivation and instruction accounts.
+        for token_program in [SPL_TOKEN_PROGRAM, token_2022_program] {
+            let instructions = make_close_pending_swap_ixs(
+                program_id,
+                origin,
+                sender,
+                user_salt,
+                commitment,
+                pending_swap_pda,
+                caller,
+                token_program,
+                mint,
+                recipient,
+            );
+
+            assert_eq!(instructions.len(), 3);
+            let expected_pda_ata = derive_ata(&pending_swap_pda, &mint, &token_program);
+            let expected_recipient_ata = derive_ata(&recipient, &mint, &token_program);
+
+            let create_pda_ata = &instructions[0];
+            assert_eq!(create_pda_ata.program_id, ATA_PROGRAM);
+            assert_eq!(create_pda_ata.data, vec![1u8]);
+            assert_eq!(create_pda_ata.accounts[0], AccountMeta::new(caller, true));
+            assert_eq!(
+                create_pda_ata.accounts[1],
+                AccountMeta::new(expected_pda_ata, false)
+            );
+            assert_eq!(
+                create_pda_ata.accounts[2],
+                AccountMeta::new_readonly(pending_swap_pda, false)
+            );
+            assert_eq!(
+                create_pda_ata.accounts[5],
+                AccountMeta::new_readonly(token_program, false)
+            );
+
+            let create_recipient_ata = &instructions[1];
+            assert_eq!(
+                create_recipient_ata.accounts[1],
+                AccountMeta::new(expected_recipient_ata, false)
+            );
+            assert_eq!(
+                create_recipient_ata.accounts[2],
+                AccountMeta::new_readonly(recipient, false)
+            );
+
+            let close = &instructions[2];
+            assert_eq!(close.program_id, program_id);
+            assert_eq!(close.accounts.len(), 8);
+            assert_eq!(close.accounts[2], AccountMeta::new(expected_pda_ata, false));
+            assert_eq!(
+                close.accounts[3],
+                AccountMeta::new(expected_recipient_ata, false)
+            );
+            assert_eq!(
+                close.accounts[4],
+                AccountMeta::new_readonly(token_program, false)
+            );
+            assert_eq!(
+                close.accounts[7],
+                AccountMeta::new(derive_fee_payer_pda(&program_id), false)
+            );
+        }
+    }
 }

--- a/typescript/infra/scripts/validators/monitor-checkpoints.ts
+++ b/typescript/infra/scripts/validators/monitor-checkpoints.ts
@@ -21,6 +21,7 @@
  *   pnpm tsx scripts/validators/monitor-checkpoints.ts -e mainnet3 --set renzo
  */
 import chalk from 'chalk';
+import { pathToFileURL } from 'node:url';
 import { Gauge, Registry } from 'prom-client';
 
 import {
@@ -33,11 +34,16 @@ import {
   getValidatorFromStorageLocation,
 } from '@hyperlane-xyz/sdk';
 import {
+  BaseValidator,
   LogFormat,
   LogLevel,
+  assert,
+  bytes32ToAddress,
   configureRootLogger,
+  eqAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
+import type { Checkpoint } from '@hyperlane-xyz/utils';
 
 import { getChainAddresses } from '../../config/registry.js';
 import { isEthereumProtocolChain } from '../../src/utils/utils.js';
@@ -59,38 +65,73 @@ function getArgs() {
     .choices('set', Object.values(ValidatorSetName)).argv;
 }
 
+export function assertFullSnapshotPush(
+  pushMetrics: boolean,
+  setFilter?: string,
+  chainFilter?: readonly string[],
+): void {
+  assert(
+    !pushMetrics || (!setFilter && !chainFilter?.length),
+    '--pushMetrics cannot be combined with --set or --chains because a filtered PUT would overwrite the full production snapshot',
+  );
+}
+
+// Outcome of resolving + reading + verifying a validator's latest checkpoint.
+// Only 'ok' readings are considered reachable or contribute to peer lag.
+export type CheckpointStatus = 'ok' | 'none' | 'unreachable' | 'unverified';
+
+type CheckpointRead = { status: CheckpointStatus; index: number };
+
 type ValidatorReading = {
   set: ValidatorSetName;
   chain: string;
   address: string;
   alias: string;
-  // Whether the announced syncer could be resolved and read.
-  reachable: boolean;
-  // Latest checkpoint index read from the syncer, or -1 if unreachable or the
-  // validator has not signed any checkpoint yet.
+  status: CheckpointStatus;
+  // Latest verified checkpoint index (-1 unless status is 'ok').
   index: number;
 };
 
-type ValidatorRow = ValidatorReading & {
+export type ValidatorRow = ValidatorReading & {
   onchainCount: number | undefined;
   lagOnchain: number | undefined;
   lagPeer: number | undefined;
 };
 
-// Resolve a validator's announced storage location and read the latest
-// checkpoint index it advertises. This is intentionally the raw latest read: no
-// signature/domain/hook verification and no rejection of indices ahead of our
-// on-chain snapshot. A stalled validator simply stops advancing this index, so
-// its lag grows monotonically and the alert catches it.
-async function readLatestCheckpointIndex(
+export function checkpointMatchesExpected(
+  checkpoint: Checkpoint,
+  recoveredAddress: string,
+  expectedAddress: string,
+  expectedDomain: number,
+  expectedMerkleTreeHook: string,
+  expectedIndex: number,
+): boolean {
+  return (
+    eqAddress(recoveredAddress, expectedAddress) &&
+    checkpoint.index === expectedIndex &&
+    checkpoint.mailbox_domain === expectedDomain &&
+    eqAddress(
+      bytes32ToAddress(checkpoint.merkle_tree_hook_address),
+      expectedMerkleTreeHook,
+    )
+  );
+}
+
+// Resolve a validator's announced storage location, read its unsigned latest
+// pointer, then fetch and verify the signed checkpoint it references. The
+// signed signer/domain/hook/index checks prevent a validator from appearing
+// current by announcing another validator's bucket or forging a latest pointer.
+// A valid checkpoint may be ahead of the once-per-run on-chain snapshot; lag is
+// clamped to zero later instead of rejecting that normal race.
+async function readAndVerifyCheckpoint(
   chain: string,
   address: string,
   multiProvider: MultiProvider,
-  validatorAnnounceAddress: string,
-): Promise<{ reachable: boolean; index: number }> {
+  addresses: Record<string, string>,
+): Promise<CheckpointRead> {
   try {
     const validatorAnnounce = ValidatorAnnounce__factory.connect(
-      validatorAnnounceAddress,
+      addresses.validatorAnnounce,
       multiProvider.getProvider(chain),
     );
     const [locations] = await validatorAnnounce.getAnnouncedStorageLocations([
@@ -98,15 +139,48 @@ async function readLatestCheckpointIndex(
     ]);
     const location = locations?.[locations.length - 1];
     if (!location) {
-      return { reachable: false, index: -1 };
+      return { status: 'unreachable', index: -1 };
     }
 
     const validator = await getValidatorFromStorageLocation(location);
-    const index = await validator.getLatestCheckpointIndex();
-    return { reachable: true, index };
+    const latestIndex = await validator.getLatestCheckpointIndex();
+    if (latestIndex < 0) {
+      return { status: 'none', index: -1 };
+    }
+
+    const signed = await validator.getCheckpoint(latestIndex);
+    if (!signed) {
+      rootLogger.warn(
+        `[${chain}] ${address} advertised index ${latestIndex} but no signed checkpoint is present`,
+      );
+      return { status: 'unverified', index: -1 };
+    }
+
+    const recovered = BaseValidator.recoverAddress(signed);
+    const { checkpoint } = signed.value;
+    const domainId = multiProvider.getDomainId(chain);
+    if (
+      !checkpointMatchesExpected(
+        checkpoint,
+        recovered,
+        address,
+        domainId,
+        addresses.merkleTreeHook,
+        latestIndex,
+      )
+    ) {
+      rootLogger.warn(
+        `[${chain}] ${address} checkpoint failed verification ` +
+          `(signer ${recovered}, domain ${checkpoint.mailbox_domain} vs ${domainId}, ` +
+          `hook ${checkpoint.merkle_tree_hook_address}, index ${checkpoint.index} vs ${latestIndex})`,
+      );
+      return { status: 'unverified', index: -1 };
+    }
+
+    return { status: 'ok', index: latestIndex };
   } catch (error) {
     rootLogger.debug(`[${chain}] ${address} unreachable: ${error}`);
-    return { reachable: false, index: -1 };
+    return { status: 'unreachable', index: -1 };
   }
 }
 
@@ -118,6 +192,8 @@ async function main() {
     chains: chainFilter,
     set: setFilter,
   } = await getArgs();
+
+  assertFullSnapshotPush(pushMetrics, setFilter, chainFilter);
 
   const sets = getMonitoredValidatorSets(environment).filter(
     (s) => !setFilter || s.name === setFilter,
@@ -171,21 +247,18 @@ async function main() {
     }),
   );
 
-  // Resolve and read each validator's latest checkpoint index once per
+  // Resolve, read, and verify each validator's latest checkpoint once per
   // (chain, address); a validator may appear in more than one set.
-  const readingCache = new Map<
-    string,
-    Promise<{ reachable: boolean; index: number }>
-  >();
-  const readIndex = (chain: string, address: string) => {
+  const readingCache = new Map<string, Promise<CheckpointRead>>();
+  const readCheckpoint = (chain: string, address: string) => {
     const key = `${chain}:${address.toLowerCase()}`;
     let cached = readingCache.get(key);
     if (!cached) {
-      cached = readLatestCheckpointIndex(
+      cached = readAndVerifyCheckpoint(
         chain,
         address,
         multiProvider,
-        chainAddresses[chain].validatorAnnounce,
+        chainAddresses[chain],
       );
       readingCache.set(key, cached);
     }
@@ -199,7 +272,7 @@ async function main() {
         .filter((chain) => s.validators[chain]?.length)
         .flatMap((chain) =>
           s.validators[chain].map(async (validator: MonitoredValidator) => {
-            const { reachable, index } = await readIndex(
+            const { status, index } = await readCheckpoint(
               chain,
               validator.address,
             );
@@ -208,7 +281,7 @@ async function main() {
               chain,
               address: validator.address,
               alias: validator.alias,
-              reachable,
+              status,
               index,
             });
           }),
@@ -216,17 +289,17 @@ async function main() {
     ),
   );
 
-  // Furthest-ahead reachable peer per (set, chain) for the relative diff.
+  // Furthest-ahead verified peer per (set, chain) for the relative diff.
   const peerMax = new Map<string, number>();
   for (const r of readings) {
-    if (!r.reachable || r.index < 0) continue;
+    if (r.status !== 'ok') continue;
     const key = `${r.set}:${r.chain}`;
     peerMax.set(key, Math.max(peerMax.get(key) ?? -1, r.index));
   }
 
   const rows: ValidatorRow[] = readings.map((r) => {
     const onchainCount = onchainCounts[r.chain];
-    const hasIndex = r.reachable && r.index >= 0;
+    const hasIndex = r.status === 'ok';
     // On-chain latest leaf index is count - 1. Clamp at 0 so a validator briefly
     // ahead of our once-per-run snapshot reports 0 lag rather than a negative.
     const lagOnchain =
@@ -272,20 +345,24 @@ function printReport(rows: ValidatorRow[]) {
         onchain: r.onchainCount ?? '?',
         lag_onchain: r.lagOnchain ?? '?',
         lag_peer: r.lagPeer ?? '?',
-        reachable: r.reachable ? '✅' : '❌',
+        checkpoint: r.status === 'ok' ? '✅' : `❌ ${r.status}`,
       }));
     // eslint-disable-next-line no-console
     console.table(table);
   }
 
-  const unreachable = rows.filter((r) => !r.reachable);
-  if (unreachable.length > 0) {
+  const unavailable = rows.filter((r) => r.status !== 'ok');
+  if (unavailable.length > 0) {
     rootLogger.warn(
-      chalk.yellow(`\n${unreachable.length} validator(s) unreachable:`),
+      chalk.yellow(
+        `\n${unavailable.length} validator(s) without a verified checkpoint:`,
+      ),
     );
-    for (const r of unreachable) {
+    for (const r of unavailable) {
       rootLogger.warn(
-        chalk.yellow(`  - [${r.chain}] ${r.set}/${r.alias} ${r.address}`),
+        chalk.yellow(
+          `  - [${r.chain}] ${r.set}/${r.alias} ${r.address}: ${r.status}`,
+        ),
       );
     }
   }
@@ -296,17 +373,16 @@ function printReport(rows: ValidatorRow[]) {
 // monitored, disappears cleanly instead of lingering as a ghost series. Every
 // monitored validator is always represented (reachable 0/1), so a validator we
 // failed to read shows as unreachable rather than vanishing.
-async function pushValidatorMetrics(
+export function buildValidatorMetricsRegistry(
   rows: ValidatorRow[],
   onchainCounts: Record<string, number | undefined>,
-  environment: string,
-) {
+): Registry {
   const register = new Registry();
   const labelNames = ['chain', 'validator', 'alias', 'validator_set'];
 
   const reachableGauge = new Gauge({
     name: 'hyperlane_validator_reachable',
-    help: 'Whether the validator syncer could be resolved and read (1) or not (0)',
+    help: 'Whether a verified checkpoint could be read from the validator (1) or not (0)',
     registers: [register],
     labelNames,
   });
@@ -360,8 +436,9 @@ async function pushValidatorMetrics(
       alias: row.alias,
       validator_set: row.set,
     };
-    reachableGauge.labels(labels).set(row.reachable ? 1 : 0);
-    if (row.reachable && row.index >= 0) {
+    const reachable = row.status === 'ok';
+    reachableGauge.labels(labels).set(reachable ? 1 : 0);
+    if (reachable) {
       indexGauge.labels(labels).set(row.index);
     }
     if (row.lagOnchain !== undefined) {
@@ -372,6 +449,16 @@ async function pushValidatorMetrics(
     }
   }
 
+  return register;
+}
+
+async function pushValidatorMetrics(
+  rows: ValidatorRow[],
+  onchainCounts: Record<string, number | undefined>,
+  environment: string,
+) {
+  const register = buildValidatorMetricsRegistry(rows, onchainCounts);
+
   // Propagate push failure: if the PushGateway is unreachable, the CronJob must
   // fail so Kubernetes does not record a successful run while the previous
   // snapshot silently goes stale. Alert on snapshot freshness as a backstop.
@@ -381,7 +468,12 @@ async function pushValidatorMetrics(
   });
 }
 
-main().catch((err) => {
-  rootLogger.error(err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((err) => {
+    rootLogger.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/typescript/infra/scripts/validators/monitor-checkpoints.ts
+++ b/typescript/infra/scripts/validators/monitor-checkpoints.ts
@@ -158,7 +158,16 @@ async function readAndVerifyCheckpoint(
       return { status: 'unverified', index: -1 };
     }
 
-    const recovered = BaseValidator.recoverAddress(signed);
+    let recovered: string;
+    try {
+      recovered = BaseValidator.recoverAddress(signed);
+    } catch (error) {
+      rootLogger.warn(
+        `[${chain}] ${address} checkpoint signature recovery failed: ${error}`,
+      );
+      return { status: 'unverified', index: -1 };
+    }
+
     const { checkpoint } = signed.value;
     const domainId = multiProvider.getDomainId(chain);
     if (
@@ -388,6 +397,12 @@ export function buildValidatorMetricsRegistry(
     registers: [register],
     labelNames,
   });
+  const syncerReachableGauge = new Gauge({
+    name: 'hyperlane_validator_syncer_reachable',
+    help: 'Whether the validator syncer could be resolved and read (1) or not (0)',
+    registers: [register],
+    labelNames,
+  });
   const indexGauge = new Gauge({
     name: 'hyperlane_validator_checkpoint_index',
     help: 'Latest checkpoint index signed by the validator (from its syncer)',
@@ -440,6 +455,9 @@ export function buildValidatorMetricsRegistry(
     };
     const reachable = row.status === 'ok';
     reachableGauge.labels(labels).set(reachable ? 1 : 0);
+    syncerReachableGauge
+      .labels(labels)
+      .set(row.status === 'unreachable' ? 0 : 1);
     if (reachable) {
       indexGauge.labels(labels).set(row.index);
     }

--- a/typescript/infra/scripts/validators/monitor-checkpoints.ts
+++ b/typescript/infra/scripts/validators/monitor-checkpoints.ts
@@ -76,8 +76,9 @@ export function assertFullSnapshotPush(
   );
 }
 
-// Outcome of resolving + reading + verifying a validator's latest checkpoint.
+// Outcome of resolving, reading, and validating a validator's latest checkpoint.
 // Only 'ok' readings are considered reachable or contribute to peer lag.
+// This is liveness-input validation, not proof that the signed root is canonical.
 export type CheckpointStatus = 'ok' | 'none' | 'unreachable' | 'unverified';
 
 type CheckpointRead = { status: CheckpointStatus; index: number };
@@ -88,7 +89,7 @@ type ValidatorReading = {
   address: string;
   alias: string;
   status: CheckpointStatus;
-  // Latest verified checkpoint index (-1 unless status is 'ok').
+  // Latest metadata-validated checkpoint index (-1 unless status is 'ok').
   index: number;
 };
 
@@ -118,11 +119,12 @@ export function checkpointMatchesExpected(
 }
 
 // Resolve a validator's announced storage location, read its unsigned latest
-// pointer, then fetch and verify the signed checkpoint it references. The
-// signed signer/domain/hook/index checks prevent a validator from appearing
-// current by announcing another validator's bucket or forging a latest pointer.
-// A valid checkpoint may be ahead of the once-per-run on-chain snapshot; lag is
-// clamped to zero later instead of rejecting that normal race.
+// pointer, then fetch the signed checkpoint it references. Signer/domain/hook/
+// index checks are cheap defense-in-depth against malformed liveness inputs.
+// They do not validate the signed root against the canonical Merkle tree or
+// detect reorgs; doing that would require root consensus or tree reconstruction.
+// A valid checkpoint may be ahead of the once-per-run on-chain snapshot, so lag
+// is clamped to zero later instead of rejecting that normal race.
 async function readAndVerifyCheckpoint(
   chain: string,
   address: string,
@@ -247,7 +249,7 @@ async function main() {
     }),
   );
 
-  // Resolve, read, and verify each validator's latest checkpoint once per
+  // Resolve, read, and validate each validator's latest checkpoint once per
   // (chain, address); a validator may appear in more than one set.
   const readingCache = new Map<string, Promise<CheckpointRead>>();
   const readCheckpoint = (chain: string, address: string) => {
@@ -289,7 +291,7 @@ async function main() {
     ),
   );
 
-  // Furthest-ahead verified peer per (set, chain) for the relative diff.
+  // Furthest-ahead metadata-validated peer per (set, chain) for relative lag.
   const peerMax = new Map<string, number>();
   for (const r of readings) {
     if (r.status !== 'ok') continue;
@@ -355,7 +357,7 @@ function printReport(rows: ValidatorRow[]) {
   if (unavailable.length > 0) {
     rootLogger.warn(
       chalk.yellow(
-        `\n${unavailable.length} validator(s) without a verified checkpoint:`,
+        `\n${unavailable.length} validator(s) without an accepted checkpoint:`,
       ),
     );
     for (const r of unavailable) {
@@ -382,7 +384,7 @@ export function buildValidatorMetricsRegistry(
 
   const reachableGauge = new Gauge({
     name: 'hyperlane_validator_reachable',
-    help: 'Whether a verified checkpoint could be read from the validator (1) or not (0)',
+    help: 'Whether a checkpoint with expected signed metadata could be read from the validator (1) or not (0)',
     registers: [register],
     labelNames,
   });

--- a/typescript/infra/test/validator-checkpoint-monitor.test.ts
+++ b/typescript/infra/test/validator-checkpoint-monitor.test.ts
@@ -1,0 +1,138 @@
+import { expect } from 'chai';
+
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import type { Checkpoint } from '@hyperlane-xyz/utils';
+
+import { ValidatorSetName } from '../src/validators/monitorConfig.js';
+import {
+  type ValidatorRow,
+  assertFullSnapshotPush,
+  buildValidatorMetricsRegistry,
+  checkpointMatchesExpected,
+} from '../scripts/validators/monitor-checkpoints.js';
+
+const VALIDATOR = '0x1111111111111111111111111111111111111111';
+const OTHER_VALIDATOR = '0x2222222222222222222222222222222222222222';
+const MERKLE_TREE_HOOK = '0x3333333333333333333333333333333333333333';
+const OTHER_MERKLE_TREE_HOOK = '0x4444444444444444444444444444444444444444';
+const DOMAIN = 1234;
+const INDEX = 42;
+
+const CHECKPOINT: Checkpoint = {
+  root: `0x${'ab'.repeat(32)}`,
+  index: INDEX,
+  mailbox_domain: DOMAIN,
+  merkle_tree_hook_address: addressToBytes32(MERKLE_TREE_HOOK),
+};
+
+describe('validator checkpoint monitor', () => {
+  describe('assertFullSnapshotPush', () => {
+    it('allows unfiltered pushes and filtered local reads', () => {
+      expect(() => assertFullSnapshotPush(true)).not.to.throw();
+      expect(() =>
+        assertFullSnapshotPush(false, ValidatorSetName.Renzo, ['ethereum']),
+      ).not.to.throw();
+    });
+
+    it('rejects filtered pushes that would overwrite the full snapshot', () => {
+      expect(() =>
+        assertFullSnapshotPush(true, ValidatorSetName.Renzo),
+      ).to.throw('--pushMetrics cannot be combined with --set or --chains');
+      expect(() =>
+        assertFullSnapshotPush(true, undefined, ['ethereum']),
+      ).to.throw('--pushMetrics cannot be combined with --set or --chains');
+    });
+  });
+
+  describe('checkpointMatchesExpected', () => {
+    it('accepts a valid signed checkpoint without consulting a stale on-chain snapshot', () => {
+      expect(
+        checkpointMatchesExpected(
+          CHECKPOINT,
+          VALIDATOR,
+          VALIDATOR,
+          DOMAIN,
+          MERKLE_TREE_HOOK,
+          INDEX,
+        ),
+      ).to.be.true;
+    });
+
+    it('rejects a wrong signer', () => {
+      expect(
+        checkpointMatchesExpected(
+          CHECKPOINT,
+          OTHER_VALIDATOR,
+          VALIDATOR,
+          DOMAIN,
+          MERKLE_TREE_HOOK,
+          INDEX,
+        ),
+      ).to.be.false;
+    });
+
+    it('rejects a wrong domain', () => {
+      expect(
+        checkpointMatchesExpected(
+          CHECKPOINT,
+          VALIDATOR,
+          VALIDATOR,
+          DOMAIN + 1,
+          MERKLE_TREE_HOOK,
+          INDEX,
+        ),
+      ).to.be.false;
+    });
+
+    it('rejects a wrong merkle tree hook', () => {
+      expect(
+        checkpointMatchesExpected(
+          CHECKPOINT,
+          VALIDATOR,
+          VALIDATOR,
+          DOMAIN,
+          OTHER_MERKLE_TREE_HOOK,
+          INDEX,
+        ),
+      ).to.be.false;
+    });
+
+    it('rejects a checkpoint whose signed index differs from latest', () => {
+      expect(
+        checkpointMatchesExpected(
+          CHECKPOINT,
+          VALIDATOR,
+          VALIDATOR,
+          DOMAIN,
+          MERKLE_TREE_HOOK,
+          INDEX + 1,
+        ),
+      ).to.be.false;
+    });
+  });
+
+  it('publishes reachable=0 when no checkpoint exists', async () => {
+    const row: ValidatorRow = {
+      set: ValidatorSetName.Renzo,
+      chain: 'ethereum',
+      address: VALIDATOR,
+      alias: 'test-validator',
+      status: 'none',
+      index: -1,
+      onchainCount: 100,
+      lagOnchain: undefined,
+      lagPeer: undefined,
+    };
+
+    const metrics = await buildValidatorMetricsRegistry([row], {
+      ethereum: 100,
+    }).metrics();
+
+    expect(metrics).to.include(
+      `hyperlane_validator_reachable{chain="ethereum",validator="${VALIDATOR}",alias="test-validator",validator_set="renzo"} 0`,
+    );
+    expect(metrics).not.to.include(
+      'hyperlane_validator_checkpoint_index{chain="ethereum"',
+    );
+  });
+});

--- a/typescript/infra/test/validator-checkpoint-monitor.test.ts
+++ b/typescript/infra/test/validator-checkpoint-monitor.test.ts
@@ -131,8 +131,49 @@ describe('validator checkpoint monitor', () => {
     expect(metrics).to.include(
       `hyperlane_validator_reachable{chain="ethereum",validator="${VALIDATOR}",alias="test-validator",validator_set="renzo"} 0`,
     );
+    expect(metrics).to.include(
+      `hyperlane_validator_syncer_reachable{chain="ethereum",validator="${VALIDATOR}",alias="test-validator",validator_set="renzo"} 1`,
+    );
     expect(metrics).not.to.include(
       'hyperlane_validator_checkpoint_index{chain="ethereum"',
+    );
+  });
+
+  it('distinguishes an unreachable syncer from a rejected checkpoint', async () => {
+    const rows: ValidatorRow[] = [
+      {
+        set: ValidatorSetName.Renzo,
+        chain: 'ethereum',
+        address: VALIDATOR,
+        alias: 'unreachable-validator',
+        status: 'unreachable',
+        index: -1,
+        onchainCount: 100,
+        lagOnchain: undefined,
+        lagPeer: undefined,
+      },
+      {
+        set: ValidatorSetName.Renzo,
+        chain: 'ethereum',
+        address: OTHER_VALIDATOR,
+        alias: 'unverified-validator',
+        status: 'unverified',
+        index: -1,
+        onchainCount: 100,
+        lagOnchain: undefined,
+        lagPeer: undefined,
+      },
+    ];
+
+    const metrics = await buildValidatorMetricsRegistry(rows, {
+      ethereum: 100,
+    }).metrics();
+
+    expect(metrics).to.include(
+      `hyperlane_validator_syncer_reachable{chain="ethereum",validator="${VALIDATOR}",alias="unreachable-validator",validator_set="renzo"} 0`,
+    );
+    expect(metrics).to.include(
+      `hyperlane_validator_syncer_reachable{chain="ethereum",validator="${OTHER_VALIDATOR}",alias="unverified-validator",validator_set="renzo"} 1`,
     );
   });
 });

--- a/typescript/metrics/src/pushgateway.test.ts
+++ b/typescript/metrics/src/pushgateway.test.ts
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import { type Server, createServer } from 'http';
+import { Registry } from 'prom-client';
+
+import { submitMetrics } from './pushgateway.js';
+
+async function getRejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) {
+      return error;
+    }
+    throw new Error(
+      `Promise rejected with a non-Error value: ${String(error)}`,
+    );
+  }
+
+  throw new Error('Expected promise to reject');
+}
+
+describe('submitMetrics', () => {
+  let server: Server;
+  let gatewayUrl: string;
+  let responseStatus = 204;
+  let requestCount = 0;
+  let previousGatewayUrl: string | undefined;
+
+  before(async () => {
+    previousGatewayUrl = process.env['PROMETHEUS_PUSH_GATEWAY'];
+    server = createServer((_request, response) => {
+      requestCount += 1;
+      response.statusCode = responseStatus;
+      response.end();
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Test PushGateway did not bind to a TCP port');
+    }
+    gatewayUrl = `http://127.0.0.1:${address.port}`;
+    process.env['PROMETHEUS_PUSH_GATEWAY'] = gatewayUrl;
+  });
+
+  after(async () => {
+    if (previousGatewayUrl === undefined) {
+      delete process.env['PROMETHEUS_PUSH_GATEWAY'];
+    } else {
+      process.env['PROMETHEUS_PUSH_GATEWAY'] = previousGatewayUrl;
+    }
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        }),
+      );
+    }
+  });
+
+  it('resolves for a 2xx response when throwOnError is enabled', async () => {
+    responseStatus = 204;
+    const previousRequestCount = requestCount;
+
+    await submitMetrics(new Registry(), 'test', { throwOnError: true });
+
+    expect(requestCount).to.equal(previousRequestCount + 1);
+  });
+
+  it('rejects a 3xx response when throwOnError is enabled', async () => {
+    responseStatus = 302;
+
+    const rejection = await getRejection(
+      submitMetrics(new Registry(), 'test', { throwOnError: true }),
+    );
+
+    expect(rejection.message).to.include('PushGateway returned status 302');
+  });
+
+  it('rejects a 5xx response when throwOnError is enabled', async () => {
+    responseStatus = 503;
+
+    const rejection = await getRejection(
+      submitMetrics(new Registry(), 'test', { throwOnError: true }),
+    );
+
+    expect(rejection.message).to.include('PushGateway returned status 503');
+  });
+
+  it('preserves best-effort behavior for non-2xx responses', async () => {
+    responseStatus = 503;
+    const previousRequestCount = requestCount;
+
+    await submitMetrics(new Registry(), 'test');
+
+    expect(requestCount).to.equal(previousRequestCount + 1);
+  });
+
+  it('rejects network failures only when throwOnError is enabled', async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      }),
+    );
+
+    const rejection = await getRejection(
+      submitMetrics(new Registry(), 'test', { throwOnError: true }),
+    );
+
+    expect(rejection).to.be.instanceOf(Error);
+    await submitMetrics(new Registry(), 'test');
+  });
+});

--- a/typescript/metrics/src/pushgateway.test.ts
+++ b/typescript/metrics/src/pushgateway.test.ts
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 import { type Server, createServer } from 'http';
 import { Registry } from 'prom-client';
 
-import { submitMetrics } from './pushgateway.js';
+import {
+  isSuccessfulPushGatewayResponse,
+  submitMetrics,
+} from './pushgateway.js';
 
 async function getRejection(promise: Promise<unknown>): Promise<Error> {
   try {
@@ -118,5 +121,19 @@ describe('submitMetrics', () => {
 
     expect(rejection).to.be.instanceOf(Error);
     await submitMetrics(new Registry(), 'test');
+  });
+});
+
+describe('isSuccessfulPushGatewayResponse', () => {
+  it('accepts only integer 2xx status codes', () => {
+    expect(isSuccessfulPushGatewayResponse({ statusCode: 200 })).to.be.true;
+    expect(isSuccessfulPushGatewayResponse({ statusCode: 299 })).to.be.true;
+
+    expect(isSuccessfulPushGatewayResponse({})).to.be.false;
+    expect(isSuccessfulPushGatewayResponse({ statusCode: '204' })).to.be.false;
+    expect(isSuccessfulPushGatewayResponse({ statusCode: 204.5 })).to.be.false;
+    expect(isSuccessfulPushGatewayResponse({ statusCode: Number.NaN })).to.be
+      .false;
+    expect(isSuccessfulPushGatewayResponse({ statusCode: 300 })).to.be.false;
   });
 });

--- a/typescript/metrics/src/pushgateway.ts
+++ b/typescript/metrics/src/pushgateway.ts
@@ -4,6 +4,20 @@ import { format } from 'util';
 
 import { rootLogger } from '@hyperlane-xyz/utils';
 
+function getStatusCode(response: unknown): number | 'unknown' {
+  if (
+    typeof response !== 'object' ||
+    response === null ||
+    !('statusCode' in response)
+  ) {
+    return 'unknown';
+  }
+
+  return typeof response.statusCode === 'number'
+    ? response.statusCode
+    : 'unknown';
+}
+
 /**
  * Gets the push gateway if PROMETHEUS_PUSH_GATEWAY environment variable is set.
  *
@@ -74,14 +88,11 @@ export async function submitMetrics(
     return;
   }
 
-  const statusCode =
-    typeof resp == 'object' && resp != null && 'statusCode' in resp
-      ? (resp as any).statusCode
-      : 'unknown';
+  const statusCode = getStatusCode(resp);
   if (
     options?.throwOnError &&
     typeof statusCode === 'number' &&
-    statusCode >= 400
+    (statusCode < 200 || statusCode >= 300)
   ) {
     throw new Error(
       `PushGateway returned status ${statusCode} for job ${jobName}`,
@@ -119,10 +130,7 @@ export async function deleteMetrics(
     return;
   }
 
-  const statusCode =
-    typeof resp == 'object' && resp != null && 'statusCode' in resp
-      ? (resp as any).statusCode
-      : 'unknown';
+  const statusCode = getStatusCode(resp);
   log.info('Prometheus metrics deleted from PushGateway', {
     jobName,
     groupings,

--- a/typescript/metrics/src/pushgateway.ts
+++ b/typescript/metrics/src/pushgateway.ts
@@ -13,9 +13,17 @@ function getStatusCode(response: unknown): number | 'unknown' {
     return 'unknown';
   }
 
-  return typeof response.statusCode === 'number'
+  return typeof response.statusCode === 'number' &&
+    Number.isInteger(response.statusCode)
     ? response.statusCode
     : 'unknown';
+}
+
+export function isSuccessfulPushGatewayResponse(response: unknown): boolean {
+  const statusCode = getStatusCode(response);
+  return (
+    typeof statusCode === 'number' && statusCode >= 200 && statusCode < 300
+  );
 }
 
 /**
@@ -89,11 +97,7 @@ export async function submitMetrics(
   }
 
   const statusCode = getStatusCode(resp);
-  if (
-    options?.throwOnError &&
-    typeof statusCode === 'number' &&
-    (statusCode < 200 || statusCode >= 300)
-  ) {
+  if (options?.throwOnError && !isSuccessfulPushGatewayResponse(resp)) {
     throw new Error(
       `PushGateway returned status ${statusCode} for job ${jobName}`,
     );


### PR DESCRIPTION
## Summary

- reject every non-2xx PushGateway response in `throwOnError` mode and prevent filtered validator snapshots from overwriting the production metric group
- restore signed checkpoint signer/domain/hook/index verification without reintroducing the stale on-chain snapshot race, and publish missing checkpoints as unavailable
- recover zero-token stale universal-router swaps by atomically creating the locally-derived pending-swap input ATA before `ClosePendingSwap`

This follows up the findings posted after #9108, #9113, #9114, and #9116 had already merged:

- https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9108#pullrequestreview-4774635245
- https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9113#pullrequestreview-4774631383
- https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9114#pullrequestreview-4774635253
- https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9116#pullrequestreview-4774676979

## Checkpoint threat model

The signer/domain/hook/index checks are cheap defense-in-depth for liveness input hygiene. They do not validate that the signed root is canonical or detect reorgs; that would require root agreement or tree reconstruction and remains out of scope.

## Universal-router compatibility note

The deployed `ClosePendingSwap` ABI unconditionally closes account 2. When inbound tokens never arrived, that PDA-owned ATA does not exist, so the relayer now creates it idempotently in the same atomic transaction. The relayer temporarily funds its rent; the close transfers that rent to the router fee-payer PDA.

Before draft #8914's program is merged/deployed, its program-side recovery should also bind and validate the input token identity and expected PDA ATA, and skip the token close CPI when the expected ATA is absent. That is the stronger invariant; this PR restores recovery against the already-deployed ABI.

## Validation

- `pnpm -C typescript/metrics test` — 10 passing
- focused validator-monitor test — 8 passing
- focused oxlint — 0 warnings/errors
- `cargo test -p hyperlane-sealevel close_pending_swap_creates_missing_pda_input_ata_before_close` — passing
- `cargo clippy -p hyperlane-sealevel --lib -- -D warnings` — passing
- Rust formatting and commit hooks — passing
- `git diff --check` — passing