### PR TITLE
chore(infra): fully deprecate cotitestnet from testnet4 operations

### DIFF
--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -49,7 +49,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     bsctestnet: true,
     celestiatestnet: false,
     celosepolia: false, // disabled — deprecated dead testnet, no traffic (2026-07)
-    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
@@ -75,7 +74,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     bsctestnet: true,
     celestiatestnet: false,
     celosepolia: false, // disabled — deprecated dead testnet, no traffic (2026-07)
-    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,
@@ -101,7 +99,6 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     bsctestnet: true,
     celestiatestnet: false,
     celosepolia: false, // disabled — deprecated dead testnet, no traffic (2026-07)
-    cotitestnet: false, // disabled — deprecated dead testnet, no traffic (2026-07)
     eclipsetestnet: false,
     fuji: true,
     hyperliquidevmtestnet: true,

--- a/typescript/infra/config/environments/testnet4/funding.ts
+++ b/typescript/infra/config/environments/testnet4/funding.ts
@@ -35,7 +35,6 @@ export const keyFunderConfig: KeyFunderConfig<
     bsctestnet: '5',
     celestiatestnet: '0',
     celosepolia: '0.5',
-    cotitestnet: '1',
     // no funding for solana
     eclipsetestnet: '0',
     fuji: '5',

--- a/typescript/infra/config/environments/testnet4/gasPrices.json
+++ b/typescript/infra/config/environments/testnet4/gasPrices.json
@@ -23,10 +23,6 @@
     "amount": "25.001",
     "decimals": 9
   },
-  "cotitestnet": {
-    "amount": "7.400249936",
-    "decimals": 9
-  },
   "eclipsetestnet": {
     "amount": "0.001",
     "decimals": 9

--- a/typescript/infra/config/environments/testnet4/supportedChainNames.ts
+++ b/typescript/infra/config/environments/testnet4/supportedChainNames.ts
@@ -6,7 +6,6 @@ export const testnet4SupportedChainNames = [
   'bsctestnet',
   'celestiatestnet',
   'celosepolia',
-  'cotitestnet',
   'eclipsetestnet',
   'fuji',
   'hyperliquidevmtestnet',

--- a/typescript/infra/config/environments/testnet4/tokenPrices.json
+++ b/typescript/infra/config/environments/testnet4/tokenPrices.json
@@ -5,7 +5,6 @@
   "bsctestnet": "10",
   "celestiatestnet": "10",
   "celosepolia": "10",
-  "cotitestnet": "10",
   "eclipsetestnet": "10",
   "fuji": "10",
   "hyperliquidevmtestnet": "10",

--- a/typescript/infra/config/environments/testnet4/validators.ts
+++ b/typescript/infra/config/environments/testnet4/validators.ts
@@ -190,16 +190,6 @@ export const validatorChainConfig = (
         'somniatestnet',
       ),
     },
-    cotitestnet: {
-      interval: 5,
-      reorgPeriod: getReorgPeriod('cotitestnet'),
-      validators: validatorsConfig(
-        {
-          [Contexts.Hyperlane]: [AW_VALIDATOR],
-        },
-        'cotitestnet',
-      ),
-    },
     kyvetestnet: {
       interval: 5,
       reorgPeriod: getReorgPeriod('kyvetestnet'),


### PR DESCRIPTION
## Summary
- cotitestnet agents were disabled in 2026-07 ("deprecated dead testnet, no traffic") but the chain was still funded and validated, causing recurring **testnet4 key-funder failures** (`1/13 chains failed to fund: cotitestnet`, ~21 failed hourly runs / 7d).
- Completes the deprecation: removes `cotitestnet` from `supportedChainNames`, `agent`, `funding`, `validators`, `tokenPrices`, and `gasPrices` in the testnet4 environment (20 deletions).
- Leaves `verification.json` deployment-address history intact.

## Test plan
- [x] `tsc --noEmit` passes for `typescript/infra`
- [x] No remaining `cotitestnet` references outside deployment-history `verification.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)