### PR TITLE
fix(sdk): renounce ownership for zero owner configs

### DIFF
--- a/.changeset/export-evm-zeroish-helper.md
+++ b/.changeset/export-evm-zeroish-helper.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/utils": patch
+---
+
+Exported an EVM-specific zeroish address helper.

--- a/.changeset/tame-humans-judge.md
+++ b/.changeset/tame-humans-judge.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/sdk": patch
+---
+
+Renounce ownership if a zero address is provided

--- a/.changeset/tame-humans-judge.md
+++ b/.changeset/tame-humans-judge.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/sdk": patch
 ---
 
-Renounce ownership if a zero address is provided
+Renounced ownership when a zero address was provided

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -11,6 +11,7 @@ import {
   eqAddress,
   hexOrBase58ToHex,
   isEVMLike,
+  isZeroishAddress,
   objFilter,
   objMap,
   pick,
@@ -310,6 +311,21 @@ export function transferOwnershipTransactions(
 ): AnnotatedEV5Transaction[] {
   if (eqAddress(actual.owner, expected.owner)) {
     return [];
+  }
+
+  if (isZeroishAddress(expected.owner)) {
+    return [
+      {
+        chainId,
+        annotation: `Renouncing ownership of ${label ?? contract} from ${
+          actual.owner
+        }`,
+        to: contract,
+        data: Ownable__factory.createInterface().encodeFunctionData(
+          'renounceOwnership',
+        ),
+      },
+    ];
   }
 
   return [

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -11,6 +11,7 @@ import {
   eqAddress,
   hexOrBase58ToHex,
   isEVMLike,
+  isZeroishAddressEvm,
   objFilter,
   objMap,
   pick,
@@ -35,10 +36,6 @@ import {
   HyperlaneContractsMap,
   HyperlaneFactories,
 } from './types.js';
-
-function isEvmZeroishAddress(address: Address): boolean {
-  return /^0x0*$/i.test(address);
-}
 
 export function serializeContractsMap<F extends HyperlaneFactories>(
   contractsMap: HyperlaneContractsMap<F>,
@@ -314,12 +311,12 @@ export function transferOwnershipTransactions(
 ): AnnotatedEV5Transaction[] {
   if (
     eqAddress(actual.owner, expected.owner) ||
-    (isEvmZeroishAddress(actual.owner) && isEvmZeroishAddress(expected.owner))
+    (isZeroishAddressEvm(actual.owner) && isZeroishAddressEvm(expected.owner))
   ) {
     return [];
   }
 
-  if (isEvmZeroishAddress(expected.owner)) {
+  if (isZeroishAddressEvm(expected.owner)) {
     return [
       {
         chainId,

--- a/typescript/sdk/src/contracts/contracts.ts
+++ b/typescript/sdk/src/contracts/contracts.ts
@@ -11,7 +11,6 @@ import {
   eqAddress,
   hexOrBase58ToHex,
   isEVMLike,
-  isZeroishAddress,
   objFilter,
   objMap,
   pick,
@@ -36,6 +35,10 @@ import {
   HyperlaneContractsMap,
   HyperlaneFactories,
 } from './types.js';
+
+function isEvmZeroishAddress(address: Address): boolean {
+  return /^0x0*$/i.test(address);
+}
 
 export function serializeContractsMap<F extends HyperlaneFactories>(
   contractsMap: HyperlaneContractsMap<F>,
@@ -309,11 +312,14 @@ export function transferOwnershipTransactions(
   expected: OwnableConfig,
   label?: string,
 ): AnnotatedEV5Transaction[] {
-  if (eqAddress(actual.owner, expected.owner)) {
+  if (
+    eqAddress(actual.owner, expected.owner) ||
+    (isEvmZeroishAddress(actual.owner) && isEvmZeroishAddress(expected.owner))
+  ) {
     return [];
   }
 
-  if (isZeroishAddress(expected.owner)) {
+  if (isEvmZeroishAddress(expected.owner)) {
     return [
       {
         chainId,

--- a/typescript/sdk/src/deploy/proxy.test.ts
+++ b/typescript/sdk/src/deploy/proxy.test.ts
@@ -3,6 +3,8 @@ import { ethers } from 'ethers';
 
 import { Ownable__factory } from '@hyperlane-xyz/core';
 
+import { transferOwnershipTransactions } from '../contracts/contracts.js';
+
 import { isInitialized, proxyAdmin, proxyAdminUpdateTxs } from './proxy.js';
 
 describe('proxy utilities', () => {
@@ -234,6 +236,52 @@ describe('proxy utilities', () => {
           'renounceOwnership',
         ),
       );
+    });
+  });
+
+  describe('transferOwnershipTransactions', () => {
+    const CHAIN_ID = 1;
+    const CONTRACT_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const OWNER_A = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    it('should renounce ownership for expected EVM zero address', () => {
+      const txs = transferOwnershipTransactions(
+        CHAIN_ID,
+        CONTRACT_ADDRESS,
+        { owner: OWNER_A },
+        { owner: ethers.constants.AddressZero },
+      );
+
+      expect(txs.length).to.equal(1);
+      expect(txs[0].to).to.equal(CONTRACT_ADDRESS);
+      expect(txs[0].annotation).to.include('Renouncing ownership');
+      expect(txs[0].data).to.equal(
+        Ownable__factory.createInterface().encodeFunctionData(
+          'renounceOwnership',
+        ),
+      );
+    });
+
+    it('should treat EVM zero address and bytes32 zero as equal', () => {
+      const txs = transferOwnershipTransactions(
+        CHAIN_ID,
+        CONTRACT_ADDRESS,
+        { owner: ethers.constants.AddressZero },
+        { owner: ethers.constants.HashZero },
+      );
+
+      expect(txs.length).to.equal(0);
+    });
+
+    it('should reject non-EVM zero sentinels', () => {
+      expect(() =>
+        transferOwnershipTransactions(
+          CHAIN_ID,
+          CONTRACT_ADDRESS,
+          { owner: OWNER_A },
+          { owner: '111111' },
+        ),
+      ).to.throw('invalid address');
     });
   });
 });

--- a/typescript/sdk/src/deploy/proxy.test.ts
+++ b/typescript/sdk/src/deploy/proxy.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 
+import { Ownable__factory } from '@hyperlane-xyz/core';
+
 import { isInitialized, proxyAdmin, proxyAdminUpdateTxs } from './proxy.js';
 
 describe('proxy utilities', () => {
@@ -209,6 +211,29 @@ describe('proxy utilities', () => {
       );
       expect(txs.length).to.equal(1);
       expect(txs[0].annotation).to.include(OWNER_B);
+    });
+
+    it('should renounce ownership when expected proxyAdmin owner is zero address', () => {
+      const txs = proxyAdminUpdateTxs(
+        CHAIN_ID,
+        PROXY_ADDRESS,
+        {
+          owner: OWNER_A,
+          proxyAdmin: { address: PROXY_ADMIN_ADDRESS, owner: OWNER_A },
+        },
+        {
+          owner: OWNER_A,
+          proxyAdmin: { owner: ethers.constants.AddressZero },
+        },
+      );
+      expect(txs.length).to.equal(1);
+      expect(txs[0].to).to.equal(PROXY_ADMIN_ADDRESS);
+      expect(txs[0].annotation).to.include('Renouncing ownership');
+      expect(txs[0].data).to.equal(
+        Ownable__factory.createInterface().encodeFunctionData(
+          'renounceOwnership',
+        ),
+      );
     });
   });
 });

--- a/typescript/utils/src/addresses.test.ts
+++ b/typescript/utils/src/addresses.test.ts
@@ -7,6 +7,7 @@ import {
   isAddressStarknet,
   isValidAddressStarknet,
   isZeroishAddress,
+  isZeroishAddressEvm,
   normalizeAddressEvm,
   padBytesToLength,
 } from './addresses.js';
@@ -56,6 +57,20 @@ describe('Address utilities', () => {
       expect(isZeroishAddress(COSMOS_NATIVE_NON_ZERO_ADDR)).to.be.false;
       expect(isZeroishAddress(SOL_NON_ZERO_ADDR)).to.be.false;
       expect(isZeroishAddress(STARKNET_NON_ZERO_ADDR)).to.be.false;
+    });
+  });
+
+  describe('isZeroishAddressEvm', () => {
+    it('Identifies EVM 0-ish addresses', () => {
+      expect(isZeroishAddressEvm('0x')).to.be.true;
+      expect(isZeroishAddressEvm(ETH_ZERO_ADDR)).to.be.true;
+      expect(isZeroishAddressEvm(COSMOS_NATIVE_ZERO_ADDR)).to.be.true;
+    });
+
+    it('Rejects non-hex 0-ish addresses', () => {
+      expect(isZeroishAddressEvm(COS_ZERO_ADDR)).to.be.false;
+      expect(isZeroishAddressEvm(SOL_ZERO_ADDR)).to.be.false;
+      expect(isZeroishAddressEvm(STARKNET_ZERO_ADDR)).to.be.true;
     });
   });
 

--- a/typescript/utils/src/addresses.ts
+++ b/typescript/utils/src/addresses.ts
@@ -413,9 +413,13 @@ export function isEmptyAddress(address: Address | undefined | null): boolean {
   return !address || isZeroishAddress(address);
 }
 
+export function isZeroishAddressEvm(address: Address) {
+  return EVM_ZEROISH_ADDRESS_REGEX.test(address);
+}
+
 export function isZeroishAddress(address: Address) {
   return (
-    EVM_ZEROISH_ADDRESS_REGEX.test(address) ||
+    isZeroishAddressEvm(address) ||
     SEALEVEL_ZEROISH_ADDRESS_REGEX.test(address) ||
     COSMOS_ZEROISH_ADDRESS_REGEX.test(address) ||
     COSMOS_NATIVE_ZEROISH_ADDRESS_REGEX.test(address) ||

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -61,6 +61,7 @@ export {
   isValidTransactionHashTron,
   isEmptyAddress,
   isZeroishAddress,
+  isZeroishAddressEvm,
   normalizeAddress,
   normalizeAddressCosmos,
   normalizeAddressEvm,


### PR DESCRIPTION
## Summary
- emit renounceOwnership() instead of transferOwnership(0) when expected owner is zero-ish
- add proxy admin update coverage for renounce calldata
- add sdk changeset

## Test plan
- pnpm -C typescript/sdk build
- pnpm -C typescript/sdk exec mocha --config .mocharc.json ./src/deploy/proxy.test.ts --exit