### PR TITLE
fix(infra): pin check-warp-deploy to immutable image with #9206

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -50,7 +50,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   validatorFastPath: '14646bd-20260805-072134',
   scraper: '473ec14-20260814-113303',
   // monorepo services
-  checkWarpDeploy: 'main',
+  checkWarpDeploy: '322a418-20260818-163122',
   validatorMonitor: '2c47a33-20260724-134609',
   // standalone services
   keyFunder: 'b0c3c5d-20260804-175736',


### PR DESCRIPTION
## Summary
- `check-warp-deploy` was the only mainnet service running the mutable `:main` monorepo tag. That tag last built **2026-08-14** (commit `0adcbb21`), before SDK fix #9206 ("support pre-audit BlacklistIsm deployments", merged Aug 17). The stale image derived the USDT/krown `blacklistIsm` as `testIsm`, producing the config-mismatch false positive (PagerDuty 34602 / Q30JQ40JUJIZC7).
- A regular code merge does not rebuild the monorepo image (`monorepo-docker.yml` only fires on `Dockerfile`/`.registryrc`/`pnpm-lock.yaml`/etc. changes), so `:main` never picked up #9206. Triggered a fresh main build ([run 32160719431](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/32160719431)) → `322a418-20260818-163122` (commit `322a418`, confirmed to contain #9206).
- Pins `checkWarpDeploy` to that immutable tag, matching every other service and making the runtime reproducible.

## Test plan
- [ ] Redeploy `check-warp-deploy` helm release in mainnet3
- [ ] Next cronjob run (15:00 UTC) reports no USDT/krown mismatch