### PR TITLE
feat: add signed piecewise warp fee curves

### DIFF
--- a/.changeset/fair-quote-curves.md
+++ b/.changeset/fair-quote-curves.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/fee-quoting': minor
+---
+
+The EVM quote service now recognizes piecewise-linear offchain fee contracts and emits ABI-encoded curve quote data for them.

--- a/.changeset/fair-quote-curves.md
+++ b/.changeset/fair-quote-curves.md
@@ -2,4 +2,6 @@
 '@hyperlane-xyz/fee-quoting': minor
 ---
 
-The EVM quote service now recognizes piecewise-linear offchain fee contracts and emits ABI-encoded curve quote data for them.
+The EVM quote service now recognizes piecewise-linear offchain fee contracts,
+emitting packed linear data for transient quotes and ABI-encoded curve data for
+standing quotes.

--- a/.changeset/fair-quote-curves.md
+++ b/.changeset/fair-quote-curves.md
@@ -3,5 +3,5 @@
 ---
 
 The EVM quote service now recognizes piecewise-linear offchain fee contracts,
-emitting packed linear data for transient quotes and ABI-encoded curve data for
-standing quotes.
+emitting packed linear data for transient quotes and age-widened ABI-encoded
+curve data for standing quotes.

--- a/.changeset/tidy-piecewise-sdk.md
+++ b/.changeset/tidy-piecewise-sdk.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/provider-sdk': minor
+'@hyperlane-xyz/sdk': minor
+'@hyperlane-xyz/sealevel-sdk': patch
+---
+
+Piecewise-linear offchain-quoted fees were added to the shared fee model and the EVM deployment, read, and update flows. Sealevel now reports this EVM-only fee type as unsupported.

--- a/.changeset/tidy-piecewise-sdk.md
+++ b/.changeset/tidy-piecewise-sdk.md
@@ -2,10 +2,12 @@
 '@hyperlane-xyz/provider-sdk': minor
 '@hyperlane-xyz/sdk': minor
 '@hyperlane-xyz/sealevel-sdk': patch
+'@hyperlane-xyz/cli': patch
 ---
 
 Piecewise-linear offchain-quoted fees were added to the shared fee model and
 the EVM deployment, read, and update flows. Deployment now requires an initial
 piecewise fallback while readers expose the current signer-managed fallback
 without treating runtime changes as a redeployment. Sealevel now reports this
-EVM-only fee type as unsupported.
+EVM-only fee type as unsupported, and the CLI recognizes it when resolving
+warp-quote routing variants.

--- a/.changeset/tidy-piecewise-sdk.md
+++ b/.changeset/tidy-piecewise-sdk.md
@@ -4,4 +4,8 @@
 '@hyperlane-xyz/sealevel-sdk': patch
 ---
 
-Piecewise-linear offchain-quoted fees were added to the shared fee model and the EVM deployment, read, and update flows. Sealevel now reports this EVM-only fee type as unsupported.
+Piecewise-linear offchain-quoted fees were added to the shared fee model and
+the EVM deployment, read, and update flows. Deployment now requires an initial
+piecewise fallback while readers expose the current signer-managed fallback
+without treating runtime changes as a redeployment. Sealevel now reports this
+EVM-only fee type as unsupported.

--- a/.changeset/warm-piecewise-quotes.md
+++ b/.changeset/warm-piecewise-quotes.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+A dedicated EVM piecewise quote writer was added with raw curve validation,
+contract-compatible encoding, confirmed submission, and stored-curve readback.

--- a/.changeset/wise-fees-curve.md
+++ b/.changeset/wise-fees-curve.md
@@ -2,6 +2,6 @@
 "@hyperlane-xyz/core": minor
 ---
 
-`OffchainQuotedPiecewiseLinearFee` was added with signed marginal standing
-curves, bounded band lookup, standing-quote inspection, packed linear transient
-overrides, and a linear fallback.
+`OffchainQuotedPiecewiseLinearFee` was added with age-widened marginal standing
+curves, a signer-mutable permanent piecewise fallback, conflict-safe update
+ordering, bounded band lookup, inspection, and packed linear transient overrides.

--- a/.changeset/wise-fees-curve.md
+++ b/.changeset/wise-fees-curve.md
@@ -2,4 +2,6 @@
 "@hyperlane-xyz/core": minor
 ---
 
-`OffchainQuotedPiecewiseLinearFee` was added with signed marginal fee curves, bounded band lookup, standing-quote inspection, transient overrides, and a linear fallback.
+`OffchainQuotedPiecewiseLinearFee` was added with signed marginal standing
+curves, bounded band lookup, standing-quote inspection, packed linear transient
+overrides, and a linear fallback.

--- a/.changeset/wise-fees-curve.md
+++ b/.changeset/wise-fees-curve.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/core": minor
+---
+
+`OffchainQuotedPiecewiseLinearFee` was added with signed marginal fee curves, bounded band lookup, standing-quote inspection, transient overrides, and a linear fallback.

