### PR TITLE
fix(validator): merge rpcUrls into additional quorum RPC vote

### DIFF
--- a/.changeset/additional-quorum-rpc-urls-rename.md
+++ b/.changeset/additional-quorum-rpc-urls-rename.md
@@ -1,6 +1,6 @@
 ---
-'@hyperlane-xyz/sdk': patch
-'@hyperlane-xyz/utils': patch
+'@hyperlane-xyz/sdk': minor
+'@hyperlane-xyz/utils': minor
 ---
 
 Renamed the validator quorum RPC verification config fields to make clear they only add to, rather than replace, a chain's `rpcUrls`. `AgentChainMetadataSchema`'s `quorumRpcUrls` and `customQuorumRpcUrls` are now `additionalQuorumRpcUrls` and `customAdditionalQuorumRpcUrls`. `ValidatorMetadata.quorum_rpcs` is now `additional_quorum_rpcs`. This is a breaking rename with no backwards-compatible alias, since these fields shipped very recently and have no known external consumers yet.

--- a/.changeset/additional-quorum-rpc-urls-rename.md
+++ b/.changeset/additional-quorum-rpc-urls-rename.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/utils': patch
+---
+
+Renamed the validator quorum RPC verification config fields to make clear they only add to, rather than replace, a chain's `rpcUrls`. `AgentChainMetadataSchema`'s `quorumRpcUrls` and `customQuorumRpcUrls` are now `additionalQuorumRpcUrls` and `customAdditionalQuorumRpcUrls`. `ValidatorMetadata.quorum_rpcs` is now `additional_quorum_rpcs`. This is a breaking rename with no backwards-compatible alias, since these fields shipped very recently and have no known external consumers yet.

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -17334,6 +17334,7 @@ dependencies = [
  "hyperlane-core",
  "hyperlane-cosmos",
  "hyperlane-ethereum",
+ "hyperlane-metric",
  "hyperlane-test",
  "itertools 0.10.5",
  "k256 0.13.4",

--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -87,6 +87,7 @@ fn generate_test_chain_conf(
         metrics_conf: PrometheusMiddlewareConf {
             contracts: HashMap::new(),
             chain: None,
+            rpc_role: Default::default(),
         },
         index: IndexSettings {
             from: 0,

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -743,6 +743,7 @@ mod test {
                 metrics_conf: PrometheusMiddlewareConf {
                     contracts: HashMap::new(),
                     chain: None,
+                    rpc_role: Default::default(),
                 },
                 index: IndexSettings {
                     from: 0,

--- a/rust/main/agents/validator/Cargo.toml
+++ b/rust/main/agents/validator/Cargo.toml
@@ -37,6 +37,7 @@ hyperlane-core = { path = "../../hyperlane-core", features = [
 hyperlane-base = { path = "../../hyperlane-base" }
 hyperlane-ethereum = { path = "../../chains/hyperlane-ethereum" }
 hyperlane-cosmos = { path = "../../chains/hyperlane-cosmos" }
+hyperlane-metric = { path = "../../hyperlane-metric" }
 
 # Dependency version is determined by ethers
 rusoto_core = '*'

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -213,27 +213,40 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_u64()
             .unwrap_or(50) as usize;
 
-        let mut rpcs = get_rpc_urls(&chain, "rpcUrls", "customRpcUrls", &mut err);
+        let mut rpcs = get_rpc_urls(&chain, "rpcUrls", "customRpcUrls", false, &mut err);
         // this is only relevant for cosmos
-        rpcs.extend(get_rpc_urls(&chain, "grpcUrls", "customGrpcUrls", &mut err));
+        rpcs.extend(get_rpc_urls(
+            &chain,
+            "grpcUrls",
+            "customGrpcUrls",
+            false,
+            &mut err,
+        ));
         // tron wallet urls
         rpcs.extend(get_rpc_urls(
             &chain,
             "walletUrls",
             "customWalletUrls",
+            false,
             &mut err,
         ));
         rpcs.extend(get_rpc_urls(
             &chain,
             "walletSolidityUrls",
             "customWalletSolidityUrls",
+            false,
             &mut err,
         ));
 
+        // `additionalQuorumRpcUrls` is intended for *additional public* RPCs (see
+        // `ValidatorSettings::additional_quorum_rpcs`), so its custom-override entries
+        // default to `public: true` -- unlike the other override keys above, which are
+        // gated by `allow_public_rpcs` and so must default to private.
         let additional_quorum_rpcs = get_rpc_urls(
             &chain,
             "additionalQuorumRpcUrls",
             "customAdditionalQuorumRpcUrls",
+            true,
             &mut err,
         );
 
@@ -272,10 +285,14 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
 ///
 /// rpcKey is either grpcUrls or rpcUrls
 /// overrideKey is either customGrpcUrls or customRpcUrls
+/// overrideDefaultPublic is the `public` value given to override entries, which carry no
+/// `public` field of their own (unlike the array form) -- `true` for keys like
+/// `additionalQuorumRpcUrls` that are intended to hold public RPCs, `false` otherwise
 fn get_rpc_urls(
     chain: &ValueParser,
     rpc_key: &str,
     override_key: &str,
+    override_default_public: bool,
     err: &mut ConfigParsingError,
 ) -> Vec<RpcConfig> {
     // struct looks like the following
@@ -320,7 +337,7 @@ fn get_rpc_urls(
                 .filter(|url| !url.is_empty())
                 .map(|url| RpcConfig {
                     url: url.to_owned(),
-                    public: false,
+                    public: override_default_public,
                 })
                 .collect_vec()
         });
@@ -441,7 +458,7 @@ mod test {
 
         let mut err = ConfigParsingError::default();
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", &mut err); // why does it convert to lowercase?
+        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", false, &mut err); // why does it convert to lowercase?
 
         assert_eq!(parsed.len(), expected.len());
         for (i, rpc) in expected.iter().enumerate() {
@@ -468,7 +485,7 @@ mod test {
         let rpcs = serde_json::from_str(rpcs).unwrap();
         let mut err = ConfigParsingError::default();
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", &mut err);
+        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", false, &mut err);
 
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://my-rpc-url.com");
@@ -496,7 +513,7 @@ mod test {
         let rpcs = serde_json::from_str(rpcs).unwrap();
         let mut err = ConfigParsingError::default();
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", &mut err);
+        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", false, &mut err);
 
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://my-rpc-url-3.com");
@@ -525,16 +542,20 @@ mod test {
             &value_parser,
             "additionalQuorumRpcUrls",
             "customAdditionalQuorumRpcUrls",
+            true,
             &mut err,
         );
 
         // customAdditionalQuorumRpcUrls overrides additionalQuorumRpcUrls, same as
-        // customRpcUrls does for rpcUrls.
+        // customRpcUrls does for rpcUrls. Unlike customRpcUrls, its override entries
+        // default to public: true, since additionalQuorumRpcUrls is intended for public
+        // RPCs -- otherwise every deployment using this override would spuriously trip
+        // `warn_if_additional_quorum_rpc_not_public`.
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://quorum-b.example");
-        assert!(!parsed[0].public);
+        assert!(parsed[0].public);
         assert_eq!(parsed[1].url, "http://quorum-c.example");
-        assert!(!parsed[1].public);
+        assert!(parsed[1].public);
     }
 
     /// Regression test: an empty `customAdditionalQuorumRpcUrls` override (e.g. an env
@@ -561,6 +582,7 @@ mod test {
             &value_parser,
             "additionalQuorumRpcUrls",
             "customAdditionalQuorumRpcUrls",
+            true,
             &mut err,
         );
 

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -55,12 +55,11 @@ pub struct ValidatorSettings {
     pub interval: Duration,
     /// A list of RPCs that the validator uses
     pub rpcs: Vec<RpcConfig>,
-    /// RPCs that vote together (2/3 majority) on the merkle tree hook's safety-critical
-    /// reads; the winning value must also match what `rpcs`' own configured consensus
-    /// mode independently returns. Empty disables quorum verification entirely.
-    /// Recommended: include your private `rpcs` here too, alongside a sizeable public
-    /// batch — a pool of 1-2 entries provides little real protection.
-    pub quorum_rpcs: Vec<RpcConfig>,
+    /// Additional RPCs that vote together with `rpcs` (2/3 majority, combined) on the
+    /// merkle tree hook's safety-critical reads. Empty disables quorum verification
+    /// entirely. Intended for *additional* public RPCs only — `rpcs` already votes in the
+    /// same group, so there's no need to duplicate its (typically private) entries here.
+    pub additional_quorum_rpcs: Vec<RpcConfig>,
     /// If the validator oped into public RPCs
     pub allow_public_rpcs: bool,
     /// Test-only: skips on-chain self-announce. Never use in production.
@@ -231,7 +230,12 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             &mut err,
         ));
 
-        let quorum_rpcs = get_rpc_urls(&chain, "quorumRpcUrls", "customQuorumRpcUrls", &mut err);
+        let additional_quorum_rpcs = get_rpc_urls(
+            &chain,
+            "additionalQuorumRpcUrls",
+            "customAdditionalQuorumRpcUrls",
+            &mut err,
+        );
 
         cfg_unwrap_all!(cwp, err: [base, origin_chain, validator, checkpoint_syncer]);
 
@@ -256,7 +260,7 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             reorg_period,
             interval,
             rpcs,
-            quorum_rpcs,
+            additional_quorum_rpcs,
             allow_public_rpcs,
             skip_announce,
             max_sign_concurrency,
@@ -500,16 +504,16 @@ mod test {
     }
 
     #[test]
-    fn test_get_rpc_urls_quorum_keys() {
+    fn test_get_rpc_urls_additional_quorum_keys() {
         let rpcs = r#"
             {
-                "quorumrpcurls": [
+                "additionalquorumrpcurls": [
                     {
                         "http": "http://quorum-a.example",
                         "public": true
                     }
                 ],
-                "customquorumrpcurls": "http://quorum-b.example,http://quorum-c.example"
+                "customadditionalquorumrpcurls": "http://quorum-b.example,http://quorum-c.example"
             }
         "#;
         let rpcs = serde_json::from_str(rpcs).unwrap();
@@ -517,12 +521,13 @@ mod test {
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
         let parsed = get_rpc_urls(
             &value_parser,
-            "quorumRpcUrls",
-            "customQuorumRpcUrls",
+            "additionalQuorumRpcUrls",
+            "customAdditionalQuorumRpcUrls",
             &mut err,
         );
 
-        // customQuorumRpcUrls overrides quorumRpcUrls, same as customRpcUrls does for rpcUrls.
+        // customAdditionalQuorumRpcUrls overrides additionalQuorumRpcUrls, same as
+        // customRpcUrls does for rpcUrls.
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://quorum-b.example");
         assert!(!parsed[0].public);

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -213,40 +213,27 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             .parse_u64()
             .unwrap_or(50) as usize;
 
-        let mut rpcs = get_rpc_urls(&chain, "rpcUrls", "customRpcUrls", false, &mut err);
+        let mut rpcs = get_rpc_urls(&chain, "rpcUrls", "customRpcUrls", &mut err);
         // this is only relevant for cosmos
-        rpcs.extend(get_rpc_urls(
-            &chain,
-            "grpcUrls",
-            "customGrpcUrls",
-            false,
-            &mut err,
-        ));
+        rpcs.extend(get_rpc_urls(&chain, "grpcUrls", "customGrpcUrls", &mut err));
         // tron wallet urls
         rpcs.extend(get_rpc_urls(
             &chain,
             "walletUrls",
             "customWalletUrls",
-            false,
             &mut err,
         ));
         rpcs.extend(get_rpc_urls(
             &chain,
             "walletSolidityUrls",
             "customWalletSolidityUrls",
-            false,
             &mut err,
         ));
 
-        // `additionalQuorumRpcUrls` is intended for *additional public* RPCs (see
-        // `ValidatorSettings::additional_quorum_rpcs`), so its custom-override entries
-        // default to `public: true` -- unlike the other override keys above, which are
-        // gated by `allow_public_rpcs` and so must default to private.
         let additional_quorum_rpcs = get_rpc_urls(
             &chain,
             "additionalQuorumRpcUrls",
             "customAdditionalQuorumRpcUrls",
-            true,
             &mut err,
         );
 
@@ -285,14 +272,10 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
 ///
 /// rpcKey is either grpcUrls or rpcUrls
 /// overrideKey is either customGrpcUrls or customRpcUrls
-/// overrideDefaultPublic is the `public` value given to override entries, which carry no
-/// `public` field of their own (unlike the array form) -- `true` for keys like
-/// `additionalQuorumRpcUrls` that are intended to hold public RPCs, `false` otherwise
 fn get_rpc_urls(
     chain: &ValueParser,
     rpc_key: &str,
     override_key: &str,
-    override_default_public: bool,
     err: &mut ConfigParsingError,
 ) -> Vec<RpcConfig> {
     // struct looks like the following
@@ -333,11 +316,9 @@ fn get_rpc_urls(
         .end()
         .map(|urls| {
             urls.split(',')
-                .map(str::trim)
-                .filter(|url| !url.is_empty())
                 .map(|url| RpcConfig {
                     url: url.to_owned(),
-                    public: override_default_public,
+                    public: false,
                 })
                 .collect_vec()
         });
@@ -458,7 +439,7 @@ mod test {
 
         let mut err = ConfigParsingError::default();
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", false, &mut err); // why does it convert to lowercase?
+        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", &mut err); // why does it convert to lowercase?
 
         assert_eq!(parsed.len(), expected.len());
         for (i, rpc) in expected.iter().enumerate() {
@@ -485,7 +466,7 @@ mod test {
         let rpcs = serde_json::from_str(rpcs).unwrap();
         let mut err = ConfigParsingError::default();
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", false, &mut err);
+        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", &mut err);
 
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://my-rpc-url.com");
@@ -513,7 +494,7 @@ mod test {
         let rpcs = serde_json::from_str(rpcs).unwrap();
         let mut err = ConfigParsingError::default();
         let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", false, &mut err);
+        let parsed = get_rpc_urls(&value_parser, "rpcUrls", "customRpcUrls", &mut err);
 
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://my-rpc-url-3.com");
@@ -542,53 +523,15 @@ mod test {
             &value_parser,
             "additionalQuorumRpcUrls",
             "customAdditionalQuorumRpcUrls",
-            true,
             &mut err,
         );
 
         // customAdditionalQuorumRpcUrls overrides additionalQuorumRpcUrls, same as
-        // customRpcUrls does for rpcUrls. Unlike customRpcUrls, its override entries
-        // default to public: true, since additionalQuorumRpcUrls is intended for public
-        // RPCs -- otherwise every deployment using this override would spuriously trip
-        // `warn_if_additional_quorum_rpc_not_public`.
+        // customRpcUrls does for rpcUrls.
         assert_eq!(parsed.len(), 2);
         assert_eq!(parsed[0].url, "http://quorum-b.example");
-        assert!(parsed[0].public);
+        assert!(!parsed[0].public);
         assert_eq!(parsed[1].url, "http://quorum-c.example");
-        assert!(parsed[1].public);
-    }
-
-    /// Regression test: an empty `customAdditionalQuorumRpcUrls` override (e.g. an env
-    /// var explicitly set to `""` to disable the additional quorum pool) must produce
-    /// zero entries, not a single bogus empty-string `RpcConfig` that would later fail
-    /// `Url::parse` and crash validator startup instead of just disabling the feature.
-    #[test]
-    fn test_get_rpc_urls_empty_override_disables_pool() {
-        let rpcs = r#"
-            {
-                "additionalquorumrpcurls": [
-                    {
-                        "http": "http://quorum-a.example",
-                        "public": true
-                    }
-                ],
-                "customadditionalquorumrpcurls": ""
-            }
-        "#;
-        let rpcs = serde_json::from_str(rpcs).unwrap();
-        let mut err = ConfigParsingError::default();
-        let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
-        let parsed = get_rpc_urls(
-            &value_parser,
-            "additionalQuorumRpcUrls",
-            "customAdditionalQuorumRpcUrls",
-            true,
-            &mut err,
-        );
-
-        assert!(
-            parsed.is_empty(),
-            "an empty override string must disable the pool entirely, got {parsed:?}"
-        );
+        assert!(!parsed[1].public);
     }
 }

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -316,6 +316,8 @@ fn get_rpc_urls(
         .end()
         .map(|urls| {
             urls.split(',')
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
                 .map(|url| RpcConfig {
                     url: url.to_owned(),
                     public: false,
@@ -533,5 +535,38 @@ mod test {
         assert!(!parsed[0].public);
         assert_eq!(parsed[1].url, "http://quorum-c.example");
         assert!(!parsed[1].public);
+    }
+
+    /// Regression test: an empty `customAdditionalQuorumRpcUrls` override (e.g. an env
+    /// var explicitly set to `""` to disable the additional quorum pool) must produce
+    /// zero entries, not a single bogus empty-string `RpcConfig` that would later fail
+    /// `Url::parse` and crash validator startup instead of just disabling the feature.
+    #[test]
+    fn test_get_rpc_urls_empty_override_disables_pool() {
+        let rpcs = r#"
+            {
+                "additionalquorumrpcurls": [
+                    {
+                        "http": "http://quorum-a.example",
+                        "public": true
+                    }
+                ],
+                "customadditionalquorumrpcurls": ""
+            }
+        "#;
+        let rpcs = serde_json::from_str(rpcs).unwrap();
+        let mut err = ConfigParsingError::default();
+        let value_parser = ValueParser::new(ConfigPath::default(), &rpcs);
+        let parsed = get_rpc_urls(
+            &value_parser,
+            "additionalQuorumRpcUrls",
+            "customAdditionalQuorumRpcUrls",
+            &mut err,
+        );
+
+        assert!(
+            parsed.is_empty(),
+            "an empty override string must disable the pool entirely, got {parsed:?}"
+        );
     }
 }

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -138,16 +138,33 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     ) -> ChainResult<T> {
         let mut oks: Vec<(String, T)> = Vec::new();
         let mut first_err = None;
+        // Identified by label prefix (see `build_validator_ethereum_per_url_hooks`), not a
+        // separate role field: purely observational, doesn't affect the threshold below. A
+        // `Primary` (`rpcUrls`) failure is notable even when the round still succeeds via
+        // `additionalQuorumRpcUrls`/still counts fully against the fixed denominator either
+        // way - ops should know an `rpcUrls` entry is unhealthy.
+        let mut failed_primary_rpcs: Vec<String> = Vec::new();
 
         for (label, result) in results {
             match result {
                 Ok(value) => oks.push((label, value)),
                 Err(err) => {
+                    if label.starts_with("rpcUrls[") {
+                        failed_primary_rpcs.push(label.clone());
+                    }
                     if first_err.is_none() {
                         first_err = Some(err);
                     }
                 }
             }
+        }
+
+        if !failed_primary_rpcs.is_empty() {
+            warn!(
+                context,
+                failed_primary_rpcs = ?failed_primary_rpcs,
+                "rpcUrls entries failed this round; they still count against the quorum threshold"
+            );
         }
 
         let threshold = Self::two_thirds_threshold(self.quorum_hooks.len());
@@ -556,6 +573,8 @@ impl BaseAgent for Validator {
             // `origin_chain_conf.connection` rather than `settings.rpcs`, which also
             // comingles `grpcUrls`/`walletUrls`/`walletSolidityUrls` (non-Ethereum chains).
             let primary_rpc_urls: Vec<Url> = Self::primary_rpc_urls(&origin_chain_conf);
+            let additional_quorum_rpc_urls: Vec<Url> =
+                Self::remove_urls_already_in_primary(&primary_rpc_urls, additional_quorum_rpc_urls);
             let combined_urls: Vec<Url> = primary_rpc_urls
                 .iter()
                 .chain(additional_quorum_rpc_urls.iter())
@@ -765,6 +784,33 @@ impl Validator {
         deduped
     }
 
+    /// Removes any `additionalQuorumRpcUrls` entry that's also present in `rpcUrls`
+    /// (exact-URL match). Without this, a URL present in both pools would supply two
+    /// independent-looking `quorum_hooks` votes (one tagged `Primary`, one `Quorum`) plus
+    /// `base_hook`'s agreement - collapsing the quorum's independence assumption onto a
+    /// single physical endpoint. Order-preserving; only ever removes from the additional
+    /// pool, never the primary one, since `rpcUrls` always votes.
+    fn remove_urls_already_in_primary(
+        primary_rpc_urls: &[Url],
+        additional_quorum_rpc_urls: Vec<Url>,
+    ) -> Vec<Url> {
+        let original_count = additional_quorum_rpc_urls.len();
+        let primary_url_set: HashSet<&Url> = primary_rpc_urls.iter().collect();
+        let deduped: Vec<Url> = additional_quorum_rpc_urls
+            .into_iter()
+            .filter(|url| !primary_url_set.contains(url))
+            .collect();
+        if deduped.len() < original_count {
+            warn!(
+                original_count,
+                deduped_count = deduped.len(),
+                "additionalQuorumRpcUrls contained entries already present in rpcUrls; \
+                 removing them to preserve vote independence"
+            );
+        }
+        deduped
+    }
+
     /// Warns (doesn't reject: distinct accounts/API keys on the same provider are a
     /// legitimate choice) when multiple entries across the combined `rpcUrls` +
     /// `additionalQuorumRpcUrls` pool share a host, grouped by index rather than the host
@@ -848,6 +894,10 @@ impl Validator {
         }
     }
 
+    /// Builds a per-URL connection, preserving the WebSocket variant for `ws`/`wss` URLs
+    /// rather than always installing `Http`. A `ws://`/`wss://` primary forced into an
+    /// `Http` connection would build an unusable hook - silently losing primary quorum
+    /// availability for any validator configured with a WebSocket `rpcUrls` entry.
     fn ethereum_chain_conf_for_url(
         origin_chain_conf: &ChainConf,
         url: Url,
@@ -855,7 +905,11 @@ impl Validator {
     ) -> ChainConf {
         let mut chain_conf = origin_chain_conf.clone();
         if let ChainConnectionConf::Ethereum(updated_conn) = &mut chain_conf.connection {
-            updated_conn.rpc_connection = RpcConnectionConf::Http { url };
+            updated_conn.rpc_connection = if matches!(url.scheme(), "ws" | "wss") {
+                RpcConnectionConf::Ws { url }
+            } else {
+                RpcConnectionConf::Http { url }
+            };
         }
         chain_conf.metrics_conf.rpc_role = role;
         chain_conf
@@ -1249,6 +1303,39 @@ mod tests {
         assert_eq!(deduped, urls);
     }
 
+    /// Regression test for the cross-pool double-vote: `rpcUrls=[P]` plus
+    /// `additionalQuorumRpcUrls=[P, H]` must not let `P` cast two votes. A compromised `P`
+    /// would otherwise supply the 2/3 quorum majority by itself (via its Primary-tagged and
+    /// Quorum-tagged hooks both agreeing) *and* the agreeing `base_hook`, despite only one
+    /// of the two nominally-independent endpoints actually being compromised.
+    #[test]
+    fn remove_urls_already_in_primary_removes_cross_pool_overlap() {
+        let primary = Url::parse("http://p.example").unwrap();
+        let honest = Url::parse("http://h.example").unwrap();
+        let primary_rpc_urls = vec![primary.clone()];
+        let additional_quorum_rpc_urls = vec![primary.clone(), honest.clone()];
+
+        let deduped = Validator::remove_urls_already_in_primary(
+            &primary_rpc_urls,
+            additional_quorum_rpc_urls,
+        );
+
+        assert_eq!(deduped, vec![honest]);
+    }
+
+    #[test]
+    fn remove_urls_already_in_primary_is_noop_without_overlap() {
+        let primary_rpc_urls = vec![Url::parse("http://p.example").unwrap()];
+        let additional_quorum_rpc_urls = vec![Url::parse("http://h.example").unwrap()];
+
+        let deduped = Validator::remove_urls_already_in_primary(
+            &primary_rpc_urls,
+            additional_quorum_rpc_urls.clone(),
+        );
+
+        assert_eq!(deduped, additional_quorum_rpc_urls);
+    }
+
     #[test]
     fn primary_rpc_urls_extracts_from_http_fallback() {
         let urls = vec![
@@ -1349,6 +1436,28 @@ mod tests {
             _ => panic!("expected an ethereum connection"),
         }
         assert_eq!(per_url_conf.metrics_conf.rpc_role, RpcRole::Quorum);
+    }
+
+    /// Regression test: a `ws://`/`wss://` URL must build a `Ws` connection, not `Http` -
+    /// forcing it into `Http` would build an unusable hook, silently losing primary quorum
+    /// availability for any validator configured with a WebSocket `rpcUrls` entry.
+    #[test]
+    fn ethereum_chain_conf_for_url_preserves_websocket_connection() {
+        let chain_conf =
+            dummy_ethereum_chain_conf(vec![Url::parse("http://rpc-a.example").unwrap()]);
+        let url = Url::parse("wss://quorum-node.example").unwrap();
+
+        let per_url_conf =
+            Validator::ethereum_chain_conf_for_url(&chain_conf, url.clone(), RpcRole::Primary);
+
+        match per_url_conf.connection {
+            ChainConnectionConf::Ethereum(conn) => match conn.rpc_connection {
+                RpcConnectionConf::Ws { url: got } => assert_eq!(got, url),
+                other => panic!("expected a Ws connection, got {other:?}"),
+            },
+            _ => panic!("expected an ethereum connection"),
+        }
+        assert_eq!(per_url_conf.metrics_conf.rpc_role, RpcRole::Primary);
     }
 
     #[tokio::test]
@@ -1814,6 +1923,78 @@ mod tests {
         assert!(hook.tree(&ReorgPeriod::None).await.is_err());
         assert!(logs_contain(
             "merged quorum consensus disagrees with rpcUrls consensus"
+        ));
+    }
+
+    /// Observability regression test: a `Primary` (`rpcUrls`) entry failing must still be
+    /// logged even when the round succeeds via the other entries - this is a pure
+    /// observability signal, separate from (and must not reintroduce) any
+    /// denominator-exclusion logic. 1 failed `rpcUrls` entry + 2 agreeing
+    /// `additionalQuorumRpcUrls` entries meets the 2/3-of-3 threshold, so the round succeeds,
+    /// but ops should still be warned that an `rpcUrls` entry is unhealthy.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_warns_on_primary_failure_in_successful_round(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+        let quorum_tree = IncrementalMerkleAtBlock {
+            tree: Default::default(),
+            block_height: Some(50),
+        };
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 50);
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let quorum_tree = quorum_tree.clone();
+                move |_| Ok(quorum_tree)
+            });
+
+        let mut primary_failing = MockMerkleTreeHook::new();
+        primary_failing.expect_latest_checkpoint().never();
+        primary_failing
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("rpc down")));
+
+        let mut quorum_a = MockMerkleTreeHook::new();
+        quorum_a.expect_latest_checkpoint().never();
+        quorum_a
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let quorum_tree = quorum_tree.clone();
+                move |_| Ok(quorum_tree)
+            });
+
+        let mut quorum_b = MockMerkleTreeHook::new();
+        quorum_b.expect_latest_checkpoint().never();
+        quorum_b
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(move |_| Ok(quorum_tree));
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                quorum_rpc("rpcUrls[0]", primary_failing),
+                quorum_rpc("additionalQuorumRpcUrls[0]", quorum_a),
+                quorum_rpc("additionalQuorumRpcUrls[1]", quorum_b),
+            ],
+        };
+
+        assert!(hook.tree(&ReorgPeriod::None).await.is_ok());
+        assert!(logs_contain(
+            "rpcUrls entries failed this round; they still count against the quorum threshold"
         ));
     }
 

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -67,10 +67,16 @@ const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 /// majority vote across `quorum_hooks`: one hook per `rpcUrls` entry (role `Primary`,
 /// always counted in the threshold, whether it succeeds or fails this round) plus one hook
 /// per `additionalQuorumRpcUrls` entry (role `Quorum`, excluded from the threshold's denominator if
-/// it fails this round — see `select_quorum_result`). `additionalQuorumRpcUrls` is meant to hold
-/// *additional* public RPCs on top of what's already in `rpcUrls` — it widens the vote
-/// without weakening it: a public endpoint blipping shouldn't itself block checkpoint
-/// signing, or force unanimous agreement among the rest.
+/// it fails this round — but only if at least one other `Quorum`-role entry responded, so
+/// a fully-failed quorum pool can't shrink the denominator down to a compromised
+/// `Primary`-only remainder; see `select_quorum_result`). `additionalQuorumRpcUrls` is
+/// meant to hold *additional* public RPCs on top of what's already in `rpcUrls` — it
+/// widens the vote without weakening it: a public endpoint blipping shouldn't itself
+/// block checkpoint signing, or force unanimous agreement among the rest. The merged
+/// vote's winner must also independently match what `base_hook` (`rpcUrls`'s own
+/// consensus) returns — see `require_base_hook_agreement` — so a colluding or
+/// compromised subset of the merged group (most plausibly `additionalQuorumRpcUrls`,
+/// being public) can't outvote an honest `Primary`.
 #[derive(Debug)]
 struct ValidatorMultiRpcQuorumMerkleTreeHook {
     base_hook: Arc<dyn MerkleTreeHook>,
@@ -160,6 +166,16 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     /// RPC's error also never becomes the round's returned error (see `first_primary_err`
     /// below): it's expected/tolerated, so it must never surface up through
     /// logs/alerting the way an unexpected `Primary`-role failure would.
+    ///
+    /// The exclusion above is only granted if at least one `Quorum`-role entry actually
+    /// responded this round. If *every* `Quorum`-role entry fails simultaneously, that's
+    /// not "one entry blipping" — it's exactly the signal a target-height manipulation
+    /// attack would produce (e.g. a compromised `Primary` picks a future/nonexistent
+    /// height that only it can answer, and every honest `additionalQuorumRpcUrls` entry
+    /// correctly errors "not found"). Letting the denominator shrink to just the
+    /// `Primary` pool in that case would let a compromised `Primary` win by default. So
+    /// a fully-failed `Quorum`-role pool counts against the threshold like `Primary`
+    /// failures do, rather than being excluded.
     fn select_quorum_result<T: Clone + Debug>(
         &self,
         results: Vec<(String, RpcRole, ChainResult<T>)>,
@@ -173,33 +189,70 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         // failure could otherwise leak out).
         let mut first_primary_err = None;
         let mut excluded_quorum_rpcs: Vec<String> = Vec::new();
+        let mut failed_primary_rpcs: Vec<String> = Vec::new();
+        let mut quorum_role_total = 0usize;
+        let mut quorum_role_oks = 0usize;
 
         for (label, role, result) in results {
+            if role == RpcRole::Quorum {
+                quorum_role_total = quorum_role_total.saturating_add(1);
+            }
             match result {
-                Ok(value) => oks.push((label, value)),
+                Ok(value) => {
+                    if role == RpcRole::Quorum {
+                        quorum_role_oks = quorum_role_oks.saturating_add(1);
+                    }
+                    oks.push((label, value));
+                }
                 Err(err) => {
                     if role == RpcRole::Quorum {
                         excluded_quorum_rpcs.push(label);
-                    } else if first_primary_err.is_none() {
-                        first_primary_err = Some(err);
+                    } else {
+                        failed_primary_rpcs.push(label);
+                        if first_primary_err.is_none() {
+                            first_primary_err = Some(err);
+                        }
                     }
                 }
             }
         }
 
-        let effective_pool_size = self
-            .quorum_hooks
-            .len()
-            .saturating_sub(excluded_quorum_rpcs.len());
+        if !failed_primary_rpcs.is_empty() {
+            warn!(
+                context,
+                failed_primary_rpcs = ?failed_primary_rpcs,
+                "rpcUrls entries failed this round; they still count against the quorum threshold"
+            );
+        }
+
+        // See the doc comment above: only shrink the denominator if the exclusion isn't
+        // itself the attack signal (i.e. at least one Quorum-role entry responded).
+        let grant_quorum_exclusion = quorum_role_total == 0 || quorum_role_oks > 0;
+        let excluded_count = if grant_quorum_exclusion {
+            excluded_quorum_rpcs.len()
+        } else {
+            0
+        };
+        let effective_pool_size = self.quorum_hooks.len().saturating_sub(excluded_count);
         let threshold = Self::two_thirds_threshold(effective_pool_size);
         if !excluded_quorum_rpcs.is_empty() {
-            debug!(
-                context,
-                excluded_quorum_rpcs = ?excluded_quorum_rpcs,
-                effective_pool_size,
-                threshold,
-                "Excluding unavailable additionalQuorumRpcUrls entries from this round's quorum threshold"
-            );
+            if grant_quorum_exclusion {
+                debug!(
+                    context,
+                    excluded_quorum_rpcs = ?excluded_quorum_rpcs,
+                    effective_pool_size,
+                    threshold,
+                    "Excluding unavailable additionalQuorumRpcUrls entries from this round's quorum threshold"
+                );
+            } else {
+                warn!(
+                    context,
+                    excluded_quorum_rpcs = ?excluded_quorum_rpcs,
+                    "Every responding additionalQuorumRpcUrls entry failed this round; NOT \
+                     excluding them from the threshold, since a fully-failed quorum pool is \
+                     exactly the signal a target-height manipulation attack would produce"
+                );
+            }
         }
         let mut max_agreeing = 0;
         let mut best_agreeing_rpcs: Vec<&str> = Vec::new();
@@ -263,6 +316,34 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
             total = oks.len()
         )))
     }
+
+    /// Requires the merged group's accepted value to also match what `base_hook`
+    /// (`rpcUrls`, whatever consensus mode it's configured with) independently returns.
+    /// Guards against a colluding or compromised subset of the merged vote — most
+    /// plausibly the less-trusted `additionalQuorumRpcUrls` entries — outvoting an
+    /// honest `Primary`: e.g. 1 honest `rpcUrls` entry plus 2 colluding public
+    /// `additionalQuorumRpcUrls` entries reach the overall 2/3 threshold on the public
+    /// pair's value alone. An attacker now also has to compromise `rpcUrls`' own
+    /// consensus to force a wrong value through.
+    fn require_base_hook_agreement<T: Debug>(
+        quorum_result: &T,
+        base_result: &T,
+        matches: impl Fn(&T, &T) -> bool,
+        context: &str,
+    ) -> ChainResult<()> {
+        if matches(quorum_result, base_result) {
+            return Ok(());
+        }
+        warn!(
+            context,
+            quorum_result = ?quorum_result,
+            base_result = ?base_result,
+            "merged quorum consensus disagrees with rpcUrls consensus"
+        );
+        Err(ChainCommunicationError::from_other_str(&format!(
+            "{context}: merged quorum consensus disagrees with rpcUrls consensus"
+        )))
+    }
 }
 
 #[async_trait]
@@ -279,11 +360,19 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
                 },
             ))
             .await;
-            return self.select_quorum_result(
+            let quorum_result = self.select_quorum_result(
                 results,
                 |a, b| a.tree == b.tree,
                 "Failed to reach quorum for merkle tree",
-            );
+            )?;
+            let base_result = self.base_hook.tree_at_block(height).await?;
+            Self::require_base_hook_agreement(
+                &quorum_result,
+                &base_result,
+                |a, b| a.tree == b.tree,
+                "Failed to reach quorum for merkle tree",
+            )?;
+            return Ok(quorum_result);
         }
 
         let results = join_all(self.quorum_hooks.iter().cloned().map(|quorum_hook| {
@@ -297,11 +386,19 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             }
         }))
         .await;
-        self.select_quorum_result(
+        let quorum_result = self.select_quorum_result(
             results,
             |a, b| a.tree == b.tree && a.block_height == b.block_height,
             "Failed to reach quorum for merkle tree",
-        )
+        )?;
+        let base_result = self.base_hook.tree(reorg_period).await?;
+        Self::require_base_hook_agreement(
+            &quorum_result,
+            &base_result,
+            |a, b| a.tree == b.tree,
+            "Failed to reach quorum for merkle tree",
+        )?;
+        Ok(quorum_result)
     }
 
     async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
@@ -328,11 +425,19 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             }
         }))
         .await;
