### PR TITLE
fix(sealevel): recover log metadata from previous slot

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6629,6 +6629,7 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "maplit",
+ "mockall",
  "multisig-ism",
  "num-traits",
  "reqwest 0.11.27",

--- a/rust/main/chains/hyperlane-sealevel/Cargo.toml
+++ b/rust/main/chains/hyperlane-sealevel/Cargo.toml
@@ -72,4 +72,5 @@ serializable-account-meta = { path = "../../../sealevel/libraries/serializable-a
 
 [dev-dependencies]
 hex.workspace = true
+mockall.workspace = true
 rstest.workspace = true

--- a/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/interchain_gas.rs
@@ -7,7 +7,7 @@ use hyperlane_sealevel_igp::{
     igp_gas_payment_pda_seeds, igp_program_data_pda_seeds,
 };
 use solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey};
-use tracing::{info, instrument, warn};
+use tracing::{info, instrument};
 
 use hyperlane_core::{
     config::StrOrIntParseError, ChainCommunicationError, ChainResult, ContractLocator,
@@ -16,8 +16,6 @@ use hyperlane_core::{
 };
 
 use crate::account::{search_accounts_by_discriminator, search_and_validate_account};
-use crate::error::is_get_block_unresolvable_after_retries;
-use crate::fallback::SubmitSealevelRpc;
 use crate::log_meta_composer::{is_interchain_payment_instruction, LogMetaComposer};
 use crate::SealevelProvider;
 
@@ -231,48 +229,14 @@ impl SealevelInterchainGasPaymasterIndexer {
         payment_pda_pubkey: &Pubkey,
         payment_pda_slot: &Slot,
     ) -> ChainResult<Option<LogMeta>> {
-        let block = match self
-            .provider
-            .rpc_client()
-            .get_block(*payment_pda_slot)
+        self.log_meta_composer
+            .resolve_log_meta(
+                self.provider.rpc_client(),
+                log_index,
+                payment_pda_pubkey,
+                *payment_pda_slot,
+            )
             .await
-        {
-            Ok(block) => block,
-            Err(err) if is_get_block_unresolvable_after_retries(&err) => {
-                warn!(
-                    ?err,
-                    ?payment_pda_pubkey,
-                    ?payment_pda_slot,
-                    "Block for interchain gas payment is unavailable after provider retries; \
-                     falling back to basic log meta",
-                );
-                return Ok(None);
-            }
-            Err(err) => return Err(err),
-        };
-
-        match self.log_meta_composer.log_meta(
-            block,
-            log_index,
-            payment_pda_pubkey,
-            payment_pda_slot,
-        ) {
-            Ok(log_meta) => Ok(Some(log_meta)),
-            // The block will never contain the expected transaction after filtering, so falling
-            // back to basic log meta lets the sequence-aware cursor advance instead of rewinding
-            // on the same sequence forever.
-            Err(err) if err.is_log_meta_unresolvable() => {
-                warn!(
-                    ?err,
-                    ?payment_pda_pubkey,
-                    ?payment_pda_slot,
-                    "Could not resolve advanced log meta for interchain gas payment, \
-                     falling back to basic log meta",
-                );
-                Ok(None)
-            }
-            Err(err) => Err(err.into()),
-        }
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/log_meta_composer.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/log_meta_composer.rs
@@ -6,11 +6,12 @@ use solana_transaction_status::{
     UiCompiledInstruction, UiConfirmedBlock, UiInstruction, UiMessage, UiTransaction,
     UiTransactionStatusMeta,
 };
-use tracing::warn;
+use tracing::{info, warn};
 
-use hyperlane_core::{LogMeta, H512, U256};
+use hyperlane_core::{ChainResult, LogMeta, H512, U256};
 
-use crate::error::HyperlaneSealevelError;
+use crate::error::{is_get_block_unresolvable_after_retries, HyperlaneSealevelError};
+use crate::fallback::SubmitSealevelRpc;
 use crate::utils::{decode_h256, decode_h512, from_base58};
 
 #[derive(Debug)]
@@ -83,6 +84,101 @@ impl LogMetaComposer {
         };
 
         Ok(log_meta)
+    }
+
+    /// Resolves log metadata from the recorded slot, then checks the preceding
+    /// slot when the recorded block is unavailable or lacks the expected
+    /// transaction. Some Sealevel chains record an event PDA one slot after
+    /// its transaction was included.
+    ///
+    /// The preceding slot is only an enrichment path: it must contain exactly
+    /// one matching program instruction operating on the event PDA. Any
+    /// failure there returns `Ok(None)` so callers retain the basic-log-meta
+    /// fallback and sequence-aware indexing cannot stall.
+    pub async fn resolve_log_meta(
+        &self,
+        rpc_client: &dyn SubmitSealevelRpc,
+        log_index: U256,
+        pda_pubkey: &Pubkey,
+        recorded_slot: Slot,
+    ) -> ChainResult<Option<LogMeta>> {
+        match rpc_client.get_block(recorded_slot).await {
+            Ok(block) => match self.log_meta(block, log_index, pda_pubkey, &recorded_slot) {
+                Ok(log_meta) => return Ok(Some(log_meta)),
+                Err(HyperlaneSealevelError::NoTransactions(err)) => {
+                    warn!(
+                        %err,
+                        ?pda_pubkey,
+                        recorded_slot,
+                        transaction = %self.transaction_description,
+                        "Expected transaction was not found in recorded slot; checking previous slot",
+                    );
+                }
+                Err(err @ HyperlaneSealevelError::TooManyTransactions(_)) => {
+                    warn!(
+                        ?err,
+                        ?pda_pubkey,
+                        recorded_slot,
+                        transaction = %self.transaction_description,
+                        "Recorded slot contains ambiguous matching transactions; falling back to basic log meta",
+                    );
+                    return Ok(None);
+                }
+                Err(err) => return Err(err.into()),
+            },
+            Err(err) if is_get_block_unresolvable_after_retries(&err) => {
+                warn!(
+                    ?err,
+                    ?pda_pubkey,
+                    recorded_slot,
+                    transaction = %self.transaction_description,
+                    "Recorded block is unavailable after provider retries; checking previous slot",
+                );
+            }
+            Err(err) => return Err(err),
+        }
+
+        let Some(previous_slot) = recorded_slot.checked_sub(1) else {
+            return Ok(None);
+        };
+        let previous_block = match rpc_client.get_block(previous_slot).await {
+            Ok(block) => block,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    ?pda_pubkey,
+                    recorded_slot,
+                    previous_slot,
+                    transaction = %self.transaction_description,
+                    "Could not inspect previous slot; falling back to basic log meta",
+                );
+                return Ok(None);
+            }
+        };
+
+        match self.log_meta(previous_block, log_index, pda_pubkey, &previous_slot) {
+            Ok(log_meta) => {
+                info!(
+                    ?pda_pubkey,
+                    recorded_slot,
+                    previous_slot,
+                    transaction = %self.transaction_description,
+                    "Resolved log metadata from previous slot",
+                );
+                Ok(Some(log_meta))
+            }
+            Err(err) => {
+                warn!(
+                    ?err,
+                    ?pda_pubkey,
+                    recorded_slot,
+                    previous_slot,
+                    transaction = %self.transaction_description,
+                    "Could not resolve log metadata from previous slot; falling back to basic log meta",
+                );
+                Ok(None)
+            }
+        }
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/log_meta_composer/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/log_meta_composer/tests.rs
@@ -1,9 +1,26 @@
 use std::fs;
 use std::path::PathBuf;
 
