### PR TITLE
fix(relayer): prevent CCIP-read empty-data panic that wedges a destination

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -448,17 +448,30 @@ async fn fetch_offchain_data(
         MetadataBuildError::FailedToBuild(error_msg)
     })?;
 
-    // remove leading 0x which hex_decode doesn't like
-    let hex_data = &json.data[2..];
-
-    let metadata = hex_decode(hex_data).map_err(|err| {
-        let msg = format!(
-            "Failed to decode hex from offchain lookup server response: err: ({}), data: ({})",
-            err, json.data
-        );
-        MetadataBuildError::FailedToBuild(msg)
-    })?;
+    let metadata = decode_offchain_data(&json.data)?;
     Ok(Metadata::new(metadata))
+}
+
+/// Decode the hex `data` field returned by an offchain lookup server.
+///
+/// Strips an optional leading `0x` in a bounds-safe way rather than slicing
+/// `[2..]`: a malformed or empty `data` field would otherwise panic the
+/// per-domain message processor task, which is not respawned and wedges the
+/// whole destination.
+fn decode_offchain_data(data: &str) -> Result<Vec<u8>, MetadataBuildError> {
+    let hex_data = data.strip_prefix("0x").unwrap_or(data);
+
+    if hex_data.is_empty() {
+        return Err(MetadataBuildError::FailedToBuild(format!(
+            "Offchain lookup server returned empty data field: ({data})"
+        )));
+    }
+
+    hex_decode(hex_data).map_err(|err| {
+        MetadataBuildError::FailedToBuild(format!(
+            "Failed to decode hex from offchain lookup server response: err: ({err}), data: ({data})"
+        ))
+    })
 }
 
 fn create_ccip_url_regex() -> RegexSet {
@@ -554,6 +567,40 @@ mod test {
         assert!(!body_signals_pending("not json"));
         // success body -> not pending
         assert!(!body_signals_pending(r#"{"data":"0xdeadbeef"}"#));
+    }
+
+    #[test]
+    fn test_decode_offchain_data() {
+        // with 0x prefix
+        assert_eq!(
+            decode_offchain_data("0xdeadbeef").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+        // without 0x prefix
+        assert_eq!(
+            decode_offchain_data("deadbeef").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+        // empty string must not panic (previously `&data[2..]` panicked here)
+        assert!(matches!(
+            decode_offchain_data(""),
+            Err(MetadataBuildError::FailedToBuild(_))
+        ));
+        // bare "0x" (empty after strip) must not panic
+        assert!(matches!(
+            decode_offchain_data("0x"),
+            Err(MetadataBuildError::FailedToBuild(_))
+        ));
+        // single char shorter than the stripped prefix must not panic
+        assert!(matches!(
+            decode_offchain_data("0"),
+            Err(MetadataBuildError::FailedToBuild(_))
+        ));
+        // invalid hex -> graceful error, no panic
+        assert!(matches!(
+            decode_offchain_data("0xzz"),
+            Err(MetadataBuildError::FailedToBuild(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The CCIP-read metadata builder stripped the leading `0x` from the offchain lookup server response with an unchecked slice:

```rust
// remove leading 0x which hex_decode doesn't like
let hex_data = &json.data[2..];
```

When the offchain lookup server returned an empty (or `<2` char) `data` field, `&json.data[2..]` panicked with `byte index 2 is out of bounds of \`\``. Because this runs inside the per-domain `run_destination_processor` task — which is **not respawned** after a panic — the panic wedged **all** message delivery to that destination until a manual relayer restart.

### Impact observed
A single malformed CCIP-read offchain response (Eco HyperProver, `app_context="Unknown"`) took down **all Base-destination delivery on the mainnet3 omniscient-relayer for ~13.6h** (358+ messages stuck in the prepare queue), until the statefulset was manually restarted.

## Fix
- Extract a bounds-safe `decode_offchain_data` helper that strips an optional `0x` via `strip_prefix` instead of slicing `[2..]`.
- Guard against empty data with an explicit `MetadataBuildError::FailedToBuild`. This converts to `FetchOutcome::Failed`, which just breaks the fetch loop → the message **retries** instead of panicking and killing the whole destination.
- Add regression tests: `0x`-prefixed, un-prefixed, empty `""`, bare `"0x"`, single-char `"0"`, and invalid hex.

## Follow-up (not in this PR)
The deeper resilience gap is that a panicked per-domain `run_destination_processor` task is never respawned, so *any* future panic in that path wedges a whole destination. Worth a separate change to supervise/respawn those tasks. Filing as a follow-up.

## Test plan
- [x] `cargo test -p relayer --lib ccip_read` — 4 passed (incl. new `test_decode_offchain_data`)
- [x] `cargo fmt` clean