### PR TITLE
chore(infra): warp getter vs registry drift check (run as Haggis cron)

### DIFF
--- a/.github/workflows/warp-registry-drift.yml
+++ b/.github/workflows/warp-registry-drift.yml
@@ -1,0 +1,124 @@
+name: Warp Registry Drift
+
+# Nightly check that the getter-owned warp route configs in the monorepo
+# (source of truth) match the deploy configs on hyperlane-registry `main`.
+# When a getter has drifted from the registry, the registry deploy.yaml is
+# re-exported and a PR is opened against hyperlane-registry.
+
+on:
+  schedule:
+    # Nightly at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: warp-registry-drift
+  cancel-in-progress: false
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY_DIR: ${{ github.workspace }}/hyperlane-registry
+    steps:
+      # App token must be installed on BOTH hyperlane-monorepo (checkout) and
+      # hyperlane-registry (branch push + PR) with contents:write + pull-requests:write.
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HYPER_GONK_APP_ID }}
+          private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            hyperlane-monorepo
+            hyperlane-registry
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api /users/${{ steps.generate-token.outputs.app-slug }}[bot] --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Checkout monorepo
+        uses: actions/checkout@v6
+
+      - name: Checkout registry (main)
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository_owner }}/hyperlane-registry
+          ref: main
+          path: hyperlane-registry
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Configure Git (registry)
+        working-directory: hyperlane-registry
+        run: |
+          git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      # CI=true forces read-only registry RPCs (no signer / GCP secrets needed).
+      - name: Check warp registry drift
+        id: drift
+        working-directory: typescript/infra
+        env:
+          CI: 'true'
+          REGISTRY_URI: ${{ env.REGISTRY_DIR }}
+        run: |
+          tsx scripts/warp-routes/check-warp-registry-drift.ts -e mainnet3 \
+            | tee drift.log
+          grep '^DRIFTED_WARP_ROUTES=' drift.log | tail -1 >> "$GITHUB_OUTPUT"
+
+      - name: Open registry PR on drift
+        working-directory: hyperlane-registry
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          DRIFTED_WARP_ROUTES: ${{ steps.drift.outputs.DRIFTED_WARP_ROUTES }}
+        run: |
+          if git diff --quiet; then
+            echo "No registry drift detected. Skipping PR creation."
+            exit 0
+          fi
+
+          BRANCH="ci/warp-getter-drift"
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "chore: sync warp deploy configs with monorepo getters
+
+          Re-exported drifted getter-owned warp routes: ${DRIFTED_WARP_ROUTES}"
+
+          git push -fu origin "$BRANCH"
+
+          PR_TITLE="chore: sync warp deploy configs with monorepo getters"
+          PR_BODY="## Automated Warp Config Sync
+
+          The monorepo warp config getters are the source of truth for these
+          routes. This PR re-exports the getter output for routes whose registry
+          \`*-deploy.yaml\` had drifted.
+
+          **Drifted routes:** \`${DRIFTED_WARP_ROUTES}\`
+
+          ---
+          🤖 Generated nightly by the [warp-registry-drift workflow](https://github.com/${{ github.repository }}/blob/main/.github/workflows/warp-registry-drift.yml)."
+
+          PR_EXISTS=$(gh pr list --base main --head "$BRANCH" --json number --jq length)
+          if [ "$PR_EXISTS" -eq "0" ]; then
+            gh pr create --base main --head "$BRANCH" --title "$PR_TITLE" --body "$PR_BODY"
+          else
+            echo "PR already exists. Updating body."
+            gh pr edit "$BRANCH" --title "$PR_TITLE" --body "$PR_BODY"
+          fi

--- a/typescript/infra/scripts/warp-routes/check-warp-registry-drift.ts
+++ b/typescript/infra/scripts/warp-routes/check-warp-registry-drift.ts
@@ -1,0 +1,125 @@
+import { stringify as yamlStringify, parse as yamlParse } from 'yaml';
+
+import { WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import {
+  normalizeConfig,
+  objMap,
+  rootLogger,
+  sortNestedArrays,
+  sortObjectKeys,
+  WARP_YAML_SORT_CONFIG,
+} from '@hyperlane-xyz/utils';
+
+import { getRegistry } from '../../config/registry.js';
+import { getWarpConfig, warpConfigGetterMap } from '../../config/warp.js';
+import { getArgs, withWarpRouteIds } from '../agent-utils.js';
+import { getEnvironmentConfig, getHyperlaneCore } from '../core-utils.js';
+
+const logger = rootLogger.child({ module: 'check-warp-registry-drift' });
+
+// Compares each getter-owned warp route against the registry the current
+// REGISTRY_URI points at. Where the registry deploy config is stale, the
+// getter output (source of truth) is written back into the registry so that a
+// downstream step can open a PR. Returns the list of drifted route ids.
+async function main(): Promise<void> {
+  const { environment, warpRouteIds } = await withWarpRouteIds(getArgs()).argv;
+  const { multiProvider } = await getHyperlaneCore(environment);
+  const envConfig = getEnvironmentConfig(environment);
+  const registry = getRegistry();
+
+  const warpIdsToCheck =
+    !warpRouteIds || warpRouteIds.length === 0
+      ? Object.keys(warpConfigGetterMap)
+      : warpRouteIds;
+
+  const drifted: string[] = [];
+  const errored: string[] = [];
+
+  for (const warpRouteId of warpIdsToCheck) {
+    logger.info({ warpRouteId }, 'Checking warp config against registry');
+
+    let expected: WarpRouteDeployConfig;
+    try {
+      const warpConfig = await getWarpConfig(
+        multiProvider,
+        envConfig,
+        warpRouteId,
+      );
+      expected = objMap(warpConfig, (_, config) => {
+        const { mailbox: _mailbox, ...rest } = config;
+        return rest;
+      });
+    } catch (error) {
+      logger.error({ warpRouteId, error }, 'Failed to derive getter config');
+      errored.push(warpRouteId);
+      continue;
+    }
+
+    const sorted = sortObjectKeys(
+      sortNestedArrays(expected, WARP_YAML_SORT_CONFIG),
+    );
+    const configString = yamlStringify(sorted, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value,
+    );
+    const expectedConfig: WarpRouteDeployConfig = yamlParse(configString);
+
+    const actualConfig = await registry.getWarpDeployConfig(warpRouteId);
+
+    // mailbox is a derived addressing field, not deploy intent; the canonical
+    // registry form omits it. Compare with it stripped from both sides so only
+    // genuine config drift (owners, bridges, fees, ...) triggers a re-export.
+    if (
+      actualConfig &&
+      deepEquals(
+        sortObjectKeys(normalizeConfig(stripMailbox(expectedConfig))),
+        sortObjectKeys(normalizeConfig(stripMailbox(actualConfig))),
+      )
+    ) {
+      logger.info({ warpRouteId }, 'Registry is in sync with getter');
+      continue;
+    }
+
+    logger.warn(
+      { warpRouteId, missing: !actualConfig },
+      'Registry drift detected; writing getter config',
+    );
+    drifted.push(warpRouteId);
+    registry.addWarpRouteConfig(expectedConfig, { warpRouteId });
+  }
+
+  logger.info(
+    {
+      checked: warpIdsToCheck.length,
+      drifted,
+      errored,
+    },
+    'Warp registry drift check complete',
+  );
+
+  if (errored.length > 0) {
+    logger.error({ errored }, 'Some getters failed to derive; investigate');
+    process.exitCode = 1;
+  }
+
+  if (drifted.length > 0) {
+    console.log(`DRIFTED_WARP_ROUTES=${drifted.join(',')}`);
+  } else {
+    console.log('DRIFTED_WARP_ROUTES=');
+  }
+}
+
+function stripMailbox(config: WarpRouteDeployConfig): WarpRouteDeployConfig {
+  return objMap(config, (_, chainConfig) => {
+    const { mailbox: _mailbox, ...rest } = chainConfig;
+    return rest;
+  });
+}
+
+function deepEquals(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+main().catch((err) => {
+  logger.error({ err }, 'check-warp-registry-drift failed');
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds `check-warp-registry-drift.ts` — compares every `warpConfigGetterMap` route (the monorepo getter = source of truth) against the hyperlane-registry deploy config, and on genuine drift re-exports the getter config into the registry checkout (reusing the exact export path from `export-warp-configs.ts`) and prints `DRIFTED_WARP_ROUTES=...`.

It is **run on a recurring schedule by a Haggis cron**, not a CI job. Haggis checks out registry `main`, runs the script, and opens the hyperlane-registry PR directly with its own token — so no cross-repo GitHub App install is required.

## Why
`check-warp-deploy` compares getter output → on-chain for getter-owned routes, so a stale registry `*-deploy.yaml` is a silent blind spot (never surfaces as a warp violation). This keeps the registry artifact (consumed by Nexus/CLI/explorer) in sync with the getters without a human running `export-warp-configs` by hand.

## Behavior notes
- **`mailbox` is stripped from both sides before comparing** (matches `export-warp-configs`; 201/231 registry files already omit it). A mailbox-only difference does **not** trigger a PR.
- **`allowedRebalancingBridges` canonical form is domain IDs** — both the getters (`String(getDomainId(...))`) and the on-chain reader (`movableToken.domains()`) key by domain ID. Re-export normalizes any legacy chain-name keys → domain IDs.
- Runs with `CI=true` so `getMultiProviderForRole` returns read-only registry RPCs (no signer / GCP secrets).

## Test plan
- [x] tsc clean (`typescript/infra`).
- [x] Smoke-tested against a local registry checkout: USDT/oft, USDT/oft-legacy, WBTC/eclipsemainnet-ethereum → in-sync; USDC/aleo → genuine drift detected + re-exported; mailbox-only diffs correctly ignored.