### PR TITLE
chore(infra): spin down agents for deprecated testnet chains

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -48,13 +48,13 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     basesepolia: true,
     bsctestnet: true,
     celestiatestnet: false,
-    celosepolia: true,
-    cotitestnet: true,
+    celosepolia: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
     kyvetestnet: false,
-    modetestnet: true,
+    modetestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
     optimismsepolia: true,
     paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
@@ -74,13 +74,13 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     basesepolia: true,
     bsctestnet: true,
     celestiatestnet: false,
-    celosepolia: true,
-    cotitestnet: true,
+    celosepolia: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
     kyvetestnet: false,
-    modetestnet: true,
+    modetestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
     optimismsepolia: true,
     paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
@@ -100,13 +100,13 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     basesepolia: true,
     bsctestnet: true,
     celestiatestnet: false,
-    celosepolia: true,
-    cotitestnet: true,
+    celosepolia: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
     kyvetestnet: false,
-    modetestnet: true,
+    modetestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
     optimismsepolia: true,
     paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -48,13 +48,13 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     basesepolia: true,
     bsctestnet: true,
     celestiatestnet: false,
-    celosepolia: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
-    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    celosepolia: false, // disabled — deprecated dead testnet, no traffic (2026-07)
+    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
     kyvetestnet: false,
-    modetestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    modetestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     optimismsepolia: true,
     paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
@@ -74,13 +74,13 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     basesepolia: true,
     bsctestnet: true,
     celestiatestnet: false,
-    celosepolia: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
-    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    celosepolia: false, // disabled — deprecated dead testnet, no traffic (2026-07)
+    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
     kyvetestnet: false,
-    modetestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    modetestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     optimismsepolia: true,
     paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,
@@ -100,13 +100,13 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     basesepolia: true,
     bsctestnet: true,
     celestiatestnet: false,
-    celosepolia: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
-    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    celosepolia: false, // disabled — deprecated dead testnet, no traffic (2026-07)
+    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
     kyvetestnet: false,
-    modetestnet: false, // disabled — deprecated dead testnet, no traffic (per Nam 2026-07)
+    modetestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     optimismsepolia: true,
     paradexsepolia: false, // disabled — Paradex Sepolia testnet reset; sole RPC 503, block sync frozen at 921055 (~27d)
     polygonamoy: true,


### PR DESCRIPTION
## Summary
- Disable relayer/validator/scraper for `celosepolia`, `cotitestnet`, and `modetestnet` in testnet4 — deprecated dead testnets with no message traffic.
- `kyvetestnet`, `radixtestnet`, `sonicsvmtestnet` were already disabled (no change needed).
- Chains remain defined as config keys (set `false`), so validation still passes; no agent-config JSON regen needed (that JSON is built from `environmentChainNames`, not the per-role flags).

Requested by Nam to reduce the number of live testnets. Distinct from the validator rotation / 3-validator→1 drop (fuji/bsctestnet/sepolia), which Troy owns and will do once the validator GCP migration PR lands.

## Test plan
- [ ] Config lint/typecheck passes (pre-commit hooks green)
- [ ] Confirm agents for these 3 chains stop deploying after next testnet4 agent deploy