### PR TITLE
feat: split Starknet runtime artifacts from deployment data

### DIFF
--- a/.changeset/lazy-starknet-runtime-artifacts.md
+++ b/.changeset/lazy-starknet-runtime-artifacts.md
@@ -1,0 +1,8 @@
+---
+'@hyperlane-xyz/deploy-sdk': patch
+'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/starknet-core': minor
+'@hyperlane-xyz/starknet-sdk': minor
+---
+
+Kept Starknet deployment artifacts out of browser runtime paths by publishing ABI and class-hash data through dedicated runtime exports.

--- a/starknet/package.json
+++ b/starknet/package.json
@@ -19,6 +19,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "default": "./dist/runtime.js"
     }
   },
   "scripts": {

--- a/starknet/scripts/StarknetArtifactGenerator.ts
+++ b/starknet/scripts/StarknetArtifactGenerator.ts
@@ -16,6 +16,10 @@ type RawCompiledContract = Omit<CompiledContract, 'abi'> & {
 };
 export type ReadonlyProcessedFilesMap = ReadonlyMap<string, ProcessedFileInfo>;
 
+const CONTRACT_TYPE_PREFIX_REGEX = new RegExp(
+  `^(${Object.values(ContractType).join('|')})_?`,
+);
+
 export class StarknetArtifactGenerator {
   private compiledContractsDir: string;
   private rootOutputDir: string;
@@ -142,10 +146,7 @@ export class StarknetArtifactGenerator {
     processedFilesMap.forEach((value, name) => {
       // Extracts the contract name by removing the prefix (contracts_, token_, or mocks_)
       // Example: "token_HypErc20" becomes "HypErc20"
-      const baseName = name.replace(
-        new RegExp(`^(${Object.values(ContractType).join('|')})_?`),
-        '',
-      );
+      const baseName = name.replace(CONTRACT_TYPE_PREFIX_REGEX, '');
 
       let sierraVarName: string | undefined;
       let casmVarName: string | undefined;
@@ -208,10 +209,7 @@ export class StarknetArtifactGenerator {
     processedFilesMap.forEach((value, name) => {
       if (!value.sierra) return;
 
-      const baseName = name.replace(
-        new RegExp(`^(${Object.values(ContractType).join('|')})_?`),
-        '',
-      );
+      const baseName = name.replace(CONTRACT_TYPE_PREFIX_REGEX, '');
       const runtimeVarName = `${value.type}_${baseName}_runtime`;
       imports.push(
         `import { ${name} as ${runtimeVarName} } from './${name}.js';`,

--- a/starknet/scripts/StarknetArtifactGenerator.ts
+++ b/starknet/scripts/StarknetArtifactGenerator.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { globby } from 'globby';
 import { basename, join } from 'path';
-import { CompiledContract } from 'starknet';
+import { hash, type CompiledContract } from 'starknet';
 
 import { CONTRACT_SUFFIXES } from '../src/const.js';
 import { ContractClass, ContractType } from '../src/types.js';
@@ -11,15 +11,20 @@ import { prettierOutputTransformer } from './prettier.js';
 
 type ProcessedFileInfo = { type: ContractType; sierra: boolean; casm: boolean };
 type ProcessedFilesMap = Map<string, ProcessedFileInfo>;
+type RawCompiledContract = Omit<CompiledContract, 'abi'> & {
+  abi: CompiledContract['abi'] | string;
+};
 export type ReadonlyProcessedFilesMap = ReadonlyMap<string, ProcessedFileInfo>;
 
 export class StarknetArtifactGenerator {
   private compiledContractsDir: string;
   private rootOutputDir: string;
+  private runtimeOutputDir: string;
 
   constructor(compiledContractsDir: string, rootOutputDir: string) {
     this.compiledContractsDir = compiledContractsDir;
     this.rootOutputDir = rootOutputDir;
+    this.runtimeOutputDir = join(rootOutputDir, '../runtime-artifacts');
   }
 
   getContractTypeFromPath(path: string): ContractType {
@@ -57,7 +62,10 @@ export class StarknetArtifactGenerator {
    * @notice Creates the output directory if it doesn't exist
    */
   async createOutputDirectory() {
-    await fs.mkdir(this.rootOutputDir, { recursive: true });
+    await Promise.all([
+      fs.mkdir(this.rootOutputDir, { recursive: true }),
+      fs.mkdir(this.runtimeOutputDir, { recursive: true }),
+    ]);
   }
 
   /**
@@ -99,6 +107,24 @@ export class StarknetArtifactGenerator {
   generateDeclarationContent(name: string, isSierra: boolean) {
     const type = isSierra ? 'CompiledContract' : 'CairoAssembly';
     return Templates.dtsArtifact(name, type);
+  }
+
+  generateRuntimeJavaScriptContent(
+    name: string,
+    artifact: RawCompiledContract,
+  ) {
+    const compiledContract: CompiledContract = {
+      ...artifact,
+      abi:
+        typeof artifact.abi === 'string'
+          ? JSON.parse(artifact.abi)
+          : artifact.abi,
+    };
+
+    return Templates.jsArtifact(name, {
+      abi: compiledContract.abi,
+      classHash: hash.computeContractClassHash(compiledContract),
+    });
   }
 
   /**
@@ -170,6 +196,52 @@ export class StarknetArtifactGenerator {
     };
   }
 
+  generateRuntimeIndexContents(processedFilesMap: ReadonlyProcessedFilesMap): {
+    jsContent: string;
+    dtsContent: string;
+  } {
+    const imports: string[] = [];
+    const contractExports: string[] = [];
+    const tokenExports: string[] = [];
+    const mockExports: string[] = [];
+
+    processedFilesMap.forEach((value, name) => {
+      if (!value.sierra) return;
+
+      const baseName = name.replace(
+        new RegExp(`^(${Object.values(ContractType).join('|')})_?`),
+        '',
+      );
+      const runtimeVarName = `${value.type}_${baseName}_runtime`;
+      imports.push(
+        `import { ${name} as ${runtimeVarName} } from './${name}.js';`,
+      );
+      const exportString = `${baseName}: ${runtimeVarName},`;
+
+      switch (value.type) {
+        case ContractType.TOKEN:
+          tokenExports.push(exportString);
+          break;
+        case ContractType.MOCK:
+          mockExports.push(exportString);
+          break;
+        default:
+          contractExports.push(exportString);
+          break;
+      }
+    });
+
+    return {
+      jsContent: Templates.jsRuntimeIndex(
+        imports.join('\n'),
+        contractExports,
+        tokenExports,
+        mockExports,
+      ),
+      dtsContent: Templates.dtsRuntimeIndex(),
+    };
+  }
+
   /**
    * @notice Processes a single artifact file
    */
@@ -205,6 +277,19 @@ export class StarknetArtifactGenerator {
       join(this.rootOutputDir, outputFileName + '.d.ts'),
       await prettierOutputTransformer(dtsContent),
     );
+
+    if (contractClass === ContractClass.SIERRA) {
+      await Promise.all([
+        fs.writeFile(
+          join(this.runtimeOutputDir, name + '.js'),
+          this.generateRuntimeJavaScriptContent(name, artifact),
+        ),
+        fs.writeFile(
+          join(this.runtimeOutputDir, name + '.d.ts'),
+          await prettierOutputTransformer(Templates.dtsRuntimeArtifact(name)),
+        ),
+      ]);
+    }
 
     return { name, contractType, contractClass };
   }
@@ -251,15 +336,26 @@ export class StarknetArtifactGenerator {
 
     const { jsContent, dtsContent } =
       this.generateIndexContents(processedFilesMap);
+    const runtimeIndex = this.generateRuntimeIndexContents(processedFilesMap);
 
-    await fs.writeFile(
-      join(this.rootOutputDir, 'index.js'),
-      await prettierOutputTransformer(jsContent),
-    );
-    await fs.writeFile(
-      join(this.rootOutputDir, 'index.d.ts'),
-      await prettierOutputTransformer(dtsContent),
-    );
+    await Promise.all([
+      fs.writeFile(
+        join(this.rootOutputDir, 'index.js'),
+        await prettierOutputTransformer(jsContent),
+      ),
+      fs.writeFile(
+        join(this.rootOutputDir, 'index.d.ts'),
+        await prettierOutputTransformer(dtsContent),
+      ),
+      fs.writeFile(
+        join(this.runtimeOutputDir, 'index.js'),
+        await prettierOutputTransformer(runtimeIndex.jsContent),
+      ),
+      fs.writeFile(
+        join(this.runtimeOutputDir, 'index.d.ts'),
+        await prettierOutputTransformer(runtimeIndex.dtsContent),
+      ),
+    ]);
 
     return processedFilesMap;
   }

--- a/starknet/scripts/Templates.ts
+++ b/starknet/scripts/Templates.ts
@@ -10,6 +10,13 @@ export class Templates {
       `;
   }
 
+  static dtsRuntimeArtifact(name: string) {
+    return `
+      import type { StarknetRuntimeContract } from '../types.js';
+      export declare const ${name}: StarknetRuntimeContract;
+      `;
+  }
+
   static jsIndex(
     imports: string,
     contractExports: string[],
@@ -38,5 +45,34 @@ ${mockExports.join('\n')}
   
 import type { StarknetContracts } from '../types';
 export declare const starknetContracts: StarknetContracts;`;
+  }
+
+  static jsRuntimeIndex(
+    imports: string,
+    contractExports: string[],
+    tokenExports: string[],
+    mockExports: string[],
+  ) {
+    return `
+${imports}
+
+export const starknetRuntimeContracts = {
+  contracts: {
+${contractExports.join('\n')}
+  },
+  token: {
+${tokenExports.join('\n')}
+  },
+  mocks: {
+${mockExports.join('\n')}
+  },
+};
+`;
+  }
+
+  static dtsRuntimeIndex() {
+    return `import type { StarknetRuntimeContracts } from '../types.js';
+
+export declare const starknetRuntimeContracts: StarknetRuntimeContracts;`;
   }
 }

--- a/starknet/src/runtime-artifacts/index.d.ts
+++ b/starknet/src/runtime-artifacts/index.d.ts
@@ -1,3 +1,0 @@
-import type { StarknetRuntimeContracts } from '../types.js';
-
-export declare const starknetRuntimeContracts: StarknetRuntimeContracts;

--- a/starknet/src/runtime-artifacts/index.d.ts
+++ b/starknet/src/runtime-artifacts/index.d.ts
@@ -1,0 +1,3 @@
+import type { StarknetRuntimeContracts } from '../types.js';
+
+export declare const starknetRuntimeContracts: StarknetRuntimeContracts;

--- a/starknet/src/runtime-artifacts/index.ts
+++ b/starknet/src/runtime-artifacts/index.ts
@@ -1,0 +1,9 @@
+import type { StarknetRuntimeContracts } from '../types.js';
+
+// Default empty artifacts when `pnpm generate-artifacts` has not run.
+// The generator replaces the emitted dist file with the published runtime data.
+export const starknetRuntimeContracts: StarknetRuntimeContracts = {
+  contracts: {},
+  token: {},
+  mocks: {},
+};

--- a/starknet/src/runtime.ts
+++ b/starknet/src/runtime.ts
@@ -24,17 +24,17 @@ function getRuntimeContractGroup(
 
 function getRuntimeContract(name: string, contractType: ContractType) {
   const group = getRuntimeContractGroup(contractType);
-  const contract = group[name];
-  if (!contract) {
+  if (!Object.prototype.hasOwnProperty.call(group, name)) {
     throw new ContractError(ERR_CODES.CONTRACT_NOT_FOUND, {
       name,
       type: contractType,
     });
   }
 
-  return contract;
+  return group[name];
 }
 
+/** Returns a published contract ABI without loading deployment artifacts. */
 export function getContractAbi(
   name: string,
   contractType: ContractType = ContractType.CONTRACT,
@@ -42,11 +42,19 @@ export function getContractAbi(
   return getRuntimeContract(name, contractType).abi;
 }
 
+/** Returns a precomputed contract class hash without loading deployment artifacts. */
 export function getContractClassHash(
   name: string,
   contractType: ContractType = ContractType.CONTRACT,
 ): string {
   return getRuntimeContract(name, contractType).classHash;
+}
+
+/** Returns the names of all contracts published in a runtime artifact group. */
+export function getRuntimeContractNames(
+  contractType: ContractType = ContractType.CONTRACT,
+): string[] {
+  return Object.keys(getRuntimeContractGroup(contractType));
 }
 
 export { ContractType } from './types.js';

--- a/starknet/src/runtime.ts
+++ b/starknet/src/runtime.ts
@@ -1,0 +1,52 @@
+import type { CompiledContract } from 'starknet';
+
+import { ERR_CODES } from './const.js';
+import { ContractError } from './errors.js';
+import { starknetRuntimeContracts } from './runtime-artifacts/index.js';
+import { ContractType, type StarknetRuntimeContractGroup } from './types.js';
+
+function getRuntimeContractGroup(
+  contractType: ContractType,
+): StarknetRuntimeContractGroup {
+  switch (contractType) {
+    case ContractType.CONTRACT:
+      return starknetRuntimeContracts.contracts;
+    case ContractType.TOKEN:
+      return starknetRuntimeContracts.token;
+    case ContractType.MOCK:
+      return starknetRuntimeContracts.mocks;
+    default:
+      throw new ContractError(ERR_CODES.INVALID_CONTRACT_TYPE, {
+        type: contractType,
+      });
+  }
+}
+
+function getRuntimeContract(name: string, contractType: ContractType) {
+  const group = getRuntimeContractGroup(contractType);
+  const contract = group[name];
+  if (!contract) {
+    throw new ContractError(ERR_CODES.CONTRACT_NOT_FOUND, {
+      name,
+      type: contractType,
+    });
+  }
+
+  return contract;
+}
+
+export function getContractAbi(
+  name: string,
+  contractType: ContractType = ContractType.CONTRACT,
+): CompiledContract['abi'] {
+  return getRuntimeContract(name, contractType).abi;
+}
+
+export function getContractClassHash(
+  name: string,
+  contractType: ContractType = ContractType.CONTRACT,
+): string {
+  return getRuntimeContract(name, contractType).classHash;
+}
+
+export { ContractType } from './types.js';

--- a/starknet/src/types.ts
+++ b/starknet/src/types.ts
@@ -21,6 +21,21 @@ export interface StarknetContracts {
   mocks: StarknetContractGroup;
 }
 
+export interface StarknetRuntimeContract {
+  abi: CompiledContract['abi'];
+  classHash: string;
+}
+
+export interface StarknetRuntimeContractGroup {
+  [name: string]: StarknetRuntimeContract;
+}
+
+export interface StarknetRuntimeContracts {
+  contracts: StarknetRuntimeContractGroup;
+  token: StarknetRuntimeContractGroup;
+  mocks: StarknetRuntimeContractGroup;
+}
+
 /**
  * @notice Contract file type enum
  */

--- a/typescript/deploy-sdk/src/protocol.ts
+++ b/typescript/deploy-sdk/src/protocol.ts
@@ -40,7 +40,7 @@ export async function loadProtocolProviders(
       }
       case ProtocolType.Starknet: {
         const { StarknetProtocolProvider } =
-          await import('@hyperlane-xyz/starknet-sdk');
+          await import('@hyperlane-xyz/starknet-sdk/runtime');
         registerProtocol(protocol, () => new StarknetProtocolProvider());
         break;
       }

--- a/typescript/sdk/src/core/adapters/StarknetCoreAdapter.ts
+++ b/typescript/sdk/src/core/adapters/StarknetCoreAdapter.ts
@@ -5,7 +5,7 @@ import {
   events as eventsUtils,
 } from 'starknet';
 
-import { getCompiledContract } from '@hyperlane-xyz/starknet-core';
+import { getContractAbi } from '@hyperlane-xyz/starknet-core/runtime';
 import { Address, HexString, pollAsync } from '@hyperlane-xyz/utils';
 
 import { BaseStarknetAdapter } from '../../app/MultiProtocolApp.js';
@@ -57,7 +57,7 @@ export class StarknetCoreAdapter
           }) || [];
 
         if (emittedEvents.length === 0) return;
-        const mailboxAbi = getCompiledContract('mailbox').abi;
+        const mailboxAbi = getContractAbi('mailbox');
         parsedEvents = eventsUtils.parseEvents(
           emittedEvents,
           eventsUtils.getAbiEvents(mailboxAbi),

--- a/typescript/sdk/src/utils/starknet.ts
+++ b/typescript/sdk/src/utils/starknet.ts
@@ -10,8 +10,8 @@ import {
 
 import {
   ContractType,
-  getCompiledContract,
-} from '@hyperlane-xyz/starknet-core';
+  getContractAbi,
+} from '@hyperlane-xyz/starknet-core/runtime';
 import { Address, eqAddressStarknet } from '@hyperlane-xyz/utils';
 
 import { DispatchedMessage } from '../core/types.js';
@@ -53,8 +53,11 @@ export function getStarknetContract(
   providerOrAccount?: ProviderInterface | AccountInterface,
   contractType: ContractType = ContractType.CONTRACT,
 ): Contract {
-  const { abi } = getCompiledContract(contractName, contractType);
-  return new Contract(abi, address, providerOrAccount);
+  return new Contract(
+    getContractAbi(contractName, contractType),
+    address,
+    providerOrAccount,
+  );
 }
 
 export function getStarknetMailboxContract(

--- a/typescript/starknet-sdk/package.json
+++ b/typescript/starknet-sdk/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "default": "./dist/runtime.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "default": "./dist/testing/index.js"

--- a/typescript/starknet-sdk/src/clients/provider.ts
+++ b/typescript/starknet-sdk/src/clients/provider.ts
@@ -6,7 +6,6 @@ import {
   Contract,
   RawArgsArray,
   RpcProvider,
-  hash,
   shortString,
 } from 'starknet';
 
@@ -18,8 +17,8 @@ import {
 } from '@hyperlane-xyz/provider-sdk/warp';
 import {
   ContractType,
-  getCompiledContract,
-} from '@hyperlane-xyz/starknet-core';
+  getContractClassHash,
+} from '@hyperlane-xyz/starknet-core/runtime';
 import {
   addressToBytes32,
   assert,
@@ -52,27 +51,18 @@ function getTokenTypeByClassHash(): Map<string, AltVM.TokenType> {
 
   const entries = [
     [
-      hash.computeContractClassHash(
-        getCompiledContract(StarknetContractName.HYP_ERC20, ContractType.TOKEN),
-      ),
+      getContractClassHash(StarknetContractName.HYP_ERC20, ContractType.TOKEN),
       AltVM.TokenType.synthetic,
     ],
     [
-      hash.computeContractClassHash(
-        getCompiledContract(
-          StarknetContractName.HYP_ERC20_COLLATERAL,
-          ContractType.TOKEN,
-        ),
+      getContractClassHash(
+        StarknetContractName.HYP_ERC20_COLLATERAL,
+        ContractType.TOKEN,
       ),
       AltVM.TokenType.collateral,
     ],
     [
-      hash.computeContractClassHash(
-        getCompiledContract(
-          StarknetContractName.HYP_NATIVE,
-          ContractType.TOKEN,
-        ),
-      ),
+      getContractClassHash(StarknetContractName.HYP_NATIVE, ContractType.TOKEN),
       AltVM.TokenType.native,
     ],
   ] satisfies ReadonlyArray<readonly [string, AltVM.TokenType]>;

--- a/typescript/starknet-sdk/src/clients/signer.ts
+++ b/typescript/starknet-sdk/src/clients/signer.ts
@@ -10,12 +10,7 @@ import {
 
 import { AltVM } from '@hyperlane-xyz/provider-sdk';
 import { ChainMetadataForAltVM } from '@hyperlane-xyz/provider-sdk/chain';
-import {
-  ContractType,
-  getCompiledClassHash,
-  getCompiledContract,
-  getContractArtifact,
-} from '@hyperlane-xyz/starknet-core';
+import { ContractType } from '@hyperlane-xyz/starknet-core/runtime';
 import { assert } from '@hyperlane-xyz/utils';
 
 import {
@@ -145,6 +140,8 @@ export class StarknetSigner
     contractAddress: string;
     receipt: GetTransactionReceiptResponse;
   }> {
+    const { getCompiledClassHash, getCompiledContract, getContractArtifact } =
+      await import('@hyperlane-xyz/starknet-core');
     const compiledContract = getCompiledContract(
       params.contractName,
       params.contractType,

--- a/typescript/starknet-sdk/src/contracts.test.ts
+++ b/typescript/starknet-sdk/src/contracts.test.ts
@@ -6,6 +6,7 @@ import {
   ContractType,
   getContractAbi,
   getContractClassHash,
+  getRuntimeContractNames,
 } from '@hyperlane-xyz/starknet-core/runtime';
 import { ZERO_ADDRESS_HEX_32 } from '@hyperlane-xyz/utils';
 
@@ -87,27 +88,30 @@ describe('starknet-sdk contracts helpers', () => {
     expect(tx.calldata).to.deep.equal(new CallData(abi).compile('owner', []));
   });
 
-  it('publishes runtime data matching deployment artifacts in every group', () => {
-    const contracts = [
-      { name: StarknetContractName.MAILBOX, type: ContractType.CONTRACT },
-      { name: StarknetContractName.HYP_NATIVE, type: ContractType.TOKEN },
-      { name: 'TestERC20', type: ContractType.MOCK },
-    ];
+  it('publishes runtime data matching deployment artifacts in every group', function () {
+    this.timeout(120_000);
 
-    for (const { name, type } of contracts) {
-      const compiledContract = getCompiledContract(name, type);
+    for (const contractType of Object.values(ContractType)) {
+      const contractNames = getRuntimeContractNames(contractType);
+      expect(contractNames).not.to.be.empty;
 
-      expect(getContractAbi(name, type)).to.deep.equal(compiledContract.abi);
-      expect(getContractClassHash(name, type)).to.equal(
-        hash.computeContractClassHash(compiledContract),
-      );
+      for (const name of contractNames) {
+        const compiledContract = getCompiledContract(name, contractType);
+
+        expect(getContractAbi(name, contractType)).to.deep.equal(
+          compiledContract.abi,
+        );
+        expect(getContractClassHash(name, contractType)).to.equal(
+          hash.computeContractClassHash(compiledContract),
+        );
+      }
     }
   });
 
-  it('throws when runtime data does not contain the requested contract', () => {
-    expect(() => getContractAbi('missing-contract')).to.throw(
-      'CONTRACT_NOT_FOUND',
-    );
+  it('throws when runtime data does not own the requested contract', () => {
+    for (const name of ['missing-contract', 'toString']) {
+      expect(() => getContractAbi(name)).to.throw('CONTRACT_NOT_FOUND');
+    }
   });
 
   it('throws when coercing bigint values above the safe integer range', () => {

--- a/typescript/starknet-sdk/src/contracts.test.ts
+++ b/typescript/starknet-sdk/src/contracts.test.ts
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
-import { CallData } from 'starknet';
+import { CallData, hash } from 'starknet';
 
+import { getCompiledContract } from '@hyperlane-xyz/starknet-core';
 import {
   ContractType,
-  getCompiledContract,
-} from '@hyperlane-xyz/starknet-core';
+  getContractAbi,
+  getContractClassHash,
+} from '@hyperlane-xyz/starknet-core/runtime';
 import { ZERO_ADDRESS_HEX_32 } from '@hyperlane-xyz/utils';
 
 import {
@@ -66,7 +68,7 @@ describe('starknet-sdk contracts helpers', () => {
   });
 
   it('compiles calldata when populateTransaction helper is unavailable', async () => {
-    const { abi } = getCompiledContract(
+    const abi = getContractAbi(
       StarknetContractName.HYP_ERC20,
       ContractType.TOKEN,
     );
@@ -83,6 +85,29 @@ describe('starknet-sdk contracts helpers', () => {
     );
     expect(tx.entrypoint).to.equal('owner');
     expect(tx.calldata).to.deep.equal(new CallData(abi).compile('owner', []));
+  });
+
+  it('publishes runtime data matching deployment artifacts in every group', () => {
+    const contracts = [
+      { name: StarknetContractName.MAILBOX, type: ContractType.CONTRACT },
+      { name: StarknetContractName.HYP_NATIVE, type: ContractType.TOKEN },
+      { name: 'TestERC20', type: ContractType.MOCK },
+    ];
+
+    for (const { name, type } of contracts) {
+      const compiledContract = getCompiledContract(name, type);
+
+      expect(getContractAbi(name, type)).to.deep.equal(compiledContract.abi);
+      expect(getContractClassHash(name, type)).to.equal(
+        hash.computeContractClassHash(compiledContract),
+      );
+    }
+  });
+
+  it('throws when runtime data does not contain the requested contract', () => {
+    expect(() => getContractAbi('missing-contract')).to.throw(
+      'CONTRACT_NOT_FOUND',
+    );
   });
 
   it('throws when coercing bigint values above the safe integer range', () => {

--- a/typescript/starknet-sdk/src/contracts.ts
+++ b/typescript/starknet-sdk/src/contracts.ts
@@ -14,8 +14,8 @@ import {
 
 import {
   ContractType,
-  getCompiledContract,
-} from '@hyperlane-xyz/starknet-core';
+  getContractAbi as getPublishedContractAbi,
+} from '@hyperlane-xyz/starknet-core/runtime';
 import {
   ZERO_ADDRESS_HEX_32,
   assert,
@@ -133,9 +133,8 @@ export function getStarknetContract(
   providerOrAccount?: ProviderInterface | AccountInterface,
   contractType: ContractType = ContractType.CONTRACT,
 ): Contract {
-  const { abi } = getCompiledContract(contractName, contractType);
   return new Contract(
-    abi,
+    getPublishedContractAbi(contractName, contractType),
     normalizeStarknetAddressSafe(address),
     providerOrAccount,
   );

--- a/typescript/starknet-sdk/src/runtime.ts
+++ b/typescript/starknet-sdk/src/runtime.ts
@@ -1,0 +1,3 @@
+export { StarknetProtocolProvider } from './clients/protocol.js';
+export { StarknetProvider } from './clients/provider.js';
+export { StarknetSigner } from './clients/signer.js';

--- a/typescript/starknet-sdk/src/types.ts
+++ b/typescript/starknet-sdk/src/types.ts
@@ -1,5 +1,5 @@
 import { AnnotatedTx, TxReceipt } from '@hyperlane-xyz/provider-sdk/module';
-import { ContractType } from '@hyperlane-xyz/starknet-core';
+import type { ContractType } from '@hyperlane-xyz/starknet-core/runtime';
 import {
   Call,
   GetTransactionReceiptResponse,

--- a/typescript/starknet-sdk/src/warp/warp-tx.ts
+++ b/typescript/starknet-sdk/src/warp/warp-tx.ts
@@ -5,7 +5,7 @@ import {
   type RpcProvider,
 } from 'starknet';
 
-import { ContractType } from '@hyperlane-xyz/starknet-core';
+import { ContractType } from '@hyperlane-xyz/starknet-core/runtime';
 import {
   ZERO_ADDRESS_HEX_32,
   assert,


### PR DESCRIPTION
### Description

Splits Starknet browser runtime data from full Sierra/CASM deployment artifacts.

- Publishes ABI and precomputed class-hash data through `@hyperlane-xyz/starknet-core/runtime`.
- Routes SDK browser consumers through runtime-safe package exports.
- Dynamically imports full artifacts only when deploying a Starknet contract.
- Adds a runtime entry point for `@hyperlane-xyz/starknet-sdk` and the required changeset.
- Validates all 97 generated runtime entries against their deployment artifacts.

#### Warp UI bundle benchmark

Measured with Turbopack against the same package-updated UI revision and dependency graph:

| Route | Raw initial JS | Gzip initial JS |
| --- | ---: | ---: |
| `/` | 126.22 → 60.40 MiB (-52.15%) | 23.62 → 13.47 MiB (-42.98%) |
| `/embed` | 128.04 → 62.22 MiB (-51.41%) | 23.95 → 13.80 MiB (-42.38%) |
| `/blocked` | 100.86 → 35.04 MiB (-65.26%) | 18.05 → 7.90 MiB (-56.25%) |

Each route removes approximately 65.82 MiB raw and 10.15 MiB gzip from its shared initial bundle.

Reproduction metadata:

- Warp UI revision: [`a42ba606`](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/commit/a42ba6069a5a0fdf23cec8fdd46bd4359034289c)
- Baseline monorepo revision: `5857ead81a8783d168d48d370be72de88d5fb230`
- Starknet split benchmark revision: `f534dd1615556217a816821e5bab1e5483268afb`
- Build command: `pnpm build`
- Measurement command: `pnpm check:bundle`
- Raw bytes come from `.next/diagnostics/route-bundle-stats.json`; gzip bytes are the sum of gzipped first-load chunks, as implemented by `scripts/check-bundle-size.mjs` in the linked UI revision.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. Existing root exports and deployment behavior remain available; the runtime subpaths are additive.
