### PR TITLE
feat(sdk): estimate fees without sender balance checks

### DIFF
--- a/.changeset/estimate-unfunded-transaction-fees.md
+++ b/.changeset/estimate-unfunded-transaction-fees.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added an optional `ignoreSenderBalance` mode to multi-protocol transaction fee estimation, allowing callers to price native max-amount transactions without changing the existing balance-aware default behavior.

--- a/typescript/sdk/src/providers/MultiProviderAdapter.ts
+++ b/typescript/sdk/src/providers/MultiProviderAdapter.ts
@@ -27,6 +27,7 @@ import { defaultZKSyncProviderBuilder } from './builders/zksync.js';
 import type { ProviderBuilderFn } from './providerBuilders.js';
 import {
   TransactionFeeEstimate,
+  TransactionFeeEstimateOptions,
   estimateTransactionFee,
 } from './transactionFeeEstimators.js';
 
@@ -199,12 +200,13 @@ export class MultiProviderAdapter<
     transaction,
     sender,
     senderPubKey,
+    ignoreSenderBalance,
   }: {
     chainNameOrId: ChainNameOrId;
     transaction: TypedTransaction;
     sender: Address;
     senderPubKey?: HexString;
-  }): Promise<TransactionFeeEstimate> {
+  } & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
     const provider = this.getProvider(chainNameOrId, transaction.type);
     const chainMetadata = this.getChainMetadata(chainNameOrId);
     return estimateTransactionFee({
@@ -213,6 +215,7 @@ export class MultiProviderAdapter<
       chainMetadata,
       sender,
       senderPubKey,
+      ignoreSenderBalance,
     });
   }
 }

--- a/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/HyperlaneJsonRpcProvider.ts
@@ -135,6 +135,10 @@ export class HyperlaneJsonRpcProvider
         ],
       ];
     }
+    if (method === ProviderMethod.EstimateGas && params?.stateOverride) {
+      const [rpcMethod, rpcParams] = super.prepareRequest(method, params);
+      return [rpcMethod, [...rpcParams, 'latest', params.stateOverride]];
+    }
     return super.prepareRequest(method, params);
   }
 

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -14,8 +14,11 @@ import { BigNumber, providers as EthersV5Providers } from 'ethers';
 import { createPublicClient, custom } from 'viem';
 
 import { ProviderType, type ViemTransaction } from './ProviderType.js';
+import { HyperlaneJsonRpcProvider } from './SmartProvider/HyperlaneJsonRpcProvider.js';
+import { HyperlaneSmartProvider } from './SmartProvider/SmartProvider.js';
 import {
   clearCachedStargateClients,
+  estimateTransactionFeeEthersV5,
   estimateTransactionFeeCosmJsWasm,
   estimateTransactionFeeEthersV5ForGasUnits,
   estimateTransactionFeeSolanaWeb3,
@@ -91,6 +94,101 @@ describe('transactionFeeEstimators', () => {
     });
   });
 
