### PR TITLE
fix(infra): raise fastpath relayer CPU request to cover bursts

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -673,12 +673,16 @@ const relayerResources = {
   },
 };
 
-// Sized from 30-day observed usage: CPU p50 ~0.08 / p99 ~0.24 cores (rare
-// transient spikes to ~5.7, absorbed by burst since there is no CPU limit),
-// memory peak ~2.4Gi. Request covers the memory peak and ~2x the CPU p99.
+// Sized from 30-day observed usage: CPU p50 ~0.08 / p99 ~0.24 cores, memory
+// peak ~2.4Gi. Steady-state is tiny, but restart/cold-start catch-up bursts
+// (cursor re-sync + backlog drain) reach ~6 cores just like the main relayer;
+// with no CPU limit these are absorbed by burst. The prior 500m request made
+// those bursts read as ~12x request and constantly tripped the ratio-based
+// >75% CPU alert. Request raised to 2 cores to give burst headroom and cut
+// that alert noise; memory covers the peak with headroom.
 const fastPathRelayerResources = {
   requests: {
-    cpu: '500m',
+    cpu: '2000m',
     memory: '3G',
   },
 };


### PR DESCRIPTION
## Summary
- Raises the mainnet3 **fastpath relayer** CPU request from `500m` → `2000m` in `typescript/infra/config/environments/mainnet3/agent.ts`.
- Updates the sizing comment to document why.

## Why
The fastpath relayer idles at ~0.07 cores steady-state but its cold-start / catch-up bursts (cursor re-sync + backlog drain) reach ~6 cores — essentially identical peak work to the main relayer. At a `500m` request those bursts read as ~12x request and constantly trip the ratio-based **>75% CPU** alert. The main relayer never trips it because it's provisioned at `8000m` (~1x its peak).

There is no CPU limit, so bursts above the request are still absorbed by burst; this change only raises the *reservation* to give burst headroom and cut alert noise.

## Notes
- 2 cores is a deliberate middle ground: it covers sustained elevated load and brings the peak ratio from ~12.7x down to ~3x, without over-reserving the full 8 cores the main relayer uses (the fastpath pod only handles the narrow latency-optimized route subset).
- Complementary follow-up (not in this PR): excluding / tuning the >75% CPU alert for fastpath so the rare ~6-core cold-start spikes don't page. Tracked alongside the RPC alert-noise backlog work.
- No changeset — the infra package is private.

## Test plan
- [ ] CI (lint / typecheck / infra config build) green
- [ ] On deploy, confirm the fastpath relayer pod's CPU request shows 2 cores and the >75% CPU alert stops firing on routine bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)