### PR TITLE
chore(infra): drop rotated-out legacy hot key from awSvmSigners

### DIFF
--- a/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/aw.ts
@@ -14,13 +14,12 @@ export const awThreshold = 3;
 
 export const awSvmSigners: Address[] = [
   'A8goWfZ7a6smK9pdDgoDWyAq9p7jtvyERJN6VLd8zrx2', // 1
-  '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf', // 2
-  'A4voX3UC3TGLsKyEsDGWAvrjT3mpnA67Fx9cccdoPKqm', // 3
-  'B32qTbw8iDcVdagMAMBfDFCef88N1KtfRG5QoPVzbj5K', // 4
-  '8GjwFNTn2giBwEGo3qMrfNydEjXiQHUNf79rwAkTNmDy', // 5
-  'E7cD9kcNXUC6f7CFDUoqjWaWaPxY9WNpNxjhbh5HwMiE', // 6
-  '8U1cahSHqugrpPmEUm4ZNokJhoCDVGVjCB33EP1k2eFT', // 7
-  'AHWkCm6fuLCBqkSt5ZDNYWc8PTbWDLjrZDcLpcGQnSui', // 8
+  'A4voX3UC3TGLsKyEsDGWAvrjT3mpnA67Fx9cccdoPKqm', // 2
+  'B32qTbw8iDcVdagMAMBfDFCef88N1KtfRG5QoPVzbj5K', // 3
+  '8GjwFNTn2giBwEGo3qMrfNydEjXiQHUNf79rwAkTNmDy', // 4
+  'E7cD9kcNXUC6f7CFDUoqjWaWaPxY9WNpNxjhbh5HwMiE', // 5
+  '8U1cahSHqugrpPmEUm4ZNokJhoCDVGVjCB33EP1k2eFT', // 6
+  'AHWkCm6fuLCBqkSt5ZDNYWc8PTbWDLjrZDcLpcGQnSui', // 7
 ];
 
 export const awSvmThreshold = 3;


### PR DESCRIPTION
## Summary
- The legacy Sealevel deployer hot key (`9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf`) was removed from the AW SVM Squads multisigs on both `solanamainnet` and `eclipsemainnet` during the 2026-07/08 deployer-key rotation.
- This updates `awSvmSigners` in `mainnet3/governance/signers/aw.ts` to match the live on-chain member set (7 members: `A8go`, `A4vo`, `B32q`, `8Gjw`/Mo, `E7cD`/Troy, `8U1c`, `AHWk`).

## On-chain state (verified 2026-08-04)
- **solanamainnet** AW Squad: 7 members, threshold 4
- **eclipsemainnet** AW Squad: 7 members, threshold 3
- Both sets are identical and no longer contain the legacy `9bRS` key.

## Note
`awSvmThreshold` is left at `3`. The eclipse Squad threshold is 3, but the **solana** Squad threshold is 4 on-chain (quorum was intentionally left unchanged during the member adds, per Nam). This single config constant can't represent both; flagging for a follow-up decision rather than changing it here.

## Test plan
- [ ] Config-only change; no runtime behavior. CI lint/typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)