### PR TITLE
perf: bound scraper proxy notification work

### DIFF
--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -751,6 +751,40 @@ void it('bounds Explorer notifications without closing agents', async () => {
   }
 });
 
+void it('bounds agent notifications without closing Explorer', async () => {
+  const explorer = new WebSocket(messagesUrl);
+  const explorerMessages: Record<string, unknown>[] = [];
+  const agentMessages: Record<string, unknown>[] = [];
+  explorer.on('message', (data) =>
+    explorerMessages.push(parseRecord(rawData(data))),
+  );
+  const agent = liveAgent(agentMessages);
+  try {
+    await Promise.all([
+      waitFor(explorerMessages, 'ready'),
+      waitFor(agentMessages, 'subscribed'),
+    ]);
+    for (let index = 0; index <= 10_000; index++)
+      notify('scraper_event', notification((index + 20_000).toString()));
+
+    await waitUntil(() => agent.readyState === WebSocket.CLOSED);
+    assert.equal(explorer.readyState, WebSocket.OPEN);
+    assert.equal(events.metricsSnapshot().notificationQueue.agent, 0);
+    assert.match(
+      await metricsRegistry.metrics(),
+      /websocket_notification_queue_overflows_total\{route="agent"\} 1/,
+    );
+  } finally {
+    explorer.close();
+    if (agent.readyState !== WebSocket.CLOSED) agent.close();
+    await waitUntil(() =>
+      [explorer, agent].every(
+        ({ readyState }) => readyState === WebSocket.CLOSED,
+      ),
+    );
+  }
+});
+
 void it('keeps fast Explorer clients independent from a stalled client', async (context) => {
   const completions = delayFirstExplorerSocket(context);
   const sockets = [new WebSocket(messagesUrl), new WebSocket(messagesUrl)];

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -714,6 +714,43 @@ void it('keeps Explorer connected when an agent query fails', async () => {
   }
 });
 
+void it('bounds Explorer notifications without closing agents', async () => {
+  const explorer = new WebSocket(messagesUrl);
+  const explorerMessages: Record<string, unknown>[] = [];
+  const agentMessages: Record<string, unknown>[] = [];
+  explorer.on('message', (data) =>
+    explorerMessages.push(parseRecord(rawData(data))),
+  );
+  const agent = liveAgent(agentMessages);
+  try {
+    await Promise.all([
+      waitFor(explorerMessages, 'ready'),
+      waitFor(agentMessages, 'subscribed'),
+    ]);
+    for (let index = 0; index <= 10_000; index++) {
+      notify(
+        'scraper_explorer_event',
+        JSON.stringify({ messageId: index.toString(16).padStart(64, '0') }),
+      );
+    }
+    await waitUntil(() => explorer.readyState === WebSocket.CLOSED);
+    assert.equal(agent.readyState, WebSocket.OPEN);
+    assert.equal(events.metricsSnapshot().notificationQueue.messages, 0);
+    assert.match(
+      await metricsRegistry.metrics(),
+      /websocket_send_failures_total\{reason="notification_queue_limit"\} 1/,
+    );
+  } finally {
+    agent.close();
+    if (explorer.readyState !== WebSocket.CLOSED) explorer.close();
+    await waitUntil(() =>
+      [explorer, agent].every(
+        ({ readyState }) => readyState === WebSocket.CLOSED,
+      ),
+    );
+  }
+});
+
 void it('keeps fast Explorer clients independent from a stalled client', async (context) => {
   const completions = delayFirstExplorerSocket(context);
   const sockets = [new WebSocket(messagesUrl), new WebSocket(messagesUrl)];

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -14,6 +14,7 @@ import {
   websocketClientMessageRejections,
   websocketConnectionRejections,
   websocketConnections,
+  websocketNotificationQueueOverflows,
   websocketSendFailures,
 } from '../metrics.js';
 import { quoteIdentifier as q, tables } from '../scraperdb/tables.js';
@@ -794,6 +795,7 @@ export class EventWebSocketServer {
           this.explorerNotifications.size >= MAX_PENDING_NOTIFICATIONS
         ) {
           websocketSendFailures.inc({ reason: 'notification_queue_limit' });
+          websocketNotificationQueueOverflows.inc({ route: 'messages' });
           this.failExplorerStream(
             new Error('Explorer notification queue limit exceeded'),
           );
@@ -810,6 +812,7 @@ export class EventWebSocketServer {
           this.notifications.size >= MAX_PENDING_NOTIFICATIONS
         ) {
           websocketSendFailures.inc({ reason: 'notification_queue_limit' });
+          websocketNotificationQueueOverflows.inc({ route: 'agent' });
           this.failAgentStream(
             new Error('Agent notification queue limit exceeded'),
           );

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -51,6 +51,7 @@ const MAX_EXPLORER_PENDING_BYTES = 16_777_216;
 const MAX_EXPLORER_PENDING_MESSAGES = 2_000;
 const MAX_CLIENT_MESSAGES = 30;
 const MAX_PENDING_EVENTS = 5_000;
+const MAX_PENDING_NOTIFICATIONS = 10_000;
 
 type Row = Record<string, unknown>;
 type NotifiedRow = Row & { notification_id: number | string };
@@ -303,6 +304,7 @@ export class EventWebSocketServer {
         explorerPendingMessages: MAX_EXPLORER_PENDING_MESSAGES,
         messageConnections: this.limits.maxExplorerClients,
         messageConnectionsPerIp: MAX_EXPLORER_CLIENTS_PER_IP,
+        notificationEvents: MAX_PENDING_NOTIFICATIONS,
         pendingEvents: MAX_PENDING_EVENTS,
         socketBufferedBytes: this.limits.maxBufferedBytes,
         totalPendingBytes: this.limits.maxTotalBufferedBytes,
@@ -786,17 +788,34 @@ export class EventWebSocketServer {
     try {
       if (channel === EXPLORER_CHANNEL) {
         if (!this.explorerClients.size) return;
-        this.explorerNotifications.add(
-          parseExplorerNotification(payload).messageId,
-        );
+        const messageId = parseExplorerNotification(payload).messageId;
+        if (
+          !this.explorerNotifications.has(messageId) &&
+          this.explorerNotifications.size >= MAX_PENDING_NOTIFICATIONS
+        ) {
+          websocketSendFailures.inc({ reason: 'notification_queue_limit' });
+          this.failExplorerStream(
+            new Error('Explorer notification queue limit exceeded'),
+          );
+          return;
+        }
+        this.explorerNotifications.add(messageId);
         this.scheduleExplorerDrain();
       } else {
         const notification = parseEventNotification(payload);
         if (!this.hasSubscriber(notification)) return;
-        this.notifications.set(
-          `${notification.eventType}:${notification.id}`,
-          notification,
-        );
+        const key = `${notification.eventType}:${notification.id}`;
+        if (
+          !this.notifications.has(key) &&
+          this.notifications.size >= MAX_PENDING_NOTIFICATIONS
+        ) {
+          websocketSendFailures.inc({ reason: 'notification_queue_limit' });
+          this.failAgentStream(
+            new Error('Agent notification queue limit exceeded'),
+          );
+          return;
+        }
+        this.notifications.set(key, notification);
         this.scheduleAgentDrain();
       }
     } catch (error) {

--- a/typescript/scraper-proxy/src/metrics.test.ts
+++ b/typescript/scraper-proxy/src/metrics.test.ts
@@ -93,6 +93,51 @@ void it('serves current usage and limits from /metrics', async () => {
     output,
     /hyperlane_scraper_proxy_websocket_send_failures_total\{reason="buffer_limit"\} 0/,
   );
+  for (const reason of [
+    'notification_queue_limit',
+    'queue_limit',
+    'send_error',
+  ]) {
+    assert.match(
+      output,
+      new RegExp(`websocket_send_failures_total\\{reason="${reason}"\\} 0`),
+    );
+  }
+  for (const outcome of [
+    'aborted',
+    'capacity_rejected',
+    'failure',
+    'success',
+  ]) {
+    assert.match(
+      output,
+      new RegExp(`websocket_catch_ups_total\\{outcome="${outcome}"\\} 0`),
+    );
+  }
+  for (const route of ['agent', 'messages']) {
+    assert.match(
+      output,
+      new RegExp(
+        `websocket_notification_queue_overflows_total\\{route="${route}"\\} 0`,
+      ),
+    );
+    for (const reason of ['connection_limit', 'listener_unavailable']) {
+      assert.match(
+        output,
+        new RegExp(
+          `websocket_connection_rejections_total\\{(?=[^}]*route="${route}")(?=[^}]*reason="${reason}")[^}]*\\} 0`,
+        ),
+      );
+    }
+  }
+  for (const reason of ['invalid_client_ip', 'per_ip_limit']) {
+    assert.match(
+      output,
+      new RegExp(
+        `websocket_connection_rejections_total\\{(?=[^}]*route="messages")(?=[^}]*reason="${reason}")[^}]*\\} 0`,
+      ),
+    );
+  }
   assert.match(
     output,
     /hyperlane_scraper_proxy_database_pool_connections\{pool="main",state="active"\} 2/,

--- a/typescript/scraper-proxy/src/metrics.test.ts
+++ b/typescript/scraper-proxy/src/metrics.test.ts
@@ -39,6 +39,7 @@ void it('serves current usage and limits from /metrics', async () => {
       explorerPendingMessages: 2_000,
       messageConnections: 400,
       messageConnectionsPerIp: 5,
+      notificationEvents: 10_000,
       pendingEvents: 5_000,
       socketBufferedBytes: 1_024,
       totalPendingBytes: 4_096,
@@ -83,6 +84,14 @@ void it('serves current usage and limits from /metrics', async () => {
   assert.match(
     output,
     /hyperlane_scraper_proxy_websocket_explorer_pending_bytes 1024/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_notification_queue_limit\{route="agent"\} 10000/,
+  );
+  assert.match(
+    output,
+    /hyperlane_scraper_proxy_websocket_send_failures_total\{reason="buffer_limit"\} 0/,
   );
   assert.match(
     output,

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -128,6 +128,13 @@ export const websocketSendFailures = new Counter({
   registers: [metricsRegistry],
 });
 
+export const websocketNotificationQueueOverflows = new Counter({
+  help: 'PostgreSQL notification queue overflows by isolated route.',
+  labelNames: ['route'] as const,
+  name: `${PREFIX}websocket_notification_queue_overflows_total`,
+  registers: [metricsRegistry],
+});
+
 for (const outcome of ['aborted', 'capacity_rejected', 'failure', 'success'])
   websocketCatchUps.inc({ outcome }, 0);
 for (const reason of [
@@ -143,6 +150,8 @@ for (const route of ['agent', 'messages']) {
 }
 for (const reason of ['invalid_client_ip', 'per_ip_limit'])
   websocketConnectionRejections.inc({ reason, route: 'messages' }, 0);
+for (const route of ['agent', 'messages'])
+  websocketNotificationQueueOverflows.inc({ route }, 0);
 
 let websocketMetricsProvider: (() => WebSocketMetricsSnapshot) | undefined;
 let databaseMetricsProvider: (() => DatabaseMetricsSnapshot) | undefined;

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -30,6 +30,7 @@ export type WebSocketMetricsSnapshot = {
     explorerPendingMessages: number;
     messageConnections: number;
     messageConnectionsPerIp: number;
+    notificationEvents: number;
     pendingEvents: number;
     socketBufferedBytes: number;
     totalPendingBytes: number;
@@ -126,6 +127,22 @@ export const websocketSendFailures = new Counter({
   name: `${PREFIX}websocket_send_failures_total`,
   registers: [metricsRegistry],
 });
+
+for (const outcome of ['aborted', 'capacity_rejected', 'failure', 'success'])
+  websocketCatchUps.inc({ outcome }, 0);
+for (const reason of [
+  'buffer_limit',
+  'notification_queue_limit',
+  'queue_limit',
+  'send_error',
+])
+  websocketSendFailures.inc({ reason }, 0);
+for (const route of ['agent', 'messages']) {
+  for (const reason of ['connection_limit', 'listener_unavailable'])
+    websocketConnectionRejections.inc({ reason, route }, 0);
+}
+for (const reason of ['invalid_client_ip', 'per_ip_limit'])
+  websocketConnectionRejections.inc({ reason, route: 'messages' }, 0);
 
 let websocketMetricsProvider: (() => WebSocketMetricsSnapshot) | undefined;
 let databaseMetricsProvider: (() => DatabaseMetricsSnapshot) | undefined;
@@ -325,6 +342,15 @@ snapshotGauge(
   (gauge, snapshot) => {
     gauge.set({ route: 'agent' }, snapshot.notificationQueue.agent);
     gauge.set({ route: 'messages' }, snapshot.notificationQueue.messages);
+  },
+  ['route'],
+);
+snapshotGauge(
+  'websocket_notification_queue_limit',
+  'Maximum queued PostgreSQL notifications before route clients are closed.',
+  (gauge, snapshot) => {
+    gauge.set({ route: 'agent' }, snapshot.limits.notificationEvents);
+    gauge.set({ route: 'messages' }, snapshot.limits.notificationEvents);
   },
   ['route'],
 );


### PR DESCRIPTION
## Summary

- cap each process-wide PostgreSQL notification queue at 10,000 unique events
- shed only the overloaded route and clear its queue, allowing sequenced clients to reconnect/catch up while the other route stays healthy
- expose queue depth/limit and route-attributed overflow counters
- initialize every known alert counter label to zero at process start so the first failure burst is observable

## Measured impact

- process-wide notification buffering changes from **unbounded to 10,000 unique events per route**
- if draining stopped completely, 10,000 slots cover about **6.3h / 38m / 3.8m / 22.7s / 2.27s** at the observed ~0.44 notifications/s baseline and 10x / 100x / 1,000x / 10,000x rates respectively; overflow then fails closed instead of growing RSS indefinitely
- the incident's first 14 `buffer_limit` failures were invisible to `increase()` because the labeled counter series first appeared at 14; zero-initialization makes detection begin at the **first event instead of event 15**
- local regression tests independently enqueued 10,001 unique notifications on each route and isolated overload in **54ms Explorer / 59ms agent**, leaving the other route open

These are capacity arithmetic and deterministic local overload tests, not a production throughput claim. The 10,000-event limit is a safety fuse; at 10,000x it fills in ~2.27s if draining stops. Durable outbox/high-water replay is still required before 1,000x-10,000x sustained load.

## Validation

- `pnpm -C typescript/scraper-proxy test` (64/64)
- `pnpm -C typescript/scraper-proxy build`
- `pnpm -C typescript/scraper-proxy lint`
- `pnpm -C typescript/scraper-proxy format`
- `git diff --check`
- two adversarial reviews found no blocker; follow-up review confirmed agent symmetry, route attribution, and zero-series coverage

## Stack / rollout

Draft. Stacked on #9407 because it relies on route-specific failure isolation. Not deployed. Canary should verify queue depth/limit series, first-event counter behavior, reconnect/catch-up correctness, RSS under a forced DB stall, and that one-route overload does not move the other route's latency or connections.
