### PR TITLE
fix(sdk): harden warp timelock validation

### DIFF
--- a/.changeset/fix-warp-timelock-followups.md
+++ b/.changeset/fix-warp-timelock-followups.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Warp timelock validation and cached-controller RPC handling were hardened to prevent ignored ownership overrides and duplicate deployments.

--- a/.changeset/fix-warp-timelock-followups.md
+++ b/.changeset/fix-warp-timelock-followups.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Warp timelock validation and cached-controller RPC handling were hardened to prevent ignored ownership overrides and duplicate deployments.
+Warp timelock validation and controller RPC handling were hardened to prevent ignored ownership overrides, invalid ABI probes, and duplicate deployments.

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -6,6 +6,7 @@ import { ProxyAdmin__factory } from '@hyperlane-xyz/core';
 import {
   Address,
   ChainId,
+  assert,
   eqAddress,
   isValidAddressEvm,
   retryAsync,
@@ -54,21 +55,41 @@ export function isStorageEmpty(rawValue: string): boolean {
   return rawValue === '0x' || rawValue === '' || rawValue === '0x0';
 }
 
+class MissingContractCodeError extends Error {}
+
+export async function contractHasCode(
+  provider: EthersLikeProvider,
+  contract: Address,
+): Promise<boolean> {
+  // Retry to handle RPC lag where a just-confirmed tx isn't yet visible on
+  // all nodes in a load-balanced pool.
+  try {
+    await retryAsync(
+      async () => {
+        const code = await provider.getCode(contract);
+        if (code === '0x') {
+          throw new MissingContractCodeError(
+            `Contract at ${contract} has no code`,
+          );
+        }
+      },
+      5,
+      500,
+    );
+    return true;
+  } catch (error) {
+    if (error instanceof MissingContractCodeError) return false;
+    throw error;
+  }
+}
+
 async function assertCodeExists(
   provider: EthersLikeProvider,
   contract: Address,
 ): Promise<void> {
-  // Retry to handle RPC lag where a just-confirmed tx isn't yet visible on
-  // all nodes in a load-balanced pool.
-  await retryAsync(
-    async () => {
-      const code = await provider.getCode(contract);
-      if (code === '0x') {
-        throw new Error(`Contract at ${contract} has no code`);
-      }
-    },
-    5,
-    500,
+  assert(
+    await contractHasCode(provider, contract),
+    `Contract at ${contract} has no code`,
   );
 }
 

--- a/typescript/sdk/src/token/EvmWarpModule.test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.test.ts
@@ -116,6 +116,17 @@ describe('EvmWarpModule', () => {
     return deployStub;
   }
 
+  function stubContractCode(...codes: string[]) {
+    const provider = multiProvider.getProvider(TestChainName.test1);
+    const getCode = sandbox.stub(provider, 'getCode');
+    for (const [index, code] of codes.entries()) {
+      getCode.onCall(index).resolves(code);
+    }
+    if (codes.length === 1) getCode.resolves(codes[0]);
+    sandbox.stub(multiProvider, 'getProvider').returns(provider);
+    return getCode;
+  }
+
   function createModule() {
     // CAST: deploy-time fixture only needs the address fields used by update planning.
     return new EvmWarpModule(multiProvider, {
@@ -263,6 +274,7 @@ describe('EvmWarpModule', () => {
       .resolves(false)
       .onSecondCall()
       .resolves(true);
+    const getCodeStub = stubContractCode('0x', '0x', '0x1234');
     const deployStub = stubDeployTimelocks(TIMELOCK_ADDRESS);
     const actualConfig = proxiedConfig();
     const expectedConfig = configWithTimelock();
@@ -277,9 +289,58 @@ describe('EvmWarpModule', () => {
     );
 
     expect(deployStub.callCount).to.equal(1);
+    expect(getCodeStub.callCount).to.equal(3);
     expect(secondMatchStub.calledTwice).to.equal(true);
     expect(secondConfig.proxyAdmin?.owner).to.equal(TIMELOCK_ADDRESS);
   });
+
+  for (const [name, deploy] of [
+    [
+      'route-wide deploy',
+      (
+        deployer: HypERC20Deployer,
+        config: HypTokenRouterConfig,
+      ): Promise<unknown> => deployer.deploy({ [TestChainName.test1]: config }),
+    ],
+    [
+      'direct deployContracts',
+      (
+        deployer: HypERC20Deployer,
+        config: HypTokenRouterConfig,
+      ): Promise<unknown> =>
+        deployer.deployContracts(TestChainName.test1, config),
+    ],
+  ] as const) {
+    it(`rejects timelock with ownerOverrides.proxyAdmin before ${name} side effects`, async () => {
+      const proxyAdminConnectStub = sandbox.stub(
+        ProxyAdmin__factory,
+        'connect',
+      );
+      const deployTimelockStub = sandbox.stub(
+        HyperlaneDeployer.prototype,
+        'deployTimelock',
+      );
+      const config: HypTokenRouterConfig = {
+        ...configWithTimelock({
+          address: PROXY_ADMIN_ADDRESS,
+          owner: OWNER_ADDRESS,
+        }),
+        ownerOverrides: { proxyAdmin: OTHER_PROXY_ADMIN_ADDRESS },
+      };
+
+      try {
+        await deploy(new HypERC20Deployer(multiProvider), config);
+        expect.fail('expected conflicting ProxyAdmin ownership to reject');
+      } catch (error) {
+        expect(errorMessage(error)).to.include(
+          'Cannot configure timelock with ownerOverrides.proxyAdmin',
+        );
+      }
+
+      expect(proxyAdminConnectStub.called).to.equal(false);
+      expect(deployTimelockStub.called).to.equal(false);
+    });
+  }
 
   it('rejects fresh timelock deploy with foreign-owned supplied ProxyAdmin before deploying', async () => {
     // CAST: ProxyAdmin__factory.connect is stubbed, so the signer object is not inspected.
@@ -329,6 +390,7 @@ describe('EvmWarpModule', () => {
     const secondModule = createModuleForTest();
     sandbox.stub(firstModule, 'timelockMatchesConfig').resolves(false);
     sandbox.stub(secondModule, 'timelockMatchesConfig').resolves(false);
+    stubContractCode('0x1234');
     const deployStub = stubDeployTimelocks(
       TIMELOCK_ADDRESS,
       OTHER_TIMELOCK_ADDRESS,

--- a/typescript/sdk/src/token/EvmWarpModule.test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.test.ts
@@ -46,6 +46,7 @@ type EvmWarpModuleForTest = {
   timelockMatchesConfig(
     timelockAddress: string,
     config: NonNullable<HypTokenRouterConfig['timelock']>,
+    codeAlreadyVerified?: boolean,
   ): Promise<boolean>;
 };
 
@@ -228,6 +229,7 @@ describe('EvmWarpModule', () => {
   });
 
   it('does not reuse a timelock missing self-admin', async () => {
+    stubContractCode('0x1234');
     stubTimelockController({ hasAdminSelf: false });
 
     const matches = await createModuleForTest().timelockMatchesConfig(
@@ -238,7 +240,22 @@ describe('EvmWarpModule', () => {
     expect(matches).to.equal(false);
   });
 
+  it('does not call the timelock ABI for an EOA ProxyAdmin owner', async () => {
+    const getCodeStub = stubContractCode('0x');
+    const connectStub = sandbox.stub(TimelockController__factory, 'connect');
+
+    const matches = await createModuleForTest().timelockMatchesConfig(
+      OWNER_ADDRESS,
+      timelockConfig,
+    );
+
+    expect(matches).to.equal(false);
+    expect(getCodeStub.calledOnce).to.equal(true);
+    expect(connectStub.called).to.equal(false);
+  });
+
   it('propagates transient timelock reads without deploying a replacement', async () => {
+    stubContractCode('0x1234');
     const transientError = Object.assign(new Error('rpc timeout'), {
       code: 'SERVER_ERROR',
     });

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -54,6 +54,7 @@ import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import {
   contractHasCode,
   isInitialized,
+  isStorageEmpty,
   proxyAdmin,
   proxyAdminUpdateTxs,
 } from '../deploy/proxy.js';
@@ -234,8 +235,20 @@ export class EvmWarpModule extends HyperlaneModule<
   private async timelockMatchesConfig(
     timelockAddress: Address,
     config: NonNullable<HypTokenRouterConfig['timelock']>,
+    codeAlreadyVerified = false,
   ): Promise<boolean> {
     const provider = this.multiProvider.getProvider(this.chainName);
+    if (
+      !codeAlreadyVerified &&
+      isStorageEmpty(await provider.getCode(timelockAddress))
+    ) {
+      this.logger.debug(
+        { chain: this.chainName, timelockAddress },
+        'ProxyAdmin owner has no contract code and is not a TimelockController',
+      );
+      return false;
+    }
+
     const timelockController = TimelockController__factory.connect(
       timelockAddress,
       provider,
@@ -280,7 +293,7 @@ export class EvmWarpModule extends HyperlaneModule<
       );
       return false;
     }
-    return this.timelockMatchesConfig(timelockAddress, config);
+    return this.timelockMatchesConfig(timelockAddress, config, true);
   }
 
   private async configWithTimelockProxyAdminOwner(

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -40,7 +40,6 @@ import {
   objMap,
   promiseObjAll,
   rootLogger,
-  sleep,
 } from '@hyperlane-xyz/utils';
 
 import { ExplorerLicenseType } from '../block-explorer/etherscan.js';
@@ -53,6 +52,7 @@ import {
 } from '../core/AbstractHyperlaneModule.js';
 import { ProxyFactoryFactories } from '../deploy/contracts.js';
 import {
+  contractHasCode,
   isInitialized,
   proxyAdmin,
   proxyAdminUpdateTxs,
@@ -272,19 +272,15 @@ export class EvmWarpModule extends HyperlaneModule<
     timelockAddress: Address,
     config: NonNullable<HypTokenRouterConfig['timelock']>,
   ): Promise<boolean> {
-    const attempts = 5;
-    const retryDelayMs = 100;
-    for (let attempt = 1; attempt <= attempts; attempt++) {
-      if (await this.timelockMatchesConfig(timelockAddress, config)) {
-        return true;
-      }
-      if (attempt < attempts) await sleep(retryDelayMs);
+    const provider = this.multiProvider.getProvider(this.chainName);
+    if (!(await contractHasCode(provider, timelockAddress))) {
+      this.logger.debug(
+        { chain: this.chainName, timelockAddress },
+        'Cached TimelockController has no code after visibility retry',
+      );
+      return false;
     }
-    this.logger.debug(
-      { attempts, chain: this.chainName, timelockAddress },
-      'Cached TimelockController does not match the expected config after retry',
-    );
-    return false;
+    return this.timelockMatchesConfig(timelockAddress, config);
   }
 
   private async configWithTimelockProxyAdminOwner(

--- a/typescript/sdk/src/token/deploy.ts
+++ b/typescript/sdk/src/token/deploy.ts
@@ -72,6 +72,7 @@ import {
   PredicateWrapperConfig,
   OftTokenConfig,
   WarpRouteDeployConfig,
+  assertTimelockConfigHasNoProxyAdminOwnerOverride,
   isCctpTokenConfig,
   isCollateralTokenConfig,
   isEverclearCollateralTokenConfig,
@@ -158,6 +159,14 @@ abstract class TokenDeployer<
       contractVerifier,
       concurrentDeploy,
     }); // factories not used in deploy
+  }
+
+  async deployContracts(
+    chain: ChainName,
+    config: HypTokenRouterConfig,
+  ): Promise<HyperlaneContracts<Factories & ProxiedFactories>> {
+    assertTimelockConfigHasNoProxyAdminOwnerOverride(config, chain);
+    return super.deployContracts(chain, config);
   }
 
   async constructorArgs(
@@ -880,6 +889,10 @@ abstract class TokenDeployer<
     configMap: ChainMap<HypTokenRouterConfig>,
     rateLimitedIsms?: ChainMap<IsmConfig>,
   ): Promise<HyperlaneContractsMap<Factories & ProxiedFactories>> {
+    for (const [chain, config] of Object.entries(configMap)) {
+      assertTimelockConfigHasNoProxyAdminOwnerOverride(config, chain);
+    }
+
     // Fail fast if any chain requires a predicate wrapper but lacks the factory.
     // Checked before any on-chain work to avoid partial deployments.
     for (const [chain, config] of Object.entries(configMap)) {

--- a/typescript/sdk/src/token/types.test.ts
+++ b/typescript/sdk/src/token/types.test.ts
@@ -58,23 +58,28 @@ describe('WarpRouteDeployConfigSchema refine', () => {
   });
 
   it('should reject timelock with ownerOverrides.proxyAdmin', () => {
-    expect(() =>
-      WarpRouteDeployConfigSchema.parse({
-        arbitrum: {
-          ...config.arbitrum,
-          ownerOverrides: {
-            proxyAdmin: SOME_ADDRESS,
-          },
-          timelock: {
-            delay: 259200,
-            roles: {
-              executor: SOME_ADDRESS,
-              proposer: SOME_ADDRESS,
-            },
+    const result = WarpRouteDeployConfigSchema.safeParse({
+      arbitrum: {
+        ...config.arbitrum,
+        ownerOverrides: {
+          proxyAdmin: SOME_ADDRESS,
+        },
+        timelock: {
+          delay: 259200,
+          roles: {
+            executor: SOME_ADDRESS,
+            proposer: SOME_ADDRESS,
           },
         },
-      }),
-    ).to.throw('Cannot configure timelock with ownerOverrides.proxyAdmin');
+      },
+    });
+
+    expect(result.success).to.be.false;
+    if (!result.success) {
+      expect(result.error.issues[0].message).to.equal(
+        'Cannot configure timelock with ownerOverrides.proxyAdmin',
+      );
+    }
   });
 
   it('should accept deposit-address bridge config', () => {

--- a/typescript/sdk/src/token/types.ts
+++ b/typescript/sdk/src/token/types.ts
@@ -506,11 +506,31 @@ export const HypTokenConfigSchema = z.preprocess((val) => {
   return val;
 }, AllHypTokenConfigSchema);
 
+const TIMELOCK_PROXY_ADMIN_OWNER_OVERRIDE_ERROR =
+  'Cannot configure timelock with ownerOverrides.proxyAdmin';
+
+type TimelockProxyAdminOwnerOverrideConfig = {
+  ownerOverrides?: { proxyAdmin?: unknown };
+  timelock?: unknown;
+};
+
+function addTimelockProxyAdminOwnerOverrideIssue(
+  config: TimelockProxyAdminOwnerOverrideConfig,
+  ctx: z.RefinementCtx,
+) {
+  if (!config.timelock || !config.ownerOverrides?.proxyAdmin) return;
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path: ['ownerOverrides', 'proxyAdmin'],
+    message: TIMELOCK_PROXY_ADMIN_OWNER_OVERRIDE_ERROR,
+  });
+}
+
 export const HypTokenRouterConfigSchema = z.preprocess(
   preprocessWarpRouteDeployConfig,
-  HypTokenConfigSchema.and(GasRouterConfigSchema).and(
-    HypTokenRouterVirtualConfigSchema.partial(),
-  ),
+  HypTokenConfigSchema.and(GasRouterConfigSchema)
+    .and(HypTokenRouterVirtualConfigSchema.partial())
+    .superRefine(addTimelockProxyAdminOwnerOverrideIssue),
 );
 
 export type HypTokenRouterConfig = z.infer<typeof HypTokenRouterConfigSchema>;
@@ -536,7 +556,9 @@ export const HypTokenRouterConfigMailboxOptionalBaseSchema =
     GasRouterConfigSchema.extend({
       mailbox: z.string().optional(),
     }),
-  ).and(HypTokenRouterVirtualConfigSchema.partial());
+  )
+    .and(HypTokenRouterVirtualConfigSchema.partial())
+    .superRefine(addTimelockProxyAdminOwnerOverrideIssue);
 
 export type HypTokenRouterConfigMailboxOptionalBase = z.infer<
   typeof HypTokenRouterConfigMailboxOptionalBaseSchema
@@ -553,7 +575,6 @@ export type HypTokenRouterConfigMailboxOptional = z.infer<
 
 function preprocessWarpRouteDeployConfig(value: unknown) {
   const mutatedConfig = value as HypTokenRouterConfigMailboxOptionalBase;
-  assertTimelockConfigHasNoProxyAdminOwnerOverride(mutatedConfig);
   return populateFeeOwner({
     tokenConfig: mutatedConfig,
     feeConfig: mutatedConfig.tokenFee,
@@ -561,14 +582,12 @@ function preprocessWarpRouteDeployConfig(value: unknown) {
 }
 
 export function assertTimelockConfigHasNoProxyAdminOwnerOverride(
-  config: Pick<HypTokenRouterConfigMailboxOptionalBase, 'ownerOverrides'> & {
-    timelock?: unknown;
-  },
+  config: TimelockProxyAdminOwnerOverrideConfig,
   chain?: string,
 ) {
   assert(
     !config.timelock || !config.ownerOverrides?.proxyAdmin,
-    `Cannot configure timelock with ownerOverrides.proxyAdmin${chain ? ` on ${chain}` : ''}`,
+    `${TIMELOCK_PROXY_ADMIN_OWNER_OVERRIDE_ERROR}${chain ? ` on ${chain}` : ''}`,
   );
 }
 


### PR DESCRIPTION
## Summary

- preserve `safeParse` semantics when rejecting timelock and ProxyAdmin owner override conflicts
- reject the same conflict at typed route-wide and direct deployer boundaries before side effects
- prove the current ProxyAdmin owner has contract code before probing the TimelockController ABI
- reuse the established RPC code-visibility retry policy before replacing a cached timelock controller
- add an SDK patch changeset

## Why

Follow-up to #9244 addressing the remaining review findings and its merge-queue E2E failure. These changes prevent ignored ProxyAdmin ownership overrides, boolean validation APIs throwing, EOA owners being misclassified as provider failures, and duplicate orphan timelock deployments during RPC propagation lag.

## Validation

- `pnpm build --filter @hyperlane-xyz/sdk...`
- `pnpm -C typescript/sdk check`
- `pnpm -C typescript/sdk lint`
- focused `EvmWarpModule` suite: 10 passing
- prior focused SDK suite: 128 passing
- `git diff --check`

Stacked on #9244 and intended to merge into its feature branch before #9244 re-enters the merge queue.