### PR TITLE
perf(scraper): short-circuit failed Sealevel IGP ranges

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -1,4 +1,8 @@
-use std::{ops::RangeInclusive, sync::Arc};
+use std::{
+    future::Future,
+    ops::RangeInclusive,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use derive_new::new;
@@ -7,7 +11,7 @@ use hyperlane_sealevel_igp::{
     igp_gas_payment_pda_seeds, igp_program_data_pda_seeds,
 };
 use solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey};
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use hyperlane_core::{
     config::StrOrIntParseError, ChainCommunicationError, ChainResult, ContractLocator,
@@ -25,6 +29,77 @@ use crate::SealevelProvider;
 /// The account data includes prefixes that are accounted for here: a 1 byte initialized flag
 /// and an 8 byte discriminator.
 const UNIQUE_GAS_PAYMENT_PUBKEY_OFFSET: usize = 1 + 8 + 8 + 32 + 4 + 32 + 8 + 8;
+
+#[derive(Debug, Default)]
+struct RangeScanResume {
+    range: Option<RangeInclusive<u32>>,
+    next_sequence: Option<u32>,
+}
+
+impl RangeScanResume {
+    fn ranges_overlap(left: &RangeInclusive<u32>, right: &RangeInclusive<u32>) -> bool {
+        left.start() <= right.end() && right.start() <= left.end()
+    }
+
+    fn next_sequence_for(&self, range: &RangeInclusive<u32>) -> Option<u32> {
+        self.range
+            .as_ref()
+            .filter(|previous| Self::ranges_overlap(previous, range))
+            .and(self.next_sequence)
+    }
+
+    fn record(&mut self, range: RangeInclusive<u32>, next_sequence: Option<u32>) {
+        if let Some(next_sequence) = next_sequence {
+            self.range = Some(range);
+            self.next_sequence = Some(next_sequence);
+        } else if self
+            .range
+            .as_ref()
+            .is_some_and(|previous| Self::ranges_overlap(previous, &range))
+        {
+            *self = Self::default();
+        }
+    }
+}
+
+// Bound each attempt at the first failed RPC, then rotate the next attempt so a
+// permanently unavailable sequence does not hide later payments. The sequence
+// cursor still requires exact range coverage before it advances.
+async fn scan_range_until_error<T, F, Fut>(
+    range: RangeInclusive<u32>,
+    resume_at: Option<u32>,
+    mut fetch: F,
+) -> (Vec<(u32, T)>, Option<u32>)
+where
+    F: FnMut(u32) -> Fut,
+    Fut: Future<Output = ChainResult<T>>,
+{
+    let range_start = *range.start();
+    let range_end = *range.end();
+    let scan_start = resume_at
+        .filter(|sequence| range.contains(sequence))
+        .unwrap_or(range_start);
+    let mut values =
+        Vec::with_capacity(range_end.saturating_sub(range_start).saturating_add(1) as usize);
+
+    for sequence in (scan_start..=range_end).chain(range_start..scan_start) {
+        match fetch(sequence).await {
+            Ok(value) => values.push((sequence, value)),
+            Err(_) => {
+                let next_sequence = if sequence == range_end {
+                    range_start
+                } else {
+                    sequence.saturating_add(1)
+                };
+                values.sort_unstable_by_key(|(sequence, _)| *sequence);
+                return (values, Some(next_sequence));
+            }
+        }
+    }
+
+    values.sort_unstable_by_key(|(sequence, _)| *sequence);
+    (values, None)
+}
 
 /// A reference to an IGP contract on some Sealevel chain
 #[derive(Debug)]
@@ -95,6 +170,7 @@ pub struct SealevelInterchainGasPaymasterIndexer {
     igp: SealevelInterchainGasPaymaster,
     log_meta_composer: LogMetaComposer,
     advanced_log_meta: bool,
+    range_scan_resume: Mutex<RangeScanResume>,
 }
 
 /// IGP payment data on Sealevel
@@ -126,6 +202,7 @@ impl SealevelInterchainGasPaymasterIndexer {
             igp,
             log_meta_composer,
             advanced_log_meta,
+            range_scan_resume: Mutex::new(RangeScanResume::default()),
         })
     }
 
@@ -288,10 +365,30 @@ impl Indexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
             "Fetching SealevelInterchainGasPaymasterIndexer InterchainGasPayment logs"
         );
 
