### PR TITLE
fix(validator): expose checkpoint production readiness

### DIFF
--- a/rust/main/agents/validator/src/server/mod.rs
+++ b/rust/main/agents/validator/src/server/mod.rs
@@ -4,8 +4,9 @@ pub mod merkle_tree_insertions;
 pub use eigen_node::EigenNodeApi;
 
 use std::{
+    collections::BTreeMap,
     sync::{Arc, Mutex, MutexGuard},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Json, Router};
@@ -25,9 +26,14 @@ pub enum ValidatorReadinessState {
 
 #[derive(Debug)]
 struct ValidatorReadinessInner {
-    state: ValidatorReadinessState,
+    healthy_state: ValidatorReadinessState,
+    blockers: BTreeMap<String, ValidatorReadinessFailure>,
+}
+
+#[derive(Debug)]
+struct ValidatorReadinessFailure {
     consecutive_failures: u64,
-    first_failure_at: Option<Instant>,
+    first_failure_at: Instant,
 }
 
 #[derive(Debug, Serialize)]
@@ -36,6 +42,7 @@ pub struct ValidatorReadinessSnapshot {
     pub(crate) consecutive_failures: u64,
     pub(crate) failure_duration_ms: u128,
     pub(crate) signing_blocked: bool,
+    pub(crate) blocked_operations: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -47,9 +54,8 @@ impl Default for ValidatorReadiness {
     fn default() -> Self {
         Self {
             inner: Mutex::new(ValidatorReadinessInner {
-                state: ValidatorReadinessState::Starting,
-                consecutive_failures: 0,
-                first_failure_at: None,
+                healthy_state: ValidatorReadinessState::Starting,
+                blockers: BTreeMap::new(),
             }),
         }
     }
@@ -64,45 +70,63 @@ impl ValidatorReadiness {
 
     pub fn mark_waiting_for_first_message(&self) {
         let mut inner = self.lock();
-        inner.state = ValidatorReadinessState::WaitingForFirstMessage;
-        inner.consecutive_failures = 0;
-        inner.first_failure_at = None;
+        inner.healthy_state = ValidatorReadinessState::WaitingForFirstMessage;
     }
 
-    pub fn mark_ready(&self) {
+    pub fn mark_operation_ready(&self, operation: &str) {
         let mut inner = self.lock();
-        inner.state = ValidatorReadinessState::Ready;
-        inner.consecutive_failures = 0;
-        inner.first_failure_at = None;
+        inner.healthy_state = ValidatorReadinessState::Ready;
+        inner.blockers.remove(operation);
     }
 
-    pub fn mark_signing_blocked(&self) -> ValidatorReadinessSnapshot {
+    pub fn mark_operation_blocked(&self, operation: &str) -> ValidatorReadinessSnapshot {
         let now = Instant::now();
         let mut inner = self.lock();
-        inner.state = ValidatorReadinessState::SigningBlocked;
-        inner.consecutive_failures = inner.consecutive_failures.saturating_add(1);
-        let first_failure_at = *inner.first_failure_at.get_or_insert(now);
-        Self::snapshot_from_inner(&inner, now.saturating_duration_since(first_failure_at))
+        let failure =
+            inner
+                .blockers
+                .entry(operation.to_owned())
+                .or_insert(ValidatorReadinessFailure {
+                    consecutive_failures: 0,
+                    first_failure_at: now,
+                });
+        failure.consecutive_failures = failure.consecutive_failures.saturating_add(1);
+        Self::snapshot_from_inner(&inner, now)
     }
 
     pub fn snapshot(&self) -> ValidatorReadinessSnapshot {
         let inner = self.lock();
-        let failure_duration = inner
-            .first_failure_at
-            .map(|started_at| Instant::now().saturating_duration_since(started_at))
-            .unwrap_or(Duration::ZERO);
-        Self::snapshot_from_inner(&inner, failure_duration)
+        Self::snapshot_from_inner(&inner, Instant::now())
     }
 
     fn snapshot_from_inner(
         inner: &ValidatorReadinessInner,
-        failure_duration: Duration,
+        now: Instant,
     ) -> ValidatorReadinessSnapshot {
+        let state = if inner.blockers.is_empty() {
+            inner.healthy_state
+        } else {
+            ValidatorReadinessState::SigningBlocked
+        };
+        let consecutive_failures = inner
+            .blockers
+            .values()
+            .map(|failure| failure.consecutive_failures)
+            .max()
+            .unwrap_or(0);
+        let failure_duration_ms = inner
+            .blockers
+            .values()
+            .map(|failure| now.saturating_duration_since(failure.first_failure_at))
+            .max()
+            .map(|duration| duration.as_millis())
+            .unwrap_or(0);
         ValidatorReadinessSnapshot {
-            state: inner.state,
-            consecutive_failures: inner.consecutive_failures,
-            failure_duration_ms: failure_duration.as_millis(),
-            signing_blocked: inner.state == ValidatorReadinessState::SigningBlocked,
+            state,
+            consecutive_failures,
+            failure_duration_ms,
+            signing_blocked: state == ValidatorReadinessState::SigningBlocked,
+            blocked_operations: inner.blockers.keys().cloned().collect(),
         }
     }
 }
@@ -183,7 +207,7 @@ mod tests {
     #[tokio::test]
     async fn readiness_is_unhealthy_while_checkpoint_signing_is_blocked() {
         let readiness = Arc::new(ValidatorReadiness::default());
-        readiness.mark_signing_blocked();
+        readiness.mark_operation_blocked("merkle_tree_hook.tree");
 
         assert_eq!(
             readiness_status(test_router(readiness)).await,
@@ -195,15 +219,35 @@ mod tests {
     fn readiness_tracks_consecutive_failures_and_resets_after_recovery() {
         let readiness = ValidatorReadiness::default();
 
-        readiness.mark_signing_blocked();
-        let blocked = readiness.mark_signing_blocked();
+        readiness.mark_operation_blocked("merkle_tree_hook.tree");
+        let blocked = readiness.mark_operation_blocked("merkle_tree_hook.tree");
         assert_eq!(blocked.consecutive_failures, 2);
         assert!(blocked.signing_blocked);
 
-        readiness.mark_ready();
+        readiness.mark_operation_ready("merkle_tree_hook.tree");
         let recovered = readiness.snapshot();
         assert_eq!(recovered.consecutive_failures, 0);
         assert_eq!(recovered.failure_duration_ms, 0);
         assert!(!recovered.signing_blocked);
+    }
+
+    #[test]
+    fn readiness_does_not_clear_an_unrelated_blocker() {
+        let readiness = ValidatorReadiness::default();
+
+        readiness.mark_operation_blocked("merkle_tree_hook.tree");
+        readiness.mark_operation_blocked("base_merkle_tree_hook.count");
+        readiness.mark_waiting_for_first_message();
+        readiness.mark_operation_ready("base_merkle_tree_hook.count");
+
+        let snapshot = readiness.snapshot();
+        assert_eq!(snapshot.state, ValidatorReadinessState::SigningBlocked);
+        assert_eq!(
+            snapshot.blocked_operations,
+            vec!["merkle_tree_hook.tree".to_owned()]
+        );
+
+        readiness.mark_operation_ready("merkle_tree_hook.tree");
+        assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
     }
 }

--- a/rust/main/agents/validator/src/server/mod.rs
+++ b/rust/main/agents/validator/src/server/mod.rs
@@ -3,17 +3,207 @@ pub mod merkle_tree_insertions;
 
 pub use eigen_node::EigenNodeApi;
 
-use std::sync::Arc;
+use std::{
+    sync::{Arc, Mutex, MutexGuard},
+    time::{Duration, Instant},
+};
 
-use axum::Router;
+use axum::{http::StatusCode, response::IntoResponse, routing::get, Json, Router};
 
 use hyperlane_base::CoreMetrics;
 use hyperlane_core::HyperlaneDomain;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidatorReadinessState {
+    Starting,
+    WaitingForFirstMessage,
+    Ready,
+    SigningBlocked,
+}
+
+#[derive(Debug)]
+struct ValidatorReadinessInner {
+    state: ValidatorReadinessState,
+    consecutive_failures: u64,
+    first_failure_at: Option<Instant>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ValidatorReadinessSnapshot {
+    pub(crate) state: ValidatorReadinessState,
+    pub(crate) consecutive_failures: u64,
+    pub(crate) failure_duration_ms: u128,
+    pub(crate) signing_blocked: bool,
+}
+
+#[derive(Debug)]
+pub struct ValidatorReadiness {
+    inner: Mutex<ValidatorReadinessInner>,
+}
+
+impl Default for ValidatorReadiness {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(ValidatorReadinessInner {
+                state: ValidatorReadinessState::Starting,
+                consecutive_failures: 0,
+                first_failure_at: None,
+            }),
+        }
+    }
+}
+
+impl ValidatorReadiness {
+    fn lock(&self) -> MutexGuard<'_, ValidatorReadinessInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub fn mark_waiting_for_first_message(&self) {
+        let mut inner = self.lock();
+        inner.state = ValidatorReadinessState::WaitingForFirstMessage;
+        inner.consecutive_failures = 0;
+        inner.first_failure_at = None;
+    }
+
+    pub fn mark_ready(&self) {
+        let mut inner = self.lock();
+        inner.state = ValidatorReadinessState::Ready;
+        inner.consecutive_failures = 0;
+        inner.first_failure_at = None;
+    }
+
+    pub fn mark_signing_blocked(&self) -> ValidatorReadinessSnapshot {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        inner.state = ValidatorReadinessState::SigningBlocked;
+        inner.consecutive_failures = inner.consecutive_failures.saturating_add(1);
+        let first_failure_at = *inner.first_failure_at.get_or_insert(now);
+        Self::snapshot_from_inner(&inner, now.saturating_duration_since(first_failure_at))
+    }
+
+    pub fn snapshot(&self) -> ValidatorReadinessSnapshot {
+        let inner = self.lock();
+        let failure_duration = inner
+            .first_failure_at
+            .map(|started_at| Instant::now().saturating_duration_since(started_at))
+            .unwrap_or(Duration::ZERO);
+        Self::snapshot_from_inner(&inner, failure_duration)
+    }
+
+    fn snapshot_from_inner(
+        inner: &ValidatorReadinessInner,
+        failure_duration: Duration,
+    ) -> ValidatorReadinessSnapshot {
+        ValidatorReadinessSnapshot {
+            state: inner.state,
+            consecutive_failures: inner.consecutive_failures,
+            failure_duration_ms: failure_duration.as_millis(),
+            signing_blocked: inner.state == ValidatorReadinessState::SigningBlocked,
+        }
+    }
+}
+
+async fn readiness_handler(readiness: Arc<ValidatorReadiness>) -> impl IntoResponse {
+    let snapshot = readiness.snapshot();
+    let status = match snapshot.state {
+        ValidatorReadinessState::WaitingForFirstMessage | ValidatorReadinessState::Ready => {
+            StatusCode::OK
+        }
+        ValidatorReadinessState::Starting | ValidatorReadinessState::SigningBlocked => {
+            StatusCode::SERVICE_UNAVAILABLE
+        }
+    };
+    (status, Json(snapshot))
+}
 
 /// Returns a vector of validator-specific endpoint routes to be served.
 /// Can be extended with additional routes and feature flags to enable/disable individually.
-pub fn router(origin_chain: HyperlaneDomain, metrics: Arc<CoreMetrics>) -> Router {
+pub fn router(
+    origin_chain: HyperlaneDomain,
+    metrics: Arc<CoreMetrics>,
+    readiness: Arc<ValidatorReadiness>,
+) -> Router {
     let eigen_node_api = EigenNodeApi::new(origin_chain, metrics);
 
-    eigen_node_api.router()
+    eigen_node_api.router().route(
+        "/ready",
+        get(move || readiness_handler(Arc::clone(&readiness))),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use prometheus::Registry;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    fn test_router(readiness: Arc<ValidatorReadiness>) -> Router {
+        router(
+            HyperlaneDomain::new_test_domain("ethereum"),
+            Arc::new(
+                CoreMetrics::new("validator", 9090, Registry::new())
+                    .expect("test metrics should be valid"),
+            ),
+            readiness,
+        )
+    }
+
+    async fn readiness_status(app: Router) -> StatusCode {
+        app.oneshot(
+            Request::builder()
+                .uri("/ready")
+                .body(Body::empty())
+                .expect("readiness request should be valid"),
+        )
+        .await
+        .expect("readiness request should succeed")
+        .status()
+    }
+
+    #[tokio::test]
+    async fn readiness_is_healthy_while_waiting_for_first_message() {
+        let readiness = Arc::new(ValidatorReadiness::default());
+        readiness.mark_waiting_for_first_message();
+
+        assert_eq!(
+            readiness_status(test_router(readiness)).await,
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn readiness_is_unhealthy_while_checkpoint_signing_is_blocked() {
+        let readiness = Arc::new(ValidatorReadiness::default());
+        readiness.mark_signing_blocked();
+
+        assert_eq!(
+            readiness_status(test_router(readiness)).await,
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn readiness_tracks_consecutive_failures_and_resets_after_recovery() {
+        let readiness = ValidatorReadiness::default();
+
+        readiness.mark_signing_blocked();
+        let blocked = readiness.mark_signing_blocked();
+        assert_eq!(blocked.consecutive_failures, 2);
+        assert!(blocked.signing_blocked);
+
+        readiness.mark_ready();
+        let recovered = readiness.snapshot();
+        assert_eq!(recovered.consecutive_failures, 0);
+        assert_eq!(recovered.failure_duration_ms, 0);
+        assert!(!recovered.signing_blocked);
+    }
 }

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -21,6 +21,7 @@ use hyperlane_core::{
 use hyperlane_ethereum::{Signers, SingletonSignerHandle};
 
 use crate::reorg_reporter::ReorgReporter;
+use crate::server::ValidatorReadiness;
 
 const CHECKPOINT_SUBMISSION_CHUNK_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -38,6 +39,7 @@ pub(crate) struct ValidatorSubmitter {
     metrics: ValidatorSubmitterMetrics,
     max_sign_concurrency: usize,
     reorg_reporter: Arc<dyn ReorgReporter>,
+    readiness: Arc<ValidatorReadiness>,
 }
 
 impl ValidatorSubmitter {
@@ -54,6 +56,7 @@ impl ValidatorSubmitter {
         metrics: ValidatorSubmitterMetrics,
         max_sign_concurrency: usize,
         reorg_reporter: Arc<dyn ReorgReporter>,
+        readiness: Arc<ValidatorReadiness>,
     ) -> Self {
         Self {
             reorg_period,
@@ -67,6 +70,7 @@ impl ValidatorSubmitter {
             metrics,
             max_sign_concurrency,
             reorg_reporter,
+            readiness,
         }
     }
 
@@ -274,6 +278,7 @@ impl ValidatorSubmitter {
         // All intermediate checkpoints will be stored here and signed once the correctness
         // checkpoint is reached.
         let mut checkpoint_queue = vec![];
+        let mut blocked_insertion_operation: Option<String> = None;
 
         // If the correctness checkpoint is ahead of the tree, we need to ingest more messages.
         //
@@ -286,8 +291,25 @@ impl ValidatorSubmitter {
                 .expect("Failed to fetch merkle tree insertion");
 
             let insertion = match res {
-                Some(insertion) => insertion,
+                Some(insertion) => {
+                    if let Some(operation) = blocked_insertion_operation.take() {
+                        self.readiness.mark_operation_ready(&operation);
+                    }
+                    insertion
+                }
                 None => {
+                    if blocked_insertion_operation.is_none() {
+                        let operation = format!("merkle_tree_insertion[{}]", tree.count());
+                        let snapshot = self.readiness.mark_operation_blocked(&operation);
+                        warn!(
+                            operation,
+                            consecutive_failures = snapshot.consecutive_failures,
+                            failure_duration_ms = snapshot.failure_duration_ms,
+                            signing_blocked = snapshot.signing_blocked,
+                            "Validator checkpoint production is waiting for an indexed merkle tree insertion"
+                        );
+                        blocked_insertion_operation = Some(operation);
+                    }
                     // If we haven't yet indexed the next merkle tree insertion but know that
                     // it will soon exist (because we know the correctness checkpoint), wait a bit and
                     // try again.
@@ -502,13 +524,32 @@ impl ValidatorSubmitter {
 
             let futures = chunk.into_iter().map(|checkpoint| {
                 let self_clone = arc_self.clone();
+                let operation = format!("checkpoint_submission[{}]", checkpoint.index);
                 call_and_retry_indefinitely(move || {
                     let self_clone = self_clone.clone();
+                    let operation = operation.clone();
                     Box::pin(async move {
                         let start = Instant::now();
                         let checkpoint_index = checkpoint.index;
-                        let wrote_checkpoint =
-                            self_clone.sign_and_submit_checkpoint(checkpoint).await?;
+                        let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
+                        let wrote_checkpoint = match result {
+                            Ok(wrote_checkpoint) => {
+                                self_clone.readiness.mark_operation_ready(&operation);
+                                wrote_checkpoint
+                            }
+                            Err(error) => {
+                                let snapshot =
+                                    self_clone.readiness.mark_operation_blocked(&operation);
+                                warn!(
+                                    operation,
+                                    consecutive_failures = snapshot.consecutive_failures,
+                                    failure_duration_ms = snapshot.failure_duration_ms,
+                                    signing_blocked = snapshot.signing_blocked,
+                                    "Validator checkpoint submission is blocked"
+                                );
+                                return Err(error);
+                            }
+                        };
                         tracing::info!(
                             index = checkpoint_index,
                             wrote_checkpoint,
@@ -535,10 +576,28 @@ impl ValidatorSubmitter {
                     let self_clone = self.clone();
                     Box::pin(async move {
                         let start = Instant::now();
-                        self_clone
+                        let result = self_clone
                             .checkpoint_syncer
                             .update_latest_index(last_checkpoint_index)
-                            .await?;
+                            .await;
+                        match result {
+                            Ok(()) => self_clone
+                                .readiness
+                                .mark_operation_ready("checkpoint_latest_index"),
+                            Err(error) => {
+                                let snapshot = self_clone
+                                    .readiness
+                                    .mark_operation_blocked("checkpoint_latest_index");
+                                warn!(
+                                    operation = "checkpoint_latest_index",
+                                    consecutive_failures = snapshot.consecutive_failures,
+                                    failure_duration_ms = snapshot.failure_duration_ms,
+                                    signing_blocked = snapshot.signing_blocked,
+                                    "Validator latest checkpoint index update is blocked"
+                                );
+                                return Err(error.into());
+                            }
+                        }
                         tracing::trace!(
                             elapsed=?start.elapsed(),
                             "Updated latest index",

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -20,6 +20,7 @@ use hyperlane_core::{
 };
 
 use super::*;
+use crate::server::ValidatorReadinessState;
 
 mockall::mock! {
     pub MerkleTreeHook {}
@@ -95,6 +96,10 @@ fn dummy_singleton_handle() -> SingletonSignerHandle {
     SingletonSignerHandle::new(H160::from_low_u64_be(0), mpsc::unbounded_channel().0)
 }
 
+fn dummy_readiness() -> Arc<ValidatorReadiness> {
+    Arc::new(ValidatorReadiness::default())
+}
+
 #[tokio::test(start_paused = true)]
 async fn single_checkpoint_chunk_has_no_throttle_tail() {
     let checkpoint = CheckpointWithMessageId {
@@ -135,6 +140,7 @@ async fn single_checkpoint_chunk_has_no_throttle_tail() {
         dummy_metrics(),
         1,
         Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -151,6 +157,175 @@ async fn single_checkpoint_chunk_has_no_throttle_tail() {
         "a final checkpoint chunk must not wait for the 100ms inter-chunk throttle"
     );
     task.await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn checkpoint_submission_failure_blocks_readiness_until_recovery() {
+    let checkpoint = CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index: 7,
+        },
+        message_id: H256::zero(),
+    };
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(2)
+        .returning(|_| Ok(None));
+    let write_calls = Arc::new(AtomicUsize::new(0));
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .times(2)
+        .returning({
+            let write_calls = Arc::clone(&write_calls);
+            move |_| {
+                if write_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(eyre::eyre!("storage unavailable"))
+                } else {
+                    Ok(())
+                }
+            }
+        });
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(checkpoint.index))
+        .once()
+        .returning(|_| Ok(()));
+
+    let readiness = Arc::new(ValidatorReadiness::default());
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+        Arc::clone(&readiness),
+    );
+
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(vec![checkpoint])
+            .await;
+    });
+    while write_calls.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    let blocked = readiness.snapshot();
+    assert_eq!(blocked.state, ValidatorReadinessState::SigningBlocked);
+    assert_eq!(
+        blocked.blocked_operations,
+        vec!["checkpoint_submission[7]".to_owned()]
+    );
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    task.await.expect("checkpoint submission should recover");
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+}
+
+#[tokio::test(start_paused = true)]
+async fn missing_merkle_insertion_blocks_readiness_until_indexer_recovers() {
+    let insertion = MerkleTreeInsertion::new(0, H256::random());
+    let mut expected_tree = IncrementalMerkle::default();
+    expected_tree.ingest(insertion.message_id());
+
+    let db_calls = Arc::new(AtomicUsize::new(0));
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .with(mockall::predicate::eq(0))
+        .times(2)
+        .returning({
+            let db_calls = Arc::clone(&db_calls);
+            move |_| {
+                if db_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(None)
+                } else {
+                    Ok(Some(insertion))
+                }
+            }
+        });
+
+    let domain = dummy_domain(0, "dummy_domain");
+    let mut merkle_tree_hook = MockMerkleTreeHook::new();
+    merkle_tree_hook.expect_address().returning(H256::zero);
+    merkle_tree_hook
+        .expect_domain()
+        .return_const(domain.clone());
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .once()
+        .returning(|_| Ok(None));
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .once()
+        .returning(|_| Ok(()));
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(0))
+        .once()
+        .returning(|_| Ok(()));
+
+    let readiness = Arc::new(ValidatorReadiness::default());
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(merkle_tree_hook),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(db),
+        dummy_metrics(),
+        1,
+        Arc::new(MockReorgReporter::new()),
+        Arc::clone(&readiness),
+    );
+    let correctness_checkpoint = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: expected_tree.root(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: domain.id(),
+            index: 0,
+        },
+        block_height: Some(1),
+    };
+
+    let task = tokio::spawn(async move {
+        submitter
+            .submit_checkpoints_until_correctness_checkpoint(
+                &mut IncrementalMerkle::default(),
+                &correctness_checkpoint,
+            )
+            .await;
+    });
+    while db_calls.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    let blocked = readiness.snapshot();
+    assert_eq!(blocked.state, ValidatorReadinessState::SigningBlocked);
+    assert_eq!(
+        blocked.blocked_operations,
+        vec!["merkle_tree_insertion[0]".to_owned()]
+    );
+
+    tokio::time::advance(Duration::from_millis(100)).await;
+    task.await.expect("checkpoint submission should recover");
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
 }
 
 #[tokio::test(start_paused = true)]
@@ -193,6 +368,7 @@ async fn two_written_chunks_have_one_inter_chunk_throttle() {
         dummy_metrics(),
         1,
         Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -266,6 +442,7 @@ async fn all_existing_chunks_skip_inter_chunk_throttle() {
         dummy_metrics(),
         1,
         Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -341,6 +518,7 @@ async fn checkpoint_submitter_skips_latest_checkpoint_without_new_messages() {
         dummy_metrics(),
         1,
         Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -437,6 +615,7 @@ async fn checkpoint_submitter_quorum_verifies_base_checkpoint_ahead_of_observed_
         dummy_metrics(),
         1,
         Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -547,6 +726,7 @@ async fn checkpoint_submitter_detects_reorg_when_count_is_unchanged() {
         dummy_metrics(),
         1,
         Arc::new(mock_reorg_reporter),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -619,6 +799,7 @@ async fn checkpoint_submitter_fetches_latest_checkpoint_when_new_message_arrives
         dummy_metrics(),
         1,
         Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
     );
 
     let task = tokio::spawn(async move {
@@ -760,6 +941,7 @@ async fn reorg_is_detected_and_persisted_to_checkpoint_storage() {
         dummy_metrics(),
         50,
         Arc::new(mock_reorg_reporter),
+        dummy_readiness(),
     );
 
     // mock the correctness checkpoint response
@@ -879,6 +1061,7 @@ async fn sign_and_submit_checkpoint_same_signature() {
         dummy_metrics(),
         50,
         Arc::new(mock_reorg_reporter),
+        dummy_readiness(),
     );
 
     // Start the submitter with an empty merkle tree, so it gets rebuilt from the db.
@@ -999,6 +1182,7 @@ async fn sign_and_submit_checkpoint_different_signature() {
         dummy_metrics(),
         50,
         Arc::new(mock_reorg_reporter),
+        dummy_readiness(),
     );
 
     // Start the submitter with an empty merkle tree, so it gets rebuilt from the db.

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -30,11 +30,11 @@ use hyperlane_base::{
     SequencedDataContractSync,
 };
 use hyperlane_core::{
-    rpc_clients::{call_and_retry_indefinitely, RPC_RETRY_SLEEP_DURATION},
-    Announcement, ChainCommunicationError, ChainResult, Checkpoint, CheckpointAtBlock,
-    HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneSigner, HyperlaneSignerExt,
-    IncrementalMerkleAtBlock, Mailbox, MerkleTreeHook, MerkleTreeInsertion, ReorgPeriod, TxOutcome,
-    ValidatorAnnounce, ValidatorAnnounceSubmission, H256, U256,
+    rpc_clients::RPC_RETRY_SLEEP_DURATION, Announcement, ChainCommunicationError, ChainResult,
+    Checkpoint, CheckpointAtBlock, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
+    HyperlaneSigner, HyperlaneSignerExt, IncrementalMerkleAtBlock, Mailbox, MerkleTreeHook,
+    MerkleTreeInsertion, ReorgPeriod, TxOutcome, ValidatorAnnounce, ValidatorAnnounceSubmission,
+    H256, U256,
 };
 use hyperlane_ethereum::{RpcConnectionConf, Signers, SingletonSigner, SingletonSignerHandle};
 use hyperlane_metric::prometheus_metric::RpcRole;
@@ -42,7 +42,7 @@ use hyperlane_metric::prometheus_metric::RpcRole;
 use crate::reorg_reporter::{
     LatestCheckpointReorgReporter, LatestCheckpointReorgReporterWithStorageWriter, ReorgReporter,
 };
-use crate::server::{self as validator_server, merkle_tree_insertions};
+use crate::server::{self as validator_server, merkle_tree_insertions, ValidatorReadiness};
 use crate::{
     settings::ValidatorSettings,
     submit::{ValidatorSubmitter, ValidatorSubmitterMetrics},
@@ -178,6 +178,135 @@ const QUORUM_RPC_CALL_TIMEOUT: Duration = Duration::from_secs(20);
 /// all must unanimously agree.
 const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 
+/// Connects safety-critical MerkleTreeHook reads to the validator readiness endpoint. An empty
+/// tree is an expected ready state because there is nothing to sign. Once a tree exists, any
+/// failed correctness read blocks signing and readiness until a later read succeeds.
+#[derive(Debug)]
+struct ReadinessMerkleTreeHook {
+    inner: Arc<dyn MerkleTreeHook>,
+    readiness: Arc<ValidatorReadiness>,
+}
+
+impl ReadinessMerkleTreeHook {
+    fn new(inner: Arc<dyn MerkleTreeHook>, readiness: Arc<ValidatorReadiness>) -> Self {
+        Self { inner, readiness }
+    }
+
+    fn record_checkpoint_read<T>(&self, operation: &str, result: &ChainResult<T>) {
+        match result {
+            Ok(_) => self.readiness.mark_ready(),
+            Err(_) => {
+                let snapshot = self.readiness.mark_signing_blocked();
+                warn!(
+                    operation,
+                    consecutive_failures = snapshot.consecutive_failures,
+                    failure_duration_ms = snapshot.failure_duration_ms,
+                    signing_blocked = snapshot.signing_blocked,
+                    "Validator checkpoint production is blocked"
+                );
+            }
+        }
+    }
+
+    fn record_count(&self, result: &ChainResult<u32>) {
+        match result {
+            Ok(0) => self.readiness.mark_waiting_for_first_message(),
+            Ok(_) => {}
+            Err(_) => {
+                let snapshot = self.readiness.mark_signing_blocked();
+                warn!(
+                    operation = "count",
+                    consecutive_failures = snapshot.consecutive_failures,
+                    failure_duration_ms = snapshot.failure_duration_ms,
+                    signing_blocked = snapshot.signing_blocked,
+                    "Validator checkpoint production is blocked"
+                );
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl MerkleTreeHook for ReadinessMerkleTreeHook {
+    async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
+        let result = self.inner.tree(reorg_period).await;
+        self.record_checkpoint_read("tree", &result);
+        result
+    }
+
+    async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+        let result = self.inner.count(reorg_period).await;
+        self.record_count(&result);
+        result
+    }
+
+    async fn latest_checkpoint(
+        &self,
+        reorg_period: &ReorgPeriod,
+    ) -> ChainResult<CheckpointAtBlock> {
+        let result = self.inner.latest_checkpoint(reorg_period).await;
+        self.record_checkpoint_read("latest_checkpoint", &result);
+        result
+    }
+
+    async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
+        let result = self.inner.latest_checkpoint_at_block(height).await;
+        self.record_checkpoint_read("latest_checkpoint_at_block", &result);
+        result
+    }
+
+    async fn tree_at_block(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
+        let result = self.inner.tree_at_block(height).await;
+        self.record_checkpoint_read("tree_at_block", &result);
+        result
+    }
+}
+
+impl HyperlaneChain for ReadinessMerkleTreeHook {
+    fn domain(&self) -> &HyperlaneDomain {
+        self.inner.domain()
+    }
+
+    fn provider(&self) -> Box<dyn hyperlane_core::HyperlaneProvider> {
+        self.inner.provider()
+    }
+}
+
+impl HyperlaneContract for ReadinessMerkleTreeHook {
+    fn address(&self) -> H256 {
+        self.inner.address()
+    }
+}
+
+async fn wait_for_first_message(
+    merkle_tree_hook: Arc<dyn MerkleTreeHook>,
+    reorg_period: &ReorgPeriod,
+    interval: Duration,
+    readiness: &ValidatorReadiness,
+) -> IncrementalMerkleAtBlock {
+    loop {
+        match merkle_tree_hook.count(reorg_period).await {
+            Err(_) => {
+                error!("Error getting merkle tree count");
+            }
+            Ok(0) => {
+                info!("Waiting for first message in merkle tree hook");
+            }
+            Ok(_) => match merkle_tree_hook.tree(reorg_period).await {
+                Err(_) => {
+                    error!("Error getting merkle tree");
+                }
+                Ok(tree) if tree.count() == 0 => {
+                    readiness.mark_waiting_for_first_message();
+                    info!("Waiting for first message in merkle tree hook");
+                }
+                Ok(tree) => return tree,
+            },
+        }
+        sleep(interval).await;
+    }
+}
+
 /// `count()`/domain/address come from `base_hook` (the normal `rpcUrls` connection, using
 /// whatever consensus mode it's configured with). `tree()`/`tree_at_block()` — the actual
 /// merkle tree root reads — require BOTH: a 2/3 majority across `quorum_hooks` (one entry
@@ -262,7 +391,7 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         context: &str,
     ) -> ChainResult<T> {
         let mut oks: Vec<(String, T)> = Vec::new();
-        let mut first_err = None;
+        let mut failed_rpc_labels: Vec<String> = Vec::new();
         // Identified by label prefix (see `build_validator_ethereum_per_url_hooks`), not a
         // separate role field: purely observational, doesn't affect the threshold below. A
         // `Primary` (`rpcUrls`) failure is notable even when the round still succeeds via
@@ -273,13 +402,11 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
         for (label, result) in results {
             match result {
                 Ok(value) => oks.push((label, value)),
-                Err(err) => {
+                Err(_) => {
                     if label.starts_with("rpcUrls[") {
                         failed_primary_rpcs.push(label.clone());
                     }
-                    if first_err.is_none() {
-                        first_err = Some(err);
-                    }
+                    failed_rpc_labels.push(label);
                 }
             }
         }
@@ -330,27 +457,28 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
             }
         }
 
-        if oks.is_empty() {
-            return Err(
-                first_err.unwrap_or_else(|| ChainCommunicationError::from_other_str(context))
-            );
-        }
-
         let responding_rpcs: Vec<&str> = oks.iter().map(|(label, _)| label.as_str()).collect();
+        let configured_endpoint_count = self.quorum_hooks.len();
+        let successful_endpoint_count = oks.len();
+        let failed_endpoint_count = failed_rpc_labels.len();
         warn!(
             context,
-            total_successful = oks.len(),
-            max_agreeing,
-            threshold,
+            configured_endpoint_count,
+            successful_endpoint_count,
+            failed_endpoint_count,
+            failed_endpoint_labels = ?failed_rpc_labels,
+            required_threshold = threshold,
+            maximum_agreeing_responses = max_agreeing,
             responding_rpcs = ?responding_rpcs,
             best_agreeing_rpcs = ?best_agreeing_rpcs,
-            "Failed to reach quorum: no value reached a 2/3 majority"
+            signing_blocked = true,
+            "Failed to reach quorum: no value reached the configured threshold"
         );
         debug!(context, all_values = ?oks, "Full quorum candidate values by RPC");
         Err(ChainCommunicationError::from_other_str(&format!(
-            "{context}; best candidate had {max_agreeing}/{threshold} needed \
-             (of {total} quorum RPCs)",
-            total = oks.len()
+            "{context}; maximum agreeing responses {max_agreeing}/{threshold} required; \
+             configured endpoints {configured_endpoint_count}, successful \
+             {successful_endpoint_count}, failed {failed_endpoint_count}"
         )))
     }
 
@@ -522,6 +650,7 @@ pub struct Validator {
     mailbox: Arc<dyn Mailbox>,
     merkle_tree_hook: Arc<dyn MerkleTreeHook>,
     base_merkle_tree_hook: Arc<dyn MerkleTreeHook>,
+    readiness: Arc<ValidatorReadiness>,
     validator_announce: Arc<dyn ValidatorAnnounce>,
     signer: SingletonSignerHandle,
     raw_signer: Signers,
@@ -725,6 +854,11 @@ impl BaseAgent for Validator {
             }
             base_merkle_tree_hook.clone()
         };
+        let readiness = Arc::new(ValidatorReadiness::default());
+        let merkle_tree_hook: Arc<dyn MerkleTreeHook> = Arc::new(ReadinessMerkleTreeHook::new(
+            merkle_tree_hook,
+            Arc::clone(&readiness),
+        ));
 
         let validator_announce = settings
             .build_validator_announce(&settings.origin_chain, &metrics)
@@ -751,6 +885,7 @@ impl BaseAgent for Validator {
             mailbox: mailbox.into(),
             merkle_tree_hook,
             base_merkle_tree_hook,
+            readiness,
             merkle_tree_hook_sync,
             validator_announce: validator_announce.into(),
             signer,
@@ -779,6 +914,7 @@ impl BaseAgent for Validator {
             .merge(validator_server::router(
                 self.origin_chain.clone(),
                 self.core.metrics.clone(),
+                Arc::clone(&self.readiness),
             ))
             .merge(
                 merkle_tree_insertions::list_merkle_tree_insertions::ServerState::new(
@@ -836,22 +972,16 @@ impl BaseAgent for Validator {
         // announce the validator after spawning the signer task
         self.announce().await.expect("Failed to announce validator");
 
-        // wait for the first message before submitting checkpoints
-        loop {
-            match self.merkle_tree_hook.tree(&self.reorg_period).await {
-                Err(err) => {
-                    error!(?err, "Error getting merkle tree");
-                    sleep(self.interval).await;
-                }
-                Ok(tree) if tree.count() == 0 => {
-                    info!("Waiting for first message in merkle tree hook");
-                    sleep(self.interval).await;
-                }
-                Ok(_) => {
-                    break;
-                }
-            }
-        }
+        // `latestCheckpoint()` reverts on an empty MerkleTreeHook because the contract computes
+        // `count - 1`. Query count first so a newly deployed chain is an expected ready state,
+        // then retain the first quorum-verified tree for checkpoint startup.
+        let tip_tree = wait_for_first_message(
+            Arc::clone(&self.merkle_tree_hook),
+            &self.reorg_period,
+            self.interval,
+            &self.readiness,
+        )
+        .await;
 
         let merkle_tree_hook_sync = match self
             .try_n_times_to_run_merkle_tree_hook_sync(CURSOR_INSTANTIATION_ATTEMPTS)
@@ -864,7 +994,7 @@ impl BaseAgent for Validator {
             }
         };
         tasks.push(merkle_tree_hook_sync);
-        for checkpoint_sync_task in self.run_checkpoint_submitters().await {
+        for checkpoint_sync_task in self.run_checkpoint_submitters(tip_tree).await {
             tasks.push(checkpoint_sync_task);
         }
 
@@ -1117,7 +1247,10 @@ impl Validator {
         Ok(handle)
     }
 
-    async fn run_checkpoint_submitters(&self) -> Vec<JoinHandle<()>> {
+    async fn run_checkpoint_submitters(
+        &self,
+        tip_tree: IncrementalMerkleAtBlock,
+    ) -> Vec<JoinHandle<()>> {
         let submitter = ValidatorSubmitter::new(
             self.interval,
             self.reorg_period.clone(),
@@ -1132,16 +1265,7 @@ impl Validator {
             self.reorg_reporter.clone(),
         );
 
-        let tip_tree = call_and_retry_indefinitely(|| {
-            let merkle_tree_hook = self.merkle_tree_hook.clone();
-            let reorg_period = self.reorg_period.clone();
-            Box::pin(async move { merkle_tree_hook.tree(&reorg_period).await })
-        })
-        .await;
-
-        // This function is only called after we have already checked that the
-        // merkle tree hook has count > 0, but we assert to be extra sure this is
-        // the case.
+        // `wait_for_first_message` only returns a non-empty, quorum-verified tree.
         assert!(tip_tree.count() > 0, "merkle tree is empty");
         let backfill_target = submitter.checkpoint_at_block(&tip_tree);
 
@@ -1435,6 +1559,8 @@ impl Validator {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use async_trait::async_trait;
     use hyperlane_core::{test_utils::dummy_domain, HyperlaneProvider};
     use prometheus::Registry;
@@ -1926,6 +2052,64 @@ mod tests {
         (label.to_string(), Arc::new(hook) as Arc<dyn MerkleTreeHook>)
     }
 
+    #[tokio::test(start_paused = true)]
+    #[tracing_test::traced_test]
+    async fn empty_tree_waits_then_starts_from_first_message_without_restart() {
+        let count_calls = Arc::new(AtomicUsize::new(0));
+        let mut hook = MockMerkleTreeHook::new();
+        hook.expect_count().times(2).returning({
+            let count_calls = Arc::clone(&count_calls);
+            move |_| {
+                Ok(if count_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    0
+                } else {
+                    1
+                })
+            }
+        });
+        hook.expect_tree().once().return_once(|_| {
+            let mut tree = hyperlane_core::accumulator::incremental::IncrementalMerkle::default();
+            tree.ingest(H256::from_low_u64_be(1));
+            Ok(IncrementalMerkleAtBlock {
+                tree,
+                block_height: Some(10),
+            })
+        });
+
+        let readiness = Arc::new(ValidatorReadiness::default());
+        let readiness_hook: Arc<dyn MerkleTreeHook> = Arc::new(ReadinessMerkleTreeHook::new(
+            Arc::new(hook),
+            Arc::clone(&readiness),
+        ));
+        let task = tokio::spawn({
+            let readiness = Arc::clone(&readiness);
+            async move {
+                wait_for_first_message(
+                    readiness_hook,
+                    &ReorgPeriod::None,
+                    Duration::from_secs(5),
+                    &readiness,
+                )
+                .await
+            }
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(
+            readiness.snapshot().state,
+            validator_server::ValidatorReadinessState::WaitingForFirstMessage
+        );
+        assert!(!logs_contain("Error getting merkle tree"));
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let tree = task.await.expect("wait task should complete");
+        assert_eq!(tree.count(), 1);
+        assert_eq!(
+            readiness.snapshot().state,
+            validator_server::ValidatorReadinessState::Ready
+        );
+    }
+
     #[test]
     fn two_thirds_threshold_rounds_up() {
         // ceil(2n/3): e.g. 2 of 3, 3 of 4, 4 of 5, 4 of 6.
@@ -2245,6 +2429,95 @@ mod tests {
         assert_eq!(
             hook.tree(&ReorgPeriod::None).await.unwrap().block_height,
             Some(11)
+        );
+    }
+
+    /// A failed endpoint must not shrink a 2-of-2 threshold to 1. The same hook must recover
+    /// readiness and return a tree when that endpoint later becomes healthy.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn two_endpoint_quorum_blocks_then_recovers_without_restart() {
+        let mailbox_domain = dummy_domain(1337, "test-domain").id();
+        let expected_tree = IncrementalMerkleAtBlock {
+            tree: Default::default(),
+            block_height: Some(11),
+        };
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().never();
+        base_hook.expect_tree().never();
+        base_hook.expect_latest_checkpoint_at_block().never();
+        base_hook
+            .expect_latest_checkpoint()
+            .times(2)
+            .returning(move |_| Ok(height_resolution_checkpoint(mailbox_domain, 11)));
+        base_hook
+            .expect_tree_at_block()
+            .once()
+            .with(mockall::predicate::eq(11))
+            .return_once({
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree)
+            });
+
+        let mut quorum_a = MockMerkleTreeHook::new();
+        quorum_a
+            .expect_tree_at_block()
+            .times(2)
+            .with(mockall::predicate::eq(11))
+            .returning({
+                let expected_tree = expected_tree.clone();
+                move |_| Ok(expected_tree.clone())
+            });
+
+        let endpoint_b_calls = Arc::new(AtomicUsize::new(0));
+        let mut quorum_b = MockMerkleTreeHook::new();
+        quorum_b
+            .expect_tree_at_block()
+            .times(2)
+            .with(mockall::predicate::eq(11))
+            .returning({
+                let endpoint_b_calls = Arc::clone(&endpoint_b_calls);
+                let expected_tree = expected_tree.clone();
+                move |_| {
+                    if endpoint_b_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                        Err(ChainCommunicationError::from_other_str("rpc down"))
+                    } else {
+                        Ok(expected_tree.clone())
+                    }
+                }
+            });
+
+        let quorum_hook: Arc<dyn MerkleTreeHook> =
+            Arc::new(ValidatorMultiRpcQuorumMerkleTreeHook {
+                base_hook: Arc::new(base_hook),
+                quorum_hooks: vec![
+                    quorum_rpc("rpcUrls[0]", quorum_a),
+                    quorum_rpc("additionalQuorumRpcUrls[0]", quorum_b),
+                ],
+            });
+        let readiness = Arc::new(ValidatorReadiness::default());
+        let hook = ReadinessMerkleTreeHook::new(quorum_hook, Arc::clone(&readiness));
+
+        let err = hook
+            .tree(&ReorgPeriod::None)
+            .await
+            .expect_err("one response must not satisfy a two-response threshold");
+        let error_message = err.to_string();
+        assert!(error_message.contains("maximum agreeing responses 1/2 required"));
+        assert!(error_message.contains("configured endpoints 2, successful 1, failed 1"));
+        assert_eq!(
+            readiness.snapshot().state,
+            validator_server::ValidatorReadinessState::SigningBlocked
+        );
+        assert!(logs_contain("failed_endpoint_labels"));
+        assert!(logs_contain("additionalQuorumRpcUrls[0]"));
+        assert!(logs_contain("signing_blocked=true"));
+
+        assert!(hook.tree(&ReorgPeriod::None).await.is_ok());
+        assert_eq!(
+            readiness.snapshot().state,
+            validator_server::ValidatorReadinessState::Ready
         );
     }
 

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -185,20 +185,34 @@ const MIN_RECOMMENDED_QUORUM_RPCS: usize = 3;
 struct ReadinessMerkleTreeHook {
     inner: Arc<dyn MerkleTreeHook>,
     readiness: Arc<ValidatorReadiness>,
+    source: &'static str,
 }
 
 impl ReadinessMerkleTreeHook {
-    fn new(inner: Arc<dyn MerkleTreeHook>, readiness: Arc<ValidatorReadiness>) -> Self {
-        Self { inner, readiness }
+    fn new(
+        inner: Arc<dyn MerkleTreeHook>,
+        readiness: Arc<ValidatorReadiness>,
+        source: &'static str,
+    ) -> Self {
+        Self {
+            inner,
+            readiness,
+            source,
+        }
+    }
+
+    fn operation(&self, operation: &str) -> String {
+        format!("{}.{}", self.source, operation)
     }
 
     fn record_checkpoint_read<T>(&self, operation: &str, result: &ChainResult<T>) {
+        let operation = self.operation(operation);
         match result {
-            Ok(_) => self.readiness.mark_ready(),
+            Ok(_) => self.readiness.mark_operation_ready(&operation),
             Err(_) => {
-                let snapshot = self.readiness.mark_signing_blocked();
+                let snapshot = self.readiness.mark_operation_blocked(&operation);
                 warn!(
-                    operation,
+                    operation = operation.as_str(),
                     consecutive_failures = snapshot.consecutive_failures,
                     failure_duration_ms = snapshot.failure_duration_ms,
                     signing_blocked = snapshot.signing_blocked,
@@ -209,13 +223,13 @@ impl ReadinessMerkleTreeHook {
     }
 
     fn record_count(&self, result: &ChainResult<u32>) {
+        let operation = self.operation("count");
         match result {
-            Ok(0) => self.readiness.mark_waiting_for_first_message(),
-            Ok(_) => {}
+            Ok(_) => self.readiness.mark_operation_ready(&operation),
             Err(_) => {
-                let snapshot = self.readiness.mark_signing_blocked();
+                let snapshot = self.readiness.mark_operation_blocked(&operation);
                 warn!(
-                    operation = "count",
+                    operation = operation.as_str(),
                     consecutive_failures = snapshot.consecutive_failures,
                     failure_duration_ms = snapshot.failure_duration_ms,
                     signing_blocked = snapshot.signing_blocked,
@@ -290,6 +304,7 @@ async fn wait_for_first_message(
                 error!("Error getting merkle tree count");
             }
             Ok(0) => {
+                readiness.mark_waiting_for_first_message();
                 info!("Waiting for first message in merkle tree hook");
             }
             Ok(_) => match merkle_tree_hook.tree(reorg_period).await {
@@ -795,7 +810,7 @@ impl BaseAgent for Validator {
         let reorg_reporter = Arc::new(reorg_reporter_with_storage_writer) as Arc<dyn ReorgReporter>;
 
         let origin_chain_conf = core.settings.chain_setup(&settings.origin_chain)?.clone();
-        let additional_quorum_rpc_urls: Vec<Url> = Self::dedupe_additional_quorum_rpc_urls(
+        let additional_quorum_rpc_urls: Vec<Url> = Self::dedupe_rpc_urls(
             settings
                 .additional_quorum_rpcs
                 .iter()
@@ -808,57 +823,69 @@ impl BaseAgent for Validator {
                         .map_err(|err| eyre!("Invalid additionalQuorumRpcUrls[{i}] entry: {err}"))
                 })
                 .collect::<Result<_>>()?,
+            "additionalQuorumRpcUrls",
         );
 
         let mailbox = origin_chain_conf.build_mailbox(&metrics).await?;
 
-        let base_merkle_tree_hook: Arc<dyn MerkleTreeHook> = settings
+        let raw_base_merkle_tree_hook: Arc<dyn MerkleTreeHook> = settings
             .build_merkle_tree_hook(&settings.origin_chain, &metrics)
             .await?
             .into();
 
-        let merkle_tree_hook: Arc<dyn MerkleTreeHook> = if Self::validator_uses_split_quorum_hook(
-            &origin_chain_conf,
-            &additional_quorum_rpc_urls,
-        ) {
-            // `rpcUrls` votes alongside `additionalQuorumRpcUrls` in the same 2/3 quorum
-            // group (see `ValidatorMultiRpcQuorumMerkleTreeHook`), so `additionalQuorumRpcUrls`
-            // only needs to add public endpoints on top of it. Read the URLs directly from
-            // `origin_chain_conf.connection` rather than `settings.rpcs`, which also
-            // comingles `grpcUrls`/`walletUrls`/`walletSolidityUrls` (non-Ethereum chains).
-            let primary_rpc_urls: Vec<Url> = Self::primary_rpc_urls(&origin_chain_conf);
-            let additional_quorum_rpc_urls: Vec<Url> =
-                Self::remove_urls_already_in_primary(&primary_rpc_urls, additional_quorum_rpc_urls);
-            let combined_urls: Vec<Url> = primary_rpc_urls
-                .iter()
-                .chain(additional_quorum_rpc_urls.iter())
-                .cloned()
-                .collect();
-            Self::warn_if_quorum_pool_undersized(&combined_urls);
-            Self::warn_if_duplicate_hosts(&combined_urls);
-            Self::build_validator_quorum_merkle_tree_hook(
-                base_merkle_tree_hook.clone(),
+        let raw_merkle_tree_hook: Arc<dyn MerkleTreeHook> =
+            if Self::validator_uses_split_quorum_hook(
                 &origin_chain_conf,
-                &primary_rpc_urls,
                 &additional_quorum_rpc_urls,
-                &metrics,
-            )
-            .await?
-            .into()
-        } else {
-            if !additional_quorum_rpc_urls.is_empty() {
-                warn!(
-                    origin_chain = %settings.origin_chain,
-                    "additionalQuorumRpcUrls is set but ignored: quorum verification is only supported for Ethereum chains"
+            ) {
+                // `rpcUrls` votes alongside `additionalQuorumRpcUrls` in the same 2/3 quorum
+                // group (see `ValidatorMultiRpcQuorumMerkleTreeHook`), so `additionalQuorumRpcUrls`
+                // only needs to add public endpoints on top of it. Read the URLs directly from
+                // `origin_chain_conf.connection` rather than `settings.rpcs`, which also
+                // comingles `grpcUrls`/`walletUrls`/`walletSolidityUrls` (non-Ethereum chains).
+                let primary_rpc_urls: Vec<Url> =
+                    Self::dedupe_rpc_urls(Self::primary_rpc_urls(&origin_chain_conf), "rpcUrls");
+                let additional_quorum_rpc_urls: Vec<Url> = Self::remove_urls_already_in_primary(
+                    &primary_rpc_urls,
+                    additional_quorum_rpc_urls,
                 );
-            }
-            base_merkle_tree_hook.clone()
-        };
+                let combined_urls: Vec<Url> = primary_rpc_urls
+                    .iter()
+                    .chain(additional_quorum_rpc_urls.iter())
+                    .cloned()
+                    .collect();
+                Self::warn_if_quorum_pool_undersized(&combined_urls);
+                Self::warn_if_duplicate_hosts(&combined_urls);
+                Self::build_validator_quorum_merkle_tree_hook(
+                    raw_base_merkle_tree_hook.clone(),
+                    &origin_chain_conf,
+                    &primary_rpc_urls,
+                    &additional_quorum_rpc_urls,
+                    &metrics,
+                )
+                .await?
+                .into()
+            } else {
+                if !additional_quorum_rpc_urls.is_empty() {
+                    warn!(
+                        origin_chain = %settings.origin_chain,
+                        "additionalQuorumRpcUrls is set but ignored: quorum verification is only supported for Ethereum chains"
+                    );
+                }
+                raw_base_merkle_tree_hook.clone()
+            };
         let readiness = Arc::new(ValidatorReadiness::default());
         let merkle_tree_hook: Arc<dyn MerkleTreeHook> = Arc::new(ReadinessMerkleTreeHook::new(
-            merkle_tree_hook,
+            raw_merkle_tree_hook,
             Arc::clone(&readiness),
+            "merkle_tree_hook",
         ));
+        let base_merkle_tree_hook: Arc<dyn MerkleTreeHook> =
+            Arc::new(ReadinessMerkleTreeHook::new(
+                raw_base_merkle_tree_hook,
+                Arc::clone(&readiness),
+                "base_merkle_tree_hook",
+            ));
 
         let validator_announce = settings
             .build_validator_announce(&settings.origin_chain, &metrics)
@@ -1023,7 +1050,7 @@ impl Validator {
     /// Removes exact duplicate URLs (order-preserving). A duplicated endpoint would
     /// otherwise count as two independent votes, undermining the quorum's independence
     /// assumption.
-    fn dedupe_additional_quorum_rpc_urls(urls: Vec<Url>) -> Vec<Url> {
+    fn dedupe_rpc_urls(urls: Vec<Url>, source: &'static str) -> Vec<Url> {
         let original_count = urls.len();
         let mut seen = HashSet::new();
         let deduped: Vec<Url> = urls
@@ -1032,9 +1059,10 @@ impl Validator {
             .collect();
         if deduped.len() < original_count {
             warn!(
+                source,
                 original_count,
                 deduped_count = deduped.len(),
-                "additionalQuorumRpcUrls contained duplicate entries; deduping to preserve vote independence"
+                "RPC configuration contained duplicate entries; deduping to preserve vote independence"
             );
         }
         deduped
@@ -1263,6 +1291,7 @@ impl Validator {
             ValidatorSubmitterMetrics::new(&self.core.metrics, &self.origin_chain),
             self.max_sign_concurrency,
             self.reorg_reporter.clone(),
+            Arc::clone(&self.readiness),
         );
 
         // `wait_for_first_message` only returns a non-empty, quorum-verified tree.
@@ -1795,7 +1824,7 @@ mod tests {
     }
 
     #[test]
-    fn dedupe_additional_quorum_rpc_urls_removes_exact_duplicates_preserving_order() {
+    fn dedupe_rpc_urls_removes_exact_duplicates_preserving_order() {
         let urls = vec![
             Url::parse("http://rpc-a.example").unwrap(),
             Url::parse("http://rpc-b.example").unwrap(),
@@ -1803,7 +1832,7 @@ mod tests {
             Url::parse("http://rpc-c.example").unwrap(),
         ];
 
-        let deduped = Validator::dedupe_additional_quorum_rpc_urls(urls);
+        let deduped = Validator::dedupe_rpc_urls(urls, "rpcUrls");
 
         assert_eq!(
             deduped,
@@ -1816,13 +1845,13 @@ mod tests {
     }
 
     #[test]
-    fn dedupe_additional_quorum_rpc_urls_is_noop_without_duplicates() {
+    fn dedupe_rpc_urls_is_noop_without_duplicates() {
         let urls = vec![
             Url::parse("http://rpc-a.example").unwrap(),
             Url::parse("http://rpc-b.example").unwrap(),
         ];
 
-        let deduped = Validator::dedupe_additional_quorum_rpc_urls(urls.clone());
+        let deduped = Validator::dedupe_rpc_urls(urls.clone(), "additionalQuorumRpcUrls");
 
         assert_eq!(deduped, urls);
     }
@@ -2080,6 +2109,7 @@ mod tests {
         let readiness_hook: Arc<dyn MerkleTreeHook> = Arc::new(ReadinessMerkleTreeHook::new(
             Arc::new(hook),
             Arc::clone(&readiness),
+            "merkle_tree_hook",
         ));
         let task = tokio::spawn({
             let readiness = Arc::clone(&readiness);
@@ -2104,6 +2134,65 @@ mod tests {
         tokio::time::advance(Duration::from_secs(5)).await;
         let tree = task.await.expect("wait task should complete");
         assert_eq!(tree.count(), 1);
+        assert_eq!(
+            readiness.snapshot().state,
+            validator_server::ValidatorReadinessState::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_quorum_read_does_not_hide_failed_base_read() {
+        let readiness = Arc::new(ValidatorReadiness::default());
+
+        let mut base_hook = MockMerkleTreeHook::new();
+        base_hook.expect_count().times(2).returning({
+            let calls = Arc::new(AtomicUsize::new(0));
+            move |_| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(ChainCommunicationError::from_other_str("base RPC down"))
+                } else {
+                    Ok(1)
+                }
+            }
+        });
+        let base_hook = ReadinessMerkleTreeHook::new(
+            Arc::new(base_hook),
+            Arc::clone(&readiness),
+            "base_merkle_tree_hook",
+        );
+
+        let mut quorum_hook = MockMerkleTreeHook::new();
+        quorum_hook.expect_tree().once().returning(|_| {
+            Ok(IncrementalMerkleAtBlock {
+                tree: Default::default(),
+                block_height: None,
+            })
+        });
+        let quorum_hook = ReadinessMerkleTreeHook::new(
+            Arc::new(quorum_hook),
+            Arc::clone(&readiness),
+            "merkle_tree_hook",
+        );
+
+        assert!(base_hook.count(&ReorgPeriod::None).await.is_err());
+        assert!(quorum_hook.tree(&ReorgPeriod::None).await.is_ok());
+        let blocked = readiness.snapshot();
+        assert_eq!(
+            blocked.state,
+            validator_server::ValidatorReadinessState::SigningBlocked
+        );
+        assert_eq!(
+            blocked.blocked_operations,
+            vec!["base_merkle_tree_hook.count".to_owned()]
+        );
+
+        assert_eq!(
+            base_hook
+                .count(&ReorgPeriod::None)
+                .await
+                .expect("base hook should recover"),
+            1
+        );
         assert_eq!(
             readiness.snapshot().state,
             validator_server::ValidatorReadinessState::Ready
@@ -2497,7 +2586,8 @@ mod tests {
                 ],
             });
         let readiness = Arc::new(ValidatorReadiness::default());
-        let hook = ReadinessMerkleTreeHook::new(quorum_hook, Arc::clone(&readiness));
+        let hook =
+            ReadinessMerkleTreeHook::new(quorum_hook, Arc::clone(&readiness), "merkle_tree_hook");
 
         let err = hook
             .tree(&ReorgPeriod::None)

--- a/rust/main/helm/hyperlane-agent/templates/validator-statefulset.yaml
+++ b/rust/main/helm/hyperlane-agent/templates/validator-statefulset.yaml
@@ -80,6 +80,13 @@ spec:
         ports:
         - name: metrics
           containerPort: {{ .Values.hyperlane.metrics.port }}
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: metrics
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 1
       volumes:
       - name: config-env-vars
         configMap:


### PR DESCRIPTION
## What failed on Arc

The validator announcement succeeded before checkpoint production started, so it did not prove the validator could read or sign the MerkleTreeHook.

Two failures then occurred in sequence:

1. While the new hook was empty, startup called `latestCheckpoint()`. The contract computes `count - 1`, so every poll reverted with an arithmetic underflow instead of representing the expected "waiting for the first message" state.
2. After the first message, `rpc.arc.io` remained unavailable. The configured two-endpoint pool required 2-of-2 responses, but only the private RPC succeeded. Signing correctly stopped; the bug was that Kubernetes still reported the validator Ready indefinitely and the error described only the successful response count.

Revision 2 did not prove that restarting recovered the endpoint. Its configuration made the public and private URL identical; deduplication reduced the pool to one provider. The durable operational mitigation was the validator-only blocklist, but that still leaves Arc with no independent quorum protection.

## Why this fixes those failures

- **Empty hook:** startup calls `count()` before any checkpoint/tree read. `count == 0` is exposed as `waiting_for_first_message` and remains Kubernetes Ready because there is nothing to sign. Polling continues. When the first message appears, the same process performs a quorum-verified tree read and passes that tree into checkpoint startup, so no restart or second unguarded startup read is needed.
- **Unavailable quorum endpoint:** the 2/3 threshold is computed from the configured unique voter set before responses arrive. Failed endpoints remain in the denominator. Arc's one successful response in a two-endpoint pool therefore remains 1-of-2 and cannot sign; a three-endpoint pool can still sign with two agreeing responses. Recovery requires the missing endpoint to recover or an explicit configuration change.
- **False Kubernetes readiness:** `/ready` now reflects checkpoint-production blockers, not merely a running process or successful announcement. The Helm StatefulSet probes it. Quorum reads, direct/base RPC reads, local Merkle insertion availability, checkpoint signing/storage, and latest-index publication register independent blockers. A success clears only its own blocker, so one healthy path cannot hide another failed path.
- **Recovery without restart:** existing retry loops remain active. When the exact failed RPC, indexer, signer, or storage operation succeeds, its blocker is cleared and readiness/signing recover in-process. Persistent bad configuration stays NotReady; this PR deliberately does not add a liveness restart because restarting cannot repair it.
- **Quorum independence and diagnostics:** exact duplicates are removed within `rpcUrls`, within `additionalQuorumRpcUrls`, and across the two pools before votes are built. Failures report configured, successful, failed, required, and maximum-agreement counts plus URL-safe endpoint index labels. Private URLs are not logged.

This is the runtime/root fix; `rpcBlocklist.ts` remains an operational escape hatch rather than the health mechanism.

## Validation

- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo test -p validator -j 2` (73 passed)
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo check -p validator --tests -j 2`
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_INCREMENTAL=0 cargo clippy -p validator --bin validator --no-deps -j 2 -- -D warnings`
- `cargo fmt --package validator -- --check`
- Helm dependency build, lint, and render of the validator StatefulSet readiness probe

Coverage includes empty-to-first-message recovery, 2-endpoint failure/recovery, valid 2-of-3 operation, fixed denominator/no downgrade, duplicate-vote removal, diagnostic counts, Kubernetes readiness, independent base/quorum blockers, local indexer recovery, and checkpoint-storage recovery.

## Discrete follow-ups

- deployment preflight for DNS/connectivity, expected chain ID, block freshness, required hook calls, semantic URL normalization, and provider/failure-domain independence
- stop outstanding quorum calls once success or impossibility is mathematically determined, without changing the configured threshold
- detect successful-but-stale RPCs and cross-provider height skew; fallback providers currently treat stale success as healthy
- add watchdogs/timeouts for checkpoint-critical base RPC, signer, and storage calls that never return; returned errors are covered here, but a permanently hung future needs an independent age signal
- align the legacy Eigen health endpoints with checkpoint readiness and add a dedicated Prometheus blocker/age alert
- decide an operator policy for sustained failure termination after readiness/alerting has exposed the cause; do not treat restart as remediation
- add independent Arc RPC providers; the current validator-only blocklist leaves a one-provider trust model
