### PR TITLE
fix(http-registry): allow cross-origin reads

### DIFF
--- a/docs/offchain-fee-quoting.md
+++ b/docs/offchain-fee-quoting.md
@@ -395,127 +395,24 @@ Existing warp routes can adopt offchain quoting by setting the new fee recipient
 | `test/igps/IGPOffchainQuoting.t.sol`               | Created  | Unit tests for IGP offchain quoting        |
 | `test/token/CrossCollateralRouter.t.sol`           | Modified | QuotedCalls + cross-collateral demo test   |
 
-## Local Development Sandbox
+## Local Fork Registry
 
-Persistent local sandbox for testing the full offchain fee quoting stack against a frontend (e.g. Nexus UI). Uses anvil forks of real chains with a writable registry overlay.
+`hyperlane warp fork` starts local fork nodes and exposes their merged chain
+metadata through an HTTP registry. The HTTP registry is intentionally read-only:
+GET and HEAD requests can consume the forked metadata, while mutation endpoints
+return HTTP 405.
 
-### Registry Architecture
-
-```mermaid
-graph LR
-    subgraph Consumers
-        CLI[CLI]
-        FQS[FeeQuotingServer]
-        NEX[Nexus UI]
-    end
-
-    CLI -- read + write --> HS
-    FQS -- read --> HS
-    NEX -- read --> HS
-
-    HS["HttpServer :8535\nwriteMode: true"]
-
-    subgraph "forkRegistry Proxy"
-        direction TB
-        HS -- GET --> MR
-        HS -- POST --> OV
-    end
-
-    subgraph MergedRegistry
-        direction TB
-        UP["Upstream\nread-only"] --> MR[merge]
-        OV["PartialRegistry\nin-memory overlay"] --> MR
-    end
-```
-
-The fork registry uses a `Proxy` that reads from the full `MergedRegistry` (upstream + overlay) but routes writes only to the `PartialRegistry` overlay. This prevents `core apply` or `warp apply` from writing to the upstream registry.
-
-### Sandbox Sequence
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant CLI
-    participant Registry as HttpServer :8535
-    participant Overlay as PartialRegistry
-    participant Anvil as Anvil :8545
-    participant FQS as FeeQuotingServer :3001
-    participant Nexus as Nexus UI
-
-    Note over User,Nexus: Step 1 — warp fork
-    User->>CLI: warp fork --warpRouteId id
-    CLI->>Anvil: start anvil --fork-url rpc --chain-id id
-    CLI->>Registry: start HttpServer(forkRegistry, writeMode)
-
-    Note over User,Nexus: Step 2 — core apply (deploy QuotedCalls)
-    User->>CLI: core apply --registry http://localhost:8535
-    CLI->>Registry: GET /chain/chainA/addresses
-    Registry-->>CLI: addresses (no quotedCalls)
-    CLI->>Anvil: deploy QuotedCalls → 0xABC
-    CLI->>Registry: POST /chain/chainA {quotedCalls: 0xABC}
-    Registry->>Overlay: updateChain (write to overlay only)
-    Note over Registry,Overlay: GET now returns quotedCalls: 0xABC
-
-    Note over User,Nexus: Step 3 — warp apply (impersonated owner)
-    User->>CLI: warp apply --strategy impersonated.yaml
-    CLI->>Anvil: anvil_impersonateAccount(owner)
-    CLI->>Anvil: anvil_setBalance(owner)
-    CLI->>Anvil: deploy OffchainQuotedLinearFee (from: owner)
-    CLI->>Anvil: setTokenFee(feeContract) (from: owner)
-    CLI->>Anvil: addQuoteSigner(signer) (from: owner)
-
-    Note over User,Nexus: Step 4 — fee-quoting server
-    User->>FQS: start --registry http://localhost:8535
-    FQS->>Registry: GET warp route + chain addresses
-    Registry-->>FQS: includes quotedCalls from overlay
-    FQS->>Anvil: EvmWarpRouteReader (reads fee config on-chain)
-    FQS-->>User: Listening on :3001
-
-    Note over User,Nexus: Step 5 — Nexus UI transfer
-    Nexus->>Registry: GET chain metadata + addresses
-    Nexus->>FQS: GET /quote/transferRemote
-    FQS-->>Nexus: signed quotes (IGP + warp fee)
-    Nexus->>Anvil: QuotedCalls.execute(SUBMIT_QUOTE, TRANSFER_FROM, TRANSFER_REMOTE, SWEEP)
-    Anvil-->>Nexus: tx receipt
-```
-
-### Commands
+The endpoint can therefore be used by read-only consumers such as a fee-quoting
+service or frontend:
 
 ```bash
