### PR TITLE
perf(lander): index pending payloads

### DIFF
--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -16,7 +16,7 @@ use hyperlane_base::{
 };
 use hyperlane_core::{HyperlaneDomain, HyperlaneMessage, QueueOperation, H512};
 use prometheus::IntGauge;
-use tokio::sync::mpsc::{error::TryRecvError, Receiver, UnboundedSender};
+use tokio::sync::mpsc::{error::TryRecvError, Receiver, Sender};
 use tracing::{debug, instrument, trace};
 
 use super::{blacklist::AddressBlacklist, metadata::AppContextClassifier, pending_message::*};
@@ -35,7 +35,7 @@ pub struct MessageDbLoader {
     metrics: MessageDbLoaderMetrics,
     /// channel for each destination chain to send operations (i.e. message
     /// submissions) to
-    send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
+    send_channels: HashMap<u32, Sender<QueueOperation>>,
     /// Needed context to send a message for each destination chain
     destination_ctxs: HashMap<u32, Arc<MessageContext>>,
     metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
@@ -319,7 +319,9 @@ impl DbLoaderExt for MessageDbLoader {
                 self.max_retries,
             );
             if let Some(pending_msg) = pending_msg {
-                self.send_channels[&destination].send(Box::new(pending_msg) as QueueOperation)?;
+                self.send_channels[&destination]
+                    .send(Box::new(pending_msg) as QueueOperation)
+                    .await?;
             }
         } else {
             self.wait_for_index_notification().await;
@@ -336,7 +338,7 @@ impl MessageDbLoader {
         message_blacklist: Arc<MatchingList>,
         address_blacklist: Arc<AddressBlacklist>,
         metrics: MessageDbLoaderMetrics,
-        send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
+        send_channels: HashMap<u32, Sender<QueueOperation>>,
         destination_ctxs: HashMap<u32, Arc<MessageContext>>,
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,

--- a/rust/main/agents/relayer/src/msg/db_loader.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader.rs
@@ -19,7 +19,10 @@ use prometheus::IntGauge;
 use tokio::sync::mpsc::{error::TryRecvError, Receiver, Sender};
 use tracing::{debug, instrument, trace};
 
-use super::{blacklist::AddressBlacklist, metadata::AppContextClassifier, pending_message::*};
+use super::{
+    blacklist::AddressBlacklist, metadata::AppContextClassifier, pending_message::*,
+    QueueOperationBatch,
+};
 use crate::{db_loader::DbLoaderExt, settings::matching_list::MatchingList};
 
 /// Finds unprocessed messages from an origin and submits then through a channel
@@ -35,7 +38,7 @@ pub struct MessageDbLoader {
     metrics: MessageDbLoaderMetrics,
     /// channel for each destination chain to send operations (i.e. message
     /// submissions) to
-    send_channels: HashMap<u32, Sender<QueueOperation>>,
+    send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
     /// Needed context to send a message for each destination chain
     destination_ctxs: HashMap<u32, Arc<MessageContext>>,
     metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
@@ -320,7 +323,7 @@ impl DbLoaderExt for MessageDbLoader {
             );
             if let Some(pending_msg) = pending_msg {
                 self.send_channels[&destination]
-                    .send(Box::new(pending_msg) as QueueOperation)
+                    .send(vec![Box::new(pending_msg) as QueueOperation])
                     .await?;
             }
         } else {
@@ -338,7 +341,7 @@ impl MessageDbLoader {
         message_blacklist: Arc<MatchingList>,
         address_blacklist: Arc<AddressBlacklist>,
         metrics: MessageDbLoaderMetrics,
-        send_channels: HashMap<u32, Sender<QueueOperation>>,
+        send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
         destination_ctxs: HashMap<u32, Arc<MessageContext>>,
         metric_app_contexts: Arc<Vec<(MatchingList, String)>>,
         max_retries: u32,

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -68,7 +68,7 @@ fn dummy_message_loader(
     destination_domain: &HyperlaneDomain,
     db: &HyperlaneRocksDB,
     cache: OptionalCache<MeteredCache<LocalCache>>,
-) -> (MessageDbLoader, Receiver<QueueOperation>) {
+) -> (MessageDbLoader, Receiver<QueueOperationBatch>) {
     dummy_message_loader_with_notifications(origin_domain, destination_domain, db, cache, None)
 }
 
@@ -78,7 +78,7 @@ fn dummy_message_loader_with_notifications(
     db: &HyperlaneRocksDB,
     cache: OptionalCache<MeteredCache<LocalCache>>,
     index_notifications: Option<Receiver<H512>>,
-) -> (MessageDbLoader, Receiver<QueueOperation>) {
+) -> (MessageDbLoader, Receiver<QueueOperationBatch>) {
     let base_metadata_builder =
         dummy_metadata_builder(origin_domain, destination_domain, db, cache.clone());
     let message_context = Arc::new(dummy_message_context(
@@ -87,7 +87,7 @@ fn dummy_message_loader_with_notifications(
         cache,
     ));
 
-    let (send_channel, receive_channel) = mpsc::channel::<QueueOperation>(1);
+    let (send_channel, receive_channel) = mpsc::channel::<QueueOperationBatch>(1);
     (
         MessageDbLoader::new(
             db.clone(),
@@ -286,8 +286,8 @@ async fn get_first_n_operations_from_db_loader(
     let load_fut = db_loader.spawn(info_span!("MessageDbLoader"));
     let mut pending_messages = vec![];
     let pending_message_accumulator = async {
-        while let Some(pm) = receive_channel.recv().await {
-            pending_messages.push(pm);
+        while let Some(batch) = receive_channel.recv().await {
+            pending_messages.extend(batch);
             if pending_messages.len() == num_operations {
                 break;
             }

--- a/rust/main/agents/relayer/src/msg/db_loader/tests.rs
+++ b/rust/main/agents/relayer/src/msg/db_loader/tests.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use prometheus::IntCounterVec;
 use tokio::{
-    sync::mpsc::{self, Receiver, UnboundedReceiver},
+    sync::mpsc::{self, Receiver},
     time::{sleep, timeout},
 };
 use tokio_metrics::TaskMonitor;
@@ -68,7 +68,7 @@ fn dummy_message_loader(
     destination_domain: &HyperlaneDomain,
     db: &HyperlaneRocksDB,
     cache: OptionalCache<MeteredCache<LocalCache>>,
-) -> (MessageDbLoader, UnboundedReceiver<QueueOperation>) {
+) -> (MessageDbLoader, Receiver<QueueOperation>) {
     dummy_message_loader_with_notifications(origin_domain, destination_domain, db, cache, None)
 }
 
@@ -78,7 +78,7 @@ fn dummy_message_loader_with_notifications(
     db: &HyperlaneRocksDB,
     cache: OptionalCache<MeteredCache<LocalCache>>,
     index_notifications: Option<Receiver<H512>>,
-) -> (MessageDbLoader, UnboundedReceiver<QueueOperation>) {
+) -> (MessageDbLoader, Receiver<QueueOperation>) {
     let base_metadata_builder =
         dummy_metadata_builder(origin_domain, destination_domain, db, cache.clone());
     let message_context = Arc::new(dummy_message_context(
@@ -87,7 +87,7 @@ fn dummy_message_loader_with_notifications(
         cache,
     ));
 
-    let (send_channel, receive_channel) = mpsc::unbounded_channel::<QueueOperation>();
+    let (send_channel, receive_channel) = mpsc::channel::<QueueOperation>(1);
     (
         MessageDbLoader::new(
             db.clone(),

--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -47,6 +47,22 @@ mod stage;
 /// update the number of queues an MessageProcessor has.
 pub const MESSAGE_PROCESSOR_QUEUE_COUNT: usize = 3;
 
+/// Ingress only bridges producers into the destination priority queue. Keeping
+/// one slot avoids a duplicate backlog while still decoupling task scheduling.
+pub const MESSAGE_PROCESSOR_INGRESS_CAPACITY: usize = 1;
+
+#[async_trait::async_trait]
+trait RecoveryWaiter: Send + Sync {
+    async fn wait_for_recovery(&self);
+}
+
+#[async_trait::async_trait]
+impl RecoveryWaiter for DispatcherEntrypoint {
+    async fn wait_for_recovery(&self) {
+        DispatcherEntrypoint::wait_for_recovery(self).await;
+    }
+}
+
 /// MessageProcessor accepts operations over a channel, prepares them for submission,
 /// and if successful, sends them to the destination chain via a submitter.
 ///
@@ -86,7 +102,7 @@ pub struct MessageProcessor {
     /// Domain this processor delivers to.
     domain: HyperlaneDomain,
     /// Receiver for new messages to submit.
-    rx: Option<mpsc::UnboundedReceiver<QueueOperation>>,
+    rx: Option<mpsc::Receiver<QueueOperation>>,
     /// Metrics for message processor.
     metrics: MessageProcessorMetrics,
     /// Max batch size for submitting messages
@@ -105,7 +121,7 @@ impl MessageProcessor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         domain: HyperlaneDomain,
-        rx: mpsc::UnboundedReceiver<QueueOperation>,
+        rx: mpsc::Receiver<QueueOperation>,
         retry_op_transmitter: &Sender<MessageRetryRequest>,
         metrics: MessageProcessorMetrics,
         max_batch_size: u32,
@@ -167,6 +183,9 @@ impl MessageProcessor {
         let rx_prepare = self.rx.take().expect("rx should be initialised");
 
         let entrypoint = self.payload_dispatcher_entrypoint.take().map(Arc::new);
+        let recovery_waiter = entrypoint
+            .as_ref()
+            .map(|entrypoint| -> Arc<dyn RecoveryWaiter> { entrypoint.clone() });
 
         let prepare_task = match &entrypoint {
             None => self.create_classic_prepare_task(),
@@ -181,7 +200,7 @@ impl MessageProcessor {
         let confirm_task = self.create_classic_confirm_task();
 
         let tasks = [
-            self.create_receive_task(rx_prepare),
+            self.create_receive_task(rx_prepare, recovery_waiter),
             prepare_task,
             submit_task,
             confirm_task,
@@ -198,14 +217,20 @@ impl MessageProcessor {
 
     fn create_receive_task(
         &self,
-        rx_prepare: mpsc::UnboundedReceiver<QueueOperation>,
+        rx_prepare: mpsc::Receiver<QueueOperation>,
+        recovery_waiter: Option<Arc<dyn RecoveryWaiter>>,
     ) -> JoinHandle<()> {
         let name = Self::task_name("receive::", &self.domain);
         tokio::task::Builder::new()
             .name(&name)
             .spawn(TaskMonitor::instrument(
                 &self.task_monitor,
-                receive_task(self.domain.clone(), rx_prepare, self.prepare_queue.clone()),
+                receive_task(
+                    self.domain.clone(),
+                    rx_prepare,
+                    self.prepare_queue.clone(),
+                    recovery_waiter,
+                ),
             ))
             .expect("spawning tokio task from Builder is infallible")
     }
@@ -334,9 +359,14 @@ impl MessageProcessor {
 #[instrument(skip_all, fields(%domain))]
 async fn receive_task(
     domain: HyperlaneDomain,
-    mut rx: mpsc::UnboundedReceiver<QueueOperation>,
+    mut rx: mpsc::Receiver<QueueOperation>,
     prepare_queue: OpQueue,
+    recovery_waiter: Option<Arc<dyn RecoveryWaiter>>,
 ) {
+    if let Some(recovery_waiter) = recovery_waiter {
+        recovery_waiter.wait_for_recovery().await;
+    }
+
     // Pull any messages sent to this message processor
     while let Some(op) = rx.recv().await {
         trace!(?op, "Received new operation");

--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -32,8 +32,8 @@ use crate::msg::pending_message::CONFIRM_DELAY;
 use crate::server::operations::message_retry::MessageRetryRequest;
 
 use super::op_batch::OperationBatch;
-use super::op_queue::OpQueue;
 use super::op_queue::OperationPriorityQueue;
+use super::{op_queue::OpQueue, QueueOperationBatch};
 
 use stage::prepare;
 use stage::submit::filter_operations_for_submit;
@@ -102,7 +102,7 @@ pub struct MessageProcessor {
     /// Domain this processor delivers to.
     domain: HyperlaneDomain,
     /// Receiver for new messages to submit.
-    rx: Option<mpsc::Receiver<QueueOperation>>,
+    rx: Option<mpsc::Receiver<QueueOperationBatch>>,
     /// Metrics for message processor.
     metrics: MessageProcessorMetrics,
     /// Max batch size for submitting messages
@@ -121,7 +121,7 @@ impl MessageProcessor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         domain: HyperlaneDomain,
-        rx: mpsc::Receiver<QueueOperation>,
+        rx: mpsc::Receiver<QueueOperationBatch>,
         retry_op_transmitter: &Sender<MessageRetryRequest>,
         metrics: MessageProcessorMetrics,
         max_batch_size: u32,
@@ -217,7 +217,7 @@ impl MessageProcessor {
 
     fn create_receive_task(
         &self,
-        rx_prepare: mpsc::Receiver<QueueOperation>,
+        rx_prepare: mpsc::Receiver<QueueOperationBatch>,
         recovery_waiter: Option<Arc<dyn RecoveryWaiter>>,
     ) -> JoinHandle<()> {
         let name = Self::task_name("receive::", &self.domain);
@@ -359,7 +359,7 @@ impl MessageProcessor {
 #[instrument(skip_all, fields(%domain))]
 async fn receive_task(
     domain: HyperlaneDomain,
-    mut rx: mpsc::Receiver<QueueOperation>,
+    mut rx: mpsc::Receiver<QueueOperationBatch>,
     prepare_queue: OpQueue,
     recovery_waiter: Option<Arc<dyn RecoveryWaiter>>,
 ) {
@@ -368,13 +368,15 @@ async fn receive_task(
     }
 
     // Pull any messages sent to this message processor
-    while let Some(op) = rx.recv().await {
-        trace!(?op, "Received new operation");
-        // make sure things are getting wired up correctly; if this works in testing it
-        // should also be valid in production.
-        debug_assert_eq!(*op.destination_domain(), domain);
-        let op_status = op.status();
-        prepare_queue.push(op, Some(op_status)).await;
+    while let Some(operations) = rx.recv().await {
+        for op in operations {
+            trace!(?op, "Received new operation");
+            // make sure things are getting wired up correctly; if this works in testing it
+            // should also be valid in production.
+            debug_assert_eq!(*op.destination_domain(), domain);
+            let op_status = op.status();
+            prepare_queue.push(op, Some(op_status)).await;
+        }
     }
 }
 

--- a/rust/main/agents/relayer/src/msg/message_processor/tests.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests.rs
@@ -1,1 +1,85 @@
 pub(crate) mod tests_common;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hyperlane_core::{PendingOperationStatus, QueueOperation, H256};
+use tokio::sync::{mpsc, Semaphore};
+use tokio::time::timeout;
+
+use super::{receive_task, RecoveryWaiter, MESSAGE_PROCESSOR_INGRESS_CAPACITY};
+use tests_common::{create_test_queue, MockQueueOperation};
+
+struct TestRecoveryWaiter(Arc<Semaphore>);
+
+#[async_trait]
+impl RecoveryWaiter for TestRecoveryWaiter {
+    async fn wait_for_recovery(&self) {
+        self.0
+            .acquire()
+            .await
+            .expect("test recovery semaphore should remain open")
+            .forget();
+    }
+}
+
+#[tokio::test]
+async fn test_recovery_backpressures_message_processor_ingress() {
+    let domain = hyperlane_core::HyperlaneDomain::new_test_domain("test");
+    let prepare_queue = create_test_queue();
+    let recovery = Arc::new(Semaphore::new(0));
+    let recovery_waiter: Arc<dyn RecoveryWaiter> = Arc::new(TestRecoveryWaiter(recovery.clone()));
+    let (send_channel, receive_channel) =
+        mpsc::channel::<QueueOperation>(MESSAGE_PROCESSOR_INGRESS_CAPACITY);
+
+    let receive_handle = tokio::spawn(receive_task(
+        domain.clone(),
+        receive_channel,
+        prepare_queue.clone(),
+        Some(recovery_waiter),
+    ));
+    let first_operation: QueueOperation = Box::new(MockQueueOperation::new(
+        H256::from_low_u64_be(1),
+        PendingOperationStatus::FirstPrepareAttempt,
+        domain.clone(),
+    ));
+    send_channel
+        .send(first_operation)
+        .await
+        .expect("first operation should fill the ingress slot");
+
+    let second_send_channel = send_channel.clone();
+    let second_operation: QueueOperation = Box::new(MockQueueOperation::new(
+        H256::from_low_u64_be(2),
+        PendingOperationStatus::FirstPrepareAttempt,
+        domain,
+    ));
+    let mut blocked_send =
+        tokio::spawn(async move { second_send_channel.send(second_operation).await });
+
+    assert!(timeout(Duration::from_millis(20), &mut blocked_send)
+        .await
+        .is_err());
+    assert_eq!(prepare_queue.len().await, 0);
+
+    recovery.add_permits(1);
+    timeout(Duration::from_secs(1), &mut blocked_send)
+        .await
+        .expect("second producer should unblock after recovery")
+        .expect("second producer task should not panic")
+        .expect("receiver should remain open");
+
+    timeout(Duration::from_secs(1), async {
+        while prepare_queue.len().await != 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("both operations should drain after recovery");
+
+    drop(send_channel);
+    receive_handle
+        .await
+        .expect("receive task should stop when ingress closes");
+}

--- a/rust/main/agents/relayer/src/msg/message_processor/tests.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests.rs
@@ -9,6 +9,7 @@ use tokio::sync::{mpsc, Semaphore};
 use tokio::time::timeout;
 
 use super::{receive_task, RecoveryWaiter, MESSAGE_PROCESSOR_INGRESS_CAPACITY};
+use crate::msg::QueueOperationBatch;
 use tests_common::{create_test_queue, MockQueueOperation};
 
 struct TestRecoveryWaiter(Arc<Semaphore>);
@@ -31,7 +32,7 @@ async fn test_recovery_backpressures_message_processor_ingress() {
     let recovery = Arc::new(Semaphore::new(0));
     let recovery_waiter: Arc<dyn RecoveryWaiter> = Arc::new(TestRecoveryWaiter(recovery.clone()));
     let (send_channel, receive_channel) =
-        mpsc::channel::<QueueOperation>(MESSAGE_PROCESSOR_INGRESS_CAPACITY);
+        mpsc::channel::<QueueOperationBatch>(MESSAGE_PROCESSOR_INGRESS_CAPACITY);
 
     let receive_handle = tokio::spawn(receive_task(
         domain.clone(),
@@ -45,7 +46,7 @@ async fn test_recovery_backpressures_message_processor_ingress() {
         domain.clone(),
     ));
     send_channel
-        .send(first_operation)
+        .send(vec![first_operation])
         .await
         .expect("first operation should fill the ingress slot");
 
@@ -56,7 +57,7 @@ async fn test_recovery_backpressures_message_processor_ingress() {
         domain,
     ));
     let mut blocked_send =
-        tokio::spawn(async move { second_send_channel.send(second_operation).await });
+        tokio::spawn(async move { second_send_channel.send(vec![second_operation]).await });
 
     assert!(timeout(Duration::from_millis(20), &mut blocked_send)
         .await

--- a/rust/main/agents/relayer/src/msg/mod.rs
+++ b/rust/main/agents/relayer/src/msg/mod.rs
@@ -28,3 +28,7 @@ mod utils;
 pub mod pending_message;
 
 pub use gas_payment::GAS_EXPENDITURE_LOG_MESSAGE;
+
+use hyperlane_core::QueueOperation;
+
+pub(crate) type QueueOperationBatch = Vec<QueueOperation>;

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
@@ -159,7 +159,7 @@ pub struct ServerState {
     /// gas payment check never races the background `tx_id_indexer_task`.
     igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>>,
     dbs: HashMap<u32, HyperlaneRocksDB>,
-    send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
+    send_channels: HashMap<u32, Sender<QueueOperation>>,
     msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
     metrics: RelayApiMetrics,
     // Optional features
@@ -176,7 +176,7 @@ impl ServerState {
         indexers: HashMap<String, Arc<dyn Indexer<HyperlaneMessage>>>,
         igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>>,
         dbs: HashMap<u32, HyperlaneRocksDB>,
-        send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
+        send_channels: HashMap<u32, Sender<QueueOperation>>,
         msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
         metrics: RelayApiMetrics,
     ) -> Self {
@@ -525,7 +525,7 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
     // If any message fails here, no side effects have occurred.
     struct ValidatedMessage {
         pending_msg: PendingMessage,
-        send_channel: UnboundedSender<QueueOperation>,
+        send_channel: Sender<QueueOperation>,
         message_id: H256,
         origin_domain: u32,
         tx_hash: H512,
@@ -795,9 +795,8 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
     // Phase 3: send all validated messages.
     //
     // Pre-check: verify every destination channel is open before sending anything.
-    // UnboundedSender::send() only fails when the receiver (processor) has been
-    // dropped. If any channel is already closed we bail here — no messages have
-    // entered the queue yet, so the caller's retry is safe and won't double-enqueue.
+    // If any channel is already closed, bail before awaiting bounded sends. No
+    // messages have entered the queue yet, so the caller can retry safely.
     for v in &validated {
         if v.send_channel.is_closed() {
             error!(
@@ -821,6 +820,7 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         if let Err(e) = v
             .send_channel
             .send(Box::new(v.pending_msg) as QueueOperation)
+            .await
         {
             error!(
                 message_id = ?v.message_id,

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -18,7 +18,10 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
-use crate::msg::pending_message::{MessageContext, PendingMessage};
+use crate::msg::{
+    pending_message::{MessageContext, PendingMessage},
+    QueueOperationBatch,
+};
 use crate::relay_api::metrics::RelayApiMetrics;
 
 /// Bounded cache for tracking recently submitted tx hashes to prevent replay attacks
@@ -159,7 +162,7 @@ pub struct ServerState {
     /// gas payment check never races the background `tx_id_indexer_task`.
     igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>>,
     dbs: HashMap<u32, HyperlaneRocksDB>,
-    send_channels: HashMap<u32, Sender<QueueOperation>>,
+    send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
     msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
     metrics: RelayApiMetrics,
     // Optional features
@@ -176,7 +179,7 @@ impl ServerState {
         indexers: HashMap<String, Arc<dyn Indexer<HyperlaneMessage>>>,
         igp_indexers: HashMap<u32, Arc<dyn Indexer<InterchainGasPayment>>>,
         dbs: HashMap<u32, HyperlaneRocksDB>,
-        send_channels: HashMap<u32, Sender<QueueOperation>>,
+        send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
         msg_ctxs: HashMap<(u32, u32), Arc<MessageContext>>,
         metrics: RelayApiMetrics,
     ) -> Self {
@@ -460,20 +463,14 @@ async fn create_relay(
         None
     };
 
-    let result = relay_work(&state, &req).await;
-
-    if result.is_ok() {
-        if let Some(reservation) = maybe_reservation {
-            reservation.commit();
-        }
-    }
-    // On Err (or if this future is dropped/cancelled), `maybe_reservation` drops here
-    // and TxHashReservation::drop removes the entry so the client can retry.
-
-    result
+    relay_work(&state, &req, maybe_reservation).await
 }
 
-async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Json<RelayResponse>> {
+async fn relay_work(
+    state: &ServerState,
+    req: &RelayRequest,
+    maybe_reservation: Option<TxHashReservation>,
+) -> ServerResult<Json<RelayResponse>> {
     // 1. Extract message using indexers (with timeout)
     let indexers = &state.indexers;
 
@@ -525,7 +522,7 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
     // If any message fails here, no side effects have occurred.
     struct ValidatedMessage {
         pending_msg: PendingMessage,
-        send_channel: Sender<QueueOperation>,
+        send_channel: Sender<QueueOperationBatch>,
         message_id: H256,
         origin_domain: u32,
         tx_hash: H512,
@@ -792,48 +789,76 @@ async fn relay_work(state: &ServerState, req: &RelayRequest) -> ServerResult<Jso
         }
     }
 
-    // Phase 3: send all validated messages.
-    //
-    // Pre-check: verify every destination channel is open before sending anything.
-    // If any channel is already closed, bail before awaiting bounded sends. No
-    // messages have entered the queue yet, so the caller can retry safely.
-    for v in &validated {
-        if v.send_channel.is_closed() {
-            error!(
-                message_id = ?v.message_id,
-                destination_domain = v.destination_domain,
-                "Processor channel closed for destination; aborting before any send"
-            );
-            state.record_failure("send_failed");
-            return Err(ServerError::InternalError(
-                "Processor channel closed for destination".to_string(),
-            ));
+    // Phase 3: reserve one bounded channel slot per destination before enqueueing
+    // anything. Cancellation while awaiting capacity releases every permit and the
+    // tx-hash reservation, so a retry cannot duplicate a partially handed-off tx.
+    // Once every permit is held, committing the reservation and sending the batches
+    // are synchronous: the transaction becomes deduplicated at the same atomic
+    // boundary where all of its operations become owned by processor channels.
+    struct SentMessage {
+        message_id: H256,
+        origin_domain: u32,
+        tx_hash: H512,
+        destination_domain: u32,
+        app_context: Option<String>,
+        nonce: u32,
+    }
+
+    let mut batches: HashMap<u32, (Sender<QueueOperationBatch>, QueueOperationBatch)> =
+        HashMap::new();
+    let mut sent_messages = Vec::with_capacity(validated.len());
+    for validated_message in validated {
+        let ValidatedMessage {
+            pending_msg,
+            send_channel,
+            message_id,
+            origin_domain,
+            tx_hash,
+            destination_domain,
+            app_context,
+            nonce,
+        } = validated_message;
+        batches
+            .entry(destination_domain)
+            .or_insert_with(|| (send_channel, Vec::new()))
+            .1
+            .push(Box::new(pending_msg) as QueueOperation);
+        sent_messages.push(SentMessage {
+            message_id,
+            origin_domain,
+            tx_hash,
+            destination_domain,
+            app_context,
+            nonce,
+        });
+    }
+
+    let mut reserved_batches = Vec::with_capacity(batches.len());
+    for (destination, (send_channel, batch)) in batches {
+        match send_channel.reserve_owned().await {
+            Ok(permit) => reserved_batches.push((permit, batch)),
+            Err(error) => {
+                error!(
+                    destination_domain = destination,
+                    %error,
+                    "Processor channel closed before transaction handoff"
+                );
+                state.record_failure("send_failed");
+                return Err(ServerError::InternalError(
+                    "Failed to reserve processor channel capacity".to_string(),
+                ));
+            }
         }
     }
 
-    // Send phase. A failure here is an extreme race (channel closed between the
-    // is_closed() check above and this send). If that happens, messages already
-    // sent in this loop may be double-enqueued on the caller's retry — this is
-    // unavoidable without transactional send semantics, but the pre-check above
-    // eliminates the common case (channel already closed before we start).
-    for v in validated {
-        if let Err(e) = v
-            .send_channel
-            .send(Box::new(v.pending_msg) as QueueOperation)
-            .await
-        {
-            error!(
-                message_id = ?v.message_id,
-                error = %e,
-                "Processor channel closed mid-send (race); earlier messages in this \
-                 batch may be double-enqueued on retry"
-            );
-            state.record_failure("send_failed");
-            return Err(ServerError::InternalError(
-                "Failed to send message to processor".to_string(),
-            ));
-        }
+    if let Some(reservation) = maybe_reservation {
+        reservation.commit();
+    }
+    for (permit, batch) in reserved_batches {
+        permit.send(batch);
+    }
 
+    for v in sent_messages {
         info!(
             message_id = ?v.message_id,
             destination = v.destination_domain,

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -181,7 +181,7 @@ fn test_msg(origin: u32, destination: u32, nonce: u32) -> HyperlaneMessage {
 
 struct TestHarness {
     state: ServerState,
-    rx: mpsc::UnboundedReceiver<QueueOperation>,
+    rx: mpsc::Receiver<QueueOperation>,
     _tempdir: TempDir,
 }
 
@@ -225,7 +225,7 @@ async fn make_state_multi(
     let mut dbs = HashMap::new();
     dbs.insert(origin, rocks_db);
 
-    let (tx, rx) = mpsc::unbounded_channel();
+    let (tx, rx) = mpsc::channel(10);
     let mut send_channels = HashMap::new();
     for &dest in &dests {
         send_channels.insert(dest, tx.clone());
@@ -525,9 +525,9 @@ async fn test_partial_send_failure_releases_dedup_for_retry() {
         application_operation_verifier: Arc::new(DummyApplicationOperationVerifier {}),
     });
 
-    let (tx_a, _rx_a2) = mpsc::unbounded_channel::<QueueOperation>();
+    let (tx_a, _rx_a2) = mpsc::channel::<QueueOperation>(10);
     // dest_b sender: drop the receiver immediately so sends fail
-    let (tx_b, rx_b_dropped) = mpsc::unbounded_channel::<QueueOperation>();
+    let (tx_b, rx_b_dropped) = mpsc::channel::<QueueOperation>(10);
     drop(rx_b_dropped);
 
     let mut indexers = HashMap::new();
@@ -626,7 +626,7 @@ async fn test_igp_payments_stored_before_enqueue() {
     );
     let mut dbs = HashMap::new();
     dbs.insert(ORIGIN_ID, rocks_db);
-    let (tx, mut rx) = mpsc::unbounded_channel::<QueueOperation>();
+    let (tx, mut rx) = mpsc::channel::<QueueOperation>(10);
     let mut send_channels = HashMap::new();
     send_channels.insert(DEST_ID, tx);
     let mut msg_ctxs = HashMap::new();

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -12,7 +12,7 @@ use hyperlane_base::{
 };
 use hyperlane_core::{
     ChainResult, GasPaymentKey, HyperlaneDomain, HyperlaneMessage, Indexed, Indexer,
-    InterchainGasPayment, LogMeta, QueueOperation, H256, H512, U256,
+    InterchainGasPayment, LogMeta, H256, H512, U256,
 };
 use hyperlane_test::mocks::MockMailboxContract;
 use parking_lot::Mutex;
@@ -24,6 +24,7 @@ use tower::ServiceExt;
 use crate::msg::db_loader::tests::DummyApplicationOperationVerifier;
 use crate::msg::gas_payment::GasPaymentEnforcer;
 use crate::msg::pending_message::MessageContext;
+use crate::msg::QueueOperationBatch;
 use crate::relay_api::handlers::{RateLimiter, ServerState, TxHashCache};
 use crate::relay_api::metrics::RelayApiMetrics;
 use crate::settings::matching_list::MatchingList;
@@ -181,7 +182,7 @@ fn test_msg(origin: u32, destination: u32, nonce: u32) -> HyperlaneMessage {
 
 struct TestHarness {
     state: ServerState,
-    rx: mpsc::Receiver<QueueOperation>,
+    rx: mpsc::Receiver<QueueOperationBatch>,
     _tempdir: TempDir,
 }
 
@@ -198,6 +199,17 @@ async fn make_state_multi(
     origin: u32,
     dests: Vec<u32>,
 ) -> TestHarness {
+    make_state_multi_with_capacity(indexer, origin, dests, 10)
+        .await
+        .0
+}
+
+async fn make_state_multi_with_capacity(
+    indexer: Arc<dyn Indexer<HyperlaneMessage>>,
+    origin: u32,
+    dests: Vec<u32>,
+    channel_capacity: usize,
+) -> (TestHarness, mpsc::Sender<QueueOperationBatch>) {
     let tempdir = TempDir::new().unwrap();
     let db = test_utils::setup_db(tempdir.path().to_str().unwrap().to_owned());
     let domain = HyperlaneDomain::new_test_domain("relay_api_test");
@@ -225,7 +237,7 @@ async fn make_state_multi(
     let mut dbs = HashMap::new();
     dbs.insert(origin, rocks_db);
 
-    let (tx, rx) = mpsc::channel(10);
+    let (tx, rx) = mpsc::channel(channel_capacity);
     let mut send_channels = HashMap::new();
     for &dest in &dests {
         send_channels.insert(dest, tx.clone());
@@ -246,11 +258,14 @@ async fn make_state_multi(
         metrics,
     );
 
-    TestHarness {
-        state,
-        rx,
-        _tempdir: tempdir,
-    }
+    (
+        TestHarness {
+            state,
+            rx,
+            _tempdir: tempdir,
+        },
+        tx,
+    )
 }
 
 fn relay_request(tx_hash: &str) -> Request<Body> {
@@ -294,6 +309,72 @@ async fn test_happy_path_enqueue() {
 
     assert_eq!(status, StatusCode::OK);
     assert!(rx.try_recv().is_ok(), "message should have been enqueued");
+}
+
+#[tokio::test]
+async fn test_same_destination_transaction_is_enqueued_as_one_batch() {
+    let messages = vec![
+        test_msg(ORIGIN_ID, DEST_ID, 1),
+        test_msg(ORIGIN_ID, DEST_ID, 2),
+    ];
+    let (TestHarness { state, mut rx, .. }, _tx) = make_state_multi_with_capacity(
+        Arc::new(MockIndexer::with_messages(messages)),
+        ORIGIN_ID,
+        vec![DEST_ID],
+        1,
+    )
+    .await;
+
+    let status = send_relay(state.router(), TX_HASH).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let batch = rx.try_recv().expect("transaction should be enqueued");
+    assert_eq!(batch.len(), 2);
+    assert!(rx.try_recv().is_err(), "only one batch should be enqueued");
+}
+
+#[tokio::test]
+async fn test_cancelled_capacity_wait_enqueues_nothing_and_allows_retry() {
+    let messages = vec![
+        test_msg(ORIGIN_ID, DEST_ID, 1),
+        test_msg(ORIGIN_ID, DEST_ID, 2),
+    ];
+    let (TestHarness { state, mut rx, .. }, tx) = make_state_multi_with_capacity(
+        Arc::new(MockIndexer::with_messages(messages)),
+        ORIGIN_ID,
+        vec![DEST_ID],
+        1,
+    )
+    .await;
+    tx.send(Vec::new()).await.expect("prefill should succeed");
+
+    let cache = Arc::new(Mutex::new(TxHashCache::new(100)));
+    let router = state.with_tx_hash_cache(cache.clone()).router();
+    let blocked_router = router.clone();
+    let request = tokio::spawn(async move { send_relay(blocked_router, TX_HASH).await });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !cache.lock().contains("ethereum", TX_HASH) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("request should reserve its tx hash while waiting for capacity");
+
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+    assert_eq!(rx.len(), 1, "cancelled request must not enqueue a batch");
+    assert!(
+        !cache.lock().contains("ethereum", TX_HASH),
+        "cancellation must release the tx-hash reservation"
+    );
+
+    let placeholder = rx.recv().await.expect("prefilled batch should remain");
+    assert!(placeholder.is_empty());
+
+    let retry = send_relay(router, TX_HASH).await;
+    assert_eq!(retry, StatusCode::OK);
+    assert_eq!(rx.recv().await.expect("retry batch").len(), 2);
 }
 
 #[tokio::test]
@@ -525,9 +606,9 @@ async fn test_partial_send_failure_releases_dedup_for_retry() {
         application_operation_verifier: Arc::new(DummyApplicationOperationVerifier {}),
     });
 
-    let (tx_a, _rx_a2) = mpsc::channel::<QueueOperation>(10);
+    let (tx_a, _rx_a2) = mpsc::channel::<QueueOperationBatch>(10);
     // dest_b sender: drop the receiver immediately so sends fail
-    let (tx_b, rx_b_dropped) = mpsc::channel::<QueueOperation>(10);
+    let (tx_b, rx_b_dropped) = mpsc::channel::<QueueOperationBatch>(10);
     drop(rx_b_dropped);
 
     let mut indexers = HashMap::new();
@@ -626,7 +707,7 @@ async fn test_igp_payments_stored_before_enqueue() {
     );
     let mut dbs = HashMap::new();
     dbs.insert(ORIGIN_ID, rocks_db);
-    let (tx, mut rx) = mpsc::channel::<QueueOperation>(10);
+    let (tx, mut rx) = mpsc::channel::<QueueOperationBatch>(10);
     let mut send_channels = HashMap::new();
     send_channels.insert(DEST_ID, tx);
     let mut msg_ctxs = HashMap::new();

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -412,7 +412,7 @@ impl BaseAgent for Relayer {
                 .get(dest_domain)
                 .and_then(|d| d.dispatcher.clone());
             if let Some(dispatcher) = dispatcher {
-                tasks.push(dispatcher.spawn().await);
+                tasks.push(dispatcher.spawn());
             }
 
             let metrics_updater = match ChainSpecificMetricsUpdater::new(

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -34,7 +34,7 @@ use hyperlane_base::{
 use hyperlane_core::{
     rpc_clients::call_and_retry_n_times, ChainCommunicationError, ChainResult, ContractSyncCursor,
     HyperlaneDomain, HyperlaneMessage, Indexer, InterchainGasPayment, MerkleTreeInsertion,
-    PendingOperation, QueueOperation, H512, U256,
+    PendingOperation, H512, U256,
 };
 use lander::{CommandEntrypoint, DispatcherMetrics};
 
@@ -60,6 +60,7 @@ use crate::{
             IsmCachePolicyClassifier,
         },
         pending_message::MessageContext,
+        QueueOperationBatch,
     },
     server::{self as relayer_server},
     settings::{matching_list::MatchingList, RelayerSettings},
@@ -351,7 +352,7 @@ impl BaseAgent for Relayer {
             let dest_conf = &destination.chain_conf;
 
             let (send_channel, receive_channel) =
-                mpsc::channel::<QueueOperation>(MESSAGE_PROCESSOR_INGRESS_CAPACITY);
+                mpsc::channel::<QueueOperationBatch>(MESSAGE_PROCESSOR_INGRESS_CAPACITY);
             send_channels.insert(dest_domain.id(), send_channel);
 
             let dispatcher_entrypoint = self
@@ -609,7 +610,7 @@ impl Relayer {
     async fn build_router(
         &self,
         prep_queues: PrepQueue,
-        send_channels: HashMap<u32, mpsc::Sender<QueueOperation>>,
+        send_channels: HashMap<u32, mpsc::Sender<QueueOperationBatch>>,
         sender: BroadcastSender<relayer_server::operations::message_retry::MessageRetryRequest>,
     ) -> (Router, Option<RelayApiState>) {
         let dbs: HashMap<u32, HyperlaneRocksDB> = self
@@ -918,7 +919,7 @@ impl Relayer {
     fn run_message_db_loader(
         &self,
         origin: &Origin,
-        send_channels: HashMap<u32, Sender<QueueOperation>>,
+        send_channels: HashMap<u32, Sender<QueueOperationBatch>>,
         index_notifications: Option<MpscReceiver<H512>>,
         task_monitor: TaskMonitor,
     ) -> eyre::Result<JoinHandle<()>> {

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -14,7 +14,7 @@ use futures_util::future::try_join_all;
 use tokio::{
     sync::{
         broadcast::Sender as BroadcastSender,
-        mpsc::{self, Receiver as MpscReceiver, UnboundedSender},
+        mpsc::{self, Receiver as MpscReceiver, Sender},
         RwLock,
     },
     task::JoinHandle,
@@ -52,7 +52,9 @@ use crate::{
     msg::{
         blacklist::AddressBlacklist,
         db_loader::{MessageDbLoader, MessageDbLoaderMetrics},
-        message_processor::{MessageProcessor, MessageProcessorMetrics},
+        message_processor::{
+            MessageProcessor, MessageProcessorMetrics, MESSAGE_PROCESSOR_INGRESS_CAPACITY,
+        },
         metadata::{
             BaseMetadataBuilder, DefaultIsmCache, IsmAwareAppContextClassifier,
             IsmCachePolicyClassifier,
@@ -348,7 +350,8 @@ impl BaseAgent for Relayer {
         for (dest_domain, destination) in &self.destinations {
             let dest_conf = &destination.chain_conf;
 
-            let (send_channel, receive_channel) = mpsc::unbounded_channel::<QueueOperation>();
+            let (send_channel, receive_channel) =
+                mpsc::channel::<QueueOperation>(MESSAGE_PROCESSOR_INGRESS_CAPACITY);
             send_channels.insert(dest_domain.id(), send_channel);
 
             let dispatcher_entrypoint = self
@@ -606,7 +609,7 @@ impl Relayer {
     async fn build_router(
         &self,
         prep_queues: PrepQueue,
-        send_channels: HashMap<u32, mpsc::UnboundedSender<QueueOperation>>,
+        send_channels: HashMap<u32, mpsc::Sender<QueueOperation>>,
         sender: BroadcastSender<relayer_server::operations::message_retry::MessageRetryRequest>,
     ) -> (Router, Option<RelayApiState>) {
         let dbs: HashMap<u32, HyperlaneRocksDB> = self
@@ -915,7 +918,7 @@ impl Relayer {
     fn run_message_db_loader(
         &self,
         origin: &Origin,
-        send_channels: HashMap<u32, UnboundedSender<QueueOperation>>,
+        send_channels: HashMap<u32, Sender<QueueOperation>>,
         index_notifications: Option<MpscReceiver<H512>>,
         task_monitor: TaskMonitor,
     ) -> eyre::Result<JoinHandle<()>> {

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -77,12 +77,10 @@ pub struct RelayerSettings {
     ///
     /// # Deployment requirement
     ///
-    /// The relay API feeds an `UnboundedSender` that is shared with the normal
-    /// message-processing path. There is no back-pressure at the channel level:
-    /// the rate limiter (`relay_api_rate_limit_*`) and `MAX_MESSAGES_PER_TX=10`
-    /// provide a soft cap (~17 ops/sec at default limits) but will not prevent
-    /// unbounded queue growth under sustained load if the endpoint is exposed
-    /// publicly without per-tenant limiting at the ingress layer.
+    /// The relay API shares the bounded, backpressured message-processing channel
+    /// with the normal loader. The rate limiter (`relay_api_rate_limit_*`) and
+    /// `MAX_MESSAGES_PER_TX=10` additionally limit admitted work, but do not
+    /// replace per-tenant limiting at the ingress layer.
     ///
     /// **The relay API must be deployed behind an ingress that enforces
     /// per-tenant rate limits.** Enabling it on a publicly reachable port

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use super::error::DbError;
-use rocksdb::{Options, DB as Rocks};
+use rocksdb::{Direction, IteratorMode, Options, WriteBatch, WriteBatchIterator, DB as Rocks};
 use tracing::info;
 
 pub use hyperlane_db::*;
@@ -19,9 +19,46 @@ mod typed_db;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
+// Keep enough archived WAL to make rollback detection cheap during the normal
+// deployment rollback window. Sequence continuity checks below make expiration
+// safe by forcing a full derived-index rebuild when history is unavailable.
+const ROLLBACK_WAL_RETENTION_SECONDS: u64 = 7 * 24 * 60 * 60;
+// Cap the retained fast path so a high-write database cannot grow without bound.
+const ROLLBACK_WAL_SIZE_LIMIT_MB: u64 = 1_024;
+
 #[derive(Debug, Clone)]
 /// A KV Store
 pub struct DB(Arc<Rocks>);
+
+/// A set of writes committed atomically to RocksDB.
+pub struct DbBatch {
+    db: DB,
+    writes: WriteBatch,
+}
+
+struct PrefixWriteDetector<'a> {
+    source_prefix: &'a [u8],
+    marker_prefix: &'a [u8],
+    source_written: bool,
+    marker_written: bool,
+}
+
+impl PrefixWriteDetector<'_> {
+    fn record(&mut self, key: &[u8]) {
+        self.source_written |= key.starts_with(self.source_prefix);
+        self.marker_written |= key.starts_with(self.marker_prefix);
+    }
+}
+
+impl WriteBatchIterator for PrefixWriteDetector<'_> {
+    fn put(&mut self, key: &[u8], _value: &[u8]) {
+        self.record(key);
+    }
+
+    fn delete(&mut self, key: &[u8]) {
+        self.record(key);
+    }
+}
 
 impl From<Rocks> for DB {
     fn from(rocks: Rocks) -> Self {
@@ -55,6 +92,8 @@ impl DB {
 
         let mut opts = Options::default();
         opts.create_if_missing(true);
+        opts.set_wal_ttl_seconds(ROLLBACK_WAL_RETENTION_SECONDS);
+        opts.set_wal_size_limit_mb(ROLLBACK_WAL_SIZE_LIMIT_MB);
 
         Rocks::open(&opts, &path)
             .map_err(|e| DbError::OpeningError {
@@ -73,5 +112,158 @@ impl DB {
     /// Retrieve a value from the DB
     pub fn retrieve(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.0.get(key)?)
+    }
+
+    /// Retrieve all values stored under a key prefix.
+    pub fn retrieve_values_by_prefix(&self, prefix: &[u8]) -> Result<Vec<Vec<u8>>> {
+        let mut values = Vec::new();
+        for item in self
+            .0
+            .iterator(IteratorMode::From(prefix, Direction::Forward))
+        {
+            let (key, value) = item?;
+            if !key.starts_with(prefix) {
+                break;
+            }
+            values.push(value.to_vec());
+        }
+        Ok(values)
+    }
+
+    /// Return the latest RocksDB sequence number.
+    pub fn latest_sequence_number(&self) -> u64 {
+        self.0.latest_sequence_number()
+    }
+
+    /// Detect source-prefix writes not accompanied by a marker-prefix write in
+    /// the same atomic batch. This lets derived indexes detect writes from an
+    /// older binary which does not maintain them.
+    pub fn has_unmarked_writes_since(
+        &self,
+        sequence: u64,
+        source_prefix: &[u8],
+        marker_prefix: &[u8],
+    ) -> Result<bool> {
+        let latest_sequence = self.0.latest_sequence_number();
+        let mut expected_sequence = sequence
+            .checked_add(1)
+            .ok_or_else(|| DbError::Other("RocksDB sequence number overflowed".to_string()))?;
+
+        for update in self.0.get_updates_since(sequence)? {
+            let (batch_sequence, batch) = update?;
+            if batch_sequence != expected_sequence {
+                return Err(DbError::Other(format!(
+                    "RocksDB WAL history is incomplete: expected sequence {expected_sequence}, found {batch_sequence}"
+                )));
+            }
+            expected_sequence = batch_sequence
+                .checked_add(batch.len() as u64)
+                .ok_or_else(|| DbError::Other("RocksDB sequence number overflowed".to_string()))?;
+            let mut detector = PrefixWriteDetector {
+                source_prefix,
+                marker_prefix,
+                source_written: false,
+                marker_written: false,
+            };
+            batch.iterate(&mut detector);
+            if detector.source_written && !detector.marker_written {
+                return Ok(true);
+            }
+        }
+
+        let sequence_after_latest = latest_sequence
+            .checked_add(1)
+            .ok_or_else(|| DbError::Other("RocksDB sequence number overflowed".to_string()))?;
+        if expected_sequence < sequence_after_latest {
+            return Err(DbError::Other(format!(
+                "RocksDB WAL history ended at sequence {}, before latest sequence {latest_sequence}",
+                expected_sequence.saturating_sub(1)
+            )));
+        }
+        Ok(false)
+    }
+
+    /// Start an atomic write batch.
+    pub fn batch(&self) -> DbBatch {
+        DbBatch {
+            db: self.clone(),
+            writes: WriteBatch::default(),
+        }
+    }
+}
+
+impl DbBatch {
+    /// Store a raw key/value pair in this batch.
+    pub fn store(&mut self, key: &[u8], value: &[u8]) {
+        self.writes.put(key, value);
+    }
+
+    /// Delete a raw key in this batch.
+    pub fn delete(&mut self, key: &[u8]) {
+        self.writes.delete(key);
+    }
+
+    /// Delete a raw key range in this batch.
+    pub fn delete_range(&mut self, start: &[u8], end: &[u8]) {
+        self.writes.delete_range(start, end);
+    }
+
+    /// Atomically commit this batch.
+    pub fn commit(self) -> Result<()> {
+        Ok(self.db.0.write(self.writes)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocksdb::{Options, WriteBatch, DB as Rocks};
+
+    use super::DB;
+
+    #[test]
+    fn rejects_incomplete_wal_history() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut options = Options::default();
+        options.create_if_missing(true);
+
+        let checkpoint;
+        {
+            let db = Rocks::open(&options, temp_dir.path()).unwrap();
+            db.put(b"checkpoint", b"1").unwrap();
+            checkpoint = db.latest_sequence_number();
+            db.put(b"source_old", b"ready").unwrap();
+            db.flush().unwrap();
+
+            let mut batch = WriteBatch::default();
+            batch.put(b"source_new", b"ready");
+            batch.put(b"marker", b"1");
+            db.write(batch).unwrap();
+        }
+
+        let db = DB::from(Rocks::open(&options, temp_dir.path()).unwrap());
+        assert!(db
+            .has_unmarked_writes_since(checkpoint, b"source_", b"marker")
+            .is_err());
+    }
+
+    #[test]
+    fn accepts_contiguous_marked_batches() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = DB::from(Rocks::open_default(temp_dir.path()).unwrap());
+        db.store(b"checkpoint", b"1").unwrap();
+        let checkpoint = db.latest_sequence_number();
+
+        let mut batch = db.batch();
+        batch.store(b"source_one", b"ready");
+        batch.store(b"marker", b"1");
+        batch.commit().unwrap();
+        let mut batch = db.batch();
+        batch.store(b"source_two", b"ready");
+        batch.store(b"marker", b"1");
+        batch.commit().unwrap();
+
+        assert!(!db
+            .has_unmarked_writes_since(checkpoint, b"source_", b"marker")
+            .unwrap());
     }
 }

--- a/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/typed_db.rs
@@ -1,6 +1,6 @@
 use hyperlane_core::{Decode, Encode, HyperlaneDomain};
 
-use crate::db::{error::DbError, DB};
+use crate::db::{error::DbError, DbBatch, DB};
 
 type Result<T> = std::result::Result<T, DbError>;
 
@@ -11,6 +11,12 @@ type Result<T> = std::result::Result<T, DbError>;
 pub struct TypedDB {
     domain_prefix: Vec<u8>,
     db: DB,
+}
+
+/// An atomic write batch scoped to a domain.
+pub struct TypedDbBatch {
+    domain_prefix: Vec<u8>,
+    batch: DbBatch,
 }
 
 impl AsRef<DB> for TypedDB {
@@ -84,5 +90,96 @@ impl TypedDB {
         key: &K,
     ) -> Result<Option<V>> {
         self.retrieve_decodable(prefix, key.to_vec())
+    }
+
+    /// Retrieve and decode every value stored under a prefix.
+    pub fn retrieve_decodables_by_prefix<V: Decode>(
+        &self,
+        prefix: impl AsRef<[u8]>,
+    ) -> Result<Vec<V>> {
+        let prefix = self.prefixed_key(prefix.as_ref(), &[]);
+        self.db
+            .retrieve_values_by_prefix(&prefix)?
+            .into_iter()
+            .map(|value| V::read_from(&mut value.as_slice()).map_err(Into::into))
+            .collect()
+    }
+
+    /// Return the latest sequence number for the underlying RocksDB.
+    pub fn latest_sequence_number(&self) -> u64 {
+        self.db.latest_sequence_number()
+    }
+
+    /// Detect domain-scoped source writes which were not paired with a marker
+    /// write in the same atomic batch.
+    pub fn has_unmarked_writes_since(
+        &self,
+        sequence: u64,
+        source_prefix: impl AsRef<[u8]>,
+        marker_prefix: impl AsRef<[u8]>,
+    ) -> Result<bool> {
+        self.db.has_unmarked_writes_since(
+            sequence,
+            &self.prefixed_key(source_prefix.as_ref(), &[]),
+            &self.prefixed_key(marker_prefix.as_ref(), &[]),
+        )
+    }
+
+    /// Start an atomic write batch scoped to this domain.
+    pub fn batch(&self) -> TypedDbBatch {
+        TypedDbBatch {
+            domain_prefix: self.domain_prefix.clone(),
+            batch: self.db.batch(),
+        }
+    }
+}
+
+impl TypedDbBatch {
+    fn prefixed_key(&self, prefix: &[u8], key: &[u8]) -> Vec<u8> {
+        self.domain_prefix
+            .iter()
+            .chain(prefix)
+            .chain(key)
+            .copied()
+            .collect()
+    }
+
+    /// Store an encoded key/value pair in this batch.
+    pub fn store_keyed_encodable<K: Encode, V: Encode>(
+        &mut self,
+        prefix: impl AsRef<[u8]>,
+        key: &K,
+        value: &V,
+    ) {
+        self.batch.store(
+            &self.prefixed_key(prefix.as_ref(), &key.to_vec()),
+            &value.to_vec(),
+        );
+    }
+
+    /// Delete an encoded key from this batch.
+    pub fn delete_keyed<K: Encode>(&mut self, prefix: impl AsRef<[u8]>, key: &K) {
+        self.batch
+            .delete(&self.prefixed_key(prefix.as_ref(), &key.to_vec()));
+    }
+
+    /// Delete every key under a prefix.
+    pub fn delete_prefix(&mut self, prefix: impl AsRef<[u8]>) -> Result<()> {
+        let start = self.prefixed_key(prefix.as_ref(), &[]);
+        let mut end = start.clone();
+        let Some(last_non_max) = end.iter().rposition(|byte| *byte != u8::MAX) else {
+            return Err(DbError::Other(
+                "Cannot construct an upper bound for an all-0xff prefix".to_string(),
+            ));
+        };
+        end[last_non_max] = end[last_non_max].saturating_add(1);
+        end.truncate(last_non_max.saturating_add(1));
+        self.batch.delete_range(&start, &end);
+        Ok(())
+    }
+
+    /// Atomically commit this batch.
+    pub fn commit(self) -> Result<()> {
+        self.batch.commit()
     }
 }

--- a/rust/main/lander/src/dispatcher/core.rs
+++ b/rust/main/lander/src/dispatcher/core.rs
@@ -18,9 +18,7 @@ use tracing::{instrument, Instrument};
 
 use crate::{
     adapter::{AdapterFactory, AdaptsChain},
-    dispatcher::{
-        BuildingStage, BuildingStageQueue, FinalityStage, InclusionStage, PayloadDbLoader,
-    },
+    dispatcher::{BuildingStage, FinalityStage, InclusionStage, PayloadDbLoader},
     transaction::Transaction,
 };
 
@@ -85,33 +83,27 @@ impl Dispatcher {
         Self { inner, domain }
     }
 
-    // this is an async "constructor" that returns a JoinHandle, so the clippy warning doesn't apply
-    #[allow(clippy::async_yields_async)]
     #[instrument(skip(self), fields(domain = %self.domain))]
-    pub async fn spawn(self) -> JoinHandle<()> {
+    pub fn spawn(self) -> JoinHandle<()> {
+        let domain = self.domain.clone();
+        tokio::task::Builder::new()
+            .name("dispatcher")
+            .spawn(
+                async move {
+                    self.run().await;
+                }
+                .instrument(tracing::info_span!("dispatcher", %domain)),
+            )
+            .expect("spawning tokio task from Builder is infallible")
+    }
+
+    async fn run(self) {
         let mut tasks = vec![];
-        let building_stage_queue = BuildingStageQueue::new();
+        let building_stage_queue = self.inner.building_stage_queue.clone();
         let (inclusion_stage_sender, inclusion_stage_receiver) =
             tokio::sync::mpsc::channel::<Transaction>(SUBMITTER_CHANNEL_SIZE);
         let (finality_stage_sender, finality_stage_receiver) =
             tokio::sync::mpsc::channel::<Transaction>(SUBMITTER_CHANNEL_SIZE);
-
-        let building_stage = BuildingStage::new(
-            building_stage_queue.clone(),
-            inclusion_stage_sender.clone(),
-            self.inner.clone(),
-            self.domain.clone(),
-        );
-        let building_task = tokio::task::Builder::new()
-            .name("building_stage")
-            .spawn(
-                async move {
-                    building_stage.run().await;
-                }
-                .instrument(tracing::info_span!("building_stage")),
-            )
-            .expect("spawning tokio task from Builder is infallible");
-        tasks.push(building_task);
 
         let inclusion_stage = InclusionStage::new(
             inclusion_stage_receiver,
@@ -147,27 +139,6 @@ impl Dispatcher {
             .expect("spawning tokio task from Builder is infallible");
         tasks.push(finality_task);
 
-        let payload_db_loader = PayloadDbLoader::new(
-            self.inner.payload_db.clone(),
-            building_stage_queue.clone(),
-            self.domain.clone(),
-        );
-        let mut payload_iterator = payload_db_loader.into_iterator().await;
-        let metrics = self.inner.metrics.clone();
-        let payload_loader_task = tokio::task::Builder::new()
-            .name("payload_loader")
-            .spawn(
-                async move {
-                    payload_iterator
-                        .load_from_db(metrics)
-                        .await
-                        .expect("Payload loader crashed");
-                }
-                .instrument(tracing::info_span!("payload_db_loader")),
-            )
-            .expect("spawning tokio task from Builder is infallible");
-        tasks.push(payload_loader_task);
-
         let transaction_db_loader = TransactionDbLoader::new(
             self.inner.tx_db.clone(),
             inclusion_stage_sender.clone(),
@@ -190,15 +161,37 @@ impl Dispatcher {
             .expect("spawning tokio task from Builder is infallible");
         tasks.push(transaction_loader_task);
 
-        tokio::task::Builder::new()
-            .name("dispatcher")
+        // Transaction recovery and its consumers remain live while the derived
+        // payload index is rebuilt. New ingress and the building consumer stay
+        // gated so reconciliation cannot race a payload into a second transaction.
+        PayloadDbLoader::new(
+            self.inner.payload_db.clone(),
+            building_stage_queue,
+            self.domain.clone(),
+        )
+        .load_from_db(self.inner.metrics.clone())
+        .await
+        .expect("Payload loader crashed");
+
+        let building_stage = BuildingStage::new(
+            self.inner.building_stage_queue.clone(),
+            inclusion_stage_sender,
+            self.inner.clone(),
+            self.domain.clone(),
+        );
+        let building_task = tokio::task::Builder::new()
+            .name("building_stage")
             .spawn(
                 async move {
-                    join_all(tasks).await;
+                    building_stage.run().await;
                 }
-                .instrument(tracing::info_span!("dispatcher")),
+                .instrument(tracing::info_span!("building_stage")),
             )
-            .expect("spawning tokio task from Builder is infallible")
+            .expect("spawning tokio task from Builder is infallible");
+        tasks.push(building_task);
+        self.inner.mark_recovery_complete();
+
+        join_all(tasks).await;
     }
 }
 

--- a/rust/main/lander/src/dispatcher/db/payload/loader.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/loader.rs
@@ -1,19 +1,22 @@
 use std::{
     fmt::{Debug, Formatter},
-    sync::{mpsc::Sender, Arc},
+    sync::Arc,
+    time::Instant,
 };
 
-use async_trait::async_trait;
 use derive_new::new;
-use tracing::{debug, trace};
+use tracing::info;
 
 use crate::{
-    dispatcher::{BuildingStageQueue, DbIterator, LoadableFromDb, LoadingOutcome},
+    dispatcher::{metrics::DispatcherMetrics, BuildingStageQueue},
     error::LanderError,
-    payload::{FullPayload, PayloadStatus},
 };
 
 use super::PayloadDb;
+
+// Bound each synchronous chunk to at most 2,000 point reads and 1,000 derived
+// writes while amortizing one RocksDB commit across the whole chunk.
+const RECONCILIATION_BATCH_SIZE: u32 = 1_000;
 
 #[derive(new)]
 pub struct PayloadDbLoader {
@@ -23,40 +26,73 @@ pub struct PayloadDbLoader {
 }
 
 impl PayloadDbLoader {
-    pub async fn into_iterator(self) -> DbIterator<Self> {
-        let domain = self.domain.clone();
-        DbIterator::new(Arc::new(self), "Payload".to_string(), false, domain).await
+    pub async fn load_from_db(&self, metrics: DispatcherMetrics) -> Result<(), LanderError> {
+        let started_at = Instant::now();
+        metrics.update_liveness_metric("PayloadDbLoader", &self.domain);
+
+        let checkpoint = self.db.pending_payload_index_checkpoint().await?;
+        let requires_reconciliation = match checkpoint {
+            Some(checkpoint) => {
+                self.db
+                    .pending_payload_index_requires_reconciliation(checkpoint)
+                    .await?
+            }
+            None => true,
+        };
+
+        if !requires_reconciliation {
+            let payloads = self.db.retrieve_pending_payloads().await?;
+            let count = payloads.len();
+            self.building_stage_queue.extend(payloads).await;
+            info!(
+                count,
+                elapsed_ms = started_at.elapsed().as_millis(),
+                domain = %self.domain,
+                "Loaded pending payload index"
+            );
+            return Ok(());
+        }
+
+        let highest_index = self.db.retrieve_highest_payload_index().await?;
+        info!(
+            highest_index,
+            domain = %self.domain,
+            "Backfilling pending payload index"
+        );
+        self.db.begin_pending_payload_index_reconciliation().await?;
+        let mut pending_count = 0usize;
+        let mut last_index = highest_index;
+        while last_index > 0 {
+            let first_index = last_index
+                .saturating_sub(RECONCILIATION_BATCH_SIZE.saturating_sub(1))
+                .max(1);
+            let payloads = self
+                .db
+                .reconcile_pending_payloads(first_index, last_index)
+                .await?;
+            pending_count = pending_count.saturating_add(payloads.len());
+            self.building_stage_queue.extend(payloads).await;
+
+            if first_index == 1 {
+                break;
+            }
+            last_index = first_index.saturating_sub(1);
+            tokio::task::yield_now().await;
+        }
+        self.db.mark_pending_payload_index_reconciled().await?;
+        info!(
+            highest_index,
+            pending_count,
+            elapsed_ms = started_at.elapsed().as_millis(),
+            domain = %self.domain,
+            "Pending payload index backfill complete"
+        );
+        Ok(())
     }
 }
 
 impl Debug for PayloadDbLoader {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PayloadDbLoader").finish()
-    }
-}
-
-#[async_trait]
-impl LoadableFromDb for PayloadDbLoader {
-    type Item = FullPayload;
-
-    async fn highest_index(&self) -> Result<u32, LanderError> {
-        Ok(self.db.retrieve_highest_payload_index().await?)
-    }
-
-    async fn retrieve_by_index(&self, index: u32) -> Result<Option<Self::Item>, LanderError> {
-        Ok(self.db.retrieve_payload_by_index(index).await?)
-    }
-
-    async fn load(&self, item: FullPayload) -> Result<LoadingOutcome, LanderError> {
-        match item.status {
-            PayloadStatus::ReadyToSubmit | PayloadStatus::Retry(_) => {
-                self.building_stage_queue.push_back(item).await;
-                Ok(LoadingOutcome::Loaded)
-            }
-            PayloadStatus::Dropped(_) | PayloadStatus::InTransaction(_) => {
-                debug!(?item, "Payload already processed");
-                Ok(LoadingOutcome::Skipped)
-            }
-        }
     }
 }

--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -1,13 +1,17 @@
 // TODO: re-enable clippy warnings
 #![allow(dead_code)]
 
-use std::io::Write;
+use std::{
+    collections::HashMap,
+    io::Write,
+    sync::{Arc, LazyLock, Mutex},
+};
 
 use async_trait::async_trait;
 use eyre::eyre;
 use hyperlane_base::db::{DbError, DbResult, HyperlaneRocksDB};
 use hyperlane_core::{identifiers::UniqueIdentifier, Decode, Encode, HyperlaneProtocolError};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{
     payload::{self, FullPayload, PayloadStatus, PayloadUuid},
@@ -19,7 +23,22 @@ const TRANSACTION_UUID_BY_PAYLOAD_UUID_STORAGE_PREFIX: &str = "transaction_uuid_
 const PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX: &str = "payload_index_by_uuid_";
 const PAYLOAD_UUID_BY_INDEX_STORAGE_PREFIX: &str = "payload_uuid_by_index_";
 const HIGHEST_PAYLOAD_INDEX_STORAGE_PREFIX: &str = "highest_payload_index_";
+const PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX: &str = "pending_payload_by_index_";
+const PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX: &str = "pending_payload_index_checkpoint_";
+const PENDING_PAYLOAD_INDEX_WRITE_MARKER_STORAGE_PREFIX: &str =
+    "pending_payload_index_write_marker_";
+static PAYLOAD_WRITE_LOCKS: LazyLock<Mutex<HashMap<u32, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
+fn payload_write_lock(db: &HyperlaneRocksDB) -> DbResult<Arc<Mutex<()>>> {
+    let mut locks = PAYLOAD_WRITE_LOCKS
+        .lock()
+        .map_err(|_| DbError::Other("Payload write-lock registry was poisoned".to_string()))?;
+    Ok(locks
+        .entry(db.domain().id())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone())
+}
 #[async_trait]
 pub trait PayloadDb: Send + Sync {
     /// Retrieve a payload by its unique ID
@@ -70,6 +89,33 @@ pub trait PayloadDb: Send + Sync {
     /// Retrieve the highest payload index
     async fn retrieve_highest_payload_index(&self) -> DbResult<u32>;
 
+    /// Retrieve payloads which still need transaction building.
+    async fn retrieve_pending_payloads(&self) -> DbResult<Vec<FullPayload>>;
+
+    /// RocksDB sequence through which the pending index was last validated.
+    async fn pending_payload_index_checkpoint(&self) -> DbResult<Option<u64>>;
+
+    /// Whether canonical payload writes after the checkpoint were made by a
+    /// binary which did not atomically maintain the pending index.
+    async fn pending_payload_index_requires_reconciliation(
+        &self,
+        checkpoint: u64,
+    ) -> DbResult<bool>;
+
+    /// Record that the pending index is consistent through the latest RocksDB
+    /// sequence.
+    async fn mark_pending_payload_index_reconciled(&self) -> DbResult<()>;
+
+    /// Clear the pending index before a full reconciliation.
+    async fn begin_pending_payload_index_reconciliation(&self) -> DbResult<()>;
+
+    /// Reconcile a bounded inclusive range of historical payload indexes.
+    async fn reconcile_pending_payloads(
+        &self,
+        first_index: u32,
+        last_index: u32,
+    ) -> DbResult<Vec<FullPayload>>;
+
     /// Set the status of a payload by its unique ID. Performs one read (to first fetch the full payload) and one write.
     async fn store_new_payload_status(
         &self,
@@ -109,32 +155,76 @@ impl PayloadDb for HyperlaneRocksDB {
     }
 
     async fn store_payload_by_uuid(&self, payload: &FullPayload) -> DbResult<()> {
-        if self
-            .retrieve_payload_index_by_uuid(payload.uuid())
-            .await?
-            .is_none()
+        let write_lock = payload_write_lock(self)?;
+        let _write_guard = write_lock
+            .lock()
+            .map_err(|_| DbError::Other("Payload database write lock was poisoned".to_string()))?;
+        let mut batch = self.batch();
+
+        let payload_index = if let Some(payload_index) = self
+            .retrieve_value_by_key::<_, u32>(PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX, payload.uuid())?
         {
-            let highest_index = self.retrieve_highest_payload_index().await?;
+            debug!(
+                payload_uuid = ?payload.uuid(),
+                "Payload with UUID already exists, not updating index",
+            );
+            payload_index
+        } else {
+            let highest_index: u32 = self
+                .retrieve_value_by_key(HIGHEST_PAYLOAD_INDEX_STORAGE_PREFIX, &bool::default())?
+                .unwrap_or_default();
             let payload_index = highest_index.checked_add(1).ok_or_else(|| {
                 DbError::Other("Highest payload index exhausted (u32::MAX)".into())
             })?;
-            self.store_highest_payload_index(payload_index).await?;
-            self.store_payload_index_by_uuid(payload_index, payload.uuid())
-                .await?;
-            self.store_payload_uuid_by_index(payload_index, payload.uuid())
-                .await?;
+            batch.store_keyed_encodable(
+                HIGHEST_PAYLOAD_INDEX_STORAGE_PREFIX,
+                &bool::default(),
+                &payload_index,
+            );
+            batch.store_keyed_encodable(
+                PAYLOAD_INDEX_BY_UUID_STORAGE_PREFIX,
+                payload.uuid(),
+                &payload_index,
+            );
+            batch.store_keyed_encodable(
+                PAYLOAD_UUID_BY_INDEX_STORAGE_PREFIX,
+                &payload_index,
+                payload.uuid(),
+            );
             debug!(
                 ?payload,
                 index = payload_index,
                 "Updated highest index for incoming payload"
             );
-        } else {
-            debug!(
-                payload_uuid = ?payload.uuid(),
-                "Payload with UUID already exists, not updating index",
+            payload_index
+        };
+        batch.store_keyed_encodable(PAYLOAD_BY_UUID_STORAGE_PREFIX, payload.uuid(), payload);
+        match &payload.status {
+            PayloadStatus::ReadyToSubmit | PayloadStatus::Retry(_) => {
+                batch.store_keyed_encodable(
+                    PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX,
+                    &payload_index,
+                    payload,
+                );
+            }
+            PayloadStatus::Dropped(_) | PayloadStatus::InTransaction(_) => {
+                batch.delete_keyed(PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX, &payload_index);
+            }
+        }
+        batch.store_keyed_encodable(
+            PENDING_PAYLOAD_INDEX_WRITE_MARKER_STORAGE_PREFIX,
+            &bool::default(),
+            &true,
+        );
+        batch.commit()?;
+        drop(_write_guard);
+        if let Err(error) = self.mark_pending_payload_index_reconciled().await {
+            warn!(
+                ?error,
+                "Payload committed but pending-index checkpoint could not advance"
             );
         }
-        self.store_value_by_key(PAYLOAD_BY_UUID_STORAGE_PREFIX, payload.uuid(), payload)
+        Ok(())
     }
 
     async fn retrieve_payload_index_by_uuid(
@@ -177,6 +267,107 @@ impl PayloadDb for HyperlaneRocksDB {
         // return the default value (0) if no index has been stored yet
         self.retrieve_value_by_key(HIGHEST_PAYLOAD_INDEX_STORAGE_PREFIX, &bool::default())
             .map(|index: Option<u32>| index.unwrap_or_default())
+    }
+
+    async fn retrieve_pending_payloads(&self) -> DbResult<Vec<FullPayload>> {
+        let mut payloads =
+            self.retrieve_decodables_by_prefix(PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX)?;
+        payloads.reverse();
+        Ok(payloads)
+    }
+
+    async fn pending_payload_index_checkpoint(&self) -> DbResult<Option<u64>> {
+        self.retrieve_value_by_key(
+            PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX,
+            &bool::default(),
+        )
+    }
+
+    async fn pending_payload_index_requires_reconciliation(
+        &self,
+        checkpoint: u64,
+    ) -> DbResult<bool> {
+        match self.has_unmarked_writes_since(
+            checkpoint,
+            PAYLOAD_BY_UUID_STORAGE_PREFIX,
+            PENDING_PAYLOAD_INDEX_WRITE_MARKER_STORAGE_PREFIX,
+        ) {
+            Ok(requires_reconciliation) => Ok(requires_reconciliation),
+            Err(error) => {
+                warn!(
+                    ?error,
+                    checkpoint,
+                    "Pending payload index checkpoint is outside the retained WAL; rebuilding"
+                );
+                Ok(true)
+            }
+        }
+    }
+
+    async fn mark_pending_payload_index_reconciled(&self) -> DbResult<()> {
+        let checkpoint = self.latest_sequence_number();
+        self.store_value_by_key(
+            PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX,
+            &bool::default(),
+            &checkpoint,
+        )
+    }
+
+    async fn begin_pending_payload_index_reconciliation(&self) -> DbResult<()> {
+        let write_lock = payload_write_lock(self)?;
+        let _write_guard = write_lock
+            .lock()
+            .map_err(|_| DbError::Other("Payload database write lock was poisoned".to_string()))?;
+        let mut batch = self.batch();
+        batch.delete_prefix(PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX)?;
+        batch.delete_keyed(
+            PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX,
+            &bool::default(),
+        );
+        batch.commit()
+    }
+
+    async fn reconcile_pending_payloads(
+        &self,
+        first_index: u32,
+        last_index: u32,
+    ) -> DbResult<Vec<FullPayload>> {
+        let write_lock = payload_write_lock(self)?;
+        let _write_guard = write_lock
+            .lock()
+            .map_err(|_| DbError::Other("Payload database write lock was poisoned".to_string()))?;
+        let mut batch = self.batch();
+        let mut pending_payloads = Vec::new();
+
+        for index in (first_index..=last_index).rev() {
+            let Some(payload_uuid) = self.retrieve_value_by_key::<_, PayloadUuid>(
+                PAYLOAD_UUID_BY_INDEX_STORAGE_PREFIX,
+                &index,
+            )?
+            else {
+                continue;
+            };
+            let Some(payload) = self.retrieve_value_by_key::<_, FullPayload>(
+                PAYLOAD_BY_UUID_STORAGE_PREFIX,
+                &payload_uuid,
+            )?
+            else {
+                continue;
+            };
+            if matches!(
+                &payload.status,
+                PayloadStatus::ReadyToSubmit | PayloadStatus::Retry(_)
+            ) {
+                batch.store_keyed_encodable(
+                    PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX,
+                    &index,
+                    &payload,
+                );
+                pending_payloads.push(payload);
+            }
+        }
+        batch.commit()?;
+        Ok(pending_payloads)
     }
 
     async fn store_tx_uuid_by_payload_uuid(
@@ -234,21 +425,28 @@ mod tests {
     use std::sync::Arc;
 
     use hyperlane_base::db::{HyperlaneRocksDB, DB};
-    use hyperlane_core::KnownHyperlaneDomain;
+    use hyperlane_core::{identifiers::UniqueIdentifier, KnownHyperlaneDomain};
 
     use crate::{
+        dispatcher::{BuildingStageQueue, DispatcherMetrics, PayloadDbLoader},
         payload::{FullPayload, PayloadStatus},
         transaction::TransactionStatus,
     };
 
-    use super::PayloadDb;
+    use super::{
+        PayloadDb, PAYLOAD_BY_UUID_STORAGE_PREFIX, PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX,
+        PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX,
+    };
 
-    fn tmp_db() -> Arc<dyn PayloadDb> {
-        let temp_dir = tempfile::tempdir().unwrap();
+    fn db_in(temp_dir: &tempfile::TempDir) -> Arc<HyperlaneRocksDB> {
         let db = DB::from_path(temp_dir.path()).unwrap();
         let domain = KnownHyperlaneDomain::Arbitrum.into();
 
-        (Arc::new(HyperlaneRocksDB::new(&domain, db))) as _
+        Arc::new(HyperlaneRocksDB::new(&domain, db))
+    }
+
+    fn tmp_db() -> Arc<HyperlaneRocksDB> {
+        db_in(&tempfile::tempdir().unwrap())
     }
 
     #[tokio::test]
@@ -284,5 +482,173 @@ mod tests {
             let highest_index = db.retrieve_highest_payload_index().await.unwrap();
             assert_eq!(highest_index, expected_payload_index);
         }
+    }
+
+    #[tokio::test]
+    async fn pending_index_tracks_payload_status() {
+        let db = tmp_db();
+        let mut payload = FullPayload::random();
+
+        db.store_payload_by_uuid(&payload).await.unwrap();
+        assert_eq!(
+            db.retrieve_pending_payloads().await.unwrap(),
+            vec![payload.clone()]
+        );
+
+        payload.status = PayloadStatus::InTransaction(TransactionStatus::PendingInclusion);
+        db.store_payload_by_uuid(&payload).await.unwrap();
+        assert!(db.retrieve_pending_payloads().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_index_preserves_newest_first_order() {
+        let db = tmp_db();
+        let payloads = (0..3).map(|_| FullPayload::random()).collect::<Vec<_>>();
+
+        for payload in &payloads {
+            db.store_payload_by_uuid(payload).await.unwrap();
+        }
+
+        assert_eq!(
+            db.retrieve_pending_payloads().await.unwrap(),
+            payloads.into_iter().rev().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn loader_backfills_missing_pending_index() {
+        let db = tmp_db();
+        let payload = FullPayload::random();
+        db.store_payload_by_uuid(&payload).await.unwrap();
+
+        // Simulate a database written before the pending index existed.
+        let payload_index = db
+            .retrieve_payload_index_by_uuid(payload.uuid())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut batch = db.batch();
+        batch.delete_keyed(PENDING_PAYLOAD_BY_INDEX_STORAGE_PREFIX, &payload_index);
+        batch.delete_keyed(
+            PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX,
+            &bool::default(),
+        );
+        batch.commit().unwrap();
+
+        let queue = BuildingStageQueue::new();
+        let loader = PayloadDbLoader::new(db.clone(), queue.clone(), "test".to_string());
+        loader
+            .load_from_db(DispatcherMetrics::dummy_instance())
+            .await
+            .unwrap();
+
+        assert!(db
+            .pending_payload_index_checkpoint()
+            .await
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            db.retrieve_pending_payloads().await.unwrap(),
+            vec![payload.clone()]
+        );
+        assert_eq!(queue.pop_n(1).await, vec![payload]);
+    }
+
+    #[tokio::test]
+    async fn loader_reconciles_writes_from_rollback_binary() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = db_in(&temp_dir);
+        let mut becomes_terminal = FullPayload::random();
+        let mut becomes_pending = FullPayload::random();
+        becomes_pending.status = PayloadStatus::InTransaction(TransactionStatus::PendingInclusion);
+        db.store_payload_by_uuid(&becomes_terminal).await.unwrap();
+        db.store_payload_by_uuid(&becomes_pending).await.unwrap();
+
+        let checkpoint = db
+            .pending_payload_index_checkpoint()
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!db
+            .pending_payload_index_requires_reconciliation(checkpoint)
+            .await
+            .unwrap());
+
+        // Simulate the old binary: it updates canonical payloads but does not
+        // maintain the new index/write marker.
+        becomes_terminal.status = PayloadStatus::InTransaction(TransactionStatus::PendingInclusion);
+        db.store_value_by_key(
+            PAYLOAD_BY_UUID_STORAGE_PREFIX,
+            becomes_terminal.uuid(),
+            &becomes_terminal,
+        )
+        .unwrap();
+        becomes_pending.status = PayloadStatus::ReadyToSubmit;
+        db.store_value_by_key(
+            PAYLOAD_BY_UUID_STORAGE_PREFIX,
+            becomes_pending.uuid(),
+            &becomes_pending,
+        )
+        .unwrap();
+        let legacy_new_pending = FullPayload::random();
+        db.store_highest_payload_index(3).await.unwrap();
+        db.store_payload_index_by_uuid(3, legacy_new_pending.uuid())
+            .await
+            .unwrap();
+        db.store_payload_uuid_by_index(3, legacy_new_pending.uuid())
+            .await
+            .unwrap();
+        db.store_value_by_key(
+            PAYLOAD_BY_UUID_STORAGE_PREFIX,
+            legacy_new_pending.uuid(),
+            &legacy_new_pending,
+        )
+        .unwrap();
+
+        assert!(db
+            .pending_payload_index_requires_reconciliation(checkpoint)
+            .await
+            .unwrap());
+
+        let queue = BuildingStageQueue::new();
+        PayloadDbLoader::new(db.clone(), queue.clone(), "test".to_string())
+            .load_from_db(DispatcherMetrics::dummy_instance())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            db.retrieve_pending_payloads().await.unwrap(),
+            vec![legacy_new_pending.clone(), becomes_pending.clone()]
+        );
+        assert_eq!(
+            queue.pop_n(3).await,
+            vec![legacy_new_pending, becomes_pending]
+        );
+    }
+
+    #[tokio::test]
+    async fn loader_rebuilds_sparse_history_in_bounded_batches() {
+        let db = tmp_db();
+        let payload = FullPayload::random();
+        db.store_payload_by_uuid(&payload).await.unwrap();
+        db.store_highest_payload_index(2_501).await.unwrap();
+
+        let mut batch = db.batch();
+        batch.delete_keyed(
+            PENDING_PAYLOAD_INDEX_CHECKPOINT_STORAGE_PREFIX,
+            &bool::default(),
+        );
+        batch.commit().unwrap();
+        let sequence_before = db.latest_sequence_number();
+
+        let queue = BuildingStageQueue::new();
+        PayloadDbLoader::new(db.clone(), queue.clone(), "test".to_string())
+            .load_from_db(DispatcherMetrics::dummy_instance())
+            .await
+            .unwrap();
+
+        let sequence_writes = db.latest_sequence_number().saturating_sub(sequence_before);
+        assert!(sequence_writes <= 5, "used {sequence_writes} writes");
+        assert_eq!(queue.pop_n(1).await, vec![payload]);
     }
 }

--- a/rust/main/lander/src/dispatcher/entrypoint.rs
+++ b/rust/main/lander/src/dispatcher/entrypoint.rs
@@ -36,12 +36,17 @@ impl DispatcherEntrypoint {
     pub(crate) fn from_inner(inner: DispatcherState) -> Self {
         Self { inner }
     }
+
+    /// Wait until persisted payload recovery has completed.
+    pub async fn wait_for_recovery(&self) {
+        self.inner.wait_for_recovery().await;
+    }
 }
 
 #[async_trait]
 impl Entrypoint for DispatcherEntrypoint {
     async fn send_payload(&self, payload: &FullPayload) -> Result<(), LanderError> {
-        self.inner.wait_for_recovery().await;
+        self.wait_for_recovery().await;
         self.inner.payload_db.store_payload_by_uuid(payload).await?;
         self.inner
             .building_stage_queue

--- a/rust/main/lander/src/dispatcher/entrypoint.rs
+++ b/rust/main/lander/src/dispatcher/entrypoint.rs
@@ -41,7 +41,12 @@ impl DispatcherEntrypoint {
 #[async_trait]
 impl Entrypoint for DispatcherEntrypoint {
     async fn send_payload(&self, payload: &FullPayload) -> Result<(), LanderError> {
+        self.inner.wait_for_recovery().await;
         self.inner.payload_db.store_payload_by_uuid(payload).await?;
+        self.inner
+            .building_stage_queue
+            .push_back(payload.clone())
+            .await;
         info!(payload=?payload.details, "Sent payload to dispatcher");
         Ok(())
     }
@@ -133,6 +138,19 @@ pub mod tests {
             async fn retrieve_payload_uuid_by_index(&self, index: u32) -> DbResult<Option<PayloadUuid>>;
             async fn store_highest_payload_index(&self, index: u32) -> DbResult<()>;
             async fn retrieve_highest_payload_index(&self) -> DbResult<u32>;
+            async fn retrieve_pending_payloads(&self) -> DbResult<Vec<FullPayload>>;
+            async fn pending_payload_index_checkpoint(&self) -> DbResult<Option<u64>>;
+            async fn pending_payload_index_requires_reconciliation(
+                &self,
+                checkpoint: u64,
+            ) -> DbResult<bool>;
+            async fn mark_pending_payload_index_reconciled(&self) -> DbResult<()>;
+            async fn begin_pending_payload_index_reconciliation(&self) -> DbResult<()>;
+            async fn reconcile_pending_payloads(
+                &self,
+                first_index: u32,
+                last_index: u32,
+            ) -> DbResult<Vec<FullPayload>>;
             async fn store_payload_index_by_uuid(
                 &self,
                 index: u32,

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -34,13 +34,8 @@ impl BuildingStage {
             // event-driven by the Building queue
             let payloads = self
                 .queue
-                .pop_n(self.state.adapter.max_batch_size() as usize)
+                .pop_n_or_wait(self.state.adapter.max_batch_size() as usize)
                 .await;
-            if payloads.is_empty() {
-                // wait for more payloads to arrive
-                tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
-                continue;
-            }
             // note: this will set the queue length metric to `length - payloads.len()`,
             // so worst case this will be lower by `max_batch_size`
             self.update_metrics().await;

--- a/rust/main/lander/src/dispatcher/stages/building_stage/queue.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/queue.rs
@@ -1,40 +1,76 @@
-use std::collections::VecDeque;
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
 
-use tokio::sync::Mutex;
+use hyperlane_core::identifiers::UniqueIdentifier;
+use tokio::sync::{Mutex, Notify};
 
-use crate::FullPayload;
+use crate::{FullPayload, PayloadUuid};
 
 #[derive(Debug, Clone)]
-pub struct BuildingStageQueue(Arc<Mutex<VecDeque<FullPayload>>>);
+pub struct BuildingStageQueue {
+    inner: Arc<Mutex<QueueInner>>,
+    activity: Arc<Notify>,
+}
+
+#[derive(Debug, Default)]
+struct QueueInner {
+    payloads: VecDeque<FullPayload>,
+    uuids: HashSet<PayloadUuid>,
+}
 
 impl BuildingStageQueue {
     pub fn new() -> Self {
-        BuildingStageQueue(Arc::new(Mutex::new(VecDeque::new())))
+        Self {
+            inner: Arc::new(Mutex::new(QueueInner::default())),
+            activity: Arc::new(Notify::new()),
+        }
     }
 
     /// Push a payload to the back of the queue.
     pub async fn push_back(&self, payload: FullPayload) {
-        self.0.lock().await.push_back(payload);
+        let mut inner = self.inner.lock().await;
+        if inner.uuids.insert(payload.uuid().clone()) {
+            inner.payloads.push_back(payload);
+            drop(inner);
+            self.activity.notify_one();
+        }
     }
 
     /// Push a payload to the front of the queue.
     pub async fn push_front(&self, payload: FullPayload) {
-        self.0.lock().await.push_front(payload);
+        let mut inner = self.inner.lock().await;
+        if inner.uuids.insert(payload.uuid().clone()) {
+            inner.payloads.push_front(payload);
+            drop(inner);
+            self.activity.notify_one();
+        }
     }
 
     /// Extend the queue with an iterator of payloads.
     pub async fn extend<I: IntoIterator<Item = FullPayload>>(&self, iter: I) {
-        self.0.lock().await.extend(iter);
+        let mut inner = self.inner.lock().await;
+        let mut added = false;
+        for payload in iter {
+            if inner.uuids.insert(payload.uuid().clone()) {
+                inner.payloads.push_back(payload);
+                added = true;
+            }
+        }
+        drop(inner);
+        if added {
+            self.activity.notify_one();
+        }
     }
 
     /// Pops up to `count` payloads from the front of the queue.
     pub async fn pop_n(&self, count: usize) -> Vec<FullPayload> {
-        let mut queue = self.0.lock().await;
+        let mut inner = self.inner.lock().await;
         let mut result = Vec::with_capacity(count);
         for _ in 0..count {
-            if let Some(payload) = queue.pop_front() {
+            if let Some(payload) = inner.payloads.pop_front() {
+                inner.uuids.remove(payload.uuid());
                 result.push(payload);
             } else {
                 break;
@@ -43,9 +79,20 @@ impl BuildingStageQueue {
         result
     }
 
+    /// Wait for activity and pop up to `count` payloads.
+    pub async fn pop_n_or_wait(&self, count: usize) -> Vec<FullPayload> {
+        loop {
+            let payloads = self.pop_n(count).await;
+            if !payloads.is_empty() {
+                return payloads;
+            }
+            self.activity.notified().await;
+        }
+    }
+
     /// Get the length of the queue.
     pub async fn len(&self) -> usize {
-        self.0.lock().await.len()
+        self.inner.lock().await.payloads.len()
     }
 }
 

--- a/rust/main/lander/src/dispatcher/stages/building_stage/queue/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/queue/tests.rs
@@ -84,3 +84,28 @@ async fn test_len_is_correct_after_operations() {
     let _ = queue.pop_n(1).await;
     assert_eq!(queue.len().await, 0);
 }
+
+#[tokio::test]
+async fn test_duplicate_payload_is_only_queued_once() {
+    let queue = BuildingStageQueue::new();
+    let payload = FullPayload::random();
+
+    queue.push_back(payload.clone()).await;
+    queue.push_back(payload.clone()).await;
+
+    assert_eq!(queue.pop_n(2).await, vec![payload]);
+}
+
+#[tokio::test]
+async fn test_push_wakes_waiting_consumer() {
+    let queue = BuildingStageQueue::new();
+    let payload = FullPayload::random();
+    let waiter = tokio::spawn({
+        let queue = queue.clone();
+        async move { queue.pop_n_or_wait(1).await }
+    });
+
+    queue.push_back(payload.clone()).await;
+
+    assert_eq!(waiter.await.unwrap(), vec![payload]);
+}

--- a/rust/main/lander/src/dispatcher/stages/state.rs
+++ b/rust/main/lander/src/dispatcher/stages/state.rs
@@ -1,7 +1,10 @@
 // TODO: re-enable clippy warnings
 #![allow(dead_code)]
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use chrono::format;
 use derive_new::new;
@@ -22,7 +25,8 @@ use hyperlane_core::HyperlaneDomain;
 use crate::{
     adapter::{AdapterFactory, AdaptsChain},
     dispatcher::{
-        metrics::DispatcherMetrics, DatabaseOrPath, DispatcherSettings, PayloadDb, TransactionDb,
+        metrics::DispatcherMetrics, BuildingStageQueue, DatabaseOrPath, DispatcherSettings,
+        PayloadDb, TransactionDb,
     },
     payload::{DropReason, PayloadDetails, PayloadStatus},
     transaction::Transaction,
@@ -37,7 +41,38 @@ pub struct DispatcherState {
     pub(crate) adapter: Arc<dyn AdaptsChain>,
     pub(crate) metrics: DispatcherMetrics,
     pub(crate) domain: String,
+    pub(crate) building_stage_queue: BuildingStageQueue,
+    recovery_gate: Arc<RecoveryGate>,
     reprocess_txs_wakeup: Arc<Notify>,
+}
+
+struct RecoveryGate {
+    ready: AtomicBool,
+    activity: Notify,
+}
+
+impl RecoveryGate {
+    fn new(ready: bool) -> Self {
+        Self {
+            ready: AtomicBool::new(ready),
+            activity: Notify::new(),
+        }
+    }
+
+    async fn wait(&self) {
+        while !self.ready.load(Ordering::Acquire) {
+            let notified = self.activity.notified();
+            if self.ready.load(Ordering::Acquire) {
+                break;
+            }
+            notified.await;
+        }
+    }
+
+    fn open(&self) {
+        self.ready.store(true, Ordering::Release);
+        self.activity.notify_waiters();
+    }
 }
 
 impl DispatcherState {
@@ -48,14 +83,45 @@ impl DispatcherState {
         metrics: DispatcherMetrics,
         domain: String,
     ) -> Self {
+        Self::new_with_recovery_state(payload_db, tx_db, adapter, metrics, domain, true)
+    }
+
+    fn new_with_recovery_state(
+        payload_db: Arc<dyn PayloadDb>,
+        tx_db: Arc<dyn TransactionDb>,
+        adapter: Arc<dyn AdaptsChain>,
+        metrics: DispatcherMetrics,
+        domain: String,
+        recovery_complete: bool,
+    ) -> Self {
         Self {
             payload_db,
             tx_db,
             adapter,
             metrics,
             domain,
+            building_stage_queue: BuildingStageQueue::new(),
+            recovery_gate: Arc::new(RecoveryGate::new(recovery_complete)),
             reprocess_txs_wakeup: Arc::new(Notify::new()),
         }
+    }
+
+    pub(crate) fn new_recovery_pending(
+        payload_db: Arc<dyn PayloadDb>,
+        tx_db: Arc<dyn TransactionDb>,
+        adapter: Arc<dyn AdaptsChain>,
+        metrics: DispatcherMetrics,
+        domain: String,
+    ) -> Self {
+        Self::new_with_recovery_state(payload_db, tx_db, adapter, metrics, domain, false)
+    }
+
+    pub(crate) async fn wait_for_recovery(&self) {
+        self.recovery_gate.wait().await;
+    }
+
+    pub(crate) fn mark_recovery_complete(&self) {
+        self.recovery_gate.open();
     }
 
     pub(crate) fn notify_reprocess_txs_activity(&self) {
@@ -86,7 +152,9 @@ impl DispatcherState {
         let payload_db = rocksdb.clone() as Arc<dyn PayloadDb>;
         let tx_db = rocksdb as Arc<dyn TransactionDb>;
         let domain = settings.domain.to_string();
-        Ok(Self::new(payload_db, tx_db, adapter, metrics, domain))
+        Ok(Self::new_recovery_pending(
+            payload_db, tx_db, adapter, metrics, domain,
+        ))
     }
 
     pub(crate) async fn update_status_for_payloads(

--- a/rust/main/lander/src/dispatcher/tests.rs
+++ b/rust/main/lander/src/dispatcher/tests.rs
@@ -4,7 +4,7 @@ use tokio::{sync::Mutex, time::sleep};
 
 use crate::adapter::TxBuildingResult;
 use crate::dispatcher::metrics::DispatcherMetrics;
-use crate::dispatcher::{BuildingStageQueue, DispatcherState, PayloadDbLoader};
+use crate::dispatcher::{BuildingStageQueue, DispatcherState};
 use crate::tests::test_utils::{dummy_tx, tmp_dbs, MockAdapter};
 use crate::transaction::TransactionUuid;
 use crate::{
@@ -15,42 +15,60 @@ use crate::{
 use super::PayloadDb;
 
 #[tokio::test]
-async fn test_entrypoint_send_is_detected_by_loader() {
+async fn test_entrypoint_send_is_enqueued_directly() {
     let (payload_db, tx_db, _) = tmp_dbs();
-    let building_stage_queue = BuildingStageQueue::new();
     let domain = "dummy_domain".to_string();
-    let payload_db_loader = PayloadDbLoader::new(
-        payload_db.clone(),
-        building_stage_queue.clone(),
-        domain.clone(),
-    );
-    let mut payload_iterator = payload_db_loader.into_iterator().await;
-
     let metrics = DispatcherMetrics::dummy_instance();
     let adapter = Arc::new(MockAdapter::new());
     let state = DispatcherState::new(payload_db, tx_db, adapter, metrics.clone(), domain.clone());
+    let building_stage_queue = state.building_stage_queue.clone();
     let dispatcher_entrypoint = DispatcherEntrypoint {
         inner: state.clone(),
     };
 
-    let _payload_db_loader = tokio::spawn(async move {
-        payload_iterator
-            .load_from_db(metrics.clone())
-            .await
-            .expect("Payload loader crashed");
-    });
-
-    // Simulate writing to the database
     let payload = FullPayload::random();
     dispatcher_entrypoint.send_payload(&payload).await.unwrap();
 
-    // Check if the loader detects the new payload
-    sleep(Duration::from_millis(100)).await; // Wait for the loader to process the payload
-    let detected_payload_count = building_stage_queue.len().await;
-    assert_eq!(
-        detected_payload_count, 1,
-        "Loader did not detect the new payload"
+    assert_eq!(building_stage_queue.len().await, 1);
+}
+
+#[tokio::test]
+async fn test_entrypoint_send_waits_for_recovery() {
+    let (payload_db, tx_db, _) = tmp_dbs();
+    let metrics = DispatcherMetrics::dummy_instance();
+    let state = DispatcherState::new_recovery_pending(
+        payload_db.clone(),
+        tx_db,
+        Arc::new(MockAdapter::new()),
+        metrics,
+        "dummy_domain".to_string(),
     );
+    let building_stage_queue = state.building_stage_queue.clone();
+    let entrypoint = DispatcherEntrypoint {
+        inner: state.clone(),
+    };
+    let payload = FullPayload::random();
+    let payload_uuid = payload.uuid().clone();
+
+    let send_task = tokio::spawn(async move { entrypoint.send_payload(&payload).await });
+    tokio::task::yield_now().await;
+
+    assert!(payload_db
+        .retrieve_payload_by_uuid(&payload_uuid)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(building_stage_queue.len().await, 0);
+
+    state.mark_recovery_complete();
+    send_task.await.unwrap().unwrap();
+
+    assert!(payload_db
+        .retrieve_payload_by_uuid(&payload_uuid)
+        .await
+        .unwrap()
+        .is_some());
+    assert_eq!(building_stage_queue.len().await, 1);
 }
 
 #[tracing_test::traced_test]
@@ -64,7 +82,7 @@ async fn test_entrypoint_send_is_finalized_by_dispatcher() {
     let (entrypoint, dispatcher) = mock_entrypoint_and_dispatcher(adapter.clone()).await;
     let metrics = dispatcher.inner.metrics.clone();
 
-    let _payload_dispatcher = tokio::spawn(async move { dispatcher.spawn().await });
+    let _payload_dispatcher = dispatcher.spawn();
     entrypoint.send_payload(&payload).await.unwrap();
 
     // wait until the payload status is InTransaction(Finalized)
@@ -128,7 +146,7 @@ async fn test_entrypoint_send_fails_simulation_after_first_submission_but_finali
     let (entrypoint, dispatcher) = mock_entrypoint_and_dispatcher(adapter.clone()).await;
     let metrics = dispatcher.inner.metrics.clone();
 
-    let _payload_dispatcher = tokio::spawn(async move { dispatcher.spawn().await });
+    let _payload_dispatcher = dispatcher.spawn();
     entrypoint.send_payload(&payload).await.unwrap();
 
     // wait until the payload status is InTransaction(Finalized)
@@ -180,7 +198,7 @@ async fn test_entrypoint_send_fails_simulation_before_first_submission() {
     let (entrypoint, dispatcher) = mock_entrypoint_and_dispatcher(adapter.clone()).await;
     let metrics = dispatcher.inner.metrics.clone();
 
-    let _payload_dispatcher = tokio::spawn(async move { dispatcher.spawn().await });
+    let _payload_dispatcher = dispatcher.spawn();
     entrypoint.send_payload(&payload).await.unwrap();
 
     // wait until the payload status is InTransaction(Dropped(_))
@@ -236,7 +254,7 @@ async fn test_entrypoint_send_fails_estimation_after_first_submission() {
     let (entrypoint, dispatcher) = mock_entrypoint_and_dispatcher(adapter.clone()).await;
     let metrics = dispatcher.inner.metrics.clone();
 
-    let _payload_dispatcher = tokio::spawn(async move { dispatcher.spawn().await });
+    let _payload_dispatcher = dispatcher.spawn();
     entrypoint.send_payload(&payload).await.unwrap();
 
     // wait until the payload status is InTransaction(Dropped(_))
@@ -288,7 +306,7 @@ async fn test_entrypoint_send_fails_estimation_before_first_submission() {
     let (entrypoint, dispatcher) = mock_entrypoint_and_dispatcher(adapter.clone()).await;
     let metrics = dispatcher.inner.metrics.clone();
 
-    let _payload_dispatcher = tokio::spawn(async move { dispatcher.spawn().await });
+    let _payload_dispatcher = dispatcher.spawn();
     entrypoint.send_payload(&payload).await.unwrap();
 
     // wait until the payload status is InTransaction(Dropped(_))
@@ -329,28 +347,12 @@ async fn mock_entrypoint_and_dispatcher(
     let domain = "test_domain".to_string();
 
     let (payload_db, tx_db, _) = tmp_dbs();
-    let building_stage_queue = BuildingStageQueue::new();
-    let payload_db_loader = PayloadDbLoader::new(
-        payload_db.clone(),
-        building_stage_queue.clone(),
-        domain.clone(),
-    );
-    let mut payload_iterator = payload_db_loader.into_iterator().await;
-
     let metrics = DispatcherMetrics::dummy_instance();
 
     let state = DispatcherState::new(payload_db, tx_db, adapter, metrics.clone(), domain.clone());
     let dispatcher_entrypoint = DispatcherEntrypoint {
         inner: state.clone(),
     };
-
-    let metrics_to_move = metrics.clone();
-    let _payload_db_loader = tokio::spawn(async move {
-        payload_iterator
-            .load_from_db(metrics_to_move)
-            .await
-            .expect("Payload loader crashed");
-    });
 
     let dispatcher = Dispatcher {
         inner: state.clone(),

--- a/rust/main/lander/tests/integration_sealevel.rs
+++ b/rust/main/lander/tests/integration_sealevel.rs
@@ -369,7 +369,7 @@ async fn test_sealevel_payload_reaches_finalized_status() {
         lander::create_test_dispatcher(adapter, payload_db, tx_db, "sealevel".to_string()).await;
 
     // Spawn dispatcher
-    let _dispatcher_handle = tokio::spawn(async move { dispatcher.spawn().await.await });
+    let _dispatcher_handle = dispatcher.spawn();
 
     // Send payload
     entrypoint
@@ -429,7 +429,7 @@ async fn test_sealevel_versioned_tx_payload_reaches_finalized_status() {
         lander::create_test_dispatcher(adapter, payload_db, tx_db, "sealevel".to_string()).await;
 
     // Spawn dispatcher
-    let _dispatcher_handle = tokio::spawn(async move { dispatcher.spawn().await.await });
+    let _dispatcher_handle = dispatcher.spawn();
 
     // Send payload
     entrypoint
@@ -497,7 +497,7 @@ async fn test_sealevel_payload_simulation_failure_results_in_dropped() {
     let (entrypoint, dispatcher) =
         lander::create_test_dispatcher(adapter, payload_db, tx_db, "sealevel".to_string()).await;
 
-    let _dispatcher_handle = tokio::spawn(async move { dispatcher.spawn().await.await });
+    let _dispatcher_handle = dispatcher.spawn();
 
     // Send payload
     entrypoint
@@ -580,7 +580,7 @@ async fn test_sealevel_payload_estimation_failure_results_in_dropped() {
     let (entrypoint, dispatcher) =
         lander::create_test_dispatcher(adapter, payload_db, tx_db, "sealevel".to_string()).await;
 
-    let _dispatcher_handle = tokio::spawn(async move { dispatcher.spawn().await.await });
+    let _dispatcher_handle = dispatcher.spawn();
 
     // Send payload
     entrypoint
@@ -669,7 +669,7 @@ async fn test_sealevel_versioned_tx_estimation_failure_results_in_dropped() {
     let (entrypoint, dispatcher) =
         lander::create_test_dispatcher(adapter, payload_db, tx_db, "sealevel".to_string()).await;
 
-    let _dispatcher_handle = tokio::spawn(async move { dispatcher.spawn().await.await });
+    let _dispatcher_handle = dispatcher.spawn();
 
     // Send payload
     entrypoint

--- a/rust/main/utils/run-locally/src/cosmos/mod.rs
+++ b/rust/main/utils/run-locally/src/cosmos/mod.rs
@@ -32,7 +32,7 @@ use crate::logging::log;
 use crate::metrics::agent_balance_sum;
 use crate::program::Program;
 use crate::utils::{
-    as_task, concat_path, get_workspace_path, stop_child, AgentHandles, TaskHandle,
+    as_task, concat_path, get_workspace_path, start_postgres, stop_child, AgentHandles, TaskHandle,
 };
 use crate::AGENT_BIN_PATH;
 use cli::{OsmosisCLI, OsmosisEndpoint};
@@ -498,14 +498,7 @@ fn run_locally() {
     .unwrap();
 
     log!("Running postgres db...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
 
     crate::utils::wait_for_postgres();
 

--- a/rust/main/utils/run-locally/src/cosmosnative/mod.rs
+++ b/rust/main/utils/run-locally/src/cosmosnative/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     fetch_metric, log,
     metrics::agent_balance_sum,
     program::Program,
-    utils::{as_task, concat_path, stop_child, AgentHandles, TaskHandle},
+    utils::{as_task, concat_path, start_postgres, stop_child, AgentHandles, TaskHandle},
     AGENT_BIN_PATH,
 };
 
@@ -290,14 +290,7 @@ fn run_locally() {
     .unwrap();
 
     log!("Running postgres db...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
 
     crate::utils::wait_for_postgres();
 

--- a/rust/main/utils/run-locally/src/main.rs
+++ b/rust/main/utils/run-locally/src/main.rs
@@ -43,7 +43,10 @@ use crate::{
     ethereum::{ethereum_termination_invariants::termination_invariants_met, start_anvil},
     invariants::post_startup_invariants,
     metrics::agent_balance_sum,
-    utils::{concat_path, make_static, stop_child, AgentHandles, ArbitraryData, TaskHandle},
+    utils::{
+        concat_path, make_static, start_postgres, stop_child, AgentHandles, ArbitraryData,
+        TaskHandle,
+    },
 };
 
 mod config;
@@ -280,14 +283,7 @@ fn main() -> ExitCode {
     let start_anvil = start_anvil(config.clone());
 
     log!("Running postgres db...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
     state.push_agent(postgres);
 
     build_main.join();

--- a/rust/main/utils/run-locally/src/radix/mod.rs
+++ b/rust/main/utils/run-locally/src/radix/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     log,
     metrics::agent_balance_sum,
     program::Program,
-    utils::{as_task, concat_path, stop_child, AgentHandles, TaskHandle},
+    utils::{as_task, concat_path, start_postgres, stop_child, AgentHandles, TaskHandle},
     wait_for_condition, AGENT_BIN_PATH, RELAYER_METRICS_PORT, SCRAPER_METRICS_PORT,
 };
 
@@ -382,14 +382,7 @@ pub async fn run_locally() {
 
     log!("Config path: {:#?}", agent_config_path);
     log!("Running postgres db...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
 
     crate::utils::wait_for_postgres();
 

--- a/rust/main/utils/run-locally/src/sealevel/mod.rs
+++ b/rust/main/utils/run-locally/src/sealevel/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     sealevel::{sealevel_termination_invariants::*, solana::*},
     utils::{
         concat_path, get_sealevel_path, get_ts_infra_path, get_workspace_path, make_static,
-        TaskHandle,
+        start_postgres, TaskHandle,
     },
     wait_for_condition, State, AGENT_LOGGING_DIR, RELAYER_METRICS_PORT, SCRAPER_METRICS_PORT,
 };
@@ -216,14 +216,7 @@ fn run_locally() {
         .run();
 
     log!("Running postgres db...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
     state.push_agent(postgres);
 
     build_main.join();

--- a/rust/main/utils/run-locally/src/starknet/mod.rs
+++ b/rust/main/utils/run-locally/src/starknet/mod.rs
@@ -14,7 +14,7 @@ use crate::metrics::agent_balance_sum;
 use crate::program::Program;
 use crate::starknet::types::{AgentConfigOut, ValidatorConfig};
 use crate::starknet::utils::{STARKNET_ACCOUNT, STARKNET_KEY};
-use crate::utils::{as_task, concat_path, stop_child, AgentHandles, TaskHandle};
+use crate::utils::{as_task, concat_path, start_postgres, stop_child, AgentHandles, TaskHandle};
 use crate::{fetch_metric, AGENT_BIN_PATH};
 
 use self::cli::StarknetCLI;
@@ -414,14 +414,7 @@ fn run_locally() {
     .unwrap();
 
     log!("Running postgres db...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
 
     crate::utils::wait_for_postgres();
 

--- a/rust/main/utils/run-locally/src/tron/mod.rs
+++ b/rust/main/utils/run-locally/src/tron/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     program::Program,
     server::{fetch_relayer_gas_payment_event_count, fetch_relayer_message_processed_count},
     utils::{
-        concat_path, get_workspace_path, make_static, stop_child, wait_for_postgres, AgentHandles,
-        TaskHandle,
+        concat_path, get_workspace_path, make_static, start_postgres, stop_child,
+        wait_for_postgres, AgentHandles, TaskHandle,
     },
     wait_for_condition, AGENT_BIN_PATH, AGENT_LOGGING_DIR, RELAYER_METRICS_PORT,
     SCRAPER_METRICS_PORT,
@@ -302,14 +302,7 @@ fn run_locally() {
 
     // Start postgres
     log!("Starting postgres...");
-    let postgres = Program::new("docker")
-        .cmd("run")
-        .flag("rm")
-        .arg("name", "scraper-testnet-postgres")
-        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
-        .arg("publish", "5432:5432")
-        .cmd("postgres:14")
-        .spawn("SQL", None);
+    let postgres = start_postgres();
 
     wait_for_postgres();
 

--- a/rust/main/utils/run-locally/src/utils.rs
+++ b/rust/main/utils/run-locally/src/utils.rs
@@ -193,6 +193,40 @@ pub fn get_ts_infra_path() -> PathBuf {
     concat_path(git_workspace_path, "typescript/infra")
 }
 
+const POSTGRES_IMAGE: &str = "postgres:14";
+
+/// Start the test Postgres container after ensuring its image is available.
+///
+/// `docker run` pulls a missing image in the foreground. If it is spawned and
+/// readiness polling starts immediately, a cold pull consumes the readiness
+/// timeout before the container exists. Pulling first keeps image acquisition
+/// separate from the bounded database startup check.
+pub fn start_postgres() -> AgentHandles {
+    let image_available = Program::new("docker")
+        .cmd("image")
+        .cmd("inspect")
+        .cmd(POSTGRES_IMAGE)
+        .run_to_success()
+        .join();
+    if !image_available {
+        log!("Pulling {}...", POSTGRES_IMAGE);
+        Program::new("docker")
+            .cmd("pull")
+            .cmd(POSTGRES_IMAGE)
+            .run()
+            .join();
+    }
+
+    Program::new("docker")
+        .cmd("run")
+        .flag("rm")
+        .arg("name", "scraper-testnet-postgres")
+        .arg("env", "POSTGRES_PASSWORD=47221c18c610")
+        .arg("publish", "5432:5432")
+        .cmd(POSTGRES_IMAGE)
+        .spawn("SQL", None)
+}
+
 /// Poll postgres container until pg_isready succeeds.
 #[allow(dead_code)]
 pub fn wait_for_postgres() {


### PR DESCRIPTION
## Problem

Lander restart recovery walks the complete payload history for every destination, then keeps a forward/backward database iterator alive on a 10ms timer. New payloads are discovered indirectly through that scan. The building stage independently polls its queue every 5ms.

In one live mainnet sample, the backward cursor moved from payload index 69,853 to 67,179 in 31 seconds: 2,674 already-processed payloads, about 86 records/second. `retrieve_payload_by_index` reads the UUID mapping and then the payload, so that sample represents about 5,348 RocksDB key reads before finding no useful work. At the observed rate, one full 69,853-record recovery pass is roughly 13.5 minutes.

With 68 destinations near idle, the configured timers can schedule up to 6,800 payload-loader checks/second (10ms) plus 13,600 empty building-queue checks/second (5ms): 20,400 checks/second, or 1.76 billion/day. These are timer opportunities, not measured CPU utilization.

The first revision also awaited recovery inside each sequential relayer destination setup. If all 68 destinations required the sampled 13.5-minute backfill, the equal-work upper bound was 918 minutes / 15.3 hours before the last destination started. This is a model; shared RocksDB contention will change the actual bound.

## Solution

- maintain a RocksDB pending-payload index containing only `ReadyToSubmit` and `Retry` payloads, keyed by historical payload index
- update canonical payload state, historical indexes, pending membership and a schema write marker in one atomic batch
- store a RocksDB sequence checkpoint and prove WAL sequence continuity from that checkpoint through a captured latest sequence; any first, intermediate or trailing gap fails closed to a full rebuild
- retain archived WAL for seven days with a 1 GiB size cap, making ordinary rollback detection cheap without allowing retained WAL to grow without bound
- on full reconciliation, atomically range-delete the derived prefix and checkpoint, scan history newest-first in 1,000-index chunks, batch one commit per chunk, and avoid writes for absent or terminal payloads
- keep inclusion/finality stages and transaction recovery live during the rebuild, while gating the destination MessageProcessor receiver and building consumer; its one-slot bounded batch ingress propagates backpressure to MessageDbLoader and relay API producers
- group relay API operations by destination, reserve every destination slot before handing off anything, then commit deduplication and synchronously send every batch so request cancellation cannot leave a partially enqueued transaction
- share the building queue through `DispatcherState`, enqueue immediately after durable entrypoint storage and deduplicate payload UUIDs
- replace the 5ms building-stage poll with a `Notify` wakeup and remove the perpetual 10ms payload-loader loop
- log examined/pending counts and elapsed recovery time for canary comparison

Stacked on #9425 because the entrypoint and dispatcher must share the same queue.

## Number choices

- **7-day WAL TTL:** covers the normal weekly deployment/canary/rollback window, so a rollback followed by roll-forward normally uses the cheap WAL proof instead of an `O(N)` rebuild. Correctness does not depend on seven days: expiration or pruning creates a sequence gap and forces reconciliation.
- **1,024 MiB WAL cap:** a power-of-two, intentionally conservative initial ceiling that bounds the extra disk retained by this optimization to 1 GiB per RocksDB database. It is not a workload-derived correctness threshold; if write volume reaches the cap before seven days, continuity detection deliberately trades startup time for a safe full rebuild. Canary WAL size and rebuild frequency before tuning it.
- **1,000 historical indexes per reconciliation chunk:** bounds one synchronous chunk to at most 2,000 point reads (index-to-UUID plus UUID-to-payload) and at most 1,000 derived writes, while amortizing one RocksDB commit over the chunk and yielding between chunks. This is a round initial operational bound, not a benchmark-tuned optimum; chunk latency is included in canary observation.
- **1-slot MessageProcessor batch ingress:** the minimum non-zero Tokio channel capacity decouples producer/receiver scheduling without creating a second unbounded backlog beside the priority heap. During recovery, at most one batch is queued per destination and subsequent producers await capacity. MessageDbLoader batches contain exactly one operation; relay API batches contain at most 10 operations because the existing transaction extraction limit rejects larger transactions. Thus the bounded ingress holds at most 10 queued operations per destination, with one chosen only for the DB path and 10 chosen by the existing API abuse/work limit, not new throughput tuning.
- **10ms/5ms deleted polls:** these are the existing loader/building intervals, not new tuning choices. `Notify` preserves event-driven wakeup without choosing replacement polling periods.
- **68 destinations / 69,853 records / 86 records per second:** these are from the named live sample above. All startup and reduction figures derived from them remain modeled until canaried.

## Expected impact

**Observed baseline:** 2,674 historical records in 31 seconds, about 86 records/second and 5,348 logical key reads in the sampled window. The full sampled history contains 69,853 records.

**Validated-checkpoint restart:** selection changes from `O(N)` historical records and two key reads per record to `O(P)` pending values, where `P` is the actual pending set. The record reduction is `(1 - P/N) * 100%`; with `N=69,853`, any restart with `P<=69` is more than 99.9% smaller. This remains modeled until canaried.

**Migration/rollback restart:** first migration, an older-binary write, or unavailable/incomplete WAL deliberately remains `O(N)` so derived state cannot silently go stale. Range deletion and batched sparse writes remove the previous per-index rewrite behavior.

**Destination startup:** recoveries run concurrently. Against the flawed equal-work serial model, the 68-destination critical path changes from up to 918 minutes to about 13.5 minutes: up to 68x / 98.5% less startup wall time. This is modeled and excludes shared-database contention.

**Exact timer removal:** the steady-state 10ms payload-loader timer and 5ms empty-building timer are deleted. For 68 idle destinations, that removes the configured ceiling of 20,400 timer-driven checks/second / 1.76 billion per day. It does not claim an equivalent CPU reduction.

**Arrival latency:** after recovery, direct enqueue removes the payload-loader polling component (0-10ms, 5ms mean) and notification removes the empty building poll component (0-5ms, 2.5ms mean). RPC, storage, runtime contention and submission time are excluded.

## Correctness

- canonical payload writes and pending membership commit atomically under the per-database write lock
- status transitions to `Dropped` or `InTransaction` atomically delete pending membership
- WAL validation rejects missing history even when RocksDB returns a clean empty iterator; regression coverage reproduces the flush/reopen case
- the rebuild starts by deleting the derived prefix and checkpoint atomically, so a crash at any later chunk restarts a full rebuild rather than blessing partial state
- sparse/terminal history produces no per-index delete writes; only pending payloads are rewritten
- transaction recovery and inclusion/finality processing continue during payload reconciliation
- the MessageProcessor receiver waits before draining; its one-slot channel accepts at most one batch per destination during recovery, bounded to one DB-loaded operation or at most 10 relay API operations, subsequent producers await capacity, and the priority heap remains empty
- relay API transactions reserve all destination slots before any handoff; cancellation releases the permits and tx-hash reservation, while the final dedup commit and batch sends contain no async cancellation point
- the building consumer starts only after reconciliation, preventing recovered payloads from racing transaction recovery into duplicate transactions
- pending rows and full rebuild chunks are loaded highest index first, matching the previous reverse historical iterator
- `Notify` stores a permit when the consumer is between its empty check and wait, avoiding a lost wake
- database and recovery errors remain fail-closed

## CI reliability follow-up

The CosmWasm E2E run at `be865b0638` exposed a cold-run race in the shared harness: `docker run postgres:14` was spawned while Docker was still downloading the missing image, so the 30-attempt readiness loop expired before the container existed. The fix checks for the image and completes any required pull before spawning Postgres across all seven Rust E2E variants. This keeps the existing 30-second readiness window scoped to database startup, avoids inflating a timeout to hide image acquisition, skips the pull when the image is already cached, and surfaces pull failures directly.

## Verification

- `cargo test -p hyperlane-base db::rocks::tests --lib` (2 passed: incomplete-WAL regression and contiguous control)
- `cargo test -p lander dispatcher:: --lib` (69 passed)
- `cargo check -p relayer`
- `cargo clippy -p hyperlane-base -p lander --lib --no-deps -- -D warnings`
- `cargo test -p relayer test_recovery_backpressures_message_processor_ingress --lib` (1 passed)
- `cargo test -p relayer relay_api::tests --lib` (14 passed, including capacity-1 batching and cancellation/retry regressions)
- `cargo test -p relayer msg::db_loader::tests --lib` (6 passed)
- `cargo clippy -p relayer -p lander --lib --no-deps -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- repository pre-commit hooks: gitleaks, lint-staged and both Rust format checks
- `cargo check -p run-locally --all-features`
- `cargo clippy -p run-locally --no-deps -- -D warnings`
- exact head: `febf7cc8fb7d6db7bcf7578fbe709e189587743c`

## Canary

Compare restart logs and RocksDB state by destination:

- migration/rollback: reconciliation examined count, pending count, chunk latency and total elapsed milliseconds
- validated restart: pending count and elapsed milliseconds
- all destination recovery tasks begin without serial destination blocking
- WAL archive bytes stay below the 1 GiB cap; track how often continuity gaps trigger a full rebuild within the seven-day window
- each destination's ingress holds at most one operation while its recovery runs; subsequent producers are backpressured, while recovered inclusion/finality work progresses
- absence of the old per-record payload-loader debug stream and 5ms/10ms steady polling
- building queue length, transaction count, duplicate/resubmission count, delivery latency, RocksDB errors, RSS and CPU as non-regression guards

Keep recovery-read and startup reductions modeled until observed on a restart.

Master performance epic: #9386.


## Post-merge follow-up

#9451 removes the cross-destination permit-order deadlock and scopes archived rollback WAL to relayer/Lander databases.
