### PR TITLE
fix(infra): correct stale solanamainnet relayer thresholds in key-funder alert footers

### DIFF
--- a/typescript/infra/src/config/funding/alert-query-templates.ts
+++ b/typescript/infra/src/config/funding/alert-query-templates.ts
@@ -14,7 +14,7 @@ export const LOW_URGENCY_KEY_FUNDER_FOOTER = `    # Mainnets that don't use key-
     last_over_time(hyperlane_wallet_balance{wallet_name=~"SOL/eclipsemainnet-solanamainnet/ata-payer | USDC/eclipsemainnet/ata-payer", chain=~"eclipsemainnet"}[1d]) - 0.1 or
 
     # Solana
-    last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 27 or
+    last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 12 or
     # Any ATA payer on Solana
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"solanamainnet"}[1d]) - 0.2 or
     # USDC/eclipsemainnet
@@ -48,7 +48,7 @@ export const LOW_URGENCY_ENG_KEY_FUNDER_FOOTER = `    # Mainnets that don't use 
     last_over_time(hyperlane_wallet_balance{wallet_name=~"SOL/eclipsemainnet-solanamainnet/ata-payer | USDC/eclipsemainnet/ata-payer", chain=~"eclipsemainnet"}[1d]) - 0.05 or
 
     # Solana
-    last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 13.5 or
+    last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 6 or
     # Any ATA payer on Solana
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"solanamainnet"}[1d]) - 0.1 or
     # Any ATA payer on Solana


### PR DESCRIPTION
## Summary
- Follow-up to #9130. That PR corrected the JSON-derived balance thresholds for solanamainnet, but the low-urgency key-funder alert kept firing (PD Q1I2L9GSO6O62Y).
- Root cause: solanamainnet has **no key-funder wallet** — its funds live in the **relayer** wallet, which is a hardcoded special case in `LOW_URGENCY_KEY_FUNDER_FOOTER` / `LOW_URGENCY_ENG_KEY_FUNDER_FOOTER`. Those hardcoded thresholds (`27` low-urgency, `13.5` eng) were derived from the old stale `dailyRelayerBurn` (3.27) and were untouched by #9130.
- Balance sits at ~25.6 SOL (weeks of runway at ~0.4 SOL/day) but `25.6 - 27 < 0` kept the alert firing.
- Lowers the footer thresholds to `12` (low-urgency) and `6` (eng), consistent with the corrected JSON thresholds from #9130.

## Test plan
- [ ] infra-test / test:balance passes after pushing regenerated queries to Grafana via write-alert.ts
- [ ] Confirm PD Q1I2L9GSO6O62Y clears once thresholds propagate

🤖 Generated with [Claude Code](https://claude.com/claude-code)