### PR TITLE
fix(ccip-server): match CCTP V1 multi-MessageSent burns in cctpMessageMatcher

### DIFF
--- a/typescript/ccip-server/src/services/cctpMessageMatcher.ts
+++ b/typescript/ccip-server/src/services/cctpMessageMatcher.ts
@@ -1,25 +1,39 @@
 import { ethers } from 'ethers';
 
-// NOTE: Offsets below are for CctpMessageV2 only. V1 header is 116 bytes (not 148),
-// so multi-message V1 transactions will not match either strategy and return null.
-// CctpMessageV2 + BurnMessageV2 field offsets within the full Circle message.
-// CctpMessageV2 header is 148 bytes; BurnMessageV2 body follows immediately.
-// BurnMessageV2: version(4) burnToken(32) mintRecipient(32) amount(32) messageSender(32) ...
-const CIRCLE_HEADER_LENGTH = 148;
-const BURN_MSG_MINT_RECIPIENT_OFFSET = 36; // within BurnMessageV2 body
-const BURN_MSG_AMOUNT_OFFSET = 68; // within BurnMessageV2 body
-const BURN_MSG_SENDER_OFFSET = 100; // within BurnMessageV2 body
-export const CIRCLE_MINT_RECIPIENT_OFFSET =
-  CIRCLE_HEADER_LENGTH + BURN_MSG_MINT_RECIPIENT_OFFSET; // 184
-export const CIRCLE_AMOUNT_OFFSET =
-  CIRCLE_HEADER_LENGTH + BURN_MSG_AMOUNT_OFFSET; // 216
-export const CIRCLE_SENDER_OFFSET =
-  CIRCLE_HEADER_LENGTH + BURN_MSG_SENDER_OFFSET; // 248
-const CIRCLE_BURN_MSG_MIN_LENGTH = CIRCLE_SENDER_OFFSET + 32; // 280
+// Circle message header lengths differ by CCTP version:
+//   CCTP V1 (MessageTransmitter)   header = 116 bytes
+//   CCTP V2 (MessageTransmitterV2) header = 148 bytes
+// The BurnMessage / GMP body that follows the header has the same field layout
+// in both versions, so we match against BOTH header lengths rather than trusting
+// the on-wire version field. This lets multi-message V1 transactions match too.
+const CIRCLE_HEADER_LENGTH_V1 = 116;
+const CIRCLE_HEADER_LENGTH_V2 = 148;
+const CIRCLE_HEADER_LENGTHS = [
+  CIRCLE_HEADER_LENGTH_V1,
+  CIRCLE_HEADER_LENGTH_V2,
+];
 
-// Circle GMP message body = abi.encode(messageId) = 32 bytes starting at header end.
-const CIRCLE_GMP_BODY_OFFSET = CIRCLE_HEADER_LENGTH; // 148
-const CIRCLE_GMP_MSG_LENGTH = CIRCLE_HEADER_LENGTH + 32; // 180
+// BurnMessage body field offsets, relative to the end of the Circle header:
+// version(4) burnToken(32) mintRecipient(32) amount(32) messageSender(32) ...
+const BURN_MSG_MINT_RECIPIENT_OFFSET = 36;
+const BURN_MSG_AMOUNT_OFFSET = 68;
+const BURN_MSG_SENDER_OFFSET = 100;
+const BURN_MSG_BODY_MIN_LENGTH = 132; // through messageSender
+
+// Backwards-compatible absolute offsets within a CctpMessageV2 (header = 148).
+export const CIRCLE_MINT_RECIPIENT_OFFSET =
+  CIRCLE_HEADER_LENGTH_V2 + BURN_MSG_MINT_RECIPIENT_OFFSET; // 184
+export const CIRCLE_AMOUNT_OFFSET =
+  CIRCLE_HEADER_LENGTH_V2 + BURN_MSG_AMOUNT_OFFSET; // 216
+export const CIRCLE_SENDER_OFFSET =
+  CIRCLE_HEADER_LENGTH_V2 + BURN_MSG_SENDER_OFFSET; // 248
+
+// Circle GMP message body = abi.encode(messageId) = the trailing 32 bytes after
+// the header. So V1 GMP messages are 148 bytes and V2 GMP messages are 180 bytes.
+const CIRCLE_GMP_BODY_LENGTH = 32;
+const CIRCLE_GMP_MSG_LENGTHS = CIRCLE_HEADER_LENGTHS.map(
+  (h) => h + CIRCLE_GMP_BODY_LENGTH,
+); // [148, 180]
 
 // TokenMessage body layout (Hyperlane warp route):
 // recipient(32) amount(32) [metadata...]
