### PR TITLE
fix(sdk): reuse configured fee contract addresses

### DIFF
--- a/.changeset/reuse-routing-fee-addresses.md
+++ b/.changeset/reuse-routing-fee-addresses.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Explicit routing-fee child addresses were preserved so interrupted deployments could reuse previously deployed fee contracts.

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.hardhat-test.ts
@@ -7,6 +7,7 @@ import {
   CrossCollateralRoutingFee__factory,
   ERC20Test,
   ERC20Test__factory,
+  RoutingFee__factory,
 } from '@hyperlane-xyz/core';
 import { assert } from '@hyperlane-xyz/utils';
 
@@ -30,6 +31,7 @@ import {
   ResolvedTokenFeeConfigInput,
   RoutingFeeConfig,
   TokenFeeConfig,
+  TokenFeeConfigInput,
   TokenFeeConfigSchema,
   TokenFeeType,
 } from './types.js';
@@ -239,6 +241,65 @@ describe('EvmTokenFeeModule', () => {
         `Must be ${TokenFeeType.RoutingFee}`,
       );
       expect(onchainConfig.feeContracts[test4Chain]?.bps).to.equal(BPS + 1);
+    });
+
+    it('should reuse an explicitly addressed routing fee contract', async () => {
+      const routingFeeConfig: RoutingFeeConfig = {
+        type: TokenFeeType.RoutingFee,
+        owner: signer.address,
+        token: token.address,
+        feeContracts: {
+          [test4Chain]: config,
+        },
+      };
+      const module = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: routingFeeConfig,
+      });
+      const reusableConfig: OffchainQuotedLinearFeeConfig = {
+        ...config,
+        type: TokenFeeType.OffchainQuotedLinearFee,
+        quoteSigners: [signer.address],
+      };
+      const reusableModule = await EvmTokenFeeModule.create({
+        multiProvider,
+        chain: test4Chain,
+        config: reusableConfig,
+      });
+      const reusableAddress = reusableModule.serialize().deployedFee;
+      const addressedReusableConfig = {
+        ...reusableConfig,
+        address: reusableAddress,
+      };
+      const targetConfig: TokenFeeConfigInput = {
+        ...routingFeeConfig,
+        feeContracts: {
+          [test4Chain]: addressedReusableConfig,
+        },
+      };
+
+      const txs = await module.update(targetConfig);
+
+      expect(txs).to.have.lengthOf(1);
+      expect(txs[0].to).to.equal(module.serialize().deployedFee);
+      expect(txs[0].data).to.equal(
+        RoutingFee__factory.createInterface().encodeFunctionData(
+          'setFeeContract(uint32,address)',
+          [multiProvider.getDomainId(test4Chain), reusableAddress],
+        ),
+      );
+      await multiProvider.sendTransaction(test4Chain, txs[0]);
+      const onchainConfig = await module.read({
+        routingDestinations: [multiProvider.getDomainId(test4Chain)],
+      });
+      assert(
+        onchainConfig.type === TokenFeeType.RoutingFee,
+        `Must be ${TokenFeeType.RoutingFee}`,
+      );
+      expect(onchainConfig.feeContracts[test4Chain]?.address).to.equal(
+        reusableAddress,
+      );
     });
 
     it('should transfer ownership if they are different', async () => {

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -622,10 +622,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       for (const [chainName, targetSubFee] of Object.entries(
         targetConfig.feeContracts,
       )) {
-        if (
-          'address' in targetSubFee &&
-          typeof targetSubFee.address === 'string'
-        ) {
+        if (typeof targetSubFee.address === 'string') {
           const mergedSubFee = mergedConfig.feeContracts[chainName];
           assert(mergedSubFee, `Missing target fee config for ${chainName}`);
           mergedSubFee.address = targetSubFee.address;

--- a/typescript/sdk/src/fee/EvmTokenFeeModule.ts
+++ b/typescript/sdk/src/fee/EvmTokenFeeModule.ts
@@ -31,7 +31,7 @@ import {
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
-import { ChainNameOrId } from '../types.js';
+import { ChainName, ChainNameOrId } from '../types.js';
 import { normalizeConfig } from '../utils/ism.js';
 
 import { EvmTokenFeeDeployer } from './EvmTokenFeeDeployer.js';
@@ -51,6 +51,7 @@ import { EvmTokenFeeFactories } from './contracts.js';
 import {
   ResolvedCrossCollateralRoutingFeeConfigInput,
   ResolvedTokenFeeConfigInput,
+  RoutingFeeConfig,
   TokenFeeConfig,
   TokenFeeConfigInput,
   TokenFeeConfigInputSchema,
@@ -61,6 +62,10 @@ import { convertToBps } from './utils.js';
 
 type TokenFeeModuleAddresses = {
   deployedFee: Address;
+};
+
+type RoutingFeeUpdateConfig = Omit<RoutingFeeConfig, 'feeContracts'> & {
+  feeContracts: Record<ChainName, TokenFeeConfig & { address?: Address }>;
 };
 
 function getDeployedFeeAddress(
@@ -604,17 +609,31 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     // Routing fee: update sub-fee contracts
     if (
       normalizedTargetConfig.type === TokenFeeType.RoutingFee &&
-      normalizedActualConfig.type === TokenFeeType.RoutingFee
+      normalizedActualConfig.type === TokenFeeType.RoutingFee &&
+      actualConfig.type === TokenFeeType.RoutingFee &&
+      targetConfig.type === TokenFeeType.RoutingFee
     ) {
+      const mergedConfig = objMerge<RoutingFeeUpdateConfig>(
+        actualConfig,
+        normalizedTargetConfig,
+        10,
+        true,
+      );
+      for (const [chainName, targetSubFee] of Object.entries(
+        targetConfig.feeContracts,
+      )) {
+        if (
+          'address' in targetSubFee &&
+          typeof targetSubFee.address === 'string'
+        ) {
+          const mergedSubFee = mergedConfig.feeContracts[chainName];
+          assert(mergedSubFee, `Missing target fee config for ${chainName}`);
+          mergedSubFee.address = targetSubFee.address;
+        }
+      }
+
       return [
-        ...(await this.updateRoutingFee(
-          objMerge(
-            actualConfig,
-            normalizedTargetConfig,
-            10,
-            true,
-          ) as DerivedRoutingFeeConfig,
-        )),
+        ...(await this.updateRoutingFee(mergedConfig, actualConfig)),
         ...this.createOwnershipUpdateTxs(
           normalizedActualConfig,
           normalizedTargetConfig,
@@ -787,7 +806,10 @@ export class EvmTokenFeeModule extends HyperlaneModule<
     return updateTransactions;
   }
 
-  private async updateRoutingFee(targetConfig: DerivedRoutingFeeConfig) {
+  private async updateRoutingFee(
+    targetConfig: RoutingFeeUpdateConfig,
+    currentConfig: DerivedRoutingFeeConfig,
+  ) {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
 
     if (!targetConfig.feeContracts) return [];
@@ -796,6 +818,7 @@ export class EvmTokenFeeModule extends HyperlaneModule<
       targetConfig.feeContracts,
     )) {
       const address = config.address;
+      const currentAddress = currentConfig.feeContracts[chainName]?.address;
 
       let subFeeModule: EvmTokenFeeModule;
       let deployedSubFee: string;
@@ -844,8 +867,8 @@ export class EvmTokenFeeModule extends HyperlaneModule<
 
         updateTransactions.push(...subFeeUpdateTransactions);
 
-        if (!eqAddress(deployedSubFee, address)) {
-          const annotation = `Sub fee contract redeployed on chain ${this.chainName}. Updating fee contract for destination ${chainName} to ${deployedSubFee}`;
+        if (!currentAddress || !eqAddress(deployedSubFee, currentAddress)) {
+          const annotation = `Updating fee contract for destination ${chainName} to ${deployedSubFee}`;
           this.logger.debug(annotation);
           updateTransactions.push({
             annotation: annotation,

--- a/typescript/sdk/src/fee/types.ts
+++ b/typescript/sdk/src/fee/types.ts
@@ -72,6 +72,7 @@ export type BaseTokenFeeConfig = z.infer<typeof BaseFeeConfigSchema>;
 
 // For input configs - token is NOT specified by user, resolved at deploy time based on token type
 export const BaseFeeConfigInputSchema = z.object({
+  address: ZHash.optional(),
   owner: ZHash,
   beneficiary: ZHash.optional(),
 });

--- a/typescript/sdk/src/token/types.test.ts
+++ b/typescript/sdk/src/token/types.test.ts
@@ -464,6 +464,38 @@ describe('WarpRouteDeployConfigSchema refine', () => {
       );
     });
 
+    it('should preserve an addressed nested fee contract', () => {
+      const feeAddress = ethers.Wallet.createRandom().address;
+      const parseResults = WarpRouteDeployConfigSchema.safeParse({
+        arbitrum: {
+          type: TokenType.synthetic,
+          owner: SOME_ADDRESS,
+          mailbox: SOME_ADDRESS,
+          name: 'Test Token',
+          symbol: 'TEST',
+          tokenFee: {
+            type: TokenFeeType.RoutingFee,
+            feeContracts: {
+              ethereum: {
+                type: TokenFeeType.OffchainQuotedLinearFee,
+                address: feeAddress,
+                bps: 100,
+                quoteSigners: [SOME_ADDRESS],
+              },
+            },
+          },
+        },
+      });
+
+      assert(parseResults.success, 'must be true');
+      const tokenFee = parseResults.data.arbitrum.tokenFee;
+      assert(
+        tokenFee?.type === TokenFeeType.RoutingFee,
+        `must be ${TokenFeeType.RoutingFee}`,
+      );
+      expect(tokenFee.feeContracts.ethereum.address).to.equal(feeAddress);
+    });
+
     it('should accept tokenFee for collateral tokens', () => {
       const parseResults = WarpRouteDeployConfigSchema.safeParse({
         ethereum: {


### PR DESCRIPTION
## Summary

- Preserve explicit nested fee-contract addresses while parsing warp deploy configs.
- Reuse an explicitly addressed RoutingFee child when its immutable config already matches.
- Compare the current parent pointer separately, emitting only `setFeeContract` when the target child is already deployed.

## Why

This supports a staged deployment flow: deploy fee leaves with the normal deployer, record their addresses, then hand the parent-pointer transactions to a restricted external signer. A later `warp apply` should reuse those recorded contracts rather than orphaning them and deploying replacements.

This is the SDK base for #9143; that PR will contain only the Eclipse infra/getter configuration.

## Tests

- `pnpm -C typescript/sdk lint`
- focused `WarpRouteDeployConfigSchema` addressed-child regression
- focused `EvmTokenFeeModule` addressed-routing-fee hardhat regression
- SDK and dependency build
