### PR TITLE
fix(rebalancer): await bridge seed receipts in e2e

### DIFF
--- a/typescript/rebalancer/src/e2e/harness/NativeLocalDeploymentManager.ts
+++ b/typescript/rebalancer/src/e2e/harness/NativeLocalDeploymentManager.ts
@@ -115,10 +115,11 @@ export class NativeLocalDeploymentManager extends BaseLocalDeploymentManager<Nat
     for (const chain of TEST_CHAIN_CONFIGS) {
       const provider = providersByChain.get(chain.name)!;
       const deployer = deployerWallet.connect(provider);
-      await deployer.sendTransaction({
+      const seedTx = await deployer.sendTransaction({
         to: bridgeRouters[chain.name].address,
         value: bridgeSeedAmount,
       });
+      await seedTx.wait();
     }
 
     return {


### PR DESCRIPTION
## Summary

- wait for native mock bridge seed transactions to be mined before capturing the E2E snapshot
- prevent restored snapshots from intermittently lacking bridge liquidity

## Root cause

The inventory-weighted shard repeatedly failed because bridge relay reverted with `Address: insufficient balance`. Setup submitted each 10 ETH bridge seed transaction but did not await its receipt before the suite snapshot. On slower Anvil runs, the snapshot permanently captured an unfunded bridge and later assertions cascaded.

Observed on runs [31711904253](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/31711904253), [31782269187](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/31782269187), [31821844508](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/31821844508), [32154309474](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/32154309474), and [33225374292](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33225374292).

## Validation

- affected inventory-weighted E2E shard: 3 consecutive passes, 6 tests each, Node 26.6.0
- `pnpm build` in `typescript/rebalancer`
- `pnpm lint` in `typescript/rebalancer` (only existing expect-expect warnings)
- focused format check and `git diff --check`

No changeset: test harness only.