### PR TITLE
fix(rust): heartbeat idle contract sync tasks

### DIFF
--- a/rust/main/agents/scraper/Cargo.toml
+++ b/rust/main/agents/scraper/Cargo.toml
@@ -37,6 +37,7 @@ hyperlane-base = { path = "../../hyperlane-base", features = ["test-utils"] }
 reqwest.workspace = true
 testcontainers.workspace = true
 testcontainers-modules.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tokio-test = "0.4"
 tracing-test.workspace = true
 ethers-prometheus = { path = "../../ethers-prometheus", features = ["serde"] }

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -12,8 +12,12 @@ use hyperlane_core::{
     rpc_clients::RPC_RETRY_SLEEP_DURATION, Delivery, HyperlaneDomain, HyperlaneLogStore,
     HyperlaneMessage, InterchainGasPayment, SameChainCcrSwap, H512,
 };
-use prometheus::IntGaugeVec;
-use tokio::{sync::mpsc::Receiver as MpscReceiver, task::JoinHandle, time::sleep};
+use prometheus::{IntGauge, IntGaugeVec};
+use tokio::{
+    sync::mpsc::Receiver as MpscReceiver,
+    task::JoinHandle,
+    time::{interval, sleep, MissedTickBehavior},
+};
 use tracing::{info, info_span, instrument, trace, warn, Instrument};
 
 use hyperlane_base::{
@@ -32,6 +36,36 @@ const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
 const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
 const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(60);
 const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
+const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
+
+fn update_liveness_metric(liveness_metric: &IntGauge) {
+    let seconds_since_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    liveness_metric.set(seconds_since_epoch.try_into().unwrap_or(i64::MAX));
+}
+
+async fn sleep_with_liveness(duration: Duration, liveness_metric: &IntGauge) {
+    if duration <= LIVENESS_UPDATE_INTERVAL {
+        sleep(duration).await;
+        return;
+    }
+
+    let sleep = sleep(duration);
+    tokio::pin!(sleep);
+
+    let mut liveness_interval = interval(LIVENESS_UPDATE_INTERVAL);
+    liveness_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    liveness_interval.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = &mut sleep => break,
+            _ = liveness_interval.tick() => update_liveness_metric(liveness_metric),
+        }
+    }
+}
 
 /// A message explorer scraper agent
 #[derive(Debug, AsRef)]
