### PR TITLE
fix(infra): reconcile rebalancing config getters

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
@@ -71,7 +71,7 @@ const usdtDecimals = {
   tron: 6,
 } as const;
 
-// ENI's collateral routers use route-specific TokenBridgeDepositAddress
+// ENI's collateral routers use route-specific TokenBridgeCctpV2
 // adapters for the fast CCTP path instead of the fast warp-router addresses.
 const eniUsdcFastCctpAdapters = {
   arbitrum: '0xb0B8D4C6EF212D76d5079df5Ff7A0888A27e9b32',

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
@@ -71,6 +71,16 @@ const usdtDecimals = {
   tron: 6,
 } as const;
 
+// ENI's collateral routers use route-specific TokenBridgeDepositAddress
+// adapters for the fast CCTP path instead of the fast warp-router addresses.
+const eniUsdcFastCctpAdapters = {
+  arbitrum: '0xb0B8D4C6EF212D76d5079df5Ff7A0888A27e9b32',
+  base: '0x584244d02b0fBf9054A5D5C9e9cE9A2E8adA0e28',
+  ethereum: '0xEE4a09db2C25592C04b8b342CB89f9a7f5E20BD2',
+  optimism: '0xb0B8D4C6EF212D76d5079df5Ff7A0888A27e9b32',
+  polygon: '0x8dadbDE67eD0589d90cdE3C940045F10092AcC11',
+} as const;
+
 function getScaledTokenConfig(
   name: string,
   symbol: string,
@@ -160,7 +170,7 @@ export async function getEniUsdcWarpConfig(
 
   const rebalancingConfigByChain = getUSDCRebalancingBridgesConfigFor(
     rebalanceableChains,
-    [WarpRouteIds.MainnetCCTPV2Standard, WarpRouteIds.MainnetCCTPV2Fast],
+    [WarpRouteIds.MainnetCCTPV2Standard],
   );
 
   const maxDecimals = 18;
@@ -177,6 +187,14 @@ export async function getEniUsdcWarpConfig(
 
   for (const chain of rebalanceableChains) {
     const rebalancingConfig = rebalancingConfigByChain[chain];
+    const allowedRebalancingBridges = Object.fromEntries(
+      Object.entries(rebalancingConfig.allowedRebalancingBridges).map(
+        ([destination, bridges]) => [
+          destination,
+          [...bridges, { bridge: eniUsdcFastCctpAdapters[chain] }],
+        ],
+      ),
+    );
     const config: HypTokenRouterConfig = {
       ...routerConfig[chain],
       owner: owners[chain],
@@ -189,6 +207,7 @@ export async function getEniUsdcWarpConfig(
         maxDecimals,
       ),
       ...rebalancingConfig,
+      allowedRebalancingBridges,
     };
     configs.push([chain, config]);
   }

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getUSDTCitreaMoonpayStagingWarpConfig.ts
@@ -72,7 +72,7 @@ export async function getUSDTCitreaMoonpayStagingWarpConfig(
       token: tokens.base.USDT,
       mailbox: routerConfig.base.mailbox,
       owner: DEPLOYER_EVM,
-      allowedRebalancers: [EXTRA_REBALANCER],
+      allowedRebalancers: ALLOWED_REBALANCERS,
       crossCollateralRouters,
     },
     bsc: {


### PR DESCRIPTION
### Summary

- preserve the shared MCR signer in the Base config for the CROSS/moonpay staging USDT route
- use ENI route-specific fast CCTP deposit adapters instead of the generic fast warp-router addresses

These changes reconcile the config getters with the live on-chain configuration and unblock regeneration of hyperlane-registry PR #1628.

### Validation

- pnpm exec turbo run build --filter=@hyperlane-xyz/infra...
- pnpm -C typescript/infra check
- targeted oxlint on both changed getters
- targeted oxfmt --check on both changed getters
- direct on-chain validation of the five ENI fast adapter addresses