### PR TITLE
feat(infra): blacklist NES warp route on mainnet3 relayer

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -752,6 +752,8 @@ const blacklist: MatchingList = [
     originDomain: getDomainId('starknet'),
     destinationDomain: getDomainId('starknet'),
   },
+  // NES warp route paused - blacklisted pending on-chain route pause
+  ...warpRouteMatchingList(WarpRouteIds.BscNES),
 ];
 
 const ismCacheConfigs: Array<IsmCacheConfig> = [


### PR DESCRIPTION
## Summary
- Adds the `NES/bsc` warp route to the mainnet3 relayer `blacklist` via `warpRouteMatchingList(WarpRouteIds.BscNES)`.
- Stops the relayer from delivering NES warp-route messages in **both directions across all 7 legs** (nesa, ethereum, arbitrum, base, bsc, hyperevm, solanamainnet) — 42 directional matcher entries.
- Immediate operational stopgap requested by @Troy to pause Nesa, pending an on-chain pause of the route.

## Notes
- No changeset (typescript/infra is not published).
- Messages will queue but not be delivered; fully reversible by removing the entry.
- **Takes effect only after this is merged and the mainnet3 relayer is redeployed with the new config.**

## Test plan
- [x] `warpRouteMatchingList(WarpRouteIds.BscNES)` resolves against the registry → 42 entries, correct router addresses.
- [x] Pre-commit lint/format + secret scan pass.
- [ ] Merge + relayer redeploy to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)