### PR TITLE
fix(infra): scope agent key reconciliation to deployed roles

### DIFF
--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -10,7 +10,7 @@ import {
   warnIfPrTag,
 } from '../../src/utils/gcloud.js';
 import { HelmCommand } from '../../src/utils/helm.js';
-import { getArgs, withYes } from '../agent-utils.js';
+import { getArgs, withAgentRolesRequired, withYes } from '../agent-utils.js';
 import { getConfigsBasedOnArgs } from '../core-utils.js';
 
 import { AgentCli } from './utils.js';
@@ -109,12 +109,16 @@ async function main() {
   // whose keys / users are not chain-specific) will be attempted multiple times.
   // While this function still has these side effects, the workaround is to just
   // run the create-keys script first.
-  const { yes: skipConfirmation } = await withYes(getArgs()).argv;
+  const { yes: skipConfirmation, roles } = await withYes(
+    withAgentRolesRequired(getArgs()),
+  ).argv;
 
   const { agentConfig } = await getConfigsBasedOnArgs();
   await checkDockerTagsExist(agentConfig);
 
-  await createAgentKeysIfNotExistsWithPrompt(agentConfig);
+  // Scope key reconciliation to the roles being deployed. Deploying the relayer
+  // or scraper must not require read access to validator KMS keys.
+  await createAgentKeysIfNotExistsWithPrompt(agentConfig, roles);
 
   // Check if current branch is up-to-date with the main branch
   const commitsBehind = await getCommitsBehindMain();

--- a/typescript/infra/src/agents/gcp-kms/kms-key.ts
+++ b/typescript/infra/src/agents/gcp-kms/kms-key.ts
@@ -148,7 +148,17 @@ export class AgentGcpKmsKey extends CloudAgentKey {
     try {
       await this.fetch();
       return true;
-    } catch {
+    } catch (error) {
+      // A permission-denied read means the key exists but the caller lacks
+      // access to it. Treat it as existing so we never prompt to (re)create a
+      // key that is already provisioned.
+      const message = error instanceof Error ? error.message : String(error);
+      if (/permission[_ ]denied/i.test(message)) {
+        this.logger.debug(
+          'Permission denied reading KMS key; treating as existing',
+        );
+        return true;
+      }
       return false;
     }
   }

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -6,6 +6,7 @@ import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 import {
   Address,
   ProtocolType,
+  assert,
   deepEquals,
   objMap,
   rootLogger,
@@ -47,6 +48,24 @@ const logger = rootLogger.child({ module: 'infra:agents:key-utils' });
 export interface KeyAsAddress {
   identifier: string;
   address: string;
+}
+
+function isKeyAsAddressArray(value: unknown): value is KeyAsAddress[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as KeyAsAddress).identifier === 'string' &&
+        typeof (entry as KeyAsAddress).address === 'string',
+    )
+  );
+}
+
+function isSecretNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /not[_\s]?found/i.test(message);
 }
 
 const CONFIG_DIRECTORY_PATH = join(getInfraPath(), 'config');
