### PR TITLE
chore(helm): bump cloudflared to 2026.8.2

### DIFF
--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -109,7 +109,7 @@ hyperlane:
       enabled: false
       port: 8900
       tunnel:
-        image: cloudflare/cloudflared:2025.4.0
+        image: cloudflare/cloudflared:2026.8.2
     podAnnotations:
       prometheus.io/port: '9090'
       prometheus.io/scrape: 'true'


### PR DESCRIPTION
## Summary
- Bump the relayer relay-API Cloudflare tunnel sidecar image from `cloudflare/cloudflared:2025.4.0` to `cloudflare/cloudflared:2026.8.2`.

This is the only `cloudflared` image reference in the monorepo (`rust/main/helm/hyperlane-agent/values.yaml`); the relayer statefulset consumes it via `.Values.hyperlane.relayer.relayApi.tunnel.image`.

## Test plan
- [ ] Helm chart renders with the new tag (`helm template`)
- [ ] Relayer relay-API tunnel pod pulls and runs `2026.8.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)