### PR TITLE
feat(solidity): exact-in fee quoting for warp routes

### DIFF
--- a/.changeset/exact-in-fee-quoting.md
+++ b/.changeset/exact-in-fee-quoting.md
@@ -1,0 +1,9 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Added exact-in fee quoting for warp route fee contracts. A new `IExactInFee` capability interface exposes `quoteTransferRemoteFrom`, which inverts the exact-out `quoteTransferRemote`: given a spend budget in the collateral token, it returns the largest deliverable `amount` such that `amount + fee(amount) <= budget`.
+
+- Added the `IExactInFee` interface to `ITokenBridge.sol` and a `BaseFee` default that reverts with `ExactInNotSupported` for fee curves that are not invertible.
+- Implemented a closed-form capped-linear inverse in `LinearFee` (no binary search), reused by `OffchainQuotedLinearFee`, which resolves the active linear params through the same transient → standing → immutable cascade as the forward quote before inverting.
+- Extended `ICrossCollateralFee` / `CrossCollateralRoutingFee` with router-aware `quoteTransferRemoteFromTo`, and added budget-based `quoteTransferRemoteFrom` / `transferRemoteFrom` (with a `minAmountOut` slippage guard) to `CrossCollateralRouter`, plus the delegating override on `PredicateCrossCollateralRouterWrapper`.

--- a/solidity/contracts/interfaces/ITokenBridge.sol
+++ b/solidity/contracts/interfaces/ITokenBridge.sol
@@ -24,6 +24,26 @@ interface ITokenFee {
     ) external view returns (Quote[] memory quotes);
 }
 