@@ -606,23 +625,33 @@ async function persistAddressesInGcp(
   // Key reconciliation may be scoped to a subset of roles (e.g. a relayer-only
   // deploy), so a wholesale overwrite would drop addresses for the roles that
   // were not reconciled this run.
-  let mergedByIdentifier = new Map<string, KeyAsAddress>();
+  let existingKeys: KeyAsAddress[] = [];
   try {
-    const existingSecret = (await fetchGCPSecret(
+    const existingSecret = await fetchGCPSecret(
       addressesIdentifier(environment, context),
       true,
-    )) as KeyAsAddress[];
-    mergedByIdentifier = new Map(
-      existingSecret.map((key) => [key.identifier, key]),
     );
-  } catch {
-    // If the secret doesn't exist, we'll create it below.
+    assert(
+      isKeyAsAddressArray(existingSecret),
+      `Unexpected shape for ${context} addresses secret in ${environment}`,
+    );
+    existingKeys = existingSecret;
+  } catch (error) {
+    // Only a confirmed missing secret is safe to treat as empty. Any other
+    // failure (transient, permission, malformed) must abort: proceeding would
+    // overwrite the secret with a reduced, role-scoped set and drop the
+    // addresses of roles that were not reconciled this run.
+    if (!isSecretNotFoundError(error)) {
+      throw error;
+    }
     logger.debug(
       `No existing secret found for ${context} context in ${environment} environment`,
     );
   }
 
-  const existingKeys = [...mergedByIdentifier.values()];
+  const mergedByIdentifier = new Map<string, KeyAsAddress>(
+    existingKeys.map((key) => [key.identifier, key]),
+  );
   for (const key of keys) {
     mergedByIdentifier.set(key.identifier, key);
   }

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -86,9 +86,15 @@ export function getRoleKeysPerChain(
 // }
 function getRoleKeyMapPerChain(
   agentConfig: RootAgentConfig,
+  deployedRoles?: Role[],
 ): ChainMap<Record<Role, Record<string, CloudAgentKey>>> {
   const keysPerChain: ChainMap<Record<Role, Record<string, CloudAgentKey>>> =
     {};
+
+  // Validator keys are Cloud KMS keys whose read access is restricted; only
+  // reconcile them when validators are actually being deployed.
+  const includeValidatorKeys =
+    !deployedRoles || deployedRoles.includes(Role.Validator);
 
   const setValidatorKeys = () => {
     const validators = agentConfig.validators;
@@ -181,7 +187,9 @@ function getRoleKeyMapPerChain(
   for (const role of agentConfig.rolesWithKeys) {
     switch (role) {
       case Role.Validator:
-        setValidatorKeys();
+        if (includeValidatorKeys) {
+          setValidatorKeys();
+        }
         break;
       case Role.Relayer:
         setRelayerKeys();
@@ -209,9 +217,10 @@ function getRoleKeyMapPerChain(
 // Gets a big array of all keys.
 export function getAllCloudAgentKeys(
   agentConfig: RootAgentConfig,
+  deployedRoles?: Role[],
 ): Array<CloudAgentKey> {
   logger.debug('Retrieving all cloud agent keys');
-  const keysPerChain = getRoleKeyMapPerChain(agentConfig);
+  const keysPerChain = getRoleKeyMapPerChain(agentConfig, deployedRoles);
 
   const keysByIdentifier = Object.keys(keysPerChain).reduce(
     (acc, chainName) => {
@@ -407,8 +416,12 @@ export function getValidatorKeysForChain(
 
 export async function createAgentKeysIfNotExistsWithPrompt(
   agentConfig: RootAgentConfig,
+  deployedRoles?: Role[],
 ) {
-  const agentKeysToCreate = await agentKeysToBeCreated(agentConfig);
+  const agentKeysToCreate = await agentKeysToBeCreated(
+    agentConfig,
+    deployedRoles,
+  );
   const shouldCreateKeys = agentKeysToCreate.length > 0;
 
   if (shouldCreateKeys) {
@@ -424,18 +437,21 @@ export async function createAgentKeysIfNotExistsWithPrompt(
     }
 
     console.log(chalk.blue.bold('Creating new agent keys if needed.'));
-    await createAgentKeys(agentConfig, agentKeysToCreate);
+    await createAgentKeys(agentConfig, agentKeysToCreate, deployedRoles);
   } else {
     console.log(chalk.gray.bold('No new agent keys will be created.'));
     // Persist all keys, even if no new ones were created
-    await persistAddresses(agentConfig);
+    await persistAddresses(agentConfig, deployedRoles);
   }
   return shouldCreateKeys;
 }
 
 // We can create or delete keys if they are not Starknet keys.
-function getModifiableKeys(agentConfig: RootAgentConfig): CloudAgentKey[] {
-  const keys = getAllCloudAgentKeys(agentConfig);
+function getModifiableKeys(
+  agentConfig: RootAgentConfig,
+  deployedRoles?: Role[],
+): CloudAgentKey[] {
+  const keys = getAllCloudAgentKeys(agentConfig, deployedRoles);
   // if the key has a chainName and it is a Starknet chain, filter it out
   return keys.filter(
     (key) => !(key.chainName && isStarknetChain(key.chainName)),
@@ -445,10 +461,11 @@ function getModifiableKeys(agentConfig: RootAgentConfig): CloudAgentKey[] {
 async function createAgentKeys(
   agentConfig: RootAgentConfig,
   agentKeysToCreate: string[],
+  deployedRoles?: Role[],
 ) {
   logger.debug('Creating agent keys if none exist');
 
-  const keys = getAllCloudAgentKeys(agentConfig);
+  const keys = getAllCloudAgentKeys(agentConfig, deployedRoles);
 
   const keysToCreate = keys.filter((key) =>
     agentKeysToCreate.includes(key.identifier),
@@ -462,18 +479,21 @@ async function createAgentKeys(
     }),
   );
 
-  await persistAddresses(agentConfig);
+  await persistAddresses(agentConfig, deployedRoles);
 }
 
-async function persistAddresses(agentConfig: RootAgentConfig) {
-  const keys = getModifiableKeys(agentConfig);
+async function persistAddresses(
+  agentConfig: RootAgentConfig,
+  deployedRoles?: Role[],
+) {
+  const keys = getModifiableKeys(agentConfig, deployedRoles);
   const addresses = await Promise.all(
     keys.map(async (key) => {
       await key.fetch();
       return key.serializeAsAddress();
     }),
   );
-  await persistAddressesLocally(agentConfig, keys);
+  await persistAddressesLocally(agentConfig, keys, deployedRoles);
   await persistAddressesInGcp(
     agentConfig.runEnv,
     agentConfig.context,
@@ -484,8 +504,9 @@ async function persistAddresses(agentConfig: RootAgentConfig) {
 
 async function agentKeysToBeCreated(
   agentConfig: RootAgentConfig,
+  deployedRoles?: Role[],
 ): Promise<string[]> {
-  const keysToCreateIfNotExist = getModifiableKeys(agentConfig);
+  const keysToCreateIfNotExist = getModifiableKeys(agentConfig, deployedRoles);
   return (
     await Promise.all(
       keysToCreateIfNotExist.map(async (key) =>
@@ -581,17 +602,19 @@ async function persistAddressesInGcp(
   context: Contexts,
   keys: KeyAsAddress[],
 ) {
+  // Upsert by identifier into the existing secret rather than overwriting it.
+  // Key reconciliation may be scoped to a subset of roles (e.g. a relayer-only
+  // deploy), so a wholesale overwrite would drop addresses for the roles that
+  // were not reconciled this run.
+  let mergedByIdentifier = new Map<string, KeyAsAddress>();
   try {
     const existingSecret = (await fetchGCPSecret(
       addressesIdentifier(environment, context),
       true,
     )) as KeyAsAddress[];
-    if (deepEquals(keys, existingSecret)) {
-      logger.debug(
-        `Addresses already persisted to GCP for ${context} context in ${environment} environment`,
-      );
-      return;
-    }
+    mergedByIdentifier = new Map(
+      existingSecret.map((key) => [key.identifier, key]),
+    );
   } catch {
     // If the secret doesn't exist, we'll create it below.
     logger.debug(
@@ -599,12 +622,25 @@ async function persistAddressesInGcp(
     );
   }
 
+  const existingKeys = [...mergedByIdentifier.values()];
+  for (const key of keys) {
+    mergedByIdentifier.set(key.identifier, key);
+  }
+  const mergedKeys = [...mergedByIdentifier.values()];
+
+  if (deepEquals(mergedKeys, existingKeys)) {
+    logger.debug(
+      `Addresses already persisted to GCP for ${context} context in ${environment} environment`,
+    );
+    return;
+  }
+
   logger.debug(
     `Persisting addresses to GCP for ${context} context in ${environment} environment`,
   );
   await setGCPSecretUsingClient(
     addressesIdentifier(environment, context),
-    JSON.stringify(keys),
+    JSON.stringify(mergedKeys),
     {
       environment,
       context,
@@ -615,6 +651,7 @@ async function persistAddressesInGcp(
 async function persistAddressesLocally(
   agentConfig: RootAgentConfig,
   keys: CloudAgentKey[],
+  deployedRoles?: Role[],
 ) {
   logger.debug(
     `Persisting addresses locally for ${agentConfig.context} context in ${agentConfig.runEnv} environment`,
@@ -645,7 +682,13 @@ async function persistAddressesLocally(
   }
 
   const validators = agentConfig.validators;
-  if (validators && agentConfig.rolesWithKeys.includes(Role.Validator)) {
+  const includeValidatorKeys =
+    !deployedRoles || deployedRoles.includes(Role.Validator);
+  if (
+    validators &&
+    includeValidatorKeys &&
+    agentConfig.rolesWithKeys.includes(Role.Validator)
+  ) {
     for (const chainName of agentConfig.contextChainNames.validator) {
       const validatorCount =
         validators.chains[chainName]?.validators.length ?? 1;


### PR DESCRIPTION
## Summary
- Deploying the relayer or scraper no longer requires read access to validator Cloud KMS keys. The deploy script now passes the roles being deployed into the key preflight, which skips validator keys unless validators are actually being deployed.
- `persistAddressesInGcp` upserts addresses by identifier instead of overwriting, so a role-scoped run cannot drop addresses for roles it didn't reconcile.
- `KmsKey.exists()` treats a `PERMISSION_DENIED` read as "exists" rather than "missing", so an already-provisioned key whose read access is restricted is never flagged for (re)creation.

### Motivation
A relayer-only `deploy-agents` run (e.g. removing a chain from `relayChains`) blocked on a global key-reconciliation preflight because the running service account has no read access to validator KMS keys. The bare `catch` in `exists()` turned the permission-denied read into a false negative and prompted to **create** new `validator-0` keys — a footgun. This scopes the preflight to the deployed role and hardens the existence check.

## Changes
- `scripts/agents/deploy-agents.ts`: parse and pass `--role`s into `createAgentKeysIfNotExistsWithPrompt`.
- `src/agents/key-utils.ts`: thread an optional `deployedRoles` scope through `getRoleKeyMapPerChain` / `getAllCloudAgentKeys` / `getModifiableKeys` / create+persist path; skip validator keys unless deploying validators; gate the validator block in `persistAddressesLocally`; make `persistAddressesInGcp` upsert-by-identifier.
- `src/agents/gcp-kms/kms-key.ts`: `exists()` treats permission-denied as existing.

## Test plan
- [x] `tsc --noEmit` (typescript/infra) passes
- [x] `oxlint` on changed files passes
- [ ] Relayer-only deploy no longer prompts to create validator keys (verified manually during the botanix removal deploy by bypassing only key creation; this PR makes that unnecessary)
- [ ] Validator deploy still reconciles validator keys as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)