### PR TITLE
perf(ethereum): hedge pinned fallback reads

### DIFF
--- a/.changeset/fuzzy-bags-hedge.md
+++ b/.changeset/fuzzy-bags-hedge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+Added optional agent chain metadata settings for hedging immutable fallback RPC reads.

--- a/.changeset/tender-timelocks-switch.md
+++ b/.changeset/tender-timelocks-switch.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': patch
+---
+
+The Ethereum test chain configuration now prioritizes the Tenderly public RPC endpoint, which supports the archive log queries used by the block explorer fallback path.

--- a/.changeset/tender-timelocks-switch.md
+++ b/.changeset/tender-timelocks-switch.md
@@ -2,4 +2,4 @@
 '@hyperlane-xyz/sdk': patch
 ---
 
-The Ethereum test chain configuration now prioritizes the Tenderly public RPC endpoint, which supports the archive log queries used by the block explorer fallback path.
+The Ethereum test chain configuration now lists Routescan as a fallback block explorer so full-history log reads stay on indexed explorer APIs, and keeps the archive-capable Tenderly public RPC as a last-resort endpoint.

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6501,6 +6501,7 @@ dependencies = [
  "k256 0.13.4",
  "num 0.4.3",
  "num-traits",
+ "prometheus",
  "reqwest 0.11.27",
  "reqwest-utils",
  "serde",

--- a/rust/main/agents/relayer/src/msg/op_batch.rs
+++ b/rust/main/agents/relayer/src/msg/op_batch.rs
@@ -355,6 +355,7 @@ mod tests {
                     ..Default::default()
                 },
                 consider_null_transaction_receipt: false,
+                fallback_hedge: None,
             }),
             metrics_conf: Default::default(),
             index: Default::default(),

--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -83,6 +83,7 @@ fn generate_test_chain_conf(
                 ..Default::default()
             },
             consider_null_transaction_receipt: false,
+            fallback_hedge: None,
         }),
         metrics_conf: PrometheusMiddlewareConf {
             contracts: HashMap::new(),

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -43,6 +43,7 @@ pub fn dummy_chain_conf(domain: &HyperlaneDomain) -> ChainConf {
             transaction_overrides: Default::default(),
             op_submission_config: Default::default(),
             consider_null_transaction_receipt: false,
+            fallback_hedge: None,
         }),
         metrics_conf: Default::default(),
         index: Default::default(),

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -848,6 +848,7 @@ mod test {
                         ..Default::default()
                     },
                     consider_null_transaction_receipt: false,
+                    fallback_hedge: None,
                 }),
                 metrics_conf: PrometheusMiddlewareConf {
                     contracts: HashMap::new(),

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -1796,6 +1796,7 @@ mod tests {
                 transaction_overrides: Default::default(),
                 op_submission_config: Default::default(),
                 consider_null_transaction_receipt: false,
+                fallback_hedge: None,
             }),
             metrics_conf: Default::default(),
             index: Default::default(),

--- a/rust/main/chains/hyperlane-ethereum/Cargo.toml
+++ b/rust/main/chains/hyperlane-ethereum/Cargo.toml
@@ -49,6 +49,7 @@ abigen = { path = "../../utils/abigen", features = ["ethers"] }
 hyperlane-core = { path = "../../hyperlane-core", features = ["test-utils"] }
 
 [dev-dependencies]
+prometheus.workspace = true
 tracing-test.workspace = true
 
 [features]

--- a/rust/main/chains/hyperlane-ethereum/src/config.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/config.rs
@@ -1,5 +1,6 @@
 use ethers::providers::Middleware;
 use ethers_core::types::{BlockId, BlockNumber};
+use std::time::Duration;
 use url::Url;
 
 use hyperlane_core::{
@@ -8,6 +9,15 @@ use hyperlane_core::{
 };
 
 static BATCH_CONTRACT_ADDRESS_DEFAULT: &str = "0xcA11bde05977b3631167028862bE2a173976CA11";
+
+/// Configuration for speculative fallback RPC reads.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FallbackHedgeConfig {
+    /// Grace period before starting a request to the next provider.
+    pub delay: Duration,
+    /// Timeout applied independently to every hedged provider attempt.
+    pub attempt_timeout: Duration,
+}
 
 /// Ethereum RPC connection configuration
 #[derive(Debug, Clone)]
