### PR TITLE
perf(rust): back off repeated contract sync fetch errors

### DIFF
--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -81,6 +81,7 @@ color-eyre.workspace = true
 hyper = "0.14"
 reqwest.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-test.workspace = true
 walkdir.workspace = true
 

--- a/rust/main/hyperlane-base/src/contract_sync/metrics.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/metrics.rs
@@ -26,6 +26,12 @@ pub struct ContractSyncMetrics {
     /// Contract sync liveness metric
     pub liveness_metrics: IntGaugeVec,
 
+    /// Fetch errors which scheduled a range retry.
+    pub fetch_retries: IntCounterVec,
+
+    /// Current delay before retrying a failed range fetch.
+    pub fetch_backoff_seconds: IntGaugeVec,
+
     /// Metrics for SequenceAware and RateLimited cursors.
     pub cursor_metrics: Arc<CursorMetrics>,
 }
@@ -57,12 +63,30 @@ impl ContractSyncMetrics {
             )
             .expect("failed to register liveness metric");
 
+        let fetch_retries = metrics
+            .new_int_counter(
+                "contract_sync_fetch_retries",
+                "Range fetch errors which scheduled a retry",
+                &["data_type", "chain"],
+            )
+            .expect("failed to register contract_sync_fetch_retries metric");
+
+        let fetch_backoff_seconds = metrics
+            .new_int_gauge(
+                "contract_sync_fetch_backoff_seconds",
+                "Current delay before retrying a failed range fetch",
+                &["data_type", "chain"],
+            )
+            .expect("failed to register contract_sync_fetch_backoff_seconds metric");
+
         let cursor_metrics = Arc::new(CursorMetrics::new(metrics));
 
         ContractSyncMetrics {
             indexed_height,
             stored_events,
             liveness_metrics,
+            fetch_retries,
+            fetch_backoff_seconds,
             cursor_metrics,
         }
     }

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -10,7 +10,7 @@ use derive_new::new;
 use eyre::Result;
 use prometheus::core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge};
 use tokio::sync::{mpsc::Receiver as MpscReceiver, Mutex};
-use tokio::time::sleep;
+use tokio::time::{sleep, Instant};
 use tracing::{debug, info, instrument, trace, warn, Instrument};
 
 use hyperlane_core::{
@@ -34,6 +34,74 @@ pub use metrics::ContractSyncMetrics;
 use cursors::ForwardBackwardSequenceAwareSyncCursor;
 
 const SLEEP_DURATION: Duration = Duration::from_secs(5);
+const MAX_FETCH_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Debug, Default)]
+struct FetchRetryBackoff {
+    failed_range: Option<std::ops::RangeInclusive<u32>>,
+    consecutive_failures: u32,
+    retry_at: Option<Instant>,
+}
+
+impl FetchRetryBackoff {
+    fn ranges_overlap(
+        left: &std::ops::RangeInclusive<u32>,
+        right: &std::ops::RangeInclusive<u32>,
+    ) -> bool {
+        left.start() <= right.end() && right.start() <= left.end()
+    }
+
+    fn reset(&mut self) {
+        self.failed_range = None;
+        self.consecutive_failures = 0;
+        self.retry_at = None;
+    }
+
+    fn remaining_delay(&self, range: &std::ops::RangeInclusive<u32>) -> Option<Duration> {
+        if self
+            .failed_range
+            .as_ref()
+            .is_none_or(|failed| !Self::ranges_overlap(failed, range))
+        {
+            return None;
+        }
+        self.retry_at
+            .and_then(|retry_at| retry_at.checked_duration_since(Instant::now()))
+            .filter(|delay| !delay.is_zero())
+    }
+
+    fn record_success(&mut self, range: &std::ops::RangeInclusive<u32>) -> bool {
+        let recovered = self
+            .failed_range
+            .as_ref()
+            .is_some_and(|failed| Self::ranges_overlap(failed, range));
+        if recovered {
+            self.reset();
+        }
+        recovered
+    }
+
+    fn record_failure(&mut self, range: std::ops::RangeInclusive<u32>) -> Duration {
+        match self.failed_range.take() {
+            Some(failed) if Self::ranges_overlap(&failed, &range) => {
+                self.failed_range =
+                    Some((*failed.start()).min(*range.start())..=(*failed.end()).max(*range.end()));
+            }
+            _ => {
+                self.reset();
+                self.failed_range = Some(range);
+            }
+        }
+
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let exponent = self.consecutive_failures.saturating_sub(1).min(6);
+        let delay = SLEEP_DURATION
+            .saturating_mul(1_u32 << exponent)
+            .min(MAX_FETCH_RETRY_BACKOFF);
+        self.retry_at = Instant::now().checked_add(delay);
+        delay
+    }
+}
 
 #[derive(Debug, derive_new::new)]
 #[allow(dead_code)]
@@ -108,6 +176,14 @@ where
             .metrics
             .stored_events
             .with_label_values(&[label, chain_name]);
+        let fetch_retries_metric = self
+            .metrics
+            .fetch_retries
+            .with_label_values(&[label, chain_name]);
+        let fetch_backoff_metric = self
+            .metrics
+            .fetch_backoff_seconds
+            .with_label_values(&[label, chain_name]);
 
         // need to put this behind an Arc Mutex because we might
         // index the same event twice now. Which causes e2e to fail
@@ -166,6 +242,8 @@ where
                             stored_logs_metric,
                             indexed_height_metric,
                             liveness_metric,
+                            fetch_retries_metric,
+                            fetch_backoff_metric,
                         )
                         .await
                     }
@@ -249,7 +327,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(fields(domain=domain.name()), skip(indexer, store, cursor, broadcast_sender, stored_logs_metric, indexed_height_metric, liveness_metric))]
+    #[instrument(fields(domain=domain.name()), skip(indexer, store, cursor, broadcast_sender, stored_logs_metric, indexed_height_metric, liveness_metric, fetch_retries_metric, fetch_backoff_metric))]
     async fn cursor_indexer_task(
         domain: HyperlaneDomain,
         indexer: I,
@@ -259,7 +337,10 @@ where
         stored_logs_metric: GenericCounter<AtomicU64>,
         indexed_height_metric: GenericGauge<AtomicI64>,
         liveness_metric: GenericGauge<AtomicI64>,
+        fetch_retries_metric: GenericCounter<AtomicU64>,
+        fetch_backoff_metric: GenericGauge<AtomicI64>,
     ) {
+        let mut fetch_backoff = FetchRetryBackoff::default();
         loop {
             Self::update_liveness_metric(&liveness_metric);
             indexed_height_metric.set(cursor.latest_queried_block() as i64);
@@ -287,11 +368,31 @@ where
             };
             trace!(?range, "Looking for events in index range");
 
+            if let Some(remaining_delay) = fetch_backoff.remaining_delay(&range) {
+                // Re-check the cursor at the normal polling interval so newly available
+                // forward work is not held behind a long backward-range backoff.
+                sleep(remaining_delay.min(SLEEP_DURATION)).await;
+                continue;
+            }
+
             let logs = match indexer.fetch_logs_in_range(range.clone()).await {
-                Ok(logs) => logs,
+                Ok(logs) => {
+                    if fetch_backoff.record_success(&range) {
+                        fetch_backoff_metric.set(0);
+                    }
+                    logs
+                }
                 Err(err) => {
-                    warn!(?err, ?range, "Error fetching logs in range");
-                    sleep(SLEEP_DURATION).await;
+                    let retry_delay = fetch_backoff.record_failure(range.clone());
+                    fetch_retries_metric.inc();
+                    fetch_backoff_metric.set(retry_delay.as_secs() as i64);
+                    warn!(
+                        ?err,
+                        ?range,
+                        ?retry_delay,
+                        consecutive_failures = fetch_backoff.consecutive_failures,
+                        "Error fetching logs in range"
+                    );
                     continue;
                 }
             };
@@ -370,6 +471,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         ops::RangeInclusive,
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -443,6 +545,16 @@ mod tests {
 
     fn liveness_metric() -> IntGauge {
         IntGauge::new("test_liveness", "test liveness").expect("test gauge should be valid")
+    }
+
+    fn fetch_retries_metric() -> IntCounter {
+        IntCounter::new("test_fetch_retries", "test fetch retries")
+            .expect("test counter should be valid")
+    }
+
+    fn fetch_backoff_metric() -> IntGauge {
+        IntGauge::new("test_fetch_backoff", "test fetch backoff")
+            .expect("test gauge should be valid")
     }
 
     fn test_logs() -> Vec<(Indexed<HyperlaneMessage>, LogMeta)> {
@@ -543,6 +655,8 @@ mod tests {
                 stored_logs_metric(),
                 indexed_height_metric(),
                 liveness_metric(),
+                fetch_retries_metric(),
+                fetch_backoff_metric(),
             ),
         );
 
@@ -558,6 +672,242 @@ mod tests {
 
         task.abort();
         let _ = task.await;
+    }
+
+    #[derive(Clone, Debug)]
+    struct FailingThenSuccessfulIndexer {
+        failures: usize,
+        calls: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Indexer<HyperlaneMessage> for FailingThenSuccessfulIndexer {
+        async fn fetch_logs_in_range(
+            &self,
+            _range: RangeInclusive<u32>,
+        ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call < self.failures {
+                Err(ChainCommunicationError::from_other_str(
+                    "mock range fetch failed",
+                ))
+            } else {
+                Ok(Vec::new())
+            }
+        }
+
+        async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+            Err(ChainCommunicationError::from_other_str(
+                "mock indexer does not fetch finalized blocks",
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct ScriptedCursor {
+        ranges: VecDeque<RangeInclusive<u32>>,
+        repeat_range: RangeInclusive<u32>,
+        updates: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ContractSyncCursor<HyperlaneMessage> for ScriptedCursor {
+        async fn next_action(&mut self) -> Result<(CursorAction, Duration)> {
+            if self.updates.load(Ordering::SeqCst) > 0 {
+                return Ok((CursorAction::Sleep(Duration::from_secs(60)), Duration::ZERO));
+            }
+            let range = self
+                .ranges
+                .pop_front()
+                .unwrap_or_else(|| self.repeat_range.clone());
+            Ok((CursorAction::Query(range), Duration::ZERO))
+        }
+
+        fn latest_queried_block(&self) -> u32 {
+            0
+        }
+
+        async fn update(
+            &mut self,
+            _logs: Vec<(Indexed<HyperlaneMessage>, LogMeta)>,
+            _range: RangeInclusive<u32>,
+        ) -> Result<()> {
+            self.updates.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    async fn run_pending_tasks() {
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn repeated_fetch_errors_back_off_without_advancing_cursor() {
+        let calls = StdArc::new(AtomicUsize::new(0));
+        let updates = StdArc::new(AtomicUsize::new(0));
+        let retries = fetch_retries_metric();
+        let delay = fetch_backoff_metric();
+        let task = tokio::spawn(ContractSync::<
+            HyperlaneMessage,
+            StoreResult,
+            FailingThenSuccessfulIndexer,
+        >::cursor_indexer_task(
+            test_domain(),
+            FailingThenSuccessfulIndexer {
+                failures: 3,
+                calls: calls.clone(),
+            },
+            Arc::new(Mutex::new(StoreResult {
+                stored: 0,
+                error: None,
+                calls: None,
+            })),
+            Box::new(ScriptedCursor {
+                ranges: VecDeque::new(),
+                repeat_range: 7..=9,
+                updates: updates.clone(),
+            }),
+            None,
+            stored_logs_metric(),
+            indexed_height_metric(),
+            liveness_metric(),
+            retries.clone(),
+            delay.clone(),
+        ));
+
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(retries.get(), 1);
+        assert_eq!(delay.get(), 5);
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(delay.get(), 10);
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(delay.get(), 20);
+
+        tokio::time::advance(Duration::from_secs(20)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert_eq!(updates.load(Ordering::SeqCst), 1);
+        assert_eq!(retries.get(), 3);
+        assert_eq!(delay.get(), 0);
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn changed_range_bypasses_fetch_backoff() {
+        let calls = StdArc::new(AtomicUsize::new(0));
+        let updates = StdArc::new(AtomicUsize::new(0));
+        let retries = fetch_retries_metric();
+        let delay = fetch_backoff_metric();
+        let task = tokio::spawn(ContractSync::<
+            HyperlaneMessage,
+            StoreResult,
+            FailingThenSuccessfulIndexer,
+        >::cursor_indexer_task(
+            test_domain(),
+            FailingThenSuccessfulIndexer {
+                failures: 1,
+                calls: calls.clone(),
+            },
+            Arc::new(Mutex::new(StoreResult {
+                stored: 0,
+                error: None,
+                calls: None,
+            })),
+            Box::new(ScriptedCursor {
+                ranges: VecDeque::from([7..=9, 10..=12]),
+                repeat_range: 10..=12,
+                updates: updates.clone(),
+            }),
+            None,
+            stored_logs_metric(),
+            indexed_height_metric(),
+            liveness_metric(),
+            retries.clone(),
+            delay.clone(),
+        ));
+
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(updates.load(Ordering::SeqCst), 1);
+        assert_eq!(retries.get(), 1);
+        assert_eq!(delay.get(), 5);
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fetch_backoff_is_exponential_and_bounded() {
+        let mut backoff = FetchRetryBackoff::default();
+        for expected in [5, 10, 20, 40, 80, 160, 300, 300] {
+            let delay = backoff.record_failure(7..=9);
+            assert_eq!(delay, Duration::from_secs(expected));
+            tokio::time::advance(delay).await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unrelated_success_does_not_reset_failed_range_backoff() {
+        let failed_range = 7..=9;
+        let forward_range = 10..=12;
+        let mut backoff = FetchRetryBackoff::default();
+
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(5)
+        );
+        assert_eq!(backoff.remaining_delay(&forward_range), None);
+        assert!(!backoff.record_success(&forward_range));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(10)
+        );
+        assert_eq!(backoff.remaining_delay(&forward_range), None);
+        assert!(!backoff.record_success(&forward_range));
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(20)
+        );
+        assert!(backoff.record_success(&failed_range));
+        assert_eq!(backoff.failed_range, None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn moving_range_end_preserves_fetch_backoff() {
+        let mut backoff = FetchRetryBackoff::default();
+
+        assert_eq!(backoff.record_failure(7..=9), Duration::from_secs(5));
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(backoff.record_failure(7..=12), Duration::from_secs(10));
+        assert_eq!(backoff.failed_range, Some(7..=12));
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(backoff.record_failure(8..=15), Duration::from_secs(20));
+        assert_eq!(backoff.failed_range, Some(7..=15));
+        assert!(backoff.record_success(&(10..=20)));
+        assert_eq!(backoff.failed_range, None);
     }
 }
 

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -71,6 +71,15 @@ impl FetchRetryBackoff {
             .filter(|delay| !delay.is_zero())
     }
 
+    /// True when `range` overlaps the failed range and its backoff has expired,
+    /// so a retry may run immediately. Disjoint forward work is never eligible.
+    fn retry_eligible(&self, range: &std::ops::RangeInclusive<u32>) -> bool {
+        self.failed_range
+            .as_ref()
+            .is_some_and(|failed| Self::ranges_overlap(failed, range))
+            && self.remaining_delay(range).is_none()
+    }
+
     fn record_success(&mut self, range: &std::ops::RangeInclusive<u32>) -> bool {
         let recovered = self
             .failed_range
@@ -388,6 +397,13 @@ where
                 // forward work is not held behind a long backward-range backoff.
                 sleep(remaining_delay.min(SLEEP_DURATION)).await;
                 continue;
+            }
+
+            if fetch_backoff.retry_eligible(&range) {
+                // Backoff for this range has expired: clear the stale scheduled
+                // delay before the retry runs. Disjoint forward work leaves the
+                // gauge untouched.
+                fetch_backoff_metric.set(0);
             }
 
             let logs = match indexer.fetch_logs_in_range(range.clone()).await {
@@ -972,6 +988,113 @@ mod tests {
         assert_eq!(backoff.failed_range, Some(7..=15));
         assert!(backoff.record_success(&(10..=20)));
         assert_eq!(backoff.failed_range, None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_backoff_is_eligible_for_overlapping_range_only() {
+        let mut backoff = FetchRetryBackoff::default();
+        let failed_range = 7..=9;
+        let forward_range = 10..=12;
+
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(5)
+        );
+        assert!(!backoff.retry_eligible(&failed_range));
+        assert!(!backoff.retry_eligible(&forward_range));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(backoff.retry_eligible(&failed_range));
+        assert!(backoff.retry_eligible(&(7..=12)));
+        assert!(!backoff.retry_eligible(&forward_range));
+    }
+
+    #[derive(Clone, Debug)]
+    struct FailOnceThenGatedIndexer {
+        calls: StdArc<AtomicUsize>,
+        release: StdArc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl Indexer<HyperlaneMessage> for FailOnceThenGatedIndexer {
+        async fn fetch_logs_in_range(
+            &self,
+            _range: RangeInclusive<u32>,
+        ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Err(ChainCommunicationError::from_other_str(
+                    "mock range fetch failed",
+                ));
+            }
+            self.release.notified().await;
+            Ok(Vec::new())
+        }
+
+        async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+            Err(ChainCommunicationError::from_other_str(
+                "mock indexer does not fetch finalized blocks",
+            ))
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_backoff_resets_gauge_before_retry_completes() {
+        let calls = StdArc::new(AtomicUsize::new(0));
+        let updates = StdArc::new(AtomicUsize::new(0));
+        let retries = fetch_retries_metric();
+        let delay = fetch_backoff_metric();
+        let release = StdArc::new(tokio::sync::Notify::new());
+        let task = tokio::spawn(ContractSync::<
+            HyperlaneMessage,
+            StoreResult,
+            FailOnceThenGatedIndexer,
+        >::cursor_indexer_task(
+            test_domain(),
+            FailOnceThenGatedIndexer {
+                calls: calls.clone(),
+                release: release.clone(),
+            },
+            Arc::new(Mutex::new(StoreResult {
+                stored: 0,
+                error: None,
+                calls: None,
+            })),
+            Box::new(ScriptedCursor {
+                ranges: VecDeque::new(),
+                repeat_range: 7..=9,
+                updates: updates.clone(),
+            }),
+            None,
+            stored_logs_metric(),
+            indexed_height_metric(),
+            liveness_metric(),
+            retries.clone(),
+            delay.clone(),
+        ));
+
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(retries.get(), 1);
+        assert_eq!(delay.get(), 5);
+
+        // Expire the backoff; the retry starts but stays gated, so the gauge
+        // must already read zero before the retry completes.
+        tokio::time::advance(Duration::from_secs(5)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(delay.get(), 0);
+
+        release.notify_one();
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(updates.load(Ordering::SeqCst), 1);
+        assert_eq!(delay.get(), 0);
+
+        task.abort();
+        let _ = task.await;
     }
 }
 

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -10,7 +10,7 @@ use derive_new::new;
 use eyre::Result;
 use prometheus::core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge};
 use tokio::sync::{mpsc::Receiver as MpscReceiver, Mutex};
-use tokio::time::{interval, sleep, MissedTickBehavior};
+use tokio::time::{interval, sleep, Instant, MissedTickBehavior};
 use tracing::{debug, info, instrument, trace, warn, Instrument};
 
 use hyperlane_core::{
@@ -35,6 +35,74 @@ use cursors::ForwardBackwardSequenceAwareSyncCursor;
 
 const SLEEP_DURATION: Duration = Duration::from_secs(5);
 const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_FETCH_RETRY_BACKOFF: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Debug, Default)]
+struct FetchRetryBackoff {
+    failed_range: Option<std::ops::RangeInclusive<u32>>,
+    consecutive_failures: u32,
+    retry_at: Option<Instant>,
+}
+
+impl FetchRetryBackoff {
+    fn ranges_overlap(
+        left: &std::ops::RangeInclusive<u32>,
+        right: &std::ops::RangeInclusive<u32>,
+    ) -> bool {
+        left.start() <= right.end() && right.start() <= left.end()
+    }
+
+    fn reset(&mut self) {
+        self.failed_range = None;
+        self.consecutive_failures = 0;
+        self.retry_at = None;
+    }
+
+    fn remaining_delay(&self, range: &std::ops::RangeInclusive<u32>) -> Option<Duration> {
+        if self
+            .failed_range
+            .as_ref()
+            .is_none_or(|failed| !Self::ranges_overlap(failed, range))
+        {
+            return None;
+        }
+        self.retry_at
+            .and_then(|retry_at| retry_at.checked_duration_since(Instant::now()))
+            .filter(|delay| !delay.is_zero())
+    }
+
+    fn record_success(&mut self, range: &std::ops::RangeInclusive<u32>) -> bool {
+        let recovered = self
+            .failed_range
+            .as_ref()
+            .is_some_and(|failed| Self::ranges_overlap(failed, range));
+        if recovered {
+            self.reset();
+        }
+        recovered
+    }
+
+    fn record_failure(&mut self, range: std::ops::RangeInclusive<u32>) -> Duration {
+        match self.failed_range.take() {
+            Some(failed) if Self::ranges_overlap(&failed, &range) => {
+                self.failed_range =
+                    Some((*failed.start()).min(*range.start())..=(*failed.end()).max(*range.end()));
+            }
+            _ => {
+                self.reset();
+                self.failed_range = Some(range);
+            }
+        }
+
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let exponent = self.consecutive_failures.saturating_sub(1).min(6);
+        let delay = SLEEP_DURATION
+            .saturating_mul(1_u32 << exponent)
+            .min(MAX_FETCH_RETRY_BACKOFF);
+        self.retry_at = Instant::now().checked_add(delay);
+        delay
+    }
+}
 
 #[derive(Debug, derive_new::new)]
 #[allow(dead_code)]
@@ -109,6 +177,14 @@ where
             .metrics
             .stored_events
             .with_label_values(&[label, chain_name]);
+        let fetch_retries_metric = self
+            .metrics
+            .fetch_retries
+            .with_label_values(&[label, chain_name]);
+        let fetch_backoff_metric = self
+            .metrics
+            .fetch_backoff_seconds
+            .with_label_values(&[label, chain_name]);
 
         // need to put this behind an Arc Mutex because we might
         // index the same event twice now. Which causes e2e to fail
@@ -167,6 +243,8 @@ where
                             stored_logs_metric,
                             indexed_height_metric,
                             liveness_metric,
+                            fetch_retries_metric,
+                            fetch_backoff_metric,
                         )
                         .await
                     }
@@ -264,7 +342,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(fields(domain=domain.name()), skip(indexer, store, cursor, broadcast_sender, stored_logs_metric, indexed_height_metric, liveness_metric))]
+    #[instrument(fields(domain=domain.name()), skip(indexer, store, cursor, broadcast_sender, stored_logs_metric, indexed_height_metric, liveness_metric, fetch_retries_metric, fetch_backoff_metric))]
     async fn cursor_indexer_task(
         domain: HyperlaneDomain,
         indexer: I,
@@ -274,7 +352,10 @@ where
         stored_logs_metric: GenericCounter<AtomicU64>,
         indexed_height_metric: GenericGauge<AtomicI64>,
         liveness_metric: GenericGauge<AtomicI64>,
+        fetch_retries_metric: GenericCounter<AtomicU64>,
+        fetch_backoff_metric: GenericGauge<AtomicI64>,
     ) {
+        let mut fetch_backoff = FetchRetryBackoff::default();
         loop {
             Self::update_liveness_metric(&liveness_metric);
             indexed_height_metric.set(cursor.latest_queried_block() as i64);
@@ -302,11 +383,31 @@ where
             };
             trace!(?range, "Looking for events in index range");
 
+            if let Some(remaining_delay) = fetch_backoff.remaining_delay(&range) {
+                // Re-check the cursor at the normal polling interval so newly available
+                // forward work is not held behind a long backward-range backoff.
+                sleep(remaining_delay.min(SLEEP_DURATION)).await;
+                continue;
+            }
+
             let logs = match indexer.fetch_logs_in_range(range.clone()).await {
-                Ok(logs) => logs,
+                Ok(logs) => {
+                    if fetch_backoff.record_success(&range) {
+                        fetch_backoff_metric.set(0);
+                    }
+                    logs
+                }
                 Err(err) => {
-                    warn!(?err, ?range, "Error fetching logs in range");
-                    sleep(SLEEP_DURATION).await;
+                    let retry_delay = fetch_backoff.record_failure(range.clone());
+                    fetch_retries_metric.inc();
+                    fetch_backoff_metric.set(retry_delay.as_secs() as i64);
+                    warn!(
+                        ?err,
+                        ?range,
+                        ?retry_delay,
+                        consecutive_failures = fetch_backoff.consecutive_failures,
+                        "Error fetching logs in range"
+                    );
                     continue;
                 }
             };
@@ -390,6 +491,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         ops::RangeInclusive,
         sync::{
             atomic::{AtomicUsize, Ordering},
@@ -463,6 +565,16 @@ mod tests {
 
     fn liveness_metric() -> IntGauge {
         IntGauge::new("test_liveness", "test liveness").expect("test gauge should be valid")
+    }
+
+    fn fetch_retries_metric() -> IntCounter {
+        IntCounter::new("test_fetch_retries", "test fetch retries")
+            .expect("test counter should be valid")
+    }
+
+    fn fetch_backoff_metric() -> IntGauge {
+        IntGauge::new("test_fetch_backoff", "test fetch backoff")
+            .expect("test gauge should be valid")
     }
 
     fn test_logs() -> Vec<(Indexed<HyperlaneMessage>, LogMeta)> {
@@ -569,6 +681,8 @@ mod tests {
                 stored_logs_metric(),
                 indexed_height_metric(),
                 liveness_metric(),
+                fetch_retries_metric(),
+                fetch_backoff_metric(),
             ),
         );
 
@@ -628,6 +742,236 @@ mod tests {
         drop(sender);
         task.await
             .expect("task should stop when its channel closes");
+    }
+
+    #[derive(Clone, Debug)]
+    struct FailingThenSuccessfulIndexer {
+        failures: usize,
+        calls: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Indexer<HyperlaneMessage> for FailingThenSuccessfulIndexer {
+        async fn fetch_logs_in_range(
+            &self,
+            _range: RangeInclusive<u32>,
+        ) -> ChainResult<Vec<(Indexed<HyperlaneMessage>, LogMeta)>> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call < self.failures {
+                Err(ChainCommunicationError::from_other_str(
+                    "mock range fetch failed",
+                ))
+            } else {
+                Ok(Vec::new())
+            }
+        }
+
+        async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+            Err(ChainCommunicationError::from_other_str(
+                "mock indexer does not fetch finalized blocks",
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct ScriptedCursor {
+        ranges: VecDeque<RangeInclusive<u32>>,
+        repeat_range: RangeInclusive<u32>,
+        updates: StdArc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ContractSyncCursor<HyperlaneMessage> for ScriptedCursor {
+        async fn next_action(&mut self) -> Result<(CursorAction, Duration)> {
+            if self.updates.load(Ordering::SeqCst) > 0 {
+                return Ok((CursorAction::Sleep(Duration::from_secs(60)), Duration::ZERO));
+            }
+            let range = self
+                .ranges
+                .pop_front()
+                .unwrap_or_else(|| self.repeat_range.clone());
+            Ok((CursorAction::Query(range), Duration::ZERO))
+        }
+
+        fn latest_queried_block(&self) -> u32 {
+            0
+        }
+
+        async fn update(
+            &mut self,
+            _logs: Vec<(Indexed<HyperlaneMessage>, LogMeta)>,
+            _range: RangeInclusive<u32>,
+        ) -> Result<()> {
+            self.updates.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn repeated_fetch_errors_back_off_without_advancing_cursor() {
+        let calls = StdArc::new(AtomicUsize::new(0));
+        let updates = StdArc::new(AtomicUsize::new(0));
+        let retries = fetch_retries_metric();
+        let delay = fetch_backoff_metric();
+        let task = tokio::spawn(ContractSync::<
+            HyperlaneMessage,
+            StoreResult,
+            FailingThenSuccessfulIndexer,
+        >::cursor_indexer_task(
+            test_domain(),
+            FailingThenSuccessfulIndexer {
+                failures: 3,
+                calls: calls.clone(),
+            },
+            Arc::new(Mutex::new(StoreResult {
+                stored: 0,
+                error: None,
+                calls: None,
+            })),
+            Box::new(ScriptedCursor {
+                ranges: VecDeque::new(),
+                repeat_range: 7..=9,
+                updates: updates.clone(),
+            }),
+            None,
+            stored_logs_metric(),
+            indexed_height_metric(),
+            liveness_metric(),
+            retries.clone(),
+            delay.clone(),
+        ));
+
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(retries.get(), 1);
+        assert_eq!(delay.get(), 5);
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(delay.get(), 10);
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert_eq!(updates.load(Ordering::SeqCst), 0);
+        assert_eq!(delay.get(), 20);
+
+        tokio::time::advance(Duration::from_secs(20)).await;
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 4);
+        assert_eq!(updates.load(Ordering::SeqCst), 1);
+        assert_eq!(retries.get(), 3);
+        assert_eq!(delay.get(), 0);
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn changed_range_bypasses_fetch_backoff() {
+        let calls = StdArc::new(AtomicUsize::new(0));
+        let updates = StdArc::new(AtomicUsize::new(0));
+        let retries = fetch_retries_metric();
+        let delay = fetch_backoff_metric();
+        let task = tokio::spawn(ContractSync::<
+            HyperlaneMessage,
+            StoreResult,
+            FailingThenSuccessfulIndexer,
+        >::cursor_indexer_task(
+            test_domain(),
+            FailingThenSuccessfulIndexer {
+                failures: 1,
+                calls: calls.clone(),
+            },
+            Arc::new(Mutex::new(StoreResult {
+                stored: 0,
+                error: None,
+                calls: None,
+            })),
+            Box::new(ScriptedCursor {
+                ranges: VecDeque::from([7..=9, 10..=12]),
+                repeat_range: 10..=12,
+                updates: updates.clone(),
+            }),
+            None,
+            stored_logs_metric(),
+            indexed_height_metric(),
+            liveness_metric(),
+            retries.clone(),
+            delay.clone(),
+        ));
+
+        run_pending_tasks().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(updates.load(Ordering::SeqCst), 1);
+        assert_eq!(retries.get(), 1);
+        assert_eq!(delay.get(), 5);
+
+        task.abort();
+        let _ = task.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fetch_backoff_is_exponential_and_bounded() {
+        let mut backoff = FetchRetryBackoff::default();
+        for expected in [5, 10, 20, 40, 80, 160, 300, 300] {
+            let delay = backoff.record_failure(7..=9);
+            assert_eq!(delay, Duration::from_secs(expected));
+            tokio::time::advance(delay).await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unrelated_success_does_not_reset_failed_range_backoff() {
+        let failed_range = 7..=9;
+        let forward_range = 10..=12;
+        let mut backoff = FetchRetryBackoff::default();
+
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(5)
+        );
+        assert_eq!(backoff.remaining_delay(&forward_range), None);
+        assert!(!backoff.record_success(&forward_range));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(10)
+        );
+        assert_eq!(backoff.remaining_delay(&forward_range), None);
+        assert!(!backoff.record_success(&forward_range));
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(
+            backoff.record_failure(failed_range.clone()),
+            Duration::from_secs(20)
+        );
+        assert!(backoff.record_success(&failed_range));
+        assert_eq!(backoff.failed_range, None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn moving_range_end_preserves_fetch_backoff() {
+        let mut backoff = FetchRetryBackoff::default();
+
+        assert_eq!(backoff.record_failure(7..=9), Duration::from_secs(5));
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert_eq!(backoff.record_failure(7..=12), Duration::from_secs(10));
+        assert_eq!(backoff.failed_range, Some(7..=12));
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(backoff.record_failure(8..=15), Duration::from_secs(20));
+        assert_eq!(backoff.failed_range, Some(7..=15));
+        assert!(backoff.record_success(&(10..=20)));
+        assert_eq!(backoff.failed_range, None);
     }
 }
 


### PR DESCRIPTION
## Summary

- exponentially back off repeated fetch errors for the same or overlapping contract-sync interval, from 5s to a 5m cap
- re-check the cursor every 5s so new forward work bypasses a backed-off historical range
- retain failed historical-range state across unrelated success and cursor sleep
- expose bounded `{data_type, chain}` retry-count and current-delay metrics

## Production evidence

Refreshed 24h Prometheus evidence on 2026-08-10:

- testnet scraper `hyperliquidevmtestnet`: 154,804 failed `eth_getLogs` requests and zero successes. Three cursor tasks repeatedly request the same historical ranges and receive `invalid block range`.
- mainnet scraper SVM: 370,732 failed `getBlock` requests: Eclipse 250,946; Sonic SVM 59,893 on each of two providers. The stable requested blocks are below the providers' archive horizons.

There are two distinct common-contract-sync paths:

- Hyperliquid EVM and SVM mailbox dispatch/delivery indexers propagate the provider error from `fetch_logs_in_range` before `cursor.update()`. This PR backs off that path.
- Eclipse IGP intentionally turns failed per-sequence lookups into a partial successful range. The backward cursor then observes missing sequences. Existing draft #9165 backs off that path; this PR does not claim it.

A ten-minute GCP sample contained 2,555 SVM `getBlock` failures: 1,176 from Eclipse IGP's partial-success path and 1,379 from Eclipse/Sonic mailbox fetch-error paths. This split is a sample, not a 24h measurement.

At the 5m cap, one continuously failing stable range makes at most 288 scheduled attempts/day instead of a fixed ~5s loop. Internal provider retries still occur within each attempt. With the current stable ranges and retry fanout, the combined #9165 + this PR code-path model is:

- Hyperliquid: about 3,456 failed provider calls/day instead of 154,804, a modeled 97.8% reduction.
- Eclipse/Sonic: about 28,800 failed `getBlock` calls/day instead of 370,732, a modeled 92.2% reduction.

These are pre-deploy models, not observed savings. An archive provider is still required to complete the backfills.

## Correctness boundaries

- fetch errors never advance or update the cursor
- unrelated forward work is checked at least every 5s and is not held behind a historical backoff
- a successful overlapping fetch clears that interval's failure state
- unrelated success or `Sleep` does not erase a permanent historical failure's backoff
- a different failing range replaces the single remembered range; state remains intentionally bounded per task
- store errors retain their existing fixed retry behavior and are out of scope
- #9165's incomplete-range path rewinds to the same last indexed snapshot and never marks a missing sequence complete

## Tests

- repeated failures schedule 5s/10s/20s retries without cursor advancement, then reset on recovery
- unrelated successful ranges bypass but do not reset a failed range's backoff
- moving/overlapping ranges retain the prior interval's backoff; disjoint ranges bypass it
- exponential delay caps at 5m
- `cargo test -p hyperlane-base contract_sync::tests --lib` (9 passed)
- `cargo check -p hyperlane-base --lib`
- `cargo clippy -p hyperlane-base --lib -- -D warnings`
- `cargo fmt --package hyperlane-base --check`
- `git diff --check`

Related: #9165 covers incomplete sequence ranges after a successful fetch. This PR covers errors returned before cursor update.

## Stack refresh

Rebased directly onto `main` at `06d8269ef1`; exact head `e5be0c6632`. Independent of #9165/#9227: this PR covers range fetch errors returned before cursor update.

## Integration order

Land this independent range-fetch backoff before the #9397 -> #9402 and #9393 -> #9404 shared-index descendants. Their `contract_sync/mod.rs` resolution must retain this interval-scoped no-skip backoff together with shared-source fallback and completeness behavior.