### PR TITLE
fix(solidity): support ICA fee-token dispatches safely

### DIFF
--- a/.changeset/ica-commit-reveal-fee-token-value.md
+++ b/.changeset/ica-commit-reveal-fee-token-value.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/core': patch
+'@hyperlane-xyz/core': minor
 ---
 
 ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. QuotedCalls ICA commands were changed to reconstruct the messages they execute, and Minimal ICA routers gained support for salted calls. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.

--- a/.changeset/ica-commit-reveal-fee-token-value.md
+++ b/.changeset/ica-commit-reveal-fee-token-value.md
@@ -3,3 +3,5 @@
 ---
 
 ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. QuotedCalls ICA commands were changed to reconstruct the messages they execute, and Minimal ICA routers gained support for salted calls. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.
+
+Existing immutable ICA routers are not supported for these fee-token commands. The updated QuotedCalls and ICA routers must be deployed together, and registry configuration must be migrated to the paired deployments.

--- a/.changeset/ica-commit-reveal-fee-token-value.md
+++ b/.changeset/ica-commit-reveal-fee-token-value.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': patch
+---
+
+ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.

--- a/.changeset/ica-commit-reveal-fee-token-value.md
+++ b/.changeset/ica-commit-reveal-fee-token-value.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/core': patch
 ---
 
-ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.
+ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. QuotedCalls ICA commands were changed to reconstruct the messages they execute using existing router getters, preserving compatibility with older router ABIs. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.

--- a/.changeset/ica-commit-reveal-fee-token-value.md
+++ b/.changeset/ica-commit-reveal-fee-token-value.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/core': patch
 ---
 
-ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. QuotedCalls ICA commands were changed to reconstruct the messages they execute using existing router getters, preserving compatibility with older router ABIs. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.
+ICA fee-token dispatches were fixed to quote the actual remote router, message body, and resolved hook. QuotedCalls ICA commands were changed to reconstruct the messages they execute, and Minimal ICA routers gained support for salted calls. Commit-reveal calls were changed to forward and refund only native value from the current call, leaving existing router balances untouched. Token-pulling child hooks still require explicit approval.

--- a/solidity/contracts/client/Router.sol
+++ b/solidity/contracts/client/Router.sol
@@ -222,7 +222,28 @@ abstract contract Router is MailboxClient, IMessageRecipient {
         bytes memory _hookMetadata,
         address _hook
     ) internal view returns (uint256) {
-        bytes32 _router = _mustHaveRemoteRouter(_destinationDomain);
+        return
+            _Router_quoteDispatch(
+                _destinationDomain,
+                _mustHaveRemoteRouter(_destinationDomain),
+                _messageBody,
+                _hookMetadata,
+                _hook
+            );
+    }
+
+    /**
+     * @dev Quotes a dispatch to an explicit router without consulting the
+     * enrolled router mapping. This keeps override dispatches and their quotes
+     * bound to the same recipient and message body.
+     */
+    function _Router_quoteDispatch(
+        uint32 _destinationDomain,
+        bytes32 _router,
+        bytes memory _messageBody,
+        bytes memory _hookMetadata,
+        address _hook
+    ) internal view returns (uint256) {
         return
             mailbox.quoteDispatch(
                 _destinationDomain,

--- a/solidity/contracts/libs/Message.sol
+++ b/solidity/contracts/libs/Message.sol
@@ -52,6 +52,31 @@ library Message {
     }
 
     /**
+     * @notice Formats a message whose body is already in memory.
+     * @dev Mirrors formatMessage for callers that reconstruct dispatch quotes.
+     */
+    function formatMessageMemory(
+        uint8 _version,
+        uint32 _nonce,
+        uint32 _originDomain,
+        bytes32 _sender,
+        uint32 _destinationDomain,
+        bytes32 _recipient,
+        bytes memory _messageBody
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                _version,
+                _nonce,
+                _originDomain,
+                _sender,
+                _destinationDomain,
+                _recipient,
+                _messageBody
+            );
+    }
+
+    /**
      * @notice Returns the message ID.
      * @param _message ABI encoded Hyperlane message.
      * @return ID of `_message`

--- a/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
@@ -235,31 +235,52 @@ abstract contract AbstractInterchainAccountRouter is Router {
     ) internal returns (bytes32) {
         require(_router != bytes32(0), "no router specified for destination");
 
+        // Mailbox resolves a zero hook only after this function performs the
+        // fee-token approval. Resolve it here so quote, approval, and dispatch
+        // all target the same hook.
+        IPostDispatchHook _effectiveHook = address(_hook) == address(0)
+            ? mailbox.defaultHook()
+            : _hook;
+
         address _feeToken = _hookMetadata.feeToken();
+        uint256 _tokenBalanceBefore;
         if (_feeToken != address(0)) {
+            _tokenBalanceBefore = IERC20(_feeToken).balanceOf(address(this));
             uint256 _fee = _Router_quoteDispatch(
-                _destination,
-                bytes(""),
-                _hookMetadata,
-                address(_hook)
-            );
-
-            IERC20(_feeToken).safeTransferFrom(msg.sender, address(this), _fee);
-            // Standing approval is acceptable here: postDispatch replay with a
-            // crafted message could spend this approval, but tokens are never held
-            // in this contract so there is nothing to drain. Funds collected by the
-            // hook are recoverable by the hook beneficiary, not the attacker.
-            IERC20(_feeToken).forceApprove(address(_hook), type(uint256).max);
-        }
-
-        return
-            mailbox.dispatch{value: _value}(
                 _destination,
                 _router,
                 _body,
                 _hookMetadata,
-                _hook
+                address(_effectiveHook)
             );
+
+            IERC20(_feeToken).safeTransferFrom(msg.sender, address(this), _fee);
+            // This approves only the selected top-level hook. Required hooks and
+            // child hooks that pull tokens must be pre-approved separately through
+            // approveFeeTokenForHook.
+            IERC20(_feeToken).forceApprove(
+                address(_effectiveHook),
+                type(uint256).max
+            );
+        }
+
+        bytes32 _messageId = mailbox.dispatch{value: _value}(
+            _destination,
+            _router,
+            _body,
+            _hookMetadata,
+            _effectiveHook
+        );
+
+        // A successful fee-token dispatch must consume exactly the amount
+        // transferred in for this call, preserving any pre-existing balance.
+        if (_feeToken != address(0)) {
+            assert(
+                IERC20(_feeToken).balanceOf(address(this)) ==
+                    _tokenBalanceBefore
+            );
+        }
+        return _messageId;
     }
 
     function _implementationBytecode(

--- a/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/AbstractInterchainAccountRouter.sol
@@ -202,17 +202,37 @@ abstract contract AbstractInterchainAccountRouter is Router {
         CallLib.Call[] calldata _calls,
         bytes memory _hookMetadata
     ) public payable virtual returns (bytes32) {
+        return
+            callRemoteWithOverrides(
+                _destination,
+                _router,
+                _ism,
+                _calls,
+                _hookMetadata,
+                InterchainAccountMessage.EMPTY_SALT
+            );
+    }
+
+    function callRemoteWithOverrides(
+        uint32 _destination,
+        bytes32 _router,
+        bytes32 _ism,
+        CallLib.Call[] calldata _calls,
+        bytes memory _hookMetadata,
+        bytes32 _userSalt
+    ) public payable virtual returns (bytes32) {
         emit RemoteCallDispatched(
             _destination,
             msg.sender,
             _router,
             _ism,
-            InterchainAccountMessage.EMPTY_SALT
+            _userSalt
         );
         bytes memory _body = InterchainAccountMessage.encode(
             msg.sender,
             _ism,
-            _calls
+            _calls,
+            _userSalt
         );
         return
             _dispatchMessageWithValue(

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -29,6 +29,7 @@ import {AbstractRoutingIsm} from "../isms/routing/AbstractRoutingIsm.sol";
 
 // ============ External Imports ============
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /*
  * @title A contract that allows accounts on chain A to call contracts via a
@@ -544,6 +545,11 @@ contract InterchainAccountRouter is
         bytes32 _salt,
         bytes32 _commitment
     ) public payable returns (bytes32 _commitmentMsgId, bytes32 _revealMsgId) {
+        // Exclude this invocation's value from the baseline. The commitment
+        // hook may refund overpayment to this router to fund the reveal, but an
+        // unrelated pre-existing balance must never fund or block the reveal.
+        uint256 _balanceBefore = address(this).balance - msg.value;
+
         bytes memory _commitmentMsg = InterchainAccountMessage
             .encodeCommitment({
                 _owner: msg.sender.addressToBytes32(),
@@ -565,12 +571,7 @@ contract InterchainAccountRouter is
             _destination,
             _router,
             _commitmentMsg,
-            StandardHookMetadata.formatWithFeeToken(
-                0,
-                COMMIT_TX_GAS_USAGE,
-                address(this),
-                _hookMetadata.feeToken()
-            ),
+            _commitmentHookMetadata(_hookMetadata),
             _hook,
             msg.value
         );
@@ -579,14 +580,44 @@ contract InterchainAccountRouter is
             _ism: _ccipReadIsm,
             _commitment: _commitment
         });
+
+        // Forward only the net native value returned during this call's
+        // commitment dispatch.
+        uint256 _revealValue = address(this).balance - _balanceBefore;
         _revealMsgId = _dispatchMessageWithValue(
             _destination,
             _router,
             _revealMsg,
             _hookMetadata,
             _hook,
-            address(this).balance
+            _revealValue
         );
+
+        // Empty or short reveal metadata defaults hook refunds to this router.
+        // Return only this call's residual so it cannot become stranded or be
+        // swept by another caller; never touch the pre-existing baseline.
+        uint256 _residual = address(this).balance - _balanceBefore;
+        if (_residual != 0) {
+            Address.sendValue(payable(msg.sender), _residual);
+        }
+        assert(address(this).balance == _balanceBefore);
+    }
+
+    /**
+     * @dev Uses the fixed commitment gas limit and this router as refund
+     * recipient so the commitment's native refund can fund the reveal. The fee
+     * token is preserved so both dispatches use the same payment currency.
+     */
+    function _commitmentHookMetadata(
+        bytes memory _revealHookMetadata
+    ) internal view returns (bytes memory) {
+        return
+            StandardHookMetadata.formatWithFeeToken(
+                0,
+                COMMIT_TX_GAS_USAGE,
+                address(this),
+                _revealHookMetadata.feeToken()
+            );
     }
 
     function callRemoteCommitReveal(

--- a/solidity/contracts/middleware/InterchainAccountRouter.sol
+++ b/solidity/contracts/middleware/InterchainAccountRouter.sol
@@ -421,35 +421,6 @@ contract InterchainAccountRouter is
      * @param _ism The remote ISM address
      * @param _calls The sequence of calls to make
      * @param _hookMetadata The hook metadata to override with for the hook set by the owner
-     * @return The Hyperlane message ID
-     */
-    function callRemoteWithOverrides(
-        uint32 _destination,
-        bytes32 _router,
-        bytes32 _ism,
-        CallLib.Call[] calldata _calls,
-        bytes memory _hookMetadata
-    ) public payable override returns (bytes32) {
-        return
-            callRemoteWithOverrides(
-                _destination,
-                _router,
-                _ism,
-                _calls,
-                _hookMetadata,
-                InterchainAccountMessage.EMPTY_SALT
-            );
-    }
-
-    /**
-     * @notice Dispatches a sequence of remote calls to be made by an owner's
-     * interchain account on the destination domain
-     * @dev Recommend using CallLib.build to format the interchain calls
-     * @param _destination The remote domain of the chain to make calls on
-     * @param _router The remote router address
-     * @param _ism The remote ISM address
-     * @param _calls The sequence of calls to make
-     * @param _hookMetadata The hook metadata to override with for the hook set by the owner
      * @param _userSalt Salt provided by the user, allows control over account derivation.
      * @return The Hyperlane message ID
      */
@@ -460,7 +431,7 @@ contract InterchainAccountRouter is
         CallLib.Call[] calldata _calls,
         bytes memory _hookMetadata,
         bytes32 _userSalt
-    ) public payable returns (bytes32) {
+    ) public payable override returns (bytes32) {
         return
             callRemoteWithOverrides(
                 _destination,

--- a/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
+++ b/solidity/contracts/middleware/libs/InterchainAccountMessage.sol
@@ -106,6 +106,26 @@ library InterchainAccountMessage {
     }
 
     /**
+     * @notice Returns a formatted InterchainAccountMessage from calls in memory.
+     * @dev Mirrors encode while allowing decoded command inputs to reuse the
+     * canonical ICA wire format.
+     */
+    function encodeMemory(
+        address _owner,
+        bytes32 _ism,
+        CallLib.Call[] memory _calls,
+        bytes32 _userSalt
+    ) internal pure returns (bytes memory) {
+        bytes memory prefix = abi.encodePacked(
+            MessageType.CALLS,
+            TypeCasts.addressToBytes32(_owner),
+            _ism,
+            _userSalt
+        );
+        return bytes.concat(prefix, abi.encode(_calls));
+    }
+
+    /**
      * @notice Returns formatted (packed) InterchainAccountMessage
      * @dev This function should only be used in memory message construction.
      * @param _owner The owner of the interchain account

--- a/solidity/contracts/token/QuotedCalls.sol
+++ b/solidity/contracts/token/QuotedCalls.sol
@@ -20,10 +20,14 @@ import {ReentrancyGuardTransient} from "../libs/ReentrancyGuardTransient.sol";
 import {IAllowanceTransfer} from "permit2/interfaces/IAllowanceTransfer.sol";
 
 import {IPostDispatchHook} from "../interfaces/hooks/IPostDispatchHook.sol";
+import {IMailbox} from "../interfaces/IMailbox.sol";
 import {SignedQuote, IOffchainQuoter} from "../interfaces/IOffchainQuoter.sol";
 import {Quote, ITokenBridge} from "../interfaces/ITokenBridge.sol";
 import {StandardHookMetadata} from "../hooks/libs/StandardHookMetadata.sol";
 import {CallLib} from "../middleware/libs/Call.sol";
+import {InterchainAccountMessage} from "../middleware/libs/InterchainAccountMessage.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {Message} from "../libs/Message.sol";
 import {PackageVersioned} from "../PackageVersioned.sol";
 
 interface ICrossCollateralRouter {
@@ -62,17 +66,15 @@ interface IInterchainAccountRouter {
         bytes32 _commitment
     ) external payable returns (bytes32, bytes32);
 
-    function quoteGasPayment(
-        address _feeToken,
-        uint32 _destination,
-        uint256 _gasLimit
-    ) external view returns (uint256);
+    function mailbox() external view returns (IMailbox);
 
-    function quoteGasForCommitReveal(
-        address _feeToken,
-        uint32 _destination,
-        uint256 _gasLimit
-    ) external view returns (uint256);
+    function hook() external view returns (IPostDispatchHook);
+
+    function COMMIT_TX_GAS_USAGE() external view returns (uint256);
+}
+
+interface IVersionedMailbox {
+    function VERSION() external view returns (uint8);
 }
 
 /**
@@ -167,6 +169,8 @@ library CalldataHeadLib {
  */
 contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
     using SafeERC20 for IERC20;
+    using StandardHookMetadata for bytes;
+    using TypeCasts for address;
 
     // ============ Immutables ============
 
@@ -299,6 +303,10 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
      *      transient quotes), skips token pull/sweep commands, and returns
      *      per-command Quote[] arrays for transfer/ICA commands.
      *      Same command bytes and inputs as execute().
+     *      ICA hook quotes must be caller-independent and pricing-stable
+     *      between quote and execution. Commands that dispatch before an ICA
+     *      command may change its Mailbox nonce and invalidate nonce-sensitive
+     *      hook pricing.
      * @param commands Concatenated command bytes (1 byte per command)
      * @param inputs ABI-encoded inputs for each command
      * @return results Per-command Quote arrays. Empty for non-quoting commands.
@@ -604,34 +612,17 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
             );
     }
 
