### PR TITLE
feat(middleware): Express Web2 API calls inside Mailbox & ISM abstraction (#4703)

### DIFF
--- a/solidity/contracts/interfaces/isms/IWeb2SecurityModule.sol
+++ b/solidity/contracts/interfaces/isms/IWeb2SecurityModule.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {IInterchainSecurityModule} from "../IInterchainSecurityModule.sol";
+
+interface IWeb2SecurityModule is IInterchainSecurityModule {
+    event SignersUpdated(address[] signers, uint8 threshold);
+    event EndpointRegistered(bytes32 indexed endpointHash);
+    event EndpointUnregistered(bytes32 indexed endpointHash);
+    event Web2DomainUpdated(uint32 oldDomain, uint32 newDomain);
+    event AttestationAgeLimitUpdated(uint256 oldLimit, uint256 newLimit);
+
+    function web2Domain() external view returns (uint32);
+
+    function threshold() external view returns (uint8);
+
+    function signers() external view returns (address[] memory);
+
+    function isAuthorizedSigner(address _signer) external view returns (bool);
+
+    function isAuthorizedEndpoint(
+        bytes32 _endpointHash
+    ) external view returns (bool);
+
+    function requireEndpointAuthorization() external view returns (bool);
+
+    function maxAttestationAge() external view returns (uint256);
+}

--- a/solidity/contracts/interfaces/middleware/IWeb2ApiRouter.sol
+++ b/solidity/contracts/interfaces/middleware/IWeb2ApiRouter.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {Web2Message} from "../../middleware/libs/Web2Message.sol";
+
+interface IWeb2ApiRouter {
+    /**
+     * @notice Emitted when a new Web2 API request is dispatched to the Web2 domain.
+     * @param requestId Unique identifier for the request.
+     * @param web2Domain The domain ID corresponding to Web2.
+     * @param endpointHash The hash of the URL (keccak256(bytes(url))).
+     * @param sender The address initiating the API request.
+     * @param url The target Web2 endpoint URL.
+     * @param method The HTTP method (GET, POST, etc.).
+     */
+    event ApiRequestDispatched(
+        bytes32 indexed requestId,
+        uint32 indexed web2Domain,
+        bytes32 indexed endpointHash,
+        address sender,
+        string url,
+        Web2Message.HttpMethod method
+    );
+
+    /**
+     * @notice Emitted when a Web2 API response is received from the Web2 domain.
+     * @param requestId Unique identifier for the request.
+     * @param originDomain The origin domain (Web2 domain).
+     * @param endpointHash The hash of the URL.
+     * @param statusCode The HTTP status code returned.
+     * @param recipient The callback recipient contract.
+     */
+    event ApiResponseReceived(
+        bytes32 indexed requestId,
+        uint32 indexed originDomain,
+        bytes32 indexed endpointHash,
+        uint256 statusCode,
+        address recipient
+    );
+
+    /**
+     * @notice Returns the designated Web2 domain ID.
+     */
+    function web2Domain() external view returns (uint32);
+
+    /**
+     * @notice Dispatches an API request using structured RequestParams.
+     * @param _params Parameters defining target domain, method, url, headers, body, callback, and callback data.
+     * @return requestId The unique ID assigned to this request.
+     * @return messageId The Hyperlane message ID returned by Mailbox.dispatch.
+     */
+    function requestApi(
+        Web2Message.RequestParams calldata _params
+    ) external payable returns (bytes32 requestId, bytes32 messageId);
+
+    /**
+     * @notice Quotes the fee required to dispatch a Web2 API request.
+     * @param _params Request parameters.
+     * @return fee The estimated gas payment / dispatch fee.
+     */
+    function quoteApiRequest(
+        Web2Message.RequestParams calldata _params
+    ) external view returns (uint256 fee);
+}

--- a/solidity/contracts/interfaces/middleware/IWeb2Receiver.sol
+++ b/solidity/contracts/interfaces/middleware/IWeb2Receiver.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+interface IWeb2Receiver {
+    /**
+     * @notice Handles an incoming Web2 API response delivered from Hyperlane.
+     * @param requestId The unique identifier for the originating request.
+     * @param origin The domain ID of the Web2 domain.
+     * @param endpointHash The bytes32 hash of the API URL (keccak256(bytes(url))).
+     * @param statusCode The HTTP status code returned by the API (e.g. 200, 404, 500).
+     * @param responseBody The raw byte payload returned in the HTTP response.
+     * @param callbackData Contextual data passed by the requester when dispatching.
+     */
+    function handleWeb2Response(
+        bytes32 requestId,
+        uint32 origin,
+        bytes32 endpointHash,
+        uint256 statusCode,
+        bytes calldata responseBody,
+        bytes calldata callbackData
+    ) external payable;
+}

--- a/solidity/contracts/isms/libs/Web2IsmMetadata.sol
+++ b/solidity/contracts/isms/libs/Web2IsmMetadata.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/**
+ * @title Web2IsmMetadata
+ * @notice Parsing and formatting library for Web2 Interchain Security Module metadata.
+ *
+ * Format of metadata:
+ * [   0:  32] Endpoint hash (keccak256(bytes(url)))
+ * [  32:  40] Timestamp (uint64)
+ * [  40:  72] Request ID (bytes32)
+ * [  72:????] Keeper signatures (length := threshold * 65)
+ */
+library Web2IsmMetadata {
+    uint8 private constant ENDPOINT_HASH_OFFSET = 0;
+    uint8 private constant TIMESTAMP_OFFSET = 32;
+    uint8 private constant REQUEST_ID_OFFSET = 40;
+    uint8 private constant SIGNATURES_OFFSET = 72;
+    uint8 private constant SIGNATURE_LENGTH = 65;
+
+    /**
+     * @notice Returns the endpoint hash encoded in metadata.
+     * @param _metadata Encoded Web2 ISM metadata.
+     * @return bytes32 hash of the API URL.
+     */
+    function endpointHash(
+        bytes calldata _metadata
+    ) internal pure returns (bytes32) {
+        return
+            bytes32(_metadata[ENDPOINT_HASH_OFFSET:ENDPOINT_HASH_OFFSET + 32]);
+    }
+
+    /**
+     * @notice Returns the timestamp when the keeper executed the request.
+     * @param _metadata Encoded Web2 ISM metadata.
+     * @return uint64 timestamp.
+     */
+    function timestamp(
+        bytes calldata _metadata
+    ) internal pure returns (uint64) {
+        return uint64(bytes8(_metadata[TIMESTAMP_OFFSET:TIMESTAMP_OFFSET + 8]));
+    }
+
+    /**
+     * @notice Returns the request ID associated with the Web2 call.
+     * @param _metadata Encoded Web2 ISM metadata.
+     * @return bytes32 request ID.
+     */
+    function requestId(
+        bytes calldata _metadata
+    ) internal pure returns (bytes32) {
+        return bytes32(_metadata[REQUEST_ID_OFFSET:REQUEST_ID_OFFSET + 32]);
+    }
+
+    /**
+     * @notice Returns the keeper ECDSA signature at `_index`.
+     * @param _metadata Encoded Web2 ISM metadata.
+     * @param _index The index of the signature.
+     * @return The 65-byte signature.
+     */
+    function signatureAt(
+        bytes calldata _metadata,
+        uint256 _index
+    ) internal pure returns (bytes calldata) {
+        uint256 start = SIGNATURES_OFFSET + (_index * SIGNATURE_LENGTH);
+        uint256 end = start + SIGNATURE_LENGTH;
+        require(
+            end <= _metadata.length,
+            "Web2IsmMetadata: signature index out of bounds"
+        );
+        return _metadata[start:end];
+    }
+
+    /**
+     * @notice Returns the total number of signatures in metadata.
+     * @param _metadata Encoded Web2 ISM metadata.
+     * @return count Number of 65-byte signatures.
+     */
+    function signatureCount(
+        bytes calldata _metadata
+    ) internal pure returns (uint256) {
+        if (_metadata.length < SIGNATURES_OFFSET) {
+            return 0;
+        }
+        uint256 sigBytes = _metadata.length - SIGNATURES_OFFSET;
+        require(
+            sigBytes % SIGNATURE_LENGTH == 0,
+            "Web2IsmMetadata: invalid signatures length"
+        );
+        return sigBytes / SIGNATURE_LENGTH;
+    }
+
+    /**
+     * @notice Formats metadata from individual fields.
+     * @param _endpointHash The hash of the URL.
+     * @param _timestamp The execution timestamp.
+     * @param _requestId The request ID.
+     * @param _signatures Concatenated 65-byte signatures.
+     * @return Formatted metadata bytes.
+     */
+    function formatMetadata(
+        bytes32 _endpointHash,
+        uint64 _timestamp,
+        bytes32 _requestId,
+        bytes memory _signatures
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                _endpointHash,
+                _timestamp,
+                _requestId,
+                _signatures
+            );
+    }
+}

