### PR TITLE
chore: temporarily block SOLX/nitro message processing

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -749,6 +749,10 @@ const blacklist: MatchingList = [
     originDomain: getDomainId('starknet'),
     destinationDomain: getDomainId('starknet'),
   },
+  // SOLX/nitro temporarily blocked [2026-08-18]
+  // Active ATA rent-reclamation drain on Solaxy=>Solana (incident 01M0B3TFB2CBXS1G1SVKFJNXDT).
+  // Blocking all message processing for this route until the drain vector is mitigated.
+  ...warpRouteMatchingList('SOLX/nitro'),
 ];
 
 const ismCacheConfigs: Array<IsmCacheConfig> = [


### PR DESCRIPTION
## Summary
- Adds the `SOLX/nitro` warp route to the relayer blacklist matching list, halting **all** message processing for the route across ethereum, solanamainnet, and solaxy.
- Mitigation for an active ATA rent-reclamation drain on Solaxy=>Solana (Haggis incident `01M0B3TFB2CBXS1G1SVKFJNXDT`).
- Temporary — should be reverted once the drain vector is addressed.

## Details
Uses the existing `warpRouteMatchingList('SOLX/nitro')` helper, which resolves the route's router addresses from the registry and matches on both origin sender and destination recipient for every origin/destination pair.

## Test plan
- [ ] Confirm the block covers all three legs (ethereum <-> solanamainnet <-> solaxy)
- [ ] Deploy relayer with updated blacklist
- [ ] Verify SOLX/nitro messages stop being processed