--- a/docs/offchain-fee-quoting.md
+++ b/docs/offchain-fee-quoting.md
@@ -39,7 +39,7 @@ struct SignedQuote {
 
 - **IGP**: `abi.encodePacked(uint128 tokenExchangeRate, uint128 gasPrice)` — two uint128 values. Fee = `gasLimit * gasPrice * tokenExchangeRate / 1e10`.
 - **Linear Warp fee**: `abi.encodePacked(uint256 maxFee, uint256 halfAmount)` — linear fee params. Fee = `min(maxFee, amount * maxFee / (2 * halfAmount))`. Same formula as `LinearFee`.
-- **Piecewise Warp fee**: `abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)` — marginal amount bands with four decimal places of bps precision.
+- **Piecewise Warp fee**: `abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4, uint32 staleAfterSeconds, uint32[] staleMarginalSurchargeBpsX1e4)` — marginal amount bands plus a single age-widening step. Its permanent fallback uses `abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)`.
 
 **Transient vs standing**:
 
@@ -81,11 +81,17 @@ Fee quote data (64 bytes packed):
 Piecewise fee quote data is standard ABI encoding rather than packed bytes:
 
 ```solidity
-abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)
+abi.encode(
+    uint128[] breakpoints,
+    uint32[] marginalBpsX1e4,
+    uint32 staleAfterSeconds,
+    uint32[] staleMarginalSurchargeBpsX1e4
+)
 ```
 
 The number of rates is one greater than the number of breakpoints. The final
-rate is open-ended. `1 bp == 10_000` encoded rate units.
+rate is open-ended. The surcharge vector has the same length as the rate
+vector. `1 bp == 10_000` encoded rate units.
 
 Each concrete contract decodes context to extract mapping keys for standing quotes. Wildcards use `type(T).max`.
 
@@ -178,12 +184,25 @@ bytes32 constant TRANSIENT_AMOUNT_SLOT = keccak256("OffchainQuotedLinearFee.amou
 | 4        | `quotes[WILDCARD][recipient]`                            | Recipient-only rate (any destination)   |
 | 5        | immutable `maxFee`/`halfAmount`                          | LinearFee fallback (constructor config) |
 
+### Piecewise Warp Fee (OffchainQuotedPiecewiseLinearFee)
+
+The piecewise variant preserves the first four resolution levels above. A
+normal curve uses its base marginal rates until `issuedAt + staleAfterSeconds`,
+then uses the full base-plus-surcharge curve through its inclusive expiry. Its
+fifth level is a required, non-expiring piecewise fallback that an authorized
+quote signer can replace through `submitFallbackCurve` without redeployment.
+
+Fallback updates use a distinct EIP-712 `SignedFallbackCurve` message, are
+bound to a nonzero transaction submitter, and are ordered by `issuedAt`. They
+have no expiry. Equal-timestamp retries are accepted only when the economic
+state is identical.
+
 ### Properties
 
 - **No replay protection needed** — transient quotes auto-clear (EIP-1153), standing quotes are intentionally reusable
 - **Intra-tx transient reuse is acceptable** — a transient quote can satisfy multiple calls with the same context tuple within one transaction. The quote's scoped `salt` binds it to a specific `msg.sender`, the `submitter` field restricts submission to a specific contract, and context fields must match. Same authorized user reusing the same rate for the same route in the same tx.
 - **Field-level matching** — transient quotes match individual context fields, supporting wildcards per-field
-- **Graceful degradation** — falls back through specificity levels to oracle / immutable config
+- **Graceful degradation** — falls back through specificity levels to oracle, immutable linear config, or the mutable permanent piecewise curve
 - **Compound matching** — Alice-to-Arbitrum, Alice-to-any, anyone-to-Arbitrum all coexist
 - **Scoped salt binding** — QuotedCalls verifies `salt == keccak256(msg.sender, clientSalt)`, preventing unauthorized quote use
 - **Submitter restriction** — quotes can be locked to a specific submitter contract
@@ -233,6 +252,13 @@ OffchainQuotedLinearFee is AbstractOffchainQuoter, LinearFee
   ├── _matchesTransient() — field-level wildcard matching
   ├── addQuoteSigner() / removeQuoteSigner() — owner-gated
   └── Inherits claim(), token, receive() from BaseFee
+
+OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, TokenFeeBase
+  ├── Fresh and effective-stale marginal curves with precomputed prefixes
+  ├── Required permanent fallback and signed fallback replacement
+  ├── Packed linear transient compatibility
+  ├── Fixed eight-probe band lookup (maximum 256 bands)
+  └── Inherits claim(), token, receive() from TokenFeeBase
 
 QuotedCalls is PackageVersioned
   ├── Command-based router: execute(bytes commands, bytes[] inputs)

--- a/docs/offchain-fee-quoting.md
+++ b/docs/offchain-fee-quoting.md
@@ -1,5 +1,8 @@
 # Real-Time Warp Route Fees via Offchain Quoting
 
+For the signed marginal-curve extension and its economic risk analysis, see
+[Signed Piecewise Warp Fee Curves](./offchain-piecewise-fee-curve.md).
+
 ## Context
 
 Current warp route fees use onchain-configured models (Linear, Progressive, Regressive) and StorageGasOracle for IGP. These can't react to real-time market conditions. This leads to overpaying or failed relaying.
@@ -35,7 +38,8 @@ struct SignedQuote {
 **Quote data formats** (`bytes`, contract-specific encoding):
 
 - **IGP**: `abi.encodePacked(uint128 tokenExchangeRate, uint128 gasPrice)` — two uint128 values. Fee = `gasLimit * gasPrice * tokenExchangeRate / 1e10`.
-- **Warp fee**: `abi.encodePacked(uint256 maxFee, uint256 halfAmount)` — linear fee params. Fee = `min(maxFee, amount * maxFee / (2 * halfAmount))`. Same formula as `LinearFee`.
+- **Linear Warp fee**: `abi.encodePacked(uint256 maxFee, uint256 halfAmount)` — linear fee params. Fee = `min(maxFee, amount * maxFee / (2 * halfAmount))`. Same formula as `LinearFee`.
+- **Piecewise Warp fee**: `abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)` — marginal amount bands with four decimal places of bps precision.
 
 **Transient vs standing**:
 
@@ -73,6 +77,15 @@ Fee quote data (64 bytes packed):
 [0:32]   Maximum fee (uint256)
 [32:64]  Half amount — transfer size at which fee = maxFee/2 (uint256)
 ```
+
+Piecewise fee quote data is standard ABI encoding rather than packed bytes:
+
+```solidity
+abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)
+```
+
+The number of rates is one greater than the number of breakpoints. The final
+rate is open-ended. `1 bp == 10_000` encoded rate units.
 
 Each concrete contract decodes context to extract mapping keys for standing quotes. Wildcards use `type(T).max`.
 

--- a/docs/offchain-piecewise-fee-curve.md
+++ b/docs/offchain-piecewise-fee-curve.md
@@ -4,138 +4,68 @@
 
 Add an EVM `OffchainQuotedPiecewiseLinearFee` for Warp Routes. An authorized
 signer publishes a reusable marginal fee curve for a destination and optional
-recipient. The contract preserves the existing signed-quote context, expiry,
-wildcard resolution, transient overrides, and `LinearFee` fallback.
+recipient. A normal curve widens once as it ages, expires, and then resolves to
+a required permanent piecewise fallback.
 
-The first rollout is deliberately stateless. It improves pricing by transfer
-size, but it does not reserve inventory or remove the time between observing
-state and execution. Production curves therefore need a risk buffer.
-
-## Current boundary
-
-The Warp fee and interchain gas payment (IGP) are separate quotes:
-
-- The Warp fee compensates the route operator for liquidity, inventory, and
-  rebalancing risk.
-- IGP pays for destination message execution. A direct integration obtains it
-  separately from the Warp fee.
-- An aggregator may present one all-in amount to its user, but the onchain
-  components remain separate.
-
-Signature-based pricing means an authorized account signs pricing state that a
-contract verifies. A standing quote is reusable until expiry. A transient quote
-is installed and consumed in the same transaction through `QuotedCalls`.
-
-This differs from a traditional request for quote (RFQ). In an RFQ, a taker
-reveals an exact pair, direction, and amount; a maker responds with a short-lived
-firm price for that request. The proposed curve is standing liquidity: takers
-choose when and how much to execute against it.
+This design is stateless per transfer. It prices transfer size and quote age,
+but does not reserve inventory, consume a band, or couple a market observation
+to transaction inclusion.
 
 ## Marginal amount bands
 
 Amount ranges are marginal tranches, not whole-order buckets. With breakpoints
-`[100,000, 250,000]` and marginal rates `[1, 4, 12]` bps:
+`[100,000, 250,000]` and rates `[2, 6, 12]` bps:
 
-| Transfer | Fee calculation                                    | Fee |
-| -------- | -------------------------------------------------- | --: |
-| 100,000  | 100,000 x 1 bp                                     |  10 |
-| 200,000  | 100,000 x 1 bp + 100,000 x 4 bps                   |  50 |
-| 300,000  | 100,000 x 1 bp + 150,000 x 4 bps + 50,000 x 12 bps | 130 |
+| Transfer | Fee calculation                                     | Fee |
+| -------- | --------------------------------------------------- | --: |
+| 100,000  | 100,000 x 2 bps                                     |  20 |
+| 200,000  | 100,000 x 2 bps + 100,000 x 6 bps                   |  80 |
+| 300,000  | 100,000 x 2 bps + 150,000 x 6 bps + 50,000 x 12 bps | 170 |
 
-The final rate is open-ended. Marginal rates must be nondecreasing, so the fee
-is continuous and the incremental price never improves as an order gets larger.
-Rates may be zero, but rebates and fixed token fees are not supported.
+The final rate is open-ended. Breakpoints must be positive and strictly
+increasing. Marginal rates must be nondecreasing. A zero-rate normal curve is
+valid, but the permanent fallback must contain at least one positive rate.
 
-## Why a curve
+The curve is stateless. Several smaller transfers can repeatedly use its cheap
+first band. Stateful capacity or inventory consumption is a separate contract
+design.
 
-A flat percentage makes a 1,000 token transfer and a 500,000 token transfer pay
-the same marginal rate even though the latter can consume scarce destination
-inventory and force an expensive rebalance. A marginal curve can keep ordinary
-flow competitive while charging the tail for the risk it creates.
+## Quote-age widening
 
-IGP being separate simplifies the curve: it need not approximate destination
-execution gas. Rebalancing gas, bridge costs, inventory opportunity cost, and
-market movement still belong in the Warp fee.
+A standing quote grants the user an option: execute when the published price is
+favorable and ignore it otherwise. Updating every block reduces this exposure
+but does not remove market movement between publication and execution.
 
-## Adverse selection
+Each normal curve therefore carries one age threshold and one surcharge per
+size band:
 
-A standing curve grants the taker an option. The taker executes when the signed
-price is favorable and ignores it when it is not. The maker is exposed between
-the state observation used to produce the curve and the transfer's execution.
+```text
+fresh marginal rate[i] = marginalBpsX1e4[i]
+stale marginal rate[i] =
+    marginalBpsX1e4[i] + staleMarginalSurchargeBpsX1e4[i]
+```
 
-Example:
+For example:
 
-1. Base has 1,000,000 USDC, of which 700,000 is usable above reserves.
-2. The maker publishes an Arbitrum-to-Base curve with a cheap first 100,000.
-3. A 500,000 Ethereum-to-Base transfer consumes the same Base inventory.
-4. Before the Arbitrum curve is replaced, an informed taker executes its cheap
-   100,000 tranche.
-5. If replacement liquidity now costs 12 bps and the stale curve charges 1 bp,
-   the maker loses about 11 bps, or 110 USDC on that transfer.
+```text
+breakpoints       = [100,000, 250,000]
+fresh rates       = [2, 6, 12] bps
+stale surcharges  = [2, 4, 8] bps
+stale rates       = [4, 10, 20] bps
+```
 
-A curve prices the expected cost of size. It does not see concurrent fills,
-cross-origin inventory consumption, price moves, delayed rebalances, or chain
-reorganizations after publication.
+The stale surcharge is discrete, not continuous. The contract uses block
+timestamp and treats the curve as stale when:
 
-### Split orders
+```solidity
+block.timestamp >= uint256(issuedAt) + staleAfterSeconds
+```
 
-The curve is stateless per call. One 300,000 transfer under the example curve
-costs 130, while three independent 100,000 transfers cost 30. Repeated gas and
-IGP can make splitting less attractive, but they do not enforce aggregate
-capacity and are especially weak on inexpensive origins.
+The normal curve remains valid at its exact expiry timestamp and becomes
+unavailable when `block.timestamp > expiry`. Consequently a curve can use its
+stale rates at exact expiry, with fallback beginning in the first later block.
 
-The Q3 2026 audit found the analogous fragmentation problem in flow limiting.
-That system required persistent debt accounting so splitting could not reset
-the marginal state. The stateless fee curve intentionally does not add such
-accounting in its first version.
-
-### Mitigations in the first version
-
-- Publish nondecreasing marginal rates with a wider tail buffer.
-- Keep standing quote expiries short enough for the publisher's update cadence.
-- Refresh after inventory, replacement cost, or market volatility moves.
-- Fall back to an onchain linear rate when no standing quote is valid.
-- Monitor curve age, inventory, realized rebalancing cost, fee revenue, and
-  clustering of transfers just below breakpoints.
-- Roll out on one staging origin before proposing production configuration.
-
-These reduce expected loss; they do not eliminate the option. Without atomic
-state-to-execution protection, persistent consumption, or protected order flow,
-the signed rates need a buffer for the remaining window.
-
-## Integration models
-
-### Direct integrations
-
-Existing callers continue to use `quoteTransferRemote` and
-`transferRemote`/`transferRemoteTo`. No caller ABI changes. A standing curve is
-resolved onchain; IGP remains a separate quote. `QuotedCalls` can atomically
-install a transaction-scoped linear override before transferring.
-
-### API-driven aggregators
-
-[LI.FI](https://docs.li.fi/agents/reference/endpoint-specs) and
-[Relay](https://docs.relay.link/references/api/get-quote-v2) accept an amount and
-return executable routing data. They can quote the same Warp Route at the
-requested amount and combine its fees with other route costs. This proposal does
-not add an amount-specific Hyperlane API or change aggregator integration.
-
-### Comparables
-
-- [Across](https://docs.across.to/introduction/fees) uses utilization-sensitive
-  pricing with a kink above which the rate rises more steeply. It is the closest
-  economic analogue for charging more as liquidity becomes scarce.
-- [Titan](https://docs.titanbuilder.xyz/) exposes fresh PropAMM state to quoting
-  infrastructure. The open
-  [LambdaClass PropAMM router](https://github.com/lambdaclass/propamm-router-contracts)
-  requotes using Titan state overrides and can fall back to Uniswap. This reduces
-  the stale-state window when the fresh state is available at execution, but it
-  is not an assumption or dependency of the Warp fee curve.
-- Smooth AMM-style functions can remove visible breakpoints. They do not solve
-  stale state or split-order consumption and are deferred until there is data
-  showing that piecewise operations are insufficient.
-
-## Contract design
+## Wire formats
 
 The signed context remains packed as:
 
@@ -145,88 +75,110 @@ The signed context remains packed as:
 [36:68]  amount (uint256)
 ```
 
-Quote data is selected by lifetime. A transient quote reuses the exact packed
-wire format from `OffchainQuotedLinearFee`:
+A transient quote keeps the existing capped-linear format:
 
 ```solidity
 abi.encodePacked(uint256 maxFee, uint256 halfAmount)
 ```
 
-Because a transient RFQ can bind the requested amount in its context, it does
-not need to carry a reusable multi-band curve. Reusing the linear payload keeps
-the existing Moonpay signer and `QuotedCalls` integration compatible: only the
-EIP-712 `verifyingContract` changes to the new piecewise leaf.
-
-A standing quote uses standard ABI encoding for the reusable curve:
+A normal standing quote uses:
 
 ```solidity
-abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)
+abi.encode(
+    uint128[] breakpoints,
+    uint32[] marginalBpsX1e4,
+    uint32 staleAfterSeconds,
+    uint32[] staleMarginalSurchargeBpsX1e4
+)
 ```
 
-One basis point is encoded as `10_000`, and 10,000 bps is encoded as
-`100_000_000`. The denominator is therefore `100_000_000`. Breakpoints are in
-the source token's local atomic units. On BSC Moonpay routes, local USDC and USDT
-have 18 decimals; the router charges the fee before scaling the message amount
-to 6 decimals.
+One basis point is encoded as `10_000`; 10,000 bps is `100_000_000`.
+Breakpoints use the source token's local atomic units.
 
-Submission validates and precomputes cumulative weighted fees. Transfer quoting
-uses a fixed eight-step binary-lifting lookup supporting at most 256 bands, so
-the transfer path never loops over the configured curve. `maxBands` is immutable
-per deployment; increasing it redeploys only the leaf fee contract.
+Validation requires:
 
-Resolution is unchanged:
+- one more rate than breakpoint;
+- at most the immutable `maxBands` deployment limit;
+- nondecreasing base rates and stale surcharges;
+- every base-plus-surcharge rate at or below 10,000 bps;
+- `staleAfterSeconds > 0`; and
+- `issuedAt + staleAfterSeconds <= expiry`.
+
+Submission precomputes fresh and complete stale weighted prefixes. Quoting
+selects one curve and performs one rounded calculation; it does not add two
+separately rounded fees. Eight fixed binary-lifting probes support up to 256
+bands without looping over the active curve in the transfer path.
+
+## Permanent mutable fallback
+
+Deployment requires a valid piecewise fallback:
+
+```solidity
+constructor(
+    address quoteSigner,
+    address feeToken,
+    uint128[] memory fallbackBreakpoints,
+    uint32[] memory fallbackMarginalBpsX1e4,
+    uint16 maxBands,
+    address owner
+)
+```
+
+The fallback:
+
+- is contract-global;
+- does not expire or widen with age;
+- may be a one-rate constant-bps curve or a multi-band curve;
+- rejects an all-zero rate vector; and
+- remains active until an authorized quote signer replaces it.
+
+Fallback replacement uses a separate EIP-712 message:
+
+```solidity
+struct SignedFallbackCurve {
+    bytes data; // abi.encode(uint128[], uint32[])
+    uint48 issuedAt;
+    address submitter;
+}
+```
+
+The signature has no submission deadline. It is bound to a nonzero transaction
+submitter, cannot be future-dated, and is ordered by `issuedAt`. An identical
+equal-timestamp retry is a no-op; different state at the same timestamp reverts.
+An older signed update remains submit-able by its bound operator until a newer
+fallback has been installed.
+
+Removing a quote signer prevents new signatures from that signer from being
+accepted. It does not invalidate the already installed fallback or unexpired
+normal curves.
+
+## Resolution
+
+Fee resolution remains:
 
 1. Matching transient quote.
-2. Exact destination and recipient standing curve.
+2. Exact destination and recipient normal curve.
 3. Destination and wildcard recipient.
 4. Wildcard destination and exact recipient.
-5. Immutable `LinearFee` fallback.
+5. Permanent fallback curve.
 
-Standing curves require wildcard amount. Transient linear quotes may bind an
-exact amount or use the wildcard. The payload formats are deliberately distinct
-and a quote encoded for one mode is rejected in the other mode. Removing a
-signer does not invalidate an already stored standing curve.
+An expired higher-priority curve continues through the lower-priority wildcard
+scopes before reaching fallback.
 
-## Rollout stages
+No caller ABI changes are required for `quoteTransferRemote` or
+`transferRemote`. Interchain gas payment remains a separate quote.
 
-### Stage 1: contract and manual staging curves
+## Configuration lifecycle
 
-- Deploy with `maxBands = 4` on BSC for both Moonpay staging routes.
-- Configure a 3 bps linear fallback.
-- Publish `[100,000, 250,000]` with `[1, 4, 12]` bps for every discovered
-  destination and target-router slot.
-- Verify direct, target-router, linear transient, expiry, and fallback paths.
+Deployment config uses atomic token units and calls the required curve
+`initialFallback`. Contract readers expose current signer-managed state as
+`fallbackCurve` with its latest `issuedAt`.
 
-The example is a staging test, not a production recommendation. The 3 bps
-fallback preserves current configuration but may be less protective than the
-tail and must be reconsidered for production.
+Changing `initialFallback` in declarative config after deployment never causes
+a redeployment. Operators use the signed curve publisher. The immutable
+`maxBands` cap, fee token, or contract type still require a new leaf contract;
+owner and quote-signer changes remain ordinary owner transactions.
 
-### Stage 2: automated publishing
-
-Build a service that derives curves from inventory, replacement paths, market
-state, and volatility. Set TTL below the maximum tolerated stale-state window,
-alert on curve age, and compare collected fees with realized rebalancing costs.
-The pricing algorithm is outside Stage 1.
-
-### Stage 3: stronger execution protection
-
-If splitting or concurrent consumption is material, add stateful per-origin or
-shared capacity accounting, or use an execution environment that couples fresh
-state with inclusion. This is a separate contract and audit decision because it
-adds writes to the transfer path.
-
-### Stage 4: RFQ/API products
-
-An amount-specific API can serve direct takers or aggregators with shorter-lived
-transient quotes. It is optional and does not block standing curves.
-
-## Production gate
-
-Production configuration is proposed only after BSC staging shows:
-
-- Onchain fees match the offchain reference at and around every breakpoint.
-- Direct and `QuotedCalls` paths work for USDC and USDT target slots.
-- Expired curves reliably resolve to fallback.
-- No unhandled quote or transfer reverts during a seven-day soak.
-- The product owner and route operator approve the production fallback, curve
-  parameters, publisher cadence, monitoring, and canary origin.
+Publishing and route-specific rollout configuration are separate operational
+concerns. This contract does not add transfer maximum-fee/deadline parameters,
+onchain derivation from rebalance inputs, or persistent band consumption.

--- a/docs/offchain-piecewise-fee-curve.md
+++ b/docs/offchain-piecewise-fee-curve.md
@@ -228,5 +228,5 @@ Production configuration is proposed only after BSC staging shows:
 - Direct and `QuotedCalls` paths work for USDC and USDT target slots.
 - Expired curves reliably resolve to fallback.
 - No unhandled quote or transfer reverts during a seven-day soak.
-- Nam and the route operator approve the production fallback, curve parameters,
-  publisher cadence, monitoring, and canary origin.
+- The product owner and route operator approve the production fallback, curve
+  parameters, publisher cadence, monitoring, and canary origin.

--- a/docs/offchain-piecewise-fee-curve.md
+++ b/docs/offchain-piecewise-fee-curve.md
@@ -110,7 +110,7 @@ the signed rates need a buffer for the remaining window.
 Existing callers continue to use `quoteTransferRemote` and
 `transferRemote`/`transferRemoteTo`. No caller ABI changes. A standing curve is
 resolved onchain; IGP remains a separate quote. `QuotedCalls` can atomically
-install a transaction-scoped curve override before transferring.
+install a transaction-scoped linear override before transferring.
 
 ### API-driven aggregators
 
@@ -145,7 +145,19 @@ The signed context remains packed as:
 [36:68]  amount (uint256)
 ```
 
-Curve data uses standard ABI encoding:
+Quote data is selected by lifetime. A transient quote reuses the exact packed
+wire format from `OffchainQuotedLinearFee`:
+
+```solidity
+abi.encodePacked(uint256 maxFee, uint256 halfAmount)
+```
+
+Because a transient RFQ can bind the requested amount in its context, it does
+not need to carry a reusable multi-band curve. Reusing the linear payload keeps
+the existing Moonpay signer and `QuotedCalls` integration compatible: only the
+EIP-712 `verifyingContract` changes to the new piecewise leaf.
+
+A standing quote uses standard ABI encoding for the reusable curve:
 
 ```solidity
 abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)
@@ -170,9 +182,10 @@ Resolution is unchanged:
 4. Wildcard destination and exact recipient.
 5. Immutable `LinearFee` fallback.
 
-Standing curves require wildcard amount. Transient curves may bind an exact
-amount or use the wildcard. Removing a signer does not invalidate an already
-stored standing curve.
+Standing curves require wildcard amount. Transient linear quotes may bind an
+exact amount or use the wildcard. The payload formats are deliberately distinct
+and a quote encoded for one mode is rejected in the other mode. Removing a
+signer does not invalidate an already stored standing curve.
 
 ## Rollout stages
 
@@ -182,7 +195,7 @@ stored standing curve.
 - Configure a 3 bps linear fallback.
 - Publish `[100,000, 250,000]` with `[1, 4, 12]` bps for every discovered
   destination and target-router slot.
-- Verify direct, target-router, transient, expiry, and fallback paths.
+- Verify direct, target-router, linear transient, expiry, and fallback paths.
 
 The example is a staging test, not a production recommendation. The 3 bps
 fallback preserves current configuration but may be less protective than the

--- a/docs/offchain-piecewise-fee-curve.md
+++ b/docs/offchain-piecewise-fee-curve.md
@@ -1,0 +1,219 @@
+# Signed Piecewise Warp Fee Curves
+
+## Decision
+
+Add an EVM `OffchainQuotedPiecewiseLinearFee` for Warp Routes. An authorized
+signer publishes a reusable marginal fee curve for a destination and optional
+recipient. The contract preserves the existing signed-quote context, expiry,
+wildcard resolution, transient overrides, and `LinearFee` fallback.
+
+The first rollout is deliberately stateless. It improves pricing by transfer
+size, but it does not reserve inventory or remove the time between observing
+state and execution. Production curves therefore need a risk buffer.
+
+## Current boundary
+
+The Warp fee and interchain gas payment (IGP) are separate quotes:
+
+- The Warp fee compensates the route operator for liquidity, inventory, and
+  rebalancing risk.
+- IGP pays for destination message execution. A direct integration obtains it
+  separately from the Warp fee.
+- An aggregator may present one all-in amount to its user, but the onchain
+  components remain separate.
+
+Signature-based pricing means an authorized account signs pricing state that a
+contract verifies. A standing quote is reusable until expiry. A transient quote
+is installed and consumed in the same transaction through `QuotedCalls`.
+
+This differs from a traditional request for quote (RFQ). In an RFQ, a taker
+reveals an exact pair, direction, and amount; a maker responds with a short-lived
+firm price for that request. The proposed curve is standing liquidity: takers
+choose when and how much to execute against it.
+
+## Marginal amount bands
+
+Amount ranges are marginal tranches, not whole-order buckets. With breakpoints
+`[100,000, 250,000]` and marginal rates `[1, 4, 12]` bps:
+
+| Transfer | Fee calculation                                    | Fee |
+| -------- | -------------------------------------------------- | --: |
+| 100,000  | 100,000 x 1 bp                                     |  10 |
+| 200,000  | 100,000 x 1 bp + 100,000 x 4 bps                   |  50 |
+| 300,000  | 100,000 x 1 bp + 150,000 x 4 bps + 50,000 x 12 bps | 130 |
+
+The final rate is open-ended. Marginal rates must be nondecreasing, so the fee
+is continuous and the incremental price never improves as an order gets larger.
+Rates may be zero, but rebates and fixed token fees are not supported.
+
+## Why a curve
+
+A flat percentage makes a 1,000 token transfer and a 500,000 token transfer pay
+the same marginal rate even though the latter can consume scarce destination
+inventory and force an expensive rebalance. A marginal curve can keep ordinary
+flow competitive while charging the tail for the risk it creates.
+
+IGP being separate simplifies the curve: it need not approximate destination
+execution gas. Rebalancing gas, bridge costs, inventory opportunity cost, and
+market movement still belong in the Warp fee.
+
+## Adverse selection
+
+A standing curve grants the taker an option. The taker executes when the signed
+price is favorable and ignores it when it is not. The maker is exposed between
+the state observation used to produce the curve and the transfer's execution.
+
+Example:
+
+1. Base has 1,000,000 USDC, of which 700,000 is usable above reserves.
+2. The maker publishes an Arbitrum-to-Base curve with a cheap first 100,000.
+3. A 500,000 Ethereum-to-Base transfer consumes the same Base inventory.
+4. Before the Arbitrum curve is replaced, an informed taker executes its cheap
+   100,000 tranche.
+5. If replacement liquidity now costs 12 bps and the stale curve charges 1 bp,
+   the maker loses about 11 bps, or 110 USDC on that transfer.
+
+A curve prices the expected cost of size. It does not see concurrent fills,
+cross-origin inventory consumption, price moves, delayed rebalances, or chain
+reorganizations after publication.
+
+### Split orders
+
+The curve is stateless per call. One 300,000 transfer under the example curve
+costs 130, while three independent 100,000 transfers cost 30. Repeated gas and
+IGP can make splitting less attractive, but they do not enforce aggregate
+capacity and are especially weak on inexpensive origins.
+
+The Q3 2026 audit found the analogous fragmentation problem in flow limiting.
+That system required persistent debt accounting so splitting could not reset
+the marginal state. The stateless fee curve intentionally does not add such
+accounting in its first version.
+
+### Mitigations in the first version
+
+- Publish nondecreasing marginal rates with a wider tail buffer.
+- Keep standing quote expiries short enough for the publisher's update cadence.
+- Refresh after inventory, replacement cost, or market volatility moves.
+- Fall back to an onchain linear rate when no standing quote is valid.
+- Monitor curve age, inventory, realized rebalancing cost, fee revenue, and
+  clustering of transfers just below breakpoints.
+- Roll out on one staging origin before proposing production configuration.
+
+These reduce expected loss; they do not eliminate the option. Without atomic
+state-to-execution protection, persistent consumption, or protected order flow,
+the signed rates need a buffer for the remaining window.
+
+## Integration models
+
+### Direct integrations
+
+Existing callers continue to use `quoteTransferRemote` and
+`transferRemote`/`transferRemoteTo`. No caller ABI changes. A standing curve is
+resolved onchain; IGP remains a separate quote. `QuotedCalls` can atomically
+install a transaction-scoped curve override before transferring.
+
+### API-driven aggregators
+
+[LI.FI](https://docs.li.fi/agents/reference/endpoint-specs) and
+[Relay](https://docs.relay.link/references/api/get-quote-v2) accept an amount and
+return executable routing data. They can quote the same Warp Route at the
+requested amount and combine its fees with other route costs. This proposal does
+not add an amount-specific Hyperlane API or change aggregator integration.
+
+### Comparables
+
+- [Across](https://docs.across.to/introduction/fees) uses utilization-sensitive
+  pricing with a kink above which the rate rises more steeply. It is the closest
+  economic analogue for charging more as liquidity becomes scarce.
+- [Titan](https://docs.titanbuilder.xyz/) exposes fresh PropAMM state to quoting
+  infrastructure. The open
+  [LambdaClass PropAMM router](https://github.com/lambdaclass/propamm-router-contracts)
+  requotes using Titan state overrides and can fall back to Uniswap. This reduces
+  the stale-state window when the fresh state is available at execution, but it
+  is not an assumption or dependency of the Warp fee curve.
+- Smooth AMM-style functions can remove visible breakpoints. They do not solve
+  stale state or split-order consumption and are deferred until there is data
+  showing that piecewise operations are insufficient.
+
+## Contract design
+
+The signed context remains packed as:
+
+```text
+[0:4]    destination (uint32)
+[4:36]   recipient (bytes32)
+[36:68]  amount (uint256)
+```
+
+Curve data uses standard ABI encoding:
+
+```solidity
+abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4)
+```
+
+One basis point is encoded as `10_000`, and 10,000 bps is encoded as
+`100_000_000`. The denominator is therefore `100_000_000`. Breakpoints are in
+the source token's local atomic units. On BSC Moonpay routes, local USDC and USDT
+have 18 decimals; the router charges the fee before scaling the message amount
+to 6 decimals.
+
+Submission validates and precomputes cumulative weighted fees. Transfer quoting
+uses a fixed eight-step binary-lifting lookup supporting at most 256 bands, so
+the transfer path never loops over the configured curve. `maxBands` is immutable
+per deployment; increasing it redeploys only the leaf fee contract.
+
+Resolution is unchanged:
+
+1. Matching transient quote.
+2. Exact destination and recipient standing curve.
+3. Destination and wildcard recipient.
+4. Wildcard destination and exact recipient.
+5. Immutable `LinearFee` fallback.
+
+Standing curves require wildcard amount. Transient curves may bind an exact
+amount or use the wildcard. Removing a signer does not invalidate an already
+stored standing curve.
+
+## Rollout stages
+
+### Stage 1: contract and manual staging curves
+
+- Deploy with `maxBands = 4` on BSC for both Moonpay staging routes.
+- Configure a 3 bps linear fallback.
+- Publish `[100,000, 250,000]` with `[1, 4, 12]` bps for every discovered
+  destination and target-router slot.
+- Verify direct, target-router, transient, expiry, and fallback paths.
+
+The example is a staging test, not a production recommendation. The 3 bps
+fallback preserves current configuration but may be less protective than the
+tail and must be reconsidered for production.
+
+### Stage 2: automated publishing
+
+Build a service that derives curves from inventory, replacement paths, market
+state, and volatility. Set TTL below the maximum tolerated stale-state window,
+alert on curve age, and compare collected fees with realized rebalancing costs.
+The pricing algorithm is outside Stage 1.
+
+### Stage 3: stronger execution protection
+
+If splitting or concurrent consumption is material, add stateful per-origin or
+shared capacity accounting, or use an execution environment that couples fresh
+state with inclusion. This is a separate contract and audit decision because it
+adds writes to the transfer path.
+
+### Stage 4: RFQ/API products
+
+An amount-specific API can serve direct takers or aggregators with shorter-lived
+transient quotes. It is optional and does not block standing curves.
+
+## Production gate
+
+Production configuration is proposed only after BSC staging shows:
+
+- Onchain fees match the offchain reference at and around every breakpoint.
+- Direct and `QuotedCalls` paths work for USDC and USDT target slots.
+- Expired curves reliably resolve to fallback.
+- No unhandled quote or transfer reverts during a seven-day soak.
+- Nam and the route operator approve the production fallback, curve parameters,
+  publisher cadence, monitoring, and canary origin.

--- a/solidity/contracts/libs/AbstractOffchainQuoter.sol
+++ b/solidity/contracts/libs/AbstractOffchainQuoter.sol
@@ -173,6 +173,13 @@ abstract contract AbstractOffchainQuoter is IOffchainQuoter {
                 sq.submitter
             )
         );
+        _verifyQuoteSigner(structHash, signature);
+    }
+
+    function _verifyQuoteSigner(
+        bytes32 structHash,
+        bytes calldata signature
+    ) internal view {
         bytes32 digest = ECDSA.toTypedDataHash(_domainSeparator(), structHash);
         address signer = ECDSA.recover(digest, signature);
         if (!isQuoteSigner(signer)) revert InvalidSigner();

--- a/solidity/contracts/token/fees/BaseFee.sol
+++ b/solidity/contracts/token/fees/BaseFee.sol
@@ -15,7 +15,8 @@ enum FeeType {
     PROGRESSIVE,
     ROUTING,
     CROSS_COLLATERAL_ROUTING,
-    OFFCHAIN_QUOTED_LINEAR
+    OFFCHAIN_QUOTED_LINEAR,
+    OFFCHAIN_QUOTED_PIECEWISE_LINEAR
 }
 
 abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {

--- a/solidity/contracts/token/fees/BaseFee.sol
+++ b/solidity/contracts/token/fees/BaseFee.sol
@@ -19,7 +19,7 @@ enum FeeType {
     OFFCHAIN_QUOTED_PIECEWISE_LINEAR
 }
 
-abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
+abstract contract TokenFeeBase is Ownable, ITokenFee, PackageVersioned {
     using Address for address payable;
     using SafeERC20 for IERC20;
 
@@ -28,31 +28,10 @@ abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
      */
     IERC20 public immutable token;
 
-    /**
-     * @notice The maximum fee (in token units) that can be charged for a transfer.
-     * @dev Used as the cap or asymptote in fee calculations for derived contracts.
-     */
-    uint256 public immutable maxFee;
-
-    /**
-     * @notice The reference amount at which the fee equals half of maxFee.
-     * @dev Used as a scaling parameter in fee formulas; its interpretation depends on the fee model.
-     */
-    uint256 public immutable halfAmount;
-
-    constructor(
-        address _token,
-        uint256 _maxFee,
-        uint256 _halfAmount,
-        address _owner
-    ) Ownable() {
-        require(_maxFee > 0, "maxFee must be greater than zero");
-        require(_halfAmount > 0, "halfAmount must be greater than zero");
+    constructor(address _token, address _owner) Ownable() {
         require(_owner != address(0), "owner cannot be zero address");
 
         token = IERC20(_token);
-        maxFee = _maxFee;
-        halfAmount = _halfAmount;
         _transferOwnership(_owner);
     }
 
@@ -84,5 +63,32 @@ abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
 
     receive() external payable {
         require(address(token) == address(0), "Not native token");
+    }
+}
+
+abstract contract BaseFee is TokenFeeBase {
+    /**
+     * @notice The maximum fee (in token units) that can be charged for a transfer.
+     * @dev Used as the cap or asymptote in fee calculations for derived contracts.
+     */
+    uint256 public immutable maxFee;
+
+    /**
+     * @notice The reference amount at which the fee equals half of maxFee.
+     * @dev Used as a scaling parameter in fee formulas; its interpretation depends on the fee model.
+     */
+    uint256 public immutable halfAmount;
+
+    constructor(
+        address _token,
+        uint256 _maxFee,
+        uint256 _halfAmount,
+        address _owner
+    ) TokenFeeBase(_token, _owner) {
+        require(_maxFee > 0, "maxFee must be greater than zero");
+        require(_halfAmount > 0, "halfAmount must be greater than zero");
+
+        maxFee = _maxFee;
+        halfAmount = _halfAmount;
     }
 }

--- a/solidity/contracts/token/fees/LinearFee.sol
+++ b/solidity/contracts/token/fees/LinearFee.sol
@@ -3,6 +3,18 @@ pragma solidity >=0.8.0;
 
 import {BaseFee, FeeType} from "./BaseFee.sol";
 
+library CappedLinearFeeMath {
+    function compute(
+        uint256 maxFee,
+        uint256 halfAmount,
+        uint256 amount
+    ) internal pure returns (uint256) {
+        if (maxFee == 0 || halfAmount == 0) return 0;
+        uint256 uncapped = (amount * maxFee) / (2 * halfAmount);
+        return uncapped > maxFee ? maxFee : uncapped;
+    }
+}
+
 /**
  * @title Linear Fee Structure
  * @dev Implements a linear fee model where the fee increases linearly with the transfer amount, up to a maximum cap.
@@ -40,9 +52,7 @@ contract LinearFee is BaseFee {
         uint256 halfAmount_,
         uint256 amount
     ) internal pure returns (uint256) {
-        if (maxFee_ == 0 || halfAmount_ == 0) return 0;
-        uint256 uncapped = (amount * maxFee_) / (2 * halfAmount_);
-        return uncapped > maxFee_ ? maxFee_ : uncapped;
+        return CappedLinearFeeMath.compute(maxFee_, halfAmount_, amount);
     }
 
     function feeType() external pure virtual override returns (FeeType) {

--- a/solidity/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol
+++ b/solidity/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.24;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+import {AbstractOffchainQuoter} from "../../libs/AbstractOffchainQuoter.sol";
+import {SignedQuote} from "../../interfaces/IOffchainQuoter.sol";
+import {TransientStorage} from "../../libs/TransientStorage.sol";
+import {Quote} from "../../interfaces/ITokenBridge.sol";
+import {FeeType} from "./BaseFee.sol";
+import {FeeQuoteContext} from "./OffchainQuotedLinearFee.sol";
+import {LinearFee} from "./LinearFee.sol";
+
+/**
+ * @dev Piecewise fee data uses standard ABI encoding:
+ *      abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4).
+ *      There is one more marginal rate than breakpoint. The last rate is
+ *      open-ended. One basis point is encoded as 10_000.
+ */
+library PiecewiseFeeQuoteData {
+    function encode(
+        uint128[] memory breakpoints,
+        uint32[] memory marginalBpsX1e4
+    ) internal pure returns (bytes memory) {
+        return abi.encode(breakpoints, marginalBpsX1e4);
+    }
+
+    function decode(
+        bytes calldata data
+    )
+        internal
+        pure
+        returns (uint128[] memory breakpoints, uint32[] memory marginalBpsX1e4)
+    {
+        return abi.decode(data, (uint128[], uint32[]));
+    }
+}
+
+/**
+ * @title OffchainQuotedPiecewiseLinearFee
+ * @notice Signed marginal fee curves with an immutable LinearFee fallback.
+ * @dev Resolution cascade:
+ *      transient -> (destination, recipient) -> (destination, *) ->
+ *      (*, recipient) -> immutable LinearFee fallback.
+ *
+ *      Curve submission is O(number of bands): it validates the curve and
+ *      precomputes cumulative weighted fees. Transfer quoting uses eight
+ *      unrolled binary-lifting probes and never loops over active bands.
+ */
+contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using TransientStorage for bytes32;
+
+    // ============ Constants ============
+
+    uint32 constant WILDCARD_DEST = type(uint32).max;
+    bytes32 constant WILDCARD_RECIPIENT = bytes32(type(uint256).max);
+    uint256 constant WILDCARD_AMOUNT = type(uint256).max;
+
+    uint256 public constant BPS_DENOMINATOR = 100_000_000;
+    uint32 public constant MAX_MARGINAL_BPS_X1E4 = 100_000_000;
+    uint16 public constant MAX_SUPPORTED_BANDS = 256;
+
+    bytes32 private constant TRANSIENT_QUOTED_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.quoted");
+    bytes32 private constant TRANSIENT_DESTINATION_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.destination");
+    bytes32 private constant TRANSIENT_RECIPIENT_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.recipient");
+    bytes32 private constant TRANSIENT_AMOUNT_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.amount");
+    bytes32 private constant TRANSIENT_BAND_COUNT_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.bandCount");
+    bytes32 private constant TRANSIENT_BREAKPOINT_BASE_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.breakpoints");
+    bytes32 private constant TRANSIENT_RATE_BASE_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.rates");
+    bytes32 private constant TRANSIENT_PREFIX_BASE_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.prefixWeighted");
+
+    // ============ Structs ============
+
+    struct StoredCurve {
+        uint128[] breakpoints;
+        uint32[] marginalBpsX1e4;
+        uint256[] prefixWeighted;
+        uint48 issuedAt;
+        uint48 expiry;
+    }
+
+    struct CurveQuote {
+        uint128[] breakpoints;
+        uint32[] marginalBpsX1e4;
+        uint48 issuedAt;
+        uint48 expiry;
+    }
+
+    struct QuoteEntry {
+        bytes32 recipient;
+        CurveQuote quote;
+    }
+
+    // ============ Storage ============
+
+    uint16 public immutable maxBands;
+
+    mapping(uint32 destination => mapping(bytes32 recipient => StoredCurve))
+        private _quotes;
+    EnumerableSet.UintSet private _domainIds;
+    mapping(uint32 destination => EnumerableSet.Bytes32Set recipients)
+        private _recipients;
+
+    // ============ Errors ============
+
+    error InvalidMaxBands();
+    error InvalidCurve();
+
+    // ============ Constructor ============
+
+    constructor(
+        address _quoteSigner,
+        address _feeToken,
+        uint256 _fallbackMaxFee,
+        uint256 _fallbackHalfAmount,
+        uint16 _maxBands,
+        address _owner
+    ) LinearFee(_feeToken, _fallbackMaxFee, _fallbackHalfAmount, _owner) {
+        if (_maxBands == 0 || _maxBands > MAX_SUPPORTED_BANDS) {
+            revert InvalidMaxBands();
+        }
+        maxBands = _maxBands;
+        _addQuoteSigner(_quoteSigner);
+    }
+
+    // ============ Owner ============
+
+    function addQuoteSigner(address _signer) external onlyOwner {
+        _addQuoteSigner(_signer);
+    }
+
+    function removeQuoteSigner(address _signer) external onlyOwner {
+        _removeQuoteSigner(_signer);
+    }
+
+    // ============ ITokenFee ============
+
+    function feeType() external pure override returns (FeeType) {
+        return FeeType.OFFCHAIN_QUOTED_PIECEWISE_LINEAR;
+    }
+
+    function quoteTransferRemote(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _amount
+    ) external view override returns (Quote[] memory) {
+        if (_matchesTransient(_destination, _recipient, _amount)) {
+            return _singleQuote(_computeTransientFee(_amount));
+        }
+
+        (bool found, uint256 fee) = _resolveStored(
+            _quotes[_destination][_recipient],
+            _amount
+        );
+        if (found) return _singleQuote(fee);
+
+        (found, fee) = _resolveStored(
+            _quotes[_destination][WILDCARD_RECIPIENT],
+            _amount
+        );
+        if (found) return _singleQuote(fee);
+
+        (found, fee) = _resolveStored(
+            _quotes[WILDCARD_DEST][_recipient],
+            _amount
+        );
+        if (found) return _singleQuote(fee);
+
+        return _singleQuote(_computeLinearFee(maxFee, halfAmount, _amount));
+    }
+
+    // ============ Inspection ============
+
+    function getCurve(
+        uint32 destination,
+        bytes32 recipient
+    ) public view returns (CurveQuote memory) {
+        StoredCurve storage stored = _quotes[destination][recipient];
+        return
+            CurveQuote({
+                breakpoints: stored.breakpoints,
+                marginalBpsX1e4: stored.marginalBpsX1e4,
+                issuedAt: stored.issuedAt,
+                expiry: stored.expiry
+            });
+    }
+
+    /// @notice Returns exact domain keys with at least one standing curve.
+    /// @dev Entries are never pruned and may all be expired. Order unspecified.
+    function quoteDomains() external view returns (uint32[] memory domains) {
+        uint256 length = _domainIds.length();
+        domains = new uint32[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            domains[i] = uint32(_domainIds.at(i));
+        }
+    }
+
+    /// @notice Returns all raw standing curves under an exact domain key.
+    /// @dev Offchain inspection only. Unbounded and may include expired curves.
+    function getQuotesForDomain(
+        uint32 destination
+    ) external view returns (QuoteEntry[] memory entries) {
+        EnumerableSet.Bytes32Set storage recipients = _recipients[destination];
+        uint256 length = recipients.length();
+        entries = new QuoteEntry[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            bytes32 recipient = recipients.at(i);
+            entries[i] = QuoteEntry({
+                recipient: recipient,
+                quote: getCurve(destination, recipient)
+            });
+        }
+    }
+
+    // ============ AbstractOffchainQuoter ============
+
+    function _storeTransient(SignedQuote calldata sq) internal override {
+        (
+            uint32 destination,
+            bytes32 recipient,
+            uint256 amount
+        ) = FeeQuoteContext.decode(sq.context);
+        (
+            uint128[] memory breakpoints,
+            uint32[] memory marginalBpsX1e4
+        ) = PiecewiseFeeQuoteData.decode(sq.data);
+        uint256[] memory prefixWeighted = _validateAndBuildPrefixes(
+            breakpoints,
+            marginalBpsX1e4
+        );
+
+        TRANSIENT_QUOTED_SLOT.set();
+        TRANSIENT_DESTINATION_SLOT.store(destination);
+        TRANSIENT_RECIPIENT_SLOT.store(recipient);
+        TRANSIENT_AMOUNT_SLOT.store(amount);
+        TRANSIENT_BAND_COUNT_SLOT.store(marginalBpsX1e4.length);
+
+        for (uint256 i = 0; i < marginalBpsX1e4.length; ++i) {
+            _transientSlot(TRANSIENT_RATE_BASE_SLOT, i).store(
+                marginalBpsX1e4[i]
+            );
+            _transientSlot(TRANSIENT_PREFIX_BASE_SLOT, i).store(
+                prefixWeighted[i]
+            );
+            if (i < breakpoints.length) {
+                _transientSlot(TRANSIENT_BREAKPOINT_BASE_SLOT, i).store(
+                    breakpoints[i]
+                );
+            }
+        }
+    }
+
+    function _storeStanding(
+        SignedQuote calldata sq
+    ) internal override returns (bool) {
+        (
+            uint32 destination,
+            bytes32 recipient,
+            uint256 amount
+        ) = FeeQuoteContext.decode(sq.context);
+        if (amount != WILDCARD_AMOUNT) revert InvalidCurve();
+
+        StoredCurve storage existing = _quotes[destination][recipient];
+        if (sq.issuedAt < existing.issuedAt) revert StaleQuote();
+        if (sq.issuedAt == existing.issuedAt) return false;
+
+        (
+            uint128[] memory breakpoints,
+            uint32[] memory marginalBpsX1e4
+        ) = PiecewiseFeeQuoteData.decode(sq.data);
+        uint256[] memory prefixWeighted = _validateAndBuildPrefixes(
+            breakpoints,
+            marginalBpsX1e4
+        );
+
+        existing.breakpoints = breakpoints;
+        existing.marginalBpsX1e4 = marginalBpsX1e4;
+        existing.prefixWeighted = prefixWeighted;
+        existing.issuedAt = sq.issuedAt;
+        existing.expiry = sq.expiry;
+
+        _domainIds.add(destination);
+        _recipients[destination].add(recipient);
+        return true;
+    }
+
+    // ============ Curve Validation ============
+
+    function _validateAndBuildPrefixes(
+        uint128[] memory breakpoints,
+        uint32[] memory marginalBpsX1e4
+    ) internal view returns (uint256[] memory prefixWeighted) {
+        uint256 bandCount = marginalBpsX1e4.length;
+        if (
+            bandCount == 0 ||
+            bandCount > maxBands ||
+            breakpoints.length + 1 != bandCount
+        ) revert InvalidCurve();
+
+        prefixWeighted = new uint256[](bandCount);
+        uint128 previousBreakpoint;
+        uint32 previousRate;
+
+        for (uint256 i = 0; i < bandCount; ++i) {
+            uint32 rate = marginalBpsX1e4[i];
+            if (rate > MAX_MARGINAL_BPS_X1E4 || (i > 0 && rate < previousRate))
+                revert InvalidCurve();
+
+            if (i < breakpoints.length) {
+                uint128 breakpoint = breakpoints[i];
+                if (breakpoint == 0 || breakpoint <= previousBreakpoint) {
+                    revert InvalidCurve();
+                }
+                prefixWeighted[i + 1] =
+                    prefixWeighted[i] +
+                    uint256(breakpoint - previousBreakpoint) *
+                    rate;
+                previousBreakpoint = breakpoint;
+            }
+            previousRate = rate;
+        }
+    }
+
+    // ============ Curve Resolution ============
+
+    function _matchesTransient(
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount
+    ) private view returns (bool) {
+        if (!TRANSIENT_QUOTED_SLOT.loadBool()) return false;
+
+        uint32 quotedDestination = TRANSIENT_DESTINATION_SLOT.loadUint32();
+        if (
+            quotedDestination != WILDCARD_DEST &&
+            quotedDestination != destination
+        ) return false;
+
+        bytes32 quotedRecipient = TRANSIENT_RECIPIENT_SLOT.loadBytes32();
+        if (
+            quotedRecipient != WILDCARD_RECIPIENT &&
+            quotedRecipient != recipient
+        ) return false;
+
+        uint256 quotedAmount = TRANSIENT_AMOUNT_SLOT.loadUint256();
+        return quotedAmount == WILDCARD_AMOUNT || quotedAmount == amount;
+    }
+
+    function _resolveStored(
+        StoredCurve storage curve,
+        uint256 amount
+    ) private view returns (bool, uint256) {
+        if (curve.expiry == 0 || uint48(block.timestamp) > curve.expiry) {
+            return (false, 0);
+        }
+        return (true, _computeStoredFee(curve, amount));
+    }
+
+    function _computeStoredFee(
+        StoredCurve storage curve,
+        uint256 amount
+    ) private view returns (uint256) {
+        uint256 band;
+        band = _advanceStored(curve, amount, band, 128);
+        band = _advanceStored(curve, amount, band, 64);
+        band = _advanceStored(curve, amount, band, 32);
+        band = _advanceStored(curve, amount, band, 16);
+        band = _advanceStored(curve, amount, band, 8);
+        band = _advanceStored(curve, amount, band, 4);
+        band = _advanceStored(curve, amount, band, 2);
+        band = _advanceStored(curve, amount, band, 1);
+
+        uint256 start = band == 0 ? 0 : curve.breakpoints[band - 1];
+        return
+            _computeMarginalFee(
+                curve.prefixWeighted[band],
+                amount - start,
+                curve.marginalBpsX1e4[band]
+            );
+    }
+
+    function _advanceStored(
+        StoredCurve storage curve,
+        uint256 amount,
+        uint256 band,
+        uint256 step
+    ) private view returns (uint256) {
+        uint256 candidate = band + step;
+        if (
+            candidate < curve.marginalBpsX1e4.length &&
+            amount > curve.breakpoints[candidate - 1]
+        ) return candidate;
+        return band;
+    }
+
+    function _computeTransientFee(
+        uint256 amount
+    ) private view returns (uint256) {
+        uint256 bandCount = TRANSIENT_BAND_COUNT_SLOT.loadUint256();
+        uint256 band;
+        band = _advanceTransient(amount, bandCount, band, 128);
+        band = _advanceTransient(amount, bandCount, band, 64);
+        band = _advanceTransient(amount, bandCount, band, 32);
+        band = _advanceTransient(amount, bandCount, band, 16);
+        band = _advanceTransient(amount, bandCount, band, 8);
+        band = _advanceTransient(amount, bandCount, band, 4);
+        band = _advanceTransient(amount, bandCount, band, 2);
+        band = _advanceTransient(amount, bandCount, band, 1);
+
+        uint256 start = band == 0
+            ? 0
+            : _transientSlot(TRANSIENT_BREAKPOINT_BASE_SLOT, band - 1)
+                .loadUint256();
+        return
+            _computeMarginalFee(
+                _transientSlot(TRANSIENT_PREFIX_BASE_SLOT, band).loadUint256(),
+                amount - start,
+                _transientSlot(TRANSIENT_RATE_BASE_SLOT, band).loadUint32()
+            );
+    }
+
+    function _advanceTransient(
+        uint256 amount,
+        uint256 bandCount,
+        uint256 band,
+        uint256 step
+    ) private view returns (uint256) {
+        uint256 candidate = band + step;
+        if (
+            candidate < bandCount &&
+            amount >
+            _transientSlot(TRANSIENT_BREAKPOINT_BASE_SLOT, candidate - 1)
+                .loadUint256()
+        ) return candidate;
+        return band;
+    }
+
+    function _computeMarginalFee(
+        uint256 prefixWeighted,
+        uint256 amountInBand,
+        uint32 marginalBpsX1e4
+    ) private pure returns (uint256) {
+        uint256 prefixQuotient = prefixWeighted / BPS_DENOMINATOR;
+        uint256 prefixRemainder = prefixWeighted % BPS_DENOMINATOR;
+        uint256 marginalQuotient = Math.mulDiv(
+            amountInBand,
+            marginalBpsX1e4,
+            BPS_DENOMINATOR
+        );
+        uint256 marginalRemainder = mulmod(
+            amountInBand,
+            marginalBpsX1e4,
+            BPS_DENOMINATOR
+        );
+        return
+            prefixQuotient +
+            marginalQuotient +
+            (prefixRemainder + marginalRemainder) /
+            BPS_DENOMINATOR;
+    }
+
+    function _transientSlot(
+        bytes32 base,
+        uint256 index
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encode(base, index));
+    }
+
+    function _singleQuote(
+        uint256 fee
+    ) private view returns (Quote[] memory result) {
+        result = new Quote[](1);
+        result[0] = Quote(address(token), fee);
+    }
+}

--- a/solidity/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol
+++ b/solidity/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol
@@ -20,22 +20,33 @@ import {AbstractOffchainQuoter} from "../../libs/AbstractOffchainQuoter.sol";
 import {SignedQuote} from "../../interfaces/IOffchainQuoter.sol";
 import {TransientStorage} from "../../libs/TransientStorage.sol";
 import {Quote} from "../../interfaces/ITokenBridge.sol";
-import {FeeType} from "./BaseFee.sol";
+import {FeeType, TokenFeeBase} from "./BaseFee.sol";
 import {FeeQuoteContext, FeeQuoteData} from "./OffchainQuotedLinearFee.sol";
-import {LinearFee} from "./LinearFee.sol";
+import {CappedLinearFeeMath} from "./LinearFee.sol";
 
 /**
- * @dev Piecewise fee data uses standard ABI encoding:
- *      abi.encode(uint128[] breakpoints, uint32[] marginalBpsX1e4).
- *      There is one more marginal rate than breakpoint. The last rate is
- *      open-ended. One basis point is encoded as 10_000.
+ * @dev Standing curve data uses standard ABI encoding:
+ *      abi.encode(
+ *          uint128[] breakpoints,
+ *          uint32[] marginalBpsX1e4,
+ *          uint32 staleAfterSeconds,
+ *          uint32[] staleMarginalSurchargeBpsX1e4
+ *      ).
  */
 library PiecewiseFeeQuoteData {
     function encode(
         uint128[] memory breakpoints,
-        uint32[] memory marginalBpsX1e4
+        uint32[] memory marginalBpsX1e4,
+        uint32 staleAfterSeconds,
+        uint32[] memory staleMarginalSurchargeBpsX1e4
     ) internal pure returns (bytes memory) {
-        return abi.encode(breakpoints, marginalBpsX1e4);
+        return
+            abi.encode(
+                breakpoints,
+                marginalBpsX1e4,
+                staleAfterSeconds,
+                staleMarginalSurchargeBpsX1e4
+            );
     }
 
     function decode(
@@ -43,31 +54,38 @@ library PiecewiseFeeQuoteData {
     )
         internal
         pure
-        returns (uint128[] memory breakpoints, uint32[] memory marginalBpsX1e4)
+        returns (
+            uint128[] memory breakpoints,
+            uint32[] memory marginalBpsX1e4,
+            uint32 staleAfterSeconds,
+            uint32[] memory staleMarginalSurchargeBpsX1e4
+        )
     {
-        return abi.decode(data, (uint128[], uint32[]));
+        return abi.decode(data, (uint128[], uint32[], uint32, uint32[]));
     }
 }
 
 /**
  * @title OffchainQuotedPiecewiseLinearFee
- * @notice Signed marginal standing curves with linear transient quotes and an
- *         immutable LinearFee fallback.
+ * @notice Signed marginal standing curves with age-based per-band surcharges,
+ *         linear transient quotes, and a signer-mutable permanent fallback.
  * @dev Resolution cascade:
  *      transient -> (destination, recipient) -> (destination, *) ->
- *      (*, recipient) -> immutable LinearFee fallback.
+ *      (*, recipient) -> permanent fallback.
  *
  *      Transient quote data reuses OffchainQuotedLinearFee's packed
- *      abi.encodePacked(uint256 maxFee, uint256 halfAmount) format. Standing
- *      quote data uses PiecewiseFeeQuoteData.
+ *      abi.encodePacked(uint256 maxFee, uint256 halfAmount) format.
  *
  *      Curve submission is O(number of bands): it validates the curve and
- *      precomputes cumulative weighted fees. Transfer quoting uses eight
- *      unrolled binary-lifting probes and never loops over active bands.
+ *      precomputes fresh and stale cumulative weighted fees. Transfer quoting
+ *      uses eight unrolled binary-lifting probes and never loops over bands.
  */
 // Domain keys are enumerated explicitly through _domainIds.
 // solhint-disable-next-line hyperlane/enumerable-domain-mapping
-contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
+contract OffchainQuotedPiecewiseLinearFee is
+    AbstractOffchainQuoter,
+    TokenFeeBase
+{
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using EnumerableSet for EnumerableSet.UintSet;
     using TransientStorage for bytes32;
@@ -81,6 +99,11 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
     uint256 public constant BPS_DENOMINATOR = 100_000_000;
     uint32 public constant MAX_MARGINAL_BPS_X1E4 = 100_000_000;
     uint16 public constant MAX_SUPPORTED_BANDS = 256;
+
+    bytes32 public constant SIGNED_FALLBACK_CURVE_TYPEHASH =
+        keccak256(
+            "SignedFallbackCurve(bytes data,uint48 issuedAt,address submitter)"
+        );
 
     bytes32 private constant TRANSIENT_QUOTED_SLOT =
         keccak256("OffchainQuotedPiecewiseLinearFee.quoted");
@@ -97,19 +120,45 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
 
     // ============ Structs ============
 
+    struct SignedFallbackCurve {
+        bytes data;
+        uint48 issuedAt;
+        address submitter;
+    }
+
     struct StoredCurve {
         uint128[] breakpoints;
         uint32[] marginalBpsX1e4;
+        uint32[] staleMarginalBpsX1e4;
         uint256[] prefixWeighted;
+        uint256[] stalePrefixWeighted;
+        uint32 staleAfterSeconds;
         uint48 issuedAt;
         uint48 expiry;
+        bytes32 curveHash;
     }
 
     struct CurveQuote {
         uint128[] breakpoints;
         uint32[] marginalBpsX1e4;
+        uint32[] staleMarginalSurchargeBpsX1e4;
+        uint32 staleAfterSeconds;
         uint48 issuedAt;
         uint48 expiry;
+    }
+
+    struct StoredFallbackCurve {
+        uint128[] breakpoints;
+        uint32[] marginalBpsX1e4;
+        uint256[] prefixWeighted;
+        uint48 issuedAt;
+        bytes32 curveHash;
+    }
+
+    struct FallbackCurve {
+        uint128[] breakpoints;
+        uint32[] marginalBpsX1e4;
+        uint48 issuedAt;
     }
 
     struct QuoteEntry {
@@ -123,6 +172,7 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
 
     mapping(uint32 destination => mapping(bytes32 recipient => StoredCurve))
         private _quotes;
+    StoredFallbackCurve private _fallbackCurve;
     EnumerableSet.UintSet private _domainIds;
     mapping(uint32 destination => EnumerableSet.Bytes32Set recipients)
         private _recipients;
@@ -131,21 +181,42 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
 
     error InvalidMaxBands();
     error InvalidCurve();
+    error ConflictingQuote();
+
+    // ============ Events ============
+
+    event FallbackCurveSubmitted(
+        uint48 indexed issuedAt,
+        bytes32 indexed curveHash
+    );
 
     // ============ Constructor ============
 
     constructor(
         address _quoteSigner,
         address _feeToken,
-        uint256 _fallbackMaxFee,
-        uint256 _fallbackHalfAmount,
+        uint128[] memory _fallbackBreakpoints,
+        uint32[] memory _fallbackMarginalBpsX1e4,
         uint16 _maxBands,
         address _owner
-    ) LinearFee(_feeToken, _fallbackMaxFee, _fallbackHalfAmount, _owner) {
+    ) TokenFeeBase(_feeToken, _owner) {
         if (_maxBands == 0 || _maxBands > MAX_SUPPORTED_BANDS) {
             revert InvalidMaxBands();
         }
         maxBands = _maxBands;
+
+        uint256[] memory prefixes = _validateAndBuildPrefixes(
+            _fallbackBreakpoints,
+            _fallbackMarginalBpsX1e4,
+            true
+        );
+        _fallbackCurve.breakpoints = _fallbackBreakpoints;
+        _fallbackCurve.marginalBpsX1e4 = _fallbackMarginalBpsX1e4;
+        _fallbackCurve.prefixWeighted = prefixes;
+        _fallbackCurve.curveHash = keccak256(
+            abi.encode(_fallbackBreakpoints, _fallbackMarginalBpsX1e4)
+        );
+
         _addQuoteSigner(_quoteSigner);
     }
 
@@ -173,7 +244,7 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         if (_matchesTransient(_destination, _recipient, _amount)) {
             return
                 _singleQuote(
-                    _computeLinearFee(
+                    CappedLinearFeeMath.compute(
                         TRANSIENT_MAX_FEE_SLOT.loadUint256(),
                         TRANSIENT_HALF_AMOUNT_SLOT.loadUint256(),
                         _amount
@@ -199,7 +270,60 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         );
         if (found) return _singleQuote(fee);
 
-        return _singleQuote(_computeLinearFee(maxFee, halfAmount, _amount));
+        return
+            _singleQuote(
+                _computeCurveFee(
+                    _fallbackCurve.breakpoints,
+                    _fallbackCurve.marginalBpsX1e4,
+                    _fallbackCurve.prefixWeighted,
+                    _amount
+                )
+            );
+    }
+
+    // ============ Fallback Submission ============
+
+    function submitFallbackCurve(
+        SignedFallbackCurve calldata update,
+        bytes calldata signature
+    ) external {
+        if (update.submitter == address(0) || update.submitter != msg.sender) {
+            revert InvalidSubmitter();
+        }
+        if (update.issuedAt > uint48(block.timestamp)) revert InvalidQuote();
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SIGNED_FALLBACK_CURVE_TYPEHASH,
+                keccak256(update.data),
+                update.issuedAt,
+                update.submitter
+            )
+        );
+        _verifyQuoteSigner(structHash, signature);
+
+        bytes32 curveHash = keccak256(update.data);
+        if (update.issuedAt < _fallbackCurve.issuedAt) revert StaleQuote();
+        if (update.issuedAt == _fallbackCurve.issuedAt) {
+            if (curveHash == _fallbackCurve.curveHash) return;
+            revert ConflictingQuote();
+        }
+
+        (uint128[] memory breakpoints, uint32[] memory marginalBpsX1e4) = abi
+            .decode(update.data, (uint128[], uint32[]));
+        uint256[] memory prefixes = _validateAndBuildPrefixes(
+            breakpoints,
+            marginalBpsX1e4,
+            true
+        );
+
+        _fallbackCurve.breakpoints = breakpoints;
+        _fallbackCurve.marginalBpsX1e4 = marginalBpsX1e4;
+        _fallbackCurve.prefixWeighted = prefixes;
+        _fallbackCurve.issuedAt = update.issuedAt;
+        _fallbackCurve.curveHash = curveHash;
+
+        emit FallbackCurveSubmitted(update.issuedAt, curveHash);
     }
 
     // ============ Inspection ============
@@ -207,14 +331,31 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
     function getCurve(
         uint32 destination,
         bytes32 recipient
-    ) public view returns (CurveQuote memory) {
+    ) public view returns (CurveQuote memory result) {
         StoredCurve storage stored = _quotes[destination][recipient];
+        uint256 length = stored.marginalBpsX1e4.length;
+        uint32[] memory surcharges = new uint32[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            surcharges[i] =
+                stored.staleMarginalBpsX1e4[i] -
+                stored.marginalBpsX1e4[i];
+        }
+        result = CurveQuote({
+            breakpoints: stored.breakpoints,
+            marginalBpsX1e4: stored.marginalBpsX1e4,
+            staleMarginalSurchargeBpsX1e4: surcharges,
+            staleAfterSeconds: stored.staleAfterSeconds,
+            issuedAt: stored.issuedAt,
+            expiry: stored.expiry
+        });
+    }
+
+    function getFallbackCurve() external view returns (FallbackCurve memory) {
         return
-            CurveQuote({
-                breakpoints: stored.breakpoints,
-                marginalBpsX1e4: stored.marginalBpsX1e4,
-                issuedAt: stored.issuedAt,
-                expiry: stored.expiry
+            FallbackCurve({
+                breakpoints: _fallbackCurve.breakpoints,
+                marginalBpsX1e4: _fallbackCurve.marginalBpsX1e4,
+                issuedAt: _fallbackCurve.issuedAt
             });
     }
 
@@ -273,24 +414,50 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         ) = FeeQuoteContext.decode(sq.context);
         if (amount != WILDCARD_AMOUNT) revert InvalidCurve();
 
+        bytes32 curveHash = keccak256(
+            abi.encode(keccak256(sq.data), sq.expiry)
+        );
         StoredCurve storage existing = _quotes[destination][recipient];
         if (sq.issuedAt < existing.issuedAt) revert StaleQuote();
-        if (sq.issuedAt == existing.issuedAt) return false;
+        if (sq.issuedAt == existing.issuedAt) {
+            if (curveHash == existing.curveHash) return false;
+            revert ConflictingQuote();
+        }
 
         (
             uint128[] memory breakpoints,
-            uint32[] memory marginalBpsX1e4
+            uint32[] memory marginalBpsX1e4,
+            uint32 staleAfterSeconds,
+            uint32[] memory staleSurcharges
         ) = PiecewiseFeeQuoteData.decode(sq.data);
-        uint256[] memory prefixWeighted = _validateAndBuildPrefixes(
+        if (
+            staleAfterSeconds == 0 ||
+            uint256(sq.issuedAt) + staleAfterSeconds > sq.expiry
+        ) revert InvalidCurve();
+
+        uint256[] memory prefixes = _validateAndBuildPrefixes(
             breakpoints,
-            marginalBpsX1e4
+            marginalBpsX1e4,
+            false
         );
+        (
+            uint32[] memory staleRates,
+            uint256[] memory stalePrefixes
+        ) = _validateAndBuildStaleCurve(
+                breakpoints,
+                marginalBpsX1e4,
+                staleSurcharges
+            );
 
         existing.breakpoints = breakpoints;
         existing.marginalBpsX1e4 = marginalBpsX1e4;
-        existing.prefixWeighted = prefixWeighted;
+        existing.staleMarginalBpsX1e4 = staleRates;
+        existing.prefixWeighted = prefixes;
+        existing.stalePrefixWeighted = stalePrefixes;
+        existing.staleAfterSeconds = staleAfterSeconds;
         existing.issuedAt = sq.issuedAt;
         existing.expiry = sq.expiry;
+        existing.curveHash = curveHash;
 
         _domainIds.add(destination);
         _recipients[destination].add(recipient);
@@ -301,13 +468,15 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
 
     function _validateAndBuildPrefixes(
         uint128[] memory breakpoints,
-        uint32[] memory marginalBpsX1e4
+        uint32[] memory marginalBpsX1e4,
+        bool requirePositive
     ) internal view returns (uint256[] memory prefixWeighted) {
         uint256 bandCount = marginalBpsX1e4.length;
         if (
             bandCount == 0 ||
             bandCount > maxBands ||
-            breakpoints.length + 1 != bandCount
+            breakpoints.length + 1 != bandCount ||
+            (requirePositive && marginalBpsX1e4[bandCount - 1] == 0)
         ) revert InvalidCurve();
 
         prefixWeighted = new uint256[](bandCount);
@@ -332,6 +501,37 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
             }
             previousRate = rate;
         }
+    }
+
+    function _validateAndBuildStaleCurve(
+        uint128[] memory breakpoints,
+        uint32[] memory marginalBpsX1e4,
+        uint32[] memory surcharges
+    )
+        internal
+        view
+        returns (uint32[] memory staleRates, uint256[] memory stalePrefixes)
+    {
+        uint256 bandCount = marginalBpsX1e4.length;
+        if (surcharges.length != bandCount) revert InvalidCurve();
+
+        staleRates = new uint32[](bandCount);
+        uint32 previousSurcharge;
+        for (uint256 i = 0; i < bandCount; ++i) {
+            uint32 surcharge = surcharges[i];
+            uint256 staleRate = uint256(marginalBpsX1e4[i]) + surcharge;
+            if (
+                (i > 0 && surcharge < previousSurcharge) ||
+                staleRate > MAX_MARGINAL_BPS_X1E4
+            ) revert InvalidCurve();
+            staleRates[i] = uint32(staleRate);
+            previousSurcharge = surcharge;
+        }
+        stalePrefixes = _validateAndBuildPrefixes(
+            breakpoints,
+            staleRates,
+            false
+        );
     }
 
     // ============ Curve Resolution ============
@@ -366,43 +566,60 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         if (curve.expiry == 0 || uint48(block.timestamp) > curve.expiry) {
             return (false, 0);
         }
-        return (true, _computeStoredFee(curve, amount));
+        bool stale = block.timestamp >=
+            uint256(curve.issuedAt) + curve.staleAfterSeconds;
+        return
+            stale
+                ? (
+                    true,
+                    _computeCurveFee(
+                        curve.breakpoints,
+                        curve.staleMarginalBpsX1e4,
+                        curve.stalePrefixWeighted,
+                        amount
+                    )
+                )
+                : (
+                    true,
+                    _computeCurveFee(
+                        curve.breakpoints,
+                        curve.marginalBpsX1e4,
+                        curve.prefixWeighted,
+                        amount
+                    )
+                );
     }
 
-    function _computeStoredFee(
-        StoredCurve storage curve,
+    function _computeCurveFee(
+        uint128[] storage breakpoints,
+        uint32[] storage rates,
+        uint256[] storage prefixes,
         uint256 amount
     ) private view returns (uint256) {
         uint256 band;
-        band = _advanceStored(curve, amount, band, 128);
-        band = _advanceStored(curve, amount, band, 64);
-        band = _advanceStored(curve, amount, band, 32);
-        band = _advanceStored(curve, amount, band, 16);
-        band = _advanceStored(curve, amount, band, 8);
-        band = _advanceStored(curve, amount, band, 4);
-        band = _advanceStored(curve, amount, band, 2);
-        band = _advanceStored(curve, amount, band, 1);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 128);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 64);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 32);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 16);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 8);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 4);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 2);
+        band = _advanceStored(breakpoints, rates.length, amount, band, 1);
 
-        uint256 start = band == 0 ? 0 : curve.breakpoints[band - 1];
-        return
-            _computeMarginalFee(
-                curve.prefixWeighted[band],
-                amount - start,
-                curve.marginalBpsX1e4[band]
-            );
+        uint256 start = band == 0 ? 0 : breakpoints[band - 1];
+        return _computeMarginalFee(prefixes[band], amount - start, rates[band]);
     }
 
     function _advanceStored(
-        StoredCurve storage curve,
+        uint128[] storage breakpoints,
+        uint256 bandCount,
         uint256 amount,
         uint256 band,
         uint256 step
     ) private view returns (uint256) {
         uint256 candidate = band + step;
-        if (
-            candidate < curve.marginalBpsX1e4.length &&
-            amount > curve.breakpoints[candidate - 1]
-        ) return candidate;
+        if (candidate < bandCount && amount > breakpoints[candidate - 1])
+            return candidate;
         return band;
     }
 

--- a/solidity/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol
+++ b/solidity/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol
@@ -21,7 +21,7 @@ import {SignedQuote} from "../../interfaces/IOffchainQuoter.sol";
 import {TransientStorage} from "../../libs/TransientStorage.sol";
 import {Quote} from "../../interfaces/ITokenBridge.sol";
 import {FeeType} from "./BaseFee.sol";
-import {FeeQuoteContext} from "./OffchainQuotedLinearFee.sol";
+import {FeeQuoteContext, FeeQuoteData} from "./OffchainQuotedLinearFee.sol";
 import {LinearFee} from "./LinearFee.sol";
 
 /**
@@ -51,15 +51,22 @@ library PiecewiseFeeQuoteData {
 
 /**
  * @title OffchainQuotedPiecewiseLinearFee
- * @notice Signed marginal fee curves with an immutable LinearFee fallback.
+ * @notice Signed marginal standing curves with linear transient quotes and an
+ *         immutable LinearFee fallback.
  * @dev Resolution cascade:
  *      transient -> (destination, recipient) -> (destination, *) ->
  *      (*, recipient) -> immutable LinearFee fallback.
+ *
+ *      Transient quote data reuses OffchainQuotedLinearFee's packed
+ *      abi.encodePacked(uint256 maxFee, uint256 halfAmount) format. Standing
+ *      quote data uses PiecewiseFeeQuoteData.
  *
  *      Curve submission is O(number of bands): it validates the curve and
  *      precomputes cumulative weighted fees. Transfer quoting uses eight
  *      unrolled binary-lifting probes and never loops over active bands.
  */
+// Domain keys are enumerated explicitly through _domainIds.
+// solhint-disable-next-line hyperlane/enumerable-domain-mapping
 contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using EnumerableSet for EnumerableSet.UintSet;
@@ -83,14 +90,10 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         keccak256("OffchainQuotedPiecewiseLinearFee.recipient");
     bytes32 private constant TRANSIENT_AMOUNT_SLOT =
         keccak256("OffchainQuotedPiecewiseLinearFee.amount");
-    bytes32 private constant TRANSIENT_BAND_COUNT_SLOT =
-        keccak256("OffchainQuotedPiecewiseLinearFee.bandCount");
-    bytes32 private constant TRANSIENT_BREAKPOINT_BASE_SLOT =
-        keccak256("OffchainQuotedPiecewiseLinearFee.breakpoints");
-    bytes32 private constant TRANSIENT_RATE_BASE_SLOT =
-        keccak256("OffchainQuotedPiecewiseLinearFee.rates");
-    bytes32 private constant TRANSIENT_PREFIX_BASE_SLOT =
-        keccak256("OffchainQuotedPiecewiseLinearFee.prefixWeighted");
+    bytes32 private constant TRANSIENT_MAX_FEE_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.maxFee");
+    bytes32 private constant TRANSIENT_HALF_AMOUNT_SLOT =
+        keccak256("OffchainQuotedPiecewiseLinearFee.halfAmount");
 
     // ============ Structs ============
 
@@ -168,7 +171,14 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         uint256 _amount
     ) external view override returns (Quote[] memory) {
         if (_matchesTransient(_destination, _recipient, _amount)) {
-            return _singleQuote(_computeTransientFee(_amount));
+            return
+                _singleQuote(
+                    _computeLinearFee(
+                        TRANSIENT_MAX_FEE_SLOT.loadUint256(),
+                        TRANSIENT_HALF_AMOUNT_SLOT.loadUint256(),
+                        _amount
+                    )
+                );
         }
 
         (bool found, uint256 fee) = _resolveStored(
@@ -243,34 +253,14 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
             bytes32 recipient,
             uint256 amount
         ) = FeeQuoteContext.decode(sq.context);
-        (
-            uint128[] memory breakpoints,
-            uint32[] memory marginalBpsX1e4
-        ) = PiecewiseFeeQuoteData.decode(sq.data);
-        uint256[] memory prefixWeighted = _validateAndBuildPrefixes(
-            breakpoints,
-            marginalBpsX1e4
-        );
+        (uint256 maxFee_, uint256 halfAmount_) = FeeQuoteData.decode(sq.data);
 
         TRANSIENT_QUOTED_SLOT.set();
         TRANSIENT_DESTINATION_SLOT.store(destination);
         TRANSIENT_RECIPIENT_SLOT.store(recipient);
         TRANSIENT_AMOUNT_SLOT.store(amount);
-        TRANSIENT_BAND_COUNT_SLOT.store(marginalBpsX1e4.length);
-
-        for (uint256 i = 0; i < marginalBpsX1e4.length; ++i) {
-            _transientSlot(TRANSIENT_RATE_BASE_SLOT, i).store(
-                marginalBpsX1e4[i]
-            );
-            _transientSlot(TRANSIENT_PREFIX_BASE_SLOT, i).store(
-                prefixWeighted[i]
-            );
-            if (i < breakpoints.length) {
-                _transientSlot(TRANSIENT_BREAKPOINT_BASE_SLOT, i).store(
-                    breakpoints[i]
-                );
-            }
-        }
+        TRANSIENT_MAX_FEE_SLOT.store(maxFee_);
+        TRANSIENT_HALF_AMOUNT_SLOT.store(halfAmount_);
     }
 
     function _storeStanding(
@@ -416,48 +406,6 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
         return band;
     }
 
