### PR TITLE
chore(infra): bump mainnet validator images to f265295-20260729-073530

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -45,9 +45,9 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: 'c1678d0-20260728-164228',
   relayerRC: '7da5e55-20260724-123611',
   relayerFastPath: 'e22be4b-20260715-194756',
-  validator: 'c1678d0-20260728-164228',
-  validatorRC: 'e22be4b-20260715-194756',
-  validatorFastPath: 'e22be4b-20260715-194756',
+  validator: 'f265295-20260729-073530',
+  validatorRC: 'f265295-20260729-073530',
+  validatorFastPath: 'f265295-20260729-073530',
   scraper: 'c1678d0-20260728-164228',
   // monorepo services
   checkWarpDeploy: 'main',


### PR DESCRIPTION
## Summary
- Bumps mainnet `validator`, `validatorRc`, and `validatorFastPath` docker tags to `f265295-20260729-073530` in `typescript/infra/config/docker.ts`.
- This is the public RPC quorum validator build (from #9124 / quorum-verify safety-critical merkle tree reads) being rolled out to AW validators.

Requested by @troykessler as part of the validator public RPC quorum rollout.

## Test plan
- [x] Confirm image tag `f265295-20260729-073530` exists on GHCR (verified: manifest returns 200)
- [x] Deploy to mainnet validators and monitor for downtime during the week