### PR TITLE
fix(relayer): cache routes and track metadata waits

### DIFF
--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::Mutex,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -19,6 +19,61 @@ const ENDED_EVENT: &str = "ended";
 struct MetadataWaitStart {
     instant: Instant,
     unix_timestamp_seconds: i64,
+}
+
+#[derive(Debug, Default)]
+struct AppMetadataWaits {
+    by_message: HashMap<H256, MetadataWaitStart>,
+    timestamp_counts: BTreeMap<i64, usize>,
+}
+
+impl AppMetadataWaits {
+    fn insert(&mut self, message_id: H256, start: MetadataWaitStart) -> bool {
+        match self.by_message.entry(message_id) {
+            std::collections::hash_map::Entry::Occupied(_) => return false,
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(start);
+            }
+        }
+        self.timestamp_counts
+            .entry(start.unix_timestamp_seconds)
+            .and_modify(|count| *count = count.saturating_add(1))
+            .or_insert(1);
+        true
+    }
+
+    fn remove(&mut self, message_id: &H256) -> Option<MetadataWaitStart> {
+        let removed = self.by_message.remove(message_id)?;
+        let remove_timestamp = self
+            .timestamp_counts
+            .get_mut(&removed.unix_timestamp_seconds)
+            .map(|count| {
+                *count = count.saturating_sub(1);
+                *count == 0
+            })
+            .unwrap_or_default();
+        debug_assert!(
+            self.timestamp_counts
+                .contains_key(&removed.unix_timestamp_seconds),
+            "tracked wait timestamp must have a count"
+        );
+        if remove_timestamp {
+            self.timestamp_counts
+                .remove(&removed.unix_timestamp_seconds);
+        }
+        Some(removed)
+    }
+
+    fn oldest_timestamp_seconds(&self) -> i64 {
+        self.timestamp_counts
+            .first_key_value()
+            .map(|(timestamp, _)| *timestamp)
+            .unwrap_or_default()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_message.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -165,11 +220,40 @@ mod tests {
             expected_oldest
         );
     }