-        self.select_quorum_result(
+        let quorum_result = self.select_quorum_result(
             results,
             |a, b| a.checkpoint == b.checkpoint && a.block_height == b.block_height,
             "Failed to reach quorum for latest_checkpoint",
-        )
+        )?;
+        let base_result = self.base_hook.latest_checkpoint(reorg_period).await?;
+        Self::require_base_hook_agreement(
+            &quorum_result,
+            &base_result,
+            |a, b| a.checkpoint == b.checkpoint,
+            "Failed to reach quorum for latest_checkpoint",
+        )?;
+        Ok(quorum_result)
     }
 
     async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
@@ -352,11 +457,19 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
                 }),
         )
         .await;
-        self.select_quorum_result(
+        let quorum_result = self.select_quorum_result(
             results,
             |a, b| a.checkpoint == b.checkpoint && a.block_height == b.block_height,
             "Failed to reach quorum for latest_checkpoint_at_block",
-        )
+        )?;
+        let base_result = self.base_hook.latest_checkpoint_at_block(height).await?;
+        Self::require_base_hook_agreement(
+            &quorum_result,
+            &base_result,
+            |a, b| a.checkpoint == b.checkpoint,
+            "Failed to reach quorum for latest_checkpoint_at_block",
+        )?;
+        Ok(quorum_result)
     }
 }
 
@@ -556,14 +669,18 @@ impl BaseAgent for Validator {
             // `rpcUrls` (`primary_rpc_urls` below) votes alongside `additionalQuorumRpcUrls` in the
             // same 2/3 quorum group (see `ValidatorMultiRpcQuorumMerkleTreeHook`), so
             // `additionalQuorumRpcUrls` only needs to add public endpoints on top of it.
-            let primary_rpc_urls: Vec<Url> = settings
-                .rpcs
-                .iter()
-                .enumerate()
-                .map(|(i, rpc)| {
-                    Url::parse(&rpc.url).map_err(|err| eyre!("Invalid rpcUrls[{i}] entry: {err}"))
-                })
-                .collect::<Result<_>>()?;
+            //
+            // Read directly from `origin_chain_conf.connection` rather than `settings.rpcs`:
+            // `settings.rpcs` also comingles `grpcUrls`/`walletUrls`/`walletSolidityUrls`
+            // entries (used for non-Ethereum chains), which would otherwise leak into the
+            // `Primary` vote pool as URLs that can never successfully serve an Ethereum
+            // JSON-RPC read, spuriously tightening the threshold every round.
+            let primary_rpc_urls: Vec<Url> = Self::primary_rpc_urls(&origin_chain_conf);
+            let additional_quorum_rpc_urls =
+                Self::dedupe_additional_quorum_rpc_urls_against_primary(
+                    &primary_rpc_urls,
+                    additional_quorum_rpc_urls,
+                );
             Self::warn_if_additional_quorum_rpc_not_public(&additional_quorum_rpc_urls);
             Self::warn_if_quorum_pool_undersized(
                 primary_rpc_urls.len(),
@@ -772,6 +889,33 @@ impl Validator {
         deduped
     }
 
+    /// Removes any `additionalQuorumRpcUrls` entry whose URL is already in `rpcUrls`.
+    /// Since both pools now vote together (see `ValidatorMultiRpcQuorumMerkleTreeHook`),
+    /// keeping such a duplicate would cast two votes for what's really one provider,
+    /// undermining the vote's independence assumption exactly like an in-pool duplicate
+    /// would — `dedupe_additional_quorum_rpc_urls` only catches duplicates *within*
+    /// `additionalQuorumRpcUrls`, not across the two pools.
+    fn dedupe_additional_quorum_rpc_urls_against_primary(
+        primary_rpc_urls: &[Url],
+        additional_quorum_rpc_urls: Vec<(Url, bool)>,
+    ) -> Vec<(Url, bool)> {
+        let primary_set: HashSet<&Url> = primary_rpc_urls.iter().collect();
+        let original_count = additional_quorum_rpc_urls.len();
+        let deduped: Vec<(Url, bool)> = additional_quorum_rpc_urls
+            .into_iter()
+            .filter(|(url, _)| !primary_set.contains(url))
+            .collect();
+        if deduped.len() < original_count {
+            warn!(
+                original_count,
+                deduped_count = deduped.len(),
+                "additionalQuorumRpcUrls contained entries already present in rpcUrls; \
+                 removing them to preserve vote independence"
+            );
+        }
+        deduped
+    }
+
     /// Warns (doesn't reject: distinct accounts/API keys on the same provider are a
     /// legitimate choice) when multiple entries across `rpcUrls` and `additionalQuorumRpcUrls`
     /// combined share a host, grouped by label rather than the host itself so the log
@@ -875,6 +1019,22 @@ impl Validator {
             base_hook: base_hook.into(),
             quorum_hooks,
         }) as Box<dyn MerkleTreeHook>)
+    }
+
+    /// The actual URLs `base_hook` (`rpcUrls`) is configured with, read directly from
+    /// `origin_chain_conf.connection` rather than `settings.rpcs` (see the call site for
+    /// why). Returns empty for a non-Ethereum connection; callers only reach this after
+    /// `validator_uses_split_quorum_hook` has already confirmed it's Ethereum.
+    fn primary_rpc_urls(origin_chain_conf: &ChainConf) -> Vec<Url> {
+        let ChainConnectionConf::Ethereum(conn) = &origin_chain_conf.connection else {
+            return Vec::new();
+        };
+        match &conn.rpc_connection {
+            RpcConnectionConf::HttpQuorum { urls } | RpcConnectionConf::HttpFallback { urls } => {
+                urls.clone()
+            }
+            RpcConnectionConf::Http { url } | RpcConnectionConf::Ws { url } => vec![url.clone()],
+        }
     }
 
     fn ethereum_chain_conf_for_url(
@@ -1286,6 +1446,68 @@ mod tests {
 
     #[test]
     #[tracing_test::traced_test]
+    fn dedupe_additional_quorum_rpc_urls_against_primary_removes_shared_url() {
+        let primary_urls = vec![Url::parse("http://rpc-a.example").unwrap()];
+        let additional_urls = vec![
+            (Url::parse("http://rpc-a.example").unwrap(), true),
+            (Url::parse("http://rpc-b.example").unwrap(), true),
+        ];
+
+        let deduped = Validator::dedupe_additional_quorum_rpc_urls_against_primary(
+            &primary_urls,
+            additional_urls,
+        );
+
+        assert_eq!(
+            deduped,
+            vec![(Url::parse("http://rpc-b.example").unwrap(), true)]
+        );
+        assert!(logs_contain(
+            "additionalQuorumRpcUrls contained entries already present in rpcUrls"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn dedupe_additional_quorum_rpc_urls_against_primary_is_noop_when_disjoint() {
+        let primary_urls = vec![Url::parse("http://rpc-a.example").unwrap()];
+        let additional_urls = vec![(Url::parse("http://rpc-b.example").unwrap(), true)];
+
+        let deduped = Validator::dedupe_additional_quorum_rpc_urls_against_primary(
+            &primary_urls,
+            additional_urls.clone(),
+        );
+
+        assert_eq!(deduped, additional_urls);
+        assert!(!logs_contain(
+            "additionalQuorumRpcUrls contained entries already present in rpcUrls"
+        ));
+    }
+
+    #[test]
+    fn primary_rpc_urls_extracts_from_http_fallback() {
+        let urls = vec![
+            Url::parse("http://rpc-a.example").unwrap(),
+            Url::parse("http://rpc-b.example").unwrap(),
+        ];
+        let chain_conf = dummy_ethereum_chain_conf(urls.clone());
+
+        assert_eq!(Validator::primary_rpc_urls(&chain_conf), urls);
+    }
+
+    #[test]
+    fn primary_rpc_urls_extracts_from_single_http() {
+        let mut chain_conf = dummy_ethereum_chain_conf(vec![]);
+        let url = Url::parse("http://rpc-a.example").unwrap();
+        if let ChainConnectionConf::Ethereum(conn) = &mut chain_conf.connection {
+            conn.rpc_connection = RpcConnectionConf::Http { url: url.clone() };
+        }
+
+        assert_eq!(Validator::primary_rpc_urls(&chain_conf), vec![url]);
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
     fn warn_if_quorum_pool_undersized_warns_below_minimum() {
         Validator::warn_if_quorum_pool_undersized(1, 0);
 
@@ -1627,12 +1849,18 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
-        // base_hook is only used to resolve the target height, never for a post-vote
-        // cross-check.
-        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree)
+            });
 
-        // 2 of 3 (>= two_thirds_threshold(3) == 2) is enough for the quorum_hooks vote.
+        // 2 of 3 (>= two_thirds_threshold(3) == 2) is enough for the quorum_hooks vote, and
+        // that value matches base_hook's own result.
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
         quorum_a
@@ -1857,6 +2085,152 @@ mod tests {
         );
     }
 
+    /// Regression test for a fail-open attack: if a compromised `Primary` manipulates the
+    /// target height such that every honest `Quorum`-role RPC errors (e.g. "header not
+    /// found" for a fabricated future height), the `Quorum`-role pool must NOT be
+    /// excluded from the threshold -- otherwise the compromised `Primary` would trivially
+    /// "win" a 1-of-1 vote against itself.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_fully_fails(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        // Never reached: the merged vote fails before base_hook would be consulted.
+        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 42);
+
+        let mut compromised_primary = MockMerkleTreeHook::new();
+        compromised_primary.expect_latest_checkpoint().never();
+        compromised_primary
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|_| {
+                let mut fabricated =
+                    hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+                fabricated.ingest(H256::from_low_u64_be(1));
+                Ok(IncrementalMerkleAtBlock {
+                    tree: fabricated,
+                    block_height: Some(42),
+                })
+            });
+
+        let mut quorum_a = MockMerkleTreeHook::new();
+        quorum_a.expect_latest_checkpoint().never();
+        quorum_a
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
+
+        let mut quorum_b = MockMerkleTreeHook::new();
+        quorum_b.expect_latest_checkpoint().never();
+        quorum_b
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                primary_rpc("rpc-primary-compromised", compromised_primary),
+                quorum_rpc("rpc-quorum-a", quorum_a),
+                quorum_rpc("rpc-quorum-b", quorum_b),
+            ],
+        };
+
+        assert!(
+            hook.tree(&ReorgPeriod::None).await.is_err(),
+            "a fully-failed Quorum-role pool must not let a lone Primary win by default"
+        );
+    }
+
+    /// Regression test: 2 colluding/compromised `additionalQuorumRpcUrls` (`Quorum`-role,
+    /// less-trusted public) entries can reach the overall 2/3 threshold on a wrong value
+    /// even with an honest `Primary` disagreeing (1 Primary + 2 colluding Quorum = 2/3 on
+    /// the colluding pair's value). `require_base_hook_agreement` must catch this:
+    /// `base_hook` independently reflects the honest `rpcUrls` consensus, which disagrees
+    /// with the colluding pair's value, so the round must be rejected.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_colluding_quorum_role_majority(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+        let honest_tree = IncrementalMerkleAtBlock {
+            tree: Default::default(),
+            block_height: Some(50),
+        };
+        let mut colluding_merkle =
+            hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+        colluding_merkle.ingest(H256::from_low_u64_be(1));
+        let colluding_tree = IncrementalMerkleAtBlock {
+            tree: colluding_merkle,
+            block_height: Some(50),
+        };
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 50);
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let honest_tree = honest_tree.clone();
+                move |_| Ok(honest_tree)
+            });
+
+        let mut honest_primary = MockMerkleTreeHook::new();
+        honest_primary.expect_latest_checkpoint().never();
+        honest_primary
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let honest_tree = honest_tree.clone();
+                move |_| Ok(honest_tree)
+            });
+
+        let mut colluding_a = MockMerkleTreeHook::new();
+        colluding_a.expect_latest_checkpoint().never();
+        colluding_a
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let colluding_tree = colluding_tree.clone();
+                move |_| Ok(colluding_tree)
+            });
+
+        let mut colluding_b = MockMerkleTreeHook::new();
+        colluding_b.expect_latest_checkpoint().never();
+        colluding_b
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(move |_| Ok(colluding_tree));
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                primary_rpc("rpc-primary-honest", honest_primary),
+                quorum_rpc("rpc-quorum-colluding-a", colluding_a),
+                quorum_rpc("rpc-quorum-colluding-b", colluding_b),
+            ],
+        };
+
+        assert!(
+            hook.tree(&ReorgPeriod::None).await.is_err(),
+            "2 colluding Quorum-role entries must not be able to outvote an honest Primary"
+        );
+    }
+
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_tolerates_rpc_failure_within_two_thirds_threshold(
     ) {
@@ -1870,8 +2244,15 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
-        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 11);
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(11))
+            .return_once({
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree)
+            });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
@@ -1939,8 +2320,15 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
-        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree)
+            });
 
         let mut quorum_down = MockMerkleTreeHook::new();
         quorum_down.expect_latest_checkpoint().never();
@@ -1998,6 +2386,7 @@ mod tests {
     /// the threshold, so it stays at ceil(2*4/3) = 3; only 2 of the 3 responders agree ->
     /// quorum fails.
     #[tokio::test]
+    #[tracing_test::traced_test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_does_not_exclude_down_primary_role_rpc_from_threshold(
     ) {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
@@ -2067,6 +2456,9 @@ mod tests {
         };
 
         assert!(hook.tree(&ReorgPeriod::None).await.is_err());
+        assert!(logs_contain(
+            "rpcUrls entries failed this round; they still count against the quorum threshold"
+        ));
     }
 
     /// Regression test for the tip-relative-comparison bug: honest quorum RPCs that all
