### PR TITLE
fix(sdk): canonicalize warp rebalance target/recipient keys

### DIFF
--- a/.changeset/warp-rebalance-target-recipient-key-canonicalization.md
+++ b/.changeset/warp-rebalance-target-recipient-key-canonicalization.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Updated `expandWarpDeployConfig` to canonicalize `rebalanceTargets` and `rebalanceRecipients` keys to domain IDs on cross-collateral token configs, mirroring the treatment of `allowedRebalancingBridges`, `remoteRouters`, and `destinationGas`. Previously a config keyed by chain name compared unequal to the domain-ID-keyed on-chain state read by `EvmWarpRouteReader`, so the warp config checker reported a permanent false-positive `ConfigMismatch`; now name-keyed and domain-ID-keyed configs compare equal. Keys resolving to the same canonical domain ID have their rebalance targets unioned.

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -18,6 +18,8 @@ import type { WarpCoreConfig } from '../warp/types.js';
 import { TokenType } from './config.js';
 import {
   canonicalizeAllowedRebalancingBridges,
+  canonicalizeDomainKeyedMap,
+  mergeRebalanceTargets,
   filterWarpCoreConfigMapByChains,
   getDefaultRemoteRouterAndDestinationGasConfig,
   getChainsFromWarpCoreConfig,
@@ -1252,6 +1254,62 @@ describe('configUtils', () => {
         resolveDomainId,
       );
       expect(result).to.deep.equal({ unknownchain: [{ bridge: BRIDGE_A }] });
+    });
+  });
+
+  describe(canonicalizeDomainKeyedMap.name, () => {
+    const TARGET_A = '0x1111111111111111111111111111111111111111';
+    const TARGET_B = '0x2222222222222222222222222222222222222222';
+    const TEST1_DOMAIN = test1.domainId.toString();
+
+    // Only test1 resolves; everything else is treated as unknown.
+    const resolveDomainId = (key: string): number | undefined =>
+      key === test1.name ? test1.domainId : undefined;
+
+    it('canonicalizes chain-name keys to domain ids for rebalanceTargets', () => {
+      const result = canonicalizeDomainKeyedMap(
+        { [test1.name]: [TARGET_A] },
+        resolveDomainId,
+        mergeRebalanceTargets,
+      );
+      expect(result).to.deep.equal({ [TEST1_DOMAIN]: [TARGET_A] });
+    });
+
+    it('unions targets when chain name and domain id collapse to one key', () => {
+      const result = canonicalizeDomainKeyedMap(
+        { [test1.name]: [TARGET_A], [TEST1_DOMAIN]: [TARGET_B] },
+        resolveDomainId,
+        mergeRebalanceTargets,
+      );
+      expect(result[TEST1_DOMAIN]).to.have.deep.members([TARGET_A, TARGET_B]);
+    });
+
+    it('deduplicates a target keyed by both chain name and domain id', () => {
+      const targetMixedCase = '0x' + TARGET_A.slice(2).toUpperCase();
+      const result = canonicalizeDomainKeyedMap(
+        { [test1.name]: [TARGET_A], [TEST1_DOMAIN]: [targetMixedCase] },
+        resolveDomainId,
+        mergeRebalanceTargets,
+      );
+      expect(result[TEST1_DOMAIN]).to.have.lengthOf(1);
+    });
+
+    it('canonicalizes rebalanceRecipients with a last-write merge', () => {
+      const result = canonicalizeDomainKeyedMap<string>(
+        { [test1.name]: TARGET_A },
+        resolveDomainId,
+        (_existing, incoming) => incoming,
+      );
+      expect(result).to.deep.equal({ [TEST1_DOMAIN]: TARGET_A });
+    });
+
+    it('preserves keys the resolver does not recognize', () => {
+      const result = canonicalizeDomainKeyedMap(
+        { unknownchain: [TARGET_A] },
+        resolveDomainId,
+        mergeRebalanceTargets,
+      );
+      expect(result).to.deep.equal({ unknownchain: [TARGET_A] });
     });
   });
 });

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -310,6 +310,42 @@ export function canonicalizeAllowedRebalancingBridges(
 }
 
 /**
+ * Canonicalizes the keys of a domain-or-chain-name keyed map to domain ids,
+ * mirroring canonicalizeAllowedRebalancingBridges, so a name-keyed source
+ * config does not read as drift against the domain-id-keyed on-chain state.
+ * When two source keys collapse to the same domain their values are combined
+ * via `merge`. Keys the resolver does not recognize are kept as-is rather than
+ * erroring the whole route check.
+ */
+export function canonicalizeDomainKeyedMap<V>(
+  map: Record<string, V>,
+  resolveDomainId: (domainOrChain: string) => number | undefined,
+  merge: (existing: V | undefined, incoming: V) => V,
+): Record<string, V> {
+  const canonicalized: Record<string, V> = {};
+  for (const [domainOrChain, value] of Object.entries(map)) {
+    const canonicalKey =
+      resolveDomainId(domainOrChain)?.toString() ?? domainOrChain;
+    canonicalized[canonicalKey] = merge(canonicalized[canonicalKey], value);
+  }
+  return canonicalized;
+}
+
+export function mergeRebalanceTargets(
+  existing: string[] | undefined,
+  incoming: string[],
+): string[] {
+  const byTarget = new Map<string, string>();
+  for (const target of [...(existing ?? []), ...incoming]) {
+    const key = target.toLowerCase();
+    if (!byTarget.has(key)) {
+      byTarget.set(key, target);
+    }
+  }
+  return Array.from(byTarget.values());
+}
+
+/**
  * Expands a Warp deploy config with additional data
  *
  * @param multiProvider
@@ -460,6 +496,29 @@ export async function expandWarpDeployConfig(params: {
             (domainOrChain) =>
               multiProvider.tryGetDomainId(domainOrChain) ?? undefined,
           );
+      }
+
+      // rebalanceTargets/rebalanceRecipients keys likewise accept a chain name
+      // or a domain id (RemoteRouterDomainOrChainNameSchema) while the on-chain
+      // reader emits domain-id keys, so canonicalize them the same way to avoid
+      // a false ConfigMismatch on a name-keyed source config.
+      if (isCrossCollateralTokenConfig(chainConfig)) {
+        const resolveDomainId = (domainOrChain: string) =>
+          multiProvider.tryGetDomainId(domainOrChain) ?? undefined;
+        if (chainConfig.rebalanceTargets) {
+          chainConfig.rebalanceTargets = canonicalizeDomainKeyedMap(
+            chainConfig.rebalanceTargets,
+            resolveDomainId,
+            mergeRebalanceTargets,
+          );
+        }
+        if (chainConfig.rebalanceRecipients) {
+          chainConfig.rebalanceRecipients = canonicalizeDomainKeyedMap(
+            chainConfig.rebalanceRecipients,
+            resolveDomainId,
+            (_existing, incoming) => incoming,
+          );
+        }
       }
 
       const protocol = multiProvider.getProtocol(chain);


### PR DESCRIPTION
## Summary

- `expandWarpDeployConfig` now canonicalizes `rebalanceTargets` and `rebalanceRecipients` keys to domain IDs on cross-collateral token configs, mirroring the existing treatment of `allowedRebalancingBridges` (#9138), `remoteRouters`, and `destinationGas`.
- These fields were added by the atomic local rebalancing bridge work (#9212, SDK 41.3.0). Their keys accept either a chain name or a domain id (`RemoteRouterDomainOrChainNameSchema`), but `EvmWarpRouteReader` always emits domain-id keys. Chain-name-keyed source configs (e.g. `getUSDTCitreaMoonpayWarpConfig`) therefore compared unequal to on-chain state, producing a permanent false-positive `ConfigMismatch` from the daily warp config checker → `WarpRoute-ConfigMismatch` alert → PagerDuty.
- Added `canonicalizeDomainKeyedMap` (generic key canonicalizer with a merge callback) and `mergeRebalanceTargets` (case-insensitive union), plus regression tests.

Closes #9303

## Test plan

- [x] `pnpm -C typescript/sdk build`
- [x] `pnpm -C typescript/sdk mocha --config .mocharc.json ./src/token/configUtils.test.ts` (51 passing, incl. new `canonicalizeDomainKeyedMap` cases)
- [x] lint clean on changed files
- [ ] Confirm the next daily `check-warp-deploy` run pushes 0 `rebalance*` violations for USDT/moonpay once merged and the registry pin advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)