### PR TITLE
perf(relayer): persist retry deadlines across restarts

### DIFF
--- a/rust/main/agents/relayer/src/msg/message_processor/tests/tests_common.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests/tests_common.rs
@@ -143,7 +143,9 @@ impl PendingOperation for MockQueueOperation {
     fn set_next_attempt_after(&mut self, delay: Duration) {
         self.next_attempt = Instant::now().checked_add(delay);
     }
-    fn reset_attempts(&mut self) {}
+    fn reset_attempts(&mut self) -> bool {
+        true
+    }
     #[cfg(any(test, feature = "test-utils"))]
     fn set_retries(&mut self, retries: u32) {
         self.retries = retries;

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -148,8 +148,10 @@ impl OpQueue {
                     })
                     .collect::<Vec<_>>();
                 if matched {
-                    op.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
                     let reset_succeeded = op.reset_attempts();
+                    if reset_succeeded {
+                        op.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
+                    }
                     for i in matching_requests {
                         let retry_response = &mut retry_responses[i];
                         if reset_succeeded {

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -135,21 +135,29 @@ impl OpQueue {
             .drain()
             .map(|Reverse(mut op)| {
                 let mut matched = false;
-                retry_responses
-                    .iter_mut()
+                let matching_requests = retry_responses
+                    .iter()
                     .enumerate()
-                    .for_each(|(i, retry_response)| {
+                    .filter_map(|(i, _)| {
                         let retry_req = &retry_requests[i];
                         if !retry_req.pattern.op_matches(&op) {
-                            return;
+                            return None;
                         }
-                        // update retry metrics
-                        retry_response.matched = retry_response.matched.saturating_add(1);
                         matched = true;
-                    });
+                        Some(i)
+                    })
+                    .collect::<Vec<_>>();
                 if matched {
                     op.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
-                    op.reset_attempts();
+                    let reset_succeeded = op.reset_attempts();
+                    for i in matching_requests {
+                        let retry_response = &mut retry_responses[i];
+                        if reset_succeeded {
+                            retry_response.matched = retry_response.matched.saturating_add(1);
+                        } else {
+                            retry_response.failed = retry_response.failed.saturating_add(1);
+                        }
+                    }
                 }
                 Reverse(op)
             })

--- a/rust/main/agents/relayer/src/msg/op_queue/tests.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue/tests.rs
@@ -31,6 +31,7 @@ pub struct MockPendingOperation {
     seconds_to_next_attempt: u64,
     destination_domain: HyperlaneDomain,
     retry_count: u32,
+    #[serde(skip)]
     reset_succeeds: bool,
     #[serde(skip)]
     pub mailbox: Option<Arc<dyn Mailbox>>,

--- a/rust/main/agents/relayer/src/msg/op_queue/tests.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue/tests.rs
@@ -31,6 +31,7 @@ pub struct MockPendingOperation {
     seconds_to_next_attempt: u64,
     destination_domain: HyperlaneDomain,
     retry_count: u32,
+    reset_succeeds: bool,
     #[serde(skip)]
     pub mailbox: Option<Arc<dyn Mailbox>>,
 }
@@ -46,6 +47,7 @@ impl MockPendingOperation {
             recipient_address: H256::random(),
             origin_domain_id: 0,
             retry_count: 0,
+            reset_succeeds: true,
             mailbox: None,
         }
     }
@@ -59,6 +61,7 @@ impl MockPendingOperation {
             destination_domain_id: message.destination,
             seconds_to_next_attempt: 0,
             retry_count: 0,
+            reset_succeeds: true,
             destination_domain: HyperlaneDomain::Unknown {
                 domain_id: message.destination,
                 domain_name: "test".to_string(),
@@ -106,6 +109,11 @@ impl MockPendingOperation {
         self.set_retries(retry_count);
         self
     }
+
+    pub fn with_failed_reset(mut self) -> Self {
+        self.reset_succeeds = false;
+        self
+    }
 }
 
 impl TryBatchAs<HyperlaneMessage> for MockPendingOperation {}
@@ -123,8 +131,12 @@ impl PendingOperation for MockPendingOperation {
 
     fn set_status(&mut self, _status: PendingOperationStatus) {}
 
-    fn reset_attempts(&mut self) {
+    fn reset_attempts(&mut self) -> bool {
+        if !self.reset_succeeds {
+            return false;
+        }
         self.seconds_to_next_attempt = 0;
+        true
     }
 
     fn sender_address(&self) -> &H256 {
@@ -277,6 +289,25 @@ fn generate_test_messages(
         })
         .collect();
     ops
+}
+
+#[test]
+fn failed_manual_retry_reset_is_reported_not_matched() {
+    let destination_domain: HyperlaneDomain = KnownHyperlaneDomain::Base.into();
+    let op = MockPendingOperation::new(60, destination_domain).with_failed_reset();
+    let id = op.id();
+    let mut queue = BinaryHeap::from([Reverse(Box::new(op) as QueueOperation)]);
+    let (transmitter, _receiver) = mpsc::channel(1);
+    let requests = [MessageRetryRequest {
+        uuid: "failed-reset".to_owned(),
+        pattern: MatchingList::with_message_id(id),
+        transmitter,
+    }];
+
+    let responses = OpQueue::reprioritize_matching(&mut queue, &requests);
+
+    assert_eq!(responses[0].matched, 0);
+    assert_eq!(responses[0].failed, 1);
 }
 
 #[tokio::test]

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -227,12 +227,15 @@ impl PendingOperation for PendingMessage {
     }
 
     fn set_status(&mut self, status: PendingOperationStatus) {
-        if let Err(e) = self
-            .ctx
-            .origin_db
-            .store_status_by_message_id(&self.message.id(), &status)
-        {
-            warn!(message_id = ?self.message.id(), err = %e, status = %status, "Persisting `status` failed for message");
+        // Manual status commits atomically with the cleared retry deadline.
+        if status != PendingOperationStatus::Retry(ReprepareReason::Manual) {
+            if let Err(e) = self
+                .ctx
+                .origin_db
+                .store_status_by_message_id(&self.message.id(), &status)
+            {
+                warn!(message_id = ?self.message.id(), err = %e, status = %status, "Persisting `status` failed for message");
+            }
         }
         self.status = status;
     }
@@ -1155,7 +1158,19 @@ impl PendingMessage {
     fn reset_attempts(&mut self) {
         self.next_attempt_after = None;
         self.last_attempted_at = Instant::now();
-        self.persist_retry_state(None, None);
+        let status = self.status.clone();
+        let state = PendingMessageRetryState::new(self.num_retries, None, None, None);
+        if let Err(e) = self
+            .ctx
+            .origin_db
+            .store_pending_message_retry_state_and_status_by_message_id(
+                &self.message.id(),
+                &state,
+                &status,
+            )
+        {
+            warn!(message_id = ?self.message.id(), err = %e, "Persisting manual retry reset failed for message");
+        }
     }
 
     fn inc_attempts(&mut self, reason: Option<&ReprepareReason>) {
@@ -1616,7 +1631,7 @@ mod test {
             .store_pending_message_retry_count_by_message_id(&message.id(), &2)
             .expect("store lagging legacy retry count");
 
-        let restored = PendingMessage::maybe_from_persisted_retries(
+        let mut restored = PendingMessage::maybe_from_persisted_retries(
             message.clone(),
             ctx.clone(),
             None,
@@ -1634,6 +1649,35 @@ mod test {
         );
         assert!(remaining > Duration::from_secs(58));
         assert!(remaining <= Duration::from_secs(60));
+
+        restored.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
+        restored.reset_attempts();
+        assert_eq!(
+            base_db
+                .retrieve_status_by_message_id(&message.id())
+                .expect("read manual retry status"),
+            Some(PendingOperationStatus::Retry(ReprepareReason::Manual))
+        );
+        let manual_state = base_db
+            .retrieve_pending_message_retry_state_by_message_id(&message.id())
+            .expect("read manual retry state")
+            .expect("manual retry state");
+        assert_eq!(manual_state.retry_count, 3);
+        assert_eq!(manual_state.next_attempt_at_millis, None);
+        assert_eq!(manual_state.retry_delay_millis, None);
+        assert_eq!(manual_state.reason, None);
+        let manual = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore manual retry");
+        assert_eq!(
+            manual.status(),
+            PendingOperationStatus::Retry(ReprepareReason::Manual)
+        );
+        assert_eq!(manual.next_attempt_after(), None);
 
         let expired_state = PendingMessageRetryState::new(
             3,

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -701,20 +701,20 @@ impl PendingMessage {
     ) -> Option<Self> {
         let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
         let legacy_num_retries = Self::get_num_retries(ctx.origin_db.clone(), &message);
-        let (num_retries, mut retry_state) =
+        let (mut num_retries, mut retry_state) =
             Self::reconcile_retry_state(retry_state, legacy_num_retries, &message.id());
-        if Self::should_skip(num_retries, max_retries) {
-            return None;
-        }
         let mut message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
         // Old binaries persist Manual status without clearing the versioned deadline. On
-        // roll-forward the operator's manual retry remains authoritative at equal counts.
-        if message_status == PendingOperationStatus::Retry(ReprepareReason::Manual)
-            && retry_state
-                .as_ref()
-                .is_some_and(|state| state.next_attempt_at_millis.is_some())
+        // roll-forward the operator's manual retry remains authoritative, including at
+        // the retry ceiling. Normalize it to the same zero-count state as new binaries.
+        let manual_retry = message_status == PendingOperationStatus::Retry(ReprepareReason::Manual);
+        if manual_retry
+            && (num_retries != 0
+                || retry_state
+                    .as_ref()
+                    .is_some_and(|state| state.next_attempt_at_millis.is_some()))
         {
-            let normalized = PendingMessageRetryState::new(num_retries, None, None, None);
+            let normalized = PendingMessageRetryState::new(0, None, None, None);
             if let Err(err) = ctx
                 .origin_db
                 .store_pending_message_retry_state_and_status_by_message_id(
@@ -724,8 +724,13 @@ impl PendingMessage {
                 )
             {
                 warn!(message_id = ?message.id(), %err, "Failed to normalize legacy manual retry state");
+            } else {
+                num_retries = 0;
+                retry_state = Some(normalized);
             }
-            retry_state = Some(normalized);
+        }
+        if Self::should_skip(num_retries, max_retries) && !manual_retry {
+            return None;
         }
         let reprepare_reason = match &message_status {
             PendingOperationStatus::Retry(r) => Some(r.clone()),
@@ -1176,10 +1181,8 @@ impl PendingMessage {
     }
 
     fn reset_attempts(&mut self) -> bool {
-        self.next_attempt_after = None;
-        self.last_attempted_at = Instant::now();
-        let status = self.status.clone();
-        let state = PendingMessageRetryState::new(self.num_retries, None, None, None);
+        let status = PendingOperationStatus::Retry(ReprepareReason::Manual);
+        let state = PendingMessageRetryState::new(0, None, None, None);
         if let Err(e) = self
             .ctx
             .origin_db
@@ -1192,6 +1195,10 @@ impl PendingMessage {
             warn!(message_id = ?self.message.id(), err = %e, "Persisting manual retry reset failed for message");
             return false;
         }
+        self.status = status;
+        self.num_retries = 0;
+        self.next_attempt_after = None;
+        self.last_attempted_at = Instant::now();
         true
     }
 
@@ -1563,6 +1570,47 @@ mod test {
         );
     }
 
+    #[test]
+    fn failed_manual_retry_commit_leaves_memory_unchanged() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().expect("temp db directory");
+        let db = DB::from_path(temp_dir.path()).expect("open temp db");
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let mut ctx = dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+        let mut failing_db = MockDb::new();
+        failing_db
+            .expect_store_pending_message_retry_state_and_status_by_message_id()
+            .withf(|_, state, status| {
+                state.retry_count == 0
+                    && *status == PendingOperationStatus::Retry(ReprepareReason::Manual)
+            })
+            .returning(|_, _, _| Err(DbError::Other("injected failure".to_owned())));
+        ctx.origin_db = Arc::new(failing_db);
+
+        let original_status = PendingOperationStatus::Retry(ReprepareReason::ErrorSubmitting);
+        let mut pending = PendingMessage::new(
+            HyperlaneMessage::default(),
+            Arc::new(ctx),
+            original_status.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        pending.num_retries = 5;
+        let deadline = Instant::now() + Duration::from_secs(60);
+        pending.next_attempt_after = Some(deadline);
+        let attempted_at = pending.last_attempted_at;
+
+        assert!(!pending.reset_attempts());
+        assert_eq!(pending.status, original_status);
+        assert_eq!(pending.num_retries, 5);
+        assert_eq!(pending.next_attempt_after, Some(deadline));
+        assert_eq!(pending.last_attempted_at, attempted_at);
+    }
+
     #[tokio::test]
     async fn restores_durable_deadline_and_falls_back_from_malformed_state() {
         let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
@@ -1714,7 +1762,6 @@ mod test {
         assert!(remaining > Duration::from_secs(58));
         assert!(remaining <= Duration::from_secs(60));
 
-        restored.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
         assert!(restored.reset_attempts());
         assert_eq!(
             base_db
@@ -1726,7 +1773,7 @@ mod test {
             .retrieve_pending_message_retry_state_by_message_id(&message.id())
             .expect("read manual retry state")
             .expect("manual retry state");
-        assert_eq!(manual_state.retry_count, 3);
+        assert_eq!(manual_state.retry_count, 0);
         assert_eq!(manual_state.next_attempt_at_millis, None);
         assert_eq!(manual_state.retry_delay_millis, None);
         assert_eq!(manual_state.reason, None);
@@ -1742,6 +1789,36 @@ mod test {
             PendingOperationStatus::Retry(ReprepareReason::Manual)
         );
         assert_eq!(manual.next_attempt_after(), None);
+        assert_eq!(manual.get_retries(), 0);
+
+        // A manual retry written by an old binary at the retry ceiling must also
+        // survive restart and normalize to the new zero-count representation.
+        let ceiling_state = PendingMessageRetryState::new(
+            DEFAULT_MAX_MESSAGE_RETRIES,
+            Some(unix_millis(SystemTime::now() + Duration::from_secs(60))),
+            Some(60_000),
+            Some(ReprepareReason::ErrorSubmitting),
+        );
+        base_db
+            .store_pending_message_retry_state_and_status_by_message_id(
+                &message.id(),
+                &ceiling_state,
+                &PendingOperationStatus::Retry(ReprepareReason::Manual),
+            )
+            .expect("store ceiling manual retry");
+        let ceiling_manual = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore ceiling manual retry");
+        assert_eq!(ceiling_manual.get_retries(), 0);
+        assert_eq!(ceiling_manual.next_attempt_after(), None);
+        assert_eq!(
+            ceiling_manual.status(),
+            PendingOperationStatus::Retry(ReprepareReason::Manual)
+        );
 
         let expired_state = PendingMessageRetryState::new(
             3,
@@ -1750,7 +1827,11 @@ mod test {
             Some(ReprepareReason::CouldNotFetchMetadata),
         );
         base_db
-            .store_pending_message_retry_state_by_message_id(&message.id(), &expired_state)
+            .store_pending_message_retry_state_and_status_by_message_id(
+                &message.id(),
+                &expired_state,
+                &PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata),
+            )
             .expect("store expired retry state");
         let expired = PendingMessage::maybe_from_persisted_retries(
             message.clone(),

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1683,6 +1683,12 @@ mod test {
         base_db
             .store_pending_message_retry_state_by_message_id(&message.id(), &state)
             .expect("store retry state");
+        base_db
+            .store_status_by_message_id(
+                &message.id(),
+                &PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata),
+            )
+            .expect("store retry reason");
         // Simulate the historical write-order fault where the combined state landed
         // before its legacy mirror. The higher combined count must remain authoritative.
         base_db

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -632,8 +632,8 @@ impl PendingOperation for PendingMessage {
         self.persist_retry_state(Some(delay), None);
     }
 
-    fn reset_attempts(&mut self) {
-        self.reset_attempts();
+    fn reset_attempts(&mut self) -> bool {
+        self.reset_attempts()
     }
 
     fn set_retries(&mut self, retries: u32) {
@@ -701,12 +701,32 @@ impl PendingMessage {
     ) -> Option<Self> {
         let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
         let legacy_num_retries = Self::get_num_retries(ctx.origin_db.clone(), &message);
-        let (num_retries, retry_state) =
+        let (num_retries, mut retry_state) =
             Self::reconcile_retry_state(retry_state, legacy_num_retries, &message.id());
         if Self::should_skip(num_retries, max_retries) {
             return None;
         }
         let mut message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
+        // Old binaries persist Manual status without clearing the versioned deadline. On
+        // roll-forward the operator's manual retry remains authoritative at equal counts.
+        if message_status == PendingOperationStatus::Retry(ReprepareReason::Manual)
+            && retry_state
+                .as_ref()
+                .is_some_and(|state| state.next_attempt_at_millis.is_some())
+        {
+            let normalized = PendingMessageRetryState::new(num_retries, None, None, None);
+            if let Err(err) = ctx
+                .origin_db
+                .store_pending_message_retry_state_and_status_by_message_id(
+                    &message.id(),
+                    &normalized,
+                    &message_status,
+                )
+            {
+                warn!(message_id = ?message.id(), %err, "Failed to normalize legacy manual retry state");
+            }
+            retry_state = Some(normalized);
+        }
         let reprepare_reason = match &message_status {
             PendingOperationStatus::Retry(r) => Some(r.clone()),
             _ => None,
@@ -1155,7 +1175,7 @@ impl PendingMessage {
         Ok(())
     }
 
-    fn reset_attempts(&mut self) {
+    fn reset_attempts(&mut self) -> bool {
         self.next_attempt_after = None;
         self.last_attempted_at = Instant::now();
         let status = self.status.clone();
@@ -1170,7 +1190,9 @@ impl PendingMessage {
             )
         {
             warn!(message_id = ?self.message.id(), err = %e, "Persisting manual retry reset failed for message");
+            return false;
         }
+        true
     }
 
     fn inc_attempts(&mut self, reason: Option<&ReprepareReason>) {
@@ -1615,6 +1637,42 @@ mod test {
         );
         assert!(remaining.duration_since(Instant::now()) <= Duration::from_secs(10));
 
+        // Simulate an old binary applying a manual retry after the v1 record was
+        // written at the same count. Roll-forward must not restore its stale deadline.
+        let stale_manual_state = PendingMessageRetryState::new(
+            2,
+            Some(unix_millis(SystemTime::now() + Duration::from_secs(60))),
+            Some(60_000),
+            Some(ReprepareReason::ErrorSubmitting),
+        );
+        base_db
+            .store_pending_message_retry_state_by_message_id(&message.id(), &stale_manual_state)
+            .expect("store stale manual retry state");
+        base_db
+            .store_status_by_message_id(
+                &message.id(),
+                &PendingOperationStatus::Retry(ReprepareReason::Manual),
+            )
+            .expect("store legacy manual status");
+        let manual_roll_forward = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore legacy manual retry");
+        assert_eq!(manual_roll_forward.next_attempt_after(), None);
+        assert_eq!(
+            manual_roll_forward.status(),
+            PendingOperationStatus::Retry(ReprepareReason::Manual)
+        );
+        let normalized = base_db
+            .retrieve_pending_message_retry_state_by_message_id(&message.id())
+            .expect("read normalized manual state")
+            .expect("normalized manual state");
+        assert_eq!(normalized.next_attempt_at_millis, None);
+        assert_eq!(normalized.reason, None);
+
         let deadline = SystemTime::now() + Duration::from_secs(60);
         let state = PendingMessageRetryState::new(
             3,
@@ -1651,7 +1709,7 @@ mod test {
         assert!(remaining <= Duration::from_secs(60));
 
         restored.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
-        restored.reset_attempts();
+        assert!(restored.reset_attempts());
         assert_eq!(
             base_db
                 .retrieve_status_by_message_id(&message.id())

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -3,7 +3,7 @@
 use std::{
     fmt::{Debug, Formatter},
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
@@ -16,7 +16,7 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 
 use hyperlane_base::{
     cache::{FunctionCallCache, LocalCache, MeteredCache, OptionalCache},
-    db::HyperlaneDb,
+    db::{HyperlaneDb, PendingMessageRetryState},
 };
 use hyperlane_core::{
     gas_used_by_operation, BatchItem, ChainCommunicationError, ChainResult, ConfirmReason,
@@ -626,6 +626,7 @@ impl PendingOperation for PendingMessage {
 
     fn set_next_attempt_after(&mut self, delay: Duration) {
         self.next_attempt_after = Instant::now().checked_add(delay);
+        self.persist_retry_state(Some(delay), None);
     }
 
     fn reset_attempts(&mut self) {
@@ -695,19 +696,41 @@ impl PendingMessage {
         app_context: Option<String>,
         max_retries: u32,
     ) -> Option<Self> {
-        let num_retries = Self::get_retries_or_skip(ctx.origin_db.clone(), &message, max_retries)?;
-        let message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
+        let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
+        let num_retries = retry_state
+            .as_ref()
+            .map(|state| state.retry_count)
+            .unwrap_or_else(|| Self::get_num_retries(ctx.origin_db.clone(), &message));
+        if Self::should_skip(num_retries, max_retries) {
+            return None;
+        }
+        let mut message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
         let reprepare_reason = match &message_status {
             PendingOperationStatus::Retry(r) => Some(r.clone()),
             _ => None,
         };
-        let mut pending_message = Self::new(message, ctx, message_status, app_context, max_retries);
-        if num_retries > 0 {
-            let next_attempt_after =
-                Self::next_attempt_after(num_retries, max_retries, reprepare_reason.as_ref());
-            pending_message.num_retries = num_retries;
-            pending_message.next_attempt_after = next_attempt_after;
+        let next_attempt_after = retry_state
+            .as_ref()
+            .and_then(|state| {
+                Self::restore_retry_deadline(state, SystemTime::now(), Instant::now())
+            })
+            .or_else(|| {
+                if retry_state.is_some() || num_retries == 0 {
+                    None
+                } else {
+                    Self::next_attempt_after(num_retries, max_retries, reprepare_reason.as_ref())
+                }
+            });
+        // While a deadline remains active, the retry record is the atomic source of its
+        // reason too. This closes the crash window before the queue persists Retry(status).
+        if next_attempt_after.is_some() {
+            if let Some(reason) = retry_state.as_ref().and_then(|state| state.reason.clone()) {
+                message_status = PendingOperationStatus::Retry(reason);
+            }
         }
+        let mut pending_message = Self::new(message, ctx, message_status, app_context, max_retries);
+        pending_message.num_retries = num_retries;
+        pending_message.next_attempt_after = next_attempt_after;
         Some(pending_message)
     }
 
@@ -728,6 +751,32 @@ impl PendingMessage {
             .and_then(|dur| Instant::now().checked_add(dur))
     }
 
+    fn restore_retry_deadline(
+        state: &PendingMessageRetryState,
+        wall_now: SystemTime,
+        monotonic_now: Instant,
+    ) -> Option<Instant> {
+        let deadline =
+            UNIX_EPOCH.checked_add(Duration::from_millis(state.next_attempt_at_millis?))?;
+        let remaining = deadline.duration_since(wall_now).ok()?;
+        let original_delay = Duration::from_millis(state.retry_delay_millis?);
+        monotonic_now.checked_add(remaining.min(original_delay))
+    }
+
+    fn get_retry_state(
+        origin_db: Arc<dyn HyperlaneDb>,
+        message: &HyperlaneMessage,
+    ) -> Option<PendingMessageRetryState> {
+        match origin_db.retrieve_pending_message_retry_state_by_message_id(&message.id()) {
+            Ok(state) => state,
+            Err(err) => {
+                warn!(message_id = ?message.id(), %err, "Failed to read durable retry state; falling back to legacy retry count");
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
     fn get_retries_or_skip(
         origin_db: Arc<dyn HyperlaneDb>,
         message: &HyperlaneMessage,
@@ -986,6 +1035,7 @@ impl PendingMessage {
         self.submitted = false;
         self.last_attempted_at = Instant::now();
         self.next_attempt_after = self.last_attempted_at.checked_add(delay);
+        self.persist_retry_state(Some(delay), Some(reason.clone()));
         PendingOperationResult::Reprepare(reason)
     }
 
@@ -1086,22 +1136,53 @@ impl PendingMessage {
     fn reset_attempts(&mut self) {
         self.next_attempt_after = None;
         self.last_attempted_at = Instant::now();
+        self.persist_retry_state(None, None);
     }
 
     fn inc_attempts(&mut self, reason: Option<&ReprepareReason>) {
-        self.set_retries(self.num_retries.saturating_add(1));
+        self.num_retries = self.num_retries.saturating_add(1);
         self.last_attempted_at = Instant::now();
-        self.next_attempt_after = PendingMessage::calculate_msg_backoff(
+        let delay = PendingMessage::calculate_msg_backoff(
             self.num_retries,
             self.max_retries,
             Some(self.message.id()),
             reason,
-        )
-        .and_then(|dur| self.last_attempted_at.checked_add(dur));
+        );
+        self.next_attempt_after = delay.and_then(|dur| self.last_attempted_at.checked_add(dur));
+        self.persist_retry_state(delay, reason.cloned());
     }
 
     fn set_retries(&mut self, retries: u32) {
         self.num_retries = retries;
+        self.persist_retries();
+    }
+
+    fn persist_retry_state(&self, delay: Option<Duration>, reason: Option<ReprepareReason>) {
+        let next_attempt_at_millis = delay.and_then(|delay| {
+            SystemTime::now()
+                .checked_add(delay)?
+                .duration_since(UNIX_EPOCH)
+                .ok()?
+                .as_millis()
+                .try_into()
+                .ok()
+        });
+        let retry_delay_millis = delay.and_then(|delay| delay.as_millis().try_into().ok());
+        let state = PendingMessageRetryState::new(
+            self.num_retries,
+            next_attempt_at_millis,
+            retry_delay_millis,
+            reason,
+        );
+        if let Err(e) = self
+            .ctx
+            .origin_db
+            .store_pending_message_retry_state_by_message_id(&self.message.id(), &state)
+        {
+            warn!(message_id = ?self.message.id(), err = %e, "Persisting durable retry state failed for message");
+        }
+        // Keep the legacy count current so rolling back to an older binary remains safe.
+        // New binaries always prefer the combined record when it is valid.
         self.persist_retries();
     }
 
@@ -1334,7 +1415,7 @@ impl PendingMessage {
 mod test {
     use std::{
         sync::Arc,
-        time::{Duration, Instant},
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     };
 
     use chrono::TimeDelta;
@@ -1345,6 +1426,169 @@ mod test {
     use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
     use super::{PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES, VALIDATOR_SIGNATURE_FAST_RETRY_MAX};
+
+    fn unix_millis(time: SystemTime) -> u64 {
+        time.duration_since(UNIX_EPOCH)
+            .expect("test time must follow Unix epoch")
+            .as_millis()
+            .try_into()
+            .expect("test timestamp must fit in u64")
+    }
+
+    #[test]
+    fn restores_remaining_retry_delay_and_bounds_backward_clock_skew() {
+        let wall_now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let monotonic_now = Instant::now();
+        let state = PendingMessageRetryState::new(
+            8,
+            Some(unix_millis(wall_now + Duration::from_secs(10))),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+
+        assert_eq!(
+            PendingMessage::restore_retry_deadline(&state, wall_now, monotonic_now),
+            monotonic_now.checked_add(Duration::from_secs(10))
+        );
+
+        let skewed_wall_now = wall_now - Duration::from_secs(3_600);
+        assert_eq!(
+            PendingMessage::restore_retry_deadline(&state, skewed_wall_now, monotonic_now),
+            monotonic_now.checked_add(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn expired_retry_deadline_runs_immediately() {
+        let wall_now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let state = PendingMessageRetryState::new(
+            8,
+            Some(unix_millis(wall_now - Duration::from_secs(1))),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+
+        assert_eq!(
+            PendingMessage::restore_retry_deadline(&state, wall_now, Instant::now()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn restores_durable_deadline_and_falls_back_from_malformed_state() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().expect("temp db directory");
+        let db = DB::from_path(temp_dir.path()).expect("open temp db");
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = HyperlaneMessage {
+            nonce: 7,
+            origin: KnownHyperlaneDomain::Arbitrum as u32,
+            destination: KnownHyperlaneDomain::Ethereum as u32,
+            ..Default::default()
+        };
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let ctx = Arc::new(dummy_message_context(
+            Arc::new(base_metadata_builder),
+            &base_db,
+            cache,
+        ));
+        let mut pending = PendingMessage::new(
+            message.clone(),
+            ctx.clone(),
+            PendingOperationStatus::FirstPrepareAttempt,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        assert!(matches!(
+            pending.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata),
+            PendingOperationResult::Reprepare(ReprepareReason::CouldNotFetchMetadata)
+        ));
+        let persisted = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore production retry state");
+        assert_eq!(persisted.get_retries(), 1);
+        assert_eq!(
+            persisted.status(),
+            PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata)
+        );
+        assert!(persisted.next_attempt_after().is_some());
+
+        let deadline = SystemTime::now() + Duration::from_secs(60);
+        let state = PendingMessageRetryState::new(
+            3,
+            Some(unix_millis(deadline)),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+        base_db
+            .store_pending_message_retry_state_by_message_id(&message.id(), &state)
+            .expect("store retry state");
+
+        let restored = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore pending message");
+        let remaining = restored
+            .next_attempt_after()
+            .expect("future deadline")
+            .duration_since(Instant::now());
+        assert_eq!(restored.get_retries(), 3);
+        assert_eq!(
+            restored.status(),
+            PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata)
+        );
+        assert!(remaining > Duration::from_secs(58));
+        assert!(remaining <= Duration::from_secs(60));
+
+        let expired_state = PendingMessageRetryState::new(
+            3,
+            Some(unix_millis(SystemTime::now() - Duration::from_secs(1))),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+        base_db
+            .store_pending_message_retry_state_by_message_id(&message.id(), &expired_state)
+            .expect("store expired retry state");
+        let expired = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore expired pending message");
+        assert_eq!(expired.get_retries(), 3);
+        assert_eq!(expired.next_attempt_after(), None);
+
+        base_db
+            .store_value_by_key(
+                "pending_message_retry_state_for_message_id_v1_",
+                &message.id(),
+                &H256::zero(),
+            )
+            .expect("store malformed retry state");
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &2)
+            .expect("store legacy retry count");
+        let fallback = PendingMessage::maybe_from_persisted_retries(
+            message,
+            ctx,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("fallback to legacy retry state");
+        assert_eq!(fallback.get_retries(), 2);
+        assert!(fallback.next_attempt_after().is_some());
+    }
 
     #[test]
     fn test_calculate_msg_backoff_does_not_overflow() {

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -697,10 +697,9 @@ impl PendingMessage {
         max_retries: u32,
     ) -> Option<Self> {
         let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
-        let num_retries = retry_state
-            .as_ref()
-            .map(|state| state.retry_count)
-            .unwrap_or_else(|| Self::get_num_retries(ctx.origin_db.clone(), &message));
+        let legacy_num_retries = Self::get_num_retries(ctx.origin_db.clone(), &message);
+        let (num_retries, retry_state) =
+            Self::reconcile_retry_state(retry_state, legacy_num_retries, &message.id());
         if Self::should_skip(num_retries, max_retries) {
             return None;
         }
@@ -732,6 +731,26 @@ impl PendingMessage {
         pending_message.num_retries = num_retries;
         pending_message.next_attempt_after = next_attempt_after;
         Some(pending_message)
+    }
+
+    fn reconcile_retry_state(
+        retry_state: Option<PendingMessageRetryState>,
+        legacy_num_retries: u32,
+        message_id: &H256,
+    ) -> (u32, Option<PendingMessageRetryState>) {
+        let Some(retry_state) = retry_state else {
+            return (legacy_num_retries, None);
+        };
+        if legacy_num_retries > retry_state.retry_count {
+            warn!(
+                ?message_id,
+                legacy_num_retries,
+                retry_state_num_retries = retry_state.retry_count,
+                "Ignoring stale durable retry state after legacy retry count advanced"
+            );
+            return (legacy_num_retries, None);
+        }
+        (retry_state.retry_count, Some(retry_state))
     }
 
     /// Set fail-fast mode: drop the message immediately when `num_retries` exceeds
@@ -1154,7 +1173,18 @@ impl PendingMessage {
 
     fn set_retries(&mut self, retries: u32) {
         self.num_retries = retries;
-        self.persist_retries();
+        let reason = match &self.status {
+            PendingOperationStatus::Retry(reason) => Some(reason.clone()),
+            _ => None,
+        };
+        let delay = Self::calculate_msg_backoff(
+            self.num_retries,
+            self.max_retries,
+            Some(self.message.id()),
+            reason.as_ref(),
+        );
+        self.next_attempt_after = delay.and_then(|delay| Instant::now().checked_add(delay));
+        self.persist_retry_state(delay, reason);
     }
 
     fn persist_retry_state(&self, delay: Option<Duration>, reason: Option<ReprepareReason>) {
@@ -1180,19 +1210,6 @@ impl PendingMessage {
             .store_pending_message_retry_state_by_message_id(&self.message.id(), &state)
         {
             warn!(message_id = ?self.message.id(), err = %e, "Persisting durable retry state failed for message");
-        }
-        // Keep the legacy count current so rolling back to an older binary remains safe.
-        // New binaries always prefer the combined record when it is valid.
-        self.persist_retries();
-    }
-
-    fn persist_retries(&self) {
-        if let Err(e) = self
-            .ctx
-            .origin_db
-            .store_pending_message_retry_count_by_message_id(&self.message.id(), &self.num_retries)
-        {
-            warn!(message_id = ?self.message.id(), err = %e, "Persisting the `num_retries` failed for message");
         }
     }
 
@@ -1413,6 +1430,7 @@ impl PendingMessage {
 
 #[cfg(test)]
 mod test {
+    use std::io::Write;
     use std::{
         sync::Arc,
         time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -1433,6 +1451,40 @@ mod test {
             .as_millis()
             .try_into()
             .expect("test timestamp must fit in u64")
+    }
+
+    struct RawRetryState(&'static [u8]);
+
+    impl Encode for RawRetryState {
+        fn write_to<W: Write>(&self, writer: &mut W) -> std::io::Result<usize> {
+            writer.write(self.0)
+        }
+    }
+
+    #[test]
+    fn retry_state_reconciliation_uses_authoritative_count() {
+        let message_id = H256::zero();
+        let stale_state = PendingMessageRetryState::new(
+            1,
+            Some(60_000),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+        assert_eq!(
+            PendingMessage::reconcile_retry_state(Some(stale_state), 2, &message_id),
+            (2, None)
+        );
+
+        let ahead_state = PendingMessageRetryState::new(
+            3,
+            Some(60_000),
+            Some(60_000),
+            Some(ReprepareReason::ErrorSubmitting),
+        );
+        assert_eq!(
+            PendingMessage::reconcile_retry_state(Some(ahead_state.clone()), 2, &message_id),
+            (3, Some(ahead_state))
+        );
     }
 
     #[test]
@@ -1520,6 +1572,34 @@ mod test {
         );
         assert!(persisted.next_attempt_after().is_some());
 
+        // Simulate rollback to an old binary, which advances only the legacy count,
+        // followed by rolling forward to this version.
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &2)
+            .expect("advance legacy retry count");
+        base_db
+            .store_status_by_message_id(
+                &message.id(),
+                &PendingOperationStatus::Retry(ReprepareReason::ErrorSubmitting),
+            )
+            .expect("store legacy retry reason");
+        let rolled_forward = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore after rollback");
+        let remaining = rolled_forward
+            .next_attempt_after()
+            .expect("legacy schedule");
+        assert_eq!(rolled_forward.get_retries(), 2);
+        assert_eq!(
+            rolled_forward.status(),
+            PendingOperationStatus::Retry(ReprepareReason::ErrorSubmitting)
+        );
+        assert!(remaining.duration_since(Instant::now()) <= Duration::from_secs(10));
+
         let deadline = SystemTime::now() + Duration::from_secs(60);
         let state = PendingMessageRetryState::new(
             3,
@@ -1530,6 +1610,11 @@ mod test {
         base_db
             .store_pending_message_retry_state_by_message_id(&message.id(), &state)
             .expect("store retry state");
+        // Simulate the historical write-order fault where the combined state landed
+        // before its legacy mirror. The higher combined count must remain authoritative.
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &2)
+            .expect("store lagging legacy retry count");
 
         let restored = PendingMessage::maybe_from_persisted_retries(
             message.clone(),
@@ -1588,6 +1673,57 @@ mod test {
         .expect("fallback to legacy retry state");
         assert_eq!(fallback.get_retries(), 2);
         assert!(fallback.next_attempt_after().is_some());
+
+        let message = fallback.message.clone();
+        let ctx = fallback.ctx.clone();
+        base_db
+            .store_value_by_key(
+                "pending_message_retry_state_for_message_id_v1_",
+                &message.id(),
+                &RawRetryState(
+                    br#"{"version":2,"retry_count":9,"next_attempt_at_millis":null,"retry_delay_millis":null,"reason":null}"#,
+                ),
+            )
+            .expect("store unsupported retry state");
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &3)
+            .expect("store fallback retry count");
+        let mut unsupported = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("fallback from unsupported retry state");
+        assert_eq!(unsupported.get_retries(), 3);
+        assert!(unsupported.next_attempt_after().is_some());
+
+        // An intentional lower/manual reset must replace both records; otherwise
+        // monotonic reconciliation would resurrect the older higher v1 count.
+        unsupported.set_retries(0);
+        assert_eq!(
+            base_db
+                .retrieve_pending_message_retry_count_by_message_id(&message.id())
+                .expect("read reset legacy count"),
+            Some(0)
+        );
+        assert_eq!(
+            base_db
+                .retrieve_pending_message_retry_state_by_message_id(&message.id())
+                .expect("read reset durable state")
+                .expect("reset durable state")
+                .retry_count,
+            0
+        );
+        let reset = PendingMessage::maybe_from_persisted_retries(
+            message,
+            ctx,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore manually reset state");
+        assert_eq!(reset.get_retries(), 0);
+        assert_eq!(reset.next_attempt_after(), None);
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/server/operations/message_retry.rs
+++ b/rust/main/agents/relayer/src/server/operations/message_retry.rs
@@ -35,6 +35,8 @@ pub struct MessageRetryQueueResponse {
     pub evaluated: usize,
     /// how many of the pending operations matched the retry request pattern
     pub matched: u64,
+    /// how many matching operations could not persist their manual retry
+    pub failed: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -80,6 +82,7 @@ async fn handler(
         evaluated: 0,
         matched: 0,
     };
+    let mut failed = 0_u64;
 
     // Wait for responses from relayer
     tracing::debug!(uuid = resp.uuid, "Waiting for response from relayer");
@@ -91,6 +94,13 @@ async fn handler(
         );
         resp.evaluated = resp.evaluated.saturating_add(relayer_resp.evaluated);
         resp.matched = resp.matched.saturating_add(relayer_resp.matched);
+        failed = failed.saturating_add(relayer_resp.failed);
+    }
+
+    if failed > 0 {
+        return Err(format!(
+            "Failed to persist manual retry for {failed} matching operations"
+        ));
     }
 
     Ok(Json(resp))
@@ -142,7 +152,11 @@ mod tests {
             for (op, (evaluated, matched)) in pending_operations.iter().zip(metrics) {
                 // Check that the list received by the server matches the pending operation
                 assert!(req.pattern.op_matches(op));
-                let resp = MessageRetryQueueResponse { evaluated, matched };
+                let resp = MessageRetryQueueResponse {
+                    evaluated,
+                    matched,
+                    failed: 0,
+                };
                 req.transmitter.send(resp).await.unwrap();
             }
         }

--- a/rust/main/agents/relayer/src/server/operations/message_retry.rs
+++ b/rust/main/agents/relayer/src/server/operations/message_retry.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, routing, Json, Router};
+use axum::{extract::State, http::StatusCode, routing, Json, Router};
 use derive_new::new;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast::Sender, mpsc};
@@ -52,7 +52,7 @@ pub struct MessageRetryResponse {
 async fn handler(
     State(state): State<ServerState>,
     Json(payload): Json<MatchingList>,
-) -> Result<Json<MessageRetryResponse>, String> {
+) -> Result<Json<MessageRetryResponse>, (StatusCode, String)> {
     let uuid = uuid::Uuid::new_v4();
     let uuid_string = uuid.to_string();
 
@@ -74,7 +74,10 @@ async fn handler(
         .map_err(|err| {
             // Technically it's bad practice to print the error message to the user, but
             // this endpoint is for debugging purposes only.
-            format!("Failed to send retry request to the queue: {err}")
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to send retry request to the queue: {err}"),
+            )
         })?;
 
     let mut resp = MessageRetryResponse {
@@ -98,8 +101,9 @@ async fn handler(
     }
 
     if failed > 0 {
-        return Err(format!(
-            "Failed to persist manual retry for {failed} matching operations"
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to persist manual retry for {failed} matching operations"),
         ));
     }
 
@@ -206,6 +210,38 @@ mod tests {
         let resp_json: MessageRetryResponse = parse_body_to_json(response.into_body()).await;
         assert_eq!(resp_json.evaluated, 1);
         assert_eq!(resp_json.matched, 1);
+    }
+
+    #[tokio::test]
+    async fn test_persistence_failure_returns_internal_server_error() {
+        let TestServerSetup { app, retry_req_rx } = setup_test_server();
+        let mut retry_req_rx = retry_req_rx;
+
+        // spawn a task reporting that persisting the manual retry failed
+        tokio::task::spawn(async move {
+            if let Ok(req) = retry_req_rx.recv().await {
+                req.transmitter
+                    .send(MessageRetryQueueResponse {
+                        evaluated: 1,
+                        matched: 1,
+                        failed: 1,
+                    })
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let body = json!([
+            {
+                "messageid": HyperlaneMessage::default().id()
+            }
+        ]);
+
+        // Send a POST request to the server
+        let response = send_retry_request(app, &body).await;
+
+        // Persistence failures must not return a 2xx response
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -1,4 +1,6 @@
-pub use self::storage_types::{InterchainGasExpenditureData, InterchainGasPaymentData};
+pub use self::storage_types::{
+    InterchainGasExpenditureData, InterchainGasPaymentData, PendingMessageRetryState,
+};
 pub use error::*;
 pub use rocks::*;
 
@@ -123,6 +125,19 @@ pub trait HyperlaneDb: Send + Sync {
         &self,
         message_id: &H256,
     ) -> DbResult<Option<u32>>;
+
+    /// Store retry count, deadline, and reason atomically for a pending message.
+    fn store_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+    ) -> DbResult<()>;
+
+    /// Retrieve durable retry state for a pending message.
+    fn retrieve_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+    ) -> DbResult<Option<PendingMessageRetryState>>;
 
     fn store_merkle_tree_insertion_by_leaf_index(
         &self,

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -128,12 +128,20 @@ pub trait HyperlaneDb: Send + Sync {
 
     /// Atomically store retry state and its legacy retry-count mirror.
     ///
-    /// Status is persisted separately by the operation queue. The retry state carries
-    /// its reason to close that write boundary while its deadline is active.
+    /// Status is normally persisted separately by the operation queue. The retry state
+    /// carries its reason to close that write boundary while its deadline is active.
     fn store_pending_message_retry_state_by_message_id(
         &self,
         message_id: &H256,
         state: &PendingMessageRetryState,
+    ) -> DbResult<()>;
+
+    /// Atomically store retry state, its legacy count mirror, and message status.
+    fn store_pending_message_retry_state_and_status_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+        status: &PendingOperationStatus,
     ) -> DbResult<()>;
 
     /// Retrieve durable retry state for a pending message.

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -126,7 +126,10 @@ pub trait HyperlaneDb: Send + Sync {
         message_id: &H256,
     ) -> DbResult<Option<u32>>;
 
-    /// Store retry count, deadline, and reason atomically for a pending message.
+    /// Atomically store retry state and its legacy retry-count mirror.
+    ///
+    /// Status is persisted separately by the operation queue. The retry state carries
+    /// its reason to close that write boundary while its deadline is active.
     fn store_pending_message_retry_state_by_message_id(
         &self,
         message_id: &H256,

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -640,11 +640,22 @@ impl HyperlaneDb for HyperlaneRocksDB {
         message_id: &H256,
         state: &PendingMessageRetryState,
     ) -> DbResult<()> {
-        self.store_value_by_key(
-            PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID,
-            message_id,
-            state,
-        )
+        self.store_batch([
+            (
+                PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.to_vec(),
+            ),
+            (
+                PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.retry_count.to_vec(),
+            ),
+        ])
     }
 
     fn retrieve_pending_message_retry_state_by_message_id(

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -658,6 +658,35 @@ impl HyperlaneDb for HyperlaneRocksDB {
         ])
     }
 
+    fn store_pending_message_retry_state_and_status_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+        status: &PendingOperationStatus,
+    ) -> DbResult<()> {
+        self.store_batch([
+            (
+                PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.to_vec(),
+            ),
+            (
+                PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.retry_count.to_vec(),
+            ),
+            (
+                STATUS_BY_MESSAGE_ID.as_bytes().to_vec(),
+                message_id.to_vec(),
+                status.to_vec(),
+            ),
+        ])
+    }
+
     fn retrieve_pending_message_retry_state_by_message_id(
         &self,
         message_id: &H256,

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -12,7 +12,9 @@ use hyperlane_core::{
 };
 
 use crate::db::{
-    storage_types::{InterchainGasExpenditureData, InterchainGasPaymentData},
+    storage_types::{
+        InterchainGasExpenditureData, InterchainGasPaymentData, PendingMessageRetryState,
+    },
     HyperlaneDb,
 };
 
@@ -34,6 +36,8 @@ const GAS_EXPENDITURE_FOR_MESSAGE_ID: &str = "gas_expenditure_for_message_id_v2_
 const STATUS_BY_MESSAGE_ID: &str = "status_by_message_id_";
 const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
     "pending_message_retry_count_for_message_id_";
+const PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID: &str =
+    "pending_message_retry_state_for_message_id_v1_";
 const MERKLE_TREE_INSERTION: &str = "merkle_tree_insertion_";
 const MERKLE_LEAF_INDEX_BY_MESSAGE_ID: &str = "merkle_leaf_index_by_message_id_";
 const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
@@ -629,6 +633,25 @@ impl HyperlaneDb for HyperlaneRocksDB {
         message_id: &H256,
     ) -> DbResult<Option<u32>> {
         self.retrieve_value_by_key(PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID, message_id)
+    }
+
+    fn store_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+    ) -> DbResult<()> {
+        self.store_value_by_key(
+            PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID,
+            message_id,
+            state,
+        )
+    }
+
+    fn retrieve_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+    ) -> DbResult<Option<PendingMessageRetryState>> {
+        self.retrieve_value_by_key(PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID, message_id)
     }
 
     fn store_merkle_tree_insertion_by_leaf_index(

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -109,6 +109,15 @@ impl DB {
         Ok(self.0.put(key, value)?)
     }
 
+    /// Atomically store multiple key-value pairs in the DB.
+    pub fn store_batch(&self, entries: impl IntoIterator<Item = (Vec<u8>, Vec<u8>)>) -> Result<()> {
+        let mut batch = WriteBatch::default();
+        for (key, value) in entries {
+            batch.put(key, value);
+        }
+        Ok(self.0.write(batch)?)
+    }
+
     /// Retrieve a value from the DB
     pub fn retrieve(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
@@ -265,5 +274,25 @@ mod tests {
         assert!(!db
             .has_unmarked_writes_since(checkpoint, b"source_", b"marker")
             .unwrap());
+    }
+
+    #[test]
+    fn failed_batch_writes_no_keys() {
+        let temp_dir = tempfile::tempdir().expect("temp db directory");
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        drop(Rocks::open(&options, temp_dir.path()).expect("initialize db"));
+
+        let rocks =
+            Rocks::open_for_read_only(&options, temp_dir.path(), false).expect("open read-only db");
+        let db = DB::from(rocks);
+        assert!(db
+            .store_batch([
+                (b"retry-state".to_vec(), b"state".to_vec()),
+                (b"retry-count".to_vec(), b"count".to_vec()),
+            ])
+            .is_err());
+        assert_eq!(db.retrieve(b"retry-state").expect("read state"), None);
+        assert_eq!(db.retrieve(b"retry-count").expect("read count"), None);
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -277,22 +277,37 @@ mod tests {
     }
 
     #[test]
-    fn failed_batch_writes_no_keys() {
+    fn failed_batch_preserves_all_old_values() {
         let temp_dir = tempfile::tempdir().expect("temp db directory");
         let mut options = Options::default();
         options.create_if_missing(true);
-        drop(Rocks::open(&options, temp_dir.path()).expect("initialize db"));
+        let writable = Rocks::open(&options, temp_dir.path()).expect("initialize db");
+        writable
+            .put(b"retry-state", b"old-state")
+            .expect("store old state");
+        writable
+            .put(b"retry-count", b"old-count")
+            .expect("store old count");
+        drop(writable);
 
         let rocks =
             Rocks::open_for_read_only(&options, temp_dir.path(), false).expect("open read-only db");
         let db = DB::from(rocks);
         assert!(db
             .store_batch([
-                (b"retry-state".to_vec(), b"state".to_vec()),
-                (b"retry-count".to_vec(), b"count".to_vec()),
+                (b"retry-state".to_vec(), b"new-state".to_vec()),
+                (b"retry-count".to_vec(), b"new-count".to_vec()),
+                (b"status".to_vec(), b"manual".to_vec()),
             ])
             .is_err());
-        assert_eq!(db.retrieve(b"retry-state").expect("read state"), None);
-        assert_eq!(db.retrieve(b"retry-count").expect("read count"), None);
+        assert_eq!(
+            db.retrieve(b"retry-state").expect("read state"),
+            Some(b"old-state".to_vec())
+        );
+        assert_eq!(
+            db.retrieve(b"retry-count").expect("read count"),
+            Some(b"old-count".to_vec())
+        );
+        assert_eq!(db.retrieve(b"status").expect("read status"), None);
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -47,6 +47,18 @@ impl TypedDB {
             .collect()
     }
 
+    /// Atomically store encoded values under domain-prefixed keys.
+    pub(crate) fn store_batch(
+        &self,
+        entries: impl IntoIterator<Item = (Vec<u8>, Vec<u8>, Vec<u8>)>,
+    ) -> Result<()> {
+        self.db.store_batch(
+            entries
+                .into_iter()
+                .map(|(prefix, key, value)| (self.prefixed_key(&prefix, &key), value)),
+        )
+    }
+
     /// Store encodable value
     pub fn store_encodable<V: Encode>(
         &self,

--- a/rust/main/hyperlane-base/src/db/storage_types.rs
+++ b/rust/main/hyperlane-base/src/db/storage_types.rs
@@ -1,9 +1,81 @@
 use std::io::{Read, Write};
 
 use hyperlane_core::{
-    Decode, Encode, HyperlaneProtocolError, InterchainGasExpenditure, InterchainGasPayment, H256,
-    U256,
+    Decode, Encode, HyperlaneProtocolError, InterchainGasExpenditure, InterchainGasPayment,
+    ReprepareReason, H256, U256,
 };
+use serde::{Deserialize, Serialize};
+
+const PENDING_MESSAGE_RETRY_STATE_VERSION: u8 = 1;
+
+/// Durable retry state for a pending message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PendingMessageRetryState {
+    version: u8,
+    /// Number of delivery attempts made.
+    pub retry_count: u32,
+    /// Absolute Unix timestamp for the next attempt.
+    pub next_attempt_at_millis: Option<u64>,
+    /// Original delay, used to bound backwards wall-clock skew.
+    pub retry_delay_millis: Option<u64>,
+    /// Retry reason used when the deadline was calculated.
+    pub reason: Option<ReprepareReason>,
+}
+
+impl PendingMessageRetryState {
+    /// Creates a versioned retry-state record.
+    pub fn new(
+        retry_count: u32,
+        next_attempt_at_millis: Option<u64>,
+        retry_delay_millis: Option<u64>,
+        reason: Option<ReprepareReason>,
+    ) -> Self {
+        Self {
+            version: PENDING_MESSAGE_RETRY_STATE_VERSION,
+            retry_count,
+            next_attempt_at_millis,
+            retry_delay_millis,
+            reason,
+        }
+    }
+}
+
+impl Encode for PendingMessageRetryState {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: Write,
+    {
+        #[allow(clippy::io_other_error)]
+        let serialized = serde_json::to_vec(self)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Failed to serialize"))?;
+        writer.write(&serialized)
+    }
+}
+
+impl Decode for PendingMessageRetryState {
+    fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+    where
+        R: Read,
+        Self: Sized,
+    {
+        let state: Self = serde_json::from_reader(reader).map_err(|err| {
+            #[allow(clippy::io_other_error)]
+            HyperlaneProtocolError::IoError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to deserialize retry state: {err}"),
+            ))
+        })?;
+        if state.version != PENDING_MESSAGE_RETRY_STATE_VERSION
+            || state.next_attempt_at_millis.is_some() != state.retry_delay_millis.is_some()
+        {
+            return Err(HyperlaneProtocolError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Unsupported or inconsistent pending-message retry state",
+            )));
+        }
+        Ok(state)
+    }
+}
 
 /// Subset of `InterchainGasPayment` excluding the message id which is stored in
 /// the key.

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
-use crate::db::{DbResult, HyperlaneDb, InterchainGasExpenditureData, InterchainGasPaymentData};
+use crate::db::{
+    DbResult, HyperlaneDb, InterchainGasExpenditureData, InterchainGasPaymentData,
+    PendingMessageRetryState,
+};
 use hyperlane_core::{
     identifiers::UniqueIdentifier, GasPaymentKey, HyperlaneDomain, HyperlaneMessage,
     HyperlaneProvider, InterchainGasPayment, InterchainGasPaymentMeta, MerkleTreeInsertion,
@@ -95,6 +98,15 @@ mockall::mock! {
             &self,
             message_id: &H256,
         ) -> DbResult<Option<u32>>;
+        fn store_pending_message_retry_state_by_message_id(
+            &self,
+            message_id: &H256,
+            state: &PendingMessageRetryState,
+        ) -> DbResult<()>;
+        fn retrieve_pending_message_retry_state_by_message_id(
+            &self,
+            message_id: &H256,
+        ) -> DbResult<Option<PendingMessageRetryState>>;
         fn store_merkle_tree_insertion_by_leaf_index(
             &self,
             leaf_index: &u32,

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -103,6 +103,12 @@ mockall::mock! {
             message_id: &H256,
             state: &PendingMessageRetryState,
         ) -> DbResult<()>;
+        fn store_pending_message_retry_state_and_status_by_message_id(
+            &self,
+            message_id: &H256,
+            state: &PendingMessageRetryState,
+            status: &PendingOperationStatus,
+        ) -> DbResult<()>;
         fn retrieve_pending_message_retry_state_by_message_id(
             &self,
             message_id: &H256,

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -164,7 +164,8 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
 
     /// Reset the number of attempts this operation has made, causing it to be
     /// retried immediately.
-    fn reset_attempts(&mut self);
+    /// Reset attempts durably. Returns false when the reset could not be persisted.
+    fn reset_attempts(&mut self) -> bool;
 
     /// Set the number of times this operation has been retried.
     fn set_retries(&mut self, retries: u32);

--- a/rust/main/hyperlane-core/src/traits/pending_operation/tests.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation/tests.rs
@@ -71,7 +71,9 @@ impl PendingOperation for MockQueueOperation {
     ) {
     }
     fn set_next_attempt_after(&mut self, _delay: Duration) {}
-    fn reset_attempts(&mut self) {}
+    fn reset_attempts(&mut self) -> bool {
+        true
+    }
     #[cfg(any(test, feature = "test-utils"))]
     fn set_retries(&mut self, _retries: u32) {}
     fn get_retries(&self) -> u32 {


### PR DESCRIPTION
## Summary

- persist retry count, wall-clock deadline, original delay, and retry reason in one versioned RocksDB value
- restore only the remaining delay after restart, run expired deadlines immediately, and cap backwards-clock skew at the original delay
- atomically dual-write the v1 retry state and legacy count, then reconcile both monotonically across rollback and roll-forward
- commit manual-retry status and its cleared deadline/count mirror in one batch

This is the durable-deadline slice only. Bounded notified operation queues remain a follow-up under #9384 because the ingress channel is shared by the DB loader and Relay API producers and needs a separate async backpressure change.

## Expected impact

Modeled restart scenario: restarting 59 minutes into a 60-minute retry delay now preserves about 1 minute remaining instead of resetting the full 60 minutes. That is a 98.3% reduction in restart-added wait, or 60x sooner eligibility, for that scenario. The restore error is bounded by timestamp precision and scheduling overhead (about 1 ms plus runtime scheduling); backwards wall-clock movement cannot delay longer than the originally persisted delay. No steady-state throughput or RPC reduction is claimed.

Canary metric: compare post-restart `hyperlane_submitter_queue_length{queue_name="prepare_queue"}` drain shape and `hyperlane_operations_processed_count` retry-stage bursts against a control relayer. Alert on a restart-correlated retry burst or queue dwell exceeding the persisted backoff window.

## Correctness and migration

- authoritative retry count is `max(v1.retry_count, legacy_count)`; `should_skip` uses that reconciled value
- v1 deadline and reason are used only when v1 carries the authoritative count; if an old binary advances legacy state during rollback, roll-forward discards the stale v1 deadline/reason and reconstructs from legacy count/status
- v1 state and its legacy count mirror commit in one RocksDB write batch; a failed batch writes neither key
- status normally remains a separate queue-persistence boundary; active v1 state carries its reason across that boundary
- manual retry is the exception: Manual status, cleared v1 deadline, and legacy count mirror commit in one batch
- lower retry-count assignment atomically replaces both retry records while retaining the existing reconstructed-backoff behavior
- expired deadlines are immediately eligible; malformed, unsupported, or absent v1 records fall back to legacy count/status

## Tests

- `cargo check -p relayer`
- `cargo fmt --check`
- `cargo clippy -p hyperlane-base -p relayer --lib -- -D warnings`
- `cargo test -p relayer msg::pending_message::test --lib` (16 passed)
- `cargo test -p relayer msg::op_queue::tests --lib` (9 passed)
- `cargo test -p relayer test_full_pending_message_persistence_flow --lib` (1 passed)
- `cargo test -p hyperlane-base failed_batch_preserves_all_old_values --lib` (1 passed)

Regressions cover rollback→roll-forward (`v1 < legacy`), historical opposite write order (`v1 > legacy`), atomic manual reset, lower retry-count reset, malformed and unsupported v1 fallback, deadline restore/expiry/skew, and failed-batch atomicity.

## Stack and review fixes

Stacked on #9169 (`a48d1eeaef`) so routing-cache metadata-wait lifecycle changes land before retry persistence. Equal-count old-binary manual retries now clear stale v1 deadlines on roll-forward, and a failed durable manual reset is surfaced by the retry endpoint instead of counted as matched. Focused regressions cover both paths. Exact head: `41584452e7`.

Part of #9384.

