### PR TITLE
refactor(agents): share scraper websocket protocol

### DIFF
--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -1472,7 +1472,7 @@ mod tests {
                 },
                 domain: 1,
                 event_type: EVENT_TYPE.to_owned(),
-                sequence: sequence.to_string(),
+                sequence: Some(sequence.to_string()),
             };
             assert!(sync
                 .process_event(

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use eyre::{bail, eyre, Context, Result};
 use futures_util::{future::BoxFuture, FutureExt, SinkExt, StreamExt};
 use prometheus::IntGauge;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tokio::{
     sync::Notify,
     task::JoinHandle,
@@ -19,6 +19,10 @@ use url::Url;
 
 use hyperlane_base::{
     db::{HyperlaneDb, HyperlaneRocksDB},
+    scraper_websocket::{
+        EventMessage, SequenceCursor, ServerMessage as ScraperServerMessage, StringOrNumber,
+        SubscribeMessage, SubscribeStream,
+    },
     settings::IndexSettings,
     ContractSyncer, SequencedDataContractSync,
 };
@@ -707,14 +711,14 @@ impl MerkleTreeHookWebSocketSync {
     fn subscription(&self, next_sequence: u32) -> Result<String> {
         let after_sequence = next_sequence.checked_sub(1).map(i64::from).unwrap_or(-1);
         serde_json::to_string(&SubscribeMessage {
-            streams: [SubscribeStream {
-                cursors: [SequenceCursor {
+            streams: vec![SubscribeStream {
+                cursors: Some(vec![SequenceCursor {
                     address: format!("{:#x}", self.merkle_tree_hook),
-                    allow_replay: true,
-                    after_sequence: after_sequence.to_string(),
+                    allow_replay: Some(true),
+                    after_sequence: Some(after_sequence.to_string()),
                     domain: self.domain,
-                }],
-                domains: [self.domain],
+                }]),
+                domains: Some(vec![self.domain]),
                 event_type: EVENT_TYPE,
             }],
             message_type: "subscribe",
@@ -728,7 +732,7 @@ impl MerkleTreeHookWebSocketSync {
     /// Exact duplicates reuse the previously verified local row without another RPC query.
     async fn process_event(
         &self,
-        event: EventMessage,
+        event: EventMessage<EventData>,
         next_sequence: &mut u32,
         dependencies: &StreamDependencies,
         canonical_cache: &mut Vec<(Indexed<MerkleTreeInsertion>, LogMeta)>,
@@ -746,9 +750,13 @@ impl MerkleTreeHookWebSocketSync {
         }
 
         let leaf_index = event.data.leaf_index.as_u32("leaf_index")?;
-        let sequence = event.sequence.parse::<u32>().with_context(|| {
-            format!("Invalid Merkle tree insertion sequence {}", event.sequence)
-        })?;
+        let raw_sequence = event
+            .sequence
+            .as_deref()
+            .ok_or_else(|| eyre!("Missing Merkle tree insertion sequence"))?;
+        let sequence = raw_sequence
+            .parse::<u32>()
+            .with_context(|| format!("Invalid Merkle tree insertion sequence {raw_sequence}"))?;
         if sequence != leaf_index || leaf_index > *next_sequence {
             bail!(
                 "Unexpected Merkle tree insertion sequence: expected {}, received {sequence}/{leaf_index}",
@@ -1018,60 +1026,6 @@ fn matches_canonical_insertion(
     }))
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SubscribeMessage<'a> {
-    streams: [SubscribeStream<'a>; 1],
-    #[serde(rename = "type")]
-    message_type: &'a str,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SubscribeStream<'a> {
-    cursors: [SequenceCursor; 1],
-    domains: [u32; 1],
-    event_type: &'a str,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct SequenceCursor {
-    address: String,
-    allow_replay: bool,
-    after_sequence: String,
-    domain: u32,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum ServerMessage {
-    Ready,
-    Subscribed,
-    #[serde(rename_all = "camelCase")]
-    CaughtUp {
-        address: String,
-        domain: u32,
-        event_type: String,
-        sequence: String,
-    },
-    Event(EventMessage),
-    Error {
-        error: String,
-    },
-    #[serde(other)]
-    Other,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct EventMessage {
-    data: EventData,
-    domain: u32,
-    event_type: String,
-    sequence: String,
-}
-
 #[derive(Debug, Deserialize)]
 struct EventData {
     block_number: StringOrNumber,
@@ -1081,30 +1035,7 @@ struct EventData {
     message_id: String,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum StringOrNumber {
-    String(String),
-    Number(u64),
-}
-
-impl StringOrNumber {
-    fn as_u32(&self, field: &str) -> Result<u32> {
-        let value = self.as_u64(field)?;
-        value
-            .try_into()
-            .with_context(|| format!("{field} exceeds u32"))
-    }
-
-    fn as_u64(&self, field: &str) -> Result<u64> {
-        match self {
-            Self::String(value) => value
-                .parse()
-                .with_context(|| format!("Invalid {field} value {value}")),
-            Self::Number(value) => Ok(*value),
-        }
-    }
-}
+type ServerMessage = ScraperServerMessage<EventData>;
 
 fn parse_address(value: &str) -> Result<H256> {
     bytes_to_address(parse_hex(value)?).context("Invalid Merkle tree hook address")
@@ -1672,7 +1603,7 @@ mod tests {
             },
             domain: 1,
             event_type: EVENT_TYPE.to_owned(),
-            sequence: "0".to_owned(),
+            sequence: Some("0".to_owned()),
         };
 
         assert!(sync
@@ -1704,7 +1635,7 @@ mod tests {
                     },
                     domain: 1,
                     event_type: EVENT_TYPE.to_owned(),
-                    sequence: "0".to_owned(),
+                    sequence: Some("0".to_owned()),
                 },
                 &mut next_sequence,
                 &dependencies,
@@ -1730,7 +1661,7 @@ mod tests {
             },
             domain: 1,
             event_type: EVENT_TYPE.to_owned(),
-            sequence: "2".to_owned(),
+            sequence: Some("2".to_owned()),
         };
         assert!(sync
             .process_event(gap, &mut next_sequence, &dependencies, &mut canonical_cache,)

--- a/rust/main/hyperlane-base/src/lib.rs
+++ b/rust/main/hyperlane-base/src/lib.rs
@@ -24,6 +24,9 @@ mod metadata;
 pub mod metrics;
 pub use metrics::*;
 
+/// Scraper-proxy WebSocket protocol types shared by agent consumers.
+pub mod scraper_websocket;
+
 /// Hyperlane server utils
 pub mod server;
 

--- a/rust/main/hyperlane-base/src/scraper_websocket.rs
+++ b/rust/main/hyperlane-base/src/scraper_websocket.rs
@@ -1,0 +1,240 @@
+//! Wire types shared by agents consuming scraper-proxy WebSocket streams.
+
+use eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// A scraper-proxy stream subscription request.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscribeMessage<'a> {
+    /// Streams requested on this connection.
+    pub streams: Vec<SubscribeStream<'a>>,
+    /// Protocol message type.
+    #[serde(rename = "type")]
+    pub message_type: &'a str,
+}
+
+/// One event stream within a subscription request.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscribeStream<'a> {
+    /// Durable cursors from which replay should resume.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursors: Option<Vec<SequenceCursor>>,
+    /// Domains included in the stream.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domains: Option<Vec<u32>>,
+    /// Scraper event type.
+    pub event_type: &'a str,
+}
+
+/// Durable sequence cursor for one contract and domain.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SequenceCursor {
+    /// Contract address encoded for scraper-proxy.
+    pub address: String,
+    /// Whether scraper-proxy should replay events after the cursor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_replay: Option<bool>,
+    /// Last processed sequence, encoded as a decimal string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_sequence: Option<String>,
+    /// Hyperlane domain identifier.
+    pub domain: u32,
+}
+
+/// Messages emitted by scraper-proxy.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMessage<T> {
+    /// The connection is ready to receive a subscription.
+    Ready,
+    /// The subscription was accepted.
+    Subscribed,
+    /// Historical replay reached the scraper's current cursor.
+    #[serde(rename_all = "camelCase")]
+    CaughtUp {
+        /// Contract address for the cursor.
+        address: String,
+        /// Hyperlane domain identifier.
+        domain: u32,
+        /// Scraper event type.
+        event_type: String,
+        /// Last available sequence, encoded as a decimal string.
+        sequence: String,
+    },
+    /// One event from a requested stream.
+    Event(EventMessage<T>),
+    /// The server rejected the request or stream.
+    Error {
+        /// Human-readable server error.
+        error: String,
+    },
+    /// A forwards-compatible protocol message not understood by this client.
+    #[serde(other)]
+    Other,
+}
+
+/// Common envelope around scraper event-specific data.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventMessage<T> {
+    /// Event-specific payload.
+    pub data: T,
+    /// Hyperlane domain identifier.
+    pub domain: u32,
+    /// Scraper event type.
+    pub event_type: String,
+    /// Durable event sequence, encoded as a decimal string when the stream is sequenced.
+    pub sequence: Option<String>,
+}
+
+/// A non-negative integer accepted in either JSON representation used by scraper-proxy.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum StringOrNumber {
+    /// Decimal string representation.
+    String(String),
+    /// JSON number representation.
+    Number(u64),
+}
+
+impl StringOrNumber {
+    /// Parses this value as a `u32`, naming the field in errors.
+    pub fn as_u32(&self, field: &str) -> Result<u32> {
+        let value = self.as_u64(field)?;
+        value
+            .try_into()
+            .with_context(|| format!("{field} exceeds u32"))
+    }
+
+    /// Parses this value as a `u64`, naming the field in errors.
+    pub fn as_u64(&self, field: &str) -> Result<u64> {
+        match self {
+            Self::String(value) => value
+                .parse()
+                .with_context(|| format!("Invalid {field} value {value}")),
+            Self::Number(value) => Ok(*value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestData {
+        value: String,
+    }
+
+    #[test]
+    fn serializes_subscription_protocol() {
+        let message = SubscribeMessage {
+            streams: vec![SubscribeStream {
+                cursors: Some(vec![SequenceCursor {
+                    address: "0x1234".to_owned(),
+                    allow_replay: Some(true),
+                    after_sequence: Some("41".to_owned()),
+                    domain: 5,
+                }]),
+                domains: Some(vec![5]),
+                event_type: "dispatch",
+            }],
+            message_type: "subscribe",
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("subscription should serialize"),
+            serde_json::json!({
+                "streams": [{
+                    "cursors": [{
+                        "address": "0x1234",
+                        "allowReplay": true,
+                        "afterSequence": "41",
+                        "domain": 5
+                    }],
+                    "domains": [5],
+                    "eventType": "dispatch"
+                }],
+                "type": "subscribe"
+            })
+        );
+    }
+
+    #[test]
+    fn omits_optional_cursor_fields_for_live_streams() {
+        let message = SubscribeMessage {
+            streams: vec![SubscribeStream {
+                cursors: None,
+                domains: Some(vec![5]),
+                event_type: "gas_payment",
+            }],
+            message_type: "subscribe",
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("subscription should serialize"),
+            serde_json::json!({
+                "streams": [{
+                    "domains": [5],
+                    "eventType": "gas_payment"
+                }],
+                "type": "subscribe"
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_generic_event_envelope() {
+        let message: ServerMessage<TestData> = serde_json::from_value(serde_json::json!({
+            "type": "event",
+            "data": { "value": "payload" },
+            "domain": 5,
+            "eventType": "dispatch",
+            "sequence": "42"
+        }))
+        .expect("event should deserialize");
+
+        match message {
+            ServerMessage::Event(event) => {
+                assert_eq!(
+                    event.data,
+                    TestData {
+                        value: "payload".to_owned()
+                    }
+                );
+                assert_eq!(event.domain, 5);
+                assert_eq!(event.event_type, "dispatch");
+                assert_eq!(event.sequence.as_deref(), Some("42"));
+            }
+            _ => panic!("expected event"),
+        }
+    }
+
+    #[test]
+    fn deserializes_live_event_without_sequence() {
+        let message: ServerMessage<TestData> = serde_json::from_value(serde_json::json!({
+            "type": "event",
+            "data": { "value": "payload" },
+            "domain": 5,
+            "eventType": "gas_payment"
+        }))
+        .expect("live event should deserialize");
+
+        match message {
+            ServerMessage::Event(event) => assert_eq!(event.sequence, None),
+            _ => panic!("expected event"),
+        }
+    }
+
+    #[test]
+    fn parses_string_or_number() {
+        let string: StringOrNumber = serde_json::from_str("\"42\"").expect("string value");
+        let number: StringOrNumber = serde_json::from_str("43").expect("number value");
+
+        assert_eq!(string.as_u32("sequence").expect("valid u32"), 42);
+        assert_eq!(number.as_u64("sequence").expect("valid u64"), 43);
+    }
+}


### PR DESCRIPTION
## Summary

- move scraper-proxy WebSocket request and response wire types into `hyperlane-base`
- migrate the validator consumer without changing its source arbitration
- model sequenced replay events and live-only events explicitly; live IGP events may omit `sequence`
- cover durable subscriptions, live subscriptions, generic event decoding, and integer wire variants

## Expected impact

This is an enabling refactor, so no independent latency or RPC reduction is claimed. It removes the need for each agent consumer to reimplement the protocol and lets the relayer dispatch/Merkle work reuse the validator-tested envelope.

The downstream relayer dispatch + Merkle cutover is modeled to remove 2.0-3.0B CU/month, or 21.71-32.56% of modeled agent CU and 11.19-16.79% of observed trailing-30-day enterprise CU. Those gains belong to the later consumer/cutover PRs, not this one.

## Validation

- `cargo test --offline -p hyperlane-base scraper_websocket --lib` (5 passed)
- `cargo test --offline -p validator merkle_tree_hook_sync` (10 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-commit hooks, including gitleaks and both Rust workspace format checks

## Stack

Stacked on #9324 (`8db48678f1b5173d22e56948e830fd2383306a30`). Exact head: `5ee0a1ddf1719b328868f6c29333364bb105a420`. Groundwork for #9377, #9378, and #9386.