### PR TITLE
feat: adopt native Zod 4 registry schemas

### DIFF
--- a/.changeset/clean-dodos-build.md
+++ b/.changeset/clean-dodos-build.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/cli': patch
+'@hyperlane-xyz/http-registry-server': minor
+'@hyperlane-xyz/sdk': patch
+---
+
+The temporary Zod 3 registry compatibility layer was removed after adopting the registry's Zod 4 schemas. Repeated server and config validators are now compiled once, and boolean-only checks use Zod's allocation-free validation path.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^1.3.5
       version: 1.3.5
     '@hyperlane-xyz/registry':
-      specifier: 0.0.0-beta-20260831225032
-      version: 0.0.0-beta-20260831225032
+      specifier: 26.0.0
+      version: 26.0.0
     '@inquirer/prompts':
       specifier: 3.3.2
       version: 3.3.2
@@ -621,7 +621,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -772,7 +772,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1093,7 +1093,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1242,7 +1242,7 @@ importers:
         version: link:../../solidity
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1354,7 +1354,7 @@ importers:
         version: 1.3.5(supports-color@10.2.2)
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1499,7 +1499,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1713,7 +1713,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1963,7 +1963,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2087,7 +2087,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2157,7 +2157,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2660,7 +2660,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2820,7 +2820,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -3020,7 +3020,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.27)(react@18.3.1)(supports-color@10.2.2)
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 0.0.0-beta-20260831225032
+        version: 26.0.0
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -5357,8 +5357,8 @@ packages:
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
 
-  '@hyperlane-xyz/registry@0.0.0-beta-20260831225032':
-    resolution: {integrity: sha512-k4DWFYMfo3C74m3hT1wljPlInMgyyb58QCzka1qH6xg8d+RIvcmnOWZtKyHR1ELVniY4x3IoeWUxklGfiXFJpw==}
+  '@hyperlane-xyz/registry@26.0.0':
+    resolution: {integrity: sha512-7rNFOo2Uf4KI8xRE03idKv4aysdATNLdQ2xzzfEjGZHRxXMzDZcexBtbUx3CdKnCWJLOmQQLmzEIzmtgAccE6w==}
     engines: {node: '>=24'}
 
   '@img/sharp-darwin-arm64@0.33.5':
@@ -20793,7 +20793,7 @@ snapshots:
 
   '@humanwhocodes/momoa@2.0.4': {}
 
-  '@hyperlane-xyz/registry@0.0.0-beta-20260831225032':
+  '@hyperlane-xyz/registry@26.0.0':
     dependencies:
       jszip: 3.10.1
       pino: 8.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^1.3.5
       version: 1.3.5
     '@hyperlane-xyz/registry':
-      specifier: 25.3.0
-      version: 25.3.0
+      specifier: 0.0.0-beta-20260831225032
+      version: 0.0.0-beta-20260831225032
     '@inquirer/prompts':
       specifier: 3.3.2
       version: 3.3.2
@@ -621,7 +621,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -772,7 +772,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1093,7 +1093,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1242,7 +1242,7 @@ importers:
         version: link:../../solidity
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1354,7 +1354,7 @@ importers:
         version: 1.3.5(supports-color@10.2.2)
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1499,7 +1499,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/relayer':
         specifier: workspace:*
         version: link:../relayer
@@ -1713,7 +1713,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1963,7 +1963,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2087,7 +2087,7 @@ importers:
         version: link:../rebalancer
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2157,7 +2157,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -2660,7 +2660,7 @@ importers:
         version: link:../provider-sdk
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/utils':
         specifier: workspace:*
         version: link:../utils
@@ -2820,7 +2820,7 @@ importers:
         version: link:../metrics
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -3020,7 +3020,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)(supports-color@10.2.2))(@types/react@18.3.27)(react@18.3.1)(supports-color@10.2.2)
       '@hyperlane-xyz/registry':
         specifier: 'catalog:'
-        version: 25.3.0
+        version: 0.0.0-beta-20260831225032
       '@hyperlane-xyz/tsconfig':
         specifier: workspace:^
         version: link:../tsconfig
@@ -5357,8 +5357,8 @@ packages:
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
 
