### PR TITLE
fix(sdk): use EIP-1559 fee cap

### DIFF
--- a/.changeset/evm-fee-cap.md
+++ b/.changeset/evm-fee-cap.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Used the EIP-1559 maximum fee directly as the total gas price cap in transaction fee estimates.

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -15,6 +15,7 @@ import { ProviderType } from './ProviderType.js';
 import {
   clearCachedStargateClients,
   estimateTransactionFeeCosmJsWasm,
+  estimateTransactionFeeEthersV5ForGasUnits,
   estimateTransactionFeeSolanaWeb3,
 } from './transactionFeeEstimators.js';
 
@@ -39,6 +40,25 @@ describe('transactionFeeEstimators', () => {
   afterEach(() => {
     clearCachedStargateClients();
     sandbox.restore();
+  });
+
+  it('uses the EIP-1559 max fee as the total gas price cap', async () => {
+    const estimate = await estimateTransactionFeeEthersV5ForGasUnits({
+      provider: {
+        getFeeData: sandbox.stub().resolves({
+          gasPrice: 1n,
+          maxFeePerGas: 2n,
+          maxPriorityFeePerGas: 1n,
+        }),
+      } as any,
+      gasUnits: 600_000n,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 600_000n,
+      gasPrice: 2n,
+      fee: 1_200_000n,
+    });
   });
 
   function makeProvider(url: string) {

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -10,14 +10,20 @@ import {
   TransactionMessage,
   VersionedTransaction,
 } from '@solana/web3.js';
+import { BigNumber, providers as EthersV5Providers } from 'ethers';
+import { createPublicClient, custom } from 'viem';
 
-import { ProviderType } from './ProviderType.js';
+import { ProviderType, type ViemTransaction } from './ProviderType.js';
 import {
   clearCachedStargateClients,
   estimateTransactionFeeCosmJsWasm,
   estimateTransactionFeeEthersV5ForGasUnits,
   estimateTransactionFeeSolanaWeb3,
+  estimateTransactionFeeViem,
 } from './transactionFeeEstimators.js';
+
+const EVM_ADDRESS = '0x0000000000000000000000000000000000000001';
+const EVM_HASH = `0x${'01'.repeat(32)}` as const;
 
 describe('transactionFeeEstimators', () => {
   const sender = 'cosmos1sender';
@@ -42,15 +48,26 @@ describe('transactionFeeEstimators', () => {
     sandbox.restore();
   });
 
+  function makeEthersFeeProvider({
+    gasPrice,
+    maxFeePerGas,
+  }: {
+    gasPrice: bigint | null;
+    maxFeePerGas: bigint | null;
+  }): EthersV5Providers.Provider {
+    const provider = new EthersV5Providers.JsonRpcProvider();
+    sandbox.stub(provider, 'getFeeData').resolves({
+      gasPrice: gasPrice === null ? null : BigNumber.from(gasPrice),
+      lastBaseFeePerGas: null,
+      maxFeePerGas: maxFeePerGas === null ? null : BigNumber.from(maxFeePerGas),
+      maxPriorityFeePerGas: null,
+    });
+    return provider;
+  }
+
   it('uses the EIP-1559 max fee as the total gas price cap', async () => {
     const estimate = await estimateTransactionFeeEthersV5ForGasUnits({
-      provider: {
-        getFeeData: sandbox.stub().resolves({
-          gasPrice: 1n,
-          maxFeePerGas: 2n,
-          maxPriorityFeePerGas: 1n,
-        }),
-      } as any,
+      provider: makeEthersFeeProvider({ gasPrice: 1n, maxFeePerGas: 2n }),
       gasUnits: 600_000n,
     });
 
@@ -58,6 +75,61 @@ describe('transactionFeeEstimators', () => {
       gasUnits: 600_000n,
       gasPrice: 2n,
       fee: 1_200_000n,
+    });
+  });
+
+  it('keeps zero-valued Ethers fee data as present', async () => {
+    const estimate = await estimateTransactionFeeEthersV5ForGasUnits({
+      provider: makeEthersFeeProvider({ gasPrice: 0n, maxFeePerGas: 0n }),
+      gasUnits: 600_000n,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 600_000n,
+      gasPrice: 0n,
+      fee: 0n,
+    });
+  });
+
+  it('keeps zero-valued Viem fee data as present', async () => {
+    const client = createPublicClient({
+      transport: custom({
+        request: async () => {
+          throw new Error('Unexpected RPC request');
+        },
+      }),
+    });
+    sandbox.stub(client, 'estimateGas').resolves(21_000n);
+    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 0n });
+    const transaction = {
+      blockHash: EVM_HASH,
+      blockNumber: 1n,
+      from: EVM_ADDRESS,
+      gas: 21_000n,
+      gasPrice: 0n,
+      hash: EVM_HASH,
+      input: '0x',
+      nonce: 0,
+      r: '0x',
+      s: '0x',
+      to: EVM_ADDRESS,
+      transactionIndex: 0,
+      type: 'legacy',
+      typeHex: '0x0',
+      v: 27n,
+      value: 0n,
+    } satisfies ViemTransaction['transaction'];
+
+    const estimate = await estimateTransactionFeeViem({
+      transaction: { type: ProviderType.Viem, transaction },
+      provider: { type: ProviderType.Viem, provider: client },
+      sender: EVM_ADDRESS,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 21_000n,
+      gasPrice: 0n,
+      fee: 0n,
     });
   });
 

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -23,6 +23,7 @@ import {
   ProtocolType,
   assert,
   convertToProtocolAddress,
+  isNullish,
 } from '@hyperlane-xyz/utils';
 
 import { ChainMetadata } from '../metadata/chainMetadataTypes.js';
@@ -96,8 +97,12 @@ export async function estimateTransactionFeeEthersV5ForGasUnits({
   const feeData = await provider.getFeeData();
   return computeEvmTxFee(
     gasUnits,
-    feeData.gasPrice ? BigInt(feeData.gasPrice.toString()) : undefined,
-    feeData.maxFeePerGas ? BigInt(feeData.maxFeePerGas.toString()) : undefined,
+    !isNullish(feeData.gasPrice)
+      ? BigInt(feeData.gasPrice.toString())
+      : undefined,
+    !isNullish(feeData.maxFeePerGas)
+      ? BigInt(feeData.maxFeePerGas.toString())
+      : undefined,
   );
 }
 
@@ -125,9 +130,9 @@ function computeEvmTxFee(
   maxFeePerGas?: bigint,
 ): TransactionFeeEstimate {
   let estGasPrice: bigint;
-  if (maxFeePerGas) {
+  if (!isNullish(maxFeePerGas)) {
     estGasPrice = maxFeePerGas;
-  } else if (gasPrice) {
+  } else if (!isNullish(gasPrice)) {
     estGasPrice = gasPrice;
   } else {
     throw new Error('Invalid fee data, neither 1559 nor legacy');

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -98,9 +98,6 @@ export async function estimateTransactionFeeEthersV5ForGasUnits({
     gasUnits,
     feeData.gasPrice ? BigInt(feeData.gasPrice.toString()) : undefined,
     feeData.maxFeePerGas ? BigInt(feeData.maxFeePerGas.toString()) : undefined,
-    feeData.maxPriorityFeePerGas
-      ? BigInt(feeData.maxPriorityFeePerGas.toString())
-      : undefined,
   );
 }
 
@@ -119,23 +116,17 @@ export async function estimateTransactionFeeViem({
     account: sender as `0x${string}`,
   } as any); // Cast to silence overly-protective type enforcement from viem here
   const feeData = await provider.provider.estimateFeesPerGas();
-  return computeEvmTxFee(
-    gasUnits,
-    feeData.gasPrice,
-    feeData.maxFeePerGas,
-    feeData.maxPriorityFeePerGas,
-  );
+  return computeEvmTxFee(gasUnits, feeData.gasPrice, feeData.maxFeePerGas);
 }
 
 function computeEvmTxFee(
   gasUnits: bigint,
   gasPrice?: bigint,
   maxFeePerGas?: bigint,
-  maxPriorityFeePerGas?: bigint,
 ): TransactionFeeEstimate {
   let estGasPrice: bigint;
-  if (maxFeePerGas && maxPriorityFeePerGas) {
-    estGasPrice = maxFeePerGas + maxPriorityFeePerGas;
+  if (maxFeePerGas) {
+    estGasPrice = maxFeePerGas;
   } else if (gasPrice) {
     estGasPrice = gasPrice;
   } else {


### PR DESCRIPTION
## Summary

- treat maxFeePerGas as the full EIP-1559 gas price cap
- preserve the legacy gasPrice fallback
- add a regression covering the previous priority-fee double count

## Context

This keeps source transaction fee estimates consistent for universal-router-engine#92 and hyperlane-warp-ui-template#1197. It complements the Solana message-fee fix in #9270; consumers can bump once both SDK fixes are released.