### PR TITLE
fix(infra): export Tollkeeper metrics to Grafana

### DIFF
--- a/typescript/infra/src/infrastructure/monitoring/prometheus.ts
+++ b/typescript/infra/src/infrastructure/monitoring/prometheus.ts
@@ -110,6 +110,7 @@ async function getPrometheusConfig(
                 // Application metrics
                 'ethereum.*',
                 'hyperlane.*',
+                'tollkeeper.*',
                 // Kubernetes metrics
                 'kube_pod_status_phase',
                 'kube_pod_container_status_restarts_total',


### PR DESCRIPTION
## Summary

- include `tollkeeper_*` metrics in Prometheus remote-write to Grafana Cloud
- preserve the existing local Prometheus scrape and label-drop policy

## Root cause

The cluster Prometheus already scrapes Tollkeeper successfully, but `write_relabel_configs` only forwards selected metric families. `tollkeeper_*` was absent, so Grafana Cloud dropped the series before ingestion.

## Production evidence

- in-cluster Prometheus currently has 91 `tollkeeper_igp_lane_margin_pct` series
- the live remote-write keep regex does not include `tollkeeper.*`
- Grafana Cloud therefore has no Tollkeeper series

## Validation

- `git diff --check`
- `pnpm -C typescript/infra exec oxfmt --check src/infrastructure/monitoring/prometheus.ts`
- commit hooks: gitleaks, oxlint, oxfmt
- `pnpm -C typescript/infra check` remains blocked by unrelated existing errors in `getCrossMoonpayLocalBridgeWarpConfig.ts` and `getUSDTCitreaMoonpayWarpConfig.ts`
