### PR TITLE
fix(infra): correct stale solanamainnet dailyRelayerBurn and balance thresholds

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/dailyRelayerBurn.json
+++ b/typescript/infra/config/environments/mainnet3/balances/dailyRelayerBurn.json
@@ -75,7 +75,7 @@
   "robinhood": 0.00154,
   "ronin": 31.9,
   "sei": 51.4,
-  "solanamainnet": 3.27,
+  "solanamainnet": 1,
   "solaxy": 57700,
   "somnia": 18.2,
   "soneium": 0.0394,

--- a/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
@@ -75,7 +75,7 @@
   "robinhood": 0.0123,
   "ronin": 255,
   "sei": 411,
-  "solanamainnet": 26.2,
+  "solanamainnet": 8,
   "solaxy": 0.05,
   "somnia": 146,
   "soneium": 0.315,

--- a/typescript/infra/config/environments/mainnet3/balances/highUrgencyRelayerBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/highUrgencyRelayerBalance.json
@@ -75,7 +75,7 @@
   "robinhood": 0.00308,
   "ronin": 63.8,
   "sei": 103,
-  "solanamainnet": 7.5,
+  "solanamainnet": 2,
   "solaxy": 0.0125,
   "somnia": 36.4,
   "soneium": 0.0788,

--- a/typescript/infra/config/environments/mainnet3/balances/lowUrgencyEngKeyFunderBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/lowUrgencyEngKeyFunderBalance.json
@@ -75,7 +75,7 @@
   "robinhood": 0.00924,
   "ronin": 191,
   "sei": 308,
-  "solanamainnet": 22.5,
+  "solanamainnet": 6,
   "solaxy": 0.0375,
   "somnia": 109,
   "soneium": 0.236,

--- a/typescript/infra/config/environments/mainnet3/balances/lowUrgencyKeyFunderBalance.json
+++ b/typescript/infra/config/environments/mainnet3/balances/lowUrgencyKeyFunderBalance.json
@@ -75,7 +75,7 @@
   "robinhood": 0.0185,
   "ronin": 383,
   "sei": 617,
-  "solanamainnet": 45,
+  "solanamainnet": 12,
   "solaxy": 0.075,
   "somnia": 218,
   "soneium": 0.473,

--- a/typescript/infra/src/config/funding/alert-query-templates.ts
+++ b/typescript/infra/src/config/funding/alert-query-templates.ts
@@ -87,6 +87,5 @@ export const HIGH_URGENCY_RELAYER_FOOTER = `    # Special contexts already have 
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"soon"}[1d]) - 0.005 or
     
     # Sonic SVM
-    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"sonicsvm"}[1d]) - 0.075 or
-
+    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"sonicsvm"}[1d]) - 0.075
 `;


### PR DESCRIPTION
## Summary
- The stored `solanamainnet` `dailyRelayerBurn` of **3.27 SOL/day** was a stale high-water mark — measured real burn is **~0.4 SOL/day** (14d Prometheus wallet drawdown between manual top-ups: 26.20→24.47 over 4.5d; 28.02→27.20 over 2d).
- Because every balance threshold derives from `dailyRelayerBurn × multiplier`, the inflated burn made the key-funder/relayer low-balance PagerDuty alert fire while the relayer wallet (`G5FM3UKwcBJ47PwLWLLY1RQpqNtTMgnqnd6nZGcJqaBp`) held ~27 SOL ≈ **60+ days of real runway** (PD Q1I2L9GSO6O62Y, and previously PD 33658).
- Lowered burn to **1 SOL/day** (~2.5x buffer over measured, leaving headroom for solana priority-fee spikes) and regenerated the four thresholds from it:
  - desiredRelayerBalances: 26.2 → **8**
  - lowUrgencyKeyFunderBalance: 45 → **12**
  - lowUrgencyEngKeyFunderBalance: 22.5 → **6**
  - highUrgencyRelayerBalance: 7.5 → **2**
- Note: the previous non-desired thresholds (45/22.5/7.5) were internally inconsistent with the stored burn (derived from an effective ~3.75 burn); this also reconciles them.

solana is non-EVM, so the EVM-only key-funder never auto-funds it — the wallet is topped up manually, and these thresholds now reflect that reality without early paging.

## Test plan
- [ ] Confirm derived values match multipliers: burn 1 × {8, 12, 6, 2} = {8, 12, 6, 2}.
- [ ] After merge, run `scripts/funding/write-alert.ts` to push thresholds to Grafana (not done here — needs sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)