### PR TITLE
feat(agents): persist backward index progress

### DIFF
--- a/rust/main/agents/relayer/src/relayer/origin.rs
+++ b/rust/main/agents/relayer/src/relayer/origin.rs
@@ -10,9 +10,9 @@ use hyperlane_base::{
     SequencedDataContractSync, WatermarkContractSync, WatermarkLogStore,
 };
 use hyperlane_core::{
-    HyperlaneDomain, HyperlaneLogStore, HyperlaneMessage, HyperlaneSequenceAwareIndexerStoreReader,
-    HyperlaneWatermarkedLogStore, Indexer, InterchainGasPayment, MerkleTreeInsertion,
-    ValidatorAnnounce,
+    HyperlaneBackwardCursorStore, HyperlaneDomain, HyperlaneLogStore, HyperlaneMessage,
+    HyperlaneSequenceAwareIndexerStoreReader, HyperlaneWatermarkedLogStore, Indexer,
+    InterchainGasPayment, MerkleTreeInsertion, ValidatorAnnounce,
 };
 use tokio::sync::RwLock;
 
@@ -367,7 +367,10 @@ impl OriginFactory {
     where
         T: Indexable + Debug,
         SequenceIndexer<T>: TryFromWithMetrics<ChainConf>,
-        S: HyperlaneLogStore<T> + HyperlaneSequenceAwareIndexerStoreReader<T> + 'static,
+        S: HyperlaneLogStore<T>
+            + HyperlaneSequenceAwareIndexerStoreReader<T>
+            + HyperlaneBackwardCursorStore<T>
+            + 'static,
     {
         // Currently, all indexers are of the `SequenceIndexer` type
         let indexer =

--- a/rust/main/agents/scraper/src/db/block_cursor.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor.rs
@@ -6,6 +6,8 @@ use sea_orm::{prelude::*, ActiveValue::*, Insert, Order, QueryOrder, QuerySelect
 use tokio::sync::RwLock;
 use tracing::{debug, info, instrument, warn};
 
+use hyperlane_core::BackwardCursorProgress;
+
 use crate::{date_time, db::ScraperDb};
 
 use super::generated::cursor;
@@ -155,6 +157,146 @@ impl ScraperDb {
         default_height: u64,
     ) -> Result<BlockCursor> {
         BlockCursor::new(self.clone_connection(), domain, event_type, default_height).await
+    }
+
+    pub async fn retrieve_backward_cursor(
+        &self,
+        domain: u32,
+        event_type: &str,
+    ) -> Result<Option<BackwardCursorProgress>> {
+        let event_type = format!("backward_{event_type}");
+        // Keep the pair atomic by packing both u32s into the cursor table's
+        // signed i64. Flipping the sign bit preserves unsigned ordering under
+        // PostgreSQL's signed LEAST comparison.
+        let packed = cursor::Entity::find()
+            .filter(cursor::Column::Domain.eq(domain))
+            .filter(cursor::Column::EventType.eq(event_type))
+            .one(&self.0)
+            .await?
+            .map(|model| (model.height as u64) ^ (1 << 63));
+        Ok(packed.map(|packed| BackwardCursorProgress {
+            sequence: (packed >> 32) as u32,
+            block: packed as u32,
+        }))
+    }
+
+    pub async fn store_backward_cursor(
+        &self,
+        domain: u32,
+        event_type: &str,
+        progress: BackwardCursorProgress,
+    ) -> Result<()> {
+        let packed = ((progress.sequence as u64) << 32) | progress.block as u64;
+        let model = cursor::ActiveModel {
+            id: NotSet,
+            domain: Set(domain as i32),
+            time_created: Set(date_time::now()),
+            height: Set((packed ^ (1 << 63)) as i64),
+            event_type: Set(format!("backward_{event_type}")),
+        };
+        Insert::one(model)
+            .on_conflict(
+                OnConflict::columns([cursor::Column::Domain, cursor::Column::EventType])
+                    .update_column(cursor::Column::TimeCreated)
+                    .value(
+                        cursor::Column::Height,
+                        Func::least([
+                            Expr::col((Alias::new("cursor"), cursor::Column::Height)).into(),
+                            Expr::col((Alias::new("excluded"), cursor::Column::Height)).into(),
+                        ]),
+                    )
+                    .to_owned(),
+            )
+            .exec(&self.0)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn reset_backward_cursor(
+        &self,
+        domain: u32,
+        event_type: &str,
+        progress: BackwardCursorProgress,
+    ) -> Result<()> {
+        let packed = ((progress.sequence as u64) << 32) | progress.block as u64;
+        let model = cursor::ActiveModel {
+            id: NotSet,
+            domain: Set(domain as i32),
+            time_created: Set(date_time::now()),
+            height: Set((packed ^ (1 << 63)) as i64),
+            event_type: Set(format!("backward_{event_type}")),
+        };
+        Insert::one(model)
+            .on_conflict(
+                OnConflict::columns([cursor::Column::Domain, cursor::Column::EventType])
+                    .update_columns([cursor::Column::Height, cursor::Column::TimeCreated])
+                    .to_owned(),
+            )
+            .exec(&self.0)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlane_core::BackwardCursorProgress;
+    use migration::MigratorTrait;
+    use sea_orm::Database;
+    use testcontainers::runners::AsyncRunner;
+    use testcontainers_modules::postgres::Postgres;
+
+    use super::ScraperDb;
+
+    #[tokio::test]
+    async fn backward_cursors_are_durable_and_event_specific() -> eyre::Result<()> {
+        let postgres = Postgres::default().start().await?;
+        let port = postgres.get_host_port_ipv4(5432).await?;
+        let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+        let connection = Database::connect(&url).await?;
+        migration::Migrator::up(&connection, None).await?;
+
+        let db = ScraperDb::connect(&url).await?;
+        let message = BackwardCursorProgress {
+            sequence: u32::MAX,
+            block: 34,
+        };
+        let payment = BackwardCursorProgress {
+            sequence: 56,
+            block: u32::MAX,
+        };
+        db.store_backward_cursor(13375, "message", message).await?;
+        db.store_backward_cursor(13375, "gas_payment", payment)
+            .await?;
+        let updated_message = BackwardCursorProgress {
+            sequence: 12,
+            block: 34,
+        };
+        db.store_backward_cursor(13375, "message", updated_message)
+            .await?;
+        db.store_backward_cursor(13375, "message", message).await?;
+        let rewind = BackwardCursorProgress {
+            sequence: 12,
+            block: 500,
+        };
+        db.reset_backward_cursor(13375, "message", rewind).await?;
+
+        let reopened = ScraperDb::connect(&url).await?;
+        assert_eq!(
+            reopened.retrieve_backward_cursor(13375, "message").await?,
+            Some(rewind)
+        );
+        assert_eq!(
+            reopened
+                .retrieve_backward_cursor(13375, "gas_payment")
+                .await?,
+            Some(payment)
+        );
+        assert_eq!(
+            reopened.retrieve_backward_cursor(13375, "delivery").await?,
+            None
+        );
+        Ok(())
     }
 }
 

--- a/rust/main/agents/scraper/src/db/block_cursor.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor.rs
@@ -159,25 +159,30 @@ impl ScraperDb {
         BlockCursor::new(self.clone_connection(), domain, event_type, default_height).await
     }
 
-    pub async fn retrieve_backward_cursor(
+    pub async fn retrieve_backward_cursors(
         &self,
         domain: u32,
         event_type: &str,
-    ) -> Result<Option<BackwardCursorProgress>> {
-        let event_type = format!("backward_{event_type}");
-        // Keep the pair atomic by packing both u32s into the cursor table's
-        // signed i64. Flipping the sign bit preserves unsigned ordering under
-        // PostgreSQL's signed LEAST comparison.
-        let packed = cursor::Entity::find()
+    ) -> Result<Vec<BackwardCursorProgress>> {
+        let event_type_prefix = format!("backward_{event_type}_");
+        cursor::Entity::find()
             .filter(cursor::Column::Domain.eq(domain))
-            .filter(cursor::Column::EventType.eq(event_type))
-            .one(&self.0)
+            .filter(cursor::Column::EventType.starts_with(&event_type_prefix))
+            .all(&self.0)
             .await?
-            .map(|model| (model.height as u64) ^ (1 << 63));
-        Ok(packed.map(|packed| BackwardCursorProgress {
-            sequence: (packed >> 32) as u32,
-            block: packed as u32,
-        }))
+            .into_iter()
+            .map(|model| {
+                let sequence = model
+                    .event_type
+                    .strip_prefix(&event_type_prefix)
+                    .ok_or_else(|| eyre::eyre!("Invalid backwards cursor event type"))?
+                    .parse()?;
+                Ok(BackwardCursorProgress {
+                    sequence,
+                    block: model.height.try_into()?,
+                })
+            })
+            .collect()
     }
 
     pub async fn store_backward_cursor(
@@ -186,13 +191,12 @@ impl ScraperDb {
         event_type: &str,
         progress: BackwardCursorProgress,
     ) -> Result<()> {
-        let packed = ((progress.sequence as u64) << 32) | progress.block as u64;
         let model = cursor::ActiveModel {
             id: NotSet,
             domain: Set(domain as i32),
             time_created: Set(date_time::now()),
-            height: Set((packed ^ (1 << 63)) as i64),
-            event_type: Set(format!("backward_{event_type}")),
+            height: Set(progress.block.into()),
+            event_type: Set(format!("backward_{event_type}_{}", progress.sequence)),
         };
         Insert::one(model)
             .on_conflict(
@@ -218,13 +222,12 @@ impl ScraperDb {
         event_type: &str,
         progress: BackwardCursorProgress,
     ) -> Result<()> {
-        let packed = ((progress.sequence as u64) << 32) | progress.block as u64;
         let model = cursor::ActiveModel {
             id: NotSet,
             domain: Set(domain as i32),
             time_created: Set(date_time::now()),
-            height: Set((packed ^ (1 << 63)) as i64),
-            event_type: Set(format!("backward_{event_type}")),
+            height: Set(progress.block.into()),
+            event_type: Set(format!("backward_{event_type}_{}", progress.sequence)),
         };
         Insert::one(model)
             .on_conflict(
@@ -236,66 +239,18 @@ impl ScraperDb {
             .await?;
         Ok(())
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use hyperlane_core::BackwardCursorProgress;
-    use migration::MigratorTrait;
-    use sea_orm::Database;
-    use testcontainers::runners::AsyncRunner;
-    use testcontainers_modules::postgres::Postgres;
-
-    use super::ScraperDb;
-
-    #[tokio::test]
-    async fn backward_cursors_are_durable_and_event_specific() -> eyre::Result<()> {
-        let postgres = Postgres::default().start().await?;
-        let port = postgres.get_host_port_ipv4(5432).await?;
-        let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
-        let connection = Database::connect(&url).await?;
-        migration::Migrator::up(&connection, None).await?;
-
-        let db = ScraperDb::connect(&url).await?;
-        let message = BackwardCursorProgress {
-            sequence: u32::MAX,
-            block: 34,
-        };
-        let payment = BackwardCursorProgress {
-            sequence: 56,
-            block: u32::MAX,
-        };
-        db.store_backward_cursor(13375, "message", message).await?;
-        db.store_backward_cursor(13375, "gas_payment", payment)
+    pub async fn delete_backward_cursor(
+        &self,
+        domain: u32,
+        event_type: &str,
+        sequence: u32,
+    ) -> Result<()> {
+        cursor::Entity::delete_many()
+            .filter(cursor::Column::Domain.eq(domain))
+            .filter(cursor::Column::EventType.eq(format!("backward_{event_type}_{sequence}")))
+            .exec(&self.0)
             .await?;
-        let updated_message = BackwardCursorProgress {
-            sequence: 12,
-            block: 34,
-        };
-        db.store_backward_cursor(13375, "message", updated_message)
-            .await?;
-        db.store_backward_cursor(13375, "message", message).await?;
-        let rewind = BackwardCursorProgress {
-            sequence: 12,
-            block: 500,
-        };
-        db.reset_backward_cursor(13375, "message", rewind).await?;
-
-        let reopened = ScraperDb::connect(&url).await?;
-        assert_eq!(
-            reopened.retrieve_backward_cursor(13375, "message").await?,
-            Some(rewind)
-        );
-        assert_eq!(
-            reopened
-                .retrieve_backward_cursor(13375, "gas_payment")
-                .await?,
-            Some(payment)
-        );
-        assert_eq!(
-            reopened.retrieve_backward_cursor(13375, "delivery").await?,
-            None
-        );
         Ok(())
     }
 }

--- a/rust/main/agents/scraper/src/db/block_cursor/tests.rs
+++ b/rust/main/agents/scraper/src/db/block_cursor/tests.rs
@@ -136,3 +136,62 @@ async fn cursor_persistence_is_monotonic_scoped_and_survives_reopen_in_postgres(
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn backward_cursors_are_durable_and_event_specific() -> Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let url = format!("postgresql://postgres:postgres@127.0.0.1:{port}/postgres");
+    let connection = Database::connect(&url).await?;
+    migration::Migrator::up(&connection, None).await?;
+
+    let db = ScraperDb::connect(&url).await?;
+    let message = BackwardCursorProgress {
+        sequence: u32::MAX,
+        block: 34,
+    };
+    let payment = BackwardCursorProgress {
+        sequence: 56,
+        block: u32::MAX,
+    };
+    db.store_backward_cursor(13375, "message", message).await?;
+    db.store_backward_cursor(13375, "gas_payment", payment)
+        .await?;
+    let updated_message = BackwardCursorProgress {
+        sequence: 12,
+        block: 34,
+    };
+    db.store_backward_cursor(13375, "message", updated_message)
+        .await?;
+    db.store_backward_cursor(13375, "message", message).await?;
+    let rewind = BackwardCursorProgress {
+        sequence: 12,
+        block: 500,
+    };
+    db.reset_backward_cursor(13375, "message", rewind).await?;
+
+    let reopened = ScraperDb::connect(&url).await?;
+    let message_cursors = reopened.retrieve_backward_cursors(13375, "message").await?;
+    assert!(message_cursors.contains(&rewind));
+    assert!(message_cursors.contains(&message));
+    assert_eq!(
+        reopened
+            .retrieve_backward_cursors(13375, "gas_payment")
+            .await?,
+        vec![payment]
+    );
+    assert_eq!(
+        reopened
+            .retrieve_backward_cursors(13375, "delivery")
+            .await?,
+        Vec::new()
+    );
+    reopened
+        .delete_backward_cursor(13375, "message", message.sequence)
+        .await?;
+    assert_eq!(
+        reopened.retrieve_backward_cursors(13375, "message").await?,
+        vec![rewind]
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/store/deliveries.rs
+++ b/rust/main/agents/scraper/src/store/deliveries.rs
@@ -77,11 +77,11 @@ impl HyperlaneSequenceAwareIndexerStoreReader<Delivery> for HyperlaneDbStore {
 
 #[async_trait]
 impl hyperlane_core::HyperlaneBackwardCursorStore<Delivery> for HyperlaneDbStore {
-    async fn retrieve_backward_cursor(
+    async fn retrieve_backward_cursors(
         &self,
-    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+    ) -> Result<Vec<hyperlane_core::BackwardCursorProgress>> {
         self.db
-            .retrieve_backward_cursor(self.domain.id(), "delivery")
+            .retrieve_backward_cursors(self.domain.id(), "delivery")
             .await
     }
 
@@ -100,6 +100,12 @@ impl hyperlane_core::HyperlaneBackwardCursorStore<Delivery> for HyperlaneDbStore
     ) -> Result<()> {
         self.db
             .reset_backward_cursor(self.domain.id(), "delivery", progress)
+            .await
+    }
+
+    async fn delete_backward_cursor(&self, sequence: u32) -> Result<()> {
+        self.db
+            .delete_backward_cursor(self.domain.id(), "delivery", sequence)
             .await
     }
 }

--- a/rust/main/agents/scraper/src/store/deliveries.rs
+++ b/rust/main/agents/scraper/src/store/deliveries.rs
@@ -74,3 +74,32 @@ impl HyperlaneSequenceAwareIndexerStoreReader<Delivery> for HyperlaneDbStore {
             .await
     }
 }
+
+#[async_trait]
+impl hyperlane_core::HyperlaneBackwardCursorStore<Delivery> for HyperlaneDbStore {
+    async fn retrieve_backward_cursor(
+        &self,
+    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+        self.db
+            .retrieve_backward_cursor(self.domain.id(), "delivery")
+            .await
+    }
+
+    async fn store_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .store_backward_cursor(self.domain.id(), "delivery", progress)
+            .await
+    }
+
+    async fn reset_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .reset_backward_cursor(self.domain.id(), "delivery", progress)
+            .await
+    }
+}

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -450,11 +450,11 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneDbS
 
 #[async_trait]
 impl hyperlane_core::HyperlaneBackwardCursorStore<HyperlaneMessage> for HyperlaneDbStore {
-    async fn retrieve_backward_cursor(
+    async fn retrieve_backward_cursors(
         &self,
-    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+    ) -> Result<Vec<hyperlane_core::BackwardCursorProgress>> {
         self.db
-            .retrieve_backward_cursor(self.domain.id(), "message")
+            .retrieve_backward_cursors(self.domain.id(), "message")
             .await
     }
 
@@ -473,6 +473,12 @@ impl hyperlane_core::HyperlaneBackwardCursorStore<HyperlaneMessage> for Hyperlan
     ) -> Result<()> {
         self.db
             .reset_backward_cursor(self.domain.id(), "message", progress)
+            .await
+    }
+
+    async fn delete_backward_cursor(&self, sequence: u32) -> Result<()> {
+        self.db
+            .delete_backward_cursor(self.domain.id(), "message", sequence)
             .await
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -448,6 +448,35 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneDbS
     }
 }
 
+#[async_trait]
+impl hyperlane_core::HyperlaneBackwardCursorStore<HyperlaneMessage> for HyperlaneDbStore {
+    async fn retrieve_backward_cursor(
+        &self,
+    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+        self.db
+            .retrieve_backward_cursor(self.domain.id(), "message")
+            .await
+    }
+
+    async fn store_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .store_backward_cursor(self.domain.id(), "message", progress)
+            .await
+    }
+
+    async fn reset_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .reset_backward_cursor(self.domain.id(), "message", progress)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/main/agents/scraper/src/store/merkle_tree_insertions.rs
+++ b/rust/main/agents/scraper/src/store/merkle_tree_insertions.rs
@@ -54,3 +54,32 @@ impl HyperlaneSequenceAwareIndexerStoreReader<MerkleTreeInsertion> for Hyperlane
             .map(|(_, block_number)| block_number))
     }
 }
+
+#[async_trait]
+impl hyperlane_core::HyperlaneBackwardCursorStore<MerkleTreeInsertion> for HyperlaneDbStore {
+    async fn retrieve_backward_cursor(
+        &self,
+    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+        self.db
+            .retrieve_backward_cursor(self.domain.id(), "merkle_tree_insertion")
+            .await
+    }
+
+    async fn store_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .store_backward_cursor(self.domain.id(), "merkle_tree_insertion", progress)
+            .await
+    }
+
+    async fn reset_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .reset_backward_cursor(self.domain.id(), "merkle_tree_insertion", progress)
+            .await
+    }
+}

--- a/rust/main/agents/scraper/src/store/merkle_tree_insertions.rs
+++ b/rust/main/agents/scraper/src/store/merkle_tree_insertions.rs
@@ -57,11 +57,11 @@ impl HyperlaneSequenceAwareIndexerStoreReader<MerkleTreeInsertion> for Hyperlane
 
 #[async_trait]
 impl hyperlane_core::HyperlaneBackwardCursorStore<MerkleTreeInsertion> for HyperlaneDbStore {
-    async fn retrieve_backward_cursor(
+    async fn retrieve_backward_cursors(
         &self,
-    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+    ) -> Result<Vec<hyperlane_core::BackwardCursorProgress>> {
         self.db
-            .retrieve_backward_cursor(self.domain.id(), "merkle_tree_insertion")
+            .retrieve_backward_cursors(self.domain.id(), "merkle_tree_insertion")
             .await
     }
 
@@ -80,6 +80,12 @@ impl hyperlane_core::HyperlaneBackwardCursorStore<MerkleTreeInsertion> for Hyper
     ) -> Result<()> {
         self.db
             .reset_backward_cursor(self.domain.id(), "merkle_tree_insertion", progress)
+            .await
+    }
+
+    async fn delete_backward_cursor(&self, sequence: u32) -> Result<()> {
+        self.db
+            .delete_backward_cursor(self.domain.id(), "merkle_tree_insertion", sequence)
             .await
     }
 }

--- a/rust/main/agents/scraper/src/store/payments.rs
+++ b/rust/main/agents/scraper/src/store/payments.rs
@@ -96,3 +96,32 @@ impl HyperlaneSequenceAwareIndexerStoreReader<InterchainGasPayment> for Hyperlan
             .await
     }
 }
+
+#[async_trait]
+impl hyperlane_core::HyperlaneBackwardCursorStore<InterchainGasPayment> for HyperlaneDbStore {
+    async fn retrieve_backward_cursor(
+        &self,
+    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+        self.db
+            .retrieve_backward_cursor(self.domain.id(), "gas_payment")
+            .await
+    }
+
+    async fn store_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .store_backward_cursor(self.domain.id(), "gas_payment", progress)
+            .await
+    }
+
+    async fn reset_backward_cursor(
+        &self,
+        progress: hyperlane_core::BackwardCursorProgress,
+    ) -> Result<()> {
+        self.db
+            .reset_backward_cursor(self.domain.id(), "gas_payment", progress)
+            .await
+    }
+}

--- a/rust/main/agents/scraper/src/store/payments.rs
+++ b/rust/main/agents/scraper/src/store/payments.rs
@@ -99,11 +99,11 @@ impl HyperlaneSequenceAwareIndexerStoreReader<InterchainGasPayment> for Hyperlan
 
 #[async_trait]
 impl hyperlane_core::HyperlaneBackwardCursorStore<InterchainGasPayment> for HyperlaneDbStore {
-    async fn retrieve_backward_cursor(
+    async fn retrieve_backward_cursors(
         &self,
-    ) -> Result<Option<hyperlane_core::BackwardCursorProgress>> {
+    ) -> Result<Vec<hyperlane_core::BackwardCursorProgress>> {
         self.db
-            .retrieve_backward_cursor(self.domain.id(), "gas_payment")
+            .retrieve_backward_cursors(self.domain.id(), "gas_payment")
             .await
     }
 
@@ -122,6 +122,12 @@ impl hyperlane_core::HyperlaneBackwardCursorStore<InterchainGasPayment> for Hype
     ) -> Result<()> {
         self.db
             .reset_backward_cursor(self.domain.id(), "gas_payment", progress)
+            .await
+    }
+
+    async fn delete_backward_cursor(&self, sequence: u32) -> Result<()> {
+        self.db
+            .delete_backward_cursor(self.domain.id(), "gas_payment", sequence)
             .await
     }
 }

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -1,7 +1,7 @@
 //! A sequence-aware cursor that syncs backwards until there are no earlier logs to index.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     fmt::Debug,
     ops::RangeInclusive,
     sync::Arc,
@@ -44,9 +44,9 @@ pub(crate) struct BackwardSequenceAwareSyncCursor<T> {
     pub lowest_block_height_or_sequence: i64,
     /// A store used to check which logs have already been indexed.
     store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
-    /// The last backwards position stored durably. Also used to restore progress
-    /// after already-indexed higher sequences have been skipped.
-    persisted_progress: Option<BackwardCursorProgress>,
+    /// Durable backwards positions by missing sequence. Multiple checkpoints let
+    /// newer gaps advance without discarding unfinished older scans.
+    persisted_progress: BTreeMap<u32, u32>,
     /// A snapshot of the last log to be indexed, or if no indexing has occurred yet,
     /// the initial log to start indexing backward from.
     last_indexed_snapshot: LastIndexedSnapshot,
@@ -86,7 +86,7 @@ pub struct BackwardSequenceAwareSyncCursorParams<T> {
     pub latest_sequence_querier: Arc<dyn SequenceAwareIndexer<T>>,
     pub lowest_block_height_or_sequence: i64,
     pub store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
-    pub persisted_progress: Option<BackwardCursorProgress>,
+    pub persisted_progress: Vec<BackwardCursorProgress>,
     pub current_sequence_count: u32,
     pub start_block: u32,
     pub index_mode: IndexMode,
@@ -124,6 +124,10 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             index_mode,
             metrics_data,
         } = params;
+        let persisted_progress = persisted_progress
+            .into_iter()
+            .map(|progress| (progress.sequence, progress.block))
+            .collect();
 
         // If the current sequence count is 0, we haven't indexed anything yet.
         // Otherwise, consider the current sequence count as the last indexed snapshot,
@@ -202,20 +206,21 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
     /// Applies durable empty-range progress once DB fast-forwarding reaches the
     /// sequence that was missing when the progress was stored.
     fn apply_persisted_progress(&mut self) {
-        let (Some(current), Some(persisted)) =
-            (&mut self.current_indexing_snapshot, self.persisted_progress)
-        else {
+        let Some(current) = &mut self.current_indexing_snapshot else {
+            return;
+        };
+        let Some(&persisted_block) = self.persisted_progress.get(&current.sequence) else {
             return;
         };
 
-        if current.sequence == persisted.sequence && persisted.block < current.at_block {
+        if persisted_block < current.at_block {
             debug!(
                 current_sequence = current.sequence,
                 current_block = current.at_block,
-                persisted_block = persisted.block,
+                persisted_block,
                 "Restoring backwards cursor progress"
             );
-            current.at_block = persisted.block;
+            current.at_block = persisted_block;
         }
     }
 
@@ -227,23 +232,22 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             sequence: current.sequence,
             block: current.at_block,
         };
-        let should_persist = match self.persisted_progress {
+        let should_persist = match self.persisted_progress.get(&progress.sequence) {
             None => true,
-            Some(persisted) if progress.sequence < persisted.sequence => true,
-            Some(persisted) if progress.sequence == persisted.sequence => {
-                progress.block < persisted.block
+            Some(&persisted_block) => {
+                progress.block < persisted_block
                     && (force
-                        || persisted.block.saturating_sub(progress.block)
+                        || persisted_block.saturating_sub(progress.block)
                             >= BACKWARD_CURSOR_PERSIST_BLOCK_INTERVAL)
             }
-            Some(_) => false,
         };
         if !should_persist {
             return Ok(());
         }
 
         self.store.store_backward_cursor(progress).await?;
-        self.persisted_progress = Some(progress);
+        self.persisted_progress
+            .insert(progress.sequence, progress.block);
         Ok(())
     }
 
@@ -256,7 +260,8 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             block: current.at_block,
         };
         self.store.reset_backward_cursor(progress).await?;
-        self.persisted_progress = Some(progress);
+        self.persisted_progress
+            .insert(progress.sequence, progress.block);
         Ok(())
     }
 
@@ -376,6 +381,15 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
                 .get_sequence_log_block_number(current_indexing_sequence)
                 .await?
             {
+                if self
+                    .persisted_progress
+                    .contains_key(&current_indexing_sequence)
+                {
+                    self.store
+                        .delete_backward_cursor(current_indexing_sequence)
+                        .await?;
+                    self.persisted_progress.remove(&current_indexing_sequence);
+                }
                 made_progress = true;
                 self.last_indexed_snapshot = LastIndexedSnapshot {
                     sequence: Some(current_indexing_sequence),
@@ -812,7 +826,7 @@ mod test {
             latest_sequence_querier,
             lowest_block_height_or_sequence,
             store: db,
-            persisted_progress: None,
+            persisted_progress: Vec::new(),
             current_sequence_count: INITIAL_SEQUENCE_COUNT,
             start_block: INITIAL_START_BLOCK,
             index_mode: mode,
@@ -895,25 +909,65 @@ mod test {
         #[tokio::test]
         async fn restores_and_checkpoints_empty_block_progress() {
             let mut cursor = get_cursor().await;
-            cursor.persisted_progress = Some(BackwardCursorProgress {
-                sequence: INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence,
-                block: 850,
-            });
+            cursor
+                .persisted_progress
+                .insert(INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence, 850);
 
             assert_eq!(cursor.get_next_range().await.unwrap(), Some(750..=850));
 
-            cursor.persisted_progress = None;
+            cursor.persisted_progress.clear();
             cursor
                 .update(Vec::new(), 750..=850)
                 .await
                 .expect("checkpoint empty range");
             assert_eq!(
-                cursor.persisted_progress,
-                Some(BackwardCursorProgress {
-                    sequence: INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence,
-                    block: 749,
-                })
+                cursor
+                    .persisted_progress
+                    .get(&INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence),
+                Some(&749)
             );
+        }
+
+        #[tokio::test]
+        async fn checkpoints_new_frontier_without_losing_older_progress() {
+            let mut cursor = get_cursor().await;
+            cursor.persisted_progress.insert(0, 50);
+
+            cursor
+                .update(Vec::new(), 900..=1000)
+                .await
+                .expect("checkpoint newer missing sequence");
+            assert_eq!(cursor.persisted_progress.get(&0), Some(&50));
+            assert_eq!(
+                cursor
+                    .persisted_progress
+                    .get(&INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence),
+                Some(&899)
+            );
+
+            let persisted_progress = cursor
+                .persisted_progress
+                .iter()
+                .map(|(&sequence, &block)| BackwardCursorProgress { sequence, block })
+                .collect();
+            let params = BackwardSequenceAwareSyncCursorParams {
+                chunk_size: CHUNK_SIZE,
+                latest_sequence_querier: cursor.latest_sequence_querier.clone(),
+                lowest_block_height_or_sequence: LOWEST_BLOCK_HEIGHT,
+                store: cursor.store.clone(),
+                persisted_progress,
+                current_sequence_count: INITIAL_SEQUENCE_COUNT,
+                start_block: INITIAL_START_BLOCK,
+                index_mode: INDEX_MODE,
+                metrics_data: MetricsData {
+                    domain: HyperlaneDomain::new_test_domain("test"),
+                    metrics: Arc::new(mock_cursor_metrics()),
+                },
+            };
+            let mut restarted = BackwardSequenceAwareSyncCursor::new(params);
+
+            assert_eq!(restarted.get_next_range().await.unwrap(), Some(799..=899));
+            assert_eq!(restarted.persisted_progress.get(&0), Some(&50));
         }
 
         #[tracing_test::traced_test]
@@ -1189,7 +1243,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: LOWEST_BLOCK_HEIGHT,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: INITIAL_SEQUENCE_COUNT,
                 start_block: INITIAL_START_BLOCK,
                 index_mode: INDEX_MODE,
@@ -1339,7 +1393,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_block_height,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: 1,
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -1377,7 +1431,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_block_height,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: 1,
                 start_block: 1000, // Below lowest_block_height
                 index_mode: INDEX_MODE,
@@ -1415,7 +1469,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_block_height,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: 2,
                 start_block: 1001,
                 index_mode: INDEX_MODE,
@@ -2128,7 +2182,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_sequence,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: 1,
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -2166,7 +2220,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_sequence,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: 1, // sequence 0, below lowest
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -2204,7 +2258,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_sequence,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: 2, // sequences 0 and 1
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -2243,7 +2297,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: latest_sequence_count,
                 start_block: latest_tip,
                 index_mode: IndexMode::Block,
@@ -2322,7 +2376,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence,
                 store: db,
-                persisted_progress: None,
+                persisted_progress: Vec::new(),
                 current_sequence_count: latest_sequence_count,
                 start_block: latest_tip,
                 index_mode: IndexMode::Sequence,

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/backward.rs
@@ -16,9 +16,9 @@ use tokio::time::sleep;
 use tracing::{debug, info, instrument, warn};
 
 use hyperlane_core::{
-    indexed_to_sequence_indexed_array, ContractSyncCursor, CursorAction, HyperlaneDomain,
-    HyperlaneSequenceAwareIndexerStoreReader, IndexMode, Indexed, LogMeta, SequenceAwareIndexer,
-    SequenceIndexed,
+    indexed_to_sequence_indexed_array, BackwardCursorProgress, ContractSyncCursor, CursorAction,
+    HyperlaneDomain, HyperlaneSequenceAwareIndexerStore, IndexMode, Indexed, LogMeta,
+    SequenceAwareIndexer, SequenceIndexed,
 };
 
 use crate::cursors::Indexable;
@@ -28,6 +28,7 @@ use super::{CursorMetrics, LastIndexedSnapshot, MetricsData, TargetSnapshot};
 const MAX_BACKWARD_SYNC_BLOCKING_TIME: Duration = Duration::from_secs(5);
 const INITIAL_SEQUENCE_GAP_BACKOFF: Duration = Duration::from_secs(5);
 const MAX_SEQUENCE_GAP_BACKOFF: Duration = Duration::from_secs(5 * 60);
+const BACKWARD_CURSOR_PERSIST_BLOCK_INTERVAL: u32 = 1_000;
 
 /// A sequence-aware cursor that syncs backward until there are no earlier logs to index.
 pub(crate) struct BackwardSequenceAwareSyncCursor<T> {
@@ -42,7 +43,10 @@ pub(crate) struct BackwardSequenceAwareSyncCursor<T> {
     /// The lowest block height or sequence of an entity which should be indexed.
     pub lowest_block_height_or_sequence: i64,
     /// A store used to check which logs have already been indexed.
-    store: Arc<dyn HyperlaneSequenceAwareIndexerStoreReader<T>>,
+    store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
+    /// The last backwards position stored durably. Also used to restore progress
+    /// after already-indexed higher sequences have been skipped.
+    persisted_progress: Option<BackwardCursorProgress>,
     /// A snapshot of the last log to be indexed, or if no indexing has occurred yet,
     /// the initial log to start indexing backward from.
     last_indexed_snapshot: LastIndexedSnapshot,
@@ -81,7 +85,8 @@ pub struct BackwardSequenceAwareSyncCursorParams<T> {
     pub chunk_size: u32,
     pub latest_sequence_querier: Arc<dyn SequenceAwareIndexer<T>>,
     pub lowest_block_height_or_sequence: i64,
-    pub store: Arc<dyn HyperlaneSequenceAwareIndexerStoreReader<T>>,
+    pub store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
+    pub persisted_progress: Option<BackwardCursorProgress>,
     pub current_sequence_count: u32,
     pub start_block: u32,
     pub index_mode: IndexMode,
@@ -113,6 +118,7 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             latest_sequence_querier,
             lowest_block_height_or_sequence,
             store,
+            persisted_progress,
             current_sequence_count,
             start_block,
             index_mode,
@@ -133,6 +139,7 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             latest_sequence_querier,
             lowest_block_height_or_sequence,
             store,
+            persisted_progress,
             current_indexing_snapshot: last_indexed_snapshot.previous_target(),
             last_indexed_snapshot,
             index_mode,
@@ -161,6 +168,8 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             _ = sleep(MAX_BACKWARD_SYNC_BLOCKING_TIME) => { return Ok(None); }
         }
 
+        self.apply_persisted_progress();
+
         // While a gap backoff is active, don't issue another range query.
         if self
             .sequence_gap_retry_at
@@ -181,10 +190,74 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
                             .await
                     }
                 };
+                if range.is_none() && matches!(self.index_mode, IndexMode::Block) {
+                    self.persist_progress(true).await?;
+                }
                 Ok(range)
             }
             None => Ok(None),
         }
+    }
+
+    /// Applies durable empty-range progress once DB fast-forwarding reaches the
+    /// sequence that was missing when the progress was stored.
+    fn apply_persisted_progress(&mut self) {
+        let (Some(current), Some(persisted)) =
+            (&mut self.current_indexing_snapshot, self.persisted_progress)
+        else {
+            return;
+        };
+
+        if current.sequence == persisted.sequence && persisted.block < current.at_block {
+            debug!(
+                current_sequence = current.sequence,
+                current_block = current.at_block,
+                persisted_block = persisted.block,
+                "Restoring backwards cursor progress"
+            );
+            current.at_block = persisted.block;
+        }
+    }
+
+    async fn persist_progress(&mut self, force: bool) -> Result<()> {
+        let Some(current) = self.current_indexing_snapshot.as_ref() else {
+            return Ok(());
+        };
+        let progress = BackwardCursorProgress {
+            sequence: current.sequence,
+            block: current.at_block,
+        };
+        let should_persist = match self.persisted_progress {
+            None => true,
+            Some(persisted) if progress.sequence < persisted.sequence => true,
+            Some(persisted) if progress.sequence == persisted.sequence => {
+                progress.block < persisted.block
+                    && (force
+                        || persisted.block.saturating_sub(progress.block)
+                            >= BACKWARD_CURSOR_PERSIST_BLOCK_INTERVAL)
+            }
+            Some(_) => false,
+        };
+        if !should_persist {
+            return Ok(());
+        }
+
+        self.store.store_backward_cursor(progress).await?;
+        self.persisted_progress = Some(progress);
+        Ok(())
+    }
+
+    async fn persist_rewind(&mut self) -> Result<()> {
+        let Some(current) = self.current_indexing_snapshot.as_ref() else {
+            return Ok(());
+        };
+        let progress = BackwardCursorProgress {
+            sequence: current.sequence,
+            block: current.at_block,
+        };
+        self.store.reset_backward_cursor(progress).await?;
+        self.persisted_progress = Some(progress);
+        Ok(())
     }
 
     /// Gets the next block range to index.
@@ -366,7 +439,7 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
         all_log_sequences: &HashSet<u32>,
         range: RangeInclusive<u32>,
         current_indexing_snapshot: TargetSnapshot,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         // We require no sequence gaps and to build upon the last snapshot.
         // A non-inclusive range is used to allow updates without any logs.
         let expected_sequences = (current_indexing_snapshot
@@ -379,7 +452,7 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             // If there are any missing sequences, rewind to just before the last indexed snapshot.
             // Rewind to the last snapshot.
             self.rewind_due_to_sequence_gaps(&logs, all_log_sequences, &expected_sequences, &range);
-            return Ok(());
+            return Ok(false);
         }
 
         let logs_len: u32 = logs.len().try_into()?;
@@ -409,7 +482,7 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> BackwardSequenceAware
             };
         }
 
-        Ok(())
+        Ok(true)
     }
 
     /// Updates the cursor with the logs that were found in the range.
@@ -643,12 +716,13 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> ContractSyncCursor<T>
             .filter(|(log, _)| log.sequence <= current_indexing_snapshot.sequence)
             .sorted_by_key(|(log, _)| log.sequence)
             .collect::<Vec<_>>();
+        let logs_are_empty = logs.is_empty();
         let all_log_sequences = logs
             .iter()
             .map(|(log, _)| log.sequence)
             .collect::<HashSet<_>>();
 
-        match &self.index_mode {
+        let block_progressed = match &self.index_mode {
             IndexMode::Sequence => {
                 if let Some(missing_sequences) = self.update_sequence_range(
                     logs,
@@ -663,9 +737,20 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> ContractSyncCursor<T>
                 } else {
                     self.clear_sequence_gap_retry();
                 }
+                false
             }
             IndexMode::Block => {
                 self.update_block_range(logs, &all_log_sequences, range, current_indexing_snapshot)?
+            }
+        };
+
+        // Stored logs already restore their sequence and block via skip_indexed.
+        // Only empty ranges need a separate durable checkpoint.
+        if matches!(self.index_mode, IndexMode::Block) {
+            if block_progressed && logs_are_empty {
+                self.persist_progress(false).await?;
+            } else if !block_progressed {
+                self.persist_rewind().await?;
             }
         }
 
@@ -727,6 +812,7 @@ mod test {
             latest_sequence_querier,
             lowest_block_height_or_sequence,
             store: db,
+            persisted_progress: None,
             current_sequence_count: INITIAL_SEQUENCE_COUNT,
             start_block: INITIAL_START_BLOCK,
             index_mode: mode,
@@ -803,6 +889,30 @@ mod test {
                     sequence: Some(97),
                     at_block: 970,
                 }
+            );
+        }
+
+        #[tokio::test]
+        async fn restores_and_checkpoints_empty_block_progress() {
+            let mut cursor = get_cursor().await;
+            cursor.persisted_progress = Some(BackwardCursorProgress {
+                sequence: INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence,
+                block: 850,
+            });
+
+            assert_eq!(cursor.get_next_range().await.unwrap(), Some(750..=850));
+
+            cursor.persisted_progress = None;
+            cursor
+                .update(Vec::new(), 750..=850)
+                .await
+                .expect("checkpoint empty range");
+            assert_eq!(
+                cursor.persisted_progress,
+                Some(BackwardCursorProgress {
+                    sequence: INITIAL_CURRENT_INDEXING_SNAPSHOT.sequence,
+                    block: 749,
+                })
             );
         }
 
@@ -1079,6 +1189,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: LOWEST_BLOCK_HEIGHT,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: INITIAL_SEQUENCE_COUNT,
                 start_block: INITIAL_START_BLOCK,
                 index_mode: INDEX_MODE,
@@ -1228,6 +1339,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_block_height,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: 1,
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -1265,6 +1377,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_block_height,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: 1,
                 start_block: 1000, // Below lowest_block_height
                 index_mode: INDEX_MODE,
@@ -1302,6 +1415,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_block_height,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: 2,
                 start_block: 1001,
                 index_mode: INDEX_MODE,
@@ -2014,6 +2128,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_sequence,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: 1,
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -2051,6 +2166,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_sequence,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: 1, // sequence 0, below lowest
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -2088,6 +2204,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence: lowest_sequence,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: 2, // sequences 0 and 1
                 start_block: 1000,
                 index_mode: INDEX_MODE,
@@ -2126,6 +2243,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: latest_sequence_count,
                 start_block: latest_tip,
                 index_mode: IndexMode::Block,
@@ -2204,6 +2322,7 @@ mod test {
                 latest_sequence_querier,
                 lowest_block_height_or_sequence,
                 store: db,
+                persisted_progress: None,
                 current_sequence_count: latest_sequence_count,
                 start_block: latest_tip,
                 index_mode: IndexMode::Sequence,

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/forward.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/forward.rs
@@ -13,7 +13,7 @@ use tracing::{debug, instrument, warn};
 
 use hyperlane_core::{
     indexed_to_sequence_indexed_array, ContractSyncCursor, CursorAction, HyperlaneDomain,
-    HyperlaneSequenceAwareIndexerStoreReader, IndexMode, Indexed, LogMeta, SequenceAwareIndexer,
+    HyperlaneSequenceAwareIndexerStore, IndexMode, Indexed, LogMeta, SequenceAwareIndexer,
     SequenceIndexed,
 };
 
@@ -32,7 +32,7 @@ pub(crate) struct ForwardSequenceAwareSyncCursor<T> {
     /// establish targets to index towards.
     latest_sequence_querier: Arc<dyn SequenceAwareIndexer<T>>,
     /// A store used to check which logs have already been indexed.
-    store: Arc<dyn HyperlaneSequenceAwareIndexerStoreReader<T>>,
+    store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
     /// A snapshot of the last indexed log, or if no indexing has occurred yet,
     /// the initial log to start indexing forward from.
     last_indexed_snapshot: LastIndexedSnapshot,
@@ -71,7 +71,7 @@ impl<T: Debug + Clone + Sync + Send + Indexable + 'static> ForwardSequenceAwareS
     pub fn new(
         chunk_size: u32,
         latest_sequence_querier: Arc<dyn SequenceAwareIndexer<T>>,
-        store: Arc<dyn HyperlaneSequenceAwareIndexerStoreReader<T>>,
+        store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
         next_sequence: u32,
         start_block: u32,
         index_mode: IndexMode,
@@ -532,7 +532,8 @@ impl<T: Send + Sync + Clone + Debug + Indexable + 'static> ContractSyncCursor<T>
 pub(crate) mod test {
     use derive_new::new;
     use hyperlane_core::{
-        ChainResult, HyperlaneDomainProtocol, HyperlaneLogStore, Indexed, Indexer, Sequenced,
+        ChainResult, HyperlaneDomainProtocol, HyperlaneLogStore,
+        HyperlaneSequenceAwareIndexerStoreReader, Indexed, Indexer, Sequenced,
     };
 
     use crate::cursors::CursorType;
@@ -607,6 +608,32 @@ pub(crate) mod test {
                 .iter()
                 .find(|(log, _)| log.sequence() == Some(sequence))
                 .map(|(_, meta)| meta.block_number))
+        }
+    }
+
+    #[async_trait]
+    impl<T: Sequenced + Debug + Clone + Send + Sync + Indexable + 'static>
+        hyperlane_core::HyperlaneBackwardCursorStore<T>
+        for MockHyperlaneSequenceAwareIndexerStore<T>
+    {
+        async fn retrieve_backward_cursor(
+            &self,
+        ) -> eyre::Result<Option<hyperlane_core::BackwardCursorProgress>> {
+            Ok(None)
+        }
+
+        async fn store_backward_cursor(
+            &self,
+            _progress: hyperlane_core::BackwardCursorProgress,
+        ) -> eyre::Result<()> {
+            Ok(())
+        }
+
+        async fn reset_backward_cursor(
+            &self,
+            _progress: hyperlane_core::BackwardCursorProgress,
+        ) -> eyre::Result<()> {
+            Ok(())
         }
     }
 

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/forward.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/forward.rs
@@ -616,10 +616,10 @@ pub(crate) mod test {
         hyperlane_core::HyperlaneBackwardCursorStore<T>
         for MockHyperlaneSequenceAwareIndexerStore<T>
     {
-        async fn retrieve_backward_cursor(
+        async fn retrieve_backward_cursors(
             &self,
-        ) -> eyre::Result<Option<hyperlane_core::BackwardCursorProgress>> {
-            Ok(None)
+        ) -> eyre::Result<Vec<hyperlane_core::BackwardCursorProgress>> {
+            Ok(Vec::new())
         }
 
         async fn store_backward_cursor(
@@ -633,6 +633,10 @@ pub(crate) mod test {
             &self,
             _progress: hyperlane_core::BackwardCursorProgress,
         ) -> eyre::Result<()> {
+            Ok(())
+        }
+
+        async fn delete_backward_cursor(&self, _sequence: u32) -> eyre::Result<()> {
             Ok(())
         }
     }

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/mod.rs
@@ -118,9 +118,9 @@ impl<T: Debug + Indexable + Clone + Sync + Send + 'static>
         );
 
         let persisted_progress = if matches!(mode, IndexMode::Block) {
-            store.retrieve_backward_cursor().await?
+            store.retrieve_backward_cursors().await?
         } else {
-            None
+            Vec::new()
         };
         let params = BackwardSequenceAwareSyncCursorParams {
             chunk_size,
@@ -218,9 +218,10 @@ mod tests {
 
         #[async_trait::async_trait]
         impl<T: Indexable + Send + Sync> HyperlaneBackwardCursorStore<T> for Db<T> {
-            async fn retrieve_backward_cursor(&self) -> eyre::Result<Option<BackwardCursorProgress>>;
+            async fn retrieve_backward_cursors(&self) -> eyre::Result<Vec<BackwardCursorProgress>>;
             async fn store_backward_cursor(&self, progress: BackwardCursorProgress) -> eyre::Result<()>;
             async fn reset_backward_cursor(&self, progress: BackwardCursorProgress) -> eyre::Result<()>;
+            async fn delete_backward_cursor(&self, sequence: u32) -> eyre::Result<()>;
         }
     }
 
@@ -353,9 +354,9 @@ mod tests {
         let mut store = MockDb::new();
         store.expect_retrieve_by_sequence().returning(|_| Ok(None));
         store
-            .expect_retrieve_backward_cursor()
+            .expect_retrieve_backward_cursors()
             .once()
-            .return_once(move || Ok(Some(progress)));
+            .return_once(move || Ok(vec![progress]));
 
         let mut cursor = ForwardBackwardSequenceAwareSyncCursor::new(
             &domain,

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/sequence_aware/mod.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 
 use hyperlane_core::{
     ChainCommunicationError, ContractSyncCursor, CursorAction, HyperlaneDomain,
-    HyperlaneSequenceAwareIndexerStoreReader, IndexMode, Indexed, LogMeta, SequenceAwareIndexer,
+    HyperlaneSequenceAwareIndexerStore, IndexMode, Indexed, LogMeta, SequenceAwareIndexer,
 };
 
 mod backward;
@@ -91,7 +91,7 @@ impl<T: Debug + Indexable + Clone + Sync + Send + 'static>
         domain: &HyperlaneDomain,
         metrics: Arc<CursorMetrics>,
         latest_sequence_querier: Arc<dyn SequenceAwareIndexer<T>>,
-        store: Arc<dyn HyperlaneSequenceAwareIndexerStoreReader<T>>,
+        store: Arc<dyn HyperlaneSequenceAwareIndexerStore<T>>,
         chunk_size: u32,
         lowest_block_height_or_sequence: i64,
         mode: IndexMode,
@@ -117,10 +117,16 @@ impl<T: Debug + Indexable + Clone + Sync + Send + 'static>
             metrics_data.clone(),
         );
 
+        let persisted_progress = if matches!(mode, IndexMode::Block) {
+            store.retrieve_backward_cursor().await?
+        } else {
+            None
+        };
         let params = BackwardSequenceAwareSyncCursorParams {
             chunk_size,
             latest_sequence_querier: latest_sequence_querier.clone(),
             lowest_block_height_or_sequence,
+            persisted_progress,
             store,
             current_sequence_count: sequence_count,
             start_block: tip,
@@ -178,9 +184,10 @@ mod tests {
     use std::{fmt::Debug, ops::RangeInclusive, sync::Arc, time::Duration};
 
     use hyperlane_core::{
-        ChainResult, HyperlaneDomain, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader,
-        HyperlaneWatermarkedLogStore, IndexMode, Indexed, Indexer, KnownHyperlaneDomain, LogMeta,
-        SequenceAwareIndexer, H256, H512,
+        BackwardCursorProgress, ChainResult, HyperlaneBackwardCursorStore, HyperlaneDomain,
+        HyperlaneLogStore, HyperlaneSequenceAwareIndexerStore,
+        HyperlaneSequenceAwareIndexerStoreReader, HyperlaneWatermarkedLogStore, IndexMode, Indexed,
+        Indexer, KnownHyperlaneDomain, LogMeta, SequenceAwareIndexer, H256, H512,
     };
 
     use crate::cursors::{CursorMetrics, ForwardBackwardSequenceAwareSyncCursor, Indexable};
@@ -207,6 +214,13 @@ mod tests {
         impl<T: Indexable + Send + Sync> HyperlaneSequenceAwareIndexerStoreReader<T> for Db<T> {
             async fn retrieve_by_sequence(&self, sequence: u32) -> eyre::Result<Option<T>>;
             async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> eyre::Result<Option<u64>>;
+        }
+
+        #[async_trait::async_trait]
+        impl<T: Indexable + Send + Sync> HyperlaneBackwardCursorStore<T> for Db<T> {
+            async fn retrieve_backward_cursor(&self) -> eyre::Result<Option<BackwardCursorProgress>>;
+            async fn store_backward_cursor(&self, progress: BackwardCursorProgress) -> eyre::Result<()>;
+            async fn reset_backward_cursor(&self, progress: BackwardCursorProgress) -> eyre::Result<()>;
         }
     }
 
@@ -285,7 +299,7 @@ mod tests {
 
         let metrics = mock_cursor_metrics();
 
-        let mut sequencer = MockSequenceAwareIndexerMock::new();
+        let mut sequencer = MockSequenceAwareIndexerMock::<H256>::new();
 
         sequencer
             .expect_latest_sequence_count_and_tip()
@@ -303,7 +317,7 @@ mod tests {
         let lowest_block_height_or_sequence: i64 = -10;
         let mode = IndexMode::Sequence;
 
-        let store_arc: Arc<dyn HyperlaneSequenceAwareIndexerStoreReader<H256>> = Arc::new(store);
+        let store_arc: Arc<dyn HyperlaneSequenceAwareIndexerStore<H256>> = Arc::new(store);
 
         let cursor = ForwardBackwardSequenceAwareSyncCursor::new(
             &domain,
@@ -321,6 +335,44 @@ mod tests {
         assert_eq!(
             cursor.backward.lowest_block_height_or_sequence,
             lowest_block_height_or_sequence
+        );
+    }
+
+    #[tokio::test]
+    async fn restores_backward_block_progress() {
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let mut sequencer = MockSequenceAwareIndexerMock::<H256>::new();
+        sequencer
+            .expect_latest_sequence_count_and_tip()
+            .returning(|| Ok((Some(100), 1_000)));
+
+        let progress = BackwardCursorProgress {
+            sequence: 99,
+            block: 500,
+        };
+        let mut store = MockDb::new();
+        store.expect_retrieve_by_sequence().returning(|_| Ok(None));
+        store
+            .expect_retrieve_backward_cursor()
+            .once()
+            .return_once(move || Ok(Some(progress)));
+
+        let mut cursor = ForwardBackwardSequenceAwareSyncCursor::new(
+            &domain,
+            Arc::new(mock_cursor_metrics()),
+            Arc::new(sequencer),
+            Arc::new(store),
+            20,
+            0,
+            IndexMode::Block,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("restore backward cursor");
+
+        assert_eq!(
+            cursor.backward.get_next_range().await.unwrap(),
+            Some(480..=500)
         );
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -5,10 +5,11 @@ use eyre::{bail, Result};
 use tracing::{debug, instrument, trace};
 
 use hyperlane_core::{
-    identifiers::UniqueIdentifier, Decode, Encode, GasPaymentKey, HyperlaneDomain,
-    HyperlaneLogStore, HyperlaneMessage, HyperlaneSequenceAwareIndexerStoreReader,
-    HyperlaneWatermarkedLogStore, Indexed, InterchainGasExpenditure, InterchainGasPayment,
-    InterchainGasPaymentMeta, LogMeta, MerkleTreeInsertion, PendingOperationStatus, H256, H512,
+    identifiers::UniqueIdentifier, BackwardCursorProgress, Decode, Encode, GasPaymentKey,
+    HyperlaneBackwardCursorStore, HyperlaneDomain, HyperlaneLogStore, HyperlaneMessage,
+    HyperlaneSequenceAwareIndexerStoreReader, HyperlaneWatermarkedLogStore, Indexed,
+    InterchainGasExpenditure, InterchainGasPayment, InterchainGasPaymentMeta, LogMeta,
+    MerkleTreeInsertion, PendingOperationStatus, H256, H512,
 };
 
 use crate::db::{
@@ -47,6 +48,9 @@ const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
 const LATEST_INDEXED_GAS_PAYMENT_BLOCK: &str = "latest_indexed_gas_payment_block";
 const PAYLOAD_UUIDS_BY_MESSAGE_ID: &str = "payload_uuids_by_message_id_";
 const MESSAGE_DISPATCHED_TX_HASH_BY_MESSAGE_ID: &str = "message_dispatched_tx_hash_by_message_id_";
+const MESSAGE_BACKWARD_CURSOR: &str = "message_backward_cursor_v1";
+const GAS_PAYMENT_BACKWARD_CURSOR: &str = "gas_payment_backward_cursor_v1";
+const MERKLE_TREE_INSERTION_BACKWARD_CURSOR: &str = "merkle_tree_insertion_backward_cursor_v1";
 
 /// Rocks DB result type
 pub type DbResult<T> = std::result::Result<T, DbError>;
@@ -84,6 +88,21 @@ impl HyperlaneRocksDB {
     /// Get the domain this database is scoped to
     pub fn domain(&self) -> &HyperlaneDomain {
         &self.0
+    }
+
+    fn retrieve_backward_cursor_progress(
+        &self,
+        key: &str,
+    ) -> Result<Option<BackwardCursorProgress>> {
+        Ok(self.retrieve_decodable("", key)?)
+    }
+
+    fn store_backward_cursor_progress(
+        &self,
+        key: &str,
+        progress: BackwardCursorProgress,
+    ) -> Result<()> {
+        Ok(self.store_encodable("", key, &progress)?)
     }
 
     /// Store a raw committed message. If message already exists, then do nothing.
@@ -650,6 +669,29 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneRoc
         Ok(number)
     }
 }
+
+macro_rules! impl_backward_cursor_store {
+    ($event:ty, $key:expr) => {
+        #[async_trait]
+        impl HyperlaneBackwardCursorStore<$event> for HyperlaneRocksDB {
+            async fn retrieve_backward_cursor(&self) -> Result<Option<BackwardCursorProgress>> {
+                self.retrieve_backward_cursor_progress($key)
+            }
+
+            async fn store_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()> {
+                self.store_backward_cursor_progress($key, progress)
+            }
+
+            async fn reset_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()> {
+                self.store_backward_cursor_progress($key, progress)
+            }
+        }
+    };
+}
+
+impl_backward_cursor_store!(HyperlaneMessage, MESSAGE_BACKWARD_CURSOR);
+impl_backward_cursor_store!(InterchainGasPayment, GAS_PAYMENT_BACKWARD_CURSOR);
+impl_backward_cursor_store!(MerkleTreeInsertion, MERKLE_TREE_INSERTION_BACKWARD_CURSOR);
 
 #[async_trait]
 impl HyperlaneSequenceAwareIndexerStoreReader<MerkleTreeInsertion> for HyperlaneRocksDB {

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -48,9 +48,9 @@ const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
 const LATEST_INDEXED_GAS_PAYMENT_BLOCK: &str = "latest_indexed_gas_payment_block";
 const PAYLOAD_UUIDS_BY_MESSAGE_ID: &str = "payload_uuids_by_message_id_";
 const MESSAGE_DISPATCHED_TX_HASH_BY_MESSAGE_ID: &str = "message_dispatched_tx_hash_by_message_id_";
-const MESSAGE_BACKWARD_CURSOR: &str = "message_backward_cursor_v1";
-const GAS_PAYMENT_BACKWARD_CURSOR: &str = "gas_payment_backward_cursor_v1";
-const MERKLE_TREE_INSERTION_BACKWARD_CURSOR: &str = "merkle_tree_insertion_backward_cursor_v1";
+const MESSAGE_BACKWARD_CURSOR: &str = "message_backward_cursor_v2_";
+const GAS_PAYMENT_BACKWARD_CURSOR: &str = "gas_payment_backward_cursor_v2_";
+const MERKLE_TREE_INSERTION_BACKWARD_CURSOR: &str = "merkle_tree_insertion_backward_cursor_v2_";
 
 /// Rocks DB result type
 pub type DbResult<T> = std::result::Result<T, DbError>;
@@ -92,17 +92,23 @@ impl HyperlaneRocksDB {
 
     fn retrieve_backward_cursor_progress(
         &self,
-        key: &str,
-    ) -> Result<Option<BackwardCursorProgress>> {
-        Ok(self.retrieve_decodable("", key)?)
+        prefix: &str,
+    ) -> Result<Vec<BackwardCursorProgress>> {
+        Ok(self.retrieve_decodables_by_prefix(prefix)?)
     }
 
     fn store_backward_cursor_progress(
         &self,
-        key: &str,
+        prefix: &str,
         progress: BackwardCursorProgress,
     ) -> Result<()> {
-        Ok(self.store_encodable("", key, &progress)?)
+        Ok(self.store_keyed_encodable(prefix, &progress.sequence, &progress)?)
+    }
+
+    fn delete_backward_cursor_progress(&self, prefix: &str, sequence: u32) -> Result<()> {
+        let mut batch = self.1.batch();
+        batch.delete_keyed(prefix, &sequence);
+        Ok(batch.commit()?)
     }
 
     /// Store a raw committed message. If message already exists, then do nothing.
@@ -674,7 +680,7 @@ macro_rules! impl_backward_cursor_store {
     ($event:ty, $key:expr) => {
         #[async_trait]
         impl HyperlaneBackwardCursorStore<$event> for HyperlaneRocksDB {
-            async fn retrieve_backward_cursor(&self) -> Result<Option<BackwardCursorProgress>> {
+            async fn retrieve_backward_cursors(&self) -> Result<Vec<BackwardCursorProgress>> {
                 self.retrieve_backward_cursor_progress($key)
             }
 
@@ -684,6 +690,10 @@ macro_rules! impl_backward_cursor_store {
 
             async fn reset_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()> {
                 self.store_backward_cursor_progress($key, progress)
+            }
+
+            async fn delete_backward_cursor(&self, sequence: u32) -> Result<()> {
+                self.delete_backward_cursor_progress($key, sequence)
             }
         }
     };

--- a/rust/main/hyperlane-base/src/db/rocks/test_utils.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/test_utils.rs
@@ -141,6 +141,10 @@ mod test {
             sequence: 12,
             block: 34,
         };
+        let newer_message_progress = BackwardCursorProgress {
+            sequence: 90,
+            block: 123,
+        };
         let payment_progress = BackwardCursorProgress {
             sequence: 56,
             block: 78,
@@ -151,6 +155,12 @@ mod test {
             HyperlaneBackwardCursorStore::<HyperlaneMessage>::store_backward_cursor(
                 &store,
                 message_progress,
+            )
+            .await
+            .unwrap();
+            HyperlaneBackwardCursorStore::<HyperlaneMessage>::store_backward_cursor(
+                &store,
+                newer_message_progress,
             )
             .await
             .unwrap();
@@ -167,29 +177,43 @@ mod test {
 
         {
             let reopened = HyperlaneRocksDB::new(&domain, setup_db(db_path));
+            let message_cursors =
+                HyperlaneBackwardCursorStore::<HyperlaneMessage>::retrieve_backward_cursors(
+                    &reopened,
+                )
+                .await
+                .unwrap();
+            assert!(message_cursors.contains(&message_progress));
+            assert!(message_cursors.contains(&newer_message_progress));
             assert_eq!(
-                HyperlaneBackwardCursorStore::<HyperlaneMessage>::retrieve_backward_cursor(
+                HyperlaneBackwardCursorStore::<InterchainGasPayment>::retrieve_backward_cursors(
                     &reopened
                 )
                 .await
                 .unwrap(),
-                Some(message_progress)
+                vec![payment_progress]
             );
             assert_eq!(
-                HyperlaneBackwardCursorStore::<InterchainGasPayment>::retrieve_backward_cursor(
+                HyperlaneBackwardCursorStore::<MerkleTreeInsertion>::retrieve_backward_cursors(
                     &reopened
                 )
                 .await
                 .unwrap(),
-                Some(payment_progress)
+                Vec::new()
             );
+            HyperlaneBackwardCursorStore::<HyperlaneMessage>::delete_backward_cursor(
+                &reopened,
+                message_progress.sequence,
+            )
+            .await
+            .unwrap();
             assert_eq!(
-                HyperlaneBackwardCursorStore::<MerkleTreeInsertion>::retrieve_backward_cursor(
+                HyperlaneBackwardCursorStore::<HyperlaneMessage>::retrieve_backward_cursors(
                     &reopened
                 )
                 .await
                 .unwrap(),
-                None
+                vec![newer_message_progress]
             );
         }
         let _ = rocksdb::DB::destroy(&Options::default(), db_tmp_dir);

--- a/rust/main/hyperlane-base/src/db/rocks/test_utils.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/test_utils.rs
@@ -37,7 +37,8 @@ where
 #[cfg(test)]
 mod test {
     use hyperlane_core::{
-        HyperlaneDomain, HyperlaneLogStore, HyperlaneMessage, Indexed, LogMeta,
+        BackwardCursorProgress, HyperlaneBackwardCursorStore, HyperlaneDomain, HyperlaneLogStore,
+        HyperlaneMessage, Indexed, InterchainGasPayment, LogMeta, MerkleTreeInsertion,
         RawHyperlaneMessage, H256, H512, U256,
     };
 
@@ -122,5 +123,75 @@ mod test {
             assert_eq!(retrieved, tx_hash);
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn backward_cursors_are_durable_and_event_specific() {
+        // Manage our own temporary path so the database can be dropped and
+        // genuinely reopened from disk, proving cursor durability. Wrapping
+        // the still-open handle would not exercise the reload path.
+        let db_tmp_dir = TempDir::new().expect("Failed to create tempdir");
+        let db_path = db_tmp_dir
+            .path()
+            .to_str()
+            .expect("Failed to create db")
+            .to_owned();
+        let domain = HyperlaneDomain::new_test_domain("backward_cursor_progress");
+        let message_progress = BackwardCursorProgress {
+            sequence: 12,
+            block: 34,
+        };
+        let payment_progress = BackwardCursorProgress {
+            sequence: 56,
+            block: 78,
+        };
+
+        {
+            let store = HyperlaneRocksDB::new(&domain, setup_db(db_path.clone()));
+            HyperlaneBackwardCursorStore::<HyperlaneMessage>::store_backward_cursor(
+                &store,
+                message_progress,
+            )
+            .await
+            .unwrap();
+            HyperlaneBackwardCursorStore::<InterchainGasPayment>::store_backward_cursor(
+                &store,
+                payment_progress,
+            )
+            .await
+            .unwrap();
+            // Drop all handles before reopening so the read below comes
+            // from disk, not the still-open instance.
+            drop(store);
+        }
+
+        {
+            let reopened = HyperlaneRocksDB::new(&domain, setup_db(db_path));
+            assert_eq!(
+                HyperlaneBackwardCursorStore::<HyperlaneMessage>::retrieve_backward_cursor(
+                    &reopened
+                )
+                .await
+                .unwrap(),
+                Some(message_progress)
+            );
+            assert_eq!(
+                HyperlaneBackwardCursorStore::<InterchainGasPayment>::retrieve_backward_cursor(
+                    &reopened
+                )
+                .await
+                .unwrap(),
+                Some(payment_progress)
+            );
+            assert_eq!(
+                HyperlaneBackwardCursorStore::<MerkleTreeInsertion>::retrieve_backward_cursor(
+                    &reopened
+                )
+                .await
+                .unwrap(),
+                None
+            );
+        }
+        let _ = rocksdb::DB::destroy(&Options::default(), db_tmp_dir);
     }
 }

--- a/rust/main/hyperlane-base/src/settings/base.rs
+++ b/rust/main/hyperlane-base/src/settings/base.rs
@@ -4,7 +4,7 @@ use eyre::{eyre, Context, Result};
 use futures_util::future::join_all;
 
 use hyperlane_core::{
-    HyperlaneDomain, HyperlaneLogStore, HyperlaneProvider,
+    HyperlaneBackwardCursorStore, HyperlaneDomain, HyperlaneLogStore, HyperlaneProvider,
     HyperlaneSequenceAwareIndexerStoreReader, HyperlaneWatermarkedLogStore, InterchainGasPaymaster,
     MerkleTreeHook, MultisigIsm, SequenceAwareIndexer, ValidatorAnnounce, H256,
 };
@@ -168,7 +168,10 @@ impl Settings {
     where
         T: Indexable + Debug,
         SequenceIndexer<T>: TryFromWithMetrics<ChainConf>,
-        S: HyperlaneLogStore<T> + HyperlaneSequenceAwareIndexerStoreReader<T> + 'static,
+        S: HyperlaneLogStore<T>
+            + HyperlaneSequenceAwareIndexerStoreReader<T>
+            + HyperlaneBackwardCursorStore<T>
+            + 'static,
     {
         let setup = self.chain_setup(domain)?;
         // Currently, all indexers are of the `SequenceIndexer` type
@@ -227,6 +230,7 @@ impl Settings {
         SequenceIndexer<T>: TryFromWithMetrics<ChainConf>,
         S: HyperlaneLogStore<T>
             + HyperlaneSequenceAwareIndexerStoreReader<T>
+            + HyperlaneBackwardCursorStore<T>
             + HyperlaneWatermarkedLogStore<T>
             + 'static,
     {
@@ -265,6 +269,7 @@ impl Settings {
         SequenceIndexer<T>: TryFromWithMetrics<ChainConf>,
         S: HyperlaneLogStore<T>
             + HyperlaneSequenceAwareIndexerStoreReader<T>
+            + HyperlaneBackwardCursorStore<T>
             + HyperlaneWatermarkedLogStore<T>
             + 'static,
     {

--- a/rust/main/hyperlane-core/src/traits/db.rs
+++ b/rust/main/hyperlane-core/src/traits/db.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use auto_impl::auto_impl;
 use eyre::Result;
 
-use crate::{Indexed, LogMeta};
+use crate::{Decode, Encode, HyperlaneProtocolError, Indexed, LogMeta};
 
 /// Interface for a HyperlaneLogStore that ingests logs.
 #[async_trait]
@@ -34,16 +34,70 @@ pub trait HyperlaneSequenceAwareIndexerStoreReader<T>: Send + Sync + Debug {
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>>;
 }
 
+/// Durable progress for a backwards block-mode sequence-aware cursor.
+///
+/// Both fields are required: the block is only meaningful for the sequence the
+/// cursor was searching for when it completed that block range.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BackwardCursorProgress {
+    /// The next sequence the backwards cursor is searching for.
+    pub sequence: u32,
+    /// The next block at or below which the cursor should resume searching.
+    pub block: u32,
+}
+
+impl Encode for BackwardCursorProgress {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: std::io::Write,
+    {
+        self.sequence.write_to(writer)?;
+        self.block.write_to(writer)?;
+        Ok(8)
+    }
+}
+
+impl Decode for BackwardCursorProgress {
+    fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+    where
+        R: std::io::Read,
+    {
+        Ok(Self {
+            sequence: u32::read_from(reader)?,
+            block: u32::read_from(reader)?,
+        })
+    }
+}
+
+/// Store for direction- and event-specific backwards cursor progress.
+#[async_trait]
+#[auto_impl(&, Box, Arc)]
+pub trait HyperlaneBackwardCursorStore<T>: Send + Sync + Debug {
+    /// Retrieves the last durable backwards cursor position.
+    async fn retrieve_backward_cursor(&self) -> Result<Option<BackwardCursorProgress>>;
+
+    /// Stores a durable backwards cursor position.
+    async fn store_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()>;
+
+    /// Resets progress to an earlier position after the cursor detects a gap.
+    async fn reset_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()>;
+}
+
 /// Extension of HyperlaneLogStore trait for sequence-aware indexer stores.
 #[async_trait]
 pub trait HyperlaneSequenceAwareIndexerStore<T>:
-    HyperlaneLogStore<T> + HyperlaneSequenceAwareIndexerStoreReader<T>
+    HyperlaneLogStore<T> + HyperlaneSequenceAwareIndexerStoreReader<T> + HyperlaneBackwardCursorStore<T>
 {
 }
 
 /// Auto-impl for HyperlaneSequenceAwareIndexerStore
 impl<T, S> HyperlaneSequenceAwareIndexerStore<T> for S where
-    S: HyperlaneLogStore<T> + HyperlaneSequenceAwareIndexerStoreReader<T> + Send + Sync + Debug
+    S: HyperlaneLogStore<T>
+        + HyperlaneSequenceAwareIndexerStoreReader<T>
+        + HyperlaneBackwardCursorStore<T>
+        + Send
+        + Sync
+        + Debug
 {
 }
 

--- a/rust/main/hyperlane-core/src/traits/db.rs
+++ b/rust/main/hyperlane-core/src/traits/db.rs
@@ -73,14 +73,17 @@ impl Decode for BackwardCursorProgress {
 #[async_trait]
 #[auto_impl(&, Box, Arc)]
 pub trait HyperlaneBackwardCursorStore<T>: Send + Sync + Debug {
-    /// Retrieves the last durable backwards cursor position.
-    async fn retrieve_backward_cursor(&self) -> Result<Option<BackwardCursorProgress>>;
+    /// Retrieves all durable backwards cursor positions.
+    async fn retrieve_backward_cursors(&self) -> Result<Vec<BackwardCursorProgress>>;
 
     /// Stores a durable backwards cursor position.
     async fn store_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()>;
 
     /// Resets progress to an earlier position after the cursor detects a gap.
     async fn reset_backward_cursor(&self, progress: BackwardCursorProgress) -> Result<()>;
+
+    /// Removes progress after the corresponding sequence has been indexed.
+    async fn delete_backward_cursor(&self, sequence: u32) -> Result<()>;
 }
 
 /// Extension of HyperlaneLogStore trait for sequence-aware indexer stores.


### PR DESCRIPTION
## Stack

Stacks on #9323 and carries the durable relayer/scraper restart fix.

## Summary

- persist the exact missing sequence and next block for backward block-mode cursors
- restore relayer progress from event-specific RocksDB keys
- restore scraper progress from event-specific rows in the existing SQL cursor table
- checkpoint sparse empty ranges every 1,000 blocks and at the configured boundary
- keep normal SQL checkpoints monotonic during rolling overlap, while durably resetting after a detected sequence gap

## Why

This is the durable follow-up to #9323. The deployment guard limits RC backfills, but a restart could still discard progress through sparse empty block ranges and rescan from the chain tip. Celestia made that especially expensive because its event tail is sparse relative to block production.

## Validation

- cargo check -p hyperlane-core -p hyperlane-base -p scraper -p relayer
- cargo clippy -p hyperlane-core -p hyperlane-base -p scraper -p relayer -- -D warnings
- cargo test -p hyperlane-base backward --lib (25 passed)
- cargo test -p scraper backward_cursors_are_durable_and_event_specific -- --nocapture (real PostgreSQL; passed)
- cargo fmt --all -- --check

## Notes

No scraper schema migration is needed: the existing unique domain/event_type cursor table stores the pair atomically in one signed bigint row.