### PR TITLE
perf(infra): reduce fastpath validator polling

### DIFF
--- a/typescript/infra/config/environments/mainnet3/validators.ts
+++ b/typescript/infra/config/environments/mainnet3/validators.ts
@@ -9,7 +9,9 @@ import { validatorBaseConfigsFn } from '../utils.js';
 import { environment } from './chains.js';
 
 const DEFAULT_VALIDATOR_INTERVAL = 5;
-const FASTPATH_VALIDATOR_INTERVAL = 1;
+// Preserve about one-second average checkpoint polling delay while halving
+// steady-state polling relative to the original 1-second cadence.
+const FASTPATH_VALIDATOR_INTERVAL = 2;
 const FASTPATH_VALIDATOR_REORG_PERIOD = 1;
 // bsc (PoSA) and polygon (PoS) have a history of multi-block reorgs, so they
 // use a small non-zero reorg period instead of 1 even on the fast path.


### PR DESCRIPTION
## Summary

- increase the seven fastpath validator polling intervals from 1s to 2s
- leave standard validators at their existing 5s cadence
- trade about 0.5s average / 1s worst-case additional checkpoint polling delay for lower steady-state RPC usage

## Expected impact

A 2026-07-29 live snapshot across all seven fastpath validators measured:

- 21.6 Alchemy requests/s
- 36.7M known-weight Alchemy CU/day
- about $273 per 31-day month at the confirmed $0.24/M CU marginal overage rate

If polling traffic scales with the configured cadence, moving 1s → 2s should reduce this slice by roughly 50%: **about 18.4M CU/day, or $137 per 31-day month**. This is a trial estimate; provider retries, startup work, and message-triggered work will not scale perfectly with the interval.

This is independent cost hygiene, not an explanation for July's bill increase. Fastpath launched June 15 and account usage fell in the following week.

Formula:

```text
expected CU reduction/day = 36.7M × (1 - 1s/2s) = 18.4M
expected USD reduction/31d = 18.4M × 31 × $0.24/M = $137
```

## Validation

- `pnpm -C typescript/infra exec oxfmt --check config/environments/mainnet3/validators.ts`
- pre-commit `gitleaks`, `oxlint`, and `oxfmt`

Full infra typecheck was not available locally because its workspace dependency build stopped on missing Solidity library dependencies; CI remains authoritative.



Billing basis: monthly usage is already above the 9.5B CU pre-purchase, so avoided CU currently reduces overage at $0.24/M unless usage falls back below that floor.


