### PR TITLE
fix(infra): sync warp-check config for USDT/eni fee owner and REZ protocol fee

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEniWarpConfigs.ts
@@ -4,7 +4,10 @@ import {
   RouterConfigWithoutOwner,
   tokens,
 } from '../../../../../src/config/warp.js';
-import { getWarpFeeOwner } from '../../governance/utils.js';
+import {
+  WARP_FEES_TURNKEY_OWNER,
+  getWarpFeeOwner,
+} from '../../governance/utils.js';
 import { WarpRouteIds } from '../warpIds.js';
 
 import {
@@ -266,7 +269,9 @@ export async function getEniUsdtWarpConfig(
         maxDecimals,
       ),
       tokenFee: getFixedRoutingFeeConfig(
-        getWarpFeeOwner(chain),
+        // Fee contracts on every leg except tron were rotated to Turnkey
+        // treasury custody; tron still uses its WarpFees ICA.
+        chain === 'tron' ? getWarpFeeOwner(chain) : WARP_FEES_TURNKEY_OWNER,
         allCollateralChains.filter((otherChain) => otherChain !== chain),
         USDT_INTER_COLLATERAL_FEE_BPS,
         undefined,
@@ -288,7 +293,8 @@ export async function getEniUsdtWarpConfig(
       maxDecimals,
     ),
     tokenFee: getFixedRoutingFeeConfig(
-      getWarpFeeOwner('eni'),
+      // eni synthetic fee contract was rotated to Turnkey treasury custody.
+      WARP_FEES_TURNKEY_OWNER,
       allCollateralChains,
       WARP_FEE_BPS,
     ),

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoEZETHWarpConfig.ts
@@ -100,6 +100,7 @@ export function getRenzoHook(
   defaultHook: Address,
   chain: ChainName,
   owner: Address,
+  protocolFeeOverride?: string,
 ): HookConfig {
   return {
     type: HookType.AGGREGATION,
@@ -110,8 +111,10 @@ export function getRenzoHook(
         owner: owner,
         beneficiary: owner,
 
-        // Use hardcoded, actual onchain fees, or fallback to fee calculation
+        // Route-specific onchain fee, then the shared EZETH-derived snapshot,
+        // then fall back to the fee calculation.
         protocolFee:
+          protocolFeeOverride ??
           chainProtocolFee[chain] ??
           parseEther(getProtocolFee(chain)).toString(),
         maxProtocolFee: MAX_PROTOCOL_FEE,
@@ -497,6 +500,7 @@ export function getRenzoWarpConfigGenerator(params: {
   xERC20Lockbox: string;
   tokenPrices: ChainMap<string>;
   chainOwnerOverrides?: ChainOwnerOverrides;
+  protocolFeeOverrides?: ChainMap<string>;
 }) {
   const {
     chainsToDeploy,
@@ -506,6 +510,7 @@ export function getRenzoWarpConfigGenerator(params: {
     xERC20Lockbox,
     tokenPrices,
     chainOwnerOverrides,
+    protocolFeeOverrides,
   } = params;
   return async (): Promise<ChainMap<HypTokenRouterConfig>> => {
     const config = getEnvironmentConfig('mainnet3');
@@ -602,7 +607,12 @@ export function getRenzoWarpConfigGenerator(params: {
                   },
                 ],
               },
-              hook: getRenzoHook(defaultHook, chain, safes[chain]),
+              hook: getRenzoHook(
+                defaultHook,
+                chain,
+                safes[chain],
+                protocolFeeOverrides?.[chain],
+              ),
             };
 
             if (chainOwnerOverrides?.[chain]) {

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoREZBaseEthereum.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getRenzoREZBaseEthereum.ts
@@ -41,6 +41,15 @@ export const rezEthValidators = {
 const rezEthOwners = pick(ezEthSafes, rezEthChainsToDeploy);
 const rezEthTokenPrices = pick(renzoTokenPrices, rezEthChainsToDeploy);
 
+// Actual onchain protocol fees for the REZ route. These differ from the shared
+// EZETH-derived `chainProtocolFee` snapshot (they follow the ~$0.50 target), so
+// they are supplied as route-specific overrides to avoid a check mismatch.
+const rezProtocolFeeOverrides = {
+  base: '158365200000000',
+  ethereum: '158365200000000',
+  unichain: '192111100000000',
+};
+
 export const getREZBaseEthereumWarpConfig = getRenzoWarpConfigGenerator({
   chainsToDeploy: rezEthChainsToDeploy,
   validators: rezEthValidators,
@@ -48,4 +57,5 @@ export const getREZBaseEthereumWarpConfig = getRenzoWarpConfigGenerator({
   xERC20Addresses: rezEthAddresses,
   xERC20Lockbox: rezProductionLockbox,
   tokenPrices: rezEthTokenPrices,
+  protocolFeeOverrides: rezProtocolFeeOverrides,
 });


### PR DESCRIPTION
## Summary
Clears two persistently-firing `hyperlane_check_violations{type="ConfigMismatch"}` from the daily `check-warp-deploy-mainnet3` job. Both are cases where an intended on-chain change was never reflected in the expected config.

- **USDT/eni `tokenFee.owner`** (arbitrum, base, bsc, eni, ethereum, optimism, polygon): fee contracts were rotated on-chain to the Turnkey treasury custody key (`WARP_FEES_TURNKEY_OWNER`, `0xe95C6050…`), same pattern as the earlier eclipse rotation (#9163), but `getEniUsdtWarpConfig` still expected the per-chain WarpFees Safe/ICA. Updated all legs except tron to expect the Turnkey owner. tron keeps its WarpFees ICA (not firing).
- **REZ/base-ethereum-unichain `hook.hooks.0.protocolFee`**: the REZ route's on-chain protocol fees follow the ~$0.50 target (`158365200000000` on base/ethereum, `192111100000000` on unichain) and differ from the shared EZETH-derived `chainProtocolFee` snapshot (`400000000000000`). Since the map is shared with EZETH (which correctly matches `0.0004 ETH` on-chain and must not change), added an optional `protocolFeeOverrides` param to the Renzo generator and supplied REZ's actual on-chain values.

No on-chain transactions — expected-config sync only. Clears on the next daily check run.

## Test plan
- [ ] `pnpm -C typescript/infra tsc` (passes locally)
- [ ] Confirm the eni Turnkey fee-owner rotation was deliberate (evidence: uniform `0xe95C6050…` across all 7 legs, matches documented Turnkey custody pattern)
- [ ] Next `check-warp-deploy-mainnet3` run shows USDT/eni + REZ violations cleared, EZETH still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)