### PR TITLE
feat(cli): skip unavailable warp route chains

### DIFF
--- a/.changeset/slow-chains-warp-skip.md
+++ b/.changeset/slow-chains-warp-skip.md
@@ -1,6 +1,6 @@
 ---
 '@hyperlane-xyz/cli': minor
-'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/sdk': minor
 ---
 
-Added `--skip-chains` support to warp read, deploy, apply, and check so unavailable route chains no longer block operations on healthy chains.
+Added `--skip-chains` support to warp read, deploy, apply, and check so unavailable route chains no longer block operations on healthy chains. Added reference-route support to SDK warp config expansion and checks so partial operations preserve full-route enrollments.

--- a/.changeset/slow-chains-warp-skip.md
+++ b/.changeset/slow-chains-warp-skip.md
@@ -1,0 +1,6 @@
+---
+'@hyperlane-xyz/cli': minor
+'@hyperlane-xyz/sdk': patch
+---
+
+Added `--skip-chains` support to warp read, deploy, apply, and check so unavailable route chains no longer block operations on healthy chains.

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -158,13 +158,17 @@ export async function checkCrossCollateralWarpRoute({
 
   const allRoutes = await context.registry.getWarpRoutes();
   const constituentRouteIds: string[] = [];
+  const skippedChains = new Set(context.skipChains ?? []);
 
   for (const [routeId, routeCoreConfig] of Object.entries(allRoutes)) {
     if (routeId === warpRouteId) continue;
-    if (routeCoreConfig.tokens.length === 0) continue;
+    const activeTokens = routeCoreConfig.tokens.filter(
+      (token) => !skippedChains.has(token.chainName),
+    );
+    if (activeTokens.length === 0) continue;
 
     if (
-      routeCoreConfig.tokens.every(
+      activeTokens.every(
         (t) =>
           t.addressOrDenom &&
           crossAddresses.has(t.addressOrDenom.toLowerCase()) &&
@@ -191,14 +195,27 @@ export async function checkCrossCollateralWarpRoute({
 
   for (const constituentId of constituentRouteIds) {
     const constituentCoreConfig = allRoutes[constituentId];
+    const constituentChains = new Set(
+      constituentCoreConfig.tokens.map((token) => token.chainName),
+    );
     const constituentDeployConfig = await readWarpRouteDeployConfig({
       context,
       warpRouteId: constituentId,
+      skipChains: context.skipChains?.filter((chain) =>
+        constituentChains.has(chain),
+      ),
     });
+    const activeChains = new Set(Object.keys(constituentDeployConfig));
+    const activeCoreConfig = {
+      ...constituentCoreConfig,
+      tokens: constituentCoreConfig.tokens.filter((token) =>
+        activeChains.has(token.chainName),
+      ),
+    };
 
     const result = await checkWarpRouteDeployConfig({
       multiProvider: context.multiProvider,
-      warpCoreConfig: constituentCoreConfig,
+      warpCoreConfig: activeCoreConfig,
       warpDeployConfig: constituentDeployConfig,
     });
 

--- a/typescript/cli/src/check/warp.ts
+++ b/typescript/cli/src/check/warp.ts
@@ -150,25 +150,20 @@ export async function checkCrossCollateralWarpRoute({
   warpCoreConfig: WarpCoreConfig;
   warpRouteId: string;
 }): Promise<WarpRouteCheckResult> {
+  const allRoutes = await context.registry.getWarpRoutes();
+  const fullCrossCoreConfig = allRoutes[warpRouteId] ?? warpCoreConfig;
   const crossAddresses = new Set(
-    warpCoreConfig.tokens.flatMap((t) =>
+    fullCrossCoreConfig.tokens.flatMap((t) =>
       t.addressOrDenom ? [t.addressOrDenom.toLowerCase()] : [],
     ),
   );
-
-  const allRoutes = await context.registry.getWarpRoutes();
   const constituentRouteIds: string[] = [];
   const skippedChains = new Set(context.skipChains ?? []);
 
   for (const [routeId, routeCoreConfig] of Object.entries(allRoutes)) {
     if (routeId === warpRouteId) continue;
-    const activeTokens = routeCoreConfig.tokens.filter(
-      (token) => !skippedChains.has(token.chainName),
-    );
-    if (activeTokens.length === 0) continue;
-
     if (
-      activeTokens.every(
+      routeCoreConfig.tokens.every(
         (t) =>
           t.addressOrDenom &&
           crossAddresses.has(t.addressOrDenom.toLowerCase()) &&
@@ -192,32 +187,54 @@ export async function checkCrossCollateralWarpRoute({
     diff: {},
     scaleViolations: [],
   };
+  let checkedConstituents = 0;
 
   for (const constituentId of constituentRouteIds) {
     const constituentCoreConfig = allRoutes[constituentId];
-    const constituentChains = new Set(
-      constituentCoreConfig.tokens.map((token) => token.chainName),
+    const rawDeployConfig =
+      await context.registry.getWarpDeployConfig(constituentId);
+    assert(
+      rawDeployConfig,
+      `No warp route deploy config found for constituent "${constituentId}"`,
     );
-    const constituentDeployConfig = await readWarpRouteDeployConfig({
+    const skippedDeployChains = Object.keys(rawDeployConfig).filter((chain) =>
+      skippedChains.has(chain),
+    );
+    if (skippedDeployChains.length === Object.keys(rawDeployConfig).length) {
+      warnYellow(
+        `Skipping constituent "${constituentId}" because all of its deploy chains were excluded`,
+      );
+      continue;
+    }
+    const {
+      config: constituentDeployConfig,
+      referenceConfig: referenceWarpDeployConfig,
+    } = await readWarpRouteDeployConfig({
       context,
       warpRouteId: constituentId,
-      skipChains: context.skipChains?.filter((chain) =>
-        constituentChains.has(chain),
-      ),
+      skipChains: skippedDeployChains,
     });
-    const activeChains = new Set(Object.keys(constituentDeployConfig));
     const activeCoreConfig = {
       ...constituentCoreConfig,
+      tokens: constituentCoreConfig.tokens.filter(
+        (token) => !skippedChains.has(token.chainName),
+      ),
+    };
+    const referenceWarpCoreConfig = {
+      ...constituentCoreConfig,
       tokens: constituentCoreConfig.tokens.filter((token) =>
-        activeChains.has(token.chainName),
+        Object.hasOwn(referenceWarpDeployConfig, token.chainName),
       ),
     };
 
     const result = await checkWarpRouteDeployConfig({
       multiProvider: context.multiProvider,
       warpCoreConfig: activeCoreConfig,
+      referenceWarpCoreConfig,
       warpDeployConfig: constituentDeployConfig,
+      referenceWarpDeployConfig,
     });
+    checkedConstituents += 1;
 
     combinedResult.isValid = combinedResult.isValid && result.isValid;
     combinedResult.violations.push(...result.violations);
@@ -227,6 +244,11 @@ export async function checkCrossCollateralWarpRoute({
       combinedResult.diff[`${constituentId}/${chain}`] = diff;
     }
   }
+
+  assert(
+    checkedConstituents > 0,
+    'No constituent routes remained after applying --skip-chains',
+  );
 
   return combinedResult;
 }

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -130,7 +130,7 @@ export const chainTargetsCommandOption: Options = stringArrayOptionConfig({
 
 export const skipChainsCommandOption: Options = stringArrayOptionConfig({
   description:
-    'List of route chains to skip without reading from or submitting to them',
+    'Route chains to exclude from on-chain reads and writes in this operation',
 });
 
 export const outputFileCommandOption = (

--- a/typescript/cli/src/commands/options.ts
+++ b/typescript/cli/src/commands/options.ts
@@ -128,6 +128,11 @@ export const chainTargetsCommandOption: Options = stringArrayOptionConfig({
   alias: 'c',
 });
 
+export const skipChainsCommandOption: Options = stringArrayOptionConfig({
+  description:
+    'List of route chains to skip without reading from or submitting to them',
+});
+
 export const outputFileCommandOption = (
   defaultPath?: string,
   demandOption = false,

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -66,6 +66,7 @@ import {
   chainCommandOption,
   forkCommandOptions,
   outputFileCommandOption,
+  skipChainsCommandOption,
   strategyCommandOption,
   stringArrayOptionConfig,
   warpRouteIdCommandOption,
@@ -194,12 +195,14 @@ export const apply: CommandModuleWithWarpApplyContext<
     strategy?: string;
     receiptsDir: string;
     relay?: boolean;
+    skipChains?: string[];
   }
 > = {
   command: 'apply',
   describe: 'Update Warp Route contracts',
   builder: {
     ...WARP_ROUTE_OPTIONS,
+    'skip-chains': skipChainsCommandOption,
     strategy: { ...strategyCommandOption, demandOption: false },
     'receipts-dir': {
       type: 'string',
@@ -239,10 +242,15 @@ export const apply: CommandModuleWithWarpApplyContext<
   },
 };
 
-export const deploy: CommandModuleWithWarpDeployContext<WarpRouteOptions> = {
+export const deploy: CommandModuleWithWarpDeployContext<
+  WarpRouteOptions & { skipChains?: string[] }
+> = {
   command: 'deploy',
   describe: 'Deploy Warp Route contracts',
-  builder: WARP_ROUTE_OPTIONS,
+  builder: {
+    ...WARP_ROUTE_OPTIONS,
+    'skip-chains': skipChainsCommandOption,
+  },
   handler: async ({ context, warpRouteId }) => {
     logCommandHeader(`Hyperlane Warp Route Deployment`);
 
@@ -332,12 +340,14 @@ export const read: CommandModuleWithContext<
     chain?: string;
     address?: string;
     out?: string;
+    skipChains?: string[];
   }
 > = {
   command: 'read',
   describe: 'Derive the warp route config from onchain artifacts',
   builder: {
     ...WARP_ROUTE_OPTIONS,
+    'skip-chains': skipChainsCommandOption,
     chain: {
       ...chainCommandOption,
       demandOption: false,
@@ -595,6 +605,7 @@ export const check: CommandModuleWithContext<
     origin?: string;
     originOwner?: string;
     chains?: string[];
+    skipChains?: string[];
   }
 > = {
   command: 'check',
@@ -602,6 +613,7 @@ export const check: CommandModuleWithContext<
     'Verifies that a warp route configuration matches the on chain configuration.',
   builder: {
     ...WARP_ROUTE_OPTIONS,
+    'skip-chains': skipChainsCommandOption,
     ica: {
       type: 'boolean',
       description:

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -232,6 +232,7 @@ export const apply: CommandModuleWithWarpApplyContext<
     await runWarpRouteApply({
       context,
       warpDeployConfig: context.warpDeployConfig,
+      referenceWarpDeployConfig: context.referenceWarpDeployConfig,
       warpCoreConfig: context.warpCoreConfig,
       strategyUrl,
       receiptsDir,
@@ -257,6 +258,7 @@ export const deploy: CommandModuleWithWarpDeployContext<
     await runWarpRouteDeploy({
       context,
       warpDeployConfig: context.warpDeployConfig,
+      referenceWarpDeployConfig: context.referenceWarpDeployConfig,
       warpRouteId: context.resolvedWarpRouteId ?? warpRouteId,
     });
 
@@ -618,7 +620,6 @@ export const check: CommandModuleWithContext<
       type: 'boolean',
       description:
         'Check that destination chain owners match expected ICA addresses derived from origin chain owner',
-      default: false,
     },
     origin: {
       type: 'string',
@@ -636,6 +637,7 @@ export const check: CommandModuleWithContext<
       description:
         'List of chains to check. Defaults to all chains except origin when using --ica.',
       implies: 'ica',
+      conflicts: 'skip-chains',
     }),
   },
   handler: async ({
@@ -674,8 +676,7 @@ export const check: CommandModuleWithContext<
         warpRouteId,
       });
 
-    // If --ica flag is set, run ICA owner check instead of the regular config check
-    // Note: ICA check uses full warpDeployConfig (not filtered) to support pre-deployed chains
+    // If --ica is set, run the owner check on the selected active chains.
     if (ica) {
       assert(origin, '--origin is required when using --ica');
 
@@ -698,7 +699,11 @@ export const check: CommandModuleWithContext<
     const result = await checkWarpRouteDeployConfig({
       multiProvider: context.multiProvider,
       warpCoreConfig,
+      referenceWarpCoreConfig:
+        context.referenceWarpCoreConfig ?? warpCoreConfig,
       warpDeployConfig,
+      referenceWarpDeployConfig:
+        context.referenceWarpDeployConfig ?? warpDeployConfig,
     });
 
     await runWarpRouteCheck({

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -136,22 +136,50 @@ export async function readWarpRouteDeployConfig({
   | {
       context: CommandContext;
       warpRouteId: string;
+      skipChains?: readonly string[];
     }
   | {
       context: CommandContext;
       filePath: string;
+      skipChains?: readonly string[];
     }): Promise<WarpRouteDeployConfigMailboxRequired> {
-  let config =
+  let config: WarpRouteDeployConfig | null | undefined =
     'filePath' in args
       ? readYamlOrJson(args.filePath)
       : await context.registry.getWarpDeployConfig(args.warpRouteId);
 
   assert(config, `No warp route deploy config found!`);
+  const fullConfig = config;
 
-  config = await fillDefaults(context, config as any);
+  const skippedChains = new Set(args.skipChains ?? context.skipChains ?? []);
+  const unknownChains = [...skippedChains].filter(
+    (chain) => !Object.hasOwn(fullConfig, chain),
+  );
+  assert(
+    unknownChains.length === 0,
+    `Cannot skip chains not present in the warp route: ${unknownChains.join(', ')}`,
+  );
 
-  config = objMap(
+  context.skippedWarpDeployConfig = Object.fromEntries(
+    Object.entries(fullConfig).filter(([chain]) => skippedChains.has(chain)),
+  );
+  config = Object.fromEntries(
+    Object.entries(fullConfig).filter(([chain]) => !skippedChains.has(chain)),
+  );
+  assert(
+    Object.keys(config).length !== 0,
+    'Cannot skip every chain in the warp route',
+  );
+
+  // CAST: fillDefaults only touches mailbox-client fields; the complete warp
+  // token union is validated by WarpRouteDeployConfigMailboxRequiredSchema below.
+  const configWithDefaults = (await fillDefaults(
+    context,
     config as any,
+  )) as WarpRouteDeployConfigMailboxRequired;
+
+  const resolvedConfig = objMap(
+    configWithDefaults,
     (_chain, chainConfig: HypTokenRouterConfig) => {
       if (chainConfig.destinationGas) {
         chainConfig.destinationGas = resolveRouterMapConfig(
@@ -183,7 +211,7 @@ export async function readWarpRouteDeployConfig({
   );
 
   //fillDefaults would have added a mailbox to the config if it was missing
-  return WarpRouteDeployConfigMailboxRequiredSchema.parse(config);
+  return WarpRouteDeployConfigMailboxRequiredSchema.parse(resolvedConfig);
 }
 
 export function isValidWarpRouteDeployConfig(config: any) {

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -102,12 +102,12 @@ const TYPE_CHOICES = Object.values(TokenType)
     description: TYPE_DESCRIPTIONS[type],
   }));
 
-export async function fillDefaults(
+export async function fillDefaults<T extends Partial<MailboxClientConfig>>(
   context: CommandContext,
-  config: ChainMap<Partial<MailboxClientConfig>>,
-): Promise<ChainMap<MailboxClientConfig>> {
+  config: ChainMap<T>,
+): Promise<ChainMap<T & MailboxClientConfig>> {
   return promiseObjAll(
-    objMap(config, async (chain, config): Promise<MailboxClientConfig> => {
+    objMap(config, async (chain, config): Promise<T & MailboxClientConfig> => {
       let mailbox = config.mailbox;
       if (!mailbox) {
         const addresses = await context.registry.getChainAddresses(chain);
@@ -142,41 +142,18 @@ export async function readWarpRouteDeployConfig({
       context: CommandContext;
       filePath: string;
       skipChains?: readonly string[];
-    }): Promise<WarpRouteDeployConfigMailboxRequired> {
-  let config: WarpRouteDeployConfig | null | undefined =
+    }): Promise<{
+  config: WarpRouteDeployConfigMailboxRequired;
+  referenceConfig: WarpRouteDeployConfigMailboxRequired;
+}> {
+  const config: WarpRouteDeployConfig | null | undefined =
     'filePath' in args
       ? readYamlOrJson(args.filePath)
       : await context.registry.getWarpDeployConfig(args.warpRouteId);
 
   assert(config, `No warp route deploy config found!`);
-  const fullConfig = config;
-
   const skippedChains = new Set(args.skipChains ?? context.skipChains ?? []);
-  const unknownChains = [...skippedChains].filter(
-    (chain) => !Object.hasOwn(fullConfig, chain),
-  );
-  assert(
-    unknownChains.length === 0,
-    `Cannot skip chains not present in the warp route: ${unknownChains.join(', ')}`,
-  );
-
-  context.skippedWarpDeployConfig = Object.fromEntries(
-    Object.entries(fullConfig).filter(([chain]) => skippedChains.has(chain)),
-  );
-  config = Object.fromEntries(
-    Object.entries(fullConfig).filter(([chain]) => !skippedChains.has(chain)),
-  );
-  assert(
-    Object.keys(config).length !== 0,
-    'Cannot skip every chain in the warp route',
-  );
-
-  // CAST: fillDefaults only touches mailbox-client fields; the complete warp
-  // token union is validated by WarpRouteDeployConfigMailboxRequiredSchema below.
-  const configWithDefaults = (await fillDefaults(
-    context,
-    config as any,
-  )) as WarpRouteDeployConfigMailboxRequired;
+  const configWithDefaults = await fillDefaults(context, config);
 
   const resolvedConfig = objMap(
     configWithDefaults,
@@ -210,8 +187,21 @@ export async function readWarpRouteDeployConfig({
     },
   );
 
-  //fillDefaults would have added a mailbox to the config if it was missing
-  return WarpRouteDeployConfigMailboxRequiredSchema.parse(resolvedConfig);
+  // Normalize every route leg before filtering so active and skipped configs
+  // retain one representation when they are later persisted together.
+  const referenceConfig =
+    WarpRouteDeployConfigMailboxRequiredSchema.parse(resolvedConfig);
+  const activeConfig = Object.fromEntries(
+    Object.entries(referenceConfig).filter(
+      ([chain]) => !skippedChains.has(chain),
+    ),
+  );
+  assert(
+    Object.keys(activeConfig).length !== 0,
+    'Cannot skip every chain in the warp route',
+  );
+
+  return { config: activeConfig, referenceConfig };
 }
 
 export function isValidWarpRouteDeployConfig(config: any) {

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -7,7 +7,7 @@ import {
   type DeployableTokenType,
   type DeployedOwnableConfig,
   HypERC20Deployer,
-  type HypTokenRouterConfig,
+  type HypTokenRouterConfigMailboxOptional,
   type IsmConfig,
   IsmType,
   type MailboxClientConfig,
@@ -24,6 +24,7 @@ import {
 import {
   type Address,
   assert,
+  objFilter,
   objMap,
   promiseObjAll,
 } from '@hyperlane-xyz/utils';
@@ -144,7 +145,7 @@ export async function readWarpRouteDeployConfig({
       skipChains?: readonly string[];
     }): Promise<{
   config: WarpRouteDeployConfigMailboxRequired;
-  referenceConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceConfig: WarpRouteDeployConfig;
 }> {
   const config: WarpRouteDeployConfig | null | undefined =
     'filePath' in args
@@ -153,11 +154,10 @@ export async function readWarpRouteDeployConfig({
 
   assert(config, `No warp route deploy config found!`);
   const skippedChains = new Set(args.skipChains ?? context.skipChains ?? []);
-  const configWithDefaults = await fillDefaults(context, config);
-
-  const resolvedConfig = objMap(
-    configWithDefaults,
-    (_chain, chainConfig: HypTokenRouterConfig) => {
+  const normalizedConfig = objMap(
+    config,
+    (_chain, rawChainConfig: HypTokenRouterConfigMailboxOptional) => {
+      const chainConfig = { ...rawChainConfig };
       if (chainConfig.destinationGas) {
         chainConfig.destinationGas = resolveRouterMapConfig(
           context.multiProvider,
@@ -187,19 +187,25 @@ export async function readWarpRouteDeployConfig({
     },
   );
 
-  // Normalize every route leg before filtering so active and skipped configs
-  // retain one representation when they are later persisted together.
-  const referenceConfig =
-    WarpRouteDeployConfigMailboxRequiredSchema.parse(resolvedConfig);
-  const activeConfig = Object.fromEntries(
-    Object.entries(referenceConfig).filter(
-      ([chain]) => !skippedChains.has(chain),
-    ),
+  // Resolve defaults only for active legs. Skipped legs may be unavailable and
+  // must not require chain addresses or a signer merely to preserve their raw
+  // registry config.
+  const activeConfigWithoutDefaults = objFilter(
+    normalizedConfig,
+    (chain, _config): _config is HypTokenRouterConfigMailboxOptional =>
+      !skippedChains.has(chain),
   );
   assert(
-    Object.keys(activeConfig).length !== 0,
+    Object.keys(activeConfigWithoutDefaults).length !== 0,
     'Cannot skip every chain in the warp route',
   );
+  const activeConfig = WarpRouteDeployConfigMailboxRequiredSchema.parse(
+    await fillDefaults(context, activeConfigWithoutDefaults),
+  );
+  const referenceConfig = WarpRouteDeployConfigSchema.parse({
+    ...normalizedConfig,
+    ...activeConfig,
+  });
 
   return { config: activeConfig, referenceConfig };
 }

--- a/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
@@ -1,12 +1,17 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
+import { PartialRegistry } from '@hyperlane-xyz/registry';
 import {
+  MultiProtocolProvider,
+  MultiProvider,
   TokenStandard,
   TokenType,
   TxSubmitterType,
   type WarpCoreConfig,
   type WarpRouteDeployConfig,
 } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
 
 import { type CommandContext } from '../../types.js';
 import { type ExtendedSubmissionStrategy } from '../../../submitters/types.js';
@@ -14,6 +19,21 @@ import { type ExtendedSubmissionStrategy } from '../../../submitters/types.js';
 import { getSubmitterChains, resolveChains } from './chainResolver.js';
 
 type Submitter = ExtendedSubmissionStrategy['submitter'];
+
+function testContext(registry = new PartialRegistry({})): CommandContext {
+  const multiProvider = MultiProvider.createTestMultiProvider();
+  return {
+    registry,
+    chainMetadata: multiProvider.metadata,
+    multiProvider,
+    multiProtocolProvider:
+      MultiProtocolProvider.fromMultiProvider(multiProvider),
+    altVmProviders: {},
+    supportedProtocols: [],
+    skipConfirmation: true,
+    altVmSigners: {},
+  };
+}
 
 describe('getSubmitterChains', () => {
   it('should return chain for a JSON_RPC submitter', () => {
@@ -90,7 +110,7 @@ describe('resolveChains — STATUS command', () => {
     overrides: Partial<Parameters<typeof resolveChains>[0]> = {},
   ): Parameters<typeof resolveChains>[0] => ({
     _: ['status'],
-    context: {} as CommandContext,
+    context: testContext(),
     ...overrides,
   });
 
@@ -151,21 +171,23 @@ describe('resolveChains — warp --skip-chains', () => {
   function warpArgv(command: 'read' | 'deploy' | 'apply' | 'check') {
     let warpDeployConfig: WarpRouteDeployConfig | null = deployConfig;
     let warpCoreConfig: WarpCoreConfig = coreConfig;
-    const registry = {
-      listRegistryContent: async () => ({
-        deployments: {
-          warpDeployConfig: { [routeId]: deployConfig },
-          warpRoutes: { [routeId]: coreConfig },
-        },
-      }),
-      getWarpDeployConfig: async () => warpDeployConfig,
-      getWarpRoute: async () => warpCoreConfig,
-    };
+    const registry = new PartialRegistry({});
+    sinon.stub(registry, 'listRegistryContent').callsFake(() => ({
+      chains: {},
+      deployments: {
+        warpDeployConfig: { [routeId]: 'deploy.yaml' },
+        warpRoutes: { [routeId]: 'config.yaml' },
+      },
+    }));
+    sinon
+      .stub(registry, 'getWarpDeployConfig')
+      .callsFake(() => warpDeployConfig);
+    sinon.stub(registry, 'getWarpRoute').callsFake(() => warpCoreConfig);
     const argv: Parameters<typeof resolveChains>[0] = {
       _: ['warp', command],
       warpRouteId: routeId,
       skipChains: ['down'],
-      context: { registry } as unknown as CommandContext,
+      context: testContext(registry),
     };
     return {
       argv,
@@ -181,20 +203,60 @@ describe('resolveChains — warp --skip-chains', () => {
   it('filters a down chain before warp deploy context setup', async () => {
     const { argv } = warpArgv('deploy');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
-    expect(Object.keys(argv.context.warpDeployConfig!)).to.deep.equal([
+    assert(argv.context.warpDeployConfig, 'warp deploy config was not set');
+    assert(
+      argv.context.referenceWarpDeployConfig,
+      'reference warp deploy config was not set',
+    );
+    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
       'healthy',
     ]);
-    expect(Object.keys(argv.context.referenceWarpDeployConfig!)).to.deep.equal([
+    expect(Object.keys(argv.context.referenceWarpDeployConfig)).to.deep.equal([
       'healthy',
       'down',
     ]);
   });
 
+  it('does not resolve defaults for a skipped route leg', async () => {
+    const { argv, setWarpDeployConfig } = warpArgv('deploy');
+    setWarpDeployConfig({
+      healthy: deployConfig.healthy,
+      down: {
+        type: TokenType.synthetic,
+        owner,
+        name: 'Test',
+        symbol: 'TST',
+        decimals: 18,
+      },
+    });
+    const getChainAddresses = sinon.stub(
+      argv.context.registry,
+      'getChainAddresses',
+    );
+    const getSignerAddress = sinon.stub(
+      argv.context.multiProvider,
+      'getSignerAddress',
+    );
+
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(getChainAddresses.called).to.equal(false);
+    expect(getSignerAddress.called).to.equal(false);
+    assert(
+      argv.context.referenceWarpDeployConfig,
+      'reference warp deploy config was not set',
+    );
+    expect(argv.context.referenceWarpDeployConfig.down.mailbox).to.equal(
+      undefined,
+    );
+    expect(argv.context.referenceWarpDeployConfig.down.owner).to.equal(owner);
+  });
+
   it('filters a down chain from warp read inputs', async () => {
     const { argv } = warpArgv('read');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    assert(argv.context.warpCoreConfig, 'warp core config was not set');
     expect(
-      argv.context.warpCoreConfig!.tokens.map(
+      argv.context.warpCoreConfig.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy']);
@@ -203,11 +265,13 @@ describe('resolveChains — warp --skip-chains', () => {
   it('filters apply planning but preserves the full core route', async () => {
     const { argv } = warpArgv('apply');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
-    expect(Object.keys(argv.context.warpDeployConfig!)).to.deep.equal([
+    assert(argv.context.warpDeployConfig, 'warp deploy config was not set');
+    assert(argv.context.warpCoreConfig, 'warp core config was not set');
+    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
       'healthy',
     ]);
     expect(
-      argv.context.warpCoreConfig!.tokens.map(
+      argv.context.warpCoreConfig.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy', 'down']);
@@ -216,11 +280,13 @@ describe('resolveChains — warp --skip-chains', () => {
   it('filters a down chain from warp check inputs', async () => {
     const { argv } = warpArgv('check');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
-    expect(Object.keys(argv.context.warpDeployConfig!)).to.deep.equal([
+    assert(argv.context.warpDeployConfig, 'warp deploy config was not set');
+    assert(argv.context.warpCoreConfig, 'warp core config was not set');
+    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
       'healthy',
     ]);
     expect(
-      argv.context.warpCoreConfig!.tokens.map(
+      argv.context.warpCoreConfig.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy']);
@@ -231,8 +297,9 @@ describe('resolveChains — warp --skip-chains', () => {
     setWarpDeployConfig(null);
 
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    assert(argv.context.warpCoreConfig, 'warp core config was not set');
     expect(
-      argv.context.warpCoreConfig!.tokens.map(
+      argv.context.warpCoreConfig.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy']);

--- a/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { TxSubmitterType } from '@hyperlane-xyz/sdk';
+import { TokenStandard, TokenType, TxSubmitterType } from '@hyperlane-xyz/sdk';
 
 import { type ExtendedSubmissionStrategy } from '../../../submitters/types.js';
 
@@ -92,5 +92,138 @@ describe('resolveChains — STATUS command', () => {
   it('returns empty array when origin not provided', async () => {
     const result = await resolveChains(statusArgv());
     expect(result).to.deep.equal([]);
+  });
+});
+
+describe('resolveChains — warp --skip-chains', () => {
+  const routeId = 'TST/healthy-down';
+  const owner = '0x1111111111111111111111111111111111111111';
+  const mailbox = '0x2222222222222222222222222222222222222222';
+  const deployConfig = {
+    healthy: {
+      type: TokenType.synthetic,
+      owner,
+      mailbox,
+      name: 'Test',
+      symbol: 'TST',
+      decimals: 18,
+    },
+    down: {
+      type: TokenType.synthetic,
+      name: 'Test',
+      symbol: 'TST',
+      decimals: 18,
+    },
+  };
+  const coreConfig = {
+    tokens: [
+      {
+        chainName: 'healthy',
+        standard: TokenStandard.EvmHypSynthetic,
+        decimals: 18,
+        symbol: 'TST',
+        name: 'Test',
+        addressOrDenom: '0x3333333333333333333333333333333333333333',
+      },
+      {
+        chainName: 'down',
+        standard: TokenStandard.EvmHypSynthetic,
+        decimals: 18,
+        symbol: 'TST',
+        name: 'Test',
+        addressOrDenom: '0x4444444444444444444444444444444444444444',
+      },
+    ],
+  };
+
+  function warpArgv(command: 'read' | 'deploy' | 'apply' | 'check') {
+    const registry = {
+      listRegistryContent: async () => ({
+        deployments: {
+          warpDeployConfig: { [routeId]: deployConfig },
+          warpRoutes: { [routeId]: coreConfig },
+        },
+      }),
+      getWarpDeployConfig: async () => deployConfig,
+      getWarpRoute: async () => coreConfig,
+    };
+    const argv: Parameters<typeof resolveChains>[0] = {
+      _: ['warp', command],
+      warpRouteId: routeId,
+      skipChains: ['down'],
+      context: { registry },
+    };
+    return argv;
+  }
+
+  it('filters a down chain before warp deploy context setup', async () => {
+    const argv = warpArgv('deploy');
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
+      'healthy',
+    ]);
+  });
+
+  it('filters a down chain from warp read inputs', async () => {
+    const argv = warpArgv('read');
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(
+      argv.context.warpCoreConfig.tokens.map(
+        (token: { chainName: string }) => token.chainName,
+      ),
+    ).to.deep.equal(['healthy']);
+  });
+
+  it('filters apply planning but preserves the full core route', async () => {
+    const argv = warpArgv('apply');
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
+      'healthy',
+    ]);
+    expect(
+      argv.context.warpCoreConfig.tokens.map(
+        (token: { chainName: string }) => token.chainName,
+      ),
+    ).to.deep.equal(['healthy', 'down']);
+  });
+
+  it('filters a down chain from warp check inputs', async () => {
+    const argv = warpArgv('check');
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
+      'healthy',
+    ]);
+    expect(
+      argv.context.warpCoreConfig.tokens.map(
+        (token: { chainName: string }) => token.chainName,
+      ),
+    ).to.deep.equal(['healthy']);
+  });
+
+  it('filters a down chain from combined CROSS route checks', async () => {
+    const argv = warpArgv('check');
+    argv.context.registry.getWarpDeployConfig = async () => null;
+
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(
+      argv.context.warpCoreConfig.tokens.map(
+        (token: { chainName: string }) => token.chainName,
+      ),
+    ).to.deep.equal(['healthy']);
+  });
+
+  it('rejects skipping every route chain', async () => {
+    const argv = warpArgv('apply');
+    argv.skipChains = ['healthy', 'down'];
+    try {
+      await resolveChains(argv);
+      expect.fail('Expected resolveChains to reject');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      if (!(error instanceof Error)) throw error;
+      expect(error.message).to.equal(
+        'Cannot skip every chain in the warp route',
+      );
+    }
   });
 });

--- a/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.test.ts
@@ -1,7 +1,14 @@
 import { expect } from 'chai';
 
-import { TokenStandard, TokenType, TxSubmitterType } from '@hyperlane-xyz/sdk';
+import {
+  TokenStandard,
+  TokenType,
+  TxSubmitterType,
+  type WarpCoreConfig,
+  type WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
 
+import { type CommandContext } from '../../types.js';
 import { type ExtendedSubmissionStrategy } from '../../../submitters/types.js';
 
 import { getSubmitterChains, resolveChains } from './chainResolver.js';
@@ -79,8 +86,11 @@ describe('getSubmitterChains', () => {
 });
 
 describe('resolveChains — STATUS command', () => {
-  const statusArgv = (overrides: Record<string, any> = {}) => ({
+  const statusArgv = (
+    overrides: Partial<Parameters<typeof resolveChains>[0]> = {},
+  ): Parameters<typeof resolveChains>[0] => ({
     _: ['status'],
+    context: {} as CommandContext,
     ...overrides,
   });
 
@@ -110,6 +120,8 @@ describe('resolveChains — warp --skip-chains', () => {
     },
     down: {
       type: TokenType.synthetic,
+      owner,
+      mailbox,
       name: 'Test',
       symbol: 'TST',
       decimals: 18,
@@ -137,6 +149,8 @@ describe('resolveChains — warp --skip-chains', () => {
   };
 
   function warpArgv(command: 'read' | 'deploy' | 'apply' | 'check') {
+    let warpDeployConfig: WarpRouteDeployConfig | null = deployConfig;
+    let warpCoreConfig: WarpCoreConfig = coreConfig;
     const registry = {
       listRegistryContent: async () => ({
         deployments: {
@@ -144,76 +158,88 @@ describe('resolveChains — warp --skip-chains', () => {
           warpRoutes: { [routeId]: coreConfig },
         },
       }),
-      getWarpDeployConfig: async () => deployConfig,
-      getWarpRoute: async () => coreConfig,
+      getWarpDeployConfig: async () => warpDeployConfig,
+      getWarpRoute: async () => warpCoreConfig,
     };
     const argv: Parameters<typeof resolveChains>[0] = {
       _: ['warp', command],
       warpRouteId: routeId,
       skipChains: ['down'],
-      context: { registry },
+      context: { registry } as unknown as CommandContext,
     };
-    return argv;
+    return {
+      argv,
+      setWarpDeployConfig: (config: WarpRouteDeployConfig | null) => {
+        warpDeployConfig = config;
+      },
+      setWarpCoreConfig: (config: WarpCoreConfig) => {
+        warpCoreConfig = config;
+      },
+    };
   }
 
   it('filters a down chain before warp deploy context setup', async () => {
-    const argv = warpArgv('deploy');
+    const { argv } = warpArgv('deploy');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
-    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
+    expect(Object.keys(argv.context.warpDeployConfig!)).to.deep.equal([
       'healthy',
+    ]);
+    expect(Object.keys(argv.context.referenceWarpDeployConfig!)).to.deep.equal([
+      'healthy',
+      'down',
     ]);
   });
 
   it('filters a down chain from warp read inputs', async () => {
-    const argv = warpArgv('read');
+    const { argv } = warpArgv('read');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
     expect(
-      argv.context.warpCoreConfig.tokens.map(
+      argv.context.warpCoreConfig!.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy']);
   });
 
   it('filters apply planning but preserves the full core route', async () => {
-    const argv = warpArgv('apply');
+    const { argv } = warpArgv('apply');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
-    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
+    expect(Object.keys(argv.context.warpDeployConfig!)).to.deep.equal([
       'healthy',
     ]);
     expect(
-      argv.context.warpCoreConfig.tokens.map(
+      argv.context.warpCoreConfig!.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy', 'down']);
   });
 
   it('filters a down chain from warp check inputs', async () => {
-    const argv = warpArgv('check');
+    const { argv } = warpArgv('check');
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
-    expect(Object.keys(argv.context.warpDeployConfig)).to.deep.equal([
+    expect(Object.keys(argv.context.warpDeployConfig!)).to.deep.equal([
       'healthy',
     ]);
     expect(
-      argv.context.warpCoreConfig.tokens.map(
+      argv.context.warpCoreConfig!.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy']);
   });
 
   it('filters a down chain from combined CROSS route checks', async () => {
-    const argv = warpArgv('check');
-    argv.context.registry.getWarpDeployConfig = async () => null;
+    const { argv, setWarpDeployConfig } = warpArgv('check');
+    setWarpDeployConfig(null);
 
     expect(await resolveChains(argv)).to.deep.equal(['healthy']);
     expect(
-      argv.context.warpCoreConfig.tokens.map(
+      argv.context.warpCoreConfig!.tokens.map(
         (token: { chainName: string }) => token.chainName,
       ),
     ).to.deep.equal(['healthy']);
   });
 
   it('rejects skipping every route chain', async () => {
-    const argv = warpArgv('apply');
+    const { argv } = warpArgv('apply');
     argv.skipChains = ['healthy', 'down'];
     try {
       await resolveChains(argv);
@@ -225,5 +251,38 @@ describe('resolveChains — warp --skip-chains', () => {
         'Cannot skip every chain in the warp route',
       );
     }
+  });
+
+  it('preserves core-only chains so check reports registry drift', async () => {
+    const { argv, setWarpDeployConfig } = warpArgv('check');
+    argv.skipChains = [];
+    const deployConfigWithoutDown = { healthy: deployConfig.healthy };
+    setWarpDeployConfig(deployConfigWithoutDown);
+
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(
+      argv.context.warpCoreConfig?.tokens.map((token) => token.chainName),
+    ).to.deep.equal(['healthy', 'down']);
+  });
+
+  it('accepts a skipped chain present only in the core config', async () => {
+    const { argv, setWarpDeployConfig } = warpArgv('check');
+    const deployConfigWithoutDown = { healthy: deployConfig.healthy };
+    setWarpDeployConfig(deployConfigWithoutDown);
+
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(
+      argv.context.warpCoreConfig?.tokens.map((token) => token.chainName),
+    ).to.deep.equal(['healthy']);
+  });
+
+  it('accepts a skipped chain present only in the deploy config', async () => {
+    const { argv, setWarpCoreConfig } = warpArgv('read');
+    setWarpCoreConfig({ tokens: [coreConfig.tokens[0]] });
+
+    expect(await resolveChains(argv)).to.deep.equal(['healthy']);
+    expect(
+      argv.context.warpCoreConfig?.tokens.map((token) => token.chainName),
+    ).to.deep.equal(['healthy']);
   });
 });

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -57,7 +57,7 @@ type ChainResolverArgs = {
 export async function resolveChains(
   argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
-  const commandKey = `${argv._?.[0]}:${argv._?.[1] || ''}${
+  const commandKey = `${argv._?.[0]}:${argv._?.[1] ?? ''}${
     argv._?.[2] ? `:${argv._[2]}` : ''
   }`.trim() as CommandType;
 

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -91,9 +91,36 @@ export async function resolveChains(
   }
 }
 
+function setSkipChains(argv: Record<string, any>): Set<ChainName> {
+  const skipChains = new Set<ChainName>(argv.skipChains ?? []);
+  argv.context.skipChains = [...skipChains];
+  return skipChains;
+}
+
+function filterSkippedChains(
+  allChains: readonly ChainName[],
+  skippedChains: ReadonlySet<ChainName>,
+): ChainName[] {
+  const routeChains = new Set(allChains);
+  const unknownChains = [...skippedChains].filter(
+    (chain) => !routeChains.has(chain),
+  );
+  assert(
+    unknownChains.length === 0,
+    `Cannot skip chains not present in the warp route: ${unknownChains.join(', ')}`,
+  );
+  const activeChains = allChains.filter((chain) => !skippedChains.has(chain));
+  assert(
+    activeChains.length !== 0,
+    'Cannot skip every chain in the warp route',
+  );
+  return activeChains;
+}
+
 async function resolveWarpRouteConfigChains(
   argv: Record<string, any>,
 ): Promise<ChainName[]> {
+  setSkipChains(argv);
   const { config, resolvedWarpRouteId } = await getWarpRouteDeployConfig({
     context: argv.context,
     warpRouteId: argv.warpRouteId,
@@ -120,8 +147,23 @@ async function resolveWarpReadChains(
       context: argv.context,
       warpRouteId: argv.warpRouteId,
     });
-    argv.context.warpCoreConfig = warpCoreConfig;
-    argv.context.chains = warpCoreConfig.tokens.map((token) => token.chainName);
+    const skippedChains = setSkipChains(argv);
+    const allChains = warpCoreConfig.tokens.map((token) => token.chainName);
+    const activeChains = filterSkippedChains(allChains, skippedChains);
+    const activeChainSet = new Set(activeChains);
+    const filteredWarpCoreConfig = {
+      ...warpCoreConfig,
+      tokens: warpCoreConfig.tokens.filter((token) =>
+        activeChainSet.has(token.chainName),
+      ),
+    };
+    argv.context.warpCoreConfig = filteredWarpCoreConfig;
+    argv.context.chains = activeChains;
+  } else if (argv.chain) {
+    argv.context.chains = filterSkippedChains(
+      [argv.chain],
+      setSkipChains(argv),
+    );
   }
 
   assert(
@@ -221,6 +263,7 @@ async function resolveChain(argv: Record<string, any>): Promise<ChainName[]> {
 async function resolveWarpConfigChains(
   argv: Record<string, any>,
 ): Promise<ChainName[]> {
+  const skippedChains = setSkipChains(argv);
   const { warpCoreConfig, warpDeployConfig, resolvedWarpRouteId } =
     await getWarpConfigs({
       context: argv.context,
@@ -242,9 +285,10 @@ async function resolveWarpConfigChains(
   // so signers are set up for them before transaction submission.
   if (argv.strategy) {
     const strategy = readChainSubmissionStrategy(argv.strategy);
-    for (const config of Object.values(strategy)) {
+    for (const [chain, config] of Object.entries(strategy)) {
+      if (skippedChains.has(chain)) continue;
       for (const c of getSubmitterChains(config.submitter)) {
-        chains.add(c);
+        if (!skippedChains.has(c)) chains.add(c);
       }
     }
   }
@@ -256,6 +300,7 @@ async function resolveWarpCheckChains(
   argv: Record<string, any>,
 ): Promise<ChainName[]> {
   const context = argv.context;
+  const skippedChains = setSkipChains(argv);
   const resolvedId = await resolveWarpRouteId({
     context,
     warpRouteId: argv.warpRouteId,
@@ -268,14 +313,18 @@ async function resolveWarpCheckChains(
     const warpCoreConfigRaw = await context.registry.getWarpRoute(resolvedId);
     assert(warpCoreConfigRaw, `No warp route config found for "${resolvedId}"`);
 
-    const warpCoreConfig = WarpCoreConfigSchema.parse(warpCoreConfigRaw);
-    const uniqueChains = [
-      ...new Set(warpCoreConfig.tokens.map((t) => t.chainName)),
+    const fullWarpCoreConfig = WarpCoreConfigSchema.parse(warpCoreConfigRaw);
+    const allChains = [
+      ...new Set(fullWarpCoreConfig.tokens.map((t) => t.chainName)),
     ];
-    assert(
-      uniqueChains.length > 0,
-      `No chains found for warp route "${resolvedId}"`,
-    );
+    const uniqueChains = filterSkippedChains(allChains, skippedChains);
+    const activeChains = new Set(uniqueChains);
+    const warpCoreConfig = {
+      ...fullWarpCoreConfig,
+      tokens: fullWarpCoreConfig.tokens.filter((token) =>
+        activeChains.has(token.chainName),
+      ),
+    };
 
     context.warpCoreConfig = warpCoreConfig;
     context.resolvedWarpRouteId = resolvedId;
@@ -283,7 +332,15 @@ async function resolveWarpCheckChains(
     return uniqueChains;
   }
 
-  return resolveWarpConfigChains(argv);
+  const chains = await resolveWarpConfigChains(argv);
+  const activeChains = new Set(chains);
+  context.warpCoreConfig = {
+    ...context.warpCoreConfig,
+    tokens: context.warpCoreConfig.tokens.filter(
+      (token: { chainName: string }) => activeChains.has(token.chainName),
+    ),
+  };
+  return chains;
 }
 
 async function resolveWarpSendChains(

--- a/typescript/cli/src/context/strategies/chain/chainResolver.ts
+++ b/typescript/cli/src/context/strategies/chain/chainResolver.ts
@@ -16,6 +16,7 @@ import { CommandType } from '../../../commands/signCommands.js';
 import { readCoreDeployConfigs } from '../../../config/core.js';
 import { getTransactions } from '../../../config/submit.js';
 import { readChainSubmissionStrategy } from '../../../deploy/warp.js';
+import { warnYellow } from '../../../logger.js';
 import { type ExtendedSubmissionStrategy } from '../../../submitters/types.js';
 import {
   filterOutDisabledChains,
@@ -29,6 +30,24 @@ import {
   resolveWarpRouteId,
 } from '../../../utils/warp.js';
 import { requestAndSaveApiKeys } from '../../apiKeys.js';
+import { type CommandContext } from '../../types.js';
+
+type ChainResolverArgs = {
+  _?: readonly (string | number)[];
+  context: CommandContext;
+  chain?: ChainName;
+  chains?: ChainName[];
+  config?: string;
+  destination?: ChainName;
+  origin?: ChainName;
+  recipient?: string;
+  relay?: boolean;
+  roundTrip?: boolean;
+  skipChains?: ChainName[];
+  strategy?: string;
+  transactions?: string;
+  warpRouteId?: string;
+};
 
 /**
  * Resolves chains based on command type.
@@ -36,10 +55,10 @@ import { requestAndSaveApiKeys } from '../../apiKeys.js';
  * @returns Promise<ChainName[]> - The chains resolved based on the command type.
  */
 export async function resolveChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
-  const commandKey = `${argv._[0]}:${argv._[1] || ''}${
-    argv._[2] ? `:${argv._[2]}` : ''
+  const commandKey = `${argv._?.[0]}:${argv._?.[1] || ''}${
+    argv._?.[2] ? `:${argv._[2]}` : ''
   }`.trim() as CommandType;
 
   switch (commandKey) {
@@ -91,8 +110,11 @@ export async function resolveChains(
   }
 }
 
-function setSkipChains(argv: Record<string, any>): Set<ChainName> {
+function setSkipChains(argv: ChainResolverArgs): Set<ChainName> {
   const skipChains = new Set<ChainName>(argv.skipChains ?? []);
+  if (skipChains.size > 0 && !argv.context.skipChains) {
+    warnYellow(`Excluding route chains: ${[...skipChains].join(', ')}`);
+  }
   argv.context.skipChains = [...skipChains];
   return skipChains;
 }
@@ -118,14 +140,23 @@ function filterSkippedChains(
 }
 
 async function resolveWarpRouteConfigChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
-  setSkipChains(argv);
-  const { config, resolvedWarpRouteId } = await getWarpRouteDeployConfig({
-    context: argv.context,
-    warpRouteId: argv.warpRouteId,
-  });
+  const skippedChains = setSkipChains(argv);
+  const { config, referenceConfig, resolvedWarpRouteId } =
+    await getWarpRouteDeployConfig({
+      context: argv.context,
+      warpRouteId: argv.warpRouteId,
+    });
+  const rawWarpCoreConfig =
+    await argv.context.registry.getWarpRoute(resolvedWarpRouteId);
+  const routeChains = new Set(Object.keys(referenceConfig));
+  for (const token of rawWarpCoreConfig?.tokens ?? []) {
+    routeChains.add(token.chainName);
+  }
+  filterSkippedChains([...routeChains], skippedChains);
   argv.context.warpDeployConfig = config;
+  argv.context.referenceWarpDeployConfig = referenceConfig;
   argv.context.resolvedWarpRouteId = resolvedWarpRouteId;
   argv.context.chains = Object.keys(config);
   assert(
@@ -136,20 +167,39 @@ async function resolveWarpRouteConfigChains(
 }
 
 async function resolveWarpReadChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   if (argv.chain) {
     argv.context.chains = await resolveChain(argv);
   }
 
   if (argv.warpRouteId) {
-    const warpCoreConfig = await getWarpCoreConfigOrExit({
+    const resolvedWarpRouteId = await resolveWarpRouteId({
       context: argv.context,
       warpRouteId: argv.warpRouteId,
     });
+    const warpCoreConfig = await getWarpCoreConfigOrExit({
+      context: argv.context,
+      warpRouteId: resolvedWarpRouteId,
+    });
     const skippedChains = setSkipChains(argv);
-    const allChains = warpCoreConfig.tokens.map((token) => token.chainName);
-    const activeChains = filterSkippedChains(allChains, skippedChains);
+    const rawDeployConfig =
+      await argv.context.registry.getWarpDeployConfig(resolvedWarpRouteId);
+    const coreChains = [
+      ...new Set(warpCoreConfig.tokens.map((token) => token.chainName)),
+    ];
+    const routeChains = new Set([
+      ...coreChains,
+      ...Object.keys(rawDeployConfig ?? {}),
+    ]);
+    filterSkippedChains([...routeChains], skippedChains);
+    const activeChains = coreChains.filter(
+      (chain) => !skippedChains.has(chain),
+    );
+    assert(
+      activeChains.length !== 0,
+      'Cannot skip every chain in the warp core config',
+    );
     const activeChainSet = new Set(activeChains);
     const filteredWarpCoreConfig = {
       ...warpCoreConfig,
@@ -158,6 +208,8 @@ async function resolveWarpReadChains(
       ),
     };
     argv.context.warpCoreConfig = filteredWarpCoreConfig;
+    argv.context.referenceWarpCoreConfig = warpCoreConfig;
+    argv.context.resolvedWarpRouteId = resolvedWarpRouteId;
     argv.context.chains = activeChains;
   } else if (argv.chain) {
     argv.context.chains = filterSkippedChains(
@@ -178,7 +230,7 @@ async function resolveWarpReadChains(
 // warpRouteId is always present, so a single-chain read on a mixed EVM/SVM
 // route only provisions providers/signers for that chain.
 async function resolveWarpQuoteReadChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   if (argv.warpRouteId) {
     const warpCoreConfig = await getWarpCoreConfigOrExit({
@@ -206,7 +258,7 @@ async function resolveWarpQuoteReadChains(
 }
 
 async function resolveWarpQuoteCreateChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   assert(
     argv.chain,
@@ -219,7 +271,7 @@ async function resolveWarpQuoteCreateChains(
 // `warp alt create` signs on SVM chains only; loading EVM signers for an
 // SVM/EVM warp route would prompt for keys the command never uses.
 async function resolveWarpAltCreateChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const { multiProvider } = argv.context;
 
@@ -254,23 +306,39 @@ async function resolveWarpAltCreateChains(
   return argv.context.chains;
 }
 
-async function resolveChain(argv: Record<string, any>): Promise<ChainName[]> {
+async function resolveChain(argv: ChainResolverArgs): Promise<ChainName[]> {
   const chains = argv.chain ? [argv.chain] : [];
   assert(chains.length !== 0, 'No chains found set in parameters');
   return chains;
 }
 
 async function resolveWarpConfigChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const skippedChains = setSkipChains(argv);
-  const { warpCoreConfig, warpDeployConfig, resolvedWarpRouteId } =
-    await getWarpConfigs({
-      context: argv.context,
-      warpRouteId: argv.warpRouteId,
-    });
+  const {
+    warpCoreConfig,
+    warpDeployConfig,
+    referenceWarpDeployConfig,
+    resolvedWarpRouteId,
+  } = await getWarpConfigs({
+    context: argv.context,
+    warpRouteId: argv.warpRouteId,
+  });
+  const routeChains = new Set([
+    ...Object.keys(referenceWarpDeployConfig),
+    ...warpCoreConfig.tokens.map((token) => token.chainName),
+  ]);
+  filterSkippedChains([...routeChains], skippedChains);
   argv.context.warpCoreConfig = warpCoreConfig;
+  argv.context.referenceWarpCoreConfig = {
+    ...warpCoreConfig,
+    tokens: warpCoreConfig.tokens.filter((token) =>
+      Object.hasOwn(referenceWarpDeployConfig, token.chainName),
+    ),
+  };
   argv.context.warpDeployConfig = warpDeployConfig;
+  argv.context.referenceWarpDeployConfig = referenceWarpDeployConfig;
   argv.context.resolvedWarpRouteId = resolvedWarpRouteId;
   argv.context.chains = Object.keys(warpDeployConfig);
 
@@ -288,7 +356,11 @@ async function resolveWarpConfigChains(
     for (const [chain, config] of Object.entries(strategy)) {
       if (skippedChains.has(chain)) continue;
       for (const c of getSubmitterChains(config.submitter)) {
-        if (!skippedChains.has(c)) chains.add(c);
+        assert(
+          !skippedChains.has(c),
+          `Submission strategy for active chain "${chain}" requires skipped submitter chain "${c}"`,
+        );
+        chains.add(c);
       }
     }
   }
@@ -297,7 +369,7 @@ async function resolveWarpConfigChains(
 }
 
 async function resolveWarpCheckChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const context = argv.context;
   const skippedChains = setSkipChains(argv);
@@ -327,24 +399,25 @@ async function resolveWarpCheckChains(
     };
 
     context.warpCoreConfig = warpCoreConfig;
+    context.referenceWarpCoreConfig = fullWarpCoreConfig;
     context.resolvedWarpRouteId = resolvedId;
     context.chains = uniqueChains;
     return uniqueChains;
   }
 
   const chains = await resolveWarpConfigChains(argv);
-  const activeChains = new Set(chains);
+  assert(context.warpCoreConfig, 'Warp core config was not resolved');
   context.warpCoreConfig = {
     ...context.warpCoreConfig,
     tokens: context.warpCoreConfig.tokens.filter(
-      (token: { chainName: string }) => activeChains.has(token.chainName),
+      (token: { chainName: string }) => !skippedChains.has(token.chainName),
     ),
   };
   return chains;
 }
 
 async function resolveWarpSendChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const { multiProvider } = argv.context;
   const chainPath: ChainName[] = [];
@@ -411,9 +484,10 @@ async function resolveWarpSendChains(
 }
 
 async function resolveWarpRebalancerChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   // Load rebalancer config to get the configured chains
+  assert(argv.config, 'No rebalancer config provided');
   const rebalancerConfig = RebalancerConfig.load(argv.config);
 
   // Extract chain names from all strategies in the rebalancer config
@@ -432,7 +506,7 @@ async function resolveWarpRebalancerChains(
  * interactively selected chains will be created after selection.
  */
 async function resolveSendMessageChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const { multiProvider } = argv.context;
   const selectedChains = [argv.origin, argv.destination].filter(
@@ -464,7 +538,7 @@ async function resolveSendMessageChains(
  * Destination chains discovered from the dispatch tx are resolved lazily.
  */
 async function resolveStatusChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   // Only origin is declared by the status command builder (messageOptions).
   // Destination chains are discovered lazily from the dispatch tx.
@@ -472,7 +546,7 @@ async function resolveStatusChains(
 }
 
 async function resolveRelayerChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const { multiProvider, chainMetadata } = argv.context;
   const chains = new Set<ChainName>();
@@ -503,9 +577,11 @@ async function resolveRelayerChains(
 }
 
 async function resolveCoreApplyChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   try {
+    assert(argv.config, 'No core deploy config provided');
+    assert(argv.chain, 'No chain provided');
     const config = readCoreDeployConfigs(argv.config);
 
     if (!config?.interchainAccountRouter) {
@@ -531,7 +607,10 @@ async function resolveCoreApplyChains(
         const transactions = await evmCoreModule.update(config);
 
         return Array.from(new Set(transactions.map((tx) => tx.chainId))).map(
-          (chainId) => argv.context.multiProvider.getChainName(chainId),
+          (chainId) => {
+            assert(chainId !== undefined, 'Transaction is missing a chain ID');
+            return argv.context.multiProvider.getChainName(chainId);
+          },
         );
       }
       default: {
@@ -546,7 +625,7 @@ async function resolveCoreApplyChains(
 }
 
 async function resolveCoreDeployChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   try {
     const { chainMetadata, registry, skipConfirmation } = argv.context;
@@ -580,7 +659,7 @@ async function resolveCoreDeployChains(
 }
 
 async function resolveIcaDeployChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   const chains = new Set<ChainName>();
   if (argv.origin) chains.add(argv.origin);
@@ -590,7 +669,7 @@ async function resolveIcaDeployChains(
 }
 
 async function resolveSubmitChains(
-  argv: Record<string, any>,
+  argv: ChainResolverArgs,
 ): Promise<ChainName[]> {
   try {
     const { multiProvider } = argv.context;
@@ -605,9 +684,10 @@ async function resolveSubmitChains(
 
     const chainIds = new Set(transactions.map((tx) => tx.chainId));
     const chains = new Set(
-      Array.from(chainIds).map((chainId) =>
-        multiProvider.getChainName(chainId),
-      ),
+      Array.from(chainIds).map((chainId) => {
+        assert(chainId !== undefined, 'Transaction is missing a chain ID');
+        return multiProvider.getChainName(chainId);
+      }),
     );
 
     if (argv.strategy) {

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -14,7 +14,6 @@ import type {
   MultiProtocolProvider,
   MultiProvider,
   WarpCoreConfig,
-  WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
@@ -59,10 +58,13 @@ export interface CommandContext extends Omit<
   supportedProtocols: ProtocolType[];
   skipConfirmation: boolean;
   warpCoreConfig?: WarpCoreConfig;
+  referenceWarpCoreConfig?: WarpCoreConfig;
   warpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
   resolvedWarpRouteId?: string;
   skipChains?: string[];
-  skippedWarpDeployConfig?: WarpRouteDeployConfig;
+  chains?: string[];
+  apiKeys?: ChainMap<string>;
   altVmSigners: ChainMap<AltVM.ISigner<AnnotatedTx, TxReceipt>>;
   // just for evm chains backward compatibility
   signerAddress?: string;

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -14,6 +14,7 @@ import type {
   MultiProtocolProvider,
   MultiProvider,
   WarpCoreConfig,
+  WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
@@ -60,7 +61,7 @@ export interface CommandContext extends Omit<
   warpCoreConfig?: WarpCoreConfig;
   referenceWarpCoreConfig?: WarpCoreConfig;
   warpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
-  referenceWarpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfig;
   resolvedWarpRouteId?: string;
   skipChains?: string[];
   chains?: string[];

--- a/typescript/cli/src/context/types.ts
+++ b/typescript/cli/src/context/types.ts
@@ -14,6 +14,7 @@ import type {
   MultiProtocolProvider,
   MultiProvider,
   WarpCoreConfig,
+  WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
@@ -60,6 +61,8 @@ export interface CommandContext extends Omit<
   warpCoreConfig?: WarpCoreConfig;
   warpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
   resolvedWarpRouteId?: string;
+  skipChains?: string[];
+  skippedWarpDeployConfig?: WarpRouteDeployConfig;
   altVmSigners: ChainMap<AltVM.ISigner<AnnotatedTx, TxReceipt>>;
   // just for evm chains backward compatibility
   signerAddress?: string;

--- a/typescript/cli/src/deploy/warp.test.ts
+++ b/typescript/cli/src/deploy/warp.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
+import { Wallet } from 'ethers';
 import sinon from 'sinon';
 
+import { PartialRegistry } from '@hyperlane-xyz/registry';
 import {
   ProtocolType,
   addressToBytes32,
@@ -11,12 +13,15 @@ import {
   HyperlaneDeployer,
   HookType,
   IsmType,
+  MultiProtocolProvider,
   MultiProvider,
   TokenStandard,
   TokenType,
   type WarpCoreConfig,
   type WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
+
+import { type WriteCommandContext } from '../context/types.js';
 
 import {
   extendWarpRoute,
@@ -584,9 +589,8 @@ describe('extendWarpRoute', () => {
     const owner = '0x3333333333333333333333333333333333333333';
     const mailbox = '0x2222222222222222222222222222222222222222';
     const getAddresses = sinon.stub().resolves({});
-    const multiProvider = {
-      getProtocol: () => ProtocolType.Ethereum,
-    };
+    const multiProvider = sinon.createStubInstance(MultiProvider);
+    multiProvider.getProtocol.returns(ProtocolType.Ethereum);
     const warpCoreConfig: WarpCoreConfig = {
       tokens: [
         {
@@ -613,29 +617,36 @@ describe('extendWarpRoute', () => {
       },
     };
 
+    const context: WriteCommandContext = {
+      key: { [ProtocolType.Ethereum]: 'unused' },
+      signer: Wallet.createRandom(),
+      registry: new PartialRegistry({}),
+      chainMetadata: {},
+      multiProvider,
+      multiProtocolProvider: new MultiProtocolProvider({}),
+      altVmProviders: {},
+      supportedProtocols: [ProtocolType.Ethereum],
+      skipConfirmation: true,
+      altVmSigners: {},
+      skipChains: ['down'],
+    };
+    sinon.stub(context.registry, 'getAddresses').callsFake(getAddresses);
+    const params: Parameters<typeof extendWarpRoute>[0] = {
+      context,
+      warpCoreConfig,
+      warpDeployConfig,
+      receiptsDir: 'unused',
+    };
+
     try {
-      await extendWarpRoute(
-        {
-          context: {
-            multiProvider,
-            registry: { getAddresses },
-            skipChains: ['down'],
-            supportedProtocols: [ProtocolType.Ethereum],
-          },
-          warpCoreConfig,
-          warpDeployConfig,
-        } as unknown as Parameters<typeof extendWarpRoute>[0],
-        {},
-        warpCoreConfig,
-        {
-          ...warpDeployConfig,
-          down: {
-            type: TokenType.synthetic,
-            mailbox,
-            owner,
-          },
+      await extendWarpRoute(params, {}, warpCoreConfig, {
+        ...warpDeployConfig,
+        down: {
+          type: TokenType.synthetic,
+          mailbox,
+          owner,
         },
-      );
+      });
       expect.fail('expected skip-chains extension to reject');
     } catch (error) {
       if (!(error instanceof Error)) throw error;

--- a/typescript/cli/src/deploy/warp.test.ts
+++ b/typescript/cli/src/deploy/warp.test.ts
@@ -19,6 +19,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import {
+  extendWarpRoute,
   fullyConnectTokens,
   runWarpRouteApply,
   runWarpRouteCombine,
@@ -575,6 +576,75 @@ describe('runWarpRouteApply', () => {
       expect(updateSplitSpy.called).to.equal(false);
       expect(deployTimelockSpy.called).to.equal(false);
     }
+  });
+});
+
+describe('extendWarpRoute', () => {
+  it('rejects skip-chains extensions before deployment', async () => {
+    const owner = '0x3333333333333333333333333333333333333333';
+    const mailbox = '0x2222222222222222222222222222222222222222';
+    const getAddresses = sinon.stub().resolves({});
+    const multiProvider = {
+      getProtocol: () => ProtocolType.Ethereum,
+    };
+    const warpCoreConfig: WarpCoreConfig = {
+      tokens: [
+        {
+          chainName: 'existing',
+          standard: TokenStandard.EvmHypSynthetic,
+          tokenType: TokenType.synthetic,
+          decimals: 18,
+          symbol: 'TST',
+          name: 'Test',
+          addressOrDenom: '0x1111111111111111111111111111111111111111',
+        },
+      ],
+    };
+    const warpDeployConfig: WarpRouteDeployConfigMailboxRequired = {
+      existing: {
+        type: TokenType.synthetic,
+        mailbox,
+        owner,
+      },
+      newchain: {
+        type: TokenType.synthetic,
+        mailbox,
+        owner,
+      },
+    };
+
+    try {
+      await extendWarpRoute(
+        {
+          context: {
+            multiProvider,
+            registry: { getAddresses },
+            skipChains: ['down'],
+            supportedProtocols: [ProtocolType.Ethereum],
+          },
+          warpCoreConfig,
+          warpDeployConfig,
+        } as unknown as Parameters<typeof extendWarpRoute>[0],
+        {},
+        warpCoreConfig,
+        {
+          ...warpDeployConfig,
+          down: {
+            type: TokenType.synthetic,
+            mailbox,
+            owner,
+          },
+        },
+      );
+      expect.fail('expected skip-chains extension to reject');
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      expect(error.message).to.equal(
+        'Cannot extend a warp route while skipping chains. Apply the extension after all route chains are available.',
+      );
+    }
+
+    expect(getAddresses.called).to.equal(false);
   });
 });
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -138,7 +138,7 @@ import {
 interface DeployParams {
   context: WriteCommandContext;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
-  referenceWarpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfig;
 }
 
 interface WarpApplyParams extends DeployParams {
@@ -173,7 +173,7 @@ export async function runWarpRouteDeploy({
 }: {
   context: WriteCommandContext;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
-  referenceWarpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfig;
   warpRouteId?: string;
 }) {
   const {
@@ -660,7 +660,7 @@ export async function extendWarpRoute(
   params: WarpApplyParams,
   apiKeys: ChainMap<string>,
   warpCoreConfig: WarpCoreConfig,
-  targetWarpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  targetWarpDeployConfig: WarpRouteDeployConfig,
 ): Promise<WarpCoreConfig> {
   const { context, warpDeployConfig } = params;
   const { existingConfigs, initialExtendedConfigs, warpCoreConfigByChain } =

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -65,6 +65,7 @@ import {
   TOKEN_CROSS_COLLATERAL_STANDARDS,
   altVmChainLookup,
   assertDelayedFlowRoutePreconditions,
+  assertDelayedFlowRouteCoverage,
   buildDelayedFlowEnrollmentTxs,
   deriveDelayedFlowEnrollmentTargets,
   enrollCrossChainRouters,
@@ -101,10 +102,7 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { requestAndSaveApiKeys } from '../context/apiKeys.js';
-import {
-  type CommandContext,
-  type WriteCommandContext,
-} from '../context/types.js';
+import { type WriteCommandContext } from '../context/types.js';
 import {
   errorRed,
   log,
@@ -140,6 +138,7 @@ import {
 interface DeployParams {
   context: WriteCommandContext;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
 }
 
 interface WarpApplyParams extends DeployParams {
@@ -169,10 +168,12 @@ function assertWarpApplyTimelocksSupportedByProtocols({
 export async function runWarpRouteDeploy({
   context,
   warpDeployConfig,
+  referenceWarpDeployConfig = warpDeployConfig,
   warpRouteId,
 }: {
   context: WriteCommandContext;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfigMailboxRequired;
   warpRouteId?: string;
 }) {
   const {
@@ -195,6 +196,7 @@ export async function runWarpRouteDeploy({
   const deploymentParams = {
     context,
     warpDeployConfig,
+    referenceWarpDeployConfig,
   };
 
   await runDeployPlanStep(deploymentParams);
@@ -317,7 +319,7 @@ export async function runWarpRouteDeploy({
 
   await writeDeploymentArtifacts(warpCoreConfig, context, warpRouteIdOptions);
   await context.registry.addWarpRouteConfig(
-    warpDeployConfig,
+    referenceWarpDeployConfig,
     warpRouteIdOptions,
   );
 
@@ -524,16 +526,6 @@ export function withIntermediateWarpOwner(
   };
 }
 
-function getFullWarpDeployConfig(
-  context: CommandContext,
-  warpDeployConfig: WarpRouteDeployConfig,
-): WarpRouteDeployConfig {
-  return {
-    ...context.skippedWarpDeployConfig,
-    ...warpDeployConfig,
-  };
-}
-
 export async function runWarpRouteApply(
   params: WarpApplyParams,
 ): Promise<void> {
@@ -547,8 +539,13 @@ export async function runWarpRouteApply(
     warpDeployConfig,
   });
   planWarpRouteHybrids({ multiProvider, warpDeployConfig });
-  // Checked against the whole route config, before the extension deploys any
-  // chain: a delayed-flow route only works when every leg carries an instance.
+  const referenceWarpDeployConfig =
+    params.referenceWarpDeployConfig ?? warpDeployConfig;
+  // Coverage is route-wide, while nonce reads remain scoped to active chains.
+  assertDelayedFlowRouteCoverage({
+    multiProvider,
+    warpDeployConfig: referenceWarpDeployConfig,
+  });
   await assertDelayedFlowRoutePreconditions({
     multiProvider,
     warpDeployConfig,
@@ -588,7 +585,7 @@ export async function runWarpRouteApply(
     { ...params, warpDeployConfig: intermediateOwnerConfig },
     apiKeys,
     warpCoreConfig,
-    getFullWarpDeployConfig(context, warpDeployConfig),
+    referenceWarpDeployConfig,
   );
 
   // Then create and submit update transactions
@@ -663,7 +660,7 @@ export async function extendWarpRoute(
   params: WarpApplyParams,
   apiKeys: ChainMap<string>,
   warpCoreConfig: WarpCoreConfig,
-  targetWarpDeployConfig: WarpRouteDeployConfig,
+  targetWarpDeployConfig: WarpRouteDeployConfigMailboxRequired,
 ): Promise<WarpCoreConfig> {
   const { context, warpDeployConfig } = params;
   const { existingConfigs, initialExtendedConfigs, warpCoreConfigByChain } =
@@ -687,10 +684,6 @@ export async function extendWarpRoute(
       ),
   );
 
-  const skippedChains = new Set(context.skipChains ?? []);
-  const skippedWarpCoreConfigs = Object.values(warpCoreConfigByChain).filter(
-    (config) => skippedChains.has(config.chainName),
-  );
   const activeExistingChains = new Set(Object.keys(filteredExistingConfigs));
   const filteredWarpCoreConfigByChain = objFilter(
     warpCoreConfigByChain,
@@ -699,10 +692,16 @@ export async function extendWarpRoute(
   );
   // Preserve skipped and unsupported existing chains without probing them.
   const preservedWarpCoreConfigs = warpCoreConfig.tokens.filter(
-    (token) => !activeExistingChains.has(token.chainName),
+    (token) =>
+      !activeExistingChains.has(token.chainName) &&
+      !!targetWarpDeployConfig[token.chainName],
   );
 
   const filteredExtendedChains = Object.keys(filteredExtendedConfigs);
+  assert(
+    !context.skipChains?.length || filteredExtendedChains.length === 0,
+    `Cannot extend a warp route while skipping chains. Apply the extension after all route chains are available.`,
+  );
   if (filteredExtendedChains.length === 0) {
     return warpCoreConfig;
   }
@@ -800,36 +799,6 @@ export async function extendWarpRoute(
 
   // Re-add existing chains that were excluded from this run.
   updatedWarpCoreConfig.tokens.push(...preservedWarpCoreConfigs);
-
-  // Healthy chains still target existing skipped routers. Do not add the
-  // reverse connection: no transaction is submitted to enroll new routers on
-  // the skipped chain during this run.
-  const preservedChains = new Set(
-    preservedWarpCoreConfigs.map((config) => config.chainName),
-  );
-  const skippedConnections = skippedWarpCoreConfigs.map((token) => {
-    assert(
-      token.addressOrDenom,
-      `Missing token address for skipped chain ${token.chainName}`,
-    );
-    return getTokenConnectionId(
-      context.multiProvider.getProtocol(token.chainName),
-      token.chainName,
-      token.addressOrDenom,
-    );
-  });
-  for (const token of updatedWarpCoreConfig.tokens) {
-    if (preservedChains.has(token.chainName)) continue;
-    const existingConnections = new Set(
-      token.connections?.map(({ token: connection }) => connection),
-    );
-    token.connections ??= [];
-    token.connections.push(
-      ...skippedConnections
-        .filter((connection) => !existingConnections.has(connection))
-        .map((connection) => ({ token: connection })),
-    );
-  }
 
   // Preserve metadata fields from existing config that generateTokenConfigs doesn't include
   // (e.g. logoURI, coinGeckoId, igpTokenAddressOrDenom, scale).
@@ -942,10 +911,8 @@ async function updateExistingWarpRoute(
   const expandedWarpDeployConfig = await expandWarpDeployConfig({
     multiProvider,
     warpDeployConfig,
-    referenceWarpDeployConfig: getFullWarpDeployConfig(
-      params.context,
-      warpDeployConfig,
-    ),
+    referenceWarpDeployConfig:
+      params.referenceWarpDeployConfig ?? warpDeployConfig,
     deployedRoutersAddresses,
   });
 

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -101,7 +101,10 @@ import {
 } from '@hyperlane-xyz/utils';
 
 import { requestAndSaveApiKeys } from '../context/apiKeys.js';
-import { type WriteCommandContext } from '../context/types.js';
+import {
+  type CommandContext,
+  type WriteCommandContext,
+} from '../context/types.js';
 import {
   errorRed,
   log,
@@ -521,6 +524,16 @@ export function withIntermediateWarpOwner(
   };
 }
 
+function getFullWarpDeployConfig(
+  context: CommandContext,
+  warpDeployConfig: WarpRouteDeployConfig,
+): WarpRouteDeployConfig {
+  return {
+    ...context.skippedWarpDeployConfig,
+    ...warpDeployConfig,
+  };
+}
+
 export async function runWarpRouteApply(
   params: WarpApplyParams,
 ): Promise<void> {
@@ -575,7 +588,7 @@ export async function runWarpRouteApply(
     { ...params, warpDeployConfig: intermediateOwnerConfig },
     apiKeys,
     warpCoreConfig,
-    warpDeployConfig,
+    getFullWarpDeployConfig(context, warpDeployConfig),
   );
 
   // Then create and submit update transactions
@@ -650,7 +663,7 @@ export async function extendWarpRoute(
   params: WarpApplyParams,
   apiKeys: ChainMap<string>,
   warpCoreConfig: WarpCoreConfig,
-  targetWarpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  targetWarpDeployConfig: WarpRouteDeployConfig,
 ): Promise<WarpCoreConfig> {
   const { context, warpDeployConfig } = params;
   const { existingConfigs, initialExtendedConfigs, warpCoreConfigByChain } =
@@ -674,26 +687,20 @@ export async function extendWarpRoute(
       ),
   );
 
+  const skippedChains = new Set(context.skipChains ?? []);
+  const skippedWarpCoreConfigs = Object.values(warpCoreConfigByChain).filter(
+    (config) => skippedChains.has(config.chainName),
+  );
+  const activeExistingChains = new Set(Object.keys(filteredExistingConfigs));
   const filteredWarpCoreConfigByChain = objFilter(
     warpCoreConfigByChain,
     (chainName, _): _ is (typeof warpCoreConfigByChain)[string] =>
-      context.supportedProtocols.includes(
-        context.multiProvider.getProtocol(chainName),
-      ),
+      activeExistingChains.has(chainName),
   );
-
-  // Get the non compatible chains that should not be unenrolled/removed after the extension
-  // otherwise the update will generate unenroll transactions
-  const nonCompatibleWarpCoreConfigs: WarpCoreConfig['tokens'] = Object.entries(
-    warpCoreConfigByChain,
-  )
-    .filter(
-      ([chainName]) =>
-        !context.supportedProtocols.includes(
-          context.multiProvider.getProtocol(chainName),
-        ) && !!warpDeployConfig[chainName],
-    )
-    .map(([_, config]) => config);
+  // Preserve skipped and unsupported existing chains without probing them.
+  const preservedWarpCoreConfigs = warpCoreConfig.tokens.filter(
+    (token) => !activeExistingChains.has(token.chainName),
+  );
 
   const filteredExtendedChains = Object.keys(filteredExtendedConfigs);
   if (filteredExtendedChains.length === 0) {
@@ -791,9 +798,38 @@ export async function extendWarpRoute(
     await getWarpCoreConfig(params, mergedRouters);
   WarpCoreConfigSchema.parse(updatedWarpCoreConfig);
 
-  // Re-add the non compatible chains to the warp core config so that expanding the config
-  // to get the proper remote routers and gas config works as expected
-  updatedWarpCoreConfig.tokens.push(...nonCompatibleWarpCoreConfigs);
+  // Re-add existing chains that were excluded from this run.
+  updatedWarpCoreConfig.tokens.push(...preservedWarpCoreConfigs);
+
+  // Healthy chains still target existing skipped routers. Do not add the
+  // reverse connection: no transaction is submitted to enroll new routers on
+  // the skipped chain during this run.
+  const preservedChains = new Set(
+    preservedWarpCoreConfigs.map((config) => config.chainName),
+  );
+  const skippedConnections = skippedWarpCoreConfigs.map((token) => {
+    assert(
+      token.addressOrDenom,
+      `Missing token address for skipped chain ${token.chainName}`,
+    );
+    return getTokenConnectionId(
+      context.multiProvider.getProtocol(token.chainName),
+      token.chainName,
+      token.addressOrDenom,
+    );
+  });
+  for (const token of updatedWarpCoreConfig.tokens) {
+    if (preservedChains.has(token.chainName)) continue;
+    const existingConnections = new Set(
+      token.connections?.map(({ token: connection }) => connection),
+    );
+    token.connections ??= [];
+    token.connections.push(
+      ...skippedConnections
+        .filter((connection) => !existingConnections.has(connection))
+        .map((connection) => ({ token: connection })),
+    );
+  }
 
   // Preserve metadata fields from existing config that generateTokenConfigs doesn't include
   // (e.g. logoURI, coinGeckoId, igpTokenAddressOrDenom, scale).
@@ -906,6 +942,10 @@ async function updateExistingWarpRoute(
   const expandedWarpDeployConfig = await expandWarpDeployConfig({
     multiProvider,
     warpDeployConfig,
+    referenceWarpDeployConfig: getFullWarpDeployConfig(
+      params.context,
+      warpDeployConfig,
+    ),
     deployedRoutersAddresses,
   });
 

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -77,17 +77,20 @@ export class HyperlaneE2EWarpTestCommands {
     warpAddress,
     outputPath,
     warpRouteId,
+    skipChains,
   }: {
     chain?: string;
     warpAddress?: string;
     warpRouteId?: string;
     outputPath?: string;
+    skipChains?: string[];
   }): ProcessPromise {
     return $`${localTestRunCmdPrefix()} hyperlane warp read \
             --registry ${this.registryPath} \
             ${warpAddress ? ['--address', warpAddress] : []} \
             ${chain ? ['--chain', chain] : []} \
             ${warpRouteId ? ['--warp-route-id', warpRouteId] : []} \
+            ${skipChains?.length ? ['--skip-chains', ...skipChains] : []} \
             --verbosity debug \
             ${outputPath || this.outputPath ? ['--out', outputPath || this.outputPath] : []}`;
   }

--- a/typescript/cli/src/tests/ethereum/warp/warp-read.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/warp/warp-read.e2e-test.ts
@@ -152,6 +152,39 @@ describe('hyperlane warp read e2e tests', async function () {
       expect(warpReadResult[CHAIN_NAME_3]).not.to.be.undefined;
       expect(warpReadResult[CHAIN_NAME_3].type).to.equal(TokenType.native);
     });
+
+    it('should skip reading excluded route chains', async () => {
+      const readOutputPath = `${TEMP_PATH}/warp-read-skip-chain.yaml`;
+      const warpRouteId = 'READSKIP/ethereum-warp-read-skip';
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.synthetic,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.native,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, warpConfig);
+      await hyperlaneWarpDeploy(WARP_DEPLOY_OUTPUT_PATH, warpRouteId);
+
+      const output = await hyperlaneWarp
+        .readRaw({
+          warpRouteId,
+          outputPath: readOutputPath,
+          skipChains: [CHAIN_NAME_3],
+        })
+        .nothrow();
+
+      expect(output.exitCode).to.equal(0);
+      const warpReadResult: WarpRouteDeployConfig =
+        readYamlOrJson(readOutputPath);
+      expect(Object.keys(warpReadResult)).to.deep.equal([CHAIN_NAME_2]);
+    });
   });
 
   describe('hyperlane warp read --warpRouteId ...', () => {

--- a/typescript/cli/src/utils/warp.ts
+++ b/typescript/cli/src/utils/warp.ts
@@ -5,6 +5,7 @@ import {
   type ChainName,
   filterWarpCoreConfigMapByChains,
   type WarpCoreConfig,
+  type WarpRouteDeployConfig,
   type WarpRouteDeployConfigMailboxRequired,
 } from '@hyperlane-xyz/sdk';
 import {
@@ -214,7 +215,7 @@ export async function getWarpConfigs({
   chains?: string[];
 }): Promise<{
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
-  referenceWarpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig: WarpRouteDeployConfig;
   warpCoreConfig: WarpCoreConfig;
   resolvedWarpRouteId: string;
 }> {
@@ -250,7 +251,7 @@ export async function getWarpRouteDeployConfig({
   warpRouteId?: string;
 }): Promise<{
   config: WarpRouteDeployConfigMailboxRequired;
-  referenceConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceConfig: WarpRouteDeployConfig;
   resolvedWarpRouteId: string;
 }> {
   const resolvedWarpRouteId = await resolveWarpRouteId({

--- a/typescript/cli/src/utils/warp.ts
+++ b/typescript/cli/src/utils/warp.ts
@@ -214,6 +214,7 @@ export async function getWarpConfigs({
   chains?: string[];
 }): Promise<{
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig: WarpRouteDeployConfigMailboxRequired;
   warpCoreConfig: WarpCoreConfig;
   resolvedWarpRouteId: string;
 }> {
@@ -227,12 +228,18 @@ export async function getWarpConfigs({
     context,
     warpRouteId: resolvedWarpRouteId,
   });
-  const warpDeployConfig = await readWarpRouteDeployConfig({
-    warpRouteId: resolvedWarpRouteId,
-    context,
-  });
+  const { config: warpDeployConfig, referenceConfig } =
+    await readWarpRouteDeployConfig({
+      warpRouteId: resolvedWarpRouteId,
+      context,
+    });
 
-  return { warpDeployConfig, warpCoreConfig, resolvedWarpRouteId };
+  return {
+    warpDeployConfig,
+    referenceWarpDeployConfig: referenceConfig,
+    warpCoreConfig,
+    resolvedWarpRouteId,
+  };
 }
 
 export async function getWarpRouteDeployConfig({
@@ -243,6 +250,7 @@ export async function getWarpRouteDeployConfig({
   warpRouteId?: string;
 }): Promise<{
   config: WarpRouteDeployConfigMailboxRequired;
+  referenceConfig: WarpRouteDeployConfigMailboxRequired;
   resolvedWarpRouteId: string;
 }> {
   const resolvedWarpRouteId = await resolveWarpRouteId({
@@ -251,12 +259,12 @@ export async function getWarpRouteDeployConfig({
     promptByDeploymentConfigs: true,
   });
 
-  const config = await readWarpRouteDeployConfig({
+  const { config, referenceConfig } = await readWarpRouteDeployConfig({
     context,
     warpRouteId: resolvedWarpRouteId,
   });
 
-  return { config, resolvedWarpRouteId };
+  return { config, referenceConfig, resolvedWarpRouteId };
 }
 
 export function filterWarpConfigsToMatchingChains(

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -1354,7 +1354,7 @@ export type DelayedFlowEnrollmentTarget = {
  * instead of a silent pass.
  */
 function delayedFlowIsmNodes(
-  config: WarpRouteDeployConfigMailboxRequired[string],
+  config: WarpRouteDeployConfig[string],
 ): DelayedFlowRouterHookIsmConfig[] {
   if (typeof config.interchainSecurityModule !== 'object') return [];
   return collectHybridIsmNodes(config.interchainSecurityModule).filter(
@@ -1365,14 +1365,14 @@ function delayedFlowIsmNodes(
 
 /** True when a chain's warp config installs a DELAYED_FLOW_ROUTER instance. */
 function configInstallsDelayedFlowIsm(
-  config: WarpRouteDeployConfigMailboxRequired[string],
+  config: WarpRouteDeployConfig[string],
 ): boolean {
   return delayedFlowIsmNodes(config).length > 0;
 }
 
 /** The chains of a config whose ISM tree installs a DELAYED_FLOW_ROUTER. */
 function delayedFlowChains(
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  warpDeployConfig: WarpRouteDeployConfig,
 ): ChainName[] {
   return Object.keys(warpDeployConfig).filter((chain) =>
     configInstallsDelayedFlowIsm(warpDeployConfig[chain]),
@@ -1382,7 +1382,7 @@ function delayedFlowChains(
 /** Domain id of every chain the route deploys, asserted resolvable. */
 function resolveRouteDomains(
   multiProvider: MultiProvider,
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  warpDeployConfig: WarpRouteDeployConfig,
 ): Map<ChainName, number> {
   const routeDomains = new Map<ChainName, number>();
   for (const chain of Object.keys(warpDeployConfig)) {
@@ -1408,7 +1408,7 @@ function resolveRouteDomains(
 function configuredRemoteIsmDomains(
   multiProvider: MultiProvider,
   chain: ChainName,
-  config: WarpRouteDeployConfigMailboxRequired[string],
+  config: WarpRouteDeployConfig[string],
 ): Set<number> {
   const domains = new Set<number>();
   for (const node of delayedFlowIsmNodes(config)) {
@@ -1440,7 +1440,7 @@ function configuredRemoteIsmDomains(
  */
 function assertDelayedFlowRemoteRouterCoverage(
   multiProvider: MultiProvider,
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  warpDeployConfig: WarpRouteDeployConfig,
   routeDomains: Map<ChainName, number>,
 ): void {
   const deployedDomains = new Set<number>(routeDomains.values());
@@ -1496,7 +1496,7 @@ function assertDelayedFlowRemoteRouterCoverage(
  * merely part-deployed.
  */
 function assertDelayedFlowLegCoverage(
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  warpDeployConfig: WarpRouteDeployConfig,
 ): void {
   const chains = Object.keys(warpDeployConfig);
   const covered = delayedFlowChains(warpDeployConfig);
@@ -1535,7 +1535,7 @@ export function assertDelayedFlowRouteCoverage({
   warpDeployConfig,
 }: {
   multiProvider: MultiProvider;
-  warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  warpDeployConfig: WarpRouteDeployConfig;
 }): void {
   assertDelayedFlowLegCoverage(warpDeployConfig);
   if (delayedFlowChains(warpDeployConfig).length === 0) return;

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -159,6 +159,69 @@ describe('configUtils', () => {
       );
     });
 
+    it('does not probe deployed routers omitted from the target config', async () => {
+      const owner = '0x1111111111111111111111111111111111111111';
+      const activeRouter = '0x2222222222222222222222222222222222222222';
+      const skippedRouter = '0x3333333333333333333333333333333333333333';
+      const multiProvider = buildMultiProvider();
+      const activeGetCode = sinon
+        .stub(multiProvider.getProvider(test1.name), 'getCode')
+        .resolves('0x01');
+      const activeGetStorageAt = sinon
+        .stub(multiProvider.getProvider(test1.name), 'getStorageAt')
+        .resolves('0x0');
+      const skippedGetCode = sinon
+        .stub(multiProvider.getProvider(test2.name), 'getCode')
+        .rejects(new Error('RPC unavailable'));
+
+      try {
+        const expanded = await expandWarpDeployConfig({
+          multiProvider,
+          warpDeployConfig: {
+            [test1.name]: {
+              type: TokenType.synthetic,
+              name: 'Test',
+              symbol: 'TEST',
+              decimals: 18,
+              owner,
+              mailbox: '0x4444444444444444444444444444444444444444',
+            },
+          },
+          referenceWarpDeployConfig: {
+            [test1.name]: {
+              type: TokenType.synthetic,
+              name: 'Test',
+              symbol: 'TEST',
+              decimals: 18,
+              owner,
+              mailbox: '0x4444444444444444444444444444444444444444',
+            },
+            [test2.name]: {
+              type: TokenType.synthetic,
+              name: 'Test',
+              symbol: 'TEST',
+              decimals: 18,
+              owner,
+            },
+          },
+          deployedRoutersAddresses: {
+            [test1.name]: activeRouter,
+            [test2.name]: skippedRouter,
+          },
+        });
+
+        expect(activeGetCode.calledOnce).to.equal(true);
+        expect(skippedGetCode.notCalled).to.equal(true);
+        expect(expanded[test1.name].remoteRouters).to.have.property(
+          String(test2.domainId),
+        );
+      } finally {
+        activeGetCode.restore();
+        activeGetStorageAt.restore();
+        skippedGetCode.restore();
+      }
+    });
+
     it('defaults an omitted hook to the completed hybrid ISM node', async () => {
       const owner = '0x1111111111111111111111111111111111111111';
       const router = '0x2222222222222222222222222222222222222222';

--- a/typescript/sdk/src/token/configUtils.test.ts
+++ b/typescript/sdk/src/token/configUtils.test.ts
@@ -159,7 +159,8 @@ describe('configUtils', () => {
       );
     });
 
-    it('does not probe deployed routers omitted from the target config', async () => {
+    it('does not probe deployed routers omitted from the target config', async function () {
+      this.timeout(12_000);
       const owner = '0x1111111111111111111111111111111111111111';
       const activeRouter = '0x2222222222222222222222222222222222222222';
       const skippedRouter = '0x3333333333333333333333333333333333333333';

--- a/typescript/sdk/src/token/configUtils.ts
+++ b/typescript/sdk/src/token/configUtils.ts
@@ -418,6 +418,7 @@ export function completeHybridHookNodesFromIsm(
 export async function expandWarpDeployConfig(params: {
   multiProvider: MultiProvider;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfig;
   deployedRoutersAddresses: ChainMap<Address>;
   expandedOnChainWarpConfig?: WarpRouteDeployConfigMailboxRequired;
   validateScale?: boolean;
@@ -425,6 +426,7 @@ export async function expandWarpDeployConfig(params: {
   const {
     multiProvider,
     warpDeployConfig,
+    referenceWarpDeployConfig = warpDeployConfig,
     deployedRoutersAddresses,
     expandedOnChainWarpConfig,
     validateScale = true,
@@ -439,12 +441,15 @@ export async function expandWarpDeployConfig(params: {
   // If the token is on an EVM chain check if it is deployed as a proxy
   // to expand the proxy config too
   const isDeployedAsProxyByChain = await promiseObjAll(
-    objMap(deployedRoutersAddresses, async (chain, address) => {
+    objMap(warpDeployConfig, async (chain) => {
       if (!isEVMLike(multiProvider.getProtocol(chain))) {
         return false;
       }
 
-      return isProxy(multiProvider.getProvider(chain), address);
+      const deployedRouter = deployedRoutersAddresses[chain];
+      return deployedRouter
+        ? isProxy(multiProvider.getProvider(chain), deployedRouter)
+        : false;
     }),
   );
 
@@ -455,7 +460,7 @@ export async function expandWarpDeployConfig(params: {
           multiProvider,
           chain,
           deployedRoutersAddresses,
-          warpDeployConfig,
+          referenceWarpDeployConfig,
         );
 
       const chainConfig: WarpRouteDeployConfigMailboxRequired[string] &

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -72,6 +72,7 @@ import {
   HypTokenRouterVirtualConfig,
   OwnerStatus,
   TokenMetadata,
+  WarpRouteDeployConfig,
   WarpRouteDeployConfigMailboxRequired,
   assertTimelockConfigHasNoProxyAdminOwnerOverride,
   derivedHookAddress,
@@ -708,12 +709,16 @@ export function applyAcceptedInactiveOwnerStatus({
 export async function checkWarpRouteDeployConfig({
   multiProvider,
   warpCoreConfig,
+  referenceWarpCoreConfig = warpCoreConfig,
   warpDeployConfig,
+  referenceWarpDeployConfig = warpDeployConfig,
   acceptedInactiveOwners,
 }: {
   multiProvider: MultiProvider;
   warpCoreConfig: WarpCoreConfig;
+  referenceWarpCoreConfig?: WarpCoreConfig;
   warpDeployConfig: WarpRouteDeployConfigMailboxRequired;
+  referenceWarpDeployConfig?: WarpRouteDeployConfig;
   // Owners the caller has decided to accept in an Inactive on-chain state
   // (e.g. a nonce-less governance ICA on Tron/AltVM that a multisig controls).
   // The caller owns the decision — including deriving and verifying the ICA and
@@ -746,7 +751,7 @@ export async function checkWarpRouteDeployConfig({
     'Warp route check requires at least one EVM or supported altVM chain in the selected route config',
   );
   const deployedRoutersAddresses = objFilter(
-    getRouterAddressesFromWarpCoreConfig(warpCoreConfig),
+    getRouterAddressesFromWarpCoreConfig(referenceWarpCoreConfig),
     (chain, _address): _address is Address =>
       multiProvider.tryGetProtocol(chain) !== null,
   );
@@ -827,6 +832,7 @@ export async function checkWarpRouteDeployConfig({
   const expandedWarpDeployConfig = await expandWarpDeployConfig({
     multiProvider,
     warpDeployConfig: metadataSeededWarpDeployConfig,
+    referenceWarpDeployConfig,
     deployedRoutersAddresses,
     expandedOnChainWarpConfig,
     validateScale: false,


### PR DESCRIPTION
## Description

- add `--skip-chains` to warp read, deploy, apply, and check
- separate active execution config from normalized full-route reference config
- avoid resolving owner/mailbox defaults for skipped route legs
- preserve skipped deploy artifacts and expected enrollments during partial operations
- keep regular and combined CROSS checks scoped to healthy chains without hiding registry drift
- reject `--skip-chains` during route extension before any deployment to avoid asymmetric enrollments

## Drive-by changes

- type the chain-resolver argument contract and validate command-specific fields
- make SDK/CLI skip-chain behavior visible in logs and release metadata

## Related issues

N/A

## Backward compatibility

Backward compatible. CLI flags and SDK reference-config parameters are additive. Existing commands without `--skip-chains` retain full-route behavior.

## Testing

- rebased onto `main` at `1ca32541af1994edc68ea4483f70ed90620bc0ba`
- Node `26.6.0`: dependency build through `@hyperlane-xyz/cli` passed after Soldeer and Tron artifact hydration
- SDK and CLI TypeScript builds passed
- SDK and CLI lint passed
- focused SDK suites: 137 passing
- focused CLI suites: 160 passing
- `git diff --check` passed
- commit hooks passed: gitleaks, oxlint, oxfmt
