### PR TITLE
feat(sdk): integrate Wormhole hook and ISM

### DIFF
--- a/.changeset/wormhole-hook-ism.md
+++ b/.changeset/wormhole-hook-ism.md
@@ -1,0 +1,16 @@
+---
+'@hyperlane-xyz/core': minor
+'@hyperlane-xyz/sdk': minor
+'@hyperlane-xyz/relayer': minor
+'@hyperlane-xyz/cli': patch
+---
+
+Wormhole hook/ISM routers were added:
+
+- `WormholeExecutorHookIsm` and `WormholeVaaHookIsm` were implemented as combined hook/ISM routers over a shared `AbstractWormholeHookIsm` base. One contract was deployed per chain and enrolled every remote router by Hyperlane domain, so the same local address served as an application's outbound hook and inbound ISM.
+- Both published a fixed 224-byte `WormholeMessage` envelope through Wormhole Core, copied the Hyperlane nonce into the signed Wormhole nonce, and bound each VAA to an exact origin domain, Wormhole chain ID, enrolled router address, consistency level, local destination, and message ID.
+- `WormholeExecutorHookIsm` bought Executor delivery and preauthorized the message through a permissionless `executeVAAv1` callback, verifying later with empty metadata. `WormholeVaaHookIsm` obtained the VAA through the existing CCIP-read metadata path and verified it inside `Mailbox.process`.
+- `IPostDispatchHook.HookTypes` gained an appended `WORMHOLE` member.
+- The SDK gained `EvmWormholeHookIsmModule`, paired hook/ISM schemas, recursive config validation, and readers. `warp deploy` and `warp apply` predeployed or reconciled a full mesh, then replaced both leaves with the same local address before generic Warp processing.
+- The relayer gained empty metadata for the Executor variant and CCIP-read metadata for the direct-VAA variant. CCIP-read POST requests included `origin_tx_hash` so a lookup service could find the origin event without the Explorer.
+- `WormholeExecutorHookIsm` requested Executor delivery with the callback gas limit stored for the destination at enrollment. Hook metadata did not override it, because `StandardHookMetadata.gasLimit` carries the destination `handle` budget priced by the IGP rather than the gas needed to verify a VAA.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,9 @@ importers:
       '@types/chai':
         specifier: 'catalog:'
         version: 4.3.20
+      '@types/chai-as-promised':
+        specifier: 'catalog:'
+        version: 8.0.2
       '@types/cors':
         specifier: ^2
         version: 2.8.19
@@ -802,6 +805,9 @@ importers:
       chai:
         specifier: 'catalog:'
         version: 4.5.0
+      chai-as-promised:
+        specifier: 'catalog:'
+        version: 8.0.2(chai@4.5.0)
       mocha:
         specifier: 'catalog:'
         version: 11.8.0

--- a/typescript/ccip-server/.env.example
+++ b/typescript/ccip-server/.env.example
@@ -4,3 +4,16 @@ SERVER_PORT=3000
 SERVER_BASE_URL=http://localhost:3000
 # If you want to use a different registry
 # REGISTRY_URI=/Users/nambrot/devstuff/hyperlane-registry
+
+# Wormhole CCIP-read module (ENABLED_MODULES=wormhole)
+# Redundant Wormholescan-compatible endpoints, tried in order.
+WORMHOLE_VAA_URLS=https://api.wormholescan.io
+# Per-chain deployment facts: official Core proxy, Wormhole chain ID,
+# and the enrolled Hyperlane router.
+# Replace router placeholders with the deployed combined hook/ISM addresses.
+# WORMHOLE_ROUTES={"ethereum":{"core":"0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B","wormholeChainId":2,"router":"0x1111111111111111111111111111111111111111"},"base":{"core":"0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6","wormholeChainId":30,"router":"0x2222222222222222222222222222222222222222"}}
+# WORMHOLE_VAA_TIMEOUT_MS=10000
+# WORMHOLE_VAA_MAX_BYTES=65536
+# WORMHOLE_VAA_CACHE_ENTRIES=10000
+# WORMHOLE_VAA_MAX_ATTEMPTS=4
+# WORMHOLE_VAA_RETRY_DELAY_MS=1000

--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -6,7 +6,10 @@
     "./tests/**/cctpMessageMatcher.test.ts",
     "./tests/**/CCTPService.test.ts",
     "./tests/**/AttestationPending.test.ts",
-    "./tests/**/moduleRegistry.test.ts"
+    "./tests/**/moduleRegistry.test.ts",
+    "./tests/**/WormholeVaaService.test.ts",
+    "./tests/**/WormholeVaaFetcher.test.ts",
+    "./tests/**/wormholeVaaMatcher.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/package.json
+++ b/typescript/ccip-server/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@hyperlane-xyz/tsconfig": "workspace:^",
     "@types/chai": "catalog:",
+    "@types/chai-as-promised": "catalog:",
     "@types/cors": "^2",
     "@types/express": "^4.17.1",
     "@types/mocha": "catalog:",
@@ -60,6 +61,7 @@
     "@types/sinon": "catalog:",
     "@vercel/ncc": "catalog:",
     "chai": "catalog:",
+    "chai-as-promised": "catalog:",
     "mocha": "catalog:",
     "nodemon": "^3.0.3",
     "pino-pretty": "catalog:",

--- a/typescript/ccip-server/src/moduleRegistry.ts
+++ b/typescript/ccip-server/src/moduleRegistry.ts
@@ -21,4 +21,11 @@ export const moduleRegistry: Record<string, ServiceFactory> = {
       return OPStackService.create(name);
     },
   },
+  wormhole: {
+    async create(name) {
+      const { WormholeVaaService } =
+        await import('./services/WormholeVaaService.js');
+      return WormholeVaaService.create(name);
+    },
+  },
 };

--- a/typescript/ccip-server/src/services/WormholeVaaFetcher.ts
+++ b/typescript/ccip-server/src/services/WormholeVaaFetcher.ts
@@ -1,0 +1,236 @@
+import { ethers } from 'ethers';
+import { Logger } from 'pino';
+
+import { assert, sleep } from '@hyperlane-xyz/utils';
+
+import {
+  PrometheusMetrics,
+  UnhandledErrorReason,
+} from '../utils/prometheus.js';
+
+import { ParsedVaa, formatVaaId, parseVaa } from './wormholeVaaMatcher.js';
+
+export interface WormholeVaaFetcherConfig {
+  /** Redundant Wormholescan-compatible base URLs, tried in order. */
+  urls: Array<string>;
+  timeoutMs: number;
+  maxResponseBytes: number;
+  maxCacheEntries: number;
+  maxAttempts: number;
+  baseRetryDelayMs: number;
+}
+
+interface CacheEntry {
+  encodedVaa: string;
+  guardianSetIndex: number;
+}
+
+/** Signals that Guardians have not signed yet; the relayer should retry later. */
+export class VaaPendingError extends Error {
+  constructor(vaaId: string) {
+    super(`VAA ${vaaId} is pending Guardian signatures`);
+    this.name = 'VaaPendingError';
+  }
+}
+
+/**
+ * Fetches signed VAAs from redundant public endpoints.
+ *
+ * The upstream is untrusted: only the decoded VAA bytes are used, never the
+ * surrounding response metadata. A VAA ID is immutable once signed, so
+ * successful results are held in a bounded LRU cache alongside the
+ * Guardian-set index they were signed under.
+ */
+export class WormholeVaaFetcher {
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(
+    private readonly serviceName: string,
+    private readonly config: WormholeVaaFetcherConfig,
+  ) {
+    assert(config.urls.length > 0, 'At least one VAA endpoint is required');
+    assert(
+      config.maxCacheEntries > 0,
+      'VAA cache must allow at least one entry',
+    );
+  }
+
+  async fetchVaa(
+    emitterChainId: number,
+    emitterAddress: string,
+    sequence: string,
+    logger: Logger,
+  ): Promise<{ encodedVaa: string; vaa: ParsedVaa }> {
+    const vaaId = formatVaaId(emitterChainId, emitterAddress, sequence);
+
+    const cached = this.cache.get(vaaId);
+    if (cached) {
+      // Map preserves insertion order. Reinsert to mark this entry as newest.
+      this.cache.delete(vaaId);
+      this.cache.set(vaaId, cached);
+      logger.info({ vaaId }, 'Serving VAA from immutable cache');
+      return {
+        encodedVaa: cached.encodedVaa,
+        vaa: parseVaa(cached.encodedVaa),
+      };
+    }
+
+    let lastPending: VaaPendingError | undefined;
+    for (let attempt = 0; attempt < this.config.maxAttempts; attempt++) {
+      for (const url of this.config.urls) {
+        try {
+          const encodedVaa = await this.fetchOnce(url, vaaId, logger);
+          const vaa = parseVaa(encodedVaa);
+          this.cache.set(vaaId, {
+            encodedVaa,
+            guardianSetIndex: vaa.guardianSetIndex,
+          });
+          this.evictOldestCacheEntries();
+          logger.info(
+            { vaaId, guardianSetIndex: vaa.guardianSetIndex, attempt },
+            'Fetched signed VAA',
+          );
+          return { encodedVaa, vaa };
+        } catch (error) {
+          if (error instanceof VaaPendingError) {
+            lastPending = error;
+            continue;
+          }
+          // Endpoint-level failure: try the next endpoint, then the next attempt.
+          logger.warn(
+            { vaaId, url, error: errorMessage(error) },
+            'VAA endpoint failed',
+          );
+        }
+      }
+
+      if (attempt + 1 < this.config.maxAttempts) {
+        await sleep(this.backoffMs(attempt));
+      }
+    }
+
+    PrometheusMetrics.logUnhandledError(
+      this.serviceName,
+      UnhandledErrorReason.WORMHOLE_VAA_UNAVAILABLE,
+    );
+    if (lastPending) throw lastPending;
+    throw new Error(`Unable to fetch VAA ${vaaId} from any endpoint`);
+  }
+
+  /** Exponential backoff with jitter, so retries do not synchronize. */
+  private backoffMs(attempt: number): number {
+    const base = this.config.baseRetryDelayMs * 2 ** attempt;
+    return base + Math.floor(Math.random() * this.config.baseRetryDelayMs);
+  }
+
+  private evictOldestCacheEntries(): void {
+    while (this.cache.size > this.config.maxCacheEntries) {
+      const oldest = this.cache.keys().next().value;
+      assert(oldest !== undefined, 'Non-empty cache must have an oldest entry');
+      this.cache.delete(oldest);
+    }
+  }
+
+  private async fetchOnce(
+    baseUrl: string,
+    vaaId: string,
+    logger: Logger,
+  ): Promise<string> {
+    const url = `${baseUrl.replace(/\/$/, '')}/api/v1/vaas/${vaaId}`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(this.config.timeoutMs),
+      headers: { accept: 'application/json' },
+    });
+
+    if (response.status === 404) {
+      PrometheusMetrics.logUnhandledError(
+        this.serviceName,
+        UnhandledErrorReason.WORMHOLE_VAA_PENDING,
+      );
+      throw new VaaPendingError(vaaId);
+    }
+    assert(
+      response.ok,
+      `VAA endpoint returned ${response.status} for ${vaaId}`,
+    );
+
+    const body = await readBoundedResponseBody(
+      response,
+      this.config.maxResponseBytes,
+      vaaId,
+    );
+
+    const parsed: unknown = JSON.parse(body);
+    const encoded = extractVaaField(parsed);
+    if (encoded === undefined) {
+      // A well-formed response with no VAA yet is a pending attestation, not a
+      // permanent failure.
+      logger.info({ vaaId, url }, 'Endpoint has no VAA yet');
+      throw new VaaPendingError(vaaId);
+    }
+
+    return decodeBase64OrHex(encoded);
+  }
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maxResponseBytes: number,
+  vaaId: string,
+): Promise<string> {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength !== null) {
+    const declaredLength = Number(contentLength);
+    assert(
+      Number.isSafeInteger(declaredLength) && declaredLength >= 0,
+      `VAA response for ${vaaId} has invalid content-length`,
+    );
+    assert(
+      declaredLength <= maxResponseBytes,
+      `VAA response for ${vaaId} exceeds ${maxResponseBytes} bytes`,
+    );
+  }
+
+  assert(response.body, `VAA response for ${vaaId} has no body`);
+  const reader = response.body.getReader();
+  const chunks: Array<Uint8Array> = [];
+  let receivedBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      receivedBytes += value.byteLength;
+      assert(
+        receivedBytes <= maxResponseBytes,
+        `VAA response for ${vaaId} exceeds ${maxResponseBytes} bytes`,
+      );
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel(error).catch(() => undefined);
+    throw error;
+  }
+
+  return Buffer.concat(chunks, receivedBytes).toString('utf8');
+}
+
+function extractVaaField(body: unknown): string | undefined {
+  if (typeof body !== 'object' || body === null) return undefined;
+  const data = 'data' in body ? body.data : undefined;
+  if (typeof data !== 'object' || data === null) return undefined;
+  const vaa = 'vaa' in data ? data.vaa : undefined;
+  return typeof vaa === 'string' && vaa.length > 0 ? vaa : undefined;
+}
+
+/** Wormholescan returns base64; accept hex too so other mirrors work. */
+export function decodeBase64OrHex(value: string): string {
+  if (ethers.utils.isHexString(value)) return value;
+  const bytes = Buffer.from(value, 'base64');
+  assert(bytes.length > 0, 'Endpoint returned an empty VAA');
+  return ethers.utils.hexlify(bytes);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/typescript/ccip-server/src/services/WormholeVaaService.ts
+++ b/typescript/ccip-server/src/services/WormholeVaaService.ts
@@ -1,0 +1,325 @@
+import { ethers } from 'ethers';
+import { Router } from 'express';
+import { Logger } from 'pino';
+import { z } from 'zod';
+
+import { IWormholeVaaService__factory } from '@hyperlane-xyz/core';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert, parseMessage } from '@hyperlane-xyz/utils';
+
+import { createAbiHandler } from '../utils/abiHandler.js';
+import {
+  PrometheusMetrics,
+  UnhandledErrorReason,
+} from '../utils/prometheus.js';
+
+import {
+  BaseService,
+  REGISTRY_URI_SCHEMA,
+  ServiceConfigWithMultiProvider,
+} from './BaseService.js';
+import { HyperlaneService } from './HyperlaneService.js';
+import { WormholeVaaFetcher } from './WormholeVaaFetcher.js';
+import {
+  assertVaaMatchesPublication,
+  findMatchingWormholePublication,
+} from './wormholeVaaMatcher.js';
+
+/**
+ * Per-chain Wormhole route data.
+ *
+ * These are deployment facts, not defaults: the official Core proxy for the
+ * environment, that chain's Wormhole chain ID, and the enrolled Hyperlane
+ * router. Supplying them explicitly is what lets the service reject a lookalike
+ * publication instead of scanning every log in a receipt.
+ */
+export const WormholeChainConfigSchema = z.object({
+  core: z
+    .string()
+    .refine(ethers.utils.isAddress, 'core must be an address')
+    .refine(
+      (address) => address !== ethers.constants.AddressZero,
+      'core must not be the zero address',
+    ),
+  wormholeChainId: z.number().int().positive().max(65_535),
+  router: z
+    .string()
+    .refine(ethers.utils.isAddress, 'router must be an address')
+    .refine(
+      (address) => address !== ethers.constants.AddressZero,
+      'router must not be the zero address',
+    ),
+});
+
+export type WormholeChainConfig = z.infer<typeof WormholeChainConfigSchema>;
+
+export const WormholeRoutesSchema = z.record(
+  z.string(),
+  WormholeChainConfigSchema,
+);
+
+const CommaSeparatedUrls = z
+  .string()
+  .transform((value) => value.split(',').map((url) => url.trim()))
+  .pipe(z.array(z.string().url()).min(1));
+
+const EnvSchema = z.object({
+  HYPERLANE_EXPLORER_URL: z.string().url(),
+  REGISTRY_URI: REGISTRY_URI_SCHEMA,
+  /** Comma-separated Wormholescan-compatible base URLs. */
+  WORMHOLE_VAA_URLS: CommaSeparatedUrls,
+  /** JSON object keyed by chain name; see `WormholeChainConfigSchema`. */
+  WORMHOLE_ROUTES: z
+    .string()
+    .transform((value, ctx) => {
+      try {
+        return JSON.parse(value);
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'WORMHOLE_ROUTES must be valid JSON',
+        });
+        return z.NEVER;
+      }
+    })
+    .pipe(WormholeRoutesSchema),
+  WORMHOLE_VAA_TIMEOUT_MS: z.coerce.number().int().positive().default(10_000),
+  WORMHOLE_VAA_MAX_BYTES: z.coerce.number().int().positive().default(65_536),
+  WORMHOLE_VAA_CACHE_ENTRIES: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(10_000),
+  WORMHOLE_VAA_MAX_ATTEMPTS: z.coerce.number().int().positive().default(4),
+  WORMHOLE_VAA_RETRY_DELAY_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(1_000),
+});
+
+/** The one `HyperlaneService` capability this service needs. */
+export interface OriginTransactionResolver {
+  getOriginTransactionHashByMessageId(
+    id: string,
+    logger: Logger,
+  ): Promise<string>;
+}
+
+export interface WormholeVaaServiceConfig extends ServiceConfigWithMultiProvider {
+  routes: Record<string, WormholeChainConfig>;
+  vaaFetcher: Pick<WormholeVaaFetcher, 'fetchVaa'>;
+  hyperlaneService: OriginTransactionResolver;
+}
+
+/**
+ * CCIP-read service resolving the Wormhole VAA that authenticates a Hyperlane
+ * message for `WormholeVaaHookIsm`.
+ *
+ * The service is untrusted transport. It cannot forge Guardian signatures, and
+ * destination Core re-verifies everything it returns. Its job is availability:
+ * find the one publication that belongs to this message, fetch its VAA, and
+ * re-check the VAA against that publication before answering.
+ */
+export class WormholeVaaService extends BaseService {
+  public router: Router;
+
+  private readonly multiProvider: MultiProvider;
+  private readonly routes: Record<string, WormholeChainConfig>;
+  private readonly vaaFetcher: Pick<WormholeVaaFetcher, 'fetchVaa'>;
+  private readonly hyperlaneService: OriginTransactionResolver;
+
+  static async create(serviceName: string): Promise<WormholeVaaService> {
+    const env = EnvSchema.parse(process.env);
+    const multiProvider = await BaseService.getMultiProvider(env.REGISTRY_URI);
+
+    return new WormholeVaaService({
+      serviceName,
+      multiProvider,
+      routes: env.WORMHOLE_ROUTES,
+      vaaFetcher: new WormholeVaaFetcher(serviceName, {
+        urls: env.WORMHOLE_VAA_URLS,
+        timeoutMs: env.WORMHOLE_VAA_TIMEOUT_MS,
+        maxResponseBytes: env.WORMHOLE_VAA_MAX_BYTES,
+        maxCacheEntries: env.WORMHOLE_VAA_CACHE_ENTRIES,
+        maxAttempts: env.WORMHOLE_VAA_MAX_ATTEMPTS,
+        baseRetryDelayMs: env.WORMHOLE_VAA_RETRY_DELAY_MS,
+      }),
+      hyperlaneService: new HyperlaneService(
+        serviceName,
+        env.HYPERLANE_EXPLORER_URL,
+      ),
+    });
+  }
+
+  constructor(config: WormholeVaaServiceConfig) {
+    super(config);
+    this.multiProvider = config.multiProvider;
+    this.routes = config.routes;
+    this.vaaFetcher = config.vaaFetcher;
+    this.hyperlaneService = config.hyperlaneService;
+
+    this.router = Router();
+
+    // CCIP-read spec: GET /getWormholeVaa/:sender/:callData.json
+    this.router.get(
+      '/getWormholeVaa/:sender/:callData.json',
+      createAbiHandler(
+        IWormholeVaaService__factory,
+        'getWormholeVaa',
+        (message: string, logger: Logger) =>
+          this.getWormholeVaa(message, undefined, logger),
+      ),
+    );
+
+    // CCIP-read spec: POST /getWormholeVaa
+    this.router.post('/getWormholeVaa', async (req, res) => {
+      const rawTxHash = req.body?.origin_tx_hash;
+      const originTxHash =
+        typeof rawTxHash === 'string' && ethers.utils.isHexString(rawTxHash, 32)
+          ? rawTxHash
+          : undefined;
+      return createAbiHandler(
+        IWormholeVaaService__factory,
+        'getWormholeVaa',
+        (message: string, logger: Logger) =>
+          this.getWormholeVaa(message, originTxHash, logger),
+      )(req, res);
+    });
+  }
+
+  async getWormholeVaa(
+    message: string,
+    originTxHash: string | undefined,
+    logger: Logger,
+  ): Promise<string> {
+    const log = this.addLoggerServiceContext(logger);
+
+    const messageId = ethers.utils.keccak256(message);
+    const parsed = parseMessage(message);
+    log.info(
+      {
+        messageId,
+        origin: parsed.origin,
+        destination: parsed.destination,
+        nonce: parsed.nonce,
+      },
+      'Processing Wormhole VAA request',
+    );
+
+    const origin = this.routeFor(parsed.origin, log);
+    const destination = this.routeFor(parsed.destination, log);
+
+    const txHash = await this.resolveOriginTxHash(originTxHash, messageId, log);
+
+    const receipt = await this.multiProvider
+      .getProvider(parsed.origin)
+      .getTransactionReceipt(txHash);
+    assert(receipt, `No receipt found for origin transaction ${txHash}`);
+
+    const publication = this.findPublication(receipt.logs, {
+      coreAddress: origin.core,
+      originRouter: ethers.utils.hexZeroPad(origin.router, 32),
+      destinationRouter: ethers.utils.hexZeroPad(destination.router, 32),
+      messageId,
+      originDomain: parsed.origin,
+      destinationDomain: parsed.destination,
+      nonce: parsed.nonce,
+    });
+
+    const { encodedVaa, vaa } = await this.vaaFetcher.fetchVaa(
+      origin.wormholeChainId,
+      ethers.utils.hexZeroPad(origin.router, 32),
+      publication.sequence,
+      log,
+    );
+
+    // Never trust the endpoint's own metadata; re-check the decoded VAA.
+    try {
+      assertVaaMatchesPublication(vaa, publication, {
+        emitterChainId: origin.wormholeChainId,
+        originRouter: ethers.utils.hexZeroPad(origin.router, 32),
+      });
+    } catch (error) {
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.WORMHOLE_VAA_MISMATCH,
+      );
+      throw error;
+    }
+
+    log.info(
+      {
+        messageId,
+        sequence: publication.sequence,
+        guardianSetIndex: vaa.guardianSetIndex,
+        vaaBytes: ethers.utils.hexDataLength(encodedVaa),
+      },
+      'Resolved Wormhole VAA',
+    );
+
+    // `createAbiHandler` ABI-encodes this single `bytes` return, producing
+    // exactly the metadata `WormholeVaaHookIsm.verify` decodes.
+    return encodedVaa;
+  }
+
+  private routeFor(domain: number, logger: Logger): WormholeChainConfig {
+    const chainName = this.multiProvider.tryGetChainName(domain);
+    const route = chainName ? this.routes[chainName] : undefined;
+    if (!route) {
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.WORMHOLE_ROUTE_NOT_CONFIGURED,
+      );
+      logger.error({ domain, chainName }, 'No Wormhole route configured');
+      throw new Error(`No Wormhole route configured for domain ${domain}`);
+    }
+    return route;
+  }
+
+  private findPublication(
+    logs: ReadonlyArray<{
+      address: string;
+      topics: Array<string>;
+      data: string;
+    }>,
+    query: Parameters<typeof findMatchingWormholePublication>[1],
+  ) {
+    try {
+      return findMatchingWormholePublication(logs, query);
+    } catch (error) {
+      const ambiguous =
+        error instanceof Error && error.message.includes('Ambiguous');
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        ambiguous
+          ? UnhandledErrorReason.WORMHOLE_PUBLICATION_AMBIGUOUS
+          : UnhandledErrorReason.WORMHOLE_PUBLICATION_NOT_FOUND,
+      );
+      throw error;
+    }
+  }
+
+  private async resolveOriginTxHash(
+    originTxHash: string | undefined,
+    messageId: string,
+    logger: Logger,
+  ): Promise<string> {
+    if (originTxHash) {
+      logger.info({ originTxHash, messageId }, 'Using tx hash from relayer');
+      return originTxHash;
+    }
+
+    logger.info(
+      { messageId },
+      'No tx hash from relayer, falling back to Explorer lookup',
+    );
+    const txHash =
+      await this.hyperlaneService.getOriginTransactionHashByMessageId(
+        messageId,
+        logger,
+      );
+    assert(txHash, `Unable to resolve origin transaction for ${messageId}`);
+    return txHash;
+  }
+}

--- a/typescript/ccip-server/src/services/wormholeVaaMatcher.ts
+++ b/typescript/ccip-server/src/services/wormholeVaaMatcher.ts
@@ -1,0 +1,298 @@
+import { ethers } from 'ethers';
+
+import { assert } from '@hyperlane-xyz/utils';
+
+/**
+ * Wire helpers for the Wormhole hook/ISM routers.
+ *
+ * Everything here is pure: payload encoding, receipt-log disambiguation, and
+ * VAA parsing. The CCIP-read service is untrusted transport, so each of these
+ * checks is re-applied by `AbstractWormholeHookIsm` on chain. They exist here so
+ * the service fails fast and loudly instead of returning a VAA the destination
+ * would reject.
+ */
+
+/** `bytes4(keccak256("HYPERLANE_WORMHOLE"))`, matching `WormholeMessage.MAGIC`. */
+export const WORMHOLE_PAYLOAD_MAGIC = ethers.utils.hexDataSlice(
+  ethers.utils.id('HYPERLANE_WORMHOLE'),
+  0,
+  4,
+);
+
+export const WORMHOLE_PAYLOAD_VERSION = 1;
+
+/** `abi.encode` of seven static fields. */
+export const WORMHOLE_PAYLOAD_LENGTH = 32 * 7;
+
+const PAYLOAD_ABI = [
+  'tuple(bytes4 magic, uint8 version, uint32 originDomain, uint32 destinationDomain, bytes32 destinationRouter, bytes32 messageId, uint32 nonce)',
+];
+
+/** Wormhole Core's publication event, used to locate the emitted payload. */
+export const LOG_MESSAGE_PUBLISHED_ABI = [
+  'event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel)',
+];
+
+export interface WormholePayload {
+  magic: string;
+  version: number;
+  originDomain: number;
+  destinationDomain: number;
+  destinationRouter: string;
+  messageId: string;
+  nonce: number;
+}
+
+export interface WormholePublication {
+  sender: string;
+  sequence: string;
+  nonce: number;
+  payload: string;
+  consistencyLevel: number;
+  payloadFields: WormholePayload;
+}
+
+export interface ParsedVaa {
+  version: number;
+  guardianSetIndex: number;
+  signatureCount: number;
+  timestamp: number;
+  nonce: number;
+  emitterChainId: number;
+  emitterAddress: string;
+  sequence: string;
+  consistencyLevel: number;
+  payload: string;
+}
+
+export function encodeWormholePayload(payload: WormholePayload): string {
+  return ethers.utils.defaultAbiCoder.encode(PAYLOAD_ABI, [
+    [
+      payload.magic,
+      payload.version,
+      payload.originDomain,
+      payload.destinationDomain,
+      payload.destinationRouter,
+      payload.messageId,
+      payload.nonce,
+    ],
+  ]);
+}
+
+export function decodeWormholePayload(payload: string): WormholePayload {
+  assert(
+    ethers.utils.hexDataLength(payload) === WORMHOLE_PAYLOAD_LENGTH,
+    `Wormhole payload must be ${WORMHOLE_PAYLOAD_LENGTH} bytes`,
+  );
+  const [decoded] = ethers.utils.defaultAbiCoder.decode(PAYLOAD_ABI, payload);
+  assert(
+    decoded.magic === WORMHOLE_PAYLOAD_MAGIC,
+    'Wormhole payload magic mismatch',
+  );
+  assert(
+    decoded.version === WORMHOLE_PAYLOAD_VERSION,
+    `Unsupported Wormhole payload version ${decoded.version}`,
+  );
+  return {
+    magic: decoded.magic,
+    version: decoded.version,
+    originDomain: decoded.originDomain,
+    destinationDomain: decoded.destinationDomain,
+    destinationRouter: decoded.destinationRouter,
+    messageId: decoded.messageId,
+    nonce: decoded.nonce,
+  };
+}
+
+export interface PublicationQuery {
+  /** Official Core proxy for the origin chain. Only its logs are inspected. */
+  coreAddress: string;
+  /** Enrolled origin router, as a universal `bytes32`. */
+  originRouter: string;
+  destinationRouter: string;
+  messageId: string;
+  originDomain: number;
+  destinationDomain: number;
+  nonce: number;
+}
+
+/**
+ * Finds the single Core publication in `logs` that belongs to this Hyperlane
+ * message.
+ *
+ * Logs from any address other than the configured Core are ignored outright, so
+ * a lookalike event cannot be substituted. Zero and multiple matches are both
+ * errors: the destination binds one exact VAA, so an ambiguous receipt must not
+ * resolve arbitrarily.
+ */
+export function findMatchingWormholePublication(
+  logs: ReadonlyArray<{ address: string; topics: Array<string>; data: string }>,
+  query: PublicationQuery,
+): WormholePublication {
+  const iface = new ethers.utils.Interface(LOG_MESSAGE_PUBLISHED_ABI);
+  const core = query.coreAddress.toLowerCase();
+  const matches: Array<WormholePublication> = [];
+
+  for (const log of logs) {
+    if (log.address.toLowerCase() !== core) continue;
+
+    let parsed;
+    try {
+      parsed = iface.parseLog(log);
+    } catch {
+      // A non-publication event from Core; not an error.
+      continue;
+    }
+    if (parsed.name !== 'LogMessagePublished') continue;
+
+    if (
+      ethers.utils.hexZeroPad(parsed.args.sender, 32).toLowerCase() !==
+      query.originRouter.toLowerCase()
+    ) {
+      continue;
+    }
+
+    let payloadFields: WormholePayload;
+    try {
+      payloadFields = decodeWormholePayload(parsed.args.payload);
+    } catch {
+      // Another Hyperlane-unrelated publication by the same emitter.
+      continue;
+    }
+
+    if (
+      payloadFields.messageId.toLowerCase() !== query.messageId.toLowerCase() ||
+      payloadFields.originDomain !== query.originDomain ||
+      payloadFields.destinationDomain !== query.destinationDomain ||
+      payloadFields.nonce !== query.nonce ||
+      payloadFields.destinationRouter.toLowerCase() !==
+        query.destinationRouter.toLowerCase()
+    ) {
+      continue;
+    }
+
+    assert(
+      parsed.args.nonce === query.nonce,
+      'Core publication nonce does not equal the Hyperlane nonce',
+    );
+
+    matches.push({
+      sender: parsed.args.sender,
+      sequence: parsed.args.sequence.toString(),
+      nonce: parsed.args.nonce,
+      payload: parsed.args.payload,
+      consistencyLevel: parsed.args.consistencyLevel,
+      payloadFields,
+    });
+  }
+
+  assert(
+    matches.length > 0,
+    `No Wormhole publication for message ${query.messageId} in this receipt`,
+  );
+  assert(
+    matches.length === 1,
+    `Ambiguous receipt: ${matches.length} Wormhole publications match message ${query.messageId}`,
+  );
+  return matches[0];
+}
+
+/**
+ * Parses a v1 VAA.
+ *
+ * Signature bytes are skipped rather than verified — only destination Core can
+ * verify Guardian signatures. Parsing exists so the service can re-check the
+ * signed body against what the origin actually published.
+ */
+export function parseVaa(encodedVaa: string): ParsedVaa {
+  const bytes = ethers.utils.arrayify(encodedVaa);
+  assert(bytes.length >= 6, 'VAA too short for a header');
+
+  const version = bytes[0];
+  assert(version === 1, `Unsupported VAA version ${version}`);
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const guardianSetIndex = view.getUint32(1);
+  const signatureCount = bytes[5];
+
+  const SIGNATURE_LENGTH = 66; // guardianIndex(1) r(32) s(32) v(1)
+  const bodyOffset = 6 + signatureCount * SIGNATURE_LENGTH;
+  assert(
+    bytes.length >= bodyOffset + 51,
+    'VAA truncated before the end of its body header',
+  );
+
+  const timestamp = view.getUint32(bodyOffset);
+  const nonce = view.getUint32(bodyOffset + 4);
+  const emitterChainId = view.getUint16(bodyOffset + 8);
+  const emitterAddress = ethers.utils.hexlify(
+    bytes.subarray(bodyOffset + 10, bodyOffset + 42),
+  );
+  const sequence = ethers.BigNumber.from(
+    bytes.subarray(bodyOffset + 42, bodyOffset + 50),
+  ).toString();
+  const consistencyLevel = bytes[bodyOffset + 50];
+  const payload = ethers.utils.hexlify(bytes.subarray(bodyOffset + 51));
+
+  return {
+    version,
+    guardianSetIndex,
+    signatureCount,
+    timestamp,
+    nonce,
+    emitterChainId,
+    emitterAddress,
+    sequence,
+    consistencyLevel,
+    payload,
+  };
+}
+
+/**
+ * Re-checks an upstream VAA against the publication observed on the origin
+ * chain. Wormholescan response metadata is never trusted; only the decoded VAA
+ * bytes are.
+ */
+export function assertVaaMatchesPublication(
+  vaa: ParsedVaa,
+  publication: WormholePublication,
+  expected: { emitterChainId: number; originRouter: string },
+): void {
+  assert(
+    vaa.emitterChainId === expected.emitterChainId,
+    `VAA emitter chain ${vaa.emitterChainId} does not match origin ${expected.emitterChainId}`,
+  );
+  assert(
+    vaa.emitterAddress.toLowerCase() === expected.originRouter.toLowerCase(),
+    'VAA emitter is not the enrolled origin router',
+  );
+  assert(
+    vaa.sequence === publication.sequence,
+    `VAA sequence ${vaa.sequence} does not match publication ${publication.sequence}`,
+  );
+  assert(
+    vaa.nonce === publication.nonce,
+    'VAA nonce does not match the publication nonce',
+  );
+  assert(
+    vaa.consistencyLevel === publication.consistencyLevel,
+    'VAA consistency level does not match the publication',
+  );
+  assert(
+    vaa.payload.toLowerCase() === publication.payload.toLowerCase(),
+    'VAA payload does not match the published payload',
+  );
+}
+
+/** `(emitterChain, emitterAddress, sequence)` — the canonical VAA locator. */
+export function formatVaaId(
+  emitterChainId: number,
+  emitterAddress: string,
+  sequence: string,
+): string {
+  const emitter = ethers.utils
+    .hexZeroPad(emitterAddress, 32)
+    .slice(2)
+    .toLowerCase();
+  return `${emitterChainId}/${emitter}/${sequence}`;
+}

--- a/typescript/ccip-server/src/utils/prometheus.ts
+++ b/typescript/ccip-server/src/utils/prometheus.ts
@@ -19,6 +19,14 @@ export enum UnhandledErrorReason {
   CCTP_ATTESTATION_SERVICE_JSON_PARSE_ERROR = 'cctp_attestation_service_json_parse_error',
   CCTP_ATTESTATION_SERVICE_PENDING = 'cctp_attestation_service_pending',
 
+  // Wormhole errors
+  WORMHOLE_PUBLICATION_NOT_FOUND = 'wormhole_publication_not_found',
+  WORMHOLE_PUBLICATION_AMBIGUOUS = 'wormhole_publication_ambiguous',
+  WORMHOLE_VAA_PENDING = 'wormhole_vaa_pending',
+  WORMHOLE_VAA_UNAVAILABLE = 'wormhole_vaa_unavailable',
+  WORMHOLE_VAA_MISMATCH = 'wormhole_vaa_mismatch',
+  WORMHOLE_ROUTE_NOT_CONFIGURED = 'wormhole_route_not_configured',
+
   // CallCommitments errors
   CALL_COMMITMENTS_DATABASE_ERROR = 'call_commitments_database_error',
 

--- a/typescript/ccip-server/tests/services/WormholeVaaFetcher.test.ts
+++ b/typescript/ccip-server/tests/services/WormholeVaaFetcher.test.ts
@@ -1,0 +1,114 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import {
+  WormholeVaaFetcher,
+  type WormholeVaaFetcherConfig,
+} from '../../src/services/WormholeVaaFetcher.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+
+const logger = pino({ enabled: false });
+const emitterAddress = `0x${'11'.repeat(32)}`;
+
+chai.use(chaiAsPromised);
+
+function encodeVaa(sequence: number): string {
+  const body = ethers.utils.solidityPack(
+    ['uint32', 'uint32', 'uint16', 'bytes32', 'uint64', 'uint8', 'bytes'],
+    [1, 2, 3, emitterAddress, sequence, 15, '0x1234'],
+  );
+  return ethers.utils.hexConcat([
+    ethers.utils.solidityPack(['uint8', 'uint32', 'uint8'], [1, 4, 0]),
+    body,
+  ]);
+}
+
+function responseFor(sequence: number): Response {
+  return new Response(JSON.stringify({ data: { vaa: encodeVaa(sequence) } }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function config(
+  overrides: Partial<WormholeVaaFetcherConfig> = {},
+): WormholeVaaFetcherConfig {
+  return {
+    urls: ['https://example.test'],
+    timeoutMs: 1_000,
+    maxResponseBytes: 65_536,
+    maxCacheEntries: 2,
+    maxAttempts: 1,
+    baseRetryDelayMs: 1,
+    ...overrides,
+  };
+}
+
+describe('WormholeVaaFetcher', () => {
+  before(() => initializeMetrics(new Registry()));
+
+  afterEach(() => sinon.restore());
+
+  it('evicts the least recently used VAA when the cache is full', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub.onCall(0).resolves(responseFor(1));
+    fetchStub.onCall(1).resolves(responseFor(2));
+    fetchStub.onCall(2).resolves(responseFor(3));
+
+    const fetcher = new WormholeVaaFetcher(
+      'wormhole-test',
+      config({ maxCacheEntries: 1 }),
+    );
+    await fetcher.fetchVaa(3, emitterAddress, '1', logger);
+    await fetcher.fetchVaa(3, emitterAddress, '2', logger);
+    await fetcher.fetchVaa(3, emitterAddress, '1', logger);
+
+    expect(fetchStub.callCount).to.equal(3);
+  });
+
+  it('rejects a chunked response as soon as it exceeds the byte limit', async () => {
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(9));
+        controller.enqueue(new Uint8Array(8));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    sinon.stub(globalThis, 'fetch').resolves(new Response(body));
+
+    const fetcher = new WormholeVaaFetcher(
+      'wormhole-test',
+      config({ maxResponseBytes: 16 }),
+    );
+    await expect(
+      fetcher.fetchVaa(3, emitterAddress, '1', logger),
+    ).to.be.rejectedWith('Unable to fetch VAA');
+    expect(canceled).to.equal(true);
+  });
+
+  it('rejects an oversized declared content length without reading the body', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull() {},
+    });
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(body, {
+        headers: { 'content-length': '17' },
+      }),
+    );
+
+    const fetcher = new WormholeVaaFetcher(
+      'wormhole-test',
+      config({ maxResponseBytes: 16 }),
+    );
+    await expect(
+      fetcher.fetchVaa(3, emitterAddress, '1', logger),
+    ).to.be.rejectedWith('Unable to fetch VAA');
+  });
+});

