### PR TITLE
fix(infra): set memory requests/limits on rebalancer + warp-route statefulsets

### DIFF
--- a/typescript/infra/helm/rebalancer/templates/_helpers.tpl
+++ b/typescript/infra/helm/rebalancer/templates/_helpers.tpl
@@ -69,6 +69,12 @@ The rebalancer container
 - name: rebalancer
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   imagePullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
   env:
   - name: SERVICE_NAME
     value: {{ .Values.serviceName | default "rebalancer" | quote }}

--- a/typescript/infra/helm/warp-routes/templates/_helpers.tpl
+++ b/typescript/infra/helm/warp-routes/templates/_helpers.tpl
@@ -67,6 +67,12 @@ The warp-routes container
 - name: warp-routes
   image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   imagePullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
   env:
   - name: SERVICE_NAME
     value: {{ .Values.serviceName | default "warp-monitor" | quote }}


### PR DESCRIPTION
## Summary
- Rebalancer and warp-route StatefulSets render their container with `resources: {}`, so every pod runs as **BestEffort** QoS with a zero memory request. The GKE scheduler gets no memory signal and over-packs dozens of them onto one node; when aggregate RSS exceeds node allocatable, the kernel OOM-reaps these BestEffort pods in rotation.
- This paged as PD 33953 — `hyperlane-rebalancer-usdc-matchain-0` OOMKilled 3×/hr on `gke-hyperlane-mainnet-pool-1-3eebe993-etfv` (node at ~104% memory). The rebalancer self-recovered (balances normal, no fund/delivery impact), but the node stays overcommitted so it will recur.
- Adds memory `requests`/`limits` (and a modest cpu request) to both container helper templates, converting the pods to **Burstable** QoS so the scheduler accounts for their footprint and spreads them.

Sizing reflects observed ~270–300Mi RSS with headroom: `requests` cpu 100m / memory 512Mi, `limits` memory 1Gi (no cpu limit, matching the `fee-quoting` chart precedent). Follow-up to the CPU right-sizing in #9144.

## Test plan
- [x] `helm template` renders the `resources` block on both `rebalancer` and `warp-routes` charts
- [ ] Redeploy rebalancer + warp-route releases; confirm pods report `QoS Class: Burstable` and node memory pressure drops below allocatable