-  '@hyperlane-xyz/registry@25.3.0':
-    resolution: {integrity: sha512-LkMxVYj30aoWDs8wLTV1KItBAiwhhlfJ6EYemh5WsQrFrI9Eo4g0Z0qKVMSBlt26Fq2uPRFpK2+2xdpTNSSQ0g==}
+  '@hyperlane-xyz/registry@0.0.0-beta-20260831225032':
+    resolution: {integrity: sha512-k4DWFYMfo3C74m3hT1wljPlInMgyyb58QCzka1qH6xg8d+RIvcmnOWZtKyHR1ELVniY4x3IoeWUxklGfiXFJpw==}
     engines: {node: '>=24'}
 
   '@img/sharp-darwin-arm64@0.33.5':
@@ -17437,9 +17437,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zod@4.5.2:
     resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
@@ -20796,12 +20793,12 @@ snapshots:
 
   '@humanwhocodes/momoa@2.0.4': {}
 
-  '@hyperlane-xyz/registry@25.3.0':
+  '@hyperlane-xyz/registry@0.0.0-beta-20260831225032':
     dependencies:
       jszip: 3.10.1
       pino: 8.21.0
-      yaml: 2.4.5
-      zod: 3.25.76
+      yaml: 2.9.0
+      zod: 4.5.2
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -27615,11 +27612,6 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
       zod: 3.25.76
 
