### PR TITLE
perf(sealevel): omit transactions from block info reads

### DIFF
--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -628,7 +628,7 @@ impl SealevelProvider {
     }
 
     async fn block_info_by_height(&self, slot: u64) -> Result<BlockInfo, ChainCommunicationError> {
-        let confirmed_block = self.rpc_client.get_block(slot).await?;
+        let confirmed_block = self.rpc_client.get_block_info(slot).await?;
 
         let block_hash = decode_h256(&confirmed_block.blockhash)?;
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -21,8 +21,8 @@ use solana_sdk::{
     transaction::{Transaction, VersionedTransaction},
 };
 use solana_transaction_status::{
-    EncodedConfirmedTransactionWithStatusMeta, TransactionStatus, UiConfirmedBlock,
-    UiTransactionEncoding,
+    EncodedConfirmedTransactionWithStatusMeta, TransactionDetails, TransactionStatus,
+    UiConfirmedBlock, UiTransactionEncoding,
 };
 
 use hyperlane_core::{rpc_clients::BlockNumberGetter, ChainCommunicationError, ChainResult, U256};
@@ -132,6 +132,16 @@ impl SealevelRpcClient {
     pub async fn get_block(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
         self.get_block_with_commitment(slot, CommitmentConfig::finalized())
             .await
+    }
+
+    /// Get block metadata without downloading transactions.
+    pub async fn get_block_info(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
+        self.0
+            .get_block_with_config(slot, block_info_config(CommitmentConfig::finalized()))
+            .await
+            .map_err(Box::new)
+            .map_err(HyperlaneSealevelError::ClientError)
+            .map_err(Into::into)
     }
 
     /// get block_height
@@ -411,6 +421,13 @@ fn block_config(commitment: CommitmentConfig) -> RpcBlockConfig {
         max_supported_transaction_version: Some(0),
         rewards: Some(false),
         ..Default::default()
+    }
+}
+
+fn block_info_config(commitment: CommitmentConfig) -> RpcBlockConfig {
+    RpcBlockConfig {
+        transaction_details: Some(TransactionDetails::None),
+        ..block_config(commitment)
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
+use solana_transaction_status::TransactionDetails;
 
-use super::block_config;
+use super::{block_config, block_info_config};
 use crate::client::SealevelRpcClient;
 
 //#[tokio::test]
@@ -32,4 +33,12 @@ fn get_block_config_disables_rewards() {
     assert_eq!(config.rewards, Some(false));
     assert_eq!(config.max_supported_transaction_version, Some(0));
     assert_eq!(config.commitment, Some(CommitmentConfig::finalized()));
+}
+
+#[test]
+fn get_block_info_config_omits_transactions() {
+    let config = block_info_config(CommitmentConfig::finalized());
+
+    assert_eq!(config.transaction_details, Some(TransactionDetails::None));
+    assert_eq!(config.rewards, Some(false));
 }

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
@@ -256,6 +256,16 @@ impl SealevelFallbackRpcClient {
         SealevelFallbackRpcClient::new(fallback)
     }
 
+    /// Requests block metadata without downloading transactions.
+    pub async fn get_block_info(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
+        self.fallback_provider
+            .call(move |client| {
+                let future = async move { client.get_block_info(slot).await };
+                Box::pin(future)
+            })
+            .await
+    }
+
     /// confirm transaction with given commitment
     pub async fn confirm_transaction_with_commitment(
         &self,


### PR DESCRIPTION
## Problem

Periodic Sealevel `BlockInfo` and chain-metrics reads call `getBlock` with full transaction bodies even though their consumers only use block metadata. Mailbox and IGP indexing do need transaction details, so changing the shared indexing request would be incorrect.

The `solanatestnet` validator made about 7.4k `getBlock` calls over five days while storing one Merkle event, matching the once-per-minute metrics path. For observed slot `437311865`, the full response was 24,915,096 bytes; the same request with `transactionDetails: none` returned the fields `BlockInfo` consumes in 232 bytes.

## Solution

- add a dedicated `get_block_info` request with `transactionDetails: none`
- use it only for `BlockInfo` and periodic chain metrics
- preserve full transaction responses for mailbox and IGP log-metadata indexing
- retain the existing finalized commitment, block configuration and provider fallback behavior

## Expected improvement

For the observed slot, response size changed from 24,915,096 to 232 bytes: about 107,393x / 99.9991% smaller. This is a measured single-block result, not a fleet-wide average; savings vary with block contents.

RPC request count is unchanged. The expected benefit is lower response bytes, allocation pressure and egress on the metrics path, not centralized indexing or fewer calls.

## Correctness

- the optimized path returns the block hash, previous block hash, height and timestamp consumed by `BlockInfo`
- mailbox and IGP indexing retain full transaction payloads
- finality, fallback and unavailable-slot behavior are unchanged
- a focused regression verifies that transactions are omitted while the existing rewards/finality configuration is preserved

## Verification

- `cargo test -p hyperlane-sealevel --lib` (48 passed)
- `cargo clippy -p hyperlane-sealevel --lib -- -D warnings`
- `cargo fmt -p hyperlane-sealevel -- --check`
- previous head exact-head Rust unit, lint, coverage and Sealevel e2e checks passed; rebased-head CI is running
- exact head: `3efdb8860dc29843687cfdf9c887a9e45937a633`

`cargo clippy --all-targets` remains blocked by existing `unwrap_used` errors in unrelated Sealevel tests.

## Canary rollout — 2026-09-02

Built exact PR head `cb67cf5e5538dbf18d49f1a2d3f87e5a929d1f13` in [rust-docker run 33632452079](https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33632452079):

- image: `ghcr.io/hyperlane-xyz/hyperlane-agent:cb67cf5-20260902-125321`
- digest: `sha256:a802b8ed7c3a7af276114bbd3224a4c10df7454d3f211342838a9e7ce601ef26`
- canary: `testnet4/solanatestnet-validator-hyperlane-agent-validator-0`
- observation: `12:58:57Z`–`13:29:22Z` (30m25s)

The exact digest remained Ready with zero restarts. Over the window:

- 33 successful periodic `getBlock` calls exercised the optimized path; one unavailable-slot response followed existing warning/fallback behavior and there were no error-level logs
- working set stayed 21.05–21.34 MiB (21.09 MiB average)
- RSS stayed 19.90–19.94 MiB (19.93 MiB average), with no per-request allocation steps
- chain height advanced from 437,318,751 to 437,329,708 and the Merkle-tree cursor from 437,318,755 to 437,329,675
- checkpoint remained 873 because no new messages were observed or processed

Immediately before rollout, the old process used 276.9 MiB working set / 275.1 MiB RSS. The lower post-restart baseline is directional rather than attributable to this PR because the prior image was older. The direct canary evidence is flat RSS across 34 attempted block reads with continued cursor liveness.

This was an image-only StatefulSet canary. Helm still records the previous image, so a future deployment will revert it unless this image is promoted. The duplicate GCP-managed `validator-testnet4` validator was intentionally unchanged.

Master performance epic: #9386.

## Follow-up

Stacked PR #9442 removes the periodic metrics-path `getBlock` entirely by changing `ChainInfo` to expose only the height metrics consume. In the measured current-production Sealevel window, that removes 35 calls per chain per 35 minutes across `eclipsemainnet`, `solanamainnet`, and `sonicsvm`: 105 calls / 35 minutes, or **180 calls/hour**. It also structurally removes one redundant detail request per metrics update on Aleo, Cosmos, Radix, and Starknet; #9442 documents the per-protocol accounting and does not claim unmeasured fleet totals.

This PR remains useful for actual `BlockInfo` consumers such as scraper persistence, which still need real block metadata.