-        let payments_capacity = range.end().saturating_sub(*range.start());
-        let mut payments = Vec::with_capacity(payments_capacity as usize);
-        for nonce in range {
-            if let Ok(sealevel_payment) = self.get_payment_with_sequence(nonce.into()).await {
+        let resume_at = self
+            .range_scan_resume
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .next_sequence_for(&range);
+        let (sealevel_payments, next_sequence) =
+            scan_range_until_error(range.clone(), resume_at, |nonce| {
+                self.get_payment_with_sequence(nonce.into())
+            })
+            .await;
+        self.range_scan_resume
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .record(range.clone(), next_sequence);
+        if let Some(next_sequence) = next_sequence {
+            debug!(
+                ?range,
+                next_sequence, "Stopped IGP range scan after first sequence error"
+            );
+        }
+
+        let payments = sealevel_payments
+            .into_iter()
+            .map(|(nonce, sealevel_payment)| {
                 let igp_account_filter = self.igp.igp_account;
                 let mut payment = *sealevel_payment.payment.inner();
                 // If fees is paid to a different IGP account, we zero out the payment to make sure the db entries are contiguous, but at the same time, gasEnforcer will reject the message (if not set to none policy)
@@ -300,12 +397,12 @@ impl Indexer<InterchainGasPayment> for SealevelInterchainGasPaymasterIndexer {
 
                     payment.payment = U256::from(0);
                 }
-                payments.push((
+                (
                     Indexed::new(payment).with_sequence(nonce),
                     sealevel_payment.log_meta,
-                ));
-            }
-        }
+                )
+            })
+            .collect();
         Ok(payments)
     }
 
@@ -378,5 +475,134 @@ mod tests {
             expected_unique_gas_payment_pubkey,
             sliced_unique_gas_payment_pubkey
         );