@@ -2086,8 +2478,20 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
-        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let tree = tree_content.tree.clone();
+                move |_| {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree,
+                        block_height: Some(53),
+                    })
+                }
+            });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
@@ -2176,8 +2580,15 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 99);
+        base_hook
+            .expect_latest_checkpoint_at_block()
+            .once()
+            .with(mockall::predicate::eq(99))
+            .return_once({
+                let agreed_checkpoint = agreed_checkpoint.clone();
+                move |_| Ok(agreed_checkpoint)
+            });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
@@ -2231,8 +2642,23 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_latest_checkpoint().never();
         // `latest_checkpoint_at_block` takes an explicit height, so it never needs
-        // `base_hook` at all (no height resolution, no post-vote cross-check).
-        base_hook.expect_latest_checkpoint_at_block().never();
+        // height resolution -- but it still cross-checks the merged vote's winner
+        // against base_hook's own independent result.
+        base_hook
+            .expect_latest_checkpoint_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|height| {
+                Ok(CheckpointAtBlock {
+                    checkpoint: hyperlane_core::Checkpoint {
+                        merkle_tree_hook_address: H256::from_low_u64_be(11),
+                        mailbox_domain: 1337,
+                        root: H256::from_low_u64_be(33),
+                        index: 9,
+                    },
+                    block_height: Some(height),
+                })
+            });
 
         let make_hook = |root: u64, index: u64| {
             let mut hook = MockMerkleTreeHook::new();
@@ -2301,8 +2727,10 @@ mod tests {
                     block_height: None,
                 })
             });
-        // No post-vote cross-check anymore: base_hook.tree() is never called.
-        base_hook.expect_tree().never();
+        base_hook.expect_tree().once().return_once({
+            let expected_tree = expected_tree.clone();
+            move |_| Ok(expected_tree)
+        });
 
         let make_hook = |tree: IncrementalMerkleAtBlock| {
             let mut hook = MockMerkleTreeHook::new();

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -64,19 +64,19 @@ const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 /// (`resolve_quorum_target_height`).
 ///
 /// `tree()`/`latest_checkpoint()`/`latest_checkpoint_at_block()` instead run a single 2/3
-/// majority vote across `quorum_hooks`: one hook per `rpcUrls` entry (role `Primary`,
-/// always counted in the threshold, whether it succeeds or fails this round) plus one hook
-/// per `additionalQuorumRpcUrls` entry (role `Quorum`, excluded from the threshold's denominator if
-/// it fails this round — but only if at least one other `Quorum`-role entry responded, so
-/// a fully-failed quorum pool can't shrink the denominator down to a compromised
-/// `Primary`-only remainder; see `select_quorum_result`). `additionalQuorumRpcUrls` is
-/// meant to hold *additional* public RPCs on top of what's already in `rpcUrls` — it
-/// widens the vote without weakening it: a public endpoint blipping shouldn't itself
-/// block checkpoint signing, or force unanimous agreement among the rest. The merged
-/// vote's winner must also independently match what `base_hook` (`rpcUrls`'s own
-/// consensus) returns — see `require_base_hook_agreement` — so a colluding or
-/// compromised subset of the merged group (most plausibly `additionalQuorumRpcUrls`,
-/// being public) can't outvote an honest `Primary`.
+/// majority vote across `quorum_hooks`: one hook per `rpcUrls` entry (role `Primary`) plus
+/// one hook per `additionalQuorumRpcUrls` entry (role `Quorum`). The threshold's
+/// denominator is always the full configured `quorum_hooks` pool size — a failed entry,
+/// `Primary` or `Quorum`, is always counted against it, never excluded (see
+/// `select_quorum_result` for why: every "exclude an unavailable `Quorum`-role entry"
+/// heuristic tried here turned out to have a fail-open bypass). Tolerating an
+/// `additionalQuorumRpcUrls` blip therefore comes from over-provisioning the pool size
+/// (see `MIN_RECOMMENDED_QUORUM_RPCS`/`warn_if_quorum_pool_undersized`), not from
+/// excluding failures after the fact. The merged vote's winner must also independently
+/// match what `base_hook` (`rpcUrls`'s own consensus) returns — see
+/// `require_base_hook_agreement` — so a colluding or compromised subset of the merged
+/// group (most plausibly `additionalQuorumRpcUrls`, being public) can't outvote an
+/// honest `Primary`.
 #[derive(Debug)]
 struct ValidatorMultiRpcQuorumMerkleTreeHook {
     base_hook: Arc<dyn MerkleTreeHook>,
@@ -155,29 +155,25 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
 
     /// Majority vote (2/3) across `quorum_hooks`' results.
     ///
-    /// A failed `Quorum`-role RPC (a `additionalQuorumRpcUrls` entry) this round is excluded from
-    /// the threshold's denominator, regardless of whether it's public or private (e.g. 4
-    /// configured, 1 quorum-role entry down -> 2/3-of-3, not 2/3-of-4): `additionalQuorumRpcUrls` is
-    /// additional, optional coverage, so one entry blipping shouldn't by itself force
-    /// unanimous agreement among the rest, or block checkpoint signing outright. A failed
-    /// `Primary`-role RPC (an `rpcUrls` entry) always still counts against the full pool —
-    /// `rpcUrls` is the core set every validator already depends on, so its failures should
-    /// still tighten the threshold rather than being silently tolerated. A `Quorum`-role
-    /// RPC's error also never becomes the round's returned error (see `first_primary_err`
-    /// below): it's expected/tolerated, so it must never surface up through
-    /// logs/alerting the way an unexpected `Primary`-role failure would.
+    /// The threshold's denominator is always the full configured `quorum_hooks` pool
+    /// size (`self.quorum_hooks.len()`) — a failed entry, whether `Primary`-role (an
+    /// `rpcUrls` entry) or `Quorum`-role (an `additionalQuorumRpcUrls` entry), always
+    /// still counts against it and is never excluded. Earlier revisions tried excluding
+    /// unavailable `Quorum`-role entries from the denominator so a blip wouldn't force
+    /// near-unanimous agreement among the rest, gated on some cheap signal (whether at
+    /// least one, or later a 2/3 majority, of the `Quorum`-role pool responded this
+    /// round). Every such signal turned out to have a fail-open bypass: a compromised
+    /// `Primary` can manipulate the target height so only a colluding minority of
+    /// `additionalQuorumRpcUrls` answers while the honest majority correctly errors "not
+    /// found" — and response/agreement counts alone can't reliably tell that apart from
+    /// a genuine blip. Keeping the denominator fixed removes the exploit entirely:
+    /// tolerating expected `additionalQuorumRpcUrls` blips instead comes from
+    /// over-provisioning the pool size (see `MIN_RECOMMENDED_QUORUM_RPCS` /
+    /// `warn_if_quorum_pool_undersized`), not from excluding failures after the fact.
     ///
-    /// The exclusion above is only granted if at least two thirds of the `Quorum`-role
-    /// pool actually responded this round (the same 2/3 bar used everywhere else in this
-    /// function). A minority of `Quorum`-role successes is NOT enough: that's exactly the
-    /// signal a target-height manipulation attack would produce (e.g. a compromised
-    /// `Primary` picks a future/nonexistent height that only it -- and a colluding
-    /// minority of `additionalQuorumRpcUrls` entries -- can answer, while the honest
-    /// majority correctly errors "not found"). If exclusion were granted on any single
-    /// success, that colluding minority could shrink the denominator down to just
-    /// themselves plus `Primary` and trivially clear the threshold. So unless a genuine
-    /// 2/3 majority of the `Quorum`-role pool responded, its failures count against the
-    /// threshold like `Primary` failures do, rather than being excluded.
+    /// A `Quorum`-role RPC's error also never becomes the round's returned error (see
+    /// `first_primary_err` below): metrics/alerting should surface unexpected
+    /// `Primary`-role failures, not additional-quorum blips.
     fn select_quorum_result<T: Clone + Debug>(
         &self,
         results: Vec<(String, RpcRole, ChainResult<T>)>,
@@ -190,25 +186,15 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         // error (which callers log at `error!`/`warn!`, i.e. this is the one place that
         // failure could otherwise leak out).
         let mut first_primary_err = None;
-        let mut excluded_quorum_rpcs: Vec<String> = Vec::new();
+        let mut failed_quorum_rpcs: Vec<String> = Vec::new();
         let mut failed_primary_rpcs: Vec<String> = Vec::new();
-        let mut quorum_role_total = 0usize;
-        let mut quorum_role_oks = 0usize;
 
         for (label, role, result) in results {
-            if role == RpcRole::Quorum {
-                quorum_role_total = quorum_role_total.saturating_add(1);
-            }
             match result {
-                Ok(value) => {
-                    if role == RpcRole::Quorum {
-                        quorum_role_oks = quorum_role_oks.saturating_add(1);
-                    }
-                    oks.push((label, value));
-                }
+                Ok(value) => oks.push((label, value)),
                 Err(err) => {
                     if role == RpcRole::Quorum {
-                        excluded_quorum_rpcs.push(label);
+                        failed_quorum_rpcs.push(label);
                     } else {
                         failed_primary_rpcs.push(label);
                         if first_primary_err.is_none() {
@@ -226,40 +212,15 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
                 "rpcUrls entries failed this round; they still count against the quorum threshold"
             );
         }
-
-        // See the doc comment above: only shrink the denominator if the exclusion isn't
-        // itself the attack signal (i.e. a genuine 2/3 majority of the Quorum-role pool
-        // responded, not just a colluding minority).
-        let grant_quorum_exclusion = quorum_role_total == 0
-            || quorum_role_oks >= Self::two_thirds_threshold(quorum_role_total);
-        let excluded_count = if grant_quorum_exclusion {
-            excluded_quorum_rpcs.len()
-        } else {
-            0
-        };
-        let effective_pool_size = self.quorum_hooks.len().saturating_sub(excluded_count);
-        let threshold = Self::two_thirds_threshold(effective_pool_size);
-        if !excluded_quorum_rpcs.is_empty() {
-            if grant_quorum_exclusion {
-                debug!(
-                    context,
-                    excluded_quorum_rpcs = ?excluded_quorum_rpcs,
-                    effective_pool_size,
-                    threshold,
-                    "Excluding unavailable additionalQuorumRpcUrls entries from this round's quorum threshold"
-                );
-            } else {
-                warn!(
-                    context,
-                    excluded_quorum_rpcs = ?excluded_quorum_rpcs,
-                    quorum_role_oks,
-                    quorum_role_total,
-                    "Fewer than 2/3 of additionalQuorumRpcUrls entries responded this round; NOT \
-                     excluding the failures from the threshold, since that's exactly the signal \
-                     a target-height manipulation attack would produce"
-                );
-            }
+        if !failed_quorum_rpcs.is_empty() {
+            debug!(
+                context,
+                failed_quorum_rpcs = ?failed_quorum_rpcs,
+                "additionalQuorumRpcUrls entries failed this round; they still count against the quorum threshold"
+            );
         }
+
+        let threshold = Self::two_thirds_threshold(self.quorum_hooks.len());
         let mut max_agreeing = 0;
         let mut best_agreeing_rpcs: Vec<&str> = Vec::new();
 
@@ -2093,9 +2054,9 @@ mod tests {
 
     /// Regression test for a fail-open attack: if a compromised `Primary` manipulates the
     /// target height such that every honest `Quorum`-role RPC errors (e.g. "header not
-    /// found" for a fabricated future height), the `Quorum`-role pool must NOT be
-    /// excluded from the threshold -- otherwise the compromised `Primary` would trivially
-    /// "win" a 1-of-1 vote against itself.
+    /// found" for a fabricated future height), the failed `Quorum`-role entries must
+    /// still count against the (fixed) threshold -- otherwise the compromised `Primary`
+    /// would trivially "win" a 1-of-1 vote against itself.
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_fully_fails(
     ) {
@@ -2159,11 +2120,9 @@ mod tests {
     /// Regression test for a fail-open attack on *partial* Quorum-role pool failure: if a
     /// compromised `Primary` manipulates the target height such that only a colluding
     /// minority of `additionalQuorumRpcUrls` can answer (agreeing with the fabricated
-    /// value) while the honest majority correctly errors "not found", granting the
-    /// exclusion on that single colluding success would shrink the denominator down to
-    /// just the compromised `Primary` plus its accomplice and let them trivially clear
-    /// the threshold. The exclusion must require a genuine 2/3 majority of the
-    /// `Quorum`-role pool to have responded, so this round must fail to reach quorum.
+    /// value) while the honest majority correctly errors "not found", the compromised
+    /// `Primary` plus its single accomplice (2 of the fixed 4-entry denominator) must
+    /// still fall short of the 2/3 threshold, so this round must fail to reach quorum.
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_minority_colludes(
     ) {
@@ -2237,6 +2196,100 @@ mod tests {
             hook.tree(&ReorgPeriod::None).await.is_err(),
             "a colluding minority of the Quorum-role pool must not be able to shrink the \
              denominator enough to win alongside a compromised Primary"
+        );
+    }
+
+    /// Regression test for a fail-open attack where the honest `Quorum`-role majority
+    /// *responds* rather than errors, so a response-count-based exclusion signal (e.g.
+    /// "2/3 of the Quorum-role pool responded this round") would have been satisfied even
+    /// though only a minority actually agrees with the compromised `Primary`'s fabricated
+    /// value: 1 compromised `Primary` + 1 colluding `Quorum`-role entry (agrees with the
+    /// fabricated value) + 1 honest `Quorum`-role entry that answers with the correct,
+    /// different value + 1 honest `Quorum`-role entry that errors. Neither the fabricated
+    /// value (2 of the fixed 4-entry denominator) nor the honest value (1 of 4) reaches
+    /// the 2/3 threshold, so this round must fail to reach quorum.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_partially_disagrees(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        // Never reached: the merged vote fails to reach quorum before base_hook would be
+        // consulted.
+        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 42);
+
+        let fabricated_tree = {
+            let mut fabricated =
+                hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+            fabricated.ingest(H256::from_low_u64_be(1));
+            IncrementalMerkleAtBlock {
+                tree: fabricated,
+                block_height: Some(42),
+            }
+        };
+        let honest_tree = {
+            let mut honest = hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+            honest.ingest(H256::from_low_u64_be(2));
+            IncrementalMerkleAtBlock {
+                tree: honest,
+                block_height: Some(42),
+            }
+        };
+
+        let mut compromised_primary = MockMerkleTreeHook::new();
+        compromised_primary.expect_latest_checkpoint().never();
+        compromised_primary
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once({
+                let fabricated_tree = fabricated_tree.clone();
+                move |_| Ok(fabricated_tree)
+            });
+
+        let mut colluding_quorum = MockMerkleTreeHook::new();
+        colluding_quorum.expect_latest_checkpoint().never();
+        colluding_quorum
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(move |_| Ok(fabricated_tree));
+
+        let mut honest_quorum_correct = MockMerkleTreeHook::new();
+        honest_quorum_correct.expect_latest_checkpoint().never();
+        honest_quorum_correct
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(move |_| Ok(honest_tree));
+
+        let mut honest_quorum_erroring = MockMerkleTreeHook::new();
+        honest_quorum_erroring.expect_latest_checkpoint().never();
+        honest_quorum_erroring
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                primary_rpc("rpc-primary-compromised", compromised_primary),
+                quorum_rpc("rpc-quorum-colluding", colluding_quorum),
+                quorum_rpc("rpc-quorum-honest-correct", honest_quorum_correct),
+                quorum_rpc("rpc-quorum-honest-erroring", honest_quorum_erroring),
+            ],
+        };
+
+        assert!(
+            hook.tree(&ReorgPeriod::None).await.is_err(),
+            "a compromised Primary plus a single colluding Quorum-role entry must not be \
+             able to win just because a majority of the Quorum-role pool responded -- they \
+             must also agree with the winning candidate"
         );
     }
 
@@ -2386,12 +2439,14 @@ mod tests {
         );
     }
 
-    /// 4 configured `quorum_hooks`, 1 public RPC down this round -> excluded from the
-    /// threshold, leaving an effective pool of 3 (threshold 2). Of the 3 responders, only
-    /// 2 agree (the third disagrees) -- still enough to reach the reduced threshold, even
-    /// though it wouldn't reach the un-excluded threshold of 3.
+    /// 4 configured `quorum_hooks`, 1 `Quorum`-role RPC down this round. Unlike earlier
+    /// revisions, a down `Quorum`-role entry is NOT excluded from the threshold's
+    /// denominator (same treatment as a down `Primary`-role entry) -- see
+    /// `select_quorum_result`'s doc comment for why. The threshold stays at
+    /// ceil(2*4/3) = 3; only 2 of the 3 responders agree (the third disagrees), so
+    /// quorum is not reached.
     #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_excludes_down_quorum_role_rpc_from_threshold(
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_does_not_exclude_down_quorum_role_rpc_from_threshold(
     ) {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
         let expected_tree = IncrementalMerkleAtBlock {
@@ -2409,16 +2464,10 @@ mod tests {
         let mut base_hook = MockMerkleTreeHook::new();
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
+        // Never reached: the quorum_hooks vote fails before base_hook would be consulted.
+        base_hook.expect_tree_at_block().never();
         base_hook.expect_latest_checkpoint_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-        base_hook
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let expected_tree = expected_tree.clone();
-                move |_| Ok(expected_tree)
-            });
 
         let mut quorum_down = MockMerkleTreeHook::new();
         quorum_down.expect_latest_checkpoint().never();
@@ -2465,10 +2514,7 @@ mod tests {
             ],
         };
 
-        assert_eq!(
-            hook.tree(&ReorgPeriod::None).await.unwrap().block_height,
-            Some(50)
-        );
+        assert!(hook.tree(&ReorgPeriod::None).await.is_err());
     }
 
     /// Same 4-hook, 1-down, 1-disagreeing shape as the test above, except the down RPC is

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -167,15 +167,17 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     /// below): it's expected/tolerated, so it must never surface up through
     /// logs/alerting the way an unexpected `Primary`-role failure would.
     ///
-    /// The exclusion above is only granted if at least one `Quorum`-role entry actually
-    /// responded this round. If *every* `Quorum`-role entry fails simultaneously, that's
-    /// not "one entry blipping" — it's exactly the signal a target-height manipulation
-    /// attack would produce (e.g. a compromised `Primary` picks a future/nonexistent
-    /// height that only it can answer, and every honest `additionalQuorumRpcUrls` entry
-    /// correctly errors "not found"). Letting the denominator shrink to just the
-    /// `Primary` pool in that case would let a compromised `Primary` win by default. So
-    /// a fully-failed `Quorum`-role pool counts against the threshold like `Primary`
-    /// failures do, rather than being excluded.
+    /// The exclusion above is only granted if at least two thirds of the `Quorum`-role
+    /// pool actually responded this round (the same 2/3 bar used everywhere else in this
+    /// function). A minority of `Quorum`-role successes is NOT enough: that's exactly the
+    /// signal a target-height manipulation attack would produce (e.g. a compromised
+    /// `Primary` picks a future/nonexistent height that only it -- and a colluding
+    /// minority of `additionalQuorumRpcUrls` entries -- can answer, while the honest
+    /// majority correctly errors "not found"). If exclusion were granted on any single
+    /// success, that colluding minority could shrink the denominator down to just
+    /// themselves plus `Primary` and trivially clear the threshold. So unless a genuine
+    /// 2/3 majority of the `Quorum`-role pool responded, its failures count against the
+    /// threshold like `Primary` failures do, rather than being excluded.
     fn select_quorum_result<T: Clone + Debug>(
         &self,
         results: Vec<(String, RpcRole, ChainResult<T>)>,
@@ -226,8 +228,10 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         }
 
         // See the doc comment above: only shrink the denominator if the exclusion isn't
-        // itself the attack signal (i.e. at least one Quorum-role entry responded).
-        let grant_quorum_exclusion = quorum_role_total == 0 || quorum_role_oks > 0;
+        // itself the attack signal (i.e. a genuine 2/3 majority of the Quorum-role pool
+        // responded, not just a colluding minority).
+        let grant_quorum_exclusion = quorum_role_total == 0
+            || quorum_role_oks >= Self::two_thirds_threshold(quorum_role_total);
         let excluded_count = if grant_quorum_exclusion {
             excluded_quorum_rpcs.len()
         } else {
@@ -248,9 +252,11 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
                 warn!(
                     context,
                     excluded_quorum_rpcs = ?excluded_quorum_rpcs,
-                    "Every responding additionalQuorumRpcUrls entry failed this round; NOT \
-                     excluding them from the threshold, since a fully-failed quorum pool is \
-                     exactly the signal a target-height manipulation attack would produce"
+                    quorum_role_oks,
+                    quorum_role_total,
+                    "Fewer than 2/3 of additionalQuorumRpcUrls entries responded this round; NOT \
+                     excluding the failures from the threshold, since that's exactly the signal \
+                     a target-height manipulation attack would produce"
                 );
             }
         }
@@ -2147,6 +2153,90 @@ mod tests {
         assert!(
             hook.tree(&ReorgPeriod::None).await.is_err(),
             "a fully-failed Quorum-role pool must not let a lone Primary win by default"
+        );
+    }
+
+    /// Regression test for a fail-open attack on *partial* Quorum-role pool failure: if a
+    /// compromised `Primary` manipulates the target height such that only a colluding
+    /// minority of `additionalQuorumRpcUrls` can answer (agreeing with the fabricated
+    /// value) while the honest majority correctly errors "not found", granting the
+    /// exclusion on that single colluding success would shrink the denominator down to
+    /// just the compromised `Primary` plus its accomplice and let them trivially clear
+    /// the threshold. The exclusion must require a genuine 2/3 majority of the
+    /// `Quorum`-role pool to have responded, so this round must fail to reach quorum.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_minority_colludes(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        // Never reached: the merged vote fails to reach quorum before base_hook would be
+        // consulted.
+        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 42);
+
+        let fabricated_tree = {
+            let mut fabricated =
+                hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+            fabricated.ingest(H256::from_low_u64_be(1));
+            IncrementalMerkleAtBlock {
+                tree: fabricated,
+                block_height: Some(42),
+            }
+        };
+
+        let mut compromised_primary = MockMerkleTreeHook::new();
+        compromised_primary.expect_latest_checkpoint().never();
+        compromised_primary
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once({
+                let fabricated_tree = fabricated_tree.clone();
+                move |_| Ok(fabricated_tree)
+            });
+
+        let mut colluding_quorum = MockMerkleTreeHook::new();
+        colluding_quorum.expect_latest_checkpoint().never();
+        colluding_quorum
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(move |_| Ok(fabricated_tree));
+
+        let mut honest_quorum_a = MockMerkleTreeHook::new();
+        honest_quorum_a.expect_latest_checkpoint().never();
+        honest_quorum_a
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
+
+        let mut honest_quorum_b = MockMerkleTreeHook::new();
+        honest_quorum_b.expect_latest_checkpoint().never();
+        honest_quorum_b
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(42))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                primary_rpc("rpc-primary-compromised", compromised_primary),
+                quorum_rpc("rpc-quorum-colluding", colluding_quorum),
+                quorum_rpc("rpc-quorum-honest-a", honest_quorum_a),
+                quorum_rpc("rpc-quorum-honest-b", honest_quorum_b),
+            ],
+        };
+
+        assert!(
+            hook.tree(&ReorgPeriod::None).await.is_err(),
+            "a colluding minority of the Quorum-role pool must not be able to shrink the \
+             denominator enough to win alongside a compromised Primary"
         );
     }
 

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -53,49 +53,25 @@ const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
 /// can't stall a safety-critical read (and therefore checkpoint signing) indefinitely.
 const QUORUM_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Below this, the combined `rpcUrls` + `additionalQuorumRpcUrls` pool gives little to no real
-/// protection: with 1 entry any value trivially reaches quorum, and with 2 entries all
-/// must unanimously agree.
+/// Below this, the combined `rpcUrls` + `additionalQuorumRpcUrls` pool gives little to no
+/// real protection: with 1 entry any value trivially reaches quorum, and with 2 entries
+/// all must unanimously agree.
 const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 
 /// `count()`/domain/address come from `base_hook` (the normal `rpcUrls` connection, using
