### PR TITLE
fix(infra): apply RPC quorum blocklist to validator additional quorum pool

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -26,26 +26,7 @@ spec:
    * to replace the correct value in the created secret.
    */}}
         {{- range .Values.hyperlane.chains }}
-        {{- if .blockedRpcUrls }}
-        {{- /*
-           * Validator only: strip chronically-erroring public RPC URLs from the
-           * quorum RPC pool. Only the validator's Quorum consensus fans every
-           * request out to all providers, so these count against reaching
-           * majority (see typescript/infra/src/config/rpcBlocklist.ts). The
-           * external-secrets Go template below fetches the shared RPC secret and
-           * drops any URL exactly equal to a blocked URL, leaving the
-           * relayer/scraper secret and the general agent config untouched.
-           * Exact equality means private URLs that share a host (but carry an
-           * API key) are never dropped.
-           */}}
-        {{- $conds := list }}
-        {{- range .blockedRpcUrls }}
-        {{- $conds = append $conds (printf "(ne . %q)" .) }}
-        {{- end }}
-        HYP_CHAINS_{{ .name | upper }}_CUSTOMRPCURLS: {{ printf "'{{- $kept := list -}}{{- range (.%s_rpcs | mustFromJson) -}}{{- if and %s -}}{{- $kept = append $kept . -}}{{- end -}}{{- end -}}{{ $kept | join \",\" }}'" .name (join " " $conds) }}
-        {{- else }}
         HYP_CHAINS_{{ .name | upper }}_CUSTOMRPCURLS: {{ printf "'{{ .%s_rpcs | mustFromJson | join \",\" }}'" .name }}
