### PR TITLE
fix(infra): sync USDT/eni config getter with tron extension and fee updates

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
@@ -23,9 +23,13 @@ const owners = {
   eni: '0xf0004476DDC8985C067b6BDf94a1759f7b230809',
   optimism: '0xd1219aef6eA190f6aD48525664C33ceE0169c7a8',
   polygon: '0x3211A1Fea94cd4000Bd82D7C9E9334E51938De1b',
+  tron: '0x5ac5e2cf5A0Bb92D1Ca5B8D02a069eC874294976',
 } as const;
 
 const WARP_FEE_BPS = 8;
+// Moonpay offchain quote signer for the inter-collateral fees added on the USDT/eni route
+const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';
+const USDT_INTER_COLLATERAL_FEE_BPS = 5;
 
 const usdcTokenAddresses = {
   arbitrum: tokens.arbitrum.USDC,
@@ -43,6 +47,7 @@ const usdtTokenAddresses = {
   ethereum: tokens.ethereum.USDT,
   optimism: tokens.optimism.USDT,
   polygon: tokens.polygon.USDT,
+  tron: tokens.tron.USDT,
 } as const;
 
 const usdcDecimals = {
@@ -63,6 +68,7 @@ const usdtDecimals = {
   eni: 6,
   optimism: 6,
   polygon: 6,
+  tron: 6,
 } as const;
 
 function getScaledTokenConfig(
@@ -223,6 +229,7 @@ export async function getEniUsdtWarpConfig(
     'ethereum',
     'optimism',
     'polygon',
+    'tron',
   ] as const;
 
   const configs: Array<[string, HypTokenRouterConfig]> = [];
@@ -238,6 +245,14 @@ export async function getEniUsdtWarpConfig(
         'USDT',
         usdtDecimals[chain],
         maxDecimals,
+      ),
+      tokenFee: getFixedRoutingFeeConfig(
+        getWarpFeeOwner(chain),
+        allCollateralChains.filter((otherChain) => otherChain !== chain),
+        USDT_INTER_COLLATERAL_FEE_BPS,
+        undefined,
+        // tron's fee contract charges the flat fee directly, without an offchain quote
+        chain === 'tron' ? undefined : [QUOTE_SIGNER],
       ),
     };
     configs.push([chain, config]);


### PR DESCRIPTION
## Summary
- `getEniUsdtWarpConfig` was missing the recent tron extension (`feat: extend USDT/eni with tron` in the registry) and the inter-collateral fee update, so the getter no longer matched the deployed/registry `USDT/eni` config.
- Added `tron` to the owners/token-address/decimals maps and to `allCollateralChains`.
- Added the 5bps inter-collateral `tokenFee` on every collateral leg (`OffchainQuotedLinearFee` w/ Moonpay quote signer on the 6 EVM legs, plain `LinearFee` on tron since its fee contract doesn't use an offchain quote). eni→collateral stays a flat 8bps `LinearFee`; collateral→eni remains unfeed.

## Testing
- Generated the deploy config from the updated getter and diffed it field-by-field against the registry's `deployments/warp_routes/USDT/eni-deploy.yaml` — matches (owners, token addresses, decimals/scale, fee type/bps/owner/quoteSigners per chain).
- Ran the SDK's `checkWarpRouteDeployConfig` (the same check the `check-warp-deploy` cron job uses) against live on-chain state for all 8 legs (arbitrum, base, bsc, ethereum, optimism, polygon, tron, eni): **0 violations**. The only diff was an optimism `contractVerificationStatus` Etherscan API-key error, unrelated to config and already filtered out by the cron job's `isContractVerificationViolation`.
- `tsc --noEmit` and `oxlint` pass on the changed file.