### PR TITLE
fix(ccip-server): reconcile commitment metadata

### DIFF
--- a/.changeset/curly-laws-protect.md
+++ b/.changeset/curly-laws-protect.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/ccip-server": patch
+---
+
+Hardened calls commitment reconciliation by rejecting conflicting retries and returning stored ICA metadata.

--- a/.changeset/curly-laws-protect.md
+++ b/.changeset/curly-laws-protect.md
@@ -2,4 +2,4 @@
 "@hyperlane-xyz/ccip-server": patch
 ---
 
-Hardened calls commitment reconciliation by rejecting conflicting retries and returning stored ICA metadata.
+Hardened calls commitment reconciliation by rejecting conflicting retries, returning stored ICA metadata, and atomically persisting EVM calldata with its legacy commitment.

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -53,15 +53,62 @@ const EnvSchema = z.object({
   SERVER_BASE_URL: z.string(),
 });
 
-// Zod schema for retrieving a commitment record
-const CommitmentRecordSchema = z.object({
-  commitment: z.string(),
+const CommitmentMetadataSchema = z.object({
   ica: z.string(),
-  calls: z.array(z.any()),
   relayers: z.array(z.string()),
-  salt: z.string(),
   originDomain: z.number(),
 });
+
+// Zod schema for retrieving a commitment record
+const CommitmentRecordSchema = CommitmentMetadataSchema.extend({
+  commitment: z.string(),
+  calls: z.array(z.any()),
+  salt: z.string(),
+});
+
+type CommitmentMetadata = z.infer<typeof CommitmentMetadataSchema>;
+
+const commitmentMetadataSelect = {
+  ica: true,
+  originDomain: true,
+  relayers: true,
+} as const;
+
+function normalizedRelayerSet(relayers: string[]): string[] {
+  return [...new Set(relayers.map((relayer) => relayer.toLowerCase()))].sort();
+}
+
+function hasMatchingCommitmentMetadata(
+  requested: CommitmentMetadata,
+  stored: CommitmentMetadata,
+): boolean {
+  if (
+    requested.ica.toLowerCase() !== stored.ica.toLowerCase() ||
+    requested.originDomain !== stored.originDomain
+  ) {
+    return false;
+  }
+
+  const requestedRelayers = normalizedRelayerSet(requested.relayers);
+  const storedRelayers = normalizedRelayerSet(stored.relayers);
+  return (
+    requestedRelayers.length === storedRelayers.length &&
+    requestedRelayers.every(
+      (relayer, index) => relayer === storedRelayers[index],
+    )
+  );
+}
+
+function isPrismaUniqueConstraintError(
+  error: unknown,
+): error is { code: 'P2002' } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'P2002'
+  );
+}
 
 export class CallCommitmentsService extends BaseService {
   private multiProvider: MultiProvider;
@@ -104,7 +151,7 @@ export class CallCommitmentsService extends BaseService {
   public async handleCommitment(req: Request, res: Response) {
     const logger = this.addLoggerServiceContext(req.log);
 
-    logger.info({ body: req.body }, 'Received commitment creation request');
+    logger.info('Received commitment creation request');
 
     const data = this.parseCommitmentBody(req.body, res, logger);
     if (!data) return;
@@ -119,7 +166,7 @@ export class CallCommitmentsService extends BaseService {
       logger.warn(
         {
           error: error instanceof Error ? error.message : error,
-          calls: data.calls,
+          callsCount: data.calls.length,
         },
         'Invalid call data',
       );
@@ -127,7 +174,14 @@ export class CallCommitmentsService extends BaseService {
     }
     logger.setBindings({ commitment });
 
-    logger.info(data, 'Processing commitment creation');
+    logger.info(
+      {
+        callsCount: data.calls.length,
+        originDomain: data.originDomain,
+        relayersCount: data.relayers.length,
+      },
+      'Processing commitment creation',
+    );
 
     let ica: string;
     try {
@@ -136,27 +190,38 @@ export class CallCommitmentsService extends BaseService {
       } else {
         ica = await this.deriveIcaFromDispatchTx(data, logger);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       logger.warn(
-        { error: error.message, stack: error.stack },
+        {
+          error: errorMessage,
+          stack: error instanceof Error ? error.stack : undefined,
+        },
         'Failed to derive ICA address',
       );
       return res.status(400).json({
-        error: `Failed to derive ICA address: ${error.message}`,
+        error: `Failed to derive ICA address: ${errorMessage}`,
       });
     }
 
-    // Attempt to insert the commitment. Using upsert for idempotency.
+    let storedMetadata: CommitmentMetadata;
     try {
-      await this.upsertCommitmentInDB(commitment, { ...data, ica }, logger);
-    } catch (error: any) {
+      storedMetadata = await this.upsertCommitmentInDB(
+        commitment,
+        { ...data, ica },
+        logger,
+      );
+    } catch (error: unknown) {
       // Any database error is unexpected.
       logger.error(
         {
-          ...data,
-          ica,
-          error: error.message,
-          stack: error.stack,
+          commitment,
+          callsCount: data.calls.length,
+          originDomain: data.originDomain,
+          relayersCount: data.relayers.length,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
           error_reason: UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
         },
         'Database error during commitment processing',
@@ -168,8 +233,40 @@ export class CallCommitmentsService extends BaseService {
       return res.status(500).json({ error: 'Internal server error' });
     }
 
-    logger.info(data, 'Commitment processing completed successfully');
-    return res.status(200).json({ commitment });
+    const requestedMetadata = {
+      ica,
+      originDomain: data.originDomain,
+      relayers: data.relayers,
+    };
+    if (!hasMatchingCommitmentMetadata(requestedMetadata, storedMetadata)) {
+      logger.warn(
+        {
+          commitment,
+          requestedOriginDomain: data.originDomain,
+          storedOriginDomain: storedMetadata.originDomain,
+          requestedRelayersCount: data.relayers.length,
+          storedRelayersCount: storedMetadata.relayers.length,
+        },
+        'Commitment already exists with different metadata',
+      );
+      return res
+        .status(409)
+        .json({ error: 'Commitment already exists with different metadata' });
+    }
+
+    logger.info(
+      {
+        commitment,
+        originDomain: storedMetadata.originDomain,
+        relayersCount: storedMetadata.relayers.length,
+      },
+      'Commitment processing completed successfully',
+    );
+    return res.status(200).json({
+      commitment,
+      ica: storedMetadata.ica,
+      originDomain: storedMetadata.originDomain,
+    });
   }
 
   public async handleFetchCommitment(
@@ -196,8 +293,9 @@ export class CallCommitmentsService extends BaseService {
       ) {
         log.warn(
           {
-            ...record,
+            commitment: record.commitment,
             relayer,
+            authorizedRelayersCount: record.relayers.length,
           },
           'Relayer not authorized for this commitment',
         );
@@ -242,7 +340,7 @@ export class CallCommitmentsService extends BaseService {
     const result = PostCallsSchema.safeParse(body);
     if (!result.success) {
       const errors = result.error.format();
-      logger.warn({ errors, body }, 'Invalid request body received');
+      logger.warn({ errors }, 'Invalid request body received');
       res.status(400).json({ errors });
       return null;
     }
@@ -258,21 +356,35 @@ export class CallCommitmentsService extends BaseService {
       ica: string;
     },
     logger: Logger,
-  ) {
+  ): Promise<CommitmentMetadata> {
     const { calls, relayers, salt, ica, originDomain } = data;
 
-    await prisma.commitment.upsert({
-      where: { commitment },
-      update: {}, // Do nothing if it already exists.
-      create: {
-        commitment,
-        calls,
-        relayers,
-        salt,
-        ica,
-        originDomain,
-      },
-    });
+    let record;
+    try {
+      record = await prisma.commitment.upsert({
+        where: { commitment },
+        update: {}, // Do nothing if it already exists.
+        create: {
+          commitment,
+          calls,
+          relayers,
+          salt,
+          ica,
+          originDomain,
+        },
+        select: commitmentMetadataSelect,
+      });
+    } catch (error: unknown) {
+      if (!isPrismaUniqueConstraintError(error)) throw error;
+
+      // Empty-update upserts may be client-handled by Prisma and race with a
+      // concurrent create. Re-read the winning row instead of reporting 500.
+      record = await prisma.commitment.findUnique({
+        where: { commitment },
+        select: commitmentMetadataSelect,
+      });
+      if (record === null) throw error;
+    }
 
     logger.info(
       {
@@ -282,6 +394,8 @@ export class CallCommitmentsService extends BaseService {
       },
       'Upserted commitment to database',
     );
+
+    return CommitmentMetadataSchema.parse(record);
   }
 
   /**
@@ -301,7 +415,15 @@ export class CallCommitmentsService extends BaseService {
     }
 
     const parsed = CommitmentRecordSchema.parse(record);
-    logger.info(parsed, 'Successfully fetched commitment record');
+    logger.info(
+      {
+        commitment: parsed.commitment,
+        callsCount: parsed.calls.length,
+        originDomain: parsed.originDomain,
+        relayersCount: parsed.relayers.length,
+      },
+      'Successfully fetched commitment record',
+    );
 
     return parsed;
   }
@@ -389,25 +511,33 @@ export class CallCommitmentsService extends BaseService {
   }
 
   /**
-   * GET /calls/:commitment — returns { exists: boolean }.
+   * GET /calls/:commitment — returns existence and stored routing metadata.
    * Used by the router status service to detect call_lost without a time threshold.
    */
   public async handleCheckCommitment(req: Request, res: Response) {
     const logger = this.addLoggerServiceContext(req.log);
     const { commitment } = req.params;
     assert(commitment, 'Route parameter :commitment must be present');
+    res.set('Cache-Control', 'no-store');
     try {
       const record = await prisma.commitment.findUnique({
         where: { commitment },
-        select: { commitment: true },
+        select: commitmentMetadataSelect,
       });
-      return res.json({ exists: record !== null });
-    } catch (error: any) {
+      if (record === null) return res.json({ exists: false });
+
+      const metadata = CommitmentMetadataSchema.parse(record);
+      return res.json({
+        exists: true,
+        ica: metadata.ica,
+        originDomain: metadata.originDomain,
+      });
+    } catch (error: unknown) {
       logger.error(
         {
           commitment,
-          error: error.message,
-          stack: error.stack,
+          error: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack : undefined,
           error_reason: UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
         },
         'Database error during commitment existence check',

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -29,7 +29,6 @@ import {
   addressToBytes32,
   bytes32ToAddress,
   assert,
-  eqAddress,
   parseMessage,
 } from '@hyperlane-xyz/utils';
 
@@ -144,6 +143,14 @@ function normalizedRelayerSet(relayers: string[]): string[] {
       }),
     ),
   ].sort();
+}
+
+function includesRelayer(relayers: string[], relayer: string): boolean {
+  const normalizedRelayer = normalizedRelayerSet([relayer])[0];
+  return (
+    normalizedRelayer !== undefined &&
+    normalizedRelayerSet(relayers).includes(normalizedRelayer)
+  );
 }
 
 function hasMatchingCommitmentMetadata(
@@ -428,7 +435,7 @@ export class CallCommitmentsService extends BaseService {
 
       if (
         record.relayers.length > 0 &&
-        !record.relayers.find((r: string) => eqAddress(r, relayer))
+        !includesRelayer(record.relayers, relayer)
       ) {
         log.warn(
           {

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -34,6 +34,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { prisma } from '../db.js';
+import type { Prisma } from '../generated/prisma/client.js';
 import { createAbiHandler } from '../utils/abiHandler.js';
 import {
   PrometheusMetrics,
@@ -74,8 +75,75 @@ const commitmentMetadataSelect = {
   relayers: true,
 } as const;
 
+const RevealAccountSchema = z.object({
+  pubkey: z.string(),
+  isWritable: z.boolean(),
+  isSigner: z.boolean(),
+});
+
+const CalldataMetadataSchema = z.object({
+  originDomain: z.number(),
+  data: z.string(),
+  salt: z.string(),
+  relayers: z.array(z.string()),
+  destinationAccount: z.string(),
+  revealAccounts: z.array(RevealAccountSchema).nullish(),
+});
+
+const StoredCallSchema = z.object({
+  to: z.string(),
+  data: z.string(),
+  value: z.union([z.string(), z.number()]).optional(),
+});
+
+const commitmentReconciliationSelect = {
+  ...commitmentMetadataSelect,
+  calls: true,
+  salt: true,
+} as const;
+
+const calldataMetadataSelect = {
+  originDomain: true,
+  data: true,
+  salt: true,
+  relayers: true,
+  destinationAccount: true,
+  revealAccounts: true,
+} as const;
+
+type CalldataPost = {
+  commitment: string;
+  originDomain: number;
+  data: string;
+  salt: string;
+  relayers: string[];
+  destinationAccount: string;
+  revealAccounts?: Array<z.infer<typeof RevealAccountSchema>>;
+};
+type CalldataMetadata = z.infer<typeof CalldataMetadataSchema>;
+type StoredCall = z.infer<typeof StoredCallSchema>;
+type ReconciliationDb = Pick<
+  Prisma.TransactionClient,
+  'calldata' | 'commitment'
+>;
+
+class CommitmentConflictError extends Error {}
+
+const EVM_RELAYER_REGEX = /^0x(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
 function normalizedRelayerSet(relayers: string[]): string[] {
-  return [...new Set(relayers.map((relayer) => relayer.toLowerCase()))].sort();
+  return [
+    ...new Set(
+      relayers.map((relayer) => {
+        if (EVM_RELAYER_REGEX.test(relayer)) {
+          return addressToBytes32(
+            '0x' + relayer.slice(2).toLowerCase(),
+          ).toLowerCase();
+        }
+        return relayer;
+      }),
+    ),
+  ].sort();
 }
 
 function hasMatchingCommitmentMetadata(
@@ -107,6 +175,77 @@ function isPrismaUniqueConstraintError(
     error !== null &&
     'code' in error &&
     error.code === 'P2002'
+  );
+}
+
+function hasMatchingRevealAccounts(
+  requested: CalldataMetadata['revealAccounts'],
+  stored: CalldataMetadata['revealAccounts'],
+): boolean {
+  const requestedAccounts = requested ?? [];
+  const storedAccounts = stored ?? [];
+  return (
+    requestedAccounts.length === storedAccounts.length &&
+    requestedAccounts.every((account, index) => {
+      const storedAccount = storedAccounts[index];
+      return (
+        storedAccount !== undefined &&
+        account.pubkey === storedAccount.pubkey &&
+        account.isWritable === storedAccount.isWritable &&
+        account.isSigner === storedAccount.isSigner
+      );
+    })
+  );
+}
+
+function hasMatchingCalldataMetadata(
+  requested: CalldataMetadata,
+  stored: CalldataMetadata,
+): boolean {
+  return (
+    requested.originDomain === stored.originDomain &&
+    requested.data.toLowerCase() === stored.data.toLowerCase() &&
+    requested.salt.toLowerCase() === stored.salt.toLowerCase() &&
+    requested.destinationAccount.toLowerCase() ===
+      stored.destinationAccount.toLowerCase() &&
+    normalizedRelayerSet(requested.relayers).join(',') ===
+      normalizedRelayerSet(stored.relayers).join(',') &&
+    hasMatchingRevealAccounts(requested.revealAccounts, stored.revealAccounts)
+  );
+}
+
+function hasMatchingLegacyCommitment(
+  requested: CalldataPost,
+  requestedCalls: StoredCall[],
+  stored: CommitmentMetadata & { calls: unknown; salt: string },
+): boolean {
+  const parsedCalls = z.array(StoredCallSchema).safeParse(stored.calls);
+  if (!parsedCalls.success) return false;
+
+  let storedEncodedCalls: string;
+  try {
+    storedEncodedCalls = encodeIcaCalls(
+      normalizeCalls(parsedCalls.data),
+      stored.salt,
+    );
+  } catch {
+    return false;
+  }
+
+  const requestedEncodedCalls = encodeIcaCalls(
+    normalizeCalls(requestedCalls),
+    requested.salt,
+  );
+  return (
+    requestedEncodedCalls.toLowerCase() === storedEncodedCalls.toLowerCase() &&
+    hasMatchingCommitmentMetadata(
+      {
+        ica: bytes32ToAddress(requested.destinationAccount),
+        originDomain: requested.originDomain,
+        relayers: requested.relayers,
+      },
+      stored,
+    )
   );
 }
 
@@ -610,12 +749,11 @@ export class CallCommitmentsService extends BaseService {
       return res.status(400).json({ errors: result.error.format() });
     }
     const {
-      commitment,
+      commitment: requestedCommitment,
       originDomain,
       data,
       salt,
       relayers,
-      destinationAccount,
       revealAccounts,
     } = result.data;
     // Verify commitment = keccak256(salt || data) before persisting.
@@ -623,78 +761,63 @@ export class CallCommitmentsService extends BaseService {
     const expectedCommitment = utils.keccak256(
       utils.concat([utils.arrayify(salt), utils.arrayify(data)]),
     );
-    if (expectedCommitment.toLowerCase() !== commitment.toLowerCase()) {
+    if (
+      expectedCommitment.toLowerCase() !== requestedCommitment.toLowerCase()
+    ) {
       return res
         .status(400)
         .json({ error: 'commitment does not match keccak256(salt || data)' });
     }
+    const commitment = expectedCommitment;
+
+    // Only EVM-destination routes carry ABI-encoded ICA calls. Decode before
+    // writing so those routes can persist both records in one transaction.
+    let decodedCalls: StoredCall[] | null = null;
+    try {
+      // CAST: ethers v5 ABI decoding returns Result rather than the tuple type.
+      const [raw] = utils.defaultAbiCoder.decode(
+        ['tuple(bytes32 to, uint256 value, bytes data)[]'],
+        data,
+      ) as [Array<{ to: string; value: { toString(): string }; data: string }>];
+      decodedCalls = raw.map((call) => ({
+        to: call.to,
+        value: call.value.toString(),
+        data: call.data,
+      }));
+    } catch {
+      logger.debug(
+        { commitment },
+        'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
+      );
+    }
 
     logger.info({ originDomain, commitment }, 'Storing calldata');
     try {
-      await prisma.calldata.upsert({
-        where: { commitment },
-        update: {},
-        create: {
-          commitment,
-          originDomain,
-          data,
-          salt,
-          relayers,
-          destinationAccount,
-          ...(revealAccounts != null && { revealAccounts }),
-        },
-      });
-
-      // Dual-write to Commitment table so the existing getCallsFromRevealMessage
-      // CCIP-Read endpoint keeps working. Only EVM-destination routes carry
-      // ABI-encoded ICA calls — borsh (Solana) data will fail to decode and
-      // skip the dual-write automatically.
-      let decodedCalls: Array<{
-        to: string;
-        value: string;
-        data: string;
-      }> | null = null;
-      try {
-        const [raw] = utils.defaultAbiCoder.decode(
-          ['tuple(bytes32 to, uint256 value, bytes data)[]'],
-          data,
-        ) as [
-          Array<{ to: string; value: { toString(): string }; data: string }>,
-        ];
-        decodedCalls = raw.map((c) => ({
-          to: c.to,
-          value: c.value.toString(),
-          data: c.data,
-        }));
-      } catch {
-        // Solana-destination routes carry borsh data that fails ABI decode — not an error.
-        logger.debug(
-          { commitment },
-          'Skipping Commitment dual-write (data is not ABI-encoded ICA calls)',
-        );
-      }
-      if (decodedCalls != null) {
-        const icaAddress = bytes32ToAddress(destinationAccount);
-        await prisma.commitment.upsert({
-          where: { commitment },
-          update: {},
-          create: {
-            commitment,
-            calls: decodedCalls,
-            relayers,
-            salt,
-            ica: icaAddress,
-            originDomain,
-          },
-        });
-        logger.info(
-          { commitment, icaAddress, originDomain },
-          'Dual-wrote to Commitment table',
-        );
-      }
+      await this.storeCalldata(
+        { ...result.data, commitment },
+        decodedCalls,
+        logger,
+      );
     } catch (error: unknown) {
+      if (error instanceof CommitmentConflictError) {
+        logger.warn(
+          {
+            commitment,
+            originDomain,
+            relayersCount: relayers.length,
+            hasRevealAccounts: revealAccounts !== undefined,
+          },
+          'Commitment already exists with different metadata',
+        );
+        return res
+          .status(409)
+          .json({ error: 'Commitment already exists with different metadata' });
+      }
+
       logger.error(
         {
+          commitment,
+          originDomain,
           error: error instanceof Error ? error.message : String(error),
           error_reason: UnhandledErrorReason.CALL_COMMITMENTS_DATABASE_ERROR,
         },
@@ -706,7 +829,79 @@ export class CallCommitmentsService extends BaseService {
       );
       return res.status(500).json({ error: 'Internal server error' });
     }
+
     return res.status(200).json({ commitment });
+  }
+
+  private async storeCalldata(
+    data: CalldataPost,
+    decodedCalls: StoredCall[] | null,
+    logger: Logger,
+  ): Promise<void> {
+    const write = async (db: ReconciliationDb): Promise<void> => {
+      const storedCalldata = CalldataMetadataSchema.parse(
+        await db.calldata.upsert({
+          where: { commitment: data.commitment },
+          // Non-empty no-op update makes this a database-native upsert, avoiding
+          // client-side create races while preserving first-write-wins semantics.
+          update: { commitment: data.commitment },
+          create: {
+            commitment: data.commitment,
+            originDomain: data.originDomain,
+            data: data.data,
+            salt: data.salt,
+            relayers: data.relayers,
+            destinationAccount: data.destinationAccount,
+            ...(data.revealAccounts !== undefined && {
+              revealAccounts: data.revealAccounts,
+            }),
+          },
+          select: calldataMetadataSelect,
+        }),
+      );
+      if (!hasMatchingCalldataMetadata(data, storedCalldata)) {
+        throw new CommitmentConflictError();
+      }
+
+      if (decodedCalls === null) return;
+
+      const storedCommitmentRecord = await db.commitment.upsert({
+        where: { commitment: data.commitment },
+        update: { commitment: data.commitment },
+        create: {
+          commitment: data.commitment,
+          calls: decodedCalls,
+          relayers: data.relayers,
+          salt: data.salt,
+          ica: bytes32ToAddress(data.destinationAccount),
+          originDomain: data.originDomain,
+        },
+        select: commitmentReconciliationSelect,
+      });
+      const storedCommitment = {
+        ...CommitmentMetadataSchema.parse(storedCommitmentRecord),
+        calls: storedCommitmentRecord.calls,
+        salt: storedCommitmentRecord.salt,
+      };
+      if (!hasMatchingLegacyCommitment(data, decodedCalls, storedCommitment)) {
+        throw new CommitmentConflictError();
+      }
+    };
+
+    if (decodedCalls === null) {
+      await write(prisma);
+      logger.info(
+        { commitment: data.commitment, originDomain: data.originDomain },
+        'Stored calldata',
+      );
+      return;
+    }
+
+    await prisma.$transaction(write);
+    logger.info(
+      { commitment: data.commitment, originDomain: data.originDomain },
+      'Atomically stored calldata and legacy commitment',
+    );
   }
 
   public async handleCalldataGet(req: Request, res: Response) {

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -1,3 +1,4 @@
+import { utils } from 'ethers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -7,6 +8,7 @@ import {
   isPostCallsIca,
   normalizeCalls,
 } from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
 
 import { prisma } from '../../src/db.js';
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
@@ -59,6 +61,24 @@ const storedMetadata = {
   ica: mockIca,
   originDomain: icaPayload.originDomain,
   relayers: baseRelayers,
+};
+
+const abiData = utils.defaultAbiCoder.encode(
+  ['tuple(bytes32 to, uint256 value, bytes data)[]'],
+  [[{ to: addressToBytes32(validAddress), value: 0, data: '0x' }]],
+);
+const calldataSalt = '0x' + '56'.repeat(32);
+const calldataCommitment = utils.keccak256(
+  utils.concat([utils.arrayify(calldataSalt), utils.arrayify(abiData)]),
+);
+const destinationAccount = addressToBytes32(mockIca);
+const calldataPayload = {
+  commitment: calldataCommitment,
+  originDomain: 1,
+  data: abiData,
+  salt: calldataSalt,
+  relayers: [baseRelayers[0]],
+  destinationAccount,
 };
 
 class TestPrismaUniqueConstraintError extends Error {
@@ -197,6 +217,27 @@ describe('CallCommitmentsService.handleCommitment', () => {
       }),
     ).to.be.true;
     expect(res.json.firstCall.args[0]).not.to.have.property('relayers');
+  });
+
+  it('accepts identical case-sensitive non-EVM relayers', async () => {
+    const nonEvmRelayer = '11111111111111111111111111111111';
+    const payload = { ...icaPayload, relayers: [nonEvmRelayer] };
+    const icaApp = {
+      getAccount: sinon.stub().resolves(mockIca),
+    };
+    const multiProvider = {
+      getChainName: sinon.stub().returns('ethereum'),
+    };
+    const service = createService({ icaApp, multiProvider });
+    service.upsertCommitmentInDB = sinon.stub().resolves({
+      ...storedMetadata,
+      relayers: [nonEvmRelayer],
+    });
+    const res = mockRes();
+
+    await service.handleCommitment({ body: payload, log: mockLogger() }, res);
+
+    expect(res.status.calledWith(200)).to.be.true;
   });
 
   for (const [field, conflict] of [
@@ -438,6 +479,276 @@ describe('CallCommitmentsService.handleCheckCommitment', () => {
     );
 
     expect(res.set.calledWith('Cache-Control', 'no-store')).to.be.true;
+    expect(res.status.calledWith(500)).to.be.true;
+    expect(res.json.calledWith({ error: 'Internal server error' })).to.be.true;
+  });
+});
+
+describe('CallCommitmentsService.handleCalldataPost', () => {
+  function createService() {
+    const service = Object.create(CallCommitmentsService.prototype);
+    service.addLoggerServiceContext = () => mockLogger();
+    service.config = { serviceName: 'callCommitments' };
+    return service;
+  }
+
+  function storedCalldata(
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      originDomain: calldataPayload.originDomain,
+      data: calldataPayload.data,
+      salt: calldataPayload.salt,
+      relayers: calldataPayload.relayers,
+      destinationAccount: calldataPayload.destinationAccount,
+      revealAccounts: null,
+      ...overrides,
+    };
+  }
+
+  function storedCommitment(
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      ica: mockIca,
+      originDomain: calldataPayload.originDomain,
+      relayers: calldataPayload.relayers,
+      calls: [{ to: addressToBytes32(validAddress), data: '0x', value: '0' }],
+      salt: calldataPayload.salt,
+      ...overrides,
+    };
+  }
+
+  it('atomically stores EVM calldata and its legacy commitment', async () => {
+    const calldataUpsert = sinon.stub().resolves(storedCalldata());
+    const commitmentUpsert = sinon.stub().resolves(storedCommitment());
+    const transaction = sinon.stub().callsFake(async (write) =>
+      write({
+        calldata: { upsert: calldataUpsert },
+        commitment: { upsert: commitmentUpsert },
+      }),
+    );
+    sinon.stub(prisma, '$transaction').value(transaction);
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      { body: calldataPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(transaction.calledOnce).to.be.true;
+    expect(calldataUpsert.calledOnce).to.be.true;
+    expect(commitmentUpsert.calledOnce).to.be.true;
+    expect(calldataUpsert.firstCall.args[0]).to.deep.include({
+      update: { commitment: calldataCommitment },
+    });
+    expect(commitmentUpsert.firstCall.args[0]).to.deep.include({
+      update: { commitment: calldataCommitment },
+    });
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.json.calledWith({ commitment: calldataCommitment })).to.be.true;
+  });
+
+  it('accepts an identical EVM retry with canonicalized relayers', async () => {
+    const calldataUpsert = sinon
+      .stub()
+      .resolves(
+        storedCalldata({ relayers: [addressToBytes32(baseRelayers[0])] }),
+      );
+    const commitmentUpsert = sinon
+      .stub()
+      .resolves(
+        storedCommitment({ relayers: [addressToBytes32(baseRelayers[0])] }),
+      );
+    const transaction = sinon.stub().callsFake(async (write) =>
+      write({
+        calldata: { upsert: calldataUpsert },
+        commitment: { upsert: commitmentUpsert },
+      }),
+    );
+    sinon.stub(prisma, '$transaction').value(transaction);
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      {
+        body: {
+          ...calldataPayload,
+          commitment: '0x' + calldataPayload.commitment.slice(2).toUpperCase(),
+        },
+        log: mockLogger(),
+      },
+      res,
+    );
+
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(calldataUpsert.firstCall.args[0]).to.deep.include({
+      where: { commitment: calldataCommitment },
+    });
+  });
+
+  it('accepts concurrent identical EVM retries', async () => {
+    const calldataUpsert = sinon.stub().resolves(storedCalldata());
+    const commitmentUpsert = sinon.stub().resolves(storedCommitment());
+    const transaction = sinon.stub().callsFake(async (write) =>
+      write({
+        calldata: { upsert: calldataUpsert },
+        commitment: { upsert: commitmentUpsert },
+      }),
+    );
+    sinon.stub(prisma, '$transaction').value(transaction);
+    const service = createService();
+    const responses = [mockRes(), mockRes()];
+
+    await Promise.all(
+      responses.map((res) =>
+        service.handleCalldataPost(
+          { body: calldataPayload, log: mockLogger() },
+          res,
+        ),
+      ),
+    );
+
+    expect(transaction.callCount).to.equal(2);
+    expect(calldataUpsert.callCount).to.equal(2);
+    expect(commitmentUpsert.callCount).to.equal(2);
+    expect(responses.every((res) => res.status.calledWith(200))).to.be.true;
+  });
+
+  it('rolls back both EVM writes when the legacy commitment conflicts', async () => {
+    let rolledBack = false;
+    const calldataUpsert = sinon.stub().resolves(storedCalldata());
+    const commitmentUpsert = sinon
+      .stub()
+      .resolves(storedCommitment({ originDomain: 2 }));
+    const transaction = sinon.stub().callsFake(async (write) => {
+      try {
+        return await write({
+          calldata: { upsert: calldataUpsert },
+          commitment: { upsert: commitmentUpsert },
+        });
+      } catch (error: unknown) {
+        rolledBack = true;
+        throw error;
+      }
+    });
+    sinon.stub(prisma, '$transaction').value(transaction);
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      { body: calldataPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(rolledBack).to.be.true;
+    expect(res.status.calledWith(409)).to.be.true;
+  });
+
+  it('rejects conflicting stored calldata without writing legacy state', async () => {
+    const calldataUpsert = sinon
+      .stub()
+      .resolves(
+        storedCalldata({ destinationAccount: addressToBytes32(validAddress) }),
+      );
+    const commitmentUpsert = sinon.stub();
+    const transaction = sinon.stub().callsFake(async (write) =>
+      write({
+        calldata: { upsert: calldataUpsert },
+        commitment: { upsert: commitmentUpsert },
+      }),
+    );
+    sinon.stub(prisma, '$transaction').value(transaction);
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      { body: calldataPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(commitmentUpsert.called).to.be.false;
+    expect(res.status.calledWith(409)).to.be.true;
+  });
+
+  it('stores non-ABI calldata without opening a transaction', async () => {
+    const solanaData = '0x01';
+    const solanaPayload = {
+      ...calldataPayload,
+      data: solanaData,
+      commitment: utils.keccak256(
+        utils.concat([
+          utils.arrayify(calldataPayload.salt),
+          utils.arrayify(solanaData),
+        ]),
+      ),
+    };
+    const calldataUpsert = sinon.stub().resolves(
+      storedCalldata({
+        data: solanaData,
+        destinationAccount: solanaPayload.destinationAccount,
+      }),
+    );
+    sinon.stub(prisma, 'calldata').value({ upsert: calldataUpsert });
+    const transaction = sinon.stub(prisma, '$transaction');
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      { body: solanaPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(transaction.called).to.be.false;
+    expect(res.status.calledWith(200)).to.be.true;
+  });
+
+  it('rejects conflicting non-ABI calldata without opening a transaction', async () => {
+    const solanaData = '0x01';
+    const solanaPayload = {
+      ...calldataPayload,
+      data: solanaData,
+      commitment: utils.keccak256(
+        utils.concat([
+          utils.arrayify(calldataPayload.salt),
+          utils.arrayify(solanaData),
+        ]),
+      ),
+    };
+    const calldataUpsert = sinon.stub().resolves(
+      storedCalldata({
+        data: solanaData,
+        originDomain: 2,
+      }),
+    );
+    sinon.stub(prisma, 'calldata').value({ upsert: calldataUpsert });
+    const transaction = sinon.stub(prisma, '$transaction');
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      { body: solanaPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(transaction.called).to.be.false;
+    expect(res.status.calledWith(409)).to.be.true;
+  });
+
+  it('returns 500 when the atomic EVM write fails', async () => {
+    sinon.stub(PrometheusMetrics, 'logUnhandledError');
+    sinon
+      .stub(prisma, '$transaction')
+      .rejects(new Error('database unavailable'));
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCalldataPost(
+      { body: calldataPayload, log: mockLogger() },
+      res,
+    );
+
     expect(res.status.calledWith(500)).to.be.true;
     expect(res.json.calledWith({ error: 'Internal server error' })).to.be.true;
   });

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -8,7 +8,9 @@ import {
   normalizeCalls,
 } from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
 
+import { prisma } from '../../src/db.js';
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
+import { PrometheusMetrics } from '../../src/utils/prometheus.js';
 
 function mockLogger() {
   return {
@@ -25,14 +27,16 @@ function mockRes() {
   const json = sinon.stub();
   const status = sinon.stub().returns({ json });
   const sendStatus = sinon.stub();
-  return { status, json, sendStatus };
+  const set = sinon.stub();
+  return { status, json, sendStatus, set };
 }
 
 const validAddress = '0x' + 'ab'.repeat(20);
 const salt = '0x' + '00'.repeat(32);
+const mockIca = '0x' + 'ff'.repeat(20);
 
 const baseCalls = [{ to: validAddress, data: '0x', value: '0' }];
-const baseRelayers = ['0x' + 'cd'.repeat(20)];
+const baseRelayers = ['0x' + 'cd'.repeat(20), '0x' + '12'.repeat(20)];
 
 const icaPayload = {
   calls: baseCalls,
@@ -50,6 +54,18 @@ const legacyPayload = {
   originDomain: 1,
   commitmentDispatchTx: '0x' + 'ef'.repeat(32),
 };
+
+const storedMetadata = {
+  ica: mockIca,
+  originDomain: icaPayload.originDomain,
+  relayers: baseRelayers,
+};
+
+class TestPrismaUniqueConstraintError extends Error {
+  readonly code = 'P2002';
+}
+
+afterEach(() => sinon.restore());
 
 describe('PostCallsSchema union', () => {
   it('accepts new ICA shape', () => {
@@ -89,6 +105,7 @@ describe('CallCommitmentsService.handleCommitment', () => {
   function createService(overrides: Record<string, any> = {}) {
     const service = Object.create(CallCommitmentsService.prototype);
     service.addLoggerServiceContext = () => mockLogger();
+    service.config = { serviceName: 'callCommitments' };
     service.multiProvider = overrides.multiProvider ?? {};
     service.icaApp = overrides.icaApp ?? {};
     return service;
@@ -118,7 +135,6 @@ describe('CallCommitmentsService.handleCommitment', () => {
   });
 
   it('routes ICA payload to deriveIcaFromConfig', async () => {
-    const mockIca = '0x' + 'ff'.repeat(20);
     const icaApp = {
       getAccount: sinon.stub().resolves(mockIca),
     };
@@ -127,7 +143,7 @@ describe('CallCommitmentsService.handleCommitment', () => {
       getProvider: sinon.stub(),
     };
     const service = createService({ icaApp, multiProvider });
-    service.upsertCommitmentInDB = sinon.stub().resolves();
+    service.upsertCommitmentInDB = sinon.stub().resolves(storedMetadata);
 
     const req = { body: icaPayload, log: mockLogger() };
     const res = mockRes();
@@ -136,7 +152,106 @@ describe('CallCommitmentsService.handleCommitment', () => {
 
     expect(icaApp.getAccount.called).to.be.true;
     expect(res.status.calledWith(200)).to.be.true;
-    expect(res.json.calledWithMatch(sinon.match.has('commitment'))).to.be.true;
+    expect(
+      res.json.calledWithMatch({
+        commitment: commitmentFromIcaCalls(
+          normalizeCalls(icaPayload.calls),
+          salt,
+        ),
+        ica: storedMetadata.ica,
+        originDomain: storedMetadata.originDomain,
+      }),
+    ).to.be.true;
+  });
+
+  it('accepts an idempotent retry with reordered, differently-cased relayers and ICA', async () => {
+    const icaApp = {
+      getAccount: sinon.stub().resolves(mockIca),
+    };
+    const multiProvider = {
+      getChainName: sinon.stub().returns('ethereum'),
+    };
+    const service = createService({ icaApp, multiProvider });
+    const existingMetadata = {
+      ica: mockIca.toUpperCase(),
+      originDomain: icaPayload.originDomain,
+      relayers: [
+        baseRelayers[1].toUpperCase(),
+        baseRelayers[0].toUpperCase(),
+        baseRelayers[0],
+      ],
+    };
+    service.upsertCommitmentInDB = sinon.stub().resolves(existingMetadata);
+
+    const res = mockRes();
+    await service.handleCommitment(
+      { body: icaPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(
+      res.json.calledWithMatch({
+        ica: existingMetadata.ica,
+        originDomain: existingMetadata.originDomain,
+      }),
+    ).to.be.true;
+    expect(res.json.firstCall.args[0]).not.to.have.property('relayers');
+  });
+
+  for (const [field, conflict] of [
+    ['ICA', { ...storedMetadata, ica: '0x' + 'ee'.repeat(20) }],
+    ['origin domain', { ...storedMetadata, originDomain: 3 }],
+    ['relayers', { ...storedMetadata, relayers: [baseRelayers[0]] }],
+  ] as const) {
+    it(`returns 409 without overwriting when ${field} conflicts`, async () => {
+      const icaApp = {
+        getAccount: sinon.stub().resolves(mockIca),
+      };
+      const multiProvider = {
+        getChainName: sinon.stub().returns('ethereum'),
+      };
+      const service = createService({ icaApp, multiProvider });
+      const upsert = sinon.stub().resolves(conflict);
+      service.upsertCommitmentInDB = upsert;
+
+      const res = mockRes();
+      await service.handleCommitment(
+        { body: icaPayload, log: mockLogger() },
+        res,
+      );
+
+      expect(upsert.calledOnce).to.be.true;
+      expect(res.status.calledWith(409)).to.be.true;
+      expect(
+        res.json.calledWith({
+          error: 'Commitment already exists with different metadata',
+        }),
+      ).to.be.true;
+    });
+  }
+
+  it('returns 500 when the commitment upsert fails', async () => {
+    sinon.stub(PrometheusMetrics, 'logUnhandledError');
+    const icaApp = {
+      getAccount: sinon.stub().resolves(mockIca),
+    };
+    const multiProvider = {
+      getChainName: sinon.stub().returns('ethereum'),
+    };
+    const service = createService({ icaApp, multiProvider });
+    service.upsertCommitmentInDB = sinon
+      .stub()
+      .rejects(new Error('database unavailable'));
+
+    const res = mockRes();
+    await service.handleCommitment(
+      { body: icaPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(res.status.calledWith(500)).to.be.true;
+    expect(res.json.calledWith({ error: 'Internal server error' })).to.be.true;
   });
 
   it('routes legacy payload to deriveIcaFromDispatchTx', async () => {
@@ -157,6 +272,174 @@ describe('CallCommitmentsService.handleCommitment', () => {
     expect(res.status.calledWith(400)).to.be.true;
     expect(multiProvider.getProvider.calledWith(legacyPayload.originDomain)).to
       .be.true;
+  });
+
+  it('uses one no-op upsert and returns its stored metadata', async () => {
+    const service = createService();
+    const record = {
+      commitment: commitmentFromIcaCalls(
+        normalizeCalls(icaPayload.calls),
+        salt,
+      ),
+      calls: baseCalls,
+      salt,
+      ...storedMetadata,
+      createdAt: new Date(),
+    };
+    const upsert = sinon.stub().resolves(record);
+    sinon.stub(prisma, 'commitment').value({ upsert });
+
+    const result = await service.upsertCommitmentInDB(
+      record.commitment,
+      { ...icaPayload, ica: mockIca },
+      mockLogger(),
+    );
+
+    expect(upsert.calledOnce).to.be.true;
+    expect(upsert.firstCall.args[0]).to.deep.include({
+      where: { commitment: record.commitment },
+      update: {},
+    });
+    expect(result).to.deep.equal(storedMetadata);
+  });
+
+  it('re-reads the winner when concurrent creation raises P2002', async () => {
+    const service = createService();
+    const commitment = commitmentFromIcaCalls(
+      normalizeCalls(icaPayload.calls),
+      salt,
+    );
+    const upsert = sinon.stub().callsFake(async () => {
+      throw new TestPrismaUniqueConstraintError();
+    });
+    const findUnique = sinon.stub().resolves({
+      commitment,
+      calls: baseCalls,
+      salt,
+      ...storedMetadata,
+      createdAt: new Date(),
+    });
+    sinon.stub(prisma, 'commitment').value({ upsert, findUnique });
+
+    const result = await service.upsertCommitmentInDB(
+      commitment,
+      { ...icaPayload, ica: mockIca },
+      mockLogger(),
+    );
+
+    expect(findUnique.calledOnceWithMatch({ where: { commitment } })).to.be
+      .true;
+    expect(result).to.deep.equal(storedMetadata);
+  });
+
+  it('rethrows P2002 when no winning row exists', async () => {
+    const service = createService();
+    const error = new TestPrismaUniqueConstraintError();
+    const upsert = sinon.stub().callsFake(async () => {
+      throw error;
+    });
+    const findUnique = sinon.stub().resolves(null);
+    sinon.stub(prisma, 'commitment').value({ upsert, findUnique });
+
+    let caught: unknown;
+    try {
+      await service.upsertCommitmentInDB(
+        '0x' + '34'.repeat(32),
+        { ...icaPayload, ica: mockIca },
+        mockLogger(),
+      );
+    } catch (thrown: unknown) {
+      caught = thrown;
+    }
+
+    expect(caught).to.equal(error);
+  });
+
+  it('rethrows non-race upsert errors', async () => {
+    const service = createService();
+    const error = new Error('database unavailable');
+    const upsert = sinon.stub().rejects(error);
+    const findUnique = sinon.stub();
+    sinon.stub(prisma, 'commitment').value({ upsert, findUnique });
+
+    let caught: unknown;
+    try {
+      await service.upsertCommitmentInDB(
+        '0x' + '34'.repeat(32),
+        { ...icaPayload, ica: mockIca },
+        mockLogger(),
+      );
+    } catch (thrown: unknown) {
+      caught = thrown;
+    }
+
+    expect(caught).to.equal(error);
+    expect(findUnique.called).to.be.false;
+  });
+});
+
+describe('CallCommitmentsService.handleCheckCommitment', () => {
+  function createService() {
+    const service = Object.create(CallCommitmentsService.prototype);
+    service.addLoggerServiceContext = () => mockLogger();
+    service.config = { serviceName: 'callCommitments' };
+    return service;
+  }
+
+  const commitment = '0x' + '34'.repeat(32);
+
+  it('returns stored metadata and disables caching when present', async () => {
+    const findUnique = sinon.stub().resolves(storedMetadata);
+    sinon.stub(prisma, 'commitment').value({ findUnique });
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCheckCommitment(
+      { params: { commitment }, log: mockLogger() },
+      res,
+    );
+
+    expect(res.set.calledWith('Cache-Control', 'no-store')).to.be.true;
+    expect(
+      res.json.calledWith({
+        exists: true,
+        ica: storedMetadata.ica,
+        originDomain: storedMetadata.originDomain,
+      }),
+    ).to.be.true;
+    expect(res.json.firstCall.args[0]).not.to.have.property('relayers');
+  });
+
+  it('returns exists false and disables caching when missing', async () => {
+    const findUnique = sinon.stub().resolves(null);
+    sinon.stub(prisma, 'commitment').value({ findUnique });
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCheckCommitment(
+      { params: { commitment }, log: mockLogger() },
+      res,
+    );
+
+    expect(res.set.calledWith('Cache-Control', 'no-store')).to.be.true;
+    expect(res.json.calledWith({ exists: false })).to.be.true;
+  });
+
+  it('returns 500 and disables caching when the database read fails', async () => {
+    sinon.stub(PrometheusMetrics, 'logUnhandledError');
+    const findUnique = sinon.stub().rejects(new Error('database unavailable'));
+    sinon.stub(prisma, 'commitment').value({ findUnique });
+    const service = createService();
+    const res = mockRes();
+
+    await service.handleCheckCommitment(
+      { params: { commitment }, log: mockLogger() },
+      res,
+    );
+
+    expect(res.set.calledWith('Cache-Control', 'no-store')).to.be.true;
+    expect(res.status.calledWith(500)).to.be.true;
+    expect(res.json.calledWith({ error: 'Internal server error' })).to.be.true;
   });
 });
 

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -5,10 +5,11 @@ import sinon from 'sinon';
 import {
   PostCallsSchema,
   commitmentFromIcaCalls,
+  encodeIcaCalls,
   isPostCallsIca,
   normalizeCalls,
 } from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { addressToBytes32, formatMessage } from '@hyperlane-xyz/utils';
 
 import { prisma } from '../../src/db.js';
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
@@ -481,6 +482,73 @@ describe('CallCommitmentsService.handleCheckCommitment', () => {
     expect(res.set.calledWith('Cache-Control', 'no-store')).to.be.true;
     expect(res.status.calledWith(500)).to.be.true;
     expect(res.json.calledWith({ error: 'Internal server error' })).to.be.true;
+  });
+});
+
+describe('CallCommitmentsService.handleFetchCommitment', () => {
+  function createService() {
+    const service = Object.create(CallCommitmentsService.prototype);
+    service.addLoggerServiceContext = () => mockLogger();
+    return service;
+  }
+
+  const commitment = commitmentFromIcaCalls(baseCalls, salt);
+  const revealBody = utils.solidityPack(
+    ['uint8', 'bytes32', 'bytes32'],
+    [2, salt, commitment],
+  );
+  const message = formatMessage(
+    3,
+    0,
+    1,
+    validAddress,
+    2,
+    validAddress,
+    revealBody,
+  );
+
+  it('authorizes an unpadded EVM relayer stored as bytes32', async () => {
+    const service = createService();
+    service.fetchCommitmentRecord = sinon.stub().resolves({
+      commitment,
+      calls: baseCalls,
+      salt,
+      ica: mockIca,
+      originDomain: 1,
+      relayers: [addressToBytes32(baseRelayers[0])],
+    });
+
+    const result = await service.handleFetchCommitment(
+      message,
+      baseRelayers[0],
+      mockLogger(),
+    );
+
+    expect(result).to.equal(
+      mockIca + encodeIcaCalls(normalizeCalls(baseCalls), salt).slice(2),
+    );
+  });
+
+  it('rejects an unlisted EVM relayer when the allowlist uses bytes32', async () => {
+    const service = createService();
+    service.fetchCommitmentRecord = sinon.stub().resolves({
+      commitment,
+      calls: baseCalls,
+      salt,
+      ica: mockIca,
+      originDomain: 1,
+      relayers: [addressToBytes32(baseRelayers[0])],
+    });
+
+    const result = await service.handleFetchCommitment(
+      message,
+      baseRelayers[1],
+      mockLogger(),
+    );
+
+    expect(JSON.parse(result)).to.deep.equal({
+      error: `Relayer ${baseRelayers[1]} not authorized for this commitment`,
+    });
   });
 });
 


### PR DESCRIPTION
Stacked on the CCIP rate-limit fix. Review this PR against its stacked base for the isolated reconciliation diff.

### What changed

- make duplicate `/calls` writes metadata-aware: identical retries return 200; conflicting ICA, origin domain, or relayer set returns 409 without overwrite
- recover concurrent Prisma create races by re-reading and comparing the winning row
- return stored ICA and origin domain from POST/GET so clients can reconcile ambiguous writes
- keep relayers, calls, and salt private; narrow persistence selects
- disable caching on existence reads and remove raw commitment payloads from logs
- atomically persist EVM `/calldata` and legacy `/calls` rows; reconcile duplicate metadata for EVM and non-ABI routes

### Why

The commitment hash binds calls and salt, while the database row also contains ICA, origin, and relayer metadata. The previous empty-update upsert treated a retry with conflicting metadata as success. A client could confirm that a key existed without proving it was the usable record for its request.

The `/calldata` dual-write previously had the same failure class: its new row could commit before the legacy CCIP-read row, and duplicate metadata was first-write-wins. EVM dual-writes now share one Prisma transaction; non-ABI destinations reconcile their single row.

### Quantified impact

- `/calls` now checks three routing dimensions on every duplicate: ICA, origin domain, and canonical relayer set; any mismatch changes the response from a false-positive 200 to 409
- `/calldata` reconciles six persisted dimensions: origin domain, calldata, salt, destination account, relayer set, and reveal accounts, plus the decoded legacy call record
- EVM persistence changes from two independently committed rows to two rows in one transaction, reducing the application-level half-written outcomes from one possible partial state to zero when the transaction succeeds or rolls back
- public reconciliation exposes two routing fields (`ica` and `originDomain`) while keeping the relayer allowlist, calls, and salt private

This PR is a reliability/security hardening change. It does not claim a latency improvement; the transaction and comparisons add bounded work in exchange for removing false-success and partial-write states.

### Validation

- 52 CCIP server tests on the stacked head
- CCIP server lint and build
- oxfmt and diff check
- current exact-head self-review: no blockers; prior adversarial and Kimi review: no blockers

### Scope

This hardens the legacy `/calls` record used by Dromos and the existing `/calldata` dual-write. It does not migrate Dromos to `/calldata`, expose the relayer allowlist, or change commitment hashing.
