### PR TITLE
chore(infra): bump mainnet keyFunder image tag for tron decimals fix

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -53,7 +53,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
-  keyFunder: '5af351e-20260728-162402',
+  keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
   feeQuoting: '12d899d-20260325-184337',


### PR DESCRIPTION
## Summary
- Bumps `mainnetDockerTags.keyFunder` to `b0c3c5d-20260804-175736`, the `hyperlane-node-services` image built from #9187 (merge commit b0c3c5da66).
- #9187 fixes the funding-decision decimals bug that hard-failed the whole key-funder cron run on tron (6-decimal native token), which triggered the "Key Funder Pods Failing" page.

## Test plan
- [ ] Deploy mainnet3 key-funder with the new tag and confirm a run funds tron without the false "Insufficient funder balance" hard-fail.