### PR TITLE
fix(aleo): encode mapping keys in RPC URLs

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -20,11 +20,34 @@ use crate::HyperlaneAleoError;
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
+fn append_path(base_url: &Url, path: &str) -> ChainResult<Url> {
+    let mut url = base_url.clone();
+    url.path_segments_mut()
+        .map_err(|_| HyperlaneAleoError::Other(format!("Invalid base URL: {base_url}")))?
+        .pop_if_empty()
+        .extend(path.split('/'));
+
+    // `Url` leaves square brackets unescaped in path segments, but Aleo RPC
+    // gateways reject bracketed plaintext mapping keys unless they are encoded.
+    let encoded_url = url.as_str().replace('[', "%5B").replace(']', "%5D");
+    Url::parse(&encoded_url).map_err(|error| HyperlaneAleoError::Other(error.to_string()).into())
+}
+
+fn append_network(base_url: Url, network: u16) -> ChainResult<Url> {
+    let network = match network {
+        0 => "mainnet",
+        1 => "testnet",
+        2 => "canary",
+        id => return Err(HyperlaneAleoError::UnknownNetwork(id).into()),
+    };
+    append_path(&base_url, network)
+}
+
 /// Base Http client that performs REST-ful queries
 #[derive(Clone, Debug)]
 pub struct BaseHttpClient {
     client: ReqwestClient,
-    base_url: String,
+    base_url: Url,
 }
 
 impl BaseHttpClient {
@@ -37,15 +60,9 @@ impl BaseHttpClient {
             .default_headers(headers)
             .build()
             .map_err(HyperlaneAleoError::from)?;
-        let suffix = match network {
-            0 => "mainnet",
-            1 => "testnet",
-            2 => "canary",
-            id => return Err(HyperlaneAleoError::UnknownNetwork(id).into()),
-        };
         Ok(Self {
             client,
-            base_url: url.to_string().trim_end_matches("/").to_string() + "/" + suffix,
+            base_url: append_network(url, network)?,
         })
     }
 }
