### PR TITLE
fix(infra): add ink native-gas floor for rebalancer key-funder

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredRebalancerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRebalancerBalances.json
@@ -3,6 +3,7 @@
   "avalanche": 1,
   "base": 0.2,
   "ethereum": 0.3,
+  "ink": 0.1,
   "optimism": 0.3,
   "polygon": 130,
   "unichain": 0.07


### PR DESCRIPTION
## Summary
- USDC/eclipsemainnet movable-collateral rebalancer fails every ~1min on the `ink -> optimism` USDC route (~4637.92 USDC) with `Gas estimation failed: Error: EVM error: OutOfFunds`.
- Root cause: the shared Hyperlane rebalancer key `0xa3948a15e1d0778a7d53268b651B2411AF198FE3` holds only ~0.0000251 ETH native gas on **ink**. ink was enabled as a rebalance origin (bridge correctly set to `0x92dFEB6f7Daa532de0F3c75c2091e1607c6593b7` by #8943), but ink was never added to the key-funder's `desiredRebalancerBalances.json`, so its ink gas is never auto-topped-up and drifted to ~0.
- Fix: add an `ink` floor (0.1 ETH) so the key-funder maintains native gas on ink and tops up the current deficit on its next hourly cron.

This is distinct from the prior "Bridge is not allowed" issue (that signature is absent in the running image `da26d9a-20260703-122943`; #8943 is live).

PagerDuty: Q2SR65FCU7F2UI (Rebalancer unhandled errors, low/warning, USDC/eclipsemainnet).

## Test plan
- [ ] Confirm `ink` floor value (0.1 ETH) is appropriate for expected rebalance frequency on ink.
- [ ] After merge, verify the next key-funder cron tops up `0xa3948a15...` on ink and the `ink -> optimism` rebalance passes gas estimation (no more `OutOfFunds`).
- [ ] Grafana alert `beuvwbe9j5udcd` / PD Q2SR65FCU7F2UI auto-clears once the error rate returns to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)