### PR TITLE
fix(sdk): deploy pausable hooks in configured state

### DIFF
--- a/.changeset/fix-pausable-hook-initial-state.md
+++ b/.changeset/fix-pausable-hook-initial-state.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Pausable hooks were deployed in their configured paused state before ownership was transferred.

--- a/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.hardhat-test.ts
@@ -5,6 +5,7 @@ import hre from 'hardhat';
 import {
   CONTRACTS_PACKAGE_VERSION,
   InterchainGasPaymaster__factory,
+  PausableHook__factory,
   RateLimitedHook__factory,
 } from '@hyperlane-xyz/core';
 import {
@@ -204,6 +205,23 @@ describe('EvmHookModule', async () => {
     it('deploys a hook of type CUSTOM', async () => {
       const config: HookConfig = randomAddress();
       await createHook(config);
+    });
+
+    it('deploys a pausable hook in the configured paused state', async () => {
+      const config: PausableHookConfig = {
+        owner: randomAddress(),
+        type: HookType.PAUSABLE,
+        paused: true,
+      };
+
+      const { initialHookAddress } = await createHook(config);
+      const hook = PausableHook__factory.connect(
+        initialHookAddress,
+        multiProvider.getProvider(chain),
+      );
+
+      expect(await hook.paused()).to.be.true;
+      expect(eqAddress(await hook.owner(), config.owner)).to.be.true;
     });
 
     // random configs upto depth 2

--- a/typescript/sdk/src/hook/EvmHookModule.ts
+++ b/typescript/sdk/src/hook/EvmHookModule.ts
@@ -1132,6 +1132,13 @@ export class EvmHookModule extends HyperlaneModule<
       [],
     );
 
+    if (config.paused) {
+      await this.multiProvider.handleTx(
+        this.chain,
+        hook.pause(this.txOverrides),
+      );
+    }
+
     // transfer ownership
     await this.multiProvider.handleTx(
       this.chain,

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.hardhat-test.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.hardhat-test.ts
@@ -33,7 +33,10 @@ describe('HyperlaneHookDeployer recovered hooks', () => {
   const remote = TestChainName.test2;
   const newRemote = TestChainName.test3;
 
-  async function deployFixture() {
+  async function deployFixture(
+    pausablePaused = false,
+    transferPausableOwnership = false,
+  ) {
     const [signer, newOwner, overrideOwner] = await hre.ethers.getSigners();
     const multiProvider = MultiProvider.createTestMultiProvider({ signer });
     const proxyFactoryContracts = await new HyperlaneProxyFactoryDeployer(
@@ -59,6 +62,9 @@ describe('HyperlaneHookDeployer recovered hooks', () => {
     );
 
     const owner = await signer.getAddress();
+    const pausableOwner = transferPausableOwnership
+      ? await newOwner.getAddress()
+      : owner;
     const initialConfig: FallbackRoutingHookConfig = {
       type: HookType.FALLBACK_ROUTING,
       owner,
@@ -67,7 +73,11 @@ describe('HyperlaneHookDeployer recovered hooks', () => {
         [remote]: {
           type: HookType.AGGREGATION,
           hooks: [
-            { type: HookType.PAUSABLE, owner, paused: false },
+            {
+              type: HookType.PAUSABLE,
+              owner: pausableOwner,
+              paused: pausablePaused,
+            },
             { type: HookType.MERKLE_TREE },
           ],
         },
@@ -106,6 +116,7 @@ describe('HyperlaneHookDeployer recovered hooks', () => {
       coreAddresses,
       hookDeployer,
       owner,
+      pausableOwner,
       fallbackRoutingHook,
       aggregationAddress,
       pausableAddress,
@@ -114,6 +125,17 @@ describe('HyperlaneHookDeployer recovered hooks', () => {
       childrenBefore,
     };
   }
+
+  it('applies pausable hook state before transferring ownership', async () => {
+    const { signer, pausableAddress, pausableOwner } = await deployFixture(
+      true,
+      true,
+    );
+    const pausable = PausableHook__factory.connect(pausableAddress, signer);
+
+    expect(await pausable.paused()).to.be.true;
+    expect(eqAddress(await pausable.owner(), pausableOwner)).to.be.true;
+  });
 
   it('reconciles a nested recovered pausable hook without replacing the tree', async () => {
     const {

--- a/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
+++ b/typescript/sdk/src/hook/HyperlaneHookDeployer.ts
@@ -226,7 +226,14 @@ export class HyperlaneHookDeployer extends HyperlaneDeployer<
     ) {
       hook = await this.deployRouting(chain, config, coreAddresses);
     } else if (config.type === HookType.PAUSABLE) {
-      hook = await this.deployContract(chain, config.type, []);
+      const pausableHook = await this.deployContract(chain, config.type, []);
+      if (config.paused) {
+        await this.multiProvider.handleTx(
+          chain,
+          pausableHook.pause(this.multiProvider.getTransactionOverrides(chain)),
+        );
+      }
+      hook = pausableHook;
       await this.transferOwnershipOfContracts(chain, config, {
         [HookType.PAUSABLE]: hook,
       });


### PR DESCRIPTION
### Description

Deploy pausable hooks in their configured paused state before transferring ownership. Adds a regression test and SDK patch changeset.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. Existing deployments are unchanged; new pausable hook deployments now honor the configured initial state.

### Testing

- Targeted Hardhat regression test
- SDK TypeScript check
- SDK lint
- git diff --check