### PR TITLE
chore(infra): exclude USDCSTAGE staging ata-payer from solana balance alerts

### DIFF
--- a/typescript/infra/src/config/funding/alert-query-templates.ts
+++ b/typescript/infra/src/config/funding/alert-query-templates.ts
@@ -15,7 +15,7 @@ export const LOW_URGENCY_KEY_FUNDER_FOOTER = `    # Mainnets that don't use key-
 
     # Solana
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 27 or
-    # Any ATA payer on Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, per Nam 2026-07-31)
+    # Any ATA payer on Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, excluded 2026-07-31 for PD Q1VFMA8E9P5OEO)
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", wallet_name!~"USDCSTAGE/.*", chain=~"solanamainnet"}[1d]) - 0.2 or
     # USDC/eclipsemainnet
     last_over_time(hyperlane_wallet_balance{wallet_name=~"USDC/eclipsemainnet/ata-payer", chain=~"solanamainnet"}[1d]) - 0.8 or
@@ -49,7 +49,7 @@ export const LOW_URGENCY_ENG_KEY_FUNDER_FOOTER = `    # Mainnets that don't use 
 
     # Solana
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 13.5 or
-    # Any ATA payer on Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, per Nam 2026-07-31)
+    # Any ATA payer on Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, excluded 2026-07-31 for PD Q1VFMA8E9P5OEO)
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", wallet_name!~"USDCSTAGE/.*", chain=~"solanamainnet"}[1d]) - 0.1 or
     # Any ATA payer on Solana
     last_over_time(hyperlane_wallet_balance{wallet_name=~"USDC/eclipsemainnet/ata-payer", chain=~"solanamainnet"}[1d]) - 0.4 or
@@ -79,7 +79,7 @@ export const HIGH_URGENCY_RELAYER_FOOTER = `    # Special contexts already have 
     # Eclipse
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"eclipsemainnet"}[1d]) - 0.001 or
 
-    # Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, per Nam 2026-07-31)
+    # Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, excluded 2026-07-31 for PD Q1VFMA8E9P5OEO)
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", wallet_name!~"USDCSTAGE/.*", chain=~"solanamainnet"}[1d]) - 0.1 or
 
     # SOON

--- a/typescript/infra/src/config/funding/alert-query-templates.ts
+++ b/typescript/infra/src/config/funding/alert-query-templates.ts
@@ -15,8 +15,8 @@ export const LOW_URGENCY_KEY_FUNDER_FOOTER = `    # Mainnets that don't use key-
 
     # Solana
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 27 or
-    # Any ATA payer on Solana
-    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"solanamainnet"}[1d]) - 0.2 or
+    # Any ATA payer on Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, per Nam 2026-07-31)
+    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", wallet_name!~"USDCSTAGE/.*", chain=~"solanamainnet"}[1d]) - 0.2 or
     # USDC/eclipsemainnet
     last_over_time(hyperlane_wallet_balance{wallet_name=~"USDC/eclipsemainnet/ata-payer", chain=~"solanamainnet"}[1d]) - 0.8 or
     # TIA/celestia-solanamainnet
@@ -49,8 +49,8 @@ export const LOW_URGENCY_ENG_KEY_FUNDER_FOOTER = `    # Mainnets that don't use 
 
     # Solana
     last_over_time(hyperlane_wallet_balance{wallet_name="relayer", hyperlane_context="hyperlane", chain=~"solanamainnet"}[1d]) - 13.5 or
-    # Any ATA payer on Solana
-    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"solanamainnet"}[1d]) - 0.1 or
+    # Any ATA payer on Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, per Nam 2026-07-31)
+    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", wallet_name!~"USDCSTAGE/.*", chain=~"solanamainnet"}[1d]) - 0.1 or
     # Any ATA payer on Solana
     last_over_time(hyperlane_wallet_balance{wallet_name=~"USDC/eclipsemainnet/ata-payer", chain=~"solanamainnet"}[1d]) - 0.4 or
 
@@ -79,8 +79,8 @@ export const HIGH_URGENCY_RELAYER_FOOTER = `    # Special contexts already have 
     # Eclipse
     last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"eclipsemainnet"}[1d]) - 0.001 or
 
-    # Solana
-    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", chain=~"solanamainnet"}[1d]) - 0.1 or
+    # Solana (exclude USDCSTAGE staging route ata-payer — idle staging, not important, per Nam 2026-07-31)
+    last_over_time(hyperlane_wallet_balance{wallet_name=~".*/ata-payer", wallet_name!~"USDCSTAGE/.*", chain=~"solanamainnet"}[1d]) - 0.1 or
 
     # SOON
     # Any ATA payer on SOON


### PR DESCRIPTION
## Summary
- Stops the recurring Solana ATA-payer low-balance PagerDuty pages for the **USDCSTAGE** (`USD Coin STAGE`) staging warp route, which is an idle staging deployment with no production delivery impact.
- Adds a `wallet_name!~"USDCSTAGE/.*"` negative matcher to the broad `.*/ata-payer` solanamainnet subquery in all three balance-alert tiers (`highUrgencyRelayerBalance`, `lowUrgencyKeyFunderBalance`, `lowUrgencyEngKeyFunderBalance`) so it doesn't just re-page at a lower threshold.

## Context
Triggered by PD Q1VFMA8E9P5OEO (high-urgency, `beb9c2jwhacqoe`): ata-payer `6WFaFuHKo8WNvBPmgWbcze7YRahohWBjmtsspEESRvWT` held 0.01 SOL vs the 0.1 SOL floor. Wallet is idle (6 lifetime txns). Per Nam (2026-07-31), staging routes aren't important and should not page.

There is no per-warp-route no-alert list for the funding alerts (only `ADDITIONAL_NO_ALERT_CHAINS`, which removes a whole chain — wrong here, solanamainnet has real production wallets), so the surgical fix is a negative `wallet_name` matcher, mirroring the existing per-wallet special-casing in this template file.

## Deploy note
The live Grafana rule only changes once someone runs `pnpm -C typescript/infra tsx scripts/funding/write-alert.ts` (port-forwards Prometheus + hits the Grafana API — needs cluster access). Until then the alert keeps firing; silence via the Grafana Silence URL in the PD payload if needed in the meantime.

## Test plan
- [ ] Confirm regenerated PromQL for the three rules includes `wallet_name!~"USDCSTAGE/.*"` on the solanamainnet ata-payer line after running write-alert (dry run).
- [ ] Confirm no other solanamainnet ata-payer (production routes) is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)