### PR TITLE
feat(widgets): allow custom tooltip icons

### DIFF
--- a/.changeset/widgets-tooltip-icon-prop.md
+++ b/.changeset/widgets-tooltip-icon-prop.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': minor
+---
+
+The Tooltip component accepted an optional icon node for custom trigger icons.

--- a/typescript/widgets/src/components/Tooltip.tsx
+++ b/typescript/widgets/src/components/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import React, { AnchorHTMLAttributes } from 'react';
+import React, { AnchorHTMLAttributes, ReactNode } from 'react';
 import { PlacesType, Tooltip as ReactTooltip } from 'react-tooltip';
 
 import { Circle } from '../icons/Circle.js';
@@ -11,6 +11,7 @@ type Props = AnchorHTMLAttributes<HTMLAnchorElement> & {
   size?: number;
   placement?: PlacesType;
   tooltipClassName?: string;
+  icon?: ReactNode;
 };
 
 export function Tooltip({
@@ -20,6 +21,7 @@ export function Tooltip({
   placement = 'top-start',
   size = 16,
   tooltipClassName,
+  icon,
   ...rest
 }: Props) {
   return (
@@ -36,11 +38,13 @@ export function Tooltip({
         {...rest}
       >
         <Circle size={size} className="htw-bg-gray-200 htw-border-gray-300">
-          <QuestionMarkIcon
-            width={size - 2}
-            height={size - 2}
-            className="htw-opacity-60"
-          />
+          {icon ?? (
+            <QuestionMarkIcon
+              width={size - 2}
+              height={size - 2}
+              className="htw-opacity-60"
+            />
+          )}
         </Circle>
       </a>
       <ReactTooltip id={id} />


### PR DESCRIPTION
## Summary

- Adds an optional `icon` prop to the widgets `Tooltip` component.
- Preserves the existing question-mark icon as the default when no custom icon is provided.
- Adds a changeset for `@hyperlane-xyz/widgets`.

## Validation

- `pnpm -C typescript/widgets build:ts`
- `pnpm -C typescript/widgets format`
- `pnpm -C typescript/widgets exec oxlint -c ../../oxlint.json src/components/Tooltip.tsx`

Note: full `pnpm -C typescript/widgets lint` currently fails on existing unrelated files outside this change.