### PR TITLE
feat(relayer): shadow scraper dispatch streams

### DIFF
--- a/.changeset/bright-relayers-shadow.md
+++ b/.changeset/bright-relayers-shadow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added relayer scraper WebSocket shadow-stream configuration.

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -9959,6 +9959,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "tokio-test",
+ "tokio-tungstenite 0.20.1",
  "tower 0.5.2",
  "tower-http",
  "tracing",
@@ -9966,6 +9967,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "typetag",
+ "url",
  "uuid 1.11.0",
 ]
 

--- a/rust/main/agents/relayer/Cargo.toml
+++ b/rust/main/agents/relayer/Cargo.toml
@@ -48,9 +48,11 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
 ] }
 tokio-metrics.workspace = true
+tokio-tungstenite.workspace = true
 tracing-futures.workspace = true
 tracing.workspace = true
 typetag.workspace = true
+url.workspace = true
 uuid.workspace = true
 tower-http = { version = "0.6", features = ["cors"] }
 

--- a/rust/main/agents/relayer/src/lib.rs
+++ b/rust/main/agents/relayer/src/lib.rs
@@ -9,6 +9,7 @@ mod merkle_tree;
 mod metrics;
 mod prover;
 mod relayer;
+mod scraper_websocket;
 mod settings;
 
 #[cfg(test)]

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -339,6 +339,7 @@ impl BaseAgent for Relayer {
             .map(|(domain, origin)| {
                 ScraperSource::new(
                     domain.name().to_owned(),
+                    origin.database.clone(),
                     domain.id(),
                     origin.chain_conf.addresses.mailbox,
                     origin.chain_conf.addresses.merkle_tree_hook,

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -44,6 +44,7 @@ use crate::relay_api::{
     handlers::{RateLimiter, ServerState as RelayApiState, TxHashCache},
     RelayApiMetrics,
 };
+use crate::scraper_websocket::{ScraperSource, ScraperWebSocketMonitor};
 use crate::{db_loader::DbLoader, relayer::origin::Origin, server::ENDPOINT_MESSAGES_QUEUE_SIZE};
 use crate::{
     db_loader::DbLoaderExt,
@@ -154,6 +155,7 @@ pub struct Relayer {
     agent_metrics: AgentMetrics,
     chain_metrics: ChainMetrics,
     runtime_metrics: RuntimeMetrics,
+    scraper_websocket_monitor: Option<ScraperWebSocketMonitor>,
     /// Tokio console server
     pub tokio_console_server: Option<console_subscriber::Server>,
 
@@ -332,6 +334,22 @@ impl BaseAgent for Relayer {
         }
         debug!(elapsed = ?start_entity_init.elapsed(), event = "initialized message contexts", "Relayer startup duration measurement");
 
+        let scraper_sources = origins
+            .iter()
+            .map(|(domain, origin)| {
+                ScraperSource::new(
+                    domain.name().to_owned(),
+                    domain.id(),
+                    origin.chain_conf.addresses.mailbox,
+                    origin.chain_conf.addresses.merkle_tree_hook,
+                )
+            })
+            .collect();
+        let scraper_websocket_monitor = settings
+            .websocket_url
+            .map(|url| ScraperWebSocketMonitor::new(url, scraper_sources, &core_metrics))
+            .transpose()?;
+
         debug!(elapsed = ?start.elapsed(), event = "fully initialized", "Relayer startup duration measurement");
 
         Ok(Self {
@@ -356,6 +374,7 @@ impl BaseAgent for Relayer {
             agent_metrics,
             chain_metrics,
             runtime_metrics,
+            scraper_websocket_monitor,
             tokio_console_server: Some(tokio_console_server),
             origins,
             destinations,
@@ -370,6 +389,18 @@ impl BaseAgent for Relayer {
         let mut tasks = vec![];
 
         let task_monitor = tokio_metrics::TaskMonitor::new();
+        if let Some(monitor) = self.scraper_websocket_monitor.take() {
+            let scraper_websocket = tokio::task::Builder::new()
+                .name("scraper_websocket_shadow")
+                .spawn(TaskMonitor::instrument(
+                    &task_monitor,
+                    monitor
+                        .run()
+                        .instrument(info_span!("ScraperWebSocketShadow")),
+                ))
+                .expect("spawning tokio task from Builder is infallible");
+            tasks.push(scraper_websocket);
+        }
         if let Some(tokio_console_server) = self.tokio_console_server.take() {
             let console_server = tokio::task::Builder::new()
                 .name("tokio_console_server")

--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -177,6 +177,7 @@ fn generate_test_relayer_settings(
         max_retries: 1,
         tx_id_indexing_enabled: true,
         igp_indexing_enabled: true,
+        websocket_url: None,
         relay_api_enabled: false,
         relay_api_port: None,
         relay_api_rate_limit_max_requests: None,

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -10,6 +10,7 @@ use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
     scraper_websocket::{
         EventMessage, ServerMessage, StringOrNumber, SubscribeMessage, SubscribeStream,
+        SubscribedStream,
     },
     CoreMetrics,
 };
@@ -27,6 +28,7 @@ const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
+const CROSS_STREAM_WINDOW: usize = 1_024;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
@@ -66,6 +68,101 @@ impl EventKind {
 enum SequenceResult {
     Accepted,
     Duplicate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ProtocolProjection {
+    block_number: u64,
+    message_id: H256,
+}
+
+#[derive(Debug, Default)]
+struct CrossStreamPair {
+    dispatch: Option<ProtocolProjection>,
+    merkle: Option<ProtocolProjection>,
+}
+
+impl CrossStreamPair {
+    fn complete(&self) -> bool {
+        self.dispatch.is_some() && self.merkle.is_some()
+    }
+
+    fn get(&self, kind: EventKind) -> Option<ProtocolProjection> {
+        match kind {
+            EventKind::Dispatch => self.dispatch,
+            EventKind::MerkleTreeInsertion => self.merkle,
+        }
+    }
+
+    fn get_mut(&mut self, kind: EventKind) -> &mut Option<ProtocolProjection> {
+        match kind {
+            EventKind::Dispatch => &mut self.dispatch,
+            EventKind::MerkleTreeInsertion => &mut self.merkle,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct CrossStreamState {
+    entries: HashMap<u32, BTreeMap<u32, CrossStreamPair>>,
+}
+
+impl CrossStreamState {
+    fn validate(
+        &mut self,
+        domain: u32,
+        sequence: u32,
+        kind: EventKind,
+        projection: ProtocolProjection,
+    ) -> Result<()> {
+        let entries = self.entries.entry(domain).or_default();
+
+        let mismatch = if let Some(pair) = entries.get(&sequence) {
+            if let Some(previous) = pair.get(kind) {
+                if previous != projection {
+                    bail!("Conflicting scraper projection at sequence {sequence}");
+                }
+            }
+            if let Some(counterpart) = pair.get(match kind {
+                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
+                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
+            }) {
+                if counterpart.message_id != projection.message_id {
+                    Some(format!(
+                        "Dispatch and Merkle message IDs differ at sequence {sequence}"
+                    ))
+                } else if counterpart.block_number != projection.block_number {
+                    Some(format!(
+                        "Dispatch and Merkle block numbers differ at sequence {sequence}"
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
+            let oldest_complete = entries
+                .first_key_value()
+                .is_some_and(|(_, pair)| pair.complete());
+            if !oldest_complete {
+                bail!("Scraper cross-stream skew exceeds {CROSS_STREAM_WINDOW} sequences");
+            }
+        }
+
+        if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
+            entries.pop_first();
+        }
+        let pair = entries.entry(sequence).or_default();
+        *pair.get_mut(kind) = Some(projection);
+        if let Some(mismatch) = mismatch {
+            bail!(mismatch);
+        }
+        Ok(())
+    }
 }
 
 type EventFingerprint = H256;
@@ -128,6 +225,7 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
+    cross_stream: CrossStreamState,
     cursors: HashMap<(u32, EventKind), StreamCursor>,
 }
 
@@ -147,7 +245,7 @@ impl StreamState {
             .parse::<u32>()
             .context("Invalid scraper event sequence")?;
 
-        let (kind, fingerprint) = match event.event_type.as_str() {
+        let (kind, fingerprint, projection) = match event.event_type.as_str() {
             DISPATCH_EVENT_TYPE => {
                 let data: DispatchEventData =
                     serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
@@ -201,6 +299,10 @@ impl StreamState {
                         origin_tx_hash.as_ref(),
                         data.time_created.as_bytes(),
                     ]),
+                    ProtocolProjection {
+                        block_number: origin_block_height,
+                        message_id,
+                    },
                 )
             }
             MERKLE_EVENT_TYPE => {
@@ -228,6 +330,10 @@ impl StreamState {
                         merkle_tree_hook.as_ref(),
                         message_id.as_ref(),
                     ]),
+                    ProtocolProjection {
+                        block_number,
+                        message_id,
+                    },
                 )
             }
             event_type => bail!("Unexpected scraper event type {event_type}"),
@@ -242,6 +348,8 @@ impl StreamState {
                 SequenceResult::Accepted
             }
         };
+        self.cross_stream
+            .validate(event.domain, sequence, kind, projection)?;
         Ok((kind, result))
     }
 }
@@ -261,13 +369,14 @@ impl HandshakeState {
         Ok(())
     }
 
-    fn subscribed(&mut self) -> Result<()> {
+    fn subscribed(&mut self, streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
         if !self.sent {
             bail!("Received subscribed before ready");
         }
         if self.confirmed {
             bail!("Received duplicate scraper-proxy subscribed message");
         }
+        validate_subscription(streams, domains)?;
         self.confirmed = true;
         Ok(())
     }
@@ -364,8 +473,8 @@ impl ScraperWebSocketMonitor {
                                 .await
                                 .context("Subscribing to relayer scraper-proxy streams")?;
                         }
-                        ServerMessage::Subscribed => {
-                            handshake.subscribed()?;
+                        ServerMessage::Subscribed { streams } => {
+                            handshake.subscribed(&streams, &self.domains())?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
@@ -414,7 +523,13 @@ impl ScraperWebSocketMonitor {
     }
 
     fn subscription(&self) -> Result<String> {
-        subscription(self.sources.keys().copied().collect())
+        subscription(self.domains())
+    }
+
+    fn domains(&self) -> Vec<u32> {
+        let mut domains = self.sources.keys().copied().collect::<Vec<_>>();
+        domains.sort_unstable();
+        domains
     }
 
     fn set_active(&self, active: bool) {
@@ -454,6 +569,21 @@ fn subscription(mut domains: Vec<u32>) -> Result<String> {
         message_type: "subscribe",
     })
     .context("Serializing relayer scraper-proxy subscription")
+}
+
+fn validate_subscription(streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
+    if streams.len() != 2 {
+        bail!("Scraper-proxy confirmed an unexpected number of streams");
+    }
+    for (stream, event_type) in streams.iter().zip([DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]) {
+        if stream.event_type != event_type
+            || stream.cursors.is_some()
+            || stream.domains.as_deref() != Some(domains)
+        {
+            bail!("Scraper-proxy subscription confirmation does not match request");
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Deserialize)]
@@ -558,8 +688,8 @@ mod tests {
         }
     }
 
-    fn dispatch_data(nonce: u32, body: &[u8]) -> serde_json::Value {
-        let message = HyperlaneMessage {
+    fn dispatch_message(nonce: u32, body: &[u8]) -> HyperlaneMessage {
+        HyperlaneMessage {
             version: 3,
             nonce,
             origin: 5,
@@ -567,7 +697,11 @@ mod tests {
             destination: 6,
             recipient: H256::from_low_u64_be(4),
             body: body.to_vec(),
-        };
+        }
+    }
+
+    fn dispatch_data(nonce: u32, body: &[u8]) -> serde_json::Value {
+        let message = dispatch_message(nonce, body);
         serde_json::json!({
             "destination_domain": message.destination,
             "id": "42",
@@ -586,13 +720,33 @@ mod tests {
     }
 
     fn merkle_data(index: u32, hook: H256) -> serde_json::Value {
+        merkle_data_for(index, hook, H256::from_low_u64_be(7), 101)
+    }
+
+    fn merkle_data_for(
+        index: u32,
+        hook: H256,
+        message_id: H256,
+        block_number: u64,
+    ) -> serde_json::Value {
         serde_json::json!({
-            "block_number": "101",
+            "block_number": block_number.to_string(),
             "domain": 5,
             "leaf_index": index,
             "merkle_tree_hook": format!("{hook:#x}"),
-            "message_id": format!("{:#x}", H256::from_low_u64_be(7)),
+            "message_id": format!("{message_id:#x}"),
         })
+    }
+
+    fn subscribed_streams(domains: &[u32]) -> Vec<SubscribedStream> {
+        [DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]
+            .into_iter()
+            .map(|event_type| SubscribedStream {
+                cursors: None,
+                domains: Some(domains.to_vec()),
+                event_type: event_type.to_owned(),
+            })
+            .collect()
     }
 
     #[test]
@@ -744,16 +898,145 @@ mod tests {
     }
 
     #[test]
+    fn correlates_dispatch_and_merkle_projection() {
+        let mut state = StreamState::default();
+        let message = dispatch_message(7, b"payload");
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources(),
+            )
+            .expect("dispatch should validate");
+        state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 100),
+                ),
+                &sources(),
+            )
+            .expect("matching Merkle insertion should validate");
+    }
+
+    #[test]
+    fn rejects_cross_stream_message_and_block_mismatches() {
+        let message = dispatch_message(7, b"payload");
+        let mut wrong_message = StreamState::default();
+        wrong_message
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources(),
+            )
+            .expect("dispatch should validate");
+        assert!(wrong_message
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(7, H256::from_low_u64_be(2), H256::from_low_u64_be(8), 100,),
+                ),
+                &sources(),
+            )
+            .expect_err("message mismatch must reject")
+            .to_string()
+            .contains("message IDs differ"));
+
+        let mut wrong_block = StreamState::default();
+        wrong_block
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources(),
+            )
+            .expect("dispatch should validate");
+        assert!(wrong_block
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 101),
+                ),
+                &sources(),
+            )
+            .expect_err("block mismatch must reject")
+            .to_string()
+            .contains("block numbers differ"));
+    }
+
+    #[test]
+    fn bounds_unmatched_cross_stream_projections() {
+        let projection = ProtocolProjection {
+            block_number: 100,
+            message_id: H256::from_low_u64_be(7),
+        };
+        let mut state = CrossStreamState::default();
+        for sequence in 0..CROSS_STREAM_WINDOW as u32 {
+            state
+                .validate(5, sequence, EventKind::Dispatch, projection)
+                .expect("projection inside window");
+        }
+        assert_eq!(state.entries[&5].len(), CROSS_STREAM_WINDOW);
+        assert!(state
+            .validate(
+                5,
+                CROSS_STREAM_WINDOW as u32,
+                EventKind::Dispatch,
+                projection,
+            )
+            .expect_err("unmatched projection must not be evicted")
+            .to_string()
+            .contains("skew exceeds"));
+
+        state
+            .validate(5, 0, EventKind::MerkleTreeInsertion, projection)
+            .expect("oldest projection should complete");
+        state
+            .validate(
+                5,
+                CROSS_STREAM_WINDOW as u32,
+                EventKind::Dispatch,
+                projection,
+            )
+            .expect("completed oldest projection should be evicted");
+        assert_eq!(state.entries[&5].len(), CROSS_STREAM_WINDOW);
+        assert!(!state.entries[&5].contains_key(&0));
+        assert!(state.entries[&5].contains_key(&(CROSS_STREAM_WINDOW as u32)));
+    }
+
+    #[test]
     fn enforces_subscription_handshake_order() {
         let mut handshake = HandshakeState::default();
+        let domains = [5];
+        let streams = subscribed_streams(&domains);
         assert!(handshake.event().is_err());
-        assert!(handshake.subscribed().is_err());
+        assert!(handshake.subscribed(&streams, &domains).is_err());
         handshake.ready().expect("ready");
         assert!(handshake.event().is_err());
-        handshake.subscribed().expect("subscribed");
+        handshake
+            .subscribed(&streams, &domains)
+            .expect("subscribed");
         handshake.event().expect("event after confirmation");
-        assert!(handshake.subscribed().is_err());
+        assert!(handshake.subscribed(&streams, &domains).is_err());
         assert!(handshake.ready().is_err());
+    }
+
+    #[test]
+    fn rejects_subscription_confirmation_mismatch() {
+        let domains = [5];
+        for streams in [
+            subscribed_streams(&[9]),
+            vec![SubscribedStream {
+                cursors: None,
+                domains: Some(domains.to_vec()),
+                event_type: DISPATCH_EVENT_TYPE.to_owned(),
+            }],
+            subscribed_streams(&domains).into_iter().rev().collect(),
+        ] {
+            let mut handshake = HandshakeState::default();
+            handshake.ready().expect("ready");
+            assert!(handshake.subscribed(&streams, &domains).is_err());
+            assert!(!handshake.confirmed);
+        }
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -544,10 +544,10 @@ impl ScraperWebSocketMonitor {
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
         for source in sources.values() {
-            active.with_label_values(&[&source.chain]).set(0);
+            active.with_label_values(&[source.chain.as_str()]).set(0);
             for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
                 caught_up
-                    .with_label_values(&[&source.chain, kind.label()])
+                    .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
             }
         }
@@ -719,7 +719,9 @@ impl ScraperWebSocketMonitor {
     fn set_active(&self, active: bool) {
         let value = i64::from(active);
         for source in self.sources.values() {
-            self.active.with_label_values(&[&source.chain]).set(value);
+            self.active
+                .with_label_values(&[source.chain.as_str()])
+                .set(value);
         }
     }
 
@@ -733,7 +735,7 @@ impl ScraperWebSocketMonitor {
 
     fn set_source_caught_up(&self, source: &ScraperSource, kind: EventKind, caught_up: bool) {
         self.caught_up
-            .with_label_values(&[&source.chain, kind.label()])
+            .with_label_values(&[source.chain.as_str(), kind.label()])
             .set(i64::from(caught_up));
     }
 

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,6 +1,9 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 
 use eyre::{bail, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
@@ -10,9 +13,10 @@ use hyperlane_base::{
     },
     CoreMetrics,
 };
-use hyperlane_core::{bytes_to_address, H256};
+use hyperlane_core::{bytes_to_address, bytes_to_h512, HyperlaneMessage, H256, H512};
 use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::Deserialize;
+use sha3::{Digest, Keccak256};
 use tokio::time::{sleep, timeout, Instant};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
@@ -22,6 +26,7 @@ const DISPATCH_EVENT_TYPE: &str = "dispatch";
 const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
+const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
@@ -63,6 +68,57 @@ enum SequenceResult {
     Duplicate,
 }
 
+type EventFingerprint = H256;
+
+#[derive(Debug)]
+struct StreamCursor {
+    fingerprints: BTreeMap<u32, EventFingerprint>,
+    next_sequence: u32,
+}
+
+impl StreamCursor {
+    fn new(sequence: u32, fingerprint: EventFingerprint) -> Result<Self> {
+        let mut fingerprints = BTreeMap::new();
+        fingerprints.insert(sequence, fingerprint);
+        Ok(Self {
+            fingerprints,
+            next_sequence: sequence
+                .checked_add(1)
+                .context("Scraper event sequence exhausted")?,
+        })
+    }
+
+    fn validate(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<SequenceResult> {
+        if sequence < self.next_sequence {
+            return match self.fingerprints.get(&sequence) {
+                Some(previous) if previous == &fingerprint => Ok(SequenceResult::Duplicate),
+                Some(_) => bail!("Conflicting scraper event at sequence {sequence}"),
+                None => bail!(
+                    "Scraper event sequence {sequence} is older than the retained duplicate window"
+                ),
+            };
+        }
+        if sequence > self.next_sequence {
+            return Err(StreamGap {
+                expected: self.next_sequence,
+                received: sequence,
+            }
+            .into());
+        }
+
+        let next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .context("Scraper event sequence exhausted")?;
+        self.fingerprints.insert(sequence, fingerprint);
+        while self.fingerprints.len() > DUPLICATE_FINGERPRINT_WINDOW {
+            self.fingerprints.pop_first();
+        }
+        self.next_sequence = next_sequence;
+        Ok(SequenceResult::Accepted)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("Scraper stream gap: expected sequence {expected}, received {received}")]
 struct StreamGap {
@@ -72,7 +128,7 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
-    next_sequences: HashMap<(u32, EventKind), u32>,
+    cursors: HashMap<(u32, EventKind), StreamCursor>,
 }
 
 impl StreamState {
@@ -91,20 +147,61 @@ impl StreamState {
             .parse::<u32>()
             .context("Invalid scraper event sequence")?;
 
-        let kind = match event.event_type.as_str() {
+        let (kind, fingerprint) = match event.event_type.as_str() {
             DISPATCH_EVENT_TYPE => {
                 let data: DispatchEventData =
                     serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
                 if data.origin_domain != event.domain {
                     bail!("Dispatch payload domain does not match event envelope");
                 }
-                if parse_address(&data.origin_mailbox)? != source.mailbox {
+                let origin_mailbox = parse_address(&data.origin_mailbox)?;
+                if origin_mailbox != source.mailbox {
                     bail!("Dispatch event mailbox does not match configured mailbox");
                 }
-                if data.nonce.as_u32("dispatch nonce")? != sequence {
+                let nonce = data.nonce.as_u32("dispatch nonce")?;
+                if nonce != sequence {
                     bail!("Dispatch event nonce does not match stream sequence");
                 }
-                EventKind::Dispatch
+                let body = parse_hex(
+                    data.msg_body
+                        .as_deref()
+                        .context("Dispatch event omitted message body")?,
+                )?;
+                let message = HyperlaneMessage {
+                    version: 3,
+                    nonce,
+                    origin: data.origin_domain,
+                    sender: parse_address(&data.sender)?,
+                    destination: data.destination_domain,
+                    recipient: parse_address(&data.recipient)?,
+                    body,
+                };
+                let message_id = parse_h256(&data.msg_id, "dispatch message ID")?;
+                if message.id() != message_id {
+                    bail!("Dispatch message ID does not match reconstructed message");
+                }
+                if data.time_created.is_empty() {
+                    bail!("Dispatch event omitted creation time");
+                }
+                let origin_block_hash = parse_h256(&data.origin_block_hash, "origin block hash")?;
+                let origin_block_height = data.origin_block_height.as_u64("origin block height")?;
+                let origin_tx_hash = parse_h512(&data.origin_tx_hash)?;
+                let row_id = data.id.as_u64("dispatch row ID")?;
+                let row_id_bytes = row_id.to_be_bytes();
+                let origin_block_height_bytes = origin_block_height.to_be_bytes();
+                (
+                    EventKind::Dispatch,
+                    event_fingerprint(&[
+                        b"dispatch",
+                        &row_id_bytes,
+                        message_id.as_ref(),
+                        origin_block_hash.as_ref(),
+                        &origin_block_height_bytes,
+                        origin_mailbox.as_ref(),
+                        origin_tx_hash.as_ref(),
+                        data.time_created.as_bytes(),
+                    ]),
+                )
             }
             MERKLE_EVENT_TYPE => {
                 let data: MerkleEventData = serde_json::from_value(event.data)
@@ -112,44 +209,74 @@ impl StreamState {
                 if data.domain != event.domain {
                     bail!("Merkle payload domain does not match event envelope");
                 }
-                if parse_address(&data.merkle_tree_hook)? != source.merkle_tree_hook {
+                let merkle_tree_hook = parse_address(&data.merkle_tree_hook)?;
+                if merkle_tree_hook != source.merkle_tree_hook {
                     bail!("Merkle event hook does not match configured hook");
                 }
-                if data.leaf_index.as_u32("Merkle leaf index")? != sequence {
+                let leaf_index = data.leaf_index.as_u32("Merkle leaf index")?;
+                if leaf_index != sequence {
                     bail!("Merkle leaf index does not match stream sequence");
                 }
-                EventKind::MerkleTreeInsertion
+                let block_number = data.block_number.as_u64("Merkle block number")?;
+                let block_number_bytes = block_number.to_be_bytes();
+                let message_id = parse_h256(&data.message_id, "Merkle message ID")?;
+                (
+                    EventKind::MerkleTreeInsertion,
+                    event_fingerprint(&[
+                        b"merkle_tree_insertion",
+                        &block_number_bytes,
+                        merkle_tree_hook.as_ref(),
+                        message_id.as_ref(),
+                    ]),
+                )
             }
             event_type => bail!("Unexpected scraper event type {event_type}"),
         };
 
         let key = (event.domain, kind);
-        let result = match self.next_sequences.get_mut(&key) {
+        let result = match self.cursors.get_mut(&key) {
+            Some(cursor) => cursor.validate(sequence, fingerprint)?,
             None => {
-                self.next_sequences.insert(
-                    key,
-                    sequence
-                        .checked_add(1)
-                        .context("Scraper event sequence exhausted")?,
-                );
+                self.cursors
+                    .insert(key, StreamCursor::new(sequence, fingerprint)?);
                 SequenceResult::Accepted
-            }
-            Some(next_sequence) if sequence < *next_sequence => SequenceResult::Duplicate,
-            Some(next_sequence) if sequence == *next_sequence => {
-                *next_sequence = next_sequence
-                    .checked_add(1)
-                    .context("Scraper event sequence exhausted")?;
-                SequenceResult::Accepted
-            }
-            Some(next_sequence) => {
-                return Err(StreamGap {
-                    expected: *next_sequence,
-                    received: sequence,
-                }
-                .into())
             }
         };
         Ok((kind, result))
+    }
+}
+
+#[derive(Debug, Default)]
+struct HandshakeState {
+    confirmed: bool,
+    sent: bool,
+}
+
+impl HandshakeState {
+    fn ready(&mut self) -> Result<()> {
+        if self.sent {
+            bail!("Received duplicate scraper-proxy ready message");
+        }
+        self.sent = true;
+        Ok(())
+    }
+
+    fn subscribed(&mut self) -> Result<()> {
+        if !self.sent {
+            bail!("Received subscribed before ready");
+        }
+        if self.confirmed {
+            bail!("Received duplicate scraper-proxy subscribed message");
+        }
+        self.confirmed = true;
+        Ok(())
+    }
+
+    fn event(&self) -> Result<()> {
+        if !self.confirmed {
+            bail!("Received scraper event before subscription confirmation");
+        }
+        Ok(())
     }
 }
 
@@ -193,9 +320,10 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
+        let mut state = StreamState::default();
         loop {
             self.set_active(false);
-            match self.stream().await {
+            match self.stream(&mut state).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
                     ?err,
@@ -207,13 +335,12 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn stream(&self) -> Result<()> {
+    async fn stream(&self, state: &mut StreamState) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
-        let mut subscribed = false;
-        let mut state = StreamState::default();
+        let mut handshake = HandshakeState::default();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -231,23 +358,19 @@ impl ScraperWebSocketMonitor {
                         .context("Parsing relayer scraper-proxy WebSocket message")?;
                     match message {
                         ServerMessage::Ready => {
-                            if subscribed {
-                                bail!("Received duplicate scraper-proxy ready message");
-                            }
+                            handshake.ready()?;
                             socket
                                 .send(Message::Text(self.subscription()?))
                                 .await
                                 .context("Subscribing to relayer scraper-proxy streams")?;
-                            subscribed = true;
                         }
                         ServerMessage::Subscribed => {
-                            if !subscribed {
-                                bail!("Received subscribed before ready");
-                            }
+                            handshake.subscribed()?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
                         ServerMessage::Event(event) => {
+                            handshake.event()?;
                             let domain = event.domain;
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
@@ -334,26 +457,68 @@ fn subscription(mut domains: Vec<u32>) -> Result<String> {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DispatchEventData {
+    destination_domain: u32,
+    id: StringOrNumber,
+    msg_body: Option<String>,
+    msg_id: String,
     nonce: StringOrNumber,
+    origin_block_hash: String,
+    origin_block_height: StringOrNumber,
     origin_domain: u32,
     origin_mailbox: String,
+    origin_tx_hash: String,
+    recipient: String,
+    sender: String,
+    time_created: String,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct MerkleEventData {
+    block_number: StringOrNumber,
     domain: u32,
     leaf_index: StringOrNumber,
     merkle_tree_hook: String,
+    message_id: String,
 }
 
 fn parse_address(value: &str) -> Result<H256> {
+    bytes_to_address(parse_hex(value)?).context("Invalid scraper event address")
+}
+
+fn parse_h256(value: &str, field: &str) -> Result<H256> {
+    let bytes = parse_hex(value)?;
+    if bytes.len() != 32 {
+        bail!("Invalid {field} length {}", bytes.len());
+    }
+    Ok(H256::from_slice(&bytes))
+}
+
+fn parse_h512(value: &str) -> Result<H512> {
+    let bytes = parse_hex(value)?;
+    if !matches!(bytes.len(), 32 | 64) {
+        bail!("Invalid origin transaction hash length {}", bytes.len());
+    }
+    Ok(bytes_to_h512(&bytes))
+}
+
+fn event_fingerprint(fields: &[&[u8]]) -> H256 {
+    let mut hasher = Keccak256::new();
+    for field in fields {
+        hasher.update((field.len() as u64).to_be_bytes());
+        hasher.update(field);
+    }
+    H256::from_slice(&hasher.finalize())
+}
+
+fn parse_hex(value: &str) -> Result<Vec<u8>> {
     let value = value
         .strip_prefix("0x")
         .or_else(|| value.strip_prefix("\\x"))
         .unwrap_or(value);
-    bytes_to_address(hex::decode(value).context("Invalid hexadecimal scraper event address")?)
-        .context("Invalid scraper event address")
+    hex::decode(value).context("Invalid hexadecimal scraper event field")
 }
 
 fn event_label(event_type: &str) -> &'static str {
@@ -393,52 +558,139 @@ mod tests {
         }
     }
 
-    #[test]
-    fn accepts_contiguous_dispatch_and_rejects_gap() {
-        let sources = sources();
-        let mut state = StreamState::default();
-        let data = |nonce| {
-            serde_json::json!({
-                "nonce": nonce,
-                "origin_domain": 5,
-                "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(1)),
-            })
+    fn dispatch_data(nonce: u32, body: &[u8]) -> serde_json::Value {
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce,
+            origin: 5,
+            sender: H256::from_low_u64_be(3),
+            destination: 6,
+            recipient: H256::from_low_u64_be(4),
+            body: body.to_vec(),
         };
+        serde_json::json!({
+            "destination_domain": message.destination,
+            "id": "42",
+            "msg_body": format!("\\x{}", hex::encode(&message.body)),
+            "msg_id": format!("{:#x}", message.id()),
+            "nonce": nonce,
+            "origin_block_hash": format!("{:#x}", H256::from_low_u64_be(5)),
+            "origin_block_height": "100",
+            "origin_domain": message.origin,
+            "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(1)),
+            "origin_tx_hash": format!("\\x{}", hex::encode([6_u8; 32])),
+            "recipient": format!("{:#x}", message.recipient),
+            "sender": format!("{:#x}", message.sender),
+            "time_created": "2026-08-30T00:00:00.000Z",
+        })
+    }
+
+    fn merkle_data(index: u32, hook: H256) -> serde_json::Value {
+        serde_json::json!({
+            "block_number": "101",
+            "domain": 5,
+            "leaf_index": index,
+            "merkle_tree_hook": format!("{hook:#x}"),
+            "message_id": format!("{:#x}", H256::from_low_u64_be(7)),
+        })
+    }
+
+    #[test]
+    fn preserves_sequence_across_reconnects() {
+        let sources = sources();
+        let mut contiguous = StreamState::default();
 
         assert_eq!(
-            state
-                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
+            contiguous
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                    &sources,
+                )
                 .expect("first event"),
             (EventKind::Dispatch, SequenceResult::Accepted)
         );
         assert_eq!(
-            state
-                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
-                .expect("duplicate event"),
+            contiguous
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                    &sources,
+                )
+                .expect("duplicate event after reconnect"),
             (EventKind::Dispatch, SequenceResult::Duplicate)
         );
-        assert!(state
-            .validate(event(DISPATCH_EVENT_TYPE, 9, data(9)), &sources)
+        assert_eq!(
+            contiguous
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"eight")),
+                    &sources,
+                )
+                .expect("next event after reconnect"),
+            (EventKind::Dispatch, SequenceResult::Accepted)
+        );
+
+        let mut gapped = StreamState::default();
+        gapped
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("first event before reconnect");
+        assert!(gapped
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
+                &sources,
+            )
             .expect_err("gap must reject")
             .to_string()
             .contains("expected sequence 8"));
     }
 
     #[test]
-    fn rejects_wrong_dispatch_mailbox() {
-        let error = StreamState::default()
+    fn rejects_conflicting_duplicate_dispatch() {
+        let sources = sources();
+        let mut state = StreamState::default();
+        state
             .validate(
-                event(
-                    DISPATCH_EVENT_TYPE,
-                    7,
-                    serde_json::json!({
-                        "nonce": 7,
-                        "origin_domain": 5,
-                        "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(3)),
-                    }),
-                ),
-                &sources(),
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"original")),
+                &sources,
             )
+            .expect("first event");
+
+        assert!(state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"conflict")),
+                &sources,
+            )
+            .expect_err("conflicting duplicate must reject")
+            .to_string()
+            .contains("Conflicting scraper event"));
+    }
+
+    #[test]
+    fn rejects_invalid_dispatch_payload() {
+        let mut bad_body = dispatch_data(7, b"original");
+        bad_body["msg_body"] = serde_json::json!("\\x00");
+        assert!(StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_body), &sources())
+            .expect_err("message ID mismatch must reject")
+            .to_string()
+            .contains("message ID"));
+
+        let mut bad_sender = dispatch_data(7, b"original");
+        bad_sender["sender"] = serde_json::json!("0x12");
+        assert!(StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_sender), &sources())
+            .expect_err("invalid sender must reject")
+            .to_string()
+            .contains("address"));
+    }
+
+    #[test]
+    fn rejects_wrong_dispatch_mailbox() {
+        let mut data = dispatch_data(7, b"payload");
+        data["origin_mailbox"] = serde_json::json!(format!("{:#x}", H256::from_low_u64_be(3)));
+        let error = StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, data), &sources())
             .expect_err("wrong mailbox must reject");
 
         assert!(error.to_string().contains("configured mailbox"));
@@ -452,17 +704,56 @@ mod tests {
                 event(
                     MERKLE_EVENT_TYPE,
                     1,
-                    serde_json::json!({
-                        "domain": 5,
-                        "leaf_index": "1",
-                        "merkle_tree_hook": format!("{:#x}", H256::from_low_u64_be(3)),
-                    }),
+                    merkle_data(1, H256::from_low_u64_be(3)),
                 ),
                 &sources(),
             )
             .expect_err("wrong hook must reject");
 
         assert!(error.to_string().contains("configured hook"));
+    }
+
+    #[test]
+    fn validates_merkle_payload_fields() {
+        let mut data = merkle_data(1, H256::from_low_u64_be(2));
+        data["message_id"] = serde_json::json!("0x12");
+        assert!(StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, data), &sources())
+            .expect_err("invalid message ID must reject")
+            .to_string()
+            .contains("Merkle message ID"));
+    }
+
+    #[test]
+    fn rejects_fields_outside_wire_projection() {
+        let mut dispatch = dispatch_data(7, b"payload");
+        dispatch["time_updated"] = serde_json::json!("2026-08-30T00:00:01.000Z");
+        assert!(StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, dispatch), &sources())
+            .expect_err("unprojected dispatch field must reject")
+            .to_string()
+            .contains("Invalid dispatch event payload"));
+
+        let mut merkle = merkle_data(1, H256::from_low_u64_be(2));
+        merkle["id"] = serde_json::json!(42);
+        assert!(StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, merkle), &sources())
+            .expect_err("unprojected Merkle field must reject")
+            .to_string()
+            .contains("Invalid Merkle tree insertion payload"));
+    }
+
+    #[test]
+    fn enforces_subscription_handshake_order() {
+        let mut handshake = HandshakeState::default();
+        assert!(handshake.event().is_err());
+        assert!(handshake.subscribed().is_err());
+        handshake.ready().expect("ready");
+        assert!(handshake.event().is_err());
+        handshake.subscribed().expect("subscribed");
+        handshake.event().expect("event after confirmation");
+        assert!(handshake.subscribed().is_err());
+        assert!(handshake.ready().is_err());
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1012,6 +1012,26 @@ fn caught_up_baselines(
     ))
 }
 
+fn validate_fresh_empty_stream_starts(state: &StreamState, domain: u32) -> Result<()> {
+    for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+        let Some(cursor) = state.cursors.get(&(domain, kind)) else {
+            continue;
+        };
+        let first = cursor
+            .fingerprints
+            .first_key_value()
+            .map(|(sequence, _)| *sequence)
+            .context("Fresh scraper stream cursor omitted its first fingerprint")?;
+        if first != 0 {
+            bail!(
+                "Fresh empty {} scraper stream started at sequence {first}, expected 0",
+                kind.label()
+            );
+        }
+    }
+    Ok(())
+}
+
 fn sequenced_persistence_ready(
     plan: &SequencedReplayPlan,
     caught_up: &HashMap<(u32, EventKind), i64>,
@@ -1034,9 +1054,7 @@ fn sequenced_persistence_ready(
     if state.correlation_next.contains_key(&domain) {
         return Ok(true);
     }
-    if sequence != 0 {
-        bail!("Fresh empty scraper stream started at sequence {sequence}, expected 0");
-    }
+    validate_fresh_empty_stream_starts(state, domain)?;
     Ok(state.cross_stream.complete(domain, sequence))
 }
 
@@ -1092,6 +1110,9 @@ fn source_caught_up(
     if !correlation_required {
         if dispatch != merkle {
             bail!("Fresh scraper caught-up baselines differ: dispatch {dispatch}, Merkle {merkle}");
+        }
+        if dispatch < 0 {
+            validate_fresh_empty_stream_starts(state, domain)?;
         }
         return Ok(true);
     }
@@ -1688,7 +1709,6 @@ mod tests {
             source.correlation_cursor().expect("correlation cursor"),
             None
         );
-
         state
             .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
             .expect("set fresh Merkle baseline");
@@ -1858,6 +1878,20 @@ mod tests {
             source.correlation_cursor().expect("correlation cursor"),
             None
         );
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                &sources,
+            )
+            .expect("second dispatch event");
+        assert!(
+            !sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
+                .expect("persistence readiness")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
 
         state
             .validate(
@@ -1880,8 +1914,8 @@ mod tests {
         assert_eq!(
             cursors,
             [
-                (EventKind::Dispatch, 0),
                 (EventKind::MerkleTreeInsertion, 0),
+                (EventKind::Dispatch, 1),
             ]
         );
         for (kind, sequence) in cursors {
@@ -1905,7 +1939,7 @@ mod tests {
 
         assert_eq!(
             source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            Some(0)
+            Some(1)
         );
         assert_eq!(
             source
@@ -1919,10 +1953,19 @@ mod tests {
         );
         state
             .validate(
-                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                event(
+                    MERKLE_EVENT_TYPE,
+                    1,
+                    merkle_data_for(
+                        1,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(1, b"one").id(),
+                        100,
+                    ),
+                ),
                 &sources,
             )
-            .expect("next dispatch event");
+            .expect("next Merkle event");
         assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
             .expect("initialized persistence readiness"));
         let reconnect_plan = replay_plan(&sources);
@@ -1936,6 +1979,90 @@ mod tests {
         .expect("subscription JSON");
         assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "-1");
         assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "-1");
+    }
+
+    #[test]
+    fn fresh_empty_merkle_can_advance_while_waiting_for_dispatch() {
+        let sources = sources();
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut state = replay_state(&plan);
+        for sequence in 0..=1 {
+            state
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(
+                            sequence,
+                            H256::from_low_u64_be(2),
+                            dispatch_message(sequence, &[sequence as u8]).id(),
+                            100,
+                        ),
+                    ),
+                    &sources,
+                )
+                .expect("Merkle event while dispatch is pending");
+            assert!(
+                !sequenced_persistence_ready(&plan, &caught_up, &state, 5, sequence)
+                    .expect("persistence readiness")
+            );
+        }
+
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, &[0])),
+                &sources,
+            )
+            .expect("first dispatch event");
+        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
+            .expect("persistence readiness"));
+        assert_eq!(
+            sequenced_cursor_write_order(&state, 5).expect("cursor write order"),
+            [
+                (EventKind::Dispatch, 0),
+                (EventKind::MerkleTreeInsertion, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn fresh_empty_peer_marker_rejects_staged_nonzero_start() {
+        for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+            let sources = sources();
+            let plan = replay_plan(&sources);
+            let mut state = replay_state(&plan);
+            let first = match kind {
+                EventKind::Dispatch => event(DISPATCH_EVENT_TYPE, 5, dispatch_data(5, &[5])),
+                EventKind::MerkleTreeInsertion => event(
+                    MERKLE_EVENT_TYPE,
+                    5,
+                    merkle_data_for(
+                        5,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(5, &[5]).id(),
+                        100,
+                    ),
+                ),
+            };
+            state
+                .validate(first, &sources)
+                .expect("staged first nonzero event");
+            let peer = match kind {
+                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
+                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
+            };
+            let mut caught_up = HashMap::from([((5, kind), -1)]);
+            assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one empty marker"));
+            caught_up.insert((5, peer), -1);
+            assert!(source_caught_up(false, &caught_up, &state, 5)
+                .expect_err("peer marker must reject staged nonzero start")
+                .to_string()
+                .contains("expected 0"));
+        }
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -103,6 +103,13 @@ impl EventKind {
         }
     }
 
+    fn counterpart(self) -> Self {
+        match self {
+            Self::Dispatch => Self::MerkleTreeInsertion,
+            Self::MerkleTreeInsertion => Self::Dispatch,
+        }
+    }
+
     fn from_label(label: &str) -> Result<Self> {
         match label {
             DISPATCH_EVENT_TYPE => Ok(Self::Dispatch),
@@ -662,7 +669,13 @@ impl ScraperWebSocketMonitor {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
-                                    self.record(domain, kind.label(), result)
+                                    self.record(domain, kind.label(), result);
+                                    self.update_source_caught_up(
+                                        state,
+                                        &correlation_required,
+                                        &caught_up,
+                                        domain,
+                                    )?;
                                 }
                                 Err(err) => {
                                     let result = if err.downcast_ref::<StreamGap>().is_some() {
@@ -714,22 +727,12 @@ impl ScraperWebSocketMonitor {
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            let counterpart = match kind {
-                                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
-                                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
-                            };
-                            if caught_up.get(&(domain, counterpart)) == Some(&sequence) {
-                                let correlation_complete = correlation_ready(
-                                    correlation_required.contains(&domain),
-                                    state,
-                                    domain,
-                                    sequence,
-                                )?;
-                                if correlation_complete {
-                                    self.set_source_caught_up(source, kind, true);
-                                    self.set_source_caught_up(source, counterpart, true);
-                                }
-                            }
+                            self.update_source_caught_up(
+                                state,
+                                &correlation_required,
+                                &caught_up,
+                                domain,
+                            )?;
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -777,6 +780,31 @@ impl ScraperWebSocketMonitor {
             .set(i64::from(caught_up));
     }
 
+    fn update_source_caught_up(
+        &self,
+        state: &StreamState,
+        correlation_required: &HashSet<u32>,
+        caught_up: &HashMap<(u32, EventKind), i64>,
+        domain: u32,
+    ) -> Result<()> {
+        if !source_caught_up(
+            correlation_required.contains(&domain),
+            caught_up,
+            state,
+            domain,
+        )? {
+            return Ok(());
+        }
+        let source = self
+            .sources
+            .get(&domain)
+            .context("Validated scraper source is missing")?;
+        for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+            self.set_source_caught_up(source, kind, true);
+        }
+        Ok(())
+    }
+
     fn record(&self, domain: u32, event_type: &str, result: &str) {
         let chain = self
             .sources
@@ -799,14 +827,7 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     let cursors = |kind| -> Result<Vec<SequenceCursor>> {
         sources
             .iter()
-            .map(|source| {
-                Ok(SequenceCursor {
-                    address: format!("{:#x}", source.address(kind)),
-                    allow_replay: Some(true),
-                    after_sequence: source.cursor(kind)?.map(replay_after_sequence),
-                    domain: source.domain,
-                })
-            })
+            .map(|source| sequence_cursor(source, kind))
             .collect()
     };
     serde_json::to_string(&SubscribeMessage {
@@ -825,6 +846,19 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
         message_type: "subscribe",
     })
     .context("Serializing relayer scraper-proxy subscription")
+}
+
+fn sequence_cursor(source: &ScraperSource, kind: EventKind) -> Result<SequenceCursor> {
+    let replay_from = match source.cursor(kind)? {
+        Some(sequence) => Some(sequence),
+        None => source.cursor(kind.counterpart())?,
+    };
+    Ok(SequenceCursor {
+        address: format!("{:#x}", source.address(kind)),
+        allow_replay: Some(true),
+        after_sequence: replay_from.map(replay_after_sequence),
+        domain: source.domain,
+    })
 }
 
 fn replay_after_sequence(sequence: u32) -> String {
@@ -851,6 +885,39 @@ fn correlation_ready(
     ))
 }
 
+fn source_caught_up(
+    correlation_required: bool,
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    state: &StreamState,
+    domain: u32,
+) -> Result<bool> {
+    let Some(dispatch) = caught_up.get(&(domain, EventKind::Dispatch)) else {
+        return Ok(false);
+    };
+    let Some(merkle) = caught_up.get(&(domain, EventKind::MerkleTreeInsertion)) else {
+        return Ok(false);
+    };
+    if !correlation_required {
+        return Ok(true);
+    }
+    let target = (*dispatch).max(*merkle);
+    if target < 0 {
+        return Ok(true);
+    }
+    let target: u32 = target
+        .try_into()
+        .context("Caught-up sequence exceeds u32")?;
+    for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+        let Some(cursor) = state.cursors.get(&(domain, kind)) else {
+            return Ok(false);
+        };
+        if cursor.latest_sequence()? < target {
+            return Ok(false);
+        }
+    }
+    correlation_ready(true, state, domain, i64::from(target))
+}
+
 fn validate_subscription(
     streams: &[SubscribedStream],
     sources: &HashMap<u32, ScraperSource>,
@@ -871,9 +938,10 @@ fn validate_subscription(
         let expected_cursors = sources
             .iter()
             .map(|source| {
+                let cursor = sequence_cursor(source, kind)?;
                 Ok(SubscribedCursor {
-                    address: format!("{:#x}", source.address(kind)),
-                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    address: cursor.address,
+                    after_sequence: cursor.after_sequence,
                     domain: source.domain,
                 })
             })
@@ -1072,13 +1140,13 @@ mod tests {
                 cursors: Some(
                     sources
                         .iter()
-                        .map(|source| SubscribedCursor {
-                            address: format!("{:#x}", source.address(kind)),
-                            after_sequence: source
-                                .cursor(kind)
-                                .expect("cursor read")
-                                .map(replay_after_sequence),
-                            domain: source.domain,
+                        .map(|source| {
+                            let cursor = sequence_cursor(source, kind).expect("cursor read");
+                            SubscribedCursor {
+                                address: cursor.address,
+                                after_sequence: cursor.after_sequence,
+                                domain: source.domain,
+                            }
                         })
                         .collect(),
                 ),
@@ -1233,6 +1301,67 @@ mod tests {
                 .expect("Merkle cursor"),
             7
         );
+    }
+
+    #[test]
+    fn restart_replays_missing_peer_and_rechecks_late_correlation() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 7)
+            .expect("store dispatch cursor");
+
+        let message: serde_json::Value =
+            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
+                .expect("subscription JSON");
+        assert_eq!(message["streams"][0]["cursors"][0]["afterSequence"], "6");
+        assert_eq!(message["streams"][1]["cursors"][0]["afterSequence"], "6");
+        let streams = subscribed_streams(&sources);
+        assert_eq!(
+            streams[0].cursors.as_ref().expect("dispatch cursors")[0].after_sequence,
+            Some("6".to_owned())
+        );
+        assert_eq!(
+            streams[1].cursors.as_ref().expect("Merkle cursors")[0].after_sequence,
+            Some("6".to_owned())
+        );
+        validate_subscription(&streams, &sources).expect("subscription confirmation");
+
+        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("replay dispatch boundary");
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 7),
+            ((5, EventKind::MerkleTreeInsertion), 6),
+        ]);
+        assert!(!source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+
+        restarted
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(
+                        7,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(7, b"seven").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("late Merkle correlation");
+        assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+    }
+
+    #[test]
+    fn replay_includes_zero_boundary() {
+        assert_eq!(replay_after_sequence(0), "-1");
+        assert_eq!(replay_after_sequence(1), "0");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -994,6 +994,9 @@ fn source_caught_up(
         return Ok(false);
     };
     if !correlation_required {
+        if dispatch != merkle {
+            bail!("Fresh scraper caught-up baselines differ: dispatch {dispatch}, Merkle {merkle}");
+        }
         return Ok(true);
     }
     let target = (*dispatch).max(*merkle);
@@ -1545,6 +1548,52 @@ mod tests {
             ((5, EventKind::MerkleTreeInsertion), 100),
         ]);
         assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+    }
+
+    #[test]
+    fn fresh_unequal_baselines_reconnect_at_common_floor() {
+        let sources = sources();
+        let source = &sources[&5];
+        let initial_plan = replay_plan(&sources);
+        assert!(!initial_plan
+            .correlation_required(5)
+            .expect("correlation requirement"));
+
+        let mut state = replay_state(&initial_plan);
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store fresh dispatch baseline");
+        state
+            .set_baseline(5, EventKind::Dispatch, 100)
+            .expect("set fresh dispatch baseline");
+        let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
+        assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one fresh marker"));
+
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store fresh Merkle baseline");
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
+            .expect("set fresh Merkle baseline");
+        caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
+        assert!(source_caught_up(false, &caught_up, &state, 5)
+            .expect_err("unequal fresh baselines must reconnect")
+            .to_string()
+            .contains("Fresh scraper caught-up baselines differ"));
+
+        let reconnect_plan = replay_plan(&sources);
+        let source_plan = reconnect_plan.source(5).expect("source plan");
+        assert_eq!(source_plan.floor, Some(90));
+        assert_eq!(source_plan.correlation_next, Some(90));
+        assert!(reconnect_plan
+            .correlation_required(5)
+            .expect("correlation requirement"));
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &reconnect_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -760,15 +760,28 @@ impl ScraperWebSocketMonitor {
                                         .sources
                                         .get(&domain)
                                         .expect("validated scraper source exists");
-                                    if let Some(sequence) =
-                                        state.initialize_correlation(domain, sequence)
-                                    {
-                                        source.store_correlation_cursor(sequence)?;
-                                    }
-                                    let correlation_next = state.advance_correlation(domain)?;
-                                    source.store_cursor(kind, sequence)?;
-                                    if let Some(sequence) = correlation_next {
-                                        source.store_correlation_cursor(sequence)?;
+                                    if sequenced_persistence_ready(
+                                        plan, &caught_up, state, domain, sequence,
+                                    )? {
+                                        if caught_up_baselines(&caught_up, domain) == Some((-1, -1))
+                                            && !state.correlation_next.contains_key(&domain)
+                                        {
+                                            for (kind, sequence) in
+                                                sequenced_cursor_write_order(state, domain)?
+                                            {
+                                                source.store_cursor(kind, sequence)?;
+                                            }
+                                        }
+                                        if let Some(sequence) =
+                                            state.initialize_correlation(domain, sequence)
+                                        {
+                                            source.store_correlation_cursor(sequence)?;
+                                        }
+                                        let correlation_next = state.advance_correlation(domain)?;
+                                        source.store_cursor(kind, sequence)?;
+                                        if let Some(sequence) = correlation_next {
+                                            source.store_correlation_cursor(sequence)?;
+                                        }
                                     }
                                     let result = match sequence_result {
                                         SequenceResult::Accepted => "accepted",
@@ -811,15 +824,23 @@ impl ScraperWebSocketMonitor {
                                 bail!("Invalid negative scraper caught-up sequence {sequence}");
                             }
                             validate_caught_up_floor(plan, domain, sequence)?;
-                            if sequence >= 0 {
-                                let durable: u32 = sequence
-                                    .try_into()
-                                    .context("Scraper caught-up sequence exceeds u32")?;
-                                source.store_cursor(kind, durable)?;
-                            }
                             state.set_baseline(domain, kind, sequence)?;
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
+                            }
+                            if plan.correlation_required(domain)? {
+                                if sequence >= 0 {
+                                    let durable: u32 = sequence
+                                        .try_into()
+                                        .context("Scraper caught-up sequence exceeds u32")?;
+                                    source.store_cursor(kind, durable)?;
+                                }
+                            } else if let Some(baselines) =
+                                fresh_baseline_write_order(&caught_up, domain)?
+                            {
+                                for (kind, sequence) in baselines {
+                                    source.store_cursor(kind, sequence)?;
+                                }
                             }
                             self.update_source_caught_up(state, plan, &caught_up, domain)?;
                         }
@@ -981,16 +1002,91 @@ fn correlation_ready(
     ))
 }
 
+fn caught_up_baselines(
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    domain: u32,
+) -> Option<(i64, i64)> {
+    Some((
+        *caught_up.get(&(domain, EventKind::Dispatch))?,
+        *caught_up.get(&(domain, EventKind::MerkleTreeInsertion))?,
+    ))
+}
+
+fn sequenced_persistence_ready(
+    plan: &SequencedReplayPlan,
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    state: &StreamState,
+    domain: u32,
+    sequence: u32,
+) -> Result<bool> {
+    if plan.correlation_required(domain)? {
+        return Ok(true);
+    }
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
+        return Ok(false);
+    };
+    if dispatch != merkle {
+        return Ok(false);
+    }
+    if dispatch >= 0 {
+        return Ok(true);
+    }
+    if state.correlation_next.contains_key(&domain) {
+        return Ok(true);
+    }
+    if sequence != 0 {
+        bail!("Fresh empty scraper stream started at sequence {sequence}, expected 0");
+    }
+    Ok(state.cross_stream.complete(domain, sequence))
+}
+
+fn cursor_write_order(dispatch: u32, merkle: u32) -> [(EventKind, u32); 2] {
+    if dispatch <= merkle {
+        [
+            (EventKind::Dispatch, dispatch),
+            (EventKind::MerkleTreeInsertion, merkle),
+        ]
+    } else {
+        [
+            (EventKind::MerkleTreeInsertion, merkle),
+            (EventKind::Dispatch, dispatch),
+        ]
+    }
+}
+
+fn sequenced_cursor_write_order(state: &StreamState, domain: u32) -> Result<[(EventKind, u32); 2]> {
+    Ok(cursor_write_order(
+        state.latest_sequence(domain, EventKind::Dispatch)?,
+        state.latest_sequence(domain, EventKind::MerkleTreeInsertion)?,
+    ))
+}
+
+fn fresh_baseline_write_order(
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    domain: u32,
+) -> Result<Option<[(EventKind, u32); 2]>> {
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
+        return Ok(None);
+    };
+    if dispatch < 0 || merkle < 0 {
+        return Ok(None);
+    }
+    let dispatch: u32 = dispatch
+        .try_into()
+        .context("Scraper caught-up sequence exceeds u32")?;
+    let merkle: u32 = merkle
+        .try_into()
+        .context("Scraper caught-up sequence exceeds u32")?;
+    Ok(Some(cursor_write_order(dispatch, merkle)))
+}
+
 fn source_caught_up(
     correlation_required: bool,
     caught_up: &HashMap<(u32, EventKind), i64>,
     state: &StreamState,
     domain: u32,
 ) -> Result<bool> {
-    let Some(dispatch) = caught_up.get(&(domain, EventKind::Dispatch)) else {
-        return Ok(false);
-    };
-    let Some(merkle) = caught_up.get(&(domain, EventKind::MerkleTreeInsertion)) else {
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
         return Ok(false);
     };
     if !correlation_required {
@@ -999,7 +1095,7 @@ fn source_caught_up(
         }
         return Ok(true);
     }
-    let target = (*dispatch).max(*merkle);
+    let target = dispatch.max(merkle);
     if target < 0 {
         return Ok(true);
     }
@@ -1560,22 +1656,65 @@ mod tests {
             .expect("correlation requirement"));
 
         let mut state = replay_state(&initial_plan);
-        source
-            .store_cursor(EventKind::Dispatch, 100)
-            .expect("store fresh dispatch baseline");
         state
             .set_baseline(5, EventKind::Dispatch, 100)
             .expect("set fresh dispatch baseline");
         let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
         assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one fresh marker"));
+        assert_eq!(
+            fresh_baseline_write_order(&caught_up, 5).expect("baseline order"),
+            None
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
 
-        source
-            .store_cursor(EventKind::MerkleTreeInsertion, 90)
-            .expect("store fresh Merkle baseline");
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 101, dispatch_data(101, b"one-oh-one")),
+                &sources,
+            )
+            .expect("fresh live event after first marker");
+        assert!(
+            !sequenced_persistence_ready(&initial_plan, &caught_up, &state, 5, 101)
+                .expect("persistence readiness")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            None
+        );
+
         state
             .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
             .expect("set fresh Merkle baseline");
         caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
+        let baselines = fresh_baseline_write_order(&caught_up, 5)
+            .expect("baseline order")
+            .expect("both baselines");
+        assert_eq!(
+            baselines,
+            [
+                (EventKind::MerkleTreeInsertion, 90),
+                (EventKind::Dispatch, 100),
+            ]
+        );
+        source
+            .store_cursor(baselines[0].0, baselines[0].1)
+            .expect("store lower fresh baseline");
+
+        let interrupted_plan = replay_plan(&sources);
+        assert_eq!(
+            interrupted_plan.source(5).expect("source plan").floor,
+            Some(90)
+        );
+        source
+            .store_cursor(baselines[1].0, baselines[1].1)
+            .expect("store higher fresh baseline");
         assert!(source_caught_up(false, &caught_up, &state, 5)
             .expect_err("unequal fresh baselines must reconnect")
             .to_string()
@@ -1594,6 +1733,209 @@ mod tests {
         .expect("subscription JSON");
         assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
         assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+    }
+
+    #[test]
+    fn fresh_equal_baselines_preserve_readiness() {
+        let sources = sources();
+        let source = &sources[&5];
+        let plan = replay_plan(&sources);
+        let mut state = replay_state(&plan);
+        state
+            .set_baseline(5, EventKind::Dispatch, 100)
+            .expect("set fresh dispatch baseline");
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, 100)
+            .expect("set fresh Merkle baseline");
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 100),
+            ((5, EventKind::MerkleTreeInsertion), 100),
+        ]);
+        let baselines = fresh_baseline_write_order(&caught_up, 5)
+            .expect("baseline order")
+            .expect("both baselines");
+        for (kind, sequence) in baselines {
+            source
+                .store_cursor(kind, sequence)
+                .expect("store equal fresh baseline");
+        }
+
+        assert!(source_caught_up(false, &caught_up, &state, 5).expect("readiness check"));
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            Some(100)
+        );
+        assert_eq!(
+            source
+                .cursor(EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn fresh_negative_lower_baseline_persists_neither_tip() {
+        let sources = sources();
+        let source = &sources[&5];
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 100),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+
+        assert_eq!(
+            fresh_baseline_write_order(&caught_up, 5).expect("baseline order"),
+            None
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+        assert_eq!(
+            source
+                .cursor(EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            None
+        );
+        assert!(
+            source_caught_up(false, &caught_up, &StreamState::default(), 5)
+                .expect_err("negative unequal fresh baselines must reconnect")
+                .to_string()
+                .contains("Fresh scraper caught-up baselines differ")
+        );
+    }
+
+    #[test]
+    fn fresh_empty_baselines_wait_for_first_complete_pair() {
+        let sources = sources();
+        let source = &sources[&5];
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut skipped = replay_state(&plan);
+        skipped
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 5, dispatch_data(5, b"five")),
+                &sources,
+            )
+            .expect("first nonzero dispatch event");
+        assert!(
+            sequenced_persistence_ready(&plan, &caught_up, &skipped, 5, 5)
+                .expect_err("empty stream must start at zero")
+                .to_string()
+                .contains("expected 0")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+
+        let mut state = replay_state(&plan);
+        state
+            .set_baseline(5, EventKind::Dispatch, -1)
+            .expect("set empty dispatch baseline");
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, -1)
+            .expect("set empty Merkle baseline");
+        assert!(source_caught_up(false, &caught_up, &state, 5).expect("readiness check"));
+
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"zero")),
+                &sources,
+            )
+            .expect("first dispatch event");
+        assert!(
+            !sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
+                .expect("persistence readiness")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            None
+        );
+
+        state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    0,
+                    merkle_data_for(
+                        0,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(0, b"zero").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("first Merkle event");
+        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
+            .expect("persistence readiness"));
+        let cursors = sequenced_cursor_write_order(&state, 5).expect("cursor write order");
+        assert_eq!(
+            cursors,
+            [
+                (EventKind::Dispatch, 0),
+                (EventKind::MerkleTreeInsertion, 0),
+            ]
+        );
+        for (kind, sequence) in cursors {
+            source
+                .store_cursor(kind, sequence)
+                .expect("seed first complete pair cursor");
+        }
+        let correlation = state
+            .initialize_correlation(5, 0)
+            .expect("initialize correlation");
+        source
+            .store_correlation_cursor(correlation)
+            .expect("store initial correlation");
+        let correlation = state
+            .advance_correlation(5)
+            .expect("advance correlation")
+            .expect("complete pair advances correlation");
+        source
+            .store_correlation_cursor(correlation)
+            .expect("store advanced correlation");
+
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            Some(0)
+        );
+        assert_eq!(
+            source
+                .cursor(EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            Some(0)
+        );
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(1)
+        );
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                &sources,
+            )
+            .expect("next dispatch event");
+        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
+            .expect("initialized persistence readiness"));
+        let reconnect_plan = replay_plan(&sources);
+        assert_eq!(
+            reconnect_plan.source(5).expect("source plan").floor,
+            Some(0)
+        );
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &reconnect_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "-1");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "-1");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,0 +1,485 @@
+//! Shadow validation of relayer inputs streamed by scraper-proxy.
+
+use std::{collections::HashMap, time::Duration};
+
+use eyre::{bail, Context, ContextCompat, Result};
+use futures_util::{SinkExt, StreamExt};
+use hyperlane_base::{
+    scraper_websocket::{
+        EventMessage, ServerMessage, StringOrNumber, SubscribeMessage, SubscribeStream,
+    },
+    CoreMetrics,
+};
+use hyperlane_core::{bytes_to_address, H256};
+use prometheus::{IntCounterVec, IntGaugeVec};
+use serde::Deserialize;
+use tokio::time::{sleep, timeout, Instant};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{info, warn};
+use url::Url;
+
+const DISPATCH_EVENT_TYPE: &str = "dispatch";
+const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
+const READ_TIMEOUT: Duration = Duration::from_secs(75);
+const RETRY_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug)]
+pub(crate) struct ScraperSource {
+    chain: String,
+    domain: u32,
+    mailbox: H256,
+    merkle_tree_hook: H256,
+}
+
+impl ScraperSource {
+    pub(crate) fn new(chain: String, domain: u32, mailbox: H256, merkle_tree_hook: H256) -> Self {
+        Self {
+            chain,
+            domain,
+            mailbox,
+            merkle_tree_hook,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum EventKind {
+    Dispatch,
+    MerkleTreeInsertion,
+}
+
+impl EventKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Dispatch => DISPATCH_EVENT_TYPE,
+            Self::MerkleTreeInsertion => MERKLE_EVENT_TYPE,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum SequenceResult {
+    Accepted,
+    Duplicate,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Scraper stream gap: expected sequence {expected}, received {received}")]
+struct StreamGap {
+    expected: u32,
+    received: u32,
+}
+
+#[derive(Debug, Default)]
+struct StreamState {
+    next_sequences: HashMap<(u32, EventKind), u32>,
+}
+
+impl StreamState {
+    fn validate(
+        &mut self,
+        event: EventMessage<serde_json::Value>,
+        sources: &HashMap<u32, ScraperSource>,
+    ) -> Result<(EventKind, SequenceResult)> {
+        let source = sources
+            .get(&event.domain)
+            .with_context(|| format!("Unexpected scraper event domain {}", event.domain))?;
+        let sequence = event
+            .sequence
+            .as_deref()
+            .context("Sequenced scraper event omitted sequence")?
+            .parse::<u32>()
+            .context("Invalid scraper event sequence")?;
+
+        let kind = match event.event_type.as_str() {
+            DISPATCH_EVENT_TYPE => {
+                let data: DispatchEventData =
+                    serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
+                if data.origin_domain != event.domain {
+                    bail!("Dispatch payload domain does not match event envelope");
+                }
+                if parse_address(&data.origin_mailbox)? != source.mailbox {
+                    bail!("Dispatch event mailbox does not match configured mailbox");
+                }
+                if data.nonce.as_u32("dispatch nonce")? != sequence {
+                    bail!("Dispatch event nonce does not match stream sequence");
+                }
+                EventKind::Dispatch
+            }
+            MERKLE_EVENT_TYPE => {
+                let data: MerkleEventData = serde_json::from_value(event.data)
+                    .context("Invalid Merkle tree insertion payload")?;
+                if data.domain != event.domain {
+                    bail!("Merkle payload domain does not match event envelope");
+                }
+                if parse_address(&data.merkle_tree_hook)? != source.merkle_tree_hook {
+                    bail!("Merkle event hook does not match configured hook");
+                }
+                if data.leaf_index.as_u32("Merkle leaf index")? != sequence {
+                    bail!("Merkle leaf index does not match stream sequence");
+                }
+                EventKind::MerkleTreeInsertion
+            }
+            event_type => bail!("Unexpected scraper event type {event_type}"),
+        };
+
+        let key = (event.domain, kind);
+        let result = match self.next_sequences.get_mut(&key) {
+            None => {
+                self.next_sequences.insert(
+                    key,
+                    sequence
+                        .checked_add(1)
+                        .context("Scraper event sequence exhausted")?,
+                );
+                SequenceResult::Accepted
+            }
+            Some(next_sequence) if sequence < *next_sequence => SequenceResult::Duplicate,
+            Some(next_sequence) if sequence == *next_sequence => {
+                *next_sequence = next_sequence
+                    .checked_add(1)
+                    .context("Scraper event sequence exhausted")?;
+                SequenceResult::Accepted
+            }
+            Some(next_sequence) => {
+                return Err(StreamGap {
+                    expected: *next_sequence,
+                    received: sequence,
+                }
+                .into())
+            }
+        };
+        Ok((kind, result))
+    }
+}
+
+/// One process-wide, read-only scraper stream monitor.
+pub(crate) struct ScraperWebSocketMonitor {
+    active: IntGaugeVec,
+    events: IntCounterVec,
+    sources: HashMap<u32, ScraperSource>,
+    url: Url,
+}
+
+impl ScraperWebSocketMonitor {
+    pub(crate) fn new(
+        url: Url,
+        sources: Vec<ScraperSource>,
+        metrics: &CoreMetrics,
+    ) -> Result<Self> {
+        let active = metrics.new_int_gauge(
+            "relayer_scraper_websocket_active",
+            "Whether the relayer scraper-proxy shadow stream is active",
+            &["chain"],
+        )?;
+        let events = metrics.new_int_counter(
+            "relayer_scraper_websocket_events",
+            "Scraper-proxy shadow events validated by the relayer",
+            &["chain", "event_type", "result"],
+        )?;
+        let sources = sources
+            .into_iter()
+            .map(|source| (source.domain, source))
+            .collect::<HashMap<_, _>>();
+        for source in sources.values() {
+            active.with_label_values(&[&source.chain]).set(0);
+        }
+        Ok(Self {
+            active,
+            events,
+            sources,
+            url,
+        })
+    }
+
+    pub(crate) async fn run(self) {
+        loop {
+            self.set_active(false);
+            match self.stream().await {
+                Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
+                Err(err) => warn!(
+                    ?err,
+                    "Relayer scraper-proxy shadow stream failed; reconnecting"
+                ),
+            }
+            self.set_active(false);
+            sleep(RETRY_DELAY).await;
+        }
+    }
+
+    async fn stream(&self) -> Result<()> {
+        let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
+            .await
+            .context("Connecting to relayer scraper-proxy WebSocket timed out")?
+            .context("Connecting to relayer scraper-proxy WebSocket")?;
+        let mut subscribed = false;
+        let mut state = StreamState::default();
+        let read_deadline = sleep(READ_TIMEOUT);
+        tokio::pin!(read_deadline);
+
+        while let Some(message) = tokio::select! {
+            _ = &mut read_deadline => bail!("Relayer scraper-proxy WebSocket heartbeat timed out"),
+            message = socket.next() => message,
+        } {
+            let next_read_deadline = Instant::now()
+                .checked_add(READ_TIMEOUT)
+                .expect("read timeout cannot exceed Instant range");
+            read_deadline.as_mut().reset(next_read_deadline);
+            match message.context("Reading relayer scraper-proxy WebSocket message")? {
+                Message::Text(text) => {
+                    let message: ServerMessage<serde_json::Value> = serde_json::from_str(&text)
+                        .context("Parsing relayer scraper-proxy WebSocket message")?;
+                    match message {
+                        ServerMessage::Ready => {
+                            if subscribed {
+                                bail!("Received duplicate scraper-proxy ready message");
+                            }
+                            socket
+                                .send(Message::Text(self.subscription()?))
+                                .await
+                                .context("Subscribing to relayer scraper-proxy streams")?;
+                            subscribed = true;
+                        }
+                        ServerMessage::Subscribed => {
+                            if !subscribed {
+                                bail!("Received subscribed before ready");
+                            }
+                            self.set_active(true);
+                            info!("Relayer scraper-proxy shadow streams active");
+                        }
+                        ServerMessage::Event(event) => {
+                            let domain = event.domain;
+                            let event_type = event_label(&event.event_type);
+                            match state.validate(event, &self.sources) {
+                                Ok((kind, SequenceResult::Accepted)) => {
+                                    self.record(domain, kind.label(), "accepted")
+                                }
+                                Ok((kind, SequenceResult::Duplicate)) => {
+                                    self.record(domain, kind.label(), "duplicate")
+                                }
+                                Err(err) => {
+                                    let result = if err.downcast_ref::<StreamGap>().is_some() {
+                                        "gap"
+                                    } else {
+                                        "invalid"
+                                    };
+                                    self.record(domain, event_type, result);
+                                    return Err(err);
+                                }
+                            }
+                        }
+                        ServerMessage::CaughtUp { .. } => {
+                            bail!("Live-only relayer shadow stream received caught-up marker")
+                        }
+                        ServerMessage::Error { error } => {
+                            bail!("Scraper-proxy rejected relayer shadow stream: {error}")
+                        }
+                        ServerMessage::Other => {}
+                    }
+                }
+                Message::Ping(payload) => socket
+                    .send(Message::Pong(payload))
+                    .await
+                    .context("Responding to relayer scraper-proxy heartbeat")?,
+                Message::Close(frame) => {
+                    bail!("Relayer scraper-proxy WebSocket closed: {frame:?}")
+                }
+                Message::Binary(_) | Message::Pong(_) | Message::Frame(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn subscription(&self) -> Result<String> {
+        subscription(self.sources.keys().copied().collect())
+    }
+
+    fn set_active(&self, active: bool) {
+        let value = i64::from(active);
+        for source in self.sources.values() {
+            self.active.with_label_values(&[&source.chain]).set(value);
+        }
+    }
+
+    fn record(&self, domain: u32, event_type: &str, result: &str) {
+        let chain = self
+            .sources
+            .get(&domain)
+            .map(|source| source.chain.as_str())
+            .unwrap_or("unknown");
+        self.events
+            .with_label_values(&[chain, event_type, result])
+            .inc();
+    }
+}
+
+fn subscription(mut domains: Vec<u32>) -> Result<String> {
+    domains.sort_unstable();
+    serde_json::to_string(&SubscribeMessage {
+        streams: vec![
+            SubscribeStream {
+                cursors: None,
+                domains: Some(domains.clone()),
+                event_type: DISPATCH_EVENT_TYPE,
+            },
+            SubscribeStream {
+                cursors: None,
+                domains: Some(domains),
+                event_type: MERKLE_EVENT_TYPE,
+            },
+        ],
+        message_type: "subscribe",
+    })
+    .context("Serializing relayer scraper-proxy subscription")
+}
+
+#[derive(Debug, Deserialize)]
+struct DispatchEventData {
+    nonce: StringOrNumber,
+    origin_domain: u32,
+    origin_mailbox: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MerkleEventData {
+    domain: u32,
+    leaf_index: StringOrNumber,
+    merkle_tree_hook: String,
+}
+
+fn parse_address(value: &str) -> Result<H256> {
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("\\x"))
+        .unwrap_or(value);
+    bytes_to_address(hex::decode(value).context("Invalid hexadecimal scraper event address")?)
+        .context("Invalid scraper event address")
+}
+
+fn event_label(event_type: &str) -> &'static str {
+    match event_type {
+        DISPATCH_EVENT_TYPE => DISPATCH_EVENT_TYPE,
+        MERKLE_EVENT_TYPE => MERKLE_EVENT_TYPE,
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sources() -> HashMap<u32, ScraperSource> {
+        HashMap::from([(
+            5,
+            ScraperSource::new(
+                "test".to_owned(),
+                5,
+                H256::from_low_u64_be(1),
+                H256::from_low_u64_be(2),
+            ),
+        )])
+    }
+
+    fn event(
+        event_type: &str,
+        sequence: u32,
+        data: serde_json::Value,
+    ) -> EventMessage<serde_json::Value> {
+        EventMessage {
+            data,
+            domain: 5,
+            event_type: event_type.to_owned(),
+            sequence: Some(sequence.to_string()),
+        }
+    }
+
+    #[test]
+    fn accepts_contiguous_dispatch_and_rejects_gap() {
+        let sources = sources();
+        let mut state = StreamState::default();
+        let data = |nonce| {
+            serde_json::json!({
+                "nonce": nonce,
+                "origin_domain": 5,
+                "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(1)),
+            })
+        };
+
+        assert_eq!(
+            state
+                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
+                .expect("first event"),
+            (EventKind::Dispatch, SequenceResult::Accepted)
+        );
+        assert_eq!(
+            state
+                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
+                .expect("duplicate event"),
+            (EventKind::Dispatch, SequenceResult::Duplicate)
+        );
+        assert!(state
+            .validate(event(DISPATCH_EVENT_TYPE, 9, data(9)), &sources)
+            .expect_err("gap must reject")
+            .to_string()
+            .contains("expected sequence 8"));
+    }
+
+    #[test]
+    fn rejects_wrong_dispatch_mailbox() {
+        let error = StreamState::default()
+            .validate(
+                event(
+                    DISPATCH_EVENT_TYPE,
+                    7,
+                    serde_json::json!({
+                        "nonce": 7,
+                        "origin_domain": 5,
+                        "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(3)),
+                    }),
+                ),
+                &sources(),
+            )
+            .expect_err("wrong mailbox must reject");
+
+        assert!(error.to_string().contains("configured mailbox"));
+    }
+
+    #[test]
+    fn rejects_wrong_merkle_hook() {
+        let mut state = StreamState::default();
+        let error = state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    1,
+                    serde_json::json!({
+                        "domain": 5,
+                        "leaf_index": "1",
+                        "merkle_tree_hook": format!("{:#x}", H256::from_low_u64_be(3)),
+                    }),
+                ),
+                &sources(),
+            )
+            .expect_err("wrong hook must reject");
+
+        assert!(error.to_string().contains("configured hook"));
+    }
+
+    #[test]
+    fn multiplexes_live_streams_on_one_subscription() {
+        let message: serde_json::Value =
+            serde_json::from_str(&subscription(vec![9, 5]).expect("subscription should serialize"))
+                .expect("subscription JSON");
+
+        assert_eq!(
+            message,
+            serde_json::json!({
+                "streams": [
+                    { "domains": [5, 9], "eventType": "dispatch" },
+                    { "domains": [5, 9], "eventType": "merkle_tree_insertion" }
+                ],
+                "type": "subscribe"
+            })
+        );
+    }
+}

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,7 +1,7 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     time::Duration,
 };
 
@@ -32,6 +32,7 @@ const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
+const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor";
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
@@ -72,6 +73,35 @@ impl ScraperSource {
             .context("Reading durable scraper WebSocket cursor")
     }
 
+    fn correlation_cursor_key(&self) -> H512 {
+        let mut key = [0_u8; 64];
+        key[..32].copy_from_slice(self.mailbox.as_ref());
+        key[32..].copy_from_slice(self.merkle_tree_hook.as_ref());
+        H512::from_slice(&key)
+    }
+
+    fn correlation_cursor(&self) -> Result<Option<u32>> {
+        self.db
+            .retrieve_value_by_key(CORRELATION_CURSOR_PREFIX, &self.correlation_cursor_key())
+            .context("Reading durable scraper correlation cursor")
+    }
+
+    fn store_correlation_cursor(&self, sequence: u32) -> Result<()> {
+        if self
+            .correlation_cursor()?
+            .is_some_and(|stored| stored >= sequence)
+        {
+            return Ok(());
+        }
+        self.db
+            .store_value_by_key(
+                CORRELATION_CURSOR_PREFIX,
+                &self.correlation_cursor_key(),
+                &sequence,
+            )
+            .context("Storing durable scraper correlation cursor")
+    }
+
     fn store_cursor(&self, kind: EventKind, sequence: u32) -> Result<()> {
         if self.cursor(kind)?.is_some_and(|stored| stored >= sequence) {
             return Ok(());
@@ -103,19 +133,60 @@ impl EventKind {
         }
     }
 
-    fn counterpart(self) -> Self {
-        match self {
-            Self::Dispatch => Self::MerkleTreeInsertion,
-            Self::MerkleTreeInsertion => Self::Dispatch,
-        }
-    }
-
     fn from_label(label: &str) -> Result<Self> {
         match label {
             DISPATCH_EVENT_TYPE => Ok(Self::Dispatch),
             MERKLE_EVENT_TYPE => Ok(Self::MerkleTreeInsertion),
             _ => bail!("Unexpected scraper event type {label}"),
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SequencedReplaySource {
+    correlation_next: Option<u32>,
+    floor: Option<u32>,
+}
+
+#[derive(Debug, Default)]
+struct SequencedReplayPlan {
+    sources: HashMap<u32, SequencedReplaySource>,
+}
+
+impl SequencedReplayPlan {
+    fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
+        let mut plan = Self::default();
+        for source in sources.values() {
+            let dispatch = source.cursor(EventKind::Dispatch)?;
+            let merkle = source.cursor(EventKind::MerkleTreeInsertion)?;
+            let correlation = source.correlation_cursor()?;
+            let floor = [dispatch, merkle, correlation].into_iter().flatten().min();
+            let correlation_next = correlation.or(floor);
+            if correlation.is_none() {
+                if let Some(sequence) = correlation_next {
+                    source.store_correlation_cursor(sequence)?;
+                }
+            }
+            plan.sources.insert(
+                source.domain,
+                SequencedReplaySource {
+                    correlation_next,
+                    floor,
+                },
+            );
+        }
+        Ok(plan)
+    }
+
+    fn source(&self, domain: u32) -> Result<SequencedReplaySource> {
+        self.sources
+            .get(&domain)
+            .copied()
+            .context("Scraper replay plan omitted configured source")
+    }
+
+    fn correlation_required(&self, domain: u32) -> Result<bool> {
+        Ok(self.source(domain)?.floor.is_some())
     }
 }
 
@@ -316,24 +387,54 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
+    correlation_next: HashMap<u32, u32>,
     cross_stream: CrossStreamState,
     cursors: HashMap<(u32, EventKind), StreamCursor>,
 }
 
 impl StreamState {
-    fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
-        let mut state = Self::default();
-        for source in sources.values() {
-            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
-                if let Some(sequence) = source.cursor(kind)? {
-                    state.cursors.insert(
-                        (source.domain, kind),
+    fn reset_sequenced(&mut self, plan: &SequencedReplayPlan) {
+        self.correlation_next.clear();
+        self.cross_stream = CrossStreamState::default();
+        self.cursors.clear();
+        for (domain, source) in &plan.sources {
+            if let Some(sequence) = source.floor {
+                for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                    self.cursors.insert(
+                        (*domain, kind),
                         StreamCursor::from_durable_sequence(sequence),
                     );
                 }
             }
+            if let Some(sequence) = source.correlation_next {
+                self.correlation_next.insert(*domain, sequence);
+            }
         }
-        Ok(state)
+    }
+
+    fn advance_correlation(&mut self, domain: u32) -> Result<Option<u32>> {
+        let Some(initial) = self.correlation_next.get(&domain).copied() else {
+            return Ok(None);
+        };
+        let mut next = initial;
+        while self.cross_stream.complete(domain, next) {
+            next = next
+                .checked_add(1)
+                .context("Scraper correlation cursor exhausted")?;
+        }
+        if next == initial {
+            return Ok(None);
+        }
+        self.correlation_next.insert(domain, next);
+        Ok(Some(next))
+    }
+
+    fn initialize_correlation(&mut self, domain: u32, sequence: u32) -> Option<u32> {
+        if self.correlation_next.contains_key(&domain) {
+            return None;
+        }
+        self.correlation_next.insert(domain, sequence);
+        Some(sequence)
     }
 
     fn set_baseline(&mut self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
@@ -510,6 +611,7 @@ impl HandshakeState {
         &mut self,
         streams: &[SubscribedStream],
         sources: &HashMap<u32, ScraperSource>,
+        plan: &SequencedReplayPlan,
     ) -> Result<()> {
         if !self.sent {
             bail!("Received subscribed before ready");
@@ -517,7 +619,7 @@ impl HandshakeState {
         if self.confirmed {
             bail!("Received duplicate scraper-proxy subscribed message");
         }
-        validate_subscription(streams, sources)?;
+        validate_subscription(streams, sources, plan)?;
         self.confirmed = true;
         Ok(())
     }
@@ -582,22 +684,24 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
-        let mut state = loop {
-            match StreamState::load(&self.sources) {
-                Ok(state) => break state,
-                Err(err) => {
-                    warn!(
-                        ?err,
-                        "Loading durable scraper WebSocket cursors failed; retrying"
-                    );
-                    sleep(RETRY_DELAY).await;
-                }
-            }
-        };
+        let mut state = StreamState::default();
         loop {
+            let plan = loop {
+                match SequencedReplayPlan::load(&self.sources) {
+                    Ok(plan) => break plan,
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            "Loading durable scraper WebSocket cursors failed; retrying"
+                        );
+                        sleep(RETRY_DELAY).await;
+                    }
+                }
+            };
+            state.reset_sequenced(&plan);
             self.set_active(false);
             self.set_caught_up(false);
-            match self.stream(&mut state).await {
+            match self.stream(&mut state, &plan).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
                     ?err,
@@ -610,21 +714,12 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn stream(&self, state: &mut StreamState) -> Result<()> {
+    async fn stream(&self, state: &mut StreamState, plan: &SequencedReplayPlan) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
-        let mut correlation_required = HashSet::new();
-        for source in self.sources.values() {
-            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
-                if source.cursor(kind)?.is_some() {
-                    correlation_required.insert(source.domain);
-                    break;
-                }
-            }
-        }
         let mut caught_up = HashMap::new();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
@@ -645,12 +740,12 @@ impl ScraperWebSocketMonitor {
                         ServerMessage::Ready => {
                             handshake.ready()?;
                             socket
-                                .send(Message::Text(self.subscription()?))
+                                .send(Message::Text(self.subscription(plan)?))
                                 .await
                                 .context("Subscribing to relayer scraper-proxy streams")?;
                         }
                         ServerMessage::Subscribed { streams } => {
-                            handshake.subscribed(&streams, &self.sources)?;
+                            handshake.subscribed(&streams, &self.sources, plan)?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
@@ -661,21 +756,26 @@ impl ScraperWebSocketMonitor {
                             match state.validate(event, &self.sources) {
                                 Ok((kind, sequence_result)) => {
                                     let sequence = state.latest_sequence(domain, kind)?;
-                                    self.sources
+                                    let source = self
+                                        .sources
                                         .get(&domain)
-                                        .expect("validated scraper source exists")
-                                        .store_cursor(kind, sequence)?;
+                                        .expect("validated scraper source exists");
+                                    if let Some(sequence) =
+                                        state.initialize_correlation(domain, sequence)
+                                    {
+                                        source.store_correlation_cursor(sequence)?;
+                                    }
+                                    let correlation_next = state.advance_correlation(domain)?;
+                                    source.store_cursor(kind, sequence)?;
+                                    if let Some(sequence) = correlation_next {
+                                        source.store_correlation_cursor(sequence)?;
+                                    }
                                     let result = match sequence_result {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
                                     self.record(domain, kind.label(), result);
-                                    self.update_source_caught_up(
-                                        state,
-                                        &correlation_required,
-                                        &caught_up,
-                                        domain,
-                                    )?;
+                                    self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
                                     let result = if err.downcast_ref::<StreamGap>().is_some() {
@@ -710,13 +810,7 @@ impl ScraperWebSocketMonitor {
                             if sequence < -1 {
                                 bail!("Invalid negative scraper caught-up sequence {sequence}");
                             }
-                            if let Some(stored) = source.cursor(kind)? {
-                                if sequence < i64::from(stored) {
-                                    bail!(
-                                        "Scraper caught-up sequence {sequence} is behind durable cursor {stored}"
-                                    );
-                                }
-                            }
+                            validate_caught_up_floor(plan, domain, sequence)?;
                             if sequence >= 0 {
                                 let durable: u32 = sequence
                                     .try_into()
@@ -727,12 +821,7 @@ impl ScraperWebSocketMonitor {
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            self.update_source_caught_up(
-                                state,
-                                &correlation_required,
-                                &caught_up,
-                                domain,
-                            )?;
+                            self.update_source_caught_up(state, plan, &caught_up, domain)?;
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -753,8 +842,8 @@ impl ScraperWebSocketMonitor {
         Ok(())
     }
 
-    fn subscription(&self) -> Result<String> {
-        subscription(&self.sources)
+    fn subscription(&self, plan: &SequencedReplayPlan) -> Result<String> {
+        subscription(&self.sources, plan)
     }
 
     fn set_active(&self, active: bool) {
@@ -783,16 +872,11 @@ impl ScraperWebSocketMonitor {
     fn update_source_caught_up(
         &self,
         state: &StreamState,
-        correlation_required: &HashSet<u32>,
+        plan: &SequencedReplayPlan,
         caught_up: &HashMap<(u32, EventKind), i64>,
         domain: u32,
     ) -> Result<()> {
-        if !source_caught_up(
-            correlation_required.contains(&domain),
-            caught_up,
-            state,
-            domain,
-        )? {
+        if !source_caught_up(plan.correlation_required(domain)?, caught_up, state, domain)? {
             return Ok(());
         }
         let source = self
@@ -817,7 +901,10 @@ impl ScraperWebSocketMonitor {
     }
 }
 
-fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
+fn subscription(
+    sources: &HashMap<u32, ScraperSource>,
+    plan: &SequencedReplayPlan,
+) -> Result<String> {
     let mut sources = sources.values().collect::<Vec<_>>();
     sources.sort_unstable_by_key(|source| source.domain);
     let domains = sources
@@ -827,7 +914,7 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     let cursors = |kind| -> Result<Vec<SequenceCursor>> {
         sources
             .iter()
-            .map(|source| sequence_cursor(source, kind))
+            .map(|source| sequence_cursor(source, kind, plan))
             .collect()
     };
     serde_json::to_string(&SubscribeMessage {
@@ -848,15 +935,15 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     .context("Serializing relayer scraper-proxy subscription")
 }
 
-fn sequence_cursor(source: &ScraperSource, kind: EventKind) -> Result<SequenceCursor> {
-    let replay_from = match source.cursor(kind)? {
-        Some(sequence) => Some(sequence),
-        None => source.cursor(kind.counterpart())?,
-    };
+fn sequence_cursor(
+    source: &ScraperSource,
+    kind: EventKind,
+    plan: &SequencedReplayPlan,
+) -> Result<SequenceCursor> {
     Ok(SequenceCursor {
         address: format!("{:#x}", source.address(kind)),
         allow_replay: Some(true),
-        after_sequence: replay_from.map(replay_after_sequence),
+        after_sequence: plan.source(source.domain)?.floor.map(replay_after_sequence),
         domain: source.domain,
     })
 }
@@ -866,6 +953,15 @@ fn replay_after_sequence(sequence: u32) -> String {
         .checked_sub(1)
         .map(|sequence| sequence.to_string())
         .unwrap_or_else(|| "-1".to_owned())
+}
+
+fn validate_caught_up_floor(plan: &SequencedReplayPlan, domain: u32, sequence: i64) -> Result<()> {
+    if let Some(floor) = plan.source(domain)?.floor {
+        if sequence < i64::from(floor) {
+            bail!("Scraper caught-up sequence {sequence} is behind replay floor {floor}");
+        }
+    }
+    Ok(())
 }
 
 fn correlation_ready(
@@ -915,12 +1011,20 @@ fn source_caught_up(
             return Ok(false);
         }
     }
+    if state
+        .correlation_next
+        .get(&domain)
+        .is_none_or(|next| *next <= target)
+    {
+        return Ok(false);
+    }
     correlation_ready(true, state, domain, i64::from(target))
 }
 
 fn validate_subscription(
     streams: &[SubscribedStream],
     sources: &HashMap<u32, ScraperSource>,
+    plan: &SequencedReplayPlan,
 ) -> Result<()> {
     if streams.len() != 2 {
         bail!("Scraper-proxy confirmed an unexpected number of streams");
@@ -938,7 +1042,7 @@ fn validate_subscription(
         let expected_cursors = sources
             .iter()
             .map(|source| {
-                let cursor = sequence_cursor(source, kind)?;
+                let cursor = sequence_cursor(source, kind, plan)?;
                 Ok(SubscribedCursor {
                     address: cursor.address,
                     after_sequence: cursor.after_sequence,
@@ -1127,7 +1231,20 @@ mod tests {
         })
     }
 
-    fn subscribed_streams(sources: &HashMap<u32, ScraperSource>) -> Vec<SubscribedStream> {
+    fn replay_plan(sources: &HashMap<u32, ScraperSource>) -> SequencedReplayPlan {
+        SequencedReplayPlan::load(sources).expect("replay plan")
+    }
+
+    fn replay_state(plan: &SequencedReplayPlan) -> StreamState {
+        let mut state = StreamState::default();
+        state.reset_sequenced(plan);
+        state
+    }
+
+    fn subscribed_streams(
+        sources: &HashMap<u32, ScraperSource>,
+        plan: &SequencedReplayPlan,
+    ) -> Vec<SubscribedStream> {
         let mut sources = sources.values().collect::<Vec<_>>();
         sources.sort_unstable_by_key(|source| source.domain);
         let domains = sources
@@ -1141,7 +1258,7 @@ mod tests {
                     sources
                         .iter()
                         .map(|source| {
-                            let cursor = sequence_cursor(source, kind).expect("cursor read");
+                            let cursor = sequence_cursor(source, kind, plan).expect("cursor read");
                             SubscribedCursor {
                                 address: cursor.address,
                                 after_sequence: cursor.after_sequence,
@@ -1209,7 +1326,8 @@ mod tests {
     #[test]
     fn restores_durable_sequence_after_process_restart() {
         let sources = sources();
-        let mut first_process = StreamState::load(&sources).expect("initial cursor load");
+        let initial_plan = replay_plan(&sources);
+        let mut first_process = replay_state(&initial_plan);
         first_process
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
@@ -1220,7 +1338,8 @@ mod tests {
             .store_cursor(EventKind::Dispatch, 7)
             .expect("store first event cursor");
 
-        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        let restart_plan = replay_plan(&sources);
+        let mut restarted = replay_state(&restart_plan);
         restarted
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
@@ -1244,63 +1363,188 @@ mod tests {
     }
 
     #[test]
-    fn restart_replays_both_stream_boundaries_before_caught_up() {
+    fn fresh_event_anchors_correlation_before_stream_cursor() {
         let sources = sources();
         let source = &sources[&5];
-        source
-            .store_cursor(EventKind::Dispatch, 7)
-            .expect("store dispatch cursor");
-        source
-            .store_cursor(EventKind::MerkleTreeInsertion, 6)
-            .expect("store Merkle cursor");
-
-        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
-        restarted
+        let plan = replay_plan(&sources);
+        let mut state = replay_state(&plan);
+        state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
                 &sources,
             )
-            .expect("replay dispatch boundary");
-        restarted
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    6,
-                    merkle_data_for(
-                        6,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(6, b"six").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("replay Merkle boundary");
-        assert!(!correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
-        restarted
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    7,
-                    merkle_data_for(
-                        7,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(7, b"seven").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("complete split cursor pair");
+            .expect("first event");
 
-        assert!(restarted.cross_stream.entries[&5][&7].complete());
-        assert!(correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
+        let sequence = state
+            .latest_sequence(5, EventKind::Dispatch)
+            .expect("dispatch cursor");
+        let anchor = state
+            .initialize_correlation(5, sequence)
+            .expect("fresh correlation anchor");
+        source
+            .store_correlation_cursor(anchor)
+            .expect("store correlation anchor");
         assert_eq!(
-            restarted
-                .latest_sequence(5, EventKind::MerkleTreeInsertion)
-                .expect("Merkle cursor"),
-            7
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(7)
         );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+
+        source
+            .store_cursor(EventKind::Dispatch, sequence)
+            .expect("store dispatch cursor");
+        let restart_plan = replay_plan(&sources);
+        assert_eq!(restart_plan.source(5).expect("source plan").floor, Some(7));
+    }
+
+    #[test]
+    fn restart_replays_both_stream_boundaries_before_caught_up() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store Merkle cursor");
+        let initial_plan = replay_plan(&sources);
+        assert_eq!(initial_plan.source(5).expect("source plan").floor, Some(90));
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &initial_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+
+        let mut healing = replay_state(&initial_plan);
+        for sequence in 90_u32..=100 {
+            let body = sequence.to_be_bytes();
+            let message_id = dispatch_message(sequence, &body).id();
+            healing
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
+                    ),
+                    &sources,
+                )
+                .expect("replay Merkle event");
+            source
+                .store_cursor(EventKind::MerkleTreeInsertion, sequence)
+                .expect("store Merkle cursor");
+            assert_eq!(
+                healing.advance_correlation(5).expect("advance correlation"),
+                None
+            );
+        }
+        for sequence in 90_u32..=95 {
+            let body = sequence.to_be_bytes();
+            if sequence == 95 {
+                assert!(healing
+                    .validate(
+                        event(
+                            DISPATCH_EVENT_TYPE,
+                            sequence,
+                            dispatch_data(sequence, b"wrong")
+                        ),
+                        &sources,
+                    )
+                    .expect_err("mismatch below high cursor must reject")
+                    .to_string()
+                    .contains("message IDs differ"));
+            }
+            healing
+                .validate(
+                    event(
+                        DISPATCH_EVENT_TYPE,
+                        sequence,
+                        dispatch_data(sequence, &body),
+                    ),
+                    &sources,
+                )
+                .expect("replay dispatch event");
+            source
+                .store_cursor(EventKind::Dispatch, sequence)
+                .expect("store dispatch cursor");
+            if let Some(next) = healing.advance_correlation(5).expect("advance correlation") {
+                source
+                    .store_correlation_cursor(next)
+                    .expect("store correlation cursor");
+            }
+        }
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(96)
+        );
+
+        let restart_plan = replay_plan(&sources);
+        assert_eq!(restart_plan.source(5).expect("source plan").floor, Some(96));
+        let restart_subscription: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &restart_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(
+            restart_subscription["streams"][0]["cursors"][0]["afterSequence"],
+            "95"
+        );
+        assert_eq!(
+            restart_subscription["streams"][1]["cursors"][0]["afterSequence"],
+            "95"
+        );
+
+        let mut restarted = replay_state(&restart_plan);
+        for sequence in 96_u32..=100 {
+            let body = sequence.to_be_bytes();
+            let message_id = dispatch_message(sequence, &body).id();
+            restarted
+                .validate(
+                    event(
+                        DISPATCH_EVENT_TYPE,
+                        sequence,
+                        dispatch_data(sequence, &body),
+                    ),
+                    &sources,
+                )
+                .expect("replay dispatch event after crash");
+            source
+                .store_cursor(EventKind::Dispatch, sequence)
+                .expect("store dispatch cursor");
+            restarted
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
+                    ),
+                    &sources,
+                )
+                .expect("replay Merkle event after crash");
+            source
+                .store_cursor(EventKind::MerkleTreeInsertion, sequence)
+                .expect("store Merkle cursor");
+            if let Some(next) = restarted
+                .advance_correlation(5)
+                .expect("advance correlation")
+            {
+                source
+                    .store_correlation_cursor(next)
+                    .expect("store correlation cursor");
+            }
+        }
+        assert!((96_u32..=100).all(|sequence| restarted.cross_stream.complete(5, sequence)));
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(101)
+        );
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 100),
+            ((5, EventKind::MerkleTreeInsertion), 100),
+        ]);
+        assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
     }
 
     #[test]
@@ -1311,12 +1555,14 @@ mod tests {
             .store_cursor(EventKind::Dispatch, 7)
             .expect("store dispatch cursor");
 
-        let message: serde_json::Value =
-            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
-                .expect("subscription JSON");
+        let plan = replay_plan(&sources);
+        let message: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
         assert_eq!(message["streams"][0]["cursors"][0]["afterSequence"], "6");
         assert_eq!(message["streams"][1]["cursors"][0]["afterSequence"], "6");
-        let streams = subscribed_streams(&sources);
+        let streams = subscribed_streams(&sources, &plan);
         assert_eq!(
             streams[0].cursors.as_ref().expect("dispatch cursors")[0].after_sequence,
             Some("6".to_owned())
@@ -1325,9 +1571,9 @@ mod tests {
             streams[1].cursors.as_ref().expect("Merkle cursors")[0].after_sequence,
             Some("6".to_owned())
         );
-        validate_subscription(&streams, &sources).expect("subscription confirmation");
+        validate_subscription(&streams, &sources, &plan).expect("subscription confirmation");
 
-        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        let mut restarted = replay_state(&plan);
         restarted
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
@@ -1355,7 +1601,48 @@ mod tests {
                 &sources,
             )
             .expect("late Merkle correlation");
+        let next = restarted
+            .advance_correlation(5)
+            .expect("advance correlation")
+            .expect("late pair advances correlation");
+        source
+            .store_correlation_cursor(next)
+            .expect("store correlation cursor");
         assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+    }
+
+    #[test]
+    fn connection_plan_is_immutable_when_durable_cursors_advance() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store Merkle cursor");
+        let plan = replay_plan(&sources);
+
+        source
+            .store_cursor(EventKind::Dispatch, 200)
+            .expect("advance dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 200)
+            .expect("advance Merkle cursor");
+        source
+            .store_correlation_cursor(200)
+            .expect("advance correlation cursor");
+
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+        let streams = subscribed_streams(&sources, &plan);
+        validate_subscription(&streams, &sources, &plan).expect("subscription confirmation");
+        validate_caught_up_floor(&plan, 5, 90).expect("captured replay floor");
+        assert!(validate_caught_up_floor(&plan, 5, 89).is_err());
     }
 
     #[test]
@@ -1572,34 +1859,41 @@ mod tests {
     fn enforces_subscription_handshake_order() {
         let mut handshake = HandshakeState::default();
         let sources = sources();
-        let streams = subscribed_streams(&sources);
+        let plan = replay_plan(&sources);
+        let streams = subscribed_streams(&sources, &plan);
         assert!(handshake.event().is_err());
-        assert!(handshake.subscribed(&streams, &sources).is_err());
+        assert!(handshake.subscribed(&streams, &sources, &plan).is_err());
         handshake.ready().expect("ready");
         assert!(handshake.event().is_err());
         handshake
-            .subscribed(&streams, &sources)
+            .subscribed(&streams, &sources, &plan)
             .expect("subscribed");
         handshake.event().expect("event after confirmation");
-        assert!(handshake.subscribed(&streams, &sources).is_err());
+        assert!(handshake.subscribed(&streams, &sources, &plan).is_err());
         assert!(handshake.ready().is_err());
     }
 
     #[test]
     fn rejects_subscription_confirmation_mismatch() {
         let sources = sources();
+        let plan = replay_plan(&sources);
+        let foreign_sources = sources_for(&[9]);
+        let foreign_plan = replay_plan(&foreign_sources);
         for streams in [
-            subscribed_streams(&sources_for(&[9])),
+            subscribed_streams(&foreign_sources, &foreign_plan),
             vec![SubscribedStream {
                 cursors: None,
                 domains: Some(vec![5]),
                 event_type: DISPATCH_EVENT_TYPE.to_owned(),
             }],
-            subscribed_streams(&sources).into_iter().rev().collect(),
+            subscribed_streams(&sources, &plan)
+                .into_iter()
+                .rev()
+                .collect(),
         ] {
             let mut handshake = HandshakeState::default();
             handshake.ready().expect("ready");
-            assert!(handshake.subscribed(&streams, &sources).is_err());
+            assert!(handshake.subscribed(&streams, &sources, &plan).is_err());
             assert!(!handshake.confirmed);
         }
     }
@@ -1607,9 +1901,11 @@ mod tests {
     #[test]
     fn multiplexes_live_streams_on_one_subscription() {
         let sources = sources_for(&[9, 5]);
-        let message: serde_json::Value =
-            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
-                .expect("subscription JSON");
+        let plan = replay_plan(&sources);
+        let message: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
 
         assert_eq!(
             message,

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -156,6 +156,13 @@ struct CrossStreamState {
 }
 
 impl CrossStreamState {
+    fn complete(&self, domain: u32, sequence: u32) -> bool {
+        self.entries
+            .get(&domain)
+            .and_then(|entries| entries.get(&sequence))
+            .is_some_and(CrossStreamPair::complete)
+    }
+
     fn validate(
         &mut self,
         domain: u32,
@@ -222,6 +229,13 @@ struct StreamCursor {
 }
 
 impl StreamCursor {
+    fn from_durable_sequence(sequence: u32) -> Self {
+        Self {
+            fingerprints: BTreeMap::new(),
+            next_sequence: sequence,
+        }
+    }
+
     fn from_after_sequence(sequence: u32) -> Result<Self> {
         Ok(Self {
             fingerprints: BTreeMap::new(),
@@ -307,7 +321,7 @@ impl StreamState {
                 if let Some(sequence) = source.cursor(kind)? {
                     state.cursors.insert(
                         (source.domain, kind),
-                        StreamCursor::from_after_sequence(sequence)?,
+                        StreamCursor::from_durable_sequence(sequence),
                     );
                 }
             }
@@ -595,7 +609,16 @@ impl ScraperWebSocketMonitor {
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
-        let mut caught_up = HashSet::new();
+        let mut correlation_required = HashSet::new();
+        for source in self.sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                if source.cursor(kind)?.is_some() {
+                    correlation_required.insert(source.domain);
+                    break;
+                }
+            }
+        }
+        let mut caught_up = HashMap::new();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -688,10 +711,25 @@ impl ScraperWebSocketMonitor {
                                 source.store_cursor(kind, durable)?;
                             }
                             state.set_baseline(domain, kind, sequence)?;
-                            if !caught_up.insert((domain, kind)) {
+                            if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            self.set_source_caught_up(source, kind, true);
+                            let counterpart = match kind {
+                                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
+                                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
+                            };
+                            if caught_up.get(&(domain, counterpart)) == Some(&sequence) {
+                                let correlation_complete = correlation_ready(
+                                    correlation_required.contains(&domain),
+                                    state,
+                                    domain,
+                                    sequence,
+                                )?;
+                                if correlation_complete {
+                                    self.set_source_caught_up(source, kind, true);
+                                    self.set_source_caught_up(source, counterpart, true);
+                                }
+                            }
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -765,7 +803,7 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
                 Ok(SequenceCursor {
                     address: format!("{:#x}", source.address(kind)),
                     allow_replay: Some(true),
-                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    after_sequence: source.cursor(kind)?.map(replay_after_sequence),
                     domain: source.domain,
                 })
             })
@@ -787,6 +825,30 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
         message_type: "subscribe",
     })
     .context("Serializing relayer scraper-proxy subscription")
+}
+
+fn replay_after_sequence(sequence: u32) -> String {
+    sequence
+        .checked_sub(1)
+        .map(|sequence| sequence.to_string())
+        .unwrap_or_else(|| "-1".to_owned())
+}
+
+fn correlation_ready(
+    required: bool,
+    state: &StreamState,
+    domain: u32,
+    sequence: i64,
+) -> Result<bool> {
+    if sequence < 0 || !required {
+        return Ok(true);
+    }
+    Ok(state.cross_stream.complete(
+        domain,
+        sequence
+            .try_into()
+            .context("Caught-up sequence exceeds u32")?,
+    ))
 }
 
 fn validate_subscription(
@@ -1015,7 +1077,7 @@ mod tests {
                             after_sequence: source
                                 .cursor(kind)
                                 .expect("cursor read")
-                                .map(|value| value.to_string()),
+                                .map(replay_after_sequence),
                             domain: source.domain,
                         })
                         .collect(),
@@ -1091,6 +1153,12 @@ mod tests {
             .expect("store first event cursor");
 
         let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("replay durable boundary");
         assert!(restarted
             .validate(
                 event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
@@ -1105,6 +1173,66 @@ mod tests {
                 &sources,
             )
             .expect("replayed event after durable cursor");
+    }
+
+    #[test]
+    fn restart_replays_both_stream_boundaries_before_caught_up() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 7)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 6)
+            .expect("store Merkle cursor");
+
+        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("replay dispatch boundary");
+        restarted
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    6,
+                    merkle_data_for(
+                        6,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(6, b"six").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("replay Merkle boundary");
+        assert!(!correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
+        restarted
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(
+                        7,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(7, b"seven").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("complete split cursor pair");
+
+        assert!(restarted.cross_stream.entries[&5][&7].complete());
+        assert!(correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
+        assert_eq!(
+            restarted
+                .latest_sequence(5, EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            7
+        );
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,16 +1,17 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     time::Duration,
 };
 
 use eyre::{bail, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
+    db::HyperlaneRocksDB,
     scraper_websocket::{
-        EventMessage, ServerMessage, StringOrNumber, SubscribeMessage, SubscribeStream,
-        SubscribedStream,
+        EventMessage, SequenceCursor, ServerMessage, StringOrNumber, SubscribeMessage,
+        SubscribeStream, SubscribedCursor, SubscribedStream,
     },
     CoreMetrics,
 };
@@ -29,23 +30,55 @@ const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
+const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
+const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
     chain: String,
+    db: HyperlaneRocksDB,
     domain: u32,
     mailbox: H256,
     merkle_tree_hook: H256,
 }
 
 impl ScraperSource {
-    pub(crate) fn new(chain: String, domain: u32, mailbox: H256, merkle_tree_hook: H256) -> Self {
+    pub(crate) fn new(
+        chain: String,
+        db: HyperlaneRocksDB,
+        domain: u32,
+        mailbox: H256,
+        merkle_tree_hook: H256,
+    ) -> Self {
         Self {
             chain,
+            db,
             domain,
             mailbox,
             merkle_tree_hook,
         }
+    }
+
+    fn address(&self, kind: EventKind) -> H256 {
+        match kind {
+            EventKind::Dispatch => self.mailbox,
+            EventKind::MerkleTreeInsertion => self.merkle_tree_hook,
+        }
+    }
+
+    fn cursor(&self, kind: EventKind) -> Result<Option<u32>> {
+        self.db
+            .retrieve_value_by_key(kind.cursor_prefix(), &self.address(kind))
+            .context("Reading durable scraper WebSocket cursor")
+    }
+
+    fn store_cursor(&self, kind: EventKind, sequence: u32) -> Result<()> {
+        if self.cursor(kind)?.is_some_and(|stored| stored >= sequence) {
+            return Ok(());
+        }
+        self.db
+            .store_value_by_key(kind.cursor_prefix(), &self.address(kind), &sequence)
+            .context("Storing durable scraper WebSocket cursor")
     }
 }
 
@@ -60,6 +93,21 @@ impl EventKind {
         match self {
             Self::Dispatch => DISPATCH_EVENT_TYPE,
             Self::MerkleTreeInsertion => MERKLE_EVENT_TYPE,
+        }
+    }
+
+    fn cursor_prefix(self) -> &'static [u8] {
+        match self {
+            Self::Dispatch => DISPATCH_CURSOR_PREFIX,
+            Self::MerkleTreeInsertion => MERKLE_CURSOR_PREFIX,
+        }
+    }
+
+    fn from_label(label: &str) -> Result<Self> {
+        match label {
+            DISPATCH_EVENT_TYPE => Ok(Self::Dispatch),
+            MERKLE_EVENT_TYPE => Ok(Self::MerkleTreeInsertion),
+            _ => bail!("Unexpected scraper event type {label}"),
         }
     }
 }
@@ -144,6 +192,9 @@ impl CrossStreamState {
         } else {
             None
         };
+        if let Some(mismatch) = mismatch {
+            bail!(mismatch);
+        }
         if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
             let oldest_complete = entries
                 .first_key_value()
@@ -158,9 +209,6 @@ impl CrossStreamState {
         }
         let pair = entries.entry(sequence).or_default();
         *pair.get_mut(kind) = Some(projection);
-        if let Some(mismatch) = mismatch {
-            bail!(mismatch);
-        }
         Ok(())
     }
 }
@@ -174,6 +222,15 @@ struct StreamCursor {
 }
 
 impl StreamCursor {
+    fn from_after_sequence(sequence: u32) -> Result<Self> {
+        Ok(Self {
+            fingerprints: BTreeMap::new(),
+            next_sequence: sequence
+                .checked_add(1)
+                .context("Scraper event sequence exhausted")?,
+        })
+    }
+
     fn new(sequence: u32, fingerprint: EventFingerprint) -> Result<Self> {
         let mut fingerprints = BTreeMap::new();
         fingerprints.insert(sequence, fingerprint);
@@ -185,7 +242,7 @@ impl StreamCursor {
         })
     }
 
-    fn validate(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<SequenceResult> {
+    fn check(&self, sequence: u32, fingerprint: EventFingerprint) -> Result<SequenceResult> {
         if sequence < self.next_sequence {
             return match self.fingerprints.get(&sequence) {
                 Some(previous) if previous == &fingerprint => Ok(SequenceResult::Duplicate),
@@ -203,7 +260,15 @@ impl StreamCursor {
             .into());
         }
 
-        let next_sequence = self
+        self.next_sequence
+            .checked_add(1)
+            .context("Scraper event sequence exhausted")?;
+
+        Ok(SequenceResult::Accepted)
+    }
+
+    fn accept(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<()> {
+        self.next_sequence = self
             .next_sequence
             .checked_add(1)
             .context("Scraper event sequence exhausted")?;
@@ -211,8 +276,13 @@ impl StreamCursor {
         while self.fingerprints.len() > DUPLICATE_FINGERPRINT_WINDOW {
             self.fingerprints.pop_first();
         }
-        self.next_sequence = next_sequence;
-        Ok(SequenceResult::Accepted)
+        Ok(())
+    }
+
+    fn latest_sequence(&self) -> Result<u32> {
+        self.next_sequence
+            .checked_sub(1)
+            .context("Scraper cursor has no accepted sequence")
     }
 }
 
@@ -230,6 +300,40 @@ struct StreamState {
 }
 
 impl StreamState {
+    fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
+        let mut state = Self::default();
+        for source in sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                if let Some(sequence) = source.cursor(kind)? {
+                    state.cursors.insert(
+                        (source.domain, kind),
+                        StreamCursor::from_after_sequence(sequence)?,
+                    );
+                }
+            }
+        }
+        Ok(state)
+    }
+
+    fn set_baseline(&mut self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
+        if self.cursors.contains_key(&(domain, kind)) || sequence < 0 {
+            return Ok(());
+        }
+        let sequence: u32 = sequence
+            .try_into()
+            .context("Scraper caught-up sequence exceeds u32")?;
+        self.cursors
+            .insert((domain, kind), StreamCursor::from_after_sequence(sequence)?);
+        Ok(())
+    }
+
+    fn latest_sequence(&self, domain: u32, kind: EventKind) -> Result<u32> {
+        self.cursors
+            .get(&(domain, kind))
+            .context("Validated scraper stream has no cursor")?
+            .latest_sequence()
+    }
+
     fn validate(
         &mut self,
         event: EventMessage<serde_json::Value>,
@@ -340,16 +444,28 @@ impl StreamState {
         };
 
         let key = (event.domain, kind);
-        let result = match self.cursors.get_mut(&key) {
-            Some(cursor) => cursor.validate(sequence, fingerprint)?,
-            None => {
-                self.cursors
-                    .insert(key, StreamCursor::new(sequence, fingerprint)?);
-                SequenceResult::Accepted
-            }
+        let new_cursor = if self.cursors.contains_key(&key) {
+            None
+        } else {
+            Some(StreamCursor::new(sequence, fingerprint)?)
+        };
+        let result = match self.cursors.get(&key) {
+            Some(cursor) => cursor.check(sequence, fingerprint)?,
+            None => SequenceResult::Accepted,
         };
         self.cross_stream
             .validate(event.domain, sequence, kind, projection)?;
+        if result == SequenceResult::Accepted {
+            match self.cursors.get_mut(&key) {
+                Some(cursor) => cursor.accept(sequence, fingerprint)?,
+                None => {
+                    let _ = self.cursors.insert(
+                        key,
+                        new_cursor.expect("new cursor is prepared before persistence"),
+                    );
+                }
+            }
+        }
         Ok((kind, result))
     }
 }
@@ -369,14 +485,18 @@ impl HandshakeState {
         Ok(())
     }
 
-    fn subscribed(&mut self, streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
+    fn subscribed(
+        &mut self,
+        streams: &[SubscribedStream],
+        sources: &HashMap<u32, ScraperSource>,
+    ) -> Result<()> {
         if !self.sent {
             bail!("Received subscribed before ready");
         }
         if self.confirmed {
             bail!("Received duplicate scraper-proxy subscribed message");
         }
-        validate_subscription(streams, domains)?;
+        validate_subscription(streams, sources)?;
         self.confirmed = true;
         Ok(())
     }
@@ -392,6 +512,7 @@ impl HandshakeState {
 /// One process-wide, read-only scraper stream monitor.
 pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
+    caught_up: IntGaugeVec,
     events: IntCounterVec,
     sources: HashMap<u32, ScraperSource>,
     url: Url,
@@ -413,15 +534,26 @@ impl ScraperWebSocketMonitor {
             "Scraper-proxy shadow events validated by the relayer",
             &["chain", "event_type", "result"],
         )?;
+        let caught_up = metrics.new_int_gauge(
+            "relayer_scraper_websocket_caught_up",
+            "Whether scraper-proxy replay reached the durable cursor",
+            &["chain", "event_type"],
+        )?;
         let sources = sources
             .into_iter()
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
         for source in sources.values() {
             active.with_label_values(&[&source.chain]).set(0);
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                caught_up
+                    .with_label_values(&[&source.chain, kind.label()])
+                    .set(0);
+            }
         }
         Ok(Self {
             active,
+            caught_up,
             events,
             sources,
             url,
@@ -429,9 +561,21 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
-        let mut state = StreamState::default();
+        let mut state = loop {
+            match StreamState::load(&self.sources) {
+                Ok(state) => break state,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        "Loading durable scraper WebSocket cursors failed; retrying"
+                    );
+                    sleep(RETRY_DELAY).await;
+                }
+            }
+        };
         loop {
             self.set_active(false);
+            self.set_caught_up(false);
             match self.stream(&mut state).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
@@ -440,6 +584,7 @@ impl ScraperWebSocketMonitor {
                 ),
             }
             self.set_active(false);
+            self.set_caught_up(false);
             sleep(RETRY_DELAY).await;
         }
     }
@@ -450,6 +595,7 @@ impl ScraperWebSocketMonitor {
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
+        let mut caught_up = HashSet::new();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -474,7 +620,7 @@ impl ScraperWebSocketMonitor {
                                 .context("Subscribing to relayer scraper-proxy streams")?;
                         }
                         ServerMessage::Subscribed { streams } => {
-                            handshake.subscribed(&streams, &self.domains())?;
+                            handshake.subscribed(&streams, &self.sources)?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
@@ -483,11 +629,17 @@ impl ScraperWebSocketMonitor {
                             let domain = event.domain;
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
-                                Ok((kind, SequenceResult::Accepted)) => {
-                                    self.record(domain, kind.label(), "accepted")
-                                }
-                                Ok((kind, SequenceResult::Duplicate)) => {
-                                    self.record(domain, kind.label(), "duplicate")
+                                Ok((kind, sequence_result)) => {
+                                    let sequence = state.latest_sequence(domain, kind)?;
+                                    self.sources
+                                        .get(&domain)
+                                        .expect("validated scraper source exists")
+                                        .store_cursor(kind, sequence)?;
+                                    let result = match sequence_result {
+                                        SequenceResult::Accepted => "accepted",
+                                        SequenceResult::Duplicate => "duplicate",
+                                    };
+                                    self.record(domain, kind.label(), result)
                                 }
                                 Err(err) => {
                                     let result = if err.downcast_ref::<StreamGap>().is_some() {
@@ -500,8 +652,46 @@ impl ScraperWebSocketMonitor {
                                 }
                             }
                         }
-                        ServerMessage::CaughtUp { .. } => {
-                            bail!("Live-only relayer shadow stream received caught-up marker")
+                        ServerMessage::CaughtUp {
+                            address,
+                            domain,
+                            event_type,
+                            sequence,
+                        } => {
+                            handshake.event()?;
+                            let kind = EventKind::from_label(&event_type)?;
+                            let source = self.sources.get(&domain).with_context(|| {
+                                format!("Unexpected scraper caught-up domain {domain}")
+                            })?;
+                            if parse_address(&address)? != source.address(kind) {
+                                bail!(
+                                    "Scraper caught-up address does not match configured contract"
+                                );
+                            }
+                            let sequence = sequence
+                                .parse::<i64>()
+                                .context("Invalid scraper caught-up sequence")?;
+                            if sequence < -1 {
+                                bail!("Invalid negative scraper caught-up sequence {sequence}");
+                            }
+                            if let Some(stored) = source.cursor(kind)? {
+                                if sequence < i64::from(stored) {
+                                    bail!(
+                                        "Scraper caught-up sequence {sequence} is behind durable cursor {stored}"
+                                    );
+                                }
+                            }
+                            if sequence >= 0 {
+                                let durable: u32 = sequence
+                                    .try_into()
+                                    .context("Scraper caught-up sequence exceeds u32")?;
+                                source.store_cursor(kind, durable)?;
+                            }
+                            state.set_baseline(domain, kind, sequence)?;
+                            if !caught_up.insert((domain, kind)) {
+                                bail!("Received duplicate scraper caught-up marker");
+                            }
+                            self.set_source_caught_up(source, kind, true);
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -523,13 +713,7 @@ impl ScraperWebSocketMonitor {
     }
 
     fn subscription(&self) -> Result<String> {
-        subscription(self.domains())
-    }
-
-    fn domains(&self) -> Vec<u32> {
-        let mut domains = self.sources.keys().copied().collect::<Vec<_>>();
-        domains.sort_unstable();
-        domains
+        subscription(&self.sources)
     }
 
     fn set_active(&self, active: bool) {
@@ -537,6 +721,20 @@ impl ScraperWebSocketMonitor {
         for source in self.sources.values() {
             self.active.with_label_values(&[&source.chain]).set(value);
         }
+    }
+
+    fn set_caught_up(&self, caught_up: bool) {
+        for source in self.sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                self.set_source_caught_up(source, kind, caught_up);
+            }
+        }
+    }
+
+    fn set_source_caught_up(&self, source: &ScraperSource, kind: EventKind, caught_up: bool) {
+        self.caught_up
+            .with_label_values(&[&source.chain, kind.label()])
+            .set(i64::from(caught_up));
     }
 
     fn record(&self, domain: u32, event_type: &str, result: &str) {
@@ -551,17 +749,35 @@ impl ScraperWebSocketMonitor {
     }
 }
 
-fn subscription(mut domains: Vec<u32>) -> Result<String> {
-    domains.sort_unstable();
+fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
+    let mut sources = sources.values().collect::<Vec<_>>();
+    sources.sort_unstable_by_key(|source| source.domain);
+    let domains = sources
+        .iter()
+        .map(|source| source.domain)
+        .collect::<Vec<_>>();
+    let cursors = |kind| -> Result<Vec<SequenceCursor>> {
+        sources
+            .iter()
+            .map(|source| {
+                Ok(SequenceCursor {
+                    address: format!("{:#x}", source.address(kind)),
+                    allow_replay: Some(true),
+                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    domain: source.domain,
+                })
+            })
+            .collect()
+    };
     serde_json::to_string(&SubscribeMessage {
         streams: vec![
             SubscribeStream {
-                cursors: None,
+                cursors: Some(cursors(EventKind::Dispatch)?),
                 domains: Some(domains.clone()),
                 event_type: DISPATCH_EVENT_TYPE,
             },
             SubscribeStream {
-                cursors: None,
+                cursors: Some(cursors(EventKind::MerkleTreeInsertion)?),
                 domains: Some(domains),
                 event_type: MERKLE_EVENT_TYPE,
             },
@@ -571,14 +787,36 @@ fn subscription(mut domains: Vec<u32>) -> Result<String> {
     .context("Serializing relayer scraper-proxy subscription")
 }
 
-fn validate_subscription(streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
+fn validate_subscription(
+    streams: &[SubscribedStream],
+    sources: &HashMap<u32, ScraperSource>,
+) -> Result<()> {
     if streams.len() != 2 {
         bail!("Scraper-proxy confirmed an unexpected number of streams");
     }
-    for (stream, event_type) in streams.iter().zip([DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]) {
-        if stream.event_type != event_type
-            || stream.cursors.is_some()
-            || stream.domains.as_deref() != Some(domains)
+    let mut sources = sources.values().collect::<Vec<_>>();
+    sources.sort_unstable_by_key(|source| source.domain);
+    let domains = sources
+        .iter()
+        .map(|source| source.domain)
+        .collect::<Vec<_>>();
+    for (stream, kind) in streams
+        .iter()
+        .zip([EventKind::Dispatch, EventKind::MerkleTreeInsertion])
+    {
+        let expected_cursors = sources
+            .iter()
+            .map(|source| {
+                Ok(SubscribedCursor {
+                    address: format!("{:#x}", source.address(kind)),
+                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    domain: source.domain,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if stream.event_type != kind.label()
+            || stream.cursors.as_deref() != Some(expected_cursors.as_slice())
+            || stream.domains.as_deref() != Some(domains.as_slice())
         {
             bail!("Scraper-proxy subscription confirmation does not match request");
         }
@@ -662,17 +900,36 @@ fn event_label(event_type: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyperlane_base::db::test_utils;
+    use hyperlane_core::HyperlaneDomain;
 
     fn sources() -> HashMap<u32, ScraperSource> {
-        HashMap::from([(
-            5,
-            ScraperSource::new(
-                "test".to_owned(),
-                5,
-                H256::from_low_u64_be(1),
-                H256::from_low_u64_be(2),
-            ),
-        )])
+        sources_for(&[5])
+    }
+
+    fn sources_for(domains: &[u32]) -> HashMap<u32, ScraperSource> {
+        let tempdir = tempfile::tempdir().expect("temporary scraper cursor DB");
+        let db = test_utils::setup_db(tempdir.path().to_string_lossy().into_owned());
+        std::mem::forget(tempdir);
+        domains
+            .iter()
+            .copied()
+            .map(|domain| {
+                let chain = format!("test-{domain}");
+                let db =
+                    HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain(&chain), db.clone());
+                (
+                    domain,
+                    ScraperSource::new(
+                        chain,
+                        db,
+                        domain,
+                        H256::from_low_u64_be(1),
+                        H256::from_low_u64_be(2),
+                    ),
+                )
+            })
+            .collect()
     }
 
     fn event(
@@ -738,13 +995,31 @@ mod tests {
         })
     }
 
-    fn subscribed_streams(domains: &[u32]) -> Vec<SubscribedStream> {
-        [DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]
+    fn subscribed_streams(sources: &HashMap<u32, ScraperSource>) -> Vec<SubscribedStream> {
+        let mut sources = sources.values().collect::<Vec<_>>();
+        sources.sort_unstable_by_key(|source| source.domain);
+        let domains = sources
+            .iter()
+            .map(|source| source.domain)
+            .collect::<Vec<_>>();
+        [EventKind::Dispatch, EventKind::MerkleTreeInsertion]
             .into_iter()
-            .map(|event_type| SubscribedStream {
-                cursors: None,
-                domains: Some(domains.to_vec()),
-                event_type: event_type.to_owned(),
+            .map(|kind| SubscribedStream {
+                cursors: Some(
+                    sources
+                        .iter()
+                        .map(|source| SubscribedCursor {
+                            address: format!("{:#x}", source.address(kind)),
+                            after_sequence: source
+                                .cursor(kind)
+                                .expect("cursor read")
+                                .map(|value| value.to_string()),
+                            domain: source.domain,
+                        })
+                        .collect(),
+                ),
+                domains: Some(domains.clone()),
+                event_type: kind.label().to_owned(),
             })
             .collect()
     }
@@ -797,6 +1072,37 @@ mod tests {
             .expect_err("gap must reject")
             .to_string()
             .contains("expected sequence 8"));
+    }
+
+    #[test]
+    fn restores_durable_sequence_after_process_restart() {
+        let sources = sources();
+        let mut first_process = StreamState::load(&sources).expect("initial cursor load");
+        first_process
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("persist first event");
+        sources[&5]
+            .store_cursor(EventKind::Dispatch, 7)
+            .expect("store first event cursor");
+
+        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        assert!(restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
+                &sources,
+            )
+            .expect_err("restart gap must reject")
+            .to_string()
+            .contains("expected sequence 8"));
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"eight")),
+                &sources,
+            )
+            .expect("replayed event after durable cursor");
     }
 
     #[test]
@@ -1006,51 +1312,66 @@ mod tests {
     #[test]
     fn enforces_subscription_handshake_order() {
         let mut handshake = HandshakeState::default();
-        let domains = [5];
-        let streams = subscribed_streams(&domains);
+        let sources = sources();
+        let streams = subscribed_streams(&sources);
         assert!(handshake.event().is_err());
-        assert!(handshake.subscribed(&streams, &domains).is_err());
+        assert!(handshake.subscribed(&streams, &sources).is_err());
         handshake.ready().expect("ready");
         assert!(handshake.event().is_err());
         handshake
-            .subscribed(&streams, &domains)
+            .subscribed(&streams, &sources)
             .expect("subscribed");
         handshake.event().expect("event after confirmation");
-        assert!(handshake.subscribed(&streams, &domains).is_err());
+        assert!(handshake.subscribed(&streams, &sources).is_err());
         assert!(handshake.ready().is_err());
     }
 
     #[test]
     fn rejects_subscription_confirmation_mismatch() {
-        let domains = [5];
+        let sources = sources();
         for streams in [
-            subscribed_streams(&[9]),
+            subscribed_streams(&sources_for(&[9])),
             vec![SubscribedStream {
                 cursors: None,
-                domains: Some(domains.to_vec()),
+                domains: Some(vec![5]),
                 event_type: DISPATCH_EVENT_TYPE.to_owned(),
             }],
-            subscribed_streams(&domains).into_iter().rev().collect(),
+            subscribed_streams(&sources).into_iter().rev().collect(),
         ] {
             let mut handshake = HandshakeState::default();
             handshake.ready().expect("ready");
-            assert!(handshake.subscribed(&streams, &domains).is_err());
+            assert!(handshake.subscribed(&streams, &sources).is_err());
             assert!(!handshake.confirmed);
         }
     }
 
     #[test]
     fn multiplexes_live_streams_on_one_subscription() {
+        let sources = sources_for(&[9, 5]);
         let message: serde_json::Value =
-            serde_json::from_str(&subscription(vec![9, 5]).expect("subscription should serialize"))
+            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
                 .expect("subscription JSON");
 
         assert_eq!(
             message,
             serde_json::json!({
                 "streams": [
-                    { "domains": [5, 9], "eventType": "dispatch" },
-                    { "domains": [5, 9], "eventType": "merkle_tree_insertion" }
+                    {
+                        "cursors": [
+                            { "address": format!("{:#x}", H256::from_low_u64_be(1)), "allowReplay": true, "domain": 5 },
+                            { "address": format!("{:#x}", H256::from_low_u64_be(1)), "allowReplay": true, "domain": 9 }
+                        ],
+                        "domains": [5, 9],
+                        "eventType": "dispatch"
+                    },
+                    {
+                        "cursors": [
+                            { "address": format!("{:#x}", H256::from_low_u64_be(2)), "allowReplay": true, "domain": 5 },
+                            { "address": format!("{:#x}", H256::from_low_u64_be(2)), "allowReplay": true, "domain": 9 }
+                        ],
+                        "domains": [5, 9],
+                        "eventType": "merkle_tree_insertion"
+                    }
                 ],
                 "type": "subscribe"
             })

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -73,6 +73,8 @@ pub struct RelayerSettings {
     pub tx_id_indexing_enabled: bool,
     /// Whether to enable IGP indexing.
     pub igp_indexing_enabled: bool,
+    /// Optional scraper-proxy WebSocket used for shadow stream validation.
+    pub websocket_url: Option<url::Url>,
     /// Whether to enable the relay API endpoint (default: false)
     ///
     /// # Deployment requirement
@@ -404,6 +406,20 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_bool()
             .unwrap_or(true);
 
+        let websocket_url: Option<url::Url> = p
+            .chain(&mut err)
+            .get_opt_key("websocketUrl")
+            .parse_from_str("Expected a valid scraper-proxy WebSocket URL")
+            .end();
+        if let Some(url) = &websocket_url {
+            if !matches!(url.scheme(), "ws" | "wss") {
+                err.push(
+                    cwp.clone(),
+                    eyre::eyre!("`websocketUrl` must use ws:// or wss://"),
+                );
+            }
+        }
+
         let relay_api_enabled = p
             .chain(&mut err)
             .get_opt_key("relayApiEnabled")
@@ -480,6 +496,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             max_retries: max_message_retries,
             tx_id_indexing_enabled,
             igp_indexing_enabled,
+            websocket_url,
             relay_api_enabled,
             relay_api_port,
             relay_api_rate_limit_max_requests,
@@ -660,5 +677,37 @@ mod test {
             }],
         }))
         .expect("zero feeToken should parse");
+    }
+
+    #[test]
+    fn parses_scraper_websocket_url() {
+        let settings = parse_settings(json!({
+            "relaychains": "legacy",
+            "websocketurl": "wss://scraper.example/ws/events",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+        }))
+        .expect("valid WebSocket URL should parse");
+
+        assert_eq!(
+            settings.websocket_url.expect("configured URL").as_str(),
+            "wss://scraper.example/ws/events"
+        );
+    }
+
+    #[test]
+    fn rejects_non_websocket_scraper_url() {
+        let error = parse_settings(json!({
+            "relaychains": "legacy",
+            "websocketurl": "https://scraper.example/ws/events",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+        }))
+        .expect_err("HTTP URL must reject")
+        .to_string();
+
+        assert!(error.contains("must use ws:// or wss://"));
     }
 }

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -535,7 +535,7 @@ impl MerkleTreeHookWebSocketSync {
                             .context("Subscribing to Merkle tree hook insertions")?;
                         subscription_state = next_state;
                     }
-                    ServerMessage::Subscribed => {
+                    ServerMessage::Subscribed { .. } => {
                         subscription_state = subscription_state.receive_subscribed()?;
                         if *next_sequence < backfill_target {
                             info!(

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -1772,7 +1772,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -1934,7 +1936,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -2028,7 +2032,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -2147,7 +2153,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -2262,7 +2270,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             while calls_in_server.load(Ordering::SeqCst) == 0 {
@@ -2378,7 +2388,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -927,8 +927,15 @@ impl MerkleTreeHookWebSocketSync {
             bail!("Unexpected Merkle tree hook caught-up marker");
         }
         let sequence = sequence
-            .parse::<u32>()
+            .parse::<i64>()
             .context("Invalid caught-up sequence")?;
+        if sequence == -1 {
+            if next_sequence != 0 {
+                bail!("Empty caught-up marker does not match validator cursor");
+            }
+            return Ok(true);
+        }
+        let sequence = u32::try_from(sequence).context("Invalid caught-up sequence")?;
         if sequence >= next_sequence {
             bail!("Caught-up marker skipped Merkle tree insertions");
         }
@@ -1888,6 +1895,15 @@ mod tests {
             .expect("stale marker"));
         assert!(sync
             .validate_caught_up(&hook, 1, EVENT_TYPE, "2", 2)
+            .is_err());
+        assert!(sync
+            .validate_caught_up(&hook, 1, EVENT_TYPE, "-1", 0)
+            .expect("empty marker at empty cursor"));
+        assert!(sync
+            .validate_caught_up(&hook, 1, EVENT_TYPE, "-1", 1)
+            .is_err());
+        assert!(sync
+            .validate_caught_up(&hook, 1, EVENT_TYPE, "-2", 0)
             .is_err());
     }
 

--- a/rust/main/hyperlane-base/src/scraper_websocket.rs
+++ b/rust/main/hyperlane-base/src/scraper_websocket.rs
@@ -51,7 +51,10 @@ pub enum ServerMessage<T> {
     /// The connection is ready to receive a subscription.
     Ready,
     /// The subscription was accepted.
-    Subscribed,
+    Subscribed {
+        /// Streams accepted by scraper-proxy.
+        streams: Vec<SubscribedStream>,
+    },
     /// Historical replay reached the scraper's current cursor.
     #[serde(rename_all = "camelCase")]
     CaughtUp {
@@ -74,6 +77,30 @@ pub enum ServerMessage<T> {
     /// A forwards-compatible protocol message not understood by this client.
     #[serde(other)]
     Other,
+}
+
+/// One stream echoed by scraper-proxy after subscription.
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SubscribedStream {
+    /// Durable cursors accepted for this stream.
+    pub cursors: Option<Vec<SubscribedCursor>>,
+    /// Domains accepted for this stream.
+    pub domains: Option<Vec<u32>>,
+    /// Scraper event type.
+    pub event_type: String,
+}
+
+/// One durable cursor echoed by scraper-proxy after subscription.
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SubscribedCursor {
+    /// Contract address encoded for scraper-proxy.
+    pub address: String,
+    /// Last processed sequence, encoded as a decimal string.
+    pub after_sequence: Option<String>,
+    /// Hyperlane domain identifier.
+    pub domain: u32,
 }
 
 /// Common envelope around scraper event-specific data.
@@ -226,6 +253,30 @@ mod tests {
         match message {
             ServerMessage::Event(event) => assert_eq!(event.sequence, None),
             _ => panic!("expected event"),
+        }
+    }
+
+    #[test]
+    fn deserializes_subscription_confirmation() {
+        let message: ServerMessage<TestData> = serde_json::from_value(serde_json::json!({
+            "type": "subscribed",
+            "streams": [{
+                "domains": [5, 9],
+                "eventType": "dispatch"
+            }]
+        }))
+        .expect("subscription confirmation should deserialize");
+
+        match message {
+            ServerMessage::Subscribed { streams } => assert_eq!(
+                streams,
+                vec![SubscribedStream {
+                    cursors: None,
+                    domains: Some(vec![5, 9]),
+                    event_type: "dispatch".to_owned(),
+                }]
+            ),
+            _ => panic!("expected subscription confirmation"),
         }
     }
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -793,6 +793,7 @@ const hyperlane: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayer,
@@ -869,6 +870,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
     index: { from: RELEASE_CANDIDATE_INDEX_FROM },
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerRC,
@@ -1012,6 +1014,7 @@ const fastPath: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerFastPath,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -241,6 +241,7 @@ const hyperlane: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayer,
@@ -305,6 +306,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
     index: { from: RELEASE_CANDIDATE_INDEX_FROM },
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerRC,
@@ -349,6 +351,7 @@ const fastPath: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerFastPath,

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -84,6 +84,7 @@ export interface BaseRelayerConfig {
   batch?: RelayerBatchConfig;
   txIdIndexingEnabled?: boolean;
   igpIndexingEnabled?: boolean;
+  websocketUrl?: string;
   reorgPeriodOverrides?: ChainMap<number>;
   interval?: number;
   relayApi?: RelayApiConfig;
@@ -196,6 +197,9 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
     relayerConfig.allowContractCallCaching = baseConfig.cache?.enabled ?? false;
     relayerConfig.txIdIndexingEnabled = baseConfig.txIdIndexingEnabled ?? true;
     relayerConfig.igpIndexingEnabled = baseConfig.igpIndexingEnabled ?? true;
+    if (baseConfig.websocketUrl !== undefined) {
+      relayerConfig.websocketUrl = baseConfig.websocketUrl;
+    }
     if (baseConfig.relayApi !== undefined) {
       relayerConfig.relayApiEnabled = baseConfig.relayApi.enabled;
       if (baseConfig.relayApi.port !== undefined) {

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -207,13 +207,22 @@ describe('Agent configs', () => {
     });
 
     Object.entries(agents).forEach(([context, config]) => {
-      if (!config.validators) return;
+      const { relayer, validators } = config;
+      if (validators) {
+        it(`configures ${environment}/${context} validators for the shared scraper`, () => {
+          expect(validators.websocketUrl).to.equal(
+            `ws://scraper-proxy.${environment}.svc.cluster.local:8383/agents`,
+          );
+        });
+      }
 
-      it(`configures ${environment}/${context} validators for the shared scraper`, () => {
-        expect(config.validators?.websocketUrl).to.equal(
-          `ws://scraper-proxy.${environment}.svc.cluster.local:8383/agents`,
-        );
-      });
+      if (relayer) {
+        it(`configures ${environment}/${context} relayers for the shared scraper`, () => {
+          expect(relayer.websocketUrl).to.equal(
+            `ws://scraper-proxy.${environment}.svc.cluster.local:8383/agents`,
+          );
+        });
+      }
     });
   });
 

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -547,7 +547,7 @@ void it('enforces the catch-up deadline while pending rows replenish', async (co
   }
 });
 
-void it('rejects an empty historical cursor instead of reporting caught up', async () => {
+void it('reports a fresh empty historical cursor at -1', async () => {
   const socket = new WebSocket(url);
   const messages: Record<string, unknown>[] = [];
   socket.on('message', (data) => {
@@ -558,7 +558,38 @@ void it('rejects an empty historical cursor instead of reporting caught up', asy
         JSON.stringify({
           streams: [
             {
-              cursors: [{ address: emptyHook, afterSequence: '-1', domain: 1 }],
+              cursors: [{ address: emptyHook, domain: 1 }],
+              eventType: 'merkle_tree_insertion',
+            },
+          ],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+  const message = await waitFor(messages, 'caught_up');
+  assert.equal(message.address, '0xcccccccccccccccccccccccccccccccccccccccc');
+  assert.equal(message.sequence, '-1');
+  assert.equal(
+    messages.some(({ type }) => type === 'error'),
+    false,
+  );
+  socket.close();
+  await new Promise<void>((resolve) => socket.once('close', resolve));
+});
+
+void it('rejects a durable cursor when its history is empty', async () => {
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    messages.push(message);
+    if (message.type === 'ready') {
+      socket.send(
+        JSON.stringify({
+          streams: [
+            {
+              cursors: [{ address: emptyHook, afterSequence: '0', domain: 1 }],
               eventType: 'merkle_tree_insertion',
             },
           ],
@@ -571,6 +602,49 @@ void it('rejects an empty historical cursor instead of reporting caught up', asy
   assert.equal(message.error, 'Failed to catch up merkle_tree_insertion');
   assert.equal(
     messages.some(({ type }) => type === 'caught_up'),
+    false,
+  );
+  socket.close();
+  await new Promise<void>((resolve) => socket.once('close', resolve));
+});
+
+void it('catches up populated and fresh empty origins together', async () => {
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    messages.push(message);
+    if (message.type === 'ready') {
+      socket.send(
+        JSON.stringify({
+          streams: [
+            {
+              cursors: [
+                { address: hookA, afterSequence: '-1', domain: 1 },
+                { address: emptyHook, domain: 2 },
+              ],
+              eventType: 'merkle_tree_insertion',
+            },
+          ],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+  await waitUntil(
+    () => messages.filter(({ type }) => type === 'caught_up').length === 2,
+  );
+  assert.deepEqual(
+    messages
+      .filter(({ type }) => type === 'caught_up')
+      .map(({ domain, sequence }) => [domain, sequence]),
+    [
+      [1, '0'],
+      [2, '-1'],
+    ],
+  );
+  assert.equal(
+    messages.some(({ type }) => type === 'error'),
     false,
   );
   socket.close();

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -644,9 +644,19 @@ export class EventWebSocketServer {
     const key = sequenceKey(cursor.domain, cursor.address);
     const { first, last } = await this.sequenceBounds(eventType, cursor);
     if (last < first) {
-      throw new Error(
-        `No ${eventType} history for domain ${cursor.domain} address ${displayAddress(cursor.address)}`,
-      );
+      if (cursor.afterSequence !== undefined && cursor.afterSequence !== -1n) {
+        throw new Error(
+          `No ${eventType} history for domain ${cursor.domain} address ${displayAddress(cursor.address)}`,
+        );
+      }
+      subscription.sequences.set(key, last);
+      return this.sendAndWait(socket, {
+        address: displayAddress(cursor.address),
+        domain: cursor.domain,
+        eventType,
+        sequence: last.toString(),
+        type: 'caught_up',
+      });
     }
     const requestedAfter = cursor.afterSequence ?? last;
     if (requestedAfter > last && !cursor.allowReplay) {

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -133,6 +133,25 @@ describe('RelayerAgentConfigSchema feeToken gate', () => {
     );
     expect(result.success).to.be.true;
   });
+
+  it('accepts only WebSocket schemes for the scraper URL', () => {
+    expect(
+      RelayerAgentConfigSchema.safeParse(
+        config({
+          gasPaymentEnforcement: [{ type: 'onChainFeeQuoting' }],
+          websocketUrl: 'wss://scraper.example/ws/events',
+        }),
+      ).success,
+    ).to.be.true;
+    expect(
+      RelayerAgentConfigSchema.safeParse(
+        config({
+          gasPaymentEnforcement: [{ type: 'onChainFeeQuoting' }],
+          websocketUrl: 'https://scraper.example/ws/events',
+        }),
+      ).success,
+    ).to.be.false;
+  });
 });
 
 describe('AgentChainMetadataSchema additionalQuorumRpcUrls', () => {

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -622,7 +622,6 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
     .optional()
     .describe('Whether to enable IGP indexing'),
   websocketUrl: z
-    .string()
     .url()
     .refine(
       (value) => value.startsWith('ws://') || value.startsWith('wss://'),

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -621,6 +621,19 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
     .boolean()
     .optional()
     .describe('Whether to enable IGP indexing'),
+  websocketUrl: z
+    .string()
+    .url()
+    .refine(
+      (value) => value.startsWith('ws://') || value.startsWith('wss://'),
+      {
+        message: 'websocketUrl must use ws:// or wss://',
+      },
+    )
+    .optional()
+    .describe(
+      'Scraper-proxy WebSocket URL used to shadow dispatch and Merkle streams.',
+    ),
   relayApiEnabled: z
     .boolean()
     .optional()


### PR DESCRIPTION
## Summary

- configure every mainnet3/testnet4 relayer context with its environment-local scraper-proxy URL through SDK, infra, and Rust settings; authority remains disabled
- multiplex live dispatch and Merkle insertion shadow streams for every configured origin on one process-wide socket
- validate envelopes, payloads, exact continuity, subscription echoes, and dispatch/Merkle correlation
- persist per-stream progress plus a pair-specific contiguous-correlation watermark
- capture one immutable per-connection floor from dispatch, Merkle, and correlation progress; replay both streams from it
- rebuild every pair through the higher dispatch/Merkle caught-up watermark before readiness
- stage fresh stream markers and events until both baselines establish one crash-safe anchor
- report an explicit `caught_up: -1` for fresh empty proxy cursors so one unused origin cannot reconnect the process-wide stream forever

RPC indexing and delivery remain authoritative.

## Expected improvement

For 65 modeled origins, process-wide multiplexing changes a hypothetical per-origin/per-event ceiling from 130 consumer sockets to 1: up to **130x fewer sockets / 99.23% lower socket count**. This is an architectural bound, not an observed production saving.

Durable overlap targets **100% coverage of retained events at and after the durable boundary**. Independent RPC reduction: **0%** until authority/cutover work lands.

## Correctness

- each event is validated before its durable stream cursor advances; correlation progress advances only through contiguous complete pairs
- reconnect resets sequenced in-memory state to the captured common floor; both-missing remains a true live baseline
- readiness requires both local streams and durable correlation progress through `max(dispatch_tip, merkle_tip)`
- late counterparts re-run readiness; unequal caught-up tips cannot remain falsely ready or permanently stuck
- fresh unequal tips persist lower cursor, higher cursor, then correlation; a negative lower tip persists neither cursor
- fresh empty streams may skew from sequence zero while waiting, but an arbitrary nonzero first event fails closed
- the validator accepts the explicit empty-history `caught_up: -1` marker only while its local next sequence is zero; non-empty or lower negative markers fail closed
- fresh empty cursors remain subscribed for future sequence zero; a non-empty durable cursor against missing proxy history still fails closed
- two empty markers become durable only after the first complete sequence-zero pair
- subscription confirmation and caught-up validation reuse the immutable request, including `N-1` and cursor zero as `-1`
- a crash during asymmetric healing cannot collapse the next replay floor past unchecked pairs
- malformed payloads, gaps, conflicts, unexpected sources, and incomplete pairs fail closed

## Verification

- scraper-proxy WebSocket integration tests: **27/27 passed**, including mixed populated/empty origins
- scraper-proxy build and lint passed
- relayer scraper-WebSocket/settings tests: **25/25 passed** before this proxy-only increment
- dependency-aware infra build: **22/22 tasks passed** after configuring every relayer context
- Aleo relayer check and strict Clippy
- validator caught-up regression: **1/1 passed**, including empty `-1` acceptance and non-empty rejection
- Rust formatting, diff checks, and normal pre-commit hooks

## Stack

Stacked on exact #9391 head `5ee0a1ddf1719b328868f6c29333364bb105a420`. Exact head `6cb12379e56055d3ce2d997781380e0ea7164c32`; parent of #9402.