-    function _quoteIcaGasPayment(
-        address icaRouter,
-        uint32 destination,
-        bytes memory hookMetadata,
-        address token
-    ) internal view returns (Quote[] memory quotes) {
-        quotes = new Quote[](1);
-        quotes[0] = Quote({
-            token: token,
-            amount: IInterchainAccountRouter(icaRouter).quoteGasPayment(
-                token,
-                destination,
-                StandardHookMetadata.gasLimit(hookMetadata)
-            )
-        });
-    }
-
     function _quoteCallRemoteWithOverrides(
         bytes calldata input
-    ) internal view returns (Quote[] memory) {
+    ) internal view returns (Quote[] memory quotes) {
         (
             address icaRouter,
             uint32 destination,
-            ,
-            ,
-            ,
+            bytes32 router,
+            bytes32 ism,
+            CallLib.Call[] memory calls,
             bytes memory hookMetadata,
-            ,
+            bytes32 userSalt,
             ,
             address token,
 
@@ -650,7 +641,29 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
                     uint256
                 )
             );
-        return _quoteIcaGasPayment(icaRouter, destination, hookMetadata, token);
+
+        IInterchainAccountRouter icaRouterContract = IInterchainAccountRouter(
+            icaRouter
+        );
+        bytes memory body = InterchainAccountMessage.encodeMemory(
+            address(this),
+            ism,
+            calls,
+            _scopeSalt(msg.sender, userSalt)
+        );
+        quotes = new Quote[](1);
+        quotes[0] = Quote({
+            token: token,
+            amount: _quoteDispatchForIca(
+                icaRouterContract,
+                destination,
+                router,
+                body,
+                hookMetadata,
+                icaRouterContract.hook(),
+                0
+            )
+        });
     }
 
     function _quoteCallRemoteCommitReveal(
@@ -659,12 +672,12 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
         (
             address icaRouter,
             uint32 destination,
-            ,
-            ,
+            bytes32 router,
+            bytes32 ism,
             bytes memory hookMetadata,
-            ,
-            ,
-            ,
+            address hook,
+            bytes32 salt,
+            bytes32 commitment,
             ,
             address token,
 
@@ -685,16 +698,110 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
                 )
             );
         // Commit-reveal pays for two dispatches (commit + reveal).
-        // quoteGasForCommitReveal returns the combined cost.
+        // The reconstructed quote returns their combined cost.
+        uint256 amount = _quoteCommitRevealDispatches(
+            icaRouter,
+            destination,
+            router,
+            ism,
+            hookMetadata,
+            IPostDispatchHook(hook),
+            _scopeSalt(msg.sender, salt),
+            commitment
+        );
         quotes = new Quote[](1);
-        quotes[0] = Quote({
-            token: token,
-            amount: IInterchainAccountRouter(icaRouter).quoteGasForCommitReveal(
-                token,
-                destination,
-                StandardHookMetadata.gasLimit(hookMetadata)
-            )
+        quotes[0] = Quote({token: token, amount: amount});
+    }
+
+    function _quoteCommitRevealDispatches(
+        address icaRouter,
+        uint32 destination,
+        bytes32 router,
+        bytes32 ism,
+        bytes memory hookMetadata,
+        IPostDispatchHook selectedHook,
+        bytes32 scopedSalt,
+        bytes32 commitment
+    ) internal view returns (uint256) {
+        // Both legs are quoted against the current hook state. Hooks whose
+        // pricing changes during postDispatch are not safely prequotable.
+        IInterchainAccountRouter icaRouterContract = IInterchainAccountRouter(
+            icaRouter
+        );
+
+        bytes memory commitmentBody = InterchainAccountMessage
+            .encodeCommitment({
+                _owner: address(this).addressToBytes32(),
+                _ism: ism,
+                _commitment: commitment,
+                _userSalt: scopedSalt
+            });
+        bytes memory commitmentMetadata = StandardHookMetadata
+            .formatWithFeeToken(
+                0,
+                icaRouterContract.COMMIT_TX_GAS_USAGE(),
+                icaRouter,
+                hookMetadata.feeToken()
+            );
+        bytes memory revealBody = InterchainAccountMessage.encodeReveal({
+            _ism: bytes32(0),
+            _commitment: commitment
         });
+
+        return
+            _quoteDispatchForIca(
+                icaRouterContract,
+                destination,
+                router,
+                commitmentBody,
+                commitmentMetadata,
+                selectedHook,
+                0
+            ) +
+            _quoteDispatchForIca(
+                icaRouterContract,
+                destination,
+                router,
+                revealBody,
+                hookMetadata,
+                selectedHook,
+                1
+            );
+    }
+
+    /**
+     * @dev Reconstructs Mailbox.quoteDispatch with the ICA router as message
+     * sender. Calling Mailbox.quoteDispatch directly would encode this
+     * QuotedCalls contract as sender and misquote sender-sensitive hooks.
+     * Hooks are expected to price metadata/message inputs rather than the
+     * caller of quoteDispatch, as required for permissionless quotes.
+     */
+    function _quoteDispatchForIca(
+        IInterchainAccountRouter icaRouter,
+        uint32 destination,
+        bytes32 router,
+        bytes memory body,
+        bytes memory hookMetadata,
+        IPostDispatchHook selectedHook,
+        uint32 nonceOffset
+    ) internal view returns (uint256) {
+        IMailbox mailbox = icaRouter.mailbox();
+        bytes memory message = Message.formatMessageMemory(
+            IVersionedMailbox(address(mailbox)).VERSION(),
+            mailbox.nonce() + nonceOffset,
+            mailbox.localDomain(),
+            address(icaRouter).addressToBytes32(),
+            destination,
+            router,
+            body
+        );
+
+        if (address(selectedHook) == address(0)) {
+            selectedHook = mailbox.defaultHook();
+        }
+        return
+            mailbox.requiredHook().quoteDispatch(hookMetadata, message) +
+            selectedHook.quoteDispatch(hookMetadata, message);
     }
 
     receive() external payable {}

--- a/solidity/contracts/token/QuotedCalls.sol
+++ b/solidity/contracts/token/QuotedCalls.sol
@@ -304,9 +304,9 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
      *      per-command Quote[] arrays for transfer/ICA commands.
      *      Same command bytes and inputs as execute().
      *      ICA hook quotes must be caller-independent and pricing-stable
-     *      between quote and execution. Commands that dispatch before an ICA
-     *      command may change its Mailbox nonce and invalidate nonce-sensitive
-     *      hook pricing.
+     *      between quote and execution. Like Mailbox.quoteDispatch, every ICA
+     *      message is quoted at the current Mailbox nonce; hooks whose pricing
+     *      depends on the nonce cannot be reliably prequoted.
      * @param commands Concatenated command bytes (1 byte per command)
      * @param inputs ABI-encoded inputs for each command
      * @return results Per-command Quote arrays. Empty for non-quoting commands.
@@ -660,8 +660,7 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
                 router,
                 body,
                 hookMetadata,
-                icaRouterContract.hook(),
-                0
+                icaRouterContract.hook()
             )
         });
     }
