### PR TITLE
fix(infra): migrate stale inventorySigner configs to inventorySigners

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/ETH/viction-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/ETH/viction-config.yaml
@@ -1,6 +1,7 @@
 warpRouteId: ETH/viction
 
-inventorySigner: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
+inventorySigners:
+  ethereum: '0x6056e8E8e5Db30ffa9d721e3D73b3D558011FdA9'
 
 externalBridges:
   lifi:

--- a/typescript/infra/config/environments/mainnet3/rebalancer/ETHSTAGE/stage-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/ETHSTAGE/stage-config.yaml
@@ -1,6 +1,7 @@
 warpRouteId: ETHSTAGE/stage
 
-inventorySigner: '0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5'
+inventorySigners:
+  ethereum: '0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5'
 
 externalBridges:
   lifi:

--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDTSTAGE/mode-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDTSTAGE/mode-config.yaml
@@ -1,6 +1,7 @@
 warpRouteId: USDTSTAGE/mode
 
-inventorySigner: "0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5"
+inventorySigners:
+    ethereum: "0x3e0A78A330F2b97059A4D507ca9d8292b65B6FB5"
 
 externalBridges:
     lifi:


### PR DESCRIPTION
## Summary
- Migrated 3 rebalancer configs still on the old singular `inventorySigner: <address>` field to the current `inventorySigners: { <protocol>: <address> }` map shape: `ETH/viction`, `ETHSTAGE/stage`, `USDTSTAGE/mode`.

## Why
#8249 renamed the schema field from `inventorySigner` (single EVM address) to `inventorySigners` (a map keyed by `ProtocolType`, to support Tron/Solana signers alongside EVM). `RebalancerConfigSchema` only recognizes `inventorySigners`; the old key is silently stripped as an unrecognized field, leaving `inventorySigners` undefined. These 3 configs were never migrated after that PR, so they fail the schema's own refinement check (`inventorySigners is required when any chain uses inventory execution type`).

## Test plan
- [x] Confirmed no other rebalancer config under `typescript/infra/config/environments/mainnet3/rebalancer` still uses the old singular field (`grep -rl inventorySigner` across that directory returns nothing after this change).