--- a/typescript/ccip-server/tests/services/WormholeVaaService.test.ts
+++ b/typescript/ccip-server/tests/services/WormholeVaaService.test.ts
@@ -1,0 +1,445 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { pino } from 'pino';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+
+import {
+  WormholeChainConfigSchema,
+  WormholeVaaService,
+} from '../../src/services/WormholeVaaService.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+import {
+  LOG_MESSAGE_PUBLISHED_ABI,
+  WORMHOLE_PAYLOAD_MAGIC,
+  WORMHOLE_PAYLOAD_VERSION,
+  type WormholePayload,
+  encodeWormholePayload,
+  parseVaa,
+} from '../../src/services/wormholeVaaMatcher.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const ORIGIN_DOMAIN = 31338;
+const DESTINATION_DOMAIN = 31347;
+const ORIGIN_CHAIN = 'anvil2';
+const DESTINATION_CHAIN = 'anvil3';
+
+const ORIGIN_CORE = '0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B';
+const DESTINATION_CORE = '0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6';
+const ORIGIN_ROUTER = '0x1111111111111111111111111111111111111111';
+const DESTINATION_ROUTER = '0x2222222222222222222222222222222222222222';
+
+const WH_ORIGIN = 2;
+const WH_DESTINATION = 30;
+
+const NONCE = 3;
+const SEQUENCE = '11';
+const CONSISTENCY_LEVEL = 15;
+const TX_HASH = `0x${'ab'.repeat(32)}`;
+
+const iface = new ethers.utils.Interface(LOG_MESSAGE_PUBLISHED_ABI);
+
+const ROUTES = {
+  [ORIGIN_CHAIN]: {
+    core: ORIGIN_CORE,
+    wormholeChainId: WH_ORIGIN,
+    router: ORIGIN_ROUTER,
+  },
+  [DESTINATION_CHAIN]: {
+    core: DESTINATION_CORE,
+    wormholeChainId: WH_DESTINATION,
+    router: DESTINATION_ROUTER,
+  },
+};
+
+function buildMessage(): string {
+  return ethers.utils.solidityPack(
+    ['uint8', 'uint32', 'uint32', 'bytes32', 'uint32', 'bytes32', 'bytes'],
+    [
+      3,
+      NONCE,
+      ORIGIN_DOMAIN,
+      addressToBytes32('0x3333333333333333333333333333333333333333'),
+      DESTINATION_DOMAIN,
+      addressToBytes32('0x4444444444444444444444444444444444444444'),
+      ethers.utils.toUtf8Bytes('hello'),
+    ],
+  );
+}
+
+function buildPayload(
+  messageId: string,
+  overrides: Partial<WormholePayload> = {},
+) {
+  return encodeWormholePayload({
+    magic: WORMHOLE_PAYLOAD_MAGIC,
+    version: WORMHOLE_PAYLOAD_VERSION,
+    originDomain: ORIGIN_DOMAIN,
+    destinationDomain: DESTINATION_DOMAIN,
+    destinationRouter: addressToBytes32(DESTINATION_ROUTER),
+    messageId,
+    nonce: NONCE,
+    ...overrides,
+  });
+}
+
+function publicationLog(
+  payload: string,
+  overrides: { address?: string; sender?: string; sequence?: string } = {},
+) {
+  const encoded = iface.encodeEventLog(iface.getEvent('LogMessagePublished'), [
+    overrides.sender ?? ORIGIN_ROUTER,
+    overrides.sequence ?? SEQUENCE,
+    NONCE,
+    payload,
+    CONSISTENCY_LEVEL,
+  ]);
+  return {
+    address: overrides.address ?? ORIGIN_CORE,
+    topics: encoded.topics,
+    data: encoded.data,
+  };
+}
+
+function encodeVaa(
+  payload: string,
+  overrides: {
+    emitterChainId?: number;
+    emitterAddress?: string;
+    sequence?: string;
+    nonce?: number;
+    consistencyLevel?: number;
+  } = {},
+): string {
+  const signatureCount = 13;
+  const signatures = ethers.utils.hexlify(
+    new Uint8Array(signatureCount * 66).fill(0xcd),
+  );
+  const body = ethers.utils.solidityPack(
+    ['uint32', 'uint32', 'uint16', 'bytes32', 'uint64', 'uint8', 'bytes'],
+    [
+      1_700_000_000,
+      overrides.nonce ?? NONCE,
+      overrides.emitterChainId ?? WH_ORIGIN,
+      overrides.emitterAddress ?? addressToBytes32(ORIGIN_ROUTER),
+      overrides.sequence ?? SEQUENCE,
+      overrides.consistencyLevel ?? CONSISTENCY_LEVEL,
+      payload,
+    ],
+  );
+  return ethers.utils.hexConcat([
+    ethers.utils.solidityPack(
+      ['uint8', 'uint32', 'uint8'],
+      [1, 4, signatureCount],
+    ),
+    signatures,
+    body,
+  ]);
+}
+
+/** A `Log` shaped exactly as ethers returns it from a receipt. */
+function toLog(
+  entry: { address: string; topics: Array<string>; data: string },
+  logIndex: number,
+): ethers.providers.Log {
+  return {
+    blockNumber: 1,
+    blockHash: `0x${'11'.repeat(32)}`,
+    transactionIndex: 0,
+    removed: false,
+    address: entry.address,
+    data: entry.data,
+    topics: entry.topics,
+    transactionHash: TX_HASH,
+    logIndex,
+  };
+}
+
+function toReceipt(
+  entries: Array<{ address: string; topics: Array<string>; data: string }>,
+): ethers.providers.TransactionReceipt {
+  return {
+    to: ORIGIN_CORE,
+    from: ORIGIN_ROUTER,
+    contractAddress: '',
+    transactionIndex: 0,
+    gasUsed: ethers.BigNumber.from(21_000),
+    logsBloom: `0x${'00'.repeat(256)}`,
+    blockHash: `0x${'11'.repeat(32)}`,
+    transactionHash: TX_HASH,
+    logs: entries.map(toLog),
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: ethers.BigNumber.from(21_000),
+    effectiveGasPrice: ethers.BigNumber.from(1),
+    byzantium: true,
+    type: 2,
+    status: 1,
+  };
+}
+
+interface Harness {
+  service: WormholeVaaService;
+  getTransactionReceipt: sinon.SinonStub;
+  fetchVaa: sinon.SinonStub;
+  explorerLookup: sinon.SinonStub;
+}
+
+function harness(
+  entries: Array<{ address: string; topics: Array<string>; data: string }>,
+  vaa: string,
+): Harness {
+  const provider = new ethers.providers.JsonRpcProvider('http://127.0.0.1:1');
+  const getTransactionReceipt = sinon
+    .stub(provider, 'getTransactionReceipt')
+    .resolves(toReceipt(entries));
+
+  const multiProvider = sinon.createStubInstance(MultiProvider);
+  multiProvider.getProvider.returns(provider);
+  multiProvider.tryGetChainName.callsFake((domain) =>
+    domain === ORIGIN_DOMAIN
+      ? ORIGIN_CHAIN
+      : domain === DESTINATION_DOMAIN
+        ? DESTINATION_CHAIN
+        : null,
+  );
+
+  const fetchVaa = sinon.stub();
+  fetchVaa.resolves({ encodedVaa: vaa, vaa: parseVaa(vaa) });
+
+  const explorerLookup = sinon.stub().resolves(TX_HASH);
+
+  const service = new WormholeVaaService({
+    serviceName: 'wormhole',
+    multiProvider,
+    routes: ROUTES,
+    vaaFetcher: { fetchVaa },
+    hyperlaneService: {
+      getOriginTransactionHashByMessageId: explorerLookup,
+    },
+  });
+
+  return { service, getTransactionReceipt, fetchVaa, explorerLookup };
+}
+
+const logger = pino({ level: 'silent' });
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('WormholeVaaService', () => {
+  before(() => initializeMetrics(new Registry()));
+  afterEach(() => sinon.restore());
+
+  it('rejects zero Core and router addresses in route configuration', () => {
+    const validRoute = ROUTES[ORIGIN_CHAIN];
+
+    expect(
+      WormholeChainConfigSchema.safeParse({
+        ...validRoute,
+        core: ethers.constants.AddressZero,
+      }).success,
+    ).to.equal(false);
+    expect(
+      WormholeChainConfigSchema.safeParse({
+        ...validRoute,
+        router: ethers.constants.AddressZero,
+      }).success,
+    ).to.equal(false);
+  });
+
+  it('returns the raw VAA bytes for a matching publication', async () => {
+    const message = buildMessage();
+    const messageId = ethers.utils.keccak256(message);
+    const payload = buildPayload(messageId);
+    const vaa = encodeVaa(payload);
+    const { service } = harness([publicationLog(payload)], vaa);
+
+    const result = await service.getWormholeVaa(message, TX_HASH, logger);
+
+    expect(result).to.equal(vaa);
+  });
+
+  it('uses the relayer-provided origin transaction hash', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service, getTransactionReceipt, explorerLookup } = harness(
+      [publicationLog(payload)],
+      encodeVaa(payload),
+    );
+
+    await service.getWormholeVaa(message, TX_HASH, logger);
+
+    expect(getTransactionReceipt.calledOnceWith(TX_HASH)).to.be.true;
+    expect(explorerLookup.called).to.be.false;
+  });
+
+  it('falls back to the Explorer when the relayer sends no tx hash', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service, explorerLookup, getTransactionReceipt } = harness(
+      [publicationLog(payload)],
+      encodeVaa(payload),
+    );
+
+    await service.getWormholeVaa(message, undefined, logger);
+
+    expect(explorerLookup.calledOnce).to.be.true;
+    expect(getTransactionReceipt.calledOnceWith(TX_HASH)).to.be.true;
+  });
+
+  it('looks up the VAA by the origin emitter and published sequence', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service, fetchVaa } = harness(
+      [publicationLog(payload)],
+      encodeVaa(payload),
+    );
+
+    await service.getWormholeVaa(message, TX_HASH, logger);
+
+    const [chainId, emitter, sequence] = fetchVaa.firstCall.args;
+    expect(chainId).to.equal(WH_ORIGIN);
+    expect(emitter).to.equal(addressToBytes32(ORIGIN_ROUTER));
+    expect(sequence).to.equal(SEQUENCE);
+  });
+
+  it('rejects a receipt with no Core publication', async () => {
+    const message = buildMessage();
+    const { service } = harness(
+      [],
+      encodeVaa(buildPayload(ethers.utils.keccak256(message))),
+    );
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'No Wormhole publication',
+    );
+  });
+
+  it('ignores a lookalike publication from a non-Core address', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service } = harness(
+      [publicationLog(payload, { address: DESTINATION_CORE })],
+      encodeVaa(payload),
+    );
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'No Wormhole publication',
+    );
+  });
+
+  it('ignores a Core publication from a non-enrolled emitter', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service } = harness(
+      [publicationLog(payload, { sender: DESTINATION_ROUTER })],
+      encodeVaa(payload),
+    );
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'No Wormhole publication',
+    );
+  });
+
+  it('disambiguates when the receipt holds several publications', async () => {
+    const message = buildMessage();
+    const messageId = ethers.utils.keccak256(message);
+    const payload = buildPayload(messageId);
+    const other = buildPayload(ethers.utils.id('another message'));
+    const vaa = encodeVaa(payload);
+    const { service } = harness(
+      [publicationLog(other, { sequence: '10' }), publicationLog(payload)],
+      vaa,
+    );
+
+    const result = await service.getWormholeVaa(message, TX_HASH, logger);
+
+    expect(result).to.equal(vaa);
+  });
+
+  it('rejects an ambiguous receipt with two publications for one message', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service } = harness(
+      [publicationLog(payload), publicationLog(payload, { sequence: '12' })],
+      encodeVaa(payload),
+    );
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'Ambiguous receipt',
+    );
+  });
+
+  it('rejects an upstream VAA whose payload differs from the publication', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const tampered = buildPayload(ethers.utils.id('tampered'));
+    const { service } = harness([publicationLog(payload)], encodeVaa(tampered));
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'VAA payload does not match',
+    );
+  });
+
+  it('rejects an upstream VAA from another emitter chain', async () => {
+    const message = buildMessage();
+    const payload = buildPayload(ethers.utils.keccak256(message));
+    const { service } = harness(
+      [publicationLog(payload)],
+      encodeVaa(payload, { emitterChainId: WH_DESTINATION }),
+    );
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'does not match origin',
+    );
+  });
+
+  it('rejects a message whose origin chain has no configured route', async () => {
+    const message = ethers.utils.solidityPack(
+      ['uint8', 'uint32', 'uint32', 'bytes32', 'uint32', 'bytes32', 'bytes'],
+      [
+        3,
+        NONCE,
+        999_999,
+        addressToBytes32(ORIGIN_ROUTER),
+        DESTINATION_DOMAIN,
+        addressToBytes32(DESTINATION_ROUTER),
+        '0x',
+      ],
+    );
+    const { service } = harness(
+      [],
+      encodeVaa(buildPayload(ethers.utils.id('x'))),
+    );
+
+    await expectRejection(
+      service.getWormholeVaa(message, TX_HASH, logger),
+      'No Wormhole route configured',
+    );
+  });
+});
+
+async function expectRejection(
+  promise: Promise<unknown>,
+  expectedMessage: string,
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error instanceof Error ? error.message : String(error)).to.include(
+      expectedMessage,
+    );
+    return;
+  }
+  expect.fail(`Expected rejection containing "${expectedMessage}"`);
+}

--- a/typescript/ccip-server/tests/services/moduleRegistry.test.ts
+++ b/typescript/ccip-server/tests/services/moduleRegistry.test.ts
@@ -8,6 +8,7 @@ describe('module registry', () => {
       'callCommitments',
       'cctp',
       'opstack',
+      'wormhole',
     ]);
     expect(moduleRegistry.unknown).to.equal(undefined);
   });
