### PR TITLE
chore: deploy scraper proxy independently

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/configmap.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.hyperlane.validator.enabled .Values.hyperlane.relayer.enabled .Values.hyperlane.scraper.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,3 +15,4 @@ data:
 {{- include "agent-common.config-env-vars" (dict "config" . "key_name_prefix" (printf "chains_%s_" .name) "format" "config_map") | indent 2 }}
   {{- end }}
   HYP_METRICSPORT: {{ .Values.hyperlane.metrics.port | quote }}
+{{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/external-secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.hyperlane.validator.enabled .Values.hyperlane.relayer.enabled .Values.hyperlane.scraper.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -89,3 +90,4 @@ spec:
       key: {{ printf "%s-rpc-endpoint-helius-%s" $.Values.hyperlane.runEnv .name }}
   {{- end }}
   {{- end }}
+{{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/relayer-configmap.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/relayer-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hyperlane.relayer.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ metadata:
 data:
   relayer-config.json: |
 {{- toJson .Values.hyperlane.relayer.configMapConfig | nindent 4 }}
+{{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/scraper-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-external-secret.yaml
@@ -22,16 +22,8 @@ spec:
           {{- include "agent-common.labels" . | nindent 10 }}
       data:
         HYP_DB: {{ print "'{{ .db | toString }}'" }}
-        {{- if .Values.hyperlane.scraper.proxy.enabled }}
-        DATABASE_URL: {{ print "'{{ .proxy_db | toString }}'" }}
-        {{- end }}
   data:
   - secretKey: db
     remoteRef:
       key: {{ printf "%s-%s-scraper3-db" .Values.hyperlane.context .Values.hyperlane.runEnv }}
-  {{- if .Values.hyperlane.scraper.proxy.enabled }}
-  - secretKey: proxy_db
-    remoteRef:
-      key: {{ printf "%s-%s-scraper3-db-read-only" .Values.hyperlane.context .Values.hyperlane.runEnv }}
-  {{- end }}
 {{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.hyperlane.scraperProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-common.fullname" . }}
+  labels:
+    {{- include "agent-common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scraper-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "agent-common.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: scraper-proxy
+  template:
+    metadata:
+      annotations:
+        checksum/scraper-proxy-external-secret: {{ include (print $.Template.BasePath "/scraper-proxy-external-secret.yaml") . | sha256sum }}
+        checksum/scraper-proxy-cloudflared-external-secret: {{ include (print $.Template.BasePath "/scraper-proxy-cloudflared-external-secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "agent-common.labels" . | nindent 8 }}
+        app.kubernetes.io/component: scraper-proxy
+        {{- with .Values.podCommonLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.hyperlane.scraper.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: scraper-proxy
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: SERVICE_NAME
+          value: scraper-proxy
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "agent-common.fullname" . }}-secret
+              key: DATABASE_URL
+        - name: PORT
+          value: {{ .Values.hyperlane.scraperProxy.port | quote }}
+        ports:
+        - name: scraper-proxy
+          containerPort: {{ .Values.hyperlane.scraperProxy.port }}
+        readinessProbe:
+          tcpSocket:
+            port: scraper-proxy
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          {{- toYaml .Values.hyperlane.scraperProxy.resources | nindent 10 }}
+      - name: cloudflared
+        image: {{ .Values.hyperlane.scraperProxy.tunnel.image }}
+        args: ["tunnel", "--no-autoupdate", "run"]
+        envFrom:
+        - secretRef:
+            name: {{ include "agent-common.fullname" . }}-cloudflared-secret
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "scraper"
+          effect: "NoSchedule"
+{{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "agent-common.labels" . | nindent 4 }}
     app.kubernetes.io/component: scraper-proxy
 spec:
-  replicas: 1
+  replicas: {{ .Values.hyperlane.scraperProxy.replicas }}
   selector:
     matchLabels:
       {{- include "agent-common.selectorLabels" . | nindent 6 }}

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-external-secret.yaml
@@ -1,9 +1,8 @@
-# Pre-deploy: GCP secret {context}-{runEnv}-scraper-proxy-cloudflared-tunnel-token must exist.
 {{- if .Values.hyperlane.scraperProxy.enabled }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "agent-common.fullname" . }}-cloudflared-external-secret
+  name: {{ include "agent-common.fullname" . }}-external-secret
   labels:
     {{- include "agent-common.labels" . | nindent 4 }}
   annotations:
@@ -14,16 +13,16 @@ spec:
     kind: {{ .Values.externalSecrets.storeType }}
   refreshInterval: "1h"
   target:
-    name: {{ include "agent-common.fullname" . }}-cloudflared-secret
+    name: {{ include "agent-common.fullname" . }}-secret
     template:
       type: Opaque
       metadata:
         labels:
           {{- include "agent-common.labels" . | nindent 10 }}
       data:
-        TUNNEL_TOKEN: {{ print "'{{ .cloudflared_tunnel_token | toString }}'" }}
+        DATABASE_URL: {{ print "'{{ .database_url | toString }}'" }}
   data:
-  - secretKey: cloudflared_tunnel_token
+  - secretKey: database_url
     remoteRef:
-      key: {{ printf "%s-%s-scraper-proxy-cloudflared-tunnel-token" .Values.hyperlane.context .Values.hyperlane.runEnv }}
+      key: {{ printf "%s-%s-scraper3-db-read-only" .Values.hyperlane.context .Values.hyperlane.runEnv }}
 {{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-service.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-service.yaml
@@ -1,22 +1,22 @@
-{{- if and .Values.hyperlane.scraper.enabled .Values.hyperlane.scraper.proxy.enabled }}
+{{- if .Values.hyperlane.scraperProxy.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "agent-common.fullname" . }}-scraper-proxy
+  name: {{ include "agent-common.fullname" . }}
   annotations:
     prometheus.io/path: /metrics
-    prometheus.io/port: {{ .Values.hyperlane.scraper.proxy.port | quote }}
+    prometheus.io/port: {{ .Values.hyperlane.scraperProxy.port | quote }}
     prometheus.io/scrape: 'true'
   labels:
     {{- include "agent-common.labels" . | nindent 4 }}
-    app.kubernetes.io/component: scraper3
+    app.kubernetes.io/component: scraper-proxy
 spec:
   type: ClusterIP
   selector:
     {{- include "agent-common.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: scraper3
+    app.kubernetes.io/component: scraper-proxy
   ports:
   - name: websocket
-    port: {{ .Values.hyperlane.scraper.proxy.port }}
+    port: {{ .Values.hyperlane.scraperProxy.port }}
     targetPort: scraper-proxy
 {{- end }}

--- a/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-statefulset.yaml
@@ -19,9 +19,6 @@ spec:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/external-secret: {{ include (print $.Template.BasePath "/external-secret.yaml") . | sha256sum }}
         checksum/scraper-external-secret: {{ include (print $.Template.BasePath "/scraper-external-secret.yaml") . | sha256sum }}
-        {{- if .Values.hyperlane.scraper.proxy.enabled }}
-        checksum/scraper-proxy-cloudflared-external-secret: {{ include (print $.Template.BasePath "/scraper-proxy-cloudflared-external-secret.yaml") . | sha256sum }}
-        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -68,41 +65,6 @@ spec:
         ports:
         - name: metrics
           containerPort: {{ .Values.hyperlane.metrics.port }}
-      {{- if .Values.hyperlane.scraper.proxy.enabled }}
-      - name: scraper-proxy
-        image: "{{ .Values.hyperlane.scraper.proxy.docker.repository }}:{{ .Values.hyperlane.scraper.proxy.docker.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        env:
-        - name: SERVICE_NAME
-          value: scraper-proxy
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "agent-common.fullname" . }}-scraper3-secret
-              key: DATABASE_URL
-        - name: PORT
-          value: {{ .Values.hyperlane.scraper.proxy.port | quote }}
-        ports:
-        - name: scraper-proxy
-          containerPort: {{ .Values.hyperlane.scraper.proxy.port }}
-        readinessProbe:
-          tcpSocket:
-            port: scraper-proxy
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          {{- toYaml .Values.hyperlane.scraper.proxy.resources | nindent 10 }}
-      - name: cloudflared
-        image: {{ .Values.hyperlane.scraper.proxy.tunnel.image }}
-        args: ["tunnel", "--no-autoupdate", "run"]
-        envFrom:
-        - secretRef:
-            name: {{ include "agent-common.fullname" . }}-scraper-proxy-cloudflared-secret
-        resources:
-          requests:
-            cpu: 50m
-            memory: 64Mi
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/rust/main/helm/hyperlane-agent/templates/serviceaccount.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create (or .Values.hyperlane.validator.enabled .Values.hyperlane.relayer.enabled .Values.hyperlane.scraper.enabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -143,18 +143,6 @@ hyperlane:
 
   scraper:
     enabled: false
-    proxy:
-      enabled: false
-      docker:
-        repository: ghcr.io/hyperlane-xyz/hyperlane-node-services
-        tag: main
-      port: 8383
-      tunnel:
-        image: cloudflare/cloudflared:2026.8.2
-      resources:
-        requests:
-          cpu: 500m
-          memory: 1Gi
     podAnnotations:
       prometheus.io/port: '9090'
       prometheus.io/scrape: 'true'
@@ -170,6 +158,16 @@ hyperlane:
         memory: 256Mi
     config:
       chainsToScrape: ''
+
+  scraperProxy:
+    enabled: false
+    port: 8383
+    tunnel:
+      image: cloudflare/cloudflared:2026.8.2
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
 
   kathy:
     enabled: false

--- a/rust/main/helm/hyperlane-agent/values.yaml
+++ b/rust/main/helm/hyperlane-agent/values.yaml
@@ -162,6 +162,7 @@ hyperlane:
   scraperProxy:
     enabled: false
     port: 8383
+    replicas: 1
     tunnel:
       image: cloudflare/cloudflared:2026.8.2
     resources:

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -838,25 +838,23 @@ const hyperlane: RootAgentConfig = {
   },
   scraper: {
     scraperOnlyChains,
-    proxy: {
-      docker: {
-        repo: DockerImageRepos.NODE_SERVICES,
-        tag: mainnetDockerTags.scraperProxy,
-      },
-      // Enable after publishing an immutable node-services image and creating
-      // the scraper-proxy Cloudflare tunnel token secret.
-      enabled: true,
-      port: 8383,
-      resources: {
-        requests: { cpu: '500m', memory: '1Gi' },
-      },
-    },
     rpcConsensusType: RpcConsensusType.Fallback,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.scraper,
     },
     resources: scraperResources,
+  },
+  scraperProxy: {
+    docker: {
+      repo: DockerImageRepos.NODE_SERVICES,
+      tag: mainnetDockerTags.scraperProxy,
+    },
+    enabled: true,
+    port: 8383,
+    resources: {
+      requests: { cpu: '500m', memory: '1Gi' },
+    },
   },
 };
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -852,6 +852,7 @@ const hyperlane: RootAgentConfig = {
     },
     enabled: true,
     port: 8383,
+    replicas: 2,
     resources: {
       requests: { cpu: '500m', memory: '1Gi' },
     },

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -852,7 +852,7 @@ const hyperlane: RootAgentConfig = {
     },
     enabled: true,
     port: 8383,
-    replicas: 2,
+    replicas: 1,
     resources: {
       requests: { cpu: '500m', memory: '1Gi' },
     },

--- a/typescript/infra/scripts/agents/deploy-agents.ts
+++ b/typescript/infra/scripts/agents/deploy-agents.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process';
 
 import { createAgentKeysIfNotExistsWithPrompt } from '../../src/agents/key-utils.js';
 import { RootAgentConfig } from '../../src/config/agent/agent.js';
+import { Role } from '../../src/roles.js';
 import {
   checkAgentImageExists,
   checkMonorepoImageExists,
@@ -55,16 +56,31 @@ async function getCommitsBehindMain(): Promise<number> {
   }
 }
 
-async function checkDockerTagsExist(agentConfig: RootAgentConfig) {
-  const imagesToCheck: { agent: string; tag?: string }[] = [
-    { agent: 'scraper', tag: agentConfig.scraper?.docker.tag },
-    { agent: 'validators', tag: agentConfig.validators?.docker.tag },
-    { agent: 'relayer', tag: agentConfig.relayer?.docker.tag },
+async function checkDockerTagsExist(
+  agentConfig: RootAgentConfig,
+  roles: Role[],
+) {
+  const imagesToCheck: { agent: string; role: Role; tag?: string }[] = [
+    {
+      agent: 'scraper',
+      role: Role.Scraper,
+      tag: agentConfig.scraper?.docker.tag,
+    },
+    {
+      agent: 'validators',
+      role: Role.Validator,
+      tag: agentConfig.validators?.docker.tag,
+    },
+    {
+      agent: 'relayer',
+      role: Role.Relayer,
+      tag: agentConfig.relayer?.docker.tag,
+    },
   ];
 
   let errors = false;
-  for (const { agent, tag } of imagesToCheck) {
-    if (!tag) continue;
+  for (const { agent, role, tag } of imagesToCheck) {
+    if (!roles.includes(role) || !tag) continue;
 
     warnIfPrTag(agent, tag);
 
@@ -97,8 +113,8 @@ async function checkDockerTagsExist(agentConfig: RootAgentConfig) {
     }
   }
 
-  const proxy = agentConfig.scraper?.proxy;
-  if (proxy?.enabled) {
+  const proxy = agentConfig.scraperProxy;
+  if (roles.includes(Role.ScraperProxy) && proxy?.enabled) {
     const tag = proxy.docker.tag;
     warnIfPrTag('scraper-proxy', tag);
     if (!(await checkNodeServicesImageExists(tag))) {
@@ -129,11 +145,15 @@ async function main() {
   ).argv;
 
   const { agentConfig } = await getConfigsBasedOnArgs();
-  await checkDockerTagsExist(agentConfig);
+  await checkDockerTagsExist(agentConfig, roles);
 
-  // Scope key reconciliation to the roles being deployed. Deploying the relayer
-  // or scraper must not require read access to validator KMS keys.
-  await createAgentKeysIfNotExistsWithPrompt(agentConfig, roles);
+  // Roles without managed keys must not trigger unrelated key reconciliation.
+  const keyRoles = roles.filter((role) =>
+    agentConfig.rolesWithKeys.includes(role),
+  );
+  if (keyRoles.length > 0) {
+    await createAgentKeysIfNotExistsWithPrompt(agentConfig, keyRoles);
+  }
 
   // Check if current branch is up-to-date with the main branch
   const commitsBehind = await getCommitsBehindMain();

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -9,7 +9,10 @@ import {
   ScraperProxyHelmManager,
   ValidatorHelmManager,
 } from '../../src/agents/index.js';
-import { RootAgentConfig } from '../../src/config/agent/agent.js';
+import {
+  HelmRootAgentValues,
+  RootAgentConfig,
+} from '../../src/config/agent/agent.js';
 import { EnvironmentConfig } from '../../src/config/environment.js';
 import { Role } from '../../src/roles.js';
 import {
@@ -45,11 +48,21 @@ export class AgentCli {
   public async restartAgents() {
     await this.init();
     const managers = this.managers();
-    await refreshK8sResources(
-      Object.values(managers),
-      K8sResourceType.POD,
-      this.envConfig.environment,
+    const statefulSetManagers = Object.values(managers).filter(
+      (manager) => !(manager instanceof ScraperProxyHelmManager),
     );
+    if (statefulSetManagers.length > 0) {
+      await refreshK8sResources(
+        statefulSetManagers,
+        K8sResourceType.POD,
+        this.envConfig.environment,
+      );
+    }
+
+    const scraperProxyManager = managers[Role.ScraperProxy];
+    if (scraperProxyManager instanceof ScraperProxyHelmManager) {
+      await scraperProxyManager.restartDeployment();
+    }
   }
 
   public async runHelmCommand(command: HelmCommand) {
@@ -150,7 +163,7 @@ export class AgentCli {
   }
 
   private async runPreflightChecks(
-    managers: Record<string, HelmManager<any>>,
+    managers: Record<string, HelmManager<HelmRootAgentValues>>,
   ): Promise<boolean> {
     console.log(chalk.cyan.bold('🔍 Running pre-flight checks...\n'));
 
@@ -210,8 +223,8 @@ export class AgentCli {
     });
   }
 
-  private managers(): Record<string, HelmManager<any>> {
-    const managers: Record<string, HelmManager<any>> = {};
+  private managers(): Record<string, HelmManager<HelmRootAgentValues>> {
+    const managers: Record<string, HelmManager<HelmRootAgentValues>> = {};
     for (const role of this.roles) {
       switch (role) {
         case Role.Validator: {

--- a/typescript/infra/scripts/agents/utils.ts
+++ b/typescript/infra/scripts/agents/utils.ts
@@ -4,9 +4,9 @@ import chalk from 'chalk';
 import { concurrentMap, mapAllSettled, rootLogger } from '@hyperlane-xyz/utils';
 
 import {
-  AgentHelmManager,
   RelayerHelmManager,
   ScraperHelmManager,
+  ScraperProxyHelmManager,
   ValidatorHelmManager,
 } from '../../src/agents/index.js';
 import { RootAgentConfig } from '../../src/config/agent/agent.js';
@@ -14,6 +14,7 @@ import { EnvironmentConfig } from '../../src/config/environment.js';
 import { Role } from '../../src/roles.js';
 import {
   HelmCommand,
+  HelmManager,
   PreflightDiff,
   buildHelmChartDependencies,
 } from '../../src/utils/helm.js';
@@ -149,7 +150,7 @@ export class AgentCli {
   }
 
   private async runPreflightChecks(
-    managers: Record<string, AgentHelmManager>,
+    managers: Record<string, HelmManager<any>>,
   ): Promise<boolean> {
     console.log(chalk.cyan.bold('🔍 Running pre-flight checks...\n'));
 
@@ -209,8 +210,8 @@ export class AgentCli {
     });
   }
 
-  private managers(): Record<string, AgentHelmManager> {
-    const managers: Record<string, AgentHelmManager> = {};
+  private managers(): Record<string, HelmManager<any>> {
+    const managers: Record<string, HelmManager<any>> = {};
     for (const role of this.roles) {
       switch (role) {
         case Role.Validator: {
@@ -236,6 +237,9 @@ export class AgentCli {
           break;
         case Role.Scraper:
           managers[role] = new ScraperHelmManager(this.agentConfig);
+          break;
+        case Role.ScraperProxy:
+          managers[role] = new ScraperProxyHelmManager(this.agentConfig);
           break;
         default:
           throw new Error(`Invalid role ${role}`);

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -372,22 +372,47 @@ export class ScraperHelmManager extends OmniscientAgentHelmManager {
 
   async helmValues(): Promise<HelmRootAgentValues> {
     const values = await super.helmValues();
-    const proxy = this.config.rawConfig.scraper?.proxy;
     values.hyperlane.scraper = {
       enabled: true,
       config: await this.config.buildConfig(),
-      proxy: proxy && {
-        ...proxy,
-        docker: {
-          repository: proxy.docker.repo,
-          tag: proxy.docker.tag,
-        },
-      },
       resources: this.kubernetesResources(),
     };
     // scraper never requires aws credentials
     values.hyperlane.aws = false;
     return values;
+  }
+}
+
+export class ScraperProxyHelmManager extends HelmManager<HelmRootAgentValues> {
+  readonly helmChartPath: string = HELM_CHART_PATH;
+  readonly helmReleaseName = 'scraper-proxy';
+
+  constructor(private readonly config: RootAgentConfig) {
+    super();
+    if (!config.scraperProxy)
+      throw new Error('Scraper proxy is not defined for this context');
+  }
+
+  get namespace(): string {
+    return this.config.namespace;
+  }
+
+  async helmValues(): Promise<HelmRootAgentValues> {
+    const { docker, ...scraperProxy } = this.config.scraperProxy!;
+    return {
+      fullnameOverride: 'scraper-proxy',
+      image: {
+        repository: docker.repo,
+        tag: docker.tag,
+      },
+      hyperlane: {
+        runEnv: this.config.runEnv,
+        context: this.config.context,
+        aws: false,
+        chains: [],
+        scraperProxy,
+      },
+    };
   }
 }
 

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -28,6 +28,7 @@ import {
   RelayerEnvConfig,
 } from '../config/agent/relayer.js';
 import { ScraperConfigHelper } from '../config/agent/scraper.js';
+import type { ScraperProxyConfig } from '../config/agent/scraper-proxy.js';
 import { ValidatorConfigHelper } from '../config/agent/validator.js';
 import { DeployEnvironment } from '../config/deploy-environment.js';
 import { AgentRole, Role } from '../roles.js';
@@ -386,11 +387,14 @@ export class ScraperHelmManager extends OmniscientAgentHelmManager {
 export class ScraperProxyHelmManager extends HelmManager<HelmRootAgentValues> {
   readonly helmChartPath: string = HELM_CHART_PATH;
   readonly helmReleaseName = 'scraper-proxy';
+  private readonly scraperProxy: ScraperProxyConfig;
 
   constructor(private readonly config: RootAgentConfig) {
     super();
-    if (!config.scraperProxy)
+    const scraperProxy = config.scraperProxy;
+    if (!scraperProxy)
       throw new Error('Scraper proxy is not defined for this context');
+    this.scraperProxy = scraperProxy;
   }
 
   get namespace(): string {
@@ -398,7 +402,7 @@ export class ScraperProxyHelmManager extends HelmManager<HelmRootAgentValues> {
   }
 
   async helmValues(): Promise<HelmRootAgentValues> {
-    const { docker, ...scraperProxy } = this.config.scraperProxy!;
+    const { docker, ...scraperProxy } = this.scraperProxy;
     return {
       fullnameOverride: 'scraper-proxy',
       image: {
@@ -413,6 +417,19 @@ export class ScraperProxyHelmManager extends HelmManager<HelmRootAgentValues> {
         scraperProxy,
       },
     };
+  }
+
+  async restartDeployment(): Promise<void> {
+    await this.runCommand(
+      `kubectl rollout restart deployment/${this.helmReleaseName} -n ${this.namespace}`,
+    );
+    await this.runCommand(
+      `kubectl rollout status deployment/${this.helmReleaseName} -n ${this.namespace} --timeout=180s`,
+    );
+  }
+
+  protected async runCommand(command: string): Promise<void> {
+    await execCmd(command);
   }
 }
 

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -25,6 +25,10 @@ import type {
 } from './relayer.js';
 import type { BaseScraperConfig, HelmScraperValues } from './scraper.js';
 import type {
+  HelmScraperProxyValues,
+  ScraperProxyConfig,
+} from './scraper-proxy.js';
+import type {
   HelmValidatorValues,
   ValidatorBaseChainConfigMap,
 } from './validator.js';
@@ -38,6 +42,7 @@ export type DeepPartial<T> = T extends object
 // See rust/main/helm/values.yaml for the full list of options and their defaults.
 // This is the root object in the values file.
 export interface HelmRootAgentValues {
+  fullnameOverride?: string;
   image: HelmImageValues;
   hyperlane: HelmHyperlaneValues;
   nameOverride?: string;
@@ -63,6 +68,7 @@ interface HelmHyperlaneValues {
   relayer?: HelmRelayerValues;
   relayerChains?: HelmRelayerChainValues[];
   scraper?: HelmScraperValues;
+  scraperProxy?: HelmScraperProxyValues;
 }
 
 // See rust/main/helm/values.yaml for the full list of options and their defaults.
@@ -83,6 +89,7 @@ export interface RootAgentConfig extends AgentContextConfig {
     chains: ValidatorBaseChainConfigMap;
   };
   scraper?: AgentRoleConfig & BaseScraperConfig;
+  scraperProxy?: ScraperProxyConfig;
 }
 
 interface AgentEnvConfig {

--- a/typescript/infra/src/config/agent/scraper-proxy.ts
+++ b/typescript/infra/src/config/agent/scraper-proxy.ts
@@ -4,6 +4,7 @@ export interface ScraperProxyConfig {
   docker: DockerConfig;
   enabled: boolean;
   port?: number;
+  replicas?: number;
   resources?: KubernetesResources;
   tunnel?: { image: string };
 }

--- a/typescript/infra/src/config/agent/scraper-proxy.ts
+++ b/typescript/infra/src/config/agent/scraper-proxy.ts
@@ -1,0 +1,11 @@
+import type { DockerConfig, KubernetesResources } from './agent.js';
+
+export interface ScraperProxyConfig {
+  docker: DockerConfig;
+  enabled: boolean;
+  port?: number;
+  resources?: KubernetesResources;
+  tunnel?: { image: string };
+}
+
+export type HelmScraperProxyValues = Omit<ScraperProxyConfig, 'docker'>;

--- a/typescript/infra/src/config/agent/scraper.ts
+++ b/typescript/infra/src/config/agent/scraper.ts
@@ -8,35 +8,11 @@ import { isAddress } from '@hyperlane-xyz/utils';
 
 import { getDomainId, getRegistry } from '../../../config/registry.js';
 import { Role } from '../../roles.js';
-import type {
-  HelmImageValues,
-  HelmStatefulSetValues,
-} from '../infrastructure.js';
+import type { HelmStatefulSetValues } from '../infrastructure.js';
 
-import {
-  AgentConfigHelper,
-  type DockerConfig,
-  type KubernetesResources,
-  RootAgentConfig,
-} from './agent.js';
-
-export interface ScraperProxyConfig {
-  docker: DockerConfig;
-  enabled: boolean;
-  port?: number;
-  resources?: KubernetesResources;
-  tunnel?: { image: string };
-}
-
-export interface HelmScraperProxyValues extends Omit<
-  ScraperProxyConfig,
-  'docker'
-> {
-  docker: HelmImageValues;
-}
+import { AgentConfigHelper, RootAgentConfig } from './agent.js';
 
 export interface BaseScraperConfig {
-  proxy?: ScraperProxyConfig;
   scraperOnlyChains?: ChainMap<boolean>;
 }
 
@@ -45,7 +21,6 @@ export type ScraperConfig = Omit<ScraperAgentConfig, keyof AgentConfig | 'db'>;
 
 export interface HelmScraperValues extends HelmStatefulSetValues {
   config?: ScraperConfig;
-  proxy?: HelmScraperProxyValues;
 }
 
 /**

--- a/typescript/infra/src/roles.ts
+++ b/typescript/infra/src/roles.ts
@@ -2,6 +2,7 @@ export enum Role {
   Validator = 'validator',
   Relayer = 'relayer',
   Scraper = 'scraper',
+  ScraperProxy = 'scraper-proxy',
   Deployer = 'deployer',
   Rebalancer = 'rebalancer',
   InventoryRebalancer = 'inventoryrebalancer',

--- a/typescript/infra/test/scraper-proxy-helm-manager.test.ts
+++ b/typescript/infra/test/scraper-proxy-helm-manager.test.ts
@@ -6,28 +6,29 @@ import type { RootAgentConfig } from '../src/config/agent/agent.js';
 import { Role } from '../src/roles.js';
 
 describe('ScraperProxyHelmManager', () => {
-  it('generates an independent proxy-only Helm release', async () => {
-    const config: RootAgentConfig = {
-      runEnv: 'mainnet3',
-      namespace: 'mainnet3',
-      context: Contexts.Hyperlane,
-      rolesWithKeys: [],
-      environmentChainNames: [],
-      contextChainNames: {
-        [Role.Validator]: [],
-        [Role.Relayer]: [],
-        [Role.Scraper]: [],
+  const config: RootAgentConfig = {
+    runEnv: 'mainnet3',
+    namespace: 'mainnet3',
+    context: Contexts.Hyperlane,
+    rolesWithKeys: [],
+    environmentChainNames: [],
+    contextChainNames: {
+      [Role.Validator]: [],
+      [Role.Relayer]: [],
+      [Role.Scraper]: [],
+    },
+    scraperProxy: {
+      docker: {
+        repo: 'ghcr.io/hyperlane-xyz/hyperlane-node-services',
+        tag: 'test',
       },
-      scraperProxy: {
-        docker: {
-          repo: 'ghcr.io/hyperlane-xyz/hyperlane-node-services',
-          tag: 'test',
-        },
-        enabled: true,
-        port: 8383,
-      },
-    };
+      enabled: true,
+      port: 8383,
+      replicas: 2,
+    },
+  };
 
+  it('generates an independent proxy-only Helm release', async () => {
     const manager = new ScraperProxyHelmManager(config);
     const values = await manager.helmValues();
 
@@ -42,6 +43,26 @@ describe('ScraperProxyHelmManager', () => {
     expect(values.hyperlane.scraperProxy).to.deep.equal({
       enabled: true,
       port: 8383,
+      replicas: 2,
     });
+  });
+
+  it('restarts the Deployment and waits for its rollout', async () => {
+    class TestScraperProxyHelmManager extends ScraperProxyHelmManager {
+      readonly commands: string[] = [];
+
+      protected override async runCommand(command: string): Promise<void> {
+        this.commands.push(command);
+      }
+    }
+
+    const manager = new TestScraperProxyHelmManager(config);
+
+    await manager.restartDeployment();
+
+    expect(manager.commands).to.deep.equal([
+      'kubectl rollout restart deployment/scraper-proxy -n mainnet3',
+      'kubectl rollout status deployment/scraper-proxy -n mainnet3 --timeout=180s',
+    ]);
   });
 });

--- a/typescript/infra/test/scraper-proxy-helm-manager.test.ts
+++ b/typescript/infra/test/scraper-proxy-helm-manager.test.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import { Contexts } from '../config/contexts.js';
+import { ScraperProxyHelmManager } from '../src/agents/index.js';
+import type { RootAgentConfig } from '../src/config/agent/agent.js';
+import { Role } from '../src/roles.js';
+
+describe('ScraperProxyHelmManager', () => {
+  it('generates an independent proxy-only Helm release', async () => {
+    const config: RootAgentConfig = {
+      runEnv: 'mainnet3',
+      namespace: 'mainnet3',
+      context: Contexts.Hyperlane,
+      rolesWithKeys: [],
+      environmentChainNames: [],
+      contextChainNames: {
+        [Role.Validator]: [],
+        [Role.Relayer]: [],
+        [Role.Scraper]: [],
+      },
+      scraperProxy: {
+        docker: {
+          repo: 'ghcr.io/hyperlane-xyz/hyperlane-node-services',
+          tag: 'test',
+        },
+        enabled: true,
+        port: 8383,
+      },
+    };
+
+    const manager = new ScraperProxyHelmManager(config);
+    const values = await manager.helmValues();
+
+    expect(manager.helmReleaseName).to.equal('scraper-proxy');
+    expect(values.fullnameOverride).to.equal('scraper-proxy');
+    expect(values.image).to.deep.equal({
+      repository: 'ghcr.io/hyperlane-xyz/hyperlane-node-services',
+      tag: 'test',
+    });
+    expect(values.hyperlane.chains).to.deep.equal([]);
+    expect(values.hyperlane.scraper).to.equal(undefined);
+    expect(values.hyperlane.scraperProxy).to.deep.equal({
+      enabled: true,
+      port: 8383,
+    });
+  });
+});

--- a/typescript/scraper-proxy/README.md
+++ b/typescript/scraper-proxy/README.md
@@ -7,8 +7,8 @@ Prometheus metrics at `/metrics`.
 ## Deployment
 
 The proxy is bundled into `hyperlane-node-services` as `scraper-proxy`. The
-mainnet scraper Helm release runs it next to the scraper with a `cloudflared`
-sidecar. The existing scraper database secret supplies `DATABASE_URL`.
+dedicated scraper-proxy Helm release runs it with a `cloudflared` sidecar. Its
+ExternalSecret reads the scraper database's read-only URL into `DATABASE_URL`.
 
 Before enabling the deployment:
 
@@ -20,12 +20,12 @@ Before enabling the deployment:
    both public routes.
 3. Store its token in GCP Secret Manager as
    `hyperlane-mainnet3-scraper-proxy-cloudflared-tunnel-token`.
-4. Set `scraper.proxy.enabled` to `true` in the mainnet agent config.
-5. Deploy the scraper role:
+4. Set `scraperProxy.enabled` to `true` in the mainnet agent config.
+5. Deploy the scraper-proxy role:
 
    ```sh
    pnpm -C typescript/infra tsx scripts/agents/deploy-agents.ts \
-     --environment mainnet3 --roles scraper
+     --environment mainnet3 --roles scraper-proxy
    ```
 
 The public endpoints are then:


### PR DESCRIPTION
Deploys scraper-proxy independently from the scraper StatefulSet.

Changes:

- Adds a dedicated scraper-proxy Deployment with two replicas.
- Runs a Cloudflare tunnel sidecar beside each proxy replica.
- Moves proxy configuration into the top-level scraperProxy role.
- Adds a dedicated Service plus read-only database and tunnel secrets.
- Keeps the scraper StatefulSet focused on the scraper agent.
- Adds Helm manager coverage and updates deployment documentation.

Rollout note: deploy scraper-proxy first, then redeploy scraper. This gives Cloudflare healthy replacement connectors before removing the old sidecar.

Validation:

- pnpm -C typescript/infra check
- Focused scraper-proxy Helm manager tests: 2 passing
- helm lint rust/main/helm/hyperlane-agent
- Verified the generated proxy resources and scraper-only render
- git diff --check
