### PR TITLE
fix(validator): restrict quorum RPCs to merkle tree root reads only

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -138,8 +138,9 @@ impl ValidatorSubmitter {
             if (observed_count as usize) <= tree.count() {
                 // Count alone cannot prove the root is unchanged: a reorg may replace a
                 // leaf while leaving the count the same. Compare against the base hook
-                // checkpoint first, and only run the quorum-verified read when the base
-                // hook reports an equal-index root conflict.
+                // checkpoint first. Use the base-only fast path only when it exactly
+                // matches the local tree; otherwise verify the checkpoint through the
+                // quorum hook before signing or reporting a reorg.
                 let base_checkpoint = call_and_retry_indefinitely(|| {
                     let merkle_tree_hook = self.base_merkle_tree_hook.clone();
                     let reorg_period = self.reorg_period.clone();
@@ -157,9 +158,11 @@ impl ValidatorSubmitter {
                     continue;
                 }
 
-                let correctness_checkpoint = if base_checkpoint.index == tree.index()
-                    && base_checkpoint.root != tree.root()
-                {
+                let base_checkpoint_matches_tree =
+                    base_checkpoint.index == tree.index() && base_checkpoint.root == tree.root();
+                let correctness_checkpoint = if base_checkpoint_matches_tree {
+                    base_checkpoint
+                } else {
                     call_and_retry_indefinitely(|| {
                         let merkle_tree_hook = self.merkle_tree_hook.clone();
                         let reorg_period = self.reorg_period.clone();
@@ -168,8 +171,6 @@ impl ValidatorSubmitter {
                         )
                     })
                     .await
-                } else {
-                    base_checkpoint
                 };
 
                 if tree_exceeds_checkpoint(&correctness_checkpoint, &tree) {

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -121,6 +121,45 @@ impl ValidatorSubmitter {
         };
 
         loop {
+            // Cheap, base-hook-only (private RPC) tip check. `latest_checkpoint()` may be
+            // quorum-verified (fanning out to public RPCs, see
+            // `ValidatorMultiRpcQuorumMerkleTreeHook`); only call it when this indicates
+            // there's actually a new leaf to catch up to, so idle chains stop polling public
+            // RPCs once caught up instead of doing so every `interval` regardless of message
+            // throughput.
+            let observed_count = call_and_retry_indefinitely(|| {
+                let merkle_tree_hook = self.merkle_tree_hook.clone();
+                let reorg_period = self.reorg_period.clone();
+                Box::pin(async move { merkle_tree_hook.count(&reorg_period).await })
+            })
+            .await;
+
+            if (observed_count as usize) <= tree.count() {
+                // Nothing new since we last caught up: `tree` already reflects the fully
+                // processed state, so report it directly instead of running an unnecessary
+                // quorum-verified round.
+                let observed_checkpoint = CheckpointAtBlock {
+                    checkpoint: self.checkpoint(&tree),
+                    block_height: None,
+                };
+                self.metrics
+                    .set_latest_checkpoint_observed(&observed_checkpoint);
+                if should_log_checkpoint_info() {
+                    info!(
+                        latest_checkpoint = ?observed_checkpoint,
+                        tree_count = tree.count(),
+                        "Latest checkpoint (no new messages)"
+                    );
+                }
+                self.metrics
+                    .latest_checkpoint_processed
+                    .set(observed_checkpoint.index as i64);
+                self.metrics.reached_initial_consistency.set(1);
+
+                sleep(self.interval).await;
+                continue;
+            }
+
             // Lag by reorg period because this is our correctness checkpoint.
             let latest_checkpoint = call_and_retry_indefinitely(|| {
                 let merkle_tree_hook = self.merkle_tree_hook.clone();

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -32,6 +32,7 @@ pub(crate) struct ValidatorSubmitter {
     singleton_signer: SingletonSignerHandle,
     signer: Signers,
     merkle_tree_hook: Arc<dyn MerkleTreeHook>,
+    base_merkle_tree_hook: Arc<dyn MerkleTreeHook>,
     checkpoint_syncer: Arc<dyn CheckpointSyncer>,
     db: Arc<dyn HyperlaneDb>,
     metrics: ValidatorSubmitterMetrics,
@@ -45,6 +46,7 @@ impl ValidatorSubmitter {
         interval: Duration,
         reorg_period: ReorgPeriod,
         merkle_tree_hook: Arc<dyn MerkleTreeHook>,
+        base_merkle_tree_hook: Arc<dyn MerkleTreeHook>,
         singleton_signer: SingletonSignerHandle,
         signer: Signers,
         checkpoint_syncer: Arc<dyn CheckpointSyncer>,
@@ -57,6 +59,7 @@ impl ValidatorSubmitter {
             reorg_period,
             interval,
             merkle_tree_hook,
+            base_merkle_tree_hook,
             singleton_signer,
             signer,
             checkpoint_syncer,
@@ -121,39 +124,55 @@ impl ValidatorSubmitter {
         };
 
         loop {
-            // Cheap, base-hook-only (private RPC) tip check. `latest_checkpoint()` may be
-            // quorum-verified (fanning out to public RPCs, see
+            // Cheap, base-hook-only (private RPC) tip check. The quorum-verified
+            // `merkle_tree_hook.latest_checkpoint()` may fan out to public RPCs (see
             // `ValidatorMultiRpcQuorumMerkleTreeHook`); only call it when this indicates
-            // there's actually a new leaf to catch up to, so idle chains stop polling public
-            // RPCs once caught up instead of doing so every `interval` regardless of message
-            // throughput.
+            // there's actually a new leaf to catch up to.
             let observed_count = call_and_retry_indefinitely(|| {
-                let merkle_tree_hook = self.merkle_tree_hook.clone();
+                let merkle_tree_hook = self.base_merkle_tree_hook.clone();
                 let reorg_period = self.reorg_period.clone();
                 Box::pin(async move { merkle_tree_hook.count(&reorg_period).await })
             })
             .await;
 
             if (observed_count as usize) <= tree.count() {
-                // Nothing new since we last caught up: `tree` already reflects the fully
-                // processed state, so report it directly instead of running an unnecessary
-                // quorum-verified round.
-                let observed_checkpoint = CheckpointAtBlock {
-                    checkpoint: self.checkpoint(&tree),
-                    block_height: None,
-                };
+                // Count alone cannot prove the root is unchanged: a reorg may replace a
+                // leaf while leaving the count the same. Compare against the base hook
+                // checkpoint so same-index root mismatches still hit the reorg path below
+                // without running an unnecessary quorum-verified round.
+                let latest_checkpoint = call_and_retry_indefinitely(|| {
+                    let merkle_tree_hook = self.base_merkle_tree_hook.clone();
+                    let reorg_period = self.reorg_period.clone();
+                    Box::pin(async move { merkle_tree_hook.latest_checkpoint(&reorg_period).await })
+                })
+                .await;
+
                 self.metrics
-                    .set_latest_checkpoint_observed(&observed_checkpoint);
+                    .set_latest_checkpoint_observed(&latest_checkpoint);
                 if should_log_checkpoint_info() {
                     info!(
-                        latest_checkpoint = ?observed_checkpoint,
+                        ?latest_checkpoint,
                         tree_count = tree.count(),
                         "Latest checkpoint (no new messages)"
                     );
                 }
+
+                if tree_exceeds_checkpoint(&latest_checkpoint, &tree) {
+                    debug!(
+                        ?latest_checkpoint,
+                        tree_count = tree.count(),
+                        "Latest checkpoint is behind tree, sleeping briefly"
+                    );
+                    sleep(self.interval).await;
+                    continue;
+                }
+
+                self.submit_checkpoints_until_correctness_checkpoint(&mut tree, &latest_checkpoint)
+                    .await;
+
                 self.metrics
                     .latest_checkpoint_processed
-                    .set(observed_checkpoint.index as i64);
+                    .set(latest_checkpoint.index as i64);
                 self.metrics.reached_initial_consistency.set(1);
 
                 sleep(self.interval).await;

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -138,28 +138,18 @@ impl ValidatorSubmitter {
             if (observed_count as usize) <= tree.count() {
                 // Count alone cannot prove the root is unchanged: a reorg may replace a
                 // leaf while leaving the count the same. Compare against the base hook
-                // checkpoint so same-index root mismatches still hit the reorg path below
-                // without running an unnecessary quorum-verified round.
-                let latest_checkpoint = call_and_retry_indefinitely(|| {
+                // checkpoint first, and only run the quorum-verified read when the base
+                // hook reports an equal-index root conflict.
+                let base_checkpoint = call_and_retry_indefinitely(|| {
                     let merkle_tree_hook = self.base_merkle_tree_hook.clone();
                     let reorg_period = self.reorg_period.clone();
                     Box::pin(async move { merkle_tree_hook.latest_checkpoint(&reorg_period).await })
                 })
                 .await;
 
-                self.metrics
-                    .set_latest_checkpoint_observed(&latest_checkpoint);
-                if should_log_checkpoint_info() {
-                    info!(
-                        ?latest_checkpoint,
-                        tree_count = tree.count(),
-                        "Latest checkpoint (no new messages)"
-                    );
-                }
-
-                if tree_exceeds_checkpoint(&latest_checkpoint, &tree) {
+                if tree_exceeds_checkpoint(&base_checkpoint, &tree) {
                     debug!(
-                        ?latest_checkpoint,
+                        ?base_checkpoint,
                         tree_count = tree.count(),
                         "Latest checkpoint is behind tree, sleeping briefly"
                     );
@@ -167,12 +157,50 @@ impl ValidatorSubmitter {
                     continue;
                 }
 
-                self.submit_checkpoints_until_correctness_checkpoint(&mut tree, &latest_checkpoint)
-                    .await;
+                let correctness_checkpoint = if base_checkpoint.index == tree.index()
+                    && base_checkpoint.root != tree.root()
+                {
+                    call_and_retry_indefinitely(|| {
+                        let merkle_tree_hook = self.merkle_tree_hook.clone();
+                        let reorg_period = self.reorg_period.clone();
+                        Box::pin(
+                            async move { merkle_tree_hook.latest_checkpoint(&reorg_period).await },
+                        )
+                    })
+                    .await
+                } else {
+                    base_checkpoint
+                };
+
+                if tree_exceeds_checkpoint(&correctness_checkpoint, &tree) {
+                    debug!(
+                        ?correctness_checkpoint,
+                        tree_count = tree.count(),
+                        "Latest checkpoint is behind tree, sleeping briefly"
+                    );
+                    sleep(self.interval).await;
+                    continue;
+                }
+
+                self.metrics
+                    .set_latest_checkpoint_observed(&correctness_checkpoint);
+                if should_log_checkpoint_info() {
+                    info!(
+                        ?correctness_checkpoint,
+                        tree_count = tree.count(),
+                        "Latest checkpoint (no new messages)"
+                    );
+                }
+
+                self.submit_checkpoints_until_correctness_checkpoint(
+                    &mut tree,
+                    &correctness_checkpoint,
+                )
+                .await;
 
                 self.metrics
                     .latest_checkpoint_processed
-                    .set(latest_checkpoint.index as i64);
+                    .set(correctness_checkpoint.index as i64);
                 self.metrics.reached_initial_consistency.set(1);
 
                 sleep(self.interval).await;

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -1,4 +1,11 @@
-use std::{fmt::Debug, sync::Arc, time::Duration};
+use std::{
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use eyre::Result;
@@ -270,6 +277,141 @@ async fn all_existing_chunks_skip_inter_chunk_throttle() {
         "all-existing chunks must not wait for the inter-chunk throttle"
     );
     task.await.unwrap();
+}
+
+/// Regression test for the public-RPC load fix: `checkpoint_submitter` must not call the
+/// (potentially quorum-verified, public-RPC-fanning) `latest_checkpoint()` when the cheap,
+/// base-hook-only `count()` shows nothing new since `tree` was last caught up.
+#[tokio::test(start_paused = true)]
+async fn checkpoint_submitter_skips_latest_checkpoint_without_new_messages() {
+    let mut tree = IncrementalMerkle::default();
+    tree.ingest(H256::from_low_u64_be(1));
+    tree.ingest(H256::from_low_u64_be(2));
+    tree.ingest(H256::from_low_u64_be(3));
+    let tree_count = tree.count() as u32;
+
+    let count_calls = Arc::new(AtomicBool::new(false));
+    let count_calls_clone = count_calls.clone();
+
+    let mut mock_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_merkle_tree_hook
+        .expect_address()
+        .returning(|| H256::from_low_u64_be(0));
+    let dummy_domain = dummy_domain(0, "dummy_domain");
+    mock_merkle_tree_hook
+        .expect_domain()
+        .return_const(dummy_domain);
+    mock_merkle_tree_hook.expect_count().returning(move |_| {
+        count_calls_clone.store(true, Ordering::SeqCst);
+        Ok(tree_count)
+    });
+    mock_merkle_tree_hook.expect_latest_checkpoint().never();
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(mock_merkle_tree_hook),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(MockCheckpointSyncer::new()),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter.checkpoint_submitter(tree).await;
+    });
+
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+    }
+    tokio::task::yield_now().await;
+    task.abort();
+    let _ = task.await;
+
+    assert!(
+        count_calls.load(Ordering::SeqCst),
+        "the loop should still poll count() via the private base_hook"
+    );
+    // `expect_latest_checkpoint().never()` above is the real assertion: a panic there would
+    // have failed this test already if it were called.
+}
+
+/// Counterpart to the above: once the cheap `count()` shows a new leaf, `latest_checkpoint()`
+/// (the quorum-verified, public-RPC-fanning read) must still be called to determine what to
+/// sign.
+#[tokio::test(start_paused = true)]
+async fn checkpoint_submitter_fetches_latest_checkpoint_when_new_message_arrives() {
+    let mut tree = IncrementalMerkle::default();
+    tree.ingest(H256::from_low_u64_be(1));
+    tree.ingest(H256::from_low_u64_be(2));
+    let unchanged_tree = tree.clone();
+
+    let latest_checkpoint_called = Arc::new(AtomicBool::new(false));
+    let latest_checkpoint_called_clone = latest_checkpoint_called.clone();
+
+    let mut mock_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_merkle_tree_hook
+        .expect_address()
+        .returning(|| H256::from_low_u64_be(0));
+    let dummy_domain = dummy_domain(0, "dummy_domain");
+    mock_merkle_tree_hook
+        .expect_domain()
+        .return_const(dummy_domain.clone());
+    // One more leaf is available on-chain than what's locally ingested.
+    let observed_count = unchanged_tree.count() as u32 + 1;
+    mock_merkle_tree_hook
+        .expect_count()
+        .returning(move |_| Ok(observed_count));
+    mock_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .returning(move |_| {
+            latest_checkpoint_called_clone.store(true, Ordering::SeqCst);
+            // Reports the checkpoint as already matching the current tree, so the
+            // submitter has nothing further to ingest/sign in this test.
+            Ok(CheckpointAtBlock {
+                checkpoint: Checkpoint {
+                    root: unchanged_tree.root(),
+                    index: unchanged_tree.index(),
+                    merkle_tree_hook_address: H256::from_low_u64_be(0),
+                    mailbox_domain: dummy_domain.id(),
+                },
+                block_height: Some(1),
+            })
+        });
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(mock_merkle_tree_hook),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(MockCheckpointSyncer::new()),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter.checkpoint_submitter(tree).await;
+    });
+
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    task.abort();
+    let _ = task.await;
+
+    assert!(
+        latest_checkpoint_called.load(Ordering::SeqCst),
+        "latest_checkpoint() should be called once count() indicates a new leaf"
+    );
 }
 
 fn reorg_event_is_correct(

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -391,9 +391,6 @@ async fn checkpoint_submitter_detects_reorg_when_count_is_unchanged() {
     mock_quorum_merkle_tree_hook
         .expect_domain()
         .return_const(dummy_domain.clone());
-    mock_quorum_merkle_tree_hook
-        .expect_latest_checkpoint()
-        .never();
 
     let mut mock_base_merkle_tree_hook = MockMerkleTreeHook::new();
     let observed_count = local_tree.count() as u32;
@@ -410,6 +407,11 @@ async fn checkpoint_submitter_detects_reorg_when_count_is_unchanged() {
         },
         block_height: Some(42),
     };
+    let quorum_checkpoint = onchain_checkpoint.clone();
+    mock_quorum_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .once()
+        .returning(move |_| Ok(quorum_checkpoint.clone()));
     mock_base_merkle_tree_hook
         .expect_latest_checkpoint()
         .once()

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -127,6 +127,7 @@ async fn single_checkpoint_chunk_has_no_throttle_tail() {
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(1),
         Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
         dummy_singleton_handle(),
         signer,
         Arc::new(checkpoint_syncer),
@@ -183,6 +184,7 @@ async fn two_written_chunks_have_one_inter_chunk_throttle() {
     let submitter = ValidatorSubmitter::new(
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
         Arc::new(MockMerkleTreeHook::new()),
         dummy_singleton_handle(),
         signer,
@@ -256,6 +258,7 @@ async fn all_existing_chunks_skip_inter_chunk_throttle() {
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(1),
         Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
         dummy_singleton_handle(),
         signer,
         Arc::new(checkpoint_syncer),
@@ -280,8 +283,8 @@ async fn all_existing_chunks_skip_inter_chunk_throttle() {
 }
 
 /// Regression test for the public-RPC load fix: `checkpoint_submitter` must not call the
-/// (potentially quorum-verified, public-RPC-fanning) `latest_checkpoint()` when the cheap,
-/// base-hook-only `count()` shows nothing new since `tree` was last caught up.
+/// quorum-verified, public-RPC-fanning `latest_checkpoint()` when the cheap, base-hook-only
+/// `count()` shows nothing new since `tree` was last caught up.
 #[tokio::test(start_paused = true)]
 async fn checkpoint_submitter_skips_latest_checkpoint_without_new_messages() {
     let mut tree = IncrementalMerkle::default();
@@ -293,25 +296,44 @@ async fn checkpoint_submitter_skips_latest_checkpoint_without_new_messages() {
     let count_calls = Arc::new(AtomicBool::new(false));
     let count_calls_clone = count_calls.clone();
 
-    let mut mock_merkle_tree_hook = MockMerkleTreeHook::new();
-    mock_merkle_tree_hook
+    let mut mock_quorum_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_quorum_merkle_tree_hook
         .expect_address()
         .returning(|| H256::from_low_u64_be(0));
     let dummy_domain = dummy_domain(0, "dummy_domain");
-    mock_merkle_tree_hook
+    mock_quorum_merkle_tree_hook
         .expect_domain()
-        .return_const(dummy_domain);
-    mock_merkle_tree_hook.expect_count().returning(move |_| {
-        count_calls_clone.store(true, Ordering::SeqCst);
-        Ok(tree_count)
-    });
-    mock_merkle_tree_hook.expect_latest_checkpoint().never();
+        .return_const(dummy_domain.clone());
+    mock_quorum_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .never();
+
+    let mut mock_base_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_base_merkle_tree_hook
+        .expect_count()
+        .returning(move |_| {
+            count_calls_clone.store(true, Ordering::SeqCst);
+            Ok(tree_count)
+        });
+    let expected_checkpoint = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: tree.root(),
+            index: tree.index(),
+            merkle_tree_hook_address: H256::from_low_u64_be(0),
+            mailbox_domain: dummy_domain.id(),
+        },
+        block_height: Some(1),
+    };
+    mock_base_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .returning(move |_| Ok(expected_checkpoint.clone()));
 
     let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
     let submitter = ValidatorSubmitter::new(
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(1),
-        Arc::new(mock_merkle_tree_hook),
+        Arc::new(mock_quorum_merkle_tree_hook),
+        Arc::new(mock_base_merkle_tree_hook),
         dummy_singleton_handle(),
         signer,
         Arc::new(MockCheckpointSyncer::new()),
@@ -337,8 +359,113 @@ async fn checkpoint_submitter_skips_latest_checkpoint_without_new_messages() {
         count_calls.load(Ordering::SeqCst),
         "the loop should still poll count() via the private base_hook"
     );
-    // `expect_latest_checkpoint().never()` above is the real assertion: a panic there would
-    // have failed this test already if it were called.
+    // `mock_quorum_merkle_tree_hook.expect_latest_checkpoint().never()` above is the real
+    // assertion: a panic there would have failed this test already if it were called.
+}
+
+/// Regression test for same-index reorg detection: an unchanged count with a changed root
+/// must still go through the normal reorg reporting/panic path.
+#[tokio::test(start_paused = true)]
+async fn checkpoint_submitter_detects_reorg_when_count_is_unchanged() {
+    let expected_reorg_period = 12;
+
+    let mut local_tree = IncrementalMerkle::default();
+    local_tree.ingest(H256::from_low_u64_be(1));
+    local_tree.ingest(H256::from_low_u64_be(2));
+    local_tree.ingest(H256::from_low_u64_be(3));
+
+    let mut onchain_tree = IncrementalMerkle::default();
+    onchain_tree.ingest(H256::from_low_u64_be(1));
+    onchain_tree.ingest(H256::from_low_u64_be(2));
+    onchain_tree.ingest(H256::from_low_u64_be(4));
+
+    assert_eq!(local_tree.count(), onchain_tree.count());
+    assert_ne!(local_tree.root(), onchain_tree.root());
+
+    let dummy_domain = dummy_domain(0, "dummy_domain");
+
+    let mut mock_quorum_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_quorum_merkle_tree_hook
+        .expect_address()
+        .returning(|| H256::from_low_u64_be(0));
+    mock_quorum_merkle_tree_hook
+        .expect_domain()
+        .return_const(dummy_domain.clone());
+    mock_quorum_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .never();
+
+    let mut mock_base_merkle_tree_hook = MockMerkleTreeHook::new();
+    let observed_count = local_tree.count() as u32;
+    mock_base_merkle_tree_hook
+        .expect_count()
+        .once()
+        .returning(move |_| Ok(observed_count));
+    let onchain_checkpoint = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: onchain_tree.root(),
+            index: onchain_tree.index(),
+            merkle_tree_hook_address: H256::from_low_u64_be(0),
+            mailbox_domain: dummy_domain.id(),
+        },
+        block_height: Some(42),
+    };
+    mock_base_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .once()
+        .returning(move |_| Ok(onchain_checkpoint));
+
+    let unix_timestamp = chrono::Utc::now().timestamp() as u64;
+    let mut mock_checkpoint_syncer = MockCheckpointSyncer::new();
+    let expected_local_tree = local_tree.clone();
+    let expected_onchain_tree = onchain_tree.clone();
+    mock_checkpoint_syncer
+        .expect_write_reorg_status()
+        .once()
+        .returning(move |reorg_event| {
+            reorg_event_is_correct(
+                reorg_event,
+                &expected_local_tree,
+                &expected_onchain_tree,
+                unix_timestamp,
+                ReorgPeriod::from_blocks(expected_reorg_period),
+            );
+            Ok(())
+        });
+
+    let mut mock_reorg_reporter = MockReorgReporter::new();
+    mock_reorg_reporter
+        .expect_report_at_block()
+        .with(mockall::predicate::eq(42))
+        .once()
+        .return_once(|_| {});
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(expected_reorg_period),
+        Arc::new(mock_quorum_merkle_tree_hook),
+        Arc::new(mock_base_merkle_tree_hook),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(mock_checkpoint_syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(mock_reorg_reporter),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter.checkpoint_submitter(local_tree).await;
+    });
+    tokio::task::yield_now().await;
+
+    assert!(
+        task.is_finished(),
+        "unchanged-count root mismatch should panic in the first loop"
+    );
+    let result = task.await;
+    assert!(result.unwrap_err().is_panic());
 }
 
 /// Counterpart to the above: once the cheap `count()` shows a new leaf, `latest_checkpoint()`
@@ -354,20 +481,21 @@ async fn checkpoint_submitter_fetches_latest_checkpoint_when_new_message_arrives
     let latest_checkpoint_called = Arc::new(AtomicBool::new(false));
     let latest_checkpoint_called_clone = latest_checkpoint_called.clone();
 
-    let mut mock_merkle_tree_hook = MockMerkleTreeHook::new();
-    mock_merkle_tree_hook
+    let mut mock_quorum_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_quorum_merkle_tree_hook
         .expect_address()
         .returning(|| H256::from_low_u64_be(0));
     let dummy_domain = dummy_domain(0, "dummy_domain");
-    mock_merkle_tree_hook
+    mock_quorum_merkle_tree_hook
         .expect_domain()
         .return_const(dummy_domain.clone());
     // One more leaf is available on-chain than what's locally ingested.
     let observed_count = unchanged_tree.count() as u32 + 1;
-    mock_merkle_tree_hook
+    let mut mock_base_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_base_merkle_tree_hook
         .expect_count()
         .returning(move |_| Ok(observed_count));
-    mock_merkle_tree_hook
+    mock_quorum_merkle_tree_hook
         .expect_latest_checkpoint()
         .returning(move |_| {
             latest_checkpoint_called_clone.store(true, Ordering::SeqCst);
@@ -388,7 +516,8 @@ async fn checkpoint_submitter_fetches_latest_checkpoint_when_new_message_arrives
     let submitter = ValidatorSubmitter::new(
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(1),
-        Arc::new(mock_merkle_tree_hook),
+        Arc::new(mock_quorum_merkle_tree_hook),
+        Arc::new(mock_base_merkle_tree_hook),
         dummy_singleton_handle(),
         signer,
         Arc::new(MockCheckpointSyncer::new()),
@@ -529,6 +658,7 @@ async fn reorg_is_detected_and_persisted_to_checkpoint_storage() {
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(expected_reorg_period),
         Arc::new(mock_merkle_tree_hook),
+        Arc::new(MockMerkleTreeHook::new()),
         dummy_singleton_handle(),
         signer,
         Arc::new(mock_checkpoint_syncer),
@@ -647,6 +777,7 @@ async fn sign_and_submit_checkpoint_same_signature() {
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(expected_reorg_period),
         Arc::new(mock_merkle_tree_hook),
+        Arc::new(MockMerkleTreeHook::new()),
         dummy_singleton_handle(),
         signer,
         Arc::new(mock_checkpoint_syncer),
@@ -766,6 +897,7 @@ async fn sign_and_submit_checkpoint_different_signature() {
         Duration::from_secs(1),
         ReorgPeriod::from_blocks(expected_reorg_period),
         Arc::new(mock_merkle_tree_hook),
+        Arc::new(MockMerkleTreeHook::new()),
         dummy_singleton_handle(),
         signer,
         Arc::new(mock_checkpoint_syncer),

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -363,6 +363,98 @@ async fn checkpoint_submitter_skips_latest_checkpoint_without_new_messages() {
     // assertion: a panic there would have failed this test already if it were called.
 }
 
+/// Regression test for a race where `count()` returns the local count, but a leaf lands
+/// before `base_hook.latest_checkpoint()` resolves. The ahead checkpoint must be
+/// quorum-verified before it can drive signing.
+#[tokio::test(start_paused = true)]
+async fn checkpoint_submitter_quorum_verifies_base_checkpoint_ahead_of_observed_count() {
+    let mut tree = IncrementalMerkle::default();
+    tree.ingest(H256::from_low_u64_be(1));
+    tree.ingest(H256::from_low_u64_be(2));
+    let tree_count = tree.count() as u32;
+
+    let mut ahead_tree = tree.clone();
+    ahead_tree.ingest(H256::from_low_u64_be(3));
+
+    let dummy_domain = dummy_domain(0, "dummy_domain");
+
+    let quorum_latest_checkpoint_called = Arc::new(AtomicBool::new(false));
+    let quorum_latest_checkpoint_called_clone = quorum_latest_checkpoint_called.clone();
+
+    let mut mock_quorum_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_quorum_merkle_tree_hook
+        .expect_address()
+        .returning(|| H256::from_low_u64_be(0));
+    mock_quorum_merkle_tree_hook
+        .expect_domain()
+        .return_const(dummy_domain.clone());
+    let local_checkpoint = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: tree.root(),
+            index: tree.index(),
+            merkle_tree_hook_address: H256::from_low_u64_be(0),
+            mailbox_domain: dummy_domain.id(),
+        },
+        block_height: Some(1),
+    };
+    mock_quorum_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .once()
+        .returning(move |_| {
+            quorum_latest_checkpoint_called_clone.store(true, Ordering::SeqCst);
+            Ok(local_checkpoint.clone())
+        });
+
+    let mut mock_base_merkle_tree_hook = MockMerkleTreeHook::new();
+    mock_base_merkle_tree_hook
+        .expect_count()
+        .once()
+        .returning(move |_| Ok(tree_count));
+    let base_ahead_checkpoint = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: ahead_tree.root(),
+            index: ahead_tree.index(),
+            merkle_tree_hook_address: H256::from_low_u64_be(0),
+            mailbox_domain: dummy_domain.id(),
+        },
+        block_height: Some(2),
+    };
+    mock_base_merkle_tree_hook
+        .expect_latest_checkpoint()
+        .once()
+        .returning(move |_| Ok(base_ahead_checkpoint.clone()));
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(mock_quorum_merkle_tree_hook),
+        Arc::new(mock_base_merkle_tree_hook),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(MockCheckpointSyncer::new()),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter.checkpoint_submitter(tree).await;
+    });
+
+    for _ in 0..5 {
+        tokio::task::yield_now().await;
+    }
+    task.abort();
+    let _ = task.await;
+
+    assert!(
+        quorum_latest_checkpoint_called.load(Ordering::SeqCst),
+        "base checkpoint ahead of observed count must be quorum-verified"
+    );
+}
+
 /// Regression test for same-index reorg detection: an unchanged count with a changed root
 /// must still go through the normal reorg reporting/panic path.
 #[tokio::test(start_paused = true)]
@@ -415,7 +507,7 @@ async fn checkpoint_submitter_detects_reorg_when_count_is_unchanged() {
     mock_base_merkle_tree_hook
         .expect_latest_checkpoint()
         .once()
-        .returning(move |_| Ok(onchain_checkpoint));
+        .return_once(move |_| Ok(onchain_checkpoint));
 
     let unix_timestamp = chrono::Utc::now().timestamp() as u64;
     let mut mock_checkpoint_syncer = MockCheckpointSyncer::new();

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -30,8 +30,8 @@ use hyperlane_base::{
 };
 use hyperlane_core::{
     rpc_clients::{call_and_retry_indefinitely, RPC_RETRY_SLEEP_DURATION},
-    Announcement, ChainCommunicationError, ChainResult, CheckpointAtBlock, HyperlaneChain,
-    HyperlaneContract, HyperlaneDomain, HyperlaneSigner, HyperlaneSignerExt,
+    Announcement, ChainCommunicationError, ChainResult, Checkpoint, CheckpointAtBlock,
+    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneSigner, HyperlaneSignerExt,
     IncrementalMerkleAtBlock, Mailbox, MerkleTreeHook, MerkleTreeInsertion, ReorgPeriod, TxOutcome,
     ValidatorAnnounce, H256, U256,
 };
@@ -59,12 +59,17 @@ const QUORUM_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(20);
 const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 
 /// `count()`/domain/address come from `base_hook` (the normal `rpcUrls` connection, using
-/// whatever consensus mode it's configured with). `tree()`/`latest_checkpoint()`/
-/// `latest_checkpoint_at_block()` require BOTH: a 2/3 majority across `quorum_hooks` (one
-/// entry per `rpcUrls` URL plus one per `additionalQuorumRpcUrls` URL, independent of each
+/// whatever consensus mode it's configured with). `tree()`/`tree_at_block()` — the actual
+/// merkle tree root reads — require BOTH: a 2/3 majority across `quorum_hooks` (one entry
+/// per `rpcUrls` URL plus one per `additionalQuorumRpcUrls` URL, independent of each
 /// other), AND that majority-agreed value to match what `base_hook` independently
 /// returns. An attacker needs to compromise both the merged vote and `rpcUrls`' own
 /// consensus at once to force a wrong value through.
+///
+/// `latest_checkpoint()`/`latest_checkpoint_at_block()` never independently call
+/// `quorum_hooks`: they derive the `Checkpoint` locally (root/index from the tree,
+/// address/domain already known) from a `tree()`/`tree_at_block()` read, so the
+/// public-RPC-inclusive `quorum_hooks` pool is only ever exercised for root reads.
 #[derive(Debug)]
 struct ValidatorMultiRpcQuorumMerkleTreeHook {
     base_hook: Arc<dyn MerkleTreeHook>,
@@ -254,34 +259,76 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
             "{context}: merged quorum consensus disagrees with rpcUrls consensus"
         )))
     }
+
+    /// Fans a height-pinned tree read out to `quorum_hooks`, requiring both a 2/3 majority
+    /// and `base_hook` agreement. Shared by `tree()` (once it resolves a target height) and
+    /// `latest_checkpoint_at_block()`, so there's a single place that ever calls
+    /// `quorum_hooks` for a pinned-height root read.
+    async fn tree_at_block_via_quorum(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
+        let results = join_all(
+            self.quorum_hooks
+                .iter()
+                .cloned()
+                .map(|(label, hook)| async move {
+                    (
+                        label,
+                        Self::with_call_timeout(hook.tree_at_block(height)).await,
+                    )
+                }),
+        )
+        .await;
+        let quorum_result = self.select_quorum_result(
+            results,
+            |a, b| a.tree == b.tree,
+            "Failed to reach quorum for merkle tree",
+        )?;
+        let base_result = self.base_hook.tree_at_block(height).await?;
+        Self::require_base_hook_agreement(
+            &quorum_result,
+            &base_result,
+            |a, b| a.tree == b.tree,
+            "Failed to reach quorum for merkle tree",
+        )?;
+        Ok(quorum_result)
+    }
+
+    /// Derives a `Checkpoint` purely locally from an already quorum-verified tree read —
+    /// root/index come from the tree, `merkle_tree_hook_address`/`mailbox_domain` are known
+    /// without any RPC call. This is why `latest_checkpoint`/`latest_checkpoint_at_block`
+    /// never independently fan out to `quorum_hooks`.
+    ///
+    /// Errors (rather than panicking via `IncrementalMerkle::index()`) on an empty tree, to
+    /// match the on-chain `latestCheckpoint()` contract call this replaces: it computes
+    /// `count() - 1` under Solidity's checked arithmetic, which reverts (surfaced as a
+    /// `ChainResult::Err`, not a panic) when the tree is empty.
+    fn checkpoint_from_tree(
+        tree: IncrementalMerkleAtBlock,
+        merkle_tree_hook_address: H256,
+        mailbox_domain: u32,
+    ) -> ChainResult<CheckpointAtBlock> {
+        if tree.tree.count() == 0 {
+            return Err(ChainCommunicationError::from_other_str(
+                "cannot derive latest_checkpoint: merkle tree is empty",
+            ));
+        }
+        let checkpoint = Checkpoint {
+            merkle_tree_hook_address,
+            mailbox_domain,
+            root: tree.tree.root(),
+            index: tree.tree.index(),
+        };
+        Ok(CheckpointAtBlock {
+            checkpoint,
+            block_height: tree.block_height,
+        })
+    }
 }
 
 #[async_trait]
 impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
     async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
         if let Some(height) = self.resolve_quorum_target_height(reorg_period).await? {
-            let results = join_all(self.quorum_hooks.iter().cloned().map(
-                |(label, hook)| async move {
-                    (
-                        label,
-                        Self::with_call_timeout(hook.tree_at_block(height)).await,
-                    )
-                },
-            ))
-            .await;
-            let quorum_result = self.select_quorum_result(
-                results,
-                |a, b| a.tree == b.tree,
-                "Failed to reach quorum for merkle tree",
-            )?;
-            let base_result = self.base_hook.tree_at_block(height).await?;
-            Self::require_base_hook_agreement(
-                &quorum_result,
-                &base_result,
-                |a, b| a.tree == b.tree,
-                "Failed to reach quorum for merkle tree",
-            )?;
-            return Ok(quorum_result);
+            return self.tree_at_block_via_quorum(height).await;
         }
 
         let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
@@ -317,61 +364,13 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
         &self,
         reorg_period: &ReorgPeriod,
     ) -> ChainResult<CheckpointAtBlock> {
-        if let Some(height) = self.resolve_quorum_target_height(reorg_period).await? {
-            return self.latest_checkpoint_at_block(height).await;
-        }
-
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
-            let reorg_period = reorg_period.clone();
-            async move {
-                (
-                    label,
-                    Self::with_call_timeout(hook.latest_checkpoint(&reorg_period)).await,
-                )
-            }
-        }))
-        .await;
-        let quorum_result = self.select_quorum_result(
-            results,
-            |a, b| a.checkpoint == b.checkpoint && a.block_height == b.block_height,
-            "Failed to reach quorum for latest_checkpoint",
-        )?;
-        let base_result = self.base_hook.latest_checkpoint(reorg_period).await?;
-        Self::require_base_hook_agreement(
-            &quorum_result,
-            &base_result,
-            |a, b| a.checkpoint == b.checkpoint,
-            "Failed to reach quorum for latest_checkpoint",
-        )?;
-        Ok(quorum_result)
+        let tree = self.tree(reorg_period).await?;
+        Self::checkpoint_from_tree(tree, self.address(), self.domain().id())
     }
 
     async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
-        let results = join_all(
-            self.quorum_hooks
-                .iter()
-                .cloned()
-                .map(|(label, hook)| async move {
-                    (
-                        label,
-                        Self::with_call_timeout(hook.latest_checkpoint_at_block(height)).await,
-                    )
-                }),
-        )
-        .await;
-        let quorum_result = self.select_quorum_result(
-            results,
-            |a, b| a.checkpoint == b.checkpoint && a.block_height == b.block_height,
-            "Failed to reach quorum for latest_checkpoint_at_block",
-        )?;
-        let base_result = self.base_hook.latest_checkpoint_at_block(height).await?;
-        Self::require_base_hook_agreement(
-            &quorum_result,
-            &base_result,
-            |a, b| a.checkpoint == b.checkpoint,
-            "Failed to reach quorum for latest_checkpoint_at_block",
-        )?;
-        Ok(quorum_result)
+        let tree = self.tree_at_block_via_quorum(height).await?;
+        Self::checkpoint_from_tree(tree, self.address(), self.domain().id())
     }
 }
 
@@ -2088,71 +2087,142 @@ mod tests {
         assert!(hook.tree(&ReorgPeriod::None).await.is_ok());
     }
 
-    fn dummy_checkpoint_at_block(
-        mailbox_domain: u32,
-        root: u64,
-        index: u32,
-        height: u64,
-    ) -> CheckpointAtBlock {
-        CheckpointAtBlock {
-            checkpoint: hyperlane_core::Checkpoint {
-                merkle_tree_hook_address: H256::from_low_u64_be(11),
-                mailbox_domain,
-                root: H256::from_low_u64_be(root),
-                index,
-            },
-            block_height: Some(height),
+    /// Builds an `IncrementalMerkle` with `count` leaves, giving a concrete root/index to
+    /// assert quorum agreement/disagreement against.
+    fn tree_with_count(count: u32) -> hyperlane_core::accumulator::incremental::IncrementalMerkle {
+        let mut tree = hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+        for i in 0..count {
+            tree.ingest(H256::from_low_u64_be(i as u64 + 1));
         }
+        tree
     }
 
-    /// Also proves `latest_checkpoint()` correctly resolves a height (via `base_hook`) and
-    /// delegates to `latest_checkpoint_at_block()`.
+    /// Regression test: the on-chain `latestCheckpoint()` call this replaces reverts
+    /// (`count() - 1` underflow under Solidity's checked arithmetic) rather than succeeding
+    /// on an empty tree. `checkpoint_from_tree` must surface that as a `ChainResult::Err`,
+    /// not panic via `IncrementalMerkle::index()`'s internal assert.
+    #[test]
+    fn checkpoint_from_tree_errors_on_empty_tree_instead_of_panicking() {
+        let empty_tree = IncrementalMerkleAtBlock {
+            tree: tree_with_count(0),
+            block_height: Some(10),
+        };
+
+        let result = ValidatorMultiRpcQuorumMerkleTreeHook::checkpoint_from_tree(
+            empty_tree,
+            H256::from_low_u64_be(11),
+            1337,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn checkpoint_from_tree_derives_checkpoint_from_nonempty_tree() {
+        let tree = tree_with_count(5);
+        let expected_root = tree.root();
+
+        let result = ValidatorMultiRpcQuorumMerkleTreeHook::checkpoint_from_tree(
+            IncrementalMerkleAtBlock {
+                tree,
+                block_height: Some(10),
+            },
+            H256::from_low_u64_be(11),
+            1337,
+        )
+        .unwrap();
+
+        assert_eq!(result.checkpoint.index, 4);
+        assert_eq!(result.checkpoint.root, expected_root);
+        assert_eq!(
+            result.checkpoint.merkle_tree_hook_address,
+            H256::from_low_u64_be(11)
+        );
+        assert_eq!(result.checkpoint.mailbox_domain, 1337);
+        assert_eq!(result.block_height, Some(10));
+    }
+
+    /// `latest_checkpoint`/`latest_checkpoint_at_block` must never independently call
+    /// `quorum_hooks`/`base_hook`'s `latest_checkpoint*` methods (asserted via `.never()`
+    /// below): the checkpoint is derived locally from a quorum-verified `tree` read, so the
+    /// public-RPC-inclusive `quorum_hooks` pool is only ever exercised for root reads. Also
+    /// proves `latest_checkpoint()` correctly resolves a height (via `base_hook`) and
+    /// delegates to the same quorum machinery as `tree()`.
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_uses_quorum_for_latest_checkpoint() {
         let mailbox_domain = dummy_domain(1337, "test-domain").id();
-        let agreed_checkpoint = dummy_checkpoint_at_block(mailbox_domain, 22, 7, 99);
-        let divergent_checkpoint = dummy_checkpoint_at_block(mailbox_domain, 23, 8, 99);
+        let agreed_tree = tree_with_count(8);
+        let divergent_tree = tree_with_count(9);
 
         let mut base_hook = MockMerkleTreeHook::new();
         base_hook.expect_count().never();
         base_hook.expect_tree().never();
-        base_hook.expect_tree_at_block().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
         mock_height_resolution(&mut base_hook, mailbox_domain, 99);
         base_hook
-            .expect_latest_checkpoint_at_block()
+            .expect_address()
+            .return_const(H256::from_low_u64_be(11));
+        base_hook
+            .expect_domain()
+            .return_const(dummy_domain(1337, "test-domain"));
+        base_hook
+            .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(99))
             .return_once({
-                let agreed_checkpoint = agreed_checkpoint.clone();
-                move |_| Ok(agreed_checkpoint)
+                let tree = agreed_tree.clone();
+                move |_| {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree,
+                        block_height: Some(99),
+                    })
+                }
             });
 
         let mut quorum_a = MockMerkleTreeHook::new();
         quorum_a.expect_latest_checkpoint().never();
+        quorum_a.expect_latest_checkpoint_at_block().never();
         quorum_a
-            .expect_latest_checkpoint_at_block()
+            .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(99))
             .return_once({
-                let agreed_checkpoint = agreed_checkpoint.clone();
-                move |_| Ok(agreed_checkpoint)
+                let tree = agreed_tree.clone();
+                move |_| {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree,
+                        block_height: Some(99),
+                    })
+                }
             });
 
         let mut quorum_b = MockMerkleTreeHook::new();
         quorum_b.expect_latest_checkpoint().never();
+        quorum_b.expect_latest_checkpoint_at_block().never();
         quorum_b
-            .expect_latest_checkpoint_at_block()
+            .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(99))
-            .return_once(move |_| Ok(agreed_checkpoint));
+            .return_once(move |_| {
+                Ok(IncrementalMerkleAtBlock {
+                    tree: agreed_tree,
+                    block_height: Some(99),
+                })
+            });
 
         let mut quorum_c = MockMerkleTreeHook::new();
         quorum_c.expect_latest_checkpoint().never();
+        quorum_c.expect_latest_checkpoint_at_block().never();
         quorum_c
-            .expect_latest_checkpoint_at_block()
+            .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(99))
-            .return_once(move |_| Ok(divergent_checkpoint));
+            .return_once(move |_| {
+                Ok(IncrementalMerkleAtBlock {
+                    tree: divergent_tree,
+                    block_height: Some(99),
+                })
+            });
 
         let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
             base_hook: Arc::new(base_hook),
@@ -2173,41 +2243,47 @@ mod tests {
         );
     }
 
+    /// Same guarantee as above (quorum only ever exercised via `tree_at_block`), for the
+    /// explicit-height entry point.
     #[tokio::test]
     async fn validator_multi_rpc_quorum_merkle_tree_hook_latest_checkpoint_at_block_uses_quorum() {
+        let agreed_tree = tree_with_count(9);
+        let divergent_tree = tree_with_count(10);
+
         let mut base_hook = MockMerkleTreeHook::new();
         base_hook.expect_count().never();
         base_hook.expect_latest_checkpoint().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
         base_hook
-            .expect_latest_checkpoint_at_block()
+            .expect_address()
+            .return_const(H256::from_low_u64_be(11));
+        base_hook
+            .expect_domain()
+            .return_const(dummy_domain(1337, "test-domain"));
+        base_hook
+            .expect_tree_at_block()
             .once()
             .with(mockall::predicate::eq(42))
-            .return_once(|height| {
-                Ok(CheckpointAtBlock {
-                    checkpoint: hyperlane_core::Checkpoint {
-                        merkle_tree_hook_address: H256::from_low_u64_be(11),
-                        mailbox_domain: 1337,
-                        root: H256::from_low_u64_be(33),
-                        index: 9,
-                    },
-                    block_height: Some(height),
-                })
+            .return_once({
+                let tree = agreed_tree.clone();
+                move |height| {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree,
+                        block_height: Some(height),
+                    })
+                }
             });
 
-        let make_hook = |root: u64, index: u64| {
+        let make_hook = |tree: hyperlane_core::accumulator::incremental::IncrementalMerkle| {
             let mut hook = MockMerkleTreeHook::new();
             hook.expect_latest_checkpoint().never();
-            hook.expect_latest_checkpoint_at_block()
+            hook.expect_latest_checkpoint_at_block().never();
+            hook.expect_tree_at_block()
                 .once()
                 .with(mockall::predicate::eq(42))
                 .return_once(move |height| {
-                    Ok(CheckpointAtBlock {
-                        checkpoint: hyperlane_core::Checkpoint {
-                            merkle_tree_hook_address: H256::from_low_u64_be(11),
-                            mailbox_domain: 1337,
-                            root: H256::from_low_u64_be(root),
-                            index: index as u32,
-                        },
+                    Ok(IncrementalMerkleAtBlock {
+                        tree,
                         block_height: Some(height),
                     })
                 });
@@ -2217,9 +2293,9 @@ mod tests {
         let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
             base_hook: Arc::new(base_hook),
             quorum_hooks: vec![
-                quorum_rpc("rpc-a", make_hook(33, 9)),
-                quorum_rpc("rpc-b", make_hook(33, 9)),
-                quorum_rpc("rpc-c", make_hook(44, 10)),
+                quorum_rpc("rpc-a", make_hook(agreed_tree.clone())),
+                quorum_rpc("rpc-b", make_hook(agreed_tree)),
+                quorum_rpc("rpc-c", make_hook(divergent_tree)),
             ],
         };
 
@@ -2229,7 +2305,7 @@ mod tests {
                 .unwrap()
                 .checkpoint
                 .index,
-            9
+            8
         );
     }
 

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -401,6 +401,7 @@ pub struct Validator {
     merkle_tree_hook_sync: Arc<SequencedDataContractSync<MerkleTreeInsertion>>,
     mailbox: Arc<dyn Mailbox>,
     merkle_tree_hook: Arc<dyn MerkleTreeHook>,
+    base_merkle_tree_hook: Arc<dyn MerkleTreeHook>,
     validator_announce: Arc<dyn ValidatorAnnounce>,
     signer: SingletonSignerHandle,
     raw_signer: Signers,
@@ -562,7 +563,12 @@ impl BaseAgent for Validator {
 
         let mailbox = origin_chain_conf.build_mailbox(&metrics).await?;
 
-        let merkle_tree_hook = if Self::validator_uses_split_quorum_hook(
+        let base_merkle_tree_hook: Arc<dyn MerkleTreeHook> = settings
+            .build_merkle_tree_hook(&settings.origin_chain, &metrics)
+            .await?
+            .into();
+
+        let merkle_tree_hook: Arc<dyn MerkleTreeHook> = if Self::validator_uses_split_quorum_hook(
             &origin_chain_conf,
             &additional_quorum_rpc_urls,
         ) {
@@ -582,12 +588,14 @@ impl BaseAgent for Validator {
             Self::warn_if_quorum_pool_undersized(&combined_urls);
             Self::warn_if_duplicate_hosts(&combined_urls);
             Self::build_validator_quorum_merkle_tree_hook(
+                base_merkle_tree_hook.clone(),
                 &origin_chain_conf,
                 &primary_rpc_urls,
                 &additional_quorum_rpc_urls,
                 &metrics,
             )
             .await?
+            .into()
         } else {
             if !additional_quorum_rpc_urls.is_empty() {
                 warn!(
@@ -595,9 +603,7 @@ impl BaseAgent for Validator {
                     "additionalQuorumRpcUrls is set but ignored: quorum verification is only supported for Ethereum chains"
                 );
             }
-            settings
-                .build_merkle_tree_hook(&settings.origin_chain, &metrics)
-                .await?
+            base_merkle_tree_hook.clone()
         };
 
         let validator_announce = settings
@@ -623,7 +629,8 @@ impl BaseAgent for Validator {
             core,
             db: msg_db,
             mailbox: mailbox.into(),
-            merkle_tree_hook: merkle_tree_hook.into(),
+            merkle_tree_hook,
+            base_merkle_tree_hook,
             merkle_tree_hook_sync,
             validator_announce: validator_announce.into(),
             signer,
@@ -848,12 +855,12 @@ impl Validator {
     }
 
     async fn build_validator_quorum_merkle_tree_hook(
+        base_hook: Arc<dyn MerkleTreeHook>,
         origin_chain_conf: &ChainConf,
         primary_rpc_urls: &[Url],
         additional_quorum_rpc_urls: &[Url],
         metrics: &CoreMetrics,
     ) -> ChainResult<Box<dyn MerkleTreeHook>> {
-        let base_hook = origin_chain_conf.build_merkle_tree_hook(metrics).await?;
         let mut quorum_hooks = Self::build_validator_ethereum_per_url_hooks(
             origin_chain_conf,
             "rpcUrls",
@@ -873,7 +880,7 @@ impl Validator {
             .await?,
         );
         Ok(Box::new(ValidatorMultiRpcQuorumMerkleTreeHook {
-            base_hook: base_hook.into(),
+            base_hook,
             quorum_hooks,
         }) as Box<dyn MerkleTreeHook>)
     }
@@ -995,6 +1002,7 @@ impl Validator {
             self.interval,
             self.reorg_period.clone(),
             self.merkle_tree_hook.clone(),
+            self.base_merkle_tree_hook.clone(),
             self.signer.clone(),
             self.raw_signer.clone(),
             self.checkpoint_syncer.clone(),


### PR DESCRIPTION
## Summary
- `ValidatorMultiRpcQuorumMerkleTreeHook::latest_checkpoint()`/`latest_checkpoint_at_block()` no longer independently fan out to `quorum_hooks` (the public-RPC-inclusive quorum pool). They now derive the `Checkpoint` locally from an already quorum-verified `tree()`/`tree_at_block()` read, so `quorum_hooks` is exercised only for the actual merkle tree root read. (Pure consistency/cleanup — see note below on load.)
- Fixed a regression from that refactor: deriving the checkpoint via `IncrementalMerkle::index()` panics on an empty tree, whereas the on-chain `latestCheckpoint()` call it replaces reverts (`count() - 1` underflow) and surfaces as a normal `ChainResult::Err`. `checkpoint_from_tree` now returns an `Err` on an empty tree instead of panicking, preserving the old failure mode.
- **The actual public-RPC load fix**: `checkpoint_submitter`'s poll loop (`submit.rs`) previously called `latest_checkpoint()` — potentially quorum-verified, fanning to public RPCs — every poll interval regardless of message throughput. It now polls the cheap, base-hook-only (private) `count()` each tick first, and only calls the quorum-verified `latest_checkpoint()` when that shows a new leaf to catch up to. Idle chains stop polling public RPCs once caught up; busy chains' fan-out scales with new checkpoints, not the poll cadence.

## Why
Quorum verification was fanning routine polling reads out to public RPCs regardless of whether a decision actually needed quorum, causing constant public-RPC load independent of message throughput (this is what public RPC rate-limiting on quiet chains was tracing back to). The first commit made quorum-only-for-root-reads consistent but didn't change *how often* that fan-out happens — the second commit fixes that by gating it on an actual new-message signal.

## Test plan
- [x] `cargo test -p validator` — 51 passed, including:
  - 2 new tests proving `latest_checkpoint`/`latest_checkpoint_at_block` never call `quorum_hooks`' `latest_checkpoint*` methods directly
  - 2 new regression tests for `checkpoint_from_tree`'s empty-tree handling (errors instead of panicking)
  - 2 new tests on the `checkpoint_submitter` loop: `count()`-only polling skips `latest_checkpoint()` when nothing's new, and `latest_checkpoint()` is still called once a new leaf is observed
- [x] `cargo clippy -p validator -- -D warnings`
- [x] `cargo fmt -p validator`