### PR TITLE
perf(scraper): back off raw dispatch reconciliation scans

### DIFF
--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -29,7 +29,7 @@ use hyperlane_base::{
 use crate::{
     db::ScraperDb,
     settings::ScraperSettings,
-    store::{HyperlaneDbStore, RawDispatchRetryBackoff},
+    store::{HyperlaneDbStore, RawDispatchReconciliationResult, RawDispatchRetryBackoff},
 };
 
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
@@ -37,6 +37,21 @@ const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
 const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(60);
 const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
 const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
+
+fn raw_dispatch_reconciliation_scan_complete(result: &RawDispatchReconciliationResult) -> bool {
+    result.candidate_count < RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize
+}
+
+fn raw_dispatch_reconciliation_sleep(result: &RawDispatchReconciliationResult) -> Duration {
+    if raw_dispatch_reconciliation_scan_complete(result) {
+        result
+            .next_retry_delay
+            .unwrap_or(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP)
+            .min(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP)
+    } else {
+        RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+    }
+}
 
 fn update_liveness_metric(liveness_metric: &IntGauge) {
     let seconds_since_epoch = SystemTime::now()
@@ -467,7 +482,11 @@ impl Scraper {
                         Ok(Ok(result)) if result.candidate_count == 0 && next_after_id > 0 => {
                             next_after_id = 0;
                             max_age_seen_this_scan = 0;
-                            sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
+                            sleep_with_liveness(
+                                raw_dispatch_reconciliation_sleep(&result),
+                                &liveness_metric,
+                            )
+                            .await;
                         }
                         Ok(Ok(result)) if result.candidate_count == 0 => {
                             max_age_metric.set(0);
@@ -495,7 +514,15 @@ impl Scraper {
                                 domain = domain_name,
                                 "Reconciled raw message dispatches"
                             );
-                            sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
+                            if raw_dispatch_reconciliation_scan_complete(&result) {
+                                next_after_id = 0;
+                                max_age_seen_this_scan = 0;
+                            }
+                            sleep_with_liveness(
+                                raw_dispatch_reconciliation_sleep(&result),
+                                &liveness_metric,
+                            )
+                            .await;
                         }
                         Ok(Err(err)) => {
                             warn!(
@@ -735,7 +762,10 @@ impl Scraper {
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     use ethers::utils::hex;
     use ethers_prometheus::middleware::PrometheusMiddlewareConf;
@@ -789,6 +819,74 @@ mod test {
 
         tokio::time::advance(Duration::from_secs(5)).await;
         task.await.expect("idle sleep should complete");
+    }
+
+    #[test]
+    fn raw_dispatch_scan_uses_backlog_delay_until_final_page() {
+        let full_page = RawDispatchReconciliationResult {
+            candidate_count: RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize,
+            next_retry_delay: Some(Duration::from_secs(900)),
+            ..Default::default()
+        };
+        let final_page = RawDispatchReconciliationResult {
+            candidate_count: 1,
+            next_retry_delay: Some(Duration::from_secs(900)),
+            ..Default::default()
+        };
+
+        assert!(!raw_dispatch_reconciliation_scan_complete(&full_page));
+        assert_eq!(
+            raw_dispatch_reconciliation_sleep(&full_page),
+            RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+        );
+        assert!(raw_dispatch_reconciliation_scan_complete(&final_page));
+        assert_eq!(
+            raw_dispatch_reconciliation_sleep(&final_page),
+            RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backed_off_final_page_wait_updates_liveness_and_bounds_queries() {
+        let liveness = IntGauge::new("test_backoff_liveness", "test backoff liveness")
+            .expect("test gauge should be valid");
+        let task_liveness = liveness.clone();
+        let query_count = Arc::new(AtomicUsize::new(0));
+        let task_query_count = query_count.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                task_query_count.fetch_add(1, Ordering::SeqCst);
+                let final_page = RawDispatchReconciliationResult {
+                    candidate_count: 1,
+                    next_retry_delay: Some(Duration::from_secs(900)),
+                    ..Default::default()
+                };
+                sleep_with_liveness(
+                    raw_dispatch_reconciliation_sleep(&final_page),
+                    &task_liveness,
+                )
+                .await;
+            }
+        });
+
+        run_pending_tasks().await;
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL - Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert_eq!(liveness.get(), 0);
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert!(liveness.get() > 0);
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL).await;
+        run_pending_tasks().await;
+        assert_eq!(query_count.load(Ordering::SeqCst), 2);
+
+        task.abort();
     }
 
     fn generate_test_scraper_settings() -> ScraperSettings {

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -34,9 +34,21 @@ use crate::{
 
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
 const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
-const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(60);
+// Reconciliation is a fallback for dispatches that fail inline enrichment. Five minutes keeps
+// recovery prompt while cutting steady-state anti-join scans by 80% relative to the old minute.
+const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(5 * 60);
 const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
 const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
+
+fn raw_dispatch_reconciliation_initial_delay(domain_id: u32) -> Duration {
+    // Multiplication mixes small, sequential domain IDs before placing each chain in a stable
+    // phase of the polling window. This avoids a synchronized DB burst after scraper restarts.
+    let offset = u64::from(domain_id)
+        .wrapping_mul(2_654_435_761)
+        .checked_rem(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP.as_secs())
+        .unwrap_or_default();
+    Duration::from_secs(offset)
+}
 
 fn raw_dispatch_reconciliation_scan_complete(result: &RawDispatchReconciliationResult) -> bool {
     result.candidate_count < RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize
@@ -467,6 +479,13 @@ impl Scraper {
                 let mut retry_backoff = RawDispatchRetryBackoff::default();
                 let mut max_age_seen_this_scan = 0_u64;
 
+                update_liveness_metric(&liveness_metric);
+                sleep_with_liveness(
+                    raw_dispatch_reconciliation_initial_delay(domain.id()),
+                    &liveness_metric,
+                )
+                .await;
+
                 loop {
                     update_liveness_metric(&liveness_metric);
 
@@ -846,6 +865,18 @@ mod test {
         );
     }
 
+    #[test]
+    fn raw_dispatch_initial_delay_is_stable_and_bounded() {
+        let ethereum_delay = raw_dispatch_reconciliation_initial_delay(1);
+
+        assert_eq!(ethereum_delay, raw_dispatch_reconciliation_initial_delay(1));
+        assert!(ethereum_delay < RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP);
+        assert_ne!(
+            ethereum_delay,
+            raw_dispatch_reconciliation_initial_delay(10)
+        );
+    }
+
     #[tokio::test(start_paused = true)]
     async fn backed_off_final_page_wait_updates_liveness_and_bounds_queries() {
         let liveness = IntGauge::new("test_backoff_liveness", "test backoff liveness")
@@ -882,7 +913,12 @@ mod test {
         assert!(liveness.get() > 0);
         assert_eq!(query_count.load(Ordering::SeqCst), 1);
 
-        tokio::time::advance(LIVENESS_UPDATE_INTERVAL).await;
+        tokio::time::advance(
+            RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP
+                .checked_sub(LIVENESS_UPDATE_INTERVAL)
+                .expect("idle sleep exceeds one liveness interval"),
+        )
+        .await;
         run_pending_tasks().await;
         assert_eq!(query_count.load(Ordering::SeqCst), 2);
 

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -29,7 +29,7 @@ use hyperlane_base::{
 use crate::{
     db::ScraperDb,
     settings::ScraperSettings,
-    store::{HyperlaneDbStore, RawDispatchRetryBackoff},
+    store::{HyperlaneDbStore, RawDispatchReconciliationResult, RawDispatchRetryBackoff},
 };
 
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
@@ -37,6 +37,21 @@ const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
 const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(60);
 const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
 const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
+
+fn raw_dispatch_reconciliation_scan_complete(result: &RawDispatchReconciliationResult) -> bool {
+    result.candidate_count < RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize
+}
+
+fn raw_dispatch_reconciliation_sleep(result: &RawDispatchReconciliationResult) -> Duration {
+    if raw_dispatch_reconciliation_scan_complete(result) {
+        result
+            .next_retry_delay
+            .unwrap_or(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP)
+            .min(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP)
+    } else {
+        RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+    }
+}
 
 fn update_liveness_metric(liveness_metric: &IntGauge) {
     let seconds_since_epoch = SystemTime::now()
@@ -457,7 +472,11 @@ impl Scraper {
                         Ok(Ok(result)) if result.candidate_count == 0 && next_after_id > 0 => {
                             next_after_id = 0;
                             max_age_seen_this_scan = 0;
-                            sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
+                            sleep_with_liveness(
+                                raw_dispatch_reconciliation_sleep(&result),
+                                &liveness_metric,
+                            )
+                            .await;
                         }
                         Ok(Ok(result)) if result.candidate_count == 0 => {
                             max_age_metric.set(0);
@@ -485,7 +504,15 @@ impl Scraper {
                                 domain = domain_name,
                                 "Reconciled raw message dispatches"
                             );
-                            sleep(RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP).await;
+                            if raw_dispatch_reconciliation_scan_complete(&result) {
+                                next_after_id = 0;
+                                max_age_seen_this_scan = 0;
+                            }
+                            sleep_with_liveness(
+                                raw_dispatch_reconciliation_sleep(&result),
+                                &liveness_metric,
+                            )
+                            .await;
                         }
                         Ok(Err(err)) => {
                             warn!(
@@ -694,7 +721,10 @@ impl Scraper {
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     use ethers::utils::hex;
     use ethers_prometheus::middleware::PrometheusMiddlewareConf;
@@ -748,6 +778,74 @@ mod test {
 
         tokio::time::advance(Duration::from_secs(5)).await;
         task.await.expect("idle sleep should complete");
+    }
+
+    #[test]
+    fn raw_dispatch_scan_uses_backlog_delay_until_final_page() {
+        let full_page = RawDispatchReconciliationResult {
+            candidate_count: RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize,
+            next_retry_delay: Some(Duration::from_secs(900)),
+            ..Default::default()
+        };
+        let final_page = RawDispatchReconciliationResult {
+            candidate_count: 1,
+            next_retry_delay: Some(Duration::from_secs(900)),
+            ..Default::default()
+        };
+
+        assert!(!raw_dispatch_reconciliation_scan_complete(&full_page));
+        assert_eq!(
+            raw_dispatch_reconciliation_sleep(&full_page),
+            RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+        );
+        assert!(raw_dispatch_reconciliation_scan_complete(&final_page));
+        assert_eq!(
+            raw_dispatch_reconciliation_sleep(&final_page),
+            RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backed_off_final_page_wait_updates_liveness_and_bounds_queries() {
+        let liveness = IntGauge::new("test_backoff_liveness", "test backoff liveness")
+            .expect("test gauge should be valid");
+        let task_liveness = liveness.clone();
+        let query_count = Arc::new(AtomicUsize::new(0));
+        let task_query_count = query_count.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                task_query_count.fetch_add(1, Ordering::SeqCst);
+                let final_page = RawDispatchReconciliationResult {
+                    candidate_count: 1,
+                    next_retry_delay: Some(Duration::from_secs(900)),
+                    ..Default::default()
+                };
+                sleep_with_liveness(
+                    raw_dispatch_reconciliation_sleep(&final_page),
+                    &task_liveness,
+                )
+                .await;
+            }
+        });
+
+        run_pending_tasks().await;
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL - Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert_eq!(liveness.get(), 0);
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        run_pending_tasks().await;
+        assert!(liveness.get() > 0);
+        assert_eq!(query_count.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(LIVENESS_UPDATE_INTERVAL).await;
+        run_pending_tasks().await;
+        assert_eq!(query_count.load(Ordering::SeqCst), 2);
+
+        task.abort();
     }
 
     fn generate_test_scraper_settings() -> ScraperSettings {

--- a/rust/main/agents/scraper/src/store.rs
+++ b/rust/main/agents/scraper/src/store.rs
@@ -2,7 +2,7 @@ pub use storage::HyperlaneDbStore;
 
 mod deliveries;
 mod dispatches;
-pub(crate) use dispatches::RawDispatchRetryBackoff;
+pub(crate) use dispatches::{RawDispatchReconciliationResult, RawDispatchRetryBackoff};
 mod merkle_tree_insertions;
 mod payments;
 mod same_chain_ccr_swaps;

--- a/rust/main/agents/scraper/src/store.rs
+++ b/rust/main/agents/scraper/src/store.rs
@@ -2,7 +2,7 @@ pub use storage::HyperlaneDbStore;
 
 mod deliveries;
 mod dispatches;
-pub(crate) use dispatches::RawDispatchRetryBackoff;
+pub(crate) use dispatches::{RawDispatchReconciliationResult, RawDispatchRetryBackoff};
 mod payments;
 mod same_chain_ccr_swaps;
 mod storage;

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use eyre::Result;
@@ -25,20 +28,37 @@ pub(crate) struct RawDispatchReconciliationResult {
     pub stored_count: u32,
     pub next_after_id: i64,
     pub max_unenriched_age_seconds: u64,
+    pub next_retry_delay: Option<Duration>,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct RawDispatchRetryBackoff {
     rows: HashMap<i64, RawDispatchRetry>,
+    current_scan: u64,
 }
 
 #[derive(Debug)]
 struct RawDispatchRetry {
     attempts: u32,
     next_retry_at: OffsetDateTime,
+    last_seen_scan: u64,
 }
 
 impl RawDispatchRetryBackoff {
+    fn begin_scan(&mut self, after_id: i64) {
+        if after_id == 0 {
+            self.current_scan = self.current_scan.wrapping_add(1);
+        }
+    }
+
+    fn observe_candidates(&mut self, raw_ids: impl Iterator<Item = i64>) {
+        for raw_id in raw_ids {
+            if let Some(retry) = self.rows.get_mut(&raw_id) {
+                retry.last_seen_scan = self.current_scan;
+            }
+        }
+    }
+
     fn should_attempt(&self, raw_id: i64, now: OffsetDateTime) -> bool {
         match self.rows.get(&raw_id) {
             Some(retry) => retry.next_retry_at <= now,
@@ -47,10 +67,13 @@ impl RawDispatchRetryBackoff {
     }
 
     fn record_missing(&mut self, raw_id: i64, now: OffsetDateTime) -> u32 {
+        let current_scan = self.current_scan;
         let retry = self.rows.entry(raw_id).or_insert(RawDispatchRetry {
             attempts: 0,
             next_retry_at: now,
+            last_seen_scan: current_scan,
         });
+        retry.last_seen_scan = current_scan;
         retry.attempts = retry.attempts.saturating_add(1);
 
         let multiplier = 2_i64.pow(retry.attempts.saturating_sub(1).min(4));
@@ -63,6 +86,35 @@ impl RawDispatchRetryBackoff {
 
     fn record_success(&mut self, raw_id: i64) {
         self.rows.remove(&raw_id);
+    }
+
+    fn next_retry_delay(&self, now: OffsetDateTime) -> Option<Duration> {
+        self.rows
+            .values()
+            .map(|retry| {
+                if retry.next_retry_at <= now {
+                    Duration::ZERO
+                } else {
+                    retry
+                        .next_retry_at
+                        .unix_timestamp_nanos()
+                        .checked_sub(now.unix_timestamp_nanos())
+                        .and_then(|nanos| u64::try_from(nanos).ok())
+                        .map(Duration::from_nanos)
+                        .unwrap_or(Duration::MAX)
+                }
+            })
+            .min()
+    }
+
+    fn finish_scan(&mut self, candidate_count: usize, limit: u64) {
+        if candidate_count as u64 >= limit {
+            return;
+        }
+
+        let current_scan = self.current_scan;
+        self.rows
+            .retain(|_, retry| retry.last_seen_scan == current_scan);
     }
 }
 
@@ -160,15 +212,23 @@ impl HyperlaneDbStore {
             )
             .await?;
         let now = OffsetDateTime::now_utc();
+        retry_backoff.begin_scan(after_id);
+        retry_backoff.observe_candidates(
+            raw_dispatches
+                .iter()
+                .map(|raw_dispatch| raw_dispatch.raw_id),
+        );
         let max_unenriched_age_seconds = raw_dispatches
             .iter()
             .map(|raw_dispatch| raw_dispatch_age_seconds(raw_dispatch.time_created, now))
             .max()
             .unwrap_or_default();
         if raw_dispatches.is_empty() {
+            retry_backoff.finish_scan(0, limit);
             return Ok(RawDispatchReconciliationResult {
                 next_after_id: after_id,
                 max_unenriched_age_seconds,
+                next_retry_delay: retry_backoff.next_retry_delay(now),
                 ..Default::default()
             });
         }
@@ -187,11 +247,13 @@ impl HyperlaneDbStore {
             .collect::<Vec<_>>();
 
         if raw_dispatches_to_attempt.is_empty() {
+            retry_backoff.finish_scan(raw_dispatches.len(), limit);
             return Ok(RawDispatchReconciliationResult {
                 candidate_count: raw_dispatches.len(),
                 skipped_backoff_count,
                 next_after_id,
                 max_unenriched_age_seconds,
+                next_retry_delay: retry_backoff.next_retry_delay(now),
                 ..Default::default()
             });
         }
@@ -240,6 +302,7 @@ impl HyperlaneDbStore {
         for raw_id in stored_raw_ids {
             retry_backoff.record_success(raw_id);
         }
+        retry_backoff.finish_scan(raw_dispatches.len(), limit);
 
         if !missing_tx_hashes.is_empty() {
             warn!(
@@ -259,6 +322,7 @@ impl HyperlaneDbStore {
             stored_count: stored as u32,
             next_after_id,
             max_unenriched_age_seconds,
+            next_retry_delay: retry_backoff.next_retry_delay(OffsetDateTime::now_utc()),
         })
     }
 }
@@ -487,5 +551,56 @@ mod tests {
 
         backoff.record_success(raw_id);
         assert!(backoff.should_attempt(raw_id, now));
+    }
+
+    #[test]
+    fn raw_dispatch_retry_backoff_reports_earliest_retry() {
+        let now = OffsetDateTime::now_utc();
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.record_missing(7, now);
+        backoff.record_missing(8, offset_by_seconds(now, 30));
+
+        assert_eq!(
+            backoff.next_retry_delay(now),
+            Some(Duration::from_secs(
+                RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS as u64
+            ))
+        );
+    }
+
+    #[test]
+    fn scan_preserves_retry_that_became_due_after_its_page() {
+        let start = OffsetDateTime::now_utc();
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.begin_scan(0);
+        assert_eq!(backoff.record_missing(raw_id, start), 1);
+
+        backoff.begin_scan(0);
+        let page_time = offset_by_seconds(start, 50);
+        backoff.observe_candidates([raw_id].into_iter());
+        assert!(!backoff.should_attempt(raw_id, page_time));
+
+        backoff.finish_scan(1, 100);
+        let scan_end = offset_by_seconds(start, 70);
+        assert_eq!(backoff.next_retry_delay(scan_end), Some(Duration::ZERO));
+        assert_eq!(backoff.record_missing(raw_id, scan_end), 2);
+    }
+
+    #[test]
+    fn scan_drops_retry_rows_no_longer_returned_by_database() {
+        let now = OffsetDateTime::now_utc();
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.begin_scan(0);
+        assert_eq!(backoff.record_missing(raw_id, now), 1);
+
+        backoff.begin_scan(0);
+        backoff.finish_scan(0, 100);
+
+        assert_eq!(backoff.record_missing(raw_id, now), 1);
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -263,6 +263,9 @@ impl HyperlaneDbStore {
             .await?
             .map(|t| (t.hash, t))
             .collect();
+        // Start retry delays after the enrichment attempt finishes. A slow RPC batch must
+        // not consume the backoff before its missing rows are recorded.
+        let attempt_completed_at = OffsetDateTime::now_utc();
 
         let mut missing_tx_hashes = Vec::new();
         let mut unique_missing_tx_hashes = HashSet::new();
@@ -276,7 +279,8 @@ impl HyperlaneDbStore {
                         Some(raw_dispatch.storable_message(txn_id))
                     }
                     None => {
-                        let attempts = retry_backoff.record_missing(raw_dispatch.raw_id, now);
+                        let attempts = retry_backoff
+                            .record_missing(raw_dispatch.raw_id, attempt_completed_at);
                         if unique_missing_tx_hashes.insert(raw_dispatch.meta.transaction_id) {
                             missing_tx_hashes.push(raw_dispatch.meta.transaction_id);
                         }
@@ -555,6 +559,33 @@ mod tests {
         assert!(backoff.should_attempt(
             raw_id,
             offset_by_seconds(now, RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS)
+        ));
+    }
+
+    #[test]
+    fn slow_reconciliation_starts_backoff_after_attempt_completion() {
+        let attempt_started_at = OffsetDateTime::now_utc();
+        let attempt_completed_at = offset_by_seconds(
+            attempt_started_at,
+            RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS + 10,
+        );
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.record_missing(raw_id, attempt_completed_at);
+
+        assert_eq!(
+            backoff.next_retry_delay(attempt_completed_at),
+            Some(Duration::from_secs(
+                RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS as u64
+            ))
+        );
+        assert!(!backoff.should_attempt(
+            raw_id,
+            offset_by_seconds(
+                attempt_completed_at,
+                RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS - 1
+            )
         ));
     }
 

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use eyre::Result;
@@ -25,20 +28,37 @@ pub(crate) struct RawDispatchReconciliationResult {
     pub stored_count: u32,
     pub next_after_id: i64,
     pub max_unenriched_age_seconds: u64,
+    pub next_retry_delay: Option<Duration>,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct RawDispatchRetryBackoff {
     rows: HashMap<i64, RawDispatchRetry>,
+    current_scan: u64,
 }
 
 #[derive(Debug)]
 struct RawDispatchRetry {
     attempts: u32,
     next_retry_at: OffsetDateTime,
+    last_seen_scan: u64,
 }
 
 impl RawDispatchRetryBackoff {
+    fn begin_scan(&mut self, after_id: i64) {
+        if after_id == 0 {
+            self.current_scan = self.current_scan.wrapping_add(1);
+        }
+    }
+
+    fn observe_candidates(&mut self, raw_ids: impl Iterator<Item = i64>) {
+        for raw_id in raw_ids {
+            if let Some(retry) = self.rows.get_mut(&raw_id) {
+                retry.last_seen_scan = self.current_scan;
+            }
+        }
+    }
+
     fn should_attempt(&self, raw_id: i64, now: OffsetDateTime) -> bool {
         match self.rows.get(&raw_id) {
             Some(retry) => retry.next_retry_at <= now,
@@ -47,10 +67,13 @@ impl RawDispatchRetryBackoff {
     }
 
     fn record_missing(&mut self, raw_id: i64, now: OffsetDateTime) -> u32 {
+        let current_scan = self.current_scan;
         let retry = self.rows.entry(raw_id).or_insert(RawDispatchRetry {
             attempts: 0,
             next_retry_at: now,
+            last_seen_scan: current_scan,
         });
+        retry.last_seen_scan = current_scan;
         retry.attempts = retry.attempts.saturating_add(1);
 
         let multiplier = 2_i64.pow(retry.attempts.saturating_sub(1).min(4));
@@ -63,6 +86,35 @@ impl RawDispatchRetryBackoff {
 
     fn record_success(&mut self, raw_id: i64) {
         self.rows.remove(&raw_id);
+    }
+
+    fn next_retry_delay(&self, now: OffsetDateTime) -> Option<Duration> {
+        self.rows
+            .values()
+            .map(|retry| {
+                if retry.next_retry_at <= now {
+                    Duration::ZERO
+                } else {
+                    retry
+                        .next_retry_at
+                        .unix_timestamp_nanos()
+                        .checked_sub(now.unix_timestamp_nanos())
+                        .and_then(|nanos| u64::try_from(nanos).ok())
+                        .map(Duration::from_nanos)
+                        .unwrap_or(Duration::MAX)
+                }
+            })
+            .min()
+    }
+
+    fn finish_scan(&mut self, candidate_count: usize, limit: u64) {
+        if candidate_count as u64 >= limit {
+            return;
+        }
+
+        let current_scan = self.current_scan;
+        self.rows
+            .retain(|_, retry| retry.last_seen_scan == current_scan);
     }
 }
 
@@ -160,15 +212,23 @@ impl HyperlaneDbStore {
             )
             .await?;
         let now = OffsetDateTime::now_utc();
+        retry_backoff.begin_scan(after_id);
+        retry_backoff.observe_candidates(
+            raw_dispatches
+                .iter()
+                .map(|raw_dispatch| raw_dispatch.raw_id),
+        );
         let max_unenriched_age_seconds = raw_dispatches
             .iter()
             .map(|raw_dispatch| raw_dispatch_age_seconds(raw_dispatch.time_created, now))
             .max()
             .unwrap_or_default();
         if raw_dispatches.is_empty() {
+            retry_backoff.finish_scan(0, limit);
             return Ok(RawDispatchReconciliationResult {
                 next_after_id: after_id,
                 max_unenriched_age_seconds,
+                next_retry_delay: retry_backoff.next_retry_delay(now),
                 ..Default::default()
             });
         }
@@ -187,11 +247,13 @@ impl HyperlaneDbStore {
             .collect::<Vec<_>>();
 
         if raw_dispatches_to_attempt.is_empty() {
+            retry_backoff.finish_scan(raw_dispatches.len(), limit);
             return Ok(RawDispatchReconciliationResult {
                 candidate_count: raw_dispatches.len(),
                 skipped_backoff_count,
                 next_after_id,
                 max_unenriched_age_seconds,
+                next_retry_delay: retry_backoff.next_retry_delay(now),
                 ..Default::default()
             });
         }
@@ -240,6 +302,7 @@ impl HyperlaneDbStore {
         for raw_id in stored_raw_ids {
             retry_backoff.record_success(raw_id);
         }
+        retry_backoff.finish_scan(raw_dispatches.len(), limit);
 
         if !missing_tx_hashes.is_empty() {
             warn!(
@@ -259,6 +322,7 @@ impl HyperlaneDbStore {
             stored_count: stored as u32,
             next_after_id,
             max_unenriched_age_seconds,
+            next_retry_delay: retry_backoff.next_retry_delay(OffsetDateTime::now_utc()),
         })
     }
 }
@@ -505,5 +569,56 @@ mod tests {
 
         backoff.record_success(raw_id);
         assert!(backoff.should_attempt(raw_id, now));
+    }
+
+    #[test]
+    fn raw_dispatch_retry_backoff_reports_earliest_retry() {
+        let now = OffsetDateTime::now_utc();
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.record_missing(7, now);
+        backoff.record_missing(8, offset_by_seconds(now, 30));
+
+        assert_eq!(
+            backoff.next_retry_delay(now),
+            Some(Duration::from_secs(
+                RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS as u64
+            ))
+        );
+    }
+
+    #[test]
+    fn scan_preserves_retry_that_became_due_after_its_page() {
+        let start = OffsetDateTime::now_utc();
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.begin_scan(0);
+        assert_eq!(backoff.record_missing(raw_id, start), 1);
+
+        backoff.begin_scan(0);
+        let page_time = offset_by_seconds(start, 50);
+        backoff.observe_candidates([raw_id].into_iter());
+        assert!(!backoff.should_attempt(raw_id, page_time));
+
+        backoff.finish_scan(1, 100);
+        let scan_end = offset_by_seconds(start, 70);
+        assert_eq!(backoff.next_retry_delay(scan_end), Some(Duration::ZERO));
+        assert_eq!(backoff.record_missing(raw_id, scan_end), 2);
+    }
+
+    #[test]
+    fn scan_drops_retry_rows_no_longer_returned_by_database() {
+        let now = OffsetDateTime::now_utc();
+        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+
+        backoff.begin_scan(0);
+        assert_eq!(backoff.record_missing(raw_id, now), 1);
+
+        backoff.begin_scan(0);
+        backoff.finish_scan(0, 100);
+
+        assert_eq!(backoff.record_missing(raw_id, now), 1);
     }
 }


### PR DESCRIPTION
## Outcome

Back off raw-dispatch reconciliation once a scan reaches its final page. The production canary materially reduced slow SQL, but did not prove a CPU win; #9449 targets the remaining historical anti-joins.

## Change

| Path | Behaviour | Why |
| --- | --- | --- |
| Full 100-row page | Continue after 2s | Preserve backlog drain speed |
| Short/empty page | Wait until the earlier of the next retry or 5m | Stop poison rows forcing 2s historical scans |
| Startup | Phase each chain across 0–299s | Avoid synchronizing 75+ reconcilers after rollout |
| Long waits | Heartbeat every 30s | Avoid false liveness alerts |
| Retry state | Preserve across pages; prune after a completed scan | Keep backoff correct without retaining completed rows |

Normal inline enrichment is unchanged.

## Production evidence

The regression was DB polling, not additional chain traffic: in matched 10-minute windows CPU rose 0.171 → 0.739 cores while RPC volume only rose 51.9k → 52.7k. Logs contained 102 slow reconciliation anti-joins; Ethereum produced 39, including one 70.2s query. Both intended indexes were present and selected by `EXPLAIN`; cumulative reconciliation-index stats showed 18.4M scans and 42.9B tuples read.

The canary ran from `2026-09-03T03:00Z`:

| Metric | Previous image, age 11–71m | PR image, age 15–75m | Change |
| --- | ---: | ---: | ---: |
| CPU | 0.763 cores | 0.833 cores | +9.2% |
| Memory | 0.304 GiB | 0.280 GiB | -7.9% |
| RPC throughput | 86.86 req/s | 90.39 req/s | +4.1% |
| Slow SQL | 725/hour | 211/hour | **-70.9%** |
| Slow reconciliation SQL | 567/hour | 129/hour | **-77.2%** |
| Logged slow-query wall time | 4,616 s/hour | 1,777 s/hour | **-61.5%** |

The uptime-matched SQL result is the defensible effect. CPU did not improve in that window. The later settled hour reached 0.391 cores, 97 slow SQL/hour and 65 slow reconciliation queries/hour, but that CPU comparison is directional because the previous image only ran for ~75 minutes.

The pod remained ready with zero restarts/errors and all 76 reconciliation tasks live. Image: `ghcr.io/hyperlane-xyz/hyperlane-agent:7735041-20260903-025316`; source `77350416e8`; digest `sha256:14feb714b4edbaa3033b68fe8188425a9c48028033656eb9f9ce4e39f0005763`.

## Why these numbers

| Value | Rationale |
| --- | --- |
| 5m idle cap | 75-chain no-work model falls 108,000 → 21,600 anti-joins/day (**-80%**); new-hole discovery is 2.5m average / 5m worst case |
| 2s backlog cadence | Retains current recovery speed for real full pages |
| 100-row page | Existing bound on per-tick RPC/DB fan-out |
| 0–299s startup phase | Stable Knuth hash spreads domain IDs across the same 5m window without RNG/dependency state |
| 30s heartbeat | Safely below liveness alert windows during longer sleeps |
| 1/2/4/8/15m retry backoff | Existing retry policy; at the 15m cap, poison-row scan ceiling falls 43,200 → 288/day (**-99.33%**) |

Query reductions are code-path models; production figures above are measurements.

## Correctness / verification

- Strict cursor order; no gap skipping. Full pages advance to their last ID; final pages wrap.
- Retry deadlines survive pagination; rows absent after a completed scan are pruned.
- `cargo test -p scraper raw_dispatch`, `cargo test -p scraper scan_`, focused liveness test, clippy, fmt and `git diff --check` passed.
- No schema/config change. Rollback is image-only.

Stack refreshed onto `main` at `06d8269ef1`; exact head `763edd722b`.
