### PR TITLE
perf(rust): back off idle Lander reorg polling

### DIFF
--- a/rust/main/lander/Cargo.toml
+++ b/rust/main/lander/Cargo.toml
@@ -53,6 +53,7 @@ sbor = { workspace = true, features = ["serde"] }
 scrypto = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
 tracing-test.workspace = true
 mockall.workspace = true

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -182,6 +182,7 @@ impl FinalityStage {
                 update_tx_status(state, &mut tx, tx_status).await?;
                 Self::record_reverted_payloads(&mut tx, state).await?;
                 state.adapter.post_finalized().await?;
+                state.notify_reprocess_txs_activity();
                 let tx_uuid = tx.uuid.clone();
                 info!(?tx_uuid, "Transaction is finalized");
                 let _ = pool.remove(&tx_uuid).await;

--- a/rust/main/lander/src/dispatcher/stages/finality_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage/tests.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::tests::test_utils::{
-    are_all_txs_in_pool, are_no_txs_in_pool, create_random_txs_and_store_them, tmp_dbs, MockAdapter,
+    are_all_txs_in_pool, are_no_txs_in_pool, create_random_txs_and_store_them, dummy_tx, tmp_dbs,
+    MockAdapter,
 };
 use crate::{
     dispatcher::{metrics::DispatcherMetrics, PayloadDb, TransactionDb},
@@ -288,6 +289,39 @@ async fn test_post_finalized_not_called_when_tx_not_finalized() {
     // verify transactions remain in pool (not finalized)
     assert_eq!(txs_removed_from_pool.len(), 0);
     assert!(are_all_txs_in_pool(txs_created.clone(), &pool).await);
+}
+
+#[tokio::test]
+async fn test_successful_post_finalized_notifies_reprocess_poller() {
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter.expect_tx_status().times(0);
+    mock_adapter
+        .expect_reverted_payloads()
+        .returning(|_| Ok(Vec::new()));
+    mock_adapter.expect_post_finalized().returning(|| Ok(()));
+
+    let (payload_db, tx_db, _) = tmp_dbs();
+    let state = DispatcherState::new(
+        payload_db,
+        tx_db,
+        Arc::new(mock_adapter),
+        DispatcherMetrics::dummy_instance(),
+        "test".to_string(),
+    );
+    let tx = dummy_tx(Vec::new(), TransactionStatus::Finalized);
+    let pool = FinalityStagePool::new();
+    pool.insert(tx.clone()).await;
+
+    FinalityStage::try_process_tx(tx, pool, BuildingStageQueue::new(), &state)
+        .await
+        .unwrap();
+
+    tokio::time::timeout(
+        Duration::from_millis(10),
+        state.wait_for_reprocess_txs_activity(),
+    )
+    .await
+    .expect("finalization activity notification was not retained");
 }
 
 async fn set_up_test_and_run_stage(

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -30,6 +30,9 @@ pub type InclusionStagePool = Arc<Mutex<HashMap<TransactionUuid, Transaction>>>;
 pub const STAGE_NAME: &str = "InclusionStage";
 
 const MIN_TX_STATUS_CHECK_DELAY: Duration = Duration::from_millis(100);
+const REPROCESS_TXS_LIVENESS_RATE: Duration = Duration::from_secs(5);
+// Bounds idle reorg-detection latency without reducing the liveness heartbeat rate.
+const MAX_REPROCESS_TXS_POLL_RATE: Duration = Duration::from_secs(5 * 60);
 
 pub struct InclusionStage {
     pub(crate) pool: InclusionStagePool,
@@ -196,18 +199,34 @@ impl InclusionStage {
         pool: InclusionStagePool,
         state: DispatcherState,
     ) -> Result<(), LanderError> {
-        let poll_rate = match state.adapter.reprocess_txs_poll_rate() {
+        let base_poll_rate = match state.adapter.reprocess_txs_poll_rate() {
             Some(s) => s,
             // if no poll rate, then that means we don't worry about reprocessing txs
             None => return Ok(()),
         };
+        let max_poll_rate = MAX_REPROCESS_TXS_POLL_RATE.max(base_poll_rate);
+        let mut poll_rate = base_poll_rate;
+        let liveness_stage = format!("{STAGE_NAME}::receive_reprocess_txs");
         loop {
-            state.metrics.update_liveness_metric(
-                format!("{STAGE_NAME}::receive_reprocess_txs").as_str(),
-                &domain,
-            );
+            state
+                .metrics
+                .update_liveness_metric(&liveness_stage, &domain);
 
-            tokio::time::sleep(poll_rate).await;
+            let poll_sleep = tokio::time::sleep(poll_rate);
+            tokio::pin!(poll_sleep);
+            let woke_for_activity = loop {
+                tokio::select! {
+                    biased;
+                    _ = state.wait_for_reprocess_txs_activity() => break true,
+                    _ = &mut poll_sleep => break false,
+                    _ = tokio::time::sleep(REPROCESS_TXS_LIVENESS_RATE) => {
+                        state.metrics.update_liveness_metric(&liveness_stage, &domain);
+                    },
+                }
+            };
+            if woke_for_activity {
+                poll_rate = base_poll_rate;
+            }
             tracing::debug!(
                 domain,
                 "Checking for any transactions that needs reprocessing"
@@ -215,12 +234,21 @@ impl InclusionStage {
 
             let txs = match state.adapter.get_reprocess_txs().await {
                 Ok(s) => s,
-                _ => continue,
+                Err(err) => {
+                    poll_rate = base_poll_rate;
+                    warn!(
+                        ?err,
+                        domain, "Failed to check for transactions that need reprocessing"
+                    );
+                    continue;
+                }
             };
             if txs.is_empty() {
+                poll_rate = poll_rate.saturating_mul(2).min(max_poll_rate);
                 continue;
             }
 
+            poll_rate = base_poll_rate;
             tracing::debug!(?txs, "Reprocessing transactions");
             let mut locked_pool = pool.lock().await;
             for tx in txs {
@@ -401,7 +429,7 @@ impl InclusionStage {
         // by the node.
         // at this point, not all VMs return information about whether the tx was reverted.
         // so dropping reverted payloads has to happen in the finality step
-        call_until_success_or_nonretryable_error(
+        let submitted_tx = call_until_success_or_nonretryable_error(
             || {
                 let tx_shared_clone = tx_shared.clone();
                 async move {
@@ -420,7 +448,10 @@ impl InclusionStage {
             },
             "Submitting transaction",
             state,
-        ).await
+        )
+        .await?;
+        state.notify_reprocess_txs_activity();
+        Ok(submitted_tx)
     }
 
     async fn estimate_tx(

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -11,9 +14,221 @@ use crate::dispatcher::{
 use crate::error::LanderError;
 use crate::payload::{DropReason as PayloadDropReason, PayloadStatus};
 use crate::tests::test_utils::{
-    are_all_txs_in_pool, are_no_txs_in_pool, create_random_txs_and_store_them, tmp_dbs, MockAdapter,
+    are_all_txs_in_pool, are_no_txs_in_pool, create_random_txs_and_store_them, dummy_tx, tmp_dbs,
+    MockAdapter,
 };
 use crate::transaction::{DropReason as TxDropReason, Transaction, TransactionStatus};
+
+use super::{MAX_REPROCESS_TXS_POLL_RATE, REPROCESS_TXS_LIVENESS_RATE, STAGE_NAME};
+
+async fn yield_to_reprocess_task() {
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+}
+
+fn reprocess_test_state(mock_adapter: MockAdapter) -> (DispatcherState, InclusionStagePool) {
+    let (payload_db, tx_db, _) = tmp_dbs();
+    let state = DispatcherState::new(
+        payload_db,
+        tx_db,
+        Arc::new(mock_adapter),
+        DispatcherMetrics::dummy_instance(),
+        "test".to_string(),
+    );
+    (state, Default::default())
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_reprocess_empty_results_back_off_to_bounded_poll_rate() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_mock = calls.clone();
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_reprocess_txs_poll_rate()
+        .return_const(Some(Duration::from_secs(5)));
+    mock_adapter.expect_get_reprocess_txs().returning(move || {
+        calls_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    });
+    let (state, pool) = reprocess_test_state(mock_adapter);
+
+    let task = tokio::spawn(InclusionStage::receive_reprocess_txs(
+        "test".to_string(),
+        pool,
+        state,
+    ));
+    yield_to_reprocess_task().await;
+
+    for (expected_calls, delay) in [5, 10, 20, 40, 80, 160, 300, 300].into_iter().enumerate() {
+        tokio::time::advance(Duration::from_secs(delay - 1)).await;
+        yield_to_reprocess_task().await;
+        assert_eq!(calls.load(Ordering::SeqCst), expected_calls);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        yield_to_reprocess_task().await;
+        assert_eq!(calls.load(Ordering::SeqCst), expected_calls + 1);
+    }
+
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_reprocess_activity_wakeup_is_coalesced_and_resets_backoff() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_mock = calls.clone();
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_reprocess_txs_poll_rate()
+        .return_const(Some(Duration::from_secs(5)));
+    mock_adapter.expect_get_reprocess_txs().returning(move || {
+        calls_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    });
+    let (state, pool) = reprocess_test_state(mock_adapter);
+
+    // A notification just before the poller waits is retained. Multiple local
+    // activity notifications coalesce into one immediate check.
+    state.notify_reprocess_txs_activity();
+    state.notify_reprocess_txs_activity();
+    let task = tokio::spawn(InclusionStage::receive_reprocess_txs(
+        "test".to_string(),
+        pool,
+        state.clone(),
+    ));
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    tokio::time::advance(Duration::from_secs(10)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    // The poller is now waiting for 20s. Activity wakes it halfway through,
+    // then the successful empty check starts backoff again from the 5s base.
+    tokio::time::advance(Duration::from_secs(10)).await;
+    state.notify_reprocess_txs_activity();
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+
+    tokio::time::advance(Duration::from_secs(9)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+    tokio::time::advance(Duration::from_secs(1)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_reprocess_long_idle_wait_keeps_liveness_without_polling() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_mock = calls.clone();
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_reprocess_txs_poll_rate()
+        .return_const(Some(MAX_REPROCESS_TXS_POLL_RATE));
+    mock_adapter.expect_get_reprocess_txs().returning(move || {
+        calls_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    });
+    let (state, pool) = reprocess_test_state(mock_adapter);
+    let metrics = state.metrics.clone();
+    let stage = format!("{STAGE_NAME}::receive_reprocess_txs");
+    let task = tokio::spawn(InclusionStage::receive_reprocess_txs(
+        "test".to_string(),
+        pool,
+        state.clone(),
+    ));
+    yield_to_reprocess_task().await;
+
+    metrics
+        .task_liveness
+        .remove_label_values(&["test", &stage])
+        .unwrap();
+    assert!(!String::from_utf8(metrics.gather().unwrap())
+        .unwrap()
+        .contains(&stage));
+
+    tokio::time::advance(REPROCESS_TXS_LIVENESS_RATE).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(String::from_utf8(metrics.gather().unwrap())
+        .unwrap()
+        .contains(&stage));
+
+    state.notify_reprocess_txs_activity();
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    task.abort();
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_reprocess_nonempty_and_error_results_reset_backoff() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_mock = calls.clone();
+    let reprocessed_tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    let tx_for_mock = reprocessed_tx.clone();
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_reprocess_txs_poll_rate()
+        .return_const(Some(Duration::from_secs(5)));
+    mock_adapter.expect_get_reprocess_txs().returning(move || {
+        let call = calls_for_mock.fetch_add(1, Ordering::SeqCst) + 1;
+        match call {
+            2 => Err(LanderError::NetworkError("test error".to_string())),
+            4 => Ok(vec![tx_for_mock.clone()]),
+            _ => Ok(Vec::new()),
+        }
+    });
+    let (state, pool) = reprocess_test_state(mock_adapter);
+    let task = tokio::spawn(InclusionStage::receive_reprocess_txs(
+        "test".to_string(),
+        pool.clone(),
+        state,
+    ));
+    yield_to_reprocess_task().await;
+
+    tokio::time::advance(Duration::from_secs(5)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    tokio::time::advance(Duration::from_secs(10)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+    // An error restores the 5s base instead of suppressing retries.
+    tokio::time::advance(Duration::from_secs(5)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+    tokio::time::advance(Duration::from_secs(10)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 4);
+    assert!(pool.lock().await.contains_key(&reprocessed_tx.uuid));
+
+    // Finding work also restores the 5s base.
+    tokio::time::advance(Duration::from_secs(5)).await;
+    yield_to_reprocess_task().await;
+    assert_eq!(calls.load(Ordering::SeqCst), 5);
+
+    task.abort();
+}
+
+#[tokio::test]
+async fn test_successful_submission_notifies_reprocess_poller() {
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter.expect_submit().returning(|_| Ok(()));
+    let (state, _) = reprocess_test_state(mock_adapter);
+    let tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+
+    InclusionStage::submit_tx(&tx, &state).await.unwrap();
+
+    tokio::time::timeout(
+        Duration::from_millis(10),
+        state.wait_for_reprocess_txs_activity(),
+    )
+    .await
+    .expect("submission activity notification was not retained");
+}
 
 #[tokio::test]
 async fn test_processing_included_txs() {

--- a/rust/main/lander/src/dispatcher/stages/state.rs
+++ b/rust/main/lander/src/dispatcher/stages/state.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 use chrono::format;
 use derive_new::new;
 use eyre::Result;
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, Notify},
+    task::JoinHandle,
+};
 use tracing::{error, info, instrument, instrument::Instrumented, warn};
 
 use hyperlane_base::{
@@ -34,6 +37,7 @@ pub struct DispatcherState {
     pub(crate) adapter: Arc<dyn AdaptsChain>,
     pub(crate) metrics: DispatcherMetrics,
     pub(crate) domain: String,
+    reprocess_txs_wakeup: Arc<Notify>,
 }
 
 impl DispatcherState {
@@ -50,7 +54,16 @@ impl DispatcherState {
             adapter,
             metrics,
             domain,
+            reprocess_txs_wakeup: Arc::new(Notify::new()),
         }
+    }
+
+    pub(crate) fn notify_reprocess_txs_activity(&self) {
+        self.reprocess_txs_wakeup.notify_one();
+    }
+
+    pub(crate) async fn wait_for_reprocess_txs_activity(&self) {
+        self.reprocess_txs_wakeup.notified().await;
     }
 
     pub async fn try_from_settings(


### PR DESCRIPTION
## Summary

- back off successful empty Lander reorg polls from the chain's base interval to a five-minute cap
- wake immediately after successful local submission/finalization activity, then restart empty-result backoff from the base interval
- reset to the base interval on errors or recovered transactions
- keep the durable finalized-nonce regression range from #9219 as the source of truth

## Why this is stacked

This branch is based on #9219. Before that fix, another nonce-boundary updater could consume the downward transition before the reprocessor saw it. Slowing the transient comparison would widen a correctness race. #9219 persists the regression before boundary updates, so notifications are an optimization rather than a correctness dependency.

## Production evidence

Current relayers make about 1.381m `eth_getTransactionCount` calls/day from the fixed Lander reorg poll, 99.88% successful. Seven daily snapshots are stable at 1.380m–1.390m/day. All 229 records in a fresh five-minute GCP sample carried `receive_reprocess_txs_task`; no other nonce-read path appeared.

The 92 live EVM destination instances' configured fixed cadence models 1.494m scheduled logical checks/day. A continuously idle instance falls to 288 checks/day at the five-minute cap, so the aggregate idle scheduled component becomes 26,496/day: 98.2% fewer. Real submission/finalization wakeups and provider-error reads remain. This is a pre-deploy model, not observed saving.

## Liveness/correctness boundaries

- successful local submit/finalization retains a coalesced wake permit and resets to base polling
- notifications before or during sleep cannot be lost; repeated notifications may coalesce
- empty success doubles the delay; nonempty/error resets it
- external-only regression detection remains bounded to `max(base interval, five minutes)`; all 92 current EVM bases are below the cap
- pending reorg ranges remain durable until finalized recovery; notification loss cannot lose the range
- the task's existing liveness metric continues heartbeating during long idle waits

## Tests

- exact 5/10/20/.../300s empty-poll call counts and cap
- notification before and during wait wakes without loss; repeated activity coalesces
- nonempty/error resets to base interval
- submission/finalization paths send wake notifications
- long idle backoff continues liveness heartbeats
- `cargo test -p lander --lib` (322 passed, 1 ignored)
- focused `reprocess` tests (8 passed)
- fresh focused follow-up: six adaptive-poll/reset/liveness/submission/finalization tests passed
- `cargo check -p lander`
- `cargo clippy -p lander --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Stacked on #9219.

## Superseded work

Together with base #9219, this replaces #8243. #9219 owns durable correctness; this PR owns adaptive polling and wakeups. The older manual intervention API is intentionally omitted rather than becoming a second reprocessing owner.