+interface IExactInFee {
+    /**
+     * @notice Given a maximum spend budget, return the largest transfer amount
+     *         whose amount + fee fits within that budget (exact-in quoting).
+     * @param _destination The destination domain of the message
+     * @param _recipient The message recipient address on `destination`
+     * @param _maxSpend The maximum amount of `token` the sender is willing to
+     *        spend on amount + fee combined (gas is quoted separately).
+     * @return _amount The largest deliverable amount such that
+     *         `_amount + fee(_amount) <= _maxSpend`.
+     * @dev Inverse of `ITokenFee.quoteTransferRemote`. Only supported by fee
+     *      contracts backed by a monotonic, invertible fee curve.
+     */
+    function quoteTransferRemoteFrom(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend
+    ) external view returns (uint256 _amount);
+}
+
 interface ITokenBridge is ITokenFee {
     /**
      * @notice Transfer value to another domain

--- a/solidity/contracts/token/CrossCollateralRouter.sol
+++ b/solidity/contracts/token/CrossCollateralRouter.sol
@@ -555,6 +555,91 @@ contract CrossCollateralRouter is
         });
     }
 
+    // ============ Exact-In (budget-based) Quoting & Transfer ============
+    // Inverse of the exact-out (`quoteTransferRemoteTo`/`transferRemoteTo`) flow.
+    // Given a `_maxSpend` budget in `token()`, resolve the largest deliverable
+    // `amount` such that `amount + fee(amount) <= _maxSpend`. Gas (quotes[0]) is
+    // denominated separately and is not part of the collateral budget.
+    // externalFee is 0 on CrossCollateralRouter, so `charge == amount + fee`.
+
+    /// @notice Exact-in quote to the primary enrolled router for `_destination`.
+    function quoteTransferRemoteFrom(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend
+    ) external view returns (uint256 amount) {
+        bytes32 targetRouter = _mustHaveRemoteRouter(_destination);
+        return
+            quoteTransferRemoteFromTo(
+                _destination,
+                _recipient,
+                _maxSpend,
+                targetRouter
+            );
+    }
+
+    /// @inheritdoc ICrossCollateralFee
+    function quoteTransferRemoteFromTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        bytes32 _targetRouter
+    ) public view override returns (uint256 amount) {
+        _requireAuthorizedRouter(_destination, _targetRouter);
+        address _feeRecipient = feeRecipient();
+        if (_feeRecipient == address(0)) return _maxSpend;
+        return
+            ICrossCollateralFee(_feeRecipient).quoteTransferRemoteFromTo(
+                _destination,
+                _recipient,
+                _maxSpend,
+                _targetRouter
+            );
+    }
+
+    /// @notice Exact-in transfer to the primary enrolled router for `_destination`.
+    function transferRemoteFrom(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        uint256 _minAmountOut
+    ) external payable returns (bytes32 messageId) {
+        bytes32 targetRouter = _mustHaveRemoteRouter(_destination);
+        return
+            transferRemoteFromTo(
+                _destination,
+                _recipient,
+                _maxSpend,
+                _minAmountOut,
+                targetRouter
+            );
+    }
+
+    /**
+     * @notice Exact-in transfer: spend up to `_maxSpend` (amount + fee), deliver
+     *         the resolved amount to `_recipient` on `_targetRouter`.
+     * @param _minAmountOut Slippage guard — reverts if the resolved amount would
+     *        drop below this (e.g. the active quote curve changed between quote
+     *        and execution).
+     */
+    function transferRemoteFromTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        uint256 _minAmountOut,
+        bytes32 _targetRouter
+    ) public payable returns (bytes32 messageId) {
+        uint256 amount = quoteTransferRemoteFromTo(
+            _destination,
+            _recipient,
+            _maxSpend,
+            _targetRouter
+        );
+        require(amount >= _minAmountOut, "CCR: amountOut below min");
+        return
+            transferRemoteTo(_destination, _recipient, amount, _targetRouter);
+    }
+
     /// @dev Target-router-aware gas quote helper. Avoids Router._mustHaveRemoteRouter().
     /// Caller must validate `_targetRouter` is authorized for `_destination`.
     function _quoteGasPaymentTo(

--- a/solidity/contracts/token/CrossCollateralRoutingFee.sol
+++ b/solidity/contracts/token/CrossCollateralRoutingFee.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {ICrossCollateralFee} from "./interfaces/ICrossCollateralFee.sol";
-import {ITokenFee, Quote} from "../interfaces/ITokenBridge.sol";
+import {ITokenFee, IExactInFee, Quote} from "../interfaces/ITokenBridge.sol";
 import {PackageVersioned} from "../PackageVersioned.sol";
 import {FeeType} from "./fees/BaseFee.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
@@ -21,6 +21,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 contract CrossCollateralRoutingFee is
     ICrossCollateralFee,
     ITokenFee,
+    IExactInFee,
     Ownable,
     PackageVersioned
 {
@@ -136,6 +137,73 @@ contract CrossCollateralRoutingFee is
                     _destination,
                     _recipient,
                     _amount
+                );
+        }
+        // 3. No fee configured for router or destination default
+        revert("CCRF: no fee contract");
+    }
+
+    /**
+     * @inheritdoc IExactInFee
+     * @dev Exact-in quote using DEFAULT_ROUTER sentinel.
+     */
+    function quoteTransferRemoteFrom(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend
+    ) external view override returns (uint256) {
+        return
+            _quoteTransferRemoteFrom(
+                _destination,
+                _recipient,
+                _maxSpend,
+                DEFAULT_ROUTER
+            );
+    }
+
+    /**
+     * @inheritdoc ICrossCollateralFee
+     * @dev Routes: specific router → destination default (DEFAULT_ROUTER).
+     */
+    function quoteTransferRemoteFromTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        bytes32 _targetRouter
+    ) external view override returns (uint256) {
+        return
+            _quoteTransferRemoteFrom(
+                _destination,
+                _recipient,
+                _maxSpend,
+                _targetRouter
+            );
+    }
+
+    function _quoteTransferRemoteFrom(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        bytes32 _targetRouter
+    ) internal view returns (uint256) {
+        // 1. Check per-router fee
+        address routerFee = feeContracts[_destination][_targetRouter];
+        if (routerFee != address(0)) {
+            return
+                IExactInFee(routerFee).quoteTransferRemoteFrom(
+                    _destination,
+                    _recipient,
+                    _maxSpend
+                );
+        }
+        // 2. Fallback to destination default
+        address destFee = feeContracts[_destination][DEFAULT_ROUTER];
+        if (destFee != address(0)) {
+            return
+                IExactInFee(destFee).quoteTransferRemoteFrom(
+                    _destination,
+                    _recipient,
+                    _maxSpend
                 );
         }
         // 3. No fee configured for router or destination default

--- a/solidity/contracts/token/extensions/PredicateCrossCollateralRouterWrapper.sol
+++ b/solidity/contracts/token/extensions/PredicateCrossCollateralRouterWrapper.sol
@@ -152,6 +152,25 @@ contract PredicateCrossCollateralRouterWrapper is
             );
     }
 
+    /**
+     * @notice Exact-in quote to a specific target router by delegating to the
+     * underlying cross collateral router.
+     */
+    function quoteTransferRemoteFromTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        bytes32 _targetRouter
+    ) external view override returns (uint256) {
+        return
+            CrossCollateralRouter(address(warpRoute)).quoteTransferRemoteFromTo(
+                _destination,
+                _recipient,
+                _maxSpend,
+                _targetRouter
+            );
+    }
+
     // ============ Internal Overrides ============
 
     function _emitTransferAuthorized(

--- a/solidity/contracts/token/fees/BaseFee.sol
+++ b/solidity/contracts/token/fees/BaseFee.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import {ITokenFee, Quote} from "../../interfaces/ITokenBridge.sol";
+import {ITokenFee, IExactInFee, Quote} from "../../interfaces/ITokenBridge.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -18,9 +18,12 @@ enum FeeType {
     OFFCHAIN_QUOTED_LINEAR
 }
 
-abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
+abstract contract BaseFee is Ownable, ITokenFee, IExactInFee, PackageVersioned {
     using Address for address payable;
     using SafeERC20 for IERC20;
+
+    /// @notice Thrown when a fee curve does not support exact-in inversion.
+    error ExactInNotSupported();
 
     /**
      * @notice The ERC20 token for which this fee contract applies.
@@ -77,6 +80,27 @@ abstract contract BaseFee is Ownable, ITokenFee, PackageVersioned {
         uint256 /*_amount*/
     ) internal view virtual returns (uint256 fee) {
         return 0;
+    }
+
+    /// @inheritdoc IExactInFee
+    function quoteTransferRemoteFrom(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend
+    ) external view virtual returns (uint256 _amount) {
+        return _maxAmountForSpend(_destination, _recipient, _maxSpend);
+    }
+
+    /**
+     * @dev Inverse of `_quoteTransfer`: largest amount fitting `_maxSpend`.
+     *      Defaults to reverting; overridden by invertible fee curves.
+     */
+    function _maxAmountForSpend(
+        uint32 /*_destination*/,
+        bytes32 /*_recipient*/,
+        uint256 /*_maxSpend*/
+    ) internal view virtual returns (uint256) {
+        revert ExactInNotSupported();
     }
 
     function feeType() external view virtual returns (FeeType);

--- a/solidity/contracts/token/fees/LinearFee.sol
+++ b/solidity/contracts/token/fees/LinearFee.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.0;
 
 import {BaseFee, FeeType} from "./BaseFee.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title Linear Fee Structure