--- a/solidity/contracts/isms/web2/Web2SecurityModule.sol
+++ b/solidity/contracts/isms/web2/Web2SecurityModule.sol
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ External Imports ============
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+// ============ Internal Imports ============
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {IWeb2SecurityModule} from "../../interfaces/isms/IWeb2SecurityModule.sol";
+import {Web2IsmMetadata} from "../libs/Web2IsmMetadata.sol";
+import {Message} from "../../libs/Message.sol";
+import {PackageVersioned} from "../../PackageVersioned.sol";
+
+/**
+ * @title Web2SecurityModule
+ * @notice Interchain Security Module designed to authenticate Web2 API oracle responses
+ * delivered to smart contracts via Hyperlane Mailboxes.
+ * @dev Verifies that incoming messages originate from the designated Web2 domain,
+ * match registered API endpoints (if enabled), contain fresh execution timestamps,
+ * and carry m-of-n ECDSA signatures from authorized keepers / oracle signers.
+ */
+contract Web2SecurityModule is IWeb2SecurityModule, Ownable, PackageVersioned {
+    using Message for bytes;
+    using Web2IsmMetadata for bytes;
+
+    // ============ Constants ============
+    uint8 public constant override moduleType =
+        uint8(IInterchainSecurityModule.Types.MESSAGE_ID_MULTISIG);
+
+    // ============ Public Storage ============
+    uint32 public override web2Domain;
+    uint8 public override threshold;
+    uint256 public override maxAttestationAge;
+    bool public override requireEndpointAuthorization;
+
+    address[] internal _signers;
+    mapping(address => bool) internal _isSigner;
+    mapping(bytes32 => bool) internal _authorizedEndpoints;
+
+    // ============ Constructor ============
+    /**
+     * @notice Initializes the Web2SecurityModule.
+     * @param _owner The contract owner.
+     * @param _web2Domain The domain ID designating Web2 callers.
+     * @param _initialSigners Array of authorized keeper/oracle signer addresses.
+     * @param _threshold Required number of unique keeper signatures (m-of-n).
+     * @param _maxAttestationAge Maximum age (in seconds) for attestation timestamps (0 to disable).
+     * @param _requireEndpointAuth True if only whitelisted endpoint hashes can send responses.
+     */
+    constructor(
+        address _owner,
+        uint32 _web2Domain,
+        address[] memory _initialSigners,
+        uint8 _threshold,
+        uint256 _maxAttestationAge,
+        bool _requireEndpointAuth
+    ) Ownable() {
+        require(_owner != address(0), "Web2SecurityModule: invalid owner");
+        web2Domain = _web2Domain;
+        maxAttestationAge = _maxAttestationAge;
+        requireEndpointAuthorization = _requireEndpointAuth;
+
+        _setSignersAndThreshold(_initialSigners, _threshold);
+        _transferOwnership(_owner);
+    }
+
+    // ============ External / Admin Functions ============
+
+    /**
+     * @notice Sets the designated Web2 domain ID.
+     * @param _newDomain New domain ID.
+     */
+    function setWeb2Domain(uint32 _newDomain) external onlyOwner {
+        uint32 old = web2Domain;
+        web2Domain = _newDomain;
+        emit Web2DomainUpdated(old, _newDomain);
+    }
+
+    /**
+     * @notice Updates the maximum age of keeper attestations.
+     * @param _newMaxAge Max age in seconds.
+     */
+    function setMaxAttestationAge(uint256 _newMaxAge) external onlyOwner {
+        uint256 old = maxAttestationAge;
+        maxAttestationAge = _newMaxAge;
+        emit AttestationAgeLimitUpdated(old, _newMaxAge);
+    }
+
+    /**
+     * @notice Toggles endpoint authorization enforcement.
+     * @param _required True to restrict responses to registered endpoints.
+     */
+    function setRequireEndpointAuthorization(
+        bool _required
+    ) external onlyOwner {
+        requireEndpointAuthorization = _required;
+    }
+
+    /**
+     * @notice Registers an authorized API endpoint hash.
+     * @param _endpointHash Hash of the API URL (keccak256(bytes(url))).
+     */
+    function registerEndpoint(bytes32 _endpointHash) external onlyOwner {
+        _authorizedEndpoints[_endpointHash] = true;
+        emit EndpointRegistered(_endpointHash);
+    }
+
+    /**
+     * @notice Batch registers authorized endpoint hashes.
+     * @param _endpointHashes Array of endpoint hashes.
+     */
+    function registerEndpoints(
+        bytes32[] calldata _endpointHashes
+    ) external onlyOwner {
+        for (uint256 i = 0; i < _endpointHashes.length; i++) {
+            _authorizedEndpoints[_endpointHashes[i]] = true;
+            emit EndpointRegistered(_endpointHashes[i]);
+        }
+    }
+
+    /**
+     * @notice Unregisters an API endpoint hash.
+     * @param _endpointHash Hash of the API URL.
+     */
+    function unregisterEndpoint(bytes32 _endpointHash) external onlyOwner {
+        _authorizedEndpoints[_endpointHash] = false;
+        emit EndpointUnregistered(_endpointHash);
+    }
+
+    /**
+     * @notice Sets authorized keeper signers and threshold.
+     * @param _newSigners New array of keeper signer addresses.
+     * @param _threshold Required signatures threshold.
+     */
+    function setSignersAndThreshold(
+        address[] calldata _newSigners,
+        uint8 _threshold
+    ) external onlyOwner {
+        _setSignersAndThreshold(_newSigners, _threshold);
+    }
+
+    // ============ View Functions ============
+
+    function signers() external view override returns (address[] memory) {
+        return _signers;
+    }
+
+    function isAuthorizedSigner(
+        address _signer
+    ) external view override returns (bool) {
+        return _isSigner[_signer];
+    }
+
+    function isAuthorizedEndpoint(
+        bytes32 _endpointHash
+    ) external view override returns (bool) {
+        return _authorizedEndpoints[_endpointHash];
+    }
+
+    /**
+     * @notice Computes the cryptographic digest expected to be signed by keepers.
+     * @param _origin Origin domain of the message.
+     * @param _sender Sender address/identifier on origin.
+     * @param _recipient Recipient address on destination.
+     * @param _messageId Unique Hyperlane message ID.
+     * @param _endpointHash Hash of the API endpoint URL.
+     * @param _timestamp Execution timestamp.
+     * @param _requestId Unique request identifier.
+     * @param _bodyHash Keccak256 hash of the message body.
+     * @return Formatted EIP-191 Ethereum signed message digest.
+     */
+    function computeDigest(
+        uint32 _origin,
+        bytes32 _sender,
+        bytes32 _recipient,
+        bytes32 _messageId,
+        bytes32 _endpointHash,
+        uint64 _timestamp,
+        bytes32 _requestId,
+        bytes32 _bodyHash
+    ) public pure returns (bytes32) {
+        bytes32 hash = keccak256(
+            abi.encode(
+                _origin,
+                _sender,
+                _recipient,
+                _messageId,
+                _endpointHash,
+                _timestamp,
+                _requestId,
+                _bodyHash
+            )
+        );
+        return ECDSA.toEthSignedMessageHash(hash);
+    }
+
+    // ============ Verification ============
+
+    /**
+     * @inheritdoc IInterchainSecurityModule
+     * @notice Verifies that the Web2 message is validly signed and authenticated.
+     * @param _metadata Metadata containing timestamp, endpointHash, requestId, and keeper signatures.
+     * @param _message Hyperlane formatted interchain message.
+     * @return True if authentication succeeds.
+     */
+    function verify(
+        bytes calldata _metadata,
+        bytes calldata _message
+    ) external view override returns (bool) {
+        require(
+            _message.origin() == web2Domain,
+            "Web2SecurityModule: invalid origin domain"
+        );
+
+        if (requireEndpointAuthorization) {
+            require(
+                _authorizedEndpoints[_message.sender()],
+                "Web2SecurityModule: unauthorized endpoint sender"
+            );
+        }
+
+        (uint64 ts, bytes32 epHash) = _validateMetadata(
+            _metadata,
+            _message.sender()
+        );
+
+        require(
+            _metadata.signatureCount() >= threshold && threshold > 0,
+            "Web2SecurityModule: insufficient signatures"
+        );
+
+        bytes32 digest = _computeDigest(_metadata, _message, epHash, ts);
+
+        _verifySignatures(_metadata, digest);
+
+        return true;
+    }
+
+    // ============ Internal Functions ============
+
+    function _computeDigest(
+        bytes calldata _metadata,
+        bytes calldata _message,
+        bytes32 _endpointHash,
+        uint64 _timestamp
+    ) internal view returns (bytes32) {
+        bytes32 hash = keccak256(
+            abi.encode(
+                web2Domain,
+                _message.sender(),
+                _message.recipient(),
+                _message.id(),
+                _endpointHash,
+                _timestamp,
+                _metadata.requestId(),
+                keccak256(_message.body())
+            )
+        );
+        return ECDSA.toEthSignedMessageHash(hash);
+    }
+
+    function _validateMetadata(
+        bytes calldata _metadata,
+        bytes32 _sender
+    ) internal view returns (uint64 ts, bytes32 epHash) {
+        epHash = _metadata.endpointHash();
+        require(
+            _sender == epHash,
+            "Web2SecurityModule: sender mismatch with metadata endpoint"
+        );
+
+        ts = _metadata.timestamp();
+        if (maxAttestationAge > 0) {
+            require(
+                block.timestamp >= ts,
+                "Web2SecurityModule: future timestamp"
+            );
+            require(
+                block.timestamp - ts <= maxAttestationAge,
+                "Web2SecurityModule: attestation expired"
+            );
+        }
+    }
+
+    function _verifySignatures(
+        bytes calldata _metadata,
+        bytes32 _digest
+    ) internal view {
+        address prevSigner = address(0);
+        for (uint256 i = 0; i < threshold; i++) {
+            address signer = ECDSA.recover(_digest, _metadata.signatureAt(i));
+            require(_isSigner[signer], "Web2SecurityModule: invalid signer");
+            require(
+                signer > prevSigner,
+                "Web2SecurityModule: signatures must be strictly ascending and unique"
+            );
+            prevSigner = signer;
+        }
+    }
+
+    function _setSignersAndThreshold(
+        address[] memory _newSigners,
+        uint8 _threshold
+    ) internal {
+        require(_threshold > 0, "Web2SecurityModule: threshold must be > 0");
+        require(
+            _newSigners.length >= _threshold,
+            "Web2SecurityModule: signers count < threshold"
+        );
+
+        // Clear previous signers mapping
+        for (uint256 i = 0; i < _signers.length; i++) {
+            _isSigner[_signers[i]] = false;
+        }
+
+        _signers = new address[](_newSigners.length);
+        address prevSigner = address(0);
+        for (uint256 i = 0; i < _newSigners.length; i++) {
+            address s = _newSigners[i];
+            require(
+                s != address(0),
+                "Web2SecurityModule: invalid signer address"
+            );
+            require(
+                s > prevSigner,
+                "Web2SecurityModule: signers must be unique and in ascending order"
+            );
+            _signers[i] = s;
+            _isSigner[s] = true;
+            prevSigner = s;
+        }
+
+        threshold = _threshold;
+        emit SignersUpdated(_signers, _threshold);
+    }
+}