@@ -755,8 +754,7 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
                 router,
                 commitmentBody,
                 commitmentMetadata,
-                selectedHook,
-                0
+                selectedHook
             ) +
             _quoteDispatchForIca(
                 icaRouterContract,
@@ -764,8 +762,7 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
                 router,
                 revealBody,
                 hookMetadata,
-                selectedHook,
-                1
+                selectedHook
             );
     }
 
@@ -782,13 +779,12 @@ contract QuotedCalls is PackageVersioned, ReentrancyGuardTransient {
         bytes32 router,
         bytes memory body,
         bytes memory hookMetadata,
-        IPostDispatchHook selectedHook,
-        uint32 nonceOffset
+        IPostDispatchHook selectedHook
     ) internal view returns (uint256) {
         IMailbox mailbox = icaRouter.mailbox();
         bytes memory message = Message.formatMessageMemory(
             IVersionedMailbox(address(mailbox)).VERSION(),
-            mailbox.nonce() + nonceOffset,
+            mailbox.nonce(),
             mailbox.localDomain(),
             address(icaRouter).addressToBytes32(),
             destination,

--- a/solidity/test/InterchainAccountRouter.t.sol
+++ b/solidity/test/InterchainAccountRouter.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {StandardHookMetadata} from "../contracts/hooks/libs/StandardHookMetadata.sol";
 import {MockMailbox} from "../contracts/mock/MockMailbox.sol";
@@ -57,6 +58,91 @@ contract FailingIsm is IInterchainSecurityModule {
         bytes calldata
     ) external view returns (bool) {
         revert(failureMessage);
+    }
+}
+
+contract TestERC20FeeHook is AbstractPostDispatchHook {
+    using Message for bytes;
+    using SafeERC20 for IERC20;
+    using StandardHookMetadata for bytes;
+
+    IERC20 public immutable feeToken;
+    uint256 public dispatchCount;
+    uint256 public totalFees;
+    uint256 public lastMsgValue;
+    bytes32 public lastRecipient;
+    bytes32 public lastBodyHash;
+
+    constructor(IERC20 _feeToken) {
+        feeToken = _feeToken;
+    }
+
+    function hookType() external pure override returns (uint8) {
+        return uint8(IPostDispatchHook.HookTypes.UNUSED);
+    }
+
+    function _postDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal override {
+        require(
+            metadata.feeToken(address(0)) == address(feeToken),
+            "unexpected fee token"
+        );
+
+        uint256 fee = _quoteDispatch(metadata, message);
+        feeToken.safeTransferFrom(message.senderAddress(), address(this), fee);
+
+        dispatchCount += 1;
+        totalFees += fee;
+        lastMsgValue = msg.value;
+        lastRecipient = message.recipient();
+        lastBodyHash = keccak256(message.body());
+    }
+
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata message
+    ) internal pure override returns (uint256) {
+        return
+            1_000_000 +
+            message.body().length *
+            1_000 +
+            (uint256(message.recipient()) & 0xff);
+    }
+}
+
+contract TestUnderpullingERC20FeeHook is AbstractPostDispatchHook {
+    using Message for bytes;
+    using SafeERC20 for IERC20;
+
+    uint256 internal constant FEE = 1_000_000;
+    IERC20 public immutable feeToken;
+
+    constructor(IERC20 _feeToken) {
+        feeToken = _feeToken;
+    }
+
+    function hookType() external pure override returns (uint8) {
+        return uint8(IPostDispatchHook.HookTypes.UNUSED);
+    }
+
+    function _postDispatch(
+        bytes calldata,
+        bytes calldata message
+    ) internal override {
+        feeToken.safeTransferFrom(
+            message.senderAddress(),
+            address(this),
+            FEE - 1
+        );
+    }
+
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata
+    ) internal pure override returns (uint256) {
+        return FEE;
     }
 }
 
@@ -1489,6 +1575,37 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
         assertEq(balanceBefore - balanceAfter, quote);
     }
 
+    function test_callRemoteCommitReveal_emptyMetadata_refundsResidual(
+        bytes32 commitment
+    ) public {
+        originIcaRouter.enrollRemoteRouterAndIsm(
+            destination,
+            routerOverride,
+            ismOverride
+        );
+
+        uint256 quote = originIcaRouter.quoteGasForCommitReveal(
+            destination,
+            50_000
+        );
+        uint256 preExistingBalance = 1 wei;
+        vm.deal(address(originIcaRouter), preExistingBalance);
+        uint256 callerBalanceBefore = address(this).balance;
+
+        originIcaRouter.callRemoteCommitReveal{value: 2 * quote}(
+            destination,
+            routerOverride,
+            ismOverride,
+            bytes(""),
+            originIcaRouter.hook(),
+            bytes32(0),
+            commitment
+        );
+
+        assertEq(callerBalanceBefore - address(this).balance, quote);
+        assertEq(address(originIcaRouter).balance, preExistingBalance);
+    }
+
     function testFuzz_quoteGasForCommitReveal(bytes32 commitment) public {
         // Arrange
         // We use _Router_quoteDispatch so we actually need a remote router enrolled before quoting
@@ -1693,6 +1810,202 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
             feeQuote,
             "Fee tokens should be charged"
         );
