### PR TITLE
fix(sdk): safely recover address-bearing hook trees

### DIFF
--- a/.changeset/address-bearing-hook-recovery.md
+++ b/.changeset/address-bearing-hook-recovery.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added safe recovery for address-bearing hook trees. Recovered pausable hooks and ISMs can transfer ownership without redeployment, while recovery validates the complete tree before mutation, preserves live pause state, and rejects incorrect contract types or conflicting aliases.

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.hardhat-test.ts
@@ -1,0 +1,517 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import hre from 'hardhat';
+
+import {
+  DomainRoutingHook__factory,
+  FallbackDomainRoutingHook__factory,
+  PausableHook__factory,
+  StaticAggregationHook__factory,
+} from '@hyperlane-xyz/core';
+import { WithAddress, eqAddress } from '@hyperlane-xyz/utils';
+
+import { TestChainName } from '../consts/testChains.js';
+import { TestCoreDeployer } from '../core/TestCoreDeployer.js';
+import { HyperlaneProxyFactoryDeployer } from '../deploy/HyperlaneProxyFactoryDeployer.js';
+import { HyperlaneIsmFactory } from '../ism/HyperlaneIsmFactory.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { HyperlaneHookDeployer } from './HyperlaneHookDeployer.js';
+import {
+  AggregationHookConfig,
+  DomainRoutingHookConfig,
+  FallbackRoutingHookConfig,
+  HookType,
+  MerkleTreeHookConfig,
+  PausableHookConfig,
+} from './types.js';
+
+chai.use(chaiAsPromised);
+
+describe('HyperlaneHookDeployer recovered hooks', () => {
+  const chain = TestChainName.test1;
+  const remote = TestChainName.test2;
+  const newRemote = TestChainName.test3;
+
+  async function deployFixture() {
+    const [signer, newOwner, overrideOwner] = await hre.ethers.getSigners();
+    const multiProvider = MultiProvider.createTestMultiProvider({ signer });
+    const proxyFactoryContracts = await new HyperlaneProxyFactoryDeployer(
+      multiProvider,
+    ).deploy(multiProvider.mapKnownChains(() => ({})));
+    const ismFactory = new HyperlaneIsmFactory(
+      proxyFactoryContracts,
+      multiProvider,
+    );
+    const coreApp = await new TestCoreDeployer(
+      multiProvider,
+      ismFactory,
+    ).deployApp();
+    const core = coreApp.getContracts(chain);
+    const coreAddresses = {
+      mailbox: core.mailbox.address,
+      proxyAdmin: core.proxyAdmin.address,
+    };
+    const hookDeployer = new HyperlaneHookDeployer(
+      multiProvider,
+      { [chain]: coreAddresses },
+      ismFactory,
+    );
+
+    const owner = await signer.getAddress();
+    const initialConfig: FallbackRoutingHookConfig = {
+      type: HookType.FALLBACK_ROUTING,
+      owner,
+      fallback: { type: HookType.MERKLE_TREE },
+      domains: {
+        [remote]: {
+          type: HookType.AGGREGATION,
+          hooks: [
+            { type: HookType.PAUSABLE, owner, paused: false },
+            { type: HookType.MERKLE_TREE },
+          ],
+        },
+      },
+    };
+    const deployed = await hookDeployer.deployContracts(
+      chain,
+      initialConfig,
+      coreAddresses,
+    );
+    const fallbackRoutingHook = FallbackDomainRoutingHook__factory.connect(
+      deployed.fallbackRoutingHook.address,
+      signer,
+    );
+    const aggregationAddress = await fallbackRoutingHook.hooks(
+      multiProvider.getDomainId(remote),
+    );
+    const pausableAddress =
+      hookDeployer.deployedContracts[chain].pausableHook.address;
+    const merkleTreeAddress =
+      hookDeployer.deployedContracts[chain].merkleTreeHook.address;
+    const aggregation = StaticAggregationHook__factory.connect(
+      aggregationAddress,
+      signer,
+    );
+    const childrenBefore = await aggregation.hooks(
+      hre.ethers.constants.AddressZero,
+    );
+
+    return {
+      signer,
+      newOwner,
+      overrideOwner,
+      multiProvider,
+      coreApp,
+      coreAddresses,
+      hookDeployer,
+      owner,
+      fallbackRoutingHook,
+      aggregationAddress,
+      pausableAddress,
+      merkleTreeAddress,
+      aggregation,
+      childrenBefore,
+    };
+  }
+
+  it('reconciles a nested recovered pausable hook without replacing the tree', async () => {
+    const {
+      signer,
+      newOwner,
+      overrideOwner,
+      multiProvider,
+      coreAddresses,
+      hookDeployer,
+      owner,
+      fallbackRoutingHook,
+      aggregationAddress,
+      pausableAddress,
+      merkleTreeAddress,
+      aggregation,
+      childrenBefore,
+    } = await deployFixture();
+
+    const recoveredPausable: WithAddress<PausableHookConfig> = {
+      type: HookType.PAUSABLE,
+      address: pausableAddress,
+      owner: await newOwner.getAddress(),
+      ownerOverrides: {
+        [HookType.PAUSABLE]: await overrideOwner.getAddress(),
+      },
+      paused: false,
+    };
+    const recoveredAggregation: WithAddress<AggregationHookConfig> = {
+      type: HookType.AGGREGATION,
+      address: aggregationAddress,
+      hooks: [recoveredPausable, merkleTreeAddress],
+    };
+
+    const mismatchedAggregation: WithAddress<AggregationHookConfig> = {
+      ...recoveredAggregation,
+      hooks: [recoveredPausable, owner],
+    };
+    const mismatchedConfig: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: { [remote]: mismatchedAggregation },
+    };
+    const nonceBeforeMismatch = await signer.getTransactionCount();
+    await expect(
+      hookDeployer.deployContracts(chain, mismatchedConfig, coreAddresses),
+    ).to.be.rejectedWith('does not contain the configured children');
+    expect(await signer.getTransactionCount()).to.equal(nonceBeforeMismatch);
+    const unchangedPausable = PausableHook__factory.connect(
+      pausableAddress,
+      signer,
+    );
+    expect(await unchangedPausable.paused()).to.be.false;
+    expect(eqAddress(await unchangedPausable.owner(), owner)).to.be.true;
+
+    const pauseMismatch: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: {
+        [remote]: {
+          ...recoveredAggregation,
+          hooks: [{ ...recoveredPausable, paused: true }, merkleTreeAddress],
+        },
+      },
+    };
+    await expect(
+      hookDeployer.deployContracts(chain, pauseMismatch, coreAddresses),
+    ).to.be.rejectedWith('but config expects paused');
+    expect(await signer.getTransactionCount()).to.equal(nonceBeforeMismatch);
+
+    const invalidLaterChild: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: {
+        [remote]: recoveredAggregation,
+        [newRemote]: {
+          type: HookType.AGGREGATION,
+          address: merkleTreeAddress,
+          hooks: [],
+        },
+      },
+    };
+    await expect(
+      hookDeployer.deployContracts(chain, invalidLaterChild, coreAddresses),
+    ).to.be.rejectedWith('has type');
+    expect(await signer.getTransactionCount()).to.equal(nonceBeforeMismatch);
+    expect(eqAddress(await unchangedPausable.owner(), owner)).to.be.true;
+
+    const conflictingAggregation = {
+      ...recoveredAggregation,
+      hooks: [
+        { ...recoveredPausable, owner: await overrideOwner.getAddress() },
+        merkleTreeAddress,
+      ],
+    };
+    const conflictingAliases: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: {
+        [remote]: recoveredAggregation,
+        [newRemote]: conflictingAggregation,
+      },
+    };
+    await expect(
+      hookDeployer.deployContracts(chain, conflictingAliases, coreAddresses),
+    ).to.be.rejectedWith('has conflicting configs');
+    expect(await signer.getTransactionCount()).to.equal(nonceBeforeMismatch);
+
+    const recoveredConfig: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: {
+        [remote]: recoveredAggregation,
+        [newRemote]: recoveredAggregation,
+      },
+    };
+
+    const nonceBefore = await signer.getTransactionCount();
+    const recovered = await hookDeployer.deployContracts(
+      chain,
+      recoveredConfig,
+      coreAddresses,
+    );
+    const nonceAfter = await signer.getTransactionCount();
+
+    expect(recovered.fallbackRoutingHook.address).to.equal(
+      fallbackRoutingHook.address,
+    );
+    // transferOwnership on the recovered pausable, then one setHooks call to
+    // enroll newRemote with the existing aggregation.
+    expect(nonceAfter - nonceBefore).to.equal(2);
+    expect(
+      eqAddress(
+        await fallbackRoutingHook.hooks(multiProvider.getDomainId(remote)),
+        aggregationAddress,
+      ),
+    ).to.be.true;
+    expect(
+      eqAddress(
+        await fallbackRoutingHook.hooks(multiProvider.getDomainId(newRemote)),
+        aggregationAddress,
+      ),
+    ).to.be.true;
+    const childrenAfter = await aggregation.hooks(
+      hre.ethers.constants.AddressZero,
+    );
+    expect(childrenAfter).to.deep.equal(childrenBefore);
+
+    const pausable = PausableHook__factory.connect(pausableAddress, signer);
+    expect(await pausable.paused()).to.be.false;
+    expect(eqAddress(await pausable.owner(), await overrideOwner.getAddress()))
+      .to.be.true;
+  });
+
+  it('rejects recovery when the signer does not own a mutable hook', async () => {
+    const {
+      signer,
+      newOwner,
+      overrideOwner,
+      multiProvider,
+      coreAddresses,
+      hookDeployer,
+      owner,
+      fallbackRoutingHook,
+      aggregationAddress,
+      pausableAddress,
+      merkleTreeAddress,
+    } = await deployFixture();
+    multiProvider.setSharedSigner(overrideOwner);
+
+    const pausable = PausableHook__factory.connect(pausableAddress, signer);
+    const pausableOwnerBefore = await pausable.owner();
+    const pausablePausedBefore = await pausable.paused();
+    const nonceBeforePausable = await overrideOwner.getTransactionCount();
+    const recoveredPausable: WithAddress<PausableHookConfig> = {
+      type: HookType.PAUSABLE,
+      address: pausableAddress,
+      owner: await newOwner.getAddress(),
+      paused: false,
+    };
+    await expect(
+      hookDeployer.deployContracts(chain, recoveredPausable, coreAddresses),
+    ).to.be.rejectedWith('is not owner');
+    expect(await overrideOwner.getTransactionCount()).to.equal(
+      nonceBeforePausable,
+    );
+    expect(await pausable.owner()).to.equal(pausableOwnerBefore);
+    expect(await pausable.paused()).to.equal(pausablePausedBefore);
+
+    const routingOwnerBefore = await fallbackRoutingHook.owner();
+    const remoteHookBefore = await fallbackRoutingHook.hooks(
+      multiProvider.getDomainId(remote),
+    );
+    const nonceBeforeRouting = await overrideOwner.getTransactionCount();
+    const recoveredRouting: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner: await newOwner.getAddress(),
+      fallback: merkleTreeAddress,
+      domains: { [remote]: aggregationAddress },
+    };
+    await expect(
+      hookDeployer.deployContracts(chain, recoveredRouting, coreAddresses),
+    ).to.be.rejectedWith('is not owner');
+    expect(await overrideOwner.getTransactionCount()).to.equal(
+      nonceBeforeRouting,
+    );
+    expect(await fallbackRoutingHook.owner()).to.equal(routingOwnerBefore);
+    expect(
+      await fallbackRoutingHook.hooks(multiProvider.getDomainId(remote)),
+    ).to.equal(remoteHookBefore);
+    expect(eqAddress(routingOwnerBefore, owner)).to.be.true;
+  });
+
+  it('validates recovered hook mailboxes, including nested hooks', async () => {
+    const {
+      signer,
+      newOwner,
+      multiProvider,
+      coreApp,
+      coreAddresses,
+      hookDeployer,
+      owner,
+      fallbackRoutingHook,
+      aggregationAddress,
+      merkleTreeAddress,
+    } = await deployFixture();
+    const wrongCoreAddresses = {
+      ...coreAddresses,
+      mailbox: await newOwner.getAddress(),
+    };
+    const nonceBefore = await signer.getTransactionCount();
+
+    const recoveredMerkleTree: WithAddress<MerkleTreeHookConfig> = {
+      type: HookType.MERKLE_TREE,
+      address: merkleTreeAddress,
+    };
+    await expect(
+      hookDeployer.deployContracts(
+        chain,
+        recoveredMerkleTree,
+        wrongCoreAddresses,
+      ),
+    ).to.be.rejectedWith('has mailbox');
+
+    const recoveredFallback: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: { [remote]: aggregationAddress },
+    };
+    await expect(
+      hookDeployer.deployContracts(
+        chain,
+        recoveredFallback,
+        wrongCoreAddresses,
+      ),
+    ).to.be.rejectedWith('has mailbox');
+    expect(await signer.getTransactionCount()).to.equal(nonceBefore);
+
+    const foreignCore = coreApp.getContracts(remote);
+    const foreignMerkleTreeAddress = await foreignCore.mailbox.defaultHook();
+    const foreignAggregation = await hookDeployer.deployContracts(
+      chain,
+      {
+        type: HookType.AGGREGATION,
+        hooks: [foreignMerkleTreeAddress],
+      },
+      coreAddresses,
+    );
+    const mixedFallback = await hookDeployer.deployContracts(
+      chain,
+      {
+        type: HookType.FALLBACK_ROUTING,
+        owner,
+        fallback: merkleTreeAddress,
+        domains: {
+          [remote]: foreignAggregation.aggregationHook.address,
+        },
+      },
+      coreAddresses,
+    );
+    const recoveredMixedFallback: WithAddress<FallbackRoutingHookConfig> = {
+      type: HookType.FALLBACK_ROUTING,
+      address: mixedFallback.fallbackRoutingHook.address,
+      owner,
+      fallback: merkleTreeAddress,
+      domains: {
+        [remote]: {
+          type: HookType.AGGREGATION,
+          address: foreignAggregation.aggregationHook.address,
+          hooks: [
+            {
+              type: HookType.MERKLE_TREE,
+              address: foreignMerkleTreeAddress,
+            },
+          ],
+        },
+      },
+    };
+    const mixedFallbackHook = FallbackDomainRoutingHook__factory.connect(
+      mixedFallback.fallbackRoutingHook.address,
+      signer,
+    );
+    const mixedFallbackOwnerBefore = await mixedFallbackHook.owner();
+    const mixedFallbackRouteBefore = await mixedFallbackHook.hooks(
+      multiProvider.getDomainId(remote),
+    );
+    const nonceBeforeNestedRecovery = await signer.getTransactionCount();
+    await expect(
+      hookDeployer.deployContracts(
+        chain,
+        recoveredMixedFallback,
+        coreAddresses,
+      ),
+    ).to.be.rejectedWith('has mailbox');
+    expect(await signer.getTransactionCount()).to.equal(
+      nonceBeforeNestedRecovery,
+    );
+    expect(await mixedFallbackHook.owner()).to.equal(mixedFallbackOwnerBefore);
+    expect(
+      await mixedFallbackHook.hooks(multiProvider.getDomainId(remote)),
+    ).to.equal(mixedFallbackRouteBefore);
+  });
+
+  it('reconciles a recovered routing hook without redeployment', async () => {
+    const {
+      signer,
+      newOwner,
+      multiProvider,
+      coreAddresses,
+      hookDeployer,
+      owner,
+      merkleTreeAddress,
+    } = await deployFixture();
+    const initialConfig: DomainRoutingHookConfig = {
+      type: HookType.ROUTING,
+      owner,
+      domains: { [remote]: merkleTreeAddress },
+    };
+    const deployed = await hookDeployer.deployContracts(
+      chain,
+      initialConfig,
+      coreAddresses,
+    );
+    const routingHook = DomainRoutingHook__factory.connect(
+      deployed.domainRoutingHook.address,
+      signer,
+    );
+    const recoveredConfig: WithAddress<DomainRoutingHookConfig> = {
+      ...initialConfig,
+      address: routingHook.address,
+      owner: await newOwner.getAddress(),
+      domains: {
+        [remote]: merkleTreeAddress,
+        [newRemote]: merkleTreeAddress,
+      },
+    };
+
+    const nonceBeforeMailboxMismatch = await signer.getTransactionCount();
+    await expect(
+      hookDeployer.deployContracts(chain, recoveredConfig, {
+        ...coreAddresses,
+        mailbox: await newOwner.getAddress(),
+      }),
+    ).to.be.rejectedWith('has mailbox');
+    expect(await signer.getTransactionCount()).to.equal(
+      nonceBeforeMailboxMismatch,
+    );
+    expect(await routingHook.owner()).to.equal(owner);
+    expect(
+      await routingHook.hooks(multiProvider.getDomainId(newRemote)),
+    ).to.equal(hre.ethers.constants.AddressZero);
+
+    const nonceBefore = await signer.getTransactionCount();
+    const recovered = await hookDeployer.deployContracts(
+      chain,
+      recoveredConfig,
+      coreAddresses,
+    );
+    expect((await signer.getTransactionCount()) - nonceBefore).to.equal(2);
+    expect(recovered.domainRoutingHook.address).to.equal(routingHook.address);
+    expect(await routingHook.hooks(multiProvider.getDomainId(remote))).to.equal(
+      merkleTreeAddress,
+    );
+    expect(
+      await routingHook.hooks(multiProvider.getDomainId(newRemote)),
+    ).to.equal(merkleTreeAddress);
+    expect(await routingHook.owner()).to.equal(await newOwner.getAddress());
+  });
+});

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
@@ -1,12 +1,20 @@
+import { ethers } from 'ethers';
+
 import {
   AmountRoutingHook,
   CCIPHook,
   CCIPHook__factory,
   DomainRoutingHook,
+  DomainRoutingHook__factory,
   FallbackDomainRoutingHook,
+  FallbackDomainRoutingHook__factory,
   IL1CrossDomainMessenger__factory,
+  IPostDispatchHook__factory,
+  MailboxClient__factory,
+  MerkleTreeHook__factory,
   OPStackHook,
   OPStackIsm,
+  PausableHook__factory,
   ProtocolFee,
   StaticAggregationHook__factory,
 } from '@hyperlane-xyz/core';
