### PR TITLE
fix(relayer): distinguish expected metadata signature waits

### DIFF
--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -1,10 +1,142 @@
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 use maplit::hashmap;
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge};
+use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 use hyperlane_base::CoreMetrics;
-use hyperlane_core::{HyperlaneDomain, HyperlaneMessage};
+use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, H256};
+
+const UNKNOWN_APP_CONTEXT: &str = "Unknown";
+const WAIT_EVENT: &str = "wait";
+const RECOVERED_EVENT: &str = "recovered";
+const ENDED_EVENT: &str = "ended";
+
+#[derive(Clone, Copy, Debug)]
+struct MetadataWaitStart {
+    instant: Instant,
+    unix_timestamp_seconds: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::core::Collector;
+    use prometheus::{Encoder, Registry, TextEncoder};
+
+    use hyperlane_core::KnownHyperlaneDomain;
+
+    use super::*;
+
+    fn test_metrics() -> MessageSubmissionMetrics {
+        let core_metrics = CoreMetrics::new("relayer", 9090, Registry::new()).unwrap();
+        MessageSubmissionMetrics::new(
+            &core_metrics,
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+        )
+    }
+
+    #[test]
+    fn metadata_wait_metrics_track_retries_oldest_and_recovery_without_id_labels() {
+        let metrics = test_metrics();
+        let app_context = "test-app";
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let labels = [app_context, "ethereum", "arbitrum"];
+
+        let first = metrics.record_metadata_wait(first_id, Some(app_context));
+        assert!(first.first_observation);
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            1
+        );
+        let oldest = metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .get();
+        assert!(oldest > 0);
+
+        let retry = metrics.record_metadata_wait(first_id, Some(app_context));
+        assert!(!retry.first_observation);
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            2
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", WAIT_EVENT])
+                .get(),
+            3
+        );
+
+        assert!(metrics
+            .finish_metadata_wait(first_id, Some(app_context), true)
+            .is_some());
+        assert_eq!(
+            metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", RECOVERED_EVENT])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            1
+        );
+
+        assert!(metrics
+            .finish_metadata_wait(second_id, Some(app_context), false)
+            .is_some());
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+
+        let mut encoded = Vec::new();
+        TextEncoder::new()
+            .encode(&metrics.metadata_wait_event_count.collect(), &mut encoded)
+            .unwrap();
+        let encoded = String::from_utf8(encoded).unwrap();
+        assert!(!encoded.contains("message_id"));
+        assert!(!encoded.contains(&format!("{first_id:?}")));
+        assert!(!encoded.contains(&format!("{second_id:?}")));
+    }
+}
+
+#[derive(Debug, Default)]
+struct MetadataWaitTracker {
+    by_app_context: Mutex<HashMap<String, HashMap<H256, MetadataWaitStart>>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MetadataWaitObservation {
+    pub(crate) first_observation: bool,
+    pub(crate) elapsed: Duration,
+}
 
 #[derive(Clone, Debug)]
 pub struct MetadataBuildMetric {
@@ -27,6 +159,13 @@ pub struct MessageSubmissionMetrics {
     pub metadata_build_count: IntCounterVec,
     /// Total number of seconds spent building different types of metadata.
     pub metadata_build_duration: CounterVec,
+    /// Bounded wait-attempt and lifecycle events for validator-signature waits.
+    pub metadata_wait_event_count: IntCounterVec,
+    /// Messages currently waiting for validator signatures.
+    pub metadata_wait_active: IntGaugeVec,
+    /// Unix timestamp of the oldest active validator-signature wait.
+    pub metadata_wait_oldest_timestamp_seconds: IntGaugeVec,
+    metadata_wait_tracker: MetadataWaitTracker,
 }
 
 impl MessageSubmissionMetrics {
@@ -48,6 +187,11 @@ impl MessageSubmissionMetrics {
                 .with_label_values(&[origin, destination]),
             metadata_build_count: metrics.metadata_build_count(),
             metadata_build_duration: metrics.metadata_build_duration(),
+            metadata_wait_event_count: metrics.metadata_wait_event_count(),
+            metadata_wait_active: metrics.metadata_wait_active(),
+            metadata_wait_oldest_timestamp_seconds: metrics
+                .metadata_wait_oldest_timestamp_seconds(),
+            metadata_wait_tracker: MetadataWaitTracker::default(),
         }
     }
 
@@ -63,7 +207,7 @@ impl MessageSubmissionMetrics {
     /// a specific ISM
     pub fn insert_metadata_build_metric(&self, params: MetadataBuildMetric) {
         let labels = hashmap! {
-            "app_context" => params.app_context.as_deref().unwrap_or("Unknown"),
+            "app_context" => params.app_context.as_deref().unwrap_or(UNKNOWN_APP_CONTEXT),
             "origin" => self.origin.as_str(),
             "remote" => self.destination.as_str(),
             "status" => if params.success { "success" } else { "failure" },
@@ -72,5 +216,111 @@ impl MessageSubmissionMetrics {
         self.metadata_build_duration
             .with(&labels)
             .inc_by(params.duration.as_secs_f64());
+    }
+
+    pub(crate) fn record_metadata_wait(
+        &self,
+        message_id: H256,
+        app_context: Option<&str>,
+    ) -> MetadataWaitObservation {
+        let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
+        let now = Instant::now();
+        let unix_timestamp_seconds = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+        .unwrap_or(i64::MAX);
+        let mut waits = self
+            .metadata_wait_tracker
+            .by_app_context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let app_waits = waits.entry(app_context.to_owned()).or_default();
+        let (first_observation, start) = match app_waits.entry(message_id) {
+            std::collections::hash_map::Entry::Occupied(entry) => (false, *entry.get()),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let start = MetadataWaitStart {
+                    instant: now,
+                    unix_timestamp_seconds,
+                };
+                entry.insert(start);
+                let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+                self.metadata_wait_active.with_label_values(&labels).inc();
+                let oldest = self
+                    .metadata_wait_oldest_timestamp_seconds
+                    .with_label_values(&labels);
+                if oldest.get() == 0 || unix_timestamp_seconds < oldest.get() {
+                    oldest.set(unix_timestamp_seconds);
+                }
+                (true, start)
+            }
+        };
+
+        self.metadata_wait_event_count
+            .with_label_values(&[
+                app_context,
+                self.origin.as_str(),
+                self.destination.as_str(),
+                WAIT_EVENT,
+            ])
+            .inc();
+
+        MetadataWaitObservation {
+            first_observation,
+            elapsed: now.saturating_duration_since(start.instant),
+        }
+    }
+
+    pub(crate) fn finish_metadata_wait(
+        &self,
+        message_id: H256,
+        app_context: Option<&str>,
+        recovered: bool,
+    ) -> Option<Duration> {
+        let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
+        let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+        let oldest = self
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels);
+        let mut waits = self
+            .metadata_wait_tracker
+            .by_app_context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let current_oldest = oldest.get();
+        let app_waits = waits.get_mut(app_context)?;
+        let removed = app_waits.remove(&message_id)?;
+        let next_oldest = if removed.unix_timestamp_seconds == current_oldest {
+            app_waits
+                .values()
+                .map(|start| start.unix_timestamp_seconds)
+                .min()
+                .unwrap_or_default()
+        } else {
+            current_oldest
+        };
+        let remove_app_context = app_waits.is_empty();
+        if remove_app_context {
+            waits.remove(app_context);
+        }
+
+        self.metadata_wait_active.with_label_values(&labels).dec();
+        oldest.set(next_oldest);
+        self.metadata_wait_event_count
+            .with_label_values(&[
+                app_context,
+                self.origin.as_str(),
+                self.destination.as_str(),
+                if recovered {
+                    RECOVERED_EVENT
+                } else {
+                    ENDED_EVENT
+                },
+            ])
+            .inc();
+
+        Some(removed.instant.elapsed())
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -248,7 +248,7 @@ impl AggregationIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for AggregationIsmMetadataBuilder {
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,
@@ -275,6 +275,12 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             }
             Err(MetadataBuildError::Refused(reason)) => {
                 return Err(MetadataBuildError::Refused(reason));
+            }
+            Err(err @ MetadataBuildError::AwaitingValidatorSignatures) => {
+                debug!(
+                    ?err,
+                    "Fast path is waiting for signatures; falling back to the other submodules"
+                );
             }
             Err(err) => {
                 warn!(
@@ -545,6 +551,7 @@ mod test {
     }
 
     /// All submodules fail to build → AggregationThresholdNotMet.
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_all_build_failures_returns_threshold_not_met() {
         let agg_addr = H256::from_low_u64_be(1);
@@ -568,6 +575,7 @@ mod test {
             result.unwrap_err(),
             MetadataBuildError::AggregationThresholdNotMet(2)
         );
+        assert!(logs_contain("Metadata submodule build failed"));
     }
 
     /// All submodules build ok but every dry_run returns None → AggregationThresholdNotMet.

--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -382,7 +382,7 @@ impl CcipReadIsmMetadataBuilder {
 
 #[async_trait]
 impl MetadataBuilder for CcipReadIsmMetadataBuilder {
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -54,7 +54,7 @@ pub struct MessageMetadataBuilder {
 ///                 MessageMetadataBuilder
 #[async_trait]
 impl MetadataBuilder for MessageMetadataBuilder {
-    #[instrument(err, skip(self, message, params), fields(destination_domain=self.base_builder().destination_domain().name()))]
+    #[instrument(skip(self, message, params), fields(destination_domain=self.base_builder().destination_domain().name()))]
     async fn build(
         &self,
         ism_address: H256,
@@ -151,6 +151,43 @@ pub async fn ism_and_module_type(
 
 /// Builds metadata for a message.
 pub async fn build_message_metadata(
+    message_builder: MessageMetadataBuilder,
+    ism_address: H256,
+    message: &HyperlaneMessage,
+    params: MessageMetadataBuildParams,
+    maybe_ism_and_module_type: Option<(Box<dyn InterchainSecurityModule>, ModuleType)>,
+) -> Result<IsmWithMetadataAndType, MetadataBuildError> {
+    let result = build_message_metadata_inner(
+        message_builder,
+        ism_address,
+        message,
+        params,
+        maybe_ism_and_module_type,
+    )
+    .await;
+    match &result {
+        Err(err @ MetadataBuildError::AwaitingValidatorSignatures) => {
+            tracing::debug!(
+                ?err,
+                ?ism_address,
+                message_id = ?message.id(),
+                "Metadata submodule is waiting for validator signatures"
+            );
+        }
+        Err(err) => {
+            tracing::error!(
+                ?err,
+                ?ism_address,
+                message_id = ?message.id(),
+                "Metadata submodule build failed"
+            );
+        }
+        Ok(_) => {}
+    }
+    result
+}
+
+async fn build_message_metadata_inner(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,
     message: &HyperlaneMessage,

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -19,7 +19,7 @@ pub struct RoutingIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for RoutingIsmMetadataBuilder {
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -4,7 +4,7 @@ use derive_new::new;
 use hyperlane_core::{PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason};
 use prometheus::{IntGauge, IntGaugeVec};
 use tokio::sync::{broadcast::Receiver, Mutex};
-use tracing::{debug, instrument};
+use tracing::{instrument, trace};
 
 use crate::server::operations::message_retry::{MessageRetryQueueResponse, MessageRetryRequest};
 use crate::settings::matching_list::MatchingListExt;
@@ -60,7 +60,7 @@ impl OpQueue {
         // This function is called very often by the message processor tasks, so only log when there are operations to pop
         // to avoid spamming the logs
         if !popped.is_empty() {
-            debug!(
+            trace!(
                 queue_label = %self.queue_metrics_label,
                 operations = ?popped,
                 "Popped OpQueue operations"

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1249,19 +1249,14 @@ impl PendingMessage {
                 }
                 Ok(metadata)
             }
-            Err(MetadataBuildError::AwaitingValidatorSignatures) => {
-                let observation = self
-                    .ctx
-                    .metrics
-                    .record_metadata_wait(self.message.id(), self.app_context.as_deref());
-                Err(self.on_metadata_wait(observation))
-            }
             Err(err) => {
-                self.ctx.metrics.finish_metadata_wait(
-                    self.message.id(),
-                    self.app_context.as_deref(),
-                    false,
-                );
+                if !matches!(err, MetadataBuildError::AwaitingValidatorSignatures) {
+                    self.ctx.metrics.finish_metadata_wait(
+                        self.message.id(),
+                        self.app_context.as_deref(),
+                        false,
+                    );
+                }
                 let reprepare = match &err {
                     MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
                         self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -27,7 +27,9 @@ use hyperlane_core::{
 use hyperlane_operation_verifier::ApplicationOperationVerifier;
 
 use crate::{
-    metrics::message_submission::{MessageSubmissionMetrics, MetadataBuildMetric},
+    metrics::message_submission::{
+        MessageSubmissionMetrics, MetadataBuildMetric, MetadataWaitObservation,
+    },
     msg::metadata::{MessageMetadataBuildParams, MetadataBuildError},
 };
 
@@ -155,6 +157,16 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ica_reveal_attempts: u32,
+}
+
+impl Drop for PendingMessage {
+    fn drop(&mut self) {
+        self.ctx.metrics.finish_metadata_wait(
+            self.message.id(),
+            self.app_context.as_deref(),
+            false,
+        );
+    }
 }
 
 impl Debug for PendingMessage {
@@ -989,6 +1001,36 @@ impl PendingMessage {
         } else {
             warn!("Repreparing message: {}", reason.clone());
         }
+        self.reprepare_or_drop(reason)
+    }
+
+    fn on_metadata_wait(&mut self, observation: MetadataWaitObservation) -> PendingOperationResult {
+        let reason = ReprepareReason::AwaitingValidatorSignatures;
+        self.inc_attempts(Some(&reason));
+        self.submitted = false;
+        if observation.first_observation {
+            warn!(
+                wait_seconds = observation.elapsed.as_secs_f64(),
+                "Waiting for validator signatures"
+            );
+        } else {
+            debug!(
+                wait_seconds = observation.elapsed.as_secs_f64(),
+                "Still waiting for validator signatures"
+            );
+        }
+        let result = self.reprepare_or_drop(reason);
+        if matches!(result, PendingOperationResult::Drop) {
+            self.ctx.metrics.finish_metadata_wait(
+                self.message.id(),
+                self.app_context.as_deref(),
+                false,
+            );
+        }
+        result
+    }
+
+    fn reprepare_or_drop(&self, reason: ReprepareReason) -> PendingOperationResult {
         // For fail-fast messages (relay API), drop immediately once the retry budget is
         // exceeded. Without this check, a small max_retries value (e.g. 3) would still
         // hit the fixed early-backoff arms (1 => 5s, 2 => 10s, ...) rather than dropping.
@@ -1023,6 +1065,16 @@ impl PendingMessage {
     /// re-attempt processing for this message again, even after the relayer
     /// restarts.
     fn record_message_process_success(&mut self) -> Result<()> {
+        if let Some(wait_duration) = self.ctx.metrics.finish_metadata_wait(
+            self.message.id(),
+            self.app_context.as_deref(),
+            true,
+        ) {
+            info!(
+                wait_seconds = wait_duration.as_secs_f64(),
+                "Validator signature wait recovered after message delivery"
+            );
+        }
         self.ctx
             .origin_db
             .store_processed_by_nonce(&self.message.nonce, &true)?;
@@ -1183,50 +1235,84 @@ impl PendingMessage {
 
         tracing::debug!(?self.message, ?metadata_res, "Metadata build result");
 
-        let metadata_res = metadata_res.map_err(|err| match &err {
-            MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
+        let metadata_res = match metadata_res {
+            Ok(metadata) => {
+                if let Some(wait_duration) = self.ctx.metrics.finish_metadata_wait(
+                    self.message.id(),
+                    self.app_context.as_deref(),
+                    true,
+                ) {
+                    info!(
+                        wait_seconds = wait_duration.as_secs_f64(),
+                        "Validator signatures became available"
+                    );
+                }
+                Ok(metadata)
             }
-            MetadataBuildError::CouldNotFetch => {
-                self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata)
+            Err(MetadataBuildError::AwaitingValidatorSignatures) => {
+                let observation = self
+                    .ctx
+                    .metrics
+                    .record_metadata_wait(self.message.id(), self.app_context.as_deref());
+                Err(self.on_metadata_wait(observation))
             }
-            MetadataBuildError::AwaitingValidatorSignatures => {
-                self.on_reprepare::<String>(None, ReprepareReason::AwaitingValidatorSignatures)
+            Err(err) => {
+                self.ctx.metrics.finish_metadata_wait(
+                    self.message.id(),
+                    self.app_context.as_deref(),
+                    false,
+                );
+                let reprepare = match &err {
+                    MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::CouldNotFetch => {
+                        self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata)
+                    }
+                    // If metadata building is refused, allow it to be retried later.
+                    MetadataBuildError::Refused(reason) => {
+                        warn!(?reason, "Metadata building refused");
+                        self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused)
+                    }
+                    // These errors cannot be recovered from, so we drop them.
+                    MetadataBuildError::UnsupportedModuleType(reason) => {
+                        warn!(?reason, "Unsupported module type");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MaxIsmDepthExceeded(depth) => {
+                        warn!(depth, "Max ISM depth reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MaxIsmCountReached(count) => {
+                        warn!(count, "Max ISM count reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::AggregationThresholdNotMet(threshold) => {
+                        warn!(threshold, "Aggregation threshold not met");
+                        self.on_reprepare(Some(&err), ReprepareReason::CouldNotFetchMetadata)
+                    }
+                    MetadataBuildError::MaxValidatorCountReached(count) => {
+                        warn!(count, "Max validator count reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MerkleRootMismatch {
+                        root,
+                        canonical_root,
+                    } => {
+                        warn!(?root, ?canonical_root, "Merkle root mismatch");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::AwaitingValidatorSignatures => {
+                        let observation = self
+                            .ctx
+                            .metrics
+                            .record_metadata_wait(self.message.id(), self.app_context.as_deref());
+                        self.on_metadata_wait(observation)
+                    }
+                };
+                Err(reprepare)
             }
-            // If the metadata building is refused, we still allow it to be retried later.
-            MetadataBuildError::Refused(reason) => {
-                warn!(?reason, "Metadata building refused");
-                self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused)
-            }
-            // These errors cannot be recovered from, so we drop them
-            MetadataBuildError::UnsupportedModuleType(reason) => {
-                warn!(?reason, "Unsupported module type");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MaxIsmDepthExceeded(depth) => {
-                warn!(depth, "Max ISM depth reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MaxIsmCountReached(count) => {
-                warn!(count, "Max ISM count reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::AggregationThresholdNotMet(threshold) => {
-                warn!(threshold, "Aggregation threshold not met");
-                self.on_reprepare(Some(err), ReprepareReason::CouldNotFetchMetadata)
-            }
-            MetadataBuildError::MaxValidatorCountReached(count) => {
-                warn!(count, "Max validator count reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MerkleRootMismatch {
-                root,
-                canonical_root,
-            } => {
-                warn!(?root, ?canonical_root, "Merkle root mismatch");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-        });
+        };
         let build_metadata_end = Instant::now();
 
         let metrics_params = MetadataBuildMetric {

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use prometheus::Registry;
 use tokio::sync::RwLock;
 
 use hyperlane_base::{
@@ -10,7 +10,7 @@ use hyperlane_base::{
     settings::{ChainConf, ChainConnectionConf, Settings},
     CoreMetrics,
 };
-use hyperlane_core::{HyperlaneDomain, H256};
+use hyperlane_core::{HyperlaneDomain, KnownHyperlaneDomain, H256};
 use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
 
 use crate::{
@@ -97,22 +97,12 @@ pub fn dummy_metadata_builder(
 }
 
 pub fn dummy_submission_metrics() -> MessageSubmissionMetrics {
-    MessageSubmissionMetrics {
-        origin: "".to_string(),
-        destination: "".to_string(),
-        last_known_nonce: IntGauge::new("last_known_nonce_gauge", "help string").unwrap(),
-        messages_processed: IntCounter::new("message_processed_gauge", "help string").unwrap(),
-        metadata_build_count: IntCounterVec::new(
-            Opts::new("metadata_build_count", "help string"),
-            &["app_context", "origin", "remote", "status"],
-        )
-        .unwrap(),
-        metadata_build_duration: CounterVec::new(
-            Opts::new("metadata_build_duration", "help string"),
-            &["app_context", "origin", "remote", "status"],
-        )
-        .unwrap(),
-    }
+    let core_metrics = CoreMetrics::new("dummy_relayer", 37582, Registry::new()).unwrap();
+    MessageSubmissionMetrics::new(
+        &core_metrics,
+        &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+        &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+    )
 }
 
 pub fn dummy_message_context(

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -227,7 +227,7 @@ where
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
                 }
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     provider_host = provider_host.as_str(),

--- a/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
@@ -100,7 +100,7 @@ impl JsonRpcTransport for FallbackHttpTransport {
                 // Create log span
                 let provider = &self.inner.providers[priority.index];
 
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     "fallback_request"

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -64,6 +64,9 @@ pub struct CoreMetrics {
     // metadata building metrics
     metadata_build_count: IntCounterVec,
     metadata_build_duration: CounterVec,
+    metadata_wait_event_count: IntCounterVec,
+    metadata_wait_active: IntGaugeVec,
+    metadata_wait_oldest_timestamp_seconds: IntGaugeVec,
 
     // ism building metrics
     ism_build_count: IntCounterVec,
@@ -304,6 +307,36 @@ impl CoreMetrics {
             registry
         )?;
 
+        let metadata_wait_event_count = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_event_count"),
+                "Metadata validator-signature wait attempts and lifecycle transitions; event=wait counts attempts",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote", "event"],
+            registry
+        )?;
+
+        let metadata_wait_active = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_active"),
+                "Messages currently waiting for validator signatures",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote"],
+            registry
+        )?;
+
+        let metadata_wait_oldest_timestamp_seconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_oldest_timestamp_seconds"),
+                "Unix timestamp when the oldest active validator-signature wait began; zero when none are active",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote"],
+            registry
+        )?;
+
         let ism_build_count = register_int_counter_vec_with_registry!(
             opts!(
                 namespaced!("ism_build_count"),
@@ -355,6 +388,9 @@ impl CoreMetrics {
 
             metadata_build_count,
             metadata_build_duration,
+            metadata_wait_event_count,
+            metadata_wait_active,
+            metadata_wait_oldest_timestamp_seconds,
 
             ism_build_count,
 
@@ -692,6 +728,21 @@ impl CoreMetrics {
     /// - `status`: success or failure
     pub fn metadata_build_duration(&self) -> CounterVec {
         self.metadata_build_duration.clone()
+    }
+
+    /// Bounded wait-attempt and lifecycle events for validator-signature waits.
+    pub fn metadata_wait_event_count(&self) -> IntCounterVec {
+        self.metadata_wait_event_count.clone()
+    }
+
+    /// Number of messages currently waiting for validator signatures.
+    pub fn metadata_wait_active(&self) -> IntGaugeVec {
+        self.metadata_wait_active.clone()
+    }
+
+    /// Unix timestamp when the oldest active validator-signature wait began.
+    pub fn metadata_wait_oldest_timestamp_seconds(&self) -> IntGaugeVec {
+        self.metadata_wait_oldest_timestamp_seconds.clone()
     }
 
     /// The number of ism built by this process during its


### PR DESCRIPTION
## Summary

- treat `AwaitingValidatorSignatures` as an expected retry state instead of an error at every recursive metadata-builder boundary
- log the first wait at WARN, repeated waits at DEBUG, and recovery at INFO
- preserve ERROR/WARN visibility for unexpected nested and top-level metadata failures
- add bounded active/oldest-age/lifecycle metrics without message-ID labels

## Production evidence

A 5,000-event WARN/ERROR sample saturated after only 2h08m, so current relayers emit more than 39k WARN/ERROR events/day on this path. It contained:

- 1,777 bare `Awaiting validator signatures` ERROR events
- 380 `Repreparing ... Awaiting signatures` warnings
- 353 expected fast-path fallback warnings
- 144 fast-path awaiting-signature errors

The recursive builders use `#[instrument(err)]`, so one typed expected wait is recorded again at each propagation boundary. The pending message then warns on every retry. This is expected while validator checkpoints/signatures become available, but a genuinely old wait must remain visible.

## Observability contract

- first observed wait: WARN
- repeated wait for the same message: DEBUG with elapsed time
- signatures become available: INFO with total wait
- unexpected nested metadata failure: retained ERROR/WARN even when another aggregation submodule satisfies threshold
- bounded labels only: `app_context`, `origin`, `remote`, fixed lifecycle event
- active gauge + oldest-start timestamp support count and age alerts without message-ID cardinality
- success, fail-fast/drop and object teardown remove active wait state

## Tests

- wait retries update bounded counters, active count and oldest timestamp without ID labels
- wait recovery/termination clear active and oldest state
- failed aggregation submodules remain logged
- `cargo check -p relayer`
- `cargo test -p relayer metadata_wait_metrics_track_retries_oldest_and_recovery_without_id_labels --lib`
- `cargo test -p relayer test_all_build_failures_returns_threshold_not_met --lib`
- `cargo check -p relayer`
- `cargo clippy -p relayer --lib -- -D warnings`
- `cargo fmt --package relayer -- --check`
- `git diff --check`

## Stack and absorbed work

Stacked on #9169, which fixes the routing-cache namespace in the same module. Retarget to `main` after #9169 lands.

This head also absorbs the useful behavior from #8994, with attribution to @haggis-hyperlane:

- demote the per-request EVM and Starknet `fallback_request` logs from DEBUG to TRACE
- demote the non-empty `Popped OpQueue operations` dump from DEBUG to TRACE
- keep the existing structured fields lazy inside the tracing macro; do not eagerly allocate the compact summary that made #8994's Rust tests fail

#8994 can therefore close as superseded by this tested observability stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and retry-logging changes only; no change to message delivery semantics beyond clearer handling of an existing error variant.
> 
> **Overview**
> Cuts **WARN/ERROR noise** from `AwaitingValidatorSignatures` by treating it as a normal retry path instead of an error at every metadata-builder boundary (`#[instrument(err)]` removed on builders; signature waits logged at DEBUG in nested paths).
> 
> **Pending messages** get dedicated handling: first wait **WARN**, repeats **DEBUG**, recovery **INFO**; aggregation fast-path treats signature waits as a DEBUG fallback to other submodules instead of a WARN failure.
> 
> Adds **bounded Prometheus metrics** (`metadata_wait_event_count`, `metadata_wait_active`, `metadata_wait_oldest_timestamp_seconds`) keyed by `app_context` / origin / remote / lifecycle event—no message-ID labels—with in-memory tracking wired through prepare, success, drop, and `finish_metadata_wait`.
> 
> Demotes noisy **DEBUG** spam to **TRACE** for EVM/Starknet RPC `fallback_request` and non-empty `OpQueue` pops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600c6e622d4dfd4552abe21869aa5abaad88c3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->