### PR TITLE
fix(aleo): avoid local proving fallback memory spike

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -469,7 +469,9 @@ impl<C: AleoClient> AleoProvider<C> {
             )
             .map_err(HyperlaneAleoError::SnarkVmError)?;
 
-        // Either use the proving service (with local fallback) or generate the proof locally
+        // Use local proving only when no delegated proving service is configured. A delegated
+        // prover failure is retried by the relayer; falling back here can saturate Tokio's
+        // blocking pool and destabilize unrelated chains.
         let start = Instant::now();
         let transaction = match self.proving_service {
             Some(ref client) => {
@@ -477,41 +479,26 @@ impl<C: AleoClient> AleoProvider<C> {
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
-                match client
-                    .proving_request(authorization.clone(), fee.clone())
+                client
+                    .proving_request(authorization, fee)
                     .await
-                {
-                    Ok(tx) => Ok::<_, ChainCommunicationError>(tx),
-                    Err(e) => {
+                    .map_err(|error| {
                         warn!(
-                            error = %e,
-                            "Delegated proving failed, falling back to local proving"
+                            %error,
+                            "Delegated proving failed"
                         );
-                        debug!(
-                            program_id,
-                            function_name, "Starting local ZK proof generation (fallback)"
-                        );
-                        Ok(vm
-                            .execute_authorization(
-                                authorization,
-                                Some(fee),
-                                Some(&self.client),
-                                &mut rng,
-                            )
-                            .map_err(HyperlaneAleoError::from)?)
-                    }
-                }
+                        error
+                    })?
             }
             None => {
                 debug!(
                     program_id,
                     function_name, "Starting local ZK proof generation"
                 );
-                Ok(vm
-                    .execute_authorization(authorization, Some(fee), Some(&self.client), &mut rng)
-                    .map_err(HyperlaneAleoError::from)?)
+                vm.execute_authorization(authorization, Some(fee), Some(&self.client), &mut rng)
+                    .map_err(HyperlaneAleoError::from)?
             }
-        }?;
+        };
 
         let elapsed = start.elapsed();
         debug!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -362,6 +362,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn standard_client_get_keeps_query_out_of_path() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 4096];
+            let length = stream.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..length]);
+            request_tx
+                .send(request.lines().next().unwrap().to_owned())
+                .unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]",
+                )
+                .unwrap();
+        });
+        let client =
+            BaseHttpClient::new(Url::parse(&format!("http://{address}/v2")).unwrap(), 0).unwrap();
+
+        let response: Vec<Value> = client
+            .request("statePaths", json!({ "commitments": "field1,field2" }))
+            .await
+            .unwrap();
+
+        assert!(response.is_empty());
+        assert_eq!(
+            request_rx.recv().unwrap(),
+            "GET /v2/mainnet/statePaths?commitments=field1%2Cfield2 HTTP/1.1"
+        );
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
     async fn standard_client_post_encodes_bracketed_mapping_keys() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -368,8 +368,8 @@ impl<Client: HttpClient, N: Network> QueryTrait<N> for RpcClient<Client> {
             .join(",");
         Ok(self
             .request_blocking(
-                &format!("statePaths?commitments={commitments_string}"),
-                None,
+                "statePaths",
+                serde_json::json!({ "commitments": commitments_string }),
             )
             .unwrap_or_default())
     }
@@ -386,8 +386,8 @@ impl<Client: HttpClient, N: Network> QueryTrait<N> for RpcClient<Client> {
             .join(",");
         Ok(self
             .request(
-                &format!("statePaths?commitments={commitments_string}"),
-                None,
+                "statePaths",
+                serde_json::json!({ "commitments": commitments_string }),
             )
             .await
             .unwrap_or_default())


### PR DESCRIPTION
## Summary

- return configured delegated-prover failures to the relayer retry path instead of starting an in-process Aleo proof
- retain local proving when no delegated proving service is configured
- send Aleo state-path commitments as query parameters instead of encoding the query delimiter into the URL path

## Incident evidence

On 2026-09-01, mainnet3 omniscient-relayer memory rose from 11.7 GiB to 15.0 GiB (RSS 4.5 GiB to 7.8 GiB) immediately after the configured Aleo prover returned HTTP 522 and the relayer logged a local-proving fallback. The pod reached 562 threads, including 523 Tokio blocking workers, versus 43 total threads on the fastpath relayer. The same transaction then emitted malformed statePaths%3Fcommitments= requests.

This is complementary to #9412: that PR bounds post-submission status polling; this PR prevents a pre-submission delegated-prover outage from launching resource-intensive local proving inside the multi-chain relayer.

## Validation

- cargo test -p hyperlane-aleo --lib (76 passed)
- cargo clippy -p hyperlane-aleo --lib -- -D warnings
- cargo fmt --all -- --check
- repository pre-commit hooks

## Rollout

Roll out after #9412. Verify that a delegated-prover failure leaves relayer memory/thread count stable and retries the operation without local proving. #9390 would add useful blocking-pool observability.
