### PR TITLE
perf: route scraper proxy GraphQL to replica

### DIFF
--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-deployment.yaml
@@ -46,6 +46,11 @@ spec:
             secretKeyRef:
               name: {{ include "agent-common.fullname" . }}-secret
               key: DATABASE_URL
+        - name: DATABASE_READ_REPLICA_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "agent-common.fullname" . }}-secret
+              key: DATABASE_READ_REPLICA_URL
         - name: PORT
           value: {{ .Values.hyperlane.scraperProxy.port | quote }}
         ports:

--- a/rust/main/helm/hyperlane-agent/templates/scraper-proxy-external-secret.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/scraper-proxy-external-secret.yaml
@@ -21,8 +21,12 @@ spec:
           {{- include "agent-common.labels" . | nindent 10 }}
       data:
         DATABASE_URL: {{ print "'{{ .database_url | toString }}'" }}
+        DATABASE_READ_REPLICA_URL: {{ print "'{{ .database_read_replica_url | toString }}'" }}
   data:
   - secretKey: database_url
     remoteRef:
       key: {{ printf "%s-%s-scraper3-db-read-only" .Values.hyperlane.context .Values.hyperlane.runEnv }}
+  - secretKey: database_read_replica_url
+    remoteRef:
+      key: {{ printf "%s-%s-scraper3-db-read-replica" .Values.hyperlane.context .Values.hyperlane.runEnv }}
 {{- end }}

--- a/typescript/scraper-proxy/src/config.ts
+++ b/typescript/scraper-proxy/src/config.ts
@@ -5,6 +5,7 @@ dotenvFlow.config();
 
 const ConfigSchema = z.object({
   DATABASE_QUERY_TIMEOUT_MS: z.coerce.number().int().min(1_000).default(20_000),
+  DATABASE_READ_REPLICA_URL: z.string().min(1).optional(),
   DATABASE_STATEMENT_TIMEOUT_MS: z.coerce
     .number()
     .int()

--- a/typescript/scraper-proxy/src/db/db.service.test.ts
+++ b/typescript/scraper-proxy/src/db/db.service.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { Socket } from 'node:net';
 import { it } from 'node:test';
 
 import pg from 'pg';
@@ -6,6 +7,7 @@ import pg from 'pg';
 process.env.DATABASE_URL ??= 'postgresql://scraper-proxy-test';
 process.env.DATABASE_READ_REPLICA_URL ??=
   'postgresql://scraper-proxy-replica-test';
+process.env.DATABASE_QUERY_TIMEOUT_MS ??= '1000';
 
 void it('keeps replica health from gating primary live queries', async (context) => {
   const saturatedPools = new WeakSet<pg.Pool>();
@@ -47,4 +49,19 @@ void it('keeps replica health from gating primary live queries', async (context)
   releaseMain();
   await saturated;
   await db.onModuleDestroy();
+});
+
+void it('times out stalled replica connections', async (context) => {
+  context.mock.method(Socket.prototype, 'connect', function () {
+    return this;
+  });
+  const { DbService } = await import('./db.service.js');
+  const db = new DbService();
+  context.after(() => db.onModuleDestroy());
+
+  const started = Date.now();
+  await assert.rejects(db.query('SELECT 1'), /connection timeout/i);
+  const duration = Date.now() - started;
+  assert(duration >= 1_000);
+  assert(duration < 3_000);
 });

--- a/typescript/scraper-proxy/src/db/db.service.test.ts
+++ b/typescript/scraper-proxy/src/db/db.service.test.ts
@@ -4,14 +4,18 @@ import { it } from 'node:test';
 import pg from 'pg';
 
 process.env.DATABASE_URL ??= 'postgresql://scraper-proxy-test';
+process.env.DATABASE_READ_REPLICA_URL ??=
+  'postgresql://scraper-proxy-replica-test';
 
 void it('keeps live queries prompt while the main pool is saturated', async (context) => {
   const saturatedPools = new WeakSet<pg.Pool>();
+  const queryUrls = new Map<string, string>();
   let releaseMain: (() => void) | undefined;
   context.mock.method(
     pg.Pool.prototype,
     'query',
     function (this: pg.Pool, text: string) {
+      queryUrls.set(text, this.options.connectionString);
       if (text === 'SELECT pg_sleep(1)') {
         saturatedPools.add(this);
         return new Promise((resolve) => {
@@ -27,6 +31,11 @@ void it('keeps live queries prompt while the main pool is saturated', async (con
 
   const saturated = db.query('SELECT pg_sleep(1)');
   assert.deepEqual(await db.queryLive('SELECT 1'), [{ ready: 1 }]);
+  assert.equal(
+    queryUrls.get('SELECT pg_sleep(1)'),
+    process.env.DATABASE_READ_REPLICA_URL,
+  );
+  assert.equal(queryUrls.get('SELECT 1'), process.env.DATABASE_URL);
   assert(releaseMain);
   releaseMain();
   await saturated;

--- a/typescript/scraper-proxy/src/db/db.service.test.ts
+++ b/typescript/scraper-proxy/src/db/db.service.test.ts
@@ -7,10 +7,15 @@ process.env.DATABASE_URL ??= 'postgresql://scraper-proxy-test';
 process.env.DATABASE_READ_REPLICA_URL ??=
   'postgresql://scraper-proxy-replica-test';
 
-void it('keeps live queries prompt while the main pool is saturated', async (context) => {
+void it('keeps replica health from gating primary live queries', async (context) => {
   const saturatedPools = new WeakSet<pg.Pool>();
   const queryUrls = new Map<string, string>();
+  let connectAttempts = 0;
   let releaseMain: (() => void) | undefined;
+  context.mock.method(pg.Pool.prototype, 'connect', () => {
+    connectAttempts++;
+    throw new Error('replica unavailable');
+  });
   context.mock.method(
     pg.Pool.prototype,
     'query',
@@ -29,6 +34,8 @@ void it('keeps live queries prompt while the main pool is saturated', async (con
   const { DbService } = await import('./db.service.js');
   const db = new DbService();
 
+  await db.onModuleInit();
+  assert.equal(connectAttempts, 0);
   const saturated = db.query('SELECT pg_sleep(1)');
   assert.deepEqual(await db.queryLive('SELECT 1'), [{ ready: 1 }]);
   assert.equal(

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -40,13 +40,20 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
   private statsTimer?: NodeJS.Timeout;
 
   async onModuleInit(): Promise<void> {
+    if (config.DATABASE_READ_REPLICA_URL) {
+      this.logger.log(
+        'GraphQL db role=read-replica; connections open lazily so replica health cannot gate websocket startup',
+      );
+      this.statsTimer = setInterval(() => this.logStats(), STATS_INTERVAL_MS);
+      return;
+    }
     const started = Date.now();
     const clients = await Promise.all(
       Array.from({ length: MIN_POOL_CLIENTS }, () => this.pool().connect()),
     );
     clients.forEach((client) => client.release());
     this.logger.log(
-      `warmed ${MIN_POOL_CLIENTS} GraphQL db connections role=${config.DATABASE_READ_REPLICA_URL ? 'read-replica' : 'primary'} in ${Date.now() - started}ms`,
+      `warmed ${MIN_POOL_CLIENTS} GraphQL db connections role=primary in ${Date.now() - started}ms`,
     );
     this.statsTimer = setInterval(() => this.logStats(), STATS_INTERVAL_MS);
   }

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -144,9 +144,11 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
   }
 
   private pool(): pg.Pool {
+    const replicaUrl = config.DATABASE_READ_REPLICA_URL;
     this.mainPool ??= this.createPool(
-      config.DATABASE_READ_REPLICA_URL ?? config.DATABASE_URL,
+      replicaUrl ?? config.DATABASE_URL,
       MIN_POOL_CLIENTS,
+      replicaUrl ? config.DATABASE_QUERY_TIMEOUT_MS : undefined,
     );
     return this.mainPool;
   }
@@ -156,9 +158,14 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     return this.livePool;
   }
 
-  private createPool(connectionString: string, min?: number): pg.Pool {
+  private createPool(
+    connectionString: string,
+    min?: number,
+    connectionTimeoutMillis?: number,
+  ): pg.Pool {
     const pool = new pg.Pool({
       ...databaseOptions(connectionString),
+      connectionTimeoutMillis,
       idleTimeoutMillis: IDLE_TIMEOUT_MS,
       max: MAX_POOL_CLIENTS,
       min,

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -46,7 +46,7 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     );
     clients.forEach((client) => client.release());
     this.logger.log(
-      `warmed ${MIN_POOL_CLIENTS} db connections in ${Date.now() - started}ms`,
+      `warmed ${MIN_POOL_CLIENTS} GraphQL db connections role=${config.DATABASE_READ_REPLICA_URL ? 'read-replica' : 'primary'} in ${Date.now() - started}ms`,
     );
     this.statsTimer = setInterval(() => this.logStats(), STATS_INTERVAL_MS);
   }
@@ -137,7 +137,10 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
   }
 
   private pool(): pg.Pool {
-    this.mainPool ??= this.createPool(config.DATABASE_URL, MIN_POOL_CLIENTS);
+    this.mainPool ??= this.createPool(
+      config.DATABASE_READ_REPLICA_URL ?? config.DATABASE_URL,
+      MIN_POOL_CLIENTS,
+    );
     return this.mainPool;
   }
 


### PR DESCRIPTION
## Summary

- route bounded public GraphQL reads to the existing scraper read replica
- keep PostgreSQL LISTEN, `/agents`, `/messages`, catch-up, and notification-triggered reads on the primary for prompt/read-after-notify behavior
- wire the existing mainnet3 replica secret through ExternalSecret and Helm
- preserve a primary fallback when `DATABASE_READ_REPLICA_URL` is unset
- open replica connections lazily so replica outage cannot gate primary-backed websocket startup

## Measured impact

Production-sized query evidence from 2026-08-31:

- the recurring `message_view` sender query completed in 3.385s on a cold-ish replica run versus 16.25s on primary: **79.2% lower latency / 4.8x faster**
- a warm replica run completed in 111.7ms with ~217ms replay lag at the sample point
- the replica has **4x the vCPU and 8x the memory** of primary (`db-custom-8-32768` vs `db-custom-2-4096`)
- in the retained three-hour proxy window, GraphQL accounted for 1,394 of 4,771 classified DB queries (**29.2%**) and ~76.8% of their summed query wall time; this change moves that load off primary
- the recurring GraphQL shape had reached 15.009s and produced seven identical statement-timeout failures; those failures no longer consume primary query capacity after rollout

These are production observations, not post-deploy results. Cache state differed between runs; rollout verification must measure the same query mix on both pools.

## Correctness boundary

Only `DbService.query()`—used by GraphQL resolvers—selects the replica. `queryLive()` and `listen()` remain pinned to `DATABASE_URL`, so notifications and websocket replay/live delivery do not depend on replica freshness. Replica failure keeps GraphQL fail-closed but cannot block websocket process startup.

## Validation

- `pnpm -C typescript/scraper-proxy test` (54/54)
- regression test proves replica connections are not attempted during module startup and primary live queries remain independent
- `pnpm -C typescript/scraper-proxy build`
- `pnpm -C typescript/scraper-proxy lint`
- isolated Helm dependency build and `helm template` verified both secret keys and both environment variables
- focused infra test is locally blocked because this checkout lacks built workspace artifacts (`@hyperlane-xyz/sdk/dist` and upstream packages); no infra TypeScript changed
- `git diff --check`

## Rollout

Draft. Not deployed. Roll out canary, confirm startup logs report `role=read-replica`, verify replica replay lag, compare GraphQL p50/p95/p99 and timeout rate, and prove websocket/listener metrics are unchanged before completing the rollout.
