### PR TITLE
perf(lander): share dispatcher state

### DIFF
--- a/rust/main/agents/relayer/src/relayer/destination.rs
+++ b/rust/main/agents/relayer/src/relayer/destination.rs
@@ -36,8 +36,6 @@ pub enum FactoryError {
     ApplicationOperationVerifierCreationFailed(String, String),
     #[error("Failed to create dispatcher for domain {0}: {1}")]
     DispatcherCreationFailed(String, String),
-    #[error("Failed to create dispatcher entrypoint for domain {0}: {1}")]
-    DispatcherEntrypointCreationFailed(String, String),
     #[error("Failed to create mailbox for domain {0}: {1}")]
     MailboxCreationFailed(String, String),
     #[error("Failed to create destination for domain {0} due to missing configuration")]
@@ -174,26 +172,19 @@ impl DestinationFactory {
             metrics: self.core_metrics.clone(),
         };
 
-        let mut start_entity_init = Instant::now();
-        let dispatcher_entrypoint = DispatcherEntrypoint::try_from_settings(
-            dispatcher_settings.clone(),
-            dispatcher_metrics.clone(),
-        )
-        .await
-        .map_err(|e| {
-            FactoryError::DispatcherEntrypointCreationFailed(domain.to_string(), e.to_string())
-        })?;
-        self.measure(domain, "dispatcher_entrypoint", start_entity_init.elapsed());
-
-        start_entity_init = Instant::now();
-        let dispatcher = Dispatcher::try_from_settings(
-            dispatcher_settings.clone(),
+        let start_entity_init = Instant::now();
+        let (dispatcher_entrypoint, dispatcher) = Dispatcher::try_from_settings(
+            dispatcher_settings,
             domain.to_string(),
-            dispatcher_metrics.clone(),
+            dispatcher_metrics,
         )
         .await
         .map_err(|e| FactoryError::DispatcherCreationFailed(domain.to_string(), e.to_string()))?;
-        self.measure(domain, "dispatcher", start_entity_init.elapsed());
+        self.measure(
+            domain,
+            "dispatcher_and_entrypoint",
+            start_entity_init.elapsed(),
+        );
 
         Ok((Some(dispatcher_entrypoint), Some(dispatcher)))
     }

--- a/rust/main/lander/src/dispatcher/core.rs
+++ b/rust/main/lander/src/dispatcher/core.rs
@@ -24,7 +24,10 @@ use crate::{
     transaction::Transaction,
 };
 
-use super::{metrics::DispatcherMetrics, DispatcherState, TransactionDbLoader};
+use super::{
+    entrypoint::DispatcherEntrypoint, metrics::DispatcherMetrics, DispatcherState,
+    TransactionDbLoader,
+};
 
 const SUBMITTER_CHANNEL_SIZE: usize = 1_000;
 
@@ -59,12 +62,21 @@ impl Dispatcher {
         settings: DispatcherSettings,
         domain: String,
         metrics: DispatcherMetrics,
-    ) -> Result<Self> {
+    ) -> Result<(DispatcherEntrypoint, Self)> {
         let state = DispatcherState::try_from_settings(settings, metrics).await?;
-        Ok(Self {
+        Ok(Self::from_state_with_entrypoint(state, domain))
+    }
+
+    fn from_state_with_entrypoint(
+        state: DispatcherState,
+        domain: String,
+    ) -> (DispatcherEntrypoint, Self) {
+        let entrypoint = DispatcherEntrypoint::from_inner(state.clone());
+        let dispatcher = Self {
             inner: state,
             domain,
-        })
+        };
+        (entrypoint, dispatcher)
     }
 
     /// Create a Dispatcher from a DispatcherState and domain (for testing)
@@ -187,5 +199,45 @@ impl Dispatcher {
                 .instrument(tracing::info_span!("dispatcher")),
             )
             .expect("spawning tokio task from Builder is infallible")
+    }
+}
+
+#[cfg(test)]
+mod shared_state_tests {
+    use std::sync::Arc;
+
+    use super::Dispatcher;
+    use crate::{
+        dispatcher::{DispatcherMetrics, DispatcherState},
+        tests::test_utils::{tmp_dbs, MockAdapter},
+    };
+
+    #[test]
+    fn entrypoint_and_dispatcher_share_state() {
+        let (payload_db, tx_db, _) = tmp_dbs();
+        let adapter = Arc::new(MockAdapter::new());
+        let state = DispatcherState::new(
+            payload_db,
+            tx_db,
+            adapter,
+            DispatcherMetrics::dummy_instance(),
+            "test".to_string(),
+        );
+
+        let (entrypoint, dispatcher) =
+            Dispatcher::from_state_with_entrypoint(state, "test".to_string());
+
+        assert!(Arc::ptr_eq(
+            &entrypoint.inner.adapter,
+            &dispatcher.inner.adapter
+        ));
+        assert!(Arc::ptr_eq(
+            &entrypoint.inner.payload_db,
+            &dispatcher.inner.payload_db
+        ));
+        assert!(Arc::ptr_eq(
+            &entrypoint.inner.tx_db,
+            &dispatcher.inner.tx_db
+        ));
     }
 }

