### PR TITLE
feat(infra): add EvmWarpFeesOwner Turnkey role for warp fee owner key

### DIFF
--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -53,4 +53,5 @@ export enum TurnkeyRole {
   EvmRebalancer = 'evm-rebalancer',
   EvmIgpClaimer = 'evm-igp-claimer',
   EvmIgpUpdater = 'evm-igp-updater',
+  EvmWarpFeesOwner = 'evm-warp-fees-owner',
 }

--- a/typescript/infra/src/utils/turnkey.ts
+++ b/typescript/infra/src/utils/turnkey.ts
@@ -44,6 +44,7 @@ export async function createTurnkeySigner(
       case TurnkeyRole.EvmRebalancer:
       case TurnkeyRole.EvmIgpClaimer:
       case TurnkeyRole.EvmIgpUpdater:
+      case TurnkeyRole.EvmWarpFeesOwner:
         signer = new TurnkeyEvmSigner(turnkeyConfig);
         break;
       default:


### PR DESCRIPTION
## Summary

Addresses **Gap 1** in the eclipse OQLF warp-fee migration: there was no Turnkey signer role for the "EVM Warp Fees Owner" treasury key `0xe95C605096A1AD38BaC3E5210e145952Cbdc6998`, which became the on-chain `RoutingFee` owner after the eclipse fee-owner rotation (registry #1633). `RoutingFee.setFeeContract` (the OQLF repoint) is owner-gated by that key, so `warp apply` needs a signer that can sign as it.

- Adds `EvmWarpFeesOwner = 'evm-warp-fees-owner'` to `TurnkeyRole` (`typescript/infra/src/roles.ts`).
- Adds that role to `createTurnkeySigner`'s EVM switch case (`typescript/infra/src/utils/turnkey.ts`) so it mints a `TurnkeyEvmSigner`.

The backing GCP secret `mainnet3-turnkey-evm-warp-fees-owner` already exists, matching `turnkeySecret(env, role)` = `${env}-turnkey-${role}`, so no new secret provisioning is required.

## Scope / follow-ups (intentionally not in this PR)

- **Consumer wiring** — switching the eclipse strategy `feeSubmitter` from `getWarpFeeSubmitter` (WarpFees safe/ICA) to a `jsonRpc` submitter and calling `setTurnkeySignerForEvmChains(mp, 'mainnet3', TurnkeyRole.EvmWarpFeesOwner)` in the warp-apply path — is a separate change that consumes this role.
- **Config-owner match** — making `tokenFee.owner` match the on-chain Turnkey owner (so `warp apply` doesn't try to transfer ownership back) is handled by #9163.

## Verification

- `pnpm -C typescript/infra check` (tsc --noEmit): passes.
- No changeset: `typescript/infra` is a private package.

Before wiring the consumer path, confirm the secret's `publicKey` is `0xe95C…6998` (out-of-band; the secret also holds the Turnkey API private key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)