### PR TITLE
fix(relayer): bound cache by serialized size

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -93,6 +93,9 @@ pub fn dummy_cache_metrics() -> MeteredCacheMetrics {
             &["cache_name", "method", "status"],
         )
         .ok(),
+        entry_count: None,
+        weighted_size_bytes: None,
+        eviction_count: None,
     }
 }
 

--- a/rust/main/hyperlane-base/src/cache/metered_cache.rs
+++ b/rust/main/hyperlane-base/src/cache/metered_cache.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use derive_builder::Builder;
 use derive_new::new;
 use maplit::hashmap;
-use prometheus::IntCounterVec;
+use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::cache::FunctionCallCache;
@@ -35,6 +35,19 @@ pub struct MeteredCacheMetrics {
     /// - `status`: the status of the call.
     #[builder(setter(into, strip_option), default)]
     pub miss_count: Option<IntCounterVec>,
+    /// Approximate number of entries currently in the cache.
+    /// - `cache_name`: the name of the cache.
+    #[builder(setter(into, strip_option), default)]
+    pub entry_count: Option<IntGaugeVec>,
+    /// Approximate serialized key and value bytes currently in the cache.
+    /// - `cache_name`: the name of the cache.
+    #[builder(setter(into, strip_option), default)]
+    pub weighted_size_bytes: Option<IntGaugeVec>,
+    /// Number of entries evicted from the cache.
+    /// - `cache_name`: the name of the cache.
+    /// - `cause`: the eviction cause (`expired` or `size`).
+    #[builder(setter(into, strip_option), default)]
+    pub eviction_count: Option<IntCounterVec>,
 }
 
 /// Expected label names for the metric.
@@ -47,12 +60,60 @@ pub const MISS_COUNT_HELP: &str = "Number of cache misses";
 /// Help string for the metric.
 pub const MISS_COUNT_LABELS: &[&str] = &["cache_name", "chain", "method", "status"];
 
+/// Help string for the cache entry count metric.
+pub const ENTRY_COUNT_HELP: &str = "Approximate number of entries in the cache";
+/// Expected label names for the metric.
+pub const ENTRY_COUNT_LABELS: &[&str] = &["cache_name"];
+
+/// Help string for the weighted cache size metric.
+pub const WEIGHTED_SIZE_BYTES_HELP: &str =
+    "Approximate serialized key and value bytes in the cache";
+/// Expected label names for the metric.
+pub const WEIGHTED_SIZE_BYTES_LABELS: &[&str] = &["cache_name"];
+
+/// Help string for the cache eviction count metric.
+pub const EVICTION_COUNT_HELP: &str = "Number of entries evicted from the cache";
+/// Expected label names for the metric.
+pub const EVICTION_COUNT_LABELS: &[&str] = &["cache_name", "cause"];
+
 /// A Cache wrapper that instruments the cache calls with metrics.
 #[derive(new, Debug, Clone)]
 pub struct MeteredCache<C> {
     inner: C,
     metrics: MeteredCacheMetrics,
     config: MeteredCacheConfig,
+}
+
+impl<C> MeteredCache<C>
+where
+    C: FunctionCallCache,
+{
+    fn update_cache_metrics(&self) {
+        let cache_name = self.config.cache_name.as_str();
+        let snapshot = self.inner.metrics_snapshot();
+
+        if let (Some(entry_count), Some(value)) = (&self.metrics.entry_count, snapshot.entry_count)
+        {
+            entry_count
+                .with_label_values(&[cache_name])
+                .set(i64::try_from(value).unwrap_or(i64::MAX));
+        }
+        if let (Some(weighted_size_bytes), Some(value)) =
+            (&self.metrics.weighted_size_bytes, snapshot.weighted_size)
+        {
+            weighted_size_bytes
+                .with_label_values(&[cache_name])
+                .set(i64::try_from(value).unwrap_or(i64::MAX));
+        }
+        if let Some(eviction_count) = &self.metrics.eviction_count {
+            eviction_count
+                .with_label_values(&[cache_name, "expired"])
+                .inc_by(snapshot.expired_evictions);
+            eviction_count
+                .with_label_values(&[cache_name, "size"])
+                .inc_by(snapshot.size_evictions);
+        }
+    }
 }
 
 #[async_trait]