+  it('overrides the Ethers sender balance only when requested', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    }) as EthersV5Providers.JsonRpcProvider;
+    const estimateGas = sandbox
+      .stub(provider, 'estimateGas')
+      .resolves(BigNumber.from(21_000));
+    const send = sandbox.stub(provider, 'send').resolves('0x5208');
+
+    await estimateTransactionFeeEthersV5({
+      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      provider,
+      sender: EVM_ADDRESS,
+    });
+
+    expect(estimateGas.calledOnce).to.equal(true);
+    expect(send.notCalled).to.equal(true);
+    estimateGas.resetHistory();
+
+    const estimate = await estimateTransactionFeeEthersV5({
+      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      provider,
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 21_000n,
+      gasPrice: 2n,
+      fee: 42_000n,
+    });
+    expect(estimateGas.notCalled).to.equal(true);
+    expect(send.calledOnce).to.equal(true);
+    expect(send.firstCall.args).to.deep.equal([
+      'eth_estimateGas',
+      [
+        { from: EVM_ADDRESS, to: EVM_ADDRESS, value: '0x1' },
+        'latest',
+        { [EVM_ADDRESS]: { balance: `0x${'f'.repeat(64)}` } },
+      ],
+    ]);
+  });
+
+  it('routes Ethers balance overrides through the smart provider', async () => {
+    const provider = new HyperlaneSmartProvider(1, [
+      { http: 'http://provider' },
+    ]);
+    const perform = sandbox.stub(provider, 'perform').resolves('0x5208');
+    sandbox.stub(provider, 'getFeeData').resolves({
+      gasPrice: BigNumber.from(1),
+      lastBaseFeePerGas: null,
+      maxFeePerGas: null,
+      maxPriorityFeePerGas: null,
+    });
+
+    await estimateTransactionFeeEthersV5({
+      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      provider,
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+    });
+
+    expect(perform.calledOnce).to.equal(true);
+    expect(perform.firstCall.args[0]).to.equal('estimateGas');
+    expect(perform.firstCall.args[1]).to.deep.equal({
+      transaction: { from: EVM_ADDRESS, to: EVM_ADDRESS, value: '0x1' },
+      stateOverride: {
+        [EVM_ADDRESS]: { balance: `0x${'f'.repeat(64)}` },
+      },
+    });
+  });
+
+  it('serializes Ethers balance overrides for JSON-RPC', () => {
+    const provider = new HyperlaneJsonRpcProvider(
+      { http: 'http://provider' },
+      { chainId: 1, name: 'test' },
+    );
+    const stateOverride = {
+      [EVM_ADDRESS]: { balance: '0xffff' },
+    };
+
+    const [method, params] = provider.prepareRequest('estimateGas', {
+      transaction: { from: EVM_ADDRESS, to: EVM_ADDRESS },
+      stateOverride,
+    });
+
+    expect(method).to.equal('eth_estimateGas');
+    expect(params).to.deep.equal([
+      { from: EVM_ADDRESS, to: EVM_ADDRESS },
+      'latest',
+      stateOverride,
+    ]);
+  });
+
   it('keeps zero-valued Viem fee data as present', async () => {
     const client = createPublicClient({
       transport: custom({
@@ -131,6 +229,51 @@ describe('transactionFeeEstimators', () => {
       gasPrice: 0n,
       fee: 0n,
     });
+  });
+
+  it('overrides the Viem sender balance only when requested', async () => {
+    const client = createPublicClient({
+      transport: custom({
+        request: async () => {
+          throw new Error('Unexpected RPC request');
+        },
+      }),
+    });
+    const estimateGas = sandbox.stub(client, 'estimateGas').resolves(21_000n);
+    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 1n });
+    const transaction = {
+      blockHash: EVM_HASH,
+      blockNumber: 1n,
+      from: EVM_ADDRESS,
+      gas: 21_000n,
+      gasPrice: 1n,
+      hash: EVM_HASH,
+      input: '0x',
+      nonce: 0,
+      r: '0x',
+      s: '0x',
+      to: EVM_ADDRESS,
+      transactionIndex: 0,
+      type: 'legacy',
+      typeHex: '0x0',
+      v: 27n,
+      value: 1n,
+    } satisfies ViemTransaction['transaction'];
+
+    await estimateTransactionFeeViem({
+      transaction: { type: ProviderType.Viem, transaction },
+      provider: { type: ProviderType.Viem, provider: client },
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+    });
+
+    expect(estimateGas.calledOnce).to.equal(true);
+    expect(estimateGas.firstCall.args[0]).to.include({
+      account: EVM_ADDRESS,
+    });
+    expect(estimateGas.firstCall.args[0].stateOverride).to.deep.equal([
+      { address: EVM_ADDRESS, balance: (1n << 256n) - 1n },
+    ]);
   });
 
   function makeProvider(url: string) {
@@ -216,6 +359,38 @@ describe('transactionFeeEstimators', () => {
 
     expect(estimate.fee).to.equal(5_123n);
     expect(getFeeForMessage.calledOnceWithExactly(message)).to.equal(true);
+  });
+
+  it('gets the Solana message fee without simulating when requested', async () => {
+    const sender = Keypair.generate();
+    const transaction = new Transaction({
+      feePayer: sender.publicKey,
+      recentBlockhash: '11111111111111111111111111111111',
+    }).add(
+      SystemProgram.transfer({
+        fromPubkey: sender.publicKey,
+        toPubkey: Keypair.generate().publicKey,
+        lamports: 1,
+      }),
+    );
+    const connection = new Connection('http://localhost:8899');
+    const simulateTransaction = sandbox.stub(connection, 'simulateTransaction');
+    sandbox
+      .stub(connection, 'getFeeForMessage')
+      .resolves({ context: { slot: 1 }, value: 5_000 });
+
+    const estimate = await estimateTransactionFeeSolanaWeb3({
+      transaction: { type: ProviderType.SolanaWeb3, transaction },
+      provider: { type: ProviderType.SolanaWeb3, provider: connection },
+      ignoreSenderBalance: true,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 0n,
+      gasPrice: 0n,
+      fee: 5_000n,
+    });
+    expect(simulateTransaction.notCalled).to.equal(true);
   });
 
   function makeStargateClient(

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -57,7 +57,7 @@ describe('transactionFeeEstimators', () => {
   }: {
     gasPrice: bigint | null;
     maxFeePerGas: bigint | null;
-  }): EthersV5Providers.Provider {
+  }): EthersV5Providers.JsonRpcProvider {
     const provider = new EthersV5Providers.JsonRpcProvider();
     sandbox.stub(provider, 'getFeeData').resolves({
       gasPrice: gasPrice === null ? null : BigNumber.from(gasPrice),
@@ -98,7 +98,7 @@ describe('transactionFeeEstimators', () => {
     const provider = makeEthersFeeProvider({
       gasPrice: 2n,
       maxFeePerGas: null,
-    }) as EthersV5Providers.JsonRpcProvider;
+    });
     const estimateGas = sandbox
       .stub(provider, 'estimateGas')
       .resolves(BigNumber.from(21_000));

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -528,6 +528,8 @@ export function estimateTransactionFee({
     provider.type === ProviderType.Tron
   ) {
     // Tron is EVM-compatible; its typed transaction/provider use EthersV5 underlying types
+    // Tron does not support EVM state overrides. TronJsonRpcProvider.estimateGas
+    // already falls back to a balance-independent energy limit when estimation fails.
     sender = convertToProtocolAddress(sender, ProtocolType.Ethereum);
     return estimateTransactionFeeEthersV5({
       transaction: transaction.transaction,

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -6,9 +6,11 @@ import { Registry } from '@cosmjs/proto-signing';
 import { defaultRegistryTypes } from '@cosmjs/stargate';
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx.js';
 import { VersionedTransaction } from '@solana/web3.js';
-import type {
+import {
+  BigNumber,
   providers as EV5Providers,
-  PopulatedTransaction as EV5Transaction,
+  type PopulatedTransaction as EV5Transaction,
+  utils as EthersV5Utils,
 } from 'ethers';
 
 import {
@@ -50,6 +52,19 @@ import {
   ViemProvider,
   ViemTransaction,
 } from './ProviderType.js';
+import { HyperlaneSmartProvider } from './SmartProvider/SmartProvider.js';
+import { ProviderMethod } from './SmartProvider/ProviderMethods.js';
+
+const EVM_MAX_BALANCE = (1n << 256n) - 1n;
+const EVM_MAX_BALANCE_HEX = `0x${'f'.repeat(64)}`;
+
+export interface TransactionFeeEstimateOptions {
+  /**
+   * Estimates the fee without requiring the sender's native balance to fund
+   * both the transaction value and its network fee. Defaults to false.
+   */
+  ignoreSenderBalance?: boolean;
+}
 
 export interface TransactionFeeEstimate {
   gasUnits: number | bigint;
@@ -71,19 +86,65 @@ export async function estimateTransactionFeeEthersV5({
   transaction,
   provider,
   sender,
+  ignoreSenderBalance,
 }: {
   transaction: EV5Transaction;
   provider: EV5Providers.Provider;
   sender: Address;
-}): Promise<TransactionFeeEstimate> {
-  const gasUnits = await provider.estimateGas({
-    ...transaction,
-    from: sender,
-  });
+} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+  const gasUnits = ignoreSenderBalance
+    ? await estimateGasEthersV5WithBalanceOverride({
+        transaction,
+        provider,
+        sender,
+      })
+    : await provider.estimateGas({
+        ...transaction,
+        from: sender,
+      });
   return estimateTransactionFeeEthersV5ForGasUnits({
     provider,
     gasUnits: BigInt(gasUnits.toString()),
   });
+}
+
+async function estimateGasEthersV5WithBalanceOverride({
+  transaction,
+  provider,
+  sender,
+}: {
+  transaction: EV5Transaction;
+  provider: EV5Providers.Provider;
+  sender: Address;
+}): Promise<BigNumber> {
+  const resolvedTransaction = EV5Providers.JsonRpcProvider.hexlifyTransaction(
+    await EthersV5Utils.resolveProperties({ ...transaction, from: sender }),
+    { from: true },
+  );
+  const stateOverride = { [sender]: { balance: EVM_MAX_BALANCE_HEX } };
+
+  if (provider instanceof HyperlaneSmartProvider) {
+    return BigNumber.from(
+      await provider.perform(ProviderMethod.EstimateGas, {
+        transaction: resolvedTransaction,
+        stateOverride,
+      }),
+    );
+  }
+
+  if ('send' in provider && typeof provider.send === 'function') {
+    return BigNumber.from(
+      await provider.send('eth_estimateGas', [
+        resolvedTransaction,
+        'latest',
+        stateOverride,
+      ]),
+    );
+  }
+
+  throw new Error(
+    'Ignoring sender balance requires a JSON-RPC Ethers provider',
+  );
 }
 
 // Separating out inner function to allow WarpCore to reuse logic
@@ -110,15 +171,21 @@ export async function estimateTransactionFeeViem({
   transaction,
   provider,
   sender,
+  ignoreSenderBalance,
 }: {
   transaction: ViemTransaction;
   provider: ViemProvider;
   sender: Address;
-}): Promise<TransactionFeeEstimate> {
+} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
   const gasUnits = await provider.provider.estimateGas({
     ...transaction.transaction,
     blockNumber: undefined,
     account: sender as `0x${string}`,
+    ...(ignoreSenderBalance && {
+      stateOverride: [
+        { address: sender as `0x${string}`, balance: EVM_MAX_BALANCE },
+      ],
+    }),
   } as any); // Cast to silence overly-protective type enforcement from viem here
   const feeData = await provider.provider.estimateFeesPerGas();
   return computeEvmTxFee(gasUnits, feeData.gasPrice, feeData.maxFeePerGas);
@@ -147,10 +214,11 @@ function computeEvmTxFee(
 export async function estimateTransactionFeeSolanaWeb3({
   provider,
   transaction,
+  ignoreSenderBalance,
 }: {
   transaction: SolanaWeb3Transaction;
   provider: SolanaWeb3Provider;
-}): Promise<TransactionFeeEstimate> {
+} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
   const connection = provider.provider;
   const inner = transaction.transaction;
   const message =
@@ -161,16 +229,21 @@ export async function estimateTransactionFeeSolanaWeb3({
   // has separate overloads for legacy `Transaction` and `VersionedTransaction`
   // and the union satisfies neither, so we branch purely to narrow `inner` to a
   // concrete type and let overload resolution pick the matching signature.
-  const simulation =
-    inner instanceof VersionedTransaction
-      ? connection.simulateTransaction(inner)
-      : connection.simulateTransaction(inner);
-  const [{ value }, feeResponse] = await Promise.all([
-    simulation,
+  const [simulation, feeResponse] = await Promise.all([
+    ignoreSenderBalance
+      ? undefined
+      : inner instanceof VersionedTransaction
+        ? connection.simulateTransaction(inner)
+        : connection.simulateTransaction(inner),
     connection.getFeeForMessage(message),
   ]);
-  assert(!value.err, `Solana gas estimation failed: ${JSON.stringify(value)}`);
-  const gasUnits = BigInt(value.unitsConsumed ?? 0);
+  if (simulation) {
+    assert(
+      !simulation.value.err,
+      `Solana gas estimation failed: ${JSON.stringify(simulation.value)}`,
+    );
+  }
+  const gasUnits = BigInt(simulation?.value.unitsConsumed ?? 0);
   assert(
     feeResponse.value !== null,
     'Solana transaction fee estimation failed',
@@ -347,13 +420,14 @@ export function estimateTransactionFee({
   chainMetadata,
   sender,
   senderPubKey,
+  ignoreSenderBalance,
 }: {
   transaction: TypedTransaction;
   provider: TypedProvider;
   chainMetadata: ChainMetadata;
   sender: Address;
   senderPubKey?: HexString;
-}): Promise<TransactionFeeEstimate> {
+} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
   if (
     transaction.type === ProviderType.EthersV5 &&
     provider.type === ProviderType.EthersV5
@@ -362,17 +436,27 @@ export function estimateTransactionFee({
       transaction: transaction.transaction,
       provider: provider.provider,
       sender,
+      ignoreSenderBalance,
     });
   } else if (
     transaction.type === ProviderType.Viem &&
     provider.type === ProviderType.Viem
   ) {
-    return estimateTransactionFeeViem({ transaction, provider, sender });
+    return estimateTransactionFeeViem({
+      transaction,
+      provider,
+      sender,
+      ignoreSenderBalance,
+    });
   } else if (
     transaction.type === ProviderType.SolanaWeb3 &&
     provider.type === ProviderType.SolanaWeb3
   ) {
-    return estimateTransactionFeeSolanaWeb3({ transaction, provider });
+    return estimateTransactionFeeSolanaWeb3({
+      transaction,
+      provider,
+      ignoreSenderBalance,
+    });
   } else if (
     transaction.type === ProviderType.CosmJs &&
     provider.type === ProviderType.CosmJs


### PR DESCRIPTION
### Description

Adds an optional `ignoreSenderBalance` mode to `MultiProviderAdapter.estimateTransactionFee` for native max-amount estimation.

- EVM estimates with an ephemeral sender balance state override.
- Solana reads the message fee without balance-sensitive simulation.
- Existing behavior remains the default; other protocol estimators are unchanged.

### Drive-by changes

None.

### Related issues

Supports [universal-router-engine#92](https://github.com/hyperlane-xyz/universal-router-engine/pull/92).

### Backward compatibility

Yes. The option defaults to `false`.

### Testing

Unit tests, SDK format/lint/typecheck/build, and monorepo build.