-    function _computeTransientFee(
-        uint256 amount
-    ) private view returns (uint256) {
-        uint256 bandCount = TRANSIENT_BAND_COUNT_SLOT.loadUint256();
-        uint256 band;
-        band = _advanceTransient(amount, bandCount, band, 128);
-        band = _advanceTransient(amount, bandCount, band, 64);
-        band = _advanceTransient(amount, bandCount, band, 32);
-        band = _advanceTransient(amount, bandCount, band, 16);
-        band = _advanceTransient(amount, bandCount, band, 8);
-        band = _advanceTransient(amount, bandCount, band, 4);
-        band = _advanceTransient(amount, bandCount, band, 2);
-        band = _advanceTransient(amount, bandCount, band, 1);
-
-        uint256 start = band == 0
-            ? 0
-            : _transientSlot(TRANSIENT_BREAKPOINT_BASE_SLOT, band - 1)
-                .loadUint256();
-        return
-            _computeMarginalFee(
-                _transientSlot(TRANSIENT_PREFIX_BASE_SLOT, band).loadUint256(),
-                amount - start,
-                _transientSlot(TRANSIENT_RATE_BASE_SLOT, band).loadUint32()
-            );
-    }
-
-    function _advanceTransient(
-        uint256 amount,
-        uint256 bandCount,
-        uint256 band,
-        uint256 step
-    ) private view returns (uint256) {
-        uint256 candidate = band + step;
-        if (
-            candidate < bandCount &&
-            amount >
-            _transientSlot(TRANSIENT_BREAKPOINT_BASE_SLOT, candidate - 1)
-                .loadUint256()
-        ) return candidate;
-        return band;
-    }
-
     function _computeMarginalFee(
         uint256 prefixWeighted,
         uint256 amountInBand,
@@ -480,13 +428,6 @@ contract OffchainQuotedPiecewiseLinearFee is AbstractOffchainQuoter, LinearFee {
             marginalQuotient +
             (prefixRemainder + marginalRemainder) /
             BPS_DENOMINATOR;
-    }
-
-    function _transientSlot(
-        bytes32 base,
-        uint256 index
-    ) private pure returns (bytes32) {
-        return keccak256(abi.encode(base, index));
     }
 
     function _singleQuote(

--- a/solidity/test/token/CrossCollateralRouter.t.sol
+++ b/solidity/test/token/CrossCollateralRouter.t.sol
@@ -41,6 +41,7 @@ import {HypERC20Collateral} from "contracts/token/HypERC20Collateral.sol";
 import {TokenMessage} from "contracts/token/libs/TokenMessage.sol";
 import {GasRouter} from "contracts/client/GasRouter.sol";
 import {LinearFee} from "contracts/token/fees/LinearFee.sol";
+import {OffchainQuotedPiecewiseLinearFee} from "contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol";
 import {MockITokenBridge} from "./MovableCollateralRouter.t.sol";
 
 /// @notice Mock fee contract: fixed percentage fee.
@@ -155,6 +156,10 @@ contract CrossCollateralRouterTest is Test {
     uint256 internal constant USDT_SCALE_NUM = 1;
     uint256 internal constant USDT_SCALE_DEN = 1;
     uint256 internal constant DEFAULT_FEE_BPS = 5; // 0.05%
+    uint256 internal constant PIECEWISE_SIGNER_PK = 0xB0B;
+    uint32 internal constant PIECEWISE_FRESH_RATE = 20_000; // 2 bps
+    uint32 internal constant PIECEWISE_STALE_SURCHARGE = 30_000; // +3 bps
+    uint32 internal constant PIECEWISE_FALLBACK_RATE = 80_000; // 8 bps
 
     address internal constant ALICE = address(0x1);
     address internal constant BOB = address(0x2);
@@ -1443,6 +1448,241 @@ contract CrossCollateralRouterTest is Test {
         assertEq(quotedFee, 10e6, "quote uses primary router fee");
         assertEq(actualFee, 10e6, "charge uses primary router fee");
         assertEq(quotedFee, actualFee, "quote matches actual charge");
+    }
+
+    function test_routingFee_piecewiseLeafIntegration() public {
+        LinearFee defaultFee5bps = new LinearFee(
+            address(originUSDC),
+            10e6,
+            10000e6,
+            address(this)
+        );
+        LinearFee primaryRouterFee10bps = new LinearFee(
+            address(originUSDC),
+            20e6,
+            10000e6,
+            address(this)
+        );
+        OffchainQuotedPiecewiseLinearFee piecewiseFee = _deployPiecewiseFee();
+        CrossCollateralRoutingFee routingFee = new CrossCollateralRoutingFee(
+            address(this)
+        );
+        _configurePiecewiseRouting(
+            routingFee,
+            defaultFee5bps,
+            primaryRouterFee10bps,
+            piecewiseFee
+        );
+        usdcRouterA.setFeeRecipient(address(routingFee));
+
+        assertEq(
+            routingFee.feeContracts(
+                DESTINATION,
+                address(usdtRouterB).addressToBytes32()
+            ),
+            address(piecewiseFee),
+            "explicit target uses piecewise leaf"
+        );
+        assertEq(
+            usdcRouterA.feeRecipient(),
+            address(routingFee),
+            "routing root remains fee recipient"
+        );
+
+        uint256 amount = 10000e6;
+        _assertPrimaryQuoteAndCharge(routingFee, amount, 10e6);
+
+        bytes32 piecewiseTarget = address(usdtRouterB).addressToBytes32();
+        uint48 issuedAt = uint48(block.timestamp);
+        _submitPiecewiseStandingCurve(piecewiseFee, issuedAt, issuedAt + 20);
+
+        _assertTargetQuoteAndCharge(routingFee, piecewiseTarget, amount, 2e6);
+
+        vm.warp(issuedAt + 10);
+        _assertTargetQuoteAndCharge(routingFee, piecewiseTarget, amount, 5e6);
+
+        vm.warp(issuedAt + 21);
+        _assertTargetQuoteAndCharge(routingFee, piecewiseTarget, amount, 8e6);
+
+        _removeRouterFee(routingFee, piecewiseTarget);
+        assertEq(
+            routingFee.feeContracts(DESTINATION, piecewiseTarget),
+            address(0)
+        );
+        _assertTargetQuoteAndCharge(routingFee, piecewiseTarget, amount, 5e6);
+
+        assertEq(usdcRouterA.feeRecipient(), address(routingFee));
+        assertEq(originUSDC.balanceOf(address(piecewiseFee)), 0);
+    }
+
+    function _deployPiecewiseFee()
+        internal
+        returns (OffchainQuotedPiecewiseLinearFee)
+    {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory fallbackRates = new uint32[](1);
+        fallbackRates[0] = PIECEWISE_FALLBACK_RATE;
+        return
+            new OffchainQuotedPiecewiseLinearFee(
+                vm.addr(PIECEWISE_SIGNER_PK),
+                address(originUSDC),
+                breakpoints,
+                fallbackRates,
+                1,
+                address(this)
+            );
+    }
+
+    function _configurePiecewiseRouting(
+        CrossCollateralRoutingFee routingFee,
+        LinearFee defaultFee,
+        LinearFee primaryRouterFee,
+        OffchainQuotedPiecewiseLinearFee piecewiseFee
+    ) internal {
+        uint32[] memory destinations = new uint32[](3);
+        bytes32[] memory targetRouters = new bytes32[](3);
+        address[] memory feeContracts = new address[](3);
+        for (uint256 i = 0; i < destinations.length; ++i) {
+            destinations[i] = DESTINATION;
+        }
+        targetRouters[0] = routingFee.DEFAULT_ROUTER();
+        targetRouters[1] = address(usdcRouterB).addressToBytes32();
+        targetRouters[2] = address(usdtRouterB).addressToBytes32();
+        feeContracts[0] = address(defaultFee);
+        feeContracts[1] = address(primaryRouterFee);
+        feeContracts[2] = address(piecewiseFee);
+        routingFee.setCrossCollateralRouterFeeContracts(
+            destinations,
+            targetRouters,
+            feeContracts
+        );
+    }
+
+    function _submitPiecewiseStandingCurve(
+        OffchainQuotedPiecewiseLinearFee piecewiseFee,
+        uint48 issuedAt,
+        uint48 expiry
+    ) internal {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory freshRates = new uint32[](1);
+        freshRates[0] = PIECEWISE_FRESH_RATE;
+        uint32[] memory staleSurcharges = new uint32[](1);
+        staleSurcharges[0] = PIECEWISE_STALE_SURCHARGE;
+        SignedQuote memory sq = SignedQuote({
+            context: FeeQuoteContext.encode(
+                DESTINATION,
+                bytes32(type(uint256).max),
+                type(uint256).max
+            ),
+            data: abi.encode(
+                breakpoints,
+                freshRates,
+                uint32(10),
+                staleSurcharges
+            ),
+            issuedAt: issuedAt,
+            expiry: expiry,
+            salt: bytes32(0),
+            submitter: address(this)
+        });
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                piecewiseFee.SIGNED_QUOTE_TYPEHASH(),
+                keccak256(sq.context),
+                keccak256(sq.data),
+                sq.issuedAt,
+                sq.expiry,
+                sq.salt,
+                sq.submitter
+            )
+        );
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256("OffchainQuoter"),
+                keccak256("1"),
+                block.chainid,
+                address(piecewiseFee)
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            PIECEWISE_SIGNER_PK,
+            ECDSA.toTypedDataHash(domainSeparator, structHash)
+        );
+        piecewiseFee.submitQuote(sq, abi.encodePacked(r, s, v));
+    }
+
+    function _assertPrimaryQuoteAndCharge(
+        CrossCollateralRoutingFee routingFee,
+        uint256 amount,
+        uint256 expectedFee
+    ) internal {
+        Quote[] memory quotes = usdcRouterA.quoteTransferRemote(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            amount
+        );
+        assertEq(quotes.length, 3);
+        assertEq(quotes[1].token, address(originUSDC));
+        assertEq(quotes[1].amount, amount + expectedFee);
+
+        uint256 balanceBefore = originUSDC.balanceOf(address(routingFee));
+        vm.prank(ALICE);
+        usdcRouterA.transferRemote(DESTINATION, BOB.addressToBytes32(), amount);
+        assertEq(
+            originUSDC.balanceOf(address(routingFee)) - balanceBefore,
+            expectedFee
+        );
+    }
+
+    function _assertTargetQuoteAndCharge(
+        CrossCollateralRoutingFee routingFee,
+        bytes32 targetRouter,
+        uint256 amount,
+        uint256 expectedFee
+    ) internal {
+        Quote[] memory quotes = usdcRouterA.quoteTransferRemoteTo(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            amount,
+            targetRouter
+        );
+        assertEq(quotes.length, 3);
+        assertEq(quotes[1].token, address(originUSDC));
+        assertEq(quotes[1].amount, amount + expectedFee);
+
+        uint256 balanceBefore = originUSDC.balanceOf(address(routingFee));
+        vm.prank(ALICE);
+        usdcRouterA.transferRemoteTo(
+            DESTINATION,
+            BOB.addressToBytes32(),
+            amount,
+            targetRouter
+        );
+        assertEq(
+            originUSDC.balanceOf(address(routingFee)) - balanceBefore,
+            expectedFee
+        );
+    }
+
+    function _removeRouterFee(
+        CrossCollateralRoutingFee routingFee,
+        bytes32 targetRouter
+    ) internal {
+        uint32[] memory destinations = new uint32[](1);
+        bytes32[] memory targetRouters = new bytes32[](1);
+        address[] memory feeContracts = new address[](1);
+        destinations[0] = DESTINATION;
+        targetRouters[0] = targetRouter;
+        feeContracts[0] = address(0);
+        routingFee.setCrossCollateralRouterFeeContracts(
+            destinations,
+            targetRouters,
+            feeContracts
+        );
     }
 
     function test_quoteTransferRemote_usesScaledOutboundAmountForHookFee()

