### PR TITLE
fix(sdk): read xERC20 bridges from the token instead of its events

### DIFF
--- a/.changeset/xerc20-bridge-discovery.md
+++ b/.changeset/xerc20-bridge-discovery.md
@@ -6,4 +6,4 @@ xERC20 bridge discovery reports the bridges a token actually holds limits for. A
 
 `GetExtraLockboxesOptions` gained the optional `warpRouteAddress` and `type`, `EvmEventLogsReader` gained the read-only `getContractDeploymentBlock`, and `deriveXERC20TokenType` throws the new exported `UnknownXERC20TypeError`.
 
-Operators of Standard (non-Velodrome) xERC20 routes must add the token's current `mint` and `burn` to any deploy config that omits `xERC20.warpRouteLimits`, which are now derived and otherwise report a `warp check` violation.
+Operators of Standard (non-Velodrome) xERC20 routes must add the token's current `mint` and `burn` to any deploy config that omits `xERC20.warpRouteLimits`, which are now derived and otherwise report a `warp check` violation. Extra bridges are compared as a set, so listing them in a different order to the token's no longer reports a violation.

--- a/.changeset/xerc20-bridge-discovery.md
+++ b/.changeset/xerc20-bridge-discovery.md
@@ -1,0 +1,9 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+xERC20 bridge discovery reports the bridges a token actually holds limits for. Addresses are still collected from the token's events, but the limits are read from the token, and a bridge is no longer required to answer the lockbox `XERC20()` getter, which had dropped every configured bridge that is not a lockbox. Standard xERC20 tokens are discovered through `BridgeLimitsSet` and read through `mintingMaxLimitOf`/`burningMaxLimitOf`, where before only the Velodrome event and getters were consulted. A failed read is no longer classified as a missing selector, so a transient RPC failure surfaces instead of reporting a token with bridges as having none.
+
+`GetExtraLockboxesOptions` gained the optional `warpRouteAddress` and `type`, `EvmEventLogsReader` gained the read-only `getContractDeploymentBlock`, and `deriveXERC20TokenType` throws the new exported `UnknownXERC20TypeError`.
+
+Operators of Standard (non-Velodrome) xERC20 routes must add the token's current `mint` and `burn` to any deploy config that omits `xERC20.warpRouteLimits`, which are now derived and otherwise report a `warp check` violation.

