### PR TITLE
perf(relayer): pool checkpoint storage reads

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -8,7 +8,7 @@ use futures::{stream, StreamExt};
 use hyperlane_ethereum::Signers;
 use maplit::hashmap;
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, OptionalCache},
@@ -29,9 +29,10 @@ use crate::{merkle_tree::builder::MerkleTreeBuilder, msg::metadata::MetadataBuil
 use super::{base::IsmCachePolicyClassifier, IsmAwareAppContextClassifier};
 
 mod cached_checkpoint_syncer;
+mod checkpoint_syncer_pool;
 mod validator_announced_storages;
 
-use cached_checkpoint_syncer::CachedCheckpointSyncer;
+pub(crate) use checkpoint_syncer_pool::CheckpointSyncerPool;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct IsmBuildMetricsParams {
@@ -53,6 +54,7 @@ pub struct BaseMetadataBuilder {
     allow_local_checkpoint_syncers: bool,
     metrics: Arc<CoreMetrics>,
     cache: OptionalCache<MeteredCache<LocalCache>>,
+    checkpoint_syncer_pool: CheckpointSyncerPool,
     db: HyperlaneRocksDB,
     app_context_classifier: IsmAwareAppContextClassifier,
     ism_cache_policy_classifier: IsmCachePolicyClassifier,
@@ -318,7 +320,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
             .collect::<Vec<_>>();
 
         for (validator, checkpoint_syncer) in checkpoint_syncers_results {
-            checkpoint_syncers.insert(validator.into(), checkpoint_syncer.into());
+            checkpoint_syncers.insert(validator.into(), checkpoint_syncer);
         }
 
         Ok(MultisigCheckpointSyncer::new(
@@ -347,18 +349,19 @@ impl BaseMetadataBuilder {
         config: &CheckpointSyncerConf,
         validator: &H256,
         storage_location: &str,
-    ) -> Result<Option<Box<dyn CheckpointSyncer>>, CheckpointSyncerBuildError> {
-        match config.build_and_validate(None).await {
-            Ok(checkpoint_syncer) => {
-                let checkpoint_syncer = CachedCheckpointSyncer::new(
-                    checkpoint_syncer,
-                    self.cache.clone(),
-                    self.origin_domain.name().to_string(),
-                    *validator,
-                    storage_location.to_string(),
-                );
-                return Ok(Some(Box::new(checkpoint_syncer)));
-            }
+    ) -> Result<Option<Arc<dyn CheckpointSyncer>>, CheckpointSyncerBuildError> {
+        let checkpoint_syncer = match self
+            .checkpoint_syncer_pool
+            .get_or_build(
+                config,
+                self.cache.clone(),
+                self.origin_domain.name().to_string(),
+                *validator,
+                storage_location.to_string(),
+            )
+            .await
+        {
+            Ok(checkpoint_syncer) => checkpoint_syncer,
             Err(CheckpointSyncerBuildError::ReorgFlag(reorg_event)) => {
                 if self.ignore_reorg_reports {
                     warn!(
@@ -381,8 +384,81 @@ impl BaseMetadataBuilder {
                     ?validator,
                     "Error when loading checkpoint syncer; will attempt to use the next config"
                 );
+                return Ok(None);
+            }
+        };
+
+        // The backend is pooled, but reorg status is safety-critical and must be
+        // checked on every checkout rather than only when the client is built.
+        match checkpoint_syncer.reorg_status().await {
+            Ok(reorg_event) if reorg_event.exists => {
+                if self.ignore_reorg_reports {
+                    warn!(
+                        ?reorg_event,
+                        ?config,
+                        ?validator,
+                        "Ignoring reorg event for checkpoint syncer build"
+                    );
+                    Ok(None)
+                } else {
+                    Err(CheckpointSyncerBuildError::ReorgFlag(reorg_event))
+                }
+            }
+            Ok(_) => Ok(Some(checkpoint_syncer)),
+            Err(err) => {
+                error!(
+                    ?err,
+                    ?config,
+                    ?validator,
+                    "Failed to read reorg status. Assuming no reorg occurred."
+                );
+                Ok(Some(checkpoint_syncer))
             }
         }
-        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlane_base::db::DB;
+    use hyperlane_core::{ReorgEvent, ReorgPeriod};
+
+    use crate::test_utils::dummy_data::dummy_metadata_builder;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn revalidates_reorg_status_on_every_pool_checkout() {
+        let origin = HyperlaneDomain::new_test_domain("origin");
+        let destination = HyperlaneDomain::new_test_domain("destination");
+        let db_dir = tempfile::tempdir().unwrap();
+        let db = HyperlaneRocksDB::new(&origin, DB::from_path(db_dir.path()).unwrap());
+        let builder = dummy_metadata_builder(&origin, &destination, &db, OptionalCache::new(None));
+        let checkpoint_dir = tempfile::tempdir().unwrap();
+        let storage_location = format!("file://{}", checkpoint_dir.path().display());
+        let config = CheckpointSyncerConf::from_str(&storage_location).unwrap();
+        let validator = H256::from_low_u64_be(1);
+
+        let syncer = builder
+            .build_and_validate(&config, &validator, &storage_location)
+            .await
+            .unwrap()
+            .unwrap();
+        let reorg_event = ReorgEvent {
+            local_merkle_root: H256::from_low_u64_be(2),
+            canonical_merkle_root: H256::from_low_u64_be(3),
+            checkpoint_index: 4,
+            unix_timestamp: 5,
+            reorg_period: ReorgPeriod::from_blocks(6),
+        };
+        syncer.write_reorg_status(&reorg_event).await.unwrap();
+
+        let result = builder
+            .build_and_validate(&config, &validator, &storage_location)
+            .await;
+        assert!(matches!(
+            result,
+            Err(CheckpointSyncerBuildError::ReorgFlag(response)) if response.exists
+        ));
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
@@ -1,6 +1,7 @@
-use std::{fmt::Debug, time::Duration};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 
-use eyre::Result;
+use eyre::{eyre, Result};
+use moka::future::Cache;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -20,6 +21,13 @@ const LATEST_INDEX_METHOD: &str = "latest_index";
 // per-validator `latest_index` RPC/S3 load. The message-id multisig path only
 // uses `latest_index` for metrics, so it is unaffected by this TTL.
 const LATEST_INDEX_CACHE_TTL: Duration = Duration::from_secs(2);
+const MAX_INFLIGHT_CHECKPOINTS: u64 = 1024;
+// Normally each completed flight is invalidated immediately. This short TTL is
+// a cancellation-safety backstop if a caller is dropped between completion and
+// the asynchronous invalidation.
+const INFLIGHT_RESULT_TTL: Duration = Duration::from_millis(100);
+
+type InflightResult<T> = std::result::Result<T, Arc<str>>;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct CachedLatestIndexKey {
@@ -36,11 +44,13 @@ struct CachedCheckpointKey {
 
 #[derive(Debug)]
 pub struct CachedCheckpointSyncer<C> {
-    inner: Box<dyn CheckpointSyncer>,
+    inner: Arc<dyn CheckpointSyncer>,
     cache: C,
     origin_domain_name: String,
     validator: H256,
     storage_location: String,
+    inflight_latest_index: Cache<(), Arc<InflightResult<Option<u32>>>>,
+    inflight_checkpoints: Cache<u32, Arc<InflightResult<Option<SignedCheckpointWithMessageId>>>>,
 }
 
 impl<C> CachedCheckpointSyncer<C> {
@@ -52,11 +62,19 @@ impl<C> CachedCheckpointSyncer<C> {
         storage_location: String,
     ) -> Self {
         Self {
-            inner,
+            inner: inner.into(),
             cache,
             origin_domain_name,
             validator,
             storage_location,
+            inflight_latest_index: Cache::builder()
+                .max_capacity(1)
+                .time_to_live(INFLIGHT_RESULT_TTL)
+                .build(),
+            inflight_checkpoints: Cache::builder()
+                .max_capacity(MAX_INFLIGHT_CHECKPOINTS)
+                .time_to_live(INFLIGHT_RESULT_TTL)
+                .build(),
         }
     }
 
@@ -112,14 +130,11 @@ impl<C> CachedCheckpointSyncer<C> {
             }
         }
     }
-}
 
-#[async_trait::async_trait]
-impl<C> CheckpointSyncer for CachedCheckpointSyncer<C>
-where
-    C: FunctionCallCache + Debug,
-{
-    async fn latest_index(&self) -> Result<Option<u32>> {
+    async fn cached_latest_index(&self) -> Option<u32>
+    where
+        C: FunctionCallCache + Debug,
+    {
         let cache_key = self.latest_index_cache_key();
         match self
             .cache
@@ -130,46 +145,22 @@ where
             )
             .await
         {
-            Ok(Some(latest_index)) => return Ok(Some(latest_index)),
-            Ok(None) => {}
+            Ok(value) => value,
             Err(err) => {
                 debug!(
                     error = %err,
                     validator = ?self.validator,
                     "Failed to fetch latest checkpoint index from cache"
                 );
+                None
             }
         }
-
-        let result = self.inner.latest_index().await;
-        if let Ok(Some(latest_index)) = &result {
-            if let Err(err) = self
-                .cache
-                .cache_call_result_with_expiration(
-                    &self.origin_domain_name,
-                    LATEST_INDEX_METHOD,
-                    &cache_key,
-                    latest_index,
-                    ExpirationType::AfterDuration(LATEST_INDEX_CACHE_TTL),
-                )
-                .await
-            {
-                debug!(
-                    error = %err,
-                    validator = ?self.validator,
-                    latest_index,
-                    "Failed to cache latest checkpoint index"
-                );
-            }
-        }
-        result
     }
 
-    async fn write_latest_index(&self, index: u32) -> Result<()> {
-        self.inner.write_latest_index(index).await
-    }
-
-    async fn fetch_checkpoint(&self, index: u32) -> Result<Option<SignedCheckpointWithMessageId>> {
+    async fn cached_checkpoint(&self, index: u32) -> Option<SignedCheckpointWithMessageId>
+    where
+        C: FunctionCallCache + Debug,
+    {
         let cache_key = self.cache_key(index);
         match self
             .cache
@@ -180,8 +171,7 @@ where
             )
             .await
         {
-            Ok(Some(signed_checkpoint)) => return Ok(Some(signed_checkpoint)),
-            Ok(None) => {}
+            Ok(value) => value,
             Err(err) => {
                 debug!(
                     error = %err,
@@ -189,34 +179,121 @@ where
                     index,
                     "Failed to fetch signed checkpoint from cache"
                 );
+                None
             }
         }
+    }
 
-        let result = self.inner.fetch_checkpoint(index).await;
-        if let Ok(Some(signed_checkpoint)) = &result {
-            if !self.is_cacheable_checkpoint(index, signed_checkpoint) {
-                return result;
-            }
-
-            if let Err(err) = self
-                .cache
-                .cache_call_result(
-                    &self.origin_domain_name,
-                    FETCH_CHECKPOINT_METHOD,
-                    &cache_key,
-                    signed_checkpoint,
-                )
-                .await
-            {
-                debug!(
-                    error = %err,
-                    validator = ?self.validator,
-                    index,
-                    "Failed to cache signed checkpoint"
-                );
-            }
+    fn clone_inflight_result<T: Clone>(result: &InflightResult<T>) -> Result<T> {
+        match result {
+            Ok(value) => Ok(value.clone()),
+            Err(err) => Err(eyre!(err.to_string())),
         }
-        result
+    }
+}
+
+#[async_trait::async_trait]
+impl<C> CheckpointSyncer for CachedCheckpointSyncer<C>
+where
+    C: FunctionCallCache + Debug,
+{
+    async fn latest_index(&self) -> Result<Option<u32>> {
+        if let Some(latest_index) = self.cached_latest_index().await {
+            return Ok(Some(latest_index));
+        }
+
+        let result = self
+            .inflight_latest_index
+            .get_with((), async {
+                if let Some(latest_index) = self.cached_latest_index().await {
+                    return Arc::new(Ok(Some(latest_index)));
+                }
+
+                match self.inner.latest_index().await {
+                    Ok(result) => {
+                        if let Some(latest_index) = &result {
+                            let cache_key = self.latest_index_cache_key();
+                            if let Err(err) = self
+                                .cache
+                                .cache_call_result_with_expiration(
+                                    &self.origin_domain_name,
+                                    LATEST_INDEX_METHOD,
+                                    &cache_key,
+                                    latest_index,
+                                    ExpirationType::AfterDuration(LATEST_INDEX_CACHE_TTL),
+                                )
+                                .await
+                            {
+                                debug!(
+                                    error = %err,
+                                    validator = ?self.validator,
+                                    latest_index,
+                                    "Failed to cache latest checkpoint index"
+                                );
+                            }
+                        }
+                        Arc::new(Ok(result))
+                    }
+                    Err(err) => Arc::new(Err(Arc::from(format!("{err:#}")))),
+                }
+            })
+            .await;
+        self.inflight_latest_index.invalidate(&()).await;
+
+        Self::clone_inflight_result(&result)
+    }
+
+    async fn write_latest_index(&self, index: u32) -> Result<()> {
+        self.inner.write_latest_index(index).await
+    }
+
+    async fn fetch_checkpoint(&self, index: u32) -> Result<Option<SignedCheckpointWithMessageId>> {
+        if let Some(signed_checkpoint) = self.cached_checkpoint(index).await {
+            return Ok(Some(signed_checkpoint));
+        }
+
+        let result = self
+            .inflight_checkpoints
+            .get_with(index, async {
+                if let Some(signed_checkpoint) = self.cached_checkpoint(index).await {
+                    return Arc::new(Ok(Some(signed_checkpoint)));
+                }
+
+                match self.inner.fetch_checkpoint(index).await {
+                    Ok(result) => {
+                        if let Some(signed_checkpoint) = &result {
+                            if !self.is_cacheable_checkpoint(index, signed_checkpoint) {
+                                return Arc::new(Ok(result));
+                            }
+
+                            let cache_key = self.cache_key(index);
+                            if let Err(err) = self
+                                .cache
+                                .cache_call_result(
+                                    &self.origin_domain_name,
+                                    FETCH_CHECKPOINT_METHOD,
+                                    &cache_key,
+                                    signed_checkpoint,
+                                )
+                                .await
+                            {
+                                debug!(
+                                    error = %err,
+                                    validator = ?self.validator,
+                                    index,
+                                    "Failed to cache signed checkpoint"
+                                );
+                            }
+                        }
+                        Arc::new(Ok(result))
+                    }
+                    Err(err) => Arc::new(Err(Arc::from(format!("{err:#}")))),
+                }
+            })
+            .await;
+        self.inflight_checkpoints.invalidate(&index).await;
+
+        Self::clone_inflight_result(&result)
     }
 
     async fn write_checkpoint(
@@ -255,6 +332,7 @@ where
 mod tests {
     use std::{
         collections::VecDeque,
+        future::pending,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc, Mutex,
@@ -270,6 +348,10 @@ mod tests {
         SignedCheckpointWithMessageId,
     };
     use hyperlane_ethereum::Signers;
+    use tokio::{
+        sync::{Barrier, Notify},
+        time::timeout,
+    };
 
     use super::*;
 
@@ -279,6 +361,15 @@ mod tests {
         latest_index_count: Arc<AtomicUsize>,
         responses: Mutex<VecDeque<Result<Option<SignedCheckpointWithMessageId>>>>,
         latest_index_responses: Mutex<VecDeque<Result<Option<u32>>>>,
+        fetch_gate: Option<CallGate>,
+        latest_index_gate: Option<CallGate>,
+        cancel_first_fetch: bool,
+    }
+
+    #[derive(Debug)]
+    struct CallGate {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
     }
 
     impl CountingCheckpointSyncer {
@@ -293,6 +384,9 @@ mod tests {
                     latest_index_count,
                     responses: Mutex::new(responses.into()),
                     latest_index_responses: Mutex::new(VecDeque::new()),
+                    fetch_gate: None,
+                    latest_index_gate: None,
+                    cancel_first_fetch: false,
                 },
                 fetch_count,
             )
@@ -309,16 +403,53 @@ mod tests {
                     latest_index_count: latest_index_count.clone(),
                     responses: Mutex::new(VecDeque::new()),
                     latest_index_responses: Mutex::new(latest_index_responses.into()),
+                    fetch_gate: None,
+                    latest_index_gate: None,
+                    cancel_first_fetch: false,
                 },
                 latest_index_count,
             )
+        }
+
+        fn new_with_gated_fetches(
+            responses: Vec<Result<Option<SignedCheckpointWithMessageId>>>,
+            cancel_first_fetch: bool,
+        ) -> (Self, Arc<AtomicUsize>, Arc<Notify>, Arc<Notify>) {
+            let (mut syncer, fetch_count) = Self::new(responses);
+            let started = Arc::new(Notify::new());
+            let release = Arc::new(Notify::new());
+            syncer.fetch_gate = Some(CallGate {
+                started: started.clone(),
+                release: release.clone(),
+            });
+            syncer.cancel_first_fetch = cancel_first_fetch;
+            (syncer, fetch_count, started, release)
+        }
+
+        fn new_with_gated_latest_index(
+            responses: Vec<Result<Option<u32>>>,
+        ) -> (Self, Arc<AtomicUsize>, Arc<Notify>, Arc<Notify>) {
+            let (mut syncer, latest_index_count) = Self::new_with_latest_index_responses(responses);
+            let started = Arc::new(Notify::new());
+            let release = Arc::new(Notify::new());
+            syncer.latest_index_gate = Some(CallGate {
+                started: started.clone(),
+                release: release.clone(),
+            });
+            (syncer, latest_index_count, started, release)
         }
     }
 
     #[async_trait::async_trait]
     impl CheckpointSyncer for CountingCheckpointSyncer {
         async fn latest_index(&self) -> Result<Option<u32>> {
-            self.latest_index_count.fetch_add(1, Ordering::Relaxed);
+            let call = self.latest_index_count.fetch_add(1, Ordering::Relaxed);
+            if call == 0 {
+                if let Some(gate) = &self.latest_index_gate {
+                    gate.started.notify_one();
+                    gate.release.notified().await;
+                }
+            }
             self.latest_index_responses
                 .lock()
                 .map_err(|_| eyre::eyre!("Failed to lock latest index responses"))?
@@ -334,7 +465,17 @@ mod tests {
             &self,
             _index: u32,
         ) -> Result<Option<SignedCheckpointWithMessageId>> {
-            self.fetch_count.fetch_add(1, Ordering::Relaxed);
+            let call = self.fetch_count.fetch_add(1, Ordering::Relaxed);
+            if call == 0 {
+                if let Some(gate) = &self.fetch_gate {
+                    gate.started.notify_one();
+                    if self.cancel_first_fetch {
+                        pending::<()>().await;
+                    } else {
+                        gate.release.notified().await;
+                    }
+                }
+            }
             self.responses
                 .lock()
                 .map_err(|_| eyre::eyre!("Failed to lock responses"))?
@@ -646,5 +787,181 @@ mod tests {
         assert_eq!(first, Some(10));
         assert_eq!(second, Some(11));
         assert_eq!(latest_index_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn singleflights_concurrent_checkpoint_misses() {
+        const CALLS: usize = 8;
+
+        let signer = test_signer();
+        let signed_checkpoint = signed_checkpoint(10, &signer).await;
+        let (inner, fetch_count, started, release) =
+            CountingCheckpointSyncer::new_with_gated_fetches(
+                vec![Ok(Some(signed_checkpoint.clone()))],
+                false,
+            );
+        let syncer = Arc::new(CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        ));
+        let barrier = Arc::new(Barrier::new(CALLS + 1));
+        let tasks = (0..CALLS)
+            .map(|_| {
+                let syncer = syncer.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    syncer.fetch_checkpoint(10).await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait().await;
+        started.notified().await;
+        tokio::task::yield_now().await;
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
+        release.notify_one();
+
+        for task in tasks {
+            assert_eq!(
+                task.await.unwrap().unwrap(),
+                Some(signed_checkpoint.clone())
+            );
+        }
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn singleflights_concurrent_latest_index_misses() {
+        const CALLS: usize = 8;
+
+        let signer = test_signer();
+        let (inner, latest_index_count, started, release) =
+            CountingCheckpointSyncer::new_with_gated_latest_index(vec![Ok(Some(10))]);
+        let syncer = Arc::new(CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        ));
+        let barrier = Arc::new(Barrier::new(CALLS + 1));
+        let tasks = (0..CALLS)
+            .map(|_| {
+                let syncer = syncer.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    syncer.latest_index().await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait().await;
+        started.notified().await;
+        tokio::task::yield_now().await;
+        assert_eq!(latest_index_count.load(Ordering::Relaxed), 1);
+        release.notify_one();
+
+        for task in tasks {
+            assert_eq!(task.await.unwrap().unwrap(), Some(10));
+        }
+        assert_eq!(latest_index_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn singleflight_errors_are_retried() {
+        const CALLS: usize = 8;
+
+        let signer = test_signer();
+        let signed_checkpoint = signed_checkpoint(10, &signer).await;
+        let (inner, fetch_count, started, release) =
+            CountingCheckpointSyncer::new_with_gated_fetches(
+                vec![
+                    Err(eyre!("transient backend error")),
+                    Ok(Some(signed_checkpoint.clone())),
+                ],
+                false,
+            );
+        let syncer = Arc::new(CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        ));
+        let barrier = Arc::new(Barrier::new(CALLS + 1));
+        let tasks = (0..CALLS)
+            .map(|_| {
+                let syncer = syncer.clone();
+                let barrier = barrier.clone();
+                tokio::spawn(async move {
+                    barrier.wait().await;
+                    syncer.fetch_checkpoint(10).await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait().await;
+        started.notified().await;
+        tokio::task::yield_now().await;
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
+        release.notify_one();
+
+        for task in tasks {
+            let error = task.await.unwrap().unwrap_err();
+            assert!(error.to_string().contains("transient backend error"));
+        }
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
+
+        assert_eq!(
+            syncer.fetch_checkpoint(10).await.unwrap(),
+            Some(signed_checkpoint)
+        );
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_singleflight_leader_does_not_strand_waiters() {
+        let signer = test_signer();
+        let signed_checkpoint = signed_checkpoint(10, &signer).await;
+        let (inner, fetch_count, started, _release) =
+            CountingCheckpointSyncer::new_with_gated_fetches(
+                vec![Ok(Some(signed_checkpoint.clone()))],
+                true,
+            );
+        let syncer = Arc::new(CachedCheckpointSyncer::new(
+            Box::new(inner),
+            LocalCache::new("test-cache"),
+            "testorigin".to_string(),
+            validator(&signer),
+            "test".to_string(),
+        ));
+
+        let leader = {
+            let syncer = syncer.clone();
+            tokio::spawn(async move { syncer.fetch_checkpoint(10).await })
+        };
+        started.notified().await;
+        let waiter = {
+            let syncer = syncer.clone();
+            tokio::spawn(async move { syncer.fetch_checkpoint(10).await })
+        };
+        tokio::task::yield_now().await;
+        leader.abort();
+        assert!(leader.await.unwrap_err().is_cancelled());
+
+        assert_eq!(
+            timeout(Duration::from_secs(1), waiter)
+                .await
+                .expect("waiter should not be stranded")
+                .unwrap()
+                .unwrap(),
+            Some(signed_checkpoint)
+        );
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 2);
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
@@ -872,49 +872,24 @@ mod tests {
         assert_eq!(latest_index_count.load(Ordering::Relaxed), 1);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test]
     async fn singleflight_errors_are_retried() {
-        const CALLS: usize = 8;
-
         let signer = test_signer();
         let signed_checkpoint = signed_checkpoint(10, &signer).await;
-        let (inner, fetch_count, started, release) =
-            CountingCheckpointSyncer::new_with_gated_fetches(
-                vec![
-                    Err(eyre!("transient backend error")),
-                    Ok(Some(signed_checkpoint.clone())),
-                ],
-                false,
-            );
-        let syncer = Arc::new(CachedCheckpointSyncer::new(
+        let (inner, fetch_count) = CountingCheckpointSyncer::new(vec![
+            Err(eyre!("transient backend error")),
+            Ok(Some(signed_checkpoint.clone())),
+        ]);
+        let syncer = CachedCheckpointSyncer::new(
             Box::new(inner),
             LocalCache::new("test-cache"),
             "testorigin".to_string(),
             validator(&signer),
             "test".to_string(),
-        ));
-        let barrier = Arc::new(Barrier::new(CALLS + 1));
-        let tasks = (0..CALLS)
-            .map(|_| {
-                let syncer = syncer.clone();
-                let barrier = barrier.clone();
-                tokio::spawn(async move {
-                    barrier.wait().await;
-                    syncer.fetch_checkpoint(10).await
-                })
-            })
-            .collect::<Vec<_>>();
+        );
 
-        barrier.wait().await;
-        started.notified().await;
-        tokio::task::yield_now().await;
-        assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
-        release.notify_one();
-
-        for task in tasks {
-            let error = task.await.unwrap().unwrap_err();
-            assert!(error.to_string().contains("transient backend error"));
-        }
+        let error = syncer.fetch_checkpoint(10).await.unwrap_err();
+        assert!(error.to_string().contains("transient backend error"));
         assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
 
         assert_eq!(

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/cached_checkpoint_syncer.rs
@@ -22,9 +22,8 @@ const LATEST_INDEX_METHOD: &str = "latest_index";
 // uses `latest_index` for metrics, so it is unaffected by this TTL.
 const LATEST_INDEX_CACHE_TTL: Duration = Duration::from_secs(2);
 const MAX_INFLIGHT_CHECKPOINTS: u64 = 1024;
-// Normally each completed flight is invalidated immediately. This short TTL is
-// a cancellation-safety backstop if a caller is dropped between completion and
-// the asynchronous invalidation.
+// Retain completed flights briefly so a delayed waiter cannot invalidate a
+// newer generation. Errors and non-cacheable values are retried after the TTL.
 const INFLIGHT_RESULT_TTL: Duration = Duration::from_millis(100);
 
 type InflightResult<T> = std::result::Result<T, Arc<str>>;
@@ -238,8 +237,6 @@ where
                 }
             })
             .await;
-        self.inflight_latest_index.invalidate(&()).await;
-
         Self::clone_inflight_result(&result)
     }
 
@@ -291,8 +288,6 @@ where
                 }
             })
             .await;
-        self.inflight_checkpoints.invalidate(&index).await;
-
         Self::clone_inflight_result(&result)
     }
 
@@ -583,9 +578,12 @@ mod tests {
 
         let first = syncer.fetch_checkpoint(10).await.expect("first fetch");
         let second = syncer.fetch_checkpoint(10).await.expect("second fetch");
+        tokio::time::sleep(INFLIGHT_RESULT_TTL + Duration::from_millis(10)).await;
+        let third = syncer.fetch_checkpoint(10).await.expect("third fetch");
 
         assert_eq!(first, None);
-        assert_eq!(second, Some(signed_checkpoint));
+        assert_eq!(second, None);
+        assert_eq!(third, Some(signed_checkpoint));
         assert_eq!(fetch_count.load(Ordering::Relaxed), 2);
     }
 
@@ -652,6 +650,7 @@ mod tests {
         );
 
         let first = syncer.fetch_checkpoint(10).await.expect("first fetch");
+        tokio::time::sleep(INFLIGHT_RESULT_TTL + Duration::from_millis(10)).await;
         let second = syncer.fetch_checkpoint(10).await.expect("second fetch");
 
         assert_eq!(first, Some(signed_checkpoint.clone()));
@@ -676,6 +675,7 @@ mod tests {
         );
 
         let first = syncer.fetch_checkpoint(10).await.expect("first fetch");
+        tokio::time::sleep(INFLIGHT_RESULT_TTL + Duration::from_millis(10)).await;
         let second = syncer.fetch_checkpoint(10).await.expect("second fetch");
 
         assert_eq!(first, Some(signed_checkpoint.clone()));
@@ -758,9 +758,12 @@ mod tests {
 
         let first = syncer.latest_index().await.expect("first fetch");
         let second = syncer.latest_index().await.expect("second fetch");
+        tokio::time::sleep(INFLIGHT_RESULT_TTL + Duration::from_millis(10)).await;
+        let third = syncer.latest_index().await.expect("third fetch");
 
         assert_eq!(first, None);
-        assert_eq!(second, Some(10));
+        assert_eq!(second, None);
+        assert_eq!(third, Some(10));
         assert_eq!(latest_index_count.load(Ordering::Relaxed), 2);
     }
 
@@ -892,6 +895,13 @@ mod tests {
         assert!(error.to_string().contains("transient backend error"));
         assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
 
+        let same_flight_error = syncer.fetch_checkpoint(10).await.unwrap_err();
+        assert!(same_flight_error
+            .to_string()
+            .contains("transient backend error"));
+        assert_eq!(fetch_count.load(Ordering::Relaxed), 1);
+
+        tokio::time::sleep(INFLIGHT_RESULT_TTL + Duration::from_millis(10)).await;
         assert_eq!(
             syncer.fetch_checkpoint(10).await.unwrap(),
             Some(signed_checkpoint)

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/checkpoint_syncer_pool.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/checkpoint_syncer_pool.rs
@@ -1,0 +1,147 @@
+use std::{fmt, sync::Arc};
+
+use hyperlane_base::{
+    cache::{LocalCache, MeteredCache, OptionalCache},
+    settings::{CheckpointSyncerBuildError, CheckpointSyncerConf},
+};
+use hyperlane_core::H256;
+use moka::future::Cache;
+use tokio::sync::OnceCell;
+
+use super::cached_checkpoint_syncer::CachedCheckpointSyncer;
+
+const MAX_POOLED_CHECKPOINT_SYNCERS: u64 = 1024;
+
+type RelayerCache = OptionalCache<MeteredCache<LocalCache>>;
+type PooledCheckpointSyncer = Arc<CachedCheckpointSyncer<RelayerCache>>;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CheckpointSyncerPoolKey {
+    origin_domain_name: String,
+    validator: H256,
+    storage_location: String,
+    config: String,
+}
+
+/// Shares checkpoint storage clients and their in-flight reads across metadata builders.
+#[derive(Clone)]
+pub(crate) struct CheckpointSyncerPool {
+    syncers: Cache<CheckpointSyncerPoolKey, Arc<OnceCell<PooledCheckpointSyncer>>>,
+}
+
+impl fmt::Debug for CheckpointSyncerPool {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CheckpointSyncerPool")
+            .field("entry_count", &self.syncers.entry_count())
+            .finish()
+    }
+}
+
+impl Default for CheckpointSyncerPool {
+    fn default() -> Self {
+        Self {
+            syncers: Cache::builder()
+                .max_capacity(MAX_POOLED_CHECKPOINT_SYNCERS)
+                .build(),
+        }
+    }
+}
+
+impl CheckpointSyncerPool {
+    pub(crate) async fn get_or_build(
+        &self,
+        config: &CheckpointSyncerConf,
+        cache: RelayerCache,
+        origin_domain_name: String,
+        validator: H256,
+        storage_location: String,
+    ) -> Result<PooledCheckpointSyncer, CheckpointSyncerBuildError> {
+        let key = CheckpointSyncerPoolKey {
+            origin_domain_name: origin_domain_name.clone(),
+            validator,
+            storage_location: storage_location.clone(),
+            config: format!("{config:?}"),
+        };
+        let cell = self
+            .syncers
+            .get_with(key, async { Arc::new(OnceCell::new()) })
+            .await;
+
+        cell.get_or_try_init(|| async {
+            let inner = config.build_and_validate(None).await?;
+            Ok(Arc::new(CachedCheckpointSyncer::new(
+                inner,
+                cache,
+                origin_domain_name,
+                validator,
+                storage_location,
+            )))
+        })
+        .await
+        .map(Arc::clone)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn pools_by_origin_validator_location_and_config() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        let first_location = format!("file://{}", first_dir.path().display());
+        let second_location = format!("file://{}", second_dir.path().display());
+        let first_config = CheckpointSyncerConf::from_str(&first_location).unwrap();
+        let second_config = CheckpointSyncerConf::from_str(&second_location).unwrap();
+        let pool = CheckpointSyncerPool::default();
+        let validator = H256::from_low_u64_be(1);
+
+        let (first, duplicate) = tokio::join!(
+            pool.get_or_build(
+                &first_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                first_location.clone(),
+            ),
+            pool.get_or_build(
+                &first_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                first_location.clone(),
+            ),
+        );
+        let first = first.unwrap();
+        let duplicate = duplicate.unwrap();
+        assert!(Arc::ptr_eq(&first, &duplicate));
+
+        let other_location = pool
+            .get_or_build(
+                &second_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                second_location,
+            )
+            .await
+            .unwrap();
+        assert!(!Arc::ptr_eq(&first, &other_location));
+
+        let other_validator = pool
+            .get_or_build(
+                &first_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                H256::from_low_u64_be(2),
+                first_location,
+            )
+            .await
+            .unwrap();
+        assert!(!Arc::ptr_eq(&first, &other_validator));
+    }
+}

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder/checkpoint_syncer_pool.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder/checkpoint_syncer_pool.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::{fmt, sync::Arc, time::Duration};
 
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, OptionalCache},
@@ -11,6 +11,7 @@ use tokio::sync::OnceCell;
 use super::cached_checkpoint_syncer::CachedCheckpointSyncer;
 
 const MAX_POOLED_CHECKPOINT_SYNCERS: u64 = 1024;
+const POOLED_CHECKPOINT_SYNCER_TTL: Duration = Duration::from_secs(10 * 60);
 
 type RelayerCache = OptionalCache<MeteredCache<LocalCache>>;
 type PooledCheckpointSyncer = Arc<CachedCheckpointSyncer<RelayerCache>>;
@@ -40,15 +41,22 @@ impl fmt::Debug for CheckpointSyncerPool {
 
 impl Default for CheckpointSyncerPool {
     fn default() -> Self {
-        Self {
-            syncers: Cache::builder()
-                .max_capacity(MAX_POOLED_CHECKPOINT_SYNCERS)
-                .build(),
-        }
+        Self::with_ttl(POOLED_CHECKPOINT_SYNCER_TTL)
     }
 }
 
 impl CheckpointSyncerPool {
+    fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            syncers: Cache::builder()
+                .max_capacity(MAX_POOLED_CHECKPOINT_SYNCERS)
+                // Absolute expiry allows same-path credential rotation to rebuild
+                // even when the client remains hot.
+                .time_to_live(ttl)
+                .build(),
+        }
+    }
+
     pub(crate) async fn get_or_build(
         &self,
         config: &CheckpointSyncerConf,
@@ -85,18 +93,15 @@ impl CheckpointSyncerPool {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{path::PathBuf, str::FromStr};
 
     use super::*;
 
     #[tokio::test]
-    async fn pools_by_origin_validator_location_and_config() {
+    async fn pools_concurrent_duplicate_builds() {
         let first_dir = tempfile::tempdir().unwrap();
-        let second_dir = tempfile::tempdir().unwrap();
         let first_location = format!("file://{}", first_dir.path().display());
-        let second_location = format!("file://{}", second_dir.path().display());
         let first_config = CheckpointSyncerConf::from_str(&first_location).unwrap();
-        let second_config = CheckpointSyncerConf::from_str(&second_location).unwrap();
         let pool = CheckpointSyncerPool::default();
         let validator = H256::from_low_u64_be(1);
 
@@ -119,6 +124,40 @@ mod tests {
         let first = first.unwrap();
         let duplicate = duplicate.unwrap();
         assert!(Arc::ptr_eq(&first, &duplicate));
+    }
+
+    #[tokio::test]
+    async fn isolates_pool_entries_by_origin_validator_and_location() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        let first_location = format!("file://{}", first_dir.path().display());
+        let second_location = format!("file://{}", second_dir.path().display());
+        let first_config = CheckpointSyncerConf::from_str(&first_location).unwrap();
+        let second_config = CheckpointSyncerConf::from_str(&second_location).unwrap();
+        let pool = CheckpointSyncerPool::default();
+        let validator = H256::from_low_u64_be(1);
+        let first = pool
+            .get_or_build(
+                &first_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                first_location.clone(),
+            )
+            .await
+            .unwrap();
+
+        let other_origin = pool
+            .get_or_build(
+                &first_config,
+                OptionalCache::new(None),
+                "other-origin".to_string(),
+                validator,
+                first_location.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(!Arc::ptr_eq(&first, &other_origin));
 
         let other_location = pool
             .get_or_build(
@@ -143,5 +182,73 @@ mod tests {
             .await
             .unwrap();
         assert!(!Arc::ptr_eq(&first, &other_validator));
+    }
+
+    #[tokio::test]
+    async fn isolates_pool_entries_by_config() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        let storage_location = format!("file://{}", first_dir.path().display());
+        let first_config = CheckpointSyncerConf::from_str(&storage_location).unwrap();
+        let different_config = CheckpointSyncerConf::LocalStorage {
+            path: PathBuf::from(second_dir.path()),
+        };
+        let pool = CheckpointSyncerPool::default();
+        let validator = H256::from_low_u64_be(1);
+        let first = pool
+            .get_or_build(
+                &first_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                storage_location.clone(),
+            )
+            .await
+            .unwrap();
+        let other_config = pool
+            .get_or_build(
+                &different_config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                storage_location,
+            )
+            .await
+            .unwrap();
+
+        assert!(!Arc::ptr_eq(&first, &other_config));
+    }
+
+    #[tokio::test]
+    async fn rebuilds_client_after_absolute_ttl() {
+        let checkpoint_dir = tempfile::tempdir().unwrap();
+        let storage_location = format!("file://{}", checkpoint_dir.path().display());
+        let config = CheckpointSyncerConf::from_str(&storage_location).unwrap();
+        let pool = CheckpointSyncerPool::with_ttl(Duration::from_millis(10));
+        let validator = H256::from_low_u64_be(1);
+        let first = pool
+            .get_or_build(
+                &config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                storage_location.clone(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let rebuilt = pool
+            .get_or_build(
+                &config,
+                OptionalCache::new(None),
+                "origin".to_string(),
+                validator,
+                storage_location,
+            )
+            .await
+            .unwrap();
+
+        assert!(!Arc::ptr_eq(&first, &rebuilt));
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/mod.rs
@@ -14,5 +14,7 @@ pub(crate) use base::{
     MetadataBuilder,
 };
 #[allow(unused_imports)]
-pub(crate) use base_builder::{BaseMetadataBuilder, BuildsBaseMetadata, IsmBuildMetricsParams};
+pub(crate) use base_builder::{
+    BaseMetadataBuilder, BuildsBaseMetadata, CheckpointSyncerPool, IsmBuildMetricsParams,
+};
 pub(crate) use message_builder::MessageMetadataBuilder;

--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -399,6 +399,7 @@ mod tests {
             false,
             core_metrics.clone(),
             cache.clone(),
+            Default::default(),
             base_db.clone(),
             IsmAwareAppContextClassifier::new(default_ism_getter.clone(), vec![].into()),
             IsmCachePolicyClassifier::new(default_ism_getter, Default::default()),

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -55,8 +55,8 @@ use crate::{
             MessageProcessor, MessageProcessorMetrics, MESSAGE_PROCESSOR_INGRESS_CAPACITY,
         },
         metadata::{
-            BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
-            IsmCachePolicyClassifier,
+            BaseMetadataBuilder, CheckpointSyncerPool, DefaultIsmCache,
+            IsmAwareAppContextClassifier, IsmCachePolicyClassifier,
         },
         op_queue::OpQueue,
         pending_message::MessageContext,
@@ -179,6 +179,7 @@ impl BaseAgent for Relayer {
             None
         };
         let cache = OptionalCache::new(inner_cache);
+        let checkpoint_syncer_pool = CheckpointSyncerPool::default();
         debug!(elapsed = ?start_entity_init.elapsed(), event = "initialized cache", "Relayer startup duration measurement");
 
         let db = DB::from_path_with_rollback_wal(&settings.db)?;
@@ -251,6 +252,7 @@ impl BaseAgent for Relayer {
                     settings.allow_local_checkpoint_syncers,
                     core.metrics.clone(),
                     cache.clone(),
+                    checkpoint_syncer_pool.clone(),
                     db.clone(),
                     IsmAwareAppContextClassifier::new(
                         default_ism_getter.clone(),

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -89,6 +89,7 @@ pub fn dummy_metadata_builder(
         false,
         Arc::new(core_metrics),
         cache,
+        Default::default(),
         db.clone(),
         IsmAwareAppContextClassifier::new(default_ism_getter.clone(), vec![].into()),
         IsmCachePolicyClassifier::new(default_ism_getter, Default::default()),


### PR DESCRIPTION
## Summary

- pool checkpoint syncers across origin/destination metadata builders by origin, validator, storage location, and parsed config/auth context
- singleflight concurrent identical latest-index and checkpoint cache misses
- retain each completed flight for 100 ms so delayed waiters cannot evict a newer generation; retry errors and missing/invalid values after that bound
- revalidate reorg status on every pooled checkout
- expire pooled clients absolutely every 10 minutes so hot same-path credentials can rotate without a restart

## Expected improvement

**Analytical:** for `N` concurrent metadata attempts using the same pooled key, syncer/client construction changes from `N` to `1` (up to `N`x fewer constructions, `(N-1)/N` fewer). For an identical cache miss, backend reads likewise change from `N` to `1` while the flight is active. Reusing the SDK client is expected to reuse its HTTP connection pool; no exact socket reduction is claimed before canary observation. The absolute TTL permits at most one scheduled rebuild per hot key per 10-minute window.

**Synthetic:** focused tests launch 8 concurrent checkpoint misses and 8 concurrent latest-index misses. Each case records exactly 1 backend read instead of 8: 8x coalescing and 87.5% fewer reads. Pool tests prove duplicate keys return the same wrapper; origin, validator, storage-location, and config changes remain isolated; and an expired hot entry rebuilds.

**Observed:** no production result yet. No RSS, socket-count, or end-to-end latency improvement is claimed until canary data exists.

## Safety

- positive checkpoint validation remains unchanged before value caching
- errors and missing/invalid values are retained only for the 100 ms flight window, then retried
- canceled leaders do not strand waiters
- a reorg flag written after initial pooling is rejected on the next checkout
- the pool and per-key in-flight maps are bounded to 1,024 entries
- absolute 10-minute expiry refreshes auth-bearing clients even under continuous use

## Canary

Compare canary with equal traffic/image baseline:

- S3/GCS request count per prepared metadata attempt
- metadata build latency and failure rate
- open file descriptor/TCP socket count
- relayer throughput, delivery latency, and prepare queue length

Expected direction: identical-miss backend request ratio falls toward one request per unique key/flight. Non-regression guards: metadata failures, delivery latency, queue depth, credential-rotation recovery within 10 minutes, and reorg rejection behavior.

## Verification

- `CARGO_BUILD_JOBS=1 cargo test --offline -p relayer msg::metadata::base_builder::` (23 passed before the test-only follow-up)
- regressions prove errors and missing/invalid values share one 100 ms generation, then retry; delayed waiters cannot invalidate newer work
- repository pre-commit hooks (gitleaks, lint-staged, Rust fmt)
- prior exact-head CI was green on `70572c9678`; new exact-head CI gates the generation-retention fix
- `cargo fmt --package relayer -- --check`, `git diff --check`, and commit hooks passed
- fresh exact-head self-review; no blocking findings

Exact head: `ef788feb8a`.

Closes #9382.
Master performance epic: #9386.
