### PR TITLE
fix: add Cosmos gas floor for validator announcements

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/providers/rpc.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/rpc.rs
@@ -459,7 +459,8 @@ impl RpcProvider {
             ))?
             .gas_used;
 
-        let gas_estimate = (gas_used as f64 * self.conf.get_gas_multiplier()) as u64;
+        let gas_multiplier = self.conf.get_gas_multiplier().max(2.0);
+        let gas_estimate = (gas_used as f64 * gas_multiplier).ceil() as u64;
 
         Ok(gas_estimate)
     }


### PR DESCRIPTION
## Summary
- apply a minimum 2x gas multiplier to Cosmos transaction simulation
- round the multiplied gas estimate up before submitting transactions
- fixes validator self-announces failing slightly above simulated gas on Cosmos chains

## Testing
- pnpm -C typescript/infra check
- cargo check -p hyperlane-cosmos