### PR TITLE
fix(validator): gate websocket cutover on canonical freshness

### DIFF
--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -57,6 +57,39 @@ struct StreamTimeouts {
     progress_grace: Duration,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SubscriptionState {
+    AwaitingReady,
+    AwaitingSubscribed,
+    Subscribed,
+}
+
+impl SubscriptionState {
+    fn receive_ready(self) -> Result<Self> {
+        match self {
+            Self::AwaitingReady => Ok(Self::AwaitingSubscribed),
+            Self::AwaitingSubscribed | Self::Subscribed => {
+                bail!("Received duplicate WebSocket ready message")
+            }
+        }
+    }
+
+    fn receive_subscribed(self) -> Result<Self> {
+        match self {
+            Self::AwaitingSubscribed => Ok(Self::Subscribed),
+            Self::AwaitingReady => bail!("Received WebSocket subscribed message before ready"),
+            Self::Subscribed => bail!("Received duplicate WebSocket subscribed message"),
+        }
+    }
+
+    fn require_subscribed(self, message_type: &str) -> Result<()> {
+        if self != Self::Subscribed {
+            bail!("Received WebSocket {message_type} before subscription acknowledgement");
+        }
+        Ok(())
+    }
+}
+
 impl RpcFallback {
     fn start(
         sync: Arc<SequencedDataContractSync<MerkleTreeInsertion>>,
@@ -280,7 +313,7 @@ impl MerkleTreeHookWebSocketSync {
             .await
             .context("Connecting to Merkle tree hook WebSocket timed out")?
             .context("Connecting to Merkle tree hook WebSocket")?;
-        let mut subscribed = false;
+        let mut subscription_state = SubscriptionState::AwaitingReady;
         let mut caught_up = false;
         let mut lag_started_at = None;
         let mut progress_checks = interval(timeouts.progress_check);
@@ -337,16 +370,15 @@ impl MerkleTreeHookWebSocketSync {
                     .context("Parsing Merkle tree hook WebSocket message")?
                 {
                     ServerMessage::Ready => {
-                        if subscribed {
-                            bail!("Received duplicate WebSocket ready message");
-                        }
+                        let next_state = subscription_state.receive_ready()?;
                         socket
                             .send(Message::Text(self.subscription(*next_sequence)?))
                             .await
                             .context("Subscribing to Merkle tree hook insertions")?;
-                        subscribed = true;
+                        subscription_state = next_state;
                     }
                     ServerMessage::Subscribed => {
+                        subscription_state = subscription_state.receive_subscribed()?;
                         if *next_sequence < backfill_target {
                             info!(
                                 domain = self.domain,
@@ -368,6 +400,7 @@ impl MerkleTreeHookWebSocketSync {
                         event_type,
                         sequence,
                     } => {
+                        subscription_state.require_subscribed("caught-up marker")?;
                         let reached_cursor = self.validate_caught_up(
                             &address,
                             domain,
@@ -382,12 +415,21 @@ impl MerkleTreeHookWebSocketSync {
                             self.persist_next_sequence(*next_sequence)?;
                             lag_started_at = None;
                             if *next_sequence >= backfill_target {
-                                self.activate_websocket(fallback).await;
-                                info!(
-                                    domain = self.domain,
-                                    next_sequence = *next_sequence,
-                                    "Caught up Merkle tree hook WebSocket"
-                                );
+                                if self
+                                    .try_activate_websocket(
+                                        *next_sequence,
+                                        fallback,
+                                        RPC_PROBE_TIMEOUT,
+                                        dependencies,
+                                    )
+                                    .await?
+                                {
+                                    info!(
+                                        domain = self.domain,
+                                        next_sequence = *next_sequence,
+                                        "Caught up Merkle tree hook WebSocket"
+                                    );
+                                }
                             } else {
                                 warn!(
                                     domain = self.domain,
@@ -406,6 +448,7 @@ impl MerkleTreeHookWebSocketSync {
                         }
                     }
                     ServerMessage::Event(event) => {
+                        subscription_state.require_subscribed("event")?;
                         if self
                             .process_event(event, next_sequence, dependencies, &mut canonical_cache)
                             .await?
@@ -415,7 +458,13 @@ impl MerkleTreeHookWebSocketSync {
                             // fallback; live-stream lag is checked after `caught_up`.
                             record_stream_progress(&mut lag_started_at, caught_up);
                             if caught_up && *next_sequence >= backfill_target {
-                                self.activate_websocket(fallback).await;
+                                self.try_activate_websocket(
+                                    *next_sequence,
+                                    fallback,
+                                    RPC_PROBE_TIMEOUT,
+                                    dependencies,
+                                )
+                                .await?;
                             }
                         }
                     }
@@ -447,9 +496,36 @@ impl MerkleTreeHookWebSocketSync {
         }
     }
 
-    async fn activate_websocket(&self, fallback: &mut Option<RpcFallback>) {
+    async fn try_activate_websocket(
+        &self,
+        next_sequence: u32,
+        fallback: &mut Option<RpcFallback>,
+        rpc_probe_timeout: Duration,
+        dependencies: &StreamDependencies,
+    ) -> Result<bool> {
+        if fallback.is_none() {
+            return Ok(true);
+        }
+        let hook = dependencies
+            .merkle_tree_hook
+            .as_ref()
+            .ok_or_else(|| eyre!("WebSocket cutover requires a Merkle tree hook"))?;
+        let onchain_count = timeout(rpc_probe_timeout, hook.count(&dependencies.reorg_period))
+            .await
+            .context("On-chain Merkle tree count cutover probe timed out")?
+            .context("Reading on-chain Merkle tree count for WebSocket cutover")?;
+        if !validate_cutover_freshness(onchain_count, next_sequence)? {
+            warn!(
+                domain = self.domain,
+                next_sequence,
+                onchain_count,
+                "WebSocket is behind canonical Merkle tree count; keeping RPC fallback active"
+            );
+            return Ok(false);
+        }
         self.stop_fallback(fallback).await;
         self.websocket_active.set(1);
+        Ok(true)
     }
 
     fn subscription(&self, next_sequence: u32) -> Result<String> {
@@ -688,6 +764,15 @@ fn check_stream_lag(
     Ok(())
 }
 
+fn validate_cutover_freshness(onchain_count: u32, next_sequence: u32) -> Result<bool> {
+    if next_sequence > onchain_count {
+        bail!(
+            "WebSocket cursor is ahead of canonical Merkle tree count: next sequence {next_sequence}, on-chain count {onchain_count}"
+        );
+    }
+    Ok(next_sequence == onchain_count)
+}
+
 fn record_stream_progress(lag_started_at: &mut Option<Instant>, caught_up: bool) {
     if !caught_up {
         *lag_started_at = None;
@@ -861,6 +946,7 @@ mod tests {
     struct CountHook {
         count: Arc<AtomicUsize>,
         domain: HyperlaneDomain,
+        pending: bool,
     }
 
     impl HyperlaneChain for CountHook {
@@ -886,6 +972,9 @@ mod tests {
         }
 
         async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+            if self.pending {
+                return pending().await;
+            }
             Ok(self.count.load(Ordering::SeqCst) as u32)
         }
 
@@ -929,6 +1018,173 @@ mod tests {
             merkle_tree_hook: None,
             reorg_period: ReorgPeriod::None,
         }
+    }
+
+    fn test_dependencies_with_count(count: Arc<AtomicUsize>) -> StreamDependencies {
+        StreamDependencies {
+            merkle_tree_hook: Some(Arc::new(CountHook {
+                count,
+                domain: HyperlaneDomain::new_test_domain("count-hook"),
+                pending: false,
+            })),
+            ..test_dependencies()
+        }
+    }
+
+    fn test_fallback(active: &IntGauge) -> RpcFallback {
+        active.set(1);
+        RpcFallback {
+            handle: tokio::spawn(pending()),
+            active: active.clone(),
+        }
+    }
+
+    #[test]
+    fn subscription_state_requires_ordered_acknowledgement() {
+        let awaiting_ready = SubscriptionState::AwaitingReady;
+        assert!(awaiting_ready.receive_subscribed().is_err());
+        assert!(awaiting_ready.require_subscribed("event").is_err());
+
+        let awaiting_subscribed = awaiting_ready.receive_ready().expect("ready");
+        assert_eq!(awaiting_subscribed, SubscriptionState::AwaitingSubscribed);
+        assert!(awaiting_subscribed.receive_ready().is_err());
+        assert!(awaiting_subscribed
+            .require_subscribed("caught-up marker")
+            .is_err());
+
+        let subscribed = awaiting_subscribed
+            .receive_subscribed()
+            .expect("subscription acknowledgement");
+        assert_eq!(subscribed, SubscriptionState::Subscribed);
+        subscribed
+            .require_subscribed("event")
+            .expect("data allowed");
+        assert!(subscribed.receive_ready().is_err());
+        assert!(subscribed.receive_subscribed().is_err());
+    }
+
+    #[test]
+    fn cutover_requires_exact_canonical_count() {
+        assert!(!validate_cutover_freshness(4, 3).expect("lag keeps fallback"));
+        assert!(validate_cutover_freshness(4, 4).expect("matching canonical count"));
+        assert!(validate_cutover_freshness(3, 4).is_err());
+    }
+
+    #[tokio::test]
+    async fn cutover_keeps_fallback_until_canonical_count_matches() {
+        let (sync, _temp_dir) = test_sync();
+        let count = Arc::new(AtomicUsize::new(0));
+        let dependencies = test_dependencies_with_count(count.clone());
+        let mut fallback = Some(test_fallback(&sync.fallback_active));
+
+        assert!(sync
+            .try_activate_websocket(1, &mut fallback, Duration::from_millis(10), &dependencies,)
+            .await
+            .is_err());
+        assert!(fallback.is_some());
+        assert_eq!(sync.fallback_active.get(), 1);
+        assert_eq!(sync.websocket_active.get(), 0);
+
+        count.store(2, Ordering::SeqCst);
+        assert!(!sync
+            .try_activate_websocket(1, &mut fallback, Duration::from_millis(10), &dependencies,)
+            .await
+            .expect("lagging cursor keeps fallback"));
+        assert!(fallback.is_some());
+
+        count.store(1, Ordering::SeqCst);
+        assert!(sync
+            .try_activate_websocket(1, &mut fallback, Duration::from_millis(10), &dependencies,)
+            .await
+            .expect("matching count permits cutover"));
+        assert!(fallback.is_none());
+        assert_eq!(sync.fallback_active.get(), 0);
+        assert_eq!(sync.websocket_active.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn cutover_probe_timeout_keeps_fallback_active() {
+        let (sync, _temp_dir) = test_sync();
+        let dependencies = StreamDependencies {
+            merkle_tree_hook: Some(Arc::new(CountHook {
+                count: Arc::new(AtomicUsize::new(1)),
+                domain: HyperlaneDomain::new_test_domain("pending-count-hook"),
+                pending: true,
+            })),
+            ..test_dependencies()
+        };
+        let mut fallback = Some(test_fallback(&sync.fallback_active));
+
+        assert!(sync
+            .try_activate_websocket(1, &mut fallback, Duration::from_millis(1), &dependencies,)
+            .await
+            .is_err());
+        assert!(fallback.is_some());
+        assert_eq!(sync.fallback_active.get(), 1);
+        assert_eq!(sync.websocket_active.get(), 0);
+    }
+
+    #[tokio::test]
+    async fn event_before_subscription_ack_keeps_fallback_active() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener");
+        let (mut sync, _temp_dir) = test_sync();
+        sync.url = Url::parse(&format!(
+            "ws://{}",
+            listener.local_addr().expect("test listener address")
+        ))
+        .expect("test WebSocket URL");
+        let hook = format!("{:#x}", sync.merkle_tree_hook);
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("connection");
+            let mut socket = accept_async(stream).await.expect("WebSocket");
+            socket
+                .send(Message::Text(r#"{"type":"ready"}"#.into()))
+                .await
+                .expect("send ready message");
+            socket
+                .next()
+                .await
+                .expect("subscription message")
+                .expect("read subscription message");
+            socket
+                .send(Message::Text(format!(
+                    r#"{{"type":"event","data":{{"block_number":12,"domain":1,"leaf_index":0,"merkle_tree_hook":"{hook}","message_id":"{:#x}"}},"domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#,
+                    H256::from_low_u64_be(4)
+                )))
+                .await
+                .expect("send event before acknowledgement");
+        });
+
+        let mut next_sequence = 0;
+        let mut fallback = Some(test_fallback(&sync.fallback_active));
+        let error = sync
+            .stream_with_timeout(
+                &mut next_sequence,
+                0,
+                &mut fallback,
+                StreamTimeouts {
+                    read: Duration::from_secs(1),
+                    progress_check: Duration::from_secs(1),
+                    progress_grace: Duration::from_secs(1),
+                },
+                &test_dependencies(),
+            )
+            .await
+            .expect_err("event before acknowledgement");
+
+        assert!(error
+            .to_string()
+            .contains("event before subscription acknowledgement"));
+        assert!(fallback.is_some());
+        assert_eq!(sync.fallback_active.get(), 1);
+        assert_eq!(sync.websocket_active.get(), 0);
+        assert!(sync
+            .db
+            .retrieve_merkle_tree_insertion_by_leaf_index(&0)
+            .expect("retrieve insertion")
+            .is_none());
     }
 
     #[test]
@@ -1172,6 +1428,10 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
+                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .await
+                .expect("send subscribed message");
+            socket
                 .send(Message::Text(format!(
                     r#"{{"type":"event","data":{{"block_number":12,"domain":1,"leaf_index":1,"merkle_tree_hook":"{hook}","message_id":"{first_message_id}"}},"domain":1,"eventType":"merkle_tree_insertion","sequence":"1"}}"#
                 )))
@@ -1205,6 +1465,7 @@ mod tests {
         let active_after_backfill = active.clone();
         let websocket_active = sync.websocket_active.clone();
         let db = sync.db.clone();
+        let dependencies = test_dependencies_with_count(Arc::new(AtomicUsize::new(4)));
         let task = tokio::spawn(async move {
             sync.run_loop(
                 1,
@@ -1215,7 +1476,7 @@ mod tests {
                     progress_grace: Duration::from_secs(1),
                 },
                 Duration::from_secs(1),
-                test_dependencies(),
+                dependencies,
                 move || {
                     active.set(1);
                     RpcFallback {
@@ -1320,6 +1581,10 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
+                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .await
+                .expect("send subscribed message");
+            socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
                 )))
@@ -1335,6 +1600,7 @@ mod tests {
         let db = sync.db.clone();
         let websocket_active = sync.websocket_active.clone();
         let websocket_active_after_recovery = websocket_active.clone();
+        let dependencies = test_dependencies_with_count(Arc::new(AtomicUsize::new(1)));
         let task = tokio::spawn(async move {
             sync.run_loop(
                 1,
@@ -1345,7 +1611,7 @@ mod tests {
                     progress_grace: Duration::from_secs(1),
                 },
                 Duration::from_millis(1),
-                test_dependencies(),
+                dependencies,
                 move || {
                     active_in_fallback.set(1);
                     starts_in_fallback.fetch_add(1, Ordering::SeqCst);
@@ -1392,6 +1658,7 @@ mod tests {
         let hook_address = format!("{:#x}", sync.merkle_tree_hook);
         let onchain_count = Arc::new(AtomicUsize::new(1));
         let server_count = onchain_count.clone();
+        let (advance_tx, advance_rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
             let (stream, _) = listener.accept().await.expect("connection");
             let mut socket = accept_async(stream).await.expect("WebSocket");
@@ -1405,11 +1672,16 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
+                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .await
+                .expect("send subscribed message");
+            socket
                 .send(Message::Text(format!(
                     r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
                 )))
                 .await
                 .expect("send caught-up message");
+            advance_rx.await.expect("advance on-chain count");
             server_count.store(2, Ordering::SeqCst);
             let mut heartbeats = interval(Duration::from_millis(2));
             loop {
@@ -1434,6 +1706,7 @@ mod tests {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count: onchain_count,
                 domain: HyperlaneDomain::new_test_domain("count-hook"),
+                pending: false,
             })),
             ..test_dependencies()
         };
@@ -1459,6 +1732,15 @@ mod tests {
             )
             .await;
         });
+
+        timeout(Duration::from_secs(1), async {
+            while active.get() != 0 || websocket_active_after_stale.get() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("initial WebSocket cutover");
+        advance_tx.send(()).expect("advance on-chain count");
 
         timeout(Duration::from_secs(1), async {
             while starts.load(Ordering::SeqCst) != 2

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use eyre::{bail, eyre, Context, Result};
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{future::BoxFuture, FutureExt, SinkExt, StreamExt};
 use prometheus::IntGauge;
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -320,46 +320,46 @@ impl MerkleTreeHookWebSocketSync {
         let mut progress_checks = interval(timeouts.progress_check);
         progress_checks.set_missed_tick_behavior(MissedTickBehavior::Delay);
         progress_checks.tick().await;
+        let mut count_probe: Option<BoxFuture<'static, Result<u32>>> = None;
         let read_deadline = sleep(timeouts.read);
         tokio::pin!(read_deadline);
         let mut canonical_cache = Vec::new();
 
         loop {
             let message = tokio::select! {
+                biased;
                 _ = &mut read_deadline => bail!("Merkle tree hook WebSocket heartbeat timed out"),
-                message = socket.next() => Some(message),
-                _ = progress_checks.tick(), if dependencies.merkle_tree_hook.is_some() => {
-                    let hook = dependencies
-                        .merkle_tree_hook
-                        .as_ref()
-                        .expect("progress check requires a Merkle tree hook");
-                    tokio::select! {
-                        _ = &mut read_deadline => {
-                            bail!("Merkle tree hook WebSocket heartbeat timed out")
-                        }
-                        message = socket.next() => Some(message),
-                        count = timeout(
-                            RPC_PROBE_TIMEOUT,
-                            hook.count(&dependencies.reorg_period),
-                        ) => {
-                            let onchain_count = count
-                                .context("On-chain Merkle tree count probe timed out")?
-                                .context("Reading on-chain Merkle tree count for WebSocket freshness")?;
-                            check_stream_lag(
-                                &mut lag_started_at,
-                                onchain_count,
-                                *next_sequence,
-                                timeouts.progress_grace,
-                                fallback.is_none(),
-                            )?;
-                            if caught_up && fallback.is_some() {
-                                cutover_target = (onchain_count > *next_sequence)
-                                    .then_some(onchain_count);
-                            }
-                            None
-                        }
+                count = async {
+                    count_probe
+                        .as_mut()
+                        .expect("count probe branch requires an in-flight probe")
+                        .await
+                }, if count_probe.is_some() => {
+                    count_probe = None;
+                    let onchain_count = count?;
+                    check_stream_lag(
+                        &mut lag_started_at,
+                        onchain_count,
+                        *next_sequence,
+                        timeouts.progress_grace,
+                        fallback.is_none(),
+                    )?;
+                    if caught_up && fallback.is_some() && *next_sequence >= backfill_target {
+                        self.apply_cutover_count(
+                            *next_sequence,
+                            onchain_count,
+                            fallback,
+                            &mut cutover_target,
+                        )
+                        .await?;
                     }
+                    None
                 }
+                _ = progress_checks.tick(), if dependencies.merkle_tree_hook.is_some() && count_probe.is_none() => {
+                    count_probe = Some(stream_count_probe(dependencies));
+                    None
+                }
+                message = socket.next() => Some(message),
             };
             let Some(message) = message else {
                 continue;
@@ -529,6 +529,17 @@ impl MerkleTreeHookWebSocketSync {
             .await
             .context("On-chain Merkle tree count cutover probe timed out")?
             .context("Reading on-chain Merkle tree count for WebSocket cutover")?;
+        self.apply_cutover_count(next_sequence, onchain_count, fallback, cutover_target)
+            .await
+    }
+
+    async fn apply_cutover_count(
+        &self,
+        next_sequence: u32,
+        onchain_count: u32,
+        fallback: &mut Option<RpcFallback>,
+        cutover_target: &mut Option<u32>,
+    ) -> Result<bool> {
         if !validate_cutover_freshness(onchain_count, next_sequence)? {
             *cutover_target = Some(onchain_count);
             warn!(
@@ -762,6 +773,22 @@ impl MerkleTreeHookWebSocketSync {
     }
 }
 
+fn stream_count_probe(dependencies: &StreamDependencies) -> BoxFuture<'static, Result<u32>> {
+    let hook = dependencies
+        .merkle_tree_hook
+        .as_ref()
+        .expect("progress check requires a Merkle tree hook")
+        .clone();
+    let reorg_period = dependencies.reorg_period.clone();
+    async move {
+        timeout(RPC_PROBE_TIMEOUT, hook.count(&reorg_period))
+            .await
+            .context("On-chain Merkle tree count probe timed out")?
+            .context("Reading on-chain Merkle tree count for WebSocket freshness")
+    }
+    .boxed()
+}
+
 fn check_stream_lag(
     lag_started_at: &mut Option<Instant>,
     onchain_count: u32,
@@ -969,6 +996,7 @@ mod tests {
     struct CountHook {
         count: Arc<AtomicUsize>,
         calls: Option<Arc<AtomicUsize>>,
+        delay: Option<Duration>,
         domain: HyperlaneDomain,
         pending: bool,
     }
@@ -998,6 +1026,9 @@ mod tests {
         async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
             if let Some(calls) = &self.calls {
                 calls.fetch_add(1, Ordering::SeqCst);
+            }
+            if let Some(delay) = self.delay {
+                sleep(delay).await;
             }
             if self.pending {
                 return pending().await;
@@ -1052,6 +1083,7 @@ mod tests {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count,
                 calls: None,
+                delay: None,
                 domain: HyperlaneDomain::new_test_domain("count-hook"),
                 pending: false,
             })),
@@ -1156,6 +1188,7 @@ mod tests {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count: Arc::new(AtomicUsize::new(1)),
                 calls: None,
+                delay: None,
                 domain: HyperlaneDomain::new_test_domain("pending-count-hook"),
                 pending: true,
             })),
@@ -1188,6 +1221,7 @@ mod tests {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count: count.clone(),
                 calls: Some(calls.clone()),
+                delay: None,
                 domain: HyperlaneDomain::new_test_domain("count-hook"),
                 pending: false,
             })),
@@ -1891,7 +1925,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn duplicate_caught_up_markers_do_not_reset_lag_grace() {
+    async fn delayed_count_probe_survives_frequent_duplicate_markers() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("test listener");
@@ -1932,7 +1966,7 @@ mod tests {
             let duplicate = Message::Text(format!(
                 r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
             ));
-            let mut markers = interval(Duration::from_millis(2));
+            let mut markers = interval(Duration::from_millis(1));
             loop {
                 markers.tick().await;
                 if socket.send(duplicate.clone()).await.is_err() {
@@ -1947,7 +1981,16 @@ mod tests {
         let active_in_fallback = active.clone();
         let websocket_active = sync.websocket_active.clone();
         let websocket_active_after_stale = websocket_active.clone();
-        let dependencies = test_dependencies_with_count(onchain_count);
+        let dependencies = StreamDependencies {
+            merkle_tree_hook: Some(Arc::new(CountHook {
+                count: onchain_count,
+                calls: None,
+                delay: Some(Duration::from_millis(8)),
+                domain: HyperlaneDomain::new_test_domain("delayed-count-hook"),
+                pending: false,
+            })),
+            ..test_dependencies()
+        };
         let task = tokio::spawn(async move {
             sync.run_loop(
                 1,
@@ -1990,6 +2033,125 @@ mod tests {
         })
         .await
         .expect("duplicate markers cannot mask lag");
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn scheduled_probe_activates_when_cached_target_retreats_to_cursor() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener");
+        let (mut sync, _temp_dir) = test_sync();
+        sync.url = Url::parse(&format!(
+            "ws://{}",
+            listener.local_addr().expect("test listener address")
+        ))
+        .expect("test WebSocket URL");
+        let hook_address = format!("{:#x}", sync.merkle_tree_hook);
+        let onchain_count = Arc::new(AtomicUsize::new(2));
+        let server_count = onchain_count.clone();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_hook = calls.clone();
+        let calls_in_server = calls.clone();
+        let (retreat_tx, retreat_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("connection");
+            let mut socket = accept_async(stream).await.expect("WebSocket");
+            socket
+                .send(Message::Text(r#"{"type":"ready"}"#.into()))
+                .await
+                .expect("send ready message");
+            socket
+                .next()
+                .await
+                .expect("subscription message")
+                .expect("read subscription message");
+            socket
+                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .await
+                .expect("send subscribed message");
+            while calls_in_server.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+            socket
+                .send(Message::Text(format!(
+                    r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
+                )))
+                .await
+                .expect("send caught-up message");
+            retreat_rx.await.expect("retreat on-chain count");
+            server_count.store(1, Ordering::SeqCst);
+            let mut heartbeats = interval(Duration::from_millis(2));
+            loop {
+                heartbeats.tick().await;
+                if socket
+                    .send(Message::Text(r#"{"type":"heartbeat"}"#.into()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        let starts = Arc::new(AtomicUsize::new(0));
+        let starts_in_fallback = starts.clone();
+        let active = sync.fallback_active.clone();
+        let active_in_fallback = active.clone();
+        let websocket_active = sync.websocket_active.clone();
+        let websocket_active_after_retreat = websocket_active.clone();
+        let dependencies = StreamDependencies {
+            merkle_tree_hook: Some(Arc::new(CountHook {
+                count: onchain_count,
+                calls: Some(calls_in_hook),
+                delay: None,
+                domain: HyperlaneDomain::new_test_domain("retreat-count-hook"),
+                pending: false,
+            })),
+            ..test_dependencies()
+        };
+        let task = tokio::spawn(async move {
+            sync.run_loop(
+                1,
+                1,
+                StreamTimeouts {
+                    read: Duration::from_millis(50),
+                    progress_check: Duration::from_millis(20),
+                    progress_grace: Duration::from_millis(10),
+                },
+                Duration::from_secs(1),
+                dependencies,
+                move || {
+                    active_in_fallback.set(1);
+                    starts_in_fallback.fetch_add(1, Ordering::SeqCst);
+                    RpcFallback {
+                        handle: tokio::spawn(pending()),
+                        active: active_in_fallback.clone(),
+                    }
+                },
+            )
+            .await;
+        });
+
+        timeout(Duration::from_secs(1), async {
+            while calls.load(Ordering::SeqCst) < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cache ahead target");
+        assert_eq!(active.get(), 1);
+        assert_eq!(websocket_active_after_retreat.get(), 0);
+        retreat_tx.send(()).expect("retreat on-chain count");
+
+        timeout(Duration::from_secs(1), async {
+            while active.get() != 0 || websocket_active_after_retreat.get() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("scheduled probe activates WebSocket at retreated target");
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
         task.abort();
     }
 
@@ -2055,6 +2217,7 @@ mod tests {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count: onchain_count,
                 calls: None,
+                delay: None,
                 domain: HyperlaneDomain::new_test_domain("count-hook"),
                 pending: false,
             })),

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -316,6 +316,7 @@ impl MerkleTreeHookWebSocketSync {
         let mut subscription_state = SubscriptionState::AwaitingReady;
         let mut caught_up = false;
         let mut lag_started_at = None;
+        let mut cutover_target = None;
         let mut progress_checks = interval(timeouts.progress_check);
         progress_checks.set_missed_tick_behavior(MissedTickBehavior::Delay);
         progress_checks.tick().await;
@@ -349,7 +350,12 @@ impl MerkleTreeHookWebSocketSync {
                                 onchain_count,
                                 *next_sequence,
                                 timeouts.progress_grace,
+                                fallback.is_none(),
                             )?;
+                            if caught_up && fallback.is_some() {
+                                cutover_target = (onchain_count > *next_sequence)
+                                    .then_some(onchain_count);
+                            }
                             None
                         }
                     }
@@ -410,15 +416,19 @@ impl MerkleTreeHookWebSocketSync {
                         )?;
                         // Any valid, non-ahead marker proves historical replay has completed.
                         // A stale marker may still need live events to reach our local cursor.
+                        let first_caught_up = !caught_up;
                         caught_up = true;
                         if reached_cursor {
                             self.persist_next_sequence(*next_sequence)?;
-                            lag_started_at = None;
+                            if first_caught_up {
+                                lag_started_at = None;
+                            }
                             if *next_sequence >= backfill_target {
                                 if self
                                     .try_activate_websocket(
                                         *next_sequence,
                                         fallback,
+                                        &mut cutover_target,
                                         RPC_PROBE_TIMEOUT,
                                         dependencies,
                                     )
@@ -461,6 +471,7 @@ impl MerkleTreeHookWebSocketSync {
                                 self.try_activate_websocket(
                                     *next_sequence,
                                     fallback,
+                                    &mut cutover_target,
                                     RPC_PROBE_TIMEOUT,
                                     dependencies,
                                 )
@@ -500,11 +511,15 @@ impl MerkleTreeHookWebSocketSync {
         &self,
         next_sequence: u32,
         fallback: &mut Option<RpcFallback>,
+        cutover_target: &mut Option<u32>,
         rpc_probe_timeout: Duration,
         dependencies: &StreamDependencies,
     ) -> Result<bool> {
         if fallback.is_none() {
             return Ok(true);
+        }
+        if cutover_target.is_some_and(|target| next_sequence < target) {
+            return Ok(false);
         }
         let hook = dependencies
             .merkle_tree_hook
@@ -515,6 +530,7 @@ impl MerkleTreeHookWebSocketSync {
             .context("On-chain Merkle tree count cutover probe timed out")?
             .context("Reading on-chain Merkle tree count for WebSocket cutover")?;
         if !validate_cutover_freshness(onchain_count, next_sequence)? {
+            *cutover_target = Some(onchain_count);
             warn!(
                 domain = self.domain,
                 next_sequence,
@@ -523,6 +539,7 @@ impl MerkleTreeHookWebSocketSync {
             );
             return Ok(false);
         }
+        *cutover_target = None;
         self.stop_fallback(fallback).await;
         self.websocket_active.set(1);
         Ok(true)
@@ -750,7 +767,13 @@ fn check_stream_lag(
     onchain_count: u32,
     next_sequence: u32,
     progress_grace: Duration,
+    require_canonical_cursor: bool,
 ) -> Result<()> {
+    if require_canonical_cursor && next_sequence > onchain_count {
+        bail!(
+            "Merkle tree hook WebSocket cursor rolled ahead of canonical count: next sequence {next_sequence}, on-chain count {onchain_count}"
+        );
+    }
     if onchain_count <= next_sequence {
         *lag_started_at = None;
         return Ok(());
@@ -945,6 +968,7 @@ mod tests {
     #[derive(Debug)]
     struct CountHook {
         count: Arc<AtomicUsize>,
+        calls: Option<Arc<AtomicUsize>>,
         domain: HyperlaneDomain,
         pending: bool,
     }
@@ -972,6 +996,9 @@ mod tests {
         }
 
         async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+            if let Some(calls) = &self.calls {
+                calls.fetch_add(1, Ordering::SeqCst);
+            }
             if self.pending {
                 return pending().await;
             }
@@ -1024,6 +1051,7 @@ mod tests {
         StreamDependencies {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count,
+                calls: None,
                 domain: HyperlaneDomain::new_test_domain("count-hook"),
                 pending: false,
             })),
@@ -1076,9 +1104,16 @@ mod tests {
         let count = Arc::new(AtomicUsize::new(0));
         let dependencies = test_dependencies_with_count(count.clone());
         let mut fallback = Some(test_fallback(&sync.fallback_active));
+        let mut cutover_target = None;
 
         assert!(sync
-            .try_activate_websocket(1, &mut fallback, Duration::from_millis(10), &dependencies,)
+            .try_activate_websocket(
+                1,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(10),
+                &dependencies,
+            )
             .await
             .is_err());
         assert!(fallback.is_some());
@@ -1087,14 +1122,26 @@ mod tests {
 
         count.store(2, Ordering::SeqCst);
         assert!(!sync
-            .try_activate_websocket(1, &mut fallback, Duration::from_millis(10), &dependencies,)
+            .try_activate_websocket(
+                1,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(10),
+                &dependencies,
+            )
             .await
             .expect("lagging cursor keeps fallback"));
         assert!(fallback.is_some());
 
-        count.store(1, Ordering::SeqCst);
+        count.store(2, Ordering::SeqCst);
         assert!(sync
-            .try_activate_websocket(1, &mut fallback, Duration::from_millis(10), &dependencies,)
+            .try_activate_websocket(
+                2,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(10),
+                &dependencies,
+            )
             .await
             .expect("matching count permits cutover"));
         assert!(fallback.is_none());
@@ -1108,20 +1155,96 @@ mod tests {
         let dependencies = StreamDependencies {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count: Arc::new(AtomicUsize::new(1)),
+                calls: None,
                 domain: HyperlaneDomain::new_test_domain("pending-count-hook"),
                 pending: true,
             })),
             ..test_dependencies()
         };
         let mut fallback = Some(test_fallback(&sync.fallback_active));
+        let mut cutover_target = None;
 
         assert!(sync
-            .try_activate_websocket(1, &mut fallback, Duration::from_millis(1), &dependencies,)
+            .try_activate_websocket(
+                1,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(1),
+                &dependencies,
+            )
             .await
             .is_err());
         assert!(fallback.is_some());
         assert_eq!(sync.fallback_active.get(), 1);
         assert_eq!(sync.websocket_active.get(), 0);
+    }
+
+    #[tokio::test]
+    async fn catch_up_count_probes_only_when_cached_target_is_reached() {
+        let (sync, _temp_dir) = test_sync();
+        let count = Arc::new(AtomicUsize::new(100));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let dependencies = StreamDependencies {
+            merkle_tree_hook: Some(Arc::new(CountHook {
+                count: count.clone(),
+                calls: Some(calls.clone()),
+                domain: HyperlaneDomain::new_test_domain("count-hook"),
+                pending: false,
+            })),
+            ..test_dependencies()
+        };
+        let mut fallback = Some(test_fallback(&sync.fallback_active));
+        let mut cutover_target = None;
+
+        assert!(!sync
+            .try_activate_websocket(
+                1,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(10),
+                &dependencies,
+            )
+            .await
+            .expect("initial probe caches target"));
+        for next_sequence in 2..100 {
+            assert!(!sync
+                .try_activate_websocket(
+                    next_sequence,
+                    &mut fallback,
+                    &mut cutover_target,
+                    Duration::from_millis(10),
+                    &dependencies,
+                )
+                .await
+                .expect("events below target skip probe"));
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        count.store(101, Ordering::SeqCst);
+        assert!(!sync
+            .try_activate_websocket(
+                100,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(10),
+                &dependencies,
+            )
+            .await
+            .expect("target advance is cached"));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        assert!(sync
+            .try_activate_websocket(
+                101,
+                &mut fallback,
+                &mut cutover_target,
+                Duration::from_millis(10),
+                &dependencies,
+            )
+            .await
+            .expect("matching target permits cutover"));
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+        assert!(fallback.is_none());
     }
 
     #[tokio::test]
@@ -1372,13 +1495,13 @@ mod tests {
         let grace = Duration::from_secs(10);
         let mut lag_started_at = None;
 
-        check_stream_lag(&mut lag_started_at, 100, 1, grace).expect("initial lag");
+        check_stream_lag(&mut lag_started_at, 100, 1, grace, false).expect("initial lag");
         tokio::time::advance(Duration::from_secs(5)).await;
         record_stream_progress(&mut lag_started_at, true);
-        check_stream_lag(&mut lag_started_at, 102, 2, grace).expect("progress within grace");
+        check_stream_lag(&mut lag_started_at, 102, 2, grace, false).expect("progress within grace");
         tokio::time::advance(Duration::from_secs(5)).await;
 
-        assert!(check_stream_lag(&mut lag_started_at, 104, 3, grace).is_err());
+        assert!(check_stream_lag(&mut lag_started_at, 104, 3, grace, false).is_err());
     }
 
     #[tokio::test(start_paused = true)]
@@ -1386,14 +1509,15 @@ mod tests {
         let grace = Duration::from_secs(10);
         let mut lag_started_at = None;
 
-        check_stream_lag(&mut lag_started_at, 100, 1, grace).expect("initial lag");
+        check_stream_lag(&mut lag_started_at, 100, 1, grace, false).expect("initial lag");
         tokio::time::advance(Duration::from_secs(6)).await;
         record_stream_progress(&mut lag_started_at, false);
-        check_stream_lag(&mut lag_started_at, 102, 2, grace).expect("first backfill progress");
+        check_stream_lag(&mut lag_started_at, 102, 2, grace, false)
+            .expect("first backfill progress");
         tokio::time::advance(Duration::from_secs(6)).await;
         record_stream_progress(&mut lag_started_at, false);
 
-        check_stream_lag(&mut lag_started_at, 104, 3, grace)
+        check_stream_lag(&mut lag_started_at, 104, 3, grace, false)
             .expect("continuous backfill remains healthy beyond one grace period");
     }
 
@@ -1645,6 +1769,231 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn canonical_count_rollback_restores_fallback_for_replacement() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener");
+        let (mut sync, _temp_dir) = test_sync();
+        sync.url = Url::parse(&format!(
+            "ws://{}",
+            listener.local_addr().expect("test listener address")
+        ))
+        .expect("test WebSocket URL");
+        sync.db
+            .store_tree_insertion(&MerkleTreeInsertion::new(0, H256::from_low_u64_be(4)), 10)
+            .expect("store original insertion");
+        let hook_address = format!("{:#x}", sync.merkle_tree_hook);
+        let onchain_count = Arc::new(AtomicUsize::new(1));
+        let server_count = onchain_count.clone();
+        let (rollback_tx, rollback_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("connection");
+            let mut socket = accept_async(stream).await.expect("WebSocket");
+            socket
+                .send(Message::Text(r#"{"type":"ready"}"#.into()))
+                .await
+                .expect("send ready message");
+            socket
+                .next()
+                .await
+                .expect("subscription message")
+                .expect("read subscription message");
+            socket
+                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .await
+                .expect("send subscribed message");
+            socket
+                .send(Message::Text(format!(
+                    r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
+                )))
+                .await
+                .expect("send caught-up message");
+            rollback_rx.await.expect("roll back on-chain count");
+            server_count.store(0, Ordering::SeqCst);
+            let mut heartbeats = interval(Duration::from_millis(2));
+            loop {
+                heartbeats.tick().await;
+                if socket
+                    .send(Message::Text(r#"{"type":"heartbeat"}"#.into()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        let starts = Arc::new(AtomicUsize::new(0));
+        let starts_in_fallback = starts.clone();
+        let active = sync.fallback_active.clone();
+        let active_in_fallback = active.clone();
+        let db = sync.db.clone();
+        let db_in_fallback = db.clone();
+        let websocket_active = sync.websocket_active.clone();
+        let websocket_active_after_rollback = websocket_active.clone();
+        let dependencies = test_dependencies_with_count(onchain_count);
+        let task = tokio::spawn(async move {
+            sync.run_loop(
+                1,
+                1,
+                StreamTimeouts {
+                    read: Duration::from_millis(50),
+                    progress_check: Duration::from_millis(5),
+                    progress_grace: Duration::from_millis(10),
+                },
+                Duration::from_secs(1),
+                dependencies,
+                move || {
+                    active_in_fallback.set(1);
+                    let start = starts_in_fallback.fetch_add(1, Ordering::SeqCst) + 1;
+                    if start == 2 {
+                        db_in_fallback
+                            .store_tree_insertion(
+                                &MerkleTreeInsertion::new(0, H256::from_low_u64_be(5)),
+                                11,
+                            )
+                            .expect("replace rolled-back insertion");
+                    }
+                    RpcFallback {
+                        handle: tokio::spawn(pending()),
+                        active: active_in_fallback.clone(),
+                    }
+                },
+            )
+            .await;
+        });
+
+        timeout(Duration::from_secs(1), async {
+            while active.get() != 0 || websocket_active_after_rollback.get() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("initial WebSocket cutover");
+        rollback_tx.send(()).expect("roll back on-chain count");
+
+        timeout(Duration::from_secs(1), async {
+            while starts.load(Ordering::SeqCst) != 2
+                || active.get() != 1
+                || websocket_active_after_rollback.get() != 0
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("rollback fallback");
+        assert_eq!(
+            db.retrieve_merkle_tree_insertion_by_leaf_index(&0)
+                .expect("retrieve replacement insertion"),
+            Some(MerkleTreeInsertion::new(0, H256::from_low_u64_be(5)))
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn duplicate_caught_up_markers_do_not_reset_lag_grace() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("test listener");
+        let (mut sync, _temp_dir) = test_sync();
+        sync.url = Url::parse(&format!(
+            "ws://{}",
+            listener.local_addr().expect("test listener address")
+        ))
+        .expect("test WebSocket URL");
+        let hook_address = format!("{:#x}", sync.merkle_tree_hook);
+        let onchain_count = Arc::new(AtomicUsize::new(1));
+        let server_count = onchain_count.clone();
+        let (advance_tx, advance_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("connection");
+            let mut socket = accept_async(stream).await.expect("WebSocket");
+            socket
+                .send(Message::Text(r#"{"type":"ready"}"#.into()))
+                .await
+                .expect("send ready message");
+            socket
+                .next()
+                .await
+                .expect("subscription message")
+                .expect("read subscription message");
+            socket
+                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .await
+                .expect("send subscribed message");
+            socket
+                .send(Message::Text(format!(
+                    r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
+                )))
+                .await
+                .expect("send caught-up message");
+            advance_rx.await.expect("advance on-chain count");
+            server_count.store(2, Ordering::SeqCst);
+            let duplicate = Message::Text(format!(
+                r#"{{"type":"caught_up","address":"{hook_address}","domain":1,"eventType":"merkle_tree_insertion","sequence":"0"}}"#
+            ));
+            let mut markers = interval(Duration::from_millis(2));
+            loop {
+                markers.tick().await;
+                if socket.send(duplicate.clone()).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let starts = Arc::new(AtomicUsize::new(0));
+        let starts_in_fallback = starts.clone();
+        let active = sync.fallback_active.clone();
+        let active_in_fallback = active.clone();
+        let websocket_active = sync.websocket_active.clone();
+        let websocket_active_after_stale = websocket_active.clone();
+        let dependencies = test_dependencies_with_count(onchain_count);
+        let task = tokio::spawn(async move {
+            sync.run_loop(
+                1,
+                1,
+                StreamTimeouts {
+                    read: Duration::from_millis(50),
+                    progress_check: Duration::from_millis(5),
+                    progress_grace: Duration::from_millis(10),
+                },
+                Duration::from_secs(1),
+                dependencies,
+                move || {
+                    active_in_fallback.set(1);
+                    starts_in_fallback.fetch_add(1, Ordering::SeqCst);
+                    RpcFallback {
+                        handle: tokio::spawn(pending()),
+                        active: active_in_fallback.clone(),
+                    }
+                },
+            )
+            .await;
+        });
+
+        timeout(Duration::from_secs(1), async {
+            while active.get() != 0 || websocket_active_after_stale.get() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("initial WebSocket cutover");
+        advance_tx.send(()).expect("advance on-chain count");
+
+        timeout(Duration::from_secs(1), async {
+            while starts.load(Ordering::SeqCst) != 2
+                || active.get() != 1
+                || websocket_active_after_stale.get() != 0
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("duplicate markers cannot mask lag");
+        task.abort();
+    }
+
+    #[tokio::test]
     async fn heartbeat_only_stream_falls_back_when_onchain_count_advances() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -1705,6 +2054,7 @@ mod tests {
         let dependencies = StreamDependencies {
             merkle_tree_hook: Some(Arc::new(CountHook {
                 count: onchain_count,
+                calls: None,
                 domain: HyperlaneDomain::new_test_domain("count-hook"),
                 pending: false,
             })),


### PR DESCRIPTION
> Folded into #9324 at `a0ffbb367b5081d9540339f4331c8eac3af9ed51` and closed. See the closing comment for the exact range-diff accounting. The final root head adds test-only timing stabilization; production timing is unchanged.

## Folded behavior

- require `ready -> subscribe -> subscribed` before accepting events or caught-up markers
- keep RPC polling active until a bounded count probe exactly matches the contiguous cursor
- retain scheduled probes across socket traffic so rollback and lag detection cannot be starved
- restore RPC fallback on probe failure, post-cutover rollback, lag, or a cursor ahead of canonical state

This gate has 0% independent steady-state RPC reduction. It makes #9324's modeled validator cutover safe to realize.
