### PR TITLE
chore(infra): deploy scraper proxy performance improvements

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'rust/main/**'
+      - '!rust/main/helm/**'
       - 'rust/scripts/ci/**'
       - '.github/workflows/rust-release.yml'
   workflow_dispatch:
@@ -54,7 +55,7 @@ jobs:
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             # Check if there are commits to rust/main since last release
-            COMMITS_SINCE=$(git log "$LATEST_TAG"..HEAD --oneline -- . | wc -l)
+            COMMITS_SINCE=$(git log "$LATEST_TAG"..HEAD --oneline -- . ':(exclude)helm/**' | wc -l)
             echo "Commits since $LATEST_TAG: $COMMITS_SINCE"
 
             if [ "$COMMITS_SINCE" -gt 0 ]; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,8 +64,8 @@ jobs:
             exit 0
           fi
 
-          # Filter out sealevel deployment config paths that don't affect build/tests
-          RUST_CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '^rust/sealevel/(environments/(mainnet3|testnet4)/|\.vscode/)' || true)
+          # Filter out deployment paths that don't affect Rust build/tests
+          RUST_CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '^rust/(main/helm/|sealevel/(environments/(mainnet3|testnet4)/|\.vscode/))' || true)
           if echo "$RUST_CODE_CHANGES" | grep -qE '^(rust/|\.github/workflows/(rust\.|test\.yml|test-rust)|\.github/actions/)'; then
             echo "skip_rust=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/test-rust-e2e.yml
+++ b/.github/workflows/test-rust-e2e.yml
@@ -53,8 +53,8 @@ jobs:
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             PARENT_SHA=$(git rev-parse HEAD^)
             CHANGES=$(git diff --name-only $PARENT_SHA HEAD -- ./rust ./.github/workflows/test.yml ./.github/workflows/test-rust-e2e.yml ./.github/actions/)
-            # Filter out sealevel deployment config paths that don't affect build/tests
-            CHANGES=$(echo "$CHANGES" | grep -vE '^rust/sealevel/(environments/(mainnet3|testnet4)/|\.vscode/)' || true)
+            # Filter out deployment paths that don't affect Rust build/tests
+            CHANGES=$(echo "$CHANGES" | grep -vE '^rust/(main/helm/|sealevel/(environments/(mainnet3|testnet4)/|\.vscode/))' || true)
 
             if [[ -n "$CHANGES" ]]; then
               echo "rust_changes=true" >> $GITHUB_OUTPUT
@@ -67,8 +67,8 @@ jobs:
             # For PRs, use GitHub CLI to check changes
             PR_NUMBER=${{ github.event.pull_request.number }}
             CHANGES=$(gh pr view $PR_NUMBER --json files -q '.files[].path | select(startswith("rust/") or . == ".github/workflows/test.yml" or . == ".github/workflows/test-rust-e2e.yml" or test("^\\.github/workflows/rust\\.") or startswith(".github/actions/"))')
-            # Filter out sealevel deployment config paths that don't affect build/tests
-            CHANGES=$(echo "$CHANGES" | grep -vE '^rust/sealevel/(environments/(mainnet3|testnet4)/|\.vscode/)' || true)
+            # Filter out deployment paths that don't affect Rust build/tests
+            CHANGES=$(echo "$CHANGES" | grep -vE '^rust/(main/helm/|sealevel/(environments/(mainnet3|testnet4)/|\.vscode/))' || true)
 
             if [[ -n "$CHANGES" ]]; then
               echo "rust_changes=true" >> $GITHUB_OUTPUT
@@ -82,8 +82,8 @@ jobs:
             BASE_SHA="${{ github.event.merge_group.base_sha }}"
             HEAD_SHA="${{ github.event.merge_group.head_sha }}"
             CHANGES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA" -- ./rust ./.github/workflows/test.yml ./.github/workflows/test-rust-e2e.yml ./.github/actions/)
-            # Filter out sealevel deployment config paths that don't affect build/tests
-            CHANGES=$(echo "$CHANGES" | grep -vE '^rust/sealevel/(environments/(mainnet3|testnet4)/|\.vscode/)' || true)
+            # Filter out deployment paths that don't affect Rust build/tests
+            CHANGES=$(echo "$CHANGES" | grep -vE '^rust/(main/helm/|sealevel/(environments/(mainnet3|testnet4)/|\.vscode/))' || true)
 
             if [[ -n "$CHANGES" ]]; then
               echo "rust_changes=true" >> $GITHUB_OUTPUT

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -57,7 +57,7 @@ export const mainnetDockerTags: MainnetDockerTags = {
   keyFunder: 'b0c3c5d-20260804-175736',
   warpMonitor: '744b3bb-20260521-215958',
   rebalancer: 'da26d9a-20260703-122943',
-  scraperProxy: 'b831bf9-20260831-143408',
+  scraperProxy: 'b3619ad-20260901-171710',
   feeQuoting: '12d899d-20260325-184337',
 };
 


### PR DESCRIPTION
## Summary

- deploy the main image containing scraper-proxy performance PRs #9407, #9408, #9410, and #9411
- skip Rust CI/e2e and Rust releases for Helm-only changes under rust/main/helm
- keep Rust Docker triggers unchanged; they already exclude Helm files

## Rollout

- image: ghcr.io/hyperlane-xyz/hyperlane-node-services:b3619ad-20260901-171710
- digest: sha256:f89d34b9d86abdf9de8c8669c41b91e001ee9fab10c3146c6ba9389129a5657e
- build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33536824225
- mainnet3 scraper-proxy Helm revision 6 successfully rolled out
- one ready pod, zero restarts, exact immutable image digest confirmed
- live message_view GraphQL query succeeded
- GraphQL queries observed on graphql_replica only; listener ready; notification queues and WebSocket send failures zero

## Validation

- pnpm -C typescript/infra test test/scraper-proxy-helm-manager.test.ts
- actionlint syntax validation for changed workflows
- explicit change-filter cases for Helm, Rust source, Sealevel deployment config, and workflow changes
- git diff --check