--- a/rust/main/lander/src/dispatcher/entrypoint.rs
+++ b/rust/main/lander/src/dispatcher/entrypoint.rs
@@ -13,7 +13,7 @@ use crate::{
     payload::{FullPayload, PayloadStatus, PayloadUuid},
 };
 
-use super::{metrics::DispatcherMetrics, DispatcherSettings, DispatcherState};
+use super::DispatcherState;
 
 #[async_trait]
 pub trait Entrypoint {
@@ -32,18 +32,8 @@ pub struct DispatcherEntrypoint {
 }
 
 impl DispatcherEntrypoint {
-    pub async fn try_from_settings(
-        settings: DispatcherSettings,
-        metrics: DispatcherMetrics,
-    ) -> Result<Self> {
-        Ok(Self {
-            inner: DispatcherState::try_from_settings(settings, metrics).await?,
-        })
-    }
-
-    /// Create a DispatcherEntrypoint from a DispatcherState (for testing)
-    #[cfg(any(test, feature = "integration_test"))]
-    pub fn from_inner(inner: DispatcherState) -> Self {
+    /// Create an entrypoint from shared dispatcher state.
+    pub(crate) fn from_inner(inner: DispatcherState) -> Self {
         Self { inner }
     }
 }


### PR DESCRIPTION
## Problem

The relayer constructs `DispatcherEntrypoint` and `Dispatcher` independently for every destination. Each path calls `DispatcherState::try_from_settings`, so both rebuild the RocksDB handles and the full chain adapter stack, including providers, caches, signers and chain-specific state such as the Ethereum nonce manager. The two objects then operate on the same destination while holding independent in-memory adapter state.

The sampled mainnet relayer has 68 destinations. The current path therefore builds 136 dispatcher adapter stacks at startup: two per destination.

## Solution

- construct one `DispatcherState` per destination
- derive both `DispatcherEntrypoint` and `Dispatcher` from that state
- share the adapter and database handles through the state
- replace the two destination-factory timings with one `dispatcher_and_entrypoint` timing
- remove the now-unused independent entrypoint constructor and error path

## Expected impact

**Exact construction reduction:** 136 -> 68 adapter stacks for the sampled 68-destination mainnet configuration: 68 fewer, or 50%. Per destination, `DispatcherState::try_from_settings` and `AdapterFactory::build` change from two calls to one.

This also removes one duplicate provider/cache stack per destination and, for EVM destinations, one duplicate nonce manager. Those downstream memory, connection and startup-latency savings are structurally expected but not yet measured, so this PR does not claim an RSS or wall-time percentage.

## Correctness

- the entrypoint and worker now use the same adapter state rather than merely equivalent configuration
- payload and transaction databases remain `Arc`-shared as before
- dispatcher stage topology, persistence, submission, retry and finalization behavior are unchanged
- a regression proves the returned entrypoint and dispatcher have pointer-identical adapter, payload DB and transaction DB handles

## Verification

- `RUSTFLAGS="--cfg tokio_unstable" cargo +1.88.0 test --manifest-path rust/main/Cargo.toml -p lander shared_state_tests` (1 passed)
- `RUSTFLAGS="--cfg tokio_unstable" cargo +1.88.0 check --manifest-path rust/main/Cargo.toml -p relayer`
- repository pre-commit hooks: gitleaks, lint-staged and both Rust format checks
- exact head: `ac9909252566a20f5e208bddd5f0f4738942c744`

## Canary

Compare equal-workload startup before/after:

- `chain_init_latency{role="destination",entity="dispatcher_and_entrypoint"}` against the sum of the former dispatcher and entrypoint series
- provider connection/socket counts after all destinations initialize
- container anonymous RSS and working set after cache warmup
- nonce errors, resubmissions, queue lengths, delivery latency and finalized count as non-regression guards

Expected structural result: one adapter construction per configured destination. Keep runtime resource savings unmeasured until canaried.

Master performance epic: #9386.