### PR TITLE
fix(scraper)!: compact scraper cursor table

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -11028,23 +11028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-orm-cli"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3d39b35e43a05998228f6c4abaa50b7fcaf001dea94fbdc04188a8be82a016"
-dependencies = [
- "chrono",
- "clap",
- "dotenvy",
- "glob",
- "regex",
- "sea-schema",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
 name = "sea-orm-macros"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11065,10 +11048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae8b2af58a56c8f850e8d8a18a462255eb36a571f085f3405f6b83d9cf23e0f"
 dependencies = [
  "async-trait",
- "clap",
- "dotenvy",
  "sea-orm",
- "sea-orm-cli",
  "sea-schema",
  "tracing",
  "tracing-subscriber",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -145,7 +145,7 @@ sea-orm = { version = "1.1.10", features = [
   "with-time",
   "macros",
 ] }
-sea-orm-migration = { version = "1.1.10", features = [
+sea-orm-migration = { version = "1.1.10", default-features = false, features = [
   "sqlx-postgres",
   "runtime-tokio-native-tls",
 ] }
@@ -312,4 +312,3 @@ version = "=0.12.1"
 branch = "hyperlane"
 git = "https://github.com/hyperlane-xyz/parity-common.git"
 version = "=0.5.2"
-

--- a/rust/main/agents/scraper/migration/src/lib.rs
+++ b/rust/main/agents/scraper/migration/src/lib.rs
@@ -16,6 +16,7 @@ mod m20230309_000005_create_table_message;
 mod m20250224_000006_create_table_raw_message_dispatch;
 mod m20250521_000007_add_cursor_event_type;
 mod m20260613_000008_add_msg_body_to_raw_message_dispatch;
+mod m20260814_000009_compact_cursor_table;
 
 pub struct Migrator;
 
@@ -36,6 +37,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250224_000006_create_table_raw_message_dispatch::Migration),
             Box::new(m20250521_000007_add_cursor_event_type::Migration),
             Box::new(m20260613_000008_add_msg_body_to_raw_message_dispatch::Migration),
+            Box::new(m20260814_000009_compact_cursor_table::Migration),
         ]
     }
 }

