### PR TITLE
chore(infra): bump mainnet3 scraper-proxy image to b831bf9

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
-  scraperProxy: '220f01c-20260827-145329',
+  scraperProxy: 'b831bf9-20260831-143408',
   feeQuoting: '12d899d-20260325-184337',
 };
 


### PR DESCRIPTION
Bumps the mainnet3 scraper-proxy image to `b831bf9-20260831-143408`, which includes the websocket broadcast pacing fix from #9406. Already deployed to mainnet3 via `deploy-agents.ts --roles scraper-proxy` (helm release revision 5).