### PR TITLE
fix(infra): support Safe delegate signer rotations

### DIFF
--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -60,6 +60,21 @@ type SafeMultisigTransactionResponse = Awaited<
   ReturnType<SafeService['getTransaction']>
 >;
 
+interface SafeTxProposer {
+  proposer?: Address | null;
+  proposedByDelegate?: Address | null;
+}
+
+export function wasSafeTxProposedBy(
+  tx: SafeTxProposer,
+  signerAddress: Address,
+): boolean {
+  return (
+    (!!tx.proposer && eqAddress(tx.proposer, signerAddress)) ||
+    (!!tx.proposedByDelegate && eqAddress(tx.proposedByDelegate, signerAddress))
+  );
+}
+
 /**
  * Retry helper for Safe API calls with random delay between 1-3 seconds.
  * Handles rate limiting (429) errors with jittered backoff.
@@ -376,9 +391,10 @@ export async function deleteSafeTx(
     return;
   }
 
-  // Compare proposer to signer
+  // Safe attributes delegate submissions to the owner that delegated access.
+  // Permit either the attributed owner or the actual delegate to delete them.
   const signerAddress = await signer.getAddress();
-  if (!eqAddress(proposer, signerAddress)) {
+  if (!wasSafeTxProposedBy(txDetails, signerAddress)) {
     rootLogger.info(
       chalk.italic(
         `Skipping deletion of transaction ${safeTxHash} proposed by ${proposer}`,
@@ -738,11 +754,18 @@ export async function updateSafeOwner({
     newThreshold <= expectedOwners.length,
     `Safe threshold ${newThreshold} exceeds owner count ${expectedOwners.length}`,
   );
-  assert(
-    !proposer ||
-      expectedOwners.some((owner: Address) => eqAddress(owner, proposer)),
-    `Proposer ${proposer} must remain a Safe owner`,
-  );
+  // Safe delegates can propose without being owners. Only require retention
+  // when the proposer is an existing owner.
+  if (proposer) {
+    const proposerIsCurrentOwner = currentOwners.some((owner: Address) =>
+      eqAddress(owner, proposer),
+    );
+    assert(
+      !proposerIsCurrentOwner ||
+        expectedOwners.some((owner: Address) => eqAddress(owner, proposer)),
+      `Proposer ${proposer} must remain a Safe owner`,
+    );
+  }
 
   // Sort ownersToRemove by their position in the currentOwners array. Safe owners
   // are stored in a linked list, and each update changes the prevOwner needed for

--- a/typescript/infra/src/utils/safe.ts
+++ b/typescript/infra/src/utils/safe.ts
@@ -60,18 +60,19 @@ type SafeMultisigTransactionResponse = Awaited<
   ReturnType<SafeService['getTransaction']>
 >;
 
-interface SafeTxProposer {
-  proposer?: Address | null;
-  proposedByDelegate?: Address | null;
-}
+type SafeTxProposer = Pick<
+  SafeMultisigTransactionResponse,
+  'proposer' | 'proposedByDelegate'
+>;
 
 export function wasSafeTxProposedBy(
   tx: SafeTxProposer,
   signerAddress: Address,
 ): boolean {
   return (
-    (!!tx.proposer && eqAddress(tx.proposer, signerAddress)) ||
-    (!!tx.proposedByDelegate && eqAddress(tx.proposedByDelegate, signerAddress))
+    (tx.proposer !== null && eqAddress(tx.proposer, signerAddress)) ||
+    (tx.proposedByDelegate !== null &&
+      eqAddress(tx.proposedByDelegate, signerAddress))
   );
 }
 

--- a/typescript/infra/test/safe.test.ts
+++ b/typescript/infra/test/safe.test.ts
@@ -109,7 +109,7 @@ describe('Safe Utils', () => {
     it('should accept the attributed owner', () => {
       expect(
         wasSafeTxProposedBy(
-          { proposer: ownerA, proposedByDelegate: ownerB },
+          { proposer: ownerA, proposedByDelegate: null },
           ownerA,
         ),
       ).to.be.true;

--- a/typescript/infra/test/safe.test.ts
+++ b/typescript/infra/test/safe.test.ts
@@ -8,6 +8,7 @@ import {
   getOwnerChanges,
   parseSafeTx,
   updateSafeOwner,
+  wasSafeTxProposedBy,
 } from '../src/utils/safe.js';
 
 const safeAddress = '0x1234567890123456789012345678901234567890';
@@ -104,6 +105,35 @@ async function expectRejection(promise: Promise<unknown>, message: string) {
 }
 
 describe('Safe Utils', () => {
+  describe('wasSafeTxProposedBy', () => {
+    it('should accept the attributed owner', () => {
+      expect(
+        wasSafeTxProposedBy(
+          { proposer: ownerA, proposedByDelegate: ownerB },
+          ownerA,
+        ),
+      ).to.be.true;
+    });
+
+    it('should accept the submitting delegate', () => {
+      expect(
+        wasSafeTxProposedBy(
+          { proposer: ownerA, proposedByDelegate: ownerB },
+          ownerB,
+        ),
+      ).to.be.true;
+    });
+
+    it('should reject unrelated signers', () => {
+      expect(
+        wasSafeTxProposedBy(
+          { proposer: ownerA, proposedByDelegate: ownerB },
+          ownerC,
+        ),
+      ).to.be.false;
+    });
+  });
+
   describe('getOwnerChanges', () => {
     it('should identify owners to add and remove', async () => {
       const currentOwners = [
@@ -254,6 +284,17 @@ describe('Safe Utils', () => {
             name: 'removeOwner',
             args: [productionNewOwner, productionOwners[2], 3],
           },
+        ],
+      },
+      {
+        name: 'allow a non-owner delegate to propose owner updates',
+        currentOwners: [ownerA, ownerB, ownerC],
+        currentThreshold: 2,
+        expectedOwners: [ownerB, ownerC, ownerE],
+        newThreshold: 2,
+        proposer: ownerF,
+        expectedCalls: [
+          { name: 'swapOwner', args: [sentinelOwners, ownerA, ownerE] },
         ],
       },
       {


### PR DESCRIPTION
## Summary

- allowed non-owner Safe delegates to generate signer rotations
- preserved the guard preventing an existing owner-proposer from rotating itself out
- allowed the submitting delegate to delete transactions attributed by Safe Transaction Service to its delegating owner

## Validation

- `pnpm exec mocha --config ../sdk/.mocharc.json --timeout 10000 test/safe.test.ts` — 28 passing
- `pnpm build` in `typescript/infra`
- live irregular-Safe delegate submission and exact-hash deletion succeeded