--- a/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
@@ -892,14 +892,25 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
     }
 
     function test_replacesOnlyWithNewerIssuedAt() public {
+        // Use fixed timestamps so this ordering test is independent of the
+        // runner-provided initial block timestamp and coverage instrumentation.
+        vm.warp(100);
         uint128[] memory breakpoints = new uint128[](0);
         uint32[] memory oneBp = new uint32[](1);
         oneBp[0] = 10_000;
-        _submitStanding(DESTINATION, RECIPIENT, breakpoints, oneBp);
+        _submitCurve(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            oneBp,
+            10,
+            10_000
+        );
 
         uint32[] memory twoBps = new uint32[](1);
         twoBps[0] = 20_000;
-        uint48 now_ = uint48(block.timestamp);
         vm.expectRevert(AbstractOffchainQuoter.StaleQuote.selector);
         _submitCurve(
             quotedFee,
@@ -908,12 +919,10 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
             WILDCARD_AMOUNT,
             breakpoints,
             twoBps,
-            now_ - 1,
-            now_ + 1 days
+            9,
+            10_000
         );
 
-        vm.warp(block.timestamp + 1);
-        uint48 later = uint48(block.timestamp);
         _submitCurve(
             quotedFee,
             DESTINATION,
@@ -921,8 +930,8 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
             WILDCARD_AMOUNT,
             breakpoints,
             twoBps,
-            later,
-            later + 1 days
+            11,
+            10_000
         );
         assertEq(
             _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),

--- a/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
@@ -1,0 +1,598 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import {AbstractOffchainQuoter} from "../../contracts/libs/AbstractOffchainQuoter.sol";
+import {SignedQuote} from "../../contracts/interfaces/IOffchainQuoter.sol";
+import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
+import {FeeType} from "../../contracts/token/fees/BaseFee.sol";
+import {OffchainQuotedPiecewiseLinearFee} from "../../contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol";
+
+contract OffchainQuotedPiecewiseLinearFeeTest is Test {
+    uint256 internal constant SIGNER_KEY = 0xA11CE;
+    address internal constant FEE_TOKEN = address(0xFEE);
+    uint32 internal constant DESTINATION = 42;
+    bytes32 internal constant RECIPIENT = bytes32(uint256(0xBEEF));
+    bytes32 internal constant WILDCARD_RECIPIENT = bytes32(type(uint256).max);
+    uint256 internal constant WILDCARD_AMOUNT = type(uint256).max;
+
+    uint256 internal constant FALLBACK_MAX_FEE = 0.02 ether;
+    uint256 internal constant FALLBACK_HALF_AMOUNT = 1 ether;
+    uint256 internal constant DENOMINATOR = 100_000_000;
+    bytes32 internal constant SIGNED_QUOTE_TYPEHASH =
+        keccak256(
+            "SignedQuote(bytes context,bytes data,uint48 issuedAt,uint48 expiry,bytes32 salt,address submitter)"
+        );
+
+    address internal signer;
+    OffchainQuotedPiecewiseLinearFee internal quotedFee;
+
+    function setUp() public {
+        signer = vm.addr(SIGNER_KEY);
+        quotedFee = _deploy(4);
+    }
+
+    function _deploy(
+        uint16 maxBands
+    ) internal returns (OffchainQuotedPiecewiseLinearFee) {
+        return
+            new OffchainQuotedPiecewiseLinearFee(
+                signer,
+                FEE_TOKEN,
+                FALLBACK_MAX_FEE,
+                FALLBACK_HALF_AMOUNT,
+                maxBands,
+                signer
+            );
+    }
+
+    function _domainSeparator(
+        OffchainQuotedPiecewiseLinearFee fee
+    ) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    ),
+                    keccak256("OffchainQuoter"),
+                    keccak256("1"),
+                    block.chainid,
+                    address(fee)
+                )
+            );
+    }
+
+    function _signQuote(
+        OffchainQuotedPiecewiseLinearFee fee,
+        SignedQuote memory signedQuote
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SIGNED_QUOTE_TYPEHASH,
+                keccak256(signedQuote.context),
+                keccak256(signedQuote.data),
+                signedQuote.issuedAt,
+                signedQuote.expiry,
+                signedQuote.salt,
+                signedQuote.submitter
+            )
+        );
+        bytes32 digest = ECDSA.toTypedDataHash(
+            _domainSeparator(fee),
+            structHash
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(SIGNER_KEY, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _context(
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(destination, recipient, amount);
+    }
+
+    function _data(
+        uint128[] memory breakpoints,
+        uint32[] memory rates
+    ) internal pure returns (bytes memory) {
+        return abi.encode(breakpoints, rates);
+    }
+
+    function _submit(
+        OffchainQuotedPiecewiseLinearFee fee,
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount,
+        uint128[] memory breakpoints,
+        uint32[] memory rates,
+        uint48 issuedAt,
+        uint48 expiry
+    ) internal {
+        SignedQuote memory signedQuote = SignedQuote({
+            context: _context(destination, recipient, amount),
+            data: _data(breakpoints, rates),
+            issuedAt: issuedAt,
+            expiry: expiry,
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        fee.submitQuote(signedQuote, _signQuote(fee, signedQuote));
+    }
+
+    function _submitStanding(
+        uint32 destination,
+        bytes32 recipient,
+        uint128[] memory breakpoints,
+        uint32[] memory rates
+    ) internal {
+        uint48 now_ = uint48(block.timestamp);
+        _submit(
+            quotedFee,
+            destination,
+            recipient,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 1 days
+        );
+    }
+
+    function _quote(
+        OffchainQuotedPiecewiseLinearFee fee,
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount
+    ) internal view returns (uint256) {
+        Quote[] memory quotes = fee.quoteTransferRemote(
+            destination,
+            recipient,
+            amount
+        );
+        assertEq(quotes.length, 1);
+        assertEq(quotes[0].token, FEE_TOKEN);
+        return quotes[0].amount;
+    }
+
+    function _fallbackFee(uint256 amount) internal pure returns (uint256) {
+        uint256 uncapped = (amount * FALLBACK_MAX_FEE) /
+            (2 * FALLBACK_HALF_AMOUNT);
+        return uncapped > FALLBACK_MAX_FEE ? FALLBACK_MAX_FEE : uncapped;
+    }
+
+    function _exampleCurve()
+        internal
+        pure
+        returns (uint128[] memory breakpoints, uint32[] memory rates)
+    {
+        breakpoints = new uint128[](2);
+        breakpoints[0] = 100_000 ether;
+        breakpoints[1] = 250_000 ether;
+        rates = new uint32[](3);
+        rates[0] = 10_000; // 1 bp
+        rates[1] = 40_000; // 4 bps
+        rates[2] = 120_000; // 12 bps
+    }
+
+    function _referenceFee(
+        uint128[] memory breakpoints,
+        uint32[] memory rates,
+        uint256 amount
+    ) internal pure returns (uint256) {
+        uint256 weighted;
+        uint256 start;
+        for (uint256 i = 0; i < rates.length; ++i) {
+            uint256 end = i < breakpoints.length ? breakpoints[i] : amount;
+            if (amount <= start) break;
+            if (end > amount) end = amount;
+            weighted += (end - start) * rates[i];
+            if (amount <= end) break;
+            start = end;
+        }
+        return weighted / DENOMINATOR;
+    }
+
+    // ============ Constructor and type ============
+
+    function test_constructorAndFeeType() public view {
+        assertEq(quotedFee.maxBands(), 4);
+        assertEq(
+            uint8(quotedFee.feeType()),
+            uint8(FeeType.OFFCHAIN_QUOTED_PIECEWISE_LINEAR)
+        );
+    }
+
+    function test_constructorRejectsInvalidMaxBands() public {
+        vm.expectRevert(
+            OffchainQuotedPiecewiseLinearFee.InvalidMaxBands.selector
+        );
+        _deploy(0);
+
+        vm.expectRevert(
+            OffchainQuotedPiecewiseLinearFee.InvalidMaxBands.selector
+        );
+        _deploy(257);
+    }
+
+    // ============ Fee calculation ============
+
+    function test_exampleMarginalCurve() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        _submitStanding(DESTINATION, WILDCARD_RECIPIENT, breakpoints, rates);
+
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 100_000 ether),
+            10 ether
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 200_000 ether),
+            50 ether
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            130 ether
+        );
+    }
+
+    function test_breakpointContinuity() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+
+        uint256 atFirst = _quote(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            breakpoints[0]
+        );
+        uint256 afterFirst = _quote(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            uint256(breakpoints[0]) + 1
+        );
+        assertEq(atFirst, 10 ether);
+        assertEq(afterFirst, atFirst);
+
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, breakpoints[1]),
+            70 ether
+        );
+    }
+
+    function test_zeroFeeCurve() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, type(uint256).max),
+            0
+        );
+    }
+
+    function test_fullRateHandlesMaxAmount() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 100_000_000;
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, type(uint256).max),
+            type(uint256).max
+        );
+    }
+
+    function test_maximumBandCount() public {
+        OffchainQuotedPiecewiseLinearFee maxFeeContract = _deploy(256);
+        uint128[] memory breakpoints = new uint128[](255);
+        uint32[] memory rates = new uint32[](256);
+        for (uint256 i = 0; i < rates.length; ++i) {
+            rates[i] = 10_000;
+            if (i < breakpoints.length) {
+                breakpoints[i] = uint128((i + 1) * 1 ether);
+            }
+        }
+
+        uint48 now_ = uint48(block.timestamp);
+        _submit(
+            maxFeeContract,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 1 days
+        );
+        assertEq(
+            _quote(maxFeeContract, DESTINATION, RECIPIENT, 300 ether),
+            0.03 ether
+        );
+    }
+
+    function testFuzz_feeMatchesReference(uint128 amount) public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, amount),
+            _referenceFee(breakpoints, rates, amount)
+        );
+    }
+
+    // ============ Resolution ============
+
+    function test_resolutionPriorityAndFallback() public {
+        uint128[] memory noBreakpoints = new uint128[](0);
+        uint32[] memory oneBp = new uint32[](1);
+        oneBp[0] = 10_000;
+        uint32[] memory twoBps = new uint32[](1);
+        twoBps[0] = 20_000;
+
+        _submitStanding(DESTINATION, WILDCARD_RECIPIENT, noBreakpoints, oneBp);
+        vm.warp(block.timestamp + 1);
+        _submitStanding(DESTINATION, RECIPIENT, noBreakpoints, twoBps);
+
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),
+            0.0002 ether
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, bytes32(uint256(0xCAFE)), 1 ether),
+            0.0001 ether
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION + 1, RECIPIENT, 1 ether),
+            _fallbackFee(1 ether)
+        );
+    }
+
+    function test_expiredCurveUsesFallback() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+        vm.warp(block.timestamp + 1 days + 1);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),
+            _fallbackFee(1 ether)
+        );
+    }
+
+    function test_transientExactAndWildcardAmount() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        uint48 now_ = uint48(block.timestamp);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            300_000 ether,
+            breakpoints,
+            rates,
+            now_,
+            now_
+        );
+
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            130 ether
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 200_000 ether),
+            _fallbackFee(200_000 ether)
+        );
+
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 200_000 ether),
+            50 ether
+        );
+    }
+
+    function test_standingAndTransientCurvesAgree() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+        uint256 standingFee = _quote(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            300_000 ether
+        );
+
+        uint48 now_ = uint48(block.timestamp);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            standingFee
+        );
+    }
+
+    // ============ Validation and replacement ============
+
+    function test_rejectsNonWildcardStandingAmount() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        uint48 now_ = uint48(block.timestamp);
+        vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            1 ether,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 1 days
+        );
+    }
+
+    function test_rejectsMalformedCurves() public {
+        uint128[] memory noBreakpoints = new uint128[](0);
+        uint32[] memory noRates = new uint32[](0);
+        _expectInvalidCurve(noBreakpoints, noRates);
+
+        uint128[] memory oneBreakpoint = new uint128[](1);
+        oneBreakpoint[0] = 1 ether;
+        uint32[] memory oneRate = new uint32[](1);
+        oneRate[0] = 10_000;
+        _expectInvalidCurve(oneBreakpoint, oneRate);
+
+        uint128[] memory twoBreakpoints = new uint128[](2);
+        twoBreakpoints[0] = 2 ether;
+        twoBreakpoints[1] = 1 ether;
+        uint32[] memory threeRates = new uint32[](3);
+        threeRates[0] = 10_000;
+        threeRates[1] = 20_000;
+        threeRates[2] = 30_000;
+        _expectInvalidCurve(twoBreakpoints, threeRates);
+
+        twoBreakpoints[0] = 1 ether;
+        twoBreakpoints[1] = 2 ether;
+        threeRates[0] = 20_000;
+        threeRates[1] = 10_000;
+        _expectInvalidCurve(twoBreakpoints, threeRates);
+
+        threeRates[0] = 10_000;
+        threeRates[1] = 20_000;
+        threeRates[2] = 100_000_001;
+        _expectInvalidCurve(twoBreakpoints, threeRates);
+    }
+
+    function test_rejectsMoreThanConfiguredBands() public {
+        uint128[] memory breakpoints = new uint128[](4);
+        uint32[] memory rates = new uint32[](5);
+        for (uint256 i = 0; i < breakpoints.length; ++i) {
+            breakpoints[i] = uint128((i + 1) * 1 ether);
+        }
+        _expectInvalidCurve(breakpoints, rates);
+    }
+
+    function _expectInvalidCurve(
+        uint128[] memory breakpoints,
+        uint32[] memory rates
+    ) internal {
+        uint48 now_ = uint48(block.timestamp);
+        vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 1 days
+        );
+    }
+
+    function test_rejectsFutureStandingIssuedAt() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        uint48 future = uint48(block.timestamp) + 1;
+        vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            future,
+            future + 1 days
+        );
+    }
+
+    function test_replacesOnlyWithNewerIssuedAt() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory oneBp = new uint32[](1);
+        oneBp[0] = 10_000;
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, oneBp);
+
+        uint32[] memory twoBps = new uint32[](1);
+        twoBps[0] = 20_000;
+        uint48 now_ = uint48(block.timestamp);
+        vm.expectRevert(AbstractOffchainQuoter.StaleQuote.selector);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            twoBps,
+            now_ - 1,
+            now_ + 1 days
+        );
+
+        vm.warp(block.timestamp + 1);
+        uint48 later = uint48(block.timestamp);
+        _submit(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            twoBps,
+            later,
+            later + 1 days
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),
+            0.0002 ether
+        );
+    }
+
+    // ============ Inspection ============
+
+    function test_enumeratesStandingCurvesOnly() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+
+        uint32[] memory domains = quotedFee.quoteDomains();
+        assertEq(domains.length, 1);
+        assertEq(domains[0], DESTINATION);
+
+        OffchainQuotedPiecewiseLinearFee.QuoteEntry[] memory entries = quotedFee
+            .getQuotesForDomain(DESTINATION);
+        assertEq(entries.length, 1);
+        assertEq(entries[0].recipient, RECIPIENT);
+        assertEq(entries[0].quote.breakpoints.length, breakpoints.length);
+        assertEq(entries[0].quote.marginalBpsX1e4.length, rates.length);
+        for (uint256 i = 0; i < breakpoints.length; ++i) {
+            assertEq(entries[0].quote.breakpoints[i], breakpoints[i]);
+        }
+        for (uint256 i = 0; i < rates.length; ++i) {
+            assertEq(entries[0].quote.marginalBpsX1e4[i], rates[i]);
+        }
+
+        uint48 now_ = uint48(block.timestamp);
+        _submit(
+            quotedFee,
+            DESTINATION + 1,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_
+        );
+        assertEq(quotedFee.quoteDomains().length, 1);
+    }
+}

--- a/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
@@ -19,12 +19,16 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
     bytes32 internal constant WILDCARD_RECIPIENT = bytes32(type(uint256).max);
     uint256 internal constant WILDCARD_AMOUNT = type(uint256).max;
 
-    uint256 internal constant FALLBACK_MAX_FEE = 0.02 ether;
-    uint256 internal constant FALLBACK_HALF_AMOUNT = 1 ether;
+    uint32 internal constant FALLBACK_RATE = 20_000; // 2 bps
+    uint32 internal constant DEFAULT_STALE_AFTER = 1 hours;
     uint256 internal constant DENOMINATOR = 100_000_000;
     bytes32 internal constant SIGNED_QUOTE_TYPEHASH =
         keccak256(
             "SignedQuote(bytes context,bytes data,uint48 issuedAt,uint48 expiry,bytes32 salt,address submitter)"
+        );
+    bytes32 internal constant SIGNED_FALLBACK_CURVE_TYPEHASH =
+        keccak256(
+            "SignedFallbackCurve(bytes data,uint48 issuedAt,address submitter)"
         );
 
     address internal signer;
@@ -38,12 +42,15 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
     function _deploy(
         uint16 maxBands
     ) internal returns (OffchainQuotedPiecewiseLinearFee) {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = FALLBACK_RATE;
         return
             new OffchainQuotedPiecewiseLinearFee(
                 signer,
                 FEE_TOKEN,
-                FALLBACK_MAX_FEE,
-                FALLBACK_HALF_AMOUNT,
+                breakpoints,
+                rates,
                 maxBands,
                 signer
             );
@@ -89,6 +96,27 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         return abi.encodePacked(r, s, v);
     }
 
+    function _signFallback(
+        OffchainQuotedPiecewiseLinearFee fee,
+        OffchainQuotedPiecewiseLinearFee.SignedFallbackCurve memory update,
+        uint256 signerKey
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SIGNED_FALLBACK_CURVE_TYPEHASH,
+                keccak256(update.data),
+                update.issuedAt,
+                update.submitter
+            )
+        );
+        bytes32 digest = ECDSA.toTypedDataHash(
+            _domainSeparator(fee),
+            structHash
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
     function _context(
         uint32 destination,
         bytes32 recipient,
@@ -101,7 +129,17 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         uint128[] memory breakpoints,
         uint32[] memory rates
     ) internal pure returns (bytes memory) {
-        return abi.encode(breakpoints, rates);
+        uint32[] memory surcharges = new uint32[](rates.length);
+        return abi.encode(breakpoints, rates, DEFAULT_STALE_AFTER, surcharges);
+    }
+
+    function _curveData(
+        uint128[] memory breakpoints,
+        uint32[] memory rates,
+        uint32 staleAfter,
+        uint32[] memory surcharges
+    ) internal pure returns (bytes memory) {
+        return abi.encode(breakpoints, rates, staleAfter, surcharges);
     }
 
     function _submitData(
@@ -143,6 +181,44 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
             issuedAt,
             expiry
         );
+    }
+
+    function _submitCurveWithStaleness(
+        OffchainQuotedPiecewiseLinearFee fee,
+        uint32 destination,
+        bytes32 recipient,
+        uint128[] memory breakpoints,
+        uint32[] memory rates,
+        uint32 staleAfter,
+        uint32[] memory surcharges,
+        uint48 issuedAt,
+        uint48 expiry
+    ) internal {
+        _submitData(
+            fee,
+            destination,
+            recipient,
+            WILDCARD_AMOUNT,
+            _curveData(breakpoints, rates, staleAfter, surcharges),
+            issuedAt,
+            expiry
+        );
+    }
+
+    function _submitFallback(
+        OffchainQuotedPiecewiseLinearFee fee,
+        uint128[] memory breakpoints,
+        uint32[] memory rates,
+        uint48 issuedAt
+    ) internal {
+        OffchainQuotedPiecewiseLinearFee.SignedFallbackCurve
+            memory update = OffchainQuotedPiecewiseLinearFee
+                .SignedFallbackCurve({
+                    data: abi.encode(breakpoints, rates),
+                    issuedAt: issuedAt,
+                    submitter: address(this)
+                });
+        fee.submitFallbackCurve(update, _signFallback(fee, update, SIGNER_KEY));
     }
 
     function _submitLinearTransient(
@@ -201,9 +277,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
     }
 
     function _fallbackFee(uint256 amount) internal pure returns (uint256) {
-        uint256 uncapped = (amount * FALLBACK_MAX_FEE) /
-            (2 * FALLBACK_HALF_AMOUNT);
-        return uncapped > FALLBACK_MAX_FEE ? FALLBACK_MAX_FEE : uncapped;
+        return (amount * FALLBACK_RATE) / DENOMINATOR;
     }
 
     function _exampleCurve()
@@ -246,6 +320,13 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
             uint8(quotedFee.feeType()),
             uint8(FeeType.OFFCHAIN_QUOTED_PIECEWISE_LINEAR)
         );
+
+        OffchainQuotedPiecewiseLinearFee.FallbackCurve
+            memory fallback_ = quotedFee.getFallbackCurve();
+        assertEq(fallback_.breakpoints.length, 0);
+        assertEq(fallback_.marginalBpsX1e4.length, 1);
+        assertEq(fallback_.marginalBpsX1e4[0], FALLBACK_RATE);
+        assertEq(fallback_.issuedAt, 0);
     }
 
     function test_constructorRejectsInvalidMaxBands() public {
@@ -258,6 +339,34 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
             OffchainQuotedPiecewiseLinearFee.InvalidMaxBands.selector
         );
         _deploy(257);
+    }
+
+    function test_constructorRejectsInvalidOrZeroFallback() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+
+        vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
+        new OffchainQuotedPiecewiseLinearFee(
+            signer,
+            FEE_TOKEN,
+            breakpoints,
+            rates,
+            4,
+            signer
+        );
+
+        breakpoints = new uint128[](1);
+        breakpoints[0] = 1 ether;
+        rates[0] = FALLBACK_RATE;
+        vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
+        new OffchainQuotedPiecewiseLinearFee(
+            signer,
+            FEE_TOKEN,
+            breakpoints,
+            rates,
+            4,
+            signer
+        );
     }
 
     // ============ Fee calculation ============
@@ -360,6 +469,88 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         assertEq(
             _quote(quotedFee, DESTINATION, RECIPIENT, amount),
             _referenceFee(breakpoints, rates, amount)
+        );
+    }
+
+    function test_staleThresholdUsesPerBandSurcharges() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        uint32[] memory surcharges = new uint32[](3);
+        surcharges[0] = 20_000; // +2 bps
+        surcharges[1] = 40_000; // +4 bps
+        surcharges[2] = 80_000; // +8 bps
+        uint48 issuedAt = uint48(block.timestamp);
+        uint48 expiry = issuedAt + 1 days;
+        _submitCurveWithStaleness(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            breakpoints,
+            rates,
+            12,
+            surcharges,
+            issuedAt,
+            expiry
+        );
+
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            130 ether
+        );
+        vm.warp(issuedAt + 11);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            130 ether
+        );
+
+        uint32[] memory staleRates = new uint32[](3);
+        staleRates[0] = 30_000;
+        staleRates[1] = 80_000;
+        staleRates[2] = 200_000;
+        vm.warp(issuedAt + 12);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            _referenceFee(breakpoints, staleRates, 300_000 ether)
+        );
+
+        vm.warp(expiry);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            250 ether
+        );
+        vm.warp(expiry + 1);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            _fallbackFee(300_000 ether)
+        );
+    }
+
+    function testFuzz_staleFeeMatchesReference(uint128 amount) public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        uint32[] memory surcharges = new uint32[](3);
+        surcharges[0] = 10_000;
+        surcharges[1] = 20_000;
+        surcharges[2] = 30_000;
+        uint48 now_ = uint48(block.timestamp);
+        _submitCurveWithStaleness(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            breakpoints,
+            rates,
+            1,
+            surcharges,
+            now_,
+            now_ + 1 days
+        );
+        vm.warp(now_ + 1);
+
+        uint32[] memory staleRates = new uint32[](3);
+        for (uint256 i = 0; i < rates.length; ++i) {
+            staleRates[i] = rates[i] + surcharges[i];
+        }
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, amount),
+            _referenceFee(breakpoints, staleRates, amount)
         );
     }
 
@@ -583,6 +774,88 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         _expectInvalidCurve(breakpoints, rates);
     }
 
+    function test_rejectsInvalidStalePolicy() public {
+        uint128[] memory breakpoints = new uint128[](1);
+        breakpoints[0] = 1 ether;
+        uint32[] memory rates = new uint32[](2);
+        rates[0] = 10_000;
+        rates[1] = 20_000;
+        uint32[] memory surcharges = new uint32[](1);
+        uint48 now_ = uint48(block.timestamp);
+
+        _expectInvalidStaleCurve(
+            breakpoints,
+            rates,
+            1,
+            surcharges,
+            now_,
+            now_ + 1 days
+        );
+
+        surcharges = new uint32[](2);
+        _expectInvalidStaleCurve(
+            breakpoints,
+            rates,
+            0,
+            surcharges,
+            now_,
+            now_ + 1 days
+        );
+        _expectInvalidStaleCurve(
+            breakpoints,
+            rates,
+            uint32(1 days + 1),
+            surcharges,
+            now_,
+            now_ + 1 days
+        );
+
+        surcharges[0] = 20_000;
+        surcharges[1] = 10_000;
+        _expectInvalidStaleCurve(
+            breakpoints,
+            rates,
+            1,
+            surcharges,
+            now_,
+            now_ + 1 days
+        );
+
+        rates[1] = 99_999_999;
+        surcharges[0] = 1;
+        surcharges[1] = 2;
+        _expectInvalidStaleCurve(
+            breakpoints,
+            rates,
+            1,
+            surcharges,
+            now_,
+            now_ + 1 days
+        );
+    }
+
+    function _expectInvalidStaleCurve(
+        uint128[] memory breakpoints,
+        uint32[] memory rates,
+        uint32 staleAfter,
+        uint32[] memory surcharges,
+        uint48 issuedAt,
+        uint48 expiry
+    ) internal {
+        vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
+        _submitCurveWithStaleness(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            breakpoints,
+            rates,
+            staleAfter,
+            surcharges,
+            issuedAt,
+            expiry
+        );
+    }
+
     function _expectInvalidCurve(
         uint128[] memory breakpoints,
         uint32[] memory rates
@@ -657,6 +930,167 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         );
     }
 
+    function test_equalIssuedAtIsIdempotentOrConflicting() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 10_000;
+        uint48 now_ = uint48(block.timestamp);
+        _submitCurve(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 1 days
+        );
+
+        _submitCurve(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 1 days
+        );
+
+        vm.expectRevert(
+            OffchainQuotedPiecewiseLinearFee.ConflictingQuote.selector
+        );
+        _submitCurve(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            breakpoints,
+            rates,
+            now_,
+            now_ + 2 days
+        );
+    }
+
+    // ============ Permanent fallback ============
+
+    function test_quoteSignerCanReplaceFallback() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        uint48 now_ = uint48(block.timestamp);
+        _submitFallback(quotedFee, breakpoints, rates, now_);
+
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            130 ether
+        );
+        OffchainQuotedPiecewiseLinearFee.FallbackCurve
+            memory fallback_ = quotedFee.getFallbackCurve();
+        assertEq(fallback_.issuedAt, now_);
+        assertEq(fallback_.breakpoints.length, 2);
+        assertEq(fallback_.marginalBpsX1e4.length, 3);
+
+        vm.warp(block.timestamp + 365 days);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
+            130 ether
+        );
+    }
+
+    function test_fallbackEqualIssuedAtIsIdempotentOrConflicting() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 30_000;
+        uint48 now_ = uint48(block.timestamp);
+        _submitFallback(quotedFee, breakpoints, rates, now_);
+        _submitFallback(quotedFee, breakpoints, rates, now_);
+
+        rates[0] = 40_000;
+        vm.expectRevert(
+            OffchainQuotedPiecewiseLinearFee.ConflictingQuote.selector
+        );
+        _submitFallback(quotedFee, breakpoints, rates, now_);
+    }
+
+    function test_fallbackRejectsOlderAndFutureUpdates() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 30_000;
+        uint48 now_ = uint48(block.timestamp);
+        _submitFallback(quotedFee, breakpoints, rates, now_);
+
+        vm.expectRevert(AbstractOffchainQuoter.StaleQuote.selector);
+        _submitFallback(quotedFee, breakpoints, rates, now_ - 1);
+
+        vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
+        _submitFallback(quotedFee, breakpoints, rates, now_ + 1);
+    }
+
+    function test_fallbackRequiresBoundSubmitter() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 30_000;
+        OffchainQuotedPiecewiseLinearFee.SignedFallbackCurve
+            memory update = OffchainQuotedPiecewiseLinearFee
+                .SignedFallbackCurve({
+                    data: abi.encode(breakpoints, rates),
+                    issuedAt: uint48(block.timestamp),
+                    submitter: address(0)
+                });
+        vm.expectRevert(AbstractOffchainQuoter.InvalidSubmitter.selector);
+        quotedFee.submitFallbackCurve(
+            update,
+            _signFallback(quotedFee, update, SIGNER_KEY)
+        );
+
+        update.submitter = address(0xB0B);
+        vm.expectRevert(AbstractOffchainQuoter.InvalidSubmitter.selector);
+        quotedFee.submitFallbackCurve(
+            update,
+            _signFallback(quotedFee, update, SIGNER_KEY)
+        );
+    }
+
+    function test_fallbackRejectsInvalidSignerAndCurve() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 30_000;
+        OffchainQuotedPiecewiseLinearFee.SignedFallbackCurve
+            memory update = OffchainQuotedPiecewiseLinearFee
+                .SignedFallbackCurve({
+                    data: abi.encode(breakpoints, rates),
+                    issuedAt: uint48(block.timestamp),
+                    submitter: address(this)
+                });
+        vm.expectRevert(AbstractOffchainQuoter.InvalidSigner.selector);
+        quotedFee.submitFallbackCurve(
+            update,
+            _signFallback(quotedFee, update, 0xBAD)
+        );
+
+        rates[0] = 0;
+        update.data = abi.encode(breakpoints, rates);
+        vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
+        quotedFee.submitFallbackCurve(
+            update,
+            _signFallback(quotedFee, update, SIGNER_KEY)
+        );
+    }
+
+    function test_removedSignerDoesNotInvalidateFallback() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 30_000;
+        _submitFallback(quotedFee, breakpoints, rates, uint48(block.timestamp));
+        vm.prank(signer);
+        quotedFee.removeQuoteSigner(signer);
+
+        vm.warp(block.timestamp + 365 days);
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),
+            0.0003 ether
+        );
+    }
+
     // ============ Inspection ============
 
     function test_enumeratesStandingCurvesOnly() public {
@@ -673,6 +1107,11 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         assertEq(entries[0].recipient, RECIPIENT);
         assertEq(entries[0].quote.breakpoints.length, breakpoints.length);
         assertEq(entries[0].quote.marginalBpsX1e4.length, rates.length);
+        assertEq(
+            entries[0].quote.staleMarginalSurchargeBpsX1e4.length,
+            rates.length
+        );
+        assertEq(entries[0].quote.staleAfterSeconds, DEFAULT_STALE_AFTER);
         for (uint256 i = 0; i < breakpoints.length; ++i) {
             assertEq(entries[0].quote.breakpoints[i], breakpoints[i]);
         }

--- a/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedPiecewiseLinearFee.t.sol
@@ -15,6 +15,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
     address internal constant FEE_TOKEN = address(0xFEE);
     uint32 internal constant DESTINATION = 42;
     bytes32 internal constant RECIPIENT = bytes32(uint256(0xBEEF));
+    uint32 internal constant WILDCARD_DESTINATION = type(uint32).max;
     bytes32 internal constant WILDCARD_RECIPIENT = bytes32(type(uint256).max);
     uint256 internal constant WILDCARD_AMOUNT = type(uint256).max;
 
@@ -96,14 +97,34 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         return abi.encodePacked(destination, recipient, amount);
     }
 
