### PR TITLE
feat(cli): support isolated Turnkey warp fee signing

### DIFF
--- a/.changeset/quiet-pandas-sign.md
+++ b/.changeset/quiet-pandas-sign.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+The warp apply command was extended with isolated Turnkey signing for fee-owner transactions, and JSON-RPC submitters were extended with explicit signer injection and partial submission results.

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -25,6 +25,7 @@ import {
   type CommandModuleWithWarpDeployContext,
   type CommandModuleWithWriteContext,
 } from '../context/types.js';
+import { loadTurnkeyEvmSigner } from '../context/turnkey.js';
 import {
   runWarpRouteApply,
   runWarpRouteCombine,
@@ -192,6 +193,7 @@ const balances: CommandModuleWithContext<
 export const apply: CommandModuleWithWarpApplyContext<
   WarpRouteOptions & {
     strategy?: string;
+    feeTurnkeyConfig?: string;
     receiptsDir: string;
     relay?: boolean;
   }
@@ -201,6 +203,11 @@ export const apply: CommandModuleWithWarpApplyContext<
   builder: {
     ...WARP_ROUTE_OPTIONS,
     strategy: { ...strategyCommandOption, demandOption: false },
+    'fee-turnkey-config': {
+      type: 'string',
+      description:
+        'Path to a private Turnkey JSON config used only by JSON-RPC fee submitters',
+    },
     'receipts-dir': {
       type: 'string',
       description: 'The directory to output transaction receipts.',
@@ -217,6 +224,7 @@ export const apply: CommandModuleWithWarpApplyContext<
   handler: async ({
     context,
     strategy: strategyUrl,
+    feeTurnkeyConfig,
     receiptsDir,
     relay,
     warpRouteId,
@@ -225,6 +233,14 @@ export const apply: CommandModuleWithWarpApplyContext<
 
     if (strategyUrl)
       ExtendedChainSubmissionStrategySchema.parse(readYamlOrJson(strategyUrl));
+    assert(
+      !feeTurnkeyConfig || strategyUrl,
+      '--strategy is required with --fee-turnkey-config',
+    );
+
+    const feeSigner = feeTurnkeyConfig
+      ? await loadTurnkeyEvmSigner(feeTurnkeyConfig)
+      : undefined;
 
     await runWarpRouteApply({
       context,
@@ -232,6 +248,7 @@ export const apply: CommandModuleWithWarpApplyContext<
       warpCoreConfig: context.warpCoreConfig,
       strategyUrl,
       receiptsDir,
+      feeSigner,
       selfRelay: relay,
       warpRouteId: context.resolvedWarpRouteId ?? warpRouteId,
     });

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -206,7 +206,7 @@ export const apply: CommandModuleWithWarpApplyContext<
     'fee-turnkey-config': {
       type: 'string',
       description:
-        'Path to a private Turnkey JSON config used only by JSON-RPC fee submitters',
+        'Path to a private Turnkey JSON config used only by JSON-RPC fee submitters on Ethereum chains. Requires --strategy',
     },
     'receipts-dir': {
       type: 'string',

--- a/typescript/cli/src/context/turnkey.test.ts
+++ b/typescript/cli/src/context/turnkey.test.ts
@@ -1,0 +1,67 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { TurnkeyEvmSigner } from '@hyperlane-xyz/sdk';
+
+import { loadTurnkeyEvmSigner, readTurnkeyConfig } from './turnkey.js';
+
+const tempDirs: string[] = [];
+
+describe('readTurnkeyConfig', () => {
+  const config = {
+    organizationId: 'organization-id',
+    apiPublicKey: 'api-public-key',
+    apiPrivateKey: 'api-private-key',
+    privateKeyId: 'private-key-id',
+    publicKey: '0x0000000000000000000000000000000000000001',
+  };
+
+  afterEach(() => {
+    sinon.restore();
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
+  });
+
+  it('reads a private JSON config', () => {
+    const path = writeConfig(0o600, config);
+    expect(readTurnkeyConfig(path)).to.deep.equal(config);
+  });
+
+  it('rejects group-readable config files', () => {
+    if (process.platform === 'win32') return;
+    const path = writeConfig(0o640, config);
+    expect(() => readTurnkeyConfig(path)).to.throw(
+      'Turnkey config permissions are too broad',
+    );
+  });
+
+  it('rejects malformed config', () => {
+    const path = writeConfig(0o600, { organizationId: 'organization-id' });
+    expect(() => readTurnkeyConfig(path)).to.throw();
+  });
+
+  it('rejects an unhealthy Turnkey signer', async () => {
+    const path = writeConfig(0o600, config);
+    sinon.stub(TurnkeyEvmSigner.prototype, 'healthCheck').resolves(false);
+
+    let error: Error | undefined;
+    try {
+      await loadTurnkeyEvmSigner(path);
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+    expect(error?.message).to.include('Turnkey health check failed');
+  });
+});
+
+function writeConfig(mode: number, value: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hyperlane-turnkey-config-'));
+  tempDirs.push(dir);
+  const path = join(dir, 'turnkey.json');
+  writeFileSync(path, JSON.stringify(value), { mode: 0o600 });
+  chmodSync(path, mode);
+  return path;
+}

--- a/typescript/cli/src/context/turnkey.ts
+++ b/typescript/cli/src/context/turnkey.ts
@@ -1,0 +1,31 @@
+import { readFileSync, statSync } from 'fs';
+
+import {
+  type TurnkeyConfig,
+  TurnkeyConfigSchema,
+  TurnkeyEvmSigner,
+} from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+
+export function readTurnkeyConfig(configPath: string): TurnkeyConfig {
+  const stat = statSync(configPath);
+  assert(stat.isFile(), `Turnkey config is not a file: ${configPath}`);
+  if (process.platform !== 'win32') {
+    assert(
+      (stat.mode & 0o077) === 0,
+      `Turnkey config permissions are too broad: ${configPath}. Run chmod 600 ${configPath}`,
+    );
+  }
+
+  return TurnkeyConfigSchema.parse(
+    JSON.parse(readFileSync(configPath, 'utf8')),
+  );
+}
+
+export async function loadTurnkeyEvmSigner(
+  configPath: string,
+): Promise<TurnkeyEvmSigner> {
+  const signer = new TurnkeyEvmSigner(readTurnkeyConfig(configPath));
+  assert(await signer.healthCheck(), 'Turnkey health check failed');
+  return signer;
+}

--- a/typescript/cli/src/deploy/warp.test.ts
+++ b/typescript/cli/src/deploy/warp.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { expect } from 'chai';
-import { Wallet } from 'ethers';
+import { BigNumber, Wallet, constants, utils } from 'ethers';
 import sinon from 'sinon';
 
 import {
@@ -13,6 +13,8 @@ import {
 } from '@hyperlane-xyz/utils';
 import {
   EvmWarpModule,
+  type DerivedTokenFeeConfig,
+  EvmTokenFeeReader,
   HyperlaneDeployer,
   IsmType,
   MultiProvider,
@@ -28,6 +30,7 @@ import { type WriteCommandContext } from '../context/types.js';
 
 import {
   fullyConnectTokens,
+  assertLiveFeeOwners,
   type WarpApplyParams,
   preflightFeeSigner,
   runWarpRouteApply,
@@ -84,6 +87,7 @@ describe('fullyConnectTokens', () => {
 
 describe('preflightFeeSigner', () => {
   const chain = TestChainName.test1;
+  const destination = TestChainName.test2;
   let tempDir: string;
 
   beforeEach(() => {
@@ -154,7 +158,264 @@ describe('preflightFeeSigner', () => {
     expect(error?.message).to.include('does not match target RoutingFee owner');
     expect(getProvider.called).to.equal(false);
   });
+
+  it('ignores JSON-RPC fee submitters outside the apply scope', async () => {
+    const feeSigner = Wallet.createRandom();
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    const getProvider = sinon.spy(multiProvider, 'getProvider');
+    const strategyUrl = writeStrategy({
+      [chain]: jsonRpcStrategy(chain),
+      [destination]: jsonRpcStrategy(destination),
+    });
+
+    await preflightFeeSigner(
+      buildPreflightParams({
+        feeSigner,
+        multiProvider,
+        strategyUrl,
+      }),
+    );
+
+    expect(getProvider.called).to.equal(false);
+  });
+
+  it('rejects a JSON-RPC fee submitter targeting another chain', async () => {
+    const feeSigner = Wallet.createRandom();
+    const multiProvider = MultiProvider.createTestMultiProvider();
+
+    const error = await captureError(
+      preflightFeeSigner(
+        buildPreflightParams({
+          feeSigner,
+          multiProvider,
+          strategyUrl: writeStrategy({
+            [chain]: {
+              ...jsonRpcStrategy(chain),
+              feeSubmitter: { type: 'jsonRpc', chain: destination },
+            },
+          }),
+        }),
+      ),
+    );
+
+    expect(error.message).to.include(`for ${chain} targets ${destination}`);
+  });
+
+  it('allows replacing a zero fee recipient', async () => {
+    const feeSigner = Wallet.createRandom();
+    const routerAddress = Wallet.createRandom().address;
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    const provider = multiProvider.getProvider(chain);
+    sinon
+      .stub(provider, 'call')
+      .resolves(
+        utils.defaultAbiCoder.encode(['address'], [constants.AddressZero]),
+      );
+    const getGasPrice = sinon.spy(provider, 'getGasPrice');
+
+    await preflightFeeSigner(
+      buildPreflightParams({
+        feeSigner,
+        multiProvider,
+        routerAddress,
+        strategyUrl: writeStrategy({ [chain]: jsonRpcStrategy(chain) }),
+      }),
+    );
+
+    expect(getGasPrice.called).to.equal(false);
+  });
+
+  it('allows replacing a non-RoutingFee recipient', async () => {
+    const feeSigner = Wallet.createRandom();
+    const routerAddress = Wallet.createRandom().address;
+    const feeRecipient = Wallet.createRandom().address;
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    const provider = multiProvider.getProvider(chain);
+    sinon
+      .stub(provider, 'call')
+      .resolves(utils.defaultAbiCoder.encode(['address'], [feeRecipient]));
+    const getGasPrice = sinon.spy(provider, 'getGasPrice');
+    sinon
+      .stub(EvmTokenFeeReader.prototype, 'deriveTokenFeeConfig')
+      .resolves(linearFeeConfig(Wallet.createRandom().address, feeRecipient));
+
+    await preflightFeeSigner(
+      buildPreflightParams({
+        feeSigner,
+        multiProvider,
+        routerAddress,
+        strategyUrl: writeStrategy({ [chain]: jsonRpcStrategy(chain) }),
+      }),
+    );
+
+    expect(getGasPrice.called).to.equal(false);
+  });
+
+  it('rejects an unfunded fee signer before planning', async () => {
+    const feeSigner = Wallet.createRandom();
+    const routerAddress = Wallet.createRandom().address;
+    const feeRecipient = Wallet.createRandom().address;
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    const provider = multiProvider.getProvider(chain);
+    sinon
+      .stub(provider, 'call')
+      .resolves(utils.defaultAbiCoder.encode(['address'], [feeRecipient]));
+    sinon.stub(provider, 'getGasPrice').resolves(BigNumber.from(1));
+    sinon.stub(provider, 'getBalance').resolves(BigNumber.from(0));
+    sinon
+      .stub(EvmTokenFeeReader.prototype, 'deriveTokenFeeConfig')
+      .resolves(routingFeeConfig(feeSigner.address, feeRecipient));
+
+    const error = await captureError(
+      preflightFeeSigner(
+        buildPreflightParams({
+          feeSigner,
+          multiProvider,
+          routerAddress,
+          strategyUrl: writeStrategy({ [chain]: jsonRpcStrategy(chain) }),
+        }),
+      ),
+    );
+
+    expect(error.message).to.include('has insufficient gas balance');
+  });
+
+  it('rejects a matching live child owned by another signer', () => {
+    const feeSigner = Wallet.createRandom();
+    const feeRecipient = Wallet.createRandom().address;
+    const targetConfig = targetFeeConfig(feeSigner.address)[chain].tokenFee;
+    if (targetConfig?.type !== TokenFeeType.RoutingFee) {
+      throw new Error('Expected RoutingFee test fixture');
+    }
+    const liveConfig = routingFeeConfig(feeSigner.address, feeRecipient);
+    const liveChild = liveConfig.feeContracts[destination];
+    if (liveChild.type !== TokenFeeType.LinearFee) {
+      throw new Error('Expected LinearFee test fixture');
+    }
+    liveConfig.feeContracts[destination] = {
+      ...liveChild,
+      type: TokenFeeType.OffchainQuotedLinearFee,
+      owner: Wallet.createRandom().address,
+      quoteSigners: [],
+    };
+
+    expect(() =>
+      assertLiveFeeOwners(targetConfig, liveConfig, feeSigner.address, chain),
+    ).to.throw('does not match live fee owner');
+  });
+
+  function writeStrategy(strategy: Record<string, unknown>): string {
+    const strategyUrl = join(tempDir, 'strategy.json');
+    writeFileSync(strategyUrl, JSON.stringify(strategy));
+    return strategyUrl;
+  }
+
+  function jsonRpcStrategy(strategyChain: string) {
+    return {
+      submitter: { type: 'jsonRpc', chain: strategyChain },
+      feeSubmitter: { type: 'jsonRpc', chain: strategyChain },
+    };
+  }
+
+  function targetFeeConfig(
+    owner: string,
+  ): WarpRouteDeployConfigMailboxRequired {
+    return {
+      [chain]: {
+        type: TokenType.synthetic,
+        owner,
+        mailbox: owner,
+        tokenFee: {
+          type: TokenFeeType.RoutingFee,
+          owner,
+          feeContracts: {
+            [destination]: {
+              type: TokenFeeType.OffchainQuotedLinearFee,
+              owner,
+              bps: 1,
+              quoteSigners: [],
+            },
+          },
+        },
+      },
+    };
+  }
+
+  function buildPreflightParams({
+    feeSigner,
+    multiProvider,
+    strategyUrl,
+    routerAddress,
+  }: {
+    feeSigner: Wallet;
+    multiProvider: MultiProvider;
+    strategyUrl: string;
+    routerAddress?: string;
+  }): WarpApplyParams {
+    const warpCoreConfig: WarpCoreConfig = {
+      tokens: routerAddress
+        ? [
+            {
+              chainName: chain,
+              standard: TokenStandard.EvmHypSynthetic,
+              decimals: 18,
+              symbol: 'TEST',
+              name: 'Test token',
+              addressOrDenom: routerAddress,
+            },
+          ]
+        : [],
+    };
+    return {
+      // CAST: focused test context; preflight only consumes multiProvider.
+      context: { multiProvider } as WriteCommandContext,
+      feeSigner,
+      strategyUrl,
+      receiptsDir: tempDir,
+      warpCoreConfig,
+      warpDeployConfig: targetFeeConfig(feeSigner.address),
+    };
+  }
+
+  function routingFeeConfig(
+    owner: string,
+    address: string,
+  ): Extract<DerivedTokenFeeConfig, { type: 'RoutingFee' }> {
+    return {
+      type: TokenFeeType.RoutingFee,
+      owner,
+      address,
+      token: Wallet.createRandom().address,
+      feeContracts: {
+        [destination]: linearFeeConfig(owner, Wallet.createRandom().address),
+      },
+    };
+  }
+
+  function linearFeeConfig(
+    owner: string,
+    address: string,
+  ): Extract<DerivedTokenFeeConfig, { type: 'LinearFee' }> {
+    return {
+      type: TokenFeeType.LinearFee,
+      owner,
+      address,
+      token: Wallet.createRandom().address,
+      maxFee: 1n,
+      halfAmount: 1n,
+      bps: 1,
+    };
+  }
 });
+
+async function captureError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  throw new Error('Expected promise to reject');
+}
 
 const DOMAIN_BY_CHAIN: Record<string, number> = {
   anvil2: 31337,

--- a/typescript/cli/src/deploy/warp.test.ts
+++ b/typescript/cli/src/deploy/warp.test.ts
@@ -1,4 +1,9 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
 import { expect } from 'chai';
+import { Wallet } from 'ethers';
 import sinon from 'sinon';
 
 import {
@@ -11,14 +16,20 @@ import {
   HyperlaneDeployer,
   IsmType,
   MultiProvider,
+  TestChainName,
+  TokenFeeType,
   TokenStandard,
   TokenType,
   type WarpCoreConfig,
   type WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
 
+import { type WriteCommandContext } from '../context/types.js';
+
 import {
   fullyConnectTokens,
+  type WarpApplyParams,
+  preflightFeeSigner,
   runWarpRouteApply,
   runWarpRouteCombine,
   transformDeployConfigForDisplay,
@@ -68,6 +79,80 @@ describe('fullyConnectTokens', () => {
           ),
         ),
     ).to.equal(false);
+  });
+});
+
+describe('preflightFeeSigner', () => {
+  const chain = TestChainName.test1;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hyperlane-fee-signer-'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('rejects an owner mismatch before making live contract reads', async () => {
+    const feeSigner = Wallet.createRandom();
+    const otherOwner = Wallet.createRandom().address;
+    const strategyUrl = join(tempDir, 'strategy.json');
+    writeFileSync(
+      strategyUrl,
+      JSON.stringify({
+        [chain]: {
+          submitter: { type: 'jsonRpc', chain },
+          feeSubmitter: { type: 'jsonRpc', chain },
+        },
+      }),
+    );
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    const getProvider = sinon.stub(multiProvider, 'getProvider');
+    const warpCoreConfig: WarpCoreConfig = {
+      tokens: [
+        {
+          chainName: chain,
+          standard: TokenStandard.EvmHypSynthetic,
+          decimals: 18,
+          symbol: 'TEST',
+          name: 'Test token',
+          addressOrDenom: otherOwner,
+        },
+      ],
+    };
+    const warpDeployConfig: WarpRouteDeployConfigMailboxRequired = {
+      [chain]: {
+        type: TokenType.synthetic,
+        owner: otherOwner,
+        mailbox: otherOwner,
+        tokenFee: {
+          type: TokenFeeType.RoutingFee,
+          owner: otherOwner,
+          feeContracts: {},
+        },
+      },
+    };
+
+    const params: WarpApplyParams = {
+      // CAST: focused test context; preflight only consumes multiProvider.
+      context: { multiProvider } as WriteCommandContext,
+      feeSigner,
+      strategyUrl,
+      receiptsDir: tempDir,
+      warpCoreConfig,
+      warpDeployConfig,
+    };
+
+    let error: Error | undefined;
+    try {
+      await preflightFeeSigner(params);
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+    expect(error?.message).to.include('does not match target RoutingFee owner');
+    expect(getProvider.called).to.equal(false);
   });
 });
 

--- a/typescript/cli/src/deploy/warp.test.ts
+++ b/typescript/cli/src/deploy/warp.test.ts
@@ -201,6 +201,40 @@ describe('preflightFeeSigner', () => {
     expect(error.message).to.include(`for ${chain} targets ${destination}`);
   });
 
+  it('does not treat nested JSON-RPC as a dedicated fee submitter', async () => {
+    const feeSigner = Wallet.createRandom();
+    const multiProvider = MultiProvider.createTestMultiProvider();
+    const getProvider = sinon.spy(multiProvider, 'getProvider');
+    const chainConfig = targetFeeConfig(feeSigner.address)[chain];
+
+    await preflightFeeSigner(
+      buildPreflightParams({
+        feeSigner,
+        multiProvider,
+        strategyUrl: writeStrategy({
+          [chain]: jsonRpcStrategy(chain),
+          [destination]: {
+            submitter: { type: 'jsonRpc', chain: destination },
+            feeSubmitter: {
+              type: 'interchainAccount',
+              chain,
+              destinationChain: destination,
+              owner: feeSigner.address,
+              originInterchainAccountRouter: Wallet.createRandom().address,
+              internalSubmitter: { type: 'jsonRpc', chain },
+            },
+          },
+        }),
+        warpDeployConfig: {
+          [chain]: chainConfig,
+          [destination]: { ...chainConfig, mailbox: feeSigner.address },
+        },
+      }),
+    );
+
+    expect(getProvider.called).to.equal(false);
+  });
+
   it('allows replacing a zero fee recipient', async () => {
     const feeSigner = Wallet.createRandom();
     const routerAddress = Wallet.createRandom().address;
@@ -346,11 +380,13 @@ describe('preflightFeeSigner', () => {
     multiProvider,
     strategyUrl,
     routerAddress,
+    warpDeployConfig,
   }: {
     feeSigner: Wallet;
     multiProvider: MultiProvider;
     strategyUrl: string;
     routerAddress?: string;
+    warpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
   }): WarpApplyParams {
     const warpCoreConfig: WarpCoreConfig = {
       tokens: routerAddress
@@ -373,7 +409,7 @@ describe('preflightFeeSigner', () => {
       strategyUrl,
       receiptsDir: tempDir,
       warpCoreConfig,
-      warpDeployConfig: targetFeeConfig(feeSigner.address),
+      warpDeployConfig: warpDeployConfig ?? targetFeeConfig(feeSigner.address),
     };
   }
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -2,7 +2,7 @@ import { confirm } from '@inquirer/prompts';
 import type { Signer } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
-import { BaseFee__factory, TokenRouter__factory } from '@hyperlane-xyz/core';
+import { TokenRouter__factory } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   AltVMJsonRpcSubmitter,
@@ -40,13 +40,14 @@ import {
   type CompositeIsmNodeConfig,
   CompositeIsmNodeType,
   ContractVerifier,
+  type DerivedTokenFeeConfig,
+  EvmTokenFeeReader,
   EvmWarpModule,
   EV5JsonRpcSubmissionError,
   EV5JsonRpcTxSubmitter,
   ExplorerLicenseType,
   HypERC20Deployer,
   IsmType,
-  OnchainTokenFeeType,
   type MultiProvider,
   type MultisigIsmConfig,
   type OpStackIsmConfig,
@@ -57,10 +58,11 @@ import {
   type SubmissionStrategy,
   type SubmitterMetadata,
   type TokenMetadataMap,
+  type TokenFeeConfigInput,
   TokenFeeType,
   TokenType,
   type TrustedRelayerIsmConfig,
-  type TxSubmitterBuilder,
+  TxSubmitterBuilder,
   TxSubmitterType,
   type TypedAnnotatedTransaction,
   type WarpCoreConfig,
@@ -91,6 +93,7 @@ import {
   formatError,
   isEVMLike,
   isNullish,
+  isZeroishAddress,
   mapAllSettled,
   mustGet,
   objFilter,
@@ -147,6 +150,10 @@ export interface WarpApplyParams extends DeployParams {
   selfRelay?: boolean;
   warpRouteId?: string;
 }
+
+// Conservative budget for one owner-gated fee update (setFeeContract or a
+// nested mutable-fee update). This is checked before planning can deploy fees.
+const FEE_UPDATE_GAS_PER_DESTINATION = 100_000;
 
 function assertWarpApplyTimelocksSupportedByProtocols({
   multiProvider,
@@ -600,13 +607,20 @@ export async function preflightFeeSigner({
   const routerAddresses = getRouterAddressesFromWarpCoreConfig(warpCoreConfig);
   let configuredFeeSubmitter = false;
 
-  for (const [chain, chainStrategy] of Object.entries(strategy)) {
-    if (chainStrategy.feeSubmitter?.type !== TxSubmitterType.JSON_RPC) continue;
+  for (const chain of Object.keys(warpDeployConfig)) {
+    const chainStrategy = strategy[chain];
+    if (chainStrategy?.feeSubmitter?.type !== TxSubmitterType.JSON_RPC)
+      continue;
     configuredFeeSubmitter = true;
 
     assert(
       context.multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
       `Dedicated EVM fee signer cannot submit ${chainStrategy.feeSubmitter.type} transactions on non-Ethereum chain ${chain}`,
+    );
+    assert(
+      context.multiProvider.getChainId(chainStrategy.feeSubmitter.chain) ===
+        context.multiProvider.getChainId(chain),
+      `JSON-RPC feeSubmitter for ${chain} targets ${chainStrategy.feeSubmitter.chain}`,
     );
 
     const targetFeeConfig = warpDeployConfig[chain]?.tokenFee;
@@ -618,6 +632,7 @@ export async function preflightFeeSigner({
       eqAddress(targetFeeConfig.owner, signerAddress),
       `Dedicated fee signer ${signerAddress} does not match target RoutingFee owner ${targetFeeConfig.owner} on ${chain}`,
     );
+    assertTargetFeeOwners(targetFeeConfig, signerAddress, chain);
 
     const routerAddress = routerAddresses[chain];
     if (!routerAddress) continue;
@@ -627,18 +642,40 @@ export async function preflightFeeSigner({
       routerAddress,
       provider,
     ).feeRecipient();
-    const liveFee = BaseFee__factory.connect(feeRecipient, provider);
-    const [feeType, liveOwner] = await Promise.all([
-      liveFee.feeType(),
-      liveFee.owner(),
-    ]);
-    assert(
-      feeType === OnchainTokenFeeType.RoutingFee,
-      `Existing fee recipient ${feeRecipient} on ${chain} is not a RoutingFee`,
+    if (isZeroishAddress(feeRecipient)) continue;
+
+    const routingDestinations = Object.keys(targetFeeConfig.feeContracts).map(
+      (destination) => context.multiProvider.getDomainId(destination),
     );
+    const liveFeeConfig = await new EvmTokenFeeReader(
+      context.multiProvider,
+      chain,
+    ).deriveTokenFeeConfig({
+      address: feeRecipient,
+      routingDestinations,
+    });
+
+    // Replacing a non-RoutingFee only requires the router owner. The new
+    // RoutingFee is deployed directly and setFeeRecipient stays in the main
+    // transaction bucket.
+    if (liveFeeConfig.type !== TokenFeeType.RoutingFee) continue;
+
+    assertLiveFeeOwners(targetFeeConfig, liveFeeConfig, signerAddress, chain);
+
+    const feeUpdateCount = Math.max(
+      1,
+      Object.keys(targetFeeConfig.feeContracts).length,
+    );
+    const [gasPrice, signerBalance] = await Promise.all([
+      provider.getGasPrice(),
+      provider.getBalance(signerAddress),
+    ]);
+    const requiredBalance = gasPrice
+      .mul(FEE_UPDATE_GAS_PER_DESTINATION)
+      .mul(feeUpdateCount);
     assert(
-      eqAddress(liveOwner, signerAddress),
-      `Dedicated fee signer ${signerAddress} does not match live RoutingFee owner ${liveOwner} on ${chain}`,
+      signerBalance.gte(requiredBalance),
+      `Dedicated fee signer ${signerAddress} has insufficient gas balance on ${chain}: requires at least ${requiredBalance.toString()} wei for ${feeUpdateCount} fee updates, found ${signerBalance.toString()} wei`,
     );
   }
 
@@ -646,6 +683,137 @@ export async function preflightFeeSigner({
     configuredFeeSubmitter,
     'Submission strategy has no JSON-RPC feeSubmitter for the dedicated fee signer',
   );
+}
+
+function assertTargetFeeOwners(
+  targetConfig: TokenFeeConfigInput,
+  signerAddress: string,
+  feePath: string,
+): void {
+  assert(
+    eqAddress(targetConfig.owner, signerAddress),
+    `Dedicated fee signer ${signerAddress} does not match target fee owner ${targetConfig.owner} at ${feePath}`,
+  );
+
+  if (targetConfig.type === TokenFeeType.RoutingFee) {
+    for (const [destination, childConfig] of Object.entries(
+      targetConfig.feeContracts,
+    )) {
+      assertTargetFeeOwners(
+        childConfig,
+        signerAddress,
+        `${feePath}.${destination}`,
+      );
+    }
+  }
+
+  if (targetConfig.type === TokenFeeType.CrossCollateralRoutingFee) {
+    for (const [destination, routerConfigs] of Object.entries(
+      targetConfig.feeContracts,
+    )) {
+      for (const [router, childConfig] of Object.entries(routerConfigs)) {
+        assertTargetFeeOwners(
+          childConfig,
+          signerAddress,
+          `${feePath}.${destination}.${router}`,
+        );
+      }
+    }
+  }
+}
+
+export function assertLiveFeeOwners(
+  targetConfig: TokenFeeConfigInput,
+  liveConfig: DerivedTokenFeeConfig,
+  signerAddress: string,
+  feePath: string,
+): void {
+  if (feeConfigWillRedeploy(targetConfig, liveConfig)) return;
+
+  assert(
+    eqAddress(liveConfig.owner, signerAddress),
+    `Dedicated fee signer ${signerAddress} does not match live fee owner ${liveConfig.owner} at ${feePath}`,
+  );
+
+  if (
+    targetConfig.type === TokenFeeType.RoutingFee &&
+    liveConfig.type === TokenFeeType.RoutingFee
+  ) {
+    for (const [destination, childTarget] of Object.entries(
+      targetConfig.feeContracts,
+    )) {
+      const childLive = liveConfig.feeContracts[destination];
+      if (childLive) {
+        assertLiveFeeOwners(
+          childTarget,
+          childLive,
+          signerAddress,
+          `${feePath}.${destination}`,
+        );
+      }
+    }
+  }
+
+  if (
+    targetConfig.type === TokenFeeType.CrossCollateralRoutingFee &&
+    liveConfig.type === TokenFeeType.CrossCollateralRoutingFee
+  ) {
+    for (const [destination, targetRouterConfigs] of Object.entries(
+      targetConfig.feeContracts,
+    )) {
+      const liveRouterConfigs = liveConfig.feeContracts[destination];
+      if (!liveRouterConfigs) continue;
+      for (const [router, childTarget] of Object.entries(targetRouterConfigs)) {
+        const childLive = liveRouterConfigs[router];
+        if (childLive) {
+          assertLiveFeeOwners(
+            childTarget,
+            childLive,
+            signerAddress,
+            `${feePath}.${destination}.${router}`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function feeConfigWillRedeploy(
+  targetConfig: TokenFeeConfigInput,
+  liveConfig: DerivedTokenFeeConfig,
+): boolean {
+  if (targetConfig.type !== liveConfig.type) return true;
+  if (
+    targetConfig.type === TokenFeeType.RoutingFee ||
+    targetConfig.type === TokenFeeType.CrossCollateralRoutingFee
+  ) {
+    return false;
+  }
+
+  if (
+    'bps' in targetConfig &&
+    'bps' in liveConfig &&
+    targetConfig.bps !== liveConfig.bps
+  ) {
+    return true;
+  }
+  if (
+    'maxFee' in targetConfig &&
+    'maxFee' in liveConfig &&
+    targetConfig.maxFee !== undefined &&
+    BigInt(targetConfig.maxFee) !== BigInt(liveConfig.maxFee)
+  ) {
+    return true;
+  }
+  if (
+    'halfAmount' in targetConfig &&
+    'halfAmount' in liveConfig &&
+    targetConfig.halfAmount !== undefined &&
+    BigInt(targetConfig.halfAmount) !== BigInt(liveConfig.halfAmount)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -1373,7 +1541,7 @@ function buildAltVmSubmitterFactories({
   };
 }
 
-async function getFeeSubmitterByStrategy<T extends ProtocolType>({
+async function getFeeSubmitterByStrategy({
   chain,
   context,
   feeSigner,
@@ -1383,7 +1551,7 @@ async function getFeeSubmitterByStrategy<T extends ProtocolType>({
   context: WriteCommandContext;
   feeSigner?: Signer;
   strategyUrl?: string;
-}): Promise<TxSubmitterBuilder<T> | undefined> {
+}): Promise<TxSubmitterBuilder<ProtocolType> | undefined> {
   const { multiProvider, altVmSigners, registry } = context;
 
   if (!strategyUrl) return undefined;
@@ -1396,6 +1564,23 @@ async function getFeeSubmitterByStrategy<T extends ProtocolType>({
   };
 
   const protocol = multiProvider.getProtocol(chain);
+  if (
+    feeSigner &&
+    submissionStrategy.feeSubmitter.type === TxSubmitterType.JSON_RPC
+  ) {
+    assert(
+      protocol === ProtocolType.Ethereum,
+      `Dedicated EVM fee signer cannot submit JSON-RPC transactions on ${protocol} chain ${chain}`,
+    );
+    return new TxSubmitterBuilder<ProtocolType>(
+      new EV5JsonRpcTxSubmitter(
+        multiProvider,
+        submissionStrategy.feeSubmitter,
+        feeSigner,
+      ),
+    );
+  }
+
   const additionalSubmitterFactories: any = {
     [ProtocolType.Tron]: {
       file: (_multiProvider: MultiProvider, metadata: any) =>
@@ -1404,24 +1589,6 @@ async function getFeeSubmitterByStrategy<T extends ProtocolType>({
     [ProtocolType.Ethereum]: {
       file: (_multiProvider: MultiProvider, metadata: any) =>
         new EV5FileSubmitter(metadata),
-      ...(feeSigner
-        ? {
-            [TxSubmitterType.JSON_RPC]: (
-              feeMultiProvider: MultiProvider,
-              metadata: SubmitterMetadata,
-            ) => {
-              assert(
-                metadata.type === TxSubmitterType.JSON_RPC,
-                `Invalid fee submitter type ${metadata.type}`,
-              );
-              return new EV5JsonRpcTxSubmitter(
-                feeMultiProvider,
-                metadata,
-                feeSigner,
-              );
-            },
-          }
-        : {}),
     },
   };
 
@@ -1435,7 +1602,7 @@ async function getFeeSubmitterByStrategy<T extends ProtocolType>({
     });
   }
 
-  return getSubmitterBuilder<T>({
+  return getSubmitterBuilder<ProtocolType>({
     submissionStrategy: feeStrategy as SubmissionStrategy,
     multiProvider,
     coreAddressesByChain: await registry.getAddresses(),

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -1,6 +1,8 @@
 import { confirm } from '@inquirer/prompts';
+import type { Signer } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
+import { BaseFee__factory, TokenRouter__factory } from '@hyperlane-xyz/core';
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   AltVMJsonRpcSubmitter,
@@ -39,9 +41,12 @@ import {
   CompositeIsmNodeType,
   ContractVerifier,
   EvmWarpModule,
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
   ExplorerLicenseType,
   HypERC20Deployer,
   IsmType,
+  OnchainTokenFeeType,
   type MultiProvider,
   type MultisigIsmConfig,
   type OpStackIsmConfig,
@@ -52,6 +57,7 @@ import {
   type SubmissionStrategy,
   type SubmitterMetadata,
   type TokenMetadataMap,
+  TokenFeeType,
   TokenType,
   type TrustedRelayerIsmConfig,
   type TxSubmitterBuilder,
@@ -81,6 +87,7 @@ import {
   type Annotated,
   addressToBytes32,
   assert,
+  eqAddress,
   formatError,
   isEVMLike,
   isNullish,
@@ -132,10 +139,11 @@ interface DeployParams {
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
 }
 
-interface WarpApplyParams extends DeployParams {
+export interface WarpApplyParams extends DeployParams {
   warpCoreConfig: WarpCoreConfig;
   strategyUrl?: string;
   receiptsDir: string;
+  feeSigner?: Signer;
   selfRelay?: boolean;
   warpRouteId?: string;
 }
@@ -499,6 +507,8 @@ export async function runWarpRouteApply(
     warpDeployConfig,
   });
 
+  await preflightFeeSigner(params);
+
   const chains = Object.keys(warpDeployConfig);
 
   let apiKeys: ChainMap<string> = {};
@@ -565,6 +575,76 @@ export async function runWarpRouteApply(
     updateTransactions,
     feeUpdateTransactions,
     ownershipTransactions,
+  );
+}
+
+/**
+ * Verifies the dedicated signer can authorize every JSON-RPC fee submission
+ * before warp apply deploys replacement fee contracts.
+ */
+export async function preflightFeeSigner({
+  context,
+  feeSigner,
+  strategyUrl,
+  warpCoreConfig,
+  warpDeployConfig,
+}: WarpApplyParams): Promise<void> {
+  if (!feeSigner) return;
+
+  assert(
+    strategyUrl,
+    'A submission strategy is required when using a dedicated fee signer',
+  );
+  const strategy = readChainSubmissionStrategy(strategyUrl);
+  const signerAddress = await feeSigner.getAddress();
+  const routerAddresses = getRouterAddressesFromWarpCoreConfig(warpCoreConfig);
+  let configuredFeeSubmitter = false;
+
+  for (const [chain, chainStrategy] of Object.entries(strategy)) {
+    if (chainStrategy.feeSubmitter?.type !== TxSubmitterType.JSON_RPC) continue;
+    configuredFeeSubmitter = true;
+
+    assert(
+      context.multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+      `Dedicated EVM fee signer cannot submit ${chainStrategy.feeSubmitter.type} transactions on non-Ethereum chain ${chain}`,
+    );
+
+    const targetFeeConfig = warpDeployConfig[chain]?.tokenFee;
+    assert(
+      targetFeeConfig?.type === TokenFeeType.RoutingFee,
+      `Dedicated fee signer requires a target RoutingFee config on ${chain}`,
+    );
+    assert(
+      eqAddress(targetFeeConfig.owner, signerAddress),
+      `Dedicated fee signer ${signerAddress} does not match target RoutingFee owner ${targetFeeConfig.owner} on ${chain}`,
+    );
+
+    const routerAddress = routerAddresses[chain];
+    if (!routerAddress) continue;
+
+    const provider = context.multiProvider.getProvider(chain);
+    const feeRecipient = await TokenRouter__factory.connect(
+      routerAddress,
+      provider,
+    ).feeRecipient();
+    const liveFee = BaseFee__factory.connect(feeRecipient, provider);
+    const [feeType, liveOwner] = await Promise.all([
+      liveFee.feeType(),
+      liveFee.owner(),
+    ]);
+    assert(
+      feeType === OnchainTokenFeeType.RoutingFee,
+      `Existing fee recipient ${feeRecipient} on ${chain} is not a RoutingFee`,
+    );
+    assert(
+      eqAddress(liveOwner, signerAddress),
+      `Dedicated fee signer ${signerAddress} does not match live RoutingFee owner ${liveOwner} on ${chain}`,
+    );
+  }
+
+  assert(
+    configuredFeeSubmitter,
+    'Submission strategy has no JSON-RPC feeSubmitter for the dedicated fee signer',
   );
 }
 
@@ -1296,10 +1376,12 @@ function buildAltVmSubmitterFactories({
 async function getFeeSubmitterByStrategy<T extends ProtocolType>({
   chain,
   context,
+  feeSigner,
   strategyUrl,
 }: {
   chain: ChainName;
   context: WriteCommandContext;
+  feeSigner?: Signer;
   strategyUrl?: string;
 }): Promise<TxSubmitterBuilder<T> | undefined> {
   const { multiProvider, altVmSigners, registry } = context;
@@ -1322,6 +1404,24 @@ async function getFeeSubmitterByStrategy<T extends ProtocolType>({
     [ProtocolType.Ethereum]: {
       file: (_multiProvider: MultiProvider, metadata: any) =>
         new EV5FileSubmitter(metadata),
+      ...(feeSigner
+        ? {
+            [TxSubmitterType.JSON_RPC]: (
+              feeMultiProvider: MultiProvider,
+              metadata: SubmitterMetadata,
+            ) => {
+              assert(
+                metadata.type === TxSubmitterType.JSON_RPC,
+                `Invalid fee submitter type ${metadata.type}`,
+              );
+              return new EV5JsonRpcTxSubmitter(
+                feeMultiProvider,
+                metadata,
+                feeSigner,
+              );
+            },
+          }
+        : {}),
     },
   };
 
@@ -1515,13 +1615,14 @@ async function submitChainTransactions(
       // live (so fee txs are kept out of the retried main submit() and isolated
       // here). Intentionally wrapped in try/catch so a fee failure does NOT bubble
       // up to retryAsync and re-run the main submit block (which would rebroadcast
-      // already-submitted main txs); the failure is surfaced as a soft warning via
-      // returnedFeeError instead.
+      // already-submitted main txs). The failure is returned so the caller can
+      // preserve other chain results before exiting nonzero.
       if (!mergeFeeIntoMain && feeTxs.length > 0) {
         try {
           const dedicatedFeeSubmitter = await getFeeSubmitterByStrategy({
             chain,
             context: params.context,
+            feeSigner: params.feeSigner,
             strategyUrl: params.strategyUrl,
           });
           // Fall back to the main submitter when no dedicated feeSubmitter is
@@ -1552,8 +1653,21 @@ async function submitChainTransactions(
             );
           }
         } catch (error) {
+          if (
+            error instanceof EV5JsonRpcSubmissionError &&
+            error.submittedTransactions.length > 0
+          ) {
+            writePartialSubmissionResults(
+              params.receiptsDir,
+              chain,
+              'fee',
+              error,
+            );
+          }
           returnedFeeError =
-            error instanceof Error ? error.message : String(error);
+            error instanceof EV5JsonRpcSubmissionError
+              ? error.message
+              : formatError(error);
           warnYellow(
             `Error when submitting fee transactions for ${chain}`,
             error,
@@ -1655,6 +1769,7 @@ async function submitWarpApplyTransactions(
     );
 
     for (const [chain, error] of rejected) {
+      writePartialSubmissionResults(params.receiptsDir, chain, 'main', error);
       rootLogger.debug(
         `Error in submitWarpApplyTransactions for ${chain}`,
         error,
@@ -1695,17 +1810,35 @@ async function submitWarpApplyTransactions(
   // so a partial success (e.g. chain A ok, chain B failed) doesn't lose chain A's bundle.
   writeCombinedBundles(params.receiptsDir, allPayloads);
 
-  if (failures.length > 0) {
-    throw new Error(
+  const failureMessages: string[] = [];
+  if (failures.length > 0)
+    failureMessages.push(
       `Warp apply transaction submission failed for chain(s): ${failures.join(', ')}`,
     );
-  }
-
-  if (feeFailures.length > 0) {
-    warnYellow(
-      `Fee transaction submission failed for the following chain(s) — main transactions were NOT affected:\n${feeFailures.join('\n')}`,
+  if (feeFailures.length > 0)
+    failureMessages.push(
+      `Fee transaction submission failed; main transactions were not affected:\n${feeFailures.join('\n')}`,
     );
-  }
+  if (failureMessages.length > 0) throw new Error(failureMessages.join('\n'));
+}
+
+function writePartialSubmissionResults(
+  receiptsDir: string,
+  chain: ChainName,
+  bucket: 'fee' | 'main',
+  error: unknown,
+): void {
+  if (
+    !(error instanceof EV5JsonRpcSubmissionError) ||
+    error.submittedTransactions.length === 0
+  )
+    return;
+
+  const partialReceiptPath = `${receiptsDir}/${chain}-${bucket}-partial-${Date.now()}-receipts.json`;
+  writeYamlOrJson(partialReceiptPath, error.submittedTransactions);
+  warnYellow(
+    `Partial ${bucket} transaction results for ${chain} written to ${partialReceiptPath}`,
+  );
 }
 
 function writeCombinedBundles(

--- a/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-submitters.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/apply/warp-apply-submitters.e2e-test.ts
@@ -1,10 +1,15 @@
+import { generateKeyPairSync } from 'crypto';
 import { expect } from 'chai';
 import { type Signer, Wallet, ethers } from 'ethers';
-import { existsSync, rmSync } from 'fs';
+import { existsSync, rmSync, writeFileSync } from 'fs';
+import { type IncomingMessage, type ServerResponse, createServer } from 'http';
 
 import {
+  BaseFee__factory,
   InterchainAccountRouter__factory,
   MockSafe__factory,
+  RoutingFee__factory,
+  TokenRouter__factory,
   type TimelockController,
   TimelockController__factory,
 } from '@hyperlane-xyz/core';
@@ -95,6 +100,9 @@ describe('hyperlane warp apply with submitters', async function () {
   const FEE_BUCKET_SPLIT_STRATEGY_PATH = `${TEMP_PATH}/fee-bucket-split-strategy.yaml`;
   const FEE_BUCKET_SPLIT_MAIN_OUTPUT_PATH = `${TEMP_PATH}/fee-bucket-split-main-output.json`;
   const FEE_BUCKET_SPLIT_FEE_OUTPUT_PATH = `${TEMP_PATH}/fee-bucket-split-fee-output.json`;
+  const TURNKEY_FEE_STRATEGY_PATH = `${TEMP_PATH}/turnkey-fee-strategy.yaml`;
+  const TURNKEY_FEE_MAIN_OUTPUT_PATH = `${TEMP_PATH}/turnkey-fee-main-output.json`;
+  const TURNKEY_CONFIG_PATH = `${TEMP_PATH}/turnkey-fee-config.json`;
 
   const evmChain2Core = new HyperlaneE2ECoreTestCommands(
     ProtocolType.Ethereum,
@@ -306,6 +314,8 @@ describe('hyperlane warp apply with submitters', async function () {
       FEE_BUCKET_MERGED_OUTPUT_PATH,
       FEE_BUCKET_SPLIT_MAIN_OUTPUT_PATH,
       FEE_BUCKET_SPLIT_FEE_OUTPUT_PATH,
+      TURNKEY_FEE_MAIN_OUTPUT_PATH,
+      TURNKEY_CONFIG_PATH,
     ]) {
       if (existsSync(outputPath)) {
         rmSync(outputPath);
@@ -929,6 +939,130 @@ describe('hyperlane warp apply with submitters', async function () {
       ).to.be.true;
       expect(mainInnerCalls.some(isFeeContractOp)).to.be.false;
     });
+
+    it('deploys fee leaves with the deployer and repoints them with the Turnkey fee signer', async () => {
+      const provider = chain3Signer.provider;
+      assert(provider, 'Expected chain3 provider');
+      const feeWallet = Wallet.createRandom().connect(provider);
+      await (
+        await chain3Signer.sendTransaction({
+          to: feeWallet.address,
+          value: ethers.utils.parseEther('1'),
+        })
+      ).wait();
+      const warpDeployConfig = fixture.getDeployConfig();
+      const chain3Config =
+        warpDeployConfig[TEST_CHAIN_NAMES_BY_PROTOCOL.ethereum.CHAIN_NAME_3];
+      chain3Config.owner = chain3IcaAddress;
+      chain3Config.tokenFee = {
+        type: TokenFeeType.RoutingFee,
+        owner: feeWallet.address,
+        feeContracts: {
+          [TEST_CHAIN_NAMES_BY_PROTOCOL.ethereum.CHAIN_NAME_2]: {
+            type: TokenFeeType.LinearFee,
+            bps: 50,
+          },
+        },
+      };
+      await deployAndExportWarpRoute();
+
+      const chain3WarpToken = getChain3WarpTokenAddress();
+      const tokenRouter = TokenRouter__factory.connect(
+        chain3WarpToken,
+        provider,
+      );
+      const routingFeeAddress = await tokenRouter.feeRecipient();
+      const routingFee = RoutingFee__factory.connect(
+        routingFeeAddress,
+        provider,
+      );
+      expect(eqAddress(await routingFee.owner(), feeWallet.address)).to.be.true;
+      const oldLeaf = await routingFee.feeContracts(chain2DomainId);
+
+      chain3Config.destinationGas = { [chain2DomainId]: '46000' };
+      chain3Config.tokenFee = {
+        type: TokenFeeType.RoutingFee,
+        owner: feeWallet.address,
+        feeContracts: {
+          [TEST_CHAIN_NAMES_BY_PROTOCOL.ethereum.CHAIN_NAME_2]: {
+            type: TokenFeeType.LinearFee,
+            bps: 25,
+          },
+        },
+      };
+      writeYamlOrJson(WARP_DEPLOY_CONFIG_PATH, warpDeployConfig);
+      writeYamlOrJson(TURNKEY_FEE_STRATEGY_PATH, {
+        [TEST_CHAIN_NAMES_BY_PROTOCOL.ethereum.CHAIN_NAME_3]: {
+          submitter: buildIcaFileSubmitter(TURNKEY_FEE_MAIN_OUTPUT_PATH),
+          feeSubmitter: {
+            type: TxSubmitterType.JSON_RPC,
+            chain: TEST_CHAIN_NAMES_BY_PROTOCOL.ethereum.CHAIN_NAME_3,
+          },
+        },
+      });
+
+      const mockTurnkey = await startMockTurnkeyApi(feeWallet);
+      writeFileSync(
+        TURNKEY_CONFIG_PATH,
+        JSON.stringify({
+          ...mockTurnkey.apiKey,
+          organizationId: 'test-organization',
+          privateKeyId: 'test-private-key',
+          publicKey: feeWallet.address,
+          apiBaseUrl: mockTurnkey.url,
+        }),
+        { mode: 0o600 },
+      );
+      const firstApplyBlock = (await provider.getBlockNumber()) + 1;
+
+      try {
+        await evmWarpCommands.applyRaw({
+          warpRouteId: WARP_ROUTE_ID,
+          strategyUrl: TURNKEY_FEE_STRATEGY_PATH,
+          hypKey: HYP_KEY_BY_PROTOCOL.ethereum,
+          extraArgs: ['--fee-turnkey-config', TURNKEY_CONFIG_PATH],
+        });
+      } finally {
+        await mockTurnkey.close();
+      }
+
+      const newLeaf = await routingFee.feeContracts(chain2DomainId);
+      expect(eqAddress(newLeaf, oldLeaf)).to.be.false;
+      expect(
+        eqAddress(
+          await BaseFee__factory.connect(newLeaf, provider).owner(),
+          feeWallet.address,
+        ),
+      ).to.be.true;
+
+      const applyTransactions = await getTransactionsSince(
+        provider,
+        firstApplyBlock,
+      );
+      const leafDeployment = applyTransactions.find(
+        ({ receipt }) =>
+          receipt.contractAddress &&
+          eqAddress(receipt.contractAddress, newLeaf),
+      );
+      expect(
+        eqAddress(
+          leafDeployment?.transaction.from ?? ethers.constants.AddressZero,
+          initialOwnerAddress,
+        ),
+      ).to.be.true;
+      const setFeeContractTx = applyTransactions.find(
+        ({ transaction }) =>
+          transaction.to &&
+          eqAddress(transaction.to, routingFeeAddress) &&
+          transaction.data.startsWith(SET_FEE_CONTRACT_SELECTOR),
+      );
+      expect(
+        eqAddress(
+          setFeeContractTx?.transaction.from ?? ethers.constants.AddressZero,
+          feeWallet.address,
+        ),
+      ).to.be.true;
+    });
   });
 
   describe(`${TxSubmitterType.GNOSIS_TX_BUILDER}/${TxSubmitterType.GNOSIS_SAFE}`, () => {
@@ -1047,3 +1181,128 @@ describe('hyperlane warp apply with submitters', async function () {
     });
   });
 });
+
+async function startMockTurnkeyApi(wallet: Wallet): Promise<{
+  url: string;
+  apiKey: { apiPublicKey: string; apiPrivateKey: string };
+  close: () => Promise<void>;
+}> {
+  const keyPair = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const jwk = keyPair.privateKey.export({ format: 'jwk' });
+  assert(jwk.x && jwk.y && jwk.d, 'Expected complete P-256 JWK');
+  const x = Buffer.from(jwk.x, 'base64url');
+  const y = Buffer.from(jwk.y, 'base64url');
+  assert(y.length > 0, 'Expected P-256 public key bytes');
+  const apiKey = {
+    apiPublicKey: `${y[y.length - 1] & 1 ? '03' : '02'}${x.toString('hex')}`,
+    apiPrivateKey: Buffer.from(jwk.d, 'base64url').toString('hex'),
+  };
+
+  const server = createServer((request, response) => {
+    void handleTurnkeyRequest(wallet, request, response);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert(address && typeof address !== 'string', 'Expected TCP server address');
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}
+
+async function handleTurnkeyRequest(
+  wallet: Wallet,
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> {
+  try {
+    const body = JSON.parse(await readRequestBody(request));
+    if (request.url === '/public/v1/query/whoami') {
+      return sendJson(response, { organizationId: 'test-organization' });
+    }
+    if (request.url === '/public/v1/submit/sign_transaction') {
+      const unsignedTransaction = body?.parameters?.unsignedTransaction;
+      assert(
+        typeof unsignedTransaction === 'string',
+        'Expected unsigned transaction',
+      );
+      const signedTransaction = await wallet.signTransaction(
+        parseUnsignedTransaction(`0x${unsignedTransaction}`),
+      );
+      return sendJson(response, {
+        activity: {
+          id: 'test-activity',
+          status: 'ACTIVITY_STATUS_COMPLETED',
+          result: { signTransactionResult: { signedTransaction } },
+        },
+      });
+    }
+    response.writeHead(404).end();
+  } catch (error) {
+    response.writeHead(500).end(error instanceof Error ? error.message : '');
+  }
+}
+
+function parseUnsignedTransaction(
+  serialized: string,
+): ethers.providers.TransactionRequest {
+  const parsed = ethers.utils.parseTransaction(serialized);
+  return {
+    to: parsed.to ?? undefined,
+    nonce: parsed.nonce,
+    gasLimit: parsed.gasLimit,
+    gasPrice: parsed.gasPrice ?? undefined,
+    data: parsed.data,
+    value: parsed.value,
+    chainId: parsed.chainId,
+    type: parsed.type ?? undefined,
+    maxPriorityFeePerGas: parsed.maxPriorityFeePerGas ?? undefined,
+    maxFeePerGas: parsed.maxFeePerGas ?? undefined,
+    accessList: parsed.accessList ?? undefined,
+  };
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendJson(response: ServerResponse, body: unknown): void {
+  response.setHeader('content-type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+async function getTransactionsSince(
+  provider: ethers.providers.Provider,
+  firstBlock: number,
+): Promise<
+  Array<{
+    transaction: ethers.providers.TransactionResponse;
+    receipt: ethers.providers.TransactionReceipt;
+  }>
+> {
+  const transactions: Array<{
+    transaction: ethers.providers.TransactionResponse;
+    receipt: ethers.providers.TransactionReceipt;
+  }> = [];
+  const lastBlock = await provider.getBlockNumber();
+  for (let blockNumber = firstBlock; blockNumber <= lastBlock; blockNumber++) {
+    const block = await provider.getBlockWithTransactions(blockNumber);
+    for (const transaction of block.transactions) {
+      transactions.push({
+        transaction,
+        receipt: await provider.getTransactionReceipt(transaction.hash),
+      });
+    }
+  }
+  return transactions;
+}

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -638,7 +638,11 @@ export {
 export { EV5GnosisSafeTxBuilder } from './providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.js';
 export { EV5GnosisSafeTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.js';
 export { EV5ImpersonatedAccountTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.js';
-export { EV5JsonRpcTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.js';
+export {
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
+  EV5SubmittedTransaction,
+} from './providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.js';
 export { EV5TxSubmitterInterface } from './providers/transactions/submitter/ethersV5/EV5TxSubmitterInterface.js';
 export { EvmIcaTxSubmitter } from './providers/transactions/submitter/IcaTxSubmitter.js';
 export {

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
@@ -1,0 +1,141 @@
+import { expect } from 'chai';
+import {
+  ContractReceipt,
+  ContractTransaction,
+  Wallet,
+  providers,
+} from 'ethers';
+import sinon from 'sinon';
+
+import { TestChainName } from '../../../../consts/testChains.js';
+import { randomAddress } from '../../../../test/testUtils.js';
+import { MultiProvider } from '../../../MultiProvider.js';
+
+import {
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
+} from './EV5JsonRpcTxSubmitter.js';
+
+describe('EV5JsonRpcTxSubmitter', () => {
+  const chain = TestChainName.test1;
+  const chainId = 9913371;
+  const props = { type: 'jsonRpc' as const, chain };
+  const tx = { chainId, to: randomAddress() };
+
+  let multiProvider: MultiProvider;
+  let mainSigner: Wallet;
+  let explicitSigner: Wallet;
+  let connectedExplicitSigner: Wallet;
+  let prepareTx: sinon.SinonStub;
+
+  beforeEach(() => {
+    const provider = new providers.JsonRpcProvider('http://127.0.0.1:8545');
+    mainSigner = Wallet.createRandom().connect(provider);
+    explicitSigner = Wallet.createRandom();
+    connectedExplicitSigner = explicitSigner.connect(provider);
+    multiProvider = MultiProvider.createTestMultiProvider({
+      signer: mainSigner,
+      provider,
+    });
+
+    sinon.stub(explicitSigner, 'connect').returns(connectedExplicitSigner);
+    prepareTx = sinon
+      .stub(multiProvider, 'prepareTx')
+      .callsFake(async (_, request) => request);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('uses an explicit signer instead of the MultiProvider signer', async () => {
+    const response = transactionResponse('0x01');
+    const receipt = transactionReceipt('0x01', 1);
+    const explicitSend = sinon
+      .stub(connectedExplicitSigner, 'sendTransaction')
+      .resolves(response);
+    const mainSend = sinon.stub(mainSigner, 'sendTransaction');
+    sinon.stub(multiProvider, 'handleTx').resolves(receipt);
+
+    const submitter = new EV5JsonRpcTxSubmitter(
+      multiProvider,
+      props,
+      explicitSigner,
+    );
+
+    expect(await submitter.submit(tx)).to.deep.equal([receipt]);
+    expect(explicitSend.calledOnce).to.equal(true);
+    expect(mainSend.called).to.equal(false);
+    expect(
+      prepareTx.calledWith(chain, sinon.match.object, explicitSigner.address),
+    ).to.equal(true);
+  });
+
+  it('fails when a receipt has status zero', async () => {
+    const response = transactionResponse('0x02');
+    const receipt = transactionReceipt('0x02', 0);
+    sinon.stub(connectedExplicitSigner, 'sendTransaction').resolves(response);
+    sinon.stub(multiProvider, 'handleTx').resolves(receipt);
+
+    const error = await captureSubmissionError(
+      new EV5JsonRpcTxSubmitter(multiProvider, props, explicitSigner).submit(
+        tx,
+      ),
+    );
+
+    expect(error.submittedTransactions).to.deep.equal([
+      { transactionHash: response.hash, receipt },
+    ]);
+  });
+
+  it('retains confirmed receipts and the pending hash on partial failure', async () => {
+    const firstResponse = transactionResponse('0x03');
+    const secondResponse = transactionResponse('0x04');
+    const firstReceipt = transactionReceipt('0x03', 1);
+    sinon
+      .stub(connectedExplicitSigner, 'sendTransaction')
+      .onFirstCall()
+      .resolves(firstResponse)
+      .onSecondCall()
+      .resolves(secondResponse);
+    sinon
+      .stub(multiProvider, 'handleTx')
+      .onFirstCall()
+      .resolves(firstReceipt)
+      .onSecondCall()
+      .rejects(new Error('confirmation timeout'));
+
+    const error = await captureSubmissionError(
+      new EV5JsonRpcTxSubmitter(multiProvider, props, explicitSigner).submit(
+        tx,
+        tx,
+      ),
+    );
+
+    expect(error.submittedTransactions).to.deep.equal([
+      { transactionHash: firstResponse.hash, receipt: firstReceipt },
+      { transactionHash: secondResponse.hash },
+    ]);
+    expect(error.isRecoverable).to.equal(false);
+  });
+});
+
+async function captureSubmissionError(
+  submission: Promise<unknown>,
+): Promise<EV5JsonRpcSubmissionError> {
+  try {
+    await submission;
+  } catch (error) {
+    if (error instanceof EV5JsonRpcSubmissionError) return error;
+    throw error;
+  }
+  throw new Error('Expected submission to fail');
+}
+
+function transactionResponse(hash: string): ContractTransaction {
+  // CAST: minimal ethers response test double; only hash is read before handleTx.
+  return { hash } as ContractTransaction;
+}
+
+function transactionReceipt(hash: string, status: number): ContractReceipt {
+  // CAST: minimal ethers receipt test double; only hash/status are inspected.
+  return { transactionHash: hash, status } as ContractReceipt;
+}

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
@@ -69,6 +69,42 @@ describe('EV5JsonRpcTxSubmitter', () => {
     ).to.equal(true);
   });
 
+  it('uses the MultiProvider signer when no explicit signer is supplied', async () => {
+    const response = transactionResponse('0x05');
+    const receipt = transactionReceipt('0x05', 1);
+    const mainSend = sinon
+      .stub(mainSigner, 'sendTransaction')
+      .resolves(response);
+    sinon.stub(multiProvider, 'handleTx').resolves(receipt);
+
+    const submitter = new EV5JsonRpcTxSubmitter(multiProvider, props);
+
+    expect(await submitter.submit(tx)).to.deep.equal([receipt]);
+    expect(mainSend.calledOnce).to.equal(true);
+    expect(
+      prepareTx.calledWith(chain, sinon.match.object, mainSigner.address),
+    ).to.equal(true);
+  });
+
+  it('validates the complete batch before broadcasting', async () => {
+    const explicitSend = sinon.stub(connectedExplicitSigner, 'sendTransaction');
+    const submitter = new EV5JsonRpcTxSubmitter(
+      multiProvider,
+      props,
+      explicitSigner,
+    );
+
+    let error: Error | undefined;
+    try {
+      await submitter.submit(tx, { ...tx, chainId: chainId + 1 });
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+
+    expect(error?.message).to.include('does not match submitter chainId');
+    expect(explicitSend.called).to.equal(false);
+  });
+
   it('fails when a receipt has status zero', async () => {
     const response = transactionResponse('0x02');
     const receipt = transactionReceipt('0x02', 0);

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -28,7 +28,7 @@ export class EV5JsonRpcSubmissionError extends Error {
     message: string,
     public readonly submittedTransactions: EV5SubmittedTransaction[],
     public readonly cause: unknown,
-    isRecoverable = submittedTransactions.length === 0,
+    isRecoverable: boolean,
   ) {
     super(message);
     this.isRecoverable = isRecoverable;
@@ -54,6 +54,15 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
     const receipts: TransactionReceipt[] = [];
     const submittedTransactions: EV5SubmittedTransaction[] = [];
     const submitterChainId = this.multiProvider.getChainId(this.props.chain);
+
+    for (const tx of txs) {
+      assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
+      assert(
+        tx.chainId === submitterChainId,
+        `Transaction chainId ${tx.chainId} does not match submitter chainId ${submitterChainId}`,
+      );
+    }
+
     const provider = this.multiProvider.getProvider(this.props.chain);
     const signer = this.signer
       ? this.signer.provider === provider
@@ -63,12 +72,6 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
     const signerAddress = await signer.getAddress();
 
     for (const tx of txs) {
-      assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
-      assert(
-        tx.chainId === submitterChainId,
-        `Transaction chainId ${tx.chainId} does not match submitter chainId ${submitterChainId}`,
-      );
-
       let broadcastAttempted = false;
       try {
         const { annotation, ...populatedTx } = tx;

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -1,8 +1,8 @@
 import { TransactionReceipt } from '@ethersproject/providers';
-import { ContractReceipt } from 'ethers';
+import { ContractReceipt, Signer } from 'ethers';
 import { Logger } from 'pino';
 
-import { assert, rootLogger } from '@hyperlane-xyz/utils';
+import { assert, formatError, rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../../../MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
@@ -10,6 +10,30 @@ import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
 import { EV5JsonRpcTxSubmitterProps } from './types.js';
+
+export interface EV5SubmittedTransaction {
+  transactionHash: string;
+  receipt?: TransactionReceipt;
+}
+
+/**
+ * Retains irreversible progress when a sequential JSON-RPC batch fails.
+ * A record without a receipt was broadcast but not confirmed before the error.
+ */
+export class EV5JsonRpcSubmissionError extends Error {
+  readonly name = 'EV5JsonRpcSubmissionError';
+  readonly isRecoverable: boolean;
+
+  constructor(
+    message: string,
+    public readonly submittedTransactions: EV5SubmittedTransaction[],
+    public readonly cause: unknown,
+    isRecoverable = submittedTransactions.length === 0,
+  ) {
+    super(message);
+    this.isRecoverable = isRecoverable;
+  }
+}
 
 export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   public readonly txSubmitterType: TxSubmitterType = TxSubmitterType.JSON_RPC;
@@ -21,27 +45,69 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   constructor(
     public readonly multiProvider: MultiProvider,
     public readonly props: EV5JsonRpcTxSubmitterProps,
+    public readonly signer?: Signer,
   ) {}
 
   public async submit(
     ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
+    const submittedTransactions: EV5SubmittedTransaction[] = [];
     const submitterChainId = this.multiProvider.getChainId(this.props.chain);
+    const provider = this.multiProvider.getProvider(this.props.chain);
+    const signer = this.signer
+      ? this.signer.provider === provider
+        ? this.signer
+        : this.signer.connect(provider)
+      : this.multiProvider.getSigner(this.props.chain);
+    const signerAddress = await signer.getAddress();
+
     for (const tx of txs) {
       assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
       assert(
         tx.chainId === submitterChainId,
         `Transaction chainId ${tx.chainId} does not match submitter chainId ${submitterChainId}`,
       );
-      const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
-        this.props.chain,
-        tx,
-      );
-      this.logger.debug(
-        `Submitted PopulatedTransaction on ${this.props.chain}: ${receipt.transactionHash}`,
-      );
-      receipts.push(receipt);
+
+      let broadcastAttempted = false;
+      try {
+        const { annotation, ...populatedTx } = tx;
+        if (annotation) this.logger.info(annotation);
+
+        const txRequest = await this.multiProvider.prepareTx(
+          this.props.chain,
+          populatedTx,
+          signerAddress,
+        );
+        broadcastAttempted = true;
+        const response = await signer.sendTransaction(txRequest);
+        const submittedTransaction: EV5SubmittedTransaction = {
+          transactionHash: response.hash,
+        };
+        submittedTransactions.push(submittedTransaction);
+        this.logger.info(`Sent tx ${response.hash}`);
+
+        const receipt: ContractReceipt = await this.multiProvider.handleTx(
+          this.props.chain,
+          response,
+        );
+        submittedTransaction.receipt = receipt;
+        assert(
+          receipt.status === 1,
+          `Transaction ${receipt.transactionHash} reverted`,
+        );
+        this.logger.debug(
+          `Submitted PopulatedTransaction on ${this.props.chain}: ${receipt.transactionHash}`,
+        );
+        receipts.push(receipt);
+      } catch (error) {
+        throw new EV5JsonRpcSubmissionError(
+          `Failed to submit JSON-RPC transaction batch on ${this.props.chain}: ${formatError(error)}`,
+          submittedTransactions,
+          error,
+          !broadcastAttempted && submittedTransactions.length === 0,
+        );
+      }
     }
     return receipts;
   }

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -801,8 +801,9 @@ const FIELDS_TO_IGNORE = new Set<keyof HypTokenRouterConfig>([
 ]);
 
 // Nested LinearFee sub-fee owners are intentionally excluded from the warp
-// check. A LinearFee owner's only lever is setFee (bps), and bps is compared
-// directly, so its owner carries no additional security-relevant authority.
+// check. LinearFee pricing parameters are immutable, and transfer fees accrue
+// at the top-level RoutingFee, so its owner has no live pricing or treasury
+// authority over the route.
 // Collapsing nested LinearFee owners to a fixed sentinel on both sides of the
 // diff makes that owner drift invisible while the top-level RoutingFee owner
 // (which controls setFeeContract routing and claim) still diffs normally.


### PR DESCRIPTION
## Summary
- inject an explicit signer into EVM JSON-RPC submitters without changing MultiProvider signers
- add `warp apply --fee-turnkey-config` with private-file validation and Turnkey health checking
- preflight only in-scope, direct JSON-RPC fee strategies before planning: chain binding, recursive target/live fee ownership, and conservative gas balance
- allow zero and non-RoutingFee recipients to be replaced under the router-owner submission path
- preserve partial broadcast results, validate complete batches before broadcasting, and exit nonzero on fee submission failures

## Tests
- SDK, CLI, and dependency builds
- SDK/CLI typechecks and lint
- focused SDK/CLI unit tests covering batch prevalidation, legacy signer fallback, apply scope, chain binding, replacement recipients, gas balance, and nested fee owners
- EVM warp-apply integration test with separate deployer and mocked Turnkey fee signer