### PR TITLE
fix(sealevel): fall back to basic log meta when advanced log meta is unresolvable

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/error.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/error.rs
@@ -50,8 +50,41 @@ pub enum HyperlaneSealevelError {
     NoNonNativePrograms(Box<H512>),
 }
 
+impl HyperlaneSealevelError {
+    /// Whether this error means a specific event's log meta could not be
+    /// resolved from the block recorded on its storage account (the block does
+    /// not contain the expected transaction after filtering, or contains more
+    /// than one). These are non-retryable: the block will never contain the
+    /// transaction, so sequence-aware indexing should fall back to basic log
+    /// meta and advance rather than rewinding on the same sequence forever.
+    pub fn is_log_meta_unresolvable(&self) -> bool {
+        matches!(self, Self::NoTransactions(_) | Self::TooManyTransactions(_))
+    }
+}
+
 impl From<HyperlaneSealevelError> for ChainCommunicationError {
     fn from(value: HyperlaneSealevelError) -> Self {
         ChainCommunicationError::from_other(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_meta_unresolvable_errors_are_non_retryable() {
+        assert!(HyperlaneSealevelError::NoTransactions("x".into()).is_log_meta_unresolvable());
+        assert!(HyperlaneSealevelError::TooManyTransactions("x".into()).is_log_meta_unresolvable());
+    }
+
+    #[test]
+    fn other_errors_are_not_log_meta_unresolvable() {
+        assert!(!HyperlaneSealevelError::EmptyMetadata.is_log_meta_unresolvable());
+        assert!(!HyperlaneSealevelError::EmptyComputeUnitsConsumed.is_log_meta_unresolvable());
+        assert!(
+            !HyperlaneSealevelError::UnsignedTransaction(Box::new(H512::zero()))
+                .is_log_meta_unresolvable()
+        );
     }
 }

--- a/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -7,7 +7,7 @@ use hyperlane_sealevel_igp::{
     igp_gas_payment_pda_seeds, igp_program_data_pda_seeds,
 };
 use solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use hyperlane_core::{
     config::StrOrIntParseError, ChainCommunicationError, ChainResult, ContractLocator,
@@ -175,6 +175,16 @@ impl SealevelInterchainGasPaymasterIndexer {
             gas_amount: gas_payment_account.gas_amount.into(),
         };
 
+        let basic_log_meta = LogMeta {
+            address: self.igp.program_id.to_bytes().into(),
+            block_number: gas_payment_account.slot,
+            // TODO: get these when building out scraper support.
+            // It's inconvenient to get these :|
+            block_hash: H256::zero(),
+            transaction_id: H512::zero(),
+            transaction_index: 0,
+            log_index: sequence_number.into(),
+        };
         let log_meta = if self.advanced_log_meta {
             self.interchain_payment_log_meta(
                 U256::from(sequence_number),
@@ -182,17 +192,9 @@ impl SealevelInterchainGasPaymasterIndexer {
                 &gas_payment_account.slot,
             )
             .await?
+            .unwrap_or(basic_log_meta)
         } else {
-            LogMeta {
-                address: self.igp.program_id.to_bytes().into(),
-                block_number: gas_payment_account.slot,
-                // TODO: get these when building out scraper support.
-                // It's inconvenient to get these :|
-                block_hash: H256::zero(),
-                transaction_id: H512::zero(),
-                transaction_index: 0,
-                log_index: sequence_number.into(),
-            }
+            basic_log_meta
         };
 
         Ok(SealevelGasPayment::new(
@@ -227,16 +229,35 @@ impl SealevelInterchainGasPaymasterIndexer {
         log_index: U256,
         payment_pda_pubkey: &Pubkey,
         payment_pda_slot: &Slot,
-    ) -> ChainResult<LogMeta> {
+    ) -> ChainResult<Option<LogMeta>> {
         let block = self
             .provider
             .rpc_client()
             .get_block(*payment_pda_slot)
             .await?;
 
-        self.log_meta_composer
-            .log_meta(block, log_index, payment_pda_pubkey, payment_pda_slot)
-            .map_err(Into::<ChainCommunicationError>::into)
+        match self.log_meta_composer.log_meta(
+            block,
+            log_index,
+            payment_pda_pubkey,
+            payment_pda_slot,
+        ) {
+            Ok(log_meta) => Ok(Some(log_meta)),
+            // The block will never contain the expected transaction after filtering, so falling
+            // back to basic log meta lets the sequence-aware cursor advance instead of rewinding
+            // on the same sequence forever.
+            Err(err) if err.is_log_meta_unresolvable() => {
+                warn!(
+                    ?err,
+                    ?payment_pda_pubkey,
+                    ?payment_pda_slot,
+                    "Could not resolve advanced log meta for interchain gas payment, \
+                     falling back to basic log meta",
+                );
+                Ok(None)
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox_indexer.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox_indexer.rs
@@ -12,7 +12,7 @@ use hyperlane_sealevel_mailbox::{
     mailbox_dispatched_message_pda_seeds, mailbox_processed_message_pda_seeds,
 };
 use solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use hyperlane_core::{
     config::StrOrIntParseError, ChainCommunicationError, ChainResult, ContractLocator, Decode as _,
@@ -107,6 +107,16 @@ impl SealevelMailboxIndexer {
         let hyperlane_message =
             HyperlaneMessage::read_from(&mut &dispatched_message_account.encoded_message[..])?;
 
+        let basic_log_meta = LogMeta {
+            address: self.program_id.to_bytes().into(),
+            block_number: dispatched_message_account.slot,
+            // TODO: get these when building out scraper support.
+            // It's inconvenient to get these :|
+            block_hash: H256::zero(),
+            transaction_id: H512::zero(),
+            transaction_index: 0,
+            log_index: U256::zero(),
+        };
         let log_meta = if self.advanced_log_meta {
             self.dispatch_message_log_meta(
                 U256::from(nonce),
@@ -114,17 +124,9 @@ impl SealevelMailboxIndexer {
                 &dispatched_message_account.slot,
             )
             .await?
+            .unwrap_or(basic_log_meta)
         } else {
-            LogMeta {
-                address: self.program_id.to_bytes().into(),
-                block_number: dispatched_message_account.slot,
-                // TODO: get these when building out scraper support.
-                // It's inconvenient to get these :|
-                block_hash: H256::zero(),
-                transaction_id: H512::zero(),
-                transaction_index: 0,
-                log_index: U256::zero(),
-            }
+            basic_log_meta
         };
 
         Ok((hyperlane_message.into(), log_meta))
@@ -146,12 +148,19 @@ impl SealevelMailboxIndexer {
         Ok(expected_pubkey)
     }
 
+    /// Resolves the on-chain log meta for a dispatched message.
+    ///
+    /// Returns `Ok(None)` when the log meta cannot be resolved from the block
+    /// recorded on the message account (the block does not contain the dispatch
+    /// transaction). This is non-retryable, so callers fall back to basic log
+    /// meta instead of stalling the sequence-aware cursor. Transient RPC errors
+    /// still propagate as `Err` so they are retried.
     async fn dispatch_message_log_meta(
         &self,
         log_index: U256,
         message_storage_pda_pubkey: &Pubkey,
         message_account_slot: &Slot,
-    ) -> ChainResult<LogMeta> {
+    ) -> ChainResult<Option<LogMeta>> {
         let block = self
             .mailbox
             .provider
@@ -159,14 +168,24 @@ impl SealevelMailboxIndexer {
             .get_block(*message_account_slot)
             .await?;
 
-        self.dispatch_message_log_meta_composer
-            .log_meta(
-                block,
-                log_index,
-                message_storage_pda_pubkey,
-                message_account_slot,
-            )
-            .map_err(Into::<ChainCommunicationError>::into)
+        match self.dispatch_message_log_meta_composer.log_meta(
+            block,
+            log_index,
+            message_storage_pda_pubkey,
+            message_account_slot,
+        ) {
+            Ok(log_meta) => Ok(Some(log_meta)),
+            Err(err) if err.is_log_meta_unresolvable() => {
+                warn!(
+                    ?err,
+                    ?message_storage_pda_pubkey,
+                    slot = message_account_slot,
+                    "Could not resolve advanced log meta for message dispatch; falling back to basic log meta",
+                );
+                Ok(None)
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 
     async fn get_delivered_message_with_sequence(
@@ -205,6 +224,16 @@ impl SealevelMailboxIndexer {
             .into_inner();
         let message_id = delivered_message_account.message_id;
 
+        let basic_log_meta = LogMeta {
+            address: self.program_id.to_bytes().into(),
+            block_number: delivered_message_account.slot,
+            // TODO: get these when building out scraper support.
+            // It's inconvenient to get these :|
+            block_hash: H256::zero(),
+            transaction_id: H512::zero(),
+            transaction_index: 0,
+            log_index: U256::zero(),
+        };
         let log_meta = if self.advanced_log_meta {
             self.delivered_message_log_meta(
                 U256::from(sequence),
@@ -212,17 +241,9 @@ impl SealevelMailboxIndexer {
                 &delivered_message_account.slot,
             )
             .await?
+            .unwrap_or(basic_log_meta)
         } else {
-            LogMeta {
-                address: self.program_id.to_bytes().into(),
-                block_number: delivered_message_account.slot,
-                // TODO: get these when building out scraper support.
-                // It's inconvenient to get these :|
-                block_hash: H256::zero(),
-                transaction_id: H512::zero(),
-                transaction_index: 0,
-                log_index: U256::zero(),
-            }
+            basic_log_meta
         };
 
         let mut indexed = Indexed::from(message_id);
@@ -243,12 +264,14 @@ impl SealevelMailboxIndexer {
         Ok(expected_pubkey)
     }
 
+    /// Resolves the on-chain log meta for a delivered message. See
+    /// [`Self::dispatch_message_log_meta`] for the `Ok(None)` fallback contract.
     async fn delivered_message_log_meta(
         &self,
         log_index: U256,
         message_storage_pda_pubkey: &Pubkey,
         message_account_slot: &Slot,
-    ) -> ChainResult<LogMeta> {
+    ) -> ChainResult<Option<LogMeta>> {
         let block = self
             .mailbox
             .provider
@@ -256,14 +279,24 @@ impl SealevelMailboxIndexer {
             .get_block(*message_account_slot)
             .await?;
 
-        self.delivery_message_log_meta_composer
-            .log_meta(
-                block,
-                log_index,
-                message_storage_pda_pubkey,
-                message_account_slot,
-            )
-            .map_err(Into::<ChainCommunicationError>::into)
+        match self.delivery_message_log_meta_composer.log_meta(
+            block,
+            log_index,
+            message_storage_pda_pubkey,
+            message_account_slot,
+        ) {
+            Ok(log_meta) => Ok(Some(log_meta)),
+            Err(err) if err.is_log_meta_unresolvable() => {
+                warn!(
+                    ?err,
+                    ?message_storage_pda_pubkey,
+                    slot = message_account_slot,
+                    "Could not resolve advanced log meta for message delivery; falling back to basic log meta",
+                );
+                Ok(None)
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a head-of-line-blocking stall in the **scraper's** Sealevel (Solana/SVM) message and gas-payment indexing.

### Mechanism
The scraper runs sequence-aware indexers with `advanced_log_meta = true`. To build advanced `LogMeta`, it fetches the block recorded on a message/payment storage account (`get_block(slot)`) and uses `LogMetaComposer` to find the transaction that operated on that account's PDA with the expected instruction (`OutboxDispatch` / `InboxProcess` / `PayForGas`).

When that block does **not** contain a matching transaction after filtering (or contains more than one), the composer returned `NoTransactions` / `TooManyTransactions`. The `ForwardSequenceAwareSyncCursor` treats any error as retryable: it rewinds to the last snapshot and retries the **same** sequence forever. Because sequences are processed in strict order, one unresolvable sequence freezes indexing for **every** later sequence on that chain.

This is exactly what happened on `solaxy`: the `message_dispatch` / `gas_payment` cursors were stuck at seq ~344 (block ~23970264) for 4+ hours, ~1740 messages behind, because that block's dispatch transactions did not include the target sequence's PDA (a slot/tx-mapping quirk on that chain).

### Fix
- Add `HyperlaneSealevelError::is_log_meta_unresolvable()` to classify the two **permanent, block-level** composer failures (`NoTransactions`, `TooManyTransactions`) as non-retryable — the block will never contain the transaction.
- The mailbox dispatch/delivery and IGP payment log-meta helpers now return `ChainResult<Option<LogMeta>>`. On an unresolvable failure they log a warning and return `None`; the caller falls back to **basic (zero-filled) `LogMeta`** so the cursor advances. Transient RPC errors still propagate as `Err` and are retried.

### Why this is safe / scoped
- **Relayer is unaffected**: it runs with `ADVANCED_LOG_META = false` and already uses basic log meta.
- Downstream storage tolerates zero-tx log meta: `ensure_txns` filters `!hash.is_zero()`, so a zero-filled fallback does not error the batch.
- Behavior only changes on the permanent-failure path that previously stalled the cursor.

### Limitation
Genuinely unresolvable messages get basic log meta (no real block hash / tx id), so the scraper stores them without full on-chain tx enrichment rather than stalling. The underlying `solaxy` slot↔tx mapping quirk (message account records a slot whose block lacks the dispatch tx) should be raised with the solaxy team separately.

## Test plan
- [x] `cargo check -p hyperlane-sealevel`
- [x] `cargo clippy -p hyperlane-sealevel -- -D warnings`
- [x] `cargo test -p hyperlane-sealevel error::` (new unit tests for `is_log_meta_unresolvable`)
- [ ] Observe scraper `solaxy` cursors advance after deploy (`hyperlane_contract_sync_stored_events{agent="scraper",chain="solaxy"}`)