--- a/solidity/contracts/middleware/Web2ApiRouter.sol
+++ b/solidity/contracts/middleware/Web2ApiRouter.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+// ============ External Imports ============
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// ============ Internal Imports ============
+import {Router} from "../client/Router.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
+import {PackageVersioned} from "../PackageVersioned.sol";
+import {IWeb2ApiRouter} from "../interfaces/middleware/IWeb2ApiRouter.sol";
+import {IWeb2Receiver} from "../interfaces/middleware/IWeb2Receiver.sol";
+import {Web2Message} from "./libs/Web2Message.sol";
+
+/**
+ * @title Web2ApiRouter
+ * @notice Router contract that facilitates bidirectional communication between on-chain smart contracts
+ * and off-chain Web2 APIs using the Hyperlane Mailbox and ISM abstraction.
+ */
+contract Web2ApiRouter is Router, IWeb2ApiRouter {
+    using TypeCasts for address;
+    using TypeCasts for bytes32;
+    using Web2Message for bytes;
+
+    // ============ Public State ============
+    uint32 public override web2Domain;
+    uint256 private _requestNonce;
+
+    // ============ Constructor ============
+    constructor(address _mailbox, uint32 _web2Domain) Router(_mailbox) {
+        web2Domain = _web2Domain;
+    }
+
+    // ============ Initializer ============
+    function initialize(
+        address _hook,
+        address _interchainSecurityModule,
+        address _owner,
+        uint32 _web2Domain
+    ) external initializer {
+        _MailboxClient_initialize(_hook, _interchainSecurityModule, _owner);
+        web2Domain = _web2Domain;
+    }
+
+    // ============ Owner Settings ============
+    function setWeb2Domain(uint32 _newDomain) external onlyOwner {
+        web2Domain = _newDomain;
+    }
+
+    // ============ External API Dispatch ============
+
+    /**
+     * @inheritdoc IWeb2ApiRouter
+     */
+    function requestApi(
+        Web2Message.RequestParams calldata _params
+    ) external payable override returns (bytes32 requestId, bytes32 messageId) {
+        uint32 destDomain = _params.targetDomain == 0
+            ? web2Domain
+            : _params.targetDomain;
+        bytes32 endpointHash = keccak256(bytes(_params.url));
+
+        requestId = _generateRequestId();
+
+        bytes memory messageBody = Web2Message.formatRequest(
+            requestId,
+            msg.sender.addressToBytes32(),
+            _params
+        );
+
+        emit ApiRequestDispatched(
+            requestId,
+            destDomain,
+            endpointHash,
+            msg.sender,
+            _params.url,
+            _params.method
+        );
+
+        messageId = mailbox.dispatch{value: msg.value}(
+            destDomain,
+            endpointHash,
+            messageBody,
+            "",
+            hook
+        );
+    }
+
+    /**
+     * @inheritdoc IWeb2ApiRouter
+     */
+    function quoteApiRequest(
+        Web2Message.RequestParams calldata _params
+    ) external view override returns (uint256 fee) {
+        uint32 destDomain = _params.targetDomain == 0
+            ? web2Domain
+            : _params.targetDomain;
+        bytes32 endpointHash = keccak256(bytes(_params.url));
+
+        bytes memory messageBody = Web2Message.formatRequest(
+            bytes32(0),
+            msg.sender.addressToBytes32(),
+            _params
+        );
+
+        return
+            mailbox.quoteDispatch(
+                destDomain,
+                endpointHash,
+                messageBody,
+                "",
+                hook
+            );
+    }
+
+    // ============ Inbound Message Handling ============
+
+    /**
+     * @notice Handles incoming messages delivered by the Mailbox.
+     */
+    function handle(
+        uint32 _origin,
+        bytes32 _sender,
+        bytes calldata _message
+    ) external payable virtual override onlyMailbox {
+        if (_origin == web2Domain) {
+            _handle(_origin, _sender, _message);
+        } else {
+            bytes32 _router = _mustHaveRemoteRouter(_origin);
+            require(
+                _router == _sender,
+                "Enrolled router does not match sender"
+            );
+            _handle(_origin, _sender, _message);
+        }
+    }
+
+    /**
+     * @notice Processes the decoded Web2 response and triggers the recipient callback.
+     */
+    function _handle(
+        uint32 _origin,
+        bytes32 _sender,
+        bytes calldata _message
+    ) internal virtual override {
+        Web2Message.Response memory response = Web2Message.decodeResponse(
+            _message
+        );
+
+        address recipient = response.callbackAddress.bytes32ToAddress();
+
+        emit ApiResponseReceived(
+            response.requestId,
+            _origin,
+            _sender,
+            response.statusCode,
+            recipient
+        );
+
+        if (recipient != address(0)) {
+            IWeb2Receiver(recipient).handleWeb2Response{value: msg.value}(
+                response.requestId,
+                _origin,
+                _sender,
+                response.statusCode,
+                response.responseBody,
+                response.callbackData
+            );
+        }
+    }
+
+    // ============ Internal Helpers ============
+
+    function _generateRequestId() internal returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    block.chainid,
+                    address(this),
+                    msg.sender,
+                    _requestNonce++,
+                    block.timestamp
+                )
+            );
+    }
+}

--- a/solidity/contracts/middleware/libs/Web2Message.sol
+++ b/solidity/contracts/middleware/libs/Web2Message.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {TypeCasts} from "../../libs/TypeCasts.sol";
+
+/**
+ * @title Web2Message Library
+ * @notice Serializes and deserializes Web2 API requests and responses formatted for Hyperlane Mailbox messaging.
+ */
+library Web2Message {
+    using TypeCasts for address;
+    using TypeCasts for bytes32;
+
+    enum HttpMethod {
+        GET,
+        POST,
+        PUT,
+        DELETE,
+        PATCH,
+        HEAD
+    }
+
+    enum MessageType {
+        REQUEST,
+        RESPONSE
+    }
+
+    struct RequestParams {
+        uint32 targetDomain;
+        HttpMethod method;
+        string url;
+        string headers;
+        bytes body;
+        address callbackAddress;
+        bytes callbackData;
+    }
+
+    struct Request {
+        bytes32 requestId;
+        bytes32 sender;
+        HttpMethod method;
+        string url;
+        string headers;
+        bytes body;
+        bytes32 callbackAddress;
+        bytes callbackData;
+    }
+
+    struct Response {
+        bytes32 requestId;
+        bytes32 callbackAddress;
+        uint256 statusCode;
+        string headers;
+        bytes responseBody;
+        bytes callbackData;
+    }
+
+    /**
+     * @notice Formats and encodes an outgoing Web2 API request from RequestParams calldata.
+     */
+    function formatRequest(
+        bytes32 _requestId,
+        bytes32 _sender,
+        RequestParams calldata _params
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encode(
+                MessageType.REQUEST,
+                _requestId,
+                _sender,
+                _params.method,
+                _params.url,
+                _params.headers,
+                _params.body,
+                _params.callbackAddress.addressToBytes32(),
+                _params.callbackData
+            );
+    }
+
+    /**
+     * @notice Formats and encodes an outgoing Web2 API request from a struct.
+     */
+    function encodeRequest(
+        Request memory req
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encode(
+                MessageType.REQUEST,
+                req.requestId,
+                req.sender,
+                req.method,
+                req.url,
+                req.headers,
+                req.body,
+                req.callbackAddress,
+                req.callbackData
+            );
+    }
+
+    /**
+     * @notice Decodes an incoming Web2 API request.
+     */
+    function decodeRequest(
+        bytes calldata data
+    ) internal pure returns (Request memory req) {
+        MessageType msgType;
+        (
+            msgType,
+            req.requestId,
+            req.sender,
+            req.method,
+            req.url,
+            req.headers,
+            req.body,
+            req.callbackAddress,
+            req.callbackData
+        ) = abi.decode(
+            data,
+            (
+                MessageType,
+                bytes32,
+                bytes32,
+                HttpMethod,
+                string,
+                string,
+                bytes,
+                bytes32,
+                bytes
+            )
+        );
+        require(msgType == MessageType.REQUEST, "Web2Message: not a request");
+        return req;
+    }
+
+    /**
+     * @notice Formats and encodes a Web2 API response from memory parameters.
+     */
+    function formatResponse(
+        bytes32 _requestId,
+        bytes32 _callbackAddress,
+        uint256 _statusCode,
+        string memory _headers,
+        bytes memory _responseBody,
+        bytes memory _callbackData
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encode(
+                MessageType.RESPONSE,
+                _requestId,
+                _callbackAddress,
+                _statusCode,
+                _headers,
+                _responseBody,
+                _callbackData
+            );
+    }
+
+    /**
+     * @notice Formats and encodes a Web2 API response from a struct.
+     */
+    function encodeResponse(
+        Response memory resp
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encode(
+                MessageType.RESPONSE,
+                resp.requestId,
+                resp.callbackAddress,
+                resp.statusCode,
+                resp.headers,
+                resp.responseBody,
+                resp.callbackData
+            );
+    }
+
+    /**
+     * @notice Decodes an incoming Web2 API response.
+     */
+    function decodeResponse(
+        bytes calldata data
+    ) internal pure returns (Response memory resp) {
+        MessageType msgType;
+        (
+            msgType,
+            resp.requestId,
+            resp.callbackAddress,
+            resp.statusCode,
+            resp.headers,
+            resp.responseBody,
+            resp.callbackData
+        ) = abi.decode(
+            data,
+            (MessageType, bytes32, bytes32, uint256, string, bytes, bytes)
+        );
+        require(msgType == MessageType.RESPONSE, "Web2Message: not a response");
+        return resp;
+    }
+
+    /**
+     * @notice Returns the message type of the raw message body.
+     */
+    function messageType(
+        bytes calldata data
+    ) internal pure returns (MessageType) {
+        return abi.decode(data, (MessageType));
+    }
+}

