### PR TITLE
fix(infra): refresh Tollkeeper RPCs by namespace

### DIFF
--- a/typescript/infra/src/tollkeeper/helm.ts
+++ b/typescript/infra/src/tollkeeper/helm.ts
@@ -1,15 +1,15 @@
 import { DeployEnvironment } from '../config/deploy-environment.js';
 import { HelmManager, HelmValues } from '../utils/helm.js';
 import { execCmd } from '../utils/utils.js';
+import {
+  getTollkeeperDeploymentNames,
+  getTollkeeperReleaseConfigs,
+} from './releases.js';
 
 // Tollkeeper (https://github.com/hyperlane-xyz/tollkeeper) is deployed from a
 // separate repo. This manager only exists so that the set-rpc-urls script can
 // refresh tollkeeper's k8s secret and restart its pods after rotating shared
 // `{env}-rpc-endpoints-{chain}` GCP secrets. It does not deploy the chart.
-const RELEASE_NAMES: Partial<Record<DeployEnvironment, string[]>> = {
-  mainnet3: ['tollkeeper-prod', 'tollkeeper-staging'],
-};
-
 const RPC_ENV_PREFIX = 'RPC_URL_';
 
 export class TollkeeperHelmManager extends HelmManager {
@@ -17,10 +17,10 @@ export class TollkeeperHelmManager extends HelmManager {
   readonly namespace: string;
   readonly helmChartPath: string = '';
 
-  private constructor(environment: DeployEnvironment, releaseName: string) {
+  private constructor(namespace: string, releaseName: string) {
     super();
     this.helmReleaseName = releaseName;
-    this.namespace = environment;
+    this.namespace = namespace;
   }
 
   async helmValues(): Promise<HelmValues> {
@@ -62,33 +62,49 @@ export class TollkeeperHelmManager extends HelmManager {
 
   // Deployment-aware restart: rolls pods without name-based polling.
   async restartDeployment(): Promise<void> {
-    console.log(
-      `🔄 Restarting deployment ${this.helmReleaseName} in ${this.namespace}...`,
-    );
-    await execCmd(
-      `kubectl rollout restart deployment/${this.helmReleaseName} -n ${this.namespace}`,
-    );
-    await execCmd(
-      `kubectl rollout status deployment/${this.helmReleaseName} -n ${this.namespace} --timeout=180s`,
-    );
-    console.log(`✅  ${this.helmReleaseName} rollout complete`);
+    for (const deploymentName of getTollkeeperDeploymentNames(
+      this.helmReleaseName,
+    )) {
+      const [existing] = await execCmd(
+        `kubectl get deployment ${deploymentName} -n ${this.namespace} --ignore-not-found -o name`,
+      );
+      if (!existing.trim()) continue;
+
+      console.log(
+        `🔄 Restarting deployment ${deploymentName} in ${this.namespace}...`,
+      );
+      await execCmd(
+        `kubectl rollout restart deployment/${deploymentName} -n ${this.namespace}`,
+      );
+      await execCmd(
+        `kubectl rollout status deployment/${deploymentName} -n ${this.namespace} --timeout=180s`,
+      );
+      console.log(`✅  ${deploymentName} rollout complete`);
+    }
   }
 
   static async getManagersForChain(
     environment: DeployEnvironment,
     chain: string,
   ): Promise<TollkeeperHelmManager[]> {
-    const releaseNames = RELEASE_NAMES[environment] ?? [];
+    const releases = getTollkeeperReleaseConfigs(environment);
+    let foundDeployment = false;
     const managers = await Promise.all(
-      releaseNames.map(async (releaseName) => {
-        const manager = new TollkeeperHelmManager(environment, releaseName);
+      releases.map(async ({ releaseName, namespace }) => {
+        const manager = new TollkeeperHelmManager(namespace, releaseName);
         const [existsOutput] = await execCmd(
-          `kubectl get deployment ${releaseName} -n ${environment} --ignore-not-found -o name`,
+          `kubectl get deployment ${releaseName} -n ${namespace} --ignore-not-found -o name`,
         );
         if (!existsOutput.trim()) return null;
+        foundDeployment = true;
         return (await manager.includesChain(chain)) ? manager : null;
       }),
     );
+    if (releases.length > 0 && !foundDeployment) {
+      console.warn(
+        `⚠️  No Tollkeeper deployment found for ${environment}; RPC rotation will not restart Tollkeeper`,
+      );
+    }
     return managers.filter((m): m is TollkeeperHelmManager => m !== null);
   }
 }

--- a/typescript/infra/src/tollkeeper/releases.ts
+++ b/typescript/infra/src/tollkeeper/releases.ts
@@ -1,0 +1,21 @@
+import { DeployEnvironment } from '../config/deploy-environment.js';
+
+export interface TollkeeperReleaseConfig {
+  releaseName: string;
+  namespace: string;
+}
+
+const RELEASES: Partial<Record<DeployEnvironment, TollkeeperReleaseConfig[]>> =
+  {
+    mainnet3: [{ releaseName: 'tollkeeper-prod', namespace: 'tollkeeper' }],
+  };
+
+export function getTollkeeperReleaseConfigs(
+  environment: DeployEnvironment,
+): TollkeeperReleaseConfig[] {
+  return RELEASES[environment] ?? [];
+}
+
+export function getTollkeeperDeploymentNames(releaseName: string): string[] {
+  return [releaseName, `${releaseName}-signer`];
+}

--- a/typescript/infra/src/utils/refresh-by-namespace.ts
+++ b/typescript/infra/src/utils/refresh-by-namespace.ts
@@ -1,0 +1,35 @@
+interface NamespacedManager {
+  namespace: string;
+}
+
+interface RefreshOptions {
+  skipConfirmation?: boolean;
+}
+
+type RefreshResourcesFn<TManager, TResourceType> = (
+  managers: TManager[],
+  resourceType: TResourceType,
+  namespace: string,
+  options?: RefreshOptions,
+) => Promise<void>;
+
+export async function refreshK8sResourcesByNamespace<
+  TManager extends NamespacedManager,
+  TResourceType,
+>(
+  managers: TManager[],
+  resourceType: TResourceType,
+  options: RefreshOptions | undefined,
+  refreshResources: RefreshResourcesFn<TManager, TResourceType>,
+): Promise<void> {
+  const managersByNamespace = new Map<string, TManager[]>();
+  for (const manager of managers) {
+    const existing = managersByNamespace.get(manager.namespace) ?? [];
+    existing.push(manager);
+    managersByNamespace.set(manager.namespace, existing);
+  }
+
+  for (const [namespace, namespaceManagers] of managersByNamespace) {
+    await refreshResources(namespaceManagers, resourceType, namespace, options);
+  }
+}

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -26,6 +26,7 @@ import { WarpRouteMonitorHelmManager } from '../warp-monitor/helm.js';
 import { disableGCPSecretVersion } from './gcloud.js';
 import { HelmManager } from './helm.js';
 import { K8sResourceType, refreshK8sResources } from './k8s.js';
+import { refreshK8sResourcesByNamespace } from './refresh-by-namespace.js';
 
 /**
  * Set the RPC URLs for the given chain in the given environment interactively.
@@ -318,10 +319,17 @@ async function refreshDependentK8sResourcesInteractive(
     await refreshK8sResourcesByNamespace(
       allManagersForSecrets,
       K8sResourceType.SECRET,
+      undefined,
+      refreshK8sResources,
     );
   }
   if (serviceManagers.length > 0) {
-    await refreshK8sResourcesByNamespace(serviceManagers, K8sResourceType.POD);
+    await refreshK8sResourcesByNamespace(
+      serviceManagers,
+      K8sResourceType.POD,
+      undefined,
+      refreshK8sResources,
+    );
   }
   for (const manager of tollkeeperManagers) {
     await manager.restartDeployment();
@@ -639,28 +647,6 @@ async function collectAllK8sHelmManagers(
   };
 }
 
-async function refreshK8sResourcesByNamespace(
-  managers: HelmManager[],
-  resourceType: K8sResourceType,
-  options?: { skipConfirmation?: boolean },
-): Promise<void> {
-  const managersByNamespace = new Map<string, HelmManager[]>();
-  for (const manager of managers) {
-    const existing = managersByNamespace.get(manager.namespace) ?? [];
-    existing.push(manager);
-    managersByNamespace.set(manager.namespace, existing);
-  }
-
-  for (const [namespace, namespaceManagers] of managersByNamespace) {
-    await refreshK8sResources(
-      namespaceManagers,
-      resourceType,
-      namespace,
-      options,
-    );
-  }
-}
-
 /**
  * Non-interactively set RPC URLs for a chain. Validates each URL, updates the
  * GCP secret, and optionally refreshes dependent K8s resources.
@@ -702,6 +688,7 @@ export async function setRpcUrls(
         allManagersForSecrets,
         K8sResourceType.SECRET,
         { skipConfirmation: true },
+        refreshK8sResources,
       );
     }
     if (serviceManagers.length > 0) {
@@ -709,6 +696,7 @@ export async function setRpcUrls(
         serviceManagers,
         K8sResourceType.POD,
         { skipConfirmation: true },
+        refreshK8sResources,
       );
     }
     for (const manager of tollkeeperManagers) {
@@ -807,15 +795,19 @@ export async function refreshSelectedReleases(
     `Refreshing ${allForSecrets.length} releases: ${allForSecrets.map((m) => m.helmReleaseName).join(', ')}`,
   );
 
-  await refreshK8sResourcesByNamespace(allForSecrets, K8sResourceType.SECRET, {
-    skipConfirmation: true,
-  });
+  await refreshK8sResourcesByNamespace(
+    allForSecrets,
+    K8sResourceType.SECRET,
+    { skipConfirmation: true },
+    refreshK8sResources,
+  );
 
   if (selectedServices.length > 0) {
     await refreshK8sResourcesByNamespace(
       selectedServices,
       K8sResourceType.POD,
       { skipConfirmation: true },
+      refreshK8sResources,
     );
   }
   for (const manager of selectedTollkeeper) {

--- a/typescript/infra/src/utils/rpcUrls.ts
+++ b/typescript/infra/src/utils/rpcUrls.ts
@@ -315,18 +315,13 @@ async function refreshDependentK8sResourcesInteractive(
   ];
 
   if (allManagersForSecrets.length > 0) {
-    await refreshK8sResources(
+    await refreshK8sResourcesByNamespace(
       allManagersForSecrets,
       K8sResourceType.SECRET,
-      environment,
     );
   }
   if (serviceManagers.length > 0) {
-    await refreshK8sResources(
-      serviceManagers,
-      K8sResourceType.POD,
-      environment,
-    );
+    await refreshK8sResourcesByNamespace(serviceManagers, K8sResourceType.POD);
   }
   for (const manager of tollkeeperManagers) {
     await manager.restartDeployment();
@@ -644,6 +639,28 @@ async function collectAllK8sHelmManagers(
   };
 }
 
+async function refreshK8sResourcesByNamespace(
+  managers: HelmManager[],
+  resourceType: K8sResourceType,
+  options?: { skipConfirmation?: boolean },
+): Promise<void> {
+  const managersByNamespace = new Map<string, HelmManager[]>();
+  for (const manager of managers) {
+    const existing = managersByNamespace.get(manager.namespace) ?? [];
+    existing.push(manager);
+    managersByNamespace.set(manager.namespace, existing);
+  }
+
+  for (const [namespace, namespaceManagers] of managersByNamespace) {
+    await refreshK8sResources(
+      namespaceManagers,
+      resourceType,
+      namespace,
+      options,
+    );
+  }
+}
+
 /**
  * Non-interactively set RPC URLs for a chain. Validates each URL, updates the
  * GCP secret, and optionally refreshes dependent K8s resources.
@@ -681,18 +698,16 @@ export async function setRpcUrls(
     ];
 
     if (allManagersForSecrets.length > 0) {
-      await refreshK8sResources(
+      await refreshK8sResourcesByNamespace(
         allManagersForSecrets,
         K8sResourceType.SECRET,
-        environment,
         { skipConfirmation: true },
       );
     }
     if (serviceManagers.length > 0) {
-      await refreshK8sResources(
+      await refreshK8sResourcesByNamespace(
         serviceManagers,
         K8sResourceType.POD,
-        environment,
         { skipConfirmation: true },
       );
     }
@@ -792,18 +807,14 @@ export async function refreshSelectedReleases(
     `Refreshing ${allForSecrets.length} releases: ${allForSecrets.map((m) => m.helmReleaseName).join(', ')}`,
   );
 
-  await refreshK8sResources(
-    allForSecrets,
-    K8sResourceType.SECRET,
-    environment,
-    { skipConfirmation: true },
-  );
+  await refreshK8sResourcesByNamespace(allForSecrets, K8sResourceType.SECRET, {
+    skipConfirmation: true,
+  });
 
   if (selectedServices.length > 0) {
-    await refreshK8sResources(
+    await refreshK8sResourcesByNamespace(
       selectedServices,
       K8sResourceType.POD,
-      environment,
       { skipConfirmation: true },
     );
   }

--- a/typescript/infra/test/rpc-urls.test.ts
+++ b/typescript/infra/test/rpc-urls.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import { refreshK8sResourcesByNamespace } from '../src/utils/refresh-by-namespace.js';
+
+describe('RPC URL Kubernetes refresh', () => {
+  it('refreshes managers once per namespace with the requested options', async () => {
+    const alphaOne = {
+      helmReleaseName: 'alpha-one',
+      namespace: 'namespace-alpha',
+    };
+    const beta = { helmReleaseName: 'beta', namespace: 'namespace-beta' };
+    const alphaTwo = {
+      helmReleaseName: 'alpha-two',
+      namespace: 'namespace-alpha',
+    };
+    const calls: Array<{
+      managers: (typeof alphaOne)[];
+      resourceType: string;
+      namespace: string;
+      options?: { skipConfirmation?: boolean };
+    }> = [];
+    const options = { skipConfirmation: true };
+
+    await refreshK8sResourcesByNamespace(
+      [alphaOne, beta, alphaTwo],
+      'pod',
+      options,
+      async (managers, resourceType, namespace, receivedOptions) => {
+        calls.push({
+          managers,
+          resourceType,
+          namespace,
+          options: receivedOptions,
+        });
+      },
+    );
+
+    expect(calls).to.have.length(2);
+    expect(calls[0]).to.deep.equal({
+      managers: [alphaOne, alphaTwo],
+      resourceType: 'pod',
+      namespace: 'namespace-alpha',
+      options,
+    });
+    expect(calls[1]).to.deep.equal({
+      managers: [beta],
+      resourceType: 'pod',
+      namespace: 'namespace-beta',
+      options,
+    });
+  });
+});

--- a/typescript/infra/test/tollkeeper-helm.test.ts
+++ b/typescript/infra/test/tollkeeper-helm.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+
+import {
+  getTollkeeperDeploymentNames,
+  getTollkeeperReleaseConfigs,
+} from '../src/tollkeeper/releases.js';
+
+describe('Tollkeeper Helm integration', () => {
+  it('maps the mainnet3 environment to the dedicated production namespace', () => {
+    expect(getTollkeeperReleaseConfigs('mainnet3')).to.deep.equal([
+      { releaseName: 'tollkeeper-prod', namespace: 'tollkeeper' },
+    ]);
+  });
+
+  it('does not invent Tollkeeper releases for other environments', () => {
+    expect(getTollkeeperReleaseConfigs('testnet4')).to.deep.equal([]);
+  });
+
+  it('restarts both RPC consumers after secret rotation', () => {
+    expect(getTollkeeperDeploymentNames('tollkeeper-prod')).to.deep.equal([
+      'tollkeeper-prod',
+      'tollkeeper-prod-signer',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- resolve Tollkeeper production in its dedicated namespace
- group dependent secret/pod refreshes by each manager namespace
- restart both Tollkeeper API and signer after RPC rotation
- remove the nonexistent staging release mapping

## Validation
- infra formatting and lint-staged hooks
- focused Tollkeeper release mapping tests (3 passing)
- gitleaks hook