### PR TITLE
feat(scraper-proxy): support query cursors

### DIFF
--- a/.changeset/scraper-proxy-query-cursors.md
+++ b/.changeset/scraper-proxy-query-cursors.md
@@ -1,5 +1,8 @@
 ---
 '@hyperlane-xyz/scraper-proxy': minor
+'@hyperlane-xyz/utils': patch
 ---
 
-Added cursor pagination to scraper message queries, with validation that cursors use a single column matching the requested sort order.
+Added cursor pagination to scraper message queries. Message cursors must contain exactly one non-null `id`; `order_by` may be omitted, in which case the cursor direction determines the ordering.
+
+Added lightweight error, set, and validation utility subpath exports.

--- a/.changeset/scraper-proxy-query-cursors.md
+++ b/.changeset/scraper-proxy-query-cursors.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/scraper-proxy': minor
+---
+
+Added cursor pagination to scraper message queries, with validation that cursors use a single column matching the requested sort order.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2249,6 +2249,9 @@ importers:
 
   typescript/scraper-proxy:
     dependencies:
+      '@hyperlane-xyz/utils':
+        specifier: workspace:^
+        version: link:../utils
       '@apollo/server':
         specifier: 'catalog:'
         version: 5.5.1(graphql@16.14.2)(supports-color@10.2.2)

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
-  scraperProxy: '33ff5e4-20260821-113547',
+  scraperProxy: '220f01c-20260827-145329',
   feeQuoting: '12d899d-20260325-184337',
 };
 

--- a/typescript/scraper-proxy/package.json
+++ b/typescript/scraper-proxy/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@apollo/server": "catalog:",
     "@as-integrations/express5": "catalog:",
+    "@hyperlane-xyz/utils": "workspace:^",
     "@nestjs/apollo": "catalog:",
     "@nestjs/common": "catalog:",
     "@nestjs/core": "catalog:",

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -4,6 +4,7 @@ import {
   type OnModuleDestroy,
   type OnModuleInit,
 } from '@nestjs/common';
+import { formatError } from '@hyperlane-xyz/utils';
 import pg from 'pg';
 
 import { config } from '../config.js';
@@ -66,7 +67,7 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
       result.status === 'rejected' ? [result.reason] : [],
     );
     failures.forEach((error) =>
-      this.logger.error(`database shutdown failed: ${errorMessage(error)}`),
+      this.logger.error(`database shutdown failed: ${formatError(error)}`),
     );
     if (failures.length) throw failures[0];
   }
@@ -180,7 +181,7 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
       const duration = Date.now() - started;
       this.record(duration, 0, true);
       this.logger.debug(
-        `query id=${id} failed ${duration}ms error=${error instanceof Error ? error.message : String(error)}`,
+        `query id=${id} failed ${duration}ms error=${formatError(error)}`,
       );
       throw error;
     }
@@ -210,10 +211,6 @@ function poolMetrics(pool?: pg.Pool): DatabaseMetricsSnapshot['pools']['main'] {
     total: pool?.totalCount ?? 0,
     waiting: pool?.waitingCount ?? 0,
   };
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function databaseOptions(connectionString: string): pg.ClientConfig {

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -4,7 +4,7 @@ import {
   type OnModuleDestroy,
   type OnModuleInit,
 } from '@nestjs/common';
-import { formatError } from '@hyperlane-xyz/utils';
+import { formatError } from '@hyperlane-xyz/utils/errors';
 import pg from 'pg';
 
 import { config } from '../config.js';

--- a/typescript/scraper-proxy/src/graphql/scraperdb-schema.graphql
+++ b/typescript/scraper-proxy/src/graphql/scraperdb-schema.graphql
@@ -89,6 +89,8 @@ type query_root {
     order_by: [message_view_order_by!]
     "limit the number of rows returned"
     limit: Int
+    "cursor to continue an ordered query"
+    cursor: [message_view_stream_cursor_input!]
     "skip the first n rows. Use only with order_by"
     offset: Int
     "distinct select on columns"

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -231,7 +231,7 @@ void it('enforces the historical replay row budget', async () => {
     }
   });
   const message = await waitFor(messages, 'error');
-  assert.match(String(message.error), /row limit exceeded/);
+  assert.equal(message.error, 'Failed to catch up merkle_tree_insertion');
   socket.close();
   await new Promise<void>((resolve) => socket.once('close', resolve));
 });
@@ -472,7 +472,7 @@ void it('enforces the catch-up deadline while pending rows replenish', async (co
     completions.shift()?.();
 
     const error = await waitFor(messages, 'error');
-    assert.match(String(error.error), /time limit exceeded \(10ms\)/);
+    assert.equal(error.error, 'Failed to catch up merkle_tree_insertion');
     assert.deepEqual(eventSequences(messages), ['0', '1', '2']);
   } finally {
     socket.close();
@@ -505,7 +505,7 @@ void it('rejects an empty historical cursor instead of reporting caught up', asy
     }
   });
   const message = await waitFor(messages, 'error');