+
+    #[test]
+    fn metadata_wait_tracker_keeps_an_ordered_oldest_timestamp() {
+        let mut waits = AppMetadataWaits::default();
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let third_id = H256::from_low_u64_be(3);
+        let now = Instant::now();
+
+        for (message_id, unix_timestamp_seconds) in
+            [(first_id, 20), (second_id, 10), (third_id, 10)]
+        {
+            assert!(waits.insert(
+                message_id,
+                MetadataWaitStart {
+                    instant: now,
+                    unix_timestamp_seconds,
+                },
+            ));
+        }
+        assert_eq!(waits.oldest_timestamp_seconds(), 10);
+
+        waits.remove(&second_id).unwrap();
+        assert_eq!(waits.oldest_timestamp_seconds(), 10);
+        waits.remove(&third_id).unwrap();
+        assert_eq!(waits.oldest_timestamp_seconds(), 20);
+        waits.remove(&first_id).unwrap();
+        assert_eq!(waits.oldest_timestamp_seconds(), 0);
+    }
 }
 
 #[derive(Debug, Default)]
 struct MetadataWaitTracker {
-    by_app_context: Mutex<HashMap<String, HashMap<H256, MetadataWaitStart>>>,
+    by_app_context: Mutex<HashMap<String, AppMetadataWaits>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -278,28 +362,21 @@ impl MessageSubmissionMetrics {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let app_waits = waits.entry(app_context.to_owned()).or_default();
-        let (first_observation, start) = match app_waits.entry(message_id) {
-            std::collections::hash_map::Entry::Occupied(entry) => (false, *entry.get()),
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                let start = MetadataWaitStart {
-                    instant: now,
-                    unix_timestamp_seconds,
-                };
-                entry.insert(start);
-                (true, start)
-            }
-        };
+        let start = app_waits
+            .by_message
+            .get(&message_id)
+            .copied()
+            .unwrap_or(MetadataWaitStart {
+                instant: now,
+                unix_timestamp_seconds,
+            });
+        let first_observation = app_waits.insert(message_id, start);
         if first_observation {
             let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
             self.metadata_wait_active.with_label_values(&labels).inc();
-            let oldest = app_waits
-                .values()
-                .map(|start| start.unix_timestamp_seconds)
-                .min()
-                .unwrap_or(unix_timestamp_seconds);
             self.metadata_wait_oldest_timestamp_seconds
                 .with_label_values(&labels)
-                .set(oldest);
+                .set(app_waits.oldest_timestamp_seconds());
         }
 
         self.metadata_wait_event_count
@@ -332,11 +409,7 @@ impl MessageSubmissionMetrics {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let app_waits = waits.get_mut(app_context)?;
         let removed = app_waits.remove(&message_id)?;
-        let next_oldest = app_waits
-            .values()
-            .map(|start| start.unix_timestamp_seconds)
-            .min()
-            .unwrap_or_default();
+        let next_oldest = app_waits.oldest_timestamp_seconds();
         let remove_app_context = app_waits.is_empty();
         if remove_app_context {
             waits.remove(app_context);

--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -125,6 +125,39 @@ mod tests {
         assert!(!encoded.contains(&format!("{first_id:?}")));
         assert!(!encoded.contains(&format!("{second_id:?}")));
     }
+
+    #[test]
+    fn metadata_wait_oldest_uses_tracker_as_source_of_truth() {
+        let metrics = test_metrics();
+        let app_context = "test-app";
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let labels = [app_context, "ethereum", "arbitrum"];
+
+        metrics.record_metadata_wait(first_id, Some(app_context));
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        let expected_oldest = metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .get();
+
+        // The gauge is an exported view, not authoritative tracker state.
+        metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .set(i64::MAX);
+        assert!(metrics
+            .finish_metadata_wait(second_id, Some(app_context), false)
+            .is_some());
+
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            expected_oldest
+        );
+    }
 }
 
 #[derive(Debug, Default)]
@@ -281,33 +314,27 @@ impl MessageSubmissionMetrics {
     ) -> Option<Duration> {
         let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
         let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
-        let oldest = self
-            .metadata_wait_oldest_timestamp_seconds
-            .with_label_values(&labels);
         let mut waits = self
             .metadata_wait_tracker
             .by_app_context
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let current_oldest = oldest.get();
         let app_waits = waits.get_mut(app_context)?;
         let removed = app_waits.remove(&message_id)?;
-        let next_oldest = if removed.unix_timestamp_seconds == current_oldest {
-            app_waits
-                .values()
-                .map(|start| start.unix_timestamp_seconds)
-                .min()
-                .unwrap_or_default()
-        } else {
-            current_oldest
-        };
+        let next_oldest = app_waits
+            .values()
+            .map(|start| start.unix_timestamp_seconds)
+            .min()
+            .unwrap_or_default();
         let remove_app_context = app_waits.is_empty();
         if remove_app_context {
             waits.remove(app_context);
         }
 
         self.metadata_wait_active.with_label_values(&labels).dec();
-        oldest.set(next_oldest);
+        self.metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .set(next_oldest);
         self.metadata_wait_event_count
             .with_label_values(&[
                 app_context,

--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -1,10 +1,142 @@
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 use maplit::hashmap;
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge};
+use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 use hyperlane_base::CoreMetrics;
-use hyperlane_core::{HyperlaneDomain, HyperlaneMessage};
+use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, H256};
+
+const UNKNOWN_APP_CONTEXT: &str = "Unknown";
+const WAIT_EVENT: &str = "wait";
+const RECOVERED_EVENT: &str = "recovered";
+const ENDED_EVENT: &str = "ended";
+
+#[derive(Clone, Copy, Debug)]
+struct MetadataWaitStart {
+    instant: Instant,
+    unix_timestamp_seconds: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::core::Collector;
+    use prometheus::{Encoder, Registry, TextEncoder};
+
+    use hyperlane_core::KnownHyperlaneDomain;
+
+    use super::*;
+
+    fn test_metrics() -> MessageSubmissionMetrics {
+        let core_metrics = CoreMetrics::new("relayer", 9090, Registry::new()).unwrap();
+        MessageSubmissionMetrics::new(
+            &core_metrics,
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+        )
+    }
+
+    #[test]
+    fn metadata_wait_metrics_track_retries_oldest_and_recovery_without_id_labels() {
+        let metrics = test_metrics();
+        let app_context = "test-app";
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let labels = [app_context, "ethereum", "arbitrum"];
+
+        let first = metrics.record_metadata_wait(first_id, Some(app_context));
+        assert!(first.first_observation);
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            1
+        );
+        let oldest = metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .get();
+        assert!(oldest > 0);
+
+        let retry = metrics.record_metadata_wait(first_id, Some(app_context));
+        assert!(!retry.first_observation);
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            2
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", WAIT_EVENT])
+                .get(),
+            3
+        );
+
+        assert!(metrics
+            .finish_metadata_wait(first_id, Some(app_context), true)
+            .is_some());
+        assert_eq!(
+            metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", RECOVERED_EVENT])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            1
+        );
+
+        assert!(metrics
+            .finish_metadata_wait(second_id, Some(app_context), false)
+            .is_some());
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+
+        let mut encoded = Vec::new();
+        TextEncoder::new()
+            .encode(&metrics.metadata_wait_event_count.collect(), &mut encoded)
+            .unwrap();
+        let encoded = String::from_utf8(encoded).unwrap();
+        assert!(!encoded.contains("message_id"));
+        assert!(!encoded.contains(&format!("{first_id:?}")));
+        assert!(!encoded.contains(&format!("{second_id:?}")));
+    }
+}
+
+#[derive(Debug, Default)]
+struct MetadataWaitTracker {
+    by_app_context: Mutex<HashMap<String, HashMap<H256, MetadataWaitStart>>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MetadataWaitObservation {
+    pub(crate) first_observation: bool,
+    pub(crate) elapsed: Duration,
+}
 
 #[derive(Clone, Debug)]
 pub struct MetadataBuildMetric {
@@ -27,6 +159,13 @@ pub struct MessageSubmissionMetrics {
     pub metadata_build_count: IntCounterVec,
     /// Total number of seconds spent building different types of metadata.
     pub metadata_build_duration: CounterVec,
+    /// Bounded wait-attempt and lifecycle events for validator-signature waits.
+    pub metadata_wait_event_count: IntCounterVec,
+    /// Messages currently waiting for validator signatures.
+    pub metadata_wait_active: IntGaugeVec,
+    /// Unix timestamp of the oldest active validator-signature wait.
+    pub metadata_wait_oldest_timestamp_seconds: IntGaugeVec,
+    metadata_wait_tracker: MetadataWaitTracker,
 }
 
 impl MessageSubmissionMetrics {
@@ -48,6 +187,11 @@ impl MessageSubmissionMetrics {
                 .with_label_values(&[origin, destination]),
             metadata_build_count: metrics.metadata_build_count(),
             metadata_build_duration: metrics.metadata_build_duration(),
+            metadata_wait_event_count: metrics.metadata_wait_event_count(),
+            metadata_wait_active: metrics.metadata_wait_active(),
+            metadata_wait_oldest_timestamp_seconds: metrics
+                .metadata_wait_oldest_timestamp_seconds(),
+            metadata_wait_tracker: MetadataWaitTracker::default(),
         }
     }
 
@@ -63,7 +207,7 @@ impl MessageSubmissionMetrics {
     /// a specific ISM
     pub fn insert_metadata_build_metric(&self, params: MetadataBuildMetric) {
         let labels = hashmap! {
-            "app_context" => params.app_context.as_deref().unwrap_or("Unknown"),
+            "app_context" => params.app_context.as_deref().unwrap_or(UNKNOWN_APP_CONTEXT),
             "origin" => self.origin.as_str(),
             "remote" => self.destination.as_str(),
             "status" => if params.success { "success" } else { "failure" },
@@ -72,5 +216,111 @@ impl MessageSubmissionMetrics {
         self.metadata_build_duration
             .with(&labels)
             .inc_by(params.duration.as_secs_f64());
+    }
+
+    pub(crate) fn record_metadata_wait(
+        &self,
+        message_id: H256,
+        app_context: Option<&str>,
+    ) -> MetadataWaitObservation {
+        let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
+        let now = Instant::now();
+        let unix_timestamp_seconds = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+        .unwrap_or(i64::MAX);
+        let mut waits = self
+            .metadata_wait_tracker
+            .by_app_context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let app_waits = waits.entry(app_context.to_owned()).or_default();
+        let (first_observation, start) = match app_waits.entry(message_id) {
+            std::collections::hash_map::Entry::Occupied(entry) => (false, *entry.get()),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let start = MetadataWaitStart {
+                    instant: now,
+                    unix_timestamp_seconds,
+                };
+                entry.insert(start);
+                let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+                self.metadata_wait_active.with_label_values(&labels).inc();
+                let oldest = self
+                    .metadata_wait_oldest_timestamp_seconds
+                    .with_label_values(&labels);
+                if oldest.get() == 0 || unix_timestamp_seconds < oldest.get() {
+                    oldest.set(unix_timestamp_seconds);
+                }
+                (true, start)
+            }
+        };
+
+        self.metadata_wait_event_count
+            .with_label_values(&[
+                app_context,
+                self.origin.as_str(),
+                self.destination.as_str(),
+                WAIT_EVENT,
+            ])
+            .inc();
+
+        MetadataWaitObservation {
+            first_observation,
+            elapsed: now.saturating_duration_since(start.instant),
+        }
+    }
+
+    pub(crate) fn finish_metadata_wait(
+        &self,
+        message_id: H256,
+        app_context: Option<&str>,
+        recovered: bool,
+    ) -> Option<Duration> {
+        let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
+        let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+        let oldest = self
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels);
+        let mut waits = self
+            .metadata_wait_tracker
+            .by_app_context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let current_oldest = oldest.get();
+        let app_waits = waits.get_mut(app_context)?;
+        let removed = app_waits.remove(&message_id)?;
+        let next_oldest = if removed.unix_timestamp_seconds == current_oldest {
+            app_waits
+                .values()
+                .map(|start| start.unix_timestamp_seconds)
+                .min()
+                .unwrap_or_default()
+        } else {
+            current_oldest
+        };
+        let remove_app_context = app_waits.is_empty();
+        if remove_app_context {
+            waits.remove(app_context);
+        }
+
+        self.metadata_wait_active.with_label_values(&labels).dec();
+        oldest.set(next_oldest);
+        self.metadata_wait_event_count
+            .with_label_values(&[
+                app_context,
+                self.origin.as_str(),
+                self.destination.as_str(),
+                if recovered {
+                    RECOVERED_EVENT
+                } else {
+                    ENDED_EVENT
+                },
+            ])
+            .inc();
+
+        Some(removed.instant.elapsed())
     }
 }

--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -135,7 +135,6 @@ mod tests {
         let labels = [app_context, "ethereum", "arbitrum"];
 
         metrics.record_metadata_wait(first_id, Some(app_context));
-        metrics.record_metadata_wait(second_id, Some(app_context));
         let expected_oldest = metrics
             .metadata_wait_oldest_timestamp_seconds
             .with_label_values(&labels)
@@ -145,7 +144,15 @@ mod tests {
         metrics
             .metadata_wait_oldest_timestamp_seconds
             .with_label_values(&labels)
-            .set(i64::MAX);
+            .set(1);
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            expected_oldest
+        );
         assert!(metrics
             .finish_metadata_wait(second_id, Some(app_context), false)
             .is_some());
@@ -279,17 +286,21 @@ impl MessageSubmissionMetrics {
                     unix_timestamp_seconds,
                 };
                 entry.insert(start);
-                let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
-                self.metadata_wait_active.with_label_values(&labels).inc();
-                let oldest = self
-                    .metadata_wait_oldest_timestamp_seconds
-                    .with_label_values(&labels);
-                if oldest.get() == 0 || unix_timestamp_seconds < oldest.get() {
-                    oldest.set(unix_timestamp_seconds);
-                }
                 (true, start)
             }
         };
+        if first_observation {
+            let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+            self.metadata_wait_active.with_label_values(&labels).inc();
+            let oldest = app_waits
+                .values()
+                .map(|start| start.unix_timestamp_seconds)
+                .min()
+                .unwrap_or(unix_timestamp_seconds);
+            self.metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .set(oldest);
+        }
 
         self.metadata_wait_event_count
             .with_label_values(&[

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -248,7 +248,7 @@ impl AggregationIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for AggregationIsmMetadataBuilder {
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,
@@ -275,6 +275,12 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             }
             Err(MetadataBuildError::Refused(reason)) => {
                 return Err(MetadataBuildError::Refused(reason));
+            }
+            Err(err @ MetadataBuildError::AwaitingValidatorSignatures) => {
+                debug!(
+                    ?err,
+                    "Fast path is waiting for signatures; falling back to the other submodules"
+                );
             }
             Err(err) => {
                 warn!(
@@ -545,6 +551,7 @@ mod test {
     }
 
     /// All submodules fail to build → AggregationThresholdNotMet.
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_all_build_failures_returns_threshold_not_met() {
         let agg_addr = H256::from_low_u64_be(1);
@@ -568,6 +575,7 @@ mod test {
             result.unwrap_err(),
             MetadataBuildError::AggregationThresholdNotMet(2)
         );
+        assert!(logs_contain("Metadata submodule build failed"));
     }
 
     /// All submodules build ok but every dry_run returns None → AggregationThresholdNotMet.

--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -382,7 +382,7 @@ impl CcipReadIsmMetadataBuilder {
 
 #[async_trait]
 impl MetadataBuilder for CcipReadIsmMetadataBuilder {
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -54,7 +54,7 @@ pub struct MessageMetadataBuilder {
 ///                 MessageMetadataBuilder
 #[async_trait]
 impl MetadataBuilder for MessageMetadataBuilder {
-    #[instrument(err, skip(self, message, params), fields(destination_domain=self.base_builder().destination_domain().name()))]
+    #[instrument(skip(self, message, params), fields(destination_domain=self.base_builder().destination_domain().name()))]
     async fn build(
         &self,
         ism_address: H256,
@@ -151,6 +151,43 @@ pub async fn ism_and_module_type(
 
 /// Builds metadata for a message.
 pub async fn build_message_metadata(
+    message_builder: MessageMetadataBuilder,
+    ism_address: H256,
+    message: &HyperlaneMessage,
+    params: MessageMetadataBuildParams,
+    maybe_ism_and_module_type: Option<(Box<dyn InterchainSecurityModule>, ModuleType)>,
+) -> Result<IsmWithMetadataAndType, MetadataBuildError> {
+    let result = build_message_metadata_inner(
+        message_builder,
+        ism_address,
+        message,
+        params,
+        maybe_ism_and_module_type,
+    )
+    .await;
+    match &result {
+        Err(err @ MetadataBuildError::AwaitingValidatorSignatures) => {
+            tracing::debug!(
+                ?err,
+                ?ism_address,
+                message_id = ?message.id(),
+                "Metadata submodule is waiting for validator signatures"
+            );
+        }
+        Err(err) => {
+            tracing::error!(
+                ?err,
+                ?ism_address,
+                message_id = ?message.id(),
+                "Metadata submodule build failed"
+            );
+        }
+        Ok(_) => {}
+    }
+    result
+}
+
+async fn build_message_metadata_inner(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,
     message: &HyperlaneMessage,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -175,7 +175,7 @@ pub async fn build_message_metadata(
             );
         }
         Err(err) => {
-            tracing::error!(
+            tracing::warn!(
                 ?err,
                 ?ism_address,
                 message_id = ?message.id(),

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -3,7 +3,7 @@ use derive_more::Deref;
 use derive_new::new;
 use hyperlane_base::cache::FunctionCallCache;
 
-use hyperlane_core::{HyperlaneMessage, Metadata, ModuleType, H256};
+use hyperlane_core::{HyperlaneMessage, Metadata, ModuleType, RoutingIsm, H256};
 use tracing::instrument;
 
 use super::{
@@ -32,10 +32,6 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
             .await
             .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
 
-        let ism_domain = ism.domain().name();
-        let message_domain = self.base.base_builder().origin_domain();
-        let fn_key = "route";
-
         let cache_policy = self
             .base_builder()
             .ism_cache_policy_classifier()
@@ -46,6 +42,22 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
                 self.base.app_context.as_ref(),
             )
             .await;
+
+        let module = self.route(ism.as_ref(), message, cache_policy).await?;
+
+        self.base.build(module, message, params).await
+    }
+}
+
+impl RoutingIsmMetadataBuilder {
+    async fn route(
+        &self,
+        ism: &dyn RoutingIsm,
+        message: &HyperlaneMessage,
+        cache_policy: IsmCachePolicy,
+    ) -> Result<H256, MetadataBuildError> {
+        let ism_domain = ism.domain().name();
+        let fn_key = "route";
 
         let cache_result: Option<H256> = match cache_policy {
             // if cache is ISM specific, we use the message origin for caching
@@ -71,44 +83,247 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
         .ok()
         .flatten();
 
-        let module =
-            match cache_result {
-                Some(result) => result,
-                None => {
-                    let module = ism
-                        .route(message)
-                        .await
-                        .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
+        let module = match cache_result {
+            Some(result) => result,
+            None => {
+                let module = ism
+                    .route(message)
+                    .await
+                    .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
 
-                    // store result in cache
-                    match cache_policy {
+                // store result in cache
+                match cache_policy {
                     IsmCachePolicy::IsmSpecific => {
                         let params_cache_key = (ism.address(), message.origin);
-                        self.base_builder().cache().cache_call_result(
-                            message_domain.name(),
-                            fn_key,
-                            &params_cache_key,
-                            &module,
-                        ).await
+                        self.base_builder()
+                            .cache()
+                            .cache_call_result(ism_domain, fn_key, &params_cache_key, &module)
+                            .await
                     }
                     IsmCachePolicy::MessageSpecific => {
                         let params_cache_key = (ism.address(), message.id());
-                        self.base_builder().cache().cache_call_result(
-                            message_domain.name(),
-                            fn_key,
-                            &params_cache_key,
-                            &module,
-                        ).await
+                        self.base_builder()
+                            .cache()
+                            .cache_call_result(ism_domain, fn_key, &params_cache_key, &module)
+                            .await
                     }
                 }
                 .map_err(|err| {
                     tracing::warn!(error = %err, "Error when caching call result for {:?}", fn_key);
                 })
                 .ok();
-                    module
-                }
-            };
+                module
+            }
+        };
 
-        self.base.build(module, message, params).await
+        Ok(module)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use hyperlane_base::cache::{
+        LocalCache, MeteredCache, MeteredCacheConfig, MeteredCacheMetricsBuilder, OptionalCache,
+    };
+    use hyperlane_core::{
+        ChainCommunicationError, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+        HyperlaneMessage, KnownHyperlaneDomain, RoutingIsm, H256,
+    };
+
+    use crate::{
+        msg::metadata::message_builder::MessageMetadataBuilder,
+        test_utils::mock_base_builder::build_mock_base_builder,
+    };
+
+    use super::{IsmCachePolicy, RoutingIsmMetadataBuilder};
+
+    #[derive(Debug)]
+    struct CountingRoutingIsm {
+        address: H256,
+        domain: HyperlaneDomain,
+        calls: Arc<AtomicUsize>,
+        fail_first: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl RoutingIsm for CountingRoutingIsm {
+        async fn route(&self, _message: &HyperlaneMessage) -> ChainResult<H256> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_first && call == 0 {
+                Err(ChainCommunicationError::from_other_str(
+                    "simulated provider failure",
+                ))
+            } else {
+                Ok(H256::from_low_u64_be(42))
+            }
+        }
+    }
+
+    impl HyperlaneContract for CountingRoutingIsm {
+        fn address(&self) -> H256 {
+            self.address
+        }
+    }
+
+    impl HyperlaneChain for CountingRoutingIsm {
+        fn domain(&self) -> &HyperlaneDomain {
+            &self.domain
+        }
+
+        fn provider(&self) -> Box<dyn hyperlane_core::HyperlaneProvider> {
+            unimplemented!("provider is not used by routing cache tests")
+        }
+    }
+
+    fn builder() -> RoutingIsmMetadataBuilder {
+        let origin = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let destination = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let mut base = build_mock_base_builder(origin, destination);
+        let cache_name = "routing-cache-test";
+        base.responses.cache = Some(OptionalCache::new(Some(MeteredCache::new(
+            LocalCache::new(cache_name),
+            MeteredCacheMetricsBuilder::default()
+                .build()
+                .expect("cache metrics should build"),
+            MeteredCacheConfig {
+                cache_name: cache_name.to_owned(),
+            },
+        ))));
+
+        RoutingIsmMetadataBuilder::new(MessageMetadataBuilder {
+            base: Arc::new(base),
+            app_context: None,
+            root_ism: H256::from_low_u64_be(1),
+            max_ism_depth: 10,
+            max_ism_count: 10,
+        })
+    }
+
+    fn ism(calls: Arc<AtomicUsize>, fail_first: bool) -> CountingRoutingIsm {
+        ism_on_domain(calls, fail_first, KnownHyperlaneDomain::Arbitrum.into())
+    }
+
+    fn ism_on_domain(
+        calls: Arc<AtomicUsize>,
+        fail_first: bool,
+        domain: HyperlaneDomain,
+    ) -> CountingRoutingIsm {
+        CountingRoutingIsm {
+            address: H256::from_low_u64_be(1),
+            domain,
+            calls,
+            fail_first,
+        }
+    }
+
+    #[tokio::test]
+    async fn ism_specific_routes_are_cached_by_origin_on_the_ism_domain() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ism = ism(calls.clone(), false);
+        let ethereum_message = HyperlaneMessage {
+            origin: HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum).id(),
+            ..HyperlaneMessage::default()
+        };
+        let arbitrum_message = HyperlaneMessage {
+            origin: HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum).id(),
+            ..HyperlaneMessage::default()
+        };
+
+        assert_eq!(
+            builder
+                .route(&ism, &ethereum_message, IsmCachePolicy::IsmSpecific)
+                .await
+                .unwrap(),
+            H256::from_low_u64_be(42)
+        );
+        assert_eq!(
+            builder
+                .route(&ism, &ethereum_message, IsmCachePolicy::IsmSpecific)
+                .await
+                .unwrap(),
+            H256::from_low_u64_be(42)
+        );
+        builder
+            .route(&ism, &arbitrum_message, IsmCachePolicy::IsmSpecific)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn ism_specific_routes_are_isolated_by_ism_domain() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ethereum_ism =
+            ism_on_domain(calls.clone(), false, KnownHyperlaneDomain::Ethereum.into());
+        let arbitrum_ism =
+            ism_on_domain(calls.clone(), false, KnownHyperlaneDomain::Arbitrum.into());
+        let message = HyperlaneMessage::default();
+
+        builder
+            .route(&ethereum_ism, &message, IsmCachePolicy::IsmSpecific)
+            .await
+            .unwrap();
+        builder
+            .route(&arbitrum_ism, &message, IsmCachePolicy::IsmSpecific)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn message_specific_routes_are_isolated_by_message_id() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ism = ism(calls.clone(), false);
+        let first = HyperlaneMessage {
+            nonce: 1,
+            ..HyperlaneMessage::default()
+        };
+        let second = HyperlaneMessage {
+            nonce: 2,
+            ..HyperlaneMessage::default()
+        };
+
+        builder
+            .route(&ism, &first, IsmCachePolicy::MessageSpecific)
+            .await
+            .unwrap();
+        builder
+            .route(&ism, &first, IsmCachePolicy::MessageSpecific)
+            .await
+            .unwrap();
+        builder
+            .route(&ism, &second, IsmCachePolicy::MessageSpecific)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_routes_are_not_cached() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ism = ism(calls.clone(), true);
+        let message = HyperlaneMessage::default();
+
+        assert!(builder
+            .route(&ism, &message, IsmCachePolicy::MessageSpecific)
+            .await
+            .is_err());
+        assert!(builder
+            .route(&ism, &message, IsmCachePolicy::MessageSpecific)
+            .await
+            .is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -19,7 +19,7 @@ pub struct RoutingIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for RoutingIsmMetadataBuilder {
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -4,7 +4,7 @@ use derive_new::new;
 use hyperlane_core::{PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason};
 use prometheus::{IntGauge, IntGaugeVec};
 use tokio::sync::{broadcast::Receiver, Mutex};
-use tracing::{debug, instrument};
+use tracing::{instrument, trace};
 
 use crate::server::operations::message_retry::{MessageRetryQueueResponse, MessageRetryRequest};
 use crate::settings::matching_list::MatchingListExt;
@@ -60,7 +60,7 @@ impl OpQueue {
         // This function is called very often by the message processor tasks, so only log when there are operations to pop
         // to avoid spamming the logs
         if !popped.is_empty() {
-            debug!(
+            trace!(
                 queue_label = %self.queue_metrics_label,
                 operations = ?popped,
                 "Popped OpQueue operations"

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1020,7 +1020,7 @@ impl PendingMessage {
             );
         }
         let result = self.reprepare_or_drop(reason);
-        if matches!(result, PendingOperationResult::Drop) {
+        if Self::should_skip(self.num_retries, self.max_retries) {
             self.ctx.metrics.finish_metadata_wait(
                 self.message.id(),
                 self.app_context.as_deref(),
@@ -1641,5 +1641,69 @@ mod test {
         let pending_message_debug = format!("{pending_message:?}");
         let expected = r#"PendingMessage { num_retries: 0, since_last_attempt_s: 0, next_attempt_after_s: 0, message_id: 0xaeafdd9f018e66a50d30bb141184d10e57bd956e839f70213c163eb41a3c0d87, status: FirstPrepareAttempt, app_context: Some("test-0") }"#;
         assert_eq!(pending_message_debug, expected);
+    }
+
+    #[test]
+    fn metadata_wait_ends_at_normal_message_retry_limit() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = DB::from_path(temp_dir.path()).unwrap();
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = HyperlaneMessage {
+            origin: KnownHyperlaneDomain::Arbitrum as u32,
+            destination: KnownHyperlaneDomain::Arbitrum as u32,
+            ..Default::default()
+        };
+        let message_id = message.id();
+        let app_context = "test-app";
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let message_context =
+            dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+        let mut pending_message = PendingMessage::new(
+            message,
+            Arc::new(message_context),
+            PendingOperationStatus::FirstPrepareAttempt,
+            Some(app_context.to_owned()),
+            1,
+        );
+        let labels = [app_context, "ethereum", "arbitrum"];
+        let observation = pending_message
+            .ctx
+            .metrics
+            .record_metadata_wait(message_id, Some(app_context));
+
+        let result = pending_message.on_metadata_wait(observation);
+
+        assert!(matches!(result, PendingOperationResult::Reprepare(_)));
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", "ended"])
+                .get(),
+            1
+        );
     }
 }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -27,7 +27,9 @@ use hyperlane_core::{
 use hyperlane_operation_verifier::ApplicationOperationVerifier;
 
 use crate::{
-    metrics::message_submission::{MessageSubmissionMetrics, MetadataBuildMetric},
+    metrics::message_submission::{
+        MessageSubmissionMetrics, MetadataBuildMetric, MetadataWaitObservation,
+    },
     msg::metadata::{MessageMetadataBuildParams, MetadataBuildError},
 };
 
@@ -155,6 +157,16 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ica_reveal_attempts: u32,
+}
+
+impl Drop for PendingMessage {
+    fn drop(&mut self) {
+        self.ctx.metrics.finish_metadata_wait(
+            self.message.id(),
+            self.app_context.as_deref(),
+            false,
+        );
+    }
 }
 
 impl Debug for PendingMessage {
@@ -989,6 +1001,36 @@ impl PendingMessage {
         } else {
             warn!("Repreparing message: {}", reason.clone());
         }
+        self.reprepare_or_drop(reason)
+    }
+
+    fn on_metadata_wait(&mut self, observation: MetadataWaitObservation) -> PendingOperationResult {
+        let reason = ReprepareReason::AwaitingValidatorSignatures;
+        self.inc_attempts(Some(&reason));
+        self.submitted = false;
+        if observation.first_observation {
+            warn!(
+                wait_seconds = observation.elapsed.as_secs_f64(),
+                "Waiting for validator signatures"
+            );
+        } else {
+            debug!(
+                wait_seconds = observation.elapsed.as_secs_f64(),
+                "Still waiting for validator signatures"
+            );
+        }
+        let result = self.reprepare_or_drop(reason);
+        if matches!(result, PendingOperationResult::Drop) {
+            self.ctx.metrics.finish_metadata_wait(
+                self.message.id(),
+                self.app_context.as_deref(),
+                false,
+            );
+        }
+        result
+    }
+
+    fn reprepare_or_drop(&self, reason: ReprepareReason) -> PendingOperationResult {
         // For fail-fast messages (relay API), drop immediately once the retry budget is
         // exceeded. Without this check, a small max_retries value (e.g. 3) would still
         // hit the fixed early-backoff arms (1 => 5s, 2 => 10s, ...) rather than dropping.
@@ -1023,6 +1065,16 @@ impl PendingMessage {
     /// re-attempt processing for this message again, even after the relayer
     /// restarts.
     fn record_message_process_success(&mut self) -> Result<()> {
+        if let Some(wait_duration) = self.ctx.metrics.finish_metadata_wait(
+            self.message.id(),
+            self.app_context.as_deref(),
+            true,
+        ) {
+            info!(
+                wait_seconds = wait_duration.as_secs_f64(),
+                "Validator signature wait recovered after message delivery"
+            );
+        }
         self.ctx
             .origin_db
             .store_processed_by_nonce(&self.message.nonce, &true)?;
@@ -1183,50 +1235,79 @@ impl PendingMessage {
 
         tracing::debug!(?self.message, ?metadata_res, "Metadata build result");
 
-        let metadata_res = metadata_res.map_err(|err| match &err {
-            MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
+        let metadata_res = match metadata_res {
+            Ok(metadata) => {
+                if let Some(wait_duration) = self.ctx.metrics.finish_metadata_wait(
+                    self.message.id(),
+                    self.app_context.as_deref(),
+                    true,
+                ) {
+                    info!(
+                        wait_seconds = wait_duration.as_secs_f64(),
+                        "Validator signatures became available"
+                    );
+                }
+                Ok(metadata)
             }
-            MetadataBuildError::CouldNotFetch => {
-                self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata)
+            Err(err) => {
+                if !matches!(err, MetadataBuildError::AwaitingValidatorSignatures) {
+                    self.ctx.metrics.finish_metadata_wait(
+                        self.message.id(),
+                        self.app_context.as_deref(),
+                        false,
+                    );
+                }
+                let reprepare = match &err {
+                    MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::CouldNotFetch => {
+                        self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata)
+                    }
+                    // If metadata building is refused, allow it to be retried later.
+                    MetadataBuildError::Refused(reason) => {
+                        warn!(?reason, "Metadata building refused");
+                        self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused)
+                    }
+                    // These errors cannot be recovered from, so we drop them.
+                    MetadataBuildError::UnsupportedModuleType(reason) => {
+                        warn!(?reason, "Unsupported module type");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MaxIsmDepthExceeded(depth) => {
+                        warn!(depth, "Max ISM depth reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MaxIsmCountReached(count) => {
+                        warn!(count, "Max ISM count reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::AggregationThresholdNotMet(threshold) => {
+                        warn!(threshold, "Aggregation threshold not met");
+                        self.on_reprepare(Some(&err), ReprepareReason::CouldNotFetchMetadata)
+                    }
+                    MetadataBuildError::MaxValidatorCountReached(count) => {
+                        warn!(count, "Max validator count reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MerkleRootMismatch {
+                        root,
+                        canonical_root,
+                    } => {
+                        warn!(?root, ?canonical_root, "Merkle root mismatch");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::AwaitingValidatorSignatures => {
+                        let observation = self
+                            .ctx
+                            .metrics
+                            .record_metadata_wait(self.message.id(), self.app_context.as_deref());
+                        self.on_metadata_wait(observation)
+                    }
+                };
+                Err(reprepare)
             }
-            MetadataBuildError::AwaitingValidatorSignatures => {
-                self.on_reprepare::<String>(None, ReprepareReason::AwaitingValidatorSignatures)
-            }
-            // If the metadata building is refused, we still allow it to be retried later.
-            MetadataBuildError::Refused(reason) => {
-                warn!(?reason, "Metadata building refused");
-                self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused)
-            }
-            // These errors cannot be recovered from, so we drop them
-            MetadataBuildError::UnsupportedModuleType(reason) => {
-                warn!(?reason, "Unsupported module type");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MaxIsmDepthExceeded(depth) => {
-                warn!(depth, "Max ISM depth reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MaxIsmCountReached(count) => {
-                warn!(count, "Max ISM count reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::AggregationThresholdNotMet(threshold) => {
-                warn!(threshold, "Aggregation threshold not met");
-                self.on_reprepare(Some(err), ReprepareReason::CouldNotFetchMetadata)
-            }
-            MetadataBuildError::MaxValidatorCountReached(count) => {
-                warn!(count, "Max validator count reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MerkleRootMismatch {
-                root,
-                canonical_root,
-            } => {
-                warn!(?root, ?canonical_root, "Merkle root mismatch");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-        });
+        };
         let build_metadata_end = Instant::now();
 
         let metrics_params = MetadataBuildMetric {

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use prometheus::Registry;
 use tokio::sync::RwLock;
 
 use hyperlane_base::{
@@ -10,7 +10,7 @@ use hyperlane_base::{
     settings::{ChainConf, ChainConnectionConf, Settings},
     CoreMetrics,
 };
-use hyperlane_core::{HyperlaneDomain, H256};
+use hyperlane_core::{HyperlaneDomain, KnownHyperlaneDomain, H256};
 use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
 
 use crate::{
@@ -98,22 +98,12 @@ pub fn dummy_metadata_builder(
 }
 
 pub fn dummy_submission_metrics() -> MessageSubmissionMetrics {
-    MessageSubmissionMetrics {
-        origin: "".to_string(),
-        destination: "".to_string(),
-        last_known_nonce: IntGauge::new("last_known_nonce_gauge", "help string").unwrap(),
-        messages_processed: IntCounter::new("message_processed_gauge", "help string").unwrap(),
-        metadata_build_count: IntCounterVec::new(
-            Opts::new("metadata_build_count", "help string"),
-            &["app_context", "origin", "remote", "status"],
-        )
-        .unwrap(),
-        metadata_build_duration: CounterVec::new(
-            Opts::new("metadata_build_duration", "help string"),
-            &["app_context", "origin", "remote", "status"],
-        )
-        .unwrap(),
-    }
+    let core_metrics = CoreMetrics::new("dummy_relayer", 37582, Registry::new()).unwrap();
+    MessageSubmissionMetrics::new(
+        &core_metrics,
+        &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+        &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+    )
 }
 
 pub fn dummy_message_context(

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -597,7 +597,7 @@ where
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
                 }
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     provider_host = provider_host.as_str(),

--- a/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
@@ -100,7 +100,7 @@ impl JsonRpcTransport for FallbackHttpTransport {
                 // Create log span
                 let provider = &self.inner.providers[priority.index];
 
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     "fallback_request"

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -64,6 +64,9 @@ pub struct CoreMetrics {
     // metadata building metrics
     metadata_build_count: IntCounterVec,
     metadata_build_duration: CounterVec,
+    metadata_wait_event_count: IntCounterVec,
+    metadata_wait_active: IntGaugeVec,
+    metadata_wait_oldest_timestamp_seconds: IntGaugeVec,
 
     // ism building metrics
     ism_build_count: IntCounterVec,
@@ -304,6 +307,36 @@ impl CoreMetrics {
             registry
         )?;
 
+        let metadata_wait_event_count = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_event_count"),
+                "Metadata validator-signature wait attempts and lifecycle transitions; event=wait counts attempts",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote", "event"],
+            registry
+        )?;
+
+        let metadata_wait_active = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_active"),
+                "Messages currently waiting for validator signatures",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote"],
+            registry
+        )?;
+
+        let metadata_wait_oldest_timestamp_seconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_oldest_timestamp_seconds"),
+                "Unix timestamp when the oldest active validator-signature wait began; zero when none are active",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote"],
+            registry
+        )?;
+
         let ism_build_count = register_int_counter_vec_with_registry!(
             opts!(
                 namespaced!("ism_build_count"),
@@ -355,6 +388,9 @@ impl CoreMetrics {
 
             metadata_build_count,
             metadata_build_duration,
+            metadata_wait_event_count,
+            metadata_wait_active,
+            metadata_wait_oldest_timestamp_seconds,
 
             ism_build_count,
 
@@ -692,6 +728,21 @@ impl CoreMetrics {
     /// - `status`: success or failure
     pub fn metadata_build_duration(&self) -> CounterVec {
         self.metadata_build_duration.clone()
+    }
+
+    /// Bounded wait-attempt and lifecycle events for validator-signature waits.
+    pub fn metadata_wait_event_count(&self) -> IntCounterVec {
+        self.metadata_wait_event_count.clone()
+    }
+
+    /// Number of messages currently waiting for validator signatures.
+    pub fn metadata_wait_active(&self) -> IntGaugeVec {
+        self.metadata_wait_active.clone()
+    }
+
+    /// Unix timestamp when the oldest active validator-signature wait began.
+    pub fn metadata_wait_oldest_timestamp_seconds(&self) -> IntGaugeVec {
+        self.metadata_wait_oldest_timestamp_seconds.clone()
     }
 
     /// The number of ism built by this process during its


### PR DESCRIPTION
## Summary

- write Routing ISM cache entries under the same execution-chain namespace used for reads
- track validator-signature waits with bounded lifecycle metrics and first-wait/repeat/recovery logging
- keep oldest-wait updates O(log K) with ordered timestamp counts
- let aggregation ISMs continue past tolerated submodule failures without ERROR-level noise
- demote hot non-empty queue and fallback-request logs to TRACE

This preserves the complete metadata-wait scope from #9221 and the useful log-demotion portion of the closed #8994.

## Why it matters

Routing cache reads used the chain where the Routing ISM call executes, while writes used the message-origin namespace. Repeated keys therefore missed and repeated the provider call. Sampled relayer metrics showed zero `route` hits:

| Process | Observed route misses | Daily equivalent |
|---|---:|---:|
| Standard relayer | 7,867 since pod start | 8,828/day |
| Fastpath relayer | 9 since pod start | 83/day |
| Total | | 8,911/day |

Expected validator-signature waits also appeared at recursive builder boundaries, inflating error logs without exposing a bounded count or wait age.

## Expected improvement

**Measured input, modeled result:** the sampled ceiling is 8,911 generic EVM requests/day. For `N` repeated lookups of one key during its cache lifetime, provider calls change from `N` to `1`: up to `N`x fewer calls, or `(N - 1) / N` fewer. The first unique lookup still calls the provider; realized savings require a canary.

Each hit also removes one routing-contract RPC latency component. No production latency reduction is claimed yet. Metadata and log-volume improvements are directional but unquantified.

## Correctness boundary

- cache policy and parameter keys are unchanged
- same-address ISMs on different domains remain isolated
- distinct origins remain isolated for ISM-specific caching; distinct messages remain isolated for message-specific caching
- provider failures are not cached
- wait metrics have bounded labels; message IDs remain only in-process
- tracker entries close on recovery, terminal errors, retry exhaustion, and drop
- the oldest-wait gauge is derived from tracker state under the same lock
- ordered timestamp counts keep wait insertion/removal O(log K), including same-second bursts
- tolerated aggregation submodule failures are WARN; top-level retry and delivery behavior is unchanged

## Verification

- `cargo fmt --all -- --check`
- `cargo test --offline -p relayer metrics::message_submission::tests --lib` — 3 passed
- existing focused routing, aggregation, and pending-message tests retained
- normal pre-commit hooks passed: gitleaks, lint-staged, and Rust formatting

## Canary and rollback

Canary the standard relayer first. Compare route hit/miss rate, `eth_call` request rate, metadata-wait metrics, metadata failures, queue age, delivery latency, and Lander stage queues. Require route hits above zero after warm-up and no reliability regression. Roll back to the prior immutable image if those reliability signals regress; no migration is required.

## Integration order

Rebased directly onto `main@0aeb76aaea`. This is the base of #9396 -> #9399 -> #9403 -> #9388. Exact head: `a48d1eeaef`.

Part of #9386.
