### PR TITLE
chore(infra): rotate igra warp-fee owner to Turnkey treasury key

### DIFF
--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getIgraUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getIgraUSDCWarpConfig.ts
@@ -3,12 +3,14 @@ import {
   ChainSubmissionStrategy,
   HypTokenRouterConfig,
   SubmissionStrategy,
+  SubmitterMetadata,
   TxSubmitterType,
 } from '@hyperlane-xyz/sdk';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
 import { getChainAddresses } from '../../../../registry.js';
+import { warpFeesSafes } from '../../governance/safe/warpFees.js';
 import { WARP_FEES_TURNKEY_OWNER } from '../../governance/utils.js';
 import { WarpRouteIds } from '../warpIds.js';
 
@@ -95,21 +97,45 @@ export const getIgraUSDCStrategyConfig = (): ChainSubmissionStrategy => {
     (c) => c !== ORIGIN_CHAIN,
   );
 
-  const icaStrategies: [string, SubmissionStrategy][] = icaChains.map(
-    (chain) => [
-      chain,
-      {
-        submitter: {
-          type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
-          chain: ORIGIN_CHAIN,
-          destinationChain: chain,
-          owner: safeAddress,
-          originInterchainAccountRouter,
-          internalSubmitter: originSafeSubmitter,
-        },
+  // The igra fee (RoutingFee) contract is owned by the WarpFees ICA on igra,
+  // controlled by the ethereum WarpFees Safe — a different hierarchy from the
+  // router owner (Igra Safe). Route fee-owner txs (transferOwnership to the
+  // Turnkey key) through the WarpFees Safe so they are submitted by the actual
+  // owner; without this the CLI merges fee txs into the router submitter and the
+  // transferOwnership reverts (not owner).
+  const warpFeeSafeAddress = warpFeesSafes[ORIGIN_CHAIN];
+  assert(warpFeeSafeAddress, `Missing WarpFees safe for ${ORIGIN_CHAIN}`);
+  const originWarpFeeSafeSubmitter = {
+    type: TxSubmitterType.GNOSIS_SAFE as const,
+    chain: ORIGIN_CHAIN,
+    safeAddress: warpFeeSafeAddress,
+  };
+  const igraWarpFeeSubmitter: SubmitterMetadata = {
+    type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+    chain: ORIGIN_CHAIN,
+    destinationChain: 'igra',
+    owner: warpFeeSafeAddress,
+    originInterchainAccountRouter,
+    internalSubmitter: originWarpFeeSafeSubmitter,
+  };
+
+  const icaStrategies: [
+    string,
+    SubmissionStrategy & { feeSubmitter?: SubmitterMetadata },
+  ][] = icaChains.map((chain) => [
+    chain,
+    {
+      submitter: {
+        type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,
+        chain: ORIGIN_CHAIN,
+        destinationChain: chain,
+        owner: safeAddress,
+        originInterchainAccountRouter,
+        internalSubmitter: originSafeSubmitter,
       },
-    ],
-  );
+      ...(chain === 'igra' ? { feeSubmitter: igraWarpFeeSubmitter } : {}),
+    },
+  ]);
 
   return Object.fromEntries([
     [ORIGIN_CHAIN, { submitter: originSafeSubmitter }],

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getIgraUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getIgraUSDCWarpConfig.ts
@@ -9,7 +9,7 @@ import { assert } from '@hyperlane-xyz/utils';
 
 import { RouterConfigWithoutOwner } from '../../../../../src/config/warp.js';
 import { getChainAddresses } from '../../../../registry.js';
-import { getWarpFeeOwner } from '../../governance/utils.js';
+import { WARP_FEES_TURNKEY_OWNER } from '../../governance/utils.js';
 import { WarpRouteIds } from '../warpIds.js';
 
 import {
@@ -51,7 +51,10 @@ const rebalancingConfigByChain = getUSDCRebalancingBridgesConfigFor(
 export const getIgraUSDCWarpConfig = async (
   routerConfig: ChainMap<RouterConfigWithoutOwner>,
 ): Promise<ChainMap<HypTokenRouterConfig>> => {
-  const feeOwner = getWarpFeeOwner('igra');
+  // igra warp-fee ownership rotated to the Turnkey treasury key so agent-driven
+  // sweeps can claim fees directly (see eni/moonpay rotation). Previously the
+  // WarpFees ICA on igra, controlled by the ethereum WarpFees Safe.
+  const feeOwner = WARP_FEES_TURNKEY_OWNER;
 
   return {
     ...Object.fromEntries(

--- a/typescript/infra/config/environments/mainnet3/warp/configGetters/getIgraUSDCWarpConfig.ts
+++ b/typescript/infra/config/environments/mainnet3/warp/configGetters/getIgraUSDCWarpConfig.ts
@@ -80,9 +80,10 @@ export const getIgraUSDCWarpConfig = async (
 export const getIgraUSDCStrategyConfig = (): ChainSubmissionStrategy => {
   const safeAddress = ownersByChain[ORIGIN_CHAIN];
   const originSafeSubmitter = {
-    type: TxSubmitterType.GNOSIS_SAFE as const,
+    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
     chain: ORIGIN_CHAIN,
     safeAddress,
+    version: '1',
   };
 
   const chainAddress = getChainAddresses();
@@ -106,9 +107,10 @@ export const getIgraUSDCStrategyConfig = (): ChainSubmissionStrategy => {
   const warpFeeSafeAddress = warpFeesSafes[ORIGIN_CHAIN];
   assert(warpFeeSafeAddress, `Missing WarpFees safe for ${ORIGIN_CHAIN}`);
   const originWarpFeeSafeSubmitter = {
-    type: TxSubmitterType.GNOSIS_SAFE as const,
+    type: TxSubmitterType.GNOSIS_TX_BUILDER as const,
     chain: ORIGIN_CHAIN,
     safeAddress: warpFeeSafeAddress,
+    version: '1',
   };
   const igraWarpFeeSubmitter: SubmitterMetadata = {
     type: TxSubmitterType.INTERCHAIN_ACCOUNT as const,


### PR DESCRIPTION
## Summary
- Rotates the igra USDC warp-route fee owner from the WarpFees ICA (controlled by the ethereum WarpFees Safe) to the Turnkey treasury key (`WARP_FEES_TURNKEY_OWNER`, `0xe95C605096A1AD38BaC3E5210e145952Cbdc6998`).
- Matches the eni/moonpay rotation so agent-driven treasury sweeps can claim igra warp fees directly instead of routing through the Safe→ICA governance path.

## Context
- `getIgraUSDCWarpConfig.ts` previously set `feeOwner = getWarpFeeOwner('igra')`, which resolves to the WarpFees ICA `0x42cb788529463B1F41de9E3cd3d2906930aCd32F` on igra.
- Config-only change. On-chain the current fee owner is still the ICA, so a follow-up on-chain ownership transfer (Safe → ICA remote call via `warp apply`) is required to make on-chain state match this config.

## Test plan
- [ ] `warp apply` dry-run / `warp-route-check` shows only the intended owner diff on the igra leg
- [ ] Ownership transfer executed via the ethereum WarpFees Safe ICA path
- [ ] Post-transfer on-chain owner == Turnkey key; end-to-end fee quote unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)