### PR TITLE
fix(infra): schema-parse registry warp configs in check-warp-deploy

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -553,18 +553,24 @@ async function getWarpConfigsToCheck({
           `Warp route config not found for ${warpRouteId}`,
         );
 
-        const warpDeployConfig = warpConfigGetterMap[warpRouteId]
-          ? WarpRouteDeployConfigMailboxRequiredSchema.parse(
-              await getWarpConfig(
-                getterInputsMultiProvider,
-                envConfig,
-                warpRouteId,
-                registryUris,
-                false,
-                warpConfigGetterInputs,
-              ),
-            )
-          : registryWarpDeployConfigMap[warpRouteId];
+        // Both branches parse through the schema so defaults (e.g. the
+        // RateLimited ISM `duration`) and normalization are applied
+        // consistently. Registry configs arrive as raw YAML, so without this
+        // parse an omitted schema-defaulted field would false-positive against
+        // the on-chain value.
+        const warpDeployConfig =
+          WarpRouteDeployConfigMailboxRequiredSchema.parse(
+            warpConfigGetterMap[warpRouteId]
+              ? await getWarpConfig(
+                  getterInputsMultiProvider,
+                  envConfig,
+                  warpRouteId,
+                  registryUris,
+                  false,
+                  warpConfigGetterInputs,
+                )
+              : registryWarpDeployConfigMap[warpRouteId],
+          );
 
         const requiredChains = new Set([
           ...Object.keys(warpDeployConfig),


### PR DESCRIPTION
## Summary
- `check-warp-deploy` only ran configs from **custom getters** through `WarpRouteDeployConfigMailboxRequiredSchema.parse()`; standard **registry-sourced** configs (`registryWarpDeployConfigMap[warpRouteId]`) were used as raw YAML straight from `yamlParse`, with no schema parse.
- Because the schema is what applies defaults/normalization, an omitted schema-defaulted field on a registry route diffed against the concrete on-chain value as a **false positive**.
- Concretely: the RateLimited ISM `duration` default (86400s, added in #9168) never reached registry routes, so `PB/eni` (staticAggregationIsm → rateLimitedIsm with no `duration` in the manifest) fired a spurious `WarpRoute-ConfigMismatch` at `interchainSecurityModule.modules.*.duration` (expected missing vs on-chain `86400`).
- Fix: parse **both** branches through the schema so defaults and normalization apply consistently. The parse stays inside the existing per-route `try/catch`, so a single malformed registry config still fails only its own route rather than aborting the run.

## Root cause detail
- `@hyperlane-xyz/registry` `readConfigsForIds` returns `yamlParse(data)` with no schema validation, so schema defaults are never applied on the registry read path.
- The SDK `RateLimitedIsmConfigSchema.duration` `.default(86400n)` only takes effect when the expected config is `.parse()`-ed; the CLI `warp check` path already does this, but the infra cron's registry branch did not.

## Test plan
- [ ] Run `check-warp-deploy` for mainnet3 and confirm `PB/eni` no longer reports a `interchainSecurityModule.modules.*.duration` violation.
- [ ] Confirm routes sourced from custom getters are unaffected (identical parse as before).
- [ ] Confirm a genuinely divergent `duration` still surfaces as a violation.