-  assert.match(String(message.error), /No merkle_tree_insertion history/);
+  assert.equal(message.error, 'Failed to catch up merkle_tree_insertion');
   assert.equal(
     messages.some(({ type }) => type === 'caught_up'),
     false,

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -3,7 +3,7 @@ import { isIP } from 'node:net';
 import type { Duplex } from 'node:stream';
 
 import { Logger } from '@nestjs/common';
-import { formatError } from '@hyperlane-xyz/utils';
+import { formatError } from '@hyperlane-xyz/utils/errors';
 import { WebSocket, WebSocketServer } from 'ws';
 
 import { config } from '../config.js';

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -536,10 +536,7 @@ export class EventWebSocketServer {
       this.logger.warn(
         `websocket catch-up failed eventType=${request.eventType}: ${reason}`,
       );
-      this.sendError(
-        socket,
-        `Failed to catch up ${request.eventType}: ${reason}`,
-      );
+      this.sendError(socket, `Failed to catch up ${request.eventType}`);
     } finally {
       this.catchUps--;
     }

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -3,6 +3,7 @@ import { isIP } from 'node:net';
 import type { Duplex } from 'node:stream';
 
 import { Logger } from '@nestjs/common';
+import { formatError } from '@hyperlane-xyz/utils';
 import { WebSocket, WebSocketServer } from 'ws';
 
 import { config } from '../config.js';
@@ -417,7 +418,7 @@ export class EventWebSocketServer {
     try {
       message = parseClientMessage(raw);
     } catch (error) {
-      this.sendError(socket, errorMessage(error));
+      this.sendError(socket, formatError(error));
       return;
     }
     if (message.type === 'ping') {
@@ -531,7 +532,7 @@ export class EventWebSocketServer {
       }
       websocketCatchUps.inc({ outcome: 'failure' });
       client.subscriptions.delete(request.eventType);
-      const reason = errorMessage(error);
+      const reason = formatError(error);
       this.logger.warn(
         `websocket catch-up failed eventType=${request.eventType}: ${reason}`,
       );
@@ -735,7 +736,7 @@ export class EventWebSocketServer {
       );
       this.listenerReady = true;
     } catch (error) {
-      this.logger.error(`database listener failed: ${errorMessage(error)}`);
+      this.logger.error(`database listener failed: ${formatError(error)}`);
       this.reconnectListener();
     }
   }
@@ -760,7 +761,7 @@ export class EventWebSocketServer {
       }
     } catch (error) {
       this.logger.warn(
-        `skipping invalid database notification: ${errorMessage(error)}`,
+        `skipping invalid database notification: ${formatError(error)}`,
       );
       return;
     }
@@ -829,7 +830,7 @@ export class EventWebSocketServer {
         returned.add(parseId(notification_id).toString());
       } catch (error) {
         this.logger.warn(
-          `invalid notified ${eventType} row ID: ${errorMessage(error)}`,
+          `invalid notified ${eventType} row ID: ${formatError(error)}`,
         );
       }
     }
@@ -850,7 +851,7 @@ export class EventWebSocketServer {
         return [row];
       } catch (error) {
         this.logger.warn(
-          `skipping invalid notified ${eventType} row: ${errorMessage(error)}`,
+          `skipping invalid notified ${eventType} row: ${formatError(error)}`,
         );
         return [];
       }
@@ -900,7 +901,7 @@ export class EventWebSocketServer {
   }
 
   private fail(error: unknown): void {
-    this.logger.error(`event stream failed: ${errorMessage(error)}`);
+    this.logger.error(`event stream failed: ${formatError(error)}`);
     this.closeClients('Event stream read failed');
   }
 
@@ -981,7 +982,7 @@ export class EventWebSocketServer {
       this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
       completed?.(false);
       websocketSendFailures.inc({ reason: 'send_error' });
-      this.failSocket(socket, `send failed: ${errorMessage(error)}`);
+      this.failSocket(socket, `send failed: ${formatError(error)}`);
       return false;
     }
     return true;
