### PR TITLE
chore(infra): bump RPC-efficiency agent images

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -42,8 +42,8 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'c1678d0-20260728-164228',
-  relayerRC: '7da5e55-20260724-123611',
+  relayer: '0cee059-20260730-000935',
+  relayerRC: '0cee059-20260730-000935',
   relayerFastPath: '0cee059-20260730-000935',
   validator: '0cee059-20260730-000935',
   validatorRC: '0cee059-20260730-000935',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -44,10 +44,10 @@ export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
   relayer: 'c1678d0-20260728-164228',
   relayerRC: '7da5e55-20260724-123611',
-  relayerFastPath: 'e22be4b-20260715-194756',
-  validator: 'f265295-20260729-073530',
-  validatorRC: 'f265295-20260729-073530',
-  validatorFastPath: 'f265295-20260729-073530',
+  relayerFastPath: '0cee059-20260730-000935',
+  validator: '0cee059-20260730-000935',
+  validatorRC: '0cee059-20260730-000935',
+  validatorFastPath: '0cee059-20260730-000935',
   scraper: 'c1678d0-20260728-164228',
   // monorepo services
   checkWarpDeploy: 'main',


### PR DESCRIPTION
## Summary

- pin every canonical mainnet relayer and validator context to the Rust agent image built from `main` after #9148, #9149, and #9150
- update both standard and RC relayer configuration tags; retain the existing scraper pin
- deploy the standard relayer only; leave the RC relayer scaled to zero

## Image

- source: `0cee059c37aea9ceab63085c24bba2e090ff0a11`
- tag: `0cee059-20260730-000935`
- digest: `sha256:61d38af95976dd7cee88712ed0378e342ef0acc7fef76f29da22d6e40a83b629`
- build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/30501795662

## Rollout evidence

- fastpath: all 7 validators and the relayer are Ready on the new image with zero restarts
- rendered fastpath polling interval is 2 seconds for both validator and relayer
- validator monitor: 21/21 fastpath validators reachable, max peer lag 1, max on-chain lag 0
- mainnet validators: all 105 active StatefulSets are Ready/current with zero pod restarts; 103 use the new image
- the 103 comprise 96 canonical standard validators plus 7 fastpath validators
- Tempo and Zircuit retain their deliberate non-canonical image pins; inactive RC validator StatefulSets remain scaled to zero
- standard relayer: Helm revision 586, pod 2/2 Ready, zero restarts, exact image digest verified
- standard relayer post-rollout: lander building queues 0; aggregate submitter queue 273 -> 46 and max per-series 120 -> 8 across the sampled pre/post windows
- standard relayer logs had no ERROR/FATAL/panic; two expected WARNs (Paradex initial watermark and one gas-payment reprepare)
- RC relayer was not deployed: live StatefulSet remains at 0 replicas and Helm revision 591

## Verification

- `pnpm build`
- `pnpm --dir typescript/infra check`
- pre-commit gitleaks, oxlint, and oxfmt hooks
- full PR CI green
- immutable image digest inspection
- staged rollout: fastpath validators/relayer, canonical standard validators, then standard relayer
