### PR TITLE
fix(infra): disable deprecated agents and key funding

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -75,7 +75,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     adichain: true,
     aleo: true,
     apechain: true,
-    appchain: true,
+    appchain: false, // disabled — deprecation per ENG-3932
     arbitrum: true,
     avalanche: true,
     base: true,
@@ -94,14 +94,14 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     eni: true,
     ethereum: true,
     fluent: true,
-    flowmainnet: true,
+    flowmainnet: false, // disabled — deprecation per ENG-4006
     forma: false, // relayer + scraper only
     fraxtal: true,
     galactica: true,
     gnosis: true,
     hyperevm: true,
     igra: true,
-    immutablezkevmmainnet: true,
+    immutablezkevmmainnet: false, // disabled — deprecation per ENG-4119
     ink: true,
     katana: true,
     kiichain: true,
@@ -136,7 +136,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     soneium: true,
     sonic: true,
     sonicsvm: true,
-    soon: true,
+    soon: false, // disabled — deprecation per ENG-3607
     stable: true,
     starknet: true,
     subtensor: true,
@@ -158,7 +158,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     adichain: true,
     aleo: true,
     apechain: true,
-    appchain: true,
+    appchain: false, // disabled — deprecation per ENG-3932
     arbitrum: true,
     avalanche: true,
     base: true,
@@ -177,14 +177,14 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     eni: true,
     ethereum: true,
     fluent: true,
-    flowmainnet: true,
+    flowmainnet: false, // disabled — deprecation per ENG-4006
     forma: true,
     fraxtal: true,
     galactica: true,
     gnosis: true,
     hyperevm: true,
     igra: true,
-    immutablezkevmmainnet: true,
+    immutablezkevmmainnet: false, // disabled — deprecation per ENG-4119
     ink: true,
     katana: true,
     kiichain: true,
@@ -219,7 +219,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     soneium: true,
     sonic: true,
     sonicsvm: true,
-    soon: true,
+    soon: false, // disabled — deprecation per ENG-3607
     stable: true,
     starknet: true,
     subtensor: true,
@@ -241,7 +241,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     adichain: true,
     aleo: true,
     apechain: true,
-    appchain: true,
+    appchain: false, // disabled — deprecation per ENG-3932
     arbitrum: true,
     avalanche: true,
     base: true,
@@ -260,14 +260,14 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     eni: true,
     ethereum: true,
     fluent: true,
-    flowmainnet: true,
+    flowmainnet: false, // disabled — deprecation per ENG-4006
     forma: true,
     fraxtal: true,
     galactica: true,
     gnosis: true,
     hyperevm: true,
     igra: true,
-    immutablezkevmmainnet: true,
+    immutablezkevmmainnet: false, // disabled — deprecation per ENG-4119
     ink: true,
     katana: true,
     kiichain: true,
@@ -302,7 +302,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     soneium: true,
     sonic: true,
     sonicsvm: true,
-    soon: true,
+    soon: false, // disabled — deprecation per ENG-3607
     stable: true,
     starknet: true,
     subtensor: true,

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -80,7 +80,12 @@ export const keyFunderConfig: KeyFunderConfig<
     [Contexts.ReleaseCandidate]: [Role.Relayer],
     [Contexts.FastPath]: [Role.Relayer],
   },
-  chainsToSkip: ['mocachain'],
+  chainsToSkip: [
+    'appchain',
+    'flowmainnet',
+    'immutablezkevmmainnet',
+    'mocachain',
+  ],
   // desired balance config, must be set for each chain
   desiredBalancePerChain: desiredRelayerBalancePerChain,
   // desired rebalancer balance config


### PR DESCRIPTION
## Summary

- disable validator, relayer, and scraper roles for appchain, flowmainnet, immutablezkevmmainnet, and soon
- skip the three EVM chains in keyfunder; SOON is Sealevel and was already excluded by the EVM-only keyfunder path
- preserve supported-chain configuration for the later full-removal/cleanup phase

Companion registry metadata PR: https://github.com/hyperlane-xyz/hyperlane-registry/pull/1678

## Tracking

- AppChain: https://linear.app/hyperlane-xyz/issue/ENG-3932/appchain
- Flow: https://linear.app/hyperlane-xyz/issue/ENG-4006/flowmainnet
- Immutable zkEVM: https://linear.app/hyperlane-xyz/issue/ENG-4119/immutablezkevmmainnet
- SOON: https://linear.app/hyperlane-xyz/issue/ENG-3607/soon

## Operational scope

Deployed from exact head 8cbd594b90eef7f53e77cb372661970a90ab7e7b on 2026-08-28:

- omniscient-relayer revision 599 and omniscient-scraper revision 324 exclude all four chains and are ready
- key-funder revision 256 includes the updated skip list
- seven active validator StatefulSets across mainnet3 and validator-mainnet3 were scaled to 0; Helm releases and PVCs were preserved
- the pre-existing AppChain RC validator was already at 0 and was left unchanged

## Validation

- Node 26.6.0: pnpm build --filter=@hyperlane-xyz/infra... (22 successful)
- agent-configs.test.ts (5 passing)
- key-funder.test.ts (1 passing)
- generated keyfunder config contains none of the four target chains
- oxlint and oxfmt checks passed
- commit hooks passed