### PR TITLE
perf: isolate scraper proxy websocket clients

### DIFF
--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -5,7 +5,7 @@ import { after, before, it, type TestContext } from 'node:test';
 import { WebSocket } from 'ws';
 import type { QueryResultRow } from 'pg';
 
-import { websocketCatchUps } from '../metrics.js';
+import { metricsRegistry, websocketCatchUps } from '../metrics.js';
 import type { EventDatabase, EventWebSocketServer } from './event-websocket.js';
 import { rawData } from './websocket-data.js';
 
@@ -22,7 +22,12 @@ const rows = new Map([
   ['2', row(hookA)],
 ]);
 let notify: (channel: string, payload?: string) => void;
+const explorerBatchSizes: number[] = [];
 let explorerQuery = '';
+let explorerQueryCount = 0;
+let explorerQueryError: Error | undefined;
+let explorerQueryGate: Promise<void> | undefined;
+let notificationQueryError: Error | undefined;
 const notifiedIds = new Set<string>();
 
 const db: EventDatabase = {
@@ -45,8 +50,13 @@ const db: EventDatabase = {
       ]);
     if (sql.includes('"message_view"')) {
       explorerQuery = sql;
+      explorerQueryCount++;
+      await explorerQueryGate;
+      if (explorerQueryError) throw explorerQueryError;
+      const messageIds = stringArray(values[0]);
+      explorerBatchSizes.push(messageIds.length);
       return queryRows<T>(
-        stringArray(values[0]).map((messageId) => ({
+        messageIds.map((messageId) => ({
           id: '42',
           is_delivered: false,
           msg_body: msgBody,
@@ -68,6 +78,7 @@ const db: EventDatabase = {
       return queryRows<T>([row(hookA, 0)]);
     }
     if (!sql.includes('notification_id')) return [];
+    if (notificationQueryError) throw notificationQueryError;
     const ids = stringArray(values[0]);
     ids.forEach((id) => notifiedIds.add(id));
     return queryRows<T>(
@@ -91,7 +102,7 @@ before(async () => {
     maxAgentClients: 1,
     maxCatchUpRows: 2,
     maxExplorerClients: 8,
-    maxTotalBufferedBytes: 512,
+    maxTotalBufferedBytes: 1_024,
   });
   await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
   const address = http.address();
@@ -566,6 +577,301 @@ void it('emits normalized message upserts to Explorer', async () => {
   await new Promise<void>((resolve) => socket.once('close', () => resolve()));
 });
 
+void it('keeps agent delivery independent from a blocked Explorer query', async () => {
+  let releaseExplorerQuery: (() => void) | undefined;
+  explorerQueryGate = new Promise<void>((resolve) => {
+    releaseExplorerQuery = resolve;
+  });
+  const explorer = new WebSocket(messagesUrl);
+  const agent = new WebSocket(url);
+  const explorerMessages: Record<string, unknown>[] = [];
+  const agentMessages: Record<string, unknown>[] = [];
+  explorer.on('message', (data) =>
+    explorerMessages.push(parseRecord(rawData(data))),
+  );
+  agent.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    agentMessages.push(message);
+    if (message.type === 'ready') {
+      agent.send(
+        JSON.stringify({
+          streams: [{ eventType: 'merkle_tree_insertion' }],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+  try {
+    await Promise.all([
+      waitFor(explorerMessages, 'ready'),
+      waitFor(agentMessages, 'subscribed'),
+    ]);
+    const queriesBefore = explorerQueryCount;
+    notify(
+      'scraper_explorer_event',
+      JSON.stringify({ messageId: msgId.slice(2) }),
+    );
+    await waitUntil(() => explorerQueryCount > queriesBefore);
+
+    rows.set('5', row(hookA, 5));
+    notify('scraper_event', notification('5'));
+    const event = await waitFor(agentMessages, 'event');
+    assert.equal(record(event.data).leaf_index, 5);
+    assert.equal(
+      explorerMessages.some(({ type }) => type === 'message_upsert'),
+      false,
+    );
+
+    releaseExplorerQuery();
+    await waitFor(explorerMessages, 'message_upsert');
+  } finally {
+    releaseExplorerQuery?.();
+    explorerQueryGate = undefined;
+    explorer.close();
+    agent.close();
+    await waitUntil(() =>
+      [explorer, agent].every(
+        ({ readyState }) => readyState === WebSocket.CLOSED,
+      ),
+    );
+  }
+});
+
+void it('keeps agents connected when an Explorer query fails', async () => {
+  const explorer = new WebSocket(messagesUrl);
+  const explorerMessages: Record<string, unknown>[] = [];
+  const agentMessages: Record<string, unknown>[] = [];
+  explorer.on('message', (data) =>
+    explorerMessages.push(parseRecord(rawData(data))),
+  );
+  const agent = liveAgent(agentMessages);
+  try {
+    await Promise.all([
+      waitFor(explorerMessages, 'ready'),
+      waitFor(agentMessages, 'subscribed'),
+    ]);
+    explorerQueryError = new Error('Explorer query failed');
+    notify(
+      'scraper_explorer_event',
+      JSON.stringify({ messageId: msgId.slice(2) }),
+    );
+    await new Promise<void>((resolve) =>
+      explorer.once('close', () => resolve()),
+    );
+    explorerQueryError = undefined;
+
+    rows.set('6', row(hookA, 6));
+    notify('scraper_event', notification('6'));
+    const event = await waitFor(agentMessages, 'event');
+    assert.equal(record(event.data).leaf_index, 6);
+    assert.equal(agent.readyState, WebSocket.OPEN);
+  } finally {
+    explorerQueryError = undefined;
+    explorer.close();
+    agent.close();
+    await waitUntil(() =>
+      [explorer, agent].every(
+        ({ readyState }) => readyState === WebSocket.CLOSED,
+      ),
+    );
+  }
+});
+
+void it('keeps Explorer connected when an agent query fails', async () => {
+  const explorer = new WebSocket(messagesUrl);
+  const explorerMessages: Record<string, unknown>[] = [];
+  const agentMessages: Record<string, unknown>[] = [];
+  explorer.on('message', (data) =>
+    explorerMessages.push(parseRecord(rawData(data))),
+  );
+  const agent = liveAgent(agentMessages);
+  try {
+    await Promise.all([
+      waitFor(explorerMessages, 'ready'),
+      waitFor(agentMessages, 'subscribed'),
+    ]);
+    notificationQueryError = new Error('Agent query failed');
+    rows.set('7', row(hookA, 7));
+    notify('scraper_event', notification('7'));
+    await new Promise<void>((resolve) => agent.once('close', () => resolve()));
+    notificationQueryError = undefined;
+
+    notify(
+      'scraper_explorer_event',
+      JSON.stringify({ messageId: msgId.slice(2) }),
+    );
+    await waitFor(explorerMessages, 'message_upsert');
+    assert.equal(explorer.readyState, WebSocket.OPEN);
+  } finally {
+    notificationQueryError = undefined;
+    agent.close();
+    explorer.close();
+    await waitUntil(() =>
+      [agent, explorer].every(
+        ({ readyState }) => readyState === WebSocket.CLOSED,
+      ),
+    );
+  }
+});
+
+void it('keeps fast Explorer clients independent from a stalled client', async (context) => {
+  const completions = delayFirstExplorerSocket(context);
+  const sockets = [new WebSocket(messagesUrl), new WebSocket(messagesUrl)];
+  const messages: Record<string, unknown>[][] = sockets.map(() => []);
+  sockets.forEach((socket, index) =>
+    socket.on('message', (data) =>
+      messages[index]?.push(parseRecord(rawData(data))),
+    ),
+  );
+  try {
+    await Promise.all(messages.map((items) => waitFor(items, 'ready')));
+    for (const byte of ['02', '03']) {
+      notify(
+        'scraper_explorer_event',
+        JSON.stringify({ messageId: byte.repeat(32) }),
+      );
+      if (byte === '02') {
+        await waitUntil(
+          () =>
+            messages.every(
+              (items) =>
+                items.filter(({ type }) => type === 'message_upsert').length ===
+                1,
+            ) && completions.length === 1,
+        );
+      }
+    }
+    await waitUntil(() =>
+      messages.some(
+        (items) =>
+          items.filter(({ type }) => type === 'message_upsert').length === 2,
+      ),
+    );
+    assert.deepEqual(
+      messages
+        .map(
+          (items) =>
+            items.filter(({ type }) => type === 'message_upsert').length,
+        )
+        .sort(),
+      [1, 2],
+    );
+
+    completions.shift()?.();
+    await waitUntil(() =>
+      messages.every(
+        (items) =>
+          items.filter(({ type }) => type === 'message_upsert').length === 2,
+      ),
+    );
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    sockets.forEach((socket) => socket.close());
+    await waitUntil(() =>
+      sockets.every(({ readyState }) => readyState === WebSocket.CLOSED),
+    );
+  }
+});
+
+void it('paces a full Explorer notification batch one send at a time', async (context) => {
+  const completions = delayServerSendCompletions(context);
+  const socket = new WebSocket(messagesUrl);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+  try {
+    await waitFor(messages, 'ready');
+    const batchesBefore = explorerBatchSizes.length;
+    const messageIds = Array.from(
+      { length: 1_000 },
+      (_, index) => `\\x${index.toString(16).padStart(64, '0')}`,
+    );
+    for (const messageId of messageIds) {
+      notify(
+        'scraper_explorer_event',
+        JSON.stringify({ messageId: messageId.slice(2) }),
+      );
+    }
+    await waitUntil(() => completions.length === 1);
+    for (let sent = 1; sent <= messageIds.length; sent++) {
+      assert.equal(completions.length, 1);
+      completions.shift()?.();
+      if (sent < messageIds.length) {
+        await waitUntilImmediate(() => completions.length === 1);
+      }
+    }
+    await waitUntil(
+      () =>
+        messages.filter(({ type }) => type === 'message_upsert').length ===
+          messageIds.length &&
+        events.metricsSnapshot().explorerPendingMessages === 0,
+    );
+    const upserts = messages.filter(({ type }) => type === 'message_upsert');
+    assert.deepEqual(
+      new Set(upserts.map(({ data }) => record(data).msg_id)),
+      new Set(messageIds),
+    );
+    assert.equal(events.metricsSnapshot().explorerPendingBytes, 0);
+    assert.equal(events.metricsSnapshot().outboundPendingBytes, 0);
+    assert.equal(socket.readyState, WebSocket.OPEN);
+    const batchSizes = explorerBatchSizes.slice(batchesBefore);
+    assert.equal(
+      batchSizes.reduce((total, size) => total + size, 0),
+      1_000,
+    );
+    assert(batchSizes.every((size) => size <= 100));
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    socket.close();
+    await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+  }
+});
+
+void it('sheds only an Explorer client that exceeds its queue limit', async (context) => {
+  const slow = new WebSocket(messagesUrl);
+  const slowMessages: Record<string, unknown>[] = [];
+  slow.on('message', (data) => slowMessages.push(parseRecord(rawData(data))));
+  await waitFor(slowMessages, 'ready');
+  const fast = new WebSocket(messagesUrl);
+  const fastMessages: Record<string, unknown>[] = [];
+  fast.on('message', (data) => fastMessages.push(parseRecord(rawData(data))));
+  await waitFor(fastMessages, 'ready');
+  const completions = delayFirstExplorerSocket(context);
+
+  try {
+    for (let batch = 0; batch < 21; batch++) {
+      for (let index = 0; index < 100; index++) {
+        const messageId = (batch * 100 + index + 10_000)
+          .toString(16)
+          .padStart(64, '0');
+        notify('scraper_explorer_event', JSON.stringify({ messageId }));
+      }
+      const expected = Math.min((batch + 1) * 100, 2_000);
+      await waitUntil(
+        () =>
+          fastMessages.filter(({ type }) => type === 'message_upsert').length >=
+          expected,
+      );
+    }
+
+    await waitUntil(() => slow.readyState === WebSocket.CLOSED);
+    assert.equal(fast.readyState, WebSocket.OPEN);
+    assert.equal(events.metricsSnapshot().connections.messages, 1);
+    assert.equal(events.metricsSnapshot().explorerPendingMessages, 0);
+    assert.equal(events.metricsSnapshot().explorerPendingBytes, 0);
+    assert.match(
+      await metricsRegistry.metrics(),
+      /websocket_send_failures_total\{reason="queue_limit"\} 1/,
+    );
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    fast.close();
+    if (slow.readyState !== WebSocket.CLOSED) slow.close();
+    await waitUntil(() =>
+      [slow, fast].every(({ readyState }) => readyState === WebSocket.CLOSED),
+    );
+  }
+});
+
 void it('paces Explorer batches by send completion', async (context) => {
   const socket = new WebSocket(messagesUrl);
   const messages: Record<string, unknown>[] = [];
@@ -607,6 +913,34 @@ void it('paces Explorer batches by send completion', async (context) => {
       await closed;
     }
   }
+});
+
+void it('releases a peer-closed Explorer queue immediately', async (context) => {
+  const socket = new WebSocket(messagesUrl);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+  await waitFor(messages, 'ready');
+  const completions = delayServerSendCompletions(context);
+  for (const byte of ['04', '05']) {
+    notify(
+      'scraper_explorer_event',
+      JSON.stringify({ messageId: byte.repeat(32) }),
+    );
+  }
+  await waitUntil(
+    () =>
+      completions.length === 1 &&
+      events.metricsSnapshot().explorerPendingMessages === 1,
+  );
+  socket.close();
+  await waitUntil(
+    () =>
+      socket.readyState === WebSocket.CLOSED &&
+      events.metricsSnapshot().connections.messages === 0,
+  );
+  assert.equal(events.metricsSnapshot().explorerPendingMessages, 0);
+  assert.equal(events.metricsSnapshot().explorerPendingBytes, 0);
+  for (const complete of completions.splice(0)) complete();
 });
 
 void it('bounds aggregate Explorer outbound buffering', async () => {
@@ -655,6 +989,23 @@ function explorerSocket(ip: string): WebSocket {
   });
 }
 
+function liveAgent(messages: Record<string, unknown>[]): WebSocket {
+  const socket = new WebSocket(url);
+  socket.on('message', (data) => {
+    const message = parseRecord(rawData(data));
+    messages.push(message);
+    if (message.type === 'ready') {
+      socket.send(
+        JSON.stringify({
+          streams: [{ eventType: 'merkle_tree_insertion' }],
+          type: 'subscribe',
+        }),
+      );
+    }
+  });
+  return socket;
+}
+
 function delayServerSendCompletions(context: TestContext): Array<() => void> {
   const completions: Array<() => void> = [];
   // oxlint-disable-next-line typescript/unbound-method -- called with the socket receiver below.
@@ -685,6 +1036,50 @@ function delayServerSendCompletions(context: TestContext): Array<() => void> {
         originalSend.call(this, data, completed);
       } else {
         originalSend.call(this, data, optionsOrCallback, completed);
+      }
+    },
+  );
+  return completions;
+}
+
+function delayFirstExplorerSocket(context: TestContext): Array<() => void> {
+  const completions: Array<() => void> = [];
+  const delayedSockets = new WeakSet<WebSocket>();
+  let selectedDelayedSocket = false;
+  // oxlint-disable-next-line typescript/unbound-method -- called with the socket receiver below.
+  const originalSend = WebSocket.prototype.send;
+  context.mock.method(
+    WebSocket.prototype,
+    'send',
+    function (
+      this: WebSocket,
+      data: Parameters<WebSocket['send']>[0],
+      optionsOrCallback?:
+        | Parameters<WebSocket['send']>[1]
+        | ((error?: Error) => void),
+      callback?: (error?: Error) => void,
+    ): void {
+      const completion =
+        typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+      const message = typeof data === 'string' ? parseRecord(data) : undefined;
+      if (
+        !selectedDelayedSocket &&
+        completion &&
+        message?.type === 'message_upsert'
+      ) {
+        delayedSockets.add(this);
+        selectedDelayedSocket = true;
+      }
+      const delayedCompletion =
+        completion &&
+        message?.type === 'message_upsert' &&
+        delayedSockets.has(this)
+          ? (error?: Error) => completions.push(() => completion(error))
+          : completion;
+      if (typeof optionsOrCallback === 'function' || !optionsOrCallback) {
+        originalSend.call(this, data, delayedCompletion);
+      } else {
+        originalSend.call(this, data, optionsOrCallback, delayedCompletion);
       }
     },
   );
@@ -725,6 +1120,16 @@ async function waitUntil(
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error('Timed out waiting for condition');
+}
+
+async function waitUntilImmediate(
+  predicate: () => boolean | Promise<boolean>,
+): Promise<void> {
+  for (let attempts = 0; attempts < 10_000; attempts++) {
+    if (await predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error('Timed out waiting for immediate condition');
 }
 
 async function catchUpOutcome(outcome: string): Promise<number> {

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -43,9 +43,12 @@ const HEARTBEAT_MS = 30_000;
 const LISTENER_RETRY_MS = 1_000;
 const NOTIFICATION_BATCH_MS = 100;
 const NOTIFICATION_BATCH_SIZE = 1_000;
+const EXPLORER_NOTIFICATION_BATCH_SIZE = 100;
 const MAX_AGENT_CLIENTS = 100;
 const MAX_EXPLORER_CLIENTS = 400;
 const MAX_EXPLORER_CLIENTS_PER_IP = 5;
+const MAX_EXPLORER_PENDING_BYTES = 16_777_216;
+const MAX_EXPLORER_PENDING_MESSAGES = 2_000;
 const MAX_CLIENT_MESSAGES = 30;
 const MAX_PENDING_EVENTS = 5_000;
 
@@ -73,7 +76,13 @@ type Client = {
   messageWindow: number;
   subscriptions: Map<EventType, Subscription>;
 };
-type ExplorerClient = { alive: boolean; ip: string };
+type ExplorerClient = {
+  alive: boolean;
+  ip: string;
+  queuedBytes: number;
+  queue: SerializedMessage[];
+  sending: boolean;
+};
 type Limits = {
   maxAgentClients: number;
   maxBufferedBytes: number;
@@ -143,8 +152,10 @@ export class EventWebSocketServer {
   private readonly notifications = new Map<string, EventNotification>();
   private heartbeatTimer?: NodeJS.Timeout;
   private listenerRetryTimer?: NodeJS.Timeout;
-  private notificationTimer?: NodeJS.Timeout;
-  private draining = false;
+  private agentNotificationTimer?: NodeJS.Timeout;
+  private explorerNotificationTimer?: NodeJS.Timeout;
+  private drainingAgentNotifications = false;
+  private drainingExplorerNotifications = false;
   private catchUps = 0;
   private pendingBytes = 0;
   private listenerReady = false;
@@ -198,7 +209,8 @@ export class EventWebSocketServer {
     [
       this.heartbeatTimer,
       this.listenerRetryTimer,
-      this.notificationTimer,
+      this.agentNotificationTimer,
+      this.explorerNotificationTimer,
     ].forEach((timer) => timer && clearTimeout(timer));
     this.explorerNotifications.clear();
     this.notifications.clear();
@@ -256,6 +268,26 @@ export class EventWebSocketServer {
         agent: this.clients.size,
         messages: this.explorerClients.size,
       },
+      explorerPendingMessages: [...this.explorerClients.values()].reduce(
+        (total, client) => total + client.queue.length,
+        0,
+      ),
+      explorerPendingBytes: [...this.explorerClients.values()].reduce(
+        (total, client) => total + client.queuedBytes,
+        0,
+      ),
+      maxExplorerPendingBytes: Math.max(
+        0,
+        ...[...this.explorerClients.values()].map(
+          (client) => client.queuedBytes,
+        ),
+      ),
+      maxExplorerPendingMessages: Math.max(
+        0,
+        ...[...this.explorerClients.values()].map(
+          (client) => client.queue.length,
+        ),
+      ),
       messageClientIps: this.explorerClientsByIp.size,
       messageMaxConnectionsPerIp: Math.max(
         0,
@@ -267,6 +299,8 @@ export class EventWebSocketServer {
         catchUpRows: this.limits.maxCatchUpRows,
         clientMessagesPerMinute: MAX_CLIENT_MESSAGES,
         concurrentCatchUps: this.limits.maxConcurrentCatchUps,
+        explorerPendingBytes: MAX_EXPLORER_PENDING_BYTES,
+        explorerPendingMessages: MAX_EXPLORER_PENDING_MESSAGES,
         messageConnections: this.limits.maxExplorerClients,
         messageConnectionsPerIp: MAX_EXPLORER_CLIENTS_PER_IP,
         pendingEvents: MAX_PENDING_EVENTS,
@@ -351,15 +385,22 @@ export class EventWebSocketServer {
       return;
     }
     this.explorerClientsByIp.set(ip, connections + 1);
-    this.explorerClients.set(socket, { alive: true, ip });
+    this.explorerClients.set(socket, {
+      alive: true,
+      ip,
+      queuedBytes: 0,
+      queue: [],
+      sending: false,
+    });
     websocketConnections.inc({ route: 'messages' });
     this.send(socket, {
       eventTypes: ['message_upsert'],
       type: 'ready',
     });
-    this.watch(socket, this.explorerClients, ({ ip }) =>
-      this.releaseExplorerClient(ip),
-    );
+    this.watch(socket, this.explorerClients, (client) => {
+      this.clearExplorerQueue(client);
+      this.releaseExplorerClient(client.ip);
+    });
   }
 
   private accept(socket: WebSocket, route: 'agent' | 'explorer'): boolean {
@@ -748,6 +789,7 @@ export class EventWebSocketServer {
         this.explorerNotifications.add(
           parseExplorerNotification(payload).messageId,
         );
+        this.scheduleExplorerDrain();
       } else {
         const notification = parseEventNotification(payload);
         if (!this.hasSubscriber(notification)) return;
@@ -755,6 +797,7 @@ export class EventWebSocketServer {
           `${notification.eventType}:${notification.id}`,
           notification,
         );
+        this.scheduleAgentDrain();
       }
     } catch (error) {
       this.logger.warn(
@@ -762,19 +805,38 @@ export class EventWebSocketServer {
       );
       return;
     }
-    if (!this.notificationTimer && !this.draining) {
-      this.notificationTimer = setTimeout(() => {
-        this.notificationTimer = undefined;
-        void this.drainNotifications().catch((error) => this.fail(error));
+  }
+
+  private scheduleAgentDrain(): void {
+    if (!this.agentNotificationTimer && !this.drainingAgentNotifications) {
+      this.agentNotificationTimer = setTimeout(() => {
+        this.agentNotificationTimer = undefined;
+        void this.drainAgentNotifications().catch((error) =>
+          this.failAgentStream(error),
+        );
       }, NOTIFICATION_BATCH_MS);
     }
   }
 
-  private async drainNotifications(): Promise<void> {
-    if (this.draining) return;
-    this.draining = true;
+  private scheduleExplorerDrain(): void {
+    if (
+      !this.explorerNotificationTimer &&
+      !this.drainingExplorerNotifications
+    ) {
+      this.explorerNotificationTimer = setTimeout(() => {
+        this.explorerNotificationTimer = undefined;
+        void this.drainExplorerNotifications().catch((error) =>
+          this.failExplorerStream(error),
+        );
+      }, NOTIFICATION_BATCH_MS);
+    }
+  }
+
+  private async drainAgentNotifications(): Promise<void> {
+    if (this.drainingAgentNotifications) return;
+    this.drainingAgentNotifications = true;
     try {
-      while (this.notifications.size || this.explorerNotifications.size) {
+      while (this.notifications.size) {
         const batch = [...this.notifications.entries()].slice(
           0,
           NOTIFICATION_BATCH_SIZE,
@@ -790,19 +852,28 @@ export class EventWebSocketServer {
         for (const [eventType, notifications] of grouped) {
           await this.publishNotifications(eventType, notifications);
         }
-        if (this.explorerNotifications.size) {
-          const messageIds = [...this.explorerNotifications].slice(
-            0,
-            NOTIFICATION_BATCH_SIZE,
-          );
-          messageIds.forEach((messageId) =>
-            this.explorerNotifications.delete(messageId),
-          );
-          await this.publishExplorer(messageIds);
-        }
       }
     } finally {
-      this.draining = false;
+      this.drainingAgentNotifications = false;
+    }
+  }
+
+  private async drainExplorerNotifications(): Promise<void> {
+    if (this.drainingExplorerNotifications) return;
+    this.drainingExplorerNotifications = true;
+    try {
+      while (this.explorerNotifications.size) {
+        const messageIds = [...this.explorerNotifications].slice(
+          0,
+          EXPLORER_NOTIFICATION_BATCH_SIZE,
+        );
+        messageIds.forEach((messageId) =>
+          this.explorerNotifications.delete(messageId),
+        );
+        await this.publishExplorer(messageIds);
+      }
+    } finally {
+      this.drainingExplorerNotifications = false;
     }
   }
 
@@ -866,13 +937,45 @@ export class EventWebSocketServer {
     const messages = rows.map((row) =>
       serialize({ data: row, type: 'message_upsert' }),
     );
-    await Promise.all(
-      [...this.explorerClients.keys()].map(async (socket) => {
-        for (const message of messages) {
-          if (!(await this.sendSerializedAndWait(socket, message))) return;
-        }
-      }),
-    );
+    for (const [socket, client] of this.explorerClients) {
+      this.enqueueExplorer(socket, client, messages);
+    }
+  }
+
+  private enqueueExplorer(
+    socket: WebSocket,
+    client: ExplorerClient,
+    messages: SerializedMessage[],
+  ): void {
+    const bytes = messages.reduce((total, message) => total + message.bytes, 0);
+    if (
+      client.queue.length + messages.length > MAX_EXPLORER_PENDING_MESSAGES ||
+      client.queuedBytes + bytes > MAX_EXPLORER_PENDING_BYTES
+    ) {
+      websocketSendFailures.inc({ reason: 'queue_limit' });
+      this.failSocket(socket, 'outbound message queue limit exceeded');
+      return;
+    }
+    client.queue.push(...messages);
+    client.queuedBytes += bytes;
+    if (!client.sending) void this.drainExplorerClient(socket, client);
+  }
+
+  private async drainExplorerClient(
+    socket: WebSocket,
+    client: ExplorerClient,
+  ): Promise<void> {
+    client.sending = true;
+    try {
+      while (this.explorerClients.get(socket) === client) {
+        const message = client.queue.shift();
+        if (!message) return;
+        client.queuedBytes = Math.max(0, client.queuedBytes - message.bytes);
+        if (!(await this.sendSerializedAndWait(socket, message))) return;
+      }
+    } finally {
+      client.sending = false;
+    }
   }
 
   private hasSubscriber({ domain, eventType }: EventNotification): boolean {
@@ -901,17 +1004,33 @@ export class EventWebSocketServer {
     }, LISTENER_RETRY_MS);
   }
 
-  private fail(error: unknown): void {
-    this.logger.error(`event stream failed: ${formatError(error)}`);
-    this.closeClients('Event stream read failed');
+  private failAgentStream(error: unknown): void {
+    this.logger.error(`agent event stream failed: ${formatError(error)}`);
+    this.closeAgentClients('Event stream read failed');
+  }
+
+  private failExplorerStream(error: unknown): void {
+    this.logger.error(`Explorer event stream failed: ${formatError(error)}`);
+    this.closeExplorerClients('Event stream read failed');
   }
 
   private closeClients(reason: string, code = 1013): void {
+    this.closeAgentClients(reason, code);
+    this.closeExplorerClients(reason, code);
+  }
+
+  private closeAgentClients(reason: string, code = 1013): void {
+    this.notifications.clear();
     this.clients.forEach((_client, socket) => socket.close(code, reason));
-    this.explorerClients.forEach((_client, socket) =>
-      socket.close(code, reason),
-    );
     this.clients.clear();
+  }
+
+  private closeExplorerClients(reason: string, code = 1013): void {
+    this.explorerNotifications.clear();
+    this.explorerClients.forEach((client, socket) => {
+      this.clearExplorerQueue(client);
+      socket.close(code, reason);
+    });
     this.explorerClients.clear();
     this.explorerClientsByIp.clear();
   }
@@ -1008,8 +1127,16 @@ export class EventWebSocketServer {
     this.clients.get(socket)?.subscriptions.clear();
     this.clients.delete(socket);
     const explorerClient = this.explorerClients.get(socket);
-    if (explorerClient) this.releaseExplorerClient(explorerClient.ip);
+    if (explorerClient) {
+      this.clearExplorerQueue(explorerClient);
+      this.releaseExplorerClient(explorerClient.ip);
+    }
     this.explorerClients.delete(socket);
+  }
+
+  private clearExplorerQueue(client: ExplorerClient): void {
+    client.queue.length = 0;
+    client.queuedBytes = 0;
   }
 
   private releaseExplorerClient(ip: string): void {

--- a/typescript/scraper-proxy/src/metrics.test.ts
+++ b/typescript/scraper-proxy/src/metrics.test.ts
@@ -23,6 +23,10 @@ void it('serves current usage and limits from /metrics', async () => {
   setWebSocketMetricsProvider(() => ({
     catchUps: 2,
     connections: { agent: 3, messages: 4 },
+    explorerPendingBytes: 1_024,
+    explorerPendingMessages: 9,
+    maxExplorerPendingBytes: 512,
+    maxExplorerPendingMessages: 5,
     messageClientIps: 2,
     messageMaxConnectionsPerIp: 3,
     limits: {
@@ -31,6 +35,8 @@ void it('serves current usage and limits from /metrics', async () => {
       catchUpRows: 1_000,
       clientMessagesPerMinute: 30,
       concurrentCatchUps: 5,
+      explorerPendingBytes: 16_777_216,
+      explorerPendingMessages: 2_000,
       messageConnections: 400,
       messageConnectionsPerIp: 5,
       pendingEvents: 5_000,
@@ -69,6 +75,14 @@ void it('serves current usage and limits from /metrics', async () => {
   assert.match(
     output,
     /hyperlane_scraper_proxy_websocket_outbound_pending_bytes 256/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_explorer_pending_messages 9/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_explorer_pending_bytes 1024/,
   );
   assert.match(
     output,

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -14,6 +14,10 @@ const PREFIX = 'hyperlane_scraper_proxy_';
 export type WebSocketMetricsSnapshot = {
   catchUps: number;
   connections: Record<'agent' | 'messages', number>;
+  explorerPendingBytes: number;
+  explorerPendingMessages: number;
+  maxExplorerPendingBytes: number;
+  maxExplorerPendingMessages: number;
   messageClientIps: number;
   messageMaxConnectionsPerIp: number;
   limits: {
@@ -22,6 +26,8 @@ export type WebSocketMetricsSnapshot = {
     catchUpRows: number;
     clientMessagesPerMinute: number;
     concurrentCatchUps: number;
+    explorerPendingBytes: number;
+    explorerPendingMessages: number;
     messageConnections: number;
     messageConnectionsPerIp: number;
     pendingEvents: number;
@@ -321,6 +327,36 @@ snapshotGauge(
     gauge.set({ route: 'messages' }, snapshot.notificationQueue.messages);
   },
   ['route'],
+);
+snapshotGauge(
+  'websocket_explorer_pending_bytes',
+  'Current serialized Explorer bytes queued behind send callbacks.',
+  (gauge, snapshot) => gauge.set(snapshot.explorerPendingBytes),
+);
+snapshotGauge(
+  'websocket_explorer_max_pending_bytes',
+  'Largest current serialized Explorer byte queue for one client.',
+  (gauge, snapshot) => gauge.set(snapshot.maxExplorerPendingBytes),
+);
+snapshotGauge(
+  'websocket_explorer_pending_byte_limit',
+  'Maximum serialized Explorer bytes queued behind one client callback.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.explorerPendingBytes),
+);
+snapshotGauge(
+  'websocket_explorer_pending_messages',
+  'Current Explorer messages queued behind per-client send callbacks.',
+  (gauge, snapshot) => gauge.set(snapshot.explorerPendingMessages),
+);
+snapshotGauge(
+  'websocket_explorer_max_pending_messages',
+  'Largest current per-client Explorer message queue.',
+  (gauge, snapshot) => gauge.set(snapshot.maxExplorerPendingMessages),
+);
+snapshotGauge(
+  'websocket_explorer_pending_message_limit',
+  'Maximum Explorer messages queued behind one client send callback.',
+  (gauge, snapshot) => gauge.set(snapshot.limits.explorerPendingMessages),
 );
 snapshotGauge(
   'websocket_outbound_pending_bytes',


### PR DESCRIPTION
## Summary

- isolate `/agents` and `/messages` notification drains and failure domains
- fan Explorer updates through per-client ordered send pumps so one stalled socket cannot block healthy clients
- bound each Explorer queue by 2,000 messages and 16 MiB, with count/byte metrics and cleanup on every close path
- cap Explorer DB notification batches at 100 IDs; agent notification batches remain 1,000

## Measured impact

Production evidence from 2026-08-31:

- Explorer DB batches are capped at 100 rather than 1,000 IDs: **90% fewer IDs / 10x smaller maximum batch work**
- observed 11-100 ID batches averaged 158ms versus 9.443s for the two 501-1,000 ID batches: **98.3% lower observed latency / 59.8x faster** for the smaller range (traffic and cache state differed)
- the two 1,000-ID batches took 9.006s and 9.879s, immediately before all 14 Explorer sockets were shed
- incident event-loop delay peaked at 656ms versus an ordinary p99 of ~11.3ms: a **58x spike**; smaller route-specific drains bound per-turn work and keep `/agents` scheduling independent
- per-client pending memory changes from unbounded to the first of **2,000 messages or 16 MiB**, and the aggregate metrics expose current/max pressure

The latency figures are production observations, not post-deploy benchmarks. The PR's deterministic tests establish isolation and bounds; canary metrics must establish the realized p95/p99 change.

## Validation

- `pnpm -C typescript/scraper-proxy test` (62/62)
- `pnpm -C typescript/scraper-proxy build`
- `pnpm -C typescript/scraper-proxy lint`
- `pnpm -C typescript/scraper-proxy format`
- `git diff --check`

Regression coverage proves:

- blocked/failed Explorer work does not delay or close agents
- failed agent work does not close Explorer clients
- a stalled Explorer does not delay a healthy Explorer
- 1,000 notifications are delivered through <=100-ID DB batches
- a client exceeding 2,000 queued messages is shed alone and all accounting returns to zero
- peer-close immediately releases queued messages/bytes

## Rollout

Draft. Rebased onto `main` after #9406 merged. Not deployed. Build an immutable image, canary, then compare Explorer batch p50/p95/p99, event-loop delay, queue pressure, send failures, listener readiness, and reconnect behavior against the production figures above.
