### PR TITLE
fix(infra): sync USDC/aleo getter owner to on-chain/registry value

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getAleoUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getAleoUSDCWarpConfig.ts
@@ -14,7 +14,7 @@ import { WarpRouteIds } from '../warpIds.js';
 import { getUSDCRebalancingBridgesConfigFor } from './utils.js';
 
 const owners = {
-  aleo: 'aleo1mx0tldt5qsqymn5a3whnmf9rx2whp837jjn0tvqgxqf86zg6dvyqnc8spm',
+  aleo: 'aleo1xvxtrlg5a4kze76xejvmremj8qnkkquqtfpece47csw64pegeyqq36xvtr',
   arbitrum: '0x63C65aFC66C7247a3d43197744Da7F5838ACbf77',
   avalanche: '0x117f4a84f98b3C8BEF00a2371672031694C1Fa0A',
   base: '0xc88297c52BED07aecAec13BD3bB21647C319a73d',


### PR DESCRIPTION
## Summary
- `getAleoUSDCWarpConfig` held a stale Aleo owner (`aleo1mx0t...c8spm`, set by #9097). Because the monorepo getters override the registry for getter-based routes, this stale value overrode the current registry owner and kept re-firing `WarpRoute-ConfigMismatch` on USDC/aleo `owner`.
- Bumped `owners.aleo` to the current on-chain/registry owner `aleo1xvxtrlg5a4kze76xejvmremj8qnkkquqtfpece47csw64pegeyqq36xvtr`, so the getter now reproduces the registry `USDC/aleo-deploy.yaml` exactly (owner was the only differing field).

## Verification
- `pnpm -C typescript/infra exec tsc --noEmit` passes.
- Confirmed on-chain owner == registry owner == this new value (`aleo1xvxt...36xvtr`); all other USDC/aleo fields already matched the registry.

## Follow-up
- After merge + the next `check-warp-deploy-mainnet3` cron (15:00 UTC) re-derives clean, the residual USDC/aleo `owner` PushGateway series will be manually cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)