### PR TITLE
fix(relayer): guard CCIP-read offchain hex decode against empty data

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -448,17 +448,25 @@ async fn fetch_offchain_data(
         MetadataBuildError::FailedToBuild(error_msg)
     })?;
 
-    // remove leading 0x which hex_decode doesn't like
-    let hex_data = &json.data[2..];
+    let metadata = decode_offchain_hex(&json.data)?;
+    Ok(Metadata::new(metadata))
+}
 
-    let metadata = hex_decode(hex_data).map_err(|err| {
+/// Decode the hex `data` field returned by an offchain lookup server.
+///
+/// Strips an optional `0x` prefix before hex-decoding. Uses `strip_prefix`
+/// rather than a raw `&data[2..]` slice: the latter panics with
+/// "byte index 2 is out of bounds" when the server returns an empty or
+/// otherwise malformed `data` field, and that panic previously killed the
+/// whole per-destination MessageProcessor task and wedged the destination.
+fn decode_offchain_hex(data: &str) -> Result<Vec<u8>, MetadataBuildError> {
+    let hex_data = data.strip_prefix("0x").unwrap_or(data);
+    hex_decode(hex_data).map_err(|err| {
         let msg = format!(
-            "Failed to decode hex from offchain lookup server response: err: ({}), data: ({})",
-            err, json.data
+            "Failed to decode hex from offchain lookup server response: err: ({err}), data: ({data})"
         );
         MetadataBuildError::FailedToBuild(msg)
-    })?;
-    Ok(Metadata::new(metadata))
+    })
 }
 
 fn create_ccip_url_regex() -> RegexSet {
@@ -554,6 +562,26 @@ mod test {
         assert!(!body_signals_pending("not json"));
         // success body -> not pending
         assert!(!body_signals_pending(r#"{"data":"0xdeadbeef"}"#));
+    }
+
+    #[test]
+    fn test_decode_offchain_hex() {
+        // with and without 0x prefix decode identically
+        assert_eq!(
+            decode_offchain_hex("0xdeadbeef").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+        assert_eq!(
+            decode_offchain_hex("deadbeef").unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+        // empty / short inputs must NOT panic (regression: "byte index 2 is
+        // out of bounds of ``" killed the base MessageProcessor task)
+        assert_eq!(decode_offchain_hex("").unwrap(), Vec::<u8>::new());
+        assert_eq!(decode_offchain_hex("0x").unwrap(), Vec::<u8>::new());
+        assert!(decode_offchain_hex("0").is_err());
+        // invalid hex returns an error rather than panicking
+        assert!(decode_offchain_hex("0xzz").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The CCIP-read offchain-lookup path decoded the server's `data` field with a raw `&json.data[2..]` slice to strip a leading `0x`. When the offchain server returned an **empty or malformed `data`** field, that slice panicked:

```
byte index 2 is out of bounds of ``
```

The panic propagated out of the per-destination `MessageProcessor` tokio task, which was **never respawned**. The dead task took the destination's `BuildingStage` down with it, silently wedging *all* messages to that destination until a manual relayer restart.

Observed in prod (mainnet3 omniscient-relayer, incident `01KXK3D7X4HV3YMVA7HMSCJ6Q8`): destination `base` wedged for **13.6h** with a **358-message** prepare-queue backlog and 0 deliveries, while base RPC/validator/gas were all healthy.

## Fix

- Extract a `decode_offchain_hex` helper that strips an optional `0x` prefix via `strip_prefix("0x")` (falls back to the whole string) instead of an unchecked byte slice — it can no longer panic on empty/short input. Malformed hex still returns a `MetadataBuildError` and is retried, as before.
- Add a regression unit test (`test_decode_offchain_hex`) covering the empty-string and `"0x"` cases that triggered the original panic, plus prefix/no-prefix and invalid-hex paths.

Scope is limited to the offchain-decode call site; behavior for well-formed `0x…` responses is unchanged.

## Test plan

- [ ] CI: `cargo test -p relayer` (includes the new `test_decode_offchain_hex`)
- [ ] CI: `cargo clippy --features aleo,integration_test -- -D warnings`
- [ ] CI: `cargo fmt --check`

Note: a separate, broader hardening (respawning panicked per-domain MessageProcessor tasks so a single poison message can't wedge a whole destination) is a good follow-up but intentionally out of scope for this targeted panic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)