### PR TITLE
chore(infra): update mainnet relayer image

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,9 +43,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'c35e861-20260831-121837',
-  relayerRC: 'c35e861-20260831-121837',
-  relayerFastPath: 'c35e861-20260831-121837',
+  relayer: 'fede1e2-20260901-191753',
+  relayerRC: 'fede1e2-20260901-191753',
+  relayerFastPath: 'fede1e2-20260901-191753',
   validator: 'c35e861-20260831-121837',
   validatorRC: 'c35e861-20260831-121837',
   validatorFastPath: 'c35e861-20260831-121837',


### PR DESCRIPTION
Pins all three mainnet relayer contexts to the post-merge agent image built from `fede1e2671ca6b6b61543c413a327f695120e625`.\n\nMain and fastpath will be rolled out from this config. RC remains scaled to zero and will not be deployed.