### PR TITLE
ci: bind remaining cache/status/release inputs via env before shell

### DIFF
--- a/.github/actions/check-job-status/action.yml
+++ b/.github/actions/check-job-status/action.yml
@@ -12,10 +12,13 @@ runs:
   steps:
     - name: Check job status
       shell: bash
+      env:
+        RESULT: ${{ inputs.result }}
+        JOB_NAME: ${{ inputs.job_name }}
       run: |
-        if [[ "${{ inputs.result }}" == "skipped" ]]; then
-          echo "${{ inputs.job_name }} was skipped!"
-        elif [[ "${{ inputs.result }}" != "success" ]]; then
-          echo "${{ inputs.job_name }} failed"
+        if [[ "$RESULT" == "skipped" ]]; then
+          echo "$JOB_NAME was skipped!"
+        elif [[ "$RESULT" != "success" ]]; then
+          echo "$JOB_NAME failed"
           exit 1
         fi

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Determine Cache Provider
       id: determine-cache
       shell: bash
-      run: echo "cache_provider=${{ inputs.cache-provider }}" >> $GITHUB_ENV
+      run: echo "cache_provider=${CACHE_PROVIDER}" >> $GITHUB_ENV
 
     - name: Get pnpm store directory
       id: pnpm-store
@@ -50,4 +50,6 @@ runs:
         path: ${{ steps.pnpm-store.outputs.store_path }}
         key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-11-store-
+          ${{ runner.os }}-pnpm-11-store-env:
+        CACHE_PROVIDER: ${{ inputs.cache-provider }}
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,9 @@ jobs:
         run: pnpm run build:zk
 
       - name: Create snapshot versions
-        run: pnpm exec changeset version --snapshot ${{ inputs.snapshot_tag }}
+        env:
+          SNAPSHOT_TAG: ${{ inputs.snapshot_tag }}
+        run: pnpm exec changeset version --snapshot "$SNAPSHOT_TAG"
 
       - name: Get snapshot version
         id: version
@@ -282,11 +284,15 @@ jobs:
           echo "snapshot=$SNAPSHOT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Publish beta packages
-        run: pnpm exec changeset publish --tag ${{ inputs.snapshot_tag }} --no-git-tag
+        env:
+          SNAPSHOT_TAG: ${{ inputs.snapshot_tag }}
+        run: pnpm exec changeset publish --tag "$SNAPSHOT_TAG" --no-git-tag
         env:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Summary
+        env:
+          SNAPSHOT_TAG: ${{ inputs.snapshot_tag }}
         run: |
           echo "### Beta Release Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -296,8 +302,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Install with:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npm install @hyperlane-xyz/sdk@${{ inputs.snapshot_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "npm install @hyperlane-xyz/cli@${{ inputs.snapshot_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "npm install @hyperlane-xyz/sdk@${SNAPSHOT_TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "npm install @hyperlane-xyz/cli@${SNAPSHOT_TAG}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   notify-publish-failure:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
           echo "### Beta Release Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** \`${{ steps.version.outputs.snapshot }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**NPM Tag:** \`${{ inputs.snapshot_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**NPM Tag:** \`${SNAPSHOT_TAG}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Install with:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Follow-up to #9196: bind remaining composite/workflow inputs through `env:` before shell.
- Covers `pnpm-cache` `cache-provider`, `check-job-status` `job_name`/`result`, and release `snapshot_tag` (changeset version/publish + summary).
- Same class as GitHub’s documented script-injection guidance for interpolating inputs into `run:` scripts.

## Test plan
- [ ] pnpm-cache still exports the configured cache_provider
- [ ] check-job-status still reports skip/fail correctly
- [ ] snapshot release still versions/publishes under the configured tag


Made with [Cursor](https://cursor.com)