### PR TITLE
fix(infra): lower USDC/subtensor rebalancer target sum to 90k

### DIFF
--- a/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
+++ b/typescript/infra/config/environments/mainnet3/rebalancer/USDC/subtensor-config.yaml
@@ -5,7 +5,7 @@ strategy:
     base:
       minAmount:
         min: 5000
-        target: 15000
+        target: 11250
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
@@ -23,7 +23,7 @@ strategy:
     polygon:
       minAmount:
         min: 5000
-        target: 15000
+        target: 11250
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
@@ -32,7 +32,7 @@ strategy:
     arbitrum:
       minAmount:
         min: 5000
-        target: 15000
+        target: 11250
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000
@@ -41,7 +41,7 @@ strategy:
     unichain:
       minAmount:
         min: 5000
-        target: 15000
+        target: 11250
         type: 'absolute'
       bridgeLockTime: 1800 # 30 mins in seconds
       bridgeMinAcceptedAmount: 3000


### PR DESCRIPTION
## Summary

Lowers the USDC/subtensor rebalancer `minAmount` **target sum from 105,000 → 90,000 USDC** to restore headroom below live route collateral, per @mo's request.

Per-chain absolute targets:

| chain | min | target (before → after) |
| --- | --- | --- |
| base | 5,000 | 15,000 → **11,250** |
| ethereum | 45,000 | 45,000 (unchanged — min-locked) |
| polygon | 5,000 | 15,000 → **11,250** |
| arbitrum | 5,000 | 15,000 → **11,250** |
| unichain | 5,000 | 15,000 → **11,250** |
| **sum** | 65,000 | **105,000 → 90,000** |

Ethereum stays at 45,000 (equal to its `min`, so it can't go lower). The remaining 45k is split evenly across the other four chains (11,250 each), all comfortably above their 5,000 mins.

## Why

`hyperlane-rebalancer-usdc-subtensor-0` crash-loops on startup whenever `MinAmountStrategy.validateAmounts` finds the target sum exceeds total live collateral. Today (PD Q24U2BVJFRUYAX) collateral dipped to ~100,837 USDC < the 105k target sum and the pod crash-looped (~09:49–09:57Z) until collateral drifted back above 105k. This is the 3rd occurrence of the mechanism (PR #8972 previously lowered ethereum 55k→45k for the same reason). Dropping the sum to 90k gives ~10k+ headroom below current collateral.

Root-cause group: `01KWKTMM68BXDFKJCY7YFMQWXH`.

## Test plan

- [ ] Confirm rebalancer config validates and pod starts cleanly after merge/deploy
- [ ] Verify auto-rebalancing resumes (`No rebalancing needed` / normal polling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)