### PR TITLE
perf(lander): batch Sealevel transaction statuses

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 use derive_new::new;
 use solana_client::rpc_config::RpcProgramAccountsConfig;
 use solana_client::rpc_response::{
-    Response, RpcConfirmedTransactionStatusWithSignature, RpcResponseContext,
-    RpcSimulateTransactionResult,
+    Response, RpcConfirmedTransactionStatusWithSignature, RpcSimulateTransactionResult,
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::hash::Hash;
@@ -68,20 +67,13 @@ fn all_signature_statuses_finalized(
 fn merge_signature_status_responses(
     signature_count: usize,
     responses: Vec<ChainResult<Response<Vec<Option<TransactionStatus>>>>>,
-) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
-    let mut context = None;
+) -> Vec<ChainResult<Option<TransactionStatus>>> {
     let mut statuses = vec![None; signature_count];
     let mut errors = Vec::new();
 
     for response in responses {
         match response {
             Ok(response) => {
-                if context
-                    .as_ref()
-                    .is_none_or(|current: &RpcResponseContext| response.context.slot > current.slot)
-                {
-                    context = Some(response.context);
-                }
                 for (current, candidate) in statuses.iter_mut().zip(response.value) {
                     let should_replace = candidate.as_ref().is_some_and(|candidate| {
                         current.as_ref().is_none_or(|current| {
@@ -100,17 +92,16 @@ fn merge_signature_status_responses(
         }
     }
 
-    let Some(context) = context else {
-        return Err(RpcClientError::FallbackProvidersFailed(errors).into());
-    };
-    if !errors.is_empty() && statuses.iter().any(Option::is_none) {
-        return Err(RpcClientError::FallbackProvidersFailed(errors).into());
-    }
-
-    Ok(Response {
-        context,
-        value: statuses,
-    })
+    let fallback_error =
+        (!errors.is_empty()).then(|| RpcClientError::FallbackProvidersFailed(errors).to_string());
+    statuses
+        .into_iter()
+        .map(|status| match (status, &fallback_error) {
+            (Some(status), _) => Ok(Some(status)),
+            (None, None) => Ok(None),
+            (None, Some(error)) => Err(ChainCommunicationError::from_other_str(error)),
+        })
+        .collect()
 }
 
 /// Defines methods required to submit transactions to Sealevel chains
@@ -146,10 +137,12 @@ pub trait SubmitSealevelRpc: Send + Sync {
     ) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
 
     /// Requests transaction statuses from recent and rooted history.
+    /// Returns exactly one result per input signature so a provider failure only
+    /// marks unresolved entries as ambiguous.
     async fn get_signature_statuses_with_history(
         &self,
         signatures: &[Signature],
-    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>>;
+    ) -> Vec<ChainResult<Option<TransactionStatus>>>;
 
     /// Simulates Sealevel legacy transaction
     async fn simulate_transaction(
@@ -209,7 +202,7 @@ impl SubmitSealevelRpc for SealevelFallbackRpcClient {
     async fn get_signature_statuses_with_history(
         &self,
         signatures: &[Signature],
-    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+    ) -> Vec<ChainResult<Option<TransactionStatus>>> {
         SealevelFallbackRpcClient::get_signature_statuses_with_history(self, signatures).await
     }
 
@@ -537,10 +530,12 @@ impl SealevelFallbackRpcClient {
     }
 
     /// Get signature statuses, including rooted transaction history.
+    /// Resolved statuses survive partial fallback-provider failures; unresolved
+    /// entries carry individual errors.
     pub async fn get_signature_statuses_with_history(
         &self,
         signatures: &[Signature],
-    ) -> ChainResult<Response<Vec<Option<TransactionStatus>>>> {
+    ) -> Vec<ChainResult<Option<TransactionStatus>>> {
         let signature_count = signatures.len();
         let responses = self
             .fallback_provider
@@ -575,6 +570,7 @@ impl Debug for SealevelFallbackRpcClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solana_client::rpc_response::RpcResponseContext;
 
     fn status(confirmation_status: TransactionConfirmationStatus) -> TransactionStatus {
         TransactionStatus {
@@ -613,12 +609,11 @@ mod tests {
                     ],
                 )),
             ],
-        )
-        .unwrap();
+        );
 
-        assert_eq!(merged.context.slot, 11);
-        assert!(merged.value.into_iter().all(|status| {
-            status.unwrap().confirmation_status() == TransactionConfirmationStatus::Finalized
+        assert!(merged.into_iter().all(|status| {
+            status.unwrap().unwrap().confirmation_status()
+                == TransactionConfirmationStatus::Finalized
         }));
     }
 
@@ -653,7 +648,7 @@ mod tests {
             ],
         );
 
-        assert!(merged.is_err());
+        assert!(merged[0].is_err());
     }
 
     #[test]
@@ -661,10 +656,31 @@ mod tests {
         let merged = merge_signature_status_responses(
             1,
             vec![Ok(response(10, vec![None])), Ok(response(11, vec![None]))],
-        )
-        .unwrap();
+        );
 
-        assert_eq!(merged.value, vec![None]);
+        assert!(matches!(merged.as_slice(), [Ok(None)]));
+    }
+
+    #[test]
+    fn signature_status_merge_preserves_resolved_entries_with_provider_failure() {
+        let merged = merge_signature_status_responses(
+            3,
+            vec![
+                Ok(response(
+                    10,
+                    vec![
+                        Some(status(TransactionConfirmationStatus::Finalized)),
+                        Some(status(TransactionConfirmationStatus::Finalized)),
+                        None,
+                    ],
+                )),
+                Err(ChainCommunicationError::from_other_str("RPC unavailable")),
+            ],
+        );
+
+        assert!(matches!(merged[0], Ok(Some(_))));
+        assert!(matches!(merged[1], Ok(Some(_))));
+        assert!(merged[2].is_err());
     }
 
     #[test]

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
@@ -296,23 +296,37 @@ impl SealevelAdapter {
         let signature = Signature::try_from(tx_hash.as_ref())
             .map_err(|e| LanderError::TxSubmissionError(format!("Invalid signature: {e}")))?;
 
-        let response = self
-            .client
-            .get_signature_statuses_with_history(&[signature])
-            .await?;
-        if response.value.len() != 1 {
-            return Err(LanderError::NetworkError(format!(
-                "Signature status response length {} did not match request length 1",
-                response.value.len()
-            )));
-        }
-        let Some(status) = response.value.into_iter().next().flatten() else {
+        let status = self
+            .signature_status_results(std::slice::from_ref(&signature))
+            .await?
+            .into_iter()
+            .next()
+            .expect("single-signature result length was validated")?;
+        let Some(status) = status else {
             return Err(LanderError::TxHashNotFound(format!(
                 "Transaction signature {signature} was not found"
             )));
         };
 
         Ok(Self::classify_signature_status(status))
+    }
+
+    async fn signature_status_results(
+        &self,
+        signatures: &[Signature],
+    ) -> Result<Vec<ChainResult<Option<SealevelTransactionStatus>>>, LanderError> {
+        let statuses = self
+            .client
+            .get_signature_statuses_with_history(signatures)
+            .await;
+        if statuses.len() != signatures.len() {
+            return Err(LanderError::NetworkError(format!(
+                "Signature status response length {} did not match request length {}",
+                statuses.len(),
+                signatures.len()
+            )));
+        }
+        Ok(statuses)
     }
 
     fn classify_signature_status(status: SealevelTransactionStatus) -> TransactionStatus {
@@ -473,45 +487,28 @@ impl AdaptsChain for SealevelAdapter {
                 .iter()
                 .map(|(_, signature)| *signature)
                 .collect::<Vec<_>>();
-            match self
-                .client
-                .get_signature_statuses_with_history(&batch_signatures)
-                .await
-            {
-                Ok(response) => {
-                    if response.value.len() != signature_batch.len() {
-                        let error = format!(
-                            "Signature status response length {} did not match request length {}",
-                            response.value.len(),
-                            signature_batch.len()
-                        );
-                        for (tx_index, _) in signature_batch {
-                            statuses_by_tx[*tx_index]
-                                .push(Err(LanderError::NetworkError(error.clone())));
-                        }
-                        continue;
-                    }
-                    let mut response_statuses = response.value.into_iter();
-                    for (tx_index, signature) in signature_batch {
-                        let status = response_statuses
-                            .next()
-                            .flatten()
-                            .map(Self::classify_signature_status)
-                            .ok_or_else(|| {
-                                LanderError::TxHashNotFound(format!(
-                                    "Transaction signature {signature} was not found"
-                                ))
-                            });
-                        statuses_by_tx[*tx_index].push(status);
-                    }
-                }
-                Err(err) => {
-                    let message = err.to_string();
-                    for (tx_index, _) in signature_batch {
-                        statuses_by_tx[*tx_index]
-                            .push(Err(LanderError::NetworkError(message.clone())));
-                    }
-                }
+            let batch_statuses: Vec<Result<Option<SealevelTransactionStatus>, LanderError>> =
+                match self.signature_status_results(&batch_signatures).await {
+                    Ok(statuses) => statuses
+                        .into_iter()
+                        .map(|status| {
+                            status.map_err(|error| LanderError::NetworkError(error.to_string()))
+                        })
+                        .collect(),
+                    Err(error) => (0..signature_batch.len())
+                        .map(|_| Err(LanderError::NetworkError(error.to_string())))
+                        .collect(),
+                };
+
+            for ((tx_index, signature), status) in signature_batch.iter().zip(batch_statuses) {
+                let status = status.and_then(|status| {
+                    status.map(Self::classify_signature_status).ok_or_else(|| {
+                        LanderError::TxHashNotFound(format!(
+                            "Transaction signature {signature} was not found"
+                        ))
+                    })
+                });
+                statuses_by_tx[*tx_index].push(status);
             }
         }
 

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter.rs
@@ -58,6 +58,8 @@ use crate::{
 };
 
 const TX_RESUBMISSION_BLOCK_TIME_MULTIPLIER: f32 = 3.0;
+const STATUS_TX_BATCH_SIZE: usize = 16;
+const MAX_SIGNATURES_PER_STATUS_REQUEST: usize = 256;
 
 #[derive(Default, Clone, Copy, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
 pub enum EstimateFreshnessCache {
@@ -298,6 +300,12 @@ impl SealevelAdapter {
             .client
             .get_signature_statuses_with_history(&[signature])
             .await?;
+        if response.value.len() != 1 {
+            return Err(LanderError::NetworkError(format!(
+                "Signature status response length {} did not match request length 1",
+                response.value.len()
+            )));
+        }
         let Some(status) = response.value.into_iter().next().flatten() else {
             return Err(LanderError::TxHashNotFound(format!(
                 "Transaction signature {signature} was not found"
@@ -440,6 +448,92 @@ impl AdaptsChain for SealevelAdapter {
         let status = self.get_tx_hash_status(hash).await?;
         info!(?hash, ?status, "got transaction hash status");
         Ok(status)
+    }
+
+    async fn tx_statuses(
+        &self,
+        txs: &[Transaction],
+    ) -> Vec<Result<TransactionStatus, LanderError>> {
+        let mut statuses_by_tx = (0..txs.len()).map(|_| Vec::new()).collect::<Vec<_>>();
+        let mut signatures = Vec::new();
+
+        for (tx_index, tx) in txs.iter().enumerate() {
+            for hash in &tx.tx_hashes {
+                match Signature::try_from(hash.as_ref()) {
+                    Ok(signature) => signatures.push((tx_index, signature)),
+                    Err(err) => statuses_by_tx[tx_index].push(Err(LanderError::TxSubmissionError(
+                        format!("Invalid signature: {err}"),
+                    ))),
+                }
+            }
+        }
+
+        for signature_batch in signatures.chunks(MAX_SIGNATURES_PER_STATUS_REQUEST) {
+            let batch_signatures = signature_batch
+                .iter()
+                .map(|(_, signature)| *signature)
+                .collect::<Vec<_>>();
+            match self
+                .client
+                .get_signature_statuses_with_history(&batch_signatures)
+                .await
+            {
+                Ok(response) => {
+                    if response.value.len() != signature_batch.len() {
+                        let error = format!(
+                            "Signature status response length {} did not match request length {}",
+                            response.value.len(),
+                            signature_batch.len()
+                        );
+                        for (tx_index, _) in signature_batch {
+                            statuses_by_tx[*tx_index]
+                                .push(Err(LanderError::NetworkError(error.clone())));
+                        }
+                        continue;
+                    }
+                    let mut response_statuses = response.value.into_iter();
+                    for (tx_index, signature) in signature_batch {
+                        let status = response_statuses
+                            .next()
+                            .flatten()
+                            .map(Self::classify_signature_status)
+                            .ok_or_else(|| {
+                                LanderError::TxHashNotFound(format!(
+                                    "Transaction signature {signature} was not found"
+                                ))
+                            });
+                        statuses_by_tx[*tx_index].push(status);
+                    }
+                }
+                Err(err) => {
+                    let message = err.to_string();
+                    for (tx_index, _) in signature_batch {
+                        statuses_by_tx[*tx_index]
+                            .push(Err(LanderError::NetworkError(message.clone())));
+                    }
+                }
+            }
+        }
+
+        statuses_by_tx
+            .into_iter()
+            .map(|mut statuses| {
+                if statuses.iter().all(Result::is_err) {
+                    if let Some(index) = statuses.iter().position(|status| {
+                        status.as_ref().is_err_and(|error| error.is_infra_error())
+                    }) {
+                        statuses.swap_remove(index)?;
+                    }
+                }
+                Ok(TransactionStatus::classify_tx_status_from_hash_statuses(
+                    statuses,
+                ))
+            })
+            .collect()
+    }
+
+    fn tx_status_batch_size(&self) -> usize {
+        STATUS_TX_BATCH_SIZE
     }
 
     async fn tx_ready_for_resubmission(&self, tx: &Transaction) -> bool {

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use mockall::mock;
-use solana_client::rpc_response::{Response, RpcResponseContext, RpcSimulateTransactionResult};
+use solana_client::rpc_response::RpcSimulateTransactionResult;
 use solana_commitment_config::CommitmentConfig;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::account::Account;
@@ -63,7 +63,7 @@ mock! {
         async fn get_signature_statuses_with_history(
             &self,
             signatures: &[Signature],
-        ) -> ChainResult<Response<Vec<Option<SealevelTransactionStatus>>>>;
+        ) -> Vec<ChainResult<Option<SealevelTransactionStatus>>>;
 
         async fn simulate_transaction(
             &self,
@@ -276,11 +276,7 @@ fn mock_client() -> MockClient {
         .returning(move |_, _| Ok(svm_block()));
     client
         .expect_get_signature_statuses_with_history()
-        .returning(move |_| {
-            Ok(signature_status_response(
-                Some(finalized_signature_status()),
-            ))
-        });
+        .returning(move |_| signature_status_response(Some(finalized_signature_status())));
     let result_clone = result.clone();
     client
         .expect_simulate_transaction()
@@ -293,20 +289,14 @@ fn mock_client() -> MockClient {
 
 pub fn signature_status_response(
     status: Option<SealevelTransactionStatus>,
-) -> Response<Vec<Option<SealevelTransactionStatus>>> {
+) -> Vec<ChainResult<Option<SealevelTransactionStatus>>> {
     signature_statuses_response(vec![status])
 }
 
 pub fn signature_statuses_response(
     statuses: Vec<Option<SealevelTransactionStatus>>,
-) -> Response<Vec<Option<SealevelTransactionStatus>>> {
-    Response {
-        context: RpcResponseContext {
-            slot: 43,
-            api_version: None,
-        },
-        value: statuses,
-    }
+) -> Vec<ChainResult<Option<SealevelTransactionStatus>>> {
+    statuses.into_iter().map(Ok).collect()
 }
 
 pub fn finalized_signature_status() -> SealevelTransactionStatus {

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_common.rs
@@ -294,12 +294,18 @@ fn mock_client() -> MockClient {
 pub fn signature_status_response(
     status: Option<SealevelTransactionStatus>,
 ) -> Response<Vec<Option<SealevelTransactionStatus>>> {
+    signature_statuses_response(vec![status])
+}
+
+pub fn signature_statuses_response(
+    statuses: Vec<Option<SealevelTransactionStatus>>,
+) -> Response<Vec<Option<SealevelTransactionStatus>>> {
     Response {
         context: RpcResponseContext {
             slot: 43,
             api_version: None,
         },
-        value: vec![status],
+        value: statuses,
     }
 }
 

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_status.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_status.rs
@@ -1,14 +1,28 @@
 use crate::adapter::AdaptsChain;
 use crate::error::LanderError;
-use crate::transaction::TransactionStatus;
+use crate::transaction::{Transaction, TransactionStatus};
 use hyperlane_core::{ChainCommunicationError, H512};
+use mockall::Sequence;
 use solana_transaction_status::{
     TransactionConfirmationStatus, TransactionStatus as SealevelTransactionStatus,
 };
 
 use super::tests_common::{
-    adapter, adapter_with_mock_client, signature_status_response, transaction, MockClient,
+    adapter, adapter_with_mock_client, finalized_signature_status, signature_status_response,
+    signature_statuses_response, transaction, MockClient,
 };
+
+fn hash(index: u64) -> H512 {
+    let mut bytes = [0u8; 64];
+    bytes[..8].copy_from_slice(&index.to_be_bytes());
+    H512::from(bytes)
+}
+
+fn transaction_with_hashes(hashes: impl IntoIterator<Item = H512>) -> Transaction {
+    let mut tx = transaction();
+    tx.tx_hashes = hashes.into_iter().collect();
+    tx
+}
 
 #[tokio::test]
 async fn test_tx_status() {
@@ -54,6 +68,156 @@ async fn signature_status_provider_error_is_infrastructure_error() {
         status,
         Err(LanderError::ChainCommunicationError(_))
     ));
+}
+
+#[tokio::test]
+async fn transaction_statuses_share_one_rpc_batch() {
+    let mut client = MockClient::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 3)
+        .times(1)
+        .returning(|_| {
+            let mut confirmed = finalized_signature_status();
+            confirmed.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
+            Ok(signature_statuses_response(vec![
+                Some(finalized_signature_status()),
+                Some(confirmed),
+                None,
+            ]))
+        });
+    let adapter = adapter_with_mock_client(client);
+    let transactions = vec![transaction(), transaction(), transaction()];
+
+    let statuses = adapter.tx_statuses(&transactions).await;
+
+    assert_eq!(statuses.len(), transactions.len());
+    assert_eq!(statuses[0].as_ref().unwrap(), &TransactionStatus::Finalized);
+    assert_eq!(statuses[1].as_ref().unwrap(), &TransactionStatus::Included);
+    assert_eq!(
+        statuses[2].as_ref().unwrap(),
+        &TransactionStatus::PendingInclusion
+    );
+    assert_eq!(adapter.tx_status_batch_size(), 16);
+}
+
+#[tokio::test]
+async fn transaction_statuses_align_mixed_multi_hash_results() {
+    let mut client = MockClient::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 4)
+        .times(1)
+        .returning(|_| {
+            let mut confirmed = finalized_signature_status();
+            confirmed.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
+            let mut processed = finalized_signature_status();
+            processed.confirmation_status = Some(TransactionConfirmationStatus::Processed);
+            Ok(signature_statuses_response(vec![
+                None,
+                Some(confirmed),
+                Some(processed),
+                Some(finalized_signature_status()),
+            ]))
+        });
+    let adapter = adapter_with_mock_client(client);
+    let transactions = vec![
+        transaction_with_hashes([hash(1), hash(2)]),
+        transaction_with_hashes([hash(3), hash(4)]),
+        transaction_with_hashes([]),
+    ];
+
+    let statuses = adapter.tx_statuses(&transactions).await;
+
+    assert_eq!(statuses.len(), transactions.len());
+    assert_eq!(statuses[0].as_ref().unwrap(), &TransactionStatus::Included);
+    assert_eq!(statuses[1].as_ref().unwrap(), &TransactionStatus::Finalized);
+    assert_eq!(
+        statuses[2].as_ref().unwrap(),
+        &TransactionStatus::PendingInclusion
+    );
+}
+
+#[tokio::test]
+async fn transaction_statuses_split_at_256_signatures() {
+    let mut client = MockClient::new();
+    let mut sequence = Sequence::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 256)
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| Ok(signature_statuses_response(vec![None; 256])));
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 1)
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| {
+            Ok(signature_statuses_response(vec![Some(
+                finalized_signature_status(),
+            )]))
+        });
+    let adapter = adapter_with_mock_client(client);
+    let transaction = transaction_with_hashes((0..257).map(hash));
+
+    let statuses = adapter.tx_statuses(&[transaction]).await;
+
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].as_ref().unwrap(), &TransactionStatus::Finalized);
+}
+
+#[tokio::test]
+async fn transaction_statuses_surface_partial_rpc_failure() {
+    let mut client = MockClient::new();
+    let mut sequence = Sequence::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 256)
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| {
+            let mut confirmed = finalized_signature_status();
+            confirmed.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
+            Ok(signature_statuses_response(vec![Some(confirmed); 256]))
+        });
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 1)
+        .times(1)
+        .in_sequence(&mut sequence)
+        .returning(|_| Err(ChainCommunicationError::from_other_str("RPC unavailable")));
+    let adapter = adapter_with_mock_client(client);
+    let transactions = vec![
+        transaction_with_hashes((0..256).map(hash)),
+        transaction_with_hashes([hash(256)]),
+    ];
+
+    let statuses = adapter.tx_statuses(&transactions).await;
+
+    assert_eq!(statuses[0].as_ref().unwrap(), &TransactionStatus::Included);
+    assert!(matches!(statuses[1], Err(LanderError::NetworkError(_))));
+}
+
+#[tokio::test]
+async fn transaction_statuses_reject_short_response() {
+    let mut client = MockClient::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 2)
+        .times(1)
+        .returning(|_| Ok(signature_status_response(None)));
+    let adapter = adapter_with_mock_client(client);
+    let transactions = vec![
+        transaction_with_hashes([hash(1)]),
+        transaction_with_hashes([hash(2)]),
+    ];
+
+    let statuses = adapter.tx_statuses(&transactions).await;
+
+    assert!(statuses
+        .iter()
+        .all(|status| matches!(status, Err(LanderError::NetworkError(_)))));
 }
 
 #[test]

--- a/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_status.rs
+++ b/rust/main/lander/src/adapter/chains/sealevel/adapter/tests/tests_status.rs
@@ -45,7 +45,7 @@ async fn signature_status_uses_one_rpc_call() {
     client
         .expect_get_signature_statuses_with_history()
         .times(1)
-        .returning(|_| Ok(signature_status_response(None)));
+        .returning(|_| signature_status_response(None));
     let adapter = adapter_with_mock_client(client);
 
     let status = adapter.get_tx_hash_status(H512::zero()).await;
@@ -59,7 +59,11 @@ async fn signature_status_provider_error_is_infrastructure_error() {
     client
         .expect_get_signature_statuses_with_history()
         .times(1)
-        .returning(|_| Err(ChainCommunicationError::from_other_str("RPC unavailable")));
+        .returning(|_| {
+            vec![Err(ChainCommunicationError::from_other_str(
+                "RPC unavailable",
+            ))]
+        });
     let adapter = adapter_with_mock_client(client);
 
     let status = adapter.get_tx_hash_status(H512::zero()).await;
@@ -80,11 +84,11 @@ async fn transaction_statuses_share_one_rpc_batch() {
         .returning(|_| {
             let mut confirmed = finalized_signature_status();
             confirmed.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
-            Ok(signature_statuses_response(vec![
+            signature_statuses_response(vec![
                 Some(finalized_signature_status()),
                 Some(confirmed),
                 None,
-            ]))
+            ])
         });
     let adapter = adapter_with_mock_client(client);
     let transactions = vec![transaction(), transaction(), transaction()];
@@ -113,12 +117,12 @@ async fn transaction_statuses_align_mixed_multi_hash_results() {
             confirmed.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
             let mut processed = finalized_signature_status();
             processed.confirmation_status = Some(TransactionConfirmationStatus::Processed);
-            Ok(signature_statuses_response(vec![
+            signature_statuses_response(vec![
                 None,
                 Some(confirmed),
                 Some(processed),
                 Some(finalized_signature_status()),
-            ]))
+            ])
         });
     let adapter = adapter_with_mock_client(client);
     let transactions = vec![
@@ -147,17 +151,13 @@ async fn transaction_statuses_split_at_256_signatures() {
         .withf(|signatures| signatures.len() == 256)
         .times(1)
         .in_sequence(&mut sequence)
-        .returning(|_| Ok(signature_statuses_response(vec![None; 256])));
+        .returning(|_| signature_statuses_response(vec![None; 256]));
     client
         .expect_get_signature_statuses_with_history()
         .withf(|signatures| signatures.len() == 1)
         .times(1)
         .in_sequence(&mut sequence)
-        .returning(|_| {
-            Ok(signature_statuses_response(vec![Some(
-                finalized_signature_status(),
-            )]))
-        });
+        .returning(|_| signature_statuses_response(vec![Some(finalized_signature_status())]));
     let adapter = adapter_with_mock_client(client);
     let transaction = transaction_with_hashes((0..257).map(hash));
 
@@ -179,14 +179,18 @@ async fn transaction_statuses_surface_partial_rpc_failure() {
         .returning(|_| {
             let mut confirmed = finalized_signature_status();
             confirmed.confirmation_status = Some(TransactionConfirmationStatus::Confirmed);
-            Ok(signature_statuses_response(vec![Some(confirmed); 256]))
+            signature_statuses_response(vec![Some(confirmed); 256])
         });
     client
         .expect_get_signature_statuses_with_history()
         .withf(|signatures| signatures.len() == 1)
         .times(1)
         .in_sequence(&mut sequence)
-        .returning(|_| Err(ChainCommunicationError::from_other_str("RPC unavailable")));
+        .returning(|_| {
+            vec![Err(ChainCommunicationError::from_other_str(
+                "RPC unavailable",
+            ))]
+        });
     let adapter = adapter_with_mock_client(client);
     let transactions = vec![
         transaction_with_hashes((0..256).map(hash)),
@@ -206,7 +210,7 @@ async fn transaction_statuses_reject_short_response() {
         .expect_get_signature_statuses_with_history()
         .withf(|signatures| signatures.len() == 2)
         .times(1)
-        .returning(|_| Ok(signature_status_response(None)));
+        .returning(|_| signature_status_response(None));
     let adapter = adapter_with_mock_client(client);
     let transactions = vec![
         transaction_with_hashes([hash(1)]),
@@ -218,6 +222,34 @@ async fn transaction_statuses_reject_short_response() {
     assert!(statuses
         .iter()
         .all(|status| matches!(status, Err(LanderError::NetworkError(_)))));
+}
+
+#[tokio::test]
+async fn transaction_statuses_preserve_resolved_entries_with_ambiguous_sibling() {
+    let mut client = MockClient::new();
+    client
+        .expect_get_signature_statuses_with_history()
+        .withf(|signatures| signatures.len() == 3)
+        .times(1)
+        .returning(|_| {
+            vec![
+                Ok(Some(finalized_signature_status())),
+                Ok(Some(finalized_signature_status())),
+                Err(ChainCommunicationError::from_other_str("RPC unavailable")),
+            ]
+        });
+    let adapter = adapter_with_mock_client(client);
+    let transactions = vec![
+        transaction_with_hashes([hash(1)]),
+        transaction_with_hashes([hash(2)]),
+        transaction_with_hashes([hash(3)]),
+    ];
+
+    let statuses = adapter.tx_statuses(&transactions).await;
+
+    assert_eq!(statuses[0].as_ref().unwrap(), &TransactionStatus::Finalized);
+    assert_eq!(statuses[1].as_ref().unwrap(), &TransactionStatus::Finalized);
+    assert!(matches!(statuses[2], Err(LanderError::NetworkError(_))));
 }
 
 #[test]

--- a/rust/main/lander/src/adapter/core.rs
+++ b/rust/main/lander/src/adapter/core.rs
@@ -83,6 +83,23 @@ pub trait AdaptsChain: Send + Sync {
         Ok(status)
     }
 
+    /// Queries transaction statuses in an adapter-sized batch.
+    ///
+    /// The default preserves the existing per-transaction behavior. Adapters
+    /// with a native batch RPC can override this together with
+    /// [`Self::tx_status_batch_size`].
+    async fn tx_statuses(
+        &self,
+        txs: &[Transaction],
+    ) -> Vec<Result<TransactionStatus, LanderError>> {
+        join_all(txs.iter().map(|tx| self.tx_status(tx))).await
+    }
+
+    /// Number of transactions to pass to one [`Self::tx_statuses`] call.
+    fn tx_status_batch_size(&self) -> usize {
+        1
+    }
+
     /// Return true if the transaction can be resubmitted (such as by escalating the gas price). Called in the Inclusion Stage (PayloadDispatcher).
     /// Defaults to true, since most chains don't have special rules for tx resubmission.
     async fn tx_ready_for_resubmission(&self, _tx: &Transaction) -> bool {

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -23,7 +23,10 @@ use crate::{
 
 use super::{
     building_stage::BuildingStageQueue,
-    utils::{buffer_ordered_bounded, call_until_success_or_nonretryable_error},
+    utils::{
+        buffer_ordered_bounded, call_until_success_or_nonretryable_error,
+        read_transaction_status_batch, FinalizedStatusRead,
+    },
     DispatcherState,
 };
 
@@ -157,11 +160,29 @@ impl FinalityStage {
         super::utils::sort_transactions_for_mutation(&mut pool_snapshot);
         info!(pool_size=?pool_snapshot.len() , "Processing transactions in finality pool");
 
-        let status_reads = pool_snapshot.into_iter().map(|snapshot_tx| async move {
-            let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
-            (snapshot_tx, checked_tx, status)
-        });
-        let status_reads = buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY);
+        let status_batch_size = state
+            .adapter
+            .tx_status_batch_size()
+            .clamp(1, STATUS_READ_CONCURRENCY);
+        let status_reads = if status_batch_size == 1 {
+            let status_reads = pool_snapshot.into_iter().map(|snapshot_tx| async move {
+                let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
+                (snapshot_tx, checked_tx, status)
+            });
+            buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY).boxed()
+        } else {
+            let status_batch_concurrency = STATUS_READ_CONCURRENCY.div_ceil(status_batch_size);
+            let status_batches = pool_snapshot
+                .chunks(status_batch_size)
+                .map(<[Transaction]>::to_vec)
+                .collect::<Vec<_>>();
+            let status_reads = status_batches.into_iter().map(|batch| {
+                read_transaction_status_batch(state, batch, FinalizedStatusRead::TrustPersisted)
+            });
+            buffer_ordered_bounded(status_reads, status_batch_concurrency)
+                .flat_map(futures_util::stream::iter)
+                .boxed()
+        };
         futures_util::pin_mut!(status_reads);
 
         while let Some((snapshot_tx, checked_tx, status)) = status_reads.next().await {

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -20,7 +20,10 @@ use crate::{
 };
 
 use super::{
-    utils::{buffer_ordered_bounded, call_until_success_or_nonretryable_error},
+    utils::{
+        buffer_ordered_bounded, call_until_success_or_nonretryable_error,
+        read_transaction_status_batch, FinalizedStatusRead,
+    },
     DispatcherState,
 };
 
@@ -198,11 +201,20 @@ impl InclusionStage {
             .filter(|tx| Self::tx_ready_for_processing(base_interval, now, tx))
             .collect::<Vec<_>>();
         super::utils::sort_transactions_for_mutation(&mut eligible_txs);
-        let status_reads = eligible_txs.into_iter().map(|snapshot_tx| async move {
-            let (checked_tx, status) = Self::read_tx_status(snapshot_tx.clone(), state).await;
-            (snapshot_tx, checked_tx, status)
-        });
-        let status_reads = buffer_ordered_bounded(status_reads, STATUS_READ_CONCURRENCY);
+        let status_batch_size = state
+            .adapter
+            .tx_status_batch_size()
+            .clamp(1, STATUS_READ_CONCURRENCY);
+        let status_batch_concurrency = STATUS_READ_CONCURRENCY.div_ceil(status_batch_size);
+        let status_batches = eligible_txs
+            .chunks(status_batch_size)
+            .map(<[Transaction]>::to_vec)
+            .collect::<Vec<_>>();
+        let status_reads = status_batches
+            .into_iter()
+            .map(|batch| read_transaction_status_batch(state, batch, FinalizedStatusRead::Query));
+        let status_reads = buffer_ordered_bounded(status_reads, status_batch_concurrency);
+        let status_reads = status_reads.flat_map(futures_util::stream::iter);
         futures_util::pin_mut!(status_reads);
 
         let result = async {
@@ -279,20 +291,6 @@ impl InclusionStage {
             domain,
         );
         result
-    }
-
-    #[instrument(
-        skip_all,
-        name = "InclusionStage::read_tx_status",
-        fields(tx_uuid = ?tx.uuid, tx_status = ?tx.status, payloads = ?tx.payload_details)
-    )]
-    async fn read_tx_status(
-        mut tx: Transaction,
-        state: &DispatcherState,
-    ) -> (Transaction, Result<TransactionStatus, LanderError>) {
-        tx.last_status_check = Some(chrono::Utc::now());
-        let status = state.adapter.tx_status(&tx).await;
-        (tx, status)
     }
 
     #[instrument(skip_all, fields(?domain))]

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage/tests.rs
@@ -395,6 +395,51 @@ async fn test_status_provider_error_keeps_tx_for_later_retry() {
 }
 
 #[tokio::test]
+async fn finalized_reprocessed_tx_is_rechecked_and_resubmitted() {
+    let mut mock_adapter = MockAdapter::new();
+    mock_adapter
+        .expect_estimated_block_time()
+        .return_const(Duration::from_secs(1));
+    mock_adapter
+        .expect_tx_status()
+        .withf(|tx| tx.status == TransactionStatus::Finalized)
+        .once()
+        .returning(|_| Ok(TransactionStatus::PendingInclusion));
+    mock_adapter
+        .expect_tx_ready_for_resubmission()
+        .once()
+        .return_const(true);
+    mock_adapter.expect_simulate_tx().returning(|_| Ok(vec![]));
+    mock_adapter
+        .expect_estimate_tx()
+        .once()
+        .returning(|_| Ok(()));
+    mock_adapter.expect_submit().once().returning(|_| Ok(()));
+    mock_adapter
+        .expect_update_vm_specific_metrics()
+        .once()
+        .returning(|_, _| ());
+
+    let (state, pool) = reprocess_test_state(mock_adapter);
+    let tx = dummy_tx(Vec::new(), TransactionStatus::Finalized);
+    state.store_tx(&tx).await;
+    pool.lock().await.insert(tx.uuid.clone(), tx.clone());
+    let (finality_stage_sender, mut finality_stage_receiver) = mpsc::channel(1);
+
+    InclusionStage::process_txs_step(&pool, &finality_stage_sender, &state, "test")
+        .await
+        .unwrap();
+
+    let reprocessed_tx = pool.lock().await.get(&tx.uuid).cloned().unwrap();
+    assert_eq!(reprocessed_tx.status, TransactionStatus::Mempool);
+    assert_eq!(
+        reprocessed_tx.submission_attempts,
+        tx.submission_attempts + 1
+    );
+    assert!(finality_stage_receiver.try_recv().is_err());
+}
+
+#[tokio::test]
 async fn test_status_provider_error_preserves_latest_persisted_status() {
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_for_mock = calls.clone();

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -33,6 +33,65 @@ pub(super) fn sort_transactions_for_mutation(transactions: &mut [Transaction]) {
     });
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum FinalizedStatusRead {
+    Query,
+    TrustPersisted,
+}
+
+pub(super) async fn read_transaction_status_batch(
+    state: &DispatcherState,
+    snapshot_txs: Vec<Transaction>,
+    finalized_status_read: FinalizedStatusRead,
+) -> Vec<(
+    Transaction,
+    Transaction,
+    Result<TransactionStatus, LanderError>,
+)> {
+    let mut checked_txs = snapshot_txs.clone();
+    let checked_at = chrono::Utc::now();
+    for tx in &mut checked_txs {
+        tx.last_status_check = Some(checked_at);
+    }
+    let mut query_txs = Vec::new();
+    let status_slots = checked_txs
+        .iter()
+        .map(|tx| {
+            if tx.status == TransactionStatus::Finalized
+                && matches!(finalized_status_read, FinalizedStatusRead::TrustPersisted)
+            {
+                Some(Ok(TransactionStatus::Finalized))
+            } else {
+                query_txs.push(tx.clone());
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    let queried_statuses = state.adapter.tx_statuses(&query_txs).await;
+    assert_eq!(
+        queried_statuses.len(),
+        query_txs.len(),
+        "adapter returned a mismatched transaction status count"
+    );
+    let mut queried_statuses = queried_statuses.into_iter();
+    let statuses = status_slots
+        .into_iter()
+        .map(|status| {
+            status.unwrap_or_else(|| {
+                queried_statuses
+                    .next()
+                    .expect("queried transaction status count was checked")
+            })
+        })
+        .collect::<Vec<_>>();
+    snapshot_txs
+        .into_iter()
+        .zip(checked_txs)
+        .zip(statuses)
+        .map(|((snapshot_tx, checked_tx), status)| (snapshot_tx, checked_tx, status))
+        .collect()
+}
+
 pub async fn call_until_success_or_nonretryable_error<F, T, Fut>(
     f: F,
     action: &str,

--- a/rust/main/lander/src/tests/svm/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/svm/tests_inclusion_stage.rs
@@ -124,7 +124,7 @@ async fn test_svm_inclusion_gas_spike() {
             } else {
                 processed_signature_status()
             };
-            Ok(signature_statuses_response(vec![Some(status)]))
+            signature_statuses_response(vec![Some(status)])
         });
 
     let mut submitter = MockSubmitter::new();
@@ -200,7 +200,7 @@ async fn test_svm_inclusion_escalate_but_old_hash_finalized() {
             } else {
                 assert_eq!(signatures, &[signature1, signature2]);
             }
-            Ok(signature_statuses_response(
+            signature_statuses_response(
                 signatures
                     .iter()
                     .map(|signature| {
@@ -211,7 +211,7 @@ async fn test_svm_inclusion_escalate_but_old_hash_finalized() {
                         })
                     })
                     .collect(),
-            ))
+            )
         });
 
     let oracle = MockOracle::new();
@@ -676,12 +676,7 @@ fn mock_get_signature_statuses_finalized(mock_provider: &mut MockClient, times: 
         .expect_get_signature_statuses_with_history()
         .times(times)
         .returning(|signatures| {
-            Ok(signature_statuses_response(vec![
-                Some(
-                    finalized_signature_status()
-                );
-                signatures.len()
-            ]))
+            signature_statuses_response(vec![Some(finalized_signature_status()); signatures.len()])
         });
 }
 

--- a/rust/main/lander/src/tests/svm/tests_inclusion_stage.rs
+++ b/rust/main/lander/src/tests/svm/tests_inclusion_stage.rs
@@ -12,15 +12,15 @@ use solana_sdk::{
 };
 use solana_system_interface::instruction as system_instruction;
 use tokio::{select, sync::mpsc};
-use tracing::info;
 use tracing_test::traced_test;
 
 use crate::{
     adapter::{
         chains::sealevel::{
             adapter::tests::tests_common::{
-                finalized_signature_status, processed_signature_status, signature_status_response,
-                svm_block, MockClient, MockOracle, MockSubmitter, MockSvmProvider,
+                finalized_signature_status, processed_signature_status,
+                signature_statuses_response, svm_block, MockClient, MockOracle, MockSubmitter,
+                MockSvmProvider,
             },
             transaction::{Precursor, TransactionFactory},
             SealevelAdapter,
@@ -44,7 +44,7 @@ async fn test_svm_inclusion_happy_path() {
 
     let mut client = MockClient::new();
     mock_simulate_transaction(&mut client);
-    mock_finalized_signature_status(&mut client, 1);
+    mock_get_signature_statuses_finalized(&mut client, 1);
     mock_get_block_with_commitment(&mut client);
     let oracle = MockOracle::new();
     let mut provider = MockSvmProvider::new();
@@ -119,16 +119,12 @@ async fn test_svm_inclusion_gas_spike() {
         .returning(move |signatures| {
             assert_eq!(signatures.len(), 1);
             status_call_counter += 1;
-            info!(
-                ?status_call_counter,
-                "calling get_signature_statuses_with_history"
-            );
             let status = if status_call_counter == 4 {
                 finalized_signature_status()
             } else {
                 processed_signature_status()
             };
-            Ok(signature_status_response(Some(status)))
+            Ok(signature_statuses_response(vec![Some(status)]))
         });
 
     let mut submitter = MockSubmitter::new();
@@ -192,27 +188,30 @@ async fn test_svm_inclusion_escalate_but_old_hash_finalized() {
     mock_simulate_transaction(&mut client);
     mock_get_block_with_commitment(&mut client);
 
-    // The first signature becomes finalized on its third status check while the
-    // replacement signature remains processed.
-    let mut signature1_status_checks = 0;
+    // Simulate the first signature being finalized after two resubmission scans.
+    let mut status_call_counter = 0;
     client
         .expect_get_signature_statuses_with_history()
-        .times(5)
+        .times(3)
         .returning(move |signatures| {
-            assert_eq!(signatures.len(), 1);
-            let signature = signatures[0];
-            let status = if signature == signature1 {
-                signature1_status_checks += 1;
-                if signature1_status_checks == 3 {
-                    finalized_signature_status()
-                } else {
-                    processed_signature_status()
-                }
+            status_call_counter += 1;
+            if status_call_counter == 1 {
+                assert_eq!(signatures, &[signature1]);
             } else {
-                assert_eq!(signature, signature2);
-                processed_signature_status()
-            };
-            Ok(signature_status_response(Some(status)))
+                assert_eq!(signatures, &[signature1, signature2]);
+            }
+            Ok(signature_statuses_response(
+                signatures
+                    .iter()
+                    .map(|signature| {
+                        Some(if status_call_counter == 3 && *signature == signature1 {
+                            finalized_signature_status()
+                        } else {
+                            processed_signature_status()
+                        })
+                    })
+                    .collect(),
+            ))
         });
 
     let oracle = MockOracle::new();
@@ -303,7 +302,7 @@ async fn test_svm_inclusion_send_returns_blockhash_not_found() {
     let mut client = MockClient::new();
     mock_simulate_transaction(&mut client);
     mock_get_block_with_commitment(&mut client);
-    mock_finalized_signature_status(&mut client, 1);
+    mock_get_signature_statuses_finalized(&mut client, 1);
 
     let oracle = MockOracle::new();
     let mut provider = MockSvmProvider::new();
@@ -374,7 +373,7 @@ async fn test_svm_failure_to_estimate_costs_causes_tx_to_be_dropped() {
     let mut client = MockClient::new();
     mock_simulate_transaction(&mut client);
     mock_get_block_with_commitment(&mut client);
-    mock_finalized_signature_status(&mut client, 0);
+    mock_get_signature_statuses_finalized(&mut client, 0);
 
     let oracle = MockOracle::new();
     let mut provider = MockSvmProvider::new();
@@ -672,15 +671,17 @@ fn mock_confirm_transaction(mock_submitter: &mut MockSubmitter) {
         .returning(move |_, _| Ok(true));
 }
 
-fn mock_finalized_signature_status(mock_provider: &mut MockClient, times: usize) {
+fn mock_get_signature_statuses_finalized(mock_provider: &mut MockClient, times: usize) {
     mock_provider
         .expect_get_signature_statuses_with_history()
         .times(times)
         .returning(|signatures| {
-            assert_eq!(signatures.len(), 1);
-            Ok(signature_status_response(
-                Some(finalized_signature_status()),
-            ))
+            Ok(signature_statuses_response(vec![
+                Some(
+                    finalized_signature_status()
+                );
+                signatures.len()
+            ]))
         });
 }
 

--- a/rust/main/lander/tests/integration_sealevel.rs
+++ b/rust/main/lander/tests/integration_sealevel.rs
@@ -7,7 +7,7 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use mockall::mock;
-use solana_client::rpc_response::{Response, RpcResponseContext, RpcSimulateTransactionResult};
+use solana_client::rpc_response::RpcSimulateTransactionResult;
 use solana_commitment_config::CommitmentConfig;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_sdk::{
@@ -53,7 +53,7 @@ mock! {
         async fn get_block_with_commitment(&self, slot: u64, commitment: CommitmentConfig) -> ChainResult<UiConfirmedBlock>;
         async fn get_transaction(&self, signature: Signature) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
         async fn get_transaction_with_commitment(&self, signature: Signature, commitment: CommitmentConfig) -> ChainResult<EncodedConfirmedTransactionWithStatusMeta>;
-        async fn get_signature_statuses_with_history(&self, signatures: &[Signature]) -> ChainResult<Response<Vec<Option<SealevelTransactionStatus>>>>;
+        async fn get_signature_statuses_with_history(&self, signatures: &[Signature]) -> Vec<ChainResult<Option<SealevelTransactionStatus>>>;
         async fn simulate_transaction(&self, transaction: &SealevelLegacyTransaction) -> ChainResult<RpcSimulateTransactionResult>;
         async fn simulate_versioned_transaction(&self, transaction: &SealevelVersionedTransaction) -> ChainResult<RpcSimulateTransactionResult>;
     }
@@ -227,15 +227,7 @@ fn create_sealevel_client() -> MockClient {
         .returning(move |_, _| Ok(svm_block()));
     client
         .expect_get_signature_statuses_with_history()
-        .returning(move |_| {
-            Ok(Response {
-                context: RpcResponseContext {
-                    slot: 43,
-                    api_version: None,
-                },
-                value: vec![Some(finalized_signature_status())],
-            })
-        });
+        .returning(move |_| vec![Ok(Some(finalized_signature_status()))]);
     let result_clone = result.clone();
     client
         .expect_simulate_transaction()


### PR DESCRIPTION
## Problem

#9398 bounds Lander status reads to 16 concurrent transactions, and #9428 replaces each Sealevel transaction's commitment probes with one history-aware status operation. The remaining burst was still one logical operation per transaction: 16 operations for a full scan wave.

## Solution

- add an opt-in adapter transaction-status batch API; non-batching adapters retain batch size one
- group 16 Sealevel transactions, flatten their resubmission signatures into history-aware requests, and map every response back to its transaction before mutation
- cap each Solana request at 256 signatures and split larger flattened batches
- preserve deterministic mutation order and stale-snapshot checks
- make persisted-finalized short-circuiting an explicit finality-stage policy; inclusion/reorg recovery always re-queries finalized transactions and can resubmit them
- require response cardinality to equal request cardinality, at both fallback and adapter boundaries; truncated responses and transport failures remain retryable infrastructure errors instead of false missing signatures
- return fallback outcomes per signature, preserving resolved siblings when another signature remains ambiguous after a provider failure

## Expected improvement

For one signature per transaction and one provider:

- one 16-transaction wave: 16 -> 1 physical request (15 fewer, 93.75%) after #9428
- cumulative from the pre-#9428 ceiling: up to 48 -> 1 (47 fewer, 97.9%)
- `N` transaction reads: `N` -> `ceil(N / 16)` requests

With `P` fallback providers, each non-finalized/missing batch may fan out to at most `P` physical requests so provider results can be merged correctly. Thus a full 16-transaction wave becomes one logical fallback operation and `1..P` physical requests, rather than 16 logical operations and up to `16P`. Transactions with enough resubmission signatures may require multiple 256-signature chunks. Partial provider failures are merged into per-signature results without retrying the batch as individual signatures, so the 256-signature cap cannot create a 256-request recovery fanout. These are analytical bounds, not measured production savings.

## Correctness

- non-Sealevel adapters keep their existing per-transaction behavior
- `searchTransactionHistory=true` preserves rooted/archive lookup
- finality-stage scans can trust persisted finality, while inclusion-stage reorg recovery cannot
- malformed/truncated batches never synthesize `PendingInclusion` or trigger accidental resubmission
- a known status from any healthy provider remains usable even when a sibling signature is unresolved because another provider failed; only the ambiguous transaction is retried later
- result alignment covers mixed statuses, zero/multiple hashes, 256+1 splitting, partial RPC failure, resolved siblings beside an ambiguous result, and short responses

## Verification

- focused Sealevel status tests: 11 passed
- Sealevel fallback merge tests: 6 passed
- finalized reprocessed -> queried -> `PendingInclusion` -> resubmitted regression: passed
- broader Sealevel Lander tests: 40 passed
- SVM inclusion status scenarios: 5 passed
- strict clippy for `hyperlane-core`, `hyperlane-sealevel`, and `lander`
- `integration_sealevel` compiled with the `integration_test` feature
- Rust formatting, diff check, and repository hooks
- exact head: `3da06146a22a2507e0cfb3ef76bc63d57c1aa74e`

## Canary

Compare provider request rate/fanout, errors/rate limits, status-scan duration, inclusion/finality pool lengths, resubmissions, drops, and delivery latency. Expected direction: fewer logical status operations with unchanged transaction outcomes.

Master performance epic: #9386.