### PR TITLE
test(infra): cover validator RPC blocklist

### DIFF
--- a/typescript/infra/src/config/rpcBlocklist.ts
+++ b/typescript/infra/src/config/rpcBlocklist.ts
@@ -4,11 +4,11 @@ import { ChainMap } from '@hyperlane-xyz/sdk';
 // pool (CUSTOMADDITIONALQUORUMRPCURLS), matched exactly against the public
 // registry rpcUrls. Only the validator fans every request out to all providers
 // in this pool, so a chronically-erroring endpoint counts against reaching
-// majority and trips the "Validator RPC Quorum Risk" alert. Relayer/scraper use
-// Fallback consensus and never reach these endpoints, so this list is
-// intentionally NOT applied to the general agent config or the shared RPC secret
-// — only to the validator's publicRpcUrls at Helm-values build time (see
-// ValidatorHelmManager in src/agents/index.ts).
+// majority and trips the "Validator RPC Quorum Risk" alert. Relayers and
+// scrapers may still use these endpoints through their ordinary Fallback
+// configuration; this list intentionally leaves the general agent config and
+// shared RPC secret unchanged and only filters the validator's publicRpcUrls at
+// Helm-values build time (see ValidatorHelmManager in src/agents/index.ts).
 //
 // Match is an exact full-URL equality: list only the public URLs, so private
 // URLs that happen to share a host (but carry an API key) are never blocked.

--- a/typescript/infra/test/validator-helm-manager.test.ts
+++ b/typescript/infra/test/validator-helm-manager.test.ts
@@ -59,4 +59,51 @@ describe('ValidatorHelmManager', () => {
     expect(values.hyperlane.validator?.configs).to.have.lengthOf(1);
     expect(values.hyperlane.validator?.configs?.[0].interval).to.equal(1);
   });
+
+  it('filters blocked RPCs from the validator additional quorum pool', async () => {
+    const config: RootAgentConfig = {
+      runEnv: 'mainnet3',
+      namespace: 'test',
+      context: Contexts.Hyperlane,
+      rolesWithKeys: [Role.Validator],
+      environmentChainNames: ['arbitrum'],
+      contextChainNames: {
+        [Role.Validator]: ['arbitrum'],
+        [Role.Relayer]: [],
+        [Role.Scraper]: [],
+      },
+      validators: {
+        rpcConsensusType: RpcConsensusType.Quorum,
+        docker: {
+          repo: 'ghcr.io/hyperlane-xyz/hyperlane-agent',
+          tag: 'test',
+        },
+        chains: {
+          arbitrum: {
+            interval: 1,
+            reorgPeriod: 1,
+            quorumVerificationEnabled: true,
+            validators: [
+              {
+                name: 'arbitrum-test-validator-0',
+                address: '',
+                checkpointSyncer: {
+                  type: CheckpointSyncerType.LocalStorage,
+                  path: '/tmp/arbitrum-test-validator-0',
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const manager = new ValidatorHelmManager(config, 'arbitrum');
+    const values = await manager.helmValues();
+    const publicRpcUrls = values.hyperlane.chains[0].publicRpcUrls;
+
+    expect(publicRpcUrls).to.include('https://arbitrum-one-rpc.publicnode.com');
+    expect(publicRpcUrls).not.to.include('https://arbitrum.drpc.org');
+    expect(publicRpcUrls).not.to.include('https://arb1.arbitrum.io/rpc');
+  });
 });


### PR DESCRIPTION
## Summary

- adds regression coverage for the validator additional-quorum RPC blocklist introduced across #9292 and #9294
- proves the two blocked Arbitrum RPCs are excluded while the healthy PublicNode endpoint remains
- corrects the blocklist comment: relayers and scrapers may still use these URLs through their ordinary fallback configuration

## Validation

- `REGISTRY_URI=/Users/pbio/work/hyperlane-registry ./node_modules/.bin/mocha --config ../sdk/.mocharc.json --timeout 10000 test/validator-helm-manager.test.ts` (2 passing)
- `../../node_modules/.bin/tsc --noEmit`
- `../../node_modules/.bin/oxfmt --check src/config/rpcBlocklist.ts test/validator-helm-manager.test.ts`
- `pnpm turbo run build --filter=@hyperlane-xyz/infra...`
- pre-commit oxlint, oxfmt, and gitleaks
