### PR TITLE
fix(widgets): support custom Starknet chains

### DIFF
--- a/.changeset/soft-starknet-paymasters.md
+++ b/.changeset/soft-starknet-paymasters.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/widgets': patch
+---
+
+A Starknet paymaster provider factory was added for custom chains without paymaster metadata.

--- a/typescript/widgets/src/stories/MultiProtocolWalletModal.stories.tsx
+++ b/typescript/widgets/src/stories/MultiProtocolWalletModal.stories.tsx
@@ -27,6 +27,7 @@ import { ConnectWalletButton } from '../walletIntegrations/ConnectWalletButton.j
 import { MultiProtocolWalletModal } from '../walletIntegrations/MultiProtocolWalletModal.js';
 import { getCosmosKitChainConfigs } from '../walletIntegrations/cosmos.js';
 import { getWagmiChainConfigs } from '../walletIntegrations/ethereum.js';
+import { starknetPaymasterProvider } from '../walletIntegrations/starknet.js';
 
 const multiProvider = new MultiProtocolProvider({
   ethereum,
@@ -114,7 +115,11 @@ function SolanaWalletProvider({ children }: PropsWithChildren<unknown>) {
 
 function StarknetWalletProvider({ children }: PropsWithChildren<unknown>) {
   return (
-    <StarknetConfig chains={[sepolia]} provider={publicProvider()}>
+    <StarknetConfig
+      chains={[sepolia]}
+      provider={publicProvider()}
+      paymasterProvider={starknetPaymasterProvider}
+    >
       {children}
     </StarknetConfig>
   );

--- a/typescript/widgets/src/walletIntegrations/starknet.test.ts
+++ b/typescript/widgets/src/walletIntegrations/starknet.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+
+import type { Chain } from '@starknet-react/chains';
+
+import { starknetPaymasterProvider } from './starknet.js';
+
+const chain: Chain = {
+  id: 1n,
+  name: 'Custom Starknet chain',
+  network: 'custom',
+  nativeCurrency: {
+    address: '0x0',
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: { http: ['https://default.rpc.example'] },
+    public: { http: ['https://public.rpc.example'] },
+  },
+  paymasterRpcUrls: {},
+};
+
+describe('starknetPaymasterProvider', () => {
+  it('supports custom chains without paymaster metadata', () => {
+    const provider = starknetPaymasterProvider(chain);
+
+    assert.equal(provider?.nodeUrl, 'https://public.rpc.example');
+  });
+
+  it('prefers a configured AVNU paymaster endpoint', () => {
+    const provider = starknetPaymasterProvider({
+      ...chain,
+      paymasterRpcUrls: {
+        avnu: { http: ['https://paymaster.example'] },
+      },
+    });
+
+    assert.equal(provider?.nodeUrl, 'https://paymaster.example');
+  });
+});

--- a/typescript/widgets/src/walletIntegrations/starknet.ts
+++ b/typescript/widgets/src/walletIntegrations/starknet.ts
@@ -1,5 +1,6 @@
 import { Chain } from '@starknet-react/chains';
 import {
+  paymasterRpcProvider,
   useAccount,
   useSendTransaction,
   useSwitchChain,
@@ -169,3 +170,19 @@ export function getStarknetChains(
     chainMetadataToStarknetChain,
   );
 }
+
+/**
+ * Creates the paymaster factory required by Starknet React v5. Hyperlane
+ * transactions do not use paymasters, so custom chains can fall back to their
+ * normal RPC without crashing during context initialization. Paymaster calls
+ * on chains without paymaster support still fail at the RPC boundary.
+ */
+export const starknetPaymasterProvider = paymasterRpcProvider({
+  rpc: (chain) => {
+    const nodeUrl =
+      chain.paymasterRpcUrls.avnu?.http[0] ??
+      chain.rpcUrls.public.http[0] ??
+      chain.rpcUrls.default.http[0];
+    return nodeUrl ? { nodeUrl } : null;
+  },
+});


### PR DESCRIPTION
### Description

`@starknet-react/core@5.0.3` defaults to AVNU and assumes every configured chain has `paymasterRpcUrls.avnu.http`. Hyperlane-generated custom chains correctly omit unsupported paymaster metadata, so consumers crash during `StarknetConfig` initialization before rendering.

This exports `starknetPaymasterProvider` from the widgets Starknet integration. It prefers a configured AVNU endpoint and otherwise uses the chain RPC as the required inert provider. Hyperlane widget transactions do not invoke paymaster methods; unsupported paymaster calls still fail at the RPC boundary.

The widgets story now demonstrates the required configuration. Unit tests cover custom-chain fallback and configured AVNU endpoints.

Soft follow-on to #9357 and hyperlane-xyz/hyperlane-warp-ui-template#1231.

### Drive-by changes

None.

### Related issues

- WUI failure: https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/actions/runs/33641031230/job/100284681958

### Backward compatibility

Yes. Additive widgets export; no infrastructure implications.

### Testing

- `pnpm exec turbo run build --filter=@hyperlane-xyz/widgets^...` (16/16)
- `pnpm -C typescript/widgets test` (10 passing)
- `pnpm -C typescript/widgets build:ts`
- `pnpm -C typescript/widgets lint` (one pre-existing Cosmos hooks warning)
- `pnpm -C typescript/widgets exec oxfmt --check ./src`
- `pnpm changeset status`
- `git diff --check`
