### PR TITLE
feat(infra): OQLF fees on USDC/eclipse and USDT/eclipse EVM legs

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -15,7 +15,10 @@ import { awSafes } from '../../governance/safe/aw.js';
 import { getWarpFeeOwner } from '../../governance/utils.js';
 import { chainOwners } from '../../owners.js';
 import { usdcTokenAddresses } from '../cctp.js';
-import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
+import {
+  QUOTE_SIGNER,
+  SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+} from '../consts.js';
 import { WarpRouteIds } from '../warpIds.js';
 
 import {
@@ -47,9 +50,6 @@ type DeploymentChains<T> = {
 };
 
 export type DeploymentChain = keyof DeploymentChains<unknown>;
-
-// Hyperlane quote signer authorized to sign offchain standing fee quotes.
-const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';
 
 /**
  * Eclipse USDC Warp Route

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -2,24 +2,25 @@ import {
   ChainMap,
   ChainSubmissionStrategy,
   HypTokenRouterConfig,
-  SubmissionStrategy,
   TokenType,
-  TxSubmitterType,
 } from '@hyperlane-xyz/sdk';
 import { assert, objMap } from '@hyperlane-xyz/utils';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
-import { getChainAddresses } from '../../../../registry.js';
 import { awIcas } from '../../governance/ica/aw.js';
 import { awSafes } from '../../governance/safe/aw.js';
 import { WARP_FEES_TURNKEY_OWNER } from '../../governance/utils.js';
 import { chainOwners } from '../../owners.js';
 import { usdcTokenAddresses } from '../cctp.js';
-import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
+import {
+  QUOTE_SIGNER,
+  SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+} from '../consts.js';
 import { WarpRouteIds } from '../warpIds.js';
 
 import {
   getCollateralTokenConfigForChain,
+  getEclipseWarpStrategyConfig,
   getFileSubmitterStrategyConfig,
   getFixedRoutingFeeConfig,
   getRebalancingUSDCConfigForChain,
@@ -383,6 +384,7 @@ export const getEclipseUSDCWarpConfig = async (
       name: 'USD Coin',
       symbol: 'USDC',
     },
+    quoteSigners: [QUOTE_SIGNER],
   });
 
 // Strategies
@@ -392,58 +394,12 @@ export const getUSDCEclipseFileSubmitterStrategyConfig = () =>
     '/tmp/eclipse-usdc-combined.json',
   );
 
-const ORIGIN_CHAIN = 'ethereum';
-
 export const getEclipseUSDCStrategyConfig = (): ChainSubmissionStrategy => {
-  const safeAddress = awSafes[ORIGIN_CHAIN];
-  const originSafeSubmitter = {
-    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
-    chain: ORIGIN_CHAIN,
-    safeAddress,
-    version: '1',
-  };
-
-  const chainAddress = getChainAddresses();
-  const originInterchainAccountRouter =
-    chainAddress[ORIGIN_CHAIN].interchainAccountRouter;
-  assert(
-    originInterchainAccountRouter,
-    `Could not fetch originInterchainAccountRouter for ${ORIGIN_CHAIN}`,
-  );
-
-  const icaChains = evmDeploymentChains.filter((c) => c !== ORIGIN_CHAIN);
-  const icaStrategies: [string, SubmissionStrategy][] = icaChains.map(
-    (chain) => [
-      chain,
-      {
-        submitter: {
-          type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
-          chain: ORIGIN_CHAIN,
-          destinationChain: chain,
-          owner: safeAddress,
-          originInterchainAccountRouter,
-          internalSubmitter: originSafeSubmitter,
-        },
-      },
-    ],
-  );
-
-  const svmFileStrategies: [
-    string,
-    { submitter: { type: 'file'; filepath: string } },
-  ][] = nonEvmDeploymentChains.map((chain) => [
-    chain,
-    {
-      submitter: {
-        type: 'file' as const,
-        filepath: `/tmp/eclipse-usdc-${chain}.json`,
-      },
-    },
-  ]);
-
-  return Object.fromEntries([
-    [ORIGIN_CHAIN, { submitter: originSafeSubmitter }],
-    ...icaStrategies,
-    ...svmFileStrategies,
-  ]);
+  // CAST: The CLI-specific file feeSubmitter is not represented by SDK types.
+  return getEclipseWarpStrategyConfig({
+    route: 'usdc',
+    evmChains: evmDeploymentChains,
+    nonEvmChains: nonEvmDeploymentChains,
+    turnkeyFeeChains: new Set(evmDeploymentChains),
+  }) as unknown as ChainSubmissionStrategy;
 };

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -3,6 +3,7 @@ import {
   ChainSubmissionStrategy,
   HypTokenRouterConfig,
   SubmissionStrategy,
+  SubmitterMetadata,
   TokenType,
   TxSubmitterType,
 } from '@hyperlane-xyz/sdk';
@@ -27,6 +28,7 @@ import {
   getFixedRoutingFeeConfig,
   getRebalancingUSDCConfigForChain,
   getUSDCRebalancingBridgesConfigFor,
+  getWarpFeeSubmitter,
   scaleDownConfig,
 } from './utils.js';
 
@@ -409,21 +411,27 @@ export const getEclipseUSDCStrategyConfig = (): ChainSubmissionStrategy => {
   );
 
   const icaChains = evmDeploymentChains.filter((c) => c !== ORIGIN_CHAIN);
-  const icaStrategies: [string, SubmissionStrategy][] = icaChains.map(
-    (chain) => [
-      chain,
-      {
-        submitter: {
-          type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
-          chain: ORIGIN_CHAIN,
-          destinationChain: chain,
-          owner: safeAddress,
-          originInterchainAccountRouter,
-          internalSubmitter: originSafeSubmitter,
-        },
+  const icaStrategies: [
+    string,
+    SubmissionStrategy & { feeSubmitter: SubmitterMetadata },
+  ][] = icaChains.map((chain) => [
+    chain,
+    {
+      submitter: {
+        type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+        chain: ORIGIN_CHAIN,
+        destinationChain: chain,
+        owner: safeAddress,
+        originInterchainAccountRouter,
+        internalSubmitter: originSafeSubmitter,
       },
-    ],
-  );
+      feeSubmitter: getWarpFeeSubmitter(
+        chain,
+        ORIGIN_CHAIN,
+        originInterchainAccountRouter,
+      ),
+    },
+  ]);
 
   const svmFileStrategies: [
     string,
@@ -439,7 +447,17 @@ export const getEclipseUSDCStrategyConfig = (): ChainSubmissionStrategy => {
   ]);
 
   return Object.fromEntries([
-    [ORIGIN_CHAIN, { submitter: originSafeSubmitter }],
+    [
+      ORIGIN_CHAIN,
+      {
+        submitter: originSafeSubmitter,
+        feeSubmitter: getWarpFeeSubmitter(
+          ORIGIN_CHAIN,
+          ORIGIN_CHAIN,
+          originInterchainAccountRouter,
+        ),
+      },
+    ],
     ...icaStrategies,
     ...svmFileStrategies,
   ]);

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -48,6 +48,9 @@ type DeploymentChains<T> = {
 
 export type DeploymentChain = keyof DeploymentChains<unknown>;
 
+// Hyperlane quote signer authorized to sign offchain standing fee quotes.
+const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';
+
 /**
  * Eclipse USDC Warp Route
  *
@@ -376,6 +379,7 @@ export const getEclipseUSDCWarpConfig = async (
       name: 'USD Coin',
       symbol: 'USDC',
     },
+    quoteSigners: [QUOTE_SIGNER],
   });
 
 // Strategies

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -1,5 +1,10 @@
-import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
-import { assert, objFilter } from '@hyperlane-xyz/utils';
+import {
+  ChainMap,
+  ChainSubmissionStrategy,
+  HypTokenRouterConfig,
+  TokenType,
+} from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
 import { awIcas } from '../../governance/ica/aw.js';
 import { awProxyAdmins } from '../../governance/proxy-admin/aw.js';
@@ -9,16 +14,19 @@ import {
   getWarpFeeOwner,
 } from '../../governance/utils.js';
 import { chainOwners } from '../../owners.js';
-import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
+import {
+  QUOTE_SIGNER,
+  SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+} from '../consts.js';
 import { usdtTokenAddresses } from '../tokens.js';
 import { WarpRouteIds } from '../warpIds.js';
 import {
   getFixedRoutingFeeConfig,
+  getEclipseWarpStrategyConfig,
   getRebalancingBridgesConfigFor,
   getRebalancingUSDTConfigForChain,
   scaleDownConfig,
 } from './utils.js';
-import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';
 
 const contractVersion = '11.1.0';
 
@@ -131,11 +139,14 @@ export interface EclipseUSDTWarpConfigOptions {
     solanamainnet: string;
   };
   proxyAdmins: ChainMap<{ address?: string; owner: string }>;
+  /** When set, fee contracts use OffchainQuotedLinearFee with these signers */
+  quoteSigners?: string[];
 }
 
 const getBaseEvmConfig = (
   chain: DeploymentChain,
   proxyAdmins: ChainMap<{ address?: string; owner: string }>,
+  quoteSigners?: string[],
 ) => {
   const proxyAdmin = proxyAdmins[chain];
   assert(proxyAdmin, `Missing proxyAdmin for chain ${chain}`);
@@ -144,12 +155,14 @@ const getBaseEvmConfig = (
   const destinations = evmDeploymentChains.filter((c) => c !== chain);
   const destinationFeeBps = feeBps[chain];
   assert(destinationFeeBps, `Missing destination fee bps for ${chain}`);
-  // tron's RoutingFee owner was not rotated to the Turnkey treasury key (EVM
-  // ICA tooling can't drive tron), so it stays with governance; every other EVM
-  // leg uses the Turnkey key. Sub-fee owners are not a meaningful authority and
-  // are not checked (see normalizeTokenFeeForCheck), so a single owner suffices.
-  const routingFeeOwner =
-    chain === 'tron' ? getWarpFeeOwner(chain) : WARP_FEES_TURNKEY_OWNER;
+  const isTron = chain === 'tron';
+  // Tron stays on LinearFee by design, matching USDT/eni (AW-675): its flat-fee
+  // reimbursement model is managed through Tron-native governance. OQLF is
+  // technically supported; every other EVM leg uses the Turnkey fee-owner key.
+  const routingFeeOwner = isTron
+    ? getWarpFeeOwner(chain)
+    : WARP_FEES_TURNKEY_OWNER;
+  const chainQuoteSigners = isTron ? undefined : quoteSigners;
   return {
     ...chainTokenMetadata[chain],
     proxyAdmin,
@@ -159,6 +172,8 @@ const getBaseEvmConfig = (
       routingFeeOwner,
       destinations,
       destinationFeeBps,
+      undefined,
+      chainQuoteSigners,
     ),
     ...scaleDownConfig(decimals, MESSAGE_DECIMALS),
   };
@@ -168,7 +183,7 @@ export const buildEclipseUSDTWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   options: EclipseUSDTWarpConfigOptions,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const { ownersByChain, programIds, proxyAdmins } = options;
+  const { ownersByChain, programIds, proxyAdmins, quoteSigners } = options;
 
   const rebalancingConfigByChain = getRebalancingBridgesConfigFor(
     rebalanceableCollateralChains,
@@ -189,7 +204,7 @@ export const buildEclipseUSDTWarpConfig = async (
     );
     configs.push([
       chain,
-      { ...baseConfig, ...getBaseEvmConfig(chain, proxyAdmins) },
+      { ...baseConfig, ...getBaseEvmConfig(chain, proxyAdmins, quoteSigners) },
     ]);
   }
 
@@ -201,7 +216,7 @@ export const buildEclipseUSDTWarpConfig = async (
     configs.push([
       chain,
       {
-        ...getBaseEvmConfig(chain, proxyAdmins),
+        ...getBaseEvmConfig(chain, proxyAdmins, quoteSigners),
         type: TokenType.collateral,
         token: usdtToken,
         owner: ownersByChain[chain],
@@ -250,13 +265,18 @@ export const getEclipseUSDTWarpConfig = async (
     ownersByChain: productionOwnersByChain,
     programIds: PRODUCTION_PROGRAM_IDS,
     proxyAdmins: awProxyAdmins,
+    quoteSigners: [QUOTE_SIGNER],
   });
 
 // Strategies
-export const getEclipseUSDTGnosisSafeBuilderStrategyConfig =
-  getGnosisSafeBuilderStrategyConfigGenerator(
-    objFilter(
-      productionOwnersByChain,
-      (chain, _v): _v is string => chain === 'ethereum',
+export const getEclipseUSDTStrategyConfig = (): ChainSubmissionStrategy => {
+  // CAST: The CLI-specific file feeSubmitter is not represented by SDK types.
+  return getEclipseWarpStrategyConfig({
+    route: 'usdt',
+    evmChains: evmDeploymentChains,
+    nonEvmChains: nonEvmDeploymentChains,
+    turnkeyFeeChains: new Set(
+      evmDeploymentChains.filter((chain) => chain !== 'tron'),
     ),
-  );
+  }) as unknown as ChainSubmissionStrategy;
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -1,6 +1,15 @@
-import { ChainMap, HypTokenRouterConfig, TokenType } from '@hyperlane-xyz/sdk';
-import { assert, objFilter } from '@hyperlane-xyz/utils';
+import {
+  ChainMap,
+  ChainSubmissionStrategy,
+  HypTokenRouterConfig,
+  SubmissionStrategy,
+  SubmitterMetadata,
+  TokenType,
+  TxSubmitterType,
+} from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
+import { getChainAddresses } from '../../../../registry.js';
 import { awIcas } from '../../governance/ica/aw.js';
 import { awProxyAdmins } from '../../governance/proxy-admin/aw.js';
 import { awSafes } from '../../governance/safe/aw.js';
@@ -16,9 +25,9 @@ import {
   getFixedRoutingFeeConfig,
   getRebalancingBridgesConfigFor,
   getRebalancingUSDTConfigForChain,
+  getWarpFeeSubmitter,
   scaleDownConfig,
 } from './utils.js';
-import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';
 
 const contractVersion = '11.1.0';
 
@@ -255,10 +264,74 @@ export const getEclipseUSDTWarpConfig = async (
   });
 
 // Strategies
-export const getEclipseUSDTGnosisSafeBuilderStrategyConfig =
-  getGnosisSafeBuilderStrategyConfigGenerator(
-    objFilter(
-      productionOwnersByChain,
-      (chain, _v): _v is string => chain === 'ethereum',
-    ),
+const ORIGIN_CHAIN = 'ethereum';
+
+export const getEclipseUSDTStrategyConfig = (): ChainSubmissionStrategy => {
+  const safeAddress = awSafes[ORIGIN_CHAIN];
+  const originSafeSubmitter = {
+    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
+    chain: ORIGIN_CHAIN,
+    safeAddress,
+    version: '1',
+  };
+
+  const chainAddress = getChainAddresses();
+  const originInterchainAccountRouter =
+    chainAddress[ORIGIN_CHAIN].interchainAccountRouter;
+  assert(
+    originInterchainAccountRouter,
+    `Could not fetch originInterchainAccountRouter for ${ORIGIN_CHAIN}`,
   );
+
+  const icaChains = evmDeploymentChains.filter((c) => c !== ORIGIN_CHAIN);
+  const icaStrategies: [
+    string,
+    SubmissionStrategy & { feeSubmitter: SubmitterMetadata },
+  ][] = icaChains.map((chain) => [
+    chain,
+    {
+      submitter: {
+        type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+        chain: ORIGIN_CHAIN,
+        destinationChain: chain,
+        owner: safeAddress,
+        originInterchainAccountRouter,
+        internalSubmitter: originSafeSubmitter,
+      },
+      feeSubmitter: getWarpFeeSubmitter(
+        chain,
+        ORIGIN_CHAIN,
+        originInterchainAccountRouter,
+      ),
+    },
+  ]);
+
+  const svmFileStrategies: [
+    string,
+    { submitter: { type: 'file'; filepath: string } },
+  ][] = nonEvmDeploymentChains.map((chain) => [
+    chain,
+    {
+      submitter: {
+        type: 'file' as const,
+        filepath: `/tmp/eclipse-usdt-${chain}.json`,
+      },
+    },
+  ]);
+
+  return Object.fromEntries([
+    [
+      ORIGIN_CHAIN,
+      {
+        submitter: originSafeSubmitter,
+        feeSubmitter: getWarpFeeSubmitter(
+          ORIGIN_CHAIN,
+          ORIGIN_CHAIN,
+          originInterchainAccountRouter,
+        ),
+      },
+    ],
+    ...icaStrategies,
+    ...svmFileStrategies,
+  ]);
+};

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -19,6 +19,9 @@ import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';
 
 const contractVersion = '11.1.0';
 
+// Hyperlane quote signer authorized to sign offchain standing fee quotes.
+const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';
+
 const chainTokenMetadata: Record<string, { name: string; symbol: string }> = {
   ethereum: { name: 'Tether USD', symbol: 'USDT' },
   tron: { name: 'Tether USD', symbol: 'USDT' },
@@ -128,11 +131,14 @@ export interface EclipseUSDTWarpConfigOptions {
     solanamainnet: string;
   };
   proxyAdmins: ChainMap<{ address?: string; owner: string }>;
+  /** When set, fee contracts use OffchainQuotedLinearFee with these signers */
+  quoteSigners?: string[];
 }
 
 const getBaseEvmConfig = (
   chain: DeploymentChain,
   proxyAdmins: ChainMap<{ address?: string; owner: string }>,
+  quoteSigners?: string[],
 ) => {
   const proxyAdmin = proxyAdmins[chain];
   assert(proxyAdmin, `Missing proxyAdmin for chain ${chain}`);
@@ -141,6 +147,8 @@ const getBaseEvmConfig = (
   const destinations = evmDeploymentChains.filter((c) => c !== chain);
   const destinationFeeBps = feeBps[chain];
   assert(destinationFeeBps, `Missing destination fee bps for ${chain}`);
+  // Tron OQLF quote signing is not wired up; keep tron source legs on LinearFee.
+  const chainQuoteSigners = chain === 'tron' ? undefined : quoteSigners;
   return {
     ...chainTokenMetadata[chain],
     proxyAdmin,
@@ -150,6 +158,8 @@ const getBaseEvmConfig = (
       getWarpFeeOwner(chain),
       destinations,
       destinationFeeBps,
+      undefined,
+      chainQuoteSigners,
     ),
     ...scaleDownConfig(decimals, MESSAGE_DECIMALS),
   };
@@ -159,7 +169,7 @@ export const buildEclipseUSDTWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   options: EclipseUSDTWarpConfigOptions,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const { ownersByChain, programIds, proxyAdmins } = options;
+  const { ownersByChain, programIds, proxyAdmins, quoteSigners } = options;
 
   const rebalancingConfigByChain = getRebalancingBridgesConfigFor(
     rebalanceableCollateralChains,
@@ -180,7 +190,7 @@ export const buildEclipseUSDTWarpConfig = async (
     );
     configs.push([
       chain,
-      { ...baseConfig, ...getBaseEvmConfig(chain, proxyAdmins) },
+      { ...baseConfig, ...getBaseEvmConfig(chain, proxyAdmins, quoteSigners) },
     ]);
   }
 
@@ -192,7 +202,7 @@ export const buildEclipseUSDTWarpConfig = async (
     configs.push([
       chain,
       {
-        ...getBaseEvmConfig(chain, proxyAdmins),
+        ...getBaseEvmConfig(chain, proxyAdmins, quoteSigners),
         type: TokenType.collateral,
         token: usdtToken,
         owner: ownersByChain[chain],
@@ -241,6 +251,7 @@ export const getEclipseUSDTWarpConfig = async (
     ownersByChain: productionOwnersByChain,
     programIds: PRODUCTION_PROGRAM_IDS,
     proxyAdmins: awProxyAdmins,
+    quoteSigners: [QUOTE_SIGNER],
   });
 
 // Strategies

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.ts
@@ -6,7 +6,10 @@ import { awProxyAdmins } from '../../governance/proxy-admin/aw.js';
 import { awSafes } from '../../governance/safe/aw.js';
 import { getWarpFeeOwner } from '../../governance/utils.js';
 import { chainOwners } from '../../owners.js';
-import { SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT } from '../consts.js';
+import {
+  QUOTE_SIGNER,
+  SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT,
+} from '../consts.js';
 import { usdtTokenAddresses } from '../tokens.js';
 import { WarpRouteIds } from '../warpIds.js';
 import {
@@ -18,9 +21,6 @@ import {
 import { getGnosisSafeBuilderStrategyConfigGenerator } from '../../../utils.js';
 
 const contractVersion = '11.1.0';
-
-// Hyperlane quote signer authorized to sign offchain standing fee quotes.
-const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';
 
 const chainTokenMetadata: Record<string, { name: string; symbol: string }> = {
   ethereum: { name: 'Tether USD', symbol: 'USDT' },

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -4,9 +4,11 @@ import {
   ChainSubmissionStrategy,
   HypTokenRouterConfig,
   MovableTokenConfig,
+  SubmitterMetadata,
   TokenFeeConfigInput,
   TokenFeeType,
   TokenType,
+  TxSubmitterType,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
@@ -19,6 +21,7 @@ import {
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
 import { getRegistry } from '../../../../registry.js';
+import { warpFeesSafes } from '../../governance/safe/warpFees.js';
 import { usdcTokenAddresses } from '../cctp.js';
 import { usdtTokenAddresses } from '../tokens.js';
 import { WarpRouteIds } from '../warpIds.js';
@@ -446,4 +449,41 @@ export function getImpersonatedAccountStrategyConfig(
       { submitter: { type: 'impersonatedAccount', userAddress, chain } },
     ]),
   ) as unknown as ChainSubmissionStrategy;
+}
+
+/**
+ * Builds the WarpFees governance submitter for a warp route fee contract on
+ * `chain`. Fee contracts (e.g. OffchainQuotedLinearFee) are owned by the
+ * WarpFees governance safe on `originChain`; remote chains are reached via that
+ * safe's interchain account. This is used as the `feeSubmitter` in strategy
+ * configs so that owner-gated `setFeeContract` repoints route to the WarpFees
+ * owner rather than the router (AbacusWorks) owner.
+ */
+export function getWarpFeeSubmitter(
+  chain: string,
+  originChain: string,
+  originInterchainAccountRouter: string,
+): SubmitterMetadata {
+  const feeSafeAddress = warpFeesSafes[originChain];
+  assert(feeSafeAddress, `Missing WarpFees governance safe for ${originChain}`);
+
+  const originFeeSafeSubmitter = {
+    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
+    chain: originChain,
+    safeAddress: feeSafeAddress,
+    version: '1',
+  };
+
+  if (chain === originChain) {
+    return originFeeSafeSubmitter;
+  }
+
+  return {
+    type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+    chain: originChain,
+    destinationChain: chain,
+    owner: feeSafeAddress,
+    originInterchainAccountRouter,
+    internalSubmitter: originFeeSafeSubmitter,
+  };
 }

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/utils.ts
@@ -4,9 +4,11 @@ import {
   ChainSubmissionStrategy,
   HypTokenRouterConfig,
   MovableTokenConfig,
+  SubmitterMetadata,
   TokenFeeConfigInput,
   TokenFeeType,
   TokenType,
+  TxSubmitterType,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
@@ -18,7 +20,9 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
-import { getRegistry } from '../../../../registry.js';
+import { getChainAddresses, getRegistry } from '../../../../registry.js';
+import { awSafes } from '../../governance/safe/aw.js';
+import { warpFeesSafes } from '../../governance/safe/warpFees.js';
 import { usdcTokenAddresses } from '../cctp.js';
 import { usdtTokenAddresses } from '../tokens.js';
 import { WarpRouteIds } from '../warpIds.js';
@@ -340,12 +344,9 @@ export function scaleDownConfig(
  * The fee token is auto-derived at deploy time based on the warp route token type.
  *
  * The `owner` is applied to the top-level RoutingFee contract and to every
- * nested per-destination sub-fee contract. Sub-fee ownership is not a
- * meaningful authority — the RoutingFee owner controls pricing via
- * `setFeeContract` and claims accrued fees — so the warp check ignores sub-fee
- * owners (see `normalizeTokenFeeForCheck`) and a single owner is sufficient.
+ * nested per-destination sub-fee contract.
  *
- * @param owner - The owner of the RoutingFee contract (and its sub-fee contracts)
+ * @param owner - The owner of the RoutingFee contract and its sub-fee contracts
  * @param feeDestinations - List of destination chains that should have the fee applied
  * @param bps - The fee in basis points to apply for feeDestinations
  * @param feeParams - Optional pre-deployed fee parameters per chain
@@ -452,4 +453,139 @@ export function getImpersonatedAccountStrategyConfig(
       { submitter: { type: 'impersonatedAccount', userAddress, chain } },
     ]),
   ) as unknown as ChainSubmissionStrategy;
+}
+
+/**
+ * Builds the WarpFees governance submitter for a governance-owned RoutingFee.
+ * Remote chains are reached through the governance safe's interchain account.
+ */
+export function getWarpFeeSubmitter(
+  chain: string,
+  originChain: string,
+  originInterchainAccountRouter: string,
+): SubmitterMetadata {
+  const feeSafeAddress = warpFeesSafes[originChain];
+  assert(feeSafeAddress, `Missing WarpFees governance safe for ${originChain}`);
+
+  const originFeeSafeSubmitter = {
+    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
+    chain: originChain,
+    safeAddress: feeSafeAddress,
+    version: '1',
+  };
+
+  if (chain === originChain) {
+    return originFeeSafeSubmitter;
+  }
+
+  return {
+    type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+    chain: originChain,
+    destinationChain: chain,
+    owner: feeSafeAddress,
+    originInterchainAccountRouter,
+    internalSubmitter: originFeeSafeSubmitter,
+  };
+}
+
+type FileSubmitterMetadata = {
+  type: 'file';
+  chain: string;
+  filepath: string;
+};
+
+type EclipseSubmitterMetadata = SubmitterMetadata | FileSubmitterMetadata;
+
+export type EclipseWarpSubmissionStrategy = Record<
+  string,
+  {
+    submitter: EclipseSubmitterMetadata;
+    feeSubmitter?: EclipseSubmitterMetadata;
+  }
+>;
+
+/**
+ * Builds the shared Eclipse route strategy. Router-owner transactions use the
+ * AbacusWorks Safe/ICAs. Turnkey-owned RoutingFee transactions are written to
+ * a dedicated file for later review and external-signer submission;
+ * governance-owned RoutingFees retain the WarpFees Safe/ICA path.
+ */
+export function getEclipseWarpStrategyConfig({
+  route,
+  evmChains,
+  nonEvmChains,
+  turnkeyFeeChains,
+  originInterchainAccountRouter: configuredInterchainAccountRouter,
+}: {
+  route: 'usdc' | 'usdt';
+  evmChains: readonly string[];
+  nonEvmChains: readonly string[];
+  turnkeyFeeChains: ReadonlySet<string>;
+  originInterchainAccountRouter?: string;
+}): EclipseWarpSubmissionStrategy {
+  const originChain = 'ethereum';
+  const safeAddress = awSafes[originChain];
+  const originSafeSubmitter = {
+    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
+    chain: originChain,
+    safeAddress,
+    version: '1',
+  };
+
+  const originInterchainAccountRouter =
+    configuredInterchainAccountRouter ??
+    getChainAddresses()[originChain]?.interchainAccountRouter;
+  assert(
+    originInterchainAccountRouter,
+    `Could not fetch originInterchainAccountRouter for ${originChain}`,
+  );
+
+  // One fresh file preserves the complete cross-chain fee batch for review and
+  // a subsequent `hyperlane submit --signer-config` invocation.
+  const turnkeyFeeFilepath = `/tmp/eclipse-${route}-turnkey-fees-${Date.now()}.json`;
+  const getFeeSubmitter = (chain: string): EclipseSubmitterMetadata =>
+    turnkeyFeeChains.has(chain)
+      ? {
+          type: 'file',
+          chain,
+          filepath: turnkeyFeeFilepath,
+        }
+      : getWarpFeeSubmitter(chain, originChain, originInterchainAccountRouter);
+
+  const evmStrategies: [
+    string,
+    {
+      submitter: SubmitterMetadata;
+      feeSubmitter: EclipseSubmitterMetadata;
+    },
+  ][] = evmChains.map((chain) => [
+    chain,
+    {
+      submitter:
+        chain === originChain
+          ? originSafeSubmitter
+          : {
+              type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+              chain: originChain,
+              destinationChain: chain,
+              owner: safeAddress,
+              originInterchainAccountRouter,
+              internalSubmitter: originSafeSubmitter,
+            },
+      feeSubmitter: getFeeSubmitter(chain),
+    },
+  ]);
+
+  const nonEvmStrategies = nonEvmChains.map((chain) => [
+    chain,
+    {
+      submitter: {
+        type: 'file' as const,
+        chain,
+        filepath: `/tmp/eclipse-${route}-${chain}.json`,
+      },
+    },
+  ]);
+
+  return Object.fromEntries([...evmStrategies, ...nonEvmStrategies]);
 }

--- a/typescript/infra/config/environments/mainnet3/warp/consts.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/consts.ts
@@ -2,3 +2,6 @@
 export const SEALEVEL_WARP_ROUTE_HANDLER_GAS_AMOUNT = 300_000;
 
 export const STARKNET_WARP_ROUTE_HANDLER_GAS_AMOUNT = 5_000_000;
+
+// Hyperlane quote signer authorized to sign offchain standing fee quotes.
+export const QUOTE_SIGNER = '0xEd1829805De615eEFC7303766D395Ea0a1B2b04d';

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -28,7 +28,7 @@ import {
 import { getCarrChainCARRWarpConfig } from './environments/mainnet3/warp/configGetters/getCarrchainCARRWarpConfig.js';
 import { getEclipseEthereumESWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.js';
 import {
-  getEclipseUSDTGnosisSafeBuilderStrategyConfig,
+  getEclipseUSDTStrategyConfig,
   getEclipseUSDTWarpConfig,
 } from './environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.js';
 import { getEclipseEthereumWBTCWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.js';
@@ -157,7 +157,7 @@ export const strategyConfigGetterMap: Record<string, StrategyConfigGetter> = {
   [WarpRouteIds.BaseEthereumREZSTAGING]:
     getRezStagingGnosisSafeBuilderStrategyConfig,
   [WarpRouteIds.EclipseUSDC]: getEclipseUSDCStrategyConfig,
-  [WarpRouteIds.EclipseUSDT]: getEclipseUSDTGnosisSafeBuilderStrategyConfig,
+  [WarpRouteIds.EclipseUSDT]: getEclipseUSDTStrategyConfig,
   [WarpRouteIds.IgraUSDC]: getIgraUSDCStrategyConfig,
   [WarpRouteIds.EclipseUSDCSTAGE]:
     getUSDCSTAGEEclipseFileSubmitterStrategyConfig,

--- a/typescript/infra/config/warp.ts
+++ b/typescript/infra/config/warp.ts
@@ -40,7 +40,7 @@ import {
 import { getCarrChainCARRWarpConfig } from './environments/mainnet3/warp/configGetters/getCarrchainCARRWarpConfig.js';
 import { getEclipseEthereumESWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumESWarpConfig.js';
 import {
-  getEclipseUSDTGnosisSafeBuilderStrategyConfig,
+  getEclipseUSDTStrategyConfig,
   getEclipseUSDTWarpConfig,
 } from './environments/mainnet3/warp/configGetters/getEclipseUSDTWarpConfig.js';
 import { getEclipseEthereumWBTCWarpConfig } from './environments/mainnet3/warp/configGetters/getEclipseEthereumWBTCWarpConfig.js';
@@ -183,7 +183,7 @@ export const strategyConfigGetterMap: Record<string, StrategyConfigGetter> = {
     getRezStagingGnosisSafeBuilderStrategyConfig,
   [WarpRouteIds.BsquaredUBTC]: getUbtcGnosisSafeBuilderStrategyConfigGenerator,
   [WarpRouteIds.EclipseUSDC]: getEclipseUSDCStrategyConfig,
-  [WarpRouteIds.EclipseUSDT]: getEclipseUSDTGnosisSafeBuilderStrategyConfig,
+  [WarpRouteIds.EclipseUSDT]: getEclipseUSDTStrategyConfig,
   [WarpRouteIds.IgraUSDC]: getIgraUSDCStrategyConfig,
   [WarpRouteIds.EclipseUSDCSTAGE]:
     getUSDCSTAGEEclipseFileSubmitterStrategyConfig,

--- a/typescript/infra/test/eclipse-warp-fees.test.ts
+++ b/typescript/infra/test/eclipse-warp-fees.test.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+
+import { TokenFeeType, TxSubmitterType } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  getEclipseWarpStrategyConfig,
+  getFixedRoutingFeeConfig,
+} from '../config/environments/mainnet3/warp/configGetters/utils.js';
+import { WARP_FEES_TURNKEY_OWNER } from '../config/environments/mainnet3/governance/utils.js';
+
+describe('Eclipse warp fee config', () => {
+  const originInterchainAccountRouter =
+    '0x4444444444444444444444444444444444444444';
+
+  it('uses the RoutingFee owner for OQLF leaves', () => {
+    const quoteSigner = '0x3333333333333333333333333333333333333333';
+    const config = getFixedRoutingFeeConfig(
+      WARP_FEES_TURNKEY_OWNER,
+      ['destination'],
+      1,
+      undefined,
+      [quoteSigner],
+    );
+
+    assert(config.type === TokenFeeType.RoutingFee, 'Expected RoutingFee');
+    expect(config.owner).to.equal(WARP_FEES_TURNKEY_OWNER);
+    expect(config.feeContracts.destination.type).to.equal(
+      TokenFeeType.OffchainQuotedLinearFee,
+    );
+    expect(config.feeContracts.destination.owner).to.equal(
+      WARP_FEES_TURNKEY_OWNER,
+    );
+  });
+
+  it('writes only Turnkey-owned fees to one fresh submission file', () => {
+    const usdcStrategy = getEclipseWarpStrategyConfig({
+      route: 'usdc',
+      evmChains: ['ethereum', 'arbitrum'],
+      nonEvmChains: ['eclipsemainnet'],
+      turnkeyFeeChains: new Set(['ethereum', 'arbitrum']),
+      originInterchainAccountRouter,
+    });
+    const usdtStrategy = getEclipseWarpStrategyConfig({
+      route: 'usdt',
+      evmChains: ['ethereum', 'tron'],
+      nonEvmChains: ['eclipsemainnet'],
+      turnkeyFeeChains: new Set(['ethereum']),
+      originInterchainAccountRouter,
+    });
+
+    const usdcEthereumFeeSubmitter = usdcStrategy.ethereum.feeSubmitter;
+    const usdcArbitrumFeeSubmitter = usdcStrategy.arbitrum.feeSubmitter;
+    assert(
+      usdcEthereumFeeSubmitter?.type === 'file',
+      'Expected USDC Turnkey fee file',
+    );
+    assert(
+      usdcArbitrumFeeSubmitter?.type === 'file',
+      'Expected shared USDC Turnkey fee file',
+    );
+    expect(usdcEthereumFeeSubmitter.filepath).to.equal(
+      usdcArbitrumFeeSubmitter.filepath,
+    );
+    expect(usdcEthereumFeeSubmitter.filepath).to.match(
+      /^\/tmp\/eclipse-usdc-turnkey-fees-\d+\.json$/,
+    );
+
+    const usdtEthereumFeeSubmitter = usdtStrategy.ethereum.feeSubmitter;
+    assert(
+      usdtEthereumFeeSubmitter?.type === 'file',
+      'Expected USDT Turnkey fee file',
+    );
+    expect(usdtEthereumFeeSubmitter.filepath).to.match(
+      /^\/tmp\/eclipse-usdt-turnkey-fees-\d+\.json$/,
+    );
+
+    assert(
+      usdtStrategy.tron.feeSubmitter,
+      'Expected Tron fee submitter to be configured',
+    );
+    expect(usdtStrategy.tron.feeSubmitter.type).to.equal(
+      TxSubmitterType.INTERCHAIN_ACCOUNT,
+    );
+    expect(usdtStrategy.eclipsemainnet.feeSubmitter).to.equal(undefined);
+    expect(usdtStrategy.ethereum.submitter.type).to.equal(
+      TxSubmitterType.GNOSIS_TX_BUILDER,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Switch configured EVM RoutingFee leaves on USDC/eclipse and non-Tron USDT/eclipse from LinearFee to OffchainQuotedLinearFee.
- Keep both the top-level RoutingFee and new OQLF leaves owned by Turnkey `0xe95C…6998`, matching the single-owner model finalized in #9163.
- Authorize quote signer `0xEd1829805De615eEFC7303766D395Ea0a1B2b04d`.
- Keep Tron WarpFees-governed and on LinearFee by product design.
- Route Turnkey-owned fee transactions to one fresh per-run file. Router-owner transactions retain the AbacusWorks Safe/ICA path; Tron fee transactions retain the WarpFees Safe/ICA path.

## Stack

1. #9299 (merged): generic `hyperlane submit` external-signer/Turnkey support.
2. This PR: Eclipse infra getters and file-submitter strategy.
3. [hyperlane-registry#1662](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1662): deployed OQLF addresses and live target route config.

#9309 was closed after confirming it is not required by this rollout: the initial addressless apply deployed the OQLFs and generated exact transaction files, while `hyperlane submit` consumed those files without the fee deployment SDK. This PR is based directly on `main` and contains only the six Eclipse infra/test files.

## Design

The flow follows the existing file-submitter handoff:

1. Generate the route strategy with one fresh shared fee-file path per route.
2. Run `warp apply` with the normal deployer. OQLF deployments use that deployer; privileged parent updates are written to the fee file.
3. Review the generated file and registry target.
4. Submit separately with `hyperlane submit --transactions <fee-file> --signer-config <turnkey-config.json> --receipts <directory>`.

This keeps the restricted Turnkey fee signer out of deployment/planning while retaining generic signer validation, funding preflight, sequential submission, and partial-receipt persistence from #9299.

## Deployment status — executed 2026-08-21

The normal mainnet3 EVM deployer deployed all new OQLF leaves. After review of this PR and [registry PR #1662](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1662), the dedicated Warp Fees Turnkey signer executed the reviewed parent updates:

- USDC: 182/182 `RoutingFee.setFeeContract` calls confirmed across 14 chains.
- USDT: 16/16 `RoutingFee.setFeeContract` calls confirmed across Plasma, Arbitrum, Ethereum, and BSC.
- Every receipt has status `1`; every call used selector `0x16068373`.
- Tron remains unchanged on its intentional WarpFees-governed `LinearFee` configuration.

The USDC submission encountered CLI confirmation timeouts on Ethereum and HyperEVM. Each timed-out hash was verified on chain before a non-overlapping remainder batch was created; no known successful call was intentionally rebroadcast. The USDT batch completed without interruption.

## Validation

- Read back all 198 OQLFs: type, owner, token, quote signer, `maxFee`, and `halfAmount` match the registry target.
- Final live USDC `warp check`: `No violations found` (exit 0).
- Final live USDT `warp check`: `No violations found` (exit 0).
- Direct HyperEVM readback on Alchemy and Dwellir matches all 13 targets. Chainstack was excluded from the final check because its `eth_call(latest)` returned stale pre-update state while explicit-block calls and canonical receipts were correct.
- Explorer verification was skipped for Linea, Optimism, Unichain, and World Chain during the final config checks because the configured Etherscan key returned `Invalid API Key`; the preceding run showed only those unrelated verification-status differences.
- `pnpm -C typescript/infra check`.
- Focused Eclipse fee ownership/strategy tests.
- Production USDC and USDT strategies parse through the CLI extended strategy schema.
- Focused formatter/lint and commit hooks.

## Review state

The on-chain rollout and registry state are complete. This infra PR remains intentionally unmerged and ready for final code review; it makes future strategy generation reflect the now-live configuration.
