### PR TITLE
perf: reduce scraper proxy query logging

### DIFF
--- a/typescript/scraper-proxy/src/config.ts
+++ b/typescript/scraper-proxy/src/config.ts
@@ -6,6 +6,7 @@ dotenvFlow.config();
 const ConfigSchema = z.object({
   DATABASE_QUERY_TIMEOUT_MS: z.coerce.number().int().min(1_000).default(20_000),
   DATABASE_READ_REPLICA_URL: z.string().min(1).optional(),
+  DATABASE_SLOW_QUERY_MS: z.coerce.number().int().min(1).default(1_000),
   DATABASE_STATEMENT_TIMEOUT_MS: z.coerce
     .number()
     .int()

--- a/typescript/scraper-proxy/src/db/db.service.test.ts
+++ b/typescript/scraper-proxy/src/db/db.service.test.ts
@@ -29,12 +29,15 @@ void it('keeps replica health from gating primary live queries', async (context)
           releaseMain = () => resolve({ rowCount: 0, rows: [] });
         });
       }
+      if (text === 'SELECT fail')
+        return Promise.reject(new Error('query failed'));
       assert(!saturatedPools.has(this));
       return Promise.resolve({ rowCount: 0, rows: [{ ready: 1 }] });
     },
   );
   const { DbService } = await import('./db.service.js');
   const db = new DbService();
+  context.after(() => db.onModuleDestroy());
 
   await db.onModuleInit();
   assert.equal(connectAttempts, 0);
@@ -48,7 +51,21 @@ void it('keeps replica health from gating primary live queries', async (context)
   assert(releaseMain);
   releaseMain();
   await saturated;
-  await db.onModuleDestroy();
+  await assert.rejects(db.query('SELECT fail'), /query failed/);
+  const { metricsRegistry } = await import('../metrics.js');
+  const metrics = await metricsRegistry.metrics();
+  assert.match(
+    metrics,
+    /database_queries_total\{(?=[^}]*role="graphql_replica")(?=[^}]*outcome="success")[^}]*\} 1/,
+  );
+  assert.match(
+    metrics,
+    /database_queries_total\{(?=[^}]*role="graphql_replica")(?=[^}]*outcome="error")[^}]*\} 1/,
+  );
+  assert.match(
+    metrics,
+    /database_queries_total\{(?=[^}]*role="live_primary")(?=[^}]*outcome="success")[^}]*\} 1/,
+  );
 });
 
 void it('times out stalled replica connections', async (context) => {

--- a/typescript/scraper-proxy/src/db/db.service.test.ts
+++ b/typescript/scraper-proxy/src/db/db.service.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { Socket } from 'node:net';
 import { it } from 'node:test';
 
+import { Logger } from '@nestjs/common';
 import pg from 'pg';
 
 process.env.DATABASE_URL ??= 'postgresql://scraper-proxy-test';
@@ -11,9 +12,19 @@ process.env.DATABASE_QUERY_TIMEOUT_MS ??= '1000';
 
 void it('keeps replica health from gating primary live queries', async (context) => {
   const saturatedPools = new WeakSet<pg.Pool>();
+  const debugLogs: unknown[] = [];
   const queryUrls = new Map<string, string>();
+  const warnings: unknown[] = [];
   let connectAttempts = 0;
   let releaseMain: (() => void) | undefined;
+  let now = 0;
+  context.mock.method(Date, 'now', () => now);
+  context.mock.method(Logger.prototype, 'debug', (message) =>
+    debugLogs.push(message),
+  );
+  context.mock.method(Logger.prototype, 'warn', (message) =>
+    warnings.push(message),
+  );
   context.mock.method(pg.Pool.prototype, 'connect', () => {
     connectAttempts++;
     throw new Error('replica unavailable');
@@ -26,12 +37,22 @@ void it('keeps replica health from gating primary live queries', async (context)
       if (text === 'SELECT pg_sleep(1)') {
         saturatedPools.add(this);
         return new Promise((resolve) => {
-          releaseMain = () => resolve({ rowCount: 0, rows: [] });
+          releaseMain = () => {
+            saturatedPools.delete(this);
+            resolve({ rowCount: 0, rows: [] });
+          };
         });
       }
       if (text === 'SELECT fail')
         return Promise.reject(new Error('query failed'));
       assert(!saturatedPools.has(this));
+      if (text === 'SELECT slow') {
+        now += 1_000;
+        return Promise.resolve({
+          rowCount: 2,
+          rows: [{ ready: 1 }, { ready: 2 }],
+        });
+      }
       return Promise.resolve({ rowCount: 0, rows: [{ ready: 1 }] });
     },
   );
@@ -51,12 +72,22 @@ void it('keeps replica health from gating primary live queries', async (context)
   assert(releaseMain);
   releaseMain();
   await saturated;
+  assert.deepEqual(await db.query('SELECT slow'), [{ ready: 1 }, { ready: 2 }]);
   await assert.rejects(db.query('SELECT fail'), /query failed/);
+  assert.deepEqual(debugLogs, []);
+  assert.equal(warnings.length, 2);
+  assert.match(
+    String(warnings[0]),
+    /slow query.*role=graphql_replica.*durationMs=1000/,
+  );
+  assert.match(String(warnings[0]), /sql=SELECT slow values=\[\]/);
+  assert.match(String(warnings[1]), /query failed.*role=graphql_replica/);
+  assert.match(String(warnings[1]), /sql=SELECT fail values=\[\]/);
   const { metricsRegistry } = await import('../metrics.js');
   const metrics = await metricsRegistry.metrics();
   assert.match(
     metrics,
-    /database_queries_total\{(?=[^}]*role="graphql_replica")(?=[^}]*outcome="success")[^}]*\} 1/,
+    /database_queries_total\{(?=[^}]*role="graphql_replica")(?=[^}]*outcome="success")[^}]*\} 2/,
   );
   assert.match(
     metrics,
@@ -66,6 +97,11 @@ void it('keeps replica health from gating primary live queries', async (context)
     metrics,
     /database_queries_total\{(?=[^}]*role="live_primary")(?=[^}]*outcome="success")[^}]*\} 1/,
   );