@@ -67,9 +128,12 @@ where
         fn_params: &(impl Serialize + Send + Sync),
         result: &(impl Serialize + Send + Sync),
     ) -> CacheResult<()> {
-        self.inner
+        let result = self
+            .inner
             .cache_call_result(domain_name, fn_key, fn_params, result)
-            .await
+            .await;
+        self.update_cache_metrics();
+        result
     }
 
     async fn cache_call_result_with_expiration(
@@ -80,9 +144,12 @@ where
         result: &(impl Serialize + Send + Sync),
         expiration: ExpirationType,
     ) -> CacheResult<()> {
-        self.inner
+        let result = self
+            .inner
             .cache_call_result_with_expiration(domain_name, fn_key, fn_params, result, expiration)
-            .await
+            .await;
+        self.update_cache_metrics();
+        result
     }
 
     async fn get_cached_call_result<T>(
@@ -114,6 +181,8 @@ where
         } else if let Some(miss_count) = &self.metrics.miss_count {
             miss_count.with(&labels).inc();
         }
+
+        self.update_cache_metrics();
 
         result
     }

--- a/rust/main/hyperlane-base/src/cache/mod.rs
+++ b/rust/main/hyperlane-base/src/cache/mod.rs
@@ -9,10 +9,25 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use error::CacheError;
 pub use metered_cache::{
     MeteredCache, MeteredCacheConfig, MeteredCacheMetrics, MeteredCacheMetricsBuilder,
-    HIT_COUNT_HELP, HIT_COUNT_LABELS, MISS_COUNT_HELP, MISS_COUNT_LABELS,
+    ENTRY_COUNT_HELP, ENTRY_COUNT_LABELS, EVICTION_COUNT_HELP, EVICTION_COUNT_LABELS,
+    HIT_COUNT_HELP, HIT_COUNT_LABELS, MISS_COUNT_HELP, MISS_COUNT_LABELS, WEIGHTED_SIZE_BYTES_HELP,
+    WEIGHTED_SIZE_BYTES_LABELS,
 };
 pub use moka::{CacheResult, Expiration, ExpirationType, LocalCache};
 pub use optional_cache::OptionalCache;
