### PR TITLE
fix(infra): bound release candidate backfills

### DIFF
--- a/.changeset/wise-cursors-index.md
+++ b/.changeset/wise-cursors-index.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Agent chain metadata indexing configuration was updated to accept negative relative starting block offsets.

--- a/typescript/infra/config/contexts.ts
+++ b/typescript/infra/config/contexts.ts
@@ -5,6 +5,10 @@ export enum Contexts {
   FastPath = 'fastpath',
 }
 
+// RC agents are short-lived canaries. Bound their cold-start history so a stale
+// database cannot trigger an unbounded multi-chain backfill on every rollout.
+export const RELEASE_CANDIDATE_INDEX_FROM = -10_000;
+
 function isValidContext(context: string): context is Contexts {
   return Object.values(Contexts).includes(context as Contexts);
 }

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -40,7 +40,7 @@ import {
 } from '../../../src/config/agent/relayer.js';
 import { BaseScraperConfig } from '../../../src/config/agent/scraper.js';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
-import { Contexts } from '../../contexts.js';
+import { Contexts, RELEASE_CANDIDATE_INDEX_FROM } from '../../contexts.js';
 import { DockerImageRepos, mainnetDockerTags } from '../../docker.js';
 import { getDomainId, getWarpAddresses } from '../../registry.js';
 import { fallbackHedgeConfig } from '../utils.js';
@@ -863,6 +863,7 @@ const releaseCandidate: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    index: { from: RELEASE_CANDIDATE_INDEX_FROM },
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerRC,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -20,7 +20,7 @@ import {
   MetricAppContext,
 } from '../../../src/config/agent/relayer.js';
 import { ALL_KEY_ROLES, Role } from '../../../src/roles.js';
-import { Contexts } from '../../contexts.js';
+import { Contexts, RELEASE_CANDIDATE_INDEX_FROM } from '../../contexts.js';
 import { DockerImageRepos, testnetDockerTags } from '../../docker.js';
 import { getDomainId } from '../../registry.js';
 import { fallbackHedgeConfig } from '../utils.js';
@@ -371,6 +371,7 @@ const releaseCandidate: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    index: { from: RELEASE_CANDIDATE_INDEX_FROM },
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerRC,

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -142,6 +142,12 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
           }
 
           const batchConfig = this.batchConfig(chain);
+          const index = {
+            ...this.config.agentRoleConfig.index,
+            ...(this.config.rawConfig.relayer?.interval != null
+              ? { interval: this.config.rawConfig.relayer.interval }
+              : {}),
+          };
 
           return {
             name: chain,
@@ -159,9 +165,7 @@ export abstract class AgentHelmManager extends HelmManager<HelmRootAgentValues> 
                   maxSubmitQueueLength: batchConfig.maxSubmitQueueLength,
                 }
               : {}),
-            ...(this.config.rawConfig.relayer?.interval != null
-              ? { index: { interval: this.config.rawConfig.relayer.interval } }
-              : {}),
+            ...(Object.keys(index).length > 0 ? { index } : {}),
             priorityFeeOracle,
             transactionSubmitter,
             urReveal,

--- a/typescript/infra/src/config/agent/agent.ts
+++ b/typescript/infra/src/config/agent/agent.ts
@@ -167,10 +167,7 @@ export type KeyConfig =
   | CosmosKeyConfig
   | StarknetKeyConfig
   | RadixKeyConfig;
