### PR TITLE
feat(infra): own default-ISM pausable modules with dedicated Turnkey pauser

### DIFF
--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -28,7 +28,7 @@ import { legacyIgpChains } from '../../../src/config/chain.js';
 import { getEdenCoreConfig } from './eden.js';
 import { getTronCoreConfig } from './tron.js';
 import { getIgp } from './igp.js';
-import { DEPLOYER, ethereumChainOwners } from './owners.js';
+import { PAUSER, ethereumChainOwners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
 
 // There are no static ISMs or hooks for zkSync, this means
@@ -113,7 +113,7 @@ export function getCore(): ChainMap<CoreConfig> {
     const pausableIsm: PausableIsmConfig = {
       type: IsmType.PAUSABLE,
       paused: false,
-      owner: DEPLOYER, // keep pausable hot
+      owner: PAUSER, // dedicated Turnkey pauser (pause solo, unpause gated)
     };
 
     // No static aggregation ISM support on zkSync
@@ -134,7 +134,7 @@ export function getCore(): ChainMap<CoreConfig> {
     const pausableHook: PausableHookConfig = {
       type: HookType.PAUSABLE,
       paused: false,
-      owner: DEPLOYER, // keep pausable hot
+      owner: PAUSER, // dedicated Turnkey pauser (pause solo, unpause gated)
     };
 
     // No static aggregation hook support on zkSync

--- a/typescript/infra/config/environments/mainnet3/owners.ts
+++ b/typescript/infra/config/environments/mainnet3/owners.ts
@@ -20,6 +20,11 @@ export const timelocks: ChainMap<Address> = {
 export const icaOwnerChain = 'ethereum';
 export const DEPLOYER = '0xa7ECcdb9Be08178f896c26b7BbD8C3D4E844d9Ba';
 
+// Dedicated Turnkey pauser wallet account. Owns PausableIsm / PausableHook so
+// services can pause() autonomously while unpause() requires a rootuser-tagged
+// human approval (enforced by Turnkey policy in the private-agents repo).
+export const PAUSER = '0x60Cc386C85717CB51C2827A75e14826883dF5da4';
+
 // Celestia multisig that owns the eden core deployment.
 // IGP/oracle ownership stays with the deployer.
 export const EDEN_CORE_OWNER = '0x260eDfa1d9f7Ec832E079f90c043360d394d2ce4';

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -53,4 +53,5 @@ export enum TurnkeyRole {
   EvmRebalancer = 'evm-rebalancer',
   EvmIgpClaimer = 'evm-igp-claimer',
   EvmIgpUpdater = 'evm-igp-updater',
+  EvmPauser = 'evm-pauser',
 }

--- a/typescript/infra/src/utils/turnkey.ts
+++ b/typescript/infra/src/utils/turnkey.ts
@@ -44,6 +44,7 @@ export async function createTurnkeySigner(
       case TurnkeyRole.EvmRebalancer:
       case TurnkeyRole.EvmIgpClaimer:
       case TurnkeyRole.EvmIgpUpdater:
+      case TurnkeyRole.EvmPauser:
         signer = new TurnkeyEvmSigner(turnkeyConfig);
         break;
       default:


### PR DESCRIPTION
## Summary
- Swap the mainnet3 default-ISM `PausableIsm` + `PausableHook` owner from the deployer key to a new dedicated Turnkey **pauser** wallet account (`PAUSER` = `0x60Cc386C85717CB51C2827A75e14826883dF5da4`).
- Add `TurnkeyRole.EvmPauser` and wire it into the EVM Turnkey signer factory (`createTurnkeySigner`).

## Why
Gives the default ISM a dedicated pauser key with **asymmetric control**: services (Haggis et al.) can `pause()` autonomously as a fail-safe halt, but `unpause()` requires a rootuser-tagged human approval. The gating is enforced by a Turnkey policy versioned in the `private-agents` repo (`turnkey-policy` package: `Pauser pause() (Haggis solo)` + `Pauser unpause() (rootuser consensus)`), pinned to this wallet account by the bare `pause()`/`unpause()` selectors so it applies to every pausable module the key owns across chains.

Owner change is picked up on the next default-ISM rotation/apply — no redeploy required beyond the normal core apply.

## Follow-ups (not in this PR)
- Create GCP secret `mainnet3-turnkey-evm-pauser` (JSON: organizationId, apiPublicKey, apiPrivateKey, publicKey; wallet account `85df8915-85c6-4675-8c07-4e73b1b5afcf`) before any service uses the signer.
- Apply the Turnkey pauser policies (private-agents branch `feat/turnkey-pauser-policy`, `turnkey-policy-apply --submit`, then rootuser approval).

## Test plan
- [ ] `pnpm -C typescript/infra` typecheck passes (verified locally via `tsc --noEmit`).
- [ ] Default-ISM apply/rotation reflects the new pauser owner on `pausableIsm` + `pausableHook`.
- [ ] Turnkey policy validated on testnet: `pause()` succeeds solo, `unpause()` blocks until rootuser approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)