-        {{- end }}
         {{- if .publicRpcUrls }}
         {{- /*
            * Validator additional quorum verification: additional public registry RPCs

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -433,20 +433,17 @@ export class ValidatorHelmManager extends MultichainAgentHelmManager {
     // external-secret.yaml emits CUSTOMADDITIONALQUORUMRPCURLS whenever
     // publicRpcUrls is non-empty, so leaving this unset keeps quorum verification
     // off until a chain deliberately enables it.
+    //
+    // Chronically-erroring public RPCs are stripped here (see rpcBlocklist.ts).
+    // These are the validator's additional quorum pool, where every request is
+    // fanned out to all providers, so a bad endpoint counts against reaching
+    // majority. Matched by exact full-URL equality, so private URLs that share a
+    // host (but carry an API key) are never dropped.
     if (this.config.quorumVerificationEnabled) {
-      originChain.publicRpcUrls = getChain(cfg.originChainName).rpcUrls.map(
-        (rpc) => rpc.http,
-      );
-    }
-
-    // Strip chronically-erroring public RPC URLs from the validator's Quorum
-    // pool only. Only the validator fans every request out to all providers, so
-    // these are excluded from its CUSTOMRPCURLS at render time (see
-    // external-secret.yaml) without touching the shared secret or general config
-    // (see rpcBlocklist.ts).
-    const blockedRpcUrls = blockedQuorumRpcUrls[cfg.originChainName];
-    if (blockedRpcUrls?.length) {
-      originChain.blockedRpcUrls = blockedRpcUrls;
+      const blocked = new Set(blockedQuorumRpcUrls[cfg.originChainName] ?? []);
+      originChain.publicRpcUrls = getChain(cfg.originChainName)
+        .rpcUrls.map((rpc) => rpc.http)
+        .filter((url) => !blocked.has(url));
     }
 
     helmValues.hyperlane.validator = {

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -74,13 +74,6 @@ export interface HelmAgentChainOverride extends DeepPartial<AgentChainMetadata> 
   // already votes in the same quorum group, so this is public-only. Not part of
   // AgentChainMetadata itself — consumed only by the external-secret Helm template.
   publicRpcUrls?: string[];
-  // Validator only: full public RPC URLs to strip from the validator's
-  // CUSTOMRPCURLS at render time (see rpcBlocklist.ts). Only the validator's
-  // Quorum consensus hits every provider, so chronically-erroring endpoints are
-  // excluded from its quorum pool without touching the shared secret or the
-  // general config. Matched by exact URL equality. Consumed only by the
-  // external-secret Helm template.
-  blockedRpcUrls?: string[];
 }
 
 export interface RootAgentConfig extends AgentContextConfig {

--- a/typescript/infra/src/config/rpcBlocklist.ts
+++ b/typescript/infra/src/config/rpcBlocklist.ts
@@ -1,14 +1,14 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
 
-// Full public RPC URLs to exclude from the validator's Quorum RPC pool, matched
-// exactly against the URLs in the shared per-chain RPC secret. Only the
-// validator's Quorum consensus fans every request out to all providers, so a
-// chronically-erroring endpoint counts against reaching majority and trips the
-// "Validator RPC Quorum Risk" alert. Relayer/scraper use Fallback consensus and
-// never reach these endpoints, so this list is intentionally NOT applied to the
-// general agent config or the shared RPC secret — only to the validator's
-// CUSTOMRPCURLS at Helm render time (see hyperlane-agent/templates/
-// external-secret.yaml, which drops these exact URLs from the secret list).
+// Full public RPC URLs to exclude from the validator's additional quorum RPC
+// pool (CUSTOMADDITIONALQUORUMRPCURLS), matched exactly against the public
+// registry rpcUrls. Only the validator fans every request out to all providers
+// in this pool, so a chronically-erroring endpoint counts against reaching
+// majority and trips the "Validator RPC Quorum Risk" alert. Relayer/scraper use
+// Fallback consensus and never reach these endpoints, so this list is
+// intentionally NOT applied to the general agent config or the shared RPC secret
+// — only to the validator's publicRpcUrls at Helm-values build time (see
+// ValidatorHelmManager in src/agents/index.ts).
 //
 // Match is an exact full-URL equality: list only the public URLs, so private
 // URLs that happen to share a host (but carry an API key) are never blocked.


### PR DESCRIPTION
## Summary
- Follow-up to #9292. That PR filtered the validator's `CUSTOMRPCURLS`, but the two faulty arbitrum public RPCs (`arb1.arbitrum.io/rpc`, `arbitrum.drpc.org`) are never in `CUSTOMRPCURLS` (which holds only the private keyed URLs from the GCP secret). They are injected via `publicRpcUrls` → `CUSTOMADDITIONALQUORUMRPCURLS` at validator deploy time, because arbitrum has `quorumVerificationEnabled: true`. So as merged, the blocklist did not actually drop them.
- Move the blocklist filter to `publicRpcUrls` in `ValidatorHelmManager.helmValues()` (exact full-URL match), which is the validator's additional-quorum pool, pulled from the FileSystem registry metadata at deploy time — not from GCP secrets.
- Drop the now-dead `CUSTOMRPCURLS`-filtering template branch and the `blockedRpcUrls` `HelmAgentChainOverride` field.
- Registry metadata and `mainnet_config.json` are left untouched (all 3 arbitrum RPCs remain), so relayer/scraper/general usage keeps them; only the validator's additional-quorum pool drops the two.

Net effect: validator additional quorum pool for arbitrum = only `arbitrum-one-rpc.publicnode.com`.

## Test plan
- [x] `tsc --noEmit` clean, `oxlint` clean
- [x] Exact-equality verified against live registry URLs; after filter `CUSTOMADDITIONALQUORUMRPCURLS` = only `arbitrum-one-rpc.publicnode.com`
- [ ] After merge: redeploy both arbitrum validators (`arbitrum-validator` / hyperlane ctx, `arbitrum-validator-fastpath` / fastpath ctx) and confirm `hyperlane_request_count` shows neither hitting `arbitrum.drpc.org` / `arb1.arbitrum.io`

🤖 Generated with [Claude Code](https://claude.com/claude-code)