### PR TITLE
fix: add timeout to FallbackProvider::call to unblock stalled providers

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -223,7 +223,7 @@ where
                 let provider = &self.inner.providers[priority.index];
                 let fut = Self::provider_request(provider, method, &params);
                 let (provider_host, resp) = fut.await;
-                self.handle_stalled_provider(priority, provider).await;
+                let _ = self.handle_stalled_provider(priority, provider).await;
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
                 }
@@ -285,7 +285,7 @@ where
                 let provider = &self.inner.providers[priority.index];
                 let fut = Self::provider_request(provider, method, &params);
                 let (provider_host, resp) = fut.await;
-                self.handle_stalled_provider(&priority, provider).await;
+                let _ = self.handle_stalled_provider(&priority, provider).await;
                 if resp.is_err() {
                     self.handle_failed_provider(&priority).await;
                 }

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -166,23 +166,32 @@ where
         (*read_lock).clone()
     }
 
-    /// De-prioritize a provider that has either timed out or returned a bad response
-    pub async fn handle_stalled_provider(&self, priority: &PrioritizedProviderInner, provider: &T) {
+    /// De-prioritize a provider that has either timed out or returned a bad response.
+    /// Returns an error if the block height probe itself times out.
+    pub async fn handle_stalled_provider(
+        &self,
+        priority: &PrioritizedProviderInner,
+        provider: &T,
+    ) -> ChainResult<()> {
         let now = Instant::now();
         if now
             .duration_since(priority.last_block_height.1)
             .le(&self.max_block_time)
         {
             // Do nothing, it's too early to tell if the provider has stalled
-            return;
+            return Ok(());
         }
 
         let block_getter: B = provider.clone().into();
         let current_block_height =
-            tokio::time::timeout(self.call_timeout, block_getter.get_block_number())
-                .await
-                .unwrap_or(Ok(priority.last_block_height.0))
-                .unwrap_or(priority.last_block_height.0);
+            match tokio::time::timeout(self.call_timeout, block_getter.get_block_number()).await {
+                Ok(result) => result.unwrap_or(priority.last_block_height.0),
+                Err(_) => {
+                    return Err(crate::ChainCommunicationError::from_other_str(
+                        "fallback provider call timed out",
+                    ))
+                }
+            };
         if current_block_height <= priority.last_block_height.0 {
             let new_priority = priority.reset_failed_count();
 
@@ -198,6 +207,7 @@ where
             self.update_last_seen_block(priority.index, current_block_height)
                 .await;
         }
+        Ok(())
     }
 
     /// De-prioritize a provider that has returned a bad response
@@ -239,15 +249,18 @@ where
             let priorities_snapshot = self.take_priorities_snapshot().await;
             for (idx, priority) in priorities_snapshot.iter().enumerate() {
                 let provider = &self.inner.providers[priority.index];
-                let resp = match tokio::time::timeout(self.call_timeout, f(provider.clone())).await
-                {
-                    Ok(resp) => {
-                        // Only check for a stalled block height on a provider that actually
-                        // responded. A provider that just timed out shouldn't be hit with
-                        // another unbounded call from handle_stalled_provider.
-                        self.handle_stalled_provider(priority, provider).await;
-                        resp
+                let resp = match tokio::time::timeout(self.call_timeout, async {
+                    let resp = f(provider.clone()).await;
+                    if resp.is_ok() {
+                        // A probe timeout is treated the same as a request timeout,
+                        // not silently ignored.
+                        self.handle_stalled_provider(priority, provider).await?;
                     }
+                    resp
+                })
+                .await
+                {
+                    Ok(resp) => resp,
                     Err(_) => Err(crate::ChainCommunicationError::from_other_str(
                         "fallback provider call timed out",
                     )),
@@ -518,32 +531,47 @@ pub mod test {
 
     #[tokio::test]
     async fn test_call_timeout_unblocks_stalled_block_height_check() {
-        // Provider responds fine to the main call, but hangs on the
-        // get_block_number() call that handle_stalled_provider makes
-        // afterwards to check for a stalled block height.
+        // Provider1 responds fine to the main call but hangs on the
+        // get_block_number() probe. The combined timeout should fail the
+        // whole attempt over to provider2, not return provider1's response.
         let provider1 = ProviderMock::new(Some(Duration::from_secs(5)));
+        let provider2 = ProviderMock::new(None);
 
         let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
             FallbackProvider::builder()
-                .add_providers(vec![provider1])
+                .add_providers(vec![provider1, provider2])
                 .with_call_timeout(Duration::from_millis(50))
                 // Zero so handle_stalled_provider doesn't skip the block height
                 // check as "too early to tell".
                 .with_max_block_time(Duration::ZERO)
                 .build();
 
-        let call = fallback_provider.call(|_provider: ProviderMock| {
-            let future = async move { Ok(100) };
+        let call = fallback_provider.call(|provider: ProviderMock| {
+            let future = async move {
+                provider.push("call", true);
+                Ok(100)
+            };
             Box::pin(future)
         });
 
-        // If the get_block_number() check inside handle_stalled_provider isn't
-        // bounded, this outer timeout is what catches the hang.
+        // If the combined timeout doesn't kick in, this outer timeout catches the hang.
         let result = tokio::time::timeout(Duration::from_secs(2), call).await;
-        assert!(
-            result.is_ok(),
-            "call() hung past the configured timeout while checking for a stalled provider"
-        );
+        assert!(result.is_ok(), "call() hung past the configured timeout");
         assert_eq!(result.unwrap().unwrap(), 100);
+
+        let priorities = fallback_provider.inner.priorities.read().await;
+        let failed_counts: Vec<_> = priorities.iter().map(|p| p.last_failed_count).collect();
+        assert_eq!(
+            failed_counts[0], 1,
+            "provider1's attempt should count as a failure"
+        );
+
+        // Confirms the fallback actually reached provider2, not just that the
+        // call didn't hang.
+        let call_counts: Vec<_> = priorities
+            .iter()
+            .map(|p| fallback_provider.inner.providers[p.index].requests().len())
+            .collect();
+        assert_eq!(call_counts[1], 1, "provider2 should have been tried");
     }
 }

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -178,10 +178,11 @@ where
         }
 
         let block_getter: B = provider.clone().into();
-        let current_block_height = block_getter
-            .get_block_number()
-            .await
-            .unwrap_or(priority.last_block_height.0);
+        let current_block_height =
+            tokio::time::timeout(self.call_timeout, block_getter.get_block_number())
+                .await
+                .unwrap_or(Ok(priority.last_block_height.0))
+                .unwrap_or(priority.last_block_height.0);
         if current_block_height <= priority.last_block_height.0 {
             let new_priority = priority.reset_failed_count();
 
@@ -428,7 +429,10 @@ pub mod test {
     #[async_trait::async_trait]
     impl BlockNumberGetter for ProviderMock {
         async fn get_block_number(&self) -> ChainResult<u64> {
-            return Ok(100);
+            if let Some(sleep) = self.request_sleep {
+                tokio::time::sleep(sleep).await;
+            }
+            Ok(100)
         }
     }
 
@@ -510,5 +514,36 @@ pub mod test {
             .map(|p| p.last_failed_count)
             .collect();
         assert_eq!(failed_counts[0], 1);
+    }
+
+    #[tokio::test]
+    async fn test_call_timeout_unblocks_stalled_block_height_check() {
+        // Provider responds fine to the main call, but hangs on the
+        // get_block_number() call that handle_stalled_provider makes
+        // afterwards to check for a stalled block height.
+        let provider1 = ProviderMock::new(Some(Duration::from_secs(5)));
+
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::builder()
+                .add_providers(vec![provider1])
+                .with_call_timeout(Duration::from_millis(50))
+                // Zero so handle_stalled_provider doesn't skip the block height
+                // check as "too early to tell".
+                .with_max_block_time(Duration::ZERO)
+                .build();
+
+        let call = fallback_provider.call(|_provider: ProviderMock| {
+            let future = async move { Ok(100) };
+            Box::pin(future)
+        });
+
+        // If the get_block_number() check inside handle_stalled_provider isn't
+        // bounded, this outer timeout is what catches the hang.
+        let result = tokio::time::timeout(Duration::from_secs(2), call).await;
+        assert!(
+            result.is_ok(),
+            "call() hung past the configured timeout while checking for a stalled provider"
+        );
+        assert_eq!(result.unwrap().unwrap(), 100);
     }
 }

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -29,6 +29,9 @@ const MAX_BLOCK_TIME: Duration = Duration::from_secs(2 * 60);
 
 const FAILED_REQUEST_THRESHOLD: u32 = 10;
 
+// Caps how long we wait on one provider; otherwise a stalled connection blocks the whole loop.
+const FALLBACK_PROVIDER_CALL_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Information about a provider in `PrioritizedProviders`
 
 #[derive(Clone, Copy, Debug, new)]
@@ -77,6 +80,7 @@ pub struct FallbackProvider<T, B> {
     /// The sub-providers called by this provider
     pub inner: Arc<PrioritizedProviders<T>>,
     max_block_time: Duration,
+    call_timeout: Duration,
     _phantom: PhantomData<B>,
 }
 
@@ -97,6 +101,7 @@ impl<T, B> Clone for FallbackProvider<T, B> {
         Self {
             inner: self.inner.clone(),
             max_block_time: self.max_block_time,
+            call_timeout: self.call_timeout,
             _phantom: PhantomData,
         }
     }
@@ -233,8 +238,19 @@ where
             let priorities_snapshot = self.take_priorities_snapshot().await;
             for (idx, priority) in priorities_snapshot.iter().enumerate() {
                 let provider = &self.inner.providers[priority.index];
-                let resp = f(provider.clone()).await;
-                self.handle_stalled_provider(priority, provider).await;
+                let resp = match tokio::time::timeout(self.call_timeout, f(provider.clone())).await
+                {
+                    Ok(resp) => {
+                        // Only check for a stalled block height on a provider that actually
+                        // responded. A provider that just timed out shouldn't be hit with
+                        // another unbounded call from handle_stalled_provider.
+                        self.handle_stalled_provider(priority, provider).await;
+                        resp
+                    }
+                    Err(_) => Err(crate::ChainCommunicationError::from_other_str(
+                        "fallback provider call timed out",
+                    )),
+                };
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
                 }
@@ -262,6 +278,7 @@ where
 pub struct FallbackProviderBuilder<T, B> {
     providers: Vec<T>,
     max_block_time: Duration,
+    call_timeout: Duration,
     _phantom: PhantomData<B>,
 }
 
@@ -270,6 +287,7 @@ impl<T, B> Default for FallbackProviderBuilder<T, B> {
         Self {
             providers: Vec::new(),
             max_block_time: MAX_BLOCK_TIME,
+            call_timeout: FALLBACK_PROVIDER_CALL_TIMEOUT,
             _phantom: PhantomData,
         }
     }
@@ -296,6 +314,13 @@ impl<T, B> FallbackProviderBuilder<T, B> {
         self
     }
 
+    /// Override the per-provider call timeout. Mainly useful for tests that
+    /// need to exercise the timeout path without waiting 30 seconds.
+    pub fn with_call_timeout(mut self, call_timeout: Duration) -> Self {
+        self.call_timeout = call_timeout;
+        self
+    }
+
     /// Create a fallback provider.
     pub fn build(self) -> FallbackProvider<T, B> {
         let provider_count = self.providers.len();
@@ -311,6 +336,7 @@ impl<T, B> FallbackProviderBuilder<T, B> {
         FallbackProvider {
             inner: Arc::new(prioritized_providers),
             max_block_time: self.max_block_time,
+            call_timeout: self.call_timeout,
             _phantom: PhantomData,
         }
     }
@@ -443,5 +469,46 @@ pub mod test {
             .map(|p| p.index)
             .collect();
         assert_eq!(expected, actual);
+    }
+
+    #[tokio::test]
+    async fn test_call_timeout_unblocks_stalled_provider() {
+        let provider1 = ProviderMock::new(None);
+        let provider2 = ProviderMock::new(None);
+        provider2.push("aaa", true);
+
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::builder()
+                .add_providers(vec![provider1, provider2])
+                .with_call_timeout(Duration::from_millis(50))
+                .build();
+
+        let call = fallback_provider.call(|provider: ProviderMock| {
+            let future = async move {
+                if provider.requests.lock().unwrap().is_empty() {
+                    // simulate a provider that connects but never responds
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    Ok(100)
+                } else {
+                    Ok(100)
+                }
+            };
+            Box::pin(future)
+        });
+
+        // If the timeout doesn't kick in, this outer timeout is what catches the hang.
+        let result = tokio::time::timeout(Duration::from_secs(2), call).await;
+        assert!(result.is_ok(), "call() hung past the configured timeout");
+        assert_eq!(result.unwrap().unwrap(), 100);
+
+        let failed_counts: Vec<_> = fallback_provider
+            .inner
+            .priorities
+            .read()
+            .await
+            .iter()
+            .map(|p| p.last_failed_count)
+            .collect();
+        assert_eq!(failed_counts[0], 1);
     }
 }


### PR DESCRIPTION
### Description
<!--
What's included in this PR?
-->

`FallbackProvider::call()` has no bound on how long it waits for a single provider to respond. If a provider TCP-connects but then never replies (as opposed to refusing the connection or erroring out), the call to it just hangs forever. Since the fallback loop awaits each provider in priority order, one stalled provider blocks the entire loop: no other provider in the list ever gets tried, no error is ever recorded, and nothing fires an alert because from the outside nothing looks like a failure, it looks like the call is still in flight.

We hit this in production: an overloaded RPC node kept its connection open without responding, and a validator wedged on it with no visible error.

Added a `call_timeout` field to `FallbackProvider` (default 30s, in line with other timeouts already used in this codebase such as `QUORUM_RPC_CALL_TIMEOUT` and `HTTP_CLIENT_TIMEOUT`), with a `with_call_timeout()` builder method for overriding it, mirroring the existing `max_block_time` / `with_max_block_time()` pattern.

The per-provider call in the fallback loop is now wrapped in `tokio::time::timeout`. A timeout produces a normal `ChainCommunicationError`, so it flows through the existing error handling unchanged, the provider's failure count increments and it gets deprioritized after enough failures, same as any other kind of failure.

`handle_stalled_provider` only runs when the provider actually responded to the main call, since retrying it after a timeout would just hang on the same stalled provider a second time. But that function makes its own call to check the provider's block height, and the first pass left that call unbounded: a provider that answers the main call fine but then hangs on this follow-up check could still block the loop, the same failure mode this PR set out to fix, one level down. Caught in review, that call is now wrapped in the same `call_timeout`, falling back to the last known block height on timeout the same way it already did on any other error.

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

None.

### Related issues

<!--
- Fixes #[issue number here]
-->

None directly. #2189 covers a related but distinct failure mode (a provider that responds but reports a stale block height, handled by the existing `handle_stalled_provider` check) and was already closed by that work in 2023. This PR addresses a provider that never responds at all, which nothing currently bounds.

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes. `call_timeout` defaults to 30s and is only reachable through the new `with_call_timeout()` builder method, so existing callers and configs are unaffected. No infra or deploy implications.
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
Unit Tests.

Added `test_call_timeout_unblocks_stalled_provider`, which builds a `FallbackProvider` with a 50ms call timeout, has the first provider sleep past that timeout and the second provider respond normally, and asserts the call still returns `Ok` within a bounded wall clock deadline (wrappedin an outer timeout so the test itself fails loudly if the fix regresses) and that the stalled provider's failure count incremented.

Added `test_call_timeout_unblocks_stalled_block_height_check` for the follow-up fix: a provider responds fine to the main call but hangs on the block-height check, `max_block_time` is set to zero so that check isn't skipped as "too early to tell", and the assertion is the same, the call still returns within the outer timeout instead of hanging.

Ran `cargo fmt --check`, `cargo clippy -p hyperlane-core -- -D warnings`, and the full `fallback` test module (`cargo test -p hyperlane-core -p hyperlane-base --lib -- fallback`). Both the new test and the existing `test_deprioritization_by_failed_count` pass.