+    }
+
+    function test_callRemote_withERC20Fee_usesMailboxDefaultHook() public {
+        environment.mailboxes(origin).setDefaultHook(address(erc20Igp));
+        InterchainAccountRouter defaultHookRouter = deployIcaRouter(
+            environment.mailboxes(origin),
+            IPostDispatchHook(address(0)),
+            address(this)
+        );
+        defaultHookRouter.enrollRemoteRouterAndIsm(
+            destination,
+            erc20RouterOverride,
+            ismOverride
+        );
+
+        uint256 feeQuote = defaultHookRouter.quoteGasPayment(
+            address(feeToken),
+            destination,
+            GAS_LIMIT_OVERRIDE
+        );
+        feeToken.approve(address(defaultHookRouter), feeQuote);
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT_OVERRIDE,
+            address(this),
+            address(feeToken)
+        );
+        CallLib.Call[] memory calls = getCalls(bytes32("default_hook"), 0);
+
+        defaultHookRouter.callRemote(destination, calls, hookMetadata);
+
+        assertEq(feeToken.balanceOf(address(erc20Igp)), feeQuote);
+        assertEq(feeToken.balanceOf(address(defaultHookRouter)), 0);
+        assertEq(
+            feeToken.allowance(address(defaultHookRouter), address(erc20Igp)),
+            type(uint256).max
+        );
+        assertEq(feeToken.allowance(address(defaultHookRouter), address(0)), 0);
+    }
+
+    function test_callRemote_withERC20Fee_defaultAggregationRequiresChildApproval()
+        public
+    {
+        address[] memory hooks = new address[](1);
+        hooks[0] = address(erc20Igp);
+        StaticAggregationHook aggregationHook = StaticAggregationHook(
+            new StaticAggregationHookFactory().deploy(hooks)
+        );
+        environment.mailboxes(origin).setDefaultHook(address(aggregationHook));
+
+        InterchainAccountRouter defaultHookRouter = deployIcaRouter(
+            environment.mailboxes(origin),
+            IPostDispatchHook(address(0)),
+            address(this)
+        );
+        defaultHookRouter.enrollRemoteRouterAndIsm(
+            destination,
+            erc20RouterOverride,
+            ismOverride
+        );
+
+        uint256 feeQuote = defaultHookRouter.quoteGasPayment(
+            address(feeToken),
+            destination,
+            GAS_LIMIT_OVERRIDE
+        );
+        feeToken.approve(address(defaultHookRouter), feeQuote);
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT_OVERRIDE,
+            address(this),
+            address(feeToken)
+        );
+        CallLib.Call[] memory calls = getCalls(bytes32("aggregation"), 0);
+
+        vm.expectRevert("ERC20: insufficient allowance");
+        defaultHookRouter.callRemote(destination, calls, hookMetadata);
+
+        defaultHookRouter.approveFeeTokenForHook(
+            address(feeToken),
+            address(erc20Igp)
+        );
+        defaultHookRouter.callRemote(destination, calls, hookMetadata);
+
+        assertEq(feeToken.balanceOf(address(erc20Igp)), feeQuote);
+        assertEq(feeToken.balanceOf(address(defaultHookRouter)), 0);
+    }
+
+    function test_callRemoteWithOverrides_withERC20Fee_unenrolledDestination()
+        public
+    {
+        InterchainAccountRouter unenrolledRouter = deployIcaRouter(
+            environment.mailboxes(origin),
+            IPostDispatchHook(address(erc20Igp)),
+            address(this)
+        );
+        feeToken.approve(address(unenrolledRouter), type(uint256).max);
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT_OVERRIDE,
+            address(this),
+            address(feeToken)
+        );
+        CallLib.Call[] memory calls = getCalls(bytes32("unenrolled"), 0);
+        uint256 hookBalanceBefore = feeToken.balanceOf(address(erc20Igp));
+
+        unenrolledRouter.callRemoteWithOverrides(
+            destination,
+            erc20RouterOverride,
+            ismOverride,
+            calls,
+            hookMetadata
+        );
+
+        assertGt(feeToken.balanceOf(address(erc20Igp)), hookBalanceBefore);
+        assertEq(feeToken.balanceOf(address(unenrolledRouter)), 0);
+        assertEq(unenrolledRouter.routers(destination), bytes32(0));
+    }
+
+    function test_callRemoteWithOverrides_withERC20Fee_customHook() public {
+        TestERC20FeeHook customHook = new TestERC20FeeHook(feeToken);
+        bytes32 customRouter = bytes32(uint256(0xBEEF));
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT_OVERRIDE,
+            address(this),
+            address(feeToken)
+        );
+        CallLib.Call[] memory calls = getCalls(bytes32("custom_hook"), 0);
+        uint256 bodyLength = 97 + abi.encode(calls).length;
+        uint256 expectedFee = 1_000_000 +
+            bodyLength *
+            1_000 +
+            (uint256(customRouter) & 0xff);
+        feeToken.approve(address(originErc20Router), expectedFee);
+        uint256 callerBalanceBefore = feeToken.balanceOf(address(this));
+
+        originErc20Router.callRemoteWithOverrides(
+            destination,
+            customRouter,
+            ismOverride,
+            calls,
+            hookMetadata,
+            bytes32(0),
+            IPostDispatchHook(address(customHook))
+        );
+
+        assertEq(customHook.dispatchCount(), 1);
+        assertEq(customHook.lastRecipient(), customRouter);
+        assertNotEq(customHook.lastBodyHash(), keccak256(bytes("")));
+        assertEq(customHook.lastMsgValue(), 0);
+        assertEq(customHook.totalFees(), expectedFee);
+        assertEq(feeToken.balanceOf(address(customHook)), expectedFee);
+        assertEq(
+            callerBalanceBefore - feeToken.balanceOf(address(this)),
+            expectedFee
+        );
+        assertEq(feeToken.balanceOf(address(erc20Igp)), 0);
+        assertEq(feeToken.balanceOf(address(originErc20Router)), 0);
+        assertEq(
+            feeToken.allowance(address(originErc20Router), address(customHook)),
+            type(uint256).max
+        );
+    }
+
+    function test_callRemoteWithOverrides_withERC20Fee_revertsWhenHookUnderpulls()
+        public
+    {
+        TestUnderpullingERC20FeeHook underpullingHook = new TestUnderpullingERC20FeeHook(
+                feeToken
+            );
+        feeToken.approve(address(originErc20Router), type(uint256).max);
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT_OVERRIDE,
+            address(this),
+            address(feeToken)
+        );
+        CallLib.Call[] memory calls = getCalls(bytes32("underpull"), 0);
+
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x01));
+        originErc20Router.callRemoteWithOverrides(
+            destination,
+            erc20RouterOverride,
+            ismOverride,
+            calls,
+            hookMetadata,
+            bytes32(0),
+            IPostDispatchHook(address(underpullingHook))
+        );
+
+        assertEq(feeToken.balanceOf(address(originErc20Router)), 0);
+        assertEq(feeToken.balanceOf(address(underpullingHook)), 0);
     }
 
     function test_feeToken_shortMetadata_returnsZeroAddress() public {
@@ -1998,6 +2311,201 @@ contract InterchainAccountRouterTest is InterchainAccountRouterTestBase {
             feeBalanceBefore - feeBalanceAfter,
             totalQuote,
             "Fee tokens charged should match quoteGasForCommitReveal"
+        );
+    }
+
+    function test_callRemoteCommitReveal_withERC20Fee_nonZeroRouterBalance()
+        public
+    {
+        // Only this call's commit refund may fund its reveal. An unrelated
+        // native balance must not brick the ERC20 fee path.
+        vm.deal(address(1), 1 wei);
+        vm.prank(address(1));
+        (bool sent, ) = address(originErc20Router).call{value: 1 wei}("");
+        assertTrue(sent, "balance not sent");
+
+        uint256 revealGasLimit = 100_000;
+        uint256 totalQuote = originErc20Router.quoteGasForCommitReveal(
+            address(feeToken),
+            destination,
+            revealGasLimit
+        );
+        feeToken.approve(address(originErc20Router), totalQuote);
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            revealGasLimit,
+            address(this),
+            address(feeToken)
+        );
+        uint256 feeBalanceBefore = feeToken.balanceOf(address(this));
+
+        originErc20Router.callRemoteCommitReveal{value: 0}(
+            destination,
+            erc20RouterOverride,
+            ismOverride,
+            hookMetadata,
+            IPostDispatchHook(address(erc20Igp)),
+            bytes32(0),
+            keccak256("balance_commitment")
+        );
+
+        assertEq(
+            feeBalanceBefore - feeToken.balanceOf(address(this)),
+            totalQuote,
+            "Fee tokens charged should match quoteGasForCommitReveal"
+        );
+        assertEq(
+            address(originErc20Router).balance,
+            1 wei,
+            "Native balance should be untouched by the fee token path"
+        );
+    }
+
+    function test_callRemoteCommitReveal_withERC20Fee_customHook_nonZeroRouterBalance()
+        public
+    {
+        TestERC20FeeHook customHook = new TestERC20FeeHook(feeToken);
+        bytes32 customRouter = bytes32(uint256(0xCAFE));
+        feeToken.approve(address(originErc20Router), type(uint256).max);
+
+        vm.deal(address(1), 1 wei);
+        vm.prank(address(1));
+        (bool sent, ) = address(originErc20Router).call{value: 1 wei}("");
+        assertTrue(sent, "balance not sent");
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            100_000,
+            address(this),
+            address(feeToken)
+        );
+
+        originErc20Router.callRemoteCommitReveal(
+            destination,
+            customRouter,
+            ismOverride,
+            hookMetadata,
+            IPostDispatchHook(address(customHook)),
+            bytes32(0),
+            keccak256("custom_hook_commitment")
+        );
+
+        assertEq(customHook.dispatchCount(), 2);
+        assertEq(customHook.lastRecipient(), customRouter);
+        assertEq(customHook.lastMsgValue(), 0);
+        assertEq(
+            feeToken.balanceOf(address(customHook)),
+            customHook.totalFees()
+        );
+        assertEq(feeToken.balanceOf(address(erc20Igp)), 0);
+        assertEq(feeToken.balanceOf(address(originErc20Router)), 0);
+        assertEq(address(originErc20Router).balance, 1 wei);
+    }
+
+    function test_callRemoteCommitReveal_withERC20Fee_revertsWhen_nativeValueSent()
+        public
+    {
+        uint256 revealGasLimit = 100_000;
+        uint256 totalQuote = originErc20Router.quoteGasForCommitReveal(
+            address(feeToken),
+            destination,
+            revealGasLimit
+        );
+        feeToken.approve(address(originErc20Router), totalQuote);
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            revealGasLimit,
+            address(this),
+            address(feeToken)
+        );
+
+        vm.expectRevert("IGP: native value not accepted with ERC20 fee");
+        originErc20Router.callRemoteCommitReveal{value: 1 wei}(
+            destination,
+            erc20RouterOverride,
+            ismOverride,
+            hookMetadata,
+            IPostDispatchHook(address(erc20Igp)),
+            bytes32(0),
+            keccak256("mixed_commitment")
+        );
+    }
+
+    function test_callRemoteCommitReveal_withNativeFee_preservesPreExistingBalance()
+        public
+    {
+        vm.deal(address(1), 1 wei);
+        vm.prank(address(1));
+        (bool sent, ) = address(originErc20Router).call{value: 1 wei}("");
+        assertTrue(sent, "balance not sent");
+
+        uint256 revealGasLimit = 100_000;
+        uint256 quote = originErc20Router.quoteGasForCommitReveal(
+            destination,
+            revealGasLimit
+        );
+        bytes memory hookMetadata = StandardHookMetadata.formatMetadata(
+            0,
+            revealGasLimit,
+            address(this),
+            bytes("")
+        );
+
+        originErc20Router.callRemoteCommitReveal{value: quote}(
+            destination,
+            erc20RouterOverride,
+            ismOverride,
+            hookMetadata,
+            IPostDispatchHook(address(erc20Igp)),
+            bytes32(0),
+            keccak256("native_balance_commitment")
+        );
+
+        assertEq(
+            address(originErc20Router).balance,
+            1 wei,
+            "Native path should preserve the pre-existing router balance"
+        );
+    }
+
+    function testFuzz_callRemoteCommitReveal_withNativeFee_preservesPreExistingBalance(
+        uint96 preExistingBalance,
+        uint96 extraPayment,
+        bytes32 commitment
+    ) public {
+        vm.deal(address(originErc20Router), preExistingBalance);
+
+        uint256 revealGasLimit = 100_000;
+        uint256 quote = originErc20Router.quoteGasForCommitReveal(
+            destination,
+            revealGasLimit
+        );
+        uint256 payment = quote + extraPayment;
+        vm.deal(address(this), payment);
+
+        bytes memory hookMetadata = StandardHookMetadata.formatMetadata(
+            0,
+            revealGasLimit,
+            address(this),
+            bytes("")
+        );
+
+        originErc20Router.callRemoteCommitReveal{value: payment}(
+            destination,
+            erc20RouterOverride,
+            ismOverride,
+            hookMetadata,
+            IPostDispatchHook(address(erc20Igp)),
+            bytes32(0),
+            commitment
+        );
+
+        assertEq(
+            address(originErc20Router).balance,
+            preExistingBalance,
+            "Native path should preserve arbitrary pre-existing balance"
         );
     }
 

--- a/solidity/test/MinimalInterchainAccountRouter.t.sol
+++ b/solidity/test/MinimalInterchainAccountRouter.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {IPostDispatchHook} from "../contracts/interfaces/hooks/IPostDispatchHook.sol";
+import {StandardHookMetadata} from "../contracts/hooks/libs/StandardHookMetadata.sol";
 import {MockMailbox} from "../contracts/mock/MockMailbox.sol";
 import {CallLib, InterchainAccountRouter} from "../contracts/middleware/InterchainAccountRouter.sol";
 import {MinimalInterchainAccountRouter} from "../contracts/middleware/MinimalInterchainAccountRouter.sol";
@@ -29,5 +30,46 @@ contract MinimalInterchainAccountRouterTest is InterchainAccountRouterTestBase {
                     )
                 )
             );
+    }
+
+    function test_callRemoteWithOverrides_withERC20Fee_usesMailboxDefaultHook()
+        public
+    {
+        environment.mailboxes(origin).setDefaultHook(address(erc20Igp));
+        InterchainAccountRouter defaultHookRouter = deployIcaRouter(
+            environment.mailboxes(origin),
+            IPostDispatchHook(address(0)),
+            address(this)
+        );
+        feeToken.approve(address(defaultHookRouter), type(uint256).max);
+
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT_OVERRIDE,
+            address(this),
+            address(feeToken)
+        );
+        uint256 feeQuote = erc20Igp.quoteGasPayment(
+            address(feeToken),
+            destination,
+            GAS_LIMIT_OVERRIDE
+        );
+
+        defaultHookRouter.callRemoteWithOverrides(
+            destination,
+            routerOverride,
+            ismOverride,
+            getCalls(bytes32("minimal_default_hook"), 0),
+            hookMetadata
+        );
+
+        assertEq(feeToken.balanceOf(address(erc20Igp)), feeQuote);
+        assertEq(feeToken.balanceOf(address(defaultHookRouter)), 0);
+        assertEq(
+            feeToken.allowance(address(defaultHookRouter), address(erc20Igp)),
+            type(uint256).max
+        );
+        assertEq(feeToken.allowance(address(defaultHookRouter), address(0)), 0);
+        assertEq(defaultHookRouter.routers(destination), bytes32(0));
     }
 }

