### PR TITLE
perf(lander): collapse Sealevel status reads

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -219,6 +219,17 @@ impl SealevelRpcClient {
             .map_err(ChainCommunicationError::from_other)
     }
 
+    /// Get signature statuses, including rooted transaction history.
+    pub async fn get_signature_statuses_with_history(
+        &self,
+        signatures: &[Signature],
+    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+        self.0
+            .get_signature_statuses_with_history(signatures)
+            .await
+            .map_err(ChainCommunicationError::from_other)
+    }
+
     /// get slot
     pub async fn get_slot(&self) -> ChainResult<u32> {
         let slot = self

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use derive_new::new;
 use solana_client::rpc_config::RpcProgramAccountsConfig;
 use solana_client::rpc_response::{
-    Response, RpcConfirmedTransactionStatusWithSignature, RpcSimulateTransactionResult,
+    Response, RpcConfirmedTransactionStatusWithSignature, RpcResponseContext,
+    RpcSimulateTransactionResult,
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
@@ -13,16 +14,104 @@ use solana_sdk::signature::Signature;
 use solana_sdk::transaction::{Transaction, VersionedTransaction};
 use solana_sdk::{account::Account, clock::Slot};
 use solana_transaction_status::{
-    EncodedConfirmedTransactionWithStatusMeta, TransactionStatus, UiConfirmedBlock,
+    EncodedConfirmedTransactionWithStatusMeta, TransactionConfirmationStatus, TransactionStatus,
+    UiConfirmedBlock,
 };
 use url::Url;
 
-use hyperlane_core::{rpc_clients::FallbackProvider, ChainResult, U256};
+use hyperlane_core::{
+    rpc_clients::{FallbackProvider, RpcClientError},
+    ChainCommunicationError, ChainResult, U256,
+};
 use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
 
 use crate::client::SealevelRpcClient;
 use crate::client_builder::SealevelRpcClientBuilder;
 use crate::tx_type::SealevelTxType;
+
+fn validate_signature_status_response(
+    response: Response<Vec<Option<TransactionStatus>>>,
+    expected_len: usize,
+) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+    if response.value.len() != expected_len {
+        return Err(ChainCommunicationError::from_other_str(&format!(
+            "getSignatureStatuses returned {} statuses for {expected_len} signatures",
+            response.value.len()
+        )));
+    }
+    Ok(response)
+}
+
+fn signature_status_rank(status: &TransactionStatus) -> u8 {
+    match status.confirmation_status() {
+        TransactionConfirmationStatus::Processed => 0,
+        TransactionConfirmationStatus::Confirmed => 1,
+        TransactionConfirmationStatus::Finalized => 2,
+    }
+}
+
+fn all_signature_statuses_finalized(
+    signature_count: usize,
+    responses: &[ChainResult<Response<Vec<Option<TransactionStatus>>>>],
+) -> bool {
+    (0..signature_count).all(|index| {
+        responses.iter().any(|response| {
+            response.as_ref().is_ok_and(|response| {
+                response.value[index].as_ref().is_some_and(|status| {
+                    status.confirmation_status() == TransactionConfirmationStatus::Finalized
+                })
+            })
+        })
+    })
+}
+
+fn merge_signature_status_responses(
+    signature_count: usize,
+    responses: Vec<ChainResult<Response<Vec<Option<TransactionStatus>>>>>,
+) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+    let mut context = None;
+    let mut statuses = vec![None; signature_count];
+    let mut errors = Vec::new();
+
+    for response in responses {
+        match response {
+            Ok(response) => {
+                if context
+                    .as_ref()
+                    .is_none_or(|current: &RpcResponseContext| response.context.slot > current.slot)
+                {
+                    context = Some(response.context);
+                }
+                for (current, candidate) in statuses.iter_mut().zip(response.value) {
+                    let should_replace = candidate.as_ref().is_some_and(|candidate| {
+                        current.as_ref().is_none_or(|current| {
+                            let candidate_rank = signature_status_rank(candidate);
+                            let current_rank = signature_status_rank(current);
+                            candidate_rank > current_rank
+                                || (candidate_rank == current_rank && candidate.slot > current.slot)
+                        })
+                    });
+                    if should_replace {
+                        *current = candidate;
+                    }
+                }
+            }
+            Err(error) => errors.push(error),
+        }
+    }
+
+    let Some(context) = context else {
+        return Err(RpcClientError::FallbackProvidersFailed(errors).into());
+    };
+    if !errors.is_empty() && statuses.iter().any(Option::is_none) {
+        return Err(RpcClientError::FallbackProvidersFailed(errors).into());
+    }
+
+    Ok(Response {
+        context,
+        value: statuses,
+    })
+}
 
 /// Defines methods required to submit transactions to Sealevel chains
 #[async_trait]
@@ -55,6 +144,12 @@ pub trait SubmitSealevelRpc: Send + Sync {
         signature: Signature,
         commitment: CommitmentConfig,
     ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
+
+    /// Requests transaction statuses from recent and rooted history.
+    async fn get_signature_statuses_with_history(
+        &self,
+        signatures: &[Signature],
+    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>>;
 
     /// Simulates Sealevel legacy transaction
     async fn simulate_transaction(
@@ -109,6 +204,13 @@ impl SubmitSealevelRpc for SealevelFallbackRpcClient {
                 Box::pin(future)
             })
             .await
+    }
+
+    async fn get_signature_statuses_with_history(
+        &self,
+        signatures: &[Signature],
+    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+        SealevelFallbackRpcClient::get_signature_statuses_with_history(self, signatures).await
     }
 
     /// simulate a legacy transaction
@@ -433,6 +535,31 @@ impl SealevelFallbackRpcClient {
             })
             .await
     }
