### PR TITLE
fix: solaxy backfill

### DIFF
--- a/rust/main/config/mainnet_config.json
+++ b/rust/main/config/mainnet_config.json
@@ -4652,7 +4652,7 @@
       "domainId": 1936682104,
       "gasCurrencyCoinGeckoId": "solaxy",
       "index": {
-        "from": 1,
+        "from": 0,
         "mode": "sequence",
         "chunk": 1
       },


### PR DESCRIPTION
## Summary
- set Solaxy sequence index start to 0 so sequence 0 is included in backfill

## Tests
- successfully backfilled solaxy validator