--- a/solidity/contracts/test/TestWeb2Receiver.sol
+++ b/solidity/contracts/test/TestWeb2Receiver.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+import {IWeb2Receiver} from "../interfaces/middleware/IWeb2Receiver.sol";
+import {IWeb2ApiRouter} from "../interfaces/middleware/IWeb2ApiRouter.sol";
+import {Web2Message} from "../middleware/libs/Web2Message.sol";
+
+contract TestWeb2Receiver is IWeb2Receiver {
+    bytes32 public lastRequestId;
+    uint32 public lastOrigin;
+    bytes32 public lastEndpointHash;
+    uint256 public lastStatusCode;
+    bytes public lastResponseBody;
+    bytes public lastCallbackData;
+    uint256 public responseCount;
+
+    bool public shouldRevert;
+
+    event TestResponseHandled(
+        bytes32 indexed requestId,
+        uint32 origin,
+        bytes32 endpointHash,
+        uint256 statusCode,
+        bytes responseBody,
+        bytes callbackData
+    );
+
+    function setShouldRevert(bool _revert) external {
+        shouldRevert = _revert;
+    }
+
+    function dispatchViaRouter(
+        address _router,
+        uint32 _web2Domain,
+        Web2Message.HttpMethod _method,
+        string calldata _url,
+        string calldata _headers,
+        bytes calldata _body,
+        bytes calldata _callbackData
+    ) external payable returns (bytes32 requestId, bytes32 messageId) {
+        Web2Message.RequestParams memory params = Web2Message.RequestParams({
+            targetDomain: _web2Domain,
+            method: _method,
+            url: _url,
+            headers: _headers,
+            body: _body,
+            callbackAddress: address(this),
+            callbackData: _callbackData
+        });
+        return IWeb2ApiRouter(_router).requestApi{value: msg.value}(params);
+    }
+
+    function handleWeb2Response(
+        bytes32 requestId,
+        uint32 origin,
+        bytes32 endpointHash,
+        uint256 statusCode,
+        bytes calldata responseBody,
+        bytes calldata callbackData
+    ) external payable override {
+        require(!shouldRevert, "TestWeb2Receiver: intentional revert");
+
+        lastRequestId = requestId;
+        lastOrigin = origin;
+        lastEndpointHash = endpointHash;
+        lastStatusCode = statusCode;
+        lastResponseBody = responseBody;
+        lastCallbackData = callbackData;
+        responseCount++;
+
+        emit TestResponseHandled(
+            requestId,
+            origin,
+            endpointHash,
+            statusCode,
+            responseBody,
+            callbackData
+        );
+    }
+}

