### PR TITLE
docs(review): exempt const assertions from the type-cast audit

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -41,7 +41,7 @@
 
 ## Type Cast Audit (MANDATORY PASS)
 
-**Do a dedicated pass over the diff looking for every `as` keyword and `any` type.** Flag each one. This is the most common source of bugs in this codebase.
+**Do a dedicated pass over the diff looking for every type-assertion `as` and `any` type.** Flag each one. This is the most common source of bugs in this codebase.
 
 - **`as X`** — flag it. The fix is almost always to fix the function signature, add a type guard, or restructure the code
 - **`as unknown as X`** — always flag. This completely bypasses type checking
@@ -51,6 +51,8 @@
 - **`!` (non-null assertion)** — flag unless the value is provably non-null on the preceding line
 
 The only acceptable cast is one with a `// CAST:` comment explaining why it's unavoidable.
+
+> **`as const` is exempt** — it is a _const assertion_, not a type assertion. It only narrows a literal to its readonly literal type and cannot widen or reinterpret a value, so it is not a type-safety escape. It is the endorsed idiom for the `const { … } as const` object + `type X = (typeof X)[keyof typeof X]` derived-union pattern used throughout the codebase. Do **not** flag it and do **not** require a `// CAST:` comment for it.
 
 ## TypeScript/SDK Patterns
 


### PR DESCRIPTION
### Description

Clarifies the mandatory Type Cast Audit in `REVIEW.md` so it no longer sweeps in `as const`. A const assertion is **not** a type assertion — it only narrows a literal to its readonly literal type and cannot widen or reinterpret a value, so it isn't a type-safety escape and shouldn't require a `// CAST:` justification. This scopes the audit to *type-assertion* `as` and adds an explicit `as const` exemption, so the endorsed `const { … } as const` object + `type X = (typeof X)[keyof typeof X]` derived-union pattern (used across the codebase, e.g. `ProposalResultStatus`) stops being flagged.

### Drive-by changes

None.

### Related issues

Split out of the cast-audit discussion on #9155, where the mechanical "inspect every `as`" wording was flagging `as const` const-assertions. Keeping the guidance fix separate from that feature PR.

### Backward compatibility

Yes — documentation only; no code or tooling changes.

### Testing

None (docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
