### PR TITLE
feat(infra): allow overriding turnkey account in propose-warp-batch

### DIFF
--- a/typescript/infra/scripts/safes/propose-warp-batch.ts
+++ b/typescript/infra/scripts/safes/propose-warp-batch.ts
@@ -22,7 +22,10 @@ import {
   proposeSafeTransaction,
   retrySafeApi,
 } from '../../src/utils/safe.js';
-import { createTurnkeySigner } from '../../src/utils/turnkey.js';
+import {
+  createTurnkeySigner,
+  getTurnkeyEvmSignerWithAccountOverride,
+} from '../../src/utils/turnkey.js';
 import {
   ProposalResultStatus,
   computeExitCode,
@@ -211,10 +214,20 @@ async function main(): Promise<void> {
       describe:
         'Comma-separated list of chain names to limit which files are proposed',
     })
+    .option('turnkey-account-secret', {
+      type: 'string',
+      describe:
+        'GCP secret name of a Turnkey API-key (account) to authenticate the ' +
+        'signer, overriding the default EvmLegacyDeployer account. The signing ' +
+        'wallet stays the EvmLegacyDeployer key; only the authenticating ' +
+        'Turnkey user changes (e.g. haggis-turnkey-api-key for autonomous ' +
+        'Haggis-solo policy consensus).',
+    })
     .strict().argv;
 
   const { directory } = argv;
   const dryRun = argv['dry-run'];
+  const turnkeyAccountSecret = argv['turnkey-account-secret'];
   const chainFilter = argv['chain-filter']
     ? new Set(
         argv['chain-filter']
@@ -236,15 +249,28 @@ async function main(): Promise<void> {
 
   rootLogger.info(`Found ${files.length} JSON file(s) in ${directory}`);
 
-  const signer = await createTurnkeySigner(
-    ENVIRONMENT,
-    TurnkeyRole.EvmLegacyDeployer,
-  );
-  assert(
-    signer instanceof TurnkeyEvmSigner,
-    `Expected TurnkeyEvmSigner for role ${TurnkeyRole.EvmLegacyDeployer}, got ${signer.constructor.name}`,
-  );
-  rootLogger.info(`Using Turnkey signer ${signer.address}`);
+  let signer: TurnkeyEvmSigner;
+  if (turnkeyAccountSecret) {
+    signer = await getTurnkeyEvmSignerWithAccountOverride(
+      ENVIRONMENT,
+      TurnkeyRole.EvmLegacyDeployer,
+      turnkeyAccountSecret,
+    );
+    rootLogger.info(
+      `Using Turnkey signer ${signer.address} authed as account ${turnkeyAccountSecret}`,
+    );
+  } else {
+    const defaultSigner = await createTurnkeySigner(
+      ENVIRONMENT,
+      TurnkeyRole.EvmLegacyDeployer,
+    );
+    assert(
+      defaultSigner instanceof TurnkeyEvmSigner,
+      `Expected TurnkeyEvmSigner for role ${TurnkeyRole.EvmLegacyDeployer}, got ${defaultSigner.constructor.name}`,
+    );
+    signer = defaultSigner;
+    rootLogger.info(`Using Turnkey signer ${signer.address}`);
+  }
 
   const allocateNonce = createNonceAllocator();
   // Safes with a bundle that threw in this run. A failure after nonce

--- a/typescript/infra/src/utils/turnkey.ts
+++ b/typescript/infra/src/utils/turnkey.ts
@@ -1,10 +1,12 @@
+import { z } from 'zod';
+
 import {
   MultiProvider,
   TurnkeyConfigSchema,
   TurnkeyEvmSigner,
   TurnkeySealevelSigner,
 } from '@hyperlane-xyz/sdk';
-import { isEVMLike, rootLogger } from '@hyperlane-xyz/utils';
+import { assert, isEVMLike, rootLogger } from '@hyperlane-xyz/utils';
 
 import { DeployEnvironment } from '../config/deploy-environment.js';
 import { TurnkeyRole } from '../roles.js';
@@ -67,6 +69,48 @@ export async function createTurnkeySigner(
     );
     throw error;
   }
+}
+
+/**
+ * A standalone Turnkey API-key secret (e.g. `haggis-turnkey-api-key`): only the
+ * account credential, no wallet identity. Used to override which Turnkey user
+ * authenticates a signer while keeping the base role's private key (wallet).
+ */
+const TurnkeyAccountKeySchema = z.object({
+  publicKey: z.string(),
+  privateKey: z.string(),
+});
+
+/**
+ * Build a Turnkey EVM signer that signs with the given role's private key
+ * (wallet) but authenticates as the Turnkey account stored in a separate
+ * API-key secret. This lets a caller keep the default deployer wallet while
+ * swapping the authenticating user, so a user-scoped Turnkey policy (consensus)
+ * can auto-complete for that user instead of stalling on root consensus.
+ */
+export async function getTurnkeyEvmSignerWithAccountOverride(
+  deployEnvironment: DeployEnvironment,
+  role: Exclude<TurnkeyRole, TurnkeyRole.SealevelDeployer>,
+  accountSecretName: string,
+): Promise<TurnkeyEvmSigner> {
+  const baseSecretName = turnkeySecret(deployEnvironment, role);
+  const baseConfig = TurnkeyConfigSchema.parse(
+    JSON.parse(await fetchLatestGCPSecret(baseSecretName)),
+  );
+  const account = TurnkeyAccountKeySchema.parse(
+    JSON.parse(await fetchLatestGCPSecret(accountSecretName)),
+  );
+
+  const signer = new TurnkeyEvmSigner({
+    ...baseConfig,
+    apiPublicKey: account.publicKey,
+    apiPrivateKey: account.privateKey,
+  });
+  assert(
+    await signer.healthCheck(),
+    `Turnkey health check failed for ${role} wallet authed as account ${accountSecretName}`,
+  );
+  return signer;
 }
 
 // TurnkeySealevelSigner is now imported from SDK


### PR DESCRIPTION
## Summary
- Add optional `--turnkey-account-secret <gcp-secret>` to `safes/propose-warp-batch.ts`. It authenticates the signer as a different Turnkey account (API key) while keeping the `EvmLegacyDeployer` wallet. Default behavior is unchanged.
- Add `getTurnkeyEvmSignerWithAccountOverride` in `src/utils/turnkey.ts`: loads the base role config for the wallet identity (org, `privateKeyId`, `publicKey`) and swaps in the API creds from the override account secret.

## Why
`propose-warp-batch` authenticates as the `mainnet3-turnkey-EvmLegacyDeployer` account (Paul's Turnkey user). The Haggis-solo Safe-propose policy (`HaggisDeployer sign Safe proposal (SafeTx EIP-712)`, consensus `approverIsUser(haggisUserId)`) only auto-completes when the Haggis user initiates. So Haggis-initiated runs stall at `CONSENSUS_NEEDED`. Passing `--turnkey-account-secret haggis-turnkey-api-key` authenticates as the Haggis user (same deployer wallet), so the policy auto-completes and Haggis can post governance Safe proposals autonomously. On-chain control is unchanged: the deployer is 1 of 7 owners on the 2-of-7 WarpFees Safe.

## Test plan
- [x] `tsc --noEmit` clean; oxlint/oxfmt clean
- [x] Dry-run with `--turnkey-account-secret haggis-turnkey-api-key` authenticates as the Haggis account, resolves the deployer wallet `0xa7ECcdb9...`, and idempotently skips the already-queued eni payload
- [ ] Default run (no flag) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)