### PR TITLE
fix(infra): fail closed when persisting agent key addresses

### DIFF
--- a/typescript/infra/src/agents/key-addresses.ts
+++ b/typescript/infra/src/agents/key-addresses.ts
@@ -1,0 +1,37 @@
+export interface KeyAsAddress {
+  identifier: string;
+  address: string;
+}
+
+export function isKeyAsAddressArray(value: unknown): value is KeyAsAddress[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        'identifier' in entry &&
+        typeof entry.identifier === 'string' &&
+        'address' in entry &&
+        typeof entry.address === 'string',
+    )
+  );
+}
+
+export function reconcilePersistedKeyAddresses(
+  existingKeys: KeyAsAddress[],
+  currentKeys: KeyAsAddress[],
+  preserveExistingKeys: boolean,
+): KeyAsAddress[] {
+  if (!preserveExistingKeys) {
+    return currentKeys;
+  }
+
+  const mergedByIdentifier = new Map<string, KeyAsAddress>(
+    existingKeys.map((key) => [key.identifier, key]),
+  );
+  for (const key of currentKeys) {
+    mergedByIdentifier.set(key.identifier, key);
+  }
+  return [...mergedByIdentifier.values()];
+}

--- a/typescript/infra/src/agents/key-utils.ts
+++ b/typescript/infra/src/agents/key-utils.ts
@@ -23,7 +23,11 @@ import type {
 import type { DeployEnvironment } from '../config/deploy-environment.js';
 import { getAWValidatorsPath } from '../paths.js';
 import { Role } from '../roles.js';
-import { fetchGCPSecret, setGCPSecretUsingClient } from '../utils/gcloud.js';
+import {
+  fetchGCPSecret,
+  isGcpNotFoundError,
+  setGCPSecretUsingClient,
+} from '../utils/gcloud.js';
 import {
   execCmd,
   getInfraPath,
@@ -34,6 +38,11 @@ import {
 import { AgentAwsKey } from './aws/key.js';
 import { AgentGCPKey } from './gcp.js';
 import { AgentGcpKmsKey } from './gcp-kms/kms-key.js';
+import {
+  type KeyAsAddress,
+  isKeyAsAddressArray,
+  reconcilePersistedKeyAddresses,
+} from './key-addresses.js';
 import { CloudAgentKey } from './keys.js';
 
 export type LocalRoleAddresses = Record<
@@ -44,29 +53,6 @@ export const relayerAddresses: LocalRoleAddresses =
   localRelayerAddresses as LocalRoleAddresses;
 
 const logger = rootLogger.child({ module: 'infra:agents:key-utils' });
-
-export interface KeyAsAddress {
-  identifier: string;
-  address: string;
-}
-
-function isKeyAsAddressArray(value: unknown): value is KeyAsAddress[] {
-  return (
-    Array.isArray(value) &&
-    value.every(
-      (entry) =>
-        typeof entry === 'object' &&
-        entry !== null &&
-        typeof (entry as KeyAsAddress).identifier === 'string' &&
-        typeof (entry as KeyAsAddress).address === 'string',
-    )
-  );
-}
-
-function isSecretNotFoundError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /not[_\s]?found/i.test(message);
-}
 
 const CONFIG_DIRECTORY_PATH = join(getInfraPath(), 'config');
 
@@ -517,6 +503,10 @@ async function persistAddresses(
     agentConfig.runEnv,
     agentConfig.context,
     addresses,
+    // Validator-scoped and unscoped reconciliation both enumerate every key
+    // role. A non-validator deploy intentionally omits validator KMS keys, so
+    // only that partial path must preserve unreconciled secret entries.
+    deployedRoles !== undefined && !deployedRoles.includes(Role.Validator),
   );
   return;
 }
@@ -620,11 +610,11 @@ async function persistAddressesInGcp(
   environment: DeployEnvironment,
   context: Contexts,
   keys: KeyAsAddress[],
+  preserveExistingKeys: boolean,
 ) {
-  // Upsert by identifier into the existing secret rather than overwriting it.
-  // Key reconciliation may be scoped to a subset of roles (e.g. a relayer-only
-  // deploy), so a wholesale overwrite would drop addresses for the roles that
-  // were not reconciled this run.
+  // Partial role deployments upsert by identifier so they preserve addresses
+  // for roles that were not reconciled. Full reconciliation replaces the list
+  // so retired identifiers are removed.
   let existingKeys: KeyAsAddress[] = [];
   try {
     const existingSecret = await fetchGCPSecret(
@@ -641,7 +631,7 @@ async function persistAddressesInGcp(
     // failure (transient, permission, malformed) must abort: proceeding would
     // overwrite the secret with a reduced, role-scoped set and drop the
     // addresses of roles that were not reconciled this run.
-    if (!isSecretNotFoundError(error)) {
+    if (!isGcpNotFoundError(error)) {
       throw error;
     }
     logger.debug(
@@ -649,15 +639,13 @@ async function persistAddressesInGcp(
     );
   }
 
-  const mergedByIdentifier = new Map<string, KeyAsAddress>(
-    existingKeys.map((key) => [key.identifier, key]),
+  const nextKeys = reconcilePersistedKeyAddresses(
+    existingKeys,
+    keys,
+    preserveExistingKeys,
   );
-  for (const key of keys) {
-    mergedByIdentifier.set(key.identifier, key);
-  }
-  const mergedKeys = [...mergedByIdentifier.values()];
 
-  if (deepEquals(mergedKeys, existingKeys)) {
+  if (deepEquals(nextKeys, existingKeys)) {
     logger.debug(
       `Addresses already persisted to GCP for ${context} context in ${environment} environment`,
     );
@@ -669,7 +657,7 @@ async function persistAddressesInGcp(
   );
   await setGCPSecretUsingClient(
     addressesIdentifier(environment, context),
-    JSON.stringify(mergedKeys),
+    JSON.stringify(nextKeys),
     {
       environment,
       context,

--- a/typescript/infra/src/utils/gcloud.ts
+++ b/typescript/infra/src/utils/gcloud.ts
@@ -28,6 +28,33 @@ const kmsIamGrantQueues = new Map<string, Promise<void>>();
 const gcsBucketMutationQueues = new Map<string, Promise<void>>();
 let serviceAccountCreateQueue: Promise<void> = Promise.resolve();
 
+// google-gax uses the canonical gRPC status code for missing resources.
+const GRPC_NOT_FOUND_STATUS_CODE = 5;
+
+/**
+ * Checks a GCP error (including errors wrapped with `cause`) for a structured
+ * NOT_FOUND status. Message matching is intentionally avoided: parse errors,
+ * DNS failures, and permission errors can all contain the words "not found".
+ */
+export function isGcpNotFoundError(error: unknown): boolean {
+  const seen = new Set<object>();
+  let current = error;
+
+  while (typeof current === 'object' && current !== null) {
+    if (seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
+
+    if ('code' in current && current.code === GRPC_NOT_FOUND_STATUS_CODE) {
+      return true;
+    }
+    current = 'cause' in current ? current.cause : undefined;
+  }
+
+  return false;
+}
+
 async function withKmsIamGrantQueue<T>(
   queueKey: string,
   task: () => Promise<T>,
@@ -107,6 +134,7 @@ export async function fetchGCPSecret(
     } catch (err) {
       throw new Error(
         `Error fetching GCP secret with name ${secretName}: ${err}`,
+        { cause: err },
       );
     }
   }

--- a/typescript/infra/test/gcloud.test.ts
+++ b/typescript/infra/test/gcloud.test.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+
+import { isGcpNotFoundError } from '../src/utils/gcloud.js';
+
+describe('isGcpNotFoundError', () => {
+  it('recognizes a structured GCP NOT_FOUND error through wrappers', () => {
+    const gcpError = Object.assign(new Error('secret missing'), { code: 5 });
+    const wrapped = new Error('Error fetching GCP secret', {
+      cause: gcpError,
+    });
+
+    expect(isGcpNotFoundError(wrapped)).to.equal(true);
+  });
+
+  it('does not classify malformed JSON containing not found as missing', () => {
+    let parseError: unknown;
+    try {
+      JSON.parse('not found');
+    } catch (error: unknown) {
+      parseError = error;
+    }
+
+    expect(isGcpNotFoundError(parseError)).to.equal(false);
+  });
+
+  it('does not classify transient or permission errors by message text', () => {
+    expect(
+      isGcpNotFoundError(new Error('getaddrinfo ENOTFOUND secretmanager')),
+    ).to.equal(false);
+    expect(
+      isGcpNotFoundError(
+        Object.assign(new Error('PERMISSION_DENIED: resource not found'), {
+          code: 7,
+        }),
+      ),
+    ).to.equal(false);
+  });
+});

--- a/typescript/infra/test/key-addresses.test.ts
+++ b/typescript/infra/test/key-addresses.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+
+import {
+  type KeyAsAddress,
+  reconcilePersistedKeyAddresses,
+} from '../src/agents/key-addresses.js';
+
+describe('reconcilePersistedKeyAddresses', () => {
+  const retired: KeyAsAddress = {
+    identifier: 'hyperlane-mainnet3-key-validator-1',
+    address: '0xretired',
+  };
+  const priorRelayer: KeyAsAddress = {
+    identifier: 'hyperlane-mainnet3-key-relayer',
+    address: '0xold',
+  };
+  const currentRelayer: KeyAsAddress = {
+    ...priorRelayer,
+    address: '0xnew',
+  };
+
+  it('preserves unreconciled entries during a partial role deployment', () => {
+    expect(
+      reconcilePersistedKeyAddresses(
+        [retired, priorRelayer],
+        [currentRelayer],
+        true,
+      ),
+    ).to.deep.equal([retired, currentRelayer]);
+  });
+
+  it('removes retired entries during a full reconciliation', () => {
+    expect(
+      reconcilePersistedKeyAddresses(
+        [retired, priorRelayer],
+        [currentRelayer],
+        false,
+      ),
+    ).to.deep.equal([currentRelayer]);
+  });
+});


### PR DESCRIPTION
## Summary

- classify missing Secret Manager resources only from structured gRPC `NOT_FOUND` status
- preserve wrapped GCP error causes so callers can fail closed on malformed, permission, and transient failures
- preserve unreconciled keys for role-scoped deploys, but restore exact replacement for full reconciliation so retired identifiers are removed

Follow-up to #9239. The merged implementation could treat parse/DNS/permission errors containing `not found` as an absent secret and overwrite it with a partial key set. It also retained retired identifiers during full reconciliation.

## Validation

- `pnpm --filter @hyperlane-xyz/infra... build`
- `pnpm -C typescript/infra check`
- `pnpm -C typescript/infra exec mocha --config ../sdk/.mocharc.json test/gcloud.test.ts test/key-addresses.test.ts` (5 passing)
- changed-file `oxlint` and `oxfmt --check`

The pre-existing concurrent read/modify/write assumption remains out of scope; agent key reconciliation is still expected to be serialized.
