### PR TITLE
fix(infra): right-size mainnet3 relayer and validator CPU requests

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -661,10 +661,15 @@ const metricAppContextsGetter = (): MetricAppContext[] => {
 };
 
 // Resource requests are based on observed usage found in https://abacusworks.grafana.net/d/FSR9YWr7k
+// Sized from 30-day observed usage: steady-state CPU ~0.7-1.3 cores, memory
+// working set ~11-12G. Restart/cold-start catch-up bursts (cursor re-sync +
+// backlog drain) reach ~6 cores; these are absorbed by burst since there is no
+// CPU limit. Request covers the burst peak with headroom; memory covers the
+// working set with ~30% headroom.
 const relayerResources = {
   requests: {
-    cpu: '14000m',
-    memory: '24G',
+    cpu: '8000m',
+    memory: '16G',
   },
 };
 
@@ -678,28 +683,31 @@ const fastPathRelayerResources = {
   },
 };
 
-// Validator resource tiers. Sized from 30-day observed peaks
+// Validator resource tiers. Sized from 30-day observed usage
 // (https://abacusworks.grafana.net/d/FSR9YWr7k). Memory must clear each tier's
-// peak to avoid OOM; CPU is compressible. The default (light) covers the ~90
-// low-traffic validators; heavier chains are overridden below, keyed by chain
-// name (applies across the hyperlane, RC, and fastpath validator contexts).
+// peak to avoid OOM, so memory stays tiered. CPU is compressible and there is
+// no CPU limit, so requests are sized to p95 steady-state (all validators sit
+// <0.2 cores at p95; busiest is aleo ~0.17) rather than to the rare
+// checkpoint-signing bursts, which burst absorbs. The default (light) covers
+// the ~90 low-traffic validators; heavier chains are overridden below, keyed by
+// chain name (applies across the hyperlane, RC, and fastpath validator contexts).
 const validatorResources = {
   requests: {
-    cpu: '100m',
+    cpu: '50m',
     memory: '256Mi',
   },
 };
 
 const heavyValidatorResources = {
   requests: {
-    cpu: '1000m',
+    cpu: '300m',
     memory: '1G',
   },
 };
 
 const mediumValidatorResources = {
   requests: {
-    cpu: '500m',
+    cpu: '150m',
     memory: '512Mi',
   },
 };


### PR DESCRIPTION
## Summary

Follow-up to #8980. Trims over-provisioned CPU requests on the mainnet3 relayer and validators, based on 30-day observed usage. **Memory is only reduced on the relayer; validator memory tiers are left untouched** since memory is the OOM floor.

### Relayer
- CPU `14000m` → `8000m`, memory `24G` → `16G`
- Steady-state over 30 days is ~0.7–1.3 cores / ~11–12G working set. The high readings that motivated the 14-core request are cold-start catch-up bursts (cursor re-sync + backlog drain on restart) peaking ~6 cores. There is no CPU limit, so those bursts are absorbed regardless of the request. 8 cores covers the burst peak with headroom; 16G covers the working set +~30%.

### Validators (CPU only; memory unchanged)
- default `100m` → `50m`
- medium `500m` → `150m`
- heavy `1000m` → `300m`
- p95 steady-state CPU is <0.2 cores for **every** validator (busiest is aleo at ~0.17). The 100/500/1000m requests were almost pure scheduling reservation. Rare checkpoint-signing bursts (e.g. arbitrum/aleo spiking to ~1.8 cores for a single hour) are absorbed by burst since there is no CPU limit.

### Why this saves money
The mainnet3 pool is **CPU-request-bound** (requests ~1.5 GB/core vs the node's 4 GB/core ratio), so node count is driven by summed CPU requests, not memory. This change removes ~22 cores of reservation (relayer −6, validators ~−16.7), taking mainnet3 CPU requests from ~81 → ~59 cores.

## Test plan
- [ ] Deploys via `deploy-agents.ts` (merging does not auto-deploy)
- [ ] After rollout, confirm no relayer OOM and prepare/submit queues drain normally
- [ ] Confirm validators do not OOM and checkpoint indices keep advancing
- [ ] Watch autoscaler drop node count on the mainnet3 pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)