### PR TITLE
test(sdk): decouple legacy allowance fixture from release version

### DIFF
--- a/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
@@ -66,7 +66,10 @@ import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeModule } from '../fee/EvmTokenFeeModule.js';
 import { DEFAULT_ROUTER_KEY } from '../fee/types.js';
-import { EvmWarpModule } from './EvmWarpModule.js';
+import {
+  EvmWarpModule,
+  MAX_LEGACY_BRIDGE_APPROVAL_VERSION,
+} from './EvmWarpModule.js';
 import {
   EverclearTokenBridgeTokenType,
   MovableTokenType,
@@ -1636,10 +1639,16 @@ describe('EvmWarpModule', async () => {
           // Plant a legacy allowance so a stray revoke would be visible.
           await plantLegacyAllowance(router, allowedBridge);
 
-          // No version spoof and no contractVersion bump: actual == expected, so
+          // Keep the fixture on a legacy version. With no contractVersion bump,
           // update() generates no upgrade tx and the revoke gate stays closed.
+          const versionStub = sinon
+            .stub(evmERC20WarpModule.reader, 'fetchPackageVersion')
+            .resolves(MAX_LEGACY_BRIDGE_APPROVAL_VERSION);
+
           const txs = await evmERC20WarpModule.update(config);
           await sendTxs(txs);
+
+          versionStub.restore();
 
           // The legacy allowance is untouched (revoke must run only post-upgrade).
           expect(


### PR DESCRIPTION
## Summary

- pin the no-upgrade legacy allowance fixture to `MAX_LEGACY_BRIDGE_APPROVAL_VERSION`
- restore the package-version stub after the update
- keep the test independent of the generated release package version

## Root cause

The fixture relied on the deployed contract reporting the repository's current package version. A release PR changes that generated version, which moves the fixture onto the already-upgraded cleanup path and emits a revoke transaction. The test is specifically asserting legacy behavior without an upgrade, so its on-chain version must be explicit.

This is test-only and does not change SDK behavior or generated release files.

## Validation

- pre-commit gitleaks, oxlint, and oxfmt passed
- `git diff --check` passed
- focused Hardhat test setup compiled its Solidity dependency, then local execution stopped because a fresh worktree did not have `@hyperlane-xyz/core/dist/index.js`; CI will run against the built workspace
