### PR TITLE
feat(infra): enable keyfunder sweeps to AW signer

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -53,7 +53,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
-  keyFunder: '5af351e-20260728-162402',
+  keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
   feeQuoting: '12d899d-20260325-184337',

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -114,8 +114,8 @@ export const keyFunderConfig: KeyFunderConfig<
     sonicsvm: '0',
   },
   // Low urgency key funder balance thresholds for sweep calculations
-  // Automatic sweep enabled by default for all chains with these thresholds
-  // Defaults: sweep to 0x478be6076f31E9666123B9721D0B6631baD944AF when balance > 2x threshold, leave 1.5x threshold
+  // Automatic sweep enabled for the expected chain allowlist
+  // Defaults: sweep to 0x5b73A98165778BCCE72979B4EE3faCdb31728b8E when balance > 2x threshold, leave 1.5x threshold
   lowUrgencyKeyFunderBalances: lowUrgencyKeyFunderBalancePerChain,
   // Per-chain overrides for sweep (optional)
   sweepOverrides: {},

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -14,7 +14,7 @@ import { DockerConfig } from './agent/agent.js';
  * Can be overridden per-chain via sweepOverrides config.
  */
 export const DEFAULT_SWEEP_ADDRESS =
-  '0x478be6076f31E9666123B9721D0B6631baD944AF';
+  '0x5b73A98165778BCCE72979B4EE3faCdb31728b8E';
 
 export interface ContextAndRoles {
   context: Contexts;
@@ -43,7 +43,7 @@ export interface KeyFunderConfig<
   igpClaimThresholdPerChain: ChainMap<string>;
   chainsToSkip: ChainName[];
   // Per-chain overrides for automatic sweep of excess funds to Safes
-  // Defaults: sweep to 0x478be6076f31E9666123B9721D0B6631baD944AF when balance > 2x threshold, leave behind 1.5x threshold
+  // Defaults: sweep to 0x5b73A98165778BCCE72979B4EE3faCdb31728b8E when balance > 2x threshold, leave behind 1.5x threshold
   sweepOverrides?: ChainMap<SweepOverrideConfig>;
   // Low urgency key funder balance thresholds for sweep calculations
   lowUrgencyKeyFunderBalances?: ChainMap<string>;

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -9,7 +9,7 @@ import { DockerConfig } from './agent/agent.js';
 
 /**
  * Default address for sweeping excess funds from the keyfunder wallet.
- * This is a Hyperlane-controlled Safe address used to collect surplus funds
+ * This is an Abacus Works signer EOA used to collect surplus funds
  * when the keyfunder wallet balance exceeds the configured threshold.
  * Can be overridden per-chain via sweepOverrides config.
  */
@@ -42,7 +42,7 @@ export interface KeyFunderConfig<
   desiredStableswapInventoryRebalancerBalancePerChain?: ChainMap<string>;
   igpClaimThresholdPerChain: ChainMap<string>;
   chainsToSkip: ChainName[];
-  // Per-chain overrides for automatic sweep of excess funds to Safes
+  // Per-chain overrides for automatic sweep of excess funds
   // Defaults: sweep to 0x5b73A98165778BCCE72979B4EE3faCdb31728b8E when balance > 2x threshold, leave behind 1.5x threshold
   sweepOverrides?: ChainMap<SweepOverrideConfig>;
   // Low urgency key funder balance thresholds for sweep calculations

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -176,8 +176,7 @@ export class KeyFunderHelmManager extends HelmManager {
 
         const override = this.config.sweepOverrides?.[chain];
         chainConfig.sweep = {
-          // Temporarily disabled; re-enable once sweep destination is confirmed.
-          enabled: false,
+          enabled: true,
           address: override?.sweepAddress ?? DEFAULT_SWEEP_ADDRESS,
           threshold: sweepThreshold,
           targetMultiplier: override?.targetMultiplier ?? 1.5,


### PR DESCRIPTION
## Summary

- re-enable keyfunder sweeping now that the destination is confirmed
- send default sweeps to the familiar Abacus Works signer EOA `0x5b73A98165778BCCE72979B4EE3faCdb31728b8E`
- preserve the existing 18-chain sweep allowlist so long-tail chains remain unswept
- pin mainnet3 keyfunder to the deployed `b0c3c5d-20260804-175736` image, which includes the native-token decimals fix

## Impact

The mainnet3 keyfunder will sweep excess balances above the existing trigger thresholds to the AW signer EOA, while retaining the existing per-chain target balances and restricted chain scope. The checked-in image now matches the live Helm revision 249 deployment.

The destination was classified with `eth_getCode` across all 18 sweep chains: every chain returned `0x`, confirming a plain EOA with no EIP-7702 delegation. It is also the current AW governance signer 5 in the 3-of-7 signer set.

## Validation

- `pnpm -C typescript/infra check`
- rendered and schema-validated the generated mainnet3 keyfunder YAML
- confirmed exactly the existing 18 allowlisted chains have `sweep.enabled: true` and the new destination
- confirmed the destination is a plain EOA across all 18 sweep chains
- deployed and read back Helm revision 249 with image `b0c3c5d-20260804-175736`
- pre-commit gitleaks, oxlint, and oxfmt checks