--- a/solidity/test/isms/Web2SecurityModule.t.sol
+++ b/solidity/test/isms/Web2SecurityModule.t.sol
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {Web2SecurityModule} from "../../contracts/isms/web2/Web2SecurityModule.sol";
+import {Web2IsmMetadata} from "../../contracts/isms/libs/Web2IsmMetadata.sol";
+import {Message} from "../../contracts/libs/Message.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+
+contract Web2SecurityModuleTest is Test {
+    using TypeCasts for address;
+    using TypeCasts for bytes32;
+
+    Web2SecurityModule public ism;
+
+    uint32 public web2Domain = 999;
+    uint32 public localDomain = 123;
+    uint8 public threshold = 2;
+    uint256 public maxAttestationAge = 300; // 5 minutes
+
+    uint256 internal key1 = 0x1111;
+    uint256 internal key2 = 0x2222;
+    uint256 internal key3 = 0x3333;
+    uint256 internal unauthorizedKey = 0x9999;
+
+    address internal signer1;
+    address internal signer2;
+    address internal signer3;
+    address internal unauthorizedSigner;
+
+    address internal owner;
+    address internal recipientAddress;
+    bytes32 internal endpointHash;
+    string internal apiUrl = "https://api.coingecko.com/api/v3/simple/price";
+
+    function setUp() public {
+        owner = address(this);
+        recipientAddress = address(0xCAFE);
+        endpointHash = keccak256(bytes(apiUrl));
+
+        address a1 = vm.addr(key1);
+        address a2 = vm.addr(key2);
+        address a3 = vm.addr(key3);
+        unauthorizedSigner = vm.addr(unauthorizedKey);
+
+        // Sort signers in ascending order
+        address[3] memory addrs = [a1, a2, a3];
+        uint256[3] memory keys = [key1, key2, key3];
+
+        for (uint256 i = 0; i < 3; i++) {
+            for (uint256 j = i + 1; j < 3; j++) {
+                if (addrs[i] > addrs[j]) {
+                    address tempA = addrs[i];
+                    addrs[i] = addrs[j];
+                    addrs[j] = tempA;
+
+                    uint256 tempK = keys[i];
+                    keys[i] = keys[j];
+                    keys[j] = tempK;
+                }
+            }
+        }
+
+        signer1 = addrs[0];
+        signer2 = addrs[1];
+        signer3 = addrs[2];
+        key1 = keys[0];
+        key2 = keys[1];
+        key3 = keys[2];
+
+        address[] memory initialSigners = new address[](3);
+        initialSigners[0] = signer1;
+        initialSigners[1] = signer2;
+        initialSigners[2] = signer3;
+
+        ism = new Web2SecurityModule(
+            owner,
+            web2Domain,
+            initialSigners,
+            threshold,
+            maxAttestationAge,
+            false
+        );
+    }
+
+    function _signDigest(
+        uint256 privateKey,
+        bytes32 digest
+    ) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _createMessage(
+        uint32 origin,
+        bytes32 sender,
+        uint32 destination,
+        bytes32 recipient,
+        bytes memory body
+    ) internal pure returns (bytes memory) {
+        uint8 version = 0;
+        uint32 nonce = 1;
+        return
+            abi.encodePacked(
+                version,
+                nonce,
+                origin,
+                sender,
+                destination,
+                recipient,
+                body
+            );
+    }
+
+    function test_ConstructorInitialState() public view {
+        assertEq(ism.web2Domain(), web2Domain);
+        assertEq(ism.threshold(), threshold);
+        assertEq(ism.maxAttestationAge(), maxAttestationAge);
+        assertFalse(ism.requireEndpointAuthorization());
+
+        address[] memory signersList = ism.signers();
+        assertEq(signersList.length, 3);
+        assertEq(signersList[0], signer1);
+        assertEq(signersList[1], signer2);
+        assertEq(signersList[2], signer3);
+
+        assertTrue(ism.isAuthorizedSigner(signer1));
+        assertTrue(ism.isAuthorizedSigner(signer2));
+        assertTrue(ism.isAuthorizedSigner(signer3));
+        assertFalse(ism.isAuthorizedSigner(unauthorizedSigner));
+    }
+
+    function test_VerifyValidSignatures() public view {
+        bytes memory body = abi.encode("mock response body data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes32 msgId = Message.id(message);
+        uint64 timestamp = uint64(block.timestamp);
+        bytes32 requestId = keccak256("req-1");
+
+        bytes32 digest = ism.computeDigest(
+            web2Domain,
+            endpointHash,
+            recipientAddress.addressToBytes32(),
+            msgId,
+            endpointHash,
+            timestamp,
+            requestId,
+            keccak256(body)
+        );
+
+        bytes memory sig1 = _signDigest(key1, digest);
+        bytes memory sig2 = _signDigest(key2, digest);
+        bytes memory signatures = abi.encodePacked(sig1, sig2);
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            timestamp,
+            requestId,
+            signatures
+        );
+
+        bool success = ism.verify(metadata, message);
+        assertTrue(success);
+    }
+
+    function test_RevertIfInvalidOriginDomain() public {
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            111, // Wrong domain
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            uint64(block.timestamp),
+            keccak256("req-1"),
+            ""
+        );
+
+        vm.expectRevert("Web2SecurityModule: invalid origin domain");
+        ism.verify(metadata, message);
+    }
+
+    function test_RevertIfEndpointSenderMismatch() public {
+        bytes memory body = abi.encode("data");
+        bytes32 wrongSender = keccak256("wrong endpoint");
+        bytes memory message = _createMessage(
+            web2Domain,
+            wrongSender,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            uint64(block.timestamp),
+            keccak256("req-1"),
+            ""
+        );
+
+        vm.expectRevert(
+            "Web2SecurityModule: sender mismatch with metadata endpoint"
+        );
+        ism.verify(metadata, message);
+    }
+
+    function test_EndpointAuthorizationEnforcement() public {
+        ism.setRequireEndpointAuthorization(true);
+        assertTrue(ism.requireEndpointAuthorization());
+
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            uint64(block.timestamp),
+            keccak256("req-1"),
+            ""
+        );
+
+        // Before registration -> reverts
+        vm.expectRevert("Web2SecurityModule: unauthorized endpoint sender");
+        ism.verify(metadata, message);
+
+        // Register endpoint
+        ism.registerEndpoint(endpointHash);
+        assertTrue(ism.isAuthorizedEndpoint(endpointHash));
+
+        // Sign and verify
+        bytes32 msgId = Message.id(message);
+        uint64 timestamp = uint64(block.timestamp);
+        bytes32 requestId = keccak256("req-1");
+        bytes32 digest = ism.computeDigest(
+            web2Domain,
+            endpointHash,
+            recipientAddress.addressToBytes32(),
+            msgId,
+            endpointHash,
+            timestamp,
+            requestId,
+            keccak256(body)
+        );
+
+        bytes memory sig1 = _signDigest(key1, digest);
+        bytes memory sig2 = _signDigest(key2, digest);
+        bytes memory signatures = abi.encodePacked(sig1, sig2);
+
+        metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            timestamp,
+            requestId,
+            signatures
+        );
+
+        assertTrue(ism.verify(metadata, message));
+
+        // Unregister endpoint
+        ism.unregisterEndpoint(endpointHash);
+        assertFalse(ism.isAuthorizedEndpoint(endpointHash));
+
+        vm.expectRevert("Web2SecurityModule: unauthorized endpoint sender");
+        ism.verify(metadata, message);
+    }
+
+    function test_RevertIfAttestationExpired() public {
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        // Warp time forward past maxAttestationAge
+        vm.warp(1000);
+        uint64 staleTimestamp = uint64(1000 - maxAttestationAge - 1);
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            staleTimestamp,
+            keccak256("req-1"),
+            ""
+        );
+
+        vm.expectRevert("Web2SecurityModule: attestation expired");
+        ism.verify(metadata, message);
+    }
+
+    function test_RevertIfFutureTimestamp() public {
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        uint64 futureTimestamp = uint64(block.timestamp + 100);
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            futureTimestamp,
+            keccak256("req-1"),
+            ""
+        );
+
+        vm.expectRevert("Web2SecurityModule: future timestamp");
+        ism.verify(metadata, message);
+    }
+
+    function test_RevertIfInsufficientSignatures() public {
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes32 msgId = Message.id(message);
+        uint64 timestamp = uint64(block.timestamp);
+        bytes32 requestId = keccak256("req-1");
+        bytes32 digest = ism.computeDigest(
+            web2Domain,
+            endpointHash,
+            recipientAddress.addressToBytes32(),
+            msgId,
+            endpointHash,
+            timestamp,
+            requestId,
+            keccak256(body)
+        );
+
+        // Only 1 signature when threshold is 2
+        bytes memory sig1 = _signDigest(key1, digest);
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            timestamp,
+            requestId,
+            sig1
+        );
+
+        vm.expectRevert("Web2SecurityModule: insufficient signatures");
+        ism.verify(metadata, message);
+    }
+
+    function test_RevertIfUnauthorizedSigner() public {
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes32 msgId = Message.id(message);
+        uint64 timestamp = uint64(block.timestamp);
+        bytes32 requestId = keccak256("req-1");
+        bytes32 digest = ism.computeDigest(
+            web2Domain,
+            endpointHash,
+            recipientAddress.addressToBytes32(),
+            msgId,
+            endpointHash,
+            timestamp,
+            requestId,
+            keccak256(body)
+        );
+
+        bytes memory sig1 = _signDigest(key1, digest);
+        bytes memory unauthSig = _signDigest(unauthorizedKey, digest);
+
+        bytes memory signatures;
+        if (signer1 < unauthorizedSigner) {
+            signatures = abi.encodePacked(sig1, unauthSig);
+        } else {
+            signatures = abi.encodePacked(unauthSig, sig1);
+        }
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            timestamp,
+            requestId,
+            signatures
+        );
+
+        vm.expectRevert("Web2SecurityModule: invalid signer");
+        ism.verify(metadata, message);
+    }
+
+    function test_RevertIfDuplicateOrUnsortedSignatures() public {
+        bytes memory body = abi.encode("data");
+        bytes memory message = _createMessage(
+            web2Domain,
+            endpointHash,
+            localDomain,
+            recipientAddress.addressToBytes32(),
+            body
+        );
+
+        bytes32 msgId = Message.id(message);
+        uint64 timestamp = uint64(block.timestamp);
+        bytes32 requestId = keccak256("req-1");
+        bytes32 digest = ism.computeDigest(
+            web2Domain,
+            endpointHash,
+            recipientAddress.addressToBytes32(),
+            msgId,
+            endpointHash,
+            timestamp,
+            requestId,
+            keccak256(body)
+        );
+
+        // Duplicate signature from signer1
+        bytes memory sig1 = _signDigest(key1, digest);
+        bytes memory signatures = abi.encodePacked(sig1, sig1);
+
+        bytes memory metadata = Web2IsmMetadata.formatMetadata(
+            endpointHash,
+            timestamp,
+            requestId,
+            signatures
+        );
+
+        vm.expectRevert(
+            "Web2SecurityModule: signatures must be strictly ascending and unique"
+        );
+        ism.verify(metadata, message);
+    }
+
+    function test_AdminFunctions() public {
+        ism.setWeb2Domain(888);
+        assertEq(ism.web2Domain(), 888);
+
+        ism.setMaxAttestationAge(600);
+        assertEq(ism.maxAttestationAge(), 600);
+
+        bytes32[] memory endpoints = new bytes32[](2);
+        endpoints[0] = keccak256("endpoint1");
+        endpoints[1] = keccak256("endpoint2");
+        ism.registerEndpoints(endpoints);
+        assertTrue(ism.isAuthorizedEndpoint(endpoints[0]));
+        assertTrue(ism.isAuthorizedEndpoint(endpoints[1]));
+
+        // Non-owner reverts
+        address nonOwner = address(0xBEEF);
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        ism.setWeb2Domain(777);
+    }
+}