@@ -43,6 +44,56 @@ contract LinearFee is BaseFee {
         if (maxFee_ == 0 || halfAmount_ == 0) return 0;
         uint256 uncapped = (amount * maxFee_) / (2 * halfAmount_);
         return uncapped > maxFee_ ? maxFee_ : uncapped;
+    }
+
+    function _maxAmountForSpend(
+        uint32 /*_destination*/,
+        bytes32 /*_recipient*/,
+        uint256 _maxSpend
+    ) internal view virtual override returns (uint256) {
+        return _invertCappedLinear(maxFee, halfAmount, _maxSpend);
+    }
+
+    /**
+     * @notice Closed-form inverse of the capped-linear fee curve.
+     * @dev Returns the largest `amount` with `amount + fee(amount) <= maxSpend`,
+     *      where `fee` is `_computeLinearFee(maxFee_, halfAmount_, amount)`.
+     *
+     *      The forward charge `T(a) = a + min(maxFee_, floor(a*maxFee_/D))`,
+     *      with `D = 2*halfAmount_`, is nondecreasing, so the inverse is well
+     *      defined. Two regions:
+     *        - Capped (`a >= D`): `fee == maxFee_`, so `T(a) = a + maxFee_`.
+     *          Solved exactly by `a = maxSpend - maxFee_` when
+     *          `maxSpend >= D + maxFee_`.
+     *        - Uncapped (`a < D`): `T` has slope `(D + maxFee_)/D`. The continuous
+     *          inverse `floor(maxSpend*D/(D+maxFee_))` is always feasible and
+     *          undershoots the true integer answer by at most one (a single
+     *          floor in `fee`), corrected by a bounded +1 fixup.
+     */
+    function _invertCappedLinear(
+        uint256 maxFee_,
+        uint256 halfAmount_,
+        uint256 maxSpend
+    ) internal pure returns (uint256) {
+        // Degenerate curve: fee is always zero, so the whole budget is amount.
+        if (maxFee_ == 0 || halfAmount_ == 0) return maxSpend;
+
+        uint256 D = 2 * halfAmount_;
+
+        // Capped region: fee saturates at maxFee_ once amount >= D.
+        if (maxSpend >= D + maxFee_) {
+            return maxSpend - maxFee_;
+        }
+
+        // Uncapped region. mulDiv avoids intermediate overflow.
+        uint256 amount = Math.mulDiv(maxSpend, D, D + maxFee_);
+        if (
+            amount + 1 + _computeLinearFee(maxFee_, halfAmount_, amount + 1) <=
+            maxSpend
+        ) {
+            amount += 1;
+        }
+        return amount;
     }
 
     function feeType() external pure virtual override returns (FeeType) {

--- a/solidity/contracts/token/fees/OffchainQuotedLinearFee.sol
+++ b/solidity/contracts/token/fees/OffchainQuotedLinearFee.sol
@@ -196,6 +196,69 @@ contract OffchainQuotedLinearFee is AbstractOffchainQuoter, LinearFee {
         return _singleQuote(_computeLinearFee(maxFee, halfAmount, _amount));
     }
 
+    // ============ IExactInFee ============
+
+    // Resolve the active linear params via the same cascade as the forward
+    // quote, then invert the capped-linear curve for the given spend budget.
+    // The transient quote is only usable when its amount is wildcard: a point
+    // (specific-amount) transient quote does not define a curve to invert.
+    function _maxAmountForSpend(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend
+    ) internal view override returns (uint256) {
+        (uint256 maxFee_, uint256 halfAmount_) = _resolveLinearParams(
+            _destination,
+            _recipient
+        );
+        return _invertCappedLinear(maxFee_, halfAmount_, _maxSpend);
+    }
+
+    // Mirror of the quoteTransferRemote resolution cascade, returning the linear
+    // params (maxFee, halfAmount) of the winning quote instead of a fee.
+    function _resolveLinearParams(
+        uint32 _destination,
+        bytes32 _recipient
+    ) private view returns (uint256 maxFee_, uint256 halfAmount_) {
+        // 1. Transient quote — only when amount is wildcard (curve, not point).
+        if (TRANSIENT_QUOTED_SLOT.loadBool()) {
+            uint32 dest = TRANSIENT_DESTINATION_SLOT.loadUint32();
+            bytes32 recipient = TRANSIENT_RECIPIENT_SLOT.loadBytes32();
+            uint256 amount = TRANSIENT_AMOUNT_SLOT.loadUint256();
+            if (
+                (dest == WILDCARD_DEST || dest == _destination) &&
+                (recipient == WILDCARD_RECIPIENT || recipient == _recipient) &&
+                amount == WILDCARD_AMOUNT
+            ) {
+                return (
+                    TRANSIENT_MAX_FEE_SLOT.loadUint256(),
+                    TRANSIENT_HALF_AMOUNT_SLOT.loadUint256()
+                );
+            }
+        }
+
+        // 2. Specific: destination + recipient
+        StoredQuote storage sq = quotes[_destination][_recipient];
+        if (sq.expiry > 0 && uint48(block.timestamp) <= sq.expiry) {
+            return (sq.maxFee, sq.halfAmount);
+        }
+
+        // 3. Destination-only
+        sq = quotes[_destination][WILDCARD_RECIPIENT];
+        if (sq.expiry > 0 && uint48(block.timestamp) <= sq.expiry) {
+            return (sq.maxFee, sq.halfAmount);
+        }
+
+        // 4. Recipient-only
+        sq = quotes[WILDCARD_DEST][_recipient];
+        if (sq.expiry > 0 && uint48(block.timestamp) <= sq.expiry) {
+            return (sq.maxFee, sq.halfAmount);
+        }
+
+        // 5. Immutable LinearFee fallback
+        return (maxFee, halfAmount);
+    }
+
     // ============ Internal ============
 
     // Destination, recipient, and amount each support wildcard (type max).

--- a/solidity/contracts/token/interfaces/ICrossCollateralFee.sol
+++ b/solidity/contracts/token/interfaces/ICrossCollateralFee.sol
@@ -10,4 +10,16 @@ interface ICrossCollateralFee {
         uint256 _amount,
         bytes32 _targetRouter
     ) external view returns (Quote[] memory);
+
+    /**
+     * @notice Router-aware exact-in quote: largest deliverable amount whose
+     *         amount + fee fits within `_maxSpend`.
+     * @dev Inverse of `quoteTransferRemoteTo` on the fee (token) leg.
+     */
+    function quoteTransferRemoteFromTo(
+        uint32 _destination,
+        bytes32 _recipient,
+        uint256 _maxSpend,
+        bytes32 _targetRouter
+    ) external view returns (uint256 _amount);
 }

--- a/solidity/test/token/CrossCollateralRouter.t.sol
+++ b/solidity/test/token/CrossCollateralRouter.t.sol
@@ -72,6 +72,15 @@ contract MockDepositFee is ITokenFee, ICrossCollateralFee {
         quotes = new Quote[](1);
         quotes[0] = Quote(token, (_amount * feeBps) / 10000);
     }
+
+    function quoteTransferRemoteFromTo(
+        uint32,
+        bytes32,
+        uint256 _maxSpend,
+        bytes32 /*_targetRouter*/
+    ) external view override returns (uint256) {
+        return (_maxSpend * 10000) / (10000 + feeBps);
+    }
 }
 
 /// @notice Mock fee contract that implements only ICrossCollateralFee.
