### PR TITLE
fix(sdk): respect pausable ISM state

### DIFF
--- a/.changeset/fix-pausable-ism-state.md
+++ b/.changeset/fix-pausable-ism-state.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-Pausable ISM deployments respected their configured initial state, and signer-owned state changes were applied directly.
+Pausable ISMs now respect the configured `paused` state. Signer-owned changes are applied directly; all others are returned as transactions.

--- a/.changeset/fix-pausable-ism-state.md
+++ b/.changeset/fix-pausable-ism-state.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Pausable ISM deployments respected their configured initial state, and signer-owned state changes were applied directly.

--- a/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.hardhat-test.ts
@@ -11,6 +11,7 @@ import {
   DelayedFlowRouterHookIsm__factory,
   HypERC20__factory,
   NetFlowRateLimitedHookIsm__factory,
+  PausableIsm__factory,
   RateLimitedIsm__factory,
   StaticAggregationIsm__factory,
   TestLegacyBlacklistIsm__factory,
@@ -57,6 +58,7 @@ import {
   ModuleType,
   MultisigIsmConfig,
   NetFlowRateLimitedHookIsmConfig,
+  PausableIsmConfig,
   RateLimitedIsmConfig,
   RoutingIsmConfig,
   TrustedRelayerIsmConfig,
@@ -501,6 +503,55 @@ describe('EvmIsmModule', async () => {
   });
 
   describe('update', async () => {
+    it('applies a pausable state change when the signer is the owner', async () => {
+      const config: PausableIsmConfig = {
+        type: IsmType.PAUSABLE,
+        owner: await multiProvider.getSignerAddress(chain),
+        paused: false,
+      };
+      const { ism, initialIsmAddress } = await createIsm(config);
+      const pausable = PausableIsm__factory.connect(
+        initialIsmAddress,
+        multiProvider.getProvider(chain),
+      );
+
+      const target = { ...config, paused: true };
+      const txs = await ism.update(target);
+      testConfig = target;
+
+      expect(txs).to.be.empty;
+      expect(await pausable.paused()).to.be.true;
+    });
+
+    it('returns a pausable state change when the signer is not the owner', async () => {
+      const owner = randomAddress();
+      const config: PausableIsmConfig = {
+        type: IsmType.PAUSABLE,
+        owner,
+        paused: false,
+      };
+      const { ism, initialIsmAddress } = await createIsm(config);
+      const pausable = PausableIsm__factory.connect(
+        initialIsmAddress,
+        multiProvider.getProvider(chain),
+      );
+
+      const target = { ...config, paused: true };
+      const txs = await ism.update(target);
+
+      expect(txs).to.have.length(1);
+      expect(txs[0].to).to.equal(initialIsmAddress);
+      expect(txs[0].data).to.equal(
+        PausableIsm__factory.createInterface().encodeFunctionData('pause'),
+      );
+      expect(await pausable.paused()).to.be.false;
+
+      const ownerMultiProvider = await impersonateAccount(owner);
+      await ownerMultiProvider.sendTransaction(chain, txs[0]);
+      testConfig = target;
+      expect(await pausable.paused()).to.be.true;
+    });
+
     for (const type of [IsmType.ROUTING, IsmType.FALLBACK_ROUTING]) {
       beforeEach(() => {
         exampleRoutingConfig.type = type;

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -643,7 +643,7 @@ export class EvmIsmModule extends HyperlaneModule<
       ? ismInterface.encodeFunctionData('pause')
       : ismInterface.encodeFunctionData('unpause');
 
-    const tx = {
+    const tx: AnnotatedEV5Transaction = {
       annotation: `${target.paused ? 'Pausing' : 'Unpausing'} Pausable ISM on chain "${this.chain}" and address "${this.args.addresses.deployedIsm}"`,
       chainId: this.multiProvider.getEvmChainId(this.chain),
       to: this.args.addresses.deployedIsm,

--- a/typescript/sdk/src/ism/EvmIsmModule.ts
+++ b/typescript/sdk/src/ism/EvmIsmModule.ts
@@ -460,10 +460,10 @@ export class EvmIsmModule extends HyperlaneModule<
       target.type === IsmType.PAUSABLE
     ) {
       updateTxs.push(
-        ...this.updatePausableIsm({
+        ...(await this.updatePausableIsm({
           current,
           target,
-        }),
+        })),
       );
     } else if (
       current.type === IsmType.OFFCHAIN_LOOKUP &&
@@ -627,13 +627,13 @@ export class EvmIsmModule extends HyperlaneModule<
     return updateTxs;
   }
 
-  protected updatePausableIsm({
+  protected async updatePausableIsm({
     current,
     target,
   }: {
     current: PausableIsmConfig;
     target: PausableIsmConfig;
-  }): AnnotatedEV5Transaction[] {
+  }): Promise<AnnotatedEV5Transaction[]> {
     if (current.paused === target.paused) {
       return [];
     }
@@ -643,14 +643,20 @@ export class EvmIsmModule extends HyperlaneModule<
       ? ismInterface.encodeFunctionData('pause')
       : ismInterface.encodeFunctionData('unpause');
 
-    return [
-      {
-        annotation: `${target.paused ? 'Pausing' : 'Unpausing'} Pausable ISM on chain "${this.chain}" and address "${this.args.addresses.deployedIsm}"`,
-        chainId: this.multiProvider.getEvmChainId(this.chain),
-        to: this.args.addresses.deployedIsm,
-        data,
-      },
-    ];
+    const tx = {
+      annotation: `${target.paused ? 'Pausing' : 'Unpausing'} Pausable ISM on chain "${this.chain}" and address "${this.args.addresses.deployedIsm}"`,
+      chainId: this.multiProvider.getEvmChainId(this.chain),
+      to: this.args.addresses.deployedIsm,
+      data,
+    };
+
+    const signerAddress = await this.multiProvider.getSignerAddress(this.chain);
+    if (eqAddress(signerAddress, current.owner)) {
+      await this.multiProvider.sendTransaction(this.chain, tx);
+      return [];
+    }
+
+    return [tx];
   }
 
   protected updateOffchainLookupIsm({

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.hardhat-test.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.hardhat-test.ts
@@ -651,6 +651,61 @@ describe('HyperlaneIsmFactory', async () => {
     ).to.be.rejectedWith('Warp router address is required');
   });
 
+  it('deploys a pausable ism with the configured initial state and owner', async () => {
+    const owner = randomAddress();
+
+    for (const paused of [false, true]) {
+      const deployed = await ismFactory.deploy({
+        destination: chain,
+        config: {
+          type: IsmType.PAUSABLE,
+          owner,
+          paused,
+        },
+      });
+      const pausable = PausableIsm__factory.connect(
+        deployed.address,
+        multiProvider.getProvider(chain),
+      );
+
+      expect(await pausable.paused()).to.equal(paused);
+      expect((await pausable.owner()).toLowerCase()).to.equal(
+        owner.toLowerCase(),
+      );
+    }
+  });
+
+  it('deploys an aggregation with its pausable submodule initially paused', async () => {
+    const owner = randomAddress();
+    const config: AggregationIsmConfig = {
+      type: IsmType.AGGREGATION,
+      modules: [
+        randomMultisigIsmConfig(3, 5),
+        {
+          type: IsmType.PAUSABLE,
+          owner,
+          paused: true,
+        },
+      ],
+      threshold: 2,
+    };
+
+    const deployed = await ismFactory.deploy({
+      destination: chain,
+      config,
+    });
+
+    expect(
+      await moduleMatchesConfig(
+        chain,
+        deployed.address,
+        config,
+        multiProvider,
+        ismFactory.getContracts(chain),
+      ),
+    ).to.be.true;
+  });
+
   it('recovers an address-bearing pausable ism config', async () => {
     const config: PausableIsmConfig = {
       type: IsmType.PAUSABLE,

--- a/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
+++ b/typescript/sdk/src/ism/HyperlaneIsmFactory.ts
@@ -82,6 +82,7 @@ import {
   IsmConfigSchema,
   IsmType,
   MultisigIsmConfig,
+  PausableIsmConfig,
   RoutingIsmConfig,
   RoutingIsmDelta,
   WeightedMultisigIsmConfig,
@@ -399,9 +400,7 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
               derivedConfig.data.address,
               this.multiProvider.getSignerOrProvider(destination),
             )
-          : await this.deployer.deployContract(destination, IsmType.PAUSABLE, [
-              config.owner,
-            ]);
+          : await this.deployPausableIsm(destination, config);
         break;
       }
       case IsmType.TRUSTED_RELAYER:
@@ -620,6 +619,34 @@ export class HyperlaneIsmFactory extends HyperlaneApp<ProxyFactoryFactories> {
 
     if (blacklistedIds.length > 0) {
       const tx = await contract.blacklist(blacklistedIds, overrides);
+      await this.multiProvider.handleTx(destination, tx);
+    }
+
+    if (!eqAddress(signerAddress, config.owner)) {
+      const tx = await contract.transferOwnership(config.owner, overrides);
+      await this.multiProvider.handleTx(destination, tx);
+    }
+
+    return contract;
+  }
+
+  protected async deployPausableIsm(
+    destination: ChainName,
+    config: PausableIsmConfig,
+  ): Promise<DeployedIsmType[typeof IsmType.PAUSABLE]> {
+    const signer = this.multiProvider.getSigner(destination);
+    const signerAddress = await signer.getAddress();
+    const overrides = this.multiProvider.getTransactionOverrides(destination);
+    const contract = await this.deployer.deployContract(
+      destination,
+      IsmType.PAUSABLE,
+      [signerAddress],
+    );
+
+    // Apply owner-gated state before transferring ownership so fresh ISMs
+    // always match the requested config when this method returns.
+    if (config.paused) {
+      const tx = await contract.pause(overrides);
       await this.multiProvider.handleTx(destination, tx);
     }
 


### PR DESCRIPTION
## Summary

- initialized newly deployed Pausable ISMs in the requested paused state before transferring ownership
- applied pause-state mutations immediately when the configured owner is the active signer
- returned annotated pause/unpause transactions when governance owns the existing ISM
- added deployment and mutation regression coverage plus an SDK changeset

## Behavior

For `paused: true`:

- new ISM: deployer temporarily owns it, pauses it, then transfers ownership
- existing ISM with signer as owner: `pause()` is submitted immediately
- existing ISM with a different owner: the annotated `pause()` transaction is returned for governance execution

The inverse behavior is applied for an existing paused ISM targeting `paused: false`.

## Validation

- `pnpm exec turbo run build --filter=@hyperlane-xyz/sdk...`
- SDK lint
- `NODE_OPTIONS='--import tsx/esm' pnpm -C typescript/sdk exec hardhat --config hardhat.config.cts test src/ism/HyperlaneIsmFactory.hardhat-test.ts src/ism/EvmIsmModule.hardhat-test.ts` — 144 passing
- changeset status and `git diff --check`
