### PR TITLE
fix(sdk): poll zero-confirmation receipts

### DIFF
--- a/.changeset/quiet-receipts-arrive.md
+++ b/.changeset/quiet-receipts-arrive.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+`MultiProvider.handleTx` was updated to return an included receipt for successful transactions when zero confirmations are configured, without waiting for ethers' default confirmation polling interval.

--- a/typescript/sdk/src/providers/MultiProvider.test.ts
+++ b/typescript/sdk/src/providers/MultiProvider.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { ContractFactory } from 'ethers';
+import type { ContractTransaction } from 'ethers';
 
 import {
   Mailbox__factory,
@@ -115,19 +116,24 @@ describe('MultiProvider', () => {
       expect(mockTx.wait.calledOnce).to.be.true;
     });
 
-    it('should wait for inclusion when wait(0) returns null', async () => {
+    it('should wait for inclusion when zero confirmations are requested', async () => {
       const mockReceipt = {
         transactionHash: '0xabc123def456',
         blockNumber: 100,
         status: 1,
       } as unknown as ProtocolReceipt<any>;
 
-      const waitStub = sinon
-        .stub()
-        .callsFake(async (confirmations?: number) => {
-          if (confirmations === 0) return null;
-          return mockReceipt;
-        });
+      const waitStub = sinon.stub();
+      waitStub.withArgs(0).resolves(mockReceipt);
+      waitStub.withArgs(1).returns(new Promise(() => {}));
+      const receiptProbe = sinon
+        .stub(
+          multiProvider.getProvider(TestChainName.test1),
+          'getTransactionReceipt',
+        )
+        .onFirstCall()
+        .resolves(undefined);
+      receiptProbe.onSecondCall().resolves(mockReceipt);
 
       const mockTx = {
         hash: '0xabc123def456',
@@ -140,10 +146,60 @@ describe('MultiProvider', () => {
       });
 
       expect(result).to.deep.equal(mockReceipt);
-      expect(waitStub.calledTwice).to.be.true;
-      expect(waitStub.firstCall.args[0]).to.equal(0);
-      expect(waitStub.secondCall.args[0]).to.equal(1);
+      expect(receiptProbe.calledTwice).to.be.true;
+      expect(waitStub.withArgs(0).calledOnce).to.be.true;
+      expect(waitStub.withArgs(1).calledOnce).to.be.true;
     });
+
+    for (const { reason, cancelled } of [
+      { reason: 'cancelled', cancelled: true },
+      { reason: 'repriced', cancelled: false },
+    ] as const) {
+      it(`should propagate ${reason} transaction replacements`, async () => {
+        const replacementReceipt = {
+          transactionHash: '0xreplacement',
+          blockNumber: 101,
+          status: 1,
+        };
+        const replacementError = Object.assign(
+          new Error('transaction was replaced'),
+          {
+            code: 'TRANSACTION_REPLACED',
+            reason,
+            cancelled,
+            receipt: replacementReceipt,
+          },
+        );
+        const waitStub = sinon.stub();
+        waitStub.withArgs(1).rejects(replacementError);
+        const receiptProbe = sinon
+          .stub(
+            multiProvider.getProvider(TestChainName.test1),
+            'getTransactionReceipt',
+          )
+          .resolves(undefined);
+        // CAST: handleTx only reads hash and wait; a complete ethers transaction
+        // would add unrelated fields to this focused replacement-error test.
+        const mockTx = {
+          hash: '0xabc123def456',
+          wait: waitStub,
+        } as unknown as ContractTransaction;
+
+        try {
+          await multiProvider.handleTx(TestChainName.test1, mockTx, {
+            waitConfirmations: 0,
+            timeoutMs: 5000,
+          });
+          expect.fail('Expected transaction replacement error');
+        } catch (error) {
+          expect(error).to.equal(replacementError);
+          expect(replacementError.reason).to.equal(reason);
+          expect(replacementError.receipt).to.equal(replacementReceipt);
+          expect(receiptProbe.called).to.be.true;
+          expect(waitStub.withArgs(0).notCalled).to.be.true;
+        }
+      });
+    }
 
     it('should not timeout when timeoutMs is 0', async () => {
       const mockReceipt = {

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -23,6 +23,7 @@ import {
   assert,
   pick,
   rootLogger,
+  sleep,
   timeout,
 } from '@hyperlane-xyz/utils';
 
@@ -47,6 +48,47 @@ type Provider = providers.Provider | ZKSyncProvider;
 
 const DEFAULT_CONFIRMATION_TIMEOUT_MS = 300_000;
 const MIN_CONFIRMATION_TIMEOUT_MS = 30_000;
+const INITIAL_RECEIPT_POLL_INTERVAL_MS = 100;
+
+// Preserve ethers' replacement detection while polling its non-blocking
+// zero-confirmation receipt probe more frequently than the default interval.
+async function waitForInitialReceipt(
+  response: ContractTransaction,
+  provider: Provider,
+  timeoutMs: number,
+): Promise<ContractReceipt> {
+  let shouldPoll = true;
+  const replacementAwareReceipt = response.wait(1);
+  const fastReceipt = async (): Promise<ContractReceipt> => {
+    while (shouldPoll) {
+      // ContractTransaction.wait(0) attempts to parse receipt.logs even when
+      // ethers' provider-level wait returns null. Probe the provider first so
+      // the contract wrapper only runs after the transaction is included.
+      const receipt = await provider.getTransactionReceipt(response.hash);
+      if (receipt) {
+        const contractReceipt = await response.wait(0);
+        assert(
+          contractReceipt,
+          `Transaction ${response.hash} was not included`,
+        );
+        return contractReceipt;
+      }
+      await sleep(INITIAL_RECEIPT_POLL_INTERVAL_MS);
+    }
+
+    return replacementAwareReceipt;
+  };
+
+  try {
+    return await timeout(
+      Promise.race([fastReceipt(), replacementAwareReceipt]),
+      timeoutMs,
+      `Timeout (${timeoutMs}ms) waiting for initial inclusion for tx ${response.hash}`,
+    );
+  } finally {
+    shouldPoll = false;
+  }
+}
 
 export interface MultiProviderOptions {
   logger?: Logger;
@@ -538,6 +580,14 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
       );
     }
 
+    if (confirmations === 0) {
+      return waitForInitialReceipt(
+        response,
+        this.getProvider(chainNameOrId),
+        timeoutMs,
+      );
+    }
+
     // Handle numeric confirmations
     this.logger.info(
       `Pending ${txUrl || response.hash} (waiting ${confirmations} blocks for confirmation)`,
@@ -548,19 +598,8 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
       `Timeout (${timeoutMs}ms) waiting for ${confirmations} block confirmations for tx ${response.hash}`,
     );
 
-    // ethers v5 can return null for wait(0) if tx is still pending.
-    if (receipt) return receipt;
-
-    this.logger.info(
-      `Pending ${txUrl || response.hash} (wait(0) returned pending, waiting for initial inclusion)`,
-    );
-    const inclusionReceipt = await timeout(
-      response.wait(1),
-      timeoutMs,
-      `Timeout (${timeoutMs}ms) waiting for initial inclusion for tx ${response.hash}`,
-    );
-    assert(inclusionReceipt, `Transaction ${response.hash} was not included`);
-    return inclusionReceipt;
+    assert(receipt, `Transaction ${response.hash} was not included`);
+    return receipt;
   }
 
   /**


### PR DESCRIPTION
## Summary

- preserve `MultiProvider.handleTx`'s guarantee that successful zero-confirmation calls return an included receipt
- poll the provider for inclusion every 100 ms, then invoke ethers' contract receipt parser only after a receipt exists
- race that fast probe with ethers' replacement-aware `wait(1)` path so cancellation and repricing errors retain their reason, replacement, and receipt
- add focused inclusion, cancellation, and repricing regression coverage plus an SDK patch changeset

## Context

The Node 26 dependency-upgrade run exposed the existing ethers v5 race where `wait(0)` can initially return `null`. The fallback introduced in #8133 correctly prevented `handleTx` from returning `null`, but `wait(1)` uses ethers' default polling interval and added roughly four seconds to each affected local transaction.

Calling `ContractTransaction.wait(0)` while the transaction is pending can also make ethers attempt to parse `null.logs`. The provider-level probe avoids that contract-wrapper failure while preserving the parsed contract receipt after inclusion.

This keeps #8133's inclusion and replacement semantics while making the receipt probe responsive. It is split from #9190 so the SDK behavior change can land and be reviewed independently. Rebalancer E2E sharding will follow in a separate PR.

## Validation

- `pnpm install --frozen-lockfile` (Node 24)
- `pnpm -C typescript/sdk check`
- focused `MultiProvider.handleTx` unit tests: 9 passing
- repository Oxfmt check: 2,492 files
- `git diff --check`
