### PR TITLE
chore(infra): bump mainnet3 relayer + RC relayer to 7f119d7 (NES blacklist)

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,8 +43,8 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'a060727-20260821-093506',
-  relayerRC: 'a060727-20260821-093506',
+  relayer: '7f119d7-20260824-154750',
+  relayerRC: '7f119d7-20260824-154750',
   relayerFastPath: '14646bd-20260805-072134',
   validator: 'f0f8a56-20260824-030242',
   validatorRC: '14646bd-20260805-072134',


### PR DESCRIPTION
## Summary
- Pins the mainnet3 **relayer** and **RC relayer** to image `7f119d7-20260824-154750` (`typescript/infra/config/docker.ts`).
- Built from commit `7f119d7` = the merged NES warp-route blacklist (#9326), so the deployed relayers carry the NES/bsc blacklist.

## Notes
- Only `relayer` + `relayerRC` bumped; validator/scraper/fastPath tags unchanged.
- Could not independently verify the tag on GHCR (the CI token lacks package-read scope), but the commit prefix matches #9326 and the tag was provided from the build.
- Takes effect on relayer redeploy.

## Test plan
- [ ] Merge + redeploy mainnet3 relayer and RC relayer
- [ ] Confirm relayers come up on `7f119d7-20260824-154750`

🤖 Generated with [Claude Code](https://claude.com/claude-code)