### PR TITLE
perf(validator): bound persistent log growth

### DIFF
--- a/.changeset/quiet-validators-rest.md
+++ b/.changeset/quiet-validators-rest.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Validator signing concurrency configuration was added and constrained to a safe positive range.

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -23,6 +23,8 @@ use itertools::Itertools;
 use serde::Deserialize;
 use serde_json::Value;
 
+const DEFAULT_MAX_SIGN_CONCURRENCY: usize = 50;
+
 /// Settings for RPCs
 #[derive(Debug, Clone)]
 pub struct RpcConfig {
@@ -207,11 +209,13 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
                 config_err
             })?;
 
-        let max_sign_concurrency = p
+        let configured_max_sign_concurrency = p
             .chain(&mut err)
             .get_opt_key("maxSignConcurrency")
             .parse_u64()
-            .unwrap_or(50) as usize;
+            .end();
+        let max_sign_concurrency =
+            parse_max_sign_concurrency(configured_max_sign_concurrency, cwp, &mut err);
 
         let mut rpcs = get_rpc_urls(&chain, "rpcUrls", "customRpcUrls", &mut err);
         // this is only relevant for cosmos
@@ -265,6 +269,24 @@ impl FromRawConf<RawValidatorSettings> for ValidatorSettings {
             skip_announce,
             max_sign_concurrency,
         })
+    }
+}
+
+fn parse_max_sign_concurrency(
+    configured: Option<u64>,
+    cwp: &ConfigPath,
+    err: &mut ConfigParsingError,
+) -> usize {
+    let configured = configured.unwrap_or(DEFAULT_MAX_SIGN_CONCURRENCY as u64);
+    match usize::try_from(configured) {
+        Ok(value @ 1..) => value,
+        _ => {
+            err.push(
+                cwp.add("max_sign_concurrency"),
+                eyre::eyre!("`maxSignConcurrency` must be greater than zero"),
+            );
+            DEFAULT_MAX_SIGN_CONCURRENCY
+        }
     }
 }
 
