### PR TITLE
fix(ccip-server): isolate commitment rate limits

### DIFF
--- a/.changeset/fair-calls-rate-limit.md
+++ b/.changeset/fair-calls-rate-limit.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/ccip-server': patch
+---
+
+The CCIP server rate limits were isolated by client and request class behind the GCE ingress, with endpoint-specific rejection metrics added.

--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -1,3 +1,9 @@
 {
-  "import": ["tsx"]
+  "import": ["tsx"],
+  "spec": [
+    "./tests/**/CallCommitmentsService.test.ts",
+    "./tests/**/RateLimiting.test.ts",
+    "./tests/**/cctpMessageMatcher.test.ts"
+  ],
+  "exit": true
 }

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -18,7 +18,7 @@
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",
-    "test": "mocha './tests/**/CallCommitmentsService.test.ts' './tests/**/RateLimiting.test.ts' './tests/**/cctpMessageMatcher.test.ts' --exit",
+    "test": "mocha --config .mocharc.json",
     "test:ci": "pnpm test",
     "lint": "oxlint -c ../../oxlint.json",
     "format": "oxfmt --write ./src ./tests"

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -18,7 +18,7 @@
     "bundle": "rm -rf ./bundle && ncc build ./dist/server.js -o bundle -e @google-cloud/pino-logging-gcp-config && node ../../scripts/ncc.post-bundle.mjs",
     "start": "tsx src/server.ts",
     "dev": "NODE_ENV=development LOG_FORMAT=pretty tsx watch src/server.ts",
-    "test": "mocha './tests/**/CallCommitmentsService.test.ts' './tests/**/cctpMessageMatcher.test.ts' --exit",
+    "test": "mocha './tests/**/CallCommitmentsService.test.ts' './tests/**/RateLimiting.test.ts' './tests/**/cctpMessageMatcher.test.ts' --exit",
     "test:ci": "pnpm test",
     "lint": "oxlint -c ../../oxlint.json",
     "format": "oxfmt --write ./src ./tests"

--- a/typescript/ccip-server/src/server.ts
+++ b/typescript/ccip-server/src/server.ts
@@ -12,6 +12,7 @@ import { CCTPService } from './services/CCTPService.js';
 import { CallCommitmentsService } from './services/CallCommitmentsService.js';
 import { HealthService } from './services/HealthService.js';
 import { OPStackService } from './services/OPStackService.js';