--- a/rust/main/agents/scraper/migration/src/m20260814_000009_compact_cursor_table.rs
+++ b/rust/main/agents/scraper/migration/src/m20260814_000009_compact_cursor_table.rs
@@ -10,19 +10,21 @@ impl MigrationTrait for Migration {
             .get_connection()
             .execute_unprepared(
                 r#"
-                DELETE FROM "cursor" stale
-                USING "cursor" latest
-                WHERE stale.domain = latest.domain
-                  AND stale.event_type = latest.event_type
-                  AND (
-                    latest.height,
-                    latest.time_created,
-                    latest.id
-                  ) > (
-                    stale.height,
-                    stale.time_created,
-                    stale.id
-                  )
+                CREATE TEMP TABLE cursor_survivors ON COMMIT DROP AS
+                SELECT DISTINCT ON (domain, event_type)
+                  id,
+                  domain,
+                  time_created,
+                  height,
+                  event_type
+                FROM "cursor"
+                ORDER BY domain, event_type, height DESC, time_created DESC, id DESC;
+
+                TRUNCATE TABLE "cursor";
+
+                INSERT INTO "cursor" (id, domain, time_created, height, event_type)
+                SELECT id, domain, time_created, height, event_type
+                FROM cursor_survivors;
                 "#,
             )
             .await?;

--- a/rust/main/agents/scraper/migration/src/m20260814_000009_compact_cursor_table.rs
+++ b/rust/main/agents/scraper/migration/src/m20260814_000009_compact_cursor_table.rs
@@ -1,0 +1,121 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DELETE FROM "cursor" stale
+                USING "cursor" latest
+                WHERE stale.domain = latest.domain
+                  AND stale.event_type = latest.event_type
+                  AND (
+                    latest.height,
+                    latest.time_created,
+                    latest.id
+                  ) > (
+                    stale.height,
+                    stale.time_created,
+                    stale.id
+                  )
+                "#,
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_height_idx")
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_idx")
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_event_type_idx")
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_event_type_idx")
+                    .col(Cursor::Domain)
+                    .col(Cursor::EventType)
+                    .unique()
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_event_type_idx")
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_event_type_idx")
+                    .col(Cursor::Domain)
+                    .col(Cursor::EventType)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_idx")
+                    .col(Cursor::Domain)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .table(Cursor::Table)
+                    .name("cursor_domain_height_idx")
+                    .col(Cursor::Domain)
+                    .col(Cursor::Height)
+                    .index_type(IndexType::BTree)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Cursor {
+    Table,
+    Domain,
+    EventType,
+    Height,
+}

--- a/rust/main/agents/scraper/migration/src/m20260814_000009_compact_cursor_table.rs
+++ b/rust/main/agents/scraper/migration/src/m20260814_000009_compact_cursor_table.rs
@@ -11,14 +11,20 @@ impl MigrationTrait for Migration {
             .execute_unprepared(
                 r#"
                 CREATE TEMP TABLE cursor_survivors ON COMMIT DROP AS
-                SELECT DISTINCT ON (domain, event_type)
-                  id,
-                  domain,
-                  time_created,
-                  height,
-                  event_type
-                FROM "cursor"
-                ORDER BY domain, event_type, height DESC, time_created DESC, id DESC;
+                WITH keys AS (
+                  SELECT DISTINCT domain, event_type
+                  FROM "cursor"
+                )
+                SELECT latest.id, latest.domain, latest.time_created, latest.height, latest.event_type
+                FROM keys
+                CROSS JOIN LATERAL (
+                  SELECT id, domain, time_created, height, event_type
+                  FROM "cursor"
+                  WHERE "cursor".domain = keys.domain
+                    AND "cursor".event_type = keys.event_type
+                  ORDER BY height DESC, time_created DESC, id DESC
+                  LIMIT 1
+                ) latest;
 
                 TRUNCATE TABLE "cursor";
 

--- a/rust/main/agents/scraper/src/db/block_cursor.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor.rs
@@ -1,11 +1,12 @@
 use std::time::{Duration, Instant};
 
 use eyre::Result;
-use sea_orm::{prelude::*, ActiveValue, Insert, Order, QueryOrder, QuerySelect};
+use migration::OnConflict;
+use sea_orm::{prelude::*, ActiveValue::*, Insert, Order, QueryOrder, QuerySelect};
 use tokio::sync::RwLock;
 use tracing::{debug, info, instrument, warn};
 
-use crate::db::ScraperDb;
+use crate::{date_time, db::ScraperDb};
 
 use super::generated::cursor;
 
@@ -84,22 +85,12 @@ impl BlockCursor {
 
         let now = Instant::now();
         let time_since_last_save = now.duration_since(inner.last_saved_at);
-        if height > old_height && time_since_last_save > MAX_WRITE_BACK_FREQUENCY {
-            inner.last_saved_at = now;
-            // prevent any more writes to the inner struct until the write is complete.
-            let inner = inner.downgrade();
-            let model = cursor::ActiveModel {
-                id: ActiveValue::NotSet,
-                domain: ActiveValue::Set(self.domain as i32),
-                time_created: ActiveValue::NotSet,
-                height: ActiveValue::Set(height as i64),
-                event_type: ActiveValue::Set(self.event_type.clone()),
-            };
-            debug!(?model, "Inserting cursor");
-            if let Err(e) = Insert::one(model).exec(&self.db).await {
+        let should_flush = height > old_height && time_since_last_save > MAX_WRITE_BACK_FREQUENCY;
+        drop(inner);
+
+        if should_flush {
+            if let Err(e) = self.flush().await {
                 warn!(error = ?e, "Failed to update database with new cursor. When you just started this, ensure that the migrations included this domain.")
-            } else {
-                debug!(cursor = ?*inner, "Updated cursor")
             }
         }
     }
@@ -115,15 +106,28 @@ impl BlockCursor {
     pub async fn flush(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
         let height = inner.height;
+        debug!(
+            height,
+            domain = self.domain,
+            event_type = self.event_type,
+            "Flushing cursor to database"
+        );
         let model = cursor::ActiveModel {
-            id: ActiveValue::NotSet,
-            domain: ActiveValue::Set(self.domain as i32),
-            time_created: ActiveValue::NotSet,
-            height: ActiveValue::Set(height as i64),
-            event_type: ActiveValue::Set(self.event_type.clone()),
+            id: NotSet,
+            domain: Set(self.domain as i32),
+            time_created: Set(date_time::now()),
+            height: Set(height as i64),
+            event_type: Set(self.event_type.clone()),
         };
-        debug!(?model, "Flushing cursor to database");
-        Insert::one(model).exec(&self.db).await?;
+
+        Insert::one(model)
+            .on_conflict(
+                OnConflict::columns([cursor::Column::Domain, cursor::Column::EventType])
+                    .update_columns([cursor::Column::TimeCreated, cursor::Column::Height])
+                    .to_owned(),
+            )
+            .exec(&self.db)
+            .await?;
         inner.last_saved_at = Instant::now();
         let inner = inner.downgrade();
         debug!(cursor = ?*inner, "Flushed cursor");

--- a/rust/main/agents/scraper/src/db/block_cursor.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use eyre::Result;
-use migration::OnConflict;
+use migration::{Alias, Expr, Func, OnConflict};
 use sea_orm::{prelude::*, ActiveValue::*, Insert, Order, QueryOrder, QuerySelect};
 use tokio::sync::RwLock;
 use tracing::{debug, info, instrument, warn};
@@ -123,7 +123,14 @@ impl BlockCursor {
         Insert::one(model)
             .on_conflict(
                 OnConflict::columns([cursor::Column::Domain, cursor::Column::EventType])
-                    .update_columns([cursor::Column::TimeCreated, cursor::Column::Height])
+                    .update_column(cursor::Column::TimeCreated)
+                    .value(
+                        cursor::Column::Height,
+                        Func::greatest([
+                            Expr::col((Alias::new("cursor"), cursor::Column::Height)).into(),
+                            Expr::col((Alias::new("excluded"), cursor::Column::Height)).into(),
+                        ]),
+                    )
                     .to_owned(),
             )
             .exec(&self.db)

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -48,7 +48,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   validator: '14646bd-20260805-072134',
   validatorRC: '14646bd-20260805-072134',
   validatorFastPath: '14646bd-20260805-072134',
-  scraper: 'c1678d0-20260728-164228',
+  scraper: '473ec14-20260814-113303',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -67,7 +67,7 @@ export const testnetDockerTags: BaseDockerTags = {
   validator: '14646bd-20260805-072134',
   validatorRC: '14646bd-20260805-072134',
   validatorFastPath: '14646bd-20260805-072134',
-  scraper: '4ef51c4-20260717-113727',
+  scraper: '473ec14-20260814-113303',
   // standalone services
   keyFunder: '5dc6aa4-20260714-184449',
 };


### PR DESCRIPTION
will stop the scraper before applying the migration by hand. We wont rollback anything. Goal is to get rid of the 36gb cursor table which is growing indefinitely right now