### PR TITLE
fix(lander): bound Aleo transaction status polling

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -92,6 +92,31 @@ impl HttpClient for BaseHttpClient {
         Ok(json)
     }
 
+    async fn request_optional<T: DeserializeOwned + Send>(
+        &self,
+        path: &str,
+        query: impl Into<Option<serde_json::Value>> + Send,
+    ) -> ChainResult<Option<T>> {
+        let url = append_path(&self.base_url, path)?;
+        let query: serde_json::Value = query.into().unwrap_or_default();
+        let response = self
+            .client
+            .get(url)
+            .query(&query)
+            .send()
+            .await
+            .map_err(HyperlaneAleoError::from)?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let response = response
+            .error_for_status()
+            .map_err(HyperlaneAleoError::from)?;
+        Ok(Some(
+            response.json().await.map_err(HyperlaneAleoError::from)?,
+        ))
+    }
+
     /// Makes a POST request to the API
     async fn request_post<T: DeserializeOwned + Send>(
         &self,
@@ -224,6 +249,37 @@ impl HttpClient for JWTBaseHttpClient {
         Ok(json)
     }
 
+    async fn request_optional<T: DeserializeOwned + Send>(
+        &self,
+        path: &str,
+        query: impl Into<Option<serde_json::Value>> + Send,
+    ) -> ChainResult<Option<T>> {
+        let url = append_path(&self.base_url, path)?;
+        let query: serde_json::Value = query.into().unwrap_or_default();
+        let auth = self.get_auth_token().await?;
+        let response = self
+            .client
+            .get(url)
+            .header(AUTHORIZATION, auth)
+            .query(&query)
+            .send()
+            .await
+            .map_err(HyperlaneAleoError::from)?;
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            self.clear_auth_token().await;
+        }
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let response = response
+            .error_for_status()
+            .map_err(HyperlaneAleoError::from)?;
+        Ok(Some(
+            response.json().await.map_err(HyperlaneAleoError::from)?,
+        ))
+    }
+
     /// Makes a POST request to the API
     async fn request_post<T: DeserializeOwned + Send>(
         &self,
@@ -337,6 +393,32 @@ mod tests {
             request_rx.recv().unwrap(),
             "POST /v2/mainnet/mapping/%7Bbytes:%5B1u8%5D%7D HTTP/1.1"
         );
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn optional_request_returns_none_for_not_found() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 4096];
+            stream.read(&mut buffer).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+        let client =
+            BaseHttpClient::new(Url::parse(&format!("http://{address}/v2")).unwrap(), 0).unwrap();
+
+        let response: Option<Value> = client
+            .request_optional("transaction/confirmed/missing", None)
+            .await
+            .unwrap();
+
+        assert_eq!(response, None);
         server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
@@ -71,6 +71,22 @@ impl<C: AleoClient> HttpClient for FallbackHttpClient<C> {
             .await
     }
 
