### PR TITLE
fix(rust): allow recipient-less native Cosmos transactions

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/cw/cw_query_client.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/cw/cw_query_client.rs
@@ -67,8 +67,8 @@ impl BuildableQueryClient for CwQueryClient {
 
     // extract the message recipient contract address from the tx
     // this is implementation specific
-    fn parse_tx_message_recipient(&self, tx: &Tx, tx_hash: &H512) -> ChainResult<H256> {
-        Self::contract(tx, tx_hash)
+    fn parse_tx_message_recipient(&self, tx: &Tx, tx_hash: &H512) -> ChainResult<Option<H256>> {
+        Self::contract(tx, tx_hash).map(Some)
     }
 
     /// Returns the Block height of the query client

--- a/rust/main/chains/hyperlane-cosmos/src/native/module_query_client.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/native/module_query_client.rs
@@ -16,9 +16,7 @@ use hyperlane_cosmos_rs::hyperlane::warp::v1::MsgRemoteTransfer;
 use hyperlane_cosmos_rs::prost::{Message, Name};
 use tonic::async_trait;
 
-use hyperlane_core::{
-    ChainCommunicationError, ChainResult, Decode, HyperlaneMessage, RawHyperlaneMessage, H256, H512,
-};
+use hyperlane_core::{ChainResult, Decode, HyperlaneMessage, RawHyperlaneMessage, H256, H512};
 
 use crate::GrpcProvider;
 use crate::{BuildableQueryClient, HyperlaneCosmosError};
@@ -42,21 +40,8 @@ impl BuildableQueryClient for ModuleQueryClient {
         Ok(Self { grpc })
     }
 
-    // the tx is either a MsgProcessMessage on the destination or a MsgRemoteTransfer on the origin
-    // we check for both tx types, if both are missing or an error occurred while parsing we return the error
-    fn parse_tx_message_recipient(&self, tx: &Tx, _hash: &H512) -> ChainResult<H256> {
-        // first check for the process message
-        if let Some(recipient) = Self::parse_msg_process_recipient(tx)? {
-            return Ok(recipient);
-        }
-        // if not found check for the remote transfer
-        if let Some(recipient) = Self::parse_msg_remote_transfer_recipient(tx)? {
-            return Ok(recipient);
-        }
-        // if both are missing we return an error
-        Err(HyperlaneCosmosError::ParsingFailed(
-            "transaction does not contain any process message or remote transfer".to_owned(),
-        ))?
+    fn parse_tx_message_recipient(&self, tx: &Tx, _hash: &H512) -> ChainResult<Option<H256>> {
+        Self::message_recipient(tx)
     }
 
     async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
@@ -70,6 +55,18 @@ impl BuildableQueryClient for ModuleQueryClient {
 }
 
 impl ModuleQueryClient {
+    fn message_recipient(tx: &Tx) -> ChainResult<Option<H256>> {
+        // first check for the process message
+        if let Some(recipient) = Self::parse_msg_process_recipient(tx)? {
+            return Ok(Some(recipient));
+        }
+        // if not found check for the remote transfer
+        if let Some(recipient) = Self::parse_msg_remote_transfer_recipient(tx)? {
+            return Ok(Some(recipient));
+        }
+        Ok(None)
+    }
+
     /// parses the message recipient if the transaction contains a MsgProcessMessage
     fn parse_msg_process_recipient(tx: &Tx) -> ChainResult<Option<H256>> {
         // check for all messages processes
@@ -117,9 +114,9 @@ impl ModuleQueryClient {
             Err(HyperlaneCosmosError::ParsingFailed(msg.to_owned()))?
         }
 
-        let msg = remote_transfers.first().ok_or_else(|| {
-            ChainCommunicationError::from_other_str("tx does not contain any remote transfers")
-        })?;
+        let Some(msg) = remote_transfers.first() else {
+            return Ok(None);
+        };
         let result =
             MsgRemoteTransfer::decode(msg.value.as_slice()).map_err(HyperlaneCosmosError::from)?;
         // the recipient is the token id of the transfer, which is the address that the user interacts with
@@ -291,5 +288,69 @@ impl ModuleQueryClient {
                 Box::pin(future)
             })
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmrs::tx::{AuthInfo, Body, Fee};
+
+    use super::*;
+
+    fn tx_with_messages(messages: Vec<Any>) -> Tx {
+        Tx {
+            body: Body::new(messages, "", 0_u8),
+            auth_info: AuthInfo {
+                signer_infos: Vec::new(),
+                fee: Fee {
+                    amount: Vec::new(),
+                    gas_limit: 0,
+                    payer: None,
+                    granter: None,
+                },
+            },
+            signatures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn unrecognized_native_message_has_no_recipient() {
+        let tx = tx_with_messages(vec![Any {
+            type_url: "/cosmos.bank.v1beta1.MsgSend".to_owned(),
+            value: Vec::new(),
+        }]);
+
+        assert_eq!(
+            ModuleQueryClient::message_recipient(&tx).expect("generic message should parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_remote_transfer_is_an_error() {
+        let tx = tx_with_messages(vec![Any {
+            type_url: MsgRemoteTransfer::type_url(),
+            value: vec![0xff],
+        }]);
+
+        assert!(ModuleQueryClient::message_recipient(&tx).is_err());
+    }
+
+    #[test]
+    fn remote_transfer_recipient_is_preserved() {
+        let recipient = H256::repeat_byte(0x11);
+        let transfer = MsgRemoteTransfer {
+            token_id: format!("{recipient:#x}"),
+            ..Default::default()
+        };
+        let tx = tx_with_messages(vec![Any {
+            type_url: MsgRemoteTransfer::type_url(),
+            value: transfer.encode_to_vec(),
+        }]);
+
+        assert_eq!(
+            ModuleQueryClient::message_recipient(&tx).expect("remote transfer should parse"),
+            Some(recipient)
+        );
     }
 }

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
@@ -34,9 +34,9 @@ pub trait BuildableQueryClient: Sized + std::fmt::Debug + Sync + Send + 'static 
     /// Whether or not the given address is a contract
     async fn is_contract(&self, address: &H256) -> ChainResult<bool>;
 
-    /// Extract the message recipient contract address from the tx
+    /// Extract the optional message recipient contract address from the tx
     /// this is implementation specific
-    fn parse_tx_message_recipient(&self, tx: &Tx, hash: &H512) -> ChainResult<H256>;
+    fn parse_tx_message_recipient(&self, tx: &Tx, hash: &H512) -> ChainResult<Option<H256>>;
 
     /// Returns the Block height of the query client
     async fn get_block_number(&self) -> ChainResult<u64>;
@@ -282,7 +282,7 @@ impl<T: BuildableQueryClient> HyperlaneProvider for CosmosProvider<T> {
         let response = self.rpc.get_tx(hash).await?;
         let tx = Tx::from_bytes(&response.tx)?;
 
-        let contract = self.query.parse_tx_message_recipient(&tx, hash)?;
+        let recipient = self.query.parse_tx_message_recipient(&tx, hash)?;
         let (sender, nonce) = self.sender_and_nonce(&tx)?;
 
         let hash: H256 = H256::from_slice(&h512_to_bytes(hash));
@@ -296,7 +296,7 @@ impl<T: BuildableQueryClient> HyperlaneProvider for CosmosProvider<T> {
             gas_price: Some(gas_price),
             nonce,
             sender,
-            recipient: Some(contract),
+            recipient,
             receipt: Some(TxnReceiptInfo {
                 gas_used: response.tx_result.gas_used.into(),
                 cumulative_gas_used: response.tx_result.gas_used.into(),


### PR DESCRIPTION
## Summary

- return `None` for the recipient of generic native Cosmos transactions
- preserve recipient extraction for native Hyperlane process/remote-transfer messages
- keep malformed recognized Hyperlane messages as errors
- keep CosmWasm contract recipients required

## Production evidence

The scraper's raw-dispatch reconciler repeatedly retries valid Celestia transactions with `tx does not contain any remote transfers`. Generic native Cosmos transactions are being forced through `MsgRemoteTransfer` recipient inference even though `TxnInfo.recipient` is already optional.

At 2026-08-10 00:22 UTC, the oldest unenriched raw dispatch was 17,144,804 seconds old (about 198 days). This patch removes the observed recipient-only blocker; it does not relax sender, nonce, gas, transaction decoding, or recognized Hyperlane message validation.

## Correctness boundaries

- an unrecognized native message yields `recipient: None`
- a valid native process or remote-transfer message still yields `Some(recipient)`
- a malformed recognized remote transfer still fails decoding
- CosmWasm continues to require and return its contract recipient

## Tests

- generic bank `MsgSend` has no recipient
- malformed `MsgRemoteTransfer` remains an error
- valid `MsgRemoteTransfer` preserves its token ID recipient
- `cargo test -p hyperlane-cosmos --lib module_query_client::tests` (3 passed)
- `cargo check -p hyperlane-cosmos --lib`
- `cargo clippy -p hyperlane-cosmos --lib -- -D warnings`
- `cargo fmt --package hyperlane-cosmos -- --check`
- `git diff --check`