--- a/solidity/test/token/QuotedCalls.t.sol
+++ b/solidity/test/token/QuotedCalls.t.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {IAllowanceTransfer} from "permit2/interfaces/IAllowanceTransfer.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
 import {MockMailbox} from "../../contracts/mock/MockMailbox.sol";
@@ -16,6 +18,10 @@ import {IGasOracle} from "../../contracts/interfaces/IGasOracle.sol";
 import {GasRouter} from "../../contracts/client/GasRouter.sol";
 import {ITokenBridge} from "../../contracts/interfaces/ITokenBridge.sol";
 import {StandardHookMetadata} from "../../contracts/hooks/libs/StandardHookMetadata.sol";
+import {AbstractPostDispatchHook} from "../../contracts/hooks/libs/AbstractPostDispatchHook.sol";
+import {IPostDispatchHook} from "../../contracts/interfaces/hooks/IPostDispatchHook.sol";
+import {IMailbox} from "../../contracts/interfaces/IMailbox.sol";
+import {Message} from "../../contracts/libs/Message.sol";
 
 import {AbstractOffchainQuoter} from "../../contracts/libs/AbstractOffchainQuoter.sol";
 import {SignedQuote} from "../../contracts/interfaces/IOffchainQuoter.sol";
@@ -27,9 +33,220 @@ import {HypERC20Collateral} from "../../contracts/token/HypERC20Collateral.sol";
 import {TokenRouter} from "../../contracts/token/libs/TokenRouter.sol";
 import {InterchainAccountRouter} from "../../contracts/middleware/InterchainAccountRouter.sol";
 import {CallLib} from "../../contracts/middleware/libs/Call.sol";
+import {InterchainAccountMessage} from "../../contracts/middleware/libs/InterchainAccountMessage.sol";
 import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ReentrancyGuardTransient} from "../../contracts/libs/ReentrancyGuardTransient.sol";