-/// whatever consensus mode it's configured with). `base_hook` is also used to resolve a
-/// canonical block height that every vote below is pinned to
-/// (`resolve_quorum_target_height`).
-///
-/// `tree()`/`latest_checkpoint()`/`latest_checkpoint_at_block()` instead run a single 2/3
-/// majority vote across `quorum_hooks`: one hook per `rpcUrls` entry (role `Primary`) plus
-/// one hook per `additionalQuorumRpcUrls` entry (role `Quorum`). The threshold's
-/// denominator is always the full configured `quorum_hooks` pool size — a failed entry,
-/// `Primary` or `Quorum`, is always counted against it, never excluded (see
-/// `select_quorum_result` for why: every "exclude an unavailable `Quorum`-role entry"
-/// heuristic tried here turned out to have a fail-open bypass). Tolerating an
-/// `additionalQuorumRpcUrls` blip therefore comes from over-provisioning the pool size
-/// (see `MIN_RECOMMENDED_QUORUM_RPCS`/`warn_if_quorum_pool_undersized`), not from
-/// excluding failures after the fact. The merged vote's winner must also independently
-/// match what `base_hook` (`rpcUrls`'s own consensus) returns — see
-/// `require_base_hook_agreement` — so a colluding or compromised subset of the merged
-/// group (most plausibly `additionalQuorumRpcUrls`, being public) can't outvote an
-/// honest `Primary`.
+/// whatever consensus mode it's configured with). `tree()`/`latest_checkpoint()`/
+/// `latest_checkpoint_at_block()` require BOTH: a 2/3 majority across `quorum_hooks` (one
+/// entry per `rpcUrls` URL plus one per `additionalQuorumRpcUrls` URL, independent of each
+/// other), AND that majority-agreed value to match what `base_hook` independently
+/// returns. An attacker needs to compromise both the merged vote and `rpcUrls`' own
+/// consensus at once to force a wrong value through.
 #[derive(Debug)]
 struct ValidatorMultiRpcQuorumMerkleTreeHook {
     base_hook: Arc<dyn MerkleTreeHook>,
-    quorum_hooks: Vec<QuorumHook>,
-}
-
-/// A single per-URL vote in the merged `rpcUrls` + `additionalQuorumRpcUrls` quorum group.
-#[derive(Debug, Clone)]
-struct QuorumHook {
-    /// `rpcUrls[i]`/`additionalQuorumRpcUrls[i]` index label (0-based), not the host/URL itself —
-    /// some entries may be private RPCs, so logging which one disagreed must never reveal
-    /// which URL/provider that is.
-    label: String,
-    /// Whether this came from `rpcUrls` (`Primary`) or `additionalQuorumRpcUrls` (`Quorum`) — also
-    /// tags the underlying connection's `rpc_role` Prometheus label, so `Quorum`-role
-    /// failures (expected/tolerated) can be distinguished from `Primary`-role ones in
-    /// metrics/alerting.
-    role: RpcRole,
-    hook: Arc<dyn MerkleTreeHook>,
+    /// Paired with an `rpcUrls[i]`/`additionalQuorumRpcUrls[i]` index label (0-based), not
+    /// the host/URL itself — some entries may be private RPCs, so logging which one
+    /// disagreed must never reveal which URL/provider that is.
+    quorum_hooks: Vec<(String, Arc<dyn MerkleTreeHook>)>,
 }
 
 impl ValidatorMultiRpcQuorumMerkleTreeHook {
@@ -154,70 +130,24 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     }
 
     /// Majority vote (2/3) across `quorum_hooks`' results.
-    ///
-    /// The threshold's denominator is always the full configured `quorum_hooks` pool
-    /// size (`self.quorum_hooks.len()`) — a failed entry, whether `Primary`-role (an
-    /// `rpcUrls` entry) or `Quorum`-role (an `additionalQuorumRpcUrls` entry), always
-    /// still counts against it and is never excluded. Earlier revisions tried excluding
-    /// unavailable `Quorum`-role entries from the denominator so a blip wouldn't force
-    /// near-unanimous agreement among the rest, gated on some cheap signal (whether at
-    /// least one, or later a 2/3 majority, of the `Quorum`-role pool responded this
-    /// round). Every such signal turned out to have a fail-open bypass: a compromised
-    /// `Primary` can manipulate the target height so only a colluding minority of
-    /// `additionalQuorumRpcUrls` answers while the honest majority correctly errors "not
-    /// found" — and response/agreement counts alone can't reliably tell that apart from
-    /// a genuine blip. Keeping the denominator fixed removes the exploit entirely:
-    /// tolerating expected `additionalQuorumRpcUrls` blips instead comes from
-    /// over-provisioning the pool size (see `MIN_RECOMMENDED_QUORUM_RPCS` /
-    /// `warn_if_quorum_pool_undersized`), not from excluding failures after the fact.
-    ///
-    /// A `Quorum`-role RPC's error also never becomes the round's returned error (see
-    /// `first_primary_err` below): metrics/alerting should surface unexpected
-    /// `Primary`-role failures, not additional-quorum blips.
     fn select_quorum_result<T: Clone + Debug>(
         &self,
-        results: Vec<(String, RpcRole, ChainResult<T>)>,
+        results: Vec<(String, ChainResult<T>)>,
         matches: impl Fn(&T, &T) -> bool,
         context: &str,
     ) -> ChainResult<T> {
         let mut oks: Vec<(String, T)> = Vec::new();
-        // Only ever populated from a Primary-role failure: a Quorum-role entry failing is
-        // expected/tolerated, so its error must never surface as the round's returned
-        // error (which callers log at `error!`/`warn!`, i.e. this is the one place that
-        // failure could otherwise leak out).
-        let mut first_primary_err = None;
-        let mut failed_quorum_rpcs: Vec<String> = Vec::new();
-        let mut failed_primary_rpcs: Vec<String> = Vec::new();
+        let mut first_err = None;
 
-        for (label, role, result) in results {
+        for (label, result) in results {
             match result {
                 Ok(value) => oks.push((label, value)),
                 Err(err) => {
-                    if role == RpcRole::Quorum {
-                        failed_quorum_rpcs.push(label);
-                    } else {
-                        failed_primary_rpcs.push(label);
-                        if first_primary_err.is_none() {
-                            first_primary_err = Some(err);
-                        }
+                    if first_err.is_none() {
+                        first_err = Some(err);
                     }
                 }
             }
-        }
-
-        if !failed_primary_rpcs.is_empty() {
-            warn!(
-                context,
-                failed_primary_rpcs = ?failed_primary_rpcs,
-                "rpcUrls entries failed this round; they still count against the quorum threshold"
-            );
-        }
-        if !failed_quorum_rpcs.is_empty() {
-            debug!(
-                context,
-                failed_quorum_rpcs = ?failed_quorum_rpcs,
-                "additionalQuorumRpcUrls entries failed this round; they still count against the quorum threshold"
-            );
         }
 
         let threshold = Self::two_thirds_threshold(self.quorum_hooks.len());
@@ -259,11 +189,9 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         }
 
         if oks.is_empty() {
-            // Prefer a Primary-role RPC's error; if every quorum_hooks entry that failed
-            // was Quorum-role, fall back to a generic message rather than surfacing that
-            // RPC's error verbatim.
-            return Err(first_primary_err
-                .unwrap_or_else(|| ChainCommunicationError::from_other_str(context)));
+            return Err(
+                first_err.unwrap_or_else(|| ChainCommunicationError::from_other_str(context))
+            );
         }
 
         let responding_rpcs: Vec<&str> = oks.iter().map(|(label, _)| label.as_str()).collect();
@@ -288,10 +216,8 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     /// (`rpcUrls`, whatever consensus mode it's configured with) independently returns.
     /// Guards against a colluding or compromised subset of the merged vote — most
     /// plausibly the less-trusted `additionalQuorumRpcUrls` entries — outvoting an
-    /// honest `Primary`: e.g. 1 honest `rpcUrls` entry plus 2 colluding public
-    /// `additionalQuorumRpcUrls` entries reach the overall 2/3 threshold on the public
-    /// pair's value alone. An attacker now also has to compromise `rpcUrls`' own
-    /// consensus to force a wrong value through.
+    /// honest `rpcUrls`: an attacker also has to compromise `rpcUrls`' own consensus to
+    /// force a wrong value through.
     fn require_base_hook_agreement<T: Debug>(
         quorum_result: &T,
         base_result: &T,
@@ -318,11 +244,10 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
     async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
         if let Some(height) = self.resolve_quorum_target_height(reorg_period).await? {
             let results = join_all(self.quorum_hooks.iter().cloned().map(
-                |quorum_hook| async move {
+                |(label, hook)| async move {
                     (
-                        quorum_hook.label,
-                        quorum_hook.role,
-                        Self::with_call_timeout(quorum_hook.hook.tree_at_block(height)).await,
+                        label,
+                        Self::with_call_timeout(hook.tree_at_block(height)).await,
                     )
                 },
             ))
@@ -342,13 +267,12 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             return Ok(quorum_result);
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|quorum_hook| {
+        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    quorum_hook.label,
-                    quorum_hook.role,
-                    Self::with_call_timeout(quorum_hook.hook.tree(&reorg_period)).await,
+                    label,
+                    Self::with_call_timeout(hook.tree(&reorg_period)).await,
                 )
             }
         }))
@@ -380,14 +304,12 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             return self.latest_checkpoint_at_block(height).await;
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|quorum_hook| {
+        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    quorum_hook.label,
-                    quorum_hook.role,
-                    Self::with_call_timeout(quorum_hook.hook.latest_checkpoint(&reorg_period))
-                        .await,
+                    label,
+                    Self::with_call_timeout(hook.latest_checkpoint(&reorg_period)).await,
                 )
             }
         }))
@@ -412,14 +334,10 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             self.quorum_hooks
                 .iter()
                 .cloned()