@@ -17,13 +25,15 @@ import {
   addressToBytes32,
   assert,
   deepEquals,
+  eqAddress,
+  isZeroishAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { HyperlaneContracts } from '../contracts/types.js';
 import { CoreAddresses } from '../core/contracts.js';
 import { HyperlaneDeployer } from '../deploy/HyperlaneDeployer.js';
-import { submitBatched } from '../deploy/utils.js';
+import { getTxConfigBatchSize, submitBatched } from '../deploy/utils.js';
 import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
 import { HyperlaneIgpDeployer } from '../gas/HyperlaneIgpDeployer.js';
 import { IgpFactories } from '../gas/contracts.js';
@@ -42,9 +52,51 @@ import {
   HookConfig,
   HookType,
   IgpHookConfig,
+  OnchainHookType,
   OpStackHookConfig,
+  PausableHookConfig,
   ProtocolFeeHookConfig,
 } from './types.js';
+
+// Hook types that can be recovered without redeployment when the config carries
+// an existing address. Mutable recovered hooks are reconciled in place, and
+// recovered composites traverse only explicitly addressed children.
+const RECOVERABLE_HOOK_TYPES: HookType[] = [
+  HookType.MERKLE_TREE,
+  HookType.AGGREGATION,
+  HookType.PAUSABLE,
+  HookType.ROUTING,
+  HookType.FALLBACK_ROUTING,
+];
+
+const RECOVERABLE_ONCHAIN_HOOK_TYPES: Partial<
+  Record<HookType, OnchainHookType>
+> = {
+  [HookType.MERKLE_TREE]: OnchainHookType.MERKLE_TREE,
+  [HookType.AGGREGATION]: OnchainHookType.AGGREGATION,
+  [HookType.PAUSABLE]: OnchainHookType.PAUSABLE,
+  [HookType.ROUTING]: OnchainHookType.ROUTING,
+  [HookType.FALLBACK_ROUTING]: OnchainHookType.FALLBACK_ROUTING,
+};
+
+function configuredHookAddress(config: HookConfig): Address | undefined {
+  if (typeof config === 'string') return config;
+  return 'address' in config && typeof config.address === 'string'
+    ? config.address
+    : undefined;
+}
+
+interface RecoveredRoutingHookState {
+  routingHook: DomainRoutingHook | FallbackDomainRoutingHook;
+  routingConfigs: DomainRoutingHook.HookConfigStruct[];
+  childConfigs: Map<Address, Exclude<HookConfig, string>>;
+}
+
+interface RecoveredHookContext {
+  expectedMailbox?: Address;
+  configs: Map<string, Exclude<HookConfig, string>>;
+  routingHooks: Map<string, RecoveredRoutingHookState>;
+}
 
 export class HyperlaneHookDeployer extends HyperlaneDeployer<
   HookConfig,
@@ -81,6 +133,67 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
   ): Promise<HyperlaneContracts<HookFactories>> {
     if (typeof config === 'string') {
       throw new Error('Hook deployer should not receive address config');
+    }
+
+    // Configs carrying an `address` reference an already-deployed hook:
+    // recover the existing contract instead of deploying a new one.
+    const existingHookAddress = configuredHookAddress(config);
+    if (existingHookAddress && RECOVERABLE_HOOK_TYPES.includes(config.type)) {
+      const context: RecoveredHookContext = {
+        expectedMailbox: coreAddresses.mailbox,
+        configs: new Map(),
+        routingHooks: new Map(),
+      };
+      await this.validateRecoveredHook(
+        chain,
+        config,
+        existingHookAddress,
+        context,
+      );
+      await this.reconcileRecoveredHook(
+        chain,
+        config,
+        existingHookAddress,
+        new Set<string>(),
+        context,
+      );
+      const signerOrProvider = this.multiProvider.getSignerOrProvider(chain);
+      const hook = (() => {
+        switch (config.type) {
+          case HookType.MERKLE_TREE:
+            return MerkleTreeHook__factory.connect(
+              existingHookAddress,
+              signerOrProvider,
+            );
+          case HookType.AGGREGATION:
+            return StaticAggregationHook__factory.connect(
+              existingHookAddress,
+              signerOrProvider,
+            );
+          case HookType.PAUSABLE:
+            return PausableHook__factory.connect(
+              existingHookAddress,
+              signerOrProvider,
+            );
+          case HookType.ROUTING:
+            return DomainRoutingHook__factory.connect(
+              existingHookAddress,
+              signerOrProvider,
+            );
+          case HookType.FALLBACK_ROUTING:
+            return FallbackDomainRoutingHook__factory.connect(
+              existingHookAddress,
+              signerOrProvider,
+            );
+          default:
+            throw new Error(`Hook type ${config.type} cannot be recovered`);
+        }
+      })();
+      // CAST: deployers return the subset of HookFactories materialized by the
+      // requested config; HyperlaneContracts currently models a complete map.
+      const deployedContracts = { [config.type]: hook } as any; // partial
+      this.addDeployedContracts(chain, deployedContracts);
+      return deployedContracts;
     }
 
     let hook: DeployedHook;
@@ -128,6 +241,420 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
     const deployedContracts = { [config.type]: hook } as any; // partial
     this.addDeployedContracts(chain, deployedContracts);
     return deployedContracts;
+  }
+
+  private recoveredOwner(
+    config:
+      | PausableHookConfig
+      | DomainRoutingHookConfig
+      | FallbackRoutingHookConfig,
+  ) {
+    const owner = config.ownerOverrides?.[config.type] ?? config.owner;
+    assert(
+      !isZeroishAddress(owner),
+      `Recovered ${config.type} owner cannot be the zero address`,
+    );
+    return owner;
+  }
+
+  private addRecoveredConfig(
+    configs: Map<string, Exclude<HookConfig, string>>,
+    address: Address,
+    config: Exclude<HookConfig, string>,
+  ): boolean {
+    const key = address.toLowerCase();
+    const existing = configs.get(key);
+    assert(
+      !existing || deepEquals(existing, config),
+      `Recovered hook ${address} has conflicting configs`,
+    );
+    if (existing) return false;
+    configs.set(key, config);
+    return true;
+  }
+
+  private async validateRecoveredHook(
+    chain: ChainName,
+    config: Exclude<HookConfig, string>,
+    address: Address,
+    context: RecoveredHookContext,
+  ): Promise<void> {
+    if (!this.addRecoveredConfig(context.configs, address, config)) return;
+
+    const expectedType = RECOVERABLE_ONCHAIN_HOOK_TYPES[config.type];
+    assert(
+      expectedType !== undefined,
+      `Hook type ${config.type} cannot be recovered by address`,
+    );
+    const actualType = await IPostDispatchHook__factory.connect(
+      address,
+      this.multiProvider.getProvider(chain),
+    ).hookType();
+    assert(
+      actualType === expectedType,
+      `Recovered hook ${address} on ${chain} has type ${actualType}, expected ${expectedType}`,
+    );
+
+    if (
+      config.type === HookType.MERKLE_TREE ||
+      config.type === HookType.ROUTING ||
+      config.type === HookType.FALLBACK_ROUTING
+    ) {
+      assert(
+        context.expectedMailbox,
+        `Mailbox address is required to recover ${config.type}`,
+      );
+      const actualMailbox = await MailboxClient__factory.connect(
+        address,
+        this.multiProvider.getProvider(chain),
+      ).mailbox();
+      assert(
+        eqAddress(actualMailbox, context.expectedMailbox),
+        `Recovered hook ${address} on ${chain} has mailbox ${actualMailbox}, expected ${context.expectedMailbox}`,
+      );
+    }
+
+    switch (config.type) {
+      case HookType.PAUSABLE:
+        await this.validateRecoveredPausableHook(chain, config, address);
+        break;
+      case HookType.AGGREGATION:
+        await this.validateRecoveredAggregationHook(
+          chain,
+          config,
+          address,
+          context,
+        );
+        break;
+      case HookType.ROUTING:
+      case HookType.FALLBACK_ROUTING:
+        await this.validateRecoveredRoutingHook(
+          chain,
+          config,
+          address,
+          context,
+        );
+        break;
+      case HookType.MERKLE_TREE:
+        break;
+      default:
+        assert(
+          false,
+          `Hook type ${config.type} cannot be recovered by address`,
+        );
+    }
+  }
+
+  private async validateRecoveredPausableHook(
+    chain: ChainName,
+    config: PausableHookConfig,
+    address: Address,
+  ): Promise<void> {
+    const hook = PausableHook__factory.connect(
+      address,
+      this.multiProvider.getProvider(chain),
+    );
+    const [currentOwner, currentPaused, signer] = await Promise.all([
+      hook.owner(),
+      hook.paused(),
+      this.multiProvider.getSignerAddress(chain),
+    ]);
+    assert(
+      currentPaused === config.paused,
+      `Recovered pausable hook ${address} on ${chain} is ${currentPaused ? '' : 'not '}paused, but config expects ${config.paused ? '' : 'not '}paused`,
+    );
+    const owner = this.recoveredOwner(config);
+    if (!eqAddress(currentOwner, owner)) {
+      assert(
+        eqAddress(currentOwner, signer),
+        `Cannot reconcile recovered pausable hook ${address} on ${chain}: signer ${signer} is not owner ${currentOwner}`,
+      );
+    }
+  }
+
+  private async validateRecoveredAggregationHook(
+    chain: ChainName,
+    config: AggregationHookConfig,
+    address: Address,
+    context: RecoveredHookContext,
+  ): Promise<void> {
+    await this.assertRecoveredAggregationChildren(chain, config, address);
+    for (const hookConfig of config.hooks) {
+      if (typeof hookConfig === 'string') continue;
+      const hookAddress = configuredHookAddress(hookConfig);
+      assert(hookAddress, 'Recovered aggregation child address is required');
+      await this.validateRecoveredHook(chain, hookConfig, hookAddress, context);
+    }
+  }
+
+  private async validateRecoveredRoutingHook(
+    chain: ChainName,
+    config: DomainRoutingHookConfig | FallbackRoutingHookConfig,
+    address: Address,
+    context: RecoveredHookContext,
+  ): Promise<void> {
+    const recoveredRoutingHook = await this.readRecoveredRoutingHook(
+      chain,
+      config,
+      address,
+    );
+    context.routingHooks.set(address.toLowerCase(), recoveredRoutingHook);
+    const { routingHook, routingConfigs, childConfigs } = recoveredRoutingHook;
+    const [currentOwner, signer] = await Promise.all([
+      routingHook.owner(),
+      this.multiProvider.getSignerAddress(chain),
+    ]);
+    const owner = this.recoveredOwner(config);
+    if (routingConfigs.length > 0 || !eqAddress(currentOwner, owner)) {
+      assert(
+        eqAddress(currentOwner, signer),
+        `Cannot reconcile recovered routing hook ${address} on ${chain}: signer ${signer} is not owner ${currentOwner}`,
+      );
+    }
+
+    const batchSize = getTxConfigBatchSize(chain);
+    for (let i = 0; i < routingConfigs.length; i += batchSize) {
+      await routingHook.estimateGas.setHooks(
+        routingConfigs.slice(i, i + batchSize),
+      );
+    }
+    for (const [childAddress, childConfig] of childConfigs) {
+      await this.validateRecoveredHook(
+        chain,
+        childConfig,
+        childAddress,
+        context,
+      );
+    }
+  }
+
+  private async reconcileRecoveredHook(
+    chain: ChainName,
+    config: Exclude<HookConfig, string>,
+    address: Address,
+    reconciled: Set<string>,
+    context: RecoveredHookContext,
+  ): Promise<void> {
+    const key = address.toLowerCase();
+    if (reconciled.has(key)) return;
+    reconciled.add(key);
+    switch (config.type) {
+      case HookType.PAUSABLE:
+        await this.reconcileRecoveredPausableHook(chain, config, address);
+        break;
+      case HookType.AGGREGATION:
+        await this.reconcileRecoveredAggregationHook(
+          chain,
+          config,
+          address,
+          reconciled,
+          context,
+        );
+        break;
+      case HookType.ROUTING:
+      case HookType.FALLBACK_ROUTING:
+        await this.reconcileRecoveredRoutingHook(
+          chain,
+          config,
+          address,
+          reconciled,
+          context,
+        );
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async reconcileRecoveredPausableHook(
+    chain: ChainName,
+    config: PausableHookConfig,
+    address: Address,
+  ): Promise<void> {
+    const hook = PausableHook__factory.connect(
+      address,
+      this.multiProvider.getSignerOrProvider(chain),
+    );
+    const currentOwner = await hook.owner();
+    const owner = this.recoveredOwner(config);
+    if (eqAddress(currentOwner, owner)) return;
+    const overrides = this.multiProvider.getTransactionOverrides(chain);
+    await this.multiProvider.handleTx(
+      chain,
+      hook.transferOwnership(owner, overrides),
+    );
+  }
+
+  private async assertRecoveredAggregationChildren(
+    chain: ChainName,
+    config: AggregationHookConfig,
+    address: Address,
+  ): Promise<void> {
+    const expectedAddresses = config.hooks.map((hookConfig) => {
+      const hookAddress = configuredHookAddress(hookConfig);
+      assert(
+        hookAddress,
+        `Recovered aggregation hook ${address} on ${chain} requires addresses for every child`,
+      );
+      return hookAddress;
+    });
+
+    const aggregation = StaticAggregationHook__factory.connect(
+      address,
+      this.multiProvider.getProvider(chain),
+    );
+    const actualAddresses = await aggregation.hooks(
+      ethers.constants.AddressZero,
+    );
+    const expectedSorted = [...expectedAddresses].sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase()),
+    );
+    const actualSorted = [...actualAddresses].sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase()),
+    );
+    assert(
+      actualSorted.length === expectedSorted.length &&
+        actualSorted.every((hookAddress, index) =>
+          eqAddress(hookAddress, expectedSorted[index]),
+        ),
+      `Recovered aggregation hook ${address} on ${chain} does not contain the configured children`,
+    );
+  }
+
+  private async reconcileRecoveredAggregationHook(
+    chain: ChainName,
+    config: AggregationHookConfig,
+    address: Address,
+    reconciled: Set<string>,
+    context: RecoveredHookContext,
+  ): Promise<void> {
+    for (const hookConfig of config.hooks) {
+      if (typeof hookConfig === 'string') continue;
+      const hookAddress = configuredHookAddress(hookConfig);
+      assert(hookAddress, 'Recovered aggregation child address is required');
+      await this.reconcileRecoveredHook(
+        chain,
+        hookConfig,
+        hookAddress,
+        reconciled,
+        context,
+      );
+    }
+  }
+
+  private async readRecoveredRoutingHook(
+    chain: ChainName,
+    config: DomainRoutingHookConfig | FallbackRoutingHookConfig,
+    address: Address,
+  ): Promise<RecoveredRoutingHookState> {
+    let routingHook: DomainRoutingHook | FallbackDomainRoutingHook;
+    const childConfigs = new Map<string, Exclude<HookConfig, string>>();
+
+    if (config.type === HookType.FALLBACK_ROUTING) {
+      const fallbackRoutingHook = FallbackDomainRoutingHook__factory.connect(
+        address,
+        this.multiProvider.getSignerOrProvider(chain),
+      );
+      routingHook = fallbackRoutingHook;
+      const fallbackAddress = configuredHookAddress(config.fallback);
+      assert(
+        fallbackAddress,
+        `Recovered fallback routing hook ${address} on ${chain} requires a fallback address`,
+      );
+      const actualFallback = await fallbackRoutingHook.fallbackHook();
+      assert(
+        eqAddress(actualFallback, fallbackAddress),
+        `Recovered fallback routing hook ${address} on ${chain} has fallback ${actualFallback}, expected ${fallbackAddress}`,
+      );
+      if (typeof config.fallback !== 'string') {
+        this.addRecoveredConfig(childConfigs, fallbackAddress, config.fallback);
+      }
+    } else {
+      routingHook = DomainRoutingHook__factory.connect(
+        address,
+        this.multiProvider.getSignerOrProvider(chain),
+      );
+    }
+
+    const domainConfigs = Object.entries(config.domains).map(
+      ([destination, hookConfig]) => {
+        const hookAddress = configuredHookAddress(hookConfig);
+        assert(
+          hookAddress,
+          `Recovered routing hook ${address} on ${chain} requires an address for ${destination}`,
+        );
+        if (typeof hookConfig !== 'string') {
+          this.addRecoveredConfig(childConfigs, hookAddress, hookConfig);
+        }
+
+        return {
+          destination: this.multiProvider.getDomainId(destination),
+          hook: hookAddress,
+        };
+      },
+    );
+    const actualHooks = await Promise.all(
+      domainConfigs.map(({ destination }) => routingHook.hooks(destination)),
+    );
+    const routingConfigs = domainConfigs.filter(
+      ({ hook }, index) => !eqAddress(actualHooks[index], hook),
+    );
+
+    return { routingHook, routingConfigs, childConfigs };
+  }
+
+  private async reconcileRecoveredRoutingHook(
+    chain: ChainName,
+    config: DomainRoutingHookConfig | FallbackRoutingHookConfig,
+    address: Address,
+    reconciled: Set<string>,
+    context: RecoveredHookContext,
+  ): Promise<void> {
+    const recoveredRoutingHook = context.routingHooks.get(
+      address.toLowerCase(),
+    );
+    assert(
+      recoveredRoutingHook,
+      `Recovered routing hook ${address} on ${chain} was not validated`,
+    );
+    const { routingHook, routingConfigs, childConfigs } = recoveredRoutingHook;
+    for (const [childAddress, childConfig] of childConfigs) {
+      await this.reconcileRecoveredHook(
+        chain,
+        childConfig,
+        childAddress,
+        reconciled,
+        context,
+      );
+    }
+
+    const overrides = this.multiProvider.getTransactionOverrides(chain);
+    if (routingConfigs.length > 0) {
+      await submitBatched(
+        chain,
+        routingConfigs,
+        async (batch) => {
+          const estimatedGas = await routingHook.estimateGas.setHooks(batch);
+          await this.multiProvider.handleTx(
+            chain,
+            routingHook.setHooks(batch, {
+              gasLimit: addBufferToGasLimit(estimatedGas),
+              ...overrides,
+            }),
+          );
+        },
+        this.logger,
+        'recovered routing hook configs',
+      );
+    }
+    const owner = this.recoveredOwner(config);
+    const currentOwner = await routingHook.owner();
+    if (!eqAddress(currentOwner, owner)) {
+      await this.multiProvider.handleTx(
+        chain,
+        routingHook.transferOwnership(owner, overrides),
+      );
+    }
   }
 
   async deployCCIPHook(

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -145,9 +145,15 @@ export type CCIPHookConfig = z.infer<typeof CCIPHookSchema>;
 export type AggregationHookConfig = {
   type: typeof HookType.AGGREGATION;
   hooks: Array<HookConfig>;
+  // Optional address of an already-deployed hook to recover instead of
+  // redeploying (mirrors the ISM derived-config schemas in ../ism/types.ts).
+  address?: Address;
 };
 export type RoutingHookConfig = OwnableConfig & {
   domains: ChainMap<HookConfig>;
+  // Optional address of an already-deployed hook to recover instead of
+  // redeploying (mirrors the ISM derived-config schemas in ../ism/types.ts).
+  address?: Address;
 };
 export type DomainRoutingHookConfig = RoutingHookConfig & {
   type: typeof HookType.ROUTING;
@@ -226,6 +232,9 @@ export const ProtocolFeeSchema = OwnableSchema.extend({
 
 export const MerkleTreeSchema = z.object({
   type: z.literal(HookType.MERKLE_TREE),
+  // Optional address of an already-deployed hook to recover instead of
+  // redeploying (mirrors the ISM derived-config schemas in ../ism/types.ts).
+  address: ZHash.optional(),
 });
 
 export const PredicateHookSchema = z.object({
@@ -236,6 +245,9 @@ export type PredicateHookConfig = z.infer<typeof PredicateHookSchema>;
 
 export const PausableHookSchema = PausableSchema.extend({
   type: z.literal(HookType.PAUSABLE),
+  // Optional address of an already-deployed hook to recover instead of
+  // redeploying (mirrors the ISM derived-config schemas in ../ism/types.ts).
+  address: ZHash.optional(),
 });
 
 export const MailboxDefaultHookSchema = z.object({
@@ -302,6 +314,7 @@ export const DomainRoutingHookConfigSchema: z.ZodType<
   OwnableSchema.extend({
     type: z.literal(HookType.ROUTING),
     domains: z.record(HookConfigSchema),
+    address: ZHash.optional(),
   }),
 );
 
@@ -314,6 +327,7 @@ export const FallbackRoutingHookConfigSchema: z.ZodType<
     type: z.literal(HookType.FALLBACK_ROUTING),
     domains: z.record(HookConfigSchema),
     fallback: HookConfigSchema,
+    address: ZHash.optional(),
   }),
 );
 
@@ -338,6 +352,7 @@ export const AggregationHookConfigSchema: z.ZodType<
   z.object({
     type: z.literal(HookType.AGGREGATION),
     hooks: z.array(HookConfigSchema),
+    address: ZHash.optional(),
   }),
 );
 

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.hardhat-test.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.hardhat-test.ts
@@ -706,16 +706,40 @@ describe('HyperlaneIsmFactory', async () => {
     ).to.be.true;
   });
 
-  it('recovers an address-bearing pausable ism config', async () => {
+  it('reconciles an address-bearing pausable ism config', async () => {
+    const [, newOwner, overrideOwner] = await hre.ethers.getSigners();
     const config: PausableIsmConfig = {
       type: IsmType.PAUSABLE,
       owner: await multiProvider.getSignerAddress(chain),
       paused: false,
     };
     const deployed = await ismFactory.deploy({ destination: chain, config });
+    const pauseMismatch: WithAddress<PausableIsmConfig> = {
+      ...config,
+      address: deployed.address,
+      owner: await newOwner.getAddress(),
+      paused: true,
+    };
+
+    await expect(
+      ismFactory.deploy({
+        destination: chain,
+        config: pauseMismatch,
+      }),
+    ).to.be.rejectedWith('but config expects paused');
+    const pausable = PausableIsm__factory.connect(
+      deployed.address,
+      multiProvider.getProvider(chain),
+    );
+    expect(await pausable.owner()).to.equal(config.owner);
+
     const recoveredConfig: WithAddress<PausableIsmConfig> = {
       ...config,
       address: deployed.address,
+      owner: await newOwner.getAddress(),
+      ownerOverrides: {
+        [IsmType.PAUSABLE]: await overrideOwner.getAddress(),
+      },
     };
 
     const recovered = await ismFactory.deploy({
@@ -724,6 +748,8 @@ describe('HyperlaneIsmFactory', async () => {
     });
 
     expect(recovered.address).to.equal(deployed.address);
+    expect(await pausable.paused()).to.be.false;
+    expect(await pausable.owner()).to.equal(await overrideOwner.getAddress());
   });
 
   it('deploys a trusted relayer ism', async () => {

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -26,6 +26,7 @@ import {
   IStaticWeightedMultisigIsm,
   NetFlowRateLimitedHookIsm__factory,
   OPStackIsm__factory,
+  PausableIsm,
   PausableIsm__factory,
   RateLimitedIsm__factory,
   StaticAddressSetFactory,
@@ -44,6 +45,7 @@ import {
   addBufferToGasLimit,
   assert,
   eqAddress,
+  isZeroishAddress,
   objFilter,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -81,6 +83,7 @@ import {
   IsmConfig,
   IsmConfigSchema,
   IsmType,
+  ModuleType,
   MultisigIsmConfig,
   PausableIsmConfig,
   RoutingIsmConfig,
@@ -395,12 +398,20 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
         const derivedConfig = DerivedPausableIsmConfigSchema.safeParse(config);
         // Address-bearing configs represent recovered artifacts. Normal
         // pausable configs omit address and deploy a chain/route-local ISM.
-        contract = derivedConfig.success
+        const pausableIsm = derivedConfig.success
           ? PausableIsm__factory.connect(
               derivedConfig.data.address,
               this.multiProvider.getSignerOrProvider(destination),
             )
           : await this.deployPausableIsm(destination, config);
+        if (derivedConfig.success) {
+          await this.reconcileRecoveredPausableIsm(
+            destination,
+            pausableIsm,
+            config,
+          );
+        }
+        contract = pausableIsm;
         break;
       }
       case IsmType.TRUSTED_RELAYER:
@@ -581,6 +592,46 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
     }
 
     return contract;
+  }
+
+  private async reconcileRecoveredPausableIsm(
+    destination: ChainName,
+    contract: PausableIsm,
+    config: PausableIsmConfig,
+  ): Promise<void> {
+    const [moduleType, currentOwner, currentPaused, signer] = await Promise.all(
+      [
+        contract.moduleType(),
+        contract.owner(),
+        contract.paused(),
+        this.multiProvider.getSignerAddress(destination),
+      ],
+    );
+    assert(
+      moduleType === ModuleType.NULL,
+      `Recovered pausable ISM ${contract.address} on ${destination} has module type ${moduleType}, expected ${ModuleType.NULL}`,
+    );
+    assert(
+      currentPaused === config.paused,
+      `Recovered pausable ISM ${contract.address} on ${destination} is ${currentPaused ? '' : 'not '}paused, but config expects ${config.paused ? '' : 'not '}paused`,
+    );
+    const owner = config.ownerOverrides?.[config.type] ?? config.owner;
+    assert(
+      !isZeroishAddress(owner),
+      `Recovered pausable ISM owner cannot be the zero address`,
+    );
+    if (eqAddress(currentOwner, owner)) return;
+
+    assert(
+      eqAddress(currentOwner, signer),
+      `Cannot reconcile recovered pausable ISM ${contract.address} on ${destination}: signer ${signer} is not owner ${currentOwner}`,
+    );
+
+    const overrides = this.multiProvider.getTransactionOverrides(destination);
+    await this.multiProvider.handleTx(
+      destination,
+      contract.transferOwnership(owner, overrides),
+    );
   }
 
   protected async deployCCIPIsm(


### PR DESCRIPTION
## Summary

Adds an explicit recovery path for existing hook trees and PausableISMs that must be mutated without redeploying current EVM bytecode.

- Hook configs may carry existing addresses for Merkle, aggregation, pausable, routing, and fallback-routing hooks.
- `HyperlaneHookDeployer` validates and recovers those explicit trees; ordinary configs keep existing deployment behavior.
- Recovered PausableHook and PausableISM contracts preserve live pause state and transfer ownership in place.
- No generic `EvmHookModule` update behavior changes are included.
- Includes an SDK changeset.

This is the SDK base for stacked draft #9317.

## Safety boundary

Recovery is opt-in via `address` fields and completes a recursive preflight before any transaction:

- validates each declared on-chain hook type and recovered PausableISM module type;
- validates aggregation membership, fallback identity, domain mappings, routing authority, and every `setHooks` gas estimate;
- rejects conflicting configs for the same recovered address;
- rejects a live/config pause-state mismatch rather than pausing or unpausing;
- respects per-contract `ownerOverrides` and rejects zero ownership targets.

Only ownership and explicitly configured routing enrollments are changed. Address-bearing IGP recovery is intentionally unsupported because its mutable owner, beneficiary, oracle, and overhead state is outside this change.

## Validation

- SDK TypeScript build and lint pass.
- Standalone `HyperlaneHookDeployer.hardhat-test.ts`: 1 passing.
- Combined `HyperlaneHookDeployer` and `HyperlaneIsmFactory` Hardhat files: 67 passing.
- Adversarial coverage proves wrong types, aggregation mismatches, later-child validation failures, conflicting aliases, and pause mismatches fail before mutation; owner overrides and valid ownership transfer succeed without replacing the tree.
- Live topology reads for #9317's nine current legacy recovery chains confirm the expected fallback-routing -> aggregation -> Pausable/IGP/Merkle tree and unpaused state.
- Full CI is green at exact head `bce8705ccd`.

Operational caveat for the stacked rollout: use the direct infra deployer path. The existing infra `check-deploy --govern` path invokes ISM factory deployment while mapping violations, before its submission prompt; changing that checker/governor behavior is a separate follow-up.