-# Default anvil private key (account 0, funded on all forks)
-export HYP_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-
-# 1. Fork warp route — anvil forks on :8545+, writable registry on :8535
+# Fork nodes start on :8545+ and the read-only registry starts on :8535.
 hyperlane warp fork --warpRouteId <id>
 
-# 2. Deploy QuotedCalls (anyone can deploy, uses default anvil key)
-hyperlane core apply \
-  --registry http://localhost:8535 \
-  --chain <chain> \
-  --config core.yaml
-
-# 3. Apply warp config (fee contract + quoteSigners) via impersonated owner
-hyperlane warp apply \
-  --registry http://localhost:8535 \
-  --strategy strategy.yaml \
-  --config warp-deploy.yaml
-
-# 4. Start fee-quoting HTTP server
-pnpm -C typescript/fee-quoting exec tsx scripts/run-server.ts \
-  --signer-key $HYP_KEY \
-  --warp-route-ids <id> \
-  --registry http://localhost:8535 \
-  --api-keys test-key \
-  --quote-mode transient \
-  --port 3001
-
-# 5. Point Nexus UI at fork registry :8535 and fee service :3001
+# Point read-only consumers at http://localhost:8535.
 ```
 
-Where `strategy.yaml` impersonates the warp route owner for `onlyOwner` transactions:
-
-```yaml
-submitter:
-  type: impersonatedAccount
-  userAddress: '0x<warp-route-owner>'
-```
+Do not point `core apply`, `warp apply`, or another command that persists registry
+metadata at the fork registry. Prepare the required registry metadata before
+starting the fork, or use a separately configured development registry with
+write mode explicitly enabled. The CLI fork command does not enable writes.

--- a/typescript/cli/src/fork/fork.test.ts
+++ b/typescript/cli/src/fork/fork.test.ts
@@ -99,7 +99,7 @@ describe('runForkCommand --kill teardown', () => {
     expect(createStub.called).to.equal(false);
   });
 
-  it('starts the registry server and does not kill when kill is not set', async () => {
+  it('starts a read-only registry server and does not kill when kill is not set', async () => {
     const created: FakeForkManager[] = [];
     stubRegistry(created);
     const serverStub = sinon.createStubInstance(HttpServer);
@@ -116,6 +116,7 @@ describe('runForkCommand --kill teardown', () => {
     expect(created.length).to.equal(1);
     expect(created.every((manager) => manager.killCount === 0)).to.equal(true);
     expect(createStub.calledOnce).to.equal(true);
+    expect(createStub.firstCall.args[1]).to.be.undefined;
     expect(serverStub.start.calledOnce).to.equal(true);
   });
 

--- a/typescript/http-registry-server/HttpServer.ts
+++ b/typescript/http-registry-server/HttpServer.ts
@@ -36,6 +36,12 @@ export class HttpServer {
     this.writeMode = options.writeMode ?? false;
     this.app = express();
     this.app.set('trust proxy', true); // trust proxy for x-forwarded-for header
+    this.app.use((req, res, next) => {
+      if (req.method === 'GET' || req.method === 'HEAD') {
+        res.setHeader('Access-Control-Allow-Origin', '*');
+      }
+      next();
+    });
     this.app.use(express.json());
   }
 

--- a/typescript/http-registry-server/HttpServer.ts
+++ b/typescript/http-registry-server/HttpServer.ts
@@ -114,7 +114,9 @@ export class HttpServer {
       );
       this.app.use(
         '/chain',
-        createChainRouter(new ChainService(this.registryService)),
+        createChainRouter(new ChainService(this.registryService), {
+          writeMode: this.writeMode,
+        }),
       );
       this.app.use(
         '/warp-route',

--- a/typescript/http-registry-server/HttpServer.ts
+++ b/typescript/http-registry-server/HttpServer.ts
@@ -54,12 +54,15 @@ export class HttpServer {
     this.app.set('trust proxy', true); // trust proxy for x-forwarded-for header
     this.app.use((req, res, next) => {
       const origin = req.get('origin');
-      if (origin && (req.method === 'GET' || req.method === 'HEAD')) {
+      const isCorsRead =
+        this.corsAllowedOrigins.size > 0 &&
+        (req.method === 'GET' || req.method === 'HEAD');
+      if (isCorsRead) {
         res.vary('Origin');
       }
       if (
         origin &&
-        (req.method === 'GET' || req.method === 'HEAD') &&
+        isCorsRead &&
         (this.corsAllowedOrigins.has('*') ||
           this.corsAllowedOrigins.has(origin))
       ) {

--- a/typescript/http-registry-server/HttpServer.ts
+++ b/typescript/http-registry-server/HttpServer.ts
@@ -19,6 +19,18 @@ import { FileSystemRegistryWatcher } from './src/services/watcherService.js';
 
 export interface HttpServerOptions {
   writeMode?: boolean;
+  corsAllowedOrigins?: string[];
+}
+
+export function parseCorsAllowedOrigins(
+  value = process.env.CORS_ALLOWED_ORIGINS,
+): string[] {
+  return value
+    ? value
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : [];
 }
 
 export class HttpServer {
@@ -26,6 +38,7 @@ export class HttpServer {
   protected readonly logger: Logger;
   private registryService: RegistryService | null = null;
   protected readonly writeMode: boolean;
+  protected readonly corsAllowedOrigins: Set<string>;
 
   private constructor(
     protected getRegistry: () => Promise<IRegistry>,
@@ -34,11 +47,26 @@ export class HttpServer {
   ) {
     this.logger = logger;
     this.writeMode = options.writeMode ?? false;
+    this.corsAllowedOrigins = new Set(
+      options.corsAllowedOrigins ?? parseCorsAllowedOrigins(),
+    );
     this.app = express();
     this.app.set('trust proxy', true); // trust proxy for x-forwarded-for header
     this.app.use((req, res, next) => {
-      if (req.method === 'GET' || req.method === 'HEAD') {
-        res.setHeader('Access-Control-Allow-Origin', '*');
+      const origin = req.get('origin');
+      if (origin && (req.method === 'GET' || req.method === 'HEAD')) {
+        res.vary('Origin');
+      }
+      if (
+        origin &&
+        (req.method === 'GET' || req.method === 'HEAD') &&
+        (this.corsAllowedOrigins.has('*') ||
+          this.corsAllowedOrigins.has(origin))
+      ) {
+        res.setHeader(
+          'Access-Control-Allow-Origin',
+          this.corsAllowedOrigins.has('*') ? '*' : origin,
+        );
       }
       next();
     });

--- a/typescript/http-registry-server/README.md
+++ b/typescript/http-registry-server/README.md
@@ -24,13 +24,14 @@ pnpm install
 
 The server is configured using environment variables. You can place these in a `.env` file in the package root (`typescript/http-registry-server/.env`).
 
-| Variable           | Description                                      | Default              |
-| ------------------ | ------------------------------------------------ | -------------------- |
-| `PORT`             | The port for the server to listen on.            | `3000`               |
-| `HOST`             | The host address to bind to.                     | `0.0.0.0`            |
-| `REFRESH_INTERVAL` | The interval (in ms) to refresh registry data.   | `60000` (60 seconds) |
-| `LOG_LEVEL`        | The minimum log level to output.                 | `info`               |
-| `LOG_FORMAT`       | The log format. Set to `pretty` for development. | `json`               |
+| Variable               | Description                                                                          | Default              |
+| ---------------------- | ------------------------------------------------------------------------------------ | -------------------- |
+| `PORT`                 | The port for the server to listen on.                                                | `3000`               |
+| `HOST`                 | The host address to bind to.                                                         | `0.0.0.0`            |
+| `REFRESH_INTERVAL`     | The interval (in ms) to refresh registry data.                                       | `60000` (60 seconds) |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated browser origins allowed to read; use `*` explicitly for public data. | none                 |
+| `LOG_LEVEL`            | The minimum log level to output.                                                     | `info`               |
+| `LOG_FORMAT`           | The log format. Set to `pretty` for development.                                     | `json`               |
 
 ## Usage
 

--- a/typescript/http-registry-server/src/middleware/writeMode.ts
+++ b/typescript/http-registry-server/src/middleware/writeMode.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { MethodNotAllowedError } from '../errors/ApiError.js';
+
+export function requireWriteMode(writeMode: boolean) {
+  return (_req: Request, _res: Response, next: NextFunction) => {
+    if (!writeMode) {
+      return next(new MethodNotAllowedError());
+    }
+    next();
+  };
+}

--- a/typescript/http-registry-server/src/routes/chain.ts
+++ b/typescript/http-registry-server/src/routes/chain.ts
@@ -8,10 +8,19 @@ import {
   validateBody,
   validateRequestParam,
 } from '../middleware/validateRequest.js';
+import { requireWriteMode } from '../middleware/writeMode.js';
 import { ChainService } from '../services/chainService.js';
 
-export function createChainRouter(chainService: ChainService): Router {
+export interface ChainRouterOptions {
+  writeMode?: boolean;
+}
+
+export function createChainRouter(
+  chainService: ChainService,
+  options: ChainRouterOptions = {},
+): Router {
   const router = Router();
+  const { writeMode = false } = options;
 
   router.get(
     '/:chain/metadata',
@@ -33,6 +42,7 @@ export function createChainRouter(chainService: ChainService): Router {
 
   router.post(
     '/:chain',
+    requireWriteMode(writeMode),
     validateRequestParam('chain', ZChainName),
     validateBody(UpdateChainSchema.strict()),
     async (req: Request<{ chain: string }>, res: Response) => {

--- a/typescript/http-registry-server/src/routes/warp.ts
+++ b/typescript/http-registry-server/src/routes/warp.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response, Router } from 'express';
+import { Request, Response, Router } from 'express';
 import { z } from 'zod';
 
 import {
@@ -11,13 +11,13 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import { AppConstants } from '../constants/AppConstants.js';
-import { MethodNotAllowedError } from '../errors/ApiError.js';
 import {
   joinPathSegments,
   validateBody,
   validateQueryParams,
   validateRequestParam,
 } from '../middleware/validateRequest.js';
+import { requireWriteMode } from '../middleware/writeMode.js';
 import { WarpService } from '../services/warpService.js';
 
 export interface WarpRouterOptions {
@@ -33,15 +33,6 @@ const AddWarpRouteConfigBodySchema = z.object({
   config: WarpRouteDeployConfigSchema,
   options: AddWarpRouteConfigOptionsSchema,
 });
-
-function requireWriteMode(writeMode: boolean) {
-  return (_req: Request, _res: Response, next: NextFunction) => {
-    if (!writeMode) {
-      return next(new MethodNotAllowedError());
-    }
-    next();
-  };
-}
 
 export function createWarpRouter(
   warpService: WarpService,

--- a/typescript/http-registry-server/test/HttpServer.test.ts
+++ b/typescript/http-registry-server/test/HttpServer.test.ts
@@ -30,6 +30,7 @@ describe('HttpServer CORS', () => {
       { corsAllowedOrigins: ['http://localhost:3000'] },
     );
 
+    const originlessResponse = await request(httpServer.app).get('/anything');
     const readResponse = await request(httpServer.app)
       .get('/anything')
       .set('Origin', 'http://localhost:3000');
@@ -43,6 +44,9 @@ describe('HttpServer CORS', () => {
       .post('/anything')
       .set('Origin', 'http://localhost:3000');
 
+    expect(originlessResponse.headers['access-control-allow-origin']).to.be
+      .undefined;
+    expect(originlessResponse.headers.vary).to.equal('Origin');
     expect(readResponse.headers['access-control-allow-origin']).to.equal(
       'http://localhost:3000',
     );

--- a/typescript/http-registry-server/test/HttpServer.test.ts
+++ b/typescript/http-registry-server/test/HttpServer.test.ts
@@ -5,6 +5,7 @@ import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import sinon from 'sinon';
+import request from 'supertest';
 
 import { PartialRegistry } from '@hyperlane-xyz/registry';
 import { FileSystemRegistry } from '@hyperlane-xyz/registry/fs';
@@ -13,6 +14,21 @@ import { HttpServer } from '../HttpServer.js';
 import { RegistryService } from '../src/services/registryService.js';
 
 chaiUse(chaiAsPromised);
+
+describe('HttpServer CORS', () => {
+  it('allows cross-origin reads without allowing cross-origin writes', async () => {
+    const httpServer = await HttpServer.create(
+      async () => new PartialRegistry({}),
+    );
+
+    const readResponse = await request(httpServer.app).get('/anything');
+    const writeResponse = await request(httpServer.app).post('/anything');
+
+    expect(readResponse.headers['access-control-allow-origin']).to.equal('*');
+    expect(writeResponse.headers['access-control-allow-origin']).to.be
+      .undefined;
+  });
+});
 
 async function bindPort(): Promise<{
   port: number;

--- a/typescript/http-registry-server/test/HttpServer.test.ts
+++ b/typescript/http-registry-server/test/HttpServer.test.ts
@@ -22,9 +22,11 @@ describe('HttpServer CORS', () => {
     );
 
     const readResponse = await request(httpServer.app).get('/anything');
+    const headResponse = await request(httpServer.app).head('/anything');
     const writeResponse = await request(httpServer.app).post('/anything');
 
     expect(readResponse.headers['access-control-allow-origin']).to.equal('*');
+    expect(headResponse.headers['access-control-allow-origin']).to.equal('*');
     expect(writeResponse.headers['access-control-allow-origin']).to.be
       .undefined;
   });

--- a/typescript/http-registry-server/test/HttpServer.test.ts
+++ b/typescript/http-registry-server/test/HttpServer.test.ts
@@ -10,25 +10,75 @@ import request from 'supertest';
 import { PartialRegistry } from '@hyperlane-xyz/registry';
 import { FileSystemRegistry } from '@hyperlane-xyz/registry/fs';
 
-import { HttpServer } from '../HttpServer.js';
+import { HttpServer, parseCorsAllowedOrigins } from '../HttpServer.js';
 import { RegistryService } from '../src/services/registryService.js';
 
 chaiUse(chaiAsPromised);
 
 describe('HttpServer CORS', () => {
-  it('allows cross-origin reads without allowing cross-origin writes', async () => {
+  it('parses the comma-separated origin allowlist', () => {
+    expect(
+      parseCorsAllowedOrigins(
+        'http://localhost:3000, https://bridge.example, ,*',
+      ),
+    ).to.deep.equal(['http://localhost:3000', 'https://bridge.example', '*']);
+  });
+
+  it('allows configured cross-origin reads without allowing other origins or writes', async () => {
     const httpServer = await HttpServer.create(
       async () => new PartialRegistry({}),
+      { corsAllowedOrigins: ['http://localhost:3000'] },
     );
 
-    const readResponse = await request(httpServer.app).get('/anything');
-    const headResponse = await request(httpServer.app).head('/anything');
-    const writeResponse = await request(httpServer.app).post('/anything');
+    const readResponse = await request(httpServer.app)
+      .get('/anything')
+      .set('Origin', 'http://localhost:3000');
+    const headResponse = await request(httpServer.app)
+      .head('/anything')
+      .set('Origin', 'http://localhost:3000');
+    const deniedResponse = await request(httpServer.app)
+      .get('/anything')
+      .set('Origin', 'https://malicious.example');
+    const writeResponse = await request(httpServer.app)
+      .post('/anything')
+      .set('Origin', 'http://localhost:3000');
 
-    expect(readResponse.headers['access-control-allow-origin']).to.equal('*');
-    expect(headResponse.headers['access-control-allow-origin']).to.equal('*');
+    expect(readResponse.headers['access-control-allow-origin']).to.equal(
+      'http://localhost:3000',
+    );
+    expect(readResponse.headers.vary).to.equal('Origin');
+    expect(headResponse.headers['access-control-allow-origin']).to.equal(
+      'http://localhost:3000',
+    );
+    expect(headResponse.headers.vary).to.equal('Origin');
+    expect(deniedResponse.headers['access-control-allow-origin']).to.be
+      .undefined;
+    expect(deniedResponse.headers.vary).to.equal('Origin');
     expect(writeResponse.headers['access-control-allow-origin']).to.be
       .undefined;
+  });
+
+  it('requires an explicit wildcard before allowing every browser origin', async () => {
+    const defaultServer = await HttpServer.create(
+      async () => new PartialRegistry({}),
+      { corsAllowedOrigins: [] },
+    );
+    const publicServer = await HttpServer.create(
+      async () => new PartialRegistry({}),
+      { corsAllowedOrigins: ['*'] },
+    );
+
+    const deniedResponse = await request(defaultServer.app)
+      .get('/anything')
+      .set('Origin', 'https://example.com');
+    const publicResponse = await request(publicServer.app)
+      .get('/anything')
+      .set('Origin', 'https://example.com');
+
+    expect(deniedResponse.headers['access-control-allow-origin']).to.be
+      .undefined;
+    expect(publicResponse.headers['access-control-allow-origin']).to.equal('*');
+    expect(publicResponse.headers.vary).to.equal('Origin');
   });
 });
 

--- a/typescript/http-registry-server/test/routes/chain.test.ts
+++ b/typescript/http-registry-server/test/routes/chain.test.ts
@@ -20,6 +20,7 @@ chaiUse(chaiAsPromised);
 
 describe('Chain Routes', () => {
   let app: Express;
+  let appWithWriteMode: Express;
   let mockChainService: sinon.SinonStubbedInstance<ChainService>;
 
   beforeEach(() => {
@@ -32,6 +33,14 @@ describe('Chain Routes', () => {
     app.use(express.json());
     app.use('/chain', createChainRouter(mockChainService));
     app.use(createErrorHandler(mockLogger));
+
+    appWithWriteMode = express();
+    appWithWriteMode.use(express.json());
+    appWithWriteMode.use(
+      '/chain',
+      createChainRouter(mockChainService, { writeMode: true }),
+    );
+    appWithWriteMode.use(createErrorHandler(mockLogger));
   });
 
   afterEach(() => {
@@ -88,6 +97,15 @@ describe('Chain Routes', () => {
   });
 
   describe('POST /chain/:chain', () => {
+    it('should return 405 when writeMode is disabled', async () => {
+      await request(app)
+        .post(`/chain/${MOCK_CHAIN_NAME}`)
+        .send({ metadata: mockChainMetadata })
+        .expect(AppConstants.HTTP_STATUS_METHOD_NOT_ALLOWED);
+
+      expect(mockChainService.updateChain.called).to.be.false;
+    });
+
     it('should update chain successfully', async () => {
       const updateParams = {
         metadata: {
@@ -97,7 +115,7 @@ describe('Chain Routes', () => {
       };
       mockChainService.updateChain.resolves();
 
-      await request(app)
+      await request(appWithWriteMode)
         .post(`/chain/${MOCK_CHAIN_NAME}`)
         .send(updateParams)
         .expect(AppConstants.HTTP_STATUS_NO_CONTENT);
@@ -113,7 +131,7 @@ describe('Chain Routes', () => {
     it('should return 400 for invalid metadata schema', async () => {
       const invalidMetadata = { invalidField: 'invalid' };
 
-      const response = await request(app)
+      const response = await request(appWithWriteMode)
         .post(`/chain/${MOCK_CHAIN_NAME}`)
         .send(invalidMetadata)
         .expect(AppConstants.HTTP_STATUS_BAD_REQUEST);
@@ -123,7 +141,7 @@ describe('Chain Routes', () => {
     });
 
     it('should return 400 for missing request body', async () => {
-      const response = await request(app)
+      const response = await request(appWithWriteMode)
         .post(`/chain/${MOCK_CHAIN_NAME}`)
         .expect(AppConstants.HTTP_STATUS_BAD_REQUEST);
 
@@ -136,7 +154,7 @@ describe('Chain Routes', () => {
       };
       mockChainService.updateChain.rejects(new Error('Update failed'));
 
-      const response = await request(app)
+      const response = await request(appWithWriteMode)
         .post(`/chain/${MOCK_CHAIN_NAME}`)
         .send(updateParams)
         .expect(AppConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR);
@@ -153,7 +171,7 @@ describe('Chain Routes', () => {
       };
       mockChainService.updateChain.resolves();
 
-      await request(app)
+      await request(appWithWriteMode)
         .post(`/chain/${MOCK_CHAIN_NAME}`)
         .set('Content-Type', 'application/json')
         .send(updateParams)


### PR DESCRIPTION
### Description

Adds explicit browser-origin allowlisting for HTTP registry `GET` and `HEAD` responses. Origins can be configured through `HttpServerOptions.corsAllowedOrigins` or the comma-separated `CORS_ALLOWED_ORIGINS` environment variable; browser access defaults to disabled, and public deployments must explicitly opt into `*`.

Allowed and denied origin-bearing read responses set `Vary: Origin`. Write responses never receive CORS access.

Also applies the existing server-level `writeMode` setting to `POST /chain/:chain`, matching the protection already used by warp-route write endpoints.

### Drive-by changes

- Moves the existing `requireWriteMode` middleware into a shared module for chain and warp routers.
- Adds configured, denied, wildcard, `HEAD`, and write CORS coverage.
- Locks the CLI fork caller to its existing read-only default with caller-level regression coverage.

### Related issues

- Supports https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/1209

### Backward compatibility

Read endpoints are unchanged for non-browser clients. Browser consumers must configure an allowed origin; unrestricted public reads require an explicit `*`.

Chain write callers must enable `writeMode`, consistent with the server option and existing warp-route writes. Default read-only deployments—including the CLI fork registry—return HTTP 405 for `POST /chain/:chain`.

### Testing

- HTTP registry unit tests: 110 passing
- CLI focused regression suite: 149 passing
- HTTP registry build
- HTTP registry lint
