### PR TITLE
fix(igp): correct solaxy IGP oracles to tollkeeper-recommended values

### DIFF
--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -112,14 +112,6 @@
       },
       "overhead": 166887
     },
-    "flowmainnet": {
-      "oracleConfig": {
-        "tokenExchangeRate": "6472163454775636",
-        "gasPrice": "20041879688128",
-        "tokenDecimals": 18
-      },
-      "overhead": 166887
-    },
     "fluent": {
       "oracleConfig": {
         "tokenExchangeRate": "368201575467716978478",

--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -112,6 +112,14 @@
       },
       "overhead": 166887
     },
+    "flowmainnet": {
+      "oracleConfig": {
+        "tokenExchangeRate": "6472163454775636",
+        "gasPrice": "20041879688128",
+        "tokenDecimals": 18
+      },
+      "overhead": 166887
+    },
     "fluent": {
       "oracleConfig": {
         "tokenExchangeRate": "368201575467716978478",
@@ -488,8 +496,8 @@
     },
     "solanamainnet": {
       "oracleConfig": {
-        "gasPrice": "25000",
-        "tokenExchangeRate": "15000000000000000000",
+        "gasPrice": "1",
+        "tokenExchangeRate": "375000000000000000000000",
         "tokenDecimals": 6
       },
       "overhead": 600000

--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -480,17 +480,17 @@
   "solaxy": {
     "ethereum": {
       "oracleConfig": {
-        "gasPrice": "9",
-        "tokenExchangeRate": "15000000000000000000",
-        "tokenDecimals": 6
+        "gasPrice": "51695712",
+        "tokenExchangeRate": "691771710368053885013231",
+        "tokenDecimals": 18
       },
       "overhead": 159337
     },
     "solanamainnet": {
       "oracleConfig": {
-        "gasPrice": "1",
-        "tokenExchangeRate": "375000000000000000000000",
-        "tokenDecimals": 6
+        "gasPrice": "6",
+        "tokenExchangeRate": "2784941063266778928",
+        "tokenDecimals": 9
       },
       "overhead": 600000
     }

--- a/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
+++ b/rust/sealevel/environments/mainnet3/gas-oracle-configs.json
@@ -488,7 +488,7 @@
     },
     "solanamainnet": {
       "oracleConfig": {
-        "gasPrice": "1",
+        "gasPrice": "25000",
         "tokenExchangeRate": "15000000000000000000",
         "tokenDecimals": 6
       },

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -37,9 +37,15 @@ function getOracleConfigWithOverrides(origin: ChainName) {
       tokenExchangeRate: '15000000000000000000',
       tokenDecimals: 6,
     };
+    // solaxy -> solanamainnet must quote above the ~0.00204 SOL ATA rent the
+    // relayer fronts per delivery, otherwise it can be drained via ATA-rent
+    // reclaim. The min-USD-cost floor does not reach this hardcoded override, so
+    // the fee is raised here via the exchange rate (the SOLX-price proxy) rather
+    // than gasPrice, keeping gasPrice='1' as the true solana gas signal and
+    // isolating the change to this leg. 25000x the base rate -> ~$0.72.
     oracleConfig.solanamainnet = {
       gasPrice: '1',
-      tokenExchangeRate: '15000000000000000000',
+      tokenExchangeRate: '375000000000000000000000',
       tokenDecimals: 6,
     };
   }

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -27,16 +27,25 @@ const tokenPrices: ChainMap<string> = rawTokenPrices;
 function getOracleConfigWithOverrides(origin: ChainName) {
   const oracleConfig = getStorageGasOracleConfig()[origin];
 
-  // WORKAROUND for Sealevel IGP decimal bug (solaxy-specific):
-  // The Rust Sealevel IGP code hardcodes local SOL_DECIMALS = 9, but solaxy's
-  // native SOLX has 6 decimals, so convert_decimals over-scales by 10^(9-6)=1000.
-  // These values mirror what is set on-chain and are the values tollkeeper's
-  // (decimal-compensated, min-USD-floored) IGP logic recommends: gasPrice is the
-  // true remote gas signal, tokenExchangeRate carries the SOLX-price proxy plus
-  // the 10^(D-9) decimal compensation, and tokenDecimals is the REMOTE token's
-  // decimals (9 for solana, 18 for ethereum). Keep this block in sync with any
-  // on-chain change (see scripts/sealevel-helpers/update-gas-oracles.ts and the
-  // svm-igp-gas-oracle-update skill's two-signer path).
+  // INTENTION: correct the two underpriced solaxy IGP legs (they were drained via
+  // ATA-rent reclaim) while isolating the change to the solaxy origin only. We do
+  // NOT touch gasPrices.json or tokenPrices.json, so no sibling lane and no other
+  // origin->solanamainnet rate moves; the fix lives entirely in this per-origin
+  // override.
+  //
+  // WHY A HARDCODED PER-LEG BLOCK (not a solaxy token-price bump): the deployed
+  // Rust Sealevel IGP hardcodes local SOL_DECIMALS = 9, but solaxy's native SOLX
+  // has 6 decimals, so convert_decimals over-scales every solaxy leg by
+  // 10^(9-6)=1000. A plain token-price change would be 1000x off and could not
+  // encode the per-leg remote tokenDecimals. So each leg carries: gasPrice = the
+  // true remote gas signal; tokenExchangeRate = SOLX-price proxy x the 10^(D-9)
+  // decimal compensation; tokenDecimals = the REMOTE token's decimals (9 solana /
+  // 18 ethereum).
+  //
+  // These are exactly the values tollkeeper's (decimal-compensated, min-USD-
+  // floored) IGP logic recommends and that are set on-chain. This block MUST stay
+  // in sync with on-chain (see scripts/sealevel-helpers/update-gas-oracles.ts and
+  // the svm-igp-gas-oracle-update skill's two-signer path).
   if (origin === 'solaxy') {
     oracleConfig.ethereum = {
       gasPrice: '51695712',

--- a/typescript/infra/config/environments/mainnet3/igp.ts
+++ b/typescript/infra/config/environments/mainnet3/igp.ts
@@ -28,25 +28,28 @@ function getOracleConfigWithOverrides(origin: ChainName) {
   const oracleConfig = getStorageGasOracleConfig()[origin];
 
   // WORKAROUND for Sealevel IGP decimal bug (solaxy-specific):
-  // The Rust Sealevel IGP code hardcodes SOL_DECIMALS = 9, but solaxy has 6 decimals.
-  // Rather than trying to calculate the correct workaround values, we hardcode
-  // the values that are already set on-chain and known to work.
+  // The Rust Sealevel IGP code hardcodes local SOL_DECIMALS = 9, but solaxy's
+  // native SOLX has 6 decimals, so convert_decimals over-scales by 10^(9-6)=1000.
+  // These values mirror what is set on-chain and are the values tollkeeper's
+  // (decimal-compensated, min-USD-floored) IGP logic recommends: gasPrice is the
+  // true remote gas signal, tokenExchangeRate carries the SOLX-price proxy plus
+  // the 10^(D-9) decimal compensation, and tokenDecimals is the REMOTE token's
+  // decimals (9 for solana, 18 for ethereum). Keep this block in sync with any
+  // on-chain change (see scripts/sealevel-helpers/update-gas-oracles.ts and the
+  // svm-igp-gas-oracle-update skill's two-signer path).
   if (origin === 'solaxy') {
     oracleConfig.ethereum = {
-      gasPrice: '9',
-      tokenExchangeRate: '15000000000000000000',
-      tokenDecimals: 6,
+      gasPrice: '51695712',
+      tokenExchangeRate: '691771710368053885013231',
+      tokenDecimals: 18,
     };
     // solaxy -> solanamainnet must quote above the ~0.00204 SOL ATA rent the
     // relayer fronts per delivery, otherwise it can be drained via ATA-rent
-    // reclaim. The min-USD-cost floor does not reach this hardcoded override, so
-    // the fee is raised here via the exchange rate (the SOLX-price proxy) rather
-    // than gasPrice, keeping gasPrice='1' as the true solana gas signal and
-    // isolating the change to this leg. 25000x the base rate -> ~$0.72.
+    // reclaim. Quotes ~$0.45 (above rent + delivery gas).
     oracleConfig.solanamainnet = {
-      gasPrice: '1',
-      tokenExchangeRate: '375000000000000000000000',
-      tokenDecimals: 6,
+      gasPrice: '6',
+      tokenExchangeRate: '2784941063266778928',
+      tokenDecimals: 9,
     };
   }
 


### PR DESCRIPTION
## Summary
- Corrects the hardcoded solaxy IGP gas-oracle overrides (`solaxy->solanamainnet`, `solaxy->ethereum`) in `mainnet3/igp.ts` and regenerates the matching entries in `gas-oracle-configs.json`.
- Values mirror what is now set **on-chain** (applied via the Turnkey-owner + separate-fee-payer two-signer path) and match tollkeeper's decimal-compensated, min-USD-floored recommendation.
- The prior override did not compensate for the deployed Rust IGP hardcoding local `SOL_DECIMALS=9` while solaxy's native SOLX has 6 decimals. `tokenExchangeRate` now carries the SOLX-price proxy plus the `10^(D-9)` decimal compensation, `gasPrice` stays the true remote gas signal, and `tokenDecimals` is the remote token's decimals (9 solana / 18 ethereum). The solana leg quotes ~$0.45, above the ~0.00204 SOL ATA rent the relayer fronts (the ATA-rent-reclaim drain vector).

New on-chain / config values:
| leg | gasPrice | tokenExchangeRate | tokenDecimals |
| --- | --- | --- | --- |
| solaxy->solanamainnet | 6 | 2784941063266778928 | 9 |
| solaxy->ethereum | 51695712 | 691771710368053885013231 | 18 |

Diff scope is limited to the two solaxy legs (no unrelated regen drift).

## Test plan
- [x] Values applied and verified on-chain (re-deserialized IGP account shows the new gas_oracles).
- [x] `gas-oracle-configs.json` diff vs main is limited to the two solaxy legs.
- [x] Lint/format hooks pass.