### PR TITLE
chore(infra): bump mainnet3 scraper image to f0f8a56 (getBlock rewards fix)

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -49,7 +49,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   validator: '5e51f62-20260819-162717',
   validatorRC: '14646bd-20260805-072134',
   validatorFastPath: '14646bd-20260805-072134',
-  scraper: 'f67b777-20260821-100101',
+  scraper: 'f0f8a56-20260824-030242',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',


### PR DESCRIPTION
## Summary
- Bumps the mainnet3 `scraper` docker tag from the pre-fix `f67b777-20260821-100101` to `f0f8a56-20260824-030242`, which contains #9307 (`RpcBlockConfig.rewards=Some(false)` in sealevel `getBlock`).
- Persists a hotfix already rolled out via `kubectl set image` on `statefulset/omniscient-scraper-hyperlane-agent-scraper3` so the next helm/GitOps sync doesn't revert the scraper to the stalling image.

## Context
PD Q2YT28F9CF3PD3 / ENG-4405: Solana `getBlock` started returning a `DeactivatedStake` reward variant the scraper's solana crates can't deserialize -> SerdeJson error -> the `delivery` forward_sequenced cursor hard-stalled on solanamainnet (restart does not help). #9307 fixes it by disabling rewards in the getBlock request.

The old pinned tag `f67b777` was built 22 min *before* #9307 merged, so the deployed scraper predated the fix.

## Test plan
- [x] Built `f0f8a56-20260824-030242` from main (sha `f0f8a56c`, confirmed contains #9307) via rust-docker run 32685047303
- [x] Rolled out to mainnet3 scraper; verified zero getBlock/DeactivatedStake errors and the sync-lag metric recovered to live tip
- [ ] Merge so config matches the live deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)