### PR TITLE
chore(infra): temporarily disable tac on mainnet3 agents

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -141,7 +141,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     starknet: true,
     subtensor: true,
     superseed: true,
-    tac: true,
+    tac: false, // temporarily disabled — TAC chain halted (no new blocks) since 2026-08-22; re-enable when block production resumes
     taiko: false, // temporarily disabled out of caution (Taiko network incident)
     tea: true,
     tron: true,
@@ -224,7 +224,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     starknet: true,
     subtensor: true,
     superseed: true,
-    tac: true,
+    tac: false, // temporarily disabled — TAC chain halted (no new blocks) since 2026-08-22; re-enable when block production resumes
     taiko: false, // temporarily disabled out of caution (Taiko network incident)
     tea: true,
     tron: true,
@@ -307,7 +307,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     starknet: true,
     subtensor: true,
     superseed: true,
-    tac: true,
+    tac: false, // temporarily disabled — TAC chain halted (no new blocks) since 2026-08-22; re-enable when block production resumes
     taiko: true,
     tea: true,
     tron: true,


### PR DESCRIPTION
## Summary
- Temporarily disable `tac` for the validator, relayer, and scraper in mainnet3 `agent.ts`.
- TAC chain (chainId 239) halted block production at block 24671475 (tip 2026-08-22T23:58:11Z) and remains frozen ~6 days later, confirmed via independent RPCs (tac.drpc.org serves the frozen tip; ankr + rpc.tac.build return the halt error). This set `hyperlane_critical_error{chain=tac,agent=relayer}=1` and fired a critical liveness page (PD Q1ZB5BG79BAA66).
- No tac warp routes / collateral in the registry, so no delivery impact beyond tac itself.

Requested by @Paul as a temporary disable until TAC resumes.

## Re-enable trigger
Revert these three lines to `tac: true` once TAC resumes producing blocks (block height advances past 24671475 on independent RPCs). Haggis is checking every 24h.

## Test plan
- [ ] CI passes (config typecheck)
- [ ] On deploy, confirm relayer/scraper/validator no longer index tac and the critical liveness alert clears