### PR TITLE
fix(relayer): read GCS validator checkpoints

### DIFF
--- a/.changeset/gentle-clouds-relay.md
+++ b/.changeset/gentle-clouds-relay.md
@@ -1,0 +1,5 @@
+---
+"@hyperlane-xyz/relayer": patch
+---
+
+Multisig metadata builders were updated to read validator checkpoints from GCS announcements in addition to S3.

--- a/typescript/relayer/src/metadata/multisig.test.ts
+++ b/typescript/relayer/src/metadata/multisig.test.ts
@@ -1,7 +1,13 @@
 import { expect } from 'chai';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import sinon from 'sinon';
 
-import { IsmType, ModuleType } from '@hyperlane-xyz/sdk';
+import {
+  GcpValidator,
+  HyperlaneCore,
+  IsmType,
+  ModuleType,
+} from '@hyperlane-xyz/sdk';
 import { SignatureLike } from '@hyperlane-xyz/utils';
 
 import { MultisigMetadata, MultisigMetadataBuilder } from './multisig.js';
@@ -48,6 +54,51 @@ const fixtures: Fixture<MultisigMetadata>[] = files
     }
     return { decoded, encoded: contents.encoded };
   });
+
+class TestMultisigMetadataBuilder extends MultisigMetadataBuilder {
+  public constructor(private readonly storageLocations: string[][]) {
+    super(sinon.createStubInstance(HyperlaneCore));
+  }
+
+  protected override async getAnnouncedStorageLocations(): Promise<string[][]> {
+    return this.storageLocations;
+  }
+
+  public getCheckpointValidators(originChain: string, validators: string[]) {
+    return this.checkpointValidators(originChain, validators);
+  }
+}
+
+describe('MultisigMetadataBuilder validator storage', () => {
+  afterEach(() => sinon.restore());
+
+  it('initializes GCS validators from announced storage locations', async () => {
+    const location =
+      'gs://hyperlane-mainnet3-validator-0/nesachain/gcsAnnouncementKey';
+    const validatorAddress = '0xA5962eFA3ec138Bf7CA8f7fDe86b7ee32E24bf03';
+    const validator = new GcpValidator(
+      {
+        address: validatorAddress,
+        localDomain: 41444,
+        mailbox: '0x0000000000000000000000000000000000000001',
+      },
+      {
+        bucket: 'hyperlane-mainnet3-validator-0',
+        folder: 'nesachain',
+        caching: true,
+      },
+    );
+    const fromStorageLocation = sinon
+      .stub(GcpValidator, 'fromStorageLocation')
+      .resolves(validator);
+    const builder = new TestMultisigMetadataBuilder([[location]]);
+
+    expect(
+      await builder.getCheckpointValidators('nesachain', [validatorAddress]),
+    ).to.deep.equal([validator]);
+    expect(fromStorageLocation.calledOnceWithExactly(location)).to.equal(true);
+  });
+});
 
 // FIXME: migrate to mocha rules
 // eslint-disable-next-line jest/no-disabled-tests -- intentionally skipped pending migration

--- a/typescript/relayer/src/metadata/multisig.ts
+++ b/typescript/relayer/src/metadata/multisig.ts
@@ -7,8 +7,8 @@ import {
   IsmType,
   MerkleTreeHookConfig,
   MultisigIsmConfig,
-  S3Validator,
   defaultMultisigConfigs,
+  getValidatorFromStorageLocation,
 } from '@hyperlane-xyz/sdk';
 import {
   Address,
@@ -60,10 +60,14 @@ export type MultisigMetadata =
   | MessageIdMultisigMetadata
   | MerkleRootMultisigMetadata;
 
+type CheckpointValidator = Awaited<
+  ReturnType<typeof getValidatorFromStorageLocation>
+>;
+
 export class MultisigMetadataBuilder implements MetadataBuilder {
   protected validatorCache: Record<
     ChainName,
-    Record<string, S3Validator | undefined>
+    Record<string, CheckpointValidator | undefined>
   > = {};
 
   constructor(
@@ -88,21 +92,29 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     return validator?.alias;
   }
 
-  protected async s3Validators(
+  protected getAnnouncedStorageLocations(
     originChain: ChainName,
     validators: string[],
-  ): Promise<(S3Validator | undefined)[]> {
+  ): Promise<string[][]> {
+    return this.core
+      .getContracts(originChain)
+      .validatorAnnounce.getAnnouncedStorageLocations(validators);
+  }
+
+  protected async checkpointValidators(
+    originChain: ChainName,
+    validators: string[],
+  ): Promise<(CheckpointValidator | undefined)[]> {
     this.validatorCache[originChain] ??= {};
     const toFetch = validators.filter(
       (v) => !(v in this.validatorCache[originChain]),
     );
 
     if (toFetch.length > 0) {
-      const validatorAnnounce =
-        this.core.getContracts(originChain).validatorAnnounce;
-
-      const storageLocations =
-        await validatorAnnounce.getAnnouncedStorageLocations(toFetch);
+      const storageLocations = await this.getAnnouncedStorageLocations(
+        originChain,
+        toFetch,
+      );
 
       this.logger.debug({ storageLocations }, 'Fetched storage locations');
 
@@ -117,7 +129,7 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
               `No storage location announced for validator ${toFetch[index]}`,
             );
           }
-          return S3Validator.fromStorageLocation(latestLocation);
+          return getValidatorFromStorageLocation(latestLocation);
         },
       );
 
@@ -125,7 +137,7 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
       rejected.forEach((error, index) => {
         this.logger.warn(
           { validator: toFetch[index], error: error.message },
-          'Failed to initialize S3Validator',
+          'Failed to initialize checkpoint validator',
         );
       });
 
@@ -163,16 +175,19 @@ export class MultisigMetadataBuilder implements MetadataBuilder {
     this.logger.debug({ match, validators }, 'Fetching validator checkpoints');
 
     const originChain = this.core.multiProvider.getChainName(match.origin);
-    const s3Validators = await this.s3Validators(originChain, validators);
+    const checkpointValidators = await this.checkpointValidators(
+      originChain,
+      validators,
+    );
 
     const { fulfilled, rejected } = await mapAllSettled(
       validators,
       async (_, index) => {
-        const s3Validator = s3Validators[index];
-        if (!s3Validator) {
+        const checkpointValidator = checkpointValidators[index];
+        if (!checkpointValidator) {
           throw new Error('No valid storage location for validator');
         }
-        return s3Validator.getCheckpoint(match.index);
+        return checkpointValidator.getCheckpoint(match.index);
       },
     );
 


### PR DESCRIPTION
## Summary

- route announced validator storage locations through the SDK's storage-agnostic dispatcher
- support GCS-backed validator checkpoints during CLI self-relay while preserving S3 behavior
- cover the announced `gs://bucket/folder/gcsAnnouncementKey` format with a regression test

## Root cause

The SDK already supported GCS validator storage, but the relayer metadata builder instantiated every announced location with `S3Validator.fromStorageLocation`. CLI self-relay therefore rejected valid `gs://` announcements before fetching checkpoints.

## Validation

- `pnpm -C typescript/relayer build`
- `pnpm -C typescript/relayer lint`
- `pnpm -C typescript/relayer test:unit` (11 passing)
- live SDK read of `gs://hyperlane-mainnet3-validator-0/nesachain/gcsAnnouncementKey` fetched checkpoint index 1 for message `0x3096a9d3c7faa163e4795622515b1e25b52b6fffbc31976ef72e8d59849792b9`