@@ -16,6 +17,7 @@ describe('module registry', () => {
     ['callCommitments', 'SERVER_BASE_URL'],
     ['cctp', 'HYPERLANE_EXPLORER_URL'],
     ['opstack', 'HYPERLANE_EXPLORER_API'],
+    ['wormhole', 'HYPERLANE_EXPLORER_URL'],
   ] as const) {
     it(`loads ${name} and preserves required configuration validation`, async function () {
       if (name === 'callCommitments') this.timeout(10_000);

--- a/typescript/ccip-server/tests/services/wormholeVaaMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/wormholeVaaMatcher.test.ts
@@ -1,0 +1,359 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import {
+  LOG_MESSAGE_PUBLISHED_ABI,
+  WORMHOLE_PAYLOAD_LENGTH,
+  WORMHOLE_PAYLOAD_MAGIC,
+  WORMHOLE_PAYLOAD_VERSION,
+  assertVaaMatchesPublication,
+  decodeWormholePayload,
+  encodeWormholePayload,
+  findMatchingWormholePublication,
+  formatVaaId,
+  parseVaa,
+} from '../../src/services/wormholeVaaMatcher.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const CORE = '0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B';
+const ORIGIN_ROUTER = '0x1111111111111111111111111111111111111111';
+const DESTINATION_ROUTER = '0x2222222222222222222222222222222222222222';
+const MESSAGE_ID = ethers.utils.id('message');
+const ORIGIN_DOMAIN = 1;
+const DESTINATION_DOMAIN = 8453;
+const NONCE = 7;
+const EMITTER_CHAIN_ID = 2;
+const SEQUENCE = '42';
+const CONSISTENCY_LEVEL = 15;
+
+const iface = new ethers.utils.Interface(LOG_MESSAGE_PUBLISHED_ABI);
+
+function bytes32(address: string): string {
+  return ethers.utils.hexZeroPad(address, 32);
+}
+
+function payload(
+  overrides: Partial<Parameters<typeof encodeWormholePayload>[0]> = {},
+) {
+  return encodeWormholePayload({
+    magic: WORMHOLE_PAYLOAD_MAGIC,
+    version: WORMHOLE_PAYLOAD_VERSION,
+    originDomain: ORIGIN_DOMAIN,
+    destinationDomain: DESTINATION_DOMAIN,
+    destinationRouter: bytes32(DESTINATION_ROUTER),
+    messageId: MESSAGE_ID,
+    nonce: NONCE,
+    ...overrides,
+  });
+}
+
+function publicationLog(
+  overrides: {
+    address?: string;
+    sender?: string;
+    sequence?: string;
+    nonce?: number;
+    payload?: string;
+    consistencyLevel?: number;
+  } = {},
+) {
+  const encoded = iface.encodeEventLog(iface.getEvent('LogMessagePublished'), [
+    overrides.sender ?? ORIGIN_ROUTER,
+    overrides.sequence ?? SEQUENCE,
+    overrides.nonce ?? NONCE,
+    overrides.payload ?? payload(),
+    overrides.consistencyLevel ?? CONSISTENCY_LEVEL,
+  ]);
+  return {
+    address: overrides.address ?? CORE,
+    topics: encoded.topics,
+    data: encoded.data,
+  };
+}
+
+const QUERY = {
+  coreAddress: CORE,
+  originRouter: bytes32(ORIGIN_ROUTER),
+  destinationRouter: bytes32(DESTINATION_ROUTER),
+  messageId: MESSAGE_ID,
+  originDomain: ORIGIN_DOMAIN,
+  destinationDomain: DESTINATION_DOMAIN,
+  nonce: NONCE,
+};
+
+/** Builds a v1 VAA with `signatureCount` unverifiable placeholder signatures. */
+function encodeVaa(
+  overrides: {
+    guardianSetIndex?: number;
+    signatureCount?: number;
+    timestamp?: number;
+    nonce?: number;
+    emitterChainId?: number;
+    emitterAddress?: string;
+    sequence?: string;
+    consistencyLevel?: number;
+    payload?: string;
+  } = {},
+): string {
+  const signatureCount = overrides.signatureCount ?? 13;
+  const signatures = ethers.utils.hexlify(
+    new Uint8Array(signatureCount * 66).fill(0xab),
+  );
+  const body = ethers.utils.solidityPack(
+    ['uint32', 'uint32', 'uint16', 'bytes32', 'uint64', 'uint8', 'bytes'],
+    [
+      overrides.timestamp ?? 1_700_000_000,
+      overrides.nonce ?? NONCE,
+      overrides.emitterChainId ?? EMITTER_CHAIN_ID,
+      overrides.emitterAddress ?? bytes32(ORIGIN_ROUTER),
+      overrides.sequence ?? SEQUENCE,
+      overrides.consistencyLevel ?? CONSISTENCY_LEVEL,
+      overrides.payload ?? payload(),
+    ],
+  );
+  return ethers.utils.hexConcat([
+    ethers.utils.solidityPack(
+      ['uint8', 'uint32', 'uint8'],
+      [1, overrides.guardianSetIndex ?? 4, signatureCount],
+    ),
+    signatures,
+    body,
+  ]);
+}
+
+// ─── Payload ─────────────────────────────────────────────────────────────────
+
+describe('wormholeVaaMatcher payload', () => {
+  it('round-trips the fixed 224-byte envelope', () => {
+    const encoded = payload();
+
+    expect(ethers.utils.hexDataLength(encoded)).to.equal(
+      WORMHOLE_PAYLOAD_LENGTH,
+    );
+
+    const decoded = decodeWormholePayload(encoded);
+
+    expect(decoded.originDomain).to.equal(ORIGIN_DOMAIN);
+    expect(decoded.destinationDomain).to.equal(DESTINATION_DOMAIN);
+    expect(decoded.destinationRouter).to.equal(bytes32(DESTINATION_ROUTER));
+    expect(decoded.messageId).to.equal(MESSAGE_ID);
+    expect(decoded.nonce).to.equal(NONCE);
+  });
+
+  it('rejects a wrong magic', () => {
+    const encoded = payload({ magic: '0xdeadbeef' });
+
+    expect(() => decodeWormholePayload(encoded)).to.throw('magic mismatch');
+  });
+
+  it('rejects an unsupported version', () => {
+    const encoded = payload({ version: 2 });
+
+    expect(() => decodeWormholePayload(encoded)).to.throw(
+      'Unsupported Wormhole payload version',
+    );
+  });
+
+  it('rejects a payload of the wrong length', () => {
+    expect(() => decodeWormholePayload('0xdeadbeef')).to.throw(
+      'must be 224 bytes',
+    );
+  });
+});
+
+// ─── Receipt disambiguation ──────────────────────────────────────────────────
+
+describe('findMatchingWormholePublication', () => {
+  it('finds the single matching publication', () => {
+    const match = findMatchingWormholePublication([publicationLog()], QUERY);
+
+    expect(match.sequence).to.equal(SEQUENCE);
+    expect(match.nonce).to.equal(NONCE);
+    expect(match.consistencyLevel).to.equal(CONSISTENCY_LEVEL);
+    expect(match.payloadFields.messageId).to.equal(MESSAGE_ID);
+  });
+
+  it('throws when the receipt has no publication', () => {
+    expect(() => findMatchingWormholePublication([], QUERY)).to.throw(
+      'No Wormhole publication',
+    );
+  });
+
+  it('ignores a lookalike event from a non-Core address', () => {
+    const impostor = publicationLog({
+      address: '0x3333333333333333333333333333333333333333',
+    });
+
+    expect(() => findMatchingWormholePublication([impostor], QUERY)).to.throw(
+      'No Wormhole publication',
+    );
+  });
+
+  it('ignores a publication from another emitter on Core', () => {
+    const other = publicationLog({
+      sender: '0x4444444444444444444444444444444444444444',
+    });
+
+    expect(() => findMatchingWormholePublication([other], QUERY)).to.throw(
+      'No Wormhole publication',
+    );
+  });
+
+  it('ignores a Core publication whose payload is not a Hyperlane envelope', () => {
+    const unrelated = publicationLog({ payload: '0x1234' });
+
+    expect(() => findMatchingWormholePublication([unrelated], QUERY)).to.throw(
+      'No Wormhole publication',
+    );
+  });
+
+  it('disambiguates several publications by message ID', () => {
+    const other = publicationLog({
+      sequence: '41',
+      payload: payload({ messageId: ethers.utils.id('other') }),
+    });
+
+    const match = findMatchingWormholePublication(
+      [other, publicationLog()],
+      QUERY,
+    );
+
+    expect(match.sequence).to.equal(SEQUENCE);
+  });
+
+  it('rejects a receipt with two publications for the same message', () => {
+    expect(() =>
+      findMatchingWormholePublication(
+        [publicationLog(), publicationLog({ sequence: '43' })],
+        QUERY,
+      ),
+    ).to.throw('Ambiguous receipt');
+  });
+
+  it('rejects a publication bound to another destination router', () => {
+    const wrongRouter = publicationLog({
+      payload: payload({
+        destinationRouter: bytes32(
+          '0x5555555555555555555555555555555555555555',
+        ),
+      }),
+    });
+
+    expect(() =>
+      findMatchingWormholePublication([wrongRouter], QUERY),
+    ).to.throw('No Wormhole publication');
+  });
+});
+
+// ─── VAA parsing ─────────────────────────────────────────────────────────────
+
+describe('parseVaa', () => {
+  it('parses a realistic 13-signature VAA', () => {
+    const parsed = parseVaa(encodeVaa());
+
+    expect(parsed.version).to.equal(1);
+    expect(parsed.guardianSetIndex).to.equal(4);
+    expect(parsed.signatureCount).to.equal(13);
+    expect(parsed.emitterChainId).to.equal(EMITTER_CHAIN_ID);
+    expect(parsed.emitterAddress).to.equal(bytes32(ORIGIN_ROUTER));
+    expect(parsed.sequence).to.equal(SEQUENCE);
+    expect(parsed.consistencyLevel).to.equal(CONSISTENCY_LEVEL);
+    expect(parsed.nonce).to.equal(NONCE);
+    expect(parsed.payload).to.equal(payload());
+  });
+
+  it('rejects an unsupported VAA version', () => {
+    const vaa = encodeVaa();
+    const mutated = ethers.utils.hexConcat([
+      '0x02',
+      ethers.utils.hexDataSlice(vaa, 1),
+    ]);
+
+    expect(() => parseVaa(mutated)).to.throw('Unsupported VAA version');
+  });
+
+  it('rejects a truncated VAA', () => {
+    const vaa = encodeVaa();
+    const truncated = ethers.utils.hexDataSlice(vaa, 0, 40);
+
+    expect(() => parseVaa(truncated)).to.throw('truncated');
+  });
+});
+
+// ─── Upstream response validation ────────────────────────────────────────────
+
+describe('assertVaaMatchesPublication', () => {
+  const publication = () =>
+    findMatchingWormholePublication([publicationLog()], QUERY);
+  const expected = {
+    emitterChainId: EMITTER_CHAIN_ID,
+    originRouter: bytes32(ORIGIN_ROUTER),
+  };
+
+  it('accepts a VAA that matches the publication', () => {
+    assertVaaMatchesPublication(parseVaa(encodeVaa()), publication(), expected);
+  });
+
+  it('rejects a VAA from another emitter chain', () => {
+    const vaa = parseVaa(encodeVaa({ emitterChainId: 30 }));
+
+    expect(() =>
+      assertVaaMatchesPublication(vaa, publication(), expected),
+    ).to.throw('does not match origin');
+  });
+
+  it('rejects a VAA from another emitter address', () => {
+    const vaa = parseVaa(
+      encodeVaa({
+        emitterAddress: bytes32('0x6666666666666666666666666666666666666666'),
+      }),
+    );
+
+    expect(() =>
+      assertVaaMatchesPublication(vaa, publication(), expected),
+    ).to.throw('not the enrolled origin router');
+  });
+
+  it('rejects a VAA for another sequence', () => {
+    const vaa = parseVaa(encodeVaa({ sequence: '43' }));
+
+    expect(() =>
+      assertVaaMatchesPublication(vaa, publication(), expected),
+    ).to.throw('does not match publication');
+  });
+
+  it('rejects a VAA whose consistency level was downgraded', () => {
+    const vaa = parseVaa(encodeVaa({ consistencyLevel: 1 }));
+
+    expect(() =>
+      assertVaaMatchesPublication(vaa, publication(), expected),
+    ).to.throw('consistency level');
+  });
+
+  it('rejects a VAA carrying a different payload', () => {
+    const vaa = parseVaa(
+      encodeVaa({ payload: payload({ messageId: ethers.utils.id('other') }) }),
+    );
+
+    expect(() =>
+      assertVaaMatchesPublication(vaa, publication(), expected),
+    ).to.throw('payload does not match');
+  });
+});
+
+describe('formatVaaId', () => {
+  it('formats the canonical VAA locator', () => {
+    expect(
+      formatVaaId(EMITTER_CHAIN_ID, bytes32(ORIGIN_ROUTER), SEQUENCE),
+    ).to.equal(`2/${bytes32(ORIGIN_ROUTER).slice(2)}/42`);
+  });
+
+  it('normalizes checksummed emitter addresses', () => {
+    const emitterAddress =
+      '0x' + '00'.repeat(12) + '34084eAEbe9Cbc209A85FFe22fa387223CDFB3e8';
+    expect(formatVaaId(EMITTER_CHAIN_ID, emitterAddress, SEQUENCE)).to.equal(
+      `2/${emitterAddress.slice(2).toLowerCase()}/42`,
+    );
+  });
+});

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -38,7 +38,10 @@ import {
   type CompositeIsmNodeConfig,
   CompositeIsmNodeType,
   ContractVerifier,
+  EvmWormholeHookIsmModule,
+  EvmWormholeHookIsmReader,
   EvmWarpModule,
+  EvmWarpRouteReader,
   ExplorerLicenseType,
   HypERC20Deployer,
   IsmType,
@@ -67,6 +70,9 @@ import {
   assertDelayedFlowRoutePreconditions,
   buildDelayedFlowEnrollmentTxs,
   deriveDelayedFlowEnrollmentTargets,
+  buildWormholeMeshConfig,
+  collectHookAddresses,
+  collectIsmAddresses,
   enrollCrossChainRouters,
   executeWarpDeploy,
   executeWarpRouteExtensionDeploy,
@@ -76,8 +82,10 @@ import {
   getSubmitterBuilder,
   getTokenConnectionId,
   isCrossCollateralTokenConfig,
+  materializeWormholeWarpConfig,
   normalizeScale,
   planWarpRouteHybrids,
+  pairWormholeConfigs,
   splitWarpCoreAndExtendedConfigs,
   tokenTypeToStandard,
 } from '@hyperlane-xyz/sdk';
@@ -230,13 +238,24 @@ export async function runWarpRouteDeploy({
 
   const initialBalances = await getBalances(context, deploymentChains);
 
+  const effectiveWarpDeployConfig = await materializeNewWormholeMesh(
+    multiProvider,
+    warpDeployConfig,
+  );
+  deploymentParams.warpDeployConfig = effectiveWarpDeployConfig;
+
   logBlue('🚀 All systems ready, captain! Beginning deployment...');
   const { deployedContracts } = await executeDeploy(deploymentParams, apiKeys);
 
   const registryAddresses = await registry.getAddresses();
 
   const enrollTxs = await enrollCrossChainRouters(
-    { multiProvider, altVmSigners, registryAddresses, warpDeployConfig },
+    {
+      multiProvider,
+      altVmSigners,
+      registryAddresses,
+      warpDeployConfig: effectiveWarpDeployConfig,
+    },
     deployedContracts,
   );
 
@@ -325,6 +344,22 @@ export async function runWarpRouteDeploy({
     null,
     deploymentChains,
   );
+}
+
+async function materializeNewWormholeMesh(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+): Promise<WarpRouteDeployConfigMailboxRequired> {
+  const pairs = pairWormholeConfigs(warpDeployConfig);
+  if (Object.keys(pairs).length === 0) return warpDeployConfig;
+
+  logBlue('Deploying and enrolling combined Wormhole hook/ISM routers...');
+  const mesh = buildWormholeMeshConfig(warpDeployConfig, pairs);
+  const addresses = await EvmWormholeHookIsmModule.deployMesh(
+    multiProvider,
+    mesh,
+  );
+  return materializeWormholeWarpConfig(warpDeployConfig, addresses);
 }
 
 async function runDeployPlanStep({ context, warpDeployConfig }: DeployParams) {
@@ -551,10 +586,20 @@ export async function runWarpRouteApply(
       context.registry,
     );
 
+  const wormhole = await materializeWormholeMeshForApply(
+    context.multiProvider,
+    warpDeployConfig,
+    warpCoreConfig,
+  );
+  const effectiveParams: WarpApplyParams = {
+    ...params,
+    warpDeployConfig: wormhole.config,
+  };
+
   // temporarily configure deployer as owner so that warp update after extension
   // can leverage JSON RPC submitter on new chains
   const intermediateOwnerConfig = await promiseObjAll(
-    objMap(params.warpDeployConfig, async (chain, config) => {
+    objMap(wormhole.config, async (chain, config) => {
       const protocolType = multiProvider.getProtocol(chain);
       if (isEVMLike(protocolType)) {
         return withIntermediateWarpOwner(
@@ -572,7 +617,7 @@ export async function runWarpRouteApply(
 
   // Extend the warp route and get the updated configs
   const updatedWarpCoreConfig = await extendWarpRoute(
-    { ...params, warpDeployConfig: intermediateOwnerConfig },
+    { ...effectiveParams, warpDeployConfig: intermediateOwnerConfig },
     apiKeys,
     warpCoreConfig,
     warpDeployConfig,
@@ -584,11 +629,18 @@ export async function runWarpRouteApply(
     feeTxs: feeUpdateTransactions,
     ownershipTxs: ownershipTransactions,
   } = await updateExistingWarpRoute(
-    params,
+    effectiveParams,
     apiKeys,
-    warpDeployConfig,
+    wormhole.config,
     updatedWarpCoreConfig,
   );
+
+  for (const [chain, transactions] of Object.entries(wormhole.transactions)) {
+    updateTransactions[chain] = [
+      ...transactions,
+      ...(updateTransactions[chain] ?? []),
+    ];
+  }
 
   // Check if update transactions are empty
   const hasAnyTx = [
@@ -601,11 +653,76 @@ export async function runWarpRouteApply(
     return logGreen(`Warp config is the same as target. No updates needed.`);
 
   await submitWarpApplyTransactions(
-    params,
+    effectiveParams,
     updateTransactions,
     feeUpdateTransactions,
     ownershipTransactions,
   );
+}
+
+async function materializeWormholeMeshForApply(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  warpCoreConfig: WarpCoreConfig,
+): Promise<{
+  config: WarpRouteDeployConfigMailboxRequired;
+  transactions: ChainMap<TypedAnnotatedTransaction[]>;
+}> {
+  const pairs = pairWormholeConfigs(warpDeployConfig);
+  if (Object.keys(pairs).length === 0) {
+    return { config: warpDeployConfig, transactions: {} };
+  }
+
+  const deployedWarpRouters =
+    getRouterAddressesFromWarpCoreConfig(warpCoreConfig);
+  const existingWormholeRouters: ChainMap<Address> = {};
+  for (const chain of Object.keys(pairs)) {
+    const deployedWarpRouter = deployedWarpRouters[chain];
+    if (!deployedWarpRouter) continue;
+
+    const actual = await new EvmWarpRouteReader(
+      multiProvider,
+      chain,
+    ).deriveWarpRouteConfig(deployedWarpRouter);
+    const hookAddresses = new Set(
+      collectHookAddresses(actual.hook).map((address) => address.toLowerCase()),
+    );
+    const candidates = Array.from(
+      new Set(
+        collectIsmAddresses(actual.interchainSecurityModule).filter((address) =>
+          hookAddresses.has(address.toLowerCase()),
+        ),
+      ),
+    );
+    const matches: Address[] = [];
+    for (const candidate of candidates) {
+      try {
+        await new EvmWormholeHookIsmReader(multiProvider, chain).deriveVariant(
+          candidate,
+        );
+        matches.push(candidate);
+      } catch {
+        // Shared hook/ISM addresses of other types are not Wormhole candidates.
+      }
+    }
+    assert(
+      matches.length <= 1,
+      `${chain} has multiple deployed combined Wormhole hook/ISM routers`,
+    );
+    if (matches[0]) existingWormholeRouters[chain] = matches[0];
+  }
+
+  logBlue('Reconciling combined Wormhole hook/ISM routers...');
+  const mesh = buildWormholeMeshConfig(warpDeployConfig, pairs);
+  const result = await EvmWormholeHookIsmModule.reconcileMesh(
+    multiProvider,
+    mesh,
+    existingWormholeRouters,
+  );
+  return {
+    config: materializeWormholeWarpConfig(warpDeployConfig, result.addresses),
+    transactions: result.transactions,
+  };
 }
 
 /**

--- a/typescript/cli/src/tests/ethereum/commands/core.ts
+++ b/typescript/cli/src/tests/ethereum/commands/core.ts
@@ -96,10 +96,7 @@ export function hyperlaneCoreInit(
 /**
  * Updates a Hyperlane core deployment on the specified chain using the provided config.
  */
-export async function hyperlaneCoreApply(
-  chain: string,
-  coreOutputPath: string,
-) {
+export function hyperlaneCoreApply(chain: string, coreOutputPath: string) {
   return $`${localTestRunCmdPrefix()} hyperlane core apply \
         --registry ${REGISTRY_PATH} \
         --config ${coreOutputPath} \

--- a/typescript/cli/src/tests/ethereum/commands/helpers.ts
+++ b/typescript/cli/src/tests/ethereum/commands/helpers.ts
@@ -197,7 +197,7 @@ export async function getDomainId(
  * Set the appropriate signer type on the MultiProvider based on the chain's
  * technical stack (TronWallet for Tron chains, ethers.Wallet otherwise).
  */
-function setSignerForChain(
+export function setSignerForChain(
   multiProvider: MultiProvider,
   chain: string,
   privateKey: string,

--- a/typescript/cli/src/tests/ethereum/wormhole/fixtures.ts
+++ b/typescript/cli/src/tests/ethereum/wormhole/fixtures.ts
@@ -1,0 +1,413 @@
+import { ethers } from 'ethers';
+import http from 'http';
+import { $, type ProcessPromise } from 'zx';
+
+import {
+  type MockExecutorQuoterRouter,
+  MockExecutorQuoterRouter__factory,
+  type MockWormholeCore,
+  MockWormholeCore__factory,
+  TestRecipient__factory,
+} from '@hyperlane-xyz/core';
+import {
+  type ChainMap,
+  type ChainName,
+  EvmWormholeHookIsmModule,
+  type MultiProvider,
+  WormholeConsistencyLevel,
+  WormholeConsistencyType,
+  type WormholeHookIsmConfig,
+  type WormholeMeshConfig,
+  WormholeVariant,
+} from '@hyperlane-xyz/sdk';
+import { type Address, addressToBytes32, assert } from '@hyperlane-xyz/utils';
+
+import { getContext } from '../../../context/context.js';
+import { setSignerForChain } from '../commands/helpers.js';
+import { ANVIL_KEY, REGISTRY_PATH } from '../consts.js';
+
+/**
+ * Local Wormhole fixture for the CLI E2E suite.
+ *
+ * Anvil has no Guardian network, so Wormhole Core and the Executor Quoter
+ * Router are replaced with the repository's deterministic mocks. Everything
+ * above them — the CLI, the SDK deploy/read/apply module, the metadata builder,
+ * the CCIP-read HTTP handler, and `Mailbox.process` — is the real thing.
+ */
+
+export const WH_CHAIN_ID_2 = 4001;
+export const WH_CHAIN_ID_3 = 4002;
+export const CALLBACK_GAS_LIMIT = 400_000n;
+export const CORE_MESSAGE_FEE = 0n;
+export const EXECUTOR_FEE = 0n;
+
+export interface WormholeChainFixture {
+  chain: ChainName;
+  wormholeChainId: number;
+  core: MockWormholeCore;
+  quoterRouter: MockExecutorQuoterRouter;
+}
+
+export async function getMultiProvider(): Promise<MultiProvider> {
+  const { multiProvider } = await getContext({
+    registryUris: [REGISTRY_PATH],
+    key: ANVIL_KEY,
+  });
+  return multiProvider;
+}
+
+/** Deploys the mock Wormhole infrastructure a chain's router will point at. */
+export async function deployWormholeMocks(
+  multiProvider: MultiProvider,
+  chain: ChainName,
+  wormholeChainId: number,
+): Promise<WormholeChainFixture> {
+  setSignerForChain(multiProvider, chain, ANVIL_KEY);
+
+  const core = await multiProvider.handleDeploy(
+    chain,
+    new MockWormholeCore__factory(),
+    [wormholeChainId, CORE_MESSAGE_FEE],
+  );
+  const quoterRouter = await multiProvider.handleDeploy(
+    chain,
+    new MockExecutorQuoterRouter__factory(),
+    [EXECUTOR_FEE],
+  );
+
+  return { chain, wormholeChainId, core, quoterRouter };
+}
+
+/**
+ * Builds a symmetric two-chain mesh config. Router addresses are placeholders
+ * until `deployMesh` fills in the real ones — the routers cannot know each
+ * other's address before they exist.
+ */
+export function buildMeshConfig({
+  variant,
+  origin,
+  destination,
+  mailboxes,
+  owner,
+  urls,
+}: {
+  variant: WormholeVariant;
+  origin: WormholeChainFixture;
+  destination: WormholeChainFixture;
+  mailboxes: ChainMap<Address>;
+  owner: Address;
+  urls?: Array<string>;
+}): WormholeMeshConfig {
+  const chainConfig = (
+    self: WormholeChainFixture,
+    remote: WormholeChainFixture,
+  ): WormholeHookIsmConfig => {
+    const remoteRouter = {
+      router: ethers.constants.AddressZero,
+      wormholeChainId: remote.wormholeChainId,
+      expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+      ...(variant === WormholeVariant.Executor
+        ? { quoter: owner, callbackGasLimit: CALLBACK_GAS_LIMIT }
+        : {}),
+    };
+
+    return {
+      type: variant,
+      owner,
+      mailbox: mailboxes[self.chain],
+      core: self.core.address,
+      consistencyLevel: { type: WormholeConsistencyType.Finalized },
+      remoteRouters: { [remote.chain]: remoteRouter },
+      ...(variant === WormholeVariant.Executor
+        ? { executorQuoterRouter: self.quoterRouter.address }
+        : { urls }),
+    };
+  };
+
+  return {
+    [origin.chain]: chainConfig(origin, destination),
+    [destination.chain]: chainConfig(destination, origin),
+  };
+}
+
+/**
+ * Deploys one router per chain and enrolls the mesh once every address exists.
+ *
+ * `deployMesh` replaces the placeholder router addresses, so the enrollment the
+ * routers end up with is derived from the deployment, never hand-written.
+ */
+export async function deployWormholeMesh(
+  multiProvider: MultiProvider,
+  mesh: WormholeMeshConfig,
+): Promise<ChainMap<Address>> {
+  for (const chain of Object.keys(mesh)) {
+    setSignerForChain(multiProvider, chain, ANVIL_KEY);
+  }
+  return EvmWormholeHookIsmModule.deployMesh(multiProvider, mesh);
+}
+
+/** Points the deployed TestRecipient at the local Wormhole router. */
+export async function setRecipientIsm(
+  multiProvider: MultiProvider,
+  chain: ChainName,
+  testRecipient: Address,
+  ism: Address,
+): Promise<void> {
+  setSignerForChain(multiProvider, chain, ANVIL_KEY);
+  const recipient = TestRecipient__factory.connect(
+    testRecipient,
+    multiProvider.getSigner(chain),
+  );
+  await multiProvider.handleTx(
+    chain,
+    recipient.setInterchainSecurityModule(ism),
+  );
+}
+
+export interface WormholePublication {
+  sender: Address;
+  sequence: string;
+  nonce: number;
+  payload: string;
+  consistencyLevel: number;
+}
+
+/**
+ * Extracts the publications the mock Core emitted in a dispatch transaction.
+ *
+ * The E2E asserts there is exactly one, which is the same ambiguity check the
+ * lookup service and the destination router both enforce.
+ */
+export async function readPublications(
+  multiProvider: MultiProvider,
+  chain: ChainName,
+  txHash: string,
+  core: MockWormholeCore,
+): Promise<Array<WormholePublication>> {
+  const receipt = await multiProvider
+    .getProvider(chain)
+    .getTransactionReceipt(txHash);
+  assert(receipt, `No receipt for ${txHash} on ${chain}`);
+
+  const iface = MockWormholeCore__factory.createInterface();
+  const publications: Array<WormholePublication> = [];
+
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== core.address.toLowerCase()) continue;
+    let parsed;
+    try {
+      parsed = iface.parseLog(log);
+    } catch {
+      continue;
+    }
+    if (parsed.name !== 'LogMessagePublished') continue;
+    publications.push({
+      sender: parsed.args.sender,
+      sequence: parsed.args.sequence.toString(),
+      nonce: parsed.args.nonce,
+      payload: parsed.args.payload,
+      consistencyLevel: parsed.args.consistencyLevel,
+    });
+  }
+
+  return publications;
+}
+
+/** Builds the mock VAA the destination Core will accept for a publication. */
+export function encodeMockVaa({
+  emitterChainId,
+  emitterAddress,
+  publication,
+}: {
+  emitterChainId: number;
+  emitterAddress: Address;
+  publication: WormholePublication;
+}): string {
+  // Real v1 VAA wire layout with zero mock signatures. The CCIP service parses
+  // this exact layout; MockWormholeCore deliberately accepts it without doing
+  // Guardian cryptography, which is covered by the Core fork tests.
+  return ethers.utils.solidityPack(
+    [
+      'uint8',
+      'uint32',
+      'uint8',
+      'uint32',
+      'uint32',
+      'uint16',
+      'bytes32',
+      'uint64',
+      'uint8',
+      'bytes',
+    ],
+    [
+      1,
+      0,
+      0,
+      1_700_000_000,
+      publication.nonce,
+      emitterChainId,
+      addressToBytes32(emitterAddress),
+      publication.sequence,
+      publication.consistencyLevel,
+      publication.payload,
+    ],
+  );
+}
+
+/**
+ * Submits a VAA to the destination router from an account with no relationship
+ * to the Executor quote, proving the callback is permissionless.
+ */
+export async function submitExecutorCallback({
+  multiProvider,
+  chain,
+  router,
+  encodedVaa,
+  rescuerKey,
+}: {
+  multiProvider: MultiProvider;
+  chain: ChainName;
+  router: Address;
+  encodedVaa: string;
+  rescuerKey: string;
+}): Promise<void> {
+  const provider = multiProvider.getProvider(chain);
+  const rescuer = new ethers.Wallet(rescuerKey, provider);
+
+  const iface = new ethers.utils.Interface([
+    'function executeVAAv1(bytes encodedVaa) payable',
+  ]);
+  const tx = await rescuer.sendTransaction({
+    to: router,
+    data: iface.encodeFunctionData('executeVAAv1', [encodedVaa]),
+  });
+  await tx.wait();
+}
+
+/**
+ * Deterministic stand-in for Wormholescan.
+ *
+ * Only the upstream VAA endpoint is faked. The `WormholeVaaService` that reads
+ * from it runs for real, so the ABI handler, the receipt scan, the tuple
+ * recheck, and the response encoding are all exercised.
+ */
+export interface LocalVaaUpstream {
+  url: string;
+  close: () => Promise<void>;
+  setAvailable: (available: boolean) => void;
+  requestCount: () => number;
+}
+
+export async function startVaaUpstream(
+  vaaForId: (vaaId: string) => string | undefined,
+): Promise<LocalVaaUpstream> {
+  let available = true;
+  let requests = 0;
+
+  const server = http.createServer((req, res) => {
+    requests += 1;
+    if (!available) {
+      res.writeHead(503).end('unavailable');
+      return;
+    }
+
+    const vaaId = (req.url ?? '').replace('/api/v1/vaas/', '');
+    const encodedVaa = vaaForId(vaaId);
+    if (!encodedVaa) {
+      // Wormholescan answers 404 while Guardians have not signed yet.
+      res.writeHead(404).end(JSON.stringify({ error: 'not found' }));
+      return;
+    }
+
+    const base64 = Buffer.from(ethers.utils.arrayify(encodedVaa)).toString(
+      'base64',
+    );
+    res
+      .writeHead(200, { 'Content-Type': 'application/json' })
+      .end(JSON.stringify({ data: { vaa: base64 } }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert(
+    address && typeof address === 'object',
+    'Failed to bind the VAA upstream',
+  );
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+    setAvailable: (value: boolean) => {
+      available = value;
+    },
+    requestCount: () => requests,
+  };
+}
+
+/**
+ * Starts the real `WormholeVaaService` by running the ccip-server with only the
+ * `wormhole` module enabled.
+ *
+ * Running the actual server — rather than re-mounting the router in-process —
+ * keeps the express wiring, the ABI handler, and the CCIP-read response shape
+ * inside this test's blast radius, which is the point of the E2E.
+ */
+export interface LocalVaaService {
+  url: string;
+  close: () => Promise<void>;
+}
+
+export interface WormholeServiceRoute {
+  core: Address;
+  wormholeChainId: number;
+  router: Address;
+}
+
+export async function startWormholeVaaService({
+  port,
+  upstreamUrl,
+  routes,
+}: {
+  port: number;
+  upstreamUrl: string;
+  routes: Record<string, WormholeServiceRoute>;
+}): Promise<LocalVaaService> {
+  const serverProcess: ProcessPromise = $({
+    env: {
+      ...process.env,
+      ENABLED_MODULES: 'wormhole',
+      SERVER_PORT: String(port),
+      REGISTRY_URI: REGISTRY_PATH,
+      WORMHOLE_VAA_URLS: upstreamUrl,
+      WORMHOLE_ROUTES: JSON.stringify(routes),
+      WORMHOLE_VAA_MAX_ATTEMPTS: '3',
+      WORMHOLE_VAA_RETRY_DELAY_MS: '250',
+      // The relayer supplies origin_tx_hash, so the Explorer is never reached.
+      HYPERLANE_EXPLORER_URL: 'http://127.0.0.1:1',
+    },
+    nothrow: true,
+  })`pnpm --filter @hyperlane-xyz/ccip-server run start`;
+
+  const health = `http://127.0.0.1:${port}/health`;
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      const response = await fetch(health);
+      if (response.ok) break;
+    } catch {
+      // Not listening yet.
+    }
+    assert(Date.now() < deadline, 'WormholeVaaService did not become healthy');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return {
+    url: `http://127.0.0.1:${port}/wormhole/getWormholeVaa`,
+    close: async () => {
+      await serverProcess.kill();
+    },
+  };
+}

--- a/typescript/cli/src/tests/ethereum/wormhole/wormhole-hook-ism.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/wormhole/wormhole-hook-ism.e2e-test.ts
@@ -1,0 +1,464 @@
+import { expect } from 'chai';
+
+import { type ChainAddresses } from '@hyperlane-xyz/registry';
+import {
+  type ChainMap,
+  type ChainName,
+  type DerivedCoreConfig,
+  EvmWormholeHookIsmModule,
+  WormholeConsistencyLevel,
+  WormholeConsistencyType,
+  WormholeVariant,
+} from '@hyperlane-xyz/sdk';
+import { type Address, addressToBytes32, assert } from '@hyperlane-xyz/utils';
+
+import { getContext } from '../../../context/context.js';
+import { writeYamlOrJson } from '../../../utils/files.js';
+import {
+  hyperlaneCoreApply,
+  hyperlaneCoreDeploy,
+  readCoreConfig,
+} from '../commands/core.js';
+import { hyperlaneSendMessage, hyperlaneStatus } from '../commands/helpers.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  TEMP_PATH,
+} from '../consts.js';
+
+import {
+  WH_CHAIN_ID_2,
+  WH_CHAIN_ID_3,
+  type WormholeChainFixture,
+  buildMeshConfig,
+  deployWormholeMesh,
+  deployWormholeMocks,
+  encodeMockVaa,
+  getMultiProvider,
+  readPublications,
+  setRecipientIsm,
+  startVaaUpstream,
+  startWormholeVaaService,
+  submitExecutorCallback,
+} from './fixtures.js';
+
+const DIRECTIONS: ReadonlyArray<readonly [ChainName, ChainName]> = [
+  [CHAIN_NAME_2, CHAIN_NAME_3],
+  [CHAIN_NAME_3, CHAIN_NAME_2],
+];
+
+// Second anvil account: an arbitrary submitter with no Executor relationship.
+const RESCUER_KEY =
+  '0x' +
+  ['59c6995e998f97a5a0044966f0945389', 'dc9e86dae88c7a8412f4603b6b78690d'].join(
+    '',
+  );
+
+const VAA_SERVICE_PORT = 3801;
+
+function extractDispatchTx(output: string): string {
+  const match = output.match(/Dispatch TX: (0x[a-fA-F0-9]{64})/);
+  assert(match, 'Could not extract dispatch TX from send output');
+  return match[1];
+}
+
+function extractMessageId(output: string): string {
+  const match = output.match(/Message ID: (0x[a-fA-F0-9]{64})/);
+  assert(match, 'Could not extract message ID from send output');
+  return match[1];
+}
+
+describe('hyperlane wormhole hook/ISM e2e tests', function () {
+  this.timeout(10 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  const chains: Array<ChainName> = [CHAIN_NAME_2, CHAIN_NAME_3];
+  let addresses: ChainMap<ChainAddresses>;
+  let mocks: ChainMap<WormholeChainFixture>;
+
+  before(async function () {
+    await hyperlaneCoreDeploy(CHAIN_NAME_2, CORE_CONFIG_PATH);
+    await hyperlaneCoreDeploy(CHAIN_NAME_3, CORE_CONFIG_PATH);
+
+    const { registry } = await getContext({
+      registryUris: [REGISTRY_PATH],
+      key: ANVIL_KEY,
+    });
+    const chainAddresses = await registry.getAddresses();
+    addresses = {
+      [CHAIN_NAME_2]: chainAddresses[CHAIN_NAME_2],
+      [CHAIN_NAME_3]: chainAddresses[CHAIN_NAME_3],
+    };
+
+    const multiProvider = await getMultiProvider();
+    mocks = {
+      [CHAIN_NAME_2]: await deployWormholeMocks(
+        multiProvider,
+        CHAIN_NAME_2,
+        WH_CHAIN_ID_2,
+      ),
+      [CHAIN_NAME_3]: await deployWormholeMocks(
+        multiProvider,
+        CHAIN_NAME_3,
+        WH_CHAIN_ID_3,
+      ),
+    };
+  });
+
+  /**
+   * Installs the deployed router as the Mailbox default hook through the
+   * standard `hyperlane core read` -> edit -> `hyperlane core apply` flow, and
+   * points the test application's ISM at the same address.
+   */
+  async function installRouters(routers: ChainMap<Address>): Promise<void> {
+    const multiProvider = await getMultiProvider();
+
+    for (const chain of chains) {
+      const configPath = `${TEMP_PATH}/${chain}/wormhole-core-config.yaml`;
+      const current = await readCoreConfig(chain, configPath);
+
+      writeYamlOrJson(configPath, {
+        ...current,
+        // Combined hook/ISM routers are address-only in generic core configs;
+        // their concrete Wormhole variant is recovered by the on-chain reader.
+        defaultHook: routers[chain],
+      });
+      const applyResult = await hyperlaneCoreApply(chain, configPath).nothrow();
+      assert(
+        applyResult.exitCode === 0,
+        `core apply failed on ${chain}:\n${applyResult.stdout}\n${applyResult.stderr}`,
+      );
+
+      // The core deployment gives TestRecipient its own ISM, so the Mailbox
+      // default ISM is not consulted for it.
+      await setRecipientIsm(
+        multiProvider,
+        chain,
+        addresses[chain].testRecipient,
+        routers[chain],
+      );
+    }
+  }
+
+  /** Asserts the read-back mesh is reciprocal and one address serves both roles. */
+  async function assertMeshReadsBack(
+    routers: ChainMap<Address>,
+    variant: WormholeVariant,
+  ): Promise<void> {
+    const multiProvider = await getMultiProvider();
+    const configs = await EvmWormholeHookIsmModule.readMesh(
+      multiProvider,
+      routers,
+    );
+
+    for (const chain of chains) {
+      const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+      const config = configs[chain];
+
+      expect(config.type).to.equal(variant);
+      expect(config.owner).to.equal(ANVIL_DEPLOYER_ADDRESS);
+      expect(config.core.toLowerCase()).to.equal(
+        mocks[chain].core.address.toLowerCase(),
+      );
+      expect(config.consistencyLevel).to.deep.equal({
+        type: WormholeConsistencyType.Finalized,
+      });
+
+      const route = config.remoteRouters[remote];
+      expect(route, `${chain} does not enroll ${remote}`).to.not.be.undefined;
+      expect(route.router.toLowerCase()).to.equal(
+        routers[remote].toLowerCase(),
+      );
+      expect(route.wormholeChainId).to.equal(mocks[remote].wormholeChainId);
+      expect(route.expectedConsistencyLevel).to.equal(
+        WormholeConsistencyLevel.Finalized,
+      );
+
+      if (variant === WormholeVariant.Executor) {
+        expect(config.executorQuoterRouter?.toLowerCase()).to.equal(
+          mocks[chain].quoterRouter.address.toLowerCase(),
+        );
+        expect(route.quoter).to.not.be.undefined;
+        expect(BigInt(route.callbackGasLimit ?? 0) > 0n).to.be.true;
+      } else {
+        expect(config.urls?.length).to.be.greaterThan(0);
+      }
+
+      // One deployed address serves as both the hook and the ISM.
+      const core: DerivedCoreConfig = await readCoreConfig(
+        chain,
+        `${TEMP_PATH}/${chain}/wormhole-core-read.yaml`,
+      );
+      const defaultHook = core.defaultHook;
+      assert(
+        typeof defaultHook !== 'string',
+        'Expected a structured default hook config',
+      );
+      expect(defaultHook.address?.toLowerCase()).to.equal(
+        routers[chain].toLowerCase(),
+      );
+    }
+  }
+
+  /** Sends one message and asserts the origin published exactly one payload. */
+  async function sendAndAssertPublication(
+    origin: ChainName,
+    destination: ChainName,
+    routers: ChainMap<Address>,
+  ) {
+    const sendResult = await hyperlaneSendMessage(origin, destination, {
+      quick: true,
+    });
+    const dispatchTx = extractDispatchTx(sendResult.stdout);
+    const messageId = extractMessageId(sendResult.stdout);
+
+    const multiProvider = await getMultiProvider();
+    const publications = await readPublications(
+      multiProvider,
+      origin,
+      dispatchTx,
+      mocks[origin].core,
+    );
+
+    expect(
+      publications.length,
+      'expected exactly one Core publication',
+    ).to.equal(1);
+    const publication = publications[0];
+    expect(publication.sender.toLowerCase()).to.equal(
+      routers[origin].toLowerCase(),
+    );
+    expect(publication.consistencyLevel).to.equal(
+      WormholeConsistencyLevel.Finalized,
+    );
+
+    // The payload binds this exact message to the destination router.
+    expect(publication.payload.toLowerCase()).to.contain(
+      messageId.slice(2).toLowerCase(),
+    );
+    expect(publication.payload.toLowerCase()).to.contain(
+      addressToBytes32(routers[destination]).slice(2).toLowerCase(),
+    );
+
+    return { dispatchTx, messageId, publication };
+  }
+
+  describe('Executor variant', function () {
+    let routers: ChainMap<Address>;
+
+    before(async function () {
+      const multiProvider = await getMultiProvider();
+      const mesh = buildMeshConfig({
+        variant: WormholeVariant.Executor,
+        origin: mocks[CHAIN_NAME_2],
+        destination: mocks[CHAIN_NAME_3],
+        mailboxes: {
+          [CHAIN_NAME_2]: addresses[CHAIN_NAME_2].mailbox,
+          [CHAIN_NAME_3]: addresses[CHAIN_NAME_3].mailbox,
+        },
+        owner: ANVIL_DEPLOYER_ADDRESS,
+      });
+
+      routers = await deployWormholeMesh(multiProvider, mesh);
+      await installRouters(routers);
+    });
+
+    it('reads back a reciprocal mesh with Executor delivery config', async function () {
+      await assertMeshReadsBack(routers, WormholeVariant.Executor);
+    });
+
+    it('records an Executor request for each dispatch', async function () {
+      const { publication } = await sendAndAssertPublication(
+        CHAIN_NAME_2,
+        CHAIN_NAME_3,
+        routers,
+      );
+
+      const request = await mocks[CHAIN_NAME_2].quoterRouter.lastRequest();
+      expect(request.dstChain).to.equal(WH_CHAIN_ID_3);
+      expect(request.dstAddr.toLowerCase()).to.equal(
+        addressToBytes32(routers[CHAIN_NAME_3]).toLowerCase(),
+      );
+      // ERV1 request carrying the sequence that was actually published.
+      expect(request.requestBytes.toLowerCase()).to.contain(
+        Buffer.from('ERV1').toString('hex'),
+      );
+      const sequenceHex = BigInt(publication.sequence)
+        .toString(16)
+        .padStart(16, '0');
+      expect(request.requestBytes.toLowerCase().endsWith(sequenceHex)).to.be
+        .true;
+    });
+
+    for (const [origin, destination] of DIRECTIONS) {
+      it(`self-relays ${origin} -> ${destination} only after the callback`, async function () {
+        const { dispatchTx, messageId, publication } =
+          await sendAndAssertPublication(origin, destination, routers);
+
+        // Before the callback the message is unauthorized, so self-relay fails.
+        const before = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(
+          before.exitCode,
+          'self-relay must fail before the callback',
+        ).to.not.equal(0);
+
+        const multiProvider = await getMultiProvider();
+        await submitExecutorCallback({
+          multiProvider,
+          chain: destination,
+          router: routers[destination],
+          encodedVaa: encodeMockVaa({
+            emitterChainId: mocks[origin].wormholeChainId,
+            emitterAddress: routers[origin],
+            publication,
+          }),
+          rescuerKey: RESCUER_KEY,
+        });
+
+        const after = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        });
+        expect(after.exitCode).to.equal(0);
+
+        const status = await hyperlaneStatus({
+          origin,
+          messageId,
+          quick: true,
+        });
+        expect(status.stdout).to.include('delivered');
+      });
+    }
+  });
+
+  describe('direct-VAA variant', function () {
+    let routers: ChainMap<Address>;
+    let upstream: Awaited<ReturnType<typeof startVaaUpstream>>;
+    let service: Awaited<ReturnType<typeof startWormholeVaaService>>;
+    const signedVaas = new Map<string, string>();
+
+    before(async function () {
+      upstream = await startVaaUpstream((vaaId) => signedVaas.get(vaaId));
+
+      const multiProvider = await getMultiProvider();
+      const serviceUrl = `http://127.0.0.1:${VAA_SERVICE_PORT}/wormhole/getWormholeVaa`;
+      const mesh = buildMeshConfig({
+        variant: WormholeVariant.DirectVaa,
+        origin: mocks[CHAIN_NAME_2],
+        destination: mocks[CHAIN_NAME_3],
+        mailboxes: {
+          [CHAIN_NAME_2]: addresses[CHAIN_NAME_2].mailbox,
+          [CHAIN_NAME_3]: addresses[CHAIN_NAME_3].mailbox,
+        },
+        owner: ANVIL_DEPLOYER_ADDRESS,
+        urls: [serviceUrl],
+      });
+
+      routers = await deployWormholeMesh(multiProvider, mesh);
+      await installRouters(routers);
+
+      service = await startWormholeVaaService({
+        port: VAA_SERVICE_PORT,
+        upstreamUrl: upstream.url,
+        routes: {
+          [CHAIN_NAME_2]: {
+            core: mocks[CHAIN_NAME_2].core.address,
+            wormholeChainId: WH_CHAIN_ID_2,
+            router: routers[CHAIN_NAME_2],
+          },
+          [CHAIN_NAME_3]: {
+            core: mocks[CHAIN_NAME_3].core.address,
+            wormholeChainId: WH_CHAIN_ID_3,
+            router: routers[CHAIN_NAME_3],
+          },
+        },
+      });
+    });
+
+    after(async function () {
+      await service?.close();
+      await upstream?.close();
+    });
+
+    it('reads back a reciprocal mesh with CCIP-read URLs', async function () {
+      await assertMeshReadsBack(routers, WormholeVariant.DirectVaa);
+    });
+
+    it('never asks the Executor Quoter Router for a quote', async function () {
+      const before = (
+        await mocks[CHAIN_NAME_2].quoterRouter.requestCount()
+      ).toString();
+
+      await sendAndAssertPublication(CHAIN_NAME_2, CHAIN_NAME_3, routers);
+
+      const after = (
+        await mocks[CHAIN_NAME_2].quoterRouter.requestCount()
+      ).toString();
+      expect(after).to.equal(before);
+    });
+
+    for (const [origin, destination] of DIRECTIONS) {
+      it(`self-relays ${origin} -> ${destination} through the lookup service`, async function () {
+        const { dispatchTx, messageId, publication } =
+          await sendAndAssertPublication(origin, destination, routers);
+
+        const emitter = addressToBytes32(routers[origin]).slice(2);
+        const vaaId = `${mocks[origin].wormholeChainId}/${emitter}/${publication.sequence}`;
+
+        // While the upstream has no VAA the relayer cannot build metadata, and
+        // no delivery state is written.
+        const pending = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(
+          pending.exitCode,
+          'self-relay must fail without a VAA',
+        ).to.not.equal(0);
+
+        signedVaas.set(
+          vaaId,
+          encodeMockVaa({
+            emitterChainId: mocks[origin].wormholeChainId,
+            emitterAddress: routers[origin],
+            publication,
+          }),
+        );
+
+        const relayed = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(
+          relayed.exitCode,
+          `self-relay failed:\n${relayed.stdout}\n${relayed.stderr}`,
+        ).to.equal(0);
+
+        const status = await hyperlaneStatus({
+          origin,
+          messageId,
+          quick: true,
+        });
+        expect(status.stdout).to.include('delivered');
+
+        // The service really was consulted rather than bypassed.
+        expect(upstream.requestCount()).to.be.greaterThan(0);
+      });
+    }
+  });
+});

--- a/typescript/cli/src/tests/ethereum/wormhole/wormhole-warp.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/wormhole/wormhole-warp.e2e-test.ts
@@ -1,0 +1,495 @@
+import { expect } from 'chai';
+import { constants } from 'ethers';
+
+import {
+  DefaultHook__factory,
+  MailboxClient__factory,
+  StaticAggregationHook__factory,
+  WormholeExecutorHookIsm__factory,
+  WormholeVaaHookIsm__factory,
+} from '@hyperlane-xyz/core';
+import {
+  EvmWormholeHookIsmReader,
+  type HookConfig,
+  HookType,
+  IsmType,
+  TokenType,
+  type WarpRouteDeployConfigMailboxRequired,
+  WormholeConsistencyLevel,
+  WormholeConsistencyType,
+  WormholeVariant,
+} from '@hyperlane-xyz/sdk';
+import { addressToBytes32, assert, type Address } from '@hyperlane-xyz/utils';
+
+import { syncWarpDeployConfigToRegistry } from '../../commands/warp-config-sync.js';
+import { writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import {
+  getDeployedWarpAddress,
+  setSignerForChain,
+} from '../commands/helpers.js';
+import {
+  hyperlaneWarpApply,
+  hyperlaneWarpCheck,
+  hyperlaneWarpDeploy,
+  readWarpConfig,
+} from '../commands/warp.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  TEMP_PATH,
+  getCombinedWarpRoutePath,
+  getWarpRouteId,
+} from '../consts.js';
+
+import {
+  CALLBACK_GAS_LIMIT,
+  WH_CHAIN_ID_2,
+  WH_CHAIN_ID_3,
+  type WormholeChainFixture,
+  deployWormholeMocks,
+  getMultiProvider,
+} from './fixtures.js';
+
+describe('hyperlane warp deploy/apply with Wormhole hook/ISM', function () {
+  this.timeout(10 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  const chains = [CHAIN_NAME_2, CHAIN_NAME_3];
+  let mailboxes: Record<string, Address>;
+  let mocks: Record<string, WormholeChainFixture>;
+
+  before(async () => {
+    const [chain2Core, chain3Core] = await Promise.all([
+      deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+      deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+    ]);
+    mailboxes = {
+      [CHAIN_NAME_2]: chain2Core.mailbox,
+      [CHAIN_NAME_3]: chain3Core.mailbox,
+    };
+
+    const multiProvider = await getMultiProvider();
+    mocks = {
+      [CHAIN_NAME_2]: await deployWormholeMocks(
+        multiProvider,
+        CHAIN_NAME_2,
+        WH_CHAIN_ID_2,
+      ),
+      [CHAIN_NAME_3]: await deployWormholeMocks(
+        multiProvider,
+        CHAIN_NAME_3,
+        WH_CHAIN_ID_3,
+      ),
+    };
+  });
+
+  function configFor(
+    variant: WormholeVariant,
+    symbol: string,
+  ): WarpRouteDeployConfigMailboxRequired {
+    const configs: WarpRouteDeployConfigMailboxRequired = {};
+    for (const [index, chain] of chains.entries()) {
+      const remote = chains[index === 0 ? 1 : 0];
+      const wormholeHook: HookConfig =
+        variant === WormholeVariant.Executor
+          ? {
+              type: HookType.WORMHOLE_EXECUTOR,
+              executorQuoterRouter: mocks[chain].quoterRouter.address,
+              routes: {
+                [remote]: {
+                  quoter: ANVIL_DEPLOYER_ADDRESS,
+                  callbackGasLimit: CALLBACK_GAS_LIMIT,
+                },
+              },
+            }
+          : { type: HookType.WORMHOLE_VAA };
+      const hook: HookConfig = {
+        type: HookType.AGGREGATION,
+        hooks: [{ type: HookType.MAILBOX_DEFAULT }, wormholeHook],
+      };
+      const interchainSecurityModule =
+        variant === WormholeVariant.Executor
+          ? {
+              type: IsmType.WORMHOLE_EXECUTOR,
+              owner: ANVIL_DEPLOYER_ADDRESS,
+              core: mocks[chain].core.address,
+              wormholeChainId: mocks[chain].wormholeChainId,
+              consistencyLevel: { type: WormholeConsistencyType.Finalized },
+            }
+          : {
+              type: IsmType.WORMHOLE_VAA,
+              owner: ANVIL_DEPLOYER_ADDRESS,
+              core: mocks[chain].core.address,
+              wormholeChainId: mocks[chain].wormholeChainId,
+              consistencyLevel: { type: WormholeConsistencyType.Finalized },
+              urls: ['https://vaa.example/v1'],
+            };
+      configs[chain] = {
+        type: index === 0 ? TokenType.native : TokenType.synthetic,
+        owner: ANVIL_DEPLOYER_ADDRESS,
+        mailbox: mailboxes[chain],
+        name: `${symbol} token`,
+        symbol,
+        decimals: 18,
+        hook,
+        interchainSecurityModule,
+      };
+    }
+    return configs;
+  }
+
+  function withoutWormhole(
+    config: WarpRouteDeployConfigMailboxRequired,
+  ): WarpRouteDeployConfigMailboxRequired {
+    return Object.fromEntries(
+      Object.entries(config).map(([chain, chainConfig]) => [
+        chain,
+        {
+          ...chainConfig,
+          hook: { type: HookType.MAILBOX_DEFAULT },
+          interchainSecurityModule: constants.AddressZero,
+        },
+      ]),
+    );
+  }
+
+  async function assertWormholeHookIsExpanded(
+    chain: string,
+    warpCorePath: string,
+    outputPath: string,
+    variant: WormholeVariant,
+  ): Promise<void> {
+    const readConfig = await readWarpConfig(chain, warpCorePath, outputPath, {
+      preserveExistingChains: false,
+    });
+    const hook = readConfig[chain].hook;
+    assert(
+      typeof hook !== 'string' && hook?.type === HookType.AGGREGATION,
+      `Expected aggregation hook on ${chain}`,
+    );
+    const expectedType =
+      variant === WormholeVariant.Executor
+        ? HookType.WORMHOLE_EXECUTOR
+        : HookType.WORMHOLE_VAA;
+    const wormholeHook = hook.hooks.find(
+      (child) => typeof child !== 'string' && child.type === expectedType,
+    );
+    assert(
+      typeof wormholeHook !== 'string' && wormholeHook,
+      `Expected expanded ${expectedType} child on ${chain}`,
+    );
+    assert(
+      'remoteRouters' in wormholeHook &&
+        typeof wormholeHook.remoteRouters === 'object' &&
+        wormholeHook.remoteRouters !== null,
+      `Expected expanded Wormhole remote routers on ${chain}`,
+    );
+    const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+    assert(
+      remote in wormholeHook.remoteRouters,
+      `Expected expanded ${remote} Wormhole router on ${chain}`,
+    );
+  }
+
+  for (const [variant, symbol] of [
+    [WormholeVariant.Executor, 'WHEX'],
+    [WormholeVariant.DirectVaa, 'WHVA'],
+  ] as const) {
+    describe(variant, () => {
+      const configPath = `${TEMP_PATH}/wormhole-${variant}-warp.yaml`;
+      const routeId = getWarpRouteId(symbol, chains);
+      const warpCorePath = getCombinedWarpRoutePath(symbol, chains);
+      let config: WarpRouteDeployConfigMailboxRequired;
+      let wormholeRouters: Record<string, Address>;
+      let aggregationHooks: Record<string, Address>;
+
+      it('adds Wormhole to an existing route through warp apply', async () => {
+        const transitionSymbol = `${symbol}A`;
+        const transitionConfigPath = `${TEMP_PATH}/wormhole-${variant}-apply-warp.yaml`;
+        const transitionRouteId = getWarpRouteId(transitionSymbol, chains);
+        const transitionWarpCorePath = getCombinedWarpRoutePath(
+          transitionSymbol,
+          chains,
+        );
+        const target = configFor(variant, transitionSymbol);
+
+        writeYamlOrJson(transitionConfigPath, withoutWormhole(target));
+        const deployResult = await hyperlaneWarpDeploy(
+          transitionConfigPath,
+          transitionRouteId,
+        );
+        expect(deployResult.exitCode).to.equal(0);
+
+        writeYamlOrJson(transitionConfigPath, target);
+        syncWarpDeployConfigToRegistry({
+          warpDeployPath: transitionConfigPath,
+          warpRouteId: transitionRouteId,
+          registryPath: REGISTRY_PATH,
+        });
+        const applyResult = await hyperlaneWarpApply(transitionRouteId);
+        expect(applyResult.exitCode).to.equal(0);
+
+        const multiProvider = await getMultiProvider();
+        for (const chain of chains) {
+          const warpRouter = getDeployedWarpAddress(
+            chain,
+            transitionWarpCorePath,
+          );
+          const client = MailboxClient__factory.connect(
+            warpRouter,
+            multiProvider.getProvider(chain),
+          );
+          const [hookAddress, ismAddress] = await Promise.all([
+            client.hook(),
+            client.interchainSecurityModule(),
+          ]);
+          expect(ismAddress).not.to.equal(constants.AddressZero);
+          const childHooks = await StaticAggregationHook__factory.connect(
+            hookAddress,
+            multiProvider.getProvider(chain),
+          ).hooks('0x');
+          expect(childHooks).to.include(ismAddress);
+
+          await assertWormholeHookIsExpanded(
+            chain,
+            transitionWarpCorePath,
+            `${TEMP_PATH}/wormhole-${variant}-${chain}-read.yaml`,
+            variant,
+          );
+        }
+      });
+
+      it('deploys and updates through the real warp commands', async () => {
+        config = configFor(variant, symbol);
+        writeYamlOrJson(configPath, config);
+
+        const result = await hyperlaneWarpDeploy(configPath, routeId);
+        expect(result.exitCode).to.equal(0);
+
+        const multiProvider = await getMultiProvider();
+        wormholeRouters = {};
+        aggregationHooks = {};
+        for (const chain of chains) {
+          const warpRouter = getDeployedWarpAddress(chain, warpCorePath);
+          const client = MailboxClient__factory.connect(
+            warpRouter,
+            multiProvider.getProvider(chain),
+          );
+          const [hook, ism] = await Promise.all([
+            client.hook(),
+            client.interchainSecurityModule(),
+          ]);
+          expect(hook).not.to.equal(ism);
+          aggregationHooks[chain] = hook;
+          wormholeRouters[chain] = ism;
+
+          const childHooks = await StaticAggregationHook__factory.connect(
+            hook,
+            multiProvider.getProvider(chain),
+          ).hooks('0x');
+          const defaultHook = childHooks.find(
+            (address) => address.toLowerCase() !== ism.toLowerCase(),
+          );
+          assert(defaultHook, `Missing default hook on ${chain}`);
+          expect(childHooks).to.have.length(2);
+          expect(
+            await DefaultHook__factory.connect(
+              defaultHook,
+              multiProvider.getProvider(chain),
+            ).mailbox(),
+          ).to.equal(mailboxes[chain]);
+
+          const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+          const derived = await new EvmWormholeHookIsmReader(
+            multiProvider,
+            chain,
+          ).deriveWormholeConfig(ism);
+          expect(derived.type).to.equal(variant);
+          expect(derived.remoteRouters[remote].router.toLowerCase()).to.equal(
+            wormholeRouters[remote]?.toLowerCase() ??
+              derived.remoteRouters[remote].router.toLowerCase(),
+          );
+        }
+
+        // Assert reciprocal addresses after both local addresses are known.
+        for (const chain of chains) {
+          const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+          const derived = await new EvmWormholeHookIsmReader(
+            multiProvider,
+            chain,
+          ).deriveWormholeConfig(wormholeRouters[chain]);
+          expect(derived.remoteRouters[remote].router.toLowerCase()).to.equal(
+            wormholeRouters[remote].toLowerCase(),
+          );
+        }
+
+        const healthyCheck = await hyperlaneWarpCheck(routeId);
+        expect(healthyCheck.exitCode).to.equal(0);
+
+        // Trust-policy drift lives on the combined hook/ISM, outside the token
+        // router. Check must expose it and apply must repair it.
+        const driftChain = CHAIN_NAME_2;
+        const driftRemote = CHAIN_NAME_3;
+        const remoteRouterEnrollment = {
+          domain: multiProvider.getDomainId(driftRemote),
+          router: addressToBytes32(wormholeRouters[driftRemote]),
+          wormholeChainId: WH_CHAIN_ID_3,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Safe,
+        };
+        setSignerForChain(multiProvider, driftChain, ANVIL_KEY);
+        const signer = multiProvider.getSigner(driftChain);
+        let enrollmentData: string;
+        if (variant === WormholeVariant.Executor) {
+          enrollmentData =
+            WormholeExecutorHookIsm__factory.createInterface().encodeFunctionData(
+              'enrollRemoteRouter(((uint32,bytes32,uint16,uint8),address,uint128))',
+              [
+                {
+                  remoteRouter: remoteRouterEnrollment,
+                  quoter: ANVIL_DEPLOYER_ADDRESS,
+                  callbackGasLimit: CALLBACK_GAS_LIMIT,
+                },
+              ],
+            );
+        } else {
+          enrollmentData =
+            WormholeVaaHookIsm__factory.createInterface().encodeFunctionData(
+              'enrollRemoteRouter((uint32,bytes32,uint16,uint8))',
+              [remoteRouterEnrollment],
+            );
+        }
+        await (
+          await signer.sendTransaction({
+            to: wormholeRouters[driftChain],
+            data: enrollmentData,
+          })
+        ).wait();
+
+        const driftCheck = await hyperlaneWarpCheck(routeId).nothrow();
+        expect(driftCheck.exitCode).not.to.equal(0);
+        expect(`${driftCheck.stdout}\n${driftCheck.stderr}`).to.include(
+          'wormholeRemoteRouters',
+        );
+
+        const repairApply = await hyperlaneWarpApply(routeId);
+        expect(repairApply.exitCode).to.equal(0);
+        const repairedCheck = await hyperlaneWarpCheck(routeId);
+        expect(repairedCheck.exitCode).to.equal(0);
+
+        if (variant === WormholeVariant.Executor) {
+          for (const chain of chains) {
+            const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+            const hook = config[chain].hook;
+            if (
+              typeof hook !== 'string' &&
+              hook?.type === HookType.AGGREGATION
+            ) {
+              const wormholeHook = hook.hooks.find(
+                (child) =>
+                  typeof child !== 'string' &&
+                  child.type === HookType.WORMHOLE_EXECUTOR,
+              );
+              if (
+                typeof wormholeHook !== 'string' &&
+                wormholeHook?.type === HookType.WORMHOLE_EXECUTOR
+              ) {
+                wormholeHook.routes[remote].callbackGasLimit = 500_000n;
+              }
+            }
+          }
+        } else {
+          for (const chain of chains) {
+            const ism = config[chain].interchainSecurityModule;
+            if (typeof ism !== 'string' && ism?.type === IsmType.WORMHOLE_VAA) {
+              ism.urls = ['https://vaa.example/v2'];
+            }
+          }
+        }
+        writeYamlOrJson(configPath, config);
+        syncWarpDeployConfigToRegistry({
+          warpDeployPath: configPath,
+          warpRouteId: routeId,
+          registryPath: REGISTRY_PATH,
+        });
+
+        const applyResult = await hyperlaneWarpApply(routeId);
+        expect(applyResult.exitCode).to.equal(0);
+
+        for (const chain of chains) {
+          const warpRouter = getDeployedWarpAddress(chain, warpCorePath);
+          const client = MailboxClient__factory.connect(
+            warpRouter,
+            multiProvider.getProvider(chain),
+          );
+          expect(await client.hook()).to.equal(aggregationHooks[chain]);
+          expect(await client.interchainSecurityModule()).to.equal(
+            wormholeRouters[chain],
+          );
+
+          const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+          const derived = await new EvmWormholeHookIsmReader(
+            multiProvider,
+            chain,
+          ).deriveWormholeConfig(wormholeRouters[chain]);
+          if (variant === WormholeVariant.Executor) {
+            expect(derived.remoteRouters[remote].callbackGasLimit).to.equal(
+              500_000n,
+            );
+          } else {
+            expect(derived.urls).to.deep.equal(['https://vaa.example/v2']);
+          }
+        }
+
+        const idempotent = await hyperlaneWarpApply(routeId);
+        expect(idempotent.exitCode).to.equal(0);
+        expect(idempotent.stdout).to.include(
+          'Warp config is the same as target. No updates needed.',
+        );
+
+        const previousRouters = { ...wormholeRouters };
+        for (const chain of chains) {
+          const ism = config[chain].interchainSecurityModule;
+          assert(
+            typeof ism !== 'string' &&
+              ism &&
+              (ism.type === IsmType.WORMHOLE_EXECUTOR ||
+                ism.type === IsmType.WORMHOLE_VAA),
+            `Expected Wormhole ISM config on ${chain}`,
+          );
+          ism.consistencyLevel = {
+            type: WormholeConsistencyType.Instant,
+          };
+        }
+        writeYamlOrJson(configPath, config);
+        syncWarpDeployConfigToRegistry({
+          warpDeployPath: configPath,
+          warpRouteId: routeId,
+          registryPath: REGISTRY_PATH,
+        });
+
+        const immutableApply = await hyperlaneWarpApply(routeId);
+        expect(immutableApply.exitCode).to.equal(0);
+
+        for (const chain of chains) {
+          const warpRouter = getDeployedWarpAddress(chain, warpCorePath);
+          const client = MailboxClient__factory.connect(
+            warpRouter,
+            multiProvider.getProvider(chain),
+          );
+          const replacement = await client.interchainSecurityModule();
+          expect(replacement).not.to.equal(previousRouters[chain]);
+          const childHooks = await StaticAggregationHook__factory.connect(
+            await client.hook(),
+            multiProvider.getProvider(chain),
+          ).hooks('0x');
+          expect(childHooks).to.include(replacement);
+        }
+      });
+    });
+  }
+});

--- a/typescript/relayer/src/metadata/builder.ts
+++ b/typescript/relayer/src/metadata/builder.ts
@@ -72,6 +72,12 @@ export class BaseMetadataBuilder implements MetadataBuilder {
       case IsmType.DELAYED_FLOW_ROUTER:
         return this.nullMetadataBuilder.build({ ...context, ism });
 
+      case IsmType.WORMHOLE_EXECUTOR:
+        return this.nullMetadataBuilder.build({
+          ...context,
+          ism: { ...ism, type: IsmType.WORMHOLE_EXECUTOR },
+        });
+
       case IsmType.MERKLE_ROOT_MULTISIG:
       case IsmType.MESSAGE_ID_MULTISIG:
       case IsmType.STORAGE_MERKLE_ROOT_MULTISIG:
@@ -125,6 +131,12 @@ export class BaseMetadataBuilder implements MetadataBuilder {
         return this.ccipReadMetadataBuilder.build({
           ...context,
           ism,
+        });
+
+      case IsmType.WORMHOLE_VAA:
+        return this.ccipReadMetadataBuilder.build({
+          ...context,
+          ism: { ...ism, type: IsmType.WORMHOLE_VAA },
         });
 
       default:

--- a/typescript/relayer/src/metadata/ccipread.ts
+++ b/typescript/relayer/src/metadata/ccipread.ts
@@ -5,6 +5,7 @@ import {
   HyperlaneCore,
   IsmType,
   OffchainLookupIsmConfig,
+  WormholeIsmConfig,
   offchainLookupRequestMessageHash,
 } from '@hyperlane-xyz/sdk';
 import { WithAddress, ensure0x } from '@hyperlane-xyz/utils';
@@ -49,6 +50,15 @@ function extractRevertData(error: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * ISMs that answer `getOffchainVerifyInfo` with an EIP-3668 `OffchainLookup`.
+ * Only the ISM address is needed to trigger it, so the direct-VAA Wormhole
+ * router reuses this builder unchanged.
+ */
+export type OffchainLookupContextConfig =
+  | OffchainLookupIsmConfig
+  | (WormholeIsmConfig & { type: typeof IsmType.WORMHOLE_VAA });
+
 export class OffchainLookupMetadataBuilder implements MetadataBuilder {
   readonly type = IsmType.OFFCHAIN_LOOKUP;
   private core: HyperlaneCore;
@@ -58,9 +68,9 @@ export class OffchainLookupMetadataBuilder implements MetadataBuilder {
   }
 
   async build(
-    context: MetadataContext<WithAddress<OffchainLookupIsmConfig>>,
+    context: MetadataContext<WithAddress<OffchainLookupContextConfig>>,
   ): Promise<CcipReadMetadataBuildResult> {
-    const { ism, message } = context;
+    const { ism, message, dispatchTx } = context;
     const provider = this.core.multiProvider.getProvider(
       message.parsed.destination,
     );
@@ -91,7 +101,7 @@ export class OffchainLookupMetadataBuilder implements MetadataBuilder {
     ];
 
     const baseResult: Omit<CcipReadMetadataBuildResult, 'metadata'> = {
-      type: IsmType.OFFCHAIN_LOOKUP,
+      type: ism.type,
       ismAddress: ism.address,
       urls,
     };
@@ -128,10 +138,13 @@ export class OffchainLookupMetadataBuilder implements MetadataBuilder {
               sender,
               data: callDataHex,
               signature,
+              // Matches the Rust relayer: lets a service locate the origin
+              // event directly instead of querying the Explorer for it.
+              origin_tx_hash: dispatchTx.transactionHash,
             }),
           });
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         this.core.logger.warn(
           `CCIP-read metadata fetch failed for ${url}: ${error}`,
         );

--- a/typescript/relayer/src/metadata/null.ts
+++ b/typescript/relayer/src/metadata/null.ts
@@ -1,4 +1,9 @@
-import { IsmType, MultiProvider, NullIsmConfig } from '@hyperlane-xyz/sdk';
+import {
+  IsmType,
+  MultiProvider,
+  NullIsmConfig,
+  WormholeIsmConfig,
+} from '@hyperlane-xyz/sdk';
 import { WithAddress, assert, eqAddress } from '@hyperlane-xyz/utils';
 
 import type {
@@ -10,14 +15,19 @@ import type {
 export const NULL_METADATA = '0x';
 
 export type NullMetadata = {
-  type: NullIsmConfig['type'];
+  type: NullIsmConfig['type'] | typeof IsmType.WORMHOLE_EXECUTOR;
 };
+
+/** ISM configs whose metadata is always empty. */
+export type EmptyMetadataIsmConfig =
+  | NullIsmConfig
+  | (WormholeIsmConfig & { type: typeof IsmType.WORMHOLE_EXECUTOR });
 
 export class NullMetadataBuilder implements MetadataBuilder {
   constructor(protected multiProvider: MultiProvider) {}
 
   async build(
-    context: MetadataContext<WithAddress<NullIsmConfig>>,
+    context: MetadataContext<WithAddress<EmptyMetadataIsmConfig>>,
   ): Promise<NullMetadataBuildResult> {
     if (context.ism.type === IsmType.TRUSTED_RELAYER) {
       const destinationSigner = await this.multiProvider.getSignerAddress(
@@ -36,7 +46,7 @@ export class NullMetadataBuilder implements MetadataBuilder {
     };
   }
 
-  static decode(ism: NullIsmConfig): NullMetadata {
+  static decode(ism: EmptyMetadataIsmConfig): NullMetadata {
     return { ...ism };
   }
 }

--- a/typescript/relayer/src/metadata/types.ts
+++ b/typescript/relayer/src/metadata/types.ts
@@ -124,7 +124,10 @@ export interface NullMetadataBuildResult extends BaseMetadataBuildResult {
     | typeof IsmType.RATE_LIMITED
     | typeof IsmType.BLACKLIST
     | typeof IsmType.NET_FLOW_RATE_LIMITED
-    | typeof IsmType.DELAYED_FLOW_ROUTER;
+    | typeof IsmType.DELAYED_FLOW_ROUTER
+    // The Executor router is preauthorized by executeVAAv1 before process, so
+    // Hyperlane carries no metadata for it.
+    | typeof IsmType.WORMHOLE_EXECUTOR;
   /** Always present for null ISMs */
   metadata: string;
 }
@@ -140,7 +143,9 @@ export interface ArbL2ToL1MetadataBuildResult extends BaseMetadataBuildResult {
 
 /** Result for offchain lookup (CCIP-Read) ISM */
 export interface CcipReadMetadataBuildResult extends BaseMetadataBuildResult {
-  type: typeof IsmType.OFFCHAIN_LOOKUP;
+  // The direct-VAA Wormhole router reverts with the same OffchainLookup shape
+  // and its response is a single ABI-encoded `bytes`, so it reuses this path.
+  type: typeof IsmType.OFFCHAIN_LOOKUP | typeof IsmType.WORMHOLE_VAA;
   /** URLs configured for offchain lookup */
   urls: string[];
 }

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -85,6 +85,8 @@ import { MAX_GAS_OVERHEAD, TokenType, gasOverhead } from '../token/config.js';
 import { HypERC20Factories, hypERC20factories } from '../token/contracts.js';
 import { HypERC20Deployer, HypERC721Deployer } from '../token/deploy.js';
 import {
+  derivedHookAddress,
+  derivedIsmAddress,
   HypTokenRouterConfig,
   WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
@@ -102,6 +104,7 @@ import {
   resolveDelayedFlowRemoteIsms,
   setRateLimitedIsmRecipient,
 } from '../utils/ism.js';
+import { findWormholeHooks, findWormholeIsms } from '../wormhole/config.js';
 
 import { HyperlaneProxyFactoryDeployer } from './HyperlaneProxyFactoryDeployer.js';
 import {
@@ -2004,6 +2007,10 @@ export async function enrollCrossChainRouters(
 
           const actualConfig = await evmWarpModule.read();
           const targetOwner = resolvedConfigMap[currentChain].owner;
+          const hasWormholeHook =
+            findWormholeHooks(actualConfig.hook).length > 0;
+          const hasWormholeIsm =
+            findWormholeIsms(actualConfig.interchainSecurityModule).length > 0;
           const expectedConfig: HypTokenRouterConfig = {
             ...actualConfig,
             owner: targetOwner,
@@ -2011,16 +2018,18 @@ export async function enrollCrossChainRouters(
             // the deployer until this final pass. Describe their common target
             // owner on both config surfaces so EvmWarpModule can transfer them
             // together after enrollment.
-            interchainSecurityModule:
-              typeof actualConfig.interchainSecurityModule === 'object' &&
-              actualConfig.interchainSecurityModule
+            interchainSecurityModule: hasWormholeIsm
+              ? derivedIsmAddress(actualConfig)
+              : typeof actualConfig.interchainSecurityModule === 'object' &&
+                  actualConfig.interchainSecurityModule
                 ? mapHybridIsmNodes(
                     actualConfig.interchainSecurityModule,
                     (node) => ({ ...node, owner: targetOwner }),
                   )
                 : actualConfig.interchainSecurityModule,
-            hook:
-              typeof actualConfig.hook === 'object' && actualConfig.hook
+            hook: hasWormholeHook
+              ? derivedHookAddress(actualConfig)
+              : typeof actualConfig.hook === 'object' && actualConfig.hook
                 ? mapHybridHookNodes(actualConfig.hook, (node) => ({
                     ...node,
                     owner: targetOwner,

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -223,9 +223,14 @@ export class EvmHookModule extends HyperlaneModule<
     }
 
     // We need to normalize the current and target configs to compare.
-    let normalizedTargetConfig: HookConfig = normalizeConfig(
-      await this.reader.deriveHookConfig(targetConfig),
-    );
+    const derivedTargetConfig =
+      await this.reader.deriveHookConfig(targetConfig);
+    let normalizedTargetConfig: HookConfig =
+      typeof targetConfig === 'string' &&
+      (derivedTargetConfig.type === HookType.WORMHOLE_EXECUTOR ||
+        derivedTargetConfig.type === HookType.WORMHOLE_VAA)
+        ? targetConfig
+        : normalizeConfig(derivedTargetConfig);
     for (const address of opaqueHybridAddresses) {
       normalizedTargetConfig = resolveHybridHookNodesToAddress(
         normalizedTargetConfig,

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -81,8 +81,9 @@ import {
 import { EvmHookReader } from './EvmHookReader.js';
 import { DeployedHook, HookFactories, hookFactories } from './contracts.js';
 import {
-  collapseMatchingHybridHookNodes,
-  resolveHybridHookNodesToAddress,
+  collapseMatchingCombinedHookIsmNodes,
+  isCombinedHookIsmHookNode,
+  resolveCombinedHookIsmNodesToAddress,
 } from './utils.js';
 import {
   AggregationHookConfig,
@@ -215,7 +216,7 @@ export class EvmHookModule extends HyperlaneModule<
 
   public async update(
     targetConfig: HookConfig,
-    opaqueHybridAddresses: Address[] = [],
+    opaqueCombinedHookIsmAddresses: Address[] = [],
   ): Promise<AnnotatedEV5Transaction[]> {
     // Nothing to do if its the default hook
     if (typeof targetConfig === 'string' && isZeroishAddress(targetConfig)) {
@@ -227,20 +228,22 @@ export class EvmHookModule extends HyperlaneModule<
       await this.reader.deriveHookConfig(targetConfig);
     let normalizedTargetConfig: HookConfig =
       typeof targetConfig === 'string' &&
-      (derivedTargetConfig.type === HookType.WORMHOLE_EXECUTOR ||
-        derivedTargetConfig.type === HookType.WORMHOLE_VAA)
+      isCombinedHookIsmHookNode(derivedTargetConfig)
         ? targetConfig
         : normalizeConfig(derivedTargetConfig);
-    for (const address of opaqueHybridAddresses) {
-      normalizedTargetConfig = resolveHybridHookNodesToAddress(
+    for (const address of opaqueCombinedHookIsmAddresses) {
+      normalizedTargetConfig = resolveCombinedHookIsmNodesToAddress(
         normalizedTargetConfig,
         address,
       );
     }
     normalizedTargetConfig = normalizeConfig(normalizedTargetConfig);
     let currentConfig: HookConfig = await this.read();
-    for (const address of opaqueHybridAddresses) {
-      currentConfig = collapseMatchingHybridHookNodes(currentConfig, address);
+    for (const address of opaqueCombinedHookIsmAddresses) {
+      currentConfig = collapseMatchingCombinedHookIsmNodes(
+        currentConfig,
+        address,
+      );
     }
     const normalizedCurrentConfig: HookConfig = normalizeConfig(currentConfig);
 

--- a/typescript/sdk/src/hook/EvmHookReader.test.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.test.ts
@@ -33,7 +33,7 @@ import {
   StorageGasOracle,
   StorageGasOracle__factory,
 } from '@hyperlane-xyz/core';
-import { WithAddress, addressToBytes32 } from '@hyperlane-xyz/utils';
+import { WithAddress, addressToBytes32, assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName, test1 } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
@@ -44,6 +44,9 @@ import {
 } from '../test/errors.js';
 import { contractDouble } from '../test/contractDouble.js';
 import { randomAddress } from '../test/testUtils.js';
+import { EvmWormholeHookIsmReader } from '../wormhole/EvmWormholeHookIsmReader.js';
+import { WormholeConsistencyType } from '../wormhole/consistency.js';
+import { WormholeVariant } from '../wormhole/types.js';
 
 import { EvmHookReader } from './EvmHookReader.js';
 import {
@@ -60,6 +63,7 @@ import {
   PausableHookConfig,
   ProtocolFeeHookConfig,
   RateLimitedHookConfig,
+  WormholeHookConfig,
 } from './types.js';
 
 // Message HyperlaneJsonRpcProvider emits for an empty eth_call result, which
@@ -163,6 +167,124 @@ describe('EvmHookReader', () => {
     // should get same result if we call the specific method for the hook type
     const config = await evmHookReader.deriveProtocolFeeConfig(mockAddress);
     expect(config).to.deep.equal(hookConfig);
+  });
+
+  describe('nested Wormhole hooks', () => {
+    const wormholeAddress = randomAddress();
+    const derivedWormholeHook = {
+      address: wormholeAddress,
+      type: HookType.WORMHOLE_EXECUTOR,
+      executorQuoterRouter: randomAddress(),
+      routes: {},
+    } as const;
+
+    it('preserves the address for deployment readers', async () => {
+      sandbox
+        .stub(evmHookReader, 'deriveHookConfigFromAddress')
+        .resolves(derivedWormholeHook);
+
+      const config = await evmHookReader.deriveHookConfig({
+        type: HookType.AGGREGATION,
+        hooks: [wormholeAddress],
+      });
+
+      assert(
+        config.type === HookType.AGGREGATION,
+        'Expected aggregation hook config',
+      );
+      expect(config.hooks).to.deep.equal([wormholeAddress]);
+    });
+
+    it('preserves an undeployed Wormhole config object', async () => {
+      const wormholeConfig: WormholeHookConfig = {
+        type: HookType.WORMHOLE_EXECUTOR,
+        executorQuoterRouter: randomAddress(),
+        routes: {},
+      };
+
+      const config = await evmHookReader.deriveHookConfig({
+        type: HookType.AGGREGATION,
+        hooks: [wormholeConfig],
+      });
+
+      assert(
+        config.type === HookType.AGGREGATION,
+        'Expected aggregation hook config',
+      );
+      expect(config.hooks).to.deep.equal([wormholeConfig]);
+    });
+
+    it('expands the config when requested for diagnostics', async () => {
+      const diagnosticReader = new EvmHookReader(
+        multiProvider,
+        TestChainName.test1,
+        undefined,
+        undefined,
+        { expandWormhole: true },
+      );
+      sandbox
+        .stub(diagnosticReader, 'deriveHookConfigFromAddress')
+        .resolves(derivedWormholeHook);
+
+      const config = await diagnosticReader.deriveHookConfig({
+        type: HookType.AGGREGATION,
+        hooks: [wormholeAddress],
+      });
+
+      assert(
+        config.type === HookType.AGGREGATION,
+        'Expected aggregation hook config',
+      );
+      expect(config.hooks).to.deep.equal([derivedWormholeHook]);
+    });
+  });
+
+  it('includes remote-router trust configuration in Wormhole diagnostics', async () => {
+    const router = randomAddress();
+    const remoteRouter = randomAddress();
+    const executorQuoterRouter = randomAddress();
+    const quoter = randomAddress();
+    sandbox.stub(IPostDispatchHook__factory, 'connect').returns({
+      hookType: sandbox.stub().resolves(OnchainHookType.WORMHOLE),
+    } as unknown as IPostDispatchHook);
+    sandbox
+      .stub(EvmWormholeHookIsmReader.prototype, 'deriveWormholeConfig')
+      .resolves({
+        address: router,
+        type: WormholeVariant.Executor,
+        owner: randomAddress(),
+        mailbox: randomAddress(),
+        core: randomAddress(),
+        wormholeChainId: 2,
+        consistencyLevel: { type: WormholeConsistencyType.Finalized },
+        executorQuoterRouter,
+        remoteRouters: {
+          [TestChainName.test2]: {
+            router: remoteRouter,
+            wormholeChainId: 30,
+            expectedConsistencyLevel: 202,
+            quoter,
+            callbackGasLimit: 300_000n,
+          },
+        },
+      });
+
+    const config = await new EvmHookReader(
+      multiProvider,
+      TestChainName.test1,
+      undefined,
+      undefined,
+      { expandWormhole: true },
+    ).deriveHookConfigFromAddress(router);
+
+    expect(config).to.have.nested.property(
+      `remoteRouters.${TestChainName.test2}.router`,
+      remoteRouter,
+    );
+    expect(config).to.have.nested.property(
+      `remoteRouters.${TestChainName.test2}.expectedConsistencyLevel`,
+      202,
+    );
   });
 
   it('should derive pausable config correctly', async () => {

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -41,6 +41,8 @@ import { deriveDelayedFlowRemoteIsms } from '../ism/delayedFlow.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
+import { EvmWormholeHookIsmReader } from '../wormhole/EvmWormholeHookIsmReader.js';
+import { WormholeVariant } from '../wormhole/types.js';
 import {
   fetchPackageVersion,
   isMissingSelectorCallException,
@@ -70,6 +72,7 @@ import {
   ProtocolFeeHookConfig,
   RateLimitedHookConfig,
   RoutingHookConfig,
+  WormholeHookConfig,
 } from './types.js';
 
 function isUnsupportedIgpDomainError(
@@ -125,6 +128,10 @@ export interface HookReader {
   ): void;
 }
 
+export interface EvmHookReaderOptions {
+  expandWormhole?: boolean;
+}
+
 export class EvmHookReader extends HyperlaneReader implements HookReader {
   protected readonly logger = rootLogger.child({ module: 'EvmHookReader' });
   /**
@@ -133,6 +140,7 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
    * the specific hook methods.
    */
   private _cache: Map<Address, any> = new Map();
+  protected readonly expandWormhole: boolean;
 
   constructor(
     protected readonly multiProvider: MultiProvider,
@@ -141,8 +149,10 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
       chain,
     ) ?? DEFAULT_CONTRACT_READ_CONCURRENCY,
     protected readonly messageContext?: DispatchedMessage,
+    options: EvmHookReaderOptions = {},
   ) {
     super(multiProvider, chain);
+    this.expandWormhole = options.expandWormhole ?? false;
   }
 
   async deriveHookConfigFromAddress(
@@ -224,6 +234,10 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           break;
         case OnchainHookType.CCTP:
           derivedHookConfig = { type: HookType.CCTP, address };
+          this._cache.set(address, derivedHookConfig);
+          break;
+        case OnchainHookType.WORMHOLE:
+          derivedHookConfig = await this.deriveWormholeHookConfig(address);
           this._cache.set(address, derivedHookConfig);
           break;
         case OnchainHookType.RATE_LIMITED: {
@@ -326,21 +340,85 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
   }
 
   // Returns original HookConfig for non-redeployable standalone types (CCTP,
-  // PREDICATE) so that normalizeConfig — which strips 'address' from all
-  // objects — does not discard the address. Hybrid hook/ISMs deliberately keep
-  // their derived config: warp read/apply needs the typed node on both the hook
-  // and ISM surfaces to identify the shared instance. EvmWarpModule resolves
-  // that node back to its address before handing the tree to EvmHookModule.
+  // PREDICATE, and Wormhole) so that normalizeConfig — which strips 'address'
+  // from all objects — does not discard the address. Flow-control hybrid
+  // hook/ISMs deliberately keep their derived config: warp read/apply needs
+  // the typed node on both surfaces to identify the shared instance.
   private preserveUnredeployable(
     original: HookConfig,
     derived: DerivedHookConfig,
   ): HookConfig {
-    const nonRedeployable: HookType[] = [HookType.CCTP, HookType.PREDICATE];
+    if (
+      this.expandWormhole &&
+      (derived.type === HookType.WORMHOLE_EXECUTOR ||
+        derived.type === HookType.WORMHOLE_VAA)
+    ) {
+      return derived;
+    }
+    const nonRedeployable: HookType[] = [
+      HookType.CCTP,
+      HookType.PREDICATE,
+      HookType.WORMHOLE_EXECUTOR,
+      HookType.WORMHOLE_VAA,
+    ];
     if (!nonRedeployable.includes(derived.type)) {
       return derived;
     }
     if (typeof original === 'string') return original;
-    return derived.address;
+    return 'address' in derived && typeof derived.address === 'string'
+      ? derived.address
+      : original;
+  }
+
+  /**
+   * Both Wormhole variants report `hookType() == WORMHOLE`, so the concrete
+   * subtype comes from the ISM side: Executor preauthorizes and verifies with
+   * empty metadata (`NULL`), direct-VAA verifies through CCIP-read.
+   */
+  private async deriveWormholeHookConfig(
+    address: Address,
+  ): Promise<WithAddress<WormholeHookConfig>> {
+    const derived = await new EvmWormholeHookIsmReader(
+      this.multiProvider,
+      this.chain,
+    ).deriveWormholeConfig(address);
+
+    if (derived.type === WormholeVariant.Executor) {
+      assert(
+        derived.executorQuoterRouter,
+        `Executor router ${address} is missing its Quoter Router`,
+      );
+      const routes = objMap(derived.remoteRouters, (chain, config) => {
+        assert(
+          config.quoter && config.callbackGasLimit !== undefined,
+          `Executor route ${chain} on ${this.chain} is incomplete`,
+        );
+        return {
+          quoter: config.quoter,
+          callbackGasLimit: config.callbackGasLimit,
+        };
+      });
+      const diagnosticConfig = {
+        address,
+        type: HookType.WORMHOLE_EXECUTOR,
+        executorQuoterRouter: derived.executorQuoterRouter,
+        routes,
+        remoteRouters: derived.remoteRouters,
+      };
+      return diagnosticConfig;
+    }
+    if (derived.type === WormholeVariant.DirectVaa) {
+      const diagnosticConfig = {
+        address,
+        type: HookType.WORMHOLE_VAA,
+        remoteRouters: derived.remoteRouters,
+      };
+      return diagnosticConfig;
+    }
+
+    throw new Error(
+      `Wormhole hook at ${address} reports unexpected variant ${derived.type}`,
+    );
   }
 
   async deriveMailboxDefaultHookConfig(

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -47,6 +47,7 @@ export enum OnchainHookType {
   CCTP,
   TIMELOCK_ROUTING,
   PREDICATE_ROUTER_WRAPPER,
+  WORMHOLE,
 }
 
 export const HookType = {
@@ -93,6 +94,14 @@ export const HookType = {
    * IsmType.DELAYED_FLOW_ROUTER). Excluded from `DeployableHookType`.
    */
   DELAYED_FLOW_ROUTER: 'delayedFlowRouterHookIsm',
+  /**
+   * Combined Wormhole hook/ISM router, Executor delivery. Excluded from
+   * `DeployableHookType`: one contract serves as both hook and ISM, so it is
+   * deployed by `EvmWormholeHookIsmModule`, never by the generic hook deployer.
+   */
+  WORMHOLE_EXECUTOR: 'wormholeExecutorHook',
+  /** Combined Wormhole hook/ISM router, CCIP-read VAA delivery. */
+  WORMHOLE_VAA: 'wormholeVaaHook',
   UNKNOWN: 'unknownHook',
   PREDICATE: 'predicateHook',
 } as const;
@@ -107,6 +116,8 @@ export type DeployableHookType = Exclude<
   | typeof HookType.CCTP
   | typeof HookType.NET_FLOW_RATE_LIMITED
   | typeof HookType.DELAYED_FLOW_ROUTER
+  | typeof HookType.WORMHOLE_EXECUTOR
+  | typeof HookType.WORMHOLE_VAA
 >;
 
 export const HookTypeToContractNameMap: Record<DeployableHookType, string> = {
@@ -192,6 +203,7 @@ export type HookConfig =
   | RateLimitedHookConfig
   | NetFlowRateLimitedHookConfig
   | DelayedFlowRouterHookConfig
+  | WormholeHookConfig
   | UnknownHookConfig
   | PredicateHookConfig;
 
@@ -363,6 +375,37 @@ export const CctpHookSchema = z.object({
 });
 export type CctpHookConfig = z.infer<typeof CctpHookSchema>;
 
+export const WormholeExecutorRouteSchema = z.object({
+  /** Executor provider quoter registered in the local Quoter Router. */
+  quoter: ZHash,
+  /** Destination gas purchased for executeVAAv1. */
+  callbackGasLimit: ZBigNumberish.refine((value) => value > 0n, {
+    message: 'callbackGasLimit must be greater than zero',
+  }),
+});
+
+/**
+ * Outbound half of a combined Wormhole Executor hook/ISM. The Warp prepass
+ * pairs this leaf with the local Wormhole ISM leaf, deploys one contract, and
+ * replaces both leaves with that same address before generic deployment.
+ */
+export const WormholeExecutorHookSchema = z.object({
+  type: z.literal(HookType.WORMHOLE_EXECUTOR),
+  executorQuoterRouter: ZHash,
+  routes: z.record(ZChainName, WormholeExecutorRouteSchema),
+});
+
+/** Direct-VAA publication has no hook-only configuration. */
+export const WormholeVaaHookSchema = z.object({
+  type: z.literal(HookType.WORMHOLE_VAA),
+});
+
+export const WormholeHookSchema = z.union([
+  WormholeExecutorHookSchema,
+  WormholeVaaHookSchema,
+]);
+export type WormholeHookConfig = z.infer<typeof WormholeHookSchema>;
+
 export const UnknownHookSchema = z.looseObject({
   type: z.literal(HookType.UNKNOWN),
 });
@@ -500,6 +543,7 @@ export const HookConfigSchema: z.ZodType<HookConfig, unknown> = z.union([
   RateLimitedHookSchema,
   NetFlowRateLimitedHookConfigSchema,
   DelayedFlowRouterHookConfigSchema,
+  WormholeHookSchema,
   UnknownHookSchema,
   PredicateHookSchema,
 ]);

--- a/typescript/sdk/src/hook/updates.ts
+++ b/typescript/sdk/src/hook/updates.ts
@@ -29,7 +29,7 @@ type UpdateHookParams = {
   ccipContractCache?: CCIPContractCache;
   contractVerifier?: ContractVerifier;
   rateLimitedSender?: Address;
-  opaqueHybridAddresses?: Address[];
+  opaqueCombinedHookIsmAddresses?: Address[];
 };
 
 export async function getEvmHookUpdateTransactions(
@@ -51,7 +51,7 @@ export async function getEvmHookUpdateTransactions(
     ccipContractCache,
     contractVerifier,
     rateLimitedSender,
-    opaqueHybridAddresses,
+    opaqueCombinedHookIsmAddresses,
   } = updateHookParams;
 
   const hookModule = new EvmHookModule(
@@ -83,7 +83,7 @@ export async function getEvmHookUpdateTransactions(
   );
   const updateTransactions = await hookModule.update(
     deepCopy(expectedConfig),
-    opaqueHybridAddresses,
+    opaqueCombinedHookIsmAddresses,
   );
   const { deployedHook: newHookAddress } = hookModule.serialize();
 

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -10,6 +10,7 @@ import {
   HookType,
   IgpVersion,
   NetFlowRateLimitedHookConfig,
+  WormholeHookConfig,
 } from './types.js';
 
 /**
@@ -96,6 +97,18 @@ export type HybridHookNodeConfig =
   | NetFlowRateLimitedHookConfig
   | DelayedFlowRouterHookConfig;
 
+/**
+ * A combined hook/ISM leaf. These leaves are deployed once and installed on
+ * both router surfaces; generic EVM module reconciliation must treat them as
+ * opaque addresses instead of trying to deploy a second hook instance.
+ *
+ * This is intentionally broader than `HybridHookNodeConfig`: the latter is
+ * the warp-router flow-control subset consumed by `warpHybridPlan`.
+ */
+export type CombinedHookIsmHookConfig =
+  | HybridHookNodeConfig
+  | WormholeHookConfig;
+
 export function isHybridHookNode(
   hook: HookConfig | undefined,
 ): hook is HybridHookNodeConfig {
@@ -104,6 +117,18 @@ export function isHybridHookNode(
     typeof hook === 'object' &&
     (hook.type === HookType.NET_FLOW_RATE_LIMITED ||
       hook.type === HookType.DELAYED_FLOW_ROUTER)
+  );
+}
+
+export function isCombinedHookIsmHookNode(
+  hook: HookConfig | undefined,
+): hook is CombinedHookIsmHookConfig {
+  return (
+    isHybridHookNode(hook) ||
+    (!!hook &&
+      typeof hook === 'object' &&
+      (hook.type === HookType.WORMHOLE_EXECUTOR ||
+        hook.type === HookType.WORMHOLE_VAA))
   );
 }
 
@@ -116,14 +141,28 @@ export function mapHybridHookNodes(
   hook: HookConfig,
   mapNode: (node: HybridHookNodeConfig) => HookConfig,
 ): HookConfig {
+  return mapHookTreeNodes(hook, isHybridHookNode, mapNode);
+}
+
+/**
+ * Rebuilds a hook tree, mapping every node accepted by `predicate`.
+ * Matching nodes are treated as leaves and their children are not traversed.
+ */
+export function mapHookTreeNodes<T extends HookConfig>(
+  hook: HookConfig,
+  predicate: (hook: HookConfig | undefined) => hook is T,
+  mapNode: (node: T) => HookConfig,
+): HookConfig {
   if (typeof hook === 'string') return hook;
-  if (isHybridHookNode(hook)) return mapNode(hook);
+  if (predicate(hook)) return mapNode(hook);
 
   switch (hook.type) {
     case HookType.AGGREGATION:
       return {
         ...hook,
-        hooks: hook.hooks.map((child) => mapHybridHookNodes(child, mapNode)),
+        hooks: hook.hooks.map((child) =>
+          mapHookTreeNodes(child, predicate, mapNode),
+        ),
       };
     case HookType.ROUTING:
       return {
@@ -131,7 +170,7 @@ export function mapHybridHookNodes(
         domains: Object.fromEntries(
           Object.entries(hook.domains).map(([domain, child]) => [
             domain,
-            mapHybridHookNodes(child, mapNode),
+            mapHookTreeNodes(child, predicate, mapNode),
           ]),
         ),
       };
@@ -141,38 +180,46 @@ export function mapHybridHookNodes(
         domains: Object.fromEntries(
           Object.entries(hook.domains).map(([domain, child]) => [
             domain,
-            mapHybridHookNodes(child, mapNode),
+            mapHookTreeNodes(child, predicate, mapNode),
           ]),
         ),
-        fallback: mapHybridHookNodes(hook.fallback, mapNode),
+        fallback: mapHookTreeNodes(hook.fallback, predicate, mapNode),
       };
     case HookType.AMOUNT_ROUTING:
       return {
         ...hook,
-        lowerHook: mapHybridHookNodes(hook.lowerHook, mapNode),
-        upperHook: mapHybridHookNodes(hook.upperHook, mapNode),
+        lowerHook: mapHookTreeNodes(hook.lowerHook, predicate, mapNode),
+        upperHook: mapHookTreeNodes(hook.upperHook, predicate, mapNode),
       };
     case HookType.ARB_L2_TO_L1:
       return {
         ...hook,
-        childHook: mapHybridHookNodes(hook.childHook, mapNode),
+        childHook: mapHookTreeNodes(hook.childHook, predicate, mapNode),
       };
     default:
       return hook;
   }
 }
 
-/** Every hybrid hook/ISM node declared anywhere in a hook tree. */
-export function collectHybridHookNodes(
+/** Collects matching hook-tree leaves. */
+export function collectHookTreeNodes<T extends HookConfig>(
   hook: HookConfig | undefined,
-): HybridHookNodeConfig[] {
+  predicate: (hook: HookConfig | undefined) => hook is T,
+): T[] {
   if (!hook) return [];
-  const collected: HybridHookNodeConfig[] = [];
-  mapHybridHookNodes(hook, (node) => {
+  const collected: T[] = [];
+  mapHookTreeNodes(hook, predicate, (node) => {
     collected.push(node);
     return node;
   });
   return collected;
+}
+
+/** Every hybrid hook/ISM node declared anywhere in a hook tree. */
+export function collectHybridHookNodes(
+  hook: HookConfig | undefined,
+): HybridHookNodeConfig[] {
+  return collectHookTreeNodes(hook, isHybridHookNode);
 }
 
 export function hookTreeContainsHybridHookIsm(
@@ -192,6 +239,36 @@ export function resolveHybridHookNodesToAddress(
   address: Address,
 ): HookConfig {
   return mapHybridHookNodes(hook, () => address);
+}
+
+/** Replaces any combined hook/ISM leaf with its shared deployed address. */
+export function resolveCombinedHookIsmNodesToAddress(
+  hook: HookConfig,
+  address: Address,
+): HookConfig {
+  return mapCombinedHookIsmNodes(hook, () => address);
+}
+
+export function collapseMatchingCombinedHookIsmNodes(
+  hook: HookConfig,
+  address: Address,
+): HookConfig {
+  return mapCombinedHookIsmNodes(hook, (node) => {
+    const derivedAddress =
+      'address' in node && typeof node.address === 'string'
+        ? node.address
+        : undefined;
+    return derivedAddress && eqAddress(derivedAddress, address)
+      ? address
+      : node;
+  });
+}
+
+function mapCombinedHookIsmNodes(
+  hook: HookConfig,
+  mapNode: (node: CombinedHookIsmHookConfig) => HookConfig,
+): HookConfig {
+  return mapHookTreeNodes(hook, isCombinedHookIsmHookNode, mapNode);
 }
 
 /** ISM-side counterpart: collapse only an already-installed matching leaf. */

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -330,6 +330,11 @@ export {
   RateLimitedHookConfig,
   RateLimitedHookSchema,
   SafeParseHookConfigSchema,
+  WormholeExecutorHookSchema,
+  WormholeExecutorRouteSchema,
+  WormholeHookConfig,
+  WormholeHookSchema,
+  WormholeVaaHookSchema,
 } from './hook/types.js';
 export {
   collectHybridHookNodes,
@@ -418,6 +423,10 @@ export {
   SafeParseIsmConfigSchema,
   RateLimitedIsmConfig,
   RateLimitedIsmConfigSchema,
+  WormholeIsmConfig,
+  WormholeIsmConfigSchema,
+  WormholeExecutorIsmConfigSchema,
+  WormholeVaaIsmConfigSchema,
   BlacklistIsmConfig,
   BlacklistIsmConfigSchema,
   TrustedRelayerIsmConfig,
@@ -1171,3 +1180,46 @@ export {
 export { TurnkeyEvmSigner } from './signers/evm/turnkey.js';
 export { TurnkeySealevelSigner } from './signers/svm/turnkey.js';
 export { IMultiProtocolSigner } from './signers/types.js';
+
+export {
+  EvmWormholeHookIsmModule,
+  WormholeMeshReconciliation,
+} from './wormhole/EvmWormholeHookIsmModule.js';
+export { EvmWormholeHookIsmReader } from './wormhole/EvmWormholeHookIsmReader.js';
+export {
+  WormholeConfigPair,
+  WormholeWarpChainConfig,
+  buildWormholeMeshConfig,
+  collectHookAddresses,
+  collectIsmAddresses,
+  findWormholeHooks,
+  findWormholeIsms,
+  materializeWormholeWarpConfig,
+  pairWormholeConfigs,
+  replaceWormholeHook,
+  replaceWormholeIsm,
+} from './wormhole/config.js';
+export {
+  DerivedWormholeHookIsmConfig,
+  WormholeConsistencyLevel,
+  WormholeConsistencyLevelConfigSchema,
+  WormholeConsistencyLevelSchema,
+  WormholeConsistencyType,
+  WormholeStandardConsistencyTypeSchema,
+  consistencyLevelConfigFromOnchain,
+  consistencyLevelForConfig,
+  standardConsistencyType,
+  WormholeHookIsmAddresses,
+  WormholeHookIsmConfig,
+  WormholeHookIsmSchema,
+  WormholeMeshConfig,
+  WormholeMeshSchema,
+  WormholeRemoteRouterConfig,
+  WormholeRemoteRouterSchema,
+  WormholeVariant,
+  findAsymmetricWormholeRoutes,
+} from './wormhole/types.js';
+export type {
+  WormholeConsistencyLevelConfig,
+  WormholeStandardConsistencyType,
+} from './wormhole/types.js';

--- a/typescript/sdk/src/ism/EvmIsmModule.test.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.test.ts
@@ -197,6 +197,30 @@ describe('EvmIsmModule blacklist enumeration probe', () => {
   // deriving it, so a pinned target converges to no transactions when the
   // deployment already matches.
   describe('pinned addresses', () => {
+    it('preserves a top-level Wormhole address for attachment', async () => {
+      const currentAddress = randomAddress();
+      const targetAddress = randomAddress();
+      const owner = randomAddress();
+
+      sandbox
+        .stub(EvmIsmReader.prototype, 'deriveIsmConfig')
+        .withArgs(targetAddress)
+        .resolves({
+          address: targetAddress,
+          type: IsmType.WORMHOLE_EXECUTOR,
+          owner,
+          core: randomAddress(),
+          wormholeChainId: 2,
+          consistencyLevel: { type: 'finalized' },
+        });
+
+      const module = moduleFor(currentAddress, targetAddress);
+      const txs = await module.update(targetAddress);
+
+      expect(txs).to.deep.equal([]);
+      expect(module.serialize().deployedIsm).to.equal(targetAddress);
+    });
+
     it('applies no transactions for a pinned address', async () => {
       stubReader({
         type: IsmType.BLACKLIST,

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -41,9 +41,10 @@ import { ChainName, ChainNameOrId } from '../types.js';
 import { throwIfNotMissingSelector } from '../utils/contract.js';
 import {
   canonicalizeRemoteIsms,
-  collapseMatchingHybridIsmNodes,
+  collapseMatchingCombinedHookIsmNodes,
+  isCombinedHookIsmNode,
   normalizeConfig,
-  resolveHybridIsmNodesToAddress,
+  resolveCombinedHookIsmNodesToAddress,
 } from '../utils/ism.js';
 
 import { EvmIsmReader } from './EvmIsmReader.js';
@@ -158,10 +159,13 @@ export class EvmIsmModule extends HyperlaneModule<
   // whoever calls update() needs to ensure that targetConfig has a valid owner
   public async update(
     targetConfig: IsmConfig,
-    opaqueHybridAddresses: Address[] = [],
+    opaqueCombinedHookIsmAddresses: Address[] = [],
   ): Promise<AnnotatedEV5Transaction[]> {
     const parsedTargetConfig = IsmConfigSchema.parse(targetConfig);
-    return this.updateInternal(parsedTargetConfig, opaqueHybridAddresses);
+    return this.updateInternal(
+      parsedTargetConfig,
+      opaqueCombinedHookIsmAddresses,
+    );
   }
 
   /**
@@ -198,7 +202,7 @@ export class EvmIsmModule extends HyperlaneModule<
 
   private async updateInternal(
     targetConfig: IsmConfig,
-    opaqueHybridAddresses: Address[] = [],
+    opaqueCombinedHookIsmAddresses: Address[] = [],
   ): Promise<AnnotatedEV5Transaction[]> {
     const parsedTargetConfig = BaseIsmConfigSchema.parse(targetConfig);
 
@@ -215,20 +219,22 @@ export class EvmIsmModule extends HyperlaneModule<
       await this.reader.deriveIsmConfig(parsedTargetConfig);
     let normalizedTargetConfig: IsmConfig =
       typeof parsedTargetConfig === 'string' &&
-      (derivedTargetConfig.type === IsmType.WORMHOLE_EXECUTOR ||
-        derivedTargetConfig.type === IsmType.WORMHOLE_VAA)
+      isCombinedHookIsmNode(derivedTargetConfig)
         ? parsedTargetConfig
         : normalizeConfig(derivedTargetConfig);
-    for (const address of opaqueHybridAddresses) {
-      normalizedTargetConfig = resolveHybridIsmNodesToAddress(
+    for (const address of opaqueCombinedHookIsmAddresses) {
+      normalizedTargetConfig = resolveCombinedHookIsmNodesToAddress(
         normalizedTargetConfig,
         address,
       );
     }
     normalizedTargetConfig = normalizeConfig(normalizedTargetConfig);
     let currentConfig = await this.read();
-    for (const address of opaqueHybridAddresses) {
-      currentConfig = collapseMatchingHybridIsmNodes(currentConfig, address);
+    for (const address of opaqueCombinedHookIsmAddresses) {
+      currentConfig = collapseMatchingCombinedHookIsmNodes(
+        currentConfig,
+        address,
+      );
     }
     const normalizedCurrentConfig: IsmConfig = normalizeConfig(currentConfig);
 

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -211,9 +211,14 @@ export class EvmIsmModule extends HyperlaneModule<
     }
 
     // We need to normalize the current and target configs to compare.
-    let normalizedTargetConfig: IsmConfig = normalizeConfig(
-      await this.reader.deriveIsmConfig(parsedTargetConfig),
-    );
+    const derivedTargetConfig =
+      await this.reader.deriveIsmConfig(parsedTargetConfig);
+    let normalizedTargetConfig: IsmConfig =
+      typeof parsedTargetConfig === 'string' &&
+      (derivedTargetConfig.type === IsmType.WORMHOLE_EXECUTOR ||
+        derivedTargetConfig.type === IsmType.WORMHOLE_VAA)
+        ? parsedTargetConfig
+        : normalizeConfig(derivedTargetConfig);
     for (const address of opaqueHybridAddresses) {
       normalizedTargetConfig = resolveHybridIsmNodesToAddress(
         normalizedTargetConfig,

--- a/typescript/sdk/src/ism/EvmIsmReader.test.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.test.ts
@@ -19,6 +19,8 @@ import {
   DomainRoutingIsm__factory,
   IInterchainSecurityModule,
   IInterchainSecurityModule__factory,
+  IPostDispatchHook,
+  IPostDispatchHook__factory,
   IMultisigIsm,
   IMultisigIsm__factory,
   IncrementalDomainRoutingIsm__factory,
@@ -47,6 +49,7 @@ import { GetEventLogsResponse } from '../rpc/evm/types.js';
 import { contractDouble } from '../test/contractDouble.js';
 import { missingSelectorError, networkError } from '../test/errors.js';
 import { randomAddress } from '../test/testUtils.js';
+import { WormholeConsistencyType } from '../wormhole/consistency.js';
 
 import { EvmIsmReader } from './EvmIsmReader.js';
 import {
@@ -60,6 +63,7 @@ import {
   NetFlowRateLimitedHookIsmConfig,
   PausableIsmConfig,
   TestIsmConfig,
+  WormholeIsmConfig,
 } from './types.js';
 
 // keccak256('MessageBlacklisted(bytes32)')
@@ -137,11 +141,16 @@ describe('EvmIsmReader', () => {
   let multiProvider: MultiProvider;
   let sandbox: sinon.SinonSandbox;
   let getContractDeploymentBlockFromExplorer: sinon.SinonStub;
+  let hookTypeStub: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     multiProvider = MultiProvider.createTestMultiProvider();
     evmIsmReader = new EvmIsmReader(multiProvider, TestChainName.test1);
+    hookTypeStub = sandbox.stub().rejects(missingSelectorError());
+    sandbox
+      .stub(IPostDispatchHook__factory, 'connect')
+      .returns(contractDouble<IPostDispatchHook>({ hookType: hookTypeStub }));
     getContractDeploymentBlockFromExplorer = sandbox
       .stub(
         EvmEventLogsReader.prototype,
@@ -152,6 +161,51 @@ describe('EvmIsmReader', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  it('propagates transient Wormhole hookType probe failures', async () => {
+    const mockAddress = randomAddress();
+    const transientError = networkError();
+    sandbox.stub(IInterchainSecurityModule__factory, 'connect').returns(
+      contractDouble<IInterchainSecurityModule>({
+        moduleType: sandbox.stub().resolves(ModuleType.NULL),
+      }),
+    );
+    hookTypeStub.rejects(transientError);
+
+    let thrown: unknown;
+    try {
+      await evmIsmReader.deriveIsmConfigFromAddress(mockAddress);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(Error);
+    if (!(thrown instanceof Error)) throw thrown;
+    expect(thrown.message).to.include(transientError.message);
+  });
+
+  it('preserves an undeployed Wormhole config object in a container', async () => {
+    const wormholeConfig: WormholeIsmConfig = {
+      type: IsmType.WORMHOLE_VAA,
+      owner: randomAddress(),
+      core: randomAddress(),
+      wormholeChainId: 2,
+      consistencyLevel: { type: WormholeConsistencyType.Finalized },
+      urls: ['https://vaa.example/v1'],
+    };
+
+    const config = await evmIsmReader.deriveIsmConfig({
+      type: IsmType.AGGREGATION,
+      threshold: 1,
+      modules: [wormholeConfig],
+    });
+
+    assert(
+      config.type === IsmType.AGGREGATION,
+      'Expected aggregation ISM config',
+    );
+    expect(config.modules).to.deep.equal([wormholeConfig]);
   });
 
   it('should derive multisig config correctly', async () => {

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -23,15 +23,12 @@ import {
   RateLimitedIsm__factory,
   StaticAggregationIsm__factory,
   TrustedRelayerIsm__factory,
-  WormholeExecutorHookIsm__factory,
-  WormholeVaaHookIsm__factory,
 } from '@hyperlane-xyz/core';
 import {
   Address,
   WithAddress,
   assert,
   concurrentMap,
-  eqAddress,
   getLogLevel,
   objMap,
   promiseObjAll,
@@ -48,7 +45,7 @@ import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
 import { ChainMap, ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 import { EvmWormholeHookIsmReader } from '../wormhole/EvmWormholeHookIsmReader.js';
-import { consistencyLevelConfigFromOnchain } from '../wormhole/consistency.js';
+import { WormholeVariant } from '../wormhole/types.js';
 import {
   contractHasString,
   isMissingSelectorCallException,
@@ -155,96 +152,27 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
       return undefined;
     }
 
-    const remoteRouters = (
-      await new EvmWormholeHookIsmReader(
-        this.multiProvider,
-        this.chain,
-      ).deriveWormholeConfig(address)
-    ).remoteRouters;
-
-    if (moduleType === ModuleType.NULL) {
-      const router = WormholeExecutorHookIsm__factory.connect(
-        address,
-        this.provider,
-      );
-      const [
-        owner,
-        core,
-        wormholeChainId,
-        consistencyLevel,
-        customConsistencyLevel,
-        baseConsistencyLevel,
-        additionalBlocks,
-      ] = await Promise.all([
-        router.owner(),
-        router.wormhole(),
-        router.wormholeChainId(),
-        router.consistencyLevel(),
-        router.customConsistencyLevel(),
-        router.baseConsistencyLevel(),
-        router.additionalBlocks(),
-      ]);
-      const diagnosticConfig = {
-        address,
-        type: IsmType.WORMHOLE_EXECUTOR,
-        owner,
-        core,
-        wormholeChainId,
-        consistencyLevel: consistencyLevelConfigFromOnchain(
-          consistencyLevel,
-          eqAddress(customConsistencyLevel, ethers.constants.AddressZero)
-            ? undefined
-            : {
-                address: customConsistencyLevel,
-                baseConsistencyLevel,
-                additionalBlocks,
-              },
-        ),
-        remoteRouters,
-      };
-      return diagnosticConfig;
-    }
-
-    const router = WormholeVaaHookIsm__factory.connect(address, this.provider);
-    const [
-      owner,
-      core,
-      wormholeChainId,
-      consistencyLevel,
-      customConsistencyLevel,
-      baseConsistencyLevel,
-      additionalBlocks,
-      urls,
-    ] = await Promise.all([
-      router.owner(),
-      router.wormhole(),
-      router.wormholeChainId(),
-      router.consistencyLevel(),
-      router.customConsistencyLevel(),
-      router.baseConsistencyLevel(),
-      router.additionalBlocks(),
-      router.urls(),
-    ]);
-    const diagnosticConfig = {
+    const variant =
+      moduleType === ModuleType.NULL
+        ? WormholeVariant.Executor
+        : WormholeVariant.DirectVaa;
+    const derived = await new EvmWormholeHookIsmReader(
+      this.multiProvider,
+      this.chain,
+    ).deriveWormholeConfig(address, variant);
+    const common = {
       address,
-      type: IsmType.WORMHOLE_VAA,
-      owner,
-      core,
-      wormholeChainId,
-      consistencyLevel: consistencyLevelConfigFromOnchain(
-        consistencyLevel,
-        eqAddress(customConsistencyLevel, ethers.constants.AddressZero)
-          ? undefined
-          : {
-              address: customConsistencyLevel,
-              baseConsistencyLevel,
-              additionalBlocks,
-            },
-      ),
-      urls,
-      remoteRouters,
+      owner: derived.owner,
+      core: derived.core,
+      wormholeChainId: derived.wormholeChainId,
+      consistencyLevel: derived.consistencyLevel,
+      remoteRouters: derived.remoteRouters,
     };
-    return diagnosticConfig;
+    if (derived.type === WormholeVariant.Executor) {
+      return { ...common, type: IsmType.WORMHOLE_EXECUTOR };
+    }
+    assert(derived.urls, `Wormhole VAA router ${address} is missing URLs`);
+    return { ...common, type: IsmType.WORMHOLE_VAA, urls: derived.urls };
   }
 
   async deriveIsmConfigFromAddress(

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -13,6 +13,7 @@ import {
   DelayedFlowRouterHookIsm__factory,
   IInterchainSecurityModule__factory,
   IMultisigIsm__factory,
+  IPostDispatchHook__factory,
   IOutbox__factory,
   InterchainAccountRouter__factory,
   NetFlowRateLimitedHookIsm__factory,
@@ -22,12 +23,15 @@ import {
   RateLimitedIsm__factory,
   StaticAggregationIsm__factory,
   TrustedRelayerIsm__factory,
+  WormholeExecutorHookIsm__factory,
+  WormholeVaaHookIsm__factory,
 } from '@hyperlane-xyz/core';
 import {
   Address,
   WithAddress,
   assert,
   concurrentMap,
+  eqAddress,
   getLogLevel,
   objMap,
   promiseObjAll,
@@ -37,11 +41,14 @@ import {
 import { getChainNameFromCCIPSelector } from '../ccip/utils.js';
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { DispatchedMessage } from '../core/types.js';
+import { OnchainHookType } from '../hook/types.js';
 import { ChainTechnicalStack } from '../metadata/chainMetadataTypes.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
 import { ChainMap, ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
+import { EvmWormholeHookIsmReader } from '../wormhole/EvmWormholeHookIsmReader.js';
+import { consistencyLevelConfigFromOnchain } from '../wormhole/consistency.js';
 import {
   contractHasString,
   isMissingSelectorCallException,
@@ -62,6 +69,7 @@ import {
   NullIsmConfig,
   OffchainLookupIsmConfig,
   RoutingIsmConfig,
+  WormholeIsmConfig,
 } from './types.js';
 import { readBlacklistedIds } from './blacklist.js';
 import { deriveDelayedFlowRemoteIsms } from './delayedFlow.js';
@@ -95,6 +103,8 @@ export interface IsmReader {
 const NON_REDEPLOYABLE_ISM_TYPES = new Set<IsmType>([
   IsmType.OFFCHAIN_LOOKUP,
   IsmType.INTERCHAIN_ACCOUNT_ROUTING,
+  IsmType.WORMHOLE_EXECUTOR,
+  IsmType.WORMHOLE_VAA,
 ]);
 
 export class EvmIsmReader extends HyperlaneReader implements IsmReader {
@@ -122,6 +132,119 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
       { chain: this.chain },
       multiProvider,
     );
+  }
+
+  /**
+   * Recognizes the combined Wormhole hook/ISM router, which is otherwise
+   * indistinguishable from a plain NULL or CCIP-read ISM. Both variants report
+   * `hookType() == WORMHOLE`; the module type then picks the variant.
+   */
+  private async tryDeriveWormholeConfig(
+    address: Address,
+    moduleType: ModuleType.NULL | ModuleType.CCIP_READ,
+  ): Promise<WithAddress<WormholeIsmConfig> | undefined> {
+    try {
+      const hookType = await IPostDispatchHook__factory.connect(
+        address,
+        this.provider,
+      ).hookType();
+      if (hookType !== OnchainHookType.WORMHOLE) return undefined;
+    } catch (error) {
+      throwIfNotMissingSelector(error);
+      // Not a hook at all, so not a combined Wormhole router.
+      return undefined;
+    }
+
+    const remoteRouters = (
+      await new EvmWormholeHookIsmReader(
+        this.multiProvider,
+        this.chain,
+      ).deriveWormholeConfig(address)
+    ).remoteRouters;
+
+    if (moduleType === ModuleType.NULL) {
+      const router = WormholeExecutorHookIsm__factory.connect(
+        address,
+        this.provider,
+      );
+      const [
+        owner,
+        core,
+        wormholeChainId,
+        consistencyLevel,
+        customConsistencyLevel,
+        baseConsistencyLevel,
+        additionalBlocks,
+      ] = await Promise.all([
+        router.owner(),
+        router.wormhole(),
+        router.wormholeChainId(),
+        router.consistencyLevel(),
+        router.customConsistencyLevel(),
+        router.baseConsistencyLevel(),
+        router.additionalBlocks(),
+      ]);
+      const diagnosticConfig = {
+        address,
+        type: IsmType.WORMHOLE_EXECUTOR,
+        owner,
+        core,
+        wormholeChainId,
+        consistencyLevel: consistencyLevelConfigFromOnchain(
+          consistencyLevel,
+          eqAddress(customConsistencyLevel, ethers.constants.AddressZero)
+            ? undefined
+            : {
+                address: customConsistencyLevel,
+                baseConsistencyLevel,
+                additionalBlocks,
+              },
+        ),
+        remoteRouters,
+      };
+      return diagnosticConfig;
+    }
+
+    const router = WormholeVaaHookIsm__factory.connect(address, this.provider);
+    const [
+      owner,
+      core,
+      wormholeChainId,
+      consistencyLevel,
+      customConsistencyLevel,
+      baseConsistencyLevel,
+      additionalBlocks,
+      urls,
+    ] = await Promise.all([
+      router.owner(),
+      router.wormhole(),
+      router.wormholeChainId(),
+      router.consistencyLevel(),
+      router.customConsistencyLevel(),
+      router.baseConsistencyLevel(),
+      router.additionalBlocks(),
+      router.urls(),
+    ]);
+    const diagnosticConfig = {
+      address,
+      type: IsmType.WORMHOLE_VAA,
+      owner,
+      core,
+      wormholeChainId,
+      consistencyLevel: consistencyLevelConfigFromOnchain(
+        consistencyLevel,
+        eqAddress(customConsistencyLevel, ethers.constants.AddressZero)
+          ? undefined
+          : {
+              address: customConsistencyLevel,
+              baseConsistencyLevel,
+              additionalBlocks,
+            },
+      ),
+      urls,
+      remoteRouters,
+    };
+    return diagnosticConfig;
   }
 
   async deriveIsmConfigFromAddress(
@@ -157,12 +280,23 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
         case ModuleType.MESSAGE_ID_MULTISIG:
           derivedIsmConfig = await this.deriveMultisigConfig(address);
           break;
-        case ModuleType.NULL:
-          derivedIsmConfig = await this.deriveNullConfig(address);
+        case ModuleType.NULL: {
+          const wormhole = await this.tryDeriveWormholeConfig(
+            address,
+            moduleType,
+          );
+          derivedIsmConfig = wormhole ?? (await this.deriveNullConfig(address));
           break;
-        case ModuleType.CCIP_READ:
-          derivedIsmConfig = await this.deriveOffchainLookupConfig(address);
+        }
+        case ModuleType.CCIP_READ: {
+          const wormhole = await this.tryDeriveWormholeConfig(
+            address,
+            moduleType,
+          );
+          derivedIsmConfig =
+            wormhole ?? (await this.deriveOffchainLookupConfig(address));
           break;
+        }
         case ModuleType.ARB_L2_TO_L1:
           return this.deriveArbL2ToL1Config(address);
         default:
@@ -254,7 +388,9 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
   ): IsmConfig {
     if (!NON_REDEPLOYABLE_ISM_TYPES.has(derived.type)) return derived;
     if (typeof original === 'string') return original;
-    return derived.address;
+    return 'address' in derived && typeof derived.address === 'string'
+      ? derived.address
+      : original;
   }
 
   async deriveRoutingConfig(

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -494,7 +494,11 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
           if (!eqAddress(signerAddress, config.owner)) {
             const overrides =
               this.multiProvider.getTransactionOverrides(destination);
-            const tx = await contract.transferOwnership(
+            const netFlowIsm = NetFlowRateLimitedHookIsm__factory.connect(
+              contract.address,
+              this.multiProvider.getSigner(destination),
+            );
+            const tx = await netFlowIsm.transferOwnership(
               config.owner,
               overrides,
             );

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -34,6 +34,8 @@ import {
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
+import { WormholeConsistencyLevelFields } from '../wormhole/consistency.js';
+
 import {
   ZBigNumberish,
   ZBytes32String,
@@ -105,6 +107,14 @@ export const IsmType = {
   // ISM config surface; the hook side is referenced by address.
   NET_FLOW_RATE_LIMITED: 'netFlowRateLimitedHookIsm',
   DELAYED_FLOW_ROUTER: 'delayedFlowRouterHookIsm',
+  /**
+   * Combined Wormhole hook/ISM router, Executor delivery. Excluded from
+   * `DeployableIsmType`: one contract serves as both hook and ISM, so it is
+   * deployed by `EvmWormholeHookIsmModule`, never by `HyperlaneIsmFactory`.
+   */
+  WORMHOLE_EXECUTOR: 'wormholeExecutorIsm',
+  /** Combined Wormhole hook/ISM router, CCIP-read VAA delivery. */
+  WORMHOLE_VAA: 'wormholeVaaIsm',
   UNKNOWN: 'unknownIsm',
 } as const;
 
@@ -112,7 +122,10 @@ export type IsmType = (typeof IsmType)[keyof typeof IsmType];
 
 export type DeployableIsmType = Exclude<
   IsmType,
-  typeof IsmType.CUSTOM | typeof IsmType.UNKNOWN
+  | typeof IsmType.CUSTOM
+  | typeof IsmType.UNKNOWN
+  | typeof IsmType.WORMHOLE_EXECUTOR
+  | typeof IsmType.WORMHOLE_VAA
 >;
 
 // ISM types that can be updated in-place on EVM chains (consumed by
@@ -188,6 +201,9 @@ export function ismTypeToModuleType(ismType: IsmType): ModuleType {
     case IsmType.BLACKLIST:
     case IsmType.NET_FLOW_RATE_LIMITED:
     case IsmType.DELAYED_FLOW_ROUTER:
+    // The Executor router is preauthorized before process, so Hyperlane
+    // supplies no metadata.
+    case IsmType.WORMHOLE_EXECUTOR:
       return ModuleType.NULL;
     case IsmType.ARB_L2_TO_L1:
       return ModuleType.ARB_L2_TO_L1;
@@ -196,6 +212,8 @@ export function ismTypeToModuleType(ismType: IsmType): ModuleType {
     case IsmType.WEIGHTED_MESSAGE_ID_MULTISIG:
       return ModuleType.WEIGHTED_MESSAGE_ID_MULTISIG;
     case IsmType.OFFCHAIN_LOOKUP:
+    // The direct-VAA router receives its VAA through the generic CCIP-read path.
+    case IsmType.WORMHOLE_VAA:
       return ModuleType.CCIP_READ;
     case IsmType.COMPOSITE:
       return ModuleType.COMPOSITE;
@@ -326,6 +344,7 @@ export type IsmConfig =
   | ArbL2ToL1IsmConfig
   | OffchainLookupIsmConfig
   | InterchainAccountRouterIsm
+  | WormholeIsmConfig
   | UnknownIsmConfig;
 
 export type DerivedIsmConfig = WithAddress<Exclude<IsmConfig, Address>>;
@@ -357,6 +376,10 @@ export type DeployedIsmType = {
   [IsmType.MAILBOX_DEFAULT]: DefaultIsm;
   [IsmType.NET_FLOW_RATE_LIMITED]: NetFlowRateLimitedHookIsm;
   [IsmType.DELAYED_FLOW_ROUTER]: DelayedFlowRouterHookIsm;
+  // Deployed by EvmWormholeHookIsmModule, never by HyperlaneIsmFactory, so the
+  // generic interface is all this map needs to express.
+  [IsmType.WORMHOLE_EXECUTOR]: IInterchainSecurityModule;
+  [IsmType.WORMHOLE_VAA]: IInterchainSecurityModule;
   [IsmType.UNKNOWN]: IInterchainSecurityModule;
 };
 
@@ -393,6 +416,30 @@ export const TrustedRelayerIsmConfigSchema = z.object({
   type: z.literal(IsmType.TRUSTED_RELAYER),
   relayer: z.string(),
 });
+
+const BaseWormholeIsmConfigSchema = OwnableSchema.extend({
+  ...WormholeConsistencyLevelFields,
+  /** Official Wormhole Core proxy on this chain. */
+  core: ZHash,
+  /** Expected value returned by the configured Core proxy. */
+  wormholeChainId: z.number().int().positive().max(65_535),
+});
+
+export const WormholeExecutorIsmConfigSchema =
+  BaseWormholeIsmConfigSchema.extend({
+    type: z.literal(IsmType.WORMHOLE_EXECUTOR),
+  });
+
+export const WormholeVaaIsmConfigSchema = BaseWormholeIsmConfigSchema.extend({
+  type: z.literal(IsmType.WORMHOLE_VAA),
+  urls: z.array(z.string().url()).min(1),
+});
+
+export const WormholeIsmConfigSchema = z.union([
+  WormholeExecutorIsmConfigSchema,
+  WormholeVaaIsmConfigSchema,
+]);
+export type WormholeIsmConfig = z.infer<typeof WormholeIsmConfigSchema>;
 
 export const BlacklistIsmConfigSchema = OwnableSchema.extend({
   type: z.literal(IsmType.BLACKLIST),
@@ -1043,6 +1090,7 @@ export const BaseIsmConfigSchema: z.ZodType<IsmConfig, unknown> = z.union([
   ArbL2ToL1IsmConfigSchema,
   OffchainLookupIsmConfigSchema,
   InterchainAccountRouterIsmSchema,
+  WormholeIsmConfigSchema,
   UnknownIsmConfigSchema,
 ]);
 

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -143,6 +143,8 @@ export const hookTypesToFilter: HookType[] = [
   // TokenRouter, so they cannot be randomly generated
   HookType.NET_FLOW_RATE_LIMITED,
   HookType.DELAYED_FLOW_ROUTER,
+  HookType.WORMHOLE_EXECUTOR,
+  HookType.WORMHOLE_VAA,
 ];
 export const DEFAULT_TOKEN_DECIMALS = 18;
 

--- a/typescript/sdk/src/token/EvmWarpModule.ts
+++ b/typescript/sdk/src/token/EvmWarpModule.ts
@@ -2144,7 +2144,7 @@ export class EvmWarpModule extends HyperlaneModule<
   async createIsmUpdateTxs(
     actualConfig: DerivedTokenRouterConfig,
     expectedConfig: HypTokenRouterConfig,
-    opaqueHybridAddress?: Address,
+    opaqueCombinedHookIsmAddress?: Address,
   ): Promise<AnnotatedEV5Transaction[]> {
     const updateTransactions: AnnotatedEV5Transaction[] = [];
     if (!expectedConfig.interchainSecurityModule) {
@@ -2160,7 +2160,7 @@ export class EvmWarpModule extends HyperlaneModule<
     } = await this.deployOrUpdateIsm(
       actualConfig,
       expectedConfig,
-      opaqueHybridAddress,
+      opaqueCombinedHookIsmAddress,
     );
 
     // If an ISM is updated in-place, push the update txs
@@ -2201,7 +2201,7 @@ export class EvmWarpModule extends HyperlaneModule<
   async createHookAndPredicateUpdateTxs(
     actualConfig: DerivedTokenRouterConfig,
     expectedConfig: HypTokenRouterConfig,
-    opaqueHybridAddress?: Address,
+    opaqueCombinedHookIsmAddress?: Address,
   ): Promise<AnnotatedEV5Transaction[]> {
     let hookTransactions: AnnotatedEV5Transaction[] = [];
     let newHookAddress: Address | undefined;
@@ -2291,8 +2291,8 @@ export class EvmWarpModule extends HyperlaneModule<
           multiProvider: this.multiProvider,
           proxyAdminAddress,
           rateLimitedSender: this.args.addresses.deployedTokenRoute,
-          opaqueHybridAddresses: opaqueHybridAddress
-            ? [opaqueHybridAddress]
+          opaqueCombinedHookIsmAddresses: opaqueCombinedHookIsmAddress
+            ? [opaqueCombinedHookIsmAddress]
             : undefined,
         },
       );
@@ -2841,7 +2841,7 @@ export class EvmWarpModule extends HyperlaneModule<
   async deployOrUpdateIsm(
     actualConfig: DerivedTokenRouterConfig,
     expectedConfig: HypTokenRouterConfig,
-    opaqueHybridAddress?: Address,
+    opaqueCombinedHookIsmAddress?: Address,
   ): Promise<{
     deployedIsm: Address;
     updateTransactions: AnnotatedEV5Transaction[];
@@ -2924,7 +2924,7 @@ export class EvmWarpModule extends HyperlaneModule<
     );
     const updateTransactions = await ismModule.update(
       expectedIsm,
-      opaqueHybridAddress ? [opaqueHybridAddress] : [],
+      opaqueCombinedHookIsmAddress ? [opaqueCombinedHookIsmAddress] : [],
     );
     const { deployedIsm } = ismModule.serialize();
 

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -167,7 +167,16 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     contractVerifier?: ContractVerifier,
   ) {
     super(multiProvider, chain);
-    this.evmHookReader = new EvmHookReader(multiProvider, chain, concurrency);
+    // Warp reads should expose the combined Wormhole hook's diagnostic config
+    // instead of reducing nested Wormhole hooks to opaque addresses. Generic
+    // deployment readers retain the address-preserving default.
+    this.evmHookReader = new EvmHookReader(
+      multiProvider,
+      chain,
+      concurrency,
+      undefined,
+      { expandWormhole: true },
+    );
     this.evmIsmReader = new EvmIsmReader(multiProvider, chain, concurrency);
     this.evmTokenFeeReader = new EvmTokenFeeReader(multiProvider, chain);
 

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -922,6 +922,17 @@ const transformWarpDeployConfigToCheck: TransformObjectTransformer = (
   const parentObjectKey = propPath[propPath.length - 2];
   const parentKey = propPath[propPath.length - 1];
 
+  // Derived Wormhole hook/ISM leaves include their complete enrollment table
+  // for diagnostics. Compare that trust anchor through the dedicated Wormhole
+  // mesh check, where the expected remote router addresses can first be
+  // resolved from the deployed peer contracts.
+  if (
+    parentKey === 'remoteRouters' &&
+    propPath.some((key) => key === 'hook' || key === 'interchainSecurityModule')
+  ) {
+    return undefined;
+  }
+
   // Remove the address and ownerOverrides fields if we are not inside the
   // remoteRouters property
   if (

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -18,6 +18,12 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { TokenStandard } from './TokenStandard.js';
 import { TokenType } from './config.js';
+import { WormholeConsistencyType } from '../wormhole/consistency.js';
+import {
+  type DerivedWormholeHookIsmConfig,
+  type WormholeMeshConfig,
+  WormholeVariant,
+} from '../wormhole/types.js';
 import {
   type DerivedWarpRouteDeployConfig,
   HypTokenConfigSchema,
@@ -28,6 +34,7 @@ import {
   altVmScaleMismatch,
   applyAcceptedInactiveOwnerStatus,
   buildAltVmWarpRouteDiff,
+  buildWormholeRemoteRouterDiff,
   buildWarpRouteDiff,
   checkWarpRouteDeployConfig,
   derivedWarpConfigToCheckConfig,
@@ -1126,5 +1133,130 @@ describe('applyAcceptedInactiveOwnerStatus', () => {
     });
 
     expect(expanded[CHAIN].ownerStatus?.[OWNER_A]).to.equal(OwnerStatus.Active);
+  });
+});
+
+describe('buildWormholeRemoteRouterDiff', () => {
+  const CHAIN_A = test1.name;
+  const CHAIN_B = test2.name;
+  const ROUTER_A = '0x1111111111111111111111111111111111111111';
+  const ROUTER_B = '0x2222222222222222222222222222222222222222';
+  const CORE_A = '0x3333333333333333333333333333333333333333';
+  const CORE_B = '0x4444444444444444444444444444444444444444';
+  const QUOTER_ROUTER = '0x5555555555555555555555555555555555555555';
+  const QUOTER = '0x6666666666666666666666666666666666666666';
+
+  function mesh(): WormholeMeshConfig {
+    return {
+      [CHAIN_A]: {
+        type: WormholeVariant.Executor,
+        owner: OWNER,
+        mailbox: MAILBOX,
+        core: CORE_A,
+        wormholeChainId: 2,
+        consistencyLevel: { type: WormholeConsistencyType.Finalized },
+        executorQuoterRouter: QUOTER_ROUTER,
+        remoteRouters: {
+          [CHAIN_B]: {
+            router: ROUTER_B,
+            wormholeChainId: 30,
+            expectedConsistencyLevel: 202,
+            quoter: QUOTER,
+            callbackGasLimit: 300_000n,
+          },
+        },
+      },
+      [CHAIN_B]: {
+        type: WormholeVariant.Executor,
+        owner: OWNER,
+        mailbox: MAILBOX,
+        core: CORE_B,
+        wormholeChainId: 30,
+        consistencyLevel: { type: WormholeConsistencyType.Finalized },
+        executorQuoterRouter: QUOTER_ROUTER,
+        remoteRouters: {
+          [CHAIN_A]: {
+            router: ROUTER_A,
+            wormholeChainId: 2,
+            expectedConsistencyLevel: 202,
+            quoter: QUOTER,
+            callbackGasLimit: 300_000n,
+          },
+        },
+      },
+    };
+  }
+
+  function derived(
+    config: WormholeMeshConfig,
+  ): Record<string, DerivedWormholeHookIsmConfig> {
+    return Object.fromEntries(
+      Object.entries(config).map(([chain, chainConfig]) => [
+        chain,
+        {
+          ...chainConfig,
+          address: chain === CHAIN_A ? ROUTER_A : ROUTER_B,
+        },
+      ]),
+    );
+  }
+
+  it('accepts an exact remote-router trust mesh', () => {
+    const expected = mesh();
+    expect(
+      buildWormholeRemoteRouterDiff(derived(expected), expected),
+    ).to.deep.equal({});
+  });
+
+  it('reports remote router, Wormhole ID, consistency, and executor drift', () => {
+    const expected = mesh();
+    const actual = derived(mesh());
+    actual[CHAIN_A].remoteRouters[CHAIN_B] = {
+      router: ROUTER_A,
+      wormholeChainId: 31,
+      expectedConsistencyLevel: 201,
+      quoter: ROUTER_B,
+      callbackGasLimit: 1n,
+    };
+
+    const diff = buildWormholeRemoteRouterDiff(actual, expected);
+    expect(diff[CHAIN_A]).to.have.nested.property(
+      `wormholeRemoteRouters.${CHAIN_B}.router.actual`,
+      ROUTER_A.toLowerCase(),
+    );
+    expect(diff[CHAIN_A]).to.have.nested.property(
+      `wormholeRemoteRouters.${CHAIN_B}.wormholeChainId.actual`,
+      31,
+    );
+    expect(diff[CHAIN_A]).to.have.nested.property(
+      `wormholeRemoteRouters.${CHAIN_B}.expectedConsistencyLevel.actual`,
+      201,
+    );
+    expect(diff[CHAIN_A]).to.have.nested.property(
+      `wormholeRemoteRouters.${CHAIN_B}.callbackGasLimit.actual`,
+      '1',
+    );
+  });
+
+  it('reports unexpected enrolled domains', () => {
+    const expected = mesh();
+    const actual = derived(mesh());
+    actual[CHAIN_A].remoteRouters['999999'] = {
+      router: ROUTER_A,
+      wormholeChainId: 77,
+      expectedConsistencyLevel: 202,
+      quoter: QUOTER,
+      callbackGasLimit: 300_000n,
+    };
+
+    expect(buildWormholeRemoteRouterDiff(actual, expected)[CHAIN_A])
+      .to.have.nested.property('wormholeRemoteRouters.999999.actual')
+      .that.deep.equals({
+        router: ROUTER_A.toLowerCase(),
+        wormholeChainId: 77,
+        expectedConsistencyLevel: 202,
+        quoter: QUOTER.toLowerCase(),
+        callbackGasLimit: '300000',
+      });
   });
 });

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { zeroAddress } from 'viem';
 
 import { CrossCollateralRouter__factory } from '@hyperlane-xyz/core';
-import { ProtocolType, addressToBytes32 } from '@hyperlane-xyz/utils';
+import { ProtocolType, addressToBytes32, assert } from '@hyperlane-xyz/utils';
 
 import {
   test1,
@@ -1191,13 +1191,20 @@ describe('buildWormholeRemoteRouterDiff', () => {
     config: WormholeMeshConfig,
   ): Record<string, DerivedWormholeHookIsmConfig> {
     return Object.fromEntries(
-      Object.entries(config).map(([chain, chainConfig]) => [
-        chain,
-        {
-          ...chainConfig,
-          address: chain === CHAIN_A ? ROUTER_A : ROUTER_B,
-        },
-      ]),
+      Object.entries(config).map(([chain, chainConfig]) => {
+        assert(
+          chainConfig.wormholeChainId !== undefined,
+          `Missing Wormhole chain ID for ${chain}`,
+        );
+        return [
+          chain,
+          {
+            ...chainConfig,
+            wormholeChainId: chainConfig.wormholeChainId,
+            address: chain === CHAIN_A ? ROUTER_A : ROUTER_B,
+          },
+        ];
+      }),
     );
   }
 

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -57,6 +57,18 @@ import {
 } from '../utils/decimals.js';
 import { collectHybridIsmNodes } from '../utils/ism.js';
 import { WarpCoreConfig } from '../warp/types.js';
+import { EvmWormholeHookIsmModule } from '../wormhole/EvmWormholeHookIsmModule.js';
+import {
+  buildWormholeMeshConfig,
+  findWormholeHooks,
+  findWormholeIsms,
+  pairWormholeConfigs,
+} from '../wormhole/config.js';
+import {
+  DerivedWormholeHookIsmConfig,
+  WormholeMeshConfig,
+  WormholeRemoteRouterConfig,
+} from '../wormhole/types.js';
 
 import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
 import { TokenType, isSyntheticTokenType } from './config.js';
@@ -864,6 +876,21 @@ export async function checkWarpRouteDeployConfig({
     warpRouteConfig: evmExpandedWarpDeployConfig,
   });
 
+  const wormholeDiff = await deriveWormholeRemoteRouterDiff({
+    multiProvider,
+    onChainWarpConfig: expandedOnChainWarpConfig,
+    warpDeployConfig,
+  });
+  for (const [chain, chainDiff] of Object.entries(wormholeDiff)) {
+    if (!rawEvmDiff[chain]) {
+      rawEvmDiff[chain] = chainDiff;
+      continue;
+    }
+    assertObjectDiffMap(rawEvmDiff[chain], `Unexpected diff for ${chain}`);
+    assertObjectDiffMap(chainDiff, `Unexpected Wormhole diff for ${chain}`);
+    Object.assign(rawEvmDiff[chain], chainDiff);
+  }
+
   await addOwnerOverrideDiffs({
     multiProvider,
     diff: rawEvmDiff,
@@ -1102,6 +1129,92 @@ export function buildWarpRouteDiff({
     },
     {} as Record<string, ObjectDiff>, // CAST: reduce incrementally populates chain-keyed ObjectDiff entries
   );
+}
+
+function normalizeWormholeRemoteRouters(
+  remoteRouters: Record<string, WormholeRemoteRouterConfig>,
+) {
+  return Object.fromEntries(
+    Object.entries(remoteRouters).map(([chain, config]) => [
+      chain,
+      {
+        router: normalizeAddressEvm(config.router),
+        wormholeChainId: config.wormholeChainId,
+        expectedConsistencyLevel: config.expectedConsistencyLevel,
+        ...(config.quoter
+          ? { quoter: normalizeAddressEvm(config.quoter) }
+          : {}),
+        ...(config.callbackGasLimit !== undefined
+          ? { callbackGasLimit: config.callbackGasLimit.toString() }
+          : {}),
+      },
+    ]),
+  );
+}
+
+export function buildWormholeRemoteRouterDiff(
+  actual: Record<string, DerivedWormholeHookIsmConfig>,
+  expected: WormholeMeshConfig,
+): Record<string, ObjectDiff> {
+  const diff: Record<string, ObjectDiff> = {};
+  for (const [chain, expectedConfig] of Object.entries(expected)) {
+    const actualConfig = actual[chain];
+    if (!actualConfig) continue;
+    const result = diffObjMerge(
+      normalizeWormholeRemoteRouters(actualConfig.remoteRouters),
+      normalizeWormholeRemoteRouters(expectedConfig.remoteRouters),
+    );
+    if (result.isInvalid) {
+      diff[chain] = { wormholeRemoteRouters: result.mergedObject };
+    }
+  }
+  return diff;
+}
+
+async function deriveWormholeRemoteRouterDiff({
+  multiProvider,
+  onChainWarpConfig,
+  warpDeployConfig,
+}: {
+  multiProvider: MultiProvider;
+  onChainWarpConfig: DerivedWarpRouteDeployConfig;
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+}): Promise<Record<string, ObjectDiff>> {
+  const pairs = pairWormholeConfigs(warpDeployConfig);
+  const chains = Object.keys(pairs);
+  if (chains.length === 0) return {};
+
+  const addresses: Record<string, Address> = {};
+  for (const chain of chains) {
+    const actual = onChainWarpConfig[chain];
+    if (!actual) return {};
+    const hooks = findWormholeHooks(actual.hook);
+    const isms = findWormholeIsms(actual.interchainSecurityModule);
+    if (hooks.length !== 1 || isms.length !== 1) return {};
+
+    const hookAddress =
+      'address' in hooks[0] && typeof hooks[0].address === 'string'
+        ? hooks[0].address
+        : undefined;
+    const ismAddress =
+      'address' in isms[0] && typeof isms[0].address === 'string'
+        ? isms[0].address
+        : undefined;
+    if (!hookAddress || !ismAddress || !eqAddress(hookAddress, ismAddress)) {
+      return {};
+    }
+    addresses[chain] = ismAddress;
+  }
+
+  const expected = EvmWormholeHookIsmModule.withDeployedRouters(
+    buildWormholeMeshConfig(warpDeployConfig, pairs),
+    addresses,
+  );
+  const actual = await EvmWormholeHookIsmModule.readMesh(
+    multiProvider,
+    addresses,
+  );
+  return buildWormholeRemoteRouterDiff(actual, expected);
 }
 
 async function addTimelockDiffs({

--- a/typescript/sdk/src/utils/ism.ts
+++ b/typescript/sdk/src/utils/ism.ts
@@ -18,6 +18,7 @@ import {
   IsmConfig,
   IsmType,
   NetFlowRateLimitedHookIsmConfig,
+  WormholeIsmConfig,
 } from '../ism/types.js';
 
 type ChainAddresses = Record<string, string>;
@@ -111,6 +112,8 @@ function ismTreeSome(
     case IsmType.INTERCHAIN_ACCOUNT_ROUTING:
     case IsmType.ARB_L2_TO_L1:
     case IsmType.OFFCHAIN_LOOKUP:
+    case IsmType.WORMHOLE_EXECUTOR:
+    case IsmType.WORMHOLE_VAA:
     case IsmType.UNKNOWN:
       return false;
     default: {
@@ -214,6 +217,11 @@ export type HybridHookIsmConfig =
   | NetFlowRateLimitedHookIsmConfig
   | DelayedFlowRouterHookIsmConfig;
 
+/** Combined hook/ISM leaves handled as opaque shared instances by generic
+ * EVM reconciliation. Flow-control hybrids remain a narrower subset used by
+ * the warp hybrid deployment planner. */
+export type CombinedHookIsmConfig = HybridHookIsmConfig | WormholeIsmConfig;
+
 /**
  * True if a warp-route hybrid hook/ISM node (NET_FLOW_RATE_LIMITED or
  * DELAYED_FLOW_ROUTER) exists anywhere in the ISM config tree.
@@ -263,6 +271,16 @@ function isHybridIsmNode(node: unknown): node is HybridHookIsmConfig {
   );
 }
 
+export function isCombinedHookIsmNode(
+  node: IsmConfig,
+): node is CombinedHookIsmConfig {
+  if (isHybridIsmNode(node)) return true;
+  return (
+    isRecord(node) &&
+    (node.type === IsmType.WORMHOLE_EXECUTOR ||
+      node.type === IsmType.WORMHOLE_VAA)
+  );
+}
 function collectHybridIsmNodesFromUnknown(ism: unknown): HybridHookIsmConfig[] {
   if (!isRecord(ism)) return [];
   if (isHybridIsmNode(ism)) return [ism];
@@ -293,14 +311,20 @@ export function mapHybridIsmNodes(
   ismConfig: IsmConfig,
   mapNode: (node: HybridHookIsmConfig) => IsmConfig,
 ): IsmConfig {
-  if (typeof ismConfig === 'string') return ismConfig;
+  return mapIsmTreeNodes(ismConfig, isHybridIsmNode, mapNode);
+}
 
-  if (
-    ismConfig.type === IsmType.NET_FLOW_RATE_LIMITED ||
-    ismConfig.type === IsmType.DELAYED_FLOW_ROUTER
-  ) {
-    return mapNode(ismConfig);
-  }
+/**
+ * Rebuilds an ISM tree, mapping every node accepted by `predicate`.
+ * Matching nodes are treated as leaves and their children are not traversed.
+ */
+export function mapIsmTreeNodes<T extends IsmConfig>(
+  ismConfig: IsmConfig,
+  predicate: (node: IsmConfig) => node is T,
+  mapNode: (node: T) => IsmConfig,
+): IsmConfig {
+  if (typeof ismConfig === 'string') return ismConfig;
+  if (predicate(ismConfig)) return mapNode(ismConfig);
 
   if (
     ismConfig.type === IsmType.AGGREGATION ||
@@ -308,7 +332,9 @@ export function mapHybridIsmNodes(
   ) {
     return {
       ...ismConfig,
-      modules: ismConfig.modules.map((m) => mapHybridIsmNodes(m, mapNode)),
+      modules: ismConfig.modules.map((m) =>
+        mapIsmTreeNodes(m, predicate, mapNode),
+      ),
     };
   }
 
@@ -319,7 +345,7 @@ export function mapHybridIsmNodes(
   ) {
     const newDomains: Record<string, IsmConfig> = {};
     for (const [domain, domainIsm] of Object.entries(ismConfig.domains)) {
-      newDomains[domain] = mapHybridIsmNodes(domainIsm, mapNode);
+      newDomains[domain] = mapIsmTreeNodes(domainIsm, predicate, mapNode);
     }
     return { ...ismConfig, domains: newDomains };
   }
@@ -327,12 +353,26 @@ export function mapHybridIsmNodes(
   if (ismConfig.type === IsmType.AMOUNT_ROUTING) {
     return {
       ...ismConfig,
-      lowerIsm: mapHybridIsmNodes(ismConfig.lowerIsm, mapNode),
-      upperIsm: mapHybridIsmNodes(ismConfig.upperIsm, mapNode),
+      lowerIsm: mapIsmTreeNodes(ismConfig.lowerIsm, predicate, mapNode),
+      upperIsm: mapIsmTreeNodes(ismConfig.upperIsm, predicate, mapNode),
     };
   }
 
   return ismConfig;
+}
+
+/** Collects matching ISM-tree leaves. */
+export function collectIsmTreeNodes<T extends IsmConfig>(
+  ismConfig: IsmConfig | undefined,
+  predicate: (node: IsmConfig) => node is T,
+): T[] {
+  if (!ismConfig) return [];
+  const collected: T[] = [];
+  mapIsmTreeNodes(ismConfig, predicate, (node) => {
+    collected.push(node);
+    return node;
+  });
+  return collected;
 }
 
 /**
@@ -462,6 +502,36 @@ export function collapseMatchingHybridIsmNodes(
       ? address
       : node;
   });
+}
+
+/** Replaces any combined hook/ISM leaf with its shared deployed address. */
+export function resolveCombinedHookIsmNodesToAddress(
+  ismConfig: IsmConfig,
+  address: Address,
+): IsmConfig {
+  return mapCombinedHookIsmNodes(ismConfig, () => address);
+}
+
+export function collapseMatchingCombinedHookIsmNodes(
+  ismConfig: IsmConfig,
+  address: Address,
+): IsmConfig {
+  return mapCombinedHookIsmNodes(ismConfig, (node) => {
+    const derivedAddress =
+      'address' in node && typeof node.address === 'string'
+        ? node.address
+        : undefined;
+    return derivedAddress && eqAddress(derivedAddress, address)
+      ? address
+      : node;
+  });
+}
+
+function mapCombinedHookIsmNodes(
+  ismConfig: IsmConfig,
+  mapNode: (node: CombinedHookIsmConfig) => IsmConfig,
+): IsmConfig {
+  return mapIsmTreeNodes(ismConfig, isCombinedHookIsmNode, mapNode);
 }
 
 /**

--- a/typescript/sdk/src/wormhole/EvmWormholeHookIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/wormhole/EvmWormholeHookIsmModule.hardhat-test.ts
@@ -1,0 +1,291 @@
+import chai from 'chai';
+import hre from 'hardhat';
+
+import {
+  MockCustomConsistencyLevel__factory,
+  MockExecutorQuoterRouter__factory,
+  MockWormholeCore__factory,
+  Mailbox__factory,
+  WormholeExecutorHookIsm__factory,
+  WormholeVaaHookIsm__factory,
+} from '@hyperlane-xyz/core';
+
+import { test4 } from '../consts/testChains.js';
+import { HookType } from '../hook/types.js';
+import { IsmType } from '../ism/types.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { EvmWormholeHookIsmModule } from './EvmWormholeHookIsmModule.js';
+import {
+  WormholeWarpChainConfig,
+  buildWormholeMeshConfig,
+  materializeWormholeWarpConfig,
+  pairWormholeConfigs,
+} from './config.js';
+import { WormholeConsistencyType, WormholeVariant } from './types.js';
+import {
+  WormholeConsistencyLevel,
+  type WormholeConsistencyLevelConfig,
+} from './consistency.js';
+import { assert } from '@hyperlane-xyz/utils';
+
+const { expect } = chai;
+
+describe('EvmWormholeHookIsmModule', () => {
+  const chains = ['wormholea', 'wormholeb'];
+  const wormholeChainIds: Record<string, number> = {
+    wormholea: 4_001,
+    wormholeb: 4_002,
+  };
+
+  let multiProvider: MultiProvider;
+  let signerAddress: string;
+  let mailboxes: Record<string, string>;
+  let cores: Record<string, string>;
+  let customConsistencyLevels: Record<string, string>;
+  let quoterRouters: Record<string, string>;
+
+  before(async () => {
+    const [signer] = await hre.ethers.getSigners();
+    signerAddress = signer.address;
+    multiProvider = new MultiProvider({
+      wormholea: { ...test4, name: 'wormholea', domainId: 10_001 },
+      wormholeb: { ...test4, name: 'wormholeb', domainId: 10_002 },
+    });
+    multiProvider.setProvider('wormholea', hre.ethers.provider);
+    multiProvider.setProvider('wormholeb', hre.ethers.provider);
+    multiProvider.setSharedSigner(signer);
+
+    mailboxes = {};
+    cores = {};
+    customConsistencyLevels = {};
+    quoterRouters = {};
+    for (const chain of chains) {
+      mailboxes[chain] = (
+        await multiProvider.handleDeploy(chain, new Mailbox__factory(), [
+          multiProvider.getDomainId(chain),
+        ])
+      ).address;
+      cores[chain] = (
+        await multiProvider.handleDeploy(
+          chain,
+          new MockWormholeCore__factory(),
+          [wormholeChainIds[chain], 0],
+        )
+      ).address;
+      customConsistencyLevels[chain] = (
+        await multiProvider.handleDeploy(
+          chain,
+          new MockCustomConsistencyLevel__factory(),
+          [],
+        )
+      ).address;
+      quoterRouters[chain] = (
+        await multiProvider.handleDeploy(
+          chain,
+          new MockExecutorQuoterRouter__factory(),
+          [0],
+        )
+      ).address;
+    }
+  });
+
+  function routeConfig(
+    variant: WormholeVariant,
+    consistencyLevel: WormholeConsistencyLevelConfig = {
+      type: WormholeConsistencyType.Finalized,
+    },
+  ): Record<string, WormholeWarpChainConfig> {
+    return Object.fromEntries(
+      chains.map((chain) => {
+        const remote = chains.find((candidate) => candidate !== chain);
+        assert(remote, `Missing remote chain for ${chain}`);
+        return [
+          chain,
+          {
+            mailbox: mailboxes[chain],
+            hook:
+              variant === WormholeVariant.Executor
+                ? {
+                    type: HookType.WORMHOLE_EXECUTOR,
+                    executorQuoterRouter: quoterRouters[chain],
+                    routes: {
+                      [remote]: {
+                        quoter: signerAddress,
+                        callbackGasLimit: 400_000n,
+                      },
+                    },
+                  }
+                : { type: HookType.WORMHOLE_VAA },
+            interchainSecurityModule:
+              variant === WormholeVariant.Executor
+                ? {
+                    type: IsmType.WORMHOLE_EXECUTOR,
+                    owner: signerAddress,
+                    core: cores[chain],
+                    wormholeChainId: wormholeChainIds[chain],
+                    consistencyLevel,
+                  }
+                : {
+                    type: IsmType.WORMHOLE_VAA,
+                    owner: signerAddress,
+                    core: cores[chain],
+                    wormholeChainId: wormholeChainIds[chain],
+                    consistencyLevel,
+                    urls: ['https://example.com/{data}'],
+                  },
+          },
+        ];
+      }),
+    );
+  }
+
+  for (const variant of [WormholeVariant.Executor, WormholeVariant.DirectVaa]) {
+    it(`deploys ${variant} with custom consistency`, async () => {
+      const input = routeConfig(variant, {
+        type: WormholeConsistencyType.Custom,
+        address: customConsistencyLevels.wormholea,
+        baseConsistencyLevel: WormholeConsistencyType.Instant,
+        additionalBlocks: 2,
+      });
+      for (const chain of chains) {
+        const ism = input[chain].interchainSecurityModule;
+        assert(
+          ism && typeof ism !== 'string' && 'consistencyLevel' in ism,
+          `Missing Wormhole ISM on ${chain}`,
+        );
+        ism.consistencyLevel = {
+          type: WormholeConsistencyType.Custom,
+          address: customConsistencyLevels[chain],
+          baseConsistencyLevel: WormholeConsistencyType.Instant,
+          additionalBlocks: 2,
+        };
+      }
+
+      const mesh = buildWormholeMeshConfig(input, pairWormholeConfigs(input));
+      const addresses = await EvmWormholeHookIsmModule.deployMesh(
+        multiProvider,
+        mesh,
+      );
+
+      for (const chain of chains) {
+        const router = WormholeVaaHookIsm__factory.connect(
+          addresses[chain],
+          multiProvider.getProvider(chain),
+        );
+        expect(await router.consistencyLevel()).to.equal(
+          WormholeConsistencyLevel.Custom,
+        );
+        expect(await router.customConsistencyLevel()).to.equal(
+          customConsistencyLevels[chain],
+        );
+        expect(await router.baseConsistencyLevel()).to.equal(
+          WormholeConsistencyLevel.Instant,
+        );
+        expect(await router.additionalBlocks()).to.equal(2);
+      }
+    });
+  }
+
+  for (const variant of [WormholeVariant.Executor, WormholeVariant.DirectVaa]) {
+    it(`deploys, enrolls, materializes, and reuses a ${variant} mesh`, async () => {
+      const input = routeConfig(variant);
+      const mesh = buildWormholeMeshConfig(input, pairWormholeConfigs(input));
+      const addresses = await EvmWormholeHookIsmModule.deployMesh(
+        multiProvider,
+        mesh,
+      );
+      const materialized = materializeWormholeWarpConfig(input, addresses);
+
+      for (const chain of chains) {
+        const remote = chains.find((candidate) => candidate !== chain);
+        assert(remote, `Missing remote chain for ${chain}`);
+        expect(materialized[chain].hook).to.equal(addresses[chain]);
+        expect(materialized[chain].interchainSecurityModule).to.equal(
+          addresses[chain],
+        );
+
+        const contract =
+          variant === WormholeVariant.Executor
+            ? WormholeExecutorHookIsm__factory.connect(
+                addresses[chain],
+                multiProvider.getProvider(chain),
+              )
+            : WormholeVaaHookIsm__factory.connect(
+                addresses[chain],
+                multiProvider.getProvider(chain),
+              );
+        expect(
+          await contract.routers(multiProvider.getDomainId(remote)),
+        ).to.not.equal(hre.ethers.constants.HashZero);
+      }
+
+      const second = await EvmWormholeHookIsmModule.reconcileMesh(
+        multiProvider,
+        mesh,
+        addresses,
+      );
+      expect(second.addresses).to.deep.equal(addresses);
+      expect(Object.values(second.transactions).flat()).to.deep.equal([]);
+    });
+  }
+
+  it('returns owner-authorized mutable updates for a reused direct-VAA mesh', async () => {
+    const input = routeConfig(WormholeVariant.DirectVaa);
+    const mesh = buildWormholeMeshConfig(input, pairWormholeConfigs(input));
+    const addresses = await EvmWormholeHookIsmModule.deployMesh(
+      multiProvider,
+      mesh,
+    );
+    for (const chain of chains)
+      mesh[chain].urls = ['https://new.example/{data}'];
+
+    const result = await EvmWormholeHookIsmModule.reconcileMesh(
+      multiProvider,
+      mesh,
+      addresses,
+    );
+    expect(
+      Object.values(result.transactions).every((txs) => txs.length === 1),
+    ).to.equal(true);
+
+    for (const chain of chains) {
+      for (const transaction of result.transactions[chain]) {
+        await multiProvider.sendTransaction(chain, transaction);
+      }
+      expect(
+        await WormholeVaaHookIsm__factory.connect(
+          addresses[chain],
+          multiProvider.getProvider(chain),
+        ).urls(),
+      ).to.deep.equal(['https://new.example/{data}']);
+    }
+  });
+
+  it('redeploys when an immutable changes', async () => {
+    const input = routeConfig(WormholeVariant.DirectVaa);
+    const mesh = buildWormholeMeshConfig(input, pairWormholeConfigs(input));
+    const addresses = await EvmWormholeHookIsmModule.deployMesh(
+      multiProvider,
+      mesh,
+    );
+    for (const chain of chains) {
+      mesh[chain].consistencyLevel = {
+        type: WormholeConsistencyType.Instant,
+      };
+      for (const remote of Object.values(mesh[chain].remoteRouters)) {
+        remote.expectedConsistencyLevel = WormholeConsistencyLevel.Instant;
+      }
+    }
+
+    const result = await EvmWormholeHookIsmModule.reconcileMesh(
+      multiProvider,
+      mesh,
+      addresses,
+    );
+    for (const chain of chains) {
+      expect(result.addresses[chain]).to.not.equal(addresses[chain]);
+    }
+    expect(Object.values(result.transactions).flat()).to.deep.equal([]);
+  });
+});

--- a/typescript/sdk/src/wormhole/EvmWormholeHookIsmModule.ts
+++ b/typescript/sdk/src/wormhole/EvmWormholeHookIsmModule.ts
@@ -1,0 +1,611 @@
+import {
+  WormholeExecutorHookIsm__factory,
+  WormholeVaaHookIsm__factory,
+} from '@hyperlane-xyz/core';
+import {
+  Address,
+  Domain,
+  EvmChainId,
+  ProtocolType,
+  addressToBytes32,
+  assert,
+  deepEquals,
+  eqAddress,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+import { constants, Contract } from 'ethers';
+
+import { transferOwnershipTransactions } from '../contracts/contracts.js';
+import {
+  HyperlaneModule,
+  HyperlaneModuleParams,
+} from '../core/AbstractHyperlaneModule.js';
+import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
+import { ChainMap, ChainName } from '../types.js';
+
+import { EvmWormholeHookIsmReader } from './EvmWormholeHookIsmReader.js';
+import {
+  DerivedWormholeHookIsmConfig,
+  WormholeHookIsmAddresses,
+  WormholeHookIsmConfig,
+  WormholeHookIsmSchema,
+  WormholeMeshConfig,
+  WormholeRemoteRouterConfig,
+  WormholeVariant,
+  findAsymmetricWormholeRoutes,
+} from './types.js';
+import {
+  type WormholeConsistencyLevelConfig,
+  WormholeConsistencyType,
+  consistencyLevelForConfig,
+} from './consistency.js';
+
+function consistencyLevelConfigsEqual(
+  current: WormholeConsistencyLevelConfig | undefined,
+  target: WormholeConsistencyLevelConfig | undefined,
+): boolean {
+  if (!current || !target || current.type !== target.type) return false;
+  if (
+    current.type !== WormholeConsistencyType.Custom ||
+    target.type !== WormholeConsistencyType.Custom
+  ) {
+    return true;
+  }
+  return (
+    eqAddress(current.address, target.address) &&
+    current.baseConsistencyLevel === target.baseConsistencyLevel &&
+    current.additionalBlocks === target.additionalBlocks
+  );
+}
+
+export interface WormholeMeshReconciliation {
+  addresses: ChainMap<Address>;
+  /** Owner-authorized updates for routers that were reused. */
+  transactions: ChainMap<AnnotatedEV5Transaction[]>;
+}
+
+/** Values fixed at construction; changing one requires a fresh deployment. */
+const IMMUTABLE_FIELDS = [
+  'type',
+  'mailbox',
+  'core',
+  'wormholeChainId',
+  'executorQuoterRouter',
+] as const;
+
+/**
+ * Deploys and maintains the combined Wormhole hook/ISM router.
+ *
+ * A dedicated module exists because the generic hook and ISM deployers would
+ * each deploy their own contract, breaking the invariant that one address serves
+ * as both roles. Mesh enrollment is a static, two-phase operation: every chain's
+ * router must exist before any of them can enroll the others.
+ */
+export class EvmWormholeHookIsmModule extends HyperlaneModule<
+  ProtocolType.Ethereum,
+  WormholeHookIsmConfig,
+  WormholeHookIsmAddresses
+> {
+  static protocols = [ProtocolType.Ethereum];
+  protected readonly logger = rootLogger.child({
+    module: 'EvmWormholeHookIsmModule',
+  });
+  protected readonly reader: EvmWormholeHookIsmReader;
+
+  public readonly chain: ChainName;
+  public readonly chainId: EvmChainId;
+  public readonly domainId: Domain;
+
+  constructor(
+    protected readonly multiProvider: MultiProvider,
+    params: HyperlaneModuleParams<
+      WormholeHookIsmConfig,
+      WormholeHookIsmAddresses
+    >,
+    protected readonly contractVerifier?: ContractVerifier,
+  ) {
+    params.config = WormholeHookIsmSchema.parse(params.config);
+    super(params);
+
+    this.reader = new EvmWormholeHookIsmReader(multiProvider, params.chain);
+    this.chain = multiProvider.getChainName(this.args.chain);
+    this.chainId = multiProvider.getEvmChainId(this.chain);
+    this.domainId = multiProvider.getDomainId(this.chain);
+  }
+
+  public async read(): Promise<DerivedWormholeHookIsmConfig> {
+    return this.reader.deriveWormholeConfig(this.args.addresses.deployedRouter);
+  }
+
+  /**
+   * Returns the transactions that move the deployed router to `targetConfig`.
+   * Re-running against an already-matching deployment returns no transactions.
+   */
+  public async update(
+    targetConfig: WormholeHookIsmConfig,
+  ): Promise<AnnotatedEV5Transaction[]> {
+    const target = WormholeHookIsmSchema.parse(targetConfig);
+    const current = await this.read();
+
+    this.assertImmutablesUnchanged(current, target);
+
+    const transactions: AnnotatedEV5Transaction[] = [
+      ...this.enrollmentTransactions(current, target),
+      ...this.urlTransactions(current, target),
+    ];
+
+    // Ownership moves last so the deployer can still apply the changes above.
+    transactions.push(
+      ...transferOwnershipTransactions(
+        this.chainId,
+        this.args.addresses.deployedRouter,
+        current,
+        target,
+        `Wormhole hook/ISM on ${this.chain}`,
+      ),
+    );
+
+    this.args.config = target;
+    return transactions;
+  }
+
+  private assertImmutablesUnchanged(
+    current: DerivedWormholeHookIsmConfig,
+    target: WormholeHookIsmConfig,
+  ): void {
+    assert(
+      consistencyLevelConfigsEqual(
+        current.consistencyLevel,
+        target.consistencyLevel,
+      ),
+      `Wormhole hook/ISM on ${this.chain} has immutable consistencyLevel ${JSON.stringify(
+        current.consistencyLevel,
+      )}; target wants ${JSON.stringify(target.consistencyLevel)}. Deploy a new router instead.`,
+    );
+    for (const field of IMMUTABLE_FIELDS) {
+      const currentValue = current[field];
+      const targetValue = target[field];
+      if (field === 'wormholeChainId' && targetValue === undefined) continue;
+      if (currentValue === undefined && targetValue === undefined) continue;
+
+      const equal =
+        typeof currentValue === 'string' && typeof targetValue === 'string'
+          ? eqAddress(currentValue, targetValue) || currentValue === targetValue
+          : currentValue === targetValue;
+
+      assert(
+        equal,
+        `Wormhole hook/ISM on ${this.chain} has immutable ${field} ${String(
+          currentValue,
+        )}; target wants ${String(targetValue)}. Deploy a new router instead.`,
+      );
+    }
+  }
+
+  private enrollmentTransactions(
+    current: DerivedWormholeHookIsmConfig,
+    target: WormholeHookIsmConfig,
+  ): AnnotatedEV5Transaction[] {
+    const transactions: AnnotatedEV5Transaction[] = [];
+
+    const toUnenroll = Object.keys(current.remoteRouters).filter(
+      (chain) => !target.remoteRouters[chain],
+    );
+    const toEnroll = Object.entries(target.remoteRouters).filter(
+      ([chain, remote]) =>
+        !this.remoteRouterMatches(current.remoteRouters[chain], remote),
+    );
+
+    // Unenroll first: a Wormhole chain-ID change is never folded into an
+    // address replacement on chain, so the old entry must go before the new one.
+    for (const chain of toUnenroll) {
+      transactions.push({
+        chainId: this.chainId,
+        annotation: `Unenrolling ${chain} from the Wormhole hook/ISM on ${this.chain}`,
+        to: this.args.addresses.deployedRouter,
+        data: WormholeVaaHookIsm__factory.createInterface().encodeFunctionData(
+          'unenrollRemoteRouter',
+          [this.multiProvider.getDomainId(chain)],
+        ),
+      });
+    }
+
+    for (const [chain, remote] of toEnroll) {
+      const existing = current.remoteRouters[chain];
+      if (existing && existing.wormholeChainId !== remote.wormholeChainId) {
+        transactions.push({
+          chainId: this.chainId,
+          annotation: `Unenrolling ${chain} from the Wormhole hook/ISM on ${this.chain} before its Wormhole chain ID changes`,
+          to: this.args.addresses.deployedRouter,
+          data: WormholeVaaHookIsm__factory.createInterface().encodeFunctionData(
+            'unenrollRemoteRouter',
+            [this.multiProvider.getDomainId(chain)],
+          ),
+        });
+      }
+    }
+
+    if (toEnroll.length > 0) {
+      transactions.push({
+        chainId: this.chainId,
+        annotation: `Enrolling ${toEnroll
+          .map(([chain]) => chain)
+          .join(', ')} on the Wormhole hook/ISM on ${this.chain}`,
+        to: this.args.addresses.deployedRouter,
+        data: this.encodeBatchEnrollment(
+          target.type,
+          toEnroll.map(([chain, remote]) => [chain, remote]),
+        ),
+      });
+    }
+
+    return transactions;
+  }
+
+  private urlTransactions(
+    current: DerivedWormholeHookIsmConfig,
+    target: WormholeHookIsmConfig,
+  ): AnnotatedEV5Transaction[] {
+    if (target.type !== WormholeVariant.DirectVaa || !target.urls) return [];
+    if (deepEquals(current.urls ?? [], target.urls)) return [];
+
+    return [
+      {
+        chainId: this.chainId,
+        annotation: `Updating CCIP-read URLs on the Wormhole hook/ISM on ${this.chain}`,
+        to: this.args.addresses.deployedRouter,
+        data: WormholeVaaHookIsm__factory.createInterface().encodeFunctionData(
+          'setUrls',
+          [target.urls],
+        ),
+      },
+    ];
+  }
+
+  private remoteRouterMatches(
+    current: WormholeRemoteRouterConfig | undefined,
+    target: WormholeRemoteRouterConfig,
+  ): boolean {
+    if (!current) return false;
+    if (!eqAddress(current.router, target.router)) return false;
+    if (current.wormholeChainId !== target.wormholeChainId) return false;
+    if (current.expectedConsistencyLevel !== target.expectedConsistencyLevel) {
+      return false;
+    }
+
+    if (target.quoter !== undefined) {
+      if (!current.quoter || !eqAddress(current.quoter, target.quoter)) {
+        return false;
+      }
+    }
+    if (target.callbackGasLimit !== undefined) {
+      if (
+        current.callbackGasLimit === undefined ||
+        BigInt(current.callbackGasLimit) !== BigInt(target.callbackGasLimit)
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private encodeBatchEnrollment(
+    variant: WormholeVariant,
+    routes: Array<[ChainName, WormholeRemoteRouterConfig]>,
+  ): string {
+    const enrollments = routes.map(([chain, remote]) => ({
+      domain: this.multiProvider.getDomainId(chain),
+      router: addressToBytes32(remote.router),
+      wormholeChainId: remote.wormholeChainId,
+      expectedConsistencyLevel: remote.expectedConsistencyLevel,
+    }));
+
+    if (variant === WormholeVariant.DirectVaa) {
+      return WormholeVaaHookIsm__factory.createInterface().encodeFunctionData(
+        'enrollRemoteRouters((uint32,bytes32,uint16,uint8)[])',
+        [enrollments],
+      );
+    }
+
+    return WormholeExecutorHookIsm__factory.createInterface().encodeFunctionData(
+      'enrollRemoteRouters(((uint32,bytes32,uint16,uint8),address,uint128)[])',
+      [
+        routes.map(([, remote], index) => {
+          assert(
+            remote.quoter && remote.callbackGasLimit !== undefined,
+            'wormholeExecutor enrollment requires quoter and callbackGasLimit',
+          );
+          return {
+            remoteRouter: enrollments[index],
+            quoter: remote.quoter,
+            callbackGasLimit: remote.callbackGasLimit.toString(),
+          };
+        }),
+      ],
+    );
+  }
+
+  // ============ Mesh orchestration ============
+
+  /**
+   * Deploys one router per chain, then enrolls the complete mesh.
+   *
+   * Two phases are required, not preferred: enrollment needs every remote
+   * address, and none exist until every chain has been deployed. The mesh is
+   * validated for symmetry before anything is broadcast.
+   */
+  public static async deployMesh(
+    multiProvider: MultiProvider,
+    mesh: WormholeMeshConfig,
+    contractVerifier?: ContractVerifier,
+  ): Promise<ChainMap<Address>> {
+    const result = await EvmWormholeHookIsmModule.reconcileMesh(
+      multiProvider,
+      mesh,
+      {},
+      contractVerifier,
+    );
+    assert(
+      Object.values(result.transactions).every((txs) => txs.length === 0),
+      'Fresh Wormhole mesh unexpectedly returned deferred transactions',
+    );
+    return result.addresses;
+  }
+
+  /**
+   * Reuses compatible routers, deploys missing/replacement routers, resolves
+   * the complete mesh, and returns updates requiring the reused routers'
+   * existing owners. Fresh routers are configured immediately while the
+   * deployer still owns them, then ownership is transferred last.
+   */
+  public static async reconcileMesh(
+    multiProvider: MultiProvider,
+    mesh: WormholeMeshConfig,
+    existingAddresses: ChainMap<Address> = {},
+    contractVerifier?: ContractVerifier,
+  ): Promise<WormholeMeshReconciliation> {
+    const logger = rootLogger.child({ module: 'EvmWormholeHookIsmModule' });
+    const chains = Object.keys(mesh);
+    assert(chains.length > 1, 'A Wormhole mesh needs at least two chains');
+
+    for (const chain of chains) {
+      assert(
+        multiProvider.getProtocol(chain) === ProtocolType.Ethereum,
+        `Wormhole hook/ISM only supports EVM chains; ${chain} is not one`,
+      );
+      WormholeHookIsmSchema.parse(mesh[chain]);
+      if (mesh[chain].wormholeChainId !== undefined) {
+        const core = new Contract(
+          mesh[chain].core,
+          ['function chainId() view returns (uint16)'],
+          multiProvider.getProvider(chain),
+        );
+        const actualChainId = Number(await core.chainId());
+        assert(
+          actualChainId === mesh[chain].wormholeChainId,
+          `Wormhole Core on ${chain} reports chain ID ${actualChainId}; config expects ${mesh[chain].wormholeChainId}`,
+        );
+      }
+    }
+
+    const addresses: ChainMap<Address> = {};
+    const fresh = new Set<ChainName>();
+    for (const chain of chains) {
+      const existing = existingAddresses[chain];
+      if (existing) {
+        const current = await new EvmWormholeHookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveWormholeConfig(existing);
+        if (!EvmWormholeHookIsmModule.requiresRedeploy(current, mesh[chain])) {
+          addresses[chain] = existing;
+          continue;
+        }
+        logger.info(
+          { chain, existing },
+          'Replacing Wormhole hook/ISM because an immutable changed',
+        );
+      }
+
+      addresses[chain] = await EvmWormholeHookIsmModule.deployRouter(
+        multiProvider,
+        chain,
+        mesh[chain],
+        contractVerifier,
+      );
+      fresh.add(chain);
+      logger.info(
+        { chain, address: addresses[chain] },
+        'Deployed Wormhole hook/ISM router',
+      );
+    }
+
+    const resolved = EvmWormholeHookIsmModule.withDeployedRouters(
+      mesh,
+      addresses,
+    );
+    const problems = findAsymmetricWormholeRoutes(resolved);
+    assert(
+      problems.length === 0,
+      `Asymmetric Wormhole mesh:\n  ${problems.join('\n  ')}`,
+    );
+
+    const deferred: ChainMap<AnnotatedEV5Transaction[]> = {};
+    for (const chain of chains) {
+      const module = new EvmWormholeHookIsmModule(multiProvider, {
+        chain,
+        config: resolved[chain],
+        addresses: {
+          deployedRouter: addresses[chain],
+          mailbox: resolved[chain].mailbox,
+        },
+      });
+      const transactions = await module.update(resolved[chain]);
+      if (fresh.has(chain)) {
+        for (const transaction of transactions) {
+          await multiProvider.sendTransaction(chain, transaction);
+        }
+      } else {
+        deferred[chain] = transactions;
+      }
+      logger.info(
+        {
+          chain,
+          transactions: transactions.length,
+          deferred: !fresh.has(chain),
+        },
+        'Reconciled Wormhole hook/ISM router',
+      );
+    }
+
+    return { addresses, transactions: deferred };
+  }
+
+  private static requiresRedeploy(
+    current: DerivedWormholeHookIsmConfig,
+    target: WormholeHookIsmConfig,
+  ): boolean {
+    if (
+      !consistencyLevelConfigsEqual(
+        current.consistencyLevel,
+        target.consistencyLevel,
+      )
+    ) {
+      return true;
+    }
+    return IMMUTABLE_FIELDS.some((field) => {
+      const currentValue = current[field];
+      const targetValue = target[field];
+      if (field === 'wormholeChainId' && targetValue === undefined)
+        return false;
+      if (currentValue === undefined && targetValue === undefined) return false;
+      if (typeof currentValue === 'string' && typeof targetValue === 'string') {
+        return (
+          !eqAddress(currentValue, targetValue) && currentValue !== targetValue
+        );
+      }
+      return currentValue !== targetValue;
+    });
+  }
+
+  /**
+   * Replaces every `remoteRouters[*].router` with the freshly deployed address
+   * for that chain, leaving the rest of the mesh config untouched.
+   */
+  public static withDeployedRouters(
+    mesh: WormholeMeshConfig,
+    addresses: ChainMap<Address>,
+  ): WormholeMeshConfig {
+    return Object.fromEntries(
+      Object.entries(mesh).map(([chain, config]) => [
+        chain,
+        {
+          ...config,
+          remoteRouters: Object.fromEntries(
+            Object.entries(config.remoteRouters).map(([remote, route]) => {
+              const deployed = addresses[remote];
+              assert(
+                deployed,
+                `No deployed Wormhole router for ${remote}, enrolled by ${chain}`,
+              );
+              return [remote, { ...route, router: deployed }];
+            }),
+          ),
+        },
+      ]),
+    );
+  }
+
+  public static async readMesh(
+    multiProvider: MultiProvider,
+    addresses: ChainMap<Address>,
+  ): Promise<ChainMap<DerivedWormholeHookIsmConfig>> {
+    const entries = await Promise.all(
+      Object.entries(addresses).map(async ([chain, address]) => [
+        chain,
+        await new EvmWormholeHookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveWormholeConfig(address),
+      ]),
+    );
+    return Object.fromEntries(entries);
+  }
+
+  private static async deployRouter(
+    multiProvider: MultiProvider,
+    chain: ChainName,
+    config: WormholeHookIsmConfig,
+    contractVerifier?: ContractVerifier,
+  ): Promise<Address> {
+    const signer = multiProvider.getSigner(chain);
+    const custom =
+      config.consistencyLevel.type === WormholeConsistencyType.Custom
+        ? config.consistencyLevel
+        : undefined;
+    const consistencyLevelConfig = {
+      consistencyLevel: consistencyLevelForConfig(config.consistencyLevel),
+      customConsistencyLevel: custom?.address ?? constants.AddressZero,
+      baseConsistencyLevel: custom
+        ? consistencyLevelForConfig({ type: custom.baseConsistencyLevel })
+        : 0,
+      additionalBlocks: custom?.additionalBlocks ?? 0,
+    };
+
+    if (config.type === WormholeVariant.Executor) {
+      assert(
+        config.executorQuoterRouter,
+        `wormholeExecutor on ${chain} requires executorQuoterRouter`,
+      );
+      const router = await new WormholeExecutorHookIsm__factory(signer).deploy(
+        config.mailbox,
+        config.core,
+        consistencyLevelConfig,
+        config.executorQuoterRouter,
+        multiProvider.getTransactionOverrides(chain),
+      );
+      await multiProvider.handleTx(chain, router.deployTransaction);
+      await contractVerifier?.verifyContract(chain, {
+        name: 'WormholeExecutorHookIsm',
+        address: router.address,
+        constructorArguments: WormholeExecutorHookIsm__factory.createInterface()
+          .encodeDeploy([
+            config.mailbox,
+            config.core,
+            consistencyLevelConfig,
+            config.executorQuoterRouter,
+          ])
+          .replace('0x', ''),
+        isProxy: false,
+      });
+      return router.address;
+    }
+
+    assert(config.urls, `wormholeVaa on ${chain} requires urls`);
+    const router = await new WormholeVaaHookIsm__factory(signer).deploy(
+      config.mailbox,
+      config.core,
+      consistencyLevelConfig,
+      config.urls,
+      multiProvider.getTransactionOverrides(chain),
+    );
+    await multiProvider.handleTx(chain, router.deployTransaction);
+    await contractVerifier?.verifyContract(chain, {
+      name: 'WormholeVaaHookIsm',
+      address: router.address,
+      constructorArguments: WormholeVaaHookIsm__factory.createInterface()
+        .encodeDeploy([
+          config.mailbox,
+          config.core,
+          consistencyLevelConfig,
+          config.urls,
+        ])
+        .replace('0x', ''),
+      isProxy: false,
+    });
+    return router.address;
+  }
+}

--- a/typescript/sdk/src/wormhole/EvmWormholeHookIsmReader.ts
+++ b/typescript/sdk/src/wormhole/EvmWormholeHookIsmReader.ts
@@ -45,8 +45,9 @@ export class EvmWormholeHookIsmReader {
 
   public async deriveWormholeConfig(
     address: Address,
+    knownVariant?: WormholeVariant,
   ): Promise<DerivedWormholeHookIsmConfig> {
-    const variant = await this.deriveVariant(address);
+    const variant = knownVariant ?? (await this.deriveVariant(address));
     return variant === WormholeVariant.Executor
       ? this.deriveExecutorConfig(address)
       : this.deriveDirectVaaConfig(address);

--- a/typescript/sdk/src/wormhole/EvmWormholeHookIsmReader.ts
+++ b/typescript/sdk/src/wormhole/EvmWormholeHookIsmReader.ts
@@ -1,0 +1,226 @@
+import { Logger } from 'pino';
+
+import {
+  WormholeExecutorHookIsm__factory,
+  WormholeVaaHookIsm__factory,
+} from '@hyperlane-xyz/core';
+import {
+  Address,
+  bytes32ToAddress,
+  eqAddress,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
+import { constants } from 'ethers';
+
+import { ModuleType } from '../ism/types.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { ChainNameOrId } from '../types.js';
+
+import {
+  DerivedWormholeHookIsmConfig,
+  WormholeRemoteRouterConfig,
+  WormholeVariant,
+} from './types.js';
+import {
+  WormholeConsistencyLevelSchema,
+  consistencyLevelConfigFromOnchain,
+} from './consistency.js';
+
+/**
+ * Reads a deployed Wormhole hook/ISM router back into its configuration.
+ *
+ * Both variants report `hookType() == WORMHOLE`, so the concrete subtype is
+ * resolved from `moduleType()`: the Executor variant verifies with empty
+ * metadata (`NULL`), the direct-VAA variant through CCIP-read.
+ */
+export class EvmWormholeHookIsmReader {
+  protected readonly logger: Logger = rootLogger.child({
+    module: 'EvmWormholeHookIsmReader',
+  });
+
+  constructor(
+    protected readonly multiProvider: MultiProvider,
+    protected readonly chain: ChainNameOrId,
+  ) {}
+
+  public async deriveWormholeConfig(
+    address: Address,
+  ): Promise<DerivedWormholeHookIsmConfig> {
+    const variant = await this.deriveVariant(address);
+    return variant === WormholeVariant.Executor
+      ? this.deriveExecutorConfig(address)
+      : this.deriveDirectVaaConfig(address);
+  }
+
+  public async deriveVariant(address: Address): Promise<WormholeVariant> {
+    const provider = this.multiProvider.getProvider(this.chain);
+    // `moduleType` is the only on-chain discriminator between the variants.
+    const moduleType = await WormholeVaaHookIsm__factory.connect(
+      address,
+      provider,
+    ).moduleType();
+
+    if (moduleType === ModuleType.NULL) return WormholeVariant.Executor;
+    if (moduleType === ModuleType.CCIP_READ) return WormholeVariant.DirectVaa;
+
+    throw new Error(
+      `Address ${address} on ${this.chain} reports module type ${moduleType}, which is not a Wormhole hook/ISM`,
+    );
+  }
+
+  private async deriveExecutorConfig(
+    address: Address,
+  ): Promise<DerivedWormholeHookIsmConfig> {
+    const provider = this.multiProvider.getProvider(this.chain);
+    const router = WormholeExecutorHookIsm__factory.connect(address, provider);
+
+    const [
+      mailbox,
+      core,
+      wormholeChainId,
+      consistencyLevel,
+      customConsistencyLevel,
+      baseConsistencyLevel,
+      additionalBlocks,
+      owner,
+      quoterRouter,
+      domains,
+    ] = await Promise.all([
+      router.mailbox(),
+      router.wormhole(),
+      router.wormholeChainId(),
+      router.consistencyLevel(),
+      router.customConsistencyLevel(),
+      router.baseConsistencyLevel(),
+      router.additionalBlocks(),
+      router.owner(),
+      router.executorQuoterRouter(),
+      router.domains(),
+    ]);
+
+    const remoteRouters = await this.deriveRemoteRouters(
+      domains,
+      async (domain) => {
+        const [routerAddress, config, executorConfig] = await Promise.all([
+          router.routers(domain),
+          router.remoteRouterConfigs(domain),
+          router.executorConfigs(domain),
+        ]);
+        return {
+          router: bytes32ToAddress(routerAddress),
+          wormholeChainId: config.wormholeChainId,
+          expectedConsistencyLevel: WormholeConsistencyLevelSchema.parse(
+            config.expectedConsistencyLevel,
+          ),
+          quoter: executorConfig.quoter,
+          callbackGasLimit: executorConfig.callbackGasLimit.toBigInt(),
+        };
+      },
+    );
+
+    return {
+      address,
+      type: WormholeVariant.Executor,
+      owner,
+      mailbox,
+      core,
+      wormholeChainId,
+      consistencyLevel: consistencyLevelConfigFromOnchain(
+        consistencyLevel,
+        eqAddress(customConsistencyLevel, constants.AddressZero)
+          ? undefined
+          : {
+              address: customConsistencyLevel,
+              baseConsistencyLevel,
+              additionalBlocks,
+            },
+      ),
+      executorQuoterRouter: quoterRouter,
+      remoteRouters,
+    };
+  }
+
+  private async deriveDirectVaaConfig(
+    address: Address,
+  ): Promise<DerivedWormholeHookIsmConfig> {
+    const provider = this.multiProvider.getProvider(this.chain);
+    const router = WormholeVaaHookIsm__factory.connect(address, provider);
+
+    const [
+      mailbox,
+      core,
+      wormholeChainId,
+      consistencyLevel,
+      customConsistencyLevel,
+      baseConsistencyLevel,
+      additionalBlocks,
+      owner,
+      urls,
+      domains,
+    ] = await Promise.all([
+      router.mailbox(),
+      router.wormhole(),
+      router.wormholeChainId(),
+      router.consistencyLevel(),
+      router.customConsistencyLevel(),
+      router.baseConsistencyLevel(),
+      router.additionalBlocks(),
+      router.owner(),
+      router.urls(),
+      router.domains(),
+    ]);
+
+    const remoteRouters = await this.deriveRemoteRouters(
+      domains,
+      async (domain) => {
+        const [routerAddress, config] = await Promise.all([
+          router.routers(domain),
+          router.remoteRouterConfigs(domain),
+        ]);
+        return {
+          router: bytes32ToAddress(routerAddress),
+          wormholeChainId: config.wormholeChainId,
+          expectedConsistencyLevel: WormholeConsistencyLevelSchema.parse(
+            config.expectedConsistencyLevel,
+          ),
+        };
+      },
+    );
+
+    return {
+      address,
+      type: WormholeVariant.DirectVaa,
+      owner,
+      mailbox,
+      core,
+      wormholeChainId,
+      consistencyLevel: consistencyLevelConfigFromOnchain(
+        consistencyLevel,
+        eqAddress(customConsistencyLevel, constants.AddressZero)
+          ? undefined
+          : {
+              address: customConsistencyLevel,
+              baseConsistencyLevel,
+              additionalBlocks,
+            },
+      ),
+      urls,
+      remoteRouters,
+    };
+  }
+
+  private async deriveRemoteRouters(
+    domains: ReadonlyArray<number>,
+    read: (domain: number) => Promise<WormholeRemoteRouterConfig>,
+  ): Promise<Record<string, WormholeRemoteRouterConfig>> {
+    const entries = await Promise.all(
+      domains.map(async (domain) => {
+        const chainName =
+          this.multiProvider.tryGetChainName(domain) ?? domain.toString();
+        return [chainName, await read(domain)] as const;
+      }),
+    );
+
+    return Object.fromEntries(entries);
+  }
+}

--- a/typescript/sdk/src/wormhole/config.test.ts
+++ b/typescript/sdk/src/wormhole/config.test.ts
@@ -1,0 +1,188 @@
+import { expect } from 'chai';
+import { assert } from '@hyperlane-xyz/utils';
+
+import { HookConfig, HookType } from '../hook/types.js';
+import { IsmConfig, IsmType } from '../ism/types.js';
+
+import {
+  WormholeWarpChainConfig,
+  buildWormholeMeshConfig,
+  materializeWormholeWarpConfig,
+  pairWormholeConfigs,
+} from './config.js';
+import {
+  WormholeConsistencyLevel,
+  WormholeConsistencyType,
+  WormholeVariant,
+} from './types.js';
+
+const OWNER = '0x0000000000000000000000000000000000000001';
+const MAILBOX = '0x0000000000000000000000000000000000000002';
+const CORE = '0x0000000000000000000000000000000000000003';
+const QUOTER_ROUTER = '0x0000000000000000000000000000000000000004';
+const QUOTER = '0x0000000000000000000000000000000000000005';
+const BASE_ROUTER = '0x00000000000000000000000000000000000000ba';
+const OPTIMISM_ROUTER = '0x00000000000000000000000000000000000000b0';
+
+function executorHook(remote: string): HookConfig {
+  return {
+    type: HookType.WORMHOLE_EXECUTOR,
+    executorQuoterRouter: QUOTER_ROUTER,
+    routes: {
+      [remote]: { quoter: QUOTER, callbackGasLimit: 300_000n },
+    },
+  };
+}
+
+function executorIsm(wormholeChainId: number): IsmConfig {
+  return {
+    type: IsmType.WORMHOLE_EXECUTOR,
+    owner: OWNER,
+    core: CORE,
+    wormholeChainId,
+    consistencyLevel: { type: WormholeConsistencyType.Finalized },
+  };
+}
+
+function executorRoute(): Record<string, WormholeWarpChainConfig> {
+  return {
+    base: {
+      mailbox: MAILBOX,
+      hook: {
+        type: HookType.AGGREGATION,
+        hooks: [{ type: HookType.MAILBOX_DEFAULT }, executorHook('optimism')],
+      },
+      interchainSecurityModule: {
+        type: IsmType.AGGREGATION,
+        threshold: 2,
+        modules: [{ type: IsmType.TEST_ISM }, executorIsm(30)],
+      },
+    },
+    optimism: {
+      mailbox: MAILBOX,
+      hook: executorHook('base'),
+      interchainSecurityModule: executorIsm(24),
+    },
+  };
+}
+
+describe('Wormhole Warp config resolution', () => {
+  it('pairs nested hook and ISM leaves and derives the mesh', () => {
+    const config = executorRoute();
+    const pairs = pairWormholeConfigs(config);
+    const mesh = buildWormholeMeshConfig(config, pairs);
+
+    expect(pairs.base.variant).to.equal(WormholeVariant.Executor);
+    expect(mesh.base.remoteRouters.optimism).to.include({
+      wormholeChainId: 24,
+      expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+      quoter: QUOTER,
+      callbackGasLimit: 300_000n,
+    });
+    expect(mesh.optimism.remoteRouters.base.wormholeChainId).to.equal(30);
+  });
+
+  it('replaces both leaves with the same local address', () => {
+    const resolved = materializeWormholeWarpConfig(executorRoute(), {
+      base: BASE_ROUTER,
+      optimism: OPTIMISM_ROUTER,
+    });
+
+    const baseHook = resolved.base.hook;
+    const baseIsm = resolved.base.interchainSecurityModule;
+    assert(
+      typeof baseHook !== 'string' && baseHook.type === HookType.AGGREGATION,
+      'Expected aggregation hook',
+    );
+    assert(
+      typeof baseIsm !== 'string' && baseIsm.type === IsmType.AGGREGATION,
+      'Expected aggregation ISM',
+    );
+    expect(baseHook.hooks[0]).to.deep.equal({
+      type: HookType.MAILBOX_DEFAULT,
+    });
+    expect(baseHook.hooks[1]).to.equal(BASE_ROUTER);
+    expect(baseIsm.modules[1]).to.equal(BASE_ROUTER);
+    expect(resolved.optimism.hook).to.equal(OPTIMISM_ROUTER);
+    expect(resolved.optimism.interchainSecurityModule).to.equal(
+      OPTIMISM_ROUTER,
+    );
+  });
+
+  it('requires both leaves on every participating chain', () => {
+    const config = executorRoute();
+    delete config.base.hook;
+
+    expect(() => pairWormholeConfigs(config)).to.throw(
+      'base must contain exactly one Wormhole hook leaf; found 0',
+    );
+  });
+
+  it('rejects duplicate Wormhole leaves', () => {
+    const config = executorRoute();
+    config.base.hook = {
+      type: HookType.AGGREGATION,
+      hooks: [executorHook('optimism'), executorHook('optimism')],
+    };
+
+    expect(() => pairWormholeConfigs(config)).to.throw(
+      'base must contain exactly one Wormhole hook leaf; found 2',
+    );
+  });
+
+  it('rejects a hook/ISM variant mismatch', () => {
+    const config = executorRoute();
+    config.base.hook = { type: HookType.WORMHOLE_VAA };
+
+    expect(() => pairWormholeConfigs(config)).to.throw(
+      /base Wormhole hook is wormholeVaa but ISM is wormholeExecutor/,
+    );
+  });
+
+  it('rejects a directional pairing mismatch', () => {
+    const config = executorRoute();
+    config.base.hook = {
+      type: HookType.ROUTING,
+      owner: OWNER,
+      domains: { base: executorHook('optimism') },
+    };
+
+    expect(() => pairWormholeConfigs(config)).to.throw(
+      /Wormhole pairing mismatch for base -> optimism/,
+    );
+  });
+
+  it('supports the direct-VAA pair without Executor fields', () => {
+    const config: Record<string, WormholeWarpChainConfig> = {
+      base: {
+        mailbox: MAILBOX,
+        hook: { type: HookType.WORMHOLE_VAA },
+        interchainSecurityModule: {
+          type: IsmType.WORMHOLE_VAA,
+          owner: OWNER,
+          core: CORE,
+          wormholeChainId: 30,
+          consistencyLevel: { type: WormholeConsistencyType.Finalized },
+          urls: ['https://example.com/{data}'],
+        },
+      },
+      optimism: {
+        mailbox: MAILBOX,
+        hook: { type: HookType.WORMHOLE_VAA },
+        interchainSecurityModule: {
+          type: IsmType.WORMHOLE_VAA,
+          owner: OWNER,
+          core: CORE,
+          wormholeChainId: 24,
+          consistencyLevel: { type: WormholeConsistencyType.Finalized },
+          urls: ['https://example.com/{data}'],
+        },
+      },
+    };
+
+    const mesh = buildWormholeMeshConfig(config, pairWormholeConfigs(config));
+    expect(mesh.base.type).to.equal(WormholeVariant.DirectVaa);
+    expect(mesh.base.executorQuoterRouter).to.equal(undefined);
+    expect(mesh.base.urls).to.deep.equal(['https://example.com/{data}']);
+  });
+});

--- a/typescript/sdk/src/wormhole/config.test.ts
+++ b/typescript/sdk/src/wormhole/config.test.ts
@@ -2,7 +2,15 @@ import { expect } from 'chai';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { HookConfig, HookType } from '../hook/types.js';
+import {
+  collapseMatchingCombinedHookIsmNodes,
+  resolveCombinedHookIsmNodesToAddress,
+} from '../hook/utils.js';
 import { IsmConfig, IsmType } from '../ism/types.js';
+import {
+  collapseMatchingCombinedHookIsmNodes as collapseCombinedIsm,
+  resolveCombinedHookIsmNodesToAddress as resolveCombinedIsm,
+} from '../utils/ism.js';
 
 import {
   WormholeWarpChainConfig,
@@ -67,6 +75,31 @@ function executorRoute(): Record<string, WormholeWarpChainConfig> {
 }
 
 describe('Wormhole Warp config resolution', () => {
+  it('treats Wormhole leaves as generic opaque combined hook/ISM nodes', () => {
+    const config = executorRoute();
+    const sharedAddress = '0x00000000000000000000000000000000000000aa';
+    const hook = resolveCombinedHookIsmNodesToAddress(
+      config.base.hook!,
+      sharedAddress,
+    );
+    const ism = resolveCombinedIsm(
+      config.base.interchainSecurityModule!,
+      sharedAddress,
+    );
+
+    expect(hook).to.deep.include({
+      hooks: [{ type: HookType.MAILBOX_DEFAULT }, sharedAddress],
+    });
+    expect(ism).to.deep.include({
+      modules: [{ type: IsmType.TEST_ISM }, sharedAddress],
+    });
+
+    expect(
+      collapseMatchingCombinedHookIsmNodes(hook, sharedAddress),
+    ).to.deep.equal(hook);
+    expect(collapseCombinedIsm(ism, sharedAddress)).to.deep.equal(ism);
+  });
+
   it('pairs nested hook and ISM leaves and derives the mesh', () => {
     const config = executorRoute();
     const pairs = pairWormholeConfigs(config);

--- a/typescript/sdk/src/wormhole/config.ts
+++ b/typescript/sdk/src/wormhole/config.ts
@@ -3,8 +3,10 @@ import { constants } from 'ethers';
 import { Address, assert } from '@hyperlane-xyz/utils';
 
 import { HookConfig, HookType, WormholeHookConfig } from '../hook/types.js';
+import { collectHookTreeNodes, mapHookTreeNodes } from '../hook/utils.js';
 import { IsmConfig, IsmType, WormholeIsmConfig } from '../ism/types.js';
 import { ChainMap, ChainName } from '../types.js';
+import { collectIsmTreeNodes, mapIsmTreeNodes } from '../utils/ism.js';
 
 import {
   WormholeHookIsmConfig,
@@ -25,8 +27,11 @@ export interface WormholeConfigPair {
   variant: WormholeVariant;
 }
 
-function isWormholeHook(config: HookConfig): config is WormholeHookConfig {
+function isWormholeHook(
+  config: HookConfig | undefined,
+): config is WormholeHookConfig {
   return (
+    !!config &&
     typeof config !== 'string' &&
     (config.type === HookType.WORMHOLE_EXECUTOR ||
       config.type === HookType.WORMHOLE_VAA)
@@ -44,53 +49,13 @@ function isWormholeIsm(config: IsmConfig): config is WormholeIsmConfig {
 export function findWormholeHooks(
   config: HookConfig | undefined,
 ): WormholeHookConfig[] {
-  if (!config || typeof config === 'string') return [];
-  if (isWormholeHook(config)) return [config];
-
-  switch (config.type) {
-    case HookType.AGGREGATION:
-      return config.hooks.flatMap(findWormholeHooks);
-    case HookType.ROUTING:
-      return Object.values(config.domains).flatMap(findWormholeHooks);
-    case HookType.FALLBACK_ROUTING:
-      return [
-        ...Object.values(config.domains).flatMap(findWormholeHooks),
-        ...findWormholeHooks(config.fallback),
-      ];
-    case HookType.AMOUNT_ROUTING:
-      return [
-        ...findWormholeHooks(config.lowerHook),
-        ...findWormholeHooks(config.upperHook),
-      ];
-    case HookType.ARB_L2_TO_L1:
-      return findWormholeHooks(config.childHook);
-    default:
-      return [];
-  }
+  return collectHookTreeNodes(config, isWormholeHook);
 }
 
 export function findWormholeIsms(
   config: IsmConfig | undefined,
 ): WormholeIsmConfig[] {
-  if (!config || typeof config === 'string') return [];
-  if (isWormholeIsm(config)) return [config];
-
-  switch (config.type) {
-    case IsmType.AGGREGATION:
-    case IsmType.STORAGE_AGGREGATION:
-      return config.modules.flatMap(findWormholeIsms);
-    case IsmType.ROUTING:
-    case IsmType.FALLBACK_ROUTING:
-    case IsmType.INCREMENTAL_ROUTING:
-      return Object.values(config.domains).flatMap(findWormholeIsms);
-    case IsmType.AMOUNT_ROUTING:
-      return [
-        ...findWormholeIsms(config.lowerIsm),
-        ...findWormholeIsms(config.upperIsm),
-      ];
-    default:
-      return [];
-  }
+  return collectIsmTreeNodes(config, isWormholeIsm);
 }
 
 /** Collects concrete addresses from a derived hook tree. */
@@ -310,87 +275,14 @@ export function replaceWormholeHook(
   config: HookConfig,
   address: Address,
 ): HookConfig {
-  if (typeof config === 'string') return config;
-  if (isWormholeHook(config)) return address;
-
-  switch (config.type) {
-    case HookType.AGGREGATION:
-      return {
-        ...config,
-        hooks: config.hooks.map((hook) => replaceWormholeHook(hook, address)),
-      };
-    case HookType.ROUTING:
-      return {
-        ...config,
-        domains: Object.fromEntries(
-          Object.entries(config.domains).map(([chain, hook]) => [
-            chain,
-            replaceWormholeHook(hook, address),
-          ]),
-        ),
-      };
-    case HookType.FALLBACK_ROUTING:
-      return {
-        ...config,
-        domains: Object.fromEntries(
-          Object.entries(config.domains).map(([chain, hook]) => [
-            chain,
-            replaceWormholeHook(hook, address),
-          ]),
-        ),
-        fallback: replaceWormholeHook(config.fallback, address),
-      };
-    case HookType.AMOUNT_ROUTING:
-      return {
-        ...config,
-        lowerHook: replaceWormholeHook(config.lowerHook, address),
-        upperHook: replaceWormholeHook(config.upperHook, address),
-      };
-    case HookType.ARB_L2_TO_L1:
-      return {
-        ...config,
-        childHook: replaceWormholeHook(config.childHook, address),
-      };
-    default:
-      return config;
-  }
+  return mapHookTreeNodes(config, isWormholeHook, () => address);
 }
 
 export function replaceWormholeIsm(
   config: IsmConfig,
   address: Address,
 ): IsmConfig {
-  if (typeof config === 'string') return config;
-  if (isWormholeIsm(config)) return address;
-
-  switch (config.type) {
-    case IsmType.AGGREGATION:
-    case IsmType.STORAGE_AGGREGATION:
-      return {
-        ...config,
-        modules: config.modules.map((ism) => replaceWormholeIsm(ism, address)),
-      };
-    case IsmType.ROUTING:
-    case IsmType.FALLBACK_ROUTING:
-    case IsmType.INCREMENTAL_ROUTING:
-      return {
-        ...config,
-        domains: Object.fromEntries(
-          Object.entries(config.domains).map(([chain, ism]) => [
-            chain,
-            replaceWormholeIsm(ism, address),
-          ]),
-        ),
-      };
-    case IsmType.AMOUNT_ROUTING:
-      return {
-        ...config,
-        lowerIsm: replaceWormholeIsm(config.lowerIsm, address),
-        upperIsm: replaceWormholeIsm(config.upperIsm, address),
-      };
-    default:
-      return config;
-  }
+  return mapIsmTreeNodes(config, isWormholeIsm, () => address);
 }
 
 export function buildWormholeMeshConfig(

--- a/typescript/sdk/src/wormhole/config.ts
+++ b/typescript/sdk/src/wormhole/config.ts
@@ -1,0 +1,498 @@
+import { constants } from 'ethers';
+
+import { Address, assert } from '@hyperlane-xyz/utils';
+
+import { HookConfig, HookType, WormholeHookConfig } from '../hook/types.js';
+import { IsmConfig, IsmType, WormholeIsmConfig } from '../ism/types.js';
+import { ChainMap, ChainName } from '../types.js';
+
+import {
+  WormholeHookIsmConfig,
+  WormholeMeshConfig,
+  WormholeVariant,
+} from './types.js';
+import { consistencyLevelForConfig } from './consistency.js';
+
+export interface WormholeWarpChainConfig {
+  hook?: HookConfig;
+  interchainSecurityModule?: IsmConfig;
+  mailbox?: Address;
+}
+
+export interface WormholeConfigPair {
+  hook: WormholeHookConfig;
+  ism: WormholeIsmConfig;
+  variant: WormholeVariant;
+}
+
+function isWormholeHook(config: HookConfig): config is WormholeHookConfig {
+  return (
+    typeof config !== 'string' &&
+    (config.type === HookType.WORMHOLE_EXECUTOR ||
+      config.type === HookType.WORMHOLE_VAA)
+  );
+}
+
+function isWormholeIsm(config: IsmConfig): config is WormholeIsmConfig {
+  return (
+    typeof config !== 'string' &&
+    (config.type === IsmType.WORMHOLE_EXECUTOR ||
+      config.type === IsmType.WORMHOLE_VAA)
+  );
+}
+
+export function findWormholeHooks(
+  config: HookConfig | undefined,
+): WormholeHookConfig[] {
+  if (!config || typeof config === 'string') return [];
+  if (isWormholeHook(config)) return [config];
+
+  switch (config.type) {
+    case HookType.AGGREGATION:
+      return config.hooks.flatMap(findWormholeHooks);
+    case HookType.ROUTING:
+      return Object.values(config.domains).flatMap(findWormholeHooks);
+    case HookType.FALLBACK_ROUTING:
+      return [
+        ...Object.values(config.domains).flatMap(findWormholeHooks),
+        ...findWormholeHooks(config.fallback),
+      ];
+    case HookType.AMOUNT_ROUTING:
+      return [
+        ...findWormholeHooks(config.lowerHook),
+        ...findWormholeHooks(config.upperHook),
+      ];
+    case HookType.ARB_L2_TO_L1:
+      return findWormholeHooks(config.childHook);
+    default:
+      return [];
+  }
+}
+
+export function findWormholeIsms(
+  config: IsmConfig | undefined,
+): WormholeIsmConfig[] {
+  if (!config || typeof config === 'string') return [];
+  if (isWormholeIsm(config)) return [config];
+
+  switch (config.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return config.modules.flatMap(findWormholeIsms);
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return Object.values(config.domains).flatMap(findWormholeIsms);
+    case IsmType.AMOUNT_ROUTING:
+      return [
+        ...findWormholeIsms(config.lowerIsm),
+        ...findWormholeIsms(config.upperIsm),
+      ];
+    default:
+      return [];
+  }
+}
+
+/** Collects concrete addresses from a derived hook tree. */
+export function collectHookAddresses(
+  config: HookConfig | undefined,
+): Address[] {
+  if (!config) return [];
+  if (typeof config === 'string') return [config];
+  const ownAddress =
+    'address' in config && typeof config.address === 'string'
+      ? [config.address]
+      : [];
+  switch (config.type) {
+    case HookType.AGGREGATION:
+      return [...ownAddress, ...config.hooks.flatMap(collectHookAddresses)];
+    case HookType.ROUTING:
+      return [
+        ...ownAddress,
+        ...Object.values(config.domains).flatMap(collectHookAddresses),
+      ];
+    case HookType.FALLBACK_ROUTING:
+      return [
+        ...ownAddress,
+        ...Object.values(config.domains).flatMap(collectHookAddresses),
+        ...collectHookAddresses(config.fallback),
+      ];
+    case HookType.AMOUNT_ROUTING:
+      return [
+        ...ownAddress,
+        ...collectHookAddresses(config.lowerHook),
+        ...collectHookAddresses(config.upperHook),
+      ];
+    case HookType.ARB_L2_TO_L1:
+      return [...ownAddress, ...collectHookAddresses(config.childHook)];
+    default:
+      return ownAddress;
+  }
+}
+
+/** Collects concrete addresses from a derived ISM tree. */
+export function collectIsmAddresses(config: IsmConfig | undefined): Address[] {
+  if (!config) return [];
+  if (typeof config === 'string') return [config];
+  const ownAddress =
+    'address' in config && typeof config.address === 'string'
+      ? [config.address]
+      : [];
+  switch (config.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return [...ownAddress, ...config.modules.flatMap(collectIsmAddresses)];
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return [
+        ...ownAddress,
+        ...Object.values(config.domains).flatMap(collectIsmAddresses),
+      ];
+    case IsmType.AMOUNT_ROUTING:
+      return [
+        ...ownAddress,
+        ...collectIsmAddresses(config.lowerIsm),
+        ...collectIsmAddresses(config.upperIsm),
+      ];
+    default:
+      return ownAddress;
+  }
+}
+
+function variantForHook(config: WormholeHookConfig): WormholeVariant {
+  return config.type === HookType.WORMHOLE_EXECUTOR
+    ? WormholeVariant.Executor
+    : WormholeVariant.DirectVaa;
+}
+
+function variantForIsm(config: WormholeIsmConfig): WormholeVariant {
+  return config.type === IsmType.WORMHOLE_EXECUTOR
+    ? WormholeVariant.Executor
+    : WormholeVariant.DirectVaa;
+}
+
+/**
+ * Finds and validates the one combined Wormhole resource represented by the
+ * hook and ISM trees on every chain. An empty route returns an empty map.
+ */
+export function pairWormholeConfigs(
+  configs: ChainMap<WormholeWarpChainConfig>,
+): ChainMap<WormholeConfigPair> {
+  const pairs: ChainMap<WormholeConfigPair> = {};
+  let routeVariant: WormholeVariant | undefined;
+  const hasAnyWormhole = Object.values(configs).some(
+    (config) =>
+      findWormholeHooks(config.hook).length > 0 ||
+      findWormholeIsms(config.interchainSecurityModule).length > 0,
+  );
+  if (!hasAnyWormhole) return pairs;
+
+  for (const [chain, config] of Object.entries(configs)) {
+    const hooks = findWormholeHooks(config.hook);
+    const isms = findWormholeIsms(config.interchainSecurityModule);
+    assert(
+      hooks.length === 1,
+      `${chain} must contain exactly one Wormhole hook leaf; found ${hooks.length}`,
+    );
+    assert(
+      isms.length === 1,
+      `${chain} must contain exactly one Wormhole ISM leaf; found ${isms.length}`,
+    );
+
+    const hookVariant = variantForHook(hooks[0]);
+    const ismVariant = variantForIsm(isms[0]);
+    assert(
+      hookVariant === ismVariant,
+      `${chain} Wormhole hook is ${hookVariant} but ISM is ${ismVariant}`,
+    );
+    routeVariant ??= hookVariant;
+    assert(
+      routeVariant === hookVariant,
+      `${chain} uses ${hookVariant}; the route already uses ${routeVariant}`,
+    );
+
+    pairs[chain] = { hook: hooks[0], ism: isms[0], variant: hookVariant };
+  }
+
+  validateDirectionalPairing(configs);
+  return pairs;
+}
+
+function hookUsesWormholeFor(
+  config: HookConfig | undefined,
+  destination: ChainName,
+): boolean {
+  if (!config || typeof config === 'string') return false;
+  if (isWormholeHook(config)) return true;
+
+  switch (config.type) {
+    case HookType.AGGREGATION:
+      return config.hooks.some((hook) =>
+        hookUsesWormholeFor(hook, destination),
+      );
+    case HookType.ROUTING:
+      return hookUsesWormholeFor(config.domains[destination], destination);
+    case HookType.FALLBACK_ROUTING:
+      return hookUsesWormholeFor(
+        config.domains[destination] ?? config.fallback,
+        destination,
+      );
+    case HookType.AMOUNT_ROUTING: {
+      const lower = hookUsesWormholeFor(config.lowerHook, destination);
+      const upper = hookUsesWormholeFor(config.upperHook, destination);
+      assert(
+        lower === upper,
+        `Wormhole cannot be conditional on amount for destination ${destination}`,
+      );
+      return lower;
+    }
+    case HookType.ARB_L2_TO_L1:
+      return (
+        config.destinationChain === destination &&
+        hookUsesWormholeFor(config.childHook, destination)
+      );
+    default:
+      return false;
+  }
+}
+
+function ismUsesWormholeFor(
+  config: IsmConfig | undefined,
+  origin: ChainName,
+): boolean {
+  if (!config || typeof config === 'string') return false;
+  if (isWormholeIsm(config)) return true;
+
+  switch (config.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return config.modules.some((ism) => ismUsesWormholeFor(ism, origin));
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return ismUsesWormholeFor(config.domains[origin], origin);
+    case IsmType.AMOUNT_ROUTING: {
+      const lower = ismUsesWormholeFor(config.lowerIsm, origin);
+      const upper = ismUsesWormholeFor(config.upperIsm, origin);
+      assert(
+        lower === upper,
+        `Wormhole cannot be conditional on amount for origin ${origin}`,
+      );
+      return lower;
+    }
+    default:
+      return false;
+  }
+}
+
+function validateDirectionalPairing(
+  configs: ChainMap<WormholeWarpChainConfig>,
+): void {
+  const chains = Object.keys(configs);
+  for (const origin of chains) {
+    for (const destination of chains) {
+      if (origin === destination) continue;
+      const hookUses = hookUsesWormholeFor(configs[origin].hook, destination);
+      const ismUses = ismUsesWormholeFor(
+        configs[destination].interchainSecurityModule,
+        origin,
+      );
+      assert(
+        hookUses === ismUses,
+        `Wormhole pairing mismatch for ${origin} -> ${destination}: origin hook=${hookUses}, destination ISM=${ismUses}`,
+      );
+    }
+  }
+}
+
+export function replaceWormholeHook(
+  config: HookConfig,
+  address: Address,
+): HookConfig {
+  if (typeof config === 'string') return config;
+  if (isWormholeHook(config)) return address;
+
+  switch (config.type) {
+    case HookType.AGGREGATION:
+      return {
+        ...config,
+        hooks: config.hooks.map((hook) => replaceWormholeHook(hook, address)),
+      };
+    case HookType.ROUTING:
+      return {
+        ...config,
+        domains: Object.fromEntries(
+          Object.entries(config.domains).map(([chain, hook]) => [
+            chain,
+            replaceWormholeHook(hook, address),
+          ]),
+        ),
+      };
+    case HookType.FALLBACK_ROUTING:
+      return {
+        ...config,
+        domains: Object.fromEntries(
+          Object.entries(config.domains).map(([chain, hook]) => [
+            chain,
+            replaceWormholeHook(hook, address),
+          ]),
+        ),
+        fallback: replaceWormholeHook(config.fallback, address),
+      };
+    case HookType.AMOUNT_ROUTING:
+      return {
+        ...config,
+        lowerHook: replaceWormholeHook(config.lowerHook, address),
+        upperHook: replaceWormholeHook(config.upperHook, address),
+      };
+    case HookType.ARB_L2_TO_L1:
+      return {
+        ...config,
+        childHook: replaceWormholeHook(config.childHook, address),
+      };
+    default:
+      return config;
+  }
+}
+
+export function replaceWormholeIsm(
+  config: IsmConfig,
+  address: Address,
+): IsmConfig {
+  if (typeof config === 'string') return config;
+  if (isWormholeIsm(config)) return address;
+
+  switch (config.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return {
+        ...config,
+        modules: config.modules.map((ism) => replaceWormholeIsm(ism, address)),
+      };
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return {
+        ...config,
+        domains: Object.fromEntries(
+          Object.entries(config.domains).map(([chain, ism]) => [
+            chain,
+            replaceWormholeIsm(ism, address),
+          ]),
+        ),
+      };
+    case IsmType.AMOUNT_ROUTING:
+      return {
+        ...config,
+        lowerIsm: replaceWormholeIsm(config.lowerIsm, address),
+        upperIsm: replaceWormholeIsm(config.upperIsm, address),
+      };
+    default:
+      return config;
+  }
+}
+
+export function buildWormholeMeshConfig(
+  configs: ChainMap<WormholeWarpChainConfig>,
+  pairs: ChainMap<WormholeConfigPair>,
+): WormholeMeshConfig {
+  const chains = Object.keys(pairs);
+  return Object.fromEntries(
+    chains.map((chain) => {
+      const local = pairs[chain];
+      const mailbox = configs[chain].mailbox;
+      assert(mailbox, `${chain} requires a mailbox for Wormhole deployment`);
+
+      const remoteRouters = Object.fromEntries(
+        chains
+          .filter((remote) => remote !== chain)
+          .map((remote) => {
+            const remoteIsm = pairs[remote].ism;
+            const common = {
+              router: constants.AddressZero,
+              wormholeChainId: remoteIsm.wormholeChainId,
+              expectedConsistencyLevel: consistencyLevelForConfig(
+                remoteIsm.consistencyLevel,
+              ),
+            };
+            if (local.variant === WormholeVariant.DirectVaa) {
+              return [remote, common];
+            }
+
+            assert(
+              local.hook.type === HookType.WORMHOLE_EXECUTOR,
+              `${chain} Executor pair has a non-Executor hook`,
+            );
+            const route = local.hook.routes[remote];
+            assert(
+              route,
+              `${chain} Wormhole Executor hook is missing route ${remote}`,
+            );
+            return [remote, { ...common, ...route }];
+          }),
+      );
+
+      const common: WormholeHookIsmConfig = {
+        type: local.variant,
+        owner: local.ism.owner,
+        mailbox,
+        core: local.ism.core,
+        wormholeChainId: local.ism.wormholeChainId,
+        consistencyLevel: local.ism.consistencyLevel,
+        remoteRouters,
+        ...(local.variant === WormholeVariant.Executor
+          ? {
+              executorQuoterRouter:
+                local.hook.type === HookType.WORMHOLE_EXECUTOR
+                  ? local.hook.executorQuoterRouter
+                  : undefined,
+            }
+          : {
+              urls:
+                local.ism.type === IsmType.WORMHOLE_VAA
+                  ? local.ism.urls
+                  : undefined,
+            }),
+      };
+      return [chain, common];
+    }),
+  );
+}
+
+export type MaterializedWormholeWarpChainConfig<
+  T extends WormholeWarpChainConfig,
+> = T & {
+  hook: HookConfig;
+  interchainSecurityModule: IsmConfig;
+};
+
+export function materializeWormholeWarpConfig<
+  T extends WormholeWarpChainConfig,
+>(
+  configs: ChainMap<T>,
+  addresses: ChainMap<Address>,
+): ChainMap<MaterializedWormholeWarpChainConfig<T>> {
+  return Object.fromEntries(
+    Object.entries(configs).map(([chain, config]) => {
+      const address = addresses[chain];
+      assert(address, `Missing deployed Wormhole router for ${chain}`);
+      assert(config.hook, `${chain} is missing its Wormhole hook tree`);
+      assert(
+        config.interchainSecurityModule,
+        `${chain} is missing its Wormhole ISM tree`,
+      );
+      return [
+        chain,
+        {
+          ...config,
+          hook: replaceWormholeHook(config.hook, address),
+          interchainSecurityModule: replaceWormholeIsm(
+            config.interchainSecurityModule,
+            address,
+          ),
+        },
+      ];
+    }),
+  );
+}

--- a/typescript/sdk/src/wormhole/consistency.test.ts
+++ b/typescript/sdk/src/wormhole/consistency.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+
+import {
+  WormholeConsistencyLevel,
+  WormholeConsistencyType,
+  consistencyLevelConfigFromOnchain,
+  consistencyLevelForConfig,
+} from './consistency.js';
+
+describe('Wormhole consistency levels', () => {
+  it('maps named consistency types to Wormhole wire values', () => {
+    expect(
+      consistencyLevelForConfig({
+        type: WormholeConsistencyType.Instant,
+      }),
+    ).to.equal(WormholeConsistencyLevel.Instant);
+    expect(
+      consistencyLevelForConfig({ type: WormholeConsistencyType.Safe }),
+    ).to.equal(WormholeConsistencyLevel.Safe);
+    expect(
+      consistencyLevelForConfig({
+        type: WormholeConsistencyType.Finalized,
+      }),
+    ).to.equal(WormholeConsistencyLevel.Finalized);
+    expect(
+      consistencyLevelForConfig({
+        type: WormholeConsistencyType.Custom,
+        address: '0x0000000000000000000000000000000000000001',
+        baseConsistencyLevel: WormholeConsistencyType.Instant,
+        additionalBlocks: 2,
+      }),
+    ).to.equal(WormholeConsistencyLevel.Custom);
+  });
+
+  it('reconstructs custom consistency from contract getters', () => {
+    expect(
+      consistencyLevelConfigFromOnchain(WormholeConsistencyLevel.Custom, {
+        address: '0x0000000000000000000000000000000000000001',
+        baseConsistencyLevel: WormholeConsistencyLevel.Safe,
+        additionalBlocks: 7,
+      }),
+    ).to.deep.equal({
+      type: WormholeConsistencyType.Custom,
+      address: '0x0000000000000000000000000000000000000001',
+      baseConsistencyLevel: WormholeConsistencyType.Safe,
+      additionalBlocks: 7,
+    });
+  });
+
+  it('rejects unsupported standard consistency values', () => {
+    expect(() => consistencyLevelConfigFromOnchain(15)).to.throw(
+      'Unsupported standard Wormhole consistency level 15',
+    );
+  });
+});

--- a/typescript/sdk/src/wormhole/consistency.ts
+++ b/typescript/sdk/src/wormhole/consistency.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+
+import { ZHash } from '../metadata/customZodTypes.js';
+
+/** Wormhole EVM watcher wire values; kept internal to config encoding. */
+export const WormholeConsistencyLevel = {
+  Instant: 200,
+  Safe: 201,
+  Finalized: 202,
+  Custom: 203,
+} as const;
+export type WormholeConsistencyLevel =
+  (typeof WormholeConsistencyLevel)[keyof typeof WormholeConsistencyLevel];
+export const WormholeConsistencyLevelSchema = z.union([
+  z.literal(WormholeConsistencyLevel.Instant),
+  z.literal(WormholeConsistencyLevel.Safe),
+  z.literal(WormholeConsistencyLevel.Finalized),
+  z.literal(WormholeConsistencyLevel.Custom),
+]);
+
+export const WormholeConsistencyType = {
+  Instant: 'instant',
+  Safe: 'safe',
+  Finalized: 'finalized',
+  Custom: 'custom',
+} as const;
+export type WormholeConsistencyType =
+  (typeof WormholeConsistencyType)[keyof typeof WormholeConsistencyType];
+
+export const WormholeStandardConsistencyTypeSchema = z.union([
+  z.literal(WormholeConsistencyType.Instant),
+  z.literal(WormholeConsistencyType.Safe),
+  z.literal(WormholeConsistencyType.Finalized),
+]);
+
+export type WormholeStandardConsistencyType = z.infer<
+  typeof WormholeStandardConsistencyTypeSchema
+>;
+
+/**
+ * User-facing consistency-level configuration. The discriminant makes custom level 203
+ * impossible to represent without its CCL registration inputs.
+ */
+export const WormholeConsistencyLevelConfigSchema = z.discriminatedUnion(
+  'type',
+  [
+    z.object({ type: z.literal(WormholeConsistencyType.Instant) }),
+    z.object({ type: z.literal(WormholeConsistencyType.Safe) }),
+    z.object({ type: z.literal(WormholeConsistencyType.Finalized) }),
+    z.object({
+      type: z.literal(WormholeConsistencyType.Custom),
+      /** Official Wormhole Custom Consistency Level contract on this chain. */
+      address: ZHash,
+      /** Standard EVM level reached before counting `additionalBlocks`. */
+      baseConsistencyLevel: WormholeStandardConsistencyTypeSchema,
+      additionalBlocks: z.number().int().min(0).max(65_535),
+    }),
+  ],
+);
+
+export type WormholeConsistencyLevelConfig = z.infer<
+  typeof WormholeConsistencyLevelConfigSchema
+>;
+
+export const WormholeConsistencyLevelFields = {
+  consistencyLevel: WormholeConsistencyLevelConfigSchema,
+};
+
+export function consistencyLevelForConfig(
+  config: WormholeConsistencyLevelConfig,
+): WormholeConsistencyLevel {
+  switch (config.type) {
+    case WormholeConsistencyType.Instant:
+      return WormholeConsistencyLevel.Instant;
+    case WormholeConsistencyType.Safe:
+      return WormholeConsistencyLevel.Safe;
+    case WormholeConsistencyType.Finalized:
+      return WormholeConsistencyLevel.Finalized;
+    case WormholeConsistencyType.Custom:
+      return WormholeConsistencyLevel.Custom;
+  }
+}
+
+export function standardConsistencyType(
+  consistencyLevel: number,
+): WormholeStandardConsistencyType {
+  switch (consistencyLevel) {
+    case WormholeConsistencyLevel.Instant:
+      return WormholeConsistencyType.Instant;
+    case WormholeConsistencyLevel.Safe:
+      return WormholeConsistencyType.Safe;
+    case WormholeConsistencyLevel.Finalized:
+      return WormholeConsistencyType.Finalized;
+    default:
+      throw new Error(
+        `Unsupported standard Wormhole consistency level ${consistencyLevel}`,
+      );
+  }
+}
+
+export function consistencyLevelConfigFromOnchain(
+  consistencyLevel: number,
+  custom?: {
+    address: string;
+    baseConsistencyLevel: number;
+    additionalBlocks: number;
+  },
+): WormholeConsistencyLevelConfig {
+  if (consistencyLevel !== WormholeConsistencyLevel.Custom) {
+    return { type: standardConsistencyType(consistencyLevel) };
+  }
+  if (!custom) {
+    throw new Error('Custom Wormhole consistency level has no CCL config');
+  }
+  return {
+    type: WormholeConsistencyType.Custom,
+    address: custom.address,
+    baseConsistencyLevel: standardConsistencyType(custom.baseConsistencyLevel),
+    additionalBlocks: custom.additionalBlocks,
+  };
+}

--- a/typescript/sdk/src/wormhole/types.test.ts
+++ b/typescript/sdk/src/wormhole/types.test.ts
@@ -1,0 +1,272 @@
+import { expect } from 'chai';
+
+import {
+  WormholeConsistencyLevel,
+  WormholeConsistencyType,
+  WormholeHookIsmConfig,
+  WormholeHookIsmSchema,
+  WormholeMeshConfig,
+  WormholeVariant,
+  findAsymmetricWormholeRoutes,
+} from './types.js';
+
+const OWNER = '0x0000000000000000000000000000000000000001';
+const MAILBOX = '0x0000000000000000000000000000000000000002';
+const CORE = '0x0000000000000000000000000000000000000003';
+const QUOTER_ROUTER = '0x0000000000000000000000000000000000000004';
+const QUOTER = '0x0000000000000000000000000000000000000005';
+const ROUTER_A = '0x00000000000000000000000000000000000000aa';
+const ROUTER_B = '0x00000000000000000000000000000000000000bb';
+const CCL = '0x00000000000000000000000000000000000000cc';
+
+const URLS = ['https://vaa.example/getWormholeVaa'];
+
+function directVaaConfig(
+  overrides: Partial<WormholeHookIsmConfig> = {},
+): WormholeHookIsmConfig {
+  return {
+    type: WormholeVariant.DirectVaa,
+    owner: OWNER,
+    mailbox: MAILBOX,
+    core: CORE,
+    consistencyLevel: { type: WormholeConsistencyType.Finalized },
+    urls: URLS,
+    remoteRouters: {
+      base: {
+        router: ROUTER_B,
+        wormholeChainId: 30,
+        expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function executorConfig(
+  overrides: Partial<WormholeHookIsmConfig> = {},
+): WormholeHookIsmConfig {
+  return {
+    type: WormholeVariant.Executor,
+    owner: OWNER,
+    mailbox: MAILBOX,
+    core: CORE,
+    consistencyLevel: { type: WormholeConsistencyType.Finalized },
+    executorQuoterRouter: QUOTER_ROUTER,
+    remoteRouters: {
+      base: {
+        router: ROUTER_B,
+        wormholeChainId: 30,
+        expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+        quoter: QUOTER,
+        callbackGasLimit: 300_000n,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('WormholeHookIsmSchema', () => {
+  it('accepts a direct-VAA config', () => {
+    expect(() => WormholeHookIsmSchema.parse(directVaaConfig())).to.not.throw();
+  });
+
+  it('accepts an Executor config', () => {
+    expect(() => WormholeHookIsmSchema.parse(executorConfig())).to.not.throw();
+  });
+
+  it('accepts a complete custom consistency-level config', () => {
+    expect(() =>
+      WormholeHookIsmSchema.parse(
+        directVaaConfig({
+          consistencyLevel: {
+            type: WormholeConsistencyType.Custom,
+            address: CCL,
+            baseConsistencyLevel: WormholeConsistencyType.Instant,
+            additionalBlocks: 2,
+          },
+        }),
+      ),
+    ).to.not.throw();
+  });
+
+  it('rejects an incomplete custom consistency-level config', () => {
+    expect(() =>
+      WormholeHookIsmSchema.parse({
+        ...directVaaConfig(),
+        consistencyLevel: {
+          type: WormholeConsistencyType.Custom,
+          baseConsistencyLevel: WormholeConsistencyType.Instant,
+          additionalBlocks: 2,
+        },
+      }),
+    ).to.throw();
+  });
+
+  it('requires urls for direct VAA', () => {
+    const config = directVaaConfig();
+    delete config.urls;
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /wormholeVaa requires urls/,
+    );
+  });
+
+  it('rejects Executor fields on a direct-VAA config', () => {
+    const config = directVaaConfig({ executorQuoterRouter: QUOTER_ROUTER });
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /executorQuoterRouter is a wormholeExecutor field/,
+    );
+  });
+
+  it('rejects per-route Executor fields on a direct-VAA config', () => {
+    const config = directVaaConfig({
+      remoteRouters: {
+        base: {
+          router: ROUTER_B,
+          wormholeChainId: 30,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+          quoter: QUOTER,
+        },
+      },
+    });
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /quoter and callbackGasLimit are wormholeExecutor fields/,
+    );
+  });
+
+  it('requires the Quoter Router for Executor', () => {
+    const config = executorConfig();
+    delete config.executorQuoterRouter;
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /wormholeExecutor requires executorQuoterRouter/,
+    );
+  });
+
+  it('requires a quoter on every Executor route', () => {
+    const config = executorConfig({
+      remoteRouters: {
+        base: {
+          router: ROUTER_B,
+          wormholeChainId: 30,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+          callbackGasLimit: 300_000n,
+        },
+      },
+    });
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /requires a quoter for every route/,
+    );
+  });
+
+  it('rejects a zero callback gas limit', () => {
+    const config = executorConfig({
+      remoteRouters: {
+        base: {
+          router: ROUTER_B,
+          wormholeChainId: 30,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+          quoter: QUOTER,
+          callbackGasLimit: 0n,
+        },
+      },
+    });
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /nonzero callbackGasLimit/,
+    );
+  });
+
+  it('rejects two Hyperlane domains claiming one Wormhole chain ID', () => {
+    const config = directVaaConfig({
+      remoteRouters: {
+        base: {
+          router: ROUTER_B,
+          wormholeChainId: 30,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+        },
+        optimism: {
+          router: ROUTER_A,
+          wormholeChainId: 30,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+        },
+      },
+    });
+
+    expect(() => WormholeHookIsmSchema.parse(config)).to.throw(
+      /already claimed by base/,
+    );
+  });
+});
+
+describe('findAsymmetricWormholeRoutes', () => {
+  function mesh(): WormholeMeshConfig {
+    return {
+      ethereum: directVaaConfig({
+        remoteRouters: {
+          base: {
+            router: ROUTER_B,
+            wormholeChainId: 30,
+            expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+          },
+        },
+      }),
+      base: directVaaConfig({
+        remoteRouters: {
+          ethereum: {
+            router: ROUTER_A,
+            wormholeChainId: 2,
+            expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+          },
+        },
+      }),
+    };
+  }
+
+  it('accepts a reciprocal mesh', () => {
+    expect(findAsymmetricWormholeRoutes(mesh())).to.deep.equal([]);
+  });
+
+  it('reports a one-sided enrollment', () => {
+    const oneSided = mesh();
+    oneSided.base.remoteRouters = {};
+
+    expect(findAsymmetricWormholeRoutes(oneSided)).to.deep.equal([
+      'base does not enroll ethereum',
+      'base does not enroll ethereum',
+    ]);
+  });
+
+  it('reports a consistency-level mismatch against what the origin publishes', () => {
+    const mismatched = mesh();
+    mismatched.ethereum.remoteRouters.base.expectedConsistencyLevel =
+      WormholeConsistencyLevel.Safe;
+
+    expect(findAsymmetricWormholeRoutes(mismatched)).to.deep.equal([
+      'ethereum expects consistency 201 from base, which publishes at 202',
+    ]);
+  });
+
+  it('reports a variant mismatch across the mesh', () => {
+    const mixed = mesh();
+    mixed.base = executorConfig({
+      remoteRouters: {
+        ethereum: {
+          router: ROUTER_A,
+          wormholeChainId: 2,
+          expectedConsistencyLevel: WormholeConsistencyLevel.Finalized,
+          quoter: QUOTER,
+          callbackGasLimit: 300_000n,
+        },
+      },
+    });
+
+    expect(findAsymmetricWormholeRoutes(mixed)).to.deep.equal([
+      'ethereum is wormholeVaa but base is wormholeExecutor',
+      'base is wormholeExecutor but ethereum is wormholeVaa',
+    ]);
+  });
+});

--- a/typescript/sdk/src/wormhole/types.ts
+++ b/typescript/sdk/src/wormhole/types.ts
@@ -1,0 +1,232 @@
+import { z } from 'zod';
+
+import { Address } from '@hyperlane-xyz/utils';
+
+import {
+  ZBigNumberish,
+  ZChainName,
+  ZHash,
+} from '../metadata/customZodTypes.js';
+import { ChainMap, OwnableSchema } from '../types.js';
+
+import {
+  WormholeConsistencyLevelFields,
+  WormholeConsistencyLevelSchema,
+  consistencyLevelForConfig,
+} from './consistency.js';
+
+export {
+  WormholeConsistencyLevel,
+  WormholeConsistencyLevelConfigSchema,
+  WormholeConsistencyLevelSchema,
+  WormholeConsistencyType,
+  WormholeStandardConsistencyTypeSchema,
+  consistencyLevelConfigFromOnchain,
+  consistencyLevelForConfig,
+  standardConsistencyType,
+} from './consistency.js';
+export type {
+  WormholeConsistencyLevelConfig,
+  WormholeStandardConsistencyType,
+} from './consistency.js';
+
+/**
+ * Wormhole hook/ISM configuration.
+ *
+ * One combined router is deployed per chain and enrolls every other chain in
+ * the mesh. The same local address is configured as an application's outbound
+ * hook and inbound ISM, so hook and ISM views share this one config type and
+ * cannot diverge.
+ */
+
+export const WormholeVariant = {
+  /** Executor delivers the VAA to `executeVAAv1`; ISM metadata stays empty. */
+  Executor: 'wormholeExecutor',
+  /** Hyperlane carries the VAA as CCIP-read ISM metadata. */
+  DirectVaa: 'wormholeVaa',
+} as const;
+export type WormholeVariant =
+  (typeof WormholeVariant)[keyof typeof WormholeVariant];
+
+export const WormholeRemoteRouterSchema = z.object({
+  /** Enrolled remote router address on that chain. */
+  router: ZHash,
+  wormholeChainId: z.number().int().positive().max(65_535),
+  expectedConsistencyLevel: WormholeConsistencyLevelSchema,
+  /** Executor only: provider quoter key registered in the Quoter Router. */
+  quoter: ZHash.optional(),
+  /** Executor only: destination gas bought for `executeVAAv1`. */
+  callbackGasLimit: ZBigNumberish.optional(),
+});
+
+export type WormholeRemoteRouterConfig = z.infer<
+  typeof WormholeRemoteRouterSchema
+>;
+
+const BaseWormholeHookIsmSchema = OwnableSchema.extend({
+  ...WormholeConsistencyLevelFields,
+  type: z.union([
+    z.literal(WormholeVariant.Executor),
+    z.literal(WormholeVariant.DirectVaa),
+  ]),
+  mailbox: ZHash,
+  /** Official Wormhole Core proxy for this chain. */
+  core: ZHash,
+  /** Optional deployment-time assertion against Core.chainId(). */
+  wormholeChainId: z.number().int().positive().max(65_535).optional(),
+  /** Executor only: the shared, Wormhole-published Quoter Router. */
+  executorQuoterRouter: ZHash.optional(),
+  /** Direct-VAA only: CCIP-read lookup service URLs. */
+  urls: z.array(z.string().url()).min(1).optional(),
+  remoteRouters: z.record(ZChainName, WormholeRemoteRouterSchema),
+});
+
+/**
+ * Rejects configurations that mix the two variants' fields, and enforces that
+ * an Executor route is never enrollable without its delivery configuration —
+ * mirroring the on-chain atomicity of `enrollRemoteRouter`.
+ */
+export const WormholeHookIsmSchema = BaseWormholeHookIsmSchema.superRefine(
+  (config, ctx) => {
+    if (config.type === WormholeVariant.Executor) {
+      if (!config.executorQuoterRouter) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['executorQuoterRouter'],
+          message: 'wormholeExecutor requires executorQuoterRouter',
+        });
+      }
+      if (config.urls) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['urls'],
+          message: 'urls is a wormholeVaa field',
+        });
+      }
+      for (const [chain, remote] of Object.entries(config.remoteRouters)) {
+        if (!remote.quoter) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['remoteRouters', chain, 'quoter'],
+            message: 'wormholeExecutor requires a quoter for every route',
+          });
+        }
+        if (
+          remote.callbackGasLimit === undefined ||
+          BigInt(remote.callbackGasLimit) === 0n
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['remoteRouters', chain, 'callbackGasLimit'],
+            message:
+              'wormholeExecutor requires a nonzero callbackGasLimit for every route',
+          });
+        }
+      }
+    }
+
+    if (config.type === WormholeVariant.DirectVaa) {
+      if (!config.urls) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['urls'],
+          message: 'wormholeVaa requires urls',
+        });
+      }
+      if (config.executorQuoterRouter) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['executorQuoterRouter'],
+          message: 'executorQuoterRouter is a wormholeExecutor field',
+        });
+      }
+      for (const [chain, remote] of Object.entries(config.remoteRouters)) {
+        if (remote.quoter || remote.callbackGasLimit !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['remoteRouters', chain],
+            message: 'quoter and callbackGasLimit are wormholeExecutor fields',
+          });
+        }
+      }
+    }
+
+    // A Wormhole chain ID identifies exactly one Hyperlane domain, matching the
+    // on-chain reverse index that rejects aliases.
+    const byWormholeChainId = new Map<number, string>();
+    for (const [chain, remote] of Object.entries(config.remoteRouters)) {
+      const existing = byWormholeChainId.get(remote.wormholeChainId);
+      if (existing) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['remoteRouters', chain, 'wormholeChainId'],
+          message: `Wormhole chain ID ${remote.wormholeChainId} is already claimed by ${existing}`,
+        });
+      }
+      byWormholeChainId.set(remote.wormholeChainId, chain);
+    }
+  },
+);
+
+export type WormholeHookIsmConfig = z.infer<typeof WormholeHookIsmSchema>;
+
+/** A whole mesh, keyed by chain. */
+export const WormholeMeshSchema = z.record(ZChainName, WormholeHookIsmSchema);
+
+export type WormholeMeshConfig = ChainMap<WormholeHookIsmConfig>;
+
+export type DerivedWormholeHookIsmConfig = WormholeHookIsmConfig & {
+  address: Address;
+};
+
+export type WormholeHookIsmAddresses = {
+  deployedRouter: Address;
+  mailbox: Address;
+};
+
+/**
+ * Checks that every chain in the mesh enrolls, and is enrolled by, every other
+ * chain. A valid `A -> B` entry does not prove `B -> A`, and a one-sided mesh
+ * silently strands one direction.
+ */
+export function findAsymmetricWormholeRoutes(
+  mesh: WormholeMeshConfig,
+): Array<string> {
+  const problems: Array<string> = [];
+  const chains = Object.keys(mesh);
+
+  for (const origin of chains) {
+    for (const destination of chains) {
+      if (origin === destination) continue;
+
+      const outbound = mesh[origin].remoteRouters[destination];
+      if (!outbound) {
+        problems.push(`${origin} does not enroll ${destination}`);
+        continue;
+      }
+
+      const inbound = mesh[destination].remoteRouters[origin];
+      if (!inbound) {
+        problems.push(`${destination} does not enroll ${origin}`);
+        continue;
+      }
+
+      const destinationConsistency = consistencyLevelForConfig(
+        mesh[destination].consistencyLevel,
+      );
+      if (outbound.expectedConsistencyLevel !== destinationConsistency) {
+        problems.push(
+          `${origin} expects consistency ${outbound.expectedConsistencyLevel} from ${destination}, which publishes at ${destinationConsistency}`,
+        );
+      }
+
+      if (mesh[origin].type !== mesh[destination].type) {
+        problems.push(
+          `${origin} is ${mesh[origin].type} but ${destination} is ${mesh[destination].type}`,
+        );
+      }
+    }
+  }
+
+  return problems;
+}

--- a/typescript/sdk/src/wormhole/types.ts
+++ b/typescript/sdk/src/wormhole/types.ts
@@ -175,8 +175,12 @@ export const WormholeMeshSchema = z.record(ZChainName, WormholeHookIsmSchema);
 
 export type WormholeMeshConfig = ChainMap<WormholeHookIsmConfig>;
 
-export type DerivedWormholeHookIsmConfig = WormholeHookIsmConfig & {
+export type DerivedWormholeHookIsmConfig = Omit<
+  WormholeHookIsmConfig,
+  'wormholeChainId'
+> & {
   address: Address;
+  wormholeChainId: number;
 };
 
 export type WormholeHookIsmAddresses = {


### PR DESCRIPTION
### Description

Adds SDK, relayer, CCIP-server, and CLI support for the Wormhole wrapping ISM/hook contracts.

This PR adds:

- Discriminated Wormhole configuration schemas for Executor and direct-VAA variants.
- Named Wormhole consistency configuration using const objects, including custom consistency levels and additional finality blocks.
- Mesh validation for reciprocal router enrollment, variant consistency, destination consistency, and duplicate Wormhole chain IDs.
- Warp configuration pairing/materialization that discovers a single combined Wormhole hook/ISM resource, deploys one router per chain, and replaces the hook and ISM leaves with the deployed shared address.
- SDK readers for deployed Wormhole router state and both hook/ISM views.
- SDK deployment and reconciliation support for enrollment, Executor configuration, VAA URLs, custom consistency configuration, and address replacement.
- Relayer metadata support for Executor and direct-VAA Wormhole delivery.
- A CCIP-read Wormhole VAA service that:
  - Locates Core publication events.
  - Matches publications to the exact Hyperlane message envelope.
  - Validates emitter chain/address, sequence, payload, destination router, and consistency.
  - Fetches and bounds VAA responses.
  - Rejects ambiguous or mismatched upstream responses.
- CLI Warp deploy/apply/read/check and self-relay e2e coverage for both variants.
- The package changeset and required test dependency wiring.

The implementation follows existing Hyperlane SDK conventions and keeps Wormhole-specific deployment logic in a dedicated module rather than generic ISM/hook factories.

### Drive-by changes

- Adds the required Wormhole test dependency entries.
- Adds the Wormhole contracts to the existing Tron compiler exclusion list through the contract-layer change.
- Adds CLI test fixtures for local Wormhole Core, Executor, and VAA-service flows.

### Related issues

None.

### Backward compatibility

Yes for existing Warp routes and existing ISM/hook configurations. Wormhole support is additive. Existing generic factories continue to reject Wormhole types because the combined contract must be deployed and reconciled atomically by the dedicated Wormhole module.

### Testing

- SDK unit suite: 1,305 passing.
- CCIP-server suite: 93 passing.
- Solidity contract and invariant coverage is provided by the parent contract change.
- CLI Ethereum e2e coverage includes:
  - Executor Wormhole deploy, apply, read, check, callback authorization, and self-relay.
  - Direct-VAA Wormhole deploy, apply, read, CCIP-read lookup, and self-relay.
  - Consistency/finality configuration reconciliation.

