### PR TITLE
ci: shard rebalancer E2E tests

### DIFF
--- a/.github/workflows/rebalancer-e2e-test.yml
+++ b/.github/workflows/rebalancer-e2e-test.yml
@@ -29,9 +29,32 @@ env:
   TURBO_TEAM: ${{ secrets.DEPOT_ORG_ID }}
 
 jobs:
-  rebalancer-e2e-test:
+  rebalancer-e2e-shards:
+    name: rebalancer-e2e-shard (${{ matrix.name }})
     runs-on: depot-ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: collateral-composite
+            specs: >-
+              src/e2e/collateral-deficit.e2e-test.ts
+              src/e2e/composite.e2e-test.ts
+          - name: erc20-min-mixed
+            specs: >-
+              src/e2e/inventory-erc20-minAmount.e2e-test.ts
+              src/e2e/mixed-weighted.e2e-test.ts
+          - name: erc20-weighted-min
+            specs: >-
+              src/e2e/inventory-erc20-weighted.e2e-test.ts
+              src/e2e/minAmount.e2e-test.ts
+          - name: inventory-min-weighted
+            specs: >-
+              src/e2e/inventory-minAmount.e2e-test.ts
+              src/e2e/weighted.e2e-test.ts
+          - name: inventory-weighted
+            specs: src/e2e/inventory-weighted.e2e-test.ts
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,4 +66,21 @@ jobs:
 
       - name: Run rebalancer E2E tests (serial)
         working-directory: typescript/rebalancer
-        run: pnpm mocha --config .mocharc.e2e.json --exit
+        run: >-
+          pnpm mocha
+          --no-config
+          --extension ts
+          --node-option import=tsx/esm
+          --timeout 300000
+          --exit
+          ${{ matrix.specs }}
+
+  rebalancer-e2e-test:
+    name: rebalancer-e2e-test
+    if: always()
+    needs: rebalancer-e2e-shards
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check E2E shards
+        run: test '${{ needs.rebalancer-e2e-shards.result }}' = success


### PR DESCRIPTION
## Summary

- split the 42 rebalancer E2E cases across five balanced shards
- keep each shard within the 15-minute job cap
- retain the required `rebalancer-e2e-test` check as an aggregate gate

## Context

[#8133](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/8133) intentionally replaced the old matrix with one serial job. At the time, every matrix leg still loaded all suites through `.mocharc.e2e.json`, so CI duplicated the expensive build/container setup four times without actually partitioning the tests. Serial execution was the correct fix for that configuration.

The suite has since grown to 42 tests. It now spends roughly four minutes building and exceeds both the original 10-minute cap and a 15-minute retry. This restores parallelism without restoring #8133's fan-in bug: every shard uses `--no-config` and receives an explicit, disjoint spec list. The five balanced groups cover all nine E2E files exactly once.

This PR is stacked on #9228 so CI validates the receipt-polling fix with the complete sharded suite.

## Validation

- Oxfmt check: 2,492 files
- Actionlint: clean (excluding the repository's existing custom Depot runner-label warning)
- Mocha dry-run shard counts: 7 + 9 + 10 + 10 + 6 = 42 tests
- all nine `typescript/rebalancer/src/e2e/*e2e-test.ts` files are included exactly once
