### PR TITLE
chore(infra): remove warp monitors for routes killed by chain removals

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/warpIds.ts
@@ -1,12 +1,9 @@
 export enum WarpRouteIds {
-  Ancient8EthereumUSDC = 'USDC/ancient8-ethereum',
   RenzoEZETH = 'EZETH/renzo-prod',
   RenzoEZETHSTAGE = 'EZETHSTAGE/renzo-stage',
   RadixUSDC = 'USDC/radix',
-  ArbitrumBaseEnduranceUSDC = 'USDC/arbitrum-base-endurance',
   ArbitrumEthereumZircuitAMPHRETH = 'AMPHRETH/arbitrum-ethereum-zircuit',
   ArbitrumTIA = 'TIA/arbitrum',
-  ArtelaBaseSolanaART = 'ART/artela-base-solanamainnet',
   BscEthereumLumiaPrismPNDR = 'PNDR/bsc-ethereum-lumiaprism',
   BaseSolanamainnetTONY = 'TONY/base-solanamainnet',
   CarrChainCARR = 'CARR/carrchain',
@@ -25,8 +22,6 @@ export enum WarpRouteIds {
   EclipseSolanaKySOL = 'kySOL/kyros',
   EclipseSolanaSOL = 'SOL/eclipsemainnet-solanamainnet',
   EclipseSolanaWIF = 'WIF/eclipsemainnet-solanamainnet',
-  EclipseStrideSTTIA = 'stTIA/eclipsemainnet-stride',
-  EclipseStrideTIA = 'TIA/eclipsemainnet-stride',
   EthereumFlowCbBTC = 'CBBTC/ethereum-flowmainnet',
   EthereumInkUSDC = 'USDC/ethereum-ink',
   EthereumLineaTURTLE = 'TURTLE/ethereum-linea',
@@ -39,10 +34,7 @@ export enum WarpRouteIds {
   EthereumVictionUSDT = 'USDT/ethereum-viction',
   BerachainEthereumSwellUnichainZircuitPZETH = 'PZETH/berachain-ethereum-swell-unichain-zircuit',
   BerachainEthereumSwellUnichainZircuitPZETHSTAGE = 'PZETHSTAGE/berachain-ethereum-swell-unichain-zircuit',
-  EthereumZircuitRe7LRT = 'Re7LRT/ethereum-zircuit',
   ArbitrumAvalancheBaseBscEthereumLumiaprismOptimismPolygonLUMIA = 'LUMIA/arbitrum-avalanche-base-bsc-ethereum-lumiaprism-optimism-polygon',
-  MantapacificTIA = 'TIA/mantapacific',
-  BaseZeroNetworkCBBTC = 'CBBTC/base-zeronetwork',
   BaseEthereumREZ = 'REZ/base-ethereum-unichain',
   BaseEthereumREZSTAGING = 'REZSTAGING/base-ethereum-unichain',
   // Removed here: ETH/arbitrum-base-blast-bsc-ethereum-gnosis-lisk-mantle-mode-optimism-polygon-scroll-zeronetwork-zoramainnet
@@ -57,9 +49,6 @@ export enum WarpRouteIds {
   SuperseedUSDC = 'USDC/superseed',
   EthereumSuperseedUSDT = 'USDT/ethereum-superseed',
   OptimismSuperseedOP = 'OP/optimism-superseed',
-  EthereumZircuitRstETH = 'rstETH/ethereum-zircuit',
-  ArtelaBaseUSDC = 'USDC/artela-base',
-  ArtelaBaseWETH = 'WETH/artela-base',
   SolanaSoonBonk = 'Bonk/solanamainnet-soon',
   SolanaSoonSOL = 'SOL/solanamainnet-soon',
   SolanaSonicsvmSOL = 'SOL/solanamainnet-sonicsvm',
@@ -108,8 +97,6 @@ export enum WarpRouteIds {
   SolaxyUSDC = 'USDC/solaxy',
 
   MantraUSDC = 'USDC/mantra',
-
-  IncentivUSDC = 'USDC/incentiv',
 
   LitchainLITKEY = 'LITKEY/litchain',
 


### PR DESCRIPTION
## Summary

Removes 12 `WarpRouteIds` enum entries whose warp routes are no longer live because a synthetic or collateral leg's chain was decommissioned (chain not in mainnet3 `supportedChainNames`). Deleting the enum entry stops the corresponding warp-route balance monitor from being deployed by `deploy-warp-monitor.ts`.

Determined by cross-referencing every monitored warp route ID against mainnet3's operated chain set, then inspecting each route's collateral/synthetic topology in the registry to confirm no functional path survives the removed leg.

### Removed (route fully dead)

Two-leg routes left with a single stranded leg:

| Warp route ID | Removed chain | Only leg left |
|---|---|---|
| `USDC/ancient8-ethereum` | ancient8 | ethereum |
| `stTIA/eclipsemainnet-stride` | stride | eclipsemainnet |
| `TIA/eclipsemainnet-stride` | stride | eclipsemainnet |
| `Re7LRT/ethereum-zircuit` | zircuit | ethereum |
| `rstETH/ethereum-zircuit` | zircuit | ethereum |
| `TIA/mantapacific` | mantapacific | celestia |
| `CBBTC/base-zeronetwork` | zeronetwork | base |
| `USDC/artela-base` | artela | base |
| `WETH/artela-base` | artela | base |

Multi-leg routes whose essential leg was removed (no functional path remains):

| Warp route ID | Why dead |
|---|---|
| `ART/artela-base-solanamainnet` | artela was the native/collateral home; base+solana synthetics now unbacked |
| `USDC/incentiv` | incentiv was the only synthetic; leftover legs are all USDC collateral (CCTP-covered) |
| `USDC/arbitrum-base-endurance` | endurance held the fiat collateral; leftover arb+base are plain collateral (CCTP-covered) |

None of these 12 keys are referenced anywhere outside `warpIds.ts`, so removal is a clean enum edit.

### Follow-ups (not in this PR)
- `USDC/incentiv` still has a stale rebalancer config at `mainnet3/rebalancer/USDC/incentiv-config.yaml` (balances only the 5 collateral chains) — separate cleanup.
- `USDC/testnet-cctp` is also a dead monitor candidate but it's a testnet route with a live config generator in `warp.ts`, so it's left out of this chain-removal PR.
- Live monitor deployments for the removed routes still need teardown from the mainnet3 cluster.

## Test plan
- [ ] `@hyperlane-xyz/infra` is private (no changeset needed); enum edit only, no external references.
- [ ] CI typecheck/lint passes.