### PR TITLE
perf(lander): parallelize transaction status reads

### DIFF
--- a/rust/main/lander/src/dispatcher/metrics.rs
+++ b/rust/main/lander/src/dispatcher/metrics.rs
@@ -1,7 +1,7 @@
 // TODO: Re-enable clippy warnings
 #![allow(dead_code)]
 
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 
 use hyperlane_core::U256;
 use prometheus::{
@@ -29,6 +29,11 @@ pub struct DispatcherMetrics {
     pub building_stage_queue_length: IntGaugeVec,
     pub inclusion_stage_pool_length: IntGaugeVec,
     pub finality_stage_pool_length: IntGaugeVec,
+
+    /// Time to read statuses and apply a stage's ordered mutations.
+    pub status_scan_duration_milliseconds: IntGaugeVec,
+    /// Age since the least recently checked transaction's last status read.
+    pub oldest_unchecked_transaction_age_seconds: IntGaugeVec,
 
     // tracks inclusion stage errors
     pub inclusion_stage_error: IntCounterVec,
@@ -95,6 +100,22 @@ impl DispatcherMetrics {
                 "The number of transactions in the finality stage pool",
             ),
             &["destination",],
+            registry.clone()
+        )?;
+        let status_scan_duration_milliseconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced("status_scan_duration_milliseconds"),
+                "Duration of the latest transaction status scan",
+            ),
+            &["destination", "stage"],
+            registry.clone()
+        )?;
+        let oldest_unchecked_transaction_age_seconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced("oldest_unchecked_transaction_age_seconds"),
+                "Age since the oldest transaction status check at scan start",
+            ),
+            &["destination", "stage"],
             registry.clone()
         )?;
 
@@ -214,6 +235,8 @@ impl DispatcherMetrics {
             building_stage_queue_length,
             inclusion_stage_pool_length,
             finality_stage_pool_length,
+            status_scan_duration_milliseconds,
+            oldest_unchecked_transaction_age_seconds,
             batched_transactions,
             dropped_payloads,
             dropped_transactions,
@@ -256,6 +279,28 @@ impl DispatcherMetrics {
                 .set(length as i64),
             _ => {}
         }
+    }
+
+    pub fn update_status_scan_duration_metric(
+        &self,
+        stage: &str,
+        duration: Duration,
+        domain: &str,
+    ) {
+        self.status_scan_duration_milliseconds
+            .with_label_values(&[domain, stage])
+            .set(i64::try_from(duration.as_millis()).unwrap_or(i64::MAX));
+    }
+
+    pub fn update_oldest_unchecked_transaction_age_metric(
+        &self,
+        stage: &str,
+        oldest_unchecked_age: Duration,
+        domain: &str,
+    ) {
+        self.oldest_unchecked_transaction_age_seconds
+            .with_label_values(&[domain, stage])
+            .set(i64::try_from(oldest_unchecked_age.as_secs()).unwrap_or(i64::MAX));
     }
 
     pub fn update_dropped_payloads_metric(&self, reason: &str, domain: &str) {
@@ -380,4 +425,34 @@ pub struct PostInclusionMetricsSource {
     pub priority_fee: Option<u64>,
     // gas limit set for the transaction, if applicable
     pub gas_limit: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::DispatcherMetrics;
+
+    #[test]
+    fn status_scan_metrics_are_exported() {
+        let metrics = DispatcherMetrics::dummy_instance();
+        metrics.update_status_scan_duration_metric(
+            "InclusionStage",
+            Duration::from_millis(123),
+            "test",
+        );
+        metrics.update_oldest_unchecked_transaction_age_metric(
+            "InclusionStage",
+            Duration::from_secs(45),
+            "test",
+        );
+        let gathered = String::from_utf8(metrics.gather().unwrap()).unwrap();
+
+        assert!(gathered.contains(
+            "hyperlane_lander_status_scan_duration_milliseconds{destination=\"test\",stage=\"InclusionStage\"} 123"
+        ));
+        assert!(gathered.contains(
+            "hyperlane_lander_oldest_unchecked_transaction_age_seconds{destination=\"test\",stage=\"InclusionStage\"} 45"
+        ));
+    }
 }

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -2,12 +2,12 @@ use std::{
     collections::{HashMap, VecDeque},
     future::Future,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use derive_new::new;
 use eyre::{eyre, Result};
-use futures_util::future::try_join_all;
+use futures_util::{future::try_join_all, StreamExt};
 use tokio::{
     sync::{mpsc, Mutex},
     time::sleep,
@@ -22,7 +22,8 @@ use crate::{
 };
 
 use super::{
-    building_stage::BuildingStageQueue, utils::call_until_success_or_nonretryable_error,
+    building_stage::BuildingStageQueue,
+    utils::{buffer_ordered_bounded, call_until_success_or_nonretryable_error},
     DispatcherState,
 };
 
@@ -31,6 +32,7 @@ pub use pool::FinalityStagePool;
 mod pool;
 
 pub const STAGE_NAME: &str = "FinalityStage";
+const STATUS_READ_CONCURRENCY: usize = 16;
 
 pub struct FinalityStage {
     pub(crate) pool: FinalityStagePool,
@@ -117,33 +119,93 @@ impl FinalityStage {
                 .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), &domain);
             // evaluate the pool every block
             sleep(*estimated_block_time).await;
-
-            let pool_snapshot = pool.snapshot().await;
-            state.metrics.update_queue_length_metric(
-                STAGE_NAME,
-                pool_snapshot.len() as u64,
-                &domain,
-            );
-            info!(pool_size=?pool_snapshot.len() , "Processing transactions in finality pool");
-            for (_, tx) in pool_snapshot {
-                if let Err(err) = Self::try_process_tx(
-                    tx.clone(),
-                    pool.clone(),
-                    building_stage_queue.clone(),
-                    &state,
-                )
-                .await
-                {
-                    error!(
-                        ?err,
-                        ?tx,
-                        "Error processing finality stage transaction. Skipping for now"
-                    );
-                }
-            }
+            Self::process_txs_step(&pool, &building_stage_queue, &state, &domain).await?;
         }
     }
 
+    pub async fn process_txs_step(
+        pool: &FinalityStagePool,
+        building_stage_queue: &BuildingStageQueue,
+        state: &DispatcherState,
+        domain: &str,
+    ) -> Result<(), LanderError> {
+        state
+            .metrics
+            .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
+        let scan_started = Instant::now();
+        let mut pool_snapshot = pool.snapshot().await.into_values().collect::<Vec<_>>();
+        state
+            .metrics
+            .update_queue_length_metric(STAGE_NAME, pool_snapshot.len() as u64, domain);
+        let now = chrono::Utc::now();
+        let oldest_unchecked_age = pool_snapshot
+            .iter()
+            .filter_map(|tx| {
+                now.signed_duration_since(tx.last_status_check.unwrap_or(tx.creation_timestamp))
+                    .to_std()
+                    .ok()
+            })
+            .max()
+            .unwrap_or_default();
+        state
+            .metrics
+            .update_oldest_unchecked_transaction_age_metric(
+                STAGE_NAME,
+                oldest_unchecked_age,
+                domain,
+            );
+        super::utils::sort_transactions_for_mutation(&mut pool_snapshot);
+        info!(pool_size=?pool_snapshot.len() , "Processing transactions in finality pool");
+
+        let status_reads = pool_snapshot.into_iter().map(|snapshot_tx| async move {
+            let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
+            (snapshot_tx, checked_tx, status)
+        });
+        let status_reads = buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY);
+        futures_util::pin_mut!(status_reads);
+
+        while let Some((snapshot_tx, checked_tx, status)) = status_reads.next().await {
+            if !pool
+                .replace_if_unchanged(&snapshot_tx, checked_tx.clone())
+                .await
+            {
+                info!(tx_uuid = ?snapshot_tx.uuid, "Skipping stale transaction status result");
+                continue;
+            }
+            match status {
+                Ok(status) => {
+                    if let Err(err) = Self::try_process_tx_with_next_status(
+                        checked_tx.clone(),
+                        status,
+                        pool.clone(),
+                        building_stage_queue.clone(),
+                        state,
+                    )
+                    .await
+                    {
+                        error!(
+                            ?err,
+                            tx = ?checked_tx,
+                            "Error processing finality stage transaction. Skipping for now"
+                        );
+                    }
+                }
+                Err(err) => error!(
+                    ?err,
+                    tx = ?checked_tx,
+                    "Error reading finality stage transaction status. Skipping for now"
+                ),
+            }
+        }
+        state.metrics.update_status_scan_duration_metric(
+            STAGE_NAME,
+            scan_started.elapsed(),
+            domain,
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
     #[instrument(
         skip(tx, pool, building_stage_queue, state),
         name = "FinalityStage::try_process_tx"
@@ -153,24 +215,53 @@ impl FinalityStage {
             payloads = ?tx.payload_details
     ))]
     pub async fn try_process_tx(
-        mut tx: Transaction,
+        tx: Transaction,
         pool: FinalityStagePool,
         building_stage_queue: BuildingStageQueue,
         state: &DispatcherState,
     ) -> Result<(), LanderError> {
         info!(?tx, "Processing finality stage transaction");
+        let (tx, tx_status) = Self::read_tx_status(tx, state).await;
+        Self::try_process_tx_with_next_status(tx, tx_status?, pool, building_stage_queue, state)
+            .await
+    }
+
+    #[instrument(
+        skip_all,
+        name = "FinalityStage::read_tx_status",
+        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
+    )]
+    async fn read_tx_status(
+        mut tx: Transaction,
+        state: &DispatcherState,
+    ) -> (Transaction, Result<TransactionStatus, LanderError>) {
+        tx.last_status_check = Some(chrono::Utc::now());
         let tx_status = match &tx.status {
-            TransactionStatus::Finalized => tx.status.clone(),
+            TransactionStatus::Finalized => Ok(tx.status.clone()),
             _ => {
                 call_until_success_or_nonretryable_error(
                     || state.adapter.tx_status(&tx),
                     "Querying transaction status",
                     state,
                 )
-                .await?
+                .await
             }
         };
+        (tx, tx_status)
+    }
 
+    #[instrument(
+        skip_all,
+        name = "FinalityStage::try_process_tx_with_next_status",
+        fields(tx_uuid = ?tx.uuid, previous_tx_status = ?tx.status, next_tx_status = ?tx_status, payloads = ?tx.payload_details)
+    )]
+    async fn try_process_tx_with_next_status(
+        mut tx: Transaction,
+        tx_status: TransactionStatus,
+        pool: FinalityStagePool,
+        building_stage_queue: BuildingStageQueue,
+        state: &DispatcherState,
+    ) -> Result<(), LanderError> {
         match tx_status {
             TransactionStatus::Included => {
                 // tx is not finalized yet, keep it in the pool

--- a/rust/main/lander/src/dispatcher/stages/finality_stage/pool.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage/pool.rs
@@ -32,6 +32,19 @@ impl FinalityStagePool {
         let pool = self.pool.lock().await;
         pool.clone()
     }
+
+    pub async fn replace_if_unchanged(
+        &self,
+        snapshot: &Transaction,
+        replacement: Transaction,
+    ) -> bool {
+        let mut pool = self.pool.lock().await;
+        if pool.get(&snapshot.uuid) != Some(snapshot) {
+            return false;
+        }
+        pool.insert(replacement.uuid.clone(), replacement);
+        true
+    }
 }
 
 #[cfg(test)]
@@ -40,5 +53,28 @@ impl Deref for FinalityStagePool {
 
     fn deref(&self) -> &Self::Target {
         &self.pool
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{tests::test_utils::dummy_tx, transaction::TransactionStatus};
+
+    use super::FinalityStagePool;
+
+    #[tokio::test]
+    async fn stale_snapshot_cannot_replace_newer_pool_entry() {
+        let pool = FinalityStagePool::new();
+        let snapshot = dummy_tx(vec![], TransactionStatus::Included);
+        pool.insert(snapshot.clone()).await;
+
+        let mut newer = snapshot.clone();
+        newer.status = TransactionStatus::Finalized;
+        pool.insert(newer.clone()).await;
+
+        let mut checked = snapshot.clone();
+        checked.last_status_check = Some(chrono::Utc::now());
+        assert!(!pool.replace_if_unchanged(&snapshot, checked).await);
+        assert_eq!(pool.snapshot().await.get(&snapshot.uuid), Some(&newer));
     }
 }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -2,13 +2,12 @@ use std::cmp::max;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use derive_new::new;
 use eyre::{eyre, Result};
-use futures_util::future::try_join_all;
-use futures_util::try_join;
+use futures_util::{future::try_join_all, try_join, StreamExt};
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::sleep;
 use tracing::{error, info, info_span, instrument, warn, Instrument};
@@ -20,7 +19,10 @@ use crate::{
     transaction::{DropReason as TxDropReason, Transaction, TransactionStatus, TransactionUuid},
 };
 
-use super::{utils::call_until_success_or_nonretryable_error, DispatcherState};
+use super::{
+    utils::{buffer_ordered_bounded, call_until_success_or_nonretryable_error},
+    DispatcherState,
+};
 
 #[cfg(test)]
 pub mod tests;
@@ -37,6 +39,7 @@ const MAX_TX_STATUS_CHECK_DELAY: Duration = Duration::from_secs(5 * 60);
 const REPROCESS_TXS_LIVENESS_RATE: Duration = Duration::from_secs(5);
 // Bounds idle reorg-detection latency without reducing the liveness heartbeat rate.
 const MAX_REPROCESS_TXS_POLL_RATE: Duration = Duration::from_secs(5 * 60);
+const STATUS_READ_CONCURRENCY: usize = 16;
 
 pub struct InclusionStage {
     pub(crate) pool: InclusionStagePool,
@@ -152,59 +155,144 @@ impl InclusionStage {
             .metrics
             .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
 
+        let scan_started = Instant::now();
         let pool_snapshot = {
             let pool_snapshot = pool.lock().await;
-            let pool_snapshot = pool_snapshot.clone();
             state.metrics.update_queue_length_metric(
                 STAGE_NAME,
                 pool_snapshot.len() as u64,
                 domain,
             );
-            pool_snapshot
+            pool_snapshot.values().cloned().collect::<Vec<_>>()
         };
+        let now = chrono::Utc::now();
+        let oldest_unchecked_age = pool_snapshot
+            .iter()
+            .filter_map(|tx| {
+                now.signed_duration_since(tx.last_status_check.unwrap_or(tx.creation_timestamp))
+                    .to_std()
+                    .ok()
+            })
+            .max()
+            .unwrap_or_default();
+        state
+            .metrics
+            .update_oldest_unchecked_transaction_age_metric(
+                STAGE_NAME,
+                oldest_unchecked_age,
+                domain,
+            );
         if pool_snapshot.is_empty() {
+            state.metrics.update_status_scan_duration_metric(
+                STAGE_NAME,
+                scan_started.elapsed(),
+                domain,
+            );
             return Ok(());
         }
         info!(pool_size=?pool_snapshot.len() , "Processing transactions in inclusion pool");
 
         let base_interval = *state.adapter.estimated_block_time();
-        let now = chrono::Utc::now();
+        let mut eligible_txs = pool_snapshot
+            .into_iter()
+            .filter(|tx| Self::tx_ready_for_processing(base_interval, now, tx))
+            .collect::<Vec<_>>();
+        super::utils::sort_transactions_for_mutation(&mut eligible_txs);
+        let status_reads = eligible_txs.into_iter().map(|snapshot_tx| async move {
+            let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
+            (snapshot_tx, checked_tx, status)
+        });
+        let status_reads = buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY);
+        futures_util::pin_mut!(status_reads);
 
-        for (_, mut tx) in pool_snapshot {
-            // Update liveness metric on every tx as well.
-            // This prevents alert misfires when there are many txs to process.
-            state
-                .metrics
-                .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
+        let result = async {
+            while let Some((snapshot_tx, mut checked_tx, status)) = status_reads.next().await {
+                // Update liveness metric on every tx as well.
+                // This prevents alert misfires when there are many txs to process.
+                state
+                    .metrics
+                    .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
 
-            if !Self::tx_ready_for_processing(base_interval, now, &tx) {
-                continue;
-            }
-
-            if let Err(err) =
-                Self::try_process_tx(tx.clone(), finality_stage_sender, state, pool).await
-            {
-                if matches!(err, LanderError::ChannelSendFailure(_)) {
-                    error!(
-                        ?err,
-                        ?tx,
-                        "Failed to forward transaction. Retaining it for retry"
-                    );
-                    Self::update_inclusion_stage_metric(state, domain, &err);
+                if !Self::replace_if_unchanged(pool, &snapshot_tx, checked_tx.clone()).await {
+                    info!(tx_uuid = ?snapshot_tx.uuid, "Skipping stale transaction status result");
                     continue;
                 }
 
-                error!(?err, ?tx, "Error processing transaction. Dropping it");
-
-                let drop_reason = match &err {
-                    LanderError::TxDropped(reason) => reason.clone(),
-                    _ => TxDropReason::Other(err.to_string()),
+                let tx_status = match status {
+                    Ok(status) => status,
+                    Err(err) if err.is_infra_error() => {
+                        warn!(
+                            ?err,
+                            tx = ?checked_tx,
+                            "Error reading transaction status. Retrying later"
+                        );
+                        Self::update_inclusion_stage_metric(state, domain, &err);
+                        state.store_tx(&checked_tx).await;
+                        continue;
+                    }
+                    Err(err) => {
+                        error!(?err, tx = ?checked_tx, "Error processing transaction. Dropping it");
+                        let drop_reason = match &err {
+                            LanderError::TxDropped(reason) => reason.clone(),
+                            _ => TxDropReason::Other(err.to_string()),
+                        };
+                        Self::drop_tx(state, &mut checked_tx, drop_reason, pool).await?;
+                        Self::update_inclusion_stage_metric(state, domain, &err);
+                        continue;
+                    }
                 };
-                Self::drop_tx(state, &mut tx, drop_reason, pool).await?;
-                Self::update_inclusion_stage_metric(state, domain, &err);
+                info!(tx = ?checked_tx, next_tx_status = ?tx_status, "Transaction status");
+                if let Err(err) = Self::try_process_tx_with_next_status(
+                    checked_tx.clone(),
+                    tx_status,
+                    finality_stage_sender,
+                    state,
+                    pool,
+                )
+                .await
+                {
+                    if matches!(err, LanderError::ChannelSendFailure(_)) {
+                        error!(
+                            ?err,
+                            tx = ?checked_tx,
+                            "Failed to forward transaction. Retaining it for retry"
+                        );
+                        Self::update_inclusion_stage_metric(state, domain, &err);
+                        continue;
+                    }
+
+                    error!(?err, tx = ?checked_tx, "Error processing transaction. Dropping it");
+                    let drop_reason = match &err {
+                        LanderError::TxDropped(reason) => reason.clone(),
+                        _ => TxDropReason::Other(err.to_string()),
+                    };
+                    Self::drop_tx(state, &mut checked_tx, drop_reason, pool).await?;
+                    Self::update_inclusion_stage_metric(state, domain, &err);
+                }
             }
+            Ok(())
         }
-        Ok(())
+        .await;
+        state.metrics.update_status_scan_duration_metric(
+            STAGE_NAME,
+            scan_started.elapsed(),
+            domain,
+        );
+        result
+    }
+
+    #[instrument(
+        skip_all,
+        name = "InclusionStage::read_tx_status",
+        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
+    )]
+    async fn read_tx_status(
+        mut tx: Transaction,
+        state: &DispatcherState,
+    ) -> (Transaction, Result<TransactionStatus, LanderError>) {
+        tx.last_status_check = Some(chrono::Utc::now());
+        let status = state.adapter.tx_status(&tx).await;
+        (tx, status)
     }
 
     #[instrument(skip_all, fields(?domain))]
@@ -330,48 +418,17 @@ impl InclusionStage {
         true
     }
 
-    #[instrument(
-        skip_all,
-        name = "InclusionStage::try_process_tx",
-        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
-    )]
-    async fn try_process_tx(
-        mut tx: Transaction,
-        finality_stage_sender: &mpsc::Sender<Transaction>,
-        state: &DispatcherState,
+    async fn replace_if_unchanged(
         pool: &InclusionStagePool,
-    ) -> Result<(), LanderError> {
-        info!(?tx, "Processing inclusion stage transaction");
-
-        // Update the last status check timestamp before querying
-        tx.last_status_check = Some(chrono::Utc::now());
-
-        let tx_status = state.adapter.tx_status(&tx).await;
-
-        // Persist the check timestamp even on provider failure so normal status
-        // backoff, rather than an in-call retry loop, controls the next attempt.
-        {
-            let mut pool_lock = pool.lock().await;
-            pool_lock.insert(tx.uuid.clone(), tx.clone());
+        snapshot_tx: &Transaction,
+        checked_tx: Transaction,
+    ) -> bool {
+        let mut pool = pool.lock().await;
+        if pool.get(&snapshot_tx.uuid) != Some(snapshot_tx) {
+            return false;
         }
-        let tx_status = match tx_status {
-            Ok(status) => status,
-            Err(err) if err.is_infra_error() => {
-                warn!(
-                    ?err,
-                    ?tx,
-                    "Error reading transaction status. Retrying later"
-                );
-                Self::update_inclusion_stage_metric(state, &state.domain, &err);
-                state.store_tx(&tx).await;
-                return Ok(());
-            }
-            Err(err) => return Err(err),
-        };
-        info!(?tx, next_tx_status = ?tx_status, "Transaction status");
-
-        Self::try_process_tx_with_next_status(tx, tx_status, finality_stage_sender, state, pool)
-            .await
+        pool.insert(checked_tx.uuid.clone(), checked_tx);
+        true
     }
 
     #[instrument(

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -263,6 +263,59 @@ async fn test_processing_included_txs() {
     .await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn completed_prefix_is_applied_before_later_status_error() {
+    let mut earlier_tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    let mut later_tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    let now = chrono::Utc::now();
+    earlier_tx.creation_timestamp = now - chrono::Duration::seconds(2);
+    later_tx.creation_timestamp = now - chrono::Duration::seconds(1);
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_estimated_block_time()
+        .return_const(Duration::from_secs(1));
+    let later_uuid = later_tx.uuid.clone();
+    mock_adapter.expect_tx_status().returning(move |tx| {
+        (tx.uuid != later_uuid)
+            .then_some(TransactionStatus::Included)
+            .ok_or_else(|| LanderError::TxSubmissionError("status read failed".to_string()))
+    });
+
+    let (payload_db, tx_db, _) = tmp_dbs();
+    let state = DispatcherState::new(
+        payload_db,
+        tx_db,
+        Arc::new(mock_adapter),
+        DispatcherMetrics::dummy_instance(),
+        "test".to_string(),
+    );
+    let pool = InclusionStagePool::default();
+    pool.lock()
+        .await
+        .insert(earlier_tx.uuid.clone(), earlier_tx.clone());
+    pool.lock()
+        .await
+        .insert(later_tx.uuid.clone(), later_tx.clone());
+    let (finality_stage_sender, mut finality_stage_receiver) = mpsc::channel(2);
+
+    let scan_pool = pool.clone();
+    let scan_state = state.clone();
+    let scan = tokio::spawn(async move {
+        InclusionStage::process_txs_step(&scan_pool, &finality_stage_sender, &scan_state, "test")
+            .await
+    });
+
+    let forwarded = tokio::time::timeout(Duration::from_millis(1), finality_stage_receiver.recv())
+        .await
+        .expect("the completed prefix should be applied before the later error")
+        .expect("the finality stage receiver should remain open");
+    assert_eq!(forwarded.uuid, earlier_tx.uuid);
+    assert!(!pool.lock().await.contains_key(&earlier_tx.uuid));
+    assert!(pool.lock().await.contains_key(&later_tx.uuid));
+
+    scan.await.unwrap().unwrap();
+}
+
 #[tokio::test]
 async fn test_unincluded_txs_reach_mempool() {
     const TXS_TO_PROCESS: usize = 3;

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -1,5 +1,6 @@
 use std::{future::Future, time::Duration};
 
+use futures_util::{stream, Stream, StreamExt};
 use tokio::time::sleep;
 use tracing::{error, info, instrument};
 
@@ -10,6 +11,27 @@ use crate::{
 };
 
 use super::DispatcherState;
+
+/// Polls futures concurrently while yielding completed prefixes in input order.
+pub(super) fn buffer_ordered_bounded<Fut, T>(
+    futures: impl IntoIterator<Item = Fut>,
+    max_concurrency: usize,
+) -> impl Stream<Item = T>
+where
+    Fut: Future<Output = T>,
+{
+    assert!(max_concurrency > 0, "concurrency must be non-zero");
+
+    stream::iter(futures).buffered(max_concurrency)
+}
+
+pub(super) fn sort_transactions_for_mutation(transactions: &mut [Transaction]) {
+    transactions.sort_unstable_by(|left, right| {
+        left.creation_timestamp
+            .cmp(&right.creation_timestamp)
+            .then_with(|| left.uuid.as_bytes().cmp(right.uuid.as_bytes()))
+    });
+}
 
 pub async fn call_until_success_or_nonretryable_error<F, T, Fut>(
     f: F,
@@ -76,4 +98,131 @@ pub async fn update_tx_status(
         _ => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+
+    use tokio::sync::Semaphore;
+
+    use hyperlane_core::identifiers::UniqueIdentifier;
+    use uuid::Uuid;
+
+    use crate::{tests::test_utils::dummy_tx, transaction::TransactionStatus};
+
+    use futures_util::StreamExt;
+
+    use super::{buffer_ordered_bounded, sort_transactions_for_mutation};
+
+    #[test]
+    fn transactions_are_sorted_by_creation_then_uuid() {
+        let timestamp = chrono::Utc::now();
+        let mut same_time_later_uuid = dummy_tx(vec![], TransactionStatus::Included);
+        same_time_later_uuid.creation_timestamp = timestamp;
+        same_time_later_uuid.uuid = UniqueIdentifier::new(Uuid::from_u128(2));
+        let mut same_time_earlier_uuid = same_time_later_uuid.clone();
+        same_time_earlier_uuid.uuid = UniqueIdentifier::new(Uuid::from_u128(1));
+        let mut later_creation = same_time_later_uuid.clone();
+        later_creation.creation_timestamp = timestamp + chrono::Duration::seconds(1);
+        later_creation.uuid = UniqueIdentifier::new(Uuid::from_u128(0));
+        let mut transactions = vec![later_creation, same_time_later_uuid, same_time_earlier_uuid];
+
+        sort_transactions_for_mutation(&mut transactions);
+
+        assert_eq!(transactions[0].uuid.as_u128(), 1);
+        assert_eq!(transactions[1].uuid.as_u128(), 2);
+        assert_eq!(transactions[2].uuid.as_u128(), 0);
+    }
+
+    #[tokio::test]
+    async fn ordered_bounded_stream_yields_completed_prefix_before_later_read() {
+        const CONCURRENCY: usize = 4;
+        const ITEM_COUNT: usize = 8;
+
+        let second_read_gate = Arc::new(Semaphore::new(0));
+
+        let futures = (0..ITEM_COUNT).map(|index| {
+            let second_read_gate = second_read_gate.clone();
+            async move {
+                if index == 1 {
+                    second_read_gate
+                        .acquire()
+                        .await
+                        .expect("test semaphore is not closed")
+                        .forget();
+                }
+
+                index
+            }
+        });
+
+        let mut stream = Box::pin(buffer_ordered_bounded(futures, CONCURRENCY));
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), stream.next())
+                .await
+                .expect("the completed prefix should be yielded")
+                .expect("the stream should contain the first result"),
+            0
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), stream.next())
+                .await
+                .is_err(),
+            "input order should still wait for the gated second result"
+        );
+        second_read_gate.add_permits(1);
+        assert_eq!(
+            stream.collect::<Vec<_>>().await,
+            (1..ITEM_COUNT).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn ordered_bounded_collection_enforces_concurrency_cap() {
+        const CONCURRENCY: usize = 4;
+        const ITEM_COUNT: usize = 8;
+
+        let started = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(Semaphore::new(0));
+        let started_for_futures = started.clone();
+        let gate_for_futures = gate.clone();
+        let futures = (0..ITEM_COUNT).map(move |index| {
+            let started = started_for_futures.clone();
+            let gate = gate_for_futures.clone();
+            async move {
+                started.fetch_add(1, Ordering::SeqCst);
+                gate.acquire()
+                    .await
+                    .expect("test semaphore is not closed")
+                    .forget();
+                index
+            }
+        });
+
+        let collection = tokio::spawn(async move {
+            buffer_ordered_bounded(futures, CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while started.load(Ordering::SeqCst) < CONCURRENCY {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the configured number of reads should start");
+        tokio::task::yield_now().await;
+        assert_eq!(started.load(Ordering::SeqCst), CONCURRENCY);
+
+        gate.add_permits(ITEM_COUNT);
+        assert_eq!(
+            collection.await.unwrap(),
+            (0..ITEM_COUNT).collect::<Vec<_>>()
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Lander inclusion and finality scans read transaction status serially. For `N` transactions with similar status latency `L`, the read phase takes approximately `N * L`, delaying every mutation behind the accumulated provider latency.

## Solution

- run inclusion and finality transaction-status reads with a bounded concurrency of 16
- restore deterministic creation-time/UUID order before applying DB, nonce, resubmission, drop, and finalization mutations serially
- yield each completed ordered prefix immediately instead of collecting the full scan
- skip status results when the pool entry changed during the snapshot read
- export latest scan duration and oldest-unchecked transaction age by destination and stage
- preserve #9412's bounded provider-error behavior: failed inclusion reads persist the check timestamp and retry on a later scan rather than looping in-call

## Expected improvement

For `N` all-completing status reads with similar latency `L`, the read phase changes from approximately `N * L` to `ceil(N / 16) * L`: up to 16x faster, or 93.75% less status-read wall time at large `N`. Total scan time is the parallel read phase plus unchanged serial mutation time.

Focused utility tests use `N=8`, `C=4`: exactly four reads start before release, and an available first result is yielded while the second remains gated. This proves the cap and completed-prefix behavior; it is not a timed production speedup.

No production latency improvement has been measured yet.

## Safety and limits

- only status reads execute concurrently; mutations remain serial and deterministic
- compare-and-swap against the snapshot prevents an already-replaced pool entry from being overwritten
- inclusion provider failures retain the transaction, persist the latest check timestamp, and use normal per-transaction backoff
- finality retains its existing retry behavior
- channel-send failures retain the latest included transaction for retry
- concurrency 16 can increase instantaneous provider pressure and must be canaried

## Verification

- `cargo +1.88.0 test -p lander dispatcher:: --lib` (66 passed)
- `cargo +1.88.0 test -p lander dispatcher::stages::inclusion_stage::tests:: --lib` (23 passed)
- `cargo +1.88.0 clippy -p lander --lib --no-deps -- -D warnings`
- repository pre-commit hooks (gitleaks, dependency check, Rust fmt)
- provider-error, channel-send, stale-snapshot, ordered-prefix, concurrency-cap, reorg, drop, and finalized regressions pass

## Canary

Compare equal-traffic canary and baseline:

- `hyperlane_lander_status_scan_duration_milliseconds{stage=~"InclusionStage|FinalityStage"}`
- `hyperlane_lander_oldest_unchecked_transaction_age_seconds{stage=~"InclusionStage|FinalityStage"}`
- provider request/error/rate-limit metrics
- inclusion/finality pool length, resubmission count, drop count, finalized count, and delivery latency

Expected direction: status-scan duration approaches the slowest 16-wide batch rather than the sum of read latencies, while mutation/error metrics remain unchanged.

Closes #9385.
Master performance epic: #9386.
