### PR TITLE
perf(sdk): lazy-load zkSync deployer

### DIFF
--- a/.changeset/lazy-zksync-deployer.md
+++ b/.changeset/lazy-zksync-deployer.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Moved the zkSync contract deployer behind the existing zkSync deployment path so browser consumers do not load deployment artifacts during startup.

--- a/.changeset/lazy-zksync-deployer.md
+++ b/.changeset/lazy-zksync-deployer.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Moved the zkSync contract deployer behind the existing zkSync deployment path so browser consumers do not load deployment artifacts during startup.
+Moved the zkSync contract deployer behind the existing zkSync deployment path. This prevented browser consumers from loading deployment artifacts during startup.

--- a/typescript/sdk/src/providers/MultiProvider.test.ts
+++ b/typescript/sdk/src/providers/MultiProvider.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ContractFactory } from 'ethers';
+import { BigNumber, ContractFactory } from 'ethers';
 import type { ContractTransaction } from 'ethers';
 
 import {
@@ -7,6 +7,7 @@ import {
   ProxyAdmin__factory,
   TestRecipient__factory,
 } from '@hyperlane-xyz/core';
+import type { ZKSyncArtifact } from '@hyperlane-xyz/core';
 import {
   Mailbox__factory as TronMailbox__factory,
   ProxyAdmin__factory as TronProxyAdmin__factory,
@@ -15,7 +16,10 @@ import {
 } from '@hyperlane-xyz/tron-sdk';
 import { TestChainName, test1, test2 } from '../consts/testChains.js';
 import type { ProtocolTransaction, ProtocolReceipt } from './ProviderType.js';
-import { EthJsonRpcBlockParameterTag } from '../metadata/chainMetadataTypes.js';
+import {
+  ChainTechnicalStack,
+  EthJsonRpcBlockParameterTag,
+} from '../metadata/chainMetadataTypes.js';
 import sinon from 'sinon';
 
 import { MultiProvider } from './MultiProvider.js';
@@ -67,6 +71,64 @@ describe('MultiProvider Tron factory resolution', () => {
 });
 
 describe('MultiProvider', () => {
+  describe('handleDeploy', () => {
+    afterEach(() => sinon.restore());
+
+    it('delegates zkSync deployments through the dynamically loaded deployer', async () => {
+      const zkSyncChain = 'testzksync';
+      const multiProvider = new MultiProvider({
+        [zkSyncChain]: {
+          ...test1,
+          chainId: 260,
+          displayName: 'Test zkSync',
+          domainId: 260,
+          name: zkSyncChain,
+          technicalStack: ChainTechnicalStack.ZkSync,
+        },
+      });
+      const zkSyncSigner = {
+        provider: {},
+        connect: sinon.stub().returnsThis(),
+      };
+      multiProvider.setSigner(zkSyncChain, zkSyncSigner as any);
+
+      const artifact = {
+        abi: [],
+        bytecode: '0x00',
+        contractName: 'TestContract',
+        factoryDeps: {},
+        sourceName: 'TestContract.sol',
+      } as unknown as ZKSyncArtifact;
+      const params = ['constructor-param'];
+      const deployedContract = { address: '0x1234' };
+      const { ZKSyncDeployer } = await import('../zksync/ZKSyncDeployer.js');
+      const estimateDeployGas = sinon
+        .stub(ZKSyncDeployer.prototype, 'estimateDeployGas')
+        .resolves(BigNumber.from(100_000));
+      const deploy = sinon
+        .stub(ZKSyncDeployer.prototype, 'deploy')
+        .resolves(deployedContract as any);
+
+      const result = await multiProvider.handleDeploy(
+        zkSyncChain,
+        new ContractFactory([], '0x'),
+        params,
+        artifact,
+      );
+
+      expect(result).to.equal(deployedContract);
+      expect(zkSyncSigner.connect.calledOnceWithExactly(zkSyncSigner.provider))
+        .to.be.true;
+      expect(estimateDeployGas.calledOnceWithExactly(artifact, params)).to.be
+        .true;
+      expect(deploy.calledOnce).to.be.true;
+      expect(deploy.firstCall.args[0]).to.equal(artifact);
+      expect(deploy.firstCall.args[1]).to.equal(params);
+      expect(BigNumber.from(deploy.firstCall.args[2]?.gasLimit).gt(100_000)).to
+        .be.true;
+    });
+  });
+
   describe('handleTx', () => {
     let multiProvider: MultiProvider;
 

--- a/typescript/sdk/src/providers/MultiProvider.test.ts
+++ b/typescript/sdk/src/providers/MultiProvider.test.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
-import { BigNumber, ContractFactory } from 'ethers';
+import { BigNumber, Contract, ContractFactory, Wallet } from 'ethers';
 import type { ContractTransaction } from 'ethers';
+import {
+  Provider as ZKSyncProvider,
+  Wallet as ZKSyncWallet,
+} from 'zksync-ethers';
 
 import {
   Mailbox__factory,
@@ -86,28 +90,37 @@ describe('MultiProvider', () => {
           technicalStack: ChainTechnicalStack.ZkSync,
         },
       });
-      const zkSyncSigner = {
-        provider: {},
-        connect: sinon.stub().returnsThis(),
-      };
-      multiProvider.setSigner(zkSyncChain, zkSyncSigner as any);
+      const zkSyncSigner = new ZKSyncWallet(
+        Wallet.createRandom().privateKey,
+        new ZKSyncProvider(test1.rpcUrls[0].http),
+      );
+      const connect = sinon.spy(zkSyncSigner, 'connect');
+      multiProvider.setSigner(zkSyncChain, zkSyncSigner);
 
       const artifact = {
+        _format: 'hh-zksolc-artifact-1',
         abi: [],
         bytecode: '0x00',
         contractName: 'TestContract',
+        deployedBytecode: '0x00',
+        deployedLinkReferences: {},
         factoryDeps: {},
+        linkReferences: {},
         sourceName: 'TestContract.sol',
-      } as unknown as ZKSyncArtifact;
+      } satisfies ZKSyncArtifact;
       const params = ['constructor-param'];
-      const deployedContract = { address: '0x1234' };
+      const deployedContract = new Contract(
+        '0x0000000000000000000000000000000000001234',
+        [],
+        zkSyncSigner,
+      );
       const { ZKSyncDeployer } = await import('../zksync/ZKSyncDeployer.js');
       const estimateDeployGas = sinon
         .stub(ZKSyncDeployer.prototype, 'estimateDeployGas')
         .resolves(BigNumber.from(100_000));
       const deploy = sinon
         .stub(ZKSyncDeployer.prototype, 'deploy')
-        .resolves(deployedContract as any);
+        .resolves(deployedContract);
 
       const result = await multiProvider.handleDeploy(
         zkSyncChain,
@@ -117,8 +130,7 @@ describe('MultiProvider', () => {
       );
 
       expect(result).to.equal(deployedContract);
-      expect(zkSyncSigner.connect.calledOnceWithExactly(zkSyncSigner.provider))
-        .to.be.true;
+      expect(connect.calledOnceWithExactly(zkSyncSigner.provider)).to.be.true;
       expect(estimateDeployGas.calledOnceWithExactly(artifact, params)).to.be
         .true;
       expect(deploy.calledOnce).to.be.true;

--- a/typescript/sdk/src/providers/MultiProvider.ts
+++ b/typescript/sdk/src/providers/MultiProvider.ts
@@ -35,7 +35,6 @@ import {
   EthJsonRpcBlockParameterTag,
 } from '../metadata/chainMetadataTypes.js';
 import { ChainMap, ChainName, ChainNameOrId } from '../types.js';
-import { ZKSyncDeployer } from '../zksync/ZKSyncDeployer.js';
 
 import { AnnotatedEV5Transaction } from './ProviderType.js';
 import { ProviderBuilderFn } from './builders/types.js';
@@ -462,6 +461,7 @@ export class MultiProvider<MetaExt = {}> extends ChainMetadataManager<MetaExt> {
     if (technicalStack === ChainTechnicalStack.ZkSync) {
       if (!artifact) throw new Error(`No ZkSync contract artifact provided!`);
 
+      const { ZKSyncDeployer } = await import('../zksync/ZKSyncDeployer.js');
       const deployer = new ZKSyncDeployer(signer as ZKSyncWallet);
       estimatedGas = await deployer.estimateDeployGas(artifact, params);
       contract = await deployer.deploy(artifact, params, {


### PR DESCRIPTION
### Description

Moves `ZKSyncDeployer` from a module-level import into the existing `ChainTechnicalStack.ZkSync` branch of `MultiProvider.handleDeploy()`.

This keeps zkSync deployment code and its artifact dependencies out of the browser startup graph for SDK consumers that only need runtime functionality such as balances, quotes, and transfers. The public API and deployment behavior are unchanged: zkSync deployments still estimate gas, apply the existing gas buffer and transaction overrides, submit through `ZKSyncDeployer`, and wait for confirmation.

Adds focused regression coverage for the dynamic import and deployment delegation, plus an SDK patch changeset.

#### Warp UI integration benchmark

Measured with the same Warp UI source/configuration. The comparison is the current published-package build versus a production build using packed local monorepo packages containing this change. Browser timings are medians from three local runs.

| Metric | Published-package baseline | Packed local packages | Change |
| --- | ---: | ---: | ---: |
| `/` route JS, raw | 45.08 MiB | 15.03 MiB | -30.05 MiB (-66.7%) |
| `/` route JS, gzip | 7.60 MiB | 3.88 MiB | -3.72 MiB (-48.9%) |
| Initial Next.js JS requested | 48.53 MiB | 16.22 MiB | -32.31 MiB (-66.6%) |
| DOMContentLoaded | 1.11 s | 0.47 s | -0.64 s (-57.7%) |
| App initialization gate ready | 2.41 s | 1.35 s | -1.06 s (-44.0%) |

Additional packed-build route sizes:

- `/embed`: 16.39 MiB raw / 4.22 MiB gzip
- `/blocked`: 10.85 MiB raw / 2.92 MiB gzip

This is a downstream integration measurement rather than an isolated microbenchmark of one module. The production diff itself is limited to moving the existing deployer import behind the zkSync-only deployment branch.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. No exported types, method signatures, transaction behavior, or deployment behavior change. Only the time at which the existing zkSync deployer module is loaded changes.

### Testing

Monorepo SDK:

- `pnpm format`
- `pnpm lint`
- `pnpm check`
- `pnpm build`
- 1,048 unit tests passed
- 592 Hardhat deployment/transaction tests passed; 2 existing tests pending
- Focused `MultiProvider` suite: 17 passed, including dynamic zkSync deployment delegation
- Compiled-output smoke test confirmed `MultiProvider` retains a dynamic import and both compiled exports resolve

Warp UI regression coverage:

- Packed local monorepo packages: typecheck, lint, production build, and 294 unit tests passed
- Full wallet E2E: 62/63 passed initially; the single amount-entry timing flake then passed three consecutive isolated reruns
- Fresh targeted balance/transaction suite: 38/38 passed across Aleo, Cosmos, EVM, Radix, Starknet, and Sealevel paths
- Fresh Chromium wallet E2E: 4/4 passed for EVM approval, EVM transaction payload submission, EVM balance display, and Solana balance display
- Firefox/WebKit were not installed in the local Playwright cache; those browser projects could not launch, unrelated to application behavior

The zkSync regression uses the real dynamic import and `handleDeploy()` branch while mocking network gas estimation and broadcast. The underlying `ZKSyncDeployer` implementation is unchanged; ordinary EVM deployments and transaction confirmation are exercised against the local Hardhat chains.
