### PR TITLE
fix(starknet): pin contract reads to latest block

### DIFF
--- a/rust/main/chains/hyperlane-starknet/src/ism/aggregation_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/aggregation_ism.rs
@@ -72,6 +72,7 @@ impl AggregationIsm for StarknetAggregationIsm {
         let (isms, threshold) = self
             .contract
             .modules_and_threshold(&message)
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;

--- a/rust/main/chains/hyperlane-starknet/src/ism/interchain_security_module.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/interchain_security_module.rs
@@ -68,6 +68,7 @@ impl InterchainSecurityModule for StarknetInterchainSecurityModule {
         let module = self
             .contract
             .module_type()
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;

--- a/rust/main/chains/hyperlane-starknet/src/ism/multisig_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/multisig_ism.rs
@@ -72,6 +72,7 @@ impl MultisigIsm for StarknetMultisigIsm {
         let (validator_addresses, threshold) = self
             .contract
             .validators_and_threshold(message)
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;

--- a/rust/main/chains/hyperlane-starknet/src/ism/routing_ism.rs
+++ b/rust/main/chains/hyperlane-starknet/src/ism/routing_ism.rs
@@ -68,6 +68,7 @@ impl RoutingIsm for StarknetRoutingIsm {
         let ism = self
             .contract
             .route(message)
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;

--- a/rust/main/chains/hyperlane-starknet/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-starknet/src/mailbox.rs
@@ -115,6 +115,7 @@ impl Mailbox for StarknetMailbox {
         Ok(self
             .contract
             .delivered(&StarknetU256 { low, high })
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?)
@@ -125,6 +126,7 @@ impl Mailbox for StarknetMailbox {
         let address = self
             .contract
             .get_default_ism()
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;
@@ -136,6 +138,7 @@ impl Mailbox for StarknetMailbox {
         let address = self
             .contract
             .recipient_ism(&StarknetU256::from_bytes_be(&recipient.to_fixed_bytes()))
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;

--- a/rust/main/chains/hyperlane-starknet/src/validator_announce.rs
+++ b/rust/main/chains/hyperlane-starknet/src/validator_announce.rs
@@ -114,6 +114,7 @@ impl ValidatorAnnounce for StarknetValidatorAnnounce {
         let storage_locations_res = self
             .contract
             .get_announced_storage_locations(&validators_calldata)
+            .block_id(BlockId::Tag(BlockTag::Latest))
             .call()
             .await
             .map_err(Into::<HyperlaneStarknetError>::into)?;


### PR DESCRIPTION
## Summary

Starknet contract read calls (`get_announced_storage_locations`, `delivered`, `get_default_ism`, `recipient_ism`, ISM `module_type`/`modules_and_threshold`/`validators_and_threshold`/`route`) constructed the cainome `FCall` without a block id, so they defaulted to the **`pending`** block tag.

Newer Starknet JSON-RPC node versions reject `pending` with `-32602 "Invalid block id"`. This caused external validators to **panic on announce** (the announce loop's first read is `get_announced_storage_locations`) and would break relayer reads against the same nodes:

```
thread 'main' panicked at agents/validator/src/validator.rs:
Failed to announce validator: Provider errror Other(JsonRpcError { code: -32602, message: "Invalid params", data: {"reason":"Invalid block id"} })
```

Our in-house agents haven't hit this only because their RPC endpoint still accepts `pending`.

## Root cause

#9208 attempted to fix this by adding `.with_block(BlockId::Tag(BlockTag::Latest))` at the **contract-construction** layer. But the cainome-generated read methods build a fresh `FCall::new(call, self.provider())` and never read the contract-level block id — so that fix was a silent no-op for reads. The FCall default remained `pending`.

## Fix

Set `.block_id(BlockId::Tag(BlockTag::Latest))` directly on each read `FCall`, matching the existing correct pattern already used in `merkle_tree_hook.rs` (`.block_id(BlockId::Number(...))`).

## Test plan

- [ ] CI compiles `hyperlane-starknet` (local full build blocked by an unrelated pre-existing `tokio::test` macro-resolution issue in `hyperlane-core`, present on `main` too)
- [ ] Build agent image and confirm an external Starknet validator pointed at a newer-spec RPC node announces successfully instead of panicking with `-32602 Invalid block id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)