### PR TITLE
feat(scraper-proxy): expose Prometheus metrics

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2279,6 +2279,9 @@ importers:
       pg:
         specifier: ^8.17.2
         version: 8.22.0
+      prom-client:
+        specifier: 'catalog:'
+        version: 14.2.0
       reflect-metadata:
         specifier: 'catalog:'
         version: 0.2.2

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-service.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-service.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "agent-common.fullname" . }}-scraper-proxy
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: {{ .Values.hyperlane.scraper.proxy.port | quote }}
+    prometheus.io/scrape: 'true'
   labels:
     {{- include "agent-common.labels" . | nindent 4 }}
     app.kubernetes.io/component: scraper3

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
-  scraperProxy: 'afadf4e-20260820-111137',
+  scraperProxy: '33ff5e4-20260821-113547',
   feeQuoting: '12d899d-20260325-184337',
 };
 

--- a/typescript/scraper-proxy/README.md
+++ b/typescript/scraper-proxy/README.md
@@ -1,7 +1,8 @@
 # Scraper proxy
 
 Exposes the scraper PostgreSQL database through GraphQL at `/graphql`, protocol
-events for agents at `/agents`, and enriched message updates at `/messages`.
+events for agents at `/agents`, enriched message updates at `/messages`, and
+Prometheus metrics at `/metrics`.
 
 ## Deployment
 
@@ -46,3 +47,8 @@ The private `/agents` endpoint always supports historical WebSocket catch-up.
 Outbound WebSocket buffering is limited to 1 MiB per socket and 32 MiB across
 all sockets. GraphQL is limited to 25 concurrent requests; Cloudflare owns
 public per-client request-rate enforcement.
+
+`/metrics` reports GraphQL request usage and latency; WebSocket connections,
+subscriptions, catch-ups, notification queues, outbound buffering, limits and
+rejections; database pool pressure and listener readiness; and standard Node.js
+process metrics.

--- a/typescript/scraper-proxy/package.json
+++ b/typescript/scraper-proxy/package.json
@@ -40,6 +40,7 @@
     "dotenv-flow": "^4.1.0",
     "graphql": "catalog:",
     "pg": "^8.17.2",
+    "prom-client": "catalog:",
     "reflect-metadata": "catalog:",
     "rxjs": "catalog:",
     "ws": "^8.21.1",

--- a/typescript/scraper-proxy/package.json
+++ b/typescript/scraper-proxy/package.json
@@ -26,7 +26,7 @@
     "lint": "oxlint -c ../../oxlint.json",
     "start": "node dist/main.js",
     "start:dev": "NODE_ENV=development LOG_FORMAT=pretty node dist/main.js",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test src/*.test.ts src/**/*.test.ts",
     "test:ci": "pnpm test"
   },
   "dependencies": {

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -7,9 +7,11 @@ import {
 import pg from 'pg';
 
 import { config } from '../config.js';
+import type { DatabaseMetricsSnapshot } from '../metrics.js';
 import { quoteIdentifier } from '../scraperdb/tables.js';
 
 const MIN_POOL_CLIENTS = 5;
+const MAX_POOL_CLIENTS = 10;
 const STATS_INTERVAL_MS = 60_000;
 const IDLE_TIMEOUT_MS = 300_000;
 
@@ -67,6 +69,16 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
       this.logger.error(`database shutdown failed: ${errorMessage(error)}`),
     );
     if (failures.length) throw failures[0];
+  }
+
+  metricsSnapshot(): DatabaseMetricsSnapshot {
+    return {
+      listeners: this.listeners.size,
+      pools: {
+        live: poolMetrics(this.livePool),
+        main: poolMetrics(this.mainPool),
+      },
+    };
   }
 
   query<T extends pg.QueryResultRow>(
@@ -137,6 +149,7 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     const pool = new pg.Pool({
       ...databaseOptions(connectionString),
       idleTimeoutMillis: IDLE_TIMEOUT_MS,
+      max: MAX_POOL_CLIENTS,
       min,
     });
     pool.on('error', (error) =>
@@ -188,6 +201,15 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
       `db stats queries=${queries} errors=${errors} rows=${rows} avgMs=${queries ? Math.round(totalMs / queries) : 0} maxMs=${maxMs} poolTotal=${this.mainPool?.totalCount ?? 0} poolIdle=${this.mainPool?.idleCount ?? 0} poolWaiting=${this.mainPool?.waitingCount ?? 0}`,
     );
   }
