### PR TITLE
chore(infra): disable radix in mainnet3 agent operations

### DIFF
--- a/typescript/infra/config/environments/mainnet3/agent.ts
+++ b/typescript/infra/config/environments/mainnet3/agent.ts
@@ -129,7 +129,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     plasma: true,
     polygon: true,
     pulsechain: true,
-    radix: true,
+    radix: false, // disabled — removed from agent operations per request
     robinhood: true,
     sei: true,
     solanamainnet: true,
@@ -214,7 +214,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     plasma: true,
     polygon: true,
     pulsechain: true,
-    radix: true,
+    radix: false, // disabled — removed from agent operations per request
     robinhood: true,
     sei: true,
     solanamainnet: true,
@@ -299,7 +299,7 @@ export const hyperlaneContextAgentChainConfig: AgentChainConfig<
     plasma: true,
     polygon: true,
     pulsechain: true,
-    radix: true,
+    radix: false, // disabled — removed from agent operations per request
     robinhood: true,
     sei: true,
     solanamainnet: true,


### PR DESCRIPTION
## Summary
- Set `radix: false` for the Validator, Relayer, and Scraper roles in mainnet3 `agent.ts`, removing Radix from agent operations.

Requested by @Nam Chu Hoai. Follows the same pattern as prior single-chain agent disables (e.g. nibiru #9089).

## Test plan
- [ ] Config-only change; deploy mainnet3 agents to take effect.

Source Haggis thread: https://haggis.services.hyperlane.xyz/threads/01M1CF831HG9QD3BDMDWK00YNJ

🤖 Generated with [Claude Code](https://claude.com/claude-code)