@@ -92,6 +101,15 @@ contract MockRouterOnlyFee is ICrossCollateralFee {
     ) external view override returns (Quote[] memory quotes) {
         quotes = new Quote[](1);
         quotes[0] = Quote(token, (_amount * feeBps) / 10000);
+    }
+
+    function quoteTransferRemoteFromTo(
+        uint32,
+        bytes32,
+        uint256 _maxSpend,
+        bytes32 /*_targetRouter*/
+    ) external view override returns (uint256) {
+        return (_maxSpend * 10000) / (10000 + feeBps);
     }
 }
 

--- a/solidity/test/token/LinearFeeExactIn.t.sol
+++ b/solidity/test/token/LinearFeeExactIn.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+
+import {LinearFee} from "../../contracts/token/fees/LinearFee.sol";
+import {BaseFee, FeeType} from "../../contracts/token/fees/BaseFee.sol";
+import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
+
+/// @dev Minimal BaseFee that does NOT override exact-in, to exercise the
+///      default `ExactInNotSupported` revert.
+contract UnsupportedExactInFee is BaseFee {
+    constructor(
+        address _token,
+        uint256 _maxFee,
+        uint256 _halfAmount,
+        address _owner
+    ) BaseFee(_token, _maxFee, _halfAmount, _owner) {}
+
+    function feeType() external pure override returns (FeeType) {
+        return FeeType.ZERO;
+    }
+}
+
+contract LinearFeeExactInTest is Test {
+    LinearFee fee;
+
+    address constant FEE_TOKEN = address(0xFEE);
+    address constant OWNER = address(0x111);
+
+    uint32 constant DEST = 42;
+    bytes32 constant RECIPIENT = bytes32(uint256(0xBEEF));
+
+    uint256 constant MAX_FEE = 0.01 ether;
+    uint256 constant HALF_AMOUNT = 0.5 ether; // cap reached at amount = 1 ether
+
+    function setUp() public {
+        fee = new LinearFee(FEE_TOKEN, MAX_FEE, HALF_AMOUNT, OWNER);
+    }
+
+    // Mirror of LinearFee._computeLinearFee.
+    function _fee(
+        uint256 maxFee_,
+        uint256 halfAmount_,
+        uint256 amount
+    ) internal pure returns (uint256) {
+        if (maxFee_ == 0 || halfAmount_ == 0) return 0;
+        uint256 uncapped = (amount * maxFee_) / (2 * halfAmount_);
+        return uncapped > maxFee_ ? maxFee_ : uncapped;
+    }
+
+    function _forwardFee(uint256 amount) internal view returns (uint256) {
+        Quote[] memory q = fee.quoteTransferRemote(DEST, RECIPIENT, amount);
+        return q[0].amount;
+    }
+
+    // amount + fee(amount) must fit the budget, and amount+1 must not: the
+    // returned amount is the exact-in maximum.
+    function _assertMaximal(uint256 maxSpend) internal view {
+        uint256 amount = fee.quoteTransferRemoteFrom(DEST, RECIPIENT, maxSpend);
+        assertLe(amount, maxSpend, "amount exceeds budget");
+        assertLe(amount + _forwardFee(amount), maxSpend, "charge over budget");
+        // amount + 1 must exceed the budget (no larger deliverable exists).
+        uint256 up = amount + 1;
+        assertGt(up + _forwardFee(up), maxSpend, "not maximal");
+    }
+
+    // ============ Deterministic boundaries ============
+
+    function test_exactIn_uncappedRegion() public view {
+        // Small budget: sits in the linear (uncapped) region, amount < 1 ether.
+        _assertMaximal(0.1 ether);
+    }
+
+    function test_exactIn_capBoundary() public view {
+        // Budget straddling the cap boundary (amount ~= 2*halfAmount).
+        _assertMaximal(1 ether + MAX_FEE);
+        _assertMaximal(1 ether + MAX_FEE - 1);
+        _assertMaximal(1 ether + MAX_FEE + 1);
+    }
+
+    function test_exactIn_cappedRegion() public view {
+        // Large budget: fee saturates at MAX_FEE, amount = maxSpend - MAX_FEE.
+        uint256 maxSpend = 100 ether;
+        uint256 amount = fee.quoteTransferRemoteFrom(DEST, RECIPIENT, maxSpend);
+        assertEq(amount, maxSpend - MAX_FEE);
+        _assertMaximal(maxSpend);
+    }
+
+    function test_exactIn_zeroBudget() public view {
+        assertEq(fee.quoteTransferRemoteFrom(DEST, RECIPIENT, 0), 0);
+    }
+
+    function test_exactIn_budgetBelowMaxFee() public view {
+        // Even when the budget is below MAX_FEE, the uncapped branch yields the
+        // largest feasible amount (fee grows with amount, so a small amount is
+        // still deliverable).
+        _assertMaximal(MAX_FEE / 2);
+        _assertMaximal(MAX_FEE);
+    }
+
+    // ============ Round-trip: exact-out then exact-in ============
+
+    function testFuzz_roundTrip_exactOutThenIn(uint256 amount) public view {
+        amount = bound(amount, 0, 1e30);
+        uint256 charge = amount + _forwardFee(amount);
+        // With budget == charge, we must be able to afford at least `amount`.
+        uint256 recovered = fee.quoteTransferRemoteFrom(
+            DEST,
+            RECIPIENT,
+            charge
+        );
+        assertGe(recovered, amount, "cannot recover exact-out amount");
+        // And recovered stays within budget.
+        assertLe(recovered + _forwardFee(recovered), charge);
+    }
+
+    // ============ Fuzz: maximality across the whole curve ============
+
+    function testFuzz_exactIn_isMaximal(uint256 maxSpend) public view {
+        maxSpend = bound(maxSpend, 0, 1e40);
+        _assertMaximal(maxSpend);
+    }
+
+    function testFuzz_exactIn_paramsAndBudget(
+        uint256 maxFee_,
+        uint256 halfAmount_,
+        uint256 maxSpend
+    ) public {
+        maxFee_ = bound(maxFee_, 1, 1e27);
+        halfAmount_ = bound(halfAmount_, 1, 1e27);
+        maxSpend = bound(maxSpend, 0, 1e40);
+
+        LinearFee f = new LinearFee(FEE_TOKEN, maxFee_, halfAmount_, OWNER);
+        uint256 amount = f.quoteTransferRemoteFrom(DEST, RECIPIENT, maxSpend);
+
+        assertLe(amount, maxSpend);
+        assertLe(amount + _fee(maxFee_, halfAmount_, amount), maxSpend);
+        uint256 up = amount + 1;
+        assertGt(up + _fee(maxFee_, halfAmount_, up), maxSpend);
+    }
+
+    // ============ BaseFee default revert ============
+
+    function test_exactIn_defaultReverts() public {
+        UnsupportedExactInFee unsupported = new UnsupportedExactInFee(
+            FEE_TOKEN,
+            MAX_FEE,
+            HALF_AMOUNT,
+            OWNER
+        );
+        vm.expectRevert(BaseFee.ExactInNotSupported.selector);
+        unsupported.quoteTransferRemoteFrom(DEST, RECIPIENT, 1 ether);
+    }
+}