@@ -58,11 +75,11 @@ impl HttpClient for BaseHttpClient {
         path: &str,
         query: impl Into<Option<serde_json::Value>> + Send,
     ) -> ChainResult<T> {
-        let url = format!("{}/{}", self.base_url, path);
+        let url = append_path(&self.base_url, path)?;
         let query: serde_json::Value = query.into().unwrap_or_default();
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .query(&query)
             .send()
             .await
@@ -107,8 +124,7 @@ impl HttpClientBuilder for BaseHttpClient {
 #[derive(Clone, Debug)]
 pub struct JWTBaseHttpClient {
     client: ReqwestClient,
-    base_url: String,
-    suffix: String,
+    base_url: Url,
     auth_url: String,
     auth_token: Arc<RwLock<Option<(HeaderValue, Instant)>>>,
 }
@@ -130,17 +146,10 @@ impl JWTBaseHttpClient {
             .cookie_store(true)
             .build()
             .map_err(HyperlaneAleoError::from)?;
-        let suffix = match network {
-            0 => "mainnet",
-            1 => "testnet",
-            2 => "canary",
-            id => return Err(HyperlaneAleoError::UnknownNetwork(id).into()),
-        };
         Ok(Self {
             client,
-            base_url: url.to_string().trim_end_matches("/").to_string(),
+            base_url: append_network(url, network)?,
             auth_token: Default::default(),
-            suffix: suffix.to_string(),
             auth_url,
         })
     }
@@ -189,12 +198,12 @@ impl HttpClient for JWTBaseHttpClient {
         path: &str,
         query: impl Into<Option<serde_json::Value>> + Send,
     ) -> ChainResult<T> {
-        let url = format!("{}/{}/{}", self.base_url, self.suffix, path);
+        let url = append_path(&self.base_url, path)?;
         let query: serde_json::Value = query.into().unwrap_or_default();
         let auth = self.get_auth_token().await?;
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .header(AUTHORIZATION, auth)
             .query(&query)
             .send()
@@ -220,11 +229,11 @@ impl HttpClient for JWTBaseHttpClient {
         path: &str,
         body: &serde_json::Value,
     ) -> ChainResult<T> {
-        let url = format!("{}/{}/{}", self.base_url, self.suffix, path);
+        let url = append_path(&self.base_url, path)?;
         let auth = self.get_auth_token().await?;
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .header(AUTHORIZATION, auth)
             .json(body)
             .send()
@@ -248,5 +257,30 @@ impl HttpClientBuilder for JWTBaseHttpClient {
 
     fn build(url: Url, network: u16) -> ChainResult<Self::Client> {
         JWTBaseHttpClient::new(url, network)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_network, append_path};
+    use url::Url;
+
+    #[test]
+    fn appends_and_encodes_path_segments() {
+        let base_url = append_network(
+            Url::parse("https://api.explorer.provable.com/v2/").unwrap(),
+            0,
+        )
+        .unwrap();
+        let url = append_path(
+            &base_url,
+            "program/hyp_validator_announce.aleo/mapping/storage_sequences/{ bytes: [79u8, 151u8] }",
+        )
+        .unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "https://api.explorer.provable.com/v2/mainnet/program/hyp_validator_announce.aleo/mapping/storage_sequences/%7B%20bytes:%20%5B79u8,%20151u8%5D%20%7D"
+        );
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -98,10 +98,10 @@ impl HttpClient for BaseHttpClient {
         path: &str,
         body: &serde_json::Value,
     ) -> ChainResult<T> {
-        let url = format!("{}/{}", self.base_url, path);
+        let url = append_path(&self.base_url, path)?;
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .json(body)
             .send()
             .await
@@ -263,8 +263,17 @@ impl HttpClientBuilder for JWTBaseHttpClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{append_network, append_path};
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::mpsc,
+        thread,
+    };
+
+    use serde_json::{json, Value};
     use url::Url;
+
+    use super::{append_network, append_path, BaseHttpClient, HttpClient};
 
     #[test]
     fn appends_and_encodes_path_segments() {
@@ -294,5 +303,40 @@ mod tests {
             url.as_str(),
             "http://[::1]:3030/v2/mapping/%7B%20bytes:%20%5B79u8%5D%20%7D"
         );
+    }
+
+    #[tokio::test]
+    async fn standard_client_post_encodes_bracketed_mapping_keys() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 4096];
+            let length = stream.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..length]);
+            request_tx
+                .send(request.lines().next().unwrap().to_owned())
+                .unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"ok\":true}",
+                )
+                .unwrap();
+        });
+        let client =
+            BaseHttpClient::new(Url::parse(&format!("http://{address}/v2")).unwrap(), 0).unwrap();
+
+        let response: Value = client
+            .request_post("mapping/{bytes:[1u8]}", &json!({}))
+            .await
+            .unwrap();
+
+        assert_eq!(response, json!({ "ok": true }));
+        assert_eq!(
+            request_rx.recv().unwrap(),
+            "POST /v2/mainnet/mapping/%7Bbytes:%5B1u8%5D%7D HTTP/1.1"
+        );
+        server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -29,8 +29,9 @@ fn append_path(base_url: &Url, path: &str) -> ChainResult<Url> {
 
     // `Url` leaves square brackets unescaped in path segments, but Aleo RPC
     // gateways reject bracketed plaintext mapping keys unless they are encoded.
-    let encoded_url = url.as_str().replace('[', "%5B").replace(']', "%5D");
-    Url::parse(&encoded_url).map_err(|error| HyperlaneAleoError::Other(error.to_string()).into())
+    let encoded_path = url.path().replace('[', "%5B").replace(']', "%5D");
+    url.set_path(&encoded_path);
+    Ok(url)
 }
 
 fn append_network(base_url: Url, network: u16) -> ChainResult<Url> {
@@ -281,6 +282,17 @@ mod tests {
         assert_eq!(
             url.as_str(),
             "https://api.explorer.provable.com/v2/mainnet/program/hyp_validator_announce.aleo/mapping/storage_sequences/%7B%20bytes:%20%5B79u8,%20151u8%5D%20%7D"
+        );
+    }
+
+    #[test]
+    fn appends_path_to_ipv6_base_url() {
+        let base_url = Url::parse("http://[::1]:3030/v2").unwrap();
+        let url = append_path(&base_url, "mapping/{ bytes: [79u8] }").unwrap();
+
+        assert_eq!(
+            url.as_str(),
+            "http://[::1]:3030/v2/mapping/%7B%20bytes:%20%5B79u8%5D%20%7D"
         );
     }
 }

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -42,8 +42,8 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '5e51f62-20260819-162717',
-  relayerRC: '14646bd-20260805-072134',
+  relayer: '1d11d91-20260820-115307',
+  relayerRC: '1d11d91-20260820-115307',
   relayerFastPath: '14646bd-20260805-072134',
   validator: '5e51f62-20260819-162717',
   validatorRC: '14646bd-20260805-072134',


### PR DESCRIPTION
## Summary

- construct Aleo RPC URLs with URL path-segment encoding
- percent-encode bracketed mapping keys rejected by the Aleo gateway
- apply the same URL construction to standard and JWT HTTP clients
- add regression coverage for bracketed validator-announcement mapping paths

## Context

Aleo validator-announcement reads such as `storage_sequences/{ bytes: [...] }` returned HTTP 400 because literal brackets reached the gateway. This prevented relayers from resolving validator storage locations even when quorum signatures were available in S3.

## Verification

- `cargo test -p hyperlane-aleo` (71 passed)
- `cargo clippy -p hyperlane-aleo --lib -- -D warnings`
- `cargo fmt --package hyperlane-aleo -- --check`

Full test-target clippy remains blocked by pre-existing lint failures in unchanged Aleo test files.