--- a/typescript/cli/src/tests/ethereum/commands/xerc20.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/commands/xerc20.e2e-test.ts
@@ -57,6 +57,8 @@ describe('xerc20 e2e tests', function () {
   let xERC20Lockbox2: XERC20LockboxTest;
   let xERC20VS2: XERC20VSTest;
   let xERC20VS3: XERC20VSTest;
+  let vsWarpRouteAddress2: Address | undefined;
+  let vsWarpRouteAddress3: Address | undefined;
 
   const XERC20_LOCKBOX_DEPLOY_PATH = `${TEMP_PATH}/warp-xerc20-lockbox-deploy.yaml`;
   const XERC20_VS_DEPLOY_PATH = `${TEMP_PATH}/warp-xerc20-vs-deploy.yaml`;
@@ -158,6 +160,9 @@ describe('xerc20 e2e tests', function () {
   }
 
   async function deployWarpRoutesAndSetupBridges(): Promise<void> {
+    vsWarpRouteAddress2 = undefined;
+    vsWarpRouteAddress3 = undefined;
+
     const xerc20LockboxConfig: WarpRouteDeployConfig = {
       [CHAIN_NAME_2]: {
         type: TokenType.XERC20Lockbox,
@@ -188,28 +193,22 @@ describe('xerc20 e2e tests', function () {
 
     const xerc20VSCoreConfig: WarpCoreConfig =
       readYamlOrJson(XERC20_VS_CORE_PATH);
-    const vsWarpRouteAddress2 = xerc20VSCoreConfig.tokens.find(
+    vsWarpRouteAddress2 = xerc20VSCoreConfig.tokens.find(
       (t) => t.chainName === CHAIN_NAME_2,
     )?.addressOrDenom;
-    const vsWarpRouteAddress3 = xerc20VSCoreConfig.tokens.find(
+    vsWarpRouteAddress3 = xerc20VSCoreConfig.tokens.find(
       (t) => t.chainName === CHAIN_NAME_3,
     )?.addressOrDenom;
 
-    if (vsWarpRouteAddress2) {
-      const tx = await xERC20VS2.addBridge({
-        bridge: vsWarpRouteAddress2,
-        ...BRIDGE_LIMITS,
-      });
-      await tx.wait();
-    }
+    assert(vsWarpRouteAddress2, `Missing warp route on ${CHAIN_NAME_2}`);
+    assert(vsWarpRouteAddress3, `Missing warp route on ${CHAIN_NAME_3}`);
 
-    if (vsWarpRouteAddress3) {
-      const tx = await xERC20VS3.addBridge({
-        bridge: vsWarpRouteAddress3,
-        ...BRIDGE_LIMITS,
-      });
-      await tx.wait();
-    }
+    await xERC20VS2
+      .addBridge({ bridge: vsWarpRouteAddress2, ...BRIDGE_LIMITS })
+      .then((tx) => tx.wait());
+    await xERC20VS3
+      .addBridge({ bridge: vsWarpRouteAddress3, ...BRIDGE_LIMITS })
+      .then((tx) => tx.wait());
 
     const xerc20VSConfigWithLimits: WarpRouteDeployConfig = {
       [CHAIN_NAME_2]: {
@@ -244,6 +243,17 @@ describe('xerc20 e2e tests', function () {
 
   beforeEach(async function () {
     await deployWarpRoutesAndSetupBridges();
+  });
+
+  afterEach(async function () {
+    await Promise.all([
+      vsWarpRouteAddress2
+        ? xERC20VS2.removeBridge(vsWarpRouteAddress2).then((tx) => tx.wait())
+        : Promise.resolve(),
+      vsWarpRouteAddress3
+        ? xERC20VS3.removeBridge(vsWarpRouteAddress3).then((tx) => tx.wait())
+        : Promise.resolve(),
+    ]);
   });
 
   describe('apply', function () {

--- a/typescript/cli/src/tests/ethereum/commands/xerc20.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/commands/xerc20.e2e-test.ts
@@ -16,8 +16,9 @@ import {
   type WarpCoreConfig,
   type WarpRouteDeployConfig,
   XERC20Type,
+  isXERC20TokenConfig,
 } from '@hyperlane-xyz/sdk';
-import { type Address } from '@hyperlane-xyz/utils';
+import { type Address, assert } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
 import {
@@ -40,7 +41,7 @@ import {
   deployXERC20VSToken,
   localTestRunCmdPrefix,
 } from './helpers.js';
-import { hyperlaneWarpDeploy } from './warp.js';
+import { hyperlaneWarpDeploy, readWarpConfig } from './warp.js';
 
 $.verbose = true;
 
@@ -404,6 +405,42 @@ describe('xerc20 e2e tests', function () {
 
       const output = result.stdout;
       expect(output).to.include(CHAIN_NAME_2);
+    });
+  });
+
+  describe('warp read', function () {
+    // A bridge that is neither a lockbox nor the route's own router used to be
+    // dropped from the derived config, which reported a token carrying extra
+    // bridges as carrying none.
+    it('reports an extra bridge that is not a lockbox', async function () {
+      const extraBridge = tokenChain2.address;
+      await xERC20VS2
+        .addBridge({ bridge: extraBridge, ...BRIDGE_LIMITS })
+        .then((tx) => tx.wait());
+
+      try {
+        const config = await readWarpConfig(
+          CHAIN_NAME_2,
+          XERC20_VS_CORE_PATH,
+          `${TEMP_PATH}/xerc20-vs-extra-bridge-read.yaml`,
+        );
+
+        const chainConfig = config[CHAIN_NAME_2];
+        assert(
+          isXERC20TokenConfig(chainConfig),
+          `Expected an xERC20 config for ${CHAIN_NAME_2}`,
+        );
+        expect(chainConfig.xERC20?.extraBridges).to.deep.equal([
+          {
+            lockbox: extraBridge,
+            limits: { type: XERC20Type.Velo, ...BRIDGE_LIMITS },
+          },
+        ]);
+      } finally {
+        // The token is deployed once for the whole suite, so a bridge left
+        // behind would make the later apply runs emit a removeBridge.
+        await xERC20VS2.removeBridge(extraBridge).then((tx) => tx.wait());
+      }
     });
   });
 });

--- a/typescript/sdk/src/deploy/proxy.ts
+++ b/typescript/sdk/src/deploy/proxy.ts
@@ -19,6 +19,11 @@ import { DeployedOwnableConfig } from '../types.js';
 
 export type EthersLikeProvider = ethers.providers.Provider | ZKSyncProvider;
 
+export const EIP1967_IMPLEMENTATION_SLOT =
+  '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
+export const EIP1967_ADMIN_SLOT =
+  '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
+
 const ZEvmAddress = z
   .string()
   .refine(isValidAddressEvm, 'Must be a valid EVM address');
@@ -98,10 +103,9 @@ export async function proxyImplementation(
   proxy: Address,
 ): Promise<Address> {
   await assertCodeExists(provider, proxy);
-  // Hardcoded storage slot for implementation per EIP-1967
   const storageValue = await provider.getStorageAt(
     proxy,
-    '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc',
+    EIP1967_IMPLEMENTATION_SLOT,
   );
   if (isStorageEmpty(storageValue)) {
     return ethers.constants.AddressZero;
@@ -128,11 +132,7 @@ export async function proxyAdmin(
   proxy: Address,
 ): Promise<Address> {
   await assertCodeExists(provider, proxy);
-  // Hardcoded storage slot for admin per EIP-1967
-  const storageValue = await provider.getStorageAt(
-    proxy,
-    '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103',
-  );
+  const storageValue = await provider.getStorageAt(proxy, EIP1967_ADMIN_SLOT);
   if (isStorageEmpty(storageValue)) {
     return ethers.constants.AddressZero;
   }

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -1002,6 +1002,7 @@ export {
   isPredicateWrapperConfig,
 } from './token/types.js';
 export {
+  UnknownXERC20TypeError,
   deriveBridgesConfig,
   deriveStandardBridgesConfig,
   deriveXERC20TokenType,

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.test.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.test.ts
@@ -12,7 +12,11 @@ import {
 import { TestChainName } from '../../consts/testChains.js';
 import { MultiProvider } from '../../providers/MultiProvider.js';
 
-import { EvmEtherscanLikeEventLogsReader } from './EvmEventLogsReader.js';
+import {
+  EvmEtherscanLikeEventLogsReader,
+  EvmEventLogsReader,
+  EvmRpcEventLogsReader,
+} from './EvmEventLogsReader.js';
 
 const EXPLORER_BLOCK_NUMBER = 5755676;
 const RECEIPT_BLOCK_NUMBER = 22216691;
@@ -120,5 +124,85 @@ describe('EvmEtherscanLikeEventLogsReader.getContractDeploymentBlockNumber', () 
 
     expect(blockNumber).to.equal(RECEIPT_BLOCK_NUMBER);
     expect(receiptStub.calledOnceWithExactly(DEPLOYMENT_TX_HASH)).to.be.true;
+  });
+});
+
+describe('EvmEventLogsReader.getContractDeploymentBlock', () => {
+  const RPC_BLOCK_NUMBER = 132196375;
+
+  let sandbox: sinon.SinonSandbox;
+  let multiProvider: MultiProvider;
+  let explorerDeploymentBlock: sinon.SinonStub;
+  let rpcDeploymentBlock: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    multiProvider = MultiProvider.createTestMultiProvider();
+
+    explorerDeploymentBlock = sandbox
+      .stub(
+        EvmEtherscanLikeEventLogsReader.prototype,
+        'getContractDeploymentBlockNumber',
+      )
+      .resolves(EXPLORER_BLOCK_NUMBER);
+    rpcDeploymentBlock = sandbox
+      .stub(EvmRpcEventLogsReader.prototype, 'getContractDeploymentBlockNumber')
+      .resolves(RPC_BLOCK_NUMBER);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function reader(): EvmEventLogsReader {
+    return EvmEventLogsReader.fromConfig(
+      { chain: TestChainName.test1 },
+      multiProvider,
+    );
+  }
+
+  it('resolves over the block explorer where the chain has one', async () => {
+    expect(
+      await reader().getContractDeploymentBlock(CONTRACT_ADDRESS),
+    ).to.equal(EXPLORER_BLOCK_NUMBER);
+    expect(rpcDeploymentBlock.called).to.be.false;
+  });
+
+  it('resolves it once per instance', async () => {
+    const logsReader = reader();
+
+    expect(
+      await logsReader.getContractDeploymentBlock(CONTRACT_ADDRESS),
+    ).to.equal(EXPLORER_BLOCK_NUMBER);
+    expect(
+      await logsReader.getContractDeploymentBlock(CONTRACT_ADDRESS),
+    ).to.equal(EXPLORER_BLOCK_NUMBER);
+
+    expect(explorerDeploymentBlock.calledOnce).to.be.true;
+  });
+
+  it('falls back to the RPC when the explorer cannot answer', async () => {
+    explorerDeploymentBlock.rejects(new Error('NOTOK'));
+
+    expect(
+      await reader().getContractDeploymentBlock(CONTRACT_ADDRESS),
+    ).to.equal(RPC_BLOCK_NUMBER);
+  });
+
+  it('raises when neither can answer', async () => {
+    explorerDeploymentBlock.rejects(new Error('NOTOK'));
+    rpcDeploymentBlock.rejects(new Error('missing trie node'));
+
+    let thrown: unknown;
+    try {
+      await reader().getContractDeploymentBlock(CONTRACT_ADDRESS);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(Error);
+    expect(thrown)
+      .to.have.property('message')
+      .that.includes('missing trie node');
   });
 });

--- a/typescript/sdk/src/rpc/evm/EvmEventLogsReader.ts
+++ b/typescript/sdk/src/rpc/evm/EvmEventLogsReader.ts
@@ -320,6 +320,38 @@ export class EvmEventLogsReader {
     return block;
   }
 
+  /**
+   * The block the contract was deployed in, which is where a scan of its whole
+   * history starts. Read over the block explorer where the chain has a usable
+   * one and over the RPC otherwise, the same way `getLogsByTopic` resolves it
+   * when a caller does not supply `fromBlock`, and cached per instance.
+   *
+   * Exposed for callers that read the same range more than once: resolving it
+   * here and passing it as `fromBlock` keeps a later read from deriving it
+   * again over the RPC, which bisects `eth_getCode` through historical blocks
+   * that a chain serving no archive state cannot answer.
+   */
+  async getContractDeploymentBlock(contractAddress: Address): Promise<number> {
+    try {
+      return await retryAsync(() =>
+        this.getDeploymentBlock(contractAddress, this.logReaderStrategy),
+      );
+    } catch (err) {
+      if (!this.fallbackLogReaderStrategy) {
+        throw err;
+      }
+
+      this.logger.debug(
+        `Failed to read the deployment block of ${contractAddress} on chain "${this.config.chain}": ${err}. Falling back to using the RPC`,
+      );
+
+      return this.getDeploymentBlock(
+        contractAddress,
+        this.fallbackLogReaderStrategy,
+      );
+    }
+  }
+
   async getLogsByTopic(
     options: GetLogByTopicOptions,
   ): Promise<GetEventLogsResponse[]> {

--- a/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
@@ -1,24 +1,33 @@
 import { PackageVersioned__factory } from '@hyperlane-xyz/core';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { ethers } from 'ethers';
 import sinon from 'sinon';
+
+import { assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
+import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
+import { GetEventLogsResponse } from '../rpc/evm/types.js';
 import { missingSelectorError, networkError } from '../test/errors.js';
 import { randomAddress } from '../test/testUtils.js';
 
 import { EvmWarpRouteReader } from './EvmWarpRouteReader.js';
+import { XERC20Type } from './types.js';
+import { CONFIGURATION_CHANGED_EVENT_SELECTOR } from './xerc20-abi.js';
+
+chai.use(chaiAsPromised);
 
 describe('EvmWarpRouteReader', () => {
   let sandbox: sinon.SinonSandbox;
+  let multiProvider: MultiProvider;
   let reader: EvmWarpRouteReader;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    reader = new EvmWarpRouteReader(
-      MultiProvider.createTestMultiProvider(),
-      TestChainName.test1,
-    );
+    multiProvider = MultiProvider.createTestMultiProvider();
+    reader = new EvmWarpRouteReader(multiProvider, TestChainName.test1);
   });
 
   afterEach(() => {
@@ -49,5 +58,235 @@ describe('EvmWarpRouteReader', () => {
     }
 
     expect(thrown).to.equal(transientError);
+  });
+
+  describe('fetchXERC20Config', () => {
+    // A mainnet router, one of the bridges its token holds limits for, and
+    // that token. Real addresses so the checksummed casing below is the casing
+    // a deploy config carries.
+    const WARP_ROUTER = '0x88AC0fC430130983c0DDEB4C22574056D8340Ca8';
+    const EXTRA_BRIDGE = '0x6D265C7dD8d76F25155F1a7687C693FDC1220D12';
+    const XERC20_ADDRESS = '0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189';
+
+    const setBufferCapSelector = ethers.utils
+      .id('setBufferCap(address,uint256)')
+      .slice(2, 10);
+    const setLimitsSelector = ethers.utils
+      .id('setLimits(address,uint256,uint256)')
+      .slice(2, 10);
+    const rateLimitsSelector = ethers.utils
+      .id('rateLimits(address)')
+      .slice(0, 10);
+    const mintingMaxLimitOfSelector = ethers.utils
+      .id('mintingMaxLimitOf(address)')
+      .slice(0, 10);
+    const burningMaxLimitOfSelector = ethers.utils
+      .id('burningMaxLimitOf(address)')
+      .slice(0, 10);
+
+    // The scan resolves the token's deployment block before it reads, which
+    // would otherwise be a live block explorer request.
+    beforeEach(() => {
+      sandbox
+        .stub(EvmEventLogsReader.prototype, 'getContractDeploymentBlock')
+        .resolves(1);
+    });
+
+    function bridgeAnnouncement(bridge: string): GetEventLogsResponse {
+      return {
+        address: XERC20_ADDRESS,
+        blockNumber: 10,
+        data: ethers.utils.defaultAbiCoder.encode(
+          ['uint112', 'uint128'],
+          [1, 1],
+        ),
+        logIndex: 0,
+        topics: [
+          CONFIGURATION_CHANGED_EVENT_SELECTOR,
+          ethers.utils.hexZeroPad(bridge, 32),
+        ],
+        transactionHash: ethers.utils.hexZeroPad('0x10', 32),
+        transactionIndex: 0,
+      };
+    }
+
+    function stubToken(
+      type: XERC20Type,
+      limits: Record<string, [string, string]>,
+    ): sinon.SinonStub {
+      const provider = multiProvider.getProvider(TestChainName.test1);
+      const getCode = sandbox
+        .stub(provider, 'getCode')
+        .resolves(
+          `0x${type === XERC20Type.Velo ? setBufferCapSelector : setLimitsSelector}`,
+        );
+      sandbox.stub(provider, 'call').callsFake(async (transaction) => {
+        const data = await transaction.data;
+        assert(typeof data === 'string', 'Expected call data');
+        const selector = data.slice(0, 10);
+        const [bridge] = ethers.utils.defaultAbiCoder.decode(
+          ['address'],
+          `0x${data.slice(10)}`,
+        );
+        const entry = limits[bridge.toLowerCase()];
+        assert(entry, `Unexpected limits read for ${bridge}`);
+
+        if (selector === rateLimitsSelector) {
+          return ethers.utils.defaultAbiCoder.encode(
+            ['tuple(uint128,uint112,uint32,uint112,uint112)'],
+            [[entry[1], entry[0], 0, 0, 0]],
+          );
+        }
+        if (selector === mintingMaxLimitOfSelector) {
+          return ethers.utils.defaultAbiCoder.encode(['uint256'], [entry[0]]);
+        }
+        if (selector === burningMaxLimitOfSelector) {
+          return ethers.utils.defaultAbiCoder.encode(['uint256'], [entry[1]]);
+        }
+        throw new Error(`Unexpected call ${selector}`);
+      });
+
+      return getCode;
+    }
+
+    // A Standard xERC20 exposes no bufferCap getter, so reading it as a
+    // Velodrome token dropped the whole xERC20 block from the derived config.
+    it('derives the limits of a Standard xERC20', async () => {
+      sandbox.stub(EvmEventLogsReader.prototype, 'getLogsByTopic').resolves([]);
+      const getCode = stubToken(XERC20Type.Standard, {
+        [WARP_ROUTER.toLowerCase()]: ['20000000000000', '20000000000000'],
+      });
+
+      const config = await reader.fetchXERC20Config(
+        XERC20_ADDRESS,
+        WARP_ROUTER,
+      );
+
+      expect(config).to.deep.equal({
+        xERC20: {
+          warpRouteLimits: {
+            type: XERC20Type.Standard,
+            mint: '20000000000000',
+            burn: '20000000000000',
+          },
+          extraBridges: undefined,
+        },
+      });
+      expect(getCode.calledOnce).to.be.true;
+    });
+
+    it('derives the limits of a Velodrome xERC20', async () => {
+      sandbox.stub(EvmEventLogsReader.prototype, 'getLogsByTopic').resolves([]);
+      stubToken(XERC20Type.Velo, {
+        [WARP_ROUTER.toLowerCase()]: ['2000000000000', '500000000'],
+      });
+
+      const config = await reader.fetchXERC20Config(
+        XERC20_ADDRESS,
+        WARP_ROUTER,
+      );
+
+      expect(config).to.deep.equal({
+        xERC20: {
+          warpRouteLimits: {
+            type: XERC20Type.Velo,
+            bufferCap: '2000000000000',
+            rateLimitPerSecond: '500000000',
+          },
+          extraBridges: undefined,
+        },
+      });
+    });
+
+    // The route's own router holds bridge limits like any other bridge and the
+    // token announces it alongside the rest. They are reported as
+    // warpRouteLimits, so repeating them as an extra bridge would double count
+    // the route against itself.
+    it('never reports the warp route router as an extra bridge', async () => {
+      sandbox
+        .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
+        .resolves([
+          bridgeAnnouncement(WARP_ROUTER),
+          bridgeAnnouncement(EXTRA_BRIDGE),
+        ]);
+      stubToken(XERC20Type.Velo, {
+        [WARP_ROUTER.toLowerCase()]: ['2000000000000', '500000000'],
+        [EXTRA_BRIDGE.toLowerCase()]: ['20000000000000', '5000000000'],
+      });
+
+      const config = await reader.fetchXERC20Config(
+        XERC20_ADDRESS,
+        WARP_ROUTER,
+      );
+
+      // Checksummed because the reader normalizes every bridge address it
+      // reports, which is what the diff against the deploy config compares.
+      expect(config.xERC20?.extraBridges).to.deep.equal([
+        {
+          lockbox: '0x6D265C7dD8d76F25155F1a7687C693FDC1220D12',
+          limits: {
+            type: XERC20Type.Velo,
+            bufferCap: '20000000000000',
+            rateLimitPerSecond: '5000000000',
+          },
+        },
+      ]);
+    });
+
+    // A third-party token implementing neither limit interface is not drift and
+    // not a failure: the reader has nothing to say about its limits, and making
+    // that fatal would take down the whole check for the route it belongs to.
+    it('reports no xERC20 config for a token implementing neither interface', async () => {
+      const provider = multiProvider.getProvider(TestChainName.test1);
+      sandbox.stub(provider, 'getCode').resolves('0xbeef');
+      sandbox
+        .stub(provider, 'getStorageAt')
+        .resolves(ethers.utils.hexZeroPad('0x00', 32));
+
+      const config = await reader.fetchXERC20Config(
+        XERC20_ADDRESS,
+        WARP_ROUTER,
+      );
+
+      expect(config).to.deep.equal({});
+    });
+
+    // A token whose type is detectable but whose limit getter is not there has
+    // answered: it holds no limits this SDK can read.
+    it('reports no xERC20 config when the limit getter is missing', async () => {
+      sandbox.stub(EvmEventLogsReader.prototype, 'getLogsByTopic').resolves([]);
+      const provider = multiProvider.getProvider(TestChainName.test1);
+      sandbox.stub(provider, 'getCode').resolves(`0x${setBufferCapSelector}`);
+      sandbox.stub(provider, 'call').rejects(
+        Object.assign(new Error('call revert exception'), {
+          code: 'CALL_EXCEPTION',
+          data: '0x',
+        }),
+      );
+
+      const config = await reader.fetchXERC20Config(
+        XERC20_ADDRESS,
+        WARP_ROUTER,
+      );
+
+      expect(config).to.deep.equal({});
+    });
+
+    // A provider answering an empty response is not a contract answering that
+    // it has no bridges. Reporting one as the other reported a route whose
+    // bridges are all configured as having none.
+    it('propagates a transient failure instead of reporting no extra bridges', async () => {
+      const transientError = new Error('Invalid response from provider');
+      sandbox
+        .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
+        .rejects(transientError);
+      stubToken(XERC20Type.Velo, {
+        [WARP_ROUTER.toLowerCase()]: ['2000000000000', '500000000'],
+      });
+
+      await expect(
+        reader.fetchXERC20Config(XERC20_ADDRESS, WARP_ROUTER),
+      ).to.be.rejectedWith('Invalid response from provider');
+    });
   });
 });

--- a/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.test.ts
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../consts/testChains.js';
+import { EIP1967_IMPLEMENTATION_SLOT } from '../deploy/proxy.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
 import { GetEventLogsResponse } from '../rpc/evm/types.js';
@@ -67,6 +68,7 @@ describe('EvmWarpRouteReader', () => {
     const WARP_ROUTER = '0x88AC0fC430130983c0DDEB4C22574056D8340Ca8';
     const EXTRA_BRIDGE = '0x6D265C7dD8d76F25155F1a7687C693FDC1220D12';
     const XERC20_ADDRESS = '0x1217BfE6c773EEC6cc4A38b5Dc45B92292B6E189';
+    const IMPLEMENTATION = '0xf24508eC5f0208589be2B206173993fBd7D6506d';
 
     const setBufferCapSelector = ethers.utils
       .id('setBufferCap(address,uint256)')
@@ -231,6 +233,49 @@ describe('EvmWarpRouteReader', () => {
           },
         },
       ]);
+    });
+
+    // A UUPS proxy holds its upgrade logic in the implementation and leaves the
+    // admin slot empty, so a derivation keyed on an admin never reads the
+    // bytecode that carries the selectors and reports the token as having no
+    // limits interface, which the caller turns into an empty config and the
+    // check reads as nothing to verify.
+    it('derives the limits of a token behind a UUPS proxy', async () => {
+      sandbox.stub(EvmEventLogsReader.prototype, 'getLogsByTopic').resolves([]);
+      const getCode = stubToken(XERC20Type.Standard, {
+        [WARP_ROUTER.toLowerCase()]: ['20000000000000', '20000000000000'],
+      });
+      // The proxy delegates, so its own bytecode carries neither selector.
+      getCode.withArgs(XERC20_ADDRESS).resolves('0xdead');
+      getCode.withArgs(IMPLEMENTATION).resolves(`0x${setLimitsSelector}`);
+
+      const provider = multiProvider.getProvider(TestChainName.test1);
+      sandbox
+        .stub(provider, 'getStorageAt')
+        .callsFake(async (_address, position) => {
+          const slot = await position;
+          assert(
+            slot === EIP1967_IMPLEMENTATION_SLOT,
+            `Read storage slot ${slot}, which a UUPS proxy does not populate`,
+          );
+          return ethers.utils.hexZeroPad(IMPLEMENTATION, 32);
+        });
+
+      const config = await reader.fetchXERC20Config(
+        XERC20_ADDRESS,
+        WARP_ROUTER,
+      );
+
+      expect(config).to.deep.equal({
+        xERC20: {
+          warpRouteLimits: {
+            type: XERC20Type.Standard,
+            mint: '20000000000000',
+            burn: '20000000000000',
+          },
+          extraBridges: undefined,
+        },
+      });
     });
 
     // A third-party token implementing neither limit interface is not drift and

--- a/typescript/sdk/src/token/EvmWarpRouteReader.ts
+++ b/typescript/sdk/src/token/EvmWarpRouteReader.ts
@@ -63,13 +63,14 @@ import {
 import { EvmHookReader } from '../hook/EvmHookReader.js';
 import { DerivedHookConfig, HookType, OnchainHookType } from '../hook/types.js';
 import { EvmIsmReader } from '../ism/EvmIsmReader.js';
+import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmRouterReader } from '../router/EvmRouterReader.js';
 import { DestinationGas, RemoteRouters } from '../router/types.js';
 import { ChainName, ChainNameOrId, DeployedOwnableConfig } from '../types.js';
 import {
   fetchPackageVersion as fetchContractPackageVersion,
-  isMissingSelectorCallException,
+  isMissingSelectorRevert,
   throwIfNotMissingSelector,
   throwIfNotMissingSelectorRevert,
 } from '../utils/contract.js';
@@ -107,7 +108,12 @@ import {
   isCrossCollateralTokenConfig,
   PredicateWrapperConfig,
 } from './types.js';
-import { getExtraLockBoxConfigs } from './xerc20.js';
+import { readXERC20Limits } from './xerc20-limits.js';
+import {
+  UnknownXERC20TypeError,
+  deriveXERC20TokenType,
+  getExtraLockBoxConfigs,
+} from './xerc20.js';
 
 const REBALANCING_CONTRACT_VERSION = '8.0.0';
 export const TOKEN_FEE_CONTRACT_VERSION = '10.0.0';
@@ -973,40 +979,65 @@ export class EvmWarpRouteReader extends EvmRouterReader {
     xERC20Address: Address,
     warpRouteAddress: Address,
   ): Promise<XERC20TokenMetadata> {
-    // fetch the limits if possible
-    const rateLimitsABI = [
-      'function rateLimitPerSecond(address) external view returns (uint128)',
-      'function bufferCap(address) external view returns (uint112)',
-    ];
-    const xERC20 = new Contract(xERC20Address, rateLimitsABI, this.provider);
-    let extraBridgesLimits: XERC20TokenExtraBridgesLimits[] | undefined;
+    // Which getter holds the limits differs between the Standard and the
+    // Velodrome implementation, so the route's own limits are read through the
+    // type rather than through a fixed ABI.
+    let type: XERC20Type;
+    try {
+      type = await deriveXERC20TokenType(
+        this.multiProvider,
+        this.chain,
+        xERC20Address,
+      );
+    } catch (error) {
+      if (!(error instanceof UnknownXERC20TypeError)) throw error;
+      this.logger.warn(
+        `Token at ${xERC20Address} on chain ${this.chain} exposes no known xERC20 limits interface, skipping its xERC20 config`,
+        error,
+      );
+      return {};
+    }
 
+    let extraBridgesLimits: XERC20TokenExtraBridgesLimits[] | undefined;
     try {
       extraBridgesLimits = await getExtraLockBoxConfigs({
         chain: this.chain,
         multiProvider: this.multiProvider,
         xERC20Address,
         logger: this.logger,
+        type,
+        warpRouteAddress,
       });
     } catch (error) {
-      if (!isMissingSelectorCallException(error)) throw error;
+      // Only a contract answering that it does not have the getter is an
+      // answer. Everything else, an unreachable RPC above all, would otherwise
+      // report a token that has extra bridges as having none.
+      throwIfNotMissingSelectorRevert(error);
       this.logger.warn(
-        `Skipping extra xERC20 lockbox configs after missing-selector error for token at ${xERC20Address} on chain ${this.chain}`,
+        `Skipping extra xERC20 bridge configs after missing-selector error for token at ${xERC20Address} on chain ${this.chain}`,
         error,
       );
     }
 
     try {
-      // TODO: fix this such that it fetches from WL's values too
+      const limitsByBridge = await readXERC20Limits({
+        multiProtocolProvider: MultiProtocolProvider.fromMultiProvider(
+          this.multiProvider,
+        ),
+        chain: this.multiProvider.getChainName(this.chain),
+        xERC20Address,
+        bridges: [warpRouteAddress],
+        type,
+      });
+      const warpRouteLimits = limitsByBridge[warpRouteAddress];
+      assert(
+        warpRouteLimits,
+        `Missing xERC20 limits for warp route ${warpRouteAddress} on chain ${this.chain}`,
+      );
+
       return {
         xERC20: {
-          warpRouteLimits: {
-            type: XERC20Type.Velo,
-            rateLimitPerSecond: (
-              await xERC20.rateLimitPerSecond(warpRouteAddress)
-            ).toString(),
-            bufferCap: (await xERC20.bufferCap(warpRouteAddress)).toString(),
-          },
+          warpRouteLimits,
           extraBridges:
             extraBridgesLimits && extraBridgesLimits.length > 0
               ? extraBridgesLimits
@@ -1014,7 +1045,7 @@ export class EvmWarpRouteReader extends EvmRouterReader {
         },
       };
     } catch (error) {
-      if (isMissingSelectorCallException(error)) return {};
+      if (isMissingSelectorRevert(error)) return {};
       this.logger.error(
         `Error fetching xERC20 limits for token at ${xERC20Address} on chain ${this.chain}`,
         error,

--- a/typescript/sdk/src/token/EvmXERC20Reader.test.ts
+++ b/typescript/sdk/src/token/EvmXERC20Reader.test.ts
@@ -10,7 +10,12 @@ import { HyperlaneJsonRpcProvider } from '../providers/SmartProvider/HyperlaneJs
 import { ProviderMethod } from '../providers/SmartProvider/ProviderMethods.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
 
+import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
+
 import { EvmXERC20Reader } from './EvmXERC20Reader.js';
+import { EvmXERC20VSAdapter } from './adapters/EvmTokenAdapter.js';
+import { RateLimitMidPoint } from './adapters/ITokenAdapter.js';
+import { VeloXERC20Limits } from './xerc20-limits.js';
 import { XERC20Type } from './types.js';
 import { CONFIGURATION_CHANGED_EVENT_SELECTOR } from './xerc20-abi.js';
 
@@ -185,6 +190,43 @@ function createReader(pagination: RpcUrl['pagination']): EvmXERC20Reader {
   return new EvmXERC20Reader(multiProvider, CHAIN_NAME);
 }
 
+const OVERRIDE_BRIDGE: Address = '0xEeEeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+const LIMIT_BRIDGES: Address[] = Array.from(
+  { length: 12 },
+  (_value, index) =>
+    `0x${(index + 1).toString(16).padStart(2, '0').repeat(20)}`,
+);
+
+function createLimitsReader(concurrency?: number): EvmXERC20Reader {
+  const rpcUrl: RpcUrl = { http: RPC_URL, concurrency };
+  const metadata: ChainMetadata = {
+    chainId: CHAIN_ID,
+    domainId: CHAIN_ID,
+    name: CHAIN_NAME,
+    protocol: ProtocolType.Ethereum,
+    rpcUrls: [rpcUrl],
+  };
+  const multiProvider = new MultiProvider({ [CHAIN_NAME]: metadata });
+  multiProvider.setProvider(
+    CHAIN_NAME,
+    new HyperlaneJsonRpcProvider(rpcUrl, {
+      chainId: CHAIN_ID,
+      name: CHAIN_NAME,
+    }),
+  );
+  return new EvmXERC20Reader(multiProvider, CHAIN_NAME);
+}
+
+function rateLimits(bufferCap: bigint): RateLimitMidPoint {
+  return {
+    rateLimitPerSecond: 1n,
+    bufferCap,
+    lastBufferUsedTime: 0,
+    bufferStored: 0n,
+    midPoint: 0n,
+  };
+}
+
 describe('EvmXERC20Reader', () => {
   beforeEach(() => {
     // The chain declares no block explorer, so the reader is RPC only and any
@@ -308,5 +350,101 @@ describe('EvmXERC20Reader', () => {
       expect(bridges).to.deep.equal([]);
       expect(fromConfig.notCalled).to.be.true;
     });
+  });
+  describe('readLimits', () => {
+    // The conversions are protected on a root-exported class, so an override is
+    // part of what the class promises. Reading through the module functions
+    // directly would leave one silently uncalled.
+    it('reports what a subclass override returns', async () => {
+      class OverridingReader extends EvmXERC20Reader {
+        protected override toVeloLimits(
+          rateLimit: RateLimitMidPoint,
+        ): VeloXERC20Limits {
+          return {
+            type: XERC20Type.Velo,
+            bufferCap: `overridden-${rateLimit.bufferCap}`,
+            rateLimitPerSecond: 'overridden',
+          };
+        }
+      }
+
+      sinon
+        .stub(EvmXERC20VSAdapter.prototype, 'getRateLimits')
+        .resolves(rateLimits(7n));
+      const multiProvider = new MultiProvider({
+        [CHAIN_NAME]: {
+          chainId: CHAIN_ID,
+          domainId: CHAIN_ID,
+          name: CHAIN_NAME,
+          protocol: ProtocolType.Ethereum,
+          rpcUrls: [{ http: RPC_URL }],
+        },
+      });
+      multiProvider.setProvider(
+        CHAIN_NAME,
+        new HyperlaneJsonRpcProvider(
+          { http: RPC_URL },
+          { chainId: CHAIN_ID, name: CHAIN_NAME },
+        ),
+      );
+
+      const limits = await new OverridingReader(
+        multiProvider,
+        CHAIN_NAME,
+      ).readLimits(XERC20_ADDRESS, [OVERRIDE_BRIDGE], XERC20Type.Velo);
+
+      expect(limits).to.deep.equal({
+        [OVERRIDE_BRIDGE]: {
+          type: XERC20Type.Velo,
+          bufferCap: 'overridden-7',
+          rateLimitPerSecond: 'overridden',
+        },
+      });
+    });
+
+    interface ConcurrencyCase {
+      name: string;
+      configured?: number;
+      expectedPeak: number;
+    }
+
+    // Discovery hands over every address the token ever announced, so an
+    // unbounded read opens that whole history at once against one provider.
+    const concurrencyCases: ConcurrencyCase[] = [
+      {
+        name: 'reads no more bridges at once than the chain allows',
+        configured: 3,
+        expectedPeak: 3,
+      },
+      {
+        name: 'reads one bridge at a time when the chain configures nothing',
+        expectedPeak: DEFAULT_CONTRACT_READ_CONCURRENCY,
+      },
+    ];
+
+    for (const testCase of concurrencyCases) {
+      it(testCase.name, async () => {
+        let inFlight = 0;
+        let peak = 0;
+        sinon
+          .stub(EvmXERC20VSAdapter.prototype, 'getRateLimits')
+          .callsFake(async () => {
+            inFlight += 1;
+            peak = Math.max(peak, inFlight);
+            await new Promise((resolve) => setImmediate(resolve));
+            inFlight -= 1;
+            return rateLimits(1n);
+          });
+
+        const limits = await createLimitsReader(testCase.configured).readLimits(
+          XERC20_ADDRESS,
+          LIMIT_BRIDGES,
+          XERC20Type.Velo,
+        );
+
+        expect(Object.keys(limits)).to.have.members(LIMIT_BRIDGES);
+        expect(peak).to.equal(testCase.expectedPeak);
+      });
+    }
   });
 });

--- a/typescript/sdk/src/token/EvmXERC20Reader.ts
+++ b/typescript/sdk/src/token/EvmXERC20Reader.ts
@@ -16,9 +16,17 @@ import { viemLogFromGetEventLogsResponse } from '../rpc/evm/utils.js';
 import { ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
+import { RateLimitMidPoint, xERC20Limits } from './adapters/ITokenAdapter.js';
 import { XERC20Type } from './types.js';
 import { CONFIGURATION_CHANGED_EVENT_SELECTOR } from './xerc20-abi.js';
-import { XERC20LimitsMap, readXERC20Limits } from './xerc20-limits.js';
+import {
+  StandardXERC20Limits,
+  VeloXERC20Limits,
+  XERC20LimitsMap,
+  readXERC20Limits,
+  toStandardLimits,
+  toVeloLimits,
+} from './xerc20-limits.js';
 import {
   XERC20_LOG_SCAN_BLOCK_RANGE,
   deriveXERC20TokenType,
@@ -68,6 +76,12 @@ export class EvmXERC20Reader extends HyperlaneReader {
       xERC20Address,
       bridges,
       type,
+      // Bound rather than passed by reference so a subclass overriding either
+      // still decides what its reader reports.
+      converters: {
+        toStandardLimits: (limits) => this.toStandardLimits(limits),
+        toVeloLimits: (rateLimits) => this.toVeloLimits(rateLimits),
+      },
     });
   }
 
@@ -167,5 +181,13 @@ export class EvmXERC20Reader extends HyperlaneReader {
       address: normalizeAddress(proxyAdminAddress),
       owner: normalizeAddress(owner),
     };
+  }
+
+  protected toStandardLimits(limits: xERC20Limits): StandardXERC20Limits {
+    return toStandardLimits(limits);
+  }
+
+  protected toVeloLimits(rateLimits: RateLimitMidPoint): VeloXERC20Limits {
+    return toVeloLimits(rateLimits);
   }
 }

--- a/typescript/sdk/src/token/EvmXERC20Reader.ts
+++ b/typescript/sdk/src/token/EvmXERC20Reader.ts
@@ -16,40 +16,22 @@ import { viemLogFromGetEventLogsResponse } from '../rpc/evm/utils.js';
 import { ChainNameOrId } from '../types.js';
 import { HyperlaneReader } from '../utils/HyperlaneReader.js';
 
-import {
-  EvmXERC20Adapter,
-  EvmXERC20VSAdapter,
-} from './adapters/EvmTokenAdapter.js';
-import { RateLimitMidPoint, xERC20Limits } from './adapters/ITokenAdapter.js';
 import { XERC20Type } from './types.js';
 import { CONFIGURATION_CHANGED_EVENT_SELECTOR } from './xerc20-abi.js';
+import { XERC20LimitsMap, readXERC20Limits } from './xerc20-limits.js';
 import {
   XERC20_LOG_SCAN_BLOCK_RANGE,
   deriveXERC20TokenType,
   latestConfigurationPerBridge,
 } from './xerc20.js';
 
-export interface StandardXERC20Limits {
-  type: typeof XERC20Type.Standard;
-  mint: string;
-  burn: string;
-}
-
-export interface VeloXERC20Limits {
-  type: typeof XERC20Type.Velo;
-  bufferCap: string;
-  rateLimitPerSecond: string;
-}
-
-/**
- * Unified XERC20 limits type
- */
-export type XERC20Limits = StandardXERC20Limits | VeloXERC20Limits;
-
-/**
- * Map of bridge addresses to their limits
- */
-export type XERC20LimitsMap = Record<Address, XERC20Limits>;
+export type {
+  StandardXERC20Limits,
+  VeloXERC20Limits,
+  XERC20Limits,
+  XERC20LimitsMap,
+} from './xerc20-limits.js';
+export { limitsAreZero, limitsMatch } from './xerc20-limits.js';
 
 /**
  * Reader for on-chain XERC20 state.
@@ -80,42 +62,26 @@ export class EvmXERC20Reader extends HyperlaneReader {
     bridges: Address[],
     type: XERC20Type,
   ): Promise<XERC20LimitsMap> {
-    const limitsMap: XERC20LimitsMap = {};
-    const chainName = this.multiProvider.getChainName(this.chain);
-
-    if (type === XERC20Type.Standard) {
-      const adapter = new EvmXERC20Adapter(
-        chainName,
-        this.multiProtocolProvider,
-        { token: xERC20Address },
-      );
-
-      for (const bridge of bridges) {
-        const limits = await adapter.getLimits(bridge);
-        limitsMap[bridge] = this.toStandardLimits(limits);
-      }
-    } else {
-      const adapter = new EvmXERC20VSAdapter(
-        chainName,
-        this.multiProtocolProvider,
-        { token: xERC20Address },
-      );
-
-      for (const bridge of bridges) {
-        const rateLimits = await adapter.getRateLimits(bridge);
-        limitsMap[bridge] = this.toVeloLimits(rateLimits);
-      }
-    }
-
-    return limitsMap;
+    return readXERC20Limits({
+      multiProtocolProvider: this.multiProtocolProvider,
+      chain: this.multiProvider.getChainName(this.chain),
+      xERC20Address,
+      bridges,
+      type,
+    });
   }
 
   /**
    * Read all bridges configured on-chain for a Velodrome XERC20 by parsing ConfigurationChanged events.
-   * Returns empty array for Standard XERC20 since it has no event-based bridge enumeration.
    * The scan covers the token's whole history, from the block it was deployed in
    * to the chain head, over the block explorer where the chain has a usable one
    * and over the paginated RPC otherwise.
+   *
+   * Returns an empty array for Standard XERC20, whose bridges this does not
+   * enumerate. They are enumerable: a Standard token announces them through
+   * BridgeLimitsSet, which getExtraLockBoxConfigs reads. Callers relying on
+   * this therefore fall back to the bridges their config names for a Standard
+   * token, which is why bringing the two paths together is worth doing.
    */
   async readOnChainBridges(
     xERC20Address: Address,
@@ -123,7 +89,7 @@ export class EvmXERC20Reader extends HyperlaneReader {
   ): Promise<Address[]> {
     if (type === XERC20Type.Standard) {
       this.logger.debug(
-        'Standard XERC20 does not support on-chain bridge enumeration',
+        'Standard XERC20 bridge enumeration is not implemented here',
       );
       return [];
     }
@@ -202,44 +168,4 @@ export class EvmXERC20Reader extends HyperlaneReader {
       owner: normalizeAddress(owner),
     };
   }
-
-  protected toStandardLimits(limits: xERC20Limits): StandardXERC20Limits {
-    return {
-      type: XERC20Type.Standard,
-      mint: limits.mint.toString(),
-      burn: limits.burn.toString(),
-    };
-  }
-
-  protected toVeloLimits(rateLimits: RateLimitMidPoint): VeloXERC20Limits {
-    return {
-      type: XERC20Type.Velo,
-      bufferCap: rateLimits.bufferCap.toString(),
-      rateLimitPerSecond: rateLimits.rateLimitPerSecond.toString(),
-    };
-  }
-}
-
-export function limitsAreZero(limits: XERC20Limits): boolean {
-  if (limits.type === XERC20Type.Standard) {
-    return limits.mint === '0' && limits.burn === '0';
-  }
-  return limits.bufferCap === '0' && limits.rateLimitPerSecond === '0';
-}
-
-export function limitsMatch(a: XERC20Limits, b: XERC20Limits): boolean {
-  if (a.type !== b.type) return false;
-
-  if (a.type === XERC20Type.Standard && b.type === XERC20Type.Standard) {
-    return a.mint === b.mint && a.burn === b.burn;
-  }
-
-  if (a.type === XERC20Type.Velo && b.type === XERC20Type.Velo) {
-    return (
-      a.bufferCap === b.bufferCap &&
-      a.rateLimitPerSecond === b.rateLimitPerSecond
-    );
-  }
-
-  return false;
 }

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -36,6 +36,9 @@ import {
   HypTokenRouterConfig,
   WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
+  XERC20TokenExtraBridgesLimits,
+  XERC20Type,
+  isXERC20TokenConfig,
 } from './types.js';
 
 function buildMultiProvider(): MultiProvider {
@@ -420,6 +423,64 @@ describe('configUtils', () => {
         expect(transformedObj).to.eql(expected);
       });
     }
+
+    // The derived side is ordered by the events the token emitted and the
+    // expected side by whoever wrote the deploy config. Comparing them index by
+    // index reports two orderings of the same bridges as drift.
+    it('orders xERC20 extraBridges by the bridge they hold limits for', () => {
+      // The reader reports a bridge EIP-55 checksummed and a deploy config
+      // carries whatever its author typed, so the two sides only order alike if
+      // they are lowercased before they are sorted. These two make that
+      // load-bearing: the checksum uppercases the leading b and leaves the
+      // leading a alone, so sorting the raw strings puts "0xB" (0x42) ahead of
+      // "0xa" (0x61) and the sides canonicalise to opposite orders.
+      const LOWER_A = '0xa000000000000000000000000000000000000000';
+      const LOWER_B = '0xb000000000000000000000000000000000000000';
+      const CHECKSUMMED_A = utils.getAddress(LOWER_A);
+      const CHECKSUMMED_B = utils.getAddress(LOWER_B);
+      expect(CHECKSUMMED_B).to.equal(
+        '0xB000000000000000000000000000000000000000',
+      );
+
+      const limits = {
+        type: XERC20Type.Velo,
+        bufferCap: '20000000000000',
+        rateLimitPerSecond: '5000000000',
+      };
+      const config = (
+        extraBridges: XERC20TokenExtraBridgesLimits[],
+      ): HypTokenRouterConfig => ({
+        type: TokenType.XERC20,
+        token: ADDRESS,
+        mailbox: ADDRESS,
+        owner: ADDRESS,
+        xERC20: { warpRouteLimits: limits, extraBridges },
+      });
+
+      // As the reader reports them, announced in the opposite order to the
+      // deploy config below.
+      const announced = transformConfigToCheck(
+        config([
+          { lockbox: CHECKSUMMED_B, limits },
+          { lockbox: CHECKSUMMED_A, limits },
+        ]),
+      );
+      const declared = transformConfigToCheck(
+        config([
+          { lockbox: LOWER_A, limits },
+          { lockbox: LOWER_B, limits },
+        ]),
+      );
+
+      expect(announced).to.eql(declared);
+      assert(
+        isXERC20TokenConfig(announced),
+        'Expected the transformed config to stay an xERC20 config',
+      );
+      expect(
+        announced.xERC20?.extraBridges?.map(({ lockbox }) => lockbox),
+      ).to.eql([LOWER_A, LOWER_B]);
+    });
 
     it('normalizes plain number scale to {numerator, denominator} bigint', () => {
       const transformedObj = transformConfigToCheck({

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -948,6 +948,16 @@ const sortArraysInConfigToCheck = (a: any, b: any): number => {
     return 0;
   }
 
+  // Sort xERC20 extraBridges by the bridge they hold limits for. The derived
+  // side is ordered by the events the token emitted and the expected side by
+  // whoever wrote the deploy config, so without this the same set of bridges
+  // in two orders diffs index by index and reports drift that is not there.
+  if (a.lockbox && b.lockbox) {
+    if (a.lockbox < b.lockbox) return -1;
+    if (a.lockbox > b.lockbox) return 1;
+    return 0;
+  }
+
   if (a < b) return -1;
   if (a > b) return 1;
 

--- a/typescript/sdk/src/token/deploy.hardhat-test.ts
+++ b/typescript/sdk/src/token/deploy.hardhat-test.ts
@@ -25,6 +25,8 @@ import {
   XERC20LockboxTest__factory,
   XERC20Test,
   XERC20Test__factory,
+  XERC20VSTest,
+  XERC20VSTest__factory,
 } from '@hyperlane-xyz/core';
 import {
   Address,
@@ -33,6 +35,7 @@ import {
   assert,
   deepCopy,
   eqAddress,
+  isNullish,
   isZeroishAddress,
   objMap,
 } from '@hyperlane-xyz/utils';
@@ -70,6 +73,8 @@ import { HypERC20Deployer } from './deploy.js';
 import {
   SyntheticTokenConfig,
   WarpRouteDeployConfigMailboxRequired,
+  XERC20TokenExtraBridgesLimits,
+  XERC20Type,
   isAtomicLocalRebalancingBridgeTokenConfig,
   isDepositAddressTokenConfig,
 } from './types.js';
@@ -480,12 +485,28 @@ describe('TokenDeployer', async () => {
           })),
         }) as WarpCoreConfig;
 
+      // XERC20Test answers mintingMaxLimitOf/burningMaxLimitOf with the uint256
+      // max for every bridge, so a deploy config declaring no limits reads as
+      // drift against what the token holds.
+      const MAX_UINT256 =
+        '115792089237316195423570985008687907853269984665640564039457584007913129639935';
+
       beforeEach(async () => {
         // @ts-expect-error - Test assigns varying token types to config
         config[chain] = {
           ...config[chain],
           type,
           token: token(),
+          xERC20:
+            type === TokenType.XERC20
+              ? {
+                  warpRouteLimits: {
+                    type: XERC20Type.Standard,
+                    mint: MAX_UINT256,
+                    burn: MAX_UINT256,
+                  },
+                }
+              : undefined,
         };
 
         contractsMap = await deployer.deploy(config);
@@ -865,6 +886,155 @@ describe('TokenDeployer', async () => {
       });
     });
   }
+
+  describe('checkWarpRouteDeployConfig for a Velodrome xERC20', () => {
+    // The values the CLI e2e uses, which XERC20VSTest accepts for addBridge.
+    const BRIDGE_LIMITS = {
+      bufferCap: '1000000000000000000000',
+      rateLimitPerSecond: '1000000000000000000',
+    };
+    const VELO_LIMITS = { type: XERC20Type.Velo, ...BRIDGE_LIMITS };
+
+    let sandbox: sinon.SinonSandbox;
+    let veloToken: XERC20VSTest;
+    let extraBridge: Address;
+    let contractsMap: Awaited<ReturnType<HypERC20Deployer['deploy']>>;
+
+    const veloConfig = (
+      extraBridges?: XERC20TokenExtraBridgesLimits[],
+    ): WarpRouteDeployConfigMailboxRequired => ({
+      ...config,
+      [chain]: {
+        ...config[chain],
+        type: TokenType.XERC20,
+        token: veloToken.address,
+        xERC20: { warpRouteLimits: VELO_LIMITS, extraBridges },
+      },
+    });
+
+    // CAST: the check only reads chainName and addressOrDenom off each token,
+    // and filling in the rest of WarpCoreConfig's token metadata would state
+    // things about the deployment this test does not know.
+    const getWarpCoreConfig = (): WarpCoreConfig =>
+      ({
+        tokens: Object.keys(config).map((currentChain) => ({
+          addressOrDenom:
+            contractsMap[currentChain][
+              currentChain === chain
+                ? TokenType.XERC20
+                : config[currentChain].type
+            ].address,
+          chainName: currentChain,
+        })),
+      }) as WarpCoreConfig;
+
+    beforeEach(async () => {
+      sandbox = sinon.createSandbox();
+      // The test chains declare a placeholder Etherscan explorer, and the bridge
+      // scan would spend a network round trip on it before falling through. The
+      // RPC is the path this exercises.
+      sandbox.stub(multiProvider, 'tryGetEvmExplorerMetadataList').returns([]);
+
+      const { name, decimals, symbol } = config[chain];
+      assert(
+        name && symbol && !isNullish(decimals),
+        `Missing token metadata for ${chain}`,
+      );
+      veloToken = await new XERC20VSTest__factory(signer).deploy(
+        name,
+        symbol,
+        totalSupply,
+        decimals,
+      );
+
+      contractsMap = await deployer.deploy(veloConfig());
+
+      // The route's own router is a bridge of the token like any other, and the
+      // extra bridge is an address nothing but the token's events knows about.
+      extraBridge = randomAddress();
+      for (const bridge of [
+        contractsMap[chain][TokenType.XERC20].address,
+        extraBridge,
+      ]) {
+        await veloToken
+          .addBridge({ bridge, ...BRIDGE_LIMITS })
+          .then((tx) => tx.wait());
+      }
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('reports no violations for a bridge discovered from the token', async () => {
+      const result = await checkWarpRouteDeployConfig({
+        multiProvider,
+        warpCoreConfig: getWarpCoreConfig(),
+        warpDeployConfig: veloConfig([
+          { lockbox: extraBridge, limits: VELO_LIMITS },
+        ]),
+      });
+
+      expect(result.diff).to.deep.equal({});
+      expect(result.violations).to.deep.equal([]);
+      expect(result.isValid).to.equal(true);
+    });
+
+    // Guards the assertion above against passing because the declared limits
+    // were echoed back rather than read: declare the same bridge with limits
+    // the token does not hold and the check has to report it.
+    it('reports drift when the declared limits are not the ones the token holds', async () => {
+      const result = await checkWarpRouteDeployConfig({
+        multiProvider,
+        warpCoreConfig: getWarpCoreConfig(),
+        warpDeployConfig: veloConfig([
+          {
+            lockbox: extraBridge,
+            limits: {
+              type: XERC20Type.Velo,
+              bufferCap: '1',
+              rateLimitPerSecond: '1',
+            },
+          },
+        ]),
+      });
+
+      expect(result.isValid).to.equal(false);
+      expect(
+        result.violations.map(({ chain: violationChain, name }) => ({
+          chain: violationChain,
+          name,
+        })),
+      ).to.deep.equal([
+        { chain, name: 'xERC20.extraBridges.0.limits.bufferCap' },
+        { chain, name: 'xERC20.extraBridges.0.limits.rateLimitPerSecond' },
+      ]);
+    });
+
+    // A bridge on chain that the deploy config does not name is drift the check
+    // exists to surface, and it is only visible because the bridge set is read
+    // from the token rather than from the config.
+    it('reports a bridge the deploy config does not name', async () => {
+      const result = await checkWarpRouteDeployConfig({
+        multiProvider,
+        warpCoreConfig: getWarpCoreConfig(),
+        warpDeployConfig: veloConfig(),
+      });
+
+      expect(result.isValid).to.equal(false);
+      // isValid alone is true of any drift on any field, so the violation has
+      // to name the bridge for this to be about the bridge.
+      expect(
+        result.violations.map(({ chain: violationChain, name, actual }) => ({
+          chain: violationChain,
+          name,
+          namesTheBridge: actual.includes(extraBridge.toLowerCase()),
+        })),
+      ).to.deep.equal([
+        { chain, name: 'xERC20.extraBridges', namesTheBridge: true },
+      ]);
+    });
+  });
 
   describe('RateLimitedIsm with non-deployer warp owner', () => {
     let ismDeployer: HypERC20Deployer;

--- a/typescript/sdk/src/token/deploy.hardhat-test.ts
+++ b/typescript/sdk/src/token/deploy.hardhat-test.ts
@@ -889,11 +889,13 @@ describe('TokenDeployer', async () => {
 
   describe('checkWarpRouteDeployConfig for a Velodrome xERC20', () => {
     // The values the CLI e2e uses, which XERC20VSTest accepts for addBridge.
-    const BRIDGE_LIMITS = {
-      bufferCap: '1000000000000000000000',
-      rateLimitPerSecond: '1000000000000000000',
+    const BUFFER_CAP = '1000000000000000000000';
+    const RATE_LIMIT_PER_SECOND = '1000000000000000000';
+    const VELO_LIMITS = {
+      type: XERC20Type.Velo,
+      bufferCap: BUFFER_CAP,
+      rateLimitPerSecond: RATE_LIMIT_PER_SECOND,
     };
-    const VELO_LIMITS = { type: XERC20Type.Velo, ...BRIDGE_LIMITS };
 
     let sandbox: sinon.SinonSandbox;
     let veloToken: XERC20VSTest;
@@ -957,7 +959,11 @@ describe('TokenDeployer', async () => {
         extraBridge,
       ]) {
         await veloToken
-          .addBridge({ bridge, ...BRIDGE_LIMITS })
+          .addBridge({
+            bridge,
+            bufferCap: BUFFER_CAP,
+            rateLimitPerSecond: RATE_LIMIT_PER_SECOND,
+          })
           .then((tx) => tx.wait());
       }
     });
@@ -971,6 +977,34 @@ describe('TokenDeployer', async () => {
         multiProvider,
         warpCoreConfig: getWarpCoreConfig(),
         warpDeployConfig: veloConfig([
+          { lockbox: extraBridge, limits: VELO_LIMITS },
+        ]),
+      });
+
+      expect(result.diff).to.deep.equal({});
+      expect(result.violations).to.deep.equal([]);
+      expect(result.isValid).to.equal(true);
+    });
+
+    // Discovery follows the order the token announced its bridges in and the
+    // deploy config follows whoever wrote it. Comparing the two index by index
+    // reports the same set of bridges in two orders as drift.
+    it('reports no violations when the deploy config names the bridges in another order', async () => {
+      const laterBridge = randomAddress();
+      await veloToken
+        .addBridge({
+          bridge: laterBridge,
+          bufferCap: BUFFER_CAP,
+          rateLimitPerSecond: RATE_LIMIT_PER_SECOND,
+        })
+        .then((tx) => tx.wait());
+
+      const result = await checkWarpRouteDeployConfig({
+        multiProvider,
+        warpCoreConfig: getWarpCoreConfig(),
+        // Announced extraBridge first, so name it last.
+        warpDeployConfig: veloConfig([
+          { lockbox: laterBridge, limits: VELO_LIMITS },
           { lockbox: extraBridge, limits: VELO_LIMITS },
         ]),
       });

--- a/typescript/sdk/src/token/xerc20-abi.ts
+++ b/typescript/sdk/src/token/xerc20-abi.ts
@@ -38,3 +38,47 @@ export const CONFIGURATION_CHANGED_EVENT_SELECTOR = toEventSelector(
     name: 'ConfigurationChanged',
   }),
 );
+
+/**
+ * Minimal ABI for the event a Standard XERC20 emits when a bridge's limits are
+ * set. The bridge is the only indexed parameter, so a log carries it in
+ * topics[1] whichever implementation emitted it.
+ *
+ * Not the `BridgeLimitsSet(address,uint256)` that IXERC20VS.sol declares: the
+ * deployed Standard tokens emit this three-parameter form, and querying the
+ * other signature's topic returns nothing.
+ */
+export const XERC20_STANDARD_ABI = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: '_mintingLimit',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: '_burningLimit',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: '_bridge',
+        type: 'address',
+      },
+    ],
+    name: 'BridgeLimitsSet',
+    type: 'event',
+  },
+] as const;
+
+export const BRIDGE_LIMITS_SET_EVENT_SELECTOR = toEventSelector(
+  getAbiItem({
+    abi: XERC20_STANDARD_ABI,
+    name: 'BridgeLimitsSet',
+  }),
+);

--- a/typescript/sdk/src/token/xerc20-limits.ts
+++ b/typescript/sdk/src/token/xerc20-limits.ts
@@ -1,0 +1,138 @@
+import { Address, assert } from '@hyperlane-xyz/utils';
+
+import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
+import { ChainName } from '../types.js';
+
+import {
+  EvmXERC20Adapter,
+  EvmXERC20VSAdapter,
+} from './adapters/EvmTokenAdapter.js';
+import { RateLimitMidPoint, xERC20Limits } from './adapters/ITokenAdapter.js';
+import { XERC20Type } from './types.js';
+
+export interface StandardXERC20Limits {
+  type: typeof XERC20Type.Standard;
+  mint: string;
+  burn: string;
+}
+
+export interface VeloXERC20Limits {
+  type: typeof XERC20Type.Velo;
+  bufferCap: string;
+  rateLimitPerSecond: string;
+}
+
+/**
+ * Unified XERC20 limits type
+ */
+export type XERC20Limits = StandardXERC20Limits | VeloXERC20Limits;
+
+/**
+ * Map of bridge addresses to their limits
+ */
+export type XERC20LimitsMap = Record<Address, XERC20Limits>;
+
+function toStandardLimits(limits: xERC20Limits): StandardXERC20Limits {
+  return {
+    type: XERC20Type.Standard,
+    mint: limits.mint.toString(),
+    burn: limits.burn.toString(),
+  };
+}
+
+function toVeloLimits(rateLimits: RateLimitMidPoint): VeloXERC20Limits {
+  return {
+    type: XERC20Type.Velo,
+    bufferCap: rateLimits.bufferCap.toString(),
+    rateLimitPerSecond: rateLimits.rateLimitPerSecond.toString(),
+  };
+}
+
+/**
+ * Reads the current limits the xERC20 holds for each bridge, keyed by the
+ * bridge address as it was passed in.
+ *
+ * Which getter answers depends on the implementation, so the type decides:
+ * Velodrome exposes the whole rate limit struct through `rateLimits`, while a
+ * canonical xERC20 exposes `mintingMaxLimitOf`/`burningMaxLimitOf`. Both are
+ * read from the token itself rather than from the events it emitted, so a
+ * limit changed by an implementation that emits nothing, or emits an event
+ * this SDK does not know, is still reported at its current value.
+ */
+export async function readXERC20Limits({
+  multiProtocolProvider,
+  chain,
+  xERC20Address,
+  bridges,
+  type,
+}: {
+  multiProtocolProvider: MultiProtocolProvider;
+  chain: ChainName;
+  xERC20Address: Address;
+  bridges: Address[];
+  type: XERC20Type;
+}): Promise<XERC20LimitsMap> {
+  const readLimitsOf =
+    type === XERC20Type.Standard
+      ? standardLimitsReader(chain, multiProtocolProvider, xERC20Address)
+      : veloLimitsReader(chain, multiProtocolProvider, xERC20Address);
+
+  const limits = await Promise.all(bridges.map(readLimitsOf));
+
+  const limitsMap: XERC20LimitsMap = {};
+  bridges.forEach((bridge, index) => {
+    const bridgeLimits = limits[index];
+    assert(bridgeLimits, `Missing xERC20 limits for bridge ${bridge}`);
+    limitsMap[bridge] = bridgeLimits;
+  });
+
+  return limitsMap;
+}
+
+function standardLimitsReader(
+  chain: ChainName,
+  multiProtocolProvider: MultiProtocolProvider,
+  xERC20Address: Address,
+): (bridge: Address) => Promise<XERC20Limits> {
+  const adapter = new EvmXERC20Adapter(chain, multiProtocolProvider, {
+    token: xERC20Address,
+  });
+
+  return async (bridge) => toStandardLimits(await adapter.getLimits(bridge));
+}
+
+function veloLimitsReader(
+  chain: ChainName,
+  multiProtocolProvider: MultiProtocolProvider,
+  xERC20Address: Address,
+): (bridge: Address) => Promise<XERC20Limits> {
+  const adapter = new EvmXERC20VSAdapter(chain, multiProtocolProvider, {
+    token: xERC20Address,
+  });
+
+  return async (bridge) => toVeloLimits(await adapter.getRateLimits(bridge));
+}
+
+export function limitsAreZero(limits: XERC20Limits): boolean {
+  if (limits.type === XERC20Type.Standard) {
+    return limits.mint === '0' && limits.burn === '0';
+  }
+  return limits.bufferCap === '0' && limits.rateLimitPerSecond === '0';
+}
+
+export function limitsMatch(a: XERC20Limits, b: XERC20Limits): boolean {
+  if (a.type !== b.type) return false;
+
+  if (a.type === XERC20Type.Standard && b.type === XERC20Type.Standard) {
+    return a.mint === b.mint && a.burn === b.burn;
+  }
+
+  if (a.type === XERC20Type.Velo && b.type === XERC20Type.Velo) {
+    return (
+      a.bufferCap === b.bufferCap &&
+      a.rateLimitPerSecond === b.rateLimitPerSecond
+    );
+  }
+
+  return false;
+}

--- a/typescript/sdk/src/token/xerc20-limits.ts
+++ b/typescript/sdk/src/token/xerc20-limits.ts
@@ -1,5 +1,6 @@
-import { Address, assert } from '@hyperlane-xyz/utils';
+import { Address, assert, concurrentMap } from '@hyperlane-xyz/utils';
 
+import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { ChainName } from '../types.js';
 
@@ -32,7 +33,7 @@ export type XERC20Limits = StandardXERC20Limits | VeloXERC20Limits;
  */
 export type XERC20LimitsMap = Record<Address, XERC20Limits>;
 
-function toStandardLimits(limits: xERC20Limits): StandardXERC20Limits {
+export function toStandardLimits(limits: xERC20Limits): StandardXERC20Limits {
   return {
     type: XERC20Type.Standard,
     mint: limits.mint.toString(),
@@ -40,12 +41,23 @@ function toStandardLimits(limits: xERC20Limits): StandardXERC20Limits {
   };
 }
 
-function toVeloLimits(rateLimits: RateLimitMidPoint): VeloXERC20Limits {
+export function toVeloLimits(rateLimits: RateLimitMidPoint): VeloXERC20Limits {
   return {
     type: XERC20Type.Velo,
     bufferCap: rateLimits.bufferCap.toString(),
     rateLimitPerSecond: rateLimits.rateLimitPerSecond.toString(),
   };
+}
+
+/**
+ * The conversions from what a token's getters return to the limits this SDK
+ * reports. EvmXERC20Reader exposes them as protected methods, so its
+ * readLimits hands its own bound versions here and a subclass overriding one
+ * still decides what its reader reports.
+ */
+export interface XERC20LimitsConverters {
+  toStandardLimits: (limits: xERC20Limits) => StandardXERC20Limits;
+  toVeloLimits: (rateLimits: RateLimitMidPoint) => VeloXERC20Limits;
 }
 
 /**
@@ -58,6 +70,12 @@ function toVeloLimits(rateLimits: RateLimitMidPoint): VeloXERC20Limits {
  * read from the token itself rather than from the events it emitted, so a
  * limit changed by an implementation that emits nothing, or emits an event
  * this SDK does not know, is still reported at its current value.
+ *
+ * The bridges are read at the chain's configured RPC concurrency. Discovery
+ * hands over every address the token ever announced, deactivated ones included
+ * because the zero-limit filter runs on what is read here, and a Standard token
+ * costs two calls per bridge, so a token with a long history would otherwise
+ * open that whole history's worth of reads at once.
  */
 export async function readXERC20Limits({
   multiProtocolProvider,
@@ -65,19 +83,36 @@ export async function readXERC20Limits({
   xERC20Address,
   bridges,
   type,
+  converters = { toStandardLimits, toVeloLimits },
 }: {
   multiProtocolProvider: MultiProtocolProvider;
   chain: ChainName;
   xERC20Address: Address;
   bridges: Address[];
   type: XERC20Type;
+  converters?: XERC20LimitsConverters;
 }): Promise<XERC20LimitsMap> {
   const readLimitsOf =
     type === XERC20Type.Standard
-      ? standardLimitsReader(chain, multiProtocolProvider, xERC20Address)
-      : veloLimitsReader(chain, multiProtocolProvider, xERC20Address);
+      ? standardLimitsReader(
+          chain,
+          multiProtocolProvider,
+          xERC20Address,
+          converters.toStandardLimits,
+        )
+      : veloLimitsReader(
+          chain,
+          multiProtocolProvider,
+          xERC20Address,
+          converters.toVeloLimits,
+        );
 
-  const limits = await Promise.all(bridges.map(readLimitsOf));
+  const limits = await concurrentMap(
+    multiProtocolProvider.tryGetRpcConcurrency(chain) ??
+      DEFAULT_CONTRACT_READ_CONCURRENCY,
+    bridges,
+    readLimitsOf,
+  );
 
   const limitsMap: XERC20LimitsMap = {};
   bridges.forEach((bridge, index) => {
@@ -93,24 +128,26 @@ function standardLimitsReader(
   chain: ChainName,
   multiProtocolProvider: MultiProtocolProvider,
   xERC20Address: Address,
+  toLimits: XERC20LimitsConverters['toStandardLimits'],
 ): (bridge: Address) => Promise<XERC20Limits> {
   const adapter = new EvmXERC20Adapter(chain, multiProtocolProvider, {
     token: xERC20Address,
   });
 
-  return async (bridge) => toStandardLimits(await adapter.getLimits(bridge));
+  return async (bridge) => toLimits(await adapter.getLimits(bridge));
 }
 
 function veloLimitsReader(
   chain: ChainName,
   multiProtocolProvider: MultiProtocolProvider,
   xERC20Address: Address,
+  toLimits: XERC20LimitsConverters['toVeloLimits'],
 ): (bridge: Address) => Promise<XERC20Limits> {
   const adapter = new EvmXERC20VSAdapter(chain, multiProtocolProvider, {
     token: xERC20Address,
   });
 
-  return async (bridge) => toVeloLimits(await adapter.getRateLimits(bridge));
+  return async (bridge) => toLimits(await adapter.getRateLimits(bridge));
 }
 
 export function limitsAreZero(limits: XERC20Limits): boolean {

--- a/typescript/sdk/src/token/xerc20.test.ts
+++ b/typescript/sdk/src/token/xerc20.test.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { TestChainName } from '../consts/testChains.js';
+import { EIP1967_IMPLEMENTATION_SLOT } from '../deploy/proxy.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
 import { GetEventLogsResponse } from '../rpc/evm/types.js';
@@ -27,7 +28,6 @@ chai.use(chaiAsPromised);
 
 const PROXY_ADDRESS = '0x1111111111111111111111111111111111111111';
 const IMPLEMENTATION_ADDRESS = '0x2222222222222222222222222222222222222222';
-const PROXY_ADMIN_ADDRESS = '0x3333333333333333333333333333333333333333';
 
 const setBufferCapSelector = ethers.utils
   .id('setBufferCap(address,uint256)')
@@ -37,13 +37,6 @@ const setLimitsSelector = ethers.utils
   .id('setLimits(address,uint256,uint256)')
   .slice(2, 10)
   .toLowerCase();
-
-// EIP-1967 admin slot read by proxyAdmin() / isProxy().
-const ADMIN_SLOT =
-  '0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103';
-// EIP-1967 implementation slot read by proxyImplementation().
-const IMPLEMENTATION_SLOT =
-  '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
 
 function storageAddress(address: string): string {
   return ethers.utils.hexZeroPad(address, 32);
@@ -77,15 +70,15 @@ const cases: Case[] = [
   },
   {
     // Proxy bytecode is a delegatecall stub lacking the selectors; the
-    // implementation bytecode carries the Velodrome selector.
+    // implementation bytecode carries the Velodrome selector. The admin slot is
+    // left out so the stub throws if the derivation reads one.
     name: 'inspects the implementation bytecode when the Velo token is behind a proxy',
     code: {
       [PROXY_ADDRESS]: '0xdead',
       [IMPLEMENTATION_ADDRESS]: `0x${setBufferCapSelector}`,
     },
     storage: {
-      [ADMIN_SLOT]: storageAddress(PROXY_ADMIN_ADDRESS),
-      [IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+      [EIP1967_IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
     },
     expected: { type: XERC20Type.Velo },
   },
@@ -97,10 +90,50 @@ const cases: Case[] = [
       [IMPLEMENTATION_ADDRESS]: `0x${setLimitsSelector}`,
     },
     storage: {
-      [ADMIN_SLOT]: storageAddress(PROXY_ADMIN_ADDRESS),
-      [IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+      [EIP1967_IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
     },
     expected: { type: XERC20Type.Standard },
+  },
+  {
+    // A UUPS proxy keeps its upgrade logic in the implementation, so its admin
+    // slot is empty. Reading the implementation off an admin would skip the
+    // only bytecode carrying the selectors; omitting the admin slot here makes
+    // the stub throw if it is consulted.
+    name: 'inspects the implementation bytecode of a Velo token behind a UUPS proxy',
+    code: {
+      [PROXY_ADDRESS]: '0xdead',
+      [IMPLEMENTATION_ADDRESS]: `0x${setBufferCapSelector}`,
+    },
+    storage: {
+      [EIP1967_IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+    },
+    expected: { type: XERC20Type.Velo },
+  },
+  {
+    name: 'inspects the implementation bytecode of a Standard token behind a UUPS proxy',
+    code: {
+      [PROXY_ADDRESS]: '0xdead',
+      [IMPLEMENTATION_ADDRESS]: `0x${setLimitsSelector}`,
+    },
+    storage: {
+      [EIP1967_IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+    },
+    expected: { type: XERC20Type.Standard },
+  },
+  {
+    // Nothing behind the address to inspect, so the zero implementation must
+    // not be fetched as though it were one.
+    name: 'throws when the implementation slot is empty',
+    code: { [PROXY_ADDRESS]: '0xdead' },
+    storage: {
+      [EIP1967_IMPLEMENTATION_SLOT]: storageAddress(
+        ethers.constants.AddressZero,
+      ),
+    },
+    expected: {
+      errorIncludes:
+        'does not implement Standard or Velodrome XERC20 interface',
+    },
   },
   {
     // Proxy resolves to an implementation that still lacks both selectors.
@@ -110,8 +143,7 @@ const cases: Case[] = [
       [IMPLEMENTATION_ADDRESS]: '0xbeef',
     },
     storage: {
-      [ADMIN_SLOT]: storageAddress(PROXY_ADMIN_ADDRESS),
-      [IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
+      [EIP1967_IMPLEMENTATION_SLOT]: storageAddress(IMPLEMENTATION_ADDRESS),
     },
     expected: {
       errorIncludes:

--- a/typescript/sdk/src/token/xerc20.test.ts
+++ b/typescript/sdk/src/token/xerc20.test.ts
@@ -3,14 +3,25 @@ import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'ethers';
 import sinon from 'sinon';
 
+import { assert } from '@hyperlane-xyz/utils';
+
 import { TestChainName } from '../consts/testChains.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
 import { GetEventLogsResponse } from '../rpc/evm/types.js';
+import { viemLogFromGetEventLogsResponse } from '../rpc/evm/utils.js';
 
 import { XERC20TokenExtraBridgesLimits, XERC20Type } from './types.js';
-import { CONFIGURATION_CHANGED_EVENT_SELECTOR } from './xerc20-abi.js';
-import { deriveXERC20TokenType, getExtraLockBoxConfigs } from './xerc20.js';
+import {
+  BRIDGE_LIMITS_SET_EVENT_SELECTOR,
+  CONFIGURATION_CHANGED_EVENT_SELECTOR,
+} from './xerc20-abi.js';
+import {
+  UnknownXERC20TypeError,
+  deriveXERC20TokenType,
+  getExtraLockBoxConfigs,
+  latestConfigurationPerBridge,
+} from './xerc20.js';
 
 chai.use(chaiAsPromised);
 
@@ -179,22 +190,94 @@ describe('deriveXERC20TokenType', () => {
   }
 });
 
+describe('UnknownXERC20TypeError', () => {
+  let sandbox: sinon.SinonSandbox;
+  let multiProvider: MultiProvider;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    multiProvider = MultiProvider.createTestMultiProvider();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // Callers tell an undetectable interface apart from a failure to read the
+  // bytecode by the error type, so the type is part of the contract.
+  it('is thrown when the contract implements neither known interface', async () => {
+    const provider = multiProvider.getProvider(TestChainName.test1);
+    sandbox.stub(provider, 'getCode').resolves('0xbeef');
+    sandbox
+      .stub(provider, 'getStorageAt')
+      .resolves(storageAddress(PROXY_ADDRESS));
+
+    let thrown: unknown;
+    try {
+      await deriveXERC20TokenType(
+        multiProvider,
+        TestChainName.test1,
+        PROXY_ADDRESS,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.be.instanceOf(UnknownXERC20TypeError);
+  });
+
+  it('is not thrown when the bytecode cannot be read at all', async () => {
+    const provider = multiProvider.getProvider(TestChainName.test1);
+    const transientError = new Error('Invalid response from provider');
+    sandbox.stub(provider, 'getCode').rejects(transientError);
+
+    let thrown: unknown;
+    try {
+      await deriveXERC20TokenType(
+        multiProvider,
+        TestChainName.test1,
+        PROXY_ADDRESS,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).to.equal(transientError);
+  });
+});
+
 const XERC20_ADDRESS = '0x6666666666666666666666666666666666666666';
 const BRIDGE_A = '0x4444444444444444444444444444444444444444';
 const BRIDGE_B = '0x5555555555555555555555555555555555555555';
-// Value returned by a lockbox's XERC20() getter; never asserted on.
-const LOCKBOX_XERC20 = '0x7777777777777777777777777777777777777777';
+// A mainnet warp route router, which its xERC20 holds bridge limits for like
+// any other bridge. Those limits are reported as warpRouteLimits, never as an
+// extra bridge.
+const WARP_ROUTER = '0x88AC0fC430130983c0DDEB4C22574056D8340Ca8';
 
+const rateLimitsSelector = ethers.utils.id('rateLimits(address)').slice(0, 10);
+const mintingMaxLimitOfSelector = ethers.utils
+  .id('mintingMaxLimitOf(address)')
+  .slice(0, 10);
+const burningMaxLimitOfSelector = ethers.utils
+  .id('burningMaxLimitOf(address)')
+  .slice(0, 10);
+
+type OnChainLimits =
+  | { bufferCap: string; rateLimitPerSecond: string }
+  | { mint: string; burn: string };
+
+// The scan reads the bridge out of topics[1] and nothing else, so the payload
+// only matters to latestConfigurationPerBridge, which parses it.
 function configurationChangedLog({
   bridge,
-  bufferCap,
-  rateLimitPerSecond,
+  bufferCap = 100,
+  rateLimitPerSecond = 1,
   blockNumber,
   logIndex = 0,
 }: {
   bridge: string;
-  bufferCap: number;
-  rateLimitPerSecond: number;
+  bufferCap?: number;
+  rateLimitPerSecond?: number;
   blockNumber: number;
   logIndex?: number;
 }): GetEventLogsResponse {
@@ -215,197 +298,56 @@ function configurationChangedLog({
   };
 }
 
-interface LockboxCase {
+function bridgeLimitsSetLog({
+  bridge,
+  blockNumber,
+  logIndex = 0,
+}: {
+  bridge: string;
+  blockNumber: number;
+  logIndex?: number;
+}): GetEventLogsResponse {
+  return {
+    address: XERC20_ADDRESS,
+    blockNumber,
+    data: ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'uint256'],
+      [100, 100],
+    ),
+    logIndex,
+    topics: [
+      BRIDGE_LIMITS_SET_EVENT_SELECTOR,
+      ethers.utils.hexZeroPad(bridge, 32),
+    ],
+    transactionHash: ethers.utils.hexZeroPad(`0x${blockNumber}`, 32),
+    transactionIndex: 0,
+  };
+}
+
+interface BridgeCase {
   name: string;
+  type: XERC20Type;
   logs: GetEventLogsResponse[];
-  // Bridges whose XERC20() getter resolves. Any other bridge reverts with
-  // empty return data, like a contract missing the selector would.
-  lockboxBridges: string[];
+  warpRouteAddress?: string;
+  // Limits the token reports for each bridge, keyed by lowercased address. A
+  // bridge missing from here is one the token holds no limits for.
+  onChainLimits: Record<string, OnChainLimits>;
   expected: XERC20TokenExtraBridgesLimits[];
 }
 
-const lockboxCases: LockboxCase[] = [
+const bridgeCases: BridgeCase[] = [
   {
-    name: 'keeps only the most recent configuration of a bridge',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 100,
-        rateLimitPerSecond: 1,
-        blockNumber: 10,
-      }),
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 500,
-        rateLimitPerSecond: 2,
-        blockNumber: 20,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A],
+    // Every non-lockbox bridge used to be dropped, because the reader kept only
+    // the addresses answering the lockbox XERC20() getter.
+    name: 'reports a configured bridge that is not a lockbox',
+    type: XERC20Type.Velo,
+    logs: [configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 10 })],
+    onChainLimits: {
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '100', rateLimitPerSecond: '1' },
+    },
     expected: [
       {
-        lockbox: BRIDGE_A,
-        limits: {
-          type: XERC20Type.Velo,
-          bufferCap: '500',
-          rateLimitPerSecond: '2',
-        },
-      },
-    ],
-  },
-  {
-    // A bridge can be reconfigured twice in the same block, so ordering on the
-    // block number alone kept the first configuration instead of the last.
-    name: 'keeps the highest logIndex configuration of a bridge within a block',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 100,
-        rateLimitPerSecond: 1,
-        blockNumber: 10,
-        logIndex: 3,
-      }),
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 500,
-        rateLimitPerSecond: 2,
-        blockNumber: 10,
-        logIndex: 7,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A],
-    expected: [
-      {
-        lockbox: BRIDGE_A,
-        limits: {
-          type: XERC20Type.Velo,
-          bufferCap: '500',
-          rateLimitPerSecond: '2',
-        },
-      },
-    ],
-  },
-  {
-    // The same-block tiebreaker must not depend on the order the logs arrive in
-    name: 'keeps the highest logIndex configuration when logs arrive out of order',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 500,
-        rateLimitPerSecond: 2,
-        blockNumber: 10,
-        logIndex: 7,
-      }),
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 100,
-        rateLimitPerSecond: 1,
-        blockNumber: 10,
-        logIndex: 3,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A],
-    expected: [
-      {
-        lockbox: BRIDGE_A,
-        limits: {
-          type: XERC20Type.Velo,
-          bufferCap: '500',
-          rateLimitPerSecond: '2',
-        },
-      },
-    ],
-  },
-  {
-    // Deduplication must run before the zero-limit filter, otherwise the stale
-    // non-zero configuration would keep a deactivated bridge alive.
-    name: 'drops a bridge whose most recent configuration zeroes both limits',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 100,
-        rateLimitPerSecond: 1,
-        blockNumber: 10,
-      }),
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 0,
-        rateLimitPerSecond: 0,
-        blockNumber: 20,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A],
-    expected: [],
-  },
-  {
-    name: 'drops a bridge configured with both limits set to zero',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 0,
-        rateLimitPerSecond: 0,
-        blockNumber: 10,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A],
-    expected: [],
-  },
-  {
-    name: 'keeps bridges where either limit is non zero',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 0,
-        rateLimitPerSecond: 7,
-        blockNumber: 10,
-      }),
-      configurationChangedLog({
-        bridge: BRIDGE_B,
-        bufferCap: 9,
-        rateLimitPerSecond: 0,
-        blockNumber: 11,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A, BRIDGE_B],
-    expected: [
-      {
-        lockbox: BRIDGE_A,
-        limits: {
-          type: XERC20Type.Velo,
-          bufferCap: '0',
-          rateLimitPerSecond: '7',
-        },
-      },
-      {
-        lockbox: BRIDGE_B,
-        limits: {
-          type: XERC20Type.Velo,
-          bufferCap: '9',
-          rateLimitPerSecond: '0',
-        },
-      },
-    ],
-  },
-  {
-    name: 'drops bridges that are not lockbox contracts',
-    logs: [
-      configurationChangedLog({
-        bridge: BRIDGE_A,
-        bufferCap: 100,
-        rateLimitPerSecond: 1,
-        blockNumber: 10,
-      }),
-      configurationChangedLog({
-        bridge: BRIDGE_B,
-        bufferCap: 200,
-        rateLimitPerSecond: 2,
-        blockNumber: 11,
-      }),
-    ],
-    lockboxBridges: [BRIDGE_A],
-    expected: [
-      {
-        lockbox: BRIDGE_A,
+        lockbox: BRIDGE_A.toLowerCase(),
         limits: {
           type: XERC20Type.Velo,
           bufferCap: '100',
@@ -415,96 +357,375 @@ const lockboxCases: LockboxCase[] = [
     ],
   },
   {
-    name: 'returns an empty list when no configuration events were emitted',
-    logs: [],
-    lockboxBridges: [],
+    // The route's router holds bridge limits like any other bridge, and the
+    // lockbox probe used to be what kept it out of the extra bridges.
+    name: "omits the warp route's own router",
+    type: XERC20Type.Velo,
+    logs: [
+      configurationChangedLog({ bridge: WARP_ROUTER, blockNumber: 10 }),
+      configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 11 }),
+    ],
+    warpRouteAddress: WARP_ROUTER,
+    onChainLimits: {
+      [WARP_ROUTER.toLowerCase()]: {
+        bufferCap: '300',
+        rateLimitPerSecond: '3',
+      },
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '100', rateLimitPerSecond: '1' },
+    },
+    expected: [
+      {
+        lockbox: BRIDGE_A.toLowerCase(),
+        limits: {
+          type: XERC20Type.Velo,
+          bufferCap: '100',
+          rateLimitPerSecond: '1',
+        },
+      },
+    ],
+  },
+  {
+    // The event is a record of a past announcement, not of the current state:
+    // only what the token holds now decides whether a bridge is active.
+    name: 'reports a bridge on the limits it holds, not the ones it was announced with',
+    type: XERC20Type.Velo,
+    logs: [configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 20 })],
+    onChainLimits: {
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '900', rateLimitPerSecond: '9' },
+    },
+    expected: [
+      {
+        lockbox: BRIDGE_A.toLowerCase(),
+        limits: {
+          type: XERC20Type.Velo,
+          bufferCap: '900',
+          rateLimitPerSecond: '9',
+        },
+      },
+    ],
+  },
+  {
+    name: 'drops a bridge the token holds no limits for',
+    type: XERC20Type.Velo,
+    logs: [configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 10 })],
+    onChainLimits: {
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '0', rateLimitPerSecond: '0' },
+    },
     expected: [],
   },
+  {
+    name: 'keeps a bridge where either limit is non zero',
+    type: XERC20Type.Velo,
+    logs: [
+      configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 10 }),
+      configurationChangedLog({ bridge: BRIDGE_B, blockNumber: 11 }),
+    ],
+    onChainLimits: {
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '0', rateLimitPerSecond: '7' },
+      [BRIDGE_B.toLowerCase()]: { bufferCap: '9', rateLimitPerSecond: '0' },
+    },
+    expected: [
+      {
+        lockbox: BRIDGE_A.toLowerCase(),
+        limits: {
+          type: XERC20Type.Velo,
+          bufferCap: '0',
+          rateLimitPerSecond: '7',
+        },
+      },
+      {
+        lockbox: BRIDGE_B.toLowerCase(),
+        limits: {
+          type: XERC20Type.Velo,
+          bufferCap: '9',
+          rateLimitPerSecond: '0',
+        },
+      },
+    ],
+  },
+  {
+    // A bridge is announced again every time its limits change, so the same
+    // address arrives many times over a token's history.
+    name: 'reports a bridge announced more than once only once',
+    type: XERC20Type.Velo,
+    logs: [
+      configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 10 }),
+      configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 20 }),
+      configurationChangedLog({
+        bridge: BRIDGE_A,
+        blockNumber: 20,
+        logIndex: 4,
+      }),
+    ],
+    onChainLimits: {
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '100', rateLimitPerSecond: '1' },
+    },
+    expected: [
+      {
+        lockbox: BRIDGE_A.toLowerCase(),
+        limits: {
+          type: XERC20Type.Velo,
+          bufferCap: '100',
+          rateLimitPerSecond: '1',
+        },
+      },
+    ],
+  },
+  {
+    // A Standard token announces its bridges through a different event and
+    // exposes no rateLimits getter, so it used to be invisible on both counts.
+    name: 'discovers and reports the bridges of a Standard xERC20',
+    type: XERC20Type.Standard,
+    logs: [
+      bridgeLimitsSetLog({ bridge: BRIDGE_A, blockNumber: 10 }),
+      bridgeLimitsSetLog({ bridge: BRIDGE_B, blockNumber: 11 }),
+    ],
+    onChainLimits: {
+      [BRIDGE_A.toLowerCase()]: { mint: '400', burn: '500' },
+      [BRIDGE_B.toLowerCase()]: { mint: '0', burn: '0' },
+    },
+    expected: [
+      {
+        lockbox: BRIDGE_A.toLowerCase(),
+        limits: { type: XERC20Type.Standard, mint: '400', burn: '500' },
+      },
+    ],
+  },
 ];
+
+const DEPLOYMENT_BLOCK = 5755967;
 
 describe('getExtraLockBoxConfigs', () => {
   let sandbox: sinon.SinonSandbox;
   let multiProvider: MultiProvider;
+  let deploymentBlock: sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     multiProvider = MultiProvider.createTestMultiProvider();
+    deploymentBlock = sandbox
+      .stub(EvmEventLogsReader.prototype, 'getContractDeploymentBlock')
+      .resolves(DEPLOYMENT_BLOCK);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
 
-  function stubLockboxCalls(lockboxBridges: string[]): void {
-    const lockboxes = new Set(lockboxBridges.map((b) => b.toLowerCase()));
+  // Serves the token's bytecode, which is what the type derivation reads, and
+  // the limit getter of that type. An address the token holds no limits for
+  // reverts with empty return data, like a getter reading an unset entry on a
+  // contract that does not have it.
+  function stubXERC20(
+    type: XERC20Type,
+    onChainLimits: Record<string, OnChainLimits>,
+  ): void {
     const provider = multiProvider.getProvider(TestChainName.test1);
+    sandbox
+      .stub(provider, 'getCode')
+      .resolves(
+        `0x${type === XERC20Type.Velo ? setBufferCapSelector : setLimitsSelector}`,
+      );
 
     sandbox.stub(provider, 'call').callsFake(async (transaction) => {
-      const to = await transaction.to;
-      if (typeof to === 'string' && lockboxes.has(to.toLowerCase())) {
+      const data = await transaction.data;
+      assert(typeof data === 'string', 'Expected call data');
+      const selector = data.slice(0, 10);
+      const [bridge] = ethers.utils.defaultAbiCoder.decode(
+        ['address'],
+        `0x${data.slice(10)}`,
+      );
+      const limits = onChainLimits[bridge.toLowerCase()];
+      if (!limits) {
+        throw Object.assign(new Error('call revert exception'), {
+          code: 'CALL_EXCEPTION',
+          data: '0x',
+        });
+      }
+
+      if (selector === rateLimitsSelector && 'bufferCap' in limits) {
         return ethers.utils.defaultAbiCoder.encode(
-          ['address'],
-          [LOCKBOX_XERC20],
+          ['tuple(uint128,uint112,uint32,uint112,uint112)'],
+          [[limits.rateLimitPerSecond, limits.bufferCap, 0, 0, 0]],
         );
       }
 
-      throw Object.assign(new Error('call revert exception'), {
-        code: 'CALL_EXCEPTION',
-        data: '0x',
-      });
+      if (selector === mintingMaxLimitOfSelector && 'mint' in limits) {
+        return ethers.utils.defaultAbiCoder.encode(['uint256'], [limits.mint]);
+      }
+
+      if (selector === burningMaxLimitOfSelector && 'burn' in limits) {
+        return ethers.utils.defaultAbiCoder.encode(['uint256'], [limits.burn]);
+      }
+
+      throw new Error(`Unexpected call ${selector} for ${bridge}`);
     });
   }
 
-  for (const c of lockboxCases) {
+  for (const c of bridgeCases) {
     it(c.name, async () => {
       sandbox
         .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
         .resolves(c.logs);
-      stubLockboxCalls(c.lockboxBridges);
+      stubXERC20(c.type, c.onChainLimits);
 
       const result = await getExtraLockBoxConfigs({
         chain: TestChainName.test1,
         xERC20Address: XERC20_ADDRESS,
         multiProvider,
+        warpRouteAddress: c.warpRouteAddress,
       });
 
       expect(result).to.deep.equal(c.expected);
     });
   }
 
-  it('reads the ConfigurationChanged logs with the xERC20 scan block range', async () => {
-    const fromConfig = sandbox.spy(EvmEventLogsReader, 'fromConfig');
-    const getLogsByTopic = sandbox
-      .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
-      .resolves([]);
-    stubLockboxCalls([]);
+  interface TopicCase {
+    name: string;
+    type: XERC20Type;
+    expectedTopic: string;
+  }
 
-    await getExtraLockBoxConfigs({
+  // Querying the wrong signature's topic returns nothing, which reads as a
+  // token with no bridges rather than as a scan that asked the wrong question.
+  const topicCases: TopicCase[] = [
+    {
+      name: 'scans the Velodrome event topic for a Velodrome xERC20',
+      type: XERC20Type.Velo,
+      expectedTopic:
+        '0xb4ff6a860e04455b1ce16833b74cde19765c95e55c5e7e4f5a69e9707d8cc96d',
+    },
+    {
+      name: 'scans the Standard event topic for a Standard xERC20',
+      type: XERC20Type.Standard,
+      expectedTopic:
+        '0x93f3bbfe8cfb354ec059175107653f49f6eb479a8622a7d83866ea015435c944',
+    },
+  ];
+
+  for (const c of topicCases) {
+    it(c.name, async () => {
+      const fromConfig = sandbox.spy(EvmEventLogsReader, 'fromConfig');
+      const getLogsByTopic = sandbox
+        .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
+        .resolves([
+          configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 10 }),
+        ]);
+      // Non-empty so the read settles on the first answer; what it asked for is
+      // what this pins.
+      stubXERC20(c.type, {
+        [BRIDGE_A.toLowerCase()]:
+          c.type === XERC20Type.Velo
+            ? { bufferCap: '1', rateLimitPerSecond: '1' }
+            : { mint: '1', burn: '1' },
+      });
+
+      await getExtraLockBoxConfigs({
+        chain: TestChainName.test1,
+        xERC20Address: XERC20_ADDRESS,
+        multiProvider,
+      });
+
+      expect(fromConfig.calledOnce).to.be.true;
+      expect(fromConfig.firstCall.args[0]).to.deep.equal({
+        chain: TestChainName.test1,
+        paginationBlockRange: 1_000_000,
+      });
+      expect(
+        getLogsByTopic.calledOnceWithExactly({
+          contractAddress: XERC20_ADDRESS,
+          eventTopic: c.expectedTopic,
+          fromBlock: DEPLOYMENT_BLOCK,
+        }),
+      ).to.be.true;
+    });
+  }
+
+  // A route's token holds limits for at least the route's own router, so it has
+  // announced at least one bridge: an explorer answering with none has failed to
+  // answer, which is indistinguishable from a token that has none until the RPC
+  // is asked. Two of the six oUSDT chains report exactly this way.
+  it('re-reads over the RPC when the explorer announces no bridges', async () => {
+    const fromConfig = sandbox.spy(EvmEventLogsReader, 'fromConfig');
+    const getLogsByTopic = sandbox.stub(
+      EvmEventLogsReader.prototype,
+      'getLogsByTopic',
+    );
+    getLogsByTopic.onFirstCall().resolves([]);
+    getLogsByTopic
+      .onSecondCall()
+      .resolves([
+        configurationChangedLog({ bridge: BRIDGE_A, blockNumber: 10 }),
+      ]);
+    stubXERC20(XERC20Type.Velo, {
+      [BRIDGE_A.toLowerCase()]: { bufferCap: '100', rateLimitPerSecond: '1' },
+    });
+
+    const result = await getExtraLockBoxConfigs({
+      chain: TestChainName.test1,
+      xERC20Address: XERC20_ADDRESS,
+      multiProvider,
+    });
+
+    // The deployment block is resolved once and handed to both reads. Letting
+    // the RPC reader derive it is what fails on a chain that serves no archive
+    // state, so a second resolution here is the defect this guards.
+    expect(deploymentBlock.calledOnce).to.be.true;
+    const query = {
+      contractAddress: XERC20_ADDRESS,
+      eventTopic:
+        '0xb4ff6a860e04455b1ce16833b74cde19765c95e55c5e7e4f5a69e9707d8cc96d',
+      fromBlock: DEPLOYMENT_BLOCK,
+    };
+    expect(getLogsByTopic.calledTwice).to.be.true;
+    expect(getLogsByTopic.firstCall.args[0]).to.deep.equal(query);
+    expect(getLogsByTopic.secondCall.args[0]).to.deep.equal(query);
+
+    expect(fromConfig.calledTwice).to.be.true;
+    expect(fromConfig.secondCall.args[0]).to.deep.equal({
+      chain: TestChainName.test1,
+      paginationBlockRange: 1_000_000,
+      useRPC: true,
+    });
+    expect(result).to.deep.equal([
+      {
+        lockbox: BRIDGE_A.toLowerCase(),
+        limits: {
+          type: XERC20Type.Velo,
+          bufferCap: '100',
+          rateLimitPerSecond: '1',
+        },
+      },
+    ]);
+  });
+
+  // The RPC is the reader's own fallback when a chain declares no explorer, so
+  // re-reading there would scan the token's whole history a second time to
+  // reach the answer it already gave.
+  it('does not re-read when the chain declares no block explorer', async () => {
+    sandbox.stub(multiProvider, 'tryGetEvmExplorerMetadataList').returns([]);
+    const fromConfig = sandbox.spy(EvmEventLogsReader, 'fromConfig');
+    sandbox.stub(EvmEventLogsReader.prototype, 'getLogsByTopic').resolves([]);
+    stubXERC20(XERC20Type.Velo, {});
+
+    const result = await getExtraLockBoxConfigs({
       chain: TestChainName.test1,
       xERC20Address: XERC20_ADDRESS,
       multiProvider,
     });
 
     expect(fromConfig.calledOnce).to.be.true;
-    expect(fromConfig.firstCall.args[0]).to.deep.equal({
-      chain: TestChainName.test1,
-      paginationBlockRange: 1_000_000,
-    });
-    expect(
-      getLogsByTopic.calledOnceWithExactly({
-        contractAddress: XERC20_ADDRESS,
-        eventTopic: CONFIGURATION_CHANGED_EVENT_SELECTOR,
-      }),
-    ).to.be.true;
+    expect(result).to.deep.equal([]);
   });
 
-  // A failed log read used to be swallowed into an empty list, which reported
-  // a token with extra lockboxes as having none.
-  it('propagates a log read failure instead of reporting no lockboxes', async () => {
-    sandbox
-      .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
-      .rejects(new Error('rpc down'));
-    stubLockboxCalls([]);
+  it('propagates an RPC re-read failure', async () => {
+    const getLogsByTopic = sandbox.stub(
+      EvmEventLogsReader.prototype,
+      'getLogsByTopic',
+    );
+    getLogsByTopic.onFirstCall().resolves([]);
+    getLogsByTopic.onSecondCall().rejects(new Error('rpc down'));
+    stubXERC20(XERC20Type.Velo, {});
 
     await expect(
       getExtraLockBoxConfigs({
@@ -514,4 +735,137 @@ describe('getExtraLockBoxConfigs', () => {
       }),
     ).to.be.rejectedWith('rpc down');
   });
+
+  // A failed log read used to be swallowed into an empty list, which reported
+  // a token with extra bridges as having none. The events are the only place
+  // the bridge addresses exist, so a failure to read them is the answer.
+  it('propagates a log read failure', async () => {
+    sandbox
+      .stub(EvmEventLogsReader.prototype, 'getLogsByTopic')
+      .rejects(new Error('rpc down'));
+    stubXERC20(XERC20Type.Velo, {});
+
+    await expect(
+      getExtraLockBoxConfigs({
+        chain: TestChainName.test1,
+        xERC20Address: XERC20_ADDRESS,
+        multiProvider,
+      }),
+    ).to.be.rejectedWith('rpc down');
+  });
+});
+
+describe('latestConfigurationPerBridge', () => {
+  interface OrderingCase {
+    name: string;
+    logs: GetEventLogsResponse[];
+    expected: Record<string, { bufferCap: bigint; rateLimitPerSecond: bigint }>;
+  }
+
+  const orderingCases: OrderingCase[] = [
+    {
+      name: 'keeps only the most recent configuration of a bridge',
+      logs: [
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 100,
+          rateLimitPerSecond: 1,
+          blockNumber: 10,
+        }),
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 500,
+          rateLimitPerSecond: 2,
+          blockNumber: 20,
+        }),
+      ],
+      expected: {
+        [BRIDGE_A.toLowerCase()]: { bufferCap: 500n, rateLimitPerSecond: 2n },
+      },
+    },
+    {
+      // A bridge can be reconfigured twice in the same block, so ordering on the
+      // block number alone kept the first configuration instead of the last.
+      name: 'keeps the highest logIndex configuration of a bridge within a block',
+      logs: [
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 100,
+          rateLimitPerSecond: 1,
+          blockNumber: 10,
+          logIndex: 3,
+        }),
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 500,
+          rateLimitPerSecond: 2,
+          blockNumber: 10,
+          logIndex: 7,
+        }),
+      ],
+      expected: {
+        [BRIDGE_A.toLowerCase()]: { bufferCap: 500n, rateLimitPerSecond: 2n },
+      },
+    },
+    {
+      // The same-block tiebreaker must not depend on the order the logs arrive in
+      name: 'keeps the highest logIndex configuration when logs arrive out of order',
+      logs: [
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 500,
+          rateLimitPerSecond: 2,
+          blockNumber: 10,
+          logIndex: 7,
+        }),
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 100,
+          rateLimitPerSecond: 1,
+          blockNumber: 10,
+          logIndex: 3,
+        }),
+      ],
+      expected: {
+        [BRIDGE_A.toLowerCase()]: { bufferCap: 500n, rateLimitPerSecond: 2n },
+      },
+    },
+    {
+      name: 'keeps every bridge that was configured',
+      logs: [
+        configurationChangedLog({
+          bridge: BRIDGE_A,
+          bufferCap: 100,
+          rateLimitPerSecond: 1,
+          blockNumber: 10,
+        }),
+        configurationChangedLog({
+          bridge: BRIDGE_B,
+          bufferCap: 200,
+          rateLimitPerSecond: 2,
+          blockNumber: 11,
+        }),
+      ],
+      expected: {
+        [BRIDGE_A.toLowerCase()]: { bufferCap: 100n, rateLimitPerSecond: 1n },
+        [BRIDGE_B.toLowerCase()]: { bufferCap: 200n, rateLimitPerSecond: 2n },
+      },
+    },
+  ];
+
+  for (const c of orderingCases) {
+    it(c.name, () => {
+      const latest = latestConfigurationPerBridge(
+        c.logs.map(viemLogFromGetEventLogsResponse),
+      );
+
+      expect([...latest.keys()]).to.have.members(Object.keys(c.expected));
+      for (const [bridge, limits] of Object.entries(c.expected)) {
+        const log = latest.get(bridge);
+        assert(log, `Missing configuration for ${bridge}`);
+        expect(log.args.bufferCap).to.equal(limits.bufferCap);
+        expect(log.args.rateLimitPerSecond).to.equal(limits.rateLimitPerSecond);
+      }
+    });
+  }
 });

--- a/typescript/sdk/src/token/xerc20.ts
+++ b/typescript/sdk/src/token/xerc20.ts
@@ -7,11 +7,12 @@ import {
   Address,
   assert,
   bytes32ToAddress,
+  eqAddress,
   normalizeAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { isProxy, proxyImplementation } from '../deploy/proxy.js';
+import { proxyImplementation } from '../deploy/proxy.js';
 import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
@@ -565,13 +566,19 @@ export async function deriveXERC20TokenType(
 
   // xERC20 tokens are commonly deployed behind a proxy whose bytecode does not
   // embed the implementation's selectors; inspect the implementation in that case.
+  //
+  // Keyed on the EIP-1967 implementation slot alone. A UUPS proxy keeps its
+  // upgrade logic in the implementation and leaves the admin slot empty, so
+  // deciding this on an admin the way isProxy does would skip the only bytecode
+  // that carries the selectors and leave the token looking like neither type.
   if (
     !normalizedCode.includes(setBufferCapSelector) &&
-    !normalizedCode.includes(setLimitsSelector) &&
-    (await isProxy(provider, address))
+    !normalizedCode.includes(setLimitsSelector)
   ) {
     const implementation = await proxyImplementation(provider, address);
-    normalizedCode = (await provider.getCode(implementation)).toLowerCase();
+    if (!eqAddress(implementation, ethers.constants.AddressZero)) {
+      normalizedCode = (await provider.getCode(implementation)).toLowerCase();
+    }
   }
 
   // Prefer Velodrome if both selectors are present.

--- a/typescript/sdk/src/token/xerc20.ts
+++ b/typescript/sdk/src/token/xerc20.ts
@@ -2,24 +2,21 @@ import { ethers } from 'ethers';
 import { Logger } from 'pino';
 import { Log, parseEventLogs } from 'viem';
 
-import {
-  HypXERC20Lockbox__factory,
-  IXERC20Lockbox__factory,
-} from '@hyperlane-xyz/core';
+import { HypXERC20Lockbox__factory } from '@hyperlane-xyz/core';
 import {
   Address,
   assert,
+  bytes32ToAddress,
   normalizeAddress,
   rootLogger,
 } from '@hyperlane-xyz/utils';
 
-import { isContractAddress } from '../contracts/contracts.js';
 import { isProxy, proxyImplementation } from '../deploy/proxy.js';
+import { MultiProtocolProvider } from '../providers/MultiProtocolProvider.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
-import { viemLogFromGetEventLogsResponse } from '../rpc/evm/utils.js';
+import { GetEventLogsResponse } from '../rpc/evm/types.js';
 import { ChainName, ChainNameOrId } from '../types.js';
-import { throwIfNotMissingSelector } from '../utils/contract.js';
 import { WarpCoreConfig } from '../warp/types.js';
 
 import { TokenType } from './config.js';
@@ -30,9 +27,11 @@ import {
   isXERC20TokenConfig,
 } from './types.js';
 import {
+  BRIDGE_LIMITS_SET_EVENT_SELECTOR,
   CONFIGURATION_CHANGED_EVENT_SELECTOR,
   XERC20_VS_ABI,
 } from './xerc20-abi.js';
+import { limitsAreZero, readXERC20Limits } from './xerc20-limits.js';
 
 // Bridge config types for Velodrome (VS) and Standard (WL) XERC20
 type BridgeConfigBase = {
@@ -59,6 +58,14 @@ export type GetExtraLockboxesOptions = {
   xERC20Address: Address;
   multiProvider: MultiProvider;
   logger?: Logger;
+  /** Known token type, when the caller has already derived it. */
+  type?: XERC20Type;
+  /**
+   * The warp route's own router. Its limits are reported separately as
+   * warpRouteLimits, so leaving it in here would double count the route as a
+   * bridge of itself.
+   */
+  warpRouteAddress?: Address;
 };
 
 // xERC20 tokens emit ConfigurationChanged rarely, so scanning them over the
@@ -68,30 +75,176 @@ export type GetExtraLockboxesOptions = {
 // reject the chunk, and getLogsFromRpc halves the range until it is accepted.
 export const XERC20_LOG_SCAN_BLOCK_RANGE = 1_000_000;
 
+/**
+ * Reads the bridges the xERC20 holds non-zero limits for, other than the warp
+ * route's own router.
+ *
+ * Neither xERC20 interface can list its bridges: every limit getter is keyed by
+ * a bridge address, so the set of addresses is only observable through the
+ * events the token emitted when those limits were set. Those events are
+ * therefore read for the addresses alone, and every limit is then read from the
+ * token, so a bridge reconfigured by something that emits nothing this SDK
+ * parses is still reported at the limits it currently holds.
+ */
 export async function getExtraLockBoxConfigs({
   xERC20Address,
   chain,
   multiProvider,
   logger = rootLogger,
+  type: knownType,
+  warpRouteAddress,
 }: GetExtraLockboxesOptions): Promise<XERC20TokenExtraBridgesLimits[]> {
+  const type =
+    knownType ??
+    (await deriveXERC20TokenType(multiProvider, chain, xERC20Address));
+  const bridges = new Set(
+    await discoverConfiguredBridges({
+      xERC20Address,
+      chain,
+      multiProvider,
+      logger,
+      type,
+    }),
+  );
+
+  if (warpRouteAddress) {
+    bridges.delete(normalizeAddress(warpRouteAddress));
+  }
+
+  if (bridges.size === 0) {
+    return [];
+  }
+
+  const limitsByBridge = await readXERC20Limits({
+    multiProtocolProvider:
+      MultiProtocolProvider.fromMultiProvider(multiProvider),
+    chain: multiProvider.getChainName(chain),
+    xERC20Address,
+    bridges: [...bridges],
+    type,
+  });
+
+  const extraBridges: XERC20TokenExtraBridgesLimits[] = [];
+  for (const bridge of bridges) {
+    const limits = limitsByBridge[bridge];
+    assert(
+      limits,
+      `Missing xERC20 limits for bridge ${bridge} on chain ${multiProvider.getChainName(chain)}`,
+    );
+
+    // A bridge holding no limits can neither mint nor burn, which is how a
+    // bridge is deactivated.
+    if (limitsAreZero(limits)) {
+      continue;
+    }
+
+    extraBridges.push({ lockbox: bridge, limits });
+  }
+
+  return extraBridges;
+}
+
+/**
+ * The event announcing a bridge's limits, whose signature differs by
+ * implementation. Both put the bridge in the only indexed parameter, so the
+ * scan below reads it out of topics[1] without decoding the payload.
+ */
+function bridgeLimitsEventSelector(type: XERC20Type): string {
+  return type === XERC20Type.Standard
+    ? BRIDGE_LIMITS_SET_EVENT_SELECTOR
+    : CONFIGURATION_CHANGED_EVENT_SELECTOR;
+}
+
+/**
+ * Every address the token has ever announced limits for, whether or not those
+ * limits are still in force: the limits are read from the token afterwards, so
+ * a bridge the events show as deactivated is dropped on what it holds now
+ * rather than on what it was last announced with.
+ *
+ * A failed scan is raised rather than answered as an empty set, because the
+ * events are the only place the addresses exist and "no bridges" from a failed
+ * read is indistinguishable from a token that genuinely has none.
+ */
+async function discoverConfiguredBridges({
+  xERC20Address,
+  chain,
+  multiProvider,
+  logger,
+  type,
+}: {
+  xERC20Address: Address;
+  chain: ChainNameOrId;
+  multiProvider: MultiProvider;
+  logger: Logger;
+  type: XERC20Type;
+}): Promise<Address[]> {
   const logsReader = EvmEventLogsReader.fromConfig(
     { chain, paginationBlockRange: XERC20_LOG_SCAN_BLOCK_RANGE },
     multiProvider,
     logger,
   );
 
-  const logs = await logsReader.getLogsByTopic({
+  // Resolved once and handed to both reads below. A reader left to derive it
+  // reads it over whichever source it was built on, and deriving it over the
+  // RPC bisects `eth_getCode` through historical blocks: a chain serving no
+  // archive state answers eth_getLogs over its whole history but refuses that
+  // bisection, so the RPC read would fail on the one thing it can do.
+  const query = {
     contractAddress: xERC20Address,
-    eventTopic: CONFIGURATION_CHANGED_EVENT_SELECTOR,
-  });
+    eventTopic: bridgeLimitsEventSelector(type),
+    fromBlock: await logsReader.getContractDeploymentBlock(xERC20Address),
+  };
 
-  const viemLogs = logs.map(viemLogFromGetEventLogsResponse);
-  return getLockboxesFromLogs(
-    viemLogs,
-    multiProvider.getProvider(chain),
-    chain,
-    logger,
-  );
+  let logs = await logsReader.getLogsByTopic(query);
+
+  const answeredByExplorer =
+    multiProvider.tryGetEvmExplorerMetadataList(chain).length > 0;
+  if (logs.length === 0 && answeredByExplorer) {
+    // The token holds limits for at least the warp route's own router, so it
+    // has announced at least one bridge and an empty answer is an explorer that
+    // could not answer rather than a token with nothing to report.
+    //
+    // Deliberately this caller's policy rather than EvmEventLogsReader's: a
+    // timelock with no salted operations and a freshly deployed blacklist are
+    // both legitimately empty, and confirming those over the RPC would spend a
+    // whole-history scan to learn what the explorer already answered correctly.
+    logger.debug(
+      {
+        chain: multiProvider.getChainName(chain),
+        xERC20Address,
+      },
+      'Block explorer announced no xERC20 bridges, re-reading over the RPC',
+    );
+
+    logs = await EvmEventLogsReader.fromConfig(
+      {
+        chain,
+        paginationBlockRange: XERC20_LOG_SCAN_BLOCK_RANGE,
+        useRPC: true,
+      },
+      multiProvider,
+      logger,
+    ).getLogsByTopic(query);
+  }
+
+  return bridgeAddressesFromLogs(logs, xERC20Address, chain, multiProvider);
+}
+
+function bridgeAddressesFromLogs(
+  logs: GetEventLogsResponse[],
+  xERC20Address: Address,
+  chain: ChainNameOrId,
+  multiProvider: MultiProvider,
+): Address[] {
+  return logs.map((log) => {
+    const [, bridgeTopic] = log.topics;
+    assert(
+      bridgeTopic,
+      `Bridge limits log of ${xERC20Address} on chain ${multiProvider.getChainName(chain)} carries no bridge topic`,
+    );
+
+    return normalizeAddress(bytes32ToAddress(bridgeTopic));
+  });
 }
 
 export type ConfigurationChangedLog = Log<
@@ -136,58 +289,6 @@ export function latestConfigurationPerBridge(
   }
 
   return latestPerBridge;
-}
-
-async function getLockboxesFromLogs(
-  logs: Log[],
-  provider: ethers.providers.Provider,
-  chain: ChainNameOrId,
-  logger: Logger,
-): Promise<XERC20TokenExtraBridgesLimits[]> {
-  const lockboxPromises = [...latestConfigurationPerBridge(logs).entries()]
-    // Removing bridges where the limits are set to 0 because it is equivalent of being deactivated
-    // A bridge is active if EITHER bufferCap OR rateLimitPerSecond is non-zero
-    .filter(
-      ([, log]) =>
-        log.args.bufferCap !== 0n || log.args.rateLimitPerSecond !== 0n,
-    )
-    .map(async ([bridge, log]) => {
-      try {
-        const maybeXERC20Lockbox = IXERC20Lockbox__factory.connect(
-          bridge,
-          provider,
-        );
-
-        await maybeXERC20Lockbox.callStatic.XERC20();
-        return { bridge, log };
-      } catch (error) {
-        throwIfNotMissingSelector(error);
-        logger.debug(
-          `Contract at address ${bridge} on chain ${chain} is not a XERC20Lockbox contract.`,
-        );
-        return undefined;
-      }
-    });
-
-  const lockboxes = await Promise.all(lockboxPromises);
-
-  const extraBridges: XERC20TokenExtraBridgesLimits[] = [];
-  for (const lockbox of lockboxes) {
-    if (!lockbox) {
-      continue;
-    }
-
-    extraBridges.push({
-      lockbox: lockbox.bridge,
-      limits: {
-        type: XERC20Type.Velo,
-        bufferCap: lockbox.log.args.bufferCap.toString(),
-        rateLimitPerSecond: lockbox.log.args.rateLimitPerSecond.toString(),
-      },
-    });
-  }
-
-  return extraBridges;
 }
 
 /**
@@ -426,20 +527,33 @@ export async function deriveStandardBridgesConfig(
   return bridgesConfig;
 }
 
+/**
+ * Thrown when a contract exposes neither the Standard nor the Velodrome limit
+ * management interface, so which getter would answer its limits is unknown.
+ *
+ * Typed rather than a bare Error so a caller can tell it apart from a failure
+ * to read the bytecode at all, which says nothing about the contract and must
+ * not be treated as an answer.
+ */
+export class UnknownXERC20TypeError extends Error {
+  static {
+    this.prototype.name = this.name;
+  }
+}
+
 export async function deriveXERC20TokenType(
   multiProvider: MultiProvider,
   chain: ChainNameOrId,
   address: Address,
 ): Promise<XERC20Type> {
-  const isContract = await isContractAddress(multiProvider, chain, address);
-  if (!isContract) {
+  const provider = multiProvider.getProvider(chain);
+  let normalizedCode = (await provider.getCode(address)).toLowerCase();
+  if (normalizedCode === '0x') {
     throw new Error(
       `Unable to detect XERC20 type for ${address}. Contract has no bytecode.`,
     );
   }
 
-  const provider = multiProvider.getProvider(chain);
-  let normalizedCode = (await provider.getCode(address)).toLowerCase();
   const setBufferCapSelector = ethers.utils
     .id('setBufferCap(address,uint256)')
     .slice(2, 10)
@@ -470,7 +584,7 @@ export async function deriveXERC20TokenType(
   }
 
   // Neither type detected
-  throw new Error(
+  throw new UnknownXERC20TypeError(
     `Unable to detect XERC20 type for ${address}. Contract does not implement Standard or Velodrome XERC20 interface.`,
   );
 }


### PR DESCRIPTION
### Description

`warp check` reported `xERC20.extraBridges: ACTUAL: ""` for the oUSDT production route on six chains — base, bob, celo, ethereum, optimism and zerogravity — while every declared bridge demonstrably existed on chain. I verified all twelve with `mintingMaxLimitOf`/`burningMaxLimitOf`: each matches its configured limit exactly.

Three defects combined to produce that, and the derived config was wrong in a way that read as "nothing configured" rather than as a failure.

**1. Discovery kept only bridges that answer the lockbox `XERC20()` getter.** Most configured bridges are not lockboxes. Of the six chains, the entries carrying live limits (celo `0x47db76…`, base `0xa760d2…`, optimism `0x6a21a1…`, zerogravity `0xd7502c…`) all revert on `XERC20()`; the two that *are* lockboxes (base `0x9d922c…`, optimism `0x07e437…`) hold zero limits and were dropped by a zero filter. Every entry was eliminated by one filter or the other, deterministically, against a healthy RPC. `extraBridges[].lockbox` is a misnomer — the field holds arbitrary bridge addresses.

**2. Limits came from the last event payload, not from the token.** A bridge was reported with what it was last *announced* with rather than what it currently holds, so any limit changed outside an observed event went unnoticed.

**3. A transport failure was classified as a missing selector.** `isMissingSelectorCallException` treats `'Invalid response from provider'` as "the contract lacks this getter", so a flaky RPC silently removed bridges. The CI run that surfaced this logged that message 343 times. An outer catch in `fetchXERC20Config` re-swallowed the same class, so fixing the inner one alone would have been a no-op.

Separately, `fetchXERC20Config` read a token's own limits through the Velodrome getters alone, so a Standard xERC20 reverted, was caught as a missing selector, and its entire `xERC20` block vanished from the derived config. oXAUT is a live route in that state.

### What changed

Neither xERC20 interface can enumerate its bridges — every getter is address-keyed — so addresses still come from events, but **only** the addresses. Limits are then read from the token, so a bridge is reported with what it holds now.

- The lockbox probe is gone. `warpRouteAddress` now explicitly excludes the route's own router, which that probe had been keeping out incidentally; its limits are already reported as `warpRouteLimits`.
- Standard tokens are discovered through `BridgeLimitsSet(uint256,uint256,address)` and read through `mintingMaxLimitOf`/`burningMaxLimitOf`. Note this is **not** the `BridgeLimitsSet(address,uint256)` that `IXERC20VS.sol` declares — that signature returns zero logs against the live token; verified against oXAUT on ethereum.
- Both `fetchXERC20Config` catches are narrowed to the revert-only variant, so a transient RPC failure surfaces instead of reporting a token with bridges as having none.
- An explorer that announces no bridges is re-read over the RPC, because such a token holds limits for at least its own router. The re-read is handed the block range the first read resolved: deriving it again bisects `eth_getCode` through historical blocks, which a chain serving no archive state refuses while still answering `eth_getLogs` over the same span. `EvmEventLogsReader` gained `getContractDeploymentBlock` to make that resolution reachable — additive and read-only, resolving the block exactly as the reader already did for a caller supplying no `fromBlock`.

The re-read policy is deliberately the xERC20 caller's, not the shared reader's. An earlier revision put it in `EvmEventLogsReader` and it regressed two unrelated consumers: `EvmTimelockReader` (a zero-salt timelock emits no `CallSalt`, so empty is the correct permanent answer — it would have paid ~1,000 sequential `eth_getLogs` per chain per call, and a throw where `[]` was expected would have dropped a whole chain from the pending-timelock report) and `ism/blacklist.ts` (an empty blacklist is the normal state of a fresh ISM).

### Drive-by changes

`xerc20-limits.ts` is extracted so `xerc20.ts` can read limits without importing `EvmXERC20Reader`, which imports it back. Pure move; the types and helpers are re-exported so the package-root surface is unchanged.

### Related issues

None.

### Backward compatibility

Yes — additive throughout. `minor` on `@hyperlane-xyz/sdk`; nothing removed, renamed or narrowed. Two optional fields on `GetExtraLockboxesOptions`, one read-only accessor on `EvmEventLogsReader`, one new exported error.

**One migration for operators of Standard (non-Velodrome) xERC20 routes**: `fetchXERC20Config` now derives Standard limits where it previously returned an empty config, so a deploy config omitting `xERC20.warpRouteLimits` will report a `warp check` violation against the limits the token actually holds. Add the token's current `mint`/`burn` to those configs. Routes that already declare limits stay clean. Velodrome routes already behaved this way.

Expect `extraBridges` on velo routes to start reporting previously-invisible non-lockbox bridges. Some routes will surface real drift that was hidden — that is the point, but it will look like new violations.

### Testing

Unit, hardhat and manual.

- `typescript/sdk` unit: **1297 passing**. `deploy.hardhat-test.ts` **57**, `EvmWarpRouteReader.hardhat-test.ts` **56**, `EvmWarpModule.hardhat-test.ts` **125**. Timelock and ISM suites (the other `EvmEventLogsReader` consumers) **153 passing** and untouched.
- `check` and `lint` clean on `sdk` and `cli`; root `pnpm build` green.
- **Fails without the fix, measured rather than asserted.** The pre-fix function was materialised from `HEAD` into a throwaway module and the new scenarios run against it: non-lockbox bridge → `[]`; declared bridge the scan never saw → `[]`; latest event zeroed while the token still holds limits → `[]`; probe hitting `Invalid response from provider` → silently dropped; Standard xERC20 → `[]`. Reverting the source files and running the new reader tests gives 4 failing / 2 passing.
- The "deployment block resolved exactly once across both reads" test is the guard for the archive-state defect; a test asserting only "the RPC was consulted" would have passed the buggy revision.
- **Manual**: `warp read` against the live oUSDT production route on zerogravity resolves the deployment block, reads complete logs, and reports the extra bridge with its live limits.

Not run here: `CLI_E2E_TEST=xerc20 pnpm -C typescript/cli test:ethereum:e2e` (needs anvil plus a registry checkout; the new case is in a suite already in the CI matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ViCLpezP9GH8mbzqAAA4P