-                .map(|quorum_hook| async move {
+                .map(|(label, hook)| async move {
                     (
-                        quorum_hook.label,
-                        quorum_hook.role,
-                        Self::with_call_timeout(
-                            quorum_hook.hook.latest_checkpoint_at_block(height),
-                        )
-                        .await,
+                        label,
+                        Self::with_call_timeout(hook.latest_checkpoint_at_block(height)).await,
                     )
                 }),
         )
@@ -611,7 +529,7 @@ impl BaseAgent for Validator {
         let reorg_reporter = Arc::new(reorg_reporter_with_storage_writer) as Arc<dyn ReorgReporter>;
 
         let origin_chain_conf = core.settings.chain_setup(&settings.origin_chain)?.clone();
-        let additional_quorum_rpc_urls: Vec<(Url, bool)> = Self::dedupe_additional_quorum_rpc_urls(
+        let additional_quorum_rpc_urls: Vec<Url> = Self::dedupe_additional_quorum_rpc_urls(
             settings
                 .additional_quorum_rpcs
                 .iter()
@@ -621,7 +539,6 @@ impl BaseAgent for Validator {
                     // an API key, and a parse failure (e.g. a typo) is exactly the case
                     // where the URL is most likely to end up copied verbatim into logs.
                     Url::parse(&rpc.url)
-                        .map(|url| (url, rpc.public))
                         .map_err(|err| eyre!("Invalid additionalQuorumRpcUrls[{i}] entry: {err}"))
                 })
                 .collect::<Result<_>>()?,
@@ -633,27 +550,19 @@ impl BaseAgent for Validator {
             &origin_chain_conf,
             &additional_quorum_rpc_urls,
         ) {
-            // `rpcUrls` (`primary_rpc_urls` below) votes alongside `additionalQuorumRpcUrls` in the
-            // same 2/3 quorum group (see `ValidatorMultiRpcQuorumMerkleTreeHook`), so
-            // `additionalQuorumRpcUrls` only needs to add public endpoints on top of it.
-            //
-            // Read directly from `origin_chain_conf.connection` rather than `settings.rpcs`:
-            // `settings.rpcs` also comingles `grpcUrls`/`walletUrls`/`walletSolidityUrls`
-            // entries (used for non-Ethereum chains), which would otherwise leak into the
-            // `Primary` vote pool as URLs that can never successfully serve an Ethereum
-            // JSON-RPC read, spuriously tightening the threshold every round.
+            // `rpcUrls` votes alongside `additionalQuorumRpcUrls` in the same 2/3 quorum
+            // group (see `ValidatorMultiRpcQuorumMerkleTreeHook`), so `additionalQuorumRpcUrls`
+            // only needs to add public endpoints on top of it. Read the URLs directly from
+            // `origin_chain_conf.connection` rather than `settings.rpcs`, which also
+            // comingles `grpcUrls`/`walletUrls`/`walletSolidityUrls` (non-Ethereum chains).
             let primary_rpc_urls: Vec<Url> = Self::primary_rpc_urls(&origin_chain_conf);
-            let additional_quorum_rpc_urls =
-                Self::dedupe_additional_quorum_rpc_urls_against_primary(
-                    &primary_rpc_urls,
-                    additional_quorum_rpc_urls,
-                );
-            Self::warn_if_additional_quorum_rpc_not_public(&additional_quorum_rpc_urls);
-            Self::warn_if_quorum_pool_undersized(
-                primary_rpc_urls.len(),
-                additional_quorum_rpc_urls.len(),
-            );
-            Self::warn_if_duplicate_hosts(&primary_rpc_urls, &additional_quorum_rpc_urls);
+            let combined_urls: Vec<Url> = primary_rpc_urls
+                .iter()
+                .chain(additional_quorum_rpc_urls.iter())
+                .cloned()
+                .collect();
+            Self::warn_if_quorum_pool_undersized(&combined_urls);
+            Self::warn_if_duplicate_hosts(&combined_urls);
             Self::build_validator_quorum_merkle_tree_hook(
                 &origin_chain_conf,
                 &primary_rpc_urls,
@@ -827,7 +736,7 @@ impl Validator {
     /// Opt-in: only true for Ethereum with a non-empty `additionalQuorumRpcUrls`.
     fn validator_uses_split_quorum_hook(
         origin_chain_conf: &ChainConf,
-        additional_quorum_rpc_urls: &[(Url, bool)],
+        additional_quorum_rpc_urls: &[Url],
     ) -> bool {
         !additional_quorum_rpc_urls.is_empty()
             && matches!(
@@ -839,12 +748,12 @@ impl Validator {
     /// Removes exact duplicate URLs (order-preserving). A duplicated endpoint would
     /// otherwise count as two independent votes, undermining the quorum's independence
     /// assumption.
-    fn dedupe_additional_quorum_rpc_urls(urls: Vec<(Url, bool)>) -> Vec<(Url, bool)> {
+    fn dedupe_additional_quorum_rpc_urls(urls: Vec<Url>) -> Vec<Url> {
         let original_count = urls.len();
         let mut seen = HashSet::new();
-        let deduped: Vec<(Url, bool)> = urls
+        let deduped: Vec<Url> = urls
             .into_iter()
-            .filter(|(url, _)| seen.insert(url.clone()))
+            .filter(|url| seen.insert(url.clone()))
             .collect();
         if deduped.len() < original_count {
             warn!(
@@ -856,99 +765,39 @@ impl Validator {
         deduped
     }
 
-    /// Removes any `additionalQuorumRpcUrls` entry whose URL is already in `rpcUrls`.
-    /// Since both pools now vote together (see `ValidatorMultiRpcQuorumMerkleTreeHook`),
-    /// keeping such a duplicate would cast two votes for what's really one provider,
-    /// undermining the vote's independence assumption exactly like an in-pool duplicate
-    /// would — `dedupe_additional_quorum_rpc_urls` only catches duplicates *within*
-    /// `additionalQuorumRpcUrls`, not across the two pools.
-    fn dedupe_additional_quorum_rpc_urls_against_primary(
-        primary_rpc_urls: &[Url],
-        additional_quorum_rpc_urls: Vec<(Url, bool)>,
-    ) -> Vec<(Url, bool)> {
-        let primary_set: HashSet<&Url> = primary_rpc_urls.iter().collect();
-        let original_count = additional_quorum_rpc_urls.len();
-        let deduped: Vec<(Url, bool)> = additional_quorum_rpc_urls
-            .into_iter()
-            .filter(|(url, _)| !primary_set.contains(url))
-            .collect();
-        if deduped.len() < original_count {
-            warn!(
-                original_count,
-                deduped_count = deduped.len(),
-                "additionalQuorumRpcUrls contained entries already present in rpcUrls; \
-                 removing them to preserve vote independence"
-            );
-        }
-        deduped
-    }
-
     /// Warns (doesn't reject: distinct accounts/API keys on the same provider are a
-    /// legitimate choice) when multiple entries across `rpcUrls` and `additionalQuorumRpcUrls`
-    /// combined share a host, grouped by label rather than the host itself so the log
-    /// never reveals which provider it is. Both pools vote together (see
-    /// `ValidatorMultiRpcQuorumMerkleTreeHook`), so a host shared between them casts 2
-    /// votes for what's really one provider — the same independence concern as a
-    /// duplicate within a single pool.
-    fn warn_if_duplicate_hosts(
-        primary_rpc_urls: &[Url],
-        additional_quorum_rpc_urls: &[(Url, bool)],
-    ) {
-        let mut indices_by_host: HashMap<Option<&str>, Vec<String>> = HashMap::new();
-        for (i, url) in primary_rpc_urls.iter().enumerate() {
-            indices_by_host
-                .entry(url.host_str())
-                .or_default()
-                .push(format!("rpcUrls[{i}]"));
+    /// legitimate choice) when multiple entries across the combined `rpcUrls` +
+    /// `additionalQuorumRpcUrls` pool share a host, grouped by index rather than the host
+    /// itself so the log never reveals which provider it is. Exact-URL dedup alone misses
+    /// this: different paths/API keys on the same host still share a failure domain (one
+    /// provider outage or compromise counts as N votes).
+    fn warn_if_duplicate_hosts(quorum_rpc_urls: &[Url]) {
+        let mut indices_by_host: HashMap<Option<&str>, Vec<usize>> = HashMap::new();
+        for (i, url) in quorum_rpc_urls.iter().enumerate() {
+            indices_by_host.entry(url.host_str()).or_default().push(i);
         }
-        for (i, (url, _)) in additional_quorum_rpc_urls.iter().enumerate() {
-            indices_by_host
-                .entry(url.host_str())
-                .or_default()
-                .push(format!("additionalQuorumRpcUrls[{i}]"));
-        }
-        let repeated_host_groups: Vec<Vec<String>> = indices_by_host
+        let repeated_host_groups: Vec<Vec<usize>> = indices_by_host
             .into_values()
-            .filter(|labels| labels.len() > 1)
+            .filter(|indices| indices.len() > 1)
             .collect();
         if !repeated_host_groups.is_empty() {
             warn!(
                 ?repeated_host_groups,
-                "rpcUrls/additionalQuorumRpcUrls have multiple entries (by label) sharing a host; they \
-                 likely share a failure domain, weakening the independence the vote relies on"
+                "rpcUrls/additionalQuorumRpcUrls have multiple entries (by index) sharing a host; \
+                 they likely share a failure domain, weakening the independence the vote relies on"
             );
         }
     }
 
-    /// Warns if the combined `rpcUrls` + `additionalQuorumRpcUrls` pool is too small to provide
-    /// meaningful protection.
-    fn warn_if_quorum_pool_undersized(primary_count: usize, quorum_count: usize) {
-        let total = primary_count.saturating_add(quorum_count);
-        if total < MIN_RECOMMENDED_QUORUM_RPCS {
+    /// Warns if the combined `rpcUrls` + `additionalQuorumRpcUrls` pool is too small to
+    /// provide meaningful protection.
+    fn warn_if_quorum_pool_undersized(quorum_rpc_urls: &[Url]) {
+        if quorum_rpc_urls.len() < MIN_RECOMMENDED_QUORUM_RPCS {
             warn!(
-                primary_count,
-                quorum_count,
-                total,
+                quorum_rpc_count = quorum_rpc_urls.len(),
                 recommended_minimum = MIN_RECOMMENDED_QUORUM_RPCS,
-                "the combined rpcUrls + additionalQuorumRpcUrls pool has very few entries and provides \
-                 little to no real protection; consider adding more additionalQuorumRpcUrls entries"
-            );
-        }
-    }
-
-    /// Recommends `additionalQuorumRpcUrls` be used for *additional* public RPCs only: it now votes
-    /// alongside `rpcUrls` (which already covers the private endpoints), so a private
-    /// `additionalQuorumRpcUrls` entry just duplicates coverage `rpcUrls` already provides.
-    fn warn_if_additional_quorum_rpc_not_public(additional_quorum_rpc_urls: &[(Url, bool)]) {
-        let non_public_count = additional_quorum_rpc_urls
-            .iter()
-            .filter(|(_, public)| !public)
-            .count();
-        if non_public_count > 0 {
-            warn!(
-                non_public_count,
-                "additionalQuorumRpcUrls contains non-public entries; it's intended for additional \
-                 public RPCs only — private endpoints are already covered via rpcUrls"
+                "the combined rpcUrls + additionalQuorumRpcUrls pool has very few entries and \
+                 provides little to no real protection; consider adding more additionalQuorumRpcUrls entries"
             );
         }
     }
@@ -956,7 +805,7 @@ impl Validator {
     async fn build_validator_quorum_merkle_tree_hook(
         origin_chain_conf: &ChainConf,
         primary_rpc_urls: &[Url],
-        additional_quorum_rpc_urls: &[(Url, bool)],
+        additional_quorum_rpc_urls: &[Url],
         metrics: &CoreMetrics,
     ) -> ChainResult<Box<dyn MerkleTreeHook>> {
         let base_hook = origin_chain_conf.build_merkle_tree_hook(metrics).await?;
@@ -968,16 +817,12 @@ impl Validator {
             metrics,
         )
         .await?;
-        let quorum_only_urls: Vec<Url> = additional_quorum_rpc_urls
-            .iter()
-            .map(|(url, _)| url.clone())
-            .collect();
         quorum_hooks.extend(
             Self::build_validator_ethereum_per_url_hooks(
                 origin_chain_conf,
                 "additionalQuorumRpcUrls",
                 RpcRole::Quorum,
-                &quorum_only_urls,
+                additional_quorum_rpc_urls,
                 metrics,
             )
             .await?,
@@ -989,9 +834,8 @@ impl Validator {
     }
 
     /// The actual URLs `base_hook` (`rpcUrls`) is configured with, read directly from
-    /// `origin_chain_conf.connection` rather than `settings.rpcs` (see the call site for
-    /// why). Returns empty for a non-Ethereum connection; callers only reach this after
-    /// `validator_uses_split_quorum_hook` has already confirmed it's Ethereum.
+    /// `origin_chain_conf.connection` rather than `settings.rpcs` (which also comingles
+    /// `grpcUrls`/`walletUrls`/`walletSolidityUrls`, used for non-Ethereum chains).
     fn primary_rpc_urls(origin_chain_conf: &ChainConf) -> Vec<Url> {
         let ChainConnectionConf::Ethereum(conn) = &origin_chain_conf.connection else {
             return Vec::new();
@@ -1019,26 +863,20 @@ impl Validator {
 
     /// Builds one single-URL `MerkleTreeHook` per entry in `urls`, labeled
     /// `{label_prefix}[i]` (by index, never by host/URL — some entries may be private
-    /// RPCs, and even a redacted host can identify the provider, e.g. "alchemy.com", so
-    /// disagreement logs must never carry anything derived from the URL itself) and
-    /// tagged with `role` (both for `select_quorum_result`'s threshold logic and the
-    /// underlying connection's `rpc_role` Prometheus label).
+    /// RPCs, and even a redacted host can identify the provider, e.g. "alchemy.com") and
+    /// tagged with `role` for the underlying connection's `rpc_role` Prometheus label.
     async fn build_validator_ethereum_per_url_hooks(
         origin_chain_conf: &ChainConf,
         label_prefix: &str,
         role: RpcRole,
         urls: &[Url],
         metrics: &CoreMetrics,
-    ) -> ChainResult<Vec<QuorumHook>> {
+    ) -> ChainResult<Vec<(String, Arc<dyn MerkleTreeHook>)>> {
         let hooks = try_join_all(urls.iter().cloned().enumerate().map(|(i, url)| async move {
             Self::ethereum_chain_conf_for_url(origin_chain_conf, url, role)
                 .build_merkle_tree_hook(metrics)
                 .await
-                .map(|hook| QuorumHook {
-                    label: format!("{label_prefix}[{i}]"),
-                    role,
-                    hook: Arc::from(hook),
-                })
+                .map(|hook| (format!("{label_prefix}[{i}]"), Arc::from(hook)))
         }))
         .await?;
 
@@ -1371,20 +1209,20 @@ mod tests {
             &[]
         ));
 
-        let quorum_urls = vec![(Url::parse("http://quorum-a.example").unwrap(), false)];
+        let additional_quorum_urls = vec![Url::parse("http://quorum-a.example").unwrap()];
         assert!(Validator::validator_uses_split_quorum_hook(
             &chain_conf,
-            &quorum_urls
+            &additional_quorum_urls
         ));
     }
 
     #[test]
     fn dedupe_additional_quorum_rpc_urls_removes_exact_duplicates_preserving_order() {
         let urls = vec![
-            (Url::parse("http://rpc-a.example").unwrap(), false),
-            (Url::parse("http://rpc-b.example").unwrap(), true),
-            (Url::parse("http://rpc-a.example").unwrap(), false),
-            (Url::parse("http://rpc-c.example").unwrap(), true),
+            Url::parse("http://rpc-a.example").unwrap(),
+            Url::parse("http://rpc-b.example").unwrap(),
+            Url::parse("http://rpc-a.example").unwrap(),
+            Url::parse("http://rpc-c.example").unwrap(),
         ];
 
         let deduped = Validator::dedupe_additional_quorum_rpc_urls(urls);
@@ -1392,9 +1230,9 @@ mod tests {
         assert_eq!(
             deduped,
             vec![
-                (Url::parse("http://rpc-a.example").unwrap(), false),
-                (Url::parse("http://rpc-b.example").unwrap(), true),
-                (Url::parse("http://rpc-c.example").unwrap(), true),
+                Url::parse("http://rpc-a.example").unwrap(),
+                Url::parse("http://rpc-b.example").unwrap(),
+                Url::parse("http://rpc-c.example").unwrap(),
             ]
         );
     }
@@ -1402,53 +1240,13 @@ mod tests {
     #[test]
     fn dedupe_additional_quorum_rpc_urls_is_noop_without_duplicates() {
         let urls = vec![
-            (Url::parse("http://rpc-a.example").unwrap(), false),
-            (Url::parse("http://rpc-b.example").unwrap(), true),
+            Url::parse("http://rpc-a.example").unwrap(),
+            Url::parse("http://rpc-b.example").unwrap(),
         ];
 
         let deduped = Validator::dedupe_additional_quorum_rpc_urls(urls.clone());
 
         assert_eq!(deduped, urls);
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn dedupe_additional_quorum_rpc_urls_against_primary_removes_shared_url() {
-        let primary_urls = vec![Url::parse("http://rpc-a.example").unwrap()];
-        let additional_urls = vec![
-            (Url::parse("http://rpc-a.example").unwrap(), true),
-            (Url::parse("http://rpc-b.example").unwrap(), true),
-        ];
-
-        let deduped = Validator::dedupe_additional_quorum_rpc_urls_against_primary(
-            &primary_urls,
-            additional_urls,
-        );
-
-        assert_eq!(
-            deduped,
-            vec![(Url::parse("http://rpc-b.example").unwrap(), true)]
-        );
-        assert!(logs_contain(
-            "additionalQuorumRpcUrls contained entries already present in rpcUrls"
-        ));
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn dedupe_additional_quorum_rpc_urls_against_primary_is_noop_when_disjoint() {
-        let primary_urls = vec![Url::parse("http://rpc-a.example").unwrap()];
-        let additional_urls = vec![(Url::parse("http://rpc-b.example").unwrap(), true)];
-
-        let deduped = Validator::dedupe_additional_quorum_rpc_urls_against_primary(
-            &primary_urls,
-            additional_urls.clone(),
-        );
-
-        assert_eq!(deduped, additional_urls);
-        assert!(!logs_contain(
-            "additionalQuorumRpcUrls contained entries already present in rpcUrls"
-        ));
     }
 
     #[test]
@@ -1476,7 +1274,9 @@ mod tests {
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_quorum_pool_undersized_warns_below_minimum() {
-        Validator::warn_if_quorum_pool_undersized(1, 0);
+        let urls = vec![Url::parse("http://rpc-a.example").unwrap()];
+
+        Validator::warn_if_quorum_pool_undersized(&urls);
 
         assert!(logs_contain(
             "combined rpcUrls + additionalQuorumRpcUrls pool has very few entries"
@@ -1486,7 +1286,13 @@ mod tests {
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_quorum_pool_undersized_silent_at_or_above_minimum() {
-        Validator::warn_if_quorum_pool_undersized(1, 2);
+        let urls = vec![
+            Url::parse("http://rpc-a.example").unwrap(),
+            Url::parse("http://rpc-b.example").unwrap(),
+            Url::parse("http://rpc-c.example").unwrap(),
+        ];
+
+        Validator::warn_if_quorum_pool_undersized(&urls);
 
         assert!(!logs_contain(
             "combined rpcUrls + additionalQuorumRpcUrls pool has very few entries"
@@ -1495,60 +1301,32 @@ mod tests {
 
     #[test]
     #[tracing_test::traced_test]
-    fn warn_if_additional_quorum_rpc_not_public_warns_on_private_entry() {
-        let urls = vec![
-            (Url::parse("http://public-a.example").unwrap(), true),
-            (Url::parse("http://private-b.example").unwrap(), false),
-        ];
-
-        Validator::warn_if_additional_quorum_rpc_not_public(&urls);
-
-        assert!(logs_contain(
-            "additionalQuorumRpcUrls contains non-public entries"
-        ));
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn warn_if_additional_quorum_rpc_not_public_silent_when_all_public() {
-        let urls = vec![
-            (Url::parse("http://public-a.example").unwrap(), true),
-            (Url::parse("http://public-b.example").unwrap(), true),
-        ];
-
-        Validator::warn_if_additional_quorum_rpc_not_public(&urls);
-
-        assert!(!logs_contain(
-            "additionalQuorumRpcUrls contains non-public entries"
-        ));
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
     fn warn_if_duplicate_hosts_warns_on_shared_host() {
-        let primary_urls = vec![Url::parse("http://shared.example/key-a").unwrap()];
-        let quorum_urls = vec![
-            (Url::parse("http://other.example").unwrap(), true),
-            (Url::parse("http://shared.example/key-b").unwrap(), true),
+        let urls = vec![
+            Url::parse("http://shared.example/key-a").unwrap(),
+            Url::parse("http://other.example").unwrap(),
+            Url::parse("http://shared.example/key-b").unwrap(),
         ];
 
-        Validator::warn_if_duplicate_hosts(&primary_urls, &quorum_urls);
+        Validator::warn_if_duplicate_hosts(&urls);
 
         assert!(logs_contain(
-            "rpcUrls/additionalQuorumRpcUrls have multiple entries (by label) sharing a host"
+            "rpcUrls/additionalQuorumRpcUrls have multiple entries (by index) sharing a host"
         ));
     }
 
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_duplicate_hosts_silent_when_all_distinct() {
-        let primary_urls = vec![Url::parse("http://rpc-a.example").unwrap()];
-        let quorum_urls = vec![(Url::parse("http://rpc-b.example").unwrap(), true)];
+        let urls = vec![
+            Url::parse("http://rpc-a.example").unwrap(),
+            Url::parse("http://rpc-b.example").unwrap(),
+        ];
 
-        Validator::warn_if_duplicate_hosts(&primary_urls, &quorum_urls);
+        Validator::warn_if_duplicate_hosts(&urls);
 
         assert!(!logs_contain(
-            "rpcUrls/additionalQuorumRpcUrls have multiple entries (by label) sharing a host"
+            "rpcUrls/additionalQuorumRpcUrls have multiple entries (by index) sharing a host"
         ));
     }
 
@@ -1600,7 +1378,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(hooks.len(), 3);
-        let labels: Vec<&str> = hooks.iter().map(|hook| hook.label.as_str()).collect();
+        let labels: Vec<&str> = hooks.iter().map(|(label, _)| label.as_str()).collect();
         assert_eq!(
             labels,
             vec![
@@ -1609,33 +1387,6 @@ mod tests {
                 "additionalQuorumRpcUrls[2]"
             ]
         );
-        assert!(hooks.iter().all(|hook| hook.role == RpcRole::Quorum));
-    }
-
-    #[tokio::test]
-    async fn build_validator_ethereum_per_url_hooks_empty_urls_produces_no_hooks() {
-        let chain_conf = dummy_ethereum_chain_conf(vec![
-            Url::parse("http://normal-a.example").unwrap(),
-            Url::parse("http://normal-b.example").unwrap(),
-        ]);
-        let metrics = CoreMetrics::new(
-            "validator-test-ethereum-quorum-hooks-empty",
-            9092,
-            Registry::new(),
-        )
-        .unwrap();
-
-        let hooks = Validator::build_validator_ethereum_per_url_hooks(
-            &chain_conf,
-            "additionalQuorumRpcUrls",
-            RpcRole::Quorum,
-            &[],
-            &metrics,
-        )
-        .await
-        .unwrap();
-
-        assert!(hooks.is_empty());
     }
 
     mockall::mock! {
@@ -1664,24 +1415,8 @@ mod tests {
         }
     }
 
-    /// An `additionalQuorumRpcUrls`-sourced entry (role `Quorum`): a failure is excluded from the
-    /// round's threshold denominator.
-    fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> QuorumHook {
-        quorum_rpc_with_role(label, RpcRole::Quorum, hook)
-    }
-
-    /// An `rpcUrls`-sourced entry (role `Primary`): a failure always still counts against
-    /// the round's threshold denominator.
-    fn primary_rpc(label: &str, hook: MockMerkleTreeHook) -> QuorumHook {
-        quorum_rpc_with_role(label, RpcRole::Primary, hook)
-    }
-
-    fn quorum_rpc_with_role(label: &str, role: RpcRole, hook: MockMerkleTreeHook) -> QuorumHook {
-        QuorumHook {
-            label: label.to_string(),
-            role,
-            hook: Arc::new(hook) as Arc<dyn MerkleTreeHook>,
-        }
+    fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> (String, Arc<dyn MerkleTreeHook>) {
+        (label.to_string(), Arc::new(hook) as Arc<dyn MerkleTreeHook>)
     }
 
     #[test]
@@ -1798,7 +1533,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_reaches_two_thirds_majority() {
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_reaches_two_thirds_and_agrees_with_base_hook(
+    ) {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
         let expected_tree = IncrementalMerkleAtBlock {
             tree: Default::default(),
@@ -1940,440 +1676,6 @@ mod tests {
         assert!(hook.tree(&ReorgPeriod::None).await.is_err());
     }
 
-    /// If every quorum_hooks entry that failed is role `Quorum`, the round's returned
-    /// error must not surface either entry's error text verbatim -- it should fall back
-    /// to a generic message instead.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_all_quorum_role_failures_returns_generic_error(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 5);
-
-        let mut quorum_a = MockMerkleTreeHook::new();
-        quorum_a.expect_latest_checkpoint().never();
-        quorum_a
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(5))
-            .return_once(|_| {
-                Err(ChainCommunicationError::from_other_str(
-                    "quorum-role-rpc-a-error-detail",
-                ))
-            });
-
-        let mut quorum_b = MockMerkleTreeHook::new();
-        quorum_b.expect_latest_checkpoint().never();
-        quorum_b
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(5))
-            .return_once(|_| {
-                Err(ChainCommunicationError::from_other_str(
-                    "quorum-role-rpc-b-error-detail",
-                ))
-            });
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![quorum_rpc("rpc-a", quorum_a), quorum_rpc("rpc-b", quorum_b)],
-        };
-
-        let err = hook.tree(&ReorgPeriod::None).await.unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            !msg.contains("quorum-role-rpc-a-error-detail")
-                && !msg.contains("quorum-role-rpc-b-error-detail"),
-            "a Quorum-role RPC's error text must never surface: {msg}"
-        );
-    }
-
-    /// When both a `Primary`-role and a `Quorum`-role quorum_hooks entry fail, the
-    /// returned error must surface the `Primary`-role one's detail, never the
-    /// `Quorum`-role one's.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_prefers_primary_role_error_over_quorum_role(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 5);
-
-        let mut quorum_role_rpc = MockMerkleTreeHook::new();
-        quorum_role_rpc.expect_latest_checkpoint().never();
-        quorum_role_rpc
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(5))
-            .return_once(|_| {
-                Err(ChainCommunicationError::from_other_str(
-                    "quorum-role-rpc-error-detail",
-                ))
-            });
-
-        let mut primary_role_rpc = MockMerkleTreeHook::new();
-        primary_role_rpc.expect_latest_checkpoint().never();
-        primary_role_rpc
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(5))
-            .return_once(|_| {
-                Err(ChainCommunicationError::from_other_str(
-                    "primary-role-rpc-error-detail",
-                ))
-            });
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![
-                quorum_rpc("rpc-quorum", quorum_role_rpc),
-                primary_rpc("rpc-primary", primary_role_rpc),
-            ],
-        };
-
-        let err = hook.tree(&ReorgPeriod::None).await.unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("primary-role-rpc-error-detail"),
-            "expected the Primary-role RPC's error to surface: {msg}"
-        );
-        assert!(
-            !msg.contains("quorum-role-rpc-error-detail"),
-            "a Quorum-role RPC's error text must never surface: {msg}"
-        );
-    }
-
-    /// Regression test for a fail-open attack: if a compromised `Primary` manipulates the
-    /// target height such that every honest `Quorum`-role RPC errors (e.g. "header not
-    /// found" for a fabricated future height), the failed `Quorum`-role entries must
-    /// still count against the (fixed) threshold -- otherwise the compromised `Primary`
-    /// would trivially "win" a 1-of-1 vote against itself.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_fully_fails(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        // Never reached: the merged vote fails before base_hook would be consulted.
-        base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 42);
-
-        let mut compromised_primary = MockMerkleTreeHook::new();
-        compromised_primary.expect_latest_checkpoint().never();
-        compromised_primary
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|_| {
-                let mut fabricated =
-                    hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-                fabricated.ingest(H256::from_low_u64_be(1));
-                Ok(IncrementalMerkleAtBlock {
-                    tree: fabricated,
-                    block_height: Some(42),
-                })
-            });
-
-        let mut quorum_a = MockMerkleTreeHook::new();
-        quorum_a.expect_latest_checkpoint().never();
-        quorum_a
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
-
-        let mut quorum_b = MockMerkleTreeHook::new();
-        quorum_b.expect_latest_checkpoint().never();
-        quorum_b
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![
-                primary_rpc("rpc-primary-compromised", compromised_primary),
-                quorum_rpc("rpc-quorum-a", quorum_a),
-                quorum_rpc("rpc-quorum-b", quorum_b),
-            ],
-        };
-
-        assert!(
-            hook.tree(&ReorgPeriod::None).await.is_err(),
-            "a fully-failed Quorum-role pool must not let a lone Primary win by default"
-        );
-    }
-
-    /// Regression test for a fail-open attack on *partial* Quorum-role pool failure: if a
-    /// compromised `Primary` manipulates the target height such that only a colluding
-    /// minority of `additionalQuorumRpcUrls` can answer (agreeing with the fabricated
-    /// value) while the honest majority correctly errors "not found", the compromised
-    /// `Primary` plus its single accomplice (2 of the fixed 4-entry denominator) must
-    /// still fall short of the 2/3 threshold, so this round must fail to reach quorum.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_minority_colludes(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        // Never reached: the merged vote fails to reach quorum before base_hook would be
-        // consulted.
-        base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 42);
-
-        let fabricated_tree = {
-            let mut fabricated =
-                hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-            fabricated.ingest(H256::from_low_u64_be(1));
-            IncrementalMerkleAtBlock {
-                tree: fabricated,
-                block_height: Some(42),
-            }
-        };
-
-        let mut compromised_primary = MockMerkleTreeHook::new();
-        compromised_primary.expect_latest_checkpoint().never();
-        compromised_primary
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once({
-                let fabricated_tree = fabricated_tree.clone();
-                move |_| Ok(fabricated_tree)
-            });
-
-        let mut colluding_quorum = MockMerkleTreeHook::new();
-        colluding_quorum.expect_latest_checkpoint().never();
-        colluding_quorum
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(move |_| Ok(fabricated_tree));
-
-        let mut honest_quorum_a = MockMerkleTreeHook::new();
-        honest_quorum_a.expect_latest_checkpoint().never();
-        honest_quorum_a
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
-
-        let mut honest_quorum_b = MockMerkleTreeHook::new();
-        honest_quorum_b.expect_latest_checkpoint().never();
-        honest_quorum_b
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![
-                primary_rpc("rpc-primary-compromised", compromised_primary),
-                quorum_rpc("rpc-quorum-colluding", colluding_quorum),
-                quorum_rpc("rpc-quorum-honest-a", honest_quorum_a),
-                quorum_rpc("rpc-quorum-honest-b", honest_quorum_b),
-            ],
-        };
-
-        assert!(
-            hook.tree(&ReorgPeriod::None).await.is_err(),
-            "a colluding minority of the Quorum-role pool must not be able to shrink the \
-             denominator enough to win alongside a compromised Primary"
-        );
-    }
-
-    /// Regression test for a fail-open attack where the honest `Quorum`-role majority
-    /// *responds* rather than errors, so a response-count-based exclusion signal (e.g.
-    /// "2/3 of the Quorum-role pool responded this round") would have been satisfied even
-    /// though only a minority actually agrees with the compromised `Primary`'s fabricated
-    /// value: 1 compromised `Primary` + 1 colluding `Quorum`-role entry (agrees with the
-    /// fabricated value) + 1 honest `Quorum`-role entry that answers with the correct,
-    /// different value + 1 honest `Quorum`-role entry that errors. Neither the fabricated
-    /// value (2 of the fixed 4-entry denominator) nor the honest value (1 of 4) reaches
-    /// the 2/3 threshold, so this round must fail to reach quorum.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_when_quorum_role_pool_partially_disagrees(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        // Never reached: the merged vote fails to reach quorum before base_hook would be
-        // consulted.
-        base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 42);
-
-        let fabricated_tree = {
-            let mut fabricated =
-                hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-            fabricated.ingest(H256::from_low_u64_be(1));
-            IncrementalMerkleAtBlock {
-                tree: fabricated,
-                block_height: Some(42),
-            }
-        };
-        let honest_tree = {
-            let mut honest = hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-            honest.ingest(H256::from_low_u64_be(2));
-            IncrementalMerkleAtBlock {
-                tree: honest,
-                block_height: Some(42),
-            }
-        };
-
-        let mut compromised_primary = MockMerkleTreeHook::new();
-        compromised_primary.expect_latest_checkpoint().never();
-        compromised_primary
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once({
-                let fabricated_tree = fabricated_tree.clone();
-                move |_| Ok(fabricated_tree)
-            });
-
-        let mut colluding_quorum = MockMerkleTreeHook::new();
-        colluding_quorum.expect_latest_checkpoint().never();
-        colluding_quorum
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(move |_| Ok(fabricated_tree));
-
-        let mut honest_quorum_correct = MockMerkleTreeHook::new();
-        honest_quorum_correct.expect_latest_checkpoint().never();
-        honest_quorum_correct
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(move |_| Ok(honest_tree));
-
-        let mut honest_quorum_erroring = MockMerkleTreeHook::new();
-        honest_quorum_erroring.expect_latest_checkpoint().never();
-        honest_quorum_erroring
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("header not found")));
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![
-                primary_rpc("rpc-primary-compromised", compromised_primary),
-                quorum_rpc("rpc-quorum-colluding", colluding_quorum),
-                quorum_rpc("rpc-quorum-honest-correct", honest_quorum_correct),
-                quorum_rpc("rpc-quorum-honest-erroring", honest_quorum_erroring),
-            ],
-        };
-
-        assert!(
-            hook.tree(&ReorgPeriod::None).await.is_err(),
-            "a compromised Primary plus a single colluding Quorum-role entry must not be \
-             able to win just because a majority of the Quorum-role pool responded -- they \
-             must also agree with the winning candidate"
-        );
-    }
-
-    /// Regression test: 2 colluding/compromised `additionalQuorumRpcUrls` (`Quorum`-role,
-    /// less-trusted public) entries can reach the overall 2/3 threshold on a wrong value
-    /// even with an honest `Primary` disagreeing (1 Primary + 2 colluding Quorum = 2/3 on
-    /// the colluding pair's value). `require_base_hook_agreement` must catch this:
-    /// `base_hook` independently reflects the honest `rpcUrls` consensus, which disagrees
-    /// with the colluding pair's value, so the round must be rejected.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_rejects_colluding_quorum_role_majority(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-        let honest_tree = IncrementalMerkleAtBlock {
-            tree: Default::default(),
-            block_height: Some(50),
-        };
-        let mut colluding_merkle =
-            hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-        colluding_merkle.ingest(H256::from_low_u64_be(1));
-        let colluding_tree = IncrementalMerkleAtBlock {
-            tree: colluding_merkle,
-            block_height: Some(50),
-        };
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-        base_hook
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let honest_tree = honest_tree.clone();
-                move |_| Ok(honest_tree)
-            });
-
-        let mut honest_primary = MockMerkleTreeHook::new();
-        honest_primary.expect_latest_checkpoint().never();
-        honest_primary
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let honest_tree = honest_tree.clone();
-                move |_| Ok(honest_tree)
-            });
-
-        let mut colluding_a = MockMerkleTreeHook::new();
-        colluding_a.expect_latest_checkpoint().never();
-        colluding_a
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let colluding_tree = colluding_tree.clone();
-                move |_| Ok(colluding_tree)
-            });
-
-        let mut colluding_b = MockMerkleTreeHook::new();
-        colluding_b.expect_latest_checkpoint().never();
-        colluding_b
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(colluding_tree));
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![
-                primary_rpc("rpc-primary-honest", honest_primary),
-                quorum_rpc("rpc-quorum-colluding-a", colluding_a),
-                quorum_rpc("rpc-quorum-colluding-b", colluding_b),
-            ],
-        };
-
-        assert!(
-            hook.tree(&ReorgPeriod::None).await.is_err(),
-            "2 colluding Quorum-role entries must not be able to outvote an honest Primary"
-        );
-    }
-
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_tolerates_rpc_failure_within_two_thirds_threshold(
     ) {
@@ -2439,120 +1741,47 @@ mod tests {
         );
     }
 
-    /// 4 configured `quorum_hooks`, 1 `Quorum`-role RPC down this round. Unlike earlier
-    /// revisions, a down `Quorum`-role entry is NOT excluded from the threshold's
-    /// denominator (same treatment as a down `Primary`-role entry) -- see
-    /// `select_quorum_result`'s doc comment for why. The threshold stays at
-    /// ceil(2*4/3) = 3; only 2 of the 3 responders agree (the third disagrees), so
-    /// quorum is not reached.
-    #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_does_not_exclude_down_quorum_role_rpc_from_threshold(
-    ) {
-        let mailbox_domain = dummy_domain(1337, "test-domain").id();
-        let expected_tree = IncrementalMerkleAtBlock {
-            tree: Default::default(),
-            block_height: Some(50),
-        };
-        let mut divergent_merkle =
-            hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-        divergent_merkle.ingest(H256::from_low_u64_be(1));
-        let divergent_tree = IncrementalMerkleAtBlock {
-            tree: divergent_merkle,
-            block_height: Some(50),
-        };
-
-        let mut base_hook = MockMerkleTreeHook::new();
-        base_hook.expect_count().never();
-        base_hook.expect_tree().never();
-        // Never reached: the quorum_hooks vote fails before base_hook would be consulted.
-        base_hook.expect_tree_at_block().never();
-        base_hook.expect_latest_checkpoint_at_block().never();
-        mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-
-        let mut quorum_down = MockMerkleTreeHook::new();
-        quorum_down.expect_latest_checkpoint().never();
-        quorum_down
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("quorum rpc down")));
-
-        let mut quorum_b = MockMerkleTreeHook::new();
-        quorum_b.expect_latest_checkpoint().never();
-        quorum_b
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let expected_tree = expected_tree.clone();
-                move |_| Ok(expected_tree)
-            });
-
-        let mut quorum_c = MockMerkleTreeHook::new();
-        quorum_c.expect_latest_checkpoint().never();
-        quorum_c
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(divergent_tree));
-
-        let mut quorum_d = MockMerkleTreeHook::new();
-        quorum_d.expect_latest_checkpoint().never();
-        quorum_d
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(expected_tree));
-
-        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: Arc::new(base_hook),
-            quorum_hooks: vec![
-                quorum_rpc("rpc-quorum-down", quorum_down),
-                quorum_rpc("rpc-b", quorum_b),
-                quorum_rpc("rpc-c", quorum_c),
-                quorum_rpc("rpc-d", quorum_d),
-            ],
-        };
-
-        assert!(hook.tree(&ReorgPeriod::None).await.is_err());
-    }
-
-    /// Same 4-hook, 1-down, 1-disagreeing shape as the test above, except the down RPC is
-    /// role `Primary` (an `rpcUrls` entry). `Primary`-role failures are NOT excluded from
-    /// the threshold, so it stays at ceil(2*4/3) = 3; only 2 of the 3 responders agree ->
-    /// quorum fails.
+    /// `quorum_hooks` unanimously agree on tree_x, but `base_hook` (the separate `rpcUrls`
+    /// pool) returns tree_y. Agreeing within `quorum_hooks` alone isn't enough: an
+    /// attacker would also need to compromise the independent `rpcUrls` pool.
     #[tokio::test]
     #[tracing_test::traced_test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_does_not_exclude_down_primary_role_rpc_from_threshold(
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_fails_when_quorum_agrees_but_base_hook_disagrees(
     ) {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
-        let expected_tree = IncrementalMerkleAtBlock {
+        let quorum_tree = IncrementalMerkleAtBlock {
             tree: Default::default(),
             block_height: Some(50),
         };
-        let mut divergent_merkle =
+        let mut base_merkle =
             hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-        divergent_merkle.ingest(H256::from_low_u64_be(1));
-        let divergent_tree = IncrementalMerkleAtBlock {
-            tree: divergent_merkle,
+        base_merkle.ingest(H256::from_low_u64_be(1));
+        let base_tree = IncrementalMerkleAtBlock {
+            tree: base_merkle,
             block_height: Some(50),
         };
 
         let mut base_hook = MockMerkleTreeHook::new();
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
-        // Never reached: the quorum_hooks vote fails before base_hook would be consulted.
-        base_hook.expect_tree_at_block().never();
         base_hook.expect_latest_checkpoint_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-
-        let mut primary_down = MockMerkleTreeHook::new();
-        primary_down.expect_latest_checkpoint().never();
-        primary_down
+        base_hook
             .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(50))
-            .return_once(|_| Err(ChainCommunicationError::from_other_str("primary rpc down")));
+            .return_once(move |_| Ok(base_tree));
+
+        let mut quorum_a = MockMerkleTreeHook::new();
+        quorum_a.expect_latest_checkpoint().never();
+        quorum_a
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let quorum_tree = quorum_tree.clone();
+                move |_| Ok(quorum_tree)
+            });
 
         let mut quorum_b = MockMerkleTreeHook::new();
         quorum_b.expect_latest_checkpoint().never();
@@ -2561,8 +1790,8 @@ mod tests {
             .once()
             .with(mockall::predicate::eq(50))
             .return_once({
-                let expected_tree = expected_tree.clone();
-                move |_| Ok(expected_tree)
+                let quorum_tree = quorum_tree.clone();
+                move |_| Ok(quorum_tree)
             });
 
         let mut quorum_c = MockMerkleTreeHook::new();
@@ -2571,29 +1800,20 @@ mod tests {
             .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(divergent_tree));
-
-        let mut quorum_d = MockMerkleTreeHook::new();
-        quorum_d.expect_latest_checkpoint().never();
-        quorum_d
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(expected_tree));
+            .return_once(move |_| Ok(quorum_tree));
 
         let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
             base_hook: Arc::new(base_hook),
             quorum_hooks: vec![
-                primary_rpc("rpc-primary-down", primary_down),
+                quorum_rpc("rpc-a", quorum_a),
                 quorum_rpc("rpc-b", quorum_b),
                 quorum_rpc("rpc-c", quorum_c),
-                quorum_rpc("rpc-d", quorum_d),
             ],
         };
 
         assert!(hook.tree(&ReorgPeriod::None).await.is_err());
         assert!(logs_contain(
-            "rpcUrls entries failed this round; they still count against the quorum threshold"
+            "merged quorum consensus disagrees with rpcUrls consensus"
         ));
     }
 