-use hyperlane_core::{LogMeta, U256};
-use solana_transaction_status::{EncodedTransactionWithStatusMeta, UiConfirmedBlock};
+use async_trait::async_trait;
+use hyperlane_core::{ChainCommunicationError, ChainResult, LogMeta, U256};
+use mockall::{mock, predicate::eq};
+use solana_client::{
+    client_error::{ClientError, ClientErrorKind},
+    rpc_request::{RpcError, RpcResponseErrorData},
+    rpc_response::RpcSimulateTransactionResult,
+};
+use solana_commitment_config::CommitmentConfig;
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::Signature,
+    transaction::{Transaction, VersionedTransaction},
+};
+use solana_transaction_status::{
+    EncodedConfirmedTransactionWithStatusMeta, EncodedTransactionWithStatusMeta, UiConfirmedBlock,
+};
 
+use crate::error::HyperlaneSealevelError;
+use crate::fallback::SubmitSealevelRpc;
 use crate::log_meta_composer::{
     is_interchain_payment_instruction, is_message_delivery_instruction,
     is_message_dispatch_instruction, search_transactions,
@@ -11,6 +28,37 @@ use crate::log_meta_composer::{
 use crate::utils::{decode_h256, decode_h512, decode_pubkey};
 
 use super::LogMetaComposer;
+
+mock! {
+    RpcClient {}
+
+    #[async_trait]
+    impl SubmitSealevelRpc for RpcClient {
+        async fn get_block(&self, slot: u64) -> ChainResult<UiConfirmedBlock>;
+
+        async fn get_block_with_commitment(
+            &self,
+            slot: u64,
+            commitment: CommitmentConfig,
+        ) -> ChainResult<UiConfirmedBlock>;
+
+        async fn get_transaction_with_commitment(
+            &self,
+            signature: Signature,
+            commitment: CommitmentConfig,
+        ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
+
+        async fn simulate_transaction(
+            &self,
+            transaction: &Transaction,
+        ) -> ChainResult<RpcSimulateTransactionResult>;
+
+        async fn simulate_versioned_transaction(
+            &self,
+            transaction: &VersionedTransaction,
+        ) -> ChainResult<RpcSimulateTransactionResult>;
+    }
+}
 
 #[test]
 pub fn test_search_dispatched_message_transaction() {
@@ -229,6 +277,140 @@ fn test_log_meta_block_with_txn_interchain_payment_search_solaxy() {
     });
 }
 
+#[tokio::test]
+async fn resolves_log_meta_from_previous_slot_when_recorded_slot_has_no_match() {
+    let (composer, payment_pda_account, matching_block) = solaxy_payment_fixture();
+    let expected_block_hash = decode_h256(&matching_block.blockhash).expect("valid block hash");
+    let mut recorded_block = matching_block.clone();
+    recorded_block.transactions = Some(vec![]);
+
+    let recorded_slot = 10_001;
+    let previous_slot = recorded_slot - 1;
+    let mut rpc_client = MockRpcClient::new();
+    rpc_client
+        .expect_get_block()
+        .with(eq(recorded_slot))
+        .once()
+        .return_once(move |_| Ok(recorded_block));
+    rpc_client
+        .expect_get_block()
+        .with(eq(previous_slot))
+        .once()
+        .return_once(move |_| Ok(matching_block));
+
+    let log_meta = composer
+        .resolve_log_meta(
+            &rpc_client,
+            U256::zero(),
+            &payment_pda_account,
+            recorded_slot,
+        )
+        .await
+        .expect("log meta lookup succeeds")
+        .expect("previous slot matches");
+
+    assert_eq!(log_meta.block_number, previous_slot);
+    assert_eq!(log_meta.block_hash, expected_block_hash);
+    assert!(!log_meta.transaction_id.is_zero());
+}
+
+#[tokio::test]
+async fn resolves_log_meta_from_previous_slot_when_recorded_block_is_unavailable() {
+    let (composer, payment_pda_account, matching_block) = solaxy_payment_fixture();
+
+    let recorded_slot = 10_001;
+    let previous_slot = recorded_slot - 1;
+    let mut rpc_client = MockRpcClient::new();
+    rpc_client
+        .expect_get_block()
+        .with(eq(recorded_slot))
+        .once()
+        .return_once(|_| Err(block_unavailable_error()));
+    rpc_client
+        .expect_get_block()
+        .with(eq(previous_slot))
+        .once()
+        .return_once(move |_| Ok(matching_block));
+
+    let log_meta = composer
+        .resolve_log_meta(
+            &rpc_client,
+            U256::zero(),
+            &payment_pda_account,
+            recorded_slot,
+        )
+        .await
+        .expect("log meta lookup succeeds")
+        .expect("previous slot matches");
+
+    assert_eq!(log_meta.block_number, previous_slot);
+    assert!(!log_meta.transaction_id.is_zero());
+}
+
+#[tokio::test]
+async fn previous_slot_rpc_failure_preserves_basic_log_meta_fallback() {
+    let (composer, payment_pda_account, mut recorded_block) = solaxy_payment_fixture();
+    recorded_block.transactions = Some(vec![]);
+
+    let recorded_slot = 10_001;
+    let previous_slot = recorded_slot - 1;
+    let mut rpc_client = MockRpcClient::new();
+    rpc_client
+        .expect_get_block()
+        .with(eq(recorded_slot))
+        .once()
+        .return_once(move |_| Ok(recorded_block));
+    rpc_client
+        .expect_get_block()
+        .with(eq(previous_slot))
+        .once()
+        .return_once(|_| {
+            Err(ChainCommunicationError::from_other_str(
+                "previous slot RPC failed",
+            ))
+        });
+
+    let log_meta = composer
+        .resolve_log_meta(
+            &rpc_client,
+            U256::zero(),
+            &payment_pda_account,
+            recorded_slot,
+        )
+        .await
+        .expect("optional previous-slot failure is non-fatal");
+
+    assert!(log_meta.is_none());
+}
+
+#[tokio::test]
+async fn transient_recorded_slot_error_remains_retryable() {
+    let (composer, payment_pda_account, _) = solaxy_payment_fixture();
+
+    let recorded_slot = 10_001;
+    let mut rpc_client = MockRpcClient::new();
+    rpc_client
+        .expect_get_block()
+        .with(eq(recorded_slot))
+        .once()
+        .return_once(|_| {
+            Err(ChainCommunicationError::from_other_str(
+                "transient RPC failure",
+            ))
+        });
+
+    let result = composer
+        .resolve_log_meta(
+            &rpc_client,
+            U256::zero(),
+            &payment_pda_account,
+            recorded_slot,
+        )
+        .await;
+
+    assert!(result.is_err());
+}
+
 fn read_json(path: &str) -> String {
     let relative = PathBuf::new().join("src/log_meta_composer/").join(path);
     let absolute = fs::canonicalize(relative).expect("cannot find path");
@@ -239,4 +421,34 @@ fn transactions(json: &str) -> Vec<EncodedTransactionWithStatusMeta> {
     let transaction = serde_json::from_str::<EncodedTransactionWithStatusMeta>(json).unwrap();
     let transactions = vec![transaction];
     transactions
+}
+
+fn solaxy_payment_fixture() -> (LogMetaComposer, Pubkey, UiConfirmedBlock) {
+    let igp_program_id =
+        decode_pubkey("VG7YDF5Am2hrgyydE2ufdusdtw5DjgzXJLFxn9p8ehU").expect("valid IGP program ID");
+    let payment_pda_account =
+        decode_pubkey("4hWzwVjSd2Mi9kKxJuYGEL9j4dPnTtLSSBp3txR1egPM").expect("valid payment PDA");
+    let composer = LogMetaComposer::new(
+        igp_program_id,
+        "interchain gas payment".to_owned(),
+        is_interchain_payment_instruction,
+    );
+    let block = serde_json::from_str(&read_json(
+        "dispatch_message_block_interchain_payment_search_solaxy.json",
+    ))
+    .expect("valid Solaxy block fixture");
+    (composer, payment_pda_account, block)
+}
+
+fn block_unavailable_error() -> ChainCommunicationError {
+    use solana_client::rpc_custom_error::JSON_RPC_SERVER_ERROR_SLOT_SKIPPED;
+
+    HyperlaneSealevelError::ClientError(Box::new(ClientError::from(ClientErrorKind::RpcError(
+        RpcError::RpcResponseError {
+            code: JSON_RPC_SERVER_ERROR_SLOT_SKIPPED,
+            message: "slot skipped".to_owned(),
+            data: RpcResponseErrorData::Empty,
+        },
+    ))))
+    .into()
 }

--- a/rust/main/chains/hyperlane-sealevel/src/mailbox_indexer.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/mailbox_indexer.rs
@@ -12,7 +12,7 @@ use hyperlane_sealevel_mailbox::{
     mailbox_dispatched_message_pda_seeds, mailbox_processed_message_pda_seeds,
 };
 use solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use hyperlane_core::{
     config::StrOrIntParseError, ChainCommunicationError, ChainResult, ContractLocator, Decode as _,
@@ -21,8 +21,6 @@ use hyperlane_core::{
 };
 
 use crate::account::{search_accounts_by_discriminator, search_and_validate_account};
-use crate::error::is_get_block_unresolvable_after_retries;
-use crate::fallback::SubmitSealevelRpc;
 use crate::log_meta_composer::{
     is_message_delivery_instruction, is_message_dispatch_instruction, LogMetaComposer,
 };
@@ -151,56 +149,24 @@ impl SealevelMailboxIndexer {
 
     /// Resolves the on-chain log meta for a dispatched message.
     ///
-    /// Returns `Ok(None)` when the log meta cannot be resolved from the block
-    /// recorded on the message account (the block does not contain the dispatch
-    /// transaction). This is non-retryable, so callers fall back to basic log
-    /// meta instead of stalling the sequence-aware cursor. Transient RPC errors
-    /// still propagate as `Err` so they are retried.
+    /// Returns `Ok(None)` when the log meta cannot be resolved from the recorded
+    /// or preceding block. Callers then use basic log meta instead of stalling
+    /// the sequence-aware cursor. Transient errors for the recorded slot still
+    /// propagate so they are retried.
     async fn dispatch_message_log_meta(
         &self,
         log_index: U256,
         message_storage_pda_pubkey: &Pubkey,
         message_account_slot: &Slot,
     ) -> ChainResult<Option<LogMeta>> {
-        let block = match self
-            .mailbox
-            .provider
-            .rpc_client()
-            .get_block(*message_account_slot)
+        self.dispatch_message_log_meta_composer
+            .resolve_log_meta(
+                self.mailbox.provider.rpc_client(),
+                log_index,
+                message_storage_pda_pubkey,
+                *message_account_slot,
+            )
             .await
-        {
-            Ok(block) => block,
-            Err(err) if is_get_block_unresolvable_after_retries(&err) => {
-                warn!(
-                    ?err,
-                    ?message_storage_pda_pubkey,
-                    slot = message_account_slot,
-                    "Block for message dispatch is unavailable after provider retries; \
-                     falling back to basic log meta",
-                );
-                return Ok(None);
-            }
-            Err(err) => return Err(err),
-        };
-
-        match self.dispatch_message_log_meta_composer.log_meta(
-            block,
-            log_index,
-            message_storage_pda_pubkey,
-            message_account_slot,
-        ) {
-            Ok(log_meta) => Ok(Some(log_meta)),
-            Err(err) if err.is_log_meta_unresolvable() => {
-                warn!(
-                    ?err,
-                    ?message_storage_pda_pubkey,
-                    slot = message_account_slot,
-                    "Could not resolve advanced log meta for message dispatch; falling back to basic log meta",
-                );
-                Ok(None)
-            }
-            Err(err) => Err(err.into()),
-        }
     }
 
     async fn get_delivered_message_with_sequence(
@@ -287,45 +253,14 @@ impl SealevelMailboxIndexer {
         message_storage_pda_pubkey: &Pubkey,
         message_account_slot: &Slot,
     ) -> ChainResult<Option<LogMeta>> {
-        let block = match self
-            .mailbox
-            .provider
-            .rpc_client()
-            .get_block(*message_account_slot)
+        self.delivery_message_log_meta_composer
+            .resolve_log_meta(
+                self.mailbox.provider.rpc_client(),
+                log_index,
+                message_storage_pda_pubkey,
+                *message_account_slot,
+            )
             .await
-        {
-            Ok(block) => block,
-            Err(err) if is_get_block_unresolvable_after_retries(&err) => {
-                warn!(
-                    ?err,
-                    ?message_storage_pda_pubkey,
-                    slot = message_account_slot,
-                    "Block for message delivery is unavailable after provider retries; \
-                     falling back to basic log meta",
-                );
-                return Ok(None);
-            }
-            Err(err) => return Err(err),
-        };
-
-        match self.delivery_message_log_meta_composer.log_meta(
-            block,
-            log_index,
-            message_storage_pda_pubkey,
-            message_account_slot,
-        ) {
-            Ok(log_meta) => Ok(Some(log_meta)),
-            Err(err) if err.is_log_meta_unresolvable() => {
-                warn!(
-                    ?err,
-                    ?message_storage_pda_pubkey,
-                    slot = message_account_slot,
-                    "Could not resolve advanced log meta for message delivery; falling back to basic log meta",
-                );
-                Ok(None)
-            }
-            Err(err) => Err(err.into()),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Try the slot immediately before an event PDA's recorded slot when the recorded block is unavailable or contains no exact matching transaction.
- Accept recovery only when exactly one transaction matches the expected program, event PDA, and instruction.
- Share the behavior across message dispatch, delivery, and IGP indexing.
- Keep #9284's basic-log-meta/NULL-transaction fallback when adjacent-slot enrichment cannot be proven.

## Why this follow-up

#9282 restored scraper cursor liveness when advanced Sealevel log metadata cannot be resolved, but the recovered events still used basic metadata. During the live omniscient-scraper rollout on Solaxy, the previously frozen message cursor advanced from sequence 344 to 2107 and logged 12 dispatch, 12 IGP, and 5 delivery fallbacks without further errors. This is therefore an observed production failure class, not a theoretical edge case.

#9284 closes the correctness gap by persisting those fallback events with nullable transaction relations. The remaining Termina/Solaxy hypothesis is that some event PDAs record the slot immediately after the transaction's actual block. This PR makes a single exact-match attempt against slot - 1 before accepting #9284's NULL metadata.

The number of live fallback events is measured; the fraction that slot - 1 will enrich has not yet been measured. This PR is therefore a best-effort metadata-quality improvement for affected events, not a prerequisite for scraper correctness once #9284 lands. Normal events perform no additional RPC.

## Safety

- The preceding block must contain exactly one transaction matching the event's program, PDA, and instruction; otherwise no metadata is attached.
- Recovered metadata records the actual preceding slot, keeping block hash and block number paired.
- Ambiguous matches still use basic metadata rather than guessing.
- Recorded-slot transient RPC failures remain retryable. Failures on the optional preceding-slot probe return to #9284's durable fallback, so this cannot reintroduce the cursor stall.

## Testing

- cargo test -p hyperlane-sealevel --lib (44 passed)
- cargo clippy -p hyperlane-sealevel --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Coverage includes recorded-block no-match recovery, exhausted skipped/unavailable-block recovery, actual recovered block number, optional-probe failure liveness, and transient recorded-slot retry behavior.

## Stack

This is intentionally stacked on #9284. Retarget to main after #9284 merges.