### PR TITLE
fix(scraper-proxy): pace Explorer websocket broadcasts

### DIFF
--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -566,6 +566,49 @@ void it('emits normalized message upserts to Explorer', async () => {
   await new Promise<void>((resolve) => socket.once('close', () => resolve()));
 });
 
+void it('paces Explorer batches by send completion', async (context) => {
+  const socket = new WebSocket(messagesUrl);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+  await waitFor(messages, 'ready');
+  const completions = delayServerSendCompletions(context);
+  const messageIds = [`\\x${'02'.repeat(32)}`, `\\x${'03'.repeat(32)}`];
+
+  try {
+    for (const messageId of messageIds) {
+      notify(
+        'scraper_explorer_event',
+        JSON.stringify({ messageId: messageId.slice(2) }),
+      );
+    }
+    const upserts = (): Record<string, unknown>[] =>
+      messages.filter(({ type }) => type === 'message_upsert');
+
+    await waitUntil(() => upserts().length === 1 && completions.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(upserts().length, 1);
+    assert.equal(socket.readyState, WebSocket.OPEN);
+
+    completions.shift()?.();
+    await waitUntil(() => upserts().length === 2 && completions.length === 1);
+    assert.deepEqual(
+      upserts().map(({ data }) => record(data).msg_id),
+      messageIds,
+    );
+    assert.equal(socket.readyState, WebSocket.OPEN);
+    completions.shift()?.();
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    if (socket.readyState !== WebSocket.CLOSED) {
+      const closed = new Promise<void>((resolve) =>
+        socket.once('close', () => resolve()),
+      );
+      socket.close();
+      await closed;
+    }
+  }
+});
+
 void it('bounds aggregate Explorer outbound buffering', async () => {
   const sockets = Array.from({ length: 4 }, () => new WebSocket(messagesUrl));
   const messages: Record<string, unknown>[][] = sockets.map(() => []);
@@ -632,7 +675,9 @@ function delayServerSendCompletions(context: TestContext): Array<() => void> {
       const message = typeof data === 'string' ? parseRecord(data) : undefined;
       const delay =
         completion &&
-        (message?.type === 'event' || message?.type === 'caught_up');
+        (message?.type === 'event' ||
+          message?.type === 'caught_up' ||
+          message?.type === 'message_upsert');
       const completed = delay
         ? (error?: Error) => completions.push(() => completion(error))
         : completion;

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -863,12 +863,16 @@ export class EventWebSocketServer {
       `SELECT ${tables.message_view.columns.map(q).join(', ')} FROM ${q('message_view')} WHERE ${q('msg_id')} = ANY($1::bytea[]) AND ${q('send_occurred_at')} IS NOT NULL`,
       [messageIds],
     );
-    for (const row of rows) {
-      const message = serialize({ data: row, type: 'message_upsert' });
-      this.explorerClients.forEach((_client, socket) =>
-        this.sendSerialized(socket, message),
-      );
-    }
+    const messages = rows.map((row) =>
+      serialize({ data: row, type: 'message_upsert' }),
+    );
+    await Promise.all(
+      [...this.explorerClients.keys()].map(async (socket) => {
+        for (const message of messages) {
+          if (!(await this.sendSerializedAndWait(socket, message))) return;
+        }
+      }),
+    );
   }
 
   private hasSubscriber({ domain, eventType }: EventNotification): boolean {
@@ -943,8 +947,15 @@ export class EventWebSocketServer {
     socket: WebSocket,
     message: Record<string, unknown>,
   ): Promise<boolean> {
+    return this.sendSerializedAndWait(socket, serialize(message));
+  }
+
+  private sendSerializedAndWait(
+    socket: WebSocket,
+    message: SerializedMessage,
+  ): Promise<boolean> {
     return new Promise((resolve) => {
-      if (!this.sendSerialized(socket, serialize(message), resolve)) {
+      if (!this.sendSerialized(socket, message, resolve)) {
         resolve(false);
       }
     });


### PR DESCRIPTION
## Summary

- pace `message_upsert` broadcasts by send completion for each Explorer connection
- keep connections concurrent and serialize each row once across all clients
- preserve the existing 1 MiB per-socket and 32 MiB aggregate outbound caps

## Incident evidence

The mainnet3 alert was caused by normal batched work, not one slow client:

- `12:57:59Z`: a 1,000-ID `message_view` query returned 1,000 rows in 9,006 ms; all 14 `/messages` sockets hit `buffer_limit` within the same 2 ms
- `13:02:38Z`: the next 1,000-ID query returned 998 rows in 9,879 ms; all 14 sockets were again terminated within the same millisecond
- the implementation synchronously queued every returned row to every socket, so callbacks could not release pending bytes before the next row was admitted
- no `/agents` clients were connected, listener readiness stayed `1`, the pod had zero restarts, and no further failures occurred after the burst

The new integration test holds send callbacks and proves that the second Explorer update is withheld until the first completes, while the socket remains open.

## Validation

- `pnpm -C typescript/scraper-proxy test` — 55 passed
- `pnpm -C typescript/scraper-proxy build`
- `pnpm -C typescript/scraper-proxy lint`
- changed-file `oxfmt --check`
- `git diff --check`
- clean synthetic merge with current `main` and open scraper WebSocket PR #9324

No changeset: `@hyperlane-xyz/scraper-proxy` is private.

## Deployment

Code only; not deployed by this PR.
