### PR TITLE
fix(relayer): bound validator signature retries

### DIFF
--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -54,6 +54,9 @@ pub const INVALIDATE_CACHE_METADATA_LOG: &str = "Invalidating cached metadata";
 pub const ISM_MAX_DEPTH: u32 = 13;
 pub const ISM_MAX_COUNT: u32 = 100;
 
+const VALIDATOR_SIGNATURE_FAST_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+const VALIDATOR_SIGNATURE_FAST_RETRY_MAX: u32 = 3;
+
 /// Revert string emitted by the ICA router when the originating commit has not
 /// yet been confirmed on-chain. There is no typed error variant for this today —
 /// it is an opaque on-chain revert string — so Display-format substring matching
@@ -1075,22 +1078,21 @@ impl PendingMessage {
         reason: Option<&ReprepareReason>,
     ) -> Option<Duration> {
         // Signatures are simply not yet available (validator hasn't signed past the reorg
-        // period yet). Use a 2s fast-path for the first ~10 retries so the relayer picks
-        // them up within ~2s of the validator writing them, rather than waiting through the
-        // normal 5s→10s→30s→60s exponential backoff. Note: num_retries is the total persisted
-        // retry counter across all reasons, not a per-reason count — messages that burned through
-        // >10 retries before reaching metadata-wait won't get this fast-path.
+        // period yet). Use a short 2s fast-path so the relayer can pick them up promptly
+        // without repeatedly rebuilding aggregation metadata for up to 20 seconds. Note:
+        // num_retries is the total persisted retry counter across all reasons, not a
+        // per-reason count.
         //
         // After the fast-path budget is spent, restart the normal gentle ramp (5s→10s→30s…)
         // from the beginning rather than landing mid-table at the 3-min arm.
         if matches!(reason, Some(ReprepareReason::AwaitingValidatorSignatures)) {
-            if (1..=10).contains(&num_retries) {
-                return Some(Duration::from_secs(2));
+            if (1..=VALIDATOR_SIGNATURE_FAST_RETRY_MAX).contains(&num_retries) {
+                return Some(VALIDATOR_SIGNATURE_FAST_RETRY_INTERVAL);
             }
-            // Offset retries so 11→1, 12→2, … resuming the normal ramp.
+            // Offset retries so the first retry after the fast path resumes the normal ramp.
             // Pass reason=None to avoid recursing into this branch again.
             return Self::calculate_msg_backoff(
-                num_retries.saturating_sub(10),
+                num_retries.saturating_sub(VALIDATOR_SIGNATURE_FAST_RETRY_MAX),
                 max_retries,
                 message_id,
                 None,
@@ -1374,11 +1376,11 @@ mod test {
     }
 
     #[test]
-    fn test_could_not_fetch_metadata_backoff() {
+    fn test_awaiting_validator_signatures_backoff() {
         let reason = ReprepareReason::AwaitingValidatorSignatures;
 
-        // Fast-path: retries 1–10 always return 2s
-        for i in 1..=10 {
+        // Fast path: the bounded initial retries always return 2s.
+        for i in 1..=VALIDATOR_SIGNATURE_FAST_RETRY_MAX {
             assert_eq!(
                 PendingMessage::calculate_msg_backoff(
                     i,
@@ -1391,20 +1393,21 @@ mod test {
             );
         }
 
-        // After fast-path: resumes gentle ramp (retry 11 → effective 1 → 5s)
+        // After the fast path, resume the gentle ramp from its first step.
+        let first_normal_retry = VALIDATOR_SIGNATURE_FAST_RETRY_MAX.saturating_add(1);
         assert_eq!(
             PendingMessage::calculate_msg_backoff(
-                11,
+                first_normal_retry,
                 DEFAULT_MAX_MESSAGE_RETRIES,
                 None,
                 Some(&reason)
             ),
             Some(Duration::from_secs(5)),
-            "retry 11 should resume normal ramp at 5s, not jump to 180s"
+            "first retry after the fast path should resume the normal ramp at 5s"
         );
         assert_eq!(
             PendingMessage::calculate_msg_backoff(
-                12,
+                first_normal_retry.saturating_add(1),
                 DEFAULT_MAX_MESSAGE_RETRIES,
                 None,
                 Some(&reason)
@@ -1413,7 +1416,7 @@ mod test {
         );
         assert_eq!(
             PendingMessage::calculate_msg_backoff(
-                13,
+                first_normal_retry.saturating_add(2),
                 DEFAULT_MAX_MESSAGE_RETRIES,
                 None,
                 Some(&reason)

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1268,7 +1268,7 @@ mod test {
 
     use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
-    use super::{PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES};
+    use super::{PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES, VALIDATOR_SIGNATURE_FAST_RETRY_MAX};
 
     #[test]
     fn test_calculate_msg_backoff_does_not_overflow() {


### PR DESCRIPTION
## Summary

- bound `AwaitingValidatorSignatures` fast retries to three attempts at two-second intervals
- resume the existing 5s → 10s → 30s backoff after the six-second fast window
- keep prompt pickup of newly available signatures while avoiding repeated aggregation-metadata rebuilds for up to 20 seconds

## Context

Alchemy billing investigation found `eth_call` driving the recent CU increase. The relayer's validator-signature wait path was changed to retry ten times at two-second intervals, multiplying metadata/RPC work while signatures were unavailable.

Provider routing was also investigated. No routing change is included: configured fallback order is intentional reliability behavior, and request attribution already exists through `hyperlane_request_count{provider_node,chain,method,status}`. A live mainnet relayer snapshot showed Alchemy serving 35.9% of all requests and 39.1% of `eth_call` requests, so the retry change can be measured without splitting provider projects or keys.

## Expected impact

- deterministic per-message effect: 10 → 3 special two-second retries (70% fewer fast retries)
- during the old 20-second fast window: 10 → 4 preparations after the normal 5-second step resumes (60% fewer)
- production trace replay (since the current pod started): 1,359 affected messages produced 4,717 signature-wait preparations; the new schedule would have produced an estimated 3,084, saving 1,484 preparations (32.5%)
- RPC/CU savings are not one-to-one with preparations because an aggregation-metadata build can make multiple provider calls. The RC trial captured `hyperlane_request_count` by provider and method, but retained-backlog catch-up prevented a defensible steady-state CU estimate.

Magnitude bound: the production main relayer currently makes about 13.4 Alchemy `eth_call`s/s in total, approximately 30M CU/day or $223 per 31-day month at the confirmed $0.24/M CU marginal overage rate. Even if every one were signature-wait work, a 32.5–60% reduction would be only about $73–134/month. Actual savings will be lower. July added about 192M `eth_call` CU/day, so this hypothesis cannot explain most of the increase.

The first six seconds retain the existing two-second polling latency. If signatures arrive later in the old 20-second fast window, the new 5s/10s steps can detect them up to nine seconds later. A signature becoming available just after the new 21-second attempt can be detected up to about 26 seconds later than before because the next step is 30 seconds. Delivery correctness is unchanged; RC message age and queue health are merge gates for this latency tradeoff.

The change applies in the relayer to signatures from both standard and fastpath validators. It does not change validator behavior.

## Mainnet RC trial

- exact-head image: `ghcr.io/hyperlane-xyz/hyperlane-agent:b00f0c5-20260729-113550`
- image digest: `sha256:64ab1ad8e7e85388c2bd467f1496a93476afe4c05bb1123e5336ff738effe98d`
- build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/30448166671
- deployed only to `omniscient-relayer-rc` from 2026-07-29 11:19:12 to 11:50:49 UTC (31m37s)
- first 22 minutes used runtime-equivalent commit `654b9de`; exact head then ran for 8m21s. The only intervening source change imported the retry constant into the test module.
- retained backlog made raw request rates non-causal: RC processed 17,710 messages and 1.51M RPC requests while the matched production control processed 50 messages and 186k requests
- queue fell from 17,436 to 806 in the first phase with zero restarts. Exact-head restart began with 364 items and ended at 993 while still ingesting history, also with zero restarts.
- 117 signature-wait preparations across 30 messages showed long-sequence gaps of approximately `3,3,3,6,11,31,61,181…` seconds. Roughly one second of processing overhead means this matches the intended `2,2,2,5,10,30,60,180…` schedule and confirms the fast loop stops after three retries.
- exact head reproduced the same schedule. Its errors were dominated by expected signature-wait logs plus existing missing-validator-bucket and RPC/revert failures during backlog replay; the pod remained ready.

Conclusion: runtime behavior is correct, but this catch-up trial does not prove steady-state request savings or close the latency merge gate. Keep the PR draft until a clean/near-tip RC database can provide a causal request/latency comparison.

## Verification

- `rustup run 1.88.0 cargo test --manifest-path rust/main/Cargo.toml -p relayer test_awaiting_validator_signatures_backoff --quiet`
- `rustup run 1.88.0 cargo test --manifest-path rust/main/Cargo.toml -p relayer msg::pending_message::test --quiet`
- `rustup run 1.88.0 cargo clippy --manifest-path rust/main/Cargo.toml -p relayer --all-targets -- -D warnings`
- repository pre-commit hooks, including gitleaks and `cargo fmt`



Billing basis: monthly usage is already above the 9.5B CU pre-purchase, so avoided CU currently reduces overage at $0.24/M unless usage falls back below that floor.

