### PR TITLE
perf(aleo): split browser runtime by network

### DIFF
--- a/.changeset/aleo-runtime-artifacts.md
+++ b/.changeset/aleo-runtime-artifacts.md
@@ -4,4 +4,4 @@
 '@hyperlane-xyz/widgets': patch
 ---
 
-Removed Aleo deployment artifacts, the Provable runtime, and the Shield wallet adapter from eager browser bundles. Lightweight constants and program metadata stayed synchronous, while browser providers and wallet integrations loaded their protocol runtimes on first use.
+Removed Aleo deployment artifacts, the Provable runtime, and the Shield wallet adapter from eager browser bundles. Lightweight constants and program metadata stayed synchronous, while browser providers and wallet integrations loaded their protocol runtimes on first use. Aleo mainnet and testnet runtimes were split so browser providers only downloaded the configured network.

--- a/typescript/aleo-sdk/package.json
+++ b/typescript/aleo-sdk/package.json
@@ -25,6 +25,14 @@
       "types": "./dist/runtime.d.ts",
       "default": "./dist/runtime.js"
     },
+    "./runtime/mainnet": {
+      "types": "./dist/runtime/mainnet.d.ts",
+      "default": "./dist/runtime/mainnet.js"
+    },
+    "./runtime/testnet": {
+      "types": "./dist/runtime/testnet.d.ts",
+      "default": "./dist/runtime/testnet.js"
+    },
     "./constants": {
       "types": "./dist/constants.d.ts",
       "default": "./dist/constants.js"

--- a/typescript/aleo-sdk/src/clients/base.ts
+++ b/typescript/aleo-sdk/src/clients/base.ts
@@ -1,18 +1,10 @@
-import {
-  AleoKeyProvider as AleoMainnetKeyProvider,
+import type {
   AleoNetworkClient as AleoMainnetNetworkClient,
-  Account as MainnetAccount,
-  NetworkRecordProvider as MainnetNetworkRecordProvider,
   ProgramManager as MainnetProgramManager,
-  Plaintext,
 } from '@provablehq/sdk/mainnet.js';
-import {
-  AleoKeyProvider as AleoTestnetKeyProvider,
+import type {
   AleoNetworkClient as AleoTestnetNetworkClient,
-  Account as TestnetAccount,
-  NetworkRecordProvider as TestnetNetworkRecordProvider,
   ProgramManager as TestnetProgramManager,
-  getOrInitConsensusVersionTestHeights,
 } from '@provablehq/sdk/testnet.js';
 
 import { assert, retryAsync } from '@hyperlane-xyz/utils';
@@ -22,6 +14,7 @@ import {
   RETRY_ATTEMPTS,
   RETRY_DELAY_MS,
 } from '../utils/helper.js';
+import type { AleoSdk } from '../utils/provable.js';
 import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
 
 export type AnyAleoNetworkClient =
@@ -33,6 +26,7 @@ export type AnyProgramManager = MainnetProgramManager | TestnetProgramManager;
 export class AleoBase {
   protected readonly rpcUrls: string[];
   protected readonly chainId: number;
+  protected readonly sdk: AleoSdk;
 
   protected readonly prefix: string;
 
@@ -43,7 +37,7 @@ export class AleoBase {
   protected readonly ismManager: string;
   protected readonly warpSuffix: string;
 
-  constructor(rpcUrls: string[], chainId: string | number) {
+  constructor(rpcUrls: string[], chainId: string | number, sdk: AleoSdk) {
     const aleoNetworkId = toAleoNetworkId(+chainId);
     assert(rpcUrls.length > 0, `got no rpcUrls`);
 
@@ -53,10 +47,9 @@ export class AleoBase {
       r.replaceAll('/testnet', '').replaceAll('/mainnet', ''),
     );
     this.chainId = aleoNetworkId;
+    this.sdk = sdk;
 
-    this.aleoClient = this.chainId
-      ? new AleoTestnetNetworkClient(this.rpcUrls[0])
-      : new AleoMainnetNetworkClient(this.rpcUrls[0]);
+    this.aleoClient = new this.sdk.AleoNetworkClient(this.rpcUrls[0]);
 
     this.skipProofs = JSON.parse(process.env['ALEO_SKIP_PROOFS'] || 'false');
     this.skipSuffixes = JSON.parse(
@@ -66,7 +59,9 @@ export class AleoBase {
       process.env['ALEO_CONSENSUS_VERSION_HEIGHTS'] || '';
 
     if (this.consensusVersionHeights) {
-      getOrInitConsensusVersionTestHeights(this.consensusVersionHeights);
+      this.sdk.getOrInitConsensusVersionTestHeights(
+        this.consensusVersionHeights,
+      );
     }
 
     this.prefix = getNetworkPrefix(aleoNetworkId);
@@ -83,42 +78,19 @@ export class AleoBase {
   }
 
   protected getProgramManager(privateKey?: string): AnyProgramManager {
-    if (this.chainId) {
-      const account = privateKey
-        ? new TestnetAccount({ privateKey })
-        : new TestnetAccount();
-
-      const keyProvider = new AleoTestnetKeyProvider();
-      keyProvider.useCache(true);
-
-      const networkRecordProvider = new TestnetNetworkRecordProvider(
-        account,
-        new AleoTestnetNetworkClient(this.rpcUrls[0]),
-      );
-
-      const programManager = new TestnetProgramManager(
-        this.rpcUrls[0],
-        keyProvider,
-        networkRecordProvider,
-      );
-      programManager.setAccount(account);
-
-      return programManager;
-    }
-
     const account = privateKey
-      ? new MainnetAccount({ privateKey })
-      : new MainnetAccount();
+      ? new this.sdk.Account({ privateKey })
+      : new this.sdk.Account();
 
-    const keyProvider = new AleoMainnetKeyProvider();
+    const keyProvider = new this.sdk.AleoKeyProvider();
     keyProvider.useCache(true);
 
-    const networkRecordProvider = new MainnetNetworkRecordProvider(
+    const networkRecordProvider = new this.sdk.NetworkRecordProvider(
       account,
-      new AleoMainnetNetworkClient(this.rpcUrls[0]),
+      new this.sdk.AleoNetworkClient(this.rpcUrls[0]),
     );
 
-    const programManager = new MainnetProgramManager(
+    const programManager = new this.sdk.ProgramManager(
       this.rpcUrls[0],
       keyProvider,
       networkRecordProvider,
@@ -177,7 +149,7 @@ export class AleoBase {
         return;
       }
 
-      return Plaintext.fromString(result).toObject();
+      return this.sdk.Plaintext.fromString(result).toObject();
     } catch (err) {
       throw new Error(
         `Failed to query mapping value for program ${programId}/${mappingName}/${key}: ${err}`,

--- a/typescript/aleo-sdk/src/clients/protocol.ts
+++ b/typescript/aleo-sdk/src/clients/protocol.ts
@@ -39,7 +39,7 @@ import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
 import { AleoValidatorAnnounceArtifactManager } from '../validator-announce/validator-announce-artifact-manager.js';
 import { AleoWarpArtifactManager } from '../warp/warp-artifact-manager.js';
 
-import { AleoProvider } from './provider.js';
+import { AleoProvider } from './provider.node.js';
 import { AleoSigner } from './signer.js';
 
 export class AleoProtocolProvider implements ProtocolProvider {

--- a/typescript/aleo-sdk/src/clients/provider.node.ts
+++ b/typescript/aleo-sdk/src/clients/provider.node.ts
@@ -1,0 +1,26 @@
+import * as mainnetSdk from '@provablehq/sdk/mainnet.js';
+import * as testnetSdk from '@provablehq/sdk/testnet.js';
+
+import type { AleoSdk } from '../utils/provable.js';
+import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
+
+import { AleoProvider as RuntimeAleoProvider } from './provider.js';
+
+export class AleoProvider extends RuntimeAleoProvider {
+  static async connect(
+    rpcUrls: string[],
+    chainId: string | number,
+  ): Promise<AleoProvider> {
+    return new AleoProvider(rpcUrls, chainId);
+  }
+
+  constructor(rpcUrls: string[], chainId: string | number) {
+    const networkId = toAleoNetworkId(+chainId);
+    // CAST: Both Provable network modules expose the same API, but private WASM
+    // fields make their otherwise-compatible class types nominal.
+    const sdk = (networkId === AleoNetworkId.MAINNET
+      ? mainnetSdk
+      : testnetSdk) as unknown as AleoSdk;
+    super(rpcUrls, chainId, sdk);
+  }
+}

--- a/typescript/aleo-sdk/src/clients/provider.ts
+++ b/typescript/aleo-sdk/src/clients/provider.ts
@@ -1,4 +1,3 @@
-import { U128 } from '@provablehq/sdk/mainnet.js';
 import { BigNumber } from 'bignumber.js';
 
 import { AltVM } from '@hyperlane-xyz/provider-sdk';
@@ -9,28 +8,30 @@ import {
   ALEO_NULL_ADDRESS,
   U128ToString,
   arrayToPlaintext,
+  bytesLeToU128String,
   bytes32ToU128String,
   u128PairToBytes32,
   fillArray,
   formatAddress,
   fromAleoAddress,
   generateSuffix,
-  getAddressFromProgramId,
-  getBalanceKey,
+  getAddressFromProgramIdWithSdk,
+  getBalanceKeyWithSdk,
   getProgramIdFromSuffix,
   getProgramSuffix,
   isArc20ProgramId,
   isV2WarpToken,
-  toAleoAddress,
+  toAleoAddressWithSdk,
 } from '../utils/helper.js';
+import type { AleoSdk } from '../utils/provable.js';
 import { AleoTokenType, type AleoTransaction } from '../utils/types.js';
 import {
   callViewFunction,
   getArc20ProgramId,
   getArc20TokenMetadata,
-  getRemoteRouters,
+  getRemoteRoutersWithSdk,
   parseAleoUint,
-} from '../warp/warp-query.js';
+} from '../warp/provider-query.js';
 
 import { AleoBase } from './base.js';
 
@@ -59,12 +60,13 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
   static async connect(
     rpcUrls: string[],
     chainId: string | number,
+    sdk: AleoSdk,
   ): Promise<AleoProvider> {
-    return new AleoProvider(rpcUrls, chainId);
+    return new AleoProvider(rpcUrls, chainId, sdk);
   }
 
-  constructor(rpcUrls: string[], chainId: string | number) {
-    super(rpcUrls, chainId);
+  constructor(rpcUrls: string[], chainId: string | number, sdk: AleoSdk) {
+    super(rpcUrls, chainId, sdk);
   }
 
   protected generateSuffix(n: number): string {
@@ -107,7 +109,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
       const result = await this.queryMappingValue(
         'token_registry.aleo',
         'authorized_balances',
-        getBalanceKey(aleoAddress, req.denom),
+        getBalanceKeyWithSdk(this.sdk, aleoAddress, req.denom),
       );
 
       if (!result) {
@@ -284,7 +286,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
       mailboxProgramId,
       `could not find mailbox program id on token ${req.tokenAddress}`,
     );
-    token.mailboxAddress = toAleoAddress(mailboxProgramId);
+    token.mailboxAddress = toAleoAddressWithSdk(this.sdk, mailboxProgramId);
 
     const tokenMetadata = await this.queryMappingValue(
       programId,
@@ -342,7 +344,8 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
   async getRemoteRouters(
     req: AltVM.ReqGetRemoteRouters,
   ): Promise<AltVM.ResGetRemoteRouters> {
-    const remoteRouters = await getRemoteRouters(
+    const remoteRouters = await getRemoteRoutersWithSdk(
+      this.sdk,
       this.aleoClient,
       req.tokenAddress,
     );
@@ -373,7 +376,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
     switch (metadata['token_type']) {
       case AleoTokenType.NATIVE: {
         return this.getBalance({
-          address: getAddressFromProgramId(programId),
+          address: getAddressFromProgramIdWithSdk(this.sdk, programId),
           denom: '',
         });
       }
@@ -385,7 +388,7 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
       }
       case AleoTokenType.COLLATERAL: {
         return this.getBalance({
-          address: getAddressFromProgramId(programId),
+          address: getAddressFromProgramIdWithSdk(this.sdk, programId),
           denom: arc20ProgramId ?? metadata['token_id'],
         });
       }
@@ -533,9 +536,9 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
         64,
         0,
       );
-      gasLimit = U128.fromBytesLe(Uint8Array.from(metadataBytes.slice(0, 16)))
-        .toString()
-        .replace('u128', '');
+      gasLimit = bytesLeToU128String(
+        Uint8Array.from(metadataBytes.slice(0, 16)),
+      ).replace('u128', '');
     }
 
     const { mailboxAddress } = await this.getToken({
@@ -635,9 +638,9 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
         64,
         0,
       );
-      gasLimit = U128.fromBytesLe(Uint8Array.from(metadataBytes.slice(0, 16)))
-        .toString()
-        .replace('u128', '');
+      gasLimit = bytesLeToU128String(
+        Uint8Array.from(metadataBytes.slice(0, 16)),
+      ).replace('u128', '');
     }
 
     const mailbox = await this.getMailbox({
@@ -675,9 +678,9 @@ export class AleoProvider extends AleoBase implements AltVM.IProvider {
         64,
         0,
       );
-      const gasLimit = U128.fromBytesLe(
+      const gasLimit = bytesLeToU128String(
         Uint8Array.from(metadataBytes.slice(0, 16)),
-      ).toString();
+      );
 
       const hookMetadata = `{gas_limit:${gasLimit},extra_data:[${metadataBytes.map((b) => `${b}u8`).join(',')}]}`;
 

--- a/typescript/aleo-sdk/src/clients/signer.ts
+++ b/typescript/aleo-sdk/src/clients/signer.ts
@@ -16,7 +16,7 @@ import {
 import { type AleoReceipt, type AleoTransaction } from '../utils/types.js';
 
 import { type AnyProgramManager } from './base.js';
-import { AleoProvider } from './provider.js';
+import { AleoProvider } from './provider.node.js';
 
 export class AleoSigner
   extends AleoProvider

--- a/typescript/aleo-sdk/src/constants.ts
+++ b/typescript/aleo-sdk/src/constants.ts
@@ -1,3 +1,11 @@
 export const ALEO_NULL_ADDRESS =
   'aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc';
 export const ALEO_NATIVE_DENOM = 'credits';
+
+// CAST: Preserve literal IDs so AleoNetworkId remains the 0 | 1 union.
+export const AleoNetworkId = {
+  MAINNET: 0,
+  TESTNET: 1,
+} as const;
+
+export type AleoNetworkId = (typeof AleoNetworkId)[keyof typeof AleoNetworkId];

--- a/typescript/aleo-sdk/src/hook/hook-tx.ts
+++ b/typescript/aleo-sdk/src/hook/hook-tx.ts
@@ -1,4 +1,5 @@
-import { fromAleoAddress, getAddressFromProgramId } from '../utils/helper.js';
+import { getAddressFromProgramId } from '../utils/helper.crypto.js';
+import { fromAleoAddress } from '../utils/helper.js';
 import { type AleoTransaction } from '../utils/types.js';
 
 /**

--- a/typescript/aleo-sdk/src/index.ts
+++ b/typescript/aleo-sdk/src/index.ts
@@ -4,7 +4,7 @@ export { AleoProtocolProvider } from './clients/protocol.js';
 
 export { AleoReceipt, AleoTransaction } from './utils/types.js';
 
-export { AleoProvider } from './clients/provider.js';
+export { AleoProvider } from './clients/provider.node.js';
 export { AleoSigner } from './clients/signer.js';
 export { AleoIsmArtifactManager } from './ism/ism-artifact-manager.js';
 export { AleoHookArtifactManager } from './hook/hook-artifact-manager.js';

--- a/typescript/aleo-sdk/src/mailbox/mailbox.ts
+++ b/typescript/aleo-sdk/src/mailbox/mailbox.ts
@@ -13,12 +13,12 @@ import { assert, eqAddressAleo, eqOptionalAddress } from '@hyperlane-xyz/utils';
 
 import { type AnyAleoNetworkClient } from '../clients/base.js';
 import { type AleoSigner } from '../clients/signer.js';
+import { toAleoAddress } from '../utils/helper.crypto.js';
 import {
   ALEO_NULL_ADDRESS,
   getNetworkPrefix,
   getUnusedSuffix,
   SUFFIX_LENGTH_LONG,
-  toAleoAddress,
 } from '../utils/helper.js';
 import {
   type AleoArtifactNetworkConfig,

--- a/typescript/aleo-sdk/src/runtime.ts
+++ b/typescript/aleo-sdk/src/runtime.ts
@@ -1,6 +1,6 @@
 export { ALEO_NATIVE_DENOM, ALEO_NULL_ADDRESS } from './constants.js';
-export { toKeyId } from './utils/helper.js';
+export { toKeyId } from './utils/helper.crypto.js';
 
-export { AleoProvider } from './clients/provider.js';
+export { AleoProvider } from './clients/provider.node.js';
 
 export type { AleoReceipt, AleoTransaction } from './utils/types.js';

--- a/typescript/aleo-sdk/src/runtime/mainnet.ts
+++ b/typescript/aleo-sdk/src/runtime/mainnet.ts
@@ -1,0 +1,24 @@
+import * as sdk from '@provablehq/sdk/mainnet.js';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import { AleoProvider as RuntimeAleoProvider } from '../clients/provider.js';
+import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
+
+export class AleoProvider extends RuntimeAleoProvider {
+  static async connect(
+    rpcUrls: string[],
+    chainId: string | number,
+  ): Promise<AleoProvider> {
+    return new AleoProvider(rpcUrls, chainId);
+  }
+
+  constructor(rpcUrls: string[], chainId: string | number) {
+    const networkId = toAleoNetworkId(+chainId);
+    assert(
+      networkId === AleoNetworkId.MAINNET,
+      `Mainnet runtime cannot serve Aleo chain id ${chainId}`,
+    );
+    super(rpcUrls, chainId, sdk);
+  }
+}

--- a/typescript/aleo-sdk/src/runtime/mainnet.ts
+++ b/typescript/aleo-sdk/src/runtime/mainnet.ts
@@ -1,24 +1,8 @@
 import * as sdk from '@provablehq/sdk/mainnet.js';
 
-import { assert } from '@hyperlane-xyz/utils';
+import { AleoNetworkId } from '../constants.js';
 
-import { AleoProvider as RuntimeAleoProvider } from '../clients/provider.js';
-import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
+import { createAleoProviderClass } from './provider.js';
 
-export class AleoProvider extends RuntimeAleoProvider {
-  static async connect(
-    rpcUrls: string[],
-    chainId: string | number,
-  ): Promise<AleoProvider> {
-    return new AleoProvider(rpcUrls, chainId);
-  }
-
-  constructor(rpcUrls: string[], chainId: string | number) {
-    const networkId = toAleoNetworkId(+chainId);
-    assert(
-      networkId === AleoNetworkId.MAINNET,
-      `Mainnet runtime cannot serve Aleo chain id ${chainId}`,
-    );
-    super(rpcUrls, chainId, sdk);
-  }
-}
+export const AleoProvider = createAleoProviderClass(sdk, AleoNetworkId.MAINNET);
+export type AleoProvider = InstanceType<typeof AleoProvider>;

--- a/typescript/aleo-sdk/src/runtime/provider.test.ts
+++ b/typescript/aleo-sdk/src/runtime/provider.test.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import { AleoProvider as MainnetAleoProvider } from './mainnet.js';
+import { AleoProvider as TestnetAleoProvider } from './testnet.js';
+
+describe('Aleo runtime providers', () => {
+  it('constructs providers for their configured network', () => {
+    const mainnet = new MainnetAleoProvider(['https://rpc.example/mainnet'], 0);
+    const testnet = new TestnetAleoProvider(['https://rpc.example/testnet'], 1);
+
+    expect(mainnet.getRpcUrls()).to.deep.equal(['https://rpc.example']);
+    expect(testnet.getRpcUrls()).to.deep.equal(['https://rpc.example']);
+  });
+
+  it('rejects the other network', () => {
+    expect(() => new MainnetAleoProvider(['https://rpc.example'], 1)).to.throw(
+      'Mainnet runtime cannot serve Aleo chain id 1',
+    );
+    expect(() => new TestnetAleoProvider(['https://rpc.example'], 0)).to.throw(
+      'Testnet runtime cannot serve Aleo chain id 0',
+    );
+  });
+});

--- a/typescript/aleo-sdk/src/runtime/provider.ts
+++ b/typescript/aleo-sdk/src/runtime/provider.ts
@@ -1,0 +1,40 @@
+import { assert } from '@hyperlane-xyz/utils';
+
+import { AleoProvider as RuntimeAleoProvider } from '../clients/provider.js';
+import type { AleoSdk } from '../utils/provable.js';
+import {
+  AleoNetworkId,
+  type AleoNetworkId as AleoNetworkIdValue,
+  toAleoNetworkId,
+} from '../utils/types.js';
+
+export interface AleoProviderConstructor {
+  new (rpcUrls: string[], chainId: string | number): RuntimeAleoProvider;
+  connect(
+    rpcUrls: string[],
+    chainId: string | number,
+  ): Promise<RuntimeAleoProvider>;
+}
+
+export function createAleoProviderClass(
+  sdk: AleoSdk,
+  expectedNetwork: AleoNetworkIdValue,
+): AleoProviderConstructor {
+  const runtimeName =
+    expectedNetwork === AleoNetworkId.MAINNET ? 'Mainnet' : 'Testnet';
+
+  return class AleoProvider extends RuntimeAleoProvider {
+    static async connect(rpcUrls: string[], chainId: string | number) {
+      return new AleoProvider(rpcUrls, chainId);
+    }
+
+    constructor(rpcUrls: string[], chainId: string | number) {
+      const networkId = toAleoNetworkId(+chainId);
+      assert(
+        networkId === expectedNetwork,
+        `${runtimeName} runtime cannot serve Aleo chain id ${chainId}`,
+      );
+      super(rpcUrls, chainId, sdk);
+    }
+  };
+}

--- a/typescript/aleo-sdk/src/runtime/testnet.ts
+++ b/typescript/aleo-sdk/src/runtime/testnet.ts
@@ -1,29 +1,13 @@
 import * as testnetSdk from '@provablehq/sdk/testnet.js';
 
-import { assert } from '@hyperlane-xyz/utils';
-
-import { AleoProvider as RuntimeAleoProvider } from '../clients/provider.js';
+import { AleoNetworkId } from '../constants.js';
 import type { AleoSdk } from '../utils/provable.js';
-import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
+
+import { createAleoProviderClass } from './provider.js';
 
 // CAST: Both Provable network modules expose the same API, but private WASM
 // fields make their otherwise-compatible class types nominal.
 const sdk = testnetSdk as unknown as AleoSdk;
 
-export class AleoProvider extends RuntimeAleoProvider {
-  static async connect(
-    rpcUrls: string[],
-    chainId: string | number,
-  ): Promise<AleoProvider> {
-    return new AleoProvider(rpcUrls, chainId);
-  }
-
-  constructor(rpcUrls: string[], chainId: string | number) {
-    const networkId = toAleoNetworkId(+chainId);
-    assert(
-      networkId === AleoNetworkId.TESTNET,
-      `Testnet runtime cannot serve Aleo chain id ${chainId}`,
-    );
-    super(rpcUrls, chainId, sdk);
-  }
-}
+export const AleoProvider = createAleoProviderClass(sdk, AleoNetworkId.TESTNET);
+export type AleoProvider = InstanceType<typeof AleoProvider>;

--- a/typescript/aleo-sdk/src/runtime/testnet.ts
+++ b/typescript/aleo-sdk/src/runtime/testnet.ts
@@ -1,0 +1,29 @@
+import * as testnetSdk from '@provablehq/sdk/testnet.js';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import { AleoProvider as RuntimeAleoProvider } from '../clients/provider.js';
+import type { AleoSdk } from '../utils/provable.js';
+import { AleoNetworkId, toAleoNetworkId } from '../utils/types.js';
+
+// CAST: Both Provable network modules expose the same API, but private WASM
+// fields make their otherwise-compatible class types nominal.
+const sdk = testnetSdk as unknown as AleoSdk;
+
+export class AleoProvider extends RuntimeAleoProvider {
+  static async connect(
+    rpcUrls: string[],
+    chainId: string | number,
+  ): Promise<AleoProvider> {
+    return new AleoProvider(rpcUrls, chainId);
+  }
+
+  constructor(rpcUrls: string[], chainId: string | number) {
+    const networkId = toAleoNetworkId(+chainId);
+    assert(
+      networkId === AleoNetworkId.TESTNET,
+      `Testnet runtime cannot serve Aleo chain id ${chainId}`,
+    );
+    super(rpcUrls, chainId, sdk);
+  }
+}

--- a/typescript/aleo-sdk/src/utils/helper.crypto.ts
+++ b/typescript/aleo-sdk/src/utils/helper.crypto.ts
@@ -1,0 +1,23 @@
+import * as mainnetSdk from '@provablehq/sdk/mainnet.js';
+
+import {
+  getAddressFromProgramIdWithSdk,
+  toAleoAddressWithSdk,
+  toKeyIdWithSdk,
+} from './helper.js';
+
+export function getAddressFromProgramId(programId: string): string {
+  return getAddressFromProgramIdWithSdk(mainnetSdk, programId);
+}
+
+export function toAleoAddress(programId: string): string {
+  return toAleoAddressWithSdk(mainnetSdk, programId);
+}
+
+export function toKeyId(
+  programId: string,
+  mappingName: string,
+  key: string,
+): string {
+  return toKeyIdWithSdk(mainnetSdk, programId, mappingName, key);
+}

--- a/typescript/aleo-sdk/src/utils/helper.test.ts
+++ b/typescript/aleo-sdk/src/utils/helper.test.ts
@@ -2,7 +2,11 @@ import { expect } from 'chai';
 
 import { ALEO_PROGRAMS } from '../programs.js';
 
-import { getProgramSuffix } from './helper.js';
+import {
+  bytes32ToU128String,
+  bytesLeToU128String,
+  getProgramSuffix,
+} from './helper.js';
 
 describe('getProgramSuffix', () => {
   it('uses the generated program metadata', () => {
@@ -12,5 +16,22 @@ describe('getProgramSuffix', () => {
 
   it('removes the testnet prefix', () => {
     expect(getProgramSuffix('test_hyp_mailbox_abc123.aleo')).to.equal('abc123');
+  });
+});
+
+describe('u128 byte encoding', () => {
+  it('encodes little-endian bytes without the Provable runtime', () => {
+    expect(bytesLeToU128String(Uint8Array.from([1, 1]))).to.equal('257u128');
+    expect(bytesLeToU128String(new Uint8Array(16).fill(255))).to.equal(
+      '340282366920938463463374607431768211455u128',
+    );
+  });
+
+  it('splits bytes32 values into little-endian u128 pairs', () => {
+    expect(
+      bytes32ToU128String(
+        '0x0101000000000000000000000000000002000000000000000000000000000000',
+      ),
+    ).to.equal('[257u128,2u128]');
   });
 });

--- a/typescript/aleo-sdk/src/utils/helper.ts
+++ b/typescript/aleo-sdk/src/utils/helper.ts
@@ -1,5 +1,3 @@
-import { BHP256, BHP1024, Plaintext, U128 } from '@provablehq/sdk/mainnet.js';
-
 import { TokenType } from '@hyperlane-xyz/provider-sdk/warp';
 import {
   assert,
@@ -14,6 +12,7 @@ import { ALEO_NULL_ADDRESS } from '../constants.js';
 import { ALEO_PROGRAMS, type AleoProgram } from '../programs.js';
 
 import { AleoNetworkId, AleoTokenType } from './types.js';
+import type { AleoSdk } from './provable.js';
 
 const skipSuffixes = JSON.parse(process.env['ALEO_SKIP_SUFFIXES'] || 'false');
 
@@ -53,12 +52,15 @@ export function programIdToPlaintext(programId: string): string {
   return arrayToPlaintext(fillArray(bytes, 128, `0u8`));
 }
 
-export function getAddressFromProgramId(programId: string): string {
-  return Plaintext.fromString(programId).toString();
+export function getAddressFromProgramIdWithSdk(
+  sdk: AleoSdk,
+  programId: string,
+): string {
+  return sdk.Plaintext.fromString(programId).toString();
 }
 
-export function toAleoAddress(programId: string): string {
-  return `${programId}/${getAddressFromProgramId(programId)}`;
+export function toAleoAddressWithSdk(sdk: AleoSdk, programId: string): string {
+  return `${programId}/${getAddressFromProgramIdWithSdk(sdk, programId)}`;
 }
 
 export function fromAleoAddress(aleoAddress: string): {
@@ -176,7 +178,16 @@ export function bytes32ToU128String(input: string): string {
   const lowBytes = Uint8Array.from(bytes.subarray(0, 16));
   const highBytes = Uint8Array.from(bytes.subarray(16, 32));
 
-  return `[${U128.fromBytesLe(lowBytes).toString()},${U128.fromBytesLe(highBytes).toString()}]`;
+  return `[${bytesLeToU128String(lowBytes)},${bytesLeToU128String(highBytes)}]`;
+}
+
+export function bytesLeToU128String(bytes: Uint8Array): string {
+  assert(bytes.length <= 16, `bytesLeToU128String: expected at most 16 bytes`);
+  let value = 0n;
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    value = (value << 8n) | BigInt(bytes[i]);
+  }
+  return `${value}u128`;
 }
 
 // Inverse of bytes32ToU128String: parses "[lowU128u128, highU128u128]" from dispatch_id_events
@@ -218,10 +229,16 @@ export function u128PairToBytes32(u128PairStr: string): string {
   return toHexString(Buffer.from(bytes));
 }
 
-export function getBalanceKey(address: string, denom: string): string {
-  return new BHP256()
+export function getBalanceKeyWithSdk(
+  sdk: AleoSdk,
+  address: string,
+  denom: string,
+): string {
+  return new sdk.BHP256()
     .hash(
-      Plaintext.fromString(`{account:${address},token_id:${denom}}`).toBitsLe(),
+      sdk.Plaintext.fromString(
+        `{account:${address},token_id:${denom}}`,
+      ).toBitsLe(),
     )
     .toString();
 }
@@ -255,7 +272,8 @@ function programIdToBitsLe(programId: string): boolean[] {
 // Matches the Rust `to_key_id` in hyperlane-aleo/src/utils.rs:
 //   BHP1024(programId_bits | false | mappingName_bits | false | plaintextKey_bits)
 // key must be a valid Aleo plaintext string, e.g. "0u32".
-export function toKeyId(
+export function toKeyIdWithSdk(
+  sdk: AleoSdk,
   programId: string,
   mappingName: string,
   key: string,
@@ -265,9 +283,9 @@ export function toKeyId(
     false,
     ...identifierToBitsLe(mappingName),
     false,
-    ...Plaintext.fromString(key).toBitsLe(),
+    ...sdk.Plaintext.fromString(key).toBitsLe(),
   ];
-  return new BHP1024().hash(bits).toString();
+  return new sdk.BHP1024().hash(bits).toString();
 }
 
 /**

--- a/typescript/aleo-sdk/src/utils/provable.ts
+++ b/typescript/aleo-sdk/src/utils/provable.ts
@@ -1,0 +1,5 @@
+import type * as AleoMainnetSdk from '@provablehq/sdk/mainnet.js';
+
+export type AleoSdk = typeof AleoMainnetSdk;
+
+export type AleoPlaintextRuntime = Pick<AleoSdk, 'Plaintext'>;

--- a/typescript/aleo-sdk/src/utils/types.ts
+++ b/typescript/aleo-sdk/src/utils/types.ts
@@ -7,6 +7,14 @@ import { ArtifactState } from '@hyperlane-xyz/provider-sdk/artifact';
 import { type RawWarpArtifactConfig } from '@hyperlane-xyz/provider-sdk/warp';
 import { type Annotated, assert } from '@hyperlane-xyz/utils';
 
+import {
+  AleoNetworkId as AleoNetworkIds,
+  type AleoNetworkId as AleoNetworkIdValue,
+} from '../constants.js';
+
+export const AleoNetworkId = AleoNetworkIds;
+export type AleoNetworkId = AleoNetworkIdValue;
+
 export interface AleoTransaction extends ExecuteOptions {}
 export type AnnotatedAleoTransaction = Annotated<AleoTransaction>;
 export interface AleoReceipt extends ConfirmedTransactionJSON {
@@ -35,17 +43,10 @@ export enum AleoIsmType {
   MESSAGE_ID_MULTISIG = 5,
 }
 
-export const AleoNetworkId = {
-  MAINNET: 0,
-  TESTNET: 1,
-} as const;
-
-export type AleoNetworkId = (typeof AleoNetworkId)[keyof typeof AleoNetworkId];
-
 export function toAleoNetworkId(chainId: number): AleoNetworkId {
   assert(
-    chainId === AleoNetworkId.MAINNET || chainId === AleoNetworkId.TESTNET,
-    `Unknown chain id ${chainId} for Aleo, only ${AleoNetworkId.MAINNET} or ${AleoNetworkId.TESTNET} allowed`,
+    chainId === AleoNetworkIds.MAINNET || chainId === AleoNetworkIds.TESTNET,
+    `Unknown chain id ${chainId} for Aleo, only ${AleoNetworkIds.MAINNET} or ${AleoNetworkIds.TESTNET} allowed`,
   );
   return chainId;
 }

--- a/typescript/aleo-sdk/src/validator-announce/validator-announce.ts
+++ b/typescript/aleo-sdk/src/validator-announce/validator-announce.ts
@@ -14,11 +14,11 @@ import { assert } from '@hyperlane-xyz/utils';
 import { type AnyAleoNetworkClient } from '../clients/base.js';
 import { type AleoSigner } from '../clients/signer.js';
 import { getMailboxConfig } from '../mailbox/mailbox-query.js';
+import { toAleoAddress } from '../utils/helper.crypto.js';
 import {
   getNetworkPrefix,
   getUnusedSuffix,
   SUFFIX_LENGTH_SHORT,
-  toAleoAddress,
 } from '../utils/helper.js';
 import {
   type AleoArtifactNetworkConfig,

--- a/typescript/aleo-sdk/src/warp/collateral-token.ts
+++ b/typescript/aleo-sdk/src/warp/collateral-token.ts
@@ -14,11 +14,8 @@ import { assert } from '@hyperlane-xyz/utils';
 
 import type { AnyAleoNetworkClient } from '../clients/base.js';
 import type { AleoSigner } from '../clients/signer.js';
-import {
-  fromAleoAddress,
-  getProgramSuffix,
-  toAleoAddress,
-} from '../utils/helper.js';
+import { toAleoAddress } from '../utils/helper.crypto.js';
+import { fromAleoAddress, getProgramSuffix } from '../utils/helper.js';
 import {
   type AleoReceipt,
   type AnnotatedAleoTransaction,

--- a/typescript/aleo-sdk/src/warp/native-token.ts
+++ b/typescript/aleo-sdk/src/warp/native-token.ts
@@ -14,11 +14,8 @@ import { assert } from '@hyperlane-xyz/utils';
 
 import type { AnyAleoNetworkClient } from '../clients/base.js';
 import type { AleoSigner } from '../clients/signer.js';
-import {
-  fromAleoAddress,
-  getProgramSuffix,
-  toAleoAddress,
-} from '../utils/helper.js';
+import { toAleoAddress } from '../utils/helper.crypto.js';
+import { fromAleoAddress, getProgramSuffix } from '../utils/helper.js';
 import {
   type AleoReceipt,
   type AnnotatedAleoTransaction,

--- a/typescript/aleo-sdk/src/warp/provider-query.ts
+++ b/typescript/aleo-sdk/src/warp/provider-query.ts
@@ -1,0 +1,153 @@
+import { assert, ensure0x, retryAsync } from '@hyperlane-xyz/utils';
+
+import type { AnyAleoNetworkClient } from '../clients/base.js';
+import {
+  RETRY_ATTEMPTS,
+  RETRY_DELAY_MS,
+  fromAleoAddress,
+} from '../utils/helper.js';
+import type { AleoPlaintextRuntime } from '../utils/provable.js';
+
+/** Returns the ARC-20 token program imported by an ARC-20 warp token. */
+export async function getArc20ProgramId(
+  aleoClient: AnyAleoNetworkClient,
+  warpProgramId: string,
+): Promise<string> {
+  const imports = await aleoClient.getProgramImportNames(warpProgramId);
+  const arc20ProgramId = imports.find(
+    (i) => i.includes('arc20') && !i.includes('multisig'),
+  );
+  assert(
+    arc20ProgramId,
+    `Could not find ARC-20 token import in program ${warpProgramId}`,
+  );
+  return arc20ProgramId;
+}
+
+/** Extracts the first wire-format output from a view function response. */
+export function parseViewFunctionOutputs(
+  outputs: unknown,
+  programId: string,
+  viewName: string,
+): string {
+  assert(
+    Array.isArray(outputs) &&
+      outputs.length > 0 &&
+      typeof outputs[0] === 'string',
+    `View function ${programId}/${viewName} returned an unexpected response shape: ${JSON.stringify(outputs)}`,
+  );
+  return outputs[0];
+}
+
+/** Calls an Aleo program view function through the Explorer REST API. */
+export async function callViewFunction(
+  aleoClient: AnyAleoNetworkClient,
+  programId: string,
+  viewName: string,
+  inputs: string[] = [],
+): Promise<string> {
+  const url = `${aleoClient.host}/program/${programId}/view/${viewName}`;
+  const body = inputs.length === 0 ? '{}' : JSON.stringify(inputs);
+  return retryAsync(
+    async () => {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+      assert(res.ok, `View function call failed (${res.status}): ${url}`);
+      const outputs: unknown = await res.json();
+      return parseViewFunctionOutputs(outputs, programId, viewName);
+    },
+    RETRY_ATTEMPTS,
+    RETRY_DELAY_MS,
+  );
+}
+
+/** Parses a raw Aleo uint literal such as `1000000u128`. */
+export function parseAleoUint(raw: string): bigint {
+  const match = raw.match(/^(\d+)/);
+  assert(match, `Expected numeric Aleo literal, got: ${raw}`);
+  return BigInt(match[1]);
+}
+
+function parseAleoIdentifier(raw: string): string {
+  return raw.replace(/^'|'$/g, '');
+}
+
+/** Queries token metadata from an ARC-20 token program's view functions. */
+export async function getArc20TokenMetadata(
+  aleoClient: AnyAleoNetworkClient,
+  arc20ProgramId: string,
+): Promise<{ name: string; symbol: string; decimals: number }> {
+  const [nameRaw, symbolRaw, decimalsRaw] = await Promise.all([
+    callViewFunction(aleoClient, arc20ProgramId, 'name'),
+    callViewFunction(aleoClient, arc20ProgramId, 'symbol'),
+    callViewFunction(aleoClient, arc20ProgramId, 'decimals'),
+  ]);
+  const decimals = parseInt(decimalsRaw, 10);
+  assert(
+    !Number.isNaN(decimals),
+    `Expected numeric decimals from ${arc20ProgramId}, got: ${decimalsRaw}`,
+  );
+
+  return {
+    name: parseAleoIdentifier(nameRaw),
+    symbol: parseAleoIdentifier(symbolRaw),
+    decimals,
+  };
+}
+
+/** Queries a warp token's remote routers with the selected network runtime. */
+export async function getRemoteRoutersWithSdk(
+  sdk: AleoPlaintextRuntime,
+  aleoClient: AnyAleoNetworkClient,
+  tokenAddress: string,
+): Promise<Record<number, { address: string; gas: string }>> {
+  const { programId } = fromAleoAddress(tokenAddress);
+  const remoteRouters: Record<number, { address: string; gas: string }> = {};
+  const routerLengthRes = await aleoClient.getProgramMappingValue(
+    programId,
+    'remote_router_length',
+    'true',
+  );
+
+  if (!routerLengthRes) return remoteRouters;
+
+  const routerLength = parseInt(routerLengthRes);
+  assert(
+    !isNaN(routerLength) && routerLength >= 0,
+    `Expected remote_router_length to be a non-negative number for token ${tokenAddress} but got ${routerLengthRes}`,
+  );
+
+  for (let i = 0; i < routerLength; i++) {
+    const routerKey = await aleoClient.getProgramMappingPlaintext(
+      programId,
+      'remote_router_iter',
+      `${i}u32`,
+    );
+    if (!routerKey) continue;
+
+    const remoteRouterValue = await aleoClient.getProgramMappingValue(
+      programId,
+      'remote_routers',
+      routerKey,
+    );
+    if (!remoteRouterValue) continue;
+
+    const remoteRouter = sdk.Plaintext.fromString(remoteRouterValue).toObject();
+    const domainId = Number(remoteRouter['domain']);
+    if (remoteRouters[domainId]) continue;
+
+    assert(
+      Array.isArray(remoteRouter['recipient']),
+      `Expected recipient to be an array in remote router for domain ${domainId} but got ${typeof remoteRouter['recipient']}`,
+    );
+    remoteRouters[domainId] = {
+      address: ensure0x(Buffer.from(remoteRouter['recipient']).toString('hex')),
+      gas: remoteRouter['gas'].toString(),
+    };
+  }
+
+  return remoteRouters;
+}

--- a/typescript/aleo-sdk/src/warp/synthetic-token.ts
+++ b/typescript/aleo-sdk/src/warp/synthetic-token.ts
@@ -14,11 +14,8 @@ import { assert } from '@hyperlane-xyz/utils';
 
 import type { AnyAleoNetworkClient } from '../clients/base.js';
 import type { AleoSigner } from '../clients/signer.js';
-import {
-  fromAleoAddress,
-  getProgramSuffix,
-  toAleoAddress,
-} from '../utils/helper.js';
+import { toAleoAddress } from '../utils/helper.crypto.js';
+import { fromAleoAddress, getProgramSuffix } from '../utils/helper.js';
 import {
   type AleoReceipt,
   type AnnotatedAleoTransaction,

--- a/typescript/aleo-sdk/src/warp/warp-query.ts
+++ b/typescript/aleo-sdk/src/warp/warp-query.ts
@@ -2,7 +2,6 @@ import { Plaintext } from '@provablehq/sdk';
 
 import {
   assert,
-  ensure0x,
   isNullish,
   isZeroishAddress,
   retryAsync,
@@ -15,97 +14,27 @@ import {
   U128ToString,
   fromAleoAddress,
   isV2WarpToken,
-  toAleoAddress,
 } from '../utils/helper.js';
+import { toAleoAddress } from '../utils/helper.crypto.js';
 import {
   type AleoCollateralWarpTokenConfig,
   type AleoNativeWarpTokenConfig,
   type AleoSyntheticWarpTokenConfig,
   AleoTokenType,
 } from '../utils/types.js';
+import {
+  getArc20ProgramId,
+  getArc20TokenMetadata,
+  getRemoteRoutersWithSdk,
+} from './provider-query.js';
 
-/**
- * Returns the ARC-20 token program ID imported by an ARC-20-based warp token.
- * The arc20 token import is the one that contains 'arc20' but not 'multisig'.
- */
-export async function getArc20ProgramId(
-  aleoClient: AnyAleoNetworkClient,
-  warpProgramId: string,
-): Promise<string> {
-  const imports = await aleoClient.getProgramImportNames(warpProgramId);
-  const arc20ProgramId = imports.find(
-    (i) => i.includes('arc20') && !i.includes('multisig'),
-  );
-  assert(
-    arc20ProgramId,
-    `Could not find ARC-20 token import in program ${warpProgramId}`,
-  );
-  return arc20ProgramId;
-}
-
-/**
- * Validates and extracts the first output from a view function response body.
- * Expects a JSON array of wire-format strings (e.g. ["6u8"], ["'USDC'"]).
- */
-export function parseViewFunctionOutputs(
-  outputs: unknown,
-  programId: string,
-  viewName: string,
-): string {
-  assert(
-    Array.isArray(outputs) &&
-      outputs.length > 0 &&
-      typeof outputs[0] === 'string',
-    `View function ${programId}/${viewName} returned an unexpected response shape: ${JSON.stringify(outputs)}`,
-  );
-  return outputs[0];
-}
-
-/**
- * Calls a view function on an Aleo program via the Explorer REST API.
- * POST {host}/program/{programId}/view/{viewName}
- * No-input functions use an empty object body `{}`; functions with inputs use a JSON array.
- * Returns the raw wire-format string of the first output (e.g. "6u8", "'USDC'", "1000000u128").
- */
-export async function callViewFunction(
-  aleoClient: AnyAleoNetworkClient,
-  programId: string,
-  viewName: string,
-  inputs: string[] = [],
-): Promise<string> {
-  const url = `${aleoClient.host}/program/${programId}/view/${viewName}`;
-  const body = inputs.length === 0 ? '{}' : JSON.stringify(inputs);
-  return retryAsync(
-    async () => {
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body,
-      });
-      assert(res.ok, `View function call failed (${res.status}): ${url}`);
-      const outputs: unknown = await res.json();
-      return parseViewFunctionOutputs(outputs, programId, viewName);
-    },
-    RETRY_ATTEMPTS,
-    RETRY_DELAY_MS,
-  );
-}
-
-/**
- * Parse a raw Aleo uint literal (e.g. "1000000u128", "6u8") to BigInt.
- */
-export function parseAleoUint(raw: string): bigint {
-  const match = raw.match(/^(\d+)/);
-  assert(match, `Expected numeric Aleo literal, got: ${raw}`);
-  return BigInt(match[1]);
-}
-
-/**
- * Parse a raw Aleo identifier literal (e.g. "'USDC'") to a plain string.
- */
-function parseAleoIdentifier(raw: string): string {
-  return raw.replace(/^'|'$/g, '');
-}
+export {
+  callViewFunction,
+  getArc20ProgramId,
+  getArc20TokenMetadata,
+  parseAleoUint,
+  parseViewFunctionOutputs,
+} from './provider-query.js';
 
 /**
  * Converts the v2 ARC-20 warp token standard's on-chain local_decimals/
@@ -133,31 +62,6 @@ export function nativeScaleExponentToMultiplier(
 ): number | undefined {
   if (isNullish(exponent) || exponent === 0) return undefined;
   return Math.pow(10, exponent);
-}
-
-/**
- * Query token metadata from an ARC-20 token program via its view functions.
- */
-export async function getArc20TokenMetadata(
-  aleoClient: AnyAleoNetworkClient,
-  arc20ProgramId: string,
-): Promise<{ name: string; symbol: string; decimals: number }> {
-  const [nameRaw, symbolRaw, decimalsRaw] = await Promise.all([
-    callViewFunction(aleoClient, arc20ProgramId, 'name'),
-    callViewFunction(aleoClient, arc20ProgramId, 'symbol'),
-    callViewFunction(aleoClient, arc20ProgramId, 'decimals'),
-  ]);
-  const decimals = parseInt(decimalsRaw, 10);
-  assert(
-    !Number.isNaN(decimals),
-    `Expected numeric decimals from ${arc20ProgramId}, got: ${decimalsRaw}`,
-  );
-
-  return {
-    name: parseAleoIdentifier(nameRaw),
-    symbol: parseAleoIdentifier(symbolRaw),
-    decimals,
-  };
 }
 
 /**
@@ -263,64 +167,7 @@ export async function getRemoteRouters(
   aleoClient: AnyAleoNetworkClient,
   tokenAddress: string,
 ): Promise<Record<number, { address: string; gas: string }>> {
-  const { programId } = fromAleoAddress(tokenAddress);
-
-  const remoteRouters: Record<number, { address: string; gas: string }> = {};
-
-  const routerLengthRes = await aleoClient.getProgramMappingValue(
-    programId,
-    'remote_router_length',
-    'true',
-  );
-
-  if (!routerLengthRes) {
-    return remoteRouters;
-  }
-
-  const routerLength = parseInt(routerLengthRes);
-  assert(
-    !isNaN(routerLength) && routerLength >= 0,
-    `Expected remote_router_length to be a non-negative number for token ${tokenAddress} but got ${routerLengthRes}`,
-  );
-
-  for (let i = 0; i < routerLength; i++) {
-    const routerKey = await aleoClient.getProgramMappingPlaintext(
-      programId,
-      'remote_router_iter',
-      `${i}u32`,
-    );
-
-    if (!routerKey) continue;
-
-    const remoteRouterValue = await aleoClient.getProgramMappingValue(
-      programId,
-      'remote_routers',
-      routerKey,
-    );
-
-    if (!remoteRouterValue) continue;
-
-    const remoteRouter = Plaintext.fromString(remoteRouterValue).toObject();
-
-    const domainId = Number(remoteRouter['domain']);
-
-    // Skip duplicates (defensive: shouldn't occur in normal operation)
-    if (remoteRouters[domainId]) {
-      continue;
-    }
-
-    assert(
-      Array.isArray(remoteRouter['recipient']),
-      `Expected recipient to be an array in remote router for domain ${domainId} but got ${typeof remoteRouter['recipient']}`,
-    );
-
-    remoteRouters[domainId] = {
-      address: ensure0x(Buffer.from(remoteRouter['recipient']).toString('hex')),
-      gas: remoteRouter['gas'].toString(),
-    };
-  }
-
-  return remoteRouters;
+  return getRemoteRoutersWithSdk({ Plaintext }, aleoClient, tokenAddress);
 }
 
 /**

--- a/typescript/sdk/src/providers/builders/aleo.browser.ts
+++ b/typescript/sdk/src/providers/builders/aleo.browser.ts
@@ -1,4 +1,6 @@
 import type { AleoProvider as AleoSDKProvider } from '@hyperlane-xyz/aleo-sdk/runtime';
+import { AleoNetworkId } from '@hyperlane-xyz/aleo-sdk/constants';
+import { LazyAsync } from '@hyperlane-xyz/utils';
 
 import type { RpcUrl } from '../../metadata/chainMetadataTypes.js';
 import type { AleoProvider } from '../ProviderType.js';
@@ -15,10 +17,20 @@ interface AleoRuntimeModule {
   AleoProvider: AleoProviderConstructor;
 }
 
-type AleoProviderLoader = () => Promise<AleoRuntimeModule>;
+type AleoProviderLoader = (
+  network: string | number,
+) => Promise<AleoRuntimeModule>;
 
-const loadAleoProvider: AleoProviderLoader = () =>
-  import('@hyperlane-xyz/aleo-sdk/runtime');
+const loadAleoProvider: AleoProviderLoader = (network) => {
+  switch (+network) {
+    case AleoNetworkId.MAINNET:
+      return import('@hyperlane-xyz/aleo-sdk/runtime/mainnet');
+    case AleoNetworkId.TESTNET:
+      return import('@hyperlane-xyz/aleo-sdk/runtime/testnet');
+    default:
+      throw new Error(`Unsupported Aleo network id ${network}`);
+  }
+};
 
 function createAsyncMethodProxy<T extends object>(
   getTarget: () => Promise<T>,
@@ -51,11 +63,12 @@ export function createLazyAleoProvider(
   const normalizedRpcUrls = rpcUrls.map((url) =>
     url.replaceAll('/testnet', '').replaceAll('/mainnet', ''),
   );
-  let providerPromise: Promise<AleoSDKProvider> | undefined;
-  const getProvider = () =>
-    (providerPromise ??= loadProvider().then(
+  const provider = new LazyAsync(() =>
+    loadProvider(network).then(
       ({ AleoProvider }) => new AleoProvider(rpcUrls, network),
-    ));
+    ),
+  );
+  const getProvider = () => provider.get();
   const asyncProvider = createAsyncMethodProxy(getProvider);
 
   return new Proxy(asyncProvider, {

--- a/typescript/sdk/src/providers/builders/aleo.test.ts
+++ b/typescript/sdk/src/providers/builders/aleo.test.ts
@@ -31,7 +31,9 @@ describe('createLazyAleoProvider', () => {
     const provider = createLazyAleoProvider(
       ['https://rpc.example/mainnet'],
       0,
-      (async () => {
+      // CAST: The fake only implements methods exercised by this proxy test.
+      (async (network: string | number) => {
+        expect(network).to.equal(0);
         loadCount++;
         return { AleoProvider: FakeAleoProvider };
       }) as unknown as Parameters<typeof createLazyAleoProvider>[2],
@@ -46,5 +48,54 @@ describe('createLazyAleoProvider', () => {
     expect(await provider.getAleoClient().getLatestHeight()).to.equal(42);
     expect(loadCount).to.equal(1);
     expect(constructionCount).to.equal(1);
+  });
+
+  it('selects and caches each configured network independently', async () => {
+    const loadedNetworks: (string | number)[] = [];
+
+    class FakeAleoProvider {
+      constructor(
+        public readonly rpcUrls: string[],
+        public readonly network: string | number,
+      ) {}
+
+      async getHeight() {
+        return +this.network;
+      }
+    }
+
+    const loadProvider = async (network: string | number) => {
+      loadedNetworks.push(network);
+      return { AleoProvider: FakeAleoProvider };
+    };
+    const mainnetProvider = createLazyAleoProvider(
+      ['https://rpc.example/mainnet'],
+      0,
+      // CAST: The fake only implements methods exercised by this proxy test.
+      loadProvider as unknown as Parameters<typeof createLazyAleoProvider>[2],
+    );
+    const testnetProvider = createLazyAleoProvider(
+      ['https://rpc.example/testnet'],
+      1,
+      // CAST: The fake only implements methods exercised by this proxy test.
+      loadProvider as unknown as Parameters<typeof createLazyAleoProvider>[2],
+    );
+
+    expect(loadedNetworks).to.deep.equal([]);
+    expect(await mainnetProvider.getHeight()).to.equal(0);
+    expect(await mainnetProvider.getHeight()).to.equal(0);
+    expect(loadedNetworks).to.deep.equal([0]);
+    expect(await testnetProvider.getHeight()).to.equal(1);
+    expect(loadedNetworks).to.deep.equal([0, 1]);
+  });
+
+  it('rejects unsupported Aleo network ids before loading a runtime', async () => {
+    const provider = createLazyAleoProvider(['https://rpc.example'], 2);
+
+    const error = await provider.getHeight().then(
+      () => undefined,
+      (reason: unknown) => String(reason),
+    );
+    expect(error).to.equal('Error: Unsupported Aleo network id 2');
   });
 });


### PR DESCRIPTION
### Description

Splits the Aleo browser provider into mainnet and testnet runtime entrypoints. The SDK selects one through a lazy dynamic import, so a Warp UI deployment downloads only its build-time configured Aleo network. This does not add runtime Shield wallet network switching.

Both network entrypoints use one shared provider-class factory; only their Provable SDK imports remain separate. The existing Aleo runtime export remains the eager dual-network Node/CLI implementation for backward compatibility.

Isolated runtime benchmark: 740.7 KB raw / 122.5 KB gzip combined versus 407.6 KB / 76.3 KB per network, about 45% raw and 38% gzip smaller. Bundle metadata found zero cross-network imports. Based on the measured Warp UI assets, first Aleo use should fetch one approximately 12.1 MB compressed Provable WASM instead of both approximately 24.1 MB total.

### Drive-by changes

None.

### Related issues

N/A.

### Backward compatibility

Yes. The legacy runtime export and two-argument AleoProvider constructor are preserved for Node and CLI consumers. The per-network exports are additive.

### Testing

- Aleo SDK build and 23 unit tests
- SDK build and 809 unit tests
- Mainnet/testnet runtime constructor tests, including wrong-network rejection
- CLI build and ncc bundle compatibility
- Aleo devnet E2E passed ISM, hook, native, collateral, and synthetic provider paths before stopping the remaining broad artifact matrix
- Staged lint, formatting, diff, changeset, and secret checks