+
+/// Cache statistics consumed by [`MeteredCache`].
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct CacheMetricsSnapshot {
+    /// Approximate number of entries currently in the cache, when supported.
+    pub entry_count: Option<u64>,
+    /// Approximate weighted size currently in the cache, when supported.
+    pub weighted_size: Option<u64>,
+    /// Entries evicted due to expiration since the last metrics update.
+    pub expired_evictions: u64,
+    /// Entries evicted due to capacity since the last metrics update.
+    pub size_evictions: u64,
+}
 
 /// Should be used as the `fn_params` when the function has no parameters
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,6 +36,11 @@ pub struct NoParams;
 /// Cache for storing function calls with serializable results
 #[async_trait]
 pub trait FunctionCallCache: Send + Sync {
+    /// Return cache statistics when supported by the implementation.
+    fn metrics_snapshot(&self) -> CacheMetricsSnapshot {
+        CacheMetricsSnapshot::default()
+    }
+
     /// Cache a call result with the given parameters
     async fn cache_call_result(
         &self,

--- a/rust/main/hyperlane-base/src/cache/moka/local_cache.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/local_cache.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::cache::FunctionCallCache;
+use crate::cache::{CacheMetricsSnapshot, FunctionCallCache};
 
 use super::{BaseCache, CacheResult, ExpirationType};
 
@@ -20,6 +20,10 @@ impl LocalCache {
 
 #[async_trait]
 impl FunctionCallCache for LocalCache {
+    fn metrics_snapshot(&self) -> CacheMetricsSnapshot {
+        self.0.metrics_snapshot()
+    }
+
     /// Cache a call result with the given parameters
     async fn cache_call_result(
         &self,

--- a/rust/main/hyperlane-base/src/cache/moka/mod.rs
+++ b/rust/main/hyperlane-base/src/cache/moka/mod.rs
@@ -2,15 +2,21 @@
 mod dynamic_expiry;
 mod local_cache;
 
-use std::hash::RandomState;
+use std::{
+    hash::RandomState,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
-use moka::{future::Cache, policy::EvictionPolicy};
+use moka::{future::Cache, notification::RemovalCause, policy::EvictionPolicy};
 use serde::{de::DeserializeOwned, Serialize};
 
 pub use dynamic_expiry::{DynamicExpiry, Expiration, ExpirationType};
 pub use local_cache::LocalCache;
 
-use crate::cache::CacheError;
+use crate::cache::{CacheError, CacheMetricsSnapshot};
 
 /// A simple generic cache that stores serializable values.
 /// Supports dynamic expiration times
@@ -24,9 +30,37 @@ use crate::cache::CacheError;
 #[derive(Debug, Clone)]
 pub struct BaseCache {
     cache: Cache<String, (String, Expiration), RandomState>,
+    eviction_counts: Arc<EvictionCounts>,
 }
 
-const MAX_CACHE_CAPACITY: u64 = 50 * 1024 * 1024; // 50MB
+/// Serialized key and value byte budget. Moka's bookkeeping overhead is not included.
+const MAX_CACHE_WEIGHT_BYTES: u64 = 50 * 1024 * 1024;
+
+#[derive(Debug, Default)]
+struct EvictionCounts {
+    expired: AtomicU64,
+    size: AtomicU64,
+}
+
+impl EvictionCounts {
+    fn record(&self, cause: RemovalCause) {
+        let counter = match cause {
+            RemovalCause::Expired => &self.expired,
+            RemovalCause::Size => &self.size,
+            RemovalCause::Explicit | RemovalCause::Replaced => return,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self, entry_count: u64, weighted_size: u64) -> CacheMetricsSnapshot {
+        CacheMetricsSnapshot {
+            entry_count: Some(entry_count),
+            weighted_size: Some(weighted_size),
+            expired_evictions: self.expired.swap(0, Ordering::Relaxed),
+            size_evictions: self.size.swap(0, Ordering::Relaxed),
+        }
+    }
+}
 
 /// The result type for cache operations, which can return a `CacheError`
 pub type CacheResult<T> = std::result::Result<T, CacheError>;
@@ -34,13 +68,40 @@ pub type CacheResult<T> = std::result::Result<T, CacheError>;
 impl BaseCache {
     /// Create a new cache with the given name
     pub fn new(name: &str) -> Self {
+        Self::with_capacity(name, MAX_CACHE_WEIGHT_BYTES)
+    }
+
+    fn with_capacity(name: &str, max_weight: u64) -> Self {
+        let eviction_counts = Arc::new(EvictionCounts::default());
+        let listener_counts = eviction_counts.clone();
         let cache = Cache::builder()
             .name(name)
             .expire_after(DynamicExpiry {})
             .eviction_policy(EvictionPolicy::lru())
-            .max_capacity(MAX_CACHE_CAPACITY)
+            .weigher(|key: &String, (value, _): &(String, Expiration)| {
+                let serialized_bytes = key.len().saturating_add(value.len()).max(1);
+                u32::try_from(serialized_bytes).unwrap_or(u32::MAX)
+            })
+            .eviction_listener(move |_, _, cause| listener_counts.record(cause))
+            .max_capacity(max_weight)
             .build();
-        Self { cache }
+        Self {
+            cache,
+            eviction_counts,
+        }
+    }
+
+    fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+
+    fn weighted_size(&self) -> u64 {
+        self.cache.weighted_size()
+    }
+
+    fn metrics_snapshot(&self) -> CacheMetricsSnapshot {
+        self.eviction_counts
+            .snapshot(self.entry_count(), self.weighted_size())
     }
 
     /// Get the value for the given key
@@ -90,7 +151,13 @@ impl BaseCache {
     /// which ensures that the count is accurate.
     pub async fn entries(&self) -> u64 {
         self.cache.run_pending_tasks().await;
-        self.cache.entry_count()
+        self.entry_count()
+    }
+
+    /// Get the weighted size of the cache after running pending maintenance.
+    pub async fn weight(&self) -> u64 {
+        self.cache.run_pending_tasks().await;
+        self.weighted_size()
     }
 
     /// Check if the cache contains a value for the given key
@@ -146,6 +213,23 @@ mod test {
 
         let cached_value = cache.get::<i32>(&key).await.unwrap();
         assert!(cached_value.is_some_and(|(v, _)| v == value));
+    }
+
+    #[tokio::test]
+    async fn serialized_values_obey_byte_capacity() {
+        let max_weight = 700;
+        let cache = BaseCache::with_capacity("weighted-test-cache", max_weight);
+
+        for key in 0..3 {
+            cache
+                .set(&key, &"x".repeat(512), ExpirationType::Never)
+                .await
+                .unwrap();
+        }
+
+        assert!(cache.weight().await <= max_weight);
+        assert!(cache.entries().await <= 1);
+        assert!(cache.metrics_snapshot().size_evictions >= 2);
     }
 
     #[tokio::test]

--- a/rust/main/hyperlane-base/src/metrics/cache.rs
+++ b/rust/main/hyperlane-base/src/metrics/cache.rs
@@ -8,14 +8,18 @@ pub(crate) fn create_cache_metrics(metrics: &CoreMetrics) -> Result<MeteredCache
     Ok(MeteredCacheMetricsBuilder::default()
         .hit_count(metrics.new_int_counter("hit_count", HIT_COUNT_HELP, HIT_COUNT_LABELS)?)
         .miss_count(metrics.new_int_counter("miss_count", MISS_COUNT_HELP, MISS_COUNT_LABELS)?)
-        .entry_count(metrics.new_int_gauge("entry_count", ENTRY_COUNT_HELP, ENTRY_COUNT_LABELS)?)
+        .entry_count(metrics.new_int_gauge(
+            "cache_entry_count",
+            ENTRY_COUNT_HELP,
+            ENTRY_COUNT_LABELS,
+        )?)
         .weighted_size_bytes(metrics.new_int_gauge(
-            "weighted_size_bytes",
+            "cache_weighted_size_bytes",
             WEIGHTED_SIZE_BYTES_HELP,
             WEIGHTED_SIZE_BYTES_LABELS,
         )?)
         .eviction_count(metrics.new_int_counter(
-            "eviction_count",
+            "cache_eviction_count",
             EVICTION_COUNT_HELP,
             EVICTION_COUNT_LABELS,
         )?)

--- a/rust/main/hyperlane-base/src/metrics/cache.rs
+++ b/rust/main/hyperlane-base/src/metrics/cache.rs
@@ -8,5 +8,16 @@ pub(crate) fn create_cache_metrics(metrics: &CoreMetrics) -> Result<MeteredCache
     Ok(MeteredCacheMetricsBuilder::default()
         .hit_count(metrics.new_int_counter("hit_count", HIT_COUNT_HELP, HIT_COUNT_LABELS)?)
         .miss_count(metrics.new_int_counter("miss_count", MISS_COUNT_HELP, MISS_COUNT_LABELS)?)
+        .entry_count(metrics.new_int_gauge("entry_count", ENTRY_COUNT_HELP, ENTRY_COUNT_LABELS)?)
+        .weighted_size_bytes(metrics.new_int_gauge(
+            "weighted_size_bytes",
+            WEIGHTED_SIZE_BYTES_HELP,
+            WEIGHTED_SIZE_BYTES_LABELS,
+        )?)
+        .eviction_count(metrics.new_int_counter(
+            "eviction_count",
+            EVICTION_COUNT_HELP,
+            EVICTION_COUNT_LABELS,
+        )?)
         .build()?)
 }


### PR DESCRIPTION
## Summary

- interpret the relayer Moka cache's 50 MiB capacity as serialized key and value bytes instead of entry count
- expose cache entry count, weighted serialized bytes, and evictions by cause
- regression-test capacity enforcement with serialized values larger than half the configured test budget

## Expected impact

- **Analytical:** the previous `52,428,800` capacity allowed that many entries. The new configuration bounds serialized key and value payloads to `52,428,800` bytes after Moka maintenance. At a 1 KiB average serialized entry, this changes the theoretical payload allowance from about 50 GiB to 50 MiB (about 1,024x lower); at 10 KiB, from about 500 GiB to 50 MiB (about 10,240x lower). Moka bookkeeping and allocator overhead are outside this byte budget.
- **Synthetic:** with a 700-byte test budget, three roughly 515-byte serialized entries produce at least two size evictions, at most one retained entry, and weighted size at or below 700 bytes. The old entry-count interpretation would retain all three.
- **Observed:** no production RSS reduction is claimed yet. Cache contents may not be the dominant contributor to current process memory.

## Canary proof

Compare an equal-workload canary with baseline using:

- `hyperlane_cache_weighted_size_bytes{cache_name="relayer_cache"}`: remains at or below 52,428,800 after maintenance
- `hyperlane_cache_entry_count{cache_name="relayer_cache"}`
- `rate(hyperlane_cache_eviction_count{cache_name="relayer_cache",cause="size"}[5m])`
- container working set / anonymous RSS, message throughput, delivery latency, queue length, and backend request rate as non-regression guards

## Testing

- `cargo test --offline -p hyperlane-base cache::moka::test::serialized_values_obey_byte_capacity`
- focused `rustfmt --check` on all touched Rust files
- repository pre-commit hooks, including gitleaks and both Rust workspace format checks

## Tracking

- Cache/thread attribution work: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/9383
- Agent indexing/resource epic: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/9386

Rebased on `main@06d8269ef1`; exact head `3ce74ef097`.