-    function _data(
+    function _curveData(
         uint128[] memory breakpoints,
         uint32[] memory rates
     ) internal pure returns (bytes memory) {
         return abi.encode(breakpoints, rates);
     }
 
-    function _submit(
+    function _submitData(
+        OffchainQuotedPiecewiseLinearFee fee,
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount,
+        bytes memory data,
+        uint48 issuedAt,
+        uint48 expiry
+    ) internal {
+        SignedQuote memory signedQuote = SignedQuote({
+            context: _context(destination, recipient, amount),
+            data: data,
+            issuedAt: issuedAt,
+            expiry: expiry,
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+        fee.submitQuote(signedQuote, _signQuote(fee, signedQuote));
+    }
+
+    function _submitCurve(
         OffchainQuotedPiecewiseLinearFee fee,
         uint32 destination,
         bytes32 recipient,
@@ -113,15 +134,35 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         uint48 issuedAt,
         uint48 expiry
     ) internal {
-        SignedQuote memory signedQuote = SignedQuote({
-            context: _context(destination, recipient, amount),
-            data: _data(breakpoints, rates),
-            issuedAt: issuedAt,
-            expiry: expiry,
-            salt: bytes32(0),
-            submitter: address(0)
-        });
-        fee.submitQuote(signedQuote, _signQuote(fee, signedQuote));
+        _submitData(
+            fee,
+            destination,
+            recipient,
+            amount,
+            _curveData(breakpoints, rates),
+            issuedAt,
+            expiry
+        );
+    }
+
+    function _submitLinearTransient(
+        OffchainQuotedPiecewiseLinearFee fee,
+        uint32 destination,
+        bytes32 recipient,
+        uint256 amount,
+        uint256 maxFee,
+        uint256 halfAmount
+    ) internal {
+        uint48 now_ = uint48(block.timestamp);
+        _submitData(
+            fee,
+            destination,
+            recipient,
+            amount,
+            abi.encodePacked(maxFee, halfAmount),
+            now_,
+            now_
+        );
     }
 
     function _submitStanding(
@@ -131,7 +172,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         uint32[] memory rates
     ) internal {
         uint48 now_ = uint48(block.timestamp);
-        _submit(
+        _submitCurve(
             quotedFee,
             destination,
             recipient,
@@ -297,7 +338,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         }
 
         uint48 now_ = uint48(block.timestamp);
-        _submit(
+        _submitCurve(
             maxFeeContract,
             DESTINATION,
             RECIPIENT,
@@ -359,18 +400,17 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         );
     }
 
-    function test_transientExactAndWildcardAmount() public {
+    function test_transientLinearExactAndWildcardAmount() public {
         (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
-        uint48 now_ = uint48(block.timestamp);
-        _submit(
+        _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
+
+        _submitLinearTransient(
             quotedFee,
             DESTINATION,
             RECIPIENT,
             300_000 ether,
-            breakpoints,
-            rates,
-            now_,
-            now_
+            260 ether,
+            300_000 ether
         );
 
         assertEq(
@@ -379,49 +419,107 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         );
         assertEq(
             _quote(quotedFee, DESTINATION, RECIPIENT, 200_000 ether),
-            _fallbackFee(200_000 ether)
+            50 ether
         );
 
-        _submit(
+        _submitLinearTransient(
             quotedFee,
             DESTINATION,
             RECIPIENT,
             WILDCARD_AMOUNT,
-            breakpoints,
-            rates,
-            now_,
-            now_
+            100 ether,
+            100_000 ether
         );
         assertEq(
             _quote(quotedFee, DESTINATION, RECIPIENT, 200_000 ether),
-            50 ether
+            100 ether
         );
     }
 
-    function test_standingAndTransientCurvesAgree() public {
-        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+    function test_transientLinearOverridesStandingCurve() public {
+        uint128[] memory breakpoints = new uint128[](0);
+        uint32[] memory rates = new uint32[](1);
+        rates[0] = 10_000;
         _submitStanding(DESTINATION, RECIPIENT, breakpoints, rates);
-        uint256 standingFee = _quote(
-            quotedFee,
-            DESTINATION,
-            RECIPIENT,
-            300_000 ether
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),
+            0.0001 ether
         );
 
-        uint48 now_ = uint48(block.timestamp);
-        _submit(
+        _submitLinearTransient(
             quotedFee,
             DESTINATION,
             RECIPIENT,
+            1 ether,
+            0.0004 ether,
+            1 ether
+        );
+        assertEq(
+            _quote(quotedFee, DESTINATION, RECIPIENT, 1 ether),
+            0.0002 ether
+        );
+    }
+
+    function test_transientLinearSupportsContextWildcards() public {
+        _submitLinearTransient(
+            quotedFee,
+            WILDCARD_DESTINATION,
+            WILDCARD_RECIPIENT,
             WILDCARD_AMOUNT,
+            2 ether,
+            1 ether
+        );
+
+        assertEq(
+            _quote(
+                quotedFee,
+                DESTINATION + 1,
+                bytes32(uint256(0xCAFE)),
+                1 ether
+            ),
+            1 ether
+        );
+    }
+
+    function test_transientLinearSupportsZeroFee() public {
+        _submitLinearTransient(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            1 ether,
+            0,
+            1
+        );
+        assertEq(_quote(quotedFee, DESTINATION, RECIPIENT, 1 ether), 0);
+    }
+
+    function test_rejectsCurveDataForTransientQuote() public {
+        (uint128[] memory breakpoints, uint32[] memory rates) = _exampleCurve();
+        uint48 now_ = uint48(block.timestamp);
+        vm.expectRevert();
+        _submitCurve(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            1 ether,
             breakpoints,
             rates,
             now_,
             now_
         );
-        assertEq(
-            _quote(quotedFee, DESTINATION, RECIPIENT, 300_000 ether),
-            standingFee
+    }
+
+    function test_rejectsLinearDataForStandingQuote() public {
+        uint48 now_ = uint48(block.timestamp);
+        vm.expectRevert();
+        _submitData(
+            quotedFee,
+            DESTINATION,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            abi.encodePacked(uint256(1 ether), uint256(1 ether)),
+            now_,
+            now_ + 1 days
         );
     }
 
@@ -432,7 +530,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         uint32[] memory rates = new uint32[](1);
         uint48 now_ = uint48(block.timestamp);
         vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
-        _submit(
+        _submitCurve(
             quotedFee,
             DESTINATION,
             RECIPIENT,
@@ -491,7 +589,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
     ) internal {
         uint48 now_ = uint48(block.timestamp);
         vm.expectRevert(OffchainQuotedPiecewiseLinearFee.InvalidCurve.selector);
-        _submit(
+        _submitCurve(
             quotedFee,
             DESTINATION,
             RECIPIENT,
@@ -508,7 +606,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         uint32[] memory rates = new uint32[](1);
         uint48 future = uint48(block.timestamp) + 1;
         vm.expectRevert(AbstractOffchainQuoter.InvalidQuote.selector);
-        _submit(
+        _submitCurve(
             quotedFee,
             DESTINATION,
             RECIPIENT,
@@ -530,7 +628,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
         twoBps[0] = 20_000;
         uint48 now_ = uint48(block.timestamp);
         vm.expectRevert(AbstractOffchainQuoter.StaleQuote.selector);
-        _submit(
+        _submitCurve(
             quotedFee,
             DESTINATION,
             RECIPIENT,
@@ -543,7 +641,7 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
 
         vm.warp(block.timestamp + 1);
         uint48 later = uint48(block.timestamp);
-        _submit(
+        _submitCurve(
             quotedFee,
             DESTINATION,
             RECIPIENT,
@@ -582,16 +680,13 @@ contract OffchainQuotedPiecewiseLinearFeeTest is Test {
             assertEq(entries[0].quote.marginalBpsX1e4[i], rates[i]);
         }
 
-        uint48 now_ = uint48(block.timestamp);
-        _submit(
+        _submitLinearTransient(
             quotedFee,
             DESTINATION + 1,
             RECIPIENT,
             WILDCARD_AMOUNT,
-            breakpoints,
-            rates,
-            now_,
-            now_
+            1 ether,
+            1 ether
         );
         assertEq(quotedFee.quoteDomains().length, 1);
     }

--- a/solidity/tron-hardhat.config.cts
+++ b/solidity/tron-hardhat.config.cts
@@ -17,6 +17,8 @@ const TRON_EXCLUDED_PATTERNS = [
   "/contracts/hooks/OPStackHook.sol",
   "/contracts/hooks/aggregation/ERC5164Hook.sol",
   "/contracts/token/extensions/OPL2ToL1TokenBridgeNative.sol",
+  // The piecewise quoter is EVM-only and pushes tron-solc beyond its WASM input limit.
+  "/contracts/token/fees/OffchainQuotedPiecewiseLinearFee.sol",
   "/contracts/token/CCTP",
   "/contracts/token/TokenBridgeCctp",
   "/contracts/libs/CctpMessageV1.sol",

--- a/typescript/cli/src/deploy/warp-quote.ts
+++ b/typescript/cli/src/deploy/warp-quote.ts
@@ -261,6 +261,7 @@ export function resolveTargetRouterForVariant(args: {
     case TokenFeeType.RegressiveFee:
     case TokenFeeType.ProgressiveFee:
     case TokenFeeType.OffchainQuotedLinearFee:
+    case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
     case TokenFeeType.RoutingFee:
       return WARP_TARGET_ROUTER_NONE;
 

--- a/typescript/cli/src/tests/quote/resolveTargetRouterForVariant.test.ts
+++ b/typescript/cli/src/tests/quote/resolveTargetRouterForVariant.test.ts
@@ -105,6 +105,19 @@ describe('resolveTargetRouterForVariant', () => {
         address: ADDR,
       },
       {
+        type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        token: ADDR,
+        owner: ADDR,
+        quoteSigners: [ADDR],
+        maxBands: 4,
+        fallbackCurve: {
+          breakpoints: [100_000n, 250_000n],
+          marginalBps: [4, 10, 20],
+          issuedAt: 0,
+        },
+        address: ADDR,
+      },
+      {
         type: TokenFeeType.RoutingFee,
         token: ADDR,
         owner: ADDR,

--- a/typescript/fee-quoting/src/config.ts
+++ b/typescript/fee-quoting/src/config.ts
@@ -29,6 +29,7 @@ export const ServerConfigSchema = z.object({
     .number()
     .int()
     .positive()
+    .max(0xffff_ffff)
     .default(DEFAULT_QUOTE_EXPIRY_SECONDS),
   /**
    * Transient forward-date buffer in seconds (transient mode only). Must stay

--- a/typescript/fee-quoting/src/services/evmQuoteService.ts
+++ b/typescript/fee-quoting/src/services/evmQuoteService.ts
@@ -373,7 +373,8 @@ export class EvmQuoteService implements IProtocolQuoteService {
       [destination, recipient, BigInt(2) ** BigInt(256) - BigInt(1)],
     );
     const data =
-      feeQuoter.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+      feeQuoter.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee &&
+      binding.kind === QuoteMode.STANDING
         ? encodeAbiParameters(
             [{ type: 'uint128[]' }, { type: 'uint32[]' }],
             [[], [0]],

--- a/typescript/fee-quoting/src/services/evmQuoteService.ts
+++ b/typescript/fee-quoting/src/services/evmQuoteService.ts
@@ -376,8 +376,13 @@ export class EvmQuoteService implements IProtocolQuoteService {
       feeQuoter.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee &&
       binding.kind === QuoteMode.STANDING
         ? encodeAbiParameters(
-            [{ type: 'uint128[]' }, { type: 'uint32[]' }],
-            [[], [0]],
+            [
+              { type: 'uint128[]' },
+              { type: 'uint32[]' },
+              { type: 'uint32' },
+              { type: 'uint32[]' },
+            ],
+            [[], [0], binding.ttlSeconds, [0]],
           )
         : encodePacked(
             ['uint256', 'uint256'],

--- a/typescript/fee-quoting/src/services/evmQuoteService.ts
+++ b/typescript/fee-quoting/src/services/evmQuoteService.ts
@@ -3,6 +3,7 @@ import {
   type Address,
   type Hex,
   type LocalAccount,
+  encodeAbiParameters,
   encodePacked,
   isAddress,
 } from 'viem';
@@ -282,18 +283,16 @@ export class EvmQuoteService implements IProtocolQuoteService {
   // ============ private: resolve ============
 
   /**
-   * Walks the fee tree to find the leaf `OffchainQuotedLinearFee` that
+   * Walks the fee tree to find an offchain-quoted leaf that
    * applies to `(destChainName, targetRouter)`, asserts this signer is
    * whitelisted on it, and returns the verifying contract address. Throws
-   * `NoQuoteAvailableError` on miss. `OffchainQuotedLinearFee` is the only
-   * on-chain fee variant that extends `AbstractOffchainQuoter`, so it's the
-   * only variant that carries `quoteSigners`.
+   * `NoQuoteAvailableError` on miss.
    */
   private resolveOffchainFeeLeaf(
     tokenFee: DerivedTokenFeeConfig | undefined,
     destChainName: string,
     targetRouter?: Hex,
-  ): Address {
+  ): DerivedTokenFeeConfig {
     if (!tokenFee) {
       throw new NoQuoteAvailableError(
         NoQuoteAvailableReason.NotConfigured,
@@ -302,10 +301,13 @@ export class EvmQuoteService implements IProtocolQuoteService {
     }
 
     const leaf = pickFeeLeaf(tokenFee, destChainName, targetRouter);
-    if (leaf.type !== TokenFeeType.OffchainQuotedLinearFee) {
+    if (
+      leaf.type !== TokenFeeType.OffchainQuotedLinearFee &&
+      leaf.type !== TokenFeeType.OffchainQuotedPiecewiseLinearFee
+    ) {
       throw new NoQuoteAvailableError(
         NoQuoteAvailableReason.NotUpgraded,
-        `Fee at ${leaf.address} is ${leaf.type}, not OffchainQuotedLinearFee`,
+        `Fee at ${leaf.address} is ${leaf.type}, not an offchain-quoted fee`,
       );
     }
     this.assertSignerAuthorized(
@@ -313,7 +315,7 @@ export class EvmQuoteService implements IProtocolQuoteService {
       leaf.address,
       QuoterType.WarpFee,
     );
-    return narrowAddress(leaf.address, 'warp fee quoter');
+    return leaf;
   }
 
   /** Walks the hook tree to find the destination's IGP address. */
@@ -361,7 +363,7 @@ export class EvmQuoteService implements IProtocolQuoteService {
 
   private async signWarpQuote(
     route: EvmRouteState,
-    feeQuoter: Address,
+    feeQuoter: DerivedTokenFeeConfig,
     destination: number,
     recipient: Hex,
     binding: QuoteBinding,
@@ -370,9 +372,26 @@ export class EvmQuoteService implements IProtocolQuoteService {
       ['uint32', 'bytes32', 'uint256'],
       [destination, recipient, BigInt(2) ** BigInt(256) - BigInt(1)],
     );
-    const { maxFee, halfAmount } = PLACEHOLDER_WARP_FEE_PARAMS;
-    const data = encodePacked(['uint256', 'uint256'], [maxFee, halfAmount]);
-    return this.signEip712(route, feeQuoter, context, data, binding);
+    const data =
+      feeQuoter.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+        ? encodeAbiParameters(
+            [{ type: 'uint128[]' }, { type: 'uint32[]' }],
+            [[], [0]],
+          )
+        : encodePacked(
+            ['uint256', 'uint256'],
+            [
+              PLACEHOLDER_WARP_FEE_PARAMS.maxFee,
+              PLACEHOLDER_WARP_FEE_PARAMS.halfAmount,
+            ],
+          );
+    return this.signEip712(
+      route,
+      narrowAddress(feeQuoter.address, 'warp fee quoter'),
+      context,
+      data,
+      binding,
+    );
   }
 
   private async signIgpQuote(

--- a/typescript/fee-quoting/src/services/svmQuoteService.ts
+++ b/typescript/fee-quoting/src/services/svmQuoteService.ts
@@ -545,6 +545,11 @@ function pickLeaf(
       // Top-level leaf — return as-is. Extra BaseFeeConfig fields don't hurt
       // since the consumer only reads `type`, `params`, `quoteSigners`.
       return { leaf: config, effectiveTargetRouter: undefined };
+    case FeeType.offchainQuotedPiecewiseLinear:
+      throw new NoQuoteAvailableError(
+        NoQuoteAvailableReason.NotUpgraded,
+        'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+      );
     case FeeType.routing: {
       const child = config.routes[destinationDomain];
       if (!child) {

--- a/typescript/fee-quoting/test/services/quoteService.test.ts
+++ b/typescript/fee-quoting/test/services/quoteService.test.ts
@@ -321,12 +321,24 @@ describe('QuoteService', () => {
       );
       expect(feeQuote).to.exist;
 
-      const [breakpoints, marginalBpsX1e4] = decodeAbiParameters(
-        [{ type: 'uint128[]' }, { type: 'uint32[]' }],
+      const [
+        breakpoints,
+        marginalBpsX1e4,
+        staleAfterSeconds,
+        staleMarginalSurchargeBpsX1e4,
+      ] = decodeAbiParameters(
+        [
+          { type: 'uint128[]' },
+          { type: 'uint32[]' },
+          { type: 'uint32' },
+          { type: 'uint32[]' },
+        ],
         feeQuote!.quote.data,
       );
       expect(breakpoints).to.deep.equal([]);
       expect(marginalBpsX1e4).to.deep.equal([0]);
+      expect(staleAfterSeconds).to.equal(300);
+      expect(staleMarginalSurchargeBpsX1e4).to.deep.equal([0]);
     });
   });
 

--- a/typescript/fee-quoting/test/services/quoteService.test.ts
+++ b/typescript/fee-quoting/test/services/quoteService.test.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 import { pino } from 'pino';
-import { type Address, type Hex, verifyTypedData } from 'viem';
+import {
+  type Address,
+  type Hex,
+  decodeAbiParameters,
+  verifyTypedData,
+} from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 import {
@@ -259,6 +264,38 @@ describe('QuoteService', () => {
         signature,
       });
       expect(valid).to.be.true;
+    });
+
+    it('encodes the zero placeholder as a valid piecewise curve', async () => {
+      const service = createTestService({
+        derivedConfig: {
+          ...mockDerivedConfig,
+          tokenFee: {
+            ...mockDerivedConfig.tokenFee,
+            type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+            maxBands: 4,
+          },
+        },
+      });
+      const res = await service.getQuote(
+        'ethereum',
+        FeeQuotingCommand.TransferRemote,
+        ROUTER,
+        DESTINATION,
+        SALT,
+        RECIPIENT,
+      );
+      const feeQuote = res.quotes.find(
+        (quote) => quote.quoter.toLowerCase() === FEE_CONTRACT.toLowerCase(),
+      );
+      expect(feeQuote).to.exist;
+
+      const [breakpoints, marginalBpsX1e4] = decodeAbiParameters(
+        [{ type: 'uint128[]' }, { type: 'uint32[]' }],
+        feeQuote!.quote.data,
+      );
+      expect(breakpoints).to.deep.equal([]);
+      expect(marginalBpsX1e4).to.deep.equal([0]);
     });
   });
 

--- a/typescript/fee-quoting/test/services/quoteService.test.ts
+++ b/typescript/fee-quoting/test/services/quoteService.test.ts
@@ -4,6 +4,7 @@ import {
   type Address,
   type Hex,
   decodeAbiParameters,
+  encodePacked,
   verifyTypedData,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
@@ -266,8 +267,38 @@ describe('QuoteService', () => {
       expect(valid).to.be.true;
     });
 
-    it('encodes the zero placeholder as a valid piecewise curve', async () => {
+    it('encodes the transient piecewise placeholder as linear fee data', async () => {
       const service = createTestService({
+        derivedConfig: {
+          ...mockDerivedConfig,
+          tokenFee: {
+            ...mockDerivedConfig.tokenFee,
+            type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+            maxBands: 4,
+          },
+        },
+      });
+      const res = await service.getQuote(
+        'ethereum',
+        FeeQuotingCommand.TransferRemote,
+        ROUTER,
+        DESTINATION,
+        SALT,
+        RECIPIENT,
+      );
+      const feeQuote = res.quotes.find(
+        (quote) => quote.quoter.toLowerCase() === FEE_CONTRACT.toLowerCase(),
+      );
+      expect(feeQuote).to.exist;
+
+      expect(feeQuote!.quote.data).to.equal(
+        encodePacked(['uint256', 'uint256'], [0n, 1n]),
+      );
+    });
+
+    it('encodes the standing piecewise placeholder as a valid curve', async () => {
+      const service = createTestService({
+        quoteMode: 'standing',
         derivedConfig: {
           ...mockDerivedConfig,
           tokenFee: {

--- a/typescript/provider-sdk/src/fee.test.ts
+++ b/typescript/provider-sdk/src/fee.test.ts
@@ -44,6 +44,11 @@ const rawParams = (maxFee: string, halfAmount: string): FeeParams => ({
   halfAmount,
 });
 
+const initialFallback = {
+  breakpoints: ['100000', '250000'],
+  marginalBps: [4, 10, 20],
+};
+
 describe('fee type support', () => {
   describe('feeConfigToArtifact', () => {
     it('passes through linear fee config unchanged', () => {
@@ -227,6 +232,40 @@ describe('fee type support', () => {
         maxFee: 1000n,
         halfAmount: 500n,
         bps: 10000,
+        address: '0xfee',
+      });
+    });
+
+    it('derives the piecewise fallback without linear fee params', () => {
+      const derived = feeArtifactToDerivedConfig(
+        {
+          artifactState: ArtifactState.DEPLOYED,
+          config: {
+            type: FeeType.offchainQuotedPiecewiseLinear,
+            owner: '0xowner',
+            beneficiary: '0xbeneficiary',
+            quoteSigners: ['0xsigner'],
+            maxBands: 4,
+            initialFallback,
+          },
+          deployed: { address: '0xfee' },
+        },
+        chainLookup,
+        TOKEN,
+      );
+
+      expect(derived).to.deep.equal({
+        type: FeeType.offchainQuotedPiecewiseLinear,
+        token: TOKEN,
+        owner: '0xowner',
+        beneficiary: '0xbeneficiary',
+        quoteSigners: ['0xsigner'],
+        maxBands: 4,
+        fallbackCurve: {
+          breakpoints: [100000n, 250000n],
+          marginalBps: [4, 10, 20],
+          issuedAt: 0,
+        },
         address: '0xfee',
       });
     });
@@ -704,17 +743,17 @@ describe('fee type support', () => {
           type: FeeType.offchainQuotedPiecewiseLinear,
           owner: '0xowner',
           beneficiary: '0xbeneficiary',
-          params: rawParams('1000', '500'),
           quoteSigners: ['0xsigner1'],
           maxBands: 4,
+          initialFallback,
         },
         expected: {
           type: FeeType.offchainQuotedPiecewiseLinear,
           owner: '0xowner',
           beneficiary: '0xbeneficiary',
-          params: rawParams('1000', '500'),
           quoteSigners: ['0xsigner1'],
           maxBands: 8,
+          initialFallback,
         },
         redeploy: true,
       },
@@ -724,19 +763,61 @@ describe('fee type support', () => {
           type: FeeType.offchainQuotedPiecewiseLinear,
           owner: '0xowner',
           beneficiary: '0xbeneficiary',
-          params: rawParams('1000', '500'),
           quoteSigners: ['0xsigner1'],
           maxBands: 4,
+          initialFallback,
         },
         expected: {
           type: FeeType.offchainQuotedPiecewiseLinear,
           owner: '0xowner',
           beneficiary: '0xbeneficiary',
-          params: rawParams('1000', '500'),
           quoteSigners: ['0xsigner1', '0xsigner2'],
           maxBands: 4,
+          initialFallback,
         },
         redeploy: false,
+      },
+      {
+        name: 'does not redeploy offchainQuotedPiecewiseLinear when only the fallback changes',
+        actual: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          quoteSigners: ['0xsigner1'],
+          maxBands: 4,
+          initialFallback,
+        },
+        expected: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          quoteSigners: ['0xsigner1'],
+          maxBands: 4,
+          initialFallback: { breakpoints: [], marginalBps: [25] },
+        },
+        redeploy: false,
+      },
+      {
+        name: 'redeploys offchainQuotedPiecewiseLinear when the token changes',
+        actual: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          token: '0xtoken1',
+          quoteSigners: ['0xsigner1'],
+          maxBands: 4,
+          initialFallback,
+        },
+        expected: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          token: '0xtoken2',
+          quoteSigners: ['0xsigner1'],
+          maxBands: 4,
+          initialFallback,
+        },
+        redeploy: true,
       },
     ];
 

--- a/typescript/provider-sdk/src/fee.test.ts
+++ b/typescript/provider-sdk/src/fee.test.ts
@@ -698,6 +698,46 @@ describe('fee type support', () => {
         },
         redeploy: false,
       },
+      {
+        name: 'redeploys offchainQuotedPiecewiseLinear when maxBands changes',
+        actual: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          params: rawParams('1000', '500'),
+          quoteSigners: ['0xsigner1'],
+          maxBands: 4,
+        },
+        expected: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          params: rawParams('1000', '500'),
+          quoteSigners: ['0xsigner1'],
+          maxBands: 8,
+        },
+        redeploy: true,
+      },
+      {
+        name: 'does not redeploy offchainQuotedPiecewiseLinear when only quoteSigners change',
+        actual: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          params: rawParams('1000', '500'),
+          quoteSigners: ['0xsigner1'],
+          maxBands: 4,
+        },
+        expected: {
+          type: FeeType.offchainQuotedPiecewiseLinear,
+          owner: '0xowner',
+          beneficiary: '0xbeneficiary',
+          params: rawParams('1000', '500'),
+          quoteSigners: ['0xsigner1', '0xsigner2'],
+          maxBands: 4,
+        },
+        redeploy: false,
+      },
     ];
 
     for (const { name, actual, expected, redeploy } of cases) {

--- a/typescript/provider-sdk/src/fee.ts
+++ b/typescript/provider-sdk/src/fee.ts
@@ -73,11 +73,23 @@ export interface OffchainQuotedLinearFeeStrategy {
   quoteSigners: string[];
 }
 
+/** Piecewise curve amounts are serialized atomic token units. */
+export interface PiecewiseCurveConfig {
+  breakpoints: string[];
+  marginalBps: number[];
+}
+
+export interface DerivedPiecewiseFallback {
+  breakpoints: bigint[];
+  marginalBps: number[];
+  issuedAt: number;
+}
+
 export interface OffchainQuotedPiecewiseLinearFeeStrategy {
   type: typeof FeeStrategyType.offchainQuotedPiecewiseLinear;
-  params: FeeParams;
   quoteSigners: string[];
   maxBands: number;
+  initialFallback: PiecewiseCurveConfig;
 }
 
 export type FeeStrategy =
@@ -141,9 +153,9 @@ export interface OffchainQuotedLinearFeeConfig extends BaseFeeConfig {
 
 export interface OffchainQuotedPiecewiseLinearFeeConfig extends BaseFeeConfig {
   type: typeof FeeType.offchainQuotedPiecewiseLinear;
-  params: FeeParams;
   quoteSigners: string[];
   maxBands: number;
+  initialFallback: PiecewiseCurveConfig;
 }
 
 export interface RoutingFeeConfig extends BaseFeeConfig {
@@ -202,11 +214,9 @@ export interface DerivedOffchainQuotedPiecewiseLinearFeeConfig {
   token: string;
   owner: string;
   beneficiary: string;
-  maxFee: bigint;
-  halfAmount: bigint;
-  bps: number;
   quoteSigners: string[];
   maxBands: number;
+  fallbackCurve: DerivedPiecewiseFallback;
   address: string;
 }
 
@@ -375,6 +385,23 @@ function strategyToDerivedFeeConfig(
   beneficiary: string,
   address: string,
 ): DerivedFeeConfig {
+  if (strategy.type === FeeStrategyType.offchainQuotedPiecewiseLinear) {
+    return {
+      type: strategy.type,
+      token,
+      owner,
+      beneficiary,
+      quoteSigners: strategy.quoteSigners,
+      maxBands: strategy.maxBands,
+      fallbackCurve: {
+        breakpoints: strategy.initialFallback.breakpoints.map(BigInt),
+        marginalBps: strategy.initialFallback.marginalBps,
+        issuedAt: 0,
+      },
+      address,
+    };
+  }
+
   const { maxFee, halfAmount } = resolveRawParams(strategy.params);
   const base = {
     token,
@@ -397,14 +424,6 @@ function strategyToDerivedFeeConfig(
         ...base,
         type: strategy.type,
         quoteSigners: strategy.quoteSigners,
-      };
-
-    case FeeStrategyType.offchainQuotedPiecewiseLinear:
-      return {
-        ...base,
-        type: strategy.type,
-        quoteSigners: strategy.quoteSigners,
-        maxBands: strategy.maxBands,
       };
 
     default: {
@@ -599,17 +618,18 @@ export function feeArtifactToDerivedConfig(
     }
 
     case FeeType.offchainQuotedPiecewiseLinear: {
-      const { maxFee, halfAmount } = resolveRawParams(config.params);
       return {
         type: config.type,
         token,
         owner: config.owner,
         beneficiary: config.beneficiary,
-        maxFee,
-        halfAmount,
-        bps: computeBps(maxFee, halfAmount),
         quoteSigners: config.quoteSigners,
         maxBands: config.maxBands,
+        fallbackCurve: {
+          breakpoints: config.initialFallback.breakpoints.map(BigInt),
+          marginalBps: config.initialFallback.marginalBps,
+          issuedAt: 0,
+        },
         address,
       };
     }
@@ -702,14 +722,12 @@ function isLeafFeeConfig(
   | LinearFeeConfig
   | RegressiveFeeConfig
   | ProgressiveFeeConfig
-  | OffchainQuotedLinearFeeConfig
-  | OffchainQuotedPiecewiseLinearFeeConfig {
+  | OffchainQuotedLinearFeeConfig {
   return (
     c.type === FeeType.linear ||
     c.type === FeeType.regressive ||
     c.type === FeeType.progressive ||
-    c.type === FeeType.offchainQuotedLinear ||
-    c.type === FeeType.offchainQuotedPiecewiseLinear
+    c.type === FeeType.offchainQuotedLinear
   );
 }
 
@@ -719,8 +737,10 @@ function isLeafFeeConfig(
  * A change of fee type always requires a fresh deployment (different program
  * semantics). For matching leaf types, only `params` divergence forces a
  * redeploy — EVM fee contracts have constructor-set immutable params, so a
- * params change cannot be applied in place. All other leaf fields
- * (`owner`, `beneficiary`, `token`, `quoteSigners`) are settable
+ * params change cannot be applied in place. The piecewise fee instead
+ * redeploys only for immutable token or maxBands changes; signer-managed
+ * fallback changes are deliberately ignored here. Other leaf fields
+ * (`owner`, `beneficiary`, `quoteSigners`) are settable
  * post-deploy on both SVM (UpdateFeeParams/SetBeneficiary/TransferOwnership/
  * AddWildcardQuoteSigner) and EVM (transferOwnership/setBeneficiary), so
  * they go through the writer's update path rather than triggering a
@@ -745,8 +765,7 @@ export function shouldDeployNewFee(
     case FeeType.offchainQuotedPiecewiseLinear: {
       if (actual.type !== FeeType.offchainQuotedPiecewiseLinear) return true;
       return (
-        actual.maxBands !== expected.maxBands ||
-        !feeParamsEqual(actual.params, expected.params)
+        actual.maxBands !== expected.maxBands || actual.token !== expected.token
       );
     }
 
@@ -798,9 +817,9 @@ export function withFeeAssetConfig(
         type: config.type,
         owner: config.owner,
         beneficiary: config.beneficiary,
-        params: config.params,
         quoteSigners: config.quoteSigners,
         maxBands: config.maxBands,
+        initialFallback: config.initialFallback,
         token,
       };
     case FeeType.routing:

--- a/typescript/provider-sdk/src/fee.ts
+++ b/typescript/provider-sdk/src/fee.ts
@@ -30,6 +30,7 @@ export const FeeStrategyType = {
   regressive: 'RegressiveFee',
   progressive: 'ProgressiveFee',
   offchainQuotedLinear: 'OffchainQuotedLinearFee',
+  offchainQuotedPiecewiseLinear: 'OffchainQuotedPiecewiseLinearFee',
 } as const;
 
 export type FeeStrategyType =
@@ -72,17 +73,26 @@ export interface OffchainQuotedLinearFeeStrategy {
   quoteSigners: string[];
 }
 
+export interface OffchainQuotedPiecewiseLinearFeeStrategy {
+  type: typeof FeeStrategyType.offchainQuotedPiecewiseLinear;
+  params: FeeParams;
+  quoteSigners: string[];
+  maxBands: number;
+}
+
 export type FeeStrategy =
   | LinearFeeStrategy
   | RegressiveFeeStrategy
   | ProgressiveFeeStrategy
-  | OffchainQuotedLinearFeeStrategy;
+  | OffchainQuotedLinearFeeStrategy
+  | OffchainQuotedPiecewiseLinearFeeStrategy;
 
 export const FeeType = {
   linear: 'LinearFee',
   regressive: 'RegressiveFee',
   progressive: 'ProgressiveFee',
   offchainQuotedLinear: 'OffchainQuotedLinearFee',
+  offchainQuotedPiecewiseLinear: 'OffchainQuotedPiecewiseLinearFee',
   routing: 'RoutingFee',
   crossCollateralRouting: 'CrossCollateralRoutingFee',
 } as const;
@@ -129,6 +139,13 @@ export interface OffchainQuotedLinearFeeConfig extends BaseFeeConfig {
   quoteSigners: string[];
 }
 
+export interface OffchainQuotedPiecewiseLinearFeeConfig extends BaseFeeConfig {
+  type: typeof FeeType.offchainQuotedPiecewiseLinear;
+  params: FeeParams;
+  quoteSigners: string[];
+  maxBands: number;
+}
+
 export interface RoutingFeeConfig extends BaseFeeConfig {
   type: typeof FeeType.routing;
   routes: Record<string, FeeStrategy>;
@@ -144,6 +161,7 @@ export type FeeConfig =
   | RegressiveFeeConfig
   | ProgressiveFeeConfig
   | OffchainQuotedLinearFeeConfig
+  | OffchainQuotedPiecewiseLinearFeeConfig
   | RoutingFeeConfig
   | CrossCollateralRoutingFeeConfig;
 
@@ -179,6 +197,19 @@ export interface DerivedOffchainQuotedLinearFeeConfig {
   address: string;
 }
 
+export interface DerivedOffchainQuotedPiecewiseLinearFeeConfig {
+  type: typeof FeeType.offchainQuotedPiecewiseLinear;
+  token: string;
+  owner: string;
+  beneficiary: string;
+  maxFee: bigint;
+  halfAmount: bigint;
+  bps: number;
+  quoteSigners: string[];
+  maxBands: number;
+  address: string;
+}
+
 export interface DerivedRoutingFeeConfig {
   type: typeof FeeType.routing;
   token: string;
@@ -199,6 +230,7 @@ export interface DerivedCrossCollateralRoutingFeeConfig {
 export type DerivedFeeConfig =
   | DerivedLeafFeeConfig
   | DerivedOffchainQuotedLinearFeeConfig
+  | DerivedOffchainQuotedPiecewiseLinearFeeConfig
   | DerivedRoutingFeeConfig
   | DerivedCrossCollateralRoutingFeeConfig;
 
@@ -221,6 +253,7 @@ export type FeeArtifactConfigs = {
   [FeeType.regressive]: RegressiveFeeConfig;
   [FeeType.progressive]: ProgressiveFeeConfig;
   [FeeType.offchainQuotedLinear]: OffchainQuotedLinearFeeConfig;
+  [FeeType.offchainQuotedPiecewiseLinear]: OffchainQuotedPiecewiseLinearFeeConfig;
   [FeeType.routing]: RoutingFeeArtifactConfig;
   [FeeType.crossCollateralRouting]: CrossCollateralRoutingFeeArtifactConfig;
 };
@@ -366,6 +399,14 @@ function strategyToDerivedFeeConfig(
         quoteSigners: strategy.quoteSigners,
       };
 
+    case FeeStrategyType.offchainQuotedPiecewiseLinear:
+      return {
+        ...base,
+        type: strategy.type,
+        quoteSigners: strategy.quoteSigners,
+        maxBands: strategy.maxBands,
+      };
+
     default: {
       const invalidStrategy: never = strategy;
       throw new Error(
@@ -471,6 +512,7 @@ export function feeConfigToArtifact(
     case FeeType.regressive:
     case FeeType.progressive:
     case FeeType.offchainQuotedLinear:
+    case FeeType.offchainQuotedPiecewiseLinear:
       return {
         artifactState: ArtifactState.NEW,
         config,
@@ -552,6 +594,22 @@ export function feeArtifactToDerivedConfig(
         halfAmount,
         bps: computeBps(maxFee, halfAmount),
         quoteSigners: config.quoteSigners,
+        address,
+      };
+    }
+
+    case FeeType.offchainQuotedPiecewiseLinear: {
+      const { maxFee, halfAmount } = resolveRawParams(config.params);
+      return {
+        type: config.type,
+        token,
+        owner: config.owner,
+        beneficiary: config.beneficiary,
+        maxFee,
+        halfAmount,
+        bps: computeBps(maxFee, halfAmount),
+        quoteSigners: config.quoteSigners,
+        maxBands: config.maxBands,
         address,
       };
     }
@@ -644,12 +702,14 @@ function isLeafFeeConfig(
   | LinearFeeConfig
   | RegressiveFeeConfig
   | ProgressiveFeeConfig
-  | OffchainQuotedLinearFeeConfig {
+  | OffchainQuotedLinearFeeConfig
+  | OffchainQuotedPiecewiseLinearFeeConfig {
   return (
     c.type === FeeType.linear ||
     c.type === FeeType.regressive ||
     c.type === FeeType.progressive ||
-    c.type === FeeType.offchainQuotedLinear
+    c.type === FeeType.offchainQuotedLinear ||
+    c.type === FeeType.offchainQuotedPiecewiseLinear
   );
 }
 
@@ -680,6 +740,14 @@ export function shouldDeployNewFee(
       // actual.type === expected.type already; narrow actual via guard.
       if (!isLeafFeeConfig(actual)) return true;
       return !feeParamsEqual(actual.params, expected.params);
+    }
+
+    case FeeType.offchainQuotedPiecewiseLinear: {
+      if (actual.type !== FeeType.offchainQuotedPiecewiseLinear) return true;
+      return (
+        actual.maxBands !== expected.maxBands ||
+        !feeParamsEqual(actual.params, expected.params)
+      );
     }
 
     case FeeType.routing:
@@ -723,6 +791,16 @@ export function withFeeAssetConfig(
         beneficiary: config.beneficiary,
         params: config.params,
         quoteSigners: config.quoteSigners,
+        token,
+      };
+    case FeeType.offchainQuotedPiecewiseLinear:
+      return {
+        type: config.type,
+        owner: config.owner,
+        beneficiary: config.beneficiary,
+        params: config.params,
+        quoteSigners: config.quoteSigners,
+        maxBands: config.maxBands,
         token,
       };
     case FeeType.routing:

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
@@ -369,11 +369,13 @@ describe('EvmTokenFeeDeployer', () => {
       type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
       token: token.address,
       owner: signer.address,
-      maxFee: MAX_FEE,
-      halfAmount: HALF_AMOUNT,
-      bps: BPS,
       maxBands: 4,
       quoteSigners: [signer.address, otherSigner.address],
+      fallbackCurve: {
+        breakpoints: [100_000n, 250_000n],
+        marginalBps: [4, 10, 20],
+        issuedAt: 0,
+      },
     });
 
     const deployedContracts = await deployer.deploy({
@@ -391,6 +393,11 @@ describe('EvmTokenFeeDeployer', () => {
     expect(await fee.owner()).to.equal(signer.address);
     expect(await fee.token()).to.equal(token.address);
     expect(await fee.maxBands()).to.equal(4);
+    const fallback = await fee.getFallbackCurve();
+    expect(fallback.breakpoints.map((value) => value.toBigInt())).to.deep.equal(
+      [100_000n, 250_000n],
+    );
+    expect(fallback.marginalBpsX1e4).to.deep.equal([40_000, 100_000, 200_000]);
     expect(await fee.quoteSigners()).to.have.members([
       signer.address,
       otherSigner.address,
@@ -416,11 +423,13 @@ describe('EvmTokenFeeDeployer', () => {
             type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
             token: token.address,
             owner: signer.address,
-            maxFee: MAX_FEE,
-            halfAmount: HALF_AMOUNT,
-            bps: BPS,
             maxBands: 4,
             quoteSigners: [signer.address],
+            fallbackCurve: {
+              breakpoints: [100_000n],
+              marginalBps: [4, 10],
+              issuedAt: 0,
+            },
           },
         },
       },

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.hardhat-test.ts
@@ -7,7 +7,7 @@ import {
   ERC20Test__factory,
   LinearFee__factory,
   OffchainQuotedLinearFee__factory,
-  ProgressiveFee__factory,
+  OffchainQuotedPiecewiseLinearFee__factory,
 } from '@hyperlane-xyz/core';
 import { addressToBytes32, randomInt } from '@hyperlane-xyz/utils';
 
@@ -363,6 +363,40 @@ describe('EvmTokenFeeDeployer', () => {
     expect(signers).to.include(otherSigner.address);
   });
 
+  it('should deploy OffchainQuotedPiecewiseLinearFee with correct parameters', async () => {
+    const [, otherSigner] = await hre.ethers.getSigners();
+    const config = TokenFeeConfigSchema.parse({
+      type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+      token: token.address,
+      owner: signer.address,
+      maxFee: MAX_FEE,
+      halfAmount: HALF_AMOUNT,
+      bps: BPS,
+      maxBands: 4,
+      quoteSigners: [signer.address, otherSigner.address],
+    });
+
+    const deployedContracts = await deployer.deploy({
+      [TestChainName.test2]: config,
+    });
+    const deployed =
+      deployedContracts[TestChainName.test2][
+        TokenFeeType.OffchainQuotedPiecewiseLinearFee
+      ];
+    const fee = OffchainQuotedPiecewiseLinearFee__factory.connect(
+      deployed.address,
+      signer,
+    );
+
+    expect(await fee.owner()).to.equal(signer.address);
+    expect(await fee.token()).to.equal(token.address);
+    expect(await fee.maxBands()).to.equal(4);
+    expect(await fee.quoteSigners()).to.have.members([
+      signer.address,
+      otherSigner.address,
+    ]);
+  });
+
   it('should deploy CrossCollateralRoutingFee with router-keyed fee contracts', async () => {
     const routerKey = hre.ethers.utils.hexZeroPad(signer.address, 32);
     const config = CrossCollateralRoutingFeeConfigSchema.parse({
@@ -379,11 +413,14 @@ describe('EvmTokenFeeDeployer', () => {
             bps: BPS,
           },
           [routerKey]: {
-            type: TokenFeeType.ProgressiveFee,
+            type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
             token: token.address,
             owner: signer.address,
             maxFee: MAX_FEE,
             halfAmount: HALF_AMOUNT,
+            bps: BPS,
+            maxBands: 4,
+            quoteSigners: [signer.address],
           },
         },
       },
@@ -411,7 +448,7 @@ describe('EvmTokenFeeDeployer', () => {
       defaultFeeAddress,
       signer,
     );
-    const routerFeeContract = ProgressiveFee__factory.connect(
+    const routerFeeContract = OffchainQuotedPiecewiseLinearFee__factory.connect(
       routerFeeAddress,
       signer,
     );
@@ -422,5 +459,6 @@ describe('EvmTokenFeeDeployer', () => {
     expect(await defaultFeeContract.token()).to.equal(token.address);
     expect(await routerFeeContract.owner()).to.equal(config.owner);
     expect(await routerFeeContract.token()).to.equal(token.address);
+    expect(await routerFeeContract.maxBands()).to.equal(4);
   });
 });

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -24,10 +24,10 @@ import {
   OffchainQuotedPiecewiseLinearFeeConfig,
   RoutingFeeConfig,
   TokenFeeConfig,
-  TokenFeeConfigInput,
   TokenFeeConfigSchema,
   TokenFeeType,
 } from './types.js';
+import { BPS_PRECISION } from './utils.js';
 
 type OffchainQuotedFeeConfig =
   | OffchainQuotedLinearFeeConfig
@@ -66,7 +66,7 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
   }
   async deployContracts(
     chain: ChainName,
-    config: TokenFeeConfigInput,
+    config: TokenFeeConfig,
   ): Promise<HyperlaneContracts<EvmTokenFeeFactories>> {
     const deployedContract: any = {}; // This is a partial HyperlaneContracts<EvmTokenFeeFactories>
     const parsedConfig = TokenFeeConfigSchema.parse(config);
@@ -134,13 +134,6 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
     chain: ChainName,
     config: OffchainQuotedFeeConfig,
   ): Promise<OffchainQuotedLinearFee | OffchainQuotedPiecewiseLinearFee> {
-    let { maxFee, halfAmount } = config;
-    if (config.bps && (!maxFee || !halfAmount)) {
-      const derived = this.tokenFeeReader.convertFromBps(config.bps);
-      maxFee = derived.maxFee;
-      halfAmount = derived.halfAmount;
-    }
-
     assert(
       config.quoteSigners?.length,
       `At least one quote signer is required for ${config.type}`,
@@ -150,23 +143,33 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
     const [firstSigner, ...additionalSigners] = config.quoteSigners;
 
     // addQuoteSigner is onlyOwner, so deploy with signer as temporary owner
-    const contract =
-      config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
-        ? await this.deployContract(chain, config.type, [
-            firstSigner,
-            config.token,
-            maxFee,
-            halfAmount,
-            config.maxBands,
-            signerAddress,
-          ])
-        : await this.deployContract(chain, config.type, [
-            firstSigner,
-            config.token,
-            maxFee,
-            halfAmount,
-            signerAddress,
-          ]);
+    let contract: OffchainQuotedLinearFee | OffchainQuotedPiecewiseLinearFee;
+    if (config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee) {
+      contract = await this.deployContract(chain, config.type, [
+        firstSigner,
+        config.token,
+        config.fallbackCurve.breakpoints,
+        config.fallbackCurve.marginalBps.map((bps) =>
+          Math.round(bps * Number(BPS_PRECISION)),
+        ),
+        config.maxBands,
+        signerAddress,
+      ]);
+    } else {
+      let { maxFee, halfAmount } = config;
+      if (config.bps && (!maxFee || !halfAmount)) {
+        const derived = this.tokenFeeReader.convertFromBps(config.bps);
+        maxFee = derived.maxFee;
+        halfAmount = derived.halfAmount;
+      }
+      contract = await this.deployContract(chain, config.type, [
+        firstSigner,
+        config.token,
+        maxFee,
+        halfAmount,
+        signerAddress,
+      ]);
+    }
 
     for (const signer of additionalSigners) {
       await this.multiProvider.handleTx(

--- a/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeDeployer.ts
@@ -3,6 +3,7 @@ import {
   BaseFee__factory,
   CrossCollateralRoutingFee,
   OffchainQuotedLinearFee,
+  OffchainQuotedPiecewiseLinearFee,
   RoutingFee,
 } from '@hyperlane-xyz/core';
 import { assert, eqAddress } from '@hyperlane-xyz/utils';
@@ -20,12 +21,26 @@ import { EvmTokenFeeFactories, evmTokenFeeFactories } from './contracts.js';
 import {
   CrossCollateralRoutingFeeConfig,
   OffchainQuotedLinearFeeConfig,
+  OffchainQuotedPiecewiseLinearFeeConfig,
   RoutingFeeConfig,
   TokenFeeConfig,
   TokenFeeConfigInput,
   TokenFeeConfigSchema,
   TokenFeeType,
 } from './types.js';
+
+type OffchainQuotedFeeConfig =
+  | OffchainQuotedLinearFeeConfig
+  | OffchainQuotedPiecewiseLinearFeeConfig;
+
+function isOffchainQuotedFeeConfig(
+  config: TokenFeeConfig,
+): config is OffchainQuotedFeeConfig {
+  return (
+    config.type === TokenFeeType.OffchainQuotedLinearFee ||
+    config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+  );
+}
 
 export class EvmTokenFeeDeployer extends HyperlaneDeployer<
   TokenFeeConfig,
@@ -66,8 +81,9 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
         );
         break;
       case TokenFeeType.OffchainQuotedLinearFee:
+      case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
         deployedContract[parsedConfig.type] =
-          await this.deployOffchainQuotedLinearFee(chain, parsedConfig);
+          await this.deployOffchainQuotedFee(chain, parsedConfig);
         break;
       case TokenFeeType.RoutingFee: {
         deployedContract[TokenFeeType.RoutingFee] = await this.deployRoutingFee(
@@ -92,6 +108,7 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
       | { type: typeof TokenFeeType.RoutingFee }
       | { type: typeof TokenFeeType.CrossCollateralRoutingFee }
       | { type: typeof TokenFeeType.OffchainQuotedLinearFee }
+      | { type: typeof TokenFeeType.OffchainQuotedPiecewiseLinearFee }
     >,
   ): Promise<BaseFee> {
     let { maxFee, halfAmount } = config;
@@ -113,10 +130,10 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
     ]);
   }
 
-  private async deployOffchainQuotedLinearFee(
+  private async deployOffchainQuotedFee(
     chain: ChainName,
-    config: OffchainQuotedLinearFeeConfig,
-  ): Promise<OffchainQuotedLinearFee> {
+    config: OffchainQuotedFeeConfig,
+  ): Promise<OffchainQuotedLinearFee | OffchainQuotedPiecewiseLinearFee> {
     let { maxFee, halfAmount } = config;
     if (config.bps && (!maxFee || !halfAmount)) {
       const derived = this.tokenFeeReader.convertFromBps(config.bps);
@@ -126,18 +143,30 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
 
     assert(
       config.quoteSigners?.length,
-      'At least one quote signer is required for OffchainQuotedLinearFee',
+      `At least one quote signer is required for ${config.type}`,
     );
 
     const signerAddress = await this.multiProvider.getSignerAddress(chain);
     const [firstSigner, ...additionalSigners] = config.quoteSigners;
 
     // addQuoteSigner is onlyOwner, so deploy with signer as temporary owner
-    const contract = await this.deployContract(
-      chain,
-      TokenFeeType.OffchainQuotedLinearFee,
-      [firstSigner, config.token, maxFee, halfAmount, signerAddress],
-    );
+    const contract =
+      config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+        ? await this.deployContract(chain, config.type, [
+            firstSigner,
+            config.token,
+            maxFee,
+            halfAmount,
+            config.maxBands,
+            signerAddress,
+          ])
+        : await this.deployContract(chain, config.type, [
+            firstSigner,
+            config.token,
+            maxFee,
+            halfAmount,
+            signerAddress,
+          ]);
 
     for (const signer of additionalSigners) {
       await this.multiProvider.handleTx(
@@ -185,18 +214,13 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
         ...feeConfig,
         token: feeConfig.token ?? config.token,
       };
-      const deployedFeeContract =
-        resolvedFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee
-          ? BaseFee__factory.connect(
-              (
-                await this.deployOffchainQuotedLinearFee(
-                  chain,
-                  resolvedFeeConfig,
-                )
-              ).address,
-              this.multiProvider.getSigner(chain),
-            )
-          : await this.deployFee(chain, resolvedFeeConfig);
+      const deployedFeeContract = isOffchainQuotedFeeConfig(resolvedFeeConfig)
+        ? BaseFee__factory.connect(
+            (await this.deployOffchainQuotedFee(chain, resolvedFeeConfig))
+              .address,
+            this.multiProvider.getSigner(chain),
+          )
+        : await this.deployFee(chain, resolvedFeeConfig);
 
       await this.multiProvider.handleTx(
         chain,
@@ -245,10 +269,9 @@ export class EvmTokenFeeDeployer extends HyperlaneDeployer<
       for (const [routerKey, routerFeeConfig] of Object.entries(
         destinationConfig,
       )) {
-        const { address } =
-          routerFeeConfig.type === TokenFeeType.OffchainQuotedLinearFee
-            ? await this.deployOffchainQuotedLinearFee(chain, routerFeeConfig)
-            : await this.deployFee(chain, routerFeeConfig);
+        const { address } = isOffchainQuotedFeeConfig(routerFeeConfig)
+          ? await this.deployOffchainQuotedFee(chain, routerFeeConfig)
+          : await this.deployFee(chain, routerFeeConfig);
 
         destinationDomains.push(
           this.multiProvider.getDomainId(destinationChain),

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_ROUTER_KEY,
   LinearFeeConfig,
   OffchainQuotedLinearFeeConfig,
+  OffchainQuotedPiecewiseLinearFeeConfig,
   ResolvedCrossCollateralRoutingFeeConfigInput,
   ResolvedTokenFeeConfigInput,
   RoutingFeeConfig,
@@ -1208,6 +1209,72 @@ describe('EvmTokenFeeModule', () => {
       );
       expect(onchainConfig.quoteSigners).to.have.lengthOf(1);
       expect(onchainConfig.quoteSigners).to.include(signer.address);
+    });
+  });
+
+  describe('OffchainQuotedPiecewiseLinearFee', () => {
+    let piecewiseConfig: OffchainQuotedPiecewiseLinearFeeConfig;
+
+    before(() => {
+      piecewiseConfig = TokenFeeConfigSchema.parse({
+        type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        owner: signer.address,
+        token: token.address,
+        maxFee: MAX_FEE,
+        halfAmount: HALF_AMOUNT,
+        bps: BPS,
+        maxBands: 4,
+        quoteSigners: [signer.address],
+      }) as OffchainQuotedPiecewiseLinearFeeConfig;
+    });
+
+    it('should create and read the piecewise fee', async () => {
+      const module = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: piecewiseConfig,
+      });
+
+      expect(normalizeConfig(await module.read())).to.deep.equal(
+        normalizeConfig(piecewiseConfig),
+      );
+    });
+
+    it('should update signers without redeploying', async () => {
+      const module = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: piecewiseConfig,
+      });
+      const [, otherSigner] = await hre.ethers.getSigners();
+      const updatedConfig = {
+        ...piecewiseConfig,
+        quoteSigners: [signer.address, otherSigner.address],
+      };
+
+      await expectTxsAndUpdate(module, updatedConfig, 1);
+      const onchainConfig = await module.read();
+      assert(
+        onchainConfig.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        `Must be ${TokenFeeType.OffchainQuotedPiecewiseLinearFee}`,
+      );
+      expect(onchainConfig.quoteSigners).to.include(otherSigner.address);
+    });
+
+    it('should redeploy when maxBands changes', async () => {
+      const module = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: piecewiseConfig,
+      });
+
+      await expectTxsAndUpdate(module, { ...piecewiseConfig, maxBands: 8 }, 0);
+      const onchainConfig = await module.read();
+      assert(
+        onchainConfig.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        `Must be ${TokenFeeType.OffchainQuotedPiecewiseLinearFee}`,
+      );
+      expect(onchainConfig.maxBands).to.equal(8);
     });
   });
 });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -1220,11 +1220,13 @@ describe('EvmTokenFeeModule', () => {
         type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
         owner: signer.address,
         token: token.address,
-        maxFee: MAX_FEE,
-        halfAmount: HALF_AMOUNT,
-        bps: BPS,
         maxBands: 4,
         quoteSigners: [signer.address],
+        fallbackCurve: {
+          breakpoints: [100_000n, 250_000n],
+          marginalBps: [4, 10, 20],
+          issuedAt: 0,
+        },
       }) as OffchainQuotedPiecewiseLinearFeeConfig;
     });
 
@@ -1275,6 +1277,30 @@ describe('EvmTokenFeeModule', () => {
         `Must be ${TokenFeeType.OffchainQuotedPiecewiseLinearFee}`,
       );
       expect(onchainConfig.maxBands).to.equal(8);
+    });
+
+    it('should ignore fallback drift instead of redeploying', async () => {
+      const module = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: piecewiseConfig,
+      });
+      const originalAddress = module.serialize().deployedFee;
+
+      await expectTxsAndUpdate(
+        module,
+        {
+          ...piecewiseConfig,
+          fallbackCurve: {
+            breakpoints: [],
+            marginalBps: [25],
+            issuedAt: 1,
+          },
+        },
+        0,
+      );
+
+      expect(module.serialize().deployedFee).to.equal(originalAddress);
     });
   });
 });

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -526,6 +526,86 @@ describe('EvmTokenFeeModule', () => {
       ).to.equal(BPS + 1);
     });
 
+    it('should preserve piecewise arrays while replacing a CCRF sub-fee', async () => {
+      const initialPiecewiseConfig = TokenFeeConfigSchema.parse({
+        type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        owner: signer.address,
+        token: token.address,
+        maxBands: 4,
+        quoteSigners: [signer.address],
+        fallbackCurve: {
+          breakpoints: [250_000n, 750_000n],
+          marginalBps: [4, 10, 20],
+          issuedAt: 0,
+        },
+      }) as OffchainQuotedPiecewiseLinearFeeConfig;
+      const initialSubFeeModule = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: initialPiecewiseConfig,
+      });
+      const initialSubFeeAddress = initialSubFeeModule.serialize().deployedFee;
+      const ccrf = await deployCrossCollateralRoutingFee(signer.address);
+      const routingDestination = multiProvider.getDomainId(test4Chain);
+      await ccrf.setCrossCollateralRouterFeeContracts(
+        [routingDestination],
+        [DEFAULT_ROUTER_KEY],
+        [initialSubFeeAddress],
+      );
+
+      const module = new EvmTokenFeeModule(multiProvider, {
+        chain: test4Chain,
+        config: {
+          type: TokenFeeType.CrossCollateralRoutingFee,
+          owner: signer.address,
+          feeContracts: {},
+        },
+        addresses: { deployedFee: ccrf.address },
+      });
+
+      const txs = await module.update({
+        type: TokenFeeType.CrossCollateralRoutingFee,
+        owner: signer.address,
+        feeContracts: {
+          [test4Chain]: {
+            [DEFAULT_ROUTER_KEY]: {
+              type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+              owner: signer.address,
+              maxBands: 5,
+              quoteSigners: [signer.address],
+              initialFallback: {
+                breakpoints: [250_000n, 750_000n],
+                marginalBps: [4, 10, 20],
+              },
+            },
+          },
+        },
+      });
+
+      expect(txs).to.have.lengthOf(1);
+      await multiProvider.sendTransaction(test4Chain, txs[0]);
+
+      const replacementAddress = await ccrf.feeContracts(
+        routingDestination,
+        DEFAULT_ROUTER_KEY,
+      );
+      expect(replacementAddress).to.not.equal(initialSubFeeAddress);
+      const replacement = await new EvmTokenFeeReader(
+        multiProvider,
+        test4Chain,
+      ).deriveTokenFeeConfig({ address: replacementAddress });
+      assert(
+        replacement.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        `Must be ${TokenFeeType.OffchainQuotedPiecewiseLinearFee}`,
+      );
+      expect(replacement.maxBands).to.equal(5);
+      expect(replacement.fallbackCurve.breakpoints).to.deep.equal([
+        250_000n,
+        750_000n,
+      ]);
+      expect(replacement.fallbackCurve.marginalBps).to.deep.equal([4, 10, 20]);
+    });
+
     it('should update an empty CCRF using explicitly resolved child tokens', async () => {
       const emptyCcrf = await deployCrossCollateralRoutingFee(signer.address);
       const routingDestination = multiProvider.getDomainId(test4Chain);

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -229,8 +229,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return module;
   }
 
-  // Processes the Input config to the Final config
-  // For LinearFee and offchain-quoted fees, convert bps to maxFee and halfAmount.
+  // Processes the Input config to the Final config.
   public static async expandConfig(params: {
     config: ResolvedTokenFeeConfigInput;
     multiProvider: MultiProvider;
@@ -238,10 +237,22 @@ export class EvmTokenFeeModule extends HyperlaneModule<
   }): Promise<TokenFeeConfig> {
     const { config, multiProvider, chainName } = params;
     let intermediaryConfig: TokenFeeConfig;
-    if (
+    if (config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee) {
+      const fallbackCurve =
+        'initialFallback' in config
+          ? { ...config.initialFallback, issuedAt: 0 }
+          : config.fallbackCurve;
+      intermediaryConfig = {
+        type: config.type,
+        token: config.token,
+        owner: config.owner,
+        quoteSigners: config.quoteSigners,
+        maxBands: config.maxBands,
+        fallbackCurve,
+      };
+    } else if (
       config.type === TokenFeeType.LinearFee ||
-      config.type === TokenFeeType.OffchainQuotedLinearFee ||
-      config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+      config.type === TokenFeeType.OffchainQuotedLinearFee
     ) {
       const { token } = config;
 
@@ -287,18 +298,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
         );
       }
 
-      if (config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee) {
-        intermediaryConfig = {
-          type: config.type,
-          token,
-          owner: config.owner,
-          bps,
-          maxFee,
-          halfAmount,
-          quoteSigners: config.quoteSigners,
-          maxBands: config.maxBands,
-        };
-      } else if (config.type === TokenFeeType.OffchainQuotedLinearFee) {
+      if (config.type === TokenFeeType.OffchainQuotedLinearFee) {
         intermediaryConfig = {
           type: config.type,
           token,
@@ -448,6 +448,11 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     ) {
       mutableFields.quoteSigners = true;
     }
+    if (targetConfig.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee) {
+      // The constructor fallback is only an initialization value. Runtime
+      // fallback changes are authorized by quote signers and never redeploy.
+      mutableFields.fallbackCurve = true;
+    }
     if (
       targetConfig.type === TokenFeeType.RoutingFee ||
       targetConfig.type === TokenFeeType.CrossCollateralRoutingFee
@@ -465,7 +470,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
    * Updates the fee configuration to match the target config.
    *
    * IMPORTANT: This method may deploy new contracts as a side effect when:
-   * - Any non-owner diff is detected (triggers redeploy)
+   * - An immutable config diff is detected (triggers redeploy)
+   * Mutable piecewise fallback drift is left to quote-signer tooling.
    *
    * These deployments are executed immediately and are NOT included in the returned
    * transaction array. The returned transactions only include configuration changes
@@ -527,6 +533,21 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       );
 
       return [];
+    }
+
+    if (
+      normalizedActualConfig.type ===
+        TokenFeeType.OffchainQuotedPiecewiseLinearFee &&
+      normalizedTargetConfig.type ===
+        TokenFeeType.OffchainQuotedPiecewiseLinearFee &&
+      !deepEquals(
+        normalizedActualConfig.fallbackCurve,
+        normalizedTargetConfig.fallbackCurve,
+      )
+    ) {
+      this.logger.info(
+        'Ignoring piecewise fallback drift; use quote-signer tooling to update it',
+      );
     }
 
     // Offchain-quoted fee signers are mutable; immutable params redeploy above.

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -3,6 +3,7 @@ import { constants } from 'ethers';
 import {
   CrossCollateralRoutingFee__factory,
   OffchainQuotedLinearFee__factory,
+  OffchainQuotedPiecewiseLinearFee__factory,
   RoutingFee__factory,
 } from '@hyperlane-xyz/core';
 import {
@@ -80,6 +81,8 @@ function getDeployedFeeAddress(
       return contracts.CrossCollateralRoutingFee.address;
     case TokenFeeType.OffchainQuotedLinearFee:
       return contracts.OffchainQuotedLinearFee.address;
+    case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
+      return contracts.OffchainQuotedPiecewiseLinearFee.address;
   }
 }
 
@@ -227,7 +230,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
   }
 
   // Processes the Input config to the Final config
-  // For LinearFee/OffchainQuotedLinearFee, it converts the bps to maxFee and halfAmount
+  // For LinearFee and offchain-quoted fees, convert bps to maxFee and halfAmount.
   public static async expandConfig(params: {
     config: ResolvedTokenFeeConfigInput;
     multiProvider: MultiProvider;
@@ -237,7 +240,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     let intermediaryConfig: TokenFeeConfig;
     if (
       config.type === TokenFeeType.LinearFee ||
-      config.type === TokenFeeType.OffchainQuotedLinearFee
+      config.type === TokenFeeType.OffchainQuotedLinearFee ||
+      config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
     ) {
       const { token } = config;
 
@@ -283,9 +287,20 @@ export class EvmTokenFeeModule extends HyperlaneModule<
         );
       }
 
-      if (config.type === TokenFeeType.OffchainQuotedLinearFee) {
+      if (config.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee) {
         intermediaryConfig = {
-          type: TokenFeeType.OffchainQuotedLinearFee,
+          type: config.type,
+          token,
+          owner: config.owner,
+          bps,
+          maxFee,
+          halfAmount,
+          quoteSigners: config.quoteSigners,
+          maxBands: config.maxBands,
+        };
+      } else if (config.type === TokenFeeType.OffchainQuotedLinearFee) {
+        intermediaryConfig = {
+          type: config.type,
           token,
           owner: config.owner,
           bps,
@@ -427,7 +442,10 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     if (actualConfig.type !== targetConfig.type) return true;
 
     const mutableFields: Record<string, true> = { owner: true };
-    if (targetConfig.type === TokenFeeType.OffchainQuotedLinearFee) {
+    if (
+      targetConfig.type === TokenFeeType.OffchainQuotedLinearFee ||
+      targetConfig.type === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+    ) {
       mutableFields.quoteSigners = true;
     }
     if (
@@ -511,15 +529,18 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       return [];
     }
 
-    // OffchainQuotedLinearFee: signers are mutable (fee params handled by shouldRedeploy)
+    // Offchain-quoted fee signers are mutable; immutable params redeploy above.
     if (
-      normalizedTargetConfig.type === TokenFeeType.OffchainQuotedLinearFee &&
-      normalizedActualConfig.type === TokenFeeType.OffchainQuotedLinearFee
+      (normalizedTargetConfig.type === TokenFeeType.OffchainQuotedLinearFee ||
+        normalizedTargetConfig.type ===
+          TokenFeeType.OffchainQuotedPiecewiseLinearFee) &&
+      normalizedActualConfig.type === normalizedTargetConfig.type
     ) {
       return [
         ...this.createQuoteSignerUpdateTxs(
           normalizedActualConfig.quoteSigners,
           normalizedTargetConfig.quoteSigners,
+          normalizedTargetConfig.type,
         ),
         ...this.createOwnershipUpdateTxs(
           normalizedActualConfig,
@@ -866,9 +887,15 @@ export class EvmTokenFeeModule extends HyperlaneModule<
   private createQuoteSignerUpdateTxs(
     actualSigners: string[] | undefined,
     targetSigners: string[] | undefined,
+    feeType:
+      | typeof TokenFeeType.OffchainQuotedLinearFee
+      | typeof TokenFeeType.OffchainQuotedPiecewiseLinearFee,
   ): AnnotatedEV5Transaction[] {
     const txs: AnnotatedEV5Transaction[] = [];
-    const iface = OffchainQuotedLinearFee__factory.createInterface();
+    const iface =
+      feeType === TokenFeeType.OffchainQuotedPiecewiseLinearFee
+        ? OffchainQuotedPiecewiseLinearFee__factory.createInterface()
+        : OffchainQuotedLinearFee__factory.createInterface();
     const contractAddress = this.args.addresses.deployedFee;
 
     const actualSet = new Set(

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -164,6 +164,27 @@ function resolveTokenForFeeConfig(
   };
 }
 
+function attachExistingCrossCollateralFeeAddresses(
+  actualConfig: DerivedCrossCollateralRoutingFeeConfig,
+  targetConfig: TokenFeeConfig & {
+    type: typeof TokenFeeType.CrossCollateralRoutingFee;
+  },
+): DerivedCrossCollateralRoutingFeeConfig {
+  return {
+    ...targetConfig,
+    address: actualConfig.address,
+    feeContracts: objMap(
+      targetConfig.feeContracts,
+      (chainName, routerConfigs) =>
+        objMap(routerConfigs, (routerBytes32, subFeeConfig) => {
+          const address =
+            actualConfig.feeContracts[chainName]?.[routerBytes32]?.address;
+          return address ? { ...subFeeConfig, address } : subFeeConfig;
+        }),
+    ),
+  } as DerivedCrossCollateralRoutingFeeConfig;
+}
+
 export class EvmTokenFeeModule extends HyperlaneModule<
   ProtocolType.Ethereum,
   TokenFeeConfigInput,
@@ -577,29 +598,13 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       actualConfig.type === TokenFeeType.CrossCollateralRoutingFee
     ) {
       const targetFeeContracts = normalizedTargetConfig.feeContracts ?? {};
-      // Carry actual addresses into target entries, but limit to target keys only so
-      // orphan entries from actualConfig don't get re-injected into the update loop.
-      const merged = objMerge<DerivedCrossCollateralRoutingFeeConfig>(
+      // Carry only the actual contract addresses into target entries. Deep-merging
+      // the full configs corrupts array-valued fee parameters (for example,
+      // piecewise breakpoints and marginal rates) by merging array indices.
+      const merged = attachExistingCrossCollateralFeeAddresses(
         actualConfig,
         normalizedTargetConfig,
-        10,
-        true,
       );
-      if (merged.feeContracts) {
-        for (const chainName of Object.keys(merged.feeContracts)) {
-          if (!(chainName in targetFeeContracts)) {
-            delete merged.feeContracts[chainName];
-          } else {
-            for (const routerBytes32 of Object.keys(
-              merged.feeContracts[chainName],
-            )) {
-              if (!(routerBytes32 in targetFeeContracts[chainName])) {
-                delete merged.feeContracts[chainName][routerBytes32];
-              }
-            }
-          }
-        }
-      }
 
       // Emit clearing transactions for entries removed from target.
       const removalDestinations: number[] = [];

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -214,6 +214,41 @@ describe('EvmTokenFeeReader', () => {
     });
   });
 
+  describe('OffchainQuotedPiecewiseLinearFee', () => {
+    it('should round-trip the piecewise fee deployment config', async () => {
+      const config = TokenFeeConfigSchema.parse({
+        type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+        maxFee: MAX_FEE,
+        halfAmount: HALF_AMOUNT,
+        bps: BPS,
+        maxBands: 4,
+        token: token.address,
+        owner: signer.address,
+        quoteSigners: [signer.address],
+      });
+      const deployer = new EvmTokenFeeDeployer(
+        multiProvider,
+        TestChainName.test2,
+      );
+      const deployedContracts = await deployer.deploy({
+        [TestChainName.test2]: config,
+      });
+      const reader = new EvmTokenFeeReader(multiProvider, TestChainName.test2);
+      const contract =
+        deployedContracts[TestChainName.test2][
+          TokenFeeType.OffchainQuotedPiecewiseLinearFee
+        ];
+
+      const onchainConfig = await reader.deriveTokenFeeConfig({
+        address: contract.address,
+      });
+
+      expect(normalizeConfig(onchainConfig)).to.deep.equal(
+        normalizeConfig(config),
+      );
+    });
+  });
+
   describe('RoutingFee', () => {
     it('should be able to derive a routing fee config and its sub fees', async () => {
       const routingFeeConfig: TokenFeeConfig = {

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.hardhat-test.ts
@@ -218,13 +218,15 @@ describe('EvmTokenFeeReader', () => {
     it('should round-trip the piecewise fee deployment config', async () => {
       const config = TokenFeeConfigSchema.parse({
         type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
-        maxFee: MAX_FEE,
-        halfAmount: HALF_AMOUNT,
-        bps: BPS,
         maxBands: 4,
         token: token.address,
         owner: signer.address,
         quoteSigners: [signer.address],
+        fallbackCurve: {
+          breakpoints: [100_000n, 250_000n],
+          marginalBps: [4, 10, 20],
+          issuedAt: 0,
+        },
       });
       const deployer = new EvmTokenFeeDeployer(
         multiProvider,

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -36,7 +36,11 @@ import {
 } from './crossCollateralUtils.js';
 import { bpsToRawFeeParams } from '@hyperlane-xyz/provider-sdk/fee';
 
-import { ASSUMED_MAX_AMOUNT_FOR_ZERO_SUPPLY, convertToBps } from './utils.js';
+import {
+  ASSUMED_MAX_AMOUNT_FOR_ZERO_SUPPLY,
+  BPS_PRECISION,
+  convertToBps,
+} from './utils.js';
 
 export type DerivedTokenFeeConfig = WithAddress<TokenFeeConfig>;
 type DerivedCrossCollateralFeeContracts = Record<
@@ -178,29 +182,31 @@ export class EvmTokenFeeReader extends HyperlaneReader {
       address,
       this.provider,
     );
-    const [token, owner, maxFee, halfAmount, maxBands, quoteSigners] =
+    const [token, owner, fallbackCurve, maxBands, quoteSigners] =
       await Promise.all([
         tokenFee.token(),
         tokenFee.owner(),
-        tokenFee.maxFee(),
-        tokenFee.halfAmount(),
+        tokenFee.getFallbackCurve(),
         tokenFee.maxBands(),
         tokenFee.quoteSigners(),
       ]);
-    const maxFeeBn = BigInt(maxFee.toString());
-    const halfAmountBn = BigInt(halfAmount.toString());
-    const bps = convertToBps(maxFeeBn, halfAmountBn);
 
     return {
       type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
-      maxFee: maxFeeBn,
-      halfAmount: halfAmountBn,
       maxBands,
       address,
-      bps,
       token,
       owner,
       quoteSigners: [...quoteSigners],
+      fallbackCurve: {
+        breakpoints: fallbackCurve.breakpoints.map((breakpoint) =>
+          BigInt(breakpoint.toString()),
+        ),
+        marginalBps: fallbackCurve.marginalBpsX1e4.map(
+          (marginalBps) => Number(marginalBps) / Number(BPS_PRECISION),
+        ),
+        issuedAt: Number(fallbackCurve.issuedAt),
+      },
     };
   }
 

--- a/typescript/sdk/src/fee/EvmTokenFeeReader.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeReader.ts
@@ -5,6 +5,7 @@ import {
   CrossCollateralRoutingFee__factory,
   LinearFee__factory,
   OffchainQuotedLinearFee__factory,
+  OffchainQuotedPiecewiseLinearFee__factory,
   RoutingFee__factory,
 } from '@hyperlane-xyz/core';
 import {
@@ -97,6 +98,10 @@ export class EvmTokenFeeReader extends HyperlaneReader {
       case OnchainTokenFeeType.OffchainQuotedLinearFee:
         derivedConfig = await this.deriveOffchainQuotedLinearFeeConfig(address);
         break;
+      case OnchainTokenFeeType.OffchainQuotedPiecewiseLinearFee:
+        derivedConfig =
+          await this.deriveOffchainQuotedPiecewiseLinearFeeConfig(address);
+        break;
       case OnchainTokenFeeType.CrossCollateralRoutingFee:
         derivedConfig = await this.deriveCrossCollateralRoutingFeeConfig({
           address,
@@ -158,6 +163,39 @@ export class EvmTokenFeeReader extends HyperlaneReader {
       type: TokenFeeType.OffchainQuotedLinearFee,
       maxFee: maxFeeBn,
       halfAmount: halfAmountBn,
+      address,
+      bps,
+      token,
+      owner,
+      quoteSigners: [...quoteSigners],
+    };
+  }
+
+  private async deriveOffchainQuotedPiecewiseLinearFeeConfig(
+    address: Address,
+  ): Promise<DerivedTokenFeeConfig> {
+    const tokenFee = OffchainQuotedPiecewiseLinearFee__factory.connect(
+      address,
+      this.provider,
+    );
+    const [token, owner, maxFee, halfAmount, maxBands, quoteSigners] =
+      await Promise.all([
+        tokenFee.token(),
+        tokenFee.owner(),
+        tokenFee.maxFee(),
+        tokenFee.halfAmount(),
+        tokenFee.maxBands(),
+        tokenFee.quoteSigners(),
+      ]);
+    const maxFeeBn = BigInt(maxFee.toString());
+    const halfAmountBn = BigInt(halfAmount.toString());
+    const bps = convertToBps(maxFeeBn, halfAmountBn);
+
+    return {
+      type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+      maxFee: maxFeeBn,
+      halfAmount: halfAmountBn,
+      maxBands,
       address,
       bps,
       token,

--- a/typescript/sdk/src/fee/contracts.ts
+++ b/typescript/sdk/src/fee/contracts.ts
@@ -4,6 +4,7 @@ import {
   CrossCollateralRoutingFee__factory,
   LinearFee__factory,
   OffchainQuotedLinearFee__factory,
+  OffchainQuotedPiecewiseLinearFee__factory,
   ProgressiveFee__factory,
   RegressiveFee__factory,
   RoutingFee__factory,
@@ -15,6 +16,8 @@ export const evmTokenFeeFactories = {
   [TokenFeeType.LinearFee]: new LinearFee__factory(),
   [TokenFeeType.OffchainQuotedLinearFee]:
     new OffchainQuotedLinearFee__factory(),
+  [TokenFeeType.OffchainQuotedPiecewiseLinearFee]:
+    new OffchainQuotedPiecewiseLinearFee__factory(),
   [TokenFeeType.ProgressiveFee]: new ProgressiveFee__factory(),
   [TokenFeeType.RegressiveFee]: new RegressiveFee__factory(),
   [TokenFeeType.RoutingFee]: new RoutingFee__factory(),

--- a/typescript/sdk/src/fee/feeConfigMapping.test.ts
+++ b/typescript/sdk/src/fee/feeConfigMapping.test.ts
@@ -103,6 +103,25 @@ describe('tokenFeeInputToFeeConfig', () => {
     }
   });
 
+  it('maps OffchainQuotedPiecewiseLinearFee with its maximum band count', () => {
+    const input: TokenFeeConfigInput = {
+      type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+      owner: OWNER,
+      bps: 3,
+      maxBands: 4,
+      quoteSigners: [SIGNER_A],
+    };
+
+    expect(tokenFeeInputToFeeConfig(input)).to.deep.equal({
+      type: FeeType.offchainQuotedPiecewiseLinear,
+      owner: OWNER,
+      beneficiary: OWNER,
+      params: { type: FeeParamsType.bps, bps: 3 },
+      quoteSigners: [SIGNER_A],
+      maxBands: 4,
+    });
+  });
+
   it('maps RoutingFee over per-destination leaf strategies', () => {
     const input: TokenFeeConfigInput = {
       type: TokenFeeType.RoutingFee,

--- a/typescript/sdk/src/fee/feeConfigMapping.test.ts
+++ b/typescript/sdk/src/fee/feeConfigMapping.test.ts
@@ -107,18 +107,24 @@ describe('tokenFeeInputToFeeConfig', () => {
     const input: TokenFeeConfigInput = {
       type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
       owner: OWNER,
-      bps: 3,
       maxBands: 4,
       quoteSigners: [SIGNER_A],
+      initialFallback: {
+        breakpoints: [100_000n, 250_000n],
+        marginalBps: [4, 10, 20],
+      },
     };
 
     expect(tokenFeeInputToFeeConfig(input)).to.deep.equal({
       type: FeeType.offchainQuotedPiecewiseLinear,
       owner: OWNER,
       beneficiary: OWNER,
-      params: { type: FeeParamsType.bps, bps: 3 },
       quoteSigners: [SIGNER_A],
       maxBands: 4,
+      initialFallback: {
+        breakpoints: ['100000', '250000'],
+        marginalBps: [4, 10, 20],
+      },
     });
   });
 

--- a/typescript/sdk/src/fee/feeConfigMapping.ts
+++ b/typescript/sdk/src/fee/feeConfigMapping.ts
@@ -38,15 +38,23 @@ export function tokenFeeInputToFeeConfig(
         quoteSigners: input.quoteSigners ?? [],
       };
 
-    case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
+    case TokenFeeType.OffchainQuotedPiecewiseLinearFee: {
+      const fallback =
+        'initialFallback' in input
+          ? input.initialFallback
+          : input.fallbackCurve;
       return {
         type: input.type,
         owner: input.owner,
         beneficiary,
-        params: toFeeParams(input),
         quoteSigners: input.quoteSigners ?? [],
         maxBands: input.maxBands,
+        initialFallback: {
+          breakpoints: fallback.breakpoints.map(String),
+          marginalBps: fallback.marginalBps,
+        },
       };
+    }
 
     case TokenFeeType.RoutingFee:
       return {
@@ -100,13 +108,21 @@ function toFeeStrategy(input: TokenFeeConfigInput): FeeStrategy {
         quoteSigners: input.quoteSigners ?? [],
       };
 
-    case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
+    case TokenFeeType.OffchainQuotedPiecewiseLinearFee: {
+      const fallback =
+        'initialFallback' in input
+          ? input.initialFallback
+          : input.fallbackCurve;
       return {
         type: input.type,
-        params: toFeeParams(input),
         quoteSigners: input.quoteSigners ?? [],
         maxBands: input.maxBands,
+        initialFallback: {
+          breakpoints: fallback.breakpoints.map(String),
+          marginalBps: fallback.marginalBps,
+        },
       };
+    }
 
     default: {
       const _exhaustive: never = input;

--- a/typescript/sdk/src/fee/feeConfigMapping.ts
+++ b/typescript/sdk/src/fee/feeConfigMapping.ts
@@ -38,6 +38,16 @@ export function tokenFeeInputToFeeConfig(
         quoteSigners: input.quoteSigners ?? [],
       };
 
+    case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
+      return {
+        type: input.type,
+        owner: input.owner,
+        beneficiary,
+        params: toFeeParams(input),
+        quoteSigners: input.quoteSigners ?? [],
+        maxBands: input.maxBands,
+      };
+
     case TokenFeeType.RoutingFee:
       return {
         type: input.type,
@@ -88,6 +98,14 @@ function toFeeStrategy(input: TokenFeeConfigInput): FeeStrategy {
         type: input.type,
         params: toFeeParams(input),
         quoteSigners: input.quoteSigners ?? [],
+      };
+
+    case TokenFeeType.OffchainQuotedPiecewiseLinearFee:
+      return {
+        type: input.type,
+        params: toFeeParams(input),
+        quoteSigners: input.quoteSigners ?? [],
+        maxBands: input.maxBands,
       };
 
     default: {

--- a/typescript/sdk/src/fee/types.test.ts
+++ b/typescript/sdk/src/fee/types.test.ts
@@ -7,6 +7,7 @@ import {
   CrossCollateralRoutingFeeConfigSchema,
   CrossCollateralRoutingFeeInputConfigSchema,
   LinearFeeInputConfigSchema,
+  OffchainQuotedPiecewiseLinearFeeInputConfigSchema,
   RoutingFeeInputConfigSchema,
   TokenFeeType,
 } from './types.js';
@@ -122,6 +123,38 @@ describe('LinearFeeInputConfigSchema', () => {
       expect(result.data.bps).to.exist;
       expect(result.data.bps).to.be.a('number');
     }
+  });
+});
+
+describe('OffchainQuotedPiecewiseLinearFeeInputConfigSchema', () => {
+  const config = {
+    type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
+    owner: SOME_ADDRESS,
+    bps: 3,
+  } as const;
+
+  it('accepts a bounded maximum band count', () => {
+    expect(
+      OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
+        ...config,
+        maxBands: 4,
+      }).success,
+    ).to.equal(true);
+  });
+
+  it('rejects maximum band counts outside the contract bounds', () => {
+    expect(
+      OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
+        ...config,
+        maxBands: 0,
+      }).success,
+    ).to.equal(false);
+    expect(
+      OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
+        ...config,
+        maxBands: 257,
+      }).success,
+    ).to.equal(false);
   });
 });
 

--- a/typescript/sdk/src/fee/types.test.ts
+++ b/typescript/sdk/src/fee/types.test.ts
@@ -130,7 +130,10 @@ describe('OffchainQuotedPiecewiseLinearFeeInputConfigSchema', () => {
   const config = {
     type: TokenFeeType.OffchainQuotedPiecewiseLinearFee,
     owner: SOME_ADDRESS,
-    bps: 3,
+    initialFallback: {
+      breakpoints: [100_000n, 250_000n],
+      marginalBps: [4, 10, 20],
+    },
   } as const;
 
   it('accepts a bounded maximum band count', () => {
@@ -153,6 +156,43 @@ describe('OffchainQuotedPiecewiseLinearFeeInputConfigSchema', () => {
       OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
         ...config,
         maxBands: 257,
+      }).success,
+    ).to.equal(false);
+  });
+
+  it('accepts a one-band constant fallback', () => {
+    const result = OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
+      ...config,
+      maxBands: 1,
+      initialFallback: { breakpoints: [], marginalBps: [4.5] },
+    });
+    expect(result.success).to.equal(true);
+  });
+
+  it('rejects malformed, decreasing, or all-zero fallbacks', () => {
+    const invalidFallbacks = [
+      { breakpoints: [100n], marginalBps: [4] },
+      { breakpoints: [100n, 50n], marginalBps: [4, 10, 20] },
+      { breakpoints: [100n], marginalBps: [10, 4] },
+      { breakpoints: [], marginalBps: [0] },
+    ];
+
+    for (const initialFallback of invalidFallbacks) {
+      expect(
+        OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
+          ...config,
+          maxBands: 4,
+          initialFallback,
+        }).success,
+      ).to.equal(false);
+    }
+  });
+
+  it('rejects fallbacks that exceed maxBands', () => {
+    expect(
+      OffchainQuotedPiecewiseLinearFeeInputConfigSchema.safeParse({
+        ...config,
+        maxBands: 2,
       }).success,
     ).to.equal(false);
   });

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -215,63 +215,145 @@ export type OffchainQuotedLinearFeeInputConfig = z.infer<
   typeof OffchainQuotedLinearFeeInputConfigSchema
 >;
 
+const UINT128_MAX = (1n << 128n) - 1n;
+
+function validatePiecewiseCurve(
+  curve: {
+    breakpoints: bigint[];
+    marginalBps: number[];
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (curve.breakpoints.length + 1 !== curve.marginalBps.length) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['marginalBps'],
+      message: 'marginalBps must contain one more value than breakpoints',
+    });
+  }
+
+  for (let i = 0; i < curve.breakpoints.length; i += 1) {
+    if (curve.breakpoints[i] === 0n || curve.breakpoints[i] > UINT128_MAX) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['breakpoints', i],
+        message: 'breakpoints must be positive uint128 values',
+      });
+    }
+    if (i > 0 && curve.breakpoints[i] <= curve.breakpoints[i - 1]) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['breakpoints', i],
+        message: 'breakpoints must be strictly increasing',
+      });
+    }
+  }
+
+  for (let i = 0; i < curve.marginalBps.length; i += 1) {
+    const marginalBps = curve.marginalBps[i];
+    if (marginalBps > 10_000) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['marginalBps', i],
+        message: 'marginalBps must not exceed 10000 bps',
+      });
+    }
+    if (!isBpsPrecisionValid(marginalBps)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['marginalBps', i],
+        message: `marginalBps must have at most ${MAX_BPS_DECIMALS} decimal places`,
+      });
+    }
+    if (i > 0 && marginalBps < curve.marginalBps[i - 1]) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['marginalBps', i],
+        message: 'marginalBps must be nondecreasing',
+      });
+    }
+  }
+
+  if (curve.marginalBps.every((marginalBps) => marginalBps === 0)) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['marginalBps'],
+      message: 'fallback curve must charge a positive rate',
+    });
+  }
+}
+
+const PiecewiseCurveBaseSchema = z.object({
+  breakpoints: z.array(ZBigNumberish).max(255),
+  marginalBps: z.array(ZBps).min(1).max(256),
+});
+
+export const PiecewiseCurveSchema = PiecewiseCurveBaseSchema.superRefine(
+  validatePiecewiseCurve,
+);
+export type PiecewiseCurve = z.infer<typeof PiecewiseCurveSchema>;
+
+export const DerivedPiecewiseFallbackSchema = PiecewiseCurveBaseSchema.extend({
+  issuedAt: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(2 ** 48 - 1),
+}).superRefine(validatePiecewiseCurve);
+export type DerivedPiecewiseFallback = z.infer<
+  typeof DerivedPiecewiseFallbackSchema
+>;
+
 export const OffchainQuotedPiecewiseLinearFeeConfigSchema =
-  BpsConfigSchema.merge(QuoteSignersSchema).extend({
+  BaseFeeConfigSchema.merge(QuoteSignersSchema).extend({
     type: z.literal(TokenFeeType.OffchainQuotedPiecewiseLinearFee),
     maxBands: z.number().int().min(1).max(256),
+    fallbackCurve: DerivedPiecewiseFallbackSchema,
   });
 export type OffchainQuotedPiecewiseLinearFeeConfig = z.infer<
   typeof OffchainQuotedPiecewiseLinearFeeConfigSchema
 >;
 
-export const OffchainQuotedPiecewiseLinearFeeInputConfigSchema =
+export const InitialOffchainQuotedPiecewiseLinearFeeInputConfigSchema =
   BaseFeeConfigInputSchema.merge(QuoteSignersSchema)
     .extend({
       type: z.literal(TokenFeeType.OffchainQuotedPiecewiseLinearFee),
       maxBands: z.number().int().min(1).max(256),
-      bps: ZBps.optional(),
-      ...FeeParametersSchema.partial().shape,
+      initialFallback: PiecewiseCurveSchema,
     })
     .superRefine((v, ctx) => {
-      const hasBps = v.bps !== undefined;
-      const hasFeeParams = v.maxFee !== undefined && v.halfAmount !== undefined;
-
-      if (!hasBps && !hasFeeParams) {
+      if (v.initialFallback.marginalBps.length > v.maxBands) {
         ctx.addIssue({
           code: 'custom',
-          path: ['bps'],
-          message: 'Provide bps or both maxFee and halfAmount',
+          path: ['initialFallback', 'marginalBps'],
+          message: 'initial fallback curve exceeds maxBands',
         });
       }
+    });
 
-      if (hasBps && v.bps! <= 0) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['bps'],
-          message: 'bps must be > 0',
-        });
-      }
-
-      if (hasBps && !isBpsPrecisionValid(v.bps!)) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['bps'],
-          message: `bps must have at most ${MAX_BPS_DECIMALS} decimal places`,
-        });
-      }
-
-      if (v.halfAmount === 0n) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['halfAmount'],
-          message: 'halfAmount must be > 0',
-        });
-      }
+// Read results use fallbackCurve to distinguish mutable on-chain state from
+// deployment-only initialFallback while remaining usable by generic modules.
+const DerivedOffchainQuotedPiecewiseLinearFeeInputConfigSchema =
+  BaseFeeConfigInputSchema.merge(QuoteSignersSchema)
+    .extend({
+      type: z.literal(TokenFeeType.OffchainQuotedPiecewiseLinearFee),
+      maxBands: z.number().int().min(1).max(256),
+      fallbackCurve: DerivedPiecewiseFallbackSchema,
     })
-    .transform((v) => ({
-      ...v,
-      bps: v.bps ?? convertToBps(v.maxFee!, v.halfAmount!),
-    }));
+    .superRefine((v, ctx) => {
+      if (v.fallbackCurve.marginalBps.length > v.maxBands) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['fallbackCurve', 'marginalBps'],
+          message: 'fallback curve exceeds maxBands',
+        });
+      }
+    });
+
+export const OffchainQuotedPiecewiseLinearFeeInputConfigSchema = z.union([
+  InitialOffchainQuotedPiecewiseLinearFeeInputConfigSchema,
+  DerivedOffchainQuotedPiecewiseLinearFeeInputConfigSchema,
+]);
 export type OffchainQuotedPiecewiseLinearFeeInputConfig = z.infer<
   typeof OffchainQuotedPiecewiseLinearFeeInputConfigSchema
 >;

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -23,6 +23,7 @@ export enum OnchainTokenFeeType {
   RoutingFee = 4,
   CrossCollateralRoutingFee = 5,
   OffchainQuotedLinearFee = 6,
+  OffchainQuotedPiecewiseLinearFee = 7,
 }
 
 export const TokenFeeType = {
@@ -32,6 +33,7 @@ export const TokenFeeType = {
   RoutingFee: 'RoutingFee',
   CrossCollateralRoutingFee: 'CrossCollateralRoutingFee',
   OffchainQuotedLinearFee: 'OffchainQuotedLinearFee',
+  OffchainQuotedPiecewiseLinearFee: 'OffchainQuotedPiecewiseLinearFee',
 } as const;
 
 export type TokenFeeType = (typeof TokenFeeType)[keyof typeof TokenFeeType];
@@ -55,6 +57,8 @@ export const onChainTypeToTokenFeeTypeMap: Record<
     TokenFeeType.CrossCollateralRoutingFee,
   [OnchainTokenFeeType.OffchainQuotedLinearFee]:
     TokenFeeType.OffchainQuotedLinearFee,
+  [OnchainTokenFeeType.OffchainQuotedPiecewiseLinearFee]:
+    TokenFeeType.OffchainQuotedPiecewiseLinearFee,
 };
 
 // keccak256("RoutingFee.DEFAULT_ROUTER") — same wildcard slot as provider-sdk's
@@ -211,6 +215,67 @@ export type OffchainQuotedLinearFeeInputConfig = z.infer<
   typeof OffchainQuotedLinearFeeInputConfigSchema
 >;
 
+export const OffchainQuotedPiecewiseLinearFeeConfigSchema =
+  BpsConfigSchema.merge(QuoteSignersSchema).extend({
+    type: z.literal(TokenFeeType.OffchainQuotedPiecewiseLinearFee),
+    maxBands: z.number().int().min(1).max(256),
+  });
+export type OffchainQuotedPiecewiseLinearFeeConfig = z.infer<
+  typeof OffchainQuotedPiecewiseLinearFeeConfigSchema
+>;
+
+export const OffchainQuotedPiecewiseLinearFeeInputConfigSchema =
+  BaseFeeConfigInputSchema.merge(QuoteSignersSchema)
+    .extend({
+      type: z.literal(TokenFeeType.OffchainQuotedPiecewiseLinearFee),
+      maxBands: z.number().int().min(1).max(256),
+      bps: ZBps.optional(),
+      ...FeeParametersSchema.partial().shape,
+    })
+    .superRefine((v, ctx) => {
+      const hasBps = v.bps !== undefined;
+      const hasFeeParams = v.maxFee !== undefined && v.halfAmount !== undefined;
+
+      if (!hasBps && !hasFeeParams) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['bps'],
+          message: 'Provide bps or both maxFee and halfAmount',
+        });
+      }
+
+      if (hasBps && v.bps! <= 0) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['bps'],
+          message: 'bps must be > 0',
+        });
+      }
+
+      if (hasBps && !isBpsPrecisionValid(v.bps!)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['bps'],
+          message: `bps must have at most ${MAX_BPS_DECIMALS} decimal places`,
+        });
+      }
+
+      if (v.halfAmount === 0n) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['halfAmount'],
+          message: 'halfAmount must be > 0',
+        });
+      }
+    })
+    .transform((v) => ({
+      ...v,
+      bps: v.bps ?? convertToBps(v.maxFee!, v.halfAmount!),
+    }));
+export type OffchainQuotedPiecewiseLinearFeeInputConfig = z.infer<
+  typeof OffchainQuotedPiecewiseLinearFeeInputConfigSchema
+>;
+
 export const ProgressiveFeeConfigSchema = StandardFeeConfigBaseSchema.extend({
   type: z.literal(TokenFeeType.ProgressiveFee),
 });
@@ -321,6 +386,7 @@ export type CrossCollateralRoutingFeeInputConfig = z.infer<
 export const TokenFeeConfigSchema = z.discriminatedUnion('type', [
   LinearFeeConfigSchema,
   OffchainQuotedLinearFeeConfigSchema,
+  OffchainQuotedPiecewiseLinearFeeConfigSchema,
   ProgressiveFeeConfigSchema,
   RegressiveFeeConfigSchema,
   RoutingFeeConfigSchema,
@@ -331,6 +397,7 @@ export type TokenFeeConfig = z.infer<typeof TokenFeeConfigSchema>;
 export const TokenFeeConfigInputSchema = z.union([
   LinearFeeInputConfigSchema,
   OffchainQuotedLinearFeeInputConfigSchema,
+  OffchainQuotedPiecewiseLinearFeeInputConfigSchema,
   ProgressiveFeeInputConfigSchema,
   RegressiveFeeInputConfigSchema,
   RoutingFeeInputConfigSchema,
@@ -364,9 +431,15 @@ export type ResolvedOffchainQuotedLinearFeeConfigInput =
     token: string;
   };
 
+export type ResolvedOffchainQuotedPiecewiseLinearFeeConfigInput =
+  OffchainQuotedPiecewiseLinearFeeInputConfig & {
+    token: string;
+  };
+
 export type ResolvedTokenFeeConfigInput =
   | ResolvedLinearFeeConfigInput
   | ResolvedOffchainQuotedLinearFeeConfigInput
+  | ResolvedOffchainQuotedPiecewiseLinearFeeConfigInput
   | ResolvedProgressiveFeeConfigInput
   | ResolvedRegressiveFeeConfigInput
   | ResolvedRoutingFeeConfigInput

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -1135,6 +1135,11 @@ export {
   OffchainQuotedPiecewiseLinearFeeConfigSchema,
   OffchainQuotedPiecewiseLinearFeeInputConfig,
   OffchainQuotedPiecewiseLinearFeeInputConfigSchema,
+  InitialOffchainQuotedPiecewiseLinearFeeInputConfigSchema,
+  PiecewiseCurve,
+  PiecewiseCurveSchema,
+  DerivedPiecewiseFallback,
+  DerivedPiecewiseFallbackSchema,
   QuoteSignersSchema,
   QuoteSignersConfig,
 } from './fee/types.js';

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -1131,6 +1131,10 @@ export {
   OffchainQuotedLinearFeeConfig,
   OffchainQuotedLinearFeeConfigSchema,
   OffchainQuotedLinearFeeInputConfigSchema,
+  OffchainQuotedPiecewiseLinearFeeConfig,
+  OffchainQuotedPiecewiseLinearFeeConfigSchema,
+  OffchainQuotedPiecewiseLinearFeeInputConfig,
+  OffchainQuotedPiecewiseLinearFeeInputConfigSchema,
   QuoteSignersSchema,
   QuoteSignersConfig,
 } from './fee/types.js';

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -13,6 +13,14 @@ export {
   parseEip712Signable,
 } from './quote/Eip712Signable.js';
 export { EvmPrivateKeyQuoteSigner } from './quote/EvmPrivateKeyQuoteSigner.js';
+export {
+  type CreateEvmPiecewiseWarpQuoteRequest,
+  type EvmPiecewiseStandingCurve,
+  type EvmPiecewiseStoredStandingCurve,
+  encodeEvmPiecewiseStandingQuoteData,
+  validateEvmPiecewiseStandingCurve,
+} from './quote/EvmPiecewiseQuote.js';
+export { EvmPiecewiseQuoteWriter } from './quote/EvmPiecewiseQuoteWriter.js';
 export { EvmQuoteArtifactManager } from './quote/EvmQuoteArtifactManager.js';
 export { EvmQuoteReader } from './quote/EvmQuoteReader.js';
 export { EvmQuoteWriter } from './quote/EvmQuoteWriter.js';

--- a/typescript/sdk/src/quote/EvmPiecewiseQuote.test.ts
+++ b/typescript/sdk/src/quote/EvmPiecewiseQuote.test.ts
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+import { utils as ethersUtils } from 'ethers';
+
+import {
+  type EvmPiecewiseStandingCurve,
+  encodeEvmPiecewiseStandingQuoteData,
+  validateEvmPiecewiseStandingCurve,
+} from './EvmPiecewiseQuote.js';
+
+const VALID_CURVE: EvmPiecewiseStandingCurve = {
+  breakpoints: [250_000n, 750_000n],
+  marginalBpsX1e4: [40_000, 100_000, 200_000],
+  staleAfterSeconds: 60,
+  staleMarginalSurchargeBpsX1e4: [10_000, 20_000, 30_000],
+};
+
+describe('EvmPiecewiseQuote', () => {
+  it('ABI-encodes the exact standing-curve contract layout', () => {
+    const encoded = encodeEvmPiecewiseStandingQuoteData(VALID_CURVE);
+    const [breakpoints, marginalRates, staleAfter, surcharges] =
+      ethersUtils.defaultAbiCoder.decode(
+        ['uint128[]', 'uint32[]', 'uint32', 'uint32[]'],
+        encoded,
+      );
+
+    expect(
+      breakpoints.map((value: { toString(): string }) => value.toString()),
+    ).to.deep.equal(['250000', '750000']);
+    expect(marginalRates).to.deep.equal([40_000, 100_000, 200_000]);
+    expect(staleAfter).to.equal(60);
+    expect(surcharges).to.deep.equal([10_000, 20_000, 30_000]);
+  });
+
+  it('accepts a curve bounded by a deployed maxBands value', () => {
+    expect(() => validateEvmPiecewiseStandingCurve(VALID_CURVE, 3)).to.not
+      .throw;
+  });
+
+  for (const test of [
+    {
+      name: 'empty bands',
+      curve: {
+        ...VALID_CURVE,
+        breakpoints: [],
+        marginalBpsX1e4: [],
+        staleMarginalSurchargeBpsX1e4: [],
+      },
+      error: /at least one band/,
+    },
+    {
+      name: 'too many bands for the deployed contract',
+      curve: VALID_CURVE,
+      maxBands: 2,
+      error: /3 bands but maxBands is 2/,
+    },
+    {
+      name: 'mismatched breakpoints',
+      curve: { ...VALID_CURVE, breakpoints: [250_000n] },
+      error: /one more value than breakpoints/,
+    },
+    {
+      name: 'non-increasing breakpoints',
+      curve: { ...VALID_CURVE, breakpoints: [250_000n, 250_000n] },
+      error: /strictly increasing/,
+    },
+    {
+      name: 'non-increasing marginal rates',
+      curve: { ...VALID_CURVE, marginalBpsX1e4: [40_000, 30_000, 200_000] },
+      error: /marginalBpsX1e4 must be nondecreasing/,
+    },
+    {
+      name: 'mismatched stale surcharges',
+      curve: { ...VALID_CURVE, staleMarginalSurchargeBpsX1e4: [10_000] },
+      error: /one value per band/,
+    },
+    {
+      name: 'non-increasing stale surcharges',
+      curve: {
+        ...VALID_CURVE,
+        staleMarginalSurchargeBpsX1e4: [10_000, 5_000, 30_000],
+      },
+      error: /Stale surcharges must be nondecreasing/,
+    },
+    {
+      name: 'stale rate above the contract maximum',
+      curve: {
+        ...VALID_CURVE,
+        marginalBpsX1e4: [99_990_000, 99_990_000, 99_990_000],
+        staleMarginalSurchargeBpsX1e4: [20_000, 20_000, 20_000],
+      },
+      error: /keep every stale rate at or below/,
+    },
+    {
+      name: 'zero stale threshold',
+      curve: { ...VALID_CURVE, staleAfterSeconds: 0 },
+      error: /greater than zero/,
+    },
+  ]) {
+    it(`rejects ${test.name}`, () => {
+      expect(() =>
+        validateEvmPiecewiseStandingCurve(test.curve, test.maxBands),
+      ).to.throw(test.error);
+    });
+  }
+});

--- a/typescript/sdk/src/quote/EvmPiecewiseQuote.ts
+++ b/typescript/sdk/src/quote/EvmPiecewiseQuote.ts
@@ -1,0 +1,123 @@
+import { utils as ethersUtils } from 'ethers';
+
+import { type WarpQuoteScope } from '@hyperlane-xyz/provider-sdk/quote';
+import { assert } from '@hyperlane-xyz/utils';
+
+const UINT32_MAX = 0xff_ff_ff_ff;
+const UINT128_MAX = (1n << 128n) - 1n;
+const MAX_SUPPORTED_BANDS = 256;
+const MAX_MARGINAL_BPS_X1E4 = 100_000_000;
+
+/** Raw standing-curve units expected by OffchainQuotedPiecewiseLinearFee. */
+export interface EvmPiecewiseStandingCurve {
+  breakpoints: bigint[];
+  marginalBpsX1e4: number[];
+  staleAfterSeconds: number;
+  staleMarginalSurchargeBpsX1e4: number[];
+}
+
+/** Raw stored standing-curve state returned by the EVM fee contract. */
+export interface EvmPiecewiseStoredStandingCurve extends EvmPiecewiseStandingCurve {
+  exists: boolean;
+  issuedAt: number;
+  expiry: number;
+}
+
+/** EVM-only request for a persistent piecewise warp-fee quote. */
+export interface CreateEvmPiecewiseWarpQuoteRequest {
+  scope: WarpQuoteScope;
+  curve: EvmPiecewiseStandingCurve;
+  issuedAt: number;
+  expiry: number;
+}
+
+function assertUint32(value: number, label: string): void {
+  assert(
+    Number.isInteger(value) && value >= 0 && value <= UINT32_MAX,
+    `${label} must be a uint32.`,
+  );
+}
+
+/**
+ * Validates the exact invariants enforced by the piecewise fee contract.
+ * `maxBands` may be narrowed to the deployed contract's immutable limit.
+ */
+export function validateEvmPiecewiseStandingCurve(
+  curve: EvmPiecewiseStandingCurve,
+  maxBands: number = MAX_SUPPORTED_BANDS,
+): void {
+  assert(
+    Number.isInteger(maxBands) &&
+      maxBands > 0 &&
+      maxBands <= MAX_SUPPORTED_BANDS,
+    `maxBands must be between 1 and ${MAX_SUPPORTED_BANDS}.`,
+  );
+
+  const bandCount = curve.marginalBpsX1e4.length;
+  assert(bandCount > 0, 'A piecewise curve must contain at least one band.');
+  assert(
+    bandCount <= maxBands,
+    `Piecewise curve has ${bandCount} bands but maxBands is ${maxBands}.`,
+  );
+  assert(
+    curve.breakpoints.length + 1 === bandCount,
+    'marginalBpsX1e4 must contain exactly one more value than breakpoints.',
+  );
+  assert(
+    curve.staleMarginalSurchargeBpsX1e4.length === bandCount,
+    'staleMarginalSurchargeBpsX1e4 must contain one value per band.',
+  );
+
+  let previousBreakpoint = 0n;
+  for (const breakpoint of curve.breakpoints) {
+    assert(
+      typeof breakpoint === 'bigint' &&
+        breakpoint > previousBreakpoint &&
+        breakpoint <= UINT128_MAX,
+      'breakpoints must be strictly increasing positive uint128 values.',
+    );
+    previousBreakpoint = breakpoint;
+  }
+
+  let previousRate = 0;
+  let previousSurcharge = 0;
+  for (let i = 0; i < bandCount; i += 1) {
+    const rate = curve.marginalBpsX1e4[i];
+    const surcharge = curve.staleMarginalSurchargeBpsX1e4[i];
+    assertUint32(rate, `marginalBpsX1e4[${i}]`);
+    assert(
+      rate <= MAX_MARGINAL_BPS_X1E4 && rate >= previousRate,
+      'marginalBpsX1e4 must be nondecreasing and no greater than 10000 bps.',
+    );
+    assertUint32(surcharge, `staleMarginalSurchargeBpsX1e4[${i}]`);
+    assert(
+      surcharge >= previousSurcharge &&
+        rate + surcharge <= MAX_MARGINAL_BPS_X1E4,
+      'Stale surcharges must be nondecreasing and keep every stale rate at or below 10000 bps.',
+    );
+    previousRate = rate;
+    previousSurcharge = surcharge;
+  }
+
+  assertUint32(curve.staleAfterSeconds, 'staleAfterSeconds');
+  assert(
+    curve.staleAfterSeconds > 0,
+    'staleAfterSeconds must be greater than zero.',
+  );
+}
+
+/** ABI-encodes the standing quote data consumed by the EVM piecewise fee. */
+export function encodeEvmPiecewiseStandingQuoteData(
+  curve: EvmPiecewiseStandingCurve,
+): string {
+  validateEvmPiecewiseStandingCurve(curve);
+  return ethersUtils.defaultAbiCoder.encode(
+    ['uint128[]', 'uint32[]', 'uint32', 'uint32[]'],
+    [
+      curve.breakpoints,
+      curve.marginalBpsX1e4,
+      curve.staleAfterSeconds,
+      curve.staleMarginalSurchargeBpsX1e4,
+    ],
+  );
+}

--- a/typescript/sdk/src/quote/EvmPiecewiseQuoteWriter.hardhat-test.ts
+++ b/typescript/sdk/src/quote/EvmPiecewiseQuoteWriter.hardhat-test.ts
@@ -1,0 +1,168 @@
+import { type SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { Wallet } from 'ethers';
+import hre from 'hardhat';
+
+import {
+  ERC20Test__factory,
+  type OffchainQuotedPiecewiseLinearFee,
+  OffchainQuotedPiecewiseLinearFee__factory,
+} from '@hyperlane-xyz/core';
+import {
+  WARP_QUOTE_AMOUNT_WILDCARD,
+  WARP_TARGET_ROUTER_NONE,
+  WILDCARD_BYTES32,
+} from '@hyperlane-xyz/provider-sdk/quote';
+
+import { EvmPrivateKeyQuoteSigner } from './EvmPrivateKeyQuoteSigner.js';
+import {
+  type CreateEvmPiecewiseWarpQuoteRequest,
+  type EvmPiecewiseStandingCurve,
+} from './EvmPiecewiseQuote.js';
+import { EvmPiecewiseQuoteWriter } from './EvmPiecewiseQuoteWriter.js';
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+// Anvil / hardhat default test mnemonic — public, no live funds.
+const TEST_MNEMONIC =
+  'test test test test test test test test test test test junk';
+const DESTINATION = 42161;
+const RECIPIENT = WILDCARD_BYTES32;
+
+const CURVE: EvmPiecewiseStandingCurve = {
+  breakpoints: [250_000n, 750_000n],
+  marginalBpsX1e4: [40_000, 100_000, 200_000],
+  staleAfterSeconds: 60,
+  staleMarginalSurchargeBpsX1e4: [10_000, 20_000, 30_000],
+};
+
+describe('EvmPiecewiseQuoteWriter (hardhat)', () => {
+  let owner: SignerWithAddress;
+  let fee: OffchainQuotedPiecewiseLinearFee;
+  let quoteSignerWallet: Wallet;
+
+  before(async () => {
+    [owner] = await hre.ethers.getSigners();
+    const token = await new ERC20Test__factory(owner).deploy(
+      'fake',
+      'FAKE',
+      '100000000000000000000',
+      6,
+    );
+    await token.deployed();
+
+    quoteSignerWallet = Wallet.fromMnemonic(TEST_MNEMONIC, "m/44'/60'/0'/0/1");
+    fee = await new OffchainQuotedPiecewiseLinearFee__factory(owner).deploy(
+      quoteSignerWallet.address,
+      token.address,
+      [250_000n, 750_000n],
+      [40_000, 100_000, 200_000],
+      3,
+      owner.address,
+    );
+    await fee.deployed();
+  });
+
+  function makeWriter(privateKey: string = quoteSignerWallet.privateKey) {
+    return new EvmPiecewiseQuoteWriter(
+      owner,
+      new EvmPrivateKeyQuoteSigner(privateKey),
+      fee.address,
+    );
+  }
+
+  async function nowSec(): Promise<number> {
+    return (await hre.ethers.provider.getBlock('latest')).timestamp;
+  }
+
+  async function request(
+    destination: number = DESTINATION,
+  ): Promise<CreateEvmPiecewiseWarpQuoteRequest> {
+    const issuedAt = await nowSec();
+    return {
+      scope: {
+        destination,
+        recipient: RECIPIENT,
+        targetRouter: WARP_TARGET_ROUTER_NONE,
+        amount: WARP_QUOTE_AMOUNT_WILDCARD,
+      },
+      curve: CURVE,
+      issuedAt,
+      expiry: issuedAt + 3_600,
+    };
+  }
+
+  it('submits, confirms, and reads back a raw standing curve', async () => {
+    const writer = makeWriter();
+    const req = await request();
+    const submitted = await writer.submitQuote(req);
+
+    expect(submitted.txHash).to.match(/^0x[0-9a-f]{64}$/);
+    expect(submitted.signature).to.match(/^0x[0-9a-f]+$/);
+    expect(submitted.standingStored).to.equal(true);
+
+    const stored = await writer.readStandingCurve(DESTINATION, RECIPIENT);
+    expect(stored).to.deep.equal({
+      exists: true,
+      ...CURVE,
+      issuedAt: req.issuedAt,
+      expiry: req.expiry,
+    });
+  });
+
+  it('returns an explicit empty stored-curve result for an unused scope', async () => {
+    const stored = await makeWriter().readStandingCurve(99_999, RECIPIENT);
+    expect(stored).to.deep.equal({
+      exists: false,
+      breakpoints: [],
+      marginalBpsX1e4: [],
+      staleAfterSeconds: 0,
+      staleMarginalSurchargeBpsX1e4: [],
+      issuedAt: 0,
+      expiry: 0,
+    });
+  });
+
+  it('reports an equal-issuedAt resubmission as a stored-curve no-op', async () => {
+    const writer = makeWriter();
+    const req = await request(42_162);
+    expect((await writer.submitQuote(req)).standingStored).to.equal(true);
+    expect((await writer.submitQuote(req)).standingStored).to.equal(false);
+  });
+
+  it('rejects an unauthorized quote signer before signing or submitting', async () => {
+    const otherWallet = Wallet.fromMnemonic(TEST_MNEMONIC, "m/44'/60'/0'/0/9");
+    await expect(
+      makeWriter(otherWallet.privateKey).submitQuote(await request(1)),
+    ).to.be.rejectedWith(/not authorized/);
+  });
+
+  it('rejects curves larger than the deployed maxBands', async () => {
+    const req = await request(2);
+    req.curve = {
+      breakpoints: [1n, 2n, 3n],
+      marginalBpsX1e4: [1, 2, 3, 4],
+      staleAfterSeconds: 60,
+      staleMarginalSurchargeBpsX1e4: [0, 0, 0, 0],
+    };
+    await expect(makeWriter().submitQuote(req)).to.be.rejectedWith(
+      /4 bands but maxBands is 3/,
+    );
+  });
+
+  it('rejects non-standing requests and stale thresholds after expiry', async () => {
+    const transient = await request(3);
+    transient.expiry = transient.issuedAt;
+    await expect(makeWriter().submitQuote(transient)).to.be.rejectedWith(
+      /must be standing quotes/,
+    );
+
+    const staleAfterExpiry = await request(4);
+    staleAfterExpiry.curve = { ...CURVE, staleAfterSeconds: 3_601 };
+    await expect(makeWriter().submitQuote(staleAfterExpiry)).to.be.rejectedWith(
+      /no later than expiry/,
+    );
+  });
+});

--- a/typescript/sdk/src/quote/EvmPiecewiseQuoteWriter.ts
+++ b/typescript/sdk/src/quote/EvmPiecewiseQuoteWriter.ts
@@ -1,0 +1,150 @@
+import { type Signer, constants, utils as ethersUtils } from 'ethers';
+
+import { OffchainQuotedPiecewiseLinearFee__factory } from '@hyperlane-xyz/core';
+import {
+  type RawQuoteSigner,
+  type SubmittedWarpQuote,
+  WarpQuoteAmountKind,
+} from '@hyperlane-xyz/provider-sdk/quote';
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  type CreateEvmPiecewiseWarpQuoteRequest,
+  type EvmPiecewiseStoredStandingCurve,
+  encodeEvmPiecewiseStandingQuoteData,
+  validateEvmPiecewiseStandingCurve,
+} from './EvmPiecewiseQuote.js';
+import {
+  type EvmSignedQuoteTuple,
+  buildEvmSignedQuoteSignable,
+} from './WarpSignedQuoteEip712.js';
+
+const UINT32_MAX = 0xff_ff_ff_ff;
+const UINT48_MAX = 2 ** 48 - 1;
+
+function assertUint48(value: number, label: string): void {
+  assert(
+    Number.isInteger(value) && value >= 0 && value <= UINT48_MAX,
+    `${label} must be a uint48.`,
+  );
+}
+
+/**
+ * Submits persistent piecewise warp-fee quotes to EVM. The writer binds each
+ * signature to its tx submitter, waits for finality, and exposes raw stored
+ * curve readback without requiring consumers to import the core ABI package.
+ */
+export class EvmPiecewiseQuoteWriter {
+  constructor(
+    private readonly txSigner: Signer,
+    private readonly quoteSigner: RawQuoteSigner,
+    private readonly feeAddress: string,
+  ) {}
+
+  async submitQuote(
+    req: CreateEvmPiecewiseWarpQuoteRequest,
+  ): Promise<SubmittedWarpQuote> {
+    assertUint48(req.issuedAt, 'issuedAt');
+    assertUint48(req.expiry, 'expiry');
+    assert(
+      req.expiry > req.issuedAt,
+      'EVM piecewise quotes must be standing quotes with expiry greater than issuedAt.',
+    );
+    assert(
+      Number.isInteger(req.scope.destination) &&
+        req.scope.destination >= 0 &&
+        req.scope.destination <= UINT32_MAX,
+      'scope.destination must be a uint32.',
+    );
+    assert(
+      ethersUtils.isHexString(req.scope.recipient, 32),
+      'scope.recipient must be a bytes32 hex string.',
+    );
+    assert(
+      req.scope.amount.kind === WarpQuoteAmountKind.wildcard,
+      'EVM piecewise standing quotes must use wildcard amount.',
+    );
+    assert(
+      req.issuedAt + req.curve.staleAfterSeconds <= req.expiry,
+      'staleAfterSeconds must elapse no later than expiry.',
+    );
+
+    const contract = OffchainQuotedPiecewiseLinearFee__factory.connect(
+      this.feeAddress,
+      this.txSigner,
+    );
+    const quoteSignerAddress = await this.quoteSigner.address();
+    const [isAuthorized, maxBands] = await Promise.all([
+      contract.isQuoteSigner(quoteSignerAddress),
+      contract.maxBands(),
+    ]);
+    assert(
+      isAuthorized,
+      `Quote signer ${quoteSignerAddress} is not authorized on OffchainQuotedPiecewiseLinearFee at ${this.feeAddress}.`,
+    );
+    validateEvmPiecewiseStandingCurve(req.curve, maxBands);
+
+    const chainId = await this.txSigner.getChainId();
+    const submitter = await this.txSigner.getAddress();
+    const salt = ethersUtils.hexlify(ethersUtils.randomBytes(32));
+    const sq: EvmSignedQuoteTuple = {
+      context: ethersUtils.solidityPack(
+        ['uint32', 'bytes32', 'uint256'],
+        [req.scope.destination, req.scope.recipient, constants.MaxUint256],
+      ),
+      data: encodeEvmPiecewiseStandingQuoteData(req.curve),
+      issuedAt: req.issuedAt,
+      expiry: req.expiry,
+      salt,
+      submitter,
+    };
+    const signable = buildEvmSignedQuoteSignable(sq, chainId, this.feeAddress);
+    const { signature } = await this.quoteSigner.sign(signable);
+    const signatureHex = ethersUtils.hexlify(signature);
+
+    const tx = await contract.submitQuote(sq, signatureHex);
+    const receipt = await tx.wait();
+    const standingStored = receipt.logs.some(
+      (entry) =>
+        entry.address.toLowerCase() === this.feeAddress.toLowerCase() &&
+        entry.topics[0] === contract.interface.getEventTopic('QuoteSubmitted'),
+    );
+
+    return {
+      txHash: receipt.transactionHash,
+      signature: signatureHex,
+      standingStored,
+    };
+  }
+
+  async readStandingCurve(
+    destination: number,
+    recipient: string,
+  ): Promise<EvmPiecewiseStoredStandingCurve> {
+    assert(
+      Number.isInteger(destination) &&
+        destination >= 0 &&
+        destination <= UINT32_MAX,
+      'destination must be a uint32.',
+    );
+    assert(
+      ethersUtils.isHexString(recipient, 32),
+      'recipient must be a bytes32 hex string.',
+    );
+
+    const contract = OffchainQuotedPiecewiseLinearFee__factory.connect(
+      this.feeAddress,
+      this.txSigner,
+    );
+    const stored = await contract.getCurve(destination, recipient);
+    return {
+      exists: stored.expiry !== 0,
+      breakpoints: stored.breakpoints.map((value) => value.toBigInt()),
+      marginalBpsX1e4: [...stored.marginalBpsX1e4],
+      staleAfterSeconds: stored.staleAfterSeconds,
+      staleMarginalSurchargeBpsX1e4: [...stored.staleMarginalSurchargeBpsX1e4],
+      issuedAt: stored.issuedAt,
+      expiry: stored.expiry,
+    };
+  }
+}

--- a/typescript/svm-sdk/src/alt/warp-alt.ts
+++ b/typescript/svm-sdk/src/alt/warp-alt.ts
@@ -164,6 +164,10 @@ export async function deriveFeeQuoteCascadeAltAddresses(args: {
     case FeeType.offchainQuotedLinear:
       cascade = await deriveLeafFeeCascade(cascadeArgs);
       break;
+    case FeeType.offchainQuotedPiecewiseLinear:
+      throw new Error(
+        'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+      );
     case FeeType.routing:
       cascade = await deriveRoutingFeeCascade(cascadeArgs);
       break;

--- a/typescript/svm-sdk/src/fee/fee-artifact-manager.ts
+++ b/typescript/svm-sdk/src/fee/fee-artifact-manager.ts
@@ -109,6 +109,11 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
           signer,
           this.salt,
         ),
+      [FeeType.offchainQuotedPiecewiseLinear]: () => {
+        throw new Error(
+          'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+        );
+      },
       [FeeType.routing]: () =>
         new SvmRoutingFeeWriter(
           { program },
@@ -149,6 +154,11 @@ export class SvmFeeArtifactManager implements IRawFeeArtifactManager {
         new SvmProgressiveFeeReader(this.rpc, this.salt),
       [FeeType.offchainQuotedLinear]: () =>
         new SvmOffchainQuotedLinearFeeReader(this.rpc, this.salt),
+      [FeeType.offchainQuotedPiecewiseLinear]: () => {
+        throw new Error(
+          'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+        );
+      },
       [FeeType.routing]: () =>
         new SvmRoutingFeeReader(this.rpc, context, this.salt),
       [FeeType.crossCollateralRouting]: () =>

--- a/typescript/svm-sdk/src/fee/fee-strategy-utils.ts
+++ b/typescript/svm-sdk/src/fee/fee-strategy-utils.ts
@@ -124,6 +124,11 @@ export function feeStrategyToOnChain(strategy: FeeStrategy): {
         signers: strategy.quoteSigners,
       };
 
+    case FeeStrategyType.offchainQuotedPiecewiseLinear:
+      throw new Error(
+        'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+      );
+
     default: {
       const _exhaustive: never = strategy;
       throw new Error(`Unhandled FeeStrategyType: ${String(_exhaustive)}`);
@@ -156,6 +161,11 @@ export function feeStrategiesEqual(a: FeeStrategy, b: FeeStrategy): boolean {
         new Set(b.quoteSigners.map((s) => s.toLowerCase())),
       );
     }
+
+    case FeeStrategyType.offchainQuotedPiecewiseLinear:
+      throw new Error(
+        'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+      );
 
     default: {
       const _exhaustive: never = a;

--- a/typescript/svm-sdk/src/fee/fee-strategy-utils.ts
+++ b/typescript/svm-sdk/src/fee/fee-strategy-utils.ts
@@ -138,6 +138,14 @@ export function feeStrategyToOnChain(strategy: FeeStrategy): {
 
 export function feeStrategiesEqual(a: FeeStrategy, b: FeeStrategy): boolean {
   if (a.type !== b.type) return false;
+  if (
+    a.type === FeeStrategyType.offchainQuotedPiecewiseLinear ||
+    b.type === FeeStrategyType.offchainQuotedPiecewiseLinear
+  ) {
+    throw new Error(
+      'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
+    );
+  }
 
   const aParams = resolveRawFeeParams(a.params);
   const bParams = resolveRawFeeParams(b.params);
@@ -161,11 +169,6 @@ export function feeStrategiesEqual(a: FeeStrategy, b: FeeStrategy): boolean {
         new Set(b.quoteSigners.map((s) => s.toLowerCase())),
       );
     }
-
-    case FeeStrategyType.offchainQuotedPiecewiseLinear:
-      throw new Error(
-        'OffchainQuotedPiecewiseLinearFee is not supported on Sealevel',
-      );
 
     default: {
       const _exhaustive: never = a;

--- a/typescript/svm-sdk/src/tests/fee-cross-collateral-routing.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-cross-collateral-routing.e2e-test.ts
@@ -254,9 +254,9 @@ describe('SVM Cross-Collateral Routing Fee E2E Tests', function () {
       DEFAULT_FEE_SALT,
     );
     const readResult = await reader.read(deployed.deployed.programId);
-    expect(readResult.config.routes[10]?.[ROUTER_A]?.params.maxFee).to.equal(
-      '9999',
-    );
+    const route = readResult.config.routes[10]?.[ROUTER_A];
+    assert(route?.type === FeeStrategyType.linear, 'Expected linear route');
+    expect(route.params.maxFee).to.equal('9999');
   });
 
   it('should change CC route strategy type', async () => {

--- a/typescript/svm-sdk/src/tests/fee-routing.e2e-test.ts
+++ b/typescript/svm-sdk/src/tests/fee-routing.e2e-test.ts
@@ -88,8 +88,9 @@ describe('SVM Routing Fee E2E Tests', function () {
     const readResult = await reader.read(deployed.deployed.programId);
 
     expect(readResult.config.type).to.equal(FeeType.routing);
-    expect(readResult.config.routes[10]?.type).to.equal(FeeStrategyType.linear);
-    expect(readResult.config.routes[10]?.params.maxFee).to.equal('1000');
+    const route10 = readResult.config.routes[10];
+    assert(route10?.type === FeeStrategyType.linear, 'Expected linear route');
+    expect(route10.params.maxFee).to.equal('1000');
     expect(readResult.config.routes[20]?.type).to.equal(
       FeeStrategyType.regressive,
     );
@@ -208,10 +209,12 @@ describe('SVM Routing Fee E2E Tests', function () {
       DEFAULT_FEE_SALT,
     );
     const readResult = await reader.read(deployed.deployed.programId);
-    expect(readResult.config.routes[20]?.type).to.equal(
-      FeeStrategyType.progressive,
+    const route20 = readResult.config.routes[20];
+    assert(
+      route20?.type === FeeStrategyType.progressive,
+      'Expected progressive route',
     );
-    expect(readResult.config.routes[20]?.params.maxFee).to.equal('3000');
+    expect(route20.params.maxFee).to.equal('3000');
   });
 
   it('should update params on an existing route', async () => {
@@ -246,8 +249,10 @@ describe('SVM Routing Fee E2E Tests', function () {
       DEFAULT_FEE_SALT,
     );
     const readResult = await reader.read(deployed.deployed.programId);
-    expect(readResult.config.routes[10]?.params.maxFee).to.equal('9999');
-    expect(readResult.config.routes[10]?.params.halfAmount).to.equal('4444');
+    const route10 = readResult.config.routes[10];
+    assert(route10?.type === FeeStrategyType.linear, 'Expected linear route');
+    expect(route10.params.maxFee).to.equal('9999');
+    expect(route10.params.halfAmount).to.equal('4444');
   });
 
   it('should change route strategy type', async () => {


### PR DESCRIPTION
## Summary

- Add `OffchainQuotedPiecewiseLinearFee` with marginal amount bands, per-band stale surcharges, bounded lookup, linear transient quotes, and a required permanent fallback curve.
- Allow authorized quote signers to replace both standing curves and the non-expiring fallback without redeployment; quote ordering is monotonic by `issuedAt`.
- Add provider SDK, deployment, reader, mutation, and fee-quoting support while preserving existing `quoteTransferRemote` and `transferRemote` caller ABIs.
- Keep route-specific publisher, staging topology, and production rollout changes out of this reusable contract/SDK PR.

## Behavior and risk controls

- Standing curves bind destination, recipient, wildcard amount, issue time, expiry, submitter, and verifying contract through EIP-712.
- Curves require increasing breakpoints, nondecreasing marginal rates and stale surcharges, rates at or below 100%, and an immutable `maxBands` deployment bound.
- Fresh rates widen once at `issuedAt + staleAfterSeconds`; the normal curve remains valid at exact expiry and the permanent fallback begins in the next block.
- Transient quotes retain the existing packed capped-linear payload.
- The routing root remains the router fee recipient. Explicit cross-collateral targets resolve through `quoteTransferRemoteTo`; primary/default routing continues through `quoteTransferRemote`.
- The new fee contract is excluded from the Tron compiler input because it is EVM-only and otherwise exceeds tron-solc WASM input limits.

## Validation

- Piecewise Solidity suite: 33/33 passed, including fuzz/reference, precedence, stale, expiry, mutable fallback, signer removal, and 256-band coverage.
- CrossCollateralRouter suite: 77/77 passed, including fresh/stale/expired piecewise leaf routing and quote-versus-transfer equality.
- Provider SDK: 117/117 passed.
- SDK unit suite: 911/911 passed.
- Fee-quoting focused tests: 5/5 passed.
- EVM Solidity build, Tron build with the explicit EVM-only exclusion, SDK build, and fee-quoting build passed.
- Commit hooks, formatting, lint-staged, changesets, and secret scan passed.

No route configuration, registry entry, or live onchain state is changed by this PR.