### PR TITLE
perf(ccip-server): derive ICA addresses locally

### DIFF
--- a/.changeset/small-icas-race.md
+++ b/.changeset/small-icas-race.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/ccip-server": patch
+---
+
+Parallelized router metadata reads and derived modern interchain account addresses locally, reducing the valid modern path from three sequential RPC rounds to one.

--- a/.changeset/small-icas-race.md
+++ b/.changeset/small-icas-race.md
@@ -1,5 +1,6 @@
 ---
 "@hyperlane-xyz/ccip-server": patch
+"@hyperlane-xyz/sdk": patch
 ---
 
-Parallelized router metadata reads and derived modern interchain account addresses locally, reducing the valid modern path from three sequential RPC rounds to one.
+Interchain account address derivation was moved into the shared SDK path, with router metadata reads parallelized and modern addresses derived locally. This reduced the valid modern path from three sequential RPC rounds to one.

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -14,7 +14,6 @@ import {
   InterchainAccount,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
-import { isMissingSelectorCallException } from '@hyperlane-xyz/sdk/utils/contract';
 import {
   PostCallsIcaType,
   PostCallsLegacyType,
@@ -30,7 +29,6 @@ import {
   addressToBytes32,
   bytes32ToAddress,
   assert,
-  isZeroishAddress,
   parseMessage,
 } from '@hyperlane-xyz/utils';
 
@@ -605,65 +603,7 @@ export class CallCommitmentsService extends BaseService {
       'Deriving ICA from config',
     );
 
-    const originDomain = this.multiProvider.tryGetDomainId(
-      accountConfig.origin,
-    );
-    if (!originDomain) {
-      throw new Error(
-        `Origin chain (${accountConfig.origin}) metadata needed for deriving ICA`,
-      );
-    }
-
-    const destinationRouter = this.icaApp.router(
-      this.icaApp.contractsMap[destinationChain],
-    );
-    const bytecodeHashPromise = destinationRouter
-      .bytecodeHash()
-      .then((bytecodeHash) => ({ bytecodeHash }))
-      .catch((error: unknown) => {
-        if (isMissingSelectorCallException(error)) {
-          return { bytecodeHash: null };
-        }
-        throw error;
-      });
-
-    const [rawOriginRouter, rawIsm, { bytecodeHash }] = await Promise.all([
-      destinationRouter.routers(originDomain),
-      accountConfig.ismOverride ?? destinationRouter.isms(originDomain),
-      bytecodeHashPromise,
-    ]);
-    const originRouterAddress = bytes32ToAddress(rawOriginRouter);
-    if (isZeroishAddress(originRouterAddress)) {
-      throw new Error(
-        `Origin router address is zero for ${accountConfig.origin} on ${destinationChain}`,
-      );
-    }
-
-    const destinationIsmAddress = bytes32ToAddress(addressToBytes32(rawIsm));
-    const owner = addressToBytes32(accountConfig.owner);
-    const originRouter = addressToBytes32(originRouterAddress);
-    const ism = utils.hexZeroPad(destinationIsmAddress, 32);
-    const userSalt = accountConfig.userSalt ?? InterchainAccount.EMPTY_SALT;
-
-    if (bytecodeHash === null) {
-      logger.debug(
-        { destinationChain },
-        'Falling back to onchain ICA derivation for legacy router',
-      );
-      return destinationRouter[
-        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-      ](originDomain, owner, originRouter, destinationIsmAddress, userSalt);
-    }
-
-    const deploySalt = utils.solidityKeccak256(
-      ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
-      [originDomain, owner, originRouter, ism, userSalt],
-    );
-    return utils.getCreate2Address(
-      destinationRouter.address,
-      deploySalt,
-      bytecodeHash,
-    );
+    return this.icaApp.getAccount(destinationChain, accountConfig);
   }
 
   /**

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -14,6 +14,7 @@ import {
   InterchainAccount,
   MultiProvider,
 } from '@hyperlane-xyz/sdk';
+import { isMissingSelectorCallException } from '@hyperlane-xyz/sdk/utils/contract';
 import {
   PostCallsIcaType,
   PostCallsLegacyType,
@@ -29,6 +30,7 @@ import {
   addressToBytes32,
   bytes32ToAddress,
   assert,
+  isZeroishAddress,
   parseMessage,
 } from '@hyperlane-xyz/utils';
 
@@ -603,7 +605,65 @@ export class CallCommitmentsService extends BaseService {
       'Deriving ICA from config',
     );
 
-    return this.icaApp.getAccount(destinationChain, accountConfig);
+    const originDomain = this.multiProvider.tryGetDomainId(
+      accountConfig.origin,
+    );
+    if (!originDomain) {
+      throw new Error(
+        `Origin chain (${accountConfig.origin}) metadata needed for deriving ICA`,
+      );
+    }
+
+    const destinationRouter = this.icaApp.router(
+      this.icaApp.contractsMap[destinationChain],
+    );
+    const bytecodeHashPromise = destinationRouter
+      .bytecodeHash()
+      .then((bytecodeHash) => ({ bytecodeHash }))
+      .catch((error: unknown) => {
+        if (isMissingSelectorCallException(error)) {
+          return { bytecodeHash: null };
+        }
+        throw error;
+      });
+
+    const [rawOriginRouter, rawIsm, { bytecodeHash }] = await Promise.all([
+      destinationRouter.routers(originDomain),
+      accountConfig.ismOverride ?? destinationRouter.isms(originDomain),
+      bytecodeHashPromise,
+    ]);
+    const originRouterAddress = bytes32ToAddress(rawOriginRouter);
+    if (isZeroishAddress(originRouterAddress)) {
+      throw new Error(
+        `Origin router address is zero for ${accountConfig.origin} on ${destinationChain}`,
+      );
+    }
+
+    const destinationIsmAddress = bytes32ToAddress(addressToBytes32(rawIsm));
+    const owner = addressToBytes32(accountConfig.owner);
+    const originRouter = addressToBytes32(originRouterAddress);
+    const ism = utils.hexZeroPad(destinationIsmAddress, 32);
+    const userSalt = accountConfig.userSalt ?? InterchainAccount.EMPTY_SALT;
+
+    if (bytecodeHash === null) {
+      logger.debug(
+        { destinationChain },
+        'Falling back to onchain ICA derivation for legacy router',
+      );
+      return destinationRouter[
+        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ](originDomain, owner, originRouter, destinationIsmAddress, userSalt);
+    }
+
+    const deploySalt = utils.solidityKeccak256(
+      ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
+      [originDomain, owner, originRouter, ism, userSalt],
+    );
+    return utils.getCreate2Address(
+      destinationRouter.address,
+      deploySalt,
+      bytecodeHash,
+    );
   }
 
   /**

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -1,4 +1,4 @@
-import { utils } from 'ethers';
+import { constants, utils } from 'ethers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -9,7 +9,12 @@ import {
   isPostCallsIca,
   normalizeCalls,
 } from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
-import { addressToBytes32, formatMessage } from '@hyperlane-xyz/utils';
+import { InterchainAccount } from '@hyperlane-xyz/sdk';
+import {
+  addressToBytes32,
+  bytes32ToAddress,
+  formatMessage,
+} from '@hyperlane-xyz/utils';
 
 import { prisma } from '../../src/db.js';
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
@@ -129,6 +134,8 @@ describe('CallCommitmentsService.handleCommitment', () => {
     service.config = { serviceName: 'callCommitments' };
     service.multiProvider = overrides.multiProvider ?? {};
     service.icaApp = overrides.icaApp ?? {};
+    service.deriveIcaFromConfig =
+      overrides.deriveIcaFromConfig ?? sinon.stub().resolves(mockIca);
     return service;
   }
 
@@ -156,14 +163,12 @@ describe('CallCommitmentsService.handleCommitment', () => {
   });
 
   it('routes ICA payload to deriveIcaFromConfig', async () => {
-    const icaApp = {
-      getAccount: sinon.stub().resolves(mockIca),
-    };
+    const deriveIcaFromConfig = sinon.stub().resolves(mockIca);
     const multiProvider = {
       getChainName: sinon.stub().returns('ethereum'),
       getProvider: sinon.stub(),
     };
-    const service = createService({ icaApp, multiProvider });
+    const service = createService({ deriveIcaFromConfig, multiProvider });
     service.upsertCommitmentInDB = sinon.stub().resolves(storedMetadata);
 
     const req = { body: icaPayload, log: mockLogger() };
@@ -171,7 +176,7 @@ describe('CallCommitmentsService.handleCommitment', () => {
 
     await service.handleCommitment(req, res);
 
-    expect(icaApp.getAccount.called).to.be.true;
+    expect(deriveIcaFromConfig.calledOnce).to.be.true;
     expect(res.status.calledWith(200)).to.be.true;
     expect(
       res.json.calledWithMatch({
@@ -296,6 +301,23 @@ describe('CallCommitmentsService.handleCommitment', () => {
     expect(res.json.calledWith({ error: 'Internal server error' })).to.be.true;
   });
 
+  it('does not write when ICA derivation fails', async () => {
+    const deriveIcaFromConfig = sinon
+      .stub()
+      .rejects(new Error('destination RPC unavailable'));
+    const service = createService({ deriveIcaFromConfig });
+    service.upsertCommitmentInDB = sinon.stub();
+    const res = mockRes();
+
+    await service.handleCommitment(
+      { body: icaPayload, log: mockLogger() },
+      res,
+    );
+
+    expect(res.status.calledWith(400)).to.be.true;
+    expect(service.upsertCommitmentInDB.called).to.be.false;
+  });
+
   it('routes legacy payload to deriveIcaFromDispatchTx', async () => {
     const multiProvider = {
       getChainName: sinon.stub().returns('ethereum'),
@@ -417,6 +439,275 @@ describe('CallCommitmentsService.handleCommitment', () => {
 
     expect(caught).to.equal(error);
     expect(findUnique.called).to.be.false;
+  });
+});
+
+describe('CallCommitmentsService.deriveIcaFromConfig', () => {
+  const originDomain = 1;
+  const destinationDomain = 2;
+  const originRouterAddress = '0x' + '11'.repeat(20);
+  const destinationRouterAddress = '0x' + '22'.repeat(20);
+  const ismAddress = '0x' + '33'.repeat(20);
+  const bytecodeHash = '0x' + '44'.repeat(32);
+
+  function expectedIca({
+    owner = icaPayload.owner,
+    originRouter = addressToBytes32(originRouterAddress),
+    ism = addressToBytes32(ismAddress),
+    userSalt = InterchainAccount.EMPTY_SALT,
+  }: {
+    owner?: string;
+    originRouter?: string;
+    ism?: string;
+    userSalt?: string;
+  } = {}) {
+    const deploySalt = utils.solidityKeccak256(
+      ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
+      [
+        originDomain,
+        addressToBytes32(owner),
+        addressToBytes32(bytes32ToAddress(originRouter)),
+        utils.hexZeroPad(bytes32ToAddress(addressToBytes32(ism)), 32),
+        userSalt,
+      ],
+    );
+    return utils.getCreate2Address(
+      destinationRouterAddress,
+      deploySalt,
+      bytecodeHash,
+    );
+  }
+
+  function createService({
+    router = addressToBytes32(originRouterAddress),
+    ism = addressToBytes32(ismAddress),
+    hash = bytecodeHash,
+    origin = originDomain,
+    destinationAddress = destinationRouterAddress,
+  }: {
+    router?: string;
+    ism?: string;
+    hash?: string | Error;
+    origin?: number | null;
+    destinationAddress?: string;
+  } = {}) {
+    const destinationRouter = {
+      address: destinationAddress,
+      routers: sinon.stub().resolves(router),
+      isms: sinon.stub().resolves(ism),
+      bytecodeHash:
+        hash instanceof Error
+          ? sinon.stub().rejects(hash)
+          : sinon.stub().resolves(hash),
+      'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)': sinon
+        .stub()
+        .callsFake(
+          async (
+            requestedOrigin: number,
+            owner: string,
+            requestedRouter: string,
+            requestedIsm: string,
+            userSalt: string,
+          ) => {
+            expect(requestedOrigin).to.equal(originDomain);
+            const deploySalt = utils.solidityKeccak256(
+              ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
+              [
+                requestedOrigin,
+                owner,
+                requestedRouter,
+                addressToBytes32(requestedIsm),
+                userSalt,
+              ],
+            );
+            return utils.getCreate2Address(
+              destinationRouterAddress,
+              deploySalt,
+              bytecodeHash,
+            );
+          },
+        ),
+    };
+    const multiProvider = {
+      getChainName: sinon
+        .stub()
+        .callsFake((domain: number) =>
+          domain === originDomain ? 'ethereum' : 'optimism',
+        ),
+      tryGetDomainId: sinon.stub().returns(origin),
+    };
+    const service = Object.create(CallCommitmentsService.prototype);
+    service.multiProvider = multiProvider;
+    service.icaApp = {
+      contractsMap: { optimism: {} },
+      router: sinon.stub().returns(destinationRouter),
+    };
+    return { service, destinationRouter, multiProvider };
+  }
+
+  it('derives default and custom salts without the contract getter', async () => {
+    for (const userSalt of [undefined, '0x' + '55'.repeat(32)]) {
+      const { service, destinationRouter } = createService();
+      const data = {
+        ...icaPayload,
+        destinationDomain,
+        ...(userSalt && { userSalt }),
+      };
+
+      const actual = await service.deriveIcaFromConfig(data, mockLogger());
+
+      expect(actual).to.equal(
+        expectedIca({ userSalt: userSalt ?? InterchainAccount.EMPTY_SALT }),
+      );
+      expect(
+        destinationRouter[
+          'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+        ].called,
+      ).to.be.false;
+    }
+  });
+
+  it('matches the deployed Base router golden vector', async () => {
+    const owner = '0x' + '11'.repeat(20);
+    const baseRouter = '0x44647Cd983E80558793780f9a0c7C2aa9F384D07';
+    const ethereumRouter = '0xC00b94c115742f711a6F9EA90373c33e9B72A4A9';
+    const baseBytecodeHash =
+      '0x539ad958a6ba3e4d7d060e7c4eb03f58331e502aa3dcc578f34506ddac8b37e9';
+    const { service } = createService({
+      router: addressToBytes32(ethereumRouter),
+      ism: constants.HashZero,
+      hash: baseBytecodeHash,
+      destinationAddress: baseRouter,
+    });
+
+    const actual = await service.deriveIcaFromConfig(
+      { ...icaPayload, owner, destinationDomain },
+      mockLogger(),
+    );
+
+    expect(actual).to.equal('0xa35B6C3E1604A6da3da2fb1210053Ba876d09CE7');
+  });
+
+  it('preserves a bytes32 owner and normalizes router and ISM like the SDK', async () => {
+    const owner = '0x' + '66'.repeat(32);
+    const rawRouter = `0x${'77'.repeat(12)}${'88'.repeat(20)}`;
+    const rawIsm = `0x${'99'.repeat(12)}${'aa'.repeat(20)}`;
+    const { service } = createService({ router: rawRouter, ism: rawIsm });
+
+    const actual = await service.deriveIcaFromConfig(
+      { ...icaPayload, owner, destinationDomain },
+      mockLogger(),
+    );
+
+    expect(actual).to.equal(
+      expectedIca({ owner, originRouter: rawRouter, ism: rawIsm }),
+    );
+  });
+
+  it('starts independent reads concurrently', async () => {
+    const { service, destinationRouter } = createService();
+    const pending: Array<{
+      promise: Promise<string>;
+      resolve(value: string): void;
+    }> = [];
+    for (const method of ['routers', 'isms', 'bytecodeHash'] as const) {
+      let resolve!: (value: string) => void;
+      const promise = new Promise<string>((complete) => {
+        resolve = complete;
+      });
+      pending.push({ promise, resolve });
+      destinationRouter[method].returns(promise);
+    }
+
+    const derivation = service.deriveIcaFromConfig(
+      { ...icaPayload, destinationDomain },
+      mockLogger(),
+    );
+
+    expect(destinationRouter.routers.calledOnce).to.be.true;
+    expect(destinationRouter.isms.calledOnce).to.be.true;
+    expect(destinationRouter.bytecodeHash.calledOnce).to.be.true;
+    pending[0].resolve(addressToBytes32(originRouterAddress));
+    pending[1].resolve(addressToBytes32(ismAddress));
+    pending[2].resolve(bytecodeHash);
+    expect(await derivation).to.equal(expectedIca());
+  });
+
+  it('uses an ISM override without reading the enrolled ISM', async () => {
+    const override = '0x' + 'aa'.repeat(20);
+    const { service, destinationRouter } = createService();
+
+    const actual = await service.deriveIcaFromConfig(
+      { ...icaPayload, destinationDomain, ismOverride: override },
+      mockLogger(),
+    );
+
+    expect(destinationRouter.isms.called).to.be.false;
+    expect(actual).to.equal(expectedIca({ ism: addressToBytes32(override) }));
+  });
+
+  it('falls back to the contract getter only when bytecodeHash is unavailable', async () => {
+    const missingSelector = Object.assign(new Error('missing selector'), {
+      code: 'CALL_EXCEPTION',
+      data: '0x',
+    });
+    const { service, destinationRouter } = createService({
+      hash: missingSelector,
+    });
+
+    const actual = await service.deriveIcaFromConfig(
+      { ...icaPayload, destinationDomain },
+      mockLogger(),
+    );
+
+    expect(actual).to.equal(expectedIca());
+    expect(
+      destinationRouter[
+        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ].calledOnce,
+    ).to.be.true;
+  });
+
+  it('does not mask a bytecodeHash RPC failure', async () => {
+    const error = new Error('RPC unavailable');
+    const { service, destinationRouter } = createService({ hash: error });
+
+    let caught: unknown;
+    try {
+      await service.deriveIcaFromConfig(
+        { ...icaPayload, destinationDomain },
+        mockLogger(),
+      );
+    } catch (thrown: unknown) {
+      caught = thrown;
+    }
+
+    expect(caught).to.equal(error);
+    expect(
+      destinationRouter[
+        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ].called,
+    ).to.be.false;
+  });
+
+  it('rejects zero or missing origin routing metadata', async () => {
+    const zeroRouter = createService({
+      router: constants.HashZero,
+    });
+    const missingDomain = createService({ origin: 0 });
+
+    for (const { service } of [zeroRouter, missingDomain]) {
+      let caught: unknown;
+      try {
+        await service.deriveIcaFromConfig(
+          { ...icaPayload, destinationDomain },
+          mockLogger(),
+        );
+      } catch (thrown: unknown) {
+        caught = thrown;
+      }
+      expect(caught).to.be.instanceOf(Error);
+    }
   });
 });
 

--- a/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
+++ b/typescript/ccip-server/tests/services/CallCommitmentsService.test.ts
@@ -1,4 +1,4 @@
-import { constants, utils } from 'ethers';
+import { utils } from 'ethers';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -9,12 +9,7 @@ import {
   isPostCallsIca,
   normalizeCalls,
 } from '@hyperlane-xyz/sdk/middleware/account/icaCalls';
-import { InterchainAccount } from '@hyperlane-xyz/sdk';
-import {
-  addressToBytes32,
-  bytes32ToAddress,
-  formatMessage,
-} from '@hyperlane-xyz/utils';
+import { addressToBytes32, formatMessage } from '@hyperlane-xyz/utils';
 
 import { prisma } from '../../src/db.js';
 import { CallCommitmentsService } from '../../src/services/CallCommitmentsService.js';
@@ -443,271 +438,36 @@ describe('CallCommitmentsService.handleCommitment', () => {
 });
 
 describe('CallCommitmentsService.deriveIcaFromConfig', () => {
-  const originDomain = 1;
-  const destinationDomain = 2;
-  const originRouterAddress = '0x' + '11'.repeat(20);
-  const destinationRouterAddress = '0x' + '22'.repeat(20);
-  const ismAddress = '0x' + '33'.repeat(20);
-  const bytecodeHash = '0x' + '44'.repeat(32);
-
-  function expectedIca({
-    owner = icaPayload.owner,
-    originRouter = addressToBytes32(originRouterAddress),
-    ism = addressToBytes32(ismAddress),
-    userSalt = InterchainAccount.EMPTY_SALT,
-  }: {
-    owner?: string;
-    originRouter?: string;
-    ism?: string;
-    userSalt?: string;
-  } = {}) {
-    const deploySalt = utils.solidityKeccak256(
-      ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
-      [
-        originDomain,
-        addressToBytes32(owner),
-        addressToBytes32(bytes32ToAddress(originRouter)),
-        utils.hexZeroPad(bytes32ToAddress(addressToBytes32(ism)), 32),
-        userSalt,
-      ],
-    );
-    return utils.getCreate2Address(
-      destinationRouterAddress,
-      deploySalt,
-      bytecodeHash,
-    );
-  }
-
-  function createService({
-    router = addressToBytes32(originRouterAddress),
-    ism = addressToBytes32(ismAddress),
-    hash = bytecodeHash,
-    origin = originDomain,
-    destinationAddress = destinationRouterAddress,
-  }: {
-    router?: string;
-    ism?: string;
-    hash?: string | Error;
-    origin?: number | null;
-    destinationAddress?: string;
-  } = {}) {
-    const destinationRouter = {
-      address: destinationAddress,
-      routers: sinon.stub().resolves(router),
-      isms: sinon.stub().resolves(ism),
-      bytecodeHash:
-        hash instanceof Error
-          ? sinon.stub().rejects(hash)
-          : sinon.stub().resolves(hash),
-      'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)': sinon
-        .stub()
-        .callsFake(
-          async (
-            requestedOrigin: number,
-            owner: string,
-            requestedRouter: string,
-            requestedIsm: string,
-            userSalt: string,
-          ) => {
-            expect(requestedOrigin).to.equal(originDomain);
-            const deploySalt = utils.solidityKeccak256(
-              ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
-              [
-                requestedOrigin,
-                owner,
-                requestedRouter,
-                addressToBytes32(requestedIsm),
-                userSalt,
-              ],
-            );
-            return utils.getCreate2Address(
-              destinationRouterAddress,
-              deploySalt,
-              bytecodeHash,
-            );
-          },
-        ),
-    };
-    const multiProvider = {
+  it('delegates the normalized chain config to the SDK', async () => {
+    const getAccount = sinon.stub().resolves(mockIca);
+    const service = Object.create(CallCommitmentsService.prototype);
+    service.multiProvider = {
       getChainName: sinon
         .stub()
         .callsFake((domain: number) =>
-          domain === originDomain ? 'ethereum' : 'optimism',
+          domain === icaPayload.originDomain ? 'ethereum' : 'optimism',
         ),
-      tryGetDomainId: sinon.stub().returns(origin),
     };
-    const service = Object.create(CallCommitmentsService.prototype);
-    service.multiProvider = multiProvider;
-    service.icaApp = {
-      contractsMap: { optimism: {} },
-      router: sinon.stub().returns(destinationRouter),
+    service.icaApp = { getAccount };
+    const data = {
+      ...icaPayload,
+      ismOverride: '0x' + 'bb'.repeat(20),
+      userSalt: '0x' + 'cc'.repeat(32),
     };
-    return { service, destinationRouter, multiProvider };
-  }
 
-  it('derives default and custom salts without the contract getter', async () => {
-    for (const userSalt of [undefined, '0x' + '55'.repeat(32)]) {
-      const { service, destinationRouter } = createService();
-      const data = {
-        ...icaPayload,
-        destinationDomain,
-        ...(userSalt && { userSalt }),
-      };
-
-      const actual = await service.deriveIcaFromConfig(data, mockLogger());
-
-      expect(actual).to.equal(
-        expectedIca({ userSalt: userSalt ?? InterchainAccount.EMPTY_SALT }),
-      );
-      expect(
-        destinationRouter[
-          'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-        ].called,
-      ).to.be.false;
-    }
-  });
-
-  it('matches the deployed Base router golden vector', async () => {
-    const owner = '0x' + '11'.repeat(20);
-    const baseRouter = '0x44647Cd983E80558793780f9a0c7C2aa9F384D07';
-    const ethereumRouter = '0xC00b94c115742f711a6F9EA90373c33e9B72A4A9';
-    const baseBytecodeHash =
-      '0x539ad958a6ba3e4d7d060e7c4eb03f58331e502aa3dcc578f34506ddac8b37e9';
-    const { service } = createService({
-      router: addressToBytes32(ethereumRouter),
-      ism: constants.HashZero,
-      hash: baseBytecodeHash,
-      destinationAddress: baseRouter,
-    });
-
-    const actual = await service.deriveIcaFromConfig(
-      { ...icaPayload, owner, destinationDomain },
-      mockLogger(),
+    expect(await service.deriveIcaFromConfig(data, mockLogger())).to.equal(
+      mockIca,
     );
-
-    expect(actual).to.equal('0xa35B6C3E1604A6da3da2fb1210053Ba876d09CE7');
-  });
-
-  it('preserves a bytes32 owner and normalizes router and ISM like the SDK', async () => {
-    const owner = '0x' + '66'.repeat(32);
-    const rawRouter = `0x${'77'.repeat(12)}${'88'.repeat(20)}`;
-    const rawIsm = `0x${'99'.repeat(12)}${'aa'.repeat(20)}`;
-    const { service } = createService({ router: rawRouter, ism: rawIsm });
-
-    const actual = await service.deriveIcaFromConfig(
-      { ...icaPayload, owner, destinationDomain },
-      mockLogger(),
-    );
-
-    expect(actual).to.equal(
-      expectedIca({ owner, originRouter: rawRouter, ism: rawIsm }),
-    );
-  });
-
-  it('starts independent reads concurrently', async () => {
-    const { service, destinationRouter } = createService();
-    const pending: Array<{
-      promise: Promise<string>;
-      resolve(value: string): void;
-    }> = [];
-    for (const method of ['routers', 'isms', 'bytecodeHash'] as const) {
-      let resolve!: (value: string) => void;
-      const promise = new Promise<string>((complete) => {
-        resolve = complete;
-      });
-      pending.push({ promise, resolve });
-      destinationRouter[method].returns(promise);
-    }
-
-    const derivation = service.deriveIcaFromConfig(
-      { ...icaPayload, destinationDomain },
-      mockLogger(),
-    );
-
-    expect(destinationRouter.routers.calledOnce).to.be.true;
-    expect(destinationRouter.isms.calledOnce).to.be.true;
-    expect(destinationRouter.bytecodeHash.calledOnce).to.be.true;
-    pending[0].resolve(addressToBytes32(originRouterAddress));
-    pending[1].resolve(addressToBytes32(ismAddress));
-    pending[2].resolve(bytecodeHash);
-    expect(await derivation).to.equal(expectedIca());
-  });
-
-  it('uses an ISM override without reading the enrolled ISM', async () => {
-    const override = '0x' + 'aa'.repeat(20);
-    const { service, destinationRouter } = createService();
-
-    const actual = await service.deriveIcaFromConfig(
-      { ...icaPayload, destinationDomain, ismOverride: override },
-      mockLogger(),
-    );
-
-    expect(destinationRouter.isms.called).to.be.false;
-    expect(actual).to.equal(expectedIca({ ism: addressToBytes32(override) }));
-  });
-
-  it('falls back to the contract getter only when bytecodeHash is unavailable', async () => {
-    const missingSelector = Object.assign(new Error('missing selector'), {
-      code: 'CALL_EXCEPTION',
-      data: '0x',
-    });
-    const { service, destinationRouter } = createService({
-      hash: missingSelector,
-    });
-
-    const actual = await service.deriveIcaFromConfig(
-      { ...icaPayload, destinationDomain },
-      mockLogger(),
-    );
-
-    expect(actual).to.equal(expectedIca());
-    expect(
-      destinationRouter[
-        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-      ].calledOnce,
-    ).to.be.true;
-  });
-
-  it('does not mask a bytecodeHash RPC failure', async () => {
-    const error = new Error('RPC unavailable');
-    const { service, destinationRouter } = createService({ hash: error });
-
-    let caught: unknown;
-    try {
-      await service.deriveIcaFromConfig(
-        { ...icaPayload, destinationDomain },
-        mockLogger(),
-      );
-    } catch (thrown: unknown) {
-      caught = thrown;
-    }
-
-    expect(caught).to.equal(error);
-    expect(
-      destinationRouter[
-        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-      ].called,
-    ).to.be.false;
-  });
-
-  it('rejects zero or missing origin routing metadata', async () => {
-    const zeroRouter = createService({
-      router: constants.HashZero,
-    });
-    const missingDomain = createService({ origin: 0 });
-
-    for (const { service } of [zeroRouter, missingDomain]) {
-      let caught: unknown;
-      try {
-        await service.deriveIcaFromConfig(
-          { ...icaPayload, destinationDomain },
-          mockLogger(),
-        );
-      } catch (thrown: unknown) {
-        caught = thrown;
-      }
-      expect(caught).to.be.instanceOf(Error);
-    }
+    expect(getAccount.calledOnce).to.be.true;
+    expect(getAccount.firstCall.args).to.deep.equal([
+      'optimism',
+      {
+        origin: 'ethereum',
+        owner: data.owner,
+        ismOverride: data.ismOverride,
+        userSalt: data.userSalt,
+      },
+    ]);
   });
 });
 

--- a/typescript/sdk/src/middleware/account/InterchainAccount.test.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.test.ts
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
-import { BigNumber } from 'ethers';
+import { BigNumber, constants, utils } from 'ethers';
 import sinon from 'sinon';
 
 import { InterchainAccountRouter__factory } from '@hyperlane-xyz/core';
-import { formatStandardHookMetadata } from '@hyperlane-xyz/utils';
+import {
+  addressToBytes32,
+  bytes32ToAddress,
+  formatStandardHookMetadata,
+} from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
@@ -128,6 +132,265 @@ describe('PostCallsSchema', () => {
       icaPayload({ relayers: ['not-an-address'] }),
     );
     expect(result.success).to.be.false;
+  });
+});
+
+describe('InterchainAccount.getAccount', () => {
+  const origin = TestChainName.test1;
+  const destination = TestChainName.test2;
+  const originDomain = 1;
+  const owner = '0x' + '11'.repeat(20);
+  const originRouterAddress = '0x' + '22'.repeat(20);
+  const destinationRouterAddress = '0x' + '33'.repeat(20);
+  const ismAddress = '0x' + '44'.repeat(20);
+  const bytecodeHash = '0x' + '55'.repeat(32);
+
+  afterEach(() => sinon.restore());
+
+  function expectedAccount({
+    accountOwner = owner,
+    router = addressToBytes32(originRouterAddress),
+    ism = addressToBytes32(ismAddress),
+    salt = InterchainAccount.EMPTY_SALT,
+    domain = originDomain,
+  }: {
+    accountOwner?: string;
+    router?: string;
+    ism?: string;
+    salt?: string;
+    domain?: number;
+  } = {}) {
+    const deploySalt = utils.solidityKeccak256(
+      ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
+      [
+        domain,
+        addressToBytes32(accountOwner),
+        addressToBytes32(bytes32ToAddress(router)),
+        utils.hexZeroPad(bytes32ToAddress(addressToBytes32(ism)), 32),
+        salt,
+      ],
+    );
+    return utils.getCreate2Address(
+      destinationRouterAddress,
+      deploySalt,
+      bytecodeHash,
+    );
+  }
+
+  function createApp({
+    router = addressToBytes32(originRouterAddress),
+    ism = addressToBytes32(ismAddress),
+    hash = bytecodeHash,
+    configuredDestination = true,
+    domain = originDomain,
+  }: {
+    router?: string;
+    ism?: string;
+    hash?: string | Error;
+    configuredDestination?: boolean;
+    domain?: number | null;
+  } = {}) {
+    const destinationRouter = {
+      address: destinationRouterAddress,
+      routers: sinon.stub().resolves(router),
+      isms: sinon.stub().resolves(ism),
+      bytecodeHash:
+        hash instanceof Error
+          ? sinon.stub().rejects(hash)
+          : sinon.stub().resolves(hash),
+      'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)': sinon
+        .stub()
+        .resolves(expectedAccount()),
+      'getDeployedInterchainAccount(uint32,bytes32,bytes32,address,bytes32)':
+        sinon.stub().resolves({ hash: '0x1234' }),
+      estimateGas: {
+        'getDeployedInterchainAccount(uint32,bytes32,bytes32,address,bytes32)':
+          sinon.stub().resolves(BigNumber.from(100_000)),
+      },
+    };
+    const provider = {
+      getCode: sinon.stub().resolves('0x'),
+    };
+    const multiProvider = {
+      getProvider: sinon.stub().returns(provider),
+      getTransactionOverrides: sinon.stub().returns({}),
+      handleTx: sinon.stub().resolves(),
+      tryGetDomainId: sinon.stub().returns(domain),
+    };
+    const app = Object.assign(Object.create(InterchainAccount.prototype), {
+      contractsMap: configuredDestination
+        ? { [destination]: { interchainAccountRouter: destinationRouter } }
+        : { [destination]: {} },
+      knownAccounts: {},
+      logger: { debug: sinon.stub() },
+      multiProvider,
+    });
+    return { app, destinationRouter, multiProvider };
+  }
+
+  it('matches a deployed router golden vector', async () => {
+    const baseRouter = '0x44647Cd983E80558793780f9a0c7C2aa9F384D07';
+    const ethereumRouter = '0xC00b94c115742f711a6F9EA90373c33e9B72A4A9';
+    const baseBytecodeHash = [
+      '0x539ad958a6ba3e4d7d060e7c4eb03f58',
+      '331e502aa3dcc578f34506ddac8b37e9',
+    ].join('');
+    const { app } = createApp({
+      router: addressToBytes32(ethereumRouter),
+      ism: constants.HashZero,
+      hash: baseBytecodeHash,
+    });
+    app.contractsMap[destination].interchainAccountRouter.address = baseRouter;
+
+    expect(await app.getAccount(destination, { origin, owner })).to.equal(
+      '0xa35B6C3E1604A6da3da2fb1210053Ba876d09CE7',
+    );
+  });
+
+  it('starts independent metadata reads concurrently', async () => {
+    const { app, destinationRouter } = createApp();
+    const pending: Array<{
+      promise: Promise<string>;
+      resolve(value: string): void;
+    }> = [];
+    for (const method of ['routers', 'isms', 'bytecodeHash'] as const) {
+      let resolve!: (value: string) => void;
+      const promise = new Promise<string>((complete) => {
+        resolve = complete;
+      });
+      pending.push({ promise, resolve });
+      destinationRouter[method].returns(promise);
+    }
+
+    const account = app.getAccount(destination, { origin, owner });
+
+    expect(destinationRouter.routers.calledOnce).to.be.true;
+    expect(destinationRouter.isms.calledOnce).to.be.true;
+    expect(destinationRouter.bytecodeHash.calledOnce).to.be.true;
+    pending[0].resolve(addressToBytes32(originRouterAddress));
+    pending[1].resolve(addressToBytes32(ismAddress));
+    pending[2].resolve(bytecodeHash);
+    expect(await account).to.equal(expectedAccount());
+  });
+
+  it('uses routing overrides without redundant reads', async () => {
+    const { app, destinationRouter } = createApp();
+
+    expect(
+      await app.getAccount(destination, {
+        origin,
+        owner,
+        localRouter: originRouterAddress,
+        ismOverride: ismAddress,
+      }),
+    ).to.equal(expectedAccount());
+    expect(destinationRouter.routers.called).to.be.false;
+    expect(destinationRouter.isms.called).to.be.false;
+  });
+
+  it('preserves custom salts and bytes32 normalization', async () => {
+    const accountOwner = '0x' + '66'.repeat(32);
+    const router = `0x${'77'.repeat(12)}${'88'.repeat(20)}`;
+    const ism = `0x${'99'.repeat(12)}${'aa'.repeat(20)}`;
+    const salt = '0x' + 'bb'.repeat(32);
+    const { app } = createApp({ router, ism });
+
+    expect(
+      await app.getAccount(destination, {
+        origin,
+        owner: accountOwner,
+        userSalt: salt,
+      }),
+    ).to.equal(expectedAccount({ accountOwner, router, ism, salt }));
+  });
+
+  it('accepts domain zero and rejects missing domain metadata', async () => {
+    const domainZero = createApp({ domain: 0 });
+    expect(
+      await domainZero.app.getAccount(destination, { origin, owner }),
+    ).to.equal(expectedAccount({ domain: 0 }));
+
+    const missingDomain = createApp({ domain: null });
+    let caught: unknown;
+    try {
+      await missingDomain.app.getAccount(destination, { origin, owner });
+    } catch (error: unknown) {
+      caught = error;
+    }
+    expect(caught).to.be.instanceOf(Error);
+  });
+
+  it('falls back only when bytecodeHash is unavailable', async () => {
+    const missingSelector = Object.assign(new Error('missing selector'), {
+      code: 'CALL_EXCEPTION',
+      data: '0x',
+    });
+    const fallback = createApp({ hash: missingSelector });
+
+    expect(
+      await fallback.app.getAccount(destination, { origin, owner }),
+    ).to.equal(expectedAccount());
+    expect(
+      fallback.destinationRouter[
+        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ].calledOnce,
+    ).to.be.true;
+
+    const rpcError = new Error('RPC unavailable');
+    const failed = createApp({ hash: rpcError });
+    let caught: unknown;
+    try {
+      await failed.app.getAccount(destination, { origin, owner });
+    } catch (error: unknown) {
+      caught = error;
+    }
+    expect(caught).to.equal(rpcError);
+  });
+
+  it('still deploys a locally derived account when requested', async () => {
+    const { app, destinationRouter, multiProvider } = createApp();
+    const config = { origin, owner };
+    const account = expectedAccount();
+
+    expect(await app.deployAccount(destination, config)).to.equal(account);
+    expect(
+      destinationRouter.estimateGas[
+        'getDeployedInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ].calledOnce,
+    ).to.be.true;
+    expect(
+      destinationRouter[
+        'getDeployedInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ].calledOnce,
+    ).to.be.true;
+    expect(multiProvider.handleTx.calledOnce).to.be.true;
+    expect(app.knownAccounts[account]).to.deep.equal(config);
+  });
+
+  it('rejects a destination without an ICA router', async () => {
+    const { app } = createApp({ configuredDestination: false });
+    let caught: unknown;
+    try {
+      await app.getAccount(destination, { origin, owner });
+    } catch (error: unknown) {
+      caught = error;
+    }
+    if (!(caught instanceof Error))
+      throw new Error('Expected derivation error');
+    expect(caught.message).to.include(
+      `No interchain account router configured for ${destination}`,
+    );
+  });
+
+  it('rejects a zero origin router', async () => {
+    const { app } = createApp({ router: constants.HashZero });
+    let caught: unknown;
+    try {
+      await app.getAccount(destination, { origin, owner });
+    } catch (error: unknown) {
+      caught = error;
+    }
+    expect(caught).to.be.instanceOf(Error);
   });
 });
 

--- a/typescript/sdk/src/middleware/account/InterchainAccount.ts
+++ b/typescript/sdk/src/middleware/account/InterchainAccount.ts
@@ -8,9 +8,11 @@ import {
   addBufferToGasLimit,
   addressToBytes32,
   arrayToObject,
+  assert,
   bytes32ToAddress,
   eqAddress,
   formatStandardHookMetadata,
+  isNullish,
   isZeroishAddress,
   objFilter,
   objMap,
@@ -28,6 +30,7 @@ import { MultiProvider } from '../../providers/MultiProvider.js';
 import { CallData as SdkCallData } from '../../providers/transactions/types.js';
 import { RouterApp } from '../../router/RouterApps.js';
 import { ChainMap, ChainName } from '../../types.js';
+import { isMissingSelectorCallException } from '../../utils/contract.js';
 import {
   estimateCallGas,
   estimateHandleGasForRecipient,
@@ -103,35 +106,61 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
   ): Promise<Address> {
     const userSalt = config.userSalt ?? InterchainAccount.EMPTY_SALT;
     const originDomain = this.multiProvider.tryGetDomainId(config.origin);
-    if (!originDomain) {
+    if (isNullish(originDomain)) {
       throw new Error(
         `Origin chain (${config.origin}) metadata needed for deploying ICAs ...`,
       );
     }
-    const destinationRouter = this.router(this.contractsMap[destinationChain]);
-    const originRouterAddress = config.localRouter
-      ? bytes32ToAddress(config.localRouter)
-      : bytes32ToAddress(await destinationRouter.routers(originDomain));
+    const destinationContracts = this.contractsMap[destinationChain];
+    assert(
+      destinationContracts?.interchainAccountRouter,
+      `No interchain account router configured for ${destinationChain}`,
+    );
+    const destinationRouter = this.router(destinationContracts);
+
+    const bytecodeHashPromise = destinationRouter
+      .bytecodeHash()
+      .catch((error: unknown) => {
+        if (isMissingSelectorCallException(error)) return null;
+        throw error;
+      });
+    const [rawOriginRouter, rawIsm, bytecodeHash] = await Promise.all([
+      config.localRouter ?? destinationRouter.routers(originDomain),
+      config.ismOverride ?? destinationRouter.isms(originDomain),
+      bytecodeHashPromise,
+    ]);
+    const originRouterAddress = bytes32ToAddress(rawOriginRouter);
     if (isZeroishAddress(originRouterAddress)) {
       throw new Error(
         `Origin router address is zero for ${config.origin} on ${destinationChain}`,
       );
     }
 
-    const destinationIsmAddress = bytes32ToAddress(
-      addressToBytes32(
-        config.ismOverride ?? (await destinationRouter.isms(originDomain)),
-      ),
-    );
-    const destinationAccount = await destinationRouter[
-      'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-    ](
-      originDomain,
-      addressToBytes32(config.owner),
-      addressToBytes32(originRouterAddress),
-      destinationIsmAddress,
-      userSalt,
-    );
+    const destinationIsmAddress = bytes32ToAddress(addressToBytes32(rawIsm));
+    const owner = addressToBytes32(config.owner);
+    const originRouter = addressToBytes32(originRouterAddress);
+    let destinationAccount: Address;
+    if (isNullish(bytecodeHash)) {
+      destinationAccount = await destinationRouter[
+        'getLocalInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
+      ](originDomain, owner, originRouter, destinationIsmAddress, userSalt);
+    } else {
+      const deploySalt = ethers.utils.solidityKeccak256(
+        ['uint32', 'bytes32', 'bytes32', 'bytes32', 'bytes32'],
+        [
+          originDomain,
+          owner,
+          originRouter,
+          ethers.utils.hexZeroPad(destinationIsmAddress, 32),
+          userSalt,
+        ],
+      );
+      destinationAccount = ethers.utils.getCreate2Address(
+        destinationRouter.address,
+        deploySalt,
+        bytecodeHash,
+      );
+    }
 
     // If not deploying anything, return the account address.
     if (!deployIfNotExists) {
@@ -150,13 +179,7 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
       // Estimate gas for deployment
       const gasEstimate = await destinationRouter.estimateGas[
         'getDeployedInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-      ](
-        originDomain,
-        addressToBytes32(config.owner),
-        addressToBytes32(originRouterAddress),
-        destinationIsmAddress,
-        userSalt,
-      );
+      ](originDomain, owner, originRouter, destinationIsmAddress, userSalt);
 
       // Add buffer to gas estimate
       const gasWithBuffer = addBufferToGasLimit(gasEstimate);
@@ -166,17 +189,10 @@ export class InterchainAccount extends RouterApp<InterchainAccountFactories> {
         destinationChain,
         destinationRouter[
           'getDeployedInterchainAccount(uint32,bytes32,bytes32,address,bytes32)'
-        ](
-          originDomain,
-          addressToBytes32(config.owner),
-          addressToBytes32(originRouterAddress),
-          destinationIsmAddress,
-          userSalt,
-          {
-            gasLimit: gasWithBuffer,
-            ...txOverrides,
-          },
-        ),
+        ](originDomain, owner, originRouter, destinationIsmAddress, userSalt, {
+          gasLimit: gasWithBuffer,
+          ...txOverrides,
+        }),
       );
       this.logger.debug(`Interchain account deployed at ${destinationAccount}`);
     } else {


### PR DESCRIPTION
Stacked on #9250. Review the two top commits for this PR's isolated diff.

### What changed

- move optimized ICA derivation into the shared SDK `InterchainAccount` path; CCIP server delegates to it
- fetch the enrolled origin router, ISM, and immutable ICA bytecode hash concurrently with `Promise.all`
- derive modern router ICAs locally with the same salt and CREATE2 formula as the contract
- preserve the existing onchain getter only for legacy routers missing `bytecodeHash()`
- propagate routing and genuine RPC failures without fallback
- preserve SDK normalization for domains, bytes32 owners, routers, ISMs, and user salts
- reject destinations without an ICA router explicitly and preserve valid domain `0`

### Why

The previous path performed three sequential destination RPC rounds: `routers`, `isms`, then `getLocalInterchainAccount`. Modern routers expose the immutable bytecode hash, so the same address can be derived locally after one concurrent read round. Keeping this in the SDK avoids a second ICA derivation implementation in CCIP server. There is no cache or public API change.

### Quantified impact

- reduces the modern path from three sequential RPC rounds to one concurrent round: two fewer critical-path round trips, or a 67% structural reduction
- theoretical speedup is up to 3x when the three RPC calls have similar latency; total RPC call count remains three
- Node 26.6.0 benchmark against the production-pinned registry and `MultiProvider` construction, 10 alternating measured repetitions after warmup:
  - OP -> Base: median 135.6ms -> 48.0ms (-64.6%); p95 1234.9ms -> 125.6ms
  - Base -> OP: median 130.7ms -> 48.6ms (-62.8%); p95 150.8ms -> 53.2ms

Production currently uses the pinned registry's public RPC lists; it has no private RPC secret or override. The benchmark verifies identical derived addresses on every sample. It measures only ICA derivation over that provider path, not production endpoint latency.

### Validation

- 30 focused SDK tests and 54 CCIP server tests on the stacked head
- SDK and CCIP server build and oxlint
- oxfmt and diff check
- live contract-getter equivalence:
  - OP -> Base: `0x3145a145dd8A9bC3d2a046d6aC4A1323E5D86e3E`
  - Base -> OP: `0x3887Ac97c3Ce6F1036a9FAd26313150D3F8E9AE6`
- hardcoded deployed Base golden vector covering the zero-ISM path
- exact-head self-review and independent adversarial rereview: no blockers

### Compatibility

Routers without `bytecodeHash()` take the previous onchain derivation path. The fallback is limited to missing-selector or empty-return errors; other RPC failures still fail closed. Existing `routerOverride` behavior is unchanged and outside the CCIP request path.
