### PR TITLE
fix(infra): disable keyfunder sweeps

### DIFF
--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -113,8 +113,10 @@ export const keyFunderConfig: KeyFunderConfig<
     soon: '0',
     sonicsvm: '0',
   },
+  // Temporarily disabled while the sweep destination is moved to Turnkey treasury custody.
+  sweepEnabled: false,
   // Low urgency key funder balance thresholds for sweep calculations
-  // Automatic sweep enabled for the expected chain allowlist
+  // Used for sweep calculations when automatic sweeping is enabled.
   // Defaults: sweep to 0x5b73A98165778BCCE72979B4EE3faCdb31728b8E when balance > 2x threshold, leave 1.5x threshold
   lowUrgencyKeyFunderBalances: lowUrgencyKeyFunderBalancePerChain,
   // Per-chain overrides for sweep (optional)

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -42,6 +42,8 @@ export interface KeyFunderConfig<
   desiredStableswapInventoryRebalancerBalancePerChain?: ChainMap<string>;
   igpClaimThresholdPerChain: ChainMap<string>;
   chainsToSkip: ChainName[];
+  // Emergency kill switch for automatic sweeps. Defaults to enabled.
+  sweepEnabled?: boolean;
   // Per-chain overrides for automatic sweep of excess funds
   // Defaults: sweep to 0x5b73A98165778BCCE72979B4EE3faCdb31728b8E when balance > 2x threshold, leave behind 1.5x threshold
   sweepOverrides?: ChainMap<SweepOverrideConfig>;

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -164,7 +164,7 @@ export class KeyFunderHelmManager extends HelmManager {
       }
 
       // Add sweep config only for chains in CHAINS_TO_SWEEP with valid thresholds
-      if (CHAINS_TO_SWEEP.has(chain)) {
+      if (this.config.sweepEnabled !== false && CHAINS_TO_SWEEP.has(chain)) {
         const sweepThreshold = this.config.lowUrgencyKeyFunderBalances?.[chain];
         if (!sweepThreshold) {
           throw new Error(`Sweep threshold is missing for chain ${chain}`);


### PR DESCRIPTION
## Summary

- add an emergency `sweepEnabled` kill switch to keyfunder config
- disable automatic sweeps in mainnet3 while the destination is moved to Turnkey treasury custody
- preserve the existing sweep allowlist, thresholds, destination, schedule, and deployed image for later re-enablement

## Impact

Mainnet3 keyfunder continues funding roles and claiming IGP funds, but emits no per-chain sweep configuration. This prevents additional automatic transfers to `0x5b73A98165778BCCE72979B4EE3faCdb31728b8E` while the treasury consolidation path is confirmed.

The default remains enabled when `sweepEnabled` is omitted, so other environments retain their existing behavior.

## Validation

- `pnpm -C typescript/infra check`
- Prettier, oxlint, oxfmt, and gitleaks
- rendered mainnet3 keyfunder config: 0 sweep chains
- deployed to mainnet3 as Helm revision 250
- live ConfigMap readback: 75 chains, 0 with sweep config
- live CronJob retains schedule `45 * * * *` and image `b0c3c5d-20260804-175736`