### PR TITLE
fix(infra): hand over deprecated core deployments

### DIFF
--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -31,20 +31,6 @@ import { getIgp } from './igp.js';
 import { DEPLOYER, ethereumChainOwners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
 
-const deprecatedCoreHandoffConfig: ChainMap<{
-  defaultIsm: Address;
-  owner: Address;
-}> = {
-  prom: {
-    defaultIsm: '0xEC340e9e1FA2E646aE9864B43a08Db633596341B',
-    owner: '0x65Bf3DEEbFD82ccDadadF43FB3701aEFE1d8bb00',
-  },
-  vana: {
-    defaultIsm: '0x43539a67cdAbA1a11e6ed3a394f91A47786F35b6',
-    owner: '0xDDF71a6ddf3FCABBbA4D607b57f0f6Fc0265bb84',
-  },
-};
-
 // There are no static ISMs or hooks for zkSync, this means
 // that the default ISM is a routing ISM and the default hook
 // is a fallback routing hook.
@@ -68,18 +54,6 @@ export function getCore(): ChainMap<CoreConfig> {
     if (local === 'tron') {
       return getTronCoreConfig(owner, igp['tron']);
     }
-
-    const handoffConfig = deprecatedCoreHandoffConfig[local];
-    const coreOwner = handoffConfig
-      ? {
-          ...owner,
-          owner: handoffConfig.owner,
-          ownerOverrides: {
-            ...owner.ownerOverrides,
-            proxyAdmin: handoffConfig.owner,
-          },
-        }
-      : owner;
 
     const originMultisigs: ChainMap<MultisigConfig> = Object.fromEntries(
       supportedChainNames
@@ -223,27 +197,25 @@ export function getCore(): ChainMap<CoreConfig> {
         address: addresses.pausableIsm,
       };
       return {
-        defaultIsm:
-          handoffConfig?.defaultIsm ??
-          (isZksyncChain
-            ? defaultIsm
-            : {
-                type: IsmType.AGGREGATION,
-                modules: [routingIsm, recoveredPausableIsm],
-                threshold: 2,
-              }),
+        defaultIsm: isZksyncChain
+          ? defaultIsm
+          : {
+              type: IsmType.AGGREGATION,
+              modules: [routingIsm, recoveredPausableIsm],
+              threshold: 2,
+            },
         defaultHook: addresses.fallbackRoutingHook,
         requiredHook: requiredHookAddress,
         deployQuotedCalls: false,
-        ...coreOwner,
+        ...owner,
       };
     }
 
     return {
-      defaultIsm: handoffConfig?.defaultIsm ?? defaultIsm,
+      defaultIsm,
       defaultHook,
       requiredHook,
-      ...coreOwner,
+      ...owner,
     };
   });
   return coreCache;

--- a/typescript/infra/config/environments/mainnet3/core.ts
+++ b/typescript/infra/config/environments/mainnet3/core.ts
@@ -31,6 +31,20 @@ import { getIgp } from './igp.js';
 import { DEPLOYER, ethereumChainOwners } from './owners.js';
 import { supportedChainNames } from './supportedChainNames.js';
 
+const deprecatedCoreHandoffConfig: ChainMap<{
+  defaultIsm: Address;
+  owner: Address;
+}> = {
+  prom: {
+    defaultIsm: '0xEC340e9e1FA2E646aE9864B43a08Db633596341B',
+    owner: '0x65Bf3DEEbFD82ccDadadF43FB3701aEFE1d8bb00',
+  },
+  vana: {
+    defaultIsm: '0x43539a67cdAbA1a11e6ed3a394f91A47786F35b6',
+    owner: '0xDDF71a6ddf3FCABBbA4D607b57f0f6Fc0265bb84',
+  },
+};
+
 // There are no static ISMs or hooks for zkSync, this means
 // that the default ISM is a routing ISM and the default hook
 // is a fallback routing hook.
@@ -54,6 +68,18 @@ export function getCore(): ChainMap<CoreConfig> {
     if (local === 'tron') {
       return getTronCoreConfig(owner, igp['tron']);
     }
+
+    const handoffConfig = deprecatedCoreHandoffConfig[local];
+    const coreOwner = handoffConfig
+      ? {
+          ...owner,
+          owner: handoffConfig.owner,
+          ownerOverrides: {
+            ...owner.ownerOverrides,
+            proxyAdmin: handoffConfig.owner,
+          },
+        }
+      : owner;
 
     const originMultisigs: ChainMap<MultisigConfig> = Object.fromEntries(
       supportedChainNames
@@ -197,25 +223,27 @@ export function getCore(): ChainMap<CoreConfig> {
         address: addresses.pausableIsm,
       };
       return {
-        defaultIsm: isZksyncChain
-          ? defaultIsm
-          : {
-              type: IsmType.AGGREGATION,
-              modules: [routingIsm, recoveredPausableIsm],
-              threshold: 2,
-            },
+        defaultIsm:
+          handoffConfig?.defaultIsm ??
+          (isZksyncChain
+            ? defaultIsm
+            : {
+                type: IsmType.AGGREGATION,
+                modules: [routingIsm, recoveredPausableIsm],
+                threshold: 2,
+              }),
         defaultHook: addresses.fallbackRoutingHook,
         requiredHook: requiredHookAddress,
         deployQuotedCalls: false,
-        ...owner,
+        ...coreOwner,
       };
     }
 
     return {
-      defaultIsm,
+      defaultIsm: handoffConfig?.defaultIsm ?? defaultIsm,
       defaultHook,
       requiredHook,
-      ...owner,
+      ...coreOwner,
     };
   });
   return coreCache;

