### PR TITLE
fix(keyfunder): scale funding amounts by chain native token decimals

### DIFF
--- a/typescript/keyfunder/src/core/KeyFunder.test.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { BigNumber } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
+import type { ChainMetadata } from '@hyperlane-xyz/sdk';
 import type { Logger } from 'pino';
 import sinon from 'sinon';
 
@@ -66,6 +67,8 @@ describe('KeyFunder', () => {
   });
 
   it('scales the funding amount by the chain native token decimals', async () => {
+    // CAST: minimal pino Logger double; the funder only calls child() and the
+    // level methods, so a full Logger is unnecessary here.
     const logger = {
       child: () => logger,
       debug: () => undefined,
@@ -75,54 +78,54 @@ describe('KeyFunder', () => {
     } as unknown as Logger;
 
     const multiProvider = sinon.createStubInstance(MultiProvider);
-    // Recipient key is empty, so it needs to be topped up to its desired balance.
-    multiProvider.getProvider.returns({
-      getBalance: async () => BigNumber.from(0),
-    } as never);
-    // Funder holds 2747 TRX (6 decimals). Under the 18-decimal bug this would
-    // have been read as 2747e-12 TRX and falsely flagged as insufficient.
-    multiProvider.getSigner.returns({
-      getBalance: async () => BigNumber.from('2747000000'),
-    } as never);
+
+    // Recipient key is empty, so it must be topped up to its desired balance.
+    const provider = sinon.createStubInstance(ethers.providers.JsonRpcProvider);
+    provider.getBalance.resolves(BigNumber.from(0));
+    multiProvider.getProvider.returns(provider);
+
+    // Funder holds 2747 TRX (6 decimals). Under the old 18-decimal bug this
+    // would have been read as 2747e-12 TRX and falsely flagged as insufficient.
+    const signer = sinon.createStubInstance(ethers.Wallet);
+    signer.getAddress.resolves('0x3333333333333333333333333333333333333333');
+    signer.getBalance.resolves(BigNumber.from('2747000000'));
+    multiProvider.getSigner.returns(signer);
     multiProvider.getSignerAddress.resolves(
       '0x3333333333333333333333333333333333333333',
     );
+
+    // CAST: getNativeDecimals only reads nativeToken.decimals; the rest of
+    // ChainMetadata is irrelevant to this test.
     multiProvider.getChainMetadata.returns({
       nativeToken: { name: 'TRON', symbol: 'TRX', decimals: 6 },
-    } as never);
-    const sendTransaction = sinon.stub().resolves({ transactionHash: '0xabc' });
-    multiProvider.sendTransaction = sendTransaction as never;
-    multiProvider.tryGetExplorerTxUrl.returns(undefined as never);
+    } as unknown as ChainMetadata);
+    const sendTransaction = sinon.stub<
+      Parameters<MultiProvider['sendTransaction']>,
+      ReturnType<MultiProvider['sendTransaction']>
+    >();
+    // CAST: fundKey only reads transactionHash off the receipt.
+    sendTransaction.resolves({
+      transactionHash: '0xabc',
+    } as unknown as ethers.ContractReceipt);
+    multiProvider.sendTransaction = sendTransaction;
+    multiProvider.tryGetExplorerTxUrl.returns(null);
 
-    const keyFunder = new KeyFunder(
-      multiProvider,
-      { version: '1', roles: {}, chains: {} },
-      { logger },
-    );
+    const config: KeyFunderConfig = {
+      version: '1',
+      roles: {
+        relayer: { address: '0x1111111111111111111111111111111111111111' },
+      },
+      chains: { tron: { balances: { relayer: '1000' } } },
+    };
 
-    await (
-      keyFunder as unknown as {
-        fundKey: (
-          chain: string,
-          key: {
-            address: string;
-            role: string;
-            desiredBalance: string;
-          },
-        ) => Promise<void>;
-      }
-    ).fundKey('tron', {
-      address: '0x1111111111111111111111111111111111111111',
-      role: 'relayer',
-      desiredBalance: '1000',
-    });
+    const keyFunder = new KeyFunder(multiProvider, config, { logger });
+
+    await keyFunder.fundChain('tron');
 
     // 1000 TRX at 6 decimals = 1_000_000_000 sun.
     sinon.assert.calledOnce(sendTransaction);
-    const [, tx] = sendTransaction.firstCall.args;
-    expect((tx as { value: BigNumber }).value.toString()).to.equal(
-      '1000000000',
-    );
+    const tx = await Promise.resolve(sendTransaction.firstCall.args[1]);
+    expect(tx.value?.toString()).to.equal('1000000000');
   });
 
   it('should continue funding when recordFunderBalance fails', async () => {

--- a/typescript/keyfunder/src/core/KeyFunder.test.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.test.ts
@@ -65,6 +65,66 @@ describe('KeyFunder', () => {
     );
   });
 
+  it('scales the funding amount by the chain native token decimals', async () => {
+    const logger = {
+      child: () => logger,
+      debug: () => undefined,
+      error: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+    } as unknown as Logger;
+
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    // Recipient key is empty, so it needs to be topped up to its desired balance.
+    multiProvider.getProvider.returns({
+      getBalance: async () => BigNumber.from(0),
+    } as never);
+    // Funder holds 2747 TRX (6 decimals). Under the 18-decimal bug this would
+    // have been read as 2747e-12 TRX and falsely flagged as insufficient.
+    multiProvider.getSigner.returns({
+      getBalance: async () => BigNumber.from('2747000000'),
+    } as never);
+    multiProvider.getSignerAddress.resolves(
+      '0x3333333333333333333333333333333333333333',
+    );
+    multiProvider.getChainMetadata.returns({
+      nativeToken: { name: 'TRON', symbol: 'TRX', decimals: 6 },
+    } as never);
+    const sendTransaction = sinon.stub().resolves({ transactionHash: '0xabc' });
+    multiProvider.sendTransaction = sendTransaction as never;
+    multiProvider.tryGetExplorerTxUrl.returns(undefined as never);
+
+    const keyFunder = new KeyFunder(
+      multiProvider,
+      { version: '1', roles: {}, chains: {} },
+      { logger },
+    );
+
+    await (
+      keyFunder as unknown as {
+        fundKey: (
+          chain: string,
+          key: {
+            address: string;
+            role: string;
+            desiredBalance: string;
+          },
+        ) => Promise<void>;
+      }
+    ).fundKey('tron', {
+      address: '0x1111111111111111111111111111111111111111',
+      role: 'relayer',
+      desiredBalance: '1000',
+    });
+
+    // 1000 TRX at 6 decimals = 1_000_000_000 sun.
+    sinon.assert.calledOnce(sendTransaction);
+    const [, tx] = sendTransaction.firstCall.args;
+    expect((tx as { value: BigNumber }).value.toString()).to.equal(
+      '1000000000',
+    );
+  });
+
   it('should continue funding when recordFunderBalance fails', async () => {
     const chainWarnSpy = sinon.spy();
     const chainInfoSpy = sinon.spy();

--- a/typescript/keyfunder/src/core/KeyFunder.ts
+++ b/typescript/keyfunder/src/core/KeyFunder.ts
@@ -183,20 +183,22 @@ export class KeyFunder {
     const provider = this.multiProvider.getProvider(chain);
     const igpContract =
       this.options.igp.getContracts(chain).interchainGasPaymaster;
+    const decimals = this.getNativeDecimals(chain);
     const igpBalance = await provider.getBalance(igpContract.address);
-    const claimThreshold = ethers.utils.parseEther(igpConfig.claimThreshold);
+    const claimThreshold = ethers.utils.parseUnits(
+      igpConfig.claimThreshold,
+      decimals,
+    );
 
     this.options.metrics?.recordIgpBalance(
       chain,
-      parseFloat(
-        ethers.utils.formatUnits(igpBalance, this.getNativeDecimals(chain)),
-      ),
+      parseFloat(ethers.utils.formatUnits(igpBalance, decimals)),
     );
 
     logger.info(
       {
-        igpBalance: ethers.utils.formatEther(igpBalance),
-        claimThreshold: ethers.utils.formatEther(claimThreshold),
+        igpBalance: ethers.utils.formatUnits(igpBalance, decimals),
+        claimThreshold: ethers.utils.formatUnits(claimThreshold, decimals),
       },
       'Checking IGP balance',
     );
@@ -227,7 +229,11 @@ export class KeyFunder {
       role: key.role,
     });
 
-    const desiredBalance = ethers.utils.parseEther(key.desiredBalance);
+    const decimals = this.getNativeDecimals(chain);
+    const desiredBalance = ethers.utils.parseUnits(
+      key.desiredBalance,
+      decimals,
+    );
     const fundingAmount = await this.calculateFundingAmount(
       chain,
       key.address,
@@ -242,14 +248,12 @@ export class KeyFunder {
       chain,
       key.address,
       key.role,
-      parseFloat(
-        ethers.utils.formatUnits(currentBalance, this.getNativeDecimals(chain)),
-      ),
+      parseFloat(ethers.utils.formatUnits(currentBalance, decimals)),
     );
 
     if (fundingAmount.eq(0)) {
       logger.debug(
-        { currentBalance: ethers.utils.formatEther(currentBalance) },
+        { currentBalance: ethers.utils.formatUnits(currentBalance, decimals) },
         'Key balance sufficient, skipping',
       );
       return;
@@ -263,23 +267,23 @@ export class KeyFunder {
     if (funderBalance.lt(fundingAmount)) {
       logger.error(
         {
-          funderBalance: ethers.utils.formatEther(funderBalance),
-          requiredAmount: ethers.utils.formatEther(fundingAmount),
+          funderBalance: ethers.utils.formatUnits(funderBalance, decimals),
+          requiredAmount: ethers.utils.formatUnits(fundingAmount, decimals),
         },
         'Funder balance insufficient to cover funding amount',
       );
       throw new Error(
-        `Insufficient funder balance on ${chain}: has ${ethers.utils.formatEther(funderBalance)}, needs ${ethers.utils.formatEther(fundingAmount)}`,
+        `Insufficient funder balance on ${chain}: has ${ethers.utils.formatUnits(funderBalance, decimals)}, needs ${ethers.utils.formatUnits(fundingAmount, decimals)}`,
       );
     }
 
     logger.info(
       {
-        amount: ethers.utils.formatEther(fundingAmount),
-        currentBalance: ethers.utils.formatEther(currentBalance),
-        desiredBalance: ethers.utils.formatEther(desiredBalance),
+        amount: ethers.utils.formatUnits(fundingAmount, decimals),
+        currentBalance: ethers.utils.formatUnits(currentBalance, decimals),
+        desiredBalance: ethers.utils.formatUnits(desiredBalance, decimals),
         funderAddress,
-        funderBalance: ethers.utils.formatEther(funderBalance),
+        funderBalance: ethers.utils.formatUnits(funderBalance, decimals),
       },
       'Funding key',
     );
@@ -293,7 +297,7 @@ export class KeyFunder {
       chain,
       key.address,
       key.role,
-      parseFloat(ethers.utils.formatEther(fundingAmount)),
+      parseFloat(ethers.utils.formatUnits(fundingAmount, decimals)),
     );
 
     logger.info(
@@ -342,7 +346,8 @@ export class KeyFunder {
       );
     }
 
-    const threshold = ethers.utils.parseEther(sweepConfig.threshold);
+    const decimals = this.getNativeDecimals(chain);
+    const threshold = ethers.utils.parseUnits(sweepConfig.threshold, decimals);
     const targetBalance = calculateMultipliedBalance(
       threshold,
       sweepConfig.targetMultiplier,
@@ -358,9 +363,9 @@ export class KeyFunder {
 
     logger.info(
       {
-        funderBalance: ethers.utils.formatEther(funderBalance),
-        triggerThreshold: ethers.utils.formatEther(triggerThreshold),
-        targetBalance: ethers.utils.formatEther(targetBalance),
+        funderBalance: ethers.utils.formatUnits(funderBalance, decimals),
+        triggerThreshold: ethers.utils.formatUnits(triggerThreshold, decimals),
+        targetBalance: ethers.utils.formatUnits(targetBalance, decimals),
       },
       'Checking sweep conditions',
     );
@@ -370,7 +375,7 @@ export class KeyFunder {
 
       logger.info(
         {
-          sweepAmount: ethers.utils.formatEther(sweepAmount),
+          sweepAmount: ethers.utils.formatUnits(sweepAmount, decimals),
           sweepAddress: sweepConfig.address,
         },
         'Sweeping excess funds',
@@ -383,7 +388,7 @@ export class KeyFunder {
 
       this.options.metrics?.recordSweepAmount(
         chain,
-        parseFloat(ethers.utils.formatEther(sweepAmount)),
+        parseFloat(ethers.utils.formatUnits(sweepAmount, decimals)),
       );
 
       logger.info(


### PR DESCRIPTION
## Summary
- The key-funder funding-decision path (`fundKey`, IGP-claim, and sweep thresholds) parsed config amounts with `parseEther` and rendered logs with `formatEther` — both hardcoded to 18 decimals.
- For chains whose native token uses fewer decimals (e.g. tron at 6), this inflated `desiredBalance`/`fundingAmount` by 1e12, falsely tripping `Insufficient funder balance` and hard-failing the entire cron run (→ "Key Funder Pods Failing" page).
- Now parse and format using the chain's native decimals via the existing `getNativeDecimals` helper, mirroring the metric-emission fix in #9101 (which only covered the metric paths, not the funding-decision path).

## Root cause
#9101 (`f72172eb2d`) fixed the balance *metric* to use native decimals, but the funding-*decision* path still used `parseEther`/`formatEther`. So the Prometheus metric correctly showed the funder had ~2747 TRX, yet the funder job computed `desiredBalance` at 18 decimals and concluded the funder was short by ~1e12x, hard-failing the run.

## Test plan
- [x] Added `KeyFunder.test.ts` case: a tron (6-decimal) key with `desiredBalance: '1000'` and a funder holding 2747 TRX funds correctly (tx `value` = `1_000_000_000` sun) instead of throwing insufficient.
- [x] `pnpm -C typescript/keyfunder test` — 52 passing.
- [x] `pnpm -C typescript/keyfunder lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)