--- a/solidity/test/middleware/Web2ApiRouter.t.sol
+++ b/solidity/test/middleware/Web2ApiRouter.t.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {Web2ApiRouter} from "../../contracts/middleware/Web2ApiRouter.sol";
+import {Web2Message} from "../../contracts/middleware/libs/Web2Message.sol";
+import {IWeb2ApiRouter} from "../../contracts/interfaces/middleware/IWeb2ApiRouter.sol";
+import {TestWeb2Receiver} from "../../contracts/test/TestWeb2Receiver.sol";
+import {MockHyperlaneEnvironment} from "../../contracts/mock/MockHyperlaneEnvironment.sol";
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+
+contract Web2ApiRouterTest is Test {
+    using TypeCasts for address;
+    using TypeCasts for bytes32;
+
+    event ApiRequestDispatched(
+        bytes32 indexed requestId,
+        uint32 indexed web2Domain,
+        bytes32 indexed endpointHash,
+        address sender,
+        string url,
+        Web2Message.HttpMethod method
+    );
+
+    event ApiResponseReceived(
+        bytes32 indexed requestId,
+        uint32 indexed originDomain,
+        bytes32 indexed endpointHash,
+        uint256 statusCode,
+        address recipient
+    );
+
+    MockHyperlaneEnvironment public environment;
+    Web2ApiRouter public router;
+    TestWeb2Receiver public receiver;
+
+    uint32 public originDomain = 123;
+    uint32 public web2Domain = 999;
+    uint32 public otherDomain = 456;
+
+    string public targetUrl = "https://api.coingecko.com/api/v3/simple/price";
+    bytes32 public endpointHash;
+
+    function setUp() public {
+        environment = new MockHyperlaneEnvironment(originDomain, web2Domain);
+
+        address originMailbox = address(environment.mailboxes(originDomain));
+        router = new Web2ApiRouter(originMailbox, web2Domain);
+        receiver = new TestWeb2Receiver();
+
+        endpointHash = keccak256(bytes(targetUrl));
+    }
+
+    function test_InitialState() public view {
+        assertEq(router.web2Domain(), web2Domain);
+    }
+
+    function test_RequestApiDispatched() public {
+        Web2Message.RequestParams memory params = Web2Message.RequestParams({
+            targetDomain: web2Domain,
+            method: Web2Message.HttpMethod.GET,
+            url: targetUrl,
+            headers: '{"accept":"application/json"}',
+            body: "",
+            callbackAddress: address(receiver),
+            callbackData: "context-1"
+        });
+
+        vm.expectEmit(false, true, true, false, address(router));
+        emit ApiRequestDispatched(
+            bytes32(0),
+            web2Domain,
+            endpointHash,
+            address(this),
+            targetUrl,
+            Web2Message.HttpMethod.GET
+        );
+
+        (bytes32 reqId, bytes32 msgId) = router.requestApi(params);
+        assertTrue(reqId != bytes32(0));
+        assertTrue(msgId != bytes32(0));
+    }
+
+    function test_QuoteApiRequest() public view {
+        Web2Message.RequestParams memory params = Web2Message.RequestParams({
+            targetDomain: web2Domain,
+            method: Web2Message.HttpMethod.POST,
+            url: targetUrl,
+            headers: '{"content-type":"application/json"}',
+            body: '{"query":"hyperlane"}',
+            callbackAddress: address(receiver),
+            callbackData: "quote-test"
+        });
+
+        uint256 fee = router.quoteApiRequest(params);
+        // Default MockMailbox quote is 0
+        assertEq(fee, 0);
+    }
+
+    function test_HandleWeb2Response() public {
+        bytes32 reqId = keccak256("req-123");
+        bytes memory responsePayload = abi.encode("eth_price: 3500");
+        bytes memory callbackData = "cb-data";
+
+        bytes memory responseBody = Web2Message.formatResponse(
+            reqId,
+            address(receiver).addressToBytes32(),
+            200,
+            '{"content-type":"application/json"}',
+            responsePayload,
+            callbackData
+        );
+
+        address originMailbox = address(environment.mailboxes(originDomain));
+
+        vm.expectEmit(true, true, true, true, address(router));
+        emit ApiResponseReceived(
+            reqId,
+            web2Domain,
+            endpointHash,
+            200,
+            address(receiver)
+        );
+
+        vm.prank(originMailbox);
+        router.handle(web2Domain, endpointHash, responseBody);
+
+        assertEq(receiver.lastRequestId(), reqId);
+        assertEq(receiver.lastOrigin(), web2Domain);
+        assertEq(receiver.lastEndpointHash(), endpointHash);
+        assertEq(receiver.lastStatusCode(), 200);
+        assertEq(receiver.lastResponseBody(), responsePayload);
+        assertEq(receiver.lastCallbackData(), callbackData);
+        assertEq(receiver.responseCount(), 1);
+    }
+
+    function test_EndToEndRequestAndResponse() public {
+        // Step 1: Receiver dispatches request
+        (bytes32 reqId, ) = receiver.dispatchViaRouter(
+            address(router),
+            web2Domain,
+            Web2Message.HttpMethod.GET,
+            targetUrl,
+            '{"accept":"application/json"}',
+            "",
+            "ctx-e2e"
+        );
+
+        assertTrue(reqId != bytes32(0));
+
+        // Step 2: Simulate response delivery from web2Domain
+        bytes memory respData = abi.encode("result_ok");
+        bytes memory responseBody = Web2Message.formatResponse(
+            reqId,
+            address(receiver).addressToBytes32(),
+            200,
+            "{}",
+            respData,
+            "ctx-e2e"
+        );
+
+        address originMailbox = address(environment.mailboxes(originDomain));
+
+        vm.prank(originMailbox);
+        router.handle(web2Domain, endpointHash, responseBody);
+
+        assertEq(receiver.lastRequestId(), reqId);
+        assertEq(receiver.lastStatusCode(), 200);
+        assertEq(receiver.lastResponseBody(), respData);
+        assertEq(receiver.lastCallbackData(), "ctx-e2e");
+    }
+
+    function test_HandleRevertsIfCallbackReverts() public {
+        receiver.setShouldRevert(true);
+
+        bytes32 reqId = keccak256("req-fail");
+        bytes memory responseBody = Web2Message.formatResponse(
+            reqId,
+            address(receiver).addressToBytes32(),
+            500,
+            "{}",
+            "error",
+            ""
+        );
+
+        address originMailbox = address(environment.mailboxes(originDomain));
+
+        vm.prank(originMailbox);
+        vm.expectRevert("TestWeb2Receiver: intentional revert");
+        router.handle(web2Domain, endpointHash, responseBody);
+    }
+
+    function test_HandleEnrolledRemoteRouter() public {
+        address originMailbox = address(environment.mailboxes(originDomain));
+        bytes32 remoteRouterAddr = address(0xAAAA).addressToBytes32();
+
+        // Enroll remote router for otherDomain
+        router.enrollRemoteRouter(otherDomain, remoteRouterAddr);
+
+        // Disallowed sender from otherDomain reverts
+        vm.prank(originMailbox);
+        vm.expectRevert("Enrolled router does not match sender");
+        router.handle(
+            otherDomain,
+            address(0xBBBB).addressToBytes32(),
+            Web2Message.formatResponse(
+                bytes32(0),
+                address(0).addressToBytes32(),
+                200,
+                "",
+                "",
+                ""
+            )
+        );
+
+        // Matching remote router sender succeeds
+        vm.prank(originMailbox);
+        router.handle(
+            otherDomain,
+            remoteRouterAddr,
+            Web2Message.formatResponse(
+                bytes32(0),
+                address(0).addressToBytes32(),
+                200,
+                "",
+                "",
+                ""
+            )
+        );
+    }
+
+    function test_SetWeb2DomainOnlyOwner() public {
+        router.setWeb2Domain(888);
+        assertEq(router.web2Domain(), 888);
+
+        address nonOwner = address(0xBEEF);
+        vm.prank(nonOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        router.setWeb2Domain(777);
+    }
+}

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -49,6 +49,14 @@
       "types": "./dist/middleware/account/*.d.ts",
       "default": "./dist/middleware/account/*.js"
     },
