### PR TITLE
feat(relayer): observe scraper event parity

### DIFF
--- a/.changeset/bright-relayers-shadow.md
+++ b/.changeset/bright-relayers-shadow.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/sdk': minor
+---
+
+Added relayer scraper WebSocket shadow-stream configuration.

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -9959,6 +9959,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "tokio-test",
+ "tokio-tungstenite 0.20.1",
  "tower 0.5.2",
  "tower-http",
  "tracing",
@@ -9966,6 +9967,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "typetag",
+ "url",
  "uuid 1.11.0",
 ]
 

--- a/rust/main/agents/relayer/Cargo.toml
+++ b/rust/main/agents/relayer/Cargo.toml
@@ -48,9 +48,11 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
 ] }
 tokio-metrics.workspace = true
+tokio-tungstenite.workspace = true
 tracing-futures.workspace = true
 tracing.workspace = true
 typetag.workspace = true
+url.workspace = true
 uuid.workspace = true
 tower-http = { version = "0.6", features = ["cors"] }
 

--- a/rust/main/agents/relayer/src/lib.rs
+++ b/rust/main/agents/relayer/src/lib.rs
@@ -9,6 +9,7 @@ mod merkle_tree;
 mod metrics;
 mod prover;
 mod relayer;
+mod scraper_websocket;
 mod settings;
 
 #[cfg(test)]

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -339,7 +339,6 @@ impl BaseAgent for Relayer {
             .map(|(domain, origin)| {
                 ScraperSource::new(
                     domain.name().to_owned(),
-                    origin.database.clone(),
                     domain.id(),
                     origin.chain_conf.addresses.mailbox,
                     origin.chain_conf.addresses.merkle_tree_hook,

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -339,6 +339,7 @@ impl BaseAgent for Relayer {
             .map(|(domain, origin)| {
                 ScraperSource::new(
                     domain.name().to_owned(),
+                    origin.database.clone(),
                     domain.id(),
                     origin.chain_conf.addresses.mailbox,
                     origin.chain_conf.addresses.merkle_tree_hook,

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -44,6 +44,7 @@ use crate::relay_api::{
     handlers::{RateLimiter, ServerState as RelayApiState, TxHashCache},
     RelayApiMetrics,
 };
+use crate::scraper_websocket::{ScraperSource, ScraperWebSocketMonitor};
 use crate::{db_loader::DbLoader, relayer::origin::Origin, server::ENDPOINT_MESSAGES_QUEUE_SIZE};
 use crate::{
     db_loader::DbLoaderExt,
@@ -154,6 +155,7 @@ pub struct Relayer {
     agent_metrics: AgentMetrics,
     chain_metrics: ChainMetrics,
     runtime_metrics: RuntimeMetrics,
+    scraper_websocket_monitor: Option<ScraperWebSocketMonitor>,
     /// Tokio console server
     pub tokio_console_server: Option<console_subscriber::Server>,
 
@@ -332,6 +334,22 @@ impl BaseAgent for Relayer {
         }
         debug!(elapsed = ?start_entity_init.elapsed(), event = "initialized message contexts", "Relayer startup duration measurement");
 
+        let scraper_sources = origins
+            .iter()
+            .map(|(domain, origin)| {
+                ScraperSource::new(
+                    domain.name().to_owned(),
+                    domain.id(),
+                    origin.chain_conf.addresses.mailbox,
+                    origin.chain_conf.addresses.merkle_tree_hook,
+                )
+            })
+            .collect();
+        let scraper_websocket_monitor = settings
+            .websocket_url
+            .map(|url| ScraperWebSocketMonitor::new(url, scraper_sources, &core_metrics))
+            .transpose()?;
+
         debug!(elapsed = ?start.elapsed(), event = "fully initialized", "Relayer startup duration measurement");
 
         Ok(Self {
@@ -356,6 +374,7 @@ impl BaseAgent for Relayer {
             agent_metrics,
             chain_metrics,
             runtime_metrics,
+            scraper_websocket_monitor,
             tokio_console_server: Some(tokio_console_server),
             origins,
             destinations,
@@ -370,6 +389,18 @@ impl BaseAgent for Relayer {
         let mut tasks = vec![];
 
         let task_monitor = tokio_metrics::TaskMonitor::new();
+        if let Some(monitor) = self.scraper_websocket_monitor.take() {
+            let scraper_websocket = tokio::task::Builder::new()
+                .name("scraper_websocket_shadow")
+                .spawn(TaskMonitor::instrument(
+                    &task_monitor,
+                    monitor
+                        .run()
+                        .instrument(info_span!("ScraperWebSocketShadow")),
+                ))
+                .expect("spawning tokio task from Builder is infallible");
+            tasks.push(scraper_websocket);
+        }
         if let Some(tokio_console_server) = self.tokio_console_server.take() {
             let console_server = tokio::task::Builder::new()
                 .name("tokio_console_server")

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -343,6 +343,7 @@ impl BaseAgent for Relayer {
                     domain.id(),
                     origin.chain_conf.addresses.mailbox,
                     origin.chain_conf.addresses.merkle_tree_hook,
+                    origin.database.clone(),
                 )
             })
             .collect();

--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -177,6 +177,7 @@ fn generate_test_relayer_settings(
         max_retries: 1,
         tx_id_indexing_enabled: true,
         igp_indexing_enabled: true,
+        websocket_url: None,
         relay_api_enabled: false,
         relay_api_port: None,
         relay_api_rate_limit_max_requests: None,

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -2033,7 +2033,7 @@ fn sequenced_persistence_frontier(
         return Ok(Some(u32::MAX));
     }
     validate_fresh_empty_stream_starts(state, domain)?;
-    let mut sequence = 0;
+    let mut sequence = state.correlation_next.get(&domain).copied().unwrap_or(0);
     let mut frontier = None;
     while state.cross_stream.complete(domain, sequence) {
         frontier = Some(sequence);
@@ -3174,6 +3174,74 @@ mod tests {
             ]
         );
         assert_eq!(staged.len, 0);
+    }
+
+    #[test]
+    fn fresh_empty_parity_advances_beyond_cross_stream_window() {
+        let sources = sources();
+        let source = &sources[&5];
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut state = replay_state(&plan);
+        let mut staged = StagedParity::default();
+
+        for sequence in 0..=CROSS_STREAM_WINDOW as u32 {
+            let body = sequence.to_be_bytes();
+            let message_id = dispatch_message(sequence, &body).id();
+            let dispatch = state
+                .validate(
+                    event(
+                        DISPATCH_EVENT_TYPE,
+                        sequence,
+                        dispatch_data(sequence, &body),
+                    ),
+                    &sources,
+                )
+                .expect("validate dispatch");
+            staged.push(5, dispatch).expect("stage dispatch");
+            assert!(staged
+                .drain_ready(&plan, &caught_up, &state, 5)
+                .expect("hold incomplete pair")
+                .is_empty());
+
+            let merkle = state
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
+                    ),
+                    &sources,
+                )
+                .expect("validate Merkle insertion");
+            staged.push(5, merkle).expect("stage Merkle insertion");
+            let ready = staged
+                .drain_ready(&plan, &caught_up, &state, 5)
+                .expect("drain complete pair");
+            assert_eq!(ready.len(), 2);
+
+            if let Some(anchor) = state.initialize_correlation(5, sequence) {
+                source
+                    .store_correlation_cursor(anchor)
+                    .expect("store correlation anchor");
+            }
+            let next = state
+                .advance_correlation(5)
+                .expect("advance correlation")
+                .expect("complete pair advances correlation");
+            source
+                .store_correlation_cursor(next)
+                .expect("store correlation frontier");
+        }
+
+        assert_eq!(staged.len, 0);
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(CROSS_STREAM_WINDOW as u32 + 1)
+        );
     }
 
     #[tokio::test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -10,6 +10,7 @@ use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
     scraper_websocket::{
         EventMessage, ServerMessage, StringOrNumber, SubscribeMessage, SubscribeStream,
+        SubscribedStream,
     },
     CoreMetrics,
 };
@@ -27,6 +28,7 @@ const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
+const CROSS_STREAM_WINDOW: usize = 1_024;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
@@ -66,6 +68,101 @@ impl EventKind {
 enum SequenceResult {
     Accepted,
     Duplicate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ProtocolProjection {
+    block_number: u64,
+    message_id: H256,
+}
+
+#[derive(Debug, Default)]
+struct CrossStreamPair {
+    dispatch: Option<ProtocolProjection>,
+    merkle: Option<ProtocolProjection>,
+}
+
+impl CrossStreamPair {
+    fn complete(&self) -> bool {
+        self.dispatch.is_some() && self.merkle.is_some()
+    }
+
+    fn get(&self, kind: EventKind) -> Option<ProtocolProjection> {
+        match kind {
+            EventKind::Dispatch => self.dispatch,
+            EventKind::MerkleTreeInsertion => self.merkle,
+        }
+    }
+
+    fn get_mut(&mut self, kind: EventKind) -> &mut Option<ProtocolProjection> {
+        match kind {
+            EventKind::Dispatch => &mut self.dispatch,
+            EventKind::MerkleTreeInsertion => &mut self.merkle,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct CrossStreamState {
+    entries: HashMap<u32, BTreeMap<u32, CrossStreamPair>>,
+}
+
+impl CrossStreamState {
+    fn validate(
+        &mut self,
+        domain: u32,
+        sequence: u32,
+        kind: EventKind,
+        projection: ProtocolProjection,
+    ) -> Result<()> {
+        let entries = self.entries.entry(domain).or_default();
+
+        let mismatch = if let Some(pair) = entries.get(&sequence) {
+            if let Some(previous) = pair.get(kind) {
+                if previous != projection {
+                    bail!("Conflicting scraper projection at sequence {sequence}");
+                }
+            }
+            if let Some(counterpart) = pair.get(match kind {
+                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
+                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
+            }) {
+                if counterpart.message_id != projection.message_id {
+                    Some(format!(
+                        "Dispatch and Merkle message IDs differ at sequence {sequence}"
+                    ))
+                } else if counterpart.block_number != projection.block_number {
+                    Some(format!(
+                        "Dispatch and Merkle block numbers differ at sequence {sequence}"
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
+            let oldest_complete = entries
+                .first_key_value()
+                .is_some_and(|(_, pair)| pair.complete());
+            if !oldest_complete {
+                bail!("Scraper cross-stream skew exceeds {CROSS_STREAM_WINDOW} sequences");
+            }
+        }
+
+        if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
+            entries.pop_first();
+        }
+        let pair = entries.entry(sequence).or_default();
+        *pair.get_mut(kind) = Some(projection);
+        if let Some(mismatch) = mismatch {
+            bail!(mismatch);
+        }
+        Ok(())
+    }
 }
 
 type EventFingerprint = H256;
@@ -128,6 +225,7 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
+    cross_stream: CrossStreamState,
     cursors: HashMap<(u32, EventKind), StreamCursor>,
 }
 
@@ -147,7 +245,7 @@ impl StreamState {
             .parse::<u32>()
             .context("Invalid scraper event sequence")?;
 
-        let (kind, fingerprint) = match event.event_type.as_str() {
+        let (kind, fingerprint, projection) = match event.event_type.as_str() {
             DISPATCH_EVENT_TYPE => {
                 let data: DispatchEventData =
                     serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
@@ -201,6 +299,10 @@ impl StreamState {
                         origin_tx_hash.as_ref(),
                         data.time_created.as_bytes(),
                     ]),
+                    ProtocolProjection {
+                        block_number: origin_block_height,
+                        message_id,
+                    },
                 )
             }
             MERKLE_EVENT_TYPE => {
@@ -228,6 +330,10 @@ impl StreamState {
                         merkle_tree_hook.as_ref(),
                         message_id.as_ref(),
                     ]),
+                    ProtocolProjection {
+                        block_number,
+                        message_id,
+                    },
                 )
             }
             event_type => bail!("Unexpected scraper event type {event_type}"),
@@ -242,6 +348,8 @@ impl StreamState {
                 SequenceResult::Accepted
             }
         };
+        self.cross_stream
+            .validate(event.domain, sequence, kind, projection)?;
         Ok((kind, result))
     }
 }
@@ -261,13 +369,14 @@ impl HandshakeState {
         Ok(())
     }
 
-    fn subscribed(&mut self) -> Result<()> {
+    fn subscribed(&mut self, streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
         if !self.sent {
             bail!("Received subscribed before ready");
         }
         if self.confirmed {
             bail!("Received duplicate scraper-proxy subscribed message");
         }
+        validate_subscription(streams, domains)?;
         self.confirmed = true;
         Ok(())
     }
@@ -364,8 +473,8 @@ impl ScraperWebSocketMonitor {
                                 .await
                                 .context("Subscribing to relayer scraper-proxy streams")?;
                         }
-                        ServerMessage::Subscribed => {
-                            handshake.subscribed()?;
+                        ServerMessage::Subscribed { streams } => {
+                            handshake.subscribed(&streams, &self.domains())?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
@@ -414,7 +523,13 @@ impl ScraperWebSocketMonitor {
     }
 
     fn subscription(&self) -> Result<String> {
-        subscription(self.sources.keys().copied().collect())
+        subscription(self.domains())
+    }
+
+    fn domains(&self) -> Vec<u32> {
+        let mut domains = self.sources.keys().copied().collect::<Vec<_>>();
+        domains.sort_unstable();
+        domains
     }
 
     fn set_active(&self, active: bool) {
@@ -454,6 +569,21 @@ fn subscription(mut domains: Vec<u32>) -> Result<String> {
         message_type: "subscribe",
     })
     .context("Serializing relayer scraper-proxy subscription")
+}
+
+fn validate_subscription(streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
+    if streams.len() != 2 {
+        bail!("Scraper-proxy confirmed an unexpected number of streams");
+    }
+    for (stream, event_type) in streams.iter().zip([DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]) {
+        if stream.event_type != event_type
+            || stream.cursors.is_some()
+            || stream.domains.as_deref() != Some(domains)
+        {
+            bail!("Scraper-proxy subscription confirmation does not match request");
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Deserialize)]
@@ -558,8 +688,8 @@ mod tests {
         }
     }
 
-    fn dispatch_data(nonce: u32, body: &[u8]) -> serde_json::Value {
-        let message = HyperlaneMessage {
+    fn dispatch_message(nonce: u32, body: &[u8]) -> HyperlaneMessage {
+        HyperlaneMessage {
             version: 3,
             nonce,
             origin: 5,
@@ -567,7 +697,11 @@ mod tests {
             destination: 6,
             recipient: H256::from_low_u64_be(4),
             body: body.to_vec(),
-        };
+        }
+    }
+
+    fn dispatch_data(nonce: u32, body: &[u8]) -> serde_json::Value {
+        let message = dispatch_message(nonce, body);
         serde_json::json!({
             "destination_domain": message.destination,
             "id": "42",
@@ -586,13 +720,33 @@ mod tests {
     }
 
     fn merkle_data(index: u32, hook: H256) -> serde_json::Value {
+        merkle_data_for(index, hook, H256::from_low_u64_be(7), 101)
+    }
+
+    fn merkle_data_for(
+        index: u32,
+        hook: H256,
+        message_id: H256,
+        block_number: u64,
+    ) -> serde_json::Value {
         serde_json::json!({
-            "block_number": "101",
+            "block_number": block_number.to_string(),
             "domain": 5,
             "leaf_index": index,
             "merkle_tree_hook": format!("{hook:#x}"),
-            "message_id": format!("{:#x}", H256::from_low_u64_be(7)),
+            "message_id": format!("{message_id:#x}"),
         })
+    }
+
+    fn subscribed_streams(domains: &[u32]) -> Vec<SubscribedStream> {
+        [DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]
+            .into_iter()
+            .map(|event_type| SubscribedStream {
+                cursors: None,
+                domains: Some(domains.to_vec()),
+                event_type: event_type.to_owned(),
+            })
+            .collect()
     }
 
     #[test]
@@ -744,16 +898,145 @@ mod tests {
     }
 
     #[test]
+    fn correlates_dispatch_and_merkle_projection() {
+        let mut state = StreamState::default();
+        let message = dispatch_message(7, b"payload");
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources(),
+            )
+            .expect("dispatch should validate");
+        state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 100),
+                ),
+                &sources(),
+            )
+            .expect("matching Merkle insertion should validate");
+    }
+
+    #[test]
+    fn rejects_cross_stream_message_and_block_mismatches() {
+        let message = dispatch_message(7, b"payload");
+        let mut wrong_message = StreamState::default();
+        wrong_message
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources(),
+            )
+            .expect("dispatch should validate");
+        assert!(wrong_message
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(7, H256::from_low_u64_be(2), H256::from_low_u64_be(8), 100,),
+                ),
+                &sources(),
+            )
+            .expect_err("message mismatch must reject")
+            .to_string()
+            .contains("message IDs differ"));
+
+        let mut wrong_block = StreamState::default();
+        wrong_block
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources(),
+            )
+            .expect("dispatch should validate");
+        assert!(wrong_block
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 101),
+                ),
+                &sources(),
+            )
+            .expect_err("block mismatch must reject")
+            .to_string()
+            .contains("block numbers differ"));
+    }
+
+    #[test]
+    fn bounds_unmatched_cross_stream_projections() {
+        let projection = ProtocolProjection {
+            block_number: 100,
+            message_id: H256::from_low_u64_be(7),
+        };
+        let mut state = CrossStreamState::default();
+        for sequence in 0..CROSS_STREAM_WINDOW as u32 {
+            state
+                .validate(5, sequence, EventKind::Dispatch, projection)
+                .expect("projection inside window");
+        }
+        assert_eq!(state.entries[&5].len(), CROSS_STREAM_WINDOW);
+        assert!(state
+            .validate(
+                5,
+                CROSS_STREAM_WINDOW as u32,
+                EventKind::Dispatch,
+                projection,
+            )
+            .expect_err("unmatched projection must not be evicted")
+            .to_string()
+            .contains("skew exceeds"));
+
+        state
+            .validate(5, 0, EventKind::MerkleTreeInsertion, projection)
+            .expect("oldest projection should complete");
+        state
+            .validate(
+                5,
+                CROSS_STREAM_WINDOW as u32,
+                EventKind::Dispatch,
+                projection,
+            )
+            .expect("completed oldest projection should be evicted");
+        assert_eq!(state.entries[&5].len(), CROSS_STREAM_WINDOW);
+        assert!(!state.entries[&5].contains_key(&0));
+        assert!(state.entries[&5].contains_key(&(CROSS_STREAM_WINDOW as u32)));
+    }
+
+    #[test]
     fn enforces_subscription_handshake_order() {
         let mut handshake = HandshakeState::default();
+        let domains = [5];
+        let streams = subscribed_streams(&domains);
         assert!(handshake.event().is_err());
-        assert!(handshake.subscribed().is_err());
+        assert!(handshake.subscribed(&streams, &domains).is_err());
         handshake.ready().expect("ready");
         assert!(handshake.event().is_err());
-        handshake.subscribed().expect("subscribed");
+        handshake
+            .subscribed(&streams, &domains)
+            .expect("subscribed");
         handshake.event().expect("event after confirmation");
-        assert!(handshake.subscribed().is_err());
+        assert!(handshake.subscribed(&streams, &domains).is_err());
         assert!(handshake.ready().is_err());
+    }
+
+    #[test]
+    fn rejects_subscription_confirmation_mismatch() {
+        let domains = [5];
+        for streams in [
+            subscribed_streams(&[9]),
+            vec![SubscribedStream {
+                cursors: None,
+                domains: Some(domains.to_vec()),
+                event_type: DISPATCH_EVENT_TYPE.to_owned(),
+            }],
+            subscribed_streams(&domains).into_iter().rev().collect(),
+        ] {
+            let mut handshake = HandshakeState::default();
+            handshake.ready().expect("ready");
+            assert!(handshake.subscribed(&streams, &domains).is_err());
+            assert!(!handshake.confirmed);
+        }
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -5,10 +5,10 @@ use std::{
     time::Duration,
 };
 
-use eyre::{bail, Context, ContextCompat, Result};
+use eyre::{bail, eyre, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
-    db::{HyperlaneDb, HyperlaneRocksDB},
+    db::{DbResult, HyperlaneDb, HyperlaneRocksDB},
     scraper_websocket::{
         EventMessage, SequenceCursor, ServerMessage, StringOrNumber, SubscribeMessage,
         SubscribeStream, SubscribedCursor, SubscribedStream,
@@ -21,7 +21,11 @@ use hyperlane_core::{
 use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::Deserialize;
 use sha3::{Digest, Keccak256};
-use tokio::time::{sleep, timeout, Instant};
+use tokio::{
+    sync::Semaphore,
+    task::JoinHandle,
+    time::{sleep, timeout, Instant},
+};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
 use url::Url;
@@ -30,19 +34,72 @@ const DISPATCH_EVENT_TYPE: &str = "dispatch";
 const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
+const PARITY_READ_TIMEOUT: Duration = Duration::from_secs(1);
+const PARITY_READ_CONCURRENCY: usize = 4;
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
 const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor";
 
-#[derive(Clone, Debug)]
+#[cfg_attr(test, mockall::automock)]
+trait ParityDatabase: Send + Sync {
+    fn retrieve_message_by_nonce(&self, nonce: u32) -> DbResult<Option<HyperlaneMessage>>;
+    fn retrieve_dispatched_block_number_by_nonce(&self, nonce: &u32) -> DbResult<Option<u64>>;
+    fn retrieve_dispatched_tx_hash_by_message_id(
+        &self,
+        message_id: &H256,
+    ) -> DbResult<Option<H512>>;
+    fn retrieve_merkle_tree_insertion_by_leaf_index(
+        &self,
+        leaf_index: &u32,
+    ) -> DbResult<Option<MerkleTreeInsertion>>;
+    fn retrieve_merkle_tree_insertion_block_number_by_leaf_index(
+        &self,
+        leaf_index: &u32,
+    ) -> DbResult<Option<u64>>;
+}
+
+impl ParityDatabase for HyperlaneRocksDB {
+    fn retrieve_message_by_nonce(&self, nonce: u32) -> DbResult<Option<HyperlaneMessage>> {
+        HyperlaneDb::retrieve_message_by_nonce(self, nonce)
+    }
+
+    fn retrieve_dispatched_block_number_by_nonce(&self, nonce: &u32) -> DbResult<Option<u64>> {
+        HyperlaneDb::retrieve_dispatched_block_number_by_nonce(self, nonce)
+    }
+
+    fn retrieve_dispatched_tx_hash_by_message_id(
+        &self,
+        message_id: &H256,
+    ) -> DbResult<Option<H512>> {
+        HyperlaneDb::retrieve_dispatched_tx_hash_by_message_id(self, message_id)
+    }
+
+    fn retrieve_merkle_tree_insertion_by_leaf_index(
+        &self,
+        leaf_index: &u32,
+    ) -> DbResult<Option<MerkleTreeInsertion>> {
+        HyperlaneDb::retrieve_merkle_tree_insertion_by_leaf_index(self, leaf_index)
+    }
+
+    fn retrieve_merkle_tree_insertion_block_number_by_leaf_index(
+        &self,
+        leaf_index: &u32,
+    ) -> DbResult<Option<u64>> {
+        HyperlaneDb::retrieve_merkle_tree_insertion_block_number_by_leaf_index(self, leaf_index)
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct ScraperSource {
     chain: String,
+    cursor_db: HyperlaneRocksDB,
     domain: u32,
     mailbox: H256,
     merkle_tree_hook: H256,
-    database: HyperlaneRocksDB,
+    database: std::sync::Arc<dyn ParityDatabase>,
+    parity_read_permit: std::sync::Arc<Semaphore>,
 }
 
 impl ScraperSource {
@@ -55,10 +112,38 @@ impl ScraperSource {
     ) -> Self {
         Self {
             chain,
+            cursor_db: database.clone(),
+            domain,
+            mailbox,
+            merkle_tree_hook,
+            database: std::sync::Arc::new(database),
+            parity_read_permit: std::sync::Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_database(
+        chain: String,
+        domain: u32,
+        mailbox: H256,
+        merkle_tree_hook: H256,
+        database: std::sync::Arc<dyn ParityDatabase>,
+    ) -> Self {
+        let tempdir = tempfile::tempdir().expect("temporary scraper cursor DB");
+        let db =
+            hyperlane_base::db::test_utils::setup_db(tempdir.path().to_string_lossy().into_owned());
+        std::mem::forget(tempdir);
+        Self {
+            chain,
+            cursor_db: HyperlaneRocksDB::new(
+                &hyperlane_core::HyperlaneDomain::new_test_domain("scraper-parity-cursor"),
+                db,
+            ),
             domain,
             mailbox,
             merkle_tree_hook,
             database,
+            parity_read_permit: std::sync::Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
         }
     }
 
@@ -70,7 +155,7 @@ impl ScraperSource {
     }
 
     fn cursor(&self, kind: EventKind) -> Result<Option<u32>> {
-        self.database
+        self.cursor_db
             .retrieve_value_by_key(kind.cursor_prefix(), &self.address(kind))
             .context("Reading durable scraper WebSocket cursor")
     }
@@ -108,7 +193,7 @@ impl ScraperSource {
         if self.cursor(kind)?.is_some_and(|stored| stored >= sequence) {
             return Ok(());
         }
-        self.database
+        self.cursor_db
             .store_value_by_key(kind.cursor_prefix(), &self.address(kind), &sequence)
             .context("Storing durable scraper WebSocket cursor")
     }
@@ -338,23 +423,20 @@ enum ParityInput {
 }
 
 impl ParityInput {
-    fn compare(&self, source: &ScraperSource) -> Result<ParityResult> {
+    fn compare(&self, database: &dyn ParityDatabase) -> Result<ParityResult> {
         match self {
             Self::Dispatch {
                 block_number,
                 message,
                 transaction_id,
             } => {
-                let local_message = source
-                    .database
+                let local_message = database
                     .retrieve_message_by_nonce(message.nonce)
                     .context("Reading RPC-indexed dispatch message")?;
-                let local_block_number = source
-                    .database
+                let local_block_number = database
                     .retrieve_dispatched_block_number_by_nonce(&message.nonce)
                     .context("Reading RPC-indexed dispatch block number")?;
-                let local_transaction_id = source
-                    .database
+                let local_transaction_id = database
                     .retrieve_dispatched_tx_hash_by_message_id(&message.id())
                     .context("Reading RPC-indexed dispatch transaction ID")?;
                 if local_message.as_ref().is_some_and(|local| local != message)
@@ -375,12 +457,10 @@ impl ParityInput {
                 block_number,
                 insertion,
             } => {
-                let local_insertion = source
-                    .database
+                let local_insertion = database
                     .retrieve_merkle_tree_insertion_by_leaf_index(&insertion.index())
                     .context("Reading RPC-indexed Merkle tree insertion")?;
-                let local_block_number = source
-                    .database
+                let local_block_number = database
                     .retrieve_merkle_tree_insertion_block_number_by_leaf_index(&insertion.index())
                     .context("Reading RPC-indexed Merkle insertion block number")?;
                 if local_insertion
@@ -836,7 +916,75 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn stream(&self, state: &mut StreamState, plan: &SequencedReplayPlan) -> Result<()> {
+    fn observe_parity(
+        &self,
+        domain: u32,
+        kind: EventKind,
+        parity_input: ParityInput,
+    ) -> Option<JoinHandle<()>> {
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper event source must exist");
+        let chain = source.chain.clone();
+        let event_type = kind.label();
+        let metrics = self.parity.clone();
+        let permit = match source.parity_read_permit.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(err) => {
+                metrics
+                    .with_label_values(&[chain.as_str(), event_type, "error"])
+                    .inc();
+                warn!(
+                    %chain,
+                    event_type,
+                    ?err,
+                    "Local DB parity reader is busy; skipping comparison"
+                );
+                return None;
+            }
+        };
+        let database = source.database.clone();
+        let comparison = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            parity_input.compare(database.as_ref())
+        });
+
+        Some(tokio::spawn(async move {
+            let result = match timeout(PARITY_READ_TIMEOUT, comparison).await {
+                Ok(Ok(result)) => result,
+                Ok(Err(err)) => Err(eyre!("Local DB parity task failed: {err}")),
+                Err(_) => Err(eyre!("Local DB parity read timed out")),
+            };
+            match result {
+                Ok(parity_result) => {
+                    metrics
+                        .with_label_values(&[chain.as_str(), event_type, parity_result.label()])
+                        .inc();
+                    if parity_result == ParityResult::Conflict {
+                        warn!(
+                            %chain,
+                            event_type,
+                            "Scraper event conflicts with RPC-indexed local DB"
+                        );
+                    }
+                }
+                Err(err) => {
+                    metrics
+                        .with_label_values(&[chain.as_str(), event_type, "error"])
+                        .inc();
+                    warn!(
+                        %chain,
+                        event_type,
+                        ?err,
+                        "Local DB parity comparison failed"
+                    );
+                }
+            }
+        }))
+    }
+
+    async fn stream(&self, state: &mut StreamState) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
@@ -916,30 +1064,11 @@ impl ScraperWebSocketMonitor {
                                     let source = self.sources.get(&domain).context(
                                         "Validated scraper event source unexpectedly missing",
                                     )?;
-                                    match validated.parity.compare(source) {
-                                        Ok(parity_result) => {
-                                            self.record_parity(
-                                                domain,
-                                                validated.kind.label(),
-                                                parity_result.label(),
-                                            );
-                                            if parity_result == ParityResult::Conflict {
-                                                warn!(
-                                                    chain = %source.chain,
-                                                    event_type = validated.kind.label(),
-                                                    "Scraper event conflicts with RPC-indexed local DB"
-                                                );
-                                            }
-                                        }
-                                        Err(err) => {
-                                            self.record_parity(
-                                                domain,
-                                                validated.kind.label(),
-                                                "error",
-                                            );
-                                            return Err(err);
-                                        }
-                                    }
+                                    drop(self.observe_parity(
+                                        domain,
+                                        validated.kind,
+                                        validated.parity,
+                                    ));
                                     self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
@@ -1069,17 +1198,6 @@ impl ScraperWebSocketMonitor {
             .map(|source| source.chain.as_str())
             .unwrap_or("unknown");
         self.events
-            .with_label_values(&[chain, event_type, result])
-            .inc();
-    }
-
-    fn record_parity(&self, domain: u32, event_type: &str, result: &str) {
-        let chain = self
-            .sources
-            .get(&domain)
-            .map(|source| source.chain.as_str())
-            .unwrap_or("unknown");
-        self.parity
             .with_label_values(&[chain, event_type, result])
             .inc();
     }
@@ -1421,9 +1539,11 @@ mod tests {
     use super::*;
     use hyperlane_base::db::{test_utils, DB};
     use hyperlane_core::HyperlaneDomain;
+    use prometheus::Registry;
 
     struct Fixture {
         _temp_dir: tempfile::TempDir,
+        database: HyperlaneRocksDB,
         sources: HashMap<u32, ScraperSource>,
     }
 
@@ -1444,6 +1564,7 @@ mod tests {
             HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("scraper-parity"), db);
         Fixture {
             _temp_dir: temp_dir,
+            database: database.clone(),
             sources: HashMap::from([(5, source(database))]),
         }
     }
@@ -1475,6 +1596,23 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    fn monitor(database: std::sync::Arc<dyn ParityDatabase>) -> ScraperWebSocketMonitor {
+        let metrics = CoreMetrics::new("scraper-parity-test", 9090, Registry::new())
+            .expect("create test metrics");
+        ScraperWebSocketMonitor::new(
+            Url::parse("ws://localhost:1").expect("test URL"),
+            vec![ScraperSource::with_database(
+                "test".to_owned(),
+                5,
+                H256::from_low_u64_be(1),
+                H256::from_low_u64_be(2),
+                database,
+            )],
+            &metrics,
+        )
+        .expect("create test monitor")
     }
 
     fn event(
@@ -1525,22 +1663,18 @@ mod tests {
         bytes_to_h512(&[6_u8; 32])
     }
 
-    fn store_dispatch(source: &ScraperSource, message: &HyperlaneMessage) {
+    fn store_dispatch(database: &HyperlaneRocksDB, message: &HyperlaneMessage) {
         let message_id = message.id();
-        source
-            .database
+        database
             .store_message_id_by_nonce(&message.nonce, &message_id)
             .expect("store message ID");
-        source
-            .database
+        database
             .store_message_by_id(&message_id, message)
             .expect("store message");
-        source
-            .database
+        database
             .store_dispatched_block_number_by_nonce(&message.nonce, &100)
             .expect("store dispatch block");
-        source
-            .database
+        database
             .store_dispatched_tx_hash_by_message_id(&message_id, &dispatch_transaction_id())
             .expect("store dispatch transaction");
     }
@@ -2430,11 +2564,14 @@ mod tests {
             )
             .expect("lagging event");
         assert_eq!(
-            lagging.parity.compare(source).expect("lag comparison"),
+            lagging
+                .parity
+                .compare(source.database.as_ref())
+                .expect("lag comparison"),
             ParityResult::Missing
         );
 
-        store_dispatch(source, &message);
+        store_dispatch(&fixture.database, &message);
         let duplicate = state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, data.clone()),
@@ -2443,7 +2580,10 @@ mod tests {
             .expect("duplicate event");
         assert_eq!(duplicate.sequence_result, SequenceResult::Duplicate);
         assert_eq!(
-            duplicate.parity.compare(source).expect("duplicate parity"),
+            duplicate
+                .parity
+                .compare(source.database.as_ref())
+                .expect("duplicate parity"),
             ParityResult::Match
         );
 
@@ -2452,7 +2592,10 @@ mod tests {
             .expect("event after process restart");
         assert_eq!(restarted.sequence_result, SequenceResult::Accepted);
         assert_eq!(
-            restarted.parity.compare(source).expect("restart parity"),
+            restarted
+                .parity
+                .compare(source.database.as_ref())
+                .expect("restart parity"),
             ParityResult::Match
         );
 
@@ -2465,7 +2608,10 @@ mod tests {
             )
             .expect("conflicting event payload");
         assert_eq!(
-            conflict.parity.compare(source).expect("conflict parity"),
+            conflict
+                .parity
+                .compare(source.database.as_ref())
+                .expect("conflict parity"),
             ParityResult::Conflict
         );
     }
@@ -2478,7 +2624,7 @@ mod tests {
             let db = DB::from_path(temp_dir.path()).expect("open temp DB");
             let database =
                 HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("scraper-parity"), db);
-            store_dispatch(&source(database), &message);
+            store_dispatch(&database, &message);
         }
 
         let db = DB::from_path(temp_dir.path()).expect("reopen temp DB");
@@ -2495,9 +2641,124 @@ mod tests {
         assert_eq!(
             validated
                 .parity
-                .compare(sources.get(&5).expect("source"))
+                .compare(sources.get(&5).expect("source").database.as_ref())
                 .expect("restart comparison"),
             ParityResult::Match
+        );
+    }
+
+    #[tokio::test]
+    async fn one_shot_db_error_does_not_interrupt_next_event() {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mut database = MockParityDatabase::new();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(2)
+            .returning({
+                let calls = calls.clone();
+                move |nonce| {
+                    if calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                        Err(hyperlane_base::db::DbError::Other(
+                            "one-shot read failure".to_owned(),
+                        ))
+                    } else {
+                        Ok(Some(dispatch_message(nonce, b"next")))
+                    }
+                }
+            });
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(1)
+            .returning(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(1)
+            .returning(|_| Ok(Some(dispatch_transaction_id())));
+        let monitor = monitor(std::sync::Arc::new(database));
+        monitor.set_active(true);
+        let mut state = StreamState::default();
+
+        let first = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"first")),
+                &monitor.sources,
+            )
+            .expect("first event");
+        monitor
+            .observe_parity(5, first.kind, first.parity)
+            .expect("first parity task")
+            .await
+            .expect("first parity task must not panic");
+
+        let next = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"next")),
+                &monitor.sources,
+            )
+            .expect("next event on the same stream");
+        assert_eq!(next.sequence_result, SequenceResult::Accepted);
+        monitor
+            .observe_parity(5, next.kind, next.parity)
+            .expect("next parity task")
+            .await
+            .expect("next parity task must not panic");
+
+        assert_eq!(
+            monitor
+                .parity
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE, "error"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            monitor
+                .parity
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE, "match"])
+                .get(),
+            1
+        );
+        assert_eq!(monitor.active.with_label_values(&["test"]).get(), 1);
+    }
+
+    #[tokio::test]
+    async fn blocking_db_read_does_not_block_stream_validation() {
+        let mut database = MockParityDatabase::new();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(1)
+            .returning(|_| {
+                std::thread::sleep(PARITY_READ_TIMEOUT + Duration::from_millis(100));
+                Ok(None)
+            });
+        let monitor = monitor(std::sync::Arc::new(database));
+        let mut state = StreamState::default();
+        let first = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"first")),
+                &monitor.sources,
+            )
+            .expect("first event");
+        let parity_task = monitor
+            .observe_parity(5, first.kind, first.parity)
+            .expect("parity task");
+
+        let started = std::time::Instant::now();
+        let next = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"next")),
+                &monitor.sources,
+            )
+            .expect("next event while DB read is blocked");
+        assert_eq!(next.sequence_result, SequenceResult::Accepted);
+        assert!(started.elapsed() < Duration::from_millis(100));
+
+        parity_task.await.expect("parity task must not panic");
+        assert_eq!(
+            monitor
+                .parity
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE, "error"])
+                .get(),
+            1
         );
     }
 
@@ -2512,15 +2773,18 @@ mod tests {
             .validate(event(MERKLE_EVENT_TYPE, 1, data.clone()), &fixture.sources)
             .expect("lagging Merkle event");
         assert_eq!(
-            lagging.parity.compare(source).expect("lag comparison"),
+            lagging
+                .parity
+                .compare(source.database.as_ref())
+                .expect("lag comparison"),
             ParityResult::Missing
         );
 
-        source
+        fixture
             .database
             .store_merkle_tree_insertion_by_leaf_index(&1, &insertion)
             .expect("store Merkle insertion");
-        source
+        fixture
             .database
             .store_merkle_tree_insertion_block_number_by_leaf_index(&1, &101)
             .expect("store Merkle block");
@@ -2528,7 +2792,10 @@ mod tests {
             .validate(event(MERKLE_EVENT_TYPE, 1, data), &fixture.sources)
             .expect("matching Merkle event");
         assert_eq!(
-            matched.parity.compare(source).expect("match comparison"),
+            matched
+                .parity
+                .compare(source.database.as_ref())
+                .expect("match comparison"),
             ParityResult::Match
         );
 
@@ -2540,7 +2807,7 @@ mod tests {
         assert_eq!(
             conflict
                 .parity
-                .compare(source)
+                .compare(source.database.as_ref())
                 .expect("conflict comparison"),
             ParityResult::Conflict
         );

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -488,6 +488,13 @@ impl StagedParity {
         }
         Ok(ready)
     }
+
+    fn drain_all(&mut self) -> impl Iterator<Item = (u32, ValidatedEvent)> + '_ {
+        self.len = 0;
+        self.events
+            .drain()
+            .flat_map(|(domain, events)| events.into_iter().map(move |event| (domain, event)))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1264,14 +1271,40 @@ impl ScraperWebSocketMonitor {
         kind: EventKind,
         parity_input: ParityInput,
     ) -> &'static str {
+        self.note_parity_pending(domain, kind);
+        self.observe_parity_inner(domain, kind, parity_input).await
+    }
+
+    fn note_parity_pending(&self, domain: u32, kind: EventKind) {
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper event source must exist");
+        let labels = [source.chain.as_str(), kind.label()];
+        self.parity_ready.with_label_values(&labels).set(0);
+        self.parity_pending.with_label_values(&labels).inc();
+    }
+
+    fn cancel_parity_pending(&self, domain: u32, kind: EventKind) {
         let source = self
             .sources
             .get(&domain)
             .expect("validated scraper event source must exist");
         self.parity_pending
             .with_label_values(&[source.chain.as_str(), kind.label()])
-            .inc();
-        self.observe_parity_inner(domain, kind, parity_input).await
+            .dec();
+    }
+
+    fn stage_parity(
+        &self,
+        staged: &mut StagedParity,
+        domain: u32,
+        validated: ValidatedEvent,
+    ) -> Result<()> {
+        let kind = validated.kind;
+        staged.push(domain, validated)?;
+        self.note_parity_pending(domain, kind);
+        Ok(())
     }
 
     async fn observe_parity_inner(
@@ -1388,23 +1421,16 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn enqueue_parity(
+    async fn enqueue_accounted_parity(
         self: &Arc<Self>,
         domain: u32,
         kind: EventKind,
         parity_input: ParityInput,
         sequence: u32,
-    ) {
-        let source = self
-            .sources
-            .get(&domain)
-            .expect("validated scraper event source exists");
+    ) -> bool {
         let generation = self.correlation_gate.lock().generation;
-        self.parity_ready
-            .with_label_values(&[source.chain.as_str(), kind.label()])
-            .set(0);
         if self.parity_read_disabled.load(Ordering::Acquire) {
-            return;
+            return false;
         }
         let queue_permit = self
             .parity_queue_permit
@@ -1413,11 +1439,8 @@ impl ScraperWebSocketMonitor {
             .await
             .expect("parity queue semaphore is never closed");
         if self.parity_read_disabled.load(Ordering::Acquire) {
-            return;
+            return false;
         }
-        self.parity_pending
-            .with_label_values(&[source.chain.as_str(), kind.label()])
-            .inc();
         let queue = self
             .parity_queues
             .get(&(domain, kind))
@@ -1444,6 +1467,25 @@ impl ScraperWebSocketMonitor {
                 monitor.drain_parity_queue(domain, kind, queue).await;
             });
         }
+        true
+    }
+
+    #[cfg(test)]
+    async fn enqueue_parity(
+        self: &Arc<Self>,
+        domain: u32,
+        kind: EventKind,
+        parity_input: ParityInput,
+        sequence: u32,
+    ) -> bool {
+        self.note_parity_pending(domain, kind);
+        let enqueued = self
+            .enqueue_accounted_parity(domain, kind, parity_input, sequence)
+            .await;
+        if !enqueued {
+            self.cancel_parity_pending(domain, kind);
+        }
+        enqueued
     }
 
     async fn admit_parity(
@@ -1464,8 +1506,12 @@ impl ScraperWebSocketMonitor {
         if let Some(next) = state.advance_correlation(domain)? {
             self.note_cross_stream_next(generation, domain, next);
         }
-        self.enqueue_parity(domain, validated.kind, validated.parity, validated.sequence)
-            .await;
+        if !self
+            .enqueue_accounted_parity(domain, validated.kind, validated.parity, validated.sequence)
+            .await
+        {
+            self.cancel_parity_pending(domain, validated.kind);
+        }
         Ok(())
     }
 
@@ -1478,11 +1524,27 @@ impl ScraperWebSocketMonitor {
         domain: u32,
         staged: &mut StagedParity,
     ) -> Result<()> {
-        for validated in staged.drain_ready(plan, caught_up, state, domain)? {
-            self.admit_parity(state, generation, domain, validated)
-                .await?;
+        let mut ready = staged.drain_ready(plan, caught_up, state, domain)?;
+        while let Some(validated) = ready.pop_front() {
+            let kind = validated.kind;
+            if let Err(err) = self
+                .admit_parity(state, generation, domain, validated)
+                .await
+            {
+                self.cancel_parity_pending(domain, kind);
+                for pending in ready {
+                    self.cancel_parity_pending(domain, pending.kind);
+                }
+                return Err(err);
+            }
         }
         Ok(())
+    }
+
+    fn abandon_staged_parity(&self, staged: &mut StagedParity) {
+        for (domain, event) in staged.drain_all() {
+            self.cancel_parity_pending(domain, event.kind);
+        }
     }
 
     async fn drain_parity_queue(
@@ -1573,13 +1635,27 @@ impl ScraperWebSocketMonitor {
         plan: &SequencedReplayPlan,
         generation: u64,
     ) -> Result<()> {
+        let mut staged_parity = StagedParity::default();
+        let result = self
+            .stream_inner(state, plan, generation, &mut staged_parity)
+            .await;
+        self.abandon_staged_parity(&mut staged_parity);
+        result
+    }
+
+    async fn stream_inner(
+        self: &Arc<Self>,
+        state: &mut StreamState,
+        plan: &SequencedReplayPlan,
+        generation: u64,
+        staged_parity: &mut StagedParity,
+    ) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
         let mut caught_up = HashMap::new();
-        let mut staged_parity = StagedParity::default();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -1619,14 +1695,14 @@ impl ScraperWebSocketMonitor {
                                         SequenceResult::Duplicate => "duplicate",
                                     };
                                     self.record(domain, validated.kind.label(), result);
-                                    staged_parity.push(domain, validated)?;
+                                    self.stage_parity(staged_parity, domain, validated)?;
                                     self.flush_staged_parity(
                                         state,
                                         plan,
                                         &caught_up,
                                         generation,
                                         domain,
-                                        &mut staged_parity,
+                                        staged_parity,
                                     )
                                     .await?;
                                     self.update_source_caught_up(state, plan, &caught_up, domain)?;
@@ -1703,7 +1779,7 @@ impl ScraperWebSocketMonitor {
                                 &caught_up,
                                 generation,
                                 domain,
-                                &mut staged_parity,
+                                staged_parity,
                             )
                             .await?;
                             self.update_source_caught_up(state, plan, &caught_up, domain)?;
@@ -3841,6 +3917,82 @@ mod tests {
                 .get(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn staged_event_clears_parity_readiness_until_terminal() {
+        let mut database = MockParityDatabase::new();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(1)
+            .returning(|nonce| Ok(Some(dispatch_message(nonce, b"matched"))));
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(1)
+            .returning(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(1)
+            .returning(|_| Ok(Some(dispatch_transaction_id())));
+        let monitor = Arc::new(monitor(Arc::new(database)));
+        let labels = ["test", DISPATCH_EVENT_TYPE];
+        let mut state = StreamState::default();
+        let matched = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"matched")),
+                &monitor.sources,
+            )
+            .expect("valid matched dispatch");
+        assert_eq!(
+            monitor
+                .observe_parity(5, matched.kind, matched.parity)
+                .await,
+            ParityResult::Match.label()
+        );
+        assert_eq!(monitor.parity_pending.with_label_values(&labels).get(), 0);
+        assert_eq!(monitor.parity_ready.with_label_values(&labels).get(), 1);
+
+        let staged_event = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"staged")),
+                &monitor.sources,
+            )
+            .expect("valid staged dispatch");
+        let mut staged = StagedParity::default();
+        monitor
+            .stage_parity(&mut staged, 5, staged_event)
+            .expect("stage unmatched dispatch");
+        assert_eq!(monitor.parity_pending.with_label_values(&labels).get(), 1);
+        assert_eq!(monitor.parity_ready.with_label_values(&labels).get(), 0);
+
+        let queued_event = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 2, dispatch_data(2, b"queued")),
+                &monitor.sources,
+            )
+            .expect("valid queued dispatch");
+        monitor.note_parity_pending(5, EventKind::Dispatch);
+        let queue = monitor
+            .parity_queues
+            .get(&(5, EventKind::Dispatch))
+            .expect("dispatch queue");
+        queue.lock().jobs.push_back(ParityJob {
+            generation: 1,
+            input: queued_event.parity,
+            queue_permit: monitor
+                .parity_queue_permit
+                .clone()
+                .try_acquire_owned()
+                .expect("queue permit"),
+            sequence: queued_event.sequence,
+        });
+        assert_eq!(monitor.parity_pending.with_label_values(&labels).get(), 2);
+
+        monitor.abandon_staged_parity(&mut staged);
+        assert_eq!(monitor.parity_pending.with_label_values(&labels).get(), 1);
+        assert_eq!(monitor.parity_ready.with_label_values(&labels).get(), 0);
+        monitor.abandon_parity_queue(5, EventKind::Dispatch, queue);
+        assert_eq!(monitor.parity_pending.with_label_values(&labels).get(), 0);
     }
 
     #[tokio::test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -559,6 +559,7 @@ type EventFingerprint = H256;
 #[derive(Debug)]
 struct StreamCursor {
     fingerprints: BTreeMap<u32, EventFingerprint>,
+    first_sequence: Option<u32>,
     next_sequence: u32,
 }
 
@@ -566,6 +567,7 @@ impl StreamCursor {
     fn from_durable_sequence(sequence: u32) -> Self {
         Self {
             fingerprints: BTreeMap::new(),
+            first_sequence: None,
             next_sequence: sequence,
         }
     }
@@ -573,6 +575,7 @@ impl StreamCursor {
     fn from_after_sequence(sequence: u32) -> Result<Self> {
         Ok(Self {
             fingerprints: BTreeMap::new(),
+            first_sequence: None,
             next_sequence: sequence
                 .checked_add(1)
                 .context("Scraper event sequence exhausted")?,
@@ -584,6 +587,7 @@ impl StreamCursor {
         fingerprints.insert(sequence, fingerprint);
         Ok(Self {
             fingerprints,
+            first_sequence: Some(sequence),
             next_sequence: sequence
                 .checked_add(1)
                 .context("Scraper event sequence exhausted")?,
@@ -616,6 +620,7 @@ impl StreamCursor {
     }
 
     fn accept(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<()> {
+        self.first_sequence.get_or_insert(sequence);
         self.next_sequence = self
             .next_sequence
             .checked_add(1)
@@ -702,6 +707,32 @@ impl StreamState {
             .context("Scraper caught-up sequence exceeds u32")?;
         self.cursors
             .insert((domain, kind), StreamCursor::from_after_sequence(sequence)?);
+        Ok(())
+    }
+
+    fn validate_fresh_baseline(&self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
+        if sequence < 0 {
+            return Ok(());
+        }
+        let Some(first) = self
+            .cursors
+            .get(&(domain, kind))
+            .and_then(|cursor| cursor.first_sequence)
+        else {
+            return Ok(());
+        };
+        let baseline: u32 = sequence
+            .try_into()
+            .context("Scraper caught-up sequence exceeds u32")?;
+        let expected = baseline
+            .checked_add(1)
+            .context("Scraper caught-up sequence exhausted")?;
+        if first != expected {
+            bail!(
+                "Fresh {} scraper stream started at sequence {first}, expected {expected} after caught-up baseline {baseline}",
+                kind.label()
+            );
+        }
         Ok(())
     }
 
@@ -1627,6 +1658,9 @@ impl ScraperWebSocketMonitor {
                                 bail!("Invalid negative scraper caught-up sequence {sequence}");
                             }
                             validate_caught_up_floor(plan, domain, sequence)?;
+                            if !plan.correlation_required(domain)? {
+                                state.validate_fresh_baseline(domain, kind, sequence)?;
+                            }
                             state.set_baseline(domain, kind, sequence)?;
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
@@ -1883,9 +1917,7 @@ fn validate_fresh_empty_stream_starts(state: &StreamState, domain: u32) -> Resul
             continue;
         };
         let first = cursor
-            .fingerprints
-            .first_key_value()
-            .map(|(sequence, _)| *sequence)
+            .first_sequence
             .context("Fresh scraper stream cursor omitted its first fingerprint")?;
         if first != 0 {
             bail!(
@@ -2908,6 +2940,62 @@ mod tests {
             replay_plan(&sources).source(5).expect("source plan").floor,
             Some(90)
         );
+    }
+
+    #[test]
+    fn fresh_positive_baseline_rejects_staged_sequence_gaps() {
+        let event_for = |kind, sequence| match kind {
+            EventKind::Dispatch => event(
+                DISPATCH_EVENT_TYPE,
+                sequence,
+                dispatch_data(sequence, b"message"),
+            ),
+            EventKind::MerkleTreeInsertion => event(
+                MERKLE_EVENT_TYPE,
+                sequence,
+                merkle_data_for(
+                    sequence,
+                    H256::from_low_u64_be(2),
+                    dispatch_message(sequence, b"message").id(),
+                    100,
+                ),
+            ),
+        };
+
+        for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+            let sources = sources();
+            let source = &sources[&5];
+            let mut state = StreamState::default();
+            let validated = state
+                .validate(event_for(kind, 102), &sources)
+                .expect("stage event after a gap");
+            let mut staged = StagedParity::default();
+            staged.push(5, validated).expect("stage parity");
+
+            assert!(state
+                .validate_fresh_baseline(5, kind, 100)
+                .expect_err("fresh event must immediately follow its marker")
+                .to_string()
+                .contains("expected 101"));
+            assert_eq!(staged.len, 1, "rejected parity remains unadmitted");
+            assert_eq!(source.cursor(kind).expect("stream cursor"), None);
+            assert_eq!(
+                source.correlation_cursor().expect("correlation cursor"),
+                None
+            );
+
+            let mut contiguous = StreamState::default();
+            contiguous
+                .validate(event_for(kind, 101), &sources)
+                .expect("stage contiguous event");
+            contiguous
+                .validate_fresh_baseline(5, kind, 100)
+                .expect("baseline accepts its immediate successor");
+        }
+
+        StreamState::default()
+            .validate_fresh_baseline(5, EventKind::Dispatch, 100)
+            .expect("a stream without staged events may catch up at any positive marker");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -544,10 +544,10 @@ impl ScraperWebSocketMonitor {
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
         for source in sources.values() {
-            active.with_label_values(&[&source.chain]).set(0);
+            active.with_label_values(&[source.chain.as_str()]).set(0);
             for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
                 caught_up
-                    .with_label_values(&[&source.chain, kind.label()])
+                    .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
             }
         }
@@ -719,7 +719,9 @@ impl ScraperWebSocketMonitor {
     fn set_active(&self, active: bool) {
         let value = i64::from(active);
         for source in self.sources.values() {
-            self.active.with_label_values(&[&source.chain]).set(value);
+            self.active
+                .with_label_values(&[source.chain.as_str()])
+                .set(value);
         }
     }
 
@@ -733,7 +735,7 @@ impl ScraperWebSocketMonitor {
 
     fn set_source_caught_up(&self, source: &ScraperSource, kind: EventKind, caught_up: bool) {
         self.caught_up
-            .with_label_values(&[&source.chain, kind.label()])
+            .with_label_values(&[source.chain.as_str(), kind.label()])
             .set(i64::from(caught_up));
     }
 

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,6 +1,9 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 
 use eyre::{bail, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
@@ -10,9 +13,10 @@ use hyperlane_base::{
     },
     CoreMetrics,
 };
-use hyperlane_core::{bytes_to_address, H256};
+use hyperlane_core::{bytes_to_address, bytes_to_h512, HyperlaneMessage, H256, H512};
 use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::Deserialize;
+use sha3::{Digest, Keccak256};
 use tokio::time::{sleep, timeout, Instant};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{info, warn};
@@ -22,6 +26,7 @@ const DISPATCH_EVENT_TYPE: &str = "dispatch";
 const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
+const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
@@ -63,6 +68,57 @@ enum SequenceResult {
     Duplicate,
 }
 
+type EventFingerprint = H256;
+
+#[derive(Debug)]
+struct StreamCursor {
+    fingerprints: BTreeMap<u32, EventFingerprint>,
+    next_sequence: u32,
+}
+
+impl StreamCursor {
+    fn new(sequence: u32, fingerprint: EventFingerprint) -> Result<Self> {
+        let mut fingerprints = BTreeMap::new();
+        fingerprints.insert(sequence, fingerprint);
+        Ok(Self {
+            fingerprints,
+            next_sequence: sequence
+                .checked_add(1)
+                .context("Scraper event sequence exhausted")?,
+        })
+    }
+
+    fn validate(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<SequenceResult> {
+        if sequence < self.next_sequence {
+            return match self.fingerprints.get(&sequence) {
+                Some(previous) if previous == &fingerprint => Ok(SequenceResult::Duplicate),
+                Some(_) => bail!("Conflicting scraper event at sequence {sequence}"),
+                None => bail!(
+                    "Scraper event sequence {sequence} is older than the retained duplicate window"
+                ),
+            };
+        }
+        if sequence > self.next_sequence {
+            return Err(StreamGap {
+                expected: self.next_sequence,
+                received: sequence,
+            }
+            .into());
+        }
+
+        let next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .context("Scraper event sequence exhausted")?;
+        self.fingerprints.insert(sequence, fingerprint);
+        while self.fingerprints.len() > DUPLICATE_FINGERPRINT_WINDOW {
+            self.fingerprints.pop_first();
+        }
+        self.next_sequence = next_sequence;
+        Ok(SequenceResult::Accepted)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("Scraper stream gap: expected sequence {expected}, received {received}")]
 struct StreamGap {
@@ -72,7 +128,7 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
-    next_sequences: HashMap<(u32, EventKind), u32>,
+    cursors: HashMap<(u32, EventKind), StreamCursor>,
 }
 
 impl StreamState {
@@ -91,20 +147,61 @@ impl StreamState {
             .parse::<u32>()
             .context("Invalid scraper event sequence")?;
 
-        let kind = match event.event_type.as_str() {
+        let (kind, fingerprint) = match event.event_type.as_str() {
             DISPATCH_EVENT_TYPE => {
                 let data: DispatchEventData =
                     serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
                 if data.origin_domain != event.domain {
                     bail!("Dispatch payload domain does not match event envelope");
                 }
-                if parse_address(&data.origin_mailbox)? != source.mailbox {
+                let origin_mailbox = parse_address(&data.origin_mailbox)?;
+                if origin_mailbox != source.mailbox {
                     bail!("Dispatch event mailbox does not match configured mailbox");
                 }
-                if data.nonce.as_u32("dispatch nonce")? != sequence {
+                let nonce = data.nonce.as_u32("dispatch nonce")?;
+                if nonce != sequence {
                     bail!("Dispatch event nonce does not match stream sequence");
                 }
-                EventKind::Dispatch
+                let body = parse_hex(
+                    data.msg_body
+                        .as_deref()
+                        .context("Dispatch event omitted message body")?,
+                )?;
+                let message = HyperlaneMessage {
+                    version: 3,
+                    nonce,
+                    origin: data.origin_domain,
+                    sender: parse_address(&data.sender)?,
+                    destination: data.destination_domain,
+                    recipient: parse_address(&data.recipient)?,
+                    body,
+                };
+                let message_id = parse_h256(&data.msg_id, "dispatch message ID")?;
+                if message.id() != message_id {
+                    bail!("Dispatch message ID does not match reconstructed message");
+                }
+                if data.time_created.is_empty() {
+                    bail!("Dispatch event omitted creation time");
+                }
+                let origin_block_hash = parse_h256(&data.origin_block_hash, "origin block hash")?;
+                let origin_block_height = data.origin_block_height.as_u64("origin block height")?;
+                let origin_tx_hash = parse_h512(&data.origin_tx_hash)?;
+                let row_id = data.id.as_u64("dispatch row ID")?;
+                let row_id_bytes = row_id.to_be_bytes();
+                let origin_block_height_bytes = origin_block_height.to_be_bytes();
+                (
+                    EventKind::Dispatch,
+                    event_fingerprint(&[
+                        b"dispatch",
+                        &row_id_bytes,
+                        message_id.as_ref(),
+                        origin_block_hash.as_ref(),
+                        &origin_block_height_bytes,
+                        origin_mailbox.as_ref(),
+                        origin_tx_hash.as_ref(),
+                        data.time_created.as_bytes(),
+                    ]),
+                )
             }
             MERKLE_EVENT_TYPE => {
                 let data: MerkleEventData = serde_json::from_value(event.data)
@@ -112,44 +209,74 @@ impl StreamState {
                 if data.domain != event.domain {
                     bail!("Merkle payload domain does not match event envelope");
                 }
-                if parse_address(&data.merkle_tree_hook)? != source.merkle_tree_hook {
+                let merkle_tree_hook = parse_address(&data.merkle_tree_hook)?;
+                if merkle_tree_hook != source.merkle_tree_hook {
                     bail!("Merkle event hook does not match configured hook");
                 }
-                if data.leaf_index.as_u32("Merkle leaf index")? != sequence {
+                let leaf_index = data.leaf_index.as_u32("Merkle leaf index")?;
+                if leaf_index != sequence {
                     bail!("Merkle leaf index does not match stream sequence");
                 }
-                EventKind::MerkleTreeInsertion
+                let block_number = data.block_number.as_u64("Merkle block number")?;
+                let block_number_bytes = block_number.to_be_bytes();
+                let message_id = parse_h256(&data.message_id, "Merkle message ID")?;
+                (
+                    EventKind::MerkleTreeInsertion,
+                    event_fingerprint(&[
+                        b"merkle_tree_insertion",
+                        &block_number_bytes,
+                        merkle_tree_hook.as_ref(),
+                        message_id.as_ref(),
+                    ]),
+                )
             }
             event_type => bail!("Unexpected scraper event type {event_type}"),
         };
 
         let key = (event.domain, kind);
-        let result = match self.next_sequences.get_mut(&key) {
+        let result = match self.cursors.get_mut(&key) {
+            Some(cursor) => cursor.validate(sequence, fingerprint)?,
             None => {
-                self.next_sequences.insert(
-                    key,
-                    sequence
-                        .checked_add(1)
-                        .context("Scraper event sequence exhausted")?,
-                );
+                self.cursors
+                    .insert(key, StreamCursor::new(sequence, fingerprint)?);
                 SequenceResult::Accepted
-            }
-            Some(next_sequence) if sequence < *next_sequence => SequenceResult::Duplicate,
-            Some(next_sequence) if sequence == *next_sequence => {
-                *next_sequence = next_sequence
-                    .checked_add(1)
-                    .context("Scraper event sequence exhausted")?;
-                SequenceResult::Accepted
-            }
-            Some(next_sequence) => {
-                return Err(StreamGap {
-                    expected: *next_sequence,
-                    received: sequence,
-                }
-                .into())
             }
         };
         Ok((kind, result))
+    }
+}
+
+#[derive(Debug, Default)]
+struct HandshakeState {
+    confirmed: bool,
+    sent: bool,
+}
+
+impl HandshakeState {
+    fn ready(&mut self) -> Result<()> {
+        if self.sent {
+            bail!("Received duplicate scraper-proxy ready message");
+        }
+        self.sent = true;
+        Ok(())
+    }
+
+    fn subscribed(&mut self) -> Result<()> {
+        if !self.sent {
+            bail!("Received subscribed before ready");
+        }
+        if self.confirmed {
+            bail!("Received duplicate scraper-proxy subscribed message");
+        }
+        self.confirmed = true;
+        Ok(())
+    }
+
+    fn event(&self) -> Result<()> {
+        if !self.confirmed {
+            bail!("Received scraper event before subscription confirmation");
+        }
+        Ok(())
     }
 }
 
@@ -193,9 +320,10 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
+        let mut state = StreamState::default();
         loop {
             self.set_active(false);
-            match self.stream().await {
+            match self.stream(&mut state).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
                     ?err,
@@ -207,13 +335,12 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn stream(&self) -> Result<()> {
+    async fn stream(&self, state: &mut StreamState) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
-        let mut subscribed = false;
-        let mut state = StreamState::default();
+        let mut handshake = HandshakeState::default();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -231,23 +358,19 @@ impl ScraperWebSocketMonitor {
                         .context("Parsing relayer scraper-proxy WebSocket message")?;
                     match message {
                         ServerMessage::Ready => {
-                            if subscribed {
-                                bail!("Received duplicate scraper-proxy ready message");
-                            }
+                            handshake.ready()?;
                             socket
                                 .send(Message::Text(self.subscription()?))
                                 .await
                                 .context("Subscribing to relayer scraper-proxy streams")?;
-                            subscribed = true;
                         }
                         ServerMessage::Subscribed => {
-                            if !subscribed {
-                                bail!("Received subscribed before ready");
-                            }
+                            handshake.subscribed()?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
                         ServerMessage::Event(event) => {
+                            handshake.event()?;
                             let domain = event.domain;
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
@@ -334,26 +457,68 @@ fn subscription(mut domains: Vec<u32>) -> Result<String> {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DispatchEventData {
+    destination_domain: u32,
+    id: StringOrNumber,
+    msg_body: Option<String>,
+    msg_id: String,
     nonce: StringOrNumber,
+    origin_block_hash: String,
+    origin_block_height: StringOrNumber,
     origin_domain: u32,
     origin_mailbox: String,
+    origin_tx_hash: String,
+    recipient: String,
+    sender: String,
+    time_created: String,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct MerkleEventData {
+    block_number: StringOrNumber,
     domain: u32,
     leaf_index: StringOrNumber,
     merkle_tree_hook: String,
+    message_id: String,
 }
 
 fn parse_address(value: &str) -> Result<H256> {
+    bytes_to_address(parse_hex(value)?).context("Invalid scraper event address")
+}
+
+fn parse_h256(value: &str, field: &str) -> Result<H256> {
+    let bytes = parse_hex(value)?;
+    if bytes.len() != 32 {
+        bail!("Invalid {field} length {}", bytes.len());
+    }
+    Ok(H256::from_slice(&bytes))
+}
+
+fn parse_h512(value: &str) -> Result<H512> {
+    let bytes = parse_hex(value)?;
+    if !matches!(bytes.len(), 32 | 64) {
+        bail!("Invalid origin transaction hash length {}", bytes.len());
+    }
+    Ok(bytes_to_h512(&bytes))
+}
+
+fn event_fingerprint(fields: &[&[u8]]) -> H256 {
+    let mut hasher = Keccak256::new();
+    for field in fields {
+        hasher.update((field.len() as u64).to_be_bytes());
+        hasher.update(field);
+    }
+    H256::from_slice(&hasher.finalize())
+}
+
+fn parse_hex(value: &str) -> Result<Vec<u8>> {
     let value = value
         .strip_prefix("0x")
         .or_else(|| value.strip_prefix("\\x"))
         .unwrap_or(value);
-    bytes_to_address(hex::decode(value).context("Invalid hexadecimal scraper event address")?)
-        .context("Invalid scraper event address")
+    hex::decode(value).context("Invalid hexadecimal scraper event field")
 }
 
 fn event_label(event_type: &str) -> &'static str {
@@ -393,52 +558,139 @@ mod tests {
         }
     }
 
-    #[test]
-    fn accepts_contiguous_dispatch_and_rejects_gap() {
-        let sources = sources();
-        let mut state = StreamState::default();
-        let data = |nonce| {
-            serde_json::json!({
-                "nonce": nonce,
-                "origin_domain": 5,
-                "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(1)),
-            })
+    fn dispatch_data(nonce: u32, body: &[u8]) -> serde_json::Value {
+        let message = HyperlaneMessage {
+            version: 3,
+            nonce,
+            origin: 5,
+            sender: H256::from_low_u64_be(3),
+            destination: 6,
+            recipient: H256::from_low_u64_be(4),
+            body: body.to_vec(),
         };
+        serde_json::json!({
+            "destination_domain": message.destination,
+            "id": "42",
+            "msg_body": format!("\\x{}", hex::encode(&message.body)),
+            "msg_id": format!("{:#x}", message.id()),
+            "nonce": nonce,
+            "origin_block_hash": format!("{:#x}", H256::from_low_u64_be(5)),
+            "origin_block_height": "100",
+            "origin_domain": message.origin,
+            "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(1)),
+            "origin_tx_hash": format!("\\x{}", hex::encode([6_u8; 32])),
+            "recipient": format!("{:#x}", message.recipient),
+            "sender": format!("{:#x}", message.sender),
+            "time_created": "2026-08-30T00:00:00.000Z",
+        })
+    }
+
+    fn merkle_data(index: u32, hook: H256) -> serde_json::Value {
+        serde_json::json!({
+            "block_number": "101",
+            "domain": 5,
+            "leaf_index": index,
+            "merkle_tree_hook": format!("{hook:#x}"),
+            "message_id": format!("{:#x}", H256::from_low_u64_be(7)),
+        })
+    }
+
+    #[test]
+    fn preserves_sequence_across_reconnects() {
+        let sources = sources();
+        let mut contiguous = StreamState::default();
 
         assert_eq!(
-            state
-                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
+            contiguous
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                    &sources,
+                )
                 .expect("first event"),
             (EventKind::Dispatch, SequenceResult::Accepted)
         );
         assert_eq!(
-            state
-                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
-                .expect("duplicate event"),
+            contiguous
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                    &sources,
+                )
+                .expect("duplicate event after reconnect"),
             (EventKind::Dispatch, SequenceResult::Duplicate)
         );
-        assert!(state
-            .validate(event(DISPATCH_EVENT_TYPE, 9, data(9)), &sources)
+        assert_eq!(
+            contiguous
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"eight")),
+                    &sources,
+                )
+                .expect("next event after reconnect"),
+            (EventKind::Dispatch, SequenceResult::Accepted)
+        );
+
+        let mut gapped = StreamState::default();
+        gapped
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("first event before reconnect");
+        assert!(gapped
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
+                &sources,
+            )
             .expect_err("gap must reject")
             .to_string()
             .contains("expected sequence 8"));
     }
 
     #[test]
-    fn rejects_wrong_dispatch_mailbox() {
-        let error = StreamState::default()
+    fn rejects_conflicting_duplicate_dispatch() {
+        let sources = sources();
+        let mut state = StreamState::default();
+        state
             .validate(
-                event(
-                    DISPATCH_EVENT_TYPE,
-                    7,
-                    serde_json::json!({
-                        "nonce": 7,
-                        "origin_domain": 5,
-                        "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(3)),
-                    }),
-                ),
-                &sources(),
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"original")),
+                &sources,
             )
+            .expect("first event");
+
+        assert!(state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"conflict")),
+                &sources,
+            )
+            .expect_err("conflicting duplicate must reject")
+            .to_string()
+            .contains("Conflicting scraper event"));
+    }
+
+    #[test]
+    fn rejects_invalid_dispatch_payload() {
+        let mut bad_body = dispatch_data(7, b"original");
+        bad_body["msg_body"] = serde_json::json!("\\x00");
+        assert!(StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_body), &sources())
+            .expect_err("message ID mismatch must reject")
+            .to_string()
+            .contains("message ID"));
+
+        let mut bad_sender = dispatch_data(7, b"original");
+        bad_sender["sender"] = serde_json::json!("0x12");
+        assert!(StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_sender), &sources())
+            .expect_err("invalid sender must reject")
+            .to_string()
+            .contains("address"));
+    }
+
+    #[test]
+    fn rejects_wrong_dispatch_mailbox() {
+        let mut data = dispatch_data(7, b"payload");
+        data["origin_mailbox"] = serde_json::json!(format!("{:#x}", H256::from_low_u64_be(3)));
+        let error = StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, data), &sources())
             .expect_err("wrong mailbox must reject");
 
         assert!(error.to_string().contains("configured mailbox"));
@@ -452,17 +704,56 @@ mod tests {
                 event(
                     MERKLE_EVENT_TYPE,
                     1,
-                    serde_json::json!({
-                        "domain": 5,
-                        "leaf_index": "1",
-                        "merkle_tree_hook": format!("{:#x}", H256::from_low_u64_be(3)),
-                    }),
+                    merkle_data(1, H256::from_low_u64_be(3)),
                 ),
                 &sources(),
             )
             .expect_err("wrong hook must reject");
 
         assert!(error.to_string().contains("configured hook"));
+    }
+
+    #[test]
+    fn validates_merkle_payload_fields() {
+        let mut data = merkle_data(1, H256::from_low_u64_be(2));
+        data["message_id"] = serde_json::json!("0x12");
+        assert!(StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, data), &sources())
+            .expect_err("invalid message ID must reject")
+            .to_string()
+            .contains("Merkle message ID"));
+    }
+
+    #[test]
+    fn rejects_fields_outside_wire_projection() {
+        let mut dispatch = dispatch_data(7, b"payload");
+        dispatch["time_updated"] = serde_json::json!("2026-08-30T00:00:01.000Z");
+        assert!(StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, dispatch), &sources())
+            .expect_err("unprojected dispatch field must reject")
+            .to_string()
+            .contains("Invalid dispatch event payload"));
+
+        let mut merkle = merkle_data(1, H256::from_low_u64_be(2));
+        merkle["id"] = serde_json::json!(42);
+        assert!(StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, merkle), &sources())
+            .expect_err("unprojected Merkle field must reject")
+            .to_string()
+            .contains("Invalid Merkle tree insertion payload"));
+    }
+
+    #[test]
+    fn enforces_subscription_handshake_order() {
+        let mut handshake = HandshakeState::default();
+        assert!(handshake.event().is_err());
+        assert!(handshake.subscribed().is_err());
+        handshake.ready().expect("ready");
+        assert!(handshake.event().is_err());
+        handshake.subscribed().expect("subscribed");
+        handshake.event().expect("event after confirmation");
+        assert!(handshake.subscribed().is_err());
+        assert!(handshake.ready().is_err());
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1012,6 +1012,26 @@ fn caught_up_baselines(
     ))
 }
 
+fn validate_fresh_empty_stream_starts(state: &StreamState, domain: u32) -> Result<()> {
+    for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+        let Some(cursor) = state.cursors.get(&(domain, kind)) else {
+            continue;
+        };
+        let first = cursor
+            .fingerprints
+            .first_key_value()
+            .map(|(sequence, _)| *sequence)
+            .context("Fresh scraper stream cursor omitted its first fingerprint")?;
+        if first != 0 {
+            bail!(
+                "Fresh empty {} scraper stream started at sequence {first}, expected 0",
+                kind.label()
+            );
+        }
+    }
+    Ok(())
+}
+
 fn sequenced_persistence_ready(
     plan: &SequencedReplayPlan,
     caught_up: &HashMap<(u32, EventKind), i64>,
@@ -1034,9 +1054,7 @@ fn sequenced_persistence_ready(
     if state.correlation_next.contains_key(&domain) {
         return Ok(true);
     }
-    if sequence != 0 {
-        bail!("Fresh empty scraper stream started at sequence {sequence}, expected 0");
-    }
+    validate_fresh_empty_stream_starts(state, domain)?;
     Ok(state.cross_stream.complete(domain, sequence))
 }
 
@@ -1092,6 +1110,9 @@ fn source_caught_up(
     if !correlation_required {
         if dispatch != merkle {
             bail!("Fresh scraper caught-up baselines differ: dispatch {dispatch}, Merkle {merkle}");
+        }
+        if dispatch < 0 {
+            validate_fresh_empty_stream_starts(state, domain)?;
         }
         return Ok(true);
     }
@@ -1688,7 +1709,6 @@ mod tests {
             source.correlation_cursor().expect("correlation cursor"),
             None
         );
-
         state
             .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
             .expect("set fresh Merkle baseline");
@@ -1858,6 +1878,20 @@ mod tests {
             source.correlation_cursor().expect("correlation cursor"),
             None
         );
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                &sources,
+            )
+            .expect("second dispatch event");
+        assert!(
+            !sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
+                .expect("persistence readiness")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
 
         state
             .validate(
@@ -1880,8 +1914,8 @@ mod tests {
         assert_eq!(
             cursors,
             [
-                (EventKind::Dispatch, 0),
                 (EventKind::MerkleTreeInsertion, 0),
+                (EventKind::Dispatch, 1),
             ]
         );
         for (kind, sequence) in cursors {
@@ -1905,7 +1939,7 @@ mod tests {
 
         assert_eq!(
             source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
-            Some(0)
+            Some(1)
         );
         assert_eq!(
             source
@@ -1919,10 +1953,19 @@ mod tests {
         );
         state
             .validate(
-                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                event(
+                    MERKLE_EVENT_TYPE,
+                    1,
+                    merkle_data_for(
+                        1,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(1, b"one").id(),
+                        100,
+                    ),
+                ),
                 &sources,
             )
-            .expect("next dispatch event");
+            .expect("next Merkle event");
         assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
             .expect("initialized persistence readiness"));
         let reconnect_plan = replay_plan(&sources);
@@ -1936,6 +1979,90 @@ mod tests {
         .expect("subscription JSON");
         assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "-1");
         assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "-1");
+    }
+
+    #[test]
+    fn fresh_empty_merkle_can_advance_while_waiting_for_dispatch() {
+        let sources = sources();
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut state = replay_state(&plan);
+        for sequence in 0..=1 {
+            state
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(
+                            sequence,
+                            H256::from_low_u64_be(2),
+                            dispatch_message(sequence, &[sequence as u8]).id(),
+                            100,
+                        ),
+                    ),
+                    &sources,
+                )
+                .expect("Merkle event while dispatch is pending");
+            assert!(
+                !sequenced_persistence_ready(&plan, &caught_up, &state, 5, sequence)
+                    .expect("persistence readiness")
+            );
+        }
+
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, &[0])),
+                &sources,
+            )
+            .expect("first dispatch event");
+        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
+            .expect("persistence readiness"));
+        assert_eq!(
+            sequenced_cursor_write_order(&state, 5).expect("cursor write order"),
+            [
+                (EventKind::Dispatch, 0),
+                (EventKind::MerkleTreeInsertion, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn fresh_empty_peer_marker_rejects_staged_nonzero_start() {
+        for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+            let sources = sources();
+            let plan = replay_plan(&sources);
+            let mut state = replay_state(&plan);
+            let first = match kind {
+                EventKind::Dispatch => event(DISPATCH_EVENT_TYPE, 5, dispatch_data(5, &[5])),
+                EventKind::MerkleTreeInsertion => event(
+                    MERKLE_EVENT_TYPE,
+                    5,
+                    merkle_data_for(
+                        5,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(5, &[5]).id(),
+                        100,
+                    ),
+                ),
+            };
+            state
+                .validate(first, &sources)
+                .expect("staged first nonzero event");
+            let peer = match kind {
+                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
+                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
+            };
+            let mut caught_up = HashMap::from([((5, kind), -1)]);
+            assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one empty marker"));
+            caught_up.insert((5, peer), -1);
+            assert!(source_caught_up(false, &caught_up, &state, 5)
+                .expect_err("peer marker must reject staged nonzero start")
+                .to_string()
+                .contains("expected 0"));
+        }
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -103,6 +103,13 @@ impl EventKind {
         }
     }
 
+    fn counterpart(self) -> Self {
+        match self {
+            Self::Dispatch => Self::MerkleTreeInsertion,
+            Self::MerkleTreeInsertion => Self::Dispatch,
+        }
+    }
+
     fn from_label(label: &str) -> Result<Self> {
         match label {
             DISPATCH_EVENT_TYPE => Ok(Self::Dispatch),
@@ -662,7 +669,13 @@ impl ScraperWebSocketMonitor {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
-                                    self.record(domain, kind.label(), result)
+                                    self.record(domain, kind.label(), result);
+                                    self.update_source_caught_up(
+                                        state,
+                                        &correlation_required,
+                                        &caught_up,
+                                        domain,
+                                    )?;
                                 }
                                 Err(err) => {
                                     let result = if err.downcast_ref::<StreamGap>().is_some() {
@@ -714,22 +727,12 @@ impl ScraperWebSocketMonitor {
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            let counterpart = match kind {
-                                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
-                                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
-                            };
-                            if caught_up.get(&(domain, counterpart)) == Some(&sequence) {
-                                let correlation_complete = correlation_ready(
-                                    correlation_required.contains(&domain),
-                                    state,
-                                    domain,
-                                    sequence,
-                                )?;
-                                if correlation_complete {
-                                    self.set_source_caught_up(source, kind, true);
-                                    self.set_source_caught_up(source, counterpart, true);
-                                }
-                            }
+                            self.update_source_caught_up(
+                                state,
+                                &correlation_required,
+                                &caught_up,
+                                domain,
+                            )?;
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -777,6 +780,31 @@ impl ScraperWebSocketMonitor {
             .set(i64::from(caught_up));
     }
 
+    fn update_source_caught_up(
+        &self,
+        state: &StreamState,
+        correlation_required: &HashSet<u32>,
+        caught_up: &HashMap<(u32, EventKind), i64>,
+        domain: u32,
+    ) -> Result<()> {
+        if !source_caught_up(
+            correlation_required.contains(&domain),
+            caught_up,
+            state,
+            domain,
+        )? {
+            return Ok(());
+        }
+        let source = self
+            .sources
+            .get(&domain)
+            .context("Validated scraper source is missing")?;
+        for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+            self.set_source_caught_up(source, kind, true);
+        }
+        Ok(())
+    }
+
     fn record(&self, domain: u32, event_type: &str, result: &str) {
         let chain = self
             .sources
@@ -799,14 +827,7 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     let cursors = |kind| -> Result<Vec<SequenceCursor>> {
         sources
             .iter()
-            .map(|source| {
-                Ok(SequenceCursor {
-                    address: format!("{:#x}", source.address(kind)),
-                    allow_replay: Some(true),
-                    after_sequence: source.cursor(kind)?.map(replay_after_sequence),
-                    domain: source.domain,
-                })
-            })
+            .map(|source| sequence_cursor(source, kind))
             .collect()
     };
     serde_json::to_string(&SubscribeMessage {
@@ -825,6 +846,19 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
         message_type: "subscribe",
     })
     .context("Serializing relayer scraper-proxy subscription")
+}
+
+fn sequence_cursor(source: &ScraperSource, kind: EventKind) -> Result<SequenceCursor> {
+    let replay_from = match source.cursor(kind)? {
+        Some(sequence) => Some(sequence),
+        None => source.cursor(kind.counterpart())?,
+    };
+    Ok(SequenceCursor {
+        address: format!("{:#x}", source.address(kind)),
+        allow_replay: Some(true),
+        after_sequence: replay_from.map(replay_after_sequence),
+        domain: source.domain,
+    })
 }
 
 fn replay_after_sequence(sequence: u32) -> String {
@@ -851,6 +885,39 @@ fn correlation_ready(
     ))
 }
 
+fn source_caught_up(
+    correlation_required: bool,
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    state: &StreamState,
+    domain: u32,
+) -> Result<bool> {
+    let Some(dispatch) = caught_up.get(&(domain, EventKind::Dispatch)) else {
+        return Ok(false);
+    };
+    let Some(merkle) = caught_up.get(&(domain, EventKind::MerkleTreeInsertion)) else {
+        return Ok(false);
+    };
+    if !correlation_required {
+        return Ok(true);
+    }
+    let target = (*dispatch).max(*merkle);
+    if target < 0 {
+        return Ok(true);
+    }
+    let target: u32 = target
+        .try_into()
+        .context("Caught-up sequence exceeds u32")?;
+    for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+        let Some(cursor) = state.cursors.get(&(domain, kind)) else {
+            return Ok(false);
+        };
+        if cursor.latest_sequence()? < target {
+            return Ok(false);
+        }
+    }
+    correlation_ready(true, state, domain, i64::from(target))
+}
+
 fn validate_subscription(
     streams: &[SubscribedStream],
     sources: &HashMap<u32, ScraperSource>,
@@ -871,9 +938,10 @@ fn validate_subscription(
         let expected_cursors = sources
             .iter()
             .map(|source| {
+                let cursor = sequence_cursor(source, kind)?;
                 Ok(SubscribedCursor {
-                    address: format!("{:#x}", source.address(kind)),
-                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    address: cursor.address,
+                    after_sequence: cursor.after_sequence,
                     domain: source.domain,
                 })
             })
@@ -1072,13 +1140,13 @@ mod tests {
                 cursors: Some(
                     sources
                         .iter()
-                        .map(|source| SubscribedCursor {
-                            address: format!("{:#x}", source.address(kind)),
-                            after_sequence: source
-                                .cursor(kind)
-                                .expect("cursor read")
-                                .map(replay_after_sequence),
-                            domain: source.domain,
+                        .map(|source| {
+                            let cursor = sequence_cursor(source, kind).expect("cursor read");
+                            SubscribedCursor {
+                                address: cursor.address,
+                                after_sequence: cursor.after_sequence,
+                                domain: source.domain,
+                            }
                         })
                         .collect(),
                 ),
@@ -1233,6 +1301,67 @@ mod tests {
                 .expect("Merkle cursor"),
             7
         );
+    }
+
+    #[test]
+    fn restart_replays_missing_peer_and_rechecks_late_correlation() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 7)
+            .expect("store dispatch cursor");
+
+        let message: serde_json::Value =
+            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
+                .expect("subscription JSON");
+        assert_eq!(message["streams"][0]["cursors"][0]["afterSequence"], "6");
+        assert_eq!(message["streams"][1]["cursors"][0]["afterSequence"], "6");
+        let streams = subscribed_streams(&sources);
+        assert_eq!(
+            streams[0].cursors.as_ref().expect("dispatch cursors")[0].after_sequence,
+            Some("6".to_owned())
+        );
+        assert_eq!(
+            streams[1].cursors.as_ref().expect("Merkle cursors")[0].after_sequence,
+            Some("6".to_owned())
+        );
+        validate_subscription(&streams, &sources).expect("subscription confirmation");
+
+        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("replay dispatch boundary");
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 7),
+            ((5, EventKind::MerkleTreeInsertion), 6),
+        ]);
+        assert!(!source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+
+        restarted
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(
+                        7,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(7, b"seven").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("late Merkle correlation");
+        assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+    }
+
+    #[test]
+    fn replay_includes_zero_boundary() {
+        assert_eq!(replay_after_sequence(0), "-1");
+        assert_eq!(replay_after_sequence(1), "0");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -994,6 +994,9 @@ fn source_caught_up(
         return Ok(false);
     };
     if !correlation_required {
+        if dispatch != merkle {
+            bail!("Fresh scraper caught-up baselines differ: dispatch {dispatch}, Merkle {merkle}");
+        }
         return Ok(true);
     }
     let target = (*dispatch).max(*merkle);
@@ -1545,6 +1548,52 @@ mod tests {
             ((5, EventKind::MerkleTreeInsertion), 100),
         ]);
         assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+    }
+
+    #[test]
+    fn fresh_unequal_baselines_reconnect_at_common_floor() {
+        let sources = sources();
+        let source = &sources[&5];
+        let initial_plan = replay_plan(&sources);
+        assert!(!initial_plan
+            .correlation_required(5)
+            .expect("correlation requirement"));
+
+        let mut state = replay_state(&initial_plan);
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store fresh dispatch baseline");
+        state
+            .set_baseline(5, EventKind::Dispatch, 100)
+            .expect("set fresh dispatch baseline");
+        let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
+        assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one fresh marker"));
+
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store fresh Merkle baseline");
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
+            .expect("set fresh Merkle baseline");
+        caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
+        assert!(source_caught_up(false, &caught_up, &state, 5)
+            .expect_err("unequal fresh baselines must reconnect")
+            .to_string()
+            .contains("Fresh scraper caught-up baselines differ"));
+
+        let reconnect_plan = replay_plan(&sources);
+        let source_plan = reconnect_plan.source(5).expect("source plan");
+        assert_eq!(source_plan.floor, Some(90));
+        assert_eq!(source_plan.correlation_next, Some(90));
+        assert!(reconnect_plan
+            .correlation_required(5)
+            .expect("correlation requirement"));
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &reconnect_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -8,14 +8,16 @@ use std::{
 use eyre::{bail, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
-    db::HyperlaneRocksDB,
+    db::{HyperlaneDb, HyperlaneRocksDB},
     scraper_websocket::{
         EventMessage, SequenceCursor, ServerMessage, StringOrNumber, SubscribeMessage,
         SubscribeStream, SubscribedCursor, SubscribedStream,
     },
     CoreMetrics,
 };
-use hyperlane_core::{bytes_to_address, bytes_to_h512, HyperlaneMessage, H256, H512};
+use hyperlane_core::{
+    bytes_to_address, bytes_to_h512, HyperlaneMessage, MerkleTreeInsertion, H256, H512,
+};
 use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::Deserialize;
 use sha3::{Digest, Keccak256};
@@ -37,26 +39,26 @@ const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor"
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
     chain: String,
-    db: HyperlaneRocksDB,
     domain: u32,
     mailbox: H256,
     merkle_tree_hook: H256,
+    database: HyperlaneRocksDB,
 }
 
 impl ScraperSource {
     pub(crate) fn new(
         chain: String,
-        db: HyperlaneRocksDB,
         domain: u32,
         mailbox: H256,
         merkle_tree_hook: H256,
+        database: HyperlaneRocksDB,
     ) -> Self {
         Self {
             chain,
-            db,
             domain,
             mailbox,
             merkle_tree_hook,
+            database,
         }
     }
 
@@ -68,7 +70,7 @@ impl ScraperSource {
     }
 
     fn cursor(&self, kind: EventKind) -> Result<Option<u32>> {
-        self.db
+        self.database
             .retrieve_value_by_key(kind.cursor_prefix(), &self.address(kind))
             .context("Reading durable scraper WebSocket cursor")
     }
@@ -106,7 +108,7 @@ impl ScraperSource {
         if self.cursor(kind)?.is_some_and(|stored| stored >= sequence) {
             return Ok(());
         }
-        self.db
+        self.database
             .store_value_by_key(kind.cursor_prefix(), &self.address(kind), &sequence)
             .context("Storing durable scraper WebSocket cursor")
     }
@@ -228,6 +230,23 @@ impl CrossStreamPair {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ParityResult {
+    Match,
+    Missing,
+    Conflict,
+}
+
+impl ParityResult {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Match => "match",
+            Self::Missing => "missing",
+            Self::Conflict => "conflict",
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct CrossStreamState {
     entries: HashMap<u32, BTreeMap<u32, CrossStreamPair>>,
@@ -295,6 +314,88 @@ impl CrossStreamState {
         let pair = entries.entry(sequence).or_default();
         *pair.get_mut(kind) = Some(projection);
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ValidatedEvent {
+    kind: EventKind,
+    parity: ParityInput,
+    sequence_result: SequenceResult,
+}
+
+#[derive(Debug)]
+enum ParityInput {
+    Dispatch {
+        block_number: u64,
+        message: HyperlaneMessage,
+        transaction_id: H512,
+    },
+    MerkleTreeInsertion {
+        block_number: u64,
+        insertion: MerkleTreeInsertion,
+    },
+}
+
+impl ParityInput {
+    fn compare(&self, source: &ScraperSource) -> Result<ParityResult> {
+        match self {
+            Self::Dispatch {
+                block_number,
+                message,
+                transaction_id,
+            } => {
+                let local_message = source
+                    .database
+                    .retrieve_message_by_nonce(message.nonce)
+                    .context("Reading RPC-indexed dispatch message")?;
+                let local_block_number = source
+                    .database
+                    .retrieve_dispatched_block_number_by_nonce(&message.nonce)
+                    .context("Reading RPC-indexed dispatch block number")?;
+                let local_transaction_id = source
+                    .database
+                    .retrieve_dispatched_tx_hash_by_message_id(&message.id())
+                    .context("Reading RPC-indexed dispatch transaction ID")?;
+                if local_message.as_ref().is_some_and(|local| local != message)
+                    || local_block_number.is_some_and(|local| local != *block_number)
+                    || local_transaction_id.is_some_and(|local| local != *transaction_id)
+                {
+                    return Ok(ParityResult::Conflict);
+                }
+                if local_message.is_none()
+                    || local_block_number.is_none()
+                    || local_transaction_id.is_none()
+                {
+                    return Ok(ParityResult::Missing);
+                }
+                Ok(ParityResult::Match)
+            }
+            Self::MerkleTreeInsertion {
+                block_number,
+                insertion,
+            } => {
+                let local_insertion = source
+                    .database
+                    .retrieve_merkle_tree_insertion_by_leaf_index(&insertion.index())
+                    .context("Reading RPC-indexed Merkle tree insertion")?;
+                let local_block_number = source
+                    .database
+                    .retrieve_merkle_tree_insertion_block_number_by_leaf_index(&insertion.index())
+                    .context("Reading RPC-indexed Merkle insertion block number")?;
+                if local_insertion
+                    .as_ref()
+                    .is_some_and(|local| local != insertion)
+                    || local_block_number.is_some_and(|local| local != *block_number)
+                {
+                    return Ok(ParityResult::Conflict);
+                }
+                if local_insertion.is_none() || local_block_number.is_none() {
+                    return Ok(ParityResult::Missing);
+                }
+                Ok(ParityResult::Match)
+            }
+        }
     }
 }
 
@@ -460,7 +561,7 @@ impl StreamState {
         &mut self,
         event: EventMessage<serde_json::Value>,
         sources: &HashMap<u32, ScraperSource>,
-    ) -> Result<(EventKind, SequenceResult)> {
+    ) -> Result<ValidatedEvent> {
         let source = sources
             .get(&event.domain)
             .with_context(|| format!("Unexpected scraper event domain {}", event.domain))?;
@@ -471,7 +572,7 @@ impl StreamState {
             .parse::<u32>()
             .context("Invalid scraper event sequence")?;
 
-        let (kind, fingerprint, projection) = match event.event_type.as_str() {
+        let (kind, fingerprint, projection, parity) = match event.event_type.as_str() {
             DISPATCH_EVENT_TYPE => {
                 let data: DispatchEventData =
                     serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
@@ -513,21 +614,27 @@ impl StreamState {
                 let row_id = data.id.as_u64("dispatch row ID")?;
                 let row_id_bytes = row_id.to_be_bytes();
                 let origin_block_height_bytes = origin_block_height.to_be_bytes();
+                let fingerprint = event_fingerprint(&[
+                    b"dispatch",
+                    &row_id_bytes,
+                    message_id.as_ref(),
+                    origin_block_hash.as_ref(),
+                    &origin_block_height_bytes,
+                    origin_mailbox.as_ref(),
+                    origin_tx_hash.as_ref(),
+                    data.time_created.as_bytes(),
+                ]);
                 (
                     EventKind::Dispatch,
-                    event_fingerprint(&[
-                        b"dispatch",
-                        &row_id_bytes,
-                        message_id.as_ref(),
-                        origin_block_hash.as_ref(),
-                        &origin_block_height_bytes,
-                        origin_mailbox.as_ref(),
-                        origin_tx_hash.as_ref(),
-                        data.time_created.as_bytes(),
-                    ]),
+                    fingerprint,
                     ProtocolProjection {
                         block_number: origin_block_height,
                         message_id,
+                    },
+                    ParityInput::Dispatch {
+                        block_number: origin_block_height,
+                        message,
+                        transaction_id: origin_tx_hash,
                     },
                 )
             }
@@ -560,6 +667,10 @@ impl StreamState {
                         block_number,
                         message_id,
                     },
+                    ParityInput::MerkleTreeInsertion {
+                        block_number,
+                        insertion: MerkleTreeInsertion::new(leaf_index, message_id),
+                    },
                 )
             }
             event_type => bail!("Unexpected scraper event type {event_type}"),
@@ -588,7 +699,11 @@ impl StreamState {
                 }
             }
         }
-        Ok((kind, result))
+        Ok(ValidatedEvent {
+            kind,
+            parity,
+            sequence_result: result,
+        })
     }
 }
 
@@ -637,6 +752,7 @@ pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
     caught_up: IntGaugeVec,
     events: IntCounterVec,
+    parity: IntCounterVec,
     sources: HashMap<u32, ScraperSource>,
     url: Url,
 }
@@ -662,6 +778,11 @@ impl ScraperWebSocketMonitor {
             "Whether scraper-proxy replay reached the durable cursor",
             &["chain", "event_type"],
         )?;
+        let parity = metrics.new_int_counter(
+            "relayer_scraper_websocket_parity",
+            "Read-only parity comparisons between scraper-proxy events and RPC-indexed local DB records",
+            &["chain", "event_type", "result"],
+        )?;
         let sources = sources
             .into_iter()
             .map(|source| (source.domain, source))
@@ -678,6 +799,7 @@ impl ScraperWebSocketMonitor {
             active,
             caught_up,
             events,
+            parity,
             sources,
             url,
         })
@@ -754,14 +876,17 @@ impl ScraperWebSocketMonitor {
                             let domain = event.domain;
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
-                                Ok((kind, sequence_result)) => {
-                                    let sequence = state.latest_sequence(domain, kind)?;
+                                Ok(validated) => {
                                     let source = self
                                         .sources
                                         .get(&domain)
                                         .expect("validated scraper source exists");
                                     if sequenced_persistence_ready(
-                                        plan, &caught_up, state, domain, sequence,
+                                        plan,
+                                        &caught_up,
+                                        state,
+                                        domain,
+                                        validated.sequence,
                                     )? {
                                         if caught_up_baselines(&caught_up, domain) == Some((-1, -1))
                                             && !state.correlation_next.contains_key(&domain)
@@ -772,22 +897,49 @@ impl ScraperWebSocketMonitor {
                                                 source.store_cursor(kind, sequence)?;
                                             }
                                         }
-                                        if let Some(sequence) =
-                                            state.initialize_correlation(domain, sequence)
+                                        if let Some(sequence) = state
+                                            .initialize_correlation(domain, validated.sequence)
                                         {
                                             source.store_correlation_cursor(sequence)?;
                                         }
                                         let correlation_next = state.advance_correlation(domain)?;
-                                        source.store_cursor(kind, sequence)?;
+                                        source.store_cursor(validated.kind, validated.sequence)?;
                                         if let Some(sequence) = correlation_next {
                                             source.store_correlation_cursor(sequence)?;
                                         }
                                     }
-                                    let result = match sequence_result {
+                                    let result = match validated.sequence_result {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
-                                    self.record(domain, kind.label(), result);
+                                    self.record(domain, validated.kind.label(), result);
+                                    let source = self.sources.get(&domain).context(
+                                        "Validated scraper event source unexpectedly missing",
+                                    )?;
+                                    match validated.parity.compare(source) {
+                                        Ok(parity_result) => {
+                                            self.record_parity(
+                                                domain,
+                                                validated.kind.label(),
+                                                parity_result.label(),
+                                            );
+                                            if parity_result == ParityResult::Conflict {
+                                                warn!(
+                                                    chain = %source.chain,
+                                                    event_type = validated.kind.label(),
+                                                    "Scraper event conflicts with RPC-indexed local DB"
+                                                );
+                                            }
+                                        }
+                                        Err(err) => {
+                                            self.record_parity(
+                                                domain,
+                                                validated.kind.label(),
+                                                "error",
+                                            );
+                                            return Err(err);
+                                        }
+                                    }
                                     self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
@@ -917,6 +1069,17 @@ impl ScraperWebSocketMonitor {
             .map(|source| source.chain.as_str())
             .unwrap_or("unknown");
         self.events
+            .with_label_values(&[chain, event_type, result])
+            .inc();
+    }
+
+    fn record_parity(&self, domain: u32, event_type: &str, result: &str) {
+        let chain = self
+            .sources
+            .get(&domain)
+            .map(|source| source.chain.as_str())
+            .unwrap_or("unknown");
+        self.parity
             .with_label_values(&[chain, event_type, result])
             .inc();
     }
@@ -1256,8 +1419,34 @@ fn event_label(event_type: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyperlane_base::db::test_utils;
+    use hyperlane_base::db::{test_utils, DB};
     use hyperlane_core::HyperlaneDomain;
+
+    struct Fixture {
+        _temp_dir: tempfile::TempDir,
+        sources: HashMap<u32, ScraperSource>,
+    }
+
+    fn source(database: HyperlaneRocksDB) -> ScraperSource {
+        ScraperSource::new(
+            "test".to_owned(),
+            5,
+            H256::from_low_u64_be(1),
+            H256::from_low_u64_be(2),
+            database,
+        )
+    }
+
+    fn fixture() -> Fixture {
+        let temp_dir = tempfile::tempdir().expect("temp DB directory");
+        let db = DB::from_path(temp_dir.path()).expect("open temp DB");
+        let database =
+            HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("scraper-parity"), db);
+        Fixture {
+            _temp_dir: temp_dir,
+            sources: HashMap::from([(5, source(database))]),
+        }
+    }
 
     fn sources() -> HashMap<u32, ScraperSource> {
         sources_for(&[5])
@@ -1278,10 +1467,10 @@ mod tests {
                     domain,
                     ScraperSource::new(
                         chain,
-                        db,
                         domain,
                         H256::from_low_u64_be(1),
                         H256::from_low_u64_be(2),
+                        db,
                     ),
                 )
             })
@@ -1330,6 +1519,34 @@ mod tests {
             "sender": format!("{:#x}", message.sender),
             "time_created": "2026-08-30T00:00:00.000Z",
         })
+    }
+
+    fn dispatch_transaction_id() -> H512 {
+        bytes_to_h512(&[6_u8; 32])
+    }
+
+    fn store_dispatch(source: &ScraperSource, message: &HyperlaneMessage) {
+        let message_id = message.id();
+        source
+            .database
+            .store_message_id_by_nonce(&message.nonce, &message_id)
+            .expect("store message ID");
+        source
+            .database
+            .store_message_by_id(&message_id, message)
+            .expect("store message");
+        source
+            .database
+            .store_dispatched_block_number_by_nonce(&message.nonce, &100)
+            .expect("store dispatch block");
+        source
+            .database
+            .store_dispatched_tx_hash_by_message_id(&message_id, &dispatch_transaction_id())
+            .expect("store dispatch transaction");
+    }
+
+    fn sequence(validated: ValidatedEvent) -> (EventKind, SequenceResult) {
+        (validated.kind, validated.sequence_result)
     }
 
     fn merkle_data(index: u32, hook: H256) -> serde_json::Value {
@@ -1395,34 +1612,41 @@ mod tests {
 
     #[test]
     fn preserves_sequence_across_reconnects() {
-        let sources = sources();
+        let fixture = fixture();
+        let sources = &fixture.sources;
         let mut contiguous = StreamState::default();
 
         assert_eq!(
-            contiguous
-                .validate(
-                    event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
-                    &sources,
-                )
-                .expect("first event"),
+            sequence(
+                contiguous
+                    .validate(
+                        event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                        sources,
+                    )
+                    .expect("first event"),
+            ),
             (EventKind::Dispatch, SequenceResult::Accepted)
         );
         assert_eq!(
-            contiguous
-                .validate(
-                    event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
-                    &sources,
-                )
-                .expect("duplicate event after reconnect"),
+            sequence(
+                contiguous
+                    .validate(
+                        event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                        sources,
+                    )
+                    .expect("duplicate event after reconnect"),
+            ),
             (EventKind::Dispatch, SequenceResult::Duplicate)
         );
         assert_eq!(
-            contiguous
-                .validate(
-                    event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"eight")),
-                    &sources,
-                )
-                .expect("next event after reconnect"),
+            sequence(
+                contiguous
+                    .validate(
+                        event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"eight")),
+                        sources,
+                    )
+                    .expect("next event after reconnect"),
+            ),
             (EventKind::Dispatch, SequenceResult::Accepted)
         );
 
@@ -1430,13 +1654,13 @@ mod tests {
         gapped
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
-                &sources,
+                sources,
             )
             .expect("first event before reconnect");
         assert!(gapped
             .validate(
                 event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
-                &sources,
+                sources,
             )
             .expect_err("gap must reject")
             .to_string()
@@ -2171,19 +2395,20 @@ mod tests {
 
     #[test]
     fn rejects_conflicting_duplicate_dispatch() {
-        let sources = sources();
+        let fixture = fixture();
+        let sources = &fixture.sources;
         let mut state = StreamState::default();
         state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"original")),
-                &sources,
+                sources,
             )
             .expect("first event");
 
         assert!(state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"conflict")),
-                &sources,
+                sources,
             )
             .expect_err("conflicting duplicate must reject")
             .to_string()
@@ -2191,11 +2416,154 @@ mod tests {
     }
 
     #[test]
+    fn dispatch_parity_handles_lag_duplicate_restart_and_conflict() {
+        let fixture = fixture();
+        let source = fixture.sources.get(&5).expect("source");
+        let message = dispatch_message(7, b"payload");
+        let data = dispatch_data(7, b"payload");
+        let mut state = StreamState::default();
+
+        let lagging = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, data.clone()),
+                &fixture.sources,
+            )
+            .expect("lagging event");
+        assert_eq!(
+            lagging.parity.compare(source).expect("lag comparison"),
+            ParityResult::Missing
+        );
+
+        store_dispatch(source, &message);
+        let duplicate = state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, data.clone()),
+                &fixture.sources,
+            )
+            .expect("duplicate event");
+        assert_eq!(duplicate.sequence_result, SequenceResult::Duplicate);
+        assert_eq!(
+            duplicate.parity.compare(source).expect("duplicate parity"),
+            ParityResult::Match
+        );
+
+        let restarted = StreamState::default()
+            .validate(event(DISPATCH_EVENT_TYPE, 7, data), &fixture.sources)
+            .expect("event after process restart");
+        assert_eq!(restarted.sequence_result, SequenceResult::Accepted);
+        assert_eq!(
+            restarted.parity.compare(source).expect("restart parity"),
+            ParityResult::Match
+        );
+
+        let mut conflict_data = dispatch_data(7, b"payload");
+        conflict_data["origin_block_height"] = serde_json::json!("101");
+        let conflict = StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, conflict_data),
+                &fixture.sources,
+            )
+            .expect("conflicting event payload");
+        assert_eq!(
+            conflict.parity.compare(source).expect("conflict parity"),
+            ParityResult::Conflict
+        );
+    }
+
+    #[test]
+    fn dispatch_parity_survives_database_restart() {
+        let temp_dir = tempfile::tempdir().expect("temp DB directory");
+        let message = dispatch_message(7, b"payload");
+        {
+            let db = DB::from_path(temp_dir.path()).expect("open temp DB");
+            let database =
+                HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("scraper-parity"), db);
+            store_dispatch(&source(database), &message);
+        }
+
+        let db = DB::from_path(temp_dir.path()).expect("reopen temp DB");
+        let database =
+            HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("scraper-parity"), db);
+        let sources = HashMap::from([(5, source(database))]);
+        let validated = StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &sources,
+            )
+            .expect("dispatch after restart");
+
+        assert_eq!(
+            validated
+                .parity
+                .compare(sources.get(&5).expect("source"))
+                .expect("restart comparison"),
+            ParityResult::Match
+        );
+    }
+
+    #[test]
+    fn merkle_parity_handles_lag_match_and_conflict() {
+        let fixture = fixture();
+        let source = fixture.sources.get(&5).expect("source");
+        let insertion = MerkleTreeInsertion::new(1, H256::from_low_u64_be(7));
+        let data = merkle_data(1, H256::from_low_u64_be(2));
+
+        let lagging = StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, data.clone()), &fixture.sources)
+            .expect("lagging Merkle event");
+        assert_eq!(
+            lagging.parity.compare(source).expect("lag comparison"),
+            ParityResult::Missing
+        );
+
+        source
+            .database
+            .store_merkle_tree_insertion_by_leaf_index(&1, &insertion)
+            .expect("store Merkle insertion");
+        source
+            .database
+            .store_merkle_tree_insertion_block_number_by_leaf_index(&1, &101)
+            .expect("store Merkle block");
+        let matched = StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, data), &fixture.sources)
+            .expect("matching Merkle event");
+        assert_eq!(
+            matched.parity.compare(source).expect("match comparison"),
+            ParityResult::Match
+        );
+
+        let mut conflict_data = merkle_data(1, H256::from_low_u64_be(2));
+        conflict_data["block_number"] = serde_json::json!("102");
+        let conflict = StreamState::default()
+            .validate(event(MERKLE_EVENT_TYPE, 1, conflict_data), &fixture.sources)
+            .expect("conflicting Merkle event");
+        assert_eq!(
+            conflict
+                .parity
+                .compare(source)
+                .expect("conflict comparison"),
+            ParityResult::Conflict
+        );
+    }
+
+    #[test]
     fn rejects_invalid_dispatch_payload() {
+        let fixture = fixture();
+        let mut missing_body = dispatch_data(7, b"original");
+        missing_body["msg_body"] = serde_json::Value::Null;
+        assert!(StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, missing_body),
+                &fixture.sources
+            )
+            .expect_err("missing body must reject")
+            .to_string()
+            .contains("omitted message body"));
+
         let mut bad_body = dispatch_data(7, b"original");
         bad_body["msg_body"] = serde_json::json!("\\x00");
         assert!(StreamState::default()
-            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_body), &sources())
+            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_body), &fixture.sources)
             .expect_err("message ID mismatch must reject")
             .to_string()
             .contains("message ID"));
@@ -2203,7 +2571,7 @@ mod tests {
         let mut bad_sender = dispatch_data(7, b"original");
         bad_sender["sender"] = serde_json::json!("0x12");
         assert!(StreamState::default()
-            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_sender), &sources())
+            .validate(event(DISPATCH_EVENT_TYPE, 7, bad_sender), &fixture.sources)
             .expect_err("invalid sender must reject")
             .to_string()
             .contains("address"));