+
+/// @dev ERC20 hook whose fee binds quotes to the actual metadata and complete
+///      formatted message, including its sender and Mailbox nonce.
+contract QuotedCallsERC20FeeHook is AbstractPostDispatchHook {
+    using Message for bytes;
+    using SafeERC20 for IERC20;
+    using StandardHookMetadata for bytes;
+
+    IERC20 public immutable feeToken;
+    uint256 public dispatchCount;
+    uint256 public totalFees;
+    bytes32 public lastRecipient;
+
+    constructor(IERC20 _feeToken) {
+        feeToken = _feeToken;
+    }
+
+    function hookType() external pure override returns (uint8) {
+        return uint8(IPostDispatchHook.HookTypes.UNUSED);
+    }
+
+    function _postDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal override {
+        require(
+            metadata.feeToken(address(0)) == address(feeToken),
+            "unexpected fee token"
+        );
+        uint256 fee = _quoteDispatch(metadata, message);
+        feeToken.safeTransferFrom(message.senderAddress(), address(this), fee);
+        dispatchCount += 1;
+        totalFees += fee;
+        lastRecipient = message.recipient();
+    }
+
+    function _quoteDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal pure override returns (uint256) {
+        return
+            1_000_000 +
+            metadata.gasLimit() +
+            (uint256(message.recipient()) & 0xffff) *
+            1_000_000 +
+            uint256(uint72(uint256(keccak256(message))));
+    }
+}
+
+/// @dev Models the ICA getter and quote surface deployed before exact-input
+///      quote overloads existed.
+contract LegacyIcaRouterQuoteSurface {
+    using StandardHookMetadata for bytes;
+    using TypeCasts for address;
+
+    IMailbox public immutable mailbox;
+    IPostDispatchHook public hook;
+    uint256 public immutable COMMIT_TX_GAS_USAGE;
+
+    constructor(
+        IMailbox _mailbox,
+        IPostDispatchHook _hook,
+        uint256 _commitTxGasUsage
+    ) {
+        mailbox = _mailbox;
+        hook = _hook;
+        COMMIT_TX_GAS_USAGE = _commitTxGasUsage;
+    }
+
+    function quoteGasPayment(
+        address,
+        uint32,
+        uint256
+    ) external pure returns (uint256) {
+        return 1;
+    }
+
+    function quoteGasForCommitReveal(
+        address,
+        uint32,
+        uint256
+    ) external pure returns (uint256) {
+        return 2;
+    }
+
+    function callRemoteWithOverrides(
+        uint32 destination,
+        bytes32 router,
+        bytes32 ism,
+        CallLib.Call[] calldata calls,
+        bytes calldata hookMetadata,
+        bytes32 salt
+    ) external payable returns (bytes32) {
+        bytes memory body = InterchainAccountMessage.encode(
+            msg.sender,
+            ism,
+            calls,
+            salt
+        );
+        return
+            mailbox.dispatch{value: msg.value}(
+                destination,
+                router,
+                body,
+                hookMetadata,
+                hook
+            );
+    }
+
+    function callRemoteCommitReveal(
+        uint32 destination,
+        bytes32 router,
+        bytes32 ism,
+        bytes calldata hookMetadata,
+        IPostDispatchHook selectedHook,
+        bytes32 salt,
+        bytes32 commitment
+    ) external payable returns (bytes32 commitmentId, bytes32 revealId) {
+        bytes memory commitmentBody = InterchainAccountMessage
+            .encodeCommitment({
+                _owner: msg.sender.addressToBytes32(),
+                _ism: ism,
+                _commitment: commitment,
+                _userSalt: salt
+            });
+        bytes memory commitmentMetadata = StandardHookMetadata
+            .formatWithFeeToken(
+                0,
+                COMMIT_TX_GAS_USAGE,
+                address(this),
+                hookMetadata.feeToken()
+            );
+        commitmentId = mailbox.dispatch{value: msg.value}(
+            destination,
+            router,
+            commitmentBody,
+            commitmentMetadata,
+            selectedHook
+        );
+
+        bytes memory revealBody = InterchainAccountMessage.encodeReveal({
+            _ism: bytes32(0),
+            _commitment: commitment
+        });
+        revealId = mailbox.dispatch(
+            destination,
+            router,
+            revealBody,
+            hookMetadata,
+            selectedHook
+        );
+    }
+}
+
+contract MessageEncodingHarness {
+    function icaEncodingsMatch(
+        address owner,
+        bytes32 ism,
+        CallLib.Call[] calldata calls,
+        bytes32 salt
+    ) external pure returns (bool) {
+        CallLib.Call[] memory memoryCalls = calls;
+        return
+            keccak256(
+                InterchainAccountMessage.encode(owner, ism, calls, salt)
+            ) ==
+            keccak256(
+                InterchainAccountMessage.encodeMemory(
+                    owner,
+                    ism,
+                    memoryCalls,
+                    salt
+                )
+            );
+    }
+
+    function messageEncodingsMatch(
+        uint8 version,
+        uint32 nonce,
+        uint32 origin,
+        bytes32 sender,
+        uint32 destination,
+        bytes32 recipient,
+        bytes calldata body
+    ) external pure returns (bool) {
+        bytes memory memoryBody = body;
+        return
+            keccak256(
+                Message.formatMessage(
+                    version,
+                    nonce,
+                    origin,
+                    sender,
+                    destination,
+                    recipient,
+                    body
+                )
+            ) ==
+            keccak256(
+                Message.formatMessageMemory(
+                    version,
+                    nonce,
+                    origin,
+                    sender,
+                    destination,
+                    recipient,
+                    memoryBody
+                )
+            );
+    }
+}
 
 /// @dev Contract that attempts reentrancy via the SWEEP ETH callback.
 contract ReentrantAttacker {
@@ -607,7 +824,156 @@ contract QuotedCallsTest is Test {
         inputs = ins;
     }
 
+    function _deployQuotedCallsFeeRouter()
+        internal
+        returns (
+            InterchainAccountRouter icaRouter,
+            QuotedCallsERC20FeeHook feeHook
+        )
+    {
+        feeHook = new QuotedCallsERC20FeeHook(primaryToken);
+        string[] memory icaUrls = new string[](1);
+        icaUrls[0] = "https://quoter.example.com/{data}";
+        icaRouter = new InterchainAccountRouter(
+            address(localMailbox),
+            address(feeHook),
+            address(this),
+            0,
+            icaUrls
+        );
+    }
+
+    function _singleRemoteCall(
+        bytes memory data
+    ) internal pure returns (CallLib.Call[] memory calls) {
+        calls = new CallLib.Call[](1);
+        calls[0] = CallLib.Call({
+            to: address(0xbeef).addressToBytes32(),
+            value: 0,
+            data: data
+        });
+    }
+
+    function _quoteSingleCommand(
+        bytes1 command,
+        bytes memory input
+    ) internal returns (uint256) {
+        bytes1[] memory cmds = new bytes1[](1);
+        bytes[] memory ins = new bytes[](1);
+        cmds[0] = command;
+        ins[0] = input;
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
+        assertEq(results[0].length, 1, "ICA should return one quote");
+        assertEq(results[0][0].token, address(primaryToken));
+        return results[0][0].amount;
+    }
+
+    function _quoteCallRemoteWithOverrides(
+        InterchainAccountRouter icaRouter,
+        bytes32 targetRouter,
+        bytes32 ism,
+        CallLib.Call[] memory calls,
+        bytes memory hookMetadata,
+        bytes32 salt
+    ) internal returns (uint256) {
+        (bytes1 command, bytes memory input) = _cmdCallRemoteWithOverrides(
+            address(icaRouter),
+            DESTINATION,
+            targetRouter,
+            ism,
+            calls,
+            hookMetadata,
+            salt,
+            0,
+            address(primaryToken),
+            0
+        );
+        return _quoteSingleCommand(command, input);
+    }
+
+    function _quoteCallRemoteCommitReveal(
+        InterchainAccountRouter icaRouter,
+        QuotedCallsERC20FeeHook feeHook,
+        bytes32 targetRouter,
+        bytes32 ism,
+        bytes memory hookMetadata,
+        bytes32 salt,
+        bytes32 commitment
+    ) internal returns (uint256) {
+        (bytes1 command, bytes memory input) = _cmdCallRemoteCommitReveal(
+            address(icaRouter),
+            DESTINATION,
+            targetRouter,
+            ism,
+            hookMetadata,
+            address(feeHook),
+            salt,
+            commitment,
+            0,
+            address(primaryToken),
+            0
+        );
+        return _quoteSingleCommand(command, input);
+    }
+
+    function _executeExactErc20IcaCommand(
+        bytes1 icaCommand,
+        bytes memory icaInput,
+        uint256 fee
+    ) internal {
+        bytes1[] memory cmds = new bytes1[](3);
+        bytes[] memory ins = new bytes[](3);
+        (cmds[0], ins[0]) = _cmdTransferFrom(address(primaryToken), fee);
+        cmds[1] = icaCommand;
+        ins[1] = icaInput;
+        (cmds[2], ins[2]) = _cmdSweep(address(primaryToken));
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        primaryToken.approve(address(quotedCalls), fee);
+        quotedCalls.execute(commands, inputs);
+    }
+
     // ============ Tests: ERC20 transferFrom path ============
+
+    function testFuzz_icaMemoryEncoding_matchesCalldata(
+        address owner,
+        bytes32 ism,
+        bytes32 salt,
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) public {
+        vm.assume(data.length <= 512);
+        CallLib.Call[] memory calls = new CallLib.Call[](1);
+        calls[0] = CallLib.Call({
+            to: target.addressToBytes32(),
+            value: value,
+            data: data
+        });
+        MessageEncodingHarness harness = new MessageEncodingHarness();
+        assertTrue(harness.icaEncodingsMatch(owner, ism, calls, salt));
+    }
+
+    function testFuzz_messageMemoryEncoding_matchesCalldata(
+        uint32 nonce,
+        bytes32 sender,
+        bytes calldata body
+    ) public {
+        vm.assume(body.length <= 512);
+        MessageEncodingHarness harness = new MessageEncodingHarness();
+        assertTrue(
+            harness.messageEncodingsMatch(
+                3,
+                nonce,
+                ORIGIN,
+                sender,
+                DESTINATION,
+                BOB.addressToBytes32(),
+                body
+            )
+        );
+    }
 
     /// @dev ALICE approves QuotedCalls directly — ERC20 transferFrom succeeds on first try
     function test_transferFrom_erc20Path() public {
@@ -1584,7 +1950,7 @@ contract QuotedCallsTest is Test {
             address(0xdead).addressToBytes32(),
             bytes32(0),
             hookMetadata,
-            address(noopHook),
+            address(igp),
             bytes32(0),
             keccak256("commitment"),
             0,
@@ -1598,6 +1964,522 @@ contract QuotedCallsTest is Test {
         assertEq(results[1].length, 1, "commit-reveal should return 1 quote");
         assertEq(results[1][0].token, address(0), "fee should be native");
         assertGt(results[1][0].amount, 0, "fee should be > 0");
+    }
+
+    function test_quoteExecute_icaCommands_supportLegacyRouterQuoteSurface()
+        public
+    {
+        QuotedCallsERC20FeeHook feeHook = new QuotedCallsERC20FeeHook(
+            primaryToken
+        );
+        LegacyIcaRouterQuoteSurface legacyRouter = new LegacyIcaRouterQuoteSurface(
+                localMailbox,
+                feeHook,
+                20_000
+            );
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT,
+            address(quotedCalls),
+            address(primaryToken)
+        );
+        bytes32 targetRouter = bytes32(uint256(0xbeef));
+        bytes32 ism = bytes32(uint256(0x1234));
+        bytes32 salt = bytes32(uint256(0x5678));
+
+        bytes1[] memory cmds = new bytes1[](2);
+        bytes[] memory ins = new bytes[](2);
+        (cmds[0], ins[0]) = _cmdCallRemoteWithOverrides(
+            address(legacyRouter),
+            DESTINATION,
+            targetRouter,
+            ism,
+            _singleRemoteCall(hex"123456"),
+            hookMetadata,
+            salt,
+            0,
+            address(primaryToken),
+            0
+        );
+        (cmds[1], ins[1]) = _cmdCallRemoteCommitReveal(
+            address(legacyRouter),
+            DESTINATION,
+            targetRouter,
+            ism,
+            hookMetadata,
+            address(feeHook),
+            salt,
+            keccak256("commitment"),
+            0,
+            address(primaryToken),
+            0
+        );
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
+
+        // The legacy quote methods return sentinel values. Exact quotes must
+        // instead be constructed through getters available on old routers.
+        assertGt(results[0][0].amount, 2);
+        assertGt(results[1][0].amount, 2);
+        assertEq(results[0][0].token, address(primaryToken));
+        assertEq(results[1][0].token, address(primaryToken));
+    }
+
+    function test_quoteExecuteThenExecute_icaCommands_supportLegacyRouterSurface()
+        public
+    {
+        LegacyIcaRouterQuoteSurface legacyRouter = new LegacyIcaRouterQuoteSurface(
+                localMailbox,
+                noopHook,
+                20_000
+            );
+        bytes memory hookMetadata = StandardHookMetadata.format(
+            0,
+            GAS_LIMIT,
+            address(quotedCalls)
+        );
+        bytes32 targetRouter = bytes32(uint256(0xbeef));
+        bytes32 salt = bytes32(uint256(0x5678));
+        bytes1[] memory cmds = new bytes1[](2);
+        bytes[] memory ins = new bytes[](2);
+        (cmds[0], ins[0]) = _cmdCallRemoteWithOverrides(
+            address(legacyRouter),
+            DESTINATION,
+            targetRouter,
+            bytes32(uint256(0x1234)),
+            _singleRemoteCall(hex"123456"),
+            hookMetadata,
+            salt,
+            0,
+            address(0),
+            0
+        );
+        (cmds[1], ins[1]) = _cmdCallRemoteCommitReveal(
+            address(legacyRouter),
+            DESTINATION,
+            targetRouter,
+            bytes32(uint256(0x1234)),
+            hookMetadata,
+            address(noopHook),
+            salt,
+            keccak256("commitment"),
+            0,
+            address(0),
+            0
+        );
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+        uint32 nonceBefore = localMailbox.nonce();
+
+        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
+        assertEq(results[0][0].amount, 0);
+        assertEq(results[1][0].amount, 0);
+        quotedCalls.execute(commands, inputs);
+
+        assertEq(localMailbox.nonce(), nonceBefore + 3);
+    }
+
+    function test_quoteExecute_callRemoteWithOverrides_erc20ExactInputs()
+        public
+    {
+        (
+            InterchainAccountRouter icaRouter,
+            QuotedCallsERC20FeeHook feeHook
+        ) = _deployQuotedCallsFeeRouter();
+        bytes32 targetRouter = bytes32(uint256(0xbeef));
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT,
+            address(quotedCalls),
+            address(primaryToken)
+        );
+        CallLib.Call[] memory remoteCalls = _singleRemoteCall(hex"123456");
+
+        (bytes1 command, bytes memory input) = _cmdCallRemoteWithOverrides(
+            address(icaRouter),
+            DESTINATION,
+            targetRouter,
+            bytes32(uint256(0x1234)),
+            remoteCalls,
+            hookMetadata,
+            bytes32(uint256(0x5678)),
+            0,
+            address(primaryToken),
+            0
+        );
+        uint256 fee = _quoteSingleCommand(command, input);
+        (, input) = _cmdCallRemoteWithOverrides(
+            address(icaRouter),
+            DESTINATION,
+            targetRouter,
+            bytes32(uint256(0x1234)),
+            remoteCalls,
+            hookMetadata,
+            bytes32(uint256(0x5678)),
+            0,
+            address(primaryToken),
+            fee
+        );
+
+        uint256 callerBalanceBefore = primaryToken.balanceOf(address(this));
+        assertEq(icaRouter.routers(DESTINATION), bytes32(0));
+        _executeExactErc20IcaCommand(command, input, fee);
+
+        assertEq(
+            primaryToken.balanceOf(address(this)),
+            callerBalanceBefore - fee
+        );
+        assertEq(primaryToken.balanceOf(address(feeHook)), fee);
+        assertEq(primaryToken.balanceOf(address(quotedCalls)), 0);
+        assertEq(primaryToken.balanceOf(address(icaRouter)), 0);
+        assertEq(feeHook.dispatchCount(), 1);
+        assertEq(feeHook.totalFees(), fee);
+        assertEq(feeHook.lastRecipient(), targetRouter);
+    }
+
+    function test_quoteExecute_callRemoteCommitReveal_erc20ExactInputs()
+        public
+    {
+        (
+            InterchainAccountRouter icaRouter,
+            QuotedCallsERC20FeeHook feeHook
+        ) = _deployQuotedCallsFeeRouter();
+        // Ensure quote and execution both honor the command's custom hook,
+        // rather than silently using the router's configured hook.
+        icaRouter.setHook(address(noopHook));
+        bytes32 targetRouter = bytes32(uint256(0xbeef));
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT,
+            address(quotedCalls),
+            address(primaryToken)
+        );
+
+        (bytes1 command, bytes memory input) = _cmdCallRemoteCommitReveal(
+            address(icaRouter),
+            DESTINATION,
+            targetRouter,
+            bytes32(uint256(0x1234)),
+            hookMetadata,
+            address(feeHook),
+            bytes32(uint256(0x5678)),
+            keccak256("commitment"),
+            0,
+            address(primaryToken),
+            0
+        );
+        uint256 fee = _quoteSingleCommand(command, input);
+        (, input) = _cmdCallRemoteCommitReveal(
+            address(icaRouter),
+            DESTINATION,
+            targetRouter,
+            bytes32(uint256(0x1234)),
+            hookMetadata,
+            address(feeHook),
+            bytes32(uint256(0x5678)),
+            keccak256("commitment"),
+            0,
+            address(primaryToken),
+            fee
+        );
+
+        uint256 callerBalanceBefore = primaryToken.balanceOf(address(this));
+        assertEq(icaRouter.routers(DESTINATION), bytes32(0));
+        _executeExactErc20IcaCommand(command, input, fee);
+
+        assertEq(
+            primaryToken.balanceOf(address(this)),
+            callerBalanceBefore - fee
+        );
+        assertEq(primaryToken.balanceOf(address(feeHook)), fee);
+        assertEq(primaryToken.balanceOf(address(quotedCalls)), 0);
+        assertEq(primaryToken.balanceOf(address(icaRouter)), 0);
+        assertEq(feeHook.dispatchCount(), 2);
+        assertEq(feeHook.totalFees(), fee);
+        assertEq(feeHook.lastRecipient(), targetRouter);
+    }
+
+    function test_quoteExecute_callRemoteWithOverrides_bindsExecutionInputs()
+        public
+    {
+        (InterchainAccountRouter icaRouter, ) = _deployQuotedCallsFeeRouter();
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT,
+            address(quotedCalls),
+            address(primaryToken)
+        );
+        CallLib.Call[] memory remoteCalls = _singleRemoteCall(hex"123456");
+        bytes32 targetRouter = bytes32(uint256(0xbeef));
+        bytes32 ism = bytes32(uint256(0x1234));
+        bytes32 salt = bytes32(uint256(0x5678));
+        uint256 baseQuote = _quoteCallRemoteWithOverrides(
+            icaRouter,
+            targetRouter,
+            ism,
+            remoteCalls,
+            hookMetadata,
+            salt
+        );
+
+        assertNotEq(
+            _quoteCallRemoteWithOverrides(
+                icaRouter,
+                bytes32(uint256(0xcafe)),
+                ism,
+                remoteCalls,
+                hookMetadata,
+                salt
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteWithOverrides(
+                icaRouter,
+                targetRouter,
+                bytes32(uint256(0x9999)),
+                remoteCalls,
+                hookMetadata,
+                salt
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteWithOverrides(
+                icaRouter,
+                targetRouter,
+                ism,
+                _singleRemoteCall(hex"abcdef"),
+                hookMetadata,
+                salt
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteWithOverrides(
+                icaRouter,
+                targetRouter,
+                ism,
+                remoteCalls,
+                StandardHookMetadata.formatWithFeeToken(
+                    0,
+                    GAS_LIMIT + 1,
+                    address(quotedCalls),
+                    address(primaryToken)
+                ),
+                salt
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteWithOverrides(
+                icaRouter,
+                targetRouter,
+                ism,
+                remoteCalls,
+                hookMetadata,
+                bytes32(uint256(0x7777))
+            ),
+            baseQuote
+        );
+
+        vm.startPrank(ALICE);
+        uint256 otherOwnerQuote = _quoteCallRemoteWithOverrides(
+            icaRouter,
+            targetRouter,
+            ism,
+            remoteCalls,
+            hookMetadata,
+            salt
+        );
+        vm.stopPrank();
+        assertNotEq(otherOwnerQuote, baseQuote);
+    }
+
+    function test_quoteExecute_callRemoteCommitReveal_bindsExecutionInputs()
+        public
+    {
+        (
+            InterchainAccountRouter icaRouter,
+            QuotedCallsERC20FeeHook feeHook
+        ) = _deployQuotedCallsFeeRouter();
+        icaRouter.setHook(address(noopHook));
+        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            GAS_LIMIT,
+            address(quotedCalls),
+            address(primaryToken)
+        );
+        bytes32 targetRouter = bytes32(uint256(0xbeef));
+        bytes32 ism = bytes32(uint256(0x1234));
+        bytes32 salt = bytes32(uint256(0x5678));
+        bytes32 commitment = keccak256("commitment");
+        uint256 baseQuote = _quoteCallRemoteCommitReveal(
+            icaRouter,
+            feeHook,
+            targetRouter,
+            ism,
+            hookMetadata,
+            salt,
+            commitment
+        );
+
+        assertNotEq(
+            _quoteCallRemoteCommitReveal(
+                icaRouter,
+                feeHook,
+                bytes32(uint256(0xcafe)),
+                ism,
+                hookMetadata,
+                salt,
+                commitment
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteCommitReveal(
+                icaRouter,
+                feeHook,
+                targetRouter,
+                bytes32(uint256(0x9999)),
+                hookMetadata,
+                salt,
+                commitment
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteCommitReveal(
+                icaRouter,
+                feeHook,
+                targetRouter,
+                ism,
+                StandardHookMetadata.formatWithFeeToken(
+                    0,
+                    GAS_LIMIT + 1,
+                    address(quotedCalls),
+                    address(primaryToken)
+                ),
+                salt,
+                commitment
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteCommitReveal(
+                icaRouter,
+                feeHook,
+                targetRouter,
+                ism,
+                hookMetadata,
+                bytes32(uint256(0x7777)),
+                commitment
+            ),
+            baseQuote
+        );
+        assertNotEq(
+            _quoteCallRemoteCommitReveal(
+                icaRouter,
+                feeHook,
+                targetRouter,
+                ism,
+                hookMetadata,
+                salt,
+                keccak256("other commitment")
+            ),
+            baseQuote
+        );
+
+        vm.startPrank(ALICE);
+        uint256 otherOwnerQuote = _quoteCallRemoteCommitReveal(
+            icaRouter,
+            feeHook,
+            targetRouter,
+            ism,
+            StandardHookMetadata.formatWithFeeToken(
+                0,
+                GAS_LIMIT,
+                address(quotedCalls),
+                address(primaryToken)
+            ),
+            salt,
+            commitment
+        );
+        vm.stopPrank();
+        assertNotEq(otherOwnerQuote, baseQuote);
+    }
+
+    function test_execute_callRemoteWithOverrides_erc20UnderfundRevertsAtomically()
+        public
+    {
+        (
+            InterchainAccountRouter icaRouter,
+            QuotedCallsERC20FeeHook feeHook
+        ) = _deployQuotedCallsFeeRouter();
+        uint256 callerBalanceBefore = primaryToken.balanceOf(address(this));
+        uint32 nonceBefore = localMailbox.nonce();
+        {
+            bytes1[] memory cmds = new bytes1[](2);
+            bytes[] memory ins = new bytes[](2);
+            bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
+                0,
+                GAS_LIMIT,
+                address(quotedCalls),
+                address(primaryToken)
+            );
+            CallLib.Call[] memory remoteCalls = _singleRemoteCall(hex"123456");
+            (bytes1 command, bytes memory input) = _cmdCallRemoteWithOverrides(
+                address(icaRouter),
+                DESTINATION,
+                bytes32(uint256(0xbeef)),
+                bytes32(uint256(0x1234)),
+                remoteCalls,
+                hookMetadata,
+                bytes32(uint256(0x5678)),
+                0,
+                address(primaryToken),
+                0
+            );
+            uint256 fee = _quoteSingleCommand(command, input);
+            (, input) = _cmdCallRemoteWithOverrides(
+                address(icaRouter),
+                DESTINATION,
+                bytes32(uint256(0xbeef)),
+                bytes32(uint256(0x1234)),
+                remoteCalls,
+                hookMetadata,
+                bytes32(uint256(0x5678)),
+                0,
+                address(primaryToken),
+                fee
+            );
+            (cmds[0], ins[0]) = _cmdTransferFrom(
+                address(primaryToken),
+                fee - 1
+            );
+            cmds[1] = command;
+            ins[1] = input;
+            (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+            primaryToken.approve(address(quotedCalls), fee - 1);
+
+            vm.expectRevert("ERC20: transfer amount exceeds balance");
+            quotedCalls.execute(commands, inputs);
+        }
+
+        assertEq(primaryToken.balanceOf(address(this)), callerBalanceBefore);
+        assertEq(primaryToken.balanceOf(address(quotedCalls)), 0);
+        assertEq(primaryToken.balanceOf(address(icaRouter)), 0);
+        assertEq(primaryToken.balanceOf(address(feeHook)), 0);
+        assertEq(feeHook.dispatchCount(), 0);
+        assertEq(localMailbox.nonce(), nonceBefore);
+        assertEq(
+            primaryToken.allowance(address(quotedCalls), address(icaRouter)),
+            0
+        );
+        assertEq(
+            primaryToken.allowance(address(icaRouter), address(feeHook)),
+            0
+        );
     }
 
     /// @dev quoteExecute skips TRANSFER_FROM, PERMIT2, and SWEEP commands

--- a/solidity/test/token/QuotedCalls.t.sol
+++ b/solidity/test/token/QuotedCalls.t.sol
@@ -32,13 +32,14 @@ import {HypERC20} from "../../contracts/token/HypERC20.sol";
 import {HypERC20Collateral} from "../../contracts/token/HypERC20Collateral.sol";
 import {TokenRouter} from "../../contracts/token/libs/TokenRouter.sol";
 import {InterchainAccountRouter} from "../../contracts/middleware/InterchainAccountRouter.sol";
+import {MinimalInterchainAccountRouter} from "../../contracts/middleware/MinimalInterchainAccountRouter.sol";
 import {CallLib} from "../../contracts/middleware/libs/Call.sol";
 import {InterchainAccountMessage} from "../../contracts/middleware/libs/InterchainAccountMessage.sol";
 import {Quote} from "../../contracts/interfaces/ITokenBridge.sol";
 import {ReentrancyGuardTransient} from "../../contracts/libs/ReentrancyGuardTransient.sol";
 
-/// @dev ERC20 hook whose fee binds quotes to the actual metadata and complete
-///      formatted message, including its sender and Mailbox nonce.
+/// @dev ERC20 hook whose fee binds quotes to the actual metadata, sender,
+///      recipient, destination, and body, but deliberately ignores the nonce.
 contract QuotedCallsERC20FeeHook is AbstractPostDispatchHook {
     using Message for bytes;
     using SafeERC20 for IERC20;
@@ -81,112 +82,39 @@ contract QuotedCallsERC20FeeHook is AbstractPostDispatchHook {
             metadata.gasLimit() +
             (uint256(message.recipient()) & 0xffff) *
             1_000_000 +
-            uint256(uint72(uint256(keccak256(message))));
+            uint256(
+                uint72(
+                    uint256(
+                        keccak256(
+                            abi.encode(
+                                message.sender(),
+                                message.destination(),
+                                message.recipient(),
+                                message.body()
+                            )
+                        )
+                    )
+                )
+            );
     }
 }
 
-/// @dev Models the ICA getter and quote surface deployed before exact-input
-///      quote overloads existed.
-contract LegacyIcaRouterQuoteSurface {
-    using StandardHookMetadata for bytes;
-    using TypeCasts for address;
+/// @dev Quote-only hook used to pin QuotedCalls' historical current-nonce
+///      behavior. Nonce-sensitive hooks are not supported for execution.
+contract QuotedCallsNonceFeeHook is AbstractPostDispatchHook {
+    using Message for bytes;
 
-    IMailbox public immutable mailbox;
-    IPostDispatchHook public hook;
-    uint256 public immutable COMMIT_TX_GAS_USAGE;
-
-    constructor(
-        IMailbox _mailbox,
-        IPostDispatchHook _hook,
-        uint256 _commitTxGasUsage
-    ) {
-        mailbox = _mailbox;
-        hook = _hook;
-        COMMIT_TX_GAS_USAGE = _commitTxGasUsage;
+    function hookType() external pure override returns (uint8) {
+        return uint8(IPostDispatchHook.HookTypes.UNUSED);
     }
 
-    function quoteGasPayment(
-        address,
-        uint32,
-        uint256
-    ) external pure returns (uint256) {
-        return 1;
-    }
+    function _postDispatch(bytes calldata, bytes calldata) internal override {}
 
-    function quoteGasForCommitReveal(
-        address,
-        uint32,
-        uint256
-    ) external pure returns (uint256) {
-        return 2;
-    }
-
-    function callRemoteWithOverrides(
-        uint32 destination,
-        bytes32 router,
-        bytes32 ism,
-        CallLib.Call[] calldata calls,
-        bytes calldata hookMetadata,
-        bytes32 salt
-    ) external payable returns (bytes32) {
-        bytes memory body = InterchainAccountMessage.encode(
-            msg.sender,
-            ism,
-            calls,
-            salt
-        );
-        return
-            mailbox.dispatch{value: msg.value}(
-                destination,
-                router,
-                body,
-                hookMetadata,
-                hook
-            );
-    }
-
-    function callRemoteCommitReveal(
-        uint32 destination,
-        bytes32 router,
-        bytes32 ism,
-        bytes calldata hookMetadata,
-        IPostDispatchHook selectedHook,
-        bytes32 salt,
-        bytes32 commitment
-    ) external payable returns (bytes32 commitmentId, bytes32 revealId) {
-        bytes memory commitmentBody = InterchainAccountMessage
-            .encodeCommitment({
-                _owner: msg.sender.addressToBytes32(),
-                _ism: ism,
-                _commitment: commitment,
-                _userSalt: salt
-            });
-        bytes memory commitmentMetadata = StandardHookMetadata
-            .formatWithFeeToken(
-                0,
-                COMMIT_TX_GAS_USAGE,
-                address(this),
-                hookMetadata.feeToken()
-            );
-        commitmentId = mailbox.dispatch{value: msg.value}(
-            destination,
-            router,
-            commitmentBody,
-            commitmentMetadata,
-            selectedHook
-        );
-
-        bytes memory revealBody = InterchainAccountMessage.encodeReveal({
-            _ism: bytes32(0),
-            _commitment: commitment
-        });
-        revealId = mailbox.dispatch(
-            destination,
-            router,
-            revealBody,
-            hookMetadata,
-            selectedHook
-        );
+    function _quoteDispatch(
+        bytes calldata,
+        bytes calldata message
+    ) internal pure override returns (uint256) {
+        return message.nonce();
     }
 }
 
@@ -1966,117 +1894,95 @@ contract QuotedCallsTest is Test {
         assertGt(results[1][0].amount, 0, "fee should be > 0");
     }
 
-    function test_quoteExecute_icaCommands_supportLegacyRouterQuoteSurface()
-        public
-    {
-        QuotedCallsERC20FeeHook feeHook = new QuotedCallsERC20FeeHook(
-            primaryToken
-        );
-        LegacyIcaRouterQuoteSurface legacyRouter = new LegacyIcaRouterQuoteSurface(
-                localMailbox,
-                feeHook,
-                20_000
-            );
-        bytes memory hookMetadata = StandardHookMetadata.formatWithFeeToken(
-            0,
-            GAS_LIMIT,
-            address(quotedCalls),
-            address(primaryToken)
-        );
-        bytes32 targetRouter = bytes32(uint256(0xbeef));
-        bytes32 ism = bytes32(uint256(0x1234));
-        bytes32 salt = bytes32(uint256(0x5678));
-
-        bytes1[] memory cmds = new bytes1[](2);
-        bytes[] memory ins = new bytes[](2);
-        (cmds[0], ins[0]) = _cmdCallRemoteWithOverrides(
-            address(legacyRouter),
+    function test_quoteExecute_icaQuotes_useCurrentMailboxNonce() public {
+        localMailbox.dispatch(
             DESTINATION,
-            targetRouter,
-            ism,
-            _singleRemoteCall(hex"123456"),
-            hookMetadata,
-            salt,
-            0,
-            address(primaryToken),
-            0
+            bytes32(uint256(0xbeef)),
+            bytes(""),
+            bytes(""),
+            noopHook
         );
-        (cmds[1], ins[1]) = _cmdCallRemoteCommitReveal(
-            address(legacyRouter),
-            DESTINATION,
-            targetRouter,
-            ism,
-            hookMetadata,
-            address(feeHook),
-            salt,
-            keccak256("commitment"),
+        uint32 currentNonce = localMailbox.nonce();
+        QuotedCallsNonceFeeHook nonceHook = new QuotedCallsNonceFeeHook();
+        string[] memory urls = new string[](1);
+        urls[0] = "https://quoter.example.com/{data}";
+        InterchainAccountRouter icaRouter = new InterchainAccountRouter(
+            address(localMailbox),
+            address(nonceHook),
+            address(this),
             0,
-            address(primaryToken),
-            0
+            urls
         );
-        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
-
-        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
-
-        // The legacy quote methods return sentinel values. Exact quotes must
-        // instead be constructed through getters available on old routers.
-        assertGt(results[0][0].amount, 2);
-        assertGt(results[1][0].amount, 2);
-        assertEq(results[0][0].token, address(primaryToken));
-        assertEq(results[1][0].token, address(primaryToken));
-    }
-
-    function test_quoteExecuteThenExecute_icaCommands_supportLegacyRouterSurface()
-        public
-    {
-        LegacyIcaRouterQuoteSurface legacyRouter = new LegacyIcaRouterQuoteSurface(
-                localMailbox,
-                noopHook,
-                20_000
-            );
         bytes memory hookMetadata = StandardHookMetadata.format(
             0,
             GAS_LIMIT,
             address(quotedCalls)
         );
-        bytes32 targetRouter = bytes32(uint256(0xbeef));
-        bytes32 salt = bytes32(uint256(0x5678));
         bytes1[] memory cmds = new bytes1[](2);
         bytes[] memory ins = new bytes[](2);
         (cmds[0], ins[0]) = _cmdCallRemoteWithOverrides(
-            address(legacyRouter),
+            address(icaRouter),
             DESTINATION,
-            targetRouter,
+            bytes32(uint256(0xbeef)),
             bytes32(uint256(0x1234)),
             _singleRemoteCall(hex"123456"),
             hookMetadata,
-            salt,
+            bytes32(uint256(0x5678)),
             0,
             address(0),
             0
         );
         (cmds[1], ins[1]) = _cmdCallRemoteCommitReveal(
-            address(legacyRouter),
+            address(icaRouter),
             DESTINATION,
-            targetRouter,
+            bytes32(uint256(0xbeef)),
             bytes32(uint256(0x1234)),
             hookMetadata,
-            address(noopHook),
-            salt,
+            address(nonceHook),
+            bytes32(uint256(0x5678)),
             keccak256("commitment"),
             0,
             address(0),
             0
         );
         (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
+
+        Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
+
+        assertEq(results[0][0].amount, currentNonce);
+        assertEq(results[1][0].amount, uint256(currentNonce) * 2);
+    }
+
+    function test_quoteExecuteThenExecute_supportsMinimalIcaRouter() public {
+        MinimalInterchainAccountRouter minimalRouter = new MinimalInterchainAccountRouter(
+                address(localMailbox),
+                address(noopHook),
+                address(this)
+            );
+        (bytes1 command, bytes memory input) = _cmdCallRemoteWithOverrides(
+            address(minimalRouter),
+            DESTINATION,
+            bytes32(uint256(0xbeef)),
+            bytes32(uint256(0x1234)),
+            _singleRemoteCall(hex"123456"),
+            StandardHookMetadata.format(0, GAS_LIMIT, address(quotedCalls)),
+            bytes32(uint256(0x5678)),
+            0,
+            address(0),
+            0
+        );
+        bytes1[] memory cmds = new bytes1[](1);
+        bytes[] memory ins = new bytes[](1);
+        cmds[0] = command;
+        ins[0] = input;
+        (bytes memory commands, bytes[] memory inputs) = _pack(cmds, ins);
         uint32 nonceBefore = localMailbox.nonce();
 
         Quote[][] memory results = quotedCalls.quoteExecute(commands, inputs);
         assertEq(results[0][0].amount, 0);
-        assertEq(results[1][0].amount, 0);
         quotedCalls.execute(commands, inputs);
 
-        assertEq(localMailbox.nonce(), nonceBefore + 3);
+        assertEq(localMailbox.nonce(), nonceBefore + 1);
     }
 
     function test_quoteExecute_callRemoteWithOverrides_erc20ExactInputs()


### PR DESCRIPTION
### Description

Fixes ICA ERC-20 fee-token dispatch and commit-reveal value accounting:

- Quotes the exact destination router, ICA message body, metadata, and effective top-level hook used by dispatch.
- Resolves a zero hook to the Mailbox default before ERC-20 approval.
- Preserves unrelated router native balances during commit-reveal and returns only current-call residual value.
- Enforces router token/native balance invariants after successful dispatch.
- Makes QuotedCalls reconstruct the ICA messages through router getters while preserving the historical current-Mailbox-nonce quote behavior.
- Adds memory-compatible canonical ICA and Hyperlane message encoders used by reconstructed quotes.
- Adds the salted execution selector to AbstractInterchainAccountRouter so newly deployed Minimal routers support QuotedCalls ICA commands.
- Documents that token-pulling child hooks require explicit approval.

### Drive-by changes

None.

### Related issues

Addresses the ChainSecurity ICA commit-reveal fee-token DoS finding. No public issue linked.

### Backward compatibility

No public functions are removed and storage layout is unchanged. MinimalInterchainAccountRouter gains the salted callRemoteWithOverrides selector additively.

Deployment is required: the updated QuotedCalls and production ICA routers used by this flow must be deployed together, and registry/configuration must target the corresponding new routers. Older immutable ICA routers are not supported by the new fee-token path.

Behavior intentionally changes or is constrained in these places:

- Commit-reveal no longer spends or allows later callers to sweep unrelated router balances.
- Current-call residual native value must be returned. Nonpayable contract callers must provide full metadata with a payable refund recipient or fund exactly; otherwise the call reverts atomically instead of trapping value.
- QuotedCalls preserves the standard historical behavior of quoting every ICA leg at the current Mailbox nonce. Nonce-sensitive hooks cannot be reliably prequoted and are unsupported.
- The command token and metadata fee token must match. Mismatched caller-provided inputs are unsupported.
- Hooks must quote independently of the quoteDispatch caller and remain pricing-stable between quote and execution.
- Aggregation/wrapper children that pull fee tokens require approval through approveFeeTokenForHook.

### Testing

Unit and invariant tests:

- InterchainAccountRouter test file: 93 passed
- MinimalInterchainAccountRouter: 20 passed
- GasRouter: 5 passed
- QuotedCalls: 35 passed
- Hardhat: 20 passed
- Exhaustive interface checks: 9 passed
- Full Forge run: 1,519 passed; 2 skipped; 20 environment-dependent failures from missing Base/Mainnet/Arbitrum RPC URLs and Tron-specific environment expectations
- Exact-funded ordinary and commit/reveal ERC-20 quote -> execute -> sweep regressions use a sender/body/recipient-sensitive hook
- Added input-binding, historical current-nonce, Minimal quote-to-execute, atomic rollback, and calldata/memory encoding-equivalence coverage
- Compilation and git diff checks passed
- Runtime-size build passed; CrossCollateralRouter is 24,509 bytes with 67 bytes of EIP-170 headroom
