### PR TITLE
chore(sdk): rotate Merkly out of hyperevm default_ism, move to 2-of-3

### DIFF
--- a/.changeset/rotate-merkly-out-of-hyperevm-default-ism.md
+++ b/.changeset/rotate-merkly-out-of-hyperevm-default-ism.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Rotated the stalled Merkly validator out of the hyperevm `default_ism` set and reconfigured it to 2-of-3 (AW / Mitosis / Luganodes).

--- a/typescript/sdk/src/consts/multisigIsm.ts
+++ b/typescript/sdk/src/consts/multisigIsm.ts
@@ -737,13 +737,12 @@ export const defaultMultisigConfigs: ChainMap<MultisigConfig> = {
   },
 
   hyperevm: {
-    threshold: 3,
+    threshold: 2,
     validators: [
       {
         address: '0x01be14a9eceeca36c9c1d46c056ca8c87f77c26f',
         alias: AW_VALIDATOR_ALIAS,
       },
-      DEFAULT_MERKLY_VALIDATOR,
       DEFAULT_MITOSIS_VALIDATOR,
       {
         address: '0x04d949c615c9976f89595ddcb9008c92f8ba7278',


### PR DESCRIPTION
## Summary

Rotates the stalled Merkly validator (`0xcf0211fafbb91fd9d06d7e306b30032dc3a1934f`) out of the hyperevm `default_ism` set and reconfigures it to **2-of-3** (AW / Mitosis / Luganodes).

## Context

Full context in Linear: [ENG-4332](https://linear.app/hyperlane-xyz/issue/ENG-4332/rotate-merkly-out-of-hyperevm-default-ism-move-to-2-of-3)

- Merkly's hyperevm validator has been stalled for ~48h. S3 ground truth: `checkpoint_latest_index.json` = **19280**, unchanged since 2026-07-28 16:19:59 UTC, while on-chain merkleTreeHook `count()\) advanced 19312 → ~19465.
- The previous 3-of-4 set still met quorum via the 3 live validators, so delivery was not blocked — but there was **zero redundancy**: one more validator stalling would halt all hyperevm-origin message delivery.
- Value at risk secured by this set ≈ **$29.9k** (collateral backing hyperevm synthetics inheriting the default ISM).

## Change

`typescript/sdk/src/consts/multisigIsm.ts` — hyperevm entry:
- threshold: 3 → 2
- validators: removed `DEFAULT_MERKLY_VALIDATOR`; remaining set is AW (`0x01be14a9...`), Mitosis (`0x4f977a59...`), Luganodes (`0x04d949c6...`)

Generated JSON/YAML artifacts intentionally not updated in this PR.