### PR TITLE
fix(sdk): fall back across block explorers

### DIFF
--- a/.changeset/fallback-evm-explorers.md
+++ b/.changeset/fallback-evm-explorers.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/sdk': minor
 ---
 
 EVM event reads were made resilient by trying each compatible configured block explorer before falling back to RPC.

--- a/.changeset/fallback-evm-explorers.md
+++ b/.changeset/fallback-evm-explorers.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+EVM event reads were made resilient by trying each compatible configured block explorer before falling back to RPC.

--- a/typescript/sdk/src/metadata/ChainMetadataManager.test.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.test.ts
@@ -173,6 +173,12 @@ describe(ChainMetadataManager.name, () => {
         apiUrl: 'https://tronscan.example.com/#/api',
         family: ExplorerFamily.TronScan,
       };
+      const routescanExplorer: BlockExplorer = {
+        name: 'Routescan',
+        url: 'https://routescan.example.com',
+        apiUrl: 'https://routescan.example.com/api',
+        family: ExplorerFamily.Routescan,
+      };
 
       interface Case {
         description: string;
@@ -227,6 +233,33 @@ describe(ChainMetadataManager.name, () => {
           }
         });
       }
+
+      it('returns all compatible explorers in registry order', () => {
+        const chainManager = new ChainMetadataManager({
+          testchain: {
+            chainId: 12345,
+            domainId: 12345,
+            name: 'testchain',
+            protocol: ProtocolType.Ethereum,
+            rpcUrls: [{ http: 'https://testchain.example.com' }],
+            blockExplorers: [
+              tronScanExplorer,
+              etherscanNoKeyExplorer,
+              routescanExplorer,
+              etherscanExplorer,
+              blockscoutExplorer,
+            ],
+          },
+        });
+
+        const result = chainManager.tryGetEvmExplorerMetadataList('testchain');
+
+        expect(result.map(({ family }) => family)).to.deep.equal([
+          ExplorerFamily.Routescan,
+          ExplorerFamily.Etherscan,
+          ExplorerFamily.Blockscout,
+        ]);
+      });
     },
   );
 });

--- a/typescript/sdk/src/metadata/ChainMetadataManager.ts
+++ b/typescript/sdk/src/metadata/ChainMetadataManager.ts
@@ -10,10 +10,7 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import {
-  isEtherscanApiCompatibleFamily,
-  isEvmBlockExplorerAndNotEtherscan,
-} from '../block-explorer/utils.js';
+import { isEtherscanApiCompatibleFamily } from '../block-explorer/utils.js';
 import { ChainMap, ChainName, ChainNameOrId } from '../types.js';
 
 import {
@@ -422,31 +419,30 @@ export class ChainMetadataManager<MetaExt = {}> {
   tryGetEvmExplorerMetadata(
     chainNameOrId: ChainNameOrId,
   ): ReturnType<ChainMetadataManager['getExplorerApi']> | null {
-    const defaultExplorer = this.tryGetExplorerApi(chainNameOrId);
+    return this.tryGetEvmExplorerMetadataList(chainNameOrId)[0] ?? null;
+  }
 
-    if (!defaultExplorer) {
-      return null;
-    }
+  /**
+   * Get every configured Etherscan-compatible explorer API in registry order.
+   * Etherscan APIs require a key; compatible alternatives do not necessarily.
+   */
+  tryGetEvmExplorerMetadataList(
+    chainNameOrId: ChainNameOrId,
+  ): NonNullable<ReturnType<typeof getExplorerApi>>[] {
+    const chainMetadata = this.tryGetChainMetadata(chainNameOrId);
+    if (!chainMetadata) return [];
 
-    const chainMetadata = this.getChainMetadata(chainNameOrId);
-    const [fallBackExplorer] =
-      chainMetadata.blockExplorers?.filter((blockExplorer) =>
-        isEvmBlockExplorerAndNotEtherscan(blockExplorer),
-      ) ?? [];
+    return (chainMetadata.blockExplorers ?? []).flatMap((_, index) => {
+      const explorer = getExplorerApi(chainMetadata, index);
+      if (!explorer) return [];
 
-    // Fallback to use other block explorers if the default block explorer
-    // is etherscan and an API key is not configured
-    const isExplorerConfiguredCorrectly =
-      defaultExplorer.family === ExplorerFamily.Etherscan
-        ? !!defaultExplorer.apiKey
-        : true;
-    const canUseExplorerApi =
-      isEtherscanApiCompatibleFamily(defaultExplorer.family) &&
-      isExplorerConfiguredCorrectly;
-
-    const explorer = canUseExplorerApi ? defaultExplorer : fallBackExplorer;
-
-    return explorer ?? null;
+      const hasRequiredApiKey =
+        explorer.family !== ExplorerFamily.Etherscan || !!explorer.apiKey;
+      return isEtherscanApiCompatibleFamily(explorer.family) &&
+        hasRequiredApiKey
+        ? [explorer]
+        : [];
+    });
   }
 
   /**

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.hardhat-test.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.hardhat-test.ts
@@ -13,7 +13,9 @@ import {
   KNOWN_ETHEREUM_TIMELOCK_CONTRACT,
   TestChainName,
   ethereumTestChain,
+  test1,
 } from '../../consts/testChains.js';
+import { ExplorerFamily } from '../../metadata/chainMetadataTypes.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 import { randomAddress, randomInt } from '../../test/testUtils.js';
 
@@ -21,6 +23,7 @@ import {
   EvmEtherscanLikeEventLogsReader,
   EvmEventLogsReader,
   EvmRpcEventLogsReader,
+  FallbackEvmEventLogsReader,
 } from './EvmEventLogsReader.js';
 import { GetEventLogsResponse } from './types.js';
 
@@ -91,7 +94,7 @@ describe('EvmEventLogsReader', () => {
 
       // Access the private property indirectly
       expect(readerWithRpc['logReaderStrategy']).to.be.instanceOf(
-        EvmEtherscanLikeEventLogsReader,
+        FallbackEvmEventLogsReader,
       );
     });
 
@@ -127,6 +130,51 @@ describe('EvmEventLogsReader', () => {
       expect(reader['logReaderStrategy']).to.be.instanceOf(
         EvmRpcEventLogsReader,
       );
+    });
+
+    it('should allow explorer fallback to be enabled per method', async () => {
+      const firstReader = new EvmEtherscanLikeEventLogsReader(
+        TestChainName.test1,
+        {
+          apiKey: 'first-key',
+          apiUrl: 'https://first.example.com/api',
+          family: ExplorerFamily.Etherscan,
+        },
+        multiProvider,
+      );
+      const secondReader = new EvmEtherscanLikeEventLogsReader(
+        TestChainName.test1,
+        {
+          apiUrl: 'https://second.example.com/api',
+          family: ExplorerFamily.Blockscout,
+        },
+        multiProvider,
+      );
+      const firstGetLogs = sinon
+        .stub(firstReader, 'getContractLogs')
+        .rejects(new Error('first explorer failed'));
+      const secondGetLogs = sinon
+        .stub(secondReader, 'getContractLogs')
+        .resolves([]);
+      const reader = new FallbackEvmEventLogsReader(
+        TestChainName.test1,
+        [firstReader, secondReader],
+        multiProvider.logger,
+        {
+          getContractLogs: true,
+        },
+      );
+
+      expect(
+        await reader.getContractLogs({
+          contractAddress: randomAddress(),
+          eventTopic: ethers.constants.HashZero,
+          fromBlock: 0,
+          toBlock: 0,
+        }),
+      ).to.deep.equal([]);
+      expect(firstGetLogs.calledOnce).to.be.true;
+      expect(secondGetLogs.calledOnce).to.be.true;
     });
   });
 
@@ -408,18 +456,21 @@ describe('EvmEventLogsReader', () => {
       const primaryStrategy = reader['logReaderStrategy'];
       const fallbackStrategy = reader['fallbackLogReaderStrategy'];
       assert(
-        primaryStrategy instanceof EvmEtherscanLikeEventLogsReader,
-        'Expected an explorer log reader',
+        primaryStrategy instanceof FallbackEvmEventLogsReader,
+        'Expected a fallback explorer log reader',
       );
       assert(fallbackStrategy, 'Expected an RPC fallback log reader');
+      const [explorerReader] = primaryStrategy['readers'];
       sinon
-        .stub(primaryStrategy, 'getContractDeploymentBlockNumber')
+        .stub(explorerReader, 'getContractDeploymentBlockNumber')
         .resolves(deploymentBlockNumber);
-      sinon.stub(primaryStrategy, 'getContractLogs').rejects(
-        Object.assign(new Error('explorer logs unavailable'), {
-          isRecoverable: false,
-        }),
-      );
+      const explorerGetLogs = sinon
+        .stub(explorerReader, 'getContractLogs')
+        .rejects(
+          Object.assign(new Error('explorer logs unavailable'), {
+            isRecoverable: false,
+          }),
+        );
       const fallbackGetLogs = sinon.spy(fallbackStrategy, 'getContractLogs');
 
       const fromBlock = await reader.getContractDeploymentBlockFromExplorer(
@@ -432,6 +483,7 @@ describe('EvmEventLogsReader', () => {
       });
 
       expect(logs).to.have.length(1);
+      expect(explorerGetLogs.calledOnce).to.be.true;
       expect(fallbackGetLogs.calledOnce).to.be.true;
       expect(fallbackGetLogs.firstCall.args[0].fromBlock).to.equal(
         deploymentBlockNumber,
@@ -555,6 +607,83 @@ describe('EvmEventLogsReader', () => {
   });
 
   describe('deployment block cache', () => {
+    it('falls back between explorers for deployment blocks and logs', async () => {
+      await deployTestErc20();
+
+      const multiExplorerProvider = new MultiProvider({
+        [TestChainName.test1]: {
+          ...test1,
+          blockExplorers: [
+            {
+              apiKey: 'first-key',
+              apiUrl: 'https://first.example.com/api',
+              family: ExplorerFamily.Etherscan,
+              name: 'First explorer',
+              url: 'https://first.example.com',
+            },
+            {
+              apiUrl: 'https://second.example.com/api',
+              family: ExplorerFamily.Blockscout,
+              name: 'Second explorer',
+              url: 'https://second.example.com',
+            },
+          ],
+        },
+      });
+      multiExplorerProvider.setProvider(
+        TestChainName.test1,
+        providerChainTest1,
+      );
+      const reader = EvmEventLogsReader.fromConfig(
+        { chain: TestChainName.test1 },
+        multiExplorerProvider,
+      );
+      const fallbackExplorerReader = reader['logReaderStrategy'];
+      assert(
+        fallbackExplorerReader instanceof FallbackEvmEventLogsReader,
+        'Expected a fallback explorer log reader',
+      );
+      const [firstExplorer, secondExplorer] = fallbackExplorerReader['readers'];
+      const firstError = Object.assign(new Error('first explorer failed'), {
+        isRecoverable: false,
+      });
+      const firstLookup = sinon
+        .stub(firstExplorer, 'getContractDeploymentBlockNumber')
+        .rejects(firstError);
+      const secondLookup = sinon
+        .stub(secondExplorer, 'getContractDeploymentBlockNumber')
+        .resolves(deploymentBlockNumber);
+      const firstGetLogs = sinon
+        .stub(firstExplorer, 'getContractLogs')
+        .rejects(firstError);
+      const secondGetLogs = sinon
+        .stub(secondExplorer, 'getContractLogs')
+        .resolves([]);
+      const rpcReader = reader['fallbackLogReaderStrategy'];
+      assert(rpcReader, 'Expected an RPC fallback log reader');
+      const rpcGetLogs = sinon.stub(rpcReader, 'getContractLogs').resolves([]);
+
+      expect(
+        await reader.getContractDeploymentBlockFromExplorer(
+          testContract.address,
+        ),
+      ).to.equal(deploymentBlockNumber);
+      expect(firstLookup.calledOnce).to.be.true;
+      expect(secondLookup.calledOnce).to.be.true;
+
+      expect(
+        await reader.getLogsByTopic({
+          contractAddress: testContract.address,
+          eventTopic: transferTopic,
+          fromBlock: deploymentBlockNumber,
+          toBlock: deploymentBlockNumber,
+        }),
+      ).to.deep.equal([]);
+      expect(firstGetLogs.calledOnce).to.be.true;
+      expect(secondGetLogs.calledOnce).to.be.true;
+      expect(rpcGetLogs.notCalled).to.be.true;
+    });
+
     it('should reject an explorer deployment lookup for an RPC-only reader', async () => {
       await deployTestErc20();
 
@@ -584,15 +713,16 @@ describe('EvmEventLogsReader', () => {
       );
       const primaryStrategy = reader['logReaderStrategy'];
       assert(
-        primaryStrategy instanceof EvmEtherscanLikeEventLogsReader,
-        'Expected an explorer log reader',
+        primaryStrategy instanceof FallbackEvmEventLogsReader,
+        'Expected a fallback explorer log reader',
       );
+      const [explorerReader] = primaryStrategy['readers'];
       reader['deploymentBlockCache'].set(
         testContract.address,
         deploymentBlockNumber + 1,
       );
       const deploymentStub = sinon
-        .stub(primaryStrategy, 'getContractDeploymentBlockNumber')
+        .stub(explorerReader, 'getContractDeploymentBlockNumber')
         .resolves(deploymentBlockNumber);
 
       expect(

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.ts
@@ -29,6 +29,9 @@ export type EvmEventLogsReaderConfig = {
   useRPC?: boolean;
   // Specifies how many blocks can be retrieved to read the logs in a single batch
   paginationBlockRange?: number;
+  // Explorer-to-explorer fallback by strategy method. Missing options enable
+  // fallback; set a method to false to use only the primary explorer.
+  explorerFallback?: ExplorerFallbackConfig;
 };
 
 export const GetLogByTopicOptionsSchema = z.object({
@@ -75,6 +78,10 @@ interface IEvmEventLogsReaderStrategy {
     address: RequiredGetLogByTopicOptions,
   ): Promise<GetEventLogsResponse[]>;
 }
+
+export type ExplorerFallbackConfig = Partial<
+  Record<keyof IEvmEventLogsReaderStrategy, boolean>
+>;
 
 export class EvmEtherscanLikeEventLogsReader implements IEvmEventLogsReaderStrategy {
   constructor(
@@ -158,6 +165,76 @@ export class EvmRpcEventLogsReader implements IEvmEventLogsReaderStrategy {
   }
 }
 
+class ExplorerFallbackError extends Error {
+  readonly isRecoverable: false | undefined;
+
+  constructor(
+    chain: ChainNameOrId,
+    readonly errors: readonly unknown[],
+  ) {
+    super(`All configured block explorers failed on chain "${chain}"`, {
+      cause: errors.at(-1),
+    });
+    this.isRecoverable = errors.every(
+      (error) =>
+        typeof error === 'object' &&
+        error !== null &&
+        Reflect.get(error, 'isRecoverable') === false,
+    )
+      ? false
+      : undefined;
+  }
+}
+
+export class FallbackEvmEventLogsReader implements IEvmEventLogsReaderStrategy {
+  constructor(
+    protected readonly chain: ChainNameOrId,
+    protected readonly readers: EvmEtherscanLikeEventLogsReader[],
+    protected readonly logger: Logger,
+    protected readonly config: ExplorerFallbackConfig = {},
+  ) {
+    assert(readers.length > 0, 'At least one explorer reader is required');
+  }
+
+  private async executeWithFallback<T>(
+    operation: (reader: EvmEtherscanLikeEventLogsReader) => Promise<T>,
+    fallbackEnabled: boolean,
+  ): Promise<T> {
+    if (!fallbackEnabled) return operation(this.readers[0]);
+
+    const errors: unknown[] = [];
+    for (const [explorerIndex, reader] of this.readers.entries()) {
+      try {
+        return await operation(reader);
+      } catch (error) {
+        errors.push(error);
+        this.logger.debug(
+          { err: error, explorerIndex },
+          `Block explorer request failed on chain "${this.chain}"`,
+        );
+      }
+    }
+
+    throw new ExplorerFallbackError(this.chain, errors);
+  }
+
+  getContractDeploymentBlockNumber(address: Address): Promise<number> {
+    return this.executeWithFallback(
+      (reader) => reader.getContractDeploymentBlockNumber(address),
+      this.config.getContractDeploymentBlockNumber ?? true,
+    );
+  }
+
+  getContractLogs(
+    options: RequiredGetLogByTopicOptions,
+  ): Promise<GetEventLogsResponse[]> {
+    return this.executeWithFallback(
+      (reader) => reader.getContractLogs(options),
+      this.config.getContractLogs ?? true,
+    );
+  }
+}
+
 export class EvmEventLogsReader {
   private deploymentBlockCache: Map<string, number> = new Map();
   private explorerDeploymentBlockCache: Map<string, number> = new Map();
@@ -177,15 +254,26 @@ export class EvmEventLogsReader {
       module: EvmEventLogsReader.name,
     }),
   ) {
-    const explorer = multiProvider.tryGetEvmExplorerMetadata(config.chain);
+    const explorers = config.useRPC
+      ? []
+      : multiProvider.tryGetEvmExplorerMetadataList(config.chain);
+    const explorerReaders = explorers.map(
+      (explorer) =>
+        new EvmEtherscanLikeEventLogsReader(
+          config.chain,
+          explorer,
+          multiProvider,
+        ),
+    );
 
     let logReaderStrategy: IEvmEventLogsReaderStrategy;
     let fallbackLogReaderSrategy: IEvmEventLogsReaderStrategy | undefined;
-    if (explorer && !config.useRPC) {
-      logReaderStrategy = new EvmEtherscanLikeEventLogsReader(
+    if (explorerReaders.length > 0) {
+      logReaderStrategy = new FallbackEvmEventLogsReader(
         config.chain,
-        explorer,
-        multiProvider,
+        explorerReaders,
+        logger,
+        config.explorerFallback,
       );
 
       fallbackLogReaderSrategy = new EvmRpcEventLogsReader(
@@ -213,8 +301,9 @@ export class EvmEventLogsReader {
   async getContractDeploymentBlockFromExplorer(
     contractAddress: Address,
   ): Promise<number> {
+    const explorerReader = this.logReaderStrategy;
     assert(
-      this.logReaderStrategy instanceof EvmEtherscanLikeEventLogsReader,
+      explorerReader instanceof FallbackEvmEventLogsReader,
       `No block explorer is configured for chain ${this.config.chain}`,
     );
 
@@ -224,7 +313,7 @@ export class EvmEventLogsReader {
     // Do not use deploymentBlockCache here: an earlier read may have populated
     // it from RPC bisection after an explorer failure.
     const block = await retryAsync(() =>
-      this.logReaderStrategy.getContractDeploymentBlockNumber(contractAddress),
+      explorerReader.getContractDeploymentBlockNumber(contractAddress),
     );
     this.explorerDeploymentBlockCache.set(contractAddress, block);
     this.deploymentBlockCache.set(contractAddress, block);


### PR DESCRIPTION
### Description

Adds ordered fallback across every compatible configured EVM block explorer. Deployment-block and log reads return the first successful explorer response, then retain RPC as the final fallback.

Fallback is configurable per strategy method. Options are derived from the strategy interface, optional, and enabled when omitted.

Fixes legacy Blacklist ISM reads when the primary explorer cannot return contract creation data, including USDC/krown on Base.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. Existing single-explorer and RPC-only behavior remains supported. No infrastructure implications.

### Testing

- Unit: ChainMetadataManager tests (15 passing)
- Hardhat: EvmEventLogsReader tests (27 passing)
- TypeScript typecheck
- SDK lint
- Manual: USDC/krown warp read against the local HTTP registry