### PR TITLE
fix(validator): back off failed announcement retries

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -4278,7 +4278,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -4381,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?tag=2026-01-23#c7da47b76dc5ba0540dc26f509d5912fcfdf7a80"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -4192,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "Inflector",
  "cfg-if",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -4278,7 +4278,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "ethers-core",
  "getrandom 0.2.15",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "async-trait",
  "auto_impl 0.5.0",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "async-trait",
  "auto_impl 1.2.0",
@@ -4381,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "1.0.2"
-source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=8885b1a90908b2354239a08874f69f0d44e88573#8885b1a90908b2354239a08874f69f0d44e88573"
+source = "git+https://github.com/hyperlane-xyz/ethers-rs?rev=3d086015c0a41657122bcc784ac9ea5f8cb37160#3d086015c0a41657122bcc784ac9ea5f8cb37160"
 dependencies = [
  "async-trait",
  "coins-bip32 0.7.0",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -276,27 +276,27 @@ tag = "2025-08-07"
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+rev = "8885b1a90908b2354239a08874f69f0d44e88573"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+rev = "8885b1a90908b2354239a08874f69f0d44e88573"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+rev = "8885b1a90908b2354239a08874f69f0d44e88573"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+rev = "8885b1a90908b2354239a08874f69f0d44e88573"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-tag = "2026-01-23"
+rev = "8885b1a90908b2354239a08874f69f0d44e88573"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"
@@ -312,4 +312,3 @@ version = "=0.12.1"
 branch = "hyperlane"
 git = "https://github.com/hyperlane-xyz/parity-common.git"
 version = "=0.5.2"
-

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -276,27 +276,27 @@ tag = "2025-08-07"
 [workspace.dependencies.ethers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-rev = "8885b1a90908b2354239a08874f69f0d44e88573"
+rev = "3d086015c0a41657122bcc784ac9ea5f8cb37160"
 
 [workspace.dependencies.ethers-contract]
 features = ["legacy"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-rev = "8885b1a90908b2354239a08874f69f0d44e88573"
+rev = "3d086015c0a41657122bcc784ac9ea5f8cb37160"
 
 [workspace.dependencies.ethers-core]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-rev = "8885b1a90908b2354239a08874f69f0d44e88573"
+rev = "3d086015c0a41657122bcc784ac9ea5f8cb37160"
 
 [workspace.dependencies.ethers-providers]
 features = []
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-rev = "8885b1a90908b2354239a08874f69f0d44e88573"
+rev = "3d086015c0a41657122bcc784ac9ea5f8cb37160"
 
 [workspace.dependencies.ethers-signers]
 features = ["aws"]
 git = "https://github.com/hyperlane-xyz/ethers-rs"
-rev = "8885b1a90908b2354239a08874f69f0d44e88573"
+rev = "3d086015c0a41657122bcc784ac9ea5f8cb37160"
 
 [patch.crates-io.curve25519-dalek]
 branch = "v3.2.2-relax-zeroize"

--- a/rust/main/agents/validator/Cargo.toml
+++ b/rust/main/agents/validator/Cargo.toml
@@ -22,6 +22,7 @@ futures.workspace = true
 futures-util.workspace = true
 itertools.workspace = true
 prometheus.workspace = true
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -45,7 +46,6 @@ rusoto_core = '*'
 [dev-dependencies]
 http-body-util.workspace = true
 mockall.workspace = true
-rand.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tokio-test.workspace = true

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -89,6 +89,21 @@ impl AnnouncementRetryBackoff {
             .is_none_or(|next_funding_check_at| now >= next_funding_check_at)
     }
 
+    /// Poll funding between attempts only when the last successful preflight proved the signer is
+    /// unfunded. If preflight is unavailable (for example, an RPC does not support `feeHistory`),
+    /// retrying it on a separate timer cannot detect funding and only creates more failed calls.
+    fn should_check_funding(&self, now: Instant) -> bool {
+        if self.submission_in_flight {
+            return false;
+        }
+
+        self.ready(now)
+            || (self
+                .last_tokens_needed
+                .is_some_and(|tokens_needed| !tokens_needed.is_zero())
+                && self.funding_check_due(now))
+    }
+
     fn record_funding_check(&mut self, now: Instant) {
         self.next_funding_check_at = now.checked_add(ANNOUNCEMENT_FUNDING_POLL_INTERVAL);
     }
@@ -1260,7 +1275,7 @@ impl Validator {
                     let chain_signer_string = chain_signer.address_string();
                     let chain_signer_h256 = chain_signer.address_h256();
                     let now = Instant::now();
-                    if !retry_backoff.funding_check_due(now) {
+                    if !retry_backoff.should_check_funding(now) {
                         sleep(self.interval).await;
                         continue;
                     }
@@ -1285,15 +1300,17 @@ impl Validator {
                         if let Some(balance_delta) =
                             effective_balance_delta.filter(|balance_delta| !balance_delta.is_zero())
                         {
+                            let delay = Self::jittered_announcement_retry_delay(
+                                retry_backoff.next_failure_delay(),
+                            );
                             warn!(
                                 tokens_needed=%balance_delta,
                                 eth_validator_address=?announcement.validator,
                                 ?chain_signer_string,
                                 ?chain_signer_h256,
+                                retry_delay_ms=delay.as_millis(),
+                                consecutive_failures=retry_backoff.consecutive_failures.saturating_add(1),
                                 "Please send tokens to your chain signer address to announce",
-                            );
-                            let delay = Self::jittered_announcement_retry_delay(
-                                retry_backoff.next_failure_delay(),
                             );
                             retry_backoff.record_failure(Instant::now(), delay);
                         } else {
@@ -1333,6 +1350,12 @@ impl Validator {
                             } else {
                                 let delay = Self::jittered_announcement_retry_delay(
                                     retry_backoff.next_failure_delay(),
+                                );
+                                info!(
+                                    retry_delay_ms = delay.as_millis(),
+                                    consecutive_failures =
+                                        retry_backoff.consecutive_failures.saturating_add(1),
+                                    "Scheduled validator announcement retry",
                                 );
                                 retry_backoff.record_failure(Instant::now(), delay);
                             }
@@ -1490,17 +1513,45 @@ mod tests {
     async fn funding_preflight_uses_bounded_polling_while_submission_backs_off() {
         let mut backoff = AnnouncementRetryBackoff::default();
         let now = Instant::now();
-        assert!(backoff.funding_check_due(now));
+        assert!(!backoff.observe_tokens_needed(Some(U256::from(1_u64))));
+        backoff.record_failure(now, ANNOUNCEMENT_RETRY_MAX_DELAY);
+        assert!(backoff.should_check_funding(now));
         backoff.record_funding_check(now);
-        assert!(!backoff.funding_check_due(now));
+        assert!(!backoff.should_check_funding(now));
 
         let before_poll = ANNOUNCEMENT_FUNDING_POLL_INTERVAL
             .checked_sub(Duration::from_millis(1))
             .expect("funding poll interval exceeds one millisecond");
         tokio::time::advance(before_poll).await;
-        assert!(!backoff.funding_check_due(Instant::now()));
+        assert!(!backoff.should_check_funding(Instant::now()));
         tokio::time::advance(Duration::from_millis(1)).await;
-        assert!(backoff.funding_check_due(Instant::now()));
+        assert!(backoff.should_check_funding(Instant::now()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unavailable_funding_preflight_waits_for_submission_retry_deadline() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        backoff.record_funding_check(now);
+        backoff.record_failure(now, ANNOUNCEMENT_RETRY_MAX_DELAY);
+
+        assert_eq!(backoff.last_tokens_needed, None);
+        assert!(!backoff.should_check_funding(now));
+        tokio::time::advance(ANNOUNCEMENT_RETRY_MAX_DELAY).await;
+        assert!(backoff.should_check_funding(Instant::now()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn funded_preflight_waits_for_submission_retry_deadline() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        assert!(!backoff.observe_tokens_needed(Some(U256::zero())));
+        backoff.record_funding_check(now);
+        backoff.record_failure(now, ANNOUNCEMENT_RETRY_MAX_DELAY);
+
+        assert!(!backoff.should_check_funding(now));
+        tokio::time::advance(ANNOUNCEMENT_RETRY_MAX_DELAY).await;
+        assert!(backoff.should_check_funding(Instant::now()));
     }
 
     #[tokio::test(start_paused = true)]
@@ -1513,8 +1564,10 @@ mod tests {
         backoff.mark_submission_in_flight();
         assert_eq!(backoff.consecutive_failures, 0);
         assert!(!backoff.ready(now));
+        assert!(!backoff.should_check_funding(now));
         tokio::time::advance(ANNOUNCEMENT_RETRY_MAX_DELAY.saturating_mul(10)).await;
         assert!(!backoff.ready(Instant::now()));
+        assert!(!backoff.should_check_funding(Instant::now()));
 
         // Delayed zero preflight or a transient unfunded/funded flap cannot erase in-flight state.
         assert!(!backoff.observe_tokens_needed(Some(U256::from(1_u64))));

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -11,10 +11,11 @@ use derive_more::AsRef;
 use ethers::utils::keccak256;
 use eyre::{eyre, Result};
 use futures_util::future::{join_all, try_join_all};
+use rand::Rng;
 use serde::Serialize;
 use tokio::{
     task::JoinHandle,
-    time::{sleep, timeout},
+    time::{sleep, timeout, Instant},
 };
 use tracing::{debug, error, info, info_span, warn, Instrument};
 use url::Url;
@@ -33,7 +34,7 @@ use hyperlane_core::{
     Announcement, ChainCommunicationError, ChainResult, Checkpoint, CheckpointAtBlock,
     HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneSigner, HyperlaneSignerExt,
     IncrementalMerkleAtBlock, Mailbox, MerkleTreeHook, MerkleTreeInsertion, ReorgPeriod, TxOutcome,
-    ValidatorAnnounce, H256, U256,
+    ValidatorAnnounce, ValidatorAnnounceSubmission, H256, U256,
 };
 use hyperlane_ethereum::{RpcConnectionConf, Signers, SingletonSigner, SingletonSignerHandle};
 use hyperlane_metric::prometheus_metric::RpcRole;
@@ -48,6 +49,110 @@ use crate::{
 };
 
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
+
+const ANNOUNCEMENT_RETRY_MIN_DELAY: Duration = Duration::from_secs(30);
+const ANNOUNCEMENT_RETRY_MAX_DELAY: Duration = Duration::from_secs(900);
+const ANNOUNCEMENT_FUNDING_POLL_INTERVAL: Duration = Duration::from_secs(30);
+const ANNOUNCEMENT_RETRY_MIN_JITTER_PERMILLE: u32 = 800;
+const ANNOUNCEMENT_RETRY_MAX_JITTER_PERMILLE: u32 = 1000;
+
+/// Keeps announcement submission and unfunded warnings off the validator's hot poll loop while
+/// still allowing that loop to observe funding and on-chain announcement progress promptly.
+#[derive(Debug, Default)]
+struct AnnouncementRetryBackoff {
+    consecutive_failures: u32,
+    next_attempt_at: Option<Instant>,
+    next_funding_check_at: Option<Instant>,
+    last_tokens_needed: Option<U256>,
+    consecutive_unfunded_observations: u8,
+    funding_reset_armed: bool,
+    submission_in_flight: bool,
+}
+
+impl AnnouncementRetryBackoff {
+    fn ready(&self, now: Instant) -> bool {
+        !self.submission_in_flight
+            && self
+                .next_attempt_at
+                .is_none_or(|next_attempt_at| now >= next_attempt_at)
+    }
+
+    fn next_failure_delay(&self) -> Duration {
+        let multiplier = 2_u32.saturating_pow(self.consecutive_failures.min(31));
+        ANNOUNCEMENT_RETRY_MIN_DELAY
+            .saturating_mul(multiplier)
+            .min(ANNOUNCEMENT_RETRY_MAX_DELAY)
+    }
+
+    fn funding_check_due(&self, now: Instant) -> bool {
+        self.next_funding_check_at
+            .is_none_or(|next_funding_check_at| now >= next_funding_check_at)
+    }
+
+    fn record_funding_check(&mut self, now: Instant) {
+        self.next_funding_check_at = now.checked_add(ANNOUNCEMENT_FUNDING_POLL_INTERVAL);
+    }
+
+    fn jittered(delay: Duration, jitter_permille: u32) -> Duration {
+        let bounded_jitter = jitter_permille.clamp(
+            ANNOUNCEMENT_RETRY_MIN_JITTER_PERMILLE,
+            ANNOUNCEMENT_RETRY_MAX_JITTER_PERMILLE,
+        );
+        let millis = delay
+            .as_millis()
+            .saturating_mul(u128::from(bounded_jitter))
+            .checked_div(u128::from(ANNOUNCEMENT_RETRY_MAX_JITTER_PERMILLE))
+            .unwrap_or_default();
+        Duration::from_millis(u64::try_from(millis).unwrap_or(u64::MAX))
+    }
+
+    fn record_failure(&mut self, now: Instant, delay: Duration) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        self.next_attempt_at = now.checked_add(delay);
+    }
+
+    fn mark_submission_in_flight(&mut self) {
+        self.consecutive_failures = 0;
+        self.next_attempt_at = None;
+        self.submission_in_flight = true;
+    }
+
+    /// A transition to a preflight-confirmed funded state is actionable progress: allow an
+    /// immediate attempt even if earlier failures were cooling down. Missing preflight data does
+    /// not erase the last known state, preventing intermittent RPC errors from defeating backoff.
+    fn observe_tokens_needed(&mut self, tokens_needed: Option<U256>) -> bool {
+        let Some(tokens_needed) = tokens_needed else {
+            return false;
+        };
+
+        let became_funded = if tokens_needed.is_zero() {
+            self.consecutive_unfunded_observations = 0;
+            let became_funded = self.funding_reset_armed;
+            self.funding_reset_armed = false;
+            became_funded
+        } else {
+            self.consecutive_unfunded_observations =
+                self.consecutive_unfunded_observations.saturating_add(1);
+            if self.consecutive_unfunded_observations >= 2 {
+                self.funding_reset_armed = true;
+            }
+            false
+        };
+        self.last_tokens_needed = Some(tokens_needed);
+        if became_funded {
+            self.consecutive_failures = 0;
+            self.next_attempt_at = None;
+        }
+        became_funded
+    }
+
+    /// Use the last successful preflight result when the current preflight is unavailable. In
+    /// particular, a transient estimation failure must not turn a known-unfunded signer into a
+    /// submission attempt.
+    fn effective_tokens_needed(&self, current: Option<U256>) -> Option<U256> {
+        current.or(self.last_tokens_needed)
+    }
+}
 
 /// Caps how long any single quorum/base-hook RPC call can take, so one hanging endpoint
 /// can't stall a safety-critical read (and therefore checkpoint signing) indefinitely.
@@ -1074,6 +1179,18 @@ impl Validator {
         }
     }
 
+    fn announcement_submission_may_be_in_flight(
+        result: &ChainResult<ValidatorAnnounceSubmission>,
+    ) -> bool {
+        matches!(
+            result,
+            Ok(ValidatorAnnounceSubmission::Confirmed(outcome)) if outcome.executed
+        ) || matches!(
+            result,
+            Ok(ValidatorAnnounceSubmission::BroadcastError { .. })
+        )
+    }
+
     async fn metadata(&self) -> Result<()> {
         let serialized_metadata = serde_json::to_string_pretty(&self.agent_metadata)?;
         self.checkpoint_syncer
@@ -1111,6 +1228,7 @@ impl Validator {
         // which the validator is signing checkpoints but has not announced
         // their locations, which makes them functionally unusable.
         let validators: [H256; 1] = [address.into()];
+        let mut retry_backoff = AnnouncementRetryBackoff::default();
         loop {
             info!("Checking for validator announcement");
             if let Some(locations) = self
@@ -1141,27 +1259,84 @@ impl Validator {
                 {
                     let chain_signer_string = chain_signer.address_string();
                     let chain_signer_h256 = chain_signer.address_h256();
-                    info!(eth_validator_address=?announcement.validator, ?chain_signer_string, ?chain_signer_h256, "Attempting self announce");
+                    let now = Instant::now();
+                    if !retry_backoff.funding_check_due(now) {
+                        sleep(self.interval).await;
+                        continue;
+                    }
+                    retry_backoff.record_funding_check(now);
 
                     let balance_delta = self
                         .validator_announce
                         .announce_tokens_needed(signed_announcement.clone(), chain_signer_h256)
-                        .await
-                        .unwrap_or_default();
-                    if balance_delta > U256::zero() {
-                        warn!(
-                            tokens_needed=%balance_delta,
+                        .await;
+                    if retry_backoff.observe_tokens_needed(balance_delta) {
+                        info!(
                             eth_validator_address=?announcement.validator,
                             ?chain_signer_string,
                             ?chain_signer_h256,
-                            "Please send tokens to your chain signer address to announce",
+                            "Validator chain signer is funded; resetting announcement retry backoff",
                         );
-                    } else {
-                        let result = self
-                            .validator_announce
-                            .announce(signed_announcement.clone())
-                            .await;
-                        Self::log_on_announce_failure(result, &chain_signer_string);
+                    }
+
+                    let effective_balance_delta =
+                        retry_backoff.effective_tokens_needed(balance_delta);
+                    if retry_backoff.ready(Instant::now()) {
+                        if let Some(balance_delta) =
+                            effective_balance_delta.filter(|balance_delta| !balance_delta.is_zero())
+                        {
+                            warn!(
+                                tokens_needed=%balance_delta,
+                                eth_validator_address=?announcement.validator,
+                                ?chain_signer_string,
+                                ?chain_signer_h256,
+                                "Please send tokens to your chain signer address to announce",
+                            );
+                            let delay = Self::jittered_announcement_retry_delay(
+                                retry_backoff.next_failure_delay(),
+                            );
+                            retry_backoff.record_failure(Instant::now(), delay);
+                        } else {
+                            info!(eth_validator_address=?announcement.validator, ?chain_signer_string, ?chain_signer_h256, "Attempting self announce");
+                            let result = self
+                                .validator_announce
+                                .announce_with_status(signed_announcement.clone())
+                                .await;
+                            let submission_may_be_in_flight =
+                                Self::announcement_submission_may_be_in_flight(&result);
+                            match result {
+                                Ok(ValidatorAnnounceSubmission::Confirmed(outcome)) => {
+                                    Self::log_on_announce_failure(
+                                        Ok(outcome),
+                                        &chain_signer_string,
+                                    );
+                                }
+                                Ok(ValidatorAnnounceSubmission::BroadcastError {
+                                    tx_id,
+                                    error,
+                                }) => {
+                                    error!(
+                                        ?tx_id,
+                                        ?error,
+                                        chain_signer=?chain_signer_string,
+                                        "Failed to track broadcast validator announcement; gas escalator retains ownership",
+                                    );
+                                }
+                                Err(error) => {
+                                    Self::log_on_announce_failure(Err(error), &chain_signer_string);
+                                }
+                            }
+                            if submission_may_be_in_flight {
+                                // Any error after receiving a transaction hash leaves the gas
+                                // escalator responsible for replacement with the same nonce.
+                                retry_backoff.mark_submission_in_flight();
+                            } else {
+                                let delay = Self::jittered_announcement_retry_delay(
+                                    retry_backoff.next_failure_delay(),
+                                );
+                                retry_backoff.record_failure(Instant::now(), delay);
+                            }
+                        }
                     }
                 } else {
                     warn!(origin_chain=%self.origin_chain, "Cannot announce validator without a signer; make sure a signer is set for the origin chain");
@@ -1171,6 +1346,13 @@ impl Validator {
             }
         }
         Ok(())
+    }
+
+    fn jittered_announcement_retry_delay(delay: Duration) -> Duration {
+        let jitter_permille = rand::thread_rng().gen_range(
+            ANNOUNCEMENT_RETRY_MIN_JITTER_PERMILLE..=ANNOUNCEMENT_RETRY_MAX_JITTER_PERMILLE,
+        );
+        AnnouncementRetryBackoff::jittered(delay, jitter_permille)
     }
 
     async fn report_latest_checkpoints_from_each_endpoint(
@@ -1235,6 +1417,162 @@ mod tests {
     use prometheus::Registry;
 
     use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn announcement_retry_backoff_grows_and_caps() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let expected_delays = [
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            Duration::from_secs(120),
+            Duration::from_secs(240),
+            Duration::from_secs(480),
+            Duration::from_secs(900),
+            Duration::from_secs(900),
+        ];
+
+        for expected_delay in expected_delays {
+            let now = Instant::now();
+            assert!(backoff.ready(now));
+            assert_eq!(backoff.next_failure_delay(), expected_delay);
+            backoff.record_failure(now, expected_delay);
+            assert!(!backoff.ready(now));
+
+            let before_deadline = expected_delay
+                .checked_sub(Duration::from_millis(1))
+                .expect("retry delays exceed one millisecond");
+            tokio::time::advance(before_deadline).await;
+            assert!(!backoff.ready(Instant::now()));
+            tokio::time::advance(Duration::from_millis(1)).await;
+            assert!(backoff.ready(Instant::now()));
+        }
+    }
+
+    #[test]
+    fn announcement_retry_jitter_stays_bounded() {
+        assert_eq!(
+            AnnouncementRetryBackoff::jittered(Duration::from_secs(30), 0),
+            Duration::from_secs(24)
+        );
+        assert_eq!(
+            AnnouncementRetryBackoff::jittered(Duration::from_secs(30), 900),
+            Duration::from_secs(27)
+        );
+        assert_eq!(
+            AnnouncementRetryBackoff::jittered(Duration::from_secs(30), u32::MAX),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            AnnouncementRetryBackoff::jittered(
+                ANNOUNCEMENT_RETRY_MAX_DELAY,
+                ANNOUNCEMENT_RETRY_MAX_JITTER_PERMILLE,
+            ),
+            ANNOUNCEMENT_RETRY_MAX_DELAY
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sustained_unfunded_then_confirmed_funding_resets_retry_immediately() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        backoff.record_failure(now, ANNOUNCEMENT_RETRY_MAX_DELAY);
+        assert!(!backoff.observe_tokens_needed(None));
+        assert!(!backoff.ready(now));
+
+        assert!(!backoff.observe_tokens_needed(Some(U256::from(10_u64))));
+        assert!(!backoff.observe_tokens_needed(Some(U256::from(10_u64))));
+        assert!(backoff.observe_tokens_needed(Some(U256::zero())));
+        assert!(backoff.ready(now));
+        assert_eq!(backoff.consecutive_failures, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn funding_preflight_uses_bounded_polling_while_submission_backs_off() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        assert!(backoff.funding_check_due(now));
+        backoff.record_funding_check(now);
+        assert!(!backoff.funding_check_due(now));
+
+        let before_poll = ANNOUNCEMENT_FUNDING_POLL_INTERVAL
+            .checked_sub(Duration::from_millis(1))
+            .expect("funding poll interval exceeds one millisecond");
+        tokio::time::advance(before_poll).await;
+        assert!(!backoff.funding_check_due(Instant::now()));
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(backoff.funding_check_due(Instant::now()));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn in_flight_announcement_never_creates_a_second_submission_stream() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        backoff.record_failure(now, Duration::from_secs(30));
+        backoff.record_failure(now, Duration::from_secs(60));
+
+        backoff.mark_submission_in_flight();
+        assert_eq!(backoff.consecutive_failures, 0);
+        assert!(!backoff.ready(now));
+        tokio::time::advance(ANNOUNCEMENT_RETRY_MAX_DELAY.saturating_mul(10)).await;
+        assert!(!backoff.ready(Instant::now()));
+
+        // Delayed zero preflight or a transient unfunded/funded flap cannot erase in-flight state.
+        assert!(!backoff.observe_tokens_needed(Some(U256::from(1_u64))));
+        assert!(!backoff.observe_tokens_needed(Some(U256::zero())));
+        assert!(!backoff.ready(Instant::now()));
+    }
+
+    #[test]
+    fn every_post_broadcast_error_suppresses_outer_resubmission() {
+        let tx_id = hyperlane_core::H512::from_low_u64_be(9);
+        let dropped_tx_id = H256::from_low_u64_be(9);
+        let post_broadcast_errors = [
+            ChainCommunicationError::TransactionDropped(dropped_tx_id),
+            ChainCommunicationError::TransactionTimeout,
+            ChainCommunicationError::from_other_str("receipt provider failed"),
+        ];
+
+        for error in post_broadcast_errors {
+            let result = Ok(ValidatorAnnounceSubmission::BroadcastError { tx_id, error });
+            assert!(Validator::announcement_submission_may_be_in_flight(&result));
+        }
+    }
+
+    #[test]
+    fn pre_broadcast_error_remains_retryable() {
+        let result = Err(ChainCommunicationError::from_other_str(
+            "initial send failed",
+        ));
+        assert!(!Validator::announcement_submission_may_be_in_flight(
+            &result
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_preflight_failure_preserves_known_unfunded_gate_and_backoff() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        let unfunded = U256::from(25_u64);
+        assert!(!backoff.observe_tokens_needed(Some(unfunded)));
+        backoff.record_failure(now, ANNOUNCEMENT_RETRY_MIN_DELAY);
+
+        assert!(!backoff.observe_tokens_needed(None));
+        assert_eq!(backoff.effective_tokens_needed(None), Some(unfunded));
+        tokio::time::advance(ANNOUNCEMENT_RETRY_MIN_DELAY).await;
+        assert!(backoff.ready(Instant::now()));
+        assert_eq!(backoff.effective_tokens_needed(None), Some(unfunded));
+    }
+
+    #[test]
+    fn single_unfunded_funded_flap_does_not_reset_failed_submission_backoff() {
+        let mut backoff = AnnouncementRetryBackoff::default();
+        let now = Instant::now();
+        backoff.record_failure(now, ANNOUNCEMENT_RETRY_MAX_DELAY);
+
+        assert!(!backoff.observe_tokens_needed(Some(U256::from(1_u64))));
+        assert!(!backoff.observe_tokens_needed(Some(U256::zero())));
+        assert!(!backoff.ready(now));
+    }
 
     fn dummy_ethereum_chain_conf(rpc_urls: Vec<Url>) -> ChainConf {
         ChainConf {

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
@@ -18,7 +18,10 @@ use crate::{
     interfaces::i_validator_announce::{
         IValidatorAnnounce as EthereumValidatorAnnounceInternal, IVALIDATORANNOUNCE_ABI,
     },
-    tx::{fill_tx_gas_params, report_tx, report_tx_with_status, TransactionDispatchOutcome},
+    tx::{
+        fill_tx_gas_params, fill_tx_nonce, report_tx, report_tx_with_status,
+        TransactionDispatchOutcome,
+    },
     BuildableWithProvider, ConnectionConf, EthereumProvider,
 };
 
@@ -116,6 +119,15 @@ where
         )
         .await
     }
+
+    async fn announce_contract_call_with_nonce(
+        &self,
+        announcement: SignedType<Announcement>,
+    ) -> ChainResult<ContractCall<M, bool>> {
+        let mut contract_call = self.announce_contract_call(announcement).await?;
+        fill_tx_nonce(&mut contract_call.tx, self.provider.as_ref()).await?;
+        Ok(contract_call)
+    }
 }
 
 impl<M> HyperlaneChain for EthereumValidatorAnnounce<M>
@@ -189,7 +201,7 @@ where
     #[instrument(err, ret, skip(self))]
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
     async fn announce(&self, announcement: SignedType<Announcement>) -> ChainResult<TxOutcome> {
-        let contract_call = self.announce_contract_call(announcement).await?;
+        let contract_call = self.announce_contract_call_with_nonce(announcement).await?;
         let receipt = report_tx(contract_call).await?;
         Ok(receipt.into())
     }
@@ -198,7 +210,7 @@ where
         &self,
         announcement: SignedType<Announcement>,
     ) -> ChainResult<ValidatorAnnounceSubmission> {
-        let contract_call = self.announce_contract_call(announcement).await?;
+        let contract_call = self.announce_contract_call_with_nonce(announcement).await?;
         Ok(match report_tx_with_status(contract_call).await? {
             TransactionDispatchOutcome::Confirmed(receipt) => {
                 ValidatorAnnounceSubmission::Confirmed((*receipt).into())

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
@@ -4,11 +4,13 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use ethers::middleware::gas_escalator::InitialSendFailurePolicy;
 use ethers::providers::Middleware;
 use ethers_contract::builders::ContractCall;
 use hyperlane_core::{
     Announcement, ChainResult, ContractLocator, HyperlaneAbi, HyperlaneChain, HyperlaneContract,
-    HyperlaneDomain, HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce, H160, H256, U256,
+    HyperlaneDomain, HyperlaneProvider, SignedType, TxOutcome, ValidatorAnnounce,
+    ValidatorAnnounceSubmission, H160, H256, U256,
 };
 use tracing::{instrument, trace};
 
@@ -16,7 +18,7 @@ use crate::{
     interfaces::i_validator_announce::{
         IValidatorAnnounce as EthereumValidatorAnnounceInternal, IVALIDATORANNOUNCE_ABI,
     },
-    tx::{fill_tx_gas_params, report_tx},
+    tx::{fill_tx_gas_params, report_tx, report_tx_with_status, TransactionDispatchOutcome},
     BuildableWithProvider, ConnectionConf, EthereumProvider,
 };
 
@@ -35,6 +37,17 @@ pub struct ValidatorAnnounceBuilder {}
 impl BuildableWithProvider for ValidatorAnnounceBuilder {
     type Output = Box<dyn ValidatorAnnounce>;
     const NEEDS_SIGNER: bool = true;
+
+    // Validator announcement retries are controlled by the validator. Do not create an
+    // independent retry stream for transactions whose initial send returned no hash. Successfully
+    // broadcast transactions remain monitored and fee-escalated as normal.
+    fn gas_escalator_initial_send_failure_policy(&self) -> InitialSendFailurePolicy {
+        InitialSendFailurePolicy::Drop
+    }
+
+    fn uses_nonce_manager(&self) -> bool {
+        false
+    }
 
     async fn build_with_provider<M: Middleware + 'static>(
         &self,
@@ -180,6 +193,24 @@ where
         let receipt = report_tx(contract_call).await?;
         Ok(receipt.into())
     }
+
+    async fn announce_with_status(
+        &self,
+        announcement: SignedType<Announcement>,
+    ) -> ChainResult<ValidatorAnnounceSubmission> {
+        let contract_call = self.announce_contract_call(announcement).await?;
+        Ok(match report_tx_with_status(contract_call).await? {
+            TransactionDispatchOutcome::Confirmed(receipt) => {
+                ValidatorAnnounceSubmission::Confirmed(receipt.into())
+            }
+            TransactionDispatchOutcome::BroadcastError { tx_hash, error } => {
+                ValidatorAnnounceSubmission::BroadcastError {
+                    tx_id: tx_hash.into(),
+                    error,
+                }
+            }
+        })
+    }
 }
 
 pub struct EthereumValidatorAnnounceAbi;
@@ -189,5 +220,20 @@ impl HyperlaneAbi for EthereumValidatorAnnounceAbi {
 
     fn fn_map() -> HashMap<Vec<u8>, &'static str> {
         crate::extract_fn_map(&IVALIDATORANNOUNCE_ABI)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validator_announcements_only_escalate_successfully_broadcast_transactions() {
+        assert_eq!(
+            ValidatorAnnounceBuilder {}.gas_escalator_initial_send_failure_policy(),
+            InitialSendFailurePolicy::Drop
+        );
+        assert!(ValidatorAnnounceBuilder {}.uses_ethers_submission_middleware());
+        assert!(!ValidatorAnnounceBuilder {}.uses_nonce_manager());
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/validator_announce.rs
@@ -201,7 +201,7 @@ where
         let contract_call = self.announce_contract_call(announcement).await?;
         Ok(match report_tx_with_status(contract_call).await? {
             TransactionDispatchOutcome::Confirmed(receipt) => {
-                ValidatorAnnounceSubmission::Confirmed(receipt.into())
+                ValidatorAnnounceSubmission::Confirmed((*receipt).into())
             }
             TransactionDispatchOutcome::BroadcastError { tx_hash, error } => {
                 ValidatorAnnounceSubmission::BroadcastError {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -425,12 +425,14 @@ mod tests {
         Arc, Mutex as StdMutex,
     };
 
+    use ethers::middleware::gas_escalator::GasEscalator;
     use ethers::providers::HttpClientError;
     use ethers::signers::LocalWallet;
-    use ethers::types::TransactionRequest;
+    use ethers::types::{transaction::eip2718::TypedTransaction, TransactionRequest, U256};
     use serde::{de::DeserializeOwned, Serialize};
 
     use super::*;
+    use crate::tx::fill_tx_nonce;
 
     #[derive(Clone, Debug, Default)]
     struct CountingClient {
@@ -460,6 +462,71 @@ mod tests {
     }
 
     struct SenderBuilder;
+
+    #[derive(Clone, Debug, Default)]
+    struct SuccessfulSendClient {
+        nonce_requests: Arc<AtomicUsize>,
+        raw_transactions: Arc<StdMutex<Vec<serde_json::Value>>>,
+    }
+
+    #[async_trait]
+    impl JsonRpcClient for SuccessfulSendClient {
+        type Error = HttpClientError;
+
+        async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
+        where
+            T: Debug + Serialize + Send + Sync,
+            R: DeserializeOwned,
+        {
+            let response = match method {
+                "eth_chainId" => r#""0x1""#.to_owned(),
+                "eth_getTransactionCount" => {
+                    self.nonce_requests.fetch_add(1, Ordering::Relaxed);
+                    r#""0x7""#.to_owned()
+                }
+                "eth_sendRawTransaction" => {
+                    let params =
+                        serde_json::to_value(params).map_err(|err| HttpClientError::SerdeJson {
+                            err,
+                            text: "failed to serialize raw transaction parameters".to_owned(),
+                        })?;
+                    let send_index = {
+                        let mut raw_transactions = self
+                            .raw_transactions
+                            .lock()
+                            .expect("raw transaction mutex poisoned");
+                        raw_transactions.push(params);
+                        raw_transactions.len()
+                    };
+                    format!(r#""0x{send_index:064x}""#)
+                }
+                "eth_getBlockByNumber" | "eth_getTransactionReceipt" => "null".to_owned(),
+                "eth_gasPrice" => r#""0x1""#.to_owned(),
+                _ => "not valid json".to_owned(),
+            };
+            serde_json::from_str(&response).map_err(|err| HttpClientError::SerdeJson {
+                err,
+                text: response,
+            })
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct AlwaysBump;
+
+    impl GasEscalator for AlwaysBump {
+        fn get_gas_price(&self, initial_price: U256, _time_elapsed: u64) -> U256 {
+            initial_price.saturating_add(U256::one())
+        }
+    }
+
+    fn decode_raw_transaction(value: &serde_json::Value) -> TypedTransaction {
+        let raw: ethers::types::Bytes =
+            serde_json::from_value(value[0].clone()).expect("raw transaction is bytes");
+        TypedTransaction::decode_signed(&ethers::utils::rlp::Rlp::new(raw.as_ref()))
+            .expect("raw transaction decodes")
+            .0
+    }
 
     #[async_trait]
     impl BuildableWithProvider for SenderBuilder {
@@ -637,6 +704,57 @@ mod tests {
             .expect("raw transaction mutex poisoned");
         assert_eq!(raw_transactions.len(), 2);
         assert_eq!(raw_transactions[0], raw_transactions[1]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn successful_broadcast_and_gas_escalation_reuse_explicit_nonce(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let client = SuccessfulSendClient::default();
+        let signer = test_signer()?;
+        let provider = Provider::new(client.clone());
+        let signing_provider = wrap_with_signer(provider, signer).await?;
+        let provider = GasEscalatorMiddleware::new_with_initial_send_failure_policy(
+            signing_provider,
+            AlwaysBump,
+            Frequency::Duration(1),
+            InitialSendFailurePolicy::Drop,
+        );
+        let mut tx: TypedTransaction = TransactionRequest::new()
+            .to(Address::zero())
+            .gas(21_000_u64)
+            .gas_price(1_u64)
+            .value(1_u64)
+            .into();
+        fill_tx_nonce(&mut tx, &provider).await?;
+
+        let _pending = provider.send_transaction(tx, None).await?;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if client
+                    .raw_transactions
+                    .lock()
+                    .expect("raw transaction mutex poisoned")
+                    .len()
+                    >= 2
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await?;
+
+        assert_eq!(client.nonce_requests.load(Ordering::Relaxed), 1);
+        let raw_transactions = client
+            .raw_transactions
+            .lock()
+            .expect("raw transaction mutex poisoned");
+        let initial = decode_raw_transaction(&raw_transactions[0]);
+        let replacement = decode_raw_transaction(&raw_transactions[1]);
+        assert_eq!(initial.nonce(), Some(&U256::from(7_u64)));
+        assert_eq!(replacement.nonce(), initial.nonce());
+        assert!(replacement.gas_price() > initial.gas_price());
         Ok(())
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use ethers::middleware::gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice};
+use ethers::middleware::gas_escalator::{
+    Frequency, GasEscalatorMiddleware, GeometricGasPrice, InitialSendFailurePolicy,
+};
 use ethers::middleware::gas_oracle::{
     GasCategory, GasOracle, GasOracleMiddleware, Polygon, ProviderOracle,
 };
@@ -86,6 +88,18 @@ pub trait BuildableWithProvider {
     /// gas escalator, nonce manager. It defaults to true, since it's only Lander
     /// that doesn't require it.
     fn uses_ethers_submission_middleware(&self) -> bool {
+        true
+    }
+
+    /// Controls whether the gas escalator retains a transaction when its initial broadcast
+    /// returned an error and therefore no transaction hash. Most submission paths preserve the
+    /// historical retry behavior; callers with their own bounded retry loop may opt out.
+    fn gas_escalator_initial_send_failure_policy(&self) -> InitialSendFailurePolicy {
+        InitialSendFailurePolicy::Monitor
+    }
+
+    /// Whether to cache and increment transaction nonces locally.
+    fn uses_nonce_manager(&self) -> bool {
         true
     }
 
@@ -263,8 +277,19 @@ pub trait BuildableWithProvider {
         // The signing provider is used for sending txs, which may end up stuck in the mempool due to
         // gas pricing issues. We first wrap the provider in a signer middleware, to sign any new txs sent by the gas escalator middleware.
         // We keep nonce manager as the outermost middleware, so that resubmitting a tx with a higher gas price reuses its initial nonce.
-        let gas_escalator_provider = wrap_with_gas_escalator(signing_provider);
+        let gas_escalator_provider = wrap_with_gas_escalator(
+            signing_provider,
+            self.gas_escalator_initial_send_failure_policy(),
+        );
         let gas_oracle_provider = wrap_with_gas_oracle(gas_escalator_provider, locator.domain)?;
+        if !self.uses_nonce_manager() {
+            // Without a nonce manager, the signer/provider refetches the pending nonce for every
+            // outer retry. This is required when initial send failures are not retained by the gas
+            // escalator: a local increment must not leave an unfillable nonce hole.
+            return Ok(self
+                .build_with_provider(gas_oracle_provider, conn, locator)
+                .await);
+        }
         let nonce_manager_provider = wrap_with_nonce_manager(gas_oracle_provider, signer.address())
             .await
             .map_err(ChainCommunicationError::from_other)?;
@@ -333,7 +358,10 @@ where
     Ok(GasOracleMiddleware::new(provider, gas_oracle))
 }
 
-fn wrap_with_gas_escalator<M>(provider: M) -> GasEscalatorMiddleware<M>
+fn wrap_with_gas_escalator<M>(
+    provider: M,
+    initial_send_failure_policy: InitialSendFailurePolicy,
+) -> GasEscalatorMiddleware<M>
 where
     M: Middleware + 'static,
 {
@@ -350,7 +378,12 @@ where
     // Check the status of sent txs every eth block or so. The alternative is to subscribe to new blocks and check then,
     // which adds unnecessary load on the provider.
     const FREQUENCY: Frequency = Frequency::Duration(Duration::from_secs(12).as_millis() as _);
-    GasEscalatorMiddleware::new(provider, escalator, FREQUENCY)
+    GasEscalatorMiddleware::new_with_initial_send_failure_policy(
+        provider,
+        escalator,
+        FREQUENCY,
+        initial_send_failure_policy,
+    )
 }
 
 /// Builds a new HTTP provider with the given URL.
@@ -389,11 +422,12 @@ fn get_reqwest_client_cache() -> &'static DashMap<Url, Client> {
 mod tests {
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex,
     };
 
     use ethers::providers::HttpClientError;
     use ethers::signers::LocalWallet;
+    use ethers::types::TransactionRequest;
     use serde::{de::DeserializeOwned, Serialize};
 
     use super::*;
@@ -466,6 +500,48 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug, Default)]
+    struct FailingSendClient {
+        nonce_requests: Arc<AtomicUsize>,
+        raw_transactions: Arc<StdMutex<Vec<serde_json::Value>>>,
+    }
+
+    #[async_trait]
+    impl JsonRpcClient for FailingSendClient {
+        type Error = HttpClientError;
+
+        async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
+        where
+            T: Debug + Serialize + Send + Sync,
+            R: DeserializeOwned,
+        {
+            let response = match method {
+                "eth_chainId" => r#""0x1""#,
+                "eth_getTransactionCount" => {
+                    self.nonce_requests.fetch_add(1, Ordering::Relaxed);
+                    r#""0x7""#
+                }
+                "eth_sendRawTransaction" => {
+                    let params =
+                        serde_json::to_value(params).map_err(|err| HttpClientError::SerdeJson {
+                            err,
+                            text: "failed to serialize raw transaction parameters".to_owned(),
+                        })?;
+                    self.raw_transactions
+                        .lock()
+                        .expect("raw transaction mutex poisoned")
+                        .push(params);
+                    "initial send failed"
+                }
+                _ => "not valid json",
+            };
+            serde_json::from_str(response).map_err(|err| HttpClientError::SerdeJson {
+                err,
+                text: response.to_owned(),
+            })
+        }
+    }
+
     fn test_signer() -> Result<Signers, ethers::core::k256::elliptic_curve::Error> {
         ethers::core::k256::SecretKey::from_be_bytes(&[1_u8; 32])
             .map(LocalWallet::from)
@@ -531,6 +607,36 @@ mod tests {
 
         assert_eq!(sender, Some(expected_sender));
         assert_eq!(client.chain_id_requests.load(Ordering::Relaxed), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retries_without_nonce_manager_reuse_pending_nonce_after_initial_send_failure(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let client = FailingSendClient::default();
+        let signer = test_signer()?;
+        let provider = Provider::new(client.clone());
+        let signing_provider = wrap_with_signer(provider, signer).await?;
+        let gas_escalator_provider =
+            wrap_with_gas_escalator(signing_provider, InitialSendFailurePolicy::Drop);
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let provider = wrap_with_gas_oracle(gas_escalator_provider, &domain)?;
+        let tx = TransactionRequest::new()
+            .to(Address::zero())
+            .gas(21_000_u64)
+            .gas_price(1_u64)
+            .value(1_u64);
+
+        assert!(provider.send_transaction(tx.clone(), None).await.is_err());
+        assert!(provider.send_transaction(tx, None).await.is_err());
+
+        assert_eq!(client.nonce_requests.load(Ordering::Relaxed), 2);
+        let raw_transactions = client
+            .raw_transactions
+            .lock()
+            .expect("raw transaction mutex poisoned");
+        assert_eq!(raw_transactions.len(), 2);
+        assert_eq!(raw_transactions[0], raw_transactions[1]);
         Ok(())
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -68,6 +68,36 @@ pub fn apply_gas_estimate_buffer(gas: U256, domain: &HyperlaneDomain) -> ChainRe
 const PENDING_TRANSACTION_POLLING_INTERVAL: Duration = Duration::from_secs(2);
 const EVM_RELAYER_ADDRESS: &str = "0x74cae0ecc47b02ed9b9d32e000fd70b9417970c5";
 
+/// Sets the current signer nonce without caching it locally.
+///
+/// This lets retry owners refetch the pending nonce after a definite initial-send failure while
+/// ensuring inner middleware, such as the gas escalator, receives the nonce used for a successful
+/// broadcast.
+pub(crate) async fn fill_tx_nonce<M>(tx: &mut TypedTransaction, provider: &M) -> ChainResult<()>
+where
+    M: Middleware + 'static,
+{
+    if tx.nonce().is_some() {
+        return Ok(());
+    }
+
+    let sender = tx
+        .from()
+        .copied()
+        .or_else(|| provider.default_sender())
+        .ok_or_else(|| {
+            ChainCommunicationError::from_other_str(
+                "Cannot fill transaction nonce without a sender",
+            )
+        })?;
+    let nonce = provider
+        .get_transaction_count(sender, Some(BlockNumber::Pending.into()))
+        .await
+        .map_err(ChainCommunicationError::from_other)?;
+    tx.set_nonce(nonce);
+    Ok(())
+}
+
 pub(crate) enum TransactionDispatchOutcome {
     Confirmed(Box<TransactionReceipt>),
     BroadcastError {

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -68,8 +68,40 @@ pub fn apply_gas_estimate_buffer(gas: U256, domain: &HyperlaneDomain) -> ChainRe
 const PENDING_TRANSACTION_POLLING_INTERVAL: Duration = Duration::from_secs(2);
 const EVM_RELAYER_ADDRESS: &str = "0x74cae0ecc47b02ed9b9d32e000fd70b9417970c5";
 
+pub(crate) enum TransactionDispatchOutcome {
+    Confirmed(TransactionReceipt),
+    BroadcastError {
+        tx_hash: H256,
+        error: ChainCommunicationError,
+    },
+}
+
+fn classify_broadcast_result(
+    tx_hash: H256,
+    result: ChainResult<TransactionReceipt>,
+) -> TransactionDispatchOutcome {
+    match result {
+        Ok(receipt) => TransactionDispatchOutcome::Confirmed(receipt),
+        Err(error) => TransactionDispatchOutcome::BroadcastError { tx_hash, error },
+    }
+}
+
 /// Dispatches a transaction, logs the tx id, and returns the result
 pub(crate) async fn report_tx<M, D>(tx: ContractCall<M, D>) -> ChainResult<TransactionReceipt>
+where
+    M: Middleware + 'static,
+    D: Detokenize,
+{
+    match report_tx_with_status(tx).await? {
+        TransactionDispatchOutcome::Confirmed(receipt) => Ok(receipt),
+        TransactionDispatchOutcome::BroadcastError { error, .. } => Err(error),
+    }
+}
+
+/// Dispatches a transaction while preserving whether a failure occurred after broadcast.
+pub(crate) async fn report_tx_with_status<M, D>(
+    tx: ContractCall<M, D>,
+) -> ChainResult<TransactionDispatchOutcome>
 where
     M: Middleware + 'static,
     D: Detokenize,
@@ -85,7 +117,11 @@ where
     let dispatched = dispatch_fut
         .await?
         .interval(PENDING_TRANSACTION_POLLING_INTERVAL);
-    track_pending_tx(dispatched).await
+    let tx_hash = (*dispatched).into();
+    Ok(classify_broadcast_result(
+        tx_hash,
+        track_pending_tx(dispatched).await,
+    ))
 }
 
 #[instrument(skip(pending_tx))]
@@ -114,6 +150,50 @@ pub(crate) async fn track_pending_tx<P: JsonRpcClient>(
         Err(x) => {
             error!(?tx_hash, error = ?x, "waiting for receipt timed out");
             Err(ChainCommunicationError::TransactionTimeout)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dropped_transaction_retains_broadcast_stage_and_hash() {
+        let tx_hash = H256::from_low_u64_be(7);
+        let outcome = classify_broadcast_result(
+            tx_hash,
+            Err(ChainCommunicationError::TransactionDropped(tx_hash)),
+        );
+
+        assert!(matches!(
+            outcome,
+            TransactionDispatchOutcome::BroadcastError {
+                tx_hash: observed_hash,
+                error: ChainCommunicationError::TransactionDropped(dropped_hash),
+            } if observed_hash == tx_hash && dropped_hash == tx_hash
+        ));
+    }
+
+    #[test]
+    fn receipt_provider_error_retains_broadcast_stage_and_original_error() {
+        let tx_hash = H256::from_low_u64_be(8);
+        let outcome = classify_broadcast_result(
+            tx_hash,
+            Err(ChainCommunicationError::from_other_str(
+                "receipt provider failed",
+            )),
+        );
+
+        match outcome {
+            TransactionDispatchOutcome::BroadcastError {
+                tx_hash: observed_hash,
+                error,
+            } => {
+                assert_eq!(observed_hash, tx_hash);
+                assert_eq!(error.to_string(), "receipt provider failed");
+            }
+            TransactionDispatchOutcome::Confirmed(_) => panic!("expected broadcast error"),
         }
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/src/tx.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/tx.rs
@@ -69,7 +69,7 @@ const PENDING_TRANSACTION_POLLING_INTERVAL: Duration = Duration::from_secs(2);
 const EVM_RELAYER_ADDRESS: &str = "0x74cae0ecc47b02ed9b9d32e000fd70b9417970c5";
 
 pub(crate) enum TransactionDispatchOutcome {
-    Confirmed(TransactionReceipt),
+    Confirmed(Box<TransactionReceipt>),
     BroadcastError {
         tx_hash: H256,
         error: ChainCommunicationError,
@@ -81,7 +81,7 @@ fn classify_broadcast_result(
     result: ChainResult<TransactionReceipt>,
 ) -> TransactionDispatchOutcome {
     match result {
-        Ok(receipt) => TransactionDispatchOutcome::Confirmed(receipt),
+        Ok(receipt) => TransactionDispatchOutcome::Confirmed(Box::new(receipt)),
         Err(error) => TransactionDispatchOutcome::BroadcastError { tx_hash, error },
     }
 }
@@ -93,7 +93,7 @@ where
     D: Detokenize,
 {
     match report_tx_with_status(tx).await? {
-        TransactionDispatchOutcome::Confirmed(receipt) => Ok(receipt),
+        TransactionDispatchOutcome::Confirmed(receipt) => Ok(*receipt),
         TransactionDispatchOutcome::BroadcastError { error, .. } => Err(error),
     }
 }

--- a/rust/main/hyperlane-core/src/traits/validator_announce.rs
+++ b/rust/main/hyperlane-core/src/traits/validator_announce.rs
@@ -3,7 +3,25 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 
-use crate::{Announcement, ChainResult, HyperlaneContract, SignedType, TxOutcome, H256, U256};
+use crate::{
+    Announcement, ChainCommunicationError, ChainResult, HyperlaneContract, SignedType, TxOutcome,
+    H256, H512, U256,
+};
+
+/// The stage reached by a validator announcement submission.
+#[derive(Debug)]
+pub enum ValidatorAnnounceSubmission {
+    /// The transaction was confirmed on-chain.
+    Confirmed(TxOutcome),
+    /// The transaction was broadcast, but receipt tracking failed afterwards.
+    /// The original error is retained for operator observability.
+    BroadcastError {
+        /// The hash returned by the initial broadcast.
+        tx_id: H512,
+        /// The error encountered while tracking the broadcast transaction.
+        error: ChainCommunicationError,
+    },
+}
 
 /// Interface for the ValidatorAnnounce chain contract. Allows abstraction over
 /// different chains
@@ -18,6 +36,17 @@ pub trait ValidatorAnnounce: HyperlaneContract + Send + Sync + Debug {
 
     /// Announce a storage location for a validator
     async fn announce(&self, announcement: SignedType<Announcement>) -> ChainResult<TxOutcome>;
+
+    /// Announce a storage location while preserving whether an error happened before or after
+    /// the transaction was successfully broadcast.
+    async fn announce_with_status(
+        &self,
+        announcement: SignedType<Announcement>,
+    ) -> ChainResult<ValidatorAnnounceSubmission> {
+        self.announce(announcement)
+            .await
+            .map(ValidatorAnnounceSubmission::Confirmed)
+    }
 
     /// Returns the number of additional tokens needed to pay for the announce
     /// transaction. Return `None` if the needed tokens cannot be determined.


### PR DESCRIPTION
## Summary

- back off failed and known-unfunded validator announcement attempts from 30 seconds to a 15 minute cap, with downward jitter
- keep on-chain announcement polling at the normal validator interval; poll funding every 30 seconds only while the signer is known unfunded
- preserve the distinction between a true initial-send failure and any error after receiving a transaction hash
- leave successfully broadcast announcements with the gas escalator and suppress a second outer submission stream
- disable `NonceManager` only for `ValidatorAnnounce`, so a definitely failed initial send refetches and reuses the pending nonce

## Why

The migration validator fleet is retrying known-failing announcements on the 2–5 second agent loop:

- Oort: 25,152 failed `eth_sendRawTransaction` calls in 24 hours
- Botanix: 5,570 failed calls in 24 hours
- zero successful sends on those endpoints
- Paradex emitted the unfunded warning 629 times in one hour

The first narrow backoff attempt was unsafe: removing submission middleware also removed fee escalation for a legitimately broadcast, underpriced transaction. This version keeps gas oracle and gas escalation, gives each layer explicit retry ownership, and regression-tests both post-broadcast ownership and initial-send nonce reuse.

A fixed-window refresh (`2026-08-10 08:10–09:10 UTC`) on deployed image `14646bd-20260805-072134` found:

- Oort: 1,078 failed `eth_sendRawTransaction` records, 279 outer announcement failures, no dispatched or successful announcement
- Botanix: 414 failed `eth_sendRawTransaction` records; 25 outer attempts split into 15 known-unfunded warnings and 10 submission failures; no dispatched or successful announcement
- Paradex: 61 known-unfunded warnings

Oort also returned `method eth_feeHistory does not exist` on every preflight. Unknown and last-known-funded preflight state is therefore checked only when the submission retry is due; polling it every 30 seconds during cooldown could not reset backoff and only replaced send spam with failed preflight spam. Last-known-unfunded state retains 30-second checks so newly supplied funds are detected promptly.

At the 12–15 minute jittered cap, outer attempts model to 4–5/hour. Against this window that is a 98.2–98.6% reduction for Oort and a 91.8–93.4% reduction in Paradex's repeated warning. Raw provider-request reduction should be larger because the validator-specific nonce-manager resend and hashless gas-escalator stream are also removed, but that needs post-deploy metric verification.

## Behaviour

- initial failure/unfunded delays: 30s, 60s, 120s, up to 15m; jittered to 80–100% of the bound
- a transient funding-preflight error preserves the last known funded/unfunded state
- unknown or last-known-funded preflight state waits for the submission retry deadline; last-known-unfunded state retains 30-second funding checks
- two consecutive unfunded observations arm the prompt reset; confirmed funding then retries immediately
- confirmed execution, receipt timeout, dropped-transaction result, or receipt-provider error after a hash marks the submission in flight
- the validator continues checking the on-chain storage locations while in flight and starts checkpoint submission only after the target location is observed
- reverted confirmed transactions and true pre-broadcast failures retain bounded outer retry
- retry logs include the selected delay and consecutive-failure count

## Dependency

[hyperlane-xyz/ethers-rs#49](https://github.com/hyperlane-xyz/ethers-rs/pull/49) is merged; this branch is pinned to merge commit `3d086015c0a41657122bcc784ac9ea5f8cb37160`.

That upstream change keeps the historical gas-escalator default, adds an opt-in policy to drop only initial sends that returned no hash, and retains watcher ownership across transient receipt/replacement RPC errors.

## Tests

- `cargo test -p hyperlane-ethereum --lib tx::tests`
- `cargo test -p hyperlane-ethereum --lib retries_without_nonce_manager_reuse_pending_nonce_after_initial_send_failure`
- `cargo test -p hyperlane-ethereum --lib validator_announcements_only_escalate_successfully_broadcast_transactions`
- `cargo test -p hyperlane-ethereum --lib successful_broadcast_and_gas_escalation_reuse_explicit_nonce`
- `cargo test -p validator broadcast_`
- `cargo test -p validator in_flight_announcement_never_creates_a_second_submission_stream`
- `cargo test -p validator` (64 passed)
- upstream: `cargo test -p ethers-middleware --lib gas_escalator::tests` (5 passed)
- `cargo clippy -p validator -- -D warnings`
- `cargo clippy -p hyperlane-ethereum --lib -- -D warnings`
- `cargo fmt -p validator -p hyperlane-ethereum -p hyperlane-core -- --check`
- `git diff --check`

Exact-head CI at `4f09548dce` is green across all 10 required checks, including Rust workspace tests/clippy, all seven Rust e2e matrices, TypeScript tests/lint, and coverage. Local validation also passed 54 `hyperlane-ethereum` library tests (1 ignored), 64 validator tests, the targeted nonce-escalation regression, clippy with warnings denied, formatting, and `git diff --check`.

## Residuals

- accepted-but-response-lost sends remain hashless and cannot be watcher-tracked; refetching pending nonce avoids locally skipping the nonce
- in-flight suppression assumes one writer per signer; operator restart remains recovery if a different process consumes the nonce without publishing this announcement
- the ethers fork CI is currently red on unrelated stale-toolchain, repository-format, live integration-test and external RPC failures; focused changed-target tests are green