### PR TITLE
fix(infra): re-enable SOON agents

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -136,7 +136,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     soneium: true,
     sonic: true,
     sonicsvm: true,
-    soon: false, // disabled — RPC unavailable
+    soon: true,
     stable: true,
     starknet: true,
     subtensor: true,
@@ -219,7 +219,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     soneium: true,
     sonic: true,
     sonicsvm: true,
-    soon: false, // disabled — RPC unavailable
+    soon: true,
     stable: true,
     starknet: true,
     subtensor: true,
@@ -302,7 +302,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     soneium: true,
     sonic: true,
     sonicsvm: true,
-    soon: false, // disabled — RPC unavailable
+    soon: true,
     stable: true,
     starknet: true,
     subtensor: true,


### PR DESCRIPTION
## Summary

- re-enable SOON for the mainnet3 validator
- re-enable SOON for the mainnet3 relayer
- re-enable SOON for the mainnet3 scraper
- keep registry configuration unchanged

This restores agent coverage during the communicated deprecation extension through August 28, 2026.

## Validation

- `pnpm -C typescript/infra exec mocha --config ../sdk/.mocharc.json test/agent-configs.test.ts` (5 passing)
- commit hooks passed (gitleaks, oxlint, oxfmt)
- `pnpm -C typescript/infra check` is currently blocked by unrelated existing SDK/infra type drift in MoonPay warp configs (`atomicLocalRebalancing`, `rebalanceRecipients`)