@@ -2777,9 +1997,6 @@ mod tests {
         let mut base_hook = MockMerkleTreeHook::new();
         base_hook.expect_count().never();
         base_hook.expect_latest_checkpoint().never();
-        // `latest_checkpoint_at_block` takes an explicit height, so it never needs
-        // height resolution -- but it still cross-checks the merged vote's winner
-        // against base_hook's own independent result.
         base_hook
             .expect_latest_checkpoint_at_block()
             .once()

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -36,6 +36,7 @@ use hyperlane_core::{
     ValidatorAnnounce, H256, U256,
 };
 use hyperlane_ethereum::{RpcConnectionConf, Signers, SingletonSigner, SingletonSignerHandle};
+use hyperlane_metric::prometheus_metric::RpcRole;
 
 use crate::reorg_reporter::{
     LatestCheckpointReorgReporter, LatestCheckpointReorgReporterWithStorageWriter, ReorgReporter,
@@ -52,23 +53,43 @@ const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
 /// can't stall a safety-critical read (and therefore checkpoint signing) indefinitely.
 const QUORUM_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Below this, `quorumRpcUrls` gives little to no real protection: with 1 entry any
-/// value trivially reaches quorum, and with 2 entries all must unanimously agree.
+/// Below this, the combined `rpcUrls` + `additionalQuorumRpcUrls` pool gives little to no real
+/// protection: with 1 entry any value trivially reaches quorum, and with 2 entries all
+/// must unanimously agree.
 const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 
 /// `count()`/domain/address come from `base_hook` (the normal `rpcUrls` connection, using
-/// whatever consensus mode it's configured with). `tree()`/`latest_checkpoint()`/
-/// `latest_checkpoint_at_block()` require BOTH: a 2/3 majority across `quorum_hooks`
-/// (`quorumRpcUrls`, independent of each other), AND that majority-agreed value to match
-/// what `base_hook` independently returns. An attacker needs to compromise both pools at
-/// once to force a wrong value through; compromising just one causes a safe rejection.
+/// whatever consensus mode it's configured with). `base_hook` is also used to resolve a
+/// canonical block height that every vote below is pinned to
+/// (`resolve_quorum_target_height`).
+///
+/// `tree()`/`latest_checkpoint()`/`latest_checkpoint_at_block()` instead run a single 2/3
+/// majority vote across `quorum_hooks`: one hook per `rpcUrls` entry (role `Primary`,
+/// always counted in the threshold, whether it succeeds or fails this round) plus one hook
+/// per `additionalQuorumRpcUrls` entry (role `Quorum`, excluded from the threshold's denominator if
+/// it fails this round — see `select_quorum_result`). `additionalQuorumRpcUrls` is meant to hold
+/// *additional* public RPCs on top of what's already in `rpcUrls` — it widens the vote
+/// without weakening it: a public endpoint blipping shouldn't itself block checkpoint
+/// signing, or force unanimous agreement among the rest.
 #[derive(Debug)]
 struct ValidatorMultiRpcQuorumMerkleTreeHook {
     base_hook: Arc<dyn MerkleTreeHook>,
-    /// Paired with a `quorumRpcUrls[i]` index label (0-based), not the host/URL itself —
+    quorum_hooks: Vec<QuorumHook>,
+}
+
+/// A single per-URL vote in the merged `rpcUrls` + `additionalQuorumRpcUrls` quorum group.
+#[derive(Debug, Clone)]
+struct QuorumHook {
+    /// `rpcUrls[i]`/`additionalQuorumRpcUrls[i]` index label (0-based), not the host/URL itself —
     /// some entries may be private RPCs, so logging which one disagreed must never reveal
     /// which URL/provider that is.
-    quorum_hooks: Vec<(String, Arc<dyn MerkleTreeHook>)>,
+    label: String,
+    /// Whether this came from `rpcUrls` (`Primary`) or `additionalQuorumRpcUrls` (`Quorum`) — also
+    /// tags the underlying connection's `rpc_role` Prometheus label, so `Quorum`-role
+    /// failures (expected/tolerated) can be distinguished from `Primary`-role ones in
+    /// metrics/alerting.
+    role: RpcRole,
+    hook: Arc<dyn MerkleTreeHook>,
 }
 
 impl ValidatorMultiRpcQuorumMerkleTreeHook {
@@ -127,27 +148,59 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     }
 
     /// Majority vote (2/3) across `quorum_hooks`' results.
+    ///
+    /// A failed `Quorum`-role RPC (a `additionalQuorumRpcUrls` entry) this round is excluded from
+    /// the threshold's denominator, regardless of whether it's public or private (e.g. 4
+    /// configured, 1 quorum-role entry down -> 2/3-of-3, not 2/3-of-4): `additionalQuorumRpcUrls` is
+    /// additional, optional coverage, so one entry blipping shouldn't by itself force
+    /// unanimous agreement among the rest, or block checkpoint signing outright. A failed
+    /// `Primary`-role RPC (an `rpcUrls` entry) always still counts against the full pool —
+    /// `rpcUrls` is the core set every validator already depends on, so its failures should
+    /// still tighten the threshold rather than being silently tolerated. A `Quorum`-role
+    /// RPC's error also never becomes the round's returned error (see `first_primary_err`
+    /// below): it's expected/tolerated, so it must never surface up through
+    /// logs/alerting the way an unexpected `Primary`-role failure would.
     fn select_quorum_result<T: Clone + Debug>(
         &self,
-        results: Vec<(String, ChainResult<T>)>,
+        results: Vec<(String, RpcRole, ChainResult<T>)>,
         matches: impl Fn(&T, &T) -> bool,
         context: &str,
     ) -> ChainResult<T> {
         let mut oks: Vec<(String, T)> = Vec::new();
-        let mut first_err = None;
+        // Only ever populated from a Primary-role failure: a Quorum-role entry failing is
+        // expected/tolerated, so its error must never surface as the round's returned
+        // error (which callers log at `error!`/`warn!`, i.e. this is the one place that
+        // failure could otherwise leak out).
+        let mut first_primary_err = None;
+        let mut excluded_quorum_rpcs: Vec<String> = Vec::new();
 
-        for (label, result) in results {
+        for (label, role, result) in results {
             match result {
                 Ok(value) => oks.push((label, value)),
                 Err(err) => {
-                    if first_err.is_none() {
-                        first_err = Some(err);
+                    if role == RpcRole::Quorum {
+                        excluded_quorum_rpcs.push(label);
+                    } else if first_primary_err.is_none() {
+                        first_primary_err = Some(err);
                     }
                 }
             }
         }
 
-        let threshold = Self::two_thirds_threshold(self.quorum_hooks.len());
+        let effective_pool_size = self
+            .quorum_hooks
+            .len()
+            .saturating_sub(excluded_quorum_rpcs.len());
+        let threshold = Self::two_thirds_threshold(effective_pool_size);
+        if !excluded_quorum_rpcs.is_empty() {
+            debug!(
+                context,
+                excluded_quorum_rpcs = ?excluded_quorum_rpcs,
+                effective_pool_size,
+                threshold,
+                "Excluding unavailable additionalQuorumRpcUrls entries from this round's quorum threshold"
+            );
+        }
         let mut max_agreeing = 0;
         let mut best_agreeing_rpcs: Vec<&str> = Vec::new();
 
@@ -186,9 +239,11 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         }
 
         if oks.is_empty() {
-            return Err(
-                first_err.unwrap_or_else(|| ChainCommunicationError::from_other_str(context))
-            );
+            // Prefer a Primary-role RPC's error; if every quorum_hooks entry that failed
+            // was Quorum-role, fall back to a generic message rather than surfacing that
+            // RPC's error verbatim.
+            return Err(first_primary_err
+                .unwrap_or_else(|| ChainCommunicationError::from_other_str(context)));
         }
 
         let responding_rpcs: Vec<&str> = oks.iter().map(|(label, _)| label.as_str()).collect();
@@ -208,30 +263,6 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
             total = oks.len()
         )))
     }
-
-    /// Requires the quorum-agreed value to match what `base_hook` (`rpcUrls`, whatever
-    /// consensus mode it's configured with) independently returns. Guards against
-    /// `quorumRpcUrls` alone being compromised: an attacker also has to compromise the
-    /// separate `rpcUrls` pool to force a wrong value through.
-    fn require_base_hook_agreement<T: Debug>(
-        quorum_result: &T,
-        base_result: &T,
-        matches: impl Fn(&T, &T) -> bool,
-        context: &str,
-    ) -> ChainResult<()> {
-        if matches(quorum_result, base_result) {
-            return Ok(());
-        }
-        warn!(
-            context,
-            quorum_result = ?quorum_result,
-            base_result = ?base_result,
-            "quorumRpcUrls consensus disagrees with rpcUrls consensus"
-        );
-        Err(ChainCommunicationError::from_other_str(&format!(
-            "{context}: quorumRpcUrls consensus disagrees with rpcUrls consensus"
-        )))
-    }
 }
 
 #[async_trait]
@@ -239,52 +270,38 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
     async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
         if let Some(height) = self.resolve_quorum_target_height(reorg_period).await? {
             let results = join_all(self.quorum_hooks.iter().cloned().map(
-                |(label, hook)| async move {
+                |quorum_hook| async move {
                     (
-                        label,
-                        Self::with_call_timeout(hook.tree_at_block(height)).await,
+                        quorum_hook.label,
+                        quorum_hook.role,
+                        Self::with_call_timeout(quorum_hook.hook.tree_at_block(height)).await,
                     )
                 },
             ))
             .await;
-            let quorum_result = self.select_quorum_result(
+            return self.select_quorum_result(
                 results,
                 |a, b| a.tree == b.tree,
                 "Failed to reach quorum for merkle tree",
-            )?;
-            let base_result = self.base_hook.tree_at_block(height).await?;
-            Self::require_base_hook_agreement(
-                &quorum_result,
-                &base_result,
-                |a, b| a.tree == b.tree,
-                "Failed to reach quorum for merkle tree",
-            )?;
-            return Ok(quorum_result);
+            );
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
+        let results = join_all(self.quorum_hooks.iter().cloned().map(|quorum_hook| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    label,
-                    Self::with_call_timeout(hook.tree(&reorg_period)).await,
+                    quorum_hook.label,
+                    quorum_hook.role,
+                    Self::with_call_timeout(quorum_hook.hook.tree(&reorg_period)).await,
                 )
             }
         }))
         .await;
-        let quorum_result = self.select_quorum_result(
+        self.select_quorum_result(
             results,
             |a, b| a.tree == b.tree && a.block_height == b.block_height,
             "Failed to reach quorum for merkle tree",
-        )?;
-        let base_result = self.base_hook.tree(reorg_period).await?;
-        Self::require_base_hook_agreement(
-            &quorum_result,
-            &base_result,
-            |a, b| a.tree == b.tree,
-            "Failed to reach quorum for merkle tree",
-        )?;
-        Ok(quorum_result)
+        )
     }
 
     async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
@@ -299,29 +316,23 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             return self.latest_checkpoint_at_block(height).await;
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
+        let results = join_all(self.quorum_hooks.iter().cloned().map(|quorum_hook| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    label,
-                    Self::with_call_timeout(hook.latest_checkpoint(&reorg_period)).await,
+                    quorum_hook.label,
+                    quorum_hook.role,
+                    Self::with_call_timeout(quorum_hook.hook.latest_checkpoint(&reorg_period))
+                        .await,
                 )
             }
         }))
         .await;
-        let quorum_result = self.select_quorum_result(
+        self.select_quorum_result(
             results,
             |a, b| a.checkpoint == b.checkpoint && a.block_height == b.block_height,
             "Failed to reach quorum for latest_checkpoint",
-        )?;
-        let base_result = self.base_hook.latest_checkpoint(reorg_period).await?;
-        Self::require_base_hook_agreement(
-            &quorum_result,
-            &base_result,
-            |a, b| a.checkpoint == b.checkpoint,
-            "Failed to reach quorum for latest_checkpoint",
-        )?;
-        Ok(quorum_result)
+        )
     }
 
     async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
@@ -329,27 +340,23 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             self.quorum_hooks
                 .iter()
                 .cloned()
-                .map(|(label, hook)| async move {
+                .map(|quorum_hook| async move {
                     (
-                        label,
-                        Self::with_call_timeout(hook.latest_checkpoint_at_block(height)).await,
+                        quorum_hook.label,
+                        quorum_hook.role,
+                        Self::with_call_timeout(
+                            quorum_hook.hook.latest_checkpoint_at_block(height),
+                        )
+                        .await,
                     )
                 }),
         )
         .await;
-        let quorum_result = self.select_quorum_result(
+        self.select_quorum_result(
             results,
             |a, b| a.checkpoint == b.checkpoint && a.block_height == b.block_height,
             "Failed to reach quorum for latest_checkpoint_at_block",
-        )?;
-        let base_result = self.base_hook.latest_checkpoint_at_block(height).await?;
-        Self::require_base_hook_agreement(
-            &quorum_result,
-            &base_result,
-            |a, b| a.checkpoint == b.checkpoint,
-            "Failed to reach quorum for latest_checkpoint_at_block",
-        )?;
-        Ok(quorum_result)
+        )
     }
 }
 