+
+    /// Get signature statuses, including rooted transaction history.
+    pub async fn get_signature_statuses_with_history(
+        &self,
+        signatures: &[Signature],
+    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+        let signature_count = signatures.len();
+        let responses = self
+            .fallback_provider
+            .call_until(
+                move |client| {
+                    let signatures = signatures.to_vec();
+                    let future = async move {
+                        let response = client
+                            .get_signature_statuses_with_history(&signatures)
+                            .await?;
+                        validate_signature_status_response(response, signatures.len())
+                    };
+                    Box::pin(future)
+                },
+                |responses| all_signature_statuses_finalized(signature_count, responses),
+            )
+            .await;
+        merge_signature_status_responses(signature_count, responses)
+    }
 }
 
 impl Debug for SealevelFallbackRpcClient {
@@ -442,5 +569,108 @@ impl Debug for SealevelFallbackRpcClient {
             "SealevelFallbackProvider {{ count: {} }}",
             self.fallback_provider.len()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn status(confirmation_status: TransactionConfirmationStatus) -> TransactionStatus {
+        TransactionStatus {
+            slot: 42,
+            confirmations: None,
+            status: Ok(()),
+            err: None,
+            confirmation_status: Some(confirmation_status),
+        }
+    }
+
+    fn response(
+        slot: u64,
+        value: Vec<Option<TransactionStatus>>,
+    ) -> Response<Vec<Option<TransactionStatus>>> {
+        Response {
+            context: RpcResponseContext::new(slot),
+            value,
+        }
+    }
+
+    #[test]
+    fn signature_status_merge_uses_strongest_provider_result_per_index() {
+        let merged = merge_signature_status_responses(
+            2,
+            vec![
+                Ok(response(
+                    10,
+                    vec![None, Some(status(TransactionConfirmationStatus::Confirmed))],
+                )),
+                Ok(response(
+                    11,
+                    vec![
+                        Some(status(TransactionConfirmationStatus::Finalized)),
+                        Some(status(TransactionConfirmationStatus::Finalized)),
+                    ],
+                )),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(merged.context.slot, 11);
+        assert!(merged.value.into_iter().all(|status| {
+            status.unwrap().confirmation_status() == TransactionConfirmationStatus::Finalized
+        }));
+    }
+
+    #[test]
+    fn finalized_completion_requires_every_signature() {
+        let responses = vec![Ok(response(
+            10,
+            vec![
+                Some(status(TransactionConfirmationStatus::Finalized)),
+                Some(status(TransactionConfirmationStatus::Confirmed)),
+            ],
+        ))];
+        assert!(!all_signature_statuses_finalized(2, &responses));
+
+        let responses = vec![Ok(response(
+            10,
+            vec![
+                Some(status(TransactionConfirmationStatus::Finalized)),
+                Some(status(TransactionConfirmationStatus::Finalized)),
+            ],
+        ))];
+        assert!(all_signature_statuses_finalized(2, &responses));
+    }
+
+    #[test]
+    fn signature_status_merge_reports_ambiguous_absence() {
+        let merged = merge_signature_status_responses(
+            1,
+            vec![
+                Ok(response(10, vec![None])),
+                Err(ChainCommunicationError::from_other_str("RPC unavailable")),
+            ],
+        );
+
+        assert!(merged.is_err());
+    }
+
+    #[test]
+    fn signature_status_merge_reports_absence_after_all_providers_agree() {
+        let merged = merge_signature_status_responses(
+            1,
+            vec![Ok(response(10, vec![None])), Ok(response(11, vec![None]))],
+        )
+        .unwrap();
+
+        assert_eq!(merged.value, vec![None]);
+    }
+
+    #[test]
+    fn signature_status_response_rejects_wrong_cardinality() {
+        let result = validate_signature_status_response(response(10, vec![None]), 2);
+
+        assert!(result.is_err());
     }
 }

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -136,6 +136,34 @@ where
     T: Into<B> + Debug + Clone,
     B: BlockNumberGetter,
 {
+    async fn call_provider<V>(
+        &self,
+        priority: &PrioritizedProviderInner,
+        future: Pin<Box<dyn Future<Output = ChainResult<V>> + Send>>,
+    ) -> ChainResult<V> {
+        let provider = &self.inner.providers[priority.index];
+        let response = match tokio::time::timeout(self.call_timeout, async {
+            let response = future.await;
+            if response.is_ok() {
+                // A probe timeout is treated the same as a request timeout,
+                // not silently ignored.
+                self.handle_stalled_provider(priority, provider).await?;
+            }
+            response
+        })
+        .await
+        {
+            Ok(response) => response,
+            Err(_) => Err(crate::ChainCommunicationError::from_other_str(
+                "fallback provider call timed out",
+            )),
+        };
+        if response.is_err() {
+            self.handle_failed_provider(priority).await;
+        }
+        response
+    }
+
     /// Convenience method for creating a `FallbackProviderBuilder` with same
     /// `JsonRpcClient` types
     pub fn builder() -> FallbackProviderBuilder<T, B> {
@@ -285,25 +313,7 @@ where
             let priorities_snapshot = self.take_priorities_snapshot().await;
             for (idx, priority) in priorities_snapshot.iter().enumerate() {
                 let provider = &self.inner.providers[priority.index];
-                let resp = match tokio::time::timeout(self.call_timeout, async {
-                    let resp = f(provider.clone()).await;
-                    if resp.is_ok() {
-                        // A probe timeout is treated the same as a request timeout,
-                        // not silently ignored.
-                        self.handle_stalled_provider(priority, provider).await?;
-                    }
-                    resp
-                })
-                .await
-                {
-                    Ok(resp) => resp,
-                    Err(_) => Err(crate::ChainCommunicationError::from_other_str(
-                        "fallback provider call timed out",
-                    )),
-                };
-                if resp.is_err() {
-                    self.handle_failed_provider(priority).await;
-                }
+                let resp = self.call_provider(priority, f(provider.clone())).await;
                 let _span =
                     warn_span!("FallbackProvider::call", fallback_count=%idx, provider_index=%priority.index, ?provider).entered();
                 match resp {
@@ -320,6 +330,39 @@ where
         }
 
         Err(RpcClientError::FallbackProvidersFailed(errors).into())
+    }
+
+    /// Call providers once in priority order until the accumulated responses
+    /// satisfy `is_complete` or every provider has been queried.
+    ///
+    /// This supports RPCs whose successful responses must be combined rather
+    /// than accepting the first response as authoritative.
+    pub async fn call_until<V>(
+        &self,
+        mut f: impl FnMut(T) -> Pin<Box<dyn Future<Output = ChainResult<V>> + Send>>,
+        is_complete: impl Fn(&[ChainResult<V>]) -> bool,
+    ) -> Vec<ChainResult<V>> {
+        let priorities_snapshot = self.take_priorities_snapshot().await;
+        let mut responses = Vec::with_capacity(priorities_snapshot.len());
+        for (idx, priority) in priorities_snapshot.iter().enumerate() {
+            let provider = &self.inner.providers[priority.index];
+            let response = self.call_provider(priority, f(provider.clone())).await;
+            let _span = warn_span!(
+                "FallbackProvider::call_until",
+                fallback_count = %idx,
+                provider_index = %priority.index,
+                ?provider,
+            )
+            .entered();
+            if let Err(error) = &response {
+                warn!(?error, "Got error from inner fallback provider");
+            }
+            responses.push(response);
+            if is_complete(&responses) {
+                break;
+            }
+        }
+        responses
     }
 
     /// Call each provider once until one returns `Some`.
@@ -339,23 +382,7 @@ where
 
         for (idx, priority) in priorities_snapshot.iter().enumerate() {
             let provider = &self.inner.providers[priority.index];
-            let resp = match tokio::time::timeout(self.call_timeout, async {
-                let resp = f(provider.clone()).await;
-                if resp.is_ok() {
-                    self.handle_stalled_provider(priority, provider).await?;
-                }
-                resp
-            })
-            .await
-            {
-                Ok(resp) => resp,
-                Err(_) => Err(crate::ChainCommunicationError::from_other_str(
-                    "fallback provider call timed out",
-                )),
-            };
-            if resp.is_err() {
-                self.handle_failed_provider(priority).await;
-            }
+            let resp = self.call_provider(priority, f(provider.clone())).await;
             let _span = warn_span!("FallbackProvider::call_optional", fallback_count=%idx, provider_index=%priority.index, ?provider).entered();
             match resp {
                 Ok(Some(value)) => return Ok(Some(value)),
@@ -660,6 +687,59 @@ pub mod test {
         assert_eq!(result, Some(42));
         assert_eq!(provider1.requests().len(), 2);
         assert_eq!(provider2.requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_call_until_queries_every_provider_while_incomplete() {
+        let provider1 = ProviderMock::default();
+        provider1.push("first", true);
+        let provider2 = ProviderMock::default();
+        provider2.push("second", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([provider1.clone(), provider2.clone()]);
+
+        let responses = fallback_provider
+            .call_until(
+                |provider| {
+                    let response = provider.requests()[0].0.clone();
+                    provider.push("call", true);
+                    Box::pin(async move { Ok(response) })
+                },
+                |_| false,
+            )
+            .await;
+
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0].as_ref().unwrap(), "first");
+        assert_eq!(responses[1].as_ref().unwrap(), "second");
+        assert_eq!(provider1.requests().len(), 2);
+        assert_eq!(provider2.requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_call_until_stops_when_complete() {
+        let provider1 = ProviderMock::default();
+        provider1.push("first", true);
+        let provider2 = ProviderMock::default();
+        provider2.push("second", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([provider1.clone(), provider2.clone()]);
+
+        let responses = fallback_provider
+            .call_until(
+                |provider| {
+                    let response = provider.requests()[0].0.clone();
+                    provider.push("call", true);
+                    Box::pin(async move { Ok(response) })
+                },
+                |responses| responses.len() == 1,
+            )
+            .await;
+
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].as_ref().unwrap(), "first");
+        assert_eq!(provider1.requests().len(), 2);
+        assert_eq!(provider2.requests().len(), 1);
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
@@ -6,13 +6,15 @@ use eyre::eyre;
 use futures_util::future::join_all;
 use serde_json::json;
 use solana_client::rpc_response::{Response, RpcSimulateTransactionResult};
-use solana_commitment_config::CommitmentConfig;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::{
     instruction::AccountMeta,
     message::Message,
     pubkey::Pubkey,
     signature::{Signature, Signer},
+};
+use solana_transaction_status::{
+    TransactionConfirmationStatus, TransactionStatus as SealevelTransactionStatus,
 };
 
 use hyperlane_sealevel::SealevelTxType;
@@ -292,42 +294,32 @@ impl SealevelAdapter {
         let signature = Signature::try_from(tx_hash.as_ref())
             .map_err(|e| LanderError::TxSubmissionError(format!("Invalid signature: {e}")))?;
 
-        // query the tx hash from most to least finalized to learn what level of finality it has
-        // the calls below can be parallelized if needed, but for now avoid rate limiting
-
-        let tx_resp = self
+        let response = self
             .client
-            .get_transaction_with_commitment(signature, CommitmentConfig::finalized())
-            .await;
+            .get_signature_statuses_with_history(&[signature])
+            .await?;
+        let Some(status) = response.value.into_iter().next().flatten() else {
+            return Err(LanderError::TxHashNotFound(format!(
+                "Transaction signature {signature} was not found"
+            )));
+        };
 
-        if tx_resp.is_ok() {
-            info!("transaction finalized");
-            return Ok(TransactionStatus::Finalized);
-        }
+        Ok(Self::classify_signature_status(status))
+    }
 
-        let tx_resp = self
-            .client
-            .get_transaction_with_commitment(signature, CommitmentConfig::confirmed())
-            .await;
-
-        // the "confirmed" commitment is equivalent to being "included" in a block on evm
-        if tx_resp.is_ok() {
-            info!(?tx_hash, "transaction included");
-            return Ok(TransactionStatus::Included);
-        }
-
-        match self
-            .client
-            .get_transaction_with_commitment(signature, CommitmentConfig::processed())
-            .await
-        {
-            Ok(_) => {
-                info!("transaction is in mempool");
-                Ok(TransactionStatus::Mempool)
+    fn classify_signature_status(status: SealevelTransactionStatus) -> TransactionStatus {
+        match status.confirmation_status() {
+            TransactionConfirmationStatus::Finalized => {
+                info!("transaction finalized");
+                TransactionStatus::Finalized
             }
-            Err(err) => {
-                warn!(?err, "Failed to get transaction status by hash");
-                Err(LanderError::TxHashNotFound(err.to_string()))
+            TransactionConfirmationStatus::Confirmed => {
+                info!("transaction included");
+                TransactionStatus::Included
+            }
+            TransactionConfirmationStatus::Processed => {
+                info!("transaction is in mempool");
+                TransactionStatus::Mempool
             }
         }
     }

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use mockall::mock;
-use solana_client::rpc_response::RpcSimulateTransactionResult;
+use solana_client::rpc_response::{Response, RpcResponseContext, RpcSimulateTransactionResult};
 use solana_commitment_config::CommitmentConfig;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::account::Account;
@@ -18,8 +18,8 @@ use solana_sdk::{
 };
 use solana_transaction_status::{
     option_serializer::OptionSerializer, EncodedConfirmedTransactionWithStatusMeta,
-    EncodedTransaction, EncodedTransactionWithStatusMeta, UiConfirmedBlock,
-    UiTransactionStatusMeta,
+    EncodedTransaction, EncodedTransactionWithStatusMeta,
+    TransactionStatus as SealevelTransactionStatus, UiConfirmedBlock, UiTransactionStatusMeta,
 };
 
 use hyperlane_base::settings::{ChainConf, RawChainConf};
@@ -59,6 +59,11 @@ mock! {
             signature: Signature,
             commitment: CommitmentConfig,
         ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
+
+        async fn get_signature_statuses_with_history(
+            &self,
+            signatures: &[Signature],
+        ) -> ChainResult<Response<Vec<Option<SealevelTransactionStatus>>>>;
 
         async fn simulate_transaction(
             &self,
@@ -184,6 +189,15 @@ pub fn adapter_with_mock_svm_provider(provider: MockSvmProvider) -> SealevelAdap
     )
 }
 
+pub fn adapter_with_mock_client(client: MockClient) -> SealevelAdapter {
+    SealevelAdapter::new_internal_default(
+        Arc::new(client),
+        Arc::new(create_default_mock_svm_provider()),
+        Arc::new(MockOracle::new()),
+        Arc::new(mock_submitter()),
+    )
+}
+
 fn create_default_mock_svm_provider() -> MockSvmProvider {
     let mut provider = MockSvmProvider::new();
 
@@ -261,8 +275,12 @@ fn mock_client() -> MockClient {
         .expect_get_block_with_commitment()
         .returning(move |_, _| Ok(svm_block()));
     client
-        .expect_get_transaction_with_commitment()
-        .returning(move |_, _| Ok(encoded_svm_transaction()));
+        .expect_get_signature_statuses_with_history()
+        .returning(move |_| {
+            Ok(signature_status_response(
+                Some(finalized_signature_status()),
+            ))
+        });
     let result_clone = result.clone();
     client
         .expect_simulate_transaction()
@@ -271,6 +289,38 @@ fn mock_client() -> MockClient {
         .expect_simulate_versioned_transaction()
         .returning(move |_| Ok(result.clone()));
     client
+}
+
+pub fn signature_status_response(
+    status: Option<SealevelTransactionStatus>,
+) -> Response<Vec<Option<SealevelTransactionStatus>>> {
+    Response {
+        context: RpcResponseContext {
+            slot: 43,
+            api_version: None,
+        },
+        value: vec![status],
+    }
+}
+
+pub fn finalized_signature_status() -> SealevelTransactionStatus {
+    signature_status(solana_transaction_status::TransactionConfirmationStatus::Finalized)
+}
+
+pub fn processed_signature_status() -> SealevelTransactionStatus {
+    signature_status(solana_transaction_status::TransactionConfirmationStatus::Processed)
+}
+
+fn signature_status(
+    confirmation_status: solana_transaction_status::TransactionConfirmationStatus,
+) -> SealevelTransactionStatus {
+    SealevelTransactionStatus {
+        slot: 43,
+        confirmations: None,
+        status: Ok(()),
+        err: None,
+        confirmation_status: Some(confirmation_status),
+    }
 }
 
 pub fn svm_block() -> UiConfirmedBlock {

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_status.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_status.rs
@@ -1,7 +1,14 @@
 use crate::adapter::AdaptsChain;
+use crate::error::LanderError;
 use crate::transaction::TransactionStatus;
+use hyperlane_core::{ChainCommunicationError, H512};
+use solana_transaction_status::{
+    TransactionConfirmationStatus, TransactionStatus as SealevelTransactionStatus,
+};
 
-use super::tests_common::{adapter, transaction};
+use super::tests_common::{
+    adapter, adapter_with_mock_client, signature_status_response, transaction, MockClient,
+};
 
 #[tokio::test]
 async fn test_tx_status() {
@@ -16,4 +23,88 @@ async fn test_tx_status() {
     assert!(result.is_ok());
     let status = result.unwrap();
     assert!(matches!(status, TransactionStatus::Finalized));
+}
+
+#[tokio::test]
+async fn signature_status_uses_one_rpc_call() {
+    let mut client = MockClient::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .times(1)
+        .returning(|_| Ok(signature_status_response(None)));
+    let adapter = adapter_with_mock_client(client);
+
+    let status = adapter.get_tx_hash_status(H512::zero()).await;
+
+    assert!(matches!(status, Err(LanderError::TxHashNotFound(_))));
+}
+
+#[tokio::test]
+async fn signature_status_provider_error_is_infrastructure_error() {
+    let mut client = MockClient::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .times(1)
+        .returning(|_| Err(ChainCommunicationError::from_other_str("RPC unavailable")));
+    let adapter = adapter_with_mock_client(client);
+
+    let status = adapter.get_tx_hash_status(H512::zero()).await;
+
+    assert!(matches!(
+        status,
+        Err(LanderError::ChainCommunicationError(_))
+    ));
+}
+
+#[test]
+fn legacy_confirmation_count_maps_to_lander_status() {
+    for (confirmations, expected) in [
+        (Some(0), TransactionStatus::Mempool),
+        (Some(1), TransactionStatus::Included),
+        (None, TransactionStatus::Finalized),
+    ] {
+        let status = SealevelTransactionStatus {
+            slot: 43,
+            confirmations,
+            status: Ok(()),
+            err: None,
+            confirmation_status: None,
+        };
+
+        assert_eq!(
+            super::super::SealevelAdapter::classify_signature_status(status),
+            expected
+        );
+    }
+}
+
+#[test]
+fn signature_confirmation_status_maps_to_lander_status() {
+    for (confirmation_status, expected) in [
+        (
+            TransactionConfirmationStatus::Processed,
+            TransactionStatus::Mempool,
+        ),
+        (
+            TransactionConfirmationStatus::Confirmed,
+            TransactionStatus::Included,
+        ),
+        (
+            TransactionConfirmationStatus::Finalized,
+            TransactionStatus::Finalized,
+        ),
+    ] {
+        let status = SealevelTransactionStatus {
+            slot: 43,
+            confirmations: None,
+            status: Ok(()),
+            err: None,
+            confirmation_status: Some(confirmation_status),
+        };
+
+        assert_eq!(
+            super::super::SealevelAdapter::classify_signature_status(status),
+            expected
+        );
+    }
 }

--- a/rust/main/lander/src/dispatcher/metrics.rs
+++ b/rust/main/lander/src/dispatcher/metrics.rs
@@ -1,7 +1,7 @@
 // TODO: Re-enable clippy warnings
 #![allow(dead_code)]
 
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 
 use hyperlane_core::U256;
 use prometheus::{
@@ -29,6 +29,11 @@ pub struct DispatcherMetrics {
     pub building_stage_queue_length: IntGaugeVec,
     pub inclusion_stage_pool_length: IntGaugeVec,
     pub finality_stage_pool_length: IntGaugeVec,
+
+    /// Time to read statuses and apply a stage's ordered mutations.
+    pub status_scan_duration_milliseconds: IntGaugeVec,
+    /// Age since the least recently checked transaction's last status read.
+    pub oldest_unchecked_transaction_age_seconds: IntGaugeVec,
 
     // tracks inclusion stage errors
     pub inclusion_stage_error: IntCounterVec,
@@ -95,6 +100,22 @@ impl DispatcherMetrics {
                 "The number of transactions in the finality stage pool",
             ),
             &["destination",],
+            registry.clone()
+        )?;
+        let status_scan_duration_milliseconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced("status_scan_duration_milliseconds"),
+                "Duration of the latest transaction status scan",
+            ),
+            &["destination", "stage"],
+            registry.clone()
+        )?;
+        let oldest_unchecked_transaction_age_seconds = register_int_gauge_vec_with_registry!(
+            opts!(
+                namespaced("oldest_unchecked_transaction_age_seconds"),
+                "Age since the oldest transaction status check at scan start",
+            ),
+            &["destination", "stage"],
             registry.clone()
         )?;
 
@@ -214,6 +235,8 @@ impl DispatcherMetrics {
             building_stage_queue_length,
             inclusion_stage_pool_length,
             finality_stage_pool_length,
+            status_scan_duration_milliseconds,
+            oldest_unchecked_transaction_age_seconds,
             batched_transactions,
             dropped_payloads,
             dropped_transactions,
@@ -256,6 +279,28 @@ impl DispatcherMetrics {
                 .set(length as i64),
             _ => {}
         }
+    }
+
+    pub fn update_status_scan_duration_metric(
+        &self,
+        stage: &str,
+        duration: Duration,
+        domain: &str,
+    ) {
+        self.status_scan_duration_milliseconds
+            .with_label_values(&[domain, stage])
+            .set(i64::try_from(duration.as_millis()).unwrap_or(i64::MAX));
+    }
+
+    pub fn update_oldest_unchecked_transaction_age_metric(
+        &self,
+        stage: &str,
+        oldest_unchecked_age: Duration,
+        domain: &str,
+    ) {
+        self.oldest_unchecked_transaction_age_seconds
+            .with_label_values(&[domain, stage])
+            .set(i64::try_from(oldest_unchecked_age.as_secs()).unwrap_or(i64::MAX));
     }
 
     pub fn update_dropped_payloads_metric(&self, reason: &str, domain: &str) {
@@ -380,4 +425,34 @@ pub struct PostInclusionMetricsSource {
     pub priority_fee: Option<u64>,
     // gas limit set for the transaction, if applicable
     pub gas_limit: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::DispatcherMetrics;
+
+    #[test]
+    fn status_scan_metrics_are_exported() {
+        let metrics = DispatcherMetrics::dummy_instance();
+        metrics.update_status_scan_duration_metric(
+            "InclusionStage",
+            Duration::from_millis(123),
+            "test",
+        );
+        metrics.update_oldest_unchecked_transaction_age_metric(
+            "InclusionStage",
+            Duration::from_secs(45),
+            "test",
+        );
+        let gathered = String::from_utf8(metrics.gather().unwrap()).unwrap();
+
+        assert!(gathered.contains(
+            "hyperlane_lander_status_scan_duration_milliseconds{destination=\"test\",stage=\"InclusionStage\"} 123"
+        ));
+        assert!(gathered.contains(
+            "hyperlane_lander_oldest_unchecked_transaction_age_seconds{destination=\"test\",stage=\"InclusionStage\"} 45"
+        ));
+    }
 }

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -2,12 +2,12 @@ use std::{
     collections::{HashMap, VecDeque},
     future::Future,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use derive_new::new;
 use eyre::{eyre, Result};
-use futures_util::future::try_join_all;
+use futures_util::{future::try_join_all, StreamExt};
 use tokio::{
     sync::{mpsc, Mutex},
     time::sleep,
@@ -22,7 +22,8 @@ use crate::{
 };
 
 use super::{
-    building_stage::BuildingStageQueue, utils::call_until_success_or_nonretryable_error,
+    building_stage::BuildingStageQueue,
+    utils::{buffer_ordered_bounded, call_until_success_or_nonretryable_error},
     DispatcherState,
 };
 
@@ -31,6 +32,7 @@ pub use pool::FinalityStagePool;
 mod pool;
 
 pub const STAGE_NAME: &str = "FinalityStage";
+const STATUS_READ_CONCURRENCY: usize = 16;
 
 pub struct FinalityStage {
     pub(crate) pool: FinalityStagePool,
@@ -117,33 +119,93 @@ impl FinalityStage {
                 .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), &domain);
             // evaluate the pool every block
             sleep(*estimated_block_time).await;
-
-            let pool_snapshot = pool.snapshot().await;
-            state.metrics.update_queue_length_metric(
-                STAGE_NAME,
-                pool_snapshot.len() as u64,
-                &domain,
-            );
-            info!(pool_size=?pool_snapshot.len() , "Processing transactions in finality pool");
-            for (_, tx) in pool_snapshot {
-                if let Err(err) = Self::try_process_tx(
-                    tx.clone(),
-                    pool.clone(),
-                    building_stage_queue.clone(),
-                    &state,
-                )
-                .await
-                {
-                    error!(
-                        ?err,
-                        ?tx,
-                        "Error processing finality stage transaction. Skipping for now"
-                    );
-                }
-            }
+            Self::process_txs_step(&pool, &building_stage_queue, &state, &domain).await?;
         }
     }
 
+    pub async fn process_txs_step(
+        pool: &FinalityStagePool,
+        building_stage_queue: &BuildingStageQueue,
+        state: &DispatcherState,
+        domain: &str,
+    ) -> Result<(), LanderError> {
+        state
+            .metrics
+            .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
+        let scan_started = Instant::now();
+        let mut pool_snapshot = pool.snapshot().await.into_values().collect::<Vec<_>>();
+        state
+            .metrics
+            .update_queue_length_metric(STAGE_NAME, pool_snapshot.len() as u64, domain);
+        let now = chrono::Utc::now();
+        let oldest_unchecked_age = pool_snapshot
+            .iter()
+            .filter_map(|tx| {
+                now.signed_duration_since(tx.last_status_check.unwrap_or(tx.creation_timestamp))
+                    .to_std()
+                    .ok()
+            })
+            .max()
+            .unwrap_or_default();
+        state
+            .metrics
+            .update_oldest_unchecked_transaction_age_metric(
+                STAGE_NAME,
+                oldest_unchecked_age,
+                domain,
+            );
+        super::utils::sort_transactions_for_mutation(&mut pool_snapshot);
+        info!(pool_size=?pool_snapshot.len() , "Processing transactions in finality pool");
+
+        let status_reads = pool_snapshot.into_iter().map(|snapshot_tx| async move {
+            let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
+            (snapshot_tx, checked_tx, status)
+        });
+        let status_reads = buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY);
+        futures_util::pin_mut!(status_reads);
+
+        while let Some((snapshot_tx, checked_tx, status)) = status_reads.next().await {
+            if !pool
+                .replace_if_unchanged(&snapshot_tx, checked_tx.clone())
+                .await
+            {
+                info!(tx_uuid = ?snapshot_tx.uuid, "Skipping stale transaction status result");
+                continue;
+            }
+            match status {
+                Ok(status) => {
+                    if let Err(err) = Self::try_process_tx_with_next_status(
+                        checked_tx.clone(),
+                        status,
+                        pool.clone(),
+                        building_stage_queue.clone(),
+                        state,
+                    )
+                    .await
+                    {
+                        error!(
+                            ?err,
+                            tx = ?checked_tx,
+                            "Error processing finality stage transaction. Skipping for now"
+                        );
+                    }
+                }
+                Err(err) => error!(
+                    ?err,
+                    tx = ?checked_tx,
+                    "Error reading finality stage transaction status. Skipping for now"
+                ),
+            }
+        }
+        state.metrics.update_status_scan_duration_metric(
+            STAGE_NAME,
+            scan_started.elapsed(),
+            domain,
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
     #[instrument(
         skip(tx, pool, building_stage_queue, state),
         name = "FinalityStage::try_process_tx"
@@ -153,24 +215,53 @@ impl FinalityStage {
             payloads = ?tx.payload_details
     ))]
     pub async fn try_process_tx(
-        mut tx: Transaction,
+        tx: Transaction,
         pool: FinalityStagePool,
         building_stage_queue: BuildingStageQueue,
         state: &DispatcherState,
     ) -> Result<(), LanderError> {
         info!(?tx, "Processing finality stage transaction");
+        let (tx, tx_status) = Self::read_tx_status(tx, state).await;
+        Self::try_process_tx_with_next_status(tx, tx_status?, pool, building_stage_queue, state)
+            .await
+    }
+
+    #[instrument(
+        skip_all,
+        name = "FinalityStage::read_tx_status",
+        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
+    )]
+    async fn read_tx_status(
+        mut tx: Transaction,
+        state: &DispatcherState,
+    ) -> (Transaction, Result<TransactionStatus, LanderError>) {
+        tx.last_status_check = Some(chrono::Utc::now());
         let tx_status = match &tx.status {
-            TransactionStatus::Finalized => tx.status.clone(),
+            TransactionStatus::Finalized => Ok(tx.status.clone()),
             _ => {
                 call_until_success_or_nonretryable_error(
                     || state.adapter.tx_status(&tx),
                     "Querying transaction status",
                     state,
                 )
-                .await?
+                .await
             }
         };
+        (tx, tx_status)
+    }
 
+    #[instrument(
+        skip_all,
+        name = "FinalityStage::try_process_tx_with_next_status",
+        fields(tx_uuid = ?tx.uuid, previous_tx_status = ?tx.status, next_tx_status = ?tx_status, payloads = ?tx.payload_details)
+    )]
+    async fn try_process_tx_with_next_status(
+        mut tx: Transaction,
+        tx_status: TransactionStatus,
+        pool: FinalityStagePool,
+        building_stage_queue: BuildingStageQueue,
+        state: &DispatcherState,
+    ) -> Result<(), LanderError> {
         match tx_status {
             TransactionStatus::Included => {
                 // tx is not finalized yet, keep it in the pool

--- a/rust/main/lander/src/dispatcher/stages/finality_stage/pool.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage/pool.rs
@@ -32,6 +32,19 @@ impl FinalityStagePool {
         let pool = self.pool.lock().await;
         pool.clone()
     }
+
+    pub async fn replace_if_unchanged(
+        &self,
+        snapshot: &Transaction,
+        replacement: Transaction,
+    ) -> bool {
+        let mut pool = self.pool.lock().await;
+        if pool.get(&snapshot.uuid) != Some(snapshot) {
+            return false;
+        }
+        pool.insert(replacement.uuid.clone(), replacement);
+        true
+    }
 }
 
 #[cfg(test)]
@@ -40,5 +53,28 @@ impl Deref for FinalityStagePool {
 
     fn deref(&self) -> &Self::Target {
         &self.pool
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{tests::test_utils::dummy_tx, transaction::TransactionStatus};
+
+    use super::FinalityStagePool;
+
+    #[tokio::test]
+    async fn stale_snapshot_cannot_replace_newer_pool_entry() {
+        let pool = FinalityStagePool::new();
+        let snapshot = dummy_tx(vec![], TransactionStatus::Included);
+        pool.insert(snapshot.clone()).await;
+
+        let mut newer = snapshot.clone();
+        newer.status = TransactionStatus::Finalized;
+        pool.insert(newer.clone()).await;
+
+        let mut checked = snapshot.clone();
+        checked.last_status_check = Some(chrono::Utc::now());
+        assert!(!pool.replace_if_unchanged(&snapshot, checked).await);
+        assert_eq!(pool.snapshot().await.get(&snapshot.uuid), Some(&newer));
     }
 }

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -2,13 +2,12 @@ use std::cmp::max;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use derive_new::new;
 use eyre::{eyre, Result};
-use futures_util::future::try_join_all;
-use futures_util::try_join;
+use futures_util::{future::try_join_all, try_join, StreamExt};
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::sleep;
 use tracing::{error, info, info_span, instrument, warn, Instrument};
@@ -20,7 +19,10 @@ use crate::{
     transaction::{DropReason as TxDropReason, Transaction, TransactionStatus, TransactionUuid},
 };
 
-use super::{utils::call_until_success_or_nonretryable_error, DispatcherState};
+use super::{
+    utils::{buffer_ordered_bounded, call_until_success_or_nonretryable_error},
+    DispatcherState,
+};
 
 #[cfg(test)]
 pub mod tests;
@@ -37,6 +39,7 @@ const MAX_TX_STATUS_CHECK_DELAY: Duration = Duration::from_secs(5 * 60);
 const REPROCESS_TXS_LIVENESS_RATE: Duration = Duration::from_secs(5);
 // Bounds idle reorg-detection latency without reducing the liveness heartbeat rate.
 const MAX_REPROCESS_TXS_POLL_RATE: Duration = Duration::from_secs(5 * 60);
+const STATUS_READ_CONCURRENCY: usize = 16;
 
 pub struct InclusionStage {
     pub(crate) pool: InclusionStagePool,
@@ -152,59 +155,144 @@ impl InclusionStage {
             .metrics
             .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
 
+        let scan_started = Instant::now();
         let pool_snapshot = {
             let pool_snapshot = pool.lock().await;
-            let pool_snapshot = pool_snapshot.clone();
             state.metrics.update_queue_length_metric(
                 STAGE_NAME,
                 pool_snapshot.len() as u64,
                 domain,
             );
-            pool_snapshot
+            pool_snapshot.values().cloned().collect::<Vec<_>>()
         };
+        let now = chrono::Utc::now();
+        let oldest_unchecked_age = pool_snapshot
+            .iter()
+            .filter_map(|tx| {
+                now.signed_duration_since(tx.last_status_check.unwrap_or(tx.creation_timestamp))
+                    .to_std()
+                    .ok()
+            })
+            .max()
+            .unwrap_or_default();
+        state
+            .metrics
+            .update_oldest_unchecked_transaction_age_metric(
+                STAGE_NAME,
+                oldest_unchecked_age,
+                domain,
+            );
         if pool_snapshot.is_empty() {
+            state.metrics.update_status_scan_duration_metric(
+                STAGE_NAME,
+                scan_started.elapsed(),
+                domain,
+            );
             return Ok(());
         }
         info!(pool_size=?pool_snapshot.len() , "Processing transactions in inclusion pool");
 
         let base_interval = *state.adapter.estimated_block_time();
-        let now = chrono::Utc::now();
+        let mut eligible_txs = pool_snapshot
+            .into_iter()
+            .filter(|tx| Self::tx_ready_for_processing(base_interval, now, tx))
+            .collect::<Vec<_>>();
+        super::utils::sort_transactions_for_mutation(&mut eligible_txs);
+        let status_reads = eligible_txs.into_iter().map(|snapshot_tx| async move {
+            let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
+            (snapshot_tx, checked_tx, status)
+        });
+        let status_reads = buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY);
+        futures_util::pin_mut!(status_reads);
 
-        for (_, mut tx) in pool_snapshot {
-            // Update liveness metric on every tx as well.
-            // This prevents alert misfires when there are many txs to process.
-            state
-                .metrics
-                .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
+        let result = async {
+            while let Some((snapshot_tx, mut checked_tx, status)) = status_reads.next().await {
+                // Update liveness metric on every tx as well.
+                // This prevents alert misfires when there are many txs to process.
+                state
+                    .metrics
+                    .update_liveness_metric(format!("{STAGE_NAME}::process_txs").as_str(), domain);
 
-            if !Self::tx_ready_for_processing(base_interval, now, &tx) {
-                continue;
-            }
-
-            if let Err(err) =
-                Self::try_process_tx(tx.clone(), finality_stage_sender, state, pool).await
-            {
-                if matches!(err, LanderError::ChannelSendFailure(_)) {
-                    error!(
-                        ?err,
-                        ?tx,
-                        "Failed to forward transaction. Retaining it for retry"
-                    );
-                    Self::update_inclusion_stage_metric(state, domain, &err);
+                if !Self::replace_if_unchanged(pool, &snapshot_tx, checked_tx.clone()).await {
+                    info!(tx_uuid = ?snapshot_tx.uuid, "Skipping stale transaction status result");
                     continue;
                 }
 
-                error!(?err, ?tx, "Error processing transaction. Dropping it");
-
-                let drop_reason = match &err {
-                    LanderError::TxDropped(reason) => reason.clone(),
-                    _ => TxDropReason::Other(err.to_string()),
+                let tx_status = match status {
+                    Ok(status) => status,
+                    Err(err) if err.is_infra_error() => {
+                        warn!(
+                            ?err,
+                            tx = ?checked_tx,
+                            "Error reading transaction status. Retrying later"
+                        );
+                        Self::update_inclusion_stage_metric(state, domain, &err);
+                        state.store_tx(&checked_tx).await;
+                        continue;
+                    }
+                    Err(err) => {
+                        error!(?err, tx = ?checked_tx, "Error processing transaction. Dropping it");
+                        let drop_reason = match &err {
+                            LanderError::TxDropped(reason) => reason.clone(),
+                            _ => TxDropReason::Other(err.to_string()),
+                        };
+                        Self::drop_tx(state, &mut checked_tx, drop_reason, pool).await?;
+                        Self::update_inclusion_stage_metric(state, domain, &err);
+                        continue;
+                    }
                 };
-                Self::drop_tx(state, &mut tx, drop_reason, pool).await?;
-                Self::update_inclusion_stage_metric(state, domain, &err);
+                info!(tx = ?checked_tx, next_tx_status = ?tx_status, "Transaction status");
+                if let Err(err) = Self::try_process_tx_with_next_status(
+                    checked_tx.clone(),
+                    tx_status,
+                    finality_stage_sender,
+                    state,
+                    pool,
+                )
+                .await
+                {
+                    if matches!(err, LanderError::ChannelSendFailure(_)) {
+                        error!(
+                            ?err,
+                            tx = ?checked_tx,
+                            "Failed to forward transaction. Retaining it for retry"
+                        );
+                        Self::update_inclusion_stage_metric(state, domain, &err);
+                        continue;
+                    }
+
+                    error!(?err, tx = ?checked_tx, "Error processing transaction. Dropping it");
+                    let drop_reason = match &err {
+                        LanderError::TxDropped(reason) => reason.clone(),
+                        _ => TxDropReason::Other(err.to_string()),
+                    };
+                    Self::drop_tx(state, &mut checked_tx, drop_reason, pool).await?;
+                    Self::update_inclusion_stage_metric(state, domain, &err);
+                }
             }
+            Ok(())
         }
-        Ok(())
+        .await;
+        state.metrics.update_status_scan_duration_metric(
+            STAGE_NAME,
+            scan_started.elapsed(),
+            domain,
+        );
+        result
+    }
+
+    #[instrument(
+        skip_all,
+        name = "InclusionStage::read_tx_status",
+        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
+    )]
+    async fn read_tx_status(
+        mut tx: Transaction,
+        state: &DispatcherState,
+    ) -> (Transaction, Result<TransactionStatus, LanderError>) {
+        tx.last_status_check = Some(chrono::Utc::now());
+        let status = state.adapter.tx_status(&tx).await;
+        (tx, status)
     }
 
     #[instrument(skip_all, fields(?domain))]
@@ -330,48 +418,17 @@ impl InclusionStage {
         true
     }
 
-    #[instrument(
-        skip_all,
-        name = "InclusionStage::try_process_tx",
-        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
-    )]
-    async fn try_process_tx(
-        mut tx: Transaction,
-        finality_stage_sender: &mpsc::Sender<Transaction>,
-        state: &DispatcherState,
+    async fn replace_if_unchanged(
         pool: &InclusionStagePool,
-    ) -> Result<(), LanderError> {
-        info!(?tx, "Processing inclusion stage transaction");
-
-        // Update the last status check timestamp before querying
-        tx.last_status_check = Some(chrono::Utc::now());
-
-        let tx_status = state.adapter.tx_status(&tx).await;
-
-        // Persist the check timestamp even on provider failure so normal status
-        // backoff, rather than an in-call retry loop, controls the next attempt.
-        {
-            let mut pool_lock = pool.lock().await;
-            pool_lock.insert(tx.uuid.clone(), tx.clone());
+        snapshot_tx: &Transaction,
+        checked_tx: Transaction,
+    ) -> bool {
+        let mut pool = pool.lock().await;
+        if pool.get(&snapshot_tx.uuid) != Some(snapshot_tx) {
+            return false;
         }
-        let tx_status = match tx_status {
-            Ok(status) => status,
-            Err(err) if err.is_infra_error() => {
-                warn!(
-                    ?err,
-                    ?tx,
-                    "Error reading transaction status. Retrying later"
-                );
-                Self::update_inclusion_stage_metric(state, &state.domain, &err);
-                state.store_tx(&tx).await;
-                return Ok(());
-            }
-            Err(err) => return Err(err),
-        };
-        info!(?tx, next_tx_status = ?tx_status, "Transaction status");
-
-        Self::try_process_tx_with_next_status(tx, tx_status, finality_stage_sender, state, pool)
-            .await
+        pool.insert(checked_tx.uuid.clone(), checked_tx);
+        true
     }
 
     #[instrument(

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -263,6 +263,59 @@ async fn test_processing_included_txs() {
     .await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn completed_prefix_is_applied_before_later_status_error() {
+    let mut earlier_tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    let mut later_tx = dummy_tx(Vec::new(), TransactionStatus::PendingInclusion);
+    let now = chrono::Utc::now();
+    earlier_tx.creation_timestamp = now - chrono::Duration::seconds(2);
+    later_tx.creation_timestamp = now - chrono::Duration::seconds(1);
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_estimated_block_time()
+        .return_const(Duration::from_secs(1));
+    let later_uuid = later_tx.uuid.clone();
+    mock_adapter.expect_tx_status().returning(move |tx| {
+        (tx.uuid != later_uuid)
+            .then_some(TransactionStatus::Included)
+            .ok_or_else(|| LanderError::TxSubmissionError("status read failed".to_string()))
+    });
+
+    let (payload_db, tx_db, _) = tmp_dbs();
+    let state = DispatcherState::new(
+        payload_db,
+        tx_db,
+        Arc::new(mock_adapter),
+        DispatcherMetrics::dummy_instance(),
+        "test".to_string(),
+    );
+    let pool = InclusionStagePool::default();
+    pool.lock()
+        .await
+        .insert(earlier_tx.uuid.clone(), earlier_tx.clone());
+    pool.lock()
+        .await
+        .insert(later_tx.uuid.clone(), later_tx.clone());
+    let (finality_stage_sender, mut finality_stage_receiver) = mpsc::channel(2);
+
+    let scan_pool = pool.clone();
+    let scan_state = state.clone();
+    let scan = tokio::spawn(async move {
+        InclusionStage::process_txs_step(&scan_pool, &finality_stage_sender, &scan_state, "test")
+            .await
+    });
+
+    let forwarded = tokio::time::timeout(Duration::from_millis(1), finality_stage_receiver.recv())
+        .await
+        .expect("the completed prefix should be applied before the later error")
+        .expect("the finality stage receiver should remain open");
+    assert_eq!(forwarded.uuid, earlier_tx.uuid);
+    assert!(!pool.lock().await.contains_key(&earlier_tx.uuid));
+    assert!(pool.lock().await.contains_key(&later_tx.uuid));
+
+    scan.await.unwrap().unwrap();
+}
+
 #[tokio::test]
 async fn test_unincluded_txs_reach_mempool() {
     const TXS_TO_PROCESS: usize = 3;

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -1,5 +1,6 @@
 use std::{future::Future, time::Duration};
 
+use futures_util::{stream, Stream, StreamExt};
 use tokio::time::sleep;
 use tracing::{error, info, instrument};
 
@@ -10,6 +11,27 @@ use crate::{
 };
 
 use super::DispatcherState;
+
+/// Polls futures concurrently while yielding completed prefixes in input order.
+pub(super) fn buffer_ordered_bounded<Fut, T>(
+    futures: impl IntoIterator<Item = Fut>,
+    max_concurrency: usize,
+) -> impl Stream<Item = T>
+where
+    Fut: Future<Output = T>,
+{
+    assert!(max_concurrency > 0, "concurrency must be non-zero");
+
+    stream::iter(futures).buffered(max_concurrency)
+}
+
+pub(super) fn sort_transactions_for_mutation(transactions: &mut [Transaction]) {
+    transactions.sort_unstable_by(|left, right| {
+        left.creation_timestamp
+            .cmp(&right.creation_timestamp)
+            .then_with(|| left.uuid.as_bytes().cmp(right.uuid.as_bytes()))
+    });
+}
 
 pub async fn call_until_success_or_nonretryable_error<F, T, Fut>(
     f: F,
@@ -76,4 +98,131 @@ pub async fn update_tx_status(
         _ => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
+
+    use tokio::sync::Semaphore;
+
+    use hyperlane_core::identifiers::UniqueIdentifier;
+    use uuid::Uuid;
+
+    use crate::{tests::test_utils::dummy_tx, transaction::TransactionStatus};
+
+    use futures_util::StreamExt;
+
+    use super::{buffer_ordered_bounded, sort_transactions_for_mutation};
+
+    #[test]
+    fn transactions_are_sorted_by_creation_then_uuid() {
+        let timestamp = chrono::Utc::now();
+        let mut same_time_later_uuid = dummy_tx(vec![], TransactionStatus::Included);
+        same_time_later_uuid.creation_timestamp = timestamp;
+        same_time_later_uuid.uuid = UniqueIdentifier::new(Uuid::from_u128(2));
+        let mut same_time_earlier_uuid = same_time_later_uuid.clone();
+        same_time_earlier_uuid.uuid = UniqueIdentifier::new(Uuid::from_u128(1));
+        let mut later_creation = same_time_later_uuid.clone();
+        later_creation.creation_timestamp = timestamp + chrono::Duration::seconds(1);
+        later_creation.uuid = UniqueIdentifier::new(Uuid::from_u128(0));
+        let mut transactions = vec![later_creation, same_time_later_uuid, same_time_earlier_uuid];
+
+        sort_transactions_for_mutation(&mut transactions);
+
+        assert_eq!(transactions[0].uuid.as_u128(), 1);
+        assert_eq!(transactions[1].uuid.as_u128(), 2);
+        assert_eq!(transactions[2].uuid.as_u128(), 0);
+    }
+
+    #[tokio::test]
+    async fn ordered_bounded_stream_yields_completed_prefix_before_later_read() {
+        const CONCURRENCY: usize = 4;
+        const ITEM_COUNT: usize = 8;
+
+        let second_read_gate = Arc::new(Semaphore::new(0));
+
+        let futures = (0..ITEM_COUNT).map(|index| {
+            let second_read_gate = second_read_gate.clone();
+            async move {
+                if index == 1 {
+                    second_read_gate
+                        .acquire()
+                        .await
+                        .expect("test semaphore is not closed")
+                        .forget();
+                }
+
+                index
+            }
+        });
+
+        let mut stream = Box::pin(buffer_ordered_bounded(futures, CONCURRENCY));
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), stream.next())
+                .await
+                .expect("the completed prefix should be yielded")
+                .expect("the stream should contain the first result"),
+            0
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), stream.next())
+                .await
+                .is_err(),
+            "input order should still wait for the gated second result"
+        );
+        second_read_gate.add_permits(1);
+        assert_eq!(
+            stream.collect::<Vec<_>>().await,
+            (1..ITEM_COUNT).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn ordered_bounded_collection_enforces_concurrency_cap() {
+        const CONCURRENCY: usize = 4;
+        const ITEM_COUNT: usize = 8;
+
+        let started = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(Semaphore::new(0));
+        let started_for_futures = started.clone();
+        let gate_for_futures = gate.clone();
+        let futures = (0..ITEM_COUNT).map(move |index| {
+            let started = started_for_futures.clone();
+            let gate = gate_for_futures.clone();
+            async move {
+                started.fetch_add(1, Ordering::SeqCst);
+                gate.acquire()
+                    .await
+                    .expect("test semaphore is not closed")
+                    .forget();
+                index
+            }
+        });
+
+        let collection = tokio::spawn(async move {
+            buffer_ordered_bounded(futures, CONCURRENCY)
+                .collect::<Vec<_>>()
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while started.load(Ordering::SeqCst) < CONCURRENCY {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the configured number of reads should start");
+        tokio::task::yield_now().await;
+        assert_eq!(started.load(Ordering::SeqCst), CONCURRENCY);
+
+        gate.add_permits(ITEM_COUNT);
+        assert_eq!(
+            collection.await.unwrap(),
+            (0..ITEM_COUNT).collect::<Vec<_>>()
+        );
+    }
 }

--- a/rust/main/lander/src/tests/svm/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/svm/tests_inclusion_stage.rs
@@ -19,8 +19,8 @@ use crate::{
     adapter::{
         chains::sealevel::{
             adapter::tests::tests_common::{
-                encoded_svm_transaction, svm_block, MockClient, MockOracle, MockSubmitter,
-                MockSvmProvider,
+                finalized_signature_status, processed_signature_status, signature_status_response,
+                svm_block, MockClient, MockOracle, MockSubmitter, MockSvmProvider,
             },
             transaction::{Precursor, TransactionFactory},
             SealevelAdapter,
@@ -44,7 +44,7 @@ async fn test_svm_inclusion_happy_path() {
 
     let mut client = MockClient::new();
     mock_simulate_transaction(&mut client);
-    mock_get_transaction_with_commitment(&mut client);
+    mock_finalized_signature_status(&mut client, 1);
     mock_get_block_with_commitment(&mut client);
     let oracle = MockOracle::new();
     let mut provider = MockSvmProvider::new();
@@ -73,8 +73,6 @@ async fn test_svm_inclusion_happy_path() {
         ExpectedSvmTxState {
             compute_units: 1400000,
             compute_unit_price_micro_lamports: 0,
-            // final status is `Finalized` because `get_transaction_with_commitment` returns an `Ok` response
-            // regardless of the commitment level it's called with
             status: TransactionStatus::Finalized,
             retries: 1,
         },
@@ -114,26 +112,23 @@ async fn test_svm_inclusion_gas_spike() {
             },
         );
 
-    let mut commitment_call_counter = 0;
+    let mut status_call_counter = 0;
     client
-        .expect_get_transaction_with_commitment()
-        .returning(move |_, commitment| {
-            commitment_call_counter += 1;
+        .expect_get_signature_statuses_with_history()
+        .times(4)
+        .returning(move |signatures| {
+            assert_eq!(signatures.len(), 1);
+            status_call_counter += 1;
             info!(
-                ?commitment_call_counter,
-                "calling get_transaction_with_commitment"
+                ?status_call_counter,
+                "calling get_signature_statuses_with_history"
             );
-            // when a transaction is not yet included, the status check makes 3 calls (one with each commitment level in inverse order: finalized, confirmed, processed).
-            // it takes 3 unsuccessful tx statuses to escalate twice
-            if commitment.is_finalized() && commitment_call_counter > 9 {
-                return Ok(encoded_svm_transaction()); // Simulate transaction being included at the `finalized` level after 4 retries
-            }
-            if commitment.is_processed() {
-                return Ok(encoded_svm_transaction()); // Simulate transaction being processed
-            }
-            Err(ChainCommunicationError::from_other(
-                LanderError::TxHashNotFound("Not included yet".to_string()),
-            ))
+            let status = if status_call_counter == 4 {
+                finalized_signature_status()
+            } else {
+                processed_signature_status()
+            };
+            Ok(signature_status_response(Some(status)))
         });
 
     let mut submitter = MockSubmitter::new();
@@ -197,22 +192,27 @@ async fn test_svm_inclusion_escalate_but_old_hash_finalized() {
     mock_simulate_transaction(&mut client);
     mock_get_block_with_commitment(&mut client);
 
-    // Mock `get_transaction_with_commitment` to simulate the first signature being finalized
-    let mut commitment_call_counter = 0;
+    // The first signature becomes finalized on its third status check while the
+    // replacement signature remains processed.
+    let mut signature1_status_checks = 0;
     client
-        .expect_get_transaction_with_commitment()
-        .returning(move |sig, commitment| {
-            commitment_call_counter += 1;
-
-            if commitment.is_finalized() && sig == signature1 && commitment_call_counter > 6 {
-                Ok(encoded_svm_transaction()) // First signature is finalized after 2 calls
-            } else if commitment.is_processed() {
-                Ok(encoded_svm_transaction()) // Simulate both signatures being processed
+        .expect_get_signature_statuses_with_history()
+        .times(5)
+        .returning(move |signatures| {
+            assert_eq!(signatures.len(), 1);
+            let signature = signatures[0];
+            let status = if signature == signature1 {
+                signature1_status_checks += 1;
+                if signature1_status_checks == 3 {
+                    finalized_signature_status()
+                } else {
+                    processed_signature_status()
+                }
             } else {
-                Err(ChainCommunicationError::from_other(
-                    LanderError::TxHashNotFound("Not included yet".to_string()),
-                ))
-            }
+                assert_eq!(signature, signature2);
+                processed_signature_status()
+            };
+            Ok(signature_status_response(Some(status)))
         });
 
     let oracle = MockOracle::new();
@@ -303,7 +303,7 @@ async fn test_svm_inclusion_send_returns_blockhash_not_found() {
     let mut client = MockClient::new();
     mock_simulate_transaction(&mut client);
     mock_get_block_with_commitment(&mut client);
-    mock_get_transaction_with_commitment(&mut client);
+    mock_finalized_signature_status(&mut client, 1);
 
     let oracle = MockOracle::new();
     let mut provider = MockSvmProvider::new();
@@ -374,7 +374,7 @@ async fn test_svm_failure_to_estimate_costs_causes_tx_to_be_dropped() {
     let mut client = MockClient::new();
     mock_simulate_transaction(&mut client);
     mock_get_block_with_commitment(&mut client);
-    mock_get_transaction_with_commitment(&mut client);
+    mock_finalized_signature_status(&mut client, 0);
 
     let oracle = MockOracle::new();
     let mut provider = MockSvmProvider::new();
@@ -672,10 +672,16 @@ fn mock_confirm_transaction(mock_submitter: &mut MockSubmitter) {
         .returning(move |_, _| Ok(true));
 }
 
-fn mock_get_transaction_with_commitment(mock_provider: &mut MockClient) {
+fn mock_finalized_signature_status(mock_provider: &mut MockClient, times: usize) {
     mock_provider
-        .expect_get_transaction_with_commitment()
-        .returning(|_, _| Ok(encoded_svm_transaction()));
+        .expect_get_signature_statuses_with_history()
+        .times(times)
+        .returning(|signatures| {
+            assert_eq!(signatures.len(), 1);
+            Ok(signature_status_response(
+                Some(finalized_signature_status()),
+            ))
+        });
 }
 
 fn mock_get_block_with_commitment(mock_provider: &mut MockClient) {

--- a/rust/main/lander/tests/integration_sealevel.rs
+++ b/rust/main/lander/tests/integration_sealevel.rs
@@ -7,7 +7,7 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use mockall::mock;
-use solana_client::rpc_response::RpcSimulateTransactionResult;
+use solana_client::rpc_response::{Response, RpcResponseContext, RpcSimulateTransactionResult};
 use solana_commitment_config::CommitmentConfig;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::{
@@ -25,8 +25,8 @@ use solana_sdk::{
 };
 use solana_transaction_status::{
     option_serializer::OptionSerializer, EncodedConfirmedTransactionWithStatusMeta,
-    EncodedTransaction, EncodedTransactionWithStatusMeta, UiConfirmedBlock,
-    UiTransactionStatusMeta,
+    EncodedTransaction, EncodedTransactionWithStatusMeta,
+    TransactionStatus as SealevelTransactionStatus, UiConfirmedBlock, UiTransactionStatusMeta,
 };
 
 use hyperlane_base::db::{HyperlaneRocksDB, DB};
@@ -53,6 +53,7 @@ mock! {
         async fn get_block_with_commitment(&self, slot: u64, commitment: CommitmentConfig) -> ChainResult<UiConfirmedBlock>;
         async fn get_transaction(&self, signature: Signature) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
         async fn get_transaction_with_commitment(&self, signature: Signature, commitment: CommitmentConfig) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
+        async fn get_signature_statuses_with_history(&self, signatures: &[Signature]) -> ChainResult<Response<Vec<Option<SealevelTransactionStatus>>>>;
         async fn simulate_transaction(&self, transaction: &SealevelLegacyTransaction) -> ChainResult<RpcSimulateTransactionResult>;
         async fn simulate_versioned_transaction(&self, transaction: &SealevelVersionedTransaction) -> ChainResult<RpcSimulateTransactionResult>;
     }
@@ -225,8 +226,16 @@ fn create_sealevel_client() -> MockClient {
         .expect_get_block_with_commitment()
         .returning(move |_, _| Ok(svm_block()));
     client
-        .expect_get_transaction_with_commitment()
-        .returning(move |_, _| Ok(encoded_svm_transaction()));
+        .expect_get_signature_statuses_with_history()
+        .returning(move |_| {
+            Ok(Response {
+                context: RpcResponseContext {
+                    slot: 43,
+                    api_version: None,
+                },
+                value: vec![Some(finalized_signature_status())],
+            })
+        });
     let result_clone = result.clone();
     client
         .expect_simulate_transaction()
@@ -235,6 +244,18 @@ fn create_sealevel_client() -> MockClient {
         .expect_simulate_versioned_transaction()
         .returning(move |_| Ok(result.clone()));
     client
+}
+
+fn finalized_signature_status() -> SealevelTransactionStatus {
+    SealevelTransactionStatus {
+        slot: 43,
+        confirmations: None,
+        status: Ok(()),
+        err: None,
+        confirmation_status: Some(
+            solana_transaction_status::TransactionConfirmationStatus::Finalized,
+        ),
+    }
 }
 
 fn create_sealevel_submitter() -> MockSubmitter {


### PR DESCRIPTION
## Problem

Each Sealevel Lander status check called `getTransaction` sequentially at finalized, confirmed, and processed commitment until one succeeded. A finalized transaction cost one RPC, a confirmed transaction two, and a processed or missing transaction three. Normal null responses also appeared as deserialization/fallback warnings.

The sampled mainnet relayer emitted 89 Sealevel `getTransaction` calls in 45 minutes, implying 30-89 logical status checks depending on finality mix. Stacked on #9398, one 16-wide processed/missing wave could fan out to 48 calls.

## Solution

- replace the three commitment probes with one history-aware `getSignatureStatuses` operation
- map Solana `processed`, `confirmed`, and `finalized` directly to Lander states, retaining legacy confirmation-count fallback
- merge fallback-provider responses per signature by strongest finality (`finalized > confirmed > processed`), breaking equal-finality ties by slot
- stop after the first provider only when every requested signature is already finalized; otherwise query remaining providers so a lagging provider cannot report false absence or weaker finality
- reject wrong-length provider responses, and treat absence as authoritative only when every successful provider agrees and no provider failed
- propagate transport failures as infrastructure errors rather than `TxHashNotFound`

## Expected improvement

With one provider, exact per-check request reduction remains:

- finalized: 1 -> 1 (0%)
- confirmed: 2 -> 1 (50%)
- processed or missing: 3 -> 1 (66.7%)

With `P` fallback providers, an all-finalized first response still costs one physical request. A weaker or missing response costs up to `P` requests because correctness requires consulting the remaining providers. This is an intentional availability/correctness tradeoff: provider count, latency, and history-search cost determine the physical-request reduction in those cases.

At the 16-wide ceiling, the old processed/missing maximum was 48 requests. With one provider it becomes 16; with `P` providers it is at most `16P`. Follow-up #9429 collapses the 16 logical status operations into one provider batch.

## Correctness

- full-history search preserves discovery of older rooted transactions after restart
- provider results are merged per signature rather than accepting the first successful but stale response
- normal `None` remains `TxHashNotFound` only after authoritative absence; ambiguous absence remains retryable infrastructure failure
- malformed response cardinality is rejected before positional mapping
- transaction mutation, retry ordering, and #9398 concurrency behavior are unchanged

## Verification

- Hyperlane fallback-provider stop/continue tests: 2 passed
- Sealevel fallback merge/cardinality/ambiguity tests: 5 passed
- focused Sealevel Lander status tests: 5 passed
- broader Sealevel Lander tests: 35 passed
- SVM inclusion status scenarios: 5 passed
- strict clippy for `hyperlane-core`, `hyperlane-sealevel`, and `lander`
- Rust formatting, diff check, and repository hooks
- exact head: `15a777351a8fc930dec74ad7adbeb0b61275f745`

## Canary

Compare `getTransaction` versus `getSignatureStatuses` request rate, fallback-provider fanout, provider errors/rate limits, status-scan duration, oldest-unchecked age, pool lengths, resubmissions, duplicate submissions, and delivery latency. Keep production latency/call-volume reductions unmeasured until canaried.

Master performance epic: #9386.
