### PR TITLE
ci: harden composite action inputs before shell use

### DIFF
--- a/.github/actions/check-path-changes/action.yml
+++ b/.github/actions/check-path-changes/action.yml
@@ -27,25 +27,30 @@ runs:
     - name: Check for path changes
       id: check-changes
       shell: bash
+      env:
+        BASE_SHA: ${{ inputs.base_sha }}
+        HEAD_SHA: ${{ inputs.head_sha }}
+        PATH_PATTERN: ${{ inputs.path_pattern }}
+        PATH_PATTERN_ONLY: ${{ inputs.path_pattern_only }}
       run: |
         # Check if the specified path has any changes
-        if git diff ${{ inputs.base_sha }}...${{ inputs.head_sha }} --name-only | grep -qE '^${{ inputs.path_pattern }}'; then
+        if git diff "$BASE_SHA"..."$HEAD_SHA" --name-only | grep -qE "^${PATH_PATTERN}"; then
           echo "has_changes=true" >> $GITHUB_OUTPUT
 
           # If path_pattern_only is requested, also check if ONLY this path changed
-          if [[ "${{ inputs.path_pattern_only }}" == "true" ]]; then
-            if ! git diff ${{ inputs.base_sha }}...${{ inputs.head_sha }} --name-only | grep -qvE '^${{ inputs.path_pattern }}'; then
+          if [[ "$PATH_PATTERN_ONLY" == "true" ]]; then
+            if ! git diff "$BASE_SHA"..."$HEAD_SHA" --name-only | grep -qvE "^${PATH_PATTERN}"; then
               echo "only_changes=true" >> $GITHUB_OUTPUT
-              echo "Only ${{ inputs.path_pattern }} changes detected."
+              echo "Only ${PATH_PATTERN} changes detected."
             else
               echo "only_changes=false" >> $GITHUB_OUTPUT
-              echo "${{ inputs.path_pattern }} changes detected along with other changes."
+              echo "${PATH_PATTERN} changes detected along with other changes."
             fi
           fi
         else
           echo "has_changes=false" >> $GITHUB_OUTPUT
-          if [[ "${{ inputs.path_pattern_only }}" == "true" ]]; then
+          if [[ "$PATH_PATTERN_ONLY" == "true" ]]; then
             echo "only_changes=false" >> $GITHUB_OUTPUT
           fi
-          echo "No ${{ inputs.path_pattern }} changes detected."
+          echo "No ${PATH_PATTERN} changes detected."
         fi

--- a/.github/actions/checkout-registry/action.yml
+++ b/.github/actions/checkout-registry/action.yml
@@ -13,10 +13,16 @@ runs:
       run: |
         if [ -z "$INPUT_REGISTRY_VERSION" ]; then
           REGISTRY_VERSION=$(cat .registryrc)
-          echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
         else
-          echo "REGISTRY_VERSION=$INPUT_REGISTRY_VERSION" >> $GITHUB_ENV
+          REGISTRY_VERSION="$INPUT_REGISTRY_VERSION"
         fi
+        case "$REGISTRY_VERSION" in
+          *$'\n'*|*$'\r'*)
+            echo "registry_version must be a single line" >&2
+            exit 1
+            ;;
+        esac
+        echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
 
     - name: Checkout hyperlane-registry
       uses: actions/checkout@v6

--- a/.github/actions/checkout-registry/action.yml
+++ b/.github/actions/checkout-registry/action.yml
@@ -8,12 +8,14 @@ runs:
   steps:
     - name: Read .registryrc if registry_version not provided
       shell: bash
+      env:
+        INPUT_REGISTRY_VERSION: ${{ inputs.registry_version }}
       run: |
-        if [ -z "${{ inputs.registry_version }}" ]; then
+        if [ -z "$INPUT_REGISTRY_VERSION" ]; then
           REGISTRY_VERSION=$(cat .registryrc)
           echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
         else
-          echo "REGISTRY_VERSION=${{ inputs.registry_version }}" >> $GITHUB_ENV
+          echo "REGISTRY_VERSION=$INPUT_REGISTRY_VERSION" >> $GITHUB_ENV
         fi
 
     - name: Checkout hyperlane-registry

--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -39,10 +39,12 @@ runs:
     - name: pnpm-install-build-without-cache
       if: inputs.no-cache != 'false'
       shell: bash
+      env:
+        BUILD_FILTER: ${{ inputs.build-filter }}
       run: |
         pnpm install --frozen-lockfile
-        if [ -n "${{ inputs.build-filter }}" ]; then
-          pnpm exec turbo run build --filter='${{ inputs.build-filter }}'
+        if [ -n "$BUILD_FILTER" ]; then
+          pnpm exec turbo run build --filter="$BUILD_FILTER"
         else
           pnpm run build
         fi

--- a/.github/actions/pnpm-build-with-cache/action.yml
+++ b/.github/actions/pnpm-build-with-cache/action.yml
@@ -35,9 +35,11 @@ runs:
 
     - name: Build
       shell: bash
+      env:
+        BUILD_FILTER: ${{ inputs.build-filter }}
       run: |
-        if [ -n "${{ inputs.build-filter }}" ]; then
-          pnpm exec turbo run build --filter='${{ inputs.build-filter }}'
+        if [ -n "$BUILD_FILTER" ]; then
+          pnpm exec turbo run build --filter="$BUILD_FILTER"
         else
           pnpm run build
         fi


### PR DESCRIPTION
## Summary
- CI hygiene for composite actions that interpolate free-string `inputs.*` into `run:` shells.
- Bind values under `env:` and use quoted shell vars in:
  - `.github/actions/check-path-changes` (`base_sha` / `head_sha` / `path_pattern`)
  - `.github/actions/checkout-registry` (`registry_version`)
  - `.github/actions/install-cli` and `pnpm-build-with-cache` (`build-filter`)
- Defense-in-depth for reusable CI helpers — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Existing callers of these composites continue to pass the same string inputs as today

Made with [Cursor](https://cursor.com)