### PR TITLE
perf(sdk): lazy-load Radix browser runtime

### DIFF
--- a/.changeset/lazy-radix-browser-runtime.md
+++ b/.changeset/lazy-radix-browser-runtime.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/radix-sdk': patch
+'@hyperlane-xyz/sdk': patch
+---
+
+Lazy-loaded the Radix browser provider and exposed token metadata through its public async API so applications without active Radix usage no longer include the Radix Engine Toolkit in their initial bundle.

--- a/typescript/radix-sdk/src/clients/provider.ts
+++ b/typescript/radix-sdk/src/clients/provider.ts
@@ -170,6 +170,10 @@ export class RadixProvider implements AltVM.IProvider<RadixSDKTransaction> {
     });
   }
 
+  async getTokenMetadata(resource: string) {
+    return this.base.getMetadata({ resource });
+  }
+
   async estimateTransactionFee(
     req: AltVM.ReqEstimateTransactionFee<RadixSDKTransaction>,
   ): Promise<AltVM.ResEstimateTransactionFee> {

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -16,7 +16,8 @@
   "type": "module",
   "sideEffects": false,
   "browser": {
-    "./dist/providers/builders/aleo.js": "./dist/providers/builders/aleo.browser.js"
+    "./dist/providers/builders/aleo.js": "./dist/providers/builders/aleo.browser.js",
+    "./dist/providers/builders/radix.js": "./dist/providers/builders/radix.browser.js"
   },
   "types": "./dist/index.d.ts",
   "exports": {

--- a/typescript/sdk/src/providers/builders/radix.browser.ts
+++ b/typescript/sdk/src/providers/builders/radix.browser.ts
@@ -1,0 +1,89 @@
+import type { RadixProvider as RadixSDKProvider } from '@hyperlane-xyz/radix-sdk/runtime';
+import { LazyAsync, assert, isNumeric } from '@hyperlane-xyz/utils';
+
+import type { ChainMetadata } from '../../metadata/chainMetadataTypes.js';
+import type { RadixProvider } from '../ProviderType.js';
+import { ProviderType } from '../ProviderType.js';
+
+import type { ProviderBuilderFn } from './types.js';
+
+interface RadixProviderOptions {
+  rpcUrls: string[];
+  networkId: number;
+  chainMetadata: ChainMetadata;
+}
+
+type RadixProviderConstructor = new (
+  options: RadixProviderOptions,
+) => RadixSDKProvider;
+
+interface RadixRuntimeModule {
+  RadixProvider: RadixProviderConstructor;
+}
+
+type RadixProviderLoader = () => Promise<RadixRuntimeModule>;
+
+const loadRadixProvider: RadixProviderLoader = () =>
+  import('@hyperlane-xyz/radix-sdk/runtime');
+
+function createAsyncMethodProxy<T extends object>(
+  getTarget: () => Promise<T>,
+): T {
+  // CAST: The proxy preserves RadixProvider's async method surface while
+  // deferring construction; getRpcUrls is handled synchronously by its caller.
+  return new Proxy(
+    {},
+    {
+      get: (_, property) => {
+        if (property === 'then') return undefined;
+        return async (...args: unknown[]) => {
+          const target = await getTarget();
+          const method = Reflect.get(target, property);
+          if (typeof method !== 'function') {
+            throw new Error(
+              `Radix provider property ${String(property)} is not callable`,
+            );
+          }
+          return Reflect.apply(method, target, args);
+        };
+      },
+    },
+  ) as T;
+}
+
+export function createLazyRadixProvider(
+  metadata: ChainMetadata,
+  loadProvider: RadixProviderLoader = loadRadixProvider,
+): RadixSDKProvider {
+  const { rpcUrls, chainId } = metadata;
+  assert(rpcUrls.length > 0, 'Radix requires at least one rpcUrl');
+  assert(isNumeric(chainId), 'Radix requires a numeric network id');
+
+  const urls = rpcUrls.map((rpc) => rpc.http);
+  const networkId = parseInt(chainId.toString(), 10);
+  const provider = new LazyAsync(() =>
+    loadProvider().then(
+      ({ RadixProvider }) =>
+        new RadixProvider({
+          rpcUrls: urls,
+          networkId,
+          chainMetadata: metadata,
+        }),
+    ),
+  );
+  const asyncProvider = createAsyncMethodProxy(() => provider.get());
+
+  return new Proxy(asyncProvider, {
+    get: (target, property, receiver) => {
+      if (property === 'getRpcUrls') return () => urls;
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}
+
+export const defaultRadixProviderBuilder: ProviderBuilderFn<RadixProvider> = (
+  metadata: ChainMetadata,
+) => {
+  const provider = createLazyRadixProvider(metadata);
+  return { provider, type: ProviderType.Radix };
+};

--- a/typescript/sdk/src/providers/builders/radix.test.ts
+++ b/typescript/sdk/src/providers/builders/radix.test.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import type { ChainMetadata } from '../../metadata/chainMetadataTypes.js';
+import { ProviderType } from '../ProviderType.js';
+
+import {
+  createLazyRadixProvider,
+  defaultRadixProviderBuilder,
+} from './radix.browser.js';
+
+function radixMetadata(
+  chainId: number | string = 1,
+  rpcUrls: Array<{ http: string }> = [{ http: 'https://rpc.example' }],
+): ChainMetadata {
+  return {
+    name: 'radix',
+    chainId,
+    domainId: 1,
+    protocol: ProtocolType.Radix,
+    rpcUrls,
+  };
+}
+
+describe('createLazyRadixProvider', () => {
+  it('builds a lazy provider while preserving synchronous RPC URLs', () => {
+    const result = defaultRadixProviderBuilder(radixMetadata());
+
+    expect(result.type).to.equal(ProviderType.Radix);
+    expect(result.provider.getRpcUrls()).to.deep.equal(['https://rpc.example']);
+  });
+
+  it('loads and reuses the Radix runtime on first async use', async () => {
+    let loadCount = 0;
+    let constructionCount = 0;
+    const metadata = radixMetadata();
+
+    class FakeRadixProvider {
+      constructor(
+        public readonly options: {
+          rpcUrls: string[];
+          networkId: number;
+          chainMetadata: ChainMetadata;
+        },
+      ) {
+        expect(options).to.deep.equal({
+          rpcUrls: ['https://rpc.example'],
+          networkId: 1,
+          chainMetadata: metadata,
+        });
+        constructionCount++;
+      }
+
+      async isHealthy() {
+        return true;
+      }
+
+      async getHeight() {
+        return this.options.networkId;
+      }
+
+      async getTokenMetadata(resource: string) {
+        return {
+          name: resource,
+          symbol: 'TKN',
+          description: '',
+          decimals: 18,
+        };
+      }
+    }
+
+    const provider = createLazyRadixProvider(
+      metadata,
+      // CAST: The fake implements only the methods exercised by this proxy test.
+      (async () => {
+        loadCount++;
+        return { RadixProvider: FakeRadixProvider };
+      }) as unknown as Parameters<typeof createLazyRadixProvider>[1],
+    );
+
+    expect(provider.getRpcUrls()).to.deep.equal(['https://rpc.example']);
+    expect(loadCount).to.equal(0);
+    expect(constructionCount).to.equal(0);
+
+    const [healthy, height] = await Promise.all([
+      provider.isHealthy(),
+      provider.getHeight(),
+    ]);
+
+    expect(healthy).to.equal(true);
+    expect(height).to.equal(1);
+    expect(loadCount).to.equal(1);
+    expect(constructionCount).to.equal(1);
+    expect(await provider.getHeight()).to.equal(1);
+    expect(await provider.getTokenMetadata('resource_rdx1token')).to.deep.equal(
+      {
+        name: 'resource_rdx1token',
+        symbol: 'TKN',
+        description: '',
+        decimals: 18,
+      },
+    );
+    expect(loadCount).to.equal(1);
+  });
+
+  it('validates metadata without loading the runtime', () => {
+    expect(() => createLazyRadixProvider(radixMetadata(1, []))).to.throw(
+      'Radix requires at least one rpcUrl',
+    );
+    expect(() => createLazyRadixProvider(radixMetadata('mainnet'))).to.throw(
+      'Radix requires a numeric network id',
+    );
+  });
+});

--- a/typescript/sdk/src/signers/signers.ts
+++ b/typescript/sdk/src/signers/signers.ts
@@ -5,7 +5,6 @@ import { ChainName } from '../types.js';
 
 import { CosmosNativeMultiProtocolSignerAdapter } from './cosmos/cosmjs.js';
 import { EvmMultiProtocolSignerAdapter } from './evm/ethersv5.js';
-import { RadixMultiProtocolSignerAdapter } from './radix/radix-toolkit.js';
 import { StarknetMultiProtocolSignerAdapter } from './starknet/starknetjs.js';
 import {
   KeypairSvmTransactionSigner,
@@ -66,6 +65,8 @@ export async function getSignerForChain<TProtocol extends ProtocolType>(
         multiProtocolProvider,
       );
     case ProtocolType.Radix:
+      const { RadixMultiProtocolSignerAdapter } =
+        await import('./radix/radix-toolkit.js');
       return RadixMultiProtocolSignerAdapter.init(
         chainName,
         accountConfig.privateKey,

--- a/typescript/sdk/src/signers/signers.ts
+++ b/typescript/sdk/src/signers/signers.ts
@@ -64,7 +64,7 @@ export async function getSignerForChain<TProtocol extends ProtocolType>(
         accountConfig.address,
         multiProtocolProvider,
       );
-    case ProtocolType.Radix:
+    case ProtocolType.Radix: {
       const { RadixMultiProtocolSignerAdapter } =
         await import('./radix/radix-toolkit.js');
       return RadixMultiProtocolSignerAdapter.init(
@@ -72,6 +72,7 @@ export async function getSignerForChain<TProtocol extends ProtocolType>(
         accountConfig.privateKey,
         multiProtocolProvider,
       );
+    }
     default:
       throw new Error(`Signer not supported for protocol type ${protocol}`);
   }

--- a/typescript/sdk/src/token/adapters/RadixTokenAdapter.ts
+++ b/typescript/sdk/src/token/adapters/RadixTokenAdapter.ts
@@ -1,7 +1,9 @@
 import { BigNumber } from 'bignumber.js';
 
-import { RadixProvider } from '@hyperlane-xyz/radix-sdk/runtime';
-import type { RadixSDKTransaction } from '@hyperlane-xyz/radix-sdk/runtime';
+import type {
+  RadixProvider,
+  RadixSDKTransaction,
+} from '@hyperlane-xyz/radix-sdk/runtime';
 import {
   Address,
   Domain,
@@ -56,10 +58,9 @@ export class RadixTokenAdapter
   }
 
   async getMetadata(): Promise<TokenMetadata> {
-    // Work around to access the base radix provider getMetadata method
-    const { name, symbol, decimals } = await this.provider['base'].getMetadata({
-      resource: this.tokenAddress,
-    });
+    const { name, symbol, decimals } = await this.provider.getTokenMetadata(
+      this.tokenAddress,
+    );
 
     assert(
       name !== undefined,


### PR DESCRIPTION
### Description

Lazy-loads the Radix browser provider and private-key signer so the Radix Engine Toolkit is excluded from initial bundles until Radix functionality is used.

- Adds a browser-specific lazy provider builder while preserving the synchronous `getRpcUrls()` API.
- Loads the private-key Radix signer only when `ProtocolType.Radix` is selected.
- Exposes token metadata through the public provider API, removing the adapter's protected `base` access and making it compatible with the lazy proxy.
- Leaves the Node.js provider builder unchanged.

#### Warp UI initial bundle benchmark

| Route | Before raw / gzip | After raw / gzip | Raw reduction | Gzip reduction |
| --- | ---: | ---: | ---: | ---: |
| `/` | 126.22 / 23.62 MiB | 111.46 / 17.86 MiB | 11.7% | 24.4% |
| `/embed` | 128.04 / 23.95 MiB | 113.27 / 18.20 MiB | 11.5% | 24.0% |
| `/blocked` | 100.86 / 18.05 MiB | 93.52 / 15.17 MiB | 7.3% | 16.0% |

The resulting 7.4 MiB Radix chunk is absent from generated initial HTML and referenced only through Turbopack's async loader.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. Existing browser provider methods retain their API, `getRpcUrls()` remains synchronous, and non-browser behavior is unchanged.

### Testing

- `pnpm format`
- Changed-file Oxlint: zero warnings or errors
- `pnpm -C typescript/radix-sdk build`
- `pnpm -C typescript/sdk test:unit` — 836 passing
- Patched Warp UI `pnpm build`
- Patched Warp UI `pnpm typecheck`
- Patched Warp UI `pnpm test` — 254 passing
- Patched Warp UI `pnpm check:bundle` — all routes passing