@@ -33,12 +47,13 @@ const TOKEN_MSG_MIN_LENGTH = 64;
  *
  * Strategy 1 — token transfer (depositForBurn path):
  *   Matches by (messageSender, amount, mintRecipient) from the Hyperlane message
- *   against BurnMessageV2 fields, mirroring TokenBridgeCctpV2._validateTokenMessage.
- *   Circle burn messages are ≥ 280 bytes.
+ *   against BurnMessage fields, mirroring TokenBridgeCctp._validateTokenMessage.
+ *   Tries both the CCTP V1 (116B) and V2 (148B) header lengths, so a V1 burn
+ *   message (≥ 248 bytes) matches under V1 and a V2 burn (≥ 280) under V2.
  *
  * Strategy 2 — GMP hook path (sendMessageIdToIsm):
- *   The Circle message body is abi.encode(messageId) = the 32-byte Hyperlane
- *   message ID at offset 148. Circle GMP messages are exactly 180 bytes.
+ *   The Circle message body is abi.encode(messageId) — the trailing 32 bytes.
+ *   V1 GMP messages are 148 bytes and V2 GMP messages are 180 bytes.
  *
  * Returns null if neither strategy finds a match.
  */
@@ -51,7 +66,7 @@ export function findMatchingCircleMessage(
   if (circleMessages.length === 1) return circleMessages[0];
 
   // Strategy 1: token transfer — match by (messageSender, amount, mintRecipient),
-  // mirroring the three-field check in TokenBridgeCctpV2._validateTokenMessage.
+  // mirroring the three-field check in TokenBridgeCctp._validateTokenMessage.
   if (hyperlaneBody.length >= TOKEN_MSG_MIN_LENGTH) {
     const hlRecipient = hyperlaneBody.slice(
       TOKEN_MSG_RECIPIENT_OFFSET,
@@ -65,40 +80,43 @@ export function findMatchingCircleMessage(
 
     for (const msg of circleMessages) {
       const bytes = ethers.utils.arrayify(msg);
-      if (bytes.length < CIRCLE_BURN_MSG_MIN_LENGTH) continue;
 
-      const mintRecipient = bytes.slice(
-        CIRCLE_MINT_RECIPIENT_OFFSET,
-        CIRCLE_MINT_RECIPIENT_OFFSET + 32,
-      );
-      const amount = bytes.slice(
-        CIRCLE_AMOUNT_OFFSET,
-        CIRCLE_AMOUNT_OFFSET + 32,
-      );
-      const circleSender = bytes.slice(
-        CIRCLE_SENDER_OFFSET,
-        CIRCLE_SENDER_OFFSET + 32,
-      );
+      for (const header of CIRCLE_HEADER_LENGTHS) {
+        if (bytes.length < header + BURN_MSG_BODY_MIN_LENGTH) continue;
 
-      if (
-        Buffer.from(circleSender).equals(Buffer.from(hlSenderBytes)) &&
-        Buffer.from(mintRecipient).equals(Buffer.from(hlRecipient)) &&
-        Buffer.from(amount).equals(Buffer.from(hlAmount))
-      ) {
-        return msg;
+        const mintRecipient = bytes.slice(
+          header + BURN_MSG_MINT_RECIPIENT_OFFSET,
+          header + BURN_MSG_MINT_RECIPIENT_OFFSET + 32,
+        );
+        const amount = bytes.slice(
+          header + BURN_MSG_AMOUNT_OFFSET,
+          header + BURN_MSG_AMOUNT_OFFSET + 32,
+        );
+        const circleSender = bytes.slice(
+          header + BURN_MSG_SENDER_OFFSET,
+          header + BURN_MSG_SENDER_OFFSET + 32,
+        );
+
+        if (
+          Buffer.from(circleSender).equals(Buffer.from(hlSenderBytes)) &&
+          Buffer.from(mintRecipient).equals(Buffer.from(hlRecipient)) &&
+          Buffer.from(amount).equals(Buffer.from(hlAmount))
+        ) {
+          return msg;
+        }
       }
     }
   }
 
-  // Strategy 2: GMP — match by messageId in Circle message body
+  // Strategy 2: GMP — match by messageId in the trailing 32 bytes of the body.
   const messageIdBytes = ethers.utils.arrayify(messageId);
   for (const msg of circleMessages) {
     const bytes = ethers.utils.arrayify(msg);
-    if (bytes.length !== CIRCLE_GMP_MSG_LENGTH) continue;
+    if (!CIRCLE_GMP_MSG_LENGTHS.includes(bytes.length)) continue;
 
     const circleBodyId = bytes.slice(
-      CIRCLE_GMP_BODY_OFFSET,
-      CIRCLE_GMP_BODY_OFFSET + 32,
+      bytes.length - CIRCLE_GMP_BODY_LENGTH,
+      bytes.length,
     );
     if (Buffer.from(circleBodyId).equals(Buffer.from(messageIdBytes))) {
       return msg;

--- a/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
@@ -33,6 +33,29 @@ function makeGmpCircleMessage(messageId: string): string {
   return ethers.utils.hexlify(buf);
 }
 
+/** Build a minimal CctpMessageV1 + BurnMessageV1 Circle message (248 bytes).
+ *  V1 header is 116 bytes, so the burn body offsets are 116 + {36,68,100}. */
+function makeBurnCircleMessageV1(
+  mintRecipient: Uint8Array,
+  amount: Uint8Array,
+  sender: Uint8Array = Buffer.alloc(32, 0x00),
+): string {
+  const buf = Buffer.alloc(248);
+  mintRecipient.forEach((b, i) => (buf[116 + 36 + i] = b)); // 152
+  amount.forEach((b, i) => (buf[116 + 68 + i] = b)); // 184
+  sender.forEach((b, i) => (buf[116 + 100 + i] = b)); // 216
+  return ethers.utils.hexlify(buf);
+}
+
+/** Build a CctpMessageV1 GMP Circle message (exactly 148 bytes).
+ *  Body = messageId at bytes [116, 148). */
+function makeGmpCircleMessageV1(messageId: string): string {
+  const buf = Buffer.alloc(148);
+  const idBytes = ethers.utils.arrayify(messageId);
+  idBytes.forEach((b, i) => (buf[116 + i] = b));
+  return ethers.utils.hexlify(buf);
+}
+
 /** Build a Hyperlane TokenMessage body: recipient(32) + amount(32). */
 function makeTokenBody(recipient: Uint8Array, amount: Uint8Array): Uint8Array {
   const buf = Buffer.alloc(64);
@@ -212,6 +235,75 @@ describe('findMatchingCircleMessage', () => {
           senderA,
         ),
       ).to.equal(ethers.utils.hexlify(burnA));
+    });
+  });
+
+  // Regression coverage for the CCTP V1 multi-MessageSent bug: a V1 tx with
+  // more than one burn (116B header, 248B total) previously matched neither
+  // strategy and returned null, wedging the CCIP-read ISM permanently.
+  describe('CCTP V1 (116-byte header) messages', () => {
+    it('matches the correct V1 burn message among multiple in one tx', () => {
+      const msgA = makeBurnCircleMessageV1(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const msgB = makeBurnCircleMessageV1(RECIPIENT_B, AMOUNT_B, SENDER_B);
+      const bodyB = makeTokenBody(RECIPIENT_B, AMOUNT_B);
+      expect(
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          bodyB,
+          MESSAGE_ID_B,
+          ethers.utils.hexlify(SENDER_B),
+        ),
+      ).to.equal(msgB);
+    });
+
+    it('disambiguates V1 burns by sender when recipient and amount match', () => {
+      const msgA = makeBurnCircleMessageV1(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const msgB = makeBurnCircleMessageV1(RECIPIENT_A, AMOUNT_A, SENDER_B);
+      const body = makeTokenBody(RECIPIENT_A, AMOUNT_A);
+      expect(
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          body,
+          MESSAGE_ID_A,
+          ethers.utils.hexlify(SENDER_B),
+        ),
+      ).to.equal(msgB);
+    });
+
+    it('matches a V1 GMP message (148 bytes) by messageId', () => {
+      const msgA = makeGmpCircleMessageV1(MESSAGE_ID_A);
+      const msgB = makeGmpCircleMessageV1(MESSAGE_ID_B);
+      expect(
+        findMatchingCircleMessage(
+          [msgA, msgB],
+          new Uint8Array(0),
+          MESSAGE_ID_A,
+          SENDER_ZERO_HEX,
+        ),
+      ).to.equal(msgA);
+    });
+
+    it('matches the right burn when V1 and V2 burns share a tx', () => {
+      const v1 = makeBurnCircleMessageV1(RECIPIENT_A, AMOUNT_A, SENDER_A);
+      const v2 = makeBurnCircleMessage(RECIPIENT_B, AMOUNT_B, SENDER_B);
+      const bodyV1 = makeTokenBody(RECIPIENT_A, AMOUNT_A);
+      expect(
+        findMatchingCircleMessage(
+          [v1, v2],
+          bodyV1,
+          MESSAGE_ID_A,
+          ethers.utils.hexlify(SENDER_A),
+        ),
+      ).to.equal(v1);
+      const bodyV2 = makeTokenBody(RECIPIENT_B, AMOUNT_B);
+      expect(
+        findMatchingCircleMessage(
+          [v1, v2],
+          bodyV2,
+          MESSAGE_ID_B,
+          ethers.utils.hexlify(SENDER_B),
+        ),
+      ).to.equal(v2);
     });
   });
 


### PR DESCRIPTION
## Summary

`findMatchingCircleMessage` (typescript/ccip-server/src/services/cctpMessageMatcher.ts) only implemented **CCTP V2** (148-byte header) field offsets. For a **CCTP V1** transaction (116-byte header) that emits **more than one** `MessageSent` event, both match strategies failed on the V1 message lengths and returned `null`. The offchain-lookup server then threw `Could not match any of N MessageSent events to messageId`, so the CCIP-read ISM never fetched the Circle attestation and the messages wedged in the relayer prepare queue **permanently** (they do not self-resolve).

This deterministic bug paged 3× on `USDC/mainnet-cctp` (V1) base rebalances — 2026-07-14, 2026-07-31, and again 2026-08-03 (queue flat at 9, all `Retry(Could not fetch metadata)`). The V1 matcher was diagnosed in those incidents but never merged (only the V2-only #8833 landed).

## Fix

Match against **both** the V1 (116B) and V2 (148B) Circle header lengths in both strategies:
- The BurnMessage / GMP body layout after the header is identical across versions, so a V1 burn (≥248B) matches under the V1 header and a V2 burn (≥280B) under the V2 header — no reliance on the on-wire version field (which keeps existing V2 behavior/tests intact).
- GMP messages match by the trailing 32-byte `abi.encode(messageId)` body, so V1 GMP = 148B and V2 GMP = 180B are both accepted.

Once deployed, the relayer auto-recovers the currently-stuck messages on next retry.

## Test plan

- [x] `pnpm -C typescript/ccip-server test` — 14 passing (10 existing + 4 new)
- [x] New regression tests: multi-burn V1 tx, V1 sender disambiguation, V1 GMP (148B), mixed V1/V2 burns in one tx
- [x] Existing V2 + golden-vector tests unchanged and passing
- [x] `oxlint` / `oxfmt` clean on changed files

Refs incidents 01KXGNANRDBWY8120HJEY8DXX8, 01KYWBQV97Q4KJ4DWH6DGQ53TX, 01KZ4KXT776ADP6TKT6661S67V (root-cause group 01KXGNSJQ86ATJG15QYRF5QM0S).