@@ -53,6 +63,9 @@ pub struct ConnectionConf {
     /// we will try other providers and see if another provider returns something
     /// non-null
     pub consider_null_transaction_receipt: bool,
+    /// Optional hedging for explicitly allowlisted immutable/finalized reads.
+    /// Disabled when unset.
+    pub fallback_hedge: Option<FallbackHedgeConfig>,
 }
 
 impl ConnectionConf {

--- a/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/contracts/mailbox.rs
@@ -881,6 +881,7 @@ mod test {
             transaction_overrides: Default::default(),
             op_submission_config: Default::default(),
             consider_null_transaction_receipt: false,
+            fallback_hedge: None,
         };
 
         let mailbox = EthereumMailbox::new(

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -203,8 +203,9 @@ where
     C: JsonRpcClient<Error = HttpClientError>
         + Into<JsonRpcBlockGetter<C>>
         + PrometheusConfigExt
-        + Clone,
-    JsonRpcBlockGetter<C>: BlockNumberGetter,
+        + Clone
+        + 'static,
+    JsonRpcBlockGetter<C>: BlockNumberGetter + 'static,
 {
     type Error = ProviderError;
 
@@ -237,8 +238,9 @@ where
     C: JsonRpcClient<Error = HttpClientError>
         + Into<JsonRpcBlockGetter<C>>
         + PrometheusConfigExt
-        + Clone,
-    JsonRpcBlockGetter<C>: BlockNumberGetter,
+        + Clone
+        + 'static,
+    JsonRpcBlockGetter<C>: BlockNumberGetter + 'static,
 {
     async fn fallback_hedged<T, R>(
         &self,
@@ -468,14 +470,24 @@ where
         Box::pin(async move {
             let provider = &self.inner.providers[priority.index];
             let provider_host = provider.node_host().to_owned();
-            let response = match timeout(attempt_timeout, async {
-                let (_, response) = Self::provider_request(provider, method, params).await;
-                let _ = self.handle_stalled_provider(&priority, provider).await;
-                response
-            })
+            let response = match timeout(
+                attempt_timeout,
+                Self::provider_request(provider, method, params),
+            )
             .await
             {
-                Ok(response) => AttemptResponse::Rpc(response),
+                Ok((_, response)) => {
+                    let fallback = self.provider.clone();
+                    let provider = provider.clone();
+                    let _probe = tokio::spawn(async move {
+                        if let Err(error) =
+                            fallback.handle_stalled_provider(&priority, &provider).await
+                        {
+                            tracing::debug!(?error, "stalled_provider_probe_failed");
+                        }
+                    });
+                    AttemptResponse::Rpc(response)
+                }
                 Err(_) => AttemptResponse::TimedOut,
             };
             HedgedAttempt {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -30,7 +30,6 @@ const METHOD_GET_TRANSACTION_RECEIPT: &str = "eth_getTransactionReceipt";
 const METHOD_CHAIN_ID: &str = "eth_chainId";
 const METHOD_GET_BALANCE: &str = "eth_getBalance";
 const METHOD_GET_BLOCK_BY_HASH: &str = "eth_getBlockByHash";
-const METHOD_GET_BLOCK_BY_NUMBER: &str = "eth_getBlockByNumber";
 const METHOD_GET_CODE: &str = "eth_getCode";
 const METHOD_GET_PROOF: &str = "eth_getProof";
 const METHOD_GET_STORAGE_AT: &str = "eth_getStorageAt";
@@ -46,9 +45,6 @@ fn is_hedgeable_read(method: &str, params: &Value) -> bool {
         METHOD_GET_BLOCK_BY_HASH => params
             .and_then(|params| params.first())
             .is_some_and(is_block_hash),
-        METHOD_GET_BLOCK_BY_NUMBER => params
-            .and_then(|params| params.first())
-            .is_some_and(is_finalized_tag),
         METHOD_GET_BALANCE | METHOD_GET_CODE => params
             .and_then(|params| params.get(1))
             .is_some_and(is_immutable_block_selector),
@@ -60,15 +56,10 @@ fn is_hedgeable_read(method: &str, params: &Value) -> bool {
 }
 
 fn is_immutable_block_selector(selector: &Value) -> bool {
-    is_finalized_tag(selector)
-        || selector
-            .as_object()
-            .and_then(|selector| selector.get("blockHash"))
-            .is_some_and(is_block_hash)
-}
-
-fn is_finalized_tag(selector: &Value) -> bool {
-    matches!(selector.as_str(), Some("safe" | "finalized"))
+    selector
+        .as_object()
+        .and_then(|selector| selector.get("blockHash"))
+        .is_some_and(is_block_hash)
 }
 
 fn is_block_hash(value: &Value) -> bool {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -27,6 +27,7 @@ use crate::rpc_clients::{categorize_client_response, CategorizedResponse};
 
 const METHOD_SEND_RAW_TRANSACTION: &str = "eth_sendRawTransaction";
 const METHOD_GET_TRANSACTION_RECEIPT: &str = "eth_getTransactionReceipt";
+#[cfg(test)]
 const METHOD_CHAIN_ID: &str = "eth_chainId";
 const METHOD_GET_BALANCE: &str = "eth_getBalance";
 const METHOD_GET_BLOCK_BY_HASH: &str = "eth_getBlockByHash";
@@ -41,7 +42,6 @@ fn is_hedgeable_read(method: &str, params: &Value) -> bool {
     // execution or revert semantics returned by a higher-priority provider.
     let params = params.as_array();
     match method {
-        METHOD_CHAIN_ID => true,
         METHOD_GET_BLOCK_BY_HASH => params
             .and_then(|params| params.first())
             .is_some_and(is_block_hash),
@@ -58,8 +58,7 @@ fn is_hedgeable_read(method: &str, params: &Value) -> bool {
 fn is_hedgeable_method(method: &str) -> bool {
     matches!(
         method,
-        METHOD_CHAIN_ID
-            | METHOD_GET_BLOCK_BY_HASH
+        METHOD_GET_BLOCK_BY_HASH
             | METHOD_GET_BALANCE
             | METHOD_GET_CODE
             | METHOD_GET_STORAGE_AT

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -6,38 +6,90 @@ mod tests;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::ops::Deref;
+use std::pin::Pin;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use derive_new::new;
 use ethers::providers::{HttpClientError, JsonRpcClient, ProviderError};
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout, Instant, Sleep};
 use tracing::{instrument, warn};
 
 use ethers_prometheus::json_rpc_client::JsonRpcBlockGetter;
-use hyperlane_core::rpc_clients::{BlockNumberGetter, FallbackProvider};
-use hyperlane_metric::prometheus_metric::PrometheusConfigExt;
+use hyperlane_core::rpc_clients::{BlockNumberGetter, FallbackProvider, PrioritizedProviderInner};
+use hyperlane_metric::prometheus_metric::{PrometheusClientMetrics, PrometheusConfigExt};
 
+use crate::config::FallbackHedgeConfig;
 use crate::rpc_clients::{categorize_client_response, CategorizedResponse};
 
 const METHOD_SEND_RAW_TRANSACTION: &str = "eth_sendRawTransaction";
 const METHOD_GET_TRANSACTION_RECEIPT: &str = "eth_getTransactionReceipt";
+const METHOD_CHAIN_ID: &str = "eth_chainId";
+const METHOD_GET_BALANCE: &str = "eth_getBalance";
+const METHOD_GET_BLOCK_BY_HASH: &str = "eth_getBlockByHash";
+const METHOD_GET_BLOCK_BY_NUMBER: &str = "eth_getBlockByNumber";
+const METHOD_GET_CODE: &str = "eth_getCode";
+const METHOD_GET_PROOF: &str = "eth_getProof";
+const METHOD_GET_STORAGE_AT: &str = "eth_getStorageAt";
+#[cfg(test)]
+const METHOD_CALL: &str = "eth_call";
+
+fn is_hedgeable_read(method: &str, params: &Value) -> bool {
+    // Deliberately excludes reads such as eth_call where a successful hedge could mask
+    // execution or revert semantics returned by a higher-priority provider.
+    let params = params.as_array();
+    match method {
+        METHOD_CHAIN_ID => true,
+        METHOD_GET_BLOCK_BY_HASH => params
+            .and_then(|params| params.first())
+            .is_some_and(is_block_hash),
+        METHOD_GET_BLOCK_BY_NUMBER => params
+            .and_then(|params| params.first())
+            .is_some_and(is_finalized_tag),
+        METHOD_GET_BALANCE | METHOD_GET_CODE => params
+            .and_then(|params| params.get(1))
+            .is_some_and(is_immutable_block_selector),
+        METHOD_GET_STORAGE_AT | METHOD_GET_PROOF => params
+            .and_then(|params| params.get(2))
+            .is_some_and(is_immutable_block_selector),
+        _ => false,
+    }
+}
+
+fn is_immutable_block_selector(selector: &Value) -> bool {
+    is_finalized_tag(selector)
+        || selector
+            .as_object()
+            .and_then(|selector| selector.get("blockHash"))
+            .is_some_and(is_block_hash)
+}
+
+fn is_finalized_tag(selector: &Value) -> bool {
+    matches!(selector.as_str(), Some("safe" | "finalized"))
+}
+
+fn is_block_hash(value: &Value) -> bool {
+    value.as_str().is_some_and(|value| {
+        value.len() == 66
+            && value.starts_with("0x")
+            && value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
 
 /// Wrapper of `FallbackProvider` for use in `hyperlane-ethereum`
 /// The wrapper uses two distinct strategies to place requests to chains:
 /// 1. multicast - the request will be sent to all the providers simultaneously and the first
 ///    successful response will be used.
 ///
-/// 2. fallback  - the request will be sent to each provider one by one according to their
-///    priority and the priority will be updated depending on success/failure.
+/// 2. fallback  - the request will be sent to providers according to their priority and the
+///    priority will be updated depending on success/failure. Explicitly allowlisted immutable
+///    reads can optionally start one speculative fallback after a grace period.
 ///
 /// Multicast strategy is used to submit transactions into the chain, namely with RPC method
 /// `eth_sendRawTransaction` while fallback strategy is used for all the other RPC methods.
-#[derive(new)]
 pub struct EthereumFallbackProvider<C, B> {
     /// Fallback provider
     pub provider: FallbackProvider<C, B>,
@@ -45,6 +97,51 @@ pub struct EthereumFallbackProvider<C, B> {
     /// we will try other providers and see if another provider returns something
     /// non-null
     pub consider_null_transaction_receipt: bool,
+    hedge_config: Option<FallbackHedgeConfig>,
+    hedge_metrics: Option<PrometheusClientMetrics>,
+}
+
+impl<C, B> EthereumFallbackProvider<C, B> {
+    /// Create an Ethereum fallback provider with hedging disabled.
+    pub fn new(provider: FallbackProvider<C, B>, consider_null_transaction_receipt: bool) -> Self {
+        Self {
+            provider,
+            consider_null_transaction_receipt,
+            hedge_config: None,
+            hedge_metrics: None,
+        }
+    }
+
+    /// Configure optional hedging and its metrics. `None` keeps legacy sequential behavior.
+    pub fn with_hedging(
+        mut self,
+        config: Option<FallbackHedgeConfig>,
+        metrics: Option<PrometheusClientMetrics>,
+    ) -> Self {
+        self.hedge_config = config;
+        self.hedge_metrics = metrics;
+        self
+    }
+}
+
+enum AttemptResponse {
+    Rpc(Result<Value, HttpClientError>),
+    TimedOut,
+}
+
+struct HedgedAttempt {
+    speculative: bool,
+    priority: PrioritizedProviderInner,
+    provider_host: String,
+    response: AttemptResponse,
+}
+
+type HedgedAttemptFuture<'a> = Pin<Box<dyn Future<Output = HedgedAttempt> + Send + 'a>>;
+
+enum HedgedRoundResult {
+    Success(Value, bool),
+    NonRetryable(ProviderError),
+    Retryable(Vec<ProviderError>),
 }
 
 impl<C, B> Deref for EthereumFallbackProvider<C, B> {
@@ -123,6 +220,12 @@ where
         } else if method == METHOD_GET_TRANSACTION_RECEIPT && self.consider_null_transaction_receipt
         {
             self.fallback_transaction_receipt(method, params).await
+        } else if let Some(config) = self.hedge_config.filter(|_| {
+            serde_json::to_value(&params)
+                .map(|params| is_hedgeable_read(method, &params))
+                .unwrap_or(false)
+        }) {
+            self.fallback_hedged(method, params, config).await
         } else {
             self.fallback(method, params).await
         }
@@ -137,6 +240,253 @@ where
         + Clone,
     JsonRpcBlockGetter<C>: BlockNumberGetter,
 {
+    async fn fallback_hedged<T, R>(
+        &self,
+        method: &str,
+        params: T,
+        config: FallbackHedgeConfig,
+    ) -> Result<R, ProviderError>
+    where
+        T: Serialize,
+        R: DeserializeOwned,
+    {
+        let params = serde_json::to_value(params)?;
+        let request_started = Instant::now();
+        let mut errors = Vec::new();
+
+        while errors.len() <= 3 {
+            if !errors.is_empty() {
+                sleep(Duration::from_millis(100)).await;
+            }
+
+            let priorities = self.take_priorities_snapshot().await;
+            match self
+                .hedged_round(method, &params, &priorities, config)
+                .await
+            {
+                HedgedRoundResult::Success(value, speculative) => {
+                    let (winner, event) = if speculative {
+                        ("hedge", "hedge_winner")
+                    } else {
+                        ("primary", "primary_winner")
+                    };
+                    self.increment_hedge_event(method, event);
+                    self.observe_hedge_duration(method, winner, request_started);
+                    return Ok(serde_json::from_value(value)?);
+                }
+                HedgedRoundResult::NonRetryable(error) => {
+                    self.observe_hedge_duration(method, "error", request_started);
+                    return Err(error);
+                }
+                HedgedRoundResult::Retryable(mut round_errors) => errors.append(&mut round_errors),
+            }
+        }
+
+        self.observe_hedge_duration(method, "error", request_started);
+        Err(FallbackError::AllProvidersFailed(errors).into())
+    }
+
+    async fn hedged_round(
+        &self,
+        method: &str,
+        params: &Value,
+        priorities: &[PrioritizedProviderInner],
+        config: FallbackHedgeConfig,
+    ) -> HedgedRoundResult {
+        if priorities.is_empty() {
+            return HedgedRoundResult::NonRetryable(ProviderError::CustomError(
+                "Fallback provider has no configured providers".to_owned(),
+            ));
+        }
+
+        let mut attempts = FuturesUnordered::new();
+        let mut next_ordinal = 0;
+        let mut errors = Vec::new();
+        let mut grace: Pin<Box<Sleep>> = Box::pin(sleep(config.delay));
+        let mut grace_expired = false;
+
+        attempts.push(self.timed_provider_request(
+            false,
+            priorities[next_ordinal],
+            method,
+            params,
+            config.attempt_timeout,
+        ));
+        next_ordinal = next_ordinal.saturating_add(1);
+
+        loop {
+            let attempt =
+                if !grace_expired && attempts.len() == 1 && next_ordinal < priorities.len() {
+                    tokio::select! {
+                        attempt = attempts.next() => attempt,
+                        () = &mut grace => {
+                            self.increment_hedge_event(method, "start");
+                            attempts.push(self.timed_provider_request(
+                                true,
+                                priorities[next_ordinal],
+                                method,
+                                params,
+                                config.attempt_timeout,
+                            ));
+                            next_ordinal = next_ordinal.saturating_add(1);
+                            grace_expired = true;
+                            continue;
+                        }
+                    }
+                } else {
+                    attempts.next().await
+                };
+            let Some(attempt) = attempt else {
+                return HedgedRoundResult::NonRetryable(ProviderError::CustomError(
+                    "Fallback provider lost all active requests".to_owned(),
+                ));
+            };
+            let response = match attempt.response {
+                AttemptResponse::Rpc(response) => {
+                    if response.is_err() {
+                        self.handle_failed_provider(&attempt.priority).await;
+                    }
+                    categorize_client_response(&attempt.provider_host, method, response)
+                }
+                AttemptResponse::TimedOut => {
+                    self.handle_failed_provider(&attempt.priority).await;
+                    self.increment_hedge_event(method, "timeout");
+                    errors.push(ProviderError::CustomError(format!(
+                        "Fallback provider request to {} timed out",
+                        attempt.provider_host
+                    )));
+                    self.refill_hedged_attempts(
+                        &mut attempts,
+                        &mut next_ordinal,
+                        priorities,
+                        method,
+                        params,
+                        config,
+                    );
+                    if attempts.is_empty() {
+                        return HedgedRoundResult::Retryable(errors);
+                    }
+                    continue;
+                }
+            };
+
+            match response {
+                CategorizedResponse::IsOk(value) => {
+                    self.cancel_attempts(method, attempts.len());
+                    return HedgedRoundResult::Success(value, attempt.speculative);
+                }
+                CategorizedResponse::RetryableErr(error)
+                | CategorizedResponse::RateLimitErr(error) => errors.push(error.into()),
+                CategorizedResponse::NonRetryableErr(error) => {
+                    self.cancel_attempts(method, attempts.len());
+                    return HedgedRoundResult::NonRetryable(error.into());
+                }
+            }
+
+            self.refill_hedged_attempts(
+                &mut attempts,
+                &mut next_ordinal,
+                priorities,
+                method,
+                params,
+                config,
+            );
+            if attempts.is_empty() {
+                return HedgedRoundResult::Retryable(errors);
+            }
+            if attempts.len() == 1 && !grace_expired {
+                grace = Box::pin(sleep(config.delay));
+            }
+        }
+    }
+
+    fn refill_hedged_attempts<'a>(
+        &'a self,
+        attempts: &mut FuturesUnordered<HedgedAttemptFuture<'a>>,
+        next_ordinal: &mut usize,
+        priorities: &'a [PrioritizedProviderInner],
+        method: &'a str,
+        params: &'a Value,
+        config: FallbackHedgeConfig,
+    ) {
+        if *next_ordinal >= priorities.len() {
+            return;
+        }
+        let speculative = !attempts.is_empty();
+        if speculative {
+            self.increment_hedge_event(method, "start");
+        }
+        attempts.push(self.timed_provider_request(
+            speculative,
+            priorities[*next_ordinal],
+            method,
+            params,
+            config.attempt_timeout,
+        ));
+        *next_ordinal = (*next_ordinal).saturating_add(1);
+    }
+
+    fn cancel_attempts(&self, method: &str, count: usize) {
+        for _ in 0..count {
+            self.increment_hedge_event(method, "cancellation");
+        }
+    }
+
+    fn increment_hedge_event(&self, method: &str, event: &str) {
+        if let Some(metrics) = &self.hedge_metrics {
+            metrics.increment_fallback_hedge_event(self.hedge_chain(), method, event);
+        }
+    }
+
+    fn observe_hedge_duration(&self, method: &str, winner: &str, started: Instant) {
+        if let Some(metrics) = &self.hedge_metrics {
+            metrics.observe_fallback_hedge_duration(
+                self.hedge_chain(),
+                method,
+                winner,
+                started.elapsed(),
+            );
+        }
+    }
+
+    fn hedge_chain(&self) -> &str {
+        self.inner
+            .providers
+            .first()
+            .map(PrometheusConfigExt::chain_name)
+            .unwrap_or("unknown")
+    }
+
+    fn timed_provider_request<'a>(
+        &'a self,
+        speculative: bool,
+        priority: PrioritizedProviderInner,
+        method: &'a str,
+        params: &'a Value,
+        attempt_timeout: Duration,
+    ) -> HedgedAttemptFuture<'a> {
+        Box::pin(async move {
+            let provider = &self.inner.providers[priority.index];
+            let provider_host = provider.node_host().to_owned();
+            let response = match timeout(attempt_timeout, async {
+                let (_, response) = Self::provider_request(provider, method, params).await;
+                let _ = self.handle_stalled_provider(&priority, provider).await;
+                response
+            })
+            .await
+            {
+                Ok(response) => AttemptResponse::Rpc(response),
+                Err(_) => AttemptResponse::TimedOut,
+            };
+            HedgedAttempt {
+                speculative,
+                priority,
+                provider_host,
+                response,
+            }
+        })
+    }
+
     async fn multicast<T, R>(&self, method: &str, params: T) -> Result<R, ProviderError>
     where
         T: Serialize,

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -55,6 +55,18 @@ fn is_hedgeable_read(method: &str, params: &Value) -> bool {
     }
 }
 
+fn is_hedgeable_method(method: &str) -> bool {
+    matches!(
+        method,
+        METHOD_CHAIN_ID
+            | METHOD_GET_BLOCK_BY_HASH
+            | METHOD_GET_BALANCE
+            | METHOD_GET_CODE
+            | METHOD_GET_STORAGE_AT
+            | METHOD_GET_PROOF
+    )
+}
+
 fn is_immutable_block_selector(selector: &Value) -> bool {
     selector
         .as_object()
@@ -212,12 +224,14 @@ where
         } else if method == METHOD_GET_TRANSACTION_RECEIPT && self.consider_null_transaction_receipt
         {
             self.fallback_transaction_receipt(method, params).await
-        } else if let Some(config) = self.hedge_config.filter(|_| {
-            serde_json::to_value(&params)
-                .map(|params| is_hedgeable_read(method, &params))
-                .unwrap_or(false)
-        }) {
-            self.fallback_hedged(method, params, config).await
+        } else if let Some(config) = self.hedge_config.filter(|_| is_hedgeable_method(method)) {
+            let serialized_params = serde_json::to_value(&params)?;
+            if is_hedgeable_read(method, &serialized_params) {
+                self.fallback_hedged(method, serialized_params, config)
+                    .await
+            } else {
+                self.fallback_serialized(method, serialized_params).await
+            }
         } else {
             self.fallback(method, params).await
         }
@@ -233,17 +247,15 @@ where
         + 'static,
     JsonRpcBlockGetter<C>: BlockNumberGetter + 'static,
 {
-    async fn fallback_hedged<T, R>(
+    async fn fallback_hedged<R>(
         &self,
         method: &str,
-        params: T,
+        params: Value,
         config: FallbackHedgeConfig,
     ) -> Result<R, ProviderError>
     where
-        T: Serialize,
         R: DeserializeOwned,
     {
-        let params = serde_json::to_value(params)?;
         let request_started = Instant::now();
         let mut errors = Vec::new();
 
@@ -561,9 +573,15 @@ where
         T: Serialize,
         R: DeserializeOwned,
     {
-        use CategorizedResponse::*;
-
         let params = serde_json::to_value(params).expect("valid");
+        self.fallback_serialized(method, params).await
+    }
+
+    async fn fallback_serialized<R>(&self, method: &str, params: Value) -> Result<R, ProviderError>
+    where
+        R: DeserializeOwned,
+    {
+        use CategorizedResponse::*;
 
         let mut errors: Vec<ProviderError> = vec![];
         // make sure we do at least 4 total retries.

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
@@ -14,8 +14,8 @@ use serde::Serialize;
 use tokio::time::sleep;
 
 use crate::rpc_clients::fallback::{
-    METHOD_CALL, METHOD_GET_BALANCE, METHOD_GET_BLOCK_BY_HASH, METHOD_GET_TRANSACTION_RECEIPT,
-    METHOD_SEND_RAW_TRANSACTION,
+    METHOD_CALL, METHOD_CHAIN_ID, METHOD_GET_BALANCE, METHOD_GET_BLOCK_BY_HASH,
+    METHOD_GET_TRANSACTION_RECEIPT, METHOD_SEND_RAW_TRANSACTION,
 };
 
 type ResponseList<T> = Arc<Mutex<VecDeque<T>>>;
@@ -136,7 +136,7 @@ impl JsonRpcClient for EthereumProviderMock {
         }
         if matches!(
             method,
-            METHOD_GET_BLOCK_BY_HASH | METHOD_GET_BALANCE | METHOD_CALL
+            METHOD_CHAIN_ID | METHOD_GET_BLOCK_BY_HASH | METHOD_GET_BALANCE | METHOD_CALL
         ) {
             return match self.responses.immutable_read.lock().unwrap().pop_front() {
                 Some(MockReadResponse::Success(value)) => serde_json::from_value(value.into())

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
@@ -23,6 +23,7 @@ type ResponseList<T> = Arc<Mutex<VecDeque<T>>>;
 #[derive(Clone, Debug, Default)]
 pub struct EthereumProviderMockResponses {
     pub get_block_number: ResponseList<Option<u64>>,
+    pub get_block_number_sleep: Arc<Mutex<Option<Duration>>>,
     pub get_tx_receipt: ResponseList<Option<TransactionReceipt>>,
     pub send_raw_transaction: ResponseList<Option<u64>>,
     pub immutable_read: ResponseList<MockReadResponse>,
@@ -88,6 +89,10 @@ impl JsonRpcClient for EthereumProviderMock {
         }
         tracing::debug!("Called {method}");
         if method == BLOCK_NUMBER_RPC {
+            let sleep_duration = *self.responses.get_block_number_sleep.lock().unwrap();
+            if let Some(sleep_duration) = sleep_duration {
+                sleep(sleep_duration).await;
+            }
             let resp = match self.responses.get_block_number.lock().unwrap().pop_front() {
                 Some(s) => s,
                 None => return dummy_error_return_value(),

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
@@ -13,7 +13,10 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::time::sleep;
 
-use crate::rpc_clients::fallback::{METHOD_GET_TRANSACTION_RECEIPT, METHOD_SEND_RAW_TRANSACTION};
+use crate::rpc_clients::fallback::{
+    METHOD_CALL, METHOD_GET_BLOCK_BY_HASH, METHOD_GET_TRANSACTION_RECEIPT,
+    METHOD_SEND_RAW_TRANSACTION,
+};
 
 type ResponseList<T> = Arc<Mutex<VecDeque<T>>>;
 
@@ -22,6 +25,14 @@ pub struct EthereumProviderMockResponses {
     pub get_block_number: ResponseList<Option<u64>>,
     pub get_tx_receipt: ResponseList<Option<TransactionReceipt>>,
     pub send_raw_transaction: ResponseList<Option<u64>>,
+    pub immutable_read: ResponseList<MockReadResponse>,
+}
+
+#[derive(Clone, Debug)]
+pub enum MockReadResponse {
+    Success(u64),
+    RetryableError,
+    NonRetryableError,
 }
 
 #[derive(Clone, Debug)]
@@ -117,6 +128,24 @@ impl JsonRpcClient for EthereumProviderMock {
                     text: "".to_owned(),
                 }
             });
+        }
+        if matches!(method, METHOD_GET_BLOCK_BY_HASH | METHOD_CALL) {
+            return match self.responses.immutable_read.lock().unwrap().pop_front() {
+                Some(MockReadResponse::Success(value)) => serde_json::from_value(value.into())
+                    .map_err(|err| HttpClientError::SerdeJson {
+                        err,
+                        text: "".to_owned(),
+                    }),
+                Some(MockReadResponse::NonRetryableError) => Err(HttpClientError::JsonRpcError(
+                    serde_json::from_value(serde_json::json!({
+                        "code": 3,
+                        "message": "execution reverted",
+                        "data": null,
+                    }))
+                    .unwrap(),
+                )),
+                Some(MockReadResponse::RetryableError) | None => dummy_error_return_value(),
+            };
         }
         dummy_error_return_value()
     }

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/mock.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use tokio::time::sleep;
 
 use crate::rpc_clients::fallback::{
-    METHOD_CALL, METHOD_GET_BLOCK_BY_HASH, METHOD_GET_TRANSACTION_RECEIPT,
+    METHOD_CALL, METHOD_GET_BALANCE, METHOD_GET_BLOCK_BY_HASH, METHOD_GET_TRANSACTION_RECEIPT,
     METHOD_SEND_RAW_TRANSACTION,
 };
 
@@ -134,7 +134,10 @@ impl JsonRpcClient for EthereumProviderMock {
                 }
             });
         }
-        if matches!(method, METHOD_GET_BLOCK_BY_HASH | METHOD_CALL) {
+        if matches!(
+            method,
+            METHOD_GET_BLOCK_BY_HASH | METHOD_GET_BALANCE | METHOD_CALL
+        ) {
             return match self.responses.immutable_read.lock().unwrap().pop_front() {
                 Some(MockReadResponse::Success(value)) => serde_json::from_value(value.into())
                     .map_err(|err| HttpClientError::SerdeJson {

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
@@ -14,8 +14,9 @@ where
     C: JsonRpcClient<Error = HttpClientError>
         + PrometheusConfigExt
         + Into<JsonRpcBlockGetter<C>>
-        + Clone,
-    JsonRpcBlockGetter<C>: BlockNumberGetter,
+        + Clone
+        + 'static,
+    JsonRpcBlockGetter<C>: BlockNumberGetter + 'static,
 {
     async fn fallback_test_call(&self) -> u64 {
         self.request::<_, u64>(BLOCK_NUMBER_RPC, ()).await.unwrap()
@@ -295,6 +296,46 @@ async fn per_attempt_timeout_prevents_all_hung_providers_from_blocking() {
     .expect("per-attempt timeouts should bound all provider attempts")
     .expect_err("all timed-out attempts should fail");
     assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![2, 2]);
+}
+
+#[tokio::test]
+async fn successful_read_is_not_timed_out_by_stalled_provider_probe() {
+    let providers = vec![EthereumProviderMock::new(None)];
+    push_read_response(&providers[0], MockReadResponse::Success(1));
+    providers[0]
+        .responses
+        .get_block_number
+        .lock()
+        .unwrap()
+        .push_back(Some(100));
+    *providers[0]
+        .responses
+        .get_block_number_sleep
+        .lock()
+        .unwrap() = Some(Duration::from_millis(200));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .with_max_block_time(Duration::ZERO)
+        .with_call_timeout(Duration::from_millis(100))
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(5),
+            Duration::from_millis(10),
+        )),
+        None,
+    );
+
+    assert_eq!(
+        timeout(
+            Duration::from_millis(50),
+            provider.get_block_by_hash_test_call()
+        )
+        .await
+        .expect("stalled health probe blocked the completed read")
+        .unwrap(),
+        1
+    );
 }
 
 #[tokio::test]

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
@@ -2,6 +2,9 @@ use ethers::types::{TransactionReceipt, H256};
 use ethers_prometheus::json_rpc_client::{JsonRpcBlockGetter, BLOCK_NUMBER_RPC};
 use hyperlane_core::rpc_clients::test::ProviderMock;
 use hyperlane_core::rpc_clients::FallbackProviderBuilder;
+use hyperlane_metric::prometheus_metric::PrometheusClientMetricsBuilder;
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts};
+use serde_json::json;
 
 use super::mock::*;
 use super::*;
@@ -30,6 +33,317 @@ where
         )
         .await
     }
+
+    async fn get_block_by_hash_test_call(&self) -> Result<u64, ProviderError> {
+        self.request::<_, u64>(
+            METHOD_GET_BLOCK_BY_HASH,
+            json!([format!("0x{}", "11".repeat(32)), false]),
+        )
+        .await
+    }
+
+    async fn immutable_call_test_call(&self) -> Result<u64, ProviderError> {
+        self.request::<_, u64>(METHOD_CALL, json!([{}, "finalized"]))
+            .await
+    }
+}
+
+fn hedge_config(delay: Duration, attempt_timeout: Duration) -> FallbackHedgeConfig {
+    FallbackHedgeConfig {
+        delay,
+        attempt_timeout,
+    }
+}
+
+fn push_read_response(provider: &EthereumProviderMock, response: MockReadResponse) {
+    provider
+        .responses
+        .immutable_read
+        .lock()
+        .unwrap()
+        .push_back(response);
+}
+
+fn test_hedge_metrics() -> (
+    hyperlane_metric::prometheus_metric::PrometheusClientMetrics,
+    IntCounterVec,
+    HistogramVec,
+) {
+    let events = IntCounterVec::new(
+        Opts::new("test_fallback_hedge_events", "test events"),
+        &["chain", "method", "event"],
+    )
+    .unwrap();
+    let durations = HistogramVec::new(
+        HistogramOpts::new("test_fallback_hedge_duration", "test duration"),
+        &["chain", "method", "winner"],
+    )
+    .unwrap();
+    let metrics = PrometheusClientMetricsBuilder::default()
+        .fallback_hedge_events(events.clone())
+        .fallback_hedge_duration_seconds(durations.clone())
+        .build()
+        .unwrap();
+    (metrics, events, durations)
+}
+
+#[test]
+fn hedge_allowlist_requires_immutable_or_finalized_reads() {
+    let block_hash = json!(format!("0x{}", "11".repeat(32)));
+
+    assert!(is_hedgeable_read(METHOD_CHAIN_ID, &Value::Null));
+    assert!(is_hedgeable_read(
+        METHOD_GET_BLOCK_BY_HASH,
+        &json!([block_hash, false])
+    ));
+    assert!(is_hedgeable_read(
+        METHOD_GET_BLOCK_BY_NUMBER,
+        &json!(["safe", false])
+    ));
+    for method in [METHOD_GET_BALANCE, METHOD_GET_CODE] {
+        assert!(is_hedgeable_read(method, &json!(["0x1234", "finalized"])));
+        assert!(is_hedgeable_read(
+            method,
+            &json!(["0x1234", { "blockHash": block_hash }])
+        ));
+        assert!(!is_hedgeable_read(method, &json!(["0x1234", "latest"])));
+    }
+    for method in [METHOD_GET_STORAGE_AT, METHOD_GET_PROOF] {
+        assert!(is_hedgeable_read(
+            method,
+            &json!(["0x1234", [], "finalized"])
+        ));
+        assert!(is_hedgeable_read(
+            method,
+            &json!(["0x1234", [], { "blockHash": block_hash }])
+        ));
+        assert!(!is_hedgeable_read(
+            method,
+            &json!(["0x1234", [], "pending"])
+        ));
+    }
+
+    for selector in [
+        json!("latest"),
+        json!("pending"),
+        json!("finalized"),
+        json!({"blockHash": format!("0x{}", "11".repeat(32))}),
+    ] {
+        assert!(!is_hedgeable_read(METHOD_CALL, &json!([{}, selector])));
+    }
+    for excluded in [
+        METHOD_SEND_RAW_TRANSACTION,
+        METHOD_GET_TRANSACTION_RECEIPT,
+        "eth_getLogs",
+        "eth_getTransactionByHash",
+        "eth_getTransactionCount",
+        "eth_feeHistory",
+        "eth_estimateGas",
+    ] {
+        assert!(!is_hedgeable_read(excluded, &json!([])), "{excluded}");
+    }
+}
+
+#[tokio::test]
+async fn hedged_read_uses_fast_secondary_after_grace() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_secs(5))),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::Success(1));
+    push_read_response(&providers[1], MockReadResponse::Success(2));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let (metrics, events, durations) = test_hedge_metrics();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(10),
+            Duration::from_millis(100),
+        )),
+        Some(metrics),
+    );
+
+    assert_eq!(provider.get_block_by_hash_test_call().await.unwrap(), 2);
+    assert_eq!(
+        events
+            .with_label_values(&["test_chain", METHOD_GET_BLOCK_BY_HASH, "start"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        events
+            .with_label_values(&["test_chain", METHOD_GET_BLOCK_BY_HASH, "hedge_winner"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        events
+            .with_label_values(&["test_chain", METHOD_GET_BLOCK_BY_HASH, "cancellation"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        durations
+            .with_label_values(&["test_chain", METHOD_GET_BLOCK_BY_HASH, "hedge"])
+            .get_sample_count(),
+        1
+    );
+
+    let priorities = provider.take_priorities_snapshot().await;
+    assert_eq!(priorities[0].index, 0);
+    assert_eq!(priorities[0].last_failed_count, 0);
+}
+
+#[tokio::test]
+async fn hedging_is_disabled_by_default() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_millis(20))),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::Success(1));
+    push_read_response(&providers[1], MockReadResponse::Success(2));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(None, None);
+
+    assert_eq!(provider.get_block_by_hash_test_call().await.unwrap(), 1);
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![1, 0]);
+}
+
+#[tokio::test]
+async fn primary_within_grace_does_not_start_hedge() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_millis(1))),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::Success(1));
+    push_read_response(&providers[1], MockReadResponse::Success(2));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+        )),
+        None,
+    );
+
+    assert_eq!(provider.get_block_by_hash_test_call().await.unwrap(), 1);
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![1, 0]);
+}
+
+#[tokio::test]
+async fn failed_hedge_advances_while_primary_is_hung() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_secs(5))),
+        EthereumProviderMock::new(None),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::Success(1));
+    push_read_response(&providers[1], MockReadResponse::RetryableError);
+    push_read_response(&providers[2], MockReadResponse::Success(3));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(5),
+            Duration::from_secs(1),
+        )),
+        None,
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        provider.get_block_by_hash_test_call(),
+    )
+    .await
+    .expect("failed hedge should advance before the primary timeout")
+    .unwrap();
+    assert_eq!(result, 3);
+    assert_eq!(
+        ProviderMock::get_call_counts(&provider).await,
+        vec![1, 1, 1]
+    );
+}
+
+#[tokio::test]
+async fn per_attempt_timeout_prevents_all_hung_providers_from_blocking() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_secs(5))),
+        EthereumProviderMock::new(Some(Duration::from_secs(5))),
+    ];
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+        )),
+        None,
+    );
+
+    tokio::time::timeout(
+        Duration::from_millis(500),
+        provider.get_block_by_hash_test_call(),
+    )
+    .await
+    .expect("per-attempt timeouts should bound all provider attempts")
+    .expect_err("all timed-out attempts should fail");
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![2, 2]);
+}
+
+#[tokio::test]
+async fn nonretryable_call_remains_sequential_when_hedging_is_enabled() {
+    let providers = vec![
+        EthereumProviderMock::new(None),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::NonRetryableError);
+    push_read_response(&providers[1], MockReadResponse::Success(2));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+        )),
+        None,
+    );
+
+    assert!(provider.immutable_call_test_call().await.is_err());
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![1, 0]);
+}
+
+#[tokio::test]
+async fn all_retryable_failures_keep_bounded_retry_behavior() {
+    let providers = vec![
+        EthereumProviderMock::new(None),
+        EthereumProviderMock::new(None),
+    ];
+    for provider in &providers {
+        for _ in 0..2 {
+            push_read_response(provider, MockReadResponse::RetryableError);
+        }
+    }
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(5),
+            Duration::from_millis(100),
+        )),
+        None,
+    );
+
+    assert!(provider.get_block_by_hash_test_call().await.is_err());
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![2, 2]);
 }
 
 // Explanation of the test expected result:

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
@@ -47,6 +47,11 @@ where
         self.request::<_, u64>(METHOD_CALL, json!([{}, "finalized"]))
             .await
     }