--- a/solidity/test/token/OffchainQuotedLinearFee.t.sol
+++ b/solidity/test/token/OffchainQuotedLinearFee.t.sol
@@ -5,11 +5,43 @@ import {Test} from "forge-std/Test.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 import {OffchainQuotedLinearFee} from "../../contracts/token/fees/OffchainQuotedLinearFee.sol";
+import {LinearFee} from "../../contracts/token/fees/LinearFee.sol";
 import {FeeQuoteContext, FeeQuoteData} from "../../contracts/token/fees/OffchainQuotedLinearFee.sol";
 import {AbstractOffchainQuoter} from "../../contracts/libs/AbstractOffchainQuoter.sol";
 import {SignedQuote} from "../../contracts/interfaces/IOffchainQuoter.sol";
 import {FeeType} from "../../contracts/token/fees/BaseFee.sol";
 import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
+
+// Submits a transient quote and consumes it (exact-in + bracketing forward
+// quotes) within a single top-level call, mirroring the production flow where a
+// router submits and consumes a transient quote in the same transaction. Needed
+// because transient storage does not survive across separate top-level calls.
+contract ExactInHarness {
+    OffchainQuotedLinearFee public immutable quoter;
+
+    constructor(OffchainQuotedLinearFee _quoter) {
+        quoter = _quoter;
+    }
+
+    function submitAndExactIn(
+        SignedQuote calldata sq,
+        bytes calldata sig,
+        uint32 destination,
+        bytes32 recipient,
+        uint256 maxSpend
+    ) external returns (uint256 amount, uint256 feeAt, uint256 feeAtPlus1) {
+        quoter.submitQuote(sq, sig);
+        amount = quoter.quoteTransferRemoteFrom(
+            destination,
+            recipient,
+            maxSpend
+        );
+        feeAt = quoter
+        .quoteTransferRemote(destination, recipient, amount)[0].amount;
+        feeAtPlus1 = quoter
+        .quoteTransferRemote(destination, recipient, amount + 1)[0].amount;
+    }
+}
 
 contract OffchainQuotedLinearFeeTest is Test {
     OffchainQuotedLinearFee quotedFee;
@@ -769,6 +801,160 @@ contract OffchainQuotedLinearFeeTest is Test {
             result[0].amount,
             _computeFee(IMMUTABLE_MAX_FEE, IMMUTABLE_HALF_AMOUNT, AMOUNT)
         );
+    }
+
+    // ============ Exact-In (quoteTransferRemoteFrom) ============
+
+    // The active curve is amount-independent (wildcard/standing/immutable), so
+    // the forward quote at any amount uses the same params. Assert the exact-in
+    // result is the maximum amount whose amount + fee fits the budget.
+    function _assertExactInMaximal(
+        uint32 dest,
+        bytes32 recipient,
+        uint256 maxSpend
+    ) internal view {
+        uint256 amount = quotedFee.quoteTransferRemoteFrom(
+            dest,
+            recipient,
+            maxSpend
+        );
+        assertLe(amount, maxSpend, "amount exceeds budget");
+        uint256 fee = quotedFee
+        .quoteTransferRemote(dest, recipient, amount)[0].amount;
+        assertLe(amount + fee, maxSpend, "charge over budget");
+        uint256 up = amount + 1;
+        uint256 feeUp = quotedFee
+        .quoteTransferRemote(dest, recipient, up)[0].amount;
+        assertGt(up + feeUp, maxSpend, "not maximal");
+    }
+
+    function test_exactIn_immutableFallback() public view {
+        // No quotes → immutable LinearFee inverse.
+        _assertExactInMaximal(DEST, RECIPIENT, 5 ether);
+    }
+
+    // Transient quotes only live for the duration of a single transaction, so
+    // submit + exact-in query + bracketing forward quotes must all execute in one
+    // top-level call. An ExactInHarness reproduces the production flow where a
+    // router submits the transient quote and consumes it in the same tx.
+    function test_exactIn_transientWildcard() public {
+        uint48 now_ = uint48(block.timestamp);
+        SignedQuote memory sq = SignedQuote({
+            context: _quoteContext(DEST, RECIPIENT, WILDCARD_AMOUNT),
+            data: _encodeFeeData(MAX_FEE, HALF_AMOUNT),
+            issuedAt: now_,
+            expiry: now_, // transient
+            salt: bytes32(0),
+            submitter: address(0)
+        });
+
+        ExactInHarness harness = new ExactInHarness(quotedFee);
+        (uint256 amount, uint256 feeAt, uint256 feeAtPlus1) = harness
+            .submitAndExactIn(sq, _signQuote(sq), DEST, RECIPIENT, 5 ether);
+
+        // Maximal: amount + fee(amount) fits budget, but (amount+1) does not.
+        assertLe(amount, 5 ether, "amount exceeds budget");
+        assertLe(amount + feeAt, 5 ether, "charge over budget");
+        assertGt(amount + 1 + feeAtPlus1, 5 ether, "not maximal");
+
+        // Active curve is the transient one (MAX_FEE), not immutable
+        // (IMMUTABLE_MAX_FEE). Capped region: fee == MAX_FEE.
+        assertEq(amount, 5 ether - MAX_FEE);
+    }
+
+    function test_exactIn_standingSpecific() public {
+        uint48 now_ = uint48(block.timestamp);
+        _submitStanding(
+            DEST,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            now_,
+            now_ + 3600
+        );
+        _assertExactInMaximal(DEST, RECIPIENT, 0.2 ether);
+        _assertExactInMaximal(DEST, RECIPIENT, 5 ether);
+    }
+
+    function test_exactIn_standingWildcards() public {
+        uint48 now_ = uint48(block.timestamp);
+        bytes32 wildcardRecipient = bytes32(type(uint256).max);
+        _submitStanding(
+            DEST,
+            wildcardRecipient,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            now_,
+            now_ + 3600
+        );
+        // Recipient wildcard resolves for any recipient on DEST.
+        _assertExactInMaximal(DEST, bytes32(uint256(0xCAFE)), 3 ether);
+    }
+
+    // A point (non-wildcard-amount) transient quote does not define a curve to
+    // invert, so exact-in must ignore it and use the immutable fallback.
+    function test_exactIn_transientPointIgnored() public {
+        _submitTransient(DEST, RECIPIENT, AMOUNT, MAX_FEE, HALF_AMOUNT);
+
+        LinearFee ref = new LinearFee(
+            FEE_TOKEN,
+            IMMUTABLE_MAX_FEE,
+            IMMUTABLE_HALF_AMOUNT,
+            signer
+        );
+        uint256 expected = ref.quoteTransferRemoteFrom(
+            DEST,
+            RECIPIENT,
+            5 ether
+        );
+        uint256 actual = quotedFee.quoteTransferRemoteFrom(
+            DEST,
+            RECIPIENT,
+            5 ether
+        );
+        assertEq(actual, expected);
+    }
+
+    function test_exactIn_expiredStanding_fallsToImmutable() public {
+        uint48 now_ = uint48(block.timestamp);
+        _submitStanding(
+            DEST,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            now_,
+            now_ + 1
+        );
+        vm.warp(now_ + 2);
+
+        LinearFee ref = new LinearFee(
+            FEE_TOKEN,
+            IMMUTABLE_MAX_FEE,
+            IMMUTABLE_HALF_AMOUNT,
+            signer
+        );
+        assertEq(
+            quotedFee.quoteTransferRemoteFrom(DEST, RECIPIENT, 5 ether),
+            ref.quoteTransferRemoteFrom(DEST, RECIPIENT, 5 ether)
+        );
+    }
+
+    function testFuzz_exactIn_standingRoundTrip(uint256 maxSpend) public {
+        maxSpend = bound(maxSpend, 0, 1e30);
+        uint48 now_ = uint48(block.timestamp);
+        _submitStanding(
+            DEST,
+            RECIPIENT,
+            WILDCARD_AMOUNT,
+            MAX_FEE,
+            HALF_AMOUNT,
+            now_,
+            now_ + 3600
+        );
+        _assertExactInMaximal(DEST, RECIPIENT, maxSpend);
     }
 }
 


