### PR TITLE
fix(ccip-server): match CCTP V1 burns by nonce

### DIFF
--- a/typescript/ccip-server/src/services/cctpMessageMatcher.ts
+++ b/typescript/ccip-server/src/services/cctpMessageMatcher.ts
@@ -12,6 +12,8 @@ const CIRCLE_HEADER_LENGTHS = [
   CIRCLE_HEADER_LENGTH_V1,
   CIRCLE_HEADER_LENGTH_V2,
 ];
+const CIRCLE_V1_NONCE_OFFSET = 12;
+const CIRCLE_V1_NONCE_LENGTH = 8;
 
 // BurnMessage body field offsets, relative to the end of the Circle header:
 // version(4) burnToken(32) mintRecipient(32) amount(32) messageSender(32) ...
@@ -40,6 +42,7 @@ const CIRCLE_GMP_MSG_LENGTHS = CIRCLE_HEADER_LENGTHS.map(
 const TOKEN_MSG_RECIPIENT_OFFSET = 0;
 const TOKEN_MSG_AMOUNT_OFFSET = 32;
 const TOKEN_MSG_MIN_LENGTH = 64;
+const TOKEN_MSG_METADATA_OFFSET = 64;
 
 /**
  * Given a list of raw Circle message hex strings from a transaction receipt,
@@ -48,6 +51,8 @@ const TOKEN_MSG_MIN_LENGTH = 64;
  * Strategy 1 — token transfer (depositForBurn path):
  *   Matches by (messageSender, amount, mintRecipient) from the Hyperlane message
  *   against BurnMessage fields, mirroring TokenBridgeCctp._validateTokenMessage.
+ *   Legacy V1 token messages include the Circle uint64 nonce as the first 8
+ *   metadata bytes; when present, it also disambiguates otherwise-identical burns.
  *   Tries both the CCTP V1 (116B) and V2 (148B) header lengths, so a V1 burn
  *   message (≥ 248 bytes) matches under V1 and a V2 burn (≥ 280) under V2.
  *
@@ -76,6 +81,13 @@ export function findMatchingCircleMessage(
       TOKEN_MSG_AMOUNT_OFFSET,
       TOKEN_MSG_AMOUNT_OFFSET + 32,
     );
+    const hlV1Nonce =
+      hyperlaneBody.length >= TOKEN_MSG_METADATA_OFFSET + CIRCLE_V1_NONCE_LENGTH
+        ? hyperlaneBody.slice(
+            TOKEN_MSG_METADATA_OFFSET,
+            TOKEN_MSG_METADATA_OFFSET + CIRCLE_V1_NONCE_LENGTH,
+          )
+        : undefined;
     const hlSenderBytes = ethers.utils.arrayify(hyperlaneSender);
 
     for (const msg of circleMessages) {
@@ -96,11 +108,18 @@ export function findMatchingCircleMessage(
           header + BURN_MSG_SENDER_OFFSET,
           header + BURN_MSG_SENDER_OFFSET + 32,
         );
+        const circleV1Nonce = bytes.slice(
+          CIRCLE_V1_NONCE_OFFSET,
+          CIRCLE_V1_NONCE_OFFSET + CIRCLE_V1_NONCE_LENGTH,
+        );
 
         if (
           Buffer.from(circleSender).equals(Buffer.from(hlSenderBytes)) &&
           Buffer.from(mintRecipient).equals(Buffer.from(hlRecipient)) &&
-          Buffer.from(amount).equals(Buffer.from(hlAmount))
+          Buffer.from(amount).equals(Buffer.from(hlAmount)) &&
+          (header !== CIRCLE_HEADER_LENGTH_V1 ||
+            hlV1Nonce === undefined ||
+            Buffer.from(circleV1Nonce).equals(Buffer.from(hlV1Nonce)))
         ) {
           return msg;
         }

--- a/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/cctpMessageMatcher.test.ts
@@ -39,8 +39,10 @@ function makeBurnCircleMessageV1(
   mintRecipient: Uint8Array,
   amount: Uint8Array,
   sender: Uint8Array = Buffer.alloc(32, 0x00),
+  nonce = 0,
 ): string {
   const buf = Buffer.alloc(248);
+  buf.writeBigUInt64BE(BigInt(nonce), 12);
   mintRecipient.forEach((b, i) => (buf[116 + 36 + i] = b)); // 152
   amount.forEach((b, i) => (buf[116 + 68 + i] = b)); // 184
   sender.forEach((b, i) => (buf[116 + 100 + i] = b)); // 216
@@ -56,11 +58,16 @@ function makeGmpCircleMessageV1(messageId: string): string {
   return ethers.utils.hexlify(buf);
 }
 
-/** Build a Hyperlane TokenMessage body: recipient(32) + amount(32). */
-function makeTokenBody(recipient: Uint8Array, amount: Uint8Array): Uint8Array {
-  const buf = Buffer.alloc(64);
+/** Build a Hyperlane TokenMessage body: recipient(32) + amount(32) + optional V1 nonce(8). */
+function makeTokenBody(
+  recipient: Uint8Array,
+  amount: Uint8Array,
+  nonce?: number,
+): Uint8Array {
+  const buf = Buffer.alloc(nonce === undefined ? 64 : 72);
   recipient.forEach((b, i) => (buf[i] = b));
   amount.forEach((b, i) => (buf[32 + i] = b));
+  if (nonce !== undefined) buf.writeBigUInt64BE(BigInt(nonce), 64);
   return buf;
 }
 
@@ -268,6 +275,31 @@ describe('findMatchingCircleMessage', () => {
           ethers.utils.hexlify(SENDER_B),
         ),
       ).to.equal(msgB);
+    });
+
+    it('disambiguates otherwise-identical V1 burns by TokenMessage nonce', () => {
+      const firstSibling = makeBurnCircleMessageV1(
+        RECIPIENT_A,
+        AMOUNT_A,
+        SENDER_A,
+        486337,
+      );
+      const target = makeBurnCircleMessageV1(
+        RECIPIENT_A,
+        AMOUNT_A,
+        SENDER_A,
+        486338,
+      );
+      const targetBody = makeTokenBody(RECIPIENT_A, AMOUNT_A, 486338);
+
+      expect(
+        findMatchingCircleMessage(
+          [firstSibling, target],
+          targetBody,
+          MESSAGE_ID_A,
+          ethers.utils.hexlify(SENDER_A),
+        ),
+      ).to.equal(target);
     });
 
     it('matches a V1 GMP message (148 bytes) by messageId', () => {


### PR DESCRIPTION
## Summary

- disambiguate legacy CCTP V1 burns using the uint64 nonce stored in Hyperlane TokenMessage metadata
- preserve sender, recipient, and amount matching for messages without legacy nonce metadata
- add a regression for identical sibling burns with nonces 486337 and 486338

## Why

PR #9182 exposed a multi-burn transaction where two Circle `MessageSent` events have identical sender, recipient, and amount. The existing matcher returned nonce 486337 because it appeared first, while the Hyperlane message identifies nonce 486338. The destination bridge rejects the mismatched attestation with `Invalid nonce`.

This fix makes the matcher select nonce 486338 from the same receipt. After an image is built from this change, #9182 should pin that image and remove the denylist entry; nonce 486338 is unconsumed.

## Validation

- `pnpm -C typescript/ccip-server exec mocha './tests/**/cctpMessageMatcher.test.ts' --exit` (15 passing)
- changed-file oxlint (0 warnings/errors)
- `git diff --check`

Full package test remains locally blocked by missing built workspace SDK artifacts required by the unrelated `CallCommitmentsService.test.ts`; exact-head CI will run the complete suite.