@@ -419,6 +441,28 @@ fn parse_checkpoint_syncer(syncer: ValueParser) -> ConfigResult<CheckpointSyncer
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn max_sign_concurrency_is_positive() {
+        let cwp = ConfigPath::default();
+
+        for (configured, expected) in [(None, DEFAULT_MAX_SIGN_CONCURRENCY), (Some(1), 1)] {
+            let mut err = ConfigParsingError::default();
+            assert_eq!(
+                parse_max_sign_concurrency(configured, &cwp, &mut err),
+                expected
+            );
+            assert!(err.is_ok());
+        }
+
+        let mut err = ConfigParsingError::default();
+        assert_eq!(
+            parse_max_sign_concurrency(Some(0), &cwp, &mut err),
+            DEFAULT_MAX_SIGN_CONCURRENCY
+        );
+        assert!(!err.is_ok());
+        assert!(err.to_string().contains("maxSignConcurrency"));
+    }
 
     #[test]
     fn test_get_rpc_urls_explicit() {

--- a/rust/main/agents/validator/src/settings.rs
+++ b/rust/main/agents/validator/src/settings.rs
@@ -24,6 +24,9 @@ use serde::Deserialize;
 use serde_json::Value;
 
 const DEFAULT_MAX_SIGN_CONCURRENCY: usize = 50;
+// Bounds per-batch allocation and in-flight signing work while leaving ample
+// headroom above the operational default. Keep in sync with the SDK schema.
+const MAX_SIGN_CONCURRENCY: usize = 1_000;
 
 /// Settings for RPCs
 #[derive(Debug, Clone)]
@@ -277,13 +280,13 @@ fn parse_max_sign_concurrency(
     cwp: &ConfigPath,
     err: &mut ConfigParsingError,
 ) -> usize {
-    let configured = configured.unwrap_or(DEFAULT_MAX_SIGN_CONCURRENCY as u64);
+    let configured = configured.unwrap_or(50);
     match usize::try_from(configured) {
-        Ok(value @ 1..) => value,
+        Ok(value @ 1..=MAX_SIGN_CONCURRENCY) => value,
         _ => {
             err.push(
                 cwp.add("max_sign_concurrency"),
-                eyre::eyre!("`maxSignConcurrency` must be greater than zero"),
+                eyre::eyre!("`maxSignConcurrency` must be between 1 and {MAX_SIGN_CONCURRENCY}"),
             );
             DEFAULT_MAX_SIGN_CONCURRENCY
         }
@@ -443,10 +446,16 @@ mod test {
     use super::*;
 
     #[test]
-    fn max_sign_concurrency_is_positive() {
+    fn max_sign_concurrency_is_bounded() {
         let cwp = ConfigPath::default();
+        let max_sign_concurrency =
+            u64::try_from(MAX_SIGN_CONCURRENCY).expect("MAX_SIGN_CONCURRENCY must fit in u64");
 
-        for (configured, expected) in [(None, DEFAULT_MAX_SIGN_CONCURRENCY), (Some(1), 1)] {
+        for (configured, expected) in [
+            (None, DEFAULT_MAX_SIGN_CONCURRENCY),
+            (Some(1), 1),
+            (Some(max_sign_concurrency), MAX_SIGN_CONCURRENCY),
+        ] {
             let mut err = ConfigParsingError::default();
             assert_eq!(
                 parse_max_sign_concurrency(configured, &cwp, &mut err),
@@ -455,13 +464,15 @@ mod test {
             assert!(err.is_ok());
         }
 
-        let mut err = ConfigParsingError::default();
-        assert_eq!(
-            parse_max_sign_concurrency(Some(0), &cwp, &mut err),
-            DEFAULT_MAX_SIGN_CONCURRENCY
-        );
-        assert!(!err.is_ok());
-        assert!(err.to_string().contains("maxSignConcurrency"));
+        for configured in [0, max_sign_concurrency + 1, u64::MAX] {
+            let mut err = ConfigParsingError::default();
+            assert_eq!(
+                parse_max_sign_concurrency(Some(configured), &cwp, &mut err),
+                DEFAULT_MAX_SIGN_CONCURRENCY
+            );
+            assert!(!err.is_ok());
+            assert!(err.to_string().contains("maxSignConcurrency"));
+        }
     }
 
     #[test]

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -79,6 +79,10 @@ impl ValidatorSubmitter {
         reorg_reporter: Arc<dyn ReorgReporter>,
         readiness: Arc<ValidatorReadiness>,
     ) -> Self {
+        assert!(
+            max_sign_concurrency > 0,
+            "maxSignConcurrency must be greater than zero"
+        );
         Self {
             reorg_period,
             interval,
@@ -375,11 +379,6 @@ impl ValidatorSubmitter {
             .last()
             .map(|checkpoint| checkpoint.root)
             .unwrap_or_else(|| tree.root());
-        info!(
-            ?root,
-            queue_length = checkpoint_queue.len(),
-            "Ingested leaves into in-memory merkle tree"
-        );
 
         // At this point we know that correctness_checkpoint.index == tree.index().
         assert_eq!(
@@ -431,17 +430,12 @@ impl ValidatorSubmitter {
             panic!("{panic_message}");
         }
 
-        tracing::info!(
-            elapsed=?start.elapsed(),
-            checkpoint_queue_len = checkpoint_queue.len(),
-            "Checkpoint submitter reached correctness checkpoint"
-        );
-
         if !checkpoint_queue.is_empty() {
             info!(
-                index = checkpoint.index,
-                queue_len = checkpoint_queue.len(),
-                "Reached tree consistency"
+                ?root,
+                queue_length = checkpoint_queue.len(),
+                elapsed = ?start.elapsed(),
+                "Checkpoint submitter reached correctness checkpoint"
             );
             self.sign_and_submit_checkpoints(
                 checkpoint_queue
@@ -704,7 +698,7 @@ impl ValidatorSubmitter {
                                     return Err(error);
                                 }
                             };
-                            tracing::info!(
+                            tracing::trace!(
                                 index = checkpoint_index,
                                 wrote_checkpoint,
                                 elapsed=?start.elapsed(),
@@ -725,12 +719,21 @@ impl ValidatorSubmitter {
 
             let wrote_checkpoint = join_all(futures).await.into_iter().any(|wrote| wrote);
 
-            tracing::info!(
-                elapsed=?start.elapsed(),
-                chunk_len,
-                remaining_checkpoints = checkpoints.len(),
-                "Signed and submitted checkpoint chunk",
-            );
+            if wrote_checkpoint {
+                tracing::info!(
+                    elapsed=?start.elapsed(),
+                    chunk_len,
+                    remaining_checkpoints = checkpoints.len(),
+                    "Signed and submitted checkpoint chunk",
+                );
+            } else {
+                tracing::trace!(
+                    elapsed=?start.elapsed(),
+                    chunk_len,
+                    remaining_checkpoints = checkpoints.len(),
+                    "Checkpoint chunk already existed",
+                );
+            }
 
             // Pace storage/signing bursts between chunks without delaying the latest-index
             // update, throttling all-existing backfills, or adding a final-chunk tail.

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -102,6 +102,26 @@ fn dummy_readiness() -> Arc<ValidatorReadiness> {
     Arc::new(ValidatorReadiness::default())
 }
 
+#[test]
+#[should_panic(expected = "maxSignConcurrency must be greater than zero")]
+fn validator_submitter_rejects_zero_sign_concurrency() {
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(MockCheckpointSyncer::new()),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        0,
+        Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
+    );
+}
+
 fn submission_test_submitter(
     syncer: MockCheckpointSyncer,
     readiness: Arc<ValidatorReadiness>,

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -125,16 +125,40 @@ impl DB {
     /// Opens db at `db_path` and creates if missing
     #[tracing::instrument(err)]
     pub fn from_path(db_path: &Path) -> Result<DB> {
-        Self::from_path_with_options(db_path, false)
+        Self::from_path_with_options(
+            db_path,
+            false,
+            ROCKSDB_INFO_LOG_FILE_COUNT,
+            ROCKSDB_INFO_LOG_FILE_SIZE,
+        )
     }
 
     /// Opens a DB with archived WAL retained for rollback-derived index recovery.
     #[tracing::instrument(err)]
     pub fn from_path_with_rollback_wal(db_path: &Path) -> Result<DB> {
-        Self::from_path_with_options(db_path, true)
+        Self::from_path_with_options(
+            db_path,
+            true,
+            ROCKSDB_INFO_LOG_FILE_COUNT,
+            ROCKSDB_INFO_LOG_FILE_SIZE,
+        )
     }
 
-    fn from_path_with_options(db_path: &Path, retain_rollback_wal: bool) -> Result<DB> {
+    #[cfg(test)]
+    fn from_path_with_info_log_limits(
+        db_path: &Path,
+        info_log_file_count: usize,
+        info_log_file_size: usize,
+    ) -> Result<DB> {
+        Self::from_path_with_options(db_path, false, info_log_file_count, info_log_file_size)
+    }
+
+    fn from_path_with_options(
+        db_path: &Path,
+        retain_rollback_wal: bool,
+        info_log_file_count: usize,
+        info_log_file_size: usize,
+    ) -> Result<DB> {
         let path = {
             let mut path = db_path
                 .parent()
@@ -159,8 +183,8 @@ impl DB {
             opts.set_wal_ttl_seconds(ROLLBACK_WAL_RETENTION_SECONDS);
             opts.set_wal_size_limit_mb(ROLLBACK_WAL_SIZE_LIMIT_MB);
         }
-        opts.set_keep_log_file_num(ROCKSDB_INFO_LOG_FILE_COUNT);
-        opts.set_max_log_file_size(ROCKSDB_INFO_LOG_FILE_SIZE);
+        opts.set_keep_log_file_num(info_log_file_count);
+        opts.set_max_log_file_size(info_log_file_size);
 
         let rocks = Rocks::open(&opts, &path).map_err(|e| DbError::OpeningError {
             source: Box::new(e),
@@ -339,7 +363,7 @@ mod tests {
 
     use rocksdb::{Options, WriteBatch, DB as Rocks};
 
-    use super::DB;
+    use super::{DB, ROCKSDB_INFO_LOG_FILE_COUNT};
 
     #[test]
     fn rejects_incomplete_wal_history() {
@@ -442,30 +466,56 @@ mod tests {
 
     #[test]
     fn bounds_info_logs() {
+        const TEST_INFO_LOG_FILE_SIZE: usize = 4 * 1024;
+
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("db");
 
-        for iteration in 0..ROCKSDB_INFO_LOG_FILE_COUNT + 5 {
-            let db = DB::from_path(&db_path).unwrap();
-            db.store(b"key", &iteration.to_be_bytes()).unwrap();
+        let db = DB::from_path_with_info_log_limits(
+            &db_path,
+            ROCKSDB_INFO_LOG_FILE_COUNT,
+            TEST_INFO_LOG_FILE_SIZE,
+        )
+        .unwrap();
+        for iteration in 0_u64..128 {
+            db.store(&iteration.to_be_bytes(), &iteration.to_be_bytes())
+                .unwrap();
+            db.0.flush().unwrap();
         }
-
-        let db = DB::from_path(&db_path).unwrap();
         assert_eq!(
-            db.retrieve(b"key").unwrap(),
-            Some((ROCKSDB_INFO_LOG_FILE_COUNT + 4).to_be_bytes().to_vec())
+            db.retrieve(&127_u64.to_be_bytes()).unwrap(),
+            Some(127_u64.to_be_bytes().to_vec())
         );
         drop(db);
 
-        let info_log_count = fs::read_dir(db_path)
+        let info_logs = fs::read_dir(db_path)
             .unwrap()
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.file_name().to_string_lossy().starts_with("LOG"))
-            .count();
+            .collect::<Vec<_>>();
 
+        assert_eq!(
+            info_logs.len(),
+            ROCKSDB_INFO_LOG_FILE_COUNT,
+            "expected enough rotations to exercise the {ROCKSDB_INFO_LOG_FILE_COUNT}-file retention limit"
+        );
+
+        let rotated_log_sizes = info_logs
+            .iter()
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("LOG.old."))
+            .map(|entry| entry.metadata().unwrap().len())
+            .collect::<Vec<_>>();
         assert!(
-            info_log_count <= ROCKSDB_INFO_LOG_FILE_COUNT,
-            "expected at most {ROCKSDB_INFO_LOG_FILE_COUNT} RocksDB info logs, found {info_log_count}"
+            !rotated_log_sizes.is_empty(),
+            "expected the {TEST_INFO_LOG_FILE_SIZE}-byte test limit to rotate the info log"
+        );
+        let test_info_log_file_size = u64::try_from(TEST_INFO_LOG_FILE_SIZE)
+            .expect("TEST_INFO_LOG_FILE_SIZE must fit in u64");
+        assert!(
+            rotated_log_sizes
+                .iter()
+                .all(|size| *size >= test_info_log_file_size),
+            "expected rotated logs to reach the configured {TEST_INFO_LOG_FILE_SIZE}-byte limit; sizes: {rotated_log_sizes:?}"
         );
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -115,6 +115,12 @@ impl From<Rocks> for DB {
 
 type Result<T> = std::result::Result<T, DbError>;
 
+// RocksDB keeps 1,000 archived info logs by default and does not roll the current
+// log by size. Agent databases live on persistent volumes, so routine restarts can
+// otherwise retain years of diagnostics alongside a comparatively small database.
+const ROCKSDB_INFO_LOG_FILE_COUNT: usize = 10;
+const ROCKSDB_INFO_LOG_FILE_SIZE: usize = 16 * 1024 * 1024;
+
 impl DB {
     /// Opens db at `db_path` and creates if missing
     #[tracing::instrument(err)]
@@ -153,6 +159,8 @@ impl DB {
             opts.set_wal_ttl_seconds(ROLLBACK_WAL_RETENTION_SECONDS);
             opts.set_wal_size_limit_mb(ROLLBACK_WAL_SIZE_LIMIT_MB);
         }
+        opts.set_keep_log_file_num(ROCKSDB_INFO_LOG_FILE_COUNT);
+        opts.set_max_log_file_size(ROCKSDB_INFO_LOG_FILE_SIZE);
 
         let rocks = Rocks::open(&opts, &path).map_err(|e| DbError::OpeningError {
             source: Box::new(e),
@@ -430,5 +438,34 @@ mod tests {
 
         assert!(!archive_path.join("000001.log").exists());
         assert!(archive_path.join("keep.txt").exists());
+    }
+
+    #[test]
+    fn bounds_info_logs() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("db");
+
+        for iteration in 0..ROCKSDB_INFO_LOG_FILE_COUNT + 5 {
+            let db = DB::from_path(&db_path).unwrap();
+            db.store(b"key", &iteration.to_be_bytes()).unwrap();
+        }
+
+        let db = DB::from_path(&db_path).unwrap();
+        assert_eq!(
+            db.retrieve(b"key").unwrap(),
+            Some((ROCKSDB_INFO_LOG_FILE_COUNT + 4).to_be_bytes().to_vec())
+        );
+        drop(db);
+
+        let info_log_count = fs::read_dir(db_path)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("LOG"))
+            .count();
+
+        assert!(
+            info_log_count <= ROCKSDB_INFO_LOG_FILE_COUNT,
+            "expected at most {ROCKSDB_INFO_LOG_FILE_COUNT} RocksDB info logs, found {info_log_count}"
+        );
     }
 }

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -9,8 +9,23 @@ import {
   AgentChainMetadataSchema,
   RelayerAgentConfigSchema,
   RpcConsensusType,
+  ValidatorAgentConfigSchema,
   buildAgentConfig,
 } from './agentConfig.js';
+
+describe('ValidatorAgentConfigSchema maxSignConcurrency', () => {
+  const schema = ValidatorAgentConfigSchema.shape.maxSignConcurrency;
+
+  it('accepts values from 1 through 1,000', () => {
+    expect(schema.safeParse(1).success).to.be.true;
+    expect(schema.safeParse(1_000).success).to.be.true;
+  });
+
+  it('rejects values outside the configured bounds', () => {
+    expect(schema.safeParse(0).success).to.be.false;
+    expect(schema.safeParse(1_001).success).to.be.false;
+  });
+});
 
 describe('RelayerAgentConfigSchema feeToken gate', () => {
   const FEE_TOKEN = '0x0000000000000000000000000000000000000005';

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -761,6 +761,9 @@ export const ValidatorAgentConfigSchema = AgentConfigSchema.extend({
   interval: ZNzUint.optional().describe(
     'How long to wait between checking for new checkpoints in seconds. Defaults to 2s, falling back to the origin chain’s index.interval if set and this is unset.',
   ),
+  maxSignConcurrency: ZNzUint.optional().describe(
+    'Maximum number of checkpoints signed concurrently. Defaults to 50.',
+  ),
 });
 
 export type ValidatorConfig = z.infer<typeof ValidatorAgentConfigSchema>;

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -22,6 +22,9 @@ import {
 } from './deploymentArtifacts.js';
 import { MatchingListSchema } from './matchingList.js';
 
+// Keep in sync with MAX_SIGN_CONCURRENCY in the validator settings parser.
+const MAX_SIGN_CONCURRENCY = 1_000;
+
 export enum RpcConsensusType {
   Single = 'single',
   Fallback = 'fallback',
@@ -761,9 +764,11 @@ export const ValidatorAgentConfigSchema = AgentConfigSchema.extend({
   interval: ZNzUint.optional().describe(
     'How long to wait between checking for new checkpoints in seconds. Defaults to 2s, falling back to the origin chain’s index.interval if set and this is unset.',
   ),
-  maxSignConcurrency: ZNzUint.optional().describe(
-    'Maximum number of checkpoints signed concurrently. Defaults to 50.',
-  ),
+  maxSignConcurrency: ZNzUint.max(MAX_SIGN_CONCURRENCY)
+    .optional()
+    .describe(
+      `Maximum number of checkpoints signed concurrently. Defaults to 50; maximum ${MAX_SIGN_CONCURRENCY}.`,
+    ),
 });
 
 export type ValidatorConfig = z.infer<typeof ValidatorAgentConfigSchema>;


### PR DESCRIPTION
## Summary

- bound persistent RocksDB INFO logs to 10 files of 16 MiB each
- suppress idle and already-existing checkpoint log amplification while retaining write progress, metrics, and the once-per-minute status
- reject zero `maxSignConcurrency` and expose the positive setting in the SDK schema

## Evidence

Substance Labs subsequently confirmed that most of the reported 750 GB was Docker stdout/stderr logging with no rotation. Adding Docker log rotation and cleaning those logs is the primary fix.

That diagnosis matches current mainnet3 validator PVC telemetry: 84 validators use about 3.43 GiB total, with a median of 6.3 MiB, p95 of 192 MiB, and maximum of 391 MiB. The comparable Base, BSC, Ethereum, and ZeroGravity validator databases total about 429 MiB.

This PR is defense-in-depth rather than the root fix. It eliminates two records per idle polling cycle and per-checkpoint records during already-complete restart backfills, reducing container-log input. A prior fleet model estimates the idle change avoids about 7.88 million records per day; this is modelled from a historical fleet snapshot, not a current measurement. Deployments must still configure log rotation.

A separate agent-local issue is also real: BSC had about 177 MB of archived RocksDB INFO logs versus 38 MB of SST data; Arbitrum had about 178 MB of archived logs versus 231 MB of SST data. RocksDB otherwise retains up to 1,000 archived INFO logs and leaves the active log unbounded. This PR limits that diagnostic data; it does not alter WAL or database contents. Existing excess archives are trimmed when the database next opens.

## Validation

- `cargo test -p hyperlane-base db::rocks::tests::bounds_info_logs -- --nocapture`
- `cargo test -p validator` (66 passed)
- `cargo clippy -p validator -p hyperlane-base -- -D warnings`
- `cargo fmt --package validator --package hyperlane-base -- --check`
- `pnpm -C typescript/sdk lint`
- `pnpm exec changeset status --since origin/main`
- required GitHub CI passed

`pnpm -C typescript/sdk check` remains blocked locally by exact-main errors in unchanged `typescript/sdk/src/contracts/contracts.ts` concerning `TronJsonRpcProvider.isAccountActive`.

### 7 September restack

Rebased onto `main@04a1540b`. The RocksDB integration retains current rollback-WAL cleanup/retention while independently bounding INFO logs. Exact-head `git diff --check`, Rust formatting and Prettier passed; the focused `bounds_info_logs` regression passed 1/1. CI is rerunning for the rewritten head.