### PR TITLE
fix: register irregular Ethereum timelock

### DIFF
--- a/typescript/infra/config/environments/mainnet3/governance/timelock/irregular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/timelock/irregular.ts
@@ -1,0 +1,7 @@
+import { ChainMap } from '@hyperlane-xyz/sdk';
+import { Address } from '@hyperlane-xyz/utils';
+
+export const irregularTimelocks: ChainMap<Address> = {
+  // Apr 18, 2025 - Timelock for the Ethereum "Irregular" Safe
+  ethereum: '0xfa842F02439AF6D91D7d44525956f9E5E00e339F',
+};

--- a/typescript/infra/config/environments/mainnet3/governance/timelock/irregular.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/timelock/irregular.ts
@@ -3,5 +3,5 @@ import { Address } from '@hyperlane-xyz/utils';
 
 export const irregularTimelocks: ChainMap<Address> = {
   // Apr 18, 2025 - Timelock for the Ethereum "Irregular" Safe
-  ethereum: '0xfa842F02439AF6D91D7d44525956f9E5E00e339F',
+  ethereum: '0xfA842f02439Af6d91d7D44525956F9E5e00e339f',
 };

--- a/typescript/infra/config/environments/mainnet3/governance/utils.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/utils.ts
@@ -28,6 +28,7 @@ import {
 } from './signers/regular.js';
 import { warpFeesSigners, warpFeesThreshold } from './signers/warpFees.js';
 import { awTimelocks } from './timelock/aw.js';
+import { irregularTimelocks } from './timelock/irregular.js';
 import { regularTimelocks } from './timelock/regular.js';
 
 export function getGovernanceTimelocks(governanceType: GovernanceType) {
@@ -39,7 +40,7 @@ export function getGovernanceTimelocks(governanceType: GovernanceType) {
     case GovernanceType.WarpFees:
       return {};
     case GovernanceType.Irregular:
-      return {};
+      return irregularTimelocks;
     case GovernanceType.OUSDT:
       return {};
     default:

--- a/typescript/infra/test/governance-timelocks.test.ts
+++ b/typescript/infra/test/governance-timelocks.test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+
+import { GovernanceType } from '../src/governanceTypes.js';
+import { getGovernanceTimelocks } from '../config/environments/mainnet3/governance/utils.js';
+
+describe('mainnet3 governance timelocks', () => {
+  it('associates the irregular Ethereum timelock with irregular governance', () => {
+    expect(getGovernanceTimelocks(GovernanceType.Irregular)).to.deep.equal({
+      ethereum: '0xfa842F02439AF6D91D7d44525956f9E5E00e339F',
+    });
+  });
+});

--- a/typescript/infra/test/governance-timelocks.test.ts
+++ b/typescript/infra/test/governance-timelocks.test.ts
@@ -1,12 +1,15 @@
 import { expect } from 'chai';
+import { isValidAddressEvm } from '@hyperlane-xyz/utils';
 
 import { GovernanceType } from '../src/governanceTypes.js';
 import { getGovernanceTimelocks } from '../config/environments/mainnet3/governance/utils.js';
 
 describe('mainnet3 governance timelocks', () => {
   it('associates the irregular Ethereum timelock with irregular governance', () => {
-    expect(getGovernanceTimelocks(GovernanceType.Irregular)).to.deep.equal({
-      ethereum: '0xfa842F02439AF6D91D7d44525956f9E5E00e339F',
+    const timelocks = getGovernanceTimelocks(GovernanceType.Irregular);
+    expect(timelocks).to.deep.equal({
+      ethereum: '0xfA842f02439Af6d91d7D44525956F9E5e00e339f',
     });
+    expect(isValidAddressEvm(timelocks.ethereum!)).to.equal(true);
   });
 });


### PR DESCRIPTION
## Description

Registers the existing Ethereum TimelockController used by irregular governance and returns it from `getGovernanceTimelocks(GovernanceType.Irregular)`.

Onchain review found a 14-day delay, the existing irregular 5/7 Safe as sole proposer, open execution, self-admin after deployer renunciation, and a separate 3/5 Safe with cancellation authority. This records the controller address only; it does not alter role membership or governance execution.

## Drive-by changes

None.

## Related issues

This unblocks trusted Heimdall parsing of the existing irregular-governance timelock proposal.

## Backward compatibility

Additive configuration only. Existing governance mappings and execution behavior are unchanged.

## Testing

- focused Mocha test: 1 passed
- dependency build: 22/22 packages
- `pnpm -C typescript/infra check`
- staged oxlint/oxfmt and gitleaks hooks