### PR TITLE
chore(infra): skip REZ and SUPR standard-xERC20 routes in check-warp-deploy

### DIFF
--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -58,10 +58,11 @@ const ROUTES_TO_SKIP: string[] = [
   // Staging route: not auto-skipped by isStagingOrTestRoute since the STAGE
   // marker is in the symbol before the first `/`, not a chain segment.
   WarpRouteIds.EclipseUSDCSTAGE,
-  // Standard xERC20 route: registry config omits warpRouteLimits, so the
+  // Standard xERC20 routes: registry config omits warpRouteLimits, so the
   // post-#9329 reader flags a false ConfigMismatch on the real on-chain
   // limits. Excluded until ENG-4414 lands (backfill limits or ignore missing).
   WarpRouteIds.BaseEthereumREZ,
+  'SUPR/base-ethereum-ink-optimism-superseed',
 ];
 
 // Name segments that mark a warp route as a non-production (staging/test)

--- a/typescript/infra/scripts/check/check-warp-deploy.ts
+++ b/typescript/infra/scripts/check/check-warp-deploy.ts
@@ -58,6 +58,10 @@ const ROUTES_TO_SKIP: string[] = [
   // Staging route: not auto-skipped by isStagingOrTestRoute since the STAGE
   // marker is in the symbol before the first `/`, not a chain segment.
   WarpRouteIds.EclipseUSDCSTAGE,
+  // Standard xERC20 route: registry config omits warpRouteLimits, so the
+  // post-#9329 reader flags a false ConfigMismatch on the real on-chain
+  // limits. Excluded until ENG-4414 lands (backfill limits or ignore missing).
+  WarpRouteIds.BaseEthereumREZ,
 ];
 
 // Name segments that mark a warp route as a non-production (staging/test)


### PR DESCRIPTION
Skip `REZ/base-ethereum-unichain` and `SUPR/base-ethereum-ink-optimism-superseed` in the check-warp-deploy cron to stop daily false ConfigMismatch alerts.

Both are standard xERC20 routes whose registry configs omit `warpRouteLimits`. SDK #9329 switched the reader to read real on-chain standard limits, so the checker now diffs actual limits against empty expected and fires ConfigMismatch. On-chain limits are legitimate; no funds or security impact.

Requested by Nam. Temporary skip until ENG-4414 lands (backfill registry `warpRouteLimits` or have the checker treat missing limits as unmonitored).

https://linear.app/hyperlane-xyz/issue/ENG-4414