### PR TITLE
fix(infra): raise solaxy->solanamainnet IGP quote to ~$0.40/msg (INC-34604)

### DIFF
--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -37,9 +37,13 @@ function getOracleConfigWithOverrides(origin: ChainName) {
       tokenExchangeRate: '15000000000000000000',
       tokenDecimals: 6,
     };
+    // tokenExchangeRate raised 12.65x (1.5e19 -> 1.898e20) to price the
+    // solaxy->solanamainnet IGP quote at ~$0.40/msg (from ~$0.032) at current
+    // SOLX price, deterring the ATA rent-harvest drain on the SOLX synthetic
+    // ata-payer. Fee = 664000 gas * rate/1e19 * 10^3 microSOLX (INC-34604).
     oracleConfig.solanamainnet = {
       gasPrice: '1',
-      tokenExchangeRate: '15000000000000000000',
+      tokenExchangeRate: '189800000000000000000',
       tokenDecimals: 6,
     };
   }


### PR DESCRIPTION
## Summary
- The SOLX synthetic **ata-payer** on solanamainnet is being drained by an ATA rent-harvest griefing loop: dust `1.0 SOLX` transfers from **solaxy** force the payer to prepay ATA rent (~0.00203 SOL) that the attacker reclaims by closing the ATA (~$1,850/day drain, INC-34604).
- The `solaxy→solanamainnet` IGP quote was ~**$0.032/msg** under `OnChainFeeQuoting` enforcement — far below the harvested rent, making the loop net-profitable.
- Raise the `solanamainnet` oracle `tokenExchangeRate` **12.65×** (`1.5e19 → 1.898e20`) so each message costs ~**$0.40** at current SOLX price, making the griefing loop unprofitable.

## Verification
- Ground-truthed against a live on-chain solaxy tx: `Paid IGP … for 664000 gas … to 1399811149`, IGP credited **+996,000,000 microSOLX** (= 996 SOLX ≈ $0.0316) at the old rate.
- New fee computed via a mirror of on-chain `compute_gas_fee`: `664000 × rate/1e19 × 10³ microSOLX` = **12,602.7 SOLX = $0.4000/msg** exactly.
- Fee is linear in `tokenExchangeRate`, so future re-tuning is a one-line change.
- `@hyperlane-xyz/infra` is private → no changeset.

## Notes / tradeoffs
- Legit SOLX bridgers also pay $0.40/msg on this leg.
- Static oracle: the USD value floats with SOLX price until the oracle is re-pushed.

## Deploy (post-merge, DEPLOYER / oracleKey `8MnEQt…qmay`)
```
tsx typescript/infra/scripts/deploy.ts -e mainnet3 -m igp --chains solaxy
```

## Test plan
- [ ] Confirm the computed diff in the `-m igp --chains solaxy` deploy dry-run matches only the solanamainnet remote `tokenExchangeRate` on the solaxy IGP oracle.
- [ ] After push, verify a live `solaxy→solanamainnet` transfer is quoted ~$0.40 and the drain stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)