### PR TITLE
feat(infra): +20% IGP price experiment on bsc→ethereum and bsc→base

### DIFF
--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -58,6 +58,17 @@ function getOracleConfigWithOverrides(origin: ChainName) {
             (BigInt(laneConfig.tokenExchangeRate.toString()) * 6n) /
             5n
           ).toString(),
+          // Keep the derived typicalCost metadata in sync with the +20% bump so
+          // dry-run/monitoring output matches the on-chain quote (gas amounts
+          // are unchanged; only the USD cost scales).
+          ...(laneConfig.typicalCost
+            ? {
+                typicalCost: {
+                  ...laneConfig.typicalCost,
+                  totalUsdCost: (laneConfig.typicalCost.totalUsdCost * 6) / 5,
+                },
+              }
+            : {}),
         };
       }
     }

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -44,6 +44,25 @@ function getOracleConfigWithOverrides(origin: ChainName) {
     };
   }
 
+  // Price-elasticity experiment: +20% on two price-insensitive bsc lanes
+  // (bsc→ethereum, bsc→base). Scales the market-derived exchange rate by 1.2 so
+  // the bump tracks live prices and stays isolated to these origin→remote pairs.
+  // Revert to end the test.
+  if (origin === 'bsc') {
+    for (const remote of ['ethereum', 'base'] as const) {
+      const laneConfig = oracleConfig[remote];
+      if (laneConfig) {
+        oracleConfig[remote] = {
+          ...laneConfig,
+          tokenExchangeRate: (
+            (BigInt(laneConfig.tokenExchangeRate.toString()) * 6n) /
+            5n
+          ).toString(),
+        };
+      }
+    }
+  }
+
   return oracleConfig;
 }
 


### PR DESCRIPTION
## Summary
- Price-elasticity experiment: raise the IGP quote ~20% on two bsc lanes whose traffic is expected to be **price-insensitive** — `bsc→ethereum` and `bsc→base`.
- Uses the existing per-(origin→remote) override hook `getOracleConfigWithOverrides` (same mechanism as the `solaxy` workaround), scaling `tokenExchangeRate` by 1.2 for the `ethereum` and `base` remotes, and scaling the derived `typicalCost.totalUsdCost` by the same factor so dry-run/monitoring output matches the on-chain params.
- Applied multiplicatively on top of the **final configured quote**, isolated to these two origin→remote pairs (no other origin or lane is affected).

## Note on the multiplier semantics
Both lanes currently sit on their per-destination **min-USD-cost floors** (`ethereum` $0.12, `base` $0.05 in `getMinUsdCost`), so the +20% is applied over the *final configured quote* (a binding static floor today), **not** over a pure live-market-only quote. This is the intended experiment condition. If the market quote later rises above the floor, the ×1.2 applies over that market value.

## Baselines (last 30d, before change)
| Lane | Msgs | Avg IGP price | ~Target (+20%) |
|---|---|---|---|
| bsc→ethereum | 2,028 | $0.1295 | ~$0.155 |
| bsc→base | 241 | $0.0551 | ~$0.066 |

Rationale: median transfer ~$55 and ~60% of bsc→eth msgs carry no priced amount (gov tokens, intents, treasury moves) — the fee is a rounding error against value + destination gas, so demand should be inelastic. The test measures whether volume holds under the higher price.

## Tracking
Read-only daily `msgs / avg_price / net` for both lanes on the **Hyperlane PnL** Metabase dashboard (card 6931). Flat count under higher avg price = inelastic = pure margin; a drop = we found the elastic edge.

## Rollout / rollback
- Merging this only changes the generated config. The on-chain effect requires an operator to run the IGP oracle apply (`setRemoteGasData` on bsc's StorageGasOracle) with the deployer key.
- Revert = delete the `bsc` block to end the experiment and restore market pricing.

## Test plan
- [x] `tsc --noEmit` passes for `typescript/infra`
- [ ] Confirm generated bsc→ethereum / bsc→base quotes land ~20% above baseline in the IGP apply dry-run/govern diff before executing on-chain