### PR TITLE
feat(agents): expose Tokio blocking pool metrics

### DIFF
--- a/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/runtime_metrics.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, time::Duration};
 
 use eyre::Result;
 use hyperlane_core::metrics::agent::METRICS_SCRAPE_INTERVAL;
-use prometheus::IntCounter;
+use prometheus::{IntCounter, IntGauge};
 use tokio::{task::JoinHandle, time::MissedTickBehavior};
 use tokio_metrics::{TaskMetrics, TaskMonitor};
 use tracing::{info_span, Instrument};
@@ -10,11 +10,16 @@ use tracing::{info_span, Instrument};
 use super::CoreMetrics;
 
 const RUNTIME_DROPPED_TASKS_HELP: &str = "The number of tasks dropped";
+const RUNTIME_BLOCKING_THREADS_HELP: &str =
+    "The number of Tokio blocking pool threads, including idle threads";
+const RUNTIME_IDLE_BLOCKING_THREADS_HELP: &str = "The number of idle Tokio blocking pool threads";
 
 /// Metrics for the runtime
 pub struct RuntimeMetrics {
     producer: TaskMonitor,
     dropped_tasks: IntCounter,
+    blocking_threads: IntGauge,
+    idle_blocking_threads: IntGauge,
 }
 
 // Need this to be included in the agents structs
@@ -30,15 +35,32 @@ impl RuntimeMetrics {
         let dropped_tasks = metrics
             .new_int_counter("tokio_dropped_tasks", RUNTIME_DROPPED_TASKS_HELP, &[])?
             .with_label_values::<&str>(&[]);
+        let blocking_threads = metrics
+            .new_int_gauge("tokio_blocking_threads", RUNTIME_BLOCKING_THREADS_HELP, &[])?
+            .with_label_values::<&str>(&[]);
+        let idle_blocking_threads = metrics
+            .new_int_gauge(
+                "tokio_idle_blocking_threads",
+                RUNTIME_IDLE_BLOCKING_THREADS_HELP,
+                &[],
+            )?
+            .with_label_values::<&str>(&[]);
         let chain_metrics = Self {
             producer: task_monitor,
             dropped_tasks,
+            blocking_threads,
+            idle_blocking_threads,
         };
         Ok(chain_metrics)
     }
 
     fn update(&mut self, metrics: TaskMetrics) {
         self.dropped_tasks.inc_by(metrics.dropped_count);
+        let runtime_metrics = tokio::runtime::Handle::current().metrics();
+        self.blocking_threads
+            .set(i64::try_from(runtime_metrics.num_blocking_threads()).unwrap_or(i64::MAX));
+        self.idle_blocking_threads
+            .set(i64::try_from(runtime_metrics.num_idle_blocking_threads()).unwrap_or(i64::MAX));
     }
 
     /// Periodically updates the metrics
@@ -66,5 +88,43 @@ impl RuntimeMetrics {
                 .instrument(info_span!("RuntimeMetricsUpdater")),
             )
             .expect("spawning tokio task from Builder is infallible")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::Registry;
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn updates_blocking_pool_thread_gauges() {
+        let core_metrics = CoreMetrics::new("runtime-metrics-test", 0, Registry::new()).unwrap();
+        let mut metrics = RuntimeMetrics::new(&core_metrics, TaskMonitor::new()).unwrap();
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+
+        let blocking_task = tokio::task::spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.blocking_recv();
+        });
+        started_rx.await.unwrap();
+
+        let runtime_metrics = tokio::runtime::Handle::current().metrics();
+        let blocking_threads = runtime_metrics.num_blocking_threads();
+        let idle_blocking_threads = runtime_metrics.num_idle_blocking_threads();
+        assert!(blocking_threads > idle_blocking_threads);
+
+        metrics.update(TaskMetrics::default());
+
+        assert_eq!(metrics.blocking_threads.get(), blocking_threads as i64);
+        assert_eq!(
+            metrics.idle_blocking_threads.get(),
+            idle_blocking_threads as i64
+        );
+
+        release_tx.send(()).unwrap();
+        blocking_task.await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- export Tokio blocking-pool thread count
- export idle blocking-pool thread count
- verify both gauges against Tokio runtime values while a blocking task is active

## Expected improvement

**Analytical:** blocking-pool production observability increases from 0/2 planned state signals to 2/2 (0% to 100%, +100 percentage points). Operators can derive active blocking threads as `hyperlane_tokio_blocking_threads - hyperlane_tokio_idle_blocking_threads` and distinguish pool retention from active blocking work without entering a pod.

**Synthetic:** the focused test holds one `spawn_blocking` task active, proves total blocking threads exceed idle threads, and proves both exported gauges exactly match Tokio runtime metrics.

**Observed:** no production result yet. This is diagnostic instrumentation; it does not claim lower RSS, fewer threads, or higher throughput.

## Canary

Track:

- `hyperlane_tokio_blocking_threads`
- `hyperlane_tokio_idle_blocking_threads`
- derived active blocking threads (total minus idle)
- process thread count and anonymous RSS

Expected non-regression: delivery throughput, latency, queues, and backend request rate remain unchanged. Runtime state is sampled by the existing runtime metrics loop.

## Verification

- `CARGO_TARGET_DIR=/private/tmp/hyperlane-prepare-hol.f5GCqH/rust/main/target CARGO_BUILD_JOBS=4 cargo test --offline -p hyperlane-base metrics::runtime_metrics::tests::updates_blocking_pool_thread_gauges` (1 passed)
- `cargo fmt --check --all`
- repository pre-commit hooks (gitleaks, lint-staged, Rust fmt)

Part of #9383.
Master performance epic: #9386.