### PR TITLE
feat(cli): submit transaction files with external signers

### DIFF
--- a/.changeset/quiet-pandas-sign.md
+++ b/.changeset/quiet-pandas-sign.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': minor
+---
+
+External EVM signer configs were added to transaction-file submission, and JSON-RPC submitters were extended with explicit signer injection and partial submission results.

--- a/.github/workflows/test-cli-e2e.yml
+++ b/.github/workflows/test-cli-e2e.yml
@@ -156,6 +156,7 @@ jobs:
       matrix:
         test:
           - core-deploy
+          - submit
           - warp-deploy
     steps:
       - uses: actions/checkout@v7

--- a/typescript/cli/src/commands/submit.ts
+++ b/typescript/cli/src/commands/submit.ts
@@ -4,8 +4,14 @@ import {
   type SubmissionStrategy,
   SubmissionStrategySchema,
 } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
-import { getTransactions, runSubmit } from '../config/submit.js';
+import {
+  getTransactions,
+  runExternalSubmit,
+  runSubmit,
+} from '../config/submit.js';
+import { loadExternalEvmSigner } from '../context/externalSigner.js';
 import { type CommandModuleWithWriteContext } from '../context/types.js';
 import { logBlue, logGray, logRed } from '../logger.js';
 import { isFile, readYamlOrJson } from '../utils/files.js';
@@ -21,7 +27,8 @@ import {
  */
 export const submitCommand: CommandModuleWithWriteContext<{
   transactions: string;
-  strategy: string;
+  strategy?: string;
+  signerConfig?: string;
   receipts: string;
 }> = {
   command: 'submit',
@@ -29,6 +36,11 @@ export const submitCommand: CommandModuleWithWriteContext<{
   builder: {
     transactions: transactionsCommandOption,
     strategy: strategyCommandOption,
+    'signer-config': {
+      type: 'string',
+      description:
+        'Path to a private external signer JSON config. Submits directly on EVM chains and cannot be combined with --strategy',
+    },
     receipts: outputFileCommandOption(
       './generated/transactions/receipts',
       false,
@@ -39,6 +51,7 @@ export const submitCommand: CommandModuleWithWriteContext<{
     context,
     transactions: transactionsPath,
     strategy: strategyPath,
+    signerConfig: signerConfigPath,
     receipts: receiptsFilepath,
   }) => {
     logGray(`Hyperlane Submit`);
@@ -52,10 +65,25 @@ export const submitCommand: CommandModuleWithWriteContext<{
       process.exit(1);
     }
 
-    const chainTransactions = groupBy(
-      getTransactions(transactionsPath),
-      'chainId',
+    assert(
+      !(strategyPath && signerConfigPath),
+      '--strategy cannot be combined with --signer-config',
     );
+    const transactions = getTransactions(transactionsPath);
+
+    if (signerConfigPath) {
+      const signer = await loadExternalEvmSigner(signerConfigPath);
+      await runExternalSubmit({
+        context,
+        signer,
+        transactions,
+        receiptsFilepath,
+      });
+      logBlue('✅ External signer submission complete');
+      process.exit(0);
+    }
+
+    const chainTransactions = groupBy(transactions, 'chainId');
 
     for (const [chainId, transactions] of Object.entries(chainTransactions)) {
       const chain = context.multiProvider.getChainName(chainId);

--- a/typescript/cli/src/commands/submit.ts
+++ b/typescript/cli/src/commands/submit.ts
@@ -39,7 +39,7 @@ export const submitCommand: CommandModuleWithWriteContext<{
     'signer-config': {
       type: 'string',
       description:
-        'Path to a private external signer JSON config. Submits directly on EVM chains and cannot be combined with --strategy',
+        'Path to a private external signer JSON config. Submits directly on EVM chains; cannot be combined with --strategy. Each transaction must estimate independently against current state; split dependent sequences into separate runs',
     },
     receipts: outputFileCommandOption(
       './generated/transactions/receipts',

--- a/typescript/cli/src/config/submit.test.ts
+++ b/typescript/cli/src/config/submit.test.ts
@@ -190,7 +190,13 @@ describe('external submission', () => {
         await runExternalSubmit({
           context: { multiProvider, skipConfirmation: true },
           signer,
-          transactions: [tx, { ...tx, maxFeePerGas: '-1' }],
+          transactions: [
+            tx,
+            {
+              ...tx,
+              maxFeePerGas: { _isBigNumber: true, _hex: '-0x01' },
+            },
+          ],
           receiptsFilepath: receiptsPath,
         });
       } catch (caught) {
@@ -257,7 +263,7 @@ describe('external submission', () => {
           maxFeePerGas: '3',
           maxPriorityFeePerGas: 1,
           type: 2,
-          value: BigNumber.from(0),
+          value: '0',
         },
       ]);
 
@@ -276,6 +282,12 @@ describe('external submission', () => {
       expect(() =>
         validateExternalTransactions([{ ...tx, gasPrice: 1, maxFeePerGas: 2 }]),
       ).to.throw('gasPrice cannot be combined');
+    });
+
+    it('rejects negative serialized values', () => {
+      expect(() =>
+        validateExternalTransactions([{ ...tx, maxFeePerGas: '-1' }]),
+      ).to.throw('Invalid');
     });
   });
 });

--- a/typescript/cli/src/config/submit.test.ts
+++ b/typescript/cli/src/config/submit.test.ts
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+import { BigNumber, Wallet, providers } from 'ethers';
+import { mkdtempSync, readdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import sinon from 'sinon';
+
+import {
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
+  MultiProvider,
+  testChainMetadata,
+  testSealevelChain,
+} from '@hyperlane-xyz/sdk';
+
+import { readYamlOrJson } from '../utils/files.js';
+
+import { prepareExternalSubmission, runExternalSubmit } from './submit.js';
+
+describe('prepareExternalSubmission', () => {
+  const tempDirs: string[] = [];
+  const signer = Wallet.createRandom();
+  const tx = {
+    chainId: Number(testChainMetadata.test1.chainId),
+    from: signer.address,
+    to: Wallet.createRandom().address,
+    data: '0x12345678',
+  };
+
+  let multiProvider: MultiProvider;
+  let provider: providers.JsonRpcProvider;
+  let getFeeData: sinon.SinonStub;
+
+  beforeEach(() => {
+    provider = new providers.JsonRpcProvider('http://127.0.0.1:8545');
+    multiProvider = MultiProvider.createTestMultiProvider({ provider });
+    getFeeData = sinon.stub(provider, 'getFeeData').resolves({
+      gasPrice: BigNumber.from(2),
+      maxFeePerGas: BigNumber.from(3),
+      maxPriorityFeePerGas: BigNumber.from(1),
+      lastBaseFeePerGas: BigNumber.from(1),
+    });
+    sinon.stub(provider, 'getBalance').resolves(BigNumber.from(1_000_000));
+    sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
+  });
+
+  it('preflights an EVM transaction with EIP-1559 fees', async () => {
+    const plans = await prepareExternalSubmission({
+      context: { multiProvider },
+      signer,
+      transactions: [tx],
+    });
+
+    expect(plans).to.have.length(1);
+    expect(plans[0].chain).to.equal('test1');
+    expect(plans[0].requiredBalance.eq(63_000)).to.equal(true);
+  });
+
+  it('budgets the declared gas limit and fee cap', async () => {
+    const plans = await prepareExternalSubmission({
+      context: { multiProvider },
+      signer,
+      transactions: [
+        {
+          ...tx,
+          gasLimit: BigNumber.from(30_000),
+          maxFeePerGas: BigNumber.from(5),
+        },
+      ],
+    });
+
+    expect(plans[0].requiredBalance.eq(150_000)).to.equal(true);
+  });
+
+  it('validates the complete input before making RPC requests', async () => {
+    let error: Error | undefined;
+    try {
+      await prepareExternalSubmission({
+        context: { multiProvider },
+        signer,
+        transactions: [tx, { ...tx, from: Wallet.createRandom().address }],
+      });
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+
+    expect(error?.message).to.include('does not match external signer');
+    expect(getFeeData.called).to.equal(false);
+  });
+
+  it('rejects non-Ethereum transactions', async () => {
+    const nonEvmMultiProvider = new MultiProvider({
+      ...testChainMetadata,
+      [testSealevelChain.name]: testSealevelChain,
+    });
+
+    let error: Error | undefined;
+    try {
+      await prepareExternalSubmission({
+        context: { multiProvider: nonEvmMultiProvider },
+        signer,
+        transactions: [{ ...tx, chainId: Number(testSealevelChain.chainId) }],
+      });
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+
+    expect(error?.message).to.include(
+      'External EVM signers cannot submit transactions',
+    );
+  });
+
+  it('rejects an insufficient signer balance', async () => {
+    sinon.restore();
+    sinon.stub(provider, 'getFeeData').resolves({
+      gasPrice: BigNumber.from(2),
+      maxFeePerGas: BigNumber.from(3),
+      maxPriorityFeePerGas: BigNumber.from(1),
+      lastBaseFeePerGas: BigNumber.from(1),
+    });
+    sinon.stub(provider, 'getBalance').resolves(BigNumber.from(1));
+    sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
+
+    let error: Error | undefined;
+    try {
+      await prepareExternalSubmission({
+        context: { multiProvider },
+        signer,
+        transactions: [tx],
+      });
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+
+    expect(error?.message).to.include('insufficient balance');
+  });
+
+  it('writes partial submission progress before rethrowing', async () => {
+    // CAST: minimal ethers receipt fixture; serialization is the behavior under test.
+    const receipt = {
+      transactionHash: '0x01',
+      status: 1,
+    } as providers.TransactionReceipt;
+    sinon
+      .stub(EV5JsonRpcTxSubmitter.prototype, 'submit')
+      .rejects(
+        new EV5JsonRpcSubmissionError(
+          'confirmation timeout',
+          [{ transactionHash: '0x01', receipt }, { transactionHash: '0x02' }],
+          new Error('confirmation timeout'),
+        ),
+      );
+    const receiptsPath = mkdtempSync(
+      join(tmpdir(), 'hyperlane-external-receipts-'),
+    );
+    tempDirs.push(receiptsPath);
+
+    let error: Error | undefined;
+    try {
+      await runExternalSubmit({
+        context: { multiProvider, skipConfirmation: true },
+        signer,
+        transactions: [tx],
+        receiptsFilepath: receiptsPath,
+      });
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+
+    expect(error?.message).to.include('confirmation timeout');
+    const files = readdirSync(receiptsPath);
+    expect(files).to.have.length(1);
+    expect(files[0]).to.include('jsonRpc-partial');
+    expect(readYamlOrJson(join(receiptsPath, files[0]))).to.deep.equal([
+      { transactionHash: '0x01', receipt },
+      { transactionHash: '0x02' },
+    ]);
+  });
+});

--- a/typescript/cli/src/config/submit.test.ts
+++ b/typescript/cli/src/config/submit.test.ts
@@ -35,6 +35,7 @@ describe('external submission', () => {
   let provider: providers.JsonRpcProvider;
   let getBalance: sinon.SinonStub;
   let getFeeData: sinon.SinonStub;
+  let estimateGas: sinon.SinonStub;
 
   beforeEach(() => {
     provider = new providers.JsonRpcProvider('http://127.0.0.1:8545');
@@ -48,7 +49,9 @@ describe('external submission', () => {
     getBalance = sinon
       .stub(provider, 'getBalance')
       .resolves(BigNumber.from(1_000_000));
-    sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
+    estimateGas = sinon
+      .stub(multiProvider, 'estimateGas')
+      .resolves(BigNumber.from(21_000));
   });
 
   afterEach(() => {
@@ -142,6 +145,39 @@ describe('external submission', () => {
   });
 
   describe('runExternalSubmit', () => {
+    it('rejects transactions that do not estimate independently', async () => {
+      estimateGas
+        .onFirstCall()
+        .resolves(BigNumber.from(21_000))
+        .onSecondCall()
+        .rejects(new Error('execution reverted'));
+      const submit = sinon.stub(EV5JsonRpcTxSubmitter.prototype, 'submit');
+      const receiptsPath = mkdtempSync(
+        join(tmpdir(), 'hyperlane-external-receipts-'),
+      );
+      tempDirs.push(receiptsPath);
+
+      let error: Error | undefined;
+      try {
+        await runExternalSubmit({
+          context: { multiProvider, skipConfirmation: true },
+          signer,
+          transactions: [tx, tx],
+          receiptsFilepath: receiptsPath,
+        });
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught));
+      }
+
+      expect(error?.message).to.include(
+        'Transaction 2 on test1 cannot be estimated independently',
+      );
+      expect(error?.message).to.include(
+        'Split state-dependent transactions into separate submit runs',
+      );
+      expect(submit.called).to.equal(false);
+    });
+
     it('validates the complete external batch before submission', async () => {
       const submit = sinon.stub(EV5JsonRpcTxSubmitter.prototype, 'submit');
       const receiptsPath = mkdtempSync(

--- a/typescript/cli/src/config/submit.test.ts
+++ b/typescript/cli/src/config/submit.test.ts
@@ -29,6 +29,7 @@ describe('external submission', () => {
 
   let multiProvider: MultiProvider;
   let provider: providers.JsonRpcProvider;
+  let getBalance: sinon.SinonStub;
   let getFeeData: sinon.SinonStub;
 
   beforeEach(() => {
@@ -40,7 +41,9 @@ describe('external submission', () => {
       maxPriorityFeePerGas: BigNumber.from(1),
       lastBaseFeePerGas: BigNumber.from(1),
     });
-    sinon.stub(provider, 'getBalance').resolves(BigNumber.from(1_000_000));
+    getBalance = sinon
+      .stub(provider, 'getBalance')
+      .resolves(BigNumber.from(1_000_000));
     sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
   });
 
@@ -117,15 +120,7 @@ describe('external submission', () => {
     });
 
     it('rejects an insufficient signer balance', async () => {
-      sinon.restore();
-      sinon.stub(provider, 'getFeeData').resolves({
-        gasPrice: BigNumber.from(2),
-        maxFeePerGas: BigNumber.from(3),
-        maxPriorityFeePerGas: BigNumber.from(1),
-        lastBaseFeePerGas: BigNumber.from(1),
-      });
-      sinon.stub(provider, 'getBalance').resolves(BigNumber.from(1));
-      sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
+      getBalance.resolves(BigNumber.from(1));
 
       let error: Error | undefined;
       try {

--- a/typescript/cli/src/config/submit.test.ts
+++ b/typescript/cli/src/config/submit.test.ts
@@ -17,7 +17,7 @@ import { readYamlOrJson } from '../utils/files.js';
 
 import { prepareExternalSubmission, runExternalSubmit } from './submit.js';
 
-describe('prepareExternalSubmission', () => {
+describe('external submission', () => {
   const tempDirs: string[] = [];
   const signer = Wallet.createRandom();
   const tx = {
@@ -49,136 +49,140 @@ describe('prepareExternalSubmission', () => {
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
   });
 
-  it('preflights an EVM transaction with EIP-1559 fees', async () => {
-    const plans = await prepareExternalSubmission({
-      context: { multiProvider },
-      signer,
-      transactions: [tx],
-    });
-
-    expect(plans).to.have.length(1);
-    expect(plans[0].chain).to.equal('test1');
-    expect(plans[0].requiredBalance.eq(63_000)).to.equal(true);
-  });
-
-  it('budgets the declared gas limit and fee cap', async () => {
-    const plans = await prepareExternalSubmission({
-      context: { multiProvider },
-      signer,
-      transactions: [
-        {
-          ...tx,
-          gasLimit: BigNumber.from(30_000),
-          maxFeePerGas: BigNumber.from(5),
-        },
-      ],
-    });
-
-    expect(plans[0].requiredBalance.eq(150_000)).to.equal(true);
-  });
-
-  it('validates the complete input before making RPC requests', async () => {
-    let error: Error | undefined;
-    try {
-      await prepareExternalSubmission({
-        context: { multiProvider },
-        signer,
-        transactions: [tx, { ...tx, from: Wallet.createRandom().address }],
-      });
-    } catch (caught) {
-      error = caught instanceof Error ? caught : new Error(String(caught));
-    }
-
-    expect(error?.message).to.include('does not match external signer');
-    expect(getFeeData.called).to.equal(false);
-  });
-
-  it('rejects non-Ethereum transactions', async () => {
-    const nonEvmMultiProvider = new MultiProvider({
-      ...testChainMetadata,
-      [testSealevelChain.name]: testSealevelChain,
-    });
-
-    let error: Error | undefined;
-    try {
-      await prepareExternalSubmission({
-        context: { multiProvider: nonEvmMultiProvider },
-        signer,
-        transactions: [{ ...tx, chainId: Number(testSealevelChain.chainId) }],
-      });
-    } catch (caught) {
-      error = caught instanceof Error ? caught : new Error(String(caught));
-    }
-
-    expect(error?.message).to.include(
-      'External EVM signers cannot submit transactions',
-    );
-  });
-
-  it('rejects an insufficient signer balance', async () => {
-    sinon.restore();
-    sinon.stub(provider, 'getFeeData').resolves({
-      gasPrice: BigNumber.from(2),
-      maxFeePerGas: BigNumber.from(3),
-      maxPriorityFeePerGas: BigNumber.from(1),
-      lastBaseFeePerGas: BigNumber.from(1),
-    });
-    sinon.stub(provider, 'getBalance').resolves(BigNumber.from(1));
-    sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
-
-    let error: Error | undefined;
-    try {
-      await prepareExternalSubmission({
+  describe('prepareExternalSubmission', () => {
+    it('preflights an EVM transaction with EIP-1559 fees', async () => {
+      const plans = await prepareExternalSubmission({
         context: { multiProvider },
         signer,
         transactions: [tx],
       });
-    } catch (caught) {
-      error = caught instanceof Error ? caught : new Error(String(caught));
-    }
 
-    expect(error?.message).to.include('insufficient balance');
-  });
+      expect(plans).to.have.length(1);
+      expect(plans[0].chain).to.equal('test1');
+      expect(plans[0].requiredBalance.eq(63_000)).to.equal(true);
+    });
 
-  it('writes partial submission progress before rethrowing', async () => {
-    // CAST: minimal ethers receipt fixture; serialization is the behavior under test.
-    const receipt = {
-      transactionHash: '0x01',
-      status: 1,
-    } as providers.TransactionReceipt;
-    sinon
-      .stub(EV5JsonRpcTxSubmitter.prototype, 'submit')
-      .rejects(
-        new EV5JsonRpcSubmissionError(
-          'confirmation timeout',
-          [{ transactionHash: '0x01', receipt }, { transactionHash: '0x02' }],
-          new Error('confirmation timeout'),
-        ),
+    it('budgets the declared gas limit and fee cap', async () => {
+      const plans = await prepareExternalSubmission({
+        context: { multiProvider },
+        signer,
+        transactions: [
+          {
+            ...tx,
+            gasLimit: BigNumber.from(30_000),
+            maxFeePerGas: BigNumber.from(5),
+          },
+        ],
+      });
+
+      expect(plans[0].requiredBalance.eq(150_000)).to.equal(true);
+    });
+
+    it('validates the complete input before making RPC requests', async () => {
+      let error: Error | undefined;
+      try {
+        await prepareExternalSubmission({
+          context: { multiProvider },
+          signer,
+          transactions: [tx, { ...tx, from: Wallet.createRandom().address }],
+        });
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught));
+      }
+
+      expect(error?.message).to.include('does not match external signer');
+      expect(getFeeData.called).to.equal(false);
+    });
+
+    it('rejects non-Ethereum transactions', async () => {
+      const nonEvmMultiProvider = new MultiProvider({
+        ...testChainMetadata,
+        [testSealevelChain.name]: testSealevelChain,
+      });
+
+      let error: Error | undefined;
+      try {
+        await prepareExternalSubmission({
+          context: { multiProvider: nonEvmMultiProvider },
+          signer,
+          transactions: [{ ...tx, chainId: Number(testSealevelChain.chainId) }],
+        });
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught));
+      }
+
+      expect(error?.message).to.include(
+        'External EVM signers cannot submit transactions',
       );
-    const receiptsPath = mkdtempSync(
-      join(tmpdir(), 'hyperlane-external-receipts-'),
-    );
-    tempDirs.push(receiptsPath);
+    });
 
-    let error: Error | undefined;
-    try {
-      await runExternalSubmit({
-        context: { multiProvider, skipConfirmation: true },
-        signer,
-        transactions: [tx],
-        receiptsFilepath: receiptsPath,
+    it('rejects an insufficient signer balance', async () => {
+      sinon.restore();
+      sinon.stub(provider, 'getFeeData').resolves({
+        gasPrice: BigNumber.from(2),
+        maxFeePerGas: BigNumber.from(3),
+        maxPriorityFeePerGas: BigNumber.from(1),
+        lastBaseFeePerGas: BigNumber.from(1),
       });
-    } catch (caught) {
-      error = caught instanceof Error ? caught : new Error(String(caught));
-    }
+      sinon.stub(provider, 'getBalance').resolves(BigNumber.from(1));
+      sinon.stub(multiProvider, 'estimateGas').resolves(BigNumber.from(21_000));
 
-    expect(error?.message).to.include('confirmation timeout');
-    const files = readdirSync(receiptsPath);
-    expect(files).to.have.length(1);
-    expect(files[0]).to.include('jsonRpc-partial');
-    expect(readYamlOrJson(join(receiptsPath, files[0]))).to.deep.equal([
-      { transactionHash: '0x01', receipt },
-      { transactionHash: '0x02' },
-    ]);
+      let error: Error | undefined;
+      try {
+        await prepareExternalSubmission({
+          context: { multiProvider },
+          signer,
+          transactions: [tx],
+        });
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught));
+      }
+
+      expect(error?.message).to.include('insufficient balance');
+    });
+  });
+
+  describe('runExternalSubmit', () => {
+    it('writes partial submission progress before rethrowing', async () => {
+      // CAST: minimal ethers receipt fixture; serialization is the behavior under test.
+      const receipt = {
+        transactionHash: '0x01',
+        status: 1,
+      } as providers.TransactionReceipt;
+      sinon
+        .stub(EV5JsonRpcTxSubmitter.prototype, 'submit')
+        .rejects(
+          new EV5JsonRpcSubmissionError(
+            'confirmation timeout',
+            [{ transactionHash: '0x01', receipt }, { transactionHash: '0x02' }],
+            new Error('confirmation timeout'),
+          ),
+        );
+      const receiptsPath = mkdtempSync(
+        join(tmpdir(), 'hyperlane-external-receipts-'),
+      );
+      tempDirs.push(receiptsPath);
+
+      let error: Error | undefined;
+      try {
+        await runExternalSubmit({
+          context: { multiProvider, skipConfirmation: true },
+          signer,
+          transactions: [tx],
+          receiptsFilepath: receiptsPath,
+        });
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught));
+      }
+
+      expect(error?.message).to.include('confirmation timeout');
+      const files = readdirSync(receiptsPath);
+      expect(files).to.have.length(1);
+      expect(files[0]).to.include('jsonRpc-partial');
+      expect(readYamlOrJson(join(receiptsPath, files[0]))).to.deep.equal([
+        { transactionHash: '0x01', receipt },
+        { transactionHash: '0x02' },
+      ]);
+    });
   });
 });

--- a/typescript/cli/src/config/submit.test.ts
+++ b/typescript/cli/src/config/submit.test.ts
@@ -15,7 +15,11 @@ import {
 
 import { readYamlOrJson } from '../utils/files.js';
 
-import { prepareExternalSubmission, runExternalSubmit } from './submit.js';
+import {
+  prepareExternalSubmission,
+  runExternalSubmit,
+  validateExternalTransactions,
+} from './submit.js';
 
 describe('external submission', () => {
   const tempDirs: string[] = [];
@@ -138,6 +142,30 @@ describe('external submission', () => {
   });
 
   describe('runExternalSubmit', () => {
+    it('validates the complete external batch before submission', async () => {
+      const submit = sinon.stub(EV5JsonRpcTxSubmitter.prototype, 'submit');
+      const receiptsPath = mkdtempSync(
+        join(tmpdir(), 'hyperlane-external-receipts-'),
+      );
+      tempDirs.push(receiptsPath);
+
+      let error: Error | undefined;
+      try {
+        await runExternalSubmit({
+          context: { multiProvider, skipConfirmation: true },
+          signer,
+          transactions: [tx, { ...tx, maxFeePerGas: '-1' }],
+          receiptsFilepath: receiptsPath,
+        });
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught));
+      }
+
+      expect(error?.message).to.include('Invalid');
+      expect(submit.called).to.equal(false);
+      expect(getFeeData.called).to.equal(false);
+    });
+
     it('writes partial submission progress before rethrowing', async () => {
       // CAST: minimal ethers receipt fixture; serialization is the behavior under test.
       const receipt = {
@@ -178,6 +206,40 @@ describe('external submission', () => {
         { transactionHash: '0x01', receipt },
         { transactionHash: '0x02' },
       ]);
+    });
+  });
+
+  describe('validateExternalTransactions', () => {
+    it('normalizes supported numeric and access-list fields', () => {
+      const [validated] = validateExternalTransactions([
+        {
+          ...tx,
+          accessList: {
+            [Wallet.createRandom().address]: [`0x${'00'.repeat(32)}`],
+          },
+          gasLimit: '0x5208',
+          maxFeePerGas: '3',
+          maxPriorityFeePerGas: 1,
+          type: 2,
+          value: BigNumber.from(0),
+        },
+      ]);
+
+      expect(BigNumber.isBigNumber(validated.gasLimit)).to.equal(true);
+      expect(validated.gasLimit?.toString()).to.equal('21000');
+      expect(validated.accessList).to.have.length(1);
+    });
+
+    it('rejects unsupported transaction fields', () => {
+      expect(() =>
+        validateExternalTransactions([{ ...tx, ccipReadEnabled: true }]),
+      ).to.throw('Unrecognized key');
+    });
+
+    it('rejects incompatible fee fields', () => {
+      expect(() =>
+        validateExternalTransactions([{ ...tx, gasPrice: 1, maxFeePerGas: 2 }]),
+      ).to.throw('gasPrice cannot be combined');
     });
   });
 });

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -1,14 +1,26 @@
+import { confirm } from '@inquirer/prompts';
+import { BigNumber, type Signer } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
   type AnnotatedEV5Transaction,
   type ChainName,
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
 } from '@hyperlane-xyz/sdk';
-import { type ProtocolType, errorToString } from '@hyperlane-xyz/utils';
+import {
+  ProtocolType,
+  assert,
+  eqAddress,
+  errorToString,
+} from '@hyperlane-xyz/utils';
 
-import { type WriteCommandContext } from '../context/types.js';
+import {
+  type CommandContext,
+  type WriteCommandContext,
+} from '../context/types.js';
 import { getSubmitterByStrategy } from '../deploy/warp.js';
-import { logGray, logRed } from '../logger.js';
+import { logGray, logRed, logTable } from '../logger.js';
 import {
   indentYamlOrJson,
   readYamlOrJson,
@@ -55,8 +67,214 @@ export async function runSubmit({
   }
 }
 
+interface ExternalSubmissionPlan {
+  chain: ChainName;
+  transactions: AnnotatedEV5Transaction[];
+  signerAddress: string;
+  balance: BigNumber;
+  requiredBalance: BigNumber;
+}
+
+export async function runExternalSubmit({
+  context,
+  signer,
+  transactions,
+  receiptsFilepath,
+}: {
+  context: Pick<CommandContext, 'multiProvider' | 'skipConfirmation'>;
+  signer: Signer;
+  transactions: AnnotatedEV5Transaction[];
+  receiptsFilepath: string;
+}): Promise<void> {
+  const plans = await prepareExternalSubmission({
+    context,
+    signer,
+    transactions,
+  });
+
+  logGray('External signer submission plan');
+  logTable(
+    plans.flatMap((plan) =>
+      plan.transactions.map((tx) => ({
+        chain: plan.chain,
+        signer: plan.signerAddress,
+        target: tx.to ?? '(contract creation)',
+        selector:
+          typeof tx.data === 'string' && tx.data.length >= 10
+            ? tx.data.slice(0, 10)
+            : '(none)',
+        value: BigNumber.from(tx.value ?? 0).toString(),
+      })),
+    ),
+  );
+
+  if (!context.skipConfirmation) {
+    const confirmed = await confirm({
+      message: `Submit ${transactions.length} transaction(s) with the external signer?`,
+      default: false,
+    });
+    assert(confirmed, 'Transaction submission cancelled');
+  }
+
+  for (const plan of plans) {
+    const submitter = new EV5JsonRpcTxSubmitter(
+      context.multiProvider,
+      { chain: plan.chain },
+      signer,
+    );
+
+    try {
+      const receipts = await submitter.submit(...plan.transactions);
+      writeSubmissionResults(receiptsFilepath, plan.chain, 'jsonRpc', receipts);
+    } catch (error) {
+      if (
+        error instanceof EV5JsonRpcSubmissionError &&
+        error.submittedTransactions.length > 0
+      ) {
+        writeSubmissionResults(
+          receiptsFilepath,
+          plan.chain,
+          'jsonRpc-partial',
+          error.submittedTransactions,
+        );
+      }
+      throw error;
+    }
+  }
+}
+
+export async function prepareExternalSubmission({
+  context,
+  signer,
+  transactions,
+}: {
+  context: Pick<CommandContext, 'multiProvider'>;
+  signer: Signer;
+  transactions: AnnotatedEV5Transaction[];
+}): Promise<ExternalSubmissionPlan[]> {
+  assert(transactions.length > 0, 'No transactions found in file');
+  const signerAddress = await signer.getAddress();
+  const transactionsByChain = new Map<ChainName, AnnotatedEV5Transaction[]>();
+
+  // Resolve and validate the complete input before any RPC preflight or send.
+  for (const transaction of transactions) {
+    assert(
+      transaction.chainId !== undefined,
+      'Invalid transaction: missing chainId',
+    );
+    const chain = context.multiProvider.getChainName(transaction.chainId);
+    assert(
+      context.multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+      `External EVM signers cannot submit transactions on ${chain}`,
+    );
+    if (transaction.from) {
+      assert(
+        eqAddress(transaction.from, signerAddress),
+        `Transaction sender ${transaction.from} does not match external signer ${signerAddress} on ${chain}`,
+      );
+    }
+
+    const chainTransactions = transactionsByChain.get(chain) ?? [];
+    chainTransactions.push(transaction);
+    transactionsByChain.set(chain, chainTransactions);
+  }
+
+  return Promise.all(
+    Array.from(transactionsByChain, async ([chain, chainTransactions]) => {
+      const provider = context.multiProvider.getProvider(chain);
+      const [feeData, balance] = await Promise.all([
+        provider.getFeeData(),
+        provider.getBalance(signerAddress),
+      ]);
+
+      let requiredBalance = BigNumber.from(0);
+      for (const transaction of chainTransactions) {
+        const { annotation: _annotation, ...populatedTransaction } =
+          transaction;
+        const preparedTransaction = await context.multiProvider.prepareTx(
+          chain,
+          populatedTransaction,
+          signerAddress,
+        );
+        const estimatedGas = await context.multiProvider.estimateGas(
+          chain,
+          populatedTransaction,
+          signerAddress,
+        );
+        if (preparedTransaction.gasLimit !== undefined) {
+          assert(
+            BigNumber.from(preparedTransaction.gasLimit).gte(estimatedGas),
+            `Transaction gas limit is below the estimate on ${chain}`,
+          );
+        }
+        const gasLimit = preparedTransaction.gasLimit ?? estimatedGas;
+        const maxFeePerGas =
+          preparedTransaction.maxFeePerGas ??
+          preparedTransaction.gasPrice ??
+          feeData.maxFeePerGas ??
+          feeData.gasPrice;
+        assert(maxFeePerGas, `Could not determine gas price for ${chain}`);
+        requiredBalance = requiredBalance
+          .add(BigNumber.from(gasLimit).mul(maxFeePerGas))
+          .add(preparedTransaction.value ?? 0);
+      }
+
+      assert(
+        balance.gte(requiredBalance),
+        `External signer ${signerAddress} has insufficient balance on ${chain}: requires at least ${requiredBalance.toString()} wei, found ${balance.toString()} wei`,
+      );
+
+      return {
+        chain,
+        transactions: chainTransactions,
+        signerAddress,
+        balance,
+        requiredBalance,
+      };
+    }),
+  );
+}
+
+function writeSubmissionResults(
+  receiptsFilepath: string,
+  chain: ChainName,
+  label: string,
+  results: unknown[],
+): void {
+  logGray(
+    '🧾 Transaction results:\n\n',
+    indentYamlOrJson(yamlStringify(results, null, 2), 4),
+  );
+  const receiptPath = `${receiptsFilepath}/${chain}-${label}-${Date.now()}-receipts.json`;
+  writeYamlOrJson(receiptPath, results, 'json');
+}
+
 export function getTransactions(
   transactionsFilepath: string,
 ): AnnotatedEV5Transaction[] {
-  return readYamlOrJson<AnnotatedEV5Transaction[]>(transactionsFilepath.trim());
+  const transactions = readYamlOrJson<unknown>(transactionsFilepath.trim());
+  assert(
+    Array.isArray(transactions),
+    'Transactions file must contain an array',
+  );
+  assert(
+    transactions.every(isAnnotatedEvmTransaction),
+    'Transactions file contains an invalid EVM transaction',
+  );
+  return transactions;
+}
+
+function isAnnotatedEvmTransaction(
+  value: unknown,
+): value is AnnotatedEV5Transaction {
+  if (typeof value !== 'object' || value === null || Array.isArray(value))
+    return false;
+  if (!('chainId' in value) || typeof value.chainId !== 'number') return false;
+  if ('from' in value && value.from != null && typeof value.from !== 'string')
+    return false;
+  if ('to' in value && value.to != null && typeof value.to !== 'string')
+    return false;
+  if ('data' in value && value.data != null && typeof value.data !== 'string')
+    return false;
+  return true;
 }

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -1,6 +1,7 @@
 import { confirm } from '@inquirer/prompts';
-import { BigNumber, type Signer } from 'ethers';
+import { BigNumber, type Signer, utils as ethersUtils } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
+import { z } from 'zod';
 
 import {
   type AnnotatedEV5Transaction,
@@ -13,6 +14,7 @@ import {
   assert,
   eqAddress,
   errorToString,
+  isValidAddressEvm,
 } from '@hyperlane-xyz/utils';
 
 import {
@@ -75,6 +77,116 @@ interface ExternalSubmissionPlan {
   requiredBalance: BigNumber;
 }
 
+const ExternalBigNumberSchema = z
+  .union([
+    z.custom<BigNumber>(BigNumber.isBigNumber),
+    z.number().int().safe().nonnegative(),
+    z.string().regex(/^(?:0x[0-9a-fA-F]+|[0-9]+)$/),
+  ])
+  .transform((value) => BigNumber.from(value));
+
+const EvmAddressSchema = z
+  .string()
+  .refine(isValidAddressEvm, 'Invalid EVM address');
+const EvmDataSchema = z
+  .string()
+  .regex(/^0x(?:[0-9a-fA-F]{2})*$/, 'Invalid EVM transaction data');
+const StorageKeySchema = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{64}$/, 'Invalid access-list storage key');
+const AccessListRecordSchema = z
+  .record(z.array(StorageKeySchema))
+  .refine(
+    (accessList) => Object.keys(accessList).every(isValidAddressEvm),
+    'Invalid access-list address',
+  );
+const AccessListSchema = z
+  .union([
+    z.array(
+      z
+        .object({
+          address: EvmAddressSchema,
+          storageKeys: z.array(StorageKeySchema),
+        })
+        .strict(),
+    ),
+    z.array(z.tuple([EvmAddressSchema, z.array(StorageKeySchema)])),
+    AccessListRecordSchema,
+  ])
+  .transform((accessList) => ethersUtils.accessListify(accessList));
+
+const ExternalTransactionSchema = z
+  .object({
+    accessList: AccessListSchema.optional(),
+    annotation: z.string().optional(),
+    chainId: z.number().int().safe().positive(),
+    data: EvmDataSchema.optional(),
+    from: EvmAddressSchema.optional(),
+    gasLimit: ExternalBigNumberSchema.optional(),
+    gasPrice: ExternalBigNumberSchema.optional(),
+    maxFeePerGas: ExternalBigNumberSchema.optional(),
+    maxPriorityFeePerGas: ExternalBigNumberSchema.optional(),
+    nonce: z.number().int().safe().nonnegative().optional(),
+    to: EvmAddressSchema.optional(),
+    type: z.union([z.literal(0), z.literal(1), z.literal(2)]).optional(),
+    value: ExternalBigNumberSchema.optional(),
+  })
+  .strict()
+  .superRefine((transaction, context) => {
+    if (
+      transaction.gasPrice !== undefined &&
+      (transaction.maxFeePerGas !== undefined ||
+        transaction.maxPriorityFeePerGas !== undefined)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'gasPrice cannot be combined with EIP-1559 fee fields',
+      });
+    }
+    if (
+      transaction.maxFeePerGas !== undefined &&
+      transaction.maxPriorityFeePerGas?.gt(transaction.maxFeePerGas)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'maxPriorityFeePerGas cannot exceed maxFeePerGas',
+      });
+    }
+    if (
+      transaction.type === 0 &&
+      (transaction.accessList !== undefined ||
+        transaction.maxFeePerGas !== undefined ||
+        transaction.maxPriorityFeePerGas !== undefined)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Type 0 transactions cannot use access lists or EIP-1559 fees',
+      });
+    }
+    if (
+      transaction.type === 1 &&
+      (transaction.maxFeePerGas !== undefined ||
+        transaction.maxPriorityFeePerGas !== undefined)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Type 1 transactions cannot use EIP-1559 fee fields',
+      });
+    }
+    if (transaction.type === 2 && transaction.gasPrice !== undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Type 2 transactions cannot use gasPrice',
+      });
+    }
+  });
+
+export function validateExternalTransactions(
+  transactions: unknown[],
+): AnnotatedEV5Transaction[] {
+  return z.array(ExternalTransactionSchema).min(1).parse(transactions);
+}
+
 export async function runExternalSubmit({
   context,
   signer,
@@ -83,13 +195,14 @@ export async function runExternalSubmit({
 }: {
   context: Pick<CommandContext, 'multiProvider' | 'skipConfirmation'>;
   signer: Signer;
-  transactions: AnnotatedEV5Transaction[];
+  transactions: unknown[];
   receiptsFilepath: string;
 }): Promise<void> {
+  const validatedTransactions = validateExternalTransactions(transactions);
   const plans = await prepareExternalSubmission({
     context,
     signer,
-    transactions,
+    transactions: validatedTransactions,
   });
 
   logGray('External signer submission plan');
@@ -110,7 +223,7 @@ export async function runExternalSubmit({
 
   if (!context.skipConfirmation) {
     const confirmed = await confirm({
-      message: `Submit ${transactions.length} transaction(s) with the external signer?`,
+      message: `Submit ${validatedTransactions.length} transaction(s) with the external signer?`,
       default: false,
     });
     assert(confirmed, 'Transaction submission cancelled');

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -79,11 +79,11 @@ interface ExternalSubmissionPlan {
 
 const ExternalBigNumberSchema = z
   .union([
-    z.custom<BigNumber>(BigNumber.isBigNumber),
     z.number().int().safe().nonnegative(),
     z.string().regex(/^(?:0x[0-9a-fA-F]+|[0-9]+)$/),
   ])
-  .transform((value) => BigNumber.from(value));
+  .transform((value) => BigNumber.from(value))
+  .refine((value) => !value.isNegative(), 'Value must be non-negative');
 
 const EvmAddressSchema = z
   .string()

--- a/typescript/cli/src/config/submit.ts
+++ b/typescript/cli/src/config/submit.ts
@@ -301,7 +301,10 @@ export async function prepareExternalSubmission({
       ]);
 
       let requiredBalance = BigNumber.from(0);
-      for (const transaction of chainTransactions) {
+      for (const [
+        transactionIndex,
+        transaction,
+      ] of chainTransactions.entries()) {
         const { annotation: _annotation, ...populatedTransaction } =
           transaction;
         const preparedTransaction = await context.multiProvider.prepareTx(
@@ -309,11 +312,20 @@ export async function prepareExternalSubmission({
           populatedTransaction,
           signerAddress,
         );
-        const estimatedGas = await context.multiProvider.estimateGas(
-          chain,
-          populatedTransaction,
-          signerAddress,
-        );
+        let estimatedGas: BigNumber;
+        try {
+          // Preflight does not mutate state; every transaction must stand alone.
+          estimatedGas = await context.multiProvider.estimateGas(
+            chain,
+            populatedTransaction,
+            signerAddress,
+          );
+        } catch (error) {
+          throw new Error(
+            `Transaction ${transactionIndex + 1} on ${chain} cannot be estimated independently against current on-chain state. Split state-dependent transactions into separate submit runs: ${errorToString(error)}`,
+            { cause: error },
+          );
+        }
         if (preparedTransaction.gasLimit !== undefined) {
           assert(
             BigNumber.from(preparedTransaction.gasLimit).gte(estimatedGas),

--- a/typescript/cli/src/context/context.ts
+++ b/typescript/cli/src/context/context.ts
@@ -86,7 +86,13 @@ function toOptionalSignerKey(value: unknown): ContextSettings['key'] {
 }
 
 export async function contextMiddleware(argv: ContextMiddlewareArgv) {
-  const requiresKey = isSignCommand(argv);
+  const signerConfig = toOptionalString(argv.signerConfig);
+  assert(
+    !(signerConfig && toOptionalString(argv.strategy)),
+    '--strategy cannot be combined with --signer-config',
+  );
+  const skipLocalSigner = Boolean(signerConfig);
+  const requiresKey = isSignCommand(argv) && !skipLocalSigner;
 
   const settings: ContextSettings = {
     registryUris: parseRegistryUris(argv.registry),
@@ -96,6 +102,7 @@ export async function contextMiddleware(argv: ContextMiddlewareArgv) {
     skipConfirmation: toOptionalBoolean(argv.yes),
     strategyPath: toOptionalString(argv.strategy),
     authToken: toOptionalString(argv.authToken),
+    skipLocalSigner,
   };
 
   argv.context = await getContext(settings);
@@ -123,6 +130,16 @@ export async function signerMiddleware(argv: ContextMiddlewareArgv) {
    * Resolves chains based on the command type.
    */
   const chains = await resolveChains(argv);
+
+  if (toOptionalString(argv.signerConfig)) {
+    for (const chain of chains) {
+      assert(
+        argv.context.multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+        `External EVM signers cannot submit transactions on ${chain}`,
+      );
+    }
+    return;
+  }
 
   /**
    * Load and create AltVM Providers
@@ -205,6 +222,7 @@ export async function getContext({
   disableProxy = false,
   strategyPath,
   authToken,
+  skipLocalSigner = false,
 }: ContextSettings): Promise<CommandContext> {
   const registry = getRegistry({
     registryUris,
@@ -213,10 +231,12 @@ export async function getContext({
     authToken,
   });
 
-  const { keyMap, ethereumSignerAddress } = await getSignerKeyMap(
-    key,
-    !!skipConfirmation,
-  );
+  const { keyMap, ethereumSignerAddress } = skipLocalSigner
+    ? {
+        keyMap: SignerKeyProtocolMapSchema.parse({}),
+        ethereumSignerAddress: undefined,
+      }
+    : await getSignerKeyMap(key, !!skipConfirmation);
 
   const multiProvider = await getMultiProvider(registry);
   const multiProtocolProvider = await getMultiProtocolProvider(registry);

--- a/typescript/cli/src/context/externalSigner.test.ts
+++ b/typescript/cli/src/context/externalSigner.test.ts
@@ -1,0 +1,78 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { TurnkeyEvmSigner } from '@hyperlane-xyz/sdk';
+
+import {
+  ExternalSignerType,
+  loadExternalEvmSigner,
+  readExternalSignerConfig,
+} from './externalSigner.js';
+
+const tempDirs: string[] = [];
+const config = {
+  type: ExternalSignerType.TURNKEY,
+  organizationId: 'organization-id',
+  apiPublicKey: 'api-public-key',
+  apiPrivateKey: 'api-private-key',
+  privateKeyId: 'private-key-id',
+  publicKey: '0x0000000000000000000000000000000000000001',
+};
+
+describe('externalSigner', () => {
+  afterEach(() => {
+    sinon.restore();
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true });
+  });
+
+  it('reads a private Turnkey config', () => {
+    const path = writeConfig(0o600, config);
+    expect(readExternalSignerConfig(path)).to.deep.equal(config);
+  });
+
+  it('rejects group-readable config files', () => {
+    if (process.platform === 'win32') return;
+    const path = writeConfig(0o640, config);
+    expect(() => readExternalSignerConfig(path)).to.throw(
+      'permissions are too broad',
+    );
+  });
+
+  it('rejects unsupported signer types', () => {
+    const path = writeConfig(0o600, { ...config, type: 'privy' });
+    expect(() => readExternalSignerConfig(path)).to.throw();
+  });
+
+  it('rejects a non-EVM Turnkey public key', () => {
+    const path = writeConfig(0o600, { ...config, publicKey: 'not-an-address' });
+    expect(() => readExternalSignerConfig(path)).to.throw(
+      'Turnkey publicKey must be a valid EVM address',
+    );
+  });
+
+  it('rejects an unhealthy Turnkey signer', async () => {
+    const path = writeConfig(0o600, config);
+    sinon.stub(TurnkeyEvmSigner.prototype, 'healthCheck').resolves(false);
+
+    let error: Error | undefined;
+    try {
+      await loadExternalEvmSigner(path);
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+    expect(error?.message).to.include('Turnkey health check failed');
+  });
+});
+
+function writeConfig(mode: number, value: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hyperlane-external-signer-'));
+  tempDirs.push(dir);
+  const path = join(dir, 'signer.json');
+  writeFileSync(path, JSON.stringify(value), { mode: 0o600 });
+  chmodSync(path, mode);
+  return path;
+}

--- a/typescript/cli/src/context/externalSigner.ts
+++ b/typescript/cli/src/context/externalSigner.ts
@@ -1,0 +1,56 @@
+import { readFileSync, statSync } from 'fs';
+
+import { type Signer } from 'ethers';
+import { z } from 'zod';
+
+import { TurnkeyConfigSchema, TurnkeyEvmSigner } from '@hyperlane-xyz/sdk';
+import { assert, isValidAddressEvm } from '@hyperlane-xyz/utils';
+
+export const ExternalSignerType = {
+  TURNKEY: 'turnkey',
+} as const;
+
+const TurnkeyExternalSignerConfigSchema = TurnkeyConfigSchema.extend({
+  type: z.literal(ExternalSignerType.TURNKEY),
+  publicKey: TurnkeyConfigSchema.shape.publicKey.refine(
+    isValidAddressEvm,
+    'Turnkey publicKey must be a valid EVM address',
+  ),
+});
+
+export const ExternalSignerConfigSchema = z.discriminatedUnion('type', [
+  TurnkeyExternalSignerConfigSchema,
+]);
+
+export type ExternalSignerConfig = z.infer<typeof ExternalSignerConfigSchema>;
+
+export function readExternalSignerConfig(
+  configPath: string,
+): ExternalSignerConfig {
+  const stat = statSync(configPath);
+  assert(stat.isFile(), `External signer config is not a file: ${configPath}`);
+  if (process.platform !== 'win32') {
+    assert(
+      (stat.mode & 0o077) === 0,
+      `External signer config permissions are too broad: ${configPath}. Run chmod 600 ${configPath}`,
+    );
+  }
+
+  return ExternalSignerConfigSchema.parse(
+    JSON.parse(readFileSync(configPath, 'utf8')),
+  );
+}
+
+export async function loadExternalEvmSigner(
+  configPath: string,
+): Promise<Signer> {
+  const config = readExternalSignerConfig(configPath);
+
+  switch (config.type) {
+    case ExternalSignerType.TURNKEY: {
+      const signer = new TurnkeyEvmSigner(config);
+      assert(await signer.healthCheck(), 'Turnkey health check failed');
+      return signer;
+    }
+  }
+}

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -42,6 +42,7 @@ export interface ContextSettings extends BaseContext {
   registryUris: string[];
   disableProxy?: boolean;
   authToken?: string;
+  skipLocalSigner?: boolean;
 }
 
 export interface CommandContext extends Omit<

--- a/typescript/cli/src/tests/cosmosnative/submit/submit.e2e-test.ts
+++ b/typescript/cli/src/tests/cosmosnative/submit/submit.e2e-test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { rmSync, writeFileSync } from 'fs';
+import { $ } from 'zx';
+
+import { ChainMetadataSchema, randomAddress } from '@hyperlane-xyz/sdk';
+import { randomInt } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { localTestRunCmdPrefix } from '../../commands/helpers.js';
+import {
+  CHAIN_1_METADATA_PATH,
+  CHAIN_NAME_1,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  TEMP_PATH,
+} from '../consts.js';
+
+describe('hyperlane cosmosnative submit e2e tests', function () {
+  this.timeout(DEFAULT_E2E_TEST_TIMEOUT);
+
+  it('rejects an external EVM signer before loading its config', async () => {
+    const metadata = ChainMetadataSchema.parse(
+      readYamlOrJson(CHAIN_1_METADATA_PATH),
+    );
+    const suffix = randomInt(0, 1_000_000);
+    const transactionsPath = `${TEMP_PATH}/cosmos-external-transactions-${suffix}.json`;
+    const signerConfigPath = `${TEMP_PATH}/cosmos-external-signer-${suffix}.json`;
+    writeYamlOrJson(
+      transactionsPath,
+      [
+        {
+          chainId: metadata.domainId,
+          data: '0x',
+          to: randomAddress(),
+        },
+      ],
+      'json',
+    );
+    writeFileSync(signerConfigPath, '{}', { mode: 0o600 });
+
+    try {
+      const output =
+        await $`${localTestRunCmdPrefix()} hyperlane submit --registry ${REGISTRY_PATH} --transactions ${transactionsPath} --signer-config ${signerConfigPath} --yes`.nothrow();
+
+      expect(output.exitCode).to.equal(1);
+      expect(output.text()).to.include(
+        `External EVM signers cannot submit transactions on ${CHAIN_NAME_1}`,
+      );
+    } finally {
+      rmSync(transactionsPath, { force: true });
+      rmSync(signerConfigPath, { force: true });
+    }
+  });
+});

--- a/typescript/cli/src/tests/ethereum/commands/helpers.ts
+++ b/typescript/cli/src/tests/ethereum/commands/helpers.ts
@@ -1,5 +1,7 @@
+import { generateKeyPairSync } from 'crypto';
 import { ethers } from 'ethers';
 import http from 'http';
+import { type IncomingMessage, type ServerResponse } from 'http';
 import path from 'path';
 import { $ } from 'zx';
 
@@ -462,10 +464,14 @@ async function snapshotBaseCall<T>(
 export async function hyperlaneSubmit({
   transactionsPath,
   strategyPath,
+  signerConfigPath,
+  receiptsPath,
   hypKey,
 }: {
   transactionsPath: string;
   strategyPath?: string;
+  signerConfigPath?: string;
+  receiptsPath?: string;
   hypKey?: string;
 }) {
   return $`${
@@ -473,10 +479,123 @@ export async function hyperlaneSubmit({
   } ${localTestRunCmdPrefix()} hyperlane submit \
         --registry ${REGISTRY_PATH} \
         --transactions ${transactionsPath} \
-        --key ${ANVIL_KEY} \
+        ${
+          signerConfigPath
+            ? ['--signer-config', signerConfigPath]
+            : ['--key', ANVIL_KEY]
+        } \
         --verbosity debug \
         ${strategyPath ? ['--strategy', strategyPath] : []} \
+        ${receiptsPath ? ['--receipts', receiptsPath] : []} \
         --yes`;
+}
+
+export async function startMockTurnkeyApi(wallet: ethers.Wallet): Promise<{
+  url: string;
+  apiKey: { apiPublicKey: string; apiPrivateKey: string };
+  close: () => Promise<void>;
+}> {
+  const keyPair = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const jwk = keyPair.privateKey.export({ format: 'jwk' });
+  assert(jwk.x && jwk.y && jwk.d, 'Expected complete P-256 JWK');
+  const x = Buffer.from(jwk.x, 'base64url');
+  const y = Buffer.from(jwk.y, 'base64url');
+  assert(y.length > 0, 'Expected P-256 public key bytes');
+  const apiKey = {
+    apiPublicKey: `${y[y.length - 1] & 1 ? '03' : '02'}${x.toString('hex')}`,
+    apiPrivateKey: Buffer.from(jwk.d, 'base64url').toString('hex'),
+  };
+
+  const server = http.createServer((request, response) => {
+    void handleTurnkeyRequest(wallet, request, response);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert(address && typeof address !== 'string', 'Expected TCP server address');
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    apiKey,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}
+
+async function handleTurnkeyRequest(
+  wallet: ethers.Wallet,
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> {
+  try {
+    if (request.url === '/public/v1/query/whoami') {
+      sendJson(response, { organizationId: 'test-organization' });
+      return;
+    }
+    if (request.url === '/public/v1/submit/sign_transaction') {
+      const body: unknown = JSON.parse(await readRequestBody(request));
+      assert(isRecord(body), 'Expected request body');
+      const parameters = body.parameters;
+      assert(isRecord(parameters), 'Expected request parameters');
+      const unsignedTransaction = parameters.unsignedTransaction;
+      assert(
+        typeof unsignedTransaction === 'string',
+        'Expected unsigned transaction',
+      );
+      const signedTransaction = await wallet.signTransaction(
+        parseUnsignedTransaction(`0x${unsignedTransaction}`),
+      );
+      sendJson(response, {
+        activity: {
+          id: 'test-activity',
+          status: 'ACTIVITY_STATUS_COMPLETED',
+          result: { signTransactionResult: { signedTransaction } },
+        },
+      });
+      return;
+    }
+    response.writeHead(404).end();
+  } catch (error) {
+    response.writeHead(500).end(error instanceof Error ? error.message : '');
+  }
+}
+
+function parseUnsignedTransaction(
+  serialized: string,
+): ethers.providers.TransactionRequest {
+  const parsed = ethers.utils.parseTransaction(serialized);
+  return {
+    to: parsed.to ?? undefined,
+    nonce: parsed.nonce,
+    gasLimit: parsed.gasLimit,
+    gasPrice: parsed.gasPrice ?? undefined,
+    data: parsed.data,
+    value: parsed.value,
+    chainId: parsed.chainId,
+    type: parsed.type ?? undefined,
+    maxPriorityFeePerGas: parsed.maxPriorityFeePerGas ?? undefined,
+    maxFeePerGas: parsed.maxFeePerGas ?? undefined,
+    accessList: parsed.accessList ?? undefined,
+  };
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendJson(response: ServerResponse, body: unknown): void {
+  response.setHeader('content-type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { type PopulatedTransaction as EV5Transaction, ethers } from 'ethers';
+import {
+  type PopulatedTransaction as EV5Transaction,
+  Wallet,
+  ethers,
+} from 'ethers';
+import { readdirSync, writeFileSync } from 'fs';
 
 import { type XERC20VSTest, XERC20VSTest__factory } from '@hyperlane-xyz/core';
 import { TxSubmitterType, randomAddress } from '@hyperlane-xyz/sdk';
@@ -7,8 +12,13 @@ import { type Address, randomInt } from '@hyperlane-xyz/utils';
 
 import { EV5FileSubmitter } from '../../../submitters/EV5FileSubmitter.js';
 import { CustomTxSubmitterType } from '../../../submitters/types.js';
+import { ExternalSignerType } from '../../../context/externalSigner.js';
 import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
-import { deployXERC20VSToken, hyperlaneSubmit } from '../commands/helpers.js';
+import {
+  deployXERC20VSToken,
+  hyperlaneSubmit,
+  startMockTurnkeyApi,
+} from '../commands/helpers.js';
 import {
   ANVIL_KEY,
   CHAIN_NAME_2,
@@ -160,6 +170,63 @@ describe('hyperlane submit', function () {
       initialBalances[0].add(chain2MintAmount).toNumber(),
       initialBalances[1].add(chain3MintAmount).toNumber(),
     ]);
+  });
+
+  it('submits a transaction file with a Turnkey external signer', async function () {
+    const provider = xerc20Chain2.provider;
+    const feeWallet = Wallet.createRandom().connect(provider);
+    await (
+      await xerc20Chain2.signer.sendTransaction({
+        to: feeWallet.address,
+        value: ethers.utils.parseEther('1'),
+      })
+    ).wait();
+    await (await xerc20Chain2.transferOwnership(feeWallet.address)).wait();
+
+    const mintAmount = randomInt(1, 1000);
+    const transaction = await getMintOnlyOwnerTransaction(
+      xerc20Chain2,
+      ALICE,
+      mintAmount,
+      ANVIL2_CHAIN_ID,
+    );
+    const suffix = randomInt(0, 1_000_000);
+    const transactionsPath = `${TEMP_PATH}/external-signer-transactions-${suffix}.json`;
+    const signerConfigPath = `${TEMP_PATH}/external-signer-config-${suffix}.json`;
+    const receiptsPath = `${TEMP_PATH}/external-signer-receipts-${suffix}`;
+    writeYamlOrJson(transactionsPath, [transaction], 'json');
+
+    const mockTurnkey = await startMockTurnkeyApi(feeWallet);
+    writeFileSync(
+      signerConfigPath,
+      JSON.stringify({
+        type: ExternalSignerType.TURNKEY,
+        ...mockTurnkey.apiKey,
+        organizationId: 'test-organization',
+        privateKeyId: 'test-private-key',
+        publicKey: feeWallet.address,
+        apiBaseUrl: mockTurnkey.url,
+      }),
+      { mode: 0o600 },
+    );
+
+    const initialBalance = await xerc20Chain2.balanceOf(ALICE);
+    try {
+      await hyperlaneSubmit({
+        transactionsPath,
+        signerConfigPath,
+        receiptsPath,
+      });
+    } finally {
+      await mockTurnkey.close();
+    }
+
+    expect(await xerc20Chain2.balanceOf(ALICE)).to.eql(
+      initialBalance.add(mintAmount),
+    );
+    expect(
+      readdirSync(receiptsPath).some((file) => file.includes('jsonRpc')),
+    ).to.equal(true);
   });
 
   describe('FileSubmitter', function () {

--- a/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/submit/submit.e2e-test.ts
@@ -4,7 +4,7 @@ import {
   Wallet,
   ethers,
 } from 'ethers';
-import { readdirSync, writeFileSync } from 'fs';
+import { readdirSync, rmSync, writeFileSync } from 'fs';
 
 import { type XERC20VSTest, XERC20VSTest__factory } from '@hyperlane-xyz/core';
 import { TxSubmitterType, randomAddress } from '@hyperlane-xyz/sdk';
@@ -181,6 +181,7 @@ describe('hyperlane submit', function () {
         value: ethers.utils.parseEther('1'),
       })
     ).wait();
+    const originalOwner = await xerc20Chain2.owner();
     await (await xerc20Chain2.transferOwnership(feeWallet.address)).wait();
 
     const mintAmount = randomInt(1, 1000);
@@ -218,7 +219,14 @@ describe('hyperlane submit', function () {
         receiptsPath,
       });
     } finally {
-      await mockTurnkey.close();
+      try {
+        await (
+          await xerc20Chain2.connect(feeWallet).transferOwnership(originalOwner)
+        ).wait();
+      } finally {
+        rmSync(signerConfigPath, { force: true });
+        await mockTurnkey.close();
+      }
     }
 
     expect(await xerc20Chain2.balanceOf(ALICE)).to.eql(

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -638,7 +638,11 @@ export {
 export { EV5GnosisSafeTxBuilder } from './providers/transactions/submitter/ethersV5/EV5GnosisSafeTxBuilder.js';
 export { EV5GnosisSafeTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5GnosisSafeTxSubmitter.js';
 export { EV5ImpersonatedAccountTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5ImpersonatedAccountTxSubmitter.js';
-export { EV5JsonRpcTxSubmitter } from './providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.js';
+export {
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
+  EV5SubmittedTransaction,
+} from './providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.js';
 export { EV5TxSubmitterInterface } from './providers/transactions/submitter/ethersV5/EV5TxSubmitterInterface.js';
 export { EvmIcaTxSubmitter } from './providers/transactions/submitter/IcaTxSubmitter.js';
 export {

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
@@ -134,6 +134,24 @@ describe('EV5JsonRpcTxSubmitter', () => {
       { transactionHash: secondResponse.hash },
     ]);
   });
+
+  it('retains a reverted receipt', async () => {
+    const response = transactionResponse('0x05');
+    const receipt = transactionReceipt('0x05', 0);
+    sinon.stub(connectedExplicitSigner, 'sendTransaction').resolves(response);
+    sinon.stub(multiProvider, 'handleTx').resolves(receipt);
+
+    const error = await captureSubmissionError(
+      new EV5JsonRpcTxSubmitter(multiProvider, props, explicitSigner).submit(
+        tx,
+      ),
+    );
+
+    expect(error.message).to.include(`Transaction ${response.hash} reverted`);
+    expect(error.submittedTransactions).to.deep.equal([
+      { transactionHash: response.hash, receipt },
+    ]);
+  });
 });
 
 async function captureSubmissionError(

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.test.ts
@@ -1,0 +1,159 @@
+import { expect } from 'chai';
+import {
+  ContractReceipt,
+  ContractTransaction,
+  Wallet,
+  providers,
+} from 'ethers';
+import sinon from 'sinon';
+
+import { TestChainName } from '../../../../consts/testChains.js';
+import { randomAddress } from '../../../../test/testUtils.js';
+import { MultiProvider } from '../../../MultiProvider.js';
+
+import {
+  EV5JsonRpcSubmissionError,
+  EV5JsonRpcTxSubmitter,
+} from './EV5JsonRpcTxSubmitter.js';
+
+describe('EV5JsonRpcTxSubmitter', () => {
+  const chain = TestChainName.test1;
+  const chainId = 9913371;
+  const props = { type: 'jsonRpc' as const, chain };
+  const tx = { chainId, to: randomAddress() };
+
+  let multiProvider: MultiProvider;
+  let mainSigner: Wallet;
+  let explicitSigner: Wallet;
+  let connectedExplicitSigner: Wallet;
+  let prepareTx: sinon.SinonStub;
+
+  beforeEach(() => {
+    const provider = new providers.JsonRpcProvider('http://127.0.0.1:8545');
+    mainSigner = Wallet.createRandom().connect(provider);
+    explicitSigner = Wallet.createRandom();
+    connectedExplicitSigner = explicitSigner.connect(provider);
+    multiProvider = MultiProvider.createTestMultiProvider({
+      signer: mainSigner,
+      provider,
+    });
+
+    sinon.stub(explicitSigner, 'connect').returns(connectedExplicitSigner);
+    prepareTx = sinon
+      .stub(multiProvider, 'prepareTx')
+      .callsFake(async (_, request) => request);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('uses an explicit signer instead of the MultiProvider signer', async () => {
+    const response = transactionResponse('0x01');
+    const receipt = transactionReceipt('0x01', 1);
+    const explicitSend = sinon
+      .stub(connectedExplicitSigner, 'sendTransaction')
+      .resolves(response);
+    const mainSend = sinon.stub(mainSigner, 'sendTransaction');
+    sinon.stub(multiProvider, 'handleTx').resolves(receipt);
+
+    const submitter = new EV5JsonRpcTxSubmitter(
+      multiProvider,
+      props,
+      explicitSigner,
+    );
+
+    expect(await submitter.submit(tx)).to.deep.equal([receipt]);
+    expect(explicitSend.calledOnce).to.equal(true);
+    expect(mainSend.called).to.equal(false);
+    expect(
+      prepareTx.calledWith(chain, sinon.match.object, explicitSigner.address),
+    ).to.equal(true);
+  });
+
+  it('uses the MultiProvider signer when no explicit signer is supplied', async () => {
+    const response = transactionResponse('0x02');
+    const receipt = transactionReceipt('0x02', 1);
+    const mainSend = sinon
+      .stub(mainSigner, 'sendTransaction')
+      .resolves(response);
+    sinon.stub(multiProvider, 'handleTx').resolves(receipt);
+
+    const submitter = new EV5JsonRpcTxSubmitter(multiProvider, props);
+
+    expect(await submitter.submit(tx)).to.deep.equal([receipt]);
+    expect(mainSend.calledOnce).to.equal(true);
+    expect(
+      prepareTx.calledWith(chain, sinon.match.object, mainSigner.address),
+    ).to.equal(true);
+  });
+
+  it('validates the complete batch before broadcasting', async () => {
+    const explicitSend = sinon.stub(connectedExplicitSigner, 'sendTransaction');
+    const submitter = new EV5JsonRpcTxSubmitter(
+      multiProvider,
+      props,
+      explicitSigner,
+    );
+
+    let error: Error | undefined;
+    try {
+      await submitter.submit(tx, { ...tx, chainId: chainId + 1 });
+    } catch (caught) {
+      error = caught instanceof Error ? caught : new Error(String(caught));
+    }
+
+    expect(error?.message).to.include('does not match submitter chainId');
+    expect(explicitSend.called).to.equal(false);
+  });
+
+  it('retains confirmed receipts and a pending hash on partial failure', async () => {
+    const firstResponse = transactionResponse('0x03');
+    const secondResponse = transactionResponse('0x04');
+    const firstReceipt = transactionReceipt('0x03', 1);
+    sinon
+      .stub(connectedExplicitSigner, 'sendTransaction')
+      .onFirstCall()
+      .resolves(firstResponse)
+      .onSecondCall()
+      .resolves(secondResponse);
+    sinon
+      .stub(multiProvider, 'handleTx')
+      .onFirstCall()
+      .resolves(firstReceipt)
+      .onSecondCall()
+      .rejects(new Error('confirmation timeout'));
+
+    const error = await captureSubmissionError(
+      new EV5JsonRpcTxSubmitter(multiProvider, props, explicitSigner).submit(
+        tx,
+        tx,
+      ),
+    );
+
+    expect(error.submittedTransactions).to.deep.equal([
+      { transactionHash: firstResponse.hash, receipt: firstReceipt },
+      { transactionHash: secondResponse.hash },
+    ]);
+  });
+});
+
+async function captureSubmissionError(
+  submission: Promise<unknown>,
+): Promise<EV5JsonRpcSubmissionError> {
+  try {
+    await submission;
+  } catch (error) {
+    if (error instanceof EV5JsonRpcSubmissionError) return error;
+    throw error;
+  }
+  throw new Error('Expected submission to fail');
+}
+
+function transactionResponse(hash: string): ContractTransaction {
+  // CAST: minimal ethers response test double; only hash is read before handleTx.
+  return { hash } as ContractTransaction;
+}
+
+function transactionReceipt(hash: string, status: number): ContractReceipt {
+  // CAST: minimal ethers receipt test double; only hash/status are inspected.
+  return { transactionHash: hash, status } as ContractReceipt;
+}

--- a/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
+++ b/typescript/sdk/src/providers/transactions/submitter/ethersV5/EV5JsonRpcTxSubmitter.ts
@@ -1,8 +1,8 @@
 import { TransactionReceipt } from '@ethersproject/providers';
-import { ContractReceipt } from 'ethers';
+import { ContractReceipt, Signer } from 'ethers';
 import { Logger } from 'pino';
 
-import { assert, rootLogger } from '@hyperlane-xyz/utils';
+import { assert, formatError, rootLogger } from '@hyperlane-xyz/utils';
 
 import { MultiProvider } from '../../../MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../../../ProviderType.js';
@@ -10,6 +10,24 @@ import { TxSubmitterType } from '../TxSubmitterTypes.js';
 
 import { EV5TxSubmitterInterface } from './EV5TxSubmitterInterface.js';
 import { EV5JsonRpcTxSubmitterProps } from './types.js';
+
+export interface EV5SubmittedTransaction {
+  transactionHash: string;
+  receipt?: TransactionReceipt;
+}
+
+/** Retains irreversible progress when a sequential batch fails. */
+export class EV5JsonRpcSubmissionError extends Error {
+  readonly name = 'EV5JsonRpcSubmissionError';
+
+  constructor(
+    message: string,
+    public readonly submittedTransactions: EV5SubmittedTransaction[],
+    public readonly cause: unknown,
+  ) {
+    super(message);
+  }
+}
 
 export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   public readonly txSubmitterType: TxSubmitterType = TxSubmitterType.JSON_RPC;
@@ -21,28 +39,72 @@ export class EV5JsonRpcTxSubmitter implements EV5TxSubmitterInterface {
   constructor(
     public readonly multiProvider: MultiProvider,
     public readonly props: EV5JsonRpcTxSubmitterProps,
+    public readonly signer?: Signer,
   ) {}
 
   public async submit(
     ...txs: AnnotatedEV5Transaction[]
   ): Promise<TransactionReceipt[]> {
     const receipts: TransactionReceipt[] = [];
+    const submittedTransactions: EV5SubmittedTransaction[] = [];
     const submitterChainId = this.multiProvider.getChainId(this.props.chain);
+
+    // Validate the entire batch before the first irreversible broadcast.
     for (const tx of txs) {
       assert(tx.chainId, 'Invalid PopulatedTransaction: Missing chainId field');
       assert(
         tx.chainId === submitterChainId,
         `Transaction chainId ${tx.chainId} does not match submitter chainId ${submitterChainId}`,
       );
-      const receipt: ContractReceipt = await this.multiProvider.sendTransaction(
-        this.props.chain,
-        tx,
-      );
-      this.logger.debug(
-        `Submitted PopulatedTransaction on ${this.props.chain}: ${receipt.transactionHash}`,
-      );
-      receipts.push(receipt);
     }
+
+    const provider = this.multiProvider.getProvider(this.props.chain);
+    const signer = this.signer
+      ? this.signer.provider === provider
+        ? this.signer
+        : this.signer.connect(provider)
+      : this.multiProvider.getSigner(this.props.chain);
+    const signerAddress = await signer.getAddress();
+
+    for (const tx of txs) {
+      try {
+        const { annotation, ...populatedTx } = tx;
+        if (annotation) this.logger.info(annotation);
+
+        const txRequest = await this.multiProvider.prepareTx(
+          this.props.chain,
+          populatedTx,
+          signerAddress,
+        );
+        const response = await signer.sendTransaction(txRequest);
+        const submittedTransaction: EV5SubmittedTransaction = {
+          transactionHash: response.hash,
+        };
+        submittedTransactions.push(submittedTransaction);
+        this.logger.info(`Sent tx ${response.hash}`);
+
+        const receipt: ContractReceipt = await this.multiProvider.handleTx(
+          this.props.chain,
+          response,
+        );
+        submittedTransaction.receipt = receipt;
+        assert(
+          receipt.status === 1,
+          `Transaction ${receipt.transactionHash} reverted`,
+        );
+        this.logger.debug(
+          `Submitted PopulatedTransaction on ${this.props.chain}: ${receipt.transactionHash}`,
+        );
+        receipts.push(receipt);
+      } catch (error) {
+        throw new EV5JsonRpcSubmissionError(
+          `Failed to submit JSON-RPC transaction batch on ${this.props.chain}: ${formatError(error)}`,
+          submittedTransactions,
+          error,
+        );
+      }
+    }
+
     return receipts;
   }
 }


### PR DESCRIPTION
## Summary

- add a generic ethers Signer injection point to the SDK JSON-RPC submitter
- add hyperlane submit --signer-config with Turnkey as the first external signer
- strictly validate the whole transaction file, signer identity, protocol, gas estimates, and funding before broadcast
- persist confirmed receipts, reverted receipts, and broadcast hashes on partial failure

## Why replace #9260

#9260 injected Turnkey into warp apply. That coupled fee-authority signing to planning/deployment and required route-specific preflight logic inside warp apply. It also risked using the restricted fee signer for deployments.

This PR follows the existing file handoff convention instead:

1. warp apply uses a file submitter for privileged fee transactions
2. the operator reviews the generated transaction file
3. hyperlane submit signs that file using an external signer config

The submit path depends only on the standard ethers Signer interface. Turnkey is supported now; MPC/Privy adapters can be added without changing warp apply or transaction submission.

Follow-up: #9143 will be restacked to emit its Turnkey-owned fee transactions to a file and submit them through this command.

## Safety

- signer configs must be regular files with mode 0600 on Unix
- --signer-config is mutually exclusive with --strategy and bypasses local key loading
- external signing is Ethereum-only
- all supported transaction fields and the complete batch are validated before RPC preflight or broadcast
- preflight verifies sender, independently estimates each transaction against current on-chain state, and budgets fee caps, value, and per-chain balance
- state-dependent sequences must be split into separate submit runs
- submission is sequential; partial irreversible progress is written before the error is rethrown

## Testing

- SDK JSON-RPC submitter unit tests, including partial and reverted receipts
- CLI signer/config/preflight/recovery unit tests
- CLI and SDK typechecks/lints
- Ethereum submit E2E, including Turnkey signing without --key (6 passing)
- CosmosNative rejection E2E