### PR TITLE
perf(agents): coalesce dynamic block-tip reads

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/contracts/cross_collateral_router.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/cross_collateral_router.rs
@@ -281,6 +281,10 @@ impl BuildableWithProvider for CcrSwapIndexerBuilder {
     type Output = Box<dyn Indexer<SameChainCcrSwap>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_dynamic_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
@@ -293,5 +297,21 @@ impl BuildableWithProvider for CcrSwapIndexerBuilder {
             self.ccr_to_erc20.clone(),
             self.reorg_period,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ccr_indexer_uses_dynamic_block_cache() {
+        let builder = CcrSwapIndexerBuilder {
+            local_domain: 1,
+            ccr_to_erc20: HashMap::new(),
+            reorg_period: EthereumReorgPeriod::Blocks(0),
+        };
+
+        assert!(builder.uses_dynamic_block_cache());
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
@@ -40,6 +40,10 @@ impl BuildableWithProvider for InterchainGasPaymasterIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<InterchainGasPayment>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_finalized_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/interchain_gas.rs
@@ -40,6 +40,10 @@ impl BuildableWithProvider for InterchainGasPaymasterIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<InterchainGasPayment>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_dynamic_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -60,6 +60,10 @@ impl BuildableWithProvider for SequenceIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<HyperlaneMessage>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_finalized_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
@@ -82,6 +86,10 @@ pub struct DeliveryIndexerBuilder {
 impl BuildableWithProvider for DeliveryIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<H256>>;
     const NEEDS_SIGNER: bool = false;
+
+    fn uses_finalized_block_cache(&self) -> bool {
+        true
+    }
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -60,6 +60,10 @@ impl BuildableWithProvider for SequenceIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<HyperlaneMessage>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_dynamic_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,
@@ -82,6 +86,10 @@ pub struct DeliveryIndexerBuilder {
 impl BuildableWithProvider for DeliveryIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<H256>>;
     const NEEDS_SIGNER: bool = false;
+
+    fn uses_dynamic_block_cache(&self) -> bool {
+        true
+    }
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
@@ -68,6 +68,10 @@ impl BuildableWithProvider for MerkleTreeHookIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_finalized_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/merkle_tree_hook.rs
@@ -68,6 +68,10 @@ impl BuildableWithProvider for MerkleTreeHookIndexerBuilder {
     type Output = Box<dyn SequenceAwareIndexer<MerkleTreeInsertion>>;
     const NEEDS_SIGNER: bool = false;
 
+    fn uses_dynamic_block_cache(&self) -> bool {
+        true
+    }
+
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
         provider: M,

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -89,6 +89,11 @@ pub trait BuildableWithProvider {
         true
     }
 
+    /// Whether identical dynamic block-tip reads should be coalesced per concrete endpoint.
+    fn uses_finalized_block_cache(&self) -> bool {
+        false
+    }
+
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
     /// metrics and a signer as needed.
@@ -180,7 +185,7 @@ pub trait BuildableWithProvider {
         client_metrics: &Option<PrometheusClientMetrics>,
         middleware_metrics: &Option<(MiddlewareMetrics, PrometheusMiddlewareConf)>,
     ) -> PrometheusJsonRpcClient<C> {
-        PrometheusJsonRpcClient::new(
+        let client = PrometheusJsonRpcClient::new(
             client,
             client_metrics.clone().unwrap_or_else(|| {
                 PrometheusClientMetricsBuilder::default()
@@ -201,7 +206,12 @@ pub trait BuildableWithProvider {
                     .map(|(_, v)| v.rpc_role)
                     .unwrap_or_default(),
             },
-        )
+        );
+        if self.uses_finalized_block_cache() {
+            client.with_finalized_block_cache(url.as_str())
+        } else {
+            client
+        }
     }
 
     /// Create the provider, applying any middlewares (e.g. gas oracle, signer) as needed,

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -106,6 +106,11 @@ pub trait BuildableWithProvider {
         true
     }
 
+    /// Whether identical dynamic block-tip reads should be coalesced per concrete endpoint.
+    fn uses_dynamic_block_cache(&self) -> bool {
+        false
+    }
+
     /// Construct a new instance of the associated trait using a connection
     /// config. This is the first step and will wrap the provider with
     /// metrics and a signer as needed.
@@ -197,7 +202,7 @@ pub trait BuildableWithProvider {
         client_metrics: &Option<PrometheusClientMetrics>,
         middleware_metrics: &Option<(MiddlewareMetrics, PrometheusMiddlewareConf)>,
     ) -> PrometheusJsonRpcClient<C> {
-        PrometheusJsonRpcClient::new(
+        let client = PrometheusJsonRpcClient::new(
             client,
             client_metrics.clone().unwrap_or_else(|| {
                 PrometheusClientMetricsBuilder::default()
@@ -218,7 +223,12 @@ pub trait BuildableWithProvider {
                     .map(|(_, v)| v.rpc_role)
                     .unwrap_or_default(),
             },
-        )
+        );
+        if self.uses_dynamic_block_cache() {
+            client.with_dynamic_block_cache(url.as_str())
+        } else {
+            client
+        }
     }
 
     /// Create the provider, applying any middlewares (e.g. gas oracle, signer) as needed,

--- a/rust/main/ethers-prometheus/src/json_rpc_client.rs
+++ b/rust/main/ethers-prometheus/src/json_rpc_client.rs
@@ -1,8 +1,12 @@
 //! A wrapper around a JsonRpcClient to give insight at the request level. This
 //! was designed specifically for use with the quorum provider.
 
-use std::fmt::{Debug, Formatter};
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use derive_new::new;
@@ -13,7 +17,114 @@ use hyperlane_core::ChainResult;
 use hyperlane_metric::prometheus_metric::{
     PrometheusClientMetrics, PrometheusConfig, PrometheusConfigExt,
 };
+use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
+
+const DYNAMIC_BLOCK_CACHE_TTL: Duration = Duration::from_millis(250);
+const GET_BLOCK_BY_NUMBER_RPC: &str = "eth_getBlockByNumber";
+const DYNAMIC_BLOCK_TAGS: &[&str] = &["latest", "safe", "finalized"];
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum DynamicBlockMethod {
+    BlockNumber,
+    GetBlockByNumber,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RequestCacheKey {
+    method: DynamicBlockMethod,
+    params: Vec<u8>,
+}
+
+struct EndpointRequestCache {
+    responses: Mutex<HashMap<RequestCacheKey, (Instant, Value)>>,
+    singleflight: Mutex<HashMap<RequestCacheKey, Arc<AsyncMutex<()>>>>,
+    ttl: Duration,
+}
+
+impl EndpointRequestCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            responses: Mutex::new(HashMap::new()),
+            singleflight: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    fn get(&self, key: &RequestCacheKey) -> Option<Value> {
+        let mut responses = self.responses.lock();
+        let (inserted_at, response) = responses.get(key)?;
+        if Instant::now().saturating_duration_since(*inserted_at) < self.ttl {
+            return Some(response.clone());
+        }
+        responses.remove(key);
+        None
+    }
+
+    fn insert(&self, key: RequestCacheKey, response: Value) {
+        self.responses
+            .lock()
+            .insert(key, (Instant::now(), response));
+    }
+
+    fn remove(&self, key: &RequestCacheKey) {
+        self.responses.lock().remove(key);
+    }
+
+    fn singleflight(&self, key: &RequestCacheKey) -> Arc<AsyncMutex<()>> {
+        self.singleflight
+            .lock()
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+}
+
+static DYNAMIC_BLOCK_CACHES: OnceLock<Mutex<HashMap<String, Arc<EndpointRequestCache>>>> =
+    OnceLock::new();
+
+fn endpoint_request_cache(endpoint: String, ttl: Duration) -> Arc<EndpointRequestCache> {
+    DYNAMIC_BLOCK_CACHES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .entry(endpoint)
+        .or_insert_with(|| Arc::new(EndpointRequestCache::new(ttl)))
+        .clone()
+}
+
+fn request_cache_key<T: Serialize>(method: &str, params: &T) -> Option<(RequestCacheKey, Value)> {
+    let params = serde_json::to_value(params).ok()?;
+    let method = match method {
+        BLOCK_NUMBER_RPC => DynamicBlockMethod::BlockNumber,
+        GET_BLOCK_BY_NUMBER_RPC
+            if params
+                .as_array()
+                .and_then(|values| values.first())
+                .and_then(Value::as_str)
+                .is_some_and(|tag| DYNAMIC_BLOCK_TAGS.contains(&tag)) =>
+        {
+            DynamicBlockMethod::GetBlockByNumber
+        }
+        _ => return None,
+    };
+    let serialized_params = match method {
+        DynamicBlockMethod::BlockNumber => Vec::new(),
+        DynamicBlockMethod::GetBlockByNumber => serde_json::to_vec(&params).ok()?,
+    };
+    Some((
+        RequestCacheKey {
+            method,
+            params: serialized_params,
+        },
+        params,
+    ))
+}
+
+fn deserialize_response<R: DeserializeOwned>(response: Value) -> Option<R> {
+    serde_json::from_value(response).ok()
+}
 
 /// An ethers-rs JsonRpcClient wrapper that instruments requests with prometheus
 /// metrics. To make this as flexible as possible, the metric vecs need to be
@@ -23,6 +134,7 @@ pub struct PrometheusJsonRpcClient<C> {
     inner: C,
     metrics: PrometheusClientMetrics,
     config: PrometheusConfig,
+    dynamic_block_cache: Option<Arc<EndpointRequestCache>>,
 }
 
 impl<C> PrometheusJsonRpcClient<C> {
@@ -36,7 +148,23 @@ impl<C> PrometheusJsonRpcClient<C> {
             inner,
             metrics,
             config,
+            dynamic_block_cache: None,
         }
+    }
+
+    /// Coalesce dynamic block-tip reads made through the same concrete RPC endpoint.
+    pub fn with_dynamic_block_cache(mut self, endpoint: impl Into<String>) -> Self {
+        self.dynamic_block_cache = Some(endpoint_request_cache(
+            endpoint.into(),
+            DYNAMIC_BLOCK_CACHE_TTL,
+        ));
+        self
+    }
+
+    #[cfg(test)]
+    fn with_dynamic_block_cache_ttl(mut self, endpoint: impl Into<String>, ttl: Duration) -> Self {
+        self.dynamic_block_cache = Some(endpoint_request_cache(endpoint.into(), ttl));
+        self
     }
 }
 
@@ -50,11 +178,13 @@ impl<C> Drop for PrometheusJsonRpcClient<C> {
 
 impl<C: Clone> Clone for PrometheusJsonRpcClient<C> {
     fn clone(&self) -> Self {
-        Self::new(
+        let mut cloned = Self::new(
             self.inner.clone(),
             self.metrics.clone(),
             self.config.clone(),
-        )
+        );
+        cloned.dynamic_block_cache = self.dynamic_block_cache.clone();
+        cloned
     }
 }
 
@@ -100,6 +230,74 @@ where
         T: Debug + Serialize + Send + Sync,
         R: DeserializeOwned,
     {
+        if let Some(cache) = self
+            .dynamic_block_cache
+            .as_ref()
+            .and_then(|cache| request_cache_key(method, &params).map(|key| (cache, key)))
+        {
+            let (cache, (key, params)) = cache;
+            self.metrics
+                .increment_request_cache_metric(&self.config, method, "logical_read");
+
+            if let Some(response) = cache.get(&key) {
+                if let Some(response) = deserialize_response(response) {
+                    self.metrics
+                        .increment_request_cache_metric(&self.config, method, "cache_hit");
+                    return Ok(response);
+                }
+                cache.remove(&key);
+            }
+
+            let singleflight = cache.singleflight(&key);
+            let _guard = singleflight.lock().await;
+            if let Some(response) = cache.get(&key) {
+                if let Some(response) = deserialize_response(response) {
+                    self.metrics
+                        .increment_request_cache_metric(&self.config, method, "cache_hit");
+                    return Ok(response);
+                }
+                cache.remove(&key);
+            }
+
+            self.metrics
+                .increment_request_cache_metric(&self.config, method, "upstream_read");
+            let response: Value = {
+                let start = Instant::now();
+                let result = self.inner.request(method, params.clone()).await;
+                self.metrics
+                    .increment_metrics(&self.config, method, start, result.is_ok());
+                match result {
+                    Ok(response) => response,
+                    Err(error) => {
+                        self.metrics.increment_request_cache_metric(
+                            &self.config,
+                            method,
+                            "upstream_error",
+                        );
+                        return Err(error);
+                    }
+                }
+            };
+
+            if let Some(decoded) = deserialize_response(response.clone()) {
+                cache.insert(key, response);
+                return Ok(decoded);
+            }
+
+            // Preserve the inner client's typed deserialization error.
+            self.metrics
+                .increment_request_cache_metric(&self.config, method, "upstream_read");
+            let start = Instant::now();
+            let result = self.inner.request(method, params).await;
+            self.metrics
+                .increment_metrics(&self.config, method, start, result.is_ok());
+            if result.is_err() {
+                self.metrics
+                    .increment_request_cache_metric(&self.config, method, "upstream_error");
+            }
+            return result;
+        }
+
         let start = Instant::now();
         let res = self.inner.request(method, params).await;
         self.metrics
@@ -136,5 +334,369 @@ where
             .map(|r: U64| r.as_u64())
             .map_err(Into::into)?;
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex as StdMutex,
+        },
+    };
+
+    use ethers::providers::HttpClientError;
+    use prometheus::{IntCounterVec, Opts};
+    use serde_json::json;
+    use tokio::sync::{Barrier, Notify};
+
+    use super::*;
+
+    #[derive(Clone, Debug, Default)]
+    struct CountingClient {
+        calls: Arc<AtomicUsize>,
+        failures: usize,
+        first_call_started: Option<Arc<Notify>>,
+        block_first_call: Option<Arc<Notify>>,
+        heights: Option<Arc<StdMutex<VecDeque<u64>>>>,
+    }
+
+    #[async_trait]
+    impl JsonRpcClient for CountingClient {
+        type Error = HttpClientError;
+
+        async fn request<T, R>(&self, method: &str, _params: T) -> Result<R, Self::Error>
+        where
+            T: Debug + Serialize + Send + Sync,
+            R: DeserializeOwned,
+        {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                if let Some(started) = &self.first_call_started {
+                    started.notify_waiters();
+                }
+                if let Some(release) = &self.block_first_call {
+                    release.notified().await;
+                }
+            }
+            if call < self.failures {
+                let text = "invalid json".to_owned();
+                return Err(HttpClientError::SerdeJson {
+                    err: serde_json::from_str::<Value>(&text)
+                        .expect_err("mock response should be invalid"),
+                    text,
+                });
+            }
+
+            let height = self
+                .heights
+                .as_ref()
+                .and_then(|heights| {
+                    heights
+                        .lock()
+                        .expect("heights mutex should not be poisoned")
+                        .pop_front()
+                })
+                .unwrap_or(100);
+            let response = match method {
+                BLOCK_NUMBER_RPC => json!(format!("0x{height:x}")),
+                GET_BLOCK_BY_NUMBER_RPC => json!({"number": format!("0x{height:x}")}),
+                _ => json!(null),
+            };
+            serde_json::from_value(response.clone()).map_err(|err| HttpClientError::SerdeJson {
+                err,
+                text: response.to_string(),
+            })
+        }
+    }
+
+    fn cache_metrics() -> PrometheusClientMetrics {
+        let request_cache_count = IntCounterVec::new(
+            Opts::new("test_request_cache_count", "test request cache count"),
+            &["provider_node", "chain", "method", "result", "rpc_role"],
+        )
+        .expect("test metric should be valid");
+        PrometheusClientMetrics {
+            request_cache_count: Some(request_cache_count),
+            ..PrometheusClientMetrics::default()
+        }
+    }
+
+    fn cached_client(
+        endpoint: &str,
+        inner: CountingClient,
+        metrics: PrometheusClientMetrics,
+        ttl: Duration,
+    ) -> PrometheusJsonRpcClient<CountingClient> {
+        PrometheusJsonRpcClient::new(inner, metrics, PrometheusConfig::default())
+            .with_dynamic_block_cache_ttl(endpoint, ttl)
+    }
+
+    #[tokio::test]
+    async fn concurrent_reads_share_one_upstream_request_per_endpoint() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let metrics = cache_metrics();
+        let client = cached_client(
+            "concurrent-endpoint",
+            inner,
+            metrics.clone(),
+            Duration::from_secs(1),
+        );
+        let barrier = Arc::new(Barrier::new(8));
+
+        let tasks = (0..8)
+            .map(|_| {
+                let client = client.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for task in tasks {
+            assert_eq!(
+                task.await
+                    .expect("task should not panic")
+                    .expect("request should succeed"),
+                U64::from(100_u64)
+            );
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let metric = metrics
+            .request_cache_count
+            .expect("cache metric should be configured");
+        assert_eq!(
+            metric
+                .with_label_values(&[
+                    "unknown",
+                    "unknown",
+                    BLOCK_NUMBER_RPC,
+                    "logical_read",
+                    "primary",
+                ])
+                .get(),
+            8
+        );
+        assert_eq!(
+            metric
+                .with_label_values(&[
+                    "unknown",
+                    "unknown",
+                    BLOCK_NUMBER_RPC,
+                    "upstream_read",
+                    "primary",
+                ])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metric
+                .with_label_values(&[
+                    "unknown",
+                    "unknown",
+                    BLOCK_NUMBER_RPC,
+                    "cache_hit",
+                    "primary",
+                ])
+                .get(),
+            7
+        );
+    }
+
+    #[tokio::test]
+    async fn different_endpoints_do_not_share_heights() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let first = cached_client(
+            "endpoint-one",
+            inner.clone(),
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+        let second = cached_client(
+            "endpoint-two",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+
+        first
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("first request should succeed");
+        second
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("second request should succeed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failures_are_not_cached() {
+        let inner = CountingClient {
+            failures: 1,
+            ..CountingClient::default()
+        };
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "failure-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+
+        assert!(client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .is_err());
+        assert_eq!(
+            client
+                .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+                .await
+                .expect("second request should retry"),
+            U64::from(100_u64)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn successful_values_expire_at_the_cache_boundary() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "expiry-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_millis(20),
+        );
+
+        client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("first request should succeed");
+        client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("cached request should succeed");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("expired request should refresh");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn lower_endpoint_heights_are_observable_after_expiry() {
+        let inner = CountingClient {
+            heights: Some(Arc::new(StdMutex::new(VecDeque::from([100, 99])))),
+            ..CountingClient::default()
+        };
+        let client = cached_client(
+            "lower-height-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_millis(20),
+        );
+
+        assert_eq!(
+            client
+                .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+                .await
+                .expect("first request should succeed"),
+            U64::from(100_u64)
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert_eq!(
+            client
+                .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+                .await
+                .expect("expired request should refresh"),
+            U64::from(99_u64)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_initializer_does_not_strand_followers() {
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let inner = CountingClient {
+            first_call_started: Some(started.clone()),
+            block_first_call: Some(release),
+            ..CountingClient::default()
+        };
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "cancel-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+        let started_wait = started.notified();
+        let leader = {
+            let client = client.clone();
+            tokio::spawn(async move { client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await })
+        };
+        started_wait.await;
+        let follower = {
+            let client = client.clone();
+            tokio::spawn(async move { client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await })
+        };
+        tokio::task::yield_now().await;
+        leader.abort();
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), follower)
+                .await
+                .expect("follower should not be stranded")
+                .expect("follower should not panic")
+                .expect("follower should retry"),
+            U64::from(100_u64)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn only_dynamic_block_tags_are_cached() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "tag-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+
+        for _ in 0..2 {
+            client
+                .request::<_, Value>(GET_BLOCK_BY_NUMBER_RPC, ("finalized", false))
+                .await
+                .expect("dynamic block request should succeed");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        for _ in 0..2 {
+            client
+                .request::<_, Value>(GET_BLOCK_BY_NUMBER_RPC, ("safe", false))
+                .await
+                .expect("safe block request should succeed");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        for _ in 0..2 {
+            client
+                .request::<_, Value>(GET_BLOCK_BY_NUMBER_RPC, ("0x10", false))
+                .await
+                .expect("pinned block request should succeed");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
     }
 }

--- a/rust/main/ethers-prometheus/src/json_rpc_client.rs
+++ b/rust/main/ethers-prometheus/src/json_rpc_client.rs
@@ -20,7 +20,7 @@ use hyperlane_metric::prometheus_metric::{
 use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::oneshot;
 
 const DYNAMIC_BLOCK_CACHE_TTL: Duration = Duration::from_millis(250);
 const GET_BLOCK_BY_NUMBER_RPC: &str = "eth_getBlockByNumber";
@@ -40,8 +40,34 @@ struct RequestCacheKey {
 
 struct EndpointRequestCache {
     responses: Mutex<HashMap<RequestCacheKey, (Instant, Value)>>,
-    singleflight: Mutex<HashMap<RequestCacheKey, Arc<AsyncMutex<()>>>>,
+    singleflight: Mutex<HashMap<RequestCacheKey, Vec<oneshot::Sender<()>>>>,
     ttl: Duration,
+}
+
+enum SingleflightRole {
+    Leader(InFlightLeader),
+    Follower(oneshot::Receiver<()>),
+}
+
+struct InFlightLeader {
+    cache: Arc<EndpointRequestCache>,
+    key: RequestCacheKey,
+    completed: bool,
+}
+
+impl InFlightLeader {
+    fn complete(mut self) {
+        self.cache.finish_singleflight(&self.key);
+        self.completed = true;
+    }
+}
+
+impl Drop for InFlightLeader {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.cache.finish_singleflight(&self.key);
+        }
+    }
 }
 
 impl EndpointRequestCache {
@@ -73,12 +99,27 @@ impl EndpointRequestCache {
         self.responses.lock().remove(key);
     }
 
-    fn singleflight(&self, key: &RequestCacheKey) -> Arc<AsyncMutex<()>> {
-        self.singleflight
-            .lock()
-            .entry(key.clone())
-            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
-            .clone()
+    fn singleflight(self: &Arc<Self>, key: &RequestCacheKey) -> SingleflightRole {
+        let mut singleflight = self.singleflight.lock();
+        if let Some(waiters) = singleflight.get_mut(key) {
+            let (sender, receiver) = oneshot::channel();
+            waiters.push(sender);
+            return SingleflightRole::Follower(receiver);
+        }
+
+        singleflight.insert(key.clone(), Vec::new());
+        SingleflightRole::Leader(InFlightLeader {
+            cache: self.clone(),
+            key: key.clone(),
+            completed: false,
+        })
+    }
+
+    fn finish_singleflight(&self, key: &RequestCacheKey) {
+        let waiters = self.singleflight.lock().remove(key).unwrap_or_default();
+        for waiter in waiters {
+            let _ = waiter.send(());
+        }
     }
 }
 
@@ -248,16 +289,43 @@ where
                 cache.remove(&key);
             }
 
-            let singleflight = cache.singleflight(&key);
-            let _guard = singleflight.lock().await;
-            if let Some(response) = cache.get(&key) {
-                if let Some(response) = deserialize_response(response) {
+            let leader = match cache.singleflight(&key) {
+                SingleflightRole::Leader(leader) => leader,
+                SingleflightRole::Follower(waiter) => {
+                    let _ = waiter.await;
+                    if let Some(response) = cache.get(&key) {
+                        if let Some(response) = deserialize_response(response) {
+                            self.metrics.increment_request_cache_metric(
+                                &self.config,
+                                method,
+                                "cache_hit",
+                            );
+                            return Ok(response);
+                        }
+                        cache.remove(&key);
+                    }
+
+                    // The leader failed or was cancelled. Release this generation's
+                    // followers together instead of serializing retries behind the key.
+                    self.metrics.increment_request_cache_metric(
+                        &self.config,
+                        method,
+                        "upstream_read",
+                    );
+                    let start = Instant::now();
+                    let result = self.inner.request(method, params).await;
                     self.metrics
-                        .increment_request_cache_metric(&self.config, method, "cache_hit");
-                    return Ok(response);
+                        .increment_metrics(&self.config, method, start, result.is_ok());
+                    if result.is_err() {
+                        self.metrics.increment_request_cache_metric(
+                            &self.config,
+                            method,
+                            "upstream_error",
+                        );
+                    }
+                    return result;
                 }
-                cache.remove(&key);
-            }
+            };
 
             self.metrics
                 .increment_request_cache_metric(&self.config, method, "upstream_read");
@@ -281,6 +349,7 @@ where
 
             if let Some(decoded) = deserialize_response(response.clone()) {
                 cache.insert(key, response);
+                leader.complete();
                 return Ok(decoded);
             }
 
@@ -360,6 +429,7 @@ mod tests {
         failures: usize,
         first_call_started: Option<Arc<Notify>>,
         block_first_call: Option<Arc<Notify>>,
+        block_after_first_call: Option<Arc<Barrier>>,
         heights: Option<Arc<StdMutex<VecDeque<u64>>>>,
     }
 
@@ -380,6 +450,8 @@ mod tests {
                 if let Some(release) = &self.block_first_call {
                     release.notified().await;
                 }
+            } else if let Some(barrier) = &self.block_after_first_call {
+                barrier.wait().await;
             }
             if call < self.failures {
                 let text = "invalid json".to_owned();
@@ -563,6 +635,58 @@ mod tests {
             U64::from(100_u64)
         );
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_leader_releases_current_followers_together() {
+        let started = Arc::new(Notify::new());
+        let release_leader = Arc::new(Notify::new());
+        let followers_started = Arc::new(Barrier::new(8));
+        let inner = CountingClient {
+            failures: 1,
+            first_call_started: Some(started.clone()),
+            block_first_call: Some(release_leader.clone()),
+            block_after_first_call: Some(followers_started.clone()),
+            ..CountingClient::default()
+        };
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "failed-leader-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+        let barrier = Arc::new(Barrier::new(8));
+        let started_wait = started.notified();
+
+        let tasks = (0..8)
+            .map(|_| {
+                let client = client.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        started_wait.await;
+        release_leader.notify_waiters();
+        tokio::time::timeout(Duration::from_secs(1), followers_started.wait())
+            .await
+            .expect("all followers should retry without serializing");
+
+        let mut successes = 0;
+        let mut failures = 0;
+        for task in tasks {
+            match task.await.expect("task should not panic") {
+                Ok(_) => successes += 1,
+                Err(_) => failures += 1,
+            }
+        }
+        assert_eq!(successes, 7);
+        assert_eq!(failures, 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 8);
     }
 
     #[tokio::test]

--- a/rust/main/ethers-prometheus/src/json_rpc_client.rs
+++ b/rust/main/ethers-prometheus/src/json_rpc_client.rs
@@ -1,8 +1,12 @@
 //! A wrapper around a JsonRpcClient to give insight at the request level. This
 //! was designed specifically for use with the quorum provider.
 
-use std::fmt::{Debug, Formatter};
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use derive_new::new;
@@ -13,7 +17,114 @@ use hyperlane_core::ChainResult;
 use hyperlane_metric::prometheus_metric::{
     PrometheusClientMetrics, PrometheusConfig, PrometheusConfigExt,
 };
+use parking_lot::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex as AsyncMutex;
+
+const FINALIZED_BLOCK_CACHE_TTL: Duration = Duration::from_millis(250);
+const GET_BLOCK_BY_NUMBER_RPC: &str = "eth_getBlockByNumber";
+const DYNAMIC_BLOCK_TAGS: &[&str] = &["latest", "safe", "finalized"];
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum DynamicBlockMethod {
+    BlockNumber,
+    GetBlockByNumber,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RequestCacheKey {
+    method: DynamicBlockMethod,
+    params: Vec<u8>,
+}
+
+struct EndpointRequestCache {
+    responses: Mutex<HashMap<RequestCacheKey, (Instant, Value)>>,
+    singleflight: Mutex<HashMap<RequestCacheKey, Arc<AsyncMutex<()>>>>,
+    ttl: Duration,
+}
+
+impl EndpointRequestCache {
+    fn new(ttl: Duration) -> Self {
+        Self {
+            responses: Mutex::new(HashMap::new()),
+            singleflight: Mutex::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    fn get(&self, key: &RequestCacheKey) -> Option<Value> {
+        let mut responses = self.responses.lock();
+        let (inserted_at, response) = responses.get(key)?;
+        if Instant::now().saturating_duration_since(*inserted_at) < self.ttl {
+            return Some(response.clone());
+        }
+        responses.remove(key);
+        None
+    }
+
+    fn insert(&self, key: RequestCacheKey, response: Value) {
+        self.responses
+            .lock()
+            .insert(key, (Instant::now(), response));
+    }
+
+    fn remove(&self, key: &RequestCacheKey) {
+        self.responses.lock().remove(key);
+    }
+
+    fn singleflight(&self, key: &RequestCacheKey) -> Arc<AsyncMutex<()>> {
+        self.singleflight
+            .lock()
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+}
+
+static FINALIZED_BLOCK_CACHES: OnceLock<Mutex<HashMap<String, Arc<EndpointRequestCache>>>> =
+    OnceLock::new();
+
+fn endpoint_request_cache(endpoint: String, ttl: Duration) -> Arc<EndpointRequestCache> {
+    FINALIZED_BLOCK_CACHES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .entry(endpoint)
+        .or_insert_with(|| Arc::new(EndpointRequestCache::new(ttl)))
+        .clone()
+}
+
+fn request_cache_key<T: Serialize>(method: &str, params: &T) -> Option<(RequestCacheKey, Value)> {
+    let params = serde_json::to_value(params).ok()?;
+    let method = match method {
+        BLOCK_NUMBER_RPC => DynamicBlockMethod::BlockNumber,
+        GET_BLOCK_BY_NUMBER_RPC
+            if params
+                .as_array()
+                .and_then(|values| values.first())
+                .and_then(Value::as_str)
+                .is_some_and(|tag| DYNAMIC_BLOCK_TAGS.contains(&tag)) =>
+        {
+            DynamicBlockMethod::GetBlockByNumber
+        }
+        _ => return None,
+    };
+    let serialized_params = match method {
+        DynamicBlockMethod::BlockNumber => Vec::new(),
+        DynamicBlockMethod::GetBlockByNumber => serde_json::to_vec(&params).ok()?,
+    };
+    Some((
+        RequestCacheKey {
+            method,
+            params: serialized_params,
+        },
+        params,
+    ))
+}
+
+fn deserialize_response<R: DeserializeOwned>(response: Value) -> Option<R> {
+    serde_json::from_value(response).ok()
+}
 
 /// An ethers-rs JsonRpcClient wrapper that instruments requests with prometheus
 /// metrics. To make this as flexible as possible, the metric vecs need to be
@@ -23,6 +134,7 @@ pub struct PrometheusJsonRpcClient<C> {
     inner: C,
     metrics: PrometheusClientMetrics,
     config: PrometheusConfig,
+    finalized_block_cache: Option<Arc<EndpointRequestCache>>,
 }
 
 impl<C> PrometheusJsonRpcClient<C> {
@@ -36,7 +148,27 @@ impl<C> PrometheusJsonRpcClient<C> {
             inner,
             metrics,
             config,
+            finalized_block_cache: None,
         }
+    }
+
+    /// Coalesce dynamic block-tip reads made through the same concrete RPC endpoint.
+    pub fn with_finalized_block_cache(mut self, endpoint: impl Into<String>) -> Self {
+        self.finalized_block_cache = Some(endpoint_request_cache(
+            endpoint.into(),
+            FINALIZED_BLOCK_CACHE_TTL,
+        ));
+        self
+    }
+
+    #[cfg(test)]
+    fn with_finalized_block_cache_ttl(
+        mut self,
+        endpoint: impl Into<String>,
+        ttl: Duration,
+    ) -> Self {
+        self.finalized_block_cache = Some(endpoint_request_cache(endpoint.into(), ttl));
+        self
     }
 }
 
@@ -50,11 +182,13 @@ impl<C> Drop for PrometheusJsonRpcClient<C> {
 
 impl<C: Clone> Clone for PrometheusJsonRpcClient<C> {
     fn clone(&self) -> Self {
-        Self::new(
+        let mut cloned = Self::new(
             self.inner.clone(),
             self.metrics.clone(),
             self.config.clone(),
-        )
+        );
+        cloned.finalized_block_cache = self.finalized_block_cache.clone();
+        cloned
     }
 }
 
@@ -100,6 +234,74 @@ where
         T: Debug + Serialize + Send + Sync,
         R: DeserializeOwned,
     {
+        if let Some(cache) = self
+            .finalized_block_cache
+            .as_ref()
+            .and_then(|cache| request_cache_key(method, &params).map(|key| (cache, key)))
+        {
+            let (cache, (key, params)) = cache;
+            self.metrics
+                .increment_request_cache_metric(&self.config, method, "logical_read");
+
+            if let Some(response) = cache.get(&key) {
+                if let Some(response) = deserialize_response(response) {
+                    self.metrics
+                        .increment_request_cache_metric(&self.config, method, "cache_hit");
+                    return Ok(response);
+                }
+                cache.remove(&key);
+            }
+
+            let singleflight = cache.singleflight(&key);
+            let _guard = singleflight.lock().await;
+            if let Some(response) = cache.get(&key) {
+                if let Some(response) = deserialize_response(response) {
+                    self.metrics
+                        .increment_request_cache_metric(&self.config, method, "cache_hit");
+                    return Ok(response);
+                }
+                cache.remove(&key);
+            }
+
+            self.metrics
+                .increment_request_cache_metric(&self.config, method, "upstream_read");
+            let response: Value = {
+                let start = Instant::now();
+                let result = self.inner.request(method, params.clone()).await;
+                self.metrics
+                    .increment_metrics(&self.config, method, start, result.is_ok());
+                match result {
+                    Ok(response) => response,
+                    Err(error) => {
+                        self.metrics.increment_request_cache_metric(
+                            &self.config,
+                            method,
+                            "upstream_error",
+                        );
+                        return Err(error);
+                    }
+                }
+            };
+
+            if let Some(decoded) = deserialize_response(response.clone()) {
+                cache.insert(key, response);
+                return Ok(decoded);
+            }
+
+            // Preserve the inner client's typed deserialization error.
+            self.metrics
+                .increment_request_cache_metric(&self.config, method, "upstream_read");
+            let start = Instant::now();
+            let result = self.inner.request(method, params).await;
+            self.metrics
+                .increment_metrics(&self.config, method, start, result.is_ok());
+            if result.is_err() {
+                self.metrics
+                    .increment_request_cache_metric(&self.config, method, "upstream_error");
+            }
+            return result;
+        }
+
         let start = Instant::now();
         let res = self.inner.request(method, params).await;
         self.metrics
@@ -136,5 +338,369 @@ where
             .map(|r: U64| r.as_u64())
             .map_err(Into::into)?;
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex as StdMutex,
+        },
+    };
+
+    use ethers::providers::HttpClientError;
+    use prometheus::{IntCounterVec, Opts};
+    use serde_json::json;
+    use tokio::sync::{Barrier, Notify};
+
+    use super::*;
+
+    #[derive(Clone, Debug, Default)]
+    struct CountingClient {
+        calls: Arc<AtomicUsize>,
+        failures: usize,
+        first_call_started: Option<Arc<Notify>>,
+        block_first_call: Option<Arc<Notify>>,
+        heights: Option<Arc<StdMutex<VecDeque<u64>>>>,
+    }
+
+    #[async_trait]
+    impl JsonRpcClient for CountingClient {
+        type Error = HttpClientError;
+
+        async fn request<T, R>(&self, method: &str, _params: T) -> Result<R, Self::Error>
+        where
+            T: Debug + Serialize + Send + Sync,
+            R: DeserializeOwned,
+        {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                if let Some(started) = &self.first_call_started {
+                    started.notify_waiters();
+                }
+                if let Some(release) = &self.block_first_call {
+                    release.notified().await;
+                }
+            }
+            if call < self.failures {
+                let text = "invalid json".to_owned();
+                return Err(HttpClientError::SerdeJson {
+                    err: serde_json::from_str::<Value>(&text)
+                        .expect_err("mock response should be invalid"),
+                    text,
+                });
+            }
+
+            let height = self
+                .heights
+                .as_ref()
+                .and_then(|heights| {
+                    heights
+                        .lock()
+                        .expect("heights mutex should not be poisoned")
+                        .pop_front()
+                })
+                .unwrap_or(100);
+            let response = match method {
+                BLOCK_NUMBER_RPC => json!(format!("0x{height:x}")),
+                GET_BLOCK_BY_NUMBER_RPC => json!({"number": format!("0x{height:x}")}),
+                _ => json!(null),
+            };
+            serde_json::from_value(response.clone()).map_err(|err| HttpClientError::SerdeJson {
+                err,
+                text: response.to_string(),
+            })
+        }
+    }
+
+    fn cache_metrics() -> PrometheusClientMetrics {
+        let request_cache_count = IntCounterVec::new(
+            Opts::new("test_request_cache_count", "test request cache count"),
+            &["provider_node", "chain", "method", "result", "rpc_role"],
+        )
+        .expect("test metric should be valid");
+        PrometheusClientMetrics {
+            request_cache_count: Some(request_cache_count),
+            ..PrometheusClientMetrics::default()
+        }
+    }
+
+    fn cached_client(
+        endpoint: &str,
+        inner: CountingClient,
+        metrics: PrometheusClientMetrics,
+        ttl: Duration,
+    ) -> PrometheusJsonRpcClient<CountingClient> {
+        PrometheusJsonRpcClient::new(inner, metrics, PrometheusConfig::default())
+            .with_finalized_block_cache_ttl(endpoint, ttl)
+    }
+
+    #[tokio::test]
+    async fn concurrent_reads_share_one_upstream_request_per_endpoint() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let metrics = cache_metrics();
+        let client = cached_client(
+            "concurrent-endpoint",
+            inner,
+            metrics.clone(),
+            Duration::from_secs(1),
+        );
+        let barrier = Arc::new(Barrier::new(8));
+
+        let tasks = (0..8)
+            .map(|_| {
+                let client = client.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for task in tasks {
+            assert_eq!(
+                task.await
+                    .expect("task should not panic")
+                    .expect("request should succeed"),
+                U64::from(100_u64)
+            );
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let metric = metrics
+            .request_cache_count
+            .expect("cache metric should be configured");
+        assert_eq!(
+            metric
+                .with_label_values(&[
+                    "unknown",
+                    "unknown",
+                    BLOCK_NUMBER_RPC,
+                    "logical_read",
+                    "primary",
+                ])
+                .get(),
+            8
+        );
+        assert_eq!(
+            metric
+                .with_label_values(&[
+                    "unknown",
+                    "unknown",
+                    BLOCK_NUMBER_RPC,
+                    "upstream_read",
+                    "primary",
+                ])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metric
+                .with_label_values(&[
+                    "unknown",
+                    "unknown",
+                    BLOCK_NUMBER_RPC,
+                    "cache_hit",
+                    "primary",
+                ])
+                .get(),
+            7
+        );
+    }
+
+    #[tokio::test]
+    async fn different_endpoints_do_not_share_heights() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let first = cached_client(
+            "endpoint-one",
+            inner.clone(),
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+        let second = cached_client(
+            "endpoint-two",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+
+        first
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("first request should succeed");
+        second
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("second request should succeed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failures_are_not_cached() {
+        let inner = CountingClient {
+            failures: 1,
+            ..CountingClient::default()
+        };
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "failure-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+
+        assert!(client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .is_err());
+        assert_eq!(
+            client
+                .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+                .await
+                .expect("second request should retry"),
+            U64::from(100_u64)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn successful_values_expire_at_the_cache_boundary() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "expiry-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_millis(20),
+        );
+
+        client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("first request should succeed");
+        client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("cached request should succeed");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        client
+            .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+            .await
+            .expect("expired request should refresh");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn lower_endpoint_heights_are_observable_after_expiry() {
+        let inner = CountingClient {
+            heights: Some(Arc::new(StdMutex::new(VecDeque::from([100, 99])))),
+            ..CountingClient::default()
+        };
+        let client = cached_client(
+            "lower-height-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_millis(20),
+        );
+
+        assert_eq!(
+            client
+                .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+                .await
+                .expect("first request should succeed"),
+            U64::from(100_u64)
+        );
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert_eq!(
+            client
+                .request::<_, U64>(BLOCK_NUMBER_RPC, ())
+                .await
+                .expect("expired request should refresh"),
+            U64::from(99_u64)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_initializer_does_not_strand_followers() {
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let inner = CountingClient {
+            first_call_started: Some(started.clone()),
+            block_first_call: Some(release),
+            ..CountingClient::default()
+        };
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "cancel-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+        let started_wait = started.notified();
+        let leader = {
+            let client = client.clone();
+            tokio::spawn(async move { client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await })
+        };
+        started_wait.await;
+        let follower = {
+            let client = client.clone();
+            tokio::spawn(async move { client.request::<_, U64>(BLOCK_NUMBER_RPC, ()).await })
+        };
+        tokio::task::yield_now().await;
+        leader.abort();
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), follower)
+                .await
+                .expect("follower should not be stranded")
+                .expect("follower should not panic")
+                .expect("follower should retry"),
+            U64::from(100_u64)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn only_dynamic_block_tags_are_cached() {
+        let inner = CountingClient::default();
+        let calls = inner.calls.clone();
+        let client = cached_client(
+            "tag-endpoint",
+            inner,
+            PrometheusClientMetrics::default(),
+            Duration::from_secs(1),
+        );
+
+        for _ in 0..2 {
+            client
+                .request::<_, Value>(GET_BLOCK_BY_NUMBER_RPC, ("finalized", false))
+                .await
+                .expect("dynamic block request should succeed");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        for _ in 0..2 {
+            client
+                .request::<_, Value>(GET_BLOCK_BY_NUMBER_RPC, ("safe", false))
+                .await
+                .expect("safe block request should succeed");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        for _ in 0..2 {
+            client
+                .request::<_, Value>(GET_BLOCK_BY_NUMBER_RPC, ("0x10", false))
+                .await
+                .expect("pinned block request should succeed");
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
     }
 }

--- a/rust/main/ethers-prometheus/src/json_rpc_client.rs
+++ b/rust/main/ethers-prometheus/src/json_rpc_client.rs
@@ -136,6 +136,9 @@ fn endpoint_request_cache(endpoint: String, ttl: Duration) -> Arc<EndpointReques
 }
 
 fn request_cache_key<T: Serialize>(method: &str, params: &T) -> Option<(RequestCacheKey, Value)> {
+    if !matches!(method, BLOCK_NUMBER_RPC | GET_BLOCK_BY_NUMBER_RPC) {
+        return None;
+    }
     let params = serde_json::to_value(params).ok()?;
     let method = match method {
         BLOCK_NUMBER_RPC => DynamicBlockMethod::BlockNumber,
@@ -422,6 +425,29 @@ mod tests {
     use tokio::sync::{Barrier, Notify};
 
     use super::*;
+
+    #[test]
+    fn uncacheable_methods_do_not_serialize_params() {
+        struct SerializationCounter(AtomicUsize);
+
+        impl Serialize for SerializationCounter {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                serializer.serialize_unit()
+            }
+        }
+
+        let params = SerializationCounter(AtomicUsize::new(0));
+        for method in [
+            "eth_call",
+            "eth_getLogs",
+            "eth_sendRawTransaction",
+            "eth_getTransactionReceipt",
+        ] {
+            assert!(request_cache_key(method, &params).is_none());
+        }
+        assert_eq!(params.0.load(Ordering::SeqCst), 0);
+    }
 
     #[derive(Clone, Debug, Default)]
     struct CountingClient {

--- a/rust/main/hyperlane-base/src/metrics/json_rpc_client.rs
+++ b/rust/main/hyperlane-base/src/metrics/json_rpc_client.rs
@@ -3,8 +3,9 @@ use hyperlane_metric::prometheus_metric::{
     PrometheusClientMetrics, PrometheusClientMetricsBuilder, FALLBACK_HEDGE_DURATION_SECONDS_HELP,
     FALLBACK_HEDGE_DURATION_SECONDS_LABELS, FALLBACK_HEDGE_EVENT_HELP, FALLBACK_HEDGE_EVENT_LABELS,
     PROVIDER_CREATE_COUNT_HELP, PROVIDER_CREATE_COUNT_LABELS, PROVIDER_DROP_COUNT_HELP,
-    PROVIDER_DROP_COUNT_LABELS, REQUEST_COUNT_HELP, REQUEST_COUNT_LABELS,
-    REQUEST_DURATION_SECONDS_HELP, REQUEST_DURATION_SECONDS_LABELS,
+    PROVIDER_DROP_COUNT_LABELS, REQUEST_CACHE_COUNT_HELP, REQUEST_CACHE_COUNT_LABELS,
+    REQUEST_COUNT_HELP, REQUEST_COUNT_LABELS, REQUEST_DURATION_SECONDS_HELP,
+    REQUEST_DURATION_SECONDS_LABELS,
 };
 
 use crate::CoreMetrics;
@@ -22,6 +23,11 @@ pub(crate) fn create_json_rpc_client_metrics(
             "request_duration_seconds",
             REQUEST_DURATION_SECONDS_HELP,
             REQUEST_DURATION_SECONDS_LABELS,
+        )?)
+        .request_cache_count(metrics.new_int_counter(
+            "request_cache_count",
+            REQUEST_CACHE_COUNT_HELP,
+            REQUEST_CACHE_COUNT_LABELS,
         )?)
         .provider_create_count(metrics.new_int_counter(
             "provider_create_count",

--- a/rust/main/hyperlane-base/src/metrics/json_rpc_client.rs
+++ b/rust/main/hyperlane-base/src/metrics/json_rpc_client.rs
@@ -2,8 +2,8 @@ use eyre::Result;
 use hyperlane_metric::prometheus_metric::{
     PrometheusClientMetrics, PrometheusClientMetricsBuilder, PROVIDER_CREATE_COUNT_HELP,
     PROVIDER_CREATE_COUNT_LABELS, PROVIDER_DROP_COUNT_HELP, PROVIDER_DROP_COUNT_LABELS,
-    REQUEST_COUNT_HELP, REQUEST_COUNT_LABELS, REQUEST_DURATION_SECONDS_HELP,
-    REQUEST_DURATION_SECONDS_LABELS,
+    REQUEST_CACHE_COUNT_HELP, REQUEST_CACHE_COUNT_LABELS, REQUEST_COUNT_HELP, REQUEST_COUNT_LABELS,
+    REQUEST_DURATION_SECONDS_HELP, REQUEST_DURATION_SECONDS_LABELS,
 };
 
 use crate::CoreMetrics;
@@ -21,6 +21,11 @@ pub(crate) fn create_json_rpc_client_metrics(
             "request_duration_seconds",
             REQUEST_DURATION_SECONDS_HELP,
             REQUEST_DURATION_SECONDS_LABELS,
+        )?)
+        .request_cache_count(metrics.new_int_counter(
+            "request_cache_count",
+            REQUEST_CACHE_COUNT_HELP,
+            REQUEST_CACHE_COUNT_LABELS,
         )?)
         .provider_create_count(metrics.new_int_counter(
             "provider_create_count",

--- a/rust/main/hyperlane-metric/src/prometheus_metric.rs
+++ b/rust/main/hyperlane-metric/src/prometheus_metric.rs
@@ -58,6 +58,13 @@ pub const FALLBACK_HEDGE_DURATION_SECONDS_LABELS: &[&str] = &["chain", "method",
 pub const FALLBACK_HEDGE_DURATION_SECONDS_HELP: &str =
     "End-to-end duration of fallback requests eligible for hedging";
 
+/// Expected label names for the dynamic-block request cache metric.
+pub const REQUEST_CACHE_COUNT_LABELS: &[&str] =
+    &["provider_node", "chain", "method", "result", "rpc_role"];
+/// Help string for the dynamic-block request cache metric.
+pub const REQUEST_CACHE_COUNT_HELP: &str =
+    "Logical reads, cache hits, upstream reads, and upstream errors for cached RPC requests";
+
 /// Container for all the relevant rpc client metrics.
 #[derive(Clone, Builder, Default)]
 pub struct PrometheusClientMetrics {
@@ -102,6 +109,15 @@ pub struct PrometheusClientMetrics {
     /// End-to-end latency for requests eligible for fallback hedging.
     #[builder(setter(into, strip_option), default)]
     pub fallback_hedge_duration_seconds: Option<HistogramVec>,
+
+    /// Dynamic-block request cache events.
+    /// - `provider_node`: node serving the request.
+    /// - `chain`: chain the request was made on.
+    /// - `method`: JSON-RPC method.
+    /// - `result`: `logical_read`, `cache_hit`, `upstream_read`, or `upstream_error`.
+    /// - `rpc_role`: primary or quorum pool.
+    #[builder(setter(into, strip_option), default)]
+    pub request_cache_count: Option<IntCounterVec>,
 }
 
 impl PrometheusClientMetrics {
@@ -177,6 +193,26 @@ impl PrometheusClientMetrics {
         };
         if let Some(histogram) = &self.fallback_hedge_duration_seconds {
             histogram.with(&labels).observe(duration.as_secs_f64());
+        }
+    }
+
+    /// Increment a dynamic-block request cache event.
+    pub fn increment_request_cache_metric(
+        &self,
+        config: &PrometheusConfig,
+        method: &str,
+        result: &str,
+    ) {
+        if let Some(counter) = &self.request_cache_count {
+            counter
+                .with_label_values(&[
+                    config.node_host(),
+                    config.chain_name(),
+                    method,
+                    result,
+                    config.rpc_role.as_str(),
+                ])
+                .inc();
         }
     }
 }

--- a/rust/main/hyperlane-metric/src/prometheus_metric.rs
+++ b/rust/main/hyperlane-metric/src/prometheus_metric.rs
@@ -46,6 +46,13 @@ pub const REQUEST_DURATION_SECONDS_LABELS: &[&str] = &[
 /// Help string for the metric.
 pub const REQUEST_DURATION_SECONDS_HELP: &str = "Total number of seconds spent making requests";
 
+/// Expected label names for the finalized-block request cache metric.
+pub const REQUEST_CACHE_COUNT_LABELS: &[&str] =
+    &["provider_node", "chain", "method", "result", "rpc_role"];
+/// Help string for the finalized-block request cache metric.
+pub const REQUEST_CACHE_COUNT_HELP: &str =
+    "Logical reads, cache hits, upstream reads, and upstream errors for cached RPC requests";
+
 /// Container for all the relevant rpc client metrics.
 #[derive(Clone, Builder, Default)]
 pub struct PrometheusClientMetrics {
@@ -82,6 +89,15 @@ pub struct PrometheusClientMetrics {
     ///   might still be an "error" but not one with the transport layer.
     #[builder(setter(into, strip_option), default)]
     pub request_duration_seconds: Option<CounterVec>,
+
+    /// Finalized-block request cache events.
+    /// - `provider_node`: node serving the request.
+    /// - `chain`: chain the request was made on.
+    /// - `method`: JSON-RPC method.
+    /// - `result`: `logical_read`, `cache_hit`, `upstream_read`, or `upstream_error`.
+    /// - `rpc_role`: primary or quorum pool.
+    #[builder(setter(into, strip_option), default)]
+    pub request_cache_count: Option<IntCounterVec>,
 }
 
 impl PrometheusClientMetrics {
@@ -128,6 +144,26 @@ impl PrometheusClientMetrics {
                 .with(&labels)
                 .inc_by((Instant::now().saturating_duration_since(start)).as_secs_f64())
         };
+    }
+
+    /// Increment a finalized-block request cache event.
+    pub fn increment_request_cache_metric(
+        &self,
+        config: &PrometheusConfig,
+        method: &str,
+        result: &str,
+    ) {
+        if let Some(counter) = &self.request_cache_count {
+            counter
+                .with_label_values(&[
+                    config.node_host(),
+                    config.chain_name(),
+                    method,
+                    result,
+                    config.rpc_role.as_str(),
+                ])
+                .inc();
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Relayer and scraper EVM indexers independently request the same dynamic block tip from the same concrete HTTP endpoint. These duplicate `eth_blockNumber` and `eth_getBlockByNumber` calls add provider load without improving cursor correctness.

## Change

- Coalesce successful `eth_blockNumber` plus `latest`, `safe`, and `finalized` block reads for 250ms per exact endpoint and request shape.
- Single-flight concurrent callers. Successful results are cached; errors are never cached.
- Release all current followers together when the leader fails or is cancelled, rather than serializing their retries behind the endpoint key.
- Enable the cache for all EVM contract indexers used by relayer and scraper, including CrossCollateralRouter swap indexing.
- Export logical-read, cache-hit, upstream-read, and upstream-error counters.
- Stack on #9395 so the provider-wrapper and metrics changes integrate once. Parent: `f09b807d0d`; exact head: `cd56287d4b`.

## Correctness boundary

- Different endpoints never share values.
- Pinned heights, log ranges, hashes, receipts, reorg checks, state reads, and cursor writes remain direct.
- Values are not clamped; a lower endpoint height becomes visible after the TTL.
- Validator and WebSocket providers are unchanged.
- A failed leader does not populate the cache. Its current followers retry the endpoint concurrently, allowing each outer fallback to advance independently.

## Expected improvement

The pre-centralized-indexing model removes up to **4.30M provider requests/day**. Once relayer dispatch/Merkle polling moves to the shared scraper, the residual scraper-only model is about **1.37M requests/day**. Both are models from the measured request mix, not post-rollout observations; canaries must replace them with the logical-read/upstream-read ratio and transport deltas.

On endpoint failure, N joined readers previously waited behind up to N serialized provider timeouts. They now share the first attempt and retry concurrently after its failure, bounding each joined reader to at most roughly two provider timeout windows rather than N. This is an analytical availability bound, not a production measurement.

## Tests

- Concurrent reads single-flight per endpoint.
- Failed and cancelled leaders release current followers without serialized retries.
- Endpoint isolation.
- Errors retry and are not cached.
- TTL expiry, including lower subsequent heights.
- Dynamic tags are isolated; pinned heights remain direct.
- CrossCollateralRouter builder opts into the dynamic block cache.
- `cargo test -p ethers-prometheus --features serde,hyperlane-core/async json_rpc_client::tests --lib` (8 passed at the current head)
- `cargo test -p hyperlane-ethereum ccr_indexer_uses_dynamic_block_cache --lib` (1 passed before the latest single-flight-only change)
- patch-identical restack verified with `git range-diff` and `git patch-id --stable`
- Rust workspace formatting and normal pre-commit hooks

## Rollout

Canary scraper first, then relayer. Compare upstream/logical reads, transport volume and latency, cursor lag, gaps, endpoint errors, reorg behavior, delivery latency, and queue health. Roll back the image on any freshness or correctness regression; no migration is required.


Validation of the method guard: uncacheable methods bypass cache-key serialization; the serializer-counter regression failed before the guard and passed afterward. Cache tests **9/9**, strict package Clippy, and normal commit hooks passed.