@@ -1114,10 +1115,6 @@ function compareRows(eventType: EventType, a: Row, b: Row): number {
     : left < right
       ? -1
       : 1;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function clientIp(request: IncomingMessage): string | undefined {

--- a/typescript/scraper-proxy/src/live/protocol.ts
+++ b/typescript/scraper-proxy/src/live/protocol.ts
@@ -1,4 +1,4 @@
-import { setEquality } from '@hyperlane-xyz/utils';
+import { setEquality } from '@hyperlane-xyz/utils/sets';
 
 export const EVENT_TYPES = [
   'dispatch',

--- a/typescript/scraper-proxy/src/live/protocol.ts
+++ b/typescript/scraper-proxy/src/live/protocol.ts
@@ -1,3 +1,5 @@
+import { setEquality } from '@hyperlane-xyz/utils';
+
 export const EVENT_TYPES = [
   'dispatch',
   'delivery',
@@ -165,11 +167,7 @@ function parseStream(value: unknown): StreamRequest {
     if (new Set(keys).size < keys.length)
       throw new Error('Duplicate sequence cursor');
     const cursorDomains = new Set(cursors.map(({ domain }) => domain));
-    if (
-      domains &&
-      (domains.size !== cursorDomains.size ||
-        [...domains].some((domain) => !cursorDomains.has(domain)))
-    ) {
+    if (domains && !setEquality(domains, cursorDomains)) {
       throw new Error('domains must exactly match cursor domains');
     }
     domains ??= cursorDomains;

--- a/typescript/scraper-proxy/src/main.ts
+++ b/typescript/scraper-proxy/src/main.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { formatError } from '@hyperlane-xyz/utils';
+import { formatError } from '@hyperlane-xyz/utils/errors';
 
 import { AppModule } from './module.js';
 import { config } from './config.js';

--- a/typescript/scraper-proxy/src/main.ts
+++ b/typescript/scraper-proxy/src/main.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { formatError } from '@hyperlane-xyz/utils';
 
 import { AppModule } from './module.js';
 import { config } from './config.js';
@@ -40,9 +41,7 @@ async function bootstrap(): Promise<void> {
       if (stopping) return;
       stopping = true;
       void stop().catch((error: unknown) => {
-        logger.error(
-          `shutdown failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        logger.error(`shutdown failed: ${formatError(error)}`);
         process.exitCode = 1;
       });
     });

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.test.ts
@@ -174,6 +174,40 @@ void it('ignores variable-like text inside string literals', async () => {
   await server.stop();
 });
 
+void it('preserves special variable names in cache keys', async () => {
+  let calls = 0;
+  const server = new ApolloServer({
+    plugins: plugins(),
+    resolvers: {
+      Query: {
+        value: (_parent: unknown, { key }: { key: number }) => {
+          calls++;
+          return key;
+        },
+      },
+    },
+    typeDefs: `
+      directive @cached(ttl: Int, refresh: Boolean) on QUERY
+      type Query { value(key: Int!): Int! }
+    `,
+  });
+  await server.start();
+  const query =
+    'query($__proto__: Int!) @cached(ttl: 10) { value(key: $__proto__) }';
+  const variables = (key: number): Record<string, unknown> =>
+    JSON.parse(`{"__proto__":${key}}`);
+  assert.equal(
+    value(await server.executeOperation({ query, variables: variables(1) })),
+    1,
+  );
+  assert.equal(
+    value(await server.executeOperation({ query, variables: variables(2) })),
+    2,
+  );
+  assert.equal(calls, 2);
+  await server.stop();
+});
+
 function cacheServer(
   resolver: () => unknown,
   returnType = 'String!',

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
@@ -3,7 +3,7 @@ import {
   type ApolloServerPlugin,
   type GraphQLResponse,
 } from '@apollo/server';
-import { assert, sortObjectKeys } from '@hyperlane-xyz/utils';
+import { assert } from '@hyperlane-xyz/utils';
 import { createHash } from 'node:crypto';
 import { parse, print, visit, type DocumentNode } from 'graphql';
 
@@ -128,6 +128,16 @@ function cacheKey(
     .update('\0')
     .update(serializedVariables)
     .digest('hex');
+}
+
+function sortObjectKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortObjectKeys);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, sortObjectKeys(value[key])]),
+  );
 }
 
 function cachedResponse(entry: Entry): GraphQLResponse {

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
@@ -3,6 +3,7 @@ import {
   type ApolloServerPlugin,
   type GraphQLResponse,
 } from '@apollo/server';
+import { assert, sortObjectKeys } from '@hyperlane-xyz/utils';
 import { createHash } from 'node:crypto';
 import { parse, print, visit, type DocumentNode } from 'graphql';
 
@@ -118,22 +119,15 @@ function cacheKey(
   const dataVariables = Object.fromEntries(
     Object.entries(variables).filter(([name]) => usedVariables.has(name)),
   );
+  const serializedVariables = JSON.stringify(sortObjectKeys(dataVariables));
+  assert(serializedVariables, 'Failed to serialize GraphQL variables');
   return createHash('sha256')
     .update(operation ?? '')
     .update('\0')
     .update(query)
     .update('\0')
-    .update(stableJson(dataVariables))
+    .update(serializedVariables)
     .digest('hex');
-}
-
-function stableJson(value: unknown): string {
-  if (!value || typeof value !== 'object') return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
-  return `{${Object.entries(value)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
-    .join(',')}}`;
 }
 
 function cachedResponse(entry: Entry): GraphQLResponse {

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
@@ -3,7 +3,7 @@ import {
   type ApolloServerPlugin,
   type GraphQLResponse,
 } from '@apollo/server';
-import { assert } from '@hyperlane-xyz/utils';
+import { assert } from '@hyperlane-xyz/utils/validation';
 import { createHash } from 'node:crypto';
 import { parse, print, visit, type DocumentNode } from 'graphql';
 

--- a/typescript/scraper-proxy/src/scraperdb/schema.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/schema.test.ts
@@ -83,3 +83,20 @@ void it('accepts literal and variable null optional arguments', async () => {
   }
   await server.stop();
 });
+
+void it('accepts a cursor on message queries', () => {
+  const errors = validate(
+    schema,
+    parse(`
+      query Messages($cursor: bigint!) {
+        message_view(
+          cursor: [{initial_value: {id: $cursor}, ordering: DESC}]
+          order_by: {id: desc}
+          limit: 50
+        ) { id }
+      }
+    `),
+  );
+
+  assert.deepEqual(errors, []);
+});

--- a/typescript/scraper-proxy/src/scraperdb/schema.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/schema.test.ts
@@ -100,3 +100,29 @@ void it('accepts a cursor on message queries', () => {
 
   assert.deepEqual(errors, []);
 });
+
+void it('rejects an empty message cursor through the resolver', async () => {
+  const server = new ApolloServer({
+    resolvers: {
+      query_root: {
+        message_view: (_parent: unknown, args: SelectArgs) => {
+          buildSelect('message_view', args);
+          return [];
+        },
+      },
+    },
+    typeDefs: sanitized,
+  });
+  const response = await server.executeOperation({
+    query: '{ message_view(cursor: [{initial_value: {}}]) { id } }',
+  });
+
+  assert.equal(response.body.kind, 'single');
+  if (response.body.kind === 'single') {
+    assert.match(
+      response.body.singleResult.errors?.[0]?.message ?? '',
+      /must contain one column/,
+    );
+  }
+  await server.stop();
+});

--- a/typescript/scraper-proxy/src/scraperdb/sql.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.test.ts
@@ -78,6 +78,17 @@ void describe('scraper database SQL', () => {
         order_by: [{ origin_domain: 'asc' }, { nonce: 'desc' }],
       }),
     );
+    for (const order_by of [undefined, { id: null }]) {
+      assert.throws(
+        () =>
+          buildSelect('message_view', {
+            cursor: [{ initial_value: { id: 1 } }],
+            distinct_on: ['origin_domain'],
+            order_by,
+          }),
+        /leftmost order_by/,
+      );
+    }
   });
 
   void it('builds primary-key queries and rejects unsafe inputs', () => {

--- a/typescript/scraper-proxy/src/scraperdb/sql.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.test.ts
@@ -89,6 +89,23 @@ void describe('scraper database SQL', () => {
     assert.throws(() => buildSelect('domain', { limit: 501 }), /maximum/);
     assert.throws(
       () =>
+        buildSelect('domain', {
+          cursor: [{ initial_value: { id: 1 }, ordering: 'DESC' }],
+          order_by: { id: 'asc' },
+        }),
+      /must match order_by/,
+    );
+    assert.throws(
+      () =>
+        buildSelect('message_view', {
+          cursor: [
+            { initial_value: { send_occurred_at: '2026-01-01', id: 1 } },
+          ],
+        }),
+      /cursor exceeds maximum of 1 columns/,
+    );
+    assert.throws(
+      () =>
         buildSelect('domain', { where: { id: { _in: Array(201).fill(1) } } }),
       /maximum/,
     );

--- a/typescript/scraper-proxy/src/scraperdb/sql.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.test.ts
@@ -89,11 +89,23 @@ void describe('scraper database SQL', () => {
     assert.throws(() => buildSelect('domain', { limit: 501 }), /maximum/);
     assert.throws(
       () =>
-        buildSelect('domain', {
+        buildSelect('message_view', {
           cursor: [{ initial_value: { id: 1 }, ordering: 'DESC' }],
           order_by: { id: 'asc' },
         }),
       /must match order_by/,
+    );
+    assert.doesNotThrow(() =>
+      buildSelect('message_view', {
+        cursor: [{ initial_value: { id: 1 }, ordering: 'ASC' }],
+        order_by: { id: 'asc' },
+      }),
+    );
+    assert.doesNotThrow(() =>
+      buildSelect('message_view', {
+        cursor: [{ initial_value: { id: 1 }, ordering: 'DESC' }],
+        order_by: { id: 'desc' },
+      }),
     );
     assert.throws(
       () =>
@@ -102,7 +114,33 @@ void describe('scraper database SQL', () => {
             { initial_value: { send_occurred_at: '2026-01-01', id: 1 } },
           ],
         }),
-      /cursor exceeds maximum of 1 columns/,
+      /must contain one column/,
+    );
+    assert.throws(
+      () =>
+        buildSelect('message_view', {
+          cursor: [{ initial_value: {} }],
+        }),
+      /must contain one column/,
+    );
+    assert.throws(
+      () =>
+        buildSelect('message_view', {
+          cursor: [{ initial_value: { origin_domain: 'ethereum' } }],
+        }),
+      /cursor column must be id/,
+    );
+    assert.throws(
+      () =>
+        buildSelect('message_view', {
+          cursor: [{ initial_value: { id: null } }],
+        }),
+      /cursor value must be non-null/,
+    );
+    assert.doesNotThrow(() =>
+      buildSelect('domain', {
+        cursor: [{ initial_value: { id: 1, name: 'ethereum' } }],
+      }),
     );
     assert.throws(
       () =>

--- a/typescript/scraper-proxy/src/scraperdb/sql.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.ts
@@ -39,7 +39,7 @@ export interface SelectArgs {
 const MAX = {
   boolDepth: 8,
   boolPredicates: 100,
-  cursorColumns: 3,
+  cursorColumns: 1,
   distinctColumns: 3,
   inItems: 200,
   limit: 500,
@@ -297,6 +297,7 @@ function validate(args: SelectArgs): void {
     MAX.orderColumns,
   );
   validateDistinctOrder(args.distinct_on, orders);
+  validateCursorOrder(args.cursor, orders);
   boundedColumns(
     args.cursor?.reduce(
       (total, item) => total + Object.keys(item.initial_value).length,
@@ -307,6 +308,26 @@ function validate(args: SelectArgs): void {
   );
   const state = { predicates: 0 };
   validateWhere(args.where, 0, state);
+}
+
+function validateCursorOrder(
+  cursors: Cursor[] | undefined,
+  orders: Order[],
+): void {
+  if (!cursors?.length || !orders.length) return;
+  const cursor = cursors[0];
+  const cursorColumn = Object.keys(cursor.initial_value)[0];
+  const orderColumns = orders
+    .flatMap(Object.entries)
+    .filter((entry) => entry[1] != null);
+  const [orderColumn, orderDirection] = orderColumns[0] ?? [];
+  if (
+    orderColumns.length !== 1 ||
+    cursorColumn !== orderColumn ||
+    (cursor.ordering === 'DESC') !== orderDirection?.startsWith('desc')
+  ) {
+    throw new Error('cursor columns and directions must match order_by');
+  }
 }
 
 function validateDistinctOrder(

--- a/typescript/scraper-proxy/src/scraperdb/sql.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.ts
@@ -1,4 +1,4 @@
-import { assert } from '@hyperlane-xyz/utils';
+import { assert } from '@hyperlane-xyz/utils/validation';
 
 import {
   assertColumn,

--- a/typescript/scraper-proxy/src/scraperdb/sql.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.ts
@@ -287,17 +287,17 @@ function validate(table: TableName, args: SelectArgs): void {
     : args.order_by
       ? [args.order_by]
       : [];
-  boundedColumns(
-    orders.reduce(
-      (total, item) =>
-        total + Object.values(item).filter((value) => value != null).length,
-      0,
-    ),
-    'order_by',
-    MAX.orderColumns,
+  const orderColumns = orders
+    .flatMap(Object.entries)
+    .filter((entry): entry is [string, Direction] => entry[1] != null);
+  boundedColumns(orderColumns.length, 'order_by', MAX.orderColumns);
+  validateCursor(table, args.cursor, orderColumns);
+  validateDistinctOrder(
+    args.distinct_on,
+    orderColumns.length
+      ? orderColumns.map(([column]) => column)
+      : cursorColumns(args.cursor),
   );
-  validateDistinctOrder(args.distinct_on, orders);
-  validateCursor(table, args.cursor, orders);
   const state = { predicates: 0 };
   validateWhere(args.where, 0, state);
 }
@@ -305,7 +305,7 @@ function validate(table: TableName, args: SelectArgs): void {
 function validateCursor(
   table: TableName,
   cursors: Cursor[] | undefined,
-  orders: Order[],
+  orderColumns: [string, Direction][],
 ): void {
   const cursorColumns =
     cursors?.reduce(
@@ -323,11 +323,8 @@ function validateCursor(
   const [cursorColumn, cursorValue] = Object.entries(cursor.initial_value)[0];
   assert(cursorColumn === 'id', 'message_view cursor column must be id');
   assert(cursorValue != null, 'message_view cursor value must be non-null');
-  if (!orders.length) return;
+  if (!orderColumns.length) return;
 
-  const orderColumns = orders
-    .flatMap(Object.entries)
-    .filter((entry) => entry[1] != null);
   const [orderColumn, orderDirection] = orderColumns[0] ?? [];
   assert(
     orderColumns.length === 1 &&
@@ -339,18 +336,17 @@ function validateCursor(
 
 function validateDistinctOrder(
   distinctColumns: string[] | null | undefined,
-  orders: Order[],
+  orderColumns: string[],
 ): void {
-  if (!distinctColumns?.length || !orders.length) return;
-  const orderColumns = orders.flatMap((order) =>
-    Object.entries(order).flatMap(([column, direction]) =>
-      direction == null ? [] : [column],
-    ),
-  );
+  if (!distinctColumns?.length || !orderColumns.length) return;
   assert(
     !distinctColumns.some((column, index) => orderColumns[index] !== column),
     'distinct_on columns must match the leftmost order_by columns',
   );
+}
+
+function cursorColumns(cursors: Cursor[] | undefined): string[] {
+  return (cursors ?? []).flatMap((cursor) => Object.keys(cursor.initial_value));
 }
 
 function boundedInteger(

--- a/typescript/scraper-proxy/src/scraperdb/sql.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.ts
@@ -1,3 +1,5 @@
+import { assert } from '@hyperlane-xyz/utils';
+
 import {
   assertColumn,
   quoteIdentifier as q,
@@ -39,7 +41,7 @@ export interface SelectArgs {
 const MAX = {
   boolDepth: 8,
   boolPredicates: 100,
-  cursorColumns: 1,
+  cursorColumns: 3,
   distinctColumns: 3,
   inItems: 200,
   limit: 500,
@@ -48,7 +50,7 @@ const MAX = {
 };
 
 export function buildSelect(table: TableName, args: SelectArgs = {}): Sql {
-  validate(args);
+  validate(table, args);
   const values: unknown[] = [];
   const filters = [
     where(table, args.where, values),
@@ -65,7 +67,7 @@ export function buildCount(
   args: SelectArgs = {},
   count: CountArgs = {},
 ): Sql {
-  validate(args);
+  validate(table, args);
   const countColumns = [...new Set(count.columns ?? [])];
   countColumns.forEach((column) => assertColumn(table, column));
   const values: unknown[] = [];
@@ -277,7 +279,7 @@ function bind(value: unknown, values: unknown[]): string {
   return `$${values.length}`;
 }
 
-function validate(args: SelectArgs): void {
+function validate(table: TableName, args: SelectArgs): void {
   boundedInteger(args.limit, 'limit', MAX.limit);
   boundedInteger(args.batch_size, 'batch_size', MAX.limit);
   boundedInteger(args.offset, 'offset', MAX.offset);
@@ -297,37 +299,44 @@ function validate(args: SelectArgs): void {
     MAX.orderColumns,
   );
   validateDistinctOrder(args.distinct_on, orders);
-  validateCursorOrder(args.cursor, orders);
-  boundedColumns(
-    args.cursor?.reduce(
-      (total, item) => total + Object.keys(item.initial_value).length,
-      0,
-    ),
-    'cursor',
-    MAX.cursorColumns,
-  );
+  validateCursor(table, args.cursor, orders);
   const state = { predicates: 0 };
   validateWhere(args.where, 0, state);
 }
 
-function validateCursorOrder(
+function validateCursor(
+  table: TableName,
   cursors: Cursor[] | undefined,
   orders: Order[],
 ): void {
-  if (!cursors?.length || !orders.length) return;
+  const cursorColumns =
+    cursors?.reduce(
+      (total, item) => total + Object.keys(item.initial_value).length,
+      0,
+    ) ?? 0;
+  boundedColumns(cursorColumns, 'cursor', MAX.cursorColumns);
+  if (!cursors?.length || table !== 'message_view') return;
+
+  assert(
+    cursors.length === 1 && cursorColumns === 1,
+    'message_view cursor must contain one column',
+  );
   const cursor = cursors[0];
-  const cursorColumn = Object.keys(cursor.initial_value)[0];
+  const [cursorColumn, cursorValue] = Object.entries(cursor.initial_value)[0];
+  assert(cursorColumn === 'id', 'message_view cursor column must be id');
+  assert(cursorValue != null, 'message_view cursor value must be non-null');
+  if (!orders.length) return;
+
   const orderColumns = orders
     .flatMap(Object.entries)
     .filter((entry) => entry[1] != null);
   const [orderColumn, orderDirection] = orderColumns[0] ?? [];
-  if (
-    orderColumns.length !== 1 ||
-    cursorColumn !== orderColumn ||
-    (cursor.ordering === 'DESC') !== orderDirection?.startsWith('desc')
-  ) {
-    throw new Error('cursor columns and directions must match order_by');
-  }
+  assert(
+    orderColumns.length === 1 &&
+      cursorColumn === orderColumn &&
+      (cursor.ordering === 'DESC') === orderDirection?.startsWith('desc'),
+    'cursor columns and directions must match order_by',
+  );
 }
 
 function validateDistinctOrder(

--- a/typescript/scraper-proxy/src/scraperdb/sql.ts
+++ b/typescript/scraper-proxy/src/scraperdb/sql.ts
@@ -106,8 +106,7 @@ export function buildByPk(
   selected?: string[],
 ): Sql {
   const primaryKey = tables[table].primaryKey;
-  if (!primaryKey)
-    throw new Error(`${table} does not expose a primary-key query`);
+  assert(primaryKey, `${table} does not expose a primary-key query`);
   return {
     sql: `SELECT ${columns(table, selected)} FROM ${q(table)} WHERE ${q(primaryKey)} = $1 LIMIT 1`,
     values: [id],
@@ -187,8 +186,7 @@ function comparison(
   if (value === null || value === undefined) return '';
   if (operator === '_is_null') return `${column} IS ${value ? '' : 'NOT '}NULL`;
   const sqlOperator = OPERATORS[operator];
-  if (!sqlOperator)
-    throw new Error(`Unsupported comparison operator ${operator}`);
+  assert(sqlOperator, `Unsupported comparison operator ${operator}`);
   if (operator === '_in' || operator === '_nin') {
     const items = Array.isArray(value) ? value : [];
     if (!items.length) return operator === '_in' ? 'FALSE' : 'TRUE';
@@ -349,11 +347,10 @@ function validateDistinctOrder(
       direction == null ? [] : [column],
     ),
   );
-  if (distinctColumns.some((column, index) => orderColumns[index] !== column)) {
-    throw new Error(
-      'distinct_on columns must match the leftmost order_by columns',
-    );
-  }
+  assert(
+    !distinctColumns.some((column, index) => orderColumns[index] !== column),
+    'distinct_on columns must match the leftmost order_by columns',
+  );
 }
 
 function boundedInteger(
@@ -362,10 +359,11 @@ function boundedInteger(
   max: number,
 ): void {
   if (value == null) return;
-  if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`${name} must be a non-negative integer`);
-  }
-  if (value > max) throw new Error(`${name} exceeds maximum of ${max}`);
+  assert(
+    Number.isInteger(value) && value >= 0,
+    `${name} must be a non-negative integer`,
+  );
+  assert(value <= max, `${name} exceeds maximum of ${max}`);
 }
 
 function boundedColumns(
@@ -373,8 +371,7 @@ function boundedColumns(
   name: string,
   max: number,
 ): void {
-  if (value && value > max)
-    throw new Error(`${name} exceeds maximum of ${max} columns`);
+  assert(!value || value <= max, `${name} exceeds maximum of ${max} columns`);
 }
 
 function validateWhere(
@@ -383,8 +380,10 @@ function validateWhere(
   state: { predicates: number },
 ): void {
   if (!value || typeof value !== 'object') return;
-  if (depth > MAX.boolDepth)
-    throw new Error(`where exceeds maximum depth of ${MAX.boolDepth}`);
+  assert(
+    depth <= MAX.boolDepth,
+    `where exceeds maximum depth of ${MAX.boolDepth}`,
+  );
   for (const [key, child] of Object.entries(value)) {
     if (key === '_and' || key === '_or') {
       const children = Array.isArray(child) ? child : [child];
@@ -397,15 +396,12 @@ function validateWhere(
       addPredicates(state, 1);
       if (!child || typeof child !== 'object') continue;
       for (const [operator, items] of Object.entries(child)) {
-        if (
-          (operator === '_in' || operator === '_nin') &&
-          Array.isArray(items) &&
-          items.length > MAX.inItems
-        ) {
-          throw new Error(
-            `${operator} exceeds maximum of ${MAX.inItems} items`,
-          );
-        }
+        assert(
+          (operator !== '_in' && operator !== '_nin') ||
+            !Array.isArray(items) ||
+            items.length <= MAX.inItems,
+          `${operator} exceeds maximum of ${MAX.inItems} items`,
+        );
       }
     }
   }
@@ -413,9 +409,8 @@ function validateWhere(
 
 function addPredicates(state: { predicates: number }, count: number): void {
   state.predicates += count;
-  if (state.predicates > MAX.boolPredicates) {
-    throw new Error(
-      `where exceeds maximum of ${MAX.boolPredicates} predicates`,
-    );
-  }
+  assert(
+    state.predicates <= MAX.boolPredicates,
+    `where exceeds maximum of ${MAX.boolPredicates} predicates`,
+  );
 }

--- a/typescript/scraper-proxy/src/scraperdb/tables.ts
+++ b/typescript/scraper-proxy/src/scraperdb/tables.ts
@@ -1,3 +1,5 @@
+import { assert } from '@hyperlane-xyz/utils';
+
 export type TableName = 'domain' | 'message_view' | 'raw_message_dispatch';
 
 export interface TableConfig {
@@ -106,9 +108,10 @@ function table(columns: readonly string[], primaryKey?: string): TableConfig {
 }
 
 export function assertColumn(table: TableName, column: string): void {
-  if (!tables[table].columnSet.has(column)) {
-    throw new Error(`Unsupported column ${table}.${column}`);
-  }
+  assert(
+    tables[table].columnSet.has(column),
+    `Unsupported column ${table}.${column}`,
+  );
 }
 
 export function quoteIdentifier(identifier: string): string {

--- a/typescript/scraper-proxy/src/scraperdb/tables.ts
+++ b/typescript/scraper-proxy/src/scraperdb/tables.ts
@@ -1,4 +1,4 @@
-import { assert } from '@hyperlane-xyz/utils';
+import { assert } from '@hyperlane-xyz/utils/validation';
 
 export type TableName = 'domain' | 'message_view' | 'raw_message_dispatch';
 

--- a/typescript/scraper-proxy/src/scripts/debug-event-websocket.ts
+++ b/typescript/scraper-proxy/src/scripts/debug-event-websocket.ts
@@ -1,6 +1,6 @@
 import { parseArgs } from 'node:util';
 
-import { formatError } from '@hyperlane-xyz/utils';
+import { formatError } from '@hyperlane-xyz/utils/errors';
 import { WebSocket } from 'ws';
 
 import {

--- a/typescript/scraper-proxy/src/scripts/debug-event-websocket.ts
+++ b/typescript/scraper-proxy/src/scripts/debug-event-websocket.ts
@@ -1,5 +1,6 @@
 import { parseArgs } from 'node:util';
 
+import { formatError } from '@hyperlane-xyz/utils';
 import { WebSocket } from 'ws';
 
 import {
@@ -215,7 +216,7 @@ try {
   const parsed = options();
   if (parsed) run(parsed);
 } catch (error) {
-  console.error(error instanceof Error ? error.message : error);
+  console.error(formatError(error));
   console.error('\nRun with --help for usage.');
   process.exitCode = 1;
 }

--- a/typescript/utils/package.json
+++ b/typescript/utils/package.json
@@ -18,11 +18,20 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "errors": [
+        "./dist/errors.d.ts"
+      ],
       "fs": [
         "./dist/fs/index.d.ts"
       ],
       "anvil": [
         "./dist/anvil/index.d.ts"
+      ],
+      "sets": [
+        "./dist/sets.d.ts"
+      ],
+      "validation": [
+        "./dist/validation.d.ts"
       ]
     }
   },
@@ -31,9 +40,21 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "default": "./dist/errors.js"
+    },
     "./fs": {
       "types": "./dist/fs/index.d.ts",
       "default": "./dist/fs/index.js"
+    },
+    "./sets": {
+      "types": "./dist/sets.d.ts",
+      "default": "./dist/sets.js"
+    },
+    "./validation": {
+      "types": "./dist/validation.d.ts",
+      "default": "./dist/validation.js"
     }
   },
   "scripts": {

--- a/typescript/utils/src/errors.ts
+++ b/typescript/utils/src/errors.ts
@@ -1,0 +1,31 @@
+interface ErrorWithContext {
+  context?: { logs?: unknown };
+}
+
+function isErrorWithContext(error: unknown): error is Error & ErrorWithContext {
+  return error instanceof Error && 'context' in error;
+}
+
+/**
+ * Formats an error for display, including the cause chain and any Solana
+ * program logs attached to preflight failure errors.
+ */
+export function formatError(error: unknown, depth = 0): string {
+  if (!(error instanceof Error)) return String(error);
+
+  const parts: string[] = [error.message];
+
+  if (
+    isErrorWithContext(error) &&
+    Array.isArray(error.context?.logs) &&
+    error.context.logs.length > 0
+  ) {
+    parts.push(`Logs:\n  ${error.context.logs.join('\n  ')}`);
+  }
+
+  if (error.cause != null && depth < 10) {
+    parts.push(`Caused by: ${formatError(error.cause, depth + 1)}`);
+  }
+
+  return parts.join('\n');
+}

--- a/typescript/utils/src/index.ts
+++ b/typescript/utils/src/index.ts
@@ -193,9 +193,9 @@ export {
   setEquality,
   symmetricDifference,
 } from './sets.js';
+export { formatError } from './errors.js';
 export {
   errorToString,
-  formatError,
   fromHexString,
   sanitizeString,
   streamToString,

--- a/typescript/utils/src/strings.ts
+++ b/typescript/utils/src/strings.ts
@@ -1,5 +1,7 @@
 import { ensure0x, strip0x } from './addresses.js';
 
+export { formatError } from './errors.js';
+
 export function toTitleCase(str: string) {
   return str.replace(/\w\S*/g, (txt) => {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
@@ -45,39 +47,6 @@ export function errorToString(error: any, maxLength = 300) {
   const details = error.message || error.reason || error;
   if (typeof details === 'string') return trimToLength(details, maxLength);
   return trimToLength(JSON.stringify(details), maxLength);
-}
-
-interface ErrorWithContext {
-  context?: { logs?: unknown };
-}
-
-function isErrorWithContext(e: unknown): e is Error & ErrorWithContext {
-  return e instanceof Error && 'context' in e;
-}
-
-/**
- * Formats an error for display, including the cause chain and any Solana
- * program logs attached to preflight failure errors.
- */
-export function formatError(error: unknown, depth = 0): string {
-  if (!(error instanceof Error)) return String(error);
-
-  const parts: string[] = [error.message];
-
-  // SolanaError preflight failures attach { logs, unitsConsumed, ... } to context
-  if (
-    isErrorWithContext(error) &&
-    Array.isArray(error.context?.logs) &&
-    error.context.logs.length > 0
-  ) {
-    parts.push(`Logs:\n  ${error.context.logs.join('\n  ')}`);
-  }
-
-  if (error.cause != null && depth < 10) {
-    parts.push(`Caused by: ${formatError(error.cause, depth + 1)}`);
-  }
-
-  return parts.join('\n');
 }
 
 export const fromHexString = (hexstr: string) =>


### PR DESCRIPTION
### Description

Adds cursor pagination to `message_view` GraphQL queries. A message cursor must contain exactly one non-null `id`. `order_by` may be omitted; when omitted, the cursor direction determines the ordering. When provided, its single effective column and direction must match the cursor.

### Drive-by changes

- Preserves special GraphQL variable keys during cache-key canonicalization.
- Keeps nested catch-up failure details in server logs and returns a stable client-safe WebSocket error.
- Adds lightweight utils subpath exports to avoid loading the root barrel in scraper-proxy.

### Related issues

None.

### Backward compatibility

Yes. The cursor argument is optional; existing queries are unchanged.

### Testing

- `pnpm -C typescript/utils test` (353 tests)
- `pnpm -C typescript/utils lint`
- `pnpm -C typescript/utils build`
- `pnpm -C typescript/scraper-proxy test` (54 tests)
- `pnpm -C typescript/scraper-proxy lint`
- `pnpm -C typescript/scraper-proxy build`
- `pnpm exec changeset status`