### PR TITLE
feat(warp-monitor): centralized multi-route monitor

### DIFF
--- a/typescript/warp-monitor/src/monitor.test.ts
+++ b/typescript/warp-monitor/src/monitor.test.ts
@@ -13,7 +13,7 @@ import {
   resetPendingDestinationMetrics,
   metricsRegister,
 } from './metrics.js';
-import { WarpMonitor } from './monitor.js';
+import { WarpMonitor, updatePendingAndInventoryMetrics } from './monitor.js';
 
 function createMockToken({
   collateralized,
@@ -36,7 +36,7 @@ function createMockToken({
 }
 
 async function invokeUpdatePendingAndInventoryMetrics(
-  monitor: WarpMonitor,
+  _monitor: WarpMonitor,
   warpCore: WarpCore,
   routerNodes: RouterNodeMetadata[],
   collateralByNodeId: Map<string, bigint>,
@@ -45,19 +45,7 @@ async function invokeUpdatePendingAndInventoryMetrics(
   explorerQueryLimit?: number,
   inventoryAddress?: string,
 ) {
-  const updatePendingAndInventoryMetrics = (monitor as any)
-    .updatePendingAndInventoryMetrics as (
-    warpCore: WarpCore,
-    routerNodes: RouterNodeMetadata[],
-    collateralByNodeId: Map<string, bigint>,
-    warpRouteId: string,
-    pendingTransfersClient?: ExplorerPendingTransfersClient,
-    explorerQueryLimit?: number,
-    inventoryAddress?: string,
-  ) => Promise<void>;
-
-  await updatePendingAndInventoryMetrics.call(
-    monitor,
+  await updatePendingAndInventoryMetrics(
     warpCore,
     routerNodes,
     collateralByNodeId,

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -61,6 +61,218 @@ type PendingDestinationAggregate = {
   oldestPendingSeconds: number;
 };
 
+/**
+ * Everything shared across all monitored routes: providers, chain metadata,
+ * and the price getter. Built once and reused for every route so the
+ * centralized monitor does not rebuild a MultiProtocolProvider per route.
+ */
+export type WarpMonitorSharedContext = {
+  multiProtocolProvider: MultiProtocolProvider;
+  chainMetadata: ChainMap<ChainMetadata>;
+  priceGetter: TokenPriceGetter;
+};
+
+/**
+ * Per-route state resolved once at startup. `runRouteCycle` consumes this to
+ * emit one full set of metrics for the route.
+ */
+export type WarpRouteRuntime = {
+  warpRouteId: string;
+  warpCore: WarpCore;
+  warpDeployConfig: WarpRouteDeployConfig | null;
+  routerNodes: RouterNodeMetadata[];
+  pendingTransfersClient?: ExplorerPendingTransfersClient;
+  explorerQueryLimit: number;
+  inventoryAddress?: string;
+  // When true, the shared balance metrics (token_balance / collateral_value /
+  // value_at_risk) are NOT emitted for this route because another workload
+  // (e.g. a rebalancer) already owns them. Monitor-only metrics
+  // (pending / projected_deficit / inventory / xERC20 / lockbox) still emit.
+  skipSharedBalanceMetrics: boolean;
+};
+
+export type BuildRouteRuntimeOptions = {
+  warpRouteId: string;
+  explorerApiUrl?: string;
+  explorerQueryLimit?: number;
+  inventoryAddress?: string;
+  skipSharedBalanceMetrics?: boolean;
+};
+
+/**
+ * Builds the MultiProtocolProvider shared by all routes. The Sealevel warp
+ * adapters require the Mailbox address, so mailboxes are merged into the
+ * chain metadata.
+ */
+export function buildMultiProtocolProvider(
+  chainMetadata: ChainMap<ChainMetadata>,
+  chainAddresses: ChainMap<{ mailbox?: string }>,
+): MultiProtocolProvider {
+  const mailboxes = objMap(chainAddresses, (_, { mailbox }) => ({
+    mailbox,
+  }));
+  return new MultiProtocolProvider(objMerge(chainMetadata, mailboxes));
+}
+
+export function buildPriceGetter(
+  chainMetadata: ChainMap<ChainMetadata>,
+  coingeckoApiKey: string | undefined,
+): TokenPriceGetter {
+  const tokenPriceGetter = new CoinGeckoTokenPriceGetter({
+    chainMetadata,
+    apiKey: coingeckoApiKey,
+  });
+
+  if (!coingeckoApiKey) {
+    getLogger().warn(
+      'No CoinGecko API key provided, using public tier (rate limited)',
+    );
+  }
+
+  return {
+    tryGetTokenPrice: async (token: Token) =>
+      tryGetTokenPrice(token, tokenPriceGetter),
+  };
+}
+
+/**
+ * Reads chain metadata + addresses from the registry, applies RPC overrides
+ * from the environment, and assembles the shared context.
+ */
+export async function buildSharedContext(
+  registry: IRegistry,
+  coingeckoApiKey: string | undefined,
+): Promise<WarpMonitorSharedContext> {
+  const logger = getLogger();
+  const chainMetadata = await registry.getMetadata();
+  const chainAddresses = await registry.getAddresses();
+  const overriddenChains = applyRpcUrlOverridesFromEnv(chainMetadata);
+  if (overriddenChains.length > 0) {
+    logger.info(
+      { chains: overriddenChains, count: overriddenChains.length },
+      'Applied RPC overrides from environment variables',
+    );
+  }
+
+  const multiProtocolProvider = buildMultiProtocolProvider(
+    chainMetadata,
+    chainAddresses,
+  );
+  const priceGetter = buildPriceGetter(chainMetadata, coingeckoApiKey);
+
+  return { multiProtocolProvider, chainMetadata, priceGetter };
+}
+
+/**
+ * Resolves the per-route runtime (warp core, deploy config, router nodes,
+ * explorer client) from the registry using a shared context.
+ */
+export async function buildRouteRuntime(
+  registry: IRegistry,
+  shared: WarpMonitorSharedContext,
+  options: BuildRouteRuntimeOptions,
+): Promise<WarpRouteRuntime> {
+  const logger = getLogger();
+  const {
+    warpRouteId,
+    explorerApiUrl,
+    explorerQueryLimit = 200,
+    inventoryAddress,
+    skipSharedBalanceMetrics = false,
+  } = options;
+
+  const warpCoreConfig = await registry.getWarpRoute(warpRouteId);
+  if (!warpCoreConfig) {
+    throw new Error(
+      `Warp route config for ${warpRouteId} not found in registry`,
+    );
+  }
+
+  const warpCore = WarpCore.FromConfig(
+    shared.multiProtocolProvider,
+    warpCoreConfig,
+  );
+  const warpDeployConfig = await registry.getWarpDeployConfig(warpRouteId);
+  const routerNodes = buildRouterNodes(warpCore, shared.chainMetadata);
+  const pendingTransfersClient = explorerApiUrl
+    ? new ExplorerPendingTransfersClient(explorerApiUrl, routerNodes, logger)
+    : undefined;
+
+  logger.info(
+    {
+      warpRouteId,
+      tokenCount: warpCore.tokens.length,
+      chains: warpCore.getTokenChains(),
+      crossCollateralNodeCount: routerNodes.length,
+      explorerEnabled: !!pendingTransfersClient,
+      inventoryTrackingEnabled: !!inventoryAddress,
+      skipSharedBalanceMetrics,
+    },
+    'Built warp route runtime',
+  );
+
+  return {
+    warpRouteId,
+    warpCore,
+    warpDeployConfig,
+    routerNodes,
+    pendingTransfersClient,
+    explorerQueryLimit,
+    inventoryAddress,
+    skipSharedBalanceMetrics,
+  };
+}
+
+/**
+ * Resets the per-cycle gauges (pending destination + inventory). These gauges
+ * are cleared once per full cycle so that stale label sets (e.g. removed
+ * routes or nodes) do not linger. Callers MUST invoke this once before
+ * running the routes in a cycle, never per-route (which would wipe series
+ * belonging to other routes in the centralized monitor).
+ */
+export function resetCycleMetrics(): void {
+  resetPendingDestinationMetrics();
+  resetInventoryBalanceMetrics();
+}
+
+/**
+ * Emits one full set of metrics for a single route. Does NOT reset gauges —
+ * the caller resets once per cycle before running any routes.
+ */
+export async function runRouteCycle(
+  shared: WarpMonitorSharedContext,
+  runtime: WarpRouteRuntime,
+): Promise<void> {
+  const collateralSnapshots = await Promise.all(
+    runtime.warpCore.tokens.map(async (token) =>
+      updateTokenMetrics(
+        runtime.warpCore,
+        runtime.warpDeployConfig,
+        token,
+        shared.priceGetter,
+        runtime.warpRouteId,
+        runtime.skipSharedBalanceMetrics,
+      ),
+    ),
+  );
+
+  const collateralByNodeId = new Map<string, bigint>();
+  for (const snapshot of collateralSnapshots) {
+    if (!snapshot) continue;
+    collateralByNodeId.set(snapshot.nodeId, snapshot.routerCollateralBaseUnits);
+  }
+
+  await updatePendingAndInventoryMetrics(
+    runtime.warpCore,
+    runtime.routerNodes,
+    collateralByNodeId,
+    runtime.warpRouteId,
+    runtime.pendingTransfersClient,
+    runtime.explorerQueryLimit,
+    runtime.inventoryAddress,
+  );
+}
+
 export class WarpMonitor {
   private readonly config: WarpMonitorConfig;
   private readonly registry: IRegistry;
@@ -91,134 +303,29 @@ export class WarpMonitor {
       'Metrics server started',
     );
 
-    // Get chain metadata and addresses from registry
-    const chainMetadata = await this.registry.getMetadata();
-    const chainAddresses = await this.registry.getAddresses();
-    const overriddenChains = applyRpcUrlOverridesFromEnv(chainMetadata);
-    if (overriddenChains.length > 0) {
-      logger.info(
-        { chains: overriddenChains, count: overriddenChains.length },
-        'Applied RPC overrides from environment variables',
-      );
-    }
-
-    // The Sealevel warp adapters require the Mailbox address, so we
-    // get mailboxes for all chains and merge them with the chain metadata.
-    const mailboxes = objMap(chainAddresses, (_, { mailbox }) => ({
-      mailbox,
-    }));
-    const multiProtocolProvider = new MultiProtocolProvider(
-      objMerge(chainMetadata, mailboxes),
-    );
-
-    // Get warp route config from registry
-    const warpCoreConfig = await this.registry.getWarpRoute(warpRouteId);
-    if (!warpCoreConfig) {
-      throw new Error(
-        `Warp route config for ${warpRouteId} not found in registry`,
-      );
-    }
-
-    const warpCore = WarpCore.FromConfig(multiProtocolProvider, warpCoreConfig);
-    const warpDeployConfig =
-      await this.registry.getWarpDeployConfig(warpRouteId);
-    const routerNodes = this.buildRouterNodes(warpCore, chainMetadata);
-    const pendingTransfersClient = explorerApiUrl
-      ? new ExplorerPendingTransfersClient(explorerApiUrl, routerNodes, logger)
-      : undefined;
+    const shared = await buildSharedContext(this.registry, coingeckoApiKey);
+    const runtime = await buildRouteRuntime(this.registry, shared, {
+      warpRouteId,
+      explorerApiUrl,
+      explorerQueryLimit,
+      inventoryAddress,
+    });
 
     logger.info(
       {
         warpRouteId,
         checkFrequency,
-        tokenCount: warpCore.tokens.length,
-        chains: warpCore.getTokenChains(),
-        crossCollateralNodeCount: routerNodes.length,
-        explorerEnabled: !!pendingTransfersClient,
-        inventoryTrackingEnabled: !!inventoryAddress,
+        tokenCount: runtime.warpCore.tokens.length,
+        chains: runtime.warpCore.getTokenChains(),
       },
       'Starting warp route monitor',
     );
 
-    await this.pollAndUpdateWarpRouteMetrics(
-      checkFrequency,
-      warpCore,
-      warpDeployConfig,
-      chainMetadata,
-      warpRouteId,
-      coingeckoApiKey,
-      routerNodes,
-      pendingTransfersClient,
-      explorerQueryLimit,
-      inventoryAddress,
-    );
-  }
-
-  // Indefinitely loops, updating warp route metrics at the specified frequency.
-  private async pollAndUpdateWarpRouteMetrics(
-    checkFrequency: number,
-    warpCore: WarpCore,
-    warpDeployConfig: WarpRouteDeployConfig | null,
-    chainMetadata: ChainMap<ChainMetadata>,
-    warpRouteId: string,
-    coingeckoApiKey: string | undefined,
-    routerNodes: RouterNodeMetadata[],
-    pendingTransfersClient?: ExplorerPendingTransfersClient,
-    explorerQueryLimit = 200,
-    inventoryAddress?: string,
-  ): Promise<void> {
-    const logger = getLogger();
-    const tokenPriceGetter = new CoinGeckoTokenPriceGetter({
-      chainMetadata,
-      apiKey: coingeckoApiKey,
-    });
-
-    if (!coingeckoApiKey) {
-      logger.warn(
-        'No CoinGecko API key provided, using public tier (rate limited)',
-      );
-    }
-
-    // Wrap CoinGeckoTokenPriceGetter to match TokenPriceGetter interface
-    const priceGetter: TokenPriceGetter = {
-      tryGetTokenPrice: async (token: Token) => {
-        return this.tryGetTokenPrice(token, tokenPriceGetter);
-      },
-    };
-
     for (;;) {
       await tryFn(
         async () => {
-          const collateralSnapshots = await Promise.all(
-            warpCore.tokens.map(async (token) =>
-              this.updateTokenMetrics(
-                warpCore,
-                warpDeployConfig,
-                token,
-                priceGetter,
-                warpRouteId,
-              ),
-            ),
-          );
-
-          const collateralByNodeId = new Map<string, bigint>();
-          for (const snapshot of collateralSnapshots) {
-            if (!snapshot) continue;
-            collateralByNodeId.set(
-              snapshot.nodeId,
-              snapshot.routerCollateralBaseUnits,
-            );
-          }
-
-          await this.updatePendingAndInventoryMetrics(
-            warpCore,
-            routerNodes,
-            collateralByNodeId,
-            warpRouteId,
-            pendingTransfersClient,
-            explorerQueryLimit,
-            inventoryAddress,
-          );
+          resetCycleMetrics();
+          await runRouteCycle(shared, runtime);
         },
         'Updating warp route metrics',
         logger,
@@ -226,422 +333,406 @@ export class WarpMonitor {
       await sleep(checkFrequency);
     }
   }
+}
 
-  private async updatePendingAndInventoryMetrics(
-    warpCore: WarpCore,
-    routerNodes: RouterNodeMetadata[],
-    collateralByNodeId: Map<string, bigint>,
-    warpRouteId: string,
-    pendingTransfersClient?: ExplorerPendingTransfersClient,
-    explorerQueryLimit = 200,
-    inventoryAddress?: string,
-  ): Promise<void> {
-    const logger = getLogger();
-    const now = Date.now();
+export async function updatePendingAndInventoryMetrics(
+  warpCore: WarpCore,
+  routerNodes: RouterNodeMetadata[],
+  collateralByNodeId: Map<string, bigint>,
+  warpRouteId: string,
+  pendingTransfersClient?: ExplorerPendingTransfersClient,
+  explorerQueryLimit = 200,
+  inventoryAddress?: string,
+): Promise<void> {
+  const logger = getLogger();
+  const now = Date.now();
 
-    resetPendingDestinationMetrics();
-    resetInventoryBalanceMetrics();
-
-    const pendingByNodeId = new Map<string, PendingDestinationAggregate>();
-    if (pendingTransfersClient) {
-      try {
-        const pendingTransfers =
-          await pendingTransfersClient.getPendingDestinationTransfers(
-            explorerQueryLimit,
-          );
-
-        for (const transfer of pendingTransfers) {
-          const aggregate = pendingByNodeId.get(transfer.destinationNodeId) ?? {
-            amountBaseUnits: 0n,
-            count: 0,
-            oldestPendingSeconds: 0,
-          };
-
-          aggregate.amountBaseUnits += transfer.amountBaseUnits;
-          aggregate.count += 1;
-
-          if (transfer.sendOccurredAtMs) {
-            const ageSeconds = Math.max(
-              0,
-              Math.floor((now - transfer.sendOccurredAtMs) / 1000),
-            );
-            aggregate.oldestPendingSeconds = Math.max(
-              aggregate.oldestPendingSeconds,
-              ageSeconds,
-            );
-          }
-
-          pendingByNodeId.set(transfer.destinationNodeId, aggregate);
-        }
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        logger.error(
-          {
-            error: message,
-          },
-          'Failed to query explorer pending transfers',
+  const pendingByNodeId = new Map<string, PendingDestinationAggregate>();
+  if (pendingTransfersClient) {
+    try {
+      const pendingTransfers =
+        await pendingTransfersClient.getPendingDestinationTransfers(
+          explorerQueryLimit,
         );
+
+      for (const transfer of pendingTransfers) {
+        const aggregate = pendingByNodeId.get(transfer.destinationNodeId) ?? {
+          amountBaseUnits: 0n,
+          count: 0,
+          oldestPendingSeconds: 0,
+        };
+
+        aggregate.amountBaseUnits += transfer.amountBaseUnits;
+        aggregate.count += 1;
+
+        if (transfer.sendOccurredAtMs) {
+          const ageSeconds = Math.max(
+            0,
+            Math.floor((now - transfer.sendOccurredAtMs) / 1000),
+          );
+          aggregate.oldestPendingSeconds = Math.max(
+            aggregate.oldestPendingSeconds,
+            ageSeconds,
+          );
+        }
+
+        pendingByNodeId.set(transfer.destinationNodeId, aggregate);
       }
-    }
-
-    const deficits: Array<{ nodeId: string; projectedDeficit: string }> = [];
-    for (const node of routerNodes) {
-      const aggregate = pendingByNodeId.get(node.nodeId) ?? {
-        amountBaseUnits: 0n,
-        count: 0,
-        oldestPendingSeconds: 0,
-      };
-
-      const routerCollateral = collateralByNodeId.get(node.nodeId) ?? 0n;
-
-      updatePendingDestinationMetrics({
-        warpRouteId,
-        nodeId: node.nodeId,
-        chainName: node.chainName,
-        routerAddress: node.routerAddress,
-        tokenAddress: node.tokenAddress,
-        tokenSymbol: node.tokenSymbol,
-        tokenName: node.tokenName,
-        pendingAmount: this.formatTokenAmount(
-          node.token,
-          aggregate.amountBaseUnits,
-        ),
-        pendingCount: aggregate.count,
-        oldestPendingSeconds: aggregate.oldestPendingSeconds,
-      });
-
-      if (!node.token.isCollateralized()) {
-        continue;
-      }
-
-      const projectedDeficitBaseUnits =
-        aggregate.amountBaseUnits > routerCollateral
-          ? aggregate.amountBaseUnits - routerCollateral
-          : 0n;
-
-      updateProjectedDeficitMetrics({
-        warpRouteId,
-        nodeId: node.nodeId,
-        chainName: node.chainName,
-        routerAddress: node.routerAddress,
-        tokenAddress: node.tokenAddress,
-        tokenSymbol: node.tokenSymbol,
-        tokenName: node.tokenName,
-        projectedDeficit: this.formatTokenAmount(
-          node.token,
-          projectedDeficitBaseUnits,
-        ),
-      });
-
-      if (projectedDeficitBaseUnits > 0n) {
-        deficits.push({
-          nodeId: node.nodeId,
-          projectedDeficit: projectedDeficitBaseUnits.toString(),
-        });
-      }
-    }
-
-    if (deficits.length > 0) {
-      logger.warn(
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(
         {
-          deficits,
-          deficitNodeCount: deficits.length,
+          warpRouteId,
+          error: message,
         },
-        'Detected projected destination deficits from pending transfers',
+        'Failed to query explorer pending transfers',
       );
     }
+  }
 
-    if (!inventoryAddress) return;
+  const deficits: Array<{ nodeId: string; projectedDeficit: string }> = [];
+  for (const node of routerNodes) {
+    const aggregate = pendingByNodeId.get(node.nodeId) ?? {
+      amountBaseUnits: 0n,
+      count: 0,
+      oldestPendingSeconds: 0,
+    };
 
-    await Promise.all(
-      routerNodes.map(async (node) => {
-        try {
-          const adapter = node.token.getAdapter(warpCore.multiProvider);
-          const inventoryBalance = await adapter.getBalance(inventoryAddress);
+    const routerCollateral = collateralByNodeId.get(node.nodeId) ?? 0n;
 
-          updateInventoryBalanceMetrics({
-            warpRouteId,
-            nodeId: node.nodeId,
-            chainName: node.chainName,
-            routerAddress: node.routerAddress,
-            tokenAddress: node.tokenAddress,
-            tokenSymbol: node.tokenSymbol,
-            tokenName: node.tokenName,
-            inventoryAddress,
-            inventoryBalance: this.formatTokenAmount(
-              node.token,
-              inventoryBalance,
-            ),
-          });
-        } catch (error: unknown) {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          logger.error(
-            { nodeId: node.nodeId, error: message },
-            `Reading inventory balance for ${node.nodeId} failed`,
-          );
-        }
-      }),
+    updatePendingDestinationMetrics({
+      warpRouteId,
+      nodeId: node.nodeId,
+      chainName: node.chainName,
+      routerAddress: node.routerAddress,
+      tokenAddress: node.tokenAddress,
+      tokenSymbol: node.tokenSymbol,
+      tokenName: node.tokenName,
+      pendingAmount: formatTokenAmount(node.token, aggregate.amountBaseUnits),
+      pendingCount: aggregate.count,
+      oldestPendingSeconds: aggregate.oldestPendingSeconds,
+    });
+
+    if (!node.token.isCollateralized()) {
+      continue;
+    }
+
+    const projectedDeficitBaseUnits =
+      aggregate.amountBaseUnits > routerCollateral
+        ? aggregate.amountBaseUnits - routerCollateral
+        : 0n;
+
+    updateProjectedDeficitMetrics({
+      warpRouteId,
+      nodeId: node.nodeId,
+      chainName: node.chainName,
+      routerAddress: node.routerAddress,
+      tokenAddress: node.tokenAddress,
+      tokenSymbol: node.tokenSymbol,
+      tokenName: node.tokenName,
+      projectedDeficit: formatTokenAmount(
+        node.token,
+        projectedDeficitBaseUnits,
+      ),
+    });
+
+    if (projectedDeficitBaseUnits > 0n) {
+      deficits.push({
+        nodeId: node.nodeId,
+        projectedDeficit: projectedDeficitBaseUnits.toString(),
+      });
+    }
+  }
+
+  if (deficits.length > 0) {
+    logger.warn(
+      {
+        warpRouteId,
+        deficits,
+        deficitNodeCount: deficits.length,
+      },
+      'Detected projected destination deficits from pending transfers',
     );
   }
 
-  // Updates the metrics for a single token in a warp route.
-  private async updateTokenMetrics(
-    warpCore: WarpCore,
-    warpDeployConfig: WarpRouteDeployConfig | null,
-    token: Token,
-    tokenPriceGetter: TokenPriceGetter,
-    warpRouteId: string,
-  ): Promise<RouterCollateralSnapshot | null> {
-    const logger = getLogger();
-    let collateralSnapshot: RouterCollateralSnapshot | null = null;
-    const promises = [
+  if (!inventoryAddress) return;
+
+  await Promise.all(
+    routerNodes.map(async (node) => {
+      try {
+        const adapter = node.token.getAdapter(warpCore.multiProvider);
+        const inventoryBalance = await adapter.getBalance(inventoryAddress);
+
+        updateInventoryBalanceMetrics({
+          warpRouteId,
+          nodeId: node.nodeId,
+          chainName: node.chainName,
+          routerAddress: node.routerAddress,
+          tokenAddress: node.tokenAddress,
+          tokenSymbol: node.tokenSymbol,
+          tokenName: node.tokenName,
+          inventoryAddress,
+          inventoryBalance: formatTokenAmount(node.token, inventoryBalance),
+        });
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          { warpRouteId, nodeId: node.nodeId, error: message },
+          `Reading inventory balance for ${node.nodeId} failed`,
+        );
+      }
+    }),
+  );
+}
+
+// Updates the metrics for a single token in a warp route.
+async function updateTokenMetrics(
+  warpCore: WarpCore,
+  warpDeployConfig: WarpRouteDeployConfig | null,
+  token: Token,
+  tokenPriceGetter: TokenPriceGetter,
+  warpRouteId: string,
+  skipSharedBalanceMetrics: boolean,
+): Promise<RouterCollateralSnapshot | null> {
+  const logger = getLogger();
+  let collateralSnapshot: RouterCollateralSnapshot | null = null;
+  const promises = [
+    tryFn(
+      async () => {
+        const bridgedSupply = token.isHypToken()
+          ? await token.getHypAdapter(warpCore.multiProvider).getBridgedSupply()
+          : undefined;
+
+        // The router collateral snapshot is required for the projected-deficit
+        // metric even when the shared balance metrics are skipped, so always
+        // compute the bridged supply / balance info.
+        const balanceInfo = await getTokenBridgedBalance(
+          warpCore,
+          token,
+          tokenPriceGetter,
+          logger,
+          bridgedSupply,
+        );
+
+        if (balanceInfo && !skipSharedBalanceMetrics) {
+          updateTokenBalanceMetrics(warpCore, token, balanceInfo, warpRouteId);
+        }
+
+        if (bridgedSupply !== undefined) {
+          collateralSnapshot = {
+            nodeId: buildNodeId(token),
+            routerCollateralBaseUnits: bridgedSupply,
+            token,
+          };
+        }
+      },
+      'Getting bridged balance and value',
+      logger,
+    ),
+  ];
+
+  // For Sealevel collateral and synthetic tokens, there is an
+  // "Associated Token Account" (ATA) rent payer that has a balance
+  // that's used to pay for rent for the accounts that store user balances.
+  // This is necessary if the recipient has never received any tokens before.
+  if (token.protocol === ProtocolType.Sealevel && !token.isNative()) {
+    promises.push(
       tryFn(
         async () => {
-          const bridgedSupply = token.isHypToken()
-            ? await token
-                .getHypAdapter(warpCore.multiProvider)
-                .getBridgedSupply()
-            : undefined;
-
-          const balanceInfo = await getTokenBridgedBalance(
+          const balance = await getSealevelAtaPayerBalance(
             warpCore,
             token,
-            tokenPriceGetter,
-            logger,
-            bridgedSupply,
+            warpRouteId,
           );
-          if (!balanceInfo) {
-            return;
-          }
-          updateTokenBalanceMetrics(warpCore, token, balanceInfo, warpRouteId);
-
-          if (bridgedSupply !== undefined) {
-            collateralSnapshot = {
-              nodeId: this.buildNodeId(token),
-              routerCollateralBaseUnits: bridgedSupply,
-              token,
-            };
-          }
+          updateNativeWalletBalanceMetrics(balance);
         },
-        'Getting bridged balance and value',
+        'Getting ATA payer balance',
         logger,
       ),
-    ];
+    );
+  }
 
-    // For Sealevel collateral and synthetic tokens, there is an
-    // "Associated Token Account" (ATA) rent payer that has a balance
-    // that's used to pay for rent for the accounts that store user balances.
-    // This is necessary if the recipient has never received any tokens before.
-    if (token.protocol === ProtocolType.Sealevel && !token.isNative()) {
-      promises.push(
-        tryFn(
-          async () => {
-            const balance = await getSealevelAtaPayerBalance(
-              warpCore,
-              token,
-              warpRouteId,
-            );
-            updateNativeWalletBalanceMetrics(balance);
-          },
-          'Getting ATA payer balance',
-          logger,
-        ),
+  if (token.isXerc20()) {
+    promises.push(
+      tryFn(
+        async () => {
+          const { limits, xERC20Address } = await getXERC20Info(
+            warpCore,
+            token,
+          );
+          const routerAddress = token.addressOrDenom;
+          updateXERC20LimitsMetrics(
+            token,
+            limits,
+            routerAddress,
+            token.standard,
+            xERC20Address,
+          );
+        },
+        'Getting xERC20 limits',
+        logger,
+      ),
+    );
+
+    if (!warpDeployConfig) {
+      logger.warn(
+        { token: token.symbol, chain: token.chainName },
+        'Failed to read warp deploy config, skipping extra lockboxes',
       );
+      await Promise.all(promises);
+      return collateralSnapshot;
     }
 
-    if (token.isXerc20()) {
+    // If the current token is an xERC20, we need to check if there are any extra lockboxes
+    const currentTokenDeployConfig = warpDeployConfig[token.chainName];
+    if (
+      currentTokenDeployConfig.type !== TokenType.XERC20 &&
+      currentTokenDeployConfig.type !== TokenType.XERC20Lockbox
+    ) {
+      logger.error(
+        {
+          expected: 'XERC20|XERC20Lockbox',
+          actual: currentTokenDeployConfig.type,
+          token: token.symbol,
+          chain: token.chainName,
+        },
+        'Invalid deploy config type for xERC20 token',
+      );
+      await Promise.all(promises);
+      return collateralSnapshot;
+    }
+
+    const extraLockboxes = currentTokenDeployConfig.xERC20?.extraBridges ?? [];
+
+    for (const lockbox of extraLockboxes) {
       promises.push(
         tryFn(
           async () => {
-            const { limits, xERC20Address } = await getXERC20Info(
-              warpCore,
+            const { limits, xERC20Address } = await getExtraLockboxInfo(
+              warpCore.multiProvider,
               token,
+              lockbox.lockbox,
             );
-            const routerAddress = token.addressOrDenom;
+
             updateXERC20LimitsMetrics(
               token,
               limits,
-              routerAddress,
-              token.standard,
+              lockbox.lockbox,
+              'EvmManagedLockbox',
               xERC20Address,
             );
           },
-          'Getting xERC20 limits',
+          'Getting extra lockbox limits',
+          logger,
+        ),
+        tryFn(
+          async () => {
+            const balance = await getExtraLockboxBalance(
+              warpCore.multiProvider,
+              token,
+              tokenPriceGetter,
+              lockbox.lockbox,
+              logger,
+            );
+
+            if (balance) {
+              const { tokenName, tokenAddress } =
+                await getManagedLockBoxCollateralInfo(
+                  warpCore.multiProvider,
+                  token,
+                  lockbox.lockbox,
+                );
+
+              updateManagedLockboxBalanceMetrics(
+                warpCore,
+                token.chainName,
+                tokenName,
+                tokenAddress,
+                lockbox.lockbox,
+                balance,
+                warpRouteId,
+              );
+            }
+          },
+          `Updating extra lockbox balance for contract at "${lockbox.lockbox}" on chain ${token.chainName}`,
           logger,
         ),
       );
-
-      if (!warpDeployConfig) {
-        logger.warn(
-          { token: token.symbol, chain: token.chainName },
-          'Failed to read warp deploy config, skipping extra lockboxes',
-        );
-        await Promise.all(promises);
-        return collateralSnapshot;
-      }
-
-      // If the current token is an xERC20, we need to check if there are any extra lockboxes
-      const currentTokenDeployConfig = warpDeployConfig[token.chainName];
-      if (
-        currentTokenDeployConfig.type !== TokenType.XERC20 &&
-        currentTokenDeployConfig.type !== TokenType.XERC20Lockbox
-      ) {
-        logger.error(
-          {
-            expected: 'XERC20|XERC20Lockbox',
-            actual: currentTokenDeployConfig.type,
-            token: token.symbol,
-            chain: token.chainName,
-          },
-          'Invalid deploy config type for xERC20 token',
-        );
-        await Promise.all(promises);
-        return collateralSnapshot;
-      }
-
-      const extraLockboxes =
-        currentTokenDeployConfig.xERC20?.extraBridges ?? [];
-
-      for (const lockbox of extraLockboxes) {
-        promises.push(
-          tryFn(
-            async () => {
-              const { limits, xERC20Address } = await getExtraLockboxInfo(
-                warpCore.multiProvider,
-                token,
-                lockbox.lockbox,
-              );
-
-              updateXERC20LimitsMetrics(
-                token,
-                limits,
-                lockbox.lockbox,
-                'EvmManagedLockbox',
-                xERC20Address,
-              );
-            },
-            'Getting extra lockbox limits',
-            logger,
-          ),
-          tryFn(
-            async () => {
-              const balance = await getExtraLockboxBalance(
-                warpCore.multiProvider,
-                token,
-                tokenPriceGetter,
-                lockbox.lockbox,
-                logger,
-              );
-
-              if (balance) {
-                const { tokenName, tokenAddress } =
-                  await getManagedLockBoxCollateralInfo(
-                    warpCore.multiProvider,
-                    token,
-                    lockbox.lockbox,
-                  );
-
-                updateManagedLockboxBalanceMetrics(
-                  warpCore,
-                  token.chainName,
-                  tokenName,
-                  tokenAddress,
-                  lockbox.lockbox,
-                  balance,
-                  warpRouteId,
-                );
-              }
-            },
-            `Updating extra lockbox balance for contract at "${lockbox.lockbox}" on chain ${token.chainName}`,
-            logger,
-          ),
-        );
-      }
     }
-
-    await Promise.all(promises);
-    return collateralSnapshot;
   }
 
-  private buildRouterNodes(
-    warpCore: WarpCore,
-    chainMetadata: ChainMap<ChainMetadata>,
-  ): RouterNodeMetadata[] {
-    const nodeByKey = new Map<string, RouterNodeMetadata>();
+  await Promise.all(promises);
+  return collateralSnapshot;
+}
 
-    for (const token of warpCore.tokens) {
-      if (
-        !Object.prototype.hasOwnProperty.call(chainMetadata, token.chainName)
-      ) {
-        continue;
-      }
-      const metadata = chainMetadata[token.chainName];
-      if (!ethersUtils.isAddress(token.addressOrDenom)) continue;
+function buildRouterNodes(
+  warpCore: WarpCore,
+  chainMetadata: ChainMap<ChainMetadata>,
+): RouterNodeMetadata[] {
+  const nodeByKey = new Map<string, RouterNodeMetadata>();
 
-      const domainId = metadata.domainId;
-      const routerAddress = ethersUtils
-        .getAddress(token.addressOrDenom)
-        .toLowerCase();
-      const key = `${domainId}:${routerAddress}`;
-      if (nodeByKey.has(key)) continue;
-
-      nodeByKey.set(key, {
-        nodeId: this.buildNodeId(token),
-        chainName: token.chainName,
-        domainId,
-        routerAddress,
-        tokenAddress: (
-          token.collateralAddressOrDenom ?? token.addressOrDenom
-        ).toLowerCase(),
-        tokenName: token.name,
-        tokenSymbol: token.symbol,
-        tokenDecimals: token.decimals,
-        tokenScale: token.scale ?? 1,
-        token,
-      });
+  for (const token of warpCore.tokens) {
+    if (!Object.prototype.hasOwnProperty.call(chainMetadata, token.chainName)) {
+      continue;
     }
+    const metadata = chainMetadata[token.chainName];
+    if (!ethersUtils.isAddress(token.addressOrDenom)) continue;
 
-    return [...nodeByKey.values()];
+    const domainId = metadata.domainId;
+    const routerAddress = ethersUtils
+      .getAddress(token.addressOrDenom)
+      .toLowerCase();
+    const key = `${domainId}:${routerAddress}`;
+    if (nodeByKey.has(key)) continue;
+
+    nodeByKey.set(key, {
+      nodeId: buildNodeId(token),
+      chainName: token.chainName,
+      domainId,
+      routerAddress,
+      tokenAddress: (
+        token.collateralAddressOrDenom ?? token.addressOrDenom
+      ).toLowerCase(),
+      tokenName: token.name,
+      tokenSymbol: token.symbol,
+      tokenDecimals: token.decimals,
+      tokenScale: token.scale ?? 1,
+      token,
+    });
   }
 
-  private buildNodeId(token: Token): string {
-    return `${token.symbol}|${token.chainName}|${token.addressOrDenom.toLowerCase()}`;
+  return [...nodeByKey.values()];
+}
+
+function buildNodeId(token: Token): string {
+  return `${token.symbol}|${token.chainName}|${token.addressOrDenom.toLowerCase()}`;
+}
+
+function formatTokenAmount(token: Token, amount: bigint): number {
+  return token.amount(amount).getDecimalFormattedAmount();
+}
+
+// Tries to get the price of a token from CoinGecko. Returns undefined if there's no
+// CoinGecko ID for the token.
+async function tryGetTokenPrice(
+  token: Token,
+  tokenPriceGetter: CoinGeckoTokenPriceGetter,
+): Promise<number | undefined> {
+  const logger = getLogger();
+  // We only get a price if the token defines a CoinGecko ID.
+  // This way we can ignore values of certain types of collateralized warp routes,
+  // e.g. Native warp routes on rollups that have been pre-funded.
+  const coinGeckoId = token.coinGeckoId;
+
+  if (!coinGeckoId) {
+    logger.warn(
+      { token: token.symbol, chain: token.chainName },
+      'Missing CoinGecko ID for token',
+    );
+    return undefined;
   }
 
-  private formatTokenAmount(token: Token, amount: bigint): number {
-    return token.amount(amount).getDecimalFormattedAmount();
-  }
-
-  // Tries to get the price of a token from CoinGecko. Returns undefined if there's no
-  // CoinGecko ID for the token.
-  private async tryGetTokenPrice(
-    token: Token,
-    tokenPriceGetter: CoinGeckoTokenPriceGetter,
-  ): Promise<number | undefined> {
-    const logger = getLogger();
-    // We only get a price if the token defines a CoinGecko ID.
-    // This way we can ignore values of certain types of collateralized warp routes,
-    // e.g. Native warp routes on rollups that have been pre-funded.
-    const coinGeckoId = token.coinGeckoId;
-
-    if (!coinGeckoId) {
-      logger.warn(
-        { token: token.symbol, chain: token.chainName },
-        'Missing CoinGecko ID for token',
-      );
-      return undefined;
-    }
-
-    return this.getCoingeckoPrice(tokenPriceGetter, coinGeckoId);
-  }
-
-  private async getCoingeckoPrice(
-    tokenPriceGetter: CoinGeckoTokenPriceGetter,
-    coingeckoId: string,
-  ): Promise<number | undefined> {
-    const prices = await tokenPriceGetter.getTokenPriceByIds([coingeckoId]);
-    if (!prices) return undefined;
-    return prices[0];
-  }
+  const prices = await tokenPriceGetter.getTokenPriceByIds([coinGeckoId]);
+  if (!prices) return undefined;
+  return prices[0];
 }

--- a/typescript/warp-monitor/src/multi-monitor.ts
+++ b/typescript/warp-monitor/src/multi-monitor.ts
@@ -1,0 +1,183 @@
+import { startMetricsServer } from '@hyperlane-xyz/metrics';
+import type { IRegistry } from '@hyperlane-xyz/registry';
+import { sleep, tryFn } from '@hyperlane-xyz/utils';
+
+import { metricsRegister } from './metrics.js';
+import {
+  type WarpMonitorSharedContext,
+  type WarpRouteRuntime,
+  buildRouteRuntime,
+  buildSharedContext,
+  resetCycleMetrics,
+  runRouteCycle,
+} from './monitor.js';
+import { getLogger } from './utils.js';
+
+export interface MultiWarpMonitorConfig {
+  // Explicit route ids to monitor. When undefined, every route in the
+  // registry is monitored.
+  warpRouteIds?: string[];
+  checkFrequency: number;
+  coingeckoApiKey?: string;
+  registryUri?: string;
+  explorerApiUrl?: string;
+  explorerQueryLimit?: number;
+  inventoryAddress?: string;
+  // Max number of routes processed concurrently within a single cycle.
+  concurrency: number;
+  // Routes whose shared balance metrics are owned by another workload
+  // (e.g. a rebalancer) and should NOT be re-emitted by this monitor.
+  skipSharedBalanceRouteIds?: Set<string>;
+}
+
+/**
+ * A single long-running process that monitors many warp routes. Replaces the
+ * per-route StatefulSet fleet: one metrics server, one MultiProtocolProvider,
+ * and one price getter shared across every route. Routes are processed with
+ * bounded concurrency and isolated per-route error handling so a single bad
+ * RPC cannot stall the whole cycle.
+ */
+export class MultiWarpMonitor {
+  private readonly config: MultiWarpMonitorConfig;
+  private readonly registry: IRegistry;
+
+  constructor(config: MultiWarpMonitorConfig, registry: IRegistry) {
+    this.config = config;
+    this.registry = registry;
+  }
+
+  async start(): Promise<void> {
+    const logger = getLogger();
+    const {
+      checkFrequency,
+      coingeckoApiKey,
+      explorerApiUrl,
+      explorerQueryLimit,
+      inventoryAddress,
+      concurrency,
+      skipSharedBalanceRouteIds,
+    } = this.config;
+
+    startMetricsServer(metricsRegister);
+    logger.info(
+      { port: process.env['PROMETHEUS_PORT'] ?? '9090' },
+      'Metrics server started',
+    );
+
+    const shared = await buildSharedContext(this.registry, coingeckoApiKey);
+
+    const warpRouteIds = await this.resolveRouteIds();
+    logger.info(
+      { routeCount: warpRouteIds.length, concurrency },
+      'Resolved warp routes to monitor',
+    );
+
+    const runtimes = await this.buildRuntimes(
+      shared,
+      warpRouteIds,
+      explorerApiUrl,
+      explorerQueryLimit,
+      inventoryAddress,
+      skipSharedBalanceRouteIds,
+    );
+
+    if (runtimes.length === 0) {
+      throw new Error(
+        'No warp route runtimes could be built; nothing to monitor',
+      );
+    }
+
+    logger.info(
+      {
+        requested: warpRouteIds.length,
+        built: runtimes.length,
+        skipped: warpRouteIds.length - runtimes.length,
+        checkFrequency,
+      },
+      'Starting centralized warp route monitor',
+    );
+
+    for (;;) {
+      const cycleStart = Date.now();
+      // Reset per-cycle gauges once before running any route so that stale
+      // label sets are cleared without wiping other routes mid-cycle.
+      resetCycleMetrics();
+
+      await this.runCycle(shared, runtimes, concurrency);
+
+      logger.info(
+        { durationMs: Date.now() - cycleStart, routeCount: runtimes.length },
+        'Completed warp route monitor cycle',
+      );
+      await sleep(checkFrequency);
+    }
+  }
+
+  private async resolveRouteIds(): Promise<string[]> {
+    if (this.config.warpRouteIds && this.config.warpRouteIds.length > 0) {
+      return [...this.config.warpRouteIds];
+    }
+    const warpRoutes = await this.registry.getWarpRoutes();
+    return Object.keys(warpRoutes).sort();
+  }
+
+  private async buildRuntimes(
+    shared: WarpMonitorSharedContext,
+    warpRouteIds: string[],
+    explorerApiUrl: string | undefined,
+    explorerQueryLimit: number | undefined,
+    inventoryAddress: string | undefined,
+    skipSharedBalanceRouteIds: Set<string> | undefined,
+  ): Promise<WarpRouteRuntime[]> {
+    const logger = getLogger();
+    const runtimes: WarpRouteRuntime[] = [];
+
+    for (const warpRouteId of warpRouteIds) {
+      try {
+        const runtime = await buildRouteRuntime(this.registry, shared, {
+          warpRouteId,
+          explorerApiUrl,
+          explorerQueryLimit,
+          inventoryAddress,
+          skipSharedBalanceMetrics:
+            skipSharedBalanceRouteIds?.has(warpRouteId) ?? false,
+        });
+        runtimes.push(runtime);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          { warpRouteId, error: message },
+          'Failed to build runtime for warp route; skipping',
+        );
+      }
+    }
+
+    return runtimes;
+  }
+
+  private async runCycle(
+    shared: WarpMonitorSharedContext,
+    runtimes: WarpRouteRuntime[],
+    concurrency: number,
+  ): Promise<void> {
+    const logger = getLogger();
+    const queue = [...runtimes];
+
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        const runtime = queue.shift();
+        if (!runtime) return;
+        await tryFn(
+          async () => runRouteCycle(shared, runtime),
+          `Updating metrics for warp route ${runtime.warpRouteId}`,
+          logger,
+        );
+      }
+    };
+
+    const workerCount = Math.max(1, Math.min(concurrency, runtimes.length));
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => worker()),
+    );
+  }
+}

--- a/typescript/warp-monitor/src/service.ts
+++ b/typescript/warp-monitor/src/service.ts
@@ -6,8 +6,19 @@
  * in Kubernetes or other container environments. It reads configuration from
  * environment variables, then starts the monitor in daemon mode.
  *
+ * Modes:
+ * - Single-route (legacy): set WARP_ROUTE_ID to monitor one route per process.
+ * - Centralized (multi-route): set WARP_ROUTE_IDS (comma-separated) or
+ *   WARP_ROUTE_ALL=true to monitor many routes from one process.
+ *
  * Environment Variables:
- * - WARP_ROUTE_ID: The warp route ID to monitor (required)
+ * - WARP_ROUTE_ID: Single route ID to monitor (single-route mode).
+ * - WARP_ROUTE_IDS: Comma-separated route IDs to monitor (centralized mode).
+ * - WARP_ROUTE_ALL: When "true", monitor every route in the registry (centralized mode).
+ * - WARP_MONITOR_CONCURRENCY: Max routes processed concurrently per cycle (centralized mode, default: 10)
+ * - SKIP_SHARED_BALANCE_WARP_ROUTE_IDS: Comma-separated route IDs whose shared
+ *     balance metrics are owned by another workload (e.g. a rebalancer) and
+ *     should not be re-emitted (centralized mode, optional).
  * - CHECK_FREQUENCY: Balance check frequency in ms (default: 30000)
  * - COINGECKO_API_KEY: API key for CoinGecko price fetching (optional)
  * - LOG_LEVEL: Logging level (default: "info") - supported by pino
@@ -20,65 +31,79 @@
  * Usage:
  *   node dist/service.js
  *   WARP_ROUTE_ID=ETH/ethereum-base COINGECKO_API_KEY=... node dist/service.js
+ *   WARP_ROUTE_ALL=true node dist/service.js
+ *   WARP_ROUTE_IDS=ETH/ethereum-base,USDC/eni node dist/service.js
  */
 import { DEFAULT_GITHUB_REGISTRY } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
-import { rootLogger } from '@hyperlane-xyz/utils';
+import { assert, rootLogger } from '@hyperlane-xyz/utils';
 
 import { WarpMonitor } from './monitor.js';
+import { MultiWarpMonitor } from './multi-monitor.js';
 import { initializeLogger } from './utils.js';
+
+function parseCsvEnv(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function parsePositiveIntEnv(
+  name: string,
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    rootLogger.error(`${name} must be a positive integer`);
+    process.exit(1);
+  }
+  return parsed;
+}
 
 async function main(): Promise<void> {
   const VERSION = process.env.SERVICE_VERSION ?? 'dev';
 
-  // Validate required environment variables
   const warpRouteId = process.env.WARP_ROUTE_ID;
-  if (!warpRouteId) {
-    rootLogger.error('WARP_ROUTE_ID environment variable is required');
+  const explicitRouteIds = parseCsvEnv(process.env.WARP_ROUTE_IDS);
+  const monitorAllRoutes = process.env.WARP_ROUTE_ALL === 'true';
+  const isCentralized = monitorAllRoutes || explicitRouteIds.length > 0;
+
+  if (!isCentralized && !warpRouteId) {
+    rootLogger.error(
+      'One of WARP_ROUTE_ID, WARP_ROUTE_IDS, or WARP_ROUTE_ALL=true is required',
+    );
     process.exit(1);
   }
 
-  // Parse optional environment variables
-  let checkFrequency = 30_000;
-  if (process.env.CHECK_FREQUENCY) {
-    const parsed = parseInt(process.env.CHECK_FREQUENCY, 10);
-    if (isNaN(parsed) || parsed <= 0) {
-      rootLogger.error(
-        'CHECK_FREQUENCY must be a positive number (milliseconds)',
-      );
-      process.exit(1);
-    }
-    checkFrequency = parsed;
-  }
+  const checkFrequency = parsePositiveIntEnv(
+    'CHECK_FREQUENCY',
+    process.env.CHECK_FREQUENCY,
+    30_000,
+  );
+  const explorerQueryLimit = parsePositiveIntEnv(
+    'EXPLORER_QUERY_LIMIT',
+    process.env.EXPLORER_QUERY_LIMIT,
+    200,
+  );
+  const concurrency = parsePositiveIntEnv(
+    'WARP_MONITOR_CONCURRENCY',
+    process.env.WARP_MONITOR_CONCURRENCY,
+    10,
+  );
 
   const coingeckoApiKey = process.env.COINGECKO_API_KEY;
   const explorerApiUrl = process.env.EXPLORER_API_URL;
   const inventoryAddress = process.env.INVENTORY_ADDRESS;
-
-  let explorerQueryLimit = 200;
-  if (process.env.EXPLORER_QUERY_LIMIT) {
-    const parsed = Number(process.env.EXPLORER_QUERY_LIMIT);
-    if (!Number.isInteger(parsed) || parsed <= 0) {
-      rootLogger.error('EXPLORER_QUERY_LIMIT must be a positive integer');
-      process.exit(1);
-    }
-    explorerQueryLimit = parsed;
-  }
+  const skipSharedBalanceRouteIds = new Set(
+    parseCsvEnv(process.env.SKIP_SHARED_BALANCE_WARP_ROUTE_IDS),
+  );
 
   // Create logger (uses LOG_LEVEL environment variable for level configuration)
   const logger = await initializeLogger('warp-balance-monitor', VERSION);
-
-  logger.info(
-    {
-      version: VERSION,
-      warpRouteId,
-      checkFrequency,
-      explorerApiUrl,
-      explorerQueryLimit,
-      inventoryAddress,
-    },
-    'Starting Hyperlane Warp Balance Monitor Service',
-  );
 
   try {
     // Initialize registry (uses env var or defaults to GitHub registry)
@@ -90,6 +115,54 @@ async function main(): Promise<void> {
       logger: rootLogger,
     });
     logger.info({ registryUri }, 'Initialized registry');
+
+    if (isCentralized) {
+      logger.info(
+        {
+          version: VERSION,
+          mode: 'centralized',
+          monitorAllRoutes,
+          explicitRouteCount: explicitRouteIds.length,
+          concurrency,
+          skipSharedBalanceRouteCount: skipSharedBalanceRouteIds.size,
+          checkFrequency,
+        },
+        'Starting Hyperlane Warp Balance Monitor Service (centralized)',
+      );
+
+      const monitor = new MultiWarpMonitor(
+        {
+          warpRouteIds: monitorAllRoutes ? undefined : explicitRouteIds,
+          checkFrequency,
+          coingeckoApiKey,
+          registryUri,
+          explorerApiUrl,
+          explorerQueryLimit,
+          inventoryAddress,
+          concurrency,
+          skipSharedBalanceRouteIds,
+        },
+        registry,
+      );
+
+      await monitor.start();
+      return;
+    }
+
+    logger.info(
+      {
+        version: VERSION,
+        mode: 'single',
+        warpRouteId,
+        checkFrequency,
+        explorerApiUrl,
+        explorerQueryLimit,
+        inventoryAddress,
+      },
+      'Starting Hyperlane Warp Balance Monitor Service',
+    );
+
+    assert(warpRouteId, 'WARP_ROUTE_ID is required in single-route mode');
 
     // Create and start the monitor
     const monitor = new WarpMonitor(


### PR DESCRIPTION
## Summary

Introduces a centralized multi-route warp monitor that replaces the per-route StatefulSet fleet (~212 pods in mainnet3) with a single long-running process. Motivated by the consolidation spike: giving each BestEffort StatefulSet the #9145 memory requests would reserve ~106Gi cluster-wide and force autoscaler scale-up. A single right-sized pod avoids that while preserving the Prometheus scrape model (no Pushgateway, no ghost series).

**App-only PR.** Follow-up PRs will add the single-Deployment Helm chart (sharded replicas), verify per-route Grafana metric parity, then tear down the StatefulSets.

### Changes
- `monitor.ts` — split the single-route `WarpMonitor` into reusable exported pieces (`buildSharedContext`, `buildRouteRuntime`, `runRouteCycle`, `resetCycleMetrics`) shared by both monitors. One `MultiProtocolProvider` + price getter shared across routes. Per-cycle gauge resets moved to cycle level so stale label sets clear without wiping other routes mid-cycle. Added a `skipSharedBalanceMetrics` gate.
- `multi-monitor.ts` (new) — `MultiWarpMonitor`: one metrics server, one shared context, bounded-concurrency worker pool with per-route `tryFn` isolation so one bad RPC can't stall the cycle. Routes resolved from an explicit list or the full registry.
- `service.ts` — new env vars `WARP_ROUTE_IDS`, `WARP_ROUTE_ALL`, `WARP_MONITOR_CONCURRENCY`, `SKIP_SHARED_BALANCE_WARP_ROUTE_IDS`; centralized-vs-single branch. Single-route path preserved.

### Dedup
Rebalancers and the monitor both emit the shared balance series (`token_balance`, `collateral_value`, `value_at_risk`), but rebalancers do NOT emit the monitor-only series (`pending_destination_*`, `projected_deficit`, `inventory_balance`). So `skipSharedBalanceMetrics` lets the monitor drop the double-emitted shared series for rebalancer-owned routes while still computing the monitor-only metrics.

## Test plan
- [x] `pnpm -C typescript/warp-monitor build` (tsc clean)
- [x] `pnpm -C typescript/warp-monitor test` (34 passing)
- [x] `oxlint -c oxlint.json` clean on changed files
- [x] Local parity — `ETH/coti-ethereum` single vs centralized: identical 12-series set and identical values
- [x] Dedup — route in `SKIP_SHARED_BALANCE_WARP_ROUTE_IDS`: 0 shared-balance series, 7 monitor-only series retained
- [x] Multi-route + concurrency — 2 routes @ concurrency=2: both routes emitted full 12 series each

🤖 Generated with [Claude Code](https://claude.com/claude-code)