+    }
+
+    #[tokio::test]
+    async fn range_scan_stops_at_first_error_and_resumes_after_it() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let first_calls = calls.clone();
+        let (values, resume_at) = scan_range_until_error(10..=12, None, move |sequence| {
+            let calls = first_calls.clone();
+            async move {
+                calls.lock().expect("calls mutex poisoned").push(sequence);
+                if sequence == 10 {
+                    Err(ChainCommunicationError::from_other_str("unavailable"))
+                } else {
+                    Ok(sequence)
+                }
+            }
+        })
+        .await;
+
+        assert!(values.is_empty());
+        assert_eq!(resume_at, Some(11));
+        assert_eq!(*calls.lock().expect("calls mutex poisoned"), vec![10]);
+
+        calls.lock().expect("calls mutex poisoned").clear();
+        let second_calls = calls.clone();
+        let (values, resume_at) = scan_range_until_error(10..=12, resume_at, move |sequence| {
+            let calls = second_calls.clone();
+            async move {
+                calls.lock().expect("calls mutex poisoned").push(sequence);
+                Ok(sequence)
+            }
+        })
+        .await;
+
+        assert_eq!(
+            values
+                .into_iter()
+                .map(|(sequence, _)| sequence)
+                .collect::<Vec<_>>(),
+            vec![10, 11, 12]
+        );
+        assert_eq!(resume_at, None);
+        assert_eq!(
+            *calls.lock().expect("calls mutex poisoned"),
+            vec![11, 12, 10]
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_prefix_is_returned_before_rotating_past_the_failure() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let first_calls = calls.clone();
+        let (values, resume_at) = scan_range_until_error(10..=13, None, move |sequence| {
+            let calls = first_calls.clone();
+            async move {
+                calls.lock().expect("calls mutex poisoned").push(sequence);
+                if sequence == 11 {
+                    Err(ChainCommunicationError::from_other_str("unavailable"))
+                } else {
+                    Ok(sequence)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(values, vec![(10, 10)]);
+        assert_eq!(resume_at, Some(12));
+        assert_eq!(*calls.lock().expect("calls mutex poisoned"), vec![10, 11]);
+
+        calls.lock().expect("calls mutex poisoned").clear();
+        let second_calls = calls.clone();
+        let (values, resume_at) = scan_range_until_error(10..=13, resume_at, move |sequence| {
+            let calls = second_calls.clone();
+            async move {
+                calls.lock().expect("calls mutex poisoned").push(sequence);
+                Ok(sequence)
+            }
+        })
+        .await;
+
+        assert_eq!(values, vec![(10, 10), (11, 11), (12, 12), (13, 13)]);
+        assert_eq!(resume_at, None);
+        assert_eq!(
+            *calls.lock().expect("calls mutex poisoned"),
+            vec![12, 13, 10, 11]
+        );
+    }
+
+    #[tokio::test]
+    async fn persistent_failures_rotate_across_the_full_range() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mut resume_at = None;
+
+        for expected in [20, 21, 22, 20] {
+            let attempt_calls = calls.clone();
+            let (values, next) = scan_range_until_error(20..=22, resume_at, move |sequence| {
+                let calls = attempt_calls.clone();
+                async move {
+                    calls.lock().expect("calls mutex poisoned").push(sequence);
+                    Err::<u32, _>(ChainCommunicationError::from_other_str("unavailable"))
+                }
+            })
+            .await;
+            assert!(values.is_empty());
+            assert_eq!(
+                calls.lock().expect("calls mutex poisoned").last(),
+                Some(&expected)
+            );
+            resume_at = next;
+        }
+
+        assert_eq!(
+            *calls.lock().expect("calls mutex poisoned"),
+            vec![20, 21, 22, 20]
+        );
+    }
+
+    #[test]
+    fn unrelated_range_success_does_not_clear_resume_state() {
+        let mut state = RangeScanResume::default();
+        state.record(20..=22, Some(21));
+
+        state.record(100..=102, None);
+
+        assert_eq!(state.next_sequence_for(&(20..=22)), Some(21));
+        assert_eq!(state.next_sequence_for(&(100..=102)), None);
+
+        state.record(21..=23, None);
+        assert_eq!(state.next_sequence_for(&(20..=22)), None);
     }
 }

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -1317,6 +1317,10 @@ mod test {
     }
 
     mod sequence_range {
+        use std::sync::Mutex;
+
+        use hyperlane_core::{ChainResult, Indexer};
+
         use super::*;
 
         const INDEX_MODE: IndexMode = IndexMode::Sequence;
@@ -1754,6 +1758,76 @@ mod test {
                     .get(),
                 8
             );
+        }
+
+        #[derive(Debug, Default)]
+        struct RotatingFailFastFailureIndexer {
+            next_sequence: Mutex<Option<u32>>,
+            calls: Mutex<Vec<u32>>,
+        }
+
+        #[async_trait]
+        impl Indexer<MockSequencedData> for RotatingFailFastFailureIndexer {
+            async fn fetch_logs_in_range(
+                &self,
+                range: RangeInclusive<u32>,
+            ) -> ChainResult<Vec<(Indexed<MockSequencedData>, LogMeta)>> {
+                let mut next_sequence = self
+                    .next_sequence
+                    .lock()
+                    .expect("next sequence mutex poisoned");
+                let sequence = next_sequence
+                    .filter(|sequence| range.contains(sequence))
+                    .unwrap_or(*range.start());
+                self.calls
+                    .lock()
+                    .expect("calls mutex poisoned")
+                    .push(sequence);
+                *next_sequence = Some(if sequence == *range.end() {
+                    *range.start()
+                } else {
+                    sequence.saturating_add(1)
+                });
+
+                Ok(vec![])
+            }
+
+            async fn get_finalized_block_number(&self) -> ChainResult<u32> {
+                Ok(0)
+            }
+        }
+
+        #[tokio::test]
+        async fn test_rotating_fail_fast_failures_keep_gap_backoff_at_cap() {
+            let mut cursor =
+                get_test_backward_sequence_aware_sync_cursor(INDEX_MODE, 20, LOWEST_SEQUENCE).await;
+            let indexer = RotatingFailFastFailureIndexer::default();
+            let range = 79..=99;
+            let expected_delays = [5, 10, 20, 40, 80, 160, 300, 300, 300];
+
+            for (attempt, expected_delay) in expected_delays.into_iter().enumerate() {
+                cursor.sequence_gap_retry_at = None;
+                assert_eq!(cursor.get_next_range().await.unwrap(), Some(range.clone()));
+
+                let logs = indexer.fetch_logs_in_range(range.clone()).await.unwrap();
+                assert!(logs.is_empty());
+                cursor.update(logs, range.clone()).await.unwrap();
+
+                let calls = indexer.calls.lock().expect("calls mutex poisoned");
+                assert_eq!(calls.len(), attempt + 1);
+                assert_eq!(calls[attempt], 79 + attempt as u32);
+                drop(calls);
+                assert_eq!(cursor.sequence_gap_retries, attempt as u32 + 1);
+                assert_eq!(
+                    cursor
+                        .metrics
+                        .cursor_sequence_gap_backoff_seconds
+                        .with_label_values(&["mock_indexable", "test"])
+                        .get(),
+                    expected_delay
+                );
+                assert_eq!(cursor.get_next_range().await.unwrap(), None);
+            }
         }
 
         #[tracing_test::traced_test]


### PR DESCRIPTION
## Summary

Stacked on #9165.

Sealevel IGP sequence scans currently try every sequence after an archive-node `getBlock` failure. The live Eclipse gap is 21 sequences wide, so each backed-off attempt fans out to 21 outer requests and four provider attempts per request.

This stops a scan at its first failed sequence and resumes after that sequence on the next attempt. The probe position wraps through the same range, so a permanently unavailable sequence does not hide later valid payments. Successful results are returned in canonical sequence order.

## Live evidence

At the 2026-08-10 sample:

- Prometheus recorded **370,732 failed scraper `getBlock` calls over 24h**: Eclipse 250,946; Sonic 119,786 (59,893 on each Sonic provider).
- A 10-minute log sample split 2,555 inner fallback failures into **1,176 Eclipse IGP** calls and **1,379 mailbox** calls. The RPC metric has no event/data-type label, so an exact 24-hour IGP/mailbox split is not derivable.
- Eclipse IGP repeatedly queried sequences `211562..=211582`. Each of the 21 sequences was absent, and each outer lookup tried four providers.

This PR only changes the IGP per-sequence path. #9216 covers mailbox range failures.

## Expected impact

At #9165's five-minute cap and the observed four-provider fanout:

| Path | Current model | With this stack |
| --- | ---: | ---: |
| Eclipse IGP | 21 sequences x 4 providers x 288 attempts/day = 24,192/day | 1 sequence x 4 providers x 288 = 1,152/day |
| SVM mailbox (#9216) | 4,608/day | 4,608/day |
| Combined SVM residual | 28,800/day | 5,760/day |

That is a modeled 95.2% reduction in the residual Eclipse IGP calls and a modeled 98.4% reduction from the observed 370,732 failed SVM calls when #9165, #9216, and this stack are all deployed. These are pre-deploy models, not measured savings.

## Correctness

- The cursor still requires exact sequence coverage before advancing; changing probe order cannot skip a gap.
- Partial successes are stored as before. Later attempts rotate through every sequence and wrap, while returned results remain sorted.
- Persistent all-fail responses stay externally empty, so #9165's cumulative missing set remains stable and backs off through 5/10/20/40/80/160/300 seconds rather than resetting.
- Cancellation before recording the next probe only repeats work. Mutex guards never cross an RPC await.

The original partial-success behavior came from the initial Sealevel IGP indexer design (#2585); this preserves it instead of turning a single missing historical sequence into a permanent barrier for later valid payments.

## Verification

- `cargo test -p hyperlane-sealevel interchain_gas::tests --lib` — 5 passed
- `cargo test -p hyperlane-base test_rotating_fail_fast_failures_keep_gap_backoff_at_cap --lib` — passed; real backward cursor, 21-sequence mock range, one probe/attempt, five-minute cap retained
- `cargo clippy -p hyperlane-sealevel --lib -- -D warnings` — passed
- `cargo fmt --package hyperlane-base --package hyperlane-sealevel -- --check` — passed
- `git diff --check` — passed
- Independent review — no blocking findings

## Residuals / rollout

- Forward sequence gaps do not yet have #9165's exponential backoff. Fail-fast still bounds each attempt, but a current-head failure can retry faster. The measured Eclipse issue is the backward historical path.
- Resume state is one range-scoped slot. Concurrent disjoint failing scans could overwrite scan order, but the current IGP sync uses one cursor task; this affects efficiency, not cursor correctness.
- A fully failing 21-sequence range takes up to 105 minutes to probe every sequence once at the five-minute cap. The cursor already cannot advance across the missing range; partial successes remain storable.
- Land #9165 first, then this PR. #9216 is independent and covers the mailbox half. Measure `hyperlane_request_count` and the new #9165 gap metrics after deployment before calling the savings realized.

## Stack refresh

Rebased on #9165 head `fa1b51f497`; this PR’s exact head is `214ecca352`. The stack remains one cursor-policy commit followed by one Sealevel IGP fanout commit.