### PR DESCRIPTION
## Summary

Sketch of **exact-in fee quoting** for warp routes, to serve DEX aggregators (Decent/Zev) that want to spend a fixed budget of collateral rather than deliver a fixed amount.

Exact-in is the inverse of the existing exact-out `quoteTransferRemote`: given a spend budget `B` in the collateral token, return the largest deliverable `amount` such that `amount + fee(amount) <= B`.

- **`IExactInFee`** — new capability interface in `ITokenBridge.sol` exposing `quoteTransferRemoteFrom(destination, recipient, maxSpend) -> amount`. Kept as a dedicated interface (not folded into `ITokenFee`) so the ~10 unrelated `ITokenFee`/`ITokenBridge` implementers don't need stubs.
- **`BaseFee`** — default `_maxAmountForSpend` reverts `ExactInNotSupported()`; only invertible curves opt in.
- **`LinearFee`** — closed-form capped-linear inverse (no binary search): capped branch when the budget clears `2*halfAmount + maxFee`, otherwise `floor(maxSpend * D / (D + maxFee))` with a bounded `+1` fixup (`D = 2*halfAmount`). `Math.mulDiv` avoids intermediate overflow. Regressive/Progressive curves are deprecated (no deployments) so only the linear inverse is implemented.
- **`OffchainQuotedLinearFee`** — resolves the active linear params through the same `transient → standing(dest+recipient → dest+* → *+recipient) → immutable` cascade as the forward quote, then inverts. A point (specific-amount) transient quote is ignored for exact-in since it doesn't define a curve.
- **Cross-collateral routing plumbing** — router-aware `quoteTransferRemoteFromTo` on `ICrossCollateralFee`/`CrossCollateralRoutingFee`; budget-based `quoteTransferRemoteFrom` / `transferRemoteFrom` (with a `minAmountOut` slippage guard) on `CrossCollateralRouter`; delegating override on `PredicateCrossCollateralRouterWrapper`.

Breaking `ITokenFee` was pre-approved; fee contracts are immutable/redeployable.

## Scope

Per the ask, this sketch implements + tests **`LinearFee`** and **`OffchainQuotedLinearFee`** only. `OffchainQuotedPiecewiseLinearFee` (#9180) is out of scope — it is **not a blocker**: the offchain-quoted path inverts fine through the shared cascade.

## Test plan

- [x] `test/token/LinearFeeExactIn.t.sol` — 9/9 pass. Uncapped/cap-boundary/capped regions, zero budget, budget-below-maxFee, default-reverts, plus fuzz: exact-out→exact-in round-trip, maximality, and param+budget sweeps.
- [x] `test/token/OffchainQuotedLinearFee.t.sol` — new exact-in tests pass (immutable fallback, standing specific/wildcards, expired→immutable, point-transient-ignored, transient wildcard via harness, fuzz standing round-trip).
- [x] `test/token/CrossCollateralRouter.t.sol` — 76/76 pass (mocks updated for the new interface method).

### Note on transient tests
3 **pre-existing** transient tests fail in the sandbox's Foundry *nightly* (`test_transientQuote_wildcardAmount`, `test_transientQuote_zeroFee`, `test_transientTakesPriorityOverStanding`) — verified identical on pristine `main`. The nightly clears transient storage between a test's separate top-level calls, so submit-then-query across two calls loses the quote. The new transient exact-in test avoids this by submitting + consuming the quote in a **single** top-level call via an `ExactInHarness`, which also mirrors the real router flow (submit + consume in one tx). CI's pinned Foundry is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)