### PR TITLE
fix(sealevel): use finalized slots for fallback health checks

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -384,7 +384,10 @@ impl std::fmt::Debug for SealevelRpcClient {
 #[async_trait::async_trait]
 impl BlockNumberGetter for SealevelRpcClient {
     async fn get_block_number(&self) -> ChainResult<u64> {
-        self.get_block_height().await
+        // SVM-compatible chains can expose `getBlockHeight` and finalized slot
+        // from different heads. Use the indexers' finalized-slot cursor for
+        // fallback liveness as well.
+        self.get_slot_raw().await
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -1,6 +1,8 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use solana_client::nonblocking::rpc_client::RpcClient;
+use hyperlane_core::rpc_clients::BlockNumberGetter;
+use serde_json::json;
+use solana_client::{nonblocking::rpc_client::RpcClient, rpc_request::RpcRequest};
 use solana_commitment_config::CommitmentConfig;
 
 use super::block_config;
@@ -32,4 +34,18 @@ fn get_block_config_disables_rewards() {
     assert_eq!(config.rewards, Some(false));
     assert_eq!(config.max_supported_transaction_version, Some(0));
     assert_eq!(config.commitment, Some(CommitmentConfig::finalized()));
+}
+
+#[tokio::test]
+async fn fallback_liveness_uses_finalized_slot() {
+    let rpc_client = RpcClient::new_mock_with_mocks(
+        "succeeds".to_owned(),
+        HashMap::from([
+            (RpcRequest::GetSlot, json!(123)),
+            (RpcRequest::GetBlockHeight, json!(456)),
+        ]),
+    );
+    let client = SealevelRpcClient::from_rpc_client(Arc::new(rpc_client));
+
+    assert_eq!(client.get_block_number().await.unwrap(), 123);
 }


### PR DESCRIPTION
## Summary

- use finalized slots for Sealevel fallback-provider liveness checks
- align the health cursor with the finalized slot used by Sealevel indexers
- cover the selected RPC method with a focused mock test

## Why

Solaxy's RPC returned inconsistent finalized heads on 2026-08-28:

```text
getBlockHeight(finalized)             24071703
getSlot(finalized)                    24072908
getLatestBlockhash(finalized).slot    24071704
getBlock(24072908, finalized)         succeeded
```

The fallback health probe currently uses `getBlockHeight`, while Sealevel indexers use finalized slots as their cursor. This change makes both use the same unit and RPC signal.

Incident evidence: https://gist.github.com/paulbalaji/1e34b84f7769feee8426438f0fb577d9

## Scope

This does not fix Solaxy's upstream outage. Termina returned synchronized 502s across methods and both advertised IPs, then served stale/inconsistent state. Solaxy also has no independent fallback endpoint configured.

Slot advancement alone does not prove block/account freshness. Canary validation should confirm finalized slots and indexed data advance together before rollout.

## Validation

- `cargo test -p hyperlane-sealevel --lib` (42 passed)
- `cargo clippy -p hyperlane-sealevel --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path ../sealevel/Cargo.toml --all -- --check`
- commit hooks, including gitleaks