+
+    async fn finalized_balance_test_call(&self) -> Result<u64, ProviderError> {
+        self.request::<_, u64>(METHOD_GET_BALANCE, json!(["0x1234", "finalized"]))
+            .await
+    }
 }
 
 fn hedge_config(delay: Duration, attempt_timeout: Duration) -> FallbackHedgeConfig {
@@ -89,7 +94,7 @@ fn test_hedge_metrics() -> (
 }
 
 #[test]
-fn hedge_allowlist_requires_immutable_or_finalized_reads() {
+fn hedge_allowlist_requires_pinned_reads() {
     let block_hash = json!(format!("0x{}", "11".repeat(32)));
 
     assert!(is_hedgeable_read(METHOD_CHAIN_ID, &Value::Null));
@@ -97,12 +102,12 @@ fn hedge_allowlist_requires_immutable_or_finalized_reads() {
         METHOD_GET_BLOCK_BY_HASH,
         &json!([block_hash, false])
     ));
-    assert!(is_hedgeable_read(
-        METHOD_GET_BLOCK_BY_NUMBER,
+    assert!(!is_hedgeable_read(
+        "eth_getBlockByNumber",
         &json!(["safe", false])
     ));
     for method in [METHOD_GET_BALANCE, METHOD_GET_CODE] {
-        assert!(is_hedgeable_read(method, &json!(["0x1234", "finalized"])));
+        assert!(!is_hedgeable_read(method, &json!(["0x1234", "finalized"])));
         assert!(is_hedgeable_read(
             method,
             &json!(["0x1234", { "blockHash": block_hash }])
@@ -110,7 +115,7 @@ fn hedge_allowlist_requires_immutable_or_finalized_reads() {
         assert!(!is_hedgeable_read(method, &json!(["0x1234", "latest"])));
     }
     for method in [METHOD_GET_STORAGE_AT, METHOD_GET_PROOF] {
-        assert!(is_hedgeable_read(
+        assert!(!is_hedgeable_read(
             method,
             &json!(["0x1234", [], "finalized"])
         ));
@@ -143,6 +148,29 @@ fn hedge_allowlist_requires_immutable_or_finalized_reads() {
     ] {
         assert!(!is_hedgeable_read(excluded, &json!([])), "{excluded}");
     }
+}
+
+#[tokio::test]
+async fn finalized_tag_reads_preserve_primary_freshness() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_millis(20))),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::Success(100));
+    push_read_response(&providers[1], MockReadResponse::Success(99));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(1),
+            Duration::from_millis(100),
+        )),
+        None,
+    );
+
+    assert_eq!(provider.finalized_balance_test_call().await.unwrap(), 100);
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![1, 0]);
 }
 
 #[tokio::test]

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
@@ -97,6 +97,17 @@ fn test_hedge_metrics() -> (
 fn hedge_allowlist_requires_pinned_reads() {
     let block_hash = json!(format!("0x{}", "11".repeat(32)));
 
+    for method in [
+        METHOD_CHAIN_ID,
+        METHOD_GET_BLOCK_BY_HASH,
+        METHOD_GET_BALANCE,
+        METHOD_GET_CODE,
+        METHOD_GET_STORAGE_AT,
+        METHOD_GET_PROOF,
+    ] {
+        assert!(is_hedgeable_method(method), "{method}");
+    }
+
     assert!(is_hedgeable_read(METHOD_CHAIN_ID, &Value::Null));
     assert!(is_hedgeable_read(
         METHOD_GET_BLOCK_BY_HASH,
@@ -146,6 +157,7 @@ fn hedge_allowlist_requires_pinned_reads() {
         "eth_feeHistory",
         "eth_estimateGas",
     ] {
+        assert!(!is_hedgeable_method(excluded), "{excluded}");
         assert!(!is_hedgeable_read(excluded, &json!([])), "{excluded}");
     }
 }

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback/tests.rs
@@ -43,6 +43,10 @@ where
         .await
     }
 
+    async fn chain_id_test_call(&self) -> Result<u64, ProviderError> {
+        self.request::<_, u64>(METHOD_CHAIN_ID, ()).await
+    }
+
     async fn immutable_call_test_call(&self) -> Result<u64, ProviderError> {
         self.request::<_, u64>(METHOD_CALL, json!([{}, "finalized"]))
             .await
@@ -98,7 +102,6 @@ fn hedge_allowlist_requires_pinned_reads() {
     let block_hash = json!(format!("0x{}", "11".repeat(32)));
 
     for method in [
-        METHOD_CHAIN_ID,
         METHOD_GET_BLOCK_BY_HASH,
         METHOD_GET_BALANCE,
         METHOD_GET_CODE,
@@ -108,7 +111,6 @@ fn hedge_allowlist_requires_pinned_reads() {
         assert!(is_hedgeable_method(method), "{method}");
     }
 
-    assert!(is_hedgeable_read(METHOD_CHAIN_ID, &Value::Null));
     assert!(is_hedgeable_read(
         METHOD_GET_BLOCK_BY_HASH,
         &json!([block_hash, false])
@@ -149,6 +151,7 @@ fn hedge_allowlist_requires_pinned_reads() {
         assert!(!is_hedgeable_read(METHOD_CALL, &json!([{}, selector])));
     }
     for excluded in [
+        METHOD_CHAIN_ID,
         METHOD_SEND_RAW_TRANSACTION,
         METHOD_GET_TRANSACTION_RECEIPT,
         "eth_getLogs",
@@ -160,6 +163,29 @@ fn hedge_allowlist_requires_pinned_reads() {
         assert!(!is_hedgeable_method(excluded), "{excluded}");
         assert!(!is_hedgeable_read(excluded, &json!([])), "{excluded}");
     }
+}
+
+#[tokio::test]
+async fn chain_id_preserves_primary_identity_when_hedging_is_enabled() {
+    let providers = vec![
+        EthereumProviderMock::new(Some(Duration::from_millis(20))),
+        EthereumProviderMock::new(None),
+    ];
+    push_read_response(&providers[0], MockReadResponse::Success(1));
+    push_read_response(&providers[1], MockReadResponse::Success(2));
+    let fallback = FallbackProviderBuilder::default()
+        .add_providers(providers)
+        .build();
+    let provider = EthereumFallbackProvider::new(fallback, false).with_hedging(
+        Some(hedge_config(
+            Duration::from_millis(1),
+            Duration::from_millis(100),
+        )),
+        None,
+    );
+
+    assert_eq!(provider.chain_id_test_call().await.unwrap(), 1);
+    assert_eq!(ProviderMock::get_call_counts(&provider).await, vec![1, 0]);
 }
 
 #[tokio::test]

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/trait_builder.rs
@@ -163,7 +163,8 @@ pub trait BuildableWithProvider {
                 >::new(
                     fallback_provider,
                     conn.consider_null_transaction_receipt,
-                );
+                )
+                .with_hedging(conn.fallback_hedge, client_metrics.clone());
                 self.build(ethereum_fallback_provider, conn, locator, signer)
                     .await?
             }

--- a/rust/main/hyperlane-base/src/metrics/json_rpc_client.rs
+++ b/rust/main/hyperlane-base/src/metrics/json_rpc_client.rs
@@ -1,9 +1,10 @@
 use eyre::Result;
 use hyperlane_metric::prometheus_metric::{
-    PrometheusClientMetrics, PrometheusClientMetricsBuilder, PROVIDER_CREATE_COUNT_HELP,
-    PROVIDER_CREATE_COUNT_LABELS, PROVIDER_DROP_COUNT_HELP, PROVIDER_DROP_COUNT_LABELS,
-    REQUEST_COUNT_HELP, REQUEST_COUNT_LABELS, REQUEST_DURATION_SECONDS_HELP,
-    REQUEST_DURATION_SECONDS_LABELS,
+    PrometheusClientMetrics, PrometheusClientMetricsBuilder, FALLBACK_HEDGE_DURATION_SECONDS_HELP,
+    FALLBACK_HEDGE_DURATION_SECONDS_LABELS, FALLBACK_HEDGE_EVENT_HELP, FALLBACK_HEDGE_EVENT_LABELS,
+    PROVIDER_CREATE_COUNT_HELP, PROVIDER_CREATE_COUNT_LABELS, PROVIDER_DROP_COUNT_HELP,
+    PROVIDER_DROP_COUNT_LABELS, REQUEST_COUNT_HELP, REQUEST_COUNT_LABELS,
+    REQUEST_DURATION_SECONDS_HELP, REQUEST_DURATION_SECONDS_LABELS,
 };
 
 use crate::CoreMetrics;
@@ -31,6 +32,19 @@ pub(crate) fn create_json_rpc_client_metrics(
             "provider_drop_count",
             PROVIDER_DROP_COUNT_HELP,
             PROVIDER_DROP_COUNT_LABELS,
+        )?)
+        .fallback_hedge_events(metrics.new_int_counter(
+            "fallback_hedge_events_total",
+            FALLBACK_HEDGE_EVENT_HELP,
+            FALLBACK_HEDGE_EVENT_LABELS,
+        )?)
+        .fallback_hedge_duration_seconds(metrics.new_histogram(
+            "fallback_hedge_duration_seconds",
+            FALLBACK_HEDGE_DURATION_SECONDS_HELP,
+            FALLBACK_HEDGE_DURATION_SECONDS_LABELS,
+            vec![
+                0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+            ],
         )?)
         .build()?)
 }

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -1,4 +1,4 @@
-use std::{ops::Add, str::FromStr};
+use std::{ops::Add, str::FromStr, time::Duration};
 
 use eyre::eyre;
 use hyperlane_sealevel::{
@@ -129,11 +129,58 @@ pub fn build_ethereum_connection_conf(
         .parse_bool()
         .unwrap_or(false);
 
+    let fallback_hedge_delay_millis = chain
+        .chain(err)
+        .get_opt_key("fallbackHedgeDelayMillis")
+        .parse_u64()
+        .end();
+    let fallback_hedge_timeout_millis = chain
+        .chain(err)
+        .get_opt_key("fallbackHedgeTimeoutMillis")
+        .parse_u64()
+        .end();
+    if fallback_hedge_delay_millis == Some(0) {
+        err.push(
+            (&chain.cwp).add("fallback_hedge_delay_millis"),
+            eyre!("fallback hedge delay must be greater than zero"),
+        );
+    }
+    if fallback_hedge_timeout_millis == Some(0) {
+        err.push(
+            (&chain.cwp).add("fallback_hedge_timeout_millis"),
+            eyre!("fallback hedge timeout must be greater than zero"),
+        );
+    }
+    if fallback_hedge_timeout_millis.is_some() && fallback_hedge_delay_millis.is_none() {
+        err.push(
+            (&chain.cwp).add("fallback_hedge_timeout_millis"),
+            eyre!("fallback hedge timeout requires fallbackHedgeDelayMillis"),
+        );
+    }
+    if fallback_hedge_delay_millis.is_some() && rpc_consensus_type != "fallback" {
+        err.push(
+            (&chain.cwp).add("fallback_hedge_delay_millis"),
+            eyre!("fallback RPC hedging requires rpcConsensusType fallback"),
+        );
+    }
+    let fallback_hedge =
+        fallback_hedge_delay_millis
+            .filter(|delay| *delay > 0)
+            .map(|delay_millis| h_eth::FallbackHedgeConfig {
+                delay: Duration::from_millis(delay_millis),
+                attempt_timeout: Duration::from_millis(
+                    fallback_hedge_timeout_millis
+                        .filter(|timeout| *timeout > 0)
+                        .unwrap_or(30_000),
+                ),
+            });
+
     Some(ChainConnectionConf::Ethereum(h_eth::ConnectionConf {
         rpc_connection: rpc_connection_conf?,
         transaction_overrides,
         op_submission_config: operation_batch,
         consider_null_transaction_receipt,
+        fallback_hedge,
     }))
 }
 
@@ -885,5 +932,75 @@ pub fn is_protocol_supported(protocol: HyperlaneDomainProtocol) -> bool {
         Ethereum | Fuel | Sealevel | Cosmos | CosmosNative | Starknet | Radix | Tron => true,
         // Aleo is feature-gated - only supported when the "aleo" feature is enabled
         Aleo => cfg!(feature = "aleo"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlane_core::config::ConfigPath;
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse_ethereum_hedge(value: serde_json::Value) -> (ChainConnectionConf, ConfigParsingError) {
+        let chain = ValueParser::new(ConfigPath::default(), &value);
+        let mut errors = ConfigParsingError::default();
+        let connection = build_ethereum_connection_conf(
+            &[Url::parse("http://localhost:8545").unwrap()],
+            &chain,
+            &mut errors,
+            "fallback",
+            OpSubmissionConfig::default(),
+        )
+        .unwrap();
+        (connection, errors)
+    }
+
+    #[test]
+    fn ethereum_fallback_hedging_is_default_off() {
+        let (connection, errors) = parse_ethereum_hedge(json!({}));
+        assert!(errors.is_ok());
+        let ChainConnectionConf::Ethereum(connection) = connection else {
+            panic!("expected ethereum connection");
+        };
+        assert_eq!(connection.fallback_hedge, None);
+    }
+
+    #[test]
+    fn parses_ethereum_fallback_hedge_settings() {
+        let (connection, errors) = parse_ethereum_hedge(json!({
+            "fallbackhedgedelaymillis": 250,
+            "fallbackhedgetimeoutmillis": 2_000,
+        }));
+        assert!(errors.is_ok());
+        let ChainConnectionConf::Ethereum(connection) = connection else {
+            panic!("expected ethereum connection");
+        };
+        assert_eq!(
+            connection.fallback_hedge,
+            Some(h_eth::FallbackHedgeConfig {
+                delay: Duration::from_millis(250),
+                attempt_timeout: Duration::from_secs(2),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_ethereum_fallback_hedge_settings() {
+        let (_, zero_delay_errors) = parse_ethereum_hedge(json!({
+            "fallbackhedgedelaymillis": 0,
+        }));
+        assert!(!zero_delay_errors.is_ok());
+
+        let (_, timeout_only_errors) = parse_ethereum_hedge(json!({
+            "fallbackhedgetimeoutmillis": 2_000,
+        }));
+        assert!(!timeout_only_errors.is_ok());
+
+        let (_, non_fallback_errors) = parse_ethereum_hedge(json!({
+            "rpcconsensustype": "single",
+            "fallbackhedgedelaymillis": 250,
+        }));
+        assert!(!non_fallback_errors.is_ok());
     }
 }

--- a/rust/main/hyperlane-metric/src/prometheus_metric.rs
+++ b/rust/main/hyperlane-metric/src/prometheus_metric.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, time::Instant};
 
 use derive_builder::Builder;
 use maplit::hashmap;
-use prometheus::{CounterVec, IntCounterVec};
+use prometheus::{CounterVec, HistogramVec, IntCounterVec};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -46,6 +46,18 @@ pub const REQUEST_DURATION_SECONDS_LABELS: &[&str] = &[
 /// Help string for the metric.
 pub const REQUEST_DURATION_SECONDS_HELP: &str = "Total number of seconds spent making requests";
 
+/// Expected labels for fallback hedge lifecycle events.
+pub const FALLBACK_HEDGE_EVENT_LABELS: &[&str] = &["chain", "method", "event"];
+/// Help string for fallback hedge lifecycle events.
+pub const FALLBACK_HEDGE_EVENT_HELP: &str =
+    "Total fallback hedge lifecycle events, including extra requests and cancellations";
+
+/// Expected labels for hedged fallback request latency.
+pub const FALLBACK_HEDGE_DURATION_SECONDS_LABELS: &[&str] = &["chain", "method", "winner"];
+/// Help string for hedged fallback request latency.
+pub const FALLBACK_HEDGE_DURATION_SECONDS_HELP: &str =
+    "End-to-end duration of fallback requests eligible for hedging";
+
 /// Container for all the relevant rpc client metrics.
 #[derive(Clone, Builder, Default)]
 pub struct PrometheusClientMetrics {
@@ -82,6 +94,14 @@ pub struct PrometheusClientMetrics {
     ///   might still be an "error" but not one with the transport layer.
     #[builder(setter(into, strip_option), default)]
     pub request_duration_seconds: Option<CounterVec>,
+
+    /// Lifecycle events for allowlisted fallback hedges.
+    #[builder(setter(into, strip_option), default)]
+    pub fallback_hedge_events: Option<IntCounterVec>,
+
+    /// End-to-end latency for requests eligible for fallback hedging.
+    #[builder(setter(into, strip_option), default)]
+    pub fallback_hedge_duration_seconds: Option<HistogramVec>,
 }
 
 impl PrometheusClientMetrics {
@@ -128,6 +148,36 @@ impl PrometheusClientMetrics {
                 .with(&labels)
                 .inc_by((Instant::now().saturating_duration_since(start)).as_secs_f64())
         };
+    }
+
+    /// Increment a fallback hedge lifecycle event.
+    pub fn increment_fallback_hedge_event(&self, chain: &str, method: &str, event: &str) {
+        let labels = hashmap! {
+            "chain" => chain,
+            "method" => method,
+            "event" => event,
+        };
+        if let Some(counter) = &self.fallback_hedge_events {
+            counter.with(&labels).inc();
+        }
+    }
+
+    /// Observe end-to-end latency for an eligible fallback request.
+    pub fn observe_fallback_hedge_duration(
+        &self,
+        chain: &str,
+        method: &str,
+        winner: &str,
+        duration: std::time::Duration,
+    ) {
+        let labels = hashmap! {
+            "chain" => chain,
+            "method" => method,
+            "winner" => winner,
+        };
+        if let Some(histogram) = &self.fallback_hedge_duration_seconds {
+            histogram.with(&labels).observe(duration.as_secs_f64());
+        }
     }
 }
 

--- a/rust/main/lander/src/adapter/chains/radix/conf.rs
+++ b/rust/main/lander/src/adapter/chains/radix/conf.rs
@@ -105,6 +105,7 @@ mod tests {
                 transaction_overrides: TransactionOverrides::default(),
                 op_submission_config: OpSubmissionConfig::default(),
                 consider_null_transaction_receipt: false,
+                fallback_hedge: None,
             }),
         );
 

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -237,8 +237,8 @@ export const ethereumTestChain: ChainMetadata = {
   },
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
+    { http: 'https://gateway.tenderly.co/public/mainnet' },
     { http: 'https://ethereum-rpc.publicnode.com' },
-    { http: 'https://eth.llamarpc.com' },
     { http: 'https://1rpc.io/eth' },
     { http: 'https://ethereum.blockpi.network/v1/rpc/public' },
     { http: 'https://eth.drpc.org' },

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -223,6 +223,12 @@ export const ethereumTestChain: ChainMetadata = {
       name: 'Ethereum Explorer',
       url: 'https://eth.blockscout.com',
     },
+    {
+      apiUrl: 'https://api.routescan.io/v2/network/mainnet/evm/1/etherscan',
+      family: ExplorerFamily.Routescan,
+      name: 'Routescan Ethereum Explorer',
+      url: 'https://routescan.io',
+    },
   ],
   blocks: { confirmations: 3, estimateBlockTime: 12, reorgPeriod: 14 },
   chainId: 1,
@@ -237,11 +243,11 @@ export const ethereumTestChain: ChainMetadata = {
   },
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
-    { http: 'https://gateway.tenderly.co/public/mainnet' },
     { http: 'https://ethereum-rpc.publicnode.com' },
     { http: 'https://1rpc.io/eth' },
     { http: 'https://ethereum.blockpi.network/v1/rpc/public' },
     { http: 'https://eth.drpc.org' },
+    { http: 'https://gateway.tenderly.co/public/mainnet' },
   ],
 };
 

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -176,6 +176,7 @@ describe('AgentChainMetadataSchema fallback hedging', () => {
   it('parses positive fallback hedge settings', () => {
     const result = AgentChainMetadataSchema.safeParse({
       ...baseChainMetadata,
+      rpcConsensusType: RpcConsensusType.Fallback,
       fallbackHedgeDelayMillis: 250,
       fallbackHedgeTimeoutMillis: 30_000,
     });
@@ -210,6 +211,15 @@ describe('AgentChainMetadataSchema fallback hedging', () => {
       AgentChainMetadataSchema.safeParse({
         ...baseChainMetadata,
         rpcConsensusType: RpcConsensusType.Single,
+        fallbackHedgeDelayMillis: 250,
+      }).success,
+    ).to.be.false;
+  });
+
+  it('rejects fallback hedging without explicit fallback RPC consensus', () => {
+    expect(
+      AgentChainMetadataSchema.safeParse({
+        ...baseChainMetadata,
         fallbackHedgeDelayMillis: 250,
       }).success,
     ).to.be.false;

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -8,6 +8,7 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 import {
   AgentChainMetadataSchema,
   RelayerAgentConfigSchema,
+  RpcConsensusType,
   buildAgentConfig,
 } from './agentConfig.js';
 
@@ -156,6 +157,62 @@ describe('AgentChainMetadataSchema additionalQuorumRpcUrls', () => {
     if (result.success) {
       expect(result.data.customAdditionalQuorumRpcUrls).to.be.undefined;
     }
+  });
+});
+
+describe('AgentChainMetadataSchema fallback hedging', () => {
+  const baseChainMetadata = {
+    name: 'legacy',
+    domainId: 1000,
+    chainId: 1000,
+    protocol: ProtocolType.Ethereum,
+    rpcUrls: [{ http: 'http://localhost:8545' }],
+    mailbox: '0x0000000000000000000000000000000000000001',
+    interchainGasPaymaster: '0x0000000000000000000000000000000000000002',
+    validatorAnnounce: '0x0000000000000000000000000000000000000003',
+    merkleTreeHook: '0x0000000000000000000000000000000000000004',
+  };
+
+  it('parses positive fallback hedge settings', () => {
+    const result = AgentChainMetadataSchema.safeParse({
+      ...baseChainMetadata,
+      fallbackHedgeDelayMillis: 250,
+      fallbackHedgeTimeoutMillis: 30_000,
+    });
+
+    expect(result.success).to.be.true;
+    if (result.success) {
+      expect(result.data.fallbackHedgeDelayMillis).to.equal(250);
+      expect(result.data.fallbackHedgeTimeoutMillis).to.equal(30_000);
+    }
+  });
+
+  it('rejects zero fallback hedge settings', () => {
+    expect(
+      AgentChainMetadataSchema.safeParse({
+        ...baseChainMetadata,
+        fallbackHedgeDelayMillis: 0,
+      }).success,
+    ).to.be.false;
+  });
+
+  it('rejects a timeout without a hedge delay', () => {
+    expect(
+      AgentChainMetadataSchema.safeParse({
+        ...baseChainMetadata,
+        fallbackHedgeTimeoutMillis: 30_000,
+      }).success,
+    ).to.be.false;
+  });
+
+  it('rejects fallback hedging with non-fallback RPC consensus', () => {
+    expect(
+      AgentChainMetadataSchema.safeParse({
+        ...baseChainMetadata,
+        rpcConsensusType: RpcConsensusType.Single,
+        fallbackHedgeDelayMillis: 250,
+      }).success,
+    ).to.be.false;
   });
 });
 

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -275,6 +275,12 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
       .enum(RpcConsensusType)
       .describe('The consensus type to use when multiple RPCs are configured.')
       .optional(),
+    fallbackHedgeDelayMillis: ZNzUint.optional().describe(
+      'For fallback RPC consensus, start one speculative immutable read on the next provider after this delay. Unset disables hedging.',
+    ),
+    fallbackHedgeTimeoutMillis: ZNzUint.optional().describe(
+      'Per-provider timeout for hedged immutable reads. Requires fallbackHedgeDelayMillis and defaults to 30000ms.',
+    ),
     signer: AgentSignerSchema.optional().describe(
       'The signer to use for this chain',
     ),
@@ -300,6 +306,34 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
   })
   .extend(AgentCosmosChainMetadataSchema.partial().shape)
   .extend(AgentSealevelChainMetadataSchema.partial().shape)
+  .refine(
+    (metadata) =>
+      metadata.fallbackHedgeTimeoutMillis === undefined ||
+      metadata.fallbackHedgeDelayMillis !== undefined,
+    {
+      message: 'fallbackHedgeTimeoutMillis requires fallbackHedgeDelayMillis',
+      path: ['fallbackHedgeTimeoutMillis'],
+    },
+  )
+  .refine(
+    (metadata) =>
+      metadata.fallbackHedgeDelayMillis === undefined ||
+      metadata.protocol === ProtocolType.Ethereum,
+    {
+      message: 'fallback RPC hedging is only supported for Ethereum chains',
+      path: ['fallbackHedgeDelayMillis'],
+    },
+  )
+  .refine(
+    (metadata) =>
+      metadata.fallbackHedgeDelayMillis === undefined ||
+      metadata.rpcConsensusType === undefined ||
+      metadata.rpcConsensusType === RpcConsensusType.Fallback,
+    {
+      message: 'fallback RPC hedging requires fallback RPC consensus',
+      path: ['fallbackHedgeDelayMillis'],
+    },
+  )
   .refine((metadata) => {
     // Make sure that the signer is valid for the protocol
 

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -327,7 +327,6 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
   .refine(
     (metadata) =>
       metadata.fallbackHedgeDelayMillis === undefined ||
-      metadata.rpcConsensusType === undefined ||
       metadata.rpcConsensusType === RpcConsensusType.Fallback,
     {
       message: 'fallback RPC hedging requires fallback RPC consensus',


### PR DESCRIPTION
## Summary

- optionally hedge allowlisted block-hash-pinned Ethereum fallback reads after a configured grace period
- bound every attempt with a timeout and advance through failed providers with at most two concurrent requests
- expose hedge starts, winners, cancellations, timeouts, and end-to-end duration metrics
- add canonical SDK and Rust parser configuration, default-off and restricted to explicit fallback consensus
- skip hedge parameter serialization entirely for non-allowlisted methods; reuse the serialized value when an allowlisted method enters the hedge decision

## Safety boundaries

- Hedging is disabled unless `fallbackHedgeDelayMillis` is configured.
- The SDK and Rust parser agree that hedging requires explicit fallback consensus; an omitted consensus type remains the Rust default quorum path.
- Allowlisted reads are limited to block-by-hash and state reads pinned to an EIP-1898 block hash. Moving `safe` and `finalized` selectors remain sequential because providers can expose different finalized heights.
- `eth_chainId` remains priority-preserving and sequential. A lower-priority endpoint cannot silently configure a signer for a different chain merely because the intended primary is slow.
- `eth_call`, latest/pending selectors, receipts/null semantics, logs, transaction lifecycle reads, submission, nonce, fees, and estimation remain on legacy paths.
- Losing cancellation does not count as provider failure or change priority.
- Stalled-provider health probes run outside the per-read attempt timeout, so a completed read is not discarded because the maintenance probe is slow.

## Expected improvement

**Synthetic/analytical expected improvement:** the focused slow-primary test compares the legacy 5s primary completion path with a hedge started after 10ms against an immediately responsive secondary. Expected completion is approximately 10ms plus scheduler overhead versus 5s, or about **500x faster / 99.8% lower latency** for this tail case. The canary target metric is p95 `fallback_hedge_duration_seconds`; `fallback_hedge_events_total{event="start"}` divided by eligible completions bounds the extra-request ratio. This is not a production observation.

The latest review fix removes the extra parameter allocation/serialization from hot non-hedged methods such as `eth_call` and `eth_getLogs`. No percentage is claimed for that micro-optimization without a matched benchmark.

## Tests

- `cargo test --offline -p hyperlane-ethereum --lib rpc_clients::fallback::tests` (27 passed at the current head)
- slow correct-primary / fast wrong-chain-secondary regression proves `eth_chainId` remains priority-preserving
- `cargo clippy --offline -p hyperlane-ethereum --lib -- -D warnings`
- `pnpm -C typescript/sdk exec mocha --config .mocharc.json './src/metadata/agentConfig.test.ts' --grep 'fallback hedging' --exit` (5 passed before the latest Rust-only change)
- `pnpm -C typescript/sdk lint` and `pnpm -C typescript/sdk check` (before the latest Rust-only change)
- Rust workspace formatting and normal pre-commit hooks

Restacked on `main@06d8269ef1`; exact head: `f09b807d0d`.

Related to #9381.