--- a/typescript/infra/scripts/core/handoff-deprecated-core.ts
+++ b/typescript/infra/scripts/core/handoff-deprecated-core.ts
@@ -1,0 +1,306 @@
+import { BigNumber, Contract, ethers } from 'ethers';
+import yargs from 'yargs';
+
+import { ChainMap, InterchainAccount } from '@hyperlane-xyz/sdk';
+import {
+  Address,
+  CallData,
+  assert,
+  eqAddress,
+  formatStandardHookMetadata,
+  objFilter,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+
+import { Contexts } from '../../config/contexts.js';
+import { getGovernanceSafes } from '../../config/environments/mainnet3/governance/utils.js';
+import { DEPLOYER } from '../../config/environments/mainnet3/owners.js';
+import { getEnvironmentConfig, getHyperlaneCore } from '../core-utils.js';
+import { GovernanceType } from '../../src/governanceTypes.js';
+import { SafeMultiSend, SignerMultiSend } from '../../src/govern/multisend.js';
+import { Role } from '../../src/roles.js';
+
+const originChain = 'ethereum';
+const handoffChains = ['vana', 'prom'] as const;
+type HandoffChain = (typeof handoffChains)[number];
+
+const ownableContractNames = [
+  'domainRoutingIsm',
+  'fallbackRoutingHook',
+  'interchainAccountRouter',
+  'interchainGasPaymaster',
+  'mailbox',
+  'merkleTreeHook',
+  'pausableHook',
+  'pausableIsm',
+  'protocolFee',
+  'proxyAdmin',
+  'storageGasOracle',
+  'testRecipient',
+  'validatorAnnounce',
+] as const;
+type OwnableContractName = (typeof ownableContractNames)[number];
+
+const beneficiaryContractNames = new Set<OwnableContractName>([
+  'interchainGasPaymaster',
+  'protocolFee',
+]);
+
+const handoffs: Record<
+  HandoffChain,
+  { target: Address; targetType: 'eoa' | 'safe' }
+> = {
+  prom: {
+    target: '0x65Bf3DEEbFD82ccDadadF43FB3701aEFE1d8bb00',
+    targetType: 'eoa',
+  },
+  vana: {
+    target: '0xDDF71a6ddf3FCABBbA4D607b57f0f6Fc0265bb84',
+    targetType: 'safe',
+  },
+};
+
+const ownableInterface = new ethers.utils.Interface([
+  'function owner() view returns (address)',
+  'function transferOwnership(address newOwner)',
+]);
+const beneficiaryInterface = new ethers.utils.Interface([
+  'function beneficiary() view returns (address)',
+  'function setBeneficiary(address beneficiary)',
+]);
+const safeInterface = new ethers.utils.Interface([
+  'function VERSION() view returns (string)',
+]);
+
+type PlannedCall = {
+  call: CallData;
+  description: string;
+};
+
+function encodeCall(
+  to: Address,
+  iface: ethers.utils.Interface,
+  functionName: string,
+  values: unknown[],
+): CallData {
+  return {
+    to,
+    data: iface.encodeFunctionData(functionName, values),
+    value: BigNumber.from(0),
+  };
+}
+
+async function assertTargetType(
+  provider: ethers.providers.Provider,
+  chain: HandoffChain,
+  target: Address,
+  targetType: 'eoa' | 'safe',
+): Promise<void> {
+  const code = await provider.getCode(target);
+  if (targetType === 'eoa') {
+    assert(code === '0x', `[${chain}] target ${target} is not an EOA`);
+    return;
+  }
+
+  assert(code !== '0x', `[${chain}] target ${target} has no contract code`);
+  const safe = new Contract(target, safeInterface, provider);
+  const version: string = await safe.VERSION();
+  rootLogger.info(`[${chain}] target ${target} is Safe ${version}`);
+}
+
+async function main(): Promise<void> {
+  const { proposeSafe, submitDeployer } = await yargs(process.argv.slice(2))
+    .option('submit-deployer', {
+      type: 'boolean',
+      default: false,
+      description: 'Submit calls for contracts currently owned by the deployer',
+    })
+    .option('propose-safe', {
+      type: 'boolean',
+      default: false,
+      description:
+        'Propose one Ethereum Safe MultiSend for ICA-owned contracts',
+    })
+    .strict()
+    .parse();
+
+  const environment = 'mainnet3';
+  const environmentConfig = getEnvironmentConfig(environment);
+  const multiProvider = await environmentConfig.getMultiProvider(
+    Contexts.Hyperlane,
+    Role.Deployer,
+    true,
+    [originChain, ...handoffChains],
+  );
+  const { chainAddresses } = await getHyperlaneCore(environment, multiProvider);
+  const icaChainAddresses = objFilter(
+    chainAddresses,
+    (chain, _): _ is Record<string, string> =>
+      !!chainAddresses[chain]?.interchainAccountRouter,
+  );
+  const ica = InterchainAccount.fromAddressesMap(
+    icaChainAddresses,
+    multiProvider,
+  );
+
+  const safeOwner = getGovernanceSafes(GovernanceType.Regular)[originChain];
+  assert(safeOwner, 'Missing regular Ethereum governance Safe');
+  const accountConfig = { origin: originChain, owner: safeOwner };
+
+  const deployerCalls: ChainMap<PlannedCall[]> = {};
+  const icaCalls: ChainMap<PlannedCall[]> = {};
+
+  for (const chain of handoffChains) {
+    const provider = multiProvider.getProvider(chain);
+    const { target, targetType } = handoffs[chain];
+    await assertTargetType(provider, chain, target, targetType);
+    assert(
+      (await provider.getCode(DEPLOYER)) === '0x',
+      `[${chain}] deployer ${DEPLOYER} is not a plain EOA`,
+    );
+
+    const expectedIca = await ica.getAccount(chain, accountConfig);
+    const addresses = chainAddresses[chain];
+    assert(addresses, `[${chain}] missing registry addresses`);
+
+    for (const name of ownableContractNames) {
+      const address = addresses[name];
+      assert(address, `[${chain}] missing ${name} address`);
+
+      const contract = new Contract(address, ownableInterface, provider);
+      const currentOwner: Address = await contract.owner();
+      if (eqAddress(currentOwner, target)) {
+        if (beneficiaryContractNames.has(name)) {
+          const beneficiaryContract = new Contract(
+            address,
+            beneficiaryInterface,
+            provider,
+          );
+          const beneficiary: Address = await beneficiaryContract.beneficiary();
+          assert(
+            eqAddress(beneficiary, target),
+            `[${chain}] ${name} is already target-owned but beneficiary is ${beneficiary}`,
+          );
+        }
+        continue;
+      }
+
+      const calls = eqAddress(currentOwner, DEPLOYER)
+        ? (deployerCalls[chain] ??= [])
+        : eqAddress(currentOwner, expectedIca)
+          ? (icaCalls[chain] ??= [])
+          : undefined;
+      assert(
+        calls,
+        `[${chain}] ${name} has unexpected owner ${currentOwner}; expected deployer ${DEPLOYER}, ICA ${expectedIca}, or target ${target}`,
+      );
+
+      if (beneficiaryContractNames.has(name)) {
+        const beneficiaryContract = new Contract(
+          address,
+          beneficiaryInterface,
+          provider,
+        );
+        const beneficiary: Address = await beneficiaryContract.beneficiary();
+        if (!eqAddress(beneficiary, target)) {
+          calls.push({
+            call: encodeCall(address, beneficiaryInterface, 'setBeneficiary', [
+              target,
+            ]),
+            description: `[${chain}] set ${name} beneficiary to ${target}`,
+          });
+        }
+      }
+
+      calls.push({
+        call: encodeCall(address, ownableInterface, 'transferOwnership', [
+          target,
+        ]),
+        description: `[${chain}] transfer ${name} ownership to ${target}`,
+      });
+    }
+  }
+
+  for (const chain of handoffChains) {
+    const direct = deployerCalls[chain] ?? [];
+    const remote = icaCalls[chain] ?? [];
+    rootLogger.info(
+      `[${chain}] planned ${direct.length} deployer calls and ${remote.length} ICA calls`,
+    );
+    for (const { description } of [...direct, ...remote]) {
+      rootLogger.info(`- ${description}`);
+    }
+  }
+
+  if (!submitDeployer && !proposeSafe) {
+    rootLogger.info(
+      'Dry run only; pass --submit-deployer and/or --propose-safe',
+    );
+    return;
+  }
+
+  if (submitDeployer) {
+    for (const chain of handoffChains) {
+      const calls = deployerCalls[chain] ?? [];
+      if (calls.length === 0) continue;
+      rootLogger.info(`[${chain}] submitting ${calls.length} deployer calls`);
+      await new SignerMultiSend(multiProvider, chain).sendTransactions(
+        calls.map(({ call }) => call),
+      );
+    }
+  }
+
+  if (proposeSafe) {
+    const remoteCalls: CallData[] = [];
+    for (const chain of handoffChains) {
+      const plannedCalls = icaCalls[chain] ?? [];
+      if (plannedCalls.length === 0) continue;
+      const innerCalls = plannedCalls.map(({ call }) => ({
+        to: call.to,
+        data: call.data,
+        value: call.value?.toString() ?? '0',
+      }));
+      const gasLimit = await ica.estimateIcaHandleGas({
+        origin: originChain,
+        destination: chain,
+        innerCalls,
+        config: accountConfig,
+      });
+      const hookMetadata = formatStandardHookMetadata({
+        gasLimit: gasLimit.toBigInt(),
+        refundAddress: safeOwner,
+      });
+      const callRemote = await ica.getCallRemote({
+        chain: originChain,
+        destination: chain,
+        innerCalls,
+        config: accountConfig,
+        hookMetadata,
+      });
+      assert(
+        callRemote.to && callRemote.data,
+        `[${chain}] failed to build ICA call`,
+      );
+      remoteCalls.push({
+        to: callRemote.to,
+        data: callRemote.data,
+        value: callRemote.value ?? BigNumber.from(0),
+      });
+    }
+
+    if (remoteCalls.length > 0) {
+      const safeMultiSend = await SafeMultiSend.initialize(
+        multiProvider,
+        originChain,
+        safeOwner,
+      );
+      const hashes = await safeMultiSend.sendTransactions(remoteCalls);
+      rootLogger.info(`Proposed Safe transaction(s): ${hashes.join(', ')}`);
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  rootLogger.error(error);
+  process.exit(1);
+});

--- a/typescript/infra/scripts/core/handoff-deprecated-core.ts
+++ b/typescript/infra/scripts/core/handoff-deprecated-core.ts
@@ -309,7 +309,8 @@ async function main(): Promise<void> {
       remoteCalls.push({
         to: callRemote.to,
         data: callRemote.data,
-        value: callRemote.value ?? BigNumber.from(0),
+        // Overpayment is refunded to safeOwner from the hook metadata.
+        value: BigNumber.from(callRemote.value ?? 0).mul(2),
       });
     }
 

--- a/typescript/infra/scripts/core/handoff-deprecated-core.ts
+++ b/typescript/infra/scripts/core/handoff-deprecated-core.ts
@@ -15,13 +15,19 @@ import {
 import { Contexts } from '../../config/contexts.js';
 import { getGovernanceSafes } from '../../config/environments/mainnet3/governance/utils.js';
 import { DEPLOYER } from '../../config/environments/mainnet3/owners.js';
-import { getEnvironmentConfig, getHyperlaneCore } from '../core-utils.js';
+import { getEnvironmentConfig } from '../core-utils.js';
 import { GovernanceType } from '../../src/governanceTypes.js';
 import { SafeMultiSend, SignerMultiSend } from '../../src/govern/multisend.js';
 import { Role } from '../../src/roles.js';
 
 const originChain = 'ethereum';
-const handoffChains = ['vana', 'prom'] as const;
+const handoffChains = [
+  // 'appchain', // Enable after Appchain is removed from AW infrastructure.
+  'lumiaprism',
+  'matchain',
+  'prom',
+  'vana',
+] as const;
 type HandoffChain = (typeof handoffChains)[number];
 
 const ownableContractNames = [
@@ -50,6 +56,18 @@ const handoffs: Record<
   HandoffChain,
   { target: Address; targetType: 'eoa' | 'safe' }
 > = {
+  // appchain: {
+  //   target: '0x2D3Ff22F91E5f796EeE6e864AD71385B249c34A5',
+  //   targetType: 'safe',
+  // },
+  lumiaprism: {
+    target: '0x5FE65789a7Eb447916576aF52AefF190748c08Eb',
+    targetType: 'safe',
+  },
+  matchain: {
+    target: '0x485f48CdCc2F27ACE7B4BE6398ef1dD5002b65F5',
+    targetType: 'safe',
+  },
   prom: {
     target: '0x65Bf3DEEbFD82ccDadadF43FB3701aEFE1d8bb00',
     targetType: 'eoa',
@@ -132,7 +150,14 @@ async function main(): Promise<void> {
     true,
     [originChain, ...handoffChains],
   );
-  const { chainAddresses } = await getHyperlaneCore(environment, multiProvider);
+  const registry = await environmentConfig.getRegistry(true, [
+    originChain,
+    ...handoffChains,
+  ]);
+  const chainAddresses = objFilter(
+    await registry.getAddresses(),
+    (chain, _): _ is Record<string, string> => multiProvider.hasChain(chain),
+  );
   const icaChainAddresses = objFilter(
     chainAddresses,
     (chain, _): _ is Record<string, string> =>

--- a/typescript/infra/scripts/core/handoff-deprecated-core.ts
+++ b/typescript/infra/scripts/core/handoff-deprecated-core.ts
@@ -22,7 +22,7 @@ import { Role } from '../../src/roles.js';
 
 const originChain = 'ethereum';
 const handoffChains = [
-  // 'appchain', // Enable after Appchain is removed from AW infrastructure.
+  'appchain',
   'lumiaprism',
   'matchain',
   'prom',
@@ -56,10 +56,10 @@ const handoffs: Record<
   HandoffChain,
   { target: Address; targetType: 'eoa' | 'safe' }
 > = {
-  // appchain: {
-  //   target: '0x2D3Ff22F91E5f796EeE6e864AD71385B249c34A5',
-  //   targetType: 'safe',
-  // },
+  appchain: {
+    target: '0x2D3Ff22F91E5f796EeE6e864AD71385B249c34A5',
+    targetType: 'safe',
+  },
   lumiaprism: {
     target: '0x5FE65789a7Eb447916576aF52AefF190748c08Eb',
     targetType: 'safe',

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
@@ -7,7 +7,11 @@ import {
   InterchainAccount,
   TestChainName,
 } from '@hyperlane-xyz/sdk';
-import { Address, formatStandardHookMetadata } from '@hyperlane-xyz/utils';
+import {
+  Address,
+  formatStandardHookMetadata,
+  parseStandardHookMetadata,
+} from '@hyperlane-xyz/utils';
 
 import { HyperlaneHaasGovernor } from './HyperlaneHaasGovernor.js';
 import { HyperlaneICAChecker } from './HyperlaneICAChecker.js';
@@ -27,6 +31,7 @@ describe('HyperlaneHaasGovernor', () => {
 
       // Create mock InterchainAccount
       mockIca = {
+        estimateIcaHandleGas: sandbox.stub().resolves(BigNumber.from(150_000)),
         getCallRemote: sandbox.stub(),
       } as any;
 
@@ -266,6 +271,73 @@ describe('HyperlaneHaasGovernor', () => {
         data: call3.data,
         value: '300',
       });
+    });
+
+    it('should combine calls with different gas limits and re-estimate the batch', async () => {
+      const refundAddress =
+        '0x1111111111111111111111111111111111111111' as Address;
+      const callRemoteArgs = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test2,
+        config: {
+          origin: TestChainName.test1,
+          owner: refundAddress,
+        },
+        innerCalls: [],
+        hookMetadata: formatStandardHookMetadata({
+          gasLimit: 100_000n,
+          refundAddress,
+        }),
+      };
+      const calls: AnnotatedCallData[] = [
+        {
+          to: '0x2222222222222222222222222222222222222222' as Address,
+          data: '0x1111',
+          value: BigNumber.from(0),
+          description: 'First ICA call',
+          callRemoteArgs,
+        },
+        {
+          to: '0x3333333333333333333333333333333333333333' as Address,
+          data: '0x2222',
+          value: BigNumber.from(0),
+          description: 'Second ICA call',
+          callRemoteArgs: {
+            ...callRemoteArgs,
+            hookMetadata: formatStandardHookMetadata({
+              gasLimit: 200_000n,
+              refundAddress,
+            }),
+          },
+        },
+      ];
+      (governor as any).calls = { [TestChainName.test1]: calls };
+      mockGetCallRemote.resolves({
+        to: '0x9999999999999999999999999999999999999999',
+        data: '0xcombined',
+        value: BigNumber.from(100),
+      });
+
+      await governor.batchIcaCalls();
+
+      expect((governor as any).calls[TestChainName.test1]).to.have.length(1);
+      const estimateIcaHandleGas =
+        mockIca.estimateIcaHandleGas as sinon.SinonStub;
+      expect(estimateIcaHandleGas.calledOnce).to.be.true;
+      expect(estimateIcaHandleGas.firstCall.args[0]).to.deep.equal({
+        origin: TestChainName.test1,
+        destination: TestChainName.test2,
+        innerCalls: [
+          { to: calls[0].to, data: calls[0].data, value: '0' },
+          { to: calls[1].to, data: calls[1].data, value: '0' },
+        ],
+        config: callRemoteArgs.config,
+      });
+      const combinedMetadata = parseStandardHookMetadata(
+        mockGetCallRemote.firstCall.args[0].hookMetadata,
+      );
+      expect(combinedMetadata?.gasLimit).to.equal(150_000n);
+      expect(combinedMetadata?.refundAddress).to.equal(refundAddress);
     });
 
     it('should apply 2x buffer when hookMetadata includes refund address', async () => {

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.test.ts
@@ -340,6 +340,66 @@ describe('HyperlaneHaasGovernor', () => {
       expect(combinedMetadata?.refundAddress).to.equal(refundAddress);
     });
 
+    it('should preserve msgValue and batch equivalent metadata representations', async () => {
+      const refundAddress =
+        '0x1111111111111111111111111111111111111111' as Address;
+      const baseCallRemoteArgs = {
+        chain: TestChainName.test1,
+        destination: TestChainName.test2,
+        config: {
+          origin: TestChainName.test1,
+          owner: refundAddress,
+        },
+        innerCalls: [],
+      };
+      const calls: AnnotatedCallData[] = [
+        {
+          to: '0x2222222222222222222222222222222222222222' as Address,
+          data: '0x1111',
+          value: BigNumber.from(0),
+          description: 'Object metadata ICA call',
+          callRemoteArgs: {
+            ...baseCallRemoteArgs,
+            hookMetadata: {
+              msgValue: '123',
+              gasLimit: '100000',
+              refundAddress,
+            },
+          },
+        },
+        {
+          to: '0x3333333333333333333333333333333333333333' as Address,
+          data: '0x2222',
+          value: BigNumber.from(0),
+          description: 'Encoded metadata ICA call',
+          callRemoteArgs: {
+            ...baseCallRemoteArgs,
+            hookMetadata: formatStandardHookMetadata({
+              msgValue: 123n,
+              gasLimit: 200_000n,
+              refundAddress,
+            }),
+          },
+        },
+      ];
+      (governor as any).calls = { [TestChainName.test1]: calls };
+      mockGetCallRemote.resolves({
+        to: '0x9999999999999999999999999999999999999999',
+        data: '0xcombined',
+        value: BigNumber.from(100),
+      });
+
+      await governor.batchIcaCalls();
+
+      expect(mockGetCallRemote.calledOnce).to.be.true;
+      const combinedMetadata = parseStandardHookMetadata(
+        mockGetCallRemote.firstCall.args[0].hookMetadata,
+      );
+      expect(combinedMetadata?.msgValue).to.equal(123n);
+      expect(combinedMetadata?.gasLimit).to.equal(150_000n);
+      expect(combinedMetadata?.refundAddress).to.equal(refundAddress);
+    });
+
     it('should apply 2x buffer when hookMetadata includes refund address', async () => {
       const callRemoteArgs = {
         chain: TestChainName.test1,

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -194,15 +194,19 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
           typeof hookMetadata === 'string'
             ? parseStandardHookMetadata(hookMetadata)
             : undefined;
+        const hookMetadataObject =
+          typeof hookMetadata === 'object' ? hookMetadata : undefined;
         const hookMetadataIdentity = parsedHookMetadata
           ? {
               msgValue: parsedHookMetadata.msgValue.toString(),
               refundAddress: parsedHookMetadata.refundAddress,
             }
-          : typeof hookMetadata === 'object'
+          : hookMetadataObject
             ? {
-                msgValue: hookMetadata.msgValue,
-                refundAddress: hookMetadata.refundAddress,
+                msgValue: BigNumber.from(
+                  hookMetadataObject.msgValue ?? 0,
+                ).toString(),
+                refundAddress: hookMetadataObject.refundAddress,
               }
             : hookMetadata;
 
@@ -273,7 +277,11 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
             ...combinedCallRemoteArgs,
             hookMetadata: formatStandardHookMetadata({
               gasLimit: gasLimit.toBigInt(),
-              msgValue: parsedBaseHookMetadata?.msgValue,
+              msgValue:
+                parsedBaseHookMetadata?.msgValue ??
+                (baseHookMetadataObject?.msgValue !== undefined
+                  ? BigInt(baseHookMetadataObject.msgValue)
+                  : undefined),
               refundAddress:
                 parsedBaseHookMetadata?.refundAddress ??
                 baseHookMetadataObject?.refundAddress,

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -11,9 +11,11 @@ import {
   ViolationType,
 } from '@hyperlane-xyz/sdk';
 import {
+  formatStandardHookMetadata,
   hasValidRefundAddress,
   isEVMLike,
   isZeroishAddress,
+  parseStandardHookMetadata,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
@@ -187,12 +189,29 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
       for (const call of calls) {
         if (!call.callRemoteArgs) continue;
 
-        // Create a key based on all callRemoteArgs properties except innerCalls
+        const hookMetadata = call.callRemoteArgs.hookMetadata;
+        const parsedHookMetadata =
+          typeof hookMetadata === 'string'
+            ? parseStandardHookMetadata(hookMetadata)
+            : undefined;
+        const hookMetadataIdentity = parsedHookMetadata
+          ? {
+              msgValue: parsedHookMetadata.msgValue.toString(),
+              refundAddress: parsedHookMetadata.refundAddress,
+            }
+          : typeof hookMetadata === 'object'
+            ? {
+                msgValue: hookMetadata.msgValue,
+                refundAddress: hookMetadata.refundAddress,
+              }
+            : hookMetadata;
+
+        // Gas limits differ per inner call and must be recomputed for the batch.
         const key = [
           call.callRemoteArgs.chain,
           call.callRemoteArgs.destination,
           JSON.stringify(call.callRemoteArgs.config),
-          JSON.stringify(call.callRemoteArgs.hookMetadata),
+          JSON.stringify(hookMetadataIdentity),
         ].join('|');
 
         if (!callGroups.has(key)) {
@@ -231,11 +250,36 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
           return call.callRemoteArgs.innerCalls;
         });
 
-        // Create the combined callRemoteArgs
-        const combinedCallRemoteArgs = {
+        let combinedCallRemoteArgs = {
           ...baseCallRemoteArgs,
           innerCalls: combinedInnerCalls,
         };
+
+        const baseHookMetadata = baseCallRemoteArgs.hookMetadata;
+        const parsedBaseHookMetadata =
+          typeof baseHookMetadata === 'string'
+            ? parseStandardHookMetadata(baseHookMetadata)
+            : undefined;
+        const baseHookMetadataObject =
+          typeof baseHookMetadata === 'object' ? baseHookMetadata : undefined;
+        if (parsedBaseHookMetadata || baseHookMetadataObject) {
+          const gasLimit = await this.interchainAccount.estimateIcaHandleGas({
+            origin: combinedCallRemoteArgs.chain,
+            destination: combinedCallRemoteArgs.destination,
+            innerCalls: combinedInnerCalls,
+            config: combinedCallRemoteArgs.config,
+          });
+          combinedCallRemoteArgs = {
+            ...combinedCallRemoteArgs,
+            hookMetadata: formatStandardHookMetadata({
+              gasLimit: gasLimit.toBigInt(),
+              msgValue: parsedBaseHookMetadata?.msgValue,
+              refundAddress:
+                parsedBaseHookMetadata?.refundAddress ??
+                baseHookMetadataObject?.refundAddress,
+            }),
+          };
+        }
 
         // Get the callRemote transaction
         const callRemote = await this.interchainAccount.getCallRemote(

--- a/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
+++ b/typescript/infra/src/govern/HyperlaneHaasGovernor.ts
@@ -190,25 +190,16 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
         if (!call.callRemoteArgs) continue;
 
         const hookMetadata = call.callRemoteArgs.hookMetadata;
-        const parsedHookMetadata =
+        const normalizedHookMetadata =
           typeof hookMetadata === 'string'
             ? parseStandardHookMetadata(hookMetadata)
-            : undefined;
-        const hookMetadataObject =
-          typeof hookMetadata === 'object' ? hookMetadata : undefined;
-        const hookMetadataIdentity = parsedHookMetadata
-          ? {
-              msgValue: parsedHookMetadata.msgValue.toString(),
-              refundAddress: parsedHookMetadata.refundAddress,
-            }
-          : hookMetadataObject
-            ? {
-                msgValue: BigNumber.from(
-                  hookMetadataObject.msgValue ?? 0,
-                ).toString(),
-                refundAddress: hookMetadataObject.refundAddress,
-              }
             : hookMetadata;
+        const hookMetadataIdentity = normalizedHookMetadata
+          ? {
+              msgValue: BigInt(normalizedHookMetadata.msgValue ?? 0).toString(),
+              refundAddress: normalizedHookMetadata.refundAddress,
+            }
+          : hookMetadata;
 
         // Gas limits differ per inner call and must be recomputed for the batch.
         const key = [
@@ -260,13 +251,11 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
         };
 
         const baseHookMetadata = baseCallRemoteArgs.hookMetadata;
-        const parsedBaseHookMetadata =
+        const normalizedBaseHookMetadata =
           typeof baseHookMetadata === 'string'
             ? parseStandardHookMetadata(baseHookMetadata)
-            : undefined;
-        const baseHookMetadataObject =
-          typeof baseHookMetadata === 'object' ? baseHookMetadata : undefined;
-        if (parsedBaseHookMetadata || baseHookMetadataObject) {
+            : baseHookMetadata;
+        if (normalizedBaseHookMetadata) {
           const gasLimit = await this.interchainAccount.estimateIcaHandleGas({
             origin: combinedCallRemoteArgs.chain,
             destination: combinedCallRemoteArgs.destination,
@@ -277,14 +266,8 @@ export class HyperlaneHaasGovernor extends HyperlaneAppGovernor<
             ...combinedCallRemoteArgs,
             hookMetadata: formatStandardHookMetadata({
               gasLimit: gasLimit.toBigInt(),
-              msgValue:
-                parsedBaseHookMetadata?.msgValue ??
-                (baseHookMetadataObject?.msgValue !== undefined
-                  ? BigInt(baseHookMetadataObject.msgValue)
-                  : undefined),
-              refundAddress:
-                parsedBaseHookMetadata?.refundAddress ??
-                baseHookMetadataObject?.refundAddress,
+              msgValue: BigInt(normalizedBaseHookMetadata.msgValue ?? 0),
+              refundAddress: normalizedBaseHookMetadata.refundAddress,
             }),
           };
         }


### PR DESCRIPTION
## Summary

- added an idempotent handoff script covering every Ownable artifact in five deprecated core deployments
- enabled Appchain after stacking this PR on [Appchain infrastructure removal #9455](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9455)
- transferred deployer-owned contracts directly and updated IGP/ProtocolFee beneficiaries
- batched each chain's ICA-owned contracts into one destination ICA call, then combined destination calls into one Ethereum Safe MultiSend
- fixed generic HaaS batching so per-call gas metadata does not prevent ICA aggregation
- scoped registry addresses explicitly so the script continues to work after deprecated chains leave `supportedChainNames`

## Linear handoff tickets

- [Appchain — ENG-4411](https://linear.app/hyperlane-xyz/issue/ENG-4411/transfer-core-contracts) — target `0x2D3Ff22F91E5f796EeE6e864AD71385B249c34A5`
- [Lumiaprism — ENG-4409](https://linear.app/hyperlane-xyz/issue/ENG-4409/transfer-core-contracts) — target `0x5FE65789a7Eb447916576aF52AefF190748c08Eb`
- [Matchain — ENG-4413](https://linear.app/hyperlane-xyz/issue/ENG-4413/transfer-core-contracts) — target `0x485f48CdCc2F27ACE7B4BE6398ef1dD5002b65F5`
- [Prom — ENG-4410](https://linear.app/hyperlane-xyz/issue/ENG-4410/transfer-core-contracts) — target `0x65Bf3DEEbFD82ccDadadF43FB3701aEFE1d8bb00`
- [Vana — ENG-4412](https://linear.app/hyperlane-xyz/issue/ENG-4412/transfer-core-contracts) — target `0xDDF71a6ddf3FCABBbA4D607b57f0f6Fc0265bb84`

## Scope

Each chain covers 13 Ownable contracts: domain routing ISM, fallback routing hook, ICA router, IGP, Mailbox, Merkle tree hook, pausable hook, pausable ISM, ProtocolFee, ProxyAdmin, storage gas oracle, test recipient, and ValidatorAnnounce.

The script validates current ownership before acting, accepts only the deployer, the expected regular ICA, or the final target, verifies Safe/EOA target types, and is safe to rerun after completed deployer transfers.

This is an execution-only branch and is not intended to merge into `main`.

## Execution

- all 60 direct calls are confirmed: 36 for Appchain/Lumiaprism/Matchain in this run, plus the previously executed 24 for Prom/Vana
- post-submit readback shows zero remaining deployer calls on all five chains
- proposed Ethereum Safe nonce 46: `0xc7b1839b401150189fb2c4e72a9d145bc6a69548c8138be14843b589df549e9d`
- Safe proposal contains five ICA dispatches, each with three ownership transfers: ICA router, Mailbox, and ProxyAdmin
- Safe service readback: pending, one of six confirmations
- the earlier Vana/Prom-only proposal `0xc30da37b165f37ef0f9324ce56c216b28f02cb675332d0e0c23c423cddb6d316` is no longer present in Safe service

[Open the Safe transaction](https://app.safe.global/transactions/tx?safe=eth:0x562Dfaac27A84be6C96273F5c9594DA1681C0DA7&id=multisig_0x562Dfaac27A84be6C96273F5c9594DA1681C0DA7_0xc7b1839b401150189fb2c4e72a9d145bc6a69548c8138be14843b589df549e9d)

## Current readback

- Appchain: 0 deployer calls and 3 pending ICA calls
- Lumiaprism: 0 deployer calls and 3 pending ICA calls
- Matchain: 0 deployer calls and 3 pending ICA calls
- Prom: 0 deployer calls and 3 pending ICA calls
- Vana: 0 deployer calls and 3 pending ICA calls

## Validation

- `pnpm turbo build --filter @hyperlane-xyz/infra` — 22 tasks passed
- focused HaaS governor tests — 12 passing
- Safe service decode — five CALLs to the Ethereum ICA router with the expected destinations, target owners, and three ownership transfers per destination
- post-submit no-submit readback — all direct owners and beneficiaries transferred; only ICA-owned contracts remain pending
- `git diff --check` — passed
