### PR TITLE
fix(sdk,infra): normalize paradex collateralDex type + sync eclipse katana fee

### DIFF
--- a/.changeset/warp-check-collateral-dex-type.md
+++ b/.changeset/warp-check-collateral-dex-type.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The `collateralDex` registry token-type annotation (used by paradex collateral warp routes such as ETH/paradex and DIME/paradex) is now normalized to `TokenType.collateral` in the `HypTokenConfigSchema` preprocessor. Previously it fell through to `TokenType.unknown`, which false-flagged a `type` ConfigMismatch in check-warp-deploy against the on-chain-derived `collateral` type. The now-redundant `normalizeAltVmExpectedTokenType` helper was removed since the schema normalizes the annotation before the altVM diff runs.

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getEclipseUSDCWarpConfig.ts
@@ -252,6 +252,13 @@ const rebalancingConfigByChain = getUSDCRebalancingBridgesConfigFor(
   [WarpRouteIds.MainnetCCTPV2Standard, WarpRouteIds.MainnetCCTPV2Fast],
 );
 
+const DEFAULT_FEE_BPS = 1.5;
+// katana's fee contracts were raised to 10 bps on-chain; pin the expected
+// config so the warp check keeps matching on-chain state.
+const feeBpsByOriginChain: Partial<Record<EvmChain, number>> = {
+  katana: 10,
+};
+
 export const buildEclipseUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
   options: EclipseUSDCWarpConfigOptions,
