### PR TITLE
fix(sdk): fall back when RPC rejects eth_estimateGas state override

### DIFF
--- a/.changeset/estimate-gas-state-override-fallback.md
+++ b/.changeset/estimate-gas-state-override-fallback.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Restored EVM fee estimates on RPCs that reject balance state overrides. Callers can provide fallback gas units to keep estimation balance-independent; otherwise the SDK retries against the sender's real balance.

--- a/.changeset/estimate-gas-state-override-fallback.md
+++ b/.changeset/estimate-gas-state-override-fallback.md
@@ -1,5 +1,5 @@
 ---
-'@hyperlane-xyz/sdk': patch
+'@hyperlane-xyz/sdk': minor
 ---
 
-Restored EVM fee estimates on RPCs that reject balance state overrides. Callers can provide fallback gas units to keep estimation balance-independent; otherwise the SDK retries against the sender's real balance.
+Added balance-independent EVM fee estimation with caller-provided fallback gas units for RPCs that reject state overrides. Estimation now fails with `StateOverrideUnsupportedError` when those RPCs have no fallback.

--- a/.changeset/estimate-gas-state-override-fallback.md
+++ b/.changeset/estimate-gas-state-override-fallback.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': minor
 ---
 
-Added balance-independent EVM fee estimation with caller-provided fallback gas units for RPCs that reject state overrides. Estimation now fails with `StateOverrideUnsupportedError` when those RPCs have no fallback.
+Added caller-provided fallback gas units for RPCs that reject EVM state overrides. Estimation now exposes and throws `StateOverrideUnsupportedError`, preserving JSON-RPC code `-32602`, when those RPCs have no fallback.

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -611,6 +611,12 @@ export {
 } from './providers/SmartProvider/ProviderMethods.js';
 export { HyperlaneSmartProvider } from './providers/SmartProvider/SmartProvider.js';
 export {
+  StateOverrideUnsupportedError,
+  type EvmTransactionFeeEstimateOptions,
+  type TransactionFeeEstimateParams,
+  type TransactionFeeEstimateTransactionOptions,
+} from './providers/transactionFeeEstimators.js';
+export {
   HyperlaneLogFilter,
   ProviderRetryOptions,
   SmartProviderOptions,

--- a/typescript/sdk/src/providers/MultiProtocolProvider.test.ts
+++ b/typescript/sdk/src/providers/MultiProtocolProvider.test.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import { BigNumber, providers as EthersV5Providers } from 'ethers';
+import sinon from 'sinon';
 import { Provider as ZKSyncProvider } from 'zksync-ethers';
 
 import { TestChainName, test1 } from '../consts/testChains.js';
@@ -81,6 +83,52 @@ describe('MultiProtocolProvider', () => {
       const provider =
         defaultProviderBuilderMap[ProviderType.GnosisTxBuilder](test1);
       expect(provider.type).to.equal(ProviderType.GnosisTxBuilder);
+    });
+
+    it('forwards EVM fallback options through the adapter', async () => {
+      const sandbox = sinon.createSandbox();
+      try {
+        const adapter = new MultiProviderAdapter({ test1 });
+        const provider = new EthersV5Providers.JsonRpcProvider();
+        sandbox.stub(provider, 'send').rejects(
+          Object.assign(new Error('processing response error'), {
+            code: 'SERVER_ERROR',
+            body: JSON.stringify({
+              error: {
+                code: -32602,
+                message: 'too many arguments, want at most 2',
+              },
+            }),
+          }),
+        );
+        sandbox.stub(provider, 'getFeeData').resolves({
+          gasPrice: BigNumber.from(2),
+          lastBaseFeePerGas: null,
+          maxFeePerGas: null,
+          maxPriorityFeePerGas: null,
+        });
+        adapter.setProvider('test1', {
+          type: ProviderType.EthersV5,
+          provider,
+        });
+
+        const estimate = await adapter.estimateTransactionFee({
+          chainNameOrId: 'test1',
+          transaction: {
+            type: ProviderType.EthersV5,
+            transaction: {
+              to: '0x0000000000000000000000000000000000000001',
+            },
+          },
+          sender: '0x0000000000000000000000000000000000000001',
+          ignoreSenderBalance: true,
+          fallbackGasUnits: 25_000n,
+        });
+
+        expect(estimate.gasUnits).to.equal(25_000n);
+      } finally {
+        sandbox.restore();
+      }
     });
   });
 });

--- a/typescript/sdk/src/providers/MultiProviderAdapter.ts
+++ b/typescript/sdk/src/providers/MultiProviderAdapter.ts
@@ -201,6 +201,7 @@ export class MultiProviderAdapter<
     sender,
     senderPubKey,
     ignoreSenderBalance,
+    fallbackGasUnits,
   }: {
     chainNameOrId: ChainNameOrId;
     transaction: TypedTransaction;
@@ -216,6 +217,7 @@ export class MultiProviderAdapter<
       sender,
       senderPubKey,
       ignoreSenderBalance,
+      fallbackGasUnits,
     });
   }
 }

--- a/typescript/sdk/src/providers/MultiProviderAdapter.ts
+++ b/typescript/sdk/src/providers/MultiProviderAdapter.ts
@@ -2,6 +2,7 @@ import {
   Address,
   HexString,
   ProtocolType,
+  assert,
   objFilter,
   objMap,
   pick,
@@ -20,15 +21,13 @@ import {
   EthersV5Provider,
   PROTOCOL_TO_DEFAULT_PROVIDER_TYPE,
   ProviderType,
-  TypedTransaction,
   TypedProvider,
 } from './ProviderType.js';
 import { defaultZKSyncProviderBuilder } from './builders/zksync.js';
 import type { ProviderBuilderFn } from './providerBuilders.js';
 import {
-  EvmTransactionFeeEstimateOptions,
   TransactionFeeEstimate,
-  TransactionFeeEstimateOptions,
+  TransactionFeeEstimateTransactionOptions,
   estimateTransactionFee,
 } from './transactionFeeEstimators.js';
 
@@ -197,24 +196,17 @@ export class MultiProviderAdapter<
   }
 
   estimateTransactionFee(
-    params:
-      | ({
-          chainNameOrId: ChainNameOrId;
-          transaction: Extract<
-            TypedTransaction,
-            { type: ProviderType.EthersV5 | ProviderType.Viem }
-          >;
-          sender: Address;
-          senderPubKey?: HexString;
-        } & EvmTransactionFeeEstimateOptions)
-      | ({
-          chainNameOrId: ChainNameOrId;
-          transaction: TypedTransaction;
-          sender: Address;
-          senderPubKey?: HexString;
-          fallbackGasUnits?: never;
-        } & TransactionFeeEstimateOptions),
+    params: {
+      chainNameOrId: ChainNameOrId;
+      sender: Address;
+      senderPubKey?: HexString;
+    } & TransactionFeeEstimateTransactionOptions,
   ): Promise<TransactionFeeEstimate> {
+    assert(
+      params.fallbackGasUnits === undefined ||
+        params.ignoreSenderBalance === true,
+      'fallbackGasUnits requires ignoreSenderBalance: true',
+    );
     const {
       chainNameOrId,
       transaction,
@@ -228,14 +220,24 @@ export class MultiProviderAdapter<
       transaction.type === ProviderType.EthersV5 ||
       transaction.type === ProviderType.Viem
     ) {
+      if (params.ignoreSenderBalance === true) {
+        return estimateTransactionFee({
+          transaction,
+          provider,
+          chainMetadata,
+          sender,
+          senderPubKey,
+          ignoreSenderBalance: true,
+          fallbackGasUnits: params.fallbackGasUnits,
+        });
+      }
       return estimateTransactionFee({
         transaction,
         provider,
         chainMetadata,
         sender,
         senderPubKey,
-        ignoreSenderBalance,
-        fallbackGasUnits: params.fallbackGasUnits,
+        ignoreSenderBalance: false,
       });
     }
     return estimateTransactionFee({

--- a/typescript/sdk/src/providers/MultiProviderAdapter.ts
+++ b/typescript/sdk/src/providers/MultiProviderAdapter.ts
@@ -26,6 +26,7 @@ import {
 import { defaultZKSyncProviderBuilder } from './builders/zksync.js';
 import type { ProviderBuilderFn } from './providerBuilders.js';
 import {
+  EvmTransactionFeeEstimateOptions,
   TransactionFeeEstimate,
   TransactionFeeEstimateOptions,
   estimateTransactionFee,
@@ -195,21 +196,48 @@ export class MultiProviderAdapter<
     };
   }
 
-  estimateTransactionFee({
-    chainNameOrId,
-    transaction,
-    sender,
-    senderPubKey,
-    ignoreSenderBalance,
-    fallbackGasUnits,
-  }: {
-    chainNameOrId: ChainNameOrId;
-    transaction: TypedTransaction;
-    sender: Address;
-    senderPubKey?: HexString;
-  } & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+  estimateTransactionFee(
+    params:
+      | ({
+          chainNameOrId: ChainNameOrId;
+          transaction: Extract<
+            TypedTransaction,
+            { type: ProviderType.EthersV5 | ProviderType.Viem }
+          >;
+          sender: Address;
+          senderPubKey?: HexString;
+        } & EvmTransactionFeeEstimateOptions)
+      | ({
+          chainNameOrId: ChainNameOrId;
+          transaction: TypedTransaction;
+          sender: Address;
+          senderPubKey?: HexString;
+          fallbackGasUnits?: never;
+        } & TransactionFeeEstimateOptions),
+  ): Promise<TransactionFeeEstimate> {
+    const {
+      chainNameOrId,
+      transaction,
+      sender,
+      senderPubKey,
+      ignoreSenderBalance,
+    } = params;
     const provider = this.getProvider(chainNameOrId, transaction.type);
     const chainMetadata = this.getChainMetadata(chainNameOrId);
+    if (
+      transaction.type === ProviderType.EthersV5 ||
+      transaction.type === ProviderType.Viem
+    ) {
+      return estimateTransactionFee({
+        transaction,
+        provider,
+        chainMetadata,
+        sender,
+        senderPubKey,
+        ignoreSenderBalance,
+        fallbackGasUnits: params.fallbackGasUnits,
+      });
+    }
     return estimateTransactionFee({
       transaction,
       provider,
@@ -217,7 +245,6 @@ export class MultiProviderAdapter<
       sender,
       senderPubKey,
       ignoreSenderBalance,
-      fallbackGasUnits,
     });
   }
 }

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.test.ts
@@ -17,6 +17,7 @@ import {
 } from './HyperlaneJsonRpcProvider.js';
 import {
   BlockchainError,
+  getJsonRpcErrorFrom,
   getSmartProviderErrorMessage,
   HyperlaneSmartProvider,
 } from './SmartProvider.js';
@@ -179,6 +180,50 @@ describe('SmartProvider', () => {
 
   beforeEach(() => {
     provider = new TestableSmartProvider([MockProvider.success('success')]);
+  });
+
+  describe('getJsonRpcErrorFrom', () => {
+    it('prefers a complete serialized response over an incomplete nested error', () => {
+      const error = Object.assign(new Error('processing response error'), {
+        error: { code: -32602 },
+        body: JSON.stringify({
+          error: { code: -32000, message: 'execution reverted' },
+        }),
+      });
+
+      expect(getJsonRpcErrorFrom(error)).to.deep.equal({
+        code: -32000,
+        message: 'execution reverted',
+      });
+    });
+
+    it('does not combine fields from different error layers', () => {
+      const error = Object.assign(new Error('state override not supported'), {
+        error: { code: -32602 },
+      });
+
+      expect(getJsonRpcErrorFrom(error)).to.deep.equal({
+        code: -32602,
+        message: undefined,
+      });
+    });
+
+    it('ignores an empty nested message in favor of a complete body error', () => {
+      const error = Object.assign(new Error('processing response error'), {
+        error: {
+          code: -32602,
+          message: '',
+          body: JSON.stringify({
+            error: { code: 3, message: 'execution reverted' },
+          }),
+        },
+      });
+
+      expect(getJsonRpcErrorFrom(error)).to.deep.equal({
+        code: 3,
+        message: 'execution reverted',
+      });
+    });
   });
 
   describe('explorer getLogs pagination', () => {

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -168,6 +168,39 @@ export function getNestedJsonRpcError(error: unknown): {
   };
 }
 
+/** Extracts a JSON-RPC error from direct, nested, or serialized error shapes. */
+export function getJsonRpcErrorFrom(error: unknown): {
+  code?: number | string;
+  message?: string;
+} {
+  const record = getRecord(error);
+  const nested = getRecord(record?.error);
+  const nestedError = getRecord(nested?.error);
+  const candidates = [
+    nestedError,
+    nested,
+    parseJsonRpcErrorBody(nested?.body),
+    parseJsonRpcErrorBody(record?.body),
+    record,
+  ];
+  const complete = candidates.find(
+    (candidate) =>
+      getJsonRpcErrorCode(candidate) !== undefined &&
+      getJsonRpcErrorMessage(candidate) !== undefined,
+  );
+
+  return {
+    code:
+      getJsonRpcErrorCode(complete) ??
+      candidates.map(getJsonRpcErrorCode).find((code) => code !== undefined),
+    message:
+      getJsonRpcErrorMessage(complete) ??
+      candidates
+        .map(getJsonRpcErrorMessage)
+        .find((message) => message !== undefined),
+  };
+}
+
 function isCallExceptionWithTransientRpcError(error: unknown): boolean {
   const record = getRecord(error);
   if (record?.code !== EthersError.CALL_EXCEPTION) return false;

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -129,7 +129,9 @@ function getJsonRpcErrorCode(value: unknown): number | string | undefined {
 
 function getJsonRpcErrorMessage(value: unknown): string | undefined {
   if (!isRecord(value)) return undefined;
-  return typeof value.message === 'string' ? value.message : undefined;
+  return typeof value.message === 'string' && value.message.length > 0
+    ? value.message
+    : undefined;
 }
 
 function parseJsonRpcErrorBody(body: unknown): {
@@ -149,6 +151,11 @@ function parseJsonRpcErrorBody(body: unknown): {
   }
 }
 
+/**
+ * Extracts only nested JSON-RPC fields. Top-level fields are deliberately
+ * excluded so callers can distinguish a nested RPC response from an outer
+ * provider error whose message may contain request details.
+ */
 export function getNestedJsonRpcError(error: unknown): {
   code?: number | string;
   message?: string;
@@ -168,7 +175,11 @@ export function getNestedJsonRpcError(error: unknown): {
   };
 }
 
-/** Extracts a JSON-RPC error from direct, nested, or serialized error shapes. */
+/**
+ * Extracts one JSON-RPC candidate from direct, nested, or serialized shapes.
+ * A complete same-source code/message pair wins; fields are never combined
+ * across candidates.
+ */
 export function getJsonRpcErrorFrom(error: unknown): {
   code?: number | string;
   message?: string;
@@ -176,28 +187,27 @@ export function getJsonRpcErrorFrom(error: unknown): {
   const record = getRecord(error);
   const nested = getRecord(record?.error);
   const nestedError = getRecord(nested?.error);
-  const candidates = [
+  const structuredCandidates = [
     nestedError,
     nested,
     parseJsonRpcErrorBody(nested?.body),
     parseJsonRpcErrorBody(record?.body),
-    record,
   ];
-  const complete = candidates.find(
+  const complete = structuredCandidates.find(
     (candidate) =>
       getJsonRpcErrorCode(candidate) !== undefined &&
       getJsonRpcErrorMessage(candidate) !== undefined,
   );
+  const partial = structuredCandidates.find(
+    (candidate) =>
+      getJsonRpcErrorCode(candidate) !== undefined ||
+      getJsonRpcErrorMessage(candidate) !== undefined,
+  );
+  const selected = complete ?? partial ?? record;
 
   return {
-    code:
-      getJsonRpcErrorCode(complete) ??
-      candidates.map(getJsonRpcErrorCode).find((code) => code !== undefined),
-    message:
-      getJsonRpcErrorMessage(complete) ??
-      candidates
-        .map(getJsonRpcErrorMessage)
-        .find((message) => message !== undefined),
+    code: getJsonRpcErrorCode(selected),
+    message: getJsonRpcErrorMessage(selected),
   };
 }
 
@@ -206,7 +216,7 @@ function isCallExceptionWithTransientRpcError(error: unknown): boolean {
   if (record?.code !== EthersError.CALL_EXCEPTION) return false;
   const hasRevertData = !!record.data && record.data !== '0x';
   const nestedError = record.error;
-  const jsonRpcErrorCode = getNestedJsonRpcError(error).code;
+  const jsonRpcErrorCode = getJsonRpcErrorFrom(error).code;
   return !!nestedError && !hasRevertData && jsonRpcErrorCode !== 3;
 }
 
@@ -736,7 +746,7 @@ export class HyperlaneSmartProvider
       const hasRevertData = !!e.data && e.data !== '0x';
       // Check for JSON-RPC error code 3. Ethers nesting varies and some
       // providers put the JSON-RPC error only in the response body.
-      const jsonRpcErrorCode = getNestedJsonRpcError(e).code;
+      const jsonRpcErrorCode = getJsonRpcErrorFrom(e).code;
       const isJsonRpcRevert = jsonRpcErrorCode === 3;
       // No nested error means ethers failed to decode empty return data - permanent
       const isEmptyReturnDecodeFailure = !e.error;

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -17,8 +17,10 @@ import { createPublicClient, custom } from 'viem';
 import { ProviderType, type ViemTransaction } from './ProviderType.js';
 import { HyperlaneJsonRpcProvider } from './SmartProvider/HyperlaneJsonRpcProvider.js';
 import { HyperlaneSmartProvider } from './SmartProvider/SmartProvider.js';
+import { test1 } from '../consts/testChains.js';
 import {
   clearCachedStargateClients,
+  estimateTransactionFee,
   estimateTransactionFeeEthersV5,
   estimateTransactionFeeCosmJsWasm,
   estimateTransactionFeeEthersV5ForGasUnits,
@@ -75,6 +77,7 @@ describe('transactionFeeEstimators', () => {
   function stateOverrideUnsupportedError(
     code = -32602,
     message = 'too many arguments, want at most 2',
+    directCode = code,
   ): Error {
     return Object.assign(new Error('processing response error'), {
       code: 'SERVER_ERROR',
@@ -83,7 +86,7 @@ describe('transactionFeeEstimators', () => {
         id: 1,
         error: { code, message },
       }),
-      error: { code },
+      error: { code: directCode },
     });
   }
 
@@ -222,6 +225,10 @@ describe('transactionFeeEstimators', () => {
     expect(estimateGas.notCalled).to.equal(true);
   });
 
+  it('preserves the JSON-RPC code on the typed unsupported error', () => {
+    expect(new StateOverrideUnsupportedError().code).to.equal(-32602);
+  });
+
   it('recognizes known unsupported state-override messages', async () => {
     for (const message of [
       'too many arguments, want at most 2',
@@ -287,10 +294,27 @@ describe('transactionFeeEstimators', () => {
           transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
           provider,
           sender: EVM_ADDRESS,
+          ignoreSenderBalance: true,
           fallbackGasUnits,
         }),
       ).to.be.rejectedWith('fallbackGasUnits must be positive');
     }
+  });
+
+  it('rejects Ethers fallback units without a balance override', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        fallbackGasUnits: 25_000n,
+      }),
+    ).to.be.rejectedWith('fallbackGasUnits requires ignoreSenderBalance: true');
   });
 
   it('recognizes a SmartProvider-wrapped unsupported override error', async () => {
@@ -389,6 +413,79 @@ describe('transactionFeeEstimators', () => {
       }),
     ).to.be.rejectedWith('processing response error');
     expect(estimateGas.notCalled).to.equal(true);
+  });
+
+  it('does not combine an incomplete nested code with body message text', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    sandbox
+      .stub(provider, 'send')
+      .rejects(
+        stateOverrideUnsupportedError(
+          -32000,
+          'too many arguments, want at most 2',
+          -32602,
+        ),
+      );
+
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: 25_000n,
+      }),
+    ).to.be.rejectedWith('processing response error');
+  });
+
+  it('requires both override and unsupported message tokens', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    sandbox
+      .stub(provider, 'send')
+      .rejects(
+        stateOverrideUnsupportedError(
+          -32602,
+          'state override balance exceeds maximum',
+        ),
+      );
+
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: 25_000n,
+      }),
+    ).to.be.rejectedWith('processing response error');
+  });
+
+  it('forwards fallback options through the typed dispatcher', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    sandbox.stub(provider, 'send').rejects(stateOverrideUnsupportedError());
+
+    const estimate = await estimateTransactionFee({
+      transaction: {
+        type: ProviderType.EthersV5,
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      },
+      provider: { type: ProviderType.EthersV5, provider },
+      chainMetadata: test1,
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+      fallbackGasUnits: 25_000n,
+    });
+
+    expect(estimate.gasUnits).to.equal(25_000n);
   });
 
   it('routes Ethers balance overrides through the smart provider', async () => {
@@ -607,6 +704,25 @@ describe('transactionFeeEstimators', () => {
     expect(request.calledOnce).to.equal(true);
   });
 
+  it('does not classify a Viem error when no override was sent', async () => {
+    const { client, request } = makeViemClientRejectingEstimateGas(
+      'too many arguments, want at most 2',
+    );
+
+    await expect(
+      estimateTransactionFeeViem({
+        transaction: {
+          type: ProviderType.Viem,
+          transaction: viemTransaction(),
+        },
+        provider: { type: ProviderType.Viem, provider: client },
+        sender: EVM_ADDRESS,
+      }),
+    ).to.be.rejectedWith('Invalid parameters were provided to the RPC method');
+    expect(request.calledOnce).to.equal(true);
+    expect(request.firstCall.args[0].params).to.have.length(1);
+  });
+
   it('rejects non-positive Viem fallback gas units', async () => {
     const client = createPublicClient({
       transport: custom({
@@ -640,10 +756,55 @@ describe('transactionFeeEstimators', () => {
           transaction: { type: ProviderType.Viem, transaction },
           provider: { type: ProviderType.Viem, provider: client },
           sender: EVM_ADDRESS,
+          ignoreSenderBalance: true,
           fallbackGasUnits,
         }),
       ).to.be.rejectedWith('fallbackGasUnits must be positive');
     }
+  });
+
+  it('rejects Viem fallback units without a balance override', async () => {
+    const client = createPublicClient({
+      transport: custom({
+        request: async () => {
+          throw new Error('Unexpected RPC request');
+        },
+      }),
+    });
+
+    await expect(
+      estimateTransactionFeeViem({
+        transaction: {
+          type: ProviderType.Viem,
+          transaction: viemTransaction(),
+        },
+        provider: { type: ProviderType.Viem, provider: client },
+        sender: EVM_ADDRESS,
+        fallbackGasUnits: 25_000n,
+      }),
+    ).to.be.rejectedWith('fallbackGasUnits requires ignoreSenderBalance: true');
+  });
+
+  it('fails clearly for an unsupported Viem transaction envelope', async () => {
+    const request = sandbox.stub().rejects(new Error('Unexpected RPC request'));
+    const client = createPublicClient({ transport: custom({ request }) });
+    const unsupportedTransaction = {
+      ...viemTransaction(),
+      type: 'cip64',
+    };
+
+    await expect(
+      estimateTransactionFeeViem({
+        transaction: {
+          type: ProviderType.Viem,
+          // CAST: deliberately exercises caller-supplied runtime data outside Viem's base union.
+          transaction: unsupportedTransaction as ViemTransaction['transaction'],
+        },
+        provider: { type: ProviderType.Viem, provider: client },
+        sender: EVM_ADDRESS,
+      }),
+    ).to.be.rejectedWith('Unsupported Viem transaction type: cip64');
+    expect(request.notCalled).to.equal(true);
   });
 
   function makeProvider(url: string) {

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -24,6 +24,7 @@ import {
   estimateTransactionFeeEthersV5ForGasUnits,
   estimateTransactionFeeSolanaWeb3,
   estimateTransactionFeeViem,
+  StateOverrideUnsupportedError,
 } from './transactionFeeEstimators.js';
 
 const EVM_ADDRESS = '0x0000000000000000000000000000000000000001';
@@ -71,16 +72,62 @@ describe('transactionFeeEstimators', () => {
     return provider;
   }
 
-  function stateOverrideUnsupportedError(code = -32602): Error {
+  function stateOverrideUnsupportedError(
+    code = -32602,
+    message = 'too many arguments, want at most 2',
+  ): Error {
     return Object.assign(new Error('processing response error'), {
       code: 'SERVER_ERROR',
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
-        error: { code, message: 'too many arguments, want at most 2' },
+        error: { code, message },
       }),
       error: { code },
     });
+  }
+
+  function viemTransaction(): ViemTransaction['transaction'] {
+    return {
+      blockHash: EVM_HASH,
+      blockNumber: 1n,
+      from: EVM_ADDRESS,
+      gas: 21_000n,
+      gasPrice: 2n,
+      hash: EVM_HASH,
+      input: '0x',
+      nonce: 0,
+      r: '0x',
+      s: '0x',
+      to: EVM_ADDRESS,
+      transactionIndex: 0,
+      type: 'legacy',
+      typeHex: '0x0',
+      v: 27n,
+      value: 1n,
+    };
+  }
+
+  function makeViemClientRejectingEstimateGas(message: string) {
+    const request = sandbox.stub().callsFake(async ({ method }) => {
+      if (method !== 'eth_estimateGas') {
+        throw new Error(`Unexpected RPC request: ${method}`);
+      }
+      throw Object.assign(new Error(message), { code: -32602 });
+    });
+    const client = createPublicClient({ transport: custom({ request }) });
+    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 2n });
+    return { client, request };
+  }
+
+  function errorChainNames(error: unknown): string[] {
+    const names: string[] = [];
+    let current = error;
+    while (current instanceof Error) {
+      names.push(current.name);
+      current = current.cause;
+    }
+    return names;
   }
 
   it('uses the EIP-1559 max fee as the total gas price cap', async () => {
@@ -153,33 +200,53 @@ describe('transactionFeeEstimators', () => {
     ]);
   });
 
-  it('falls back to a plain estimate when the RPC rejects the state override', async () => {
+  it('fails explicitly when an Ethers RPC rejects the override without a fallback', async () => {
     const provider = makeEthersFeeProvider({
       gasPrice: 2n,
       maxFeePerGas: null,
     });
-    const estimateGas = sandbox
-      .stub(provider, 'estimateGas')
-      .resolves(BigNumber.from(21_000));
+    const estimateGas = sandbox.stub(provider, 'estimateGas');
     const send = sandbox
       .stub(provider, 'send')
       .rejects(stateOverrideUnsupportedError());
 
-    const estimate = await estimateTransactionFeeEthersV5({
-      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
-      provider,
-      sender: EVM_ADDRESS,
-      ignoreSenderBalance: true,
-    });
-
-    expect(estimate).to.deep.equal({
-      gasUnits: 21_000n,
-      gasPrice: 2n,
-      fee: 42_000n,
-    });
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+      }),
+    ).to.be.rejectedWith(StateOverrideUnsupportedError);
     expect(send.calledOnce).to.equal(true);
-    expect(estimateGas.calledOnce).to.equal(true);
-    expect(estimateGas.firstCall.args[0]).to.include({ from: EVM_ADDRESS });
+    expect(estimateGas.notCalled).to.equal(true);
+  });
+
+  it('recognizes known unsupported state-override messages', async () => {
+    for (const message of [
+      'too many arguments, want at most 2',
+      'invalid argument 2: unsupported field',
+      'state override is not supported',
+      'stateoverride unsupported',
+    ]) {
+      const provider = makeEthersFeeProvider({
+        gasPrice: 2n,
+        maxFeePerGas: null,
+      });
+      sandbox
+        .stub(provider, 'send')
+        .rejects(stateOverrideUnsupportedError(-32602, message));
+
+      const estimate = await estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: 25_000n,
+      });
+
+      expect(estimate.gasUnits).to.equal(25_000n);
+    }
   });
 
   it('uses fallback gas units without requiring sender balance', async () => {
@@ -295,6 +362,30 @@ describe('transactionFeeEstimators', () => {
         provider,
         sender: EVM_ADDRESS,
         ignoreSenderBalance: true,
+      }),
+    ).to.be.rejectedWith('processing response error');
+    expect(estimateGas.notCalled).to.equal(true);
+  });
+
+  it('does not treat a generic invalid-parameters error as unsupported', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    const estimateGas = sandbox.stub(provider, 'estimateGas');
+    sandbox
+      .stub(provider, 'send')
+      .rejects(
+        stateOverrideUnsupportedError(-32602, 'method parameters invalid'),
+      );
+
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: 25_000n,
       }),
     ).to.be.rejectedWith('processing response error');
     expect(estimateGas.notCalled).to.equal(true);
@@ -448,86 +539,40 @@ describe('transactionFeeEstimators', () => {
     ]);
   });
 
-  it('falls back when a Viem RPC rejects the state override', async () => {
-    const client = createPublicClient({
-      transport: custom({
-        request: async () => {
-          throw new Error('Unexpected RPC request');
+  it('fails explicitly when a real Viem error chain has no fallback', async () => {
+    const { client, request } = makeViemClientRejectingEstimateGas(
+      'too many arguments, want at most 2',
+    );
+
+    let thrown: unknown;
+    try {
+      await estimateTransactionFeeViem({
+        transaction: {
+          type: ProviderType.Viem,
+          transaction: viemTransaction(),
         },
-      }),
-    });
-    const estimateGas = sandbox.stub(client, 'estimateGas');
-    estimateGas.onFirstCall().rejects(stateOverrideUnsupportedError());
-    estimateGas.onSecondCall().resolves(21_000n);
-    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 2n });
-    const transaction = {
-      blockHash: EVM_HASH,
-      blockNumber: 1n,
-      from: EVM_ADDRESS,
-      gas: 21_000n,
-      gasPrice: 2n,
-      hash: EVM_HASH,
-      input: '0x',
-      nonce: 0,
-      r: '0x',
-      s: '0x',
-      to: EVM_ADDRESS,
-      transactionIndex: 0,
-      type: 'legacy',
-      typeHex: '0x0',
-      v: 27n,
-      value: 1n,
-    } satisfies ViemTransaction['transaction'];
+        provider: { type: ProviderType.Viem, provider: client },
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+      });
+    } catch (error) {
+      thrown = error;
+    }
 
-    const estimate = await estimateTransactionFeeViem({
-      transaction: { type: ProviderType.Viem, transaction },
-      provider: { type: ProviderType.Viem, provider: client },
-      sender: EVM_ADDRESS,
-      ignoreSenderBalance: true,
-    });
-
-    expect(estimate).to.deep.equal({
-      gasUnits: 21_000n,
-      gasPrice: 2n,
-      fee: 42_000n,
-    });
-    expect(estimateGas.callCount).to.equal(2);
-    expect(estimateGas.firstCall.args[0].stateOverride).to.have.length(1);
-    expect(estimateGas.secondCall.args[0].stateOverride).to.equal(undefined);
+    expect(thrown).to.be.instanceOf(StateOverrideUnsupportedError);
+    expect(errorChainNames(thrown)).to.include('InvalidParamsRpcError');
+    expect(request.calledOnce).to.equal(true);
+    expect(request.firstCall.args[0].method).to.equal('eth_estimateGas');
+    expect(request.firstCall.args[0].params).to.have.length(3);
   });
 
   it('uses Viem fallback gas units without a balance-dependent retry', async () => {
-    const client = createPublicClient({
-      transport: custom({
-        request: async () => {
-          throw new Error('Unexpected RPC request');
-        },
-      }),
-    });
-    const estimateGas = sandbox.stub(client, 'estimateGas');
-    estimateGas.onFirstCall().rejects(stateOverrideUnsupportedError());
-    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 2n });
-    const transaction = {
-      blockHash: EVM_HASH,
-      blockNumber: 1n,
-      from: EVM_ADDRESS,
-      gas: 21_000n,
-      gasPrice: 2n,
-      hash: EVM_HASH,
-      input: '0x',
-      nonce: 0,
-      r: '0x',
-      s: '0x',
-      to: EVM_ADDRESS,
-      transactionIndex: 0,
-      type: 'legacy',
-      typeHex: '0x0',
-      v: 27n,
-      value: 1n,
-    } satisfies ViemTransaction['transaction'];
+    const { client, request } = makeViemClientRejectingEstimateGas(
+      'too many arguments, want at most 2',
+    );
 
     const estimate = await estimateTransactionFeeViem({
-      transaction: { type: ProviderType.Viem, transaction },
+      transaction: { type: ProviderType.Viem, transaction: viemTransaction() },
       provider: { type: ProviderType.Viem, provider: client },
       sender: EVM_ADDRESS,
       ignoreSenderBalance: true,
@@ -539,7 +584,27 @@ describe('transactionFeeEstimators', () => {
       gasPrice: 2n,
       fee: 50_000n,
     });
-    expect(estimateGas.calledOnce).to.equal(true);
+    expect(request.calledOnce).to.equal(true);
+  });
+
+  it('rethrows a generic Viem invalid-parameters error', async () => {
+    const { client, request } = makeViemClientRejectingEstimateGas(
+      'method parameters invalid',
+    );
+
+    await expect(
+      estimateTransactionFeeViem({
+        transaction: {
+          type: ProviderType.Viem,
+          transaction: viemTransaction(),
+        },
+        provider: { type: ProviderType.Viem, provider: client },
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: 25_000n,
+      }),
+    ).to.be.rejectedWith('Invalid parameters were provided to the RPC method');
+    expect(request.calledOnce).to.equal(true);
   });
 
   it('rejects non-positive Viem fallback gas units', async () => {

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -1,4 +1,5 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 
 import { StargateClient } from '@cosmjs/stargate';
@@ -27,6 +28,8 @@ import {
 
 const EVM_ADDRESS = '0x0000000000000000000000000000000000000001';
 const EVM_HASH = `0x${'01'.repeat(32)}` as const;
+
+chai.use(chaiAsPromised);
 
 describe('transactionFeeEstimators', () => {
   const sender = 'cosmos1sender';
@@ -203,6 +206,24 @@ describe('transactionFeeEstimators', () => {
       fee: 50_000n,
     });
     expect(estimateGas.notCalled).to.equal(true);
+  });
+
+  it('rejects non-positive Ethers fallback gas units', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+
+    for (const fallbackGasUnits of [0n, -1n]) {
+      await expect(
+        estimateTransactionFeeEthersV5({
+          transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+          provider,
+          sender: EVM_ADDRESS,
+          fallbackGasUnits,
+        }),
+      ).to.be.rejectedWith('fallbackGasUnits must be positive');
+    }
   });
 
   it('recognizes a SmartProvider-wrapped unsupported override error', async () => {
@@ -411,7 +432,17 @@ describe('transactionFeeEstimators', () => {
     expect(estimateGas.calledOnce).to.equal(true);
     expect(estimateGas.firstCall.args[0]).to.include({
       account: EVM_ADDRESS,
+      data: '0x',
+      gas: 21_000n,
+      gasPrice: 1n,
+      nonce: 0,
+      to: EVM_ADDRESS,
+      type: 'legacy',
+      value: 1n,
     });
+    expect(estimateGas.firstCall.args[0]).not.to.have.property('blockNumber');
+    expect(estimateGas.firstCall.args[0]).not.to.have.property('hash');
+    expect(estimateGas.firstCall.args[0]).not.to.have.property('input');
     expect(estimateGas.firstCall.args[0].stateOverride).to.deep.equal([
       { address: EVM_ADDRESS, balance: (1n << 256n) - 1n },
     ]);
@@ -509,6 +540,45 @@ describe('transactionFeeEstimators', () => {
       fee: 50_000n,
     });
     expect(estimateGas.calledOnce).to.equal(true);
+  });
+
+  it('rejects non-positive Viem fallback gas units', async () => {
+    const client = createPublicClient({
+      transport: custom({
+        request: async () => {
+          throw new Error('Unexpected RPC request');
+        },
+      }),
+    });
+    const transaction = {
+      blockHash: EVM_HASH,
+      blockNumber: 1n,
+      from: EVM_ADDRESS,
+      gas: 21_000n,
+      gasPrice: 2n,
+      hash: EVM_HASH,
+      input: '0x',
+      nonce: 0,
+      r: '0x',
+      s: '0x',
+      to: EVM_ADDRESS,
+      transactionIndex: 0,
+      type: 'legacy',
+      typeHex: '0x0',
+      v: 27n,
+      value: 1n,
+    } satisfies ViemTransaction['transaction'];
+
+    for (const fallbackGasUnits of [0n, -1n]) {
+      await expect(
+        estimateTransactionFeeViem({
+          transaction: { type: ProviderType.Viem, transaction },
+          provider: { type: ProviderType.Viem, provider: client },
+          sender: EVM_ADDRESS,
+          fallbackGasUnits,
+        }),
+      ).to.be.rejectedWith('fallbackGasUnits must be positive');
+    }
   });
 
   function makeProvider(url: string) {

--- a/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.test.ts
@@ -68,6 +68,18 @@ describe('transactionFeeEstimators', () => {
     return provider;
   }
 
+  function stateOverrideUnsupportedError(code = -32602): Error {
+    return Object.assign(new Error('processing response error'), {
+      code: 'SERVER_ERROR',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code, message: 'too many arguments, want at most 2' },
+      }),
+      error: { code },
+    });
+  }
+
   it('uses the EIP-1559 max fee as the total gas price cap', async () => {
     const estimate = await estimateTransactionFeeEthersV5ForGasUnits({
       provider: makeEthersFeeProvider({ gasPrice: 1n, maxFeePerGas: 2n }),
@@ -136,6 +148,135 @@ describe('transactionFeeEstimators', () => {
         { [EVM_ADDRESS]: { balance: `0x${'f'.repeat(64)}` } },
       ],
     ]);
+  });
+
+  it('falls back to a plain estimate when the RPC rejects the state override', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    const estimateGas = sandbox
+      .stub(provider, 'estimateGas')
+      .resolves(BigNumber.from(21_000));
+    const send = sandbox
+      .stub(provider, 'send')
+      .rejects(stateOverrideUnsupportedError());
+
+    const estimate = await estimateTransactionFeeEthersV5({
+      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      provider,
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 21_000n,
+      gasPrice: 2n,
+      fee: 42_000n,
+    });
+    expect(send.calledOnce).to.equal(true);
+    expect(estimateGas.calledOnce).to.equal(true);
+    expect(estimateGas.firstCall.args[0]).to.include({ from: EVM_ADDRESS });
+  });
+
+  it('uses fallback gas units without requiring sender balance', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    const estimateGas = sandbox
+      .stub(provider, 'estimateGas')
+      .rejects(new Error('insufficient balance for transfer'));
+    sandbox.stub(provider, 'send').rejects(stateOverrideUnsupportedError());
+
+    const estimate = await estimateTransactionFeeEthersV5({
+      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      provider,
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+      fallbackGasUnits: 25_000n,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 25_000n,
+      gasPrice: 2n,
+      fee: 50_000n,
+    });
+    expect(estimateGas.notCalled).to.equal(true);
+  });
+
+  it('recognizes a SmartProvider-wrapped unsupported override error', async () => {
+    const provider = new HyperlaneSmartProvider(1, [
+      { http: 'http://provider' },
+    ]);
+    const rpcError = stateOverrideUnsupportedError();
+    sandbox
+      .stub(provider, 'perform')
+      .rejects(
+        new Error('too many arguments, want at most 2', { cause: rpcError }),
+      );
+    sandbox.stub(provider, 'getFeeData').resolves({
+      gasPrice: BigNumber.from(2),
+      lastBaseFeePerGas: null,
+      maxFeePerGas: null,
+      maxPriorityFeePerGas: null,
+    });
+
+    const estimate = await estimateTransactionFeeEthersV5({
+      transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+      provider,
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+      fallbackGasUnits: 25_000n,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 25_000n,
+      gasPrice: 2n,
+      fee: 50_000n,
+    });
+  });
+
+  it('rethrows non-override errors from the balance-override estimate', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    const estimateGas = sandbox.stub(provider, 'estimateGas');
+    sandbox
+      .stub(provider, 'send')
+      .rejects(new Error('execution reverted: insufficient allowance'));
+
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+      }),
+    ).to.be.rejectedWith('execution reverted: insufficient allowance');
+    expect(estimateGas.notCalled).to.equal(true);
+  });
+
+  it('does not treat matching text under another RPC code as unsupported', async () => {
+    const provider = makeEthersFeeProvider({
+      gasPrice: 2n,
+      maxFeePerGas: null,
+    });
+    const estimateGas = sandbox.stub(provider, 'estimateGas');
+    sandbox
+      .stub(provider, 'send')
+      .rejects(stateOverrideUnsupportedError(-32000));
+
+    await expect(
+      estimateTransactionFeeEthersV5({
+        transaction: { to: EVM_ADDRESS, value: BigNumber.from(1) },
+        provider,
+        sender: EVM_ADDRESS,
+        ignoreSenderBalance: true,
+      }),
+    ).to.be.rejectedWith('processing response error');
+    expect(estimateGas.notCalled).to.equal(true);
   });
 
   it('routes Ethers balance overrides through the smart provider', async () => {
@@ -274,6 +415,100 @@ describe('transactionFeeEstimators', () => {
     expect(estimateGas.firstCall.args[0].stateOverride).to.deep.equal([
       { address: EVM_ADDRESS, balance: (1n << 256n) - 1n },
     ]);
+  });
+
+  it('falls back when a Viem RPC rejects the state override', async () => {
+    const client = createPublicClient({
+      transport: custom({
+        request: async () => {
+          throw new Error('Unexpected RPC request');
+        },
+      }),
+    });
+    const estimateGas = sandbox.stub(client, 'estimateGas');
+    estimateGas.onFirstCall().rejects(stateOverrideUnsupportedError());
+    estimateGas.onSecondCall().resolves(21_000n);
+    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 2n });
+    const transaction = {
+      blockHash: EVM_HASH,
+      blockNumber: 1n,
+      from: EVM_ADDRESS,
+      gas: 21_000n,
+      gasPrice: 2n,
+      hash: EVM_HASH,
+      input: '0x',
+      nonce: 0,
+      r: '0x',
+      s: '0x',
+      to: EVM_ADDRESS,
+      transactionIndex: 0,
+      type: 'legacy',
+      typeHex: '0x0',
+      v: 27n,
+      value: 1n,
+    } satisfies ViemTransaction['transaction'];
+
+    const estimate = await estimateTransactionFeeViem({
+      transaction: { type: ProviderType.Viem, transaction },
+      provider: { type: ProviderType.Viem, provider: client },
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 21_000n,
+      gasPrice: 2n,
+      fee: 42_000n,
+    });
+    expect(estimateGas.callCount).to.equal(2);
+    expect(estimateGas.firstCall.args[0].stateOverride).to.have.length(1);
+    expect(estimateGas.secondCall.args[0].stateOverride).to.equal(undefined);
+  });
+
+  it('uses Viem fallback gas units without a balance-dependent retry', async () => {
+    const client = createPublicClient({
+      transport: custom({
+        request: async () => {
+          throw new Error('Unexpected RPC request');
+        },
+      }),
+    });
+    const estimateGas = sandbox.stub(client, 'estimateGas');
+    estimateGas.onFirstCall().rejects(stateOverrideUnsupportedError());
+    sandbox.stub(client, 'estimateFeesPerGas').resolves({ gasPrice: 2n });
+    const transaction = {
+      blockHash: EVM_HASH,
+      blockNumber: 1n,
+      from: EVM_ADDRESS,
+      gas: 21_000n,
+      gasPrice: 2n,
+      hash: EVM_HASH,
+      input: '0x',
+      nonce: 0,
+      r: '0x',
+      s: '0x',
+      to: EVM_ADDRESS,
+      transactionIndex: 0,
+      type: 'legacy',
+      typeHex: '0x0',
+      v: 27n,
+      value: 1n,
+    } satisfies ViemTransaction['transaction'];
+
+    const estimate = await estimateTransactionFeeViem({
+      transaction: { type: ProviderType.Viem, transaction },
+      provider: { type: ProviderType.Viem, provider: client },
+      sender: EVM_ADDRESS,
+      ignoreSenderBalance: true,
+      fallbackGasUnits: 25_000n,
+    });
+
+    expect(estimate).to.deep.equal({
+      gasUnits: 25_000n,
+      gasPrice: 2n,
+      fee: 50_000n,
+    });
+    expect(estimateGas.calledOnce).to.equal(true);
   });
 
   function makeProvider(url: string) {

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -55,7 +55,7 @@ import {
   ViemTransaction,
 } from './ProviderType.js';
 import {
-  getNestedJsonRpcError,
+  getJsonRpcErrorFrom,
   HyperlaneSmartProvider,
 } from './SmartProvider/SmartProvider.js';
 import { ProviderMethod } from './SmartProvider/ProviderMethods.js';
@@ -70,21 +70,10 @@ const INVALID_PARAMS_JSON_RPC_ERROR = -32602;
 function isStateOverrideUnsupportedError(error: unknown): boolean {
   let current = error;
   while (current instanceof Error) {
-    const nestedError = getNestedJsonRpcError(current);
-    const directError = getNestedJsonRpcError({ error: current });
-    const codes = [getErrorCode(current), nestedError.code, directError.code];
-    const message = [
-      current.message,
-      getErrorBody(current),
-      nestedError.message,
-      directError.message,
-    ]
-      .filter((part): part is string => typeof part === 'string')
-      .join(' ')
-      .toLowerCase();
+    const { code, message } = getJsonRpcErrorFrom(current);
     if (
-      codes.some((code) => Number(code) === INVALID_PARAMS_JSON_RPC_ERROR) &&
-      isUnsupportedStateOverrideMessage(message)
+      Number(code) === INVALID_PARAMS_JSON_RPC_ERROR &&
+      isUnsupportedStateOverrideMessage(message?.toLowerCase() ?? '')
     ) {
       return true;
     }
@@ -94,23 +83,10 @@ function isStateOverrideUnsupportedError(error: unknown): boolean {
   return false;
 }
 
-function getErrorBody(error: Error): string | undefined {
-  if (!('body' in error)) return undefined;
-  return typeof error.body === 'string' ? error.body : undefined;
-}
-
-function getErrorCode(error: Error): number | string | undefined {
-  if (!('code' in error)) return undefined;
-  return typeof error.code === 'number' || typeof error.code === 'string'
-    ? error.code
-    : undefined;
-}
-
 function isUnsupportedStateOverrideMessage(message: string): boolean {
   return (
     message.includes('too many arguments') ||
     message.includes('invalid argument 2') ||
-    message.includes('method parameters invalid') ||
     ((message.includes('state override') ||
       message.includes('stateoverride')) &&
       (message.includes('not supported') || message.includes('unsupported')))
@@ -121,12 +97,50 @@ export interface TransactionFeeEstimateOptions {
   /**
    * Attempts to estimate the fee without requiring the sender's native balance
    * to fund both the transaction value and its network fee. Defaults to false.
-   * RPCs without state-override support use fallbackGasUnits when provided,
-   * otherwise they retry a balance-dependent estimate.
+   * EVM estimation throws StateOverrideUnsupportedError when the RPC rejects
+   * the required state override and no fallbackGasUnits are supplied.
    */
   ignoreSenderBalance?: boolean;
-  /** Positive gas units to use when an RPC rejects balance state overrides. */
+}
+
+export interface EvmTransactionFeeEstimateOptions extends TransactionFeeEstimateOptions {
+  /**
+   * Positive gas units to use when an RPC rejects balance state overrides.
+   * Supplying this value skips successful gas simulation and revert detection.
+   */
   fallbackGasUnits?: bigint;
+}
+
+type EvmTypedTransaction = Extract<
+  TypedTransaction,
+  { type: ProviderType.EthersV5 | ProviderType.Viem }
+>;
+type TransactionFeeEstimateCommon = {
+  provider: TypedProvider;
+  chainMetadata: ChainMetadata;
+  sender: Address;
+  senderPubKey?: HexString;
+};
+
+export type TransactionFeeEstimateParams =
+  | (TransactionFeeEstimateCommon &
+      EvmTransactionFeeEstimateOptions & {
+        transaction: EvmTypedTransaction;
+      })
+  | (TransactionFeeEstimateCommon &
+      TransactionFeeEstimateOptions & {
+        transaction: TypedTransaction;
+        fallbackGasUnits?: never;
+      });
+
+export class StateOverrideUnsupportedError extends Error {
+  constructor(options?: ErrorOptions) {
+    super(
+      'RPC does not support eth_estimateGas state overrides; provide fallbackGasUnits to keep estimation balance-independent',
+      options,
+    );
+    this.name = StateOverrideUnsupportedError.name;
+  }
 }
 
 export interface TransactionFeeEstimate {
@@ -155,7 +169,7 @@ export async function estimateTransactionFeeEthersV5({
   transaction: EV5Transaction;
   provider: EV5Providers.Provider;
   sender: Address;
-} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+} & EvmTransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
   assertValidFallbackGasUnits(fallbackGasUnits);
   const gasUnits = ignoreSenderBalance
     ? await estimateGasEthersV5WithBalanceOverride({
@@ -216,11 +230,14 @@ async function estimateGasEthersV5WithBalanceOverride({
     );
   } catch (error) {
     if (!isStateOverrideUnsupportedError(error)) throw error;
+    if (isNullish(fallbackGasUnits)) {
+      throw new StateOverrideUnsupportedError({ cause: error });
+    }
     logger.warn(
-      'RPC rejected eth_estimateGas state override; using fallback estimation',
+      { estimator: 'ethersV5', jsonRpcCode: INVALID_PARAMS_JSON_RPC_ERROR },
+      'Ethers v5 RPC rejected eth_estimateGas state override; using caller-provided fallback gas units without transaction simulation',
     );
-    if (!isNullish(fallbackGasUnits)) return BigNumber.from(fallbackGasUnits);
-    return provider.estimateGas({ ...transaction, from: sender });
+    return BigNumber.from(fallbackGasUnits);
   }
 }
 
@@ -254,7 +271,7 @@ export async function estimateTransactionFeeViem({
   transaction: ViemTransaction;
   provider: ViemProvider;
   sender: Address;
-} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+} & EvmTransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
   assertValidFallbackGasUnits(fallbackGasUnits);
   assert(isViemAddress(sender), `Invalid EVM sender address: ${sender}`);
   const estimateGas = (includeStateOverride: boolean) =>
@@ -272,12 +289,14 @@ export async function estimateTransactionFeeViem({
   } catch (error) {
     if (!ignoreSenderBalance || !isStateOverrideUnsupportedError(error))
       throw error;
+    if (isNullish(fallbackGasUnits)) {
+      throw new StateOverrideUnsupportedError({ cause: error });
+    }
     logger.warn(
-      'RPC rejected eth_estimateGas state override; using fallback estimation',
+      { estimator: 'viem', jsonRpcCode: INVALID_PARAMS_JSON_RPC_ERROR },
+      'Viem RPC rejected eth_estimateGas state override; using caller-provided fallback gas units without transaction simulation',
     );
-    gasUnits = !isNullish(fallbackGasUnits)
-      ? fallbackGasUnits
-      : await estimateGas(false);
+    gasUnits = fallbackGasUnits;
   }
   const feeData = await provider.provider.estimateFeesPerGas();
   return computeEvmTxFee(gasUnits, feeData.gasPrice, feeData.maxFeePerGas);
@@ -582,13 +601,7 @@ export function estimateTransactionFee({
   senderPubKey,
   ignoreSenderBalance,
   fallbackGasUnits,
-}: {
-  transaction: TypedTransaction;
-  provider: TypedProvider;
-  chainMetadata: ChainMetadata;
-  sender: Address;
-  senderPubKey?: HexString;
-} & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+}: TransactionFeeEstimateParams): Promise<TransactionFeeEstimate> {
   if (
     transaction.type === ProviderType.EthersV5 &&
     provider.type === ProviderType.EthersV5

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -103,15 +103,22 @@ export interface TransactionFeeEstimateOptions {
   ignoreSenderBalance?: boolean;
 }
 
-export interface EvmTransactionFeeEstimateOptions extends TransactionFeeEstimateOptions {
-  /**
-   * Positive gas units to use when an RPC rejects balance state overrides.
-   * Supplying this value skips successful gas simulation and revert detection.
-   */
-  fallbackGasUnits?: bigint;
-}
+export type EvmTransactionFeeEstimateOptions =
+  | {
+      ignoreSenderBalance: true;
+      /**
+       * Positive gas units to use when an RPC rejects balance state overrides.
+       * Supplying this value skips successful gas simulation and revert detection.
+       */
+      fallbackGasUnits?: bigint;
+    }
+  | {
+      ignoreSenderBalance?: false;
+      fallbackGasUnits?: never;
+    };
 
-interface EvmTransactionFeeEstimatorOptions extends EvmTransactionFeeEstimateOptions {
+interface EvmTransactionFeeEstimatorOptions extends TransactionFeeEstimateOptions {
+  fallbackGasUnits?: bigint;
   chainName?: string;
 }
 
@@ -126,18 +133,21 @@ type TransactionFeeEstimateCommon = {
   senderPubKey?: HexString;
 };
 
-export type TransactionFeeEstimateParams =
-  | (TransactionFeeEstimateCommon &
-      EvmTransactionFeeEstimateOptions & {
-        transaction: EvmTypedTransaction;
-      })
-  | (TransactionFeeEstimateCommon &
-      TransactionFeeEstimateOptions & {
-        transaction: TypedTransaction;
-        fallbackGasUnits?: never;
-      });
+export type TransactionFeeEstimateTransactionOptions =
+  | (EvmTransactionFeeEstimateOptions & {
+      transaction: EvmTypedTransaction;
+    })
+  | (TransactionFeeEstimateOptions & {
+      transaction: TypedTransaction;
+      fallbackGasUnits?: never;
+    });
+
+export type TransactionFeeEstimateParams = TransactionFeeEstimateCommon &
+  TransactionFeeEstimateTransactionOptions;
 
 export class StateOverrideUnsupportedError extends Error {
+  readonly code = INVALID_PARAMS_JSON_RPC_ERROR;
+
   constructor(options?: ErrorOptions) {
     super(
       'RPC does not support eth_estimateGas state overrides; provide fallbackGasUnits to keep estimation balance-independent',
@@ -175,7 +185,7 @@ export async function estimateTransactionFeeEthersV5({
   provider: EV5Providers.Provider;
   sender: Address;
 } & EvmTransactionFeeEstimatorOptions): Promise<TransactionFeeEstimate> {
-  assertValidFallbackGasUnits(fallbackGasUnits);
+  assertValidFallbackGasUnits(fallbackGasUnits, ignoreSenderBalance);
   const gasUnits = ignoreSenderBalance
     ? await estimateGasEthersV5WithBalanceOverride({
         transaction,
@@ -285,7 +295,7 @@ export async function estimateTransactionFeeViem({
   provider: ViemProvider;
   sender: Address;
 } & EvmTransactionFeeEstimatorOptions): Promise<TransactionFeeEstimate> {
-  assertValidFallbackGasUnits(fallbackGasUnits);
+  assertValidFallbackGasUnits(fallbackGasUnits, ignoreSenderBalance);
   assert(isViemAddress(sender), `Invalid EVM sender address: ${sender}`);
   const estimateGas = (includeStateOverride: boolean) =>
     provider.provider.estimateGas(
@@ -319,7 +329,14 @@ export async function estimateTransactionFeeViem({
   return computeEvmTxFee(gasUnits, feeData.gasPrice, feeData.maxFeePerGas);
 }
 
-function assertValidFallbackGasUnits(fallbackGasUnits?: bigint): void {
+function assertValidFallbackGasUnits(
+  fallbackGasUnits: bigint | undefined,
+  ignoreSenderBalance: boolean | undefined,
+): void {
+  assert(
+    isNullish(fallbackGasUnits) || ignoreSenderBalance === true,
+    'fallbackGasUnits requires ignoreSenderBalance: true',
+  );
   assert(
     isNullish(fallbackGasUnits) || fallbackGasUnits > 0n,
     'fallbackGasUnits must be positive',
@@ -342,6 +359,7 @@ function getViemEstimateGasParameters(
       stateOverride: [{ address: sender, balance: EVM_MAX_BALANCE }],
     }),
   };
+  const transactionType: string = transaction.type;
 
   switch (transaction.type) {
     case 'legacy':
@@ -384,6 +402,8 @@ function getViemEstimateGasParameters(
         maxFeePerGas: transaction.maxFeePerGas,
         maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
       };
+    default:
+      assert(false, `Unsupported Viem transaction type: ${transactionType}`);
   }
 }
 
@@ -610,37 +630,54 @@ export async function estimateTransactionFeeAleo({
   });
 }
 
-export function estimateTransactionFee({
-  transaction,
-  provider,
-  chainMetadata,
-  sender,
-  senderPubKey,
-  ignoreSenderBalance,
-  fallbackGasUnits,
-}: TransactionFeeEstimateParams): Promise<TransactionFeeEstimate> {
+export function estimateTransactionFee(
+  params: TransactionFeeEstimateParams,
+): Promise<TransactionFeeEstimate> {
+  assertValidFallbackGasUnits(
+    params.fallbackGasUnits,
+    params.ignoreSenderBalance,
+  );
+  const { transaction, provider, chainMetadata, sender, senderPubKey } = params;
   if (
     transaction.type === ProviderType.EthersV5 &&
     provider.type === ProviderType.EthersV5
   ) {
+    if (params.ignoreSenderBalance === true) {
+      return estimateTransactionFeeEthersV5({
+        transaction: transaction.transaction,
+        provider: provider.provider,
+        sender,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: params.fallbackGasUnits,
+        chainName: chainMetadata.name,
+      });
+    }
     return estimateTransactionFeeEthersV5({
       transaction: transaction.transaction,
       provider: provider.provider,
       sender,
-      ignoreSenderBalance,
-      fallbackGasUnits,
+      ignoreSenderBalance: false,
       chainName: chainMetadata.name,
     });
   } else if (
     transaction.type === ProviderType.Viem &&
     provider.type === ProviderType.Viem
   ) {
+    if (params.ignoreSenderBalance === true) {
+      return estimateTransactionFeeViem({
+        transaction,
+        provider,
+        sender,
+        ignoreSenderBalance: true,
+        fallbackGasUnits: params.fallbackGasUnits,
+        chainName: chainMetadata.name,
+      });
+    }
     return estimateTransactionFeeViem({
       transaction,
       provider,
       sender,
-      ignoreSenderBalance,
-      fallbackGasUnits,
+      ignoreSenderBalance: false,
       chainName: chainMetadata.name,
     });
   } else if (
@@ -650,7 +687,7 @@ export function estimateTransactionFee({
     return estimateTransactionFeeSolanaWeb3({
       transaction,
       provider,
-      ignoreSenderBalance,
+      ignoreSenderBalance: params.ignoreSenderBalance,
     });
   } else if (
     transaction.type === ProviderType.CosmJs &&
@@ -725,11 +762,11 @@ export function estimateTransactionFee({
     // Tron is EVM-compatible; its typed transaction/provider use EthersV5 underlying types
     // Tron does not support EVM state overrides. TronJsonRpcProvider.estimateGas
     // already falls back to a balance-independent energy limit when estimation fails.
-    sender = convertToProtocolAddress(sender, ProtocolType.Ethereum);
+    const evmSender = convertToProtocolAddress(sender, ProtocolType.Ethereum);
     return estimateTransactionFeeEthersV5({
       transaction: transaction.transaction,
       provider: provider.provider,
-      sender,
+      sender: evmSender,
     });
   } else {
     throw new Error(

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -12,6 +12,7 @@ import {
   type PopulatedTransaction as EV5Transaction,
   utils as EthersV5Utils,
 } from 'ethers';
+import { isAddress as isViemAddress } from 'viem';
 
 import {
   StargateClientCache,
@@ -26,6 +27,7 @@ import {
   assert,
   convertToProtocolAddress,
   isNullish,
+  rootLogger,
 } from '@hyperlane-xyz/utils';
 
 import { ChainMetadata } from '../metadata/chainMetadataTypes.js';
@@ -52,18 +54,79 @@ import {
   ViemProvider,
   ViemTransaction,
 } from './ProviderType.js';
-import { HyperlaneSmartProvider } from './SmartProvider/SmartProvider.js';
+import {
+  getNestedJsonRpcError,
+  HyperlaneSmartProvider,
+} from './SmartProvider/SmartProvider.js';
 import { ProviderMethod } from './SmartProvider/ProviderMethods.js';
 
 const EVM_MAX_BALANCE = (1n << 256n) - 1n;
 const EVM_MAX_BALANCE_HEX = `0x${'f'.repeat(64)}`;
 
+const logger = rootLogger.child({ module: 'transactionFeeEstimators' });
+
+const INVALID_PARAMS_JSON_RPC_ERROR = -32602;
+
+function isStateOverrideUnsupportedError(error: unknown): boolean {
+  let current = error;
+  while (current instanceof Error) {
+    const nestedError = getNestedJsonRpcError(current);
+    const directError = getNestedJsonRpcError({ error: current });
+    const codes = [getErrorCode(current), nestedError.code, directError.code];
+    const message = [
+      current.message,
+      getErrorBody(current),
+      nestedError.message,
+      directError.message,
+    ]
+      .filter((part): part is string => typeof part === 'string')
+      .join(' ')
+      .toLowerCase();
+    if (
+      codes.some((code) => Number(code) === INVALID_PARAMS_JSON_RPC_ERROR) &&
+      isUnsupportedStateOverrideMessage(message)
+    ) {
+      return true;
+    }
+    current = current.cause;
+  }
+
+  return false;
+}
+
+function getErrorBody(error: Error): string | undefined {
+  if (!('body' in error)) return undefined;
+  return typeof error.body === 'string' ? error.body : undefined;
+}
+
+function getErrorCode(error: Error): number | string | undefined {
+  if (!('code' in error)) return undefined;
+  return typeof error.code === 'number' || typeof error.code === 'string'
+    ? error.code
+    : undefined;
+}
+
+function isUnsupportedStateOverrideMessage(message: string): boolean {
+  return (
+    message.includes('too many arguments') ||
+    message.includes('invalid argument 2') ||
+    message.includes('method parameters invalid') ||
+    ((message.includes('state override') ||
+      message.includes('stateoverride')) &&
+      (message.includes('not supported') || message.includes('unsupported')))
+  );
+}
+
 export interface TransactionFeeEstimateOptions {
   /**
-   * Estimates the fee without requiring the sender's native balance to fund
-   * both the transaction value and its network fee. Defaults to false.
+   * Attempts to estimate the fee without requiring the sender's native balance
+   * to fund both the transaction value and its network fee. Defaults to false.
+   * RPCs without state-override support use fallbackGasUnits when provided,
+   * otherwise they retry a balance-dependent estimate.
    */
   ignoreSenderBalance?: boolean;
+  /** Gas units to use when an RPC rejects balance state overrides. */
+  fallbackGasUnits?: bigint;
 }
 
 export interface TransactionFeeEstimate {
@@ -87,6 +150,7 @@ export async function estimateTransactionFeeEthersV5({
   provider,
   sender,
   ignoreSenderBalance,
+  fallbackGasUnits,
 }: {
   transaction: EV5Transaction;
   provider: EV5Providers.Provider;
@@ -97,6 +161,7 @@ export async function estimateTransactionFeeEthersV5({
         transaction,
         provider,
         sender,
+        fallbackGasUnits,
       })
     : await provider.estimateGas({
         ...transaction,
@@ -112,10 +177,12 @@ async function estimateGasEthersV5WithBalanceOverride({
   transaction,
   provider,
   sender,
+  fallbackGasUnits,
 }: {
   transaction: EV5Transaction;
   provider: EV5Providers.Provider;
   sender: Address;
+  fallbackGasUnits?: bigint;
 }): Promise<BigNumber> {
   const resolvedTransaction = EV5Providers.JsonRpcProvider.hexlifyTransaction(
     await EthersV5Utils.resolveProperties({ ...transaction, from: sender }),
@@ -123,28 +190,37 @@ async function estimateGasEthersV5WithBalanceOverride({
   );
   const stateOverride = { [sender]: { balance: EVM_MAX_BALANCE_HEX } };
 
-  if (provider instanceof HyperlaneSmartProvider) {
-    return BigNumber.from(
-      await provider.perform(ProviderMethod.EstimateGas, {
-        transaction: resolvedTransaction,
-        stateOverride,
-      }),
-    );
-  }
+  try {
+    if (provider instanceof HyperlaneSmartProvider) {
+      return BigNumber.from(
+        await provider.perform(ProviderMethod.EstimateGas, {
+          transaction: resolvedTransaction,
+          stateOverride,
+        }),
+      );
+    }
 
-  if ('send' in provider && typeof provider.send === 'function') {
-    return BigNumber.from(
-      await provider.send('eth_estimateGas', [
-        resolvedTransaction,
-        'latest',
-        stateOverride,
-      ]),
-    );
-  }
+    if ('send' in provider && typeof provider.send === 'function') {
+      return BigNumber.from(
+        await provider.send('eth_estimateGas', [
+          resolvedTransaction,
+          'latest',
+          stateOverride,
+        ]),
+      );
+    }
 
-  throw new Error(
-    'Ignoring sender balance requires a JSON-RPC Ethers provider',
-  );
+    throw new Error(
+      'Ignoring sender balance requires a JSON-RPC Ethers provider',
+    );
+  } catch (error) {
+    if (!isStateOverrideUnsupportedError(error)) throw error;
+    logger.warn(
+      'RPC rejected eth_estimateGas state override; using fallback estimation',
+    );
+    if (!isNullish(fallbackGasUnits)) return BigNumber.from(fallbackGasUnits);
+    return provider.estimateGas({ ...transaction, from: sender });
+  }
 }
 
 // Separating out inner function to allow WarpCore to reuse logic
@@ -172,21 +248,38 @@ export async function estimateTransactionFeeViem({
   provider,
   sender,
   ignoreSenderBalance,
+  fallbackGasUnits,
 }: {
   transaction: ViemTransaction;
   provider: ViemProvider;
   sender: Address;
 } & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
-  const gasUnits = await provider.provider.estimateGas({
-    ...transaction.transaction,
-    blockNumber: undefined,
-    account: sender as `0x${string}`,
-    ...(ignoreSenderBalance && {
-      stateOverride: [
-        { address: sender as `0x${string}`, balance: EVM_MAX_BALANCE },
-      ],
-    }),
-  } as any); // Cast to silence overly-protective type enforcement from viem here
+  assert(isViemAddress(sender), `Invalid EVM sender address: ${sender}`);
+  const estimateGas = (includeStateOverride: boolean) =>
+    provider.provider.estimateGas({
+      ...transaction.transaction,
+      blockNumber: undefined,
+      account: sender,
+      ...(includeStateOverride && {
+        stateOverride: [{ address: sender, balance: EVM_MAX_BALANCE }],
+      }),
+      // CAST: Viem's estimate type rejects the normalized transaction union
+      // even though its supported fields are accepted at runtime.
+    } as any);
+
+  let gasUnits: bigint;
+  try {
+    gasUnits = await estimateGas(!!ignoreSenderBalance);
+  } catch (error) {
+    if (!ignoreSenderBalance || !isStateOverrideUnsupportedError(error))
+      throw error;
+    logger.warn(
+      'RPC rejected eth_estimateGas state override; using fallback estimation',
+    );
+    gasUnits = !isNullish(fallbackGasUnits)
+      ? fallbackGasUnits
+      : await estimateGas(false);
+  }
   const feeData = await provider.provider.estimateFeesPerGas();
   return computeEvmTxFee(gasUnits, feeData.gasPrice, feeData.maxFeePerGas);
 }
@@ -421,6 +514,7 @@ export function estimateTransactionFee({
   sender,
   senderPubKey,
   ignoreSenderBalance,
+  fallbackGasUnits,
 }: {
   transaction: TypedTransaction;
   provider: TypedProvider;
@@ -437,6 +531,7 @@ export function estimateTransactionFee({
       provider: provider.provider,
       sender,
       ignoreSenderBalance,
+      fallbackGasUnits,
     });
   } else if (
     transaction.type === ProviderType.Viem &&
@@ -447,6 +542,7 @@ export function estimateTransactionFee({
       provider,
       sender,
       ignoreSenderBalance,
+      fallbackGasUnits,
     });
   } else if (
     transaction.type === ProviderType.SolanaWeb3 &&

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -111,6 +111,10 @@ export interface EvmTransactionFeeEstimateOptions extends TransactionFeeEstimate
   fallbackGasUnits?: bigint;
 }
 
+interface EvmTransactionFeeEstimatorOptions extends EvmTransactionFeeEstimateOptions {
+  chainName?: string;
+}
+
 type EvmTypedTransaction = Extract<
   TypedTransaction,
   { type: ProviderType.EthersV5 | ProviderType.Viem }
@@ -165,11 +169,12 @@ export async function estimateTransactionFeeEthersV5({
   sender,
   ignoreSenderBalance,
   fallbackGasUnits,
+  chainName,
 }: {
   transaction: EV5Transaction;
   provider: EV5Providers.Provider;
   sender: Address;
-} & EvmTransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+} & EvmTransactionFeeEstimatorOptions): Promise<TransactionFeeEstimate> {
   assertValidFallbackGasUnits(fallbackGasUnits);
   const gasUnits = ignoreSenderBalance
     ? await estimateGasEthersV5WithBalanceOverride({
@@ -177,6 +182,7 @@ export async function estimateTransactionFeeEthersV5({
         provider,
         sender,
         fallbackGasUnits,
+        chainName,
       })
     : await provider.estimateGas({
         ...transaction,
@@ -193,11 +199,13 @@ async function estimateGasEthersV5WithBalanceOverride({
   provider,
   sender,
   fallbackGasUnits,
+  chainName,
 }: {
   transaction: EV5Transaction;
   provider: EV5Providers.Provider;
   sender: Address;
   fallbackGasUnits?: bigint;
+  chainName?: string;
 }): Promise<BigNumber> {
   const resolvedTransaction = EV5Providers.JsonRpcProvider.hexlifyTransaction(
     await EthersV5Utils.resolveProperties({ ...transaction, from: sender }),
@@ -234,7 +242,11 @@ async function estimateGasEthersV5WithBalanceOverride({
       throw new StateOverrideUnsupportedError({ cause: error });
     }
     logger.warn(
-      { estimator: 'ethersV5', jsonRpcCode: INVALID_PARAMS_JSON_RPC_ERROR },
+      {
+        estimator: 'ethersV5',
+        chainName,
+        jsonRpcCode: INVALID_PARAMS_JSON_RPC_ERROR,
+      },
       'Ethers v5 RPC rejected eth_estimateGas state override; using caller-provided fallback gas units without transaction simulation',
     );
     return BigNumber.from(fallbackGasUnits);
@@ -267,11 +279,12 @@ export async function estimateTransactionFeeViem({
   sender,
   ignoreSenderBalance,
   fallbackGasUnits,
+  chainName,
 }: {
   transaction: ViemTransaction;
   provider: ViemProvider;
   sender: Address;
-} & EvmTransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+} & EvmTransactionFeeEstimatorOptions): Promise<TransactionFeeEstimate> {
   assertValidFallbackGasUnits(fallbackGasUnits);
   assert(isViemAddress(sender), `Invalid EVM sender address: ${sender}`);
   const estimateGas = (includeStateOverride: boolean) =>
@@ -293,7 +306,11 @@ export async function estimateTransactionFeeViem({
       throw new StateOverrideUnsupportedError({ cause: error });
     }
     logger.warn(
-      { estimator: 'viem', jsonRpcCode: INVALID_PARAMS_JSON_RPC_ERROR },
+      {
+        estimator: 'viem',
+        chainName,
+        jsonRpcCode: INVALID_PARAMS_JSON_RPC_ERROR,
+      },
       'Viem RPC rejected eth_estimateGas state override; using caller-provided fallback gas units without transaction simulation',
     );
     gasUnits = fallbackGasUnits;
@@ -612,6 +629,7 @@ export function estimateTransactionFee({
       sender,
       ignoreSenderBalance,
       fallbackGasUnits,
+      chainName: chainMetadata.name,
     });
   } else if (
     transaction.type === ProviderType.Viem &&
@@ -623,6 +641,7 @@ export function estimateTransactionFee({
       sender,
       ignoreSenderBalance,
       fallbackGasUnits,
+      chainName: chainMetadata.name,
     });
   } else if (
     transaction.type === ProviderType.SolanaWeb3 &&

--- a/typescript/sdk/src/providers/transactionFeeEstimators.ts
+++ b/typescript/sdk/src/providers/transactionFeeEstimators.ts
@@ -12,7 +12,7 @@ import {
   type PopulatedTransaction as EV5Transaction,
   utils as EthersV5Utils,
 } from 'ethers';
-import { isAddress as isViemAddress } from 'viem';
+import { type EstimateGasParameters, isAddress as isViemAddress } from 'viem';
 
 import {
   StargateClientCache,
@@ -125,7 +125,7 @@ export interface TransactionFeeEstimateOptions {
    * otherwise they retry a balance-dependent estimate.
    */
   ignoreSenderBalance?: boolean;
-  /** Gas units to use when an RPC rejects balance state overrides. */
+  /** Positive gas units to use when an RPC rejects balance state overrides. */
   fallbackGasUnits?: bigint;
 }
 
@@ -156,6 +156,7 @@ export async function estimateTransactionFeeEthersV5({
   provider: EV5Providers.Provider;
   sender: Address;
 } & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+  assertValidFallbackGasUnits(fallbackGasUnits);
   const gasUnits = ignoreSenderBalance
     ? await estimateGasEthersV5WithBalanceOverride({
         transaction,
@@ -254,18 +255,16 @@ export async function estimateTransactionFeeViem({
   provider: ViemProvider;
   sender: Address;
 } & TransactionFeeEstimateOptions): Promise<TransactionFeeEstimate> {
+  assertValidFallbackGasUnits(fallbackGasUnits);
   assert(isViemAddress(sender), `Invalid EVM sender address: ${sender}`);
   const estimateGas = (includeStateOverride: boolean) =>
-    provider.provider.estimateGas({
-      ...transaction.transaction,
-      blockNumber: undefined,
-      account: sender,
-      ...(includeStateOverride && {
-        stateOverride: [{ address: sender, balance: EVM_MAX_BALANCE }],
-      }),
-      // CAST: Viem's estimate type rejects the normalized transaction union
-      // even though its supported fields are accepted at runtime.
-    } as any);
+    provider.provider.estimateGas(
+      getViemEstimateGasParameters(
+        transaction.transaction,
+        sender,
+        includeStateOverride,
+      ),
+    );
 
   let gasUnits: bigint;
   try {
@@ -282,6 +281,74 @@ export async function estimateTransactionFeeViem({
   }
   const feeData = await provider.provider.estimateFeesPerGas();
   return computeEvmTxFee(gasUnits, feeData.gasPrice, feeData.maxFeePerGas);
+}
+
+function assertValidFallbackGasUnits(fallbackGasUnits?: bigint): void {
+  assert(
+    isNullish(fallbackGasUnits) || fallbackGasUnits > 0n,
+    'fallbackGasUnits must be positive',
+  );
+}
+
+function getViemEstimateGasParameters(
+  transaction: ViemTransaction['transaction'],
+  sender: `0x${string}`,
+  includeStateOverride: boolean,
+): EstimateGasParameters {
+  const common = {
+    account: sender,
+    data: transaction.input,
+    gas: transaction.gas,
+    nonce: transaction.nonce,
+    to: transaction.to,
+    value: transaction.value,
+    ...(includeStateOverride && {
+      stateOverride: [{ address: sender, balance: EVM_MAX_BALANCE }],
+    }),
+  };
+
+  switch (transaction.type) {
+    case 'legacy':
+      return {
+        ...common,
+        type: transaction.type,
+        gasPrice: transaction.gasPrice,
+      };
+    case 'eip2930':
+      return {
+        ...common,
+        type: transaction.type,
+        accessList: transaction.accessList,
+        gasPrice: transaction.gasPrice,
+      };
+    case 'eip1559':
+      return {
+        ...common,
+        type: transaction.type,
+        accessList: transaction.accessList,
+        maxFeePerGas: transaction.maxFeePerGas,
+        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+      };
+    case 'eip4844':
+      return {
+        ...common,
+        type: transaction.type,
+        accessList: transaction.accessList,
+        blobVersionedHashes: transaction.blobVersionedHashes,
+        maxFeePerBlobGas: transaction.maxFeePerBlobGas,
+        maxFeePerGas: transaction.maxFeePerGas,
+        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+      };
+    case 'eip7702':
+      return {
+        ...common,
+        type: transaction.type,
+        accessList: transaction.accessList,
+        authorizationList: transaction.authorizationList,
+        maxFeePerGas: transaction.maxFeePerGas,
+        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+      };
+  }
 }
 
 function computeEvmTxFee(

--- a/typescript/sdk/src/timelock/evm/errors.test.ts
+++ b/typescript/sdk/src/timelock/evm/errors.test.ts
@@ -20,6 +20,18 @@ describe('timelock EVM errors', () => {
       },
       true,
     ],
+    [
+      'outer body-encoded code 3',
+      {
+        error: {},
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          error: { code: 3, message: 'execution reverted' },
+        }),
+      },
+      true,
+    ],
     ['nested transient call exception', { error: { code: -32000 } }, false],
   ];
 

--- a/typescript/sdk/src/timelock/evm/errors.ts
+++ b/typescript/sdk/src/timelock/evm/errors.ts
@@ -1,6 +1,6 @@
 import { errors as EthersError } from 'ethers';
 
-import { getNestedJsonRpcError } from '../../providers/SmartProvider/SmartProvider.js';
+import { getJsonRpcErrorFrom } from '../../providers/SmartProvider/SmartProvider.js';
 
 type EthersCallException = {
   code?: unknown;
@@ -21,7 +21,7 @@ export function isDeterministicTimelockReadError(error: unknown): boolean {
 
   const hasRevertData = !!record.data && record.data !== '0x';
   const hasNestedError = !!record.error;
-  const jsonRpcErrorCode = getNestedJsonRpcError(error).code;
+  const jsonRpcErrorCode = getJsonRpcErrorFrom(error).code;
 
   return hasRevertData || jsonRpcErrorCode === 3 || !hasNestedError;
 }


### PR DESCRIPTION
## Summary

- Fixes EVM fee estimation on RPCs that reject the third `eth_estimateGas` state-override parameter with JSON-RPC `-32602`.
- Requires both `-32602` and a narrow unsupported-parameter message across Ethers response bodies and real Viem cause chains; unrelated invalid-params errors still propagate.
- Covers Ethers v5 and Viem providers without exposing `fallbackGasUnits` to non-EVM transaction types.
- Callers can provide positive `fallbackGasUnits` to remain balance-independent. This explicitly skips successful gas simulation and revert detection.
- Throws `StateOverrideUnsupportedError` when an RPC rejects state overrides and no fallback is supplied; it no longer silently retries against the real sender balance.
- Logs only safe estimator, chain-name, and JSON-RPC-code diagnostics, never raw provider errors, URLs, request bodies, senders, calldata, or values.

## Live verification

Against `https://json-rpc.kiivalidator.com`:

- Reported funded sender, two-parameter estimate: `0x329da`
- Same estimate with state override: `-32602 too many arguments, want at most 2`
- Zero-balance sender, two-parameter estimate: `-32000 insufficient balance for transfer`

The last result is why unsupported state overrides now require an explicit fallback or produce a typed error instead of a balance-dependent retry.

## Test plan

- [x] Node.js `26.6.0`
- [x] `pnpm -C typescript/sdk build`
- [x] `pnpm -C typescript/sdk test:unit` — 1,322 passing
- [x] Focused estimator tests — 25 passing, including real Viem `InvalidParamsRpcError` chains
- [x] `pnpm -C typescript/sdk check`
- [x] `pnpm -C typescript/sdk lint`
- [x] Oxfmt and `git diff --check`
- [ ] Confirm Nexus passes the quote origin gas budget as `fallbackGasUnits` after consuming an SDK release with this patch
