### PR TITLE
perf(relayer): index pending messages by destination

### DIFF
--- a/rust/main/agents/relayer/src/db_loader.rs
+++ b/rust/main/agents/relayer/src/db_loader.rs
@@ -34,12 +34,16 @@ impl DbLoader {
         let name = self.ticker.name();
         let instrumented = TaskMonitor::instrument(
             &task_monitor,
-            async move { self.main_loop().await }.instrument(span),
+            async move { self.run().await }.instrument(span),
         );
         tokio::task::Builder::new()
             .name(&name)
             .spawn(instrumented)
             .expect("spawning tokio task from Builder is infallible")
+    }
+
+    pub async fn run(self) {
+        self.main_loop().await;
     }
 
     async fn main_loop(mut self) {

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -91,6 +91,11 @@ impl DestinationIndexIterator {
         db: &HyperlaneRocksDB,
         metrics: &MessageDbLoaderMetrics,
     ) -> Result<Option<(IndexDirection, u32, H256)>> {
+        if self.low_nonce.is_none() && self.low_range_reopen_pending {
+            self.low_range_reopen_pending = false;
+            self.reopen_low_range();
+        }
+
         if let Some(nonce) = self.reconsider_nonces.first().copied() {
             metrics
                 .logical_db_reads

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::max,
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt::{Debug, Formatter},
     sync::Arc,
     time::Duration,
@@ -16,6 +16,7 @@ use hyperlane_base::{
     CoreMetrics,
 };
 use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H256, H512};
+use parking_lot::Mutex;
 use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use tokio::sync::mpsc::{error::TryRecvError, error::TrySendError, Receiver, Sender};
 use tracing::{debug, instrument, trace};
@@ -67,6 +68,7 @@ struct DestinationIndexIterator {
     low_nonce: Option<u32>,
     next_direction: IndexDirection,
     reconsider_nonces: BTreeSet<u32>,
+    loaded_messages: Arc<Mutex<HashSet<H256>>>,
 }
 
 impl DestinationIndexIterator {
@@ -78,6 +80,7 @@ impl DestinationIndexIterator {
             low_nonce: highest_seen_nonce.and_then(|nonce| nonce.checked_sub(1)),
             next_direction: IndexDirection::High,
             reconsider_nonces: BTreeSet::new(),
+            loaded_messages: Default::default(),
         }
     }
 
@@ -674,6 +677,16 @@ impl MessageDbLoader {
             return Ok(true);
         }
 
+        let Some(loaded_message_guard) = LoadedMessageGuard::try_acquire(
+            message.id(),
+            self.destination_iterators[iterator_index]
+                .loaded_messages
+                .clone(),
+        ) else {
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        };
+
         DirectionalNonceIterator::update_max_nonce_gauge(&message, &self.metrics);
         // Retain disqualified entries so restart or configuration changes reconsider them.
         if !self.message_whitelist.msg_matches(&message, true) {
@@ -708,7 +721,7 @@ impl MessageDbLoader {
         let app_context = AppContextClassifier::new(self.metric_app_contexts.clone())
             .get_app_context(&message)
             .await?;
-        let Some(pending_message) = PendingMessage::maybe_from_persisted_retries(
+        let Some(mut pending_message) = PendingMessage::maybe_from_persisted_retries(
             message,
             destination_msg_ctx.clone(),
             app_context,
@@ -717,6 +730,7 @@ impl MessageDbLoader {
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         };
+        pending_message.set_loaded_message_guard(loaded_message_guard);
         match sender.try_send(vec![Box::new(pending_message) as QueueOperation]) {
             Ok(()) => {
                 self.destination_iterators[iterator_index].advance(direction, nonce);

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -172,6 +172,12 @@ impl DestinationIndexIterator {
             self.reconsider_nonces.insert(nonce);
         }
     }
+
+    fn reopen_low_range(&mut self) {
+        if self.low_nonce.is_none() {
+            self.low_nonce = self.high_nonce.and_then(|nonce| nonce.checked_sub(1));
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -472,10 +478,11 @@ impl MessageDbLoader {
     /// backpressure the message indexer while the loader is processing a backlog.
     fn drain_index_notifications(&mut self) {
         let mut disconnected = false;
+        let mut received = false;
         if let Some(receiver) = self.index_notifications.as_mut() {
             loop {
                 match receiver.try_recv() {
-                    Ok(_) => {}
+                    Ok(_) => received = true,
                     Err(TryRecvError::Empty) => break,
                     Err(TryRecvError::Disconnected) => {
                         disconnected = true;
@@ -486,6 +493,11 @@ impl MessageDbLoader {
         }
         if disconnected {
             self.index_notifications = None;
+        }
+        if received {
+            for iterator in &mut self.destination_iterators {
+                iterator.reopen_low_range();
+            }
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -196,6 +196,14 @@ impl DestinationIndexIterator {
         }
     }
 
+    fn reconsider_migrated(&mut self, nonce: u32) {
+        if self.high_nonce.is_none_or(|high| nonce < high) {
+            // Migration walks descending nonces. Retain a range boundary rather
+            // than one in-memory entry per row for a saturated destination.
+            self.low_nonce = Some(self.low_nonce.map_or(nonce, |low| low.max(nonce)));
+        }
+    }
+
     fn request_low_range_reopen(&mut self) {
         if self.low_nonce.is_none() {
             self.reopen_low_range();
@@ -258,15 +266,9 @@ impl LegacyMessageIterator {
         metrics: &MessageDbLoaderMetrics,
     ) -> Result<Option<HyperlaneMessage>> {
         let status = if self.high_nonce_iter.nonce.is_some() {
-            let status = self.high_nonce_iter.try_get_next_nonce(metrics)?;
-            // Newer messages are atomically indexed, so migration stops at its startup watermark.
-            self.high_nonce_iter.nonce = None;
-            status
+            self.high_nonce_iter.try_get_next_nonce(metrics)?
         } else if self.low_nonce_iter.nonce.is_some() {
-            let status = self.low_nonce_iter.try_get_next_nonce(metrics)?;
-            // Legacy gaps are safe to cross because this iterator has a fixed startup watermark.
-            self.low_nonce_iter.iterate();
-            status
+            self.low_nonce_iter.try_get_next_nonce(metrics)?
         } else {
             return Ok(None);
         };
@@ -275,6 +277,18 @@ impl LegacyMessageIterator {
             MessageStatus::Processable(message) => Some(message),
             MessageStatus::Unindexed | MessageStatus::Processed => None,
         })
+    }
+
+    // Acknowledge only after the caller has durably reconciled the current row.
+    // Failed reconciliation and cancellation must leave the nonce retryable.
+    fn advance(&mut self) {
+        if self.high_nonce_iter.nonce.is_some() {
+            // Newer messages are atomically indexed, so migration stops at its startup watermark.
+            self.high_nonce_iter.nonce = None;
+        } else {
+            // Legacy gaps are safe to cross because this iterator has a fixed startup watermark.
+            self.low_nonce_iter.iterate();
+        }
     }
 
     fn migration_complete(&self) -> bool {
@@ -461,14 +475,10 @@ impl DbLoaderExt for MessageDbLoader {
             self.destination_scan_pending = false;
         }
 
-        let migration_blocked = self
-            .destination_iterators
-            .iter()
-            .any(|iterator| !iterator.reconsider_nonces.is_empty());
         if migration_was_active && self.migration_iterator.is_none() {
             return Ok(());
         }
-        if self.migration_iterator.is_none() || migration_blocked {
+        if self.migration_iterator.is_none() {
             self.wait_for_work().await;
         }
         Ok(())
@@ -638,13 +648,6 @@ impl MessageDbLoader {
     }
 
     async fn migrate_legacy_batch(&mut self) -> Result<()> {
-        if self
-            .destination_iterators
-            .iter()
-            .any(|iterator| !iterator.reconsider_nonces.is_empty())
-        {
-            return Ok(());
-        }
         let Some(iterator) = self.migration_iterator.as_mut() else {
             return Ok(());
         };
@@ -671,11 +674,13 @@ impl MessageDbLoader {
                     .iter_mut()
                     .find(|iterator| iterator.destination == message.destination)
                 {
-                    iterator.reconsider(message.nonce);
+                    iterator.reconsider_migrated(message.nonce);
                 }
                 self.destination_scan_pending = true;
+                iterator.advance();
                 break;
             }
+            iterator.advance();
             if iterator.migration_complete() {
                 break;
             }

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::max,
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     fmt::{Debug, Formatter},
     sync::Arc,
     time::Duration,
@@ -52,10 +52,11 @@ pub struct MessageDbLoader {
     index_notifications: Option<Receiver<H512>>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum IndexDirection {
     High,
     Low,
+    Reconsider,
 }
 
 #[derive(Debug)]
@@ -64,6 +65,8 @@ struct DestinationIndexIterator {
     destination_label: Arc<str>,
     high_nonce: Option<u32>,
     low_nonce: Option<u32>,
+    next_direction: IndexDirection,
+    reconsider_nonces: BTreeSet<u32>,
 }
 
 impl DestinationIndexIterator {
@@ -73,15 +76,17 @@ impl DestinationIndexIterator {
             destination_label: destination.to_string().into(),
             high_nonce: Some(highest_seen_nonce.unwrap_or_default()),
             low_nonce: highest_seen_nonce.and_then(|nonce| nonce.checked_sub(1)),
+            next_direction: IndexDirection::High,
+            reconsider_nonces: BTreeSet::new(),
         }
     }
 
     fn peek(
-        &self,
+        &mut self,
         db: &HyperlaneRocksDB,
         metrics: &MessageDbLoaderMetrics,
     ) -> Result<Option<(IndexDirection, u32, H256)>> {
-        if let Some(nonce) = self.high_nonce {
+        if let Some(nonce) = self.reconsider_nonces.first().copied() {
             metrics
                 .logical_db_reads
                 .with_label_values(&[
@@ -91,13 +96,31 @@ impl DestinationIndexIterator {
                     "index",
                 ])
                 .inc();
-            if let Some((nonce, message_id)) =
+            if let Some((indexed_nonce, message_id)) =
                 db.retrieve_pending_message_at_or_after(self.destination, nonce)?
             {
-                return Ok(Some((IndexDirection::High, nonce, message_id)));
+                if indexed_nonce == nonce {
+                    return Ok(Some((IndexDirection::Reconsider, nonce, message_id)));
+                }
             }
+            self.reconsider_nonces.remove(&nonce);
         }
-        if let Some(nonce) = self.low_nonce {
+
+        let directions = match self.next_direction {
+            IndexDirection::High | IndexDirection::Reconsider => {
+                [IndexDirection::High, IndexDirection::Low]
+            }
+            IndexDirection::Low => [IndexDirection::Low, IndexDirection::High],
+        };
+        for direction in directions {
+            let nonce = match direction {
+                IndexDirection::High => self.high_nonce,
+                IndexDirection::Low => self.low_nonce,
+                IndexDirection::Reconsider => None,
+            };
+            let Some(nonce) = nonce else {
+                continue;
+            };
             metrics
                 .logical_db_reads
                 .with_label_values(&[
@@ -107,10 +130,20 @@ impl DestinationIndexIterator {
                     "index",
                 ])
                 .inc();
-            if let Some((nonce, message_id)) =
-                db.retrieve_pending_message_at_or_before(self.destination, nonce)?
-            {
-                return Ok(Some((IndexDirection::Low, nonce, message_id)));
+            let entry = match direction {
+                IndexDirection::High => {
+                    db.retrieve_pending_message_at_or_after(self.destination, nonce)?
+                }
+                IndexDirection::Low => {
+                    db.retrieve_pending_message_at_or_before(self.destination, nonce)?
+                }
+                IndexDirection::Reconsider => unreachable!(),
+            };
+            if let Some((nonce, message_id)) = entry {
+                return Ok(Some((direction, nonce, message_id)));
+            }
+            if direction == IndexDirection::Low {
+                self.low_nonce = None;
             }
         }
         Ok(None)
@@ -118,8 +151,25 @@ impl DestinationIndexIterator {
 
     fn advance(&mut self, direction: IndexDirection, nonce: u32) {
         match direction {
-            IndexDirection::High => self.high_nonce = nonce.checked_add(1),
-            IndexDirection::Low => self.low_nonce = nonce.checked_sub(1),
+            IndexDirection::High => {
+                self.high_nonce = nonce.checked_add(1);
+                self.next_direction = IndexDirection::Low;
+            }
+            IndexDirection::Low => {
+                self.low_nonce = nonce.checked_sub(1);
+                self.next_direction = IndexDirection::High;
+            }
+            IndexDirection::Reconsider => {
+                self.reconsider_nonces.remove(&nonce);
+            }
+        }
+    }
+
+    fn reconsider(&mut self, nonce: u32) {
+        let covered_by_high = self.high_nonce.is_some_and(|high| nonce >= high);
+        let covered_by_low = self.low_nonce.is_some_and(|low| nonce <= low);
+        if !covered_by_high && !covered_by_low {
+            self.reconsider_nonces.insert(nonce);
         }
     }
 }
@@ -134,8 +184,8 @@ struct LegacyMessageIterator {
 
 impl LegacyMessageIterator {
     #[instrument(skip(db), ret)]
-    fn new(db: Arc<dyn HyperlaneDb>) -> Self {
-        let high_nonce = db.retrieve_highest_seen_message_nonce().ok().flatten();
+    fn new(db: Arc<dyn HyperlaneDb>) -> Result<(Self, Option<u32>)> {
+        let high_nonce = db.retrieve_highest_seen_message_nonce()?;
         let domain = db.domain().name().to_owned();
         let high_nonce_iter = DirectionalNonceIterator::new(
             // If the high nonce is None, we start from the beginning
@@ -154,42 +204,38 @@ impl LegacyMessageIterator {
             ?domain,
             "Initialized LegacyMessageIterator"
         );
-        Self {
-            low_nonce_iter,
-            high_nonce_iter,
-            _domain: domain,
-        }
+        Ok((
+            Self {
+                low_nonce_iter,
+                high_nonce_iter,
+                _domain: domain,
+            },
+            high_nonce,
+        ))
     }
 
     async fn try_get_next_message(
         &mut self,
         metrics: &MessageDbLoaderMetrics,
     ) -> Result<Option<HyperlaneMessage>> {
-        loop {
-            if self.high_nonce_iter.nonce.is_some() {
-                let status = self.high_nonce_iter.try_get_next_nonce(metrics)?;
-                // Newer messages are atomically indexed, so migration stops at its startup watermark.
-                self.high_nonce_iter.nonce = None;
-                if let MessageStatus::Processable(message) = status {
-                    return Ok(Some(message));
-                }
-            }
-
-            if self.low_nonce_iter.nonce.is_none() {
-                return Ok(None);
-            }
+        let status = if self.high_nonce_iter.nonce.is_some() {
+            let status = self.high_nonce_iter.try_get_next_nonce(metrics)?;
+            // Newer messages are atomically indexed, so migration stops at its startup watermark.
+            self.high_nonce_iter.nonce = None;
+            status
+        } else if self.low_nonce_iter.nonce.is_some() {
             let status = self.low_nonce_iter.try_get_next_nonce(metrics)?;
             // Legacy gaps are safe to cross because this iterator has a fixed startup watermark.
             self.low_nonce_iter.iterate();
-            if let MessageStatus::Processable(message) = status {
-                return Ok(Some(message));
-            }
-
-            // This loop may iterate through millions of processed messages, blocking the runtime.
-            // So, to avoid starving other futures in this task, yield to the runtime
-            // on each iteration
-            tokio::task::yield_now().await;
-        }
+            status
+        } else {
+            return Ok(None);
+        };
+        tokio::task::yield_now().await;
+        Ok(match status {
+            MessageStatus::Processable(message) => Some(message),
+            MessageStatus::Unindexed | MessageStatus::Processed => None,
+        })
     }
 
     fn migration_complete(&self) -> bool {
@@ -361,9 +407,7 @@ impl DbLoaderExt for MessageDbLoader {
         self.metrics
             .update_ingress_depths(&self.send_channels, &self.destination_iterators);
 
-        if self.migrate_legacy_record().await? {
-            return Ok(());
-        }
+        self.migrate_legacy_record().await?;
 
         let destination_count = self.destination_iterators.len();
         for _ in 0..destination_count {
@@ -374,7 +418,13 @@ impl DbLoaderExt for MessageDbLoader {
             }
         }
 
-        self.wait_for_work().await;
+        let migration_blocked = self
+            .destination_iterators
+            .iter()
+            .any(|iterator| !iterator.reconsider_nonces.is_empty());
+        if self.migration_iterator.is_none() || migration_blocked {
+            self.wait_for_work().await;
+        }
         Ok(())
     }
 }
@@ -392,15 +442,16 @@ impl MessageDbLoader {
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,
         index_notifications: Option<Receiver<H512>>,
-    ) -> Self {
-        let highest_seen_nonce = db.retrieve_highest_seen_message_nonce().ok().flatten();
+    ) -> Result<Self> {
+        let (migration_iterator, highest_seen_nonce) =
+            LegacyMessageIterator::new(Arc::new(db.clone()) as Arc<dyn HyperlaneDb>)?;
         let mut destinations: Vec<_> = send_channels.keys().copied().collect();
         destinations.sort_unstable();
         let destination_iterators = destinations
             .into_iter()
             .map(|destination| DestinationIndexIterator::new(destination, highest_seen_nonce))
             .collect();
-        Self {
+        Ok(Self {
             message_whitelist,
             message_blacklist,
             address_blacklist,
@@ -408,15 +459,13 @@ impl MessageDbLoader {
             send_channels,
             destination_ctxs,
             metric_app_contexts,
-            migration_iterator: Some(LegacyMessageIterator::new(
-                Arc::new(db.clone()) as Arc<dyn HyperlaneDb>
-            )),
+            migration_iterator: Some(migration_iterator),
             db,
             destination_iterators,
             next_destination: 0,
             max_retries,
             index_notifications,
-        }
+        })
     }
 
     /// Discard already-observed index notifications so this receiver cannot
@@ -477,9 +526,16 @@ impl MessageDbLoader {
         }
     }
 
-    async fn migrate_legacy_record(&mut self) -> Result<bool> {
+    async fn migrate_legacy_record(&mut self) -> Result<()> {
+        if self
+            .destination_iterators
+            .iter()
+            .any(|iterator| !iterator.reconsider_nonces.is_empty())
+        {
+            return Ok(());
+        }
         let Some(iterator) = self.migration_iterator.as_mut() else {
-            return Ok(false);
+            return Ok(());
         };
         let _timer = self
             .metrics
@@ -498,20 +554,25 @@ impl MessageDbLoader {
                 ])
                 .inc_by(2);
             self.db.reconcile_pending_message_index(&message)?;
-            return Ok(true);
+            if let Some(iterator) = self
+                .destination_iterators
+                .iter_mut()
+                .find(|iterator| iterator.destination == message.destination)
+            {
+                iterator.reconsider(message.nonce);
+            }
         }
         if iterator.migration_complete() {
             self.migration_iterator = None;
-            return Ok(false);
         }
-        self.wait_for_work().await;
-        Ok(true)
+        Ok(())
     }
 
     async fn try_load_destination(&mut self, iterator_index: usize) -> Result<bool> {
-        let iterator = &self.destination_iterators[iterator_index];
-        let destination = iterator.destination;
-        let destination_label = iterator.destination_label.clone();
+        let destination = self.destination_iterators[iterator_index].destination;
+        let destination_label = self.destination_iterators[iterator_index]
+            .destination_label
+            .clone();
         let _timer = self
             .metrics
             .scan_duration_seconds
@@ -521,14 +582,14 @@ impl MessageDbLoader {
                 "destination_index",
             ])
             .start_timer();
-        let Some(sender) = self.send_channels.get(&destination) else {
+        let Some(sender) = self.send_channels.get(&destination).cloned() else {
             return Ok(false);
         };
         if !sender.is_closed() && sender.capacity() == 0 {
             return Ok(false);
         }
         let Some((direction, nonce, indexed_message_id)) =
-            iterator.peek(&self.db, &self.metrics)?
+            self.destination_iterators[iterator_index].peek(&self.db, &self.metrics)?
         else {
             return Ok(false);
         };
@@ -569,7 +630,17 @@ impl MessageDbLoader {
                 ])
                 .inc_by(2);
             self.db.reconcile_pending_message_index(&message)?;
+            if message.destination == destination {
+                return Ok(true);
+            }
             self.destination_iterators[iterator_index].advance(direction, nonce);
+            if let Some(target) = self
+                .destination_iterators
+                .iter_mut()
+                .find(|iterator| iterator.destination == message.destination)
+            {
+                target.reconsider(nonce);
+            }
             return Ok(true);
         }
         self.metrics

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -487,7 +487,6 @@ impl MessageDbLoader {
         destination_ctxs: HashMap<u32, Arc<MessageContext>>,
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,
-        index_notifications: Option<Receiver<IndexingNotification>>,
     ) -> Result<Self> {
         let (migration_iterator, highest_seen_nonce) =
             LegacyMessageIterator::new(Arc::new(db.clone()) as Arc<dyn HyperlaneDb>)?;
@@ -511,8 +510,15 @@ impl MessageDbLoader {
             next_destination: 0,
             destination_scan_pending: true,
             max_retries,
-            index_notifications,
+            index_notifications: None,
         })
+    }
+
+    pub fn set_index_notifications(
+        &mut self,
+        index_notifications: Option<Receiver<IndexingNotification>>,
+    ) {
+        self.index_notifications = index_notifications;
     }
 
     /// Discard already-observed index notifications so this receiver cannot
@@ -913,7 +919,7 @@ impl MessageDbLoaderMetricsShared {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MessageDbLoaderMetrics {
     last_known_message_nonce_gauge: IntGauge,
     origin: String,

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -28,6 +28,8 @@ use super::{
 };
 use crate::{db_loader::DbLoaderExt, settings::matching_list::MatchingList};
 
+const LEGACY_MIGRATION_BATCH_SIZE: usize = 256;
+
 /// Finds unprocessed messages from an origin and submits them through a channel
 /// for to the appropriate destination.
 #[allow(clippy::too_many_arguments)]
@@ -50,6 +52,7 @@ pub struct MessageDbLoader {
     migration_iterator: Option<LegacyMessageIterator>,
     destination_iterators: Vec<DestinationIndexIterator>,
     next_destination: usize,
+    destination_scan_pending: bool,
     max_retries: u32,
     index_notifications: Option<Receiver<IndexingNotification>>,
 }
@@ -440,24 +443,31 @@ impl DbLoaderExt for MessageDbLoader {
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
         self.drain_index_notifications()?;
-        self.metrics
-            .update_ingress_depths(&self.send_channels, &self.destination_iterators);
+        let migration_was_active = self.migration_iterator.is_some();
+        self.migrate_legacy_batch().await?;
 
-        self.migrate_legacy_record().await?;
+        if self.destination_scan_pending {
+            self.metrics
+                .update_ingress_depths(&self.send_channels, &self.destination_iterators);
 
-        let destination_count = self.destination_iterators.len();
-        for _ in 0..destination_count {
-            let index = self.next_destination;
-            self.next_destination = (self.next_destination + 1) % destination_count;
-            if self.try_load_destination(index).await? {
-                return Ok(());
+            let destination_count = self.destination_iterators.len();
+            for _ in 0..destination_count {
+                let index = self.next_destination;
+                self.next_destination = (self.next_destination + 1) % destination_count;
+                if self.try_load_destination(index).await? {
+                    return Ok(());
+                }
             }
+            self.destination_scan_pending = false;
         }
 
         let migration_blocked = self
             .destination_iterators
             .iter()
             .any(|iterator| !iterator.reconsider_nonces.is_empty());
+        if migration_was_active && self.migration_iterator.is_none() {
+            return Ok(());
+        }
         if self.migration_iterator.is_none() || migration_blocked {
             self.wait_for_work().await;
         }
@@ -499,6 +509,7 @@ impl MessageDbLoader {
             db,
             destination_iterators,
             next_destination: 0,
+            destination_scan_pending: true,
             max_retries,
             index_notifications,
         })
@@ -534,6 +545,7 @@ impl MessageDbLoader {
     }
 
     fn apply_index_notification(&mut self, notification: IndexingNotification) -> Result<()> {
+        self.destination_scan_pending = true;
         let mut fallback_reopen =
             notification.sequences.is_empty() || notification.sequences.iter().any(Option::is_none);
         for nonce in notification.sequences.into_iter().flatten() {
@@ -565,6 +577,7 @@ impl MessageDbLoader {
     }
 
     fn request_low_range_reopens(&mut self) {
+        self.destination_scan_pending = true;
         for iterator in &mut self.destination_iterators {
             iterator.request_low_range_reopen();
         }
@@ -615,9 +628,10 @@ impl MessageDbLoader {
                 self.request_low_range_reopens();
             }
         }
+        self.destination_scan_pending = true;
     }
 
-    async fn migrate_legacy_record(&mut self) -> Result<()> {
+    async fn migrate_legacy_batch(&mut self) -> Result<()> {
         if self
             .destination_iterators
             .iter()
@@ -633,24 +647,31 @@ impl MessageDbLoader {
             .scan_duration_seconds
             .with_label_values(&[self.metrics.origin.as_str(), "all", "migration"])
             .start_timer();
-        if let Some(message) = iterator.try_get_next_message(&self.metrics).await? {
-            let destination = message.destination.to_string();
-            self.metrics
-                .logical_db_reads
-                .with_label_values(&[
-                    self.metrics.origin.as_str(),
-                    destination.as_str(),
-                    "migration",
-                    "reconcile",
-                ])
-                .inc_by(2);
-            self.db.reconcile_pending_message_index(&message)?;
-            if let Some(iterator) = self
-                .destination_iterators
-                .iter_mut()
-                .find(|iterator| iterator.destination == message.destination)
-            {
-                iterator.reconsider(message.nonce);
+        for _ in 0..LEGACY_MIGRATION_BATCH_SIZE {
+            if let Some(message) = iterator.try_get_next_message(&self.metrics).await? {
+                let destination = message.destination.to_string();
+                self.metrics
+                    .logical_db_reads
+                    .with_label_values(&[
+                        self.metrics.origin.as_str(),
+                        destination.as_str(),
+                        "migration",
+                        "reconcile",
+                    ])
+                    .inc_by(2);
+                self.db.reconcile_pending_message_index(&message)?;
+                if let Some(iterator) = self
+                    .destination_iterators
+                    .iter_mut()
+                    .find(|iterator| iterator.destination == message.destination)
+                {
+                    iterator.reconsider(message.nonce);
+                }
+                self.destination_scan_pending = true;
+                break;
+            }
+            if iterator.migration_complete() {
+                break;
             }
         }
         if iterator.migration_complete() {
@@ -763,6 +784,7 @@ impl MessageDbLoader {
             ])
             .inc();
         if self.db.retrieve_terminally_dropped_message(&message.id())? {
+            self.db.delete_pending_message_index(&message)?;
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         }

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -12,10 +12,11 @@ use ethers::utils::hex;
 use eyre::Result;
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use hyperlane_base::{
+    broadcast::IndexingNotification,
     db::{HyperlaneDb, HyperlaneRocksDB},
     CoreMetrics,
 };
-use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H256, H512};
+use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H256};
 use parking_lot::Mutex;
 use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use tokio::sync::mpsc::{error::TryRecvError, error::TrySendError, Receiver, Sender};
@@ -50,7 +51,7 @@ pub struct MessageDbLoader {
     destination_iterators: Vec<DestinationIndexIterator>,
     next_destination: usize,
     max_retries: u32,
-    index_notifications: Option<Receiver<H512>>,
+    index_notifications: Option<Receiver<IndexingNotification>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -438,7 +439,7 @@ impl DbLoaderExt for MessageDbLoader {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
-        self.drain_index_notifications();
+        self.drain_index_notifications()?;
         self.metrics
             .update_ingress_depths(&self.send_channels, &self.destination_iterators);
 
@@ -476,7 +477,7 @@ impl MessageDbLoader {
         destination_ctxs: HashMap<u32, Arc<MessageContext>>,
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,
-        index_notifications: Option<Receiver<H512>>,
+        index_notifications: Option<Receiver<IndexingNotification>>,
     ) -> Result<Self> {
         let (migration_iterator, highest_seen_nonce) =
             LegacyMessageIterator::new(Arc::new(db.clone()) as Arc<dyn HyperlaneDb>)?;
@@ -505,13 +506,13 @@ impl MessageDbLoader {
 
     /// Discard already-observed index notifications so this receiver cannot
     /// backpressure the message indexer while the loader is processing a backlog.
-    fn drain_index_notifications(&mut self) {
+    fn drain_index_notifications(&mut self) -> Result<()> {
         let mut disconnected = false;
-        let mut received = false;
+        let mut notifications = Vec::new();
         if let Some(receiver) = self.index_notifications.as_mut() {
             loop {
                 match receiver.try_recv() {
-                    Ok(_) => received = true,
+                    Ok(notification) => notifications.push(notification),
                     Err(TryRecvError::Empty) => break,
                     Err(TryRecvError::Disconnected) => {
                         disconnected = true;
@@ -523,9 +524,44 @@ impl MessageDbLoader {
         if disconnected {
             self.index_notifications = None;
         }
-        if received {
+        for notification in notifications {
+            if let Err(err) = self.apply_index_notification(notification) {
+                self.request_low_range_reopens();
+                return Err(err);
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_index_notification(&mut self, notification: IndexingNotification) -> Result<()> {
+        let mut fallback_reopen =
+            notification.sequences.is_empty() || notification.sequences.iter().any(Option::is_none);
+        for nonce in notification.sequences.into_iter().flatten() {
+            self.metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    self.metrics.origin.as_str(),
+                    "all",
+                    "notification",
+                    "message",
+                ])
+                .inc();
+            let Some(message) = self.db.retrieve_message_by_nonce(nonce)? else {
+                fallback_reopen = true;
+                continue;
+            };
+            if let Some(iterator) = self
+                .destination_iterators
+                .iter_mut()
+                .find(|iterator| iterator.destination == message.destination)
+            {
+                iterator.reconsider(nonce);
+            }
+        }
+        if fallback_reopen {
             self.request_low_range_reopens();
         }
+        Ok(())
     }
 
     fn request_low_range_reopens(&mut self) {
@@ -553,27 +589,31 @@ impl MessageDbLoader {
             }
         };
 
-        let (disconnected, received) = if let Some(receiver) = self.index_notifications.as_mut() {
+        let (disconnected, notification) = if let Some(receiver) = self.index_notifications.as_mut()
+        {
             tokio::select! {
                 notification = receiver.recv() => match notification {
-                    Some(_) => (false, true),
-                    None => (true, false),
+                    Some(notification) => (false, Some(notification)),
+                    None => (true, None),
                 },
-                _ = capacity_wait => (false, false),
-                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, false),
+                _ = capacity_wait => (false, None),
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, None),
             }
         } else {
             tokio::select! {
-                _ = capacity_wait => (false, false),
-                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, false),
+                _ = capacity_wait => (false, None),
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, None),
             }
         };
 
         if disconnected {
             self.index_notifications = None;
         }
-        if received {
-            self.request_low_range_reopens();
+        if let Some(notification) = notification {
+            if let Err(err) = self.apply_index_notification(notification) {
+                debug!(?err, "Failed to apply index notification");
+                self.request_low_range_reopens();
+            }
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -10,13 +10,14 @@ use async_trait::async_trait;
 use derive_new::new;
 use ethers::utils::hex;
 use eyre::Result;
+use futures_util::{stream::FuturesUnordered, StreamExt};
 use hyperlane_base::{
     db::{HyperlaneDb, HyperlaneRocksDB},
     CoreMetrics,
 };
-use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H512};
-use prometheus::IntGauge;
-use tokio::sync::mpsc::{error::TryRecvError, Receiver, Sender};
+use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H256, H512};
+use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
+use tokio::sync::mpsc::{error::TryRecvError, error::TrySendError, Receiver, Sender};
 use tracing::{debug, instrument, trace};
 
 use super::{
@@ -25,7 +26,7 @@ use super::{
 };
 use crate::{db_loader::DbLoaderExt, settings::matching_list::MatchingList};
 
-/// Finds unprocessed messages from an origin and submits then through a channel
+/// Finds unprocessed messages from an origin and submits them through a channel
 /// for to the appropriate destination.
 #[allow(clippy::too_many_arguments)]
 pub struct MessageDbLoader {
@@ -42,20 +43,96 @@ pub struct MessageDbLoader {
     /// Needed context to send a message for each destination chain
     destination_ctxs: HashMap<u32, Arc<MessageContext>>,
     metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
-    nonce_iterator: ForwardBackwardIterator,
+    db: HyperlaneRocksDB,
+    // Reconcile every startup so a rollback binary cannot leave records unindexed.
+    migration_iterator: Option<LegacyMessageIterator>,
+    destination_iterators: Vec<DestinationIndexIterator>,
+    next_destination: usize,
     max_retries: u32,
     index_notifications: Option<Receiver<H512>>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum IndexDirection {
+    High,
+    Low,
+}
+
 #[derive(Debug)]
-struct ForwardBackwardIterator {
+struct DestinationIndexIterator {
+    destination: u32,
+    destination_label: Arc<str>,
+    high_nonce: Option<u32>,
+    low_nonce: Option<u32>,
+}
+
+impl DestinationIndexIterator {
+    fn new(destination: u32, highest_seen_nonce: Option<u32>) -> Self {
+        Self {
+            destination,
+            destination_label: destination.to_string().into(),
+            high_nonce: Some(highest_seen_nonce.unwrap_or_default()),
+            low_nonce: highest_seen_nonce.and_then(|nonce| nonce.checked_sub(1)),
+        }
+    }
+
+    fn peek(
+        &self,
+        db: &HyperlaneRocksDB,
+        metrics: &MessageDbLoaderMetrics,
+    ) -> Result<Option<(IndexDirection, u32, H256)>> {
+        if let Some(nonce) = self.high_nonce {
+            metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    metrics.origin.as_str(),
+                    self.destination_label.as_ref(),
+                    "destination_index",
+                    "index",
+                ])
+                .inc();
+            if let Some((nonce, message_id)) =
+                db.retrieve_pending_message_at_or_after(self.destination, nonce)?
+            {
+                return Ok(Some((IndexDirection::High, nonce, message_id)));
+            }
+        }
+        if let Some(nonce) = self.low_nonce {
+            metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    metrics.origin.as_str(),
+                    self.destination_label.as_ref(),
+                    "destination_index",
+                    "index",
+                ])
+                .inc();
+            if let Some((nonce, message_id)) =
+                db.retrieve_pending_message_at_or_before(self.destination, nonce)?
+            {
+                return Ok(Some((IndexDirection::Low, nonce, message_id)));
+            }
+        }
+        Ok(None)
+    }
+
+    fn advance(&mut self, direction: IndexDirection, nonce: u32) {
+        match direction {
+            IndexDirection::High => self.high_nonce = nonce.checked_add(1),
+            IndexDirection::Low => self.low_nonce = nonce.checked_sub(1),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LegacyMessageIterator {
     low_nonce_iter: DirectionalNonceIterator,
     high_nonce_iter: DirectionalNonceIterator,
     // here for debugging purposes
     _domain: String,
 }
 
-impl ForwardBackwardIterator {
+impl LegacyMessageIterator {
     #[instrument(skip(db), ret)]
     fn new(db: Arc<dyn HyperlaneDb>) -> Self {
         let high_nonce = db.retrieve_highest_seen_message_nonce().ok().flatten();
@@ -75,7 +152,7 @@ impl ForwardBackwardIterator {
             ?low_nonce_iter,
             ?high_nonce_iter,
             ?domain,
-            "Initialized ForwardBackwardIterator"
+            "Initialized LegacyMessageIterator"
         );
         Self {
             low_nonce_iter,
@@ -89,38 +166,34 @@ impl ForwardBackwardIterator {
         metrics: &MessageDbLoaderMetrics,
     ) -> Result<Option<HyperlaneMessage>> {
         loop {
-            let high_nonce_message_status = self.high_nonce_iter.try_get_next_nonce(metrics)?;
-            let low_nonce_message_status = self.low_nonce_iter.try_get_next_nonce(metrics)?;
-
-            match (high_nonce_message_status, low_nonce_message_status) {
-                // Always prioritize advancing the high nonce iterator, as
-                // we have a preference for higher nonces
-                (MessageStatus::Processed, _) => {
-                    self.high_nonce_iter.iterate();
+            if self.high_nonce_iter.nonce.is_some() {
+                let status = self.high_nonce_iter.try_get_next_nonce(metrics)?;
+                // Newer messages are atomically indexed, so migration stops at its startup watermark.
+                self.high_nonce_iter.nonce = None;
+                if let MessageStatus::Processable(message) = status {
+                    return Ok(Some(message));
                 }
-                (MessageStatus::Processable(high_nonce_message), _) => {
-                    self.high_nonce_iter.iterate();
-                    return Ok(Some(high_nonce_message));
-                }
-
-                // Low nonce messages are only processed if the high nonce iterator
-                // can't make any progress
-                (_, MessageStatus::Processed) => {
-                    self.low_nonce_iter.iterate();
-                }
-                (_, MessageStatus::Processable(low_nonce_message)) => {
-                    self.low_nonce_iter.iterate();
-                    return Ok(Some(low_nonce_message));
-                }
-
-                // If both iterators give us unindexed messages, there are no messages at the moment
-                (MessageStatus::Unindexed, MessageStatus::Unindexed) => return Ok(None),
             }
+
+            if self.low_nonce_iter.nonce.is_none() {
+                return Ok(None);
+            }
+            let status = self.low_nonce_iter.try_get_next_nonce(metrics)?;
+            // Legacy gaps are safe to cross because this iterator has a fixed startup watermark.
+            self.low_nonce_iter.iterate();
+            if let MessageStatus::Processable(message) = status {
+                return Ok(Some(message));
+            }
+
             // This loop may iterate through millions of processed messages, blocking the runtime.
             // So, to avoid starving other futures in this task, yield to the runtime
             // on each iteration
             tokio::task::yield_now().await;
         }
+    }
+
+    fn migration_complete(&self) -> bool {
+        self.high_nonce_iter.nonce.is_none() && self.low_nonce_iter.nonce.is_none()
     }
 }
 
@@ -171,7 +244,30 @@ impl DirectionalNonceIterator {
         metrics: &MessageDbLoaderMetrics,
     ) -> Result<MessageStatus<HyperlaneMessage>> {
         if let Some(message) = self.indexed_message_with_nonce()? {
+            let destination = message.destination.to_string();
+            metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    metrics.origin.as_str(),
+                    destination.as_str(),
+                    "migration",
+                    "message",
+                ])
+                .inc();
+            metrics
+                .records_examined
+                .with_label_values(&[metrics.origin.as_str(), destination.as_str(), "migration"])
+                .inc();
             Self::update_max_nonce_gauge(&message, metrics);
+            metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    metrics.origin.as_str(),
+                    destination.as_str(),
+                    "migration",
+                    "processed",
+                ])
+                .inc();
             if !self.is_message_processed()? {
                 trace!(hyp_message=?message, iterator=?self, "Found processable message");
                 return Ok(MessageStatus::Processable(message));
@@ -179,6 +275,10 @@ impl DirectionalNonceIterator {
                 return Ok(MessageStatus::Processed);
             }
         }
+        metrics
+            .logical_db_reads
+            .with_label_values(&[metrics.origin.as_str(), "all", "migration", "message"])
+            .inc();
         Ok(MessageStatus::Unindexed)
     }
 
@@ -232,8 +332,12 @@ impl Debug for MessageDbLoader {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "MessageDbLoader {{ message_whitelist: {:?}, message_blacklist: {:?}, address_blacklist: {:?}, nonce_iterator: {:?}}}",
-            self.message_whitelist, self.message_blacklist, self.address_blacklist, self.nonce_iterator
+            "MessageDbLoader {{ message_whitelist: {:?}, message_blacklist: {:?}, address_blacklist: {:?}, migration_iterator: {:?}, destination_iterators: {:?}}}",
+            self.message_whitelist,
+            self.message_blacklist,
+            self.address_blacklist,
+            self.migration_iterator,
+            self.destination_iterators,
         )
     }
 }
@@ -247,88 +351,30 @@ impl DbLoaderExt for MessageDbLoader {
 
     /// The domain this db_loader is getting messages from.
     fn domain(&self) -> &HyperlaneDomain {
-        self.nonce_iterator.high_nonce_iter.db.domain()
+        self.db.domain()
     }
 
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
         self.drain_index_notifications();
+        self.metrics
+            .update_ingress_depths(&self.send_channels, &self.destination_iterators);
 
-        // Forever, scan HyperlaneRocksDB looking for new messages to send. When criteria are
-        // satisfied or the message is disqualified, push the message onto
-        // self.tx_msg and then continue the scan at the next highest
-        // nonce.
-        // Scan until we find next nonce without delivery confirmation.
-        if let Some(msg) = self.try_get_unprocessed_message().await? {
-            trace!(
-                ?msg,
-                cursor = ?self.nonce_iterator,
-                "db_loader working on message"
-            );
-            let destination = msg.destination;
-
-            // Skip if not whitelisted.
-            if !self.message_whitelist.msg_matches(&msg, true) {
-                debug!(?msg, "Message not whitelisted, skipping");
-                return Ok(());
-            }
-
-            // Skip if the message is blacklisted
-            if self.message_blacklist.msg_matches(&msg, false) {
-                debug!(?msg, "Message blacklisted, skipping");
-                return Ok(());
-            }
-
-            // Skip if the message involves a blacklisted address
-            if let Some(blacklisted_address) = self.address_blacklist.find_blacklisted_address(&msg)
-            {
-                debug!(
-                    ?msg,
-                    blacklisted_address = hex::encode(blacklisted_address),
-                    "Message involves blacklisted address, skipping"
-                );
-                return Ok(());
-            }
-
-            // Skip if the message is intended for a destination we do not service
-            if !self.send_channels.contains_key(&destination) {
-                debug!(?msg, "Message destined for unknown domain, skipping");
-                return Ok(());
-            }
-
-            // Skip if message is intended for a destination we don't have message context for
-            let destination_msg_ctx = if let Some(ctx) = self.destination_ctxs.get(&destination) {
-                ctx
-            } else {
-                debug!(
-                    ?msg,
-                    "Message destined for unknown message context, skipping",
-                );
-                return Ok(());
-            };
-
-            debug!(%msg, "Sending message to submitter");
-
-            let app_context_classifier =
-                AppContextClassifier::new(self.metric_app_contexts.clone());
-
-            let app_context = app_context_classifier.get_app_context(&msg).await?;
-            // Finally, build the submit arg and dispatch it to the submitter.
-            let pending_msg = PendingMessage::maybe_from_persisted_retries(
-                msg,
-                destination_msg_ctx.clone(),
-                app_context,
-                self.max_retries,
-            );
-            if let Some(pending_msg) = pending_msg {
-                self.send_channels[&destination]
-                    .send(vec![Box::new(pending_msg) as QueueOperation])
-                    .await?;
-            }
-        } else {
-            self.wait_for_index_notification().await;
+        if self.migrate_legacy_record().await? {
+            return Ok(());
         }
+
+        let destination_count = self.destination_iterators.len();
+        for _ in 0..destination_count {
+            let index = self.next_destination;
+            self.next_destination = (self.next_destination + 1) % destination_count;
+            if self.try_load_destination(index).await? {
+                return Ok(());
+            }
+        }
+
+        self.wait_for_work().await;
         Ok(())
     }
 }
@@ -347,6 +393,13 @@ impl MessageDbLoader {
         max_retries: u32,
         index_notifications: Option<Receiver<H512>>,
     ) -> Self {
+        let highest_seen_nonce = db.retrieve_highest_seen_message_nonce().ok().flatten();
+        let mut destinations: Vec<_> = send_channels.keys().copied().collect();
+        destinations.sort_unstable();
+        let destination_iterators = destinations
+            .into_iter()
+            .map(|destination| DestinationIndexIterator::new(destination, highest_seen_nonce))
+            .collect();
         Self {
             message_whitelist,
             message_blacklist,
@@ -355,7 +408,12 @@ impl MessageDbLoader {
             send_channels,
             destination_ctxs,
             metric_app_contexts,
-            nonce_iterator: ForwardBackwardIterator::new(Arc::new(db) as Arc<dyn HyperlaneDb>),
+            migration_iterator: Some(LegacyMessageIterator::new(
+                Arc::new(db.clone()) as Arc<dyn HyperlaneDb>
+            )),
+            db,
+            destination_iterators,
+            next_destination: 0,
             max_retries,
             index_notifications,
         }
@@ -382,19 +440,36 @@ impl MessageDbLoader {
         }
     }
 
-    /// Wake as soon as the message indexer stores new logs, retaining the
-    /// periodic poll as a safety fallback for missed or unavailable notifications.
-    async fn wait_for_index_notification(&mut self) {
+    /// Wake for new index work or destination capacity, retaining a polling fallback.
+    async fn wait_for_work(&mut self) {
         const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
-        let Some(receiver) = self.index_notifications.as_mut() else {
-            tokio::time::sleep(FALLBACK_POLL_INTERVAL).await;
-            return;
+        let mut capacity_waiters: FuturesUnordered<_> = self
+            .send_channels
+            .values()
+            .filter(|sender| sender.capacity() == 0 && !sender.is_closed())
+            .cloned()
+            .map(Sender::reserve_owned)
+            .collect();
+        let capacity_wait = async {
+            if capacity_waiters.is_empty() {
+                std::future::pending::<()>().await
+            } else {
+                let _ = capacity_waiters.next().await;
+            }
         };
 
-        let disconnected = tokio::select! {
-            notification = receiver.recv() => notification.is_none(),
-            _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => false,
+        let disconnected = if let Some(receiver) = self.index_notifications.as_mut() {
+            tokio::select! {
+                notification = receiver.recv() => notification.is_none(),
+                _ = capacity_wait => false,
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => false,
+            }
+        } else {
+            tokio::select! {
+                _ = capacity_wait => false,
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => false,
+            }
         };
 
         if disconnected {
@@ -402,30 +477,256 @@ impl MessageDbLoader {
         }
     }
 
-    async fn try_get_unprocessed_message(&mut self) -> Result<Option<HyperlaneMessage>> {
-        trace!(nonce_iterator=?self.nonce_iterator, "Trying to get the next db_loader message");
-        let next_message = self
-            .nonce_iterator
-            .try_get_next_message(&self.metrics)
-            .await?;
-        if next_message.is_none() {
-            trace!(nonce_iterator=?self.nonce_iterator, "No message found in DB for nonce");
+    async fn migrate_legacy_record(&mut self) -> Result<bool> {
+        let Some(iterator) = self.migration_iterator.as_mut() else {
+            return Ok(false);
+        };
+        let _timer = self
+            .metrics
+            .scan_duration_seconds
+            .with_label_values(&[self.metrics.origin.as_str(), "all", "migration"])
+            .start_timer();
+        if let Some(message) = iterator.try_get_next_message(&self.metrics).await? {
+            let destination = message.destination.to_string();
+            self.metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    self.metrics.origin.as_str(),
+                    destination.as_str(),
+                    "migration",
+                    "reconcile",
+                ])
+                .inc_by(2);
+            self.db.reconcile_pending_message_index(&message)?;
+            return Ok(true);
         }
-        Ok(next_message)
+        if iterator.migration_complete() {
+            self.migration_iterator = None;
+            return Ok(false);
+        }
+        self.wait_for_work().await;
+        Ok(true)
+    }
+
+    async fn try_load_destination(&mut self, iterator_index: usize) -> Result<bool> {
+        let iterator = &self.destination_iterators[iterator_index];
+        let destination = iterator.destination;
+        let destination_label = iterator.destination_label.clone();
+        let _timer = self
+            .metrics
+            .scan_duration_seconds
+            .with_label_values(&[
+                self.metrics.origin.as_str(),
+                destination_label.as_ref(),
+                "destination_index",
+            ])
+            .start_timer();
+        let Some(sender) = self.send_channels.get(&destination) else {
+            return Ok(false);
+        };
+        if !sender.is_closed() && sender.capacity() == 0 {
+            return Ok(false);
+        }
+        let Some((direction, nonce, indexed_message_id)) =
+            iterator.peek(&self.db, &self.metrics)?
+        else {
+            return Ok(false);
+        };
+        self.metrics
+            .records_examined
+            .with_label_values(&[
+                self.metrics.origin.as_str(),
+                destination_label.as_ref(),
+                "destination_index",
+            ])
+            .inc();
+        self.metrics
+            .logical_db_reads
+            .with_label_values(&[
+                self.metrics.origin.as_str(),
+                destination_label.as_ref(),
+                "destination_index",
+                "message",
+            ])
+            .inc();
+        let message = self.db.retrieve_message_by_nonce(nonce)?;
+        let Some(message) = message else {
+            self.db
+                .delete_pending_message_index_by_nonce(destination, nonce)?;
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        };
+        if message.id() != indexed_message_id || message.destination != destination {
+            self.db
+                .delete_pending_message_index_by_nonce(destination, nonce)?;
+            self.metrics
+                .logical_db_reads
+                .with_label_values(&[
+                    self.metrics.origin.as_str(),
+                    destination_label.as_ref(),
+                    "destination_index",
+                    "reconcile",
+                ])
+                .inc_by(2);
+            self.db.reconcile_pending_message_index(&message)?;
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        }
+        self.metrics
+            .logical_db_reads
+            .with_label_values(&[
+                self.metrics.origin.as_str(),
+                destination_label.as_ref(),
+                "destination_index",
+                "processed",
+            ])
+            .inc();
+        if self
+            .db
+            .retrieve_processed_by_nonce(&nonce)?
+            .unwrap_or(false)
+        {
+            self.db.delete_pending_message_index(&message)?;
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        }
+
+        DirectionalNonceIterator::update_max_nonce_gauge(&message, &self.metrics);
+        // Retain disqualified entries so restart or configuration changes reconsider them.
+        if !self.message_whitelist.msg_matches(&message, true) {
+            debug!(?message, "Message not whitelisted, skipping");
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        }
+        if self.message_blacklist.msg_matches(&message, false) {
+            debug!(?message, "Message blacklisted, skipping");
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        }
+        if let Some(blacklisted_address) = self.address_blacklist.find_blacklisted_address(&message)
+        {
+            debug!(
+                ?message,
+                blacklisted_address = hex::encode(blacklisted_address),
+                "Message involves blacklisted address, skipping"
+            );
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        }
+        let Some(destination_msg_ctx) = self.destination_ctxs.get(&destination) else {
+            debug!(
+                ?message,
+                "Message destined for unknown message context, skipping"
+            );
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        };
+
+        let app_context = AppContextClassifier::new(self.metric_app_contexts.clone())
+            .get_app_context(&message)
+            .await?;
+        let Some(pending_message) = PendingMessage::maybe_from_persisted_retries(
+            message,
+            destination_msg_ctx.clone(),
+            app_context,
+            self.max_retries,
+        ) else {
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        };
+        match sender.try_send(vec![Box::new(pending_message) as QueueOperation]) {
+            Ok(()) => {
+                self.destination_iterators[iterator_index].advance(direction, nonce);
+                Ok(true)
+            }
+            Err(TrySendError::Full(_)) => Ok(false),
+            Err(TrySendError::Closed(_)) => {
+                eyre::bail!("Message processor channel closed for destination {destination}")
+            }
+        }
+    }
+}
+
+/// Metric vectors shared by all origin-specific message DB loaders.
+#[derive(Debug, Clone)]
+pub struct MessageDbLoaderMetricsShared {
+    records_examined: IntCounterVec,
+    logical_db_reads: IntCounterVec,
+    scan_duration_seconds: HistogramVec,
+    ingress_depth: IntGaugeVec,
+}
+
+impl MessageDbLoaderMetricsShared {
+    /// Register message DB loader metrics once per relayer.
+    pub fn new(metrics: &CoreMetrics) -> Result<Self> {
+        Ok(Self {
+            records_examined: metrics.new_int_counter(
+                "message_db_loader_records_examined_total",
+                "Pending-message records examined by the message DB loader",
+                &["origin", "destination", "phase"],
+            )?,
+            logical_db_reads: metrics.new_int_counter(
+                "message_db_loader_logical_db_reads_total",
+                "Logical database reads performed by the message DB loader",
+                &["origin", "destination", "phase", "operation"],
+            )?,
+            scan_duration_seconds: metrics.new_histogram(
+                "message_db_loader_scan_duration_seconds",
+                "Time spent in one message DB loader scan step",
+                &["origin", "destination", "phase"],
+                vec![0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0],
+            )?,
+            ingress_depth: metrics.new_int_gauge(
+                "message_db_loader_ingress_depth",
+                "Operations queued by the DB loader for a destination processor",
+                &["destination"],
+            )?,
+        })
+    }
+
+    /// Bind the shared metric vectors to an origin-specific loader.
+    pub fn for_origin(
+        &self,
+        metrics: &CoreMetrics,
+        origin: &HyperlaneDomain,
+    ) -> MessageDbLoaderMetrics {
+        MessageDbLoaderMetrics {
+            last_known_message_nonce_gauge: metrics
+                .last_known_message_nonce()
+                .with_label_values(&["db_loader_loop", origin.name()]),
+            origin: origin.name().to_owned(),
+            records_examined: self.records_examined.clone(),
+            logical_db_reads: self.logical_db_reads.clone(),
+            scan_duration_seconds: self.scan_duration_seconds.clone(),
+            ingress_depth: self.ingress_depth.clone(),
+        }
     }
 }
 
 #[derive(Debug)]
 pub struct MessageDbLoaderMetrics {
     last_known_message_nonce_gauge: IntGauge,
+    origin: String,
+    records_examined: IntCounterVec,
+    logical_db_reads: IntCounterVec,
+    scan_duration_seconds: HistogramVec,
+    ingress_depth: IntGaugeVec,
 }
 
 impl MessageDbLoaderMetrics {
-    pub fn new(metrics: &CoreMetrics, origin: &HyperlaneDomain) -> Self {
-        Self {
-            last_known_message_nonce_gauge: metrics
-                .last_known_message_nonce()
-                .with_label_values(&["db_loader_loop", origin.name()]),
+    fn update_ingress_depths(
+        &self,
+        send_channels: &HashMap<u32, Sender<QueueOperationBatch>>,
+        destination_iterators: &[DestinationIndexIterator],
+    ) {
+        for iterator in destination_iterators {
+            let Some(sender) = send_channels.get(&iterator.destination) else {
+                continue;
+            };
+            let depth = sender.max_capacity().saturating_sub(sender.capacity());
+            self.ingress_depth
+                .with_label_values(&[iterator.destination_label.as_ref()])
+                .set(depth as i64);
         }
     }
 }

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -68,6 +68,7 @@ struct DestinationIndexIterator {
     low_nonce: Option<u32>,
     next_direction: IndexDirection,
     reconsider_nonces: BTreeSet<u32>,
+    low_range_reopen_pending: bool,
     loaded_messages: Arc<Mutex<HashSet<H256>>>,
 }
 
@@ -80,6 +81,7 @@ impl DestinationIndexIterator {
             low_nonce: highest_seen_nonce.and_then(|nonce| nonce.checked_sub(1)),
             next_direction: IndexDirection::High,
             reconsider_nonces: BTreeSet::new(),
+            low_range_reopen_pending: false,
             loaded_messages: Default::default(),
         }
     }
@@ -115,6 +117,7 @@ impl DestinationIndexIterator {
             }
             IndexDirection::Low => [IndexDirection::Low, IndexDirection::High],
         };
+        let mut reopened_low_range = false;
         for direction in directions {
             let nonce = match direction {
                 IndexDirection::High => self.high_nonce,
@@ -147,7 +150,15 @@ impl DestinationIndexIterator {
             }
             if direction == IndexDirection::Low {
                 self.low_nonce = None;
+                if self.low_range_reopen_pending {
+                    self.low_range_reopen_pending = false;
+                    self.reopen_low_range();
+                    reopened_low_range = true;
+                }
             }
+        }
+        if reopened_low_range {
+            return self.peek(db, metrics);
         }
         Ok(None)
     }
@@ -176,10 +187,20 @@ impl DestinationIndexIterator {
         }
     }
 
-    fn reopen_low_range(&mut self) {
+    fn request_low_range_reopen(&mut self) {
         if self.low_nonce.is_none() {
-            self.low_nonce = self.high_nonce.and_then(|nonce| nonce.checked_sub(1));
+            self.reopen_low_range();
+        } else {
+            self.low_range_reopen_pending = true;
         }
+    }
+
+    fn reopen_low_range(&mut self) {
+        self.low_nonce = match self.high_nonce {
+            Some(nonce) => nonce.checked_sub(1),
+            // `None` means the high scan advanced past the largest u32 nonce.
+            None => Some(u32::MAX),
+        };
     }
 }
 
@@ -498,13 +519,13 @@ impl MessageDbLoader {
             self.index_notifications = None;
         }
         if received {
-            self.reopen_exhausted_low_ranges();
+            self.request_low_range_reopens();
         }
     }
 
-    fn reopen_exhausted_low_ranges(&mut self) {
+    fn request_low_range_reopens(&mut self) {
         for iterator in &mut self.destination_iterators {
-            iterator.reopen_low_range();
+            iterator.request_low_range_reopen();
         }
     }
 
@@ -547,7 +568,7 @@ impl MessageDbLoader {
             self.index_notifications = None;
         }
         if received {
-            self.reopen_exhausted_low_ranges();
+            self.request_low_range_reopens();
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -498,9 +498,13 @@ impl MessageDbLoader {
             self.index_notifications = None;
         }
         if received {
-            for iterator in &mut self.destination_iterators {
-                iterator.reopen_low_range();
-            }
+            self.reopen_exhausted_low_ranges();
+        }
+    }
+
+    fn reopen_exhausted_low_ranges(&mut self) {
+        for iterator in &mut self.destination_iterators {
+            iterator.reopen_low_range();
         }
     }
 
@@ -523,21 +527,27 @@ impl MessageDbLoader {
             }
         };
 
-        let disconnected = if let Some(receiver) = self.index_notifications.as_mut() {
+        let (disconnected, received) = if let Some(receiver) = self.index_notifications.as_mut() {
             tokio::select! {
-                notification = receiver.recv() => notification.is_none(),
-                _ = capacity_wait => false,
-                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => false,
+                notification = receiver.recv() => match notification {
+                    Some(_) => (false, true),
+                    None => (true, false),
+                },
+                _ = capacity_wait => (false, false),
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, false),
             }
         } else {
             tokio::select! {
-                _ = capacity_wait => false,
-                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => false,
+                _ = capacity_wait => (false, false),
+                _ = tokio::time::sleep(FALLBACK_POLL_INTERVAL) => (false, false),
             }
         };
 
         if disconnected {
             self.index_notifications = None;
+        }
+        if received {
+            self.reopen_exhausted_low_ranges();
         }
     }
 

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -687,11 +687,26 @@ impl MessageDbLoader {
             return Ok(true);
         }
 
+        self.metrics
+            .logical_db_reads
+            .with_label_values(&[
+                self.metrics.origin.as_str(),
+                destination_label.as_ref(),
+                "destination_index",
+                "terminal",
+            ])
+            .inc();
+        if self.db.retrieve_terminally_dropped_message(&message.id())? {
+            self.destination_iterators[iterator_index].advance(direction, nonce);
+            return Ok(true);
+        }
+
         let Some(loaded_message_guard) = LoadedMessageGuard::try_acquire(
             message.id(),
             self.destination_iterators[iterator_index]
                 .loaded_messages
                 .clone(),
+            self.db.clone(),
         ) else {
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -790,7 +790,8 @@ impl MessageDbLoader {
             ])
             .inc();
         if self.db.retrieve_terminally_dropped_message(&message.id())? {
-            self.db.delete_pending_message_index(&message)?;
+            self.db
+                .delete_pending_message_index_by_nonce(destination, nonce)?;
             self.destination_iterators[iterator_index].advance(direction, nonce);
             return Ok(true);
         }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -318,6 +318,47 @@ async fn index_notification_reopens_exhausted_low_range() {
 }
 
 #[tokio::test]
+async fn waited_index_notification_reopens_exhausted_low_range() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, mut receiver) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+        finish_legacy_migration(&mut loader).await;
+        loader.destination_iterators[0].high_nonce = Some(6);
+        loader.destination_iterators[0].low_nonce = None;
+
+        let late = dummy_hyperlane_message(&destination_domain, 1);
+        let notify = async {
+            sleep(Duration::from_millis(20)).await;
+            add_db_entry(&db, &late, 0);
+            notification_sender
+                .send(H512::from_low_u64_be(1))
+                .await
+                .expect("send index notification");
+        };
+
+        timeout(Duration::from_millis(750), async {
+            let (tick_result, _) = tokio::join!(loader.tick(), notify);
+            tick_result.expect("notification should wake idle loader");
+            loader.tick().await.expect("load late low nonce");
+        })
+        .await
+        .expect("consumed notification should reopen low scan");
+
+        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn reopened_low_range_does_not_duplicate_in_flight_message() {
     test_utils::run_test_db(|db| async move {
         let origin_domain = dummy_domain(0, "dummy_origin_domain");

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -121,22 +121,20 @@ fn dummy_message_loader_with_notifications(
     ));
 
     let (send_channel, receive_channel) = mpsc::channel::<QueueOperationBatch>(1);
-    (
-        MessageDbLoader::new(
-            db.clone(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            dummy_message_loader_metrics(),
-            HashMap::from([(destination_domain.id(), send_channel)]),
-            HashMap::from([(destination_domain.id(), message_context)]),
-            vec![].into(),
-            DEFAULT_MAX_MESSAGE_RETRIES,
-            index_notifications,
-        )
-        .unwrap(),
-        receive_channel,
+    let mut loader = MessageDbLoader::new(
+        db.clone(),
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        dummy_message_loader_metrics(),
+        HashMap::from([(destination_domain.id(), send_channel)]),
+        HashMap::from([(destination_domain.id(), message_context)]),
+        vec![].into(),
+        DEFAULT_MAX_MESSAGE_RETRIES,
     )
+    .unwrap();
+    loader.set_index_notifications(index_notifications);
+    (loader, receive_channel)
 }
 
 fn dummy_hyperlane_message(destination: &HyperlaneDomain, nonce: u32) -> HyperlaneMessage {
@@ -929,7 +927,6 @@ async fn moved_message_reconsiders_target_without_restart() {
             ]),
             vec![].into(),
             DEFAULT_MAX_MESSAGE_RETRIES,
-            None,
         )
         .unwrap();
         finish_legacy_migration(&mut loader).await;
@@ -1193,7 +1190,6 @@ async fn saturated_destination_does_not_block_another_destination() {
             ]),
             vec![].into(),
             DEFAULT_MAX_MESSAGE_RETRIES,
-            None,
         )
         .unwrap();
 

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -318,6 +318,53 @@ async fn index_notification_reopens_exhausted_low_range() {
 }
 
 #[tokio::test]
+async fn index_notification_defers_reopen_until_active_low_range_exhausts() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, mut receiver) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+        finish_legacy_migration(&mut loader).await;
+        loader.destination_iterators[0].high_nonce = Some(100);
+        loader.destination_iterators[0].low_nonce = Some(89);
+
+        let late = dummy_hyperlane_message(&destination_domain, 95);
+        add_db_entry(&db, &late, 0);
+        notification_sender
+            .send(H512::from_low_u64_be(95))
+            .await
+            .expect("send index notification");
+        loader.drain_index_notifications();
+
+        assert_eq!(loader.destination_iterators[0].low_nonce, Some(89));
+        assert!(loader.destination_iterators[0].low_range_reopen_pending);
+
+        loader.tick().await.expect("load late gap nonce");
+        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+        assert!(!loader.destination_iterators[0].low_range_reopen_pending);
+    })
+    .await;
+}
+
+#[test]
+fn index_notification_reopens_low_range_after_max_nonce() {
+    let mut iterator = DestinationIndexIterator::new(1, Some(u32::MAX));
+    iterator.advance(IndexDirection::High, u32::MAX);
+    iterator.low_nonce = None;
+
+    iterator.request_low_range_reopen();
+
+    assert_eq!(iterator.low_nonce, Some(u32::MAX));
+}
+
+#[tokio::test]
 async fn waited_index_notification_reopens_exhausted_low_range() {
     test_utils::run_test_db(|db| async move {
         let origin_domain = dummy_domain(0, "dummy_origin_domain");

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -285,6 +285,38 @@ async fn test_drain_index_notifications_clears_backlog() {
     .await;
 }
 
+#[tokio::test]
+async fn index_notification_reopens_exhausted_low_range() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, mut receiver) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+        finish_legacy_migration(&mut loader).await;
+        loader.destination_iterators[0].high_nonce = Some(6);
+        loader.destination_iterators[0].low_nonce = None;
+
+        let late = dummy_hyperlane_message(&destination_domain, 1);
+        add_db_entry(&db, &late, 0);
+        notification_sender
+            .send(H512::from_low_u64_be(1))
+            .await
+            .expect("send index notification");
+
+        loader.tick().await.expect("load late low nonce");
+
+        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+    })
+    .await;
+}
+
 /// Only adds database entries to the pending message prefix if the message's
 /// retry count is greater than zero
 fn persist_retried_messages(

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -34,6 +34,11 @@ fn notification(tx_id: H512) -> IndexingNotification {
     IndexingNotification::from_tx_id(tx_id)
 }
 
+fn only_operation(batch: QueueOperationBatch) -> QueueOperation {
+    assert_eq!(batch.len(), 1);
+    batch.into_iter().next().unwrap()
+}
+
 #[async_trait]
 impl ApplicationOperationVerifier for DummyApplicationOperationVerifier {
     async fn verify(
@@ -157,7 +162,7 @@ fn add_db_entry(db: &HyperlaneRocksDB, msg: &HyperlaneMessage, retry_count: u32)
 
 async fn finish_legacy_migration(loader: &mut MessageDbLoader) {
     while loader.migration_iterator.is_some() {
-        loader.migrate_legacy_record().await.unwrap();
+        loader.migrate_legacy_batch().await.unwrap();
         for iterator in &mut loader.destination_iterators {
             iterator.reconsider_nonces.clear();
         }
@@ -357,7 +362,10 @@ async fn index_notification_reopens_exhausted_low_range() {
 
         loader.tick().await.expect("load late low nonce");
 
-        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+        assert_eq!(
+            only_operation(receiver.try_recv().expect("late operation")).id(),
+            late.id()
+        );
     })
     .await;
 }
@@ -392,7 +400,10 @@ async fn index_notification_defers_reopen_until_active_low_range_exhausts() {
         assert!(loader.destination_iterators[0].low_range_reopen_pending);
 
         loader.tick().await.expect("load late gap nonce");
-        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+        assert_eq!(
+            only_operation(receiver.try_recv().expect("late operation")).id(),
+            late.id()
+        );
         assert!(!loader.destination_iterators[0].low_range_reopen_pending);
     })
     .await;
@@ -428,14 +439,17 @@ async fn index_notification_reopens_after_active_low_range_reaches_zero() {
 
         loader.tick().await.expect("load low range floor");
         assert_eq!(
-            receiver.try_recv().expect("floor operation").id(),
+            only_operation(receiver.try_recv().expect("floor operation")).id(),
             floor.id()
         );
         assert!(loader.destination_iterators[0].low_nonce.is_none());
         assert!(loader.destination_iterators[0].low_range_reopen_pending);
 
         loader.tick().await.expect("load late gap nonce");
-        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+        assert_eq!(
+            only_operation(receiver.try_recv().expect("late operation")).id(),
+            late.id()
+        );
         assert!(!loader.destination_iterators[0].low_range_reopen_pending);
     })
     .await;
@@ -488,7 +502,10 @@ async fn waited_index_notification_reopens_exhausted_low_range() {
         .await
         .expect("consumed notification should reopen low scan");
 
-        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+        assert_eq!(
+            only_operation(receiver.try_recv().expect("late operation")).id(),
+            late.id()
+        );
     })
     .await;
 }
@@ -512,7 +529,7 @@ async fn reopened_low_range_does_not_duplicate_in_flight_message() {
         let high = dummy_hyperlane_message(&destination_domain, 5);
         add_db_entry(&db, &high, 0);
         loader.tick().await.expect("load high operation");
-        let high_operation = receiver.try_recv().expect("high operation");
+        let high_operation = only_operation(receiver.try_recv().expect("high operation"));
         assert_eq!(high_operation.id(), high.id());
 
         loader.destination_iterators[0].low_nonce = None;
@@ -526,8 +543,8 @@ async fn reopened_low_range_does_not_duplicate_in_flight_message() {
         let late_operation = timeout(Duration::from_millis(750), async {
             loop {
                 loader.tick().await.expect("scan reopened low range");
-                if let Ok(operation) = receiver.try_recv() {
-                    break operation;
+                if let Ok(batch) = receiver.try_recv() {
+                    break only_operation(batch);
                 }
             }
         })
@@ -597,6 +614,12 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
             restarted_receiver.try_recv().is_err(),
             "terminal message was reloaded after restart"
         );
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination_domain.id(), message.nonce)
+                .unwrap(),
+            None,
+            "terminal message index should be removed"
+        );
 
         restarted_loader.destination_iterators[0].low_nonce = None;
         notification_sender
@@ -625,10 +648,12 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
         restarted_loader.drain_index_notifications().unwrap();
         assert!(restarted_loader.try_load_destination(0).await.unwrap());
         assert_eq!(
-            restarted_receiver
-                .try_recv()
-                .expect("replacement operation")
-                .id(),
+            only_operation(
+                restarted_receiver
+                    .try_recv()
+                    .expect("replacement operation"),
+            )
+            .id(),
             replacement.id()
         );
     })
@@ -848,7 +873,10 @@ async fn mismatched_id_is_repaired_and_loaded_without_restart() {
         );
 
         loader.try_load_destination(0).await.unwrap();
-        assert_eq!(receiver.try_recv().unwrap().id(), message.id());
+        assert_eq!(
+            only_operation(receiver.try_recv().unwrap()).id(),
+            message.id()
+        );
     })
     .await;
 }
@@ -883,8 +911,8 @@ async fn moved_message_reconsiders_target_without_restart() {
         ));
         let old = dummy_hyperlane_message(&destination_a, 0);
         add_db_entry(&db, &old, 0);
-        let (sender_a, _receiver_a) = mpsc::channel::<QueueOperation>(1);
-        let (sender_b, mut receiver_b) = mpsc::channel::<QueueOperation>(1);
+        let (sender_a, _receiver_a) = mpsc::channel::<QueueOperationBatch>(1);
+        let (sender_b, mut receiver_b) = mpsc::channel::<QueueOperationBatch>(1);
         let mut loader = MessageDbLoader::new(
             db.clone(),
             Default::default(),
@@ -931,7 +959,10 @@ async fn moved_message_reconsiders_target_without_restart() {
             .reconsider_nonces
             .contains(&moved.nonce));
         loader.try_load_destination(target_index).await.unwrap();
-        assert_eq!(receiver_b.try_recv().unwrap().id(), moved.id());
+        assert_eq!(
+            only_operation(receiver_b.try_recv().unwrap()).id(),
+            moved.id()
+        );
     })
     .await;
 }
@@ -990,14 +1021,17 @@ async fn indexed_message_loads_before_large_legacy_backfill_finishes() {
         loader.tick().await.unwrap();
 
         assert!(loader.migration_iterator.is_some());
-        assert_eq!(receiver.try_recv().unwrap().id(), indexed.id());
+        assert_eq!(
+            only_operation(receiver.try_recv().unwrap()).id(),
+            indexed.id()
+        );
         let newer = dummy_hyperlane_message(&destination, 65);
         add_db_entry(&db, &newer, 0);
         loader.tick().await.unwrap();
         loader.tick().await.unwrap();
         let next_ids = [
-            receiver.try_recv().unwrap().id(),
-            receiver.try_recv().unwrap().id(),
+            only_operation(receiver.try_recv().unwrap()).id(),
+            only_operation(receiver.try_recv().unwrap()).id(),
         ];
         assert!(next_ids.contains(&newer.id()));
         assert!(loader.migration_iterator.is_some());
@@ -1005,6 +1039,64 @@ async fn indexed_message_loads_before_large_legacy_backfill_finishes() {
             db.retrieve_pending_message_at_or_before(destination.id(), 0)
                 .unwrap(),
             None
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn processed_legacy_history_does_not_rescan_every_destination() {
+    test_utils::run_test_db(|db| async move {
+        const HISTORY_LEN: u32 = 1_024;
+        const DESTINATION_COUNT: u32 = 8;
+
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        for nonce in 0..HISTORY_LEN {
+            let message = dummy_hyperlane_message(&destination, nonce);
+            add_db_entry(&db, &message, 0);
+            db.store_message_processed(&message).unwrap();
+        }
+
+        let (mut loader, _receiver) =
+            dummy_message_loader(&origin_domain, &destination, &db, OptionalCache::new(None));
+        let mut _extra_receivers = Vec::new();
+        for destination_id in 2..=DESTINATION_COUNT {
+            let (sender, receiver) = mpsc::channel::<QueueOperationBatch>(1);
+            loader.send_channels.insert(destination_id, sender);
+            loader
+                .destination_iterators
+                .push(DestinationIndexIterator::new(
+                    destination_id,
+                    Some(HISTORY_LEN.saturating_sub(1)),
+                ));
+            _extra_receivers.push(receiver);
+        }
+
+        while loader.migration_iterator.is_some() {
+            loader.tick().await.unwrap();
+        }
+
+        let destination_index_reads: u64 = loader
+            .destination_iterators
+            .iter()
+            .map(|iterator| {
+                loader
+                    .metrics
+                    .logical_db_reads
+                    .with_label_values(&[
+                        loader.metrics.origin.as_str(),
+                        iterator.destination_label.as_ref(),
+                        "destination_index",
+                        "index",
+                    ])
+                    .get()
+            })
+            .sum();
+        assert!(
+            destination_index_reads <= u64::from(DESTINATION_COUNT).saturating_mul(2),
+            "destination indexes were rescanned during legacy history migration"
         );
     })
     .await;
@@ -1074,16 +1166,16 @@ async fn saturated_destination_does_not_block_another_destination() {
         add_db_entry(&db, &message_a, 0);
         add_db_entry(&db, &message_b, 0);
 
-        let (sender_a, mut receiver_a) = mpsc::channel::<QueueOperation>(1);
-        let (sender_b, mut receiver_b) = mpsc::channel::<QueueOperation>(1);
+        let (sender_a, mut receiver_a) = mpsc::channel::<QueueOperationBatch>(1);
+        let (sender_b, mut receiver_b) = mpsc::channel::<QueueOperationBatch>(1);
         sender_a
-            .try_send(Box::new(PendingMessage::new(
+            .try_send(vec![Box::new(PendingMessage::new(
                 message_a.clone(),
                 context_a.clone(),
                 PendingOperationStatus::FirstPrepareAttempt,
                 None,
                 DEFAULT_MAX_MESSAGE_RETRIES,
-            )))
+            ))])
             .unwrap();
         let mut loader = MessageDbLoader::new(
             db,

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -317,6 +317,54 @@ async fn index_notification_reopens_exhausted_low_range() {
     .await;
 }
 
+#[tokio::test]
+async fn reopened_low_range_does_not_duplicate_in_flight_message() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, mut receiver) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+        finish_legacy_migration(&mut loader).await;
+
+        let high = dummy_hyperlane_message(&destination_domain, 5);
+        add_db_entry(&db, &high, 0);
+        loader.tick().await.expect("load high operation");
+        let high_operation = receiver.try_recv().expect("high operation");
+        assert_eq!(high_operation.id(), high.id());
+
+        loader.destination_iterators[0].low_nonce = None;
+        let late = dummy_hyperlane_message(&destination_domain, 1);
+        add_db_entry(&db, &late, 0);
+        notification_sender
+            .send(H512::from_low_u64_be(1))
+            .await
+            .expect("send index notification");
+
+        let late_operation = timeout(Duration::from_millis(750), async {
+            loop {
+                loader.tick().await.expect("scan reopened low range");
+                if let Ok(operation) = receiver.try_recv() {
+                    break operation;
+                }
+            }
+        })
+        .await
+        .expect("late operation should be found");
+        assert_eq!(late_operation.id(), late.id());
+        assert!(receiver.try_recv().is_err(), "high message was duplicated");
+
+        drop(high_operation);
+    })
+    .await;
+}
+
 /// Only adds database entries to the pending message prefix if the message's
 /// retry count is greater than zero
 fn persist_retried_messages(

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -181,6 +181,7 @@ async fn test_idle_tick_wakes_on_index_notification() {
             OptionalCache::new(None),
             Some(notification_receiver),
         );
+        finish_legacy_migration(&mut loader).await;
 
         let notify = async move {
             sleep(Duration::from_millis(20)).await;
@@ -214,6 +215,7 @@ async fn test_idle_tick_retains_polling_fallback() {
             OptionalCache::new(None),
             Some(notification_receiver),
         );
+        finish_legacy_migration(&mut loader).await;
 
         let start = Instant::now();
         timeout(Duration::from_millis(1_500), loader.tick())
@@ -242,6 +244,7 @@ async fn test_idle_tick_returns_on_mid_wait_disconnect() {
             OptionalCache::new(None),
             Some(notification_receiver),
         );
+        finish_legacy_migration(&mut loader).await;
 
         let disconnect = async move {
             sleep(Duration::from_millis(20)).await;
@@ -630,7 +633,7 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
             .await
             .expect("send index notification");
         restarted_loader.drain_index_notifications().unwrap();
-        assert!(restarted_loader.try_load_destination(0).await.unwrap());
+        assert!(!restarted_loader.try_load_destination(0).await.unwrap());
         assert!(
             restarted_receiver.try_recv().is_err(),
             "terminal message was reloaded"
@@ -1062,11 +1065,9 @@ async fn indexed_message_loads_before_large_legacy_backfill_finishes() {
         let newer = dummy_hyperlane_message(&destination, 65);
         add_db_entry(&db, &newer, 0);
         loader.tick().await.unwrap();
+        let first_id = only_operation(receiver.try_recv().unwrap()).id();
         loader.tick().await.unwrap();
-        let next_ids = [
-            only_operation(receiver.try_recv().unwrap()).id(),
-            only_operation(receiver.try_recv().unwrap()).id(),
-        ];
+        let next_ids = [first_id, only_operation(receiver.try_recv().unwrap()).id()];
         assert!(next_ids.contains(&newer.id()));
         assert!(loader.migration_iterator.is_some());
         assert_eq!(
@@ -1299,6 +1300,7 @@ async fn legacy_iterator_stops_at_startup_watermark() {
         if let Some(message) = iterator.try_get_next_message(&dummy_metrics).await.unwrap() {
             messages.push(message.nonce);
         }
+        iterator.advance();
     }
 
     // Migration crosses the missing nonce 1 but stops at the startup watermark.
@@ -1317,4 +1319,111 @@ fn startup_watermark_error_is_propagated() {
         .returning(|| Err(DbError::Other("watermark read failed".to_owned())));
 
     assert!(LegacyMessageIterator::new(Arc::new(mock_db)).is_err());
+}
+
+#[tokio::test]
+async fn failed_legacy_reconciliation_retries_the_same_nonce() {
+    test_utils::run_test_db(|db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin, db);
+        let message = dummy_hyperlane_message(&destination, 0);
+        add_db_entry(&db, &message, 0);
+        let (mut loader, _receiver) =
+            dummy_message_loader(&origin, &destination, &db, OptionalCache::new(None));
+
+        // Make the pending-index read fail after the legacy message/processed reads
+        // succeeded, then repair it as a transient storage failure would recover.
+        let prefix = b"pending_message_by_destination_v1_"
+            .iter()
+            .chain(destination.id().to_be_bytes().iter())
+            .copied()
+            .collect::<Vec<_>>();
+        db.store_value_by_key(prefix, &message.nonce, &true)
+            .unwrap();
+        assert!(loader.migrate_legacy_batch().await.is_err());
+        db.delete_pending_message_index(&message).unwrap();
+
+        loader.migrate_legacy_batch().await.unwrap();
+
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination.id(), 0)
+                .unwrap(),
+            Some((message.nonce, message.id())),
+            "failed reconciliation must not consume the legacy cursor"
+        );
+        assert!(loader.migration_iterator.is_none());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn saturated_destination_does_not_block_legacy_migration_for_another_destination() {
+    test_utils::run_test_db(|db| async move {
+        let origin = dummy_domain(0, "origin");
+        let destination_a = dummy_domain(1, "destination_a");
+        let destination_b = dummy_domain(2, "destination_b");
+        let db = HyperlaneRocksDB::new(&origin, db);
+        let oldest_b = dummy_hyperlane_message(&destination_b, 0);
+        let middle_a = dummy_hyperlane_message(&destination_a, 1);
+        let newest_b = dummy_hyperlane_message(&destination_b, 2);
+        for message in [&oldest_b, &middle_a, &newest_b] {
+            add_db_entry(&db, message, 0);
+            db.delete_pending_message_index(message).unwrap();
+        }
+        let (mut loader, mut receiver_b) =
+            dummy_message_loader(&origin, &destination_b, &db, OptionalCache::new(None));
+        let context_a = Arc::new(dummy_message_context(
+            Arc::new(dummy_metadata_builder(
+                &origin,
+                &destination_a,
+                &db,
+                OptionalCache::new(None),
+            )),
+            &db,
+            OptionalCache::new(None),
+        ));
+        loader
+            .destination_ctxs
+            .insert(destination_a.id(), context_a);
+        let (sender_a, _receiver_a) = mpsc::channel::<QueueOperationBatch>(1);
+        loader
+            .send_channels
+            .insert(destination_a.id(), sender_a.clone());
+        loader.destination_iterators.insert(
+            0,
+            DestinationIndexIterator::new(destination_a.id(), Some(2)),
+        );
+
+        loader.tick().await.unwrap();
+        assert_eq!(
+            only_operation(receiver_b.try_recv().unwrap()).id(),
+            newest_b.id()
+        );
+        assert_eq!(loader.destination_iterators[0].low_nonce, None);
+        // A becomes saturated after its initially empty range was exhausted.
+        sender_a.try_send(Vec::new()).unwrap();
+        // Finish migration without bypassing its production scheduling gate.
+        for _ in 0..3 {
+            loader.tick().await.unwrap();
+            if !receiver_b.is_empty() {
+                break;
+            }
+        }
+        assert_eq!(
+            only_operation(
+                receiver_b
+                    .try_recv()
+                    .expect("healthy destination must finish legacy migration")
+            )
+            .id(),
+            oldest_b.id()
+        );
+        assert!(loader.migration_iterator.is_none());
+        assert!(
+            loader.destination_iterators[0].reconsider_nonces.is_empty(),
+            "migration must not accumulate blocked nonces in memory"
+        );
+    })
+    .await;
 }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -618,6 +618,11 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
             None,
             "terminal message index should be removed"
         );
+        assert!(
+            db.retrieve_terminally_dropped_message(&message.id())
+                .unwrap(),
+            "terminal marker must survive pending-index cleanup"
+        );
 
         restarted_loader.destination_iterators[0].low_nonce = None;
         notification_sender
@@ -631,6 +636,38 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
             "terminal message was reloaded"
         );
 
+        db.store_message(&message, 0)
+            .expect("duplicate indexing should reconcile the pending index");
+        drop(restarted_loader);
+        drop(restarted_receiver);
+
+        let (replacement_notification_sender, replacement_notification_receiver) = mpsc::channel(1);
+        let (mut duplicate_restart, mut duplicate_receiver) =
+            dummy_message_loader_with_notifications(
+                &origin_domain,
+                &destination_domain,
+                &db,
+                OptionalCache::new(None),
+                Some(replacement_notification_receiver),
+            );
+        finish_legacy_migration(&mut duplicate_restart).await;
+        assert!(duplicate_restart.try_load_destination(0).await.unwrap());
+        assert!(
+            duplicate_receiver.try_recv().is_err(),
+            "duplicate indexing reloaded a terminal message after restart"
+        );
+        assert!(
+            db.retrieve_terminally_dropped_message(&message.id())
+                .unwrap(),
+            "terminal marker must survive duplicate cleanup"
+        );
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination_domain.id(), message.nonce)
+                .unwrap(),
+            None,
+            "duplicate terminal index should be removed"
+        );
+
         let terminal_message_id = message.id();
         let mut replacement = message;
         replacement.body.push(1);
@@ -638,16 +675,16 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
         assert!(!db
             .retrieve_terminally_dropped_message(&terminal_message_id)
             .unwrap());
-        restarted_loader.destination_iterators[0].low_nonce = None;
-        notification_sender
+        duplicate_restart.destination_iterators[0].low_nonce = None;
+        replacement_notification_sender
             .send(notification(H512::from_low_u64_be(2)))
             .await
             .expect("send replacement notification");
-        restarted_loader.drain_index_notifications().unwrap();
-        assert!(restarted_loader.try_load_destination(0).await.unwrap());
+        duplicate_restart.drain_index_notifications().unwrap();
+        assert!(duplicate_restart.try_load_destination(0).await.unwrap());
         assert_eq!(
             only_operation(
-                restarted_receiver
+                duplicate_receiver
                     .try_recv()
                     .expect("replacement operation"),
             )

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -13,7 +13,7 @@ use hyperlane_base::{
     db::{test_utils, DbError, HyperlaneRocksDB},
     tests::mock_hyperlane_db::MockHyperlaneDb as MockDb,
 };
-use hyperlane_core::{test_utils::dummy_domain, PendingOperationStatus};
+use hyperlane_core::{test_utils::dummy_domain, PendingOperationResult, PendingOperationStatus};
 use hyperlane_operation_verifier::{
     ApplicationOperationVerifier, ApplicationOperationVerifierReport,
 };
@@ -402,6 +402,100 @@ async fn reopened_low_range_does_not_duplicate_in_flight_message() {
         assert!(receiver.try_recv().is_err(), "high message was duplicated");
 
         drop(high_operation);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn notification_after_terminal_drop_does_not_reload_message() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (mut loader, receiver) = dummy_message_loader(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+        );
+        finish_legacy_migration(&mut loader).await;
+
+        let message = dummy_hyperlane_message(&destination_domain, 1);
+        add_db_entry(&db, &message, 0);
+        let guard = LoadedMessageGuard::try_acquire(
+            message.id(),
+            loader.destination_iterators[0].loaded_messages.clone(),
+            db.clone(),
+        )
+        .expect("acquire loaded-message guard");
+        let mut pending_message = PendingMessage::new(
+            message.clone(),
+            loader.destination_ctxs[&destination_domain.id()].clone(),
+            PendingOperationStatus::FirstPrepareAttempt,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        pending_message.set_loaded_message_guard(guard);
+        assert!(matches!(
+            pending_message.terminal_drop(),
+            PendingOperationResult::Drop
+        ));
+        drop(pending_message);
+        assert!(db
+            .retrieve_terminally_dropped_message(&message.id())
+            .unwrap());
+        drop(loader);
+        drop(receiver);
+
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut restarted_loader, mut restarted_receiver) =
+            dummy_message_loader_with_notifications(
+                &origin_domain,
+                &destination_domain,
+                &db,
+                OptionalCache::new(None),
+                Some(notification_receiver),
+            );
+        finish_legacy_migration(&mut restarted_loader).await;
+        assert!(restarted_loader.try_load_destination(0).await.unwrap());
+        assert!(
+            restarted_receiver.try_recv().is_err(),
+            "terminal message was reloaded after restart"
+        );
+
+        restarted_loader.destination_iterators[0].low_nonce = None;
+        notification_sender
+            .send(H512::from_low_u64_be(1))
+            .await
+            .expect("send index notification");
+        restarted_loader.drain_index_notifications();
+        assert!(restarted_loader.try_load_destination(0).await.unwrap());
+        assert!(
+            restarted_receiver.try_recv().is_err(),
+            "terminal message was reloaded"
+        );
+
+        let terminal_message_id = message.id();
+        let mut replacement = message;
+        replacement.body.push(1);
+        db.upsert_message(&replacement, 0).unwrap();
+        assert!(!db
+            .retrieve_terminally_dropped_message(&terminal_message_id)
+            .unwrap());
+        restarted_loader.destination_iterators[0].low_nonce = None;
+        notification_sender
+            .send(H512::from_low_u64_be(2))
+            .await
+            .expect("send replacement notification");
+        restarted_loader.drain_index_notifications();
+        assert!(restarted_loader.try_load_destination(0).await.unwrap());
+        assert_eq!(
+            restarted_receiver
+                .try_recv()
+                .expect("replacement operation")
+                .id(),
+            replacement.id()
+        );
     })
     .await;
 }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -9,11 +9,14 @@ use tokio_metrics::TaskMonitor;
 use tracing::info_span;
 
 use hyperlane_base::{
+    broadcast::IndexingNotification,
     cache::{LocalCache, MeteredCache, MeteredCacheConfig, MeteredCacheMetrics, OptionalCache},
     db::{test_utils, DbError, HyperlaneRocksDB},
     tests::mock_hyperlane_db::MockHyperlaneDb as MockDb,
 };
-use hyperlane_core::{test_utils::dummy_domain, PendingOperationResult, PendingOperationStatus};
+use hyperlane_core::{
+    test_utils::dummy_domain, PendingOperationResult, PendingOperationStatus, H512,
+};
 use hyperlane_operation_verifier::{
     ApplicationOperationVerifier, ApplicationOperationVerifierReport,
 };
@@ -26,6 +29,10 @@ use crate::{
 use super::*;
 
 pub struct DummyApplicationOperationVerifier {}
+
+fn notification(tx_id: H512) -> IndexingNotification {
+    IndexingNotification::from_tx_id(tx_id)
+}
 
 #[async_trait]
 impl ApplicationOperationVerifier for DummyApplicationOperationVerifier {
@@ -98,7 +105,7 @@ fn dummy_message_loader_with_notifications(
     destination_domain: &HyperlaneDomain,
     db: &HyperlaneRocksDB,
     cache: OptionalCache<MeteredCache<LocalCache>>,
-    index_notifications: Option<Receiver<H512>>,
+    index_notifications: Option<Receiver<IndexingNotification>>,
 ) -> (MessageDbLoader, Receiver<QueueOperationBatch>) {
     let base_metadata_builder =
         dummy_metadata_builder(origin_domain, destination_domain, db, cache.clone());
@@ -175,7 +182,7 @@ async fn test_idle_tick_wakes_on_index_notification() {
         let notify = async move {
             sleep(Duration::from_millis(20)).await;
             notification_sender
-                .send(H512::zero())
+                .send(notification(H512::zero()))
                 .await
                 .expect("notification receiver should remain open");
         };
@@ -261,7 +268,7 @@ async fn test_drain_index_notifications_clears_backlog() {
         let (notification_sender, notification_receiver) = mpsc::channel(3);
         for txid in 0..3 {
             notification_sender
-                .try_send(H512::from_low_u64_be(txid))
+                .try_send(notification(H512::from_low_u64_be(txid)))
                 .expect("notification channel should have capacity");
         }
         let (mut loader, _) = dummy_message_loader_with_notifications(
@@ -272,15 +279,53 @@ async fn test_drain_index_notifications_clears_backlog() {
             Some(notification_receiver),
         );
 
-        loader.drain_index_notifications();
+        loader.drain_index_notifications().unwrap();
 
         assert_eq!(
             loader.index_notifications.as_ref().map(Receiver::len),
             Some(0)
         );
         notification_sender
-            .try_send(H512::from_low_u64_be(3))
+            .try_send(notification(H512::from_low_u64_be(3)))
             .expect("draining should free channel capacity");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn index_notification_reconsiders_only_its_destination() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let other_destination = dummy_domain(2, "other_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (mut loader, _) = dummy_message_loader(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+        );
+        loader.destination_iterators[0].high_nonce = Some(100);
+        loader.destination_iterators[0].low_nonce = None;
+        let mut other = DestinationIndexIterator::new(other_destination.id(), Some(99));
+        other.low_nonce = None;
+        loader.destination_iterators.push(other);
+
+        let late = dummy_hyperlane_message(&destination_domain, 95);
+        add_db_entry(&db, &late, 0);
+        loader
+            .apply_index_notification(IndexingNotification {
+                tx_id: H512::from_low_u64_be(95),
+                sequences: vec![Some(95)],
+            })
+            .unwrap();
+
+        assert!(loader.destination_iterators[0]
+            .reconsider_nonces
+            .contains(&95));
+        assert!(loader.destination_iterators[1].reconsider_nonces.is_empty());
+        assert!(!loader.destination_iterators[1].low_range_reopen_pending);
+        assert_eq!(loader.destination_iterators[1].low_nonce, None);
     })
     .await;
 }
@@ -306,7 +351,7 @@ async fn index_notification_reopens_exhausted_low_range() {
         let late = dummy_hyperlane_message(&destination_domain, 1);
         add_db_entry(&db, &late, 0);
         notification_sender
-            .send(H512::from_low_u64_be(1))
+            .send(notification(H512::from_low_u64_be(1)))
             .await
             .expect("send index notification");
 
@@ -338,10 +383,10 @@ async fn index_notification_defers_reopen_until_active_low_range_exhausts() {
         let late = dummy_hyperlane_message(&destination_domain, 95);
         add_db_entry(&db, &late, 0);
         notification_sender
-            .send(H512::from_low_u64_be(95))
+            .send(notification(H512::from_low_u64_be(95)))
             .await
             .expect("send index notification");
-        loader.drain_index_notifications();
+        loader.drain_index_notifications().unwrap();
 
         assert_eq!(loader.destination_iterators[0].low_nonce, Some(89));
         assert!(loader.destination_iterators[0].low_range_reopen_pending);
@@ -376,10 +421,10 @@ async fn index_notification_reopens_after_active_low_range_reaches_zero() {
         add_db_entry(&db, &floor, 0);
         add_db_entry(&db, &late, 0);
         notification_sender
-            .send(H512::from_low_u64_be(95))
+            .send(notification(H512::from_low_u64_be(95)))
             .await
             .expect("send index notification");
-        loader.drain_index_notifications();
+        loader.drain_index_notifications().unwrap();
 
         loader.tick().await.expect("load low range floor");
         assert_eq!(
@@ -430,7 +475,7 @@ async fn waited_index_notification_reopens_exhausted_low_range() {
             sleep(Duration::from_millis(20)).await;
             add_db_entry(&db, &late, 0);
             notification_sender
-                .send(H512::from_low_u64_be(1))
+                .send(notification(H512::from_low_u64_be(1)))
                 .await
                 .expect("send index notification");
         };
@@ -474,7 +519,7 @@ async fn reopened_low_range_does_not_duplicate_in_flight_message() {
         let late = dummy_hyperlane_message(&destination_domain, 1);
         add_db_entry(&db, &late, 0);
         notification_sender
-            .send(H512::from_low_u64_be(1))
+            .send(notification(H512::from_low_u64_be(1)))
             .await
             .expect("send index notification");
 
@@ -555,10 +600,10 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
 
         restarted_loader.destination_iterators[0].low_nonce = None;
         notification_sender
-            .send(H512::from_low_u64_be(1))
+            .send(notification(H512::from_low_u64_be(1)))
             .await
             .expect("send index notification");
-        restarted_loader.drain_index_notifications();
+        restarted_loader.drain_index_notifications().unwrap();
         assert!(restarted_loader.try_load_destination(0).await.unwrap());
         assert!(
             restarted_receiver.try_recv().is_err(),
@@ -574,10 +619,10 @@ async fn notification_after_terminal_drop_does_not_reload_message() {
             .unwrap());
         restarted_loader.destination_iterators[0].low_nonce = None;
         notification_sender
-            .send(H512::from_low_u64_be(2))
+            .send(notification(H512::from_low_u64_be(2)))
             .await
             .expect("send replacement notification");
-        restarted_loader.drain_index_notifications();
+        restarted_loader.drain_index_notifications().unwrap();
         assert!(restarted_loader.try_load_destination(0).await.unwrap());
         assert_eq!(
             restarted_receiver

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -10,7 +10,7 @@ use tracing::info_span;
 
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, MeteredCacheConfig, MeteredCacheMetrics, OptionalCache},
-    db::{test_utils, HyperlaneRocksDB},
+    db::{test_utils, DbError, HyperlaneRocksDB},
     tests::mock_hyperlane_db::MockHyperlaneDb as MockDb,
 };
 use hyperlane_core::{test_utils::dummy_domain, PendingOperationStatus};
@@ -121,7 +121,8 @@ fn dummy_message_loader_with_notifications(
             vec![].into(),
             DEFAULT_MAX_MESSAGE_RETRIES,
             index_notifications,
-        ),
+        )
+        .unwrap(),
         receive_channel,
     )
 }
@@ -144,6 +145,15 @@ fn add_db_entry(db: &HyperlaneRocksDB, msg: &HyperlaneMessage, retry_count: u32)
     if retry_count > 0 {
         db.store_pending_message_retry_count_by_message_id(&msg.id(), &retry_count)
             .unwrap();
+    }
+}
+
+async fn finish_legacy_migration(loader: &mut MessageDbLoader) {
+    while loader.migration_iterator.is_some() {
+        loader.migrate_legacy_record().await.unwrap();
+        for iterator in &mut loader.destination_iterators {
+            iterator.reconsider_nonces.clear();
+        }
     }
 }
 
@@ -407,12 +417,8 @@ async fn legacy_records_are_reconciled_into_destination_index() {
             &db,
             OptionalCache::new(None),
         );
-        while loader.migration_iterator.is_some() {
-            timeout(Duration::from_millis(200), loader.tick())
-                .await
-                .expect("migration tick should not wait for polling fallback")
-                .unwrap();
-        }
+        finish_legacy_migration(&mut loader).await;
+        loader.try_load_destination(0).await.unwrap();
 
         assert_eq!(
             db.retrieve_pending_message_at_or_after(destination_domain.id(), 0)
@@ -463,6 +469,198 @@ async fn stale_destination_index_entry_is_removed() {
 }
 
 #[tokio::test]
+async fn mismatched_id_is_repaired_and_loaded_without_restart() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = dummy_hyperlane_message(&destination_domain, 0);
+        add_db_entry(&db, &message, 0);
+
+        let (mut loader, mut receiver) = dummy_message_loader(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+        );
+        finish_legacy_migration(&mut loader).await;
+
+        let mut mismatched = message.clone();
+        mismatched.body = vec![1];
+        db.store_pending_message_index(&mismatched).unwrap();
+
+        loader.try_load_destination(0).await.unwrap();
+        assert!(receiver.try_recv().is_err());
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination_domain.id(), 0)
+                .unwrap(),
+            Some((message.nonce, message.id()))
+        );
+
+        loader.try_load_destination(0).await.unwrap();
+        assert_eq!(receiver.try_recv().unwrap().id(), message.id());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn moved_message_reconsiders_target_without_restart() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_a = dummy_domain(1, "destination_a");
+        let destination_b = dummy_domain(3, "destination_b");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let cache = OptionalCache::new(None);
+        let context_a = Arc::new(dummy_message_context(
+            Arc::new(dummy_metadata_builder(
+                &origin_domain,
+                &destination_a,
+                &db,
+                cache.clone(),
+            )),
+            &db,
+            cache.clone(),
+        ));
+        let context_b = Arc::new(dummy_message_context(
+            Arc::new(dummy_metadata_builder(
+                &origin_domain,
+                &destination_b,
+                &db,
+                cache,
+            )),
+            &db,
+            OptionalCache::new(None),
+        ));
+        let old = dummy_hyperlane_message(&destination_a, 0);
+        add_db_entry(&db, &old, 0);
+        let (sender_a, _receiver_a) = mpsc::channel::<QueueOperation>(1);
+        let (sender_b, mut receiver_b) = mpsc::channel::<QueueOperation>(1);
+        let mut loader = MessageDbLoader::new(
+            db.clone(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            dummy_message_loader_metrics(),
+            HashMap::from([
+                (destination_a.id(), sender_a),
+                (destination_b.id(), sender_b),
+            ]),
+            HashMap::from([
+                (destination_a.id(), context_a),
+                (destination_b.id(), context_b),
+            ]),
+            vec![].into(),
+            DEFAULT_MAX_MESSAGE_RETRIES,
+            None,
+        )
+        .unwrap();
+        finish_legacy_migration(&mut loader).await;
+
+        let mut moved = old.clone();
+        moved.destination = destination_b.id();
+        db.upsert_message(&moved, 1).unwrap();
+        db.store_pending_message_index(&old).unwrap();
+        let target_index = loader
+            .destination_iterators
+            .iter()
+            .position(|iterator| iterator.destination == destination_b.id())
+            .unwrap();
+        loader.destination_iterators[target_index].high_nonce = Some(1);
+        loader.destination_iterators[target_index].low_nonce = None;
+        loader.destination_iterators[target_index]
+            .reconsider_nonces
+            .clear();
+        let old_index = loader
+            .destination_iterators
+            .iter()
+            .position(|iterator| iterator.destination == destination_a.id())
+            .unwrap();
+
+        loader.try_load_destination(old_index).await.unwrap();
+        assert!(loader.destination_iterators[target_index]
+            .reconsider_nonces
+            .contains(&moved.nonce));
+        loader.try_load_destination(target_index).await.unwrap();
+        assert_eq!(receiver_b.try_recv().unwrap().id(), moved.id());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn alternating_cursor_does_not_starve_low_backlog() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        for nonce in 0..=4 {
+            add_db_entry(&db, &dummy_hyperlane_message(&destination, nonce), 0);
+        }
+        let mut iterator = DestinationIndexIterator::new(destination.id(), Some(4));
+        let metrics = dummy_message_loader_metrics();
+        let mut directions = Vec::new();
+        for new_high_nonce in 5..9 {
+            let (direction, nonce, _) = iterator.peek(&db, &metrics).unwrap().unwrap();
+            directions.push(direction);
+            iterator.advance(direction, nonce);
+            add_db_entry(
+                &db,
+                &dummy_hyperlane_message(&destination, new_high_nonce),
+                0,
+            );
+        }
+        assert_eq!(
+            directions,
+            vec![
+                IndexDirection::High,
+                IndexDirection::Low,
+                IndexDirection::High,
+                IndexDirection::Low,
+            ]
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn indexed_message_loads_before_large_legacy_backfill_finishes() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination = dummy_domain(1, "destination");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        for nonce in 0..64 {
+            let message = dummy_hyperlane_message(&destination, nonce);
+            add_db_entry(&db, &message, 0);
+            db.delete_pending_message_index(&message).unwrap();
+        }
+        let indexed = dummy_hyperlane_message(&destination, 64);
+        add_db_entry(&db, &indexed, 0);
+        let (mut loader, mut receiver) =
+            dummy_message_loader(&origin_domain, &destination, &db, OptionalCache::new(None));
+
+        loader.tick().await.unwrap();
+
+        assert!(loader.migration_iterator.is_some());
+        assert_eq!(receiver.try_recv().unwrap().id(), indexed.id());
+        let newer = dummy_hyperlane_message(&destination, 65);
+        add_db_entry(&db, &newer, 0);
+        loader.tick().await.unwrap();
+        loader.tick().await.unwrap();
+        let next_ids = [
+            receiver.try_recv().unwrap().id(),
+            receiver.try_recv().unwrap().id(),
+        ];
+        assert!(next_ids.contains(&newer.id()));
+        assert!(loader.migration_iterator.is_some());
+        assert_eq!(
+            db.retrieve_pending_message_at_or_before(destination.id(), 0)
+                .unwrap(),
+            None
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn closed_destination_channel_does_not_advance_index() {
     test_utils::run_test_db(|db| async move {
         let origin_domain = dummy_domain(0, "dummy_origin_domain");
@@ -477,7 +675,7 @@ async fn closed_destination_channel_does_not_advance_index() {
             &db,
             OptionalCache::new(None),
         );
-        while loader.migrate_legacy_record().await.unwrap() {}
+        finish_legacy_migration(&mut loader).await;
         drop(receiver);
         let cursor = loader.destination_iterators[0].high_nonce;
 
@@ -554,14 +752,11 @@ async fn saturated_destination_does_not_block_another_destination() {
             vec![].into(),
             DEFAULT_MAX_MESSAGE_RETRIES,
             None,
-        );
+        )
+        .unwrap();
 
-        while loader.migration_iterator.is_some() {
-            timeout(Duration::from_millis(200), loader.tick())
-                .await
-                .expect("migration tick should not wait for polling fallback")
-                .unwrap();
-        }
+        finish_legacy_migration(&mut loader).await;
+        loader.tick().await.unwrap();
 
         assert_eq!(
             receiver_b
@@ -621,11 +816,14 @@ async fn legacy_iterator_stops_at_startup_watermark() {
     let dummy_metrics = dummy_message_loader_metrics();
     let db = Arc::new(mock_db);
 
-    let mut iterator = LegacyMessageIterator::new(db.clone());
+    let (mut iterator, watermark) = LegacyMessageIterator::new(db.clone()).unwrap();
+    assert_eq!(watermark, Some(MOCK_HIGHEST_SEEN_NONCE));
 
     let mut messages = vec![];
-    while let Some(msg) = iterator.try_get_next_message(&dummy_metrics).await.unwrap() {
-        messages.push(msg.nonce);
+    while !iterator.migration_complete() {
+        if let Some(message) = iterator.try_get_next_message(&dummy_metrics).await.unwrap() {
+            messages.push(message.nonce);
+        }
     }
 
     // Migration crosses the missing nonce 1 but stops at the startup watermark.
@@ -633,4 +831,15 @@ async fn legacy_iterator_stops_at_startup_watermark() {
 
     assert_eq!(iterator.low_nonce_iter.nonce, None);
     assert_eq!(iterator.high_nonce_iter.nonce, None);
+}
+
+#[test]
+fn startup_watermark_error_is_propagated() {
+    let mut mock_db = MockDb::new();
+    mock_db
+        .expect_retrieve_highest_seen_message_nonce()
+        .times(1)
+        .returning(|| Err(DbError::Other("watermark read failed".to_owned())));
+
+    assert!(LegacyMessageIterator::new(Arc::new(mock_db)).is_err());
 }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -353,6 +353,49 @@ async fn index_notification_defers_reopen_until_active_low_range_exhausts() {
     .await;
 }
 
+#[tokio::test]
+async fn index_notification_reopens_after_active_low_range_reaches_zero() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
+        let (mut loader, mut receiver) = dummy_message_loader_with_notifications(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+            Some(notification_receiver),
+        );
+        finish_legacy_migration(&mut loader).await;
+        loader.destination_iterators[0].high_nonce = Some(100);
+        loader.destination_iterators[0].low_nonce = Some(0);
+
+        let floor = dummy_hyperlane_message(&destination_domain, 0);
+        let late = dummy_hyperlane_message(&destination_domain, 95);
+        add_db_entry(&db, &floor, 0);
+        add_db_entry(&db, &late, 0);
+        notification_sender
+            .send(H512::from_low_u64_be(95))
+            .await
+            .expect("send index notification");
+        loader.drain_index_notifications();
+
+        loader.tick().await.expect("load low range floor");
+        assert_eq!(
+            receiver.try_recv().expect("floor operation").id(),
+            floor.id()
+        );
+        assert!(loader.destination_iterators[0].low_nonce.is_none());
+        assert!(loader.destination_iterators[0].low_range_reopen_pending);
+
+        loader.tick().await.expect("load late gap nonce");
+        assert_eq!(receiver.try_recv().expect("late operation").id(), late.id());
+        assert!(!loader.destination_iterators[0].low_range_reopen_pending);
+    })
+    .await;
+}
+
 #[test]
 fn index_notification_reopens_low_range_after_max_nonce() {
     let mut iterator = DestinationIndexIterator::new(1, Some(u32::MAX));

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use prometheus::IntCounterVec;
+use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
 use tokio::{
     sync::mpsc::{self, Receiver},
     time::{sleep, timeout},
@@ -13,7 +13,7 @@ use hyperlane_base::{
     db::{test_utils, HyperlaneRocksDB},
     tests::mock_hyperlane_db::MockHyperlaneDb as MockDb,
 };
-use hyperlane_core::test_utils::dummy_domain;
+use hyperlane_core::{test_utils::dummy_domain, PendingOperationStatus};
 use hyperlane_operation_verifier::{
     ApplicationOperationVerifier, ApplicationOperationVerifierReport,
 };
@@ -43,6 +43,27 @@ pub fn dummy_message_loader_metrics() -> MessageDbLoaderMetrics {
         last_known_message_nonce_gauge: IntGauge::new(
             "dummy_last_known_message_nonce_gauge",
             "help string",
+        )
+        .unwrap(),
+        origin: "dummy_origin".to_owned(),
+        records_examined: IntCounterVec::new(
+            prometheus::Opts::new("dummy_db_loader_records_examined", "help string"),
+            &["origin", "destination", "phase"],
+        )
+        .unwrap(),
+        logical_db_reads: IntCounterVec::new(
+            prometheus::Opts::new("dummy_db_loader_logical_reads", "help string"),
+            &["origin", "destination", "phase", "operation"],
+        )
+        .unwrap(),
+        scan_duration_seconds: HistogramVec::new(
+            prometheus::HistogramOpts::new("dummy_db_loader_scan_duration", "help string"),
+            &["origin", "destination", "phase"],
+        )
+        .unwrap(),
+        ingress_depth: IntGaugeVec::new(
+            prometheus::Opts::new("dummy_db_loader_ingress_depth", "help string"),
+            &["destination"],
         )
         .unwrap(),
     }
@@ -371,13 +392,207 @@ async fn test_full_pending_message_persistence_flow() {
 }
 
 #[tokio::test]
-async fn test_forward_backward_iterator() {
-    let mut mock_db = MockDb::new();
-    const MAX_ONCHAIN_NONCE: u32 = 4;
-    const MOCK_HIGHEST_SEEN_NONCE: u32 = 2;
+async fn legacy_records_are_reconciled_into_destination_index() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = dummy_hyperlane_message(&destination_domain, 0);
+        add_db_entry(&db, &message, 0);
+        db.delete_pending_message_index(&message).unwrap();
 
-    // How many times the db was queried for the max onchain nonce message
-    let mut retrieve_calls_for_max_onchain_nonce = 0;
+        let (mut loader, mut receiver) = dummy_message_loader(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+        );
+        while loader.migration_iterator.is_some() {
+            timeout(Duration::from_millis(200), loader.tick())
+                .await
+                .expect("migration tick should not wait for polling fallback")
+                .unwrap();
+        }
+
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination_domain.id(), 0)
+                .unwrap(),
+            Some((message.nonce, message.id()))
+        );
+        assert_eq!(
+            receiver
+                .try_recv()
+                .unwrap()
+                .into_iter()
+                .next()
+                .unwrap()
+                .id(),
+            message.id()
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn stale_destination_index_entry_is_removed() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let stale_message = dummy_hyperlane_message(&destination_domain, 0);
+        db.store_pending_message_index(&stale_message).unwrap();
+
+        let (mut loader, _) = dummy_message_loader(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+        );
+        timeout(Duration::from_millis(200), loader.tick())
+            .await
+            .expect("stale index cleanup should not wait for polling fallback")
+            .unwrap();
+
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination_domain.id(), 0)
+                .unwrap(),
+            None
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn closed_destination_channel_does_not_advance_index() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_domain = dummy_domain(1, "dummy_destination_domain");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = dummy_hyperlane_message(&destination_domain, 0);
+        add_db_entry(&db, &message, 0);
+
+        let (mut loader, receiver) = dummy_message_loader(
+            &origin_domain,
+            &destination_domain,
+            &db,
+            OptionalCache::new(None),
+        );
+        while loader.migrate_legacy_record().await.unwrap() {}
+        drop(receiver);
+        let cursor = loader.destination_iterators[0].high_nonce;
+
+        assert!(loader.try_load_destination(0).await.is_err());
+        assert_eq!(loader.destination_iterators[0].high_nonce, cursor);
+        assert_eq!(
+            db.retrieve_pending_message_at_or_after(destination_domain.id(), 0)
+                .unwrap(),
+            Some((message.nonce, message.id()))
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn saturated_destination_does_not_block_another_destination() {
+    test_utils::run_test_db(|db| async move {
+        let origin_domain = dummy_domain(0, "dummy_origin_domain");
+        let destination_a = dummy_domain(1, "destination_a");
+        let destination_b = dummy_domain(2, "destination_b");
+        let db = HyperlaneRocksDB::new(&origin_domain, db);
+        let cache = OptionalCache::new(None);
+
+        let context_a = Arc::new(dummy_message_context(
+            Arc::new(dummy_metadata_builder(
+                &origin_domain,
+                &destination_a,
+                &db,
+                cache.clone(),
+            )),
+            &db,
+            cache.clone(),
+        ));
+        let context_b = Arc::new(dummy_message_context(
+            Arc::new(dummy_metadata_builder(
+                &origin_domain,
+                &destination_b,
+                &db,
+                cache,
+            )),
+            &db,
+            OptionalCache::new(None),
+        ));
+        let message_a = dummy_hyperlane_message(&destination_a, 0);
+        let message_b = dummy_hyperlane_message(&destination_b, 1);
+        add_db_entry(&db, &message_a, 0);
+        add_db_entry(&db, &message_b, 0);
+
+        let (sender_a, mut receiver_a) = mpsc::channel::<QueueOperation>(1);
+        let (sender_b, mut receiver_b) = mpsc::channel::<QueueOperation>(1);
+        sender_a
+            .try_send(Box::new(PendingMessage::new(
+                message_a.clone(),
+                context_a.clone(),
+                PendingOperationStatus::FirstPrepareAttempt,
+                None,
+                DEFAULT_MAX_MESSAGE_RETRIES,
+            )))
+            .unwrap();
+        let mut loader = MessageDbLoader::new(
+            db,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            dummy_message_loader_metrics(),
+            HashMap::from([
+                (destination_a.id(), sender_a),
+                (destination_b.id(), sender_b),
+            ]),
+            HashMap::from([
+                (destination_a.id(), context_a),
+                (destination_b.id(), context_b),
+            ]),
+            vec![].into(),
+            DEFAULT_MAX_MESSAGE_RETRIES,
+            None,
+        );
+
+        while loader.migration_iterator.is_some() {
+            timeout(Duration::from_millis(200), loader.tick())
+                .await
+                .expect("migration tick should not wait for polling fallback")
+                .unwrap();
+        }
+
+        assert_eq!(
+            receiver_b
+                .try_recv()
+                .unwrap()
+                .into_iter()
+                .next()
+                .unwrap()
+                .id(),
+            message_b.id()
+        );
+        assert_eq!(receiver_a.len(), 1);
+
+        timeout(Duration::from_millis(750), async {
+            let release_capacity = async {
+                sleep(Duration::from_millis(20)).await;
+                receiver_a.recv().await.unwrap();
+            };
+            let (tick_result, _) = tokio::join!(loader.tick(), release_capacity);
+            tick_result.unwrap();
+        })
+        .await
+        .expect("loader should wake when destination capacity becomes available");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn legacy_iterator_stops_at_startup_watermark() {
+    let mut mock_db = MockDb::new();
+    const MOCK_HIGHEST_SEEN_NONCE: u32 = 2;
 
     mock_db
         .expect_domain()
@@ -388,16 +603,7 @@ async fn test_forward_backward_iterator() {
     mock_db
         .expect_retrieve_message_by_nonce()
         .returning(move |nonce| {
-            // return `None` the first time we get a query for the last message
-            // (the `MAX_ONCHAIN_NONCE`th one), to simulate an ongoing indexing that hasn't finished
-            if nonce == MAX_ONCHAIN_NONCE && retrieve_calls_for_max_onchain_nonce == 0 {
-                retrieve_calls_for_max_onchain_nonce += 1;
-                return Ok(None);
-            }
-
-            // otherwise return a message for every nonce in the closed
-            // interval [0, MAX_ONCHAIN_NONCE]
-            if nonce > MAX_ONCHAIN_NONCE {
+            if nonce > MOCK_HIGHEST_SEEN_NONCE || nonce == 1 {
                 Ok(None)
             } else {
                 Ok(Some(dummy_hyperlane_message(
@@ -415,30 +621,16 @@ async fn test_forward_backward_iterator() {
     let dummy_metrics = dummy_message_loader_metrics();
     let db = Arc::new(mock_db);
 
-    let mut forward_backward_iterator = ForwardBackwardIterator::new(db.clone());
+    let mut iterator = LegacyMessageIterator::new(db.clone());
 
     let mut messages = vec![];
-    while let Some(msg) = forward_backward_iterator
-        .try_get_next_message(&dummy_metrics)
-        .await
-        .unwrap()
-    {
+    while let Some(msg) = iterator.try_get_next_message(&dummy_metrics).await.unwrap() {
         messages.push(msg.nonce);
     }
 
-    // we start with 2 (MOCK_HIGHEST_SEEN_NONCE) as the highest seen nonce,
-    // so we go forward and get 3.
-    // then we try going forward again but get a `None` (not indexed yet), for nonce 4 (MAX_ONCHAIN_NONCE).
-    // then we go backwards once and get 1.
-    // then retry the forward iteration, which should return a message the second time, for nonce 4.
-    // finally, going forward again returns None so we go backward and get 0.
-    assert_eq!(messages, vec![2, 3, 1, 4, 0]);
+    // Migration crosses the missing nonce 1 but stops at the startup watermark.
+    assert_eq!(messages, vec![2, 0]);
 
-    // the final bounds of the iterator are (None, MAX_ONCHAIN_NONCE + 1), where None means
-    // the backward iterator has reached the beginning (iterated past nonce 0)
-    assert_eq!(forward_backward_iterator.low_nonce_iter.nonce, None);
-    assert_eq!(
-        forward_backward_iterator.high_nonce_iter.nonce,
-        Some(MAX_ONCHAIN_NONCE + 1)
-    );
+    assert_eq!(iterator.low_nonce_iter.nonce, None);
+    assert_eq!(iterator.high_nonce_iter.nonce, None);
 }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1172,9 +1172,7 @@ impl PendingMessage {
                 "Validator signature wait recovered after message delivery"
             );
         }
-        self.ctx
-            .origin_db
-            .store_processed_by_nonce(&self.message.nonce, &true)?;
+        self.ctx.origin_db.store_message_processed(&self.message)?;
         self.ctx.metrics.update_nonce(&self.message);
         self.ctx.metrics.messages_processed.inc();
         Ok(())
@@ -2273,6 +2271,76 @@ mod test {
                 .with_label_values(&[app_context, "ethereum", "arbitrum", "ended"])
                 .get(),
             1
+        );
+    }
+
+    #[test]
+    fn process_success_finishes_metadata_wait_and_deletes_pending_index() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let cache = OptionalCache::new(None);
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = DB::from_path(temp_dir.path()).unwrap();
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let message = HyperlaneMessage {
+            nonce: 7,
+            origin: origin_domain.id(),
+            destination: destination_domain.id(),
+            ..Default::default()
+        };
+        base_db
+            .store_message(&message, Default::default())
+            .expect("store pending message and index");
+        let app_context = "test-app";
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let message_context =
+            dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+        let mut pending_message = PendingMessage::new(
+            message.clone(),
+            Arc::new(message_context),
+            PendingOperationStatus::FirstPrepareAttempt,
+            Some(app_context.to_owned()),
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        pending_message
+            .ctx
+            .metrics
+            .record_metadata_wait(message.id(), Some(app_context));
+
+        pending_message
+            .record_message_process_success()
+            .expect("commit process success");
+
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_active
+                .with_label_values(&[app_context, "ethereum", "arbitrum"])
+                .get(),
+            0
+        );
+        assert_eq!(
+            pending_message
+                .ctx
+                .metrics
+                .metadata_wait_event_count
+                .with_label_values(&[app_context, "ethereum", "arbitrum", "recovered"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            base_db
+                .retrieve_pending_message_at_or_after(destination_domain.id(), message.nonce)
+                .expect("read pending index"),
+            None
+        );
+        assert_eq!(
+            base_db
+                .retrieve_processed_by_nonce(&message.nonce)
+                .expect("read processed marker"),
+            Some(true)
         );
     }
 }

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::clone_on_ref_ptr)] // TODO: `rustc` 1.80.1 clippy issue
 
 use std::{
+    collections::HashSet,
     fmt::{Debug, Formatter},
     sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -9,6 +10,7 @@ use std::{
 use async_trait::async_trait;
 use derive_new::new;
 use eyre::Result;
+use parking_lot::Mutex;
 use prometheus::IntGauge;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::RwLock;
@@ -104,6 +106,33 @@ pub struct MessageContext {
     pub application_operation_verifier: Arc<dyn ApplicationOperationVerifier>,
 }
 
+/// Keeps an indexed message from being loaded again while its operation is alive.
+pub(super) struct LoadedMessageGuard {
+    message_id: H256,
+    loaded_messages: Arc<Mutex<HashSet<H256>>>,
+}
+
+impl LoadedMessageGuard {
+    pub(super) fn try_acquire(
+        message_id: H256,
+        loaded_messages: Arc<Mutex<HashSet<H256>>>,
+    ) -> Option<Self> {
+        if !loaded_messages.lock().insert(message_id) {
+            return None;
+        }
+        Some(Self {
+            message_id,
+            loaded_messages,
+        })
+    }
+}
+
+impl Drop for LoadedMessageGuard {
+    fn drop(&mut self) {
+        self.loaded_messages.lock().remove(&self.message_id);
+    }
+}
+
 /// A message that is pending processing and submission.
 #[derive(new, Serialize)]
 pub struct PendingMessage {
@@ -157,6 +186,15 @@ pub struct PendingMessage {
     #[new(default)]
     #[serde(skip_serializing)]
     ica_reveal_attempts: u32,
+    #[new(default)]
+    #[serde(skip_serializing)]
+    loaded_message_guard: Option<LoadedMessageGuard>,
+}
+
+impl PendingMessage {
+    pub(super) fn set_loaded_message_guard(&mut self, guard: LoadedMessageGuard) {
+        self.loaded_message_guard = Some(guard);
+    }
 }
 
 impl Drop for PendingMessage {

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument
 
 use hyperlane_base::{
     cache::{FunctionCallCache, LocalCache, MeteredCache, OptionalCache},
-    db::{HyperlaneDb, PendingMessageRetryState},
+    db::{HyperlaneDb, HyperlaneRocksDB, PendingMessageRetryState},
 };
 use hyperlane_core::{
     gas_used_by_operation, BatchItem, ChainCommunicationError, ChainResult, ConfirmReason,
@@ -110,12 +110,14 @@ pub struct MessageContext {
 pub(super) struct LoadedMessageGuard {
     message_id: H256,
     loaded_messages: Arc<Mutex<HashSet<H256>>>,
+    db: HyperlaneRocksDB,
 }
 
 impl LoadedMessageGuard {
     pub(super) fn try_acquire(
         message_id: H256,
         loaded_messages: Arc<Mutex<HashSet<H256>>>,
+        db: HyperlaneRocksDB,
     ) -> Option<Self> {
         if !loaded_messages.lock().insert(message_id) {
             return None;
@@ -123,7 +125,12 @@ impl LoadedMessageGuard {
         Some(Self {
             message_id,
             loaded_messages,
+            db,
         })
+    }
+
+    fn mark_terminal(&self) -> hyperlane_base::db::DbResult<()> {
+        self.db.store_terminally_dropped_message(&self.message_id)
     }
 }
 
@@ -194,6 +201,16 @@ pub struct PendingMessage {
 impl PendingMessage {
     pub(super) fn set_loaded_message_guard(&mut self, guard: LoadedMessageGuard) {
         self.loaded_message_guard = Some(guard);
+    }
+
+    pub(super) fn terminal_drop(&mut self) -> PendingOperationResult {
+        if let Some(guard) = self.loaded_message_guard.as_ref() {
+            if let Err(err) = guard.mark_terminal() {
+                return self
+                    .on_reprepare(Some(err), ReprepareReason::ErrorPersistingTerminalMessage);
+            }
+        }
+        PendingOperationResult::Drop
     }
 }
 
@@ -355,7 +372,7 @@ impl PendingOperation for PendingMessage {
                 recipient=?self.message.recipient,
                 "Dropping message because recipient is not a contract"
             );
-            return PendingOperationResult::Drop;
+            return self.terminal_drop();
         }
 
         // Perform a preflight check to see if we can short circuit the gas
@@ -1165,7 +1182,7 @@ impl PendingMessage {
         result
     }
 
-    fn reprepare_or_drop(&self, reason: ReprepareReason) -> PendingOperationResult {
+    fn reprepare_or_drop(&mut self, reason: ReprepareReason) -> PendingOperationResult {
         // For fail-fast messages (relay API), drop immediately once the retry budget is
         // exceeded. Without this check, a small max_retries value (e.g. 3) would still
         // hit the fixed early-backoff arms (1 => 5s, 2 => 10s, ...) rather than dropping.
@@ -1177,7 +1194,7 @@ impl PendingMessage {
                 max_retries = self.max_retries,
                 "Relay API message exceeded max retries, dropping"
             );
-            return PendingOperationResult::Drop;
+            return self.terminal_drop();
         }
         PendingOperationResult::Reprepare(reason)
     }

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -508,37 +508,13 @@ impl BaseAgent for Relayer {
             };
             tasks.push(merkle_tree_hook_sync);
 
-            let mut message_db_loader_init_failed = false;
-            let message_db_loader = loop {
-                let index_notifications =
-                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await;
-                match self.run_message_db_loader(
-                    origin,
-                    send_channels.clone(),
-                    index_notifications,
-                    task_monitor.clone(),
-                    &message_db_loader_metrics,
-                ) {
-                    Ok(task) => {
-                        if message_db_loader_init_failed {
-                            self.chain_metrics
-                                .set_critical_error(origin_domain.name(), false);
-                        }
-                        break task;
-                    }
-                    Err(err) => {
-                        message_db_loader_init_failed = true;
-                        Self::record_critical_error(
-                            origin_domain,
-                            &self.chain_metrics,
-                            &err,
-                            "Failed to run message db loader; retrying",
-                        );
-                        tokio::time::sleep(MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL).await;
-                    }
-                }
-            };
-            tasks.push(message_db_loader);
+            tasks.push(self.run_message_db_loader_supervisor(
+                origin,
+                send_channels.clone(),
+                maybe_broadcaster,
+                task_monitor.clone(),
+                &message_db_loader_metrics,
+            ));
 
             let merkle_tree_db_loader =
                 match self.run_merkle_tree_db_loader(origin, task_monitor.clone()) {
@@ -925,14 +901,14 @@ impl Relayer {
         format!("contract::sync::{prefix}{domain}")
     }
 
-    fn run_message_db_loader(
+    fn run_message_db_loader_supervisor(
         &self,
         origin: &Origin,
         send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
-        index_notifications: Option<MpscReceiver<IndexingNotification>>,
+        maybe_broadcaster: Option<BroadcastMpscSender<IndexingNotification>>,
         task_monitor: TaskMonitor,
         shared_metrics: &MessageDbLoaderMetricsShared,
-    ) -> eyre::Result<JoinHandle<()>> {
+    ) -> JoinHandle<()> {
         let metrics = shared_metrics.for_origin(&self.core.metrics, &origin.domain);
         let destination_ctxs: HashMap<_, _> = self
             .destinations
@@ -964,23 +940,63 @@ impl Relayer {
                 context
             })
             .collect();
+        let database = origin.database.clone();
+        let message_whitelist = self.message_whitelist.clone();
+        let message_blacklist = self.message_blacklist.clone();
+        let address_blacklist = self.address_blacklist.clone();
+        let metric_app_contexts = self.metric_app_contexts.clone();
+        let max_retries = self.max_retries;
+        let origin_domain = origin.domain.clone();
+        let chain_metrics = self.chain_metrics.clone();
+        let task_name = format!("message_db_loader_init::{}", origin_domain.name());
+        let span = info_span!("MessageDbLoader", origin=%origin_domain.name());
+        let instrumented = TaskMonitor::instrument(
+            &task_monitor.clone(),
+            async move {
+                let mut init_failed = false;
+                let mut message_db_loader = loop {
+                    match MessageDbLoader::new(
+                        database.clone(),
+                        message_whitelist.clone(),
+                        message_blacklist.clone(),
+                        address_blacklist.clone(),
+                        metrics.clone(),
+                        send_channels.clone(),
+                        destination_ctxs.clone(),
+                        metric_app_contexts.clone(),
+                        max_retries,
+                    ) {
+                        Ok(loader) => break loader,
+                        Err(err) => {
+                            init_failed = true;
+                            Self::record_critical_error(
+                                &origin_domain,
+                                &chain_metrics,
+                                &err,
+                                "Failed to run message db loader; retrying",
+                            );
+                            tokio::time::sleep(MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL).await;
+                        }
+                    }
+                };
+                message_db_loader.set_index_notifications(
+                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
+                );
+                if init_failed {
+                    chain_metrics.set_critical_error(origin_domain.name(), false);
+                }
 
-        let message_db_loader = MessageDbLoader::new(
-            origin.database.clone(),
-            self.message_whitelist.clone(),
-            self.message_blacklist.clone(),
-            self.address_blacklist.clone(),
-            metrics,
-            send_channels,
-            destination_ctxs,
-            self.metric_app_contexts.clone(),
-            self.max_retries,
-            index_notifications,
-        )?;
+                DbLoader::new(Box::new(message_db_loader), task_monitor)
+                    .run()
+                    .await;
+            }
+            .instrument(span),
+        );
 
-        let span = info_span!("MessageDbLoader", origin=%message_db_loader.domain());
-        let db_loader = DbLoader::new(Box::new(message_db_loader), task_monitor.clone());
-        Ok(db_loader.spawn(span))
+        tokio::task::Builder::new()
+            .name(&task_name)
+            .spawn(instrumented)
+            .expect("spawning tokio task from Builder is infallible")
     }
 
     fn run_merkle_tree_db_loader(

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -23,7 +23,7 @@ use tokio_metrics::TaskMonitor;
 use tracing::{debug, error, info, info_span, Instrument};
 
 use hyperlane_base::{
-    broadcast::BroadcastMpscSender,
+    broadcast::{BroadcastMpscSender, IndexingNotification},
     cache::{LocalCache, MeteredCache, MeteredCacheConfig, OptionalCache},
     db::{HyperlaneRocksDB, DB},
     metrics::{AgentMetrics, ChainSpecificMetricsUpdater},
@@ -33,8 +33,7 @@ use hyperlane_base::{
 };
 use hyperlane_core::{
     rpc_clients::call_and_retry_n_times, ChainCommunicationError, ChainResult, ContractSyncCursor,
-    HyperlaneDomain, HyperlaneMessage, Indexer, InterchainGasPayment, MerkleTreeInsertion, H512,
-    U256,
+    HyperlaneDomain, HyperlaneMessage, Indexer, InterchainGasPayment, MerkleTreeInsertion, U256,
 };
 use lander::{CommandEntrypoint, DispatcherMetrics};
 
@@ -789,7 +788,7 @@ impl Relayer {
     async fn run_interchain_gas_payment_sync(
         &self,
         origin: &Origin,
-        tx_id_receiver: Option<MpscReceiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
         task_monitor: TaskMonitor,
     ) -> eyre::Result<Option<JoinHandle<()>>> {
         let contract_sync = match origin.interchain_gas_payment_sync.as_ref() {
@@ -830,7 +829,7 @@ impl Relayer {
         index_settings: IndexSettings,
         contract_sync: Arc<dyn ContractSyncer<InterchainGasPayment>>,
         chain_metrics: ChainMetrics,
-        tx_id_receiver: Option<MpscReceiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
     ) {
         let cursor = match Self::instantiate_cursor_with_retries(
             contract_sync.clone(),
@@ -855,7 +854,7 @@ impl Relayer {
     async fn run_merkle_tree_hook_sync(
         &self,
         origin: &Origin,
-        tx_id_receiver: Option<MpscReceiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
         task_monitor: TaskMonitor,
     ) -> eyre::Result<JoinHandle<()>> {
         let chain_metrics = self.chain_metrics.clone();
@@ -889,7 +888,7 @@ impl Relayer {
         index_settings: IndexSettings,
         contract_sync: Arc<dyn ContractSyncer<MerkleTreeInsertion>>,
         chain_metrics: ChainMetrics,
-        tx_id_receiver: Option<MpscReceiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
     ) {
         let cursor_instantiation_result =
             Self::instantiate_cursor_with_retries(contract_sync.clone(), index_settings.clone())
@@ -917,7 +916,7 @@ impl Relayer {
         &self,
         origin: &Origin,
         send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
-        index_notifications: Option<MpscReceiver<H512>>,
+        index_notifications: Option<MpscReceiver<IndexingNotification>>,
         task_monitor: TaskMonitor,
         shared_metrics: &MessageDbLoaderMetricsShared,
     ) -> eyre::Result<JoinHandle<()>> {

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -964,7 +964,7 @@ impl Relayer {
             self.metric_app_contexts.clone(),
             self.max_retries,
             index_notifications,
-        );
+        )?;
 
         let span = info_span!("MessageDbLoader", origin=%message_db_loader.domain());
         let db_loader = DbLoader::new(Box::new(message_db_loader), task_monitor.clone());

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -51,7 +51,7 @@ use crate::{
     metrics::message_submission::MessageSubmissionMetrics,
     msg::{
         blacklist::AddressBlacklist,
-        db_loader::{MessageDbLoader, MessageDbLoaderMetrics},
+        db_loader::{MessageDbLoader, MessageDbLoaderMetricsShared},
         message_processor::{
             MessageProcessor, MessageProcessorMetrics, MESSAGE_PROCESSOR_INGRESS_CAPACITY,
         },
@@ -445,6 +445,8 @@ impl BaseAgent for Relayer {
         debug!(elapsed = ?start_entity_init.elapsed(), event = "started processors", "Relayer startup duration measurement");
 
         start_entity_init = Instant::now();
+        let message_db_loader_metrics = MessageDbLoaderMetricsShared::new(&self.core.metrics)
+            .expect("Creating message DB loader metrics is infallible");
         for (origin_domain, origin) in self.origins.iter() {
             let maybe_broadcaster = origin.message_sync.get_broadcaster();
 
@@ -511,6 +513,7 @@ impl BaseAgent for Relayer {
                 send_channels.clone(),
                 BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
                 task_monitor.clone(),
+                &message_db_loader_metrics,
             ) {
                 Ok(task) => task,
                 Err(err) => {
@@ -916,8 +919,9 @@ impl Relayer {
         send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
         index_notifications: Option<MpscReceiver<H512>>,
         task_monitor: TaskMonitor,
+        shared_metrics: &MessageDbLoaderMetricsShared,
     ) -> eyre::Result<JoinHandle<()>> {
-        let metrics = MessageDbLoaderMetrics::new(&self.core.metrics, &origin.domain);
+        let metrics = shared_metrics.for_origin(&self.core.metrics, &origin.domain);
         let destination_ctxs: HashMap<_, _> = self
             .destinations
             .keys()

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{Debug, Formatter},
     hash::Hash,
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -73,6 +73,7 @@ mod origin;
 
 const CURSOR_BUILDING_ERROR: &str = "Error building cursor for origin";
 const CURSOR_INSTANTIATION_ATTEMPTS: usize = 10;
+const MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 const ADVANCED_LOG_META: bool = false;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -507,22 +508,34 @@ impl BaseAgent for Relayer {
             };
             tasks.push(merkle_tree_hook_sync);
 
-            let message_db_loader = match self.run_message_db_loader(
-                origin,
-                send_channels.clone(),
-                BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await,
-                task_monitor.clone(),
-                &message_db_loader_metrics,
-            ) {
-                Ok(task) => task,
-                Err(err) => {
-                    Self::record_critical_error(
-                        origin_domain,
-                        &self.chain_metrics,
-                        &err,
-                        "Failed to run message db loader",
-                    );
-                    continue;
+            let mut message_db_loader_init_failed = false;
+            let message_db_loader = loop {
+                let index_notifications =
+                    BroadcastMpscSender::map_get_receiver(maybe_broadcaster.as_ref()).await;
+                match self.run_message_db_loader(
+                    origin,
+                    send_channels.clone(),
+                    index_notifications,
+                    task_monitor.clone(),
+                    &message_db_loader_metrics,
+                ) {
+                    Ok(task) => {
+                        if message_db_loader_init_failed {
+                            self.chain_metrics
+                                .set_critical_error(origin_domain.name(), false);
+                        }
+                        break task;
+                    }
+                    Err(err) => {
+                        message_db_loader_init_failed = true;
+                        Self::record_critical_error(
+                            origin_domain,
+                            &self.chain_metrics,
+                            &err,
+                            "Failed to run message db loader; retrying",
+                        );
+                        tokio::time::sleep(MESSAGE_DB_LOADER_INIT_RETRY_INTERVAL).await;
+                    }
                 }
             };
             tasks.push(message_db_loader);

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -10,7 +10,7 @@ use derive_more::AsRef;
 use futures::{future::try_join_all, FutureExt};
 use hyperlane_core::{
     rpc_clients::RPC_RETRY_SLEEP_DURATION, Delivery, HyperlaneDomain, HyperlaneLogStore,
-    HyperlaneMessage, IndexMode, InterchainGasPayment, MerkleTreeInsertion, SameChainCcrSwap, H512,
+    HyperlaneMessage, IndexMode, InterchainGasPayment, MerkleTreeInsertion, SameChainCcrSwap,
 };
 use prometheus::{IntGauge, IntGaugeVec};
 use tokio::{
@@ -21,9 +21,11 @@ use tokio::{
 use tracing::{info, info_span, instrument, trace, warn, Instrument};
 
 use hyperlane_base::{
-    broadcast::BroadcastMpscSender, metrics::AgentMetrics, settings::IndexSettings, AgentMetadata,
-    BaseAgent, ChainMetrics, ChainSpecificMetricsUpdater, ContractSyncMetrics, ContractSyncer,
-    CoreMetrics, HyperlaneAgentCore, RuntimeMetrics, SyncOptions,
+    broadcast::{BroadcastMpscSender, IndexingNotification},
+    metrics::AgentMetrics,
+    settings::IndexSettings,
+    AgentMetadata, BaseAgent, ChainMetrics, ChainSpecificMetricsUpdater, ContractSyncMetrics,
+    ContractSyncer, CoreMetrics, HyperlaneAgentCore, RuntimeMetrics, SyncOptions,
 };
 
 use crate::{
@@ -302,7 +304,10 @@ impl Scraper {
                 self.contract_sync_metrics.clone(),
                 store.clone(),
                 index_settings.clone(),
-                BroadcastMpscSender::<H512>::map_get_receiver(maybe_broadcaster.as_ref()).await,
+                BroadcastMpscSender::<IndexingNotification>::map_get_receiver(
+                    maybe_broadcaster.as_ref(),
+                )
+                .await,
             )
             .await?;
         tasks.push(gas_payment_indexer);
@@ -419,7 +424,10 @@ impl Scraper {
         contract_sync_metrics: Arc<ContractSyncMetrics>,
         store: HyperlaneDbStore,
         index_settings: IndexSettings,
-    ) -> eyre::Result<(JoinHandle<()>, Option<BroadcastMpscSender<H512>>)> {
+    ) -> eyre::Result<(
+        JoinHandle<()>,
+        Option<BroadcastMpscSender<IndexingNotification>>,
+    )> {
         let label = "message_dispatch";
         let sync = self
             .as_ref()
@@ -614,7 +622,7 @@ impl Scraper {
         contract_sync_metrics: Arc<ContractSyncMetrics>,
         store: HyperlaneDbStore,
         index_settings: IndexSettings,
-        tx_id_receiver: Option<MpscReceiver<H512>>,
+        tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
     ) -> eyre::Result<JoinHandle<()>> {
         let label = "gas_payment";
         let sync = self

--- a/rust/main/hyperlane-base/src/contract_sync/broadcast.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/broadcast.rs
@@ -22,14 +22,33 @@ pub struct BroadcastMpscSender<T> {
     sender: Arc<Mutex<Vec<MpscSender<T>>>>,
 }
 
-impl BroadcastMpscSender<H512> {
+/// Cursor-indexed transaction and the stored event sequences it contained.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IndexingNotification {
+    /// Indexed transaction id.
+    pub tx_id: H512,
+    /// Sequence numbers stored from the transaction.
+    pub sequences: Vec<Option<u32>>,
+}
+
+impl IndexingNotification {
+    /// Build a notification for a transaction without sequence metadata.
+    pub fn from_tx_id(tx_id: H512) -> Self {
+        Self {
+            tx_id,
+            sequences: Vec::new(),
+        }
+    }
+}
+
+impl<T: Clone> BroadcastMpscSender<T> {
     /// Send a message to all the receiving channels.
     // This will block if at least one of the receiving channels is full
-    pub async fn send(&self, txid: H512) -> Result<()> {
+    pub async fn send(&self, message: T) -> Result<()> {
         let mut senders = self.sender.lock().await;
         let mut index = 0;
         while index < senders.len() {
-            if senders[index].send(txid).await.is_ok() {
+            if senders[index].send(message.clone()).await.is_ok() {
                 index = index.saturating_add(1);
             } else {
                 // A closed receiver must not prevent later subscribers from
@@ -41,7 +60,7 @@ impl BroadcastMpscSender<H512> {
     }
 
     /// Get a receiver channel that will receive messages broadcasted by all the senders
-    pub async fn get_receiver(&self) -> MpscReceiver<H512> {
+    pub async fn get_receiver(&self) -> MpscReceiver<T> {
         let (sender, receiver) = tokio::sync::mpsc::channel(self.capacity);
 
         self.sender.lock().await.push(sender);
@@ -49,7 +68,7 @@ impl BroadcastMpscSender<H512> {
     }
 
     /// Utility function map an option of `BroadcastMpscSender` to an option of `MpscReceiver`
-    pub async fn map_get_receiver(maybe_self: Option<&Self>) -> Option<MpscReceiver<H512>> {
+    pub async fn map_get_receiver(maybe_self: Option<&Self>) -> Option<MpscReceiver<T>> {
         if let Some(s) = maybe_self {
             Some(s.get_receiver().await)
         } else {

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use broadcast::BroadcastMpscSender;
+use broadcast::{BroadcastMpscSender, IndexingNotification};
 use cursors::*;
 use derive_new::new;
 use eyre::Result;
@@ -53,7 +53,7 @@ pub struct ContractSync<T: Indexable, S: HyperlaneLogStore<T>, I: Indexer<T>> {
     store: S,
     indexer: I,
     metrics: ContractSyncMetrics,
-    broadcast_sender: Option<BroadcastMpscSender<H512>>,
+    broadcast_sender: Option<BroadcastMpscSender<IndexingNotification>>,
     _phantom: PhantomData<T>,
 }
 
@@ -93,7 +93,7 @@ where
         &self.domain
     }
 
-    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<H512>> {
+    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<IndexingNotification>> {
         self.broadcast_sender.clone()
     }
 
@@ -200,7 +200,7 @@ where
         domain: HyperlaneDomain,
         indexer: I,
         store: Arc<Mutex<S>>,
-        mut recv: MpscReceiver<H512>,
+        mut recv: MpscReceiver<IndexingNotification>,
         stored_logs_metric: GenericCounter<AtomicU64>,
         liveness_metric: GenericGauge<AtomicI64>,
     ) {
@@ -212,7 +212,7 @@ where
 
         loop {
             Self::update_liveness_metric(&liveness_metric);
-            let tx_id = match loop {
+            let notification = match loop {
                 tokio::select! {
                     tx_id = recv.recv() => break tx_id,
                     _ = liveness_interval.tick() => {
@@ -220,12 +220,13 @@ where
                     }
                 }
             } {
-                Some(tx_id) => tx_id,
+                Some(notification) => notification,
                 None => {
                     tracing::error!("Error: channel has closed");
                     break;
                 }
             };
+            let tx_id = notification.tx_id;
 
             let logs = match indexer.fetch_logs_by_tx_hash(tx_id).await {
                 Ok(logs) => logs,
@@ -269,7 +270,7 @@ where
         indexer: I,
         store: Arc<Mutex<S>>,
         mut cursor: Box<dyn ContractSyncCursor<T>>,
-        broadcast_sender: Option<BroadcastMpscSender<H512>>,
+        broadcast_sender: Option<BroadcastMpscSender<IndexingNotification>>,
         stored_logs_metric: GenericCounter<AtomicU64>,
         indexed_height_metric: GenericGauge<AtomicI64>,
         liveness_metric: GenericGauge<AtomicI64>,
@@ -339,11 +340,16 @@ where
             if let Some(tx) = broadcast_sender.as_ref() {
                 // If multiple logs occur in the same transaction they'll have the same transaction_id.
                 // Deduplicate their txids to avoid doing wasteful queries in txid indexer
-                let unique_txids: HashSet<_> =
-                    logs.iter().map(|(_, meta)| meta.transaction_id).collect();
+                let mut transactions = std::collections::HashMap::<_, Vec<_>>::new();
+                for (log, meta) in &logs {
+                    transactions
+                        .entry(meta.transaction_id)
+                        .or_default()
+                        .push(log.sequence);
+                }
 
-                for tx_id in unique_txids {
-                    if let Err(err) = tx.send(tx_id).await {
+                for (tx_id, sequences) in transactions {
+                    if let Err(err) = tx.send(IndexingNotification { tx_id, sequences }).await {
                         trace!(?err, "Error sending txid to receiver");
                     }
                 }
@@ -613,7 +619,7 @@ mod tests {
         assert!(!task.is_finished());
 
         sender
-            .send(H512::zero())
+            .send(IndexingNotification::from_tx_id(H512::zero()))
             .await
             .expect("idle receiver should remain connected");
         run_pending_tasks().await;
@@ -649,7 +655,7 @@ pub trait ContractSyncer<T>: Send + Sync {
     fn domain(&self) -> &HyperlaneDomain;
 
     /// If this syncer is also a broadcaster, return the channel to receive txids
-    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<H512>>;
+    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<IndexingNotification>>;
 }
 
 #[derive(new)]
@@ -659,7 +665,7 @@ pub struct SyncOptions<T> {
     // Might want to refactor into an enum later, where we either index with a cursor or rely on receiving
     // txids from a channel to other indexing tasks
     cursor: Option<Box<dyn ContractSyncCursor<T>>>,
-    tx_id_receiver: Option<MpscReceiver<H512>>,
+    tx_id_receiver: Option<MpscReceiver<IndexingNotification>>,
 }
 
 impl<T> From<Box<dyn ContractSyncCursor<T>>> for SyncOptions<T> {
@@ -711,7 +717,7 @@ where
         ContractSync::domain(self)
     }
 
-    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<H512>> {
+    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<IndexingNotification>> {
         ContractSync::get_broadcaster(self)
     }
 }
@@ -756,7 +762,7 @@ where
         ContractSync::domain(self)
     }
 
-    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<H512>> {
+    fn get_broadcaster(&self) -> Option<BroadcastMpscSender<IndexingNotification>> {
         ContractSync::get_broadcaster(self)
     }
 }

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -48,8 +48,10 @@ pub trait HyperlaneDb: Send + Sync {
     /// Store whether a message was processed by its nonce
     fn store_processed_by_nonce(&self, nonce: &u32, processed: &bool) -> DbResult<()>;
 
-    /// Atomically mark a message processed and remove it from pending loading.
-    fn store_message_processed(&self, message: &HyperlaneMessage) -> DbResult<()>;
+    /// Mark a message processed, optionally removing it from pending loading atomically.
+    fn store_message_processed(&self, message: &HyperlaneMessage) -> DbResult<()> {
+        self.store_processed_by_nonce(&message.nonce, &true)
+    }
 
     fn store_processed_by_gas_payment_meta(
         &self,

--- a/rust/main/hyperlane-base/src/db/mod.rs
+++ b/rust/main/hyperlane-base/src/db/mod.rs
@@ -48,6 +48,9 @@ pub trait HyperlaneDb: Send + Sync {
     /// Store whether a message was processed by its nonce
     fn store_processed_by_nonce(&self, nonce: &u32, processed: &bool) -> DbResult<()>;
 
+    /// Atomically mark a message processed and remove it from pending loading.
+    fn store_message_processed(&self, message: &HyperlaneMessage) -> DbResult<()>;
+
     fn store_processed_by_gas_payment_meta(
         &self,
         meta: &InterchainGasPaymentMeta,

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -38,6 +38,7 @@ const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
     "pending_message_retry_count_for_message_id_";
 const PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID: &str =
     "pending_message_retry_state_for_message_id_v1_";
+const PENDING_MESSAGE_BY_DESTINATION: &str = "pending_message_by_destination_v1_";
 const MERKLE_TREE_INSERTION: &str = "merkle_tree_insertion_";
 const MERKLE_LEAF_INDEX_BY_MESSAGE_ID: &str = "merkle_leaf_index_by_message_id_";
 const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
@@ -95,9 +96,10 @@ impl HyperlaneRocksDB {
         message: &HyperlaneMessage,
         dispatched_block_number: u64,
     ) -> DbResult<bool> {
-        if let Ok(Some(_)) = self.retrieve_message_id_by_nonce(&message.nonce) {
+        if let Some(stored_message) = self.retrieve_message_by_nonce(message.nonce)? {
             trace!(hyp_message=?message, "Message already stored in db");
             self.try_update_max_seen_message_nonce(message.nonce)?;
+            self.reconcile_pending_message_index(&stored_message)?;
             return Ok(false);
         }
         self.upsert_message(message, dispatched_block_number)?;
@@ -116,17 +118,141 @@ impl HyperlaneRocksDB {
         dispatched_block_number: u64,
     ) -> DbResult<()> {
         let id = message.id();
+        let previous = self.retrieve_message_by_nonce(message.nonce)?;
+        let max_nonce = self
+            .retrieve_highest_seen_message_nonce()?
+            .unwrap_or_default()
+            .max(message.nonce);
         debug!(hyp_message=?message,  "Storing new message in db",);
 
-        // - `id` --> `message`
-        self.store_message_by_id(&id, message)?;
-        // - `nonce` --> `id`
-        self.store_message_id_by_nonce(&message.nonce, &id)?;
-        // Update the max seen nonce to allow forward-backward iteration in the processor
-        self.try_update_max_seen_message_nonce(message.nonce)?;
-        // - `nonce` --> `dispatched block number`
-        self.store_dispatched_block_number_by_nonce(&message.nonce, &dispatched_block_number)?;
+        let entries = [
+            (MESSAGE.as_bytes().to_vec(), id.to_vec(), message.to_vec()),
+            (
+                MESSAGE_ID.as_bytes().to_vec(),
+                message.nonce.to_vec(),
+                id.to_vec(),
+            ),
+            (
+                HIGHEST_SEEN_MESSAGE_NONCE.as_bytes().to_vec(),
+                bool::default().to_vec(),
+                max_nonce.to_vec(),
+            ),
+            (
+                MESSAGE_DISPATCHED_BLOCK_NUMBER.as_bytes().to_vec(),
+                message.nonce.to_vec(),
+                dispatched_block_number.to_vec(),
+            ),
+            (
+                Self::pending_message_destination_prefix(message.destination),
+                message.nonce.to_vec(),
+                id.to_vec(),
+            ),
+        ];
+        let deletions = previous
+            .filter(|previous| previous.destination != message.destination)
+            .map(|previous| {
+                (
+                    Self::pending_message_destination_prefix(previous.destination),
+                    previous.nonce.to_vec(),
+                )
+            });
+        self.store_and_delete_batch(entries, deletions)?;
         Ok(())
+    }
+
+    fn pending_message_destination_prefix(destination: u32) -> Vec<u8> {
+        PENDING_MESSAGE_BY_DESTINATION
+            .as_bytes()
+            .iter()
+            .chain(destination.to_be_bytes().iter())
+            .copied()
+            .collect()
+    }
+
+    /// Add an unprocessed message to its destination range.
+    pub fn store_pending_message_index(&self, message: &HyperlaneMessage) -> DbResult<()> {
+        self.store_value_by_key(
+            Self::pending_message_destination_prefix(message.destination),
+            &message.nonce,
+            &message.id(),
+        )
+    }
+
+    /// Remove a message from its destination range.
+    pub fn delete_pending_message_index(&self, message: &HyperlaneMessage) -> DbResult<()> {
+        self.delete_pending_message_index_by_nonce(message.destination, message.nonce)
+    }
+
+    /// Remove a destination range entry when the message value is unavailable.
+    pub fn delete_pending_message_index_by_nonce(
+        &self,
+        destination: u32,
+        nonce: u32,
+    ) -> DbResult<()> {
+        self.store_and_delete_batch(
+            std::iter::empty(),
+            [(
+                Self::pending_message_destination_prefix(destination),
+                nonce.to_vec(),
+            )],
+        )
+    }
+
+    /// Restore or remove an index entry according to the processed marker.
+    pub fn reconcile_pending_message_index(&self, message: &HyperlaneMessage) -> DbResult<()> {
+        let existing =
+            self.retrieve_pending_message_at_or_after(message.destination, message.nonce)?;
+        let existing = existing.filter(|(nonce, _)| *nonce == message.nonce);
+        if self
+            .retrieve_processed_by_nonce(&message.nonce)?
+            .unwrap_or(false)
+        {
+            if existing.is_some() {
+                self.delete_pending_message_index(message)?;
+            }
+        } else if existing != Some((message.nonce, message.id())) {
+            self.store_pending_message_index(message)?;
+        }
+        Ok(())
+    }
+
+    /// Retrieve the first destination entry at or after `nonce`.
+    pub fn retrieve_pending_message_at_or_after(
+        &self,
+        destination: u32,
+        nonce: u32,
+    ) -> DbResult<Option<(u32, H256)>> {
+        self.retrieve_pending_message_from(destination, nonce, true)
+    }
+
+    /// Retrieve the first destination entry at or before `nonce`.
+    pub fn retrieve_pending_message_at_or_before(
+        &self,
+        destination: u32,
+        nonce: u32,
+    ) -> DbResult<Option<(u32, H256)>> {
+        self.retrieve_pending_message_from(destination, nonce, false)
+    }
+
+    fn retrieve_pending_message_from(
+        &self,
+        destination: u32,
+        nonce: u32,
+        forward: bool,
+    ) -> DbResult<Option<(u32, H256)>> {
+        let prefix = Self::pending_message_destination_prefix(destination);
+        let entry = if forward {
+            self.retrieve_by_prefix_at_or_after(&prefix, nonce.to_be_bytes())?
+        } else {
+            self.retrieve_by_prefix_at_or_before(&prefix, nonce.to_be_bytes())?
+        };
+        let Some((nonce, message_id)) = entry else {
+            return Ok(None);
+        };
+        let nonce: [u8; 4] = nonce.try_into().map_err(|nonce: Vec<u8>| {
+            DbError::Other(format!("Invalid pending message index key: {nonce:?}"))
+        })?;
+        Ok(Some((u32::from_be_bytes(nonce), message_id)))
     }
 
     /// Retrieve a message by its nonce
@@ -311,6 +437,95 @@ impl HyperlaneRocksDB {
             .retrieve_interchain_gas_expenditure_data_by_message_id(&message_id)?
             .unwrap_or_default()
             .complete(message_id))
+    }
+}
+
+#[cfg(test)]
+mod pending_index_tests {
+    use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, H256};
+
+    use super::*;
+    use crate::db::rocks::test_utils::run_test_db;
+
+    fn message(nonce: u32, destination: u32) -> HyperlaneMessage {
+        HyperlaneMessage {
+            nonce,
+            origin: 1,
+            destination,
+            sender: H256::zero(),
+            recipient: H256::zero(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn destination_index_is_ordered_and_isolated() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            let first = message(0, 10);
+            let later = message(2, 10);
+            let other = message(1, 11);
+            db.store_message(&later, 1).unwrap();
+            db.store_message(&other, 1).unwrap();
+            db.store_message(&first, 1).unwrap();
+
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(10, 0).unwrap(),
+                Some((0, first.id()))
+            );
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(10, 1).unwrap(),
+                Some((2, later.id()))
+            );
+            assert_eq!(
+                db.retrieve_pending_message_at_or_before(10, u32::MAX)
+                    .unwrap(),
+                Some((2, later.id()))
+            );
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(11, 0).unwrap(),
+                Some((1, other.id()))
+            );
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(10, 3).unwrap(),
+                None
+            );
+            assert_eq!(
+                db.retrieve_pending_message_at_or_before(11, 0).unwrap(),
+                None
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn upsert_moves_index_and_processing_removes_it() {
+        run_test_db(|raw_db| async move {
+            let db = HyperlaneRocksDB::new(&HyperlaneDomain::new_test_domain("origin"), raw_db);
+            let old = message(7, 10);
+            let moved = message(7, 11);
+            db.upsert_message(&old, 1).unwrap();
+            db.upsert_message(&moved, 2).unwrap();
+
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(10, 0).unwrap(),
+                None
+            );
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(11, 0).unwrap(),
+                Some((7, moved.id()))
+            );
+            db.store_pending_message_index(&moved).unwrap();
+            db.store_pending_message_index(&moved).unwrap();
+
+            db.store_message_processed(&moved).unwrap();
+            assert_eq!(db.retrieve_processed_by_nonce(&7).unwrap(), Some(true));
+            assert_eq!(
+                db.retrieve_pending_message_at_or_after(11, 0).unwrap(),
+                None
+            );
+        })
+        .await;
     }
 }
 
@@ -519,6 +734,20 @@ impl HyperlaneDb for HyperlaneRocksDB {
     /// Store whether a message was processed by its nonce
     fn store_processed_by_nonce(&self, nonce: &u32, processed: &bool) -> DbResult<()> {
         self.store_value_by_key(NONCE_PROCESSED, nonce, processed)
+    }
+
+    fn store_message_processed(&self, message: &HyperlaneMessage) -> DbResult<()> {
+        self.store_and_delete_batch(
+            [(
+                NONCE_PROCESSED.as_bytes().to_vec(),
+                message.nonce.to_vec(),
+                true.to_vec(),
+            )],
+            [(
+                Self::pending_message_destination_prefix(message.destination),
+                message.nonce.to_vec(),
+            )],
+        )
     }
 
     fn retrieve_processed_by_nonce(&self, nonce: &u32) -> DbResult<Option<bool>> {

--- a/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/hyperlane_db.rs
@@ -39,6 +39,7 @@ const PENDING_MESSAGE_RETRY_COUNT_FOR_MESSAGE_ID: &str =
 const PENDING_MESSAGE_RETRY_STATE_FOR_MESSAGE_ID: &str =
     "pending_message_retry_state_for_message_id_v1_";
 const PENDING_MESSAGE_BY_DESTINATION: &str = "pending_message_by_destination_v1_";
+const TERMINALLY_DROPPED_MESSAGE_BY_ID: &str = "terminally_dropped_message_by_id_v1_";
 const MERKLE_TREE_INSERTION: &str = "merkle_tree_insertion_";
 const MERKLE_LEAF_INDEX_BY_MESSAGE_ID: &str = "merkle_leaf_index_by_message_id_";
 const MERKLE_TREE_INSERTION_BLOCK_NUMBER_BY_LEAF_INDEX: &str =
@@ -148,14 +149,19 @@ impl HyperlaneRocksDB {
                 id.to_vec(),
             ),
         ];
-        let deletions = previous
-            .filter(|previous| previous.destination != message.destination)
-            .map(|previous| {
-                (
+        let mut deletions = Vec::new();
+        if let Some(previous) = previous.filter(|previous| previous.id() != id) {
+            deletions.push((
+                TERMINALLY_DROPPED_MESSAGE_BY_ID.as_bytes().to_vec(),
+                previous.id().to_vec(),
+            ));
+            if previous.destination != message.destination {
+                deletions.push((
                     Self::pending_message_destination_prefix(previous.destination),
                     previous.nonce.to_vec(),
-                )
-            });
+                ));
+            }
+        }
         self.store_and_delete_batch(entries, deletions)?;
         Ok(())
     }
@@ -180,7 +186,19 @@ impl HyperlaneRocksDB {
 
     /// Remove a message from its destination range.
     pub fn delete_pending_message_index(&self, message: &HyperlaneMessage) -> DbResult<()> {
-        self.delete_pending_message_index_by_nonce(message.destination, message.nonce)
+        self.store_and_delete_batch(
+            std::iter::empty(),
+            [
+                (
+                    Self::pending_message_destination_prefix(message.destination),
+                    message.nonce.to_vec(),
+                ),
+                (
+                    TERMINALLY_DROPPED_MESSAGE_BY_ID.as_bytes().to_vec(),
+                    message.id().to_vec(),
+                ),
+            ],
+        )
     }
 
     /// Remove a destination range entry when the message value is unavailable.
@@ -196,6 +214,19 @@ impl HyperlaneRocksDB {
                 nonce.to_vec(),
             )],
         )
+    }
+
+    /// Persist that a message reached a terminal relayer outcome.
+    /// Cleared when the message is processed or replaced at the same nonce.
+    pub fn store_terminally_dropped_message(&self, message_id: &H256) -> DbResult<()> {
+        self.store_value_by_key(TERMINALLY_DROPPED_MESSAGE_BY_ID, message_id, &true)
+    }
+
+    /// Return whether a message reached a terminal relayer outcome.
+    pub fn retrieve_terminally_dropped_message(&self, message_id: &H256) -> DbResult<bool> {
+        Ok(self
+            .retrieve_value_by_key::<_, bool>(TERMINALLY_DROPPED_MESSAGE_BY_ID, message_id)?
+            .unwrap_or(false))
     }
 
     /// Restore or remove an index entry according to the processed marker.
@@ -517,9 +548,11 @@ mod pending_index_tests {
             );
             db.store_pending_message_index(&moved).unwrap();
             db.store_pending_message_index(&moved).unwrap();
+            db.store_terminally_dropped_message(&moved.id()).unwrap();
 
             db.store_message_processed(&moved).unwrap();
             assert_eq!(db.retrieve_processed_by_nonce(&7).unwrap(), Some(true));
+            assert!(!db.retrieve_terminally_dropped_message(&moved.id()).unwrap());
             assert_eq!(
                 db.retrieve_pending_message_at_or_after(11, 0).unwrap(),
                 None
@@ -743,10 +776,16 @@ impl HyperlaneDb for HyperlaneRocksDB {
                 message.nonce.to_vec(),
                 true.to_vec(),
             )],
-            [(
-                Self::pending_message_destination_prefix(message.destination),
-                message.nonce.to_vec(),
-            )],
+            [
+                (
+                    Self::pending_message_destination_prefix(message.destination),
+                    message.nonce.to_vec(),
+                ),
+                (
+                    TERMINALLY_DROPPED_MESSAGE_BY_ID.as_bytes().to_vec(),
+                    message.id().to_vec(),
+                ),
+            ],
         )
     }
 

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -118,6 +118,42 @@ impl DB {
         Ok(self.0.write(batch)?)
     }
 
+    /// Atomically store and delete multiple keys.
+    pub fn store_and_delete_batch(
+        &self,
+        entries: impl IntoIterator<Item = (Vec<u8>, Vec<u8>)>,
+        deletions: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<()> {
+        let mut batch = WriteBatch::default();
+        for (key, value) in entries {
+            batch.put(key, value);
+        }
+        for key in deletions {
+            batch.delete(key);
+        }
+        Ok(self.0.write(batch)?)
+    }
+
+    pub(crate) fn retrieve_at_or_after(&self, key: &[u8]) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        let mut iterator = self.0.raw_iterator();
+        iterator.seek(key);
+        iterator.status()?;
+        Ok(iterator
+            .key()
+            .zip(iterator.value())
+            .map(|(key, value)| (key.to_vec(), value.to_vec())))
+    }
+
+    pub(crate) fn retrieve_at_or_before(&self, key: &[u8]) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        let mut iterator = self.0.raw_iterator();
+        iterator.seek_for_prev(key);
+        iterator.status()?;
+        Ok(iterator
+            .key()
+            .zip(iterator.value())
+            .map(|(key, value)| (key.to_vec(), value.to_vec())))
+    }
+
     /// Retrieve a value from the DB
     pub fn retrieve(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -59,6 +59,60 @@ impl TypedDB {
         )
     }
 
+    pub(crate) fn store_and_delete_batch(
+        &self,
+        entries: impl IntoIterator<Item = (Vec<u8>, Vec<u8>, Vec<u8>)>,
+        deletions: impl IntoIterator<Item = (Vec<u8>, Vec<u8>)>,
+    ) -> Result<()> {
+        self.db.store_and_delete_batch(
+            entries
+                .into_iter()
+                .map(|(prefix, key, value)| (self.prefixed_key(&prefix, &key), value)),
+            deletions
+                .into_iter()
+                .map(|(prefix, key)| self.prefixed_key(&prefix, &key)),
+        )
+    }
+
+    pub(crate) fn retrieve_by_prefix_at_or_after<V: Decode>(
+        &self,
+        prefix: impl AsRef<[u8]>,
+        key: impl AsRef<[u8]>,
+    ) -> Result<Option<(Vec<u8>, V)>> {
+        self.retrieve_by_prefix_from(prefix.as_ref(), key.as_ref(), true)
+    }
+
+    pub(crate) fn retrieve_by_prefix_at_or_before<V: Decode>(
+        &self,
+        prefix: impl AsRef<[u8]>,
+        key: impl AsRef<[u8]>,
+    ) -> Result<Option<(Vec<u8>, V)>> {
+        self.retrieve_by_prefix_from(prefix.as_ref(), key.as_ref(), false)
+    }
+
+    fn retrieve_by_prefix_from<V: Decode>(
+        &self,
+        prefix: &[u8],
+        key: &[u8],
+        forward: bool,
+    ) -> Result<Option<(Vec<u8>, V)>> {
+        let full_prefix = self.prefixed_key(prefix, &[]);
+        let start = self.prefixed_key(prefix, key);
+        let entry = if forward {
+            self.db.retrieve_at_or_after(&start)?
+        } else {
+            self.db.retrieve_at_or_before(&start)?
+        };
+        let Some((stored_key, value)) = entry else {
+            return Ok(None);
+        };
+        let Some(suffix) = stored_key.strip_prefix(full_prefix.as_slice()) else {
+            return Ok(None);
+        };
+        let value = V::read_from(&mut value.as_slice())?;
+        Ok(Some((suffix.to_vec(), value)))
+    }
+
     /// Store encodable value
     pub fn store_encodable<V: Encode>(
         &self,

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -38,7 +38,6 @@ mockall::mock! {
         ) -> DbResult<()>;
         fn retrieve_dispatched_block_number_by_nonce(&self, nonce: &u32) -> DbResult<Option<u64>>;
         fn store_processed_by_nonce(&self, nonce: &u32, processed: &bool) -> DbResult<()>;
-        fn store_message_processed(&self, message: &HyperlaneMessage) -> DbResult<()>;
         fn store_processed_by_gas_payment_meta(
             &self,
             meta: &InterchainGasPaymentMeta,

--- a/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
+++ b/rust/main/hyperlane-base/src/tests/mock_hyperlane_db.rs
@@ -38,6 +38,7 @@ mockall::mock! {
         ) -> DbResult<()>;
         fn retrieve_dispatched_block_number_by_nonce(&self, nonce: &u32) -> DbResult<Option<u64>>;
         fn store_processed_by_nonce(&self, nonce: &u32, processed: &bool) -> DbResult<()>;
+        fn store_message_processed(&self, message: &HyperlaneMessage) -> DbResult<()>;
         fn store_processed_by_gas_payment_meta(
             &self,
             meta: &InterchainGasPaymentMeta,

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -307,6 +307,9 @@ pub enum ReprepareReason {
     #[strum(to_string = "Failed to retrieve payload uuid status by message id")]
     /// Failed to retrieve payload status by message id
     ErrorRetrievingPayloadStatus,
+    #[strum(to_string = "Failed to persist terminal message state")]
+    /// Failed to persist that a message reached a terminal outcome
+    ErrorPersistingTerminalMessage,
     #[strum(to_string = "Failed to create payload success criteria")]
     /// Failed to create payload success criteria
     ErrorCreatingPayloadSuccessCriteria,


### PR DESCRIPTION
## Summary

- add a durable destination/nonce index for pending messages and update message state plus index atomically
- reconcile legacy history in 256-record batches without rescanning every destination per nonce
- scan destination indexes only on startup, indexed work, capacity/poll signals, or migration work
- retry transient loader-initialization failures in per-origin supervisors so one bad origin cannot block later origins or the relayer server
- repair wrong-ID/destination rows and remove processed or terminal rows from the pending index
- alternate high/low cursors so sustained new traffic cannot starve older backlog
- expose per-destination scan, logical-read, and ingress-depth metrics
- target low-range reconsideration to the affected destination/nonce
- retry legacy reconciliation before advancing its nonce and retain a bounded low-range cursor per destination so full ingress cannot block other destinations

## Correctness

- message insertion/moves and processed-marker cleanup use RocksDB write batches
- the startup watermark is read authoritatively; failures keep only that origin critical and retry every five seconds while other origins and the relayer server continue starting
- notification receivers are registered only after fallible DB initialization succeeds, preventing failed retries from accumulating broadcast subscribers
- migration has a fixed startup watermark, crosses nonce gaps, and yields to indexed work when it finds work or receives a notification
- processed history advances in 256-record batches; idle destination prefixes are not reopened for every historical nonce
- indexed IDs/destinations are checked against the canonical stored message before enqueue
- high/low cursors alternate when both have work
- missing/legacy/unreadable sequence metadata falls back to reopening low cursors
- terminal markers survive pending-index cleanup and suppress reloads across duplicate indexing and restart; processing or same-nonce replacement clears the marker
- process success retains #9169 metadata-wait recovery observation while atomically deleting the pending index
- #9399 per-destination reservations remain held through enqueue
- pending-record selection changes only; relay authority and message/reorg validation are unchanged

## Expected impact

**Analytical/modelled, not observed:** for one destination containing `N_d` of `N` pending records, its lookup examines `N_d` rather than filtering `N`: `N/N_d`x fewer records, or `(1 - N_d/N) * 100%` fewer. Compared with naively repeating a full scan for each of `D` destinations, aggregate work is `N` rather than `D*N`: up to `D`x / `(1 - 1/D) * 100%` fewer records. A balanced `D=100` case is 100x / 99% fewer than that comparison.

The current implementation has one global scanner, so it does **not** claim fewer total records when every destination is active. The primary gain is destination failure isolation and bounded ingress.

For a single indexed-message notification, low-range reconsideration targets the affected destination instead of reopening all `D` low ranges. The loader still round-robins destination high-range probes, so this does not establish a `D`x or 99% reduction in total destination probes. This is local DB work; no independent RPC or whole-process throughput reduction is claimed.

The processed-history regression uses 1,024 records and eight destinations. Destination-index seeks are bounded at 16 versus at least 8,192 in the former per-nonce round robin: at least 512x / 99.8% fewer for that restart shape. This is a deterministic test-model result, not production measurement.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check` across the exact rebuilt stack
- normal pre-commit hooks passed: gitleaks, lint-staged, and Rust formatting
- focused regressions include 1,024-record/eight-destination migration, terminal-marker retention across duplicate indexing/restart, and batch-channel compatibility
- `cargo check -p relayer --lib` passed at the review-fix head
- DB-loader tests: **26/26 passed**, including reconciliation retry and saturated-destination migration regressions; both new cases failed on the original code
- four stale loader test setups/assertions were corrected to exercise steady-state notification waits, bounded batch capacity and terminal-index cleanup
- cumulative metadata-wait, routing-cache, retry/lifecycle, queue and relay-API tests: **52/52 passed**
- production relayer Clippy passed with `-D warnings`

## Stack

Stacked on #9399 (`d505c70720`). Exact head: `73e5e00e7f`.

## Canary

Compare `hyperlane_message_db_loader_records_examined_total`, `hyperlane_message_db_loader_logical_db_reads_total`, scan-duration p95, restart recovery time, delivery latency, retry rate, and RSS. Confirm ingress depth stays bounded and transient loader-init failures recover without an origin disappearing.

Fixes #9400. Follow-up to #9384.