-  abitype@1.3.0(@typescript/typescript6@6.0.2)(zod@4.4.3):
-    optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
-      zod: 4.4.3
-
   abitype@1.3.0(@typescript/typescript6@6.0.2)(zod@4.5.2):
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -33202,7 +33194,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.14(@typescript/typescript6@6.0.2)(zod@4.4.3):
+  ox@0.9.14(@typescript/typescript6@6.0.2)(zod@4.5.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -33210,7 +33202,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.3.0(@typescript/typescript6@6.0.2)(zod@4.4.3)
+      abitype: 1.3.0(@typescript/typescript6@6.0.2)(zod@4.5.2)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -33656,9 +33648,9 @@ snapshots:
       hono: 4.11.4
       idb-keyval: 6.2.2
       mipd: 0.0.7(@typescript/typescript6@6.0.2)
-      ox: 0.9.14(@typescript/typescript6@6.0.2)(zod@4.4.3)
+      ox: 0.9.14(@typescript/typescript6@6.0.2)(zod@4.5.2)
       viem: 2.55.10(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zod: 4.4.3
+      zod: 4.5.2
       zustand: 5.0.8(@types/react@18.3.27)(immer@10.2.0)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/react-query': 5.101.4(react@18.3.1)
@@ -37130,8 +37122,6 @@ snapshots:
   zod@3.22.4: {}
 
   zod@3.25.76: {}
-
-  zod@4.4.3: {}
 
   zod@4.5.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,7 +97,7 @@ catalog:
   '@aws-sdk/client-kms': ^3.577.0
 
   # Registry
-  '@hyperlane-xyz/registry': 0.0.0-beta-20260831225032
+  '@hyperlane-xyz/registry': 26.0.0
 
   # CLI prompts
   '@inquirer/prompts': 3.3.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,7 +97,7 @@ catalog:
   '@aws-sdk/client-kms': ^3.577.0
 
   # Registry
-  '@hyperlane-xyz/registry': 25.3.0
+  '@hyperlane-xyz/registry': 0.0.0-beta-20260831225032
 
   # CLI prompts
   '@inquirer/prompts': 3.3.2

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -95,8 +95,6 @@ const StoredCallSchema = z.object({
   value: z.union([z.string(), z.number()]).optional(),
 });
 
-const CompiledPostCallsSchema = z.compile(PostCallsSchema);
-
 const commitmentReconciliationSelect = {
   ...commitmentMetadataSelect,
   calls: true,
@@ -485,7 +483,7 @@ export class CallCommitmentsService extends BaseService {
    * Returns parsed data or sends a 400 response and returns null.
    */
   private parseCommitmentBody(body: any, res: Response, logger: Logger) {
-    const result = CompiledPostCallsSchema.safeParse(body);
+    const result = PostCallsSchema.safeParse(body);
     if (!result.success) {
       const errors = z.treeifyError(result.error);
       logger.warn({ errors }, 'Invalid request body received');

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -95,6 +95,8 @@ const StoredCallSchema = z.object({
   value: z.union([z.string(), z.number()]).optional(),
 });
 
+const CompiledPostCallsSchema = z.compile(PostCallsSchema);
+
 const commitmentReconciliationSelect = {
   ...commitmentMetadataSelect,
   calls: true,
@@ -483,7 +485,7 @@ export class CallCommitmentsService extends BaseService {
    * Returns parsed data or sends a 400 response and returns null.
    */
   private parseCommitmentBody(body: any, res: Response, logger: Logger) {
-    const result = PostCallsSchema.safeParse(body);
+    const result = CompiledPostCallsSchema.safeParse(body);
     if (!result.success) {
       const errors = z.treeifyError(result.error);
       logger.warn({ errors }, 'Invalid request body received');
@@ -709,43 +711,45 @@ export class CallCommitmentsService extends BaseService {
     isSigner: z.boolean(),
   });
 
-  private static readonly CalldataPostSchema = z.object({
-    commitment: z
-      .string()
-      .regex(
-        /^0x[0-9a-fA-F]{64}$/,
-        'commitment must be a 32-byte 0x hex string',
-      ),
-    originDomain: z.number().int().positive(),
-    data: z
-      .string()
-      .regex(
-        /^0x(?:[0-9a-fA-F]{2})+$/,
-        'data must be a non-empty byte-aligned 0x hex string',
-      ),
-    salt: z
-      .string()
-      .regex(/^0x[0-9a-fA-F]{64}$/, 'salt must be a 32-byte 0x hex string'),
-    relayers: z
-      .array(
-        z
-          .string()
-          .regex(
-            /^0x[0-9a-fA-F]{40}$/,
-            'relayer must be a 20-byte EVM address',
-          ),
-      )
-      .default([]),
-    destinationAccount: z
-      .string()
-      .regex(
-        /^0x[0-9a-fA-F]{64}$/,
-        'destinationAccount must be a 32-byte 0x hex string',
-      ),
-    revealAccounts: z
-      .array(CallCommitmentsService.RevealAccountSchema)
-      .optional(),
-  });
+  private static readonly CalldataPostSchema = z.compile(
+    z.object({
+      commitment: z
+        .string()
+        .regex(
+          /^0x[0-9a-fA-F]{64}$/,
+          'commitment must be a 32-byte 0x hex string',
+        ),
+      originDomain: z.number().int().positive(),
+      data: z
+        .string()
+        .regex(
+          /^0x(?:[0-9a-fA-F]{2})+$/,
+          'data must be a non-empty byte-aligned 0x hex string',
+        ),
+      salt: z
+        .string()
+        .regex(/^0x[0-9a-fA-F]{64}$/, 'salt must be a 32-byte 0x hex string'),
+      relayers: z
+        .array(
+          z
+            .string()
+            .regex(
+              /^0x[0-9a-fA-F]{40}$/,
+              'relayer must be a 20-byte EVM address',
+            ),
+        )
+        .default([]),
+      destinationAccount: z
+        .string()
+        .regex(
+          /^0x[0-9a-fA-F]{64}$/,
+          'destinationAccount must be a 32-byte 0x hex string',
+        ),
+      revealAccounts: z
+        .array(CallCommitmentsService.RevealAccountSchema)
+        .optional(),
+    }),
+  );
 
   public async handleCalldataPost(req: Request, res: Response) {
     const logger = this.addLoggerServiceContext(req.log);

--- a/typescript/ccip-server/src/utils/abiHandler.ts
+++ b/typescript/ccip-server/src/utils/abiHandler.ts
@@ -6,6 +6,13 @@ import { z } from 'zod';
 
 import { offchainLookupRequestMessageHash } from '@hyperlane-xyz/sdk';
 
+const RelayerSignatureBodySchema = z.compile(
+  z.object({
+    sender: z.string().startsWith('0x').length(42, 'Invalid Ethereum address'),
+    signature: z.string().startsWith('0x'),
+  }),
+);
+
 /**
  * Creates an Express handler that:
  * 1) reads `req.body.data`
@@ -57,17 +64,11 @@ export function createAbiHandler<
         return res.status(400).json({ error: 'Missing callData' });
       }
 
-      // Validation block for sender and signature
-      const bodySchema = z.object({
-        sender: z
-          .string()
-          .startsWith('0x')
-          .length(42, 'Invalid Ethereum address'),
-        signature: z.string().startsWith('0x'),
-      });
-
       if (verifyRelayerSignatureUrl) {
-        const parseResult = bodySchema.safeParse({ sender, signature });
+        const parseResult = RelayerSignatureBodySchema.safeParse({
+          sender,
+          signature,
+        });
         if (!parseResult.success) {
           handlerLogger.warn({ body }, 'Invalid sender or signature format');
           return res.status(400).json({

--- a/typescript/cli/src/config/chain.ts
+++ b/typescript/cli/src/config/chain.ts
@@ -1,6 +1,7 @@
 import { confirm, input, select } from '@inquirer/prompts';
 import { ethers } from 'ethers';
 import { stringify as yamlStringify } from 'yaml';
+import { z } from 'zod';
 
 import {
   type ChainMetadata,
@@ -17,6 +18,9 @@ import { errorRed, log, logBlue, logGreen } from '../logger.js';
 import { indentYamlOrJson, readYamlOrJson } from '../utils/files.js';
 import { detectAndConfirmOrPrompt } from '../utils/input.js';
 
+const CompiledChainMetadataSchema = z.compile(ChainMetadataSchema);
+const CompiledZChainName = z.compile(ZChainName);
+
 export function readChainConfigs(filePath: string) {
   log(`Reading file configs in ${filePath}`);
   const chainMetadata = readYamlOrJson<ChainMetadata>(filePath);
@@ -31,7 +35,7 @@ export function readChainConfigs(filePath: string) {
   }
 
   // Validate configs from file and merge in core configs as needed
-  const parseResult = ChainMetadataSchema.safeParse(chainMetadata);
+  const parseResult = CompiledChainMetadataSchema.safeParse(chainMetadata);
   if (!parseResult.success) {
     errorRed(
       `Chain config for ${filePath} is invalid, please see https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/cli/examples/chain-config.yaml for an example`,
@@ -62,7 +66,7 @@ export async function createChainConfig({
 
   const name = await input({
     message: 'Enter chain name (one word, lower case)',
-    validate: (chainName) => ZChainName.safeParse(chainName).success,
+    validate: (chainName) => z.validate(CompiledZChainName, chainName),
   });
 
   const displayName = await input({

--- a/typescript/cli/src/config/multisig.ts
+++ b/typescript/cli/src/config/multisig.ts
@@ -24,12 +24,13 @@ const MultisigConfigMapSchema = z.object({}).catchall(
     validators: z.array(ZHash),
   }),
 );
+const CompiledMultisigConfigMapSchema = z.compile(MultisigConfigMapSchema);
 export type MultisigConfigMap = z.infer<typeof MultisigConfigMapSchema>;
 
 export function readMultisigConfig(filePath: string) {
   const config = readYamlOrJson(filePath);
   if (!config) throw new Error(`No multisig config found at ${filePath}`);
-  const result = MultisigConfigMapSchema.safeParse(config);
+  const result = CompiledMultisigConfigMapSchema.safeParse(config);
   if (!result.success) {
     const firstIssue = result.error.issues[0];
     throw new Error(
@@ -61,8 +62,8 @@ export function readMultisigConfig(filePath: string) {
   return formattedConfig;
 }
 
-export function isValidMultisigConfig(config: any) {
-  return MultisigConfigMapSchema.safeParse(config).success;
+export function isValidMultisigConfig(config: unknown) {
+  return z.validate(CompiledMultisigConfigMapSchema, config);
 }
 
 export async function createMultisigConfig({

--- a/typescript/cli/src/config/warp.ts
+++ b/typescript/cli/src/config/warp.ts
@@ -1,5 +1,6 @@
 import { confirm, input, select } from '@inquirer/prompts';
 import { stringify as yamlStringify } from 'yaml';
+import { z } from 'zod';
 
 import {
   type ChainMap,
@@ -186,8 +187,8 @@ export async function readWarpRouteDeployConfig({
   return WarpRouteDeployConfigMailboxRequiredSchema.parse(config);
 }
 
-export function isValidWarpRouteDeployConfig(config: any) {
-  return WarpRouteDeployConfigSchema.safeParse(config).success;
+export function isValidWarpRouteDeployConfig(config: unknown) {
+  return z.validate(WarpRouteDeployConfigSchema, config);
 }
 
 export async function createWarpRouteDeployConfig({

--- a/typescript/fee-quoting/src/routes/quote.ts
+++ b/typescript/fee-quoting/src/routes/quote.ts
@@ -34,12 +34,18 @@ const IcaQuerySchema = z.object({
   salt: bytes32Schema,
 });
 
+const CompiledWarpQuerySchema = z.compile(WarpQuerySchema);
+const CompiledWarpQueryWithTargetRouterSchema = z.compile(
+  WarpQueryWithTargetRouterSchema,
+);
+const CompiledIcaQuerySchema = z.compile(IcaQuerySchema);
+
 export function createQuoteRouter(quoteService: QuoteService): Router {
   const router = Router();
 
   function warpHandler(command: FeeQuotingCommand) {
     return async (req: Request, res: Response) => {
-      const data = parseAndValidate(WarpQuerySchema, req.query);
+      const data = parseAndValidate(CompiledWarpQuerySchema, req.query);
       const response = await quoteService.getQuote(
         data.origin,
         command,
@@ -54,7 +60,7 @@ export function createQuoteRouter(quoteService: QuoteService): Router {
 
   function icaHandler(command: FeeQuotingCommand) {
     return async (req: Request, res: Response) => {
-      const data = parseAndValidate(IcaQuerySchema, req.query);
+      const data = parseAndValidate(CompiledIcaQuerySchema, req.query);
       const response = await quoteService.getQuote(
         data.origin,
         command,
@@ -73,7 +79,10 @@ export function createQuoteRouter(quoteService: QuoteService): Router {
   router.get(
     '/transferRemoteTo',
     asyncHandler(async (req: Request, res: Response) => {
-      const data = parseAndValidate(WarpQueryWithTargetRouterSchema, req.query);
+      const data = parseAndValidate(
+        CompiledWarpQueryWithTargetRouterSchema,
+        req.query,
+      );
       const response = await quoteService.getQuote(
         data.origin,
         FeeQuotingCommand.TransferRemoteTo,

--- a/typescript/fee-quoting/src/routes/quote.v2.ts
+++ b/typescript/fee-quoting/src/routes/quote.v2.ts
@@ -36,6 +36,9 @@ const IgpQuerySchema = z.object({
   txSubmitter: protocolAddressSchema,
 });
 
+const CompiledWarpQuerySchema = z.compile(WarpQuerySchema);
+const CompiledIgpQuerySchema = z.compile(IgpQuerySchema);
+
 /**
  * v2 quote routes — split by quoter type rather than by command. Each route
  * returns at most one signed quote (`QuoteV2Response`) or a 404
@@ -54,7 +57,7 @@ export function createQuoteV2Router(quoteService: QuoteService): Router {
   router.get(
     '/warp',
     asyncHandler(async (req: Request, res: Response) => {
-      const data = parseAndValidate(WarpQuerySchema, req.query);
+      const data = parseAndValidate(CompiledWarpQuerySchema, req.query);
       const quote = await quoteService.getWarpQuoteV2(data);
       const response: QuoteV2Response = { quote };
       res.json(response);
@@ -64,7 +67,7 @@ export function createQuoteV2Router(quoteService: QuoteService): Router {
   router.get(
     '/igp',
     asyncHandler(async (req: Request, res: Response) => {
-      const data = parseAndValidate(IgpQuerySchema, req.query);
+      const data = parseAndValidate(CompiledIgpQuerySchema, req.query);
       const quote = await quoteService.getIgpQuoteV2(data);
       const response: QuoteV2Response = { quote };
       res.json(response);

--- a/typescript/http-registry-server/src/middleware/validateRequest.ts
+++ b/typescript/http-registry-server/src/middleware/validateRequest.ts
@@ -4,72 +4,19 @@ import { z } from 'zod';
 import { AppConstants } from '../constants/index.js';
 import { ApiError } from '../errors/ApiError.js';
 
-interface ValidationError {
-  issues: readonly {
-    message: string;
-    path: readonly PropertyKey[];
-  }[];
-}
-
-type SafeParseSchema<Output> = {
-  safeParse: (
-    input: unknown,
-  ) =>
-    | { success: true; data: Output }
-    | { success: false; error: ValidationError };
-};
-
-/** Remove after @hyperlane-xyz/registry publishes Zod 4 schemas. */
-export function legacyRegistrySchema<Output>(
-  schema: SafeParseSchema<Output>,
-): z.ZodType<Output> {
-  return z.unknown().transform((input, context) => {
-    const parsed = schema.safeParse(input);
-    if (parsed.success) return parsed.data;
-
-    for (const issue of parsed.error.issues) {
-      context.addIssue({
-        code: 'custom',
-        message: issue.message,
-        path: [...issue.path],
-      });
-    }
-    return z.NEVER;
-  });
-}
-
-function isZod4Error(error: ValidationError): error is z.ZodError {
-  return error instanceof z.ZodError;
-}
-
-function formatValidationError(error: ValidationError): string {
-  if (isZod4Error(error)) {
-    return z.prettifyError(error);
-  }
-
-  // Registry schemas currently expose Zod 3 errors, so retain a small
-  // structural fallback until the registry publishes Zod 4 schemas.
-  return error.issues
-    .map(({ message, path }) =>
-      path.length
-        ? `✖ ${message}\n  → at ${path.map(String).join('.')}`
-        : `✖ ${message}`,
-    )
-    .join('\n');
-}
-
 export function validateQueryParams<Output extends object>(
-  schema: SafeParseSchema<Output>,
+  schema: z.ZodType<Output>,
 ) {
+  const compiledSchema = z.compile(schema);
   return (req: Request, _res: Response, next: NextFunction) => {
-    const parsed = schema.safeParse(req.query);
+    const parsed = compiledSchema.safeParse(req.query);
     if (parsed.success) {
       Object.assign(req.query, parsed.data);
       next();
     } else {
       next(
         new ApiError(
-          `Validation error in query parameters: ${formatValidationError(parsed.error)}`,
+          `Validation error in query parameters: ${z.prettifyError(parsed.error)}`,
           AppConstants.HTTP_STATUS_BAD_REQUEST,
         ),
       );
@@ -79,17 +26,18 @@ export function validateQueryParams<Output extends object>(
 
 export function validateRequestParam<Output extends string | string[]>(
   name: string,
-  schema: SafeParseSchema<Output>,
+  schema: z.ZodType<Output>,
 ) {
+  const compiledSchema = z.compile(schema);
   return (req: Request, _res: Response, next: NextFunction) => {
-    const parsed = schema.safeParse(req.params[name]);
+    const parsed = compiledSchema.safeParse(req.params[name]);
     if (parsed.success) {
       req.params[name] = parsed.data;
       next();
     } else {
       next(
         new ApiError(
-          `Validation error for param '${name}': ${formatValidationError(parsed.error)}`,
+          `Validation error for param '${name}': ${z.prettifyError(parsed.error)}`,
           AppConstants.HTTP_STATUS_BAD_REQUEST,
         ),
       );
@@ -97,16 +45,17 @@ export function validateRequestParam<Output extends string | string[]>(
   };
 }
 
-export function validateBody<Output>(schema: SafeParseSchema<Output>) {
+export function validateBody<Output>(schema: z.ZodType<Output>) {
+  const compiledSchema = z.compile(schema);
   return (req: Request, _res: Response, next: NextFunction) => {
-    const parsed = schema.safeParse(req.body);
+    const parsed = compiledSchema.safeParse(req.body);
     if (parsed.success) {
       req.body = parsed.data; // Assign the parsed (and potentially transformed) body back
       next();
     } else {
       next(
         new ApiError(
-          `Validation error in body: ${formatValidationError(parsed.error)}`,
+          `Validation error in body: ${z.prettifyError(parsed.error)}`,
           AppConstants.HTTP_STATUS_BAD_REQUEST,
         ),
       );
@@ -116,17 +65,18 @@ export function validateBody<Output>(schema: SafeParseSchema<Output>) {
 
 export function validateQueryParam<Output>(
   name: string,
-  schema: SafeParseSchema<Output>,
+  schema: z.ZodType<Output>,
 ) {
+  const compiledSchema = z.compile(schema);
   return (req: Request, _res: Response, next: NextFunction) => {
-    const parsed = schema.safeParse(req.query[name]);
+    const parsed = compiledSchema.safeParse(req.query[name]);
     if (parsed.success) {
       Object.assign(req.query, { [name]: parsed.data });
       next();
     } else {
       next(
         new ApiError(
-          `Validation error in query: ${formatValidationError(parsed.error)}`,
+          `Validation error in query: ${z.prettifyError(parsed.error)}`,
           AppConstants.HTTP_STATUS_BAD_REQUEST,
         ),
       );

--- a/typescript/http-registry-server/src/routes/chain.ts
+++ b/typescript/http-registry-server/src/routes/chain.ts
@@ -1,12 +1,10 @@
 import { Request, Response, Router } from 'express';
-import { z } from 'zod';
 
-import { ChainAddressesSchema } from '@hyperlane-xyz/registry';
-import { ChainMetadataSchema, ZChainName } from '@hyperlane-xyz/sdk';
+import { UpdateChainSchema } from '@hyperlane-xyz/registry';
+import { ZChainName } from '@hyperlane-xyz/sdk';
 
 import { AppConstants } from '../constants/AppConstants.js';
 import {
-  legacyRegistrySchema,
   validateBody,
   validateRequestParam,
 } from '../middleware/validateRequest.js';
@@ -16,14 +14,6 @@ import { ChainService } from '../services/chainService.js';
 export interface ChainRouterOptions {
   writeMode?: boolean;
 }
-
-// The published registry's UpdateChainSchema combines its Zod 3 object with
-// the consumer-provided SDK schema, which is Zod 4 after this migration.
-// Compose the same boundary in Zod 4 until the linked registry release lands.
-const UpdateChainBodySchema = z.strictObject({
-  metadata: ChainMetadataSchema.optional(),
-  addresses: legacyRegistrySchema(ChainAddressesSchema).optional(),
-});
 
 export function createChainRouter(
   chainService: ChainService,
@@ -54,7 +44,7 @@ export function createChainRouter(
     '/:chain',
     requireWriteMode(writeMode),
     validateRequestParam('chain', ZChainName),
-    validateBody(UpdateChainBodySchema),
+    validateBody(UpdateChainSchema.strict()),
     async (req: Request<{ chain: string }>, res: Response) => {
       await chainService.updateChain({
         chainName: req.params.chain,

--- a/typescript/http-registry-server/src/routes/warp.ts
+++ b/typescript/http-registry-server/src/routes/warp.ts
@@ -13,7 +13,6 @@ import {
 import { AppConstants } from '../constants/AppConstants.js';
 import {
   joinPathSegments,
-  legacyRegistrySchema,
   validateBody,
   validateQueryParams,
   validateRequestParam,
@@ -27,12 +26,12 @@ export interface WarpRouterOptions {
 
 const AddWarpRouteBodySchema = z.object({
   config: WarpCoreConfigSchema,
-  options: legacyRegistrySchema(AddWarpRouteConfigOptionsSchema).optional(),
+  options: AddWarpRouteConfigOptionsSchema.optional(),
 });
 
 const AddWarpRouteConfigBodySchema = z.object({
   config: WarpRouteDeployConfigSchema,
-  options: legacyRegistrySchema(AddWarpRouteConfigOptionsSchema),
+  options: AddWarpRouteConfigOptionsSchema,
 });
 
 export function createWarpRouter(

--- a/typescript/http-registry-server/test/middleware/validateRequest.test.ts
+++ b/typescript/http-registry-server/test/middleware/validateRequest.test.ts
@@ -7,7 +7,6 @@ import { z } from 'zod';
 import { AppConstants } from '../../src/constants/AppConstants.js';
 import { ApiError } from '../../src/errors/ApiError.js';
 import {
-  legacyRegistrySchema,
   validateBody,
   validateQueryParam,
   validateQueryParams,
@@ -33,41 +32,6 @@ describe('validateRequest middleware', () => {
 
   afterEach(() => {
     sinon.restore();
-  });
-
-  describe('legacyRegistrySchema', () => {
-    it('returns parsed legacy schema output', () => {
-      const schema = legacyRegistrySchema({
-        safeParse: (_input: unknown) => ({
-          success: true,
-          data: { count: 42 },
-        }),
-      });
-
-      expect(schema.parse('ignored')).to.deep.equal({ count: 42 });
-    });
-
-    it('preserves nested legacy issue paths', () => {
-      const path = ['metadata', 'rpcUrls', 0, 'http'];
-      const schema = legacyRegistrySchema({
-        safeParse: (_input: unknown) => ({
-          success: false,
-          error: {
-            issues: [{ message: 'Invalid URL', path }],
-          },
-        }),
-      });
-
-      const result = schema.safeParse({});
-      expect(result.success).to.be.false;
-      if (!result.success) {
-        expect(result.error.issues).to.deep.include({
-          code: 'custom',
-          message: 'Invalid URL',
-          path,
-        });
-      }
-    });
   });
 
   describe('validateQueryParams', () => {

--- a/typescript/sdk/src/metadata/agentConfig.ts
+++ b/typescript/sdk/src/metadata/agentConfig.ts
@@ -242,6 +242,13 @@ export type AgentSealevelTransactionSubmitter =
 
 export type AgentSealevelUrReveal = AgentSealevelChainMetadata['urReveal'];
 
+const CompiledAgentCosmosChainMetadataSchema = z.compile(
+  AgentCosmosChainMetadataSchema,
+);
+const CompiledAgentSealevelChainMetadataSchema = z.compile(
+  AgentSealevelChainMetadataSchema,
+);
+
 export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
   HyperlaneDeploymentArtifactsSchema.shape,
 )
@@ -340,14 +347,14 @@ export const AgentChainMetadataSchema = ChainMetadataSchemaObject.extend(
       metadata.protocol === ProtocolType.Cosmos ||
       metadata.protocol === ProtocolType.CosmosNative
     ) {
-      if (!AgentCosmosChainMetadataSchema.safeParse(metadata).success) {
+      if (!z.validate(CompiledAgentCosmosChainMetadataSchema, metadata)) {
         return false;
       }
     }
 
     // If the protocol type is Sealevel, require everything in AgentSealevelChainMetadataSchema
     if (metadata.protocol === ProtocolType.Sealevel) {
-      if (!AgentSealevelChainMetadataSchema.safeParse(metadata).success) {
+      if (!z.validate(CompiledAgentSealevelChainMetadataSchema, metadata)) {
         return false;
       }
     }

--- a/typescript/sdk/src/metadata/chainMetadataTypes.ts
+++ b/typescript/sdk/src/metadata/chainMetadataTypes.ts
@@ -444,14 +444,16 @@ export type ChainMetadata<Ext = object> = z.infer<
 > &
   Ext;
 
+const CompiledChainMetadataSchema = z.compile(ChainMetadataSchema);
+
 export function safeParseChainMetadata(
   c: ChainMetadata,
 ): z.ZodSafeParseResult<ChainMetadata> {
-  return ChainMetadataSchema.safeParse(c);
+  return CompiledChainMetadataSchema.safeParse(c);
 }
 
 export function isValidChainMetadata(c: ChainMetadata): boolean {
-  return ChainMetadataSchema.safeParse(c).success;
+  return z.validate(CompiledChainMetadataSchema, c);
 }
 
 export function getDomainId(chainMetadata: ChainMetadata): number {


### PR DESCRIPTION
## Summary

- pin `@hyperlane-xyz/registry@26.0.0`, released from hyperlane-xyz/hyperlane-registry#1683
- remove the HTTP registry server's temporary Zod 3 adapter, reconstructed request schema, and error-format fallback
- compile repeated registry, CCIP, fee-quoting, SDK, and CLI validators once; use `z.validate` where parsed output is not needed
- hoist CCIP relayer-signature schema construction out of the request path
- add a minor monorepo changeset for the native Zod 4 registry boundary

## Local benchmarks

Ratios are old/new elapsed time (`Nx` faster), using representative payloads and the median of 21 alternating paired trials per case. Invalid cases retain full structured Zod errors unless the caller only needs a boolean.

| Package / use case | Valid | Invalid |
| --- | ---: | ---: |
| HTTP registry: update-chain body | 2.5x | 0.9x |
| HTTP registry: warp-route filter | 3.8x | 1.0x |
| HTTP registry: add-route options | 4.2x | 1.0x |
| CCIP: calldata request | 2.5x | 1.0x |
| CCIP: relayer signature | 266.6x | 16.1x |
| Fee quoting: v1 warp query | 2.2x | 1.0x |
| Fee quoting: v2 warp query | 2.6x | 0.8x |
| SDK: chain metadata parse | 2.9x | 0.9x |
| SDK: chain metadata boolean check | 2.8x | 1.2x |
| CLI: chain-name boolean check | 3.9x | 4.4x |
| CLI: multisig boolean check | 2.4x | 3.1x |

The CCIP relayer-signature comparison includes removing per-request schema construction, which dominates that result.

### Service audit

| Service / use case | Valid | Decision |
| --- | ---: | --- |
| Keyfunder config | 2.0x | already preloads `zod/compile` |
| Rebalancer config | 2.5x | already preloads `zod/compile` |
| Relayer config | 9.4x | already preloads `zod/compile` |
| Scraper-proxy env config | 1.3x | already preloads `zod/compile` |
| Warp-monitor full 342-route registry load | 1.0x | no preload added |
| CCIP post-calls request | 0.8x | kept uncompiled |

The warp-monitor result is an end-to-end filesystem registry read: two 21-sample baseline/compiled runs in both orders. Compilation measured 1.0x, so adding a new direct Zod dependency would not be justified.

## Validation

Current rebased release head:

- frozen install resolved `@hyperlane-xyz/registry@26.0.0`
- dependency-aware builds passed for SDK, CLI, HTTP registry server, CCIP server, fee quoting, and their workspace dependencies (23 packages)

Prior beta head `46d60b651e88e4f1582248f1b3b48dd5078817f2`:

- registry `UpdateChainSchema`, `WarpRouteFilterSchema`, and `AddWarpRouteConfigOptionsSchema` compiled with `strict: true`
- tests: HTTP registry server (130), fee quoting (76), CCIP commitment service (54), SDK metadata (12), CLI (188)
- lint: root pre-commit, SDK, CLI, HTTP registry server, CCIP server, and focused fee-quoting files
- full monorepo CI matrix passed
