### PR TITLE
fix(lander): escalate inclusion-stage confirmation backoff for aged txs

### DIFF
--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -297,7 +297,13 @@ impl InclusionStage {
                 // transactions that may never confirm, while still polling them
                 // occasionally in case they eventually do.
                 let base = max(base_interval, MIN_TX_STATUS_CHECK_DELAY);
-                let steps = ((tx_age.num_seconds() - 300) / 300).clamp(0, 16) as u32;
+                let steps = tx_age
+                    .num_seconds()
+                    .saturating_sub(300)
+                    .checked_div(300)
+                    .unwrap_or_default()
+                    .clamp(0, 16);
+                let steps = u32::try_from(steps).expect("backoff steps are clamped to u32 range");
                 base.saturating_mul(2u32.saturating_pow(steps))
                     .min(MAX_TX_STATUS_CHECK_DELAY)
             };

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -30,6 +30,10 @@ pub type InclusionStagePool = Arc<Mutex<HashMap<TransactionUuid, Transaction>>>;
 pub const STAGE_NAME: &str = "InclusionStage";
 
 const MIN_TX_STATUS_CHECK_DELAY: Duration = Duration::from_millis(100);
+// Upper bound on how rarely a long-pending tx is re-checked. Caps the
+// exponential backoff so a tx that never lands on-chain stops spamming the RPC
+// while still being polled occasionally in case it eventually confirms.
+const MAX_TX_STATUS_CHECK_DELAY: Duration = Duration::from_secs(5 * 60);
 const REPROCESS_TXS_LIVENESS_RATE: Duration = Duration::from_secs(5);
 // Bounds idle reorg-detection latency without reducing the liveness heartbeat rate.
 const MAX_REPROCESS_TXS_POLL_RATE: Duration = Duration::from_secs(5 * 60);
@@ -286,8 +290,16 @@ impl InclusionStage {
                     MIN_TX_STATUS_CHECK_DELAY.div_f64(2.0),
                 )
             } else {
-                // Old transactions: check every full block time
-                max(base_interval, MIN_TX_STATUS_CHECK_DELAY)
+                // Old transactions (likely stuck, e.g. a tx that never landed
+                // on-chain): exponentially back off from one block time, doubling
+                // every 5 minutes of age, capped at MAX_TX_STATUS_CHECK_DELAY.
+                // This stops us from hammering the RPC's confirmation endpoint for
+                // transactions that may never confirm, while still polling them
+                // occasionally in case they eventually do.
+                let base = max(base_interval, MIN_TX_STATUS_CHECK_DELAY);
+                let steps = ((tx_age.num_seconds() - 300) / 300).clamp(0, 16) as u32;
+                base.saturating_mul(2u32.saturating_pow(steps))
+                    .min(MAX_TX_STATUS_CHECK_DELAY)
             };
 
             // Skip this transaction if we checked it too recently

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -19,7 +19,9 @@ use crate::tests::test_utils::{
 };
 use crate::transaction::{DropReason as TxDropReason, Transaction, TransactionStatus};
 
