### PR TITLE
fix(infra): disable botanix agents (ENG-3999)

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -85,7 +85,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     blast: true,
     bob: true,
     boba: true,
-    botanix: true,
+    botanix: false, // disabled — RPC down (chain tip frozen); removal per ENG-3999
     bsc: true,
     bsquared: true,
     carrchain: true,
@@ -187,7 +187,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     blast: true,
     bob: true,
     boba: true,
-    botanix: true,
+    botanix: false, // disabled — RPC down (chain tip frozen); removal per ENG-3999
     bsc: true,
     bsquared: true,
     carrchain: true,
@@ -289,7 +289,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     blast: true,
     bob: true,
     boba: true,
-    botanix: true,
+    botanix: false, // disabled — RPC down (chain tip frozen); removal per ENG-3999
     bsc: true,
     bsquared: true,
     carrchain: true,


### PR DESCRIPTION
## Summary
- Disable botanix for validator, relayer, and scraper roles in mainnet3 `agent.ts` (matches existing `soon: false` / `taiko: false` disable pattern).
- Botanix's sole RPC (`rpc.botanixlabs.com`) has been returning HTTP 522 with a frozen chain tip (block 6575567) for >13h with no recovery; block delta over 30m = 0 across all three agents.
- Removal tracked in ENG-3999 ("Removal Planned").

## Operational context
- Botanix validator StatefulSet `botanix-validator-hyperlane-agent-validator` (namespace `validator-mainnet3`) has already been scaled to 0 (reversible; Helm release + PVC preserved).
- The shared omniscient relayer/scraper stop indexing botanix on the next deploy of this config.
- 3 botanix Grafana silences (destination/origin/chain) are active until 2026-08-11T02:00Z and will lapse naturally after this lands.

## Restore
- Revert this change and `kubectl scale statefulset botanix-validator-hyperlane-agent-validator -n validator-mainnet3 --replicas=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)