@@ -310,7 +317,7 @@ export const buildEclipseUSDCWarpConfig = async (
       const feeConfig = getFixedRoutingFeeConfig(
         WARP_FEES_TURNKEY_OWNER,
         feeDestinations,
-        1.5,
+        feeBpsByOriginChain[currentChain] ?? DEFAULT_FEE_BPS,
         undefined,
         quoteSigners,
       );

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -460,6 +460,13 @@ const KnownTokenTypes: string[] = Object.values(TokenType).filter(
   (t) => t !== TokenType.unknown,
 );
 
+// `collateralDex` is a paradex-only registry annotation for a collateral route
+// that performs a DEX conversion (see registry ETH/paradex & DIME/paradex). It has
+// no dedicated SDK TokenType, but on-chain the leg is a standard collateral router,
+// so normalize it to `collateral` instead of letting it fall through to `unknown`
+// (which would false-flag a `type` ConfigMismatch against the derived config).
+export const COLLATERAL_DEX_TYPE_ALIAS = 'collateralDex';
+
 const AllHypTokenConfigSchema = z.discriminatedUnion('type', [
   NativeTokenConfigSchema,
   OpL2TokenConfigSchema,
@@ -487,11 +494,13 @@ export type HypTokenConfig = z.infer<typeof AllHypTokenConfigSchema>;
 export const HypTokenConfigSchema = z.preprocess((val) => {
   if (typeof val === 'object' && val !== null && 'type' in val) {
     const obj = val as { type: unknown };
-    if (
-      typeof obj.type === 'string' &&
-      !KnownTokenTypes.includes(obj.type as TokenType)
-    ) {
-      return { ...obj, type: TokenType.unknown };
+    if (typeof obj.type === 'string') {
+      if (obj.type === COLLATERAL_DEX_TYPE_ALIAS) {
+        return { ...obj, type: TokenType.collateral };
+      }
+      if (!KnownTokenTypes.includes(obj.type as TokenType)) {
+        return { ...obj, type: TokenType.unknown };
+      }
     }
   }
   return val;

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -19,6 +19,7 @@ import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { TokenType } from './config.js';
 import {
   type DerivedWarpRouteDeployConfig,
+  HypTokenConfigSchema,
   OwnerStatus,
   type WarpRouteDeployConfigMailboxRequired,
 } from './types.js';
@@ -31,7 +32,6 @@ import {
   expandedDeployConfigToAltVmCheckConfig,
   getScaleViolations,
   normalizeAltVmDestinationGas,
-  normalizeAltVmExpectedTokenType,
 } from './warpCheck.js';
 
 const MAILBOX = '0x000000000000000000000000000000000000b001';
@@ -499,26 +499,49 @@ describe('expandedDeployConfigToAltVmCheckConfig', () => {
   });
 });
 
-describe('normalizeAltVmExpectedTokenType', () => {
+describe("HypTokenConfigSchema 'collateralDex' normalization", () => {
   it("maps the paradex-only 'collateralDex' annotation to collateral", () => {
     // collateralDex is a registry-only annotation with no SDK TokenType; the leg
-    // is a standard collateral router on-chain, so the checker must treat the two
-    // as equivalent instead of false-flagging a `type` ConfigMismatch.
-    expect(normalizeAltVmExpectedTokenType('collateralDex')).to.equal(
-      TokenType.collateral,
-    );
+    // is a standard collateral router on-chain, so the schema normalizes it to
+    // collateral instead of falling through to unknown (which would false-flag a
+    // `type` ConfigMismatch against the derived config).
+    const parsed = HypTokenConfigSchema.parse({
+      type: 'collateralDex',
+      token: TOKEN_A,
+      name: 'ETH',
+      symbol: 'ETH',
+      decimals: 18,
+    });
+    expect(parsed.type).to.equal(TokenType.collateral);
+  });
+
+  it('coerces genuinely unknown token types to unknown', () => {
+    const parsed = HypTokenConfigSchema.parse({
+      type: 'somethingBogus',
+      name: 'ETH',
+      symbol: 'ETH',
+      decimals: 18,
+    });
+    expect(parsed.type).to.equal(TokenType.unknown);
   });
 
   it('leaves known token types unchanged', () => {
-    expect(normalizeAltVmExpectedTokenType(TokenType.collateral)).to.equal(
-      TokenType.collateral,
-    );
-    expect(normalizeAltVmExpectedTokenType(TokenType.synthetic)).to.equal(
-      TokenType.synthetic,
-    );
-    expect(normalizeAltVmExpectedTokenType(TokenType.native)).to.equal(
-      TokenType.native,
-    );
+    const collateral = HypTokenConfigSchema.parse({
+      type: TokenType.collateral,
+      token: TOKEN_A,
+      name: 'ETH',
+      symbol: 'ETH',
+      decimals: 18,
+    });
+    expect(collateral.type).to.equal(TokenType.collateral);
+
+    const native = HypTokenConfigSchema.parse({
+      type: TokenType.native,
+      name: 'ETH',
+      symbol: 'ETH',
+      decimals: 18,
+    });
+    expect(native.type).to.equal(TokenType.native);
   });
 });
 

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -298,16 +298,6 @@ function normalizeCrossCollateralRouters(
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
-// `collateralDex` is a paradex-only registry annotation for a collateral route
-// that performs a DEX conversion (see registry ETH/paradex & DIME/paradex). It has
-// no matching SDK TokenType, and on-chain the leg is a standard collateral router,
-// so the deriver reports `collateral`. Treat the annotation as its underlying
-// collateral type so the generic altVM diff doesn't false-flag a `type` mismatch.
-const COLLATERAL_DEX_TYPE_ALIAS = 'collateralDex';
-export function normalizeAltVmExpectedTokenType(type: string): string {
-  return type === COLLATERAL_DEX_TYPE_ALIAS ? TokenType.collateral : type;
-}
-
 export function expandedDeployConfigToAltVmCheckConfig(
   chain: ChainName,
   config: WarpRouteDeployConfigMailboxRequired[string],
@@ -365,7 +355,7 @@ export function expandedDeployConfigToAltVmCheckConfig(
   // altVmScaleMismatch (exact bigint fraction compare against the raw expected
   // config.scale), not through this generic diff. See checkWarpRouteDeployConfig.
   const result: AltVmCheckConfig = {
-    type: normalizeAltVmExpectedTokenType(config.type),
+    type: config.type,
     owner: normalizeAddress(config.owner, protocol),
     mailbox: normalizeAddress(config.mailbox, protocol),
     interchainSecurityModule: ismAddress,
@@ -386,7 +376,7 @@ export function expandedDeployConfigToAltVmCheckConfig(
   // core-config decimals is excluded here to keep both sides symmetric.
   if (
     protocol !== ProtocolType.CosmosNative &&
-    normalizeAltVmExpectedTokenType(config.type) !== TokenType.native &&
+    config.type !== TokenType.native &&
     !isNullish(config.decimals)
   ) {
     result.decimals = config.decimals;


### PR DESCRIPTION
## Summary
Clears two persistent `check-warp-deploy-mainnet3` ConfigMismatch violations.

- **ETH/paradex (`type`: expected `unknown` vs on-chain `collateral`)** — the registry deploy config marks the paradex leg `type: collateralDex`, a paradex-only annotation with no SDK `TokenType`. The `HypTokenConfigSchema` preprocessor coerced it to `TokenType.unknown` **before** the existing check-side `normalizeAltVmExpectedTokenType` helper could map it, so the helper was dead in production. Now the schema normalizes `collateralDex` → `TokenType.collateral` directly (semantically correct: it is a standard collateral router on-chain), and the redundant helper is removed. Affects only paradex routes (ETH/paradex, DIME/paradex); nothing else consumes the annotation.
- **USDC/eclipsemainnet (`tokenFee.feeContracts.*.bps` on katana)** — the katana fee contracts were raised to 10 bps on-chain; the expected config was still 1.5. Added a per-origin-chain fee override so katana expects 10 bps while every other leg stays at the 1.5 bps default.

## Test plan
- [x] `pnpm -C typescript/sdk build` (tsc clean)
- [x] `typescript/sdk` warpCheck.test.ts — 56 passing, incl. new schema-normalization tests (collateralDex→collateral, bogus→unknown, known types unchanged)
- [x] `tsc --noEmit` on `typescript/infra` (clean)
- [x] lint/format clean on changed files
- [ ] Next daily check-warp-deploy run shows ETH/paradex and USDC/eclipsemainnet katana no longer firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)