### PR TITLE
fix(sdk): use Solana message fee estimates

### DIFF
--- a/.changeset/solana-base-transaction-fee.md
+++ b/.changeset/solana-base-transaction-fee.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Use authoritative Solana message fees, including signature and priority fees, in transaction fee estimates.

--- a/.changeset/solana-base-transaction-fee.md
+++ b/.changeset/solana-base-transaction-fee.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Use authoritative Solana message fees, including signature and priority fees, in transaction fee estimates.
+Used authoritative Solana message fees, including signature and priority fees, in transaction fee estimates.

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { StargateClient } from '@cosmjs/stargate';
+import { Keypair, SystemProgram, Transaction } from '@solana/web3.js';
 
 import { ProviderType } from './ProviderType.js';
 import {
   clearCachedStargateClients,
   estimateTransactionFeeCosmJsWasm,
+  estimateTransactionFeeSolanaWeb3,
 } from './transactionFeeEstimators.js';
 
 describe('transactionFeeEstimators', () => {
@@ -44,6 +46,38 @@ describe('transactionFeeEstimators', () => {
       }),
     } as any;
   }
+
+  it('returns the authoritative Solana message fee', async () => {
+    const sender = Keypair.generate();
+    const transaction = new Transaction({
+      feePayer: sender.publicKey,
+      recentBlockhash: '11111111111111111111111111111111',
+    }).add(
+      SystemProgram.transfer({
+        fromPubkey: sender.publicKey,
+        toPubkey: Keypair.generate().publicKey,
+        lamports: 1,
+      }),
+    );
+    const connection = {
+      simulateTransaction: sandbox.stub().resolves({
+        value: { err: null, unitsConsumed: 200_000 },
+      }),
+      getFeeForMessage: sandbox.stub().resolves({ value: 5_123 }),
+    };
+
+    const estimate = await estimateTransactionFeeSolanaWeb3({
+      transaction: { type: ProviderType.SolanaWeb3, transaction },
+      provider: { type: ProviderType.SolanaWeb3, provider: connection } as any,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 200_000n,
+      gasPrice: 0n,
+      fee: 5_123n,
+    });
+    expect(connection.getFeeForMessage.calledOnce).to.equal(true);
+  });
 
   function makeStargateClient(
     simulate: sinon.SinonStub,

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 
 import { StargateClient } from '@cosmjs/stargate';
 import {
+  Connection,
   Keypair,
   SystemProgram,
   Transaction,
@@ -65,19 +66,21 @@ describe('transactionFeeEstimators', () => {
         lamports: 1,
       }),
     );
-    const connection = {
-      simulateTransaction: sandbox.stub().resolves({
-        value: { err: null, unitsConsumed: 200_000 },
-      }),
-      getRecentPrioritizationFees: sandbox
-        .stub()
-        .resolves([{ prioritizationFee: 0 }]),
-      getFeeForMessage: sandbox.stub().resolves({ value: 5_000 }),
-    };
+    const connection = new Connection('http://localhost:8899');
+    sandbox.stub(connection, 'simulateTransaction').resolves({
+      context: { slot: 1 },
+      value: { err: null, logs: null, unitsConsumed: 200_000 },
+    });
+    const getRecentPrioritizationFees = sandbox
+      .stub(connection, 'getRecentPrioritizationFees')
+      .resolves([{ prioritizationFee: 0, slot: 1 }]);
+    const getFeeForMessage = sandbox
+      .stub(connection, 'getFeeForMessage')
+      .resolves({ context: { slot: 1 }, value: 5_000 });
 
     const estimate = await estimateTransactionFeeSolanaWeb3({
       transaction: { type: ProviderType.SolanaWeb3, transaction },
-      provider: { type: ProviderType.SolanaWeb3, provider: connection } as any,
+      provider: { type: ProviderType.SolanaWeb3, provider: connection },
     });
 
     expect(estimate).to.deep.equal({
@@ -85,8 +88,8 @@ describe('transactionFeeEstimators', () => {
       gasPrice: 0n,
       fee: 5_000n,
     });
-    expect(connection.getFeeForMessage.calledOnce).to.equal(true);
-    expect(connection.getRecentPrioritizationFees.notCalled).to.equal(true);
+    expect(getFeeForMessage.calledOnce).to.equal(true);
+    expect(getRecentPrioritizationFees.notCalled).to.equal(true);
   });
 
   it('uses the message fee for versioned Solana transactions', async () => {
@@ -102,25 +105,25 @@ describe('transactionFeeEstimators', () => {
         }),
       ],
     }).compileToV0Message();
-    const connection = {
-      simulateTransaction: sandbox.stub().resolves({
-        value: { err: null, unitsConsumed: 200_000 },
-      }),
-      getFeeForMessage: sandbox.stub().resolves({ value: 5_123 }),
-    };
+    const connection = new Connection('http://localhost:8899');
+    sandbox.stub(connection, 'simulateTransaction').resolves({
+      context: { slot: 1 },
+      value: { err: null, logs: null, unitsConsumed: 200_000 },
+    });
+    const getFeeForMessage = sandbox
+      .stub(connection, 'getFeeForMessage')
+      .resolves({ context: { slot: 1 }, value: 5_123 });
 
     const estimate = await estimateTransactionFeeSolanaWeb3({
       transaction: {
         type: ProviderType.SolanaWeb3,
         transaction: new VersionedTransaction(message),
       },
-      provider: { type: ProviderType.SolanaWeb3, provider: connection } as any,
+      provider: { type: ProviderType.SolanaWeb3, provider: connection },
     });
 
     expect(estimate.fee).to.equal(5_123n);
-    expect(connection.getFeeForMessage.calledOnceWithExactly(message)).to.equal(
-      true,
-    );
+    expect(getFeeForMessage.calledOnceWithExactly(message)).to.equal(true);
   });
 
   function makeStargateClient(

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -2,7 +2,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { StargateClient } from '@cosmjs/stargate';
-import { Keypair, SystemProgram, Transaction } from '@solana/web3.js';
+import {
+  Keypair,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
 
 import { ProviderType } from './ProviderType.js';
 import {
@@ -47,7 +53,7 @@ describe('transactionFeeEstimators', () => {
     } as any;
   }
 
-  it('returns the authoritative Solana message fee', async () => {
+  it('returns the Solana base fee when priority pricing is zero', async () => {
     const sender = Keypair.generate();
     const transaction = new Transaction({
       feePayer: sender.publicKey,
@@ -63,7 +69,10 @@ describe('transactionFeeEstimators', () => {
       simulateTransaction: sandbox.stub().resolves({
         value: { err: null, unitsConsumed: 200_000 },
       }),
-      getFeeForMessage: sandbox.stub().resolves({ value: 5_123 }),
+      getRecentPrioritizationFees: sandbox
+        .stub()
+        .resolves([{ prioritizationFee: 0 }]),
+      getFeeForMessage: sandbox.stub().resolves({ value: 5_000 }),
     };
 
     const estimate = await estimateTransactionFeeSolanaWeb3({
@@ -74,9 +83,44 @@ describe('transactionFeeEstimators', () => {
     expect(estimate).to.deep.equal({
       gasUnits: 200_000n,
       gasPrice: 0n,
-      fee: 5_123n,
+      fee: 5_000n,
     });
     expect(connection.getFeeForMessage.calledOnce).to.equal(true);
+    expect(connection.getRecentPrioritizationFees.notCalled).to.equal(true);
+  });
+
+  it('uses the message fee for versioned Solana transactions', async () => {
+    const sender = Keypair.generate();
+    const message = new TransactionMessage({
+      payerKey: sender.publicKey,
+      recentBlockhash: '11111111111111111111111111111111',
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: sender.publicKey,
+          toPubkey: Keypair.generate().publicKey,
+          lamports: 1,
+        }),
+      ],
+    }).compileToV0Message();
+    const connection = {
+      simulateTransaction: sandbox.stub().resolves({
+        value: { err: null, unitsConsumed: 200_000 },
+      }),
+      getFeeForMessage: sandbox.stub().resolves({ value: 5_123 }),
+    };
+
+    const estimate = await estimateTransactionFeeSolanaWeb3({
+      transaction: {
+        type: ProviderType.SolanaWeb3,
+        transaction: new VersionedTransaction(message),
+      },
+      provider: { type: ProviderType.SolanaWeb3, provider: connection } as any,
+    });
+
+    expect(estimate.fee).to.equal(5_123n);
+    expect(connection.getFeeForMessage.calledOnceWithExactly(message)).to.equal(
+      true,
+    );
   });
 
   function makeStargateClient(

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -157,24 +157,34 @@ export async function estimateTransactionFeeSolanaWeb3({
 }): Promise<TransactionFeeEstimate> {
   const connection = provider.provider;
   const inner = transaction.transaction;
+  const message =
+    inner instanceof VersionedTransaction
+      ? inner.message
+      : inner.compileMessage();
   // The two arms are intentionally identical: `Connection.simulateTransaction`
   // has separate overloads for legacy `Transaction` and `VersionedTransaction`
   // and the union satisfies neither, so we branch purely to narrow `inner` to a
   // concrete type and let overload resolution pick the matching signature.
-  const { value } =
+  const simulation =
     inner instanceof VersionedTransaction
-      ? await connection.simulateTransaction(inner)
-      : await connection.simulateTransaction(inner);
+      ? connection.simulateTransaction(inner)
+      : connection.simulateTransaction(inner);
+  const [{ value }, feeResponse] = await Promise.all([
+    simulation,
+    connection.getFeeForMessage(message),
+  ]);
   assert(!value.err, `Solana gas estimation failed: ${JSON.stringify(value)}`);
   const gasUnits = BigInt(value.unitsConsumed || 0);
-  const recentFees = await connection.getRecentPrioritizationFees();
-  // prioritizationFee is in micro-lamports per compute unit; divide by 1e6 to get lamports
-  const microLamportsPerCu = BigInt(recentFees[0]?.prioritizationFee ?? 0);
-  const fee = (gasUnits * microLamportsPerCu) / 1_000_000n;
+  assert(
+    feeResponse.value !== null,
+    'Solana transaction fee estimation failed',
+  );
   return {
     gasUnits,
-    gasPrice: microLamportsPerCu,
-    fee,
+    // Solana's message fee includes fixed signature and optional priority fees,
+    // so it cannot be represented as one price per consumed compute unit.
+    gasPrice: 0n,
+    fee: BigInt(feeResponse.value),
   };
 }
 

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -174,7 +174,7 @@ export async function estimateTransactionFeeSolanaWeb3({
     connection.getFeeForMessage(message),
   ]);
   assert(!value.err, `Solana gas estimation failed: ${JSON.stringify(value)}`);
-  const gasUnits = BigInt(value.unitsConsumed || 0);
+  const gasUnits = BigInt(value.unitsConsumed ?? 0);
   assert(
     feeResponse.value !== null,
     'Solana transaction fee estimation failed',


### PR DESCRIPTION
## Summary

- replace the hand-rolled Solana priority-only estimate with `getFeeForMessage`
- return the authoritative fee for the exact prepared message, including signatures and encoded priority fees
- retain simulated compute units and issue both RPC requests in parallel
- add regression coverage for a non-zero message fee when the prior estimator returned zero

This unblocks consumers using `MultiProtocolProvider.estimateTransactionFee` to reserve native SOL for source transactions.