+}
+
+function poolMetrics(pool?: pg.Pool): DatabaseMetricsSnapshot['pools']['main'] {
+  return {
+    idle: pool?.idleCount ?? 0,
+    limit: MAX_POOL_CLIENTS,
+    total: pool?.totalCount ?? 0,
+    waiting: pool?.waitingCount ?? 0,
+  };
 }
 
 function errorMessage(error: unknown): string {

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -5,6 +5,7 @@ import { after, before, it, type TestContext } from 'node:test';
 import { WebSocket } from 'ws';
 import type { QueryResultRow } from 'pg';
 
+import { websocketCatchUps } from '../metrics.js';
 import type { EventDatabase, EventWebSocketServer } from './event-websocket.js';
 import { rawData } from './websocket-data.js';
 
@@ -123,6 +124,13 @@ void it('keeps agent capacity independent from Explorer capacity', async () => {
   await Promise.all(explorerMessages.map((items) => waitFor(items, 'ready')));
   const ready = await waitFor(agentMessages, 'ready');
   assert.equal(ready.type, 'ready');
+  assert.deepEqual(events.metricsSnapshot().connections, {
+    agent: 1,
+    messages: 8,
+  });
+  assert.equal(events.metricsSnapshot().messageClientIps, 8);
+  assert.equal(events.metricsSnapshot().limits.agentConnections, 1);
+  assert.equal(events.metricsSnapshot().limits.messageConnections, 8);
   explorers.forEach((socket) => socket.close());
   agent.close();
   await waitUntil(() =>
@@ -300,6 +308,44 @@ void it('paces historical sends by send completion', async (context) => {
   assert.deepEqual(eventSequences(messages), ['0', '1']);
   socket.close();
   await new Promise<void>((resolve) => socket.once('close', resolve));
+});
+
+void it('records a disconnected historical replay as aborted', async (context) => {
+  const abortedBefore = await catchUpOutcome('aborted');
+  const successesBefore = await catchUpOutcome('success');
+  const completions = delayServerSendCompletions(context);
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    messages.push(message);
+    if (message.type === 'ready') {
+      socket.send(
+        JSON.stringify({
+          streams: [
+            {
+              cursors: [{ address: pacedHook, afterSequence: '-1', domain: 1 }],
+              eventType: 'merkle_tree_insertion',
+            },
+          ],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+
+  await waitUntil(() => eventSequences(messages).includes('0'));
+  await waitUntil(() => completions.length === 1);
+  const closed = new Promise<void>((resolve) => socket.once('close', resolve));
+  socket.close();
+  await closed;
+  await waitUntil(() => events.metricsSnapshot().connections.agent === 0);
+  completions.shift()?.();
+
+  await waitUntil(
+    async () => (await catchUpOutcome('aborted')) === abortedBefore + 1,
+  );
+  assert.equal(await catchUpOutcome('success'), successesBefore);
 });
 
 void it('drains live events arriving while the pending buffer is sent', async (context) => {
@@ -626,12 +672,21 @@ async function waitFor(
   throw new Error(`Timed out waiting for ${type}`);
 }
 
-async function waitUntil(predicate: () => boolean): Promise<void> {
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+): Promise<void> {
   for (let attempts = 0; attempts < 100; attempts++) {
-    if (predicate()) return;
+    if (await predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error('Timed out waiting for condition');
+}
+
+async function catchUpOutcome(outcome: string): Promise<number> {
+  const metric = await websocketCatchUps.get();
+  return (
+    metric.values.find(({ labels }) => labels.outcome === outcome)?.value ?? 0
+  );
 }
 
 function parseRecord(value: string): Record<string, unknown> {

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -7,6 +7,14 @@ import { WebSocket, WebSocketServer } from 'ws';
 
 import { config } from '../config.js';
 import type { DbService } from '../db/db.service.js';
+import {
+  type WebSocketMetricsSnapshot,
+  websocketCatchUps,
+  websocketClientMessageRejections,
+  websocketConnectionRejections,
+  websocketConnections,
+  websocketSendFailures,
+} from '../metrics.js';
 import { quoteIdentifier as q, tables } from '../scraperdb/tables.js';
 import {
   displayAddress,
@@ -209,6 +217,79 @@ export class EventWebSocketServer {
     );
   }
 
+  metricsSnapshot(): WebSocketMetricsSnapshot {
+    const subscriptions: WebSocketMetricsSnapshot['subscriptions'] = {
+      delivery: { catchingUp: 0, live: 0 },
+      dispatch: { catchingUp: 0, live: 0 },
+      gas_payment: { catchingUp: 0, live: 0 },
+      merkle_tree_insertion: { catchingUp: 0, live: 0 },
+    };
+    const now = Date.now();
+    let maxCatchUpDurationMs = 0;
+    let maxCatchUpRows = 0;
+    let maxPendingCatchUpEvents = 0;
+    let pendingCatchUpEvents = 0;
+    for (const client of this.clients.values()) {
+      for (const [eventType, subscription] of client.subscriptions) {
+        subscriptions[eventType][
+          subscription.catchingUp ? 'catchingUp' : 'live'
+        ]++;
+        pendingCatchUpEvents += subscription.pending.length;
+        maxPendingCatchUpEvents = Math.max(
+          maxPendingCatchUpEvents,
+          subscription.pending.length,
+        );
+        if (subscription.catchingUp) {
+          maxCatchUpDurationMs = Math.max(
+            maxCatchUpDurationMs,
+            now - subscription.catchUpStartedAt,
+          );
+          maxCatchUpRows = Math.max(maxCatchUpRows, subscription.catchUpRows);
+        }
+      }
+    }
+    const sockets = [...this.clients.keys(), ...this.explorerClients.keys()];
+    return {
+      catchUps: this.catchUps,
+      connections: {
+        agent: this.clients.size,
+        messages: this.explorerClients.size,
+      },
+      messageClientIps: this.explorerClientsByIp.size,
+      messageMaxConnectionsPerIp: Math.max(
+        0,
+        ...this.explorerClientsByIp.values(),
+      ),
+      limits: {
+        agentConnections: this.limits.maxAgentClients,
+        catchUpMs: this.limits.maxCatchUpMs,
+        catchUpRows: this.limits.maxCatchUpRows,
+        clientMessagesPerMinute: MAX_CLIENT_MESSAGES,
+        concurrentCatchUps: this.limits.maxConcurrentCatchUps,
+        messageConnections: this.limits.maxExplorerClients,
+        messageConnectionsPerIp: MAX_EXPLORER_CLIENTS_PER_IP,
+        pendingEvents: MAX_PENDING_EVENTS,
+        socketBufferedBytes: this.limits.maxBufferedBytes,
+        totalPendingBytes: this.limits.maxTotalBufferedBytes,
+      },
+      listenerReady: this.listenerReady,
+      maxCatchUpDurationMs,
+      maxCatchUpRows,
+      maxClientBufferedBytes: sockets.reduce(
+        (max, socket) => Math.max(max, socket.bufferedAmount),
+        0,
+      ),
+      notificationQueue: {
+        agent: this.notifications.size,
+        messages: this.explorerNotifications.size,
+      },
+      outboundPendingBytes: this.pendingBytes,
+      maxPendingCatchUpEvents,
+      pendingCatchUpEvents,
+      subscriptions,
+    };
+  }
+
   private connectAgent(socket: WebSocket): void {
     if (!this.accept(socket, 'agent')) return;
     this.clients.set(socket, {
@@ -217,6 +298,7 @@ export class EventWebSocketServer {
       messageWindow: Date.now(),
       subscriptions: new Map(),
     });
+    websocketConnections.inc({ route: 'agent' });
     this.send(socket, {
       eventTypes: EVENT_TYPES,
       historicalStreaming: true,
@@ -251,16 +333,25 @@ export class EventWebSocketServer {
     if (!this.accept(socket, 'explorer')) return;
     const ip = clientIp(request);
     if (!ip) {
+      websocketConnectionRejections.inc({
+        reason: 'invalid_client_ip',
+        route: 'messages',
+      });
       socket.close(1008, 'Missing or invalid client IP');
       return;
     }
     const connections = this.explorerClientsByIp.get(ip) ?? 0;
     if (connections >= MAX_EXPLORER_CLIENTS_PER_IP) {
+      websocketConnectionRejections.inc({
+        reason: 'per_ip_limit',
+        route: 'messages',
+      });
       socket.close(1008, 'Maximum connections per client reached');
       return;
     }
     this.explorerClientsByIp.set(ip, connections + 1);
     this.explorerClients.set(socket, { alive: true, ip });
+    websocketConnections.inc({ route: 'messages' });
     this.send(socket, {
       eventTypes: ['message_upsert'],
       type: 'ready',
@@ -276,6 +367,10 @@ export class EventWebSocketServer {
         ? this.clients.size >= this.limits.maxAgentClients
         : this.explorerClients.size >= this.limits.maxExplorerClients;
     if (!this.listenerReady || full) {
+      websocketConnectionRejections.inc({
+        reason: full ? 'connection_limit' : 'listener_unavailable',
+        route: route === 'explorer' ? 'messages' : route,
+      });
       socket.close(
         1013,
         this.listenerReady
@@ -312,6 +407,7 @@ export class EventWebSocketServer {
     const client = this.clients.get(socket);
     if (!client) return;
     if (!consumeMessage(client)) {
+      websocketClientMessageRejections.inc();
       this.sendError(socket, 'Client message rate limit exceeded');
       socket.close(1008, 'Client message rate limit exceeded');
       return;
@@ -369,6 +465,7 @@ export class EventWebSocketServer {
     const subscription = client.subscriptions.get(request.eventType);
     if (!subscription) return;
     if (this.catchUps >= this.limits.maxConcurrentCatchUps) {
+      websocketCatchUps.inc({ outcome: 'capacity_rejected' });
       client.subscriptions.delete(request.eventType);
       this.sendError(socket, 'Historical streaming capacity exceeded');
       return;
@@ -376,15 +473,33 @@ export class EventWebSocketServer {
     this.catchUps++;
     try {
       for (const cursor of request.cursors ?? []) {
-        await this.catchUpCursor(
+        if (
+          this.clients.get(socket) !== client ||
+          client.subscriptions.get(request.eventType) !== subscription
+        ) {
+          websocketCatchUps.inc({ outcome: 'aborted' });
+          return;
+        }
+        const completed = await this.catchUpCursor(
           socket,
           client,
           request.eventType,
           subscription,
           cursor,
         );
+        if (!completed) {
+          websocketCatchUps.inc({ outcome: 'aborted' });
+          return;
+        }
       }
       while (subscription.pending.length) {
+        if (
+          this.clients.get(socket) !== client ||
+          client.subscriptions.get(request.eventType) !== subscription
+        ) {
+          websocketCatchUps.inc({ outcome: 'aborted' });
+          return;
+        }
         const pending = subscription.pending.sort((a, b) =>
           compareRows(request.eventType, a, b),
         );
@@ -398,12 +513,23 @@ export class EventWebSocketServer {
               subscription,
               row,
             ))
-          )
+          ) {
+            websocketCatchUps.inc({ outcome: 'failure' });
             return;
+          }
         }
       }
       subscription.catchingUp = false;
+      websocketCatchUps.inc({ outcome: 'success' });
     } catch (error) {
+      const active =
+        this.clients.get(socket) === client &&
+        client.subscriptions.get(request.eventType) === subscription;
+      if (!active) {
+        websocketCatchUps.inc({ outcome: 'aborted' });
+        return;
+      }
+      websocketCatchUps.inc({ outcome: 'failure' });
       client.subscriptions.delete(request.eventType);
       const reason = errorMessage(error);
       this.logger.warn(
@@ -424,7 +550,7 @@ export class EventWebSocketServer {
     eventType: EventType,
     subscription: Subscription,
     cursor: SequenceCursor,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const key = sequenceKey(cursor.domain, cursor.address);
     const { first, last } = await this.sequenceBounds(eventType, cursor);
     if (last < first) {
@@ -445,7 +571,7 @@ export class EventWebSocketServer {
         this.clients.get(socket) !== client ||
         client.subscriptions.get(eventType) !== subscription
       ) {
-        return;
+        return false;
       }
       const current = subscription.sequences.get(key) ?? -1n;
       this.assertCatchUpBudget(subscription);
@@ -473,6 +599,7 @@ export class EventWebSocketServer {
       }))
     )
       throw new Error('Websocket closed during catch-up');
+    return true;
   }
 
   private publish(eventType: EventType, row: Row): void {
@@ -836,6 +963,7 @@ export class EventWebSocketServer {
       socket.bufferedAmount + message.bytes > this.limits.maxBufferedBytes ||
       this.pendingBytes + message.bytes > this.limits.maxTotalBufferedBytes
     ) {
+      websocketSendFailures.inc({ reason: 'buffer_limit' });
       this.failSocket(socket, 'outbound buffer limit exceeded');
       return false;
     }
@@ -844,11 +972,15 @@ export class EventWebSocketServer {
       socket.send(message.text, (error) => {
         this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
         completed?.(!error);
-        if (error) this.failSocket(socket, `send failed: ${error.message}`);
+        if (error) {
+          websocketSendFailures.inc({ reason: 'send_error' });
+          this.failSocket(socket, `send failed: ${error.message}`);
+        }
       });
     } catch (error) {
       this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
       completed?.(false);
+      websocketSendFailures.inc({ reason: 'send_error' });
       this.failSocket(socket, `send failed: ${errorMessage(error)}`);
       return false;
     }

--- a/typescript/scraper-proxy/src/main.ts
+++ b/typescript/scraper-proxy/src/main.ts
@@ -7,6 +7,10 @@ import { AppModule } from './module.js';
 import { config } from './config.js';
 import { DbService } from './db/db.service.js';
 import { EventWebSocketServer } from './live/event-websocket.js';
+import {
+  setDatabaseMetricsProvider,
+  setWebSocketMetricsProvider,
+} from './metrics.js';
 
 const logger = new Logger('Shutdown');
 
@@ -17,8 +21,11 @@ async function bootstrap(): Promise<void> {
     credentials: false,
     origin: true,
   });
+  const db = app.get(DbService);
+  const eventWebSocketServer = new EventWebSocketServer(db);
+  setDatabaseMetricsProvider(() => db.metricsSnapshot());
+  setWebSocketMetricsProvider(() => eventWebSocketServer.metricsSnapshot());
   const server = await app.listen(config.PORT);
-  const eventWebSocketServer = new EventWebSocketServer(app.get(DbService));
   await eventWebSocketServer.start(server);
   let stopping = false;
   const stop = async (): Promise<void> => {

--- a/typescript/scraper-proxy/src/metrics.test.ts
+++ b/typescript/scraper-proxy/src/metrics.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { it } from 'node:test';
+
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+process.env.DATABASE_URL ??= 'postgresql://unused:unused@localhost/unused';
+
+void it('serves current usage and limits from /metrics', async () => {
+  const {
+    MetricsController,
+    metricsRegistry,
+    setDatabaseMetricsProvider,
+    setWebSocketMetricsProvider,
+  } = await import('./metrics.js');
+  setDatabaseMetricsProvider(() => ({
+    listeners: 1,
+    pools: {
+      live: { idle: 1, limit: 10, total: 2, waiting: 0 },
+      main: { idle: 3, limit: 10, total: 5, waiting: 2 },
+    },
+  }));
+  setWebSocketMetricsProvider(() => ({
+    catchUps: 2,
+    connections: { agent: 3, messages: 4 },
+    messageClientIps: 2,
+    messageMaxConnectionsPerIp: 3,
+    limits: {
+      agentConnections: 100,
+      catchUpMs: 60_000,
+      catchUpRows: 1_000,
+      clientMessagesPerMinute: 30,
+      concurrentCatchUps: 5,
+      messageConnections: 400,
+      messageConnectionsPerIp: 5,
+      pendingEvents: 5_000,
+      socketBufferedBytes: 1_024,
+      totalPendingBytes: 4_096,
+    },
+    listenerReady: true,
+    maxCatchUpDurationMs: 3_000,
+    maxCatchUpRows: 500,
+    maxClientBufferedBytes: 128,
+    maxPendingCatchUpEvents: 5,
+    notificationQueue: { agent: 6, messages: 7 },
+    outboundPendingBytes: 256,
+    pendingCatchUpEvents: 8,
+    subscriptions: {
+      delivery: { catchingUp: 0, live: 1 },
+      dispatch: { catchingUp: 1, live: 2 },
+      gas_payment: { catchingUp: 0, live: 0 },
+      merkle_tree_insertion: { catchingUp: 1, live: 0 },
+    },
+  }));
+
+  const output = await metricsRegistry.metrics();
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_connections\{route="agent"\} 3/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_connection_limit\{route="messages"\} 400/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_subscriptions\{event_type="dispatch",state="catching_up"\} 1/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_outbound_pending_bytes 256/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_database_pool_connections\{pool="main",state="active"\} 2/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_database_pool_waiting_requests\{pool="main"\} 2/,
+  );
+  assert.match(output, /hyperlane_scraper_proxy_process_cpu/);
+
+  @Module({ controllers: [MetricsController] })
+  class MetricsTestModule {}
+  const app = await NestFactory.create(MetricsTestModule, { logger: false });
+  try {
+    const server = await app.listen(0, '127.0.0.1');
+    const address = server.address();
+    assert(address && typeof address !== 'string');
+    const response = await fetch(`http://127.0.0.1:${address.port}/metrics`);
+    assert.equal(response.status, 200);
+    const contentType = response.headers.get('content-type');
+    assert(contentType?.includes('text/plain'));
+    assert(contentType.includes('version=0.0.4'));
+    assert(contentType.includes('charset=utf-8'));
+    assert.match(
+      await response.text(),
+      /hyperlane_scraper_proxy_websocket_connections\{route="messages"\} 4/,
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -1,0 +1,353 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import {
+  collectDefaultMetrics,
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+} from 'prom-client';
+
+import type { EventType } from './live/protocol.js';
+
+const PREFIX = 'hyperlane_scraper_proxy_';
+
+export type WebSocketMetricsSnapshot = {
+  catchUps: number;
+  connections: Record<'agent' | 'messages', number>;
+  messageClientIps: number;
+  messageMaxConnectionsPerIp: number;
+  limits: {
+    agentConnections: number;
+    catchUpMs: number;
+    catchUpRows: number;
+    clientMessagesPerMinute: number;
+    concurrentCatchUps: number;
+    messageConnections: number;
+    messageConnectionsPerIp: number;
+    pendingEvents: number;
+    socketBufferedBytes: number;
+    totalPendingBytes: number;
+  };
+  listenerReady: boolean;
+  maxCatchUpDurationMs: number;
+  maxCatchUpRows: number;
+  maxClientBufferedBytes: number;
+  maxPendingCatchUpEvents: number;
+  notificationQueue: Record<'agent' | 'messages', number>;
+  outboundPendingBytes: number;
+  pendingCatchUpEvents: number;
+  subscriptions: Record<EventType, { catchingUp: number; live: number }>;
+};
+
+type DatabasePoolMetrics = {
+  idle: number;
+  limit: number;
+  total: number;
+  waiting: number;
+};
+
+export type DatabaseMetricsSnapshot = {
+  listeners: number;
+  pools: Record<'live' | 'main', DatabasePoolMetrics>;
+};
+
+export const metricsRegistry = new Registry();
+
+collectDefaultMetrics({ prefix: PREFIX, register: metricsRegistry });
+
+export const graphqlActiveRequests = new Gauge({
+  help: 'Current number of active GraphQL requests.',
+  name: `${PREFIX}graphql_active_requests`,
+  registers: [metricsRegistry],
+});
+
+export const graphqlActiveRequestLimit = new Gauge({
+  help: 'Maximum number of concurrent GraphQL requests.',
+  name: `${PREFIX}graphql_active_request_limit`,
+  registers: [metricsRegistry],
+});
+
+export const graphqlRequests = new Counter({
+  help: 'GraphQL requests by outcome.',
+  labelNames: ['outcome'] as const,
+  name: `${PREFIX}graphql_requests_total`,
+  registers: [metricsRegistry],
+});
+
+export const graphqlErrors = new Counter({
+  help: 'GraphQL errors returned by Apollo.',
+  name: `${PREFIX}graphql_errors_total`,
+  registers: [metricsRegistry],
+});
+
+export const graphqlRequestDuration = new Histogram({
+  buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20],
+  help: 'GraphQL request duration in seconds.',
+  name: `${PREFIX}graphql_request_duration_seconds`,
+  registers: [metricsRegistry],
+});
+
+export const websocketConnections = new Counter({
+  help: 'Accepted WebSocket connections by route.',
+  labelNames: ['route'] as const,
+  name: `${PREFIX}websocket_connections_total`,
+  registers: [metricsRegistry],
+});
+
+export const websocketConnectionRejections = new Counter({
+  help: 'Rejected WebSocket connections by route and reason.',
+  labelNames: ['route', 'reason'] as const,
+  name: `${PREFIX}websocket_connection_rejections_total`,
+  registers: [metricsRegistry],
+});
+
+export const websocketCatchUps = new Counter({
+  help: 'Historical WebSocket catch-ups by outcome.',
+  labelNames: ['outcome'] as const,
+  name: `${PREFIX}websocket_catch_ups_total`,
+  registers: [metricsRegistry],
+});
+
+export const websocketClientMessageRejections = new Counter({
+  help: 'Agent WebSocket messages rejected by the per-client rate limit.',
+  name: `${PREFIX}websocket_client_message_rejections_total`,
+  registers: [metricsRegistry],
+});
+
+export const websocketSendFailures = new Counter({
+  help: 'WebSocket send failures by reason.',
+  labelNames: ['reason'] as const,
+  name: `${PREFIX}websocket_send_failures_total`,
+  registers: [metricsRegistry],
+});
+
+let websocketMetricsProvider: (() => WebSocketMetricsSnapshot) | undefined;
+let databaseMetricsProvider: (() => DatabaseMetricsSnapshot) | undefined;
+
+export function setDatabaseMetricsProvider(
+  provider: () => DatabaseMetricsSnapshot,
+): void {
+  databaseMetricsProvider = provider;
+}
+
+export function setWebSocketMetricsProvider(
+  provider: () => WebSocketMetricsSnapshot,
+): void {
+  websocketMetricsProvider = provider;
+}
+
+function snapshotGauge(
+  name: string,
+  help: string,
+  collect: (gauge: Gauge, snapshot: WebSocketMetricsSnapshot) => void,
+  labelNames: string[] = [],
+): void {
+  new Gauge({
+    collect() {
+      this.reset();
+      const snapshot = websocketMetricsProvider?.();
+      if (snapshot) collect(this, snapshot);
+    },
+    help,
+    labelNames,
+    name: `${PREFIX}${name}`,
+    registers: [metricsRegistry],
+  });
+}
+
+function databaseSnapshotGauge(
+  name: string,
+  help: string,
+  collect: (gauge: Gauge, snapshot: DatabaseMetricsSnapshot) => void,
+  labelNames: string[] = [],
+): void {
+  new Gauge({
+    collect() {
+      this.reset();
+      const snapshot = databaseMetricsProvider?.();
+      if (snapshot) collect(this, snapshot);
+    },
+    help,
+    labelNames,
+    name: `${PREFIX}${name}`,
+    registers: [metricsRegistry],
+  });
+}
+
+databaseSnapshotGauge(
+  'database_pool_connections',
+  'Current database pool connections by pool and state.',
+  (gauge, snapshot) => {
+    for (const [pool, values] of Object.entries(snapshot.pools)) {
+      gauge.set({ pool, state: 'active' }, values.total - values.idle);
+      gauge.set({ pool, state: 'idle' }, values.idle);
+    }
+  },
+  ['pool', 'state'],
+);
+databaseSnapshotGauge(
+  'database_pool_connection_limit',
+  'Maximum database connections by pool.',
+  (gauge, snapshot) => {
+    for (const [pool, values] of Object.entries(snapshot.pools))
+      gauge.set({ pool }, values.limit);
+  },
+  ['pool'],
+);
+databaseSnapshotGauge(
+  'database_pool_waiting_requests',
+  'Current requests waiting for a database connection by pool.',
+  (gauge, snapshot) => {
+    for (const [pool, values] of Object.entries(snapshot.pools))
+      gauge.set({ pool }, values.waiting);
+  },
+  ['pool'],
+);
+databaseSnapshotGauge(
+  'database_listener_connections',
+  'Current dedicated PostgreSQL listener connections.',
+  (gauge, snapshot) => gauge.set(snapshot.listeners),
+);
+
+snapshotGauge(
+  'websocket_connections',
+  'Current WebSocket connections by route.',
+  (gauge, snapshot) => {
+    gauge.set({ route: 'agent' }, snapshot.connections.agent);
+    gauge.set({ route: 'messages' }, snapshot.connections.messages);
+  },
+  ['route'],
+);
+snapshotGauge(
+  'websocket_connection_limit',
+  'Maximum WebSocket connections by route.',
+  (gauge, snapshot) => {
+    gauge.set({ route: 'agent' }, snapshot.limits.agentConnections);
+    gauge.set({ route: 'messages' }, snapshot.limits.messageConnections);
+  },
+  ['route'],
+);
+snapshotGauge(
+  'websocket_message_client_ips',
+  'Current number of distinct /messages client IPs.',
+  (gauge, snapshot) => gauge.set(snapshot.messageClientIps),
+);
+snapshotGauge(
+  'websocket_message_connection_limit_per_ip',
+  'Maximum /messages WebSocket connections per client IP.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.messageConnectionsPerIp),
+);
+snapshotGauge(
+  'websocket_message_max_connections_per_ip',
+  'Largest current /messages connection count for one client IP.',
+  (gauge, snapshot) => gauge.set(snapshot.messageMaxConnectionsPerIp),
+);
+snapshotGauge(
+  'websocket_listener_ready',
+  'Whether the database event listener is ready.',
+  (gauge, snapshot) => gauge.set(snapshot.listenerReady ? 1 : 0),
+);
+snapshotGauge(
+  'websocket_catch_ups',
+  'Current historical WebSocket catch-ups.',
+  (gauge, snapshot) => gauge.set(snapshot.catchUps),
+);
+snapshotGauge(
+  'websocket_catch_up_concurrency_limit',
+  'Maximum concurrent historical WebSocket catch-ups.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.concurrentCatchUps),
+);
+snapshotGauge(
+  'websocket_catch_up_row_limit',
+  'Maximum rows delivered by one historical WebSocket catch-up.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.catchUpRows),
+);
+snapshotGauge(
+  'websocket_max_catch_up_rows',
+  'Largest current row count delivered by one historical catch-up.',
+  (gauge, snapshot) => gauge.set(snapshot.maxCatchUpRows),
+);
+snapshotGauge(
+  'websocket_catch_up_duration_limit_seconds',
+  'Maximum duration of one historical WebSocket catch-up in seconds.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.catchUpMs / 1_000),
+);
+snapshotGauge(
+  'websocket_max_catch_up_duration_seconds',
+  'Longest current historical WebSocket catch-up duration in seconds.',
+  (gauge, snapshot) => gauge.set(snapshot.maxCatchUpDurationMs / 1_000),
+);
+snapshotGauge(
+  'websocket_pending_catch_up_events',
+  'Current live events buffered behind historical catch-ups.',
+  (gauge, snapshot) => gauge.set(snapshot.pendingCatchUpEvents),
+);
+snapshotGauge(
+  'websocket_pending_catch_up_event_limit',
+  'Maximum live events buffered behind one historical catch-up.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.pendingEvents),
+);
+snapshotGauge(
+  'websocket_max_pending_catch_up_events',
+  'Largest current live-event buffer behind one historical catch-up.',
+  (gauge, snapshot) => gauge.set(snapshot.maxPendingCatchUpEvents),
+);
+snapshotGauge(
+  'websocket_client_message_limit_per_minute',
+  'Maximum agent messages accepted per client per minute.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.clientMessagesPerMinute),
+);
+snapshotGauge(
+  'websocket_subscriptions',
+  'Current agent subscriptions by event type and state.',
+  (gauge, snapshot) => {
+    for (const [eventType, subscriptions] of Object.entries(
+      snapshot.subscriptions,
+    )) {
+      gauge.set(
+        { event_type: eventType, state: 'catching_up' },
+        subscriptions.catchingUp,
+      );
+      gauge.set({ event_type: eventType, state: 'live' }, subscriptions.live);
+    }
+  },
+  ['event_type', 'state'],
+);
+snapshotGauge(
+  'websocket_notification_queue',
+  'Current queued database notifications by route.',
+  (gauge, snapshot) => {
+    gauge.set({ route: 'agent' }, snapshot.notificationQueue.agent);
+    gauge.set({ route: 'messages' }, snapshot.notificationQueue.messages);
+  },
+  ['route'],
+);
+snapshotGauge(
+  'websocket_outbound_pending_bytes',
+  'Current bytes awaiting WebSocket send callbacks.',
+  (gauge, snapshot) => gauge.set(snapshot.outboundPendingBytes),
+);
+snapshotGauge(
+  'websocket_outbound_pending_byte_limit',
+  'Maximum total bytes awaiting WebSocket send callbacks.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.totalPendingBytes),
+);
+snapshotGauge(
+  'websocket_max_client_buffered_bytes',
+  'Largest current ws bufferedAmount among connected clients.',
+  (gauge, snapshot) => gauge.set(snapshot.maxClientBufferedBytes),
+);
+snapshotGauge(
+  'websocket_client_buffered_byte_limit',
+  'Maximum ws bufferedAmount allowed for one client.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.socketBufferedBytes),
+);
+
+@Controller('metrics')
+export class MetricsController {
+  @Get()
+  @Header('Content-Type', metricsRegistry.contentType)
+  getMetrics(): Promise<string> {
+    return metricsRegistry.metrics();
+  }
+}

--- a/typescript/scraper-proxy/src/module.ts
+++ b/typescript/scraper-proxy/src/module.ts
@@ -16,6 +16,14 @@ import type { GraphQLFormattedError } from 'graphql';
 import { config } from './config.js';
 import { DbModule } from './db/db.module.js';
 import { DbService } from './db/db.service.js';
+import {
+  graphqlActiveRequestLimit,
+  graphqlActiveRequests,
+  graphqlErrors,
+  graphqlRequestDuration,
+  graphqlRequests,
+  MetricsController,
+} from './metrics.js';
 import { scraperDbCachePlugin } from './scraperdb/cache-plugin.js';
 import { normalizeGraphqlRequestBody } from './scraperdb/request-compatibility.js';
 import { buildResolvers } from './scraperdb/resolver-map.js';
@@ -59,6 +67,7 @@ if (!schemaPath) throw new Error('Missing scraper DB GraphQL schema');
 
 let stats = newStats();
 let activeRequests = 0;
+graphqlActiveRequestLimit.set(config.GRAPHQL_MAX_ACTIVE_REQUESTS);
 setInterval(() => {
   const current = stats;
   stats = newStats();
@@ -68,6 +77,7 @@ setInterval(() => {
 }, 60_000).unref();
 
 @Module({
+  controllers: [MetricsController],
   imports: [
     GraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
@@ -103,15 +113,19 @@ function graphqlMiddleware(
     res.statusCode = 503;
     res.setHeader('retry-after', '1');
     res.end('GraphQL request capacity exceeded');
+    graphqlRequests.inc({ outcome: 'capacity_rejected' });
+    graphqlRequestDuration.observe((Date.now() - started) / 1_000);
     recordRequest(started, 503, true);
     return;
   }
   activeRequests++;
+  graphqlActiveRequests.inc();
   let completed = false;
   const complete = (): void => {
     if (completed) return;
     completed = true;
     activeRequests--;
+    graphqlActiveRequests.dec();
     recordRequest(
       started,
       res.statusCode ?? 0,
@@ -132,6 +146,10 @@ function recordRequest(
   request = 'REQUEST /graphql',
 ): void {
   const duration = Date.now() - started;
+  if (!rejected) {
+    graphqlRequests.inc({ outcome: requestOutcome(status) });
+    graphqlRequestDuration.observe(duration / 1_000);
+  }
   stats.requests++;
   stats.totalMs += duration;
   stats.maxMs = Math.max(stats.maxMs, duration);
@@ -147,8 +165,15 @@ function formatError(error: GraphQLFormattedError): GraphQLFormattedError {
       ? ` code=${error.extensions.code}`
       : '';
   stats.errors++;
+  graphqlErrors.inc();
   logger.warn(`error${code}: ${error.message}`);
   return error;
+}
+
+function requestOutcome(status: number): string {
+  if (status >= 500) return 'server_error';
+  if (status >= 400) return 'client_error';
+  return 'success';
 }
 
 function newStats(): Stats {


### PR DESCRIPTION
## Summary

- expose Prometheus metrics for GraphQL usage, WebSocket connections and saturation, database pools, and Node.js runtime health
- report enforced limits plus connection rejections, send failures, and historical replay outcomes
- configure the scraper-proxy Service for Prometheus discovery on /metrics

## Validation

- scraper-proxy TypeScript build
- scraper-proxy lint
- scraper-proxy tests: 51 passed
- Helm lint and rendered Service verification
- git diff check