### PR TITLE
chore(infra): pin validator-monitor image to simplified build

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -51,7 +51,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   scraper: 'e22be4b-20260715-194756',
   // monorepo services
   checkWarpDeploy: 'main',
-  validatorMonitor: '2c47a33-20260724-134609',
+  validatorMonitor: '9997aee-20260724-163545',
   // standalone services
   keyFunder: '950782c-20260723-201236',
   warpMonitor: '744b3bb-20260521-215958',


### PR DESCRIPTION
## Summary
Repin mainnet `validatorMonitor` to `9997aee-20260724-163545` — the monorepo image built from main after #9116 simplified the checkpoint monitor to raw reads.

The prior pin (`2c47a33-20260724-134609`) contained the read-race guard that falsely flagged every bsc validator as down. This keeps `docker.ts` in sync with what's deployed to mainnet3.

## Test plan
- [x] Image built from main HEAD (run 30109667785, commit 9997aee) — includes #9116; verified that commit's `monitor-checkpoints.ts` is the simplified version
- [ ] Deploy to mainnet3 and confirm the manual job pushes metrics with bsc validators reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)