@@ -2211,10 +2579,11 @@ mod tests {
 
     #[test]
     fn rejects_wrong_dispatch_mailbox() {
+        let fixture = fixture();
         let mut data = dispatch_data(7, b"payload");
         data["origin_mailbox"] = serde_json::json!(format!("{:#x}", H256::from_low_u64_be(3)));
         let error = StreamState::default()
-            .validate(event(DISPATCH_EVENT_TYPE, 7, data), &sources())
+            .validate(event(DISPATCH_EVENT_TYPE, 7, data), &fixture.sources)
             .expect_err("wrong mailbox must reject");
 
         assert!(error.to_string().contains("configured mailbox"));
@@ -2222,6 +2591,7 @@ mod tests {
 
     #[test]
     fn rejects_wrong_merkle_hook() {
+        let fixture = fixture();
         let mut state = StreamState::default();
         let error = state
             .validate(
@@ -2230,7 +2600,7 @@ mod tests {
                     1,
                     merkle_data(1, H256::from_low_u64_be(3)),
                 ),
-                &sources(),
+                &fixture.sources,
             )
             .expect_err("wrong hook must reject");
 
@@ -2239,10 +2609,11 @@ mod tests {
 
     #[test]
     fn validates_merkle_payload_fields() {
+        let fixture = fixture();
         let mut data = merkle_data(1, H256::from_low_u64_be(2));
         data["message_id"] = serde_json::json!("0x12");
         assert!(StreamState::default()
-            .validate(event(MERKLE_EVENT_TYPE, 1, data), &sources())
+            .validate(event(MERKLE_EVENT_TYPE, 1, data), &fixture.sources)
             .expect_err("invalid message ID must reject")
             .to_string()
             .contains("Merkle message ID"));
@@ -2250,10 +2621,11 @@ mod tests {
 
     #[test]
     fn rejects_fields_outside_wire_projection() {
+        let fixture = fixture();
         let mut dispatch = dispatch_data(7, b"payload");
         dispatch["time_updated"] = serde_json::json!("2026-08-30T00:00:01.000Z");
         assert!(StreamState::default()
-            .validate(event(DISPATCH_EVENT_TYPE, 7, dispatch), &sources())
+            .validate(event(DISPATCH_EVENT_TYPE, 7, dispatch), &fixture.sources)
             .expect_err("unprojected dispatch field must reject")
             .to_string()
             .contains("Invalid dispatch event payload"));
@@ -2261,7 +2633,7 @@ mod tests {
         let mut merkle = merkle_data(1, H256::from_low_u64_be(2));
         merkle["id"] = serde_json::json!(42);
         assert!(StreamState::default()
-            .validate(event(MERKLE_EVENT_TYPE, 1, merkle), &sources())
+            .validate(event(MERKLE_EVENT_TYPE, 1, merkle), &fixture.sources)
             .expect_err("unprojected Merkle field must reject")
             .to_string()
             .contains("Invalid Merkle tree insertion payload"));
@@ -2269,12 +2641,13 @@ mod tests {
 
     #[test]
     fn correlates_dispatch_and_merkle_projection() {
+        let fixture = fixture();
         let mut state = StreamState::default();
         let message = dispatch_message(7, b"payload");
         state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
-                &sources(),
+                &fixture.sources,
             )
             .expect("dispatch should validate");
         state
@@ -2284,19 +2657,20 @@ mod tests {
                     7,
                     merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 100),
                 ),
-                &sources(),
+                &fixture.sources,
             )
             .expect("matching Merkle insertion should validate");
     }
 
     #[test]
     fn rejects_cross_stream_message_and_block_mismatches() {
+        let fixture = fixture();
         let message = dispatch_message(7, b"payload");
         let mut wrong_message = StreamState::default();
         wrong_message
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
-                &sources(),
+                &fixture.sources,
             )
             .expect("dispatch should validate");
         assert!(wrong_message
@@ -2306,7 +2680,7 @@ mod tests {
                     7,
                     merkle_data_for(7, H256::from_low_u64_be(2), H256::from_low_u64_be(8), 100,),
                 ),
-                &sources(),
+                &fixture.sources,
             )
             .expect_err("message mismatch must reject")
             .to_string()
@@ -2316,7 +2690,7 @@ mod tests {
         wrong_block
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
-                &sources(),
+                &fixture.sources,
             )
             .expect("dispatch should validate");
         assert!(wrong_block
@@ -2326,7 +2700,7 @@ mod tests {
                     7,
                     merkle_data_for(7, H256::from_low_u64_be(2), message.id(), 101),
                 ),
-                &sources(),
+                &fixture.sources,
             )
             .expect_err("block mismatch must reject")
             .to_string()

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,7 +1,8 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
     time::Duration,
 };
 
@@ -36,6 +37,7 @@ const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const PARITY_READ_TIMEOUT: Duration = Duration::from_secs(1);
 const PARITY_READ_CONCURRENCY: usize = 4;
+const PARITY_WARN_INTERVAL: Duration = Duration::from_secs(60);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
@@ -98,8 +100,7 @@ pub(crate) struct ScraperSource {
     domain: u32,
     mailbox: H256,
     merkle_tree_hook: H256,
-    database: std::sync::Arc<dyn ParityDatabase>,
-    parity_read_permit: std::sync::Arc<Semaphore>,
+    database: Arc<dyn ParityDatabase>,
 }
 
 impl ScraperSource {
@@ -116,8 +117,7 @@ impl ScraperSource {
             domain,
             mailbox,
             merkle_tree_hook,
-            database: std::sync::Arc::new(database),
-            parity_read_permit: std::sync::Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
+            database: Arc::new(database),
         }
     }
 
@@ -127,7 +127,7 @@ impl ScraperSource {
         domain: u32,
         mailbox: H256,
         merkle_tree_hook: H256,
-        database: std::sync::Arc<dyn ParityDatabase>,
+        database: Arc<dyn ParityDatabase>,
     ) -> Self {
         let tempdir = tempfile::tempdir().expect("temporary scraper cursor DB");
         let db =
@@ -143,7 +143,6 @@ impl ScraperSource {
             mailbox,
             merkle_tree_hook,
             database,
-            parity_read_permit: std::sync::Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
         }
     }
 
@@ -833,6 +832,8 @@ pub(crate) struct ScraperWebSocketMonitor {
     caught_up: IntGaugeVec,
     events: IntCounterVec,
     parity: IntCounterVec,
+    parity_read_permit: Arc<Semaphore>,
+    parity_warned_at: Arc<parking_lot::Mutex<Option<Instant>>>,
     sources: HashMap<u32, ScraperSource>,
     url: Url,
 }
@@ -860,7 +861,7 @@ impl ScraperWebSocketMonitor {
         )?;
         let parity = metrics.new_int_counter(
             "relayer_scraper_websocket_parity",
-            "Read-only parity comparisons between scraper-proxy events and RPC-indexed local DB records",
+            "Read-only parity outcomes for scraper-proxy events against RPC-indexed local DB records",
             &["chain", "event_type", "result"],
         )?;
         let sources = sources
@@ -880,6 +881,8 @@ impl ScraperWebSocketMonitor {
             caught_up,
             events,
             parity,
+            parity_read_permit: Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
+            parity_warned_at: Arc::new(parking_lot::Mutex::new(None)),
             sources,
             url,
         })
@@ -929,22 +932,20 @@ impl ScraperWebSocketMonitor {
         let chain = source.chain.clone();
         let event_type = kind.label();
         let metrics = self.parity.clone();
-        let permit = match source.parity_read_permit.clone().try_acquire_owned() {
+        let permit = match self.parity_read_permit.clone().try_acquire_owned() {
             Ok(permit) => permit,
-            Err(err) => {
+            Err(_) => {
                 metrics
-                    .with_label_values(&[chain.as_str(), event_type, "error"])
+                    .with_label_values(&[chain.as_str(), event_type, "skipped"])
                     .inc();
-                warn!(
-                    %chain,
-                    event_type,
-                    ?err,
-                    "Local DB parity reader is busy; skipping comparison"
-                );
+                if should_warn(&self.parity_warned_at) {
+                    warn!(%chain, event_type, "Local DB parity reader is busy");
+                }
                 return None;
             }
         };
         let database = source.database.clone();
+        let warned_at = self.parity_warned_at.clone();
         let comparison = tokio::task::spawn_blocking(move || {
             let _permit = permit;
             parity_input.compare(database.as_ref())
@@ -961,7 +962,7 @@ impl ScraperWebSocketMonitor {
                     metrics
                         .with_label_values(&[chain.as_str(), event_type, parity_result.label()])
                         .inc();
-                    if parity_result == ParityResult::Conflict {
+                    if parity_result == ParityResult::Conflict && should_warn(&warned_at) {
                         warn!(
                             %chain,
                             event_type,
@@ -973,12 +974,14 @@ impl ScraperWebSocketMonitor {
                     metrics
                         .with_label_values(&[chain.as_str(), event_type, "error"])
                         .inc();
-                    warn!(
-                        %chain,
-                        event_type,
-                        ?err,
-                        "Local DB parity comparison failed"
-                    );
+                    if should_warn(&warned_at) {
+                        warn!(
+                            %chain,
+                            event_type,
+                            ?err,
+                            "Local DB parity comparison failed"
+                        );
+                    }
                 }
             }
         }))
@@ -1203,10 +1206,20 @@ impl ScraperWebSocketMonitor {
     }
 }
 
-fn subscription(
-    sources: &HashMap<u32, ScraperSource>,
-    plan: &SequencedReplayPlan,
-) -> Result<String> {
+fn should_warn(warned_at: &parking_lot::Mutex<Option<Instant>>) -> bool {
+    let now = Instant::now();
+    let mut warned_at = warned_at.lock();
+    if warned_at
+        .as_ref()
+        .is_some_and(|previous| now.duration_since(*previous) < PARITY_WARN_INTERVAL)
+    {
+        return false;
+    }
+    *warned_at = Some(now);
+    true
+}
+
+fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     let mut sources = sources.values().collect::<Vec<_>>();
     sources.sort_unstable_by_key(|source| source.domain);
     let domains = sources
@@ -2738,11 +2751,10 @@ mod tests {
                 &monitor.sources,
             )
             .expect("first event");
+        let started = std::time::Instant::now();
         let parity_task = monitor
             .observe_parity(5, first.kind, first.parity)
             .expect("parity task");
-
-        let started = std::time::Instant::now();
         let next = state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"next")),
@@ -2760,6 +2772,118 @@ mod tests {
                 .get(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn bounds_parity_reads_across_origins() {
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let release = Arc::new((parking_lot::Mutex::new(false), parking_lot::Condvar::new()));
+        let metrics = CoreMetrics::new("scraper-parity-global-bound", 9090, Registry::new())
+            .expect("create test metrics");
+        let mut sources = Vec::new();
+
+        for domain in 1..=(PARITY_READ_CONCURRENCY + 1) as u32 {
+            let mut database = MockParityDatabase::new();
+            if domain <= PARITY_READ_CONCURRENCY as u32 {
+                let entered_tx = entered_tx.clone();
+                let release = release.clone();
+                database
+                    .expect_retrieve_message_by_nonce()
+                    .times(1)
+                    .returning(move |_| {
+                        entered_tx.send(()).expect("record entered parity read");
+                        let (released, signal) = release.as_ref();
+                        let mut released = released.lock();
+                        while !*released {
+                            signal.wait(&mut released);
+                        }
+                        Err(hyperlane_base::db::DbError::Other(
+                            "released test read".to_owned(),
+                        ))
+                    });
+            }
+            sources.push(ScraperSource::with_database(
+                format!("test-{domain}"),
+                domain,
+                H256::from_low_u64_be(1),
+                H256::from_low_u64_be(2),
+                Arc::new(database),
+            ));
+        }
+        let monitor = ScraperWebSocketMonitor::new(
+            Url::parse("ws://localhost:1").expect("test URL"),
+            sources,
+            &metrics,
+        )
+        .expect("create test monitor");
+        let parity_input = |domain| ParityInput::Dispatch {
+            block_number: 100,
+            message: HyperlaneMessage {
+                version: 3,
+                nonce: domain,
+                origin: domain,
+                sender: H256::from_low_u64_be(3),
+                destination: 6,
+                recipient: H256::from_low_u64_be(4),
+                body: b"payload".to_vec(),
+            },
+            transaction_id: dispatch_transaction_id(),
+        };
+        let mut parity_tasks = Vec::new();
+        for domain in 1..=PARITY_READ_CONCURRENCY as u32 {
+            if let Some(task) =
+                monitor.observe_parity(domain, EventKind::Dispatch, parity_input(domain))
+            {
+                parity_tasks.push(task);
+            }
+        }
+        let entered = (0..PARITY_READ_CONCURRENCY)
+            .filter(|_| entered_rx.recv_timeout(Duration::from_millis(500)).is_ok())
+            .count();
+
+        let skipped_domain = (PARITY_READ_CONCURRENCY + 1) as u32;
+        let skipped_chain = format!("test-{skipped_domain}");
+        let skipped = monitor
+            .observe_parity(
+                skipped_domain,
+                EventKind::Dispatch,
+                parity_input(skipped_domain),
+            )
+            .is_none();
+        let skipped_count = monitor
+            .parity
+            .with_label_values(&[skipped_chain.as_str(), DISPATCH_EVENT_TYPE, "skipped"])
+            .get();
+
+        let (released, signal) = release.as_ref();
+        *released.lock() = true;
+        signal.notify_all();
+        let scheduled = parity_tasks.len();
+        for task in parity_tasks {
+            task.await.expect("parity task must not panic");
+        }
+        timeout(Duration::from_secs(1), async {
+            while monitor.parity_read_permit.available_permits() != PARITY_READ_CONCURRENCY {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("blocking reads release global permits");
+        assert_eq!(scheduled, PARITY_READ_CONCURRENCY);
+        assert_eq!(entered, PARITY_READ_CONCURRENCY);
+        assert!(skipped);
+        assert_eq!(skipped_count, 1);
+        assert_eq!(
+            monitor.parity_read_permit.available_permits(),
+            PARITY_READ_CONCURRENCY
+        );
+    }
+
+    #[test]
+    fn rate_limits_parity_warnings() {
+        let warned_at = parking_lot::Mutex::new(None);
+        assert!(should_warn(&warned_at));
+        assert!(!should_warn(&warned_at));
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,8 +1,11 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -23,7 +26,7 @@ use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::Deserialize;
 use sha3::{Digest, Keccak256};
 use tokio::{
-    sync::{Mutex, Semaphore},
+    sync::{OwnedSemaphorePermit, Semaphore},
     time::{sleep, timeout, Instant},
 };
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -36,7 +39,10 @@ const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const PARITY_READ_CONCURRENCY: usize = 4;
 const PARITY_QUEUE_CAPACITY: usize = 256;
+#[cfg(not(test))]
 const PARITY_READ_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const PARITY_READ_TIMEOUT: Duration = Duration::from_millis(250);
 #[cfg(not(test))]
 const PARITY_RETRY_DELAY: Duration = Duration::from_secs(1);
 #[cfg(test)]
@@ -423,6 +429,7 @@ impl CrossStreamState {
 struct ValidatedEvent {
     kind: EventKind,
     parity: ParityInput,
+    sequence: u32,
     sequence_result: SequenceResult,
 }
 
@@ -647,11 +654,16 @@ impl StreamState {
         Ok(())
     }
 
+    #[cfg(test)]
     fn latest_sequence(&self, domain: u32, kind: EventKind) -> Result<u32> {
         self.cursors
             .get(&(domain, kind))
             .context("Validated scraper stream has no cursor")?
             .latest_sequence()
+    }
+
+    fn has_cursor(&self, domain: u32, kind: EventKind) -> bool {
+        self.cursors.contains_key(&(domain, kind))
     }
 
     fn validate(
@@ -799,6 +811,7 @@ impl StreamState {
         Ok(ValidatedEvent {
             kind,
             parity,
+            sequence,
             sequence_result: result,
         })
     }
@@ -844,6 +857,18 @@ impl HandshakeState {
     }
 }
 
+struct ParityJob {
+    input: ParityInput,
+    queue_permit: OwnedSemaphorePermit,
+    sequence: u32,
+}
+
+#[derive(Default)]
+struct ParityQueue {
+    jobs: VecDeque<ParityJob>,
+    worker_running: bool,
+}
+
 /// One process-wide, read-only scraper stream monitor.
 pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
@@ -852,9 +877,10 @@ pub(crate) struct ScraperWebSocketMonitor {
     parity: IntCounterVec,
     parity_pending: IntGaugeVec,
     parity_queue_permit: Arc<Semaphore>,
+    parity_queues: HashMap<(u32, EventKind), Arc<parking_lot::Mutex<ParityQueue>>>,
     parity_ready: IntGaugeVec,
+    parity_read_disabled: AtomicBool,
     parity_read_permit: Arc<Semaphore>,
-    parity_order: HashMap<(u32, EventKind), Arc<Mutex<()>>>,
     parity_unhealthy: Arc<parking_lot::Mutex<std::collections::HashSet<(u32, EventKind)>>>,
     parity_warned_at: Arc<parking_lot::Mutex<Option<Instant>>>,
     sources: HashMap<u32, ScraperSource>,
@@ -902,7 +928,7 @@ impl ScraperWebSocketMonitor {
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
         let mut parity_unhealthy = HashSet::new();
-        let mut parity_order = HashMap::new();
+        let mut parity_queues = HashMap::new();
         for source in sources.values() {
             active.with_label_values(&[source.chain.as_str()]).set(0);
             for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
@@ -915,7 +941,10 @@ impl ScraperWebSocketMonitor {
                 parity_ready
                     .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
-                parity_order.insert((source.domain, kind), Arc::new(Mutex::new(())));
+                parity_queues.insert(
+                    (source.domain, kind),
+                    Arc::new(parking_lot::Mutex::new(ParityQueue::default())),
+                );
                 if source.parity_unhealthy(kind)? {
                     parity_unhealthy.insert((source.domain, kind));
                 }
@@ -928,9 +957,10 @@ impl ScraperWebSocketMonitor {
             parity,
             parity_pending,
             parity_queue_permit: Arc::new(Semaphore::new(PARITY_QUEUE_CAPACITY)),
+            parity_queues,
             parity_ready,
+            parity_read_disabled: AtomicBool::new(false),
             parity_read_permit: Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
-            parity_order,
             parity_unhealthy: Arc::new(parking_lot::Mutex::new(parity_unhealthy)),
             parity_warned_at: Arc::new(parking_lot::Mutex::new(None)),
             sources,
@@ -968,6 +998,7 @@ impl ScraperWebSocketMonitor {
         }
     }
 
+    #[cfg(test)]
     async fn observe_parity(
         &self,
         domain: u32,
@@ -1001,23 +1032,38 @@ impl ScraperWebSocketMonitor {
         let database = source.database.clone();
         let mut terminal = None;
         for attempt in 1..=PARITY_RETRY_ATTEMPTS {
+            if self.parity_read_disabled.load(Ordering::Acquire) {
+                terminal = Some("error");
+                break;
+            }
             let database = database.clone();
             let parity_input = parity_input.clone();
-            let permit = self
-                .parity_read_permit
-                .clone()
-                .acquire_owned()
-                .await
-                .expect("parity semaphore is never closed");
+            let permit = match timeout(
+                PARITY_READ_TIMEOUT,
+                self.parity_read_permit.clone().acquire_owned(),
+            )
+            .await
+            {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_)) => unreachable!("parity semaphore is never closed"),
+                Err(_) => {
+                    self.disable_parity_reads(&chain, event_type, "read capacity timed out");
+                    terminal = Some("error");
+                    break;
+                }
+            };
+            if self.parity_read_disabled.load(Ordering::Acquire) {
+                drop(permit);
+                terminal = Some("error");
+                break;
+            }
             let mut comparison = tokio::task::spawn_blocking(move || {
                 let _permit = permit;
                 parity_input.compare(database.as_ref())
             });
             match timeout(PARITY_READ_TIMEOUT, &mut comparison).await {
                 Err(_) => {
-                    tokio::spawn(async move {
-                        let _ = comparison.await;
-                    });
+                    self.disable_parity_reads(&chain, event_type, "blocking read timed out");
                     terminal = Some("error");
                     break;
                 }
@@ -1066,6 +1112,23 @@ impl ScraperWebSocketMonitor {
         terminal
     }
 
+    fn disable_parity_reads(&self, chain: &str, event_type: &str, reason: &str) {
+        if !self.parity_read_disabled.swap(true, Ordering::AcqRel) {
+            warn!(
+                chain,
+                event_type, reason, "Disabling local DB parity reads until process restart"
+            );
+            for source in self.sources.values() {
+                for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                    self.parity_ready
+                        .with_label_values(&[source.chain.as_str(), kind.label()])
+                        .set(0);
+                    self.parity_unhealthy.lock().insert((source.domain, kind));
+                }
+            }
+        }
+    }
+
     async fn enqueue_parity(
         self: &Arc<Self>,
         domain: u32,
@@ -1073,48 +1136,123 @@ impl ScraperWebSocketMonitor {
         parity_input: ParityInput,
         sequence: u32,
     ) {
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper event source exists");
+        self.parity_ready
+            .with_label_values(&[source.chain.as_str(), kind.label()])
+            .set(0);
+        if self.parity_read_disabled.load(Ordering::Acquire) {
+            return;
+        }
         let queue_permit = self
             .parity_queue_permit
             .clone()
             .acquire_owned()
             .await
             .expect("parity queue semaphore is never closed");
+        if self.parity_read_disabled.load(Ordering::Acquire) {
+            return;
+        }
+        self.parity_pending
+            .with_label_values(&[source.chain.as_str(), kind.label()])
+            .inc();
+        let queue = self
+            .parity_queues
+            .get(&(domain, kind))
+            .expect("validated scraper stream has a parity queue")
+            .clone();
+        let start_worker = {
+            let mut queue = queue.lock();
+            queue.jobs.push_back(ParityJob {
+                input: parity_input,
+                queue_permit,
+                sequence,
+            });
+            if queue.worker_running {
+                false
+            } else {
+                queue.worker_running = true;
+                true
+            }
+        };
+        if start_worker {
+            let monitor = self.clone();
+            tokio::spawn(async move {
+                monitor.drain_parity_queue(domain, kind, queue).await;
+            });
+        }
+    }
+
+    async fn drain_parity_queue(
+        self: Arc<Self>,
+        domain: u32,
+        kind: EventKind,
+        queue: Arc<parking_lot::Mutex<ParityQueue>>,
+    ) {
+        loop {
+            let job = {
+                let mut queue = queue.lock();
+                match queue.jobs.pop_front() {
+                    Some(job) => job,
+                    None => {
+                        queue.worker_running = false;
+                        return;
+                    }
+                }
+            };
+            let terminal = self.observe_parity_inner(domain, kind, job.input).await;
+            let source = self
+                .sources
+                .get(&domain)
+                .expect("validated scraper event source exists");
+            if terminal != ParityResult::Match.label() {
+                if let Err(err) = source.store_parity_unhealthy(kind) {
+                    warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper parity failure failed; disabling parity work");
+                    self.disable_parity_reads(
+                        source.chain.as_str(),
+                        kind.label(),
+                        "durable parity failure state could not be persisted",
+                    );
+                    self.abandon_parity_queue(domain, kind, &queue);
+                    return;
+                }
+            }
+            if let Err(err) = source.store_cursor(kind, job.sequence) {
+                warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper parity cursor failed; disabling parity work");
+                self.disable_parity_reads(
+                    source.chain.as_str(),
+                    kind.label(),
+                    "durable parity cursor could not be persisted",
+                );
+                self.abandon_parity_queue(domain, kind, &queue);
+                return;
+            }
+            drop(job.queue_permit);
+        }
+    }
+
+    fn abandon_parity_queue(
+        &self,
+        domain: u32,
+        kind: EventKind,
+        queue: &parking_lot::Mutex<ParityQueue>,
+    ) {
+        let dropped = {
+            let mut queue = queue.lock();
+            let dropped = queue.jobs.len();
+            queue.jobs.clear();
+            queue.worker_running = false;
+            dropped
+        };
         let source = self
             .sources
             .get(&domain)
             .expect("validated scraper event source exists");
         self.parity_pending
             .with_label_values(&[source.chain.as_str(), kind.label()])
-            .inc();
-        self.parity_ready
-            .with_label_values(&[source.chain.as_str(), kind.label()])
-            .set(0);
-        let monitor = self.clone();
-        tokio::spawn(async move {
-            let _queue_permit = queue_permit;
-            let order = monitor
-                .parity_order
-                .get(&(domain, kind))
-                .expect("validated scraper stream has a parity queue")
-                .clone();
-            let _ordered = order.lock().await;
-            let terminal = monitor
-                .observe_parity_inner(domain, kind, parity_input)
-                .await;
-            let source = monitor
-                .sources
-                .get(&domain)
-                .expect("validated scraper event source exists");
-            if terminal != ParityResult::Match.label() {
-                if let Err(err) = source.store_parity_unhealthy(kind) {
-                    warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper parity failure failed");
-                    return;
-                }
-            }
-            if let Err(err) = source.store_cursor(kind, sequence) {
-                warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper parity cursor failed");
-            }
-        });
+            .sub(dropped as i64);
     }
 
     async fn stream(self: &Arc<Self>, state: &mut StreamState) -> Result<()> {
@@ -1346,6 +1484,35 @@ fn should_warn(warned_at: &parking_lot::Mutex<Option<Instant>>) -> bool {
     }
     *warned_at = Some(now);
     true
+}
+
+fn fresh_baseline_allowed(
+    correlation_required: bool,
+    replay_seen: bool,
+    parity_pending: i64,
+) -> bool {
+    !correlation_required && !replay_seen && parity_pending == 0
+}
+
+fn store_fresh_caught_up_baseline(
+    source: &ScraperSource,
+    kind: EventKind,
+    sequence: i64,
+    stored: Option<u32>,
+    correlation_required: bool,
+    replay_seen: bool,
+    parity_pending: i64,
+) -> Result<()> {
+    if stored.is_none()
+        && sequence >= 0
+        && fresh_baseline_allowed(correlation_required, replay_seen, parity_pending)
+    {
+        let durable: u32 = sequence
+            .try_into()
+            .context("Scraper caught-up sequence exceeds u32")?;
+        source.store_cursor(kind, durable)?;
+    }
+    Ok(())
 }
 
 fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
@@ -1941,6 +2108,79 @@ mod tests {
             .expect_err("gap must reject")
             .to_string()
             .contains("expected sequence 8"));
+    }
+
+    #[test]
+    fn replayed_boundary_keeps_its_actual_sequence() {
+        let fixture = fixture();
+        let mut state = StreamState::default();
+        for sequence in 7..=20 {
+            state
+                .validate(
+                    event(
+                        DISPATCH_EVENT_TYPE,
+                        sequence,
+                        dispatch_data(sequence, &sequence.to_be_bytes()),
+                    ),
+                    &fixture.sources,
+                )
+                .expect("contiguous dispatch event");
+        }
+
+        let replayed = state
+            .validate(
+                event(
+                    DISPATCH_EVENT_TYPE,
+                    7,
+                    dispatch_data(7, &7_u32.to_be_bytes()),
+                ),
+                &fixture.sources,
+            )
+            .expect("replayed boundary event");
+
+        assert_eq!(replayed.sequence_result, SequenceResult::Duplicate);
+        assert_eq!(replayed.sequence, 7);
+        assert_eq!(
+            state
+                .latest_sequence(5, EventKind::Dispatch)
+                .expect("latest sequence"),
+            20
+        );
+    }
+
+    #[test]
+    fn caught_up_does_not_jump_pending_replay_cursor() {
+        let sources = sources();
+        let source = &sources[&5];
+        let mut replay = StreamState::default();
+        replay
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"pending")),
+                &sources,
+            )
+            .expect("replayed event");
+
+        store_fresh_caught_up_baseline(
+            source,
+            EventKind::Dispatch,
+            20,
+            None,
+            false,
+            replay.has_cursor(5, EventKind::Dispatch),
+            1,
+        )
+        .expect("skip baseline with replay pending");
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("cursor read"),
+            None
+        );
+
+        store_fresh_caught_up_baseline(source, EventKind::Dispatch, 20, None, false, false, 0)
+            .expect("store true fresh-start baseline");
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("cursor read"),
+            Some(20)
+        );
     }
 
     #[test]
@@ -2986,6 +3226,300 @@ mod tests {
         })
         .await
         .expect("ordered worker persists the terminal cursor");
+    }
+
+    #[tokio::test]
+    async fn processes_parity_in_fifo_admission_order() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let release = Arc::new((parking_lot::Mutex::new(false), parking_lot::Condvar::new()));
+        let mut database = MockParityDatabase::new();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(2)
+            .returning({
+                let calls = calls.clone();
+                let release = release.clone();
+                move |nonce| {
+                    let call = calls.fetch_add(1, Ordering::SeqCst);
+                    if call == 0 {
+                        entered_tx.send(()).expect("record first parity read");
+                        let (released, signal) = release.as_ref();
+                        let mut released = released.lock();
+                        while !*released {
+                            signal.wait(&mut released);
+                        }
+                    }
+                    let body: &[u8] = if nonce == 7 { b"first" } else { b"second" };
+                    Ok(Some(dispatch_message(nonce, body)))
+                }
+            });
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(2)
+            .returning(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(2)
+            .returning(|_| Ok(Some(dispatch_transaction_id())));
+        let monitor = Arc::new(monitor(Arc::new(database)));
+        let first = StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"first")),
+                &monitor.sources,
+            )
+            .expect("first dispatch");
+        let second = StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"second")),
+                &monitor.sources,
+            )
+            .expect("second dispatch");
+
+        monitor
+            .enqueue_parity(5, first.kind, first.parity, first.sequence)
+            .await;
+        tokio::task::spawn_blocking(move || entered_rx.recv_timeout(Duration::from_secs(1)))
+            .await
+            .expect("wait for first parity read")
+            .expect("first parity read started");
+        monitor
+            .enqueue_parity(5, second.kind, second.parity, second.sequence)
+            .await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            monitor.sources[&5]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read"),
+            None
+        );
+
+        let (released, signal) = release.as_ref();
+        *released.lock() = true;
+        signal.notify_all();
+        timeout(Duration::from_secs(1), async {
+            while monitor.sources[&5]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read")
+                != Some(8)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("FIFO worker persists both terminal cursors");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn four_hung_reads_trip_circuit_without_stalling_later_work() {
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let release = Arc::new((parking_lot::Mutex::new(false), parking_lot::Condvar::new()));
+        let metrics = CoreMetrics::new("scraper-parity-hung-reads", 9090, Registry::new())
+            .expect("create test metrics");
+        let mut sources = Vec::new();
+
+        for domain in 1..=(PARITY_READ_CONCURRENCY + 1) as u32 {
+            let mut database = MockParityDatabase::new();
+            if domain <= PARITY_READ_CONCURRENCY as u32 {
+                let entered_tx = entered_tx.clone();
+                let release = release.clone();
+                database
+                    .expect_retrieve_message_by_nonce()
+                    .times(1)
+                    .returning(move |_| {
+                        entered_tx.send(()).expect("record hung parity read");
+                        let (released, signal) = release.as_ref();
+                        let mut released = released.lock();
+                        while !*released {
+                            signal.wait(&mut released);
+                        }
+                        Err(hyperlane_base::db::DbError::Other(
+                            "released hung read".to_owned(),
+                        ))
+                    });
+            } else {
+                database.expect_retrieve_message_by_nonce().times(0);
+            }
+            sources.push(ScraperSource::with_database(
+                format!("test-{domain}"),
+                domain,
+                H256::from_low_u64_be(1),
+                H256::from_low_u64_be(2),
+                Arc::new(database),
+            ));
+        }
+        let monitor = Arc::new(
+            ScraperWebSocketMonitor::new(
+                Url::parse("ws://localhost:1").expect("test URL"),
+                sources,
+                &metrics,
+            )
+            .expect("create test monitor"),
+        );
+        for source in monitor.sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                monitor
+                    .parity_ready
+                    .with_label_values(&[source.chain.as_str(), kind.label()])
+                    .set(1);
+            }
+        }
+        let parity_input = |domain| ParityInput::Dispatch {
+            block_number: 100,
+            message: HyperlaneMessage {
+                version: 3,
+                nonce: domain,
+                origin: domain,
+                sender: H256::from_low_u64_be(3),
+                destination: 6,
+                recipient: H256::from_low_u64_be(4),
+                body: b"payload".to_vec(),
+            },
+            transaction_id: dispatch_transaction_id(),
+        };
+
+        for domain in 1..=PARITY_READ_CONCURRENCY as u32 {
+            monitor
+                .enqueue_parity(domain, EventKind::Dispatch, parity_input(domain), domain)
+                .await;
+        }
+        let entered = tokio::task::spawn_blocking(move || {
+            (0..PARITY_READ_CONCURRENCY)
+                .filter(|_| entered_rx.recv_timeout(Duration::from_secs(1)).is_ok())
+                .count()
+        })
+        .await
+        .expect("wait for hung parity reads");
+        assert_eq!(entered, PARITY_READ_CONCURRENCY);
+
+        let later_domain = (PARITY_READ_CONCURRENCY + 1) as u32;
+        monitor
+            .enqueue_parity(
+                later_domain,
+                EventKind::Dispatch,
+                parity_input(later_domain),
+                later_domain,
+            )
+            .await;
+        timeout(Duration::from_secs(1), async {
+            while monitor.sources[&later_domain]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read")
+                != Some(later_domain)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("later parity work terminates after circuit opens");
+        timeout(Duration::from_secs(1), async {
+            while (1..=PARITY_READ_CONCURRENCY as u32).any(|domain| {
+                monitor.sources[&domain]
+                    .cursor(EventKind::Dispatch)
+                    .expect("cursor read")
+                    != Some(domain)
+            }) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("timed-out parity jobs terminate");
+        assert!(monitor.parity_read_disabled.load(Ordering::Acquire));
+        for domain in 1..=later_domain {
+            let source = &monitor.sources[&domain];
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                assert_eq!(
+                    monitor
+                        .parity_ready
+                        .with_label_values(&[source.chain.as_str(), kind.label()])
+                        .get(),
+                    0
+                );
+            }
+            assert!(source
+                .parity_unhealthy(EventKind::Dispatch)
+                .expect("durable parity poison"));
+        }
+        timeout(
+            Duration::from_millis(10),
+            monitor.enqueue_parity(
+                later_domain,
+                EventKind::Dispatch,
+                parity_input(later_domain),
+                later_domain + 1,
+            ),
+        )
+        .await
+        .expect("open circuit rejects queue admission immediately");
+        assert_eq!(
+            monitor.sources[&later_domain]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read"),
+            Some(later_domain)
+        );
+        assert_eq!(
+            monitor.parity_queue_permit.available_permits(),
+            PARITY_QUEUE_CAPACITY
+        );
+        assert_eq!(monitor.parity_read_permit.available_permits(), 0);
+
+        let (released, signal) = release.as_ref();
+        *released.lock() = true;
+        signal.notify_all();
+        timeout(Duration::from_secs(1), async {
+            while monitor.parity_read_permit.available_permits() != PARITY_READ_CONCURRENCY {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("released hung reads restore all permits");
+    }
+
+    #[tokio::test]
+    async fn waiter_does_not_spawn_a_read_after_circuit_opens() {
+        let mut database = MockParityDatabase::new();
+        database.expect_retrieve_message_by_nonce().times(0);
+        let monitor = Arc::new(monitor(Arc::new(database)));
+        let permits = monitor
+            .parity_read_permit
+            .clone()
+            .acquire_many_owned(PARITY_READ_CONCURRENCY as u32)
+            .await
+            .expect("reserve all read permits");
+        let waiter = {
+            let monitor = monitor.clone();
+            tokio::spawn(async move {
+                monitor
+                    .observe_parity(
+                        5,
+                        EventKind::Dispatch,
+                        ParityInput::Dispatch {
+                            block_number: 100,
+                            message: dispatch_message(7, b"payload"),
+                            transaction_id: dispatch_transaction_id(),
+                        },
+                    )
+                    .await
+            })
+        };
+        sleep(Duration::from_millis(10)).await;
+        monitor.disable_parity_reads("test", DISPATCH_EVENT_TYPE, "test circuit open");
+        drop(permits);
+
+        assert_eq!(
+            timeout(Duration::from_secs(1), waiter)
+                .await
+                .expect("waiting parity job terminates")
+                .expect("waiting parity task"),
+            "error"
+        );
+        assert_eq!(
+            monitor.parity_read_permit.available_permits(),
+            PARITY_READ_CONCURRENCY
+        );
     }
 
     #[tokio::test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1987,6 +1987,7 @@ fn cursor_write_order(dispatch: u32, merkle: u32) -> [(EventKind, u32); 2] {
     }
 }
 
+#[cfg(test)]
 fn sequenced_cursor_write_order(state: &StreamState, domain: u32) -> Result<[(EventKind, u32); 2]> {
     Ok(cursor_write_order(
         state.latest_sequence(domain, EventKind::Dispatch)?,

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -446,7 +446,10 @@ impl StagedParity {
             bail!("Fresh scraper parity staging exceeded {PARITY_QUEUE_CAPACITY} events");
         }
         self.events.entry(domain).or_default().push_back(event);
-        self.len += 1;
+        self.len = self
+            .len
+            .checked_add(1)
+            .context("Fresh scraper parity staging length overflowed")?;
         Ok(())
     }
 
@@ -476,7 +479,10 @@ impl StagedParity {
                 retained.push_back(event);
             }
         }
-        self.len -= ready.len();
+        self.len = self
+            .len
+            .checked_sub(ready.len())
+            .context("Fresh scraper parity staging length underflowed")?;
         if !retained.is_empty() {
             self.events.insert(domain, retained);
         }
@@ -744,6 +750,7 @@ impl StreamState {
             .latest_sequence()
     }
 
+    #[cfg(test)]
     fn has_cursor(&self, domain: u32, kind: EventKind) -> bool {
         self.cursors.contains_key(&(domain, kind))
     }
@@ -1792,6 +1799,7 @@ fn should_warn(warned_at: &parking_lot::Mutex<Option<Instant>>) -> bool {
     true
 }
 
+#[cfg(test)]
 fn fresh_baseline_allowed(
     correlation_required: bool,
     replay_seen: bool,
@@ -1800,6 +1808,7 @@ fn fresh_baseline_allowed(
     !correlation_required && !replay_seen && parity_pending == 0
 }
 
+#[cfg(test)]
 fn store_fresh_caught_up_baseline(
     source: &ScraperSource,
     kind: EventKind,
@@ -1960,6 +1969,7 @@ fn sequenced_persistence_frontier(
     Ok(frontier)
 }
 
+#[cfg(test)]
 fn sequenced_persistence_ready(
     plan: &SequencedReplayPlan,
     caught_up: &HashMap<(u32, EventKind), i64>,

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -53,6 +53,7 @@ const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
+const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor";
 const PARITY_UNHEALTHY_PREFIX: &[u8] = b"scraper_websocket_parity_unhealthy";
 
 #[cfg_attr(test, mockall::automock)]
@@ -178,7 +179,7 @@ impl ScraperSource {
     }
 
     fn correlation_cursor(&self) -> Result<Option<u32>> {
-        self.db
+        self.cursor_db
             .retrieve_value_by_key(CORRELATION_CURSOR_PREFIX, &self.correlation_cursor_key())
             .context("Reading durable scraper correlation cursor")
     }
@@ -190,7 +191,7 @@ impl ScraperSource {
         {
             return Ok(());
         }
-        self.db
+        self.cursor_db
             .store_value_by_key(
                 CORRELATION_CURSOR_PREFIX,
                 &self.correlation_cursor_key(),
@@ -858,6 +859,7 @@ impl HandshakeState {
 }
 
 struct ParityJob {
+    generation: u64,
     input: ParityInput,
     queue_permit: OwnedSemaphorePermit,
     sequence: u32,
@@ -869,10 +871,60 @@ struct ParityQueue {
     worker_running: bool,
 }
 
+#[derive(Debug, Default)]
+struct CorrelationGateSource {
+    cross_next: Option<u32>,
+    dispatch_match: Option<u32>,
+    durable_next: Option<u32>,
+    failed: bool,
+    merkle_match: Option<u32>,
+}
+
+impl CorrelationGateSource {
+    fn anchored(next: Option<u32>) -> Self {
+        Self {
+            cross_next: next,
+            dispatch_match: None,
+            durable_next: next,
+            failed: false,
+            merkle_match: None,
+        }
+    }
+
+    fn matched_mut(&mut self, kind: EventKind) -> &mut Option<u32> {
+        match kind {
+            EventKind::Dispatch => &mut self.dispatch_match,
+            EventKind::MerkleTreeInsertion => &mut self.merkle_match,
+        }
+    }
+
+    fn candidate(&self) -> Result<Option<u32>> {
+        let (Some(cross_next), Some(dispatch_match), Some(merkle_match)) =
+            (self.cross_next, self.dispatch_match, self.merkle_match)
+        else {
+            return Ok(None);
+        };
+        let dispatch_next = dispatch_match
+            .checked_add(1)
+            .context("Dispatch parity frontier exhausted")?;
+        let merkle_next = merkle_match
+            .checked_add(1)
+            .context("Merkle parity frontier exhausted")?;
+        Ok(Some(cross_next.min(dispatch_next).min(merkle_next)))
+    }
+}
+
+#[derive(Debug, Default)]
+struct CorrelationGate {
+    generation: u64,
+    sources: HashMap<u32, CorrelationGateSource>,
+}
+
 /// One process-wide, read-only scraper stream monitor.
 pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
     caught_up: IntGaugeVec,
+    correlation_gate: parking_lot::Mutex<CorrelationGate>,
     events: IntCounterVec,
     parity: IntCounterVec,
     parity_pending: IntGaugeVec,
@@ -953,6 +1005,7 @@ impl ScraperWebSocketMonitor {
         Ok(Self {
             active,
             caught_up,
+            correlation_gate: parking_lot::Mutex::new(CorrelationGate::default()),
             events,
             parity,
             parity_pending,
@@ -970,22 +1023,31 @@ impl ScraperWebSocketMonitor {
 
     pub(crate) async fn run(self) {
         let monitor = Arc::new(self);
-        let mut state = loop {
-            match StreamState::load(&monitor.sources) {
-                Ok(state) => break state,
-                Err(err) => {
-                    warn!(
-                        ?err,
-                        "Loading durable scraper WebSocket cursors failed; retrying"
-                    );
-                    sleep(RETRY_DELAY).await;
-                }
-            }
-        };
+        let mut generation = 0_u64;
+        let mut state = StreamState::default();
         loop {
+            let plan = loop {
+                match SequencedReplayPlan::load(&monitor.sources) {
+                    Ok(plan) => break plan,
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            "Loading durable scraper WebSocket cursors failed; retrying"
+                        );
+                        sleep(RETRY_DELAY).await;
+                    }
+                }
+            };
+            let Some(next_generation) = generation.checked_add(1) else {
+                warn!("Scraper WebSocket connection generation exhausted; stopping monitor");
+                return;
+            };
+            generation = next_generation;
+            state.reset_sequenced(&plan);
+            monitor.reset_correlation_gate(generation, &plan);
             monitor.set_active(false);
             monitor.set_caught_up(false);
-            match monitor.stream(&mut state).await {
+            match monitor.stream(&mut state, &plan, generation).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
                     ?err,
@@ -996,6 +1058,115 @@ impl ScraperWebSocketMonitor {
             monitor.set_caught_up(false);
             sleep(RETRY_DELAY).await;
         }
+    }
+
+    fn reset_correlation_gate(&self, generation: u64, plan: &SequencedReplayPlan) {
+        let sources = plan
+            .sources
+            .iter()
+            .map(|(domain, source)| {
+                (
+                    *domain,
+                    CorrelationGateSource::anchored(source.correlation_next),
+                )
+            })
+            .collect();
+        *self.correlation_gate.lock() = CorrelationGate {
+            generation,
+            sources,
+        };
+    }
+
+    fn anchor_correlation_gate(&self, generation: u64, domain: u32, sequence: u32) {
+        let mut gate = self.correlation_gate.lock();
+        if gate.generation != generation {
+            return;
+        }
+        gate.sources
+            .entry(domain)
+            .and_modify(|source| {
+                if source.durable_next.is_none() {
+                    *source = CorrelationGateSource::anchored(Some(sequence));
+                }
+            })
+            .or_insert_with(|| CorrelationGateSource::anchored(Some(sequence)));
+    }
+
+    fn note_cross_stream_next(&self, generation: u64, domain: u32, next: u32) {
+        let mut gate = self.correlation_gate.lock();
+        if gate.generation != generation {
+            return;
+        }
+        if let Some(source) = gate.sources.get_mut(&domain) {
+            source.cross_next = Some(source.cross_next.map_or(next, |current| current.max(next)));
+        }
+    }
+
+    fn finish_parity_correlation(
+        &self,
+        generation: u64,
+        domain: u32,
+        kind: EventKind,
+        sequence: u32,
+        terminal: &'static str,
+    ) -> Result<()> {
+        let source = self
+            .sources
+            .get(&domain)
+            .context("Validated scraper source is missing")?;
+        let mut gate = self.correlation_gate.lock();
+        if generation == 0 {
+            return Ok(());
+        }
+        if gate.generation != generation {
+            return Ok(());
+        }
+        let state = gate
+            .sources
+            .get_mut(&domain)
+            .context("Correlation gate omitted configured source")?;
+        if state.failed {
+            return Ok(());
+        }
+        if terminal != ParityResult::Match.label() {
+            state.failed = true;
+            return Ok(());
+        }
+
+        let durable_next = state
+            .durable_next
+            .context("Correlation parity frontier is not anchored")?;
+        let matched = state.matched_mut(kind);
+        let expected = match *matched {
+            Some(latest) => latest
+                .checked_add(1)
+                .context("Scraper parity frontier exhausted")?,
+            None => durable_next,
+        };
+        if sequence < expected {
+            return Ok(());
+        }
+        if sequence > expected {
+            state.failed = true;
+            bail!("Scraper parity frontier gap: expected sequence {expected}, received {sequence}");
+        }
+        *matched = Some(sequence);
+
+        let Some(candidate) = state.candidate()? else {
+            return Ok(());
+        };
+        if state
+            .durable_next
+            .is_some_and(|durable| durable >= candidate)
+        {
+            return Ok(());
+        }
+        if let Err(err) = source.store_correlation_cursor(candidate) {
+            state.failed = true;
+            return Err(err);
+        }
+        state.durable_next = Some(candidate);
+        Ok(())
     }
 
     #[cfg(test)]
@@ -1140,6 +1311,7 @@ impl ScraperWebSocketMonitor {
             .sources
             .get(&domain)
             .expect("validated scraper event source exists");
+        let generation = self.correlation_gate.lock().generation;
         self.parity_ready
             .with_label_values(&[source.chain.as_str(), kind.label()])
             .set(0);
@@ -1166,6 +1338,7 @@ impl ScraperWebSocketMonitor {
         let start_worker = {
             let mut queue = queue.lock();
             queue.jobs.push_back(ParityJob {
+                generation,
                 input: parity_input,
                 queue_permit,
                 sequence,
@@ -1229,6 +1402,18 @@ impl ScraperWebSocketMonitor {
                 self.abandon_parity_queue(domain, kind, &queue);
                 return;
             }
+            if let Err(err) =
+                self.finish_parity_correlation(job.generation, domain, kind, job.sequence, terminal)
+            {
+                warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper correlation cursor failed; disabling parity work");
+                self.disable_parity_reads(
+                    source.chain.as_str(),
+                    kind.label(),
+                    "durable correlation cursor could not be persisted",
+                );
+                self.abandon_parity_queue(domain, kind, &queue);
+                return;
+            }
             drop(job.queue_permit);
         }
     }
@@ -1255,7 +1440,12 @@ impl ScraperWebSocketMonitor {
             .sub(dropped as i64);
     }
 
-    async fn stream(self: &Arc<Self>, state: &mut StreamState) -> Result<()> {
+    async fn stream(
+        self: &Arc<Self>,
+        state: &mut StreamState,
+        plan: &SequencedReplayPlan,
+        generation: u64,
+    ) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
@@ -1296,36 +1486,13 @@ impl ScraperWebSocketMonitor {
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
                                 Ok(validated) => {
-                                    let source = self
-                                        .sources
-                                        .get(&domain)
-                                        .expect("validated scraper source exists");
-                                    if sequenced_persistence_ready(
-                                        plan,
-                                        &caught_up,
-                                        state,
-                                        domain,
-                                        validated.sequence,
-                                    )? {
-                                        if caught_up_baselines(&caught_up, domain) == Some((-1, -1))
-                                            && !state.correlation_next.contains_key(&domain)
-                                        {
-                                            for (kind, sequence) in
-                                                sequenced_cursor_write_order(state, domain)?
-                                            {
-                                                source.store_cursor(kind, sequence)?;
-                                            }
-                                        }
-                                        if let Some(sequence) = state
-                                            .initialize_correlation(domain, validated.sequence)
-                                        {
-                                            source.store_correlation_cursor(sequence)?;
-                                        }
-                                        let correlation_next = state.advance_correlation(domain)?;
-                                        source.store_cursor(validated.kind, validated.sequence)?;
-                                        if let Some(sequence) = correlation_next {
-                                            source.store_correlation_cursor(sequence)?;
-                                        }
+                                    if let Some(sequence) =
+                                        state.initialize_correlation(domain, validated.sequence)
+                                    {
+                                        self.anchor_correlation_gate(generation, domain, sequence);
+                                    }
+                                    if let Some(next) = state.advance_correlation(domain)? {
+                                        self.note_cross_stream_next(generation, domain, next);
                                     }
                                     let result = match validated.sequence_result {
                                         SequenceResult::Accepted => "accepted",
@@ -1379,18 +1546,29 @@ impl ScraperWebSocketMonitor {
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            if plan.correlation_required(domain)? {
-                                if sequence >= 0 {
-                                    let durable: u32 = sequence
-                                        .try_into()
-                                        .context("Scraper caught-up sequence exceeds u32")?;
-                                    source.store_cursor(kind, durable)?;
-                                }
-                            } else if let Some(baselines) =
-                                fresh_baseline_write_order(&caught_up, domain)?
+                            if !plan.correlation_required(domain)?
+                                && !state.correlation_next.contains_key(&domain)
                             {
-                                for (kind, sequence) in baselines {
-                                    source.store_cursor(kind, sequence)?;
+                                let parity_pending =
+                                    [EventKind::Dispatch, EventKind::MerkleTreeInsertion]
+                                        .into_iter()
+                                        .map(|kind| {
+                                            self.parity_pending
+                                                .with_label_values(&[
+                                                    source.chain.as_str(),
+                                                    kind.label(),
+                                                ])
+                                                .get()
+                                        })
+                                        .sum::<i64>();
+                                if parity_pending == 0 {
+                                    if let Some(baselines) =
+                                        fresh_baseline_write_order(&caught_up, domain)?
+                                    {
+                                        for (kind, sequence) in baselines {
+                                            source.store_cursor(kind, sequence)?;
+                                        }
+                                    }
                                 }
                             }
                             self.update_source_caught_up(state, plan, &caught_up, domain)?;
@@ -1498,12 +1676,12 @@ fn store_fresh_caught_up_baseline(
     source: &ScraperSource,
     kind: EventKind,
     sequence: i64,
-    stored: Option<u32>,
+    replay_floor: Option<u32>,
     correlation_required: bool,
     replay_seen: bool,
     parity_pending: i64,
 ) -> Result<()> {
-    if stored.is_none()
+    if replay_floor.is_none()
         && sequence >= 0
         && fresh_baseline_allowed(correlation_required, replay_seen, parity_pending)
     {
@@ -1515,7 +1693,10 @@ fn store_fresh_caught_up_baseline(
     Ok(())
 }
 
-fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
+fn subscription(
+    sources: &HashMap<u32, ScraperSource>,
+    plan: &SequencedReplayPlan,
+) -> Result<String> {
     let mut sources = sources.values().collect::<Vec<_>>();
     sources.sort_unstable_by_key(|source| source.domain);
     let domains = sources
@@ -2880,6 +3061,12 @@ mod tests {
             .store_cursor(EventKind::MerkleTreeInsertion, 90)
             .expect("store Merkle cursor");
         let plan = replay_plan(&sources);
+        let mut handshake = HandshakeState::default();
+        handshake.ready().expect("ready");
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
 
         source
             .store_cursor(EventKind::Dispatch, 200)
@@ -2891,16 +3078,56 @@ mod tests {
             .store_correlation_cursor(200)
             .expect("advance correlation cursor");
 
-        let request: serde_json::Value = serde_json::from_str(
-            &subscription(&sources, &plan).expect("subscription should serialize"),
-        )
-        .expect("subscription JSON");
         assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
         assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
         let streams = subscribed_streams(&sources, &plan);
-        validate_subscription(&streams, &sources, &plan).expect("subscription confirmation");
+        handshake
+            .subscribed(&streams, &sources, &plan)
+            .expect("subscription confirmation uses captured plan");
+        handshake
+            .event()
+            .expect("caught-up accepted after confirmation");
         validate_caught_up_floor(&plan, 5, 90).expect("captured replay floor");
         assert!(validate_caught_up_floor(&plan, 5, 89).is_err());
+    }
+
+    #[test]
+    fn parity_matches_do_not_combine_across_connection_generations() {
+        let database = MockParityDatabase::new();
+        let monitor = monitor(Arc::new(database));
+        let source = &monitor.sources[&5];
+        source
+            .store_correlation_cursor(7)
+            .expect("store replay anchor");
+        let plan = SequencedReplayPlan::load(&monitor.sources).expect("replay plan");
+
+        monitor.reset_correlation_gate(1, &plan);
+        monitor.note_cross_stream_next(1, 5, 8);
+        monitor
+            .finish_parity_correlation(1, 5, EventKind::Dispatch, 7, ParityResult::Match.label())
+            .expect("old generation dispatch match");
+        assert_eq!(source.correlation_cursor().expect("cursor read"), Some(7));
+
+        monitor.reset_correlation_gate(2, &plan);
+        monitor.note_cross_stream_next(2, 5, 8);
+        monitor
+            .finish_parity_correlation(
+                2,
+                5,
+                EventKind::MerkleTreeInsertion,
+                7,
+                ParityResult::Match.label(),
+            )
+            .expect("new generation Merkle match");
+        monitor
+            .finish_parity_correlation(1, 5, EventKind::Dispatch, 7, ParityResult::Match.label())
+            .expect("late old generation completion ignored");
+        assert_eq!(source.correlation_cursor().expect("cursor read"), Some(7));
+
+        monitor
+            .finish_parity_correlation(2, 5, EventKind::Dispatch, 7, ParityResult::Match.label())
+            .expect("same generation dispatch match");
+        assert_eq!(source.correlation_cursor().expect("cursor read"), Some(8));
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -760,15 +760,28 @@ impl ScraperWebSocketMonitor {
                                         .sources
                                         .get(&domain)
                                         .expect("validated scraper source exists");
-                                    if let Some(sequence) =
-                                        state.initialize_correlation(domain, sequence)
-                                    {
-                                        source.store_correlation_cursor(sequence)?;
-                                    }
-                                    let correlation_next = state.advance_correlation(domain)?;
-                                    source.store_cursor(kind, sequence)?;
-                                    if let Some(sequence) = correlation_next {
-                                        source.store_correlation_cursor(sequence)?;
+                                    if sequenced_persistence_ready(
+                                        plan, &caught_up, state, domain, sequence,
+                                    )? {
+                                        if caught_up_baselines(&caught_up, domain) == Some((-1, -1))
+                                            && !state.correlation_next.contains_key(&domain)
+                                        {
+                                            for (kind, sequence) in
+                                                sequenced_cursor_write_order(state, domain)?
+                                            {
+                                                source.store_cursor(kind, sequence)?;
+                                            }
+                                        }
+                                        if let Some(sequence) =
+                                            state.initialize_correlation(domain, sequence)
+                                        {
+                                            source.store_correlation_cursor(sequence)?;
+                                        }
+                                        let correlation_next = state.advance_correlation(domain)?;
+                                        source.store_cursor(kind, sequence)?;
+                                        if let Some(sequence) = correlation_next {
+                                            source.store_correlation_cursor(sequence)?;
+                                        }
                                     }
                                     let result = match sequence_result {
                                         SequenceResult::Accepted => "accepted",
@@ -811,15 +824,23 @@ impl ScraperWebSocketMonitor {
                                 bail!("Invalid negative scraper caught-up sequence {sequence}");
                             }
                             validate_caught_up_floor(plan, domain, sequence)?;
-                            if sequence >= 0 {
-                                let durable: u32 = sequence
-                                    .try_into()
-                                    .context("Scraper caught-up sequence exceeds u32")?;
-                                source.store_cursor(kind, durable)?;
-                            }
                             state.set_baseline(domain, kind, sequence)?;
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
+                            }
+                            if plan.correlation_required(domain)? {
+                                if sequence >= 0 {
+                                    let durable: u32 = sequence
+                                        .try_into()
+                                        .context("Scraper caught-up sequence exceeds u32")?;
+                                    source.store_cursor(kind, durable)?;
+                                }
+                            } else if let Some(baselines) =
+                                fresh_baseline_write_order(&caught_up, domain)?
+                            {
+                                for (kind, sequence) in baselines {
+                                    source.store_cursor(kind, sequence)?;
+                                }
                             }
                             self.update_source_caught_up(state, plan, &caught_up, domain)?;
                         }
@@ -981,16 +1002,91 @@ fn correlation_ready(
     ))
 }
 
+fn caught_up_baselines(
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    domain: u32,
+) -> Option<(i64, i64)> {
+    Some((
+        *caught_up.get(&(domain, EventKind::Dispatch))?,
+        *caught_up.get(&(domain, EventKind::MerkleTreeInsertion))?,
+    ))
+}
+
+fn sequenced_persistence_ready(
+    plan: &SequencedReplayPlan,
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    state: &StreamState,
+    domain: u32,
+    sequence: u32,
+) -> Result<bool> {
+    if plan.correlation_required(domain)? {
+        return Ok(true);
+    }
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
+        return Ok(false);
+    };
+    if dispatch != merkle {
+        return Ok(false);
+    }
+    if dispatch >= 0 {
+        return Ok(true);
+    }
+    if state.correlation_next.contains_key(&domain) {
+        return Ok(true);
+    }
+    if sequence != 0 {
+        bail!("Fresh empty scraper stream started at sequence {sequence}, expected 0");
+    }
+    Ok(state.cross_stream.complete(domain, sequence))
+}
+
+fn cursor_write_order(dispatch: u32, merkle: u32) -> [(EventKind, u32); 2] {
+    if dispatch <= merkle {
+        [
+            (EventKind::Dispatch, dispatch),
+            (EventKind::MerkleTreeInsertion, merkle),
+        ]
+    } else {
+        [
+            (EventKind::MerkleTreeInsertion, merkle),
+            (EventKind::Dispatch, dispatch),
+        ]
+    }
+}
+
+fn sequenced_cursor_write_order(state: &StreamState, domain: u32) -> Result<[(EventKind, u32); 2]> {
+    Ok(cursor_write_order(
+        state.latest_sequence(domain, EventKind::Dispatch)?,
+        state.latest_sequence(domain, EventKind::MerkleTreeInsertion)?,
+    ))
+}
+
+fn fresh_baseline_write_order(
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    domain: u32,
+) -> Result<Option<[(EventKind, u32); 2]>> {
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
+        return Ok(None);
+    };
+    if dispatch < 0 || merkle < 0 {
+        return Ok(None);
+    }
+    let dispatch: u32 = dispatch
+        .try_into()
+        .context("Scraper caught-up sequence exceeds u32")?;
+    let merkle: u32 = merkle
+        .try_into()
+        .context("Scraper caught-up sequence exceeds u32")?;
+    Ok(Some(cursor_write_order(dispatch, merkle)))
+}
+
 fn source_caught_up(
     correlation_required: bool,
     caught_up: &HashMap<(u32, EventKind), i64>,
     state: &StreamState,
     domain: u32,
 ) -> Result<bool> {
-    let Some(dispatch) = caught_up.get(&(domain, EventKind::Dispatch)) else {
-        return Ok(false);
-    };
-    let Some(merkle) = caught_up.get(&(domain, EventKind::MerkleTreeInsertion)) else {
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
         return Ok(false);
     };
     if !correlation_required {
@@ -999,7 +1095,7 @@ fn source_caught_up(
         }
         return Ok(true);
     }
-    let target = (*dispatch).max(*merkle);
+    let target = dispatch.max(merkle);
     if target < 0 {
         return Ok(true);
     }
@@ -1560,22 +1656,65 @@ mod tests {
             .expect("correlation requirement"));
 
         let mut state = replay_state(&initial_plan);
-        source
-            .store_cursor(EventKind::Dispatch, 100)
-            .expect("store fresh dispatch baseline");
         state
             .set_baseline(5, EventKind::Dispatch, 100)
             .expect("set fresh dispatch baseline");
         let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
         assert!(!source_caught_up(false, &caught_up, &state, 5).expect("one fresh marker"));
+        assert_eq!(
+            fresh_baseline_write_order(&caught_up, 5).expect("baseline order"),
+            None
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
 
-        source
-            .store_cursor(EventKind::MerkleTreeInsertion, 90)
-            .expect("store fresh Merkle baseline");
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 101, dispatch_data(101, b"one-oh-one")),
+                &sources,
+            )
+            .expect("fresh live event after first marker");
+        assert!(
+            !sequenced_persistence_ready(&initial_plan, &caught_up, &state, 5, 101)
+                .expect("persistence readiness")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            None
+        );
+
         state
             .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
             .expect("set fresh Merkle baseline");
         caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
+        let baselines = fresh_baseline_write_order(&caught_up, 5)
+            .expect("baseline order")
+            .expect("both baselines");
+        assert_eq!(
+            baselines,
+            [
+                (EventKind::MerkleTreeInsertion, 90),
+                (EventKind::Dispatch, 100),
+            ]
+        );
+        source
+            .store_cursor(baselines[0].0, baselines[0].1)
+            .expect("store lower fresh baseline");
+
+        let interrupted_plan = replay_plan(&sources);
+        assert_eq!(
+            interrupted_plan.source(5).expect("source plan").floor,
+            Some(90)
+        );
+        source
+            .store_cursor(baselines[1].0, baselines[1].1)
+            .expect("store higher fresh baseline");
         assert!(source_caught_up(false, &caught_up, &state, 5)
             .expect_err("unequal fresh baselines must reconnect")
             .to_string()
@@ -1594,6 +1733,209 @@ mod tests {
         .expect("subscription JSON");
         assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
         assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+    }
+
+    #[test]
+    fn fresh_equal_baselines_preserve_readiness() {
+        let sources = sources();
+        let source = &sources[&5];
+        let plan = replay_plan(&sources);
+        let mut state = replay_state(&plan);
+        state
+            .set_baseline(5, EventKind::Dispatch, 100)
+            .expect("set fresh dispatch baseline");
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, 100)
+            .expect("set fresh Merkle baseline");
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 100),
+            ((5, EventKind::MerkleTreeInsertion), 100),
+        ]);
+        let baselines = fresh_baseline_write_order(&caught_up, 5)
+            .expect("baseline order")
+            .expect("both baselines");
+        for (kind, sequence) in baselines {
+            source
+                .store_cursor(kind, sequence)
+                .expect("store equal fresh baseline");
+        }
+
+        assert!(source_caught_up(false, &caught_up, &state, 5).expect("readiness check"));
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            Some(100)
+        );
+        assert_eq!(
+            source
+                .cursor(EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn fresh_negative_lower_baseline_persists_neither_tip() {
+        let sources = sources();
+        let source = &sources[&5];
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 100),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+
+        assert_eq!(
+            fresh_baseline_write_order(&caught_up, 5).expect("baseline order"),
+            None
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+        assert_eq!(
+            source
+                .cursor(EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            None
+        );
+        assert!(
+            source_caught_up(false, &caught_up, &StreamState::default(), 5)
+                .expect_err("negative unequal fresh baselines must reconnect")
+                .to_string()
+                .contains("Fresh scraper caught-up baselines differ")
+        );
+    }
+
+    #[test]
+    fn fresh_empty_baselines_wait_for_first_complete_pair() {
+        let sources = sources();
+        let source = &sources[&5];
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut skipped = replay_state(&plan);
+        skipped
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 5, dispatch_data(5, b"five")),
+                &sources,
+            )
+            .expect("first nonzero dispatch event");
+        assert!(
+            sequenced_persistence_ready(&plan, &caught_up, &skipped, 5, 5)
+                .expect_err("empty stream must start at zero")
+                .to_string()
+                .contains("expected 0")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+
+        let mut state = replay_state(&plan);
+        state
+            .set_baseline(5, EventKind::Dispatch, -1)
+            .expect("set empty dispatch baseline");
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, -1)
+            .expect("set empty Merkle baseline");
+        assert!(source_caught_up(false, &caught_up, &state, 5).expect("readiness check"));
+
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"zero")),
+                &sources,
+            )
+            .expect("first dispatch event");
+        assert!(
+            !sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
+                .expect("persistence readiness")
+        );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            None
+        );
+
+        state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    0,
+                    merkle_data_for(
+                        0,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(0, b"zero").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("first Merkle event");
+        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 0)
+            .expect("persistence readiness"));
+        let cursors = sequenced_cursor_write_order(&state, 5).expect("cursor write order");
+        assert_eq!(
+            cursors,
+            [
+                (EventKind::Dispatch, 0),
+                (EventKind::MerkleTreeInsertion, 0),
+            ]
+        );
+        for (kind, sequence) in cursors {
+            source
+                .store_cursor(kind, sequence)
+                .expect("seed first complete pair cursor");
+        }
+        let correlation = state
+            .initialize_correlation(5, 0)
+            .expect("initialize correlation");
+        source
+            .store_correlation_cursor(correlation)
+            .expect("store initial correlation");
+        let correlation = state
+            .advance_correlation(5)
+            .expect("advance correlation")
+            .expect("complete pair advances correlation");
+        source
+            .store_correlation_cursor(correlation)
+            .expect("store advanced correlation");
+
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            Some(0)
+        );
+        assert_eq!(
+            source
+                .cursor(EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            Some(0)
+        );
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(1)
+        );
+        state
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                &sources,
+            )
+            .expect("next dispatch event");
+        assert!(sequenced_persistence_ready(&plan, &caught_up, &state, 5, 1)
+            .expect("initialized persistence readiness"));
+        let reconnect_plan = replay_plan(&sources);
+        assert_eq!(
+            reconnect_plan.source(5).expect("source plan").floor,
+            Some(0)
+        );
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &reconnect_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "-1");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "-1");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -434,6 +434,56 @@ struct ValidatedEvent {
     sequence_result: SequenceResult,
 }
 
+#[derive(Debug, Default)]
+struct StagedParity {
+    events: HashMap<u32, VecDeque<ValidatedEvent>>,
+    len: usize,
+}
+
+impl StagedParity {
+    fn push(&mut self, domain: u32, event: ValidatedEvent) -> Result<()> {
+        if self.len >= PARITY_QUEUE_CAPACITY {
+            bail!("Fresh scraper parity staging exceeded {PARITY_QUEUE_CAPACITY} events");
+        }
+        self.events.entry(domain).or_default().push_back(event);
+        self.len += 1;
+        Ok(())
+    }
+
+    fn drain_ready(
+        &mut self,
+        plan: &SequencedReplayPlan,
+        caught_up: &HashMap<(u32, EventKind), i64>,
+        state: &StreamState,
+        domain: u32,
+    ) -> Result<VecDeque<ValidatedEvent>> {
+        if !self.events.contains_key(&domain) {
+            return Ok(VecDeque::new());
+        }
+        let Some(frontier) = sequenced_persistence_frontier(plan, caught_up, state, domain)? else {
+            return Ok(VecDeque::new());
+        };
+        let events = self
+            .events
+            .remove(&domain)
+            .expect("checked staged parity domain exists");
+        let mut ready = VecDeque::new();
+        let mut retained = VecDeque::new();
+        for event in events {
+            if event.sequence <= frontier {
+                ready.push_back(event);
+            } else {
+                retained.push_back(event);
+            }
+        }
+        self.len -= ready.len();
+        if !retained.is_empty() {
+            self.events.insert(domain, retained);
+        }
+        Ok(ready)
+    }
+}
+
 #[derive(Clone, Debug)]
 enum ParityInput {
     Dispatch {
@@ -1358,6 +1408,45 @@ impl ScraperWebSocketMonitor {
         }
     }
 
+    async fn admit_parity(
+        self: &Arc<Self>,
+        state: &mut StreamState,
+        generation: u64,
+        domain: u32,
+        validated: ValidatedEvent,
+    ) -> Result<()> {
+        if let Some(sequence) = state.initialize_correlation(domain, validated.sequence) {
+            let source = self
+                .sources
+                .get(&domain)
+                .context("Validated scraper source is missing")?;
+            source.store_correlation_cursor(sequence)?;
+            self.anchor_correlation_gate(generation, domain, sequence);
+        }
+        if let Some(next) = state.advance_correlation(domain)? {
+            self.note_cross_stream_next(generation, domain, next);
+        }
+        self.enqueue_parity(domain, validated.kind, validated.parity, validated.sequence)
+            .await;
+        Ok(())
+    }
+
+    async fn flush_staged_parity(
+        self: &Arc<Self>,
+        state: &mut StreamState,
+        plan: &SequencedReplayPlan,
+        caught_up: &HashMap<(u32, EventKind), i64>,
+        generation: u64,
+        domain: u32,
+        staged: &mut StagedParity,
+    ) -> Result<()> {
+        for validated in staged.drain_ready(plan, caught_up, state, domain)? {
+            self.admit_parity(state, generation, domain, validated)
+                .await?;
+        }
+        Ok(())
+    }
+
     async fn drain_parity_queue(
         self: Arc<Self>,
         domain: u32,
@@ -1452,6 +1541,7 @@ impl ScraperWebSocketMonitor {
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
         let mut caught_up = HashMap::new();
+        let mut staged_parity = StagedParity::default();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -1486,26 +1576,21 @@ impl ScraperWebSocketMonitor {
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
                                 Ok(validated) => {
-                                    if let Some(sequence) =
-                                        state.initialize_correlation(domain, validated.sequence)
-                                    {
-                                        self.anchor_correlation_gate(generation, domain, sequence);
-                                    }
-                                    if let Some(next) = state.advance_correlation(domain)? {
-                                        self.note_cross_stream_next(generation, domain, next);
-                                    }
                                     let result = match validated.sequence_result {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
                                     self.record(domain, validated.kind.label(), result);
-                                    self.enqueue_parity(
+                                    staged_parity.push(domain, validated)?;
+                                    self.flush_staged_parity(
+                                        state,
+                                        plan,
+                                        &caught_up,
+                                        generation,
                                         domain,
-                                        validated.kind,
-                                        validated.parity,
-                                        validated.sequence,
+                                        &mut staged_parity,
                                     )
-                                    .await;
+                                    .await?;
                                     self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
@@ -1571,6 +1656,15 @@ impl ScraperWebSocketMonitor {
                                     }
                                 }
                             }
+                            self.flush_staged_parity(
+                                state,
+                                plan,
+                                &caught_up,
+                                generation,
+                                domain,
+                                &mut staged_parity,
+                            )
+                            .await?;
                             self.update_source_caught_up(state, plan, &caught_up, domain)?;
                         }
                         ServerMessage::Error { error } => {
@@ -1803,6 +1897,37 @@ fn validate_fresh_empty_stream_starts(state: &StreamState, domain: u32) -> Resul
     Ok(())
 }
 
+fn sequenced_persistence_frontier(
+    plan: &SequencedReplayPlan,
+    caught_up: &HashMap<(u32, EventKind), i64>,
+    state: &StreamState,
+    domain: u32,
+) -> Result<Option<u32>> {
+    if plan.correlation_required(domain)? {
+        return Ok(Some(u32::MAX));
+    }
+    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
+        return Ok(None);
+    };
+    if dispatch != merkle {
+        return Ok(None);
+    }
+    if dispatch >= 0 {
+        return Ok(Some(u32::MAX));
+    }
+    validate_fresh_empty_stream_starts(state, domain)?;
+    let mut sequence = 0;
+    let mut frontier = None;
+    while state.cross_stream.complete(domain, sequence) {
+        frontier = Some(sequence);
+        let Some(next) = sequence.checked_add(1) else {
+            break;
+        };
+        sequence = next;
+    }
+    Ok(frontier)
+}
+
 fn sequenced_persistence_ready(
     plan: &SequencedReplayPlan,
     caught_up: &HashMap<(u32, EventKind), i64>,
@@ -1810,23 +1935,10 @@ fn sequenced_persistence_ready(
     domain: u32,
     sequence: u32,
 ) -> Result<bool> {
-    if plan.correlation_required(domain)? {
-        return Ok(true);
-    }
-    let Some((dispatch, merkle)) = caught_up_baselines(caught_up, domain) else {
-        return Ok(false);
-    };
-    if dispatch != merkle {
-        return Ok(false);
-    }
-    if dispatch >= 0 {
-        return Ok(true);
-    }
-    if state.correlation_next.contains_key(&domain) {
-        return Ok(true);
-    }
-    validate_fresh_empty_stream_starts(state, domain)?;
-    Ok(state.cross_stream.complete(domain, sequence))
+    Ok(
+        sequenced_persistence_frontier(plan, caught_up, state, domain)?
+            .is_some_and(|frontier| sequence <= frontier),
+    )
 }
 
 fn cursor_write_order(dispatch: u32, merkle: u32) -> [(EventKind, u32); 2] {
@@ -2743,6 +2855,251 @@ mod tests {
                 .to_string()
                 .contains("Fresh scraper caught-up baselines differ")
         );
+    }
+
+    #[test]
+    fn staged_parity_does_not_cross_unequal_fresh_markers() {
+        let sources = sources();
+        let source = &sources[&5];
+        let plan = replay_plan(&sources);
+        let mut state = replay_state(&plan);
+        let mut staged = StagedParity::default();
+        let mut caught_up = HashMap::from([((5, EventKind::Dispatch), 100)]);
+        state
+            .set_baseline(5, EventKind::Dispatch, 100)
+            .expect("set dispatch marker");
+        staged
+            .push(
+                5,
+                state
+                    .validate(
+                        event(DISPATCH_EVENT_TYPE, 101, dispatch_data(101, b"one-oh-one")),
+                        &sources,
+                    )
+                    .expect("stage dispatch after first marker"),
+            )
+            .expect("stage parity");
+        assert!(staged
+            .drain_ready(&plan, &caught_up, &state, 5)
+            .expect("read staged frontier")
+            .is_empty());
+
+        state
+            .set_baseline(5, EventKind::MerkleTreeInsertion, 90)
+            .expect("set delayed Merkle marker");
+        caught_up.insert((5, EventKind::MerkleTreeInsertion), 90);
+        assert!(staged
+            .drain_ready(&plan, &caught_up, &state, 5)
+            .expect("unequal markers do not admit parity")
+            .is_empty());
+        assert_eq!(staged.len, 1);
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+
+        let baselines = fresh_baseline_write_order(&caught_up, 5)
+            .expect("baseline order")
+            .expect("both positive baselines");
+        source
+            .store_cursor(baselines[0].0, baselines[0].1)
+            .expect("persist lower baseline before reconnect");
+        assert_eq!(
+            replay_plan(&sources).source(5).expect("source plan").floor,
+            Some(90)
+        );
+    }
+
+    #[test]
+    fn staged_empty_parity_drains_only_complete_prefix() {
+        let sources = sources();
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut state = replay_state(&plan);
+        let mut staged = StagedParity::default();
+        for validated in [
+            state
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"zero")),
+                    &sources,
+                )
+                .expect("dispatch zero"),
+            state
+                .validate(
+                    event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+                    &sources,
+                )
+                .expect("dispatch one"),
+            state
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        0,
+                        merkle_data_for(
+                            0,
+                            H256::from_low_u64_be(2),
+                            dispatch_message(0, b"zero").id(),
+                            100,
+                        ),
+                    ),
+                    &sources,
+                )
+                .expect("Merkle zero"),
+        ] {
+            staged.push(5, validated).expect("stage parity");
+        }
+        let ready = staged
+            .drain_ready(&plan, &caught_up, &state, 5)
+            .expect("drain complete prefix")
+            .into_iter()
+            .map(|event| (event.kind, event.sequence))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ready,
+            vec![
+                (EventKind::Dispatch, 0),
+                (EventKind::MerkleTreeInsertion, 0),
+            ]
+        );
+        assert_eq!(staged.len, 1, "dispatch one waits for Merkle one");
+
+        staged
+            .push(
+                5,
+                state
+                    .validate(
+                        event(
+                            MERKLE_EVENT_TYPE,
+                            1,
+                            merkle_data_for(
+                                1,
+                                H256::from_low_u64_be(2),
+                                dispatch_message(1, b"one").id(),
+                                100,
+                            ),
+                        ),
+                        &sources,
+                    )
+                    .expect("Merkle one"),
+            )
+            .expect("stage parity");
+        assert_eq!(
+            staged
+                .drain_ready(&plan, &caught_up, &state, 5)
+                .expect("drain next complete pair")
+                .into_iter()
+                .map(|event| (event.kind, event.sequence))
+                .collect::<Vec<_>>(),
+            vec![
+                (EventKind::Dispatch, 1),
+                (EventKind::MerkleTreeInsertion, 1),
+            ]
+        );
+        assert_eq!(staged.len, 0);
+    }
+
+    #[tokio::test]
+    async fn fresh_empty_parity_anchors_replay_before_queue_admission() {
+        let monitor = Arc::new(monitor(Arc::new(MockParityDatabase::new())));
+        monitor.parity_read_disabled.store(true, Ordering::Release);
+        let plan = replay_plan(&monitor.sources);
+        monitor.reset_correlation_gate(1, &plan);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut state = replay_state(&plan);
+        let mut staged = StagedParity::default();
+
+        for event in [
+            event(DISPATCH_EVENT_TYPE, 0, dispatch_data(0, b"zero")),
+            event(DISPATCH_EVENT_TYPE, 1, dispatch_data(1, b"one")),
+        ] {
+            let validated = state
+                .validate(event, &monitor.sources)
+                .expect("validate dispatch");
+            staged.push(5, validated).expect("stage dispatch");
+            monitor
+                .flush_staged_parity(&mut state, &plan, &caught_up, 1, 5, &mut staged)
+                .await
+                .expect("unpaired dispatch remains staged");
+        }
+        assert_eq!(
+            monitor.sources[&5]
+                .correlation_cursor()
+                .expect("correlation cursor"),
+            None
+        );
+
+        let merkle_zero = state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    0,
+                    merkle_data_for(
+                        0,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(0, b"zero").id(),
+                        100,
+                    ),
+                ),
+                &monitor.sources,
+            )
+            .expect("validate Merkle zero");
+        staged.push(5, merkle_zero).expect("stage Merkle zero");
+        monitor
+            .flush_staged_parity(&mut state, &plan, &caught_up, 1, 5, &mut staged)
+            .await
+            .expect("admit complete zero pair");
+
+        assert_eq!(
+            monitor.sources[&5]
+                .correlation_cursor()
+                .expect("correlation cursor"),
+            Some(0),
+            "the replay anchor is durable before parity workers can advance"
+        );
+        let gate = monitor.correlation_gate.lock();
+        let gate_source = gate.sources.get(&5).expect("correlation gate source");
+        assert_eq!(gate_source.durable_next, Some(0));
+        assert_eq!(gate_source.cross_next, Some(1));
+        drop(gate);
+        assert_eq!(staged.len, 1, "dispatch one waits for Merkle one");
+        for queue in monitor.parity_queues.values() {
+            assert!(queue.lock().jobs.is_empty(), "parity reads are disabled");
+        }
+    }
+
+    #[test]
+    fn staged_nonzero_empty_start_never_becomes_ready() {
+        let sources = sources();
+        let plan = replay_plan(&sources);
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), -1),
+            ((5, EventKind::MerkleTreeInsertion), -1),
+        ]);
+        let mut state = replay_state(&plan);
+        let mut staged = StagedParity::default();
+        staged
+            .push(
+                5,
+                state
+                    .validate(
+                        event(DISPATCH_EVENT_TYPE, 5, dispatch_data(5, b"five")),
+                        &sources,
+                    )
+                    .expect("stage pre-marker nonzero event"),
+            )
+            .expect("stage parity");
+        assert!(staged
+            .drain_ready(&plan, &caught_up, &state, 5)
+            .expect_err("empty stream must begin at zero")
+            .to_string()
+            .contains("expected 0"));
+        assert_eq!(staged.len, 1, "invalid staged event remains unadmitted");
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,0 +1,485 @@
+//! Shadow validation of relayer inputs streamed by scraper-proxy.
+
+use std::{collections::HashMap, time::Duration};
+
+use eyre::{bail, Context, ContextCompat, Result};
+use futures_util::{SinkExt, StreamExt};
+use hyperlane_base::{
+    scraper_websocket::{
+        EventMessage, ServerMessage, StringOrNumber, SubscribeMessage, SubscribeStream,
+    },
+    CoreMetrics,
+};
+use hyperlane_core::{bytes_to_address, H256};
+use prometheus::{IntCounterVec, IntGaugeVec};
+use serde::Deserialize;
+use tokio::time::{sleep, timeout, Instant};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{info, warn};
+use url::Url;
+
+const DISPATCH_EVENT_TYPE: &str = "dispatch";
+const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
+const READ_TIMEOUT: Duration = Duration::from_secs(75);
+const RETRY_DELAY: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Debug)]
+pub(crate) struct ScraperSource {
+    chain: String,
+    domain: u32,
+    mailbox: H256,
+    merkle_tree_hook: H256,
+}
+
+impl ScraperSource {
+    pub(crate) fn new(chain: String, domain: u32, mailbox: H256, merkle_tree_hook: H256) -> Self {
+        Self {
+            chain,
+            domain,
+            mailbox,
+            merkle_tree_hook,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum EventKind {
+    Dispatch,
+    MerkleTreeInsertion,
+}
+
+impl EventKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Dispatch => DISPATCH_EVENT_TYPE,
+            Self::MerkleTreeInsertion => MERKLE_EVENT_TYPE,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum SequenceResult {
+    Accepted,
+    Duplicate,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Scraper stream gap: expected sequence {expected}, received {received}")]
+struct StreamGap {
+    expected: u32,
+    received: u32,
+}
+
+#[derive(Debug, Default)]
+struct StreamState {
+    next_sequences: HashMap<(u32, EventKind), u32>,
+}
+
+impl StreamState {
+    fn validate(
+        &mut self,
+        event: EventMessage<serde_json::Value>,
+        sources: &HashMap<u32, ScraperSource>,
+    ) -> Result<(EventKind, SequenceResult)> {
+        let source = sources
+            .get(&event.domain)
+            .with_context(|| format!("Unexpected scraper event domain {}", event.domain))?;
+        let sequence = event
+            .sequence
+            .as_deref()
+            .context("Sequenced scraper event omitted sequence")?
+            .parse::<u32>()
+            .context("Invalid scraper event sequence")?;
+
+        let kind = match event.event_type.as_str() {
+            DISPATCH_EVENT_TYPE => {
+                let data: DispatchEventData =
+                    serde_json::from_value(event.data).context("Invalid dispatch event payload")?;
+                if data.origin_domain != event.domain {
+                    bail!("Dispatch payload domain does not match event envelope");
+                }
+                if parse_address(&data.origin_mailbox)? != source.mailbox {
+                    bail!("Dispatch event mailbox does not match configured mailbox");
+                }
+                if data.nonce.as_u32("dispatch nonce")? != sequence {
+                    bail!("Dispatch event nonce does not match stream sequence");
+                }
+                EventKind::Dispatch
+            }
+            MERKLE_EVENT_TYPE => {
+                let data: MerkleEventData = serde_json::from_value(event.data)
+                    .context("Invalid Merkle tree insertion payload")?;
+                if data.domain != event.domain {
+                    bail!("Merkle payload domain does not match event envelope");
+                }
+                if parse_address(&data.merkle_tree_hook)? != source.merkle_tree_hook {
+                    bail!("Merkle event hook does not match configured hook");
+                }
+                if data.leaf_index.as_u32("Merkle leaf index")? != sequence {
+                    bail!("Merkle leaf index does not match stream sequence");
+                }
+                EventKind::MerkleTreeInsertion
+            }
+            event_type => bail!("Unexpected scraper event type {event_type}"),
+        };
+
+        let key = (event.domain, kind);
+        let result = match self.next_sequences.get_mut(&key) {
+            None => {
+                self.next_sequences.insert(
+                    key,
+                    sequence
+                        .checked_add(1)
+                        .context("Scraper event sequence exhausted")?,
+                );
+                SequenceResult::Accepted
+            }
+            Some(next_sequence) if sequence < *next_sequence => SequenceResult::Duplicate,
+            Some(next_sequence) if sequence == *next_sequence => {
+                *next_sequence = next_sequence
+                    .checked_add(1)
+                    .context("Scraper event sequence exhausted")?;
+                SequenceResult::Accepted
+            }
+            Some(next_sequence) => {
+                return Err(StreamGap {
+                    expected: *next_sequence,
+                    received: sequence,
+                }
+                .into())
+            }
+        };
+        Ok((kind, result))
+    }
+}
+
+/// One process-wide, read-only scraper stream monitor.
+pub(crate) struct ScraperWebSocketMonitor {
+    active: IntGaugeVec,
+    events: IntCounterVec,
+    sources: HashMap<u32, ScraperSource>,
+    url: Url,
+}
+
+impl ScraperWebSocketMonitor {
+    pub(crate) fn new(
+        url: Url,
+        sources: Vec<ScraperSource>,
+        metrics: &CoreMetrics,
+    ) -> Result<Self> {
+        let active = metrics.new_int_gauge(
+            "relayer_scraper_websocket_active",
+            "Whether the relayer scraper-proxy shadow stream is active",
+            &["chain"],
+        )?;
+        let events = metrics.new_int_counter(
+            "relayer_scraper_websocket_events",
+            "Scraper-proxy shadow events validated by the relayer",
+            &["chain", "event_type", "result"],
+        )?;
+        let sources = sources
+            .into_iter()
+            .map(|source| (source.domain, source))
+            .collect::<HashMap<_, _>>();
+        for source in sources.values() {
+            active.with_label_values(&[&source.chain]).set(0);
+        }
+        Ok(Self {
+            active,
+            events,
+            sources,
+            url,
+        })
+    }
+
+    pub(crate) async fn run(self) {
+        loop {
+            self.set_active(false);
+            match self.stream().await {
+                Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
+                Err(err) => warn!(
+                    ?err,
+                    "Relayer scraper-proxy shadow stream failed; reconnecting"
+                ),
+            }
+            self.set_active(false);
+            sleep(RETRY_DELAY).await;
+        }
+    }
+
+    async fn stream(&self) -> Result<()> {
+        let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
+            .await
+            .context("Connecting to relayer scraper-proxy WebSocket timed out")?
+            .context("Connecting to relayer scraper-proxy WebSocket")?;
+        let mut subscribed = false;
+        let mut state = StreamState::default();
+        let read_deadline = sleep(READ_TIMEOUT);
+        tokio::pin!(read_deadline);
+
+        while let Some(message) = tokio::select! {
+            _ = &mut read_deadline => bail!("Relayer scraper-proxy WebSocket heartbeat timed out"),
+            message = socket.next() => message,
+        } {
+            let next_read_deadline = Instant::now()
+                .checked_add(READ_TIMEOUT)
+                .expect("read timeout cannot exceed Instant range");
+            read_deadline.as_mut().reset(next_read_deadline);
+            match message.context("Reading relayer scraper-proxy WebSocket message")? {
+                Message::Text(text) => {
+                    let message: ServerMessage<serde_json::Value> = serde_json::from_str(&text)
+                        .context("Parsing relayer scraper-proxy WebSocket message")?;
+                    match message {
+                        ServerMessage::Ready => {
+                            if subscribed {
+                                bail!("Received duplicate scraper-proxy ready message");
+                            }
+                            socket
+                                .send(Message::Text(self.subscription()?))
+                                .await
+                                .context("Subscribing to relayer scraper-proxy streams")?;
+                            subscribed = true;
+                        }
+                        ServerMessage::Subscribed => {
+                            if !subscribed {
+                                bail!("Received subscribed before ready");
+                            }
+                            self.set_active(true);
+                            info!("Relayer scraper-proxy shadow streams active");
+                        }
+                        ServerMessage::Event(event) => {
+                            let domain = event.domain;
+                            let event_type = event_label(&event.event_type);
+                            match state.validate(event, &self.sources) {
+                                Ok((kind, SequenceResult::Accepted)) => {
+                                    self.record(domain, kind.label(), "accepted")
+                                }
+                                Ok((kind, SequenceResult::Duplicate)) => {
+                                    self.record(domain, kind.label(), "duplicate")
+                                }
+                                Err(err) => {
+                                    let result = if err.downcast_ref::<StreamGap>().is_some() {
+                                        "gap"
+                                    } else {
+                                        "invalid"
+                                    };
+                                    self.record(domain, event_type, result);
+                                    return Err(err);
+                                }
+                            }
+                        }
+                        ServerMessage::CaughtUp { .. } => {
+                            bail!("Live-only relayer shadow stream received caught-up marker")
+                        }
+                        ServerMessage::Error { error } => {
+                            bail!("Scraper-proxy rejected relayer shadow stream: {error}")
+                        }
+                        ServerMessage::Other => {}
+                    }
+                }
+                Message::Ping(payload) => socket
+                    .send(Message::Pong(payload))
+                    .await
+                    .context("Responding to relayer scraper-proxy heartbeat")?,
+                Message::Close(frame) => {
+                    bail!("Relayer scraper-proxy WebSocket closed: {frame:?}")
+                }
+                Message::Binary(_) | Message::Pong(_) | Message::Frame(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn subscription(&self) -> Result<String> {
+        subscription(self.sources.keys().copied().collect())
+    }
+
+    fn set_active(&self, active: bool) {
+        let value = i64::from(active);
+        for source in self.sources.values() {
+            self.active.with_label_values(&[&source.chain]).set(value);
+        }
+    }
+
+    fn record(&self, domain: u32, event_type: &str, result: &str) {
+        let chain = self
+            .sources
+            .get(&domain)
+            .map(|source| source.chain.as_str())
+            .unwrap_or("unknown");
+        self.events
+            .with_label_values(&[chain, event_type, result])
+            .inc();
+    }
+}
+
+fn subscription(mut domains: Vec<u32>) -> Result<String> {
+    domains.sort_unstable();
+    serde_json::to_string(&SubscribeMessage {
+        streams: vec![
+            SubscribeStream {
+                cursors: None,
+                domains: Some(domains.clone()),
+                event_type: DISPATCH_EVENT_TYPE,
+            },
+            SubscribeStream {
+                cursors: None,
+                domains: Some(domains),
+                event_type: MERKLE_EVENT_TYPE,
+            },
+        ],
+        message_type: "subscribe",
+    })
+    .context("Serializing relayer scraper-proxy subscription")
+}
+
+#[derive(Debug, Deserialize)]
+struct DispatchEventData {
+    nonce: StringOrNumber,
+    origin_domain: u32,
+    origin_mailbox: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MerkleEventData {
+    domain: u32,
+    leaf_index: StringOrNumber,
+    merkle_tree_hook: String,
+}
+
+fn parse_address(value: &str) -> Result<H256> {
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("\\x"))
+        .unwrap_or(value);
+    bytes_to_address(hex::decode(value).context("Invalid hexadecimal scraper event address")?)
+        .context("Invalid scraper event address")
+}
+
+fn event_label(event_type: &str) -> &'static str {
+    match event_type {
+        DISPATCH_EVENT_TYPE => DISPATCH_EVENT_TYPE,
+        MERKLE_EVENT_TYPE => MERKLE_EVENT_TYPE,
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sources() -> HashMap<u32, ScraperSource> {
+        HashMap::from([(
+            5,
+            ScraperSource::new(
+                "test".to_owned(),
+                5,
+                H256::from_low_u64_be(1),
+                H256::from_low_u64_be(2),
+            ),
+        )])
+    }
+
+    fn event(
+        event_type: &str,
+        sequence: u32,
+        data: serde_json::Value,
+    ) -> EventMessage<serde_json::Value> {
+        EventMessage {
+            data,
+            domain: 5,
+            event_type: event_type.to_owned(),
+            sequence: Some(sequence.to_string()),
+        }
+    }
+
+    #[test]
+    fn accepts_contiguous_dispatch_and_rejects_gap() {
+        let sources = sources();
+        let mut state = StreamState::default();
+        let data = |nonce| {
+            serde_json::json!({
+                "nonce": nonce,
+                "origin_domain": 5,
+                "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(1)),
+            })
+        };
+
+        assert_eq!(
+            state
+                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
+                .expect("first event"),
+            (EventKind::Dispatch, SequenceResult::Accepted)
+        );
+        assert_eq!(
+            state
+                .validate(event(DISPATCH_EVENT_TYPE, 7, data(7)), &sources)
+                .expect("duplicate event"),
+            (EventKind::Dispatch, SequenceResult::Duplicate)
+        );
+        assert!(state
+            .validate(event(DISPATCH_EVENT_TYPE, 9, data(9)), &sources)
+            .expect_err("gap must reject")
+            .to_string()
+            .contains("expected sequence 8"));
+    }
+
+    #[test]
+    fn rejects_wrong_dispatch_mailbox() {
+        let error = StreamState::default()
+            .validate(
+                event(
+                    DISPATCH_EVENT_TYPE,
+                    7,
+                    serde_json::json!({
+                        "nonce": 7,
+                        "origin_domain": 5,
+                        "origin_mailbox": format!("{:#x}", H256::from_low_u64_be(3)),
+                    }),
+                ),
+                &sources(),
+            )
+            .expect_err("wrong mailbox must reject");
+
+        assert!(error.to_string().contains("configured mailbox"));
+    }
+
+    #[test]
+    fn rejects_wrong_merkle_hook() {
+        let mut state = StreamState::default();
+        let error = state
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    1,
+                    serde_json::json!({
+                        "domain": 5,
+                        "leaf_index": "1",
+                        "merkle_tree_hook": format!("{:#x}", H256::from_low_u64_be(3)),
+                    }),
+                ),
+                &sources(),
+            )
+            .expect_err("wrong hook must reject");
+
+        assert!(error.to_string().contains("configured hook"));
+    }
+
+    #[test]
+    fn multiplexes_live_streams_on_one_subscription() {
+        let message: serde_json::Value =
+            serde_json::from_str(&subscription(vec![9, 5]).expect("subscription should serialize"))
+                .expect("subscription JSON");
+
+        assert_eq!(
+            message,
+            serde_json::json!({
+                "streams": [
+                    { "domains": [5, 9], "eventType": "dispatch" },
+                    { "domains": [5, 9], "eventType": "merkle_tree_insertion" }
+                ],
+                "type": "subscribe"
+            })
+        );
+    }
+}

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use eyre::{bail, eyre, Context, ContextCompat, Result};
+use eyre::{bail, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
     db::{DbResult, HyperlaneDb, HyperlaneRocksDB},
@@ -24,7 +24,6 @@ use serde::Deserialize;
 use sha3::{Digest, Keccak256};
 use tokio::{
     sync::Semaphore,
-    task::JoinHandle,
     time::{sleep, timeout, Instant},
 };
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -35,8 +34,12 @@ const DISPATCH_EVENT_TYPE: &str = "dispatch";
 const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
-const PARITY_READ_TIMEOUT: Duration = Duration::from_secs(1);
 const PARITY_READ_CONCURRENCY: usize = 4;
+#[cfg(not(test))]
+const PARITY_RETRY_DELAY: Duration = Duration::from_secs(1);
+#[cfg(test)]
+const PARITY_RETRY_DELAY: Duration = Duration::from_millis(10);
+const PARITY_RETRY_ATTEMPTS: usize = 60;
 const PARITY_WARN_INTERVAL: Duration = Duration::from_secs(60);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
@@ -408,7 +411,7 @@ struct ValidatedEvent {
     sequence_result: SequenceResult,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum ParityInput {
     Dispatch {
         block_number: u64,
@@ -832,7 +835,10 @@ pub(crate) struct ScraperWebSocketMonitor {
     caught_up: IntGaugeVec,
     events: IntCounterVec,
     parity: IntCounterVec,
+    parity_pending: IntGaugeVec,
+    parity_ready: IntGaugeVec,
     parity_read_permit: Arc<Semaphore>,
+    parity_unhealthy: Arc<parking_lot::Mutex<std::collections::HashSet<(u32, EventKind)>>>,
     parity_warned_at: Arc<parking_lot::Mutex<Option<Instant>>>,
     sources: HashMap<u32, ScraperSource>,
     url: Url,
@@ -864,6 +870,16 @@ impl ScraperWebSocketMonitor {
             "Read-only parity outcomes for scraper-proxy events against RPC-indexed local DB records",
             &["chain", "event_type", "result"],
         )?;
+        let parity_pending = metrics.new_int_gauge(
+            "relayer_scraper_websocket_parity_pending",
+            "Scraper events awaiting a terminal local DB parity result",
+            &["chain", "event_type"],
+        )?;
+        let parity_ready = metrics.new_int_gauge(
+            "relayer_scraper_websocket_parity_ready",
+            "Whether every observed scraper event has terminal matching local DB parity",
+            &["chain", "event_type"],
+        )?;
         let sources = sources
             .into_iter()
             .map(|source| (source.domain, source))
@@ -874,6 +890,12 @@ impl ScraperWebSocketMonitor {
                 caught_up
                     .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
+                parity_pending
+                    .with_label_values(&[&source.chain, kind.label()])
+                    .set(0);
+                parity_ready
+                    .with_label_values(&[&source.chain, kind.label()])
+                    .set(0);
             }
         }
         Ok(Self {
@@ -881,7 +903,10 @@ impl ScraperWebSocketMonitor {
             caught_up,
             events,
             parity,
+            parity_pending,
+            parity_ready,
             parity_read_permit: Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
+            parity_unhealthy: Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new())),
             parity_warned_at: Arc::new(parking_lot::Mutex::new(None)),
             sources,
             url,
@@ -919,72 +944,71 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    fn observe_parity(
-        &self,
-        domain: u32,
-        kind: EventKind,
-        parity_input: ParityInput,
-    ) -> Option<JoinHandle<()>> {
+    async fn observe_parity(&self, domain: u32, kind: EventKind, parity_input: ParityInput) {
         let source = self
             .sources
             .get(&domain)
             .expect("validated scraper event source must exist");
         let chain = source.chain.clone();
         let event_type = kind.label();
-        let metrics = self.parity.clone();
-        let permit = match self.parity_read_permit.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                metrics
-                    .with_label_values(&[chain.as_str(), event_type, "skipped"])
-                    .inc();
-                if should_warn(&self.parity_warned_at) {
-                    warn!(%chain, event_type, "Local DB parity reader is busy");
-                }
-                return None;
-            }
-        };
+        let labels = [chain.as_str(), event_type];
+        self.parity_pending.with_label_values(&labels).inc();
+        self.parity_ready.with_label_values(&labels).set(0);
+        let _permit = self
+            .parity_read_permit
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("parity semaphore is never closed");
         let database = source.database.clone();
-        let warned_at = self.parity_warned_at.clone();
-        let comparison = tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            parity_input.compare(database.as_ref())
-        });
-
-        Some(tokio::spawn(async move {
-            let result = match timeout(PARITY_READ_TIMEOUT, comparison).await {
-                Ok(Ok(result)) => result,
-                Ok(Err(err)) => Err(eyre!("Local DB parity task failed: {err}")),
-                Err(_) => Err(eyre!("Local DB parity read timed out")),
-            };
-            match result {
-                Ok(parity_result) => {
-                    metrics
-                        .with_label_values(&[chain.as_str(), event_type, parity_result.label()])
-                        .inc();
-                    if parity_result == ParityResult::Conflict && should_warn(&warned_at) {
-                        warn!(
-                            %chain,
-                            event_type,
-                            "Scraper event conflicts with RPC-indexed local DB"
-                        );
+        let mut terminal = None;
+        for attempt in 1..=PARITY_RETRY_ATTEMPTS {
+            let database = database.clone();
+            let parity_input = parity_input.clone();
+            match tokio::task::spawn_blocking(move || parity_input.compare(database.as_ref())).await
+            {
+                Ok(Ok(ParityResult::Missing)) if attempt < PARITY_RETRY_ATTEMPTS => {
+                    sleep(PARITY_RETRY_DELAY).await;
+                }
+                Ok(Ok(ParityResult::Missing)) => {
+                    terminal = Some("expired");
+                    break;
+                }
+                Ok(Ok(result)) => {
+                    terminal = Some(result.label());
+                    break;
+                }
+                Ok(Err(err)) => {
+                    if should_warn(&self.parity_warned_at) {
+                        warn!(%chain, event_type, ?err, "Local DB parity comparison failed");
                     }
+                    terminal = Some("error");
+                    break;
                 }
                 Err(err) => {
-                    metrics
-                        .with_label_values(&[chain.as_str(), event_type, "error"])
-                        .inc();
-                    if should_warn(&warned_at) {
-                        warn!(
-                            %chain,
-                            event_type,
-                            ?err,
-                            "Local DB parity comparison failed"
-                        );
+                    if should_warn(&self.parity_warned_at) {
+                        warn!(%chain, event_type, ?err, "Local DB parity task failed");
                     }
+                    terminal = Some("error");
+                    break;
                 }
             }
-        }))
+        }
+        let terminal = terminal.expect("parity retry loop always produces a terminal result");
+        self.parity
+            .with_label_values(&[chain.as_str(), event_type, terminal])
+            .inc();
+        if terminal != ParityResult::Match.label() {
+            self.parity_unhealthy.lock().insert((domain, kind));
+            if should_warn(&self.parity_warned_at) {
+                warn!(%chain, event_type, result = terminal, "Scraper event did not reach matching local DB parity");
+            }
+        }
+        let pending = self.parity_pending.with_label_values(&labels);
+        pending.dec();
+        if pending.get() == 0 && !self.parity_unhealthy.lock().contains(&(domain, kind)) {
+            self.parity_ready.with_label_values(&labels).set(1);
+        }
     }
 
     async fn stream(&self, state: &mut StreamState) -> Result<()> {
@@ -1063,15 +1087,9 @@ impl ScraperWebSocketMonitor {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
+                                    self.observe_parity(domain, validated.kind, validated.parity)
+                                        .await;
                                     self.record(domain, validated.kind.label(), result);
-                                    let source = self.sources.get(&domain).context(
-                                        "Validated scraper event source unexpectedly missing",
-                                    )?;
-                                    drop(self.observe_parity(
-                                        domain,
-                                        validated.kind,
-                                        validated.parity,
-                                    ));
                                     self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
@@ -2697,11 +2715,7 @@ mod tests {
                 &monitor.sources,
             )
             .expect("first event");
-        monitor
-            .observe_parity(5, first.kind, first.parity)
-            .expect("first parity task")
-            .await
-            .expect("first parity task must not panic");
+        monitor.observe_parity(5, first.kind, first.parity).await;
 
         let next = state
             .validate(
@@ -2710,11 +2724,7 @@ mod tests {
             )
             .expect("next event on the same stream");
         assert_eq!(next.sequence_result, SequenceResult::Accepted);
-        monitor
-            .observe_parity(5, next.kind, next.parity)
-            .expect("next parity task")
-            .await
-            .expect("next parity task must not panic");
+        monitor.observe_parity(5, next.kind, next.parity).await;
 
         assert_eq!(
             monitor
@@ -2731,44 +2741,69 @@ mod tests {
             1
         );
         assert_eq!(monitor.active.with_label_values(&["test"]).get(), 1);
+        assert_eq!(
+            monitor
+                .parity_ready
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE])
+                .get(),
+            0
+        );
     }
 
     #[tokio::test]
-    async fn blocking_db_read_does_not_block_stream_validation() {
+    async fn retries_missing_parity_until_the_local_db_matches() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let mut database = MockParityDatabase::new();
         database
             .expect_retrieve_message_by_nonce()
-            .times(1)
-            .returning(|_| {
-                std::thread::sleep(PARITY_READ_TIMEOUT + Duration::from_millis(100));
-                Ok(None)
+            .times(2)
+            .returning({
+                let calls = calls.clone();
+                move |nonce| {
+                    if calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                        Ok(None)
+                    } else {
+                        Ok(Some(dispatch_message(nonce, b"payload")))
+                    }
+                }
             });
-        let monitor = monitor(std::sync::Arc::new(database));
-        let mut state = StreamState::default();
-        let first = state
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(2)
+            .returning(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(2)
+            .returning(|_| Ok(Some(dispatch_transaction_id())));
+        let monitor = monitor(Arc::new(database));
+        let input = StreamState::default()
             .validate(
-                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"first")),
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
                 &monitor.sources,
             )
-            .expect("first event");
-        let started = std::time::Instant::now();
-        let parity_task = monitor
-            .observe_parity(5, first.kind, first.parity)
-            .expect("parity task");
-        let next = state
-            .validate(
-                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"next")),
-                &monitor.sources,
-            )
-            .expect("next event while DB read is blocked");
-        assert_eq!(next.sequence_result, SequenceResult::Accepted);
-        assert!(started.elapsed() < Duration::from_millis(100));
+            .expect("valid dispatch")
+            .parity;
 
-        parity_task.await.expect("parity task must not panic");
+        monitor.observe_parity(5, EventKind::Dispatch, input).await;
+
         assert_eq!(
             monitor
                 .parity
-                .with_label_values(&["test", DISPATCH_EVENT_TYPE, "error"])
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE, "match"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            monitor
+                .parity_pending
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE])
+                .get(),
+            0
+        );
+        assert_eq!(
+            monitor
+                .parity_ready
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE])
                 .get(),
             1
         );
@@ -2801,6 +2836,15 @@ mod tests {
                             "released test read".to_owned(),
                         ))
                     });
+            } else {
+                database
+                    .expect_retrieve_message_by_nonce()
+                    .times(1)
+                    .returning(|_| {
+                        Err(hyperlane_base::db::DbError::Other(
+                            "queued test read".to_owned(),
+                        ))
+                    });
             }
             sources.push(ScraperSource::with_database(
                 format!("test-{domain}"),
@@ -2810,12 +2854,14 @@ mod tests {
                 Arc::new(database),
             ));
         }
-        let monitor = ScraperWebSocketMonitor::new(
-            Url::parse("ws://localhost:1").expect("test URL"),
-            sources,
-            &metrics,
-        )
-        .expect("create test monitor");
+        let monitor = Arc::new(
+            ScraperWebSocketMonitor::new(
+                Url::parse("ws://localhost:1").expect("test URL"),
+                sources,
+                &metrics,
+            )
+            .expect("create test monitor"),
+        );
         let parity_input = |domain| ParityInput::Dispatch {
             block_number: 100,
             message: HyperlaneMessage {
@@ -2831,37 +2877,44 @@ mod tests {
         };
         let mut parity_tasks = Vec::new();
         for domain in 1..=PARITY_READ_CONCURRENCY as u32 {
-            if let Some(task) =
-                monitor.observe_parity(domain, EventKind::Dispatch, parity_input(domain))
-            {
-                parity_tasks.push(task);
-            }
+            let monitor = monitor.clone();
+            let input = parity_input(domain);
+            parity_tasks.push(tokio::spawn(async move {
+                monitor
+                    .observe_parity(domain, EventKind::Dispatch, input)
+                    .await;
+            }));
         }
         let entered = (0..PARITY_READ_CONCURRENCY)
             .filter(|_| entered_rx.recv_timeout(Duration::from_millis(500)).is_ok())
             .count();
 
-        let skipped_domain = (PARITY_READ_CONCURRENCY + 1) as u32;
-        let skipped_chain = format!("test-{skipped_domain}");
-        let skipped = monitor
-            .observe_parity(
-                skipped_domain,
-                EventKind::Dispatch,
-                parity_input(skipped_domain),
-            )
-            .is_none();
+        let queued_domain = (PARITY_READ_CONCURRENCY + 1) as u32;
+        let queued_chain = format!("test-{queued_domain}");
+        let queued_monitor = monitor.clone();
+        let queued_input = parity_input(queued_domain);
+        let queued = tokio::spawn(async move {
+            queued_monitor
+                .observe_parity(queued_domain, EventKind::Dispatch, queued_input)
+                .await;
+        });
+        tokio::task::yield_now().await;
         let skipped_count = monitor
             .parity
-            .with_label_values(&[skipped_chain.as_str(), DISPATCH_EVENT_TYPE, "skipped"])
+            .with_label_values(&[queued_chain.as_str(), DISPATCH_EVENT_TYPE, "skipped"])
+            .get();
+        let queued_pending = monitor
+            .parity_pending
+            .with_label_values(&[queued_chain.as_str(), DISPATCH_EVENT_TYPE])
             .get();
 
         let (released, signal) = release.as_ref();
         *released.lock() = true;
         signal.notify_all();
-        let scheduled = parity_tasks.len();
         for task in parity_tasks {
             task.await.expect("parity task must not panic");
         }
+        queued.await.expect("queued parity task must not panic");
         timeout(Duration::from_secs(1), async {
             while monitor.parity_read_permit.available_permits() != PARITY_READ_CONCURRENCY {
                 tokio::task::yield_now().await;
@@ -2869,10 +2922,9 @@ mod tests {
         })
         .await
         .expect("blocking reads release global permits");
-        assert_eq!(scheduled, PARITY_READ_CONCURRENCY);
         assert_eq!(entered, PARITY_READ_CONCURRENCY);
-        assert!(skipped);
-        assert_eq!(skipped_count, 1);
+        assert_eq!(queued_pending, 1);
+        assert_eq!(skipped_count, 0);
         assert_eq!(
             monitor.parity_read_permit.available_permits(),
             PARITY_READ_CONCURRENCY

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,7 +1,7 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     time::Duration,
 };
 
@@ -32,6 +32,7 @@ const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
+const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor";
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
@@ -72,6 +73,35 @@ impl ScraperSource {
             .context("Reading durable scraper WebSocket cursor")
     }
 
+    fn correlation_cursor_key(&self) -> H512 {
+        let mut key = [0_u8; 64];
+        key[..32].copy_from_slice(self.mailbox.as_ref());
+        key[32..].copy_from_slice(self.merkle_tree_hook.as_ref());
+        H512::from_slice(&key)
+    }
+
+    fn correlation_cursor(&self) -> Result<Option<u32>> {
+        self.db
+            .retrieve_value_by_key(CORRELATION_CURSOR_PREFIX, &self.correlation_cursor_key())
+            .context("Reading durable scraper correlation cursor")
+    }
+
+    fn store_correlation_cursor(&self, sequence: u32) -> Result<()> {
+        if self
+            .correlation_cursor()?
+            .is_some_and(|stored| stored >= sequence)
+        {
+            return Ok(());
+        }
+        self.db
+            .store_value_by_key(
+                CORRELATION_CURSOR_PREFIX,
+                &self.correlation_cursor_key(),
+                &sequence,
+            )
+            .context("Storing durable scraper correlation cursor")
+    }
+
     fn store_cursor(&self, kind: EventKind, sequence: u32) -> Result<()> {
         if self.cursor(kind)?.is_some_and(|stored| stored >= sequence) {
             return Ok(());
@@ -103,19 +133,60 @@ impl EventKind {
         }
     }
 
-    fn counterpart(self) -> Self {
-        match self {
-            Self::Dispatch => Self::MerkleTreeInsertion,
-            Self::MerkleTreeInsertion => Self::Dispatch,
-        }
-    }
-
     fn from_label(label: &str) -> Result<Self> {
         match label {
             DISPATCH_EVENT_TYPE => Ok(Self::Dispatch),
             MERKLE_EVENT_TYPE => Ok(Self::MerkleTreeInsertion),
             _ => bail!("Unexpected scraper event type {label}"),
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SequencedReplaySource {
+    correlation_next: Option<u32>,
+    floor: Option<u32>,
+}
+
+#[derive(Debug, Default)]
+struct SequencedReplayPlan {
+    sources: HashMap<u32, SequencedReplaySource>,
+}
+
+impl SequencedReplayPlan {
+    fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
+        let mut plan = Self::default();
+        for source in sources.values() {
+            let dispatch = source.cursor(EventKind::Dispatch)?;
+            let merkle = source.cursor(EventKind::MerkleTreeInsertion)?;
+            let correlation = source.correlation_cursor()?;
+            let floor = [dispatch, merkle, correlation].into_iter().flatten().min();
+            let correlation_next = correlation.or(floor);
+            if correlation.is_none() {
+                if let Some(sequence) = correlation_next {
+                    source.store_correlation_cursor(sequence)?;
+                }
+            }
+            plan.sources.insert(
+                source.domain,
+                SequencedReplaySource {
+                    correlation_next,
+                    floor,
+                },
+            );
+        }
+        Ok(plan)
+    }
+
+    fn source(&self, domain: u32) -> Result<SequencedReplaySource> {
+        self.sources
+            .get(&domain)
+            .copied()
+            .context("Scraper replay plan omitted configured source")
+    }
+
+    fn correlation_required(&self, domain: u32) -> Result<bool> {
+        Ok(self.source(domain)?.floor.is_some())
     }
 }
 
@@ -316,24 +387,54 @@ struct StreamGap {
 
 #[derive(Debug, Default)]
 struct StreamState {
+    correlation_next: HashMap<u32, u32>,
     cross_stream: CrossStreamState,
     cursors: HashMap<(u32, EventKind), StreamCursor>,
 }
 
 impl StreamState {
-    fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
-        let mut state = Self::default();
-        for source in sources.values() {
-            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
-                if let Some(sequence) = source.cursor(kind)? {
-                    state.cursors.insert(
-                        (source.domain, kind),
+    fn reset_sequenced(&mut self, plan: &SequencedReplayPlan) {
+        self.correlation_next.clear();
+        self.cross_stream = CrossStreamState::default();
+        self.cursors.clear();
+        for (domain, source) in &plan.sources {
+            if let Some(sequence) = source.floor {
+                for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                    self.cursors.insert(
+                        (*domain, kind),
                         StreamCursor::from_durable_sequence(sequence),
                     );
                 }
             }
+            if let Some(sequence) = source.correlation_next {
+                self.correlation_next.insert(*domain, sequence);
+            }
         }
-        Ok(state)
+    }
+
+    fn advance_correlation(&mut self, domain: u32) -> Result<Option<u32>> {
+        let Some(initial) = self.correlation_next.get(&domain).copied() else {
+            return Ok(None);
+        };
+        let mut next = initial;
+        while self.cross_stream.complete(domain, next) {
+            next = next
+                .checked_add(1)
+                .context("Scraper correlation cursor exhausted")?;
+        }
+        if next == initial {
+            return Ok(None);
+        }
+        self.correlation_next.insert(domain, next);
+        Ok(Some(next))
+    }
+
+    fn initialize_correlation(&mut self, domain: u32, sequence: u32) -> Option<u32> {
+        if self.correlation_next.contains_key(&domain) {
+            return None;
+        }
+        self.correlation_next.insert(domain, sequence);
+        Some(sequence)
     }
 
     fn set_baseline(&mut self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
@@ -510,6 +611,7 @@ impl HandshakeState {
         &mut self,
         streams: &[SubscribedStream],
         sources: &HashMap<u32, ScraperSource>,
+        plan: &SequencedReplayPlan,
     ) -> Result<()> {
         if !self.sent {
             bail!("Received subscribed before ready");
@@ -517,7 +619,7 @@ impl HandshakeState {
         if self.confirmed {
             bail!("Received duplicate scraper-proxy subscribed message");
         }
-        validate_subscription(streams, sources)?;
+        validate_subscription(streams, sources, plan)?;
         self.confirmed = true;
         Ok(())
     }
@@ -582,22 +684,24 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
-        let mut state = loop {
-            match StreamState::load(&self.sources) {
-                Ok(state) => break state,
-                Err(err) => {
-                    warn!(
-                        ?err,
-                        "Loading durable scraper WebSocket cursors failed; retrying"
-                    );
-                    sleep(RETRY_DELAY).await;
-                }
-            }
-        };
+        let mut state = StreamState::default();
         loop {
+            let plan = loop {
+                match SequencedReplayPlan::load(&self.sources) {
+                    Ok(plan) => break plan,
+                    Err(err) => {
+                        warn!(
+                            ?err,
+                            "Loading durable scraper WebSocket cursors failed; retrying"
+                        );
+                        sleep(RETRY_DELAY).await;
+                    }
+                }
+            };
+            state.reset_sequenced(&plan);
             self.set_active(false);
             self.set_caught_up(false);
-            match self.stream(&mut state).await {
+            match self.stream(&mut state, &plan).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
                     ?err,
@@ -610,21 +714,12 @@ impl ScraperWebSocketMonitor {
         }
     }
 
-    async fn stream(&self, state: &mut StreamState) -> Result<()> {
+    async fn stream(&self, state: &mut StreamState, plan: &SequencedReplayPlan) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
-        let mut correlation_required = HashSet::new();
-        for source in self.sources.values() {
-            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
-                if source.cursor(kind)?.is_some() {
-                    correlation_required.insert(source.domain);
-                    break;
-                }
-            }
-        }
         let mut caught_up = HashMap::new();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
@@ -645,12 +740,12 @@ impl ScraperWebSocketMonitor {
                         ServerMessage::Ready => {
                             handshake.ready()?;
                             socket
-                                .send(Message::Text(self.subscription()?))
+                                .send(Message::Text(self.subscription(plan)?))
                                 .await
                                 .context("Subscribing to relayer scraper-proxy streams")?;
                         }
                         ServerMessage::Subscribed { streams } => {
-                            handshake.subscribed(&streams, &self.sources)?;
+                            handshake.subscribed(&streams, &self.sources, plan)?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
@@ -661,21 +756,26 @@ impl ScraperWebSocketMonitor {
                             match state.validate(event, &self.sources) {
                                 Ok((kind, sequence_result)) => {
                                     let sequence = state.latest_sequence(domain, kind)?;
-                                    self.sources
+                                    let source = self
+                                        .sources
                                         .get(&domain)
-                                        .expect("validated scraper source exists")
-                                        .store_cursor(kind, sequence)?;
+                                        .expect("validated scraper source exists");
+                                    if let Some(sequence) =
+                                        state.initialize_correlation(domain, sequence)
+                                    {
+                                        source.store_correlation_cursor(sequence)?;
+                                    }
+                                    let correlation_next = state.advance_correlation(domain)?;
+                                    source.store_cursor(kind, sequence)?;
+                                    if let Some(sequence) = correlation_next {
+                                        source.store_correlation_cursor(sequence)?;
+                                    }
                                     let result = match sequence_result {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
                                     self.record(domain, kind.label(), result);
-                                    self.update_source_caught_up(
-                                        state,
-                                        &correlation_required,
-                                        &caught_up,
-                                        domain,
-                                    )?;
+                                    self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
                                     let result = if err.downcast_ref::<StreamGap>().is_some() {
@@ -710,13 +810,7 @@ impl ScraperWebSocketMonitor {
                             if sequence < -1 {
                                 bail!("Invalid negative scraper caught-up sequence {sequence}");
                             }
-                            if let Some(stored) = source.cursor(kind)? {
-                                if sequence < i64::from(stored) {
-                                    bail!(
-                                        "Scraper caught-up sequence {sequence} is behind durable cursor {stored}"
-                                    );
-                                }
-                            }
+                            validate_caught_up_floor(plan, domain, sequence)?;
                             if sequence >= 0 {
                                 let durable: u32 = sequence
                                     .try_into()
@@ -727,12 +821,7 @@ impl ScraperWebSocketMonitor {
                             if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            self.update_source_caught_up(
-                                state,
-                                &correlation_required,
-                                &caught_up,
-                                domain,
-                            )?;
+                            self.update_source_caught_up(state, plan, &caught_up, domain)?;
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -753,8 +842,8 @@ impl ScraperWebSocketMonitor {
         Ok(())
     }
 
-    fn subscription(&self) -> Result<String> {
-        subscription(&self.sources)
+    fn subscription(&self, plan: &SequencedReplayPlan) -> Result<String> {
+        subscription(&self.sources, plan)
     }
 
     fn set_active(&self, active: bool) {
@@ -783,16 +872,11 @@ impl ScraperWebSocketMonitor {
     fn update_source_caught_up(
         &self,
         state: &StreamState,
-        correlation_required: &HashSet<u32>,
+        plan: &SequencedReplayPlan,
         caught_up: &HashMap<(u32, EventKind), i64>,
         domain: u32,
     ) -> Result<()> {
-        if !source_caught_up(
-            correlation_required.contains(&domain),
-            caught_up,
-            state,
-            domain,
-        )? {
+        if !source_caught_up(plan.correlation_required(domain)?, caught_up, state, domain)? {
             return Ok(());
         }
         let source = self
@@ -817,7 +901,10 @@ impl ScraperWebSocketMonitor {
     }
 }
 
-fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
+fn subscription(
+    sources: &HashMap<u32, ScraperSource>,
+    plan: &SequencedReplayPlan,
+) -> Result<String> {
     let mut sources = sources.values().collect::<Vec<_>>();
     sources.sort_unstable_by_key(|source| source.domain);
     let domains = sources
@@ -827,7 +914,7 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     let cursors = |kind| -> Result<Vec<SequenceCursor>> {
         sources
             .iter()
-            .map(|source| sequence_cursor(source, kind))
+            .map(|source| sequence_cursor(source, kind, plan))
             .collect()
     };
     serde_json::to_string(&SubscribeMessage {
@@ -848,15 +935,15 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
     .context("Serializing relayer scraper-proxy subscription")
 }
 
-fn sequence_cursor(source: &ScraperSource, kind: EventKind) -> Result<SequenceCursor> {
-    let replay_from = match source.cursor(kind)? {
-        Some(sequence) => Some(sequence),
-        None => source.cursor(kind.counterpart())?,
-    };
+fn sequence_cursor(
+    source: &ScraperSource,
+    kind: EventKind,
+    plan: &SequencedReplayPlan,
+) -> Result<SequenceCursor> {
     Ok(SequenceCursor {
         address: format!("{:#x}", source.address(kind)),
         allow_replay: Some(true),
-        after_sequence: replay_from.map(replay_after_sequence),
+        after_sequence: plan.source(source.domain)?.floor.map(replay_after_sequence),
         domain: source.domain,
     })
 }
@@ -866,6 +953,15 @@ fn replay_after_sequence(sequence: u32) -> String {
         .checked_sub(1)
         .map(|sequence| sequence.to_string())
         .unwrap_or_else(|| "-1".to_owned())
+}
+
+fn validate_caught_up_floor(plan: &SequencedReplayPlan, domain: u32, sequence: i64) -> Result<()> {
+    if let Some(floor) = plan.source(domain)?.floor {
+        if sequence < i64::from(floor) {
+            bail!("Scraper caught-up sequence {sequence} is behind replay floor {floor}");
+        }
+    }
+    Ok(())
 }
 
 fn correlation_ready(
@@ -915,12 +1011,20 @@ fn source_caught_up(
             return Ok(false);
         }
     }
+    if state
+        .correlation_next
+        .get(&domain)
+        .is_none_or(|next| *next <= target)
+    {
+        return Ok(false);
+    }
     correlation_ready(true, state, domain, i64::from(target))
 }
 
 fn validate_subscription(
     streams: &[SubscribedStream],
     sources: &HashMap<u32, ScraperSource>,
+    plan: &SequencedReplayPlan,
 ) -> Result<()> {
     if streams.len() != 2 {
         bail!("Scraper-proxy confirmed an unexpected number of streams");
@@ -938,7 +1042,7 @@ fn validate_subscription(
         let expected_cursors = sources
             .iter()
             .map(|source| {
-                let cursor = sequence_cursor(source, kind)?;
+                let cursor = sequence_cursor(source, kind, plan)?;
                 Ok(SubscribedCursor {
                     address: cursor.address,
                     after_sequence: cursor.after_sequence,
@@ -1127,7 +1231,20 @@ mod tests {
         })
     }
 
-    fn subscribed_streams(sources: &HashMap<u32, ScraperSource>) -> Vec<SubscribedStream> {
+    fn replay_plan(sources: &HashMap<u32, ScraperSource>) -> SequencedReplayPlan {
+        SequencedReplayPlan::load(sources).expect("replay plan")
+    }
+
+    fn replay_state(plan: &SequencedReplayPlan) -> StreamState {
+        let mut state = StreamState::default();
+        state.reset_sequenced(plan);
+        state
+    }
+
+    fn subscribed_streams(
+        sources: &HashMap<u32, ScraperSource>,
+        plan: &SequencedReplayPlan,
+    ) -> Vec<SubscribedStream> {
         let mut sources = sources.values().collect::<Vec<_>>();
         sources.sort_unstable_by_key(|source| source.domain);
         let domains = sources
@@ -1141,7 +1258,7 @@ mod tests {
                     sources
                         .iter()
                         .map(|source| {
-                            let cursor = sequence_cursor(source, kind).expect("cursor read");
+                            let cursor = sequence_cursor(source, kind, plan).expect("cursor read");
                             SubscribedCursor {
                                 address: cursor.address,
                                 after_sequence: cursor.after_sequence,
@@ -1209,7 +1326,8 @@ mod tests {
     #[test]
     fn restores_durable_sequence_after_process_restart() {
         let sources = sources();
-        let mut first_process = StreamState::load(&sources).expect("initial cursor load");
+        let initial_plan = replay_plan(&sources);
+        let mut first_process = replay_state(&initial_plan);
         first_process
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
@@ -1220,7 +1338,8 @@ mod tests {
             .store_cursor(EventKind::Dispatch, 7)
             .expect("store first event cursor");
 
-        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        let restart_plan = replay_plan(&sources);
+        let mut restarted = replay_state(&restart_plan);
         restarted
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
@@ -1244,63 +1363,188 @@ mod tests {
     }
 
     #[test]
-    fn restart_replays_both_stream_boundaries_before_caught_up() {
+    fn fresh_event_anchors_correlation_before_stream_cursor() {
         let sources = sources();
         let source = &sources[&5];
-        source
-            .store_cursor(EventKind::Dispatch, 7)
-            .expect("store dispatch cursor");
-        source
-            .store_cursor(EventKind::MerkleTreeInsertion, 6)
-            .expect("store Merkle cursor");
-
-        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
-        restarted
+        let plan = replay_plan(&sources);
+        let mut state = replay_state(&plan);
+        state
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
                 &sources,
             )
-            .expect("replay dispatch boundary");
-        restarted
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    6,
-                    merkle_data_for(
-                        6,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(6, b"six").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("replay Merkle boundary");
-        assert!(!correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
-        restarted
-            .validate(
-                event(
-                    MERKLE_EVENT_TYPE,
-                    7,
-                    merkle_data_for(
-                        7,
-                        H256::from_low_u64_be(2),
-                        dispatch_message(7, b"seven").id(),
-                        100,
-                    ),
-                ),
-                &sources,
-            )
-            .expect("complete split cursor pair");
+            .expect("first event");
 
-        assert!(restarted.cross_stream.entries[&5][&7].complete());
-        assert!(correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
+        let sequence = state
+            .latest_sequence(5, EventKind::Dispatch)
+            .expect("dispatch cursor");
+        let anchor = state
+            .initialize_correlation(5, sequence)
+            .expect("fresh correlation anchor");
+        source
+            .store_correlation_cursor(anchor)
+            .expect("store correlation anchor");
         assert_eq!(
-            restarted
-                .latest_sequence(5, EventKind::MerkleTreeInsertion)
-                .expect("Merkle cursor"),
-            7
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(7)
         );
+        assert_eq!(
+            source.cursor(EventKind::Dispatch).expect("dispatch cursor"),
+            None
+        );
+
+        source
+            .store_cursor(EventKind::Dispatch, sequence)
+            .expect("store dispatch cursor");
+        let restart_plan = replay_plan(&sources);
+        assert_eq!(restart_plan.source(5).expect("source plan").floor, Some(7));
+    }
+
+    #[test]
+    fn restart_replays_both_stream_boundaries_before_caught_up() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store Merkle cursor");
+        let initial_plan = replay_plan(&sources);
+        assert_eq!(initial_plan.source(5).expect("source plan").floor, Some(90));
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &initial_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+
+        let mut healing = replay_state(&initial_plan);
+        for sequence in 90_u32..=100 {
+            let body = sequence.to_be_bytes();
+            let message_id = dispatch_message(sequence, &body).id();
+            healing
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
+                    ),
+                    &sources,
+                )
+                .expect("replay Merkle event");
+            source
+                .store_cursor(EventKind::MerkleTreeInsertion, sequence)
+                .expect("store Merkle cursor");
+            assert_eq!(
+                healing.advance_correlation(5).expect("advance correlation"),
+                None
+            );
+        }
+        for sequence in 90_u32..=95 {
+            let body = sequence.to_be_bytes();
+            if sequence == 95 {
+                assert!(healing
+                    .validate(
+                        event(
+                            DISPATCH_EVENT_TYPE,
+                            sequence,
+                            dispatch_data(sequence, b"wrong")
+                        ),
+                        &sources,
+                    )
+                    .expect_err("mismatch below high cursor must reject")
+                    .to_string()
+                    .contains("message IDs differ"));
+            }
+            healing
+                .validate(
+                    event(
+                        DISPATCH_EVENT_TYPE,
+                        sequence,
+                        dispatch_data(sequence, &body),
+                    ),
+                    &sources,
+                )
+                .expect("replay dispatch event");
+            source
+                .store_cursor(EventKind::Dispatch, sequence)
+                .expect("store dispatch cursor");
+            if let Some(next) = healing.advance_correlation(5).expect("advance correlation") {
+                source
+                    .store_correlation_cursor(next)
+                    .expect("store correlation cursor");
+            }
+        }
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(96)
+        );
+
+        let restart_plan = replay_plan(&sources);
+        assert_eq!(restart_plan.source(5).expect("source plan").floor, Some(96));
+        let restart_subscription: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &restart_plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(
+            restart_subscription["streams"][0]["cursors"][0]["afterSequence"],
+            "95"
+        );
+        assert_eq!(
+            restart_subscription["streams"][1]["cursors"][0]["afterSequence"],
+            "95"
+        );
+
+        let mut restarted = replay_state(&restart_plan);
+        for sequence in 96_u32..=100 {
+            let body = sequence.to_be_bytes();
+            let message_id = dispatch_message(sequence, &body).id();
+            restarted
+                .validate(
+                    event(
+                        DISPATCH_EVENT_TYPE,
+                        sequence,
+                        dispatch_data(sequence, &body),
+                    ),
+                    &sources,
+                )
+                .expect("replay dispatch event after crash");
+            source
+                .store_cursor(EventKind::Dispatch, sequence)
+                .expect("store dispatch cursor");
+            restarted
+                .validate(
+                    event(
+                        MERKLE_EVENT_TYPE,
+                        sequence,
+                        merkle_data_for(sequence, H256::from_low_u64_be(2), message_id, 100),
+                    ),
+                    &sources,
+                )
+                .expect("replay Merkle event after crash");
+            source
+                .store_cursor(EventKind::MerkleTreeInsertion, sequence)
+                .expect("store Merkle cursor");
+            if let Some(next) = restarted
+                .advance_correlation(5)
+                .expect("advance correlation")
+            {
+                source
+                    .store_correlation_cursor(next)
+                    .expect("store correlation cursor");
+            }
+        }
+        assert!((96_u32..=100).all(|sequence| restarted.cross_stream.complete(5, sequence)));
+        assert_eq!(
+            source.correlation_cursor().expect("correlation cursor"),
+            Some(101)
+        );
+        let caught_up = HashMap::from([
+            ((5, EventKind::Dispatch), 100),
+            ((5, EventKind::MerkleTreeInsertion), 100),
+        ]);
+        assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
     }
 
     #[test]
@@ -1311,12 +1555,14 @@ mod tests {
             .store_cursor(EventKind::Dispatch, 7)
             .expect("store dispatch cursor");
 
-        let message: serde_json::Value =
-            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
-                .expect("subscription JSON");
+        let plan = replay_plan(&sources);
+        let message: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
         assert_eq!(message["streams"][0]["cursors"][0]["afterSequence"], "6");
         assert_eq!(message["streams"][1]["cursors"][0]["afterSequence"], "6");
-        let streams = subscribed_streams(&sources);
+        let streams = subscribed_streams(&sources, &plan);
         assert_eq!(
             streams[0].cursors.as_ref().expect("dispatch cursors")[0].after_sequence,
             Some("6".to_owned())
@@ -1325,9 +1571,9 @@ mod tests {
             streams[1].cursors.as_ref().expect("Merkle cursors")[0].after_sequence,
             Some("6".to_owned())
         );
-        validate_subscription(&streams, &sources).expect("subscription confirmation");
+        validate_subscription(&streams, &sources, &plan).expect("subscription confirmation");
 
-        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        let mut restarted = replay_state(&plan);
         restarted
             .validate(
                 event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
@@ -1355,7 +1601,48 @@ mod tests {
                 &sources,
             )
             .expect("late Merkle correlation");
+        let next = restarted
+            .advance_correlation(5)
+            .expect("advance correlation")
+            .expect("late pair advances correlation");
+        source
+            .store_correlation_cursor(next)
+            .expect("store correlation cursor");
         assert!(source_caught_up(true, &caught_up, &restarted, 5).expect("readiness check"));
+    }
+
+    #[test]
+    fn connection_plan_is_immutable_when_durable_cursors_advance() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 100)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 90)
+            .expect("store Merkle cursor");
+        let plan = replay_plan(&sources);
+
+        source
+            .store_cursor(EventKind::Dispatch, 200)
+            .expect("advance dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 200)
+            .expect("advance Merkle cursor");
+        source
+            .store_correlation_cursor(200)
+            .expect("advance correlation cursor");
+
+        let request: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
+        assert_eq!(request["streams"][0]["cursors"][0]["afterSequence"], "89");
+        assert_eq!(request["streams"][1]["cursors"][0]["afterSequence"], "89");
+        let streams = subscribed_streams(&sources, &plan);
+        validate_subscription(&streams, &sources, &plan).expect("subscription confirmation");
+        validate_caught_up_floor(&plan, 5, 90).expect("captured replay floor");
+        assert!(validate_caught_up_floor(&plan, 5, 89).is_err());
     }
 
     #[test]
@@ -1572,34 +1859,41 @@ mod tests {
     fn enforces_subscription_handshake_order() {
         let mut handshake = HandshakeState::default();
         let sources = sources();
-        let streams = subscribed_streams(&sources);
+        let plan = replay_plan(&sources);
+        let streams = subscribed_streams(&sources, &plan);
         assert!(handshake.event().is_err());
-        assert!(handshake.subscribed(&streams, &sources).is_err());
+        assert!(handshake.subscribed(&streams, &sources, &plan).is_err());
         handshake.ready().expect("ready");
         assert!(handshake.event().is_err());
         handshake
-            .subscribed(&streams, &sources)
+            .subscribed(&streams, &sources, &plan)
             .expect("subscribed");
         handshake.event().expect("event after confirmation");
-        assert!(handshake.subscribed(&streams, &sources).is_err());
+        assert!(handshake.subscribed(&streams, &sources, &plan).is_err());
         assert!(handshake.ready().is_err());
     }
 
     #[test]
     fn rejects_subscription_confirmation_mismatch() {
         let sources = sources();
+        let plan = replay_plan(&sources);
+        let foreign_sources = sources_for(&[9]);
+        let foreign_plan = replay_plan(&foreign_sources);
         for streams in [
-            subscribed_streams(&sources_for(&[9])),
+            subscribed_streams(&foreign_sources, &foreign_plan),
             vec![SubscribedStream {
                 cursors: None,
                 domains: Some(vec![5]),
                 event_type: DISPATCH_EVENT_TYPE.to_owned(),
             }],
-            subscribed_streams(&sources).into_iter().rev().collect(),
+            subscribed_streams(&sources, &plan)
+                .into_iter()
+                .rev()
+                .collect(),
         ] {
             let mut handshake = HandshakeState::default();
             handshake.ready().expect("ready");
-            assert!(handshake.subscribed(&streams, &sources).is_err());
+            assert!(handshake.subscribed(&streams, &sources, &plan).is_err());
             assert!(!handshake.confirmed);
         }
     }
@@ -1607,9 +1901,11 @@ mod tests {
     #[test]
     fn multiplexes_live_streams_on_one_subscription() {
         let sources = sources_for(&[9, 5]);
-        let message: serde_json::Value =
-            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
-                .expect("subscription JSON");
+        let plan = replay_plan(&sources);
+        let message: serde_json::Value = serde_json::from_str(
+            &subscription(&sources, &plan).expect("subscription should serialize"),
+        )
+        .expect("subscription JSON");
 
         assert_eq!(
             message,

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -23,7 +23,7 @@ use prometheus::{IntCounterVec, IntGaugeVec};
 use serde::Deserialize;
 use sha3::{Digest, Keccak256};
 use tokio::{
-    sync::Semaphore,
+    sync::{Mutex, Semaphore},
     time::{sleep, timeout, Instant},
 };
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -35,6 +35,8 @@ const MERKLE_EVENT_TYPE: &str = "merkle_tree_insertion";
 const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const PARITY_READ_CONCURRENCY: usize = 4;
+const PARITY_QUEUE_CAPACITY: usize = 256;
+const PARITY_READ_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(not(test))]
 const PARITY_RETRY_DELAY: Duration = Duration::from_secs(1);
 #[cfg(test)]
@@ -45,7 +47,7 @@ const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
 const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
 const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
-const CORRELATION_CURSOR_PREFIX: &[u8] = b"scraper_websocket_correlation_cursor";
+const PARITY_UNHEALTHY_PREFIX: &[u8] = b"scraper_websocket_parity_unhealthy";
 
 #[cfg_attr(test, mockall::automock)]
 trait ParityDatabase: Send + Sync {
@@ -198,6 +200,19 @@ impl ScraperSource {
         self.cursor_db
             .store_value_by_key(kind.cursor_prefix(), &self.address(kind), &sequence)
             .context("Storing durable scraper WebSocket cursor")
+    }
+
+    fn parity_unhealthy(&self, kind: EventKind) -> Result<bool> {
+        Ok(self
+            .cursor_db
+            .retrieve_value_by_key(PARITY_UNHEALTHY_PREFIX, &self.address(kind))?
+            .unwrap_or(false))
+    }
+
+    fn store_parity_unhealthy(&self, kind: EventKind) -> Result<()> {
+        self.cursor_db
+            .store_value_by_key(PARITY_UNHEALTHY_PREFIX, &self.address(kind), &true)
+            .context("Storing durable scraper parity health")
     }
 }
 
@@ -836,8 +851,10 @@ pub(crate) struct ScraperWebSocketMonitor {
     events: IntCounterVec,
     parity: IntCounterVec,
     parity_pending: IntGaugeVec,
+    parity_queue_permit: Arc<Semaphore>,
     parity_ready: IntGaugeVec,
     parity_read_permit: Arc<Semaphore>,
+    parity_order: HashMap<(u32, EventKind), Arc<Mutex<()>>>,
     parity_unhealthy: Arc<parking_lot::Mutex<std::collections::HashSet<(u32, EventKind)>>>,
     parity_warned_at: Arc<parking_lot::Mutex<Option<Instant>>>,
     sources: HashMap<u32, ScraperSource>,
@@ -884,6 +901,8 @@ impl ScraperWebSocketMonitor {
             .into_iter()
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
+        let mut parity_unhealthy = HashSet::new();
+        let mut parity_order = HashMap::new();
         for source in sources.values() {
             active.with_label_values(&[source.chain.as_str()]).set(0);
             for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
@@ -891,11 +910,15 @@ impl ScraperWebSocketMonitor {
                     .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
                 parity_pending
-                    .with_label_values(&[&source.chain, kind.label()])
+                    .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
                 parity_ready
-                    .with_label_values(&[&source.chain, kind.label()])
+                    .with_label_values(&[source.chain.as_str(), kind.label()])
                     .set(0);
+                parity_order.insert((source.domain, kind), Arc::new(Mutex::new(())));
+                if source.parity_unhealthy(kind)? {
+                    parity_unhealthy.insert((source.domain, kind));
+                }
             }
         }
         Ok(Self {
@@ -904,9 +927,11 @@ impl ScraperWebSocketMonitor {
             events,
             parity,
             parity_pending,
+            parity_queue_permit: Arc::new(Semaphore::new(PARITY_QUEUE_CAPACITY)),
             parity_ready,
             parity_read_permit: Arc::new(Semaphore::new(PARITY_READ_CONCURRENCY)),
-            parity_unhealthy: Arc::new(parking_lot::Mutex::new(std::collections::HashSet::new())),
+            parity_order,
+            parity_unhealthy: Arc::new(parking_lot::Mutex::new(parity_unhealthy)),
             parity_warned_at: Arc::new(parking_lot::Mutex::new(None)),
             sources,
             url,
@@ -914,37 +939,57 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
-        let mut state = StreamState::default();
-        loop {
-            let plan = loop {
-                match SequencedReplayPlan::load(&self.sources) {
-                    Ok(plan) => break plan,
-                    Err(err) => {
-                        warn!(
-                            ?err,
-                            "Loading durable scraper WebSocket cursors failed; retrying"
-                        );
-                        sleep(RETRY_DELAY).await;
-                    }
+        let monitor = Arc::new(self);
+        let mut state = loop {
+            match StreamState::load(&monitor.sources) {
+                Ok(state) => break state,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        "Loading durable scraper WebSocket cursors failed; retrying"
+                    );
+                    sleep(RETRY_DELAY).await;
                 }
-            };
-            state.reset_sequenced(&plan);
-            self.set_active(false);
-            self.set_caught_up(false);
-            match self.stream(&mut state, &plan).await {
+            }
+        };
+        loop {
+            monitor.set_active(false);
+            monitor.set_caught_up(false);
+            match monitor.stream(&mut state).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
                     ?err,
                     "Relayer scraper-proxy shadow stream failed; reconnecting"
                 ),
             }
-            self.set_active(false);
-            self.set_caught_up(false);
+            monitor.set_active(false);
+            monitor.set_caught_up(false);
             sleep(RETRY_DELAY).await;
         }
     }
 
-    async fn observe_parity(&self, domain: u32, kind: EventKind, parity_input: ParityInput) {
+    async fn observe_parity(
+        &self,
+        domain: u32,
+        kind: EventKind,
+        parity_input: ParityInput,
+    ) -> &'static str {
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper event source must exist");
+        self.parity_pending
+            .with_label_values(&[source.chain.as_str(), kind.label()])
+            .inc();
+        self.observe_parity_inner(domain, kind, parity_input).await
+    }
+
+    async fn observe_parity_inner(
+        &self,
+        domain: u32,
+        kind: EventKind,
+        parity_input: ParityInput,
+    ) -> &'static str {
         let source = self
             .sources
             .get(&domain)
@@ -952,40 +997,49 @@ impl ScraperWebSocketMonitor {
         let chain = source.chain.clone();
         let event_type = kind.label();
         let labels = [chain.as_str(), event_type];
-        self.parity_pending.with_label_values(&labels).inc();
         self.parity_ready.with_label_values(&labels).set(0);
-        let _permit = self
-            .parity_read_permit
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("parity semaphore is never closed");
         let database = source.database.clone();
         let mut terminal = None;
         for attempt in 1..=PARITY_RETRY_ATTEMPTS {
             let database = database.clone();
             let parity_input = parity_input.clone();
-            match tokio::task::spawn_blocking(move || parity_input.compare(database.as_ref())).await
-            {
-                Ok(Ok(ParityResult::Missing)) if attempt < PARITY_RETRY_ATTEMPTS => {
+            let permit = self
+                .parity_read_permit
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("parity semaphore is never closed");
+            let mut comparison = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                parity_input.compare(database.as_ref())
+            });
+            match timeout(PARITY_READ_TIMEOUT, &mut comparison).await {
+                Err(_) => {
+                    tokio::spawn(async move {
+                        let _ = comparison.await;
+                    });
+                    terminal = Some("error");
+                    break;
+                }
+                Ok(Ok(Ok(ParityResult::Missing))) if attempt < PARITY_RETRY_ATTEMPTS => {
                     sleep(PARITY_RETRY_DELAY).await;
                 }
-                Ok(Ok(ParityResult::Missing)) => {
+                Ok(Ok(Ok(ParityResult::Missing))) => {
                     terminal = Some("expired");
                     break;
                 }
-                Ok(Ok(result)) => {
+                Ok(Ok(Ok(result))) => {
                     terminal = Some(result.label());
                     break;
                 }
-                Ok(Err(err)) => {
+                Ok(Ok(Err(err))) => {
                     if should_warn(&self.parity_warned_at) {
                         warn!(%chain, event_type, ?err, "Local DB parity comparison failed");
                     }
                     terminal = Some("error");
                     break;
                 }
-                Err(err) => {
+                Ok(Err(err)) => {
                     if should_warn(&self.parity_warned_at) {
                         warn!(%chain, event_type, ?err, "Local DB parity task failed");
                     }
@@ -1009,9 +1063,61 @@ impl ScraperWebSocketMonitor {
         if pending.get() == 0 && !self.parity_unhealthy.lock().contains(&(domain, kind)) {
             self.parity_ready.with_label_values(&labels).set(1);
         }
+        terminal
     }
 
-    async fn stream(&self, state: &mut StreamState) -> Result<()> {
+    async fn enqueue_parity(
+        self: &Arc<Self>,
+        domain: u32,
+        kind: EventKind,
+        parity_input: ParityInput,
+        sequence: u32,
+    ) {
+        let queue_permit = self
+            .parity_queue_permit
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("parity queue semaphore is never closed");
+        let source = self
+            .sources
+            .get(&domain)
+            .expect("validated scraper event source exists");
+        self.parity_pending
+            .with_label_values(&[source.chain.as_str(), kind.label()])
+            .inc();
+        self.parity_ready
+            .with_label_values(&[source.chain.as_str(), kind.label()])
+            .set(0);
+        let monitor = self.clone();
+        tokio::spawn(async move {
+            let _queue_permit = queue_permit;
+            let order = monitor
+                .parity_order
+                .get(&(domain, kind))
+                .expect("validated scraper stream has a parity queue")
+                .clone();
+            let _ordered = order.lock().await;
+            let terminal = monitor
+                .observe_parity_inner(domain, kind, parity_input)
+                .await;
+            let source = monitor
+                .sources
+                .get(&domain)
+                .expect("validated scraper event source exists");
+            if terminal != ParityResult::Match.label() {
+                if let Err(err) = source.store_parity_unhealthy(kind) {
+                    warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper parity failure failed");
+                    return;
+                }
+            }
+            if let Err(err) = source.store_cursor(kind, sequence) {
+                warn!(%domain, event_type = kind.label(), ?err, "Persisting scraper parity cursor failed");
+            }
+        });
+    }
+
+    async fn stream(self: &Arc<Self>, state: &mut StreamState) -> Result<()> {
         let (mut socket, _) = timeout(READ_TIMEOUT, connect_async(self.url.as_str()))
             .await
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
@@ -1087,9 +1193,14 @@ impl ScraperWebSocketMonitor {
                                         SequenceResult::Accepted => "accepted",
                                         SequenceResult::Duplicate => "duplicate",
                                     };
-                                    self.observe_parity(domain, validated.kind, validated.parity)
-                                        .await;
                                     self.record(domain, validated.kind.label(), result);
+                                    self.enqueue_parity(
+                                        domain,
+                                        validated.kind,
+                                        validated.parity,
+                                        validated.sequence,
+                                    )
+                                    .await;
                                     self.update_source_caught_up(state, plan, &caught_up, domain)?;
                                 }
                                 Err(err) => {
@@ -2810,6 +2921,138 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queues_parity_without_blocking_the_websocket_reader() {
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let release = Arc::new((parking_lot::Mutex::new(false), parking_lot::Condvar::new()));
+        let mut database = MockParityDatabase::new();
+        let read_release = release.clone();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(1)
+            .returning(move |nonce| {
+                entered_tx.send(()).expect("record parity read");
+                let (released, signal) = read_release.as_ref();
+                let mut released = released.lock();
+                while !*released {
+                    signal.wait(&mut released);
+                }
+                Ok(Some(dispatch_message(nonce, b"payload")))
+            });
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(1)
+            .returning(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(1)
+            .returning(|_| Ok(Some(dispatch_transaction_id())));
+        let monitor = Arc::new(monitor(Arc::new(database)));
+        let input = StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &monitor.sources,
+            )
+            .expect("valid dispatch")
+            .parity;
+
+        timeout(
+            Duration::from_millis(100),
+            monitor.enqueue_parity(5, EventKind::Dispatch, input, 7),
+        )
+        .await
+        .expect("queue admission must not await the DB read");
+        tokio::task::spawn_blocking(move || entered_rx.recv_timeout(Duration::from_secs(5)))
+            .await
+            .expect("wait for blocking parity read")
+            .expect("blocking parity read started");
+        assert_eq!(
+            monitor.sources[&5]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read"),
+            None
+        );
+
+        let (released, signal) = release.as_ref();
+        *released.lock() = true;
+        signal.notify_all();
+        timeout(Duration::from_secs(1), async {
+            while monitor.sources[&5]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read")
+                != Some(7)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("ordered worker persists the terminal cursor");
+    }
+
+    #[tokio::test]
+    async fn terminal_failure_is_durable_before_cursor_advancement() {
+        let mut database = MockParityDatabase::new();
+        database
+            .expect_retrieve_message_by_nonce()
+            .times(1)
+            .returning(|nonce| Ok(Some(dispatch_message(nonce, b"conflict"))));
+        database
+            .expect_retrieve_dispatched_block_number_by_nonce()
+            .times(1)
+            .returning(|_| Ok(Some(100)));
+        database
+            .expect_retrieve_dispatched_tx_hash_by_message_id()
+            .times(1)
+            .returning(|_| Ok(Some(dispatch_transaction_id())));
+        let monitor = Arc::new(monitor(Arc::new(database)));
+        let input = StreamState::default()
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"payload")),
+                &monitor.sources,
+            )
+            .expect("valid dispatch")
+            .parity;
+        monitor
+            .enqueue_parity(5, EventKind::Dispatch, input, 7)
+            .await;
+
+        timeout(Duration::from_secs(1), async {
+            while monitor.sources[&5]
+                .cursor(EventKind::Dispatch)
+                .expect("cursor read")
+                != Some(7)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal cursor persistence");
+        let source = monitor.sources[&5].clone();
+        assert!(source
+            .parity_unhealthy(EventKind::Dispatch)
+            .expect("health read"));
+
+        let metrics = CoreMetrics::new("scraper-parity-restart", 9090, Registry::new())
+            .expect("create restart metrics");
+        let restarted = ScraperWebSocketMonitor::new(
+            Url::parse("ws://localhost:1").expect("test URL"),
+            vec![source],
+            &metrics,
+        )
+        .expect("restart monitor");
+        assert!(restarted
+            .parity_unhealthy
+            .lock()
+            .contains(&(5, EventKind::Dispatch)));
+        assert_eq!(
+            restarted
+                .parity_ready
+                .with_label_values(&["test", DISPATCH_EVENT_TYPE])
+                .get(),
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn bounds_parity_reads_across_origins() {
         let (entered_tx, entered_rx) = std::sync::mpsc::channel();
         let release = Arc::new((parking_lot::Mutex::new(false), parking_lot::Condvar::new()));
@@ -2885,9 +3128,13 @@ mod tests {
                     .await;
             }));
         }
-        let entered = (0..PARITY_READ_CONCURRENCY)
-            .filter(|_| entered_rx.recv_timeout(Duration::from_millis(500)).is_ok())
-            .count();
+        let entered = tokio::task::spawn_blocking(move || {
+            (0..PARITY_READ_CONCURRENCY)
+                .filter(|_| entered_rx.recv_timeout(Duration::from_secs(2)).is_ok())
+                .count()
+        })
+        .await
+        .expect("wait for blocking parity reads");
 
         let queued_domain = (PARITY_READ_CONCURRENCY + 1) as u32;
         let queued_chain = format!("test-{queued_domain}");

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -156,6 +156,13 @@ struct CrossStreamState {
 }
 
 impl CrossStreamState {
+    fn complete(&self, domain: u32, sequence: u32) -> bool {
+        self.entries
+            .get(&domain)
+            .and_then(|entries| entries.get(&sequence))
+            .is_some_and(CrossStreamPair::complete)
+    }
+
     fn validate(
         &mut self,
         domain: u32,
@@ -222,6 +229,13 @@ struct StreamCursor {
 }
 
 impl StreamCursor {
+    fn from_durable_sequence(sequence: u32) -> Self {
+        Self {
+            fingerprints: BTreeMap::new(),
+            next_sequence: sequence,
+        }
+    }
+
     fn from_after_sequence(sequence: u32) -> Result<Self> {
         Ok(Self {
             fingerprints: BTreeMap::new(),
@@ -307,7 +321,7 @@ impl StreamState {
                 if let Some(sequence) = source.cursor(kind)? {
                     state.cursors.insert(
                         (source.domain, kind),
-                        StreamCursor::from_after_sequence(sequence)?,
+                        StreamCursor::from_durable_sequence(sequence),
                     );
                 }
             }
@@ -595,7 +609,16 @@ impl ScraperWebSocketMonitor {
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
-        let mut caught_up = HashSet::new();
+        let mut correlation_required = HashSet::new();
+        for source in self.sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                if source.cursor(kind)?.is_some() {
+                    correlation_required.insert(source.domain);
+                    break;
+                }
+            }
+        }
+        let mut caught_up = HashMap::new();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -688,10 +711,25 @@ impl ScraperWebSocketMonitor {
                                 source.store_cursor(kind, durable)?;
                             }
                             state.set_baseline(domain, kind, sequence)?;
-                            if !caught_up.insert((domain, kind)) {
+                            if caught_up.insert((domain, kind), sequence).is_some() {
                                 bail!("Received duplicate scraper caught-up marker");
                             }
-                            self.set_source_caught_up(source, kind, true);
+                            let counterpart = match kind {
+                                EventKind::Dispatch => EventKind::MerkleTreeInsertion,
+                                EventKind::MerkleTreeInsertion => EventKind::Dispatch,
+                            };
+                            if caught_up.get(&(domain, counterpart)) == Some(&sequence) {
+                                let correlation_complete = correlation_ready(
+                                    correlation_required.contains(&domain),
+                                    state,
+                                    domain,
+                                    sequence,
+                                )?;
+                                if correlation_complete {
+                                    self.set_source_caught_up(source, kind, true);
+                                    self.set_source_caught_up(source, counterpart, true);
+                                }
+                            }
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -765,7 +803,7 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
                 Ok(SequenceCursor {
                     address: format!("{:#x}", source.address(kind)),
                     allow_replay: Some(true),
-                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    after_sequence: source.cursor(kind)?.map(replay_after_sequence),
                     domain: source.domain,
                 })
             })
@@ -787,6 +825,30 @@ fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
         message_type: "subscribe",
     })
     .context("Serializing relayer scraper-proxy subscription")
+}
+
+fn replay_after_sequence(sequence: u32) -> String {
+    sequence
+        .checked_sub(1)
+        .map(|sequence| sequence.to_string())
+        .unwrap_or_else(|| "-1".to_owned())
+}
+
+fn correlation_ready(
+    required: bool,
+    state: &StreamState,
+    domain: u32,
+    sequence: i64,
+) -> Result<bool> {
+    if sequence < 0 || !required {
+        return Ok(true);
+    }
+    Ok(state.cross_stream.complete(
+        domain,
+        sequence
+            .try_into()
+            .context("Caught-up sequence exceeds u32")?,
+    ))
 }
 
 fn validate_subscription(
@@ -1015,7 +1077,7 @@ mod tests {
                             after_sequence: source
                                 .cursor(kind)
                                 .expect("cursor read")
-                                .map(|value| value.to_string()),
+                                .map(replay_after_sequence),
                             domain: source.domain,
                         })
                         .collect(),
@@ -1091,6 +1153,12 @@ mod tests {
             .expect("store first event cursor");
 
         let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("replay durable boundary");
         assert!(restarted
             .validate(
                 event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
@@ -1105,6 +1173,66 @@ mod tests {
                 &sources,
             )
             .expect("replayed event after durable cursor");
+    }
+
+    #[test]
+    fn restart_replays_both_stream_boundaries_before_caught_up() {
+        let sources = sources();
+        let source = &sources[&5];
+        source
+            .store_cursor(EventKind::Dispatch, 7)
+            .expect("store dispatch cursor");
+        source
+            .store_cursor(EventKind::MerkleTreeInsertion, 6)
+            .expect("store Merkle cursor");
+
+        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("replay dispatch boundary");
+        restarted
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    6,
+                    merkle_data_for(
+                        6,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(6, b"six").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("replay Merkle boundary");
+        assert!(!correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
+        restarted
+            .validate(
+                event(
+                    MERKLE_EVENT_TYPE,
+                    7,
+                    merkle_data_for(
+                        7,
+                        H256::from_low_u64_be(2),
+                        dispatch_message(7, b"seven").id(),
+                        100,
+                    ),
+                ),
+                &sources,
+            )
+            .expect("complete split cursor pair");
+
+        assert!(restarted.cross_stream.entries[&5][&7].complete());
+        assert!(correlation_ready(true, &restarted, 5, 7).expect("readiness check"));
+        assert_eq!(
+            restarted
+                .latest_sequence(5, EventKind::MerkleTreeInsertion)
+                .expect("Merkle cursor"),
+            7
+        );
     }
 
     #[test]

--- a/rust/main/agents/relayer/src/scraper_websocket.rs
+++ b/rust/main/agents/relayer/src/scraper_websocket.rs
@@ -1,16 +1,17 @@
 //! Shadow validation of relayer inputs streamed by scraper-proxy.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     time::Duration,
 };
 
 use eyre::{bail, Context, ContextCompat, Result};
 use futures_util::{SinkExt, StreamExt};
 use hyperlane_base::{
+    db::HyperlaneRocksDB,
     scraper_websocket::{
-        EventMessage, ServerMessage, StringOrNumber, SubscribeMessage, SubscribeStream,
-        SubscribedStream,
+        EventMessage, SequenceCursor, ServerMessage, StringOrNumber, SubscribeMessage,
+        SubscribeStream, SubscribedCursor, SubscribedStream,
     },
     CoreMetrics,
 };
@@ -29,23 +30,55 @@ const READ_TIMEOUT: Duration = Duration::from_secs(75);
 const RETRY_DELAY: Duration = Duration::from_secs(5);
 const DUPLICATE_FINGERPRINT_WINDOW: usize = 1_024;
 const CROSS_STREAM_WINDOW: usize = 1_024;
+const DISPATCH_CURSOR_PREFIX: &[u8] = b"scraper_websocket_dispatch_cursor";
+const MERKLE_CURSOR_PREFIX: &[u8] = b"scraper_websocket_merkle_cursor";
 
 #[derive(Clone, Debug)]
 pub(crate) struct ScraperSource {
     chain: String,
+    db: HyperlaneRocksDB,
     domain: u32,
     mailbox: H256,
     merkle_tree_hook: H256,
 }
 
 impl ScraperSource {
-    pub(crate) fn new(chain: String, domain: u32, mailbox: H256, merkle_tree_hook: H256) -> Self {
+    pub(crate) fn new(
+        chain: String,
+        db: HyperlaneRocksDB,
+        domain: u32,
+        mailbox: H256,
+        merkle_tree_hook: H256,
+    ) -> Self {
         Self {
             chain,
+            db,
             domain,
             mailbox,
             merkle_tree_hook,
         }
+    }
+
+    fn address(&self, kind: EventKind) -> H256 {
+        match kind {
+            EventKind::Dispatch => self.mailbox,
+            EventKind::MerkleTreeInsertion => self.merkle_tree_hook,
+        }
+    }
+
+    fn cursor(&self, kind: EventKind) -> Result<Option<u32>> {
+        self.db
+            .retrieve_value_by_key(kind.cursor_prefix(), &self.address(kind))
+            .context("Reading durable scraper WebSocket cursor")
+    }
+
+    fn store_cursor(&self, kind: EventKind, sequence: u32) -> Result<()> {
+        if self.cursor(kind)?.is_some_and(|stored| stored >= sequence) {
+            return Ok(());
+        }
+        self.db
+            .store_value_by_key(kind.cursor_prefix(), &self.address(kind), &sequence)
+            .context("Storing durable scraper WebSocket cursor")
     }
 }
 
@@ -60,6 +93,21 @@ impl EventKind {
         match self {
             Self::Dispatch => DISPATCH_EVENT_TYPE,
             Self::MerkleTreeInsertion => MERKLE_EVENT_TYPE,
+        }
+    }
+
+    fn cursor_prefix(self) -> &'static [u8] {
+        match self {
+            Self::Dispatch => DISPATCH_CURSOR_PREFIX,
+            Self::MerkleTreeInsertion => MERKLE_CURSOR_PREFIX,
+        }
+    }
+
+    fn from_label(label: &str) -> Result<Self> {
+        match label {
+            DISPATCH_EVENT_TYPE => Ok(Self::Dispatch),
+            MERKLE_EVENT_TYPE => Ok(Self::MerkleTreeInsertion),
+            _ => bail!("Unexpected scraper event type {label}"),
         }
     }
 }
@@ -144,6 +192,9 @@ impl CrossStreamState {
         } else {
             None
         };
+        if let Some(mismatch) = mismatch {
+            bail!(mismatch);
+        }
         if !entries.contains_key(&sequence) && entries.len() >= CROSS_STREAM_WINDOW {
             let oldest_complete = entries
                 .first_key_value()
@@ -158,9 +209,6 @@ impl CrossStreamState {
         }
         let pair = entries.entry(sequence).or_default();
         *pair.get_mut(kind) = Some(projection);
-        if let Some(mismatch) = mismatch {
-            bail!(mismatch);
-        }
         Ok(())
     }
 }
@@ -174,6 +222,15 @@ struct StreamCursor {
 }
 
 impl StreamCursor {
+    fn from_after_sequence(sequence: u32) -> Result<Self> {
+        Ok(Self {
+            fingerprints: BTreeMap::new(),
+            next_sequence: sequence
+                .checked_add(1)
+                .context("Scraper event sequence exhausted")?,
+        })
+    }
+
     fn new(sequence: u32, fingerprint: EventFingerprint) -> Result<Self> {
         let mut fingerprints = BTreeMap::new();
         fingerprints.insert(sequence, fingerprint);
@@ -185,7 +242,7 @@ impl StreamCursor {
         })
     }
 
-    fn validate(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<SequenceResult> {
+    fn check(&self, sequence: u32, fingerprint: EventFingerprint) -> Result<SequenceResult> {
         if sequence < self.next_sequence {
             return match self.fingerprints.get(&sequence) {
                 Some(previous) if previous == &fingerprint => Ok(SequenceResult::Duplicate),
@@ -203,7 +260,15 @@ impl StreamCursor {
             .into());
         }
 
-        let next_sequence = self
+        self.next_sequence
+            .checked_add(1)
+            .context("Scraper event sequence exhausted")?;
+
+        Ok(SequenceResult::Accepted)
+    }
+
+    fn accept(&mut self, sequence: u32, fingerprint: EventFingerprint) -> Result<()> {
+        self.next_sequence = self
             .next_sequence
             .checked_add(1)
             .context("Scraper event sequence exhausted")?;
@@ -211,8 +276,13 @@ impl StreamCursor {
         while self.fingerprints.len() > DUPLICATE_FINGERPRINT_WINDOW {
             self.fingerprints.pop_first();
         }
-        self.next_sequence = next_sequence;
-        Ok(SequenceResult::Accepted)
+        Ok(())
+    }
+
+    fn latest_sequence(&self) -> Result<u32> {
+        self.next_sequence
+            .checked_sub(1)
+            .context("Scraper cursor has no accepted sequence")
     }
 }
 
@@ -230,6 +300,40 @@ struct StreamState {
 }
 
 impl StreamState {
+    fn load(sources: &HashMap<u32, ScraperSource>) -> Result<Self> {
+        let mut state = Self::default();
+        for source in sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                if let Some(sequence) = source.cursor(kind)? {
+                    state.cursors.insert(
+                        (source.domain, kind),
+                        StreamCursor::from_after_sequence(sequence)?,
+                    );
+                }
+            }
+        }
+        Ok(state)
+    }
+
+    fn set_baseline(&mut self, domain: u32, kind: EventKind, sequence: i64) -> Result<()> {
+        if self.cursors.contains_key(&(domain, kind)) || sequence < 0 {
+            return Ok(());
+        }
+        let sequence: u32 = sequence
+            .try_into()
+            .context("Scraper caught-up sequence exceeds u32")?;
+        self.cursors
+            .insert((domain, kind), StreamCursor::from_after_sequence(sequence)?);
+        Ok(())
+    }
+
+    fn latest_sequence(&self, domain: u32, kind: EventKind) -> Result<u32> {
+        self.cursors
+            .get(&(domain, kind))
+            .context("Validated scraper stream has no cursor")?
+            .latest_sequence()
+    }
+
     fn validate(
         &mut self,
         event: EventMessage<serde_json::Value>,
@@ -340,16 +444,28 @@ impl StreamState {
         };
 
         let key = (event.domain, kind);
-        let result = match self.cursors.get_mut(&key) {
-            Some(cursor) => cursor.validate(sequence, fingerprint)?,
-            None => {
-                self.cursors
-                    .insert(key, StreamCursor::new(sequence, fingerprint)?);
-                SequenceResult::Accepted
-            }
+        let new_cursor = if self.cursors.contains_key(&key) {
+            None
+        } else {
+            Some(StreamCursor::new(sequence, fingerprint)?)
+        };
+        let result = match self.cursors.get(&key) {
+            Some(cursor) => cursor.check(sequence, fingerprint)?,
+            None => SequenceResult::Accepted,
         };
         self.cross_stream
             .validate(event.domain, sequence, kind, projection)?;
+        if result == SequenceResult::Accepted {
+            match self.cursors.get_mut(&key) {
+                Some(cursor) => cursor.accept(sequence, fingerprint)?,
+                None => {
+                    let _ = self.cursors.insert(
+                        key,
+                        new_cursor.expect("new cursor is prepared before persistence"),
+                    );
+                }
+            }
+        }
         Ok((kind, result))
     }
 }
@@ -369,14 +485,18 @@ impl HandshakeState {
         Ok(())
     }
 
-    fn subscribed(&mut self, streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
+    fn subscribed(
+        &mut self,
+        streams: &[SubscribedStream],
+        sources: &HashMap<u32, ScraperSource>,
+    ) -> Result<()> {
         if !self.sent {
             bail!("Received subscribed before ready");
         }
         if self.confirmed {
             bail!("Received duplicate scraper-proxy subscribed message");
         }
-        validate_subscription(streams, domains)?;
+        validate_subscription(streams, sources)?;
         self.confirmed = true;
         Ok(())
     }
@@ -392,6 +512,7 @@ impl HandshakeState {
 /// One process-wide, read-only scraper stream monitor.
 pub(crate) struct ScraperWebSocketMonitor {
     active: IntGaugeVec,
+    caught_up: IntGaugeVec,
     events: IntCounterVec,
     sources: HashMap<u32, ScraperSource>,
     url: Url,
@@ -413,15 +534,26 @@ impl ScraperWebSocketMonitor {
             "Scraper-proxy shadow events validated by the relayer",
             &["chain", "event_type", "result"],
         )?;
+        let caught_up = metrics.new_int_gauge(
+            "relayer_scraper_websocket_caught_up",
+            "Whether scraper-proxy replay reached the durable cursor",
+            &["chain", "event_type"],
+        )?;
         let sources = sources
             .into_iter()
             .map(|source| (source.domain, source))
             .collect::<HashMap<_, _>>();
         for source in sources.values() {
             active.with_label_values(&[&source.chain]).set(0);
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                caught_up
+                    .with_label_values(&[&source.chain, kind.label()])
+                    .set(0);
+            }
         }
         Ok(Self {
             active,
+            caught_up,
             events,
             sources,
             url,
@@ -429,9 +561,21 @@ impl ScraperWebSocketMonitor {
     }
 
     pub(crate) async fn run(self) {
-        let mut state = StreamState::default();
+        let mut state = loop {
+            match StreamState::load(&self.sources) {
+                Ok(state) => break state,
+                Err(err) => {
+                    warn!(
+                        ?err,
+                        "Loading durable scraper WebSocket cursors failed; retrying"
+                    );
+                    sleep(RETRY_DELAY).await;
+                }
+            }
+        };
         loop {
             self.set_active(false);
+            self.set_caught_up(false);
             match self.stream(&mut state).await {
                 Ok(()) => warn!("Relayer scraper-proxy shadow stream closed; reconnecting"),
                 Err(err) => warn!(
@@ -440,6 +584,7 @@ impl ScraperWebSocketMonitor {
                 ),
             }
             self.set_active(false);
+            self.set_caught_up(false);
             sleep(RETRY_DELAY).await;
         }
     }
@@ -450,6 +595,7 @@ impl ScraperWebSocketMonitor {
             .context("Connecting to relayer scraper-proxy WebSocket timed out")?
             .context("Connecting to relayer scraper-proxy WebSocket")?;
         let mut handshake = HandshakeState::default();
+        let mut caught_up = HashSet::new();
         let read_deadline = sleep(READ_TIMEOUT);
         tokio::pin!(read_deadline);
 
@@ -474,7 +620,7 @@ impl ScraperWebSocketMonitor {
                                 .context("Subscribing to relayer scraper-proxy streams")?;
                         }
                         ServerMessage::Subscribed { streams } => {
-                            handshake.subscribed(&streams, &self.domains())?;
+                            handshake.subscribed(&streams, &self.sources)?;
                             self.set_active(true);
                             info!("Relayer scraper-proxy shadow streams active");
                         }
@@ -483,11 +629,17 @@ impl ScraperWebSocketMonitor {
                             let domain = event.domain;
                             let event_type = event_label(&event.event_type);
                             match state.validate(event, &self.sources) {
-                                Ok((kind, SequenceResult::Accepted)) => {
-                                    self.record(domain, kind.label(), "accepted")
-                                }
-                                Ok((kind, SequenceResult::Duplicate)) => {
-                                    self.record(domain, kind.label(), "duplicate")
+                                Ok((kind, sequence_result)) => {
+                                    let sequence = state.latest_sequence(domain, kind)?;
+                                    self.sources
+                                        .get(&domain)
+                                        .expect("validated scraper source exists")
+                                        .store_cursor(kind, sequence)?;
+                                    let result = match sequence_result {
+                                        SequenceResult::Accepted => "accepted",
+                                        SequenceResult::Duplicate => "duplicate",
+                                    };
+                                    self.record(domain, kind.label(), result)
                                 }
                                 Err(err) => {
                                     let result = if err.downcast_ref::<StreamGap>().is_some() {
@@ -500,8 +652,46 @@ impl ScraperWebSocketMonitor {
                                 }
                             }
                         }
-                        ServerMessage::CaughtUp { .. } => {
-                            bail!("Live-only relayer shadow stream received caught-up marker")
+                        ServerMessage::CaughtUp {
+                            address,
+                            domain,
+                            event_type,
+                            sequence,
+                        } => {
+                            handshake.event()?;
+                            let kind = EventKind::from_label(&event_type)?;
+                            let source = self.sources.get(&domain).with_context(|| {
+                                format!("Unexpected scraper caught-up domain {domain}")
+                            })?;
+                            if parse_address(&address)? != source.address(kind) {
+                                bail!(
+                                    "Scraper caught-up address does not match configured contract"
+                                );
+                            }
+                            let sequence = sequence
+                                .parse::<i64>()
+                                .context("Invalid scraper caught-up sequence")?;
+                            if sequence < -1 {
+                                bail!("Invalid negative scraper caught-up sequence {sequence}");
+                            }
+                            if let Some(stored) = source.cursor(kind)? {
+                                if sequence < i64::from(stored) {
+                                    bail!(
+                                        "Scraper caught-up sequence {sequence} is behind durable cursor {stored}"
+                                    );
+                                }
+                            }
+                            if sequence >= 0 {
+                                let durable: u32 = sequence
+                                    .try_into()
+                                    .context("Scraper caught-up sequence exceeds u32")?;
+                                source.store_cursor(kind, durable)?;
+                            }
+                            state.set_baseline(domain, kind, sequence)?;
+                            if !caught_up.insert((domain, kind)) {
+                                bail!("Received duplicate scraper caught-up marker");
+                            }
+                            self.set_source_caught_up(source, kind, true);
                         }
                         ServerMessage::Error { error } => {
                             bail!("Scraper-proxy rejected relayer shadow stream: {error}")
@@ -523,13 +713,7 @@ impl ScraperWebSocketMonitor {
     }
 
     fn subscription(&self) -> Result<String> {
-        subscription(self.domains())
-    }
-
-    fn domains(&self) -> Vec<u32> {
-        let mut domains = self.sources.keys().copied().collect::<Vec<_>>();
-        domains.sort_unstable();
-        domains
+        subscription(&self.sources)
     }
 
     fn set_active(&self, active: bool) {
@@ -537,6 +721,20 @@ impl ScraperWebSocketMonitor {
         for source in self.sources.values() {
             self.active.with_label_values(&[&source.chain]).set(value);
         }
+    }
+
+    fn set_caught_up(&self, caught_up: bool) {
+        for source in self.sources.values() {
+            for kind in [EventKind::Dispatch, EventKind::MerkleTreeInsertion] {
+                self.set_source_caught_up(source, kind, caught_up);
+            }
+        }
+    }
+
+    fn set_source_caught_up(&self, source: &ScraperSource, kind: EventKind, caught_up: bool) {
+        self.caught_up
+            .with_label_values(&[&source.chain, kind.label()])
+            .set(i64::from(caught_up));
     }
 
     fn record(&self, domain: u32, event_type: &str, result: &str) {
@@ -551,17 +749,35 @@ impl ScraperWebSocketMonitor {
     }
 }
 
-fn subscription(mut domains: Vec<u32>) -> Result<String> {
-    domains.sort_unstable();
+fn subscription(sources: &HashMap<u32, ScraperSource>) -> Result<String> {
+    let mut sources = sources.values().collect::<Vec<_>>();
+    sources.sort_unstable_by_key(|source| source.domain);
+    let domains = sources
+        .iter()
+        .map(|source| source.domain)
+        .collect::<Vec<_>>();
+    let cursors = |kind| -> Result<Vec<SequenceCursor>> {
+        sources
+            .iter()
+            .map(|source| {
+                Ok(SequenceCursor {
+                    address: format!("{:#x}", source.address(kind)),
+                    allow_replay: Some(true),
+                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    domain: source.domain,
+                })
+            })
+            .collect()
+    };
     serde_json::to_string(&SubscribeMessage {
         streams: vec![
             SubscribeStream {
-                cursors: None,
+                cursors: Some(cursors(EventKind::Dispatch)?),
                 domains: Some(domains.clone()),
                 event_type: DISPATCH_EVENT_TYPE,
             },
             SubscribeStream {
-                cursors: None,
+                cursors: Some(cursors(EventKind::MerkleTreeInsertion)?),
                 domains: Some(domains),
                 event_type: MERKLE_EVENT_TYPE,
             },
@@ -571,14 +787,36 @@ fn subscription(mut domains: Vec<u32>) -> Result<String> {
     .context("Serializing relayer scraper-proxy subscription")
 }
 
-fn validate_subscription(streams: &[SubscribedStream], domains: &[u32]) -> Result<()> {
+fn validate_subscription(
+    streams: &[SubscribedStream],
+    sources: &HashMap<u32, ScraperSource>,
+) -> Result<()> {
     if streams.len() != 2 {
         bail!("Scraper-proxy confirmed an unexpected number of streams");
     }
-    for (stream, event_type) in streams.iter().zip([DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]) {
-        if stream.event_type != event_type
-            || stream.cursors.is_some()
-            || stream.domains.as_deref() != Some(domains)
+    let mut sources = sources.values().collect::<Vec<_>>();
+    sources.sort_unstable_by_key(|source| source.domain);
+    let domains = sources
+        .iter()
+        .map(|source| source.domain)
+        .collect::<Vec<_>>();
+    for (stream, kind) in streams
+        .iter()
+        .zip([EventKind::Dispatch, EventKind::MerkleTreeInsertion])
+    {
+        let expected_cursors = sources
+            .iter()
+            .map(|source| {
+                Ok(SubscribedCursor {
+                    address: format!("{:#x}", source.address(kind)),
+                    after_sequence: source.cursor(kind)?.map(|value| value.to_string()),
+                    domain: source.domain,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if stream.event_type != kind.label()
+            || stream.cursors.as_deref() != Some(expected_cursors.as_slice())
+            || stream.domains.as_deref() != Some(domains.as_slice())
         {
             bail!("Scraper-proxy subscription confirmation does not match request");
         }
@@ -662,17 +900,36 @@ fn event_label(event_type: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyperlane_base::db::test_utils;
+    use hyperlane_core::HyperlaneDomain;
 
     fn sources() -> HashMap<u32, ScraperSource> {
-        HashMap::from([(
-            5,
-            ScraperSource::new(
-                "test".to_owned(),
-                5,
-                H256::from_low_u64_be(1),
-                H256::from_low_u64_be(2),
-            ),
-        )])
+        sources_for(&[5])
+    }
+
+    fn sources_for(domains: &[u32]) -> HashMap<u32, ScraperSource> {
+        let tempdir = tempfile::tempdir().expect("temporary scraper cursor DB");
+        let db = test_utils::setup_db(tempdir.path().to_string_lossy().into_owned());
+        std::mem::forget(tempdir);
+        domains
+            .iter()
+            .copied()
+            .map(|domain| {
+                let chain = format!("test-{domain}");
+                let db =
+                    HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain(&chain), db.clone());
+                (
+                    domain,
+                    ScraperSource::new(
+                        chain,
+                        db,
+                        domain,
+                        H256::from_low_u64_be(1),
+                        H256::from_low_u64_be(2),
+                    ),
+                )
+            })
+            .collect()
     }
 
     fn event(
@@ -738,13 +995,31 @@ mod tests {
         })
     }
 
-    fn subscribed_streams(domains: &[u32]) -> Vec<SubscribedStream> {
-        [DISPATCH_EVENT_TYPE, MERKLE_EVENT_TYPE]
+    fn subscribed_streams(sources: &HashMap<u32, ScraperSource>) -> Vec<SubscribedStream> {
+        let mut sources = sources.values().collect::<Vec<_>>();
+        sources.sort_unstable_by_key(|source| source.domain);
+        let domains = sources
+            .iter()
+            .map(|source| source.domain)
+            .collect::<Vec<_>>();
+        [EventKind::Dispatch, EventKind::MerkleTreeInsertion]
             .into_iter()
-            .map(|event_type| SubscribedStream {
-                cursors: None,
-                domains: Some(domains.to_vec()),
-                event_type: event_type.to_owned(),
+            .map(|kind| SubscribedStream {
+                cursors: Some(
+                    sources
+                        .iter()
+                        .map(|source| SubscribedCursor {
+                            address: format!("{:#x}", source.address(kind)),
+                            after_sequence: source
+                                .cursor(kind)
+                                .expect("cursor read")
+                                .map(|value| value.to_string()),
+                            domain: source.domain,
+                        })
+                        .collect(),
+                ),
+                domains: Some(domains.clone()),
+                event_type: kind.label().to_owned(),
             })
             .collect()
     }
@@ -797,6 +1072,37 @@ mod tests {
             .expect_err("gap must reject")
             .to_string()
             .contains("expected sequence 8"));
+    }
+
+    #[test]
+    fn restores_durable_sequence_after_process_restart() {
+        let sources = sources();
+        let mut first_process = StreamState::load(&sources).expect("initial cursor load");
+        first_process
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 7, dispatch_data(7, b"seven")),
+                &sources,
+            )
+            .expect("persist first event");
+        sources[&5]
+            .store_cursor(EventKind::Dispatch, 7)
+            .expect("store first event cursor");
+
+        let mut restarted = StreamState::load(&sources).expect("restart cursor load");
+        assert!(restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 9, dispatch_data(9, b"nine")),
+                &sources,
+            )
+            .expect_err("restart gap must reject")
+            .to_string()
+            .contains("expected sequence 8"));
+        restarted
+            .validate(
+                event(DISPATCH_EVENT_TYPE, 8, dispatch_data(8, b"eight")),
+                &sources,
+            )
+            .expect("replayed event after durable cursor");
     }
 
     #[test]
@@ -1006,51 +1312,66 @@ mod tests {
     #[test]
     fn enforces_subscription_handshake_order() {
         let mut handshake = HandshakeState::default();
-        let domains = [5];
-        let streams = subscribed_streams(&domains);
+        let sources = sources();
+        let streams = subscribed_streams(&sources);
         assert!(handshake.event().is_err());
-        assert!(handshake.subscribed(&streams, &domains).is_err());
+        assert!(handshake.subscribed(&streams, &sources).is_err());
         handshake.ready().expect("ready");
         assert!(handshake.event().is_err());
         handshake
-            .subscribed(&streams, &domains)
+            .subscribed(&streams, &sources)
             .expect("subscribed");
         handshake.event().expect("event after confirmation");
-        assert!(handshake.subscribed(&streams, &domains).is_err());
+        assert!(handshake.subscribed(&streams, &sources).is_err());
         assert!(handshake.ready().is_err());
     }
 
     #[test]
     fn rejects_subscription_confirmation_mismatch() {
-        let domains = [5];
+        let sources = sources();
         for streams in [
-            subscribed_streams(&[9]),
+            subscribed_streams(&sources_for(&[9])),
             vec![SubscribedStream {
                 cursors: None,
-                domains: Some(domains.to_vec()),
+                domains: Some(vec![5]),
                 event_type: DISPATCH_EVENT_TYPE.to_owned(),
             }],
-            subscribed_streams(&domains).into_iter().rev().collect(),
+            subscribed_streams(&sources).into_iter().rev().collect(),
         ] {
             let mut handshake = HandshakeState::default();
             handshake.ready().expect("ready");
-            assert!(handshake.subscribed(&streams, &domains).is_err());
+            assert!(handshake.subscribed(&streams, &sources).is_err());
             assert!(!handshake.confirmed);
         }
     }
 
     #[test]
     fn multiplexes_live_streams_on_one_subscription() {
+        let sources = sources_for(&[9, 5]);
         let message: serde_json::Value =
-            serde_json::from_str(&subscription(vec![9, 5]).expect("subscription should serialize"))
+            serde_json::from_str(&subscription(&sources).expect("subscription should serialize"))
                 .expect("subscription JSON");
 
         assert_eq!(
             message,
             serde_json::json!({
                 "streams": [
-                    { "domains": [5, 9], "eventType": "dispatch" },
-                    { "domains": [5, 9], "eventType": "merkle_tree_insertion" }
+                    {
+                        "cursors": [
+                            { "address": format!("{:#x}", H256::from_low_u64_be(1)), "allowReplay": true, "domain": 5 },
+                            { "address": format!("{:#x}", H256::from_low_u64_be(1)), "allowReplay": true, "domain": 9 }
+                        ],
+                        "domains": [5, 9],
+                        "eventType": "dispatch"
+                    },
+                    {
+                        "cursors": [
+                            { "address": format!("{:#x}", H256::from_low_u64_be(2)), "allowReplay": true, "domain": 5 },
+                            { "address": format!("{:#x}", H256::from_low_u64_be(2)), "allowReplay": true, "domain": 9 }
+                        ],
+                        "domains": [5, 9],
+                        "eventType": "merkle_tree_insertion"
+                    }
                 ],
                 "type": "subscribe"
             })

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -73,6 +73,8 @@ pub struct RelayerSettings {
     pub tx_id_indexing_enabled: bool,
     /// Whether to enable IGP indexing.
     pub igp_indexing_enabled: bool,
+    /// Optional scraper-proxy WebSocket used for shadow stream validation.
+    pub websocket_url: Option<url::Url>,
     /// Whether to enable the relay API endpoint (default: false)
     ///
     /// # Deployment requirement
@@ -404,6 +406,20 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_bool()
             .unwrap_or(true);
 
+        let websocket_url: Option<url::Url> = p
+            .chain(&mut err)
+            .get_opt_key("websocketUrl")
+            .parse_from_str("Expected a valid scraper-proxy WebSocket URL")
+            .end();
+        if let Some(url) = &websocket_url {
+            if !matches!(url.scheme(), "ws" | "wss") {
+                err.push(
+                    cwp.clone(),
+                    eyre::eyre!("`websocketUrl` must use ws:// or wss://"),
+                );
+            }
+        }
+
         let relay_api_enabled = p
             .chain(&mut err)
             .get_opt_key("relayApiEnabled")
@@ -480,6 +496,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             max_retries: max_message_retries,
             tx_id_indexing_enabled,
             igp_indexing_enabled,
+            websocket_url,
             relay_api_enabled,
             relay_api_port,
             relay_api_rate_limit_max_requests,
@@ -660,5 +677,37 @@ mod test {
             }],
         }))
         .expect("zero feeToken should parse");
+    }
+
+    #[test]
+    fn parses_scraper_websocket_url() {
+        let settings = parse_settings(json!({
+            "relaychains": "legacy",
+            "websocketurl": "wss://scraper.example/ws/events",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+        }))
+        .expect("valid WebSocket URL should parse");
+
+        assert_eq!(
+            settings.websocket_url.expect("configured URL").as_str(),
+            "wss://scraper.example/ws/events"
+        );
+    }
+
+    #[test]
+    fn rejects_non_websocket_scraper_url() {
+        let error = parse_settings(json!({
+            "relaychains": "legacy",
+            "websocketurl": "https://scraper.example/ws/events",
+            "chains": {
+                "legacy": chain_config("legacy", 1000),
+            },
+        }))
+        .expect_err("HTTP URL must reject")
+        .to_string();
+
+        assert!(error.contains("must use ws:// or wss://"));
     }
 }

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -535,7 +535,7 @@ impl MerkleTreeHookWebSocketSync {
                             .context("Subscribing to Merkle tree hook insertions")?;
                         subscription_state = next_state;
                     }
-                    ServerMessage::Subscribed => {
+                    ServerMessage::Subscribed { .. } => {
                         subscription_state = subscription_state.receive_subscribed()?;
                         if *next_sequence < backfill_target {
                             info!(

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -1772,7 +1772,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -1934,7 +1936,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -2028,7 +2032,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -2147,7 +2153,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket
@@ -2262,7 +2270,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             while calls_in_server.load(Ordering::SeqCst) == 0 {
@@ -2378,7 +2388,9 @@ mod tests {
                 .expect("subscription message")
                 .expect("read subscription message");
             socket
-                .send(Message::Text(r#"{"type":"subscribed"}"#.into()))
+                .send(Message::Text(
+                    r#"{"type":"subscribed","streams":[]}"#.into(),
+                ))
                 .await
                 .expect("send subscribed message");
             socket

--- a/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
+++ b/rust/main/agents/validator/src/merkle_tree_hook_sync.rs
@@ -927,8 +927,15 @@ impl MerkleTreeHookWebSocketSync {
             bail!("Unexpected Merkle tree hook caught-up marker");
         }
         let sequence = sequence
-            .parse::<u32>()
+            .parse::<i64>()
             .context("Invalid caught-up sequence")?;
+        if sequence == -1 {
+            if next_sequence != 0 {
+                bail!("Empty caught-up marker does not match validator cursor");
+            }
+            return Ok(true);
+        }
+        let sequence = u32::try_from(sequence).context("Invalid caught-up sequence")?;
         if sequence >= next_sequence {
             bail!("Caught-up marker skipped Merkle tree insertions");
         }
@@ -1888,6 +1895,15 @@ mod tests {
             .expect("stale marker"));
         assert!(sync
             .validate_caught_up(&hook, 1, EVENT_TYPE, "2", 2)
+            .is_err());
+        assert!(sync
+            .validate_caught_up(&hook, 1, EVENT_TYPE, "-1", 0)
+            .expect("empty marker at empty cursor"));
+        assert!(sync
+            .validate_caught_up(&hook, 1, EVENT_TYPE, "-1", 1)
+            .is_err());
+        assert!(sync
+            .validate_caught_up(&hook, 1, EVENT_TYPE, "-2", 0)
             .is_err());
     }
 

--- a/rust/main/hyperlane-base/src/scraper_websocket.rs
+++ b/rust/main/hyperlane-base/src/scraper_websocket.rs
@@ -51,7 +51,10 @@ pub enum ServerMessage<T> {
     /// The connection is ready to receive a subscription.
     Ready,
     /// The subscription was accepted.
-    Subscribed,
+    Subscribed {
+        /// Streams accepted by scraper-proxy.
+        streams: Vec<SubscribedStream>,
+    },
     /// Historical replay reached the scraper's current cursor.
     #[serde(rename_all = "camelCase")]
     CaughtUp {
@@ -74,6 +77,30 @@ pub enum ServerMessage<T> {
     /// A forwards-compatible protocol message not understood by this client.
     #[serde(other)]
     Other,
+}
+
+/// One stream echoed by scraper-proxy after subscription.
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SubscribedStream {
+    /// Durable cursors accepted for this stream.
+    pub cursors: Option<Vec<SubscribedCursor>>,
+    /// Domains accepted for this stream.
+    pub domains: Option<Vec<u32>>,
+    /// Scraper event type.
+    pub event_type: String,
+}
+
+/// One durable cursor echoed by scraper-proxy after subscription.
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SubscribedCursor {
+    /// Contract address encoded for scraper-proxy.
+    pub address: String,
+    /// Last processed sequence, encoded as a decimal string.
+    pub after_sequence: Option<String>,
+    /// Hyperlane domain identifier.
+    pub domain: u32,
 }
 
 /// Common envelope around scraper event-specific data.
@@ -226,6 +253,30 @@ mod tests {
         match message {
             ServerMessage::Event(event) => assert_eq!(event.sequence, None),
             _ => panic!("expected event"),
+        }
+    }
+
+    #[test]
+    fn deserializes_subscription_confirmation() {
+        let message: ServerMessage<TestData> = serde_json::from_value(serde_json::json!({
+            "type": "subscribed",
+            "streams": [{
+                "domains": [5, 9],
+                "eventType": "dispatch"
+            }]
+        }))
+        .expect("subscription confirmation should deserialize");
+
+        match message {
+            ServerMessage::Subscribed { streams } => assert_eq!(
+                streams,
+                vec![SubscribedStream {
+                    cursors: None,
+                    domains: Some(vec![5, 9]),
+                    event_type: "dispatch".to_owned(),
+                }]
+            ),
+            _ => panic!("expected subscription confirmation"),
         }
     }
 

--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -793,6 +793,7 @@ const hyperlane: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayer,
@@ -869,6 +870,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
     index: { from: RELEASE_CANDIDATE_INDEX_FROM },
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerRC,
@@ -1012,6 +1014,7 @@ const fastPath: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: mainnetDockerTags.relayerFastPath,

--- a/typescript/infra/config/environments/testnet4/agent.ts
+++ b/typescript/infra/config/environments/testnet4/agent.ts
@@ -241,6 +241,7 @@ const hyperlane: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayer,
@@ -305,6 +306,7 @@ const releaseCandidate: RootAgentConfig = {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
     index: { from: RELEASE_CANDIDATE_INDEX_FROM },
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerRC,
@@ -349,6 +351,7 @@ const fastPath: RootAgentConfig = {
   relayer: {
     rpcConsensusType: RpcConsensusType.Fallback,
     ...fallbackHedgeConfig,
+    websocketUrl: scraperWebsocketUrl,
     docker: {
       repo: DockerImageRepos.AGENT,
       tag: testnetDockerTags.relayerFastPath,

--- a/typescript/infra/src/config/agent/relayer.ts
+++ b/typescript/infra/src/config/agent/relayer.ts
@@ -84,6 +84,7 @@ export interface BaseRelayerConfig {
   batch?: RelayerBatchConfig;
   txIdIndexingEnabled?: boolean;
   igpIndexingEnabled?: boolean;
+  websocketUrl?: string;
   reorgPeriodOverrides?: ChainMap<number>;
   interval?: number;
   relayApi?: RelayApiConfig;
@@ -196,6 +197,9 @@ export class RelayerConfigHelper extends AgentConfigHelper<RelayerConfig> {
     relayerConfig.allowContractCallCaching = baseConfig.cache?.enabled ?? false;
     relayerConfig.txIdIndexingEnabled = baseConfig.txIdIndexingEnabled ?? true;
     relayerConfig.igpIndexingEnabled = baseConfig.igpIndexingEnabled ?? true;
+    if (baseConfig.websocketUrl !== undefined) {
+      relayerConfig.websocketUrl = baseConfig.websocketUrl;
+    }
     if (baseConfig.relayApi !== undefined) {
       relayerConfig.relayApiEnabled = baseConfig.relayApi.enabled;
       if (baseConfig.relayApi.port !== undefined) {

--- a/typescript/infra/test/agent-configs.test.ts
+++ b/typescript/infra/test/agent-configs.test.ts
@@ -207,13 +207,22 @@ describe('Agent configs', () => {
     });
 
     Object.entries(agents).forEach(([context, config]) => {
-      if (!config.validators) return;
+      const { relayer, validators } = config;
+      if (validators) {
+        it(`configures ${environment}/${context} validators for the shared scraper`, () => {
+          expect(validators.websocketUrl).to.equal(
+            `ws://scraper-proxy.${environment}.svc.cluster.local:8383/agents`,
+          );
+        });
+      }
 
-      it(`configures ${environment}/${context} validators for the shared scraper`, () => {
-        expect(config.validators?.websocketUrl).to.equal(
-          `ws://scraper-proxy.${environment}.svc.cluster.local:8383/agents`,
-        );
-      });
+      if (relayer) {
+        it(`configures ${environment}/${context} relayers for the shared scraper`, () => {
+          expect(relayer.websocketUrl).to.equal(
+            `ws://scraper-proxy.${environment}.svc.cluster.local:8383/agents`,
+          );
+        });
+      }
     });
   });
 

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -547,7 +547,7 @@ void it('enforces the catch-up deadline while pending rows replenish', async (co
   }
 });
 
-void it('rejects an empty historical cursor instead of reporting caught up', async () => {
+void it('reports a fresh empty historical cursor at -1', async () => {
   const socket = new WebSocket(url);
   const messages: Record<string, unknown>[] = [];
   socket.on('message', (data) => {
@@ -558,7 +558,38 @@ void it('rejects an empty historical cursor instead of reporting caught up', asy
         JSON.stringify({
           streams: [
             {
-              cursors: [{ address: emptyHook, afterSequence: '-1', domain: 1 }],
+              cursors: [{ address: emptyHook, domain: 1 }],
+              eventType: 'merkle_tree_insertion',
+            },
+          ],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+  const message = await waitFor(messages, 'caught_up');
+  assert.equal(message.address, '0xcccccccccccccccccccccccccccccccccccccccc');
+  assert.equal(message.sequence, '-1');
+  assert.equal(
+    messages.some(({ type }) => type === 'error'),
+    false,
+  );
+  socket.close();
+  await new Promise<void>((resolve) => socket.once('close', resolve));
+});
+
+void it('rejects a durable cursor when its history is empty', async () => {
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    messages.push(message);
+    if (message.type === 'ready') {
+      socket.send(
+        JSON.stringify({
+          streams: [
+            {
+              cursors: [{ address: emptyHook, afterSequence: '0', domain: 1 }],
               eventType: 'merkle_tree_insertion',
             },
           ],
@@ -571,6 +602,49 @@ void it('rejects an empty historical cursor instead of reporting caught up', asy
   assert.equal(message.error, 'Failed to catch up merkle_tree_insertion');
   assert.equal(
     messages.some(({ type }) => type === 'caught_up'),
+    false,
+  );
+  socket.close();
+  await new Promise<void>((resolve) => socket.once('close', resolve));
+});
+
+void it('catches up populated and fresh empty origins together', async () => {
+  const socket = new WebSocket(url);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    messages.push(message);
+    if (message.type === 'ready') {
+      socket.send(
+        JSON.stringify({
+          streams: [
+            {
+              cursors: [
+                { address: hookA, afterSequence: '-1', domain: 1 },
+                { address: emptyHook, domain: 2 },
+              ],
+              eventType: 'merkle_tree_insertion',
+            },
+          ],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+  await waitUntil(
+    () => messages.filter(({ type }) => type === 'caught_up').length === 2,
+  );
+  assert.deepEqual(
+    messages
+      .filter(({ type }) => type === 'caught_up')
+      .map(({ domain, sequence }) => [domain, sequence]),
+    [
+      [1, '0'],
+      [2, '-1'],
+    ],
+  );
+  assert.equal(
+    messages.some(({ type }) => type === 'error'),
     false,
   );
   socket.close();

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -644,9 +644,19 @@ export class EventWebSocketServer {
     const key = sequenceKey(cursor.domain, cursor.address);
     const { first, last } = await this.sequenceBounds(eventType, cursor);
     if (last < first) {
-      throw new Error(
-        `No ${eventType} history for domain ${cursor.domain} address ${displayAddress(cursor.address)}`,
-      );
+      if (cursor.afterSequence !== undefined && cursor.afterSequence !== -1n) {
+        throw new Error(
+          `No ${eventType} history for domain ${cursor.domain} address ${displayAddress(cursor.address)}`,
+        );
+      }
+      subscription.sequences.set(key, last);
+      return this.sendAndWait(socket, {
+        address: displayAddress(cursor.address),
+        domain: cursor.domain,
+        eventType,
+        sequence: last.toString(),
+        type: 'caught_up',
+      });
     }
     const requestedAfter = cursor.afterSequence ?? last;
     if (requestedAfter > last && !cursor.allowReplay) {

--- a/typescript/sdk/src/metadata/agentConfig.test.ts
+++ b/typescript/sdk/src/metadata/agentConfig.test.ts
@@ -133,6 +133,25 @@ describe('RelayerAgentConfigSchema feeToken gate', () => {
     );
     expect(result.success).to.be.true;
   });
+
+  it('accepts only WebSocket schemes for the scraper URL', () => {
+    expect(
+      RelayerAgentConfigSchema.safeParse(
+        config({
+          gasPaymentEnforcement: [{ type: 'onChainFeeQuoting' }],
+          websocketUrl: 'wss://scraper.example/ws/events',
+        }),
+      ).success,
+    ).to.be.true;
+    expect(
+      RelayerAgentConfigSchema.safeParse(
+        config({
+          gasPaymentEnforcement: [{ type: 'onChainFeeQuoting' }],
+          websocketUrl: 'https://scraper.example/ws/events',
+        }),
+      ).success,
+    ).to.be.false;
+  });
 });
 
 describe('AgentChainMetadataSchema additionalQuorumRpcUrls', () => {

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -622,7 +622,6 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
     .optional()
     .describe('Whether to enable IGP indexing'),
   websocketUrl: z
-    .string()
     .url()
     .refine(
       (value) => value.startsWith('ws://') || value.startsWith('wss://'),

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -621,6 +621,19 @@ export const RelayerAgentConfigSchema = AgentConfigSchema.extend({
     .boolean()
     .optional()
     .describe('Whether to enable IGP indexing'),
+  websocketUrl: z
+    .string()
+    .url()
+    .refine(
+      (value) => value.startsWith('ws://') || value.startsWith('wss://'),
+      {
+        message: 'websocketUrl must use ws:// or wss://',
+      },
+    )
+    .optional()
+    .describe(
+      'Scraper-proxy WebSocket URL used to shadow dispatch and Merkle streams.',
+    ),
   relayApiEnabled: z
     .boolean()
     .optional()


### PR DESCRIPTION
## Summary

- compare every validated scraper dispatch/Merkle event with the RPC-indexed local RocksDB record
- admit work to a bounded 256-job global queue and one FIFO worker per `(domain, event kind)`
- carry the event's actual wire sequence through parity; never derive cursor advancement from a later in-memory tip
- run at most four blocking reads and retry `missing` until match or terminal expiry
- open a process-lifetime fail-closed circuit on a 5s blocking-read/capacity timeout
- persist terminal unhealthy state before a non-matching cursor and restrict caught-up cursor baselines to true fresh starts
- advance the durable correlation watermark only after same-connection cross-stream completion and matching FIFO parity for both streams
- stage fresh sequenced parity within the existing 256-item bound until both proxy baselines establish a replay-safe frontier
- mark staged work pending and parity unready at admission, before it can enter the worker queue
- advance fresh-source staging from the per-domain correlation frontier instead of rescanning from evicted sequence zero

RPC indexing and delivery remain authoritative.

## Expected improvement

Expected parity coverage is **100% of accepted/duplicate events**, with **0 capacity skips**. Four independent reads give a modeled **up to 4x parity-stage throughput** versus the previous effective single-file path; this is not whole-relayer throughput.

Independent RPC reduction: **0%**. This PR is a correctness gate for later cutover.

## Correctness

- per-stream FIFO admission prevents later terminal work from advancing past unresolved earlier work
- replayed duplicates persist their actual sequence, not `state.latest_sequence`
- the first blocked-read timeout drops every parity-ready gauge to zero and prevents any later blocking spawn, including pre-circuit semaphore waiters
- at most four timed-out blocking closures can remain; queue permits drain and the WebSocket reader does not deadlock
- terminal poison is durable before cursor advancement; poison/cursor persistence failure cannot advance later work or wedge `worker_running`
- a caught-up marker may create a cursor only for a true fresh start with no replay and no pending parity
- unequal fresh markers admit no parity; empty streams require sequence zero and persist a replay-required correlation anchor before any worker can advance a stream cursor
- positive fresh markers require each already-staged stream to begin at exactly `marker + 1`; the first observed sequence is retained beyond the duplicate window
- staged empty-stream parity drains only complete correlated prefixes, retaining unmatched higher sequences
- correlation-window pruning cannot strand fresh-source parity; the durable frontier advances beyond the 1,024-pair retention window
- staged admission immediately increments `parity_pending` and clears `parity_ready`; queue transfer does not double-count, and cleanup removes only work that remains staged
- timeout poison is intentionally sticky; repair must reset poison and cursor together
- each connection owns an immutable replay plan and generation; queued completions from older generations cannot combine with newer parity
- correlation progress is the minimum of the contiguous wire frontier and both matching parity frontiers
- inherited fresh baselines stage both streams until a crash-safe anchor exists; parity never authorizes an earlier durable correlation jump

## Canary targets

- parity terminal coverage / accepted events = `1.0` per chain/event type
- zero sustained `conflict`, `expired`, or `error`
- `parity_pending` drains to zero and `parity_ready` remains one

## Verification

- relayer scraper-WebSocket tests: **47/47 passed**, including a 1,025-pair fresh-source regression
- Aleo relayer check and strict Clippy
- Rust formatting, diff checks, and normal pre-commit hooks

## Stack

Stacked on exact #9397 head `6cb12379e56055d3ce2d997781380e0ea7164c32`. Exact head `24e11c624affe041394ca1d9f82639ee618f633e`; parent of #9393.
