### PR TITLE
fix(sdk): match timelock admin role

### DIFF
--- a/typescript/sdk/src/timelock/evm/constants.ts
+++ b/typescript/sdk/src/timelock/evm/constants.ts
@@ -6,4 +6,6 @@ export const EMPTY_BYTES_32 =
 export const PROPOSER_ROLE: string = keccak256(Buffer.from('PROPOSER_ROLE'));
 export const EXECUTOR_ROLE: string = keccak256(Buffer.from('EXECUTOR_ROLE'));
 export const CANCELLER_ROLE: string = keccak256(Buffer.from('CANCELLER_ROLE'));
-export const TIMELOCK_ADMIN_ROLE: string = EMPTY_BYTES_32;
+export const TIMELOCK_ADMIN_ROLE: string = keccak256(
+  Buffer.from('TIMELOCK_ADMIN_ROLE'),
+);

--- a/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.hardhat-test.ts
@@ -1210,6 +1210,44 @@ describe('EvmWarpModule', async () => {
       expect(txs.length).to.equal(0);
     });
 
+    it('should reuse a configured ProxyAdmin timelock', async () => {
+      const config: HypTokenRouterConfig = {
+        ...baseConfig,
+        type: TokenType.native,
+      };
+      const evmWarpModule = await EvmWarpModule.create({
+        chain,
+        config: {
+          ...config,
+          interchainSecurityModule: ismAddress,
+        },
+        multiProvider,
+        proxyFactoryFactories: ismFactoryAddresses,
+      });
+      const timelockConfig = {
+        delay: 259_200,
+        roles: {
+          proposer: signer.address,
+          executor: signer.address,
+        },
+      };
+
+      const firstUpdate = await evmWarpModule.updateSplit({
+        ...config,
+        timelock: timelockConfig,
+      });
+      expect(firstUpdate.ownershipTxs.length).to.equal(1);
+      await sendTxs(firstUpdate.ownershipTxs);
+
+      const secondUpdate = await evmWarpModule.updateSplit({
+        ...config,
+        timelock: timelockConfig,
+      });
+      expect(secondUpdate.txs).to.be.empty;
+      expect(secondUpdate.feeTxs).to.be.empty;
+      expect(secondUpdate.ownershipTxs).to.be.empty;
+    });
+
     it('should update the destination gas', async () => {
       const domain = 3;
       const config: HypTokenRouterConfig = {


### PR DESCRIPTION
Fixes the timelock idempotency failure exposed by #9244's merge-group run.

The pinned OpenZeppelin TimelockController defines `TIMELOCK_ADMIN_ROLE` as `keccak256("TIMELOCK_ADMIN_ROLE")`, not the zero `DEFAULT_ADMIN_ROLE`. The prior constant made every valid deployed timelock fail validation, so a rerun deployed a second controller and attempted an unauthorized ProxyAdmin ownership transfer.

Adds a Hardhat regression covering first apply plus idempotent re-plan.

Validation:
- focused Hardhat regression: 1 passing
- EvmWarpModule unit tests: 10 passing
- SDK build
- Prettier and diff check
- commit hooks