+import { configureTrustProxy } from './utils/http.js';
 import {
   PrometheusMetrics,
   UnhandledErrorReason,
@@ -38,7 +39,7 @@ async function startServer() {
   initializeMetrics(register);
 
   const app = express();
-  app.set('trust proxy', 1);
+  configureTrustProxy(app);
   app.use(cors());
   app.use(express.json({ limit: '10kb' }));
   app.use(pinoHttp({ logger }));

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -37,11 +37,9 @@ import { prisma } from '../db.js';
 import { createAbiHandler } from '../utils/abiHandler.js';
 import {
   PrometheusMetrics,
-  UnhandledErrorReason,
-} from '../utils/prometheus.js';
-import type {
   RateLimitedMethod,
   RateLimitedRoute,
+  UnhandledErrorReason,
 } from '../utils/prometheus.js';
 
 import {
@@ -625,19 +623,16 @@ export class CallCommitmentsService extends BaseService {
    */
   private registerRoutes(router: Router, baseUrl: string): void {
     const toRateLimitedMethod = (method: string): RateLimitedMethod => {
-      if (method === 'GET' || method === 'POST') return method;
-      return 'OTHER';
+      if (method === RateLimitedMethod.GET) return RateLimitedMethod.GET;
+      if (method === RateLimitedMethod.POST) return RateLimitedMethod.POST;
+      return RateLimitedMethod.OTHER;
     };
     const toRateLimitedRoute = (route: string): RateLimitedRoute => {
-      if (
-        route === '/calls' ||
-        route === '/calls/:commitment' ||
-        route === '/calldata' ||
-        route === '/calldata/:commitment'
-      ) {
-        return route;
-      }
-      return 'unknown';
+      return (
+        Object.values(RateLimitedRoute).find(
+          (knownRoute) => knownRoute === route,
+        ) ?? RateLimitedRoute.Unknown
+      );
     };
     const createRateLimit = () =>
       rateLimit({
@@ -656,19 +651,23 @@ export class CallCommitmentsService extends BaseService {
     const writeRateLimit = createRateLimit();
     const readRateLimit = createRateLimit();
 
-    router.post('/calls', writeRateLimit, this.handleCommitment.bind(this));
+    router.post(
+      RateLimitedRoute.Calls,
+      writeRateLimit,
+      this.handleCommitment.bind(this),
+    );
     router.get(
-      '/calls/:commitment',
+      RateLimitedRoute.CallsByCommitment,
       readRateLimit,
       this.handleCheckCommitment.bind(this),
     );
     router.post(
-      '/calldata',
+      RateLimitedRoute.Calldata,
       writeRateLimit,
       this.handleCalldataPost.bind(this),
     );
     router.get(
-      '/calldata/:commitment',
+      RateLimitedRoute.CalldataByCommitment,
       readRateLimit,
       this.handleCalldataGet.bind(this),
     );

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -39,6 +39,10 @@ import {
   PrometheusMetrics,
   UnhandledErrorReason,
 } from '../utils/prometheus.js';
+import type {
+  RateLimitedMethod,
+  RateLimitedRoute,
+} from '../utils/prometheus.js';
 
 import {
   BaseService,
@@ -620,35 +624,52 @@ export class CallCommitmentsService extends BaseService {
    * Register routes onto an Express Router or app.
    */
   private registerRoutes(router: Router, baseUrl: string): void {
-    const commitmentRateLimit = rateLimit({
-      windowMs: 60 * 1000,
-      max: 20,
-      standardHeaders: true,
-      legacyHeaders: false,
-      handler: (_req, res) => {
-        PrometheusMetrics.logRateLimited();
-        res.status(429).json({ error: 'Too many requests' });
-      },
-    });
+    const toRateLimitedMethod = (method: string): RateLimitedMethod => {
+      if (method === 'GET' || method === 'POST') return method;
+      return 'OTHER';
+    };
+    const toRateLimitedRoute = (route: string): RateLimitedRoute => {
+      if (
+        route === '/calls' ||
+        route === '/calls/:commitment' ||
+        route === '/calldata' ||
+        route === '/calldata/:commitment'
+      ) {
+        return route;
+      }
+      return 'unknown';
+    };
+    const createRateLimit = () =>
+      rateLimit({
+        windowMs: 60 * 1000,
+        max: 20,
+        standardHeaders: true,
+        legacyHeaders: false,
+        handler: (req, res) => {
+          PrometheusMetrics.logRateLimited(
+            toRateLimitedMethod(req.method),
+            toRateLimitedRoute(req.route.path),
+          );
+          res.status(429).json({ error: 'Too many requests' });
+        },
+      });
+    const writeRateLimit = createRateLimit();
+    const readRateLimit = createRateLimit();
 
-    router.post(
-      '/calls',
-      commitmentRateLimit,
-      this.handleCommitment.bind(this),
-    );
+    router.post('/calls', writeRateLimit, this.handleCommitment.bind(this));
     router.get(
       '/calls/:commitment',
-      commitmentRateLimit,
+      readRateLimit,
       this.handleCheckCommitment.bind(this),
     );
     router.post(
       '/calldata',
-      commitmentRateLimit,
+      writeRateLimit,
       this.handleCalldataPost.bind(this),
     );
     router.get(
       '/calldata/:commitment',
-      commitmentRateLimit,
+      readRateLimit,
       this.handleCalldataGet.bind(this),
     );
     router.post(

--- a/typescript/ccip-server/src/utils/http.ts
+++ b/typescript/ccip-server/src/utils/http.ts
@@ -1,0 +1,10 @@
+import type { Express } from 'express';
+
+// GCE ingress appends the client and load-balancer addresses to X-Forwarded-For.
+// Trust the direct proxy and the load-balancer address so Express selects the
+// client address instead of grouping every request under the load balancer.
+export const GCE_INGRESS_PROXY_HOPS = 2;
+
+export function configureTrustProxy(app: Express): void {
+  app.set('trust proxy', GCE_INGRESS_PROXY_HOPS);
+}

--- a/typescript/ccip-server/src/utils/prometheus.ts
+++ b/typescript/ccip-server/src/utils/prometheus.ts
@@ -30,13 +30,25 @@ let requestCounter: Counter<string> | undefined;
 let unhandledErrorCounter: Counter<string> | undefined;
 let rateLimitedCounter: Counter<string> | undefined;
 
-export type RateLimitedMethod = 'GET' | 'POST' | 'OTHER';
+export const RateLimitedMethod = {
+  GET: 'GET',
+  POST: 'POST',
+  OTHER: 'OTHER',
+} as const;
+
+export type RateLimitedMethod =
+  (typeof RateLimitedMethod)[keyof typeof RateLimitedMethod];
+
+export const RateLimitedRoute = {
+  Calls: '/calls',
+  CallsByCommitment: '/calls/:commitment',
+  Calldata: '/calldata',
+  CalldataByCommitment: '/calldata/:commitment',
+  Unknown: 'unknown',
+} as const;
+
 export type RateLimitedRoute =
-  | '/calls'
-  | '/calls/:commitment'
-  | '/calldata'
-  | '/calldata/:commitment'
-  | 'unknown';
+  (typeof RateLimitedRoute)[keyof typeof RateLimitedRoute];
 
 /**
  * Initializes Prometheus metrics with the given registry.

--- a/typescript/ccip-server/src/utils/prometheus.ts
+++ b/typescript/ccip-server/src/utils/prometheus.ts
@@ -30,6 +30,14 @@ let requestCounter: Counter<string> | undefined;
 let unhandledErrorCounter: Counter<string> | undefined;
 let rateLimitedCounter: Counter<string> | undefined;
 
+export type RateLimitedMethod = 'GET' | 'POST' | 'OTHER';
+export type RateLimitedRoute =
+  | '/calls'
+  | '/calls/:commitment'
+  | '/calldata'
+  | '/calldata/:commitment'
+  | 'unknown';
+
 /**
  * Initializes Prometheus metrics with the given registry.
  * Must be called before using PrometheusMetrics.
@@ -52,6 +60,7 @@ export function initializeMetrics(register: Registry): void {
   rateLimitedCounter = new Counter({
     name: 'hyperlane_offchain_lookup_server_rate_limited_requests',
     help: 'Total number of rate-limited requests',
+    labelNames: ['method', 'route'],
     registers: [register],
   });
 }
@@ -72,10 +81,10 @@ export const PrometheusMetrics = {
       error_reason: errorReason,
     });
   },
-  logRateLimited() {
+  logRateLimited(method: RateLimitedMethod, route: RateLimitedRoute) {
     if (!rateLimitedCounter) {
       throw new Error('Metrics not initialized. Call initializeMetrics first.');
     }
-    rateLimitedCounter.inc();
+    rateLimitedCounter.inc({ method, route });
   },
 };

--- a/typescript/ccip-server/tests/services/RateLimiting.test.ts
+++ b/typescript/ccip-server/tests/services/RateLimiting.test.ts
@@ -1,15 +1,17 @@
-import type { AddressInfo } from 'node:net';
-
 import { expect } from 'chai';
 import express from 'express';
 import type { RequestHandler } from 'express';
 import { Registry } from 'prom-client';
 import sinon from 'sinon';
 
-import type { InterchainAccount, MultiProvider } from '@hyperlane-xyz/sdk';
+import { InterchainAccount, MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
-import { configureTrustProxy } from '../../src/utils/http.js';
+import {
+  GCE_INGRESS_PROXY_HOPS,
+  configureTrustProxy,
+} from '../../src/utils/http.js';
 import { initializeMetrics } from '../../src/utils/prometheus.js';
 
 const loadBalancerIp = '35.191.0.1';
@@ -40,10 +42,10 @@ function createServiceWithNoopHandlers(): CallCommitmentsService {
     return new CallCommitmentsService(
       {
         serviceName: 'callCommitments',
-        multiProvider: {} as MultiProvider,
+        multiProvider: sinon.createStubInstance(MultiProvider),
         baseUrl: 'https://example.com/callCommitments',
       },
-      {} as InterchainAccount,
+      sinon.createStubInstance(InterchainAccount),
     );
   } finally {
     stubs.forEach((stub) => stub.restore());
@@ -57,7 +59,9 @@ async function startTestServer() {
 
   const server = app.listen(0);
   await new Promise<void>((resolve) => server.once('listening', resolve));
-  const { port } = server.address() as AddressInfo;
+  const address = server.address();
+  assert(address && typeof address !== 'string', 'Expected TCP server address');
+  const { port } = address;
 
   return {
     server,
@@ -77,6 +81,18 @@ async function startTestServer() {
       }),
   };
 }
+
+describe('configureTrustProxy', () => {
+  it('configures the deployed GCE ingress hop count', () => {
+    const app = express();
+    const set = sinon.spy(app, 'set');
+
+    configureTrustProxy(app);
+
+    expect(set.calledWithExactly('trust proxy', GCE_INGRESS_PROXY_HOPS)).to.be
+      .true;
+  });
+});
 
 describe('Call commitments rate limiting', () => {
   let register: Registry;

--- a/typescript/ccip-server/tests/services/RateLimiting.test.ts
+++ b/typescript/ccip-server/tests/services/RateLimiting.test.ts
@@ -1,0 +1,157 @@
+import type { AddressInfo } from 'node:net';
+
+import { expect } from 'chai';
+import express from 'express';
+import type { RequestHandler } from 'express';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import type { InterchainAccount, MultiProvider } from '@hyperlane-xyz/sdk';
+
+import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
+import { configureTrustProxy } from '../../src/utils/http.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+
+const loadBalancerIp = '35.191.0.1';
+const clientOneIp = '192.0.2.1';
+const clientTwoIp = '192.0.2.2';
+const spoofedIp = '203.0.113.1';
+
+function createServiceWithNoopHandlers(): CallCommitmentsService {
+  const handler: RequestHandler = (req, res) => {
+    res.status(200).json({ ip: req.ip });
+  };
+  const stubs = [
+    sinon
+      .stub(CallCommitmentsService.prototype, 'handleCommitment')
+      .callsFake(handler),
+    sinon
+      .stub(CallCommitmentsService.prototype, 'handleCheckCommitment')
+      .callsFake(handler),
+    sinon
+      .stub(CallCommitmentsService.prototype, 'handleCalldataPost')
+      .callsFake(handler),
+    sinon
+      .stub(CallCommitmentsService.prototype, 'handleCalldataGet')
+      .callsFake(handler),
+  ];
+
+  try {
+    return new CallCommitmentsService(
+      {
+        serviceName: 'callCommitments',
+        multiProvider: {} as MultiProvider,
+        baseUrl: 'https://example.com/callCommitments',
+      },
+      {} as InterchainAccount,
+    );
+  } finally {
+    stubs.forEach((stub) => stub.restore());
+  }
+}
+
+async function startTestServer() {
+  const app = express();
+  configureTrustProxy(app);
+  app.use(createServiceWithNoopHandlers().router);
+
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    server,
+    request: (
+      method: 'GET' | 'POST',
+      path: string,
+      clientIp: string,
+      suppliedXff?: string,
+    ) =>
+      fetch(`http://127.0.0.1:${port}${path}`, {
+        method,
+        headers: {
+          'X-Forwarded-For': [suppliedXff, clientIp, loadBalancerIp]
+            .filter(Boolean)
+            .join(', '),
+        },
+      }),
+  };
+}
+
+describe('Call commitments rate limiting', () => {
+  let register: Registry;
+
+  beforeEach(() => {
+    register = new Registry();
+    initializeMetrics(register);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('isolates clients behind the GCE ingress', async () => {
+    const { server, request } = await startTestServer();
+
+    try {
+      const firstResponse = await request(
+        'POST',
+        '/calls',
+        clientOneIp,
+        spoofedIp,
+      );
+      expect(firstResponse.status).to.equal(200);
+      expect(await firstResponse.json()).to.deep.equal({ ip: clientOneIp });
+
+      for (let i = 1; i < 20; i += 1) {
+        expect((await request('POST', '/calls', clientOneIp)).status).to.equal(
+          200,
+        );
+      }
+
+      expect((await request('POST', '/calls', clientOneIp)).status).to.equal(
+        429,
+      );
+      expect((await request('POST', '/calls', clientTwoIp)).status).to.equal(
+        200,
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it('uses independent read and write buckets', async () => {
+    const { server, request } = await startTestServer();
+
+    try {
+      for (let i = 0; i < 20; i += 1) {
+        expect((await request('POST', '/calls', clientOneIp)).status).to.equal(
+          200,
+        );
+      }
+
+      expect((await request('POST', '/calldata', clientOneIp)).status).to.equal(
+        429,
+      );
+      expect(
+        (await request('GET', '/calls/0xcommitment', clientOneIp)).status,
+      ).to.equal(200);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('records bounded method and route labels', async () => {
+    const { server, request } = await startTestServer();
+
+    try {
+      for (let i = 0; i <= 20; i += 1) {
+        await request('GET', '/calldata/0xcommitment', clientOneIp);
+      }
+
+      expect(await register.metrics()).to.include(
+        'hyperlane_offchain_lookup_server_rate_limited_requests{method="GET",route="/calldata/:commitment"} 1',
+      );
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/typescript/ccip-server/tests/services/RateLimiting.test.ts
+++ b/typescript/ccip-server/tests/services/RateLimiting.test.ts
@@ -5,7 +5,7 @@ import { Registry } from 'prom-client';
 import sinon from 'sinon';
 
 import { InterchainAccount, MultiProvider } from '@hyperlane-xyz/sdk';
-import { assert } from '@hyperlane-xyz/utils';
+import { assert, isNullish } from '@hyperlane-xyz/utils';
 
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
 import {
@@ -60,7 +60,10 @@ async function startTestServer() {
   const server = app.listen(0);
   await new Promise<void>((resolve) => server.once('listening', resolve));
   const address = server.address();
-  assert(address && typeof address !== 'string', 'Expected TCP server address');
+  assert(
+    !isNullish(address) && typeof address !== 'string',
+    'Expected TCP server address',
+  );
   const { port } = address;
 
   return {


### PR DESCRIPTION
### What changed

- trust the two addresses appended by the current GCE ingress so requests are keyed by the client, not the shared load balancer
- give commitment reads and writes separate 20/minute budgets
- label rate-limit metrics with bounded method and route values
- cover spoofed XFF input, client isolation, read/write isolation, and metrics

### Why

The current `trust proxy = 1` selects the GCE load-balancer address from its two-entry XFF suffix. That puts public clients in one shared rate-limit bucket. Dromos reconciliation also adds reads to the existing write flow, so a shared GET/POST budget makes retries compete with persistence.

This keeps each existing ceiling at 20/minute; it does not broadly raise limits.

### Quantified impact

- before: one 20 request/minute bucket was shared by every public client and by both reads and writes
- after: each client gets independent 20/minute read and 20/minute write buckets, a nominal combined budget of 40/minute per client
- for a Dromos happy path with one POST and one GET, the configured ceiling moves from at most 10 globally shared swaps/minute to 20 swaps/minute per client before rate limiting
- the spoofed-XFF integration test proves an attacker-controlled leftmost XFF value does not change the client key selected from GCE's appended suffix

These are configured capacity bounds, not measured production throughput.

### Validation

- 29 CCIP server tests
- CCIP server lint and build
- oxfmt and diff check
- current exact-head self-review: no blockers; prior adversarial and Kimi review: no blockers

### Deployment invariant

The two-hop setting matches the current GCE ingress -> ClusterIP topology and is covered by an integration test including a spoofed leftmost XFF value. If the proxy topology changes, update the setting and test together.
