### PR TITLE
chore(infra): spin down vana agents (ENG-4333)

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -164,7 +164,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     tea: true,
     tron: true,
     unichain: true,
-    vana: true,
+    vana: false, // disabled — Vana paid chain deprecation (ENG-4333)
     viction: true,
     worldchain: true,
     xlayer: true,
@@ -266,7 +266,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     tea: true,
     tron: true,
     unichain: true,
-    vana: true,
+    vana: false, // disabled — Vana paid chain deprecation (ENG-4333)
     viction: true,
     worldchain: true,
     xlayer: true,
@@ -368,7 +368,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     tea: true,
     tron: true,
     unichain: true,
-    vana: true,
+    vana: false, // disabled — Vana paid chain deprecation (ENG-4333)
     // Note: default rpc.viction.xyz endpoint can't be used for scraping (returns 429s).
     viction: true,
     worldchain: true,

--- a/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
+++ b/typescript/infra/config/environments/mainnet3/aw-validators/hyperlane.json
@@ -269,9 +269,6 @@
   "unichain": {
     "validators": ["0xa5962efa3ec138bf7ca8f7fde86b7ee32e24bf03"]
   },
-  "vana": {
-    "validators": ["0xa5962efa3ec138bf7ca8f7fde86b7ee32e24bf03"]
-  },
   "viction": {
     "validators": ["0xa5962efa3ec138bf7ca8f7fde86b7ee32e24bf03"]
   },


### PR DESCRIPTION
## Summary
- Disable relayer/validator/scraper for `vana` in mainnet3 `agent.ts` (set `false` in all three role blocks).
- Remove the `vana` entry from `aw-validators/hyperlane.json` so the validator stops deploying.
- Chain key remains defined (`false`), so config validation still passes; no agent-config JSON regen needed (that JSON is built from `environmentChainNames`, not per-role flags).

Part of the Vana **paid-chain deprecation** (ENG-4333), contract-end date 2026-08-06. Companion registry PR marks `vana` deprecated: hyperlane-xyz/hyperlane-registry#1642.

## Context
- Transfer target `0xDDF71a6ddf3FCABBbA4D607b57f0f6Fc0265bb84` verified as a Gnosis Safe v1.4.1 (3/7) on Vana; the two warp routers are already owned by it.
- Vana core contracts (mailbox `0x3a46…775E`, proxyAdmin `0x2f2a…85A7`) are still owned by the AW deployer `0x486815…E433` — ownership transfer to the multisig is a separate step.

## Follow-ups (not in this PR)
- Full config removal (balances JSONs, `validators.ts`, rust `mainnet_config.json`, SDK multisig defaults, `.registryrc` bump, etc.) — the heavyweight `chore: remove …` batch, done once agents are confirmed down.
- Core-contract ownership transfer to the customer multisig.

## Test plan
- [ ] Pre-commit hooks green (lint/format/typecheck)
- [ ] After next mainnet3 agent deploy, confirm vana relayer/validator/scraper no longer deploy