-interface IndexingConfig {
-  from: number;
-  chunk: number;
-}
+type IndexingConfig = NonNullable<AgentChainMetadata['index']>;
 
 export interface AwsConfig {
   region: string;

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -4,7 +4,7 @@ import { AgentConfig } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { readJson } from '@hyperlane-xyz/utils/fs';
 
-import { Contexts } from '../config/contexts.js';
+import { Contexts, RELEASE_CANDIDATE_INDEX_FROM } from '../config/contexts.js';
 import {
   agents as mainnet3Agents,
   hyperlaneContextAgentChainConfig as mainnet3AgentChainConfig,
@@ -157,6 +157,19 @@ describe('Agent configs', () => {
       testnet4Agents[Contexts.FastPath].relayer?.interval,
       'testnet4 fastpath interval',
     ).to.equal(2);
+  });
+
+  it('bounds release candidate relayer cold-start indexing', () => {
+    expect(mainnet3Agents[Contexts.Hyperlane].relayer?.index?.from).to.be
+      .undefined;
+    expect(testnet4Agents[Contexts.Hyperlane].relayer?.index?.from).to.be
+      .undefined;
+    expect(
+      mainnet3Agents[Contexts.ReleaseCandidate].relayer?.index?.from,
+    ).to.equal(RELEASE_CANDIDATE_INDEX_FROM);
+    expect(
+      testnet4Agents[Contexts.ReleaseCandidate].relayer?.index?.from,
+    ).to.equal(RELEASE_CANDIDATE_INDEX_FROM);
   });
 
   Object.entries(environmentChainConfigs).forEach(([environment, config]) => {

--- a/typescript/infra/test/validator-helm-manager.test.ts
+++ b/typescript/infra/test/validator-helm-manager.test.ts
@@ -24,6 +24,7 @@ describe('ValidatorHelmManager', () => {
       },
       validators: {
         rpcConsensusType: RpcConsensusType.Fallback,
+        index: { from: -10_000 },
         docker: {
           repo: 'ghcr.io/hyperlane-xyz/hyperlane-agent',
           tag: 'test',
@@ -56,6 +57,7 @@ describe('ValidatorHelmManager', () => {
     // Set from the validator's own chain config, independent of any relayer config
     // (there is none in this RootAgentConfig).
     expect(values.hyperlane.chains[0].index?.interval).to.equal(1);
+    expect(values.hyperlane.chains[0].index?.from).to.equal(-10_000);
     expect(values.hyperlane.validator?.configs).to.have.lengthOf(1);
     expect(values.hyperlane.validator?.configs?.[0].interval).to.equal(1);
   });

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -27,6 +27,28 @@ describe('ValidatorAgentConfigSchema maxSignConcurrency', () => {
   });
 });
 
+describe('AgentChainMetadataSchema index.from', () => {
+  it('accepts negative relative block offsets', () => {
+    const result = AgentChainMetadataSchema.safeParse({
+      name: 'legacy',
+      domainId: 1000,
+      chainId: 1000,
+      protocol: ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+      mailbox: '0x0000000000000000000000000000000000000001',
+      interchainGasPaymaster: '0x0000000000000000000000000000000000000002',
+      validatorAnnounce: '0x0000000000000000000000000000000000000003',
+      merkleTreeHook: '0x0000000000000000000000000000000000000004',
+      index: { from: -10_000 },
+    });
+
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(result.data.index?.from).to.equal(-10_000);
+    }
+  });
+});
+
 describe('RelayerAgentConfigSchema feeToken gate', () => {
   const FEE_TOKEN = '0x0000000000000000000000000000000000000005';
 

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -294,7 +294,7 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
           .int()
           .optional()
           .describe(
-            'The absolute starting block, or a negative offset from the current tip, from which to index events.',
+            'The absolute block or sequence to start indexing from. Negative values are offsets from the current tip in the selected index mode unit.',
           ),
         chunk: ZNzUint.optional().describe(
           'The number of blocks to index at a time.',

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -15,7 +15,7 @@ import {
   ChainMetadataSchemaObject,
   RpcUrlSchema,
 } from './chainMetadataTypes.js';
-import { ZHash, ZNzUint, ZUWei, ZUint } from './customZodTypes.js';
+import { ZHash, ZNzUint, ZUWei } from './customZodTypes.js';
 import {
   HyperlaneDeploymentArtifacts,
   HyperlaneDeploymentArtifactsSchema,
@@ -289,9 +289,13 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
     ),
     index: z
       .object({
-        from: ZUint.optional().describe(
-          'The starting block from which to index events.',
-        ),
+        from: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            'The absolute starting block, or a negative offset from the current tip, from which to index events.',
+          ),
         chunk: ZNzUint.optional().describe(
           'The number of blocks to index at a time.',
         ),


### PR DESCRIPTION
## Stack

Stacks on #9322; this PR remains the RC-only deployment guard.

## Summary

- wire role-level index overrides into generated agent Helm values
- limit release-candidate relayers to the latest 10,000 blocks or sequences on cold start
- cover mainnet3/testnet4 RC config and verify production relayers remain unchanged

## Incident

On 2026-08-20, the mainnet RC relayer rolled out Aleo test image 3bb326c-20260820-073841 while still indexing every production chain. Its existing PVC was mounted and RocksDB opened successfully; it was not a fresh database.

Celestia uses block-mode indexing and has a long sparse tail of Hyperlane events. Backward cursor progress through empty block ranges is in-memory only, so the short-lived RC resumed near the chain tip and replayed roughly 800,000 blocks before reaching data already present in RocksDB. The message and merkle-tree streams each called get_block and block_results, producing about 4.42M RC relayer requests on the peak day and triggering provider 429 retries.

The 10,000-unit relative lower bound limits a fresh or stale RC database without changing production relayer history. On Celestia it bounds the initial scan to about 17 hours of blocks. Sequence-indexed chains retain the latest 10,000 events.

This was unrelated to the relayer websocket/centralized-indexer migration: none of that branch history is present in the deployed image commit.

## Follow-up

#9325 implements the durable fix for production relayer and scraper restarts: event-specific backward progress is persisted in RocksDB and the existing scraper SQL cursor table. This PR remains the immediate RC deployment guard.

## Verification

- pnpm -C typescript/infra exec mocha --config ../sdk/.mocharc.json --timeout 10000 test/agent-configs.test.ts test/validator-helm-manager.test.ts
- pnpm -C typescript/infra check
- commit hooks: gitleaks, oxlint, oxfmt