@@ -403,8 +410,8 @@ pub struct Validator {
 pub struct ValidatorMetadata {
     git_sha: String,
     rpcs: Vec<ValidatorMetadataRpcEntry>,
-    /// The `quorumRpcUrls` set, reported separately from `rpcs`.
-    quorum_rpcs: Vec<ValidatorMetadataRpcEntry>,
+    /// The `additionalQuorumRpcUrls` set, reported separately from `rpcs`.
+    additional_quorum_rpcs: Vec<ValidatorMetadataRpcEntry>,
     allows_public_rpcs: bool,
 }
 #[derive(Debug, Serialize)]
@@ -436,15 +443,15 @@ impl MetadataFromSettings<ValidatorSettings> for ValidatorMetadata {
             .iter()
             .map(ValidatorMetadataRpcEntry::hash_rpc)
             .collect();
-        let quorum_rpcs = settings
-            .quorum_rpcs
+        let additional_quorum_rpcs = settings
+            .additional_quorum_rpcs
             .iter()
             .map(ValidatorMetadataRpcEntry::hash_rpc)
             .collect();
         ValidatorMetadata {
             git_sha: git_sha(),
             rpcs,
-            quorum_rpcs,
+            additional_quorum_rpcs,
             allows_public_rpcs: settings.allow_public_rpcs,
         }
     }
@@ -469,7 +476,7 @@ impl BaseAgent for Validator {
     where
         Self: Sized,
     {
-        // only `rpcs` is gated; quorum_rpcs is safe to be public by design
+        // only `rpcs` is gated; additional_quorum_rpcs is safe to be public by design
         let public_rpc_urls: Vec<String> = settings
             .rpcs
             .iter()
@@ -524,9 +531,9 @@ impl BaseAgent for Validator {
         let reorg_reporter = Arc::new(reorg_reporter_with_storage_writer) as Arc<dyn ReorgReporter>;
 
         let origin_chain_conf = core.settings.chain_setup(&settings.origin_chain)?.clone();
-        let quorum_rpc_urls: Vec<Url> = Self::dedupe_quorum_rpc_urls(
+        let additional_quorum_rpc_urls: Vec<(Url, bool)> = Self::dedupe_additional_quorum_rpc_urls(
             settings
-                .quorum_rpcs
+                .additional_quorum_rpcs
                 .iter()
                 .enumerate()
                 .map(|(i, rpc)| {
@@ -534,7 +541,8 @@ impl BaseAgent for Validator {
                     // an API key, and a parse failure (e.g. a typo) is exactly the case
                     // where the URL is most likely to end up copied verbatim into logs.
                     Url::parse(&rpc.url)
-                        .map_err(|err| eyre!("Invalid quorumRpcUrls[{i}] entry: {err}"))
+                        .map(|url| (url, rpc.public))
+                        .map_err(|err| eyre!("Invalid additionalQuorumRpcUrls[{i}] entry: {err}"))
                 })
                 .collect::<Result<_>>()?,
         );
@@ -543,21 +551,37 @@ impl BaseAgent for Validator {
 
         let merkle_tree_hook = if Self::validator_uses_split_quorum_hook(
             &origin_chain_conf,
-            &quorum_rpc_urls,
+            &additional_quorum_rpc_urls,
         ) {
-            Self::warn_if_quorum_pool_undersized(&quorum_rpc_urls);
-            Self::warn_if_duplicate_hosts(&quorum_rpc_urls);
+            // `rpcUrls` (`primary_rpc_urls` below) votes alongside `additionalQuorumRpcUrls` in the
+            // same 2/3 quorum group (see `ValidatorMultiRpcQuorumMerkleTreeHook`), so
+            // `additionalQuorumRpcUrls` only needs to add public endpoints on top of it.
+            let primary_rpc_urls: Vec<Url> = settings
+                .rpcs
+                .iter()
+                .enumerate()
+                .map(|(i, rpc)| {
+                    Url::parse(&rpc.url).map_err(|err| eyre!("Invalid rpcUrls[{i}] entry: {err}"))
+                })
+                .collect::<Result<_>>()?;
+            Self::warn_if_additional_quorum_rpc_not_public(&additional_quorum_rpc_urls);
+            Self::warn_if_quorum_pool_undersized(
+                primary_rpc_urls.len(),
+                additional_quorum_rpc_urls.len(),
+            );
+            Self::warn_if_duplicate_hosts(&primary_rpc_urls, &additional_quorum_rpc_urls);
             Self::build_validator_quorum_merkle_tree_hook(
                 &origin_chain_conf,
-                &quorum_rpc_urls,
+                &primary_rpc_urls,
+                &additional_quorum_rpc_urls,
                 &metrics,
             )
             .await?
         } else {
-            if !quorum_rpc_urls.is_empty() {
+            if !additional_quorum_rpc_urls.is_empty() {
                 warn!(
                     origin_chain = %settings.origin_chain,
-                    "quorumRpcUrls is set but ignored: quorum verification is only supported for Ethereum chains"
+                    "additionalQuorumRpcUrls is set but ignored: quorum verification is only supported for Ethereum chains"
                 );
             }
             settings
@@ -716,12 +740,12 @@ impl BaseAgent for Validator {
 }
 
 impl Validator {
-    /// Opt-in: only true for Ethereum with a non-empty `quorumRpcUrls`.
+    /// Opt-in: only true for Ethereum with a non-empty `additionalQuorumRpcUrls`.
     fn validator_uses_split_quorum_hook(
         origin_chain_conf: &ChainConf,
-        quorum_rpc_urls: &[Url],
+        additional_quorum_rpc_urls: &[(Url, bool)],
     ) -> bool {
-        !quorum_rpc_urls.is_empty()
+        !additional_quorum_rpc_urls.is_empty()
             && matches!(
                 origin_chain_conf.connection,
                 ChainConnectionConf::Ethereum(_)
@@ -731,107 +755,164 @@ impl Validator {
     /// Removes exact duplicate URLs (order-preserving). A duplicated endpoint would
     /// otherwise count as two independent votes, undermining the quorum's independence
     /// assumption.
-    fn dedupe_quorum_rpc_urls(urls: Vec<Url>) -> Vec<Url> {
+    fn dedupe_additional_quorum_rpc_urls(urls: Vec<(Url, bool)>) -> Vec<(Url, bool)> {
         let original_count = urls.len();
         let mut seen = HashSet::new();
-        let deduped: Vec<Url> = urls
+        let deduped: Vec<(Url, bool)> = urls
             .into_iter()
-            .filter(|url| seen.insert(url.clone()))
+            .filter(|(url, _)| seen.insert(url.clone()))
             .collect();
         if deduped.len() < original_count {
             warn!(
                 original_count,
                 deduped_count = deduped.len(),
-                "quorumRpcUrls contained duplicate entries; deduping to preserve vote independence"
+                "additionalQuorumRpcUrls contained duplicate entries; deduping to preserve vote independence"
             );
         }
         deduped
     }
 
     /// Warns (doesn't reject: distinct accounts/API keys on the same provider are a
-    /// legitimate choice) when multiple `quorumRpcUrls` entries share a host, grouped by
-    /// index rather than the host itself so the log never reveals which provider it is.
-    /// Exact-URL dedup alone misses this: different paths/API keys on the same host still
-    /// share a failure domain (one provider outage or compromise counts as N votes).
-    fn warn_if_duplicate_hosts(quorum_rpc_urls: &[Url]) {
-        let mut indices_by_host: HashMap<Option<&str>, Vec<usize>> = HashMap::new();
-        for (i, url) in quorum_rpc_urls.iter().enumerate() {
-            indices_by_host.entry(url.host_str()).or_default().push(i);
+    /// legitimate choice) when multiple entries across `rpcUrls` and `additionalQuorumRpcUrls`
+    /// combined share a host, grouped by label rather than the host itself so the log
+    /// never reveals which provider it is. Both pools vote together (see
+    /// `ValidatorMultiRpcQuorumMerkleTreeHook`), so a host shared between them casts 2
+    /// votes for what's really one provider — the same independence concern as a
+    /// duplicate within a single pool.
+    fn warn_if_duplicate_hosts(
+        primary_rpc_urls: &[Url],
+        additional_quorum_rpc_urls: &[(Url, bool)],
+    ) {
+        let mut indices_by_host: HashMap<Option<&str>, Vec<String>> = HashMap::new();
+        for (i, url) in primary_rpc_urls.iter().enumerate() {
+            indices_by_host
+                .entry(url.host_str())
+                .or_default()
+                .push(format!("rpcUrls[{i}]"));
         }
-        let repeated_host_groups: Vec<Vec<usize>> = indices_by_host
+        for (i, (url, _)) in additional_quorum_rpc_urls.iter().enumerate() {
+            indices_by_host
+                .entry(url.host_str())
+                .or_default()
+                .push(format!("additionalQuorumRpcUrls[{i}]"));
+        }
+        let repeated_host_groups: Vec<Vec<String>> = indices_by_host
             .into_values()
-            .filter(|indices| indices.len() > 1)
+            .filter(|labels| labels.len() > 1)
             .collect();
         if !repeated_host_groups.is_empty() {
             warn!(
                 ?repeated_host_groups,
-                "quorumRpcUrls has multiple entries (by index) sharing a host; they likely \
-                 share a failure domain, weakening the independence the vote relies on"
+                "rpcUrls/additionalQuorumRpcUrls have multiple entries (by label) sharing a host; they \
+                 likely share a failure domain, weakening the independence the vote relies on"
             );
         }
     }
 
-    /// Warns if `quorumRpcUrls` is too small to provide meaningful protection. Recommended:
-    /// include your private `rpcUrls` here too, alongside a sizeable public batch.
-    fn warn_if_quorum_pool_undersized(quorum_rpc_urls: &[Url]) {
-        if quorum_rpc_urls.len() < MIN_RECOMMENDED_QUORUM_RPCS {
+    /// Warns if the combined `rpcUrls` + `additionalQuorumRpcUrls` pool is too small to provide
+    /// meaningful protection.
+    fn warn_if_quorum_pool_undersized(primary_count: usize, quorum_count: usize) {
+        let total = primary_count.saturating_add(quorum_count);
+        if total < MIN_RECOMMENDED_QUORUM_RPCS {
             warn!(
-                quorum_rpc_count = quorum_rpc_urls.len(),
+                primary_count,
+                quorum_count,
+                total,
                 recommended_minimum = MIN_RECOMMENDED_QUORUM_RPCS,
-                "quorumRpcUrls has very few entries and provides little to no real protection; \
-                 consider including your private rpcUrls here too, alongside a sizeable public batch"
+                "the combined rpcUrls + additionalQuorumRpcUrls pool has very few entries and provides \
+                 little to no real protection; consider adding more additionalQuorumRpcUrls entries"
+            );
+        }
+    }
+
+    /// Recommends `additionalQuorumRpcUrls` be used for *additional* public RPCs only: it now votes
+    /// alongside `rpcUrls` (which already covers the private endpoints), so a private
+    /// `additionalQuorumRpcUrls` entry just duplicates coverage `rpcUrls` already provides.
+    fn warn_if_additional_quorum_rpc_not_public(additional_quorum_rpc_urls: &[(Url, bool)]) {
+        let non_public_count = additional_quorum_rpc_urls
+            .iter()
+            .filter(|(_, public)| !public)
+            .count();
+        if non_public_count > 0 {
+            warn!(
+                non_public_count,
+                "additionalQuorumRpcUrls contains non-public entries; it's intended for additional \
+                 public RPCs only — private endpoints are already covered via rpcUrls"
             );
         }
     }
 
     async fn build_validator_quorum_merkle_tree_hook(
         origin_chain_conf: &ChainConf,
-        quorum_rpc_urls: &[Url],
+        primary_rpc_urls: &[Url],
+        additional_quorum_rpc_urls: &[(Url, bool)],
         metrics: &CoreMetrics,
     ) -> ChainResult<Box<dyn MerkleTreeHook>> {
         let base_hook = origin_chain_conf.build_merkle_tree_hook(metrics).await?;
-        let quorum_hooks = Self::build_validator_ethereum_quorum_hooks(
+        let mut quorum_hooks = Self::build_validator_ethereum_per_url_hooks(
             origin_chain_conf,
-            quorum_rpc_urls,
+            "rpcUrls",
+            RpcRole::Primary,
+            primary_rpc_urls,
             metrics,
         )
         .await?;
+        let quorum_only_urls: Vec<Url> = additional_quorum_rpc_urls
+            .iter()
+            .map(|(url, _)| url.clone())
+            .collect();
+        quorum_hooks.extend(
+            Self::build_validator_ethereum_per_url_hooks(
+                origin_chain_conf,
+                "additionalQuorumRpcUrls",
+                RpcRole::Quorum,
+                &quorum_only_urls,
+                metrics,
+            )
+            .await?,
+        );
         Ok(Box::new(ValidatorMultiRpcQuorumMerkleTreeHook {
             base_hook: base_hook.into(),
             quorum_hooks,
         }) as Box<dyn MerkleTreeHook>)
     }
 
-    fn ethereum_chain_conf_for_url(origin_chain_conf: &ChainConf, url: Url) -> ChainConf {
+    fn ethereum_chain_conf_for_url(
+        origin_chain_conf: &ChainConf,
+        url: Url,
+        role: RpcRole,
+    ) -> ChainConf {
         let mut chain_conf = origin_chain_conf.clone();
         if let ChainConnectionConf::Ethereum(updated_conn) = &mut chain_conf.connection {
             updated_conn.rpc_connection = RpcConnectionConf::Http { url };
         }
+        chain_conf.metrics_conf.rpc_role = role;
         chain_conf
     }
 
-    async fn build_validator_ethereum_quorum_hooks(
+    /// Builds one single-URL `MerkleTreeHook` per entry in `urls`, labeled
+    /// `{label_prefix}[i]` (by index, never by host/URL — some entries may be private
+    /// RPCs, and even a redacted host can identify the provider, e.g. "alchemy.com", so
+    /// disagreement logs must never carry anything derived from the URL itself) and
+    /// tagged with `role` (both for `select_quorum_result`'s threshold logic and the
+    /// underlying connection's `rpc_role` Prometheus label).
+    async fn build_validator_ethereum_per_url_hooks(
         origin_chain_conf: &ChainConf,
-        quorum_rpc_urls: &[Url],
+        label_prefix: &str,
+        role: RpcRole,
+        urls: &[Url],
         metrics: &CoreMetrics,
-    ) -> ChainResult<Vec<(String, Arc<dyn MerkleTreeHook>)>> {
-        if quorum_rpc_urls.is_empty() {
-            return Err(ChainCommunicationError::from_other_str(
-                "build_validator_ethereum_quorum_hooks requires a non-empty quorumRpcUrls",
-            ));
-        }
-
-        // Label by index into `quorumRpcUrls`, not host/URL: some entries may be private
-        // RPCs, and even a redacted host can identify the provider (e.g. "alchemy.com"),
-        // so disagreement logs must never carry anything derived from the URL itself.
-        let hooks = try_join_all(quorum_rpc_urls.iter().cloned().enumerate().map(
-            |(i, url)| async move {
-                Self::ethereum_chain_conf_for_url(origin_chain_conf, url)
-                    .build_merkle_tree_hook(metrics)
-                    .await
-                    .map(|hook| (format!("quorumRpcUrls[{i}]"), Arc::from(hook)))
-            },
-        ))
+    ) -> ChainResult<Vec<QuorumHook>> {
+        let hooks = try_join_all(urls.iter().cloned().enumerate().map(|(i, url)| async move {
+            Self::ethereum_chain_conf_for_url(origin_chain_conf, url, role)
+                .build_merkle_tree_hook(metrics)
+                .await
+                .map(|hook| QuorumHook {
+                    label: format!("{label_prefix}[{i}]"),
+                    role,
+                    hook: Arc::from(hook),
+                })
+        }))
         .await?;
 
         Ok(hooks)
@@ -1163,7 +1244,7 @@ mod tests {
             &[]
         ));
 
-        let quorum_urls = vec![Url::parse("http://quorum-a.example").unwrap()];
+        let quorum_urls = vec![(Url::parse("http://quorum-a.example").unwrap(), false)];
         assert!(Validator::validator_uses_split_quorum_hook(
             &chain_conf,
             &quorum_urls
@@ -1171,34 +1252,34 @@ mod tests {
     }
 
     #[test]
-    fn dedupe_quorum_rpc_urls_removes_exact_duplicates_preserving_order() {
+    fn dedupe_additional_quorum_rpc_urls_removes_exact_duplicates_preserving_order() {
         let urls = vec![
-            Url::parse("http://rpc-a.example").unwrap(),
-            Url::parse("http://rpc-b.example").unwrap(),
-            Url::parse("http://rpc-a.example").unwrap(),
-            Url::parse("http://rpc-c.example").unwrap(),
+            (Url::parse("http://rpc-a.example").unwrap(), false),
+            (Url::parse("http://rpc-b.example").unwrap(), true),
+            (Url::parse("http://rpc-a.example").unwrap(), false),
+            (Url::parse("http://rpc-c.example").unwrap(), true),
         ];
 
-        let deduped = Validator::dedupe_quorum_rpc_urls(urls);
+        let deduped = Validator::dedupe_additional_quorum_rpc_urls(urls);
 
         assert_eq!(
             deduped,
             vec![
-                Url::parse("http://rpc-a.example").unwrap(),
-                Url::parse("http://rpc-b.example").unwrap(),
-                Url::parse("http://rpc-c.example").unwrap(),
+                (Url::parse("http://rpc-a.example").unwrap(), false),
+                (Url::parse("http://rpc-b.example").unwrap(), true),
+                (Url::parse("http://rpc-c.example").unwrap(), true),
             ]
         );
     }
 
     #[test]
-    fn dedupe_quorum_rpc_urls_is_noop_without_duplicates() {
+    fn dedupe_additional_quorum_rpc_urls_is_noop_without_duplicates() {
         let urls = vec![
-            Url::parse("http://rpc-a.example").unwrap(),
-            Url::parse("http://rpc-b.example").unwrap(),
+            (Url::parse("http://rpc-a.example").unwrap(), false),
+            (Url::parse("http://rpc-b.example").unwrap(), true),
         ];
 
-        let deduped = Validator::dedupe_quorum_rpc_urls(urls.clone());
+        let deduped = Validator::dedupe_additional_quorum_rpc_urls(urls.clone());
 
         assert_eq!(deduped, urls);
     }
@@ -1206,55 +1287,79 @@ mod tests {
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_quorum_pool_undersized_warns_below_minimum() {
-        let urls = vec![Url::parse("http://rpc-a.example").unwrap()];
+        Validator::warn_if_quorum_pool_undersized(1, 0);
 
-        Validator::warn_if_quorum_pool_undersized(&urls);
-
-        assert!(logs_contain("quorumRpcUrls has very few entries"));
+        assert!(logs_contain(
+            "combined rpcUrls + additionalQuorumRpcUrls pool has very few entries"
+        ));
     }
 
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_quorum_pool_undersized_silent_at_or_above_minimum() {
+        Validator::warn_if_quorum_pool_undersized(1, 2);
+
+        assert!(!logs_contain(
+            "combined rpcUrls + additionalQuorumRpcUrls pool has very few entries"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn warn_if_additional_quorum_rpc_not_public_warns_on_private_entry() {
         let urls = vec![
-            Url::parse("http://rpc-a.example").unwrap(),
-            Url::parse("http://rpc-b.example").unwrap(),
-            Url::parse("http://rpc-c.example").unwrap(),
+            (Url::parse("http://public-a.example").unwrap(), true),
+            (Url::parse("http://private-b.example").unwrap(), false),
         ];
 
-        Validator::warn_if_quorum_pool_undersized(&urls);
+        Validator::warn_if_additional_quorum_rpc_not_public(&urls);
 
-        assert!(!logs_contain("quorumRpcUrls has very few entries"));
+        assert!(logs_contain(
+            "additionalQuorumRpcUrls contains non-public entries"
+        ));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn warn_if_additional_quorum_rpc_not_public_silent_when_all_public() {
+        let urls = vec![
+            (Url::parse("http://public-a.example").unwrap(), true),
+            (Url::parse("http://public-b.example").unwrap(), true),
+        ];
+
+        Validator::warn_if_additional_quorum_rpc_not_public(&urls);
+
+        assert!(!logs_contain(
+            "additionalQuorumRpcUrls contains non-public entries"
+        ));
     }
 
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_duplicate_hosts_warns_on_shared_host() {
-        let urls = vec![
-            Url::parse("http://shared.example/key-a").unwrap(),
-            Url::parse("http://other.example").unwrap(),
-            Url::parse("http://shared.example/key-b").unwrap(),
+        let primary_urls = vec![Url::parse("http://shared.example/key-a").unwrap()];
+        let quorum_urls = vec![
+            (Url::parse("http://other.example").unwrap(), true),
+            (Url::parse("http://shared.example/key-b").unwrap(), true),
         ];
 
-        Validator::warn_if_duplicate_hosts(&urls);
+        Validator::warn_if_duplicate_hosts(&primary_urls, &quorum_urls);
 
         assert!(logs_contain(
-            "quorumRpcUrls has multiple entries (by index) sharing a host"
+            "rpcUrls/additionalQuorumRpcUrls have multiple entries (by label) sharing a host"
         ));
     }
 
     #[test]
     #[tracing_test::traced_test]
     fn warn_if_duplicate_hosts_silent_when_all_distinct() {
-        let urls = vec![
-            Url::parse("http://rpc-a.example").unwrap(),
-            Url::parse("http://rpc-b.example").unwrap(),
-        ];
+        let primary_urls = vec![Url::parse("http://rpc-a.example").unwrap()];
+        let quorum_urls = vec![(Url::parse("http://rpc-b.example").unwrap(), true)];
 
-        Validator::warn_if_duplicate_hosts(&urls);
+        Validator::warn_if_duplicate_hosts(&primary_urls, &quorum_urls);
 
         assert!(!logs_contain(
-            "quorumRpcUrls has multiple entries (by index) sharing a host"
+            "rpcUrls/additionalQuorumRpcUrls have multiple entries (by label) sharing a host"
         ));
     }
 
@@ -1266,7 +1371,8 @@ mod tests {
         ]);
         let url = Url::parse("http://quorum-node.example").unwrap();
 
-        let per_url_conf = Validator::ethereum_chain_conf_for_url(&chain_conf, url.clone());
+        let per_url_conf =
+            Validator::ethereum_chain_conf_for_url(&chain_conf, url.clone(), RpcRole::Quorum);
 
         match per_url_conf.connection {
             ChainConnectionConf::Ethereum(conn) => match conn.rpc_connection {
@@ -1275,13 +1381,14 @@ mod tests {
             },
             _ => panic!("expected an ethereum connection"),
         }
+        assert_eq!(per_url_conf.metrics_conf.rpc_role, RpcRole::Quorum);
     }
 
     #[tokio::test]
-    async fn build_validator_ethereum_quorum_hooks_produces_one_hook_per_url() {
+    async fn build_validator_ethereum_per_url_hooks_produces_one_hook_per_url() {
         let chain_conf =
             dummy_ethereum_chain_conf(vec![Url::parse("http://normal-rpc.example").unwrap()]);
-        let quorum_urls = vec![
+        let urls = vec![
             Url::parse("http://quorum-a.example").unwrap(),
             Url::parse("http://quorum-b.example").unwrap(),
             Url::parse("http://quorum-c.example").unwrap(),
@@ -1293,21 +1400,31 @@ mod tests {
         )
         .unwrap();
 
-        let hooks =
-            Validator::build_validator_ethereum_quorum_hooks(&chain_conf, &quorum_urls, &metrics)
-                .await
-                .unwrap();
+        let hooks = Validator::build_validator_ethereum_per_url_hooks(
+            &chain_conf,
+            "additionalQuorumRpcUrls",
+            RpcRole::Quorum,
+            &urls,
+            &metrics,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(hooks.len(), 3);
-        let labels: Vec<&str> = hooks.iter().map(|(label, _)| label.as_str()).collect();
+        let labels: Vec<&str> = hooks.iter().map(|hook| hook.label.as_str()).collect();
         assert_eq!(
             labels,
-            vec!["quorumRpcUrls[0]", "quorumRpcUrls[1]", "quorumRpcUrls[2]"]
+            vec![
+                "additionalQuorumRpcUrls[0]",
+                "additionalQuorumRpcUrls[1]",
+                "additionalQuorumRpcUrls[2]"
+            ]
         );
+        assert!(hooks.iter().all(|hook| hook.role == RpcRole::Quorum));
     }
 
     #[tokio::test]
-    async fn build_validator_ethereum_quorum_hooks_errors_when_quorum_urls_empty() {
+    async fn build_validator_ethereum_per_url_hooks_empty_urls_produces_no_hooks() {
         let chain_conf = dummy_ethereum_chain_conf(vec![
             Url::parse("http://normal-a.example").unwrap(),
             Url::parse("http://normal-b.example").unwrap(),
@@ -1319,10 +1436,17 @@ mod tests {
         )
         .unwrap();
 
-        let result =
-            Validator::build_validator_ethereum_quorum_hooks(&chain_conf, &[], &metrics).await;
+        let hooks = Validator::build_validator_ethereum_per_url_hooks(
+            &chain_conf,
+            "additionalQuorumRpcUrls",
+            RpcRole::Quorum,
+            &[],
+            &metrics,
+        )
+        .await
+        .unwrap();
 
-        assert!(result.is_err());
+        assert!(hooks.is_empty());
     }
 
     mockall::mock! {
@@ -1351,8 +1475,24 @@ mod tests {
         }
     }
 
-    fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> (String, Arc<dyn MerkleTreeHook>) {
-        (label.to_string(), Arc::new(hook) as Arc<dyn MerkleTreeHook>)
+    /// An `additionalQuorumRpcUrls`-sourced entry (role `Quorum`): a failure is excluded from the
+    /// round's threshold denominator.
+    fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> QuorumHook {
+        quorum_rpc_with_role(label, RpcRole::Quorum, hook)
+    }
+
+    /// An `rpcUrls`-sourced entry (role `Primary`): a failure always still counts against
+    /// the round's threshold denominator.
+    fn primary_rpc(label: &str, hook: MockMerkleTreeHook) -> QuorumHook {
+        quorum_rpc_with_role(label, RpcRole::Primary, hook)
+    }
+
+    fn quorum_rpc_with_role(label: &str, role: RpcRole, hook: MockMerkleTreeHook) -> QuorumHook {
+        QuorumHook {
+            label: label.to_string(),
+            role,
+            hook: Arc::new(hook) as Arc<dyn MerkleTreeHook>,
+        }
     }
 
     #[test]
@@ -1469,8 +1609,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_reaches_two_thirds_and_agrees_with_base_hook(
-    ) {
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_reaches_two_thirds_majority() {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
         let expected_tree = IncrementalMerkleAtBlock {
             tree: Default::default(),
@@ -1488,18 +1627,12 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
+        // base_hook is only used to resolve the target height, never for a post-vote
+        // cross-check.
+        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-        base_hook
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let expected_tree = expected_tree.clone();
-                move |_| Ok(expected_tree)
-            });
 
-        // 2 of 3 (>= two_thirds_threshold(3) == 2) is enough for the quorum_hooks vote, and
-        // that value matches base_hook's own result.
+        // 2 of 3 (>= two_thirds_threshold(3) == 2) is enough for the quorum_hooks vote.
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
         quorum_a
@@ -1612,6 +1745,118 @@ mod tests {
         assert!(hook.tree(&ReorgPeriod::None).await.is_err());
     }
 
+    /// If every quorum_hooks entry that failed is role `Quorum`, the round's returned
+    /// error must not surface either entry's error text verbatim -- it should fall back
+    /// to a generic message instead.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_all_quorum_role_failures_returns_generic_error(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 5);
+
+        let mut quorum_a = MockMerkleTreeHook::new();
+        quorum_a.expect_latest_checkpoint().never();
+        quorum_a
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(5))
+            .return_once(|_| {
+                Err(ChainCommunicationError::from_other_str(
+                    "quorum-role-rpc-a-error-detail",
+                ))
+            });
+
+        let mut quorum_b = MockMerkleTreeHook::new();
+        quorum_b.expect_latest_checkpoint().never();
+        quorum_b
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(5))
+            .return_once(|_| {
+                Err(ChainCommunicationError::from_other_str(
+                    "quorum-role-rpc-b-error-detail",
+                ))
+            });
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![quorum_rpc("rpc-a", quorum_a), quorum_rpc("rpc-b", quorum_b)],
+        };
+
+        let err = hook.tree(&ReorgPeriod::None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("quorum-role-rpc-a-error-detail")
+                && !msg.contains("quorum-role-rpc-b-error-detail"),
+            "a Quorum-role RPC's error text must never surface: {msg}"
+        );
+    }
+
+    /// When both a `Primary`-role and a `Quorum`-role quorum_hooks entry fail, the
+    /// returned error must surface the `Primary`-role one's detail, never the
+    /// `Quorum`-role one's.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_prefers_primary_role_error_over_quorum_role(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 5);
+
+        let mut quorum_role_rpc = MockMerkleTreeHook::new();
+        quorum_role_rpc.expect_latest_checkpoint().never();
+        quorum_role_rpc
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(5))
+            .return_once(|_| {
+                Err(ChainCommunicationError::from_other_str(
+                    "quorum-role-rpc-error-detail",
+                ))
+            });
+
+        let mut primary_role_rpc = MockMerkleTreeHook::new();
+        primary_role_rpc.expect_latest_checkpoint().never();
+        primary_role_rpc
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(5))
+            .return_once(|_| {
+                Err(ChainCommunicationError::from_other_str(
+                    "primary-role-rpc-error-detail",
+                ))
+            });
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                quorum_rpc("rpc-quorum", quorum_role_rpc),
+                primary_rpc("rpc-primary", primary_role_rpc),
+            ],
+        };
+
+        let err = hook.tree(&ReorgPeriod::None).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("primary-role-rpc-error-detail"),
+            "expected the Primary-role RPC's error to surface: {msg}"
+        );
+        assert!(
+            !msg.contains("quorum-role-rpc-error-detail"),
+            "a Quorum-role RPC's error text must never surface: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_tolerates_rpc_failure_within_two_thirds_threshold(
     ) {
@@ -1625,15 +1870,8 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
+        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 11);
-        base_hook
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(11))
-            .return_once({
-                let expected_tree = expected_tree.clone();
-                move |_| Ok(expected_tree)
-            });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
@@ -1677,23 +1915,23 @@ mod tests {
         );
     }
 
-    /// `quorum_hooks` unanimously agree on tree_x, but `base_hook` (the separate `rpcUrls`
-    /// pool) returns tree_y. Agreeing within `quorum_hooks` alone isn't enough: an
-    /// attacker would also need to compromise the independent `rpcUrls` pool.
+    /// 4 configured `quorum_hooks`, 1 public RPC down this round -> excluded from the
+    /// threshold, leaving an effective pool of 3 (threshold 2). Of the 3 responders, only
+    /// 2 agree (the third disagrees) -- still enough to reach the reduced threshold, even
+    /// though it wouldn't reach the un-excluded threshold of 3.
     #[tokio::test]
-    #[tracing_test::traced_test]
-    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_fails_when_quorum_agrees_but_base_hook_disagrees(
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_excludes_down_quorum_role_rpc_from_threshold(
     ) {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
-        let quorum_tree = IncrementalMerkleAtBlock {
+        let expected_tree = IncrementalMerkleAtBlock {
             tree: Default::default(),
             block_height: Some(50),
         };
-        let mut base_merkle =
+        let mut divergent_merkle =
             hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
-        base_merkle.ingest(H256::from_low_u64_be(1));
-        let base_tree = IncrementalMerkleAtBlock {
-            tree: base_merkle,
+        divergent_merkle.ingest(H256::from_low_u64_be(1));
+        let divergent_tree = IncrementalMerkleAtBlock {
+            tree: divergent_merkle,
             block_height: Some(50),
         };
 
@@ -1701,23 +1939,16 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
+        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-        base_hook
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(base_tree));
 
-        let mut quorum_a = MockMerkleTreeHook::new();
-        quorum_a.expect_latest_checkpoint().never();
-        quorum_a
+        let mut quorum_down = MockMerkleTreeHook::new();
+        quorum_down.expect_latest_checkpoint().never();
+        quorum_down
             .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(50))
-            .return_once({
-                let quorum_tree = quorum_tree.clone();
-                move |_| Ok(quorum_tree)
-            });
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("quorum rpc down")));
 
         let mut quorum_b = MockMerkleTreeHook::new();
         quorum_b.expect_latest_checkpoint().never();
@@ -1726,8 +1957,8 @@ mod tests {
             .once()
             .with(mockall::predicate::eq(50))
             .return_once({
-                let quorum_tree = quorum_tree.clone();
-                move |_| Ok(quorum_tree)
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree)
             });
 
         let mut quorum_c = MockMerkleTreeHook::new();
@@ -1736,21 +1967,106 @@ mod tests {
             .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(50))
-            .return_once(move |_| Ok(quorum_tree));
+            .return_once(move |_| Ok(divergent_tree));
+
+        let mut quorum_d = MockMerkleTreeHook::new();
+        quorum_d.expect_latest_checkpoint().never();
+        quorum_d
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(move |_| Ok(expected_tree));
 
         let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
             base_hook: Arc::new(base_hook),
             quorum_hooks: vec![
-                quorum_rpc("rpc-a", quorum_a),
+                quorum_rpc("rpc-quorum-down", quorum_down),
                 quorum_rpc("rpc-b", quorum_b),
                 quorum_rpc("rpc-c", quorum_c),
+                quorum_rpc("rpc-d", quorum_d),
+            ],
+        };
+
+        assert_eq!(
+            hook.tree(&ReorgPeriod::None).await.unwrap().block_height,
+            Some(50)
+        );
+    }
+
+    /// Same 4-hook, 1-down, 1-disagreeing shape as the test above, except the down RPC is
+    /// role `Primary` (an `rpcUrls` entry). `Primary`-role failures are NOT excluded from
+    /// the threshold, so it stays at ceil(2*4/3) = 3; only 2 of the 3 responders agree ->
+    /// quorum fails.
+    #[tokio::test]
+    async fn validator_multi_rpc_quorum_merkle_tree_hook_tree_does_not_exclude_down_primary_role_rpc_from_threshold(
+    ) {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+        let expected_tree = IncrementalMerkleAtBlock {
+            tree: Default::default(),
+            block_height: Some(50),
+        };
+        let mut divergent_merkle =
+            hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+        divergent_merkle.ingest(H256::from_low_u64_be(1));
+        let divergent_tree = IncrementalMerkleAtBlock {
+            tree: divergent_merkle,
+            block_height: Some(50),
+        };
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        // Never reached: the quorum_hooks vote fails before base_hook would be consulted.
+        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        mock_height_resolution(&mut base_hook, mailbox_domain, 50);
+
+        let mut primary_down = MockMerkleTreeHook::new();
+        primary_down.expect_latest_checkpoint().never();
+        primary_down
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(|_| Err(ChainCommunicationError::from_other_str("primary rpc down")));
+
+        let mut quorum_b = MockMerkleTreeHook::new();
+        quorum_b.expect_latest_checkpoint().never();
+        quorum_b
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once({
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree)
+            });
+
+        let mut quorum_c = MockMerkleTreeHook::new();
+        quorum_c.expect_latest_checkpoint().never();
+        quorum_c
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(move |_| Ok(divergent_tree));
+
+        let mut quorum_d = MockMerkleTreeHook::new();
+        quorum_d.expect_latest_checkpoint().never();
+        quorum_d
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(50))
+            .return_once(move |_| Ok(expected_tree));
+
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: Arc::new(base_hook),
+            quorum_hooks: vec![
+                primary_rpc("rpc-primary-down", primary_down),
+                quorum_rpc("rpc-b", quorum_b),
+                quorum_rpc("rpc-c", quorum_c),
+                quorum_rpc("rpc-d", quorum_d),
             ],
         };
 
         assert!(hook.tree(&ReorgPeriod::None).await.is_err());
-        assert!(logs_contain(
-            "quorumRpcUrls consensus disagrees with rpcUrls consensus"
-        ));
     }
 
     /// Regression test for the tip-relative-comparison bug: honest quorum RPCs that all
@@ -1770,20 +2086,8 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_latest_checkpoint_at_block().never();
+        base_hook.expect_tree_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 50);
-        base_hook
-            .expect_tree_at_block()
-            .once()
-            .with(mockall::predicate::eq(50))
-            .return_once({
-                let tree = tree_content.tree.clone();
-                move |_| {
-                    Ok(IncrementalMerkleAtBlock {
-                        tree,
-                        block_height: Some(53),
-                    })
-                }
-            });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
@@ -1872,15 +2176,8 @@ mod tests {
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
         base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 99);
-        base_hook
-            .expect_latest_checkpoint_at_block()
-            .once()
-            .with(mockall::predicate::eq(99))
-            .return_once({
-                let agreed_checkpoint = agreed_checkpoint.clone();
-                move |_| Ok(agreed_checkpoint)
-            });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
@@ -1933,21 +2230,9 @@ mod tests {
         let mut base_hook = MockMerkleTreeHook::new();
         base_hook.expect_count().never();
         base_hook.expect_latest_checkpoint().never();
-        base_hook
-            .expect_latest_checkpoint_at_block()
-            .once()
-            .with(mockall::predicate::eq(42))
-            .return_once(|height| {
-                Ok(CheckpointAtBlock {
-                    checkpoint: hyperlane_core::Checkpoint {
-                        merkle_tree_hook_address: H256::from_low_u64_be(11),
-                        mailbox_domain: 1337,
-                        root: H256::from_low_u64_be(33),
-                        index: 9,
-                    },
-                    block_height: Some(height),
-                })
-            });
+        // `latest_checkpoint_at_block` takes an explicit height, so it never needs
+        // `base_hook` at all (no height resolution, no post-vote cross-check).
+        base_hook.expect_latest_checkpoint_at_block().never();
 
         let make_hook = |root: u64, index: u64| {
             let mut hook = MockMerkleTreeHook::new();
@@ -2016,10 +2301,8 @@ mod tests {
                     block_height: None,
                 })
             });
-        base_hook.expect_tree().once().return_once({
-            let expected_tree = expected_tree.clone();
-            move |_| Ok(expected_tree)
-        });
+        // No post-vote cross-check anymore: base_hook.tree() is never called.
+        base_hook.expect_tree().never();
 
         let make_hook = |tree: IncrementalMerkleAtBlock| {
             let mut hook = MockMerkleTreeHook::new();

--- a/rust/main/chains/hyperlane-cosmos/src/providers/tests.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/tests.rs
@@ -1326,6 +1326,7 @@ async fn test_fallback_provider() {
         connection_type: ClientConnectionType::Rpc,
         node: None,
         chain: None,
+        rpc_role: Default::default(),
     };
     let rpc_client =
         CosmosHttpClient::from_url(&url, metrics.clone(), metrics_config, CompatMode::latest())

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -192,10 +192,14 @@ pub trait BuildableWithProvider {
                 node: Some(NodeInfo {
                     host: url_to_host_info(&url),
                 }),
-                // steal the chain info from the middleware conf
+                // steal the chain info and rpc role from the middleware conf
                 chain: middleware_metrics
                     .as_ref()
                     .and_then(|(_, v)| v.chain.clone()),
+                rpc_role: middleware_metrics
+                    .as_ref()
+                    .map(|(_, v)| v.rpc_role)
+                    .unwrap_or_default(),
             },
         )
     }

--- a/rust/main/ethers-prometheus/src/middleware/mod.rs
+++ b/rust/main/ethers-prometheus/src/middleware/mod.rs
@@ -13,7 +13,7 @@ use ethers::abi::AbiEncode;
 use ethers::prelude::*;
 use ethers::types::transaction::eip2718::TypedTransaction;
 use ethers::utils::hex::ToHex;
-use hyperlane_metric::prometheus_metric::ChainInfo;
+use hyperlane_metric::prometheus_metric::{ChainInfo, RpcRole};
 use maplit::hashmap;
 use prometheus::{CounterVec, IntCounterVec};
 use static_assertions::assert_impl_all;
@@ -203,6 +203,11 @@ pub struct PrometheusMiddlewareConf {
 
     /// Information about the chain this provider is for.
     pub chain: Option<ChainInfo>,
+
+    /// Which pool this connection belongs to (primary vs. a verification-only pool like
+    /// the validator's `additionalQuorumRpcUrls`). Defaults to `Primary`.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub rpc_role: RpcRole,
 }
 
 assert_impl_all!(PrometheusMiddlewareConf: Send, Sync);

--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -29,14 +29,13 @@ spec:
         HYP_CHAINS_{{ .name | upper }}_CUSTOMRPCURLS: {{ printf "'{{ .%s_rpcs | mustFromJson | join \",\" }}'" .name }}
         {{- if .publicRpcUrls }}
         {{- /*
-           * Validator quorum verification: private RPCs (same GCP secret as CUSTOMRPCURLS)
-           * first, then public registry RPCs (baked in at Helm render time, not a secret).
+           * Validator additional quorum verification: additional public registry RPCs
+           * only (baked in at Helm render time, not a secret). CUSTOMRPCURLS already
+           * votes in the same quorum group as a validator, so no private RPCs need
+           * merging in here -- unlike the old design, this is a plain static list with
+           * no secret-templating needed.
            */}}
-        {{- $quotedPublicUrls := list }}
-        {{- range .publicRpcUrls }}
-        {{- $quotedPublicUrls = append $quotedPublicUrls (printf "%q" .) }}
-        {{- end }}
-        HYP_CHAINS_{{ .name | upper }}_CUSTOMQUORUMRPCURLS: {{ printf "'{{ concat (.%s_rpcs | mustFromJson) (list %s) | join \",\" }}'" .name (join " " $quotedPublicUrls) }}
+        HYP_CHAINS_{{ .name | upper }}_CUSTOMADDITIONALQUORUMRPCURLS: {{ join "," .publicRpcUrls | quote }}
         {{- end }}
         {{- if or (eq .protocol "cosmos") (eq .protocol "cosmosnative") }}
         HYP_CHAINS_{{ .name | upper }}_CUSTOMGRPCURLS: {{ printf "'{{ .%s_grpcs | mustFromJson | join \",\" }}'" .name }}

--- a/rust/main/hyperlane-metric/src/prometheus_metric.rs
+++ b/rust/main/hyperlane-metric/src/prometheus_metric.rs
@@ -23,14 +23,26 @@ pub const PROVIDER_DROP_COUNT_HELP: &str =
     "Total number of times this provider was dropped by this client";
 
 /// Expected label names for the metric.
-pub const REQUEST_COUNT_LABELS: &[&str] =
-    &["provider_node", "connection", "chain", "method", "status"];
+pub const REQUEST_COUNT_LABELS: &[&str] = &[
+    "provider_node",
+    "connection",
+    "chain",
+    "method",
+    "status",
+    "rpc_role",
+];
 /// Help string for the metric.
 pub const REQUEST_COUNT_HELP: &str = "Total number of requests made to this client";
 
 /// Expected label names for the metric.
-pub const REQUEST_DURATION_SECONDS_LABELS: &[&str] =
-    &["provider_node", "connection", "chain", "method", "status"];
+pub const REQUEST_DURATION_SECONDS_LABELS: &[&str] = &[
+    "provider_node",
+    "connection",
+    "chain",
+    "method",
+    "status",
+    "rpc_role",
+];
 /// Help string for the metric.
 pub const REQUEST_DURATION_SECONDS_HELP: &str = "Total number of seconds spent making requests";
 
@@ -106,6 +118,7 @@ impl PrometheusClientMetrics {
             "chain" => config.chain_name(),
             "method" => method,
             "status" => if success { "success" } else { "failure" },
+            "rpc_role" => config.rpc_role.as_str(),
         };
         if let Some(counter) = &self.request_count {
             counter.with(&labels).inc()
@@ -164,6 +177,30 @@ impl ClientConnectionType {
     }
 }
 
+/// Which pool an RPC connection belongs to. Lets metrics (and downstream alerting)
+/// distinguish a chain's normal RPC pool from a verification-only pool like the
+/// validator's `additionalQuorumRpcUrls`, where failures are expected/tolerated and shouldn't be
+/// treated the same as a primary-pool failure.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcRole {
+    /// A chain's normal RPC pool (e.g. `rpcUrls`).
+    #[default]
+    Primary,
+    /// A verification-only pool (e.g. the validator's `additionalQuorumRpcUrls`).
+    Quorum,
+}
+
+impl RpcRole {
+    /// as str
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Primary => "primary",
+            Self::Quorum => "quorum",
+        }
+    }
+}
+
 /// Configuration for the prometheus JsonRpcClioent. This can be loaded via
 /// serde.
 #[derive(Default, Clone, Debug, Deserialize)]
@@ -176,6 +213,10 @@ pub struct PrometheusConfig {
 
     /// Information about the chain this client is for.
     pub chain: Option<ChainInfo>,
+
+    /// Which pool this connection belongs to (primary vs. a verification-only pool like
+    /// the validator's `additionalQuorumRpcUrls`). Defaults to `Primary`.
+    pub rpc_role: RpcRole,
 }
 
 impl PrometheusConfig {
@@ -191,6 +232,7 @@ impl PrometheusConfig {
                 host: url_to_host_info(url),
             }),
             chain,
+            rpc_role: RpcRole::default(),
         }
     }
 

--- a/rust/main/lander/src/adapter/chains/radix/conf.rs
+++ b/rust/main/lander/src/adapter/chains/radix/conf.rs
@@ -51,6 +51,7 @@ mod tests {
             metrics_conf: PrometheusMiddlewareConf {
                 contracts: HashMap::new(),
                 chain: None,
+                rpc_role: Default::default(),
             },
             index: IndexSettings::default(),
             confirmations: Default::default(),

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -45,9 +45,9 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: '0cee059-20260730-000935',
   relayerRC: '0cee059-20260730-000935',
   relayerFastPath: '0cee059-20260730-000935',
-  validator: '0cee059-20260730-000935',
-  validatorRC: '0cee059-20260730-000935',
-  validatorFastPath: '0cee059-20260730-000935',
+  validator: 'd29e3f7-20260730-125155',
+  validatorRC: 'd29e3f7-20260730-125155',
+  validatorFastPath: 'd29e3f7-20260730-125155',
   scraper: 'c1678d0-20260728-164228',
   // monorepo services
   checkWarpDeploy: 'main',

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -878,7 +878,7 @@ const hyperlane: RootAgentConfig = {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.validator,
     },
-    // Quorum verification via quorumRpcUrls (ValidatorMultiRpcQuorumMerkleTreeHook)
+    // Quorum verification via additionalQuorumRpcUrls (ValidatorMultiRpcQuorumMerkleTreeHook)
     // is opt-in per chain (quorumVerificationEnabled) and no chain has enabled it
     // yet, so rpcUrls itself must stay on Quorum consensus for now.
     rpcConsensusType: RpcConsensusType.Quorum,
@@ -936,7 +936,7 @@ const releaseCandidate: RootAgentConfig = {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.validatorRC,
     },
-    // Quorum verification via quorumRpcUrls (ValidatorMultiRpcQuorumMerkleTreeHook)
+    // Quorum verification via additionalQuorumRpcUrls (ValidatorMultiRpcQuorumMerkleTreeHook)
     // is opt-in per chain (quorumVerificationEnabled) and no chain has enabled it
     // yet, so rpcUrls itself must stay on Quorum consensus for now.
     rpcConsensusType: RpcConsensusType.Quorum,

--- a/typescript/infra/scripts/rpc/mock-disagree-rpc.ts
+++ b/typescript/infra/scripts/rpc/mock-disagree-rpc.ts
@@ -13,7 +13,7 @@
  *   pnpm tsx scripts/rpc/mock-disagree-rpc.ts --rpc https://ethereum.publicnode.com --port 8899
  *   pnpm tsx scripts/rpc/mock-disagree-rpc.ts --rpc <url> --port 8900 --seed my-fixed-seed
  *
- * Then point one of your quorumRpcUrls entries at http://127.0.0.1:<port>.
+ * Then point one of your additionalQuorumRpcUrls entries at http://127.0.0.1:<port>.
  *
  * IMPORTANT: if running multiple instances to simulate multiple disagreeing
  * providers, let each pick its own random seed (default) or pass distinct

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -418,11 +418,12 @@ export class ValidatorHelmManager extends MultichainAgentHelmManager {
       ...originChain.index,
       interval: cfg.interval,
     };
-    // Public batch for CUSTOMQUORUMRPCURLS; the private batch comes from the same
-    // GCP secret already fetched for CUSTOMRPCURLS (see external-secret.yaml).
-    // Gated on explicit per-chain opt-in: external-secret.yaml emits
-    // CUSTOMQUORUMRPCURLS whenever publicRpcUrls is non-empty, so leaving this
-    // unset keeps quorum verification off until a chain deliberately enables it.
+    // Additional public RPCs for CUSTOMADDITIONALQUORUMRPCURLS. rpcUrls already
+    // votes in the same quorum group (see external-secret.yaml), so no private
+    // batch is merged in here. Gated on explicit per-chain opt-in:
+    // external-secret.yaml emits CUSTOMADDITIONALQUORUMRPCURLS whenever
+    // publicRpcUrls is non-empty, so leaving this unset keeps quorum verification
+    // off until a chain deliberately enables it.
     if (this.config.quorumVerificationEnabled) {
       originChain.publicRpcUrls = getChain(cfg.originChainName).rpcUrls.map(
         (rpc) => rpc.http,

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -64,9 +64,10 @@ interface HelmHyperlaneValues {
 // This is at `.hyperlane.chains` in the values file.
 export interface HelmAgentChainOverride extends DeepPartial<AgentChainMetadata> {
   name: AgentChainMetadata['name'];
-  // Validator only: public registry RPC URLs to append after the private ones (from
-  // GCP Secret Manager) when building CUSTOMQUORUMRPCURLS. Not part of AgentChainMetadata
-  // itself — consumed only by the external-secret Helm template.
+  // Validator only: additional public registry RPC URLs used to build
+  // CUSTOMADDITIONALQUORUMRPCURLS. No private RPCs are merged in here — rpcUrls
+  // already votes in the same quorum group, so this is public-only. Not part of
+  // AgentChainMetadata itself — consumed only by the external-secret Helm template.
   publicRpcUrls?: string[];
 }
 

--- a/typescript/infra/src/config/agent/validator.ts
+++ b/typescript/infra/src/config/agent/validator.ts
@@ -30,8 +30,9 @@ export interface ValidatorBaseChainConfig {
   reorgPeriod: string | number;
   // Individual validator agents
   validators: Array<ValidatorBaseConfig>;
-  // Opt-in per chain: populates quorumRpcUrls (private + public batch) for the
-  // validator's safety-critical merkle tree hook reads. Defaults to false/unset
+  // Opt-in per chain: populates additionalQuorumRpcUrls (additional public batch;
+  // rpcUrls already votes in the same quorum group, so no private batch needed) for
+  // the validator's safety-critical merkle tree hook reads. Defaults to false/unset
   // so quorum verification stays off until deliberately enabled for a chain,
   // rather than turning on for every chain at once. Independent of this, the
   // base hook still uses whatever rpcConsensusType the chain is configured

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -134,6 +134,29 @@ describe('AgentChainMetadataSchema additionalQuorumRpcUrls', () => {
       expect(result.data.additionalQuorumRpcUrls).to.be.undefined;
     }
   });
+
+  it('parses and preserves a configured customAdditionalQuorumRpcUrls override string', () => {
+    const customAdditionalQuorumRpcUrls =
+      'http://quorum-a.example,http://quorum-b.example';
+    const result = AgentChainMetadataSchema.safeParse({
+      ...baseChainMetadata,
+      customAdditionalQuorumRpcUrls,
+    });
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(result.data.customAdditionalQuorumRpcUrls).to.equal(
+        customAdditionalQuorumRpcUrls,
+      );
+    }
+  });
+
+  it('leaves customAdditionalQuorumRpcUrls unset when not configured', () => {
+    const result = AgentChainMetadataSchema.safeParse(baseChainMetadata);
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(result.data.customAdditionalQuorumRpcUrls).to.be.undefined;
+    }
+  });
 });
 
 describe('Agent config', () => {

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -97,7 +97,7 @@ describe('RelayerAgentConfigSchema feeToken gate', () => {
   });
 });
 
-describe('AgentChainMetadataSchema quorumRpcUrls', () => {
+describe('AgentChainMetadataSchema additionalQuorumRpcUrls', () => {
   const baseChainMetadata = {
     name: 'legacy',
     domainId: 1000,
@@ -110,26 +110,28 @@ describe('AgentChainMetadataSchema quorumRpcUrls', () => {
     merkleTreeHook: '0x0000000000000000000000000000000000000004',
   };
 
-  it('parses and preserves a configured quorumRpcUrls array', () => {
-    const quorumRpcUrls = [
+  it('parses and preserves a configured additionalQuorumRpcUrls array', () => {
+    const additionalQuorumRpcUrls = [
       { http: 'http://quorum-a.example' },
       { http: 'http://quorum-b.example' },
     ];
     const result = AgentChainMetadataSchema.safeParse({
       ...baseChainMetadata,
-      quorumRpcUrls,
+      additionalQuorumRpcUrls,
     });
     expect(result.success).to.be.true;
     if (result.success) {
-      expect(result.data.quorumRpcUrls).to.deep.equal(quorumRpcUrls);
+      expect(result.data.additionalQuorumRpcUrls).to.deep.equal(
+        additionalQuorumRpcUrls,
+      );
     }
   });
 
-  it('leaves quorumRpcUrls unset when not configured', () => {
+  it('leaves additionalQuorumRpcUrls unset when not configured', () => {
     const result = AgentChainMetadataSchema.safeParse(baseChainMetadata);
     expect(result.success).to.be.true;
     if (result.success) {
-      expect(result.data.quorumRpcUrls).to.be.undefined;
+      expect(result.data.additionalQuorumRpcUrls).to.be.undefined;
     }
   });
 });

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -234,17 +234,17 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.merge(
       .describe(
         'Specify a comma separated list of custom RPC URLs to use for this chain. If not specified, the default RPC urls will be used.',
       ),
-    quorumRpcUrls: z
+    additionalQuorumRpcUrls: z
       .array(RpcUrlSchema)
       .optional()
       .describe(
-        'Validator only: statically configured RPC URLs that vote together (2/3 majority) on safety-critical merkle tree hook reads. Overridden entirely by customQuorumRpcUrls when set, same as rpcUrls/customRpcUrls. See customQuorumRpcUrls for the full quorum semantics.',
+        'Validator only: statically configured, *additional* RPC URLs that vote together with rpcUrls (2/3 majority, combined) on safety-critical merkle tree hook reads. Overridden entirely by customAdditionalQuorumRpcUrls when set, same as rpcUrls/customRpcUrls. See customAdditionalQuorumRpcUrls for the full quorum semantics.',
       ),
-    customQuorumRpcUrls: z
+    customAdditionalQuorumRpcUrls: z
       .string()
       .optional()
       .describe(
-        'Validator only: comma separated list of RPC URLs that vote together (2/3 majority) on safety-critical merkle tree hook reads. The winning value must also match what rpcUrls (its own configured consensus mode) independently returns. Empty disables quorum verification. Recommended: include your private rpcUrls here too, alongside a sizeable public batch -- a pool of 1-2 entries provides little real protection.',
+        'Validator only: comma separated list of *additional* RPC URLs that vote together with rpcUrls (2/3 majority, combined) on safety-critical merkle tree hook reads. Empty disables quorum verification. Intended for additional public RPCs only -- rpcUrls already votes in the same group, so there is no need to duplicate its (typically private) entries here.',
       ),
     rpcConsensusType: z
       .nativeEnum(RpcConsensusType)

--- a/typescript/utils/src/types.ts
+++ b/typescript/utils/src/types.ts
@@ -148,8 +148,8 @@ export type ValidatorMetadata = {
    * historical blob can be in either shape -- narrow before use, e.g. via
    * `validatorMetadataRpcUrlHash`. */
   rpcs?: Array<string | ValidatorMetadataRpcEntry>;
-  /** The `quorumRpcUrls` set, reported separately from `rpcs`. */
-  quorum_rpcs?: ValidatorMetadataRpcEntry[];
+  /** The `additionalQuorumRpcUrls` set, reported separately from `rpcs`. */
+  additional_quorum_rpcs?: ValidatorMetadataRpcEntry[];
   allows_public_rpcs?: boolean;
 };
 


### PR DESCRIPTION
## Summary

- Changed the config layout: renamed `quorumRpcUrls`/`customQuorumRpcUrls` → `additionalQuorumRpcUrls`/`customAdditionalQuorumRpcUrls` (Rust config parsing, TS SDK schema, TS infra, Helm env var) to make clear the field only *adds to* `rpcUrls`, not replaces it.
- Merged `rpcUrls` and `additionalQuorumRpcUrls` into a single quorum group: `ValidatorMultiRpcQuorumMerkleTreeHook` now runs one 2/3-majority vote across one hook per `rpcUrls` entry (role `Primary`, always counted in the threshold, success or failure) plus one hook per `additionalQuorumRpcUrls` entry (role `Quorum`, excluded from the threshold's denominator on failure, and its error never surfaces as the round's returned error).
- Added an `rpc_role` label (`primary`/`quorum`) on `hyperlane_request_count`/`hyperlane_request_duration_seconds`, plumbed from `ChainConf.metrics_conf` through the ethers metrics wrapper, for incident filtering — so quorum-role RPC failures can be excluded from RPC-error alerting.
- Removed the old cross-check against `base_hook`'s independently-queried consensus — now redundant (and could cause spurious failures) since `rpcUrls` entries vote directly inside the merged group instead of being compared against separately.
- Fixed a Helm template bug (`external-secret.yaml`) that was still merging private RPCs into the quorum env var — redundant and wrong under the merged design, since `rpcUrls` already votes in the same group. Now emits only the additional public RPCs.
- Added a changeset (breaking rename of fields published very recently in `@hyperlane-xyz/sdk`/`@hyperlane-xyz/utils`, with no known external consumers yet, so no backwards-compat alias).

## Test plan

- [x] `cargo test -p validator` — 30 passed
- [x] `cargo clippy -p validator -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `pnpm -C typescript/utils build`, `pnpm -C typescript/sdk build`, `pnpm -C typescript/infra build` — all clean
- [x] `pnpm -C typescript/sdk` mocha run of `agentConfig.test.ts` — 8 passed
- [x] `helm template --show-only templates/external-secret.yaml` dry-run against the `hyperlane-agent` chart to confirm the renamed/fixed env var renders correctly