### PR TITLE
perf(infra): halve fastpath relayer polling

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -1062,7 +1062,9 @@ const fastPath: RootAgentConfig = {
     cache: {
       enabled: true,
     },
-    interval: 1,
+    // Halve steady-state index polling RPCs while keeping fastpath detection
+    // within one additional second (0.5s average).
+    interval: 2,
     resources: fastPathRelayerResources,
   },
   validators: {

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -475,7 +475,9 @@ const fastPath: RootAgentConfig = {
     cache: {
       enabled: true,
     },
-    interval: 1,
+    // Halve steady-state index polling RPCs while keeping fastpath detection
+    // within one additional second (0.5s average).
+    interval: 2,
     resources: relayerResources,
   },
 };

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -3,9 +3,16 @@ import { expect } from 'chai';
 import { AgentConfig } from '@hyperlane-xyz/sdk';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 
-import { hyperlaneContextAgentChainConfig as mainnet3AgentChainConfig } from '../config/environments/mainnet3/agent.js';
+import { Contexts } from '../config/contexts.js';
+import {
+  agents as mainnet3Agents,
+  hyperlaneContextAgentChainConfig as mainnet3AgentChainConfig,
+} from '../config/environments/mainnet3/agent.js';
 import { mainnet3SupportedChainNames } from '../config/environments/mainnet3/supportedChainNames.js';
-import { hyperlaneContextAgentChainConfig as testnet4AgentChainConfig } from '../config/environments/testnet4/agent.js';
+import {
+  agents as testnet4Agents,
+  hyperlaneContextAgentChainConfig as testnet4AgentChainConfig,
+} from '../config/environments/testnet4/agent.js';
 import { testnet4SupportedChainNames } from '../config/environments/testnet4/supportedChainNames.js';
 import { getAgentConfigJsonPath } from '../scripts/agent-utils.js';
 import {
@@ -34,6 +41,17 @@ const environmentChainConfigs = {
 };
 
 describe('Agent configs', () => {
+  it('polls fastpath relayer indexes every two seconds', () => {
+    expect(
+      mainnet3Agents[Contexts.FastPath].relayer?.interval,
+      'mainnet3 fastpath interval',
+    ).to.equal(2);
+    expect(
+      testnet4Agents[Contexts.FastPath].relayer?.interval,
+      'testnet4 fastpath interval',
+    ).to.equal(2);
+  });
+
   it('uses an RPC-compatible B² index chunk', () => {
     expect(
       environmentChainConfigs.mainnet3.agentJsonConfig.chains.bsquared.index


### PR DESCRIPTION
## Summary

- change mainnet3 and testnet4 fastpath relayer index polling from 1s to 2s
- retain low-latency indexing with at most one additional second of detection delay
- assert both environment configs keep the intended interval

## Expected impact

At tip, each EVM fastpath origin runs two sequence-aware indexers (message and merkle-tree insertion) and one rate-limited IGP indexer. A steady poll therefore issues approximately:

- 2 `eth_call` requests (mailbox nonce and merkle-tree count)
- 3 `eth_blockNumber` requests

Changing 1s to 2s halves that polling load:

| Scope | Requests/day saved | CU/day saved if all requests use Alchemy |
| --- | ---: | ---: |
| mainnet3 (7 chains) | 1,512,000 | 24,796,800 |
| testnet4 (3 chains) | 648,000 | 10,627,200 |
| total | 2,160,000 | 35,424,000 |

The CU estimate uses [Alchemy’s published method weights](https://www.alchemy.com/docs/reference/compute-unit-costs) (`eth_call` = 26 CU, `eth_blockNumber` = 10 CU). The current mainnet relayer snapshot routes about 35.9% of requests to Alchemy, which would imply roughly 12.7M Alchemy CU/day saved if fastpath has a similar provider share. At the confirmed $0.24/M CU marginal overage rate, that extrapolated Alchemy slice is about $94 per 31-day month. Actual savings should be measured because fallback allocation and traffic vary by chain.

Polling detection latency increases by 0.5s on average and 1s worst case. Validator checkpoint production and the validator-signature retry schedule are unchanged.

## Validation

- pre-commit gitleaks, oxlint, and oxfmt passed
- `oxfmt --check` passed for all changed files
- focused test added to `typescript/infra/test/agent-configs.test.ts`
- local execution of that test is blocked before test discovery by the checkout's registry bootstrap error: `Chain not found: abstract`

Draft pending a short fastpath canary comparing `hyperlane_request_count` by method/provider and message latency before and after.



Billing basis: monthly usage is already above the 9.5B CU pre-purchase, so avoided CU currently reduces overage at $0.24/M unless usage falls back below that floor.