+    async fn request_optional<T: DeserializeOwned + Send>(
+        &self,
+        path: &str,
+        query: impl Into<Option<serde_json::Value>> + Send,
+    ) -> ChainResult<Option<T>> {
+        let query = query.into();
+        self.fallback
+            .call(|inner| {
+                let path = path.to_string();
+                let query = query.clone();
+                let future = async move { inner.request_optional(&path, query).await };
+                Box::pin(future)
+            })
+            .await
+    }
+
     /// Makes a POST request to the API
     async fn request_post<T: DeserializeOwned + Send>(
         &self,

--- a/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
@@ -78,7 +78,7 @@ impl<C: AleoClient> HttpClient for FallbackHttpClient<C> {
     ) -> ChainResult<Option<T>> {
         let query = query.into();
         self.fallback
-            .call(|inner| {
+            .call_optional(|inner| {
                 let path = path.to_string();
                 let query = query.clone();
                 let future = async move { inner.request_optional(&path, query).await };

--- a/rust/main/chains/hyperlane-aleo/src/provider/lander.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/lander.rs
@@ -36,13 +36,13 @@ pub trait AleoProviderForLander: Send + Sync {
     async fn request_confirmed_transaction(
         &self,
         transaction_id: H512,
-    ) -> ChainResult<ConfirmedTransaction<CurrentNetwork>>;
+    ) -> ChainResult<Option<ConfirmedTransaction<CurrentNetwork>>>;
 
     /// Gets an unconfirmed transaction from the mempool by its ID
     async fn request_unconfirmed_transaction(
         &self,
         transaction_id: H512,
-    ) -> ChainResult<Transaction<CurrentNetwork>>;
+    ) -> ChainResult<Option<Transaction<CurrentNetwork>>>;
 
     /// Queries a program mapping value
     ///
@@ -81,15 +81,17 @@ impl<C: AleoClient> AleoProviderForLander for AleoProvider<C> {
     async fn request_confirmed_transaction(
         &self,
         transaction_id: H512,
-    ) -> ChainResult<ConfirmedTransaction<CurrentNetwork>> {
-        self.get_confirmed_transaction(transaction_id).await
+    ) -> ChainResult<Option<ConfirmedTransaction<CurrentNetwork>>> {
+        self.get_confirmed_transaction_optional(transaction_id)
+            .await
     }
 
     async fn request_unconfirmed_transaction(
         &self,
         transaction_id: H512,
-    ) -> ChainResult<Transaction<CurrentNetwork>> {
-        self.get_unconfirmed_transaction(transaction_id).await
+    ) -> ChainResult<Option<Transaction<CurrentNetwork>>> {
+        self.get_unconfirmed_transaction_optional(transaction_id)
+            .await
     }
 
     async fn mapping_value_exists(

--- a/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
@@ -48,6 +48,17 @@ impl<C: AleoClient> Clone for MetricHttpClient<C> {
 }
 
 impl<C: AleoClient> MetricHttpClient<C> {
+    fn method(path: &str) -> String {
+        let mut segments = path.split('/');
+        let first = segments.next().unwrap_or_default();
+        match (first, segments.next()) {
+            ("transaction", Some(action @ ("confirmed" | "unconfirmed" | "broadcast"))) => {
+                format!("transaction_{action}")
+            }
+            _ => first.to_owned(),
+        }
+    }
+
     /// Creates a new MetricHttpClient
     pub fn new<Builder: HttpClientBuilder<Client = C>>(
         url: Url,
@@ -77,9 +88,9 @@ impl<C: AleoClient> MetricHttpClient<C> {
     {
         let start = Instant::now();
         let res = operation().await;
-        let method = path.split('/').next().unwrap_or_default();
+        let method = Self::method(path);
         self.metrics
-            .increment_metrics(&self.metrics_config, method, start, res.is_ok());
+            .increment_metrics(&self.metrics_config, &method, start, res.is_ok());
         res
     }
 }
@@ -96,6 +107,15 @@ impl<C: AleoClient> HttpClient for MetricHttpClient<C> {
             .await
     }
 
+    async fn request_optional<T: DeserializeOwned + Send>(
+        &self,
+        path: &str,
+        query: impl Into<Option<serde_json::Value>> + Send,
+    ) -> ChainResult<Option<T>> {
+        self.track_request(path, || self.inner.request_optional(path, query))
+            .await
+    }
+
     /// Makes a POST request to the API
     async fn request_post<T: DeserializeOwned + Send>(
         &self,
@@ -104,5 +124,27 @@ impl<C: AleoClient> HttpClient for MetricHttpClient<C> {
     ) -> ChainResult<T> {
         self.track_request(path, || self.inner.request_post(path, body))
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MetricHttpClient;
+    use crate::provider::BaseHttpClient;
+
+    #[test]
+    fn transaction_endpoints_have_distinct_metric_methods() {
+        assert_eq!(
+            MetricHttpClient::<BaseHttpClient>::method("transaction/confirmed/id"),
+            "transaction_confirmed"
+        );
+        assert_eq!(
+            MetricHttpClient::<BaseHttpClient>::method("transaction/unconfirmed/id"),
+            "transaction_unconfirmed"
+        );
+        assert_eq!(
+            MetricHttpClient::<BaseHttpClient>::method("transaction/broadcast"),
+            "transaction_broadcast"
+        );
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/mock.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/mock.rs
@@ -99,7 +99,13 @@ impl HttpClient for MockHttpClient {
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect::<String>();
-        let Some(value) = self.responses.read().unwrap().get(&path).cloned() else {
+        let value = {
+            let responses = self.responses.read().map_err(|err| {
+                HyperlaneAleoError::Other(format!("Mock response lock poisoned: {err}"))
+            })?;
+            responses.get(&path).cloned()
+        };
+        let Some(value) = value else {
             return Ok(None);
         };
         let parsed: T = serde_json::from_value(value).map_err(HyperlaneAleoError::from)?;

--- a/rust/main/chains/hyperlane-aleo/src/provider/mock.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/mock.rs
@@ -89,6 +89,23 @@ impl HttpClient for MockHttpClient {
         Ok(parsed)
     }
 
+    async fn request_optional<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        _query: impl Into<Option<Value>> + Send,
+    ) -> ChainResult<Option<T>> {
+        let path = path
+            .trim()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>();
+        let Some(value) = self.responses.read().unwrap().get(&path).cloned() else {
+            return Ok(None);
+        };
+        let parsed: T = serde_json::from_value(value).map_err(HyperlaneAleoError::from)?;
+        Ok(Some(parsed))
+    }
+
     /// Makes a GET request to the API in a blocking manner
     fn request_blocking<T: DeserializeOwned>(
         &self,

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -44,6 +44,13 @@ pub trait HttpClient {
         query: impl Into<Option<serde_json::Value>> + Send,
     ) -> ChainResult<T>;
 
+    /// Makes a GET request where HTTP 404 means the resource does not exist.
+    async fn request_optional<T: DeserializeOwned + Send>(
+        &self,
+        path: &str,
+        query: impl Into<Option<serde_json::Value>> + Send,
+    ) -> ChainResult<Option<T>>;
+
     /// Makes a GET request to the API in a blocking manner
     fn request_blocking<T: DeserializeOwned + Send>(
         &self,
@@ -240,6 +247,16 @@ impl<Client: HttpClient> RpcClient<Client> {
             .await
     }
 
+    /// Gets a confirmed transaction by ID, returning `None` when it is not found.
+    pub async fn get_confirmed_transaction_optional(
+        &self,
+        transaction_id: H512,
+    ) -> ChainResult<Option<ConfirmedTransaction<CurrentNetwork>>> {
+        let tx_id = get_tx_id::<CurrentNetwork>(transaction_id)?;
+        self.request_optional(&format!("transaction/confirmed/{tx_id}"), None)
+            .await
+    }
+
     /// Gets an unconfirmed transaction by ID from the mempool
     pub async fn get_unconfirmed_transaction(
         &self,
@@ -247,6 +264,16 @@ impl<Client: HttpClient> RpcClient<Client> {
     ) -> ChainResult<Transaction<CurrentNetwork>> {
         let tx_id = crate::utils::get_tx_id::<CurrentNetwork>(transaction_id)?;
         self.request(&format!("transaction/unconfirmed/{tx_id}"), None)
+            .await
+    }
+
+    /// Gets an unconfirmed transaction by ID, returning `None` when it is not found.
+    pub async fn get_unconfirmed_transaction_optional(
+        &self,
+        transaction_id: H512,
+    ) -> ChainResult<Option<Transaction<CurrentNetwork>>> {
+        let tx_id = crate::utils::get_tx_id::<CurrentNetwork>(transaction_id)?;
+        self.request_optional(&format!("transaction/unconfirmed/{tx_id}"), None)
             .await
     }
 

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -321,6 +321,61 @@ where
 
         Err(RpcClientError::FallbackProvidersFailed(errors).into())
     }
+
+    /// Call each provider once until one returns `Some`.
+    ///
+    /// Returns `None` only when every provider successfully reports absence. If
+    /// any provider fails and none reports presence, the result is ambiguous and
+    /// the provider errors are returned.
+    pub async fn call_optional<V>(
+        &self,
+        mut f: impl FnMut(T) -> Pin<Box<dyn Future<Output = ChainResult<Option<V>>> + Send>>,
+    ) -> ChainResult<Option<V>> {
+        let mut errors = vec![];
+        let priorities_snapshot = self.take_priorities_snapshot().await;
+        if priorities_snapshot.is_empty() {
+            return Err(RpcClientError::FallbackProvidersFailed(errors).into());
+        }
+
+        for (idx, priority) in priorities_snapshot.iter().enumerate() {
+            let provider = &self.inner.providers[priority.index];
+            let resp = match tokio::time::timeout(self.call_timeout, async {
+                let resp = f(provider.clone()).await;
+                if resp.is_ok() {
+                    self.handle_stalled_provider(priority, provider).await?;
+                }
+                resp
+            })
+            .await
+            {
+                Ok(resp) => resp,
+                Err(_) => Err(crate::ChainCommunicationError::from_other_str(
+                    "fallback provider call timed out",
+                )),
+            };
+            if resp.is_err() {
+                self.handle_failed_provider(priority).await;
+            }
+            let _span = warn_span!("FallbackProvider::call_optional", fallback_count=%idx, provider_index=%priority.index, ?provider).entered();
+            match resp {
+                Ok(Some(value)) => return Ok(Some(value)),
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(
+                        error=?error,
+                        "Got error from inner fallback provider",
+                    );
+                    errors.push(error);
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(None)
+        } else {
+            Err(RpcClientError::FallbackProvidersFailed(errors).into())
+        }
+    }
 }
 
 /// Builder to create a new fallback provider.
@@ -577,6 +632,81 @@ pub mod test {
             .map(|p| p.last_failed_count)
             .collect();
         assert_eq!(failed_counts[0], 1);
+    }
+
+    #[tokio::test]
+    async fn test_call_optional_prefers_secondary_presence_over_primary_absence() {
+        let provider1 = ProviderMock::default();
+        provider1.push("none", true);
+        let provider2 = ProviderMock::default();
+        provider2.push("some", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([provider1.clone(), provider2.clone()]);
+
+        let result = fallback_provider
+            .call_optional(|provider| {
+                let response = provider.requests()[0].0.clone();
+                provider.push("call", true);
+                Box::pin(async move {
+                    match response.as_str() {
+                        "some" => Ok(Some(42)),
+                        _ => Ok(None),
+                    }
+                })
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(42));
+        assert_eq!(provider1.requests().len(), 2);
+        assert_eq!(provider2.requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_call_optional_returns_none_when_all_providers_report_absence() {
+        let provider1 = ProviderMock::default();
+        provider1.push("none", true);
+        let provider2 = ProviderMock::default();
+        provider2.push("none", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([provider1.clone(), provider2.clone()]);
+
+        let result = fallback_provider
+            .call_optional(|provider| {
+                provider.push("call", true);
+                Box::pin(async move { Ok::<_, crate::ChainCommunicationError>(None::<u64>) })
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(provider1.requests().len(), 2);
+        assert_eq!(provider2.requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_call_optional_does_not_treat_provider_error_as_absence() {
+        let provider1 = ProviderMock::default();
+        provider1.push("none", true);
+        let provider2 = ProviderMock::default();
+        provider2.push("error", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([provider1, provider2]);
+
+        let result = fallback_provider
+            .call_optional(|provider| {
+                let response = provider.requests()[0].0.clone();
+                Box::pin(async move {
+                    if response == "error" {
+                        Err(crate::ChainCommunicationError::BatchingFailed)
+                    } else {
+                        Ok(None::<u64>)
+                    }
+                })
+            })
+            .await;
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/core.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/core.rs
@@ -91,13 +91,14 @@ impl<P: AleoProviderForLander> AdaptsChain for AleoAdapter<P> {
     }
 
     async fn tx_status(&self, tx: &Transaction) -> Result<TransactionStatus, LanderError> {
+        let Some(latest_hash) = tx.tx_hashes.last() else {
+            return Ok(TransactionStatus::PendingInclusion);
+        };
+
         if self.delivered(tx).await? {
             return Ok(TransactionStatus::Finalized);
         }
 
-        let Some(latest_hash) = tx.tx_hashes.last() else {
-            return Ok(TransactionStatus::PendingInclusion);
-        };
         self.get_tx_hash_status(*latest_hash).await
     }
 

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/core.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/core.rs
@@ -90,6 +90,17 @@ impl<P: AleoProviderForLander> AdaptsChain for AleoAdapter<P> {
         status::get_tx_hash_status(&self.provider, hash).await
     }
 
+    async fn tx_status(&self, tx: &Transaction) -> Result<TransactionStatus, LanderError> {
+        if self.delivered(tx).await? {
+            return Ok(TransactionStatus::Finalized);
+        }
+
+        let Some(latest_hash) = tx.tx_hashes.last() else {
+            return Ok(TransactionStatus::PendingInclusion);
+        };
+        self.get_tx_hash_status(*latest_hash).await
+    }
+
     async fn tx_ready_for_resubmission(&self, tx: &Transaction) -> bool {
         self.ready_for_resubmission(tx)
     }

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/core.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/core.rs
@@ -91,13 +91,13 @@ impl<P: AleoProviderForLander> AdaptsChain for AleoAdapter<P> {
     }
 
     async fn tx_status(&self, tx: &Transaction) -> Result<TransactionStatus, LanderError> {
-        let Some(latest_hash) = tx.tx_hashes.last() else {
-            return Ok(TransactionStatus::PendingInclusion);
-        };
-
         if self.delivered(tx).await? {
             return Ok(TransactionStatus::Finalized);
         }
+
+        let Some(latest_hash) = tx.tx_hashes.last() else {
+            return Ok(TransactionStatus::PendingInclusion);
+        };
 
         self.get_tx_hash_status(*latest_hash).await
     }

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/core/tests.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/core/tests.rs
@@ -153,7 +153,7 @@ fn set_delivery_criterion(tx: &mut Transaction) {
 }
 
 #[tokio::test]
-async fn test_tx_status_without_hash_skips_network_queries() {
+async fn test_tx_status_without_hash_uses_delivery_mapping() {
     let provider = Arc::new(CountingStatusProvider::new(true));
     let adapter = AleoAdapter {
         provider: provider.clone(),
@@ -164,9 +164,9 @@ async fn test_tx_status_without_hash_skips_network_queries() {
 
     assert_eq!(
         adapter.tx_status(&tx).await.unwrap(),
-        TransactionStatus::PendingInclusion
+        TransactionStatus::Finalized
     );
-    assert_eq!(provider.mapping_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.mapping_calls.load(Ordering::SeqCst), 1);
     assert_eq!(provider.confirmed_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.unconfirmed_calls.load(Ordering::SeqCst), 0);
 }

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/core/tests.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/core/tests.rs
@@ -153,6 +153,25 @@ fn set_delivery_criterion(tx: &mut Transaction) {
 }
 
 #[tokio::test]
+async fn test_tx_status_without_hash_skips_network_queries() {
+    let provider = Arc::new(CountingStatusProvider::new(true));
+    let adapter = AleoAdapter {
+        provider: provider.clone(),
+        estimated_block_time: Duration::from_secs(10),
+    };
+    let mut tx = create_test_transaction();
+    set_delivery_criterion(&mut tx);
+
+    assert_eq!(
+        adapter.tx_status(&tx).await.unwrap(),
+        TransactionStatus::PendingInclusion
+    );
+    assert_eq!(provider.mapping_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.confirmed_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.unconfirmed_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn test_tx_status_has_constant_width_with_historical_hashes() {
     let provider = Arc::new(CountingStatusProvider::new(false));
     let adapter = AleoAdapter {

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/core/tests.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/core/tests.rs
@@ -1,10 +1,15 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use uuid::Uuid;
 
-use hyperlane_aleo::{AleoSigner, AleoTxData};
-use hyperlane_core::H256;
+use async_trait::async_trait;
+use hyperlane_aleo::{
+    AleoConfirmedTransaction, AleoGetMappingValue, AleoProviderForLander, AleoSerialize,
+    AleoSigner, AleoTxData, AleoUnconfirmedTransaction, CurrentNetwork, DeliveryKey, Plaintext,
+};
+use hyperlane_core::{ChainResult, H256, H512};
 
 use crate::adapter::chains::{AleoAdapter, AleoTxPrecursor};
 use crate::adapter::AdaptsChain;
@@ -75,6 +80,116 @@ pub(crate) fn create_test_transaction() -> Transaction {
         last_submission_attempt: None,
         last_status_check: None,
     }
+}
+
+struct CountingStatusProvider {
+    delivered: bool,
+    confirmed_calls: AtomicUsize,
+    unconfirmed_calls: AtomicUsize,
+    mapping_calls: AtomicUsize,
+}
+
+impl CountingStatusProvider {
+    fn new(delivered: bool) -> Self {
+        Self {
+            delivered,
+            confirmed_calls: AtomicUsize::new(0),
+            unconfirmed_calls: AtomicUsize::new(0),
+            mapping_calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl AleoProviderForLander for CountingStatusProvider {
+    async fn submit_tx<I>(
+        &self,
+        _program_id: &str,
+        _function_name: &str,
+        _input: I,
+    ) -> ChainResult<H512>
+    where
+        I: IntoIterator<Item = String> + Send,
+        I::IntoIter: ExactSizeIterator,
+    {
+        Ok(H512::random())
+    }
+
+    async fn request_confirmed_transaction(
+        &self,
+        _transaction_id: H512,
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
+        self.confirmed_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }
+
+    async fn request_unconfirmed_transaction(
+        &self,
+        _transaction_id: H512,
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
+        self.unconfirmed_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }
+
+    async fn mapping_value_exists(
+        &self,
+        _program_id: &str,
+        _mapping_name: &str,
+        _mapping_key: &Plaintext<CurrentNetwork>,
+    ) -> ChainResult<bool> {
+        self.mapping_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.delivered)
+    }
+}
+
+fn set_delivery_criterion(tx: &mut Transaction) {
+    let delivery_key = DeliveryKey { id: [1u128, 1u128] };
+    let criterion = AleoGetMappingValue {
+        program_id: "mailbox.aleo".to_string(),
+        mapping_name: "deliveries".to_string(),
+        mapping_key: delivery_key.to_plaintext().unwrap(),
+    };
+    tx.payload_details[0].success_criteria = Some(serde_json::to_vec(&criterion).unwrap());
+}
+
+#[tokio::test]
+async fn test_tx_status_has_constant_width_with_historical_hashes() {
+    let provider = Arc::new(CountingStatusProvider::new(false));
+    let adapter = AleoAdapter {
+        provider: provider.clone(),
+        estimated_block_time: Duration::from_secs(10),
+    };
+    let mut tx = create_test_transaction();
+    set_delivery_criterion(&mut tx);
+    tx.tx_hashes = (0..2_000).map(|_| H512::random()).collect();
+
+    assert_eq!(
+        adapter.tx_status(&tx).await.unwrap(),
+        TransactionStatus::PendingInclusion
+    );
+    assert_eq!(provider.mapping_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.confirmed_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.unconfirmed_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_tx_status_uses_delivery_mapping_before_transaction_hashes() {
+    let provider = Arc::new(CountingStatusProvider::new(true));
+    let adapter = AleoAdapter {
+        provider: provider.clone(),
+        estimated_block_time: Duration::from_secs(10),
+    };
+    let mut tx = create_test_transaction();
+    set_delivery_criterion(&mut tx);
+    tx.tx_hashes = (0..2_000).map(|_| H512::random()).collect();
+
+    assert_eq!(
+        adapter.tx_status(&tx).await.unwrap(),
+        TransactionStatus::Finalized
+    );
+    assert_eq!(provider.mapping_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.confirmed_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.unconfirmed_calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/payload.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/payload.rs
@@ -7,6 +7,42 @@ use crate::transaction::Transaction;
 use crate::{LanderError, TransactionStatus};
 
 impl<P: AleoProviderForLander> crate::adapter::chains::aleo::adapter::core::AleoAdapter<P> {
+    async fn payload_delivered(
+        &self,
+        payload_detail: &PayloadDetails,
+    ) -> Result<Option<bool>, LanderError> {
+        let Some(ref success_criteria_bytes) = payload_detail.success_criteria else {
+            return Ok(None);
+        };
+        let get_mapping_value: AleoGetMappingValue = serde_json::from_slice(success_criteria_bytes)
+            .map_err(|e| {
+                LanderError::NonRetryableError(format!("Failed to parse success_criteria: {e}"))
+            })?;
+
+        self.provider
+            .mapping_value_exists(
+                &get_mapping_value.program_id,
+                &get_mapping_value.mapping_name,
+                &get_mapping_value.mapping_key,
+            )
+            .await
+            .map(Some)
+            .map_err(LanderError::from)
+    }
+
+    /// Returns true only when every payload has a success criterion that is satisfied on-chain.
+    pub(crate) async fn delivered(&self, tx: &Transaction) -> Result<bool, LanderError> {
+        if tx.payload_details.is_empty() {
+            return Ok(false);
+        }
+        for payload_detail in &tx.payload_details {
+            if self.payload_delivered(payload_detail).await? != Some(true) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     /// Check which payloads were reverted by verifying on-chain delivery status.
     ///
     /// For Aleo:
@@ -24,33 +60,7 @@ impl<P: AleoProviderForLander> crate::adapter::chains::aleo::adapter::core::Aleo
                 let mut reverted = Vec::new();
 
                 for payload_detail in &tx.payload_details {
-                    // Skip payloads without success_criteria
-                    let Some(ref success_criteria_bytes) = payload_detail.success_criteria else {
-                        continue;
-                    };
-
-                    // Parse the success_criteria to get the delivery check parameters
-                    let get_mapping_value: AleoGetMappingValue =
-                        serde_json::from_slice(success_criteria_bytes).map_err(|e| {
-                            LanderError::NonRetryableError(format!(
-                                "Failed to parse success_criteria: {e}"
-                            ))
-                        })?;
-
-                    // Query on-chain to check if the delivery record exists
-                    // If provider returns error, treat as delivered (not reverted) with unwrap_or(true)
-                    let delivered = self
-                        .provider
-                        .mapping_value_exists(
-                            &get_mapping_value.program_id,
-                            &get_mapping_value.mapping_name,
-                            &get_mapping_value.mapping_key,
-                        )
-                        .await
-                        .unwrap_or(true);
-
-                    // If not delivered, the payload is reverted
-                    if !delivered {
+                    if self.payload_delivered(payload_detail).await? == Some(false) {
                         reverted.push(payload_detail.clone());
                     }
                 }

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/ready.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/ready.rs
@@ -11,6 +11,10 @@ impl<P: AleoProviderForLander> crate::adapter::chains::aleo::adapter::core::Aleo
     /// - Submit immediately if the transaction has never been submitted before
     /// - For resubmissions, wait approximately one block time before trying again
     pub(crate) fn ready_for_resubmission(&self, tx: &Transaction) -> bool {
+        if tx.status == crate::TransactionStatus::Mempool {
+            return false;
+        }
+
         // If the transaction has never been submitted, it is ready for submission
         let Some(last_submission_time) = tx.last_submission_attempt else {
             return true;

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/ready/tests.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/ready/tests.rs
@@ -1,4 +1,5 @@
 use super::super::core::tests::{create_test_adapter, create_test_transaction};
+use crate::TransactionStatus;
 
 #[test]
 fn test_tx_ready_for_resubmission() {
@@ -39,4 +40,14 @@ fn test_tx_ready_for_resubmission() {
         result,
         "Transaction with future submission time should be ready (safety fallback)"
     );
+}
+
+#[test]
+fn test_mempool_transaction_is_not_resubmitted() {
+    let adapter = create_test_adapter();
+    let mut tx = create_test_transaction();
+    tx.status = TransactionStatus::Mempool;
+    tx.last_submission_attempt = Some(chrono::Utc::now() - chrono::Duration::hours(1));
+
+    assert!(!adapter.ready_for_resubmission(&tx));
 }

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/status.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/status.rs
@@ -20,7 +20,11 @@ pub async fn get_tx_hash_status<P: AleoProviderForLander>(
     debug!("Checking status of tx, hash: {:?}", hash);
 
     // First, check if the transaction is confirmed on-chain
-    if let Ok(_confirmed_tx) = provider.request_confirmed_transaction(hash).await {
+    if provider
+        .request_confirmed_transaction(hash)
+        .await?
+        .is_some()
+    {
         // Transaction is confirmed - report as finalized
         // Once we introduce transaction drop reasons Rejected and Reverted,
         // we shall check if a confirmed Aleo transaction was rejected.
@@ -33,7 +37,11 @@ pub async fn get_tx_hash_status<P: AleoProviderForLander>(
     debug!("Transaction is not finalized, hash: {}", hash);
 
     // Not confirmed yet, check if it's in the mempool (unconfirmed)
-    if let Ok(_unconfirmed_tx) = provider.request_unconfirmed_transaction(hash).await {
+    if provider
+        .request_unconfirmed_transaction(hash)
+        .await?
+        .is_some()
+    {
         // Transaction is in the mempool, waiting to be included in a block
         debug!("Transaction found in mempool, hash: {:?}", hash);
         return Ok(TransactionStatus::Mempool);
@@ -43,7 +51,7 @@ pub async fn get_tx_hash_status<P: AleoProviderForLander>(
     // This could mean:
     // 1. Transaction was just submitted and not yet propagated
     // 2. Transaction was dropped from the mempool
-    // 3. Network error
+    // Provider errors are propagated instead of being mistaken for absence.
     debug!(
         "Transaction not found in confirmed or unconfirmed, hash: {:?}",
         hash

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/status/tests.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/status/tests.rs
@@ -107,31 +107,25 @@ impl AleoProviderForLander for MockProviderWithFixtures {
     async fn request_confirmed_transaction(
         &self,
         transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
-        self.confirmed_transactions
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
+        Ok(self
+            .confirmed_transactions
             .lock()
             .unwrap()
             .get(&transaction_id)
-            .cloned()
-            .ok_or_else(|| {
-                hyperlane_core::ChainCommunicationError::from_other_str("Transaction not found")
-            })
+            .cloned())
     }
 
     async fn request_unconfirmed_transaction(
         &self,
         transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
-        self.unconfirmed_transactions
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
+        Ok(self
+            .unconfirmed_transactions
             .lock()
             .unwrap()
             .get(&transaction_id)
-            .cloned()
-            .ok_or_else(|| {
-                hyperlane_core::ChainCommunicationError::from_other_str(
-                    "Transaction not found in mempool",
-                )
-            })
+            .cloned())
     }
 
     async fn mapping_value_exists(
@@ -142,6 +136,49 @@ impl AleoProviderForLander for MockProviderWithFixtures {
     ) -> ChainResult<bool> {
         // Default: mapping values don't exist (messages not delivered)
         Ok(false)
+    }
+}
+
+struct ErrorProvider;
+
+#[async_trait]
+impl AleoProviderForLander for ErrorProvider {
+    async fn submit_tx<I>(
+        &self,
+        _program_id: &str,
+        _function_name: &str,
+        _input: I,
+    ) -> ChainResult<H512>
+    where
+        I: IntoIterator<Item = String> + Send,
+        I::IntoIter: ExactSizeIterator,
+    {
+        unreachable!()
+    }
+
+    async fn request_confirmed_transaction(
+        &self,
+        _transaction_id: H512,
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
+        Err(hyperlane_core::ChainCommunicationError::from_other_str(
+            "temporary RPC failure",
+        ))
+    }
+
+    async fn request_unconfirmed_transaction(
+        &self,
+        _transaction_id: H512,
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
+        unreachable!()
+    }
+
+    async fn mapping_value_exists(
+        &self,
+        _program_id: &str,
+        _mapping_name: &str,
+        _mapping_key: &Plaintext<CurrentNetwork>,
+    ) -> ChainResult<bool> {
+        unreachable!()
     }
 }
 
@@ -205,6 +242,16 @@ async fn test_status_not_found() {
 
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), TransactionStatus::PendingInclusion);
+}
+
+#[tokio::test]
+async fn test_status_propagates_provider_errors() {
+    let result = get_tx_hash_status(&Arc::new(ErrorProvider), H512::random()).await;
+
+    assert!(matches!(
+        result,
+        Err(crate::LanderError::ChainCommunicationError(_))
+    ));
 }
 
 #[tokio::test]

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/submit.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/submit.rs
@@ -85,10 +85,10 @@ pub async fn submit_transaction<P: AleoProviderForLander>(
         .await
         .map_err(classify_aleo_error)?;
 
-    // Store transaction hash
-    if !tx.tx_hashes.contains(&tx_hash) {
-        tx.tx_hashes.push(tx_hash);
-    }
+    // Aleo delivery is verified through payload success criteria, so only the
+    // latest submission hash is needed for mempool/confirmation status.
+    tx.tx_hashes.clear();
+    tx.tx_hashes.push(tx_hash);
 
     info!(tx_uuid=?tx.uuid, ?tx_hash, "submitted Aleo transaction");
     Ok(())

--- a/rust/main/lander/src/adapter/chains/aleo/adapter/submit/tests.rs
+++ b/rust/main/lander/src/adapter/chains/aleo/adapter/submit/tests.rs
@@ -82,7 +82,7 @@ impl AleoProviderForLander for MockProviderWithError {
     async fn request_confirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
         Err(hyperlane_core::ChainCommunicationError::from_other_str(
             "Mock provider: get_confirmed_transaction not implemented",
         ))
@@ -91,7 +91,7 @@ impl AleoProviderForLander for MockProviderWithError {
     async fn request_unconfirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
         Err(hyperlane_core::ChainCommunicationError::from_other_str(
             "Mock provider: get_unconfirmed_transaction not implemented",
         ))
@@ -141,7 +141,7 @@ impl AleoProviderForLander for MockProvider {
     async fn request_confirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
         Err(hyperlane_core::ChainCommunicationError::from_other_str(
             "Mock provider: get_confirmed_transaction not implemented",
         ))
@@ -150,7 +150,7 @@ impl AleoProviderForLander for MockProvider {
     async fn request_unconfirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
         Err(hyperlane_core::ChainCommunicationError::from_other_str(
             "Mock provider: get_unconfirmed_transaction not implemented",
         ))
@@ -221,6 +221,17 @@ async fn test_submit_transaction_stores_tx_hash() {
     // Verify transaction hash was added
     assert_eq!(tx.tx_hashes.len(), 1);
     assert_ne!(tx.tx_hashes[0], H512::zero());
+}
+
+#[tokio::test]
+async fn test_submit_transaction_replaces_historical_hashes() {
+    let provider = MockProvider::new();
+    let mut tx = create_test_transaction();
+    tx.tx_hashes = (0..2_000).map(|_| H512::random()).collect();
+
+    submit_transaction(&provider, &mut tx).await.unwrap();
+
+    assert_eq!(tx.tx_hashes.len(), 1);
 }
 
 #[tokio::test]

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -184,6 +184,16 @@ impl InclusionStage {
             if let Err(err) =
                 Self::try_process_tx(tx.clone(), finality_stage_sender, state, pool).await
             {
+                if matches!(err, LanderError::ChannelSendFailure(_)) {
+                    error!(
+                        ?err,
+                        ?tx,
+                        "Failed to forward transaction. Retaining it for retry"
+                    );
+                    Self::update_inclusion_stage_metric(state, domain, &err);
+                    continue;
+                }
+
                 error!(?err, ?tx, "Error processing transaction. Dropping it");
 
                 let drop_reason = match &err {
@@ -390,6 +400,7 @@ impl InclusionStage {
             TransactionStatus::Included | TransactionStatus::Finalized => {
                 update_tx_status(state, &mut tx, tx_status.clone()).await?;
                 let tx_uuid = tx.uuid.clone();
+                pool.lock().await.insert(tx_uuid.clone(), tx.clone());
                 finality_stage_sender.send(tx).await.map_err(|err| {
                     tracing::error!(?err, "Failed to send tx to finality stage");
                     LanderError::ChannelSendFailure(Box::new(err))

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -380,6 +380,7 @@ impl InclusionStage {
             TransactionStatus::PendingInclusion | TransactionStatus::Mempool => {
                 info!(tx_uuid = ?tx.uuid, ?tx_status, "Transaction is pending inclusion");
                 update_tx_status(state, &mut tx, tx_status.clone()).await?;
+                pool.lock().await.insert(tx.uuid.clone(), tx.clone());
                 if !state.adapter.tx_ready_for_resubmission(&tx).await {
                     info!(?tx, "Transaction is not ready for resubmission");
                     return Ok(());

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -353,6 +353,7 @@ impl InclusionStage {
                     "Error reading transaction status. Retrying later"
                 );
                 Self::update_inclusion_stage_metric(state, &state.domain, &err);
+                state.store_tx(&tx).await;
                 return Ok(());
             }
             Err(err) => return Err(err),

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -336,19 +336,28 @@ impl InclusionStage {
         // Update the last status check timestamp before querying
         tx.last_status_check = Some(chrono::Utc::now());
 
-        let tx_status = call_until_success_or_nonretryable_error(
-            || state.adapter.tx_status(&tx),
-            "Querying transaction status",
-            state,
-        )
-        .await?;
-        info!(?tx, next_tx_status = ?tx_status, "Transaction status");
+        let tx_status = state.adapter.tx_status(&tx).await;
 
-        // Update the transaction in the pool with the new timestamp
+        // Persist the check timestamp even on provider failure so normal status
+        // backoff, rather than an in-call retry loop, controls the next attempt.
         {
             let mut pool_lock = pool.lock().await;
             pool_lock.insert(tx.uuid.clone(), tx.clone());
         }
+        let tx_status = match tx_status {
+            Ok(status) => status,
+            Err(err) if err.is_infra_error() => {
+                warn!(
+                    ?err,
+                    ?tx,
+                    "Error reading transaction status. Retrying later"
+                );
+                Self::update_inclusion_stage_metric(state, &state.domain, &err);
+                return Ok(());
+            }
+            Err(err) => return Err(err),
+        };
+        info!(?tx, next_tx_status = ?tx_status, "Transaction status");
 
         Self::try_process_tx_with_next_status(tx, tx_status, finality_stage_sender, state, pool)
             .await

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -341,6 +341,58 @@ async fn test_status_provider_error_keeps_tx_for_later_retry() {
 }
 
 #[tokio::test]
+async fn test_status_provider_error_preserves_latest_persisted_status() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_mock = calls.clone();
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_estimated_block_time()
+        .return_const(Duration::from_secs(1));
+    mock_adapter
+        .expect_tx_status()
+        .times(2)
+        .returning(
+            move |_| match calls_for_mock.fetch_add(1, Ordering::SeqCst) {
+                0 => Ok(TransactionStatus::Mempool),
+                _ => Err(LanderError::ChainCommunicationError(
+                    hyperlane_core::ChainCommunicationError::from_other_str(
+                        "temporary RPC failure",
+                    ),
+                )),
+            },
+        );
+    mock_adapter
+        .expect_tx_ready_for_resubmission()
+        .once()
+        .return_const(false);
+
+    let (state, pool) = reprocess_test_state(mock_adapter);
+    let tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    state.store_tx(&tx).await;
+    pool.lock().await.insert(tx.uuid.clone(), tx.clone());
+    let (finality_stage_sender, _finality_stage_receiver) = mpsc::channel(1);
+
+    InclusionStage::process_txs_step(&pool, &finality_stage_sender, &state, "test")
+        .await
+        .unwrap();
+    InclusionStage::process_txs_step(&pool, &finality_stage_sender, &state, "test")
+        .await
+        .unwrap();
+
+    let retained_tx = pool.lock().await.get(&tx.uuid).cloned().unwrap();
+    assert_eq!(retained_tx.status, TransactionStatus::Mempool);
+    assert!(retained_tx.last_status_check.is_some());
+    let persisted_tx = state
+        .tx_db
+        .retrieve_transaction_by_uuid(&tx.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(persisted_tx.status, TransactionStatus::Mempool);
+    assert!(persisted_tx.last_status_check.is_some());
+}
+
+#[tokio::test]
 async fn test_failed_simulation() {
     const TXS_TO_PROCESS: usize = 3;
 

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -307,6 +307,32 @@ async fn test_unincluded_txs_reach_mempool() {
 }
 
 #[tokio::test]
+async fn test_status_provider_error_keeps_tx_for_later_retry() {
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_estimated_block_time()
+        .return_const(Duration::from_secs(1));
+    mock_adapter.expect_tx_status().once().returning(|_| {
+        Err(LanderError::ChainCommunicationError(
+            hyperlane_core::ChainCommunicationError::from_other_str("temporary RPC failure"),
+        ))
+    });
+
+    let (state, pool) = reprocess_test_state(mock_adapter);
+    let tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    pool.lock().await.insert(tx.uuid.clone(), tx.clone());
+    let (finality_stage_sender, mut finality_stage_receiver) = mpsc::channel(1);
+
+    InclusionStage::process_txs_step(&pool, &finality_stage_sender, &state, "test")
+        .await
+        .unwrap();
+
+    let retained_tx = pool.lock().await.get(&tx.uuid).cloned().unwrap();
+    assert!(retained_tx.last_status_check.is_some());
+    assert!(finality_stage_receiver.try_recv().is_err());
+}
+
+#[tokio::test]
 async fn test_failed_simulation() {
     const TXS_TO_PROCESS: usize = 3;
 

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -14,10 +14,11 @@ use crate::dispatcher::{
 use crate::error::LanderError;
 use crate::payload::{DropReason as PayloadDropReason, PayloadStatus};
 use crate::tests::test_utils::{
-    are_all_txs_in_pool, are_no_txs_in_pool, create_random_txs_and_store_them, dummy_tx, tmp_dbs,
-    MockAdapter,
+    are_all_txs_in_pool, are_no_txs_in_pool, create_random_txs_and_store_them, dummy_tx,
+    initialize_payload_db, tmp_dbs, MockAdapter,
 };
 use crate::transaction::{DropReason as TxDropReason, Transaction, TransactionStatus};
+use crate::FullPayload;
 
 use super::{
     MAX_REPROCESS_TXS_POLL_RATE, MAX_TX_STATUS_CHECK_DELAY, REPROCESS_TXS_LIVENESS_RATE, STAGE_NAME,
@@ -390,6 +391,41 @@ async fn test_status_provider_error_preserves_latest_persisted_status() {
         .unwrap();
     assert_eq!(persisted_tx.status, TransactionStatus::Mempool);
     assert!(persisted_tx.last_status_check.is_some());
+}
+
+#[tokio::test]
+async fn test_finality_channel_error_preserves_latest_persisted_status() {
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_estimated_block_time()
+        .return_const(Duration::from_secs(1));
+    mock_adapter
+        .expect_tx_status()
+        .once()
+        .returning(|_| Ok(TransactionStatus::Included));
+
+    let (state, pool) = reprocess_test_state(mock_adapter);
+    let payload = FullPayload::random();
+    initialize_payload_db(&state.payload_db, &payload).await;
+    let tx = dummy_tx(vec![payload], TransactionStatus::PendingInclusion);
+    state.store_tx(&tx).await;
+    pool.lock().await.insert(tx.uuid.clone(), tx.clone());
+    let (finality_stage_sender, finality_stage_receiver) = mpsc::channel(1);
+    drop(finality_stage_receiver);
+
+    InclusionStage::process_txs_step(&pool, &finality_stage_sender, &state, "test")
+        .await
+        .unwrap();
+
+    let retained_tx = pool.lock().await.get(&tx.uuid).cloned().unwrap();
+    assert_eq!(retained_tx.status, TransactionStatus::Included);
+    assert_tx_status(
+        vec![tx],
+        &state.tx_db,
+        &state.payload_db,
+        TransactionStatus::Included,
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -320,6 +320,7 @@ async fn test_status_provider_error_keeps_tx_for_later_retry() {
 
     let (state, pool) = reprocess_test_state(mock_adapter);
     let tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    state.store_tx(&tx).await;
     pool.lock().await.insert(tx.uuid.clone(), tx.clone());
     let (finality_stage_sender, mut finality_stage_receiver) = mpsc::channel(1);
 
@@ -329,6 +330,13 @@ async fn test_status_provider_error_keeps_tx_for_later_retry() {
 
     let retained_tx = pool.lock().await.get(&tx.uuid).cloned().unwrap();
     assert!(retained_tx.last_status_check.is_some());
+    let persisted_tx = state
+        .tx_db
+        .retrieve_transaction_by_uuid(&tx.uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(persisted_tx.last_status_check.is_some());
     assert!(finality_stage_receiver.try_recv().is_err());
 }
 

--- a/rust/main/lander/src/tests/aleo/test_utils.rs
+++ b/rust/main/lander/src/tests/aleo/test_utils.rs
@@ -31,7 +31,7 @@ impl AleoProviderForLander for MockAleoProvider {
     async fn request_confirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
         Err(hyperlane_core::ChainCommunicationError::from_other_str(
             "Mock provider: get_confirmed_transaction not implemented",
         ))
@@ -40,7 +40,7 @@ impl AleoProviderForLander for MockAleoProvider {
     async fn request_unconfirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
         Err(hyperlane_core::ChainCommunicationError::from_other_str(
             "Mock provider: get_unconfirmed_transaction not implemented",
         ))

--- a/rust/main/lander/src/tests/aleo/tests_finality_stage.rs
+++ b/rust/main/lander/src/tests/aleo/tests_finality_stage.rs
@@ -56,7 +56,7 @@ impl AleoProviderForLander for MockAleoProviderForFinality {
     async fn request_confirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
         Err(ChainCommunicationError::from_other_str(
             "Mock provider: get_confirmed_transaction not implemented",
         ))
@@ -65,7 +65,7 @@ impl AleoProviderForLander for MockAleoProviderForFinality {
     async fn request_unconfirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
         Err(ChainCommunicationError::from_other_str(
             "Mock provider: get_unconfirmed_transaction not implemented",
         ))

--- a/rust/main/lander/src/tests/aleo/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/aleo/tests_inclusion_stage.rs
@@ -115,7 +115,7 @@ impl AleoProviderForLander for ConfigurableMockProvider {
     async fn request_confirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
         let mut counter = self.confirmed_counter.lock().unwrap();
         *counter += 1;
 
@@ -124,18 +124,16 @@ impl AleoProviderForLander for ConfigurableMockProvider {
                 // Parse confirmed transaction from JSON fixture
                 let tx: AleoConfirmedTransaction<CurrentNetwork> =
                     serde_json::from_str(data).expect("Failed to parse confirmed transaction");
-                Ok(tx)
+                Ok(Some(tx))
             }
-            None => Err(ChainCommunicationError::from_other_str(
-                "Transaction not confirmed yet",
-            )),
+            None => Ok(None),
         }
     }
 
     async fn request_unconfirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
         let mut counter = self.unconfirmed_counter.lock().unwrap();
         *counter += 1;
 
@@ -144,11 +142,9 @@ impl AleoProviderForLander for ConfigurableMockProvider {
                 // Parse unconfirmed transaction from JSON fixture
                 let tx: AleoUnconfirmedTransaction<CurrentNetwork> =
                     serde_json::from_str(data).expect("Failed to parse unconfirmed transaction");
-                Ok(tx)
+                Ok(Some(tx))
             }
-            None => Err(ChainCommunicationError::from_other_str(
-                "Transaction not found",
-            )),
+            None => Ok(None),
         }
     }
 
@@ -216,7 +212,7 @@ impl AleoProviderForLander for AleoErrorMockProvider {
     async fn request_confirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoConfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoConfirmedTransaction<CurrentNetwork>>> {
         Err(ChainCommunicationError::from_other_str(
             "Mock provider: get_confirmed_transaction not implemented",
         ))
@@ -225,7 +221,7 @@ impl AleoProviderForLander for AleoErrorMockProvider {
     async fn request_unconfirmed_transaction(
         &self,
         _transaction_id: H512,
-    ) -> ChainResult<AleoUnconfirmedTransaction<CurrentNetwork>> {
+    ) -> ChainResult<Option<AleoUnconfirmedTransaction<CurrentNetwork>>> {
         Err(ChainCommunicationError::from_other_str(
             "Mock provider: get_unconfirmed_transaction not implemented",
         ))

--- a/rust/main/lander/src/tests/aleo/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/aleo/tests_inclusion_stage.rs
@@ -8,7 +8,8 @@ use tokio::{select, sync::mpsc};
 use tracing_test::traced_test;
 
 use hyperlane_aleo::{
-    AleoConfirmedTransaction, AleoProviderForLander, AleoUnconfirmedTransaction, CurrentNetwork,
+    AleoConfirmedTransaction, AleoGetMappingValue, AleoProviderForLander, AleoSerialize,
+    AleoUnconfirmedTransaction, CurrentNetwork, DeliveryKey,
 };
 use hyperlane_core::{ChainCommunicationError, ChainResult, KnownHyperlaneDomain, H512};
 
@@ -842,11 +843,17 @@ async fn mock_aleo_tx(
     };
 
     let payload_uuid = PayloadUuid::random();
+    let delivery_key = DeliveryKey { id: [1u128, 1u128] };
+    let success_criteria = AleoGetMappingValue {
+        program_id: "mailbox.aleo".to_string(),
+        mapping_name: "deliveries".to_string(),
+        mapping_key: delivery_key.to_plaintext().unwrap(),
+    };
     let payload = FullPayload {
         details: PayloadDetails {
             uuid: payload_uuid.clone(),
             metadata: format!("test-payload-{}", payload_uuid),
-            success_criteria: Some(vec![1, 2, 3, 4]),
+            success_criteria: Some(serde_json::to_vec(&success_criteria).unwrap()),
         },
         data: serde_json::to_vec(&tx_data).unwrap(),
         to: H256::zero(),


### PR DESCRIPTION
## Incident

On 2026-08-31 the RC relayer triggered PD incident `Q3QM3TWGKR3Q7W`: Aleo transaction RPCs reached about 210 requests/second with an approximately 100% reported failure rate across both Provable endpoints. Block/height reads remained healthy and production was unaffected.

The RC database contained 7 active Aleo transactions with 6,390 persisted submission hashes: 439-1,961 hashes per transaction, averaging 913.

## Root cause

Lander's generic status path scanned every historical hash. For each hash, Aleo queried `transaction/confirmed` and then `transaction/unconfirmed`. A normal pre-confirmation 404 was represented as an RPC error, so the two-provider fallback made up to 4 HTTP attempts per endpoint lookup before the Aleo adapter swallowed the error as "not found."

That made a full scan of the observed RC state capable of 6,390 hashes x 2 lookups x 4 attempts = 51,120 HTTP requests. Successful resubmissions appended another hash, so work grew as O(historical submissions) and survived restarts in the transaction database.

[#9308](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9308) capped how frequently old inclusion entries are scanned, but not the width or in-call retries of each scan.

## Fix

- Check the Aleo delivery mapping first, then inspect only the latest submission hash when delivery is not yet recorded.
- Replace historical hashes with the latest hash once a successful Aleo submission is persisted.
- Do not re-prove/resubmit a transaction while its latest hash remains in the mempool.
- Treat confirmed/unconfirmed 404s as successful `None` responses; accept absence only after every healthy provider agrees, prefer any provider presence, and propagate ambiguous failures.
- Perform one status attempt per inclusion scan, persist the check timestamp to the transaction database, and retain the transaction for the existing backoff after transient RPC errors and restarts.
- Synchronize persisted inclusion transitions back into the in-memory pool. If the finality-stage handoff fails after an `Included`/`Finalized` transition, retain the latest state for retry instead of dropping a stale snapshot.
- Split `transaction_confirmed`, `transaction_unconfirmed`, and `transaction_broadcast` metrics so expected absence is no longer reported as a provider failure or mixed with broadcasts.

## Measured improvement

For the 7-transaction incident snapshot:

- Status work changes from up to 51,120 transaction HTTP requests per full sweep to at most 35 healthy-provider requests: 1 delivery lookup plus confirmed and unconfirmed lookups against 2 providers per transaction. That is a 99.93% reduction and changes scaling from O(6,390 historical hashes) to O(7 active transactions).
- Persisted hash history compacts from 439-1,961 hashes to 1 on the next successful submission: a 99.77%-99.95% reduction per affected transaction (913 to 1, or 99.89%, on average).
- A hash that is still in the mempool now causes 0 resubmissions instead of 1 every 60 seconds; resubmission resumes only after it is no longer observed there.
- A normal missing latest hash produces 4 successful absence checks across both providers instead of up to 8 failed fallback attempts.

Regression tests exercise 2,000 historical hashes and assert constant logical lookup width: 1 delivery lookup, 1 confirmed lookup, and 1 unconfirmed lookup. For unanimous absence, each optional lookup checks both configured RPCs, giving the 5-request per-transaction bound above. Fallback tests cover primary absence with secondary presence, unanimous absence, and ambiguous provider errors. Sequence regressions cover persisted backoff, a successful status transition followed by RPC failure, and a successful inclusion transition followed by finality-channel failure; they assert the in-memory pool, transaction DB, and payload DB retain the latest state.

## Validation

- `cargo test -p hyperlane-aleo --lib` - 75 passed
- `cargo test -p lander --lib --features aleo adapter::chains::aleo::adapter` - 73 passed
- `cargo test -p lander --lib --features aleo dispatcher::stages::inclusion_stage::tests` - 22 passed
- `cargo test -p lander --lib --features aleo status_provider_error` - 2 passed
- `cargo test -p lander --lib --features aleo finality_channel_error` - passed
- `cargo clippy -p lander --lib --features aleo -- -D warnings`
- `cargo fmt -p lander`; Rust pre-commit formatting hook passed

## Rollout / dependent work

Merge and roll this Aleo fix out before continuing draft [#9398](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9398). That PR parallelizes outer status reads; it and its dependent DAG should be rebased onto this bounded per-transaction status path so parallelism cannot amplify historical-hash fanout.

## RC validation

RC image `fffa993-20260831-182448` (`sha256:3cb5ed5e61c6027f4585ddc001be064e9308eef08a04d8822dfb0a906b4338b9`) was rolled to `omniscient-relayer-rc` after rebasing onto #9413. Against the retained incident database:

- Failed Aleo transaction RPC rate fell from 224 requests/second immediately before the rollout to 0 requests/second in two post-rollout samples: a 100% reduction.
- Total Aleo RPC rate stabilized at 0.75-0.8 requests/second, over 99.6% below the prior failed transaction stream.
- No `transaction*` metric series was emitted during the observation window; block, find, and program reads remained successful.
- The pod remained Ready on the expected digest with 0 restarts.