+  assert.match(
+    metrics,
+    /database_query_duration_seconds_count\{(?=[^}]*role="graphql_replica")(?=[^}]*outcome="success")[^}]*\} 2/,
+  );
+  assert.match(metrics, /database_rows_total\{role="graphql_replica"\} 2/);
 });
 
 void it('times out stalled replica connections', async (context) => {

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -10,10 +10,10 @@ import pg from 'pg';
 import { config } from '../config.js';
 import {
   databaseQueries,
+  DatabaseQueryRole,
   databaseQueryDuration,
   databaseRows,
   type DatabaseMetricsSnapshot,
-  type DatabaseQueryRole,
 } from '../metrics.js';
 import { quoteIdentifier } from '../scraperdb/tables.js';
 
@@ -101,7 +101,9 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
   ): Promise<T[]> {
     return this.run(
       this.pool(),
-      config.DATABASE_READ_REPLICA_URL ? 'graphql_replica' : 'graphql_primary',
+      config.DATABASE_READ_REPLICA_URL
+        ? DatabaseQueryRole.GraphqlReplica
+        : DatabaseQueryRole.GraphqlPrimary,
       text,
       values,
     );
@@ -111,7 +113,7 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     text: string,
     values: unknown[] = [],
   ): Promise<T[]> {
-    return this.run(this.live(), 'live_primary', text, values);
+    return this.run(this.live(), DatabaseQueryRole.LivePrimary, text, values);
   }
 
   async listen(
@@ -158,7 +160,9 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     const replicaUrl = config.DATABASE_READ_REPLICA_URL;
     this.mainPool ??= this.createPool(
       replicaUrl ?? config.DATABASE_URL,
-      replicaUrl ? 'graphql_replica' : 'graphql_primary',
+      replicaUrl
+        ? DatabaseQueryRole.GraphqlReplica
+        : DatabaseQueryRole.GraphqlPrimary,
       MIN_POOL_CLIENTS,
       replicaUrl ? config.DATABASE_QUERY_TIMEOUT_MS : undefined,
     );
@@ -166,7 +170,10 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
   }
 
   private live(): pg.Pool {
-    this.livePool ??= this.createPool(config.DATABASE_URL, 'live_primary');
+    this.livePool ??= this.createPool(
+      config.DATABASE_URL,
+      DatabaseQueryRole.LivePrimary,
+    );
     return this.livePool;
   }
 

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -8,7 +8,13 @@ import { formatError } from '@hyperlane-xyz/utils/errors';
 import pg from 'pg';
 
 import { config } from '../config.js';
-import type { DatabaseMetricsSnapshot } from '../metrics.js';
+import {
+  databaseQueries,
+  databaseQueryDuration,
+  databaseRows,
+  type DatabaseMetricsSnapshot,
+  type DatabaseQueryRole,
+} from '../metrics.js';
 import { quoteIdentifier } from '../scraperdb/tables.js';
 
 const MIN_POOL_CLIENTS = 5;
@@ -93,14 +99,19 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     text: string,
     values: unknown[] = [],
   ): Promise<T[]> {
-    return this.run(this.pool(), text, values);
+    return this.run(
+      this.pool(),
+      config.DATABASE_READ_REPLICA_URL ? 'graphql_replica' : 'graphql_primary',
+      text,
+      values,
+    );
   }
 
   queryLive<T extends pg.QueryResultRow>(
     text: string,
     values: unknown[] = [],
   ): Promise<T[]> {
-    return this.run(this.live(), text, values);
+    return this.run(this.live(), 'live_primary', text, values);
   }
 
   async listen(
@@ -178,38 +189,47 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
 
   private async run<T extends pg.QueryResultRow>(
     pool: pg.Pool,
+    role: DatabaseQueryRole,
     text: string,
     values: unknown[],
   ): Promise<T[]> {
     const id = ++this.nextQueryId;
     const started = Date.now();
-    this.logger.debug(
-      `query id=${id} start sql=${text.replaceAll(/\s+/g, ' ').trim()} values=${json(values)}`,
-    );
     try {
       const result = await pool.query<T>(text, values);
       const duration = Date.now() - started;
-      this.record(duration, result.rowCount ?? 0);
-      this.logger.debug(
-        `query id=${id} completed ${duration}ms rows=${result.rowCount}`,
-      );
+      const rows = result.rowCount ?? 0;
+      this.record(role, duration, rows);
+      if (duration >= config.DATABASE_SLOW_QUERY_MS) {
+        this.logger.warn(
+          `slow query id=${id} role=${role} durationMs=${duration} rows=${rows} ${queryDetails(text, values)}`,
+        );
+      }
       return result.rows;
     } catch (error) {
       const duration = Date.now() - started;
-      this.record(duration, 0, true);
-      this.logger.debug(
-        `query id=${id} failed ${duration}ms error=${formatError(error)}`,
+      this.record(role, duration, 0, true);
+      this.logger.warn(
+        `query failed id=${id} role=${role} durationMs=${duration} error=${formatError(error)} ${queryDetails(text, values)}`,
       );
       throw error;
     }
   }
 
-  private record(duration: number, rows: number, failed = false): void {
+  private record(
+    role: DatabaseQueryRole,
+    duration: number,
+    rows: number,
+    failed = false,
+  ): void {
     this.stats.queries++;
     this.stats.rows += rows;
     this.stats.totalMs += duration;
     this.stats.maxMs = Math.max(this.stats.maxMs, duration);
     if (failed) this.stats.errors++;
+    databaseQueries.inc({ outcome: failed ? 'error' : 'success', role });
+    databaseQueryDuration.observe({ role }, duration / 1_000);
+    databaseRows.inc({ role }, rows);
   }
 
   private logStats(): void {
@@ -244,6 +264,10 @@ function newStats(): Stats {
 
 function json(value: unknown): string {
   return JSON.stringify(logValue(value));
+}
+
+function queryDetails(text: string, values: unknown[]): string {
+  return `sql=${text.replaceAll(/\s+/g, ' ').trim()} values=${json(values)}`;
 }
 
 function logValue(value: unknown): unknown {

--- a/typescript/scraper-proxy/src/db/db.service.ts
+++ b/typescript/scraper-proxy/src/db/db.service.ts
@@ -158,6 +158,7 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     const replicaUrl = config.DATABASE_READ_REPLICA_URL;
     this.mainPool ??= this.createPool(
       replicaUrl ?? config.DATABASE_URL,
+      replicaUrl ? 'graphql_replica' : 'graphql_primary',
       MIN_POOL_CLIENTS,
       replicaUrl ? config.DATABASE_QUERY_TIMEOUT_MS : undefined,
     );
@@ -165,12 +166,13 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
   }
 
   private live(): pg.Pool {
-    this.livePool ??= this.createPool(config.DATABASE_URL);
+    this.livePool ??= this.createPool(config.DATABASE_URL, 'live_primary');
     return this.livePool;
   }
 
   private createPool(
     connectionString: string,
+    role: DatabaseQueryRole,
     min?: number,
     connectionTimeoutMillis?: number,
   ): pg.Pool {
@@ -182,7 +184,9 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
       min,
     });
     pool.on('error', (error) =>
-      this.logger.error(`idle database connection failed: ${error.message}`),
+      this.logger.error(
+        `idle database connection failed role=${role}: ${error.message}`,
+      ),
     );
     return pool;
   }
@@ -228,7 +232,10 @@ export class DbService implements OnModuleDestroy, OnModuleInit {
     this.stats.maxMs = Math.max(this.stats.maxMs, duration);
     if (failed) this.stats.errors++;
     databaseQueries.inc({ outcome: failed ? 'error' : 'success', role });
-    databaseQueryDuration.observe({ role }, duration / 1_000);
+    databaseQueryDuration.observe(
+      { outcome: failed ? 'error' : 'success', role },
+      duration / 1_000,
+    );
     databaseRows.inc({ role }, rows);
   }
 

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -58,6 +58,11 @@ export type DatabaseMetricsSnapshot = {
   pools: Record<'live' | 'main', DatabasePoolMetrics>;
 };
 
+export type DatabaseQueryRole =
+  | 'graphql_primary'
+  | 'graphql_replica'
+  | 'live_primary';
+
 export const metricsRegistry = new Registry();
 
 collectDefaultMetrics({ prefix: PREFIX, register: metricsRegistry });
@@ -93,6 +98,38 @@ export const graphqlRequestDuration = new Histogram({
   name: `${PREFIX}graphql_request_duration_seconds`,
   registers: [metricsRegistry],
 });
+
+export const databaseQueries = new Counter({
+  help: 'Database queries by fixed workload role and outcome.',
+  labelNames: ['role', 'outcome'] as const,
+  name: `${PREFIX}database_queries_total`,
+  registers: [metricsRegistry],
+});
+
+export const databaseQueryDuration = new Histogram({
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20],
+  help: 'Database query duration in seconds by fixed workload role.',
+  labelNames: ['role'] as const,
+  name: `${PREFIX}database_query_duration_seconds`,
+  registers: [metricsRegistry],
+});
+
+export const databaseRows = new Counter({
+  help: 'Database rows returned by fixed workload role.',
+  labelNames: ['role'] as const,
+  name: `${PREFIX}database_rows_total`,
+  registers: [metricsRegistry],
+});
+
+for (const role of [
+  'graphql_primary',
+  'graphql_replica',
+  'live_primary',
+] satisfies DatabaseQueryRole[]) {
+  for (const outcome of ['error', 'success'])
+    databaseQueries.inc({ outcome, role }, 0);
+  databaseRows.inc({ role }, 0);
+}
 
 export const websocketConnections = new Counter({
   help: 'Accepted WebSocket connections by route.',

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -108,8 +108,8 @@ export const databaseQueries = new Counter({
 
 export const databaseQueryDuration = new Histogram({
   buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20],
-  help: 'Database query duration in seconds by fixed workload role.',
-  labelNames: ['role'] as const,
+  help: 'Database query duration in seconds by fixed workload role and outcome.',
+  labelNames: ['role', 'outcome'] as const,
   name: `${PREFIX}database_query_duration_seconds`,
   registers: [metricsRegistry],
 });

--- a/typescript/scraper-proxy/src/metrics.ts
+++ b/typescript/scraper-proxy/src/metrics.ts
@@ -58,10 +58,14 @@ export type DatabaseMetricsSnapshot = {
   pools: Record<'live' | 'main', DatabasePoolMetrics>;
 };
 
+export const DatabaseQueryRole = {
+  GraphqlPrimary: 'graphql_primary',
+  GraphqlReplica: 'graphql_replica',
+  LivePrimary: 'live_primary',
+} as const;
+
 export type DatabaseQueryRole =
-  | 'graphql_primary'
-  | 'graphql_replica'
-  | 'live_primary';
+  (typeof DatabaseQueryRole)[keyof typeof DatabaseQueryRole];
 
 export const metricsRegistry = new Registry();
 
@@ -121,11 +125,7 @@ export const databaseRows = new Counter({
   registers: [metricsRegistry],
 });
 
-for (const role of [
-  'graphql_primary',
-  'graphql_replica',
-  'live_primary',
-] satisfies DatabaseQueryRole[]) {
+for (const role of Object.values(DatabaseQueryRole)) {
   for (const outcome of ['error', 'success'])
     databaseQueries.inc({ outcome, role }, 0);
   databaseRows.inc({ role }, 0);


### PR DESCRIPTION
## Summary

- remove per-query start/completion logs from the healthy hot path
- retain one structured warning for every failure and every query slower than the configurable 1s threshold
- replace log-derived DB latency/error/row analysis with fixed-cardinality Prometheus counters and histograms
- distinguish `graphql_replica`, `graphql_primary`, and `live_primary` without exposing connection strings, including idle-pool errors
- split duration histograms by success/error outcome

## Measured impact

Retained production pod evidence from 2026-08-31:

- 10,633 retained log lines included 4,791 query starts and 4,783 completions; this removes **9,574 healthy hot-path lines, 90.0% of all retained lines** before accounting for slow queries
- query start/completion records represented **98.1% of bytes in the sampled current hour**; normal-query log bytes therefore fall by up to ~98%, while failures and >=1s queries remain
- linear log growth was modeled at roughly **0.8 / 8 / 80 / 800 GB/day** at 10x / 100x / 1,000x / 10,000x; this removes the query-volume-proportional term that dominated the sample
- the retained window had only 8 failures among 4,791 starts (**0.17%**), so failure visibility is preserved at a tiny fraction of prior log volume
- histograms retain 5ms-20s latency resolution by physical workload role and outcome, plus success/error and returned-row counters

These are measured log composition and modeled linear scale, not post-deploy ingestion-billing results. Canary should compare actual bytes/day and logging CPU.

## Validation

- `pnpm -C typescript/scraper-proxy test` (54/54)
- tests verify fast-query log silence; complete slow/failure logs; replica/live roles; success/error counters; returned rows; and duration histograms
- `pnpm -C typescript/scraper-proxy build`
- `pnpm -C typescript/scraper-proxy lint`
- `pnpm -C typescript/scraper-proxy format`
- `git diff --check`
- adversarial review found no blocker; follow-up changes addressed every concrete review gap

## Stack / rollout

Draft. Stacked on #9408 so GraphQL metrics can distinguish replica from primary. Not deployed. Canary should verify log bytes/day, slow/failure log retention, query-rate conservation, histogram p50/p95/p99 by role/outcome, statement-timeout count, replica lag, and websocket latency.
