### PR TITLE
chore(infra): bump mainnet3 validator image to f0f8a56 (#9293 fix)

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -46,7 +46,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   relayer: 'a060727-20260821-093506',
   relayerRC: 'a060727-20260821-093506',
   relayerFastPath: '14646bd-20260805-072134',
-  validator: '5e51f62-20260819-162717',
+  validator: 'f0f8a56-20260824-030242',
   validatorRC: '14646bd-20260805-072134',
   validatorFastPath: '14646bd-20260805-072134',
   scraper: 'f67b777-20260821-100101',


### PR DESCRIPTION
## Summary
- Bumps `mainnetDockerTags.validator` from `5e51f62-20260819-162717` → **`f0f8a56-20260824-030242`** (newest `hyperlane-agent` main build; verified to contain #9293).
- Fixes the mainnet3 `aleo-validator` CrashLoopBackOff (PD Q1X6XBPA6UM02G / ENG-4402).

## Why
The running aleo-validator image (`b8f91a4-20260811`) and the prior configured tag (`5e51f62-20260819`) both **predate** #9293 `fix(aleo): encode mapping keys in RPC URLs` (merged 2026-08-20 12:23 UTC). Without it, the validator's startup `announce()` `storage_sequences` lookup emits **raw `[`/`]` brackets** in the Provable RPC URL:

```
GET .../hyp_validator_announce.aleo/mapping/storage_sequences/%7B%20%20bytes:%20[...185u8...]%7D
-> HTTP 400 on both edge.provable.com & api.explorer.provable.com
-> "All fallback providers failed" -> panic (validator.rs announce()) -> exit 101 -> CrashLoopBackOff
```

`f0f8a56` percent-encodes the brackets (`%5B`/`%5D`), which Provable accepts. `git merge-base --is-ancestor 4a9a4effc5 f0f8a56` -> true; `classify_image_freshness` on the running image -> `runtime_predates_fix`.

## Test plan
- [ ] Deploy mainnet3 aleo validator on the new tag; confirm pod leaves CrashLoopBackOff, logs "Validator has announced signature storage location", and resumes correctness checkpoints.
- [ ] Confirm PD Q1X6XBPA6UM02G auto-resolves.
- [ ] (Follow-up) aleo relayer is on the same pre-fix family; roll it forward too to close the ENG-4402 relayer 400-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)