### PR TITLE
perf(validator): wake checkpoint submitter on insertions

### DIFF
--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -297,6 +297,7 @@ impl MerkleTreeHookWebSocketSync {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_with_cursor_state(
         db: HyperlaneRocksDB,
         domain: u32,

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -9,6 +9,7 @@ use futures_util::{future::BoxFuture, FutureExt, SinkExt, StreamExt};
 use prometheus::IntGauge;
 use serde::{Deserialize, Serialize};
 use tokio::{
+    sync::Notify,
     task::JoinHandle,
     time::{interval, sleep, timeout, Instant, MissedTickBehavior},
 };
@@ -270,6 +271,7 @@ pub(crate) struct MerkleTreeHookWebSocketSync {
     websocket_active: IntGauge,
     fallback_active: IntGauge,
     cursor_state: MerkleTreeCursorState,
+    checkpoint_wake: Arc<Notify>,
 }
 
 impl MerkleTreeHookWebSocketSync {
@@ -281,6 +283,7 @@ impl MerkleTreeHookWebSocketSync {
         url: Url,
         websocket_active: IntGauge,
         fallback_active: IntGauge,
+        checkpoint_wake: Arc<Notify>,
     ) -> Self {
         Self::new_with_cursor_state(
             db,
@@ -290,6 +293,7 @@ impl MerkleTreeHookWebSocketSync {
             websocket_active,
             fallback_active,
             merkle_tree_cursor_state(),
+            checkpoint_wake,
         )
     }
 
@@ -301,6 +305,7 @@ impl MerkleTreeHookWebSocketSync {
         websocket_active: IntGauge,
         fallback_active: IntGauge,
         cursor_state: MerkleTreeCursorState,
+        checkpoint_wake: Arc<Notify>,
     ) -> Self {
         websocket_active.set(0);
         fallback_active.set(0);
@@ -312,6 +317,7 @@ impl MerkleTreeHookWebSocketSync {
             websocket_active,
             fallback_active,
             cursor_state,
+            checkpoint_wake,
         }
     }
 
@@ -809,6 +815,9 @@ impl MerkleTreeHookWebSocketSync {
             if next_sequence.is_multiple_of(NEXT_SEQUENCE_PERSIST_INTERVAL) {
                 self.persist_next_sequence(*next_sequence)?;
             }
+            // Canonical validation and durable insertion have already succeeded. This is
+            // only a wake hint; the submitter still re-reads the hook before signing.
+            self.checkpoint_wake.notify_one();
             return Ok(true);
         }
         Ok(false)
@@ -1124,7 +1133,7 @@ mod tests {
     };
 
     use async_trait::async_trait;
-    use futures_util::{future::pending, SinkExt, StreamExt};
+    use futures_util::{future::pending, FutureExt, SinkExt, StreamExt};
     use hyperlane_base::db::{HyperlaneDb, DB};
     use hyperlane_core::{
         ChainResult, CheckpointAtBlock, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
@@ -1207,6 +1216,7 @@ mod tests {
                 Url::parse("ws://localhost/agents").expect("test URL"),
                 IntGauge::new("test_websocket_active", "test").expect("test gauge"),
                 IntGauge::new("test_fallback_active", "test").expect("test gauge"),
+                Arc::new(Notify::new()),
             ),
             temp_dir,
         )
@@ -1673,6 +1683,7 @@ mod tests {
             )
             .await
             .expect("valid event"));
+        assert!(sync.checkpoint_wake.notified().now_or_never().is_some());
         assert_eq!(next_sequence, 1);
         assert_eq!(
             sync.db
@@ -1700,6 +1711,7 @@ mod tests {
             )
             .await
             .expect("matching fallback insertion"));
+        assert!(sync.checkpoint_wake.notified().now_or_never().is_none());
         assert_eq!(next_sequence, 1);
         assert_eq!(
             sync.db
@@ -1723,6 +1735,7 @@ mod tests {
             .process_event(gap, &mut next_sequence, &dependencies, &mut canonical_cache,)
             .await
             .is_err());
+        assert!(sync.checkpoint_wake.notified().now_or_never().is_none());
     }
 
     #[test]

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -4,7 +4,7 @@ use std::vec;
 
 use futures::future::join_all;
 use prometheus::IntGauge;
-use tokio::time::sleep;
+use tokio::{sync::Notify, time::sleep};
 use tracing::{debug, error, info, warn};
 
 use hyperlane_base::db::HyperlaneDb;
@@ -61,6 +61,7 @@ pub(crate) struct ValidatorSubmitter {
     max_sign_concurrency: usize,
     reorg_reporter: Arc<dyn ReorgReporter>,
     readiness: Arc<ValidatorReadiness>,
+    checkpoint_wake: Option<Arc<Notify>>,
 }
 
 impl ValidatorSubmitter {
@@ -96,6 +97,23 @@ impl ValidatorSubmitter {
             max_sign_concurrency,
             reorg_reporter,
             readiness,
+            checkpoint_wake: None,
+        }
+    }
+
+    pub(crate) fn with_checkpoint_wake(mut self, checkpoint_wake: Option<Arc<Notify>>) -> Self {
+        self.checkpoint_wake = checkpoint_wake;
+        self
+    }
+
+    async fn wait_for_checkpoint_check(&self) {
+        if let Some(checkpoint_wake) = &self.checkpoint_wake {
+            tokio::select! {
+                _ = sleep(self.interval) => {}
+                _ = checkpoint_wake.notified() => {}
+            }
+        } else {
+            sleep(self.interval).await;
         }
     }
 
@@ -205,7 +223,7 @@ impl ValidatorSubmitter {
                         tree_count = tree.count(),
                         "Latest checkpoint is behind tree, sleeping briefly"
                     );
-                    sleep(self.interval).await;
+                    self.wait_for_checkpoint_check().await;
                     continue;
                 }
 
@@ -230,7 +248,7 @@ impl ValidatorSubmitter {
                         tree_count = tree.count(),
                         "Latest checkpoint is behind tree, sleeping briefly"
                     );
-                    sleep(self.interval).await;
+                    self.wait_for_checkpoint_check().await;
                     continue;
                 }
 
@@ -255,7 +273,7 @@ impl ValidatorSubmitter {
                     .set(correctness_checkpoint.index as i64);
                 self.metrics.reached_initial_consistency.set(1);
 
-                sleep(self.interval).await;
+                self.wait_for_checkpoint_check().await;
                 continue;
             }
 
@@ -289,7 +307,7 @@ impl ValidatorSubmitter {
                     tree_count = tree.count(),
                     "Latest checkpoint is behind tree, sleeping briefly"
                 );
-                sleep(self.interval).await;
+                self.wait_for_checkpoint_check().await;
                 continue;
             }
             self.submit_checkpoints_until_correctness_checkpoint(&mut tree, &latest_checkpoint)
@@ -302,7 +320,7 @@ impl ValidatorSubmitter {
             // Set that initial consistency has been reached on first loop run. Subsequent runs are idempotent.
             self.metrics.reached_initial_consistency.set(1);
 
-            sleep(self.interval).await;
+            self.wait_for_checkpoint_check().await;
         }
     }
 

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -102,6 +102,58 @@ fn dummy_readiness() -> Arc<ValidatorReadiness> {
     Arc::new(ValidatorReadiness::default())
 }
 
+fn dummy_submitter(interval: Duration) -> ValidatorSubmitter {
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    ValidatorSubmitter::new(
+        interval,
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(MockCheckpointSyncer::new()),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
+    )
+}
+
+#[tokio::test(start_paused = true)]
+async fn checkpoint_check_wakes_on_verified_insertion_hint() {
+    let checkpoint_wake = Arc::new(Notify::new());
+    let submitter = dummy_submitter(Duration::from_secs(60))
+        .with_checkpoint_wake(Some(checkpoint_wake.clone()));
+    let task = tokio::spawn(async move { submitter.wait_for_checkpoint_check().await });
+
+    tokio::task::yield_now().await;
+    assert!(!task.is_finished());
+    checkpoint_wake.notify_one();
+    tokio::task::yield_now().await;
+
+    assert!(task.is_finished());
+    task.await.expect("checkpoint wait task");
+}
+
+#[tokio::test(start_paused = true)]
+async fn checkpoint_check_retains_interval_fallback() {
+    let checkpoint_wake = Arc::new(Notify::new());
+    let submitter =
+        dummy_submitter(Duration::from_secs(60)).with_checkpoint_wake(Some(checkpoint_wake));
+    let task = tokio::spawn(async move { submitter.wait_for_checkpoint_check().await });
+
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(59)).await;
+    tokio::task::yield_now().await;
+    assert!(!task.is_finished());
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    assert!(task.is_finished());
+    task.await.expect("checkpoint wait task");
+}
+
 #[test]
 #[should_panic(expected = "maxSignConcurrency must be greater than zero")]
 fn validator_submitter_rejects_zero_sign_concurrency() {

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -14,6 +14,7 @@ use futures_util::future::{join_all, try_join_all};
 use rand::Rng;
 use serde::Serialize;
 use tokio::{
+    sync::Notify,
     task::JoinHandle,
     time::{sleep, timeout, Instant},
 };
@@ -676,6 +677,7 @@ pub struct Validator {
     core: HyperlaneAgentCore,
     db: HyperlaneRocksDB,
     merkle_tree_hook_sync: MerkleTreeHookSync,
+    checkpoint_wake: Option<Arc<Notify>>,
     mailbox: Arc<dyn Mailbox>,
     merkle_tree_hook: Arc<dyn MerkleTreeHook>,
     base_merkle_tree_hook: Arc<dyn MerkleTreeHook>,
@@ -944,24 +946,30 @@ impl BaseAgent for Validator {
         let websocket_active =
             sync_source.with_label_values(&[settings.origin_chain.name(), "websocket"]);
         let rpc_active = sync_source.with_label_values(&[settings.origin_chain.name(), "rpc"]);
-        let merkle_tree_hook_sync = if let Some(url) = settings.websocket_url.clone() {
-            MerkleTreeHookSync::WebSocket {
-                fallback: rpc_sync,
-                websocket: Box::new(MerkleTreeHookWebSocketSync::new_with_cursor_state(
-                    msg_db.clone(),
-                    settings.origin_chain.id(),
-                    origin_chain_conf.addresses.merkle_tree_hook,
-                    url,
-                    websocket_active,
-                    rpc_active,
-                    cursor_state.expect("WebSocket configuration initializes cursor state"),
-                )),
-            }
-        } else {
-            websocket_active.set(0);
-            rpc_active.set(1);
-            MerkleTreeHookSync::Rpc(rpc_sync)
-        };
+        let (merkle_tree_hook_sync, checkpoint_wake) =
+            if let Some(url) = settings.websocket_url.clone() {
+                let checkpoint_wake = Arc::new(Notify::new());
+                (
+                    MerkleTreeHookSync::WebSocket {
+                        fallback: rpc_sync,
+                        websocket: Box::new(MerkleTreeHookWebSocketSync::new_with_cursor_state(
+                            msg_db.clone(),
+                            settings.origin_chain.id(),
+                            origin_chain_conf.addresses.merkle_tree_hook,
+                            url,
+                            websocket_active,
+                            rpc_active,
+                            cursor_state.expect("WebSocket configuration initializes cursor state"),
+                            checkpoint_wake.clone(),
+                        )),
+                    },
+                    Some(checkpoint_wake),
+                )
+            } else {
+                websocket_active.set(0);
+                rpc_active.set(1);
+                (MerkleTreeHookSync::Rpc(rpc_sync), None)
+            };
 
         Ok(Self {
             origin_chain: settings.origin_chain,
@@ -973,6 +981,7 @@ impl BaseAgent for Validator {
             base_merkle_tree_hook,
             readiness,
             merkle_tree_hook_sync,
+            checkpoint_wake,
             validator_announce: validator_announce.into(),
             signer,
             raw_signer,
@@ -1400,7 +1409,8 @@ impl Validator {
             self.max_sign_concurrency,
             self.reorg_reporter.clone(),
             Arc::clone(&self.readiness),
-        );
+        )
+        .with_checkpoint_wake(self.checkpoint_wake.clone());
 
         // `wait_for_first_message` only returns a non-empty, quorum-verified tree.
         assert!(tip_tree.count() > 0, "merkle tree is empty");


### PR DESCRIPTION
## Summary

- wake the tip checkpoint submitter after a verified WebSocket insertion is durably stored
- coalesce wake hints with `tokio::sync::Notify`
- retain the configured interval fallback for missed hints and RPC-only validators
- preserve the empty-tree-safe base-hook `count()` gate plus all root and quorum checks

The reviewed `latest_checkpoint()`-only idle optimization was removed because empty EVM/Sealevel trees can error. This PR now claims no independent RPC reduction.

## Correctness

- a hint is emitted only after canonical validation and durable DB insertion
- a hint never authorizes signing; the submitter still performs its base and quorum checks
- absent or coalesced hints fall back to the existing 2-second interval

## Expected impact

Modeled, not observed: uniformly timed insertions currently pay 0-2 seconds of timer delay (1 second mean). A scheduler wake target of <=10ms removes >=99% of that mean timer component, about 100x, excluding RPC, signing, and storage time.

Canary the processed-index gap with `max by (chain) (hyperlane_latest_checkpoint{phase="validator_observed"}) - max by (chain) (hyperlane_latest_checkpoint{phase="validator_processed"})`.

## Testing

- `cargo test -p validator submit::tests -- --nocapture` (12 passed)
- `cargo test -p validator merkle_tree_hook_sync::tests -- --nocapture` (21 passed across the final stack)
- `cargo clippy -p validator -- -D warnings`
- wake-on-insertion and interval-fallback submitter regressions
- verified-insertion-only wake regressions
- normal commit hooks: gitleaks, lint-staged, Rust formatting
- `git diff --check`

Stacked on #9352 at `3c3df35f78d773743d9b31ad995ec41176c15b76`. Current head: `ad9d46a61a3b5ff007e5a81c18355ea59776a294`.

Part of #9376 and #9386.