@@ -409,12 +443,7 @@ impl Scraper {
                 let mut max_age_seen_this_scan = 0_u64;
 
                 loop {
-                    liveness_metric.set(
-                        SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .map(|duration| duration.as_secs() as i64)
-                            .unwrap_or_default(),
-                    );
+                    update_liveness_metric(&liveness_metric);
 
                     let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
                         next_after_id,
@@ -433,7 +462,11 @@ impl Scraper {
                         Ok(Ok(result)) if result.candidate_count == 0 => {
                             max_age_metric.set(0);
                             max_age_seen_this_scan = 0;
-                            sleep(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await;
+                            sleep_with_liveness(
+                                RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP,
+                                &liveness_metric,
+                            )
+                            .await;
                         }
                         Ok(Ok(result)) => {
                             next_after_id = result.next_after_id;
@@ -681,6 +714,41 @@ mod test {
     use hyperlane_ethereum as h_eth;
 
     use super::*;
+
+    async fn run_pending_tasks() {
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconciliation_idle_sleep_updates_liveness() {
+        let liveness = IntGauge::new("test_reconcile_liveness", "test reconcile liveness")
+            .expect("test gauge should be valid");
+        let liveness_clone = liveness.clone();
+        let task = tokio::spawn(async move {
+            sleep_with_liveness(Duration::from_secs(65), &liveness_clone).await;
+        });
+
+        run_pending_tasks().await;
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL - Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert_eq!(liveness.get(), 0);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert!(liveness.get() > 0);
+        assert!(!task.is_finished());
+
+        liveness.set(0);
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL).await;
+        run_pending_tasks().await;
+        assert!(liveness.get() > 0);
+        assert!(!task.is_finished());
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        task.await.expect("idle sleep should complete");
+    }
 
     fn generate_test_scraper_settings() -> ScraperSettings {
         let chains = [(

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -81,6 +81,7 @@ color-eyre.workspace = true
 hyper = "0.14"
 reqwest.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-test.workspace = true
 walkdir.workspace = true
 

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -10,7 +10,7 @@ use derive_new::new;
 use eyre::Result;
 use prometheus::core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge};
 use tokio::sync::{mpsc::Receiver as MpscReceiver, Mutex};
-use tokio::time::sleep;
+use tokio::time::{interval, sleep, MissedTickBehavior};
 use tracing::{debug, info, instrument, trace, warn, Instrument};
 
 use hyperlane_core::{
@@ -34,6 +34,7 @@ pub use metrics::ContractSyncMetrics;
 use cursors::ForwardBackwardSequenceAwareSyncCursor;
 
 const SLEEP_DURATION: Duration = Duration::from_secs(5);
+const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, derive_new::new)]
 #[allow(dead_code)]
@@ -203,9 +204,22 @@ where
         stored_logs_metric: GenericCounter<AtomicU64>,
         liveness_metric: GenericGauge<AtomicI64>,
     ) {
+        let mut liveness_interval = interval(LIVENESS_UPDATE_INTERVAL);
+        liveness_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        // The task updates liveness immediately at the top of the loop, so consume
+        // the interval's immediate first tick before waiting for a periodic one.
+        liveness_interval.tick().await;
+
         loop {
             Self::update_liveness_metric(&liveness_metric);
-            let tx_id = match recv.recv().await {
+            let tx_id = match loop {
+                tokio::select! {
+                    tx_id = recv.recv() => break tx_id,
+                    _ = liveness_interval.tick() => {
+                        Self::update_liveness_metric(&liveness_metric);
+                    }
+                }
+            } {
                 Some(tx_id) => tx_id,
                 None => {
                     tracing::error!("Error: channel has closed");
@@ -452,6 +466,12 @@ mod tests {
         )]
     }
 
+    async fn run_pending_tasks() {
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+    }
+
     #[tokio::test]
     async fn dedupe_and_store_logs_returns_logs_and_updates_metric_on_success() {
         let metric = stored_logs_metric();
@@ -558,6 +578,50 @@ mod tests {
 
         task.abort();
         let _ = task.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn tx_id_indexer_task_heartbeats_while_receiver_is_idle() {
+        let store_calls = StdArc::new(AtomicUsize::new(0));
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        let liveness = liveness_metric();
+        let task = tokio::spawn(
+            ContractSync::<HyperlaneMessage, StoreResult, MockIndexer>::tx_id_indexer_task(
+                test_domain(),
+                MockIndexer::default(),
+                Arc::new(Mutex::new(StoreResult {
+                    stored: 0,
+                    error: None,
+                    calls: Some(store_calls.clone()),
+                })),
+                receiver,
+                stored_logs_metric(),
+                liveness.clone(),
+            ),
+        );
+
+        run_pending_tasks().await;
+        liveness.set(0);
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL - Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert_eq!(liveness.get(), 0);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert!(liveness.get() > 0);
+        assert_eq!(store_calls.load(Ordering::SeqCst), 0);
+        assert!(!task.is_finished());
+
+        sender
+            .send(H512::zero())
+            .await
+            .expect("idle receiver should remain connected");
+        run_pending_tasks().await;
+        assert_eq!(store_calls.load(Ordering::SeqCst), 1);
+
+        drop(sender);
+        task.await
+            .expect("task should stop when its channel closes");
     }
 }
 


### PR DESCRIPTION
## Summary

- heartbeat contract-sync tx-ID tasks while their channel is healthy but idle
- heartbeat scraper raw-dispatch reconcilers during the 60s idle sleep
- leave short backlog/retry sleeps on the existing plain timer path
- preserve stale liveness during long RPC/DB work so genuinely stuck operations still alert

## Production evidence

The current tx-ID task updates `contract_sync_liveness` immediately before `recv().await`. On an idle healthy channel it can then wait indefinitely: 94 observed series had an age close to the scraper pod lifetime (~210k seconds), making the metric unable to distinguish idle from dead.

Raw-dispatch reconcilers update before querying and then sleep for 60s when idle. In the live sample, 79 per-chain reconcile series were older than 65s; long queries can still be real failures, but the sleep itself should not consume nearly the entire alert budget.

This patch uses the existing metric and labels. It does not add cardinality or claim load reduction.

## Behaviour

- idle channel/sleep: liveness refreshes every 30s
- queued tx ID: still handled immediately; no buffer or backpressure change
- channel closure: task still exits
- active provider/DB call: no synthetic heartbeat, so a stuck call still goes stale
- 2s backlog and fixed retry sleeps: unchanged plain sleep

## Tests

- paused-time tx-ID test proves two idle heartbeats, zero store calls, then normal message handling and channel closure
- paused-time reconcile-sleep test proves heartbeats during a 65s idle wait
- `cargo test -p hyperlane-base tx_id_indexer_task_heartbeats_while_receiver_is_idle` (1 passed)
- `cargo test -p scraper reconciliation_idle_sleep_updates_liveness` (1 passed)
- `cargo check -p hyperlane-base -p scraper`
- `cargo clippy -p hyperlane-base -p scraper -- -D warnings`
- `cargo fmt --package hyperlane-base --package scraper -- --check`
- `git diff --check`

Related: #9216 changes fetch-error retry behaviour in the same contract-sync module; this PR only fixes health-signal semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only timing changes around existing metrics; indexing and reconciliation logic are unchanged aside from how liveness is updated during idle waits.
> 
> **Overview**
> Fixes **contract sync liveness** so idle-but-healthy work no longer looks dead in Prometheus.
> 
> **Contract sync (`tx_id_indexer_task`)** now refreshes `contract_sync_liveness` every **30s** while blocked on an empty MPSC channel, using `tokio::select!` between `recv()` and an interval tick. Incoming tx IDs are still handled immediately; **RPC/DB work does not get synthetic heartbeats**, so a stuck fetch/store can still go stale.
> 
> **Scraper raw-dispatch reconciliation** uses new **`sleep_with_liveness`** for the **60s** idle sleep so liveness updates during long waits; **2s** backlog/retry sleeps stay on plain `sleep`. Liveness updates are centralized in **`update_liveness_metric`**.
> 
> Adds **paused-time tests** for both paths and enables **`tokio` `test-util`** in dev-dependencies for `hyperlane-base` and `scraper`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839c6233085ec7d7d099dedcd13a70716b94522d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->