### PR TITLE
fix(starknet): read at latest block for version-safe RPC compatibility

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/ism/aggregation_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/aggregation_ism.rs
@@ -6,7 +6,7 @@ use hyperlane_core::{
     AggregationIsm, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract,
     HyperlaneDomain, HyperlaneMessage, HyperlaneProvider, H256,
 };
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 use tracing::instrument;
 
 use crate::contracts::aggregation_ism::{AggregationIsmReader, Message as StarknetMessage};
@@ -33,7 +33,8 @@ impl StarknetAggregationIsm {
     ) -> ChainResult<Self> {
         let ism_address: Felt = HyH256(locator.address).into();
         let json_provider = provider.rpc_client().clone();
-        let contract = AggregationIsmReader::new(ism_address, json_provider);
+        let contract = AggregationIsmReader::new(ism_address, json_provider)
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,

--- a/rust/main/chains/hyperlane-starknet/src/ism/interchain_security_module.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/interchain_security_module.rs
@@ -7,7 +7,7 @@ use hyperlane_core::{
     HyperlaneMessage, HyperlaneProvider, InterchainSecurityModule, Metadata, ModuleType, H256,
     U256,
 };
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 use tracing::instrument;
 
 use crate::contracts::interchain_security_module::InterchainSecurityModuleReader;
@@ -34,7 +34,8 @@ impl StarknetInterchainSecurityModule {
     ) -> ChainResult<Self> {
         let json_provider = provider.rpc_client().clone();
         let ism_address: Felt = HyH256(locator.address).into();
-        let contract = InterchainSecurityModuleReader::new(ism_address, json_provider);
+        let contract = InterchainSecurityModuleReader::new(ism_address, json_provider)
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,

--- a/rust/main/chains/hyperlane-starknet/src/ism/multisig_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/multisig_ism.rs
@@ -6,7 +6,7 @@ use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
     HyperlaneMessage, HyperlaneProvider, MultisigIsm, H256,
 };
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 use tracing::instrument;
 
 use crate::contracts::multisig_ism::MultisigIsmReader;
@@ -33,7 +33,8 @@ impl StarknetMultisigIsm {
     ) -> ChainResult<Self> {
         let json_provider = provider.rpc_client().clone();
         let ism_address: Felt = HyH256(locator.address).into();
-        let contract = MultisigIsmReader::new(ism_address, json_provider);
+        let contract = MultisigIsmReader::new(ism_address, json_provider)
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,

--- a/rust/main/chains/hyperlane-starknet/src/ism/routing_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/routing_ism.rs
@@ -6,7 +6,7 @@ use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
     HyperlaneMessage, HyperlaneProvider, RoutingIsm, H256,
 };
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 use tracing::instrument;
 
 use crate::contracts::routing_ism::RoutingIsmReader;
@@ -32,7 +32,8 @@ impl StarknetRoutingIsm {
     ) -> ChainResult<Self> {
         let json_provider = provider.rpc_client().clone();
         let ism_address: Felt = HyH256(locator.address).into();
-        let contract = RoutingIsmReader::new(ism_address, json_provider);
+        let contract = RoutingIsmReader::new(ism_address, json_provider)
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,

--- a/rust/main/chains/hyperlane-starknet/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-starknet/src/mailbox.rs
@@ -13,7 +13,7 @@ use hyperlane_core::{
     HyperlaneMessage, HyperlaneProvider, Mailbox, TxCostEstimate, TxOutcome, H256, U256,
 };
 use starknet::accounts::{Account, ExecutionV3, SingleOwnerAccount};
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 
 use starknet::signers::LocalWallet;
 use tracing::instrument;
@@ -48,7 +48,11 @@ impl StarknetMailbox {
 
         let mailbox_address: Felt = HyH256(locator.address).into();
 
-        let contract = StarknetMailboxInternal::new(mailbox_address, account);
+        // Read at the latest accepted block. `latest` is the only block tag valid
+        // across all Starknet JSON-RPC spec versions; `pending` was renamed to
+        // `pre_confirmed` in RPC v0.9+, so providers on newer specs reject it.
+        let contract = StarknetMailboxInternal::new(mailbox_address, account)
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,

--- a/rust/main/chains/hyperlane-starknet/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-starknet/src/merkle_tree_hook.rs
@@ -9,7 +9,7 @@ use hyperlane_core::{
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneProvider,
     IncrementalMerkleAtBlock, MerkleTreeHook, ReorgPeriod, H256,
 };
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 use tracing::instrument;
 
 use crate::contracts::merkle_tree_hook::MerkleTreeHookReader;
@@ -35,7 +35,8 @@ impl StarknetMerkleTreeHook {
         locator: &ContractLocator<'_>,
     ) -> ChainResult<Self> {
         let hook_address: Felt = HyH256(locator.address).into();
-        let contract = MerkleTreeHookReader::new(hook_address, provider.rpc_client().clone());
+        let contract = MerkleTreeHookReader::new(hook_address, provider.rpc_client().clone())
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,

--- a/rust/main/chains/hyperlane-starknet/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-starknet/src/validator_announce.rs
@@ -8,7 +8,7 @@ use hyperlane_core::{
     HyperlaneProvider, TxOutcome, H256, U256,
 };
 use starknet::accounts::{Account, ExecutionV3, SingleOwnerAccount};
-use starknet::core::types::Felt;
+use starknet::core::types::{BlockId, BlockTag, Felt};
 use starknet::core::utils::{parse_cairo_short_string, ParseCairoShortStringError};
 use starknet::signers::LocalWallet;
 use tracing::{instrument, warn};
@@ -54,7 +54,8 @@ impl StarknetValidatorAnnounce {
 
         let va_address: Felt = HyH256(locator.address).into();
 
-        let contract = StarknetValidatorAnnounceInternal::new(va_address, account);
+        let contract = StarknetValidatorAnnounceInternal::new(va_address, account)
+            .with_block(BlockId::Tag(BlockTag::Latest));
 
         Ok(Self {
             contract,


### PR DESCRIPTION
## Summary
- Starknet contract reads defaulted to the `pending` block tag. Starknet JSON-RPC v0.9+ renamed `pending` → `pre_confirmed` and newer providers reject `pending` with `-32602 unknown block tag 'pending'`.
- When the relayer's `FallbackProvider` routed a delivery-status check (`Mailbox.delivered`) to a provider on spec ≥ v0.9, the call failed deterministically, wedging the prepare stage and stalling **all inbound Starknet message delivery**.
- Set the default block tag to `latest` at every read-path construction site — `mailbox`, `validator_announce`, `merkle_tree_hook`, and the `multisig` / `interchain_security_module` / `aggregation` / `routing` ISMs.
- `latest` is the only block tag valid across all Starknet JSON-RPC spec versions (0.7 → 0.10+), so this makes the agent robust to any provider's spec version rather than the specific set currently configured.

## Context
Diagnosed in a production incident: the Dwellir Starknet mainnet RPC upgraded to spec v0.10.2 (which removed `pending`), stalling all →starknet deliveries. A temporary mitigation (removing Dwellir from the RPC secret) unwedged delivery; this PR is the durable fix so any future provider spec bump can't reintroduce the failure.

## Test plan
- [ ] `cargo check -p hyperlane-starknet` (crate type-checks clean locally; note: an unrelated pre-existing `tokio::test` macro-feature error in `hyperlane-core`'s test module surfaces in this sandbox but is present on clean `main`)
- [ ] `cargo clippy -p hyperlane-starknet -- -D warnings`
- [ ] CI: confirm no regressions in the starknet chain crate build
- [ ] Post-merge: verify inbound Starknet message delivery remains healthy across mixed provider spec versions