### PR TITLE
feat(sdk): deployed-bytecode validity verification

### DIFF
--- a/.changeset/bytecode-validity-verify.md
+++ b/.changeset/bytecode-validity-verify.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Deployed bytecode manifest generation and EVM comparison helpers were added for Hyperlane contracts.

--- a/typescript/sdk/scripts/generateBytecodeManifest.ts
+++ b/typescript/sdk/scripts/generateBytecodeManifest.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+import { execFileSync } from 'child_process';
+import { createRequire } from 'module';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  type BytecodeManifest,
+  type BytecodeManifestSet,
+  type SolcBuildArtifact,
+  generateManifestFromBuildArtifact,
+} from '../src/deploy/verify/bytecodeManifest.js';
+
+interface Args {
+  versions: string[];
+  out?: string;
+}
+
+interface SolcModule {
+  compile(input: string): string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const versions: string[] = [];
+  let out: string | undefined;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--version') {
+      const version = argv[i + 1];
+      assert(version, '--version requires a value');
+      versions.push(version);
+      i += 1;
+      continue;
+    }
+    if (arg === '--out') {
+      out = argv[i + 1];
+      assert(out, '--out requires a value');
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument ${arg}`);
+  }
+  assert(versions.length > 0, 'At least one --version is required');
+  return { versions, out };
+}
+
+function lastLine(output: string): string {
+  const lines = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const line = lines[lines.length - 1];
+  assert(line, 'Expected command output');
+  return line;
+}
+
+function generateVersionManifest(version: string): BytecodeManifest {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'hyperlane-bytecode-manifest-'));
+  try {
+    writeFileSync(join(tmpDir, 'package.json'), '{"private":true}\n');
+    const tarballName = lastLine(
+      execFileSync('npm', ['pack', `@hyperlane-xyz/core@${version}`], {
+        cwd: tmpDir,
+        encoding: 'utf8',
+      }),
+    );
+    execFileSync('tar', ['-xzf', join(tmpDir, tarballName), '-C', tmpDir]);
+    const packageDir = join(tmpDir, 'package');
+    const artifact = JSON.parse(
+      readFileSync(join(packageDir, 'dist', 'buildArtifact.json'), 'utf8'),
+    ) as SolcBuildArtifact;
+    const solcVersion = artifact.solcLongVersion.split('+')[0];
+    assert(solcVersion, `Invalid solcLongVersion ${artifact.solcLongVersion}`);
+    execFileSync('npm', ['install', `solc@${solcVersion}`, '--no-save'], {
+      cwd: tmpDir,
+      stdio: 'inherit',
+    });
+    const requireFromTemp = createRequire(join(tmpDir, 'package.json'));
+    const solc = requireFromTemp('solc') as SolcModule;
+    return generateManifestFromBuildArtifact(artifact, version, (input) =>
+      solc.compile(input),
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const manifestSet: BytecodeManifestSet = {};
+  for (const version of args.versions) {
+    manifestSet[version] = generateVersionManifest(version);
+  }
+
+  const json = `${JSON.stringify(manifestSet, null, 2)}\n`;
+  if (args.out) {
+    writeFileSync(resolve(args.out), json);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+main();

--- a/typescript/sdk/scripts/verifyBytecode.ts
+++ b/typescript/sdk/scripts/verifyBytecode.ts
@@ -1,0 +1,243 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console -- standalone CLI harness; console is the intended output channel */
+import fs from 'fs';
+
+import { providers } from 'ethers';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  BytecodeComparison,
+  BytecodeValidity,
+  compareBytecode,
+} from '../src/deploy/verify/bytecodeComparator.js';
+import {
+  type BytecodeManifestSet,
+  generateManifestFromBuildInfoDir,
+} from '../src/deploy/verify/bytecodeManifest.js';
+import { MultiProvider } from '../src/providers/MultiProvider.js';
+import {
+  checkWarpRouteBytecode,
+  type WarpBytecodeComparison,
+} from '../src/token/warpBytecodeCheck.js';
+import type { ChainMap } from '../src/types.js';
+import type { WarpCoreConfig } from '../src/warp/types.js';
+
+interface Args {
+  buildInfo: string[];
+  version: string[];
+  manifest?: string;
+  out?: string;
+  address?: string;
+  chain?: string;
+  expect?: string;
+  rpc?: string;
+  warp?: string;
+}
+
+interface RegistryModule {
+  DEFAULT_GITHUB_REGISTRY: string;
+  chainMetadata: ChainMap<
+    ConstructorParameters<typeof MultiProvider>[0][string]
+  >;
+}
+
+interface FsRegistryModule {
+  getRegistry(params: { registryUris: string[]; enableProxy: boolean }): {
+    getWarpRoute(id: string): Promise<WarpCoreConfig | null>;
+  };
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { buildInfo: [], version: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (!arg.startsWith('--')) continue;
+    assert(next, `Missing value for ${arg}`);
+    i += 1;
+    switch (arg) {
+      case '--build-info':
+        args.buildInfo.push(next);
+        break;
+      case '--version':
+        args.version.push(next);
+        break;
+      case '--manifest':
+        args.manifest = next;
+        break;
+      case '--out':
+        args.out = next;
+        break;
+      case '--address':
+        args.address = next;
+        break;
+      case '--chain':
+        args.chain = next;
+        break;
+      case '--expect':
+        args.expect = next;
+        break;
+      case '--rpc':
+        args.rpc = next;
+        break;
+      case '--warp':
+        args.warp = next;
+        break;
+      default:
+        throw new Error(`Unknown arg ${arg}`);
+    }
+  }
+  return args;
+}
+
+function loadManifestSet(args: Args): BytecodeManifestSet {
+  if (args.manifest) {
+    return JSON.parse(
+      fs.readFileSync(args.manifest, 'utf8'),
+    ) as BytecodeManifestSet;
+  }
+
+  assert(
+    args.buildInfo.length > 0,
+    'Must pass --manifest or --build-info/--version',
+  );
+  assert(
+    args.buildInfo.length === args.version.length,
+    '--build-info and --version counts must match',
+  );
+
+  const manifestSet: BytecodeManifestSet = {};
+  for (let i = 0; i < args.buildInfo.length; i++) {
+    const buildInfoDir = args.buildInfo[i];
+    const version = args.version[i];
+    assert(buildInfoDir, `Missing --build-info at index ${i}`);
+    assert(version, `Missing --version at index ${i}`);
+    manifestSet[version] = generateManifestFromBuildInfoDir(
+      buildInfoDir,
+      version,
+    );
+  }
+
+  if (args.out) {
+    fs.writeFileSync(args.out, `${JSON.stringify(manifestSet, null, 2)}\n`);
+  }
+  return manifestSet;
+}
+
+async function makeMultiProvider(
+  chain: string | undefined,
+  rpc: string | undefined,
+): Promise<MultiProvider> {
+  const registryModule =
+    (await import('@hyperlane-xyz/registry')) as RegistryModule;
+  const multiProvider = new MultiProvider(registryModule.chainMetadata);
+  if (chain && rpc) {
+    multiProvider.setProvider(chain, new providers.JsonRpcProvider(rpc));
+  }
+  return multiProvider;
+}
+
+async function loadWarpCoreConfig(
+  warpRouteId: string,
+): Promise<WarpCoreConfig> {
+  const registryModule =
+    (await import('@hyperlane-xyz/registry')) as RegistryModule;
+  const fsRegistryModule =
+    (await import('@hyperlane-xyz/registry/fs')) as FsRegistryModule;
+  const registryUri =
+    process.env.REGISTRY_URI ?? registryModule.DEFAULT_GITHUB_REGISTRY;
+  const registry = fsRegistryModule.getRegistry({
+    registryUris: [registryUri],
+    enableProxy: true,
+  });
+  const warpCoreConfig = await registry.getWarpRoute(warpRouteId);
+  assert(warpCoreConfig, `Warp route not found: ${warpRouteId}`);
+  return warpCoreConfig;
+}
+
+function shortHash(hash: string | undefined): string {
+  if (!hash) return '';
+  return hash.length > 18 ? `${hash.slice(0, 10)}..${hash.slice(-8)}` : hash;
+}
+
+function printComparisons(
+  comparisons: Array<BytecodeComparison | WarpBytecodeComparison>,
+): void {
+  const rows = comparisons.map((comparison) => ({
+    chain: 'chain' in comparison ? comparison.chain : '',
+    address: comparison.address,
+    impl: comparison.implementationAddress,
+    version: comparison.onchainVersion ?? '',
+    validity: comparison.validity,
+    contract:
+      comparison.matchedContractName ?? comparison.expectedContractName ?? '',
+    onchainHash: shortHash(comparison.onchainMaskedHash),
+    expectedHash: shortHash(comparison.expectedHash),
+    note: comparison.note ?? '',
+  }));
+  console.table(rows);
+
+  const advisories = comparisons.filter(
+    (comparison) =>
+      comparison.validity === BytecodeValidity.VersionUnavailable ||
+      comparison.validity === BytecodeValidity.NoCode,
+  );
+  if (advisories.length > 0) {
+    console.error(`Advisory results: ${advisories.length}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const manifestSet = loadManifestSet(args);
+
+  if (args.address) {
+    assert(
+      args.chain || args.rpc,
+      'Single-address mode needs --chain or --rpc',
+    );
+    const provider = args.rpc
+      ? new providers.JsonRpcProvider(args.rpc)
+      : (await makeMultiProvider(args.chain, undefined)).getProvider(
+          args.chain,
+        );
+    const comparison = await compareBytecode(
+      provider,
+      args.address,
+      manifestSet,
+      {
+        expectedContractName: args.expect,
+      },
+    );
+    printComparisons([
+      args.chain ? { ...comparison, chain: args.chain } : comparison,
+    ]);
+    return;
+  }
+
+  if (args.warp) {
+    const multiProvider = await makeMultiProvider(args.chain, args.rpc);
+    const warpCoreConfig = await loadWarpCoreConfig(args.warp);
+    const comparisons = await checkWarpRouteBytecode(
+      multiProvider,
+      warpCoreConfig,
+      manifestSet,
+      { warpRouteId: args.warp },
+    );
+    printComparisons(comparisons);
+    return;
+  }
+
+  if (args.out) {
+    console.log(`Wrote manifest set to ${args.out}`);
+    return;
+  }
+
+  throw new Error('No action requested. Use --address or --warp.');
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/typescript/sdk/src/deploy/verify/bytecodeComparator.test.ts
+++ b/typescript/sdk/src/deploy/verify/bytecodeComparator.test.ts
@@ -1,0 +1,282 @@
+import { expect } from 'chai';
+import { providers, utils } from 'ethers';
+import sinon from 'sinon';
+
+import { test1, TestChainName } from '../../consts/testChains.js';
+import { MultiProvider } from '../../providers/MultiProvider.js';
+import { TokenStandard } from '../../token/TokenStandard.js';
+import { checkWarpRouteBytecode } from '../../token/warpBytecodeCheck.js';
+import type { WarpCoreConfig } from '../../warp/types.js';
+
+import {
+  BytecodeValidity,
+  compareBytecode,
+  resolveImplementation,
+  type PackageVersionRead,
+} from './bytecodeComparator.js';
+import {
+  computeMaskedRuntimeHash,
+  type BytecodeManifest,
+  type BytecodeManifestSet,
+  type ContractBytecodeEntry,
+} from './bytecodeManifest.js';
+
+const ROUTER = '0x1000000000000000000000000000000000000001';
+const IMPL = '0x2000000000000000000000000000000000000002';
+const ERC20_CODE = '0x60016002';
+const MAILBOX_CODE = '0x60026003';
+const PROXY_CODE = '0x60036004';
+const UNKNOWN_CODE = '0x60046005';
+
+function normalize(address: string): string {
+  return utils.getAddress(address).toLowerCase();
+}
+
+function implementationSlot(address: string): string {
+  return `0x${'0'.repeat(24)}${address.replace(/^0x/i, '').toLowerCase()}`;
+}
+
+function codedError(message: string, code: string): Error & { code: string } {
+  const error = new Error(message) as Error & { code: string };
+  error.code = code;
+  return error;
+}
+
+function paramString(params: Record<string, unknown>, field: string): string {
+  const value = params[field];
+  expect(value).to.be.a('string');
+  return String(value);
+}
+
+function transactionTo(params: Record<string, unknown>): string {
+  const transaction = params.transaction;
+  expect(transaction).to.be.an('object');
+  const fields = transaction as Record<string, unknown>;
+  const to = fields.to;
+  expect(to).to.be.a('string');
+  return String(to);
+}
+
+class FakeProvider extends providers.BaseProvider {
+  private readonly storage = new Map<string, string>();
+  private readonly codes = new Map<string, string>();
+  private readonly versionReads = new Map<string, PackageVersionRead>();
+
+  constructor() {
+    super({ chainId: 1, name: 'test' });
+  }
+
+  override async detectNetwork(): Promise<providers.Network> {
+    return { chainId: 1, name: 'test' };
+  }
+
+  override async perform(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (method === 'getStorageAt') {
+      return (
+        this.storage.get(normalize(paramString(params, 'address'))) ??
+        `0x${'0'.repeat(64)}`
+      );
+    }
+    if (method === 'getCode') {
+      return this.codes.get(normalize(paramString(params, 'address'))) ?? '0x';
+    }
+    if (method === 'call') {
+      const read = this.versionReads.get(normalize(transactionTo(params))) ?? {
+        kind: 'absent',
+      };
+      if (read.kind === 'version') {
+        return utils.defaultAbiCoder.encode(['string'], [read.version]);
+      }
+      if (read.kind === 'rpc_error') {
+        throw codedError('connection failed', 'SERVER_ERROR');
+      }
+      throw codedError('missing PACKAGE_VERSION', 'CALL_EXCEPTION');
+    }
+    throw new Error(`Unsupported provider method ${method}`);
+  }
+
+  setImplementation(address: string, implementationAddress?: string): void {
+    this.storage.set(
+      normalize(address),
+      implementationAddress
+        ? implementationSlot(implementationAddress)
+        : `0x${'0'.repeat(64)}`,
+    );
+  }
+
+  setCode(address: string, code: string): void {
+    this.codes.set(normalize(address), code);
+  }
+
+  setVersionRead(address: string, read: PackageVersionRead): void {
+    this.versionReads.set(normalize(address), read);
+  }
+}
+
+function manifestEntry(
+  packageVersion: string,
+  contractName: string,
+  code: string,
+): ContractBytecodeEntry {
+  return {
+    contractName,
+    sourcePath: `${contractName}.sol`,
+    packageVersion,
+    immutableRanges: [],
+    linkRanges: [],
+    maskedRuntimeHash: computeMaskedRuntimeHash(code, [], []),
+  };
+}
+
+function makeManifest(
+  packageVersion: string,
+  contracts: Record<string, string>,
+): BytecodeManifest {
+  const byName: Record<string, ContractBytecodeEntry> = {};
+  const byHash: Record<string, string[]> = {};
+  for (const [contractName, code] of Object.entries(contracts)) {
+    const entry = manifestEntry(packageVersion, contractName, code);
+    byName[contractName] = entry;
+    byHash[entry.maskedRuntimeHash] ||= [];
+    byHash[entry.maskedRuntimeHash].push(contractName);
+  }
+  return { packageVersion, byName, byHash };
+}
+
+function manifestSet(): BytecodeManifestSet {
+  return {
+    '1.0.0': makeManifest('1.0.0', {
+      HypERC20: ERC20_CODE,
+      Mailbox: MAILBOX_CODE,
+      TransparentUpgradeableProxy: PROXY_CODE,
+    }),
+  };
+}
+
+describe('bytecodeComparator', () => {
+  afterEach(() => sinon.restore());
+
+  it('resolves zero and non-zero implementation slots', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+    expect(await resolveImplementation(provider, ROUTER)).to.deep.equal({
+      isProxy: false,
+      implementationAddress: utils.getAddress(ROUTER),
+    });
+
+    provider.setImplementation(ROUTER, IMPL);
+    expect(await resolveImplementation(provider, ROUTER)).to.deep.equal({
+      isProxy: true,
+      implementationAddress: utils.getAddress(IMPL),
+    });
+  });
+
+  it('classifies absent PACKAGE_VERSION and still cross-matches', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+    provider.setCode(ROUTER, ERC20_CODE);
+
+    const comparison = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(comparison.validity).to.equal(BytecodeValidity.Match);
+    expect(comparison.versionSource).to.equal('absent');
+    expect(comparison.matchedPackageVersion).to.equal('1.0.0');
+  });
+
+  it('matches spoofed unknown versions against covered manifests', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+    provider.setCode(ROUTER, ERC20_CODE);
+    provider.setVersionRead(ROUTER, { kind: 'version', version: '99.0.0' });
+
+    const comparison = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(comparison.validity).to.equal(BytecodeValidity.Match);
+    expect(comparison.reportedVersion).to.equal('99.0.0');
+    expect(comparison.matchedPackageVersion).to.equal('1.0.0');
+    expect(comparison.note).to.include('reported version 99.0.0 differs');
+  });
+
+  it('distinguishes covered and uncovered spoofed misses', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+    provider.setCode(ROUTER, UNKNOWN_CODE);
+    provider.setVersionRead(ROUTER, { kind: 'version', version: '1.0.0' });
+
+    const covered = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(covered.validity).to.equal(BytecodeValidity.Mismatch);
+    expect(covered.note).to.include('covered but no manifest hash matched');
+
+    provider.setVersionRead(ROUTER, { kind: 'version', version: '99.0.0' });
+    const uncovered = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(uncovered.validity).to.equal(BytecodeValidity.VersionUnavailable);
+    expect(uncovered.note).to.include('reportedVersion 99.0.0 is uncovered');
+  });
+
+  it('preserves rpc_error while reading PACKAGE_VERSION', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+    provider.setCode(ROUTER, ERC20_CODE);
+    provider.setVersionRead(ROUTER, { kind: 'rpc_error' });
+
+    const comparison = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(comparison.validity).to.equal(BytecodeValidity.Match);
+    expect(comparison.versionSource).to.equal('rpc_error');
+  });
+
+  it('returns NoCode when implementation has no code', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+
+    const comparison = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(comparison.validity).to.equal(BytecodeValidity.NoCode);
+  });
+
+  it('fails closed when proxy runtime is not canonical', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER, IMPL);
+    provider.setCode(IMPL, ERC20_CODE);
+    provider.setCode(ROUTER, UNKNOWN_CODE);
+
+    const comparison = await compareBytecode(provider, ROUTER, manifestSet());
+    expect(comparison.validity).to.equal(BytecodeValidity.Mismatch);
+    expect(comparison.proxyValidity).to.equal(BytecodeValidity.Mismatch);
+    expect(comparison.note).to.equal(
+      'proxy runtime is not a canonical Hyperlane/OZ proxy',
+    );
+  });
+
+  it('flags wrong contract role at a warp leg', async () => {
+    const provider = new FakeProvider();
+    provider.setImplementation(ROUTER);
+    provider.setCode(ROUTER, MAILBOX_CODE);
+    const multiProvider = new MultiProvider(
+      { [TestChainName.test1]: test1 },
+      { providers: { [TestChainName.test1]: provider } },
+    );
+    const warpConfig: WarpCoreConfig = {
+      tokens: [
+        {
+          chainName: TestChainName.test1,
+          standard: TokenStandard.EvmHypNative,
+          decimals: 18,
+          symbol: 'T',
+          name: 'Token',
+          addressOrDenom: ROUTER,
+          scale: 1,
+        },
+      ],
+    };
+
+    const [comparison] = await checkWarpRouteBytecode(
+      multiProvider,
+      warpConfig,
+      manifestSet(),
+    );
+    expect(comparison.validity).to.equal(BytecodeValidity.Mismatch);
+    expect(comparison.note).to.equal(
+      'matched Mailbox which is not a valid contract for EvmHypNative',
+    );
+  });
+});

--- a/typescript/sdk/src/deploy/verify/bytecodeComparator.ts
+++ b/typescript/sdk/src/deploy/verify/bytecodeComparator.ts
@@ -22,13 +22,23 @@ export interface BytecodeComparison {
   implementationAddress: string;
   isProxy: boolean;
   onchainVersion?: string;
+  reportedVersion?: string;
+  matchedPackageVersion?: string;
+  versionSource?: 'onchain' | 'absent' | 'rpc_error';
   validity: BytecodeValidity;
   matchedContractName?: string;
   expectedContractName?: string;
   onchainMaskedHash?: string;
   expectedHash?: string;
+  proxyValidity?: BytecodeValidity;
+  proxyMatchedContractName?: string;
   note?: string;
 }
+
+export type PackageVersionRead =
+  | { kind: 'version'; version: string }
+  | { kind: 'absent' }
+  | { kind: 'rpc_error' };
 
 function isZeroAddressStorageValue(storageValue: string): boolean {
   const normalized = storageValue.replace(/^0x/i, '').padStart(64, '0');
@@ -66,7 +76,7 @@ export async function resolveImplementation(
 export async function readOnchainPackageVersion(
   provider: providers.Provider,
   address: string,
-): Promise<string | undefined> {
+): Promise<PackageVersionRead> {
   try {
     const contract = new Contract(
       address,
@@ -74,18 +84,52 @@ export async function readOnchainPackageVersion(
       provider,
     );
     const version: unknown = await contract.PACKAGE_VERSION();
-    if (typeof version === 'string') return version;
-    return undefined;
-  } catch {
-    return undefined;
+    if (typeof version === 'string') return { kind: 'version', version };
+    return { kind: 'absent' };
+  } catch (error) {
+    return classifyPackageVersionReadError(error);
   }
+}
+
+function classifyPackageVersionReadError(error: unknown): PackageVersionRead {
+  const code = getErrorStringField(error, 'code');
+  const message = [
+    getErrorStringField(error, 'message'),
+    getErrorStringField(error, 'reason'),
+  ]
+    .filter((part) => part)
+    .join(' ')
+    .toLowerCase();
+
+  if (
+    code === 'NETWORK_ERROR' ||
+    code === 'TIMEOUT' ||
+    code === 'SERVER_ERROR' ||
+    message.includes('connection') ||
+    message.includes('network') ||
+    message.includes('timeout')
+  ) {
+    return { kind: 'rpc_error' };
+  }
+
+  return { kind: 'absent' };
+}
+
+function getErrorStringField(
+  error: unknown,
+  field: string,
+): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const value = (error as Record<string, unknown>)[field];
+  return typeof value === 'string' ? value : undefined;
 }
 
 function versionUnavailableComparison(params: {
   address: string;
   implementationAddress: string;
   isProxy: boolean;
-  onchainVersion?: string;
+  reportedVersion?: string;
+  versionSource?: 'onchain' | 'absent' | 'rpc_error';
   manifestSet: BytecodeManifestSet;
   note?: string;
 }): BytecodeComparison {
@@ -94,108 +138,121 @@ function versionUnavailableComparison(params: {
     address: utils.getAddress(params.address),
     implementationAddress: params.implementationAddress,
     isProxy: params.isProxy,
-    onchainVersion: params.onchainVersion,
+    onchainVersion: params.reportedVersion,
+    reportedVersion: params.reportedVersion,
+    versionSource: params.versionSource,
     validity: BytecodeValidity.VersionUnavailable,
     note:
       params.note ??
       `No bytecode manifest for on-chain version ${
-        params.onchainVersion ?? '<unavailable>'
+        params.reportedVersion ?? '<unavailable>'
       }. Available versions: ${availableVersions || '<none>'}`,
   };
 }
 
-function compareAgainstManifest(params: {
+function compareAgainstEntry(params: {
   address: string;
   implementationAddress: string;
   isProxy: boolean;
-  onchainVersion?: string;
+  reportedVersion?: string;
+  versionSource?: 'onchain' | 'absent' | 'rpc_error';
   code: string;
   manifest: BytecodeManifest;
+  contractName: string;
   expectedContractName?: string;
 }): BytecodeComparison {
   const {
     address,
     implementationAddress,
     isProxy,
-    onchainVersion,
+    reportedVersion,
+    versionSource,
     code,
     manifest,
+    contractName,
     expectedContractName,
   } = params;
+  const entry = manifest.byName[contractName];
+  assert(
+    entry,
+    `Missing manifest entry ${contractName} for ${manifest.packageVersion}`,
+  );
 
-  if (expectedContractName) {
-    const entry = manifest.byName[expectedContractName];
-    if (!entry) {
-      return {
-        address: utils.getAddress(address),
-        implementationAddress,
-        isProxy,
-        onchainVersion,
-        validity: BytecodeValidity.Mismatch,
-        expectedContractName,
-        note: 'expected contract not in manifest',
-      };
-    }
-
-    const onchainMaskedHash = computeMaskedRuntimeHash(
-      code,
-      entry.immutableRanges,
-      entry.linkRanges,
-    );
-    const isMatch = onchainMaskedHash === entry.maskedRuntimeHash;
-    return {
-      address: utils.getAddress(address),
-      implementationAddress,
-      isProxy,
-      onchainVersion,
-      validity: isMatch ? BytecodeValidity.Match : BytecodeValidity.Mismatch,
-      expectedContractName,
-      matchedContractName: isMatch ? expectedContractName : undefined,
-      onchainMaskedHash,
-      expectedHash: entry.maskedRuntimeHash,
-    };
-  }
-
-  for (const [contractName, entry] of Object.entries(manifest.byName)) {
-    const onchainMaskedHash = computeMaskedRuntimeHash(
-      code,
-      entry.immutableRanges,
-      entry.linkRanges,
-    );
-    if (onchainMaskedHash === entry.maskedRuntimeHash) {
-      return {
-        address: utils.getAddress(address),
-        implementationAddress,
-        isProxy,
-        onchainVersion,
-        validity: BytecodeValidity.Match,
-        matchedContractName: contractName,
-        onchainMaskedHash,
-        expectedHash: entry.maskedRuntimeHash,
-      };
-    }
-  }
-
-  const firstEntry = Object.values(manifest.byName)[0];
-  const onchainMaskedHash = firstEntry
-    ? computeMaskedRuntimeHash(
-        code,
-        firstEntry.immutableRanges,
-        firstEntry.linkRanges,
-      )
-    : computeMaskedRuntimeHash(code, [], []);
-
+  const onchainMaskedHash = computeMaskedRuntimeHash(
+    code,
+    entry.immutableRanges,
+    entry.linkRanges,
+  );
+  const isMatch = onchainMaskedHash === entry.maskedRuntimeHash;
+  const versionNote =
+    reportedVersion && reportedVersion !== manifest.packageVersion
+      ? `reported version ${reportedVersion} differs from matched package version ${manifest.packageVersion}`
+      : undefined;
   return {
     address: utils.getAddress(address),
     implementationAddress,
     isProxy,
-    onchainVersion,
-    validity: BytecodeValidity.Mismatch,
+    onchainVersion: reportedVersion,
+    reportedVersion,
+    matchedPackageVersion: isMatch ? manifest.packageVersion : undefined,
+    versionSource,
+    validity: isMatch ? BytecodeValidity.Match : BytecodeValidity.Mismatch,
+    expectedContractName,
+    matchedContractName: isMatch ? contractName : undefined,
     onchainMaskedHash,
-    note: firstEntry
-      ? `No manifest entry matched. Reporting hash masked with ${firstEntry.contractName} ranges.`
-      : 'Manifest has no contracts.',
+    expectedHash: entry.maskedRuntimeHash,
+    note: isMatch ? versionNote : undefined,
   };
+}
+
+function mismatchComparison(params: {
+  address: string;
+  implementationAddress: string;
+  isProxy: boolean;
+  code: string;
+  manifestSet: BytecodeManifestSet;
+  reportedVersion?: string;
+  versionSource?: 'onchain' | 'absent' | 'rpc_error';
+  note: string;
+  expectedContractName?: string;
+}): BytecodeComparison {
+  const manifest = Object.values(params.manifestSet)[0];
+  const firstEntry = manifest ? Object.values(manifest.byName)[0] : undefined;
+  const onchainMaskedHash = firstEntry
+    ? computeMaskedRuntimeHash(
+        params.code,
+        firstEntry.immutableRanges,
+        firstEntry.linkRanges,
+      )
+    : computeMaskedRuntimeHash(params.code, [], []);
+
+  return {
+    address: utils.getAddress(params.address),
+    implementationAddress: params.implementationAddress,
+    isProxy: params.isProxy,
+    onchainVersion: params.reportedVersion,
+    reportedVersion: params.reportedVersion,
+    versionSource: params.versionSource,
+    validity: BytecodeValidity.Mismatch,
+    expectedContractName: params.expectedContractName,
+    onchainMaskedHash,
+    note: params.note,
+  };
+}
+
+function orderedManifests(
+  manifestSet: BytecodeManifestSet,
+  reportedVersion?: string,
+): BytecodeManifest[] {
+  const manifests: BytecodeManifest[] = [];
+  const reportedManifest = reportedVersion
+    ? manifestSet[reportedVersion]
+    : undefined;
+  if (reportedManifest) manifests.push(reportedManifest);
+  for (const [version, manifest] of Object.entries(manifestSet)) {
+    if (version !== reportedVersion) manifests.push(manifest);
+  }
+  return manifests;
 }
 
 function findComparisonAcrossManifests(params: {
@@ -204,21 +261,88 @@ function findComparisonAcrossManifests(params: {
   isProxy: boolean;
   code: string;
   manifestSet: BytecodeManifestSet;
+  reportedVersion?: string;
+  versionSource?: 'onchain' | 'absent' | 'rpc_error';
   expectedContractName?: string;
+  approvedContractNames?: Set<string>;
 }): BytecodeComparison | undefined {
-  for (const manifest of Object.values(params.manifestSet)) {
-    const comparison = compareAgainstManifest({
-      address: params.address,
-      implementationAddress: params.implementationAddress,
-      isProxy: params.isProxy,
-      code: params.code,
-      manifest,
-      onchainVersion: manifest.packageVersion,
-      expectedContractName: params.expectedContractName,
-    });
-    if (comparison.validity === BytecodeValidity.Match) return comparison;
+  for (const manifest of orderedManifests(
+    params.manifestSet,
+    params.reportedVersion,
+  )) {
+    for (const contractName of Object.keys(manifest.byName)) {
+      if (
+        params.approvedContractNames &&
+        !params.approvedContractNames.has(contractName)
+      ) {
+        continue;
+      }
+      if (!manifest.byName[contractName]) continue;
+      const comparison = compareAgainstEntry({
+        address: params.address,
+        implementationAddress: params.implementationAddress,
+        isProxy: params.isProxy,
+        code: params.code,
+        manifest,
+        contractName,
+        reportedVersion: params.reportedVersion,
+        versionSource: params.versionSource,
+        expectedContractName: params.expectedContractName,
+      });
+      if (comparison.validity === BytecodeValidity.Match) return comparison;
+    }
   }
   return undefined;
+}
+
+function proxyContractNames(manifestSet: BytecodeManifestSet): Set<string> {
+  const names = new Set<string>();
+  for (const manifest of Object.values(manifestSet)) {
+    for (const contractName of Object.keys(manifest.byName)) {
+      if (contractName.endsWith('Proxy')) names.add(contractName);
+    }
+  }
+  return names;
+}
+
+async function compareProxyRuntime(params: {
+  provider: providers.Provider;
+  address: string;
+  implementationAddress: string;
+  manifestSet: BytecodeManifestSet;
+  reportedVersion?: string;
+  versionSource: 'onchain' | 'absent' | 'rpc_error';
+}): Promise<
+  Pick<BytecodeComparison, 'proxyValidity' | 'proxyMatchedContractName'>
+> {
+  const proxyCode = await params.provider.getCode(params.address);
+  if (proxyCode === '0x') return { proxyValidity: BytecodeValidity.NoCode };
+
+  const matched = findComparisonAcrossManifests({
+    address: params.address,
+    implementationAddress: params.implementationAddress,
+    isProxy: true,
+    code: proxyCode,
+    manifestSet: params.manifestSet,
+    reportedVersion: params.reportedVersion,
+    versionSource: params.versionSource,
+    approvedContractNames: proxyContractNames(params.manifestSet),
+  });
+
+  return {
+    proxyValidity: matched ? BytecodeValidity.Match : BytecodeValidity.Mismatch,
+    proxyMatchedContractName: matched?.matchedContractName,
+  };
+}
+
+function versionUnavailableNote(read: PackageVersionRead): string {
+  if (read.kind === 'version') {
+    return `reportedVersion ${read.version} is uncovered and no manifest hash matched.`;
+  }
+  if (read.kind === 'rpc_error') {
+    return 'reportedVersion unavailable due to rpc_error and no manifest hash matched.';
+  }
+  return 'reportedVersion absent and no manifest hash matched.';
 }
 
 export async function compareBytecode(
@@ -242,54 +366,74 @@ export async function compareBytecode(
     };
   }
 
-  const proxyVersion = await readOnchainPackageVersion(provider, address);
-  const implementationVersion =
-    proxyVersion ??
-    (isProxy
+  const proxyVersionRead = await readOnchainPackageVersion(provider, address);
+  const versionRead =
+    isProxy && proxyVersionRead.kind === 'absent'
       ? await readOnchainPackageVersion(provider, implementationAddress)
-      : undefined);
-  const onchainVersion = implementationVersion;
+      : proxyVersionRead;
+  const reportedVersion =
+    versionRead.kind === 'version' ? versionRead.version : undefined;
+  const versionSource =
+    versionRead.kind === 'version' ? 'onchain' : versionRead.kind;
 
-  if (!onchainVersion) {
-    const matched = findComparisonAcrossManifests({
+  const matched = findComparisonAcrossManifests({
+    address,
+    implementationAddress,
+    isProxy,
+    code,
+    manifestSet,
+    reportedVersion,
+    versionSource,
+    expectedContractName: opts?.expectedContractName,
+  });
+
+  let comparison: BytecodeComparison;
+  if (matched) {
+    comparison = matched;
+  } else if (reportedVersion && manifestSet[reportedVersion]) {
+    comparison = mismatchComparison({
       address,
       implementationAddress,
       isProxy,
       code,
       manifestSet,
+      reportedVersion,
+      versionSource,
       expectedContractName: opts?.expectedContractName,
+      note: `reportedVersion ${reportedVersion} is covered but no manifest hash matched.`,
     });
-    if (matched) return { ...matched, onchainVersion: undefined };
-
-    return versionUnavailableComparison({
+  } else {
+    comparison = versionUnavailableComparison({
       address,
       implementationAddress,
       isProxy,
+      reportedVersion,
+      versionSource,
       manifestSet,
-      note: 'PACKAGE_VERSION unavailable and no manifest hash matched.',
+      note: versionUnavailableNote(versionRead),
     });
   }
 
-  const manifest = manifestSet[onchainVersion];
-  if (!manifest) {
-    return versionUnavailableComparison({
-      address,
-      implementationAddress,
-      isProxy,
-      onchainVersion,
-      manifestSet,
-    });
-  }
+  if (!isProxy) return comparison;
 
-  return compareAgainstManifest({
+  const proxyComparison = await compareProxyRuntime({
+    provider,
     address,
     implementationAddress,
-    isProxy,
-    code,
-    manifest,
-    onchainVersion,
-    expectedContractName: opts?.expectedContractName,
+    manifestSet,
+    reportedVersion,
+    versionSource,
   });
+  if (proxyComparison.proxyValidity === BytecodeValidity.Match) {
+    return { ...comparison, ...proxyComparison };
+  }
+
+  return {
+    ...comparison,
+    ...proxyComparison,
+    validity: BytecodeValidity.Mismatch,
+    note: 'proxy runtime is not a canonical Hyperlane/OZ proxy',
+  };
 }
 
 export async function scanAddressesBytecode(

--- a/typescript/sdk/src/deploy/verify/bytecodeComparator.ts
+++ b/typescript/sdk/src/deploy/verify/bytecodeComparator.ts
@@ -1,0 +1,313 @@
+import { Contract, providers, utils } from 'ethers';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+import {
+  EIP1967_IMPLEMENTATION_SLOT,
+  type BytecodeManifest,
+  type BytecodeManifestSet,
+  computeMaskedRuntimeHash,
+} from './bytecodeManifest.js';
+
+export enum BytecodeValidity {
+  Match = 'match',
+  Mismatch = 'mismatch',
+  VersionUnavailable = 'version_unavailable',
+  NoCode = 'no_code',
+  Unsupported = 'unsupported',
+}
+
+export interface BytecodeComparison {
+  address: string;
+  implementationAddress: string;
+  isProxy: boolean;
+  onchainVersion?: string;
+  validity: BytecodeValidity;
+  matchedContractName?: string;
+  expectedContractName?: string;
+  onchainMaskedHash?: string;
+  expectedHash?: string;
+  note?: string;
+}
+
+function isZeroAddressStorageValue(storageValue: string): boolean {
+  const normalized = storageValue.replace(/^0x/i, '').padStart(64, '0');
+  return /^0+$/.test(normalized.slice(-40));
+}
+
+function implementationAddressFromStorage(storageValue: string): string {
+  const normalized = storageValue.replace(/^0x/i, '').padStart(64, '0');
+  return utils.getAddress(`0x${normalized.slice(-40)}`);
+}
+
+export async function resolveImplementation(
+  provider: providers.Provider,
+  address: string,
+): Promise<{ isProxy: boolean; implementationAddress: string }> {
+  assert(utils.isAddress(address), `Invalid EVM address ${address}`);
+
+  const storageValue = await provider.getStorageAt(
+    address,
+    EIP1967_IMPLEMENTATION_SLOT,
+  );
+  if (isZeroAddressStorageValue(storageValue)) {
+    return {
+      isProxy: false,
+      implementationAddress: utils.getAddress(address),
+    };
+  }
+
+  return {
+    isProxy: true,
+    implementationAddress: implementationAddressFromStorage(storageValue),
+  };
+}
+
+export async function readOnchainPackageVersion(
+  provider: providers.Provider,
+  address: string,
+): Promise<string | undefined> {
+  try {
+    const contract = new Contract(
+      address,
+      ['function PACKAGE_VERSION() view returns (string)'],
+      provider,
+    );
+    const version: unknown = await contract.PACKAGE_VERSION();
+    if (typeof version === 'string') return version;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function versionUnavailableComparison(params: {
+  address: string;
+  implementationAddress: string;
+  isProxy: boolean;
+  onchainVersion?: string;
+  manifestSet: BytecodeManifestSet;
+  note?: string;
+}): BytecodeComparison {
+  const availableVersions = Object.keys(params.manifestSet).sort().join(', ');
+  return {
+    address: utils.getAddress(params.address),
+    implementationAddress: params.implementationAddress,
+    isProxy: params.isProxy,
+    onchainVersion: params.onchainVersion,
+    validity: BytecodeValidity.VersionUnavailable,
+    note:
+      params.note ??
+      `No bytecode manifest for on-chain version ${
+        params.onchainVersion ?? '<unavailable>'
+      }. Available versions: ${availableVersions || '<none>'}`,
+  };
+}
+
+function compareAgainstManifest(params: {
+  address: string;
+  implementationAddress: string;
+  isProxy: boolean;
+  onchainVersion?: string;
+  code: string;
+  manifest: BytecodeManifest;
+  expectedContractName?: string;
+}): BytecodeComparison {
+  const {
+    address,
+    implementationAddress,
+    isProxy,
+    onchainVersion,
+    code,
+    manifest,
+    expectedContractName,
+  } = params;
+
+  if (expectedContractName) {
+    const entry = manifest.byName[expectedContractName];
+    if (!entry) {
+      return {
+        address: utils.getAddress(address),
+        implementationAddress,
+        isProxy,
+        onchainVersion,
+        validity: BytecodeValidity.Mismatch,
+        expectedContractName,
+        note: 'expected contract not in manifest',
+      };
+    }
+
+    const onchainMaskedHash = computeMaskedRuntimeHash(
+      code,
+      entry.immutableRanges,
+      entry.linkRanges,
+    );
+    const isMatch = onchainMaskedHash === entry.maskedRuntimeHash;
+    return {
+      address: utils.getAddress(address),
+      implementationAddress,
+      isProxy,
+      onchainVersion,
+      validity: isMatch ? BytecodeValidity.Match : BytecodeValidity.Mismatch,
+      expectedContractName,
+      matchedContractName: isMatch ? expectedContractName : undefined,
+      onchainMaskedHash,
+      expectedHash: entry.maskedRuntimeHash,
+    };
+  }
+
+  for (const [contractName, entry] of Object.entries(manifest.byName)) {
+    const onchainMaskedHash = computeMaskedRuntimeHash(
+      code,
+      entry.immutableRanges,
+      entry.linkRanges,
+    );
+    if (onchainMaskedHash === entry.maskedRuntimeHash) {
+      return {
+        address: utils.getAddress(address),
+        implementationAddress,
+        isProxy,
+        onchainVersion,
+        validity: BytecodeValidity.Match,
+        matchedContractName: contractName,
+        onchainMaskedHash,
+        expectedHash: entry.maskedRuntimeHash,
+      };
+    }
+  }
+
+  const firstEntry = Object.values(manifest.byName)[0];
+  const onchainMaskedHash = firstEntry
+    ? computeMaskedRuntimeHash(
+        code,
+        firstEntry.immutableRanges,
+        firstEntry.linkRanges,
+      )
+    : computeMaskedRuntimeHash(code, [], []);
+
+  return {
+    address: utils.getAddress(address),
+    implementationAddress,
+    isProxy,
+    onchainVersion,
+    validity: BytecodeValidity.Mismatch,
+    onchainMaskedHash,
+    note: firstEntry
+      ? `No manifest entry matched. Reporting hash masked with ${firstEntry.contractName} ranges.`
+      : 'Manifest has no contracts.',
+  };
+}
+
+function findComparisonAcrossManifests(params: {
+  address: string;
+  implementationAddress: string;
+  isProxy: boolean;
+  code: string;
+  manifestSet: BytecodeManifestSet;
+  expectedContractName?: string;
+}): BytecodeComparison | undefined {
+  for (const manifest of Object.values(params.manifestSet)) {
+    const comparison = compareAgainstManifest({
+      address: params.address,
+      implementationAddress: params.implementationAddress,
+      isProxy: params.isProxy,
+      code: params.code,
+      manifest,
+      onchainVersion: manifest.packageVersion,
+      expectedContractName: params.expectedContractName,
+    });
+    if (comparison.validity === BytecodeValidity.Match) return comparison;
+  }
+  return undefined;
+}
+
+export async function compareBytecode(
+  provider: providers.Provider,
+  address: string,
+  manifestSet: BytecodeManifestSet,
+  opts?: { expectedContractName?: string },
+): Promise<BytecodeComparison> {
+  const { isProxy, implementationAddress } = await resolveImplementation(
+    provider,
+    address,
+  );
+  const code = await provider.getCode(implementationAddress);
+  if (code === '0x') {
+    return {
+      address: utils.getAddress(address),
+      implementationAddress,
+      isProxy,
+      validity: BytecodeValidity.NoCode,
+      note: 'implementation address has no code',
+    };
+  }
+
+  const proxyVersion = await readOnchainPackageVersion(provider, address);
+  const implementationVersion =
+    proxyVersion ??
+    (isProxy
+      ? await readOnchainPackageVersion(provider, implementationAddress)
+      : undefined);
+  const onchainVersion = implementationVersion;
+
+  if (!onchainVersion) {
+    const matched = findComparisonAcrossManifests({
+      address,
+      implementationAddress,
+      isProxy,
+      code,
+      manifestSet,
+      expectedContractName: opts?.expectedContractName,
+    });
+    if (matched) return { ...matched, onchainVersion: undefined };
+
+    return versionUnavailableComparison({
+      address,
+      implementationAddress,
+      isProxy,
+      manifestSet,
+      note: 'PACKAGE_VERSION unavailable and no manifest hash matched.',
+    });
+  }
+
+  const manifest = manifestSet[onchainVersion];
+  if (!manifest) {
+    return versionUnavailableComparison({
+      address,
+      implementationAddress,
+      isProxy,
+      onchainVersion,
+      manifestSet,
+    });
+  }
+
+  return compareAgainstManifest({
+    address,
+    implementationAddress,
+    isProxy,
+    code,
+    manifest,
+    onchainVersion,
+    expectedContractName: opts?.expectedContractName,
+  });
+}
+
+export async function scanAddressesBytecode(
+  provider: providers.Provider,
+  addresses: {
+    address: string;
+    expectedContractName?: string;
+    label?: string;
+  }[],
+  manifestSet: BytecodeManifestSet,
+): Promise<BytecodeComparison[]> {
+  const comparisons: BytecodeComparison[] = [];
+  for (const address of addresses) {
+    comparisons.push(
+      await compareBytecode(provider, address.address, manifestSet, {
+        expectedContractName: address.expectedContractName,
+      }),
+    );
+  }
+  return comparisons;
+}

--- a/typescript/sdk/src/deploy/verify/bytecodeManifest.test.ts
+++ b/typescript/sdk/src/deploy/verify/bytecodeManifest.test.ts
@@ -1,0 +1,205 @@
+import { expect } from 'chai';
+import { utils } from 'ethers';
+// eslint-disable-next-line import/no-nodejs-modules
+import fs from 'fs';
+// eslint-disable-next-line import/no-nodejs-modules
+import os from 'os';
+// eslint-disable-next-line import/no-nodejs-modules
+import path from 'path';
+
+import {
+  computeMaskedRuntimeHash,
+  flattenImmutableReferences,
+  flattenLinkReferences,
+  generateManifestFromBuildArtifact,
+  generateManifestFromBuildInfoDir,
+  maskRanges,
+  stripMetadata,
+  type SolcBuildArtifact,
+} from './bytecodeManifest.js';
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, JSON.stringify(value));
+}
+
+describe('bytecodeManifest', () => {
+  describe('stripMetadata', () => {
+    it('strips a valid CBOR tail', () => {
+      expect(stripMetadata('0x6001aabb0002')).to.equal('6001');
+    });
+
+    it('returns too-short input as-is', () => {
+      expect(stripMetadata('0f')).to.equal('0f');
+    });
+
+    it('returns input unchanged when metadata length exceeds byte length', () => {
+      expect(stripMetadata('0x600100ff')).to.equal('600100ff');
+    });
+  });
+
+  describe('maskRanges', () => {
+    it('masks exact windows and clamps to bytecode length', () => {
+      expect(
+        maskRanges('112233445566', [
+          { start: 1, length: 2 },
+          { start: 5, length: 4 },
+          { start: 9, length: 2 },
+        ]),
+      ).to.equal('110000445500');
+    });
+  });
+
+  describe('computeMaskedRuntimeHash', () => {
+    it('masks before stripping metadata and hashing', () => {
+      const bytecode = '0x1122334455aabb0002';
+      const hash = computeMaskedRuntimeHash(
+        bytecode,
+        [{ start: 1, length: 2 }],
+        [],
+      );
+      expect(hash).to.equal(utils.keccak256('0x1100004455'));
+    });
+  });
+
+  describe('flattenReferences', () => {
+    it('flattens immutable references', () => {
+      expect(
+        flattenImmutableReferences({
+          1: [{ start: 2, length: 3 }],
+          2: [{ start: 5, length: 7 }],
+        }),
+      ).to.deep.equal([
+        { start: 2, length: 3 },
+        { start: 5, length: 7 },
+      ]);
+      expect(flattenImmutableReferences(undefined)).to.deep.equal([]);
+    });
+
+    it('flattens link references', () => {
+      expect(
+        flattenLinkReferences({
+          'A.sol': {
+            LibA: [{ start: 2, length: 20 }],
+          },
+          'B.sol': {
+            LibB: [{ start: 30, length: 20 }],
+          },
+        }),
+      ).to.deep.equal([
+        { start: 2, length: 20 },
+        { start: 30, length: 20 },
+      ]);
+      expect(flattenLinkReferences(undefined)).to.deep.equal([]);
+    });
+  });
+
+  describe('generateManifestFromBuildInfoDir', () => {
+    it('keeps duplicate-name candidate from larger build-info', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bytecode-manifest-'));
+      try {
+        writeJson(path.join(dir, 'small.json'), {
+          output: {
+            contracts: {
+              'Foo.sol': {
+                Foo: {
+                  evm: { deployedBytecode: { object: '0x6001' } },
+                },
+              },
+            },
+          },
+        });
+        writeJson(path.join(dir, 'large.json'), {
+          output: {
+            contracts: {
+              'Foo.sol': {
+                Foo: {
+                  evm: { deployedBytecode: { object: '0x6002' } },
+                },
+              },
+              'Bar.sol': {
+                Bar: {
+                  evm: { deployedBytecode: { object: '0x6003' } },
+                },
+              },
+            },
+          },
+        });
+
+        const manifest = generateManifestFromBuildInfoDir(dir, '1.0.0');
+        expect(manifest.byName.Foo.maskedRuntimeHash).to.equal(
+          computeMaskedRuntimeHash('0x6002', [], []),
+        );
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('generateManifestFromBuildArtifact', () => {
+    const artifact: SolcBuildArtifact = {
+      input: {
+        language: 'Solidity',
+        sources: { 'HypERC20.sol': { content: 'contract HypERC20 {}' } },
+        settings: {},
+      },
+      solcLongVersion: '0.8.19+commit.7dd6d404',
+    };
+
+    it('builds byName and byHash from solc output', () => {
+      let compileInput = '';
+      const manifest = generateManifestFromBuildArtifact(
+        artifact,
+        '1.0.0',
+        (input) => {
+          compileInput = input;
+          return JSON.stringify({
+            contracts: {
+              'HypERC20.sol': {
+                HypERC20: {
+                  evm: {
+                    deployedBytecode: {
+                      object: '0x6001',
+                      immutableReferences: {
+                        1: [{ start: 1, length: 1 }],
+                      },
+                      linkReferences: {},
+                    },
+                  },
+                },
+              },
+            },
+          });
+        },
+      );
+
+      expect(JSON.parse(compileInput).settings.outputSelection).to.deep.equal({
+        '*': {
+          '*': [
+            'evm.deployedBytecode.object',
+            'evm.deployedBytecode.immutableReferences',
+            'evm.deployedBytecode.linkReferences',
+          ],
+        },
+      });
+      expect(manifest.byName.HypERC20.contractName).to.equal('HypERC20');
+      expect(
+        manifest.byHash[manifest.byName.HypERC20.maskedRuntimeHash],
+      ).to.deep.equal(['HypERC20']);
+    });
+
+    it('throws on solc errors', () => {
+      expect(() =>
+        generateManifestFromBuildArtifact(artifact, '1.0.0', () =>
+          JSON.stringify({
+            errors: [
+              {
+                severity: 'error',
+                formattedMessage: 'compile failed',
+              },
+            ],
+          }),
+        ),
+      ).to.throw('compile failed');
+    });
+  });
+});

--- a/typescript/sdk/src/deploy/verify/bytecodeManifest.ts
+++ b/typescript/sdk/src/deploy/verify/bytecodeManifest.ts
@@ -1,0 +1,248 @@
+// Node-only: manifest generation reads solc build-info from disk.
+// eslint-disable-next-line import/no-nodejs-modules
+import fs from 'fs';
+// eslint-disable-next-line import/no-nodejs-modules
+import path from 'path';
+
+import { utils } from 'ethers';
+
+import { assert, rootLogger } from '@hyperlane-xyz/utils';
+
+const logger = rootLogger.child({ module: 'bytecodeManifest' });
+
+export const EIP1967_IMPLEMENTATION_SLOT =
+  '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
+
+export interface ByteRange {
+  start: number;
+  length: number;
+}
+
+export interface ContractBytecodeEntry {
+  contractName: string;
+  sourcePath: string;
+  packageVersion: string;
+  immutableRanges: ByteRange[];
+  linkRanges: ByteRange[];
+  maskedRuntimeHash: string;
+}
+
+export interface BytecodeManifest {
+  packageVersion: string;
+  byName: Record<string, ContractBytecodeEntry>;
+  byHash: Record<string, string[]>;
+}
+
+export type BytecodeManifestSet = Record<string, BytecodeManifest>;
+
+interface BuildInfoDeployedBytecode {
+  object?: string;
+  immutableReferences?: Record<string, ByteRange[]>;
+  linkReferences?: Record<string, Record<string, ByteRange[]>>;
+}
+
+interface BuildInfoContractOutput {
+  evm?: {
+    deployedBytecode?: BuildInfoDeployedBytecode;
+  };
+}
+
+interface BuildInfo {
+  output?: {
+    contracts?: Record<string, Record<string, BuildInfoContractOutput>>;
+  };
+}
+
+interface ManifestCandidate {
+  entry: ContractBytecodeEntry;
+  contractCount: number;
+  buildInfoFile: string;
+}
+
+function normalizeHex(hexBytecode: string): string {
+  return hexBytecode.replace(/^0x/i, '').toLowerCase();
+}
+
+export function stripMetadata(hexBytecode: string): string {
+  const normalized = normalizeHex(hexBytecode);
+  if (normalized.length < 4) return normalized;
+
+  const byteLength = normalized.length / 2;
+  const metadataLength = parseInt(normalized.slice(-4), 16);
+  const totalMetadataLength = metadataLength + 2;
+  if (
+    metadataLength > byteLength ||
+    totalMetadataLength > byteLength ||
+    totalMetadataLength < 2
+  ) {
+    return normalized;
+  }
+
+  return normalized.slice(0, normalized.length - totalMetadataLength * 2);
+}
+
+export function maskRanges(
+  hexBytecodeNo0x: string,
+  ranges: ByteRange[],
+): string {
+  let masked = normalizeHex(hexBytecodeNo0x);
+  for (const range of ranges) {
+    assert(range.start >= 0, `Invalid byte range start ${range.start}`);
+    assert(range.length >= 0, `Invalid byte range length ${range.length}`);
+
+    const start = range.start * 2;
+    const end = start + range.length * 2;
+    if (start >= masked.length) continue;
+
+    const boundedEnd = Math.min(end, masked.length);
+    masked =
+      masked.slice(0, start) +
+      '0'.repeat(boundedEnd - start) +
+      masked.slice(boundedEnd);
+  }
+  return masked;
+}
+
+export function computeMaskedRuntimeHash(
+  deployedBytecodeHex: string,
+  immutableRanges: ByteRange[],
+  linkRanges: ByteRange[],
+): string {
+  const normalized = normalizeHex(deployedBytecodeHex);
+  const masked = stripMetadata(
+    maskRanges(normalized, [...immutableRanges, ...linkRanges]),
+  );
+  return utils.keccak256(`0x${masked}`);
+}
+
+export function flattenImmutableReferences(
+  immutableReferences: Record<string, ByteRange[]> | undefined,
+): ByteRange[] {
+  if (!immutableReferences) return [];
+  return Object.values(immutableReferences).flatMap((ranges) =>
+    ranges.map(({ start, length }) => ({ start, length })),
+  );
+}
+
+export function flattenLinkReferences(
+  linkReferences: Record<string, Record<string, ByteRange[]>> | undefined,
+): ByteRange[] {
+  if (!linkReferences) return [];
+  return Object.values(linkReferences).flatMap((libraryReferences) =>
+    Object.values(libraryReferences).flatMap((ranges) =>
+      ranges.map(({ start, length }) => ({ start, length })),
+    ),
+  );
+}
+
+function countContracts(buildInfo: BuildInfo): number {
+  const contracts = buildInfo.output?.contracts;
+  if (!contracts) return 0;
+  return Object.values(contracts).reduce(
+    (sum, sourceContracts) => sum + Object.keys(sourceContracts).length,
+    0,
+  );
+}
+
+function readBuildInfo(filePath: string): BuildInfo {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as BuildInfo;
+}
+
+function addCandidate(
+  candidates: Record<string, ManifestCandidate>,
+  candidate: ManifestCandidate,
+): void {
+  const existing = candidates[candidate.entry.contractName];
+  if (!existing) {
+    candidates[candidate.entry.contractName] = candidate;
+    return;
+  }
+
+  if (existing.entry.maskedRuntimeHash === candidate.entry.maskedRuntimeHash) {
+    return;
+  }
+
+  const shouldReplace = candidate.contractCount > existing.contractCount;
+  const selected = shouldReplace ? candidate : existing;
+  logger.warn(
+    [
+      `Bytecode manifest hash collision for ${candidate.entry.contractName}.`,
+      `Keeping ${selected.buildInfoFile} from larger build-info.`,
+      `Skipped ${shouldReplace ? existing.buildInfoFile : candidate.buildInfoFile}.`,
+    ].join(' '),
+  );
+
+  if (shouldReplace) {
+    candidates[candidate.entry.contractName] = candidate;
+  }
+}
+
+export function generateManifestFromBuildInfoDir(
+  buildInfoDir: string,
+  packageVersion: string,
+): BytecodeManifest {
+  const candidates: Record<string, ManifestCandidate> = {};
+  const files = fs
+    .readdirSync(buildInfoDir)
+    .filter((file) => file.endsWith('.json'))
+    .sort();
+
+  for (const file of files) {
+    const filePath = path.join(buildInfoDir, file);
+    const buildInfo = readBuildInfo(filePath);
+    const contractCount = countContracts(buildInfo);
+    const contracts = buildInfo.output?.contracts;
+    if (!contracts) continue;
+
+    for (const [sourcePath, sourceContracts] of Object.entries(contracts)) {
+      for (const [contractName, contract] of Object.entries(sourceContracts)) {
+        const deployedBytecode = contract.evm?.deployedBytecode;
+        const object = deployedBytecode?.object;
+        if (!object || object === '0x') continue;
+
+        const immutableRanges = flattenImmutableReferences(
+          deployedBytecode.immutableReferences,
+        );
+        const linkRanges = flattenLinkReferences(
+          deployedBytecode.linkReferences,
+        );
+        const entry: ContractBytecodeEntry = {
+          contractName,
+          sourcePath,
+          packageVersion,
+          immutableRanges,
+          linkRanges,
+          maskedRuntimeHash: computeMaskedRuntimeHash(
+            object,
+            immutableRanges,
+            linkRanges,
+          ),
+        };
+
+        addCandidate(candidates, {
+          entry,
+          contractCount,
+          buildInfoFile: filePath,
+        });
+      }
+    }
+  }
+
+  const byName = Object.fromEntries(
+    Object.entries(candidates).map(([contractName, candidate]) => [
+      contractName,
+      candidate.entry,
+    ]),
+  );
+  const byHash: Record<string, string[]> = {};
+  for (const entry of Object.values(byName)) {
+    byHash[entry.maskedRuntimeHash] ||= [];
+    byHash[entry.maskedRuntimeHash].push(entry.contractName);
+  }
+
+  return {
+    packageVersion,
+    byName,
+    byHash,
+  };
+}

--- a/typescript/sdk/src/deploy/verify/bytecodeManifest.ts
+++ b/typescript/sdk/src/deploy/verify/bytecodeManifest.ts
@@ -53,6 +53,24 @@ interface BuildInfo {
   };
 }
 
+export interface SolcBuildArtifact {
+  input: {
+    language: string;
+    sources: Record<string, unknown>;
+    settings: Record<string, unknown>;
+  };
+  solcLongVersion: string;
+}
+
+interface SolcOutput {
+  errors?: {
+    severity?: string;
+    formattedMessage?: string;
+    message?: string;
+  }[];
+  contracts?: Record<string, Record<string, BuildInfoContractOutput>>;
+}
+
 interface ManifestCandidate {
   entry: ContractBytecodeEntry;
   contractCount: number;
@@ -177,57 +195,10 @@ function addCandidate(
   }
 }
 
-export function generateManifestFromBuildInfoDir(
-  buildInfoDir: string,
+function manifestFromCandidates(
+  candidates: Record<string, ManifestCandidate>,
   packageVersion: string,
 ): BytecodeManifest {
-  const candidates: Record<string, ManifestCandidate> = {};
-  const files = fs
-    .readdirSync(buildInfoDir)
-    .filter((file) => file.endsWith('.json'))
-    .sort();
-
-  for (const file of files) {
-    const filePath = path.join(buildInfoDir, file);
-    const buildInfo = readBuildInfo(filePath);
-    const contractCount = countContracts(buildInfo);
-    const contracts = buildInfo.output?.contracts;
-    if (!contracts) continue;
-
-    for (const [sourcePath, sourceContracts] of Object.entries(contracts)) {
-      for (const [contractName, contract] of Object.entries(sourceContracts)) {
-        const deployedBytecode = contract.evm?.deployedBytecode;
-        const object = deployedBytecode?.object;
-        if (!object || object === '0x') continue;
-
-        const immutableRanges = flattenImmutableReferences(
-          deployedBytecode.immutableReferences,
-        );
-        const linkRanges = flattenLinkReferences(
-          deployedBytecode.linkReferences,
-        );
-        const entry: ContractBytecodeEntry = {
-          contractName,
-          sourcePath,
-          packageVersion,
-          immutableRanges,
-          linkRanges,
-          maskedRuntimeHash: computeMaskedRuntimeHash(
-            object,
-            immutableRanges,
-            linkRanges,
-          ),
-        };
-
-        addCandidate(candidates, {
-          entry,
-          contractCount,
-          buildInfoFile: filePath,
-        });
-      }
-    }
-  }
-
   const byName = Object.fromEntries(
     Object.entries(candidates).map(([contractName, candidate]) => [
       contractName,
@@ -245,4 +216,121 @@ export function generateManifestFromBuildInfoDir(
     byName,
     byHash,
   };
+}
+
+function addContractsToCandidates(params: {
+  candidates: Record<string, ManifestCandidate>;
+  contracts: Record<string, Record<string, BuildInfoContractOutput>>;
+  packageVersion: string;
+  contractCount: number;
+  buildInfoFile: string;
+}): void {
+  for (const [sourcePath, sourceContracts] of Object.entries(
+    params.contracts,
+  )) {
+    for (const [contractName, contract] of Object.entries(sourceContracts)) {
+      const deployedBytecode = contract.evm?.deployedBytecode;
+      const object = deployedBytecode?.object;
+      if (!object || object === '0x' || object === '') continue;
+
+      const immutableRanges = flattenImmutableReferences(
+        deployedBytecode.immutableReferences,
+      );
+      const linkRanges = flattenLinkReferences(deployedBytecode.linkReferences);
+      const entry: ContractBytecodeEntry = {
+        contractName,
+        sourcePath,
+        packageVersion: params.packageVersion,
+        immutableRanges,
+        linkRanges,
+        maskedRuntimeHash: computeMaskedRuntimeHash(
+          object,
+          immutableRanges,
+          linkRanges,
+        ),
+      };
+
+      addCandidate(params.candidates, {
+        entry,
+        contractCount: params.contractCount,
+        buildInfoFile: params.buildInfoFile,
+      });
+    }
+  }
+}
+
+export function generateManifestFromBuildInfoDir(
+  buildInfoDir: string,
+  packageVersion: string,
+): BytecodeManifest {
+  const candidates: Record<string, ManifestCandidate> = {};
+  const files = fs
+    .readdirSync(buildInfoDir)
+    .filter((file) => file.endsWith('.json'))
+    .sort();
+
+  for (const file of files) {
+    const filePath = path.join(buildInfoDir, file);
+    const buildInfo = readBuildInfo(filePath);
+    const contractCount = countContracts(buildInfo);
+    const contracts = buildInfo.output?.contracts;
+    if (!contracts) continue;
+
+    addContractsToCandidates({
+      candidates,
+      contracts,
+      packageVersion,
+      contractCount,
+      buildInfoFile: filePath,
+    });
+  }
+
+  return manifestFromCandidates(candidates, packageVersion);
+}
+
+export function generateManifestFromBuildArtifact(
+  artifact: SolcBuildArtifact,
+  packageVersion: string,
+  compile: (stdJsonInput: string) => string,
+): BytecodeManifest {
+  const input = JSON.parse(
+    JSON.stringify(artifact.input),
+  ) as SolcBuildArtifact['input'];
+  input.settings = {
+    ...input.settings,
+    outputSelection: {
+      '*': {
+        '*': [
+          'evm.deployedBytecode.object',
+          'evm.deployedBytecode.immutableReferences',
+          'evm.deployedBytecode.linkReferences',
+        ],
+      },
+    },
+  };
+
+  const output = JSON.parse(compile(JSON.stringify(input))) as SolcOutput;
+  const errors = output.errors?.filter((error) => error.severity === 'error');
+  assert(
+    !errors || errors.length === 0,
+    (errors ?? [])
+      .map((error) => error.formattedMessage ?? error.message ?? 'solc error')
+      .join('\n'),
+  );
+
+  const candidates: Record<string, ManifestCandidate> = {};
+  const contracts = output.contracts ?? {};
+  const contractCount = Object.values(contracts).reduce(
+    (sum, sourceContracts) => sum + Object.keys(sourceContracts).length,
+    0,
+  );
+  addContractsToCandidates({
+    candidates,
+    contracts,
+    packageVersion,
+    contractCount,
+    buildInfoFile: `buildArtifact:${artifact.solcLongVersion}`,
+  });
+
+  return manifestFromCandidates(candidates, packageVersion);
 }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -229,12 +229,16 @@ export {
   resolveImplementation,
   scanAddressesBytecode,
 } from './deploy/verify/bytecodeComparator.js';
-export type { BytecodeComparison } from './deploy/verify/bytecodeComparator.js';
+export type {
+  BytecodeComparison,
+  PackageVersionRead,
+} from './deploy/verify/bytecodeComparator.js';
 export {
   EIP1967_IMPLEMENTATION_SLOT,
   computeMaskedRuntimeHash,
   flattenImmutableReferences,
   flattenLinkReferences,
+  generateManifestFromBuildArtifact,
   generateManifestFromBuildInfoDir,
   maskRanges,
   stripMetadata,
@@ -244,6 +248,7 @@ export type {
   BytecodeManifest,
   BytecodeManifestSet,
   ContractBytecodeEntry,
+  SolcBuildArtifact,
 } from './deploy/verify/bytecodeManifest.js';
 export {
   BuildArtifact,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -223,6 +223,29 @@ export {
 export { ContractVerifier } from './deploy/verify/ContractVerifier.js';
 export { PostDeploymentContractVerifier } from './deploy/verify/PostDeploymentContractVerifier.js';
 export {
+  BytecodeValidity,
+  compareBytecode,
+  readOnchainPackageVersion,
+  resolveImplementation,
+  scanAddressesBytecode,
+} from './deploy/verify/bytecodeComparator.js';
+export type { BytecodeComparison } from './deploy/verify/bytecodeComparator.js';
+export {
+  EIP1967_IMPLEMENTATION_SLOT,
+  computeMaskedRuntimeHash,
+  flattenImmutableReferences,
+  flattenLinkReferences,
+  generateManifestFromBuildInfoDir,
+  maskRanges,
+  stripMetadata,
+} from './deploy/verify/bytecodeManifest.js';
+export type {
+  ByteRange,
+  BytecodeManifest,
+  BytecodeManifestSet,
+  ContractBytecodeEntry,
+} from './deploy/verify/bytecodeManifest.js';
+export {
   BuildArtifact,
   CompilerOptions,
   ContractVerificationInput,
@@ -983,6 +1006,14 @@ export {
   CONFIGURATION_CHANGED_EVENT_SELECTOR,
   XERC20_VS_ABI,
 } from './token/xerc20-abi.js';
+export {
+  bytecodeComparisonsToViolations,
+  checkWarpRouteBytecode,
+} from './token/warpBytecodeCheck.js';
+export type {
+  BytecodeMismatchViolation,
+  WarpBytecodeComparison,
+} from './token/warpBytecodeCheck.js';
 export {
   PredicateApiClient,
   PredicateAttestation,

--- a/typescript/sdk/src/token/warpBytecodeCheck.ts
+++ b/typescript/sdk/src/token/warpBytecodeCheck.ts
@@ -74,41 +74,84 @@ function getWarpLegs(input: WarpBytecodeInput): WarpLeg[] {
   });
 }
 
-const EXPECTED_BY_STANDARD: Partial<Record<TokenStandard, string>> = {
-  [TokenStandard.EvmHypCollateral]: 'HypERC20Collateral',
-  [TokenStandard.EvmHypNative]: 'HypNative',
-  [TokenStandard.EvmHypSynthetic]: 'HypERC20',
-  [TokenStandard.EvmHypCollateralFiat]: 'HypFiatToken',
-  [TokenStandard.EvmHypOwnerCollateral]: 'HypERC4626OwnerCollateral',
-  [TokenStandard.EvmHypRebaseCollateral]: 'HypERC4626Collateral',
-  [TokenStandard.EvmHypSyntheticRebase]: 'HypERC20',
-  [TokenStandard.EvmHypCrossCollateralRouter]: 'CrossCollateralRouter',
-  [TokenStandard.EvmHypXERC20]: 'HypXERC20',
-  [TokenStandard.EvmHypXERC20Lockbox]: 'HypXERC20Lockbox',
-  [TokenStandard.EvmHypVSXERC20]: 'HypXERC20',
-  [TokenStandard.EvmHypVSXERC20Lockbox]: 'HypXERC20Lockbox',
+const COMPATIBLE_CONTRACTS_BY_STANDARD: Partial<
+  Record<TokenStandard, ReadonlyArray<string>>
+> = {
+  [TokenStandard.EvmHypCollateral]: ['HypERC20Collateral'],
+  [TokenStandard.EvmHypNative]: ['HypNative'],
+  [TokenStandard.EvmHypSynthetic]: ['HypERC20'],
+  [TokenStandard.EvmHypSyntheticRebase]: ['HypERC20'],
+  [TokenStandard.EvmHypCollateralFiat]: ['HypFiatToken'],
+  [TokenStandard.EvmHypOwnerCollateral]: ['HypERC4626OwnerCollateral'],
+  [TokenStandard.EvmHypRebaseCollateral]: ['HypERC4626Collateral'],
+  [TokenStandard.EvmHypCrossCollateralRouter]: ['CrossCollateralRouter'],
+  [TokenStandard.EvmHypXERC20]: ['HypXERC20'],
+  [TokenStandard.EvmHypXERC20Lockbox]: ['HypXERC20Lockbox'],
+  [TokenStandard.EvmHypVSXERC20]: ['HypXERC20'],
+  [TokenStandard.EvmHypVSXERC20Lockbox]: ['HypXERC20Lockbox'],
 };
 
 // Minimal deploy-type fallback. Prefer standards when present because they are
 // closer to the runtime adapter semantics.
-const EXPECTED_BY_TYPE: Partial<Record<TokenType, string>> = {
-  [TokenType.collateral]: 'HypERC20Collateral',
-  [TokenType.native]: 'HypNative',
-  [TokenType.nativeScaled]: 'HypNative',
-  [TokenType.synthetic]: 'HypERC20',
-  [TokenType.syntheticRebase]: 'HypERC20',
-  [TokenType.collateralFiat]: 'HypFiatToken',
-  [TokenType.crossCollateral]: 'CrossCollateralRouter',
-  [TokenType.XERC20]: 'HypXERC20',
-  [TokenType.XERC20Lockbox]: 'HypXERC20Lockbox',
+const COMPATIBLE_CONTRACTS_BY_TYPE: Partial<
+  Record<TokenType, ReadonlyArray<string>>
+> = {
+  [TokenType.collateral]: ['HypERC20Collateral'],
+  [TokenType.native]: ['HypNative'],
+  [TokenType.nativeScaled]: ['HypNative'],
+  [TokenType.synthetic]: ['HypERC20'],
+  [TokenType.syntheticRebase]: ['HypERC20'],
+  [TokenType.collateralFiat]: ['HypFiatToken'],
+  [TokenType.crossCollateral]: ['CrossCollateralRouter'],
+  [TokenType.XERC20]: ['HypXERC20'],
+  [TokenType.XERC20Lockbox]: ['HypXERC20Lockbox'],
 };
 
-function expectedContractName(leg: WarpLeg): string | undefined {
+function compatibleContractNames(
+  leg: WarpLeg,
+): ReadonlyArray<string> | undefined {
   if (leg.standard) {
-    const byStandard = EXPECTED_BY_STANDARD[leg.standard];
+    const byStandard = COMPATIBLE_CONTRACTS_BY_STANDARD[leg.standard];
     if (byStandard) return byStandard;
   }
-  return leg.tokenType ? EXPECTED_BY_TYPE[leg.tokenType] : undefined;
+  return leg.tokenType
+    ? COMPATIBLE_CONTRACTS_BY_TYPE[leg.tokenType]
+    : undefined;
+}
+
+function expectedContractName(leg: WarpLeg): string | undefined {
+  return compatibleContractNames(leg)?.[0];
+}
+
+function roleLabel(leg: WarpLeg): string | undefined {
+  return leg.standard ?? leg.tokenType;
+}
+
+function applyRoleFamily(
+  comparison: BytecodeComparison,
+  leg: WarpLeg,
+): BytecodeComparison {
+  const family = compatibleContractNames(leg);
+  const label = roleLabel(leg);
+  if (!family) {
+    return {
+      ...comparison,
+      note: comparison.note ?? 'no role family to assert',
+    };
+  }
+  if (
+    comparison.validity !== BytecodeValidity.Match ||
+    !comparison.matchedContractName ||
+    family.includes(comparison.matchedContractName)
+  ) {
+    return comparison;
+  }
+  assert(label, 'Missing warp leg role label');
+  return {
+    ...comparison,
+    validity: BytecodeValidity.Mismatch,
+    note: `matched ${comparison.matchedContractName} which is not a valid contract for ${label}`,
+  };
 }
 
 export async function checkWarpRouteBytecode(
@@ -124,30 +167,16 @@ export async function checkWarpRouteBytecode(
 
     assert(leg.addressOrDenom, `Missing router address for ${leg.chainName}`);
 
-    // Reverse-lookup (match against ANY known contract of the on-chain version)
-    // is the validity trigger: a Mismatch then means the deployed bytecode does
-    // not correspond to any version-controlled Hyperlane contract. The expected
-    // name from the token standard is only advisory — the standard->name map
-    // drifts across releases, so using it as the hard trigger produces false
-    // violations when a route uses a validly-deployed but differently-named
-    // contract (e.g. HypFiatToken, HypERC4626OwnerCollateral).
     const expected = expectedContractName(leg);
     const comparison = await compareBytecode(
       multiProvider.getProvider(leg.chainName),
       leg.addressOrDenom,
       manifestSet,
     );
-    const typeMismatchNote =
-      comparison.validity === BytecodeValidity.Match &&
-      expected &&
-      comparison.matchedContractName &&
-      comparison.matchedContractName !== expected
-        ? `on-chain contract ${comparison.matchedContractName} differs from expected ${expected} for standard`
-        : undefined;
+    const roleCheckedComparison = applyRoleFamily(comparison, leg);
     comparisons.push({
-      ...comparison,
+      ...roleCheckedComparison,
       expectedContractName: expected,
-      note: comparison.note ?? typeMismatchNote,
       chain: leg.chainName,
       label: `${leg.chainName}:${leg.addressOrDenom}`,
       warpRouteId: opts?.warpRouteId,
@@ -161,7 +190,11 @@ export function bytecodeComparisonsToViolations(
   warpRouteId: string,
 ): BytecodeMismatchViolation[] {
   return comparisons
-    .filter((comparison) => comparison.validity === BytecodeValidity.Mismatch)
+    .filter(
+      (comparison) =>
+        comparison.validity === BytecodeValidity.Mismatch ||
+        comparison.validity === BytecodeValidity.NoCode,
+    )
     .map((comparison) => ({
       module: 'warp',
       warp_route_id: warpRouteId,
@@ -171,9 +204,17 @@ export function bytecodeComparisonsToViolations(
         comparison.matchedContractName ??
         comparison.address,
       type: 'BytecodeMismatch',
-      sub_type: comparison.validity,
-      actual: comparison.onchainMaskedHash ?? comparison.note ?? '',
+      sub_type:
+        comparison.validity === BytecodeValidity.NoCode
+          ? 'NoCode'
+          : comparison.validity,
+      actual:
+        comparison.validity === BytecodeValidity.NoCode
+          ? 'no deployed code at router address'
+          : (comparison.onchainMaskedHash ?? comparison.note ?? ''),
       expected:
-        comparison.expectedHash ?? comparison.expectedContractName ?? '',
+        comparison.validity === BytecodeValidity.NoCode
+          ? 'expected deployed code at router address'
+          : (comparison.expectedHash ?? comparison.expectedContractName ?? ''),
     }));
 }

--- a/typescript/sdk/src/token/warpBytecodeCheck.ts
+++ b/typescript/sdk/src/token/warpBytecodeCheck.ts
@@ -1,0 +1,179 @@
+import { ProtocolType, assert, isEVMLike } from '@hyperlane-xyz/utils';
+
+import {
+  BytecodeComparison,
+  BytecodeValidity,
+  compareBytecode,
+} from '../deploy/verify/bytecodeComparator.js';
+import type { BytecodeManifestSet } from '../deploy/verify/bytecodeManifest.js';
+import type { MultiProvider } from '../providers/MultiProvider.js';
+import type { ChainName } from '../types.js';
+import type { WarpCoreConfig } from '../warp/types.js';
+
+import { TokenStandard } from './TokenStandard.js';
+import { TokenType } from './config.js';
+import type { WarpRouteDeployConfig } from './types.js';
+
+export interface WarpBytecodeComparison extends BytecodeComparison {
+  chain: ChainName;
+  label?: string;
+  warpRouteId?: string;
+}
+
+export interface BytecodeMismatchViolation {
+  module: string;
+  warp_route_id: string;
+  chain: ChainName;
+  contract_name: string;
+  type: 'BytecodeMismatch';
+  sub_type: string;
+  actual: string;
+  expected: string;
+}
+
+type WarpBytecodeInput = WarpCoreConfig | WarpRouteDeployConfig;
+
+interface WarpLeg {
+  chainName: ChainName;
+  addressOrDenom: string;
+  standard?: TokenStandard;
+  tokenType?: TokenType;
+}
+
+function isWarpCoreConfig(input: WarpBytecodeInput): input is WarpCoreConfig {
+  return 'tokens' in input;
+}
+
+function getWarpLegs(input: WarpBytecodeInput): WarpLeg[] {
+  if (isWarpCoreConfig(input)) {
+    return input.tokens
+      .filter((token) => token.addressOrDenom)
+      .map((token) => ({
+        chainName: token.chainName,
+        addressOrDenom: token.addressOrDenom,
+        standard: token.standard,
+        tokenType: token.tokenType,
+      }));
+  }
+
+  // Deploy configs generally do not include deployed router addresses. Support
+  // only entries that carry an address-like override in future/local configs.
+  return Object.entries(input).flatMap(([chainName, config]) => {
+    const possibleAddress =
+      'addressOrDenom' in config && typeof config.addressOrDenom === 'string'
+        ? config.addressOrDenom
+        : undefined;
+    if (!possibleAddress) return [];
+    return [
+      {
+        chainName,
+        addressOrDenom: possibleAddress,
+        tokenType: config.type,
+      },
+    ];
+  });
+}
+
+const EXPECTED_BY_STANDARD: Partial<Record<TokenStandard, string>> = {
+  [TokenStandard.EvmHypCollateral]: 'HypERC20Collateral',
+  [TokenStandard.EvmHypNative]: 'HypNative',
+  [TokenStandard.EvmHypSynthetic]: 'HypERC20',
+  [TokenStandard.EvmHypCollateralFiat]: 'HypFiatToken',
+  [TokenStandard.EvmHypOwnerCollateral]: 'HypERC4626OwnerCollateral',
+  [TokenStandard.EvmHypRebaseCollateral]: 'HypERC4626Collateral',
+  [TokenStandard.EvmHypSyntheticRebase]: 'HypERC20',
+  [TokenStandard.EvmHypCrossCollateralRouter]: 'CrossCollateralRouter',
+  [TokenStandard.EvmHypXERC20]: 'HypXERC20',
+  [TokenStandard.EvmHypXERC20Lockbox]: 'HypXERC20Lockbox',
+  [TokenStandard.EvmHypVSXERC20]: 'HypXERC20',
+  [TokenStandard.EvmHypVSXERC20Lockbox]: 'HypXERC20Lockbox',
+};
+
+// Minimal deploy-type fallback. Prefer standards when present because they are
+// closer to the runtime adapter semantics.
+const EXPECTED_BY_TYPE: Partial<Record<TokenType, string>> = {
+  [TokenType.collateral]: 'HypERC20Collateral',
+  [TokenType.native]: 'HypNative',
+  [TokenType.nativeScaled]: 'HypNative',
+  [TokenType.synthetic]: 'HypERC20',
+  [TokenType.syntheticRebase]: 'HypERC20',
+  [TokenType.collateralFiat]: 'HypFiatToken',
+  [TokenType.crossCollateral]: 'CrossCollateralRouter',
+  [TokenType.XERC20]: 'HypXERC20',
+  [TokenType.XERC20Lockbox]: 'HypXERC20Lockbox',
+};
+
+function expectedContractName(leg: WarpLeg): string | undefined {
+  if (leg.standard) {
+    const byStandard = EXPECTED_BY_STANDARD[leg.standard];
+    if (byStandard) return byStandard;
+  }
+  return leg.tokenType ? EXPECTED_BY_TYPE[leg.tokenType] : undefined;
+}
+
+export async function checkWarpRouteBytecode(
+  multiProvider: MultiProvider,
+  warpConfig: WarpBytecodeInput,
+  manifestSet: BytecodeManifestSet,
+  opts?: { warpRouteId?: string },
+): Promise<WarpBytecodeComparison[]> {
+  const comparisons: WarpBytecodeComparison[] = [];
+  for (const leg of getWarpLegs(warpConfig)) {
+    const protocol = multiProvider.getProtocol(leg.chainName);
+    if (!isEVMLike(protocol) || protocol === ProtocolType.Tron) continue;
+
+    assert(leg.addressOrDenom, `Missing router address for ${leg.chainName}`);
+
+    // Reverse-lookup (match against ANY known contract of the on-chain version)
+    // is the validity trigger: a Mismatch then means the deployed bytecode does
+    // not correspond to any version-controlled Hyperlane contract. The expected
+    // name from the token standard is only advisory — the standard->name map
+    // drifts across releases, so using it as the hard trigger produces false
+    // violations when a route uses a validly-deployed but differently-named
+    // contract (e.g. HypFiatToken, HypERC4626OwnerCollateral).
+    const expected = expectedContractName(leg);
+    const comparison = await compareBytecode(
+      multiProvider.getProvider(leg.chainName),
+      leg.addressOrDenom,
+      manifestSet,
+    );
+    const typeMismatchNote =
+      comparison.validity === BytecodeValidity.Match &&
+      expected &&
+      comparison.matchedContractName &&
+      comparison.matchedContractName !== expected
+        ? `on-chain contract ${comparison.matchedContractName} differs from expected ${expected} for standard`
+        : undefined;
+    comparisons.push({
+      ...comparison,
+      expectedContractName: expected,
+      note: comparison.note ?? typeMismatchNote,
+      chain: leg.chainName,
+      label: `${leg.chainName}:${leg.addressOrDenom}`,
+      warpRouteId: opts?.warpRouteId,
+    });
+  }
+  return comparisons;
+}
+
+export function bytecodeComparisonsToViolations(
+  comparisons: WarpBytecodeComparison[],
+  warpRouteId: string,
+): BytecodeMismatchViolation[] {
+  return comparisons
+    .filter((comparison) => comparison.validity === BytecodeValidity.Mismatch)
+    .map((comparison) => ({
+      module: 'warp',
+      warp_route_id: warpRouteId,
+      chain: comparison.chain,
+      contract_name:
+        comparison.expectedContractName ??
+        comparison.matchedContractName ??
+        comparison.address,
+      type: 'BytecodeMismatch',
+      sub_type: comparison.validity,
+      actual: comparison.onchainMaskedHash ?? comparison.note ?? '',
+      expected:
+        comparison.expectedHash ?? comparison.expectedContractName ?? '',
+    }));
+}


### PR DESCRIPTION
## Summary

Adds a deterministic EVM **deployed-bytecode validity checker** to the SDK: it verifies that a deployed contract's on-chain bytecode actually matches version-controlled Hyperlane source, rather than only being "verified" on a block explorer.

- `deploy/verify/bytecodeManifest.ts` — strips solc CBOR metadata, masks immutable + library-link ranges, keccaks the result, and builds a version-keyed manifest from build-info. (Node-only generator; pure hashing/masking helpers are browser-safe.)
- `deploy/verify/bytecodeComparator.ts` — resolves EIP-1967 proxy→impl, reads on-chain `PACKAGE_VERSION()`, compares against the manifest. Verdicts: `Match` / `Mismatch` / `VersionUnavailable` / `NoCode`.
- `token/warpBytecodeCheck.ts` — scans every EVM leg of a warp route via **reverse-lookup** (match against any known contract of the on-chain version) and emits `BytecodeMismatch` violations in the exact shape `check-warp-deploy` already pushes.
- `scripts/verifyBytecode.ts` — tsx harness for single-address and warp-route checks.

Reverse-lookup is the mismatch trigger, not the token-standard→name map: the standard→name map drifts across releases and produces false positives (e.g. HypFiatToken, HypERC4626OwnerCollateral). A `Mismatch` therefore means the deployed bytecode corresponds to **no** version-controlled Hyperlane contract of its self-reported version.

Non-obvious gotcha (confirmed empirically): per-version solc settings vary and must be pinned — e.g. 9.0.9 = solc 0.8.22 / evm `paris` / 999999 runs; 11.3.x = 0.8.33 / `cancun` / 10000. Wrong `evm_version` → every hash mismatches. The npm `dist/buildArtifact.json` for each `@hyperlane-xyz/core` release carries the exact solc input + long version, so per-version manifests are reproducible deterministically.

## Live validation (mainnet)

**Warp routes** — 110 diverse legs sampled across 10 token standards + many chains, against manifests for 7 releases (5.11.3, 6.1.0, 7.0.0, 9.0.9, 10.1.1, 11.3.0, 11.3.1):
- 32 `match` (6 versions × 10 standards), 54 `version_unavailable` (release not in the 7-version set; advisory, non-violating), 5 `mismatch`, 19 RPC errors.
- All 5 mismatches are value-scaled xERC20 (`EvmHypVSXERC20`/`Lockbox`) whose on-chain bytecode matches **no** canonical core contract in **any** of the 7 versions (brute-forced), while same-version stock `HypXERC20` peers match cleanly — i.e. genuine variant/fork deployments, exactly what this is meant to surface. **Zero false positives on canonical routes.**

**Core contracts** — Mailbox / MerkleTreeHook / ValidatorAnnounce / IGP / ProxyAdmin across mainnet chains:
- `arcadia`'s entire core stack (Mailbox, MerkleTreeHook, ValidatorAnnounce, IGP — all 5.11.3) → `match`. `ProxyAdmin` (no `PACKAGE_VERSION`) → `match` on ~16 chains via version-less reverse-lookup. Zero mismatches; remaining chains are `version_unavailable` only because they run older core releases (5.6.x/5.8.x) not yet in the manifest set.
- So this applies to core contracts identically to warp tokens — the manifest already contains every contract in each release.

## Not in this PR (follow-up)

- Multi-version manifest build is a manual `npm pack` per release today; automating it (all ~30 live releases) is the next block of work.
- No CI/cron wiring yet. The comparator + warp scan is already the "Mode 2" background-scan engine; wiring it as a scheduled scan over the registry is a separate change.

## Test plan

- [x] SDK builds (`tsc`) and lints clean (root `oxlint.json`)
- [x] Live warp-route validation (above)
- [x] Live core-contract validation (above)
- [ ] Reviewer sanity-check on the reverse-lookup vs expected-name tradeoff