### PR TITLE
fix(sealevel): disable rewards in getBlock to avoid SerdeJson stalls

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -123,6 +123,12 @@ impl SealevelRpcClient {
         let config = RpcBlockConfig {
             commitment: Some(commitment),
             max_supported_transaction_version: Some(0),
+            // Rewards are never consumed (only blockhash, block_time, and
+            // transactions are read). Requesting them makes getBlock fail to
+            // deserialize when a block carries a reward_type our solana crates
+            // don't know (e.g. `DeactivatedStake`), permanently stalling the
+            // sequence-aware cursor since SerdeJson errors aren't skippable.
+            rewards: Some(false),
             ..Default::default()
         };
         self.0

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -120,19 +120,8 @@ impl SealevelRpcClient {
         slot: u64,
         commitment: CommitmentConfig,
     ) -> ChainResult<UiConfirmedBlock> {
-        let config = RpcBlockConfig {
-            commitment: Some(commitment),
-            max_supported_transaction_version: Some(0),
-            // Rewards are never consumed (only blockhash, block_time, and
-            // transactions are read). Requesting them makes getBlock fail to
-            // deserialize when a block carries a reward_type our solana crates
-            // don't know (e.g. `DeactivatedStake`), permanently stalling the
-            // sequence-aware cursor since SerdeJson errors aren't skippable.
-            rewards: Some(false),
-            ..Default::default()
-        };
         self.0
-            .get_block_with_config(slot, config)
+            .get_block_with_config(slot, block_config(commitment))
             .await
             .map_err(Box::new)
             .map_err(HyperlaneSealevelError::ClientError)
@@ -396,6 +385,21 @@ impl std::fmt::Debug for SealevelRpcClient {
 impl BlockNumberGetter for SealevelRpcClient {
     async fn get_block_number(&self) -> ChainResult<u64> {
         self.get_block_height().await
+    }
+}
+
+/// Builds the `getBlock` request config. Rewards are explicitly disabled: the
+/// scraper/indexer only reads blockhash, block_time, and transactions, never
+/// rewards. Requesting rewards makes getBlock fail to deserialize when a block
+/// carries a reward_type our pinned solana crates don't know (e.g.
+/// `DeactivatedStake`), and because SerdeJson errors aren't classified as
+/// skippable this permanently stalls the sequence-aware cursor.
+fn block_config(commitment: CommitmentConfig) -> RpcBlockConfig {
+    RpcBlockConfig {
+        commitment: Some(commitment),
+        max_supported_transaction_version: Some(0),
+        rewards: Some(false),
+        ..Default::default()
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_commitment_config::CommitmentConfig;
 
+use super::block_config;
 use crate::client::SealevelRpcClient;
 
 //#[tokio::test]
@@ -16,4 +18,18 @@ async fn _test_get_block() {
 
     // then
     assert!(result.is_ok());
+}
+
+/// Regression: getBlock must not request rewards. Our pinned solana crates
+/// can't deserialize newer reward types (e.g. `DeactivatedStake`), and a
+/// SerdeJson parse failure on getBlock permanently stalls the sequence-aware
+/// scraper cursor. The scraper never reads rewards, so they must stay
+/// disabled. See ENG-4405.
+#[test]
+fn get_block_config_disables_rewards() {
+    let config = block_config(CommitmentConfig::finalized());
+
+    assert_eq!(config.rewards, Some(false));
+    assert_eq!(config.max_supported_transaction_version, Some(0));
+    assert_eq!(config.commitment, Some(CommitmentConfig::finalized()));
 }

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -49,7 +49,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   validator: '5e51f62-20260819-162717',
   validatorRC: '14646bd-20260805-072134',
   validatorFastPath: '14646bd-20260805-072134',
-  scraper: '5e51f62-20260819-162717',
+  scraper: 'f67b777-20260821-100101',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',


### PR DESCRIPTION
## Summary
- Solana `getBlock` requests in the sealevel client asked for rewards by default, but the block is only used for `blockhash`, `block_time`, and transactions (`block_info_by_height` in `provider.rs`) — rewards are never consumed.
- When a block carries a reward type our solana crates don't know (currently `DeactivatedStake`), `getBlock` fails to deserialize with a `SerdeJson` error. `SerdeJson` errors are not in the skippable set (`is_fallback_get_block_error_kind` only treats four RPC response codes as unresolvable-after-retries), so the sequence-aware cursor rewinds and retries the same slot forever — hard-stalling scraper indexing on solanamainnet.
- Fix: set `RpcBlockConfig.rewards = Some(false)`. Stops the failing deserialization and shrinks the response payload.

## Incident
- PagerDuty Q2YIZ6OK3LM6EN — "mainnet3 scraper contract sync is behind" (solanamainnet). The `delivery` forward_sequenced cursor hard-stalled at 440640179 while message/IGP cursors stayed at chain tip.
- Scraper/indexing only — no message-delivery impact; Explorer delivery data for solanamainnet goes stale while stuck.
- Distinct from the documented restart-fixable known issue ("invalid type: unit variant"); a restart resumes on the same slot and re-stalls.
- Backlog: ENG-4405

## Test plan
- [ ] `cargo build -p hyperlane-sealevel`
- [ ] `cargo test -p hyperlane-sealevel`
- [ ] Deploy scraper and confirm solanamainnet delivery cursor advances past 440640179 with no `GetBlock ... SerdeJson` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)