### PR TITLE
fix(infra): order ICA calls before IGP upgrade

### DIFF
--- a/typescript/infra/config/environments/mainnet3/igp/verification.json
+++ b/typescript/infra/config/environments/mainnet3/igp/verification.json
@@ -13,5 +13,165 @@
       "isProxy": true,
       "expectedimplementation": "0xF6CC9B10c607afB777380bF71F272E4D7037C3A9"
     }
+  ],
+  "avalanche": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xc0D0eF8D8BDD7395ec02617d1c705b0c6a60D6fa",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "celo": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x8f271392b5C7728EFc6FD825FF6A200BA50040Da",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "bsc": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x284830a64E59CF85e46bA66744B2910cB4Bd9f90",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "arbitrum": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x2eBFE904CcbC143ac0a0c03250459Aa7140bA09D",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "blast": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x3e419fA7267b9A3fF0358Ef16467B095d9E8d8AE",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "base": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x0E025067fe1a009e39F9C3De6A9965Ee1EAeB2d2",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "ink": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x2761Bf59a3f129269D36676134bcaF7F6d1b7249",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "fraxtal": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x3129C37ea8083917E13d3351A4263E968CAfe80d",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "gnosis": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x4fa96B3667C276FEC8F674EcD12e09D7ff3a16A2",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "linea": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xa95064E99eF2107c31bF662a118500Fd87b64D3E",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "hyperevm": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x284f71eBF22b7C7bf43aD20c460343D1a2d697c0",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "ethereum": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xb6b16b5EEDe90e93c8E558F49EffB06193b04EdF",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "soneium": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xc1D7Ef4D477f68229c3F5AC259931C3845a80FE1",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "mode": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x28F5135a3bCb1673598D8C30Fc37A32441Fe6a0a",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "lisk": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x6783dC9f1Bf88DC554c8716c4C42C5bf640dDcc8",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "mantle": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xa6a280234E617dc9B5A41b2E568Afda2351467B8",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "optimism": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x69D1A90f1A6ce003E993678aC8d19717454d1467",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "polygon": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0xF0a2d22C7064E9F5e6C7990CeA999a57EC2d0f80",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "worldchain": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x07359FdCE1b1Ce451B8C683F8ae1274B5Bf8266C",
+      "constructorArguments": "",
+      "isProxy": false
+    }
+  ],
+  "unichain": [
+    {
+      "name": "InterchainGasPaymaster",
+      "address": "0x322BA98FdEc849ABB965F142e30edf12e6a8cbBe",
+      "constructorArguments": "",
+      "isProxy": false
+    }
   ]
 }

--- a/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
+++ b/typescript/infra/scripts/igp/upgrade-compatible-igps.ts
@@ -87,11 +87,12 @@ const localSafeUpgradeTimelockGovernance: ChainMap<GovernanceType | undefined> =
 // used by the pending-timelock scripts.
 const TIMELOCK_LOOKBACK_BLOCKS = 2_000_000;
 
-type UpgradeCall = {
+export type UpgradeCall = {
   to: Address;
   data: string;
   value: BigNumber;
   description: string;
+  deferUntilAfterIcaDispatches?: boolean;
 };
 
 type ChainPlan = {
@@ -531,6 +532,13 @@ function splitSafeCallGroups(groups: SafeCallGroup[]): SafeCallGroup[] {
   }
 
   return splitGroups;
+}
+
+export function orderUpgradeCalls(calls: UpgradeCall[]): UpgradeCall[] {
+  return [
+    ...calls.filter((call) => !call.deferUntilAfterIcaDispatches),
+    ...calls.filter((call) => call.deferUntilAfterIcaDispatches),
+  ];
 }
 
 function addSafeCall(
@@ -1544,10 +1552,18 @@ async function main() {
       let routedTransactionCount = 0;
 
       if (upgradeIndex >= 0) {
-        const upgradeCall = toUpgradeCall(
-          transactions[upgradeIndex],
-          `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION}`,
-        );
+        const upgradeCall = {
+          ...toUpgradeCall(
+            transactions[upgradeIndex],
+            `Upgrade IGP ${interchainGasPaymaster} to ${CONTRACTS_PACKAGE_VERSION}`,
+          ),
+          // Ethereum originates the governance ICA messages. Keep its legacy
+          // IGP configured until every remote upgrade has been dispatched and
+          // paid for in the same Safe transaction.
+          ...(chain === ETHEREUM_CHAIN
+            ? { deferUntilAfterIcaDispatches: true }
+            : {}),
+        };
         const route = await routeGovernedCall({
           groups: safeGroups,
           icaGroups,
@@ -1637,6 +1653,10 @@ async function main() {
     ica,
   });
 
+  for (const group of safeGroups.values()) {
+    group.calls = orderUpgradeCalls(group.calls);
+  }
+
   const groups = splitSafeCallGroups([...safeGroups.values()]);
   const runDir = join(
     OUTPUT_ROOT,
@@ -1711,6 +1731,7 @@ async function main() {
     rootLogger.warn(
       [
         `Upgrade-only mode: apply IGP config after upgrade execution for chain(s): ${upgradeChains.join(', ')}`,
+        'Until configured, normal outbound dispatches from an upgraded chain will revert.',
         `pnpm -C typescript/infra exec tsx scripts/deploy.ts -e ${environment} -x ${context} -m igp --chains ${upgradeChains.join(' ')}`,
       ].join('\n'),
     );

--- a/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
+++ b/typescript/infra/test/igp-upgrade-compatible-igps.test.ts
@@ -14,6 +14,7 @@ import {
   getUpgradeTargetImplementation,
   isMissingPackageVersionError,
   mergeVerificationInputs,
+  orderUpgradeCalls,
   splitProposableGroups,
 } from '../scripts/igp/upgrade-compatible-igps.js';
 
@@ -141,6 +142,34 @@ describe('upgrade-compatible-igps', () => {
         proxyAddress: proxy,
       }),
     ).to.equal(implementation);
+  });
+
+  it('orders governance ICA dispatches before the Ethereum IGP upgrade', () => {
+    const upgrade = {
+      to: '0x1111111111111111111111111111111111111111',
+      data: '0x01',
+      value: BigNumber.from(0),
+      description: 'Upgrade Ethereum IGP',
+      deferUntilAfterIcaDispatches: true,
+    };
+    const avalancheIca = {
+      to: '0x2222222222222222222222222222222222222222',
+      data: '0x02',
+      value: BigNumber.from(1),
+      description: 'ICA avalanche',
+    };
+    const baseIca = {
+      to: '0x3333333333333333333333333333333333333333',
+      data: '0x03',
+      value: BigNumber.from(2),
+      description: 'ICA base',
+    };
+
+    expect(orderUpgradeCalls([upgrade, avalancheIca, baseIca])).to.deep.equal([
+      avalancheIca,
+      baseIca,
+      upgrade,
+    ]);
   });
 
   it('matches timelock IGP upgrade operations across different implementations', () => {


### PR DESCRIPTION
## Summary

- order Ethereum governance ICA dispatches before the local IGP implementation upgrade
- warn operators that every upgraded IGP must be configured immediately after execution
- record verification inputs for the 20 implementations deployed during this rollout

## Root cause

The upgrade script queued direct Safe calls before flushing buffered ICA calls. On Ethereum this put the local IGP upgrade first. The new implementation uses fresh gas-oracle mappings, so the following Avalanche ICA dispatch reverted with `IGP: no gas oracle for domain 43114`.

The fix marks the Ethereum IGP upgrade as deferred and stably orders it after all ICA dispatches before Safe batch splitting.

## Operational impact

The unsafe Ethereum nonce-43 proposal was deleted and replaced with `0xc9128e70f6f435fe7bac11fe88686ddcc20d3cfb433d635378b7b199a873b083`. Safe decoded it as 15 ICA calls followed by the Ethereum ProxyAdmin upgrade, and estimation succeeded with `safeTxGas=1899782`.

Each upgraded chain still requires `deploy.ts -m igp` after its upgrade executes. Until that configuration transaction lands, normal outbound IGP-backed dispatches from the upgraded chain revert. Already-dispatched and paid messages remain relayable.

Run the following immediately after the governance upgrades begin executing. It is safe to rerun: already-configured chains are skipped.

```bash
pnpm -C typescript/infra exec tsx scripts/deploy.ts \
  -e mainnet3 \
  -m igp \
  -c ethereum arbitrum base optimism bsc polygon celo linea gnosis ink \
     unichain mode soneium avalanche blast lisk fraxtal hyperevm mantle worldchain
```

## Validation

- `pnpm test:unit -- --grep upgrade-compatible-igps` (9 passing)
- `pnpm check`
- `pnpm turbo build` from `typescript/infra` (21/21 tasks)
- `oxlint` and `oxfmt --check` on changed files
- Safe Transaction Service estimation and decoded proposal readback
