### PR TITLE
feat(infra): create and fund CROSS/moonpay quote submitter

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredQuoteSubmitterBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredQuoteSubmitterBalances.json
@@ -1,0 +1,8 @@
+{
+  "arbitrum": 0.02,
+  "base": 0.02,
+  "bsc": 0.02,
+  "ethereum": 0.02,
+  "katana": 0.04,
+  "polygon": 40
+}

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -35,12 +35,10 @@ const desiredInventoryRebalancerBalancePerChain = objMap(
   (_, balance) => balance.toString(),
 ) as Record<DesiredInventoryRebalancerBalanceChains, string>;
 
-type DesiredQuoteSubmitterBalanceChains =
-  keyof typeof desiredQuoteSubmitterBalances;
 const desiredQuoteSubmitterBalancePerChain = objMap(
   desiredQuoteSubmitterBalances,
   (_, balance) => balance.toString(),
-) as Record<DesiredQuoteSubmitterBalanceChains, string>;
+);
 
 type DesiredStableswapInventoryRebalancerBalanceChains =
   keyof typeof desiredStableswapInventoryRebalancerBalances;

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -7,6 +7,7 @@ import { DockerImageRepos, mainnetDockerTags } from '../../docker.js';
 
 import desiredRebalancerBalances from './balances/desiredRebalancerBalances.json' with { type: 'json' };
 import desiredInventoryRebalancerBalances from './balances/desiredInventoryRebalancerBalances.json' with { type: 'json' };
+import desiredQuoteSubmitterBalances from './balances/desiredQuoteSubmitterBalances.json' with { type: 'json' };
 import desiredStableswapInventoryRebalancerBalances from './balances/desiredStableswapInventoryRebalancerBalances.json' with { type: 'json' };
 import desiredRelayerBalances from './balances/desiredRelayerBalances.json' with { type: 'json' };
 import lowUrgencyKeyFunderBalances from './balances/lowUrgencyKeyFunderBalance.json' with { type: 'json' };
@@ -33,6 +34,13 @@ const desiredInventoryRebalancerBalancePerChain = objMap(
   desiredInventoryRebalancerBalances,
   (_, balance) => balance.toString(),
 ) as Record<DesiredInventoryRebalancerBalanceChains, string>;
+
+type DesiredQuoteSubmitterBalanceChains =
+  keyof typeof desiredQuoteSubmitterBalances;
+const desiredQuoteSubmitterBalancePerChain = objMap(
+  desiredQuoteSubmitterBalances,
+  (_, balance) => balance.toString(),
+) as Record<DesiredQuoteSubmitterBalanceChains, string>;
 
 type DesiredStableswapInventoryRebalancerBalanceChains =
   keyof typeof desiredStableswapInventoryRebalancerBalances;
@@ -68,6 +76,7 @@ export const keyFunderConfig: KeyFunderConfig<
       Role.Relayer,
       Role.Rebalancer,
       Role.InventoryRebalancer,
+      Role.QuoteSubmitter,
       Role.StableswapInventoryRebalancer,
     ],
     [Contexts.ReleaseCandidate]: [Role.Relayer],
@@ -80,6 +89,8 @@ export const keyFunderConfig: KeyFunderConfig<
   desiredRebalancerBalancePerChain,
   // desired inventory rebalancer balance config
   desiredInventoryRebalancerBalancePerChain,
+  // desired quote submitter balance config
+  desiredQuoteSubmitterBalancePerChain,
   // desired stableswap inventory rebalancer balance config
   desiredStableswapInventoryRebalancerBalancePerChain,
   // if not set, keyfunder defaults to using desired balance * 0.2 as the threshold

--- a/typescript/infra/config/quotesubmitter.json
+++ b/typescript/infra/config/quotesubmitter.json
@@ -1,0 +1,5 @@
+{
+  "mainnet3": {
+    "hyperlane": "0xB69f1Ec5dbC25a850Be3027f7bA0E09d68ea9044"
+  }
+}

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -40,6 +40,7 @@ export interface KeyFunderConfig<
   desiredRebalancerBalancePerChain: ChainMap<string>;
   desiredInventoryRebalancerBalancePerChain?: ChainMap<string>;
   desiredStableswapInventoryRebalancerBalancePerChain?: ChainMap<string>;
+  desiredQuoteSubmitterBalancePerChain?: ChainMap<string>;
   igpClaimThresholdPerChain: ChainMap<string>;
   chainsToSkip: ChainName[];
   // Emergency kill switch for automatic sweeps. Defaults to enabled.

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -28,6 +28,10 @@ import { getInfraPath, isEthereumProtocolChain } from '../utils/utils.js';
 const RC_FUNDING_DISCOUNT_NUMERATOR = BigNumber.from(2);
 const RC_FUNDING_DISCOUNT_DENOMINATOR = BigNumber.from(10);
 
+type RoleAddresses = Partial<
+  Record<DeployEnvironment, Partial<Record<Contexts, string>>>
+>;
+
 // Chains to sweep excess funds from (must match fund-keys-from-deployer.ts)
 const CHAINS_TO_SWEEP = new Set([
   'arbitrum',
@@ -282,35 +286,18 @@ export class KeyFunderHelmManager extends HelmManager {
     return envAddresses?.[environment]?.[context];
   }
 
-  private getRoleAddresses(
-    role: FundableRole,
-  ): Record<DeployEnvironment, Record<Contexts, string>> | undefined {
+  private getRoleAddresses(role: FundableRole): RoleAddresses | undefined {
     switch (role) {
       case Role.Relayer:
-        return relayerAddresses as Record<
-          DeployEnvironment,
-          Record<Contexts, string>
-        >;
+        return relayerAddresses;
       case Role.Rebalancer:
-        return rebalancerAddresses as Record<
-          DeployEnvironment,
-          Record<Contexts, string>
-        >;
+        return rebalancerAddresses;
       case Role.InventoryRebalancer:
-        return inventoryRebalancerAddresses as Record<
-          DeployEnvironment,
-          Record<Contexts, string>
-        >;
+        return inventoryRebalancerAddresses;
       case Role.QuoteSubmitter:
-        return quoteSubmitterAddresses as Record<
-          DeployEnvironment,
-          Record<Contexts, string>
-        >;
+        return quoteSubmitterAddresses;
       case Role.StableswapInventoryRebalancer:
-        return stableswapInventoryRebalancerAddresses as Record<
-          DeployEnvironment,
-          Record<Contexts, string>
-        >;
+        return stableswapInventoryRebalancerAddresses;
       default:
         return undefined;
     }

--- a/typescript/infra/src/funding/key-funder.ts
+++ b/typescript/infra/src/funding/key-funder.ts
@@ -11,6 +11,7 @@ import { DockerImageRepos } from '../../config/docker.js';
 import { NODE_SERVICE_NAMES } from '../utils/consts.js';
 import rebalancerAddresses from '../../config/rebalancer.json' with { type: 'json' };
 import inventoryRebalancerAddresses from '../../config/inventoryRebalancer.json' with { type: 'json' };
+import quoteSubmitterAddresses from '../../config/quotesubmitter.json' with { type: 'json' };
 import stableswapInventoryRebalancerAddresses from '../../config/stableswapInventoryRebalancer.json' with { type: 'json' };
 import { getEnvAddresses } from '../../config/registry.js';
 import { getAgentConfig } from '../../scripts/agent-utils.js';
@@ -300,6 +301,11 @@ export class KeyFunderHelmManager extends HelmManager {
           DeployEnvironment,
           Record<Contexts, string>
         >;
+      case Role.QuoteSubmitter:
+        return quoteSubmitterAddresses as Record<
+          DeployEnvironment,
+          Record<Contexts, string>
+        >;
       case Role.StableswapInventoryRebalancer:
         return stableswapInventoryRebalancerAddresses as Record<
           DeployEnvironment,
@@ -321,6 +327,8 @@ export class KeyFunderHelmManager extends HelmManager {
         return this.config.desiredRebalancerBalancePerChain?.[chain];
       case Role.InventoryRebalancer:
         return this.config.desiredInventoryRebalancerBalancePerChain?.[chain];
+      case Role.QuoteSubmitter:
+        return this.config.desiredQuoteSubmitterBalancePerChain?.[chain];
       case Role.StableswapInventoryRebalancer:
         return this.config
           .desiredStableswapInventoryRebalancerBalancePerChain?.[chain];

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -6,6 +6,10 @@ export enum Role {
   Rebalancer = 'rebalancer',
   InventoryRebalancer = 'inventoryrebalancer',
   QuoteSigner = 'quotesigner',
+  // Funding-only role: the CROSS/moonpay standing fee quote submitter.
+  // The key is externally provisioned in GCP; keyfunder only needs its address.
+  // Do NOT add to ALL_KEY_ROLES / ALL_AGENT_ROLES / rolesWithKeys.
+  QuoteSubmitter = 'quotesubmitter',
   // Funding-only role: the stableswap rebalancer's EVM inventory
   // signer. Has no managed agent key — keyfunder only needs the address to
   // send gas to it. Do NOT add to ALL_KEY_ROLES / ALL_AGENT_ROLES / rolesWithKeys.
@@ -16,6 +20,7 @@ export type FundableRole =
   | Role.Relayer
   | Role.Rebalancer
   | Role.InventoryRebalancer
+  | Role.QuoteSubmitter
   | Role.StableswapInventoryRebalancer;
 
 export const ALL_KEY_ROLES = [

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -226,6 +226,7 @@ export function assertFundableRole(roleStr: string): FundableRole {
     role !== Role.Relayer &&
     role !== Role.Rebalancer &&
     role !== Role.InventoryRebalancer &&
+    role !== Role.QuoteSubmitter &&
     role !== Role.StableswapInventoryRebalancer
   ) {
     throw Error(`Invalid fundable role ${role}`);

--- a/typescript/infra/test/key-funder.test.ts
+++ b/typescript/infra/test/key-funder.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import YAML from 'yaml';
+
+import { KeyFunderConfigSchema } from '@hyperlane-xyz/keyfunder';
+
+import quoteSubmitterAddresses from '../config/quotesubmitter.json' with { type: 'json' };
+import { KeyFunderHelmManager } from '../src/funding/key-funder.js';
+
+describe('KeyFunderHelmManager', () => {
+  it('funds the quote submitter only on CROSS/moonpay EVM origins', async () => {
+    const manager = KeyFunderHelmManager.forEnvironment(
+      'mainnet3',
+      'test-registry-commit',
+    );
+    const values = await manager.helmValues();
+    const config = KeyFunderConfigSchema.parse(
+      YAML.parse(values.hyperlane.keyfunderConfig),
+    );
+    const role = 'hyperlane-quotesubmitter';
+    const expectedBalances = new Map([
+      ['arbitrum', '0.02'],
+      ['base', '0.02'],
+      ['bsc', '0.02'],
+      ['ethereum', '0.02'],
+      ['katana', '0.04'],
+      ['polygon', '40'],
+    ]);
+
+    expect(config.roles[role].address).to.equal(
+      quoteSubmitterAddresses.mainnet3.hyperlane,
+    );
+
+    const fundedChains: string[] = [];
+    for (const [chain, chainConfig] of Object.entries(config.chains)) {
+      const balance = chainConfig.balances?.[role];
+      expect(balance).to.equal(expectedBalances.get(chain));
+      if (balance) fundedChains.push(chain);
+    }
+    expect(fundedChains.sort()).to.deep.equal(
+      [...expectedBalances.keys()].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- track the CROSS/moonpay quote submitter public address from GCP
- fund it through keyfunder on the six EVM origin chains
- add a focused Helm config test enforcing the exact chain and balance map

## Funding targets

- arbitrum, base, bsc, ethereum: 0.02 native
- katana: 0.04 native
- polygon: 40 native
- Citrea and Solana remain destination-only and are not funded

## Validation

- pnpm -C typescript/infra check
- focused keyfunder/cloud-key tests: 4 passing
- oxlint on changed TypeScript files
- commit hooks, including gitleaks, oxlint, and oxfmt

## Rollout

- [x] Confirm GCP secret and derive public address without exposing key material
- [x] Replenish the Katana deployer with 0.02 ETH using the private-agents keyfunder
- [x] Deploy mainnet3 keyfunder (Helm revision 255)
- [x] Trigger successful job key-funder-quotesubmitter-20260820-1309
- [x] Verify all six origin-chain balances

Current balances: arbitrum 0.02 ETH, base 0.02 ETH, bsc 0.04598713915 BNB, ethereum 0.02 ETH, katana 0.04 ETH, polygon 20 POL.

Polygon already held 20 POL and remains inside the keyfunder refill threshold for the configured 40 POL target. BSC is already above its 0.02 BNB target.

Context: https://github.com/hyperlane-xyz/private-agents/pull/224