-use super::{MAX_REPROCESS_TXS_POLL_RATE, REPROCESS_TXS_LIVENESS_RATE, STAGE_NAME};
+use super::{
+    MAX_REPROCESS_TXS_POLL_RATE, MAX_TX_STATUS_CHECK_DELAY, REPROCESS_TXS_LIVENESS_RATE, STAGE_NAME,
+};
 
 async fn yield_to_reprocess_task() {
     tokio::task::yield_now().await;
@@ -942,4 +944,43 @@ async fn test_processing_reprocess_txs() {
     };
 
     assert!(are_all_txs_in_pool(txs_created.clone(), &pool).await);
+}
+
+#[test]
+fn test_aged_pending_tx_backoff_is_escalated_and_capped() {
+    let base_interval = Duration::from_secs(1);
+    let now = chrono::Utc::now();
+
+    // A long-pending tx (1h old, e.g. one that never landed on-chain) checked
+    // 30s ago must be skipped: the aged backoff has escalated far past a single
+    // block time and is capped at MAX_TX_STATUS_CHECK_DELAY (5 min), so
+    // 30s < cap => not ready. Under the previous flat `base_interval` backoff
+    // this tx would have been re-polled every second, spamming the RPC.
+    let mut aged = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    aged.creation_timestamp = now - chrono::Duration::seconds(3600);
+    aged.last_status_check = Some(now - chrono::Duration::seconds(30));
+    assert!(!InclusionStage::tx_ready_for_processing(
+        base_interval,
+        now,
+        &aged
+    ));
+
+    // Once the capped interval elapses, the aged tx is polled again.
+    let past_cap = MAX_TX_STATUS_CHECK_DELAY.as_secs() as i64 + 1;
+    aged.last_status_check = Some(now - chrono::Duration::seconds(past_cap));
+    assert!(InclusionStage::tx_ready_for_processing(
+        base_interval,
+        now,
+        &aged
+    ));
+
+    // A fresh tx stays responsive: quarter-block backoff, checked 30s ago => ready.
+    let mut fresh = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    fresh.creation_timestamp = now - chrono::Duration::seconds(5);
+    fresh.last_status_check = Some(now - chrono::Duration::seconds(30));
+    assert!(InclusionStage::tx_ready_for_processing(
+        base_interval,
+        now,
+        &fresh
+    ));
 }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -951,6 +951,22 @@ fn test_aged_pending_tx_backoff_is_escalated_and_capped() {
     let base_interval = Duration::from_secs(1);
     let now = chrono::Utc::now();
 
+    // At 10 minutes old, the interval has doubled from one to two seconds.
+    let mut escalating = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    escalating.creation_timestamp = now - chrono::Duration::minutes(10);
+    escalating.last_status_check = Some(now - chrono::Duration::seconds(1));
+    assert!(!InclusionStage::tx_ready_for_processing(
+        base_interval,
+        now,
+        &escalating
+    ));
+    escalating.last_status_check = Some(now - chrono::Duration::seconds(2));
+    assert!(InclusionStage::tx_ready_for_processing(
+        base_interval,
+        now,
+        &escalating
+    ));
+
     // A long-pending tx (1h old, e.g. one that never landed on-chain) checked
     // 30s ago must be skipped: the aged backoff has escalated far past a single
     // block time and is capped at MAX_TX_STATUS_CHECK_DELAY (5 min), so
@@ -966,7 +982,9 @@ fn test_aged_pending_tx_backoff_is_escalated_and_capped() {
     ));
 
     // Once the capped interval elapses, the aged tx is polled again.
-    let past_cap = MAX_TX_STATUS_CHECK_DELAY.as_secs() as i64 + 1;
+    let past_cap = i64::try_from(MAX_TX_STATUS_CHECK_DELAY.as_secs())
+        .expect("maximum delay fits in i64")
+        .saturating_add(1);
     aged.last_status_check = Some(now - chrono::Duration::seconds(past_cap));
     assert!(InclusionStage::tx_ready_for_processing(
         base_interval,

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,8 +43,8 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '1d11d91-20260820-115307',
-  relayerRC: '1d11d91-20260820-115307',
+  relayer: 'a060727-20260821-093506',
+  relayerRC: 'a060727-20260821-093506',
   relayerFastPath: '14646bd-20260805-072134',
   validator: '5e51f62-20260819-162717',
   validatorRC: '14646bd-20260805-072134',


### PR DESCRIPTION
## Summary
When a submitted transaction never lands on-chain, the InclusionStage kept re-polling its confirmation status at a **flat one-block-time interval forever**. On Aleo this produced a self-inflicted RPC retry storm: the relayer polled `transaction/confirmed/<id>` for phantom tx ids that exist on no node, hundreds accumulated in the inclusion pool, and each polled every ~block-time indefinitely (~500-670 req/s of 404s against Provable's API, tripping PD alert 34658 / the `ext-aleo` report).

This changes the aged-transaction backoff so stuck txs are polled increasingly rarely instead of at a fixed rate:

- `inclusion_stage.rs`: for txs pending **>5min**, the check interval now grows **exponentially** from one block time, doubling every 5 minutes, capped at a new `MAX_TX_STATUS_CHECK_DELAY` (5min). Fresh txs keep their responsive quarter/half block-time cadence, so healthy delivery latency is unchanged (normal txs confirm well within 5min and never reach this branch).
- Added `test_aged_pending_tx_backoff_is_escalated_and_capped`.

Generic InclusionStage code, so all chains benefit, but it only throttles genuinely long-pending transactions.

### Scope note
This stops the endpoint spam (Troy's explicit ask). It does **not** fix the deeper Aleo issue that submitted process txs never land on-chain — the relayer records a tx id that appears on no node (confirmed/unconfirmed/general all 404, both hosts, verified live hours later). That submission/tx-id-derivation bug is tracked separately. Confirmed 404s are unrelated to the `storage_sequences` bracket-400 bug (tx ids are bech32, no `[`/`]`).

## Test plan
- [x] `cargo test -p lander --lib inclusion_stage::tests` (19 passed)
- [x] `cargo build -p lander`
- [x] `cargo fmt -p lander`
- [ ] Confirm on mainnet that aleo `transaction`-method request rate collapses after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)