### PR TITLE
perf(relayer): wake prepare work and bound relay admission

### DIFF
--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::Mutex,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -19,6 +19,61 @@ const ENDED_EVENT: &str = "ended";
 struct MetadataWaitStart {
     instant: Instant,
     unix_timestamp_seconds: i64,
+}
+
+#[derive(Debug, Default)]
+struct AppMetadataWaits {
+    by_message: HashMap<H256, MetadataWaitStart>,
+    timestamp_counts: BTreeMap<i64, usize>,
+}
+
+impl AppMetadataWaits {
+    fn insert(&mut self, message_id: H256, start: MetadataWaitStart) -> bool {
+        match self.by_message.entry(message_id) {
+            std::collections::hash_map::Entry::Occupied(_) => return false,
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(start);
+            }
+        }
+        self.timestamp_counts
+            .entry(start.unix_timestamp_seconds)
+            .and_modify(|count| *count = count.saturating_add(1))
+            .or_insert(1);
+        true
+    }
+
+    fn remove(&mut self, message_id: &H256) -> Option<MetadataWaitStart> {
+        let removed = self.by_message.remove(message_id)?;
+        let remove_timestamp = self
+            .timestamp_counts
+            .get_mut(&removed.unix_timestamp_seconds)
+            .map(|count| {
+                *count = count.saturating_sub(1);
+                *count == 0
+            })
+            .unwrap_or_default();
+        debug_assert!(
+            self.timestamp_counts
+                .contains_key(&removed.unix_timestamp_seconds),
+            "tracked wait timestamp must have a count"
+        );
+        if remove_timestamp {
+            self.timestamp_counts
+                .remove(&removed.unix_timestamp_seconds);
+        }
+        Some(removed)
+    }
+
+    fn oldest_timestamp_seconds(&self) -> i64 {
+        self.timestamp_counts
+            .first_key_value()
+            .map(|(timestamp, _)| *timestamp)
+            .unwrap_or_default()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_message.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -165,11 +220,40 @@ mod tests {
             expected_oldest
         );
     }
+
+    #[test]
+    fn metadata_wait_tracker_keeps_an_ordered_oldest_timestamp() {
+        let mut waits = AppMetadataWaits::default();
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let third_id = H256::from_low_u64_be(3);
+        let now = Instant::now();
+
+        for (message_id, unix_timestamp_seconds) in
+            [(first_id, 20), (second_id, 10), (third_id, 10)]
+        {
+            assert!(waits.insert(
+                message_id,
+                MetadataWaitStart {
+                    instant: now,
+                    unix_timestamp_seconds,
+                },
+            ));
+        }
+        assert_eq!(waits.oldest_timestamp_seconds(), 10);
+
+        waits.remove(&second_id).unwrap();
+        assert_eq!(waits.oldest_timestamp_seconds(), 10);
+        waits.remove(&third_id).unwrap();
+        assert_eq!(waits.oldest_timestamp_seconds(), 20);
+        waits.remove(&first_id).unwrap();
+        assert_eq!(waits.oldest_timestamp_seconds(), 0);
+    }
 }
 
 #[derive(Debug, Default)]
 struct MetadataWaitTracker {
-    by_app_context: Mutex<HashMap<String, HashMap<H256, MetadataWaitStart>>>,
+    by_app_context: Mutex<HashMap<String, AppMetadataWaits>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -278,28 +362,21 @@ impl MessageSubmissionMetrics {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let app_waits = waits.entry(app_context.to_owned()).or_default();
-        let (first_observation, start) = match app_waits.entry(message_id) {
-            std::collections::hash_map::Entry::Occupied(entry) => (false, *entry.get()),
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                let start = MetadataWaitStart {
-                    instant: now,
-                    unix_timestamp_seconds,
-                };
-                entry.insert(start);
-                (true, start)
-            }
-        };
+        let start = app_waits
+            .by_message
+            .get(&message_id)
+            .copied()
+            .unwrap_or(MetadataWaitStart {
+                instant: now,
+                unix_timestamp_seconds,
+            });
+        let first_observation = app_waits.insert(message_id, start);
         if first_observation {
             let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
             self.metadata_wait_active.with_label_values(&labels).inc();
-            let oldest = app_waits
-                .values()
-                .map(|start| start.unix_timestamp_seconds)
-                .min()
-                .unwrap_or(unix_timestamp_seconds);
             self.metadata_wait_oldest_timestamp_seconds
                 .with_label_values(&labels)
-                .set(oldest);
+                .set(app_waits.oldest_timestamp_seconds());
         }
 
         self.metadata_wait_event_count
@@ -332,11 +409,7 @@ impl MessageSubmissionMetrics {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let app_waits = waits.get_mut(app_context)?;
         let removed = app_waits.remove(&message_id)?;
-        let next_oldest = app_waits
-            .values()
-            .map(|start| start.unix_timestamp_seconds)
-            .min()
-            .unwrap_or_default();
+        let next_oldest = app_waits.oldest_timestamp_seconds();
         let remove_app_context = app_waits.is_empty();
         if remove_app_context {
             waits.remove(app_context);

--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -125,6 +125,39 @@ mod tests {
         assert!(!encoded.contains(&format!("{first_id:?}")));
         assert!(!encoded.contains(&format!("{second_id:?}")));
     }
+
+    #[test]
+    fn metadata_wait_oldest_uses_tracker_as_source_of_truth() {
+        let metrics = test_metrics();
+        let app_context = "test-app";
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let labels = [app_context, "ethereum", "arbitrum"];
+
+        metrics.record_metadata_wait(first_id, Some(app_context));
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        let expected_oldest = metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .get();
+
+        // The gauge is an exported view, not authoritative tracker state.
+        metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .set(i64::MAX);
+        assert!(metrics
+            .finish_metadata_wait(second_id, Some(app_context), false)
+            .is_some());
+
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            expected_oldest
+        );
+    }
 }
 
 #[derive(Debug, Default)]
@@ -281,33 +314,27 @@ impl MessageSubmissionMetrics {
     ) -> Option<Duration> {
         let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
         let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
-        let oldest = self
-            .metadata_wait_oldest_timestamp_seconds
-            .with_label_values(&labels);
         let mut waits = self
             .metadata_wait_tracker
             .by_app_context
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let current_oldest = oldest.get();
         let app_waits = waits.get_mut(app_context)?;
         let removed = app_waits.remove(&message_id)?;
-        let next_oldest = if removed.unix_timestamp_seconds == current_oldest {
-            app_waits
-                .values()
-                .map(|start| start.unix_timestamp_seconds)
-                .min()
-                .unwrap_or_default()
-        } else {
-            current_oldest
-        };
+        let next_oldest = app_waits
+            .values()
+            .map(|start| start.unix_timestamp_seconds)
+            .min()
+            .unwrap_or_default();
         let remove_app_context = app_waits.is_empty();
         if remove_app_context {
             waits.remove(app_context);
         }
 
         self.metadata_wait_active.with_label_values(&labels).dec();
-        oldest.set(next_oldest);
+        self.metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .set(next_oldest);
         self.metadata_wait_event_count
             .with_label_values(&[
                 app_context,

--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -1,10 +1,142 @@
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 
 use maplit::hashmap;
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge};
+use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 use hyperlane_base::CoreMetrics;
-use hyperlane_core::{HyperlaneDomain, HyperlaneMessage};
+use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, H256};
+
+const UNKNOWN_APP_CONTEXT: &str = "Unknown";
+const WAIT_EVENT: &str = "wait";
+const RECOVERED_EVENT: &str = "recovered";
+const ENDED_EVENT: &str = "ended";
+
+#[derive(Clone, Copy, Debug)]
+struct MetadataWaitStart {
+    instant: Instant,
+    unix_timestamp_seconds: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::core::Collector;
+    use prometheus::{Encoder, Registry, TextEncoder};
+
+    use hyperlane_core::KnownHyperlaneDomain;
+
+    use super::*;
+
+    fn test_metrics() -> MessageSubmissionMetrics {
+        let core_metrics = CoreMetrics::new("relayer", 9090, Registry::new()).unwrap();
+        MessageSubmissionMetrics::new(
+            &core_metrics,
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+            &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+        )
+    }
+
+    #[test]
+    fn metadata_wait_metrics_track_retries_oldest_and_recovery_without_id_labels() {
+        let metrics = test_metrics();
+        let app_context = "test-app";
+        let first_id = H256::from_low_u64_be(1);
+        let second_id = H256::from_low_u64_be(2);
+        let labels = [app_context, "ethereum", "arbitrum"];
+
+        let first = metrics.record_metadata_wait(first_id, Some(app_context));
+        assert!(first.first_observation);
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            1
+        );
+        let oldest = metrics
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels)
+            .get();
+        assert!(oldest > 0);
+
+        let retry = metrics.record_metadata_wait(first_id, Some(app_context));
+        assert!(!retry.first_observation);
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            2
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", WAIT_EVENT])
+                .get(),
+            3
+        );
+
+        assert!(metrics
+            .finish_metadata_wait(first_id, Some(app_context), true)
+            .is_some());
+        assert_eq!(
+            metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", RECOVERED_EVENT])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            1
+        );
+
+        assert!(metrics
+            .finish_metadata_wait(second_id, Some(app_context), false)
+            .is_some());
+        assert_eq!(
+            metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+
+        let mut encoded = Vec::new();
+        TextEncoder::new()
+            .encode(&metrics.metadata_wait_event_count.collect(), &mut encoded)
+            .unwrap();
+        let encoded = String::from_utf8(encoded).unwrap();
+        assert!(!encoded.contains("message_id"));
+        assert!(!encoded.contains(&format!("{first_id:?}")));
+        assert!(!encoded.contains(&format!("{second_id:?}")));
+    }
+}
+
+#[derive(Debug, Default)]
+struct MetadataWaitTracker {
+    by_app_context: Mutex<HashMap<String, HashMap<H256, MetadataWaitStart>>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MetadataWaitObservation {
+    pub(crate) first_observation: bool,
+    pub(crate) elapsed: Duration,
+}
 
 #[derive(Clone, Debug)]
 pub struct MetadataBuildMetric {
@@ -27,6 +159,13 @@ pub struct MessageSubmissionMetrics {
     pub metadata_build_count: IntCounterVec,
     /// Total number of seconds spent building different types of metadata.
     pub metadata_build_duration: CounterVec,
+    /// Bounded wait-attempt and lifecycle events for validator-signature waits.
+    pub metadata_wait_event_count: IntCounterVec,
+    /// Messages currently waiting for validator signatures.
+    pub metadata_wait_active: IntGaugeVec,
+    /// Unix timestamp of the oldest active validator-signature wait.
+    pub metadata_wait_oldest_timestamp_seconds: IntGaugeVec,
+    metadata_wait_tracker: MetadataWaitTracker,
 }
 
 impl MessageSubmissionMetrics {
@@ -48,6 +187,11 @@ impl MessageSubmissionMetrics {
                 .with_label_values(&[origin, destination]),
             metadata_build_count: metrics.metadata_build_count(),
             metadata_build_duration: metrics.metadata_build_duration(),
+            metadata_wait_event_count: metrics.metadata_wait_event_count(),
+            metadata_wait_active: metrics.metadata_wait_active(),
+            metadata_wait_oldest_timestamp_seconds: metrics
+                .metadata_wait_oldest_timestamp_seconds(),
+            metadata_wait_tracker: MetadataWaitTracker::default(),
         }
     }
 
@@ -63,7 +207,7 @@ impl MessageSubmissionMetrics {
     /// a specific ISM
     pub fn insert_metadata_build_metric(&self, params: MetadataBuildMetric) {
         let labels = hashmap! {
-            "app_context" => params.app_context.as_deref().unwrap_or("Unknown"),
+            "app_context" => params.app_context.as_deref().unwrap_or(UNKNOWN_APP_CONTEXT),
             "origin" => self.origin.as_str(),
             "remote" => self.destination.as_str(),
             "status" => if params.success { "success" } else { "failure" },
@@ -72,5 +216,111 @@ impl MessageSubmissionMetrics {
         self.metadata_build_duration
             .with(&labels)
             .inc_by(params.duration.as_secs_f64());
+    }
+
+    pub(crate) fn record_metadata_wait(
+        &self,
+        message_id: H256,
+        app_context: Option<&str>,
+    ) -> MetadataWaitObservation {
+        let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
+        let now = Instant::now();
+        let unix_timestamp_seconds = i64::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+        .unwrap_or(i64::MAX);
+        let mut waits = self
+            .metadata_wait_tracker
+            .by_app_context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let app_waits = waits.entry(app_context.to_owned()).or_default();
+        let (first_observation, start) = match app_waits.entry(message_id) {
+            std::collections::hash_map::Entry::Occupied(entry) => (false, *entry.get()),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let start = MetadataWaitStart {
+                    instant: now,
+                    unix_timestamp_seconds,
+                };
+                entry.insert(start);
+                let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+                self.metadata_wait_active.with_label_values(&labels).inc();
+                let oldest = self
+                    .metadata_wait_oldest_timestamp_seconds
+                    .with_label_values(&labels);
+                if oldest.get() == 0 || unix_timestamp_seconds < oldest.get() {
+                    oldest.set(unix_timestamp_seconds);
+                }
+                (true, start)
+            }
+        };
+
+        self.metadata_wait_event_count
+            .with_label_values(&[
+                app_context,
+                self.origin.as_str(),
+                self.destination.as_str(),
+                WAIT_EVENT,
+            ])
+            .inc();
+
+        MetadataWaitObservation {
+            first_observation,
+            elapsed: now.saturating_duration_since(start.instant),
+        }
+    }
+
+    pub(crate) fn finish_metadata_wait(
+        &self,
+        message_id: H256,
+        app_context: Option<&str>,
+        recovered: bool,
+    ) -> Option<Duration> {
+        let app_context = app_context.unwrap_or(UNKNOWN_APP_CONTEXT);
+        let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+        let oldest = self
+            .metadata_wait_oldest_timestamp_seconds
+            .with_label_values(&labels);
+        let mut waits = self
+            .metadata_wait_tracker
+            .by_app_context
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let current_oldest = oldest.get();
+        let app_waits = waits.get_mut(app_context)?;
+        let removed = app_waits.remove(&message_id)?;
+        let next_oldest = if removed.unix_timestamp_seconds == current_oldest {
+            app_waits
+                .values()
+                .map(|start| start.unix_timestamp_seconds)
+                .min()
+                .unwrap_or_default()
+        } else {
+            current_oldest
+        };
+        let remove_app_context = app_waits.is_empty();
+        if remove_app_context {
+            waits.remove(app_context);
+        }
+
+        self.metadata_wait_active.with_label_values(&labels).dec();
+        oldest.set(next_oldest);
+        self.metadata_wait_event_count
+            .with_label_values(&[
+                app_context,
+                self.origin.as_str(),
+                self.destination.as_str(),
+                if recovered {
+                    RECOVERED_EVENT
+                } else {
+                    ENDED_EVENT
+                },
+            ])
+            .inc();
+
+        Some(removed.instant.elapsed())
     }
 }

--- a/rust/main/agents/relayer/src/metrics/message_submission.rs
+++ b/rust/main/agents/relayer/src/metrics/message_submission.rs
@@ -135,7 +135,6 @@ mod tests {
         let labels = [app_context, "ethereum", "arbitrum"];
 
         metrics.record_metadata_wait(first_id, Some(app_context));
-        metrics.record_metadata_wait(second_id, Some(app_context));
         let expected_oldest = metrics
             .metadata_wait_oldest_timestamp_seconds
             .with_label_values(&labels)
@@ -145,7 +144,15 @@ mod tests {
         metrics
             .metadata_wait_oldest_timestamp_seconds
             .with_label_values(&labels)
-            .set(i64::MAX);
+            .set(1);
+        metrics.record_metadata_wait(second_id, Some(app_context));
+        assert_eq!(
+            metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            expected_oldest
+        );
         assert!(metrics
             .finish_metadata_wait(second_id, Some(app_context), false)
             .is_some());
@@ -279,17 +286,21 @@ impl MessageSubmissionMetrics {
                     unix_timestamp_seconds,
                 };
                 entry.insert(start);
-                let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
-                self.metadata_wait_active.with_label_values(&labels).inc();
-                let oldest = self
-                    .metadata_wait_oldest_timestamp_seconds
-                    .with_label_values(&labels);
-                if oldest.get() == 0 || unix_timestamp_seconds < oldest.get() {
-                    oldest.set(unix_timestamp_seconds);
-                }
                 (true, start)
             }
         };
+        if first_observation {
+            let labels = [app_context, self.origin.as_str(), self.destination.as_str()];
+            self.metadata_wait_active.with_label_values(&labels).inc();
+            let oldest = app_waits
+                .values()
+                .map(|start| start.unix_timestamp_seconds)
+                .min()
+                .unwrap_or(unix_timestamp_seconds);
+            self.metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .set(oldest);
+        }
 
         self.metadata_wait_event_count
             .with_label_values(&[

--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -32,7 +32,6 @@ use crate::msg::pending_message::CONFIRM_DELAY;
 use crate::server::operations::message_retry::MessageRetryRequest;
 
 use super::op_batch::OperationBatch;
-use super::op_queue::OperationPriorityQueue;
 use super::{op_queue::OpQueue, QueueOperationBatch};
 
 use stage::prepare;
@@ -164,8 +163,8 @@ impl MessageProcessor {
         }
     }
 
-    pub async fn prepare_queue(&self) -> OperationPriorityQueue {
-        self.prepare_queue.queue.clone()
+    pub async fn prepare_queue(&self) -> OpQueue {
+        self.prepare_queue.clone()
     }
 
     pub fn spawn(self) -> JoinHandle<()> {
@@ -404,9 +403,7 @@ async fn prepare_classic_task(
             continue;
         }
 
-        let Some(batch) = get_batch_or_wait(&mut prepare_queue, max_batch_size).await else {
-            continue;
-        };
+        let batch = get_batch_or_wait(&mut prepare_queue, max_batch_size).await;
 
         process_batch(
             domain.clone(),
@@ -440,9 +437,7 @@ async fn prepare_lander_task(
             continue;
         }
 
-        let Some(batch) = get_batch_or_wait(&mut prepare_queue, max_batch_size).await else {
-            continue;
-        };
+        let batch = get_batch_or_wait(&mut prepare_queue, max_batch_size).await;
 
         let batch_to_process = prepare::filter_operations_for_preparation(
             entrypoint.clone() as Arc<dyn Entrypoint + Send + Sync>,
@@ -482,14 +477,13 @@ async fn apply_backpressure(submit_queue: &OpQueue, max_len: &Option<u32>) -> bo
 }
 
 /// Helper method to get a batch from the queue or wait if the queue is empty.
-async fn get_batch_or_wait(queue: &mut OpQueue, batch_size: u32) -> Option<Vec<QueueOperation>> {
-    let batch = queue.pop_many(batch_size as usize).await;
-    if batch.is_empty() {
-        // Queue is empty, wait before retrying to prevent burning CPU.
-        sleep(Duration::from_millis(100)).await;
-        None
-    } else {
-        Some(batch)
+async fn get_batch_or_wait(queue: &mut OpQueue, batch_size: u32) -> Vec<QueueOperation> {
+    loop {
+        let (batch, next_deadline) = queue.pop_many_ready(batch_size as usize).await;
+        if !batch.is_empty() {
+            return batch;
+        }
+        queue.wait_for_ready(next_deadline).await;
     }
 }
 
@@ -509,17 +503,6 @@ async fn process_batch(
         task_prep_futures.push(op.prepare());
     }
     let res = join_all(task_prep_futures).await;
-    let not_ready_count = res
-        .iter()
-        .filter(|r| {
-            matches!(
-                r,
-                PendingOperationResult::NotReady | PendingOperationResult::Reprepare(_)
-            )
-        })
-        .count();
-
-    let batch_len = batch.len();
     for (op, prepare_result) in batch.into_iter().zip(res.into_iter()) {
         let app_context = op.app_context();
         match prepare_result {
@@ -552,10 +535,6 @@ async fn process_batch(
                     .await;
             }
         }
-    }
-    if not_ready_count == batch_len {
-        // none of the operations are ready yet, so wait for a little bit
-        sleep(Duration::from_millis(500)).await;
     }
 }
 

--- a/rust/main/agents/relayer/src/msg/message_processor/tests/tests_common.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests/tests_common.rs
@@ -143,7 +143,9 @@ impl PendingOperation for MockQueueOperation {
     fn set_next_attempt_after(&mut self, delay: Duration) {
         self.next_attempt = Instant::now().checked_add(delay);
     }
-    fn reset_attempts(&mut self) {}
+    fn reset_attempts(&mut self) -> bool {
+        true
+    }
     #[cfg(any(test, feature = "test-utils"))]
     fn set_retries(&mut self, retries: u32) {
         self.retries = retries;

--- a/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/aggregation.rs
@@ -248,7 +248,7 @@ impl AggregationIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for AggregationIsmMetadataBuilder {
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,
@@ -275,6 +275,12 @@ impl MetadataBuilder for AggregationIsmMetadataBuilder {
             }
             Err(MetadataBuildError::Refused(reason)) => {
                 return Err(MetadataBuildError::Refused(reason));
+            }
+            Err(err @ MetadataBuildError::AwaitingValidatorSignatures) => {
+                debug!(
+                    ?err,
+                    "Fast path is waiting for signatures; falling back to the other submodules"
+                );
             }
             Err(err) => {
                 warn!(
@@ -545,6 +551,7 @@ mod test {
     }
 
     /// All submodules fail to build → AggregationThresholdNotMet.
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_all_build_failures_returns_threshold_not_met() {
         let agg_addr = H256::from_low_u64_be(1);
@@ -568,6 +575,7 @@ mod test {
             result.unwrap_err(),
             MetadataBuildError::AggregationThresholdNotMet(2)
         );
+        assert!(logs_contain("Metadata submodule build failed"));
     }
 
     /// All submodules build ok but every dry_run returns None → AggregationThresholdNotMet.

--- a/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/ccip_read/mod.rs
@@ -382,7 +382,7 @@ impl CcipReadIsmMetadataBuilder {
 
 #[async_trait]
 impl MetadataBuilder for CcipReadIsmMetadataBuilder {
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -54,7 +54,7 @@ pub struct MessageMetadataBuilder {
 ///                 MessageMetadataBuilder
 #[async_trait]
 impl MetadataBuilder for MessageMetadataBuilder {
-    #[instrument(err, skip(self, message, params), fields(destination_domain=self.base_builder().destination_domain().name()))]
+    #[instrument(skip(self, message, params), fields(destination_domain=self.base_builder().destination_domain().name()))]
     async fn build(
         &self,
         ism_address: H256,
@@ -151,6 +151,43 @@ pub async fn ism_and_module_type(
 
 /// Builds metadata for a message.
 pub async fn build_message_metadata(
+    message_builder: MessageMetadataBuilder,
+    ism_address: H256,
+    message: &HyperlaneMessage,
+    params: MessageMetadataBuildParams,
+    maybe_ism_and_module_type: Option<(Box<dyn InterchainSecurityModule>, ModuleType)>,
+) -> Result<IsmWithMetadataAndType, MetadataBuildError> {
+    let result = build_message_metadata_inner(
+        message_builder,
+        ism_address,
+        message,
+        params,
+        maybe_ism_and_module_type,
+    )
+    .await;
+    match &result {
+        Err(err @ MetadataBuildError::AwaitingValidatorSignatures) => {
+            tracing::debug!(
+                ?err,
+                ?ism_address,
+                message_id = ?message.id(),
+                "Metadata submodule is waiting for validator signatures"
+            );
+        }
+        Err(err) => {
+            tracing::error!(
+                ?err,
+                ?ism_address,
+                message_id = ?message.id(),
+                "Metadata submodule build failed"
+            );
+        }
+        Ok(_) => {}
+    }
+    result
+}
+
+async fn build_message_metadata_inner(
     message_builder: MessageMetadataBuilder,
     ism_address: H256,
     message: &HyperlaneMessage,

--- a/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/message_builder.rs
@@ -175,7 +175,7 @@ pub async fn build_message_metadata(
             );
         }
         Err(err) => {
-            tracing::error!(
+            tracing::warn!(
                 ?err,
                 ?ism_address,
                 message_id = ?message.id(),

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -3,7 +3,7 @@ use derive_more::Deref;
 use derive_new::new;
 use hyperlane_base::cache::FunctionCallCache;
 
-use hyperlane_core::{HyperlaneMessage, Metadata, ModuleType, H256};
+use hyperlane_core::{HyperlaneMessage, Metadata, ModuleType, RoutingIsm, H256};
 use tracing::instrument;
 
 use super::{
@@ -32,10 +32,6 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
             .await
             .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
 
-        let ism_domain = ism.domain().name();
-        let message_domain = self.base.base_builder().origin_domain();
-        let fn_key = "route";
-
         let cache_policy = self
             .base_builder()
             .ism_cache_policy_classifier()
@@ -46,6 +42,22 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
                 self.base.app_context.as_ref(),
             )
             .await;
+
+        let module = self.route(ism.as_ref(), message, cache_policy).await?;
+
+        self.base.build(module, message, params).await
+    }
+}
+
+impl RoutingIsmMetadataBuilder {
+    async fn route(
+        &self,
+        ism: &dyn RoutingIsm,
+        message: &HyperlaneMessage,
+        cache_policy: IsmCachePolicy,
+    ) -> Result<H256, MetadataBuildError> {
+        let ism_domain = ism.domain().name();
+        let fn_key = "route";
 
         let cache_result: Option<H256> = match cache_policy {
             // if cache is ISM specific, we use the message origin for caching
@@ -71,44 +83,247 @@ impl MetadataBuilder for RoutingIsmMetadataBuilder {
         .ok()
         .flatten();
 
-        let module =
-            match cache_result {
-                Some(result) => result,
-                None => {
-                    let module = ism
-                        .route(message)
-                        .await
-                        .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
+        let module = match cache_result {
+            Some(result) => result,
+            None => {
+                let module = ism
+                    .route(message)
+                    .await
+                    .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?;
 
-                    // store result in cache
-                    match cache_policy {
+                // store result in cache
+                match cache_policy {
                     IsmCachePolicy::IsmSpecific => {
                         let params_cache_key = (ism.address(), message.origin);
-                        self.base_builder().cache().cache_call_result(
-                            message_domain.name(),
-                            fn_key,
-                            &params_cache_key,
-                            &module,
-                        ).await
+                        self.base_builder()
+                            .cache()
+                            .cache_call_result(ism_domain, fn_key, &params_cache_key, &module)
+                            .await
                     }
                     IsmCachePolicy::MessageSpecific => {
                         let params_cache_key = (ism.address(), message.id());
-                        self.base_builder().cache().cache_call_result(
-                            message_domain.name(),
-                            fn_key,
-                            &params_cache_key,
-                            &module,
-                        ).await
+                        self.base_builder()
+                            .cache()
+                            .cache_call_result(ism_domain, fn_key, &params_cache_key, &module)
+                            .await
                     }
                 }
                 .map_err(|err| {
                     tracing::warn!(error = %err, "Error when caching call result for {:?}", fn_key);
                 })
                 .ok();
-                    module
-                }
-            };
+                module
+            }
+        };
 
-        self.base.build(module, message, params).await
+        Ok(module)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use hyperlane_base::cache::{
+        LocalCache, MeteredCache, MeteredCacheConfig, MeteredCacheMetricsBuilder, OptionalCache,
+    };
+    use hyperlane_core::{
+        ChainCommunicationError, ChainResult, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+        HyperlaneMessage, KnownHyperlaneDomain, RoutingIsm, H256,
+    };
+
+    use crate::{
+        msg::metadata::message_builder::MessageMetadataBuilder,
+        test_utils::mock_base_builder::build_mock_base_builder,
+    };
+
+    use super::{IsmCachePolicy, RoutingIsmMetadataBuilder};
+
+    #[derive(Debug)]
+    struct CountingRoutingIsm {
+        address: H256,
+        domain: HyperlaneDomain,
+        calls: Arc<AtomicUsize>,
+        fail_first: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl RoutingIsm for CountingRoutingIsm {
+        async fn route(&self, _message: &HyperlaneMessage) -> ChainResult<H256> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_first && call == 0 {
+                Err(ChainCommunicationError::from_other_str(
+                    "simulated provider failure",
+                ))
+            } else {
+                Ok(H256::from_low_u64_be(42))
+            }
+        }
+    }
+
+    impl HyperlaneContract for CountingRoutingIsm {
+        fn address(&self) -> H256 {
+            self.address
+        }
+    }
+
+    impl HyperlaneChain for CountingRoutingIsm {
+        fn domain(&self) -> &HyperlaneDomain {
+            &self.domain
+        }
+
+        fn provider(&self) -> Box<dyn hyperlane_core::HyperlaneProvider> {
+            unimplemented!("provider is not used by routing cache tests")
+        }
+    }
+
+    fn builder() -> RoutingIsmMetadataBuilder {
+        let origin = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let destination = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let mut base = build_mock_base_builder(origin, destination);
+        let cache_name = "routing-cache-test";
+        base.responses.cache = Some(OptionalCache::new(Some(MeteredCache::new(
+            LocalCache::new(cache_name),
+            MeteredCacheMetricsBuilder::default()
+                .build()
+                .expect("cache metrics should build"),
+            MeteredCacheConfig {
+                cache_name: cache_name.to_owned(),
+            },
+        ))));
+
+        RoutingIsmMetadataBuilder::new(MessageMetadataBuilder {
+            base: Arc::new(base),
+            app_context: None,
+            root_ism: H256::from_low_u64_be(1),
+            max_ism_depth: 10,
+            max_ism_count: 10,
+        })
+    }
+
+    fn ism(calls: Arc<AtomicUsize>, fail_first: bool) -> CountingRoutingIsm {
+        ism_on_domain(calls, fail_first, KnownHyperlaneDomain::Arbitrum.into())
+    }
+
+    fn ism_on_domain(
+        calls: Arc<AtomicUsize>,
+        fail_first: bool,
+        domain: HyperlaneDomain,
+    ) -> CountingRoutingIsm {
+        CountingRoutingIsm {
+            address: H256::from_low_u64_be(1),
+            domain,
+            calls,
+            fail_first,
+        }
+    }
+
+    #[tokio::test]
+    async fn ism_specific_routes_are_cached_by_origin_on_the_ism_domain() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ism = ism(calls.clone(), false);
+        let ethereum_message = HyperlaneMessage {
+            origin: HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum).id(),
+            ..HyperlaneMessage::default()
+        };
+        let arbitrum_message = HyperlaneMessage {
+            origin: HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum).id(),
+            ..HyperlaneMessage::default()
+        };
+
+        assert_eq!(
+            builder
+                .route(&ism, &ethereum_message, IsmCachePolicy::IsmSpecific)
+                .await
+                .unwrap(),
+            H256::from_low_u64_be(42)
+        );
+        assert_eq!(
+            builder
+                .route(&ism, &ethereum_message, IsmCachePolicy::IsmSpecific)
+                .await
+                .unwrap(),
+            H256::from_low_u64_be(42)
+        );
+        builder
+            .route(&ism, &arbitrum_message, IsmCachePolicy::IsmSpecific)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn ism_specific_routes_are_isolated_by_ism_domain() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ethereum_ism =
+            ism_on_domain(calls.clone(), false, KnownHyperlaneDomain::Ethereum.into());
+        let arbitrum_ism =
+            ism_on_domain(calls.clone(), false, KnownHyperlaneDomain::Arbitrum.into());
+        let message = HyperlaneMessage::default();
+
+        builder
+            .route(&ethereum_ism, &message, IsmCachePolicy::IsmSpecific)
+            .await
+            .unwrap();
+        builder
+            .route(&arbitrum_ism, &message, IsmCachePolicy::IsmSpecific)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn message_specific_routes_are_isolated_by_message_id() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ism = ism(calls.clone(), false);
+        let first = HyperlaneMessage {
+            nonce: 1,
+            ..HyperlaneMessage::default()
+        };
+        let second = HyperlaneMessage {
+            nonce: 2,
+            ..HyperlaneMessage::default()
+        };
+
+        builder
+            .route(&ism, &first, IsmCachePolicy::MessageSpecific)
+            .await
+            .unwrap();
+        builder
+            .route(&ism, &first, IsmCachePolicy::MessageSpecific)
+            .await
+            .unwrap();
+        builder
+            .route(&ism, &second, IsmCachePolicy::MessageSpecific)
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_routes_are_not_cached() {
+        let builder = builder();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ism = ism(calls.clone(), true);
+        let message = HyperlaneMessage::default();
+
+        assert!(builder
+            .route(&ism, &message, IsmCachePolicy::MessageSpecific)
+            .await
+            .is_err());
+        assert!(builder
+            .route(&ism, &message, IsmCachePolicy::MessageSpecific)
+            .await
+            .is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/routing.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/routing.rs
@@ -19,7 +19,7 @@ pub struct RoutingIsmMetadataBuilder {
 #[async_trait]
 impl MetadataBuilder for RoutingIsmMetadataBuilder {
     #[allow(clippy::blocks_in_conditions)] // TODO: `rustc` 1.80.1 clippy issue
-    #[instrument(err, skip(self, message, params))]
+    #[instrument(skip(self, message, params))]
     async fn build(
         &self,
         ism_address: H256,

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -4,7 +4,7 @@ use derive_new::new;
 use hyperlane_core::{PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason};
 use prometheus::{IntGauge, IntGaugeVec};
 use tokio::sync::{broadcast::Receiver, Mutex};
-use tracing::{debug, instrument};
+use tracing::{instrument, trace};
 
 use crate::server::operations::message_retry::{MessageRetryQueueResponse, MessageRetryRequest};
 use crate::settings::matching_list::MatchingListExt;
@@ -60,7 +60,7 @@ impl OpQueue {
         // This function is called very often by the message processor tasks, so only log when there are operations to pop
         // to avoid spamming the logs
         if !popped.is_empty() {
-            debug!(
+            trace!(
                 queue_label = %self.queue_metrics_label,
                 operations = ?popped,
                 "Popped OpQueue operations"

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -148,8 +148,10 @@ impl OpQueue {
                     })
                     .collect::<Vec<_>>();
                 if matched {
-                    op.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
                     let reset_succeeded = op.reset_attempts();
+                    if reset_succeeded {
+                        op.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
+                    }
                     for i in matching_requests {
                         let retry_response = &mut retry_responses[i];
                         if reset_succeeded {

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -135,21 +135,29 @@ impl OpQueue {
             .drain()
             .map(|Reverse(mut op)| {
                 let mut matched = false;
-                retry_responses
-                    .iter_mut()
+                let matching_requests = retry_responses
+                    .iter()
                     .enumerate()
-                    .for_each(|(i, retry_response)| {
+                    .filter_map(|(i, _)| {
                         let retry_req = &retry_requests[i];
                         if !retry_req.pattern.op_matches(&op) {
-                            return;
+                            return None;
                         }
-                        // update retry metrics
-                        retry_response.matched = retry_response.matched.saturating_add(1);
                         matched = true;
-                    });
+                        Some(i)
+                    })
+                    .collect::<Vec<_>>();
                 if matched {
                     op.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
-                    op.reset_attempts();
+                    let reset_succeeded = op.reset_attempts();
+                    for i in matching_requests {
+                        let retry_response = &mut retry_responses[i];
+                        if reset_succeeded {
+                            retry_response.matched = retry_response.matched.saturating_add(1);
+                        } else {
+                            retry_response.failed = retry_response.failed.saturating_add(1);
+                        }
+                    }
                 }
                 Reverse(op)
             })

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -1,9 +1,12 @@
-use std::{cmp::Reverse, collections::BinaryHeap, sync::Arc};
+use std::{cmp::Reverse, collections::BinaryHeap, sync::Arc, time::Instant};
 
 use derive_new::new;
 use hyperlane_core::{PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason};
 use prometheus::{IntGauge, IntGaugeVec};
-use tokio::sync::{broadcast::Receiver, Mutex};
+use tokio::{
+    sync::{broadcast::Receiver, Mutex, Notify},
+    time::sleep_until,
+};
 use tracing::{instrument, trace};
 
 use crate::server::operations::message_retry::{MessageRetryQueueResponse, MessageRetryRequest};
@@ -18,6 +21,10 @@ pub struct OpQueue {
     metrics: IntGaugeVec,
     queue_metrics_label: String,
     retry_receiver: Arc<Mutex<Receiver<MessageRetryRequest>>>,
+    #[new(default)]
+    notify: Arc<Notify>,
+    #[new(default)]
+    space_available: Arc<Notify>,
     #[new(default)]
     pub queue: OperationPriorityQueue,
 }
@@ -34,6 +41,7 @@ impl OpQueue {
         op.set_status_and_update_metrics(new_status, new_metric);
 
         self.queue.lock().await.push(Reverse(op));
+        self.notify.notify_one();
     }
 
     /// Pop an element from the queue and update metrics
@@ -56,6 +64,10 @@ impl OpQueue {
                 break;
             }
         }
+        drop(queue);
+        if !popped.is_empty() {
+            self.space_available.notify_one();
+        }
 
         // This function is called very often by the message processor tasks, so only log when there are operations to pop
         // to avoid spamming the logs
@@ -67,6 +79,70 @@ impl OpQueue {
             );
         }
         popped
+    }
+
+    pub async fn pop_many_ready(&mut self, limit: usize) -> (Vec<QueueOperation>, Option<Instant>) {
+        self.process_retry_requests().await;
+        let now = Instant::now();
+        let mut queue = self.queue.lock().await;
+        let mut popped = Vec::with_capacity(limit.min(queue.len()));
+        while popped.len() < limit {
+            let Some(Reverse(next)) = queue.peek() else {
+                break;
+            };
+            if next
+                .next_attempt_after()
+                .is_some_and(|deadline| deadline > now)
+            {
+                break;
+            }
+            if let Some(Reverse(op)) = queue.pop() {
+                popped.push(op);
+            }
+        }
+        let next_deadline = queue
+            .peek()
+            .and_then(|Reverse(operation)| operation.next_attempt_after());
+        drop(queue);
+        if !popped.is_empty() {
+            self.space_available.notify_one();
+        }
+        (popped, next_deadline)
+    }
+
+    pub async fn wait_for_len_below(&self, limit: usize) {
+        loop {
+            let notified = self.space_available.notified();
+            if self.len().await < limit {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub async fn wait_for_ready(&mut self, deadline: Option<Instant>) {
+        let notify = self.notify.clone();
+        let retry_receiver = self.retry_receiver.clone();
+        let retry_request = async move { retry_receiver.lock().await.recv().await };
+
+        let retry_request = match deadline {
+            Some(deadline) => {
+                tokio::select! {
+                    _ = notify.notified() => None,
+                    _ = sleep_until(deadline.into()) => None,
+                    request = retry_request => request.ok(),
+                }
+            }
+            None => {
+                tokio::select! {
+                    _ = notify.notified() => None,
+                    request = retry_request => request.ok(),
+                }
+            }
+        };
+        if let Some(retry_request) = retry_request {
+            self.process_retry_request_batch(vec![retry_request]).await;
+        }
     }
 
     pub async fn process_retry_requests(&mut self) {
@@ -85,6 +161,14 @@ impl OpQueue {
             return;
         }
 
+        self.process_retry_request_batch(message_retry_requests)
+            .await;
+    }
+
+    async fn process_retry_request_batch(
+        &mut self,
+        message_retry_requests: Vec<MessageRetryRequest>,
+    ) {
         let (retry_responses, queue_length) = {
             let mut queue = self.queue.lock().await;
             let responses = Self::reprioritize_matching(&mut queue, &message_retry_requests);

--- a/rust/main/agents/relayer/src/msg/op_queue.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue.rs
@@ -4,7 +4,10 @@ use derive_new::new;
 use hyperlane_core::{PendingOperation, PendingOperationStatus, QueueOperation, ReprepareReason};
 use prometheus::{IntGauge, IntGaugeVec};
 use tokio::{
-    sync::{broadcast::Receiver, Mutex, Notify},
+    sync::{
+        broadcast::{error::RecvError, Receiver},
+        Mutex, Notify,
+    },
     time::sleep_until,
 };
 use tracing::{instrument, trace};
@@ -123,20 +126,30 @@ impl OpQueue {
     pub async fn wait_for_ready(&mut self, deadline: Option<Instant>) {
         let notify = self.notify.clone();
         let retry_receiver = self.retry_receiver.clone();
-        let retry_request = async move { retry_receiver.lock().await.recv().await };
+        let retry_request = async move {
+            let result = {
+                let mut receiver = retry_receiver.lock().await;
+                receiver.recv().await
+            };
+            match result {
+                Ok(request) => Some(request),
+                Err(RecvError::Lagged(_)) => None,
+                Err(RecvError::Closed) => std::future::pending().await,
+            }
+        };
 
         let retry_request = match deadline {
             Some(deadline) => {
                 tokio::select! {
                     _ = notify.notified() => None,
                     _ = sleep_until(deadline.into()) => None,
-                    request = retry_request => request.ok(),
+                    request = retry_request => request,
                 }
             }
             None => {
                 tokio::select! {
                     _ = notify.notified() => None,
-                    request = retry_request => request.ok(),
+                    request = retry_request => request,
                 }
             }
         };

--- a/rust/main/agents/relayer/src/msg/op_queue/tests.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue/tests.rs
@@ -29,6 +29,8 @@ pub struct MockPendingOperation {
     destination_domain_id: u32,
     recipient_address: H256,
     seconds_to_next_attempt: u64,
+    #[serde(skip)]
+    fixed_deadline: Option<Instant>,
     destination_domain: HyperlaneDomain,
     retry_count: u32,
     #[serde(skip)]
@@ -42,6 +44,7 @@ impl MockPendingOperation {
         Self {
             id: H256::random(),
             seconds_to_next_attempt,
+            fixed_deadline: None,
             destination_domain_id: destination_domain.id(),
             destination_domain,
             sender_address: H256::random(),
@@ -61,6 +64,7 @@ impl MockPendingOperation {
             origin_domain_id: message.origin,
             destination_domain_id: message.destination,
             seconds_to_next_attempt: 0,
+            fixed_deadline: None,
             retry_count: 0,
             reset_succeeds: true,
             destination_domain: HyperlaneDomain::Unknown {
@@ -115,6 +119,12 @@ impl MockPendingOperation {
         self.reset_succeeds = false;
         self
     }
+
+    fn with_fixed_deadline(mut self) -> Self {
+        self.fixed_deadline =
+            Instant::now().checked_add(Duration::from_secs(self.seconds_to_next_attempt));
+        self
+    }
 }
 
 impl TryBatchAs<HyperlaneMessage> for MockPendingOperation {}
@@ -137,6 +147,9 @@ impl PendingOperation for MockPendingOperation {
             return false;
         }
         self.seconds_to_next_attempt = 0;
+        if self.fixed_deadline.is_some() {
+            self.fixed_deadline = Some(Instant::now());
+        }
         true
     }
 
@@ -216,11 +229,9 @@ impl PendingOperation for MockPendingOperation {
     }
 
     fn next_attempt_after(&self) -> Option<Instant> {
-        Some(
-            Instant::now()
-                .checked_add(Duration::from_secs(self.seconds_to_next_attempt))
-                .unwrap(),
-        )
+        self.fixed_deadline.or_else(|| {
+            Instant::now().checked_add(Duration::from_secs(self.seconds_to_next_attempt))
+        })
     }
 
     fn set_next_attempt_after(&mut self, _delay: Duration) {
@@ -309,6 +320,142 @@ fn failed_manual_retry_reset_is_reported_not_matched() {
 
     assert_eq!(responses[0].matched, 0);
     assert_eq!(responses[0].failed, 1);
+}
+
+#[tokio::test]
+async fn ready_wait_wakes_for_new_earlier_operation() {
+    let broadcaster = sync::broadcast::Sender::new(10);
+    let mut waiting_queue = initialize_queue(&broadcaster);
+    waiting_queue
+        .push(
+            Box::new(
+                MockPendingOperation::new(60, KnownHyperlaneDomain::Base.into())
+                    .with_fixed_deadline(),
+            ),
+            Some(PendingOperationStatus::FirstPrepareAttempt),
+        )
+        .await;
+    let producer = waiting_queue.clone();
+
+    let waiter = tokio::spawn(async move {
+        loop {
+            let (batch, deadline) = waiting_queue.pop_many_ready(1).await;
+            if !batch.is_empty() {
+                break batch;
+            }
+            waiting_queue.wait_for_ready(deadline).await;
+        }
+    });
+    tokio::task::yield_now().await;
+    let ready_operation =
+        MockPendingOperation::new(0, KnownHyperlaneDomain::Base.into()).with_fixed_deadline();
+    let ready_operation_id = ready_operation.id();
+    producer
+        .push(
+            Box::new(ready_operation),
+            Some(PendingOperationStatus::FirstPrepareAttempt),
+        )
+        .await;
+
+    let batch = tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("earlier insertion must wake the queue")
+        .expect("wait task must not panic");
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].id(), ready_operation_id);
+}
+
+#[tokio::test]
+async fn ready_wait_wakes_for_manual_retry() {
+    let broadcaster = sync::broadcast::Sender::new(10);
+    let mut waiting_queue = initialize_queue(&broadcaster);
+    let operation =
+        MockPendingOperation::new(60, KnownHyperlaneDomain::Base.into()).with_fixed_deadline();
+    let operation_id = operation.id();
+    waiting_queue
+        .push(
+            Box::new(operation),
+            Some(PendingOperationStatus::FirstPrepareAttempt),
+        )
+        .await;
+    let (response_sender, mut response_receiver) = mpsc::channel(1);
+
+    let waiter = tokio::spawn(async move {
+        loop {
+            let (batch, deadline) = waiting_queue.pop_many_ready(1).await;
+            if !batch.is_empty() {
+                break batch;
+            }
+            waiting_queue.wait_for_ready(deadline).await;
+        }
+    });
+    tokio::task::yield_now().await;
+    broadcaster
+        .send(MessageRetryRequest {
+            uuid: "manual-retry".to_owned(),
+            pattern: MatchingList::with_message_id(operation_id),
+            transmitter: response_sender,
+        })
+        .expect("broadcast retry request");
+
+    let batch = tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("manual retry must wake the queue")
+        .expect("wait task must not panic");
+    assert_eq!(batch.len(), 1);
+    assert_eq!(batch[0].id(), operation_id);
+    assert_eq!(
+        response_receiver
+            .recv()
+            .await
+            .expect("retry response")
+            .matched,
+        1
+    );
+}
+
+#[tokio::test]
+async fn capacity_wait_wakes_after_pop() {
+    let broadcaster = sync::broadcast::Sender::new(10);
+    let mut queue = initialize_queue(&broadcaster);
+    queue
+        .push(
+            Box::new(MockPendingOperation::new(
+                0,
+                KnownHyperlaneDomain::Base.into(),
+            )),
+            Some(PendingOperationStatus::FirstPrepareAttempt),
+        )
+        .await;
+    let waiter_queue = queue.clone();
+    let waiter = tokio::spawn(async move { waiter_queue.wait_for_len_below(1).await });
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    assert!(queue.pop().await.is_some());
+    tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("capacity waiter should wake after a pop")
+        .expect("wait task must not panic");
+}
+
+#[tokio::test]
+async fn ready_pop_caps_preallocation_to_queue_length() {
+    let broadcaster = sync::broadcast::Sender::new(10);
+    let mut queue = initialize_queue(&broadcaster);
+    queue
+        .push(
+            Box::new(
+                MockPendingOperation::new(0, KnownHyperlaneDomain::Base.into())
+                    .with_fixed_deadline(),
+            ),
+            Some(PendingOperationStatus::FirstPrepareAttempt),
+        )
+        .await;
+
+    let (batch, _) = queue.pop_many_ready(usize::MAX).await;
+
+    assert_eq!(batch.len(), 1);
 }
 
 #[tokio::test]

--- a/rust/main/agents/relayer/src/msg/op_queue/tests.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue/tests.rs
@@ -31,6 +31,7 @@ pub struct MockPendingOperation {
     seconds_to_next_attempt: u64,
     destination_domain: HyperlaneDomain,
     retry_count: u32,
+    #[serde(skip)]
     reset_succeeds: bool,
     #[serde(skip)]
     pub mailbox: Option<Arc<dyn Mailbox>>,

--- a/rust/main/agents/relayer/src/msg/op_queue/tests.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue/tests.rs
@@ -31,6 +31,7 @@ pub struct MockPendingOperation {
     seconds_to_next_attempt: u64,
     destination_domain: HyperlaneDomain,
     retry_count: u32,
+    reset_succeeds: bool,
     #[serde(skip)]
     pub mailbox: Option<Arc<dyn Mailbox>>,
 }
@@ -46,6 +47,7 @@ impl MockPendingOperation {
             recipient_address: H256::random(),
             origin_domain_id: 0,
             retry_count: 0,
+            reset_succeeds: true,
             mailbox: None,
         }
     }
@@ -59,6 +61,7 @@ impl MockPendingOperation {
             destination_domain_id: message.destination,
             seconds_to_next_attempt: 0,
             retry_count: 0,
+            reset_succeeds: true,
             destination_domain: HyperlaneDomain::Unknown {
                 domain_id: message.destination,
                 domain_name: "test".to_string(),
@@ -106,6 +109,11 @@ impl MockPendingOperation {
         self.set_retries(retry_count);
         self
     }
+
+    pub fn with_failed_reset(mut self) -> Self {
+        self.reset_succeeds = false;
+        self
+    }
 }
 
 impl TryBatchAs<HyperlaneMessage> for MockPendingOperation {}
@@ -123,8 +131,12 @@ impl PendingOperation for MockPendingOperation {
 
     fn set_status(&mut self, _status: PendingOperationStatus) {}
 
-    fn reset_attempts(&mut self) {
+    fn reset_attempts(&mut self) -> bool {
+        if !self.reset_succeeds {
+            return false;
+        }
         self.seconds_to_next_attempt = 0;
+        true
     }
 
     fn sender_address(&self) -> &H256 {
@@ -277,6 +289,25 @@ fn generate_test_messages(
         })
         .collect();
     ops
+}
+
+#[test]
+fn failed_manual_retry_reset_is_reported_not_matched() {
+    let destination_domain: HyperlaneDomain = KnownHyperlaneDomain::Base.into();
+    let op = MockPendingOperation::new(60, destination_domain).with_failed_reset();
+    let id = op.id();
+    let mut queue = BinaryHeap::from([Reverse(Box::new(op) as QueueOperation)]);
+    let (transmitter, _receiver) = mpsc::channel(1);
+    let requests = [MessageRetryRequest {
+        uuid: "failed-reset".to_owned(),
+        pattern: MatchingList::with_message_id(id),
+        transmitter,
+    }];
+
+    let responses = OpQueue::reprioritize_matching(&mut queue, &requests);
+
+    assert_eq!(responses[0].matched, 0);
+    assert_eq!(responses[0].failed, 1);
 }
 
 #[tokio::test]

--- a/rust/main/agents/relayer/src/msg/op_queue/tests.rs
+++ b/rust/main/agents/relayer/src/msg/op_queue/tests.rs
@@ -415,6 +415,47 @@ async fn ready_wait_wakes_for_manual_retry() {
 }
 
 #[tokio::test]
+async fn ready_wait_does_not_spin_when_retry_channel_closes() {
+    let broadcaster = sync::broadcast::Sender::new(10);
+    let mut waiting_queue = initialize_queue(&broadcaster);
+    let operation =
+        MockPendingOperation::new(60, KnownHyperlaneDomain::Base.into()).with_fixed_deadline();
+    waiting_queue
+        .queue
+        .lock()
+        .await
+        .push(Reverse(Box::new(operation) as QueueOperation));
+    let producer = waiting_queue.clone();
+    drop(broadcaster);
+
+    let waiter = tokio::spawn(async move {
+        let (batch, deadline) = waiting_queue.pop_many_ready(1).await;
+        assert!(batch.is_empty());
+        assert!(deadline.is_some_and(|deadline| deadline > Instant::now()));
+        waiting_queue.wait_for_ready(deadline).await;
+    });
+    tokio::task::yield_now().await;
+    assert!(
+        !waiter.is_finished(),
+        "closed retry channel must not bypass a future retry deadline"
+    );
+
+    producer
+        .push(
+            Box::new(MockPendingOperation::new(
+                0,
+                KnownHyperlaneDomain::Base.into(),
+            )),
+            Some(PendingOperationStatus::FirstPrepareAttempt),
+        )
+        .await;
+    tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("queue insertion must wake the wait")
+        .expect("wait task must not panic");
+}
+
+#[tokio::test]
 async fn capacity_wait_wakes_after_pop() {
     let broadcaster = sync::broadcast::Sender::new(10);
     let mut queue = initialize_queue(&broadcaster);

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -227,12 +227,15 @@ impl PendingOperation for PendingMessage {
     }
 
     fn set_status(&mut self, status: PendingOperationStatus) {
-        if let Err(e) = self
-            .ctx
-            .origin_db
-            .store_status_by_message_id(&self.message.id(), &status)
-        {
-            warn!(message_id = ?self.message.id(), err = %e, status = %status, "Persisting `status` failed for message");
+        // Manual status commits atomically with the cleared retry deadline.
+        if status != PendingOperationStatus::Retry(ReprepareReason::Manual) {
+            if let Err(e) = self
+                .ctx
+                .origin_db
+                .store_status_by_message_id(&self.message.id(), &status)
+            {
+                warn!(message_id = ?self.message.id(), err = %e, status = %status, "Persisting `status` failed for message");
+            }
         }
         self.status = status;
     }
@@ -1155,7 +1158,19 @@ impl PendingMessage {
     fn reset_attempts(&mut self) {
         self.next_attempt_after = None;
         self.last_attempted_at = Instant::now();
-        self.persist_retry_state(None, None);
+        let status = self.status.clone();
+        let state = PendingMessageRetryState::new(self.num_retries, None, None, None);
+        if let Err(e) = self
+            .ctx
+            .origin_db
+            .store_pending_message_retry_state_and_status_by_message_id(
+                &self.message.id(),
+                &state,
+                &status,
+            )
+        {
+            warn!(message_id = ?self.message.id(), err = %e, "Persisting manual retry reset failed for message");
+        }
     }
 
     fn inc_attempts(&mut self, reason: Option<&ReprepareReason>) {
@@ -1616,7 +1631,7 @@ mod test {
             .store_pending_message_retry_count_by_message_id(&message.id(), &2)
             .expect("store lagging legacy retry count");
 
-        let restored = PendingMessage::maybe_from_persisted_retries(
+        let mut restored = PendingMessage::maybe_from_persisted_retries(
             message.clone(),
             ctx.clone(),
             None,
@@ -1634,6 +1649,35 @@ mod test {
         );
         assert!(remaining > Duration::from_secs(58));
         assert!(remaining <= Duration::from_secs(60));
+
+        restored.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
+        restored.reset_attempts();
+        assert_eq!(
+            base_db
+                .retrieve_status_by_message_id(&message.id())
+                .expect("read manual retry status"),
+            Some(PendingOperationStatus::Retry(ReprepareReason::Manual))
+        );
+        let manual_state = base_db
+            .retrieve_pending_message_retry_state_by_message_id(&message.id())
+            .expect("read manual retry state")
+            .expect("manual retry state");
+        assert_eq!(manual_state.retry_count, 3);
+        assert_eq!(manual_state.next_attempt_at_millis, None);
+        assert_eq!(manual_state.retry_delay_millis, None);
+        assert_eq!(manual_state.reason, None);
+        let manual = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore manual retry");
+        assert_eq!(
+            manual.status(),
+            PendingOperationStatus::Retry(ReprepareReason::Manual)
+        );
+        assert_eq!(manual.next_attempt_after(), None);
 
         let expired_state = PendingMessageRetryState::new(
             3,

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -701,20 +701,20 @@ impl PendingMessage {
     ) -> Option<Self> {
         let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
         let legacy_num_retries = Self::get_num_retries(ctx.origin_db.clone(), &message);
-        let (num_retries, mut retry_state) =
+        let (mut num_retries, mut retry_state) =
             Self::reconcile_retry_state(retry_state, legacy_num_retries, &message.id());
-        if Self::should_skip(num_retries, max_retries) {
-            return None;
-        }
         let mut message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
         // Old binaries persist Manual status without clearing the versioned deadline. On
-        // roll-forward the operator's manual retry remains authoritative at equal counts.
-        if message_status == PendingOperationStatus::Retry(ReprepareReason::Manual)
-            && retry_state
-                .as_ref()
-                .is_some_and(|state| state.next_attempt_at_millis.is_some())
+        // roll-forward the operator's manual retry remains authoritative, including at
+        // the retry ceiling. Normalize it to the same zero-count state as new binaries.
+        let manual_retry = message_status == PendingOperationStatus::Retry(ReprepareReason::Manual);
+        if manual_retry
+            && (num_retries != 0
+                || retry_state
+                    .as_ref()
+                    .is_some_and(|state| state.next_attempt_at_millis.is_some()))
         {
-            let normalized = PendingMessageRetryState::new(num_retries, None, None, None);
+            let normalized = PendingMessageRetryState::new(0, None, None, None);
             if let Err(err) = ctx
                 .origin_db
                 .store_pending_message_retry_state_and_status_by_message_id(
@@ -724,8 +724,13 @@ impl PendingMessage {
                 )
             {
                 warn!(message_id = ?message.id(), %err, "Failed to normalize legacy manual retry state");
+            } else {
+                num_retries = 0;
+                retry_state = Some(normalized);
             }
-            retry_state = Some(normalized);
+        }
+        if Self::should_skip(num_retries, max_retries) && !manual_retry {
+            return None;
         }
         let reprepare_reason = match &message_status {
             PendingOperationStatus::Retry(r) => Some(r.clone()),
@@ -1176,10 +1181,8 @@ impl PendingMessage {
     }
 
     fn reset_attempts(&mut self) -> bool {
-        self.next_attempt_after = None;
-        self.last_attempted_at = Instant::now();
-        let status = self.status.clone();
-        let state = PendingMessageRetryState::new(self.num_retries, None, None, None);
+        let status = PendingOperationStatus::Retry(ReprepareReason::Manual);
+        let state = PendingMessageRetryState::new(0, None, None, None);
         if let Err(e) = self
             .ctx
             .origin_db
@@ -1192,6 +1195,10 @@ impl PendingMessage {
             warn!(message_id = ?self.message.id(), err = %e, "Persisting manual retry reset failed for message");
             return false;
         }
+        self.status = status;
+        self.num_retries = 0;
+        self.next_attempt_after = None;
+        self.last_attempted_at = Instant::now();
         true
     }
 
@@ -1563,6 +1570,47 @@ mod test {
         );
     }
 
+    #[test]
+    fn failed_manual_retry_commit_leaves_memory_unchanged() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().expect("temp db directory");
+        let db = DB::from_path(temp_dir.path()).expect("open temp db");
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let mut ctx = dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+        let mut failing_db = MockDb::new();
+        failing_db
+            .expect_store_pending_message_retry_state_and_status_by_message_id()
+            .withf(|_, state, status| {
+                state.retry_count == 0
+                    && *status == PendingOperationStatus::Retry(ReprepareReason::Manual)
+            })
+            .returning(|_, _, _| Err(DbError::Other("injected failure".to_owned())));
+        ctx.origin_db = Arc::new(failing_db);
+
+        let original_status = PendingOperationStatus::Retry(ReprepareReason::ErrorSubmitting);
+        let mut pending = PendingMessage::new(
+            HyperlaneMessage::default(),
+            Arc::new(ctx),
+            original_status.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        pending.num_retries = 5;
+        let deadline = Instant::now() + Duration::from_secs(60);
+        pending.next_attempt_after = Some(deadline);
+        let attempted_at = pending.last_attempted_at;
+
+        assert!(!pending.reset_attempts());
+        assert_eq!(pending.status, original_status);
+        assert_eq!(pending.num_retries, 5);
+        assert_eq!(pending.next_attempt_after, Some(deadline));
+        assert_eq!(pending.last_attempted_at, attempted_at);
+    }
+
     #[tokio::test]
     async fn restores_durable_deadline_and_falls_back_from_malformed_state() {
         let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
@@ -1714,7 +1762,6 @@ mod test {
         assert!(remaining > Duration::from_secs(58));
         assert!(remaining <= Duration::from_secs(60));
 
-        restored.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
         assert!(restored.reset_attempts());
         assert_eq!(
             base_db
@@ -1726,7 +1773,7 @@ mod test {
             .retrieve_pending_message_retry_state_by_message_id(&message.id())
             .expect("read manual retry state")
             .expect("manual retry state");
-        assert_eq!(manual_state.retry_count, 3);
+        assert_eq!(manual_state.retry_count, 0);
         assert_eq!(manual_state.next_attempt_at_millis, None);
         assert_eq!(manual_state.retry_delay_millis, None);
         assert_eq!(manual_state.reason, None);
@@ -1742,6 +1789,36 @@ mod test {
             PendingOperationStatus::Retry(ReprepareReason::Manual)
         );
         assert_eq!(manual.next_attempt_after(), None);
+        assert_eq!(manual.get_retries(), 0);
+
+        // A manual retry written by an old binary at the retry ceiling must also
+        // survive restart and normalize to the new zero-count representation.
+        let ceiling_state = PendingMessageRetryState::new(
+            DEFAULT_MAX_MESSAGE_RETRIES,
+            Some(unix_millis(SystemTime::now() + Duration::from_secs(60))),
+            Some(60_000),
+            Some(ReprepareReason::ErrorSubmitting),
+        );
+        base_db
+            .store_pending_message_retry_state_and_status_by_message_id(
+                &message.id(),
+                &ceiling_state,
+                &PendingOperationStatus::Retry(ReprepareReason::Manual),
+            )
+            .expect("store ceiling manual retry");
+        let ceiling_manual = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore ceiling manual retry");
+        assert_eq!(ceiling_manual.get_retries(), 0);
+        assert_eq!(ceiling_manual.next_attempt_after(), None);
+        assert_eq!(
+            ceiling_manual.status(),
+            PendingOperationStatus::Retry(ReprepareReason::Manual)
+        );
 
         let expired_state = PendingMessageRetryState::new(
             3,
@@ -1750,7 +1827,11 @@ mod test {
             Some(ReprepareReason::CouldNotFetchMetadata),
         );
         base_db
-            .store_pending_message_retry_state_by_message_id(&message.id(), &expired_state)
+            .store_pending_message_retry_state_and_status_by_message_id(
+                &message.id(),
+                &expired_state,
+                &PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata),
+            )
             .expect("store expired retry state");
         let expired = PendingMessage::maybe_from_persisted_retries(
             message.clone(),

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1020,7 +1020,7 @@ impl PendingMessage {
             );
         }
         let result = self.reprepare_or_drop(reason);
-        if matches!(result, PendingOperationResult::Drop) {
+        if Self::should_skip(self.num_retries, self.max_retries) {
             self.ctx.metrics.finish_metadata_wait(
                 self.message.id(),
                 self.app_context.as_deref(),
@@ -1641,5 +1641,69 @@ mod test {
         let pending_message_debug = format!("{pending_message:?}");
         let expected = r#"PendingMessage { num_retries: 0, since_last_attempt_s: 0, next_attempt_after_s: 0, message_id: 0xaeafdd9f018e66a50d30bb141184d10e57bd956e839f70213c163eb41a3c0d87, status: FirstPrepareAttempt, app_context: Some("test-0") }"#;
         assert_eq!(pending_message_debug, expected);
+    }
+
+    #[test]
+    fn metadata_wait_ends_at_normal_message_retry_limit() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = DB::from_path(temp_dir.path()).unwrap();
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = HyperlaneMessage {
+            origin: KnownHyperlaneDomain::Arbitrum as u32,
+            destination: KnownHyperlaneDomain::Arbitrum as u32,
+            ..Default::default()
+        };
+        let message_id = message.id();
+        let app_context = "test-app";
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let message_context =
+            dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+        let mut pending_message = PendingMessage::new(
+            message,
+            Arc::new(message_context),
+            PendingOperationStatus::FirstPrepareAttempt,
+            Some(app_context.to_owned()),
+            1,
+        );
+        let labels = [app_context, "ethereum", "arbitrum"];
+        let observation = pending_message
+            .ctx
+            .metrics
+            .record_metadata_wait(message_id, Some(app_context));
+
+        let result = pending_message.on_metadata_wait(observation);
+
+        assert!(matches!(result, PendingOperationResult::Reprepare(_)));
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_active
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_oldest_timestamp_seconds
+                .with_label_values(&labels)
+                .get(),
+            0
+        );
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", "ended"])
+                .get(),
+            1
+        );
     }
 }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1683,6 +1683,12 @@ mod test {
         base_db
             .store_pending_message_retry_state_by_message_id(&message.id(), &state)
             .expect("store retry state");
+        base_db
+            .store_status_by_message_id(
+                &message.id(),
+                &PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata),
+            )
+            .expect("store retry reason");
         // Simulate the historical write-order fault where the combined state landed
         // before its legacy mirror. The higher combined count must remain authoritative.
         base_db

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -632,8 +632,8 @@ impl PendingOperation for PendingMessage {
         self.persist_retry_state(Some(delay), None);
     }
 
-    fn reset_attempts(&mut self) {
-        self.reset_attempts();
+    fn reset_attempts(&mut self) -> bool {
+        self.reset_attempts()
     }
 
     fn set_retries(&mut self, retries: u32) {
@@ -701,12 +701,32 @@ impl PendingMessage {
     ) -> Option<Self> {
         let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
         let legacy_num_retries = Self::get_num_retries(ctx.origin_db.clone(), &message);
-        let (num_retries, retry_state) =
+        let (num_retries, mut retry_state) =
             Self::reconcile_retry_state(retry_state, legacy_num_retries, &message.id());
         if Self::should_skip(num_retries, max_retries) {
             return None;
         }
         let mut message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
+        // Old binaries persist Manual status without clearing the versioned deadline. On
+        // roll-forward the operator's manual retry remains authoritative at equal counts.
+        if message_status == PendingOperationStatus::Retry(ReprepareReason::Manual)
+            && retry_state
+                .as_ref()
+                .is_some_and(|state| state.next_attempt_at_millis.is_some())
+        {
+            let normalized = PendingMessageRetryState::new(num_retries, None, None, None);
+            if let Err(err) = ctx
+                .origin_db
+                .store_pending_message_retry_state_and_status_by_message_id(
+                    &message.id(),
+                    &normalized,
+                    &message_status,
+                )
+            {
+                warn!(message_id = ?message.id(), %err, "Failed to normalize legacy manual retry state");
+            }
+            retry_state = Some(normalized);
+        }
         let reprepare_reason = match &message_status {
             PendingOperationStatus::Retry(r) => Some(r.clone()),
             _ => None,
@@ -1155,7 +1175,7 @@ impl PendingMessage {
         Ok(())
     }
 
-    fn reset_attempts(&mut self) {
+    fn reset_attempts(&mut self) -> bool {
         self.next_attempt_after = None;
         self.last_attempted_at = Instant::now();
         let status = self.status.clone();
@@ -1170,7 +1190,9 @@ impl PendingMessage {
             )
         {
             warn!(message_id = ?self.message.id(), err = %e, "Persisting manual retry reset failed for message");
+            return false;
         }
+        true
     }
 
     fn inc_attempts(&mut self, reason: Option<&ReprepareReason>) {
@@ -1615,6 +1637,42 @@ mod test {
         );
         assert!(remaining.duration_since(Instant::now()) <= Duration::from_secs(10));
 
+        // Simulate an old binary applying a manual retry after the v1 record was
+        // written at the same count. Roll-forward must not restore its stale deadline.
+        let stale_manual_state = PendingMessageRetryState::new(
+            2,
+            Some(unix_millis(SystemTime::now() + Duration::from_secs(60))),
+            Some(60_000),
+            Some(ReprepareReason::ErrorSubmitting),
+        );
+        base_db
+            .store_pending_message_retry_state_by_message_id(&message.id(), &stale_manual_state)
+            .expect("store stale manual retry state");
+        base_db
+            .store_status_by_message_id(
+                &message.id(),
+                &PendingOperationStatus::Retry(ReprepareReason::Manual),
+            )
+            .expect("store legacy manual status");
+        let manual_roll_forward = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore legacy manual retry");
+        assert_eq!(manual_roll_forward.next_attempt_after(), None);
+        assert_eq!(
+            manual_roll_forward.status(),
+            PendingOperationStatus::Retry(ReprepareReason::Manual)
+        );
+        let normalized = base_db
+            .retrieve_pending_message_retry_state_by_message_id(&message.id())
+            .expect("read normalized manual state")
+            .expect("normalized manual state");
+        assert_eq!(normalized.next_attempt_at_millis, None);
+        assert_eq!(normalized.reason, None);
+
         let deadline = SystemTime::now() + Duration::from_secs(60);
         let state = PendingMessageRetryState::new(
             3,
@@ -1651,7 +1709,7 @@ mod test {
         assert!(remaining <= Duration::from_secs(60));
 
         restored.set_status(PendingOperationStatus::Retry(ReprepareReason::Manual));
-        restored.reset_attempts();
+        assert!(restored.reset_attempts());
         assert_eq!(
             base_db
                 .retrieve_status_by_message_id(&message.id())

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -3,7 +3,7 @@
 use std::{
     fmt::{Debug, Formatter},
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
@@ -16,7 +16,7 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 
 use hyperlane_base::{
     cache::{FunctionCallCache, LocalCache, MeteredCache, OptionalCache},
-    db::HyperlaneDb,
+    db::{HyperlaneDb, PendingMessageRetryState},
 };
 use hyperlane_core::{
     gas_used_by_operation, BatchItem, ChainCommunicationError, ChainResult, ConfirmReason,
@@ -626,6 +626,7 @@ impl PendingOperation for PendingMessage {
 
     fn set_next_attempt_after(&mut self, delay: Duration) {
         self.next_attempt_after = Instant::now().checked_add(delay);
+        self.persist_retry_state(Some(delay), None);
     }
 
     fn reset_attempts(&mut self) {
@@ -695,19 +696,41 @@ impl PendingMessage {
         app_context: Option<String>,
         max_retries: u32,
     ) -> Option<Self> {
-        let num_retries = Self::get_retries_or_skip(ctx.origin_db.clone(), &message, max_retries)?;
-        let message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
+        let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
+        let num_retries = retry_state
+            .as_ref()
+            .map(|state| state.retry_count)
+            .unwrap_or_else(|| Self::get_num_retries(ctx.origin_db.clone(), &message));
+        if Self::should_skip(num_retries, max_retries) {
+            return None;
+        }
+        let mut message_status = Self::get_message_status(ctx.origin_db.clone(), &message);
         let reprepare_reason = match &message_status {
             PendingOperationStatus::Retry(r) => Some(r.clone()),
             _ => None,
         };
-        let mut pending_message = Self::new(message, ctx, message_status, app_context, max_retries);
-        if num_retries > 0 {
-            let next_attempt_after =
-                Self::next_attempt_after(num_retries, max_retries, reprepare_reason.as_ref());
-            pending_message.num_retries = num_retries;
-            pending_message.next_attempt_after = next_attempt_after;
+        let next_attempt_after = retry_state
+            .as_ref()
+            .and_then(|state| {
+                Self::restore_retry_deadline(state, SystemTime::now(), Instant::now())
+            })
+            .or_else(|| {
+                if retry_state.is_some() || num_retries == 0 {
+                    None
+                } else {
+                    Self::next_attempt_after(num_retries, max_retries, reprepare_reason.as_ref())
+                }
+            });
+        // While a deadline remains active, the retry record is the atomic source of its
+        // reason too. This closes the crash window before the queue persists Retry(status).
+        if next_attempt_after.is_some() {
+            if let Some(reason) = retry_state.as_ref().and_then(|state| state.reason.clone()) {
+                message_status = PendingOperationStatus::Retry(reason);
+            }
         }
+        let mut pending_message = Self::new(message, ctx, message_status, app_context, max_retries);
+        pending_message.num_retries = num_retries;
+        pending_message.next_attempt_after = next_attempt_after;
         Some(pending_message)
     }
 
@@ -728,6 +751,32 @@ impl PendingMessage {
             .and_then(|dur| Instant::now().checked_add(dur))
     }
 
+    fn restore_retry_deadline(
+        state: &PendingMessageRetryState,
+        wall_now: SystemTime,
+        monotonic_now: Instant,
+    ) -> Option<Instant> {
+        let deadline =
+            UNIX_EPOCH.checked_add(Duration::from_millis(state.next_attempt_at_millis?))?;
+        let remaining = deadline.duration_since(wall_now).ok()?;
+        let original_delay = Duration::from_millis(state.retry_delay_millis?);
+        monotonic_now.checked_add(remaining.min(original_delay))
+    }
+
+    fn get_retry_state(
+        origin_db: Arc<dyn HyperlaneDb>,
+        message: &HyperlaneMessage,
+    ) -> Option<PendingMessageRetryState> {
+        match origin_db.retrieve_pending_message_retry_state_by_message_id(&message.id()) {
+            Ok(state) => state,
+            Err(err) => {
+                warn!(message_id = ?message.id(), %err, "Failed to read durable retry state; falling back to legacy retry count");
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
     fn get_retries_or_skip(
         origin_db: Arc<dyn HyperlaneDb>,
         message: &HyperlaneMessage,
@@ -986,6 +1035,7 @@ impl PendingMessage {
         self.submitted = false;
         self.last_attempted_at = Instant::now();
         self.next_attempt_after = self.last_attempted_at.checked_add(delay);
+        self.persist_retry_state(Some(delay), Some(reason.clone()));
         PendingOperationResult::Reprepare(reason)
     }
 
@@ -1086,22 +1136,53 @@ impl PendingMessage {
     fn reset_attempts(&mut self) {
         self.next_attempt_after = None;
         self.last_attempted_at = Instant::now();
+        self.persist_retry_state(None, None);
     }
 
     fn inc_attempts(&mut self, reason: Option<&ReprepareReason>) {
-        self.set_retries(self.num_retries.saturating_add(1));
+        self.num_retries = self.num_retries.saturating_add(1);
         self.last_attempted_at = Instant::now();
-        self.next_attempt_after = PendingMessage::calculate_msg_backoff(
+        let delay = PendingMessage::calculate_msg_backoff(
             self.num_retries,
             self.max_retries,
             Some(self.message.id()),
             reason,
-        )
-        .and_then(|dur| self.last_attempted_at.checked_add(dur));
+        );
+        self.next_attempt_after = delay.and_then(|dur| self.last_attempted_at.checked_add(dur));
+        self.persist_retry_state(delay, reason.cloned());
     }
 
     fn set_retries(&mut self, retries: u32) {
         self.num_retries = retries;
+        self.persist_retries();
+    }
+
+    fn persist_retry_state(&self, delay: Option<Duration>, reason: Option<ReprepareReason>) {
+        let next_attempt_at_millis = delay.and_then(|delay| {
+            SystemTime::now()
+                .checked_add(delay)?
+                .duration_since(UNIX_EPOCH)
+                .ok()?
+                .as_millis()
+                .try_into()
+                .ok()
+        });
+        let retry_delay_millis = delay.and_then(|delay| delay.as_millis().try_into().ok());
+        let state = PendingMessageRetryState::new(
+            self.num_retries,
+            next_attempt_at_millis,
+            retry_delay_millis,
+            reason,
+        );
+        if let Err(e) = self
+            .ctx
+            .origin_db
+            .store_pending_message_retry_state_by_message_id(&self.message.id(), &state)
+        {
+            warn!(message_id = ?self.message.id(), err = %e, "Persisting durable retry state failed for message");
+        }
+        // Keep the legacy count current so rolling back to an older binary remains safe.
+        // New binaries always prefer the combined record when it is valid.
         self.persist_retries();
     }
 
@@ -1334,7 +1415,7 @@ impl PendingMessage {
 mod test {
     use std::{
         sync::Arc,
-        time::{Duration, Instant},
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     };
 
     use chrono::TimeDelta;
@@ -1345,6 +1426,169 @@ mod test {
     use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
     use super::{PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES, VALIDATOR_SIGNATURE_FAST_RETRY_MAX};
+
+    fn unix_millis(time: SystemTime) -> u64 {
+        time.duration_since(UNIX_EPOCH)
+            .expect("test time must follow Unix epoch")
+            .as_millis()
+            .try_into()
+            .expect("test timestamp must fit in u64")
+    }
+
+    #[test]
+    fn restores_remaining_retry_delay_and_bounds_backward_clock_skew() {
+        let wall_now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let monotonic_now = Instant::now();
+        let state = PendingMessageRetryState::new(
+            8,
+            Some(unix_millis(wall_now + Duration::from_secs(10))),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+
+        assert_eq!(
+            PendingMessage::restore_retry_deadline(&state, wall_now, monotonic_now),
+            monotonic_now.checked_add(Duration::from_secs(10))
+        );
+
+        let skewed_wall_now = wall_now - Duration::from_secs(3_600);
+        assert_eq!(
+            PendingMessage::restore_retry_deadline(&state, skewed_wall_now, monotonic_now),
+            monotonic_now.checked_add(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn expired_retry_deadline_runs_immediately() {
+        let wall_now = UNIX_EPOCH + Duration::from_secs(1_000);
+        let state = PendingMessageRetryState::new(
+            8,
+            Some(unix_millis(wall_now - Duration::from_secs(1))),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+
+        assert_eq!(
+            PendingMessage::restore_retry_deadline(&state, wall_now, Instant::now()),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn restores_durable_deadline_and_falls_back_from_malformed_state() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().expect("temp db directory");
+        let db = DB::from_path(temp_dir.path()).expect("open temp db");
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = HyperlaneMessage {
+            nonce: 7,
+            origin: KnownHyperlaneDomain::Arbitrum as u32,
+            destination: KnownHyperlaneDomain::Ethereum as u32,
+            ..Default::default()
+        };
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let ctx = Arc::new(dummy_message_context(
+            Arc::new(base_metadata_builder),
+            &base_db,
+            cache,
+        ));
+        let mut pending = PendingMessage::new(
+            message.clone(),
+            ctx.clone(),
+            PendingOperationStatus::FirstPrepareAttempt,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        assert!(matches!(
+            pending.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata),
+            PendingOperationResult::Reprepare(ReprepareReason::CouldNotFetchMetadata)
+        ));
+        let persisted = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore production retry state");
+        assert_eq!(persisted.get_retries(), 1);
+        assert_eq!(
+            persisted.status(),
+            PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata)
+        );
+        assert!(persisted.next_attempt_after().is_some());
+
+        let deadline = SystemTime::now() + Duration::from_secs(60);
+        let state = PendingMessageRetryState::new(
+            3,
+            Some(unix_millis(deadline)),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+        base_db
+            .store_pending_message_retry_state_by_message_id(&message.id(), &state)
+            .expect("store retry state");
+
+        let restored = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore pending message");
+        let remaining = restored
+            .next_attempt_after()
+            .expect("future deadline")
+            .duration_since(Instant::now());
+        assert_eq!(restored.get_retries(), 3);
+        assert_eq!(
+            restored.status(),
+            PendingOperationStatus::Retry(ReprepareReason::CouldNotFetchMetadata)
+        );
+        assert!(remaining > Duration::from_secs(58));
+        assert!(remaining <= Duration::from_secs(60));
+
+        let expired_state = PendingMessageRetryState::new(
+            3,
+            Some(unix_millis(SystemTime::now() - Duration::from_secs(1))),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+        base_db
+            .store_pending_message_retry_state_by_message_id(&message.id(), &expired_state)
+            .expect("store expired retry state");
+        let expired = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore expired pending message");
+        assert_eq!(expired.get_retries(), 3);
+        assert_eq!(expired.next_attempt_after(), None);
+
+        base_db
+            .store_value_by_key(
+                "pending_message_retry_state_for_message_id_v1_",
+                &message.id(),
+                &H256::zero(),
+            )
+            .expect("store malformed retry state");
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &2)
+            .expect("store legacy retry count");
+        let fallback = PendingMessage::maybe_from_persisted_retries(
+            message,
+            ctx,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("fallback to legacy retry state");
+        assert_eq!(fallback.get_retries(), 2);
+        assert!(fallback.next_attempt_after().is_some());
+    }
 
     #[test]
     fn test_calculate_msg_backoff_does_not_overflow() {

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -697,10 +697,9 @@ impl PendingMessage {
         max_retries: u32,
     ) -> Option<Self> {
         let retry_state = Self::get_retry_state(ctx.origin_db.clone(), &message);
-        let num_retries = retry_state
-            .as_ref()
-            .map(|state| state.retry_count)
-            .unwrap_or_else(|| Self::get_num_retries(ctx.origin_db.clone(), &message));
+        let legacy_num_retries = Self::get_num_retries(ctx.origin_db.clone(), &message);
+        let (num_retries, retry_state) =
+            Self::reconcile_retry_state(retry_state, legacy_num_retries, &message.id());
         if Self::should_skip(num_retries, max_retries) {
             return None;
         }
@@ -732,6 +731,26 @@ impl PendingMessage {
         pending_message.num_retries = num_retries;
         pending_message.next_attempt_after = next_attempt_after;
         Some(pending_message)
+    }
+
+    fn reconcile_retry_state(
+        retry_state: Option<PendingMessageRetryState>,
+        legacy_num_retries: u32,
+        message_id: &H256,
+    ) -> (u32, Option<PendingMessageRetryState>) {
+        let Some(retry_state) = retry_state else {
+            return (legacy_num_retries, None);
+        };
+        if legacy_num_retries > retry_state.retry_count {
+            warn!(
+                ?message_id,
+                legacy_num_retries,
+                retry_state_num_retries = retry_state.retry_count,
+                "Ignoring stale durable retry state after legacy retry count advanced"
+            );
+            return (legacy_num_retries, None);
+        }
+        (retry_state.retry_count, Some(retry_state))
     }
 
     /// Set fail-fast mode: drop the message immediately when `num_retries` exceeds
@@ -1154,7 +1173,18 @@ impl PendingMessage {
 
     fn set_retries(&mut self, retries: u32) {
         self.num_retries = retries;
-        self.persist_retries();
+        let reason = match &self.status {
+            PendingOperationStatus::Retry(reason) => Some(reason.clone()),
+            _ => None,
+        };
+        let delay = Self::calculate_msg_backoff(
+            self.num_retries,
+            self.max_retries,
+            Some(self.message.id()),
+            reason.as_ref(),
+        );
+        self.next_attempt_after = delay.and_then(|delay| Instant::now().checked_add(delay));
+        self.persist_retry_state(delay, reason);
     }
 
     fn persist_retry_state(&self, delay: Option<Duration>, reason: Option<ReprepareReason>) {
@@ -1180,19 +1210,6 @@ impl PendingMessage {
             .store_pending_message_retry_state_by_message_id(&self.message.id(), &state)
         {
             warn!(message_id = ?self.message.id(), err = %e, "Persisting durable retry state failed for message");
-        }
-        // Keep the legacy count current so rolling back to an older binary remains safe.
-        // New binaries always prefer the combined record when it is valid.
-        self.persist_retries();
-    }
-
-    fn persist_retries(&self) {
-        if let Err(e) = self
-            .ctx
-            .origin_db
-            .store_pending_message_retry_count_by_message_id(&self.message.id(), &self.num_retries)
-        {
-            warn!(message_id = ?self.message.id(), err = %e, "Persisting the `num_retries` failed for message");
         }
     }
 
@@ -1413,6 +1430,7 @@ impl PendingMessage {
 
 #[cfg(test)]
 mod test {
+    use std::io::Write;
     use std::{
         sync::Arc,
         time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -1433,6 +1451,40 @@ mod test {
             .as_millis()
             .try_into()
             .expect("test timestamp must fit in u64")
+    }
+
+    struct RawRetryState(&'static [u8]);
+
+    impl Encode for RawRetryState {
+        fn write_to<W: Write>(&self, writer: &mut W) -> std::io::Result<usize> {
+            writer.write(self.0)
+        }
+    }
+
+    #[test]
+    fn retry_state_reconciliation_uses_authoritative_count() {
+        let message_id = H256::zero();
+        let stale_state = PendingMessageRetryState::new(
+            1,
+            Some(60_000),
+            Some(60_000),
+            Some(ReprepareReason::CouldNotFetchMetadata),
+        );
+        assert_eq!(
+            PendingMessage::reconcile_retry_state(Some(stale_state), 2, &message_id),
+            (2, None)
+        );
+
+        let ahead_state = PendingMessageRetryState::new(
+            3,
+            Some(60_000),
+            Some(60_000),
+            Some(ReprepareReason::ErrorSubmitting),
+        );
+        assert_eq!(
+            PendingMessage::reconcile_retry_state(Some(ahead_state.clone()), 2, &message_id),
+            (3, Some(ahead_state))
+        );
     }
 
     #[test]
@@ -1520,6 +1572,34 @@ mod test {
         );
         assert!(persisted.next_attempt_after().is_some());
 
+        // Simulate rollback to an old binary, which advances only the legacy count,
+        // followed by rolling forward to this version.
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &2)
+            .expect("advance legacy retry count");
+        base_db
+            .store_status_by_message_id(
+                &message.id(),
+                &PendingOperationStatus::Retry(ReprepareReason::ErrorSubmitting),
+            )
+            .expect("store legacy retry reason");
+        let rolled_forward = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore after rollback");
+        let remaining = rolled_forward
+            .next_attempt_after()
+            .expect("legacy schedule");
+        assert_eq!(rolled_forward.get_retries(), 2);
+        assert_eq!(
+            rolled_forward.status(),
+            PendingOperationStatus::Retry(ReprepareReason::ErrorSubmitting)
+        );
+        assert!(remaining.duration_since(Instant::now()) <= Duration::from_secs(10));
+
         let deadline = SystemTime::now() + Duration::from_secs(60);
         let state = PendingMessageRetryState::new(
             3,
@@ -1530,6 +1610,11 @@ mod test {
         base_db
             .store_pending_message_retry_state_by_message_id(&message.id(), &state)
             .expect("store retry state");
+        // Simulate the historical write-order fault where the combined state landed
+        // before its legacy mirror. The higher combined count must remain authoritative.
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &2)
+            .expect("store lagging legacy retry count");
 
         let restored = PendingMessage::maybe_from_persisted_retries(
             message.clone(),
@@ -1588,6 +1673,57 @@ mod test {
         .expect("fallback to legacy retry state");
         assert_eq!(fallback.get_retries(), 2);
         assert!(fallback.next_attempt_after().is_some());
+
+        let message = fallback.message.clone();
+        let ctx = fallback.ctx.clone();
+        base_db
+            .store_value_by_key(
+                "pending_message_retry_state_for_message_id_v1_",
+                &message.id(),
+                &RawRetryState(
+                    br#"{"version":2,"retry_count":9,"next_attempt_at_millis":null,"retry_delay_millis":null,"reason":null}"#,
+                ),
+            )
+            .expect("store unsupported retry state");
+        base_db
+            .store_pending_message_retry_count_by_message_id(&message.id(), &3)
+            .expect("store fallback retry count");
+        let mut unsupported = PendingMessage::maybe_from_persisted_retries(
+            message.clone(),
+            ctx.clone(),
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("fallback from unsupported retry state");
+        assert_eq!(unsupported.get_retries(), 3);
+        assert!(unsupported.next_attempt_after().is_some());
+
+        // An intentional lower/manual reset must replace both records; otherwise
+        // monotonic reconciliation would resurrect the older higher v1 count.
+        unsupported.set_retries(0);
+        assert_eq!(
+            base_db
+                .retrieve_pending_message_retry_count_by_message_id(&message.id())
+                .expect("read reset legacy count"),
+            Some(0)
+        );
+        assert_eq!(
+            base_db
+                .retrieve_pending_message_retry_state_by_message_id(&message.id())
+                .expect("read reset durable state")
+                .expect("reset durable state")
+                .retry_count,
+            0
+        );
+        let reset = PendingMessage::maybe_from_persisted_retries(
+            message,
+            ctx,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        )
+        .expect("restore manually reset state");
+        assert_eq!(reset.get_retries(), 0);
+        assert_eq!(reset.next_attempt_after(), None);
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -27,7 +27,9 @@ use hyperlane_core::{
 use hyperlane_operation_verifier::ApplicationOperationVerifier;
 
 use crate::{
-    metrics::message_submission::{MessageSubmissionMetrics, MetadataBuildMetric},
+    metrics::message_submission::{
+        MessageSubmissionMetrics, MetadataBuildMetric, MetadataWaitObservation,
+    },
     msg::metadata::{MessageMetadataBuildParams, MetadataBuildError},
 };
 
@@ -155,6 +157,16 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ica_reveal_attempts: u32,
+}
+
+impl Drop for PendingMessage {
+    fn drop(&mut self) {
+        self.ctx.metrics.finish_metadata_wait(
+            self.message.id(),
+            self.app_context.as_deref(),
+            false,
+        );
+    }
 }
 
 impl Debug for PendingMessage {
@@ -989,6 +1001,36 @@ impl PendingMessage {
         } else {
             warn!("Repreparing message: {}", reason.clone());
         }
+        self.reprepare_or_drop(reason)
+    }
+
+    fn on_metadata_wait(&mut self, observation: MetadataWaitObservation) -> PendingOperationResult {
+        let reason = ReprepareReason::AwaitingValidatorSignatures;
+        self.inc_attempts(Some(&reason));
+        self.submitted = false;
+        if observation.first_observation {
+            warn!(
+                wait_seconds = observation.elapsed.as_secs_f64(),
+                "Waiting for validator signatures"
+            );
+        } else {
+            debug!(
+                wait_seconds = observation.elapsed.as_secs_f64(),
+                "Still waiting for validator signatures"
+            );
+        }
+        let result = self.reprepare_or_drop(reason);
+        if matches!(result, PendingOperationResult::Drop) {
+            self.ctx.metrics.finish_metadata_wait(
+                self.message.id(),
+                self.app_context.as_deref(),
+                false,
+            );
+        }
+        result
+    }
+
+    fn reprepare_or_drop(&self, reason: ReprepareReason) -> PendingOperationResult {
         // For fail-fast messages (relay API), drop immediately once the retry budget is
         // exceeded. Without this check, a small max_retries value (e.g. 3) would still
         // hit the fixed early-backoff arms (1 => 5s, 2 => 10s, ...) rather than dropping.
@@ -1023,6 +1065,16 @@ impl PendingMessage {
     /// re-attempt processing for this message again, even after the relayer
     /// restarts.
     fn record_message_process_success(&mut self) -> Result<()> {
+        if let Some(wait_duration) = self.ctx.metrics.finish_metadata_wait(
+            self.message.id(),
+            self.app_context.as_deref(),
+            true,
+        ) {
+            info!(
+                wait_seconds = wait_duration.as_secs_f64(),
+                "Validator signature wait recovered after message delivery"
+            );
+        }
         self.ctx
             .origin_db
             .store_processed_by_nonce(&self.message.nonce, &true)?;
@@ -1183,50 +1235,79 @@ impl PendingMessage {
 
         tracing::debug!(?self.message, ?metadata_res, "Metadata build result");
 
-        let metadata_res = metadata_res.map_err(|err| match &err {
-            MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
+        let metadata_res = match metadata_res {
+            Ok(metadata) => {
+                if let Some(wait_duration) = self.ctx.metrics.finish_metadata_wait(
+                    self.message.id(),
+                    self.app_context.as_deref(),
+                    true,
+                ) {
+                    info!(
+                        wait_seconds = wait_duration.as_secs_f64(),
+                        "Validator signatures became available"
+                    );
+                }
+                Ok(metadata)
             }
-            MetadataBuildError::CouldNotFetch => {
-                self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata)
+            Err(err) => {
+                if !matches!(err, MetadataBuildError::AwaitingValidatorSignatures) {
+                    self.ctx.metrics.finish_metadata_wait(
+                        self.message.id(),
+                        self.app_context.as_deref(),
+                        false,
+                    );
+                }
+                let reprepare = match &err {
+                    MetadataBuildError::FailedToBuild(_) | MetadataBuildError::FastPathError(_) => {
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::CouldNotFetch => {
+                        self.on_reprepare::<String>(None, ReprepareReason::CouldNotFetchMetadata)
+                    }
+                    // If metadata building is refused, allow it to be retried later.
+                    MetadataBuildError::Refused(reason) => {
+                        warn!(?reason, "Metadata building refused");
+                        self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused)
+                    }
+                    // These errors cannot be recovered from, so we drop them.
+                    MetadataBuildError::UnsupportedModuleType(reason) => {
+                        warn!(?reason, "Unsupported module type");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MaxIsmDepthExceeded(depth) => {
+                        warn!(depth, "Max ISM depth reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MaxIsmCountReached(count) => {
+                        warn!(count, "Max ISM count reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::AggregationThresholdNotMet(threshold) => {
+                        warn!(threshold, "Aggregation threshold not met");
+                        self.on_reprepare(Some(&err), ReprepareReason::CouldNotFetchMetadata)
+                    }
+                    MetadataBuildError::MaxValidatorCountReached(count) => {
+                        warn!(count, "Max validator count reached");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::MerkleRootMismatch {
+                        root,
+                        canonical_root,
+                    } => {
+                        warn!(?root, ?canonical_root, "Merkle root mismatch");
+                        self.on_reprepare(Some(&err), ReprepareReason::ErrorBuildingMetadata)
+                    }
+                    MetadataBuildError::AwaitingValidatorSignatures => {
+                        let observation = self
+                            .ctx
+                            .metrics
+                            .record_metadata_wait(self.message.id(), self.app_context.as_deref());
+                        self.on_metadata_wait(observation)
+                    }
+                };
+                Err(reprepare)
             }
-            MetadataBuildError::AwaitingValidatorSignatures => {
-                self.on_reprepare::<String>(None, ReprepareReason::AwaitingValidatorSignatures)
-            }
-            // If the metadata building is refused, we still allow it to be retried later.
-            MetadataBuildError::Refused(reason) => {
-                warn!(?reason, "Metadata building refused");
-                self.on_reprepare::<String>(None, ReprepareReason::MessageMetadataRefused)
-            }
-            // These errors cannot be recovered from, so we drop them
-            MetadataBuildError::UnsupportedModuleType(reason) => {
-                warn!(?reason, "Unsupported module type");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MaxIsmDepthExceeded(depth) => {
-                warn!(depth, "Max ISM depth reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MaxIsmCountReached(count) => {
-                warn!(count, "Max ISM count reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::AggregationThresholdNotMet(threshold) => {
-                warn!(threshold, "Aggregation threshold not met");
-                self.on_reprepare(Some(err), ReprepareReason::CouldNotFetchMetadata)
-            }
-            MetadataBuildError::MaxValidatorCountReached(count) => {
-                warn!(count, "Max validator count reached");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-            MetadataBuildError::MerkleRootMismatch {
-                root,
-                canonical_root,
-            } => {
-                warn!(?root, ?canonical_root, "Merkle root mismatch");
-                self.on_reprepare(Some(err), ReprepareReason::ErrorBuildingMetadata)
-            }
-        });
+        };
         let build_metadata_end = Instant::now();
 
         let metrics_params = MetadataBuildMetric {

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -11,7 +11,7 @@ use hyperlane_core::{
 };
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::Sender;
@@ -804,8 +804,8 @@ async fn relay_work(
         nonce: u32,
     }
 
-    let mut batches: HashMap<u32, (Sender<QueueOperationBatch>, QueueOperationBatch)> =
-        HashMap::new();
+    let mut batches: BTreeMap<u32, (Sender<QueueOperationBatch>, QueueOperationBatch)> =
+        BTreeMap::new();
     let mut sent_messages = Vec::with_capacity(validated.len());
     for validated_message in validated {
         let ValidatedMessage {
@@ -833,23 +833,33 @@ async fn relay_work(
         });
     }
 
-    let mut reserved_batches = Vec::with_capacity(batches.len());
-    for (destination, (send_channel, batch)) in batches {
-        match send_channel.reserve_owned().await {
-            Ok(permit) => reserved_batches.push((permit, batch)),
-            Err(error) => {
-                error!(
-                    destination_domain = destination,
-                    %error,
-                    "Processor channel closed before transaction handoff"
-                );
-                state.record_failure("send_failed");
-                return Err(ServerError::InternalError(
-                    "Failed to reserve processor channel capacity".to_string(),
-                ));
+    const PROCESSOR_CAPACITY_TIMEOUT: Duration = Duration::from_millis(250);
+    let reserve_batches = async {
+        let mut reserved_batches = Vec::with_capacity(batches.len());
+        for (destination, (send_channel, batch)) in batches {
+            match send_channel.reserve_owned().await {
+                Ok(permit) => reserved_batches.push((permit, batch)),
+                Err(error) => {
+                    error!(
+                        destination_domain = destination,
+                        %error,
+                        "Processor channel closed before transaction handoff"
+                    );
+                    state.record_failure("send_failed");
+                    return Err(ServerError::InternalError(
+                        "Failed to reserve processor channel capacity".to_string(),
+                    ));
+                }
             }
         }
-    }
+        Ok(reserved_batches)
+    };
+    let reserved_batches = tokio::time::timeout(PROCESSOR_CAPACITY_TIMEOUT, reserve_batches)
+        .await
+        .map_err(|_| {
+            state.record_failure("processor_saturated");
+            ServerError::ServiceUnavailable("Processor capacity unavailable".to_string())
+        })??;
 
     if let Some(reservation) = maybe_reservation {
         reservation.commit();

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -834,6 +834,7 @@ async fn relay_work(
     }
 
     const PROCESSOR_CAPACITY_TIMEOUT: Duration = Duration::from_millis(250);
+    let admission_started = Instant::now();
     let reserve_batches = async {
         let mut reserved_batches = Vec::with_capacity(batches.len());
         for (destination, (send_channel, batch)) in batches {
@@ -854,12 +855,14 @@ async fn relay_work(
         }
         Ok(reserved_batches)
     };
-    let reserved_batches = tokio::time::timeout(PROCESSOR_CAPACITY_TIMEOUT, reserve_batches)
-        .await
-        .map_err(|_| {
-            state.record_failure("processor_saturated");
-            ServerError::ServiceUnavailable("Processor capacity unavailable".to_string())
-        })??;
+    let reservation = tokio::time::timeout(PROCESSOR_CAPACITY_TIMEOUT, reserve_batches).await;
+    state
+        .metrics
+        .observe_processor_admission(admission_started.elapsed());
+    let reserved_batches = reservation.map_err(|_| {
+        state.record_failure("processor_saturated");
+        ServerError::ServiceUnavailable("Processor capacity unavailable".to_string())
+    })??;
 
     if let Some(reservation) = maybe_reservation {
         reservation.commit();

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -24,6 +24,8 @@ use crate::msg::{
 };
 use crate::relay_api::metrics::RelayApiMetrics;
 
+pub(super) const PROCESSOR_CAPACITY_TIMEOUT: Duration = Duration::from_millis(250);
+
 /// Bounded cache for tracking recently submitted tx hashes to prevent replay attacks
 pub enum TxHashCacheError {
     Duplicate,
@@ -833,7 +835,6 @@ async fn relay_work(
         });
     }
 
-    const PROCESSOR_CAPACITY_TIMEOUT: Duration = Duration::from_millis(250);
     let admission_started = Instant::now();
     let reserve_batches = async {
         let mut reserved_batches = Vec::with_capacity(batches.len());

--- a/rust/main/agents/relayer/src/relay_api/metrics.rs
+++ b/rust/main/agents/relayer/src/relay_api/metrics.rs
@@ -1,9 +1,12 @@
-use prometheus::{IntCounterVec, Opts, Registry};
+use std::time::Duration;
+
+use prometheus::{Histogram, HistogramOpts, IntCounterVec, Opts, Registry};
 
 #[derive(Clone)]
 pub struct RelayApiMetrics {
     /// Total relay API requests received
     pub requests_total: IntCounterVec,
+    processor_admission_duration_seconds: Histogram,
 }
 
 impl RelayApiMetrics {
@@ -18,7 +21,19 @@ impl RelayApiMetrics {
 
         registry.register(Box::new(requests_total.clone()))?;
 
-        Ok(Self { requests_total })
+        let processor_admission_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "hyperlane_relay_api_processor_admission_duration_seconds",
+                "Time spent reserving bounded processor ingress for a relay API request",
+            )
+            .buckets(vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5]),
+        )?;
+        registry.register(Box::new(processor_admission_duration_seconds.clone()))?;
+
+        Ok(Self {
+            requests_total,
+            processor_admission_duration_seconds,
+        })
     }
 
     pub fn inc_success(&self) {
@@ -31,5 +46,10 @@ impl RelayApiMetrics {
         self.requests_total
             .with_label_values(&["failure", error_type])
             .inc();
+    }
+
+    pub fn observe_processor_admission(&self, duration: Duration) {
+        self.processor_admission_duration_seconds
+            .observe(duration.as_secs_f64());
     }
 }

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -378,6 +378,31 @@ async fn test_cancelled_capacity_wait_enqueues_nothing_and_allows_retry() {
 }
 
 #[tokio::test]
+async fn test_saturated_processor_returns_503_without_partial_enqueue() {
+    let indexer = Arc::new(MockIndexer::cctp(test_msg(ORIGIN_ID, DEST_ID, 1)));
+    let (TestHarness { state, mut rx, .. }, tx) =
+        make_state_multi_with_capacity(indexer, ORIGIN_ID, vec![DEST_ID], 1).await;
+    tx.send(Vec::new()).await.expect("prefill should succeed");
+
+    let cache = Arc::new(Mutex::new(TxHashCache::new(100)));
+    let router = state.with_tx_hash_cache(cache.clone()).router();
+    let started = std::time::Instant::now();
+    let status = send_relay(router.clone(), TX_HASH).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert_eq!(rx.len(), 1, "failed request must not enqueue a batch");
+    assert!(
+        !cache.lock().contains("ethereum", TX_HASH),
+        "failed admission must release the tx-hash reservation"
+    );
+
+    let placeholder = rx.recv().await.expect("prefilled batch should remain");
+    assert!(placeholder.is_empty());
+    assert_eq!(send_relay(router, TX_HASH).await, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_duplicate_within_ttl_rejected() {
     let msg = test_msg(ORIGIN_ID, DEST_ID, 1);
     let TestHarness {

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -25,7 +25,9 @@ use crate::msg::db_loader::tests::DummyApplicationOperationVerifier;
 use crate::msg::gas_payment::GasPaymentEnforcer;
 use crate::msg::pending_message::MessageContext;
 use crate::msg::QueueOperationBatch;
-use crate::relay_api::handlers::{RateLimiter, ServerState, TxHashCache};
+use crate::relay_api::handlers::{
+    RateLimiter, ServerState, TxHashCache, PROCESSOR_CAPACITY_TIMEOUT,
+};
 use crate::relay_api::metrics::RelayApiMetrics;
 use crate::settings::matching_list::MatchingList;
 use crate::test_utils::{
@@ -390,7 +392,7 @@ async fn test_saturated_processor_returns_503_without_partial_enqueue() {
     let status = send_relay(router.clone(), TX_HASH).await;
 
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(started.elapsed() < PROCESSOR_CAPACITY_TIMEOUT * 2);
     assert_eq!(rx.len(), 1, "failed request must not enqueue a batch");
     assert!(
         !cache.lock().contains("ethereum", TX_HASH),

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -33,8 +33,8 @@ use hyperlane_base::{
 };
 use hyperlane_core::{
     rpc_clients::call_and_retry_n_times, ChainCommunicationError, ChainResult, ContractSyncCursor,
-    HyperlaneDomain, HyperlaneMessage, Indexer, InterchainGasPayment, MerkleTreeInsertion,
-    PendingOperation, H512, U256,
+    HyperlaneDomain, HyperlaneMessage, Indexer, InterchainGasPayment, MerkleTreeInsertion, H512,
+    U256,
 };
 use lander::{CommandEntrypoint, DispatcherMetrics};
 
@@ -598,14 +598,7 @@ impl BaseAgent for Relayer {
     }
 }
 
-type PrepQueue = HashMap<
-    u32,
-    Arc<
-        tokio::sync::Mutex<
-            std::collections::BinaryHeap<std::cmp::Reverse<Box<dyn PendingOperation + 'static>>>,
-        >,
-    >,
->;
+type PrepQueue = HashMap<u32, OpQueue>;
 impl Relayer {
     async fn build_router(
         &self,

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -59,6 +59,7 @@ use crate::{
             BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
             IsmCachePolicyClassifier,
         },
+        op_queue::OpQueue,
         pending_message::MessageContext,
         QueueOperationBatch,
     },

--- a/rust/main/agents/relayer/src/server/mod.rs
+++ b/rust/main/agents/relayer/src/server/mod.rs
@@ -13,7 +13,7 @@ use lander::CommandEntrypoint;
 
 use crate::merkle_tree::builder::MerkleTreeBuilder;
 use crate::msg::gas_payment::GasPaymentEnforcer;
-use crate::msg::op_queue::OperationPriorityQueue;
+use crate::msg::op_queue::OpQueue;
 use crate::msg::pending_message::MessageContext;
 
 use crate::server::environment_variable::EnvironmentVariableApi;
@@ -34,7 +34,7 @@ pub struct Server {
     #[new(default)]
     retry_transmitter: Option<Sender<operations::message_retry::MessageRetryRequest>>,
     #[new(default)]
-    op_queues: Option<HashMap<u32, OperationPriorityQueue>>,
+    op_queues: Option<HashMap<u32, OpQueue>>,
     #[new(default)]
     dbs: Option<HashMap<u32, HyperlaneRocksDB>>,
     #[new(default)]
@@ -57,7 +57,7 @@ impl Server {
         self
     }
 
-    pub fn with_message_queue(mut self, op_queues: HashMap<u32, OperationPriorityQueue>) -> Self {
+    pub fn with_message_queue(mut self, op_queues: HashMap<u32, OpQueue>) -> Self {
         self.op_queues = Some(op_queues);
         self
     }
@@ -106,8 +106,12 @@ impl Server {
             )
         }
         if let Some(op_queues) = self.op_queues {
-            router = router
-                .merge(operations::list_messages::ServerState::new(op_queues.clone()).router());
+            let priority_queues = op_queues
+                .iter()
+                .map(|(domain, queue)| (*domain, queue.queue.clone()))
+                .collect();
+            router =
+                router.merge(operations::list_messages::ServerState::new(priority_queues).router());
             if let Some(dbs) = self.dbs.as_ref() {
                 router = router.merge(
                     operations::reprocess_message::ServerState::new(

--- a/rust/main/agents/relayer/src/server/operations/message_retry.rs
+++ b/rust/main/agents/relayer/src/server/operations/message_retry.rs
@@ -35,6 +35,8 @@ pub struct MessageRetryQueueResponse {
     pub evaluated: usize,
     /// how many of the pending operations matched the retry request pattern
     pub matched: u64,
+    /// how many matching operations could not persist their manual retry
+    pub failed: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -80,6 +82,7 @@ async fn handler(
         evaluated: 0,
         matched: 0,
     };
+    let mut failed = 0_u64;
 
     // Wait for responses from relayer
     tracing::debug!(uuid = resp.uuid, "Waiting for response from relayer");
@@ -91,6 +94,13 @@ async fn handler(
         );
         resp.evaluated = resp.evaluated.saturating_add(relayer_resp.evaluated);
         resp.matched = resp.matched.saturating_add(relayer_resp.matched);
+        failed = failed.saturating_add(relayer_resp.failed);
+    }
+
+    if failed > 0 {
+        return Err(format!(
+            "Failed to persist manual retry for {failed} matching operations"
+        ));
     }
 
     Ok(Json(resp))
@@ -142,7 +152,11 @@ mod tests {
             for (op, (evaluated, matched)) in pending_operations.iter().zip(metrics) {
                 // Check that the list received by the server matches the pending operation
                 assert!(req.pattern.op_matches(op));
-                let resp = MessageRetryQueueResponse { evaluated, matched };
+                let resp = MessageRetryQueueResponse {
+                    evaluated,
+                    matched,
+                    failed: 0,
+                };
                 req.transmitter.send(resp).await.unwrap();
             }
         }

--- a/rust/main/agents/relayer/src/server/operations/message_retry.rs
+++ b/rust/main/agents/relayer/src/server/operations/message_retry.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, routing, Json, Router};
+use axum::{extract::State, http::StatusCode, routing, Json, Router};
 use derive_new::new;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{broadcast::Sender, mpsc};
@@ -52,7 +52,7 @@ pub struct MessageRetryResponse {
 async fn handler(
     State(state): State<ServerState>,
     Json(payload): Json<MatchingList>,
-) -> Result<Json<MessageRetryResponse>, String> {
+) -> Result<Json<MessageRetryResponse>, (StatusCode, String)> {
     let uuid = uuid::Uuid::new_v4();
     let uuid_string = uuid.to_string();
 
@@ -74,7 +74,10 @@ async fn handler(
         .map_err(|err| {
             // Technically it's bad practice to print the error message to the user, but
             // this endpoint is for debugging purposes only.
-            format!("Failed to send retry request to the queue: {err}")
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to send retry request to the queue: {err}"),
+            )
         })?;
 
     let mut resp = MessageRetryResponse {
@@ -98,8 +101,9 @@ async fn handler(
     }
 
     if failed > 0 {
-        return Err(format!(
-            "Failed to persist manual retry for {failed} matching operations"
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to persist manual retry for {failed} matching operations"),
         ));
     }
 
@@ -206,6 +210,38 @@ mod tests {
         let resp_json: MessageRetryResponse = parse_body_to_json(response.into_body()).await;
         assert_eq!(resp_json.evaluated, 1);
         assert_eq!(resp_json.matched, 1);
+    }
+
+    #[tokio::test]
+    async fn test_persistence_failure_returns_internal_server_error() {
+        let TestServerSetup { app, retry_req_rx } = setup_test_server();
+        let mut retry_req_rx = retry_req_rx;
+
+        // spawn a task reporting that persisting the manual retry failed
+        tokio::task::spawn(async move {
+            if let Ok(req) = retry_req_rx.recv().await {
+                req.transmitter
+                    .send(MessageRetryQueueResponse {
+                        evaluated: 1,
+                        matched: 1,
+                        failed: 1,
+                    })
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let body = json!([
+            {
+                "messageid": HyperlaneMessage::default().id()
+            }
+        ]);
+
+        // Send a POST request to the server
+        let response = send_retry_request(app, &body).await;
+
+        // Persistence failures must not return a 2xx response
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[tokio::test]

--- a/rust/main/agents/relayer/src/server/operations/reprocess_message.rs
+++ b/rust/main/agents/relayer/src/server/operations/reprocess_message.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Reverse, collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use axum::{extract::State, http::StatusCode, routing, Json, Router};
 use derive_new::new;
@@ -10,14 +10,14 @@ use hyperlane_core::{PendingOperationStatus, ReprepareReason, H256};
 use serde::{Deserialize, Serialize};
 
 use crate::msg::{
-    op_queue::OperationPriorityQueue,
+    op_queue::OpQueue,
     pending_message::{MessageContext, PendingMessage, DEFAULT_MAX_MESSAGE_RETRIES},
 };
 
 #[derive(Clone, new)]
 pub struct ServerState {
     pub dbs: HashMap<u32, HyperlaneRocksDB>,
-    pub op_queues: HashMap<u32, OperationPriorityQueue>,
+    pub op_queues: HashMap<u32, OpQueue>,
     pub msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
 }
 
@@ -155,10 +155,7 @@ async fn handler(
     // just a debug to show what was inserted into the prepare queue
     let message_str = format!("{pending_message:?}");
 
-    prep_queue
-        .lock()
-        .await
-        .push(Reverse(Box::new(pending_message)));
+    prep_queue.push(Box::new(pending_message), None).await;
 
     let resp = ResponseBody {
         pending_message: message_str,
@@ -168,7 +165,7 @@ async fn handler(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use axum::{
         body::Body,
@@ -182,10 +179,13 @@ mod tests {
         db::{HyperlaneRocksDB, DB},
     };
     use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, KnownHyperlaneDomain};
+    use hyperlane_test::mocks::MockMailboxContract;
+    use tokio::sync::{broadcast, Mutex};
 
     use super::*;
     use crate::{
         msg::db_loader::tests::dummy_cache_metrics,
+        msg::op_queue::tests::dummy_metrics_and_label,
         test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder},
     };
 
@@ -193,7 +193,9 @@ mod tests {
     struct TestServerSetup {
         pub app: Router,
         pub dbs: HashMap<u32, HyperlaneRocksDB>,
-        pub op_queues: HashMap<u32, OperationPriorityQueue>,
+        pub op_queues: HashMap<u32, OpQueue>,
+        pub _retry_sender:
+            broadcast::Sender<crate::server::operations::message_retry::MessageRetryRequest>,
     }
 
     fn setup_test_server(domains: &[HyperlaneDomain]) -> TestServerSetup {
@@ -207,9 +209,20 @@ mod tests {
             })
             .collect();
 
-        let op_queues: HashMap<u32, OperationPriorityQueue> = domains
+        let retry_sender = broadcast::Sender::new(10);
+        let op_queues: HashMap<u32, OpQueue> = domains
             .iter()
-            .map(|domain| (domain.id(), OperationPriorityQueue::default()))
+            .map(|domain| {
+                let (metrics, label) = dummy_metrics_and_label();
+                (
+                    domain.id(),
+                    OpQueue::new(
+                        metrics,
+                        label,
+                        Arc::new(Mutex::new(retry_sender.subscribe())),
+                    ),
+                )
+            })
             .collect();
 
         let cache = OptionalCache::new(Some(MeteredCache::new(
@@ -227,8 +240,13 @@ mod tests {
             for destination_domain in domains.iter() {
                 let base_metadata_builder =
                     dummy_metadata_builder(origin_domain, destination_domain, db, cache.clone());
-                let msg_ctx =
+                let mut msg_ctx =
                     dummy_message_context(Arc::new(base_metadata_builder), db, cache.clone());
+                let mut mailbox = MockMailboxContract::new_with_default_ism(H256::zero());
+                mailbox
+                    .expect__domain()
+                    .return_const(destination_domain.clone());
+                msg_ctx.destination_mailbox = Arc::new(mailbox);
                 msg_ctxs.insert(
                     (origin_domain.id(), destination_domain.id()),
                     Arc::new(msg_ctx),
@@ -243,6 +261,7 @@ mod tests {
             app,
             dbs,
             op_queues,
+            _retry_sender: retry_sender,
         }
     }
 
@@ -286,6 +305,7 @@ mod tests {
             app,
             dbs,
             op_queues,
+            _retry_sender,
         } = setup_test_server(domains);
 
         let message = HyperlaneMessage {
@@ -308,10 +328,62 @@ mod tests {
         let op_queue_len = op_queues
             .get(&(KnownHyperlaneDomain::Ethereum as u32))
             .expect("Queue not found")
-            .lock()
-            .await
-            .len();
+            .len()
+            .await;
         assert_eq!(op_queue_len, 1);
+    }
+
+    #[tokio::test]
+    async fn test_reprocess_message_wakes_empty_prepare_queue() {
+        let domains = &[
+            HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+            HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+        ];
+        let TestServerSetup {
+            app,
+            dbs,
+            op_queues,
+            _retry_sender,
+        } = setup_test_server(domains);
+        let message = HyperlaneMessage {
+            version: 0,
+            nonce: 100,
+            origin: KnownHyperlaneDomain::Arbitrum as u32,
+            sender: H256::from_low_u64_be(100),
+            destination: KnownHyperlaneDomain::Ethereum as u32,
+            recipient: H256::from_low_u64_be(200),
+            body: Vec::new(),
+        };
+        let expected_id = message.id();
+        insert_message(&dbs, &domains[0], &message, 1000);
+
+        let mut queue = op_queues
+            .get(&(KnownHyperlaneDomain::Ethereum as u32))
+            .expect("Queue not found")
+            .clone();
+        let waiter = tokio::spawn(async move {
+            loop {
+                let (batch, deadline) = queue.pop_many_ready(1).await;
+                if let Some(operation) = batch.into_iter().next() {
+                    break operation;
+                }
+                queue.wait_for_ready(deadline).await;
+            }
+        });
+        tokio::task::yield_now().await;
+
+        let response = send_request(
+            app,
+            KnownHyperlaneDomain::Arbitrum as u32,
+            format!("0x{expected_id:x}"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let operation = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("reprocessed message should wake prepare queue")
+            .expect("waiter should not panic");
+        assert_eq!(operation.id(), expected_id);
     }
 
     #[tracing_test::traced_test]
@@ -342,9 +414,8 @@ mod tests {
         let op_queue_len = op_queues
             .get(&(KnownHyperlaneDomain::Arbitrum as u32))
             .expect("Queue not found")
-            .lock()
-            .await
-            .len();
+            .len()
+            .await;
         assert_eq!(op_queue_len, 0);
     }
 }

--- a/rust/main/agents/relayer/src/test_utils/dummy_data.rs
+++ b/rust/main/agents/relayer/src/test_utils/dummy_data.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 
-use prometheus::{CounterVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry};
+use prometheus::Registry;
 use tokio::sync::RwLock;
 
 use hyperlane_base::{
@@ -10,7 +10,7 @@ use hyperlane_base::{
     settings::{ChainConf, ChainConnectionConf, Settings},
     CoreMetrics,
 };
-use hyperlane_core::{HyperlaneDomain, H256};
+use hyperlane_core::{HyperlaneDomain, KnownHyperlaneDomain, H256};
 use hyperlane_test::mocks::{MockMailboxContract, MockValidatorAnnounceContract};
 
 use crate::{
@@ -98,22 +98,12 @@ pub fn dummy_metadata_builder(
 }
 
 pub fn dummy_submission_metrics() -> MessageSubmissionMetrics {
-    MessageSubmissionMetrics {
-        origin: "".to_string(),
-        destination: "".to_string(),
-        last_known_nonce: IntGauge::new("last_known_nonce_gauge", "help string").unwrap(),
-        messages_processed: IntCounter::new("message_processed_gauge", "help string").unwrap(),
-        metadata_build_count: IntCounterVec::new(
-            Opts::new("metadata_build_count", "help string"),
-            &["app_context", "origin", "remote", "status"],
-        )
-        .unwrap(),
-        metadata_build_duration: CounterVec::new(
-            Opts::new("metadata_build_duration", "help string"),
-            &["app_context", "origin", "remote", "status"],
-        )
-        .unwrap(),
-    }
+    let core_metrics = CoreMetrics::new("dummy_relayer", 37582, Registry::new()).unwrap();
+    MessageSubmissionMetrics::new(
+        &core_metrics,
+        &HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum),
+        &HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum),
+    )
 }
 
 pub fn dummy_message_context(

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/fallback.rs
@@ -597,7 +597,7 @@ where
                 if resp.is_err() {
                     self.handle_failed_provider(priority).await;
                 }
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     provider_host = provider_host.as_str(),

--- a/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/fallback.rs
@@ -100,7 +100,7 @@ impl JsonRpcTransport for FallbackHttpTransport {
                 // Create log span
                 let provider = &self.inner.providers[priority.index];
 
-                tracing::debug!(
+                tracing::trace!(
                     fallback_count = idx,
                     provider_index = priority.index,
                     "fallback_request"

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -1,4 +1,6 @@
-pub use self::storage_types::{InterchainGasExpenditureData, InterchainGasPaymentData};
+pub use self::storage_types::{
+    InterchainGasExpenditureData, InterchainGasPaymentData, PendingMessageRetryState,
+};
 pub use error::*;
 pub use rocks::*;
 
@@ -123,6 +125,19 @@ pub trait HyperlaneDb: Send + Sync {
         &self,
         message_id: &H256,
     ) -> DbResult<Option<u32>>;
+
+    /// Store retry count, deadline, and reason atomically for a pending message.
+    fn store_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+    ) -> DbResult<()>;
+
+    /// Retrieve durable retry state for a pending message.
+    fn retrieve_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+    ) -> DbResult<Option<PendingMessageRetryState>>;
 
     fn store_merkle_tree_insertion_by_leaf_index(
         &self,

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -128,12 +128,20 @@ pub trait HyperlaneDb: Send + Sync {
 
     /// Atomically store retry state and its legacy retry-count mirror.
     ///
-    /// Status is persisted separately by the operation queue. The retry state carries
-    /// its reason to close that write boundary while its deadline is active.
+    /// Status is normally persisted separately by the operation queue. The retry state
+    /// carries its reason to close that write boundary while its deadline is active.
     fn store_pending_message_retry_state_by_message_id(
         &self,
         message_id: &H256,
         state: &PendingMessageRetryState,
+    ) -> DbResult<()>;
+
+    /// Atomically store retry state, its legacy count mirror, and message status.
+    fn store_pending_message_retry_state_and_status_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+        status: &PendingOperationStatus,
     ) -> DbResult<()>;
 
     /// Retrieve durable retry state for a pending message.

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -126,7 +126,10 @@ pub trait HyperlaneDb: Send + Sync {
         message_id: &H256,
     ) -> DbResult<Option<u32>>;
 
-    /// Store retry count, deadline, and reason atomically for a pending message.
+    /// Atomically store retry state and its legacy retry-count mirror.
+    ///
+    /// Status is persisted separately by the operation queue. The retry state carries
+    /// its reason to close that write boundary while its deadline is active.
     fn store_pending_message_retry_state_by_message_id(
         &self,
         message_id: &H256,

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -640,11 +640,22 @@ impl HyperlaneDb for HyperlaneRocksDB {
         message_id: &H256,
         state: &PendingMessageRetryState,
     ) -> DbResult<()> {
-        self.store_value_by_key(
-            PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID,
-            message_id,
-            state,
-        )
+        self.store_batch([
+            (
+                PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.to_vec(),
+            ),
+            (
+                PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.retry_count.to_vec(),
+            ),
+        ])
     }
 
     fn retrieve_pending_message_retry_state_by_message_id(

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -658,6 +658,35 @@ impl HyperlaneDb for HyperlaneRocksDB {
         ])
     }
 
+    fn store_pending_message_retry_state_and_status_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+        status: &PendingOperationStatus,
+    ) -> DbResult<()> {
+        self.store_batch([
+            (
+                PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.to_vec(),
+            ),
+            (
+                PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID
+                    .as_bytes()
+                    .to_vec(),
+                message_id.to_vec(),
+                state.retry_count.to_vec(),
+            ),
+            (
+                STATUS_BY_MESSAGE_ID.as_bytes().to_vec(),
+                message_id.to_vec(),
+                status.to_vec(),
+            ),
+        ])
+    }
+
     fn retrieve_pending_message_retry_state_by_message_id(
         &self,
         message_id: &H256,

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -12,7 +12,9 @@ use hyperlane_core::{
 };
 
 use crate::db::{
-    storage_types::{InterchainGasExpenditureData, InterchainGasPaymentData},
+    storage_types::{
+        InterchainGasExpenditureData, InterchainGasPaymentData, PendingMessageRetryState,
+    },
     HyperlaneDb,
 };
 
@@ -34,6 +36,8 @@ const GAS_EXPENDITURE_FOR_MESSAGE_ID: &str = "gas_expenditure_for_message_id_v2_
 const STATUS_BY_MESSAGE_ID: &str = "status_by_message_id_";
 const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
     "pending_message_retry_count_for_message_id_";
+const PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID: &str =
+    "pending_message_retry_state_for_message_id_v1_";
 const MERKLE_TREE_INSERTION: &str = "merkle_tree_insertion_";
 const MERKLE_LEAF_INDEX_BY_MESSAGE_ID: &str = "merkle_leaf_index_by_message_id_";
 const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
@@ -629,6 +633,25 @@ impl HyperlaneDb for HyperlaneRocksDB {
         message_id: &H256,
     ) -> DbResult<Option<u32>> {
         self.retrieve_value_by_key(PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID, message_id)
+    }
+
+    fn store_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+        state: &PendingMessageRetryState,
+    ) -> DbResult<()> {
+        self.store_value_by_key(
+            PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID,
+            message_id,
+            state,
+        )
+    }
+
+    fn retrieve_pending_message_retry_state_by_message_id(
+        &self,
+        message_id: &H256,
+    ) -> DbResult<Option<PendingMessageRetryState>> {
+        self.retrieve_value_by_key(PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID, message_id)
     }
 
     fn store_merkle_tree_insertion_by_leaf_index(

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -109,6 +109,15 @@ impl DB {
         Ok(self.0.put(key, value)?)
     }
 
+    /// Atomically store multiple key-value pairs in the DB.
+    pub fn store_batch(&self, entries: impl IntoIterator<Item = (Vec<u8>, Vec<u8>)>) -> Result<()> {
+        let mut batch = WriteBatch::default();
+        for (key, value) in entries {
+            batch.put(key, value);
+        }
+        Ok(self.0.write(batch)?)
+    }
+
     /// Retrieve a value from the DB
     pub fn retrieve(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
@@ -265,5 +274,25 @@ mod tests {
         assert!(!db
             .has_unmarked_writes_since(checkpoint, b"source_", b"marker")
             .unwrap());
+    }
+
+    #[test]
+    fn failed_batch_writes_no_keys() {
+        let temp_dir = tempfile::tempdir().expect("temp db directory");
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        drop(Rocks::open(&options, temp_dir.path()).expect("initialize db"));
+
+        let rocks =
+            Rocks::open_for_read_only(&options, temp_dir.path(), false).expect("open read-only db");
+        let db = DB::from(rocks);
+        assert!(db
+            .store_batch([
+                (b"retry-state".to_vec(), b"state".to_vec()),
+                (b"retry-count".to_vec(), b"count".to_vec()),
+            ])
+            .is_err());
+        assert_eq!(db.retrieve(b"retry-state").expect("read state"), None);
+        assert_eq!(db.retrieve(b"retry-count").expect("read count"), None);
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -277,22 +277,37 @@ mod tests {
     }
 
     #[test]
-    fn failed_batch_writes_no_keys() {
+    fn failed_batch_preserves_all_old_values() {
         let temp_dir = tempfile::tempdir().expect("temp db directory");
         let mut options = Options::default();
         options.create_if_missing(true);
-        drop(Rocks::open(&options, temp_dir.path()).expect("initialize db"));
+        let writable = Rocks::open(&options, temp_dir.path()).expect("initialize db");
+        writable
+            .put(b"retry-state", b"old-state")
+            .expect("store old state");
+        writable
+            .put(b"retry-count", b"old-count")
+            .expect("store old count");
+        drop(writable);
 
         let rocks =
             Rocks::open_for_read_only(&options, temp_dir.path(), false).expect("open read-only db");
         let db = DB::from(rocks);
         assert!(db
             .store_batch([
-                (b"retry-state".to_vec(), b"state".to_vec()),
-                (b"retry-count".to_vec(), b"count".to_vec()),
+                (b"retry-state".to_vec(), b"new-state".to_vec()),
+                (b"retry-count".to_vec(), b"new-count".to_vec()),
+                (b"status".to_vec(), b"manual".to_vec()),
             ])
             .is_err());
-        assert_eq!(db.retrieve(b"retry-state").expect("read state"), None);
-        assert_eq!(db.retrieve(b"retry-count").expect("read count"), None);
+        assert_eq!(
+            db.retrieve(b"retry-state").expect("read state"),
+            Some(b"old-state".to_vec())
+        );
+        assert_eq!(
+            db.retrieve(b"retry-count").expect("read count"),
+            Some(b"old-count".to_vec())
+        );
+        assert_eq!(db.retrieve(b"status").expect("read status"), None);
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -47,6 +47,18 @@ impl TypedDB {
             .collect()
     }
 
+    /// Atomically store encoded values under domain-prefixed keys.
+    pub(crate) fn store_batch(
+        &self,
+        entries: impl IntoIterator<Item = (Vec<u8>, Vec<u8>, Vec<u8>)>,
+    ) -> Result<()> {
+        self.db.store_batch(
+            entries
+                .into_iter()
+                .map(|(prefix, key, value)| (self.prefixed_key(&prefix, &key), value)),
+        )
+    }
+
     /// Store encodable value
     pub fn store_encodable<V: Encode>(
         &self,

--- a/rust/main/hyperlane-base/src/db/storage_types.rs
+++ b/rust/main/hyperlane-base/src/db/storage_types.rs
@@ -1,9 +1,81 @@
 use std::io::{Read, Write};
 
 use hyperlane_core::{
-    Decode, Encode, HyperlaneProtocolError, InterchainGasExpenditure, InterchainGasPayment, H256,
-    U256,
+    Decode, Encode, HyperlaneProtocolError, InterchainGasExpenditure, InterchainGasPayment,
+    ReprepareReason, H256, U256,
 };
+use serde::{Deserialize, Serialize};
+
+const PENDING_MESSAGE_RETRY_STATE_VERSION: u8 = 1;
+
+/// Durable retry state for a pending message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PendingMessageRetryState {
+    version: u8,
+    /// Number of delivery attempts made.
+    pub retry_count: u32,
+    /// Absolute Unix timestamp for the next attempt.
+    pub next_attempt_at_millis: Option<u64>,
+    /// Original delay, used to bound backwards wall-clock skew.
+    pub retry_delay_millis: Option<u64>,
+    /// Retry reason used when the deadline was calculated.
+    pub reason: Option<ReprepareReason>,
+}
+
+impl PendingMessageRetryState {
+    /// Creates a versioned retry-state record.
+    pub fn new(
+        retry_count: u32,
+        next_attempt_at_millis: Option<u64>,
+        retry_delay_millis: Option<u64>,
+        reason: Option<ReprepareReason>,
+    ) -> Self {
+        Self {
+            version: PENDING_MESSAGE_RETRY_STATE_VERSION,
+            retry_count,
+            next_attempt_at_millis,
+            retry_delay_millis,
+            reason,
+        }
+    }
+}
+
+impl Encode for PendingMessageRetryState {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: Write,
+    {
+        #[allow(clippy::io_other_error)]
+        let serialized = serde_json::to_vec(self)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Failed to serialize"))?;
+        writer.write(&serialized)
+    }
+}
+
+impl Decode for PendingMessageRetryState {
+    fn read_from<R>(reader: &mut R) -> Result<Self, HyperlaneProtocolError>
+    where
+        R: Read,
+        Self: Sized,
+    {
+        let state: Self = serde_json::from_reader(reader).map_err(|err| {
+            #[allow(clippy::io_other_error)]
+            HyperlaneProtocolError::IoError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to deserialize retry state: {err}"),
+            ))
+        })?;
+        if state.version != PENDING_MESSAGE_RETRY_STATE_VERSION
+            || state.next_attempt_at_millis.is_some() != state.retry_delay_millis.is_some()
+        {
+            return Err(HyperlaneProtocolError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Unsupported or inconsistent pending-message retry state",
+            )));
+        }
+        Ok(state)
+    }
+}
 
 /// Subset of `InterchainGasPayment` excluding the message id which is stored in
 /// the key.

--- a/rust/main/hyperlane-base/src/metrics/core.rs
+++ b/rust/main/hyperlane-base/src/metrics/core.rs
@@ -64,6 +64,9 @@ pub struct CoreMetrics {
     // metadata building metrics
     metadata_build_count: IntCounterVec,
     metadata_build_duration: CounterVec,
+    metadata_wait_event_count: IntCounterVec,
+    metadata_wait_active: IntGaugeVec,
+    metadata_wait_oldest_timestamp_seconds: IntGaugeVec,
 
     // ism building metrics
     ism_build_count: IntCounterVec,
@@ -304,6 +307,36 @@ impl CoreMetrics {
             registry
         )?;
 
+        let metadata_wait_event_count = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_event_count"),
+                "Metadata validator-signature wait attempts and lifecycle transitions; event=wait counts attempts",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote", "event"],
+            registry
+        )?;
+
+        let metadata_wait_active = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_active"),
+                "Messages currently waiting for validator signatures",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote"],
+            registry
+        )?;
+
+        let metadata_wait_oldest_timestamp_seconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced!("metadata_wait_oldest_timestamp_seconds"),
+                "Unix timestamp when the oldest active validator-signature wait began; zero when none are active",
+                const_labels_ref
+            ),
+            &["app_context", "origin", "remote"],
+            registry
+        )?;
+
         let ism_build_count = register_int_counter_vec_with_registry!(
             opts!(
                 namespaced!("ism_build_count"),
@@ -355,6 +388,9 @@ impl CoreMetrics {
 
             metadata_build_count,
             metadata_build_duration,
+            metadata_wait_event_count,
+            metadata_wait_active,
+            metadata_wait_oldest_timestamp_seconds,
 
             ism_build_count,
 
@@ -692,6 +728,21 @@ impl CoreMetrics {
     /// - `status`: success or failure
     pub fn metadata_build_duration(&self) -> CounterVec {
         self.metadata_build_duration.clone()
+    }
+
+    /// Bounded wait-attempt and lifecycle events for validator-signature waits.
+    pub fn metadata_wait_event_count(&self) -> IntCounterVec {
+        self.metadata_wait_event_count.clone()
+    }
+
+    /// Number of messages currently waiting for validator signatures.
+    pub fn metadata_wait_active(&self) -> IntGaugeVec {
+        self.metadata_wait_active.clone()
+    }
+
+    /// Unix timestamp when the oldest active validator-signature wait began.
+    pub fn metadata_wait_oldest_timestamp_seconds(&self) -> IntGaugeVec {
+        self.metadata_wait_oldest_timestamp_seconds.clone()
     }
 
     /// The number of ism built by this process during its

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -292,6 +292,12 @@ fn parse_chain(
         .get_opt_key("maxBatchSize")
         .parse_u32()
         .unwrap_or(1);
+    if max_batch_size == 0 {
+        err.push(
+            chain.cwp.clone(),
+            eyre!("`maxBatchSize` must be greater than zero"),
+        );
+    }
 
     let bypass_batch_simulation = chain
         .chain(&mut err)
@@ -779,5 +785,30 @@ mod test {
         let val: serde_json::Value = serde_json::from_str(json_str).unwrap();
         let value_parser = ValueParser::new(Default::default(), &val);
         parse_matching_list(value_parser).unwrap();
+    }
+
+    #[test]
+    fn rejects_zero_max_batch_size() {
+        let value = serde_json::json!({
+            "domainid": 1,
+            "name": "test",
+            "protocol": "ethereum",
+            "rpcurls": [{ "http": "http://localhost:8545" }],
+            "mailbox": "0x0000000000000000000000000000000000000001",
+            "interchaingaspaymaster": "0x0000000000000000000000000000000000000002",
+            "validatorannounce": "0x0000000000000000000000000000000000000003",
+            "merkletreehook": "0x0000000000000000000000000000000000000004",
+            "maxbatchsize": 0
+        });
+        let parser = ValueParser::new(Default::default(), &value);
+
+        let error = parse_chain(parser, "test", "fallback")
+            .expect_err("zero maxBatchSize must be rejected")
+            .to_string();
+
+        assert!(
+            error.contains("`maxBatchSize` must be greater than zero"),
+            "unexpected parser error: {error}"
+        );
     }
 }

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
-use crate::db::{DbResult, HyperlaneDb, InterchainGasExpenditureData, InterchainGasPaymentData};
+use crate::db::{
+    DbResult, HyperlaneDb, InterchainGasExpenditureData, InterchainGasPaymentData,
+    PendingMessageRetryState,
+};
 use hyperlane_core::{
     identifiers::UniqueIdentifier, GasPaymentKey, HyperlaneDomain, HyperlaneMessage,
     HyperlaneProvider, InterchainGasPayment, InterchainGasPaymentMeta, MerkleTreeInsertion,
@@ -95,6 +98,15 @@ mockall::mock! {
             &self,
             message_id: &H256,
         ) -> DbResult<Option<u32>>;
+        fn store_pending_message_retry_state_by_message_id(
+            &self,
+            message_id: &H256,
+            state: &PendingMessageRetryState,
+        ) -> DbResult<()>;
+        fn retrieve_pending_message_retry_state_by_message_id(
+            &self,
+            message_id: &H256,
+        ) -> DbResult<Option<PendingMessageRetryState>>;
         fn store_merkle_tree_insertion_by_leaf_index(
             &self,
             leaf_index: &u32,

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -103,6 +103,12 @@ mockall::mock! {
             message_id: &H256,
             state: &PendingMessageRetryState,
         ) -> DbResult<()>;
+        fn store_pending_message_retry_state_and_status_by_message_id(
+            &self,
+            message_id: &H256,
+            state: &PendingMessageRetryState,
+            status: &PendingOperationStatus,
+        ) -> DbResult<()>;
         fn retrieve_pending_message_retry_state_by_message_id(
             &self,
             message_id: &H256,

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -164,7 +164,8 @@ pub trait PendingOperation: Send + Sync + Debug + TryBatchAs<HyperlaneMessage> {
 
     /// Reset the number of attempts this operation has made, causing it to be
     /// retried immediately.
-    fn reset_attempts(&mut self);
+    /// Reset attempts durably. Returns false when the reset could not be persisted.
+    fn reset_attempts(&mut self) -> bool;
 
     /// Set the number of times this operation has been retried.
     fn set_retries(&mut self, retries: u32);

--- a/rust/main/hyperlane-core/src/traits/pending_operation/tests.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation/tests.rs
@@ -71,7 +71,9 @@ impl PendingOperation for MockQueueOperation {
     ) {
     }
     fn set_next_attempt_after(&mut self, _delay: Duration) {}
-    fn reset_attempts(&mut self) {}
+    fn reset_attempts(&mut self) -> bool {
+        true
+    }
     #[cfg(any(test, feature = "test-utils"))]
     fn set_retries(&mut self, _retries: u32) {}
     fn get_retries(&self) -> u32 {


### PR DESCRIPTION
## Summary

- dequeue prepare work only when its retry deadline is eligible
- wake prepare consumers on an earlier insertion, manual retry, or the exact next deadline
- remove the 100ms empty-queue poll and 500ms all-not-ready delay
- bound whole-request relay-API admission at 250ms
- reserve one batch slot per destination in canonical order and expose admission latency
- reject `maxBatchSize=0` instead of permanently parking ready work

Stacked on #9396 (`41584452e7`) so restored durable retry deadlines drive the exact wait. Exact head: `d505c70720`.

## Correctness

- preserves #9426's one-slot `QueueOperationBatch` handoff and recovery gate; a multi-message transaction consumes one slot per destination, not one slot per message
- timeout or channel closure drops every partial permit and releases the tx-hash reservation, so nothing is partially enqueued
- destination batches are reserved in ascending domain order, removing crossed-request AB/BA deadlock
- the tx-hash reservation commits only after all capacity is held; sends are synchronous after that boundary
- DB-loader and relay-API work continue to share the bounded destination channel, so recovery backpressure cannot grow an unbounded side queue
- earlier inserts and manual retries wake the prepare consumer; submit and confirm scheduling are unchanged

The five former admission-lock follow-up commits were dropped during the #9426 rebase. Batch-level atomic handoff plus canonical reservation order made those locks redundant. #9451 now stacks above #9388 and extends the ordering work with generation-matched reservations and scoped archived-WAL retention.

## Expected impact

Modeled, not observed:

- empty prepare arrivals: 0–100ms legacy poll delay (50ms mean) to a <=10ms wake target, about 5x / 80% lower mean timer component
- all-not-ready retry batches: 0–500ms legacy extra delay (250ms mean) to a <=10ms wake target, about 25x / 96% lower mean timer component
- relay API: at most 250ms waiting for whole-request destination capacity before 503

These figures exclude RPC, preparation, signing, storage, runtime contention, and downstream submission. No independent RPC or throughput reduction is claimed.

## Verification

- `cargo fmt --package relayer -- --check`
- exact stack range-diff and `git diff --check`
- focused wake, retry, reprocess, saturation, cancellation, one-batch, closed-destination, and closed-retry-channel regressions retained
- current-head compilation and tests delegated to CI after the restack

## Canary

- compare ready-to-prepare latency before/after; keep 5x/25x figures modeled until observed
- alert on relay-API 503 rate and `hyperlane_relay_api_processor_admission_duration_seconds` p50/p95/p99
- track destination queue length, duplicate/restart-delayed messages, and recovery readiness

Part of #9384 and #9386. Destination-indexed pending loading continues in #9403.