+    "./middleware/web2/*": {
+      "types": "./dist/middleware/web2/*.d.ts",
+      "default": "./dist/middleware/web2/*.js"
+    },
+    "./middleware/web2": {
+      "types": "./dist/middleware/web2/index.d.ts",
+      "default": "./dist/middleware/web2/index.js"
+    },
     "./predicate/PredicateApiClient": {
       "types": "./dist/predicate/PredicateApiClient.d.ts",
       "default": "./dist/predicate/PredicateApiClient.js"

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -527,6 +527,17 @@ export {
   InterchainQueryConfig,
   InterchainQueryDeployer,
 } from './middleware/query/InterchainQueryDeployer.js';
+export {
+  HttpMethod as Web2HttpMethod,
+  MessageType as Web2MessageType,
+  Web2RequestParams,
+  Web2Request,
+  Web2Response,
+  Web2IsmMetadataConfig,
+  Web2KeeperConfig,
+  Web2Message,
+  Web2Keeper,
+} from './middleware/web2/index.js';
 export { isBlockExplorerHealthy } from './providers/explorerHealthTest.js';
 export {
   MultiProtocolProvider,

--- a/typescript/sdk/src/middleware/web2/Web2Keeper.ts
+++ b/typescript/sdk/src/middleware/web2/Web2Keeper.ts
@@ -1,0 +1,173 @@
+import { ethers, Wallet } from 'ethers';
+import {
+  HttpMethod,
+  Web2KeeperConfig,
+  Web2Request,
+  Web2Response,
+} from './types.js';
+import { Web2Message } from './Web2Message.js';
+
+export class Web2Keeper {
+  protected wallets: Wallet[];
+
+  constructor(public readonly config: Web2KeeperConfig) {
+    this.wallets = config.privateKeys.map((pk) => new Wallet(pk));
+  }
+
+  /**
+   * Executes an off-chain HTTP request using fetch.
+   */
+  async executeHttpRequest(request: Web2Request): Promise<{
+    statusCode: number;
+    headers: string;
+    body: Uint8Array;
+  }> {
+    const methodStr = HttpMethod[request.method] || 'GET';
+    const parsedHeaders = request.headers ? JSON.parse(request.headers) : {};
+
+    let requestBody: any = undefined;
+    if (
+      request.method !== HttpMethod.GET &&
+      request.method !== HttpMethod.HEAD &&
+      request.body &&
+      request.body !== '0x'
+    ) {
+      requestBody = Buffer.from(ethers.utils.arrayify(request.body));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      this.config.requestTimeoutMs ?? 15000,
+    );
+
+    try {
+      const res = await fetch(request.url, {
+        method: methodStr,
+        headers: parsedHeaders,
+        body: requestBody,
+        signal: controller.signal,
+      });
+
+      const responseHeaders: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+
+      const arrayBuffer = await res.arrayBuffer();
+      const bodyBytes = new Uint8Array(arrayBuffer);
+
+      return {
+        statusCode: res.status,
+        headers: JSON.stringify(responseHeaders),
+        body: bodyBytes,
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Constructs the Web2Response and cryptographic attestation signatures.
+   */
+  async generateAttestation(params: {
+    request: Web2Request;
+    httpResult: {
+      statusCode: number;
+      headers: string;
+      body: Uint8Array;
+    };
+    destinationDomain: number;
+    recipientRouterAddress: string;
+  }): Promise<{
+    response: Web2Response;
+    responseBytes: string;
+    metadata: string;
+    digest: string;
+  }> {
+    const response: Web2Response = {
+      requestId: params.request.requestId,
+      callbackAddress: params.request.callbackAddress,
+      statusCode: params.httpResult.statusCode,
+      headers: params.httpResult.headers,
+      responseBody: ethers.utils.hexlify(params.httpResult.body),
+      callbackData: params.request.callbackData,
+    };
+
+    const responseBytes = Web2Message.encodeResponse(response);
+    const endpointHash = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes(params.request.url),
+    );
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    // Format message to compute ID
+    const recipientBytes32 = ethers.utils.hexZeroPad(
+      params.recipientRouterAddress,
+      32,
+    );
+
+    const rawMessage = ethers.utils.concat([
+      ethers.utils.arrayify('0x00'), // version 0
+      ethers.utils.zeroPad(ethers.utils.hexlify(1), 4), // nonce
+      ethers.utils.zeroPad(ethers.utils.hexlify(this.config.web2Domain), 4), // origin
+      ethers.utils.arrayify(endpointHash), // sender (endpointHash)
+      ethers.utils.zeroPad(ethers.utils.hexlify(params.destinationDomain), 4), // destination
+      ethers.utils.arrayify(recipientBytes32), // recipient
+      ethers.utils.arrayify(responseBytes), // body
+    ]);
+
+    const messageId = ethers.utils.keccak256(rawMessage);
+    const bodyHash = ethers.utils.keccak256(responseBytes);
+
+    const structHash = ethers.utils.solidityKeccak256(
+      [
+        'uint32',
+        'bytes32',
+        'bytes32',
+        'bytes32',
+        'bytes32',
+        'uint64',
+        'bytes32',
+        'bytes32',
+      ],
+      [
+        this.config.web2Domain,
+        endpointHash,
+        recipientBytes32,
+        messageId,
+        endpointHash,
+        timestamp,
+        params.request.requestId,
+        bodyHash,
+      ],
+    );
+
+    const messageDigest = ethers.utils.arrayify(structHash);
+
+    // Collect and sort signatures by signer address ascending
+    const signerSignatures: { address: string; signature: string }[] = [];
+    for (const wallet of this.wallets) {
+      const rawSig = await wallet.signMessage(messageDigest);
+      signerSignatures.push({
+        address: wallet.address.toLowerCase(),
+        signature: rawSig,
+      });
+    }
+
+    signerSignatures.sort((a, b) => (a.address < b.address ? -1 : 1));
+
+    const metadata = Web2Message.formatIsmMetadata({
+      endpointHash,
+      timestamp,
+      requestId: params.request.requestId,
+      signatures: signerSignatures.map((s) => s.signature),
+    });
+
+    return {
+      response,
+      responseBytes,
+      metadata,
+      digest: structHash,
+    };
+  }
+}

--- a/typescript/sdk/src/middleware/web2/Web2Message.test.ts
+++ b/typescript/sdk/src/middleware/web2/Web2Message.test.ts
@@ -1,0 +1,138 @@
+import { expect } from 'chai';
+import { ethers, Wallet } from 'ethers';
+
+import { HttpMethod, Web2Request, Web2Response } from './types.js';
+import { Web2Message } from './Web2Message.js';
+import { Web2Keeper } from './Web2Keeper.js';
+
+describe('Web2Message', () => {
+  const dummyRequestId = ethers.utils.id('test-request-1');
+  const dummySender = ethers.utils.hexZeroPad(
+    '0x1234567890123456789012345678901234567890',
+    32,
+  );
+  const dummyCallback = ethers.utils.hexZeroPad(
+    '0x0987654321098765432109876543210987654321',
+    32,
+  );
+
+  it('should encode and decode Web2 requests accurately', () => {
+    const request: Web2Request = {
+      requestId: dummyRequestId,
+      sender: dummySender,
+      method: HttpMethod.POST,
+      url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+      headers: '{"Content-Type":"application/json"}',
+      body: '0x123456',
+      callbackAddress: dummyCallback,
+      callbackData: '0xabcdef',
+    };
+
+    const encoded = Web2Message.encodeRequest(request);
+    expect(encoded).to.be.a('string');
+
+    const decoded = Web2Message.decodeRequest(encoded);
+    expect(decoded.requestId).to.equal(request.requestId);
+    expect(decoded.sender.toLowerCase()).to.equal(request.sender.toLowerCase());
+    expect(decoded.method).to.equal(request.method);
+    expect(decoded.url).to.equal(request.url);
+    expect(decoded.headers).to.equal(request.headers);
+    expect(decoded.body).to.equal(request.body);
+    expect(decoded.callbackAddress.toLowerCase()).to.equal(
+      request.callbackAddress.toLowerCase(),
+    );
+    expect(decoded.callbackData).to.equal(request.callbackData);
+  });
+
+  it('should encode and decode Web2 responses accurately', () => {
+    const response: Web2Response = {
+      requestId: dummyRequestId,
+      callbackAddress: dummyCallback,
+      statusCode: 200,
+      headers: '{"server":"cloudflare"}',
+      responseBody: '0xdeadbeef',
+      callbackData: '0xcafe',
+    };
+
+    const encoded = Web2Message.encodeResponse(response);
+    const decoded = Web2Message.decodeResponse(encoded);
+
+    expect(decoded.requestId).to.equal(response.requestId);
+    expect(decoded.callbackAddress.toLowerCase()).to.equal(
+      response.callbackAddress.toLowerCase(),
+    );
+    expect(decoded.statusCode).to.equal(200);
+    expect(decoded.headers).to.equal(response.headers);
+    expect(decoded.responseBody).to.equal(response.responseBody);
+    expect(decoded.callbackData).to.equal(response.callbackData);
+  });
+
+  it('should format ISM metadata matching Web2SecurityModule expectations', () => {
+    const endpointHash = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes('https://api.example.com'),
+    );
+    const timestamp = 1700000000;
+    const sig1 = '0x' + '11'.repeat(65);
+    const sig2 = '0x' + '22'.repeat(65);
+
+    const metadata = Web2Message.formatIsmMetadata({
+      endpointHash,
+      timestamp,
+      requestId: dummyRequestId,
+      signatures: [sig1, sig2],
+    });
+
+    const metadataBytes = ethers.utils.arrayify(metadata);
+    // 32 bytes endpointHash + 8 bytes timestamp + 32 bytes requestId + 2 * 65 bytes signatures = 202 bytes
+    expect(metadataBytes.length).to.equal(32 + 8 + 32 + 130);
+  });
+});
+
+describe('Web2Keeper', () => {
+  const wallet1 = Wallet.createRandom();
+  const wallet2 = Wallet.createRandom();
+
+  const keeper = new Web2Keeper({
+    originDomain: 123,
+    web2Domain: 999,
+    routerAddress: '0x1111111111111111111111111111111111111111',
+    mailboxAddress: '0x2222222222222222222222222222222222222222',
+    privateKeys: [wallet1.privateKey, wallet2.privateKey],
+  });
+
+  it('should generate valid multi-signer attestations and metadata', async () => {
+    const request: Web2Request = {
+      requestId: ethers.utils.id('req-keeper-test'),
+      sender: ethers.utils.hexZeroPad(
+        '0x1234567890123456789012345678901234567890',
+        32,
+      ),
+      method: HttpMethod.GET,
+      url: 'https://api.coingecko.com/api/v3/ping',
+      headers: '{}',
+      body: '0x',
+      callbackAddress: ethers.utils.hexZeroPad(
+        '0x0987654321098765432109876543210987654321',
+        32,
+      ),
+      callbackData: '0x12',
+    };
+
+    const httpResult = {
+      statusCode: 200,
+      headers: '{"status":"ok"}',
+      body: new Uint8Array([1, 2, 3, 4]),
+    };
+
+    const attestation = await keeper.generateAttestation({
+      request,
+      httpResult,
+      destinationDomain: 123,
+      recipientRouterAddress: '0x1111111111111111111111111111111111111111',
+    });
+
+    expect(attestation.response.statusCode).to.equal(200);
+    expect(attestation.metadata).to.be.a('string');
+    expect(attestation.digest).to.be.a('string');
+  });
+});

--- a/typescript/sdk/src/middleware/web2/Web2Message.ts
+++ b/typescript/sdk/src/middleware/web2/Web2Message.ts
@@ -1,0 +1,202 @@
+import { ethers } from 'ethers';
+import {
+  HttpMethod,
+  MessageType,
+  Web2Request,
+  Web2Response,
+  Web2IsmMetadataConfig,
+} from './types.js';
+
+const defaultAbiCoder = ethers.utils.defaultAbiCoder;
+
+export class Web2Message {
+  /**
+   * Encodes an outgoing Web2 API request for Mailbox dispatch.
+   */
+  static encodeRequest(req: Web2Request): string {
+    return defaultAbiCoder.encode(
+      [
+        'uint8',
+        'bytes32',
+        'bytes32',
+        'uint8',
+        'string',
+        'string',
+        'bytes',
+        'bytes32',
+        'bytes',
+      ],
+      [
+        MessageType.REQUEST,
+        req.requestId,
+        req.sender,
+        req.method,
+        req.url,
+        req.headers,
+        req.body,
+        req.callbackAddress,
+        req.callbackData,
+      ],
+    );
+  }
+
+  /**
+   * Decodes an incoming Web2 API request message body.
+   */
+  static decodeRequest(data: string): Web2Request {
+    const [
+      msgType,
+      requestId,
+      sender,
+      method,
+      url,
+      headers,
+      body,
+      callbackAddress,
+      callbackData,
+    ] = defaultAbiCoder.decode(
+      [
+        'uint8',
+        'bytes32',
+        'bytes32',
+        'uint8',
+        'string',
+        'string',
+        'bytes',
+        'bytes32',
+        'bytes',
+      ],
+      data,
+    );
+
+    if (msgType !== MessageType.REQUEST) {
+      throw new Error(`Invalid message type for request: ${msgType}`);
+    }
+
+    return {
+      requestId,
+      sender,
+      method: method as HttpMethod,
+      url,
+      headers,
+      body,
+      callbackAddress,
+      callbackData,
+    };
+  }
+
+  /**
+   * Encodes a Web2 API response message body for Mailbox delivery.
+   */
+  static encodeResponse(resp: Web2Response): string {
+    return defaultAbiCoder.encode(
+      ['uint8', 'bytes32', 'bytes32', 'uint256', 'string', 'bytes', 'bytes'],
+      [
+        MessageType.RESPONSE,
+        resp.requestId,
+        resp.callbackAddress,
+        resp.statusCode,
+        resp.headers,
+        resp.responseBody,
+        resp.callbackData,
+      ],
+    );
+  }
+
+  /**
+   * Decodes an incoming Web2 API response message body.
+   */
+  static decodeResponse(data: string): Web2Response {
+    const [
+      msgType,
+      requestId,
+      callbackAddress,
+      statusCode,
+      headers,
+      responseBody,
+      callbackData,
+    ] = defaultAbiCoder.decode(
+      ['uint8', 'bytes32', 'bytes32', 'uint256', 'string', 'bytes', 'bytes'],
+      data,
+    );
+
+    if (msgType !== MessageType.RESPONSE) {
+      throw new Error(`Invalid message type for response: ${msgType}`);
+    }
+
+    return {
+      requestId,
+      callbackAddress,
+      statusCode: statusCode.toNumber(),
+      headers,
+      responseBody,
+      callbackData,
+    };
+  }
+
+  /**
+   * Computes the EIP-191 digest to be signed by Web2 ISM oracle keepers.
+   */
+  static computeDigest(params: {
+    originDomain: number;
+    sender: string;
+    recipient: string;
+    messageId: string;
+    endpointHash: string;
+    timestamp: number;
+    requestId: string;
+    bodyHash: string;
+  }): string {
+    const structHash = ethers.utils.solidityKeccak256(
+      [
+        'uint32',
+        'bytes32',
+        'bytes32',
+        'bytes32',
+        'bytes32',
+        'uint64',
+        'bytes32',
+        'bytes32',
+      ],
+      [
+        params.originDomain,
+        params.sender,
+        params.recipient,
+        params.messageId,
+        params.endpointHash,
+        params.timestamp,
+        params.requestId,
+        params.bodyHash,
+      ],
+    );
+
+    // EIP-191 signed data format: keccak256("\x19Ethereum Signed Message:\n32" + structHash)
+    return ethers.utils.hashMessage(ethers.utils.arrayify(structHash));
+  }
+
+  /**
+   * Formats metadata for the Web2SecurityModule ISM.
+   * [endpointHash (32 bytes)][timestamp (8 bytes)][requestId (32 bytes)][signatures (65 bytes each...)]
+   */
+  static formatIsmMetadata(config: Web2IsmMetadataConfig): string {
+    const endpointHashBytes = ethers.utils.arrayify(config.endpointHash);
+    const timestampBytes = ethers.utils.zeroPad(
+      ethers.utils.hexlify(config.timestamp),
+      8,
+    );
+    const requestIdBytes = ethers.utils.arrayify(config.requestId);
+
+    const signaturesBytes = ethers.utils.concat(
+      config.signatures.map((sig) => ethers.utils.arrayify(sig)),
+    );
+
+    return ethers.utils.hexlify(
+      ethers.utils.concat([
+        endpointHashBytes,
+        timestampBytes,
+        requestIdBytes,
+        signaturesBytes,
+      ]),
+    );
+  }
+}

--- a/typescript/sdk/src/middleware/web2/index.ts
+++ b/typescript/sdk/src/middleware/web2/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './Web2Message.js';
+export * from './Web2Keeper.js';

--- a/typescript/sdk/src/middleware/web2/types.ts
+++ b/typescript/sdk/src/middleware/web2/types.ts
@@ -1,0 +1,63 @@
+import { BytesLike } from 'ethers';
+
+export enum HttpMethod {
+  GET = 0,
+  POST = 1,
+  PUT = 2,
+  DELETE = 3,
+  PATCH = 4,
+  HEAD = 5,
+}
+
+export enum MessageType {
+  REQUEST = 0,
+  RESPONSE = 1,
+}
+
+export interface Web2RequestParams {
+  targetDomain: number;
+  method: HttpMethod;
+  url: string;
+  headers: string;
+  body: BytesLike;
+  callbackAddress: string;
+  callbackData: BytesLike;
+}
+
+export interface Web2Request {
+  requestId: string;
+  sender: string;
+  method: HttpMethod;
+  url: string;
+  headers: string;
+  body: string;
+  callbackAddress: string;
+  callbackData: string;
+}
+
+export interface Web2Response {
+  requestId: string;
+  callbackAddress: string;
+  statusCode: number;
+  headers: string;
+  responseBody: string;
+  callbackData: string;
+}
+
+export interface Web2IsmMetadataConfig {
+  endpointHash: string;
+  timestamp: number;
+  requestId: string;
+  signatures: string[];
+}
+
+export interface Web2KeeperConfig {
+  originDomain: number;
+  web2Domain: number;
+  routerAddress: string;
+  mailboxAddress: string;
+  ismAddress?: string;
+  privateKeys: string[];
+  maxAttestationAge?: number;
+  requestTimeoutMs?: number;
+}


### PR DESCRIPTION
### Summary
Implements end-to-end support for expressing write/read Web2 API calls inside the Hyperlane Mailbox and ISM abstraction as requested in #4703.

### Key Architecture Components

1. **Smart Contracts (Solidity)**:
   - `Web2ApiRouter.sol`: Middleware Router enabling smart contracts to dispatch HTTP/REST requests (GET, POST, PUT, DELETE, PATCH, HEAD) over Mailbox to a designated `web2Domain`, and seamlessly receive verified responses via callback execution.
   - `Web2SecurityModule.sol`: Dedicated Interchain Security Module verifying off-chain oracle / keeper response attestations using EIP-191 ECDSA signatures, m-of-n threshold consensus, timestamp expiration checks, and optional endpoint registration allowlisting.
   - `Web2Message.sol`: Library for compact serialization and deserialization of Web2 request and response packets over Hyperlane Mailbox.
   - `Web2IsmMetadata.sol`: Metadata serialization library for parsing and packaging endpoint hashes, attestation timestamps, request IDs, and keeper signatures.
   - `IWeb2Receiver.sol` & `IWeb2ApiRouter.sol`: Standard interfaces for Web2 consumer contracts and routers.
   - `TestWeb2Receiver.sol`: Test recipient contract verifying callback handling and failure states.

2. **TypeScript SDK & Keeper Service**:
   - `Web2Message`: TypeScript codec for encoding and decoding Web2 request/response messages and ISM metadata.
   - `Web2Keeper`: Off-chain service capable of executing HTTP requests, generating cryptographic threshold attestations, and assembling Mailbox delivery transactions.
   - `types`: Strongly typed definitions for HTTP methods, request parameters, and ISM configurations.

3. **Test Suite**:
   - `Web2SecurityModule.t.sol`: 11 comprehensive Foundry tests covering threshold verification, signature ordering, attestation expiration, endpoint allowlisting, replay prevention, and administrative access controls.
   - `Web2ApiRouter.t.sol`: 8 Foundry unit/integration tests verifying request dispatching, fee quoting, callback executions, and revert handling.
   - `Web2Message.test.ts`: TypeScript Mocha tests validating request/response serialization and keeper multi-signature attestation generation.

---

## Payout Routing
- **EVM (Base/Arbitrum/Polygon/ETH):** `0xF46C9F6d70C50BF81ef3588AB523a90a594a2F89`
- **Stellar:** `GCL6OXAMLD75BMTINA6EMRUDWK5THQUSHMYNLSNBCJAPZJHNYJTUNIBC`