### PR TITLE
fix(starknet): tolerate transaction receipt fetch failures during indexing

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/client.rs
@@ -102,20 +102,30 @@ impl HyperlaneProvider for StarknetProvider {
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;
 
-        let receipt = self
+        // The receipt is only needed to populate the gas-paid fields below. Some
+        // Starknet RPC nodes (e.g. Paradex) can fail to serialize receipts due to
+        // node-side schema bugs (e.g. `l1_data_gas` typing), so degrade gracefully
+        // with a zero gas value instead of blocking message indexing entirely.
+        let gas_paid = match self
             .rpc_client()
             .get_transaction_receipt(tx.transaction_hash())
             .await
-            .map_err(Into::<HyperlaneStarknetError>::into)?;
-
-        let receipt = match receipt.receipt {
-            TransactionReceipt::Invoke(invoke_receipt) => invoke_receipt,
-            _ => {
-                return Err(HyperlaneStarknetError::InvalidBlock.into());
+        {
+            Ok(receipt) => match receipt.receipt {
+                TransactionReceipt::Invoke(invoke_receipt) => {
+                    U256::from_big_endian(invoke_receipt.actual_fee.amount.to_bytes_be().as_slice())
+                }
+                _ => return Err(HyperlaneStarknetError::InvalidBlock.into()),
+            },
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    ?hash,
+                    "Failed to fetch Starknet transaction receipt; continuing with zero gas_paid"
+                );
+                U256::zero()
             }
         };
-
-        let gas_paid = U256::from_big_endian(receipt.actual_fee.amount.to_bytes_be().as_slice());
 
         let (nonce, sender, calldata) = match tx.clone() {
             Transaction::Invoke(invoke_tx) => match invoke_tx {


### PR DESCRIPTION
## Summary
- The Starknet provider's `get_txn_by_hash` fetched the full transaction receipt **solely** to read `actual_fee.amount` (gas paid), then aborted on any receipt error via `?`.
- Some Starknet RPC nodes fail to serialize receipts due to node-side schema bugs — e.g. Paradex's node currently returns `-32000 "json unmarshal failed: json: cannot unmarshal string into Go struct field ExecutionResources.execution_resources.l1_data_gas of type int"` on `starknet_getTransactionReceipt`. `getTransactionByHash` / `getTransactionStatus` still work.
- Because every other field (nonce, sender, calldata, recipient) comes from `get_transaction_by_hash`, one unused/broken receipt field (`l1_data_gas`) was blocking **all** message indexing for the chain (scraper shows no messages, even though delivery is unaffected).
- This makes the receipt fetch **non-fatal**: on error we log a warning and fall back to `gas_paid = 0`, so messages still get indexed. Only the gas-paid field is degraded until the RPC node is fixed.

## Scope
- Change is confined to `hyperlane-starknet`'s provider impl. EVM/Cosmos/Sealevel each have their own `get_txn_by_hash`, so semantics for other protocols are unchanged.

## Context
Paradex scraper stopped surfacing messages ~2026-08-15 07:00 UTC due to the receipt serialization bug on their RPC node (reported separately to Paradex). This is the agent-side resilience fix.

## Test plan
- [x] `cargo check -p relayer` compiles cleanly (pulls in the edited Starknet provider)
- [x] `cargo fmt -p hyperlane-starknet`
- [ ] Reviewer: confirm zero `gas_paid` fallback is acceptable for the scraper's gas accounting on Starknet chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)