### PR TITLE
fix(rust): persist Lander finalized nonce regressions

### DIFF
--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -768,6 +768,9 @@ impl AdaptsChain for EthereumAdapter {
                     "No transaction found for nonce in reorg range"
                 );
             }
+            if nonce == reorged_nonce_range.end {
+                break;
+            }
             nonce = nonce.saturating_add(U256::one());
         }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter.rs
@@ -739,33 +739,20 @@ impl AdaptsChain for EthereumAdapter {
     }
 
     async fn get_reprocess_txs(&self) -> Result<Vec<Transaction>, LanderError> {
-        let old_finalized_nonce = self
-            .nonce_manager
-            .state
-            .get_finalized_nonce()
-            .await?
-            .unwrap_or_default();
         self.nonce_manager.nonce_updater.update_boundaries().await?;
-        let new_finalized_nonce = self
-            .nonce_manager
-            .state
-            .get_finalized_nonce()
-            .await?
-            .unwrap_or_default();
-
-        if new_finalized_nonce >= old_finalized_nonce {
+        let Some(reorged_nonce_range) = self.nonce_manager.state.get_reorged_nonce_range().await?
+        else {
             return Ok(Vec::new());
-        }
+        };
 
         warn!(
-            ?old_finalized_nonce,
-            ?new_finalized_nonce,
-            "New finalized nonce is lower than old finalized nonce"
+            ?reorged_nonce_range,
+            "Reprocessing transactions from a persisted finalized nonce regression"
         );
 
         let mut txs = Vec::new();
-        let mut nonce = new_finalized_nonce.saturating_add(U256::one());
-        while nonce <= old_finalized_nonce {
+        let mut nonce = reorged_nonce_range.start;
+        while nonce <= reorged_nonce_range.end {
             let tx_uuid = self.nonce_manager.state.get_tracked_tx_uuid(&nonce).await?;
             if tx_uuid == TransactionUuid::default() {
                 debug!(
@@ -783,6 +770,7 @@ impl AdaptsChain for EthereumAdapter {
             }
             nonce = nonce.saturating_add(U256::one());
         }
+
         Ok(txs)
     }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests.rs
@@ -1,4 +1,5 @@
 mod check_if_resubmission_makes_sense;
 mod tests_build;
+mod tests_reprocess;
 mod tests_submit;
 mod vm_specific_metrics;

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
@@ -1,0 +1,87 @@
+use std::time::Duration;
+
+use ethers_core::types::Address;
+use hyperlane_core::U256;
+
+use crate::adapter::chains::ethereum::nonce::tests::dummy_tx;
+use crate::adapter::chains::ethereum::tests::MockEvmProvider;
+use crate::adapter::AdaptsChain;
+use crate::tests::evm::test_utils::mock_ethereum_adapter;
+use crate::tests::test_utils::tmp_dbs;
+use crate::{TransactionStatus, TransactionUuid};
+
+#[tokio::test]
+async fn test_other_boundary_refresh_cannot_consume_reorg_transition() {
+    let (payload_db, tx_db, nonce_db) = tmp_dbs();
+    let mut provider = MockEvmProvider::new();
+    provider
+        .expect_get_next_nonce_on_finalized_block()
+        .times(1)
+        .returning(|_, _| Ok(U256::from(91)));
+    let signer = Address::random();
+    let adapter = mock_ethereum_adapter(
+        provider,
+        payload_db,
+        tx_db.clone(),
+        nonce_db,
+        signer,
+        Duration::from_secs(60),
+        Duration::from_millis(1),
+    );
+    adapter
+        .nonce_manager
+        .state
+        .set_finalized_nonce_test(&U256::from(100))
+        .await
+        .unwrap();
+    let tx_uuid = TransactionUuid::random();
+    let tx = dummy_tx(
+        tx_uuid.clone(),
+        TransactionStatus::Finalized,
+        Some(U256::from(95)),
+        Some(signer),
+    );
+    tx_db.store_transaction_by_uuid(&tx).await.unwrap();
+    adapter
+        .nonce_manager
+        .state
+        .set_tracked_tx_uuid_test(&U256::from(95), &tx_uuid)
+        .await
+        .unwrap();
+
+    // This is the competing refresh that previously consumed the old/new transition.
+    adapter.post_finalized().await.unwrap();
+    let first_reprocess_txs = adapter.get_reprocess_txs().await.unwrap();
+    let extended_finalized_nonce = U256::from(80);
+    let (second_reprocess_txs, extended_range) = tokio::join!(
+        adapter.get_reprocess_txs(),
+        adapter
+            .nonce_manager
+            .state
+            .update_boundary_nonces(&extended_finalized_nonce),
+    );
+    let second_reprocess_txs = second_reprocess_txs.unwrap();
+    extended_range.unwrap();
+
+    assert_eq!(first_reprocess_txs.len(), 1);
+    assert_eq!(first_reprocess_txs[0].uuid, tx_uuid);
+    assert_eq!(second_reprocess_txs.len(), 1);
+    assert_eq!(second_reprocess_txs[0].uuid, tx_uuid);
+    let retained_range = adapter
+        .nonce_manager
+        .state
+        .get_reorged_nonce_range()
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(retained_range.start, U256::from(81));
+    assert_eq!(retained_range.end, U256::from(100));
+
+    adapter
+        .nonce_manager
+        .state
+        .update_boundary_nonces(&U256::from(100))
+        .await
+        .unwrap();
+    assert!(adapter.get_reprocess_txs().await.unwrap().is_empty());
+}

--- a/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/adapter/tests/tests_reprocess.rs
@@ -34,18 +34,32 @@ async fn test_other_boundary_refresh_cannot_consume_reorg_transition() {
         .set_finalized_nonce_test(&U256::from(100))
         .await
         .unwrap();
-    let tx_uuid = TransactionUuid::random();
-    let tx = dummy_tx(
-        tx_uuid.clone(),
+    let middle_tx_uuid = TransactionUuid::random();
+    let middle_tx = dummy_tx(
+        middle_tx_uuid.clone(),
         TransactionStatus::Finalized,
         Some(U256::from(95)),
         Some(signer),
     );
-    tx_db.store_transaction_by_uuid(&tx).await.unwrap();
+    tx_db.store_transaction_by_uuid(&middle_tx).await.unwrap();
     adapter
         .nonce_manager
         .state
-        .set_tracked_tx_uuid_test(&U256::from(95), &tx_uuid)
+        .set_tracked_tx_uuid_test(&U256::from(95), &middle_tx_uuid)
+        .await
+        .unwrap();
+    let end_tx_uuid = TransactionUuid::random();
+    let end_tx = dummy_tx(
+        end_tx_uuid.clone(),
+        TransactionStatus::Finalized,
+        Some(U256::from(100)),
+        Some(signer),
+    );
+    tx_db.store_transaction_by_uuid(&end_tx).await.unwrap();
+    adapter
+        .nonce_manager
+        .state
+        .set_tracked_tx_uuid_test(&U256::from(100), &end_tx_uuid)
         .await
         .unwrap();
 
@@ -63,10 +77,12 @@ async fn test_other_boundary_refresh_cannot_consume_reorg_transition() {
     let second_reprocess_txs = second_reprocess_txs.unwrap();
     extended_range.unwrap();
 
-    assert_eq!(first_reprocess_txs.len(), 1);
-    assert_eq!(first_reprocess_txs[0].uuid, tx_uuid);
-    assert_eq!(second_reprocess_txs.len(), 1);
-    assert_eq!(second_reprocess_txs[0].uuid, tx_uuid);
+    assert_eq!(first_reprocess_txs.len(), 2);
+    assert_eq!(first_reprocess_txs[0].uuid, middle_tx_uuid);
+    assert_eq!(first_reprocess_txs[1].uuid, end_tx_uuid);
+    assert_eq!(second_reprocess_txs.len(), 2);
+    assert_eq!(second_reprocess_txs[0].uuid, middle_tx_uuid);
+    assert_eq!(second_reprocess_txs[1].uuid, end_tx_uuid);
     let retained_range = adapter
         .nonce_manager
         .state

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce.rs
@@ -14,4 +14,4 @@ pub(crate) use db::NonceDb;
 pub(crate) use state::NonceManagerState;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/db.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/db.rs
@@ -12,10 +12,54 @@ use crate::transaction::TransactionUuid;
 use super::super::nonce::status::NonceStatus;
 
 const FINALIZED_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX: &str = "finalized_nonce_by_signer_address_";
+const FINALIZED_NONCE_PRESENT_BY_SIGNER_ADDRESS_STORAGE_PREFIX: &str =
+    "finalized_nonce_present_by_signer_address_";
 const UPPER_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX: &str = "upper_nonce_by_signer_address_";
+const REORGED_NONCE_RANGE_BY_SIGNER_ADDRESS_STORAGE_PREFIX: &str =
+    "reorged_nonce_range_by_signer_address_";
 const TRANSACTION_UUID_BY_NONCE_AND_SIGNER_ADDRESS_STORAGE_PREFIX: &str =
     "transaction_uuid_by_nonce_and_signer_address_";
 const EVM_NONCE_BY_TRANSACTION_UUID_PREFIX: &str = "evm_nonce_by_transaction_uuid_";
+
+/// Inclusive range of nonces whose finalized transactions may have been reorged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ReorgedNonceRange {
+    pub(crate) start: U256,
+    pub(crate) end: U256,
+}
+
+struct StoredReorgedNonceRange(Option<ReorgedNonceRange>);
+
+impl Encode for StoredReorgedNonceRange {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: Write,
+    {
+        let mut written = self.0.is_some().write_to(writer)?;
+        if let Some(range) = self.0 {
+            written = written.saturating_add(range.start.write_to(writer)?);
+            written = written.saturating_add(range.end.write_to(writer)?);
+        }
+        Ok(written)
+    }
+}
+
+impl Decode for StoredReorgedNonceRange {
+    fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+    where
+        R: Read,
+    {
+        let range = if bool::read_from(reader)? {
+            Some(ReorgedNonceRange {
+                start: U256::read_from(reader)?,
+                end: U256::read_from(reader)?,
+            })
+        } else {
+            None
+        };
+        Ok(Self(range))
+    }
+}
 
 #[async_trait]
 pub trait NonceDb: Send + Sync {
@@ -30,6 +74,11 @@ pub trait NonceDb: Send + Sync {
         nonce: &U256,
     ) -> DbResult<()>;
 
+    async fn clear_finalized_nonce_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<()>;
+
     async fn retrieve_upper_nonce_by_signer_address(
         &self,
         signer_address: &Address,
@@ -39,6 +88,22 @@ pub trait NonceDb: Send + Sync {
         &self,
         signer_address: &Address,
         nonce: &U256,
+    ) -> DbResult<()>;
+
+    async fn retrieve_reorged_nonce_range_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<Option<ReorgedNonceRange>>;
+
+    async fn store_reorged_nonce_range_by_signer_address(
+        &self,
+        signer_address: &Address,
+        range: &ReorgedNonceRange,
+    ) -> DbResult<()>;
+
+    async fn clear_reorged_nonce_range_by_signer_address(
+        &self,
+        signer_address: &Address,
     ) -> DbResult<()>;
 
     async fn retrieve_transaction_uuid_by_nonce_and_signer_address(
@@ -74,6 +139,13 @@ impl NonceDb for HyperlaneRocksDB {
         &self,
         signer_address: &Address,
     ) -> DbResult<Option<U256>> {
+        let present: Option<bool> = self.retrieve_value_by_key(
+            FINALIZED_NONCE_PRESENT_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
+        )?;
+        if present == Some(false) {
+            return Ok(None);
+        }
         self.retrieve_value_by_key(
             FINALIZED_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
             &SignerAddress(*signer_address),
@@ -89,6 +161,22 @@ impl NonceDb for HyperlaneRocksDB {
             FINALIZED_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
             &SignerAddress(*signer_address),
             nonce,
+        )?;
+        self.store_value_by_key(
+            FINALIZED_NONCE_PRESENT_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
+            &true,
+        )
+    }
+
+    async fn clear_finalized_nonce_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<()> {
+        self.store_value_by_key(
+            FINALIZED_NONCE_PRESENT_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
+            &false,
         )
     }
 
@@ -111,6 +199,40 @@ impl NonceDb for HyperlaneRocksDB {
             UPPER_NONCE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
             &SignerAddress(*signer_address),
             nonce,
+        )
+    }
+
+    async fn retrieve_reorged_nonce_range_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<Option<ReorgedNonceRange>> {
+        let stored: Option<StoredReorgedNonceRange> = self.retrieve_value_by_key(
+            REORGED_NONCE_RANGE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
+        )?;
+        Ok(stored.and_then(|stored| stored.0))
+    }
+
+    async fn store_reorged_nonce_range_by_signer_address(
+        &self,
+        signer_address: &Address,
+        range: &ReorgedNonceRange,
+    ) -> DbResult<()> {
+        self.store_value_by_key(
+            REORGED_NONCE_RANGE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
+            &StoredReorgedNonceRange(Some(*range)),
+        )
+    }
+
+    async fn clear_reorged_nonce_range_by_signer_address(
+        &self,
+        signer_address: &Address,
+    ) -> DbResult<()> {
+        self.store_value_by_key(
+            REORGED_NONCE_RANGE_BY_SIGNER_ADDRESS_STORAGE_PREFIX,
+            &SignerAddress(*signer_address),
+            &StoredReorgedNonceRange(None),
         )
     }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/db/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/db/tests.rs
@@ -6,6 +6,7 @@ use crate::tests::test_utils::tmp_dbs;
 use crate::transaction::TransactionUuid;
 
 use super::super::super::nonce::status::NonceStatus;
+use super::ReorgedNonceRange;
 
 #[tokio::test]
 async fn test_nonce_db_finalized_and_upper() {
@@ -50,6 +51,63 @@ async fn test_nonce_db_finalized_and_upper() {
             .await
             .unwrap(),
         Some(nonce)
+    );
+}
+
+#[tokio::test]
+async fn test_nonce_db_clear_finalized_nonce() {
+    let (_, _, nonce_db) = tmp_dbs();
+    let signer = Address::random();
+    nonce_db
+        .store_finalized_nonce_by_signer_address(&signer, &U256::from(42))
+        .await
+        .unwrap();
+
+    nonce_db
+        .clear_finalized_nonce_by_signer_address(&signer)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        nonce_db
+            .retrieve_finalized_nonce_by_signer_address(&signer)
+            .await
+            .unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn test_nonce_db_reorged_range_round_trip_and_clear() {
+    let (_, _, nonce_db) = tmp_dbs();
+    let signer = Address::random();
+    let range = ReorgedNonceRange {
+        start: U256::from(7),
+        end: U256::from(11),
+    };
+
+    nonce_db
+        .store_reorged_nonce_range_by_signer_address(&signer, &range)
+        .await
+        .unwrap();
+    assert_eq!(
+        nonce_db
+            .retrieve_reorged_nonce_range_by_signer_address(&signer)
+            .await
+            .unwrap(),
+        Some(range)
+    );
+
+    nonce_db
+        .clear_reorged_nonce_range_by_signer_address(&signer)
+        .await
+        .unwrap();
+    assert_eq!(
+        nonce_db
+            .retrieve_reorged_nonce_range_by_signer_address(&signer)
+            .await
+            .unwrap(),
+        None
     );
 }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary.rs
@@ -1,5 +1,7 @@
 use hyperlane_core::U256;
+use tracing::{info, warn};
 
+use super::super::db::ReorgedNonceRange;
 use super::super::error::NonceResult;
 use super::NonceManagerState;
 
@@ -12,12 +14,72 @@ impl NonceManagerState {
     /// Upper nonce is the possible next nonce assuming that all the transactions in flight
     /// will be committed. If there is tracked nonce which was assigned to a dropped transaction,
     /// it will be used as the next nonce.
+    #[cfg(test)]
     pub(crate) async fn update_boundary_nonces(&self, finalized_nonce: &U256) -> NonceResult<()> {
-        self.set_finalized_nonce(finalized_nonce).await?;
+        self.update_boundary_nonces_from_chain(Some(finalized_nonce))
+            .await
+    }
+
+    /// Updates boundary nonces and durably records any finalized nonce regression.
+    ///
+    /// The pending range is stored before the finalized boundary. A crash between
+    /// those writes can cause duplicate reprocessing, but cannot lose a regression.
+    pub(crate) async fn update_boundary_nonces_from_chain(
+        &self,
+        finalized_nonce: Option<&U256>,
+    ) -> NonceResult<()> {
+        let _guard = self.boundary_update_lock.lock().await;
+        let old_finalized_nonce = self.get_finalized_nonce().await?;
+        let existing_range = self.get_reorged_nonce_range_unlocked().await?;
+
+        let pending_range = if let Some(old_finalized_nonce) =
+            old_finalized_nonce.filter(|old| finalized_nonce.is_none_or(|new| new < old))
+        {
+            let observed_range = ReorgedNonceRange {
+                start: finalized_nonce
+                    .map(|nonce| nonce.saturating_add(U256::one()))
+                    .unwrap_or_default(),
+                end: old_finalized_nonce,
+            };
+            let merged_range =
+                existing_range.map_or(observed_range, |existing| ReorgedNonceRange {
+                    start: existing.start.min(observed_range.start),
+                    end: existing.end.max(observed_range.end),
+                });
+            self.nonce_db
+                .store_reorged_nonce_range_by_signer_address(&self.address, &merged_range)
+                .await?;
+            warn!(
+                ?old_finalized_nonce,
+                ?finalized_nonce,
+                ?observed_range,
+                ?existing_range,
+                ?merged_range,
+                "Finalized nonce regressed; persisted transactions for reprocessing"
+            );
+            Some(merged_range)
+        } else {
+            existing_range
+        };
+
+        let recovered_range = pending_range.filter(|pending_range| {
+            finalized_nonce.is_some_and(|finalized_nonce| finalized_nonce >= &pending_range.end)
+        });
+
+        match finalized_nonce {
+            Some(finalized_nonce) => self.set_finalized_nonce(finalized_nonce).await?,
+            None => {
+                self.nonce_db
+                    .clear_finalized_nonce_by_signer_address(&self.address)
+                    .await?
+            }
+        }
 
         let mut upper_nonce = self.get_upper_nonce().await?;
 
-        if finalized_nonce >= &upper_nonce {
+        if let Some(finalized_nonce) =
+            finalized_nonce.filter(|finalized_nonce| *finalized_nonce >= &upper_nonce)
+        {
             // If the finalized nonce is greater than or equal to the upper nonce, it means that
             // some transactions were finalized by a service different from Lander.
             // And we need to update the upper nonce.
@@ -25,10 +87,37 @@ impl NonceManagerState {
             self.set_upper_nonce(&upper_nonce).await?;
         }
 
-        self.metrics.set_finalized_nonce(finalized_nonce);
+        self.metrics
+            .set_finalized_nonce(finalized_nonce.unwrap_or(&U256::zero()));
         self.metrics.set_upper_nonce(&upper_nonce);
 
+        // Keep re-enqueuing pending transactions until the chain proves recovery.
+        // Persist the recovered finalized boundary before clearing the range so a
+        // crash can cause duplicates, but cannot make a later regression invisible.
+        if let Some(recovered_range) = recovered_range {
+            self.nonce_db
+                .clear_reorged_nonce_range_by_signer_address(&self.address)
+                .await?;
+            info!(
+                ?finalized_nonce,
+                ?recovered_range,
+                "Finalized nonce recovered; cleared persisted reprocessing range"
+            );
+        }
+
         Ok(())
+    }
+
+    pub(crate) async fn get_reorged_nonce_range(&self) -> NonceResult<Option<ReorgedNonceRange>> {
+        let _guard = self.boundary_update_lock.lock().await;
+        self.get_reorged_nonce_range_unlocked().await
+    }
+
+    async fn get_reorged_nonce_range_unlocked(&self) -> NonceResult<Option<ReorgedNonceRange>> {
+        Ok(self
+            .nonce_db
+            .retrieve_reorged_nonce_range_by_signer_address(&self.address)
+            .await?)
     }
 }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/state/boundary/tests.rs
@@ -7,6 +7,7 @@ use hyperlane_core::{HyperlaneDomain, U256};
 use crate::tests::test_utils::tmp_dbs;
 
 use super::super::super::super::metrics::EthereumAdapterMetrics;
+use super::super::super::db::ReorgedNonceRange;
 use super::super::NonceManagerState;
 
 #[tokio::test]
@@ -35,6 +36,100 @@ async fn test_update_boundary_nonces_sets_finalized_and_upper_when_upper_missing
     assert_eq!(
         state.metrics.get_upper_nonce() as u64,
         (finalized + 1).as_u64()
+    );
+}
+
+#[tokio::test]
+async fn test_update_boundary_nonces_persists_and_merges_regressions() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let state = Arc::new(NonceManagerState::new(
+        nonce_db.clone(),
+        tx_db.clone(),
+        address,
+        EthereumAdapterMetrics::dummy_instance(),
+    ));
+
+    state
+        .update_boundary_nonces(&U256::from(100))
+        .await
+        .unwrap();
+    state.update_boundary_nonces(&U256::from(90)).await.unwrap();
+    state.update_boundary_nonces(&U256::from(95)).await.unwrap();
+    state.update_boundary_nonces(&U256::from(80)).await.unwrap();
+
+    let restarted_state = NonceManagerState::new(
+        nonce_db,
+        tx_db,
+        address,
+        EthereumAdapterMetrics::dummy_instance(),
+    );
+    assert_eq!(
+        restarted_state.get_reorged_nonce_range().await.unwrap(),
+        Some(ReorgedNonceRange {
+            start: U256::from(81),
+            end: U256::from(100),
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_new_regression_extends_pending_range_until_boundary_recovers() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let state = NonceManagerState::new(
+        nonce_db,
+        tx_db,
+        address,
+        EthereumAdapterMetrics::dummy_instance(),
+    );
+
+    state
+        .update_boundary_nonces(&U256::from(100))
+        .await
+        .unwrap();
+    state.update_boundary_nonces(&U256::from(90)).await.unwrap();
+    state.update_boundary_nonces(&U256::from(80)).await.unwrap();
+
+    assert_eq!(
+        state.get_reorged_nonce_range().await.unwrap(),
+        Some(ReorgedNonceRange {
+            start: U256::from(81),
+            end: U256::from(100),
+        })
+    );
+
+    state.update_boundary_nonces(&U256::from(99)).await.unwrap();
+    assert!(state.get_reorged_nonce_range().await.unwrap().is_some());
+
+    state
+        .update_boundary_nonces(&U256::from(100))
+        .await
+        .unwrap();
+    assert_eq!(state.get_reorged_nonce_range().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn test_update_boundary_nonces_captures_regression_to_no_transactions() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let state = NonceManagerState::new(
+        nonce_db,
+        tx_db,
+        address,
+        EthereumAdapterMetrics::dummy_instance(),
+    );
+    state.update_boundary_nonces(&U256::from(3)).await.unwrap();
+
+    state.update_boundary_nonces_from_chain(None).await.unwrap();
+
+    assert_eq!(state.get_finalized_nonce().await.unwrap(), None);
+    assert_eq!(
+        state.get_reorged_nonce_range().await.unwrap(),
+        Some(ReorgedNonceRange {
+            start: U256::zero(),
+            end: U256::from(3),
+        })
     );
 }
 

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/state/core.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/state/core.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use ethers::prelude::Address;
+use tokio::sync::Mutex;
 
 use hyperlane_core::HyperlaneDomain;
 
@@ -14,6 +15,7 @@ pub(crate) struct NonceManagerState {
     pub(super) tx_db: Arc<dyn TransactionDb>,
     pub(super) address: Address,
     pub(super) metrics: EthereumAdapterMetrics,
+    pub(super) boundary_update_lock: Mutex<()>,
 }
 
 impl NonceManagerState {
@@ -28,6 +30,7 @@ impl NonceManagerState {
             tx_db,
             address,
             metrics,
+            boundary_update_lock: Mutex::new(()),
         }
     }
 }

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/updater.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/updater.rs
@@ -49,10 +49,10 @@ impl NonceUpdater {
     }
 
     pub async fn update_boundaries(&self) -> NonceResult<()> {
-        let duration = self.updated.lock().await.elapsed();
-        if duration >= self.block_time {
+        let mut updated = self.updated.lock().await;
+        if updated.elapsed() >= self.block_time {
             self.update_boundaries_immediately().await?;
-            *self.updated.lock().await = Instant::now();
+            *updated = Instant::now();
         }
 
         Ok(())
@@ -66,10 +66,9 @@ impl NonceUpdater {
             .map_err(NonceError::ProviderError)?;
 
         let finalized_nonce = next_nonce.checked_sub(U256::one());
-
-        if let Some(finalized_nonce) = finalized_nonce {
-            self.state.update_boundary_nonces(&finalized_nonce).await?;
-        }
+        self.state
+            .update_boundary_nonces_from_chain(finalized_nonce.as_ref())
+            .await?;
 
         Ok(())
     }

--- a/rust/main/lander/src/adapter/chains/ethereum/nonce/updater/tests.rs
+++ b/rust/main/lander/src/adapter/chains/ethereum/nonce/updater/tests.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use ethers_core::types::Address;
 
+use futures_util::future::join_all;
 use hyperlane_core::{ChainCommunicationError, U256};
 use hyperlane_ethereum::EthereumReorgPeriod;
 
@@ -138,4 +139,31 @@ async fn test_update_boundaries_waits_for_block_time() {
     // Should now be updated to 2 again
     let finalized = state.get_finalized_nonce_test().await.unwrap();
     assert_eq!(finalized, Some(U256::from(2)));
+}
+
+#[tokio::test]
+async fn test_concurrent_update_boundaries_coalesces_provider_refresh() {
+    let (_, tx_db, nonce_db) = tmp_dbs();
+    let address = Address::random();
+    let metrics = EthereumAdapterMetrics::dummy_instance();
+    let state = Arc::new(NonceManagerState::new(nonce_db, tx_db, address, metrics));
+    let mut mock = MockEvmProvider::new();
+    mock.expect_get_next_nonce_on_finalized_block()
+        .times(1)
+        .returning(|_, _| Ok(U256::from(5)));
+    let updater = NonceUpdater::new(
+        address,
+        EthereumReorgPeriod::Blocks(1),
+        Duration::from_secs(60),
+        Arc::new(mock),
+        state.clone(),
+    );
+
+    let results = join_all((0..16).map(|_| updater.update_boundaries())).await;
+
+    assert!(results.into_iter().all(|result| result.is_ok()));
+    assert_eq!(
+        state.get_finalized_nonce_test().await.unwrap(),
+        Some(U256::from(4))
+    );
 }


### PR DESCRIPTION
## Summary

- persist finalized-nonce regressions before updating the stored boundary
- merge multiple pending regressions into one signer-scoped inclusive nonce range
- keep re-enqueuing UUID-idempotently until the chain's finalized nonce proves the range recovered
- represent rollback to zero without breaking existing RocksDB values
- coalesce concurrent boundary refreshes behind the existing update interval

## Correctness issue

`get_reprocess_txs()` currently detects a reorg by reading the old finalized nonce, calling `NonceUpdater::update_boundaries()`, then comparing the new value.

That transition is shared state. `calculate_next_nonce()` and `post_finalized()` also call the same updater. Either can consume the downward transition before `get_reprocess_txs()` reads it, leaving the inclusion-stage poll with equal old/new values and no transactions to reprocess.

The regression is now written to RocksDB before the finalized boundary. A crash between those writes can cause duplicate reprocessing, but cannot lose the observed regression. Pending ranges survive restart and union further downward transitions.

## Production context

Lander polls reorg state at `max(block_time, 5s)`, producing about 1.38m successful `eth_getTransactionCount` calls/day across the current relayers. This PR deliberately does not change that cadence: adaptive/idle polling is unsafe until regressions cannot be stolen by another boundary updater.

PR #8243 bounds reprocessing depth and adds manual APIs, but retains the fixed loop and transient old/new comparison. This patch is independent and should be coordinated before rebasing that older branch.

Collection never acknowledges the range. The recovered finalized boundary is persisted first and only then clears it; a crash between those writes causes duplicates, not loss. Concurrent lower regressions merge under the same state lock and cannot be erased by collection or recovery.

The remaining risk is an unbounded scan during an extreme deep rollback. The upper nonce is not lowered, so rollback-to-zero does not reuse nonces, but a very large range can cause a long DB loop. PR #8243's bounded/chunked reprocessing should be rebased on this persisted state rather than duplicated here.

## Tests

- DB range round-trip and clear
- pending range survives state reconstruction/restart
- multiple regressions merge without loss
- repeated collection retains and returns the pending range until finalized recovery
- concurrent extension cannot be erased by collection/recovery
- rollback from nonce zero is represented and reprocessed
- finalized nonce below range end retains it; reaching range end clears it
- 16 concurrent refresh callers perform one provider read
- adapter regression where `post_finalized()` refreshes before reprocess consumption
- `cargo check -p lander --lib`
- `cargo fmt --package lander -- --check`
- `cargo test -p lander --lib` (316 passed, 1 ignored)
- `cargo clippy -p lander --lib -- -D warnings`

## Supersedes

Supersedes #8243's older reorg handling. This PR persists and merges the signer-scoped range before finalized-boundary mutation, survives restart, and keeps idempotently re-enqueuing until recovery. The old 25-nonce in-memory/manual gate was intentionally not ported because it can strand recovery behind operator action. Deep-range work should be chunked against this durable record if production evidence requires it.
