### PR TITLE
perf(relayer): avoid cross-origin prepare blocking

### DIFF
--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -1,12 +1,14 @@
 #![allow(clippy::doc_markdown)] // TODO: `rustc` 1.80.1 clippy issue
 #![allow(clippy::doc_lazy_continuation)] // TODO: `rustc` 1.80.1 clippy issue
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::join_all;
 use futures_util::future::try_join_all;
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use maplit::hashmap;
 use num_traits::Zero;
 use prometheus::{IntCounterVec, IntGaugeVec};
@@ -489,51 +491,109 @@ async fn get_batch_or_wait(queue: &mut OpQueue, batch_size: u32) -> Vec<QueueOpe
 
 async fn process_batch(
     domain: HyperlaneDomain,
-    mut batch: Vec<QueueOperation>,
+    batch: Vec<QueueOperation>,
     prepare_queue: &mut OpQueue,
     submit_queue: &OpQueue,
     confirm_queue: &OpQueue,
     metrics: &MessageProcessorMetrics,
 ) {
-    let mut task_prep_futures = vec![];
-    let op_refs = batch.iter_mut().map(|op| op.as_mut()).collect::<Vec<_>>();
-    for op in op_refs {
+    let mut next_sequence_by_origin = HashMap::<u32, usize>::new();
+    let mut prepare_futures = FuturesUnordered::new();
+
+    for mut op in batch {
         trace!(?op, "Preparing operation");
         debug_assert_eq!(*op.destination_domain(), domain);
-        task_prep_futures.push(op.prepare());
-    }
-    let res = join_all(task_prep_futures).await;
-    for (op, prepare_result) in batch.into_iter().zip(res.into_iter()) {
-        let app_context = op.app_context();
-        match prepare_result {
-            PendingOperationResult::Success => {
-                debug!(?op, "Operation prepared");
 
-                metrics.inc_prepared(app_context);
-                // TODO: push multiple messages at once
-                submit_queue
-                    .push(op, Some(PendingOperationStatus::ReadyToSubmit))
-                    .await;
-            }
-            PendingOperationResult::NotReady => {
-                prepare_queue.push(op, None).await;
-            }
-            PendingOperationResult::Reprepare(reason) => {
-                metrics.inc_failed(app_context);
-                prepare_queue
-                    .push(op, Some(PendingOperationStatus::Retry(reason)))
-                    .await;
-            }
-            PendingOperationResult::Drop => {
-                metrics.inc_dropped(app_context);
-                op.decrement_metric_if_exists();
-            }
-            PendingOperationResult::Confirm(reason) => {
-                debug!(?op, "Pushing operation to confirm queue");
-                confirm_queue
-                    .push(op, Some(PendingOperationStatus::Confirm(reason)))
-                    .await;
-            }
+        let origin = op.origin_domain_id();
+        let next_sequence = next_sequence_by_origin.entry(origin).or_default();
+        let sequence = *next_sequence;
+        *next_sequence = (*next_sequence).saturating_add(1);
+        prepare_futures.push(async move {
+            let result = op.prepare().await;
+            (origin, sequence, op, result)
+        });
+    }
+    let mut next_disposition_by_origin = HashMap::<u32, usize>::new();
+    let mut completed_by_origin =
+        HashMap::<u32, HashMap<usize, (QueueOperation, PendingOperationResult)>>::new();
+
+    while let Some((origin, sequence, op, result)) = prepare_futures.next().await {
+        // Route completed work immediately unless an earlier operation from the
+        // same origin is still preparing. Operations from other origins remain
+        // independent and can make progress in the meantime.
+        completed_by_origin
+            .entry(origin)
+            .or_default()
+            .insert(sequence, (op, result));
+
+        loop {
+            let next_sequence = *next_disposition_by_origin.entry(origin).or_default();
+            let Some((op, result)) = completed_by_origin
+                .get_mut(&origin)
+                .and_then(|completed| completed.remove(&next_sequence))
+            else {
+                break;
+            };
+
+            dispose_prepared_operation(
+                op,
+                result,
+                prepare_queue,
+                submit_queue,
+                confirm_queue,
+                metrics,
+            )
+            .await;
+            next_disposition_by_origin.insert(origin, next_sequence.saturating_add(1));
+        }
+    }
+
+    debug_assert!(completed_by_origin.values().all(HashMap::is_empty));
+}
+
+/// Routes a prepared operation and returns whether it remains unready.
+async fn dispose_prepared_operation(
+    op: QueueOperation,
+    prepare_result: PendingOperationResult,
+    prepare_queue: &mut OpQueue,
+    submit_queue: &OpQueue,
+    confirm_queue: &OpQueue,
+    metrics: &MessageProcessorMetrics,
+) -> bool {
+    let app_context = op.app_context();
+    match prepare_result {
+        PendingOperationResult::Success => {
+            debug!(?op, "Operation prepared");
+
+            metrics.inc_prepared(app_context);
+            // TODO: push multiple messages at once
+            submit_queue
+                .push(op, Some(PendingOperationStatus::ReadyToSubmit))
+                .await;
+            false
+        }
+        PendingOperationResult::NotReady => {
+            prepare_queue.push(op, None).await;
+            true
+        }
+        PendingOperationResult::Reprepare(reason) => {
+            metrics.inc_failed(app_context);
+            prepare_queue
+                .push(op, Some(PendingOperationStatus::Retry(reason)))
+                .await;
+            true
+        }
+        PendingOperationResult::Drop => {
+            metrics.inc_dropped(app_context);
+            op.decrement_metric_if_exists();
+            false
+        }
+        PendingOperationResult::Confirm(reason) => {
+            debug!(?op, "Pushing operation to confirm queue");
+            confirm_queue
+                .push(op, Some(PendingOperationStatus::Confirm(reason)))
+                .await;
+            false
         }
     }
 }

--- a/rust/main/agents/relayer/src/msg/message_processor/tests.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests.rs
@@ -85,3 +85,4 @@ async fn test_recovery_backpressures_message_processor_ingress() {
         .await
         .expect("receive task should stop when ingress closes");
 }
+mod tests_process_batch;

--- a/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
@@ -170,7 +170,9 @@ impl PendingOperation for TestOperation {
 
     fn set_next_attempt_after(&mut self, _delay: Duration) {}
 
-    fn reset_attempts(&mut self) {}
+    fn reset_attempts(&mut self) -> bool {
+        true
+    }
 
     fn set_retries(&mut self, _retries: u32) {}
 

--- a/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
@@ -1,0 +1,450 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use prometheus::IntGauge;
+use serde::Serialize;
+use tokio::sync::{mpsc, Semaphore};
+
+use hyperlane_core::{
+    ChainResult, ConfirmReason, HyperlaneDomain, HyperlaneMessage, PendingOperation,
+    PendingOperationResult, PendingOperationStatus, QueueOperation, ReprepareReason, TryBatchAs,
+    TxOutcome, H256, U256,
+};
+
+use super::super::process_batch;
+use super::tests_common::{create_test_metrics, create_test_queue};
+
+#[derive(Debug, Default)]
+struct PrepareConcurrency {
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+}
+
+#[derive(Debug, Serialize)]
+struct TestOperation {
+    id: H256,
+    origin: u32,
+    destination: HyperlaneDomain,
+    status: PendingOperationStatus,
+    #[serde(skip_serializing)]
+    prepare_result: Option<PendingOperationResult>,
+    #[serde(skip_serializing)]
+    gate: Option<Arc<Semaphore>>,
+    #[serde(skip_serializing)]
+    started: mpsc::UnboundedSender<H256>,
+    #[serde(skip_serializing)]
+    completed: mpsc::UnboundedSender<H256>,
+    #[serde(skip_serializing)]
+    disposed: mpsc::UnboundedSender<H256>,
+    #[serde(skip_serializing)]
+    concurrency: Arc<PrepareConcurrency>,
+}
+
+impl TestOperation {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        id: u64,
+        origin: u32,
+        destination: HyperlaneDomain,
+        prepare_result: PendingOperationResult,
+        gate: Option<Arc<Semaphore>>,
+        started: mpsc::UnboundedSender<H256>,
+        completed: mpsc::UnboundedSender<H256>,
+        disposed: mpsc::UnboundedSender<H256>,
+        concurrency: Arc<PrepareConcurrency>,
+    ) -> Self {
+        Self {
+            id: H256::from_low_u64_be(id),
+            origin,
+            destination,
+            status: PendingOperationStatus::FirstPrepareAttempt,
+            prepare_result: Some(prepare_result),
+            gate,
+            started,
+            completed,
+            disposed,
+            concurrency,
+        }
+    }
+}
+
+#[async_trait]
+#[typetag::serialize]
+impl PendingOperation for TestOperation {
+    fn id(&self) -> H256 {
+        self.id
+    }
+
+    fn priority(&self) -> u32 {
+        self.id.to_low_u64_be() as u32
+    }
+
+    fn origin_domain_id(&self) -> u32 {
+        self.origin
+    }
+
+    fn retrieve_status_from_db(&self) -> Option<PendingOperationStatus> {
+        Some(self.status.clone())
+    }
+
+    fn destination_domain(&self) -> &HyperlaneDomain {
+        &self.destination
+    }
+
+    fn sender_address(&self) -> &H256 {
+        &self.id
+    }
+
+    fn recipient_address(&self) -> &H256 {
+        &self.id
+    }
+
+    fn body(&self) -> &[u8] {
+        &[]
+    }
+
+    fn app_context(&self) -> Option<String> {
+        None
+    }
+
+    fn get_metric(&self) -> Option<Arc<IntGauge>> {
+        None
+    }
+
+    fn set_metric(&mut self, _metric: Arc<IntGauge>) {
+        self.disposed.send(self.id).expect("disposition receiver");
+    }
+
+    fn status(&self) -> PendingOperationStatus {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, status: PendingOperationStatus) {
+        self.status = status;
+    }
+
+    async fn prepare(&mut self) -> PendingOperationResult {
+        let active = self.concurrency.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.concurrency
+            .max_active
+            .fetch_max(active, Ordering::SeqCst);
+        self.started.send(self.id).expect("started receiver");
+
+        if let Some(gate) = &self.gate {
+            gate.acquire().await.expect("gate open").forget();
+        }
+
+        self.completed.send(self.id).expect("completed receiver");
+        self.concurrency.active.fetch_sub(1, Ordering::SeqCst);
+        self.prepare_result.take().expect("single prepare call")
+    }
+
+    async fn submit(&mut self) -> PendingOperationResult {
+        unimplemented!()
+    }
+
+    fn set_submission_outcome(&mut self, _outcome: TxOutcome) {}
+
+    fn get_tx_cost_estimate(&self) -> Option<U256> {
+        None
+    }
+
+    async fn confirm(&mut self) -> PendingOperationResult {
+        unimplemented!()
+    }
+
+    async fn set_operation_outcome(
+        &mut self,
+        _submission_outcome: TxOutcome,
+        _submission_estimated_cost: U256,
+    ) {
+    }
+
+    fn next_attempt_after(&self) -> Option<Instant> {
+        None
+    }
+
+    fn set_next_attempt_after(&mut self, _delay: Duration) {}
+
+    fn reset_attempts(&mut self) {}
+
+    fn set_retries(&mut self, _retries: u32) {}
+
+    fn get_retries(&self) -> u32 {
+        0
+    }
+
+    async fn payload(&self) -> ChainResult<Vec<u8>> {
+        unimplemented!()
+    }
+
+    fn success_criteria(&self) -> ChainResult<Option<Vec<u8>>> {
+        unimplemented!()
+    }
+
+    fn on_reprepare(
+        &mut self,
+        _err_msg: Option<String>,
+        reason: ReprepareReason,
+    ) -> PendingOperationResult {
+        PendingOperationResult::Reprepare(reason)
+    }
+}
+
+impl TryBatchAs<HyperlaneMessage> for TestOperation {}
+
+struct TestHarness {
+    destination: HyperlaneDomain,
+    started_tx: mpsc::UnboundedSender<H256>,
+    started_rx: mpsc::UnboundedReceiver<H256>,
+    completed_tx: mpsc::UnboundedSender<H256>,
+    completed_rx: mpsc::UnboundedReceiver<H256>,
+    disposed_tx: mpsc::UnboundedSender<H256>,
+    disposed_rx: mpsc::UnboundedReceiver<H256>,
+    concurrency: Arc<PrepareConcurrency>,
+}
+
+impl TestHarness {
+    fn new() -> Self {
+        let (started_tx, started_rx) = mpsc::unbounded_channel();
+        let (completed_tx, completed_rx) = mpsc::unbounded_channel();
+        let (disposed_tx, disposed_rx) = mpsc::unbounded_channel();
+        Self {
+            destination: HyperlaneDomain::new_test_domain("test"),
+            started_tx,
+            started_rx,
+            completed_tx,
+            completed_rx,
+            disposed_tx,
+            disposed_rx,
+            concurrency: Arc::new(PrepareConcurrency::default()),
+        }
+    }
+
+    fn operation(
+        &self,
+        id: u64,
+        origin: u32,
+        result: PendingOperationResult,
+        gate: Option<Arc<Semaphore>>,
+    ) -> QueueOperation {
+        Box::new(TestOperation::new(
+            id,
+            origin,
+            self.destination.clone(),
+            result,
+            gate,
+            self.started_tx.clone(),
+            self.completed_tx.clone(),
+            self.disposed_tx.clone(),
+            self.concurrency.clone(),
+        ))
+    }
+}
+
+async fn run_process_batch(
+    destination: HyperlaneDomain,
+    batch: Vec<QueueOperation>,
+) -> (
+    super::super::OpQueue,
+    super::super::OpQueue,
+    super::super::OpQueue,
+    super::super::MessageProcessorMetrics,
+) {
+    let mut prepare_queue = create_test_queue();
+    let submit_queue = create_test_queue();
+    let confirm_queue = create_test_queue();
+    let metrics = create_test_metrics();
+
+    process_batch(
+        destination,
+        batch,
+        &mut prepare_queue,
+        &submit_queue,
+        &confirm_queue,
+        &metrics,
+    )
+    .await;
+
+    (prepare_queue, submit_queue, confirm_queue, metrics)
+}
+
+#[tokio::test]
+async fn slow_origin_does_not_block_fast_origin_disposition() {
+    let mut harness = TestHarness::new();
+    let slow_gate = Arc::new(Semaphore::new(0));
+    let slow_id = H256::from_low_u64_be(1);
+    let fast_id = H256::from_low_u64_be(2);
+    let batch = vec![
+        harness.operation(
+            1,
+            1000,
+            PendingOperationResult::Success,
+            Some(slow_gate.clone()),
+        ),
+        harness.operation(2, 2000, PendingOperationResult::Success, None),
+    ];
+
+    let task = tokio::spawn(run_process_batch(harness.destination.clone(), batch));
+
+    for _ in 0..2 {
+        harness.started_rx.recv().await.expect("prepare started");
+    }
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), harness.disposed_rx.recv())
+            .await
+            .expect("fast origin should be disposed")
+            .expect("disposition event"),
+        fast_id
+    );
+
+    slow_gate.add_permits(1);
+    assert_eq!(
+        harness.disposed_rx.recv().await.expect("slow disposition"),
+        slow_id
+    );
+    task.await.expect("process task");
+}
+
+#[tokio::test]
+async fn same_origin_dispositions_preserve_batch_order() {
+    let mut harness = TestHarness::new();
+    let first_gate = Arc::new(Semaphore::new(0));
+    let first_id = H256::from_low_u64_be(1);
+    let second_id = H256::from_low_u64_be(2);
+    let batch = vec![
+        harness.operation(
+            1,
+            1000,
+            PendingOperationResult::Success,
+            Some(first_gate.clone()),
+        ),
+        harness.operation(2, 1000, PendingOperationResult::Success, None),
+    ];
+
+    let task = tokio::spawn(run_process_batch(harness.destination.clone(), batch));
+
+    assert_eq!(
+        harness.completed_rx.recv().await.expect("completion event"),
+        second_id
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), harness.disposed_rx.recv())
+            .await
+            .is_err(),
+        "later same-origin operation must wait for its predecessor"
+    );
+
+    first_gate.add_permits(1);
+    assert_eq!(harness.disposed_rx.recv().await.unwrap(), first_id);
+    assert_eq!(harness.disposed_rx.recv().await.unwrap(), second_id);
+    task.await.expect("process task");
+}
+
+#[tokio::test]
+async fn preparation_concurrency_is_bounded_by_batch_size() {
+    let mut harness = TestHarness::new();
+    let gate = Arc::new(Semaphore::new(0));
+    let batch_size = 4;
+    let batch = (0..batch_size)
+        .map(|i| {
+            harness.operation(
+                i as u64 + 1,
+                i as u32 + 1,
+                PendingOperationResult::Success,
+                Some(gate.clone()),
+            )
+        })
+        .collect();
+
+    let task = tokio::spawn(run_process_batch(harness.destination.clone(), batch));
+    for _ in 0..batch_size {
+        harness.started_rx.recv().await.expect("prepare started");
+    }
+    assert_eq!(
+        harness.concurrency.max_active.load(Ordering::SeqCst),
+        batch_size
+    );
+
+    gate.add_permits(batch_size);
+    task.await.expect("process task");
+    assert_eq!(harness.concurrency.active.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn completed_results_keep_existing_dispositions_and_metrics() {
+    let harness = TestHarness::new();
+    let success_id = H256::from_low_u64_be(1);
+    let not_ready_id = H256::from_low_u64_be(2);
+    let reprepare_id = H256::from_low_u64_be(3);
+    let confirm_id = H256::from_low_u64_be(5);
+    let batch = vec![
+        harness.operation(1, 1, PendingOperationResult::Success, None),
+        harness.operation(2, 2, PendingOperationResult::NotReady, None),
+        harness.operation(
+            3,
+            3,
+            PendingOperationResult::Reprepare(ReprepareReason::Manual),
+            None,
+        ),
+        harness.operation(4, 4, PendingOperationResult::Drop, None),
+        harness.operation(
+            5,
+            5,
+            PendingOperationResult::Confirm(ConfirmReason::AlreadySubmitted),
+            None,
+        ),
+    ];
+
+    let (mut prepare_queue, mut submit_queue, mut confirm_queue, metrics) =
+        run_process_batch(harness.destination, batch).await;
+
+    let submitted = submit_queue.pop_many(10).await;
+    assert_eq!(submitted.len(), 1);
+    assert_eq!(submitted[0].id(), success_id);
+    assert_eq!(submitted[0].status(), PendingOperationStatus::ReadyToSubmit);
+
+    let prepared = prepare_queue.pop_many(10).await;
+    assert_eq!(prepared.len(), 2);
+    assert!(prepared.iter().any(|op| {
+        op.id() == not_ready_id && op.status() == PendingOperationStatus::FirstPrepareAttempt
+    }));
+    assert!(prepared.iter().any(|op| {
+        op.id() == reprepare_id
+            && op.status() == PendingOperationStatus::Retry(ReprepareReason::Manual)
+    }));
+
+    let confirmed = confirm_queue.pop_many(10).await;
+    assert_eq!(confirmed.len(), 1);
+    assert_eq!(confirmed[0].id(), confirm_id);
+    assert_eq!(
+        confirmed[0].status(),
+        PendingOperationStatus::Confirm(ConfirmReason::AlreadySubmitted)
+    );
+
+    assert_eq!(
+        metrics
+            .ops_prepared
+            .with_label_values(&["test", "prepared", "Unknown"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .ops_failed
+            .with_label_values(&["test", "failed", "Unknown"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .ops_dropped
+            .with_label_values(&["test", "dropped", "Unknown"])
+            .get(),
+        1
+    );
+}


### PR DESCRIPTION
### Description

Routes completed relayer prepare operations without waiting for unrelated origins in the same batch. Preparations remain bounded by the existing batch size, while a per-origin sequence gate preserves the priority-queue order for messages from the same origin.

Existing backpressure, retry/drop/confirm dispositions, and operation counters are unchanged.

### Expected improvement

**Analytical:** the legacy fast-operation prepare-to-disposition latency was `max(batch prepare latencies)`; this change makes cross-origin latency approximately the fast operation's own prepare latency. For a batch containing a 5 s slow origin and a 100 ms fast origin, the fast origin improves from at least 5 s to about 100 ms: **50× faster / 98% lower latency**. The target metric is p95 time from `prepare()` start to enqueueing the operation in its next processor queue, segmented by destination.

### Stack integration

Stacked after #9403 (`73e5e00e7f`), retaining its bounded destination ingress and pending-index loader while routing `FuturesUnordered` prepare completions per origin. The integrated regression holds origin A indefinitely and proves origin B reaches the submit queue. It inherits #9403 retained low-scan notifications, including nonce-0 and u32::MAX recovery. #9399's superseded 500ms all-not-ready sleep remains removed. Exact head: `46bd858e07`.

Related: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/9380

### Backward compatibility

Yes. This changes private relayer scheduling only; configuration and public APIs are unchanged.

### Testing

- `cargo fmt --package relayer -- --check`
- `cargo test -p relayer message_processor::tests::tests_process_batch -- --nocapture`
- Pre-commit secret scan and Rust formatting hooks
- final cumulative message-processor tests: **66/66 passed**
- inherited corrected DB-loader tests: **26/26 passed**

The focused tests cover a gated slow origin versus a fast origin, same-origin ordering, bounded preparation concurrency, and every existing prepare result disposition and counter branch.

