### PR TITLE
feat: add LayerZero V2 hook ISM SDK integration

### DIFF
--- a/.changeset/layerzero-v2-hook-isms.md
+++ b/.changeset/layerzero-v2-hook-isms.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/core': minor
+---
+
+Added LayerZero V2 callback and CCIP-read combined hook/ISM contracts.

--- a/.changeset/layerzero-v2-sdk-integration.md
+++ b/.changeset/layerzero-v2-sdk-integration.md
@@ -1,0 +1,7 @@
+---
+'@hyperlane-xyz/sdk': minor
+'@hyperlane-xyz/relayer': minor
+'@hyperlane-xyz/cli': patch
+---
+
+Added LayerZero V2 callback and CCIP-read hook/ISM deployment, configuration, and relay support.

--- a/solidity/build-tron.sh
+++ b/solidity/build-tron.sh
@@ -9,9 +9,11 @@ if [ ! -d dependencies/@openzeppelin-contracts-4.9.3 ]; then
 fi
 pnpm version:update
 
-# Apply Tron patches in memory. Retain Solidity artifacts/cache so Hardhat only
-# recompiles affected compilation units and removes obsolete artifacts.
-pnpm hardhat-tron compile --no-typechain
+# Apply Tron patches in memory. Compile core and Warp entrypoints separately
+# because the complete repository exceeds tron-solc's WASM input limit. Both
+# passes retain their outputs in the same artifact tree.
+TRON_BUILD_TARGET=core pnpm hardhat-tron compile --force --no-typechain
+TRON_BUILD_TARGET=warp pnpm hardhat-tron compile --force --no-typechain
 
 # Rebuild bindings from surviving artifacts so deleted/renamed contracts cannot
 # leave stale exports behind.

--- a/solidity/contracts/hooks/layerzero/AbstractLayerZeroV2HookIsm.sol
+++ b/solidity/contracts/hooks/layerzero/AbstractLayerZeroV2HookIsm.sol
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {ILayerZeroEndpointV2, MessagingFee as LayerZeroMessagingFee, MessagingParams as LayerZeroMessagingParams, MessagingReceipt as LayerZeroMessagingReceipt, Origin as LayerZeroOrigin} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {ILayerZeroReceiver} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol";
+import {SetConfigParam as LayerZeroSetConfigParam} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
+import {Router} from "../../client/Router.sol";
+import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
+import {Message} from "../../libs/Message.sol";
+import {LayerZeroMessage} from "../../libs/LayerZeroMessage.sol";
+import {StandardHookMetadata} from "../libs/StandardHookMetadata.sol";
+import {AbstractPostDispatchHook} from "../libs/AbstractPostDispatchHook.sol";
+
+// LayerZero EID mappings are a translation table, not Hyperlane domain config.
+// solhint-disable-next-line hyperlane/enumerable-domain-mapping
+abstract contract AbstractLayerZeroV2HookIsm is
+    Router,
+    AbstractPostDispatchHook,
+    ILayerZeroReceiver
+{
+    using Message for bytes;
+    using StandardHookMetadata for bytes;
+
+    // ============ Types ============
+
+    struct RemoteLayerZeroConfig {
+        uint32 eid;
+    }
+
+    struct RemoteRouterEnrollment {
+        uint32 domain;
+        bytes32 router;
+        uint32 eid;
+        address sendLibrary;
+        address receiveLibrary;
+        uint256 receiveLibraryGracePeriod;
+        address receiveLibraryTimeout;
+        uint256 receiveLibraryTimeoutExpiry;
+        LayerZeroSetConfigParam[] sendConfig;
+        LayerZeroSetConfigParam[] receiveConfig;
+    }
+
+    struct RemoteRouterConfigUpdate {
+        uint32 domain;
+        bytes32 router;
+        address receiveLibraryTimeout;
+        uint256 receiveLibraryTimeoutExpiry;
+        LayerZeroSetConfigParam[] sendConfig;
+        LayerZeroSetConfigParam[] receiveConfig;
+    }
+
+    // ============ Storage ============
+
+    ILayerZeroEndpointV2 public immutable endpoint;
+    uint32 public immutable localEid;
+
+    mapping(uint32 domain => RemoteLayerZeroConfig remoteConfig)
+        public remoteConfigs;
+    mapping(uint32 eid => uint64 domainPlusOne) public domainsByEid;
+    mapping(bytes32 messageId => bool wasSent) public sent;
+
+    // ============ Events ============
+
+    event LayerZeroRemoteRouterEnrolled(
+        uint32 indexed domain,
+        uint32 indexed eid,
+        bytes32 router
+    );
+    event LayerZeroRemoteRouterUnenrolled(
+        uint32 indexed domain,
+        uint32 indexed eid,
+        bytes32 router
+    );
+    event LayerZeroAuthorizationSent(
+        bytes32 indexed messageId,
+        uint32 indexed destination,
+        uint32 indexed dstEid,
+        bytes32 guid,
+        uint64 nonce,
+        uint256 nativeFee
+    );
+    event LayerZeroSendLibrarySet(
+        uint32 indexed eid,
+        address indexed libraryAddress
+    );
+    event LayerZeroReceiveLibrarySet(
+        uint32 indexed eid,
+        address indexed libraryAddress,
+        uint256 gracePeriod
+    );
+    event LayerZeroReceiveLibraryTimeoutSet(
+        uint32 indexed eid,
+        address indexed libraryAddress,
+        uint256 expiry
+    );
+    event LayerZeroConfigSet(address indexed libraryAddress);
+
+    // ============ Errors ============
+
+    error InvalidLayerZeroEndpoint();
+    error InvalidLocalEid();
+    error UnsupportedNativeTokenEndpoint(address nativeToken);
+    error IncompleteLayerZeroRoute(uint32 domain);
+    error UnknownLayerZeroRoute(uint32 domain);
+    error InvalidRemoteDomain(uint32 domain);
+    error InvalidRemoteEid(uint32 eid);
+    error NonCanonicalLayerZeroPeer(bytes32 peer);
+    error LayerZeroEidAlreadyEnrolled(uint32 eid, uint32 domain);
+    error LayerZeroEidChangeRequiresUnenrollment(uint32 domain);
+    error UnregisteredLayerZeroLibrary(address libraryAddress);
+    error DefaultLayerZeroLibrary(uint32 eid);
+    error InvalidLayerZeroConfigEid(uint32 eid);
+    error InvalidLayerZeroReceiveLibraryTimeout();
+    error InvalidLayerZeroReceiveLibraryGracePeriod();
+    error LayerZeroEnrollmentLengthMismatch();
+    error UnsupportedLayerZeroMetadata();
+    error MessageNotLatestDispatched(bytes32 messageId);
+    error LayerZeroAuthorizationAlreadySent(bytes32 messageId);
+    error InsufficientLayerZeroFee(uint256 required, uint256 supplied);
+    error UnsupportedLayerZeroTokenFee(uint256 fee);
+    error HyperlaneHandleUnsupported();
+
+    // ============ Constructor ============
+
+    constructor(address mailbox_, address endpoint_) Router(mailbox_) {
+        if (!Address.isContract(endpoint_)) {
+            revert InvalidLayerZeroEndpoint();
+        }
+        endpoint = ILayerZeroEndpointV2(endpoint_);
+        uint32 eid_ = endpoint.eid();
+        if (eid_ == 0) revert InvalidLocalEid();
+        localEid = eid_;
+        address nativeToken_ = endpoint.nativeToken();
+        if (nativeToken_ != address(0)) {
+            revert UnsupportedNativeTokenEndpoint(nativeToken_);
+        }
+    }
+
+    // ============ Hyperlane Hook Interface ============
+
+    function hookType() external pure returns (uint8) {
+        return uint8(IPostDispatchHook.HookTypes.LAYER_ZERO);
+    }
+
+    function supportsMetadata(
+        bytes calldata metadata
+    ) public view override returns (bool) {
+        return
+            super.supportsMetadata(metadata) &&
+            metadata.feeToken(address(0)) == address(0) &&
+            metadata.msgValue(0) == 0;
+    }
+
+    function _validateMetadata(bytes calldata metadata) internal view {
+        if (!supportsMetadata(metadata)) revert UnsupportedLayerZeroMetadata();
+    }
+
+    function _quoteDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal view override returns (uint256) {
+        _validateMetadata(metadata);
+        LayerZeroMessagingFee memory fee = endpoint.quote(
+            _lzNativeFeeQuoteParams(message),
+            address(this)
+        );
+        if (fee.lzTokenFee != 0) {
+            revert UnsupportedLayerZeroTokenFee(fee.lzTokenFee);
+        }
+        return fee.nativeFee;
+    }
+
+    function _postDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal override {
+        bytes32 messageId = message.id();
+        if (!_isLatestDispatched(messageId)) {
+            revert MessageNotLatestDispatched(messageId);
+        }
+        if (sent[messageId]) {
+            revert LayerZeroAuthorizationAlreadySent(messageId);
+        }
+        _validateMetadata(metadata);
+        sent[messageId] = true;
+
+        LayerZeroMessagingParams memory params = _lzNativeFeeQuoteParams(
+            message
+        );
+        LayerZeroMessagingFee memory fee = endpoint.quote(
+            params,
+            address(this)
+        );
+        if (fee.lzTokenFee != 0) {
+            revert UnsupportedLayerZeroTokenFee(fee.lzTokenFee);
+        }
+        if (msg.value < fee.nativeFee) {
+            revert InsufficientLayerZeroFee(fee.nativeFee, msg.value);
+        }
+        address refundAddress = metadata.refundAddress(message.senderAddress());
+        LayerZeroMessagingReceipt memory receipt = endpoint.send{
+            value: fee.nativeFee
+        }(params, refundAddress);
+        emit LayerZeroAuthorizationSent(
+            messageId,
+            message.destination(),
+            params.dstEid,
+            receipt.guid,
+            receipt.nonce,
+            fee.nativeFee
+        );
+
+        _refund(metadata, message, msg.value - fee.nativeFee);
+    }
+
+    /// @dev Shared by quote and send; always disables LZ-token payment.
+    function _lzNativeFeeQuoteParams(
+        bytes calldata message
+    ) internal view returns (LayerZeroMessagingParams memory) {
+        uint32 destination = message.destination();
+        RemoteLayerZeroConfig memory remote = _mustHaveRemoteConfig(
+            destination
+        );
+        return
+            LayerZeroMessagingParams({
+                dstEid: remote.eid,
+                receiver: _mustHaveRemoteRouter(destination),
+                message: LayerZeroMessage.encode(
+                    localDomain,
+                    destination,
+                    message.id()
+                ),
+                options: _AbstractLayerZeroV2HookIsm_options(destination),
+                payInLzToken: false
+            });
+    }
+
+    // ============ LayerZero Receiver Interface ============
+
+    /// @notice Allows Endpoint V2 to initialize an inbound message path.
+    /// @dev Endpoint.verify calls this when the path's lazy inbound nonce is
+    /// zero. Without it, the first packet from a peer cannot be committed.
+    /// Requiring an exact enrolled EID/peer binding prevents an arbitrary
+    /// sender from initializing a path to this OApp.
+    function allowInitializePath(
+        LayerZeroOrigin calldata origin
+    ) external view returns (bool) {
+        uint64 encoded = domainsByEid[origin.srcEid];
+        if (encoded == 0) return false;
+        uint32 domain = uint32(encoded - 1);
+        return routers(domain) == origin.sender;
+    }
+
+    /// @notice Reports whether this OApp requires ordered message execution.
+    /// @dev LayerZero Executors query this receiver method. Returning zero opts
+    /// out of application-level ordered execution; Endpoint V2 still assigns,
+    /// verifies, and clears packets using their protocol nonces.
+    function nextNonce(uint32, bytes32) external pure returns (uint64) {
+        return 0;
+    }
+
+    // ============ Route Configuration ============
+
+    /// @dev Prevents inherited partial enrollment. LayerZero routes must use
+    /// the rich enrollment APIs exposed by the concrete variants.
+    function _enrollRemoteRouter(uint32, bytes32) internal pure override {
+        revert IncompleteLayerZeroRoute(0);
+    }
+
+    function _enrollLayerZeroRemoteRouter(
+        RemoteRouterEnrollment calldata enrollment
+    ) internal {
+        if (enrollment.domain == localDomain) {
+            revert InvalidRemoteDomain(enrollment.domain);
+        }
+
+        if (enrollment.eid == 0 || enrollment.eid == localEid) {
+            revert InvalidRemoteEid(enrollment.eid);
+        }
+
+        if (
+            enrollment.router == bytes32(0) ||
+            uint256(enrollment.router) > type(uint160).max
+        ) {
+            revert NonCanonicalLayerZeroPeer(enrollment.router);
+        }
+        _validateReceiveLibraryTimeout(
+            enrollment.receiveLibraryTimeout,
+            enrollment.receiveLibraryTimeoutExpiry
+        );
+
+        RemoteLayerZeroConfig memory current = remoteConfigs[enrollment.domain];
+        if (current.eid != 0 && current.eid != enrollment.eid) {
+            revert LayerZeroEidChangeRequiresUnenrollment(enrollment.domain);
+        }
+        uint64 existing = domainsByEid[enrollment.eid];
+        if (existing != 0 && uint32(existing - 1) != enrollment.domain) {
+            revert LayerZeroEidAlreadyEnrolled(
+                enrollment.eid,
+                uint32(existing - 1)
+            );
+        }
+
+        super._enrollRemoteRouter(enrollment.domain, enrollment.router);
+        remoteConfigs[enrollment.domain] = RemoteLayerZeroConfig({
+            eid: enrollment.eid
+        });
+        domainsByEid[enrollment.eid] = uint64(enrollment.domain) + 1;
+        emit LayerZeroRemoteRouterEnrolled(
+            enrollment.domain,
+            enrollment.eid,
+            enrollment.router
+        );
+        bool sendLibraryChanged = endpoint.isDefaultSendLibrary(
+            address(this),
+            enrollment.eid
+        ) ||
+            endpoint.getSendLibrary(address(this), enrollment.eid) !=
+            enrollment.sendLibrary;
+        if (sendLibraryChanged) {
+            _setSendLibrary(enrollment.eid, enrollment.sendLibrary);
+        }
+
+        (address currentReceiveLibrary, bool isDefaultReceiveLibrary) = endpoint
+            .getReceiveLibrary(address(this), enrollment.eid);
+        bool receiveLibraryChanged = isDefaultReceiveLibrary ||
+            currentReceiveLibrary != enrollment.receiveLibrary;
+        if (receiveLibraryChanged) {
+            _setReceiveLibrary(
+                enrollment.eid,
+                enrollment.receiveLibrary,
+                enrollment.receiveLibraryGracePeriod
+            );
+        } else if (enrollment.receiveLibraryGracePeriod != 0) {
+            revert InvalidLayerZeroReceiveLibraryGracePeriod();
+        }
+        _setEnrollmentLayerZeroConfig(
+            enrollment.eid,
+            enrollment.sendLibrary,
+            enrollment.sendConfig
+        );
+        _setEnrollmentLayerZeroConfig(
+            enrollment.eid,
+            enrollment.receiveLibrary,
+            enrollment.receiveConfig
+        );
+        if (enrollment.receiveLibraryTimeout != address(0)) {
+            _setReceiveLibraryTimeout(
+                enrollment.eid,
+                enrollment.receiveLibraryTimeout,
+                enrollment.receiveLibraryTimeoutExpiry
+            );
+        } else if (!receiveLibraryChanged) {
+            _clearReceiveLibraryTimeout(
+                enrollment.eid,
+                enrollment.receiveLibrary
+            );
+        }
+    }
+
+    function _updateLayerZeroRemoteRouterConfig(
+        RemoteRouterConfigUpdate calldata update_
+    ) internal {
+        RemoteLayerZeroConfig memory remote = _mustHaveRemoteConfig(
+            update_.domain
+        );
+        if (
+            update_.router == bytes32(0) ||
+            uint256(update_.router) > type(uint160).max
+        ) {
+            revert NonCanonicalLayerZeroPeer(update_.router);
+        }
+        _validateReceiveLibraryTimeout(
+            update_.receiveLibraryTimeout,
+            update_.receiveLibraryTimeoutExpiry
+        );
+
+        bytes32 currentRouter = routers(update_.domain);
+        if (currentRouter != update_.router) {
+            super._enrollRemoteRouter(update_.domain, update_.router);
+            emit LayerZeroRemoteRouterEnrolled(
+                update_.domain,
+                remote.eid,
+                update_.router
+            );
+        }
+
+        address sendLibrary = endpoint.getSendLibrary(
+            address(this),
+            remote.eid
+        );
+        (address receiveLibrary, ) = endpoint.getReceiveLibrary(
+            address(this),
+            remote.eid
+        );
+        _setEnrollmentLayerZeroConfig(
+            remote.eid,
+            sendLibrary,
+            update_.sendConfig
+        );
+        _setEnrollmentLayerZeroConfig(
+            remote.eid,
+            receiveLibrary,
+            update_.receiveConfig
+        );
+        if (update_.receiveLibraryTimeout != address(0)) {
+            _setReceiveLibraryTimeout(
+                remote.eid,
+                update_.receiveLibraryTimeout,
+                update_.receiveLibraryTimeoutExpiry
+            );
+        } else {
+            _clearReceiveLibraryTimeout(remote.eid, receiveLibrary);
+        }
+    }
+
+    function _unenrollRemoteRouter(uint32 domain) internal override {
+        RemoteLayerZeroConfig memory remote = remoteConfigs[domain];
+        if (remote.eid == 0) revert UnknownLayerZeroRoute(domain);
+        bytes32 router = _mustHaveRemoteRouter(domain);
+        delete remoteConfigs[domain];
+        delete domainsByEid[remote.eid];
+        _AbstractLayerZeroV2HookIsm_onRemoteRouterUnenrolled(domain);
+        super._unenrollRemoteRouter(domain);
+        emit LayerZeroRemoteRouterUnenrolled(domain, remote.eid, router);
+    }
+
+    // ============ LayerZero Endpoint Configuration ============
+
+    function _validateConfigurationTarget(
+        uint32 eid,
+        address libraryAddress
+    ) internal view {
+        if (domainsByEid[eid] == 0) revert InvalidLayerZeroConfigEid(eid);
+        if (
+            libraryAddress == address(0) ||
+            !endpoint.isRegisteredLibrary(libraryAddress)
+        ) {
+            revert UnregisteredLayerZeroLibrary(libraryAddress);
+        }
+    }
+
+    function _setSendLibrary(uint32 eid, address libraryAddress) internal {
+        _validateConfigurationTarget(eid, libraryAddress);
+        endpoint.setSendLibrary(address(this), eid, libraryAddress);
+        emit LayerZeroSendLibrarySet(eid, libraryAddress);
+    }
+
+    function _setReceiveLibrary(
+        uint32 eid,
+        address libraryAddress,
+        uint256 gracePeriod
+    ) internal {
+        _validateConfigurationTarget(eid, libraryAddress);
+        endpoint.setReceiveLibrary(
+            address(this),
+            eid,
+            libraryAddress,
+            gracePeriod
+        );
+        emit LayerZeroReceiveLibrarySet(eid, libraryAddress, gracePeriod);
+    }
+
+    function _setReceiveLibraryTimeout(
+        uint32 eid,
+        address libraryAddress,
+        uint256 expiry
+    ) internal {
+        _validateConfigurationTarget(eid, libraryAddress);
+        endpoint.setReceiveLibraryTimeout(
+            address(this),
+            eid,
+            libraryAddress,
+            expiry
+        );
+        emit LayerZeroReceiveLibraryTimeoutSet(eid, libraryAddress, expiry);
+    }
+
+    function _clearReceiveLibraryTimeout(
+        uint32 eid,
+        address receiveLibrary
+    ) internal {
+        (, uint256 expiry) = endpoint.receiveLibraryTimeout(address(this), eid);
+        if (expiry != 0) {
+            _setReceiveLibraryTimeout(eid, receiveLibrary, 0);
+        }
+    }
+
+    function _validateReceiveLibraryTimeout(
+        address libraryAddress,
+        uint256 expiry
+    ) internal pure {
+        if ((libraryAddress == address(0)) != (expiry == 0)) {
+            revert InvalidLayerZeroReceiveLibraryTimeout();
+        }
+    }
+
+    function _setLayerZeroConfig(
+        address libraryAddress,
+        LayerZeroSetConfigParam[] calldata params
+    ) internal {
+        if (!endpoint.isRegisteredLibrary(libraryAddress)) {
+            revert UnregisteredLayerZeroLibrary(libraryAddress);
+        }
+        for (uint256 i = 0; i < params.length; ++i) {
+            if (domainsByEid[params[i].eid] == 0) {
+                revert InvalidLayerZeroConfigEid(params[i].eid);
+            }
+        }
+        endpoint.setConfig(address(this), libraryAddress, params);
+        emit LayerZeroConfigSet(libraryAddress);
+    }
+
+    function _setEnrollmentLayerZeroConfig(
+        uint32 eid,
+        address libraryAddress,
+        LayerZeroSetConfigParam[] calldata params
+    ) internal {
+        if (params.length == 0) return;
+        for (uint256 i = 0; i < params.length; ++i) {
+            if (params[i].eid != eid) {
+                revert InvalidLayerZeroConfigEid(params[i].eid);
+            }
+        }
+        _setLayerZeroConfig(libraryAddress, params);
+    }
+
+    // ============ Route Validation and Lookup ============
+
+    function _validateLayerZeroRemoteRouter(uint32 domain) internal view {
+        RemoteLayerZeroConfig memory remote = remoteConfigs[domain];
+        _validateRouteConfiguration(domain, remote.eid);
+    }
+
+    function _validateRouteConfiguration(
+        uint32 domain,
+        uint32 eid
+    ) internal view {
+        if (eid == 0 || routers(domain) == bytes32(0)) {
+            revert IncompleteLayerZeroRoute(domain);
+        }
+        if (endpoint.isDefaultSendLibrary(address(this), eid)) {
+            revert DefaultLayerZeroLibrary(eid);
+        }
+        (, bool isDefaultReceive) = endpoint.getReceiveLibrary(
+            address(this),
+            eid
+        );
+        if (isDefaultReceive) revert DefaultLayerZeroLibrary(eid);
+        if (!_AbstractLayerZeroV2HookIsm_isVariantRouteConfigured(domain)) {
+            revert IncompleteLayerZeroRoute(domain);
+        }
+    }
+
+    function _originDomain(
+        uint32 srcEid,
+        bytes32 sender
+    ) internal view returns (uint32 domain) {
+        uint64 encoded = domainsByEid[srcEid];
+        if (encoded == 0) revert InvalidRemoteEid(srcEid);
+        domain = uint32(encoded - 1);
+        if (_mustHaveRemoteRouter(domain) != sender) {
+            revert NonCanonicalLayerZeroPeer(sender);
+        }
+    }
+
+    function _mustHaveRemoteConfig(
+        uint32 domain
+    ) internal view returns (RemoteLayerZeroConfig memory remote) {
+        remote = remoteConfigs[domain];
+        if (remote.eid == 0) revert UnknownLayerZeroRoute(domain);
+    }
+
+    // ============ Hyperlane Message Recipient ============
+
+    function _handle(uint32, bytes32, bytes calldata) internal pure override {
+        revert HyperlaneHandleUnsupported();
+    }
+
+    // ============ Variant Overrides ============
+
+    function _AbstractLayerZeroV2HookIsm_options(
+        uint32 destination
+    ) internal view virtual returns (bytes memory);
+
+    function _AbstractLayerZeroV2HookIsm_onRemoteRouterUnenrolled(
+        uint32 domain
+    ) internal virtual;
+
+    function _AbstractLayerZeroV2HookIsm_isVariantRouteConfigured(
+        uint32 domain
+    ) internal view virtual returns (bool);
+}

--- a/solidity/contracts/hooks/layerzero/LayerZeroV2CallbackHookIsm.sol
+++ b/solidity/contracts/hooks/layerzero/LayerZeroV2CallbackHookIsm.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+import {OptionsBuilder} from "@layerzerolabs/oapp-evm/contracts/oapp/libs/OptionsBuilder.sol";
+import {Origin as LayerZeroOrigin} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {AddressCast} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol";
+import {GUID} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
+import {IInterchainSecurityModule} from "../../interfaces/IInterchainSecurityModule.sol";
+import {LayerZeroMessage} from "../../libs/LayerZeroMessage.sol";
+import {Message} from "../../libs/Message.sol";
+import {AbstractLayerZeroV2HookIsm} from "./AbstractLayerZeroV2HookIsm.sol";
+
+// LayerZero callback gas is only defined for explicitly enrolled routes.
+// solhint-disable-next-line hyperlane/enumerable-domain-mapping
+contract LayerZeroV2CallbackHookIsm is
+    AbstractLayerZeroV2HookIsm,
+    IInterchainSecurityModule
+{
+    using AddressCast for bytes32;
+    using Message for bytes;
+    using OptionsBuilder for bytes;
+
+    // ============ Constants ============
+
+    uint8 public constant moduleType =
+        uint8(IInterchainSecurityModule.Types.NULL);
+
+    // ============ Storage ============
+
+    /// @dev The authenticated origin is part of the key so one enrolled peer
+    /// cannot block or satisfy authorization for another origin.
+    mapping(uint32 originDomain => mapping(bytes32 messageId => bool authorized))
+        public authorizations;
+    mapping(uint32 domain => uint128 gasLimit) public callbackGasLimits;
+
+    // ============ Events ============
+
+    event LayerZeroCallbackGasLimitSet(uint32 indexed domain, uint128 gasLimit);
+    event LayerZeroAuthorizationReceived(
+        bytes32 indexed messageId,
+        uint32 indexed originDomain,
+        uint32 indexed srcEid,
+        bytes32 guid,
+        uint64 nonce
+    );
+
+    // ============ Errors ============
+
+    error InvalidLayerZeroCallbackGasLimit();
+    error UnauthorizedLayerZeroEndpoint(address caller);
+    error UnexpectedLayerZeroCallbackValue(uint256 value);
+    error WrongLayerZeroPayloadOrigin(uint32 actual, uint32 expected);
+    error WrongLayerZeroPayloadDestination(uint32 actual, uint32 expected);
+    error WrongLayerZeroGuid(bytes32 actual, bytes32 expected);
+    error UnexpectedHyperlaneMetadata();
+    error LayerZeroConfigLengthMismatch();
+
+    // ============ Constructor ============
+
+    constructor(
+        address mailbox_,
+        address endpoint_
+    ) AbstractLayerZeroV2HookIsm(mailbox_, endpoint_) {}
+
+    // ============ Route Configuration ============
+
+    function enrollLayerZeroRemoteRouter(
+        RemoteRouterEnrollment calldata enrollment,
+        uint128 callbackGasLimit
+    ) external onlyOwner {
+        _enrollAndValidateLayerZeroRemoteRouter(enrollment, callbackGasLimit);
+    }
+
+    function enrollLayerZeroRemoteRouters(
+        RemoteRouterEnrollment[] calldata enrollments,
+        uint128[] calldata callbackGasLimits_
+    ) external onlyOwner {
+        if (enrollments.length != callbackGasLimits_.length) {
+            revert LayerZeroEnrollmentLengthMismatch();
+        }
+        for (uint256 i = 0; i < enrollments.length; ++i) {
+            _enrollAndValidateLayerZeroRemoteRouter(
+                enrollments[i],
+                callbackGasLimits_[i]
+            );
+        }
+    }
+
+    function updateLayerZeroRemoteRouterConfig(
+        RemoteRouterConfigUpdate calldata update_,
+        uint128 callbackGasLimit
+    ) external onlyOwner {
+        _updateAndValidateLayerZeroRemoteRouterConfig(
+            update_,
+            callbackGasLimit
+        );
+    }
+
+    /// @notice Atomically updates multiple routes whose selected libraries are
+    /// unchanged, including each route's callback gas limit.
+    /// @dev The arrays are positional; any failed update or validation reverts
+    /// the entire batch.
+    function updateLayerZeroRemoteRouterConfigs(
+        RemoteRouterConfigUpdate[] calldata updates,
+        uint128[] calldata callbackGasLimits_
+    ) external onlyOwner {
+        if (updates.length != callbackGasLimits_.length) {
+            revert LayerZeroConfigLengthMismatch();
+        }
+        for (uint256 i = 0; i < updates.length; ++i) {
+            _updateAndValidateLayerZeroRemoteRouterConfig(
+                updates[i],
+                callbackGasLimits_[i]
+            );
+        }
+    }
+
+    function _enrollAndValidateLayerZeroRemoteRouter(
+        RemoteRouterEnrollment calldata enrollment,
+        uint128 callbackGasLimit
+    ) internal {
+        _enrollLayerZeroRemoteRouter(enrollment);
+        _setCallbackGasLimit(enrollment.domain, callbackGasLimit);
+        _validateLayerZeroRemoteRouter(enrollment.domain);
+    }
+
+    function _updateAndValidateLayerZeroRemoteRouterConfig(
+        RemoteRouterConfigUpdate calldata update_,
+        uint128 callbackGasLimit
+    ) internal {
+        _updateLayerZeroRemoteRouterConfig(update_);
+        _setCallbackGasLimit(update_.domain, callbackGasLimit);
+        _validateLayerZeroRemoteRouter(update_.domain);
+    }
+
+    function _setCallbackGasLimit(uint32 domain, uint128 gasLimit) internal {
+        if (remoteConfigs[domain].eid == 0) {
+            revert UnknownLayerZeroRoute(domain);
+        }
+        if (gasLimit == 0) revert InvalidLayerZeroCallbackGasLimit();
+        callbackGasLimits[domain] = gasLimit;
+        emit LayerZeroCallbackGasLimitSet(domain, gasLimit);
+    }
+
+    // ============ LayerZero Receiver Interface ============
+
+    /// @notice Receives a packet that Endpoint V2 has already authenticated
+    /// and cleared, then records its Hyperlane message authorization.
+    /// @dev This is the callback variant's required ILayerZeroReceiver entry
+    /// point. The Endpoint caller, enrolled EID/peer, payload, and GUID are all
+    /// checked here because Executor-supplied delivery data is untrusted.
+    function lzReceive(
+        LayerZeroOrigin calldata origin,
+        bytes32 guid,
+        bytes calldata payload,
+        address,
+        bytes calldata
+    ) external payable override {
+        if (msg.sender != address(endpoint)) {
+            revert UnauthorizedLayerZeroEndpoint(msg.sender);
+        }
+        if (msg.value != 0) revert UnexpectedLayerZeroCallbackValue(msg.value);
+
+        uint32 originDomain = _originDomain(origin.srcEid, origin.sender);
+        (
+            uint32 payloadOrigin,
+            uint32 payloadDestination,
+            bytes32 messageId
+        ) = LayerZeroMessage.decode(payload);
+        if (payloadOrigin != originDomain) {
+            revert WrongLayerZeroPayloadOrigin(payloadOrigin, originDomain);
+        }
+        if (payloadDestination != localDomain) {
+            revert WrongLayerZeroPayloadDestination(
+                payloadDestination,
+                localDomain
+            );
+        }
+
+        _validateGuid(origin, guid);
+        authorizations[originDomain][messageId] = true;
+        emit LayerZeroAuthorizationReceived(
+            messageId,
+            originDomain,
+            origin.srcEid,
+            guid,
+            origin.nonce
+        );
+    }
+
+    function _validateGuid(
+        LayerZeroOrigin calldata origin,
+        bytes32 guid
+    ) internal view {
+        bytes32 expectedGuid = GUID.generate(
+            origin.nonce,
+            origin.srcEid,
+            origin.sender.toAddress(),
+            localEid,
+            bytes32(uint256(uint160(address(this))))
+        );
+        if (guid != expectedGuid) revert WrongLayerZeroGuid(guid, expectedGuid);
+    }
+
+    // ============ Hyperlane ISM Interface ============
+
+    function verify(
+        bytes calldata metadata,
+        bytes calldata message
+    ) external view override returns (bool) {
+        if (metadata.length != 0) revert UnexpectedHyperlaneMetadata();
+        if (message.destination() != localDomain) return false;
+        return authorizations[message.origin()][message.id()];
+    }
+
+    // ============ Variant Overrides ============
+
+    function _AbstractLayerZeroV2HookIsm_options(
+        uint32 destination
+    ) internal view override returns (bytes memory) {
+        uint128 gasLimit = callbackGasLimits[destination];
+        if (gasLimit == 0) revert InvalidLayerZeroCallbackGasLimit();
+        return
+            OptionsBuilder.newOptions().addExecutorLzReceiveOption(gasLimit, 0);
+    }
+
+    function _AbstractLayerZeroV2HookIsm_onRemoteRouterUnenrolled(
+        uint32 domain
+    ) internal override {
+        delete callbackGasLimits[domain];
+    }
+
+    function _AbstractLayerZeroV2HookIsm_isVariantRouteConfigured(
+        uint32 domain
+    ) internal view override returns (bool) {
+        return callbackGasLimits[domain] != 0;
+    }
+}

--- a/solidity/contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol
+++ b/solidity/contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+import {IReceiveUlnE2} from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/interfaces/IReceiveUlnE2.sol";
+import {ILayerZeroEndpointV2, Origin as LayerZeroOrigin} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {AddressCast} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/AddressCast.sol";
+import {GUID} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
+import {PacketV1Codec} from "@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol";
+import {AbstractCcipReadIsm} from "../../isms/ccip-read/AbstractCcipReadIsm.sol";
+import {ILayerZeroPacketService} from "../../interfaces/layerzero/ILayerZeroPacketService.sol";
+import {LayerZeroMessage} from "../../libs/LayerZeroMessage.sol";
+import {LayerZeroMetadata} from "../../libs/LayerZeroMetadata.sol";
+import {Message} from "../../libs/Message.sol";
+import {AbstractLayerZeroV2HookIsm} from "./AbstractLayerZeroV2HookIsm.sol";
+
+contract LayerZeroV2CcipReadHookIsm is
+    AbstractCcipReadIsm,
+    AbstractLayerZeroV2HookIsm
+{
+    using AddressCast for bytes32;
+    using LayerZeroMetadata for bytes;
+    using PacketV1Codec for bytes;
+
+    // ============ Constants ============
+
+    // Standard Executors reject missing or zero-gas lzReceive options. One gas
+    // keeps the pathway quotable while making callback execution impossible;
+    // this variant uses the Endpoint's committed verification state directly.
+    bytes22 internal constant PULL_EXECUTOR_OPTIONS =
+        hex"00030100110100000000000000000000000000000001";
+    uint256 internal constant CLEAR_GAS_LIMIT = 100_000;
+    uint256 internal constant PACKET_MESSAGE_OFFSET = 113;
+    uint8 internal constant PACKET_VERSION = 1;
+
+    // ============ Types ============
+
+    struct PacketContext {
+        address receiveLibrary;
+        uint32 originDomain;
+        uint32 sourceEid;
+        bytes32 sender;
+        uint64 nonce;
+        bytes32 guid;
+        bytes32 payloadHash;
+        bytes message;
+        bytes header;
+    }
+
+    // ============ Events ============
+
+    event LayerZeroPayloadVerified(
+        bytes32 indexed messageId,
+        uint32 indexed originDomain,
+        uint32 indexed srcEid,
+        bytes32 guid,
+        uint64 nonce
+    );
+    event LayerZeroPayloadClearFailed(
+        bytes32 indexed messageId,
+        uint32 indexed originDomain,
+        uint32 indexed srcEid,
+        bytes32 guid,
+        uint64 nonce
+    );
+
+    // ============ Errors ============
+
+    error UnauthorizedCaller(address caller);
+    error MessageNotBeingProcessed(bytes32 messageId);
+    error WrongHyperlaneDestination(uint32 destination);
+    error WrongPacketSourceEid(uint32 actual, uint32 expected);
+    error WrongPacketSender(bytes32 actual, bytes32 expected);
+    error WrongPacketDestinationEid(uint32 actual, uint32 expected);
+    error WrongPacketReceiver(bytes32 actual, bytes32 expected);
+    error WrongPacketMessage();
+    error WrongPacketGuid(bytes32 actual, bytes32 expected);
+    error InvalidReceiveLibrary(address libraryAddress);
+    error ConflictingPayloadHash(bytes32 current, bytes32 expected);
+    error InvalidLayerZeroPacketLength(uint256 length);
+    error InvalidLayerZeroPacketVersion(uint8 version);
+    error MessageNotDelivered(bytes32 messageId);
+
+    // ============ Constructor ============
+
+    constructor(
+        address mailbox_,
+        address endpoint_,
+        string[] memory urls_
+    ) AbstractLayerZeroV2HookIsm(mailbox_, endpoint_) {
+        setUrls(urls_);
+    }
+
+    // ============ Route Configuration ============
+
+    function enrollLayerZeroRemoteRouter(
+        RemoteRouterEnrollment calldata enrollment
+    ) external onlyOwner {
+        _enrollAndValidateLayerZeroRemoteRouter(enrollment);
+    }
+
+    function enrollLayerZeroRemoteRouters(
+        RemoteRouterEnrollment[] calldata enrollments
+    ) external onlyOwner {
+        for (uint256 i = 0; i < enrollments.length; ++i) {
+            _enrollAndValidateLayerZeroRemoteRouter(enrollments[i]);
+        }
+    }
+
+    function updateLayerZeroRemoteRouterConfig(
+        RemoteRouterConfigUpdate calldata update_
+    ) external onlyOwner {
+        _updateAndValidateLayerZeroRemoteRouterConfig(update_);
+    }
+
+    /// @notice Atomically updates multiple routes whose selected libraries are
+    /// unchanged.
+    /// @dev Any failed update or validation reverts the entire batch.
+    function updateLayerZeroRemoteRouterConfigs(
+        RemoteRouterConfigUpdate[] calldata updates
+    ) external onlyOwner {
+        for (uint256 i = 0; i < updates.length; ++i) {
+            _updateAndValidateLayerZeroRemoteRouterConfig(updates[i]);
+        }
+    }
+
+    function _enrollAndValidateLayerZeroRemoteRouter(
+        RemoteRouterEnrollment calldata enrollment
+    ) internal {
+        _enrollLayerZeroRemoteRouter(enrollment);
+        _validateLayerZeroRemoteRouter(enrollment.domain);
+    }
+
+    function _updateAndValidateLayerZeroRemoteRouterConfig(
+        RemoteRouterConfigUpdate calldata update_
+    ) internal {
+        _updateLayerZeroRemoteRouterConfig(update_);
+        _validateLayerZeroRemoteRouter(update_.domain);
+    }
+
+    // ============ LayerZero Receiver Interface ============
+
+    /// @notice Allows Endpoint V2 to clear a packet only after its Hyperlane
+    /// message has been delivered.
+    /// @dev Endpoint V2 clears before this callback. Reverting here rolls that
+    /// clear back, so Executors cannot consume an undelivered authorization.
+    function lzReceive(
+        LayerZeroOrigin calldata,
+        bytes32,
+        bytes calldata payload,
+        address,
+        bytes calldata
+    ) external payable override {
+        if (msg.sender != address(endpoint)) {
+            revert UnauthorizedCaller(msg.sender);
+        }
+        (, , bytes32 messageId) = LayerZeroMessage.decode(payload);
+        if (!mailbox.delivered(messageId)) {
+            revert MessageNotDelivered(messageId);
+        }
+    }
+
+    // ============ Hyperlane ISM Interface ============
+
+    function verify(
+        bytes calldata metadata,
+        bytes calldata message
+    ) external override returns (bool) {
+        bytes32 messageId = Message.id(message);
+        if (!_isProcessing(messageId)) {
+            revert MessageNotBeingProcessed(messageId);
+        }
+
+        if (Message.destination(message) != localDomain) {
+            revert WrongHyperlaneDestination(Message.destination(message));
+        }
+
+        PacketContext memory context = _validatePacket(
+            metadata,
+            message,
+            messageId
+        );
+
+        _commitPacketVerification(context);
+        emit LayerZeroPayloadVerified(
+            messageId,
+            context.originDomain,
+            context.sourceEid,
+            context.guid,
+            context.nonce
+        );
+        _tryClearPacket(context, messageId);
+
+        return true;
+    }
+
+    // ============ Packet Validation and Verification ============
+
+    function _validatePacket(
+        bytes calldata metadata,
+        bytes calldata hyperlaneMessage,
+        bytes32 messageId
+    ) internal view returns (PacketContext memory context) {
+        bytes calldata packet;
+        (context.receiveLibrary, packet) = metadata.decode();
+        _validatePacketEncoding(packet);
+        context.originDomain = Message.origin(hyperlaneMessage);
+        RemoteLayerZeroConfig memory remote = _mustHaveRemoteConfig(
+            context.originDomain
+        );
+        context.sourceEid = packet.srcEid();
+        if (context.sourceEid != remote.eid) {
+            revert WrongPacketSourceEid(context.sourceEid, remote.eid);
+        }
+        bytes32 expectedSender = _mustHaveRemoteRouter(context.originDomain);
+        context.sender = packet.sender();
+        if (context.sender != expectedSender) {
+            revert WrongPacketSender(context.sender, expectedSender);
+        }
+        uint32 destinationEid = packet.dstEid();
+        if (destinationEid != localEid) {
+            revert WrongPacketDestinationEid(destinationEid, localEid);
+        }
+        bytes32 expectedReceiver = bytes32(uint256(uint160(address(this))));
+        bytes32 packetReceiver = packet.receiver();
+        if (packetReceiver != expectedReceiver) {
+            revert WrongPacketReceiver(packetReceiver, expectedReceiver);
+        }
+
+        context.message = LayerZeroMessage.encode(
+            context.originDomain,
+            localDomain,
+            messageId
+        );
+        if (keccak256(packet.message()) != keccak256(context.message)) {
+            revert WrongPacketMessage();
+        }
+        context.nonce = packet.nonce();
+        context.guid = packet.guid();
+        bytes32 expectedGuid = GUID.generate(
+            context.nonce,
+            context.sourceEid,
+            context.sender.toAddress(),
+            destinationEid,
+            packetReceiver
+        );
+        if (context.guid != expectedGuid) {
+            revert WrongPacketGuid(context.guid, expectedGuid);
+        }
+        context.payloadHash = packet.payloadHash();
+        context.header = packet.header();
+    }
+
+    function _validatePacketEncoding(bytes calldata packet) internal pure {
+        if (packet.length != PACKET_MESSAGE_OFFSET + LayerZeroMessage.LENGTH) {
+            revert InvalidLayerZeroPacketLength(packet.length);
+        }
+        uint8 version = packet.version();
+        if (version != PACKET_VERSION) {
+            revert InvalidLayerZeroPacketVersion(version);
+        }
+    }
+
+    function _commitPacketVerification(PacketContext memory context) internal {
+        bytes32 currentPayloadHash = endpoint.inboundPayloadHash(
+            address(this),
+            context.sourceEid,
+            context.sender,
+            context.nonce
+        );
+
+        if (currentPayloadHash == bytes32(0)) {
+            if (
+                !endpoint.isValidReceiveLibrary(
+                    address(this),
+                    context.sourceEid,
+                    context.receiveLibrary
+                )
+            ) {
+                revert InvalidReceiveLibrary(context.receiveLibrary);
+            }
+            IReceiveUlnE2(context.receiveLibrary).commitVerification(
+                context.header,
+                context.payloadHash
+            );
+            currentPayloadHash = endpoint.inboundPayloadHash(
+                address(this),
+                context.sourceEid,
+                context.sender,
+                context.nonce
+            );
+        }
+
+        if (currentPayloadHash != context.payloadHash) {
+            revert ConflictingPayloadHash(
+                currentPayloadHash,
+                context.payloadHash
+            );
+        }
+    }
+
+    function _tryClearPacket(
+        PacketContext memory context,
+        bytes32 messageId
+    ) internal {
+        (bool cleared, ) = address(endpoint).call{gas: CLEAR_GAS_LIMIT}(
+            abi.encodeCall(
+                ILayerZeroEndpointV2.clear,
+                (address(this), _origin(context), context.guid, context.message)
+            )
+        );
+        if (!cleared) {
+            emit LayerZeroPayloadClearFailed(
+                messageId,
+                context.originDomain,
+                context.sourceEid,
+                context.guid,
+                context.nonce
+            );
+        }
+    }
+
+    function _origin(
+        PacketContext memory context
+    ) internal pure returns (LayerZeroOrigin memory) {
+        return
+            LayerZeroOrigin({
+                srcEid: context.sourceEid,
+                sender: context.sender,
+                nonce: context.nonce
+            });
+    }
+
+    // ============ Hyperlane CCIP-Read Interface ============
+
+    function _offchainLookupCalldata(
+        bytes calldata message
+    ) internal pure override returns (bytes memory) {
+        return
+            abi.encodeCall(
+                ILayerZeroPacketService.getLayerZeroPacket,
+                (message)
+            );
+    }
+
+    // ============ Variant Overrides ============
+
+    function _AbstractLayerZeroV2HookIsm_options(
+        uint32
+    ) internal pure override returns (bytes memory) {
+        return abi.encodePacked(PULL_EXECUTOR_OPTIONS);
+    }
+
+    function _AbstractLayerZeroV2HookIsm_onRemoteRouterUnenrolled(
+        uint32
+    ) internal pure override {}
+
+    function _AbstractLayerZeroV2HookIsm_isVariantRouteConfigured(
+        uint32
+    ) internal pure override returns (bool) {
+        return true;
+    }
+}

--- a/solidity/contracts/interfaces/hooks/IPostDispatchHook.sol
+++ b/solidity/contracts/interfaces/hooks/IPostDispatchHook.sol
@@ -33,7 +33,8 @@ interface IPostDispatchHook {
         CCTP,
         TIMELOCK_ROUTING,
         PREDICATE_ROUTER_WRAPPER,
-        WORMHOLE
+        WORMHOLE,
+        LAYER_ZERO
     }
 
     /**

--- a/solidity/contracts/interfaces/layerzero/ILayerZeroPacketService.sol
+++ b/solidity/contracts/interfaces/layerzero/ILayerZeroPacketService.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+interface ILayerZeroPacketService {
+    function getLayerZeroPacket(
+        bytes calldata hyperlaneMessage
+    )
+        external
+        view
+        returns (address receiveLibrary, bytes memory encodedPacket);
+}

--- a/solidity/contracts/libs/LayerZeroMessage.sol
+++ b/solidity/contracts/libs/LayerZeroMessage.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+library LayerZeroMessage {
+    uint8 internal constant VERSION = 1;
+    uint256 internal constant LENGTH = 128;
+
+    error InvalidLayerZeroMessageLength(uint256 length);
+    error InvalidLayerZeroMessageVersion(uint8 version);
+
+    function encode(
+        uint32 origin,
+        uint32 destination,
+        bytes32 messageId
+    ) internal pure returns (bytes memory) {
+        return abi.encode(VERSION, origin, destination, messageId);
+    }
+
+    function decode(
+        bytes calldata payload
+    )
+        internal
+        pure
+        returns (uint32 origin, uint32 destination, bytes32 messageId)
+    {
+        if (payload.length != LENGTH) {
+            revert InvalidLayerZeroMessageLength(payload.length);
+        }
+        uint8 version;
+        (version, origin, destination, messageId) = abi.decode(
+            payload,
+            (uint8, uint32, uint32, bytes32)
+        );
+        if (version != VERSION) revert InvalidLayerZeroMessageVersion(version);
+    }
+}

--- a/solidity/contracts/libs/LayerZeroMetadata.sol
+++ b/solidity/contracts/libs/LayerZeroMetadata.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+library LayerZeroMetadata {
+    uint256 internal constant MAX_PACKET_LENGTH = 4096;
+
+    error InvalidLayerZeroMetadata();
+    error LayerZeroPacketTooLarge(uint256 length);
+
+    /// @dev Use with `using LayerZeroMetadata for bytes` as
+    /// `metadata.decode()`.
+    function decode(
+        bytes calldata metadata
+    ) internal pure returns (address receiveLibrary, bytes calldata packet) {
+        if (metadata.length < 96) revert InvalidLayerZeroMetadata();
+        bytes memory decodedPacket;
+        (receiveLibrary, decodedPacket) = abi.decode(
+            metadata,
+            (address, bytes)
+        );
+        if (receiveLibrary == address(0)) revert InvalidLayerZeroMetadata();
+        _validatePacketLength(decodedPacket.length);
+        bytes memory canonical = abi.encode(receiveLibrary, decodedPacket);
+        if (keccak256(canonical) != keccak256(metadata)) {
+            revert InvalidLayerZeroMetadata();
+        }
+        packet = metadata[96:96 + decodedPacket.length];
+    }
+
+    function _validatePacketLength(uint256 length) private pure {
+        if (length > MAX_PACKET_LENGTH) {
+            revert LayerZeroPacketTooLarge(length);
+        }
+    }
+}

--- a/solidity/contracts/mock/MockLayerZeroEndpointV2.sol
+++ b/solidity/contracts/mock/MockLayerZeroEndpointV2.sol
@@ -7,6 +7,18 @@ import {SetConfigParam as LayerZeroSetConfigParam} from "@layerzerolabs/lz-evm-p
 import {GUID} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
 import {Errors} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/Errors.sol";
 
+interface IMockLayerZeroConfigLibrary {
+    function getDefaultConfig(
+        uint32 configType
+    ) external view returns (bytes memory);
+
+    function getEffectiveConfig(
+        address oapp,
+        uint32 remoteEid,
+        uint32 configType
+    ) external view returns (bytes memory);
+}
+
 contract MockLayerZeroEndpointV2 {
     struct ReceiveLibraryTimeout {
         address libraryAddress;
@@ -322,7 +334,28 @@ contract MockLayerZeroEndpointV2 {
         uint32 remoteEid,
         uint32 configType
     ) external view returns (bytes memory) {
-        return configs[oapp][libraryAddress][remoteEid][configType];
+        try
+            IMockLayerZeroConfigLibrary(libraryAddress).getEffectiveConfig(
+                oapp,
+                remoteEid,
+                configType
+            )
+        returns (bytes memory effectiveConfig) {
+            return effectiveConfig;
+        } catch {}
+        bytes memory config = configs[oapp][libraryAddress][remoteEid][
+            configType
+        ];
+        if (config.length != 0) return config;
+        try
+            IMockLayerZeroConfigLibrary(libraryAddress).getDefaultConfig(
+                configType
+            )
+        returns (bytes memory defaultConfig) {
+            return defaultConfig;
+        } catch {
+            return config;
+        }
     }
 
     function _authorize(address oapp) internal view {

--- a/solidity/contracts/mock/MockLayerZeroEndpointV2.sol
+++ b/solidity/contracts/mock/MockLayerZeroEndpointV2.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+import {MessagingFee as LayerZeroMessagingFee, MessagingParams as LayerZeroMessagingParams, MessagingReceipt as LayerZeroMessagingReceipt, Origin as LayerZeroOrigin} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {ILayerZeroReceiver} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol";
+import {SetConfigParam as LayerZeroSetConfigParam} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
+import {GUID} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
+import {Errors} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/Errors.sol";
+
+contract MockLayerZeroEndpointV2 {
+    struct ReceiveLibraryTimeout {
+        address libraryAddress;
+        uint256 expiry;
+    }
+
+    uint32 public immutable eid;
+    address public nativeToken;
+    uint256 public nativeFee = 0.01 ether;
+    uint256 public lzTokenFee;
+    bytes public lastPacket;
+    bytes public lastOptions;
+
+    mapping(address => address) public delegates;
+    mapping(address => bool) public registeredLibraries;
+    mapping(address => mapping(uint32 => address)) public sendLibraries;
+    mapping(address => mapping(uint32 => address)) public receiveLibraries;
+    mapping(address => mapping(uint32 => ReceiveLibraryTimeout))
+        public receiveLibraryTimeout;
+    mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => bytes))))
+        public configs;
+    mapping(address => mapping(uint32 => mapping(bytes32 => mapping(uint64 => bytes32))))
+        public payloadHashes;
+    mapping(address => mapping(uint32 => mapping(bytes32 => uint64)))
+        public lazyInboundNonce;
+    mapping(address => mapping(uint32 => mapping(bytes32 => uint64)))
+        public outboundNonces;
+
+    error Unauthorized();
+    error InvalidPayloadHash();
+    error SameValue();
+    error OnlyNonDefaultLibrary();
+    error InvalidExpiry();
+
+    event PacketSent(bytes encodedPayload, bytes options, address sendLibrary);
+
+    constructor(uint32 eid_) {
+        eid = eid_;
+    }
+
+    function setNativeToken(address token) external {
+        nativeToken = token;
+    }
+
+    function setNativeFee(uint256 fee) external {
+        nativeFee = fee;
+    }
+
+    function setLzTokenFee(uint256 fee) external {
+        lzTokenFee = fee;
+    }
+
+    function registerMockLibrary(address libraryAddress) external {
+        registeredLibraries[libraryAddress] = true;
+    }
+
+    function setDelegate(address delegate) external {
+        delegates[msg.sender] = delegate;
+    }
+
+    function quote(
+        LayerZeroMessagingParams calldata,
+        address
+    ) external view returns (LayerZeroMessagingFee memory) {
+        return
+            LayerZeroMessagingFee({
+                nativeFee: nativeFee,
+                lzTokenFee: lzTokenFee
+            });
+    }
+
+    function send(
+        LayerZeroMessagingParams calldata params,
+        address
+    ) external payable returns (LayerZeroMessagingReceipt memory receipt) {
+        require(msg.value >= nativeFee, "fee");
+        uint64 nonce = ++outboundNonces[msg.sender][params.dstEid][
+            params.receiver
+        ];
+        bytes32 sender = bytes32(uint256(uint160(msg.sender)));
+        bytes32 guid = GUID.generate(
+            nonce,
+            eid,
+            msg.sender,
+            params.dstEid,
+            params.receiver
+        );
+        lastPacket = abi.encodePacked(
+            uint8(1),
+            nonce,
+            eid,
+            sender,
+            params.dstEid,
+            params.receiver,
+            guid,
+            params.message
+        );
+        lastOptions = params.options;
+        emit PacketSent(
+            lastPacket,
+            params.options,
+            sendLibraries[msg.sender][params.dstEid]
+        );
+        receipt = LayerZeroMessagingReceipt({
+            guid: guid,
+            nonce: nonce,
+            fee: LayerZeroMessagingFee({
+                nativeFee: nativeFee,
+                lzTokenFee: lzTokenFee
+            })
+        });
+    }
+
+    function clear(
+        address oapp,
+        LayerZeroOrigin calldata origin,
+        bytes32 guid,
+        bytes calldata message
+    ) external {
+        _authorize(oapp);
+        _clear(oapp, origin, guid, message);
+    }
+
+    function mockExecute(
+        address receiver,
+        LayerZeroOrigin calldata origin,
+        bytes32 guid,
+        bytes calldata message
+    ) external {
+        _clear(receiver, origin, guid, message);
+        ILayerZeroReceiver(receiver).lzReceive(
+            origin,
+            guid,
+            message,
+            msg.sender,
+            ""
+        );
+    }
+
+    function _clear(
+        address oapp,
+        LayerZeroOrigin calldata origin,
+        bytes32 guid,
+        bytes calldata message
+    ) internal {
+        uint64 currentNonce = lazyInboundNonce[oapp][origin.srcEid][
+            origin.sender
+        ];
+        if (origin.nonce > currentNonce) {
+            // Endpoint V2 only clears packets in nonce order, even when an OApp
+            // opts into unordered verification by returning zero from nextNonce.
+            for (uint64 i = currentNonce + 1; i <= origin.nonce; ++i) {
+                if (
+                    payloadHashes[oapp][origin.srcEid][origin.sender][i] ==
+                    bytes32(0)
+                ) revert Errors.LZ_InvalidNonce(i);
+            }
+            lazyInboundNonce[oapp][origin.srcEid][origin.sender] = origin.nonce;
+        }
+        bytes32 expected = keccak256(abi.encodePacked(guid, message));
+        bytes32 current = payloadHashes[oapp][origin.srcEid][origin.sender][
+            origin.nonce
+        ];
+        if (current != expected) revert InvalidPayloadHash();
+        delete payloadHashes[oapp][origin.srcEid][origin.sender][origin.nonce];
+    }
+
+    function mockVerify(
+        address receiver,
+        uint32 srcEid,
+        bytes32 sender,
+        uint64 nonce,
+        bytes32 payloadHash
+    ) external {
+        require(registeredLibraries[msg.sender], "library");
+        payloadHashes[receiver][srcEid][sender][nonce] = payloadHash;
+    }
+
+    function mockDeliver(
+        address receiver,
+        LayerZeroOrigin calldata origin,
+        bytes32 guid,
+        bytes calldata message
+    ) external {
+        ILayerZeroReceiver(receiver).lzReceive(
+            origin,
+            guid,
+            message,
+            msg.sender,
+            ""
+        );
+    }
+
+    function inboundPayloadHash(
+        address receiver,
+        uint32 srcEid,
+        bytes32 sender,
+        uint64 nonce
+    ) external view returns (bytes32) {
+        return payloadHashes[receiver][srcEid][sender][nonce];
+    }
+
+    function isRegisteredLibrary(
+        address libraryAddress
+    ) external view returns (bool) {
+        return registeredLibraries[libraryAddress];
+    }
+
+    function isValidReceiveLibrary(
+        address receiver,
+        uint32 srcEid,
+        address libraryAddress
+    ) external view returns (bool) {
+        if (receiveLibraries[receiver][srcEid] == libraryAddress) return true;
+        ReceiveLibraryTimeout memory timeout = receiveLibraryTimeout[receiver][
+            srcEid
+        ];
+        return
+            timeout.libraryAddress == libraryAddress &&
+            timeout.expiry > block.number;
+    }
+
+    function setSendLibrary(
+        address oapp,
+        uint32 dstEid,
+        address newLibrary
+    ) external {
+        _authorize(oapp);
+        if (sendLibraries[oapp][dstEid] == newLibrary) revert SameValue();
+        sendLibraries[oapp][dstEid] = newLibrary;
+    }
+
+    function getSendLibrary(
+        address sender,
+        uint32 dstEid
+    ) external view returns (address) {
+        return sendLibraries[sender][dstEid];
+    }
+
+    function isDefaultSendLibrary(
+        address sender,
+        uint32 dstEid
+    ) external view returns (bool) {
+        return sendLibraries[sender][dstEid] == address(0);
+    }
+
+    function setReceiveLibrary(
+        address oapp,
+        uint32 srcEid,
+        address newLibrary,
+        uint256 gracePeriod
+    ) external {
+        _authorize(oapp);
+        address oldLibrary = receiveLibraries[oapp][srcEid];
+        if (oldLibrary == newLibrary) revert SameValue();
+        if (
+            gracePeriod != 0 &&
+            (oldLibrary == address(0) || newLibrary == address(0))
+        ) revert OnlyNonDefaultLibrary();
+        receiveLibraries[oapp][srcEid] = newLibrary;
+        if (gracePeriod == 0) {
+            delete receiveLibraryTimeout[oapp][srcEid];
+        } else {
+            receiveLibraryTimeout[oapp][srcEid] = ReceiveLibraryTimeout({
+                libraryAddress: oldLibrary,
+                expiry: block.number + gracePeriod
+            });
+        }
+    }
+
+    function getReceiveLibrary(
+        address receiver,
+        uint32 srcEid
+    ) external view returns (address libraryAddress, bool isDefault) {
+        libraryAddress = receiveLibraries[receiver][srcEid];
+        isDefault = libraryAddress == address(0);
+    }
+
+    function setReceiveLibraryTimeout(
+        address oapp,
+        uint32 srcEid,
+        address libraryAddress,
+        uint256 expiry
+    ) external {
+        _authorize(oapp);
+        if (expiry == 0) {
+            delete receiveLibraryTimeout[oapp][srcEid];
+        } else {
+            if (expiry <= block.number) revert InvalidExpiry();
+            receiveLibraryTimeout[oapp][srcEid] = ReceiveLibraryTimeout({
+                libraryAddress: libraryAddress,
+                expiry: expiry
+            });
+        }
+    }
+
+    function setConfig(
+        address oapp,
+        address libraryAddress,
+        LayerZeroSetConfigParam[] calldata params
+    ) external {
+        _authorize(oapp);
+        for (uint256 i = 0; i < params.length; ++i) {
+            configs[oapp][libraryAddress][params[i].eid][
+                params[i].configType
+            ] = params[i].config;
+        }
+    }
+
+    function getConfig(
+        address oapp,
+        address libraryAddress,
+        uint32 remoteEid,
+        uint32 configType
+    ) external view returns (bytes memory) {
+        return configs[oapp][libraryAddress][remoteEid][configType];
+    }
+
+    function _authorize(address oapp) internal view {
+        if (msg.sender != oapp && msg.sender != delegates[oapp]) {
+            revert Unauthorized();
+        }
+    }
+}

--- a/solidity/contracts/mock/MockLayerZeroReceiveUln.sol
+++ b/solidity/contracts/mock/MockLayerZeroReceiveUln.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.20;
 
+import {ExecutorConfig} from "@layerzerolabs/lz-evm-messagelib-v2/contracts/SendLibBase.sol";
+import {UlnConfig} from "@layerzerolabs/lz-evm-messagelib-v2/contracts/uln/UlnBase.sol";
 import {MockLayerZeroEndpointV2} from "./MockLayerZeroEndpointV2.sol";
 
 contract MockLayerZeroReceiveUln {
+    uint8 internal constant NIL_DVN_COUNT = type(uint8).max;
+    uint64 internal constant NIL_CONFIRMATIONS = type(uint64).max;
+
     MockLayerZeroEndpointV2 public immutable endpoint;
     bool public ready = true;
 
@@ -13,6 +18,117 @@ contract MockLayerZeroReceiveUln {
 
     function setReady(bool ready_) external {
         ready = ready_;
+    }
+
+    function executorConfigs(
+        address oapp,
+        uint32 remoteEid
+    ) external view returns (ExecutorConfig memory config) {
+        bytes memory encoded = endpoint.configs(
+            oapp,
+            address(this),
+            remoteEid,
+            1
+        );
+        if (encoded.length != 0) config = abi.decode(encoded, (ExecutorConfig));
+    }
+
+    function getAppUlnConfig(
+        address oapp,
+        uint32 remoteEid
+    ) external view returns (UlnConfig memory config) {
+        bytes memory encoded = endpoint.configs(
+            oapp,
+            address(this),
+            remoteEid,
+            2
+        );
+        if (encoded.length != 0) config = abi.decode(encoded, (UlnConfig));
+    }
+
+    function getDefaultConfig(
+        uint32 configType
+    ) external view returns (bytes memory) {
+        if (configType == 1) {
+            return
+                abi.encode(
+                    ExecutorConfig({
+                        maxMessageSize: 10_000,
+                        executor: address(this)
+                    })
+                );
+        }
+        require(configType == 2, "config type");
+        address[] memory requiredDVNs = new address[](1);
+        requiredDVNs[0] = address(this);
+        return
+            abi.encode(
+                UlnConfig({
+                    confirmations: 12,
+                    requiredDVNCount: 1,
+                    optionalDVNCount: 0,
+                    optionalDVNThreshold: 0,
+                    requiredDVNs: requiredDVNs,
+                    optionalDVNs: new address[](0)
+                })
+            );
+    }
+
+    function getEffectiveConfig(
+        address oapp,
+        uint32 remoteEid,
+        uint32 configType
+    ) external view returns (bytes memory) {
+        if (configType == 1) {
+            ExecutorConfig memory executorDefaults = abi.decode(
+                this.getDefaultConfig(configType),
+                (ExecutorConfig)
+            );
+            ExecutorConfig memory appExecutor = this.executorConfigs(
+                oapp,
+                remoteEid
+            );
+            if (appExecutor.maxMessageSize != 0) {
+                executorDefaults.maxMessageSize = appExecutor.maxMessageSize;
+            }
+            if (appExecutor.executor != address(0)) {
+                executorDefaults.executor = appExecutor.executor;
+            }
+            return abi.encode(executorDefaults);
+        }
+        require(configType == 2, "config type");
+        UlnConfig memory ulnDefaults = abi.decode(
+            this.getDefaultConfig(configType),
+            (UlnConfig)
+        );
+        UlnConfig memory appUln = this.getAppUlnConfig(oapp, remoteEid);
+        if (appUln.confirmations != 0) {
+            ulnDefaults.confirmations = appUln.confirmations ==
+                NIL_CONFIRMATIONS
+                ? 0
+                : appUln.confirmations;
+        }
+        if (appUln.requiredDVNCount != 0) {
+            if (appUln.requiredDVNCount == NIL_DVN_COUNT) {
+                ulnDefaults.requiredDVNCount = 0;
+                ulnDefaults.requiredDVNs = new address[](0);
+            } else {
+                ulnDefaults.requiredDVNCount = appUln.requiredDVNCount;
+                ulnDefaults.requiredDVNs = appUln.requiredDVNs;
+            }
+        }
+        if (appUln.optionalDVNCount != 0) {
+            if (appUln.optionalDVNCount == NIL_DVN_COUNT) {
+                ulnDefaults.optionalDVNCount = 0;
+                ulnDefaults.optionalDVNThreshold = 0;
+                ulnDefaults.optionalDVNs = new address[](0);
+            } else {
+                ulnDefaults.optionalDVNCount = appUln.optionalDVNCount;
+                ulnDefaults.optionalDVNThreshold = appUln.optionalDVNThreshold;
+                ulnDefaults.optionalDVNs = appUln.optionalDVNs;
+            }
+        }
+        return abi.encode(ulnDefaults);
     }
 
     function commitVerification(

--- a/solidity/contracts/mock/MockLayerZeroReceiveUln.sol
+++ b/solidity/contracts/mock/MockLayerZeroReceiveUln.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.20;
+
+import {MockLayerZeroEndpointV2} from "./MockLayerZeroEndpointV2.sol";
+
+contract MockLayerZeroReceiveUln {
+    MockLayerZeroEndpointV2 public immutable endpoint;
+    bool public ready = true;
+
+    constructor(address endpoint_) {
+        endpoint = MockLayerZeroEndpointV2(endpoint_);
+    }
+
+    function setReady(bool ready_) external {
+        ready = ready_;
+    }
+
+    function commitVerification(
+        bytes calldata packetHeader,
+        bytes32 payloadHash
+    ) external {
+        require(ready, "DVNs pending");
+        require(packetHeader.length == 81, "header");
+        uint64 nonce;
+        uint32 srcEid;
+        bytes32 sender;
+        address receiver;
+        assembly ("memory-safe") {
+            nonce := shr(192, calldataload(add(packetHeader.offset, 1)))
+            srcEid := shr(224, calldataload(add(packetHeader.offset, 9)))
+            sender := calldataload(add(packetHeader.offset, 13))
+            receiver := calldataload(add(packetHeader.offset, 49))
+        }
+        endpoint.mockVerify(receiver, srcEid, sender, nonce, payloadHash);
+    }
+}

--- a/solidity/foundry.toml
+++ b/solidity/foundry.toml
@@ -3,6 +3,12 @@ src = 'contracts'
 script = 'script'
 out = 'out'
 libs = ["dependencies", "lib"]
+remappings = [
+    "@layerzerolabs/lz-evm-messagelib-v2/=dependencies/layerzero-v2-2.0.2/packages/layerzero-v2/evm/messagelib/",
+    "@layerzerolabs/lz-evm-protocol-v2/=dependencies/layerzero-v2-2.0.2/packages/layerzero-v2/evm/protocol/",
+    "@layerzerolabs/oapp-evm/=dependencies/layerzero-v2-2.0.2/packages/layerzero-v2/evm/oapp/",
+    "solidity-bytes-utils/=node_modules/solidity-bytes-utils/",
+]
 test = 'test'
 cache_path = 'forge-cache'
 solc_version = '0.8.33'
@@ -15,16 +21,28 @@ fs_permissions = [
 ]
 ignored_warnings_from = ['lib', 'test', 'contracts/test']
 
-# Pin CrossCollateralRouter below the suite-wide optimizer_runs to keep its
-# runtime bytecode under the EIP-170 24576-byte limit. Mirrors the Hardhat
-# overrides entry in rootHardhatConfig.cts; keep the two in sync.
+# Pin large contracts below the suite-wide optimizer_runs to keep their runtime
+# bytecode under the EIP-170 24576-byte limit. Mirrors hardhat.config.cts; keep
+# the two files in sync.
 [[profile.default.additional_compiler_profiles]]
 name = "size-optimized"
 optimizer_runs = 3_599
 
+[[profile.default.additional_compiler_profiles]]
+name = "layerzero-size-optimized"
+optimizer_runs = 2_239
+
 [[profile.default.compilation_restrictions]]
 paths = "contracts/token/CrossCollateralRouter.sol"
 optimizer_runs = 3_599
+
+[[profile.default.compilation_restrictions]]
+paths = "contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol"
+optimizer_runs = 2_239
+
+[[profile.default.compilation_restrictions]]
+paths = "test/hooks/LayerZeroV2HookIsm.t.sol"
+optimizer_runs = 2_239
 
 [profile.ci]
 verbosity = 4
@@ -36,8 +54,8 @@ bytecode_hash = "none"
 # Reduce optimizer runs for coverage to save memory (25k -> 200)
 optimizer_runs = 200
 # `forge coverage` drops ~half the contracts from the report when compilation is
-# split across profiles. Clear the CrossCollateralRouter size pin here: coverage
-# never deploys (EIP-170 is irrelevant) and needs a single uniform compilation.
+# split across profiles. Clear the size pins here: coverage never deploys
+# (EIP-170 is irrelevant) and needs a single uniform compilation.
 compilation_restrictions = []
 
 [profile.tron]
@@ -54,8 +72,12 @@ remappings = [
     "@arbitrum/nitro-contracts/src/=dependencies/@arbitrum-nitro-contracts-1.2.1/src/",
     "@chainlink/contracts-ccip/src/v0.8/=dependencies/@chainlink-contracts-ccip-1.5.0/contracts/src/v0.8/",
     "@eth-optimism/contracts/=dependencies/@eth-optimism-contracts-0.6.0/packages/contracts/contracts/",
+    "@layerzerolabs/lz-evm-messagelib-v2/=dependencies/layerzero-v2-2.0.2/packages/layerzero-v2/evm/messagelib/",
+    "@layerzerolabs/lz-evm-protocol-v2/=dependencies/layerzero-v2-2.0.2/packages/layerzero-v2/evm/protocol/",
+    "@layerzerolabs/oapp-evm/=dependencies/layerzero-v2-2.0.2/packages/layerzero-v2/evm/oapp/",
     "forge-std/=dependencies/forge-std-1.9.2/src/",
     "ds-test/=dependencies/forge-std-1.9.2/lib/ds-test/src/",
+    "solidity-bytes-utils/=node_modules/solidity-bytes-utils/",
 ]
 
 [rpc_endpoints]
@@ -82,6 +104,7 @@ forge-std = "1.9.2"
 "@predicate-contracts" = { version = "2.2.2", git = "https://github.com/predicatelabs/predicate-contracts.git", tag = "v2.2.2" }
 permit2 = { version = "1.0.0", git = "https://github.com/Uniswap/permit2", branch = "main" }
 wormhole-solidity-sdk = { version = "1.1.0", git = "https://github.com/wormhole-foundation/wormhole-solidity-sdk.git", tag = "v1.1.0" }
+layerzero-v2 = { version = "2.0.2", git = "https://github.com/LayerZero-Labs/LayerZero-v2.git", rev = "9c741e7f9790639537b1710a203bcdfd73b0b9ac" }
 
 [soldeer]
 remappings_generate = false  # We'll manage remappings manually to preserve import paths

--- a/solidity/hardhat.config.cts
+++ b/solidity/hardhat.config.cts
@@ -16,9 +16,9 @@ module.exports = {
   solidity: {
     compilers: [rootHardhatConfig.solidity],
     overrides: {
-      // Pinned below the suite-wide runs to keep the runtime bytecode under the
-      // EIP-170 24576-byte limit. Mirrors the Foundry compilation_restrictions
-      // entry in foundry.toml; keep the two in sync.
+      // Pinned below the suite-wide runs to keep runtime bytecode under the
+      // EIP-170 24576-byte limit. Mirrors Foundry compilation_restrictions;
+      // keep the two files in sync.
       'contracts/token/CrossCollateralRouter.sol': {
         ...rootHardhatConfig.solidity,
         settings: {
@@ -26,6 +26,16 @@ module.exports = {
           optimizer: {
             ...rootHardhatConfig.solidity.settings.optimizer,
             runs: 3_599,
+          },
+        },
+      },
+      'contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol': {
+        ...rootHardhatConfig.solidity,
+        settings: {
+          ...rootHardhatConfig.solidity.settings,
+          optimizer: {
+            ...rootHardhatConfig.solidity.settings.optimizer,
+            runs: 2_239,
           },
         },
       },

--- a/solidity/soldeer.lock
+++ b/solidity/soldeer.lock
@@ -42,6 +42,12 @@ checksum = "20fd008c7c69b6c737cc0284469d1c76497107bc3e004d8381f6d8781cb27980"
 integrity = "f49457fb6591f0dfd8b59e02e6eb4508a115ef08a86b0803feb0a3939d82d783"
 
 [[dependencies]]
+name = "layerzero-v2"
+version = "2.0.2"
+git = "https://github.com/LayerZero-Labs/LayerZero-v2.git"
+rev = "9c741e7f9790639537b1710a203bcdfd73b0b9ac"
+
+[[dependencies]]
 name = "permit2"
 version = "1.0.0"
 git = "https://github.com/Uniswap/permit2"

--- a/solidity/test/hooks/LayerZeroV2HookIsm.fork.t.sol
+++ b/solidity/test/hooks/LayerZeroV2HookIsm.fork.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ILayerZeroEndpointV2} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {SetConfigParam as LayerZeroSetConfigParam} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
+import {AbstractLayerZeroV2HookIsm} from "contracts/hooks/layerzero/AbstractLayerZeroV2HookIsm.sol";
+import {LayerZeroV2CallbackHookIsm} from "contracts/hooks/layerzero/LayerZeroV2CallbackHookIsm.sol";
+import {LayerZeroV2CcipReadHookIsm} from "contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol";
+import {IPostDispatchHook} from "contracts/interfaces/hooks/IPostDispatchHook.sol";
+import {Message} from "contracts/libs/Message.sol";
+import {TypeCasts} from "contracts/libs/TypeCasts.sol";
+import {TestMailbox} from "contracts/test/TestMailbox.sol";
+import {TestPostDispatchHook} from "contracts/test/TestPostDispatchHook.sol";
+
+contract LayerZeroV2HookIsmForkTest is Test {
+    using Message for bytes;
+    using TypeCasts for address;
+
+    uint32 internal constant ETHEREUM_DOMAIN = 1;
+    uint32 internal constant ARBITRUM_DOMAIN = 42_161;
+    uint32 internal constant ETHEREUM_EID = 30_101;
+    uint32 internal constant ARBITRUM_EID = 30_110;
+    uint128 internal constant CALLBACK_GAS = 250_000;
+    uint256 internal constant ETHEREUM_FORK_BLOCK = 25_878_200;
+
+    ILayerZeroEndpointV2 internal constant ENDPOINT =
+        ILayerZeroEndpointV2(0x1a44076050125825900e736c501f859c50fE728c);
+    address internal constant SEND_ULN_302 =
+        0xbB2Ea70C9E858123480642Cf96acbcCE1372dCe1;
+    address internal constant RECEIVE_ULN_302 =
+        0xc02Ab410f0734EFa3F14628780e6e695156024C2;
+
+    TestMailbox internal mailbox;
+    LayerZeroV2CallbackHookIsm internal router;
+
+    function setUp() public {
+        string memory rpcUrl = vm.envOr("LAYERZERO_FORK_RPC_URL", string(""));
+        if (bytes(rpcUrl).length == 0) {
+            vm.skip(true);
+            return;
+        }
+        vm.createSelectFork(rpcUrl, ETHEREUM_FORK_BLOCK);
+
+        assertEq(ENDPOINT.eid(), ETHEREUM_EID);
+        assertEq(ENDPOINT.nativeToken(), address(0));
+        assertTrue(ENDPOINT.isRegisteredLibrary(SEND_ULN_302));
+        assertTrue(ENDPOINT.isRegisteredLibrary(RECEIVE_ULN_302));
+
+        mailbox = new TestMailbox(ETHEREUM_DOMAIN);
+        TestPostDispatchHook noopHook = new TestPostDispatchHook();
+        mailbox.setDefaultHook(address(noopHook));
+        mailbox.setRequiredHook(address(noopHook));
+        router = new LayerZeroV2CallbackHookIsm(
+            address(mailbox),
+            address(ENDPOINT)
+        );
+    }
+
+    function testProductionEndpointEnrollmentConfigUpdateAndQuote() public {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        router.enrollLayerZeroRemoteRouter(
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: ARBITRUM_DOMAIN,
+                router: address(0xBEEF).addressToBytes32(),
+                eid: ARBITRUM_EID,
+                sendLibrary: SEND_ULN_302,
+                receiveLibrary: RECEIVE_ULN_302,
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            }),
+            CALLBACK_GAS
+        );
+
+        assertEq(
+            ENDPOINT.getSendLibrary(address(router), ARBITRUM_EID),
+            SEND_ULN_302
+        );
+        (address receiveLibrary, bool isDefault) = ENDPOINT.getReceiveLibrary(
+            address(router),
+            ARBITRUM_EID
+        );
+        assertEq(receiveLibrary, RECEIVE_ULN_302);
+        assertFalse(isDefault);
+
+        bytes memory executorConfig = ENDPOINT.getConfig(
+            address(router),
+            SEND_ULN_302,
+            ARBITRUM_EID,
+            1
+        );
+        (uint32 maxMessageSize, address executor) = abi.decode(
+            executorConfig,
+            (uint32, address)
+        );
+        assertGt(maxMessageSize, 1);
+        bytes memory updatedExecutorConfig = abi.encode(
+            maxMessageSize - 1,
+            executor
+        );
+        LayerZeroSetConfigParam[]
+            memory sendConfig = new LayerZeroSetConfigParam[](1);
+        sendConfig[0] = LayerZeroSetConfigParam({
+            eid: ARBITRUM_EID,
+            configType: 1,
+            config: updatedExecutorConfig
+        });
+
+        router.updateLayerZeroRemoteRouterConfig(
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: ARBITRUM_DOMAIN,
+                router: address(0xCAFE).addressToBytes32(),
+                receiveLibraryTimeout: RECEIVE_ULN_302,
+                receiveLibraryTimeoutExpiry: block.number + 100,
+                sendConfig: sendConfig,
+                receiveConfig: emptyConfig
+            }),
+            275_000
+        );
+
+        assertEq(
+            ENDPOINT.getConfig(address(router), SEND_ULN_302, ARBITRUM_EID, 1),
+            updatedExecutorConfig
+        );
+        assertEq(
+            router.routers(ARBITRUM_DOMAIN),
+            address(0xCAFE).addressToBytes32()
+        );
+        assertEq(router.callbackGasLimits(ARBITRUM_DOMAIN), 275_000);
+        (address timeoutLibrary, uint256 timeoutExpiry) = ENDPOINT
+            .receiveLibraryTimeout(address(router), ARBITRUM_EID);
+        assertEq(timeoutLibrary, RECEIVE_ULN_302);
+        assertEq(timeoutExpiry, block.number + 100);
+
+        router.updateLayerZeroRemoteRouterConfig(
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: ARBITRUM_DOMAIN,
+                router: address(0xCAFE).addressToBytes32(),
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            }),
+            275_000
+        );
+        (timeoutLibrary, timeoutExpiry) = ENDPOINT.receiveLibraryTimeout(
+            address(router),
+            ARBITRUM_EID
+        );
+        assertEq(timeoutLibrary, address(0));
+        assertEq(timeoutExpiry, 0);
+
+        bytes memory message = mailbox.buildOutboundMessage(
+            ARBITRUM_DOMAIN,
+            address(0x1234).addressToBytes32(),
+            bytes("fork quote")
+        );
+        assertGt(router.quoteDispatch("", message), 0);
+    }
+
+    function testProductionEndpointCcipReadEnrollmentAndQuote() public {
+        string[] memory urls = new string[](1);
+        urls[0] = "https://example.com/layerzero";
+        LayerZeroV2CcipReadHookIsm ccipRouter = new LayerZeroV2CcipReadHookIsm(
+            address(mailbox),
+            address(ENDPOINT),
+            urls
+        );
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        ccipRouter.enrollLayerZeroRemoteRouter(
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: ARBITRUM_DOMAIN,
+                router: address(0xBEEF).addressToBytes32(),
+                eid: ARBITRUM_EID,
+                sendLibrary: SEND_ULN_302,
+                receiveLibrary: RECEIVE_ULN_302,
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+
+        bytes memory message = mailbox.buildOutboundMessage(
+            ARBITRUM_DOMAIN,
+            address(0x1234).addressToBytes32(),
+            bytes("fork pull quote")
+        );
+        uint256 fee = ccipRouter.quoteDispatch("", message);
+        assertGt(fee, 0);
+        vm.deal(address(this), fee);
+        mailbox.dispatch{value: fee}(
+            ARBITRUM_DOMAIN,
+            address(0x1234).addressToBytes32(),
+            bytes("fork pull quote"),
+            "",
+            IPostDispatchHook(address(ccipRouter))
+        );
+        assertTrue(ccipRouter.sent(message.id()));
+    }
+}

--- a/solidity/test/hooks/LayerZeroV2HookIsm.t.sol
+++ b/solidity/test/hooks/LayerZeroV2HookIsm.t.sol
@@ -1,0 +1,2219 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {Origin as LayerZeroOrigin} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {SetConfigParam as LayerZeroSetConfigParam} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
+import {GUID} from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/GUID.sol";
+import {PacketV1Codec} from "@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol";
+import {AbstractLayerZeroV2HookIsm} from "contracts/hooks/layerzero/AbstractLayerZeroV2HookIsm.sol";
+import {LayerZeroV2CallbackHookIsm} from "contracts/hooks/layerzero/LayerZeroV2CallbackHookIsm.sol";
+import {LayerZeroV2CcipReadHookIsm} from "contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol";
+import {IInterchainSecurityModule} from "contracts/interfaces/IInterchainSecurityModule.sol";
+import {IPostDispatchHook} from "contracts/interfaces/hooks/IPostDispatchHook.sol";
+import {ICcipReadIsm} from "contracts/interfaces/isms/ICcipReadIsm.sol";
+import {StaticAggregationIsmFactory} from "contracts/isms/aggregation/StaticAggregationIsmFactory.sol";
+import {DomainRoutingIsm} from "contracts/isms/routing/DomainRoutingIsm.sol";
+import {LayerZeroMessage} from "contracts/libs/LayerZeroMessage.sol";
+import {LayerZeroMetadata} from "contracts/libs/LayerZeroMetadata.sol";
+import {Message} from "contracts/libs/Message.sol";
+import {TypeCasts} from "contracts/libs/TypeCasts.sol";
+import {StandardHookMetadata} from "contracts/hooks/libs/StandardHookMetadata.sol";
+import {MockLayerZeroEndpointV2} from "contracts/mock/MockLayerZeroEndpointV2.sol";
+import {MockLayerZeroReceiveUln} from "contracts/mock/MockLayerZeroReceiveUln.sol";
+import {TestMailbox} from "contracts/test/TestMailbox.sol";
+import {TestIsm} from "contracts/test/TestIsm.sol";
+import {TestPostDispatchHook} from "contracts/test/TestPostDispatchHook.sol";
+import {TestRecipient} from "contracts/test/TestRecipient.sol";
+
+abstract contract LayerZeroV2HookIsmTestBase is Test {
+    using Message for bytes;
+    using TypeCasts for address;
+
+    uint32 internal constant ORIGIN = 1000;
+    uint32 internal constant DESTINATION = 2000;
+    uint32 internal constant SECOND_DESTINATION = 2001;
+    uint32 internal constant ORIGIN_EID = 30101;
+    uint32 internal constant DESTINATION_EID = 30111;
+    uint32 internal constant SECOND_DESTINATION_EID = 30112;
+    uint128 internal constant CALLBACK_GAS = 250_000;
+    uint256 internal constant NATIVE_FEE = 0.01 ether;
+    uint256 internal constant EIP_170_MAX_CODE_SIZE = 24_576;
+
+    TestMailbox internal originMailbox;
+    TestMailbox internal destinationMailbox;
+    MockLayerZeroEndpointV2 internal originEndpoint;
+    MockLayerZeroEndpointV2 internal destinationEndpoint;
+    MockLayerZeroReceiveUln internal originUln;
+    MockLayerZeroReceiveUln internal destinationUln;
+    TestPostDispatchHook internal noopHook;
+    TestRecipient internal recipient;
+    AbstractLayerZeroV2HookIsm internal originRouter;
+    AbstractLayerZeroV2HookIsm internal destinationRouter;
+
+    function setUp() public virtual {
+        originMailbox = new TestMailbox(ORIGIN);
+        destinationMailbox = new TestMailbox(DESTINATION);
+        originEndpoint = new MockLayerZeroEndpointV2(ORIGIN_EID);
+        destinationEndpoint = new MockLayerZeroEndpointV2(DESTINATION_EID);
+        originUln = new MockLayerZeroReceiveUln(address(originEndpoint));
+        destinationUln = new MockLayerZeroReceiveUln(
+            address(destinationEndpoint)
+        );
+        originEndpoint.registerMockLibrary(address(originUln));
+        destinationEndpoint.registerMockLibrary(address(destinationUln));
+        noopHook = new TestPostDispatchHook();
+        recipient = new TestRecipient();
+
+        originMailbox.setDefaultHook(address(noopHook));
+        originMailbox.setRequiredHook(address(noopHook));
+        destinationMailbox.setDefaultHook(address(noopHook));
+        destinationMailbox.setRequiredHook(address(noopHook));
+        destinationMailbox.setDefaultIsm(address(noopHook));
+
+        originRouter = _deploy(address(originMailbox), address(originEndpoint));
+        destinationRouter = _deploy(
+            address(destinationMailbox),
+            address(destinationEndpoint)
+        );
+        _configure(
+            originRouter,
+            originEndpoint,
+            originUln,
+            DESTINATION,
+            DESTINATION_EID,
+            address(destinationRouter)
+        );
+        _configure(
+            destinationRouter,
+            destinationEndpoint,
+            destinationUln,
+            ORIGIN,
+            ORIGIN_EID,
+            address(originRouter)
+        );
+        recipient.setInterchainSecurityModule(address(destinationRouter));
+        vm.deal(address(this), 10 ether);
+    }
+
+    function _deploy(
+        address mailbox,
+        address endpoint
+    ) internal virtual returns (AbstractLayerZeroV2HookIsm);
+
+    function _enrollVariant(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment memory enrollment
+    ) internal virtual;
+
+    function _updateVariant(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate memory update_
+    ) internal virtual;
+
+    function _updateVariants(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[] memory updates
+    ) internal virtual;
+
+    function _configure(
+        AbstractLayerZeroV2HookIsm router,
+        MockLayerZeroEndpointV2,
+        MockLayerZeroReceiveUln uln,
+        uint32 domain,
+        uint32 eid,
+        address remote
+    ) internal {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        _enrollVariant(
+            router,
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: domain,
+                router: remote.addressToBytes32(),
+                eid: eid,
+                sendLibrary: address(uln),
+                receiveLibrary: address(uln),
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+    }
+
+    function _dispatch()
+        internal
+        returns (bytes memory message, bytes32 messageId)
+    {
+        bytes memory body = bytes("hyperlane over layerzero");
+        message = originMailbox.buildOutboundMessage(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            body
+        );
+        messageId = message.id();
+        originMailbox.dispatch{value: NATIVE_FEE}(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            body,
+            "",
+            IPostDispatchHook(address(originRouter))
+        );
+    }
+
+    function _defaultEnrollment()
+        internal
+        view
+        returns (AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment memory)
+    {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        return
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: DESTINATION,
+                router: address(destinationRouter).addressToBytes32(),
+                eid: DESTINATION_EID,
+                sendLibrary: address(originUln),
+                receiveLibrary: address(originUln),
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            });
+    }
+
+    function testConstructorRejectsInvalidEndpoints() public {
+        vm.expectRevert(
+            AbstractLayerZeroV2HookIsm.InvalidLayerZeroEndpoint.selector
+        );
+        _deploy(address(originMailbox), address(0));
+
+        MockLayerZeroEndpointV2 zeroEidEndpoint = new MockLayerZeroEndpointV2(
+            0
+        );
+        vm.expectRevert(AbstractLayerZeroV2HookIsm.InvalidLocalEid.selector);
+        _deploy(address(originMailbox), address(zeroEidEndpoint));
+
+        MockLayerZeroEndpointV2 tokenEndpoint = new MockLayerZeroEndpointV2(
+            ORIGIN_EID
+        );
+        tokenEndpoint.setNativeToken(address(0xBEEF));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm
+                    .UnsupportedNativeTokenEndpoint
+                    .selector,
+                address(0xBEEF)
+            )
+        );
+        _deploy(address(originMailbox), address(tokenEndpoint));
+    }
+
+    function testHookTypeAndPathInitialization() public view {
+        assertEq(
+            originRouter.hookType(),
+            uint8(IPostDispatchHook.HookTypes.LAYER_ZERO)
+        );
+        assertTrue(
+            originRouter.allowInitializePath(
+                LayerZeroOrigin({
+                    srcEid: DESTINATION_EID,
+                    sender: address(destinationRouter).addressToBytes32(),
+                    nonce: 1
+                })
+            )
+        );
+        assertFalse(
+            originRouter.allowInitializePath(
+                LayerZeroOrigin({
+                    srcEid: DESTINATION_EID,
+                    sender: address(0xBEEF).addressToBytes32(),
+                    nonce: 1
+                })
+            )
+        );
+        assertFalse(
+            originRouter.allowInitializePath(
+                LayerZeroOrigin({
+                    srcEid: SECOND_DESTINATION_EID,
+                    sender: bytes32(0),
+                    nonce: 1
+                })
+            )
+        );
+    }
+
+    function testRejectsPartialEnrollmentAndUnsupportedHandle() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.IncompleteLayerZeroRoute.selector,
+                0
+            )
+        );
+        originRouter.enrollRemoteRouter(
+            SECOND_DESTINATION,
+            address(0xBEEF).addressToBytes32()
+        );
+
+        vm.prank(address(originMailbox));
+        vm.expectRevert(
+            AbstractLayerZeroV2HookIsm.HyperlaneHandleUnsupported.selector
+        );
+        originRouter.handle(
+            DESTINATION,
+            address(destinationRouter).addressToBytes32(),
+            ""
+        );
+    }
+
+    function testUnenrollClearsRouteAndRejectsUnknownRoute() public {
+        originRouter.unenrollRemoteRouter(DESTINATION);
+        assertEq(originRouter.routers(DESTINATION), bytes32(0));
+        uint32 eid = originRouter.remoteConfigs(DESTINATION);
+        assertEq(eid, 0);
+        assertEq(originRouter.domainsByEid(DESTINATION_EID), 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.UnknownLayerZeroRoute.selector,
+                DESTINATION
+            )
+        );
+        originRouter.unenrollRemoteRouter(DESTINATION);
+    }
+
+    function testEnrollmentValidation() public {
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment
+            memory enrollment = _defaultEnrollment();
+
+        enrollment.domain = ORIGIN;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.InvalidRemoteDomain.selector,
+                ORIGIN
+            )
+        );
+        _enrollVariant(originRouter, enrollment);
+
+        enrollment = _defaultEnrollment();
+        enrollment.eid = ORIGIN_EID;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.InvalidRemoteEid.selector,
+                ORIGIN_EID
+            )
+        );
+        _enrollVariant(originRouter, enrollment);
+
+        enrollment = _defaultEnrollment();
+        enrollment.router = bytes32(type(uint256).max);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.NonCanonicalLayerZeroPeer.selector,
+                bytes32(type(uint256).max)
+            )
+        );
+        _enrollVariant(originRouter, enrollment);
+
+        enrollment = _defaultEnrollment();
+        enrollment.eid = SECOND_DESTINATION_EID;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm
+                    .LayerZeroEidChangeRequiresUnenrollment
+                    .selector,
+                DESTINATION
+            )
+        );
+        _enrollVariant(originRouter, enrollment);
+
+        enrollment = _defaultEnrollment();
+        enrollment.domain = SECOND_DESTINATION;
+        enrollment.router = address(0xBEEF).addressToBytes32();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.LayerZeroEidAlreadyEnrolled.selector,
+                DESTINATION_EID,
+                DESTINATION
+            )
+        );
+        _enrollVariant(originRouter, enrollment);
+
+        enrollment = _defaultEnrollment();
+        enrollment.receiveLibraryGracePeriod = 1;
+        vm.expectRevert(
+            AbstractLayerZeroV2HookIsm
+                .InvalidLayerZeroReceiveLibraryGracePeriod
+                .selector
+        );
+        _enrollVariant(originRouter, enrollment);
+    }
+
+    function testRejectsMismatchedReceiveLibraryTimeout() public {
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment
+            memory enrollment = _defaultEnrollment();
+        enrollment.receiveLibraryTimeout = address(originUln);
+        vm.expectRevert(
+            AbstractLayerZeroV2HookIsm
+                .InvalidLayerZeroReceiveLibraryTimeout
+                .selector
+        );
+        _enrollVariant(originRouter, enrollment);
+
+        enrollment = _defaultEnrollment();
+        enrollment.receiveLibraryTimeoutExpiry = block.number + 1;
+        vm.expectRevert(
+            AbstractLayerZeroV2HookIsm
+                .InvalidLayerZeroReceiveLibraryTimeout
+                .selector
+        );
+        _enrollVariant(originRouter, enrollment);
+    }
+
+    function testDispatchRejectsInvalidStateAndFees() public {
+        bytes memory message = originMailbox.buildOutboundMessage(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            bytes("not dispatched")
+        );
+        bytes32 messageId = message.id();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.MessageNotLatestDispatched.selector,
+                messageId
+            )
+        );
+        originRouter.postDispatch{value: NATIVE_FEE}("", message);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.InsufficientLayerZeroFee.selector,
+                NATIVE_FEE,
+                0
+            )
+        );
+        originMailbox.dispatch(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            bytes("insufficient"),
+            "",
+            IPostDispatchHook(address(originRouter))
+        );
+
+        (message, messageId) = _dispatch();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm
+                    .LayerZeroAuthorizationAlreadySent
+                    .selector,
+                messageId
+            )
+        );
+        originRouter.postDispatch{value: NATIVE_FEE}("", message);
+    }
+
+    function testRejectsLayerZeroTokenFees() public {
+        bytes memory message = originMailbox.buildOutboundMessage(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            bytes("lz token fee")
+        );
+        originEndpoint.setLzTokenFee(1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm
+                    .UnsupportedLayerZeroTokenFee
+                    .selector,
+                1
+            )
+        );
+        originRouter.quoteDispatch("", message);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm
+                    .UnsupportedLayerZeroTokenFee
+                    .selector,
+                1
+            )
+        );
+        originMailbox.dispatch{value: NATIVE_FEE}(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            bytes("lz token fee"),
+            "",
+            IPostDispatchHook(address(originRouter))
+        );
+    }
+
+    function testRejectsUnsupportedMetadata() public view {
+        bytes memory metadata = StandardHookMetadata.formatWithFeeToken(
+            0,
+            0,
+            address(this),
+            address(0xBEEF)
+        );
+        assertFalse(originRouter.supportsMetadata(metadata));
+        metadata = StandardHookMetadata.overrideMsgValue(1);
+        assertFalse(originRouter.supportsMetadata(metadata));
+    }
+
+    function testConfigurationRemainsMutable() public {
+        assertEq(originEndpoint.delegates(address(originRouter)), address(0));
+        MockLayerZeroReceiveUln replacement = new MockLayerZeroReceiveUln(
+            address(originEndpoint)
+        );
+        originEndpoint.registerMockLibrary(address(replacement));
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        _enrollVariant(
+            originRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: DESTINATION,
+                router: address(destinationRouter).addressToBytes32(),
+                eid: DESTINATION_EID,
+                sendLibrary: address(replacement),
+                receiveLibrary: address(originUln),
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+        assertEq(
+            originEndpoint.getSendLibrary(
+                address(originRouter),
+                DESTINATION_EID
+            ),
+            address(replacement)
+        );
+        (address receiveLibrary, ) = originEndpoint.getReceiveLibrary(
+            address(originRouter),
+            DESTINATION_EID
+        );
+        assertEq(receiveLibrary, address(originUln));
+    }
+
+    function testReceiveLibraryTimeoutUsesAbsoluteBlockExpiry() public {
+        MockLayerZeroReceiveUln graceLibrary = new MockLayerZeroReceiveUln(
+            address(originEndpoint)
+        );
+        originEndpoint.registerMockLibrary(address(graceLibrary));
+        uint256 expiry = block.number + 10;
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        _updateVariant(
+            originRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: DESTINATION,
+                router: address(destinationRouter).addressToBytes32(),
+                receiveLibraryTimeout: address(graceLibrary),
+                receiveLibraryTimeoutExpiry: expiry,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+        (address timeoutLibrary, uint256 actualExpiry) = originEndpoint
+            .receiveLibraryTimeout(address(originRouter), DESTINATION_EID);
+        assertEq(timeoutLibrary, address(graceLibrary));
+        assertEq(actualExpiry, expiry);
+        assertTrue(
+            originEndpoint.isValidReceiveLibrary(
+                address(originRouter),
+                DESTINATION_EID,
+                address(graceLibrary)
+            )
+        );
+        vm.roll(expiry);
+        assertFalse(
+            originEndpoint.isValidReceiveLibrary(
+                address(originRouter),
+                DESTINATION_EID,
+                address(graceLibrary)
+            )
+        );
+
+        _updateVariant(
+            originRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: DESTINATION,
+                router: address(destinationRouter).addressToBytes32(),
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+        (timeoutLibrary, actualExpiry) = originEndpoint.receiveLibraryTimeout(
+            address(originRouter),
+            DESTINATION_EID
+        );
+        assertEq(timeoutLibrary, address(0));
+        assertEq(actualExpiry, 0);
+    }
+
+    function testConfigOnlyUpdateIsAtomicAndPreservesLibraries() public {
+        bytes32 newRouter = address(0x1234).addressToBytes32();
+        LayerZeroSetConfigParam[]
+            memory sendConfig = new LayerZeroSetConfigParam[](1);
+        sendConfig[0] = LayerZeroSetConfigParam({
+            eid: DESTINATION_EID,
+            configType: 1,
+            config: hex"1234"
+        });
+        LayerZeroSetConfigParam[]
+            memory receiveConfig = new LayerZeroSetConfigParam[](1);
+        receiveConfig[0] = LayerZeroSetConfigParam({
+            eid: DESTINATION_EID,
+            configType: 2,
+            config: hex"abcd"
+        });
+        uint256 expiry = block.number + 10;
+
+        _updateVariant(
+            originRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: DESTINATION,
+                router: newRouter,
+                receiveLibraryTimeout: address(originUln),
+                receiveLibraryTimeoutExpiry: expiry,
+                sendConfig: sendConfig,
+                receiveConfig: receiveConfig
+            })
+        );
+
+        assertEq(originRouter.routers(DESTINATION), newRouter);
+        assertEq(
+            originEndpoint.getSendLibrary(
+                address(originRouter),
+                DESTINATION_EID
+            ),
+            address(originUln)
+        );
+        (address receiveLibrary, ) = originEndpoint.getReceiveLibrary(
+            address(originRouter),
+            DESTINATION_EID
+        );
+        assertEq(receiveLibrary, address(originUln));
+        assertEq(
+            originEndpoint.getConfig(
+                address(originRouter),
+                address(originUln),
+                DESTINATION_EID,
+                1
+            ),
+            hex"1234"
+        );
+        assertEq(
+            originEndpoint.getConfig(
+                address(originRouter),
+                address(originUln),
+                DESTINATION_EID,
+                2
+            ),
+            hex"abcd"
+        );
+    }
+
+    function testConfigOnlyUpdateRollsBackOnInvalidConfigEid() public {
+        bytes32 currentRouter = originRouter.routers(DESTINATION);
+        LayerZeroSetConfigParam[]
+            memory sendConfig = new LayerZeroSetConfigParam[](1);
+        sendConfig[0] = LayerZeroSetConfigParam({
+            eid: ORIGIN_EID,
+            configType: 1,
+            config: hex"1234"
+        });
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.InvalidLayerZeroConfigEid.selector,
+                ORIGIN_EID
+            )
+        );
+        _updateVariant(
+            originRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: DESTINATION,
+                router: address(0x1234).addressToBytes32(),
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: sendConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+        assertEq(originRouter.routers(DESTINATION), currentRouter);
+    }
+
+    function testBatchConfigUpdateIsAtomic() public {
+        _configure(
+            originRouter,
+            originEndpoint,
+            originUln,
+            SECOND_DESTINATION,
+            SECOND_DESTINATION_EID,
+            address(0xABCD)
+        );
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[]
+            memory updates = new AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[](
+                2
+            );
+        updates[0] = AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+            domain: DESTINATION,
+            router: address(0x1234).addressToBytes32(),
+            receiveLibraryTimeout: address(0),
+            receiveLibraryTimeoutExpiry: 0,
+            sendConfig: emptyConfig,
+            receiveConfig: emptyConfig
+        });
+        updates[1] = AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+            domain: SECOND_DESTINATION,
+            router: address(0x5678).addressToBytes32(),
+            receiveLibraryTimeout: address(0),
+            receiveLibraryTimeoutExpiry: 0,
+            sendConfig: emptyConfig,
+            receiveConfig: emptyConfig
+        });
+
+        _updateVariants(originRouter, updates);
+        assertEq(
+            originRouter.routers(DESTINATION),
+            address(0x1234).addressToBytes32()
+        );
+        assertEq(
+            originRouter.routers(SECOND_DESTINATION),
+            address(0x5678).addressToBytes32()
+        );
+    }
+
+    function testBatchConfigUpdateRollsBackTogether() public {
+        _configure(
+            originRouter,
+            originEndpoint,
+            originUln,
+            SECOND_DESTINATION,
+            SECOND_DESTINATION_EID,
+            address(0xABCD)
+        );
+        bytes32 currentRouter = originRouter.routers(DESTINATION);
+        bytes32 secondCurrentRouter = originRouter.routers(SECOND_DESTINATION);
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[]
+            memory updates = new AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[](
+                2
+            );
+        updates[0] = AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+            domain: DESTINATION,
+            router: address(0x1234).addressToBytes32(),
+            receiveLibraryTimeout: address(0),
+            receiveLibraryTimeoutExpiry: 0,
+            sendConfig: emptyConfig,
+            receiveConfig: emptyConfig
+        });
+        updates[1] = AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+            domain: SECOND_DESTINATION,
+            router: bytes32(0),
+            receiveLibraryTimeout: address(0),
+            receiveLibraryTimeoutExpiry: 0,
+            sendConfig: emptyConfig,
+            receiveConfig: emptyConfig
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.NonCanonicalLayerZeroPeer.selector,
+                bytes32(0)
+            )
+        );
+        _updateVariants(originRouter, updates);
+        assertEq(originRouter.routers(DESTINATION), currentRouter);
+        assertEq(originRouter.routers(SECOND_DESTINATION), secondCurrentRouter);
+    }
+
+    function testConfigurationIsOwnerGated() public {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("Ownable: caller is not the owner");
+        _updateVariant(
+            originRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                domain: DESTINATION,
+                router: address(destinationRouter).addressToBytes32(),
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+    }
+
+    function testAtomicEnrollmentRollsBackIncompleteRoute() public {
+        AbstractLayerZeroV2HookIsm router = _deploy(
+            address(originMailbox),
+            address(originEndpoint)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm
+                    .UnregisteredLayerZeroLibrary
+                    .selector,
+                address(0)
+            )
+        );
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        _enrollVariant(
+            router,
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: DESTINATION,
+                router: address(destinationRouter).addressToBytes32(),
+                eid: DESTINATION_EID,
+                sendLibrary: address(0),
+                receiveLibrary: address(originUln),
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+        assertEq(router.routers(DESTINATION), bytes32(0));
+    }
+
+    function testQuoteAndDispatchPayLayerZeroFee() public {
+        bytes memory message = originMailbox.buildOutboundMessage(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            bytes("quote")
+        );
+        assertEq(originRouter.quoteDispatch("", message), NATIVE_FEE);
+        _dispatch();
+        assertEq(address(originEndpoint).balance, NATIVE_FEE);
+    }
+
+    function testNextNonceSelectsUnorderedDelivery() public view {
+        assertEq(originRouter.nextNonce(DESTINATION_EID, bytes32(0)), 0);
+    }
+
+    function testRuntimeCodeFitsEip170() public view {
+        // Coverage instrumentation changes runtime bytecode and cannot measure
+        // the deployable artifact's EIP-170 size. The default/CI profiles do.
+        if (
+            keccak256(bytes(vm.envOr("FOUNDRY_PROFILE", string("default")))) ==
+            keccak256(bytes("coverage"))
+        ) return;
+        assertLe(address(originRouter).code.length, EIP_170_MAX_CODE_SIZE);
+    }
+
+    function testFuzzLayerZeroPayloadRoundTrip(
+        uint32 origin,
+        uint32 destination,
+        bytes32 messageId
+    ) public view {
+        (
+            uint32 decodedOrigin,
+            uint32 decodedDestination,
+            bytes32 decodedId
+        ) = this.decodeLayerZeroPayload(
+                LayerZeroMessage.encode(origin, destination, messageId)
+            );
+        assertEq(decodedOrigin, origin);
+        assertEq(decodedDestination, destination);
+        assertEq(decodedId, messageId);
+    }
+
+    function decodeLayerZeroPayload(
+        bytes calldata payload
+    ) external pure returns (uint32, uint32, bytes32) {
+        return LayerZeroMessage.decode(payload);
+    }
+
+    function decodeLayerZeroPacket(
+        bytes calldata packet
+    ) external pure returns (uint64, bytes32, bytes32) {
+        return (
+            PacketV1Codec.nonce(packet),
+            PacketV1Codec.guid(packet),
+            PacketV1Codec.payloadHash(packet)
+        );
+    }
+}
+
+contract LayerZeroV2CallbackHookIsmTest is LayerZeroV2HookIsmTestBase {
+    using TypeCasts for address;
+
+    function _deploy(
+        address mailbox,
+        address endpoint
+    ) internal override returns (AbstractLayerZeroV2HookIsm) {
+        return new LayerZeroV2CallbackHookIsm(mailbox, endpoint);
+    }
+
+    function _enrollVariant(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment memory enrollment
+    ) internal override {
+        LayerZeroV2CallbackHookIsm(address(router)).enrollLayerZeroRemoteRouter(
+            enrollment,
+            CALLBACK_GAS
+        );
+    }
+
+    function _updateVariant(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate memory update_
+    ) internal override {
+        LayerZeroV2CallbackHookIsm(address(router))
+            .updateLayerZeroRemoteRouterConfig(update_, CALLBACK_GAS);
+    }
+
+    function _updateVariants(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[] memory updates
+    ) internal override {
+        uint128[] memory gasLimits = new uint128[](updates.length);
+        for (uint256 i = 0; i < gasLimits.length; ++i) {
+            gasLimits[i] = CALLBACK_GAS;
+        }
+        LayerZeroV2CallbackHookIsm(address(router))
+            .updateLayerZeroRemoteRouterConfigs(updates, gasLimits);
+    }
+
+    function testAtomicEnrollmentRollsBackInvalidCallbackGas() public {
+        LayerZeroV2CallbackHookIsm router = new LayerZeroV2CallbackHookIsm(
+            address(originMailbox),
+            address(originEndpoint)
+        );
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment
+            memory enrollment = AbstractLayerZeroV2HookIsm
+                .RemoteRouterEnrollment({
+                    domain: DESTINATION,
+                    router: address(destinationRouter).addressToBytes32(),
+                    eid: DESTINATION_EID,
+                    sendLibrary: address(originUln),
+                    receiveLibrary: address(originUln),
+                    receiveLibraryGracePeriod: 0,
+                    receiveLibraryTimeout: address(0),
+                    receiveLibraryTimeoutExpiry: 0,
+                    sendConfig: emptyConfig,
+                    receiveConfig: emptyConfig
+                });
+
+        vm.expectRevert(
+            LayerZeroV2CallbackHookIsm.InvalidLayerZeroCallbackGasLimit.selector
+        );
+        router.enrollLayerZeroRemoteRouter(enrollment, 0);
+        assertEq(router.routers(DESTINATION), bytes32(0));
+        assertEq(
+            originEndpoint.getSendLibrary(address(router), DESTINATION_EID),
+            address(0)
+        );
+    }
+
+    function testConfigOnlyUpdateChangesCallbackGasAtomically() public {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        LayerZeroV2CallbackHookIsm(address(originRouter))
+            .updateLayerZeroRemoteRouterConfig(
+                AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate({
+                    domain: DESTINATION,
+                    router: address(destinationRouter).addressToBytes32(),
+                    receiveLibraryTimeout: address(0),
+                    receiveLibraryTimeoutExpiry: 0,
+                    sendConfig: emptyConfig,
+                    receiveConfig: emptyConfig
+                }),
+                275_000
+            );
+        assertEq(
+            LayerZeroV2CallbackHookIsm(address(originRouter)).callbackGasLimits(
+                DESTINATION
+            ),
+            275_000
+        );
+    }
+
+    function testBatchConfigUpdateRejectsGasLengthMismatch() public {
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[]
+            memory updates = new AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[](
+                1
+            );
+        uint128[] memory gasLimits = new uint128[](0);
+        vm.expectRevert(
+            LayerZeroV2CallbackHookIsm.LayerZeroConfigLengthMismatch.selector
+        );
+        LayerZeroV2CallbackHookIsm(address(originRouter))
+            .updateLayerZeroRemoteRouterConfigs(updates, gasLimits);
+    }
+
+    function testBatchEnrollmentConfiguresEveryCallbackRoute() public {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment[]
+            memory enrollments = new AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment[](
+                1
+            );
+        enrollments[0] = AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+            domain: SECOND_DESTINATION,
+            router: address(0xBEEF).addressToBytes32(),
+            eid: SECOND_DESTINATION_EID,
+            sendLibrary: address(originUln),
+            receiveLibrary: address(originUln),
+            receiveLibraryGracePeriod: 0,
+            receiveLibraryTimeout: address(0),
+            receiveLibraryTimeoutExpiry: 0,
+            sendConfig: emptyConfig,
+            receiveConfig: emptyConfig
+        });
+        uint128[] memory gasLimits = new uint128[](1);
+        gasLimits[0] = CALLBACK_GAS + 1;
+
+        LayerZeroV2CallbackHookIsm(address(originRouter))
+            .enrollLayerZeroRemoteRouters(enrollments, gasLimits);
+        assertEq(
+            LayerZeroV2CallbackHookIsm(address(originRouter)).callbackGasLimits(
+                SECOND_DESTINATION
+            ),
+            CALLBACK_GAS + 1
+        );
+    }
+
+    function testCallbackAuthorizesAndMailboxProcesses() public {
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory payload = LayerZeroMessage.encode(
+            ORIGIN,
+            DESTINATION,
+            messageId
+        );
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 packetGuid, ) = this.decodeLayerZeroPacket(
+            packet
+        );
+        LayerZeroOrigin memory origin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: packetNonce
+        });
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            origin,
+            packetGuid,
+            payload
+        );
+        destinationMailbox.process("", message);
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+    }
+
+    function testCallbackOptionsGoldenVector() public {
+        _dispatch();
+        assertEq(
+            keccak256(originEndpoint.lastOptions()),
+            keccak256(
+                abi.encodePacked(
+                    uint16(3),
+                    uint8(1),
+                    uint16(17),
+                    uint8(1),
+                    CALLBACK_GAS
+                )
+            )
+        );
+    }
+
+    function testCallbackRejectsSpoofedEndpointAndGuid() public {
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 packetGuid, ) = this.decodeLayerZeroPacket(
+            packet
+        );
+        LayerZeroOrigin memory origin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: packetNonce
+        });
+        bytes memory payload = LayerZeroMessage.encode(
+            ORIGIN,
+            DESTINATION,
+            messageId
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CallbackHookIsm
+                    .UnauthorizedLayerZeroEndpoint
+                    .selector,
+                address(this)
+            )
+        );
+        LayerZeroV2CallbackHookIsm(address(destinationRouter)).lzReceive(
+            origin,
+            packetGuid,
+            payload,
+            address(this),
+            ""
+        );
+
+        bytes32 wrongGuid = bytes32(uint256(123));
+        bytes32 expectedGuid = GUID.generate(
+            origin.nonce,
+            origin.srcEid,
+            address(originRouter),
+            DESTINATION_EID,
+            address(destinationRouter).addressToBytes32()
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CallbackHookIsm.WrongLayerZeroGuid.selector,
+                wrongGuid,
+                expectedGuid
+            )
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            origin,
+            wrongGuid,
+            payload
+        );
+        assertFalse(
+            LayerZeroV2CallbackHookIsm(address(destinationRouter)).verify(
+                "",
+                message
+            )
+        );
+    }
+
+    function testCallbackRejectsValueAndInvalidRoutes() public {
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 packetGuid, ) = this.decodeLayerZeroPacket(
+            packet
+        );
+        LayerZeroOrigin memory origin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: packetNonce
+        });
+        bytes memory payload = LayerZeroMessage.encode(
+            ORIGIN,
+            DESTINATION,
+            messageId
+        );
+
+        vm.deal(address(destinationEndpoint), 1);
+        vm.prank(address(destinationEndpoint));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CallbackHookIsm
+                    .UnexpectedLayerZeroCallbackValue
+                    .selector,
+                1
+            )
+        );
+        LayerZeroV2CallbackHookIsm(address(destinationRouter)).lzReceive{
+            value: 1
+        }(origin, packetGuid, payload, address(this), "");
+
+        LayerZeroOrigin memory invalidOrigin = origin;
+        invalidOrigin.srcEid = SECOND_DESTINATION_EID;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.InvalidRemoteEid.selector,
+                SECOND_DESTINATION_EID
+            )
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            invalidOrigin,
+            packetGuid,
+            payload
+        );
+
+        invalidOrigin = origin;
+        invalidOrigin.srcEid = ORIGIN_EID;
+        invalidOrigin.sender = address(0xBEEF).addressToBytes32();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AbstractLayerZeroV2HookIsm.NonCanonicalLayerZeroPeer.selector,
+                invalidOrigin.sender
+            )
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            invalidOrigin,
+            packetGuid,
+            payload
+        );
+    }
+
+    function testCallbackRejectsWrongPayloadDomains() public {
+        (, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 packetGuid, ) = this.decodeLayerZeroPacket(
+            packet
+        );
+        LayerZeroOrigin memory origin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: packetNonce
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CallbackHookIsm.WrongLayerZeroPayloadOrigin.selector,
+                SECOND_DESTINATION,
+                ORIGIN
+            )
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            origin,
+            packetGuid,
+            LayerZeroMessage.encode(SECOND_DESTINATION, DESTINATION, messageId)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CallbackHookIsm
+                    .WrongLayerZeroPayloadDestination
+                    .selector,
+                SECOND_DESTINATION,
+                DESTINATION
+            )
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            origin,
+            packetGuid,
+            LayerZeroMessage.encode(ORIGIN, SECOND_DESTINATION, messageId)
+        );
+    }
+
+    function testCallbackIsIdempotent() public {
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 packetGuid, ) = this.decodeLayerZeroPacket(
+            packet
+        );
+        LayerZeroOrigin memory origin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: packetNonce
+        });
+        bytes memory payload = LayerZeroMessage.encode(
+            ORIGIN,
+            DESTINATION,
+            messageId
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            origin,
+            packetGuid,
+            payload
+        );
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            origin,
+            packetGuid,
+            payload
+        );
+        assertTrue(
+            LayerZeroV2CallbackHookIsm(address(destinationRouter))
+                .authorizations(ORIGIN, messageId)
+        );
+        assertTrue(
+            LayerZeroV2CallbackHookIsm(address(destinationRouter)).verify(
+                "",
+                message
+            )
+        );
+    }
+
+    function testCallbackVerifyRejectsMetadataAndWrongDestination() public {
+        (bytes memory message, ) = _dispatch();
+        vm.expectRevert(
+            LayerZeroV2CallbackHookIsm.UnexpectedHyperlaneMetadata.selector
+        );
+        LayerZeroV2CallbackHookIsm(address(destinationRouter)).verify(
+            hex"01",
+            message
+        );
+        bytes memory wrongDestination = originMailbox.buildOutboundMessage(
+            SECOND_DESTINATION,
+            address(recipient).addressToBytes32(),
+            "wrong destination"
+        );
+        assertFalse(
+            LayerZeroV2CallbackHookIsm(address(destinationRouter)).verify(
+                "",
+                wrongDestination
+            )
+        );
+    }
+
+    function testCallbackAuthorizationIsNamespacedByOrigin() public {
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 packetGuid, ) = this.decodeLayerZeroPacket(
+            packet
+        );
+
+        _configure(
+            destinationRouter,
+            destinationEndpoint,
+            destinationUln,
+            SECOND_DESTINATION,
+            SECOND_DESTINATION_EID,
+            address(0xBEEF)
+        );
+        LayerZeroOrigin memory attackerOrigin = LayerZeroOrigin({
+            srcEid: SECOND_DESTINATION_EID,
+            sender: address(0xBEEF).addressToBytes32(),
+            nonce: 1
+        });
+        bytes32 attackerGuid = GUID.generate(
+            attackerOrigin.nonce,
+            attackerOrigin.srcEid,
+            address(0xBEEF),
+            DESTINATION_EID,
+            address(destinationRouter).addressToBytes32()
+        );
+
+        // A compromised enrolled peer observes the victim message ID and
+        // authorizes it under its own origin before the real callback arrives.
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            attackerOrigin,
+            attackerGuid,
+            LayerZeroMessage.encode(SECOND_DESTINATION, DESTINATION, messageId)
+        );
+        assertFalse(
+            LayerZeroV2CallbackHookIsm(address(destinationRouter)).verify(
+                "",
+                message
+            )
+        );
+
+        LayerZeroOrigin memory legitimateOrigin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: packetNonce
+        });
+        destinationEndpoint.mockDeliver(
+            address(destinationRouter),
+            legitimateOrigin,
+            packetGuid,
+            LayerZeroMessage.encode(ORIGIN, DESTINATION, messageId)
+        );
+
+        assertTrue(
+            LayerZeroV2CallbackHookIsm(address(destinationRouter)).verify(
+                "",
+                message
+            )
+        );
+    }
+}
+
+contract LayerZeroV2CcipReadHookIsmTest is LayerZeroV2HookIsmTestBase {
+    using TypeCasts for address;
+
+    uint256 internal constant PROCESS_GAS_LIMIT = 350_000;
+    string[] internal lookupUrls;
+
+    function setUp() public override {
+        lookupUrls.push("http://localhost:3000/layerzero");
+        super.setUp();
+    }
+
+    function _deploy(
+        address mailbox,
+        address endpoint
+    ) internal override returns (AbstractLayerZeroV2HookIsm) {
+        return new LayerZeroV2CcipReadHookIsm(mailbox, endpoint, lookupUrls);
+    }
+
+    function _enrollVariant(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment memory enrollment
+    ) internal override {
+        LayerZeroV2CcipReadHookIsm(address(router)).enrollLayerZeroRemoteRouter(
+            enrollment
+        );
+    }
+
+    function _updateVariant(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate memory update_
+    ) internal override {
+        LayerZeroV2CcipReadHookIsm(address(router))
+            .updateLayerZeroRemoteRouterConfig(update_);
+    }
+
+    function _updateVariants(
+        AbstractLayerZeroV2HookIsm router,
+        AbstractLayerZeroV2HookIsm.RemoteRouterConfigUpdate[] memory updates
+    ) internal override {
+        LayerZeroV2CcipReadHookIsm(address(router))
+            .updateLayerZeroRemoteRouterConfigs(updates);
+    }
+
+    function _replace(
+        bytes memory value,
+        uint256 offset,
+        bytes memory replacement
+    ) internal pure returns (bytes memory result) {
+        result = bytes.concat(value);
+        for (uint256 i = 0; i < replacement.length; ++i) {
+            result[offset + i] = replacement[i];
+        }
+    }
+
+    function _packetWithNonce(
+        bytes memory packet,
+        uint64 nonce
+    ) internal view returns (bytes memory) {
+        packet = _replace(packet, 1, abi.encodePacked(nonce));
+        bytes32 guid = GUID.generate(
+            nonce,
+            ORIGIN_EID,
+            address(originRouter),
+            DESTINATION_EID,
+            address(destinationRouter).addressToBytes32()
+        );
+        return _replace(packet, 81, abi.encodePacked(guid));
+    }
+
+    function _precommitPacket(
+        bytes memory packet
+    ) internal returns (bytes32 payloadHash) {
+        (uint64 nonce, , bytes32 hash) = this.decodeLayerZeroPacket(packet);
+        payloadHash = hash;
+        vm.prank(address(destinationUln));
+        destinationEndpoint.mockVerify(
+            address(destinationRouter),
+            ORIGIN_EID,
+            address(originRouter).addressToBytes32(),
+            nonce,
+            payloadHash
+        );
+    }
+
+    function _dispatchUnrelated()
+        internal
+        returns (bytes memory message, bytes memory packet)
+    {
+        TestRecipient unrelatedRecipient = new TestRecipient();
+        TestIsm unrelatedIsm = new TestIsm();
+        unrelatedRecipient.setInterchainSecurityModule(address(unrelatedIsm));
+        bytes memory body = bytes("unrelated message");
+        message = originMailbox.buildOutboundMessage(
+            DESTINATION,
+            address(unrelatedRecipient).addressToBytes32(),
+            body
+        );
+        originMailbox.dispatch{value: NATIVE_FEE}(
+            DESTINATION,
+            address(unrelatedRecipient).addressToBytes32(),
+            body,
+            "",
+            IPostDispatchHook(address(originRouter))
+        );
+        packet = originEndpoint.lastPacket();
+    }
+
+    function _replaceDestinationReceiveLibrary(
+        MockLayerZeroReceiveUln replacement
+    ) internal {
+        destinationEndpoint.registerMockLibrary(address(replacement));
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        _enrollVariant(
+            destinationRouter,
+            AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+                domain: ORIGIN,
+                router: address(originRouter).addressToBytes32(),
+                eid: ORIGIN_EID,
+                sendLibrary: address(destinationUln),
+                receiveLibrary: address(replacement),
+                receiveLibraryGracePeriod: 0,
+                receiveLibraryTimeout: address(0),
+                receiveLibraryTimeoutExpiry: 0,
+                sendConfig: emptyConfig,
+                receiveConfig: emptyConfig
+            })
+        );
+    }
+
+    function _revertSelector(
+        bytes memory returnData
+    ) internal pure returns (bytes4 selector) {
+        assembly {
+            selector := mload(add(returnData, 0x20))
+        }
+    }
+
+    function _expectPacketRevert(
+        bytes memory message,
+        bytes memory packet,
+        bytes4 selector
+    ) internal {
+        (bool success, bytes memory returnData) = address(destinationMailbox)
+            .call(
+                abi.encodeCall(
+                    destinationMailbox.process,
+                    (abi.encode(address(destinationUln), packet), message)
+                )
+            );
+        assertFalse(success);
+        assertEq(
+            _revertSelector(returnData),
+            selector,
+            "unexpected packet validation error"
+        );
+    }
+
+    function testPullCommitsClearsAndProcessesAtomically() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        bytes memory metadata = abi.encode(address(destinationUln), packet);
+        destinationMailbox.process(metadata, message);
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+        assertEq(
+            destinationEndpoint.lazyInboundNonce(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32()
+            ),
+            1
+        );
+    }
+
+    function testPullSingleMessageFitsBacklogGasLimit() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (bool success, ) = address(destinationMailbox).call{
+            gas: PROCESS_GAS_LIMIT
+        }(
+            abi.encodeCall(
+                destinationMailbox.process,
+                (abi.encode(address(destinationUln), packet), message)
+            )
+        );
+        assertTrue(success, "single LayerZero message exceeded process gas");
+    }
+
+    function testPullUnverifiedPredecessorEmitsClearFailureWithoutBlocking()
+        public
+    {
+        (bytes memory unrelatedMessage, ) = _dispatchUnrelated();
+        destinationMailbox.process("", unrelatedMessage);
+
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, bytes32 guid, bytes32 payloadHash) = this
+            .decodeLayerZeroPacket(packet);
+        assertEq(packetNonce, 2);
+
+        vm.recordLogs();
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), packet),
+            message
+        );
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 eventSignature = keccak256(
+            "LayerZeroPayloadClearFailed(bytes32,uint32,uint32,bytes32,uint64)"
+        );
+        bool foundFailure;
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (
+                logs[i].topics.length != 0 &&
+                logs[i].emitter == address(destinationRouter) &&
+                logs[i].topics[0] == eventSignature
+            ) {
+                foundFailure = true;
+                assertEq(logs[i].topics[1], messageId);
+                assertEq(logs[i].topics[2], bytes32(uint256(ORIGIN)));
+                assertEq(logs[i].topics[3], bytes32(uint256(ORIGIN_EID)));
+                (bytes32 emittedGuid, uint64 emittedNonce) = abi.decode(
+                    logs[i].data,
+                    (bytes32, uint64)
+                );
+                assertEq(emittedGuid, guid);
+                assertEq(emittedNonce, packetNonce);
+                break;
+            }
+        }
+        assertTrue(foundFailure, "missing clear failure event");
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                packetNonce
+            ),
+            payloadHash
+        );
+    }
+
+    function testPullEndpointExecutionRecoversFailedCleanupPermissionlessly()
+        public
+    {
+        (
+            bytes memory unrelatedMessage,
+            bytes memory predecessorPacket
+        ) = _dispatchUnrelated();
+        destinationMailbox.process("", unrelatedMessage);
+
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 nonce, bytes32 guid, ) = this.decodeLayerZeroPacket(packet);
+        bytes memory metadata = abi.encode(address(destinationUln), packet);
+        destinationMailbox.process(metadata, message);
+        _precommitPacket(predecessorPacket);
+
+        vm.prank(address(0xBEEF));
+        destinationEndpoint.mockExecute(
+            address(destinationRouter),
+            LayerZeroOrigin({
+                srcEid: ORIGIN_EID,
+                sender: address(originRouter).addressToBytes32(),
+                nonce: nonce
+            }),
+            guid,
+            LayerZeroMessage.encode(ORIGIN, DESTINATION, messageId)
+        );
+
+        assertEq(
+            destinationEndpoint.lazyInboundNonce(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32()
+            ),
+            2
+        );
+        assertNotEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                2
+            ),
+            bytes32(0)
+        );
+    }
+
+    function testPullMaximumSparseNonceFitsGasLimit() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = _packetWithNonce(
+            originEndpoint.lastPacket(),
+            type(uint64).max
+        );
+
+        (bool success, ) = address(destinationMailbox).call{
+            gas: PROCESS_GAS_LIMIT
+        }(
+            abi.encodeCall(
+                destinationMailbox.process,
+                (abi.encode(address(destinationUln), packet), message)
+            )
+        );
+        assertTrue(success, "LayerZero nonce affected process gas");
+    }
+
+    function testPullVerifiedBacklogCannotExhaustLaterMessageGas() public {
+        TestRecipient unrelatedRecipient = new TestRecipient();
+        TestIsm unrelatedIsm = new TestIsm();
+        unrelatedRecipient.setInterchainSecurityModule(address(unrelatedIsm));
+        uint64 backlogSize = 256;
+
+        for (uint64 i = 1; i <= backlogSize; ++i) {
+            originMailbox.dispatch{value: NATIVE_FEE}(
+                DESTINATION,
+                address(unrelatedRecipient).addressToBytes32(),
+                abi.encode(i),
+                "",
+                IPostDispatchHook(address(originRouter))
+            );
+            bytes memory packet = originEndpoint.lastPacket();
+            (uint64 packetNonce, , bytes32 packetPayloadHash) = this
+                .decodeLayerZeroPacket(packet);
+            vm.prank(address(destinationUln));
+            destinationEndpoint.mockVerify(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                packetNonce,
+                packetPayloadHash
+            );
+        }
+
+        (bytes memory message, ) = _dispatch();
+        bytes memory latestPacket = originEndpoint.lastPacket();
+        (uint64 latestNonce, , ) = this.decodeLayerZeroPacket(latestPacket);
+        assertEq(latestNonce, backlogSize + 1);
+
+        (bool success, ) = address(destinationMailbox).call{
+            gas: PROCESS_GAS_LIMIT
+        }(
+            abi.encodeCall(
+                destinationMailbox.process,
+                (abi.encode(address(destinationUln), latestPacket), message)
+            )
+        );
+        assertTrue(success, "verified LayerZero backlog exhausted process gas");
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+    }
+
+    function testPullPrecommittedPacketSkipsUnavailableReceiveLibrary() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        _precommitPacket(packet);
+        destinationUln.setReady(false);
+
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), packet),
+            message
+        );
+
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+    }
+
+    function testPullPrecommittedPacketSurvivesReceiveLibraryRotation() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        _precommitPacket(packet);
+        MockLayerZeroReceiveUln replacement = new MockLayerZeroReceiveUln(
+            address(destinationEndpoint)
+        );
+        _replaceDestinationReceiveLibrary(replacement);
+
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), packet),
+            message
+        );
+
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+    }
+
+    function testPullUncommittedPacketRequiresCurrentReceiveLibrary() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        MockLayerZeroReceiveUln replacement = new MockLayerZeroReceiveUln(
+            address(destinationEndpoint)
+        );
+        _replaceDestinationReceiveLibrary(replacement);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.InvalidReceiveLibrary.selector,
+                address(destinationUln)
+            )
+        );
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), packet),
+            message
+        );
+
+        destinationMailbox.process(
+            abi.encode(address(replacement), packet),
+            message
+        );
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+    }
+
+    function testPullBacklogOnAnotherPathDoesNotAffectProcessGas() public {
+        bytes32 unrelatedSender = address(0xBEEF).addressToBytes32();
+        for (uint64 nonce = 1; nonce <= 256; ++nonce) {
+            vm.prank(address(destinationUln));
+            destinationEndpoint.mockVerify(
+                address(destinationRouter),
+                SECOND_DESTINATION_EID,
+                unrelatedSender,
+                nonce,
+                bytes32(uint256(nonce))
+            );
+        }
+
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (bool success, ) = address(destinationMailbox).call{
+            gas: PROCESS_GAS_LIMIT
+        }(
+            abi.encodeCall(
+                destinationMailbox.process,
+                (abi.encode(address(destinationUln), packet), message)
+            )
+        );
+        assertTrue(success, "unrelated LayerZero path affected process gas");
+    }
+
+    function testPullOptionsGoldenVector() public {
+        _dispatch();
+        assertEq(
+            keccak256(originEndpoint.lastOptions()),
+            keccak256(
+                abi.encodePacked(
+                    uint16(3),
+                    uint8(1),
+                    uint16(17),
+                    uint8(1),
+                    uint128(1)
+                )
+            )
+        );
+    }
+
+    function testPullRejectsUnauthorizedCallback() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.UnauthorizedCaller.selector,
+                address(this)
+            )
+        );
+        LayerZeroV2CcipReadHookIsm(address(destinationRouter)).lzReceive(
+            LayerZeroOrigin({srcEid: ORIGIN_EID, sender: bytes32(0), nonce: 1}),
+            bytes32(0),
+            "",
+            address(this),
+            ""
+        );
+    }
+
+    function testPullEndpointExecutionCannotConsumeVerifiedPacket() public {
+        (, bytes32 messageId) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 nonce, bytes32 guid, bytes32 payloadHash) = this
+            .decodeLayerZeroPacket(packet);
+        _precommitPacket(packet);
+
+        LayerZeroOrigin memory origin = LayerZeroOrigin({
+            srcEid: ORIGIN_EID,
+            sender: address(originRouter).addressToBytes32(),
+            nonce: nonce
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.MessageNotDelivered.selector,
+                messageId
+            )
+        );
+        destinationEndpoint.mockExecute(
+            address(destinationRouter),
+            origin,
+            guid,
+            LayerZeroMessage.encode(ORIGIN, DESTINATION, messageId)
+        );
+
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                nonce
+            ),
+            payloadHash
+        );
+    }
+
+    function testPullRejectsDirectVerify() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory metadata = abi.encode(
+            address(destinationUln),
+            originEndpoint.lastPacket()
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.MessageNotBeingProcessed.selector,
+                Message.id(message)
+            )
+        );
+        LayerZeroV2CcipReadHookIsm(address(destinationRouter)).verify(
+            metadata,
+            message
+        );
+    }
+
+    function testPullVerifiesThroughAggregationIsm() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory layerZeroMetadata = abi.encode(
+            address(destinationUln),
+            originEndpoint.lastPacket()
+        );
+        TestIsm testIsm = new TestIsm();
+        address[] memory modules = new address[](2);
+        modules[0] = address(testIsm);
+        modules[1] = address(destinationRouter);
+        IInterchainSecurityModule aggregation = IInterchainSecurityModule(
+            new StaticAggregationIsmFactory().deploy(modules, 2)
+        );
+        recipient.setInterchainSecurityModule(address(aggregation));
+
+        bytes memory metadata = abi.encodePacked(
+            uint32(16),
+            uint32(16),
+            uint32(16),
+            uint32(16 + layerZeroMetadata.length),
+            layerZeroMetadata
+        );
+        destinationMailbox.process(metadata, message);
+
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+    }
+
+    function testPullVerifiesThroughRoutingIsm() public {
+        (bytes memory message, ) = _dispatch();
+        DomainRoutingIsm routing = new DomainRoutingIsm();
+        routing.initialize(address(this));
+        routing.set(
+            ORIGIN,
+            IInterchainSecurityModule(address(destinationRouter))
+        );
+        recipient.setInterchainSecurityModule(address(routing));
+
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), originEndpoint.lastPacket()),
+            message
+        );
+
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+    }
+
+    function testPullRollbackWhenRecipientReverts() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        bytes memory metadata = abi.encode(address(destinationUln), packet);
+        recipient.setInterchainSecurityModule(address(destinationRouter));
+        vm.mockCallRevert(
+            address(recipient),
+            abi.encodeWithSelector(recipient.handle.selector),
+            bytes("recipient reverted")
+        );
+        vm.expectRevert(bytes("recipient reverted"));
+        destinationMailbox.process(metadata, message);
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+
+        vm.clearMockedCalls();
+        destinationMailbox.process(metadata, message);
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+    }
+
+    function testPullPrecommittedHashSurvivesRecipientRevertAndRetry() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        bytes32 payloadHash = _precommitPacket(packet);
+        bytes memory metadata = abi.encode(address(destinationUln), packet);
+        vm.mockCallRevert(
+            address(recipient),
+            abi.encodeWithSelector(recipient.handle.selector),
+            bytes("recipient reverted")
+        );
+        vm.expectRevert(bytes("recipient reverted"));
+        destinationMailbox.process(metadata, message);
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            payloadHash
+        );
+
+        vm.clearMockedCalls();
+        destinationMailbox.process(metadata, message);
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+        assertEq(
+            destinationEndpoint.inboundPayloadHash(
+                address(destinationRouter),
+                ORIGIN_EID,
+                address(originRouter).addressToBytes32(),
+                1
+            ),
+            bytes32(0)
+        );
+    }
+
+    function testPullRejectsPendingDvnsAndConflictingPayload() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        (uint64 packetNonce, , bytes32 packetPayloadHash) = this
+            .decodeLayerZeroPacket(packet);
+        bytes memory metadata = abi.encode(address(destinationUln), packet);
+        destinationUln.setReady(false);
+        vm.expectRevert(bytes("DVNs pending"));
+        destinationMailbox.process(metadata, message);
+
+        destinationUln.setReady(true);
+        vm.prank(address(destinationUln));
+        destinationEndpoint.mockVerify(
+            address(destinationRouter),
+            ORIGIN_EID,
+            address(originRouter).addressToBytes32(),
+            packetNonce,
+            bytes32(uint256(1))
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.ConflictingPayloadHash.selector,
+                bytes32(uint256(1)),
+                packetPayloadHash
+            )
+        );
+        destinationMailbox.process(metadata, message);
+    }
+
+    function testPullRejectsNonCanonicalMetadata() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory metadata = bytes.concat(
+            abi.encode(address(destinationUln), originEndpoint.lastPacket()),
+            hex"00"
+        );
+        vm.expectRevert(LayerZeroMetadata.InvalidLayerZeroMetadata.selector);
+        destinationMailbox.process(metadata, message);
+    }
+
+    function testPullInvalidAttemptDoesNotPoisonValidDelivery() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+        bytes memory invalidPacket = _replace(
+            packet,
+            13,
+            abi.encodePacked(address(0xBEEF).addressToBytes32())
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.WrongPacketSender.selector,
+                address(0xBEEF).addressToBytes32(),
+                address(originRouter).addressToBytes32()
+            )
+        );
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), invalidPacket),
+            message
+        );
+
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), packet),
+            message
+        );
+        assertEq(recipient.lastData(), bytes("hyperlane over layerzero"));
+    }
+
+    function testPullMailboxReplayProtectionAfterVerification() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory metadata = abi.encode(
+            address(destinationUln),
+            originEndpoint.lastPacket()
+        );
+        destinationMailbox.process(metadata, message);
+
+        vm.expectRevert(bytes("Mailbox: already delivered"));
+        destinationMailbox.process(metadata, message);
+    }
+
+    function testPullBatchEnrollmentAndOffchainLookup() public {
+        LayerZeroSetConfigParam[]
+            memory emptyConfig = new LayerZeroSetConfigParam[](0);
+        AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment[]
+            memory enrollments = new AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment[](
+                1
+            );
+        enrollments[0] = AbstractLayerZeroV2HookIsm.RemoteRouterEnrollment({
+            domain: SECOND_DESTINATION,
+            router: address(0xBEEF).addressToBytes32(),
+            eid: SECOND_DESTINATION_EID,
+            sendLibrary: address(originUln),
+            receiveLibrary: address(originUln),
+            receiveLibraryGracePeriod: 0,
+            receiveLibraryTimeout: address(0),
+            receiveLibraryTimeoutExpiry: 0,
+            sendConfig: emptyConfig,
+            receiveConfig: emptyConfig
+        });
+        LayerZeroV2CcipReadHookIsm(address(originRouter))
+            .enrollLayerZeroRemoteRouters(enrollments);
+        assertEq(
+            originRouter.routers(SECOND_DESTINATION),
+            address(0xBEEF).addressToBytes32()
+        );
+
+        bytes memory message = originMailbox.buildOutboundMessage(
+            DESTINATION,
+            address(recipient).addressToBytes32(),
+            "lookup"
+        );
+        (bool success, bytes memory returnData) = address(destinationRouter)
+            .staticcall(
+                abi.encodeCall(ICcipReadIsm.getOffchainVerifyInfo, (message))
+            );
+        assertFalse(success);
+        assertEq(
+            _revertSelector(returnData),
+            ICcipReadIsm.OffchainLookup.selector
+        );
+    }
+
+    function testPullRejectsEveryInvalidPacketField() public {
+        (bytes memory message, ) = _dispatch();
+        bytes memory packet = originEndpoint.lastPacket();
+
+        _expectPacketRevert(
+            message,
+            bytes.concat(packet, hex"00"),
+            LayerZeroV2CcipReadHookIsm.InvalidLayerZeroPacketLength.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(packet, 0, abi.encodePacked(uint8(2))),
+            LayerZeroV2CcipReadHookIsm.InvalidLayerZeroPacketVersion.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(packet, 9, abi.encodePacked(uint32(123))),
+            LayerZeroV2CcipReadHookIsm.WrongPacketSourceEid.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(
+                packet,
+                13,
+                abi.encodePacked(address(0xBEEF).addressToBytes32())
+            ),
+            LayerZeroV2CcipReadHookIsm.WrongPacketSender.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(packet, 45, abi.encodePacked(uint32(123))),
+            LayerZeroV2CcipReadHookIsm.WrongPacketDestinationEid.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(
+                packet,
+                49,
+                abi.encodePacked(address(0xBEEF).addressToBytes32())
+            ),
+            LayerZeroV2CcipReadHookIsm.WrongPacketReceiver.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(packet, 113, abi.encodePacked(uint8(2))),
+            LayerZeroV2CcipReadHookIsm.WrongPacketMessage.selector
+        );
+        _expectPacketRevert(
+            message,
+            _replace(packet, 81, abi.encodePacked(bytes32(uint256(123)))),
+            LayerZeroV2CcipReadHookIsm.WrongPacketGuid.selector
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.InvalidReceiveLibrary.selector,
+                address(0xBEEF)
+            )
+        );
+        destinationMailbox.process(
+            abi.encode(address(0xBEEF), packet),
+            message
+        );
+    }
+
+    function testPullRejectsOversizedPacketMetadata() public {
+        (bytes memory message, ) = _dispatch();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroMetadata.LayerZeroPacketTooLarge.selector,
+                4097
+            )
+        );
+        destinationMailbox.process(
+            abi.encode(address(destinationUln), new bytes(4097)),
+            message
+        );
+    }
+
+    function testPullRejectsVerifyOutsideMailboxProcessing() public {
+        (bytes memory message, bytes32 messageId) = _dispatch();
+        bytes memory metadata = abi.encode(
+            address(destinationUln),
+            originEndpoint.lastPacket()
+        );
+        vm.prank(address(destinationMailbox));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LayerZeroV2CcipReadHookIsm.MessageNotBeingProcessed.selector,
+                messageId
+            )
+        );
+        LayerZeroV2CcipReadHookIsm(address(destinationRouter)).verify(
+            metadata,
+            message
+        );
+    }
+}

--- a/solidity/tron-hardhat.config.cts
+++ b/solidity/tron-hardhat.config.cts
@@ -39,6 +39,12 @@ const TRON_EXCLUDED_PATTERNS = [
     "/contracts/CheckpointFraudProofs.sol",
 ];
 
+const TRON_WARP_PATTERNS = [
+    "/contracts/token/",
+    "/contracts/hooks/warp-route/",
+    "/contracts/isms/warp-route/",
+];
+
 // Test contracts kept for tron-sdk (TestStorage, ERC20Test, TestIsm, etc.)
 const TRON_TEST_ALLOWLIST = [
     "TestStorage.sol",
@@ -56,7 +62,17 @@ const TRON_MOCK_ALLOWLIST = [
 
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS, async (_, __, runSuper) => {
     const sourcePaths = await runSuper();
+    const buildTarget = process.env.TRON_BUILD_TARGET ?? "core";
+    if (buildTarget !== "core" && buildTarget !== "warp") {
+        throw new Error(`Invalid TRON_BUILD_TARGET: ${buildTarget}`);
+    }
     return sourcePaths.filter((sourcePath: string) => {
+        const isWarpContract = TRON_WARP_PATTERNS.some((pattern) =>
+            sourcePath.includes(pattern),
+        );
+        if (buildTarget === "warp") {
+            if (!isWarpContract) return false;
+        } else if (isWarpContract) return false;
         if (sourcePath.includes("/contracts/mock/")) {
             return TRON_MOCK_ALLOWLIST.some((f) => sourcePath.endsWith(f));
         }
@@ -82,9 +98,26 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS, async (_, __, runSuper) => {
 module.exports = {
     ...rootHardhatConfig,
     solidity: {
-        ...rootHardhatConfig.solidity,
-        // tron-solc latest is 0.8.24
-        version: "0.8.24",
+        compilers: [
+            {
+                ...rootHardhatConfig.solidity,
+                // tron-solc latest is 0.8.24
+                version: "0.8.24",
+            },
+        ],
+        overrides: {
+            "contracts/hooks/layerzero/LayerZeroV2CcipReadHookIsm.sol": {
+                ...rootHardhatConfig.solidity,
+                version: "0.8.24",
+                settings: {
+                    ...rootHardhatConfig.solidity.settings,
+                    optimizer: {
+                        ...rootHardhatConfig.solidity.settings.optimizer,
+                        runs: 200,
+                    },
+                },
+            },
+        },
     },
     paths: {
         sources: "./contracts",

--- a/typescript/ccip-server/.env.example
+++ b/typescript/ccip-server/.env.example
@@ -1,5 +1,9 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/ccip_server"
 ENABLED_MODULES=cctp,callCommitments
+# LayerZero pull-mode example:
+# ENABLED_MODULES=cctp,callCommitments,layerzero
+# HYPERLANE_EXPLORER_URL=https://explorer.hyperlane.xyz/graphql
+# LAYERZERO_ROUTES={"policyA":{"chainA":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":1,"router":"0x..."},"chainB":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":2,"router":"0x..."}}}
 SERVER_PORT=3000
 SERVER_BASE_URL=http://localhost:3000
 # If you want to use a different registry

--- a/typescript/ccip-server/.env.example
+++ b/typescript/ccip-server/.env.example
@@ -3,7 +3,6 @@ ENABLED_MODULES=cctp,callCommitments
 # LayerZero pull-mode example:
 # ENABLED_MODULES=cctp,callCommitments,layerzero
 # HYPERLANE_EXPLORER_URL=https://explorer.hyperlane.xyz/graphql
-# LAYERZERO_ROUTES={"policyA":{"chainA":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":1,"router":"0x..."},"chainB":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":2,"router":"0x..."}}}
 SERVER_PORT=3000
 SERVER_BASE_URL=http://localhost:3000
 # If you want to use a different registry

--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -9,7 +9,8 @@
     "./tests/**/moduleRegistry.test.ts",
     "./tests/**/WormholeVaaService.test.ts",
     "./tests/**/WormholeVaaFetcher.test.ts",
-    "./tests/**/wormholeVaaMatcher.test.ts"
+    "./tests/**/wormholeVaaMatcher.test.ts",
+    "./tests/**/layerZeroPacketMatcher.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/README.md
+++ b/typescript/ccip-server/README.md
@@ -80,6 +80,31 @@ A lightweight Express server for CCIP Read/Write commitments, using Zod validati
 - `POST /getCallsFromCommitment`  
   CCIP-Read endpoint (uses ABI handler) to fetch & re-encode calls for a given commitment ID.
 
+### LayerZero V2 packet lookup
+
+Enable the module with `ENABLED_MODULES=layerzero` and configure:
+
+```env
+HYPERLANE_EXPLORER_URL=https://explorer.hyperlane.xyz/graphql
+LAYERZERO_ROUTES={"policyA":{"ethereum":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":30101,"router":"0x..."},"arbitrum":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":30110,"router":"0x..."}}}
+```
+
+The outer key identifies a LayerZero mesh/security policy; inner keys are
+Hyperlane chain names. Values pin that policy's Mailbox, Endpoint V2, LayerZero
+domain ID, and
+combined hook/ISM router. The CCIP `sender` selects the exact destination
+router/mesh. The module exposes the CCIP-read endpoints:
+
+- `GET /layerzero/getLayerZeroPacket/:sender/:callData.json`
+- `POST /layerzero/getLayerZeroPacket`
+
+The service finds the exact `PacketSent` event in the Hyperlane dispatch
+receipt, validates every pathway and payload field, resolves current/grace
+receive libraries from Endpoint state, and simulates `commitVerification`
+before returning `(receiveLibrary, packet)`.
+The destination contract repeats all security checks; the server is untrusted
+availability infrastructure.
+
 ## Notes
 
 - SQLite is recommended only for local dev. In production, Prisma will use whatever database is specified by `DATABASE_URL`.

--- a/typescript/ccip-server/README.md
+++ b/typescript/ccip-server/README.md
@@ -86,14 +86,13 @@ Enable the module with `ENABLED_MODULES=layerzero` and configure:
 
 ```env
 HYPERLANE_EXPLORER_URL=https://explorer.hyperlane.xyz/graphql
-LAYERZERO_ROUTES={"policyA":{"ethereum":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":30101,"router":"0x..."},"arbitrum":{"mailbox":"0x...","endpoint":"0x...","layerZeroDomainId":30110,"router":"0x..."}}}
 ```
 
-The outer key identifies a LayerZero mesh/security policy; inner keys are
-Hyperlane chain names. Values pin that policy's Mailbox, Endpoint V2, LayerZero
-domain ID, and
-combined hook/ISM router. The CCIP `sender` selects the exact destination
-router/mesh. The module exposes the CCIP-read endpoints:
+The CCIP `sender` identifies the destination combined hook/ISM. The server
+discovers its origin peer, Mailboxes, Endpoint V2 contracts, and LayerZero
+domain IDs from reciprocal on-chain enrollment. RPC URLs come from the
+Hyperlane registry selected by `REGISTRY_URI`; no deployment-address mapping is
+required. The module exposes the CCIP-read endpoints:
 
 - `GET /layerzero/getLayerZeroPacket/:sender/:callData.json`
 - `POST /layerzero/getLayerZeroPacket`

--- a/typescript/ccip-server/src/moduleRegistry.ts
+++ b/typescript/ccip-server/src/moduleRegistry.ts
@@ -15,6 +15,13 @@ export const moduleRegistry: Record<string, ServiceFactory> = {
       return CCTPService.create(name);
     },
   },
+  layerzero: {
+    async create(name) {
+      const { LayerZeroPacketService } =
+        await import('./services/LayerZeroPacketService.js');
+      return LayerZeroPacketService.create(name);
+    },
+  },
   opstack: {
     async create(name) {
       const { OPStackService } = await import('./services/OPStackService.js');

--- a/typescript/ccip-server/src/services/LayerZeroPacketService.ts
+++ b/typescript/ccip-server/src/services/LayerZeroPacketService.ts
@@ -1,0 +1,403 @@
+import { ethers } from 'ethers';
+import { Router } from 'express';
+import { Logger } from 'pino';
+import { z } from 'zod';
+
+import { ILayerZeroPacketService__factory } from '@hyperlane-xyz/core';
+import { HyperlaneSmartProvider, MultiProvider } from '@hyperlane-xyz/sdk';
+import { assert, parseMessage } from '@hyperlane-xyz/utils';
+
+import { createAbiHandler } from '../utils/abiHandler.js';
+import {
+  PrometheusMetrics,
+  UnhandledErrorReason,
+} from '../utils/prometheus.js';
+import {
+  BaseService,
+  REGISTRY_URI_SCHEMA,
+  ServiceConfigWithMultiProvider,
+} from './BaseService.js';
+import { HyperlaneService } from './HyperlaneService.js';
+import {
+  ParsedLayerZeroPacket,
+  countMatchingHyperlaneDispatches,
+  encodeLayerZeroPayload,
+  findMatchingLayerZeroPacket,
+  resolveLayerZeroReceiveLibrary,
+} from './layerZeroPacketMatcher.js';
+
+const AddressSchema = z
+  .string()
+  .refine(ethers.utils.isAddress, 'must be an address')
+  .refine(
+    (address) => address !== ethers.constants.AddressZero,
+    'must not be zero',
+  );
+
+export const LayerZeroChainConfigSchema = z.object({
+  mailbox: AddressSchema,
+  endpoint: AddressSchema,
+  layerZeroDomainId: z.number().int().positive().max(0xffffffff),
+  router: AddressSchema,
+});
+
+export type LayerZeroChainConfig = z.infer<typeof LayerZeroChainConfigSchema>;
+export const LayerZeroMeshSchema = z
+  .record(z.string(), LayerZeroChainConfigSchema)
+  .superRefine((routes, ctx) => {
+    const layerZeroDomainIds = new Map<number, string>();
+    for (const [chain, route] of Object.entries(routes)) {
+      const existing = layerZeroDomainIds.get(route.layerZeroDomainId);
+      if (existing) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [chain, 'layerZeroDomainId'],
+          message: `LayerZero domain ID ${route.layerZeroDomainId} is already configured for ${existing}`,
+        });
+      }
+      layerZeroDomainIds.set(route.layerZeroDomainId, chain);
+    }
+  });
+export const LayerZeroRoutesSchema = z
+  .record(z.string(), LayerZeroMeshSchema)
+  .superRefine((meshes, ctx) => {
+    const routers = new Map<string, string>();
+    for (const [meshName, mesh] of Object.entries(meshes)) {
+      for (const [chain, route] of Object.entries(mesh)) {
+        const key = `${chain}:${route.router.toLowerCase()}`;
+        const existing = routers.get(key);
+        if (existing) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [meshName, chain, 'router'],
+            message: `LayerZero router is already configured for policy ${existing}`,
+          });
+        }
+        routers.set(key, meshName);
+      }
+    }
+  });
+export type LayerZeroRoutes = z.infer<typeof LayerZeroRoutesSchema>;
+
+const EnvSchema = z.object({
+  HYPERLANE_EXPLORER_URL: z.string().url(),
+  REGISTRY_URI: REGISTRY_URI_SCHEMA,
+  LAYERZERO_ROUTES: z
+    .string()
+    .transform((value, ctx) => {
+      try {
+        return JSON.parse(value);
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'LAYERZERO_ROUTES must be valid JSON',
+        });
+        return z.NEVER;
+      }
+    })
+    .pipe(LayerZeroRoutesSchema),
+});
+
+export interface OriginTransactionResolver {
+  getOriginTransactionHashByMessageId(
+    id: string,
+    logger: Logger,
+  ): Promise<string>;
+}
+
+export interface LayerZeroPacketServiceConfig extends ServiceConfigWithMultiProvider {
+  routes: LayerZeroRoutes;
+  hyperlaneService: OriginTransactionResolver;
+}
+
+const ENDPOINT_ABI = [
+  'function eid() view returns (uint32)',
+  'function isValidReceiveLibrary(address receiver,uint32 srcEid,address receiveLibrary) view returns (bool)',
+  'function getReceiveLibrary(address receiver,uint32 srcEid) view returns (address,bool)',
+  'function receiveLibraryTimeout(address receiver,uint32 srcEid) view returns (address,uint256)',
+  'function inboundPayloadHash(address receiver,uint32 srcEid,bytes32 sender,uint64 nonce) view returns (bytes32)',
+];
+const RECEIVE_LIBRARY_ABI = [
+  'function commitVerification(bytes packetHeader,bytes32 payloadHash)',
+];
+
+export class LayerZeroPacketService extends BaseService {
+  public router: Router;
+  private readonly multiProvider: MultiProvider;
+  private readonly routes: LayerZeroRoutes;
+  private readonly hyperlaneService: OriginTransactionResolver;
+
+  static async create(serviceName: string): Promise<LayerZeroPacketService> {
+    const env = EnvSchema.parse(process.env);
+    const multiProvider = await BaseService.getMultiProvider(env.REGISTRY_URI);
+    const service = new LayerZeroPacketService({
+      serviceName,
+      multiProvider,
+      routes: env.LAYERZERO_ROUTES,
+      hyperlaneService: new HyperlaneService(
+        serviceName,
+        env.HYPERLANE_EXPLORER_URL,
+      ),
+    });
+    await service.validateEndpointEids();
+    return service;
+  }
+
+  private async validateEndpointEids(): Promise<void> {
+    await Promise.all(
+      Object.entries(this.routes).flatMap(([meshName, mesh]) =>
+        Object.entries(mesh).map(async ([chain, route]) => {
+          const endpoint = new ethers.Contract(
+            route.endpoint,
+            ENDPOINT_ABI,
+            this.multiProvider.getProvider(chain),
+          );
+          const actualLayerZeroDomainId = Number(await endpoint.eid());
+          assert(
+            actualLayerZeroDomainId === route.layerZeroDomainId,
+            `LayerZero mesh ${meshName} route ${chain} Endpoint reports domain ID ${actualLayerZeroDomainId}; configured ${route.layerZeroDomainId}`,
+          );
+        }),
+      ),
+    );
+  }
+
+  constructor(config: LayerZeroPacketServiceConfig) {
+    super(config);
+    this.multiProvider = config.multiProvider;
+    this.routes = config.routes;
+    this.hyperlaneService = config.hyperlaneService;
+    for (const [meshName, mesh] of Object.entries(this.routes)) {
+      for (const chain of Object.keys(mesh)) {
+        assert(
+          this.multiProvider.tryGetDomainId(chain) !== null &&
+            this.multiProvider.tryGetProvider(chain) !== null,
+          `LayerZero mesh ${meshName} route ${chain} has no configured RPC provider`,
+        );
+      }
+    }
+    this.router = Router();
+
+    this.router.get('/getLayerZeroPacket/:sender/:callData.json', (req, res) =>
+      createAbiHandler(
+        ILayerZeroPacketService__factory,
+        'getLayerZeroPacket',
+        (message: string, logger: Logger) =>
+          this.getLayerZeroPacket(
+            message,
+            req.params.sender,
+            undefined,
+            logger,
+          ),
+      )(req, res),
+    );
+    this.router.post('/getLayerZeroPacket', (req, res) => {
+      const rawTxHash = req.body?.origin_tx_hash;
+      const originTxHash =
+        typeof rawTxHash === 'string' && ethers.utils.isHexString(rawTxHash, 32)
+          ? rawTxHash
+          : undefined;
+      const requestRouter = req.body?.sender;
+      return createAbiHandler(
+        ILayerZeroPacketService__factory,
+        'getLayerZeroPacket',
+        (message: string, logger: Logger) =>
+          this.getLayerZeroPacket(message, requestRouter, originTxHash, logger),
+      )(req, res);
+    });
+  }
+
+  async getLayerZeroPacket(
+    message: string,
+    requestRouter: string,
+    originTxHash: string | undefined,
+    logger: Logger,
+  ): Promise<[string, string]> {
+    const parsed = parseMessage(message);
+    const messageId = ethers.utils.keccak256(message);
+    const { origin, destination } = this.routesFor(
+      parsed.origin,
+      parsed.destination,
+      requestRouter,
+    );
+    const txHash =
+      originTxHash ??
+      (await this.hyperlaneService.getOriginTransactionHashByMessageId(
+        messageId,
+        logger,
+      ));
+    const receipt = await this.multiProvider
+      .getProvider(parsed.origin)
+      .getTransactionReceipt(txHash);
+    assert(receipt, `No receipt found for origin transaction ${txHash}`);
+    assert(receipt.status === 1, `Origin transaction ${txHash} reverted`);
+    const dispatchCount = countMatchingHyperlaneDispatches(
+      receipt.logs,
+      origin.mailbox,
+      message,
+    );
+    assert(
+      dispatchCount === 1,
+      `Expected one exact Hyperlane Dispatch event, found ${dispatchCount}`,
+    );
+
+    let packet: ParsedLayerZeroPacket;
+    try {
+      packet = findMatchingLayerZeroPacket(receipt.logs, {
+        endpoint: origin.endpoint,
+        sourceEid: origin.layerZeroDomainId,
+        destinationEid: destination.layerZeroDomainId,
+        sender: ethers.utils.hexZeroPad(origin.router, 32),
+        receiver: ethers.utils.hexZeroPad(destination.router, 32),
+        payload: encodeLayerZeroPayload(
+          parsed.origin,
+          parsed.destination,
+          messageId,
+        ),
+      });
+    } catch (error) {
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        error instanceof Error && error.message.includes('Ambiguous')
+          ? UnhandledErrorReason.LAYERZERO_PACKET_AMBIGUOUS
+          : UnhandledErrorReason.LAYERZERO_PACKET_NOT_FOUND,
+      );
+      throw error;
+    }
+    let receiveLibrary: string;
+    try {
+      receiveLibrary = await this.resolveReadyReceiveLibrary(
+        parsed.destination,
+        origin,
+        destination,
+        packet,
+      );
+    } catch (error) {
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.LAYERZERO_RECEIVE_NOT_READY,
+      );
+      throw error;
+    }
+    return [receiveLibrary, packet.packet];
+  }
+
+  private routesFor(
+    originDomain: number,
+    destinationDomain: number,
+    requestRouter: string,
+  ): {
+    origin: LayerZeroChainConfig;
+    destination: LayerZeroChainConfig;
+  } {
+    assert(
+      typeof requestRouter === 'string' &&
+        ethers.utils.isAddress(requestRouter),
+      'Invalid LayerZero CCIP sender',
+    );
+    const originChain = this.multiProvider.tryGetChainName(originDomain);
+    const destinationChain =
+      this.multiProvider.tryGetChainName(destinationDomain);
+    assert(originChain, `Unknown Hyperlane origin domain ${originDomain}`);
+    assert(
+      destinationChain,
+      `Unknown Hyperlane destination domain ${destinationDomain}`,
+    );
+    const matches = Object.entries(this.routes).filter(([, mesh]) => {
+      const destination = mesh[destinationChain];
+      return (
+        destination?.router.toLowerCase() === requestRouter.toLowerCase() &&
+        !!mesh[originChain]
+      );
+    });
+    if (matches.length !== 1) {
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.LAYERZERO_ROUTE_NOT_CONFIGURED,
+      );
+    }
+    assert(
+      matches.length === 1,
+      `Expected one LayerZero mesh for ${originDomain} -> ${destinationDomain} and router ${requestRouter}; found ${matches.length}`,
+    );
+    const mesh = matches[0][1];
+    return {
+      origin: mesh[originChain],
+      destination: mesh[destinationChain],
+    };
+  }
+
+  private async resolveReadyReceiveLibrary(
+    destinationDomain: number,
+    origin: LayerZeroChainConfig,
+    destination: LayerZeroChainConfig,
+    packet: ParsedLayerZeroPacket,
+  ): Promise<string> {
+    const provider = this.multiProvider.getProvider(destinationDomain);
+    const endpointContract = new ethers.Contract(
+      destination.endpoint,
+      ENDPOINT_ABI,
+      provider,
+    );
+    const endpoint = {
+      getReceiveLibrary: (receiver: string, sourceEid: number) =>
+        endpointContract.getReceiveLibrary(receiver, sourceEid),
+      receiveLibraryTimeout: (receiver: string, sourceEid: number) =>
+        endpointContract.receiveLibraryTimeout(receiver, sourceEid),
+      inboundPayloadHash: (
+        receiver: string,
+        sourceEid: number,
+        sender: string,
+        nonce: ethers.BigNumberish,
+      ) =>
+        endpointContract.inboundPayloadHash(receiver, sourceEid, sender, nonce),
+      isValidReceiveLibrary: (
+        receiver: string,
+        sourceEid: number,
+        library: string,
+      ) => endpointContract.isValidReceiveLibrary(receiver, sourceEid, library),
+    };
+    return resolveLayerZeroReceiveLibrary(
+      endpoint,
+      {
+        receiver: destination.router,
+        sourceEid: origin.layerZeroDomainId,
+        sender: packet.sender,
+        nonce: packet.nonce,
+        payloadHash: packet.payloadHash,
+      },
+      async (library) => {
+        const receiveLibrary = new ethers.Contract(
+          library,
+          RECEIVE_LIBRARY_ABI,
+          provider,
+        );
+        // eth_call simulates commitVerification without persisting it. A revert
+        // means this library's configured DVNs are not ready for the packet.
+        const transaction = {
+          to: library,
+          data: receiveLibrary.interface.encodeFunctionData(
+            'commitVerification',
+            [packet.header, packet.payloadHash],
+          ),
+        };
+        if (provider instanceof HyperlaneSmartProvider) {
+          let lastError: unknown;
+          for (const rpcProvider of provider.rpcProviders) {
+            try {
+              // A successful no-return commit simulation returns `0x`.
+              // HyperlaneSmartProvider intentionally rejects empty call
+              // results, so issue raw eth_call against its RPC providers.
+              await rpcProvider.send('eth_call', [transaction, 'latest']);
+              return;
+            } catch (error) {
+              lastError = error;
+            }
+          }
+          throw lastError;
+        }
+        await provider.call(transaction);
+      },
+    );
+  }
+}

--- a/typescript/ccip-server/src/services/LayerZeroPacketService.ts
+++ b/typescript/ccip-server/src/services/LayerZeroPacketService.ts
@@ -3,7 +3,10 @@ import { Router } from 'express';
 import { Logger } from 'pino';
 import { z } from 'zod';
 
-import { ILayerZeroPacketService__factory } from '@hyperlane-xyz/core';
+import {
+  ILayerZeroPacketService__factory,
+  LayerZeroV2CcipReadHookIsm__factory,
+} from '@hyperlane-xyz/core';
 import { HyperlaneSmartProvider, MultiProvider } from '@hyperlane-xyz/sdk';
 import { assert, parseMessage } from '@hyperlane-xyz/utils';
 
@@ -25,77 +28,12 @@ import {
   findMatchingLayerZeroPacket,
   resolveLayerZeroReceiveLibrary,
 } from './layerZeroPacketMatcher.js';
-
-const AddressSchema = z
-  .string()
-  .refine(ethers.utils.isAddress, 'must be an address')
-  .refine(
-    (address) => address !== ethers.constants.AddressZero,
-    'must not be zero',
-  );
-
-export const LayerZeroChainConfigSchema = z.object({
-  mailbox: AddressSchema,
-  endpoint: AddressSchema,
-  layerZeroDomainId: z.number().int().positive().max(0xffffffff),
-  router: AddressSchema,
-});
-
-export type LayerZeroChainConfig = z.infer<typeof LayerZeroChainConfigSchema>;
-export const LayerZeroMeshSchema = z
-  .record(z.string(), LayerZeroChainConfigSchema)
-  .superRefine((routes, ctx) => {
-    const layerZeroDomainIds = new Map<number, string>();
-    for (const [chain, route] of Object.entries(routes)) {
-      const existing = layerZeroDomainIds.get(route.layerZeroDomainId);
-      if (existing) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: [chain, 'layerZeroDomainId'],
-          message: `LayerZero domain ID ${route.layerZeroDomainId} is already configured for ${existing}`,
-        });
-      }
-      layerZeroDomainIds.set(route.layerZeroDomainId, chain);
-    }
-  });
-export const LayerZeroRoutesSchema = z
-  .record(z.string(), LayerZeroMeshSchema)
-  .superRefine((meshes, ctx) => {
-    const routers = new Map<string, string>();
-    for (const [meshName, mesh] of Object.entries(meshes)) {
-      for (const [chain, route] of Object.entries(mesh)) {
-        const key = `${chain}:${route.router.toLowerCase()}`;
-        const existing = routers.get(key);
-        if (existing) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: [meshName, chain, 'router'],
-            message: `LayerZero router is already configured for policy ${existing}`,
-          });
-        }
-        routers.set(key, meshName);
-      }
-    }
-  });
-export type LayerZeroRoutes = z.infer<typeof LayerZeroRoutesSchema>;
+import { resolveLayerZeroRoutes } from './layerZeroRouteResolver.js';
+import type { LayerZeroChainConfig } from './layerZeroRouteResolver.js';
 
 const EnvSchema = z.object({
   HYPERLANE_EXPLORER_URL: z.string().url(),
   REGISTRY_URI: REGISTRY_URI_SCHEMA,
-  LAYERZERO_ROUTES: z
-    .string()
-    .transform((value, ctx) => {
-      try {
-        return JSON.parse(value);
-      } catch {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'LAYERZERO_ROUTES must be valid JSON',
-        });
-        return z.NEVER;
-      }
-    })
-    .pipe(LayerZeroRoutesSchema),
 });
 
 export interface OriginTransactionResolver {
@@ -106,7 +44,6 @@ export interface OriginTransactionResolver {
 }
 
 export interface LayerZeroPacketServiceConfig extends ServiceConfigWithMultiProvider {
-  routes: LayerZeroRoutes;
   hyperlaneService: OriginTransactionResolver;
 }
 
@@ -124,7 +61,6 @@ const RECEIVE_LIBRARY_ABI = [
 export class LayerZeroPacketService extends BaseService {
   public router: Router;
   private readonly multiProvider: MultiProvider;
-  private readonly routes: LayerZeroRoutes;
   private readonly hyperlaneService: OriginTransactionResolver;
 
   static async create(serviceName: string): Promise<LayerZeroPacketService> {
@@ -133,49 +69,18 @@ export class LayerZeroPacketService extends BaseService {
     const service = new LayerZeroPacketService({
       serviceName,
       multiProvider,
-      routes: env.LAYERZERO_ROUTES,
       hyperlaneService: new HyperlaneService(
         serviceName,
         env.HYPERLANE_EXPLORER_URL,
       ),
     });
-    await service.validateEndpointEids();
     return service;
-  }
-
-  private async validateEndpointEids(): Promise<void> {
-    await Promise.all(
-      Object.entries(this.routes).flatMap(([meshName, mesh]) =>
-        Object.entries(mesh).map(async ([chain, route]) => {
-          const endpoint = new ethers.Contract(
-            route.endpoint,
-            ENDPOINT_ABI,
-            this.multiProvider.getProvider(chain),
-          );
-          const actualLayerZeroDomainId = Number(await endpoint.eid());
-          assert(
-            actualLayerZeroDomainId === route.layerZeroDomainId,
-            `LayerZero mesh ${meshName} route ${chain} Endpoint reports domain ID ${actualLayerZeroDomainId}; configured ${route.layerZeroDomainId}`,
-          );
-        }),
-      ),
-    );
   }
 
   constructor(config: LayerZeroPacketServiceConfig) {
     super(config);
     this.multiProvider = config.multiProvider;
-    this.routes = config.routes;
     this.hyperlaneService = config.hyperlaneService;
-    for (const [meshName, mesh] of Object.entries(this.routes)) {
-      for (const chain of Object.keys(mesh)) {
-        assert(
-          this.multiProvider.tryGetDomainId(chain) !== null &&
-            this.multiProvider.tryGetProvider(chain) !== null,
-          `LayerZero mesh ${meshName} route ${chain} has no configured RPC provider`,
-        );
-      }
-    }
     this.router = Router();
 
     this.router.get('/getLayerZeroPacket/:sender/:callData.json', (req, res) =>
@@ -215,11 +120,21 @@ export class LayerZeroPacketService extends BaseService {
   ): Promise<[string, string]> {
     const parsed = parseMessage(message);
     const messageId = ethers.utils.keccak256(message);
-    const { origin, destination } = this.routesFor(
-      parsed.origin,
-      parsed.destination,
-      requestRouter,
-    );
+    let origin: LayerZeroChainConfig;
+    let destination: LayerZeroChainConfig;
+    try {
+      ({ origin, destination } = await this.routesFor(
+        parsed.origin,
+        parsed.destination,
+        requestRouter,
+      ));
+    } catch (error) {
+      PrometheusMetrics.logUnhandledError(
+        this.config.serviceName,
+        UnhandledErrorReason.LAYERZERO_ROUTE_NOT_CONFIGURED,
+      );
+      throw error;
+    }
     const txHash =
       originTxHash ??
       (await this.hyperlaneService.getOriginTransactionHashByMessageId(
@@ -282,14 +197,14 @@ export class LayerZeroPacketService extends BaseService {
     return [receiveLibrary, packet.packet];
   }
 
-  private routesFor(
+  private async routesFor(
     originDomain: number,
     destinationDomain: number,
     requestRouter: string,
-  ): {
+  ): Promise<{
     origin: LayerZeroChainConfig;
     destination: LayerZeroChainConfig;
-  } {
+  }> {
     assert(
       typeof requestRouter === 'string' &&
         ethers.utils.isAddress(requestRouter),
@@ -303,28 +218,42 @@ export class LayerZeroPacketService extends BaseService {
       destinationChain,
       `Unknown Hyperlane destination domain ${destinationDomain}`,
     );
-    const matches = Object.entries(this.routes).filter(([, mesh]) => {
-      const destination = mesh[destinationChain];
-      return (
-        destination?.router.toLowerCase() === requestRouter.toLowerCase() &&
-        !!mesh[originChain]
-      );
-    });
-    if (matches.length !== 1) {
-      PrometheusMetrics.logUnhandledError(
-        this.config.serviceName,
-        UnhandledErrorReason.LAYERZERO_ROUTE_NOT_CONFIGURED,
-      );
-    }
     assert(
-      matches.length === 1,
-      `Expected one LayerZero mesh for ${originDomain} -> ${destinationDomain} and router ${requestRouter}; found ${matches.length}`,
+      this.multiProvider.tryGetProvider(originChain) !== null,
+      `Hyperlane origin domain ${originDomain} has no configured RPC provider`,
     );
-    const mesh = matches[0][1];
-    return {
-      origin: mesh[originChain],
-      destination: mesh[destinationChain],
-    };
+    assert(
+      this.multiProvider.tryGetProvider(destinationChain) !== null,
+      `Hyperlane destination domain ${destinationDomain} has no configured RPC provider`,
+    );
+    const routes = await resolveLayerZeroRoutes(
+      originDomain,
+      destinationDomain,
+      requestRouter,
+      (router, domain) =>
+        LayerZeroV2CcipReadHookIsm__factory.connect(
+          router,
+          this.multiProvider.getProvider(domain),
+        ),
+    );
+    await Promise.all(
+      [
+        [originDomain, routes.origin] as const,
+        [destinationDomain, routes.destination] as const,
+      ].map(async ([domain, route]) => {
+        const endpoint = new ethers.Contract(
+          route.endpoint,
+          ENDPOINT_ABI,
+          this.multiProvider.getProvider(domain),
+        );
+        const endpointEid = Number(await endpoint.eid());
+        assert(
+          endpointEid === route.layerZeroDomainId,
+          `LayerZero Endpoint ${route.endpoint} reports domain ID ${endpointEid}; router reports ${route.layerZeroDomainId}`,
+        );
+      }),
+    );
+    return routes;
   }
 
   private async resolveReadyReceiveLibrary(

--- a/typescript/ccip-server/src/services/layerZeroPacketMatcher.ts
+++ b/typescript/ccip-server/src/services/layerZeroPacketMatcher.ts
@@ -1,0 +1,237 @@
+import { ethers } from 'ethers';
+
+import { Mailbox__factory } from '@hyperlane-xyz/core';
+import { assert } from '@hyperlane-xyz/utils';
+
+export const LAYER_ZERO_PACKET_VERSION = 1;
+export const LAYER_ZERO_PACKET_HEADER_LENGTH = 81;
+export const LAYER_ZERO_PACKET_MESSAGE_OFFSET = 113;
+
+const PACKET_SENT_ABI = [
+  'event PacketSent(bytes encodedPayload, bytes options, address sendLibrary)',
+];
+
+export interface LayerZeroPacketQuery {
+  endpoint: string;
+  sourceEid: number;
+  destinationEid: number;
+  sender: string;
+  receiver: string;
+  payload: string;
+}
+
+export function countMatchingHyperlaneDispatches(
+  logs: ReadonlyArray<{ address: string; topics: Array<string>; data: string }>,
+  mailboxAddress: string,
+  message: string,
+): number {
+  const mailbox = Mailbox__factory.createInterface();
+  return logs.filter((log) => {
+    if (log.address.toLowerCase() !== mailboxAddress.toLowerCase())
+      return false;
+    try {
+      const parsedLog = mailbox.parseLog(log);
+      return (
+        parsedLog.name === 'Dispatch' &&
+        parsedLog.args.message.toLowerCase() === message.toLowerCase()
+      );
+    } catch {
+      return false;
+    }
+  }).length;
+}
+
+export interface ParsedLayerZeroPacket {
+  packet: string;
+  nonce: bigint;
+  sourceEid: number;
+  sender: string;
+  destinationEid: number;
+  receiver: string;
+  guid: string;
+  payload: string;
+  header: string;
+  payloadHash: string;
+  sendLibrary: string;
+}
+
+export interface LayerZeroEndpointReader {
+  getReceiveLibrary(
+    receiver: string,
+    srcEid: number,
+  ): Promise<[string, boolean]>;
+  receiveLibraryTimeout(
+    receiver: string,
+    srcEid: number,
+  ): Promise<[string, ethers.BigNumberish]>;
+  inboundPayloadHash(
+    receiver: string,
+    srcEid: number,
+    sender: string,
+    nonce: ethers.BigNumberish,
+  ): Promise<string>;
+  isValidReceiveLibrary(
+    receiver: string,
+    srcEid: number,
+    library: string,
+  ): Promise<boolean>;
+}
+
+export interface LayerZeroReceiveQuery {
+  receiver: string;
+  sourceEid: number;
+  sender: string;
+  nonce: ethers.BigNumberish;
+  payloadHash: string;
+}
+
+export async function resolveLayerZeroReceiveLibrary(
+  endpoint: LayerZeroEndpointReader,
+  query: LayerZeroReceiveQuery,
+  simulateCommit: (library: string) => Promise<void>,
+): Promise<string> {
+  const [current, timeout, currentPayloadHash] = await Promise.all([
+    endpoint.getReceiveLibrary(query.receiver, query.sourceEid),
+    endpoint.receiveLibraryTimeout(query.receiver, query.sourceEid),
+    endpoint.inboundPayloadHash(
+      query.receiver,
+      query.sourceEid,
+      query.sender,
+      query.nonce,
+    ),
+  ]);
+  const candidates = [...new Set<string>([current[0], timeout[0]])].filter(
+    (library) =>
+      library.toLowerCase() !== ethers.constants.AddressZero.toLowerCase(),
+  );
+  const validCandidates: string[] = [];
+  for (const library of candidates) {
+    if (
+      await endpoint.isValidReceiveLibrary(
+        query.receiver,
+        query.sourceEid,
+        library,
+      )
+    ) {
+      validCandidates.push(library);
+    }
+  }
+  assert(validCandidates.length > 0, 'No valid LayerZero receive library');
+
+  if (currentPayloadHash !== ethers.constants.HashZero) {
+    assert(
+      currentPayloadHash.toLowerCase() === query.payloadHash.toLowerCase(),
+      'Endpoint contains a conflicting LayerZero payload hash',
+    );
+    return validCandidates[0];
+  }
+
+  let lastError: unknown;
+  for (const library of validCandidates) {
+    try {
+      await simulateCommit(library);
+      return library;
+    } catch (error) {
+      lastError = error;
+      continue;
+    }
+  }
+  throw new Error(`LayerZero packet is not DVN-ready: ${lastError}`);
+}
+
+export function encodeLayerZeroPayload(
+  origin: number,
+  destination: number,
+  messageId: string,
+): string {
+  return ethers.utils.defaultAbiCoder.encode(
+    ['uint8', 'uint32', 'uint32', 'bytes32'],
+    [1, origin, destination, messageId],
+  );
+}
+
+export function parseLayerZeroPacket(packet: string): ParsedLayerZeroPacket {
+  const bytes = ethers.utils.arrayify(packet);
+  assert(
+    bytes.length >= LAYER_ZERO_PACKET_MESSAGE_OFFSET,
+    'LayerZero packet is truncated',
+  );
+  assert(
+    bytes[0] === LAYER_ZERO_PACKET_VERSION,
+    `Unsupported LayerZero packet version ${bytes[0]}`,
+  );
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const nonce = view.getBigUint64(1);
+  const sourceEid = view.getUint32(9);
+  const sender = ethers.utils.hexlify(bytes.subarray(13, 45));
+  const destinationEid = view.getUint32(45);
+  const receiver = ethers.utils.hexlify(bytes.subarray(49, 81));
+  const guid = ethers.utils.hexlify(bytes.subarray(81, 113));
+  const payload = ethers.utils.hexlify(bytes.subarray(113));
+  const header = ethers.utils.hexlify(bytes.subarray(0, 81));
+  const expectedGuid = ethers.utils.solidityKeccak256(
+    ['uint64', 'uint32', 'bytes32', 'uint32', 'bytes32'],
+    [nonce.toString(), sourceEid, sender, destinationEid, receiver],
+  );
+  assert(
+    guid.toLowerCase() === expectedGuid.toLowerCase(),
+    'LayerZero GUID mismatch',
+  );
+
+  return {
+    packet,
+    nonce,
+    sourceEid,
+    sender,
+    destinationEid,
+    receiver,
+    guid,
+    payload,
+    header,
+    payloadHash: ethers.utils.keccak256(
+      ethers.utils.hexConcat([guid, payload]),
+    ),
+    sendLibrary: ethers.constants.AddressZero,
+  };
+}
+
+export function findMatchingLayerZeroPacket(
+  logs: ReadonlyArray<{ address: string; topics: Array<string>; data: string }>,
+  query: LayerZeroPacketQuery,
+): ParsedLayerZeroPacket {
+  const iface = new ethers.utils.Interface(PACKET_SENT_ABI);
+  const matches: ParsedLayerZeroPacket[] = [];
+
+  for (const log of logs) {
+    if (log.address.toLowerCase() !== query.endpoint.toLowerCase()) continue;
+    let decoded;
+    try {
+      decoded = iface.parseLog(log);
+    } catch {
+      continue;
+    }
+    if (decoded.name !== 'PacketSent') continue;
+
+    let packet: ParsedLayerZeroPacket;
+    try {
+      packet = parseLayerZeroPacket(decoded.args.encodedPayload);
+    } catch {
+      continue;
+    }
+    if (
+      packet.sourceEid !== query.sourceEid ||
+      packet.destinationEid !== query.destinationEid ||
+      packet.sender.toLowerCase() !== query.sender.toLowerCase() ||
+      packet.receiver.toLowerCase() !== query.receiver.toLowerCase() ||
+      packet.payload.toLowerCase() !== query.payload.toLowerCase()
+    ) {
+      continue;
+    }
+    matches.push({ ...packet, sendLibrary: decoded.args.sendLibrary });
+  }
+
+  assert(matches.length > 0, 'No matching LayerZero packet in origin receipt');
+  assert(matches.length === 1, 'Ambiguous LayerZero packets in origin receipt');
+  return matches[0];
+}

--- a/typescript/ccip-server/src/services/layerZeroRouteResolver.ts
+++ b/typescript/ccip-server/src/services/layerZeroRouteResolver.ts
@@ -1,0 +1,175 @@
+import { ethers } from 'ethers';
+
+import { ModuleType, OnchainHookType } from '@hyperlane-xyz/sdk';
+import {
+  addressToBytes32,
+  assert,
+  bytes32ToAddress,
+} from '@hyperlane-xyz/utils';
+
+export interface LayerZeroChainConfig {
+  mailbox: string;
+  endpoint: string;
+  layerZeroDomainId: number;
+  router: string;
+}
+
+export interface LayerZeroRouterReader {
+  endpoint(): Promise<string>;
+  hookType(): Promise<number>;
+  localDomain(): Promise<number>;
+  localEid(): Promise<number>;
+  mailbox(): Promise<string>;
+  moduleType(): Promise<number>;
+  remoteConfigs(domain: number): Promise<number>;
+  routers(domain: number): Promise<string>;
+}
+
+export type LayerZeroRouterConnector = (
+  router: string,
+  domain: number,
+) => LayerZeroRouterReader;
+
+interface LayerZeroRouterState extends LayerZeroChainConfig {
+  moduleType: number;
+  remoteLayerZeroDomainId: number;
+  remoteRouter: string;
+}
+
+function assertAddress(address: string, label: string): void {
+  assert(
+    ethers.utils.isAddress(address) && address !== ethers.constants.AddressZero,
+    `${label} is not a non-zero EVM address`,
+  );
+}
+
+async function readRouterState(
+  router: string,
+  localDomain: number,
+  remoteDomain: number,
+  connect: LayerZeroRouterConnector,
+): Promise<LayerZeroRouterState> {
+  assertAddress(router, `LayerZero router for domain ${localDomain}`);
+  const contract = connect(router, localDomain);
+  const [
+    mailbox,
+    endpoint,
+    actualLocalDomain,
+    layerZeroDomainId,
+    hookType,
+    moduleType,
+    remoteRouter,
+    remoteLayerZeroDomainId,
+  ] = await Promise.all([
+    contract.mailbox(),
+    contract.endpoint(),
+    contract.localDomain(),
+    contract.localEid(),
+    contract.hookType(),
+    contract.moduleType(),
+    contract.routers(remoteDomain),
+    contract.remoteConfigs(remoteDomain),
+  ]);
+
+  assert(
+    actualLocalDomain === localDomain,
+    `LayerZero router ${router} reports Hyperlane domain ${actualLocalDomain}; expected ${localDomain}`,
+  );
+  assert(
+    hookType === OnchainHookType.LAYER_ZERO,
+    `Contract ${router} on domain ${localDomain} is not a LayerZero hook`,
+  );
+  assert(
+    moduleType === ModuleType.NULL || moduleType === ModuleType.CCIP_READ,
+    `Contract ${router} on domain ${localDomain} is not a supported LayerZero ISM`,
+  );
+  assertAddress(mailbox, `Mailbox for LayerZero router ${router}`);
+  assertAddress(endpoint, `Endpoint for LayerZero router ${router}`);
+  assert(
+    layerZeroDomainId > 0,
+    `LayerZero router ${router} reports invalid local domain ID ${layerZeroDomainId}`,
+  );
+  assert(
+    remoteLayerZeroDomainId > 0 &&
+      remoteLayerZeroDomainId !== layerZeroDomainId,
+    `LayerZero router ${router} reports invalid remote domain ID ${remoteLayerZeroDomainId}`,
+  );
+  const remoteRouterAddress = bytes32ToAddress(remoteRouter);
+  assert(
+    addressToBytes32(remoteRouterAddress).toLowerCase() ===
+      remoteRouter.toLowerCase(),
+    `LayerZero router ${router} has a non-canonical peer for Hyperlane domain ${remoteDomain}`,
+  );
+  assertAddress(
+    remoteRouterAddress,
+    `LayerZero peer for ${localDomain} -> ${remoteDomain}`,
+  );
+
+  return {
+    mailbox,
+    endpoint,
+    layerZeroDomainId,
+    router,
+    moduleType,
+    remoteLayerZeroDomainId,
+    remoteRouter: remoteRouterAddress,
+  };
+}
+
+/**
+ * Resolves a LayerZero pathway from the CCIP-read sender and the two Hyperlane
+ * domains. Both contracts must identify themselves as LayerZero hook/ISMs and
+ * have reciprocal router and EID enrollment. No trusted deployment-address
+ * configuration is required by the offchain server.
+ */
+export async function resolveLayerZeroRoutes(
+  originDomain: number,
+  destinationDomain: number,
+  requestRouter: string,
+  connect: LayerZeroRouterConnector,
+): Promise<{
+  origin: LayerZeroChainConfig;
+  destination: LayerZeroChainConfig;
+}> {
+  const destination = await readRouterState(
+    requestRouter,
+    destinationDomain,
+    originDomain,
+    connect,
+  );
+  assert(
+    destination.moduleType === ModuleType.CCIP_READ,
+    `LayerZero CCIP sender ${requestRouter} is not a CCIP-read ISM`,
+  );
+
+  const origin = await readRouterState(
+    destination.remoteRouter,
+    originDomain,
+    destinationDomain,
+    connect,
+  );
+  assert(
+    origin.remoteRouter.toLowerCase() === requestRouter.toLowerCase(),
+    `LayerZero routers are not reciprocally enrolled for ${originDomain} -> ${destinationDomain}`,
+  );
+  assert(
+    destination.remoteLayerZeroDomainId === origin.layerZeroDomainId &&
+      origin.remoteLayerZeroDomainId === destination.layerZeroDomainId,
+    `LayerZero domain IDs are inconsistent for ${originDomain} -> ${destinationDomain}`,
+  );
+
+  return {
+    origin: {
+      mailbox: origin.mailbox,
+      endpoint: origin.endpoint,
+      layerZeroDomainId: origin.layerZeroDomainId,
+      router: origin.router,
+    },
+    destination: {
+      mailbox: destination.mailbox,
+      endpoint: destination.endpoint,
+      layerZeroDomainId: destination.layerZeroDomainId,
+      router: destination.router,
+    },
+  };
+}

--- a/typescript/ccip-server/src/utils/prometheus.ts
+++ b/typescript/ccip-server/src/utils/prometheus.ts
@@ -30,6 +30,12 @@ export enum UnhandledErrorReason {
   // CallCommitments errors
   CALL_COMMITMENTS_DATABASE_ERROR = 'call_commitments_database_error',
 
+  // LayerZero errors
+  LAYERZERO_ROUTE_NOT_CONFIGURED = 'layerzero_route_not_configured',
+  LAYERZERO_PACKET_NOT_FOUND = 'layerzero_packet_not_found',
+  LAYERZERO_PACKET_AMBIGUOUS = 'layerzero_packet_ambiguous',
+  LAYERZERO_RECEIVE_NOT_READY = 'layerzero_receive_not_ready',
+
   // Generic fallback
   UNKNOWN = 'unknown',
 }

--- a/typescript/ccip-server/tests/services/layerZeroPacketMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/layerZeroPacketMatcher.test.ts
@@ -1,0 +1,238 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
+import { Mailbox__factory } from '@hyperlane-xyz/core';
+
+import { LayerZeroRoutesSchema } from '../../src/services/LayerZeroPacketService.js';
+import {
+  countMatchingHyperlaneDispatches,
+  encodeLayerZeroPayload,
+  findMatchingLayerZeroPacket,
+  parseLayerZeroPacket,
+  resolveLayerZeroReceiveLibrary,
+} from '../../src/services/layerZeroPacketMatcher.js';
+
+describe('LayerZeroRoutesSchema', () => {
+  const chain = (
+    layerZeroDomainId: number,
+    router = ethers.Wallet.createRandom().address,
+  ) => ({
+    mailbox: ethers.Wallet.createRandom().address,
+    endpoint: ethers.Wallet.createRandom().address,
+    layerZeroDomainId,
+    router,
+  });
+
+  it('accepts policy-scoped meshes with unique LayerZero domain IDs and routers', () => {
+    expect(
+      LayerZeroRoutesSchema.safeParse({
+        policyA: { chainA: chain(101), chainB: chain(102) },
+        policyB: { chainA: chain(201), chainB: chain(202) },
+      }).success,
+    ).to.be.true;
+  });
+
+  it('rejects duplicate LayerZero domain IDs within a mesh', () => {
+    expect(
+      LayerZeroRoutesSchema.safeParse({
+        policyA: { chainA: chain(101), chainB: chain(101) },
+      }).success,
+    ).to.be.false;
+  });
+
+  it('rejects a router assigned to multiple policies on one chain', () => {
+    const router = ethers.Wallet.createRandom().address;
+    expect(
+      LayerZeroRoutesSchema.safeParse({
+        policyA: { chainA: chain(101, router) },
+        policyB: { chainA: chain(201, router) },
+      }).success,
+    ).to.be.false;
+  });
+});
+
+describe('layerZeroPacketMatcher', () => {
+  const endpoint = ethers.Wallet.createRandom().address;
+  const sender = addressToBytes32(ethers.Wallet.createRandom().address);
+  const receiver = addressToBytes32(ethers.Wallet.createRandom().address);
+  const sendLibrary = ethers.Wallet.createRandom().address;
+  const sourceEid = 101;
+  const destinationEid = 102;
+  const nonce = 7;
+  const messageId = ethers.utils.keccak256('0x1234');
+  const payload = encodeLayerZeroPayload(1000, 2000, messageId);
+  const guid = ethers.utils.solidityKeccak256(
+    ['uint64', 'uint32', 'bytes32', 'uint32', 'bytes32'],
+    [nonce, sourceEid, sender, destinationEid, receiver],
+  );
+  const packet = ethers.utils.solidityPack(
+    [
+      'uint8',
+      'uint64',
+      'uint32',
+      'bytes32',
+      'uint32',
+      'bytes32',
+      'bytes32',
+      'bytes',
+    ],
+    [1, nonce, sourceEid, sender, destinationEid, receiver, guid, payload],
+  );
+  const iface = new ethers.utils.Interface([
+    'event PacketSent(bytes encodedPayload,bytes options,address sendLibrary)',
+  ]);
+  const event = iface.encodeEventLog(iface.getEvent('PacketSent'), [
+    packet,
+    '0x0003',
+    sendLibrary,
+  ]);
+  const log = { address: endpoint, topics: event.topics, data: event.data };
+
+  it('parses the official V2 packet layout and validates its GUID', () => {
+    const parsed = parseLayerZeroPacket(packet);
+    expect(parsed.nonce).to.equal(7n);
+    expect(parsed.payload).to.equal(payload);
+    expect(parsed.payloadHash).to.equal(
+      ethers.utils.keccak256(ethers.utils.hexConcat([guid, payload])),
+    );
+  });
+
+  it('selects exactly the packet bound to the configured pathway', () => {
+    const matched = findMatchingLayerZeroPacket([log], {
+      endpoint,
+      sourceEid,
+      destinationEid,
+      sender,
+      receiver,
+      payload,
+    });
+    expect(matched.packet).to.equal(packet);
+    expect(matched.sendLibrary).to.equal(sendLibrary);
+  });
+
+  it('binds packet discovery to the exact Mailbox Dispatch event', () => {
+    const mailboxAddress = ethers.Wallet.createRandom().address;
+    const otherMailbox = ethers.Wallet.createRandom().address;
+    const message = '0x1234';
+    const mailbox = Mailbox__factory.createInterface();
+    const dispatch = mailbox.encodeEventLog(mailbox.getEvent('Dispatch'), [
+      ethers.Wallet.createRandom().address,
+      2000,
+      receiver,
+      message,
+    ]);
+    const dispatchLog = {
+      address: mailboxAddress,
+      topics: dispatch.topics,
+      data: dispatch.data,
+    };
+    expect(
+      countMatchingHyperlaneDispatches([dispatchLog], mailboxAddress, message),
+    ).to.equal(1);
+    expect(
+      countMatchingHyperlaneDispatches([dispatchLog], otherMailbox, message),
+    ).to.equal(0);
+    expect(
+      countMatchingHyperlaneDispatches([dispatchLog], mailboxAddress, '0xabcd'),
+    ).to.equal(0);
+  });
+
+  it('rejects absent and ambiguous matches', () => {
+    expect(() =>
+      findMatchingLayerZeroPacket([log], {
+        endpoint,
+        sourceEid: sourceEid + 1,
+        destinationEid,
+        sender,
+        receiver,
+        payload,
+      }),
+    ).to.throw('No matching LayerZero packet');
+    expect(() =>
+      findMatchingLayerZeroPacket([log, log], {
+        endpoint,
+        sourceEid,
+        destinationEid,
+        sender,
+        receiver,
+        payload,
+      }),
+    ).to.throw('Ambiguous LayerZero packets');
+  });
+
+  it('uses a ready grace library when the current library is pending', async () => {
+    const current = ethers.Wallet.createRandom().address;
+    const grace = ethers.Wallet.createRandom().address;
+    const simulated: string[] = [];
+    const selected = await resolveLayerZeroReceiveLibrary(
+      {
+        getReceiveLibrary: async () => [current, false],
+        receiveLibraryTimeout: async () => [grace, 100],
+        inboundPayloadHash: async () => ethers.constants.HashZero,
+        isValidReceiveLibrary: async () => true,
+      },
+      {
+        receiver,
+        sourceEid,
+        sender,
+        nonce,
+        payloadHash: ethers.utils.keccak256('0x1234'),
+      },
+      async (library) => {
+        simulated.push(library);
+        if (library === current) throw new Error('DVNs pending');
+      },
+    );
+    expect(selected).to.equal(grace);
+    expect(simulated).to.deep.equal([current, grace]);
+  });
+
+  it('accepts an already committed exact hash and rejects a conflict', async () => {
+    const library = ethers.Wallet.createRandom().address;
+    const payloadHash = ethers.utils.keccak256('0x1234');
+    const endpoint = {
+      getReceiveLibrary: async (): Promise<[string, boolean]> => [
+        library,
+        false,
+      ],
+      receiveLibraryTimeout: async (): Promise<[string, number]> => [
+        ethers.constants.AddressZero,
+        0,
+      ],
+      inboundPayloadHash: async () => payloadHash,
+      isValidReceiveLibrary: async () => true,
+    };
+    expect(
+      await resolveLayerZeroReceiveLibrary(
+        endpoint,
+        { receiver, sourceEid, sender, nonce, payloadHash },
+        async () => {
+          throw new Error('must not simulate');
+        },
+      ),
+    ).to.equal(library);
+    let error: unknown;
+    try {
+      await resolveLayerZeroReceiveLibrary(
+        endpoint,
+        {
+          receiver,
+          sourceEid,
+          sender,
+          nonce,
+          payloadHash: ethers.utils.keccak256('0xabcd'),
+        },
+        async () => undefined,
+      );
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error)
+      .to.be.an('error')
+      .with.property(
+        'message',
+        'Endpoint contains a conflicting LayerZero payload hash',
+      );
+  });
+});

--- a/typescript/ccip-server/tests/services/layerZeroPacketMatcher.test.ts
+++ b/typescript/ccip-server/tests/services/layerZeroPacketMatcher.test.ts
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 
-import { addressToBytes32 } from '@hyperlane-xyz/utils';
 import { Mailbox__factory } from '@hyperlane-xyz/core';
+import { ModuleType, OnchainHookType } from '@hyperlane-xyz/sdk';
+import { addressToBytes32 } from '@hyperlane-xyz/utils';
 
-import { LayerZeroRoutesSchema } from '../../src/services/LayerZeroPacketService.js';
+import { resolveLayerZeroRoutes } from '../../src/services/layerZeroRouteResolver.js';
+import type { LayerZeroRouterReader } from '../../src/services/layerZeroRouteResolver.js';
 import {
   countMatchingHyperlaneDispatches,
   encodeLayerZeroPayload,
@@ -13,42 +15,126 @@ import {
   resolveLayerZeroReceiveLibrary,
 } from '../../src/services/layerZeroPacketMatcher.js';
 
-describe('LayerZeroRoutesSchema', () => {
-  const chain = (
-    layerZeroDomainId: number,
-    router = ethers.Wallet.createRandom().address,
-  ) => ({
-    mailbox: ethers.Wallet.createRandom().address,
-    endpoint: ethers.Wallet.createRandom().address,
-    layerZeroDomainId,
-    router,
+describe('resolveLayerZeroRoutes', () => {
+  const originDomain = 1_000;
+  const destinationDomain = 2_000;
+  const originEid = 30_101;
+  const destinationEid = 30_110;
+  const originRouter = ethers.Wallet.createRandom().address;
+  const destinationRouter = ethers.Wallet.createRandom().address;
+
+  function reader({
+    domain,
+    eid,
+    peer,
+    peerEid,
+    moduleType,
+  }: {
+    domain: number;
+    eid: number;
+    peer: string;
+    peerEid: number;
+    moduleType: ModuleType;
+  }): LayerZeroRouterReader {
+    return {
+      endpoint: async () => ethers.Wallet.createRandom().address,
+      hookType: async () => OnchainHookType.LAYER_ZERO,
+      localDomain: async () => domain,
+      localEid: async () => eid,
+      mailbox: async () => ethers.Wallet.createRandom().address,
+      moduleType: async () => moduleType,
+      remoteConfigs: async () => peerEid,
+      routers: async () => addressToBytes32(peer),
+    };
+  }
+
+  function connector(originPeer = destinationRouter) {
+    const readers = new Map<string, LayerZeroRouterReader>([
+      [
+        `${originDomain}:${originRouter.toLowerCase()}`,
+        reader({
+          domain: originDomain,
+          eid: originEid,
+          peer: originPeer,
+          peerEid: destinationEid,
+          moduleType: ModuleType.NULL,
+        }),
+      ],
+      [
+        `${destinationDomain}:${destinationRouter.toLowerCase()}`,
+        reader({
+          domain: destinationDomain,
+          eid: destinationEid,
+          peer: originRouter,
+          peerEid: originEid,
+          moduleType: ModuleType.CCIP_READ,
+        }),
+      ],
+    ]);
+    return (router: string, domain: number): LayerZeroRouterReader => {
+      const result = readers.get(`${domain}:${router.toLowerCase()}`);
+      if (!result) throw new Error(`Unexpected router ${router}`);
+      return result;
+    };
+  }
+
+  it('discovers a reciprocally enrolled route from the CCIP sender', async () => {
+    const routes = await resolveLayerZeroRoutes(
+      originDomain,
+      destinationDomain,
+      destinationRouter,
+      connector(),
+    );
+    expect(routes.origin.router).to.equal(originRouter);
+    expect(routes.origin.layerZeroDomainId).to.equal(originEid);
+    expect(routes.destination.router).to.equal(destinationRouter);
+    expect(routes.destination.layerZeroDomainId).to.equal(destinationEid);
   });
 
-  it('accepts policy-scoped meshes with unique LayerZero domain IDs and routers', () => {
-    expect(
-      LayerZeroRoutesSchema.safeParse({
-        policyA: { chainA: chain(101), chainB: chain(102) },
-        policyB: { chainA: chain(201), chainB: chain(202) },
-      }).success,
-    ).to.be.true;
+  it('rejects routes without reciprocal enrollment', async () => {
+    let error: unknown;
+    try {
+      await resolveLayerZeroRoutes(
+        originDomain,
+        destinationDomain,
+        destinationRouter,
+        connector(ethers.Wallet.createRandom().address),
+      );
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error)
+      .to.be.an('error')
+      .with.property('message')
+      .that.includes('not reciprocally enrolled');
   });
 
-  it('rejects duplicate LayerZero domain IDs within a mesh', () => {
-    expect(
-      LayerZeroRoutesSchema.safeParse({
-        policyA: { chainA: chain(101), chainB: chain(101) },
-      }).success,
-    ).to.be.false;
-  });
-
-  it('rejects a router assigned to multiple policies on one chain', () => {
-    const router = ethers.Wallet.createRandom().address;
-    expect(
-      LayerZeroRoutesSchema.safeParse({
-        policyA: { chainA: chain(101, router) },
-        policyB: { chainA: chain(201, router) },
-      }).success,
-    ).to.be.false;
+  it('rejects a destination router that is not a CCIP-read ISM', async () => {
+    const connect = connector();
+    let error: unknown;
+    try {
+      await resolveLayerZeroRoutes(
+        originDomain,
+        destinationDomain,
+        originRouter,
+        (router, domain) =>
+          domain === destinationDomain
+            ? reader({
+                domain,
+                eid: destinationEid,
+                peer: originRouter,
+                peerEid: originEid,
+                moduleType: ModuleType.NULL,
+              })
+            : connect(router, domain),
+      );
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error)
+      .to.be.an('error')
+      .with.property('message')
+      .that.includes('not a CCIP-read ISM');
   });
 });
 

--- a/typescript/ccip-server/tests/services/moduleRegistry.test.ts
+++ b/typescript/ccip-server/tests/services/moduleRegistry.test.ts
@@ -7,6 +7,7 @@ describe('module registry', () => {
     expect(Object.keys(moduleRegistry)).to.deep.equal([
       'callCommitments',
       'cctp',
+      'layerzero',
       'opstack',
       'wormhole',
     ]);
@@ -16,6 +17,7 @@ describe('module registry', () => {
   for (const [name, requiredSetting] of [
     ['callCommitments', 'SERVER_BASE_URL'],
     ['cctp', 'HYPERLANE_EXPLORER_URL'],
+    ['layerzero', 'HYPERLANE_EXPLORER_URL'],
     ['opstack', 'HYPERLANE_EXPLORER_API'],
     ['wormhole', 'HYPERLANE_EXPLORER_URL'],
   ] as const) {

--- a/typescript/cli/src/deploy/warp.ts
+++ b/typescript/cli/src/deploy/warp.ts
@@ -38,6 +38,8 @@ import {
   type CompositeIsmNodeConfig,
   CompositeIsmNodeType,
   ContractVerifier,
+  EvmLayerZeroV2HookIsmModule,
+  EvmLayerZeroV2HookIsmReader,
   EvmWormholeHookIsmModule,
   EvmWormholeHookIsmReader,
   EvmWarpModule,
@@ -69,10 +71,11 @@ import {
   altVmChainLookup,
   assertDelayedFlowRoutePreconditions,
   buildDelayedFlowEnrollmentTxs,
-  deriveDelayedFlowEnrollmentTargets,
+  buildLayerZeroV2MeshConfig,
   buildWormholeMeshConfig,
   collectHookAddresses,
   collectIsmAddresses,
+  deriveDelayedFlowEnrollmentTargets,
   enrollCrossChainRouters,
   executeWarpDeploy,
   executeWarpRouteExtensionDeploy,
@@ -82,10 +85,12 @@ import {
   getSubmitterBuilder,
   getTokenConnectionId,
   isCrossCollateralTokenConfig,
+  materializeLayerZeroV2WarpConfig,
   materializeWormholeWarpConfig,
   normalizeScale,
-  planWarpRouteHybrids,
+  pairLayerZeroV2Configs,
   pairWormholeConfigs,
+  planWarpRouteHybrids,
   splitWarpCoreAndExtendedConfigs,
   tokenTypeToStandard,
 } from '@hyperlane-xyz/sdk';
@@ -238,9 +243,19 @@ export async function runWarpRouteDeploy({
 
   const initialBalances = await getBalances(context, deploymentChains);
 
-  const effectiveWarpDeployConfig = await materializeNewWormholeMesh(
+  const wormholeWarpDeployConfig = await materializeNewWormholeMesh(
     multiProvider,
     warpDeployConfig,
+  );
+  const effectiveWarpDeployConfig = await materializeNewLayerZeroV2Mesh(
+    multiProvider,
+    wormholeWarpDeployConfig,
+    new ContractVerifier(
+      multiProvider,
+      apiKeys,
+      coreBuildArtifact,
+      ExplorerLicenseType.MIT,
+    ),
   );
   deploymentParams.warpDeployConfig = effectiveWarpDeployConfig;
 
@@ -360,6 +375,26 @@ async function materializeNewWormholeMesh(
     mesh,
   );
   return materializeWormholeWarpConfig(warpDeployConfig, addresses);
+}
+
+async function materializeNewLayerZeroV2Mesh(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  contractVerifier: ContractVerifier,
+): Promise<WarpRouteDeployConfigMailboxRequired> {
+  const pairs = pairLayerZeroV2Configs(warpDeployConfig);
+  if (Object.keys(pairs).length === 0) return warpDeployConfig;
+
+  logBlue(
+    'Deploying and configuring combined LayerZero V2 hook/ISM routers...',
+  );
+  const mesh = buildLayerZeroV2MeshConfig(warpDeployConfig, pairs);
+  const addresses = await EvmLayerZeroV2HookIsmModule.deployMesh(
+    multiProvider,
+    mesh,
+    contractVerifier,
+  );
+  return materializeLayerZeroV2WarpConfig(warpDeployConfig, addresses);
 }
 
 async function runDeployPlanStep({ context, warpDeployConfig }: DeployParams) {
@@ -591,15 +626,26 @@ export async function runWarpRouteApply(
     warpDeployConfig,
     warpCoreConfig,
   );
+  const layerZero = await materializeLayerZeroV2MeshForApply(
+    multiProvider,
+    wormhole.config,
+    warpCoreConfig,
+    new ContractVerifier(
+      multiProvider,
+      apiKeys,
+      coreBuildArtifact,
+      ExplorerLicenseType.MIT,
+    ),
+  );
   const effectiveParams: WarpApplyParams = {
     ...params,
-    warpDeployConfig: wormhole.config,
+    warpDeployConfig: layerZero.config,
   };
 
   // temporarily configure deployer as owner so that warp update after extension
   // can leverage JSON RPC submitter on new chains
   const intermediateOwnerConfig = await promiseObjAll(
-    objMap(wormhole.config, async (chain, config) => {
+    objMap(layerZero.config, async (chain, config) => {
       const protocolType = multiProvider.getProtocol(chain);
       if (isEVMLike(protocolType)) {
         return withIntermediateWarpOwner(
@@ -631,13 +677,18 @@ export async function runWarpRouteApply(
   } = await updateExistingWarpRoute(
     effectiveParams,
     apiKeys,
-    wormhole.config,
+    layerZero.config,
     updatedWarpCoreConfig,
   );
 
-  for (const [chain, transactions] of Object.entries(wormhole.transactions)) {
+  const reconciliationChains = new Set([
+    ...Object.keys(wormhole.transactions),
+    ...Object.keys(layerZero.transactions),
+  ]);
+  for (const chain of reconciliationChains) {
     updateTransactions[chain] = [
-      ...transactions,
+      ...(wormhole.transactions[chain] ?? []),
+      ...(layerZero.transactions[chain] ?? []),
       ...(updateTransactions[chain] ?? []),
     ];
   }
@@ -721,6 +772,75 @@ async function materializeWormholeMeshForApply(
   );
   return {
     config: materializeWormholeWarpConfig(warpDeployConfig, result.addresses),
+    transactions: result.transactions,
+  };
+}
+
+async function materializeLayerZeroV2MeshForApply(
+  multiProvider: MultiProvider,
+  warpDeployConfig: WarpRouteDeployConfigMailboxRequired,
+  warpCoreConfig: WarpCoreConfig,
+  contractVerifier: ContractVerifier,
+): Promise<{
+  config: WarpRouteDeployConfigMailboxRequired;
+  transactions: ChainMap<TypedAnnotatedTransaction[]>;
+}> {
+  const pairs = pairLayerZeroV2Configs(warpDeployConfig);
+  if (Object.keys(pairs).length === 0) {
+    return { config: warpDeployConfig, transactions: {} };
+  }
+
+  const warpRouters = getRouterAddressesFromWarpCoreConfig(warpCoreConfig);
+  const existing: ChainMap<Address> = {};
+  for (const chain of Object.keys(pairs)) {
+    const warpRouter = warpRouters[chain];
+    if (!warpRouter) continue;
+    const actual = await new EvmWarpRouteReader(
+      multiProvider,
+      chain,
+    ).deriveWarpRouteConfig(warpRouter);
+    const hookAddresses = new Set(
+      collectHookAddresses(actual.hook).map((address) => address.toLowerCase()),
+    );
+    const candidates = Array.from(
+      new Set(
+        collectIsmAddresses(actual.interchainSecurityModule).filter((address) =>
+          hookAddresses.has(address.toLowerCase()),
+        ),
+      ),
+    );
+    const matches: Address[] = [];
+    for (const candidate of candidates) {
+      try {
+        await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveLayerZeroConfig(candidate);
+        matches.push(candidate);
+      } catch {
+        // A shared address belonging to another combined hook/ISM.
+      }
+    }
+    assert(
+      matches.length <= 1,
+      `${chain} has multiple deployed LayerZero V2 hook/ISM routers`,
+    );
+    if (matches[0]) existing[chain] = matches[0];
+  }
+
+  logBlue('Reconciling combined LayerZero V2 hook/ISM routers...');
+  const mesh = buildLayerZeroV2MeshConfig(warpDeployConfig, pairs);
+  const result = await EvmLayerZeroV2HookIsmModule.reconcileMesh(
+    multiProvider,
+    mesh,
+    existing,
+    contractVerifier,
+  );
+  return {
+    config: materializeLayerZeroV2WarpConfig(
+      warpDeployConfig,
+      result.addresses,
+    ),
     transactions: result.transactions,
   };
 }

--- a/typescript/cli/src/tests/ethereum/layerzero/layerzero-hook-ism.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/layerzero/layerzero-hook-ism.e2e-test.ts
@@ -187,8 +187,11 @@ describe('LayerZero V2 combined hook/ISM message E2E', function () {
                 sendLibrary: fixtures[chain].library,
                 receiveLibrary: fixtures[chain].library,
                 receiveLibraryGracePeriod: 0,
-                sendConfig: [],
-                receiveConfig: [],
+                sendConfig: {
+                  executor: { type: 'default' },
+                  uln: { type: 'default' },
+                },
+                receiveConfig: { uln: { type: 'default' } },
                 ...(variant === LayerZeroV2Variant.Callback
                   ? { callbackGasLimit: 250_000n }
                   : {}),

--- a/typescript/cli/src/tests/ethereum/layerzero/layerzero-hook-ism.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/layerzero/layerzero-hook-ism.e2e-test.ts
@@ -1,0 +1,437 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import type { ProcessPromise } from 'zx';
+import { $ } from 'zx';
+
+import {
+  ILayerZeroPacketService__factory,
+  Mailbox__factory,
+  MockLayerZeroEndpointV2__factory,
+  MockLayerZeroReceiveUln__factory,
+  TestRecipient__factory,
+} from '@hyperlane-xyz/core';
+import type { ChainAddresses } from '@hyperlane-xyz/registry';
+import {
+  EvmLayerZeroV2HookIsmModule,
+  EvmLayerZeroV2HookIsmReader,
+  LayerZeroV2Variant,
+} from '@hyperlane-xyz/sdk';
+import type {
+  ChainMap,
+  ChainName,
+  LayerZeroV2MeshConfig,
+  MultiProvider,
+} from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+import type { Address } from '@hyperlane-xyz/utils';
+
+import { getContext } from '../../../context/context.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { hyperlaneSendMessage, hyperlaneStatus } from '../commands/helpers.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+} from '../consts.js';
+
+const CHAINS: ChainName[] = [CHAIN_NAME_2, CHAIN_NAME_3];
+const DIRECTIONS: ReadonlyArray<readonly [ChainName, ChainName]> = [
+  [CHAIN_NAME_2, CHAIN_NAME_3],
+  [CHAIN_NAME_3, CHAIN_NAME_2],
+];
+const EIDS: ChainMap<number> = {
+  [CHAIN_NAME_2]: 40_201,
+  [CHAIN_NAME_3]: 40_202,
+};
+const SERVICE_PORT = 3_802;
+
+interface LayerZeroFixture {
+  endpoint: Address;
+  library: Address;
+}
+
+interface ParsedPacket {
+  nonce: bigint;
+  sourceEid: number;
+  sender: string;
+  guid: string;
+  payload: string;
+}
+
+interface LocalService {
+  close(): Promise<void>;
+}
+
+function extract(output: string, label: string): string {
+  const match = output.match(new RegExp(`${label}: (0x[a-fA-F0-9]{64})`));
+  assert(match, `Could not extract ${label}`);
+  return match[1];
+}
+
+function parsePacket(packet: string): ParsedPacket {
+  const bytes = ethers.utils.arrayify(packet);
+  assert(
+    bytes.length === 241,
+    `Unexpected LayerZero packet length ${bytes.length}`,
+  );
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return {
+    nonce: view.getBigUint64(1),
+    sourceEid: view.getUint32(9),
+    sender: ethers.utils.hexlify(bytes.subarray(13, 45)),
+    guid: ethers.utils.hexlify(bytes.subarray(81, 113)),
+    payload: ethers.utils.hexlify(bytes.subarray(113)),
+  };
+}
+
+async function startLayerZeroService(
+  routes: Record<
+    string,
+    {
+      mailbox: Address;
+      endpoint: Address;
+      layerZeroDomainId: number;
+      router: Address;
+    }
+  >,
+): Promise<LocalService> {
+  const process: ProcessPromise = $({
+    env: {
+      ...globalThis.process.env,
+      ENABLED_MODULES: 'layerzero',
+      SERVER_PORT: String(SERVICE_PORT),
+      REGISTRY_URI: REGISTRY_PATH,
+      HYPERLANE_EXPLORER_URL: 'http://127.0.0.1:1',
+      LAYERZERO_ROUTES: JSON.stringify({ policyA: routes }),
+    },
+    nothrow: true,
+  })`pnpm --filter @hyperlane-xyz/ccip-server run start`;
+
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${SERVICE_PORT}/health`);
+      if (response.ok) break;
+    } catch {
+      // Server is still starting.
+    }
+    assert(Date.now() < deadline, 'LayerZero packet service did not start');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return { close: async () => process.kill() };
+}
+
+describe('LayerZero V2 combined hook/ISM message E2E', function () {
+  this.timeout(10 * DEFAULT_E2E_TEST_TIMEOUT);
+
+  let addresses: ChainMap<ChainAddresses>;
+  let fixtures: ChainMap<LayerZeroFixture>;
+  let multiProvider: MultiProvider;
+
+  before(async () => {
+    const cores = await Promise.all(
+      CHAINS.map((chain) =>
+        deployOrUseExistingCore(chain, CORE_CONFIG_PATH, ANVIL_KEY),
+      ),
+    );
+    addresses = Object.fromEntries(
+      CHAINS.map((chain, index) => [chain, cores[index]]),
+    );
+    ({ multiProvider } = await getContext({
+      registryUris: [REGISTRY_PATH],
+      key: ANVIL_KEY,
+    }));
+    fixtures = {};
+    for (const chain of CHAINS) {
+      multiProvider.setSigner(
+        chain,
+        new ethers.Wallet(ANVIL_KEY, multiProvider.getProvider(chain)),
+      );
+      const endpoint = await multiProvider.handleDeploy(
+        chain,
+        new MockLayerZeroEndpointV2__factory(),
+        [EIDS[chain]],
+      );
+      const library = await multiProvider.handleDeploy(
+        chain,
+        new MockLayerZeroReceiveUln__factory(),
+        [endpoint.address],
+      );
+      await multiProvider.handleTx(
+        chain,
+        endpoint
+          .connect(multiProvider.getSigner(chain))
+          .registerMockLibrary(library.address),
+      );
+      fixtures[chain] = {
+        endpoint: endpoint.address,
+        library: library.address,
+      };
+    }
+  });
+
+  function mesh(
+    variant: LayerZeroV2Variant,
+    urls?: string[],
+  ): LayerZeroV2MeshConfig {
+    return Object.fromEntries(
+      CHAINS.map((chain) => {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        return [
+          chain,
+          {
+            type: variant,
+            owner: ANVIL_DEPLOYER_ADDRESS,
+            mailbox: addresses[chain].mailbox,
+            endpoint: fixtures[chain].endpoint,
+            layerZeroDomainId: EIDS[chain],
+            ...(urls ? { urls } : {}),
+            remoteRouters: {
+              [remote]: {
+                router: ethers.constants.AddressZero,
+                layerZeroDomainId: EIDS[remote],
+                sendLibrary: fixtures[chain].library,
+                receiveLibrary: fixtures[chain].library,
+                receiveLibraryGracePeriod: 0,
+                sendConfig: [],
+                receiveConfig: [],
+                ...(variant === LayerZeroV2Variant.Callback
+                  ? { callbackGasLimit: 250_000n }
+                  : {}),
+              },
+            },
+          },
+        ];
+      }),
+    );
+  }
+
+  async function install(routers: ChainMap<Address>): Promise<void> {
+    for (const chain of CHAINS) {
+      const signer = multiProvider.getSigner(chain);
+      await multiProvider.handleTx(
+        chain,
+        await Mailbox__factory.connect(
+          addresses[chain].mailbox,
+          signer,
+        ).setDefaultHook(routers[chain]),
+      );
+      await multiProvider.handleTx(
+        chain,
+        await TestRecipient__factory.connect(
+          addresses[chain].testRecipient,
+          signer,
+        ).setInterchainSecurityModule(routers[chain]),
+      );
+    }
+  }
+
+  async function send(origin: ChainName, destination: ChainName) {
+    const result = await hyperlaneSendMessage(origin, destination, {
+      quick: true,
+    });
+    const dispatchTx = extract(result.stdout, 'Dispatch TX');
+    const messageId = extract(result.stdout, 'Message ID');
+    const receipt = await multiProvider
+      .getProvider(origin)
+      .getTransactionReceipt(dispatchTx);
+    const mailboxInterface = Mailbox__factory.createInterface();
+    const dispatched = receipt.logs.flatMap((log) => {
+      if (log.address.toLowerCase() !== addresses[origin].mailbox.toLowerCase())
+        return [];
+      try {
+        const parsed = mailboxInterface.parseLog(log);
+        return parsed.name === 'Dispatch'
+          ? [parsed.args.message as string]
+          : [];
+      } catch {
+        return [];
+      }
+    });
+    assert(dispatched.length === 1, 'Expected one Mailbox Dispatch event');
+    const endpoint = MockLayerZeroEndpointV2__factory.connect(
+      fixtures[origin].endpoint,
+      multiProvider.getProvider(origin),
+    );
+    const packet = await endpoint.lastPacket();
+    expect(packet.toLowerCase()).to.include(messageId.slice(2).toLowerCase());
+    return {
+      dispatchTx,
+      messageId,
+      message: dispatched[0],
+      packet: parsePacket(packet),
+    };
+  }
+
+  async function lookupPacket(
+    router: Address,
+    dispatchTx: string,
+    message: string,
+  ): Promise<Response> {
+    return fetch(
+      `http://127.0.0.1:${SERVICE_PORT}/layerzero/getLayerZeroPacket`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sender: router,
+          signature: '0x',
+          origin_tx_hash: dispatchTx,
+          data: ILayerZeroPacketService__factory.createInterface().encodeFunctionData(
+            'getLayerZeroPacket',
+            [message],
+          ),
+        }),
+      },
+    );
+  }
+
+  async function assertDelivered(origin: ChainName, messageId: string) {
+    const status = await hyperlaneStatus({ origin, messageId, quick: true });
+    expect(status.stdout).to.include('delivered');
+  }
+
+  describe('callback variant', () => {
+    let routers: ChainMap<Address>;
+
+    before(async () => {
+      routers = await EvmLayerZeroV2HookIsmModule.deployMesh(
+        multiProvider,
+        mesh(LayerZeroV2Variant.Callback),
+      );
+      await install(routers);
+    });
+
+    for (const [origin, destination] of DIRECTIONS) {
+      it(`gates ${origin} -> ${destination} until Endpoint callback`, async () => {
+        const { dispatchTx, messageId, packet } = await send(
+          origin,
+          destination,
+        );
+        const pending = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(pending.exitCode).not.to.equal(0);
+
+        const destinationEndpoint = MockLayerZeroEndpointV2__factory.connect(
+          fixtures[destination].endpoint,
+          multiProvider.getSigner(destination),
+        );
+        await multiProvider.handleTx(
+          destination,
+          await destinationEndpoint.mockDeliver(
+            routers[destination],
+            {
+              srcEid: packet.sourceEid,
+              sender: packet.sender,
+              nonce: packet.nonce,
+            },
+            packet.guid,
+            packet.payload,
+          ),
+        );
+        const relayed = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(
+          relayed.exitCode,
+          `self-relay failed:\n${relayed.stdout}\n${relayed.stderr}`,
+        ).to.equal(0);
+        await assertDelivered(origin, messageId);
+      });
+    }
+  });
+
+  describe('CCIP-read variant', () => {
+    let routers: ChainMap<Address>;
+    let service: LocalService;
+    const serviceUrl = `http://127.0.0.1:${SERVICE_PORT}/layerzero/getLayerZeroPacket`;
+
+    before(async () => {
+      routers = await EvmLayerZeroV2HookIsmModule.deployMesh(
+        multiProvider,
+        mesh(LayerZeroV2Variant.CcipRead, [serviceUrl]),
+      );
+      await install(routers);
+      service = await startLayerZeroService(
+        Object.fromEntries(
+          CHAINS.map((chain) => [
+            chain,
+            {
+              mailbox: addresses[chain].mailbox,
+              endpoint: fixtures[chain].endpoint,
+              layerZeroDomainId: EIDS[chain],
+              router: routers[chain],
+            },
+          ]),
+        ),
+      );
+    });
+
+    after(async () => service?.close());
+
+    for (const [origin, destination] of DIRECTIONS) {
+      it(`relays ${origin} -> ${destination} through packet lookup`, async () => {
+        const library = MockLayerZeroReceiveUln__factory.connect(
+          fixtures[destination].library,
+          multiProvider.getSigner(destination),
+        );
+        await multiProvider.handleTx(
+          destination,
+          await library.setReady(false),
+        );
+        const { dispatchTx, messageId, message } = await send(
+          origin,
+          destination,
+        );
+        const pending = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(pending.exitCode).not.to.equal(0);
+
+        await multiProvider.handleTx(destination, await library.setReady(true));
+        expect(await library.ready()).to.be.true;
+        const lookup = await lookupPacket(
+          routers[destination],
+          dispatchTx,
+          message,
+        );
+        const lookupBody = await lookup.text();
+        expect(lookup.ok, lookupBody).to.be.true;
+        expect(JSON.parse(lookupBody).data).to.match(/^0x[0-9a-f]+$/i);
+        const relayed = await hyperlaneStatus({
+          origin,
+          dispatchTx,
+          relay: true,
+          key: ANVIL_KEY,
+        }).nothrow();
+        expect(
+          relayed.exitCode,
+          `self-relay failed:\n${relayed.stdout}\n${relayed.stderr}`,
+        ).to.equal(0);
+        await assertDelivered(origin, messageId);
+
+        const derived = await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          destination,
+        ).deriveLayerZeroConfig(routers[destination]);
+        expect(derived.type).to.equal(LayerZeroV2Variant.CcipRead);
+        expect(derived.urls).to.deep.equal([serviceUrl]);
+      });
+    }
+  });
+});

--- a/typescript/cli/src/tests/ethereum/layerzero/layerzero-hook-ism.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/layerzero/layerzero-hook-ism.e2e-test.ts
@@ -88,17 +88,7 @@ function parsePacket(packet: string): ParsedPacket {
   };
 }
 
-async function startLayerZeroService(
-  routes: Record<
-    string,
-    {
-      mailbox: Address;
-      endpoint: Address;
-      layerZeroDomainId: number;
-      router: Address;
-    }
-  >,
-): Promise<LocalService> {
+async function startLayerZeroService(): Promise<LocalService> {
   const process: ProcessPromise = $({
     env: {
       ...globalThis.process.env,
@@ -106,7 +96,6 @@ async function startLayerZeroService(
       SERVER_PORT: String(SERVICE_PORT),
       REGISTRY_URI: REGISTRY_PATH,
       HYPERLANE_EXPLORER_URL: 'http://127.0.0.1:1',
-      LAYERZERO_ROUTES: JSON.stringify({ policyA: routes }),
     },
     nothrow: true,
   })`pnpm --filter @hyperlane-xyz/ccip-server run start`;
@@ -364,19 +353,7 @@ describe('LayerZero V2 combined hook/ISM message E2E', function () {
         mesh(LayerZeroV2Variant.CcipRead, [serviceUrl]),
       );
       await install(routers);
-      service = await startLayerZeroService(
-        Object.fromEntries(
-          CHAINS.map((chain) => [
-            chain,
-            {
-              mailbox: addresses[chain].mailbox,
-              endpoint: fixtures[chain].endpoint,
-              layerZeroDomainId: EIDS[chain],
-              router: routers[chain],
-            },
-          ]),
-        ),
-      );
+      service = await startLayerZeroService();
     });
 
     after(async () => service?.close());

--- a/typescript/cli/src/tests/ethereum/layerzero/layerzero-warp.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/layerzero/layerzero-warp.e2e-test.ts
@@ -12,6 +12,7 @@ import {
   findLayerZeroV2Hooks,
   HookType,
   IsmType,
+  LayerZeroV2ConfigMode,
   LayerZeroV2Variant,
   TokenType,
 } from '@hyperlane-xyz/sdk';
@@ -50,7 +51,8 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
   };
   let mailboxes: Record<string, Address>;
   let endpoints: Record<string, Address>;
-  let libraries: Record<string, Address>;
+  let sendLibraries: Record<string, Address>;
+  let receiveLibraries: Record<string, Address>;
 
   before(async () => {
     const cores = await Promise.all(
@@ -66,7 +68,8 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
       key: ANVIL_KEY,
     });
     endpoints = {};
-    libraries = {};
+    sendLibraries = {};
+    receiveLibraries = {};
     for (const chain of chains) {
       multiProvider.setSigner(
         chain,
@@ -77,7 +80,12 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
         new MockLayerZeroEndpointV2__factory(),
         [eids[chain]],
       );
-      const library = await multiProvider.handleDeploy(
+      const sendLibrary = await multiProvider.handleDeploy(
+        chain,
+        new MockLayerZeroReceiveUln__factory(),
+        [endpoint.address],
+      );
+      const receiveLibrary = await multiProvider.handleDeploy(
         chain,
         new MockLayerZeroReceiveUln__factory(),
         [endpoint.address],
@@ -86,10 +94,17 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
         chain,
         endpoint
           .connect(multiProvider.getSigner(chain))
-          .registerMockLibrary(library.address),
+          .registerMockLibrary(sendLibrary.address),
+      );
+      await multiProvider.handleTx(
+        chain,
+        endpoint
+          .connect(multiProvider.getSigner(chain))
+          .registerMockLibrary(receiveLibrary.address),
       );
       endpoints[chain] = endpoint.address;
-      libraries[chain] = library.address;
+      sendLibraries[chain] = sendLibrary.address;
+      receiveLibraries[chain] = receiveLibrary.address;
     }
   });
 
@@ -118,11 +133,14 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
           pathways: {
             [remote]: {
               layerZeroDomainId: eids[remote],
-              sendLibrary: libraries[chain],
-              receiveLibrary: libraries[chain],
+              sendLibrary: sendLibraries[chain],
+              receiveLibrary: receiveLibraries[chain],
               receiveLibraryGracePeriod: 0,
-              sendConfig: [],
-              receiveConfig: [],
+              sendConfig: {
+                executor: { type: 'default' },
+                uln: { type: 'default' },
+              },
+              receiveConfig: { uln: { type: 'default' } },
             },
           },
           ...(variant === LayerZeroV2Variant.CcipRead
@@ -149,6 +167,12 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
         ];
       }),
     ) as WarpRouteDeployConfigMailboxRequired;
+  }
+
+  function orderedDvns(chain: string): Address[] {
+    return [sendLibraries[chain], receiveLibraries[chain]].toSorted((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase()),
+    );
   }
 
   for (const [variant, symbol] of [
@@ -203,6 +227,17 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
         expect(derived.remoteRouters[remote].router.toLowerCase()).to.equal(
           combined[remote].toLowerCase(),
         );
+        expect(derived.remoteRouters[remote].sendConfig).to.deep.equal({
+          executor: { type: LayerZeroV2ConfigMode.Default },
+          uln: { type: LayerZeroV2ConfigMode.Default },
+        });
+        expect(derived.remoteRouters[remote].receiveConfig).to.deep.equal({
+          uln: { type: LayerZeroV2ConfigMode.Default },
+        });
+        expect(
+          derived.remoteRouters[remote].effectiveSendConfig?.executor
+            .maxMessageSize,
+        ).to.equal(10_000);
       }
       const check = await hyperlaneWarpCheck(routeId);
       expect(check.exitCode).to.equal(0);
@@ -210,6 +245,40 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
       const updatedConfig = configFor(variant, symbol);
       for (const chain of chains) {
         const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const requiredDVNs = orderedDvns(chain);
+        const ism = updatedConfig[chain].interchainSecurityModule;
+        assert(
+          typeof ism !== 'string' &&
+            ism &&
+            (ism.type === IsmType.LAYER_ZERO_V2_CALLBACK ||
+              ism.type === IsmType.LAYER_ZERO_V2_CCIP_READ),
+          `Missing LayerZero ISM on ${chain}`,
+        );
+        const pathway = ism.pathways[remote];
+        assert(pathway, `Missing ${chain} -> ${remote} pathway`);
+        pathway.sendConfig = {
+          executor: {
+            type: LayerZeroV2ConfigMode.Override,
+            maxMessageSize: 20_000,
+            executor: sendLibraries[chain],
+          },
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            confirmations: 15n,
+            requiredDVNs,
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+          },
+        };
+        pathway.receiveConfig = {
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            confirmations: 20n,
+            requiredDVNs,
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+          },
+        };
         if (variant === LayerZeroV2Variant.Callback) {
           const hook = findLayerZeroV2Hooks(updatedConfig[chain].hook)[0];
           assert(
@@ -240,6 +309,7 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
 
       for (const chain of chains) {
         const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const requiredDVNs = orderedDvns(chain);
         const derived = await new EvmLayerZeroV2HookIsmReader(
           multiProvider,
           chain,
@@ -254,9 +324,158 @@ describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
             'http://127.0.0.1:3001/layerzero/getLayerZeroPacket',
           ]);
         }
+        expect(derived.remoteRouters[remote].sendConfig).to.deep.equal({
+          executor: {
+            type: LayerZeroV2ConfigMode.Override,
+            maxMessageSize: 20_000,
+            executor: sendLibraries[chain],
+          },
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            confirmations: 15n,
+            requiredDVNs,
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+          },
+        });
+        expect(derived.remoteRouters[remote].receiveConfig).to.deep.equal({
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            confirmations: 20n,
+            requiredDVNs,
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+          },
+        });
+        expect(derived.remoteRouters[remote].effectiveSendConfig).to.deep.equal(
+          {
+            executor: {
+              maxMessageSize: 20_000,
+              executor: sendLibraries[chain],
+            },
+            uln: {
+              confirmations: 15n,
+              requiredDVNs,
+              optionalDVNs: [],
+              optionalDVNThreshold: 0,
+            },
+          },
+        );
+        expect(
+          derived.remoteRouters[remote].effectiveReceiveConfig,
+        ).to.deep.equal({
+          uln: {
+            confirmations: 20n,
+            requiredDVNs,
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+          },
+        });
       }
       const postApplyCheck = await hyperlaneWarpCheck(routeId);
       expect(postApplyCheck.exitCode).to.equal(0);
+
+      for (const chain of chains) {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const ism = updatedConfig[chain].interchainSecurityModule;
+        assert(
+          typeof ism !== 'string' &&
+            ism &&
+            (ism.type === IsmType.LAYER_ZERO_V2_CALLBACK ||
+              ism.type === IsmType.LAYER_ZERO_V2_CCIP_READ),
+          `Missing LayerZero ISM on ${chain}`,
+        );
+        const pathway = ism.pathways[remote];
+        assert(pathway, `Missing ${chain} -> ${remote} pathway`);
+        assert(
+          pathway.sendConfig.uln.type === LayerZeroV2ConfigMode.Override &&
+            pathway.receiveConfig.uln.type === LayerZeroV2ConfigMode.Override,
+          `Missing LayerZero ULN overrides on ${chain}`,
+        );
+        const unorderedDvns = orderedDvns(chain).toReversed();
+        pathway.sendConfig.uln.requiredDVNs = unorderedDvns;
+        pathway.receiveConfig.uln.requiredDVNs = unorderedDvns;
+      }
+      writeYamlOrJson(registryDeployPath, updatedConfig);
+
+      const unorderedCheck = await hyperlaneWarpCheck(routeId);
+      expect(unorderedCheck.exitCode).to.equal(0);
+      const unorderedApply = await hyperlaneWarpApply(routeId);
+      expect(unorderedApply.exitCode).to.equal(0);
+      expect(unorderedApply.stdout).to.include(
+        'Warp config is the same as target. No updates needed.',
+      );
+
+      for (const chain of chains) {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const ism = updatedConfig[chain].interchainSecurityModule;
+        assert(
+          typeof ism !== 'string' &&
+            ism &&
+            (ism.type === IsmType.LAYER_ZERO_V2_CALLBACK ||
+              ism.type === IsmType.LAYER_ZERO_V2_CCIP_READ),
+          `Missing LayerZero ISM on ${chain}`,
+        );
+        const pathway = ism.pathways[remote];
+        assert(pathway, `Missing ${chain} -> ${remote} pathway`);
+        pathway.sendConfig = {
+          executor: { type: LayerZeroV2ConfigMode.Default },
+          uln: { type: LayerZeroV2ConfigMode.Default },
+        };
+        pathway.receiveConfig = {
+          uln: { type: LayerZeroV2ConfigMode.Default },
+        };
+      }
+      writeYamlOrJson(registryDeployPath, updatedConfig);
+
+      const resetApply = await hyperlaneWarpApply(routeId);
+      expect(resetApply.exitCode).to.equal(0);
+      for (const chain of chains) {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const derived = await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveLayerZeroConfig(combined[chain]);
+        expect(derived.remoteRouters[remote].sendConfig).to.deep.equal({
+          executor: { type: LayerZeroV2ConfigMode.Default },
+          uln: { type: LayerZeroV2ConfigMode.Default },
+        });
+        expect(derived.remoteRouters[remote].receiveConfig).to.deep.equal({
+          uln: { type: LayerZeroV2ConfigMode.Default },
+        });
+        expect(derived.remoteRouters[remote].effectiveSendConfig).to.deep.equal(
+          {
+            executor: {
+              maxMessageSize: 10_000,
+              executor: sendLibraries[chain],
+            },
+            uln: {
+              confirmations: 12n,
+              requiredDVNs: [sendLibraries[chain]],
+              optionalDVNs: [],
+              optionalDVNThreshold: 0,
+            },
+          },
+        );
+        expect(
+          derived.remoteRouters[remote].effectiveReceiveConfig,
+        ).to.deep.equal({
+          uln: {
+            confirmations: 12n,
+            requiredDVNs: [receiveLibraries[chain]],
+            optionalDVNs: [],
+            optionalDVNThreshold: 0,
+          },
+        });
+      }
+      const postResetCheck = await hyperlaneWarpCheck(routeId);
+      expect(postResetCheck.exitCode).to.equal(0);
+
+      const idempotentApply = await hyperlaneWarpApply(routeId);
+      expect(idempotentApply.exitCode).to.equal(0);
+      expect(idempotentApply.stdout).to.include(
+        'Warp config is the same as target. No updates needed.',
+      );
     });
   }
 });

--- a/typescript/cli/src/tests/ethereum/layerzero/layerzero-warp.e2e-test.ts
+++ b/typescript/cli/src/tests/ethereum/layerzero/layerzero-warp.e2e-test.ts
@@ -1,0 +1,262 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import {
+  MailboxClient__factory,
+  MockLayerZeroEndpointV2__factory,
+  MockLayerZeroReceiveUln__factory,
+  StaticAggregationHook__factory,
+} from '@hyperlane-xyz/core';
+import {
+  EvmLayerZeroV2HookIsmReader,
+  findLayerZeroV2Hooks,
+  HookType,
+  IsmType,
+  LayerZeroV2Variant,
+  TokenType,
+} from '@hyperlane-xyz/sdk';
+import type { WarpRouteDeployConfigMailboxRequired } from '@hyperlane-xyz/sdk';
+import { assert } from '@hyperlane-xyz/utils';
+import type { Address } from '@hyperlane-xyz/utils';
+
+import { getContext } from '../../../context/context.js';
+import { writeYamlOrJson } from '../../../utils/files.js';
+import { deployOrUseExistingCore } from '../commands/core.js';
+import { getDeployedWarpAddress } from '../commands/helpers.js';
+import {
+  hyperlaneWarpApply,
+  hyperlaneWarpCheck,
+  hyperlaneWarpDeploy,
+} from '../commands/warp.js';
+import {
+  ANVIL_DEPLOYER_ADDRESS,
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  REGISTRY_PATH,
+  TEMP_PATH,
+  getCombinedWarpRoutePath,
+  getWarpRouteId,
+} from '../consts.js';
+
+describe('warp deploy with LayerZero V2 combined hook/ISM', function () {
+  this.timeout(10 * DEFAULT_E2E_TEST_TIMEOUT);
+  const chains = [CHAIN_NAME_2, CHAIN_NAME_3];
+  const eids: Record<string, number> = {
+    [CHAIN_NAME_2]: 40_101,
+    [CHAIN_NAME_3]: 40_102,
+  };
+  let mailboxes: Record<string, Address>;
+  let endpoints: Record<string, Address>;
+  let libraries: Record<string, Address>;
+
+  before(async () => {
+    const cores = await Promise.all(
+      chains.map((chain) =>
+        deployOrUseExistingCore(chain, CORE_CONFIG_PATH, ANVIL_KEY),
+      ),
+    );
+    mailboxes = Object.fromEntries(
+      chains.map((chain, index) => [chain, cores[index].mailbox]),
+    );
+    const { multiProvider } = await getContext({
+      registryUris: [REGISTRY_PATH],
+      key: ANVIL_KEY,
+    });
+    endpoints = {};
+    libraries = {};
+    for (const chain of chains) {
+      multiProvider.setSigner(
+        chain,
+        new ethers.Wallet(ANVIL_KEY, multiProvider.getProvider(chain)),
+      );
+      const endpoint = await multiProvider.handleDeploy(
+        chain,
+        new MockLayerZeroEndpointV2__factory(),
+        [eids[chain]],
+      );
+      const library = await multiProvider.handleDeploy(
+        chain,
+        new MockLayerZeroReceiveUln__factory(),
+        [endpoint.address],
+      );
+      await multiProvider.handleTx(
+        chain,
+        endpoint
+          .connect(multiProvider.getSigner(chain))
+          .registerMockLibrary(library.address),
+      );
+      endpoints[chain] = endpoint.address;
+      libraries[chain] = library.address;
+    }
+  });
+
+  function configFor(
+    variant: LayerZeroV2Variant,
+    symbol: string,
+  ): WarpRouteDeployConfigMailboxRequired {
+    return Object.fromEntries(
+      chains.map((chain, index) => {
+        const remote = chains[index === 0 ? 1 : 0];
+        const hookLeaf =
+          variant === LayerZeroV2Variant.Callback
+            ? {
+                type: HookType.LAYER_ZERO_V2_CALLBACK,
+                callbackGasLimits: { [remote]: 250_000n },
+              }
+            : { type: HookType.LAYER_ZERO_V2_CCIP_READ };
+        const ism = {
+          type:
+            variant === LayerZeroV2Variant.Callback
+              ? IsmType.LAYER_ZERO_V2_CALLBACK
+              : IsmType.LAYER_ZERO_V2_CCIP_READ,
+          owner: ANVIL_DEPLOYER_ADDRESS,
+          endpoint: endpoints[chain],
+          layerZeroDomainId: eids[chain],
+          pathways: {
+            [remote]: {
+              layerZeroDomainId: eids[remote],
+              sendLibrary: libraries[chain],
+              receiveLibrary: libraries[chain],
+              receiveLibraryGracePeriod: 0,
+              sendConfig: [],
+              receiveConfig: [],
+            },
+          },
+          ...(variant === LayerZeroV2Variant.CcipRead
+            ? {
+                urls: ['http://127.0.0.1:3000/layerzero/getLayerZeroPacket'],
+              }
+            : {}),
+        };
+        return [
+          chain,
+          {
+            type: index === 0 ? TokenType.native : TokenType.synthetic,
+            owner: ANVIL_DEPLOYER_ADDRESS,
+            mailbox: mailboxes[chain],
+            name: `${symbol} token`,
+            symbol,
+            decimals: 18,
+            hook: {
+              type: HookType.AGGREGATION,
+              hooks: [{ type: HookType.MAILBOX_DEFAULT }, hookLeaf],
+            },
+            interchainSecurityModule: ism,
+          },
+        ];
+      }),
+    ) as WarpRouteDeployConfigMailboxRequired;
+  }
+
+  for (const [variant, symbol] of [
+    [LayerZeroV2Variant.Callback, 'LZCB'],
+    [LayerZeroV2Variant.CcipRead, 'LZCR'],
+  ] as const) {
+    it(`deploys and checks the ${variant} mesh`, async () => {
+      const configPath = `${TEMP_PATH}/layerzero-${variant}-warp.yaml`;
+      const routeId = getWarpRouteId(symbol, chains);
+      const warpCorePath = getCombinedWarpRoutePath(symbol, chains);
+      writeYamlOrJson(configPath, configFor(variant, symbol));
+
+      const result = await hyperlaneWarpDeploy(configPath, routeId);
+      expect(result.exitCode).to.equal(0);
+
+      const { multiProvider } = await getContext({
+        registryUris: [REGISTRY_PATH],
+        key: ANVIL_KEY,
+      });
+      const combined: Record<string, Address> = {};
+      for (const chain of chains) {
+        const warpRouter = getDeployedWarpAddress(chain, warpCorePath);
+        const client = MailboxClient__factory.connect(
+          warpRouter,
+          multiProvider.getProvider(chain),
+        );
+        const [hook, ism] = await Promise.all([
+          client.hook(),
+          client.interchainSecurityModule(),
+        ]);
+        combined[chain] = ism;
+        const children = await StaticAggregationHook__factory.connect(
+          hook,
+          multiProvider.getProvider(chain),
+        ).hooks('0x');
+        expect(children.map((child) => child.toLowerCase())).to.include(
+          ism.toLowerCase(),
+        );
+        const derived = await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveLayerZeroConfig(ism);
+        expect(derived.type).to.equal(variant);
+      }
+      for (const chain of chains) {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const derived = await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveLayerZeroConfig(combined[chain]);
+        assert(derived.remoteRouters[remote], `Missing ${remote} route`);
+        expect(derived.remoteRouters[remote].router.toLowerCase()).to.equal(
+          combined[remote].toLowerCase(),
+        );
+      }
+      const check = await hyperlaneWarpCheck(routeId);
+      expect(check.exitCode).to.equal(0);
+
+      const updatedConfig = configFor(variant, symbol);
+      for (const chain of chains) {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        if (variant === LayerZeroV2Variant.Callback) {
+          const hook = findLayerZeroV2Hooks(updatedConfig[chain].hook)[0];
+          assert(
+            hook?.type === HookType.LAYER_ZERO_V2_CALLBACK,
+            'Missing callback hook',
+          );
+          hook.callbackGasLimits[remote] = 333_333n;
+        } else {
+          const ism = updatedConfig[chain].interchainSecurityModule;
+          assert(
+            typeof ism !== 'string' &&
+              ism?.type === IsmType.LAYER_ZERO_V2_CCIP_READ,
+            'Missing CCIP-read ISM',
+          );
+          ism.urls = [
+            'http://127.0.0.1:3000/layerzero/getLayerZeroPacket',
+            'http://127.0.0.1:3001/layerzero/getLayerZeroPacket',
+          ];
+        }
+      }
+      const registryDeployPath = warpCorePath.replace(
+        '-config.yaml',
+        '-deploy.yaml',
+      );
+      writeYamlOrJson(registryDeployPath, updatedConfig);
+      const apply = await hyperlaneWarpApply(routeId);
+      expect(apply.exitCode).to.equal(0);
+
+      for (const chain of chains) {
+        const remote = chain === CHAIN_NAME_2 ? CHAIN_NAME_3 : CHAIN_NAME_2;
+        const derived = await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveLayerZeroConfig(combined[chain]);
+        if (variant === LayerZeroV2Variant.Callback) {
+          expect(derived.remoteRouters[remote].callbackGasLimit).to.equal(
+            333_333n,
+          );
+        } else {
+          expect(derived.urls).to.deep.equal([
+            'http://127.0.0.1:3000/layerzero/getLayerZeroPacket',
+            'http://127.0.0.1:3001/layerzero/getLayerZeroPacket',
+          ]);
+        }
+      }
+      const postApplyCheck = await hyperlaneWarpCheck(routeId);
+      expect(postApplyCheck.exitCode).to.equal(0);
+    });
+  }
+});

--- a/typescript/relayer/src/metadata/builder.ts
+++ b/typescript/relayer/src/metadata/builder.ts
@@ -70,6 +70,7 @@ export class BaseMetadataBuilder implements MetadataBuilder {
       case IsmType.BLACKLIST:
       case IsmType.NET_FLOW_RATE_LIMITED:
       case IsmType.DELAYED_FLOW_ROUTER:
+      case IsmType.LAYER_ZERO_V2_CALLBACK:
         return this.nullMetadataBuilder.build({ ...context, ism });
 
       case IsmType.WORMHOLE_EXECUTOR:
@@ -128,6 +129,7 @@ export class BaseMetadataBuilder implements MetadataBuilder {
       }
 
       case IsmType.OFFCHAIN_LOOKUP:
+      case IsmType.LAYER_ZERO_V2_CCIP_READ:
         return this.ccipReadMetadataBuilder.build({
           ...context,
           ism,

--- a/typescript/relayer/src/metadata/ccipread.hardhat-test.ts
+++ b/typescript/relayer/src/metadata/ccipread.hardhat-test.ts
@@ -141,9 +141,15 @@ describe('Offchain Lookup ISM Integration', () => {
       OFFCHAIN_LOOKUP_SERVER_URL.replace('{data}', payload.data),
     );
 
-    // Should include sender, data, and signature
-    expect(payload).to.include.keys('sender', 'data', 'signature');
+    // Should include authentication and the exact origin receipt hint.
+    expect(payload).to.include.keys(
+      'sender',
+      'data',
+      'signature',
+      'origin_tx_hash',
+    );
     expect(payload.sender).to.equal(ccipReadIsm.address);
+    expect(payload.origin_tx_hash).to.equal(dispatchTx.transactionHash);
 
     const recovered = ethers.utils.verifyMessage(
       ethers.utils.arrayify(

--- a/typescript/relayer/src/metadata/ccipread.ts
+++ b/typescript/relayer/src/metadata/ccipread.ts
@@ -4,6 +4,7 @@ import { AbstractCcipReadIsm__factory } from '@hyperlane-xyz/core';
 import {
   HyperlaneCore,
   IsmType,
+  LayerZeroV2IsmConfig,
   OffchainLookupIsmConfig,
   WormholeIsmConfig,
   offchainLookupRequestMessageHash,
@@ -57,7 +58,11 @@ function extractRevertData(error: unknown): string | undefined {
  */
 export type OffchainLookupContextConfig =
   | OffchainLookupIsmConfig
-  | (WormholeIsmConfig & { type: typeof IsmType.WORMHOLE_VAA });
+  | (WormholeIsmConfig & { type: typeof IsmType.WORMHOLE_VAA })
+  | Extract<
+      LayerZeroV2IsmConfig,
+      { type: typeof IsmType.LAYER_ZERO_V2_CCIP_READ }
+    >;
 
 export class OffchainLookupMetadataBuilder implements MetadataBuilder {
   readonly type = IsmType.OFFCHAIN_LOOKUP;
@@ -160,6 +165,9 @@ export class OffchainLookupMetadataBuilder implements MetadataBuilder {
             metadata: ensure0x(responseJson.data),
           };
         }
+        this.core.logger.warn(
+          `CCIP-read metadata fetch returned ${res.status} for ${url}: ${JSON.stringify(responseJson)}`,
+        );
       } catch (error) {
         this.core.logger.warn(
           `CCIP-read metadata fetch failed for ${url}: ${error}`,

--- a/typescript/relayer/src/metadata/null.ts
+++ b/typescript/relayer/src/metadata/null.ts
@@ -1,5 +1,6 @@
 import {
   IsmType,
+  LayerZeroV2IsmConfig,
   MultiProvider,
   NullIsmConfig,
   WormholeIsmConfig,
@@ -15,13 +16,20 @@ import type {
 export const NULL_METADATA = '0x';
 
 export type NullMetadata = {
-  type: NullIsmConfig['type'] | typeof IsmType.WORMHOLE_EXECUTOR;
+  type:
+    | NullIsmConfig['type']
+    | typeof IsmType.WORMHOLE_EXECUTOR
+    | typeof IsmType.LAYER_ZERO_V2_CALLBACK;
 };
 
 /** ISM configs whose metadata is always empty. */
 export type EmptyMetadataIsmConfig =
   | NullIsmConfig
-  | (WormholeIsmConfig & { type: typeof IsmType.WORMHOLE_EXECUTOR });
+  | (WormholeIsmConfig & { type: typeof IsmType.WORMHOLE_EXECUTOR })
+  | Extract<
+      LayerZeroV2IsmConfig,
+      { type: typeof IsmType.LAYER_ZERO_V2_CALLBACK }
+    >;
 
 export class NullMetadataBuilder implements MetadataBuilder {
   constructor(protected multiProvider: MultiProvider) {}

--- a/typescript/relayer/src/metadata/types.ts
+++ b/typescript/relayer/src/metadata/types.ts
@@ -127,7 +127,8 @@ export interface NullMetadataBuildResult extends BaseMetadataBuildResult {
     | typeof IsmType.DELAYED_FLOW_ROUTER
     // The Executor router is preauthorized by executeVAAv1 before process, so
     // Hyperlane carries no metadata for it.
-    | typeof IsmType.WORMHOLE_EXECUTOR;
+    | typeof IsmType.WORMHOLE_EXECUTOR
+    | typeof IsmType.LAYER_ZERO_V2_CALLBACK;
   /** Always present for null ISMs */
   metadata: string;
 }
@@ -145,7 +146,10 @@ export interface ArbL2ToL1MetadataBuildResult extends BaseMetadataBuildResult {
 export interface CcipReadMetadataBuildResult extends BaseMetadataBuildResult {
   // The direct-VAA Wormhole router reverts with the same OffchainLookup shape
   // and its response is a single ABI-encoded `bytes`, so it reuses this path.
-  type: typeof IsmType.OFFCHAIN_LOOKUP | typeof IsmType.WORMHOLE_VAA;
+  type:
+    | typeof IsmType.OFFCHAIN_LOOKUP
+    | typeof IsmType.WORMHOLE_VAA
+    | typeof IsmType.LAYER_ZERO_V2_CCIP_READ;
   /** URLs configured for offchain lookup */
   urls: string[];
 }

--- a/typescript/sdk/src/hook/EvmHookReader.ts
+++ b/typescript/sdk/src/hook/EvmHookReader.ts
@@ -37,6 +37,8 @@ import {
 
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { DispatchedMessage } from '../core/types.js';
+import { EvmLayerZeroV2HookIsmReader } from '../layerzero/EvmLayerZeroV2HookIsmReader.js';
+import { LayerZeroV2Variant } from '../layerzero/types.js';
 import { deriveDelayedFlowRemoteIsms } from '../ism/delayedFlow.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { ChainNameOrId } from '../types.js';
@@ -63,6 +65,7 @@ import {
   IgpVersion,
   IgpHookConfig,
   MailboxDefaultHookConfig,
+  LayerZeroV2HookConfig,
   MerkleTreeHookConfig,
   NetFlowRateLimitedHookConfig,
   OFFCHAIN_QUOTED_IGP_VERSION,
@@ -240,6 +243,10 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
           derivedHookConfig = await this.deriveWormholeHookConfig(address);
           this._cache.set(address, derivedHookConfig);
           break;
+        case OnchainHookType.LAYER_ZERO:
+          derivedHookConfig = await this.deriveLayerZeroV2HookConfig(address);
+          this._cache.set(address, derivedHookConfig);
+          break;
         case OnchainHookType.RATE_LIMITED: {
           // NetFlowRateLimitedHookIsm (a hook/ISM hybrid) also reports
           // hookType() == RATE_LIMITED and exposes maxCapacity()/DURATION()/
@@ -272,6 +279,31 @@ export class EvmHookReader extends HyperlaneReader implements HookReader {
     }
 
     return derivedHookConfig;
+  }
+
+  async deriveLayerZeroV2HookConfig(
+    address: Address,
+  ): Promise<WithAddress<LayerZeroV2HookConfig>> {
+    const config = await new EvmLayerZeroV2HookIsmReader(
+      this.multiProvider,
+      this.chain,
+    ).deriveLayerZeroConfig(address);
+    if (config.type === LayerZeroV2Variant.Callback) {
+      return {
+        address,
+        type: HookType.LAYER_ZERO_V2_CALLBACK,
+        callbackGasLimits: Object.fromEntries(
+          Object.entries(config.remoteRouters).map(([chain, remote]) => [
+            chain,
+            BigInt(remote.callbackGasLimit ?? 0),
+          ]),
+        ),
+      };
+    }
+    return {
+      address,
+      type: HookType.LAYER_ZERO_V2_CCIP_READ,
+    };
   }
 
   /**

--- a/typescript/sdk/src/hook/types.ts
+++ b/typescript/sdk/src/hook/types.ts
@@ -19,6 +19,7 @@ import {
   ZChainName,
   ZHash,
 } from '../metadata/customZodTypes.js';
+import { LayerZeroV2CallbackGasLimitSchema } from '../layerzero/types.js';
 import {
   ChainMap,
   OwnableConfig,
@@ -48,6 +49,7 @@ export enum OnchainHookType {
   TIMELOCK_ROUTING,
   PREDICATE_ROUTER_WRAPPER,
   WORMHOLE,
+  LAYER_ZERO,
 }
 
 export const HookType = {
@@ -102,6 +104,10 @@ export const HookType = {
   WORMHOLE_EXECUTOR: 'wormholeExecutorHook',
   /** Combined Wormhole hook/ISM router, CCIP-read VAA delivery. */
   WORMHOLE_VAA: 'wormholeVaaHook',
+  /** Combined LayerZero V2 hook/ISM router, Executor callback delivery. */
+  LAYER_ZERO_V2_CALLBACK: 'layerZeroV2CallbackHook',
+  /** Combined LayerZero V2 hook/ISM router, CCIP-read packet delivery. */
+  LAYER_ZERO_V2_CCIP_READ: 'layerZeroV2CcipReadHook',
   UNKNOWN: 'unknownHook',
   PREDICATE: 'predicateHook',
 } as const;
@@ -118,6 +124,8 @@ export type DeployableHookType = Exclude<
   | typeof HookType.DELAYED_FLOW_ROUTER
   | typeof HookType.WORMHOLE_EXECUTOR
   | typeof HookType.WORMHOLE_VAA
+  | typeof HookType.LAYER_ZERO_V2_CALLBACK
+  | typeof HookType.LAYER_ZERO_V2_CCIP_READ
 >;
 
 export const HookTypeToContractNameMap: Record<DeployableHookType, string> = {
@@ -204,6 +212,7 @@ export type HookConfig =
   | NetFlowRateLimitedHookConfig
   | DelayedFlowRouterHookConfig
   | WormholeHookConfig
+  | LayerZeroV2HookConfig
   | UnknownHookConfig
   | PredicateHookConfig;
 
@@ -406,6 +415,21 @@ export const WormholeHookSchema = z.union([
 ]);
 export type WormholeHookConfig = z.infer<typeof WormholeHookSchema>;
 
+export const LayerZeroV2CallbackHookSchema = z.object({
+  type: z.literal(HookType.LAYER_ZERO_V2_CALLBACK),
+  callbackGasLimits: z.record(ZChainName, LayerZeroV2CallbackGasLimitSchema),
+});
+
+export const LayerZeroV2CcipReadHookSchema = z.object({
+  type: z.literal(HookType.LAYER_ZERO_V2_CCIP_READ),
+});
+
+export const LayerZeroV2HookSchema = z.union([
+  LayerZeroV2CallbackHookSchema,
+  LayerZeroV2CcipReadHookSchema,
+]);
+export type LayerZeroV2HookConfig = z.infer<typeof LayerZeroV2HookSchema>;
+
 export const UnknownHookSchema = z.looseObject({
   type: z.literal(HookType.UNKNOWN),
 });
@@ -544,6 +568,7 @@ export const HookConfigSchema: z.ZodType<HookConfig, unknown> = z.union([
   NetFlowRateLimitedHookConfigSchema,
   DelayedFlowRouterHookConfigSchema,
   WormholeHookSchema,
+  LayerZeroV2HookSchema,
   UnknownHookSchema,
   PredicateHookSchema,
 ]);

--- a/typescript/sdk/src/hook/utils.ts
+++ b/typescript/sdk/src/hook/utils.ts
@@ -9,6 +9,7 @@ import {
   HookConfig,
   HookType,
   IgpVersion,
+  LayerZeroV2HookConfig,
   NetFlowRateLimitedHookConfig,
   WormholeHookConfig,
 } from './types.js';
@@ -107,7 +108,8 @@ export type HybridHookNodeConfig =
  */
 export type CombinedHookIsmHookConfig =
   | HybridHookNodeConfig
-  | WormholeHookConfig;
+  | WormholeHookConfig
+  | LayerZeroV2HookConfig;
 
 export function isHybridHookNode(
   hook: HookConfig | undefined,
@@ -128,7 +130,9 @@ export function isCombinedHookIsmHookNode(
     (!!hook &&
       typeof hook === 'object' &&
       (hook.type === HookType.WORMHOLE_EXECUTOR ||
-        hook.type === HookType.WORMHOLE_VAA))
+        hook.type === HookType.WORMHOLE_VAA ||
+        hook.type === HookType.LAYER_ZERO_V2_CALLBACK ||
+        hook.type === HookType.LAYER_ZERO_V2_CCIP_READ))
   );
 }
 

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -402,6 +402,8 @@ export {
   IsmConfig,
   IsmConfigSchema,
   IsmType,
+  LayerZeroV2IsmConfig,
+  LayerZeroV2IsmConfigSchema,
   MailboxDefaultIsmConfig,
   MailboxDefaultIsmConfigSchema,
   ModuleType,
@@ -1223,3 +1225,7 @@ export type {
   WormholeConsistencyLevelConfig,
   WormholeStandardConsistencyType,
 } from './wormhole/types.js';
+export * from './layerzero/types.js';
+export * from './layerzero/config.js';
+export * from './layerzero/EvmLayerZeroV2HookIsmReader.js';
+export * from './layerzero/EvmLayerZeroV2HookIsmModule.js';

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -1227,5 +1227,6 @@ export type {
 } from './wormhole/types.js';
 export * from './layerzero/types.js';
 export * from './layerzero/config.js';
+export * from './layerzero/configCodec.js';
 export * from './layerzero/EvmLayerZeroV2HookIsmReader.js';
 export * from './layerzero/EvmLayerZeroV2HookIsmModule.js';

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -286,6 +286,8 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
             receiveLibraryTimeout: remote.receiveLibraryTimeout,
             sendConfig: remote.sendConfig,
             receiveConfig: remote.receiveConfig,
+            effectiveSendConfig: remote.effectiveSendConfig,
+            effectiveReceiveConfig: remote.effectiveReceiveConfig,
           },
         ]),
       );

--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -39,6 +39,8 @@ import { getChainNameFromCCIPSelector } from '../ccip/utils.js';
 import { DEFAULT_CONTRACT_READ_CONCURRENCY } from '../consts/concurrency.js';
 import { DispatchedMessage } from '../core/types.js';
 import { OnchainHookType } from '../hook/types.js';
+import { EvmLayerZeroV2HookIsmReader } from '../layerzero/EvmLayerZeroV2HookIsmReader.js';
+import { LayerZeroV2Variant } from '../layerzero/types.js';
 import { ChainTechnicalStack } from '../metadata/chainMetadataTypes.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 import { EvmEventLogsReader } from '../rpc/evm/EvmEventLogsReader.js';
@@ -60,6 +62,7 @@ import {
   DomainRoutingIsmConfig,
   IsmConfig,
   IsmType,
+  LayerZeroV2IsmConfig,
   MailboxDefaultIsmConfig,
   ModuleType,
   MultisigIsmConfig,
@@ -102,6 +105,8 @@ const NON_REDEPLOYABLE_ISM_TYPES = new Set<IsmType>([
   IsmType.INTERCHAIN_ACCOUNT_ROUTING,
   IsmType.WORMHOLE_EXECUTOR,
   IsmType.WORMHOLE_VAA,
+  IsmType.LAYER_ZERO_V2_CALLBACK,
+  IsmType.LAYER_ZERO_V2_CCIP_READ,
 ]);
 
 export class EvmIsmReader extends HyperlaneReader implements IsmReader {
@@ -213,7 +218,11 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
             address,
             moduleType,
           );
-          derivedIsmConfig = wormhole ?? (await this.deriveNullConfig(address));
+          const layerZero = wormhole
+            ? undefined
+            : await this.tryDeriveLayerZeroV2IsmConfig(address, moduleType);
+          derivedIsmConfig =
+            wormhole ?? layerZero ?? (await this.deriveNullConfig(address));
           break;
         }
         case ModuleType.CCIP_READ: {
@@ -221,8 +230,13 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
             address,
             moduleType,
           );
+          const layerZero = wormhole
+            ? undefined
+            : await this.tryDeriveLayerZeroV2IsmConfig(address, moduleType);
           derivedIsmConfig =
-            wormhole ?? (await this.deriveOffchainLookupConfig(address));
+            wormhole ??
+            layerZero ??
+            (await this.deriveOffchainLookupConfig(address));
           break;
         }
         case ModuleType.ARB_L2_TO_L1:
@@ -239,6 +253,64 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
     }
 
     return derivedIsmConfig;
+  }
+
+  private async tryDeriveLayerZeroV2IsmConfig(
+    address: Address,
+    moduleType: ModuleType,
+  ): Promise<WithAddress<LayerZeroV2IsmConfig> | undefined> {
+    try {
+      const hookType = await IPostDispatchHook__factory.connect(
+        address,
+        this.provider,
+      ).hookType();
+      if (hookType !== OnchainHookType.LAYER_ZERO) return undefined;
+
+      const reader = new EvmLayerZeroV2HookIsmReader(
+        this.multiProvider,
+        this.chain,
+      );
+      const variant =
+        moduleType === ModuleType.NULL
+          ? LayerZeroV2Variant.Callback
+          : LayerZeroV2Variant.CcipRead;
+      const config = await reader.deriveLayerZeroConfig(address, variant);
+      const pathways = Object.fromEntries(
+        Object.entries(config.remoteRouters).map(([chain, remote]) => [
+          chain,
+          {
+            layerZeroDomainId: remote.layerZeroDomainId,
+            sendLibrary: remote.sendLibrary,
+            receiveLibrary: remote.receiveLibrary,
+            receiveLibraryGracePeriod: remote.receiveLibraryGracePeriod,
+            receiveLibraryTimeout: remote.receiveLibraryTimeout,
+            sendConfig: remote.sendConfig,
+            receiveConfig: remote.receiveConfig,
+          },
+        ]),
+      );
+      return variant === LayerZeroV2Variant.Callback
+        ? {
+            address,
+            type: IsmType.LAYER_ZERO_V2_CALLBACK,
+            owner: config.owner,
+            endpoint: config.endpoint,
+            layerZeroDomainId: config.layerZeroDomainId,
+            pathways,
+          }
+        : {
+            address,
+            type: IsmType.LAYER_ZERO_V2_CCIP_READ,
+            owner: config.owner,
+            endpoint: config.endpoint,
+            layerZeroDomainId: config.layerZeroDomainId,
+            pathways,
+            urls: config.urls ?? [],
+          };
+    } catch (error) {
+      if (isMissingSelectorCallException(error)) return undefined;
+      throw error;
+    }
   }
 
   async deriveOffchainLookupConfig(

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -39,8 +39,13 @@ import { WormholeConsistencyLevelFields } from '../wormhole/consistency.js';
 import {
   ZBigNumberish,
   ZBytes32String,
+  ZChainName,
   ZHash,
 } from '../metadata/customZodTypes.js';
+import {
+  LayerZeroV2AddressSchema,
+  LayerZeroV2PathwaySchema,
+} from '../layerzero/types.js';
 import {
   ChainMap,
   OwnableConfig,
@@ -115,6 +120,10 @@ export const IsmType = {
   WORMHOLE_EXECUTOR: 'wormholeExecutorIsm',
   /** Combined Wormhole hook/ISM router, CCIP-read VAA delivery. */
   WORMHOLE_VAA: 'wormholeVaaIsm',
+  /** Combined LayerZero V2 hook/ISM router, Executor callback delivery. */
+  LAYER_ZERO_V2_CALLBACK: 'layerZeroV2CallbackIsm',
+  /** Combined LayerZero V2 hook/ISM router, CCIP-read packet delivery. */
+  LAYER_ZERO_V2_CCIP_READ: 'layerZeroV2CcipReadIsm',
   UNKNOWN: 'unknownIsm',
 } as const;
 
@@ -126,6 +135,8 @@ export type DeployableIsmType = Exclude<
   | typeof IsmType.UNKNOWN
   | typeof IsmType.WORMHOLE_EXECUTOR
   | typeof IsmType.WORMHOLE_VAA
+  | typeof IsmType.LAYER_ZERO_V2_CALLBACK
+  | typeof IsmType.LAYER_ZERO_V2_CCIP_READ
 >;
 
 // ISM types that can be updated in-place on EVM chains (consumed by
@@ -204,6 +215,7 @@ export function ismTypeToModuleType(ismType: IsmType): ModuleType {
     // The Executor router is preauthorized before process, so Hyperlane
     // supplies no metadata.
     case IsmType.WORMHOLE_EXECUTOR:
+    case IsmType.LAYER_ZERO_V2_CALLBACK:
       return ModuleType.NULL;
     case IsmType.ARB_L2_TO_L1:
       return ModuleType.ARB_L2_TO_L1;
@@ -214,6 +226,7 @@ export function ismTypeToModuleType(ismType: IsmType): ModuleType {
     case IsmType.OFFCHAIN_LOOKUP:
     // The direct-VAA router receives its VAA through the generic CCIP-read path.
     case IsmType.WORMHOLE_VAA:
+    case IsmType.LAYER_ZERO_V2_CCIP_READ:
       return ModuleType.CCIP_READ;
     case IsmType.COMPOSITE:
       return ModuleType.COMPOSITE;
@@ -259,6 +272,7 @@ export type NetFlowRateLimitedHookIsmConfig = z.infer<
 export type DelayedFlowRouterHookIsmConfig = z.infer<
   typeof DelayedFlowRouterHookIsmConfigSchema
 >;
+export type LayerZeroV2IsmConfig = z.infer<typeof LayerZeroV2IsmConfigSchema>;
 
 export type NullIsmConfig =
   | TestIsmConfig
@@ -345,6 +359,7 @@ export type IsmConfig =
   | OffchainLookupIsmConfig
   | InterchainAccountRouterIsm
   | WormholeIsmConfig
+  | LayerZeroV2IsmConfig
   | UnknownIsmConfig;
 
 export type DerivedIsmConfig = WithAddress<Exclude<IsmConfig, Address>>;
@@ -380,6 +395,8 @@ export type DeployedIsmType = {
   // generic interface is all this map needs to express.
   [IsmType.WORMHOLE_EXECUTOR]: IInterchainSecurityModule;
   [IsmType.WORMHOLE_VAA]: IInterchainSecurityModule;
+  [IsmType.LAYER_ZERO_V2_CALLBACK]: IInterchainSecurityModule;
+  [IsmType.LAYER_ZERO_V2_CCIP_READ]: IInterchainSecurityModule;
   [IsmType.UNKNOWN]: IInterchainSecurityModule;
 };
 
@@ -570,6 +587,27 @@ export const OffchainLookupIsmConfigSchema = OwnableSchema.extend({
   type: z.literal(IsmType.OFFCHAIN_LOOKUP),
   urls: z.array(z.url()),
 });
+
+const LayerZeroV2BaseIsmSchema = OwnableSchema.extend({
+  endpoint: LayerZeroV2AddressSchema,
+  /** Optional deployment-time assertion against Endpoint.eid(). */
+  layerZeroDomainId: z.number().int().positive().max(0xffffffff).optional(),
+  pathways: z.record(ZChainName, LayerZeroV2PathwaySchema),
+});
+
+export const LayerZeroV2CallbackIsmSchema = LayerZeroV2BaseIsmSchema.extend({
+  type: z.literal(IsmType.LAYER_ZERO_V2_CALLBACK),
+});
+
+export const LayerZeroV2CcipReadIsmSchema = LayerZeroV2BaseIsmSchema.extend({
+  type: z.literal(IsmType.LAYER_ZERO_V2_CCIP_READ),
+  urls: z.array(z.string().url()).min(1),
+});
+
+export const LayerZeroV2IsmConfigSchema = z.union([
+  LayerZeroV2CallbackIsmSchema,
+  LayerZeroV2CcipReadIsmSchema,
+]);
 
 export const isOffchainLookupIsmConfig = isCompliant(
   OffchainLookupIsmConfigSchema,
@@ -1091,6 +1129,7 @@ export const BaseIsmConfigSchema: z.ZodType<IsmConfig, unknown> = z.union([
   OffchainLookupIsmConfigSchema,
   InterchainAccountRouterIsmSchema,
   WormholeIsmConfigSchema,
+  LayerZeroV2IsmConfigSchema,
   UnknownIsmConfigSchema,
 ]);
 

--- a/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.hardhat-test.ts
@@ -15,13 +15,25 @@ import { MultiProvider } from '../providers/MultiProvider.js';
 
 import { EvmLayerZeroV2HookIsmModule } from './EvmLayerZeroV2HookIsmModule.js';
 import { EvmLayerZeroV2HookIsmReader } from './EvmLayerZeroV2HookIsmReader.js';
-import { LayerZeroV2MeshConfig, LayerZeroV2Variant } from './types.js';
+import {
+  LayerZeroV2ConfigMode,
+  LayerZeroV2MeshConfig,
+  LayerZeroV2Variant,
+} from './types.js';
 
 describe('EvmLayerZeroV2HookIsmModule', () => {
   const chainA = TestChainName.test1;
   const chainB = TestChainName.test2;
   let signer: SignerWithAddress;
   let multiProvider: MultiProvider;
+
+  const defaultSendConfig = () => ({
+    executor: { type: LayerZeroV2ConfigMode.Default },
+    uln: { type: LayerZeroV2ConfigMode.Default },
+  });
+  const defaultReceiveConfig = () => ({
+    uln: { type: LayerZeroV2ConfigMode.Default },
+  });
 
   before(async () => {
     [signer] = await hre.ethers.getSigners();
@@ -84,8 +96,29 @@ describe('EvmLayerZeroV2HookIsmModule', () => {
               library: receiveLibraryA.address,
               expiry: timeoutExpiry,
             },
-            sendConfig: [{ configType: 1, config: '0x1234' }],
-            receiveConfig: [{ configType: 2, config: '0xabcd' }],
+            sendConfig: {
+              executor: {
+                type: LayerZeroV2ConfigMode.Override,
+                maxMessageSize: 20_000,
+                executor: signer.address,
+              },
+              uln: {
+                type: LayerZeroV2ConfigMode.Override,
+                confirmations: 15n,
+                requiredDVNs: [signer.address],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+              },
+            },
+            receiveConfig: {
+              uln: {
+                type: LayerZeroV2ConfigMode.Override,
+                confirmations: 20n,
+                requiredDVNs: [signer.address],
+                optionalDVNs: [],
+                optionalDVNThreshold: 0,
+              },
+            },
             callbackGasLimit: 250_000n,
           },
         },
@@ -103,8 +136,8 @@ describe('EvmLayerZeroV2HookIsmModule', () => {
             sendLibrary: sendLibraryB.address,
             receiveLibrary: receiveLibraryB.address,
             receiveLibraryGracePeriod: 0,
-            sendConfig: [],
-            receiveConfig: [],
+            sendConfig: defaultSendConfig(),
+            receiveConfig: defaultReceiveConfig(),
             callbackGasLimit: 300_000n,
           },
         },
@@ -127,15 +160,88 @@ describe('EvmLayerZeroV2HookIsmModule', () => {
     expect(
       derived.remoteRouters[chainB].receiveLibraryTimeout?.expiry,
     ).to.equal(timeoutExpiry);
-    expect(derived.remoteRouters[chainB].sendConfig).to.deep.equal([
-      { configType: 1, config: '0x1234' },
-    ]);
-    expect(derived.remoteRouters[chainB].receiveConfig).to.deep.equal([
-      { configType: 2, config: '0xabcd' },
-    ]);
+    expect(derived.remoteRouters[chainB].sendConfig).to.deep.equal(
+      mesh[chainA].remoteRouters[chainB].sendConfig,
+    );
+    expect(derived.remoteRouters[chainB].receiveConfig).to.deep.equal(
+      mesh[chainA].remoteRouters[chainB].receiveConfig,
+    );
+    expect(derived.remoteRouters[chainB].effectiveSendConfig).to.deep.equal({
+      executor: {
+        maxMessageSize: 20_000,
+        executor: signer.address,
+      },
+      uln: {
+        confirmations: 15n,
+        requiredDVNs: [signer.address],
+        optionalDVNs: [],
+        optionalDVNThreshold: 0,
+      },
+    });
     expect(await endpointA.delegates(addresses[chainA])).to.equal(
       hre.ethers.constants.AddressZero,
     );
+
+    const derivedDefaults = await new EvmLayerZeroV2HookIsmReader(
+      multiProvider,
+      chainB,
+    ).deriveLayerZeroConfig(addresses[chainB]);
+    expect(derivedDefaults.remoteRouters[chainA].sendConfig).to.deep.equal(
+      defaultSendConfig(),
+    );
+    expect(
+      derivedDefaults.remoteRouters[chainA].effectiveSendConfig,
+    ).to.deep.equal({
+      executor: {
+        maxMessageSize: 10_000,
+        executor: sendLibraryB.address,
+      },
+      uln: {
+        confirmations: 12n,
+        requiredDVNs: [sendLibraryB.address],
+        optionalDVNs: [],
+        optionalDVNThreshold: 0,
+      },
+    });
+
+    const configuredMesh = EvmLayerZeroV2HookIsmModule.withDeployedRouters(
+      mesh,
+      addresses,
+    );
+    const explicitDefaults = {
+      type: 'override' as const,
+      confirmations: 12n,
+      requiredDVNs: [sendLibraryB.address],
+      optionalDVNs: [],
+      optionalDVNThreshold: 0,
+    };
+    const pinDefaultValues = await new EvmLayerZeroV2HookIsmModule(
+      multiProvider,
+      chainB,
+      addresses[chainB],
+    ).update({
+      ...configuredMesh[chainB],
+      remoteRouters: {
+        [chainA]: {
+          ...configuredMesh[chainB].remoteRouters[chainA],
+          sendConfig: {
+            executor: {
+              type: LayerZeroV2ConfigMode.Override,
+              maxMessageSize: 10_000,
+              executor: sendLibraryB.address,
+            },
+            uln: explicitDefaults,
+          },
+          receiveConfig: {
+            uln: {
+              ...explicitDefaults,
+              requiredDVNs: [receiveLibraryB.address],
+            },
+          },
+        },
+      },
+    });
+    expect(pinDefaultValues).to.have.length(1);
 
     const reconciled = await EvmLayerZeroV2HookIsmModule.reconcileMesh(
       multiProvider,
@@ -156,7 +262,14 @@ describe('EvmLayerZeroV2HookIsmModule', () => {
               library: receiveLibraryA.address,
               expiry: timeoutExpiry + 100,
             },
-            sendConfig: [{ configType: 1, config: '0x5678' }],
+            sendConfig: {
+              ...mesh[chainA].remoteRouters[chainB].sendConfig,
+              executor: {
+                type: LayerZeroV2ConfigMode.Override,
+                maxMessageSize: 30_000,
+                executor: signer.address,
+              },
+            },
             callbackGasLimit: 275_000n,
           },
         },
@@ -194,9 +307,9 @@ describe('EvmLayerZeroV2HookIsmModule', () => {
       chainA,
     ).deriveLayerZeroConfig(addresses[chainA]);
     expect(updated.remoteRouters[chainB].callbackGasLimit).to.equal(275_000n);
-    expect(updated.remoteRouters[chainB].sendConfig).to.deep.equal([
-      { configType: 1, config: '0x5678' },
-    ]);
+    expect(updated.remoteRouters[chainB].sendConfig).to.deep.equal(
+      updatedMesh[chainA].remoteRouters[chainB].sendConfig,
+    );
     expect(
       updated.remoteRouters[chainB].receiveLibraryTimeout?.expiry,
     ).to.equal(timeoutExpiry + 100);
@@ -246,5 +359,58 @@ describe('EvmLayerZeroV2HookIsmModule', () => {
     expect(migrated.remoteRouters[chainB].receiveLibrary).to.equal(
       receiveLibraryA.address,
     );
+
+    const resetMesh: LayerZeroV2MeshConfig = {
+      ...migrationMesh,
+      [chainA]: {
+        ...migrationMesh[chainA],
+        remoteRouters: {
+          [chainB]: {
+            ...migrationMesh[chainA].remoteRouters[chainB],
+            sendConfig: defaultSendConfig(),
+            receiveConfig: defaultReceiveConfig(),
+          },
+        },
+      },
+    };
+    const reset = await EvmLayerZeroV2HookIsmModule.reconcileMesh(
+      multiProvider,
+      resetMesh,
+      addresses,
+    );
+    expect(reset.transactions[chainA]).to.have.length(1);
+    const resetTx = reset.transactions[chainA][0];
+    if (!resetTx.data) throw new Error('Missing reset transaction data');
+    const parsedReset =
+      LayerZeroV2CallbackHookIsm__factory.createInterface().parseTransaction({
+        data: resetTx.data,
+      });
+    expect(parsedReset.args.updates[0].sendConfig).to.have.length(2);
+    expect(parsedReset.args.updates[0].receiveConfig).to.have.length(1);
+    await multiProvider.handleTx(
+      chainA,
+      await signer.sendTransaction({
+        to: resetTx.to,
+        data: resetTx.data,
+        value: resetTx.value,
+      }),
+    );
+    const resetDerived = await new EvmLayerZeroV2HookIsmReader(
+      multiProvider,
+      chainA,
+    ).deriveLayerZeroConfig(addresses[chainA]);
+    expect(resetDerived.remoteRouters[chainB].sendConfig).to.deep.equal(
+      defaultSendConfig(),
+    );
+    expect(resetDerived.remoteRouters[chainB].receiveConfig).to.deep.equal(
+      defaultReceiveConfig(),
+    );
+    expect(
+      await new EvmLayerZeroV2HookIsmModule(
+        multiProvider,
+        chainA,
+        addresses[chainA],
+      ).update(resetDerived),
+    ).to.deep.equal([]);
   });
 });

--- a/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.hardhat-test.ts
+++ b/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.hardhat-test.ts
@@ -1,0 +1,250 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers.js';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  LayerZeroV2CallbackHookIsm__factory,
+  MockLayerZeroEndpointV2__factory,
+  MockLayerZeroReceiveUln__factory,
+  TestMailbox__factory,
+} from '@hyperlane-xyz/core';
+import { TestChainName } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { MultiProvider } from '../providers/MultiProvider.js';
+
+import { EvmLayerZeroV2HookIsmModule } from './EvmLayerZeroV2HookIsmModule.js';
+import { EvmLayerZeroV2HookIsmReader } from './EvmLayerZeroV2HookIsmReader.js';
+import { LayerZeroV2MeshConfig, LayerZeroV2Variant } from './types.js';
+
+describe('EvmLayerZeroV2HookIsmModule', () => {
+  const chainA = TestChainName.test1;
+  const chainB = TestChainName.test2;
+  let signer: SignerWithAddress;
+  let multiProvider: MultiProvider;
+
+  before(async () => {
+    [signer] = await hre.ethers.getSigners();
+    multiProvider = MultiProvider.createTestMultiProvider({ signer });
+  });
+
+  it('supports Ethereum and Tron deployments', () => {
+    expect(EvmLayerZeroV2HookIsmModule.protocols).to.have.members([
+      ProtocolType.Ethereum,
+      ProtocolType.Tron,
+    ]);
+  });
+
+  it('deploys, configures, reads, and idempotently reconciles a callback mesh', async () => {
+    const mailboxA = await new TestMailbox__factory(signer).deploy(
+      multiProvider.getDomainId(chainA),
+    );
+    const mailboxB = await new TestMailbox__factory(signer).deploy(
+      multiProvider.getDomainId(chainB),
+    );
+    const endpointA = await new MockLayerZeroEndpointV2__factory(signer).deploy(
+      30_101,
+    );
+    const endpointB = await new MockLayerZeroEndpointV2__factory(signer).deploy(
+      30_102,
+    );
+    const sendLibraryA = await new MockLayerZeroReceiveUln__factory(
+      signer,
+    ).deploy(endpointA.address);
+    const receiveLibraryA = await new MockLayerZeroReceiveUln__factory(
+      signer,
+    ).deploy(endpointA.address);
+    const sendLibraryB = await new MockLayerZeroReceiveUln__factory(
+      signer,
+    ).deploy(endpointB.address);
+    const receiveLibraryB = await new MockLayerZeroReceiveUln__factory(
+      signer,
+    ).deploy(endpointB.address);
+    await endpointA.registerMockLibrary(sendLibraryA.address);
+    await endpointA.registerMockLibrary(receiveLibraryA.address);
+    await endpointB.registerMockLibrary(sendLibraryB.address);
+    await endpointB.registerMockLibrary(receiveLibraryB.address);
+    const timeoutExpiry = (await signer.provider!.getBlockNumber()) + 1_000;
+
+    const mesh: LayerZeroV2MeshConfig = {
+      [chainA]: {
+        type: LayerZeroV2Variant.Callback,
+        owner: signer.address,
+        mailbox: mailboxA.address,
+        endpoint: endpointA.address,
+        layerZeroDomainId: 30_101,
+        remoteRouters: {
+          [chainB]: {
+            router: hre.ethers.constants.AddressZero,
+            layerZeroDomainId: 30_102,
+            sendLibrary: sendLibraryA.address,
+            receiveLibrary: receiveLibraryA.address,
+            receiveLibraryGracePeriod: 0,
+            receiveLibraryTimeout: {
+              library: receiveLibraryA.address,
+              expiry: timeoutExpiry,
+            },
+            sendConfig: [{ configType: 1, config: '0x1234' }],
+            receiveConfig: [{ configType: 2, config: '0xabcd' }],
+            callbackGasLimit: 250_000n,
+          },
+        },
+      },
+      [chainB]: {
+        type: LayerZeroV2Variant.Callback,
+        owner: signer.address,
+        mailbox: mailboxB.address,
+        endpoint: endpointB.address,
+        layerZeroDomainId: 30_102,
+        remoteRouters: {
+          [chainA]: {
+            router: hre.ethers.constants.AddressZero,
+            layerZeroDomainId: 30_101,
+            sendLibrary: sendLibraryB.address,
+            receiveLibrary: receiveLibraryB.address,
+            receiveLibraryGracePeriod: 0,
+            sendConfig: [],
+            receiveConfig: [],
+            callbackGasLimit: 300_000n,
+          },
+        },
+      },
+    };
+
+    const addresses = await EvmLayerZeroV2HookIsmModule.deployMesh(
+      multiProvider,
+      mesh,
+    );
+    expect(addresses[chainA]).not.to.equal(addresses[chainB]);
+
+    const derived = await new EvmLayerZeroV2HookIsmReader(
+      multiProvider,
+      chainA,
+    ).deriveLayerZeroConfig(addresses[chainA]);
+    expect(derived.remoteRouters[chainB].router.toLowerCase()).to.equal(
+      addresses[chainB].toLowerCase(),
+    );
+    expect(
+      derived.remoteRouters[chainB].receiveLibraryTimeout?.expiry,
+    ).to.equal(timeoutExpiry);
+    expect(derived.remoteRouters[chainB].sendConfig).to.deep.equal([
+      { configType: 1, config: '0x1234' },
+    ]);
+    expect(derived.remoteRouters[chainB].receiveConfig).to.deep.equal([
+      { configType: 2, config: '0xabcd' },
+    ]);
+    expect(await endpointA.delegates(addresses[chainA])).to.equal(
+      hre.ethers.constants.AddressZero,
+    );
+
+    const reconciled = await EvmLayerZeroV2HookIsmModule.reconcileMesh(
+      multiProvider,
+      mesh,
+      addresses,
+    );
+    expect(reconciled.transactions[chainA]).to.deep.equal([]);
+    expect(reconciled.transactions[chainB]).to.deep.equal([]);
+
+    const updatedMesh: LayerZeroV2MeshConfig = {
+      ...mesh,
+      [chainA]: {
+        ...mesh[chainA],
+        remoteRouters: {
+          [chainB]: {
+            ...mesh[chainA].remoteRouters[chainB],
+            receiveLibraryTimeout: {
+              library: receiveLibraryA.address,
+              expiry: timeoutExpiry + 100,
+            },
+            sendConfig: [{ configType: 1, config: '0x5678' }],
+            callbackGasLimit: 275_000n,
+          },
+        },
+      },
+    };
+    const update = await EvmLayerZeroV2HookIsmModule.reconcileMesh(
+      multiProvider,
+      updatedMesh,
+      addresses,
+    );
+    expect(
+      update.transactions[chainA].map((tx) => tx.annotation),
+    ).to.deep.equal([
+      `Atomically updating ${chainB} LayerZero route config on ${chainA}`,
+    ]);
+    const atomicUpdate = update.transactions[chainA][0];
+    if (!atomicUpdate.data) throw new Error('Missing atomic update data');
+    expect(
+      LayerZeroV2CallbackHookIsm__factory.createInterface().parseTransaction({
+        data: atomicUpdate.data,
+      }).name,
+    ).to.equal('updateLayerZeroRemoteRouterConfigs');
+    for (const tx of update.transactions[chainA]) {
+      await multiProvider.handleTx(
+        chainA,
+        await signer.sendTransaction({
+          to: tx.to,
+          data: tx.data,
+          value: tx.value,
+        }),
+      );
+    }
+    const updated = await new EvmLayerZeroV2HookIsmReader(
+      multiProvider,
+      chainA,
+    ).deriveLayerZeroConfig(addresses[chainA]);
+    expect(updated.remoteRouters[chainB].callbackGasLimit).to.equal(275_000n);
+    expect(updated.remoteRouters[chainB].sendConfig).to.deep.equal([
+      { configType: 1, config: '0x5678' },
+    ]);
+    expect(
+      updated.remoteRouters[chainB].receiveLibraryTimeout?.expiry,
+    ).to.equal(timeoutExpiry + 100);
+
+    const replacementSendLibrary = await new MockLayerZeroReceiveUln__factory(
+      signer,
+    ).deploy(endpointA.address);
+    await endpointA.registerMockLibrary(replacementSendLibrary.address);
+    const migrationMesh: LayerZeroV2MeshConfig = {
+      ...updatedMesh,
+      [chainA]: {
+        ...updatedMesh[chainA],
+        remoteRouters: {
+          [chainB]: {
+            ...updatedMesh[chainA].remoteRouters[chainB],
+            sendLibrary: replacementSendLibrary.address,
+          },
+        },
+      },
+    };
+    const migration = await EvmLayerZeroV2HookIsmModule.reconcileMesh(
+      multiProvider,
+      migrationMesh,
+      addresses,
+    );
+    expect(
+      migration.transactions[chainA].map((tx) => tx.annotation),
+    ).to.deep.equal([
+      `Atomically enrolling ${chainB} on LayerZero hook/ISM ${chainA}`,
+    ]);
+    const migrationTx = migration.transactions[chainA][0];
+    await multiProvider.handleTx(
+      chainA,
+      await signer.sendTransaction({
+        to: migrationTx.to,
+        data: migrationTx.data,
+        value: migrationTx.value,
+      }),
+    );
+    const migrated = await new EvmLayerZeroV2HookIsmReader(
+      multiProvider,
+      chainA,
+    ).deriveLayerZeroConfig(addresses[chainA]);
+    expect(migrated.remoteRouters[chainB].sendLibrary).to.equal(
+      replacementSendLibrary.address,
+    );
+    expect(migrated.remoteRouters[chainB].receiveLibrary).to.equal(
+      receiveLibraryA.address,
+    );
+  });
+});

--- a/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.ts
+++ b/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.ts
@@ -20,6 +20,13 @@ import { ChainMap, ChainName } from '../types.js';
 
 import { EvmLayerZeroV2HookIsmReader } from './EvmLayerZeroV2HookIsmReader.js';
 import {
+  encodeLayerZeroV2ExecutorConfig,
+  encodeLayerZeroV2UlnConfig,
+  layerZeroV2ReceiveConfigParams,
+  layerZeroV2SendConfigParams,
+  LayerZeroV2ConfigType,
+} from './configCodec.js';
+import {
   DerivedLayerZeroV2HookIsmConfig,
   LayerZeroV2HookIsmConfig,
   LayerZeroV2HookIsmSchema,
@@ -33,7 +40,6 @@ const ENDPOINT_ABI = [
   'function eid() view returns (uint32)',
   'function nativeToken() view returns (address)',
   'function delegates(address) view returns (address)',
-  'function getConfig(address,address,uint32,uint32) view returns (bytes)',
 ];
 const CCIP_READ_IFACE = new utils.Interface(['function setUrls(string[])']);
 
@@ -66,16 +72,18 @@ function remoteEnrollment(
     receiveLibraryTimeout:
       remote.receiveLibraryTimeout?.library ?? constants.AddressZero,
     receiveLibraryTimeoutExpiry: remote.receiveLibraryTimeout?.expiry ?? 0,
-    sendConfig: remote.sendConfig.map((param) => ({
+    sendConfig: layerZeroV2SendConfigParams(remote.sendConfig).map((param) => ({
       eid: remote.layerZeroDomainId,
       configType: param.configType,
       config: param.config,
     })),
-    receiveConfig: remote.receiveConfig.map((param) => ({
-      eid: remote.layerZeroDomainId,
-      configType: param.configType,
-      config: param.config,
-    })),
+    receiveConfig: layerZeroV2ReceiveConfigParams(remote.receiveConfig).map(
+      (param) => ({
+        eid: remote.layerZeroDomainId,
+        configType: param.configType,
+        config: param.config,
+      }),
+    ),
   };
 }
 
@@ -177,10 +185,7 @@ export class EvmLayerZeroV2HookIsmModule {
         continue;
       }
       assert(actual, `Missing current LayerZero route for ${remoteChain}`);
-      const changedConfig = await this.changedLayerZeroConfigs(
-        current.endpoint,
-        remote,
-      );
+      const changedConfig = this.changedLayerZeroConfigs(actual, remote);
       let callbackChanged = false;
       if (target.type === LayerZeroV2Variant.Callback) {
         assert(
@@ -271,54 +276,49 @@ export class EvmLayerZeroV2HookIsmModule {
     );
   }
 
-  private async changedLayerZeroConfigs(
-    endpointAddress: Address,
-    remote: LayerZeroV2RemoteRouterConfig,
-  ): Promise<{
+  private changedLayerZeroConfigs(
+    current: LayerZeroV2RemoteRouterConfig,
+    target: LayerZeroV2RemoteRouterConfig,
+  ): {
     sendConfig: LayerZeroV2ConfigParam[];
     receiveConfig: LayerZeroV2ConfigParam[];
-  }> {
-    const endpoint = new Contract(
-      endpointAddress,
-      ENDPOINT_ABI,
-      this.multiProvider.getProvider(this.chain),
-    );
-    const result = { sendConfig: [], receiveConfig: [] } as {
-      sendConfig: Array<{
-        eid: number;
-        configType: 1 | 2;
-        config: string;
-      }>;
-      receiveConfig: Array<{
-        eid: number;
-        configType: 1 | 2;
-        config: string;
-      }>;
+  } {
+    const result: {
+      sendConfig: LayerZeroV2ConfigParam[];
+      receiveConfig: LayerZeroV2ConfigParam[];
+    } = { sendConfig: [], receiveConfig: [] };
+    const addIfChanged = (
+      destination: LayerZeroV2ConfigParam[],
+      configType: 1 | 2,
+      currentConfig: string,
+      targetConfig: string,
+    ) => {
+      if (currentConfig.toLowerCase() !== targetConfig.toLowerCase()) {
+        destination.push({
+          eid: target.layerZeroDomainId,
+          configType,
+          config: targetConfig,
+        });
+      }
     };
-    for (const [library, params, direction] of [
-      [remote.sendLibrary, remote.sendConfig, 'send'],
-      [remote.receiveLibrary, remote.receiveConfig, 'receive'],
-    ] as const) {
-      const changed = [];
-      for (const param of params) {
-        const actual: string = await endpoint.getConfig(
-          this.address,
-          library,
-          remote.layerZeroDomainId,
-          param.configType,
-        );
-        if (actual.toLowerCase() !== param.config.toLowerCase()) {
-          changed.push({
-            eid: remote.layerZeroDomainId,
-            configType: param.configType,
-            config: param.config,
-          });
-        }
-      }
-      if (changed.length > 0) {
-        result[`${direction}Config`] = changed;
-      }
-    }
+    addIfChanged(
+      result.sendConfig,
+      LayerZeroV2ConfigType.Executor,
+      encodeLayerZeroV2ExecutorConfig(current.sendConfig.executor),
+      encodeLayerZeroV2ExecutorConfig(target.sendConfig.executor),
+    );
+    addIfChanged(
+      result.sendConfig,
+      LayerZeroV2ConfigType.Uln,
+      encodeLayerZeroV2UlnConfig(current.sendConfig.uln),
+      encodeLayerZeroV2UlnConfig(target.sendConfig.uln),
+    );
+    addIfChanged(
+      result.receiveConfig,
+      LayerZeroV2ConfigType.Uln,
+      encodeLayerZeroV2UlnConfig(current.receiveConfig.uln),
+      encodeLayerZeroV2UlnConfig(target.receiveConfig.uln),
+    );
     return result;
   }
 

--- a/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.ts
+++ b/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmModule.ts
@@ -1,0 +1,544 @@
+import {
+  LayerZeroV2CallbackHookIsm__factory,
+  LayerZeroV2CcipReadHookIsm__factory,
+} from '@hyperlane-xyz/core';
+import {
+  Address,
+  ProtocolType,
+  addressToBytes32,
+  assert,
+  eqAddress,
+  deepEquals,
+} from '@hyperlane-xyz/utils';
+import { Contract, constants, utils } from 'ethers';
+
+import { transferOwnershipTransactions } from '../contracts/contracts.js';
+import { ContractVerifier } from '../deploy/verify/ContractVerifier.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { AnnotatedEV5Transaction } from '../providers/ProviderType.js';
+import { ChainMap, ChainName } from '../types.js';
+
+import { EvmLayerZeroV2HookIsmReader } from './EvmLayerZeroV2HookIsmReader.js';
+import {
+  DerivedLayerZeroV2HookIsmConfig,
+  LayerZeroV2HookIsmConfig,
+  LayerZeroV2HookIsmSchema,
+  LayerZeroV2MeshConfig,
+  LayerZeroV2Variant,
+  findAsymmetricLayerZeroV2Routes,
+  LayerZeroV2RemoteRouterConfig,
+} from './types.js';
+
+const ENDPOINT_ABI = [
+  'function eid() view returns (uint32)',
+  'function nativeToken() view returns (address)',
+  'function delegates(address) view returns (address)',
+  'function getConfig(address,address,uint32,uint32) view returns (bytes)',
+];
+const CCIP_READ_IFACE = new utils.Interface(['function setUrls(string[])']);
+
+type LayerZeroV2ConfigParam = {
+  eid: number;
+  configType: 1 | 2;
+  config: string;
+};
+
+type LayerZeroV2ConfigUpdate = {
+  domain: number;
+  router: string;
+  receiveLibraryTimeout: string;
+  receiveLibraryTimeoutExpiry: number;
+  sendConfig: LayerZeroV2ConfigParam[];
+  receiveConfig: LayerZeroV2ConfigParam[];
+};
+
+function remoteEnrollment(
+  domain: number,
+  remote: LayerZeroV2RemoteRouterConfig,
+) {
+  return {
+    domain,
+    router: addressToBytes32(remote.router),
+    eid: remote.layerZeroDomainId,
+    sendLibrary: remote.sendLibrary,
+    receiveLibrary: remote.receiveLibrary,
+    receiveLibraryGracePeriod: remote.receiveLibraryGracePeriod,
+    receiveLibraryTimeout:
+      remote.receiveLibraryTimeout?.library ?? constants.AddressZero,
+    receiveLibraryTimeoutExpiry: remote.receiveLibraryTimeout?.expiry ?? 0,
+    sendConfig: remote.sendConfig.map((param) => ({
+      eid: remote.layerZeroDomainId,
+      configType: param.configType,
+      config: param.config,
+    })),
+    receiveConfig: remote.receiveConfig.map((param) => ({
+      eid: remote.layerZeroDomainId,
+      configType: param.configType,
+      config: param.config,
+    })),
+  };
+}
+
+export interface LayerZeroV2MeshReconciliation {
+  addresses: ChainMap<Address>;
+  transactions: ChainMap<AnnotatedEV5Transaction[]>;
+}
+
+/** Deploys and reconciles one combined LayerZero hook/ISM per mesh chain. */
+export class EvmLayerZeroV2HookIsmModule {
+  static protocols = [ProtocolType.Ethereum, ProtocolType.Tron];
+
+  constructor(
+    protected readonly multiProvider: MultiProvider,
+    public readonly chain: ChainName,
+    public readonly address: Address,
+  ) {}
+
+  read(): Promise<DerivedLayerZeroV2HookIsmConfig> {
+    return new EvmLayerZeroV2HookIsmReader(
+      this.multiProvider,
+      this.chain,
+    ).deriveLayerZeroConfig(this.address);
+  }
+
+  async update(
+    targetConfig: LayerZeroV2HookIsmConfig,
+  ): Promise<AnnotatedEV5Transaction[]> {
+    const target = LayerZeroV2HookIsmSchema.parse(targetConfig);
+    const current = await this.read();
+    for (const field of [
+      'type',
+      'mailbox',
+      'endpoint',
+      'layerZeroDomainId',
+    ] as const) {
+      const actual = current[field];
+      const desired = target[field];
+      const equal =
+        typeof actual === 'string' && typeof desired === 'string'
+          ? eqAddress(actual, desired) || actual === desired
+          : desired === undefined || actual === desired;
+      assert(
+        equal,
+        `LayerZero hook/ISM on ${this.chain} has immutable ${field} ${actual}; target wants ${desired}`,
+      );
+    }
+
+    const iface = LayerZeroV2CcipReadHookIsm__factory.createInterface();
+    const callbackIface = LayerZeroV2CallbackHookIsm__factory.createInterface();
+    const chainId = this.multiProvider.getEvmChainId(this.chain);
+    const txs: AnnotatedEV5Transaction[] = [];
+    const configUpdates: LayerZeroV2ConfigUpdate[] = [];
+    const configUpdateChains: string[] = [];
+    const callbackGasLimits: bigint[] = [];
+    const push = (annotation: string, data: string) =>
+      txs.push({ chainId, annotation, to: this.address, data });
+
+    for (const [remoteChain, remote] of Object.entries(current.remoteRouters)) {
+      const desired = target.remoteRouters[remoteChain];
+      if (!desired || remote.layerZeroDomainId !== desired.layerZeroDomainId) {
+        const domain = this.multiProvider.getDomainId(remoteChain);
+        push(
+          `Unenrolling ${remoteChain} from LayerZero hook/ISM ${this.chain}`,
+          iface.encodeFunctionData('unenrollRemoteRouter', [domain]),
+        );
+      }
+    }
+
+    for (const [remoteChain, remote] of Object.entries(target.remoteRouters)) {
+      const domain = this.multiProvider.getDomainId(remoteChain);
+      const actual = current.remoteRouters[remoteChain];
+      const requiresEnrollment =
+        !actual ||
+        actual.layerZeroDomainId !== remote.layerZeroDomainId ||
+        !eqAddress(actual.sendLibrary, remote.sendLibrary) ||
+        !eqAddress(actual.receiveLibrary, remote.receiveLibrary);
+      if (requiresEnrollment) {
+        const enrollment = remoteEnrollment(domain, remote);
+        let data: string;
+        if (target.type === LayerZeroV2Variant.Callback) {
+          assert(
+            remote.callbackGasLimit !== undefined,
+            `Missing callback gas limit for ${remoteChain}`,
+          );
+          data = callbackIface.encodeFunctionData(
+            'enrollLayerZeroRemoteRouter',
+            [enrollment, remote.callbackGasLimit],
+          );
+        } else {
+          data = iface.encodeFunctionData('enrollLayerZeroRemoteRouter', [
+            enrollment,
+          ]);
+        }
+        push(
+          `Atomically enrolling ${remoteChain} on LayerZero hook/ISM ${this.chain}`,
+          data,
+        );
+        continue;
+      }
+      assert(actual, `Missing current LayerZero route for ${remoteChain}`);
+      const changedConfig = await this.changedLayerZeroConfigs(
+        current.endpoint,
+        remote,
+      );
+      let callbackChanged = false;
+      if (target.type === LayerZeroV2Variant.Callback) {
+        assert(
+          remote.callbackGasLimit !== undefined,
+          `Missing callback gas limit for ${remoteChain}`,
+        );
+        callbackChanged =
+          actual.callbackGasLimit === undefined ||
+          BigInt(actual.callbackGasLimit) !== BigInt(remote.callbackGasLimit);
+      }
+      if (
+        eqAddress(actual.router, remote.router) &&
+        this.receiveLibraryTimeoutMatches(actual, remote) &&
+        changedConfig.sendConfig.length === 0 &&
+        changedConfig.receiveConfig.length === 0 &&
+        !callbackChanged
+      )
+        continue;
+
+      configUpdates.push({
+        domain,
+        router: addressToBytes32(remote.router),
+        receiveLibraryTimeout:
+          remote.receiveLibraryTimeout?.library ?? constants.AddressZero,
+        receiveLibraryTimeoutExpiry: remote.receiveLibraryTimeout?.expiry ?? 0,
+        ...changedConfig,
+      });
+      configUpdateChains.push(remoteChain);
+      if (target.type === LayerZeroV2Variant.Callback) {
+        assert(
+          remote.callbackGasLimit !== undefined,
+          `Missing callback gas limit for ${remoteChain}`,
+        );
+        callbackGasLimits.push(remote.callbackGasLimit);
+      }
+    }
+
+    if (configUpdates.length > 0) {
+      const data =
+        target.type === LayerZeroV2Variant.Callback
+          ? callbackIface.encodeFunctionData(
+              'updateLayerZeroRemoteRouterConfigs',
+              [configUpdates, callbackGasLimits],
+            )
+          : iface.encodeFunctionData('updateLayerZeroRemoteRouterConfigs', [
+              configUpdates,
+            ]);
+      push(
+        `Atomically updating ${configUpdateChains.join(', ')} LayerZero route config on ${this.chain}`,
+        data,
+      );
+    }
+
+    if (
+      target.type === LayerZeroV2Variant.CcipRead &&
+      !deepEquals(current.urls ?? [], target.urls ?? [])
+    ) {
+      push(
+        `Updating LayerZero CCIP-read URLs on ${this.chain}`,
+        CCIP_READ_IFACE.encodeFunctionData('setUrls', [target.urls]),
+      );
+    }
+    txs.push(
+      ...transferOwnershipTransactions(
+        chainId,
+        this.address,
+        current,
+        target,
+        `LayerZero hook/ISM on ${this.chain}`,
+      ),
+    );
+    return txs;
+  }
+
+  private receiveLibraryTimeoutMatches(
+    current: LayerZeroV2RemoteRouterConfig,
+    target: LayerZeroV2RemoteRouterConfig,
+  ): boolean {
+    if (!current.receiveLibraryTimeout || !target.receiveLibraryTimeout)
+      return current.receiveLibraryTimeout === target.receiveLibraryTimeout;
+    return (
+      eqAddress(
+        current.receiveLibraryTimeout.library,
+        target.receiveLibraryTimeout.library,
+      ) &&
+      current.receiveLibraryTimeout.expiry ===
+        target.receiveLibraryTimeout.expiry
+    );
+  }
+
+  private async changedLayerZeroConfigs(
+    endpointAddress: Address,
+    remote: LayerZeroV2RemoteRouterConfig,
+  ): Promise<{
+    sendConfig: LayerZeroV2ConfigParam[];
+    receiveConfig: LayerZeroV2ConfigParam[];
+  }> {
+    const endpoint = new Contract(
+      endpointAddress,
+      ENDPOINT_ABI,
+      this.multiProvider.getProvider(this.chain),
+    );
+    const result = { sendConfig: [], receiveConfig: [] } as {
+      sendConfig: Array<{
+        eid: number;
+        configType: 1 | 2;
+        config: string;
+      }>;
+      receiveConfig: Array<{
+        eid: number;
+        configType: 1 | 2;
+        config: string;
+      }>;
+    };
+    for (const [library, params, direction] of [
+      [remote.sendLibrary, remote.sendConfig, 'send'],
+      [remote.receiveLibrary, remote.receiveConfig, 'receive'],
+    ] as const) {
+      const changed = [];
+      for (const param of params) {
+        const actual: string = await endpoint.getConfig(
+          this.address,
+          library,
+          remote.layerZeroDomainId,
+          param.configType,
+        );
+        if (actual.toLowerCase() !== param.config.toLowerCase()) {
+          changed.push({
+            eid: remote.layerZeroDomainId,
+            configType: param.configType,
+            config: param.config,
+          });
+        }
+      }
+      if (changed.length > 0) {
+        result[`${direction}Config`] = changed;
+      }
+    }
+    return result;
+  }
+
+  static withDeployedRouters(
+    mesh: LayerZeroV2MeshConfig,
+    addresses: ChainMap<Address>,
+  ): LayerZeroV2MeshConfig {
+    return Object.fromEntries(
+      Object.entries(mesh).map(([chain, config]) => [
+        chain,
+        {
+          ...config,
+          remoteRouters: Object.fromEntries(
+            Object.entries(config.remoteRouters).map(([remote, route]) => {
+              const router = addresses[remote];
+              assert(
+                router,
+                `No deployed LayerZero router for ${remote}, enrolled by ${chain}`,
+              );
+              return [remote, { ...route, router }];
+            }),
+          ),
+        },
+      ]),
+    );
+  }
+
+  static async deployMesh(
+    multiProvider: MultiProvider,
+    inputMesh: LayerZeroV2MeshConfig,
+    contractVerifier?: ContractVerifier,
+  ): Promise<ChainMap<Address>> {
+    return (
+      await this.reconcileMesh(multiProvider, inputMesh, {}, contractVerifier)
+    ).addresses;
+  }
+
+  static async reconcileMesh(
+    multiProvider: MultiProvider,
+    inputMesh: LayerZeroV2MeshConfig,
+    existingAddresses: ChainMap<Address> = {},
+    contractVerifier?: ContractVerifier,
+  ): Promise<LayerZeroV2MeshReconciliation> {
+    const mesh = Object.fromEntries(
+      Object.entries(inputMesh).map(([chain, config]) => [
+        chain,
+        LayerZeroV2HookIsmSchema.parse(config),
+      ]),
+    );
+    const chains = Object.keys(mesh);
+    assert(chains.length > 1, 'A LayerZero mesh needs at least two chains');
+    const asymmetries = findAsymmetricLayerZeroV2Routes(mesh);
+    assert(
+      asymmetries.length === 0,
+      `Asymmetric LayerZero mesh:\n  ${asymmetries.join('\n  ')}`,
+    );
+
+    await Promise.all(
+      chains.map(async (chain) => {
+        assert(
+          EvmLayerZeroV2HookIsmModule.protocols.includes(
+            multiProvider.getProtocol(chain),
+          ),
+          `LayerZero V2 hook/ISM only supports Ethereum and Tron chains; ${chain} is neither`,
+        );
+        const endpoint = new Contract(
+          mesh[chain].endpoint,
+          ENDPOINT_ABI,
+          multiProvider.getProvider(chain),
+        );
+        const [layerZeroDomainId, nativeToken] = await Promise.all([
+          endpoint.eid(),
+          endpoint.nativeToken(),
+        ]);
+        if (mesh[chain].layerZeroDomainId !== undefined) {
+          assert(
+            Number(layerZeroDomainId) === mesh[chain].layerZeroDomainId,
+            `${chain} Endpoint reports LayerZero domain ID ${layerZeroDomainId}; config expects ${mesh[chain].layerZeroDomainId}`,
+          );
+        }
+        assert(
+          eqAddress(nativeToken, constants.AddressZero),
+          `${chain} Endpoint uses unsupported native token ${nativeToken}`,
+        );
+      }),
+    );
+
+    const addresses: ChainMap<Address> = {};
+    const fresh = new Set<ChainName>();
+    for (const chain of chains) {
+      const existing = existingAddresses[chain];
+      if (existing) {
+        const current = await new EvmLayerZeroV2HookIsmReader(
+          multiProvider,
+          chain,
+        ).deriveLayerZeroConfig(existing);
+        const target = mesh[chain];
+        if (
+          current.type === target.type &&
+          eqAddress(current.mailbox, target.mailbox) &&
+          eqAddress(current.endpoint, target.endpoint) &&
+          (target.layerZeroDomainId === undefined ||
+            current.layerZeroDomainId === target.layerZeroDomainId)
+        ) {
+          addresses[chain] = existing;
+          continue;
+        }
+      }
+      addresses[chain] = await this.deployRouter(
+        multiProvider,
+        chain,
+        mesh[chain],
+        contractVerifier,
+      );
+      fresh.add(chain);
+    }
+    const resolved = this.withDeployedRouters(mesh, addresses);
+    const transactions: ChainMap<AnnotatedEV5Transaction[]> = {};
+    for (const chain of chains) {
+      if (fresh.has(chain)) {
+        await this.configureFreshRouter(
+          multiProvider,
+          chain,
+          addresses[chain],
+          resolved[chain],
+        );
+      } else {
+        transactions[chain] = await new EvmLayerZeroV2HookIsmModule(
+          multiProvider,
+          chain,
+          addresses[chain],
+        ).update(resolved[chain]);
+      }
+    }
+    return { addresses, transactions };
+  }
+
+  private static async deployRouter(
+    multiProvider: MultiProvider,
+    chain: ChainName,
+    config: LayerZeroV2HookIsmConfig,
+    contractVerifier?: ContractVerifier,
+  ): Promise<Address> {
+    if (config.type === LayerZeroV2Variant.Callback) {
+      const router = await multiProvider.handleDeploy(
+        chain,
+        new LayerZeroV2CallbackHookIsm__factory(),
+        [config.mailbox, config.endpoint],
+      );
+      await contractVerifier?.verifyContract(chain, {
+        name: 'LayerZeroV2CallbackHookIsm',
+        address: router.address,
+        constructorArguments:
+          LayerZeroV2CallbackHookIsm__factory.createInterface()
+            .encodeDeploy([config.mailbox, config.endpoint])
+            .replace('0x', ''),
+        isProxy: false,
+      });
+      return router.address;
+    }
+    assert(config.urls, `${chain} CCIP-read LayerZero router requires URLs`);
+    const router = await multiProvider.handleDeploy(
+      chain,
+      new LayerZeroV2CcipReadHookIsm__factory(),
+      [config.mailbox, config.endpoint, config.urls],
+    );
+    await contractVerifier?.verifyContract(chain, {
+      name: 'LayerZeroV2CcipReadHookIsm',
+      address: router.address,
+      constructorArguments:
+        LayerZeroV2CcipReadHookIsm__factory.createInterface()
+          .encodeDeploy([config.mailbox, config.endpoint, config.urls])
+          .replace('0x', ''),
+      isProxy: false,
+    });
+    return router.address;
+  }
+
+  private static async configureFreshRouter(
+    multiProvider: MultiProvider,
+    chain: ChainName,
+    address: Address,
+    config: LayerZeroV2HookIsmConfig,
+  ): Promise<void> {
+    const signer = multiProvider.getSigner(chain);
+    const router = LayerZeroV2CcipReadHookIsm__factory.connect(address, signer);
+    const overrides = multiProvider.getTransactionOverrides(chain);
+
+    for (const [remoteChain, remote] of Object.entries(config.remoteRouters)) {
+      const domain = multiProvider.getDomainId(remoteChain);
+      const enrollment = remoteEnrollment(domain, remote);
+      if (config.type === LayerZeroV2Variant.Callback) {
+        assert(
+          remote.callbackGasLimit !== undefined,
+          `${chain} -> ${remoteChain} requires callback gas`,
+        );
+        const callback = LayerZeroV2CallbackHookIsm__factory.connect(
+          address,
+          signer,
+        );
+        await multiProvider.handleTx(
+          chain,
+          await callback.enrollLayerZeroRemoteRouter(
+            enrollment,
+            remote.callbackGasLimit,
+            overrides,
+          ),
+        );
+      } else {
+        await multiProvider.handleTx(
+          chain,
+          await router.enrollLayerZeroRemoteRouter(enrollment, overrides),
+        );
+      }
+    }
+    if (!eqAddress(await router.owner(), config.owner)) {
+      await multiProvider.handleTx(
+        chain,
+        await router.transferOwnership(config.owner, overrides),
+      );
+    }
+  }
+}

--- a/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmReader.ts
+++ b/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmReader.ts
@@ -1,0 +1,179 @@
+import {
+  LayerZeroV2CallbackHookIsm__factory,
+  LayerZeroV2CcipReadHookIsm__factory,
+} from '@hyperlane-xyz/core';
+import { Address, bytes32ToAddress } from '@hyperlane-xyz/utils';
+import { Contract } from 'ethers';
+
+import { OnchainHookType } from '../hook/types.js';
+import { ModuleType } from '../ism/types.js';
+import { MultiProvider } from '../providers/MultiProvider.js';
+import { ChainNameOrId } from '../types.js';
+
+import {
+  DerivedLayerZeroV2HookIsmConfig,
+  LayerZeroV2RemoteRouterConfig,
+  LayerZeroV2Variant,
+} from './types.js';
+
+const ENDPOINT_READ_ABI = [
+  'function getSendLibrary(address,uint32) view returns (address)',
+  'function getReceiveLibrary(address,uint32) view returns (address,bool)',
+  'function receiveLibraryTimeout(address,uint32) view returns (address,uint256)',
+  'function delegates(address) view returns (address)',
+  'function getConfig(address,address,uint32,uint32) view returns (bytes)',
+];
+const LAYER_ZERO_V2_SEND_CONFIG_TYPES = [1, 2] as const;
+const LAYER_ZERO_V2_RECEIVE_CONFIG_TYPES = [2] as const;
+
+export class EvmLayerZeroV2HookIsmReader {
+  constructor(
+    protected readonly multiProvider: MultiProvider,
+    protected readonly chain: ChainNameOrId,
+  ) {}
+
+  async deriveVariant(address: Address): Promise<LayerZeroV2Variant> {
+    const router = LayerZeroV2CcipReadHookIsm__factory.connect(
+      address,
+      this.multiProvider.getProvider(this.chain),
+    );
+    const moduleType = await router.moduleType();
+    if (moduleType === ModuleType.NULL) return LayerZeroV2Variant.Callback;
+    if (moduleType === ModuleType.CCIP_READ) return LayerZeroV2Variant.CcipRead;
+    throw new Error(
+      `${address} on ${this.chain} reports module type ${moduleType}, not LayerZero`,
+    );
+  }
+
+  async deriveLayerZeroConfig(
+    address: Address,
+    knownVariant?: LayerZeroV2Variant,
+  ): Promise<DerivedLayerZeroV2HookIsmConfig> {
+    const provider = this.multiProvider.getProvider(this.chain);
+    const marker = LayerZeroV2CallbackHookIsm__factory.connect(
+      address,
+      provider,
+    );
+    if ((await marker.hookType()) !== OnchainHookType.LAYER_ZERO) {
+      throw new Error(
+        `${address} on ${this.chain} is not a supported LayerZero V2 hook/ISM`,
+      );
+    }
+    const variant = knownVariant ?? (await this.deriveVariant(address));
+    const router = LayerZeroV2CcipReadHookIsm__factory.connect(
+      address,
+      provider,
+    );
+    const [mailbox, endpointAddress, layerZeroDomainId, owner, domains] =
+      await Promise.all([
+        router.mailbox(),
+        router.endpoint(),
+        router.localEid(),
+        router.owner(),
+        router.domains(),
+      ]);
+    const endpoint = new Contract(endpointAddress, ENDPOINT_READ_ABI, provider);
+    const delegate = await endpoint.delegates(address);
+    if (delegate !== '0x0000000000000000000000000000000000000000') {
+      throw new Error(
+        `LayerZero hook/ISM ${address} on ${this.chain} has unexpected Endpoint delegate ${delegate}`,
+      );
+    }
+
+    const entries = await Promise.all(
+      domains.map(async (domainValue) => {
+        const domain = Number(domainValue);
+        const remoteEid = Number(await router.remoteConfigs(domain));
+        const [routerAddress, sendLibrary, receive, timeout] =
+          await Promise.all([
+            router.routers(domain),
+            endpoint.getSendLibrary(address, remoteEid),
+            endpoint.getReceiveLibrary(address, remoteEid),
+            endpoint.receiveLibraryTimeout(address, remoteEid),
+          ]);
+        const [sendConfig, receiveConfig] = await Promise.all([
+          this.deriveLibraryConfig(
+            endpoint,
+            address,
+            sendLibrary,
+            remoteEid,
+            LAYER_ZERO_V2_SEND_CONFIG_TYPES,
+          ),
+          this.deriveLibraryConfig(
+            endpoint,
+            address,
+            receive[0],
+            remoteEid,
+            LAYER_ZERO_V2_RECEIVE_CONFIG_TYPES,
+          ),
+        ]);
+        const chainName =
+          this.multiProvider.tryGetChainName(domain) ?? domain.toString();
+        const remote: LayerZeroV2RemoteRouterConfig = {
+          router: bytes32ToAddress(routerAddress),
+          layerZeroDomainId: remoteEid,
+          sendLibrary,
+          receiveLibrary: receive[0],
+          receiveLibraryGracePeriod: 0,
+          sendConfig,
+          receiveConfig,
+          ...(timeout[0] !== '0x0000000000000000000000000000000000000000'
+            ? {
+                receiveLibraryTimeout: {
+                  library: timeout[0],
+                  expiry: Number(timeout[1]),
+                },
+              }
+            : {}),
+          ...(variant === LayerZeroV2Variant.Callback
+            ? {
+                callbackGasLimit: (
+                  await LayerZeroV2CallbackHookIsm__factory.connect(
+                    address,
+                    provider,
+                  ).callbackGasLimits(domain)
+                ).toBigInt(),
+              }
+            : {}),
+        };
+        return [chainName, remote] as const;
+      }),
+    );
+
+    return {
+      address,
+      type: variant,
+      owner,
+      mailbox,
+      endpoint: endpointAddress,
+      layerZeroDomainId: Number(layerZeroDomainId),
+      ...(variant === LayerZeroV2Variant.CcipRead
+        ? { urls: await router.urls() }
+        : {}),
+      remoteRouters: Object.fromEntries(entries),
+    };
+  }
+
+  private async deriveLibraryConfig(
+    endpoint: Contract,
+    oapp: Address,
+    library: Address,
+    eid: number,
+    configTypes: readonly (1 | 2)[],
+  ): Promise<Array<{ configType: 1 | 2; config: string }>> {
+    const entries = await Promise.all(
+      configTypes.map(async (configType) => {
+        const config: string = await endpoint.getConfig(
+          oapp,
+          library,
+          eid,
+          configType,
+        );
+        return config === '0x' ? undefined : { configType, config };
+      }),
+    );
+    return entries.filter(
+      (entry): entry is { configType: 1 | 2; config: string } => !!entry,
+    );
+  }
+}

--- a/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmReader.ts
+++ b/typescript/sdk/src/layerzero/EvmLayerZeroV2HookIsmReader.ts
@@ -3,7 +3,7 @@ import {
   LayerZeroV2CcipReadHookIsm__factory,
 } from '@hyperlane-xyz/core';
 import { Address, bytes32ToAddress } from '@hyperlane-xyz/utils';
-import { Contract } from 'ethers';
+import { BigNumberish, Contract } from 'ethers';
 
 import { OnchainHookType } from '../hook/types.js';
 import { ModuleType } from '../ism/types.js';
@@ -15,6 +15,13 @@ import {
   LayerZeroV2RemoteRouterConfig,
   LayerZeroV2Variant,
 } from './types.js';
+import {
+  decodeLayerZeroV2AppExecutorConfig,
+  decodeLayerZeroV2AppUlnConfig,
+  decodeLayerZeroV2EffectiveExecutorConfig,
+  decodeLayerZeroV2EffectiveUlnConfig,
+  LayerZeroV2ConfigType,
+} from './configCodec.js';
 
 const ENDPOINT_READ_ABI = [
   'function getSendLibrary(address,uint32) view returns (address)',
@@ -23,8 +30,10 @@ const ENDPOINT_READ_ABI = [
   'function delegates(address) view returns (address)',
   'function getConfig(address,address,uint32,uint32) view returns (bytes)',
 ];
-const LAYER_ZERO_V2_SEND_CONFIG_TYPES = [1, 2] as const;
-const LAYER_ZERO_V2_RECEIVE_CONFIG_TYPES = [2] as const;
+const MESSAGE_LIBRARY_READ_ABI = [
+  'function executorConfigs(address,uint32) view returns (uint32 maxMessageSize,address executor)',
+  'function getAppUlnConfig(address,uint32) view returns (tuple(uint64 confirmations,uint8 requiredDVNCount,uint8 optionalDVNCount,uint8 optionalDVNThreshold,address[] requiredDVNs,address[] optionalDVNs))',
+];
 
 export class EvmLayerZeroV2HookIsmReader {
   constructor(
@@ -91,22 +100,13 @@ export class EvmLayerZeroV2HookIsmReader {
             endpoint.getReceiveLibrary(address, remoteEid),
             endpoint.receiveLibraryTimeout(address, remoteEid),
           ]);
-        const [sendConfig, receiveConfig] = await Promise.all([
-          this.deriveLibraryConfig(
-            endpoint,
-            address,
-            sendLibrary,
-            remoteEid,
-            LAYER_ZERO_V2_SEND_CONFIG_TYPES,
-          ),
-          this.deriveLibraryConfig(
-            endpoint,
-            address,
-            receive[0],
-            remoteEid,
-            LAYER_ZERO_V2_RECEIVE_CONFIG_TYPES,
-          ),
-        ]);
+        const configs = await this.deriveLibraryConfigs(
+          endpoint,
+          address,
+          sendLibrary,
+          receive[0],
+          remoteEid,
+        );
         const chainName =
           this.multiProvider.tryGetChainName(domain) ?? domain.toString();
         const remote: LayerZeroV2RemoteRouterConfig = {
@@ -115,8 +115,7 @@ export class EvmLayerZeroV2HookIsmReader {
           sendLibrary,
           receiveLibrary: receive[0],
           receiveLibraryGracePeriod: 0,
-          sendConfig,
-          receiveConfig,
+          ...configs,
           ...(timeout[0] !== '0x0000000000000000000000000000000000000000'
             ? {
                 receiveLibraryTimeout: {
@@ -154,26 +153,94 @@ export class EvmLayerZeroV2HookIsmReader {
     };
   }
 
-  private async deriveLibraryConfig(
+  private async deriveLibraryConfigs(
     endpoint: Contract,
     oapp: Address,
-    library: Address,
+    sendLibraryAddress: Address,
+    receiveLibraryAddress: Address,
     eid: number,
-    configTypes: readonly (1 | 2)[],
-  ): Promise<Array<{ configType: 1 | 2; config: string }>> {
-    const entries = await Promise.all(
-      configTypes.map(async (configType) => {
-        const config: string = await endpoint.getConfig(
-          oapp,
-          library,
-          eid,
-          configType,
-        );
-        return config === '0x' ? undefined : { configType, config };
-      }),
+  ): Promise<
+    Pick<
+      LayerZeroV2RemoteRouterConfig,
+      | 'sendConfig'
+      | 'receiveConfig'
+      | 'effectiveSendConfig'
+      | 'effectiveReceiveConfig'
+    >
+  > {
+    const provider = this.multiProvider.getProvider(this.chain);
+    const sendLibrary = new Contract(
+      sendLibraryAddress,
+      MESSAGE_LIBRARY_READ_ABI,
+      provider,
     );
-    return entries.filter(
-      (entry): entry is { configType: 1 | 2; config: string } => !!entry,
+    const receiveLibrary = new Contract(
+      receiveLibraryAddress,
+      MESSAGE_LIBRARY_READ_ABI,
+      provider,
     );
+    const [
+      appExecutor,
+      appSendUln,
+      appReceiveUln,
+      effectiveExecutor,
+      effectiveSendUln,
+      effectiveReceiveUln,
+    ] = await Promise.all([
+      sendLibrary.executorConfigs(oapp, eid),
+      sendLibrary.getAppUlnConfig(oapp, eid),
+      receiveLibrary.getAppUlnConfig(oapp, eid),
+      endpoint.getConfig(
+        oapp,
+        sendLibraryAddress,
+        eid,
+        LayerZeroV2ConfigType.Executor,
+      ),
+      endpoint.getConfig(
+        oapp,
+        sendLibraryAddress,
+        eid,
+        LayerZeroV2ConfigType.Uln,
+      ),
+      endpoint.getConfig(
+        oapp,
+        receiveLibraryAddress,
+        eid,
+        LayerZeroV2ConfigType.Uln,
+      ),
+    ]);
+    const appUlnConfig = (config: {
+      confirmations: BigNumberish;
+      requiredDVNCount: number;
+      optionalDVNCount: number;
+      optionalDVNThreshold: number;
+      requiredDVNs: Address[];
+      optionalDVNs: Address[];
+    }) =>
+      decodeLayerZeroV2AppUlnConfig(
+        config.confirmations,
+        config.requiredDVNCount,
+        config.optionalDVNCount,
+        config.optionalDVNThreshold,
+        config.requiredDVNs,
+        config.optionalDVNs,
+      );
+    return {
+      sendConfig: {
+        executor: decodeLayerZeroV2AppExecutorConfig(
+          Number(appExecutor.maxMessageSize),
+          appExecutor.executor,
+        ),
+        uln: appUlnConfig(appSendUln),
+      },
+      receiveConfig: { uln: appUlnConfig(appReceiveUln) },
+      effectiveSendConfig: {
+        executor: decodeLayerZeroV2EffectiveExecutorConfig(effectiveExecutor),
+        uln: decodeLayerZeroV2EffectiveUlnConfig(effectiveSendUln),
+      },
+      effectiveReceiveConfig: {
+        uln: decodeLayerZeroV2EffectiveUlnConfig(effectiveReceiveUln),
+      },
+    };
   }
 }

--- a/typescript/sdk/src/layerzero/config.test.ts
+++ b/typescript/sdk/src/layerzero/config.test.ts
@@ -1,0 +1,190 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+
+import { HookType } from '../hook/types.js';
+import { IsmType } from '../ism/types.js';
+
+import {
+  LayerZeroV2WarpChainConfig,
+  buildLayerZeroV2MeshConfig,
+  materializeLayerZeroV2WarpConfig,
+  pairLayerZeroV2Configs,
+} from './config.js';
+import { LayerZeroV2PathwaySchema, LayerZeroV2Variant } from './types.js';
+
+const address = () => ethers.Wallet.createRandom().address;
+
+function callbackConfig(): Record<string, LayerZeroV2WarpChainConfig> {
+  const endpointA = address();
+  const endpointB = address();
+  const libraryA = address();
+  const libraryB = address();
+  const owner = address();
+  return {
+    chainA: {
+      mailbox: address(),
+      hook: {
+        type: HookType.AGGREGATION,
+        hooks: [
+          { type: HookType.MAILBOX_DEFAULT },
+          {
+            type: HookType.LAYER_ZERO_V2_CALLBACK,
+            callbackGasLimits: { chainB: 250_000n },
+          },
+        ],
+      },
+      interchainSecurityModule: {
+        type: IsmType.LAYER_ZERO_V2_CALLBACK,
+        owner,
+        endpoint: endpointA,
+        layerZeroDomainId: 101,
+        pathways: {
+          chainB: {
+            layerZeroDomainId: 102,
+            sendLibrary: libraryA,
+            receiveLibrary: libraryA,
+            receiveLibraryGracePeriod: 0,
+            sendConfig: [],
+            receiveConfig: [],
+          },
+        },
+      },
+    },
+    chainB: {
+      mailbox: address(),
+      hook: {
+        type: HookType.LAYER_ZERO_V2_CALLBACK,
+        callbackGasLimits: { chainA: 300_000n },
+      },
+      interchainSecurityModule: {
+        type: IsmType.LAYER_ZERO_V2_CALLBACK,
+        owner,
+        endpoint: endpointB,
+        layerZeroDomainId: 102,
+        pathways: {
+          chainA: {
+            layerZeroDomainId: 101,
+            sendLibrary: libraryB,
+            receiveLibrary: libraryB,
+            receiveLibraryGracePeriod: 0,
+            sendConfig: [],
+            receiveConfig: [],
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('LayerZero V2 warp config', () => {
+  it('pairs callback leaves and builds the complete mesh', () => {
+    const config = callbackConfig();
+    const pairs = pairLayerZeroV2Configs(config);
+    const mesh = buildLayerZeroV2MeshConfig(config, pairs);
+    expect(Object.keys(pairs)).to.deep.equal(['chainA', 'chainB']);
+    expect(mesh.chainA.type).to.equal(LayerZeroV2Variant.Callback);
+    expect(mesh.chainA.remoteRouters.chainB.callbackGasLimit).to.equal(
+      250_000n,
+    );
+  });
+
+  it('replaces both tree leaves with one deployed address', () => {
+    const config = callbackConfig();
+    const deployed = address();
+    const result = materializeLayerZeroV2WarpConfig(config, {
+      chainA: deployed,
+    });
+    expect(result.chainA.interchainSecurityModule).to.equal(deployed);
+    const hook = result.chainA.hook;
+    expect(typeof hook).not.to.equal('string');
+    if (typeof hook !== 'string' && hook?.type === HookType.AGGREGATION) {
+      expect(hook.hooks).to.include(deployed);
+    }
+  });
+
+  it('rejects pull mode when nested in an aggregation ISM', () => {
+    const config = callbackConfig();
+    config.chainA.hook = { type: HookType.LAYER_ZERO_V2_CCIP_READ };
+    config.chainA.interchainSecurityModule = {
+      type: IsmType.AGGREGATION,
+      threshold: 1,
+      modules: [
+        {
+          type: IsmType.LAYER_ZERO_V2_CCIP_READ,
+          owner: address(),
+          endpoint: address(),
+          urls: ['https://example.com/layerzero'],
+          pathways: {
+            chainB: {
+              layerZeroDomainId: 102,
+              sendLibrary: address(),
+              receiveLibrary: address(),
+              receiveLibraryGracePeriod: 0,
+              sendConfig: [],
+              receiveConfig: [],
+            },
+          },
+        },
+      ],
+    };
+    expect(() => pairLayerZeroV2Configs(config)).to.throw(
+      'must be direct and standalone',
+    );
+  });
+
+  it('canonicalizes and validates Endpoint config types', () => {
+    const pathway = {
+      layerZeroDomainId: 102,
+      sendLibrary: address(),
+      receiveLibrary: address(),
+      receiveLibraryGracePeriod: 0,
+      sendConfig: [
+        { configType: 2, config: '0x1234' },
+        { configType: 1, config: '0xabcd' },
+      ],
+      receiveConfig: [],
+    };
+    const parsed = LayerZeroV2PathwaySchema.parse(pathway);
+    expect(parsed.sendConfig.map(({ configType }) => configType)).to.deep.equal(
+      [1, 2],
+    );
+    expect(() =>
+      LayerZeroV2PathwaySchema.parse({
+        ...pathway,
+        sendConfig: [
+          { configType: 2, config: '0x1234' },
+          { configType: 2, config: '0xabcd' },
+        ],
+      }),
+    ).to.throw('Duplicate LayerZero config type 2');
+    expect(() =>
+      LayerZeroV2PathwaySchema.parse({
+        ...pathway,
+        receiveConfig: [{ configType: 1, config: '0x1234' }],
+      }),
+    ).to.throw('receive config only supports ULN config type 2');
+    expect(() =>
+      LayerZeroV2PathwaySchema.parse({
+        ...pathway,
+        sendLibrary: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+      }),
+    ).to.throw('valid EVM address');
+    expect(() =>
+      LayerZeroV2PathwaySchema.parse({
+        ...pathway,
+        sendConfig: [{ configType: 1, config: '0x' }],
+      }),
+    ).to.throw();
+  });
+
+  it('materializes omitted pathway defaults', () => {
+    const parsed = LayerZeroV2PathwaySchema.parse({
+      layerZeroDomainId: 102,
+      sendLibrary: address(),
+      receiveLibrary: address(),
+    });
+    expect(parsed.receiveLibraryGracePeriod).to.equal(0);
+    expect(parsed.sendConfig).to.deep.equal([]);
+    expect(parsed.receiveConfig).to.deep.equal([]);
+  });
+});

--- a/typescript/sdk/src/layerzero/config.test.ts
+++ b/typescript/sdk/src/layerzero/config.test.ts
@@ -10,9 +10,21 @@ import {
   materializeLayerZeroV2WarpConfig,
   pairLayerZeroV2Configs,
 } from './config.js';
-import { LayerZeroV2PathwaySchema, LayerZeroV2Variant } from './types.js';
+import {
+  LayerZeroV2ConfigMode,
+  LayerZeroV2PathwaySchema,
+  LayerZeroV2Variant,
+} from './types.js';
 
 const address = () => ethers.Wallet.createRandom().address;
+
+const defaultSendConfig = () => ({
+  executor: { type: LayerZeroV2ConfigMode.Default },
+  uln: { type: LayerZeroV2ConfigMode.Default },
+});
+const defaultReceiveConfig = () => ({
+  uln: { type: LayerZeroV2ConfigMode.Default },
+});
 
 function callbackConfig(): Record<string, LayerZeroV2WarpChainConfig> {
   const endpointA = address();
@@ -44,8 +56,8 @@ function callbackConfig(): Record<string, LayerZeroV2WarpChainConfig> {
             sendLibrary: libraryA,
             receiveLibrary: libraryA,
             receiveLibraryGracePeriod: 0,
-            sendConfig: [],
-            receiveConfig: [],
+            sendConfig: defaultSendConfig(),
+            receiveConfig: defaultReceiveConfig(),
           },
         },
       },
@@ -67,8 +79,8 @@ function callbackConfig(): Record<string, LayerZeroV2WarpChainConfig> {
             sendLibrary: libraryB,
             receiveLibrary: libraryB,
             receiveLibraryGracePeriod: 0,
-            sendConfig: [],
-            receiveConfig: [],
+            sendConfig: defaultSendConfig(),
+            receiveConfig: defaultReceiveConfig(),
           },
         },
       },
@@ -120,8 +132,8 @@ describe('LayerZero V2 warp config', () => {
               sendLibrary: address(),
               receiveLibrary: address(),
               receiveLibraryGracePeriod: 0,
-              sendConfig: [],
-              receiveConfig: [],
+              sendConfig: defaultSendConfig(),
+              receiveConfig: defaultReceiveConfig(),
             },
           },
         },
@@ -132,37 +144,79 @@ describe('LayerZero V2 warp config', () => {
     );
   });
 
-  it('canonicalizes and validates Endpoint config types', () => {
+  it('canonicalizes and validates typed overrides', () => {
+    const lowerDvn = '0x0000000000000000000000000000000000000001';
+    const higherDvn = '0x0000000000000000000000000000000000000002';
     const pathway = {
       layerZeroDomainId: 102,
       sendLibrary: address(),
       receiveLibrary: address(),
       receiveLibraryGracePeriod: 0,
-      sendConfig: [
-        { configType: 2, config: '0x1234' },
-        { configType: 1, config: '0xabcd' },
-      ],
-      receiveConfig: [],
+      sendConfig: {
+        executor: {
+          type: LayerZeroV2ConfigMode.Override,
+          maxMessageSize: 20_000,
+        },
+        uln: {
+          type: LayerZeroV2ConfigMode.Override,
+          confirmations: 12,
+          requiredDVNs: [higherDvn, lowerDvn],
+          optionalDVNs: [],
+        },
+      },
+      receiveConfig: defaultReceiveConfig(),
     };
     const parsed = LayerZeroV2PathwaySchema.parse(pathway);
-    expect(parsed.sendConfig.map(({ configType }) => configType)).to.deep.equal(
-      [1, 2],
-    );
+    expect(parsed.sendConfig.uln).to.include({
+      type: LayerZeroV2ConfigMode.Override,
+      confirmations: 12n,
+    });
+    expect(
+      parsed.sendConfig.uln.type === LayerZeroV2ConfigMode.Override
+        ? parsed.sendConfig.uln.requiredDVNs
+        : undefined,
+    ).to.deep.equal([lowerDvn, higherDvn]);
+    expect(
+      parsed.sendConfig.uln.type === LayerZeroV2ConfigMode.Override
+        ? parsed.sendConfig.uln.optionalDVNThreshold
+        : undefined,
+    ).to.equal(0);
     expect(() =>
       LayerZeroV2PathwaySchema.parse({
         ...pathway,
-        sendConfig: [
-          { configType: 2, config: '0x1234' },
-          { configType: 2, config: '0xabcd' },
-        ],
+        sendConfig: {
+          ...pathway.sendConfig,
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            requiredDVNs: [lowerDvn, lowerDvn],
+          },
+        },
       }),
-    ).to.throw('Duplicate LayerZero config type 2');
+    ).to.throw('Duplicate LayerZero DVN');
     expect(() =>
       LayerZeroV2PathwaySchema.parse({
         ...pathway,
-        receiveConfig: [{ configType: 1, config: '0x1234' }],
+        receiveConfig: {
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            optionalDVNs: [lowerDvn],
+            optionalDVNThreshold: 2,
+          },
+        },
       }),
-    ).to.throw('receive config only supports ULN config type 2');
+    ).to.throw('between 1 and the DVN count');
+    expect(() =>
+      LayerZeroV2PathwaySchema.parse({
+        ...pathway,
+        receiveConfig: {
+          uln: {
+            type: LayerZeroV2ConfigMode.Override,
+            requiredDVNs: [],
+            optionalDVNs: [],
+          },
+        },
+      }),
+    ).to.throw('retain at least one DVN');
     expect(() =>
       LayerZeroV2PathwaySchema.parse({
         ...pathway,
@@ -172,9 +226,27 @@ describe('LayerZero V2 warp config', () => {
     expect(() =>
       LayerZeroV2PathwaySchema.parse({
         ...pathway,
-        sendConfig: [{ configType: 1, config: '0x' }],
+        sendConfig: {
+          ...pathway.sendConfig,
+          executor: {
+            type: LayerZeroV2ConfigMode.Override,
+            executor: ethers.constants.AddressZero,
+          },
+        },
       }),
-    ).to.throw();
+    ).to.throw('nonzero EVM address');
+    expect(() =>
+      LayerZeroV2PathwaySchema.parse({
+        ...pathway,
+        sendConfig: {
+          ...pathway.sendConfig,
+          executor: {
+            type: LayerZeroV2ConfigMode.Default,
+            maxMessageSize: 20_000,
+          },
+        },
+      }),
+    ).to.throw('Unrecognized key');
   });
 
   it('materializes omitted pathway defaults', () => {
@@ -184,7 +256,7 @@ describe('LayerZero V2 warp config', () => {
       receiveLibrary: address(),
     });
     expect(parsed.receiveLibraryGracePeriod).to.equal(0);
-    expect(parsed.sendConfig).to.deep.equal([]);
-    expect(parsed.receiveConfig).to.deep.equal([]);
+    expect(parsed.sendConfig).to.deep.equal(defaultSendConfig());
+    expect(parsed.receiveConfig).to.deep.equal(defaultReceiveConfig());
   });
 });

--- a/typescript/sdk/src/layerzero/config.ts
+++ b/typescript/sdk/src/layerzero/config.ts
@@ -1,0 +1,366 @@
+import { constants } from 'ethers';
+
+import { Address, assert } from '@hyperlane-xyz/utils';
+
+import { HookConfig, HookType, LayerZeroV2HookConfig } from '../hook/types.js';
+import { collectHookTreeNodes, mapHookTreeNodes } from '../hook/utils.js';
+import { IsmConfig, IsmType, LayerZeroV2IsmConfig } from '../ism/types.js';
+import { ChainMap } from '../types.js';
+import { collectIsmTreeNodes, mapIsmTreeNodes } from '../utils/ism.js';
+
+import {
+  LayerZeroV2HookIsmConfig,
+  LayerZeroV2MeshConfig,
+  LayerZeroV2Variant,
+} from './types.js';
+
+export interface LayerZeroV2WarpChainConfig {
+  hook?: HookConfig;
+  interchainSecurityModule?: IsmConfig;
+  mailbox?: Address;
+}
+
+export interface LayerZeroV2ConfigPair {
+  hook: LayerZeroV2HookConfig;
+  ism: LayerZeroV2IsmConfig;
+  variant: LayerZeroV2Variant;
+}
+
+export function isLayerZeroV2Hook(
+  config: HookConfig | undefined,
+): config is LayerZeroV2HookConfig {
+  return (
+    !!config &&
+    typeof config !== 'string' &&
+    (config.type === HookType.LAYER_ZERO_V2_CALLBACK ||
+      config.type === HookType.LAYER_ZERO_V2_CCIP_READ)
+  );
+}
+
+export function isLayerZeroV2Ism(
+  config: IsmConfig,
+): config is LayerZeroV2IsmConfig {
+  return (
+    typeof config !== 'string' &&
+    (config.type === IsmType.LAYER_ZERO_V2_CALLBACK ||
+      config.type === IsmType.LAYER_ZERO_V2_CCIP_READ)
+  );
+}
+
+export function findLayerZeroV2Hooks(
+  config: HookConfig | undefined,
+): LayerZeroV2HookConfig[] {
+  return collectHookTreeNodes(config, isLayerZeroV2Hook);
+}
+
+export function findLayerZeroV2Isms(
+  config: IsmConfig | undefined,
+): LayerZeroV2IsmConfig[] {
+  return collectIsmTreeNodes(config, isLayerZeroV2Ism);
+}
+
+export function collectHookAddresses(
+  config: HookConfig | undefined,
+): Address[] {
+  if (!config) return [];
+  if (typeof config === 'string') return [config];
+  const own =
+    'address' in config && typeof config.address === 'string'
+      ? [config.address]
+      : [];
+  switch (config.type) {
+    case HookType.AGGREGATION:
+      return [...own, ...config.hooks.flatMap(collectHookAddresses)];
+    case HookType.ROUTING:
+      return [
+        ...own,
+        ...Object.values(config.domains).flatMap(collectHookAddresses),
+      ];
+    case HookType.FALLBACK_ROUTING:
+      return [
+        ...own,
+        ...Object.values(config.domains).flatMap(collectHookAddresses),
+        ...collectHookAddresses(config.fallback),
+      ];
+    case HookType.AMOUNT_ROUTING:
+      return [
+        ...own,
+        ...collectHookAddresses(config.lowerHook),
+        ...collectHookAddresses(config.upperHook),
+      ];
+    case HookType.ARB_L2_TO_L1:
+      return [...own, ...collectHookAddresses(config.childHook)];
+    default:
+      return own;
+  }
+}
+
+export function collectIsmAddresses(config: IsmConfig | undefined): Address[] {
+  if (!config) return [];
+  if (typeof config === 'string') return [config];
+  const own =
+    'address' in config && typeof config.address === 'string'
+      ? [config.address]
+      : [];
+  switch (config.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return [...own, ...config.modules.flatMap(collectIsmAddresses)];
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return [
+        ...own,
+        ...Object.values(config.domains).flatMap(collectIsmAddresses),
+      ];
+    case IsmType.AMOUNT_ROUTING:
+      return [
+        ...own,
+        ...collectIsmAddresses(config.lowerIsm),
+        ...collectIsmAddresses(config.upperIsm),
+      ];
+    default:
+      return own;
+  }
+}
+
+function hookVariant(hook: LayerZeroV2HookConfig): LayerZeroV2Variant {
+  return hook.type === HookType.LAYER_ZERO_V2_CALLBACK
+    ? LayerZeroV2Variant.Callback
+    : LayerZeroV2Variant.CcipRead;
+}
+
+function ismVariant(ism: LayerZeroV2IsmConfig): LayerZeroV2Variant {
+  return ism.type === IsmType.LAYER_ZERO_V2_CALLBACK
+    ? LayerZeroV2Variant.Callback
+    : LayerZeroV2Variant.CcipRead;
+}
+
+function hookUsesLayerZeroFor(
+  config: HookConfig | undefined,
+  destination: string,
+): boolean {
+  if (!config || typeof config === 'string') return false;
+  if (isLayerZeroV2Hook(config)) return true;
+  switch (config.type) {
+    case HookType.AGGREGATION:
+      return config.hooks.some((hook) =>
+        hookUsesLayerZeroFor(hook, destination),
+      );
+    case HookType.ROUTING:
+      return hookUsesLayerZeroFor(config.domains[destination], destination);
+    case HookType.FALLBACK_ROUTING:
+      return hookUsesLayerZeroFor(
+        config.domains[destination] ?? config.fallback,
+        destination,
+      );
+    case HookType.AMOUNT_ROUTING: {
+      const lower = hookUsesLayerZeroFor(config.lowerHook, destination);
+      const upper = hookUsesLayerZeroFor(config.upperHook, destination);
+      assert(
+        lower === upper,
+        `LayerZero cannot be conditional on amount for destination ${destination}`,
+      );
+      return lower;
+    }
+    case HookType.ARB_L2_TO_L1:
+      return (
+        config.destinationChain === destination &&
+        hookUsesLayerZeroFor(config.childHook, destination)
+      );
+    default:
+      return false;
+  }
+}
+
+function ismUsesLayerZeroFor(
+  config: IsmConfig | undefined,
+  origin: string,
+): boolean {
+  if (!config || typeof config === 'string') return false;
+  if (isLayerZeroV2Ism(config)) return true;
+  switch (config.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return config.modules.some((ism) => ismUsesLayerZeroFor(ism, origin));
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return ismUsesLayerZeroFor(config.domains[origin], origin);
+    case IsmType.AMOUNT_ROUTING: {
+      const lower = ismUsesLayerZeroFor(config.lowerIsm, origin);
+      const upper = ismUsesLayerZeroFor(config.upperIsm, origin);
+      assert(
+        lower === upper,
+        `LayerZero cannot be conditional on amount for origin ${origin}`,
+      );
+      return lower;
+    }
+    default:
+      return false;
+  }
+}
+
+function validateDirectionalPairing(
+  configs: ChainMap<LayerZeroV2WarpChainConfig>,
+): void {
+  const chains = Object.keys(configs);
+  for (const origin of chains) {
+    for (const destination of chains) {
+      if (origin === destination) continue;
+      const hookUses = hookUsesLayerZeroFor(configs[origin].hook, destination);
+      const ismUses = ismUsesLayerZeroFor(
+        configs[destination].interchainSecurityModule,
+        origin,
+      );
+      assert(
+        hookUses === ismUses,
+        `LayerZero pairing mismatch for ${origin} -> ${destination}: origin hook=${hookUses}, destination ISM=${ismUses}`,
+      );
+    }
+  }
+}
+
+export function pairLayerZeroV2Configs(
+  configs: ChainMap<LayerZeroV2WarpChainConfig>,
+): ChainMap<LayerZeroV2ConfigPair> {
+  const pairs: ChainMap<LayerZeroV2ConfigPair> = {};
+  const hasAny = Object.values(configs).some(
+    (config) =>
+      findLayerZeroV2Hooks(config.hook).length > 0 ||
+      findLayerZeroV2Isms(config.interchainSecurityModule).length > 0,
+  );
+  if (!hasAny) return pairs;
+
+  let meshVariant: LayerZeroV2Variant | undefined;
+  for (const [chain, config] of Object.entries(configs)) {
+    const hooks = findLayerZeroV2Hooks(config.hook);
+    const isms = findLayerZeroV2Isms(config.interchainSecurityModule);
+    assert(
+      hooks.length === 1,
+      `${chain} must contain exactly one LayerZero hook leaf; found ${hooks.length}`,
+    );
+    assert(
+      isms.length === 1,
+      `${chain} must contain exactly one LayerZero ISM leaf; found ${isms.length}`,
+    );
+    const localHookVariant = hookVariant(hooks[0]);
+    const localIsmVariant = ismVariant(isms[0]);
+    assert(
+      localHookVariant === localIsmVariant,
+      `${chain} LayerZero hook is ${localHookVariant} but ISM is ${localIsmVariant}`,
+    );
+    if (localIsmVariant === LayerZeroV2Variant.CcipRead) {
+      assert(
+        config.interchainSecurityModule === isms[0],
+        `${chain} LayerZero CCIP-read ISM must be direct and standalone`,
+      );
+    }
+    meshVariant ??= localHookVariant;
+    assert(
+      meshVariant === localHookVariant,
+      `${chain} uses ${localHookVariant}; mesh already uses ${meshVariant}`,
+    );
+    pairs[chain] = {
+      hook: hooks[0],
+      ism: isms[0],
+      variant: localHookVariant,
+    };
+  }
+  validateDirectionalPairing(configs);
+  return pairs;
+}
+
+export function buildLayerZeroV2MeshConfig(
+  configs: ChainMap<LayerZeroV2WarpChainConfig>,
+  pairs: ChainMap<LayerZeroV2ConfigPair>,
+): LayerZeroV2MeshConfig {
+  const chains = Object.keys(pairs);
+  return Object.fromEntries(
+    chains.map((chain) => {
+      const local = pairs[chain];
+      const mailbox = configs[chain].mailbox;
+      assert(mailbox, `${chain} requires a mailbox for LayerZero deployment`);
+      const remoteRouters = Object.fromEntries(
+        chains
+          .filter((remote) => remote !== chain)
+          .map((remote) => {
+            const pathway = local.ism.pathways[remote];
+            assert(pathway, `${chain} has no LayerZero pathway for ${remote}`);
+            const callbackGasLimit =
+              local.hook.type === HookType.LAYER_ZERO_V2_CALLBACK
+                ? local.hook.callbackGasLimits[remote]
+                : undefined;
+            if (local.variant === LayerZeroV2Variant.Callback) {
+              assert(
+                callbackGasLimit !== undefined,
+                `${chain} has no callback gas limit for ${remote}`,
+              );
+            }
+            return [
+              remote,
+              {
+                ...pathway,
+                router: constants.AddressZero,
+                callbackGasLimit,
+              },
+            ];
+          }),
+      );
+      const config: LayerZeroV2HookIsmConfig = {
+        type: local.variant,
+        owner: local.ism.owner,
+        mailbox,
+        endpoint: local.ism.endpoint,
+        layerZeroDomainId: local.ism.layerZeroDomainId,
+        urls:
+          local.ism.type === IsmType.LAYER_ZERO_V2_CCIP_READ
+            ? local.ism.urls
+            : undefined,
+        remoteRouters,
+      };
+      return [chain, config];
+    }),
+  );
+}
+
+export function replaceLayerZeroV2Hook(
+  config: HookConfig,
+  address: Address,
+): HookConfig {
+  return mapHookTreeNodes(config, isLayerZeroV2Hook, () => address);
+}
+
+export function replaceLayerZeroV2Ism(
+  config: IsmConfig,
+  address: Address,
+): IsmConfig {
+  return mapIsmTreeNodes(config, isLayerZeroV2Ism, () => address);
+}
+
+export function materializeLayerZeroV2WarpConfig<
+  T extends ChainMap<LayerZeroV2WarpChainConfig>,
+>(configs: T, addresses: ChainMap<Address>): T {
+  return Object.fromEntries(
+    Object.entries(configs).map(([chain, config]) => {
+      const address = addresses[chain];
+      if (!address) return [chain, config];
+      assert(config.hook, `${chain} is missing its LayerZero hook tree`);
+      assert(
+        config.interchainSecurityModule,
+        `${chain} is missing its LayerZero ISM tree`,
+      );
+      return [
+        chain,
+        {
+          ...config,
+          hook: replaceLayerZeroV2Hook(config.hook, address),
+          interchainSecurityModule: replaceLayerZeroV2Ism(
+            config.interchainSecurityModule,
+            address,
+          ),
+        },
+      ];
+    }),
+  ) as T;
+}

--- a/typescript/sdk/src/layerzero/configCodec.test.ts
+++ b/typescript/sdk/src/layerzero/configCodec.test.ts
@@ -1,0 +1,188 @@
+import { expect } from 'chai';
+import { BigNumber, constants, utils } from 'ethers';
+
+import {
+  decodeLayerZeroV2AppExecutorConfig,
+  decodeLayerZeroV2AppUlnConfig,
+  decodeLayerZeroV2EffectiveExecutorConfig,
+  decodeLayerZeroV2EffectiveUlnConfig,
+  encodeLayerZeroV2ExecutorConfig,
+  encodeLayerZeroV2UlnConfig,
+  layerZeroV2ReceiveConfigParams,
+  layerZeroV2SendConfigParams,
+} from './configCodec.js';
+import { LayerZeroV2ConfigMode } from './types.js';
+
+const EXECUTOR_CONFIG_TYPE =
+  'tuple(uint32 maxMessageSize,address executor)' as const;
+const ULN_CONFIG_TYPE =
+  'tuple(uint64 confirmations,uint8 requiredDVNCount,uint8 optionalDVNCount,uint8 optionalDVNThreshold,address[] requiredDVNs,address[] optionalDVNs)' as const;
+const executor = '0x0000000000000000000000000000000000000001';
+const dvnA = '0x0000000000000000000000000000000000000002';
+const dvnB = '0x0000000000000000000000000000000000000003';
+
+function decodeAppUln(encoded: string) {
+  const [config] = utils.defaultAbiCoder.decode([ULN_CONFIG_TYPE], encoded);
+  return decodeLayerZeroV2AppUlnConfig(
+    config.confirmations,
+    config.requiredDVNCount,
+    config.optionalDVNCount,
+    config.optionalDVNThreshold,
+    config.requiredDVNs,
+    config.optionalDVNs,
+  );
+}
+
+describe('LayerZero V2 config codec', () => {
+  it('round-trips default and partial executor configs', () => {
+    const defaultEncoded = encodeLayerZeroV2ExecutorConfig({
+      type: LayerZeroV2ConfigMode.Default,
+    });
+    const [defaultConfig] = utils.defaultAbiCoder.decode(
+      [EXECUTOR_CONFIG_TYPE],
+      defaultEncoded,
+    );
+    expect(
+      decodeLayerZeroV2AppExecutorConfig(
+        Number(defaultConfig.maxMessageSize),
+        defaultConfig.executor,
+      ),
+    ).to.deep.equal({ type: LayerZeroV2ConfigMode.Default });
+
+    const override = {
+      type: LayerZeroV2ConfigMode.Override,
+      executor,
+    } as const;
+    const [encodedOverride] = utils.defaultAbiCoder.decode(
+      [EXECUTOR_CONFIG_TYPE],
+      encodeLayerZeroV2ExecutorConfig(override),
+    );
+    expect(
+      decodeLayerZeroV2AppExecutorConfig(
+        Number(encodedOverride.maxMessageSize),
+        encodedOverride.executor,
+      ),
+    ).to.deep.equal(override);
+  });
+
+  it('round-trips inherited, literal-zero, and explicit-empty ULN fields', () => {
+    expect(
+      decodeAppUln(
+        encodeLayerZeroV2UlnConfig({
+          type: LayerZeroV2ConfigMode.Default,
+        }),
+      ),
+    ).to.deep.equal({ type: LayerZeroV2ConfigMode.Default });
+
+    const override = {
+      type: 'override' as const,
+      confirmations: 0n,
+      requiredDVNs: [],
+      optionalDVNs: [dvnA, dvnB],
+      optionalDVNThreshold: 1,
+    };
+    expect(decodeAppUln(encodeLayerZeroV2UlnConfig(override))).to.deep.equal(
+      override,
+    );
+
+    const [encoded] = utils.defaultAbiCoder.decode(
+      [ULN_CONFIG_TYPE],
+      encodeLayerZeroV2UlnConfig(override),
+    );
+    expect(encoded.confirmations).to.deep.equal(
+      BigNumber.from(2).pow(64).sub(1),
+    );
+    expect(encoded.requiredDVNCount).to.equal(255);
+
+    const largeConfirmations = (1n << 64n) - 2n;
+    expect(
+      decodeAppUln(
+        encodeLayerZeroV2UlnConfig({
+          type: LayerZeroV2ConfigMode.Override,
+          confirmations: largeConfirmations,
+        }),
+      ),
+    ).to.deep.equal({
+      type: LayerZeroV2ConfigMode.Override,
+      confirmations: largeConfirmations,
+    });
+  });
+
+  it('decodes effective values separately from app overrides', () => {
+    const effectiveExecutor = utils.defaultAbiCoder.encode(
+      [EXECUTOR_CONFIG_TYPE],
+      [{ maxMessageSize: 10_000, executor }],
+    );
+    expect(
+      decodeLayerZeroV2EffectiveExecutorConfig(effectiveExecutor),
+    ).to.deep.equal({ maxMessageSize: 10_000, executor });
+
+    const effectiveUln = utils.defaultAbiCoder.encode(
+      [ULN_CONFIG_TYPE],
+      [
+        {
+          confirmations: 12,
+          requiredDVNCount: 1,
+          optionalDVNCount: 1,
+          optionalDVNThreshold: 1,
+          requiredDVNs: [dvnA],
+          optionalDVNs: [dvnB],
+        },
+      ],
+    );
+    expect(decodeLayerZeroV2EffectiveUlnConfig(effectiveUln)).to.deep.equal({
+      confirmations: 12n,
+      requiredDVNs: [dvnA],
+      optionalDVNs: [dvnB],
+      optionalDVNThreshold: 1,
+    });
+  });
+
+  it('omits inherited configs from enrollment params', () => {
+    expect(
+      layerZeroV2SendConfigParams({
+        executor: { type: LayerZeroV2ConfigMode.Default },
+        uln: { type: LayerZeroV2ConfigMode.Default },
+      }),
+    ).to.deep.equal([]);
+    expect(
+      layerZeroV2ReceiveConfigParams({
+        uln: { type: LayerZeroV2ConfigMode.Default },
+      }),
+    ).to.deep.equal([]);
+  });
+
+  it('rejects malformed raw app config', () => {
+    expect(() =>
+      decodeLayerZeroV2AppUlnConfig(12, 2, 0, 0, [dvnA], []),
+    ).to.throw('does not match');
+    expect(() => decodeLayerZeroV2AppUlnConfig(0, 0, 0, 1, [], [])).to.throw(
+      'must be 0',
+    );
+    expect(() =>
+      decodeLayerZeroV2AppUlnConfig(0, 0, 0, 0, [dvnA], []),
+    ).to.throw('uses DEFAULT');
+    expect(() =>
+      decodeLayerZeroV2AppExecutorConfig(0, constants.AddressZero),
+    ).not.to.throw();
+  });
+
+  it('rejects malformed effective ULN config', () => {
+    const malformed = utils.defaultAbiCoder.encode(
+      [ULN_CONFIG_TYPE],
+      [
+        {
+          confirmations: 12,
+          requiredDVNCount: 2,
+          optionalDVNCount: 0,
+          optionalDVNThreshold: 0,
+          requiredDVNs: [dvnA],
+          optionalDVNs: [],
+        },
+      ],
+    );
+    expect(() => decodeLayerZeroV2EffectiveUlnConfig(malformed)).to.throw(
+      'does not match',
+    );
+  });
+});

--- a/typescript/sdk/src/layerzero/configCodec.ts
+++ b/typescript/sdk/src/layerzero/configCodec.ts
@@ -1,0 +1,268 @@
+import { BigNumber, BigNumberish, constants, utils } from 'ethers';
+
+import { Address } from '@hyperlane-xyz/utils';
+
+import {
+  LayerZeroV2ConfigMode,
+  LayerZeroV2EffectiveExecutorConfig,
+  LayerZeroV2EffectiveExecutorConfigSchema,
+  LayerZeroV2EffectiveUlnConfig,
+  LayerZeroV2EffectiveUlnConfigSchema,
+  LayerZeroV2ExecutorConfig,
+  LayerZeroV2ExecutorConfigSchema,
+  LayerZeroV2ReceiveConfig,
+  LayerZeroV2SendConfig,
+  LayerZeroV2UlnConfig,
+  LayerZeroV2UlnConfigSchema,
+} from './types.js';
+
+export const LayerZeroV2ConfigType = {
+  Executor: 1,
+  Uln: 2,
+} as const;
+
+const DEFAULT_VALUE = 0;
+const NIL_DVN_COUNT = 0xff;
+const NIL_CONFIRMATIONS = BigNumber.from(2).pow(64).sub(1);
+const EXECUTOR_CONFIG_TYPE =
+  'tuple(uint32 maxMessageSize,address executor)' as const;
+const ULN_CONFIG_TYPE =
+  'tuple(uint64 confirmations,uint8 requiredDVNCount,uint8 optionalDVNCount,uint8 optionalDVNThreshold,address[] requiredDVNs,address[] optionalDVNs)' as const;
+
+function decodeCount(
+  count: number,
+  dvns: Address[],
+  label: string,
+): Address[] | undefined {
+  if (count === DEFAULT_VALUE) {
+    if (dvns.length !== 0) {
+      throw new Error(`${label} uses DEFAULT but contains DVNs`);
+    }
+    return undefined;
+  }
+  if (count === NIL_DVN_COUNT) {
+    if (dvns.length !== 0) {
+      throw new Error(`${label} uses NONE but contains DVNs`);
+    }
+    return [];
+  }
+  if (count !== dvns.length) {
+    throw new Error(
+      `${label} count ${count} does not match ${dvns.length} DVNs`,
+    );
+  }
+  return dvns;
+}
+
+export function encodeLayerZeroV2ExecutorConfig(
+  input: LayerZeroV2ExecutorConfig,
+): string {
+  const config = LayerZeroV2ExecutorConfigSchema.parse(input);
+  return utils.defaultAbiCoder.encode(
+    [EXECUTOR_CONFIG_TYPE],
+    [
+      {
+        maxMessageSize:
+          config.type === LayerZeroV2ConfigMode.Override
+            ? (config.maxMessageSize ?? DEFAULT_VALUE)
+            : DEFAULT_VALUE,
+        executor:
+          config.type === LayerZeroV2ConfigMode.Override
+            ? (config.executor ?? constants.AddressZero)
+            : constants.AddressZero,
+      },
+    ],
+  );
+}
+
+export function decodeLayerZeroV2AppExecutorConfig(
+  maxMessageSize: number,
+  executor: Address,
+): LayerZeroV2ExecutorConfig {
+  if (maxMessageSize === DEFAULT_VALUE && executor === constants.AddressZero) {
+    return { type: LayerZeroV2ConfigMode.Default };
+  }
+  return LayerZeroV2ExecutorConfigSchema.parse({
+    type: LayerZeroV2ConfigMode.Override,
+    ...(maxMessageSize !== DEFAULT_VALUE ? { maxMessageSize } : {}),
+    ...(executor !== constants.AddressZero ? { executor } : {}),
+  });
+}
+
+export function decodeLayerZeroV2EffectiveExecutorConfig(
+  encoded: string,
+): LayerZeroV2EffectiveExecutorConfig {
+  const [config] = utils.defaultAbiCoder.decode(
+    [EXECUTOR_CONFIG_TYPE],
+    encoded,
+  );
+  return LayerZeroV2EffectiveExecutorConfigSchema.parse({
+    maxMessageSize: Number(config.maxMessageSize),
+    executor: config.executor,
+  });
+}
+
+export function encodeLayerZeroV2UlnConfig(
+  input: LayerZeroV2UlnConfig,
+): string {
+  const config = LayerZeroV2UlnConfigSchema.parse(input);
+  const isOverride = config.type === LayerZeroV2ConfigMode.Override;
+  const requiredDVNs = isOverride ? config.requiredDVNs : undefined;
+  const optionalDVNs = isOverride ? config.optionalDVNs : undefined;
+  const confirmations = isOverride ? config.confirmations : undefined;
+  const optionalDVNThreshold = isOverride
+    ? config.optionalDVNThreshold
+    : undefined;
+  return utils.defaultAbiCoder.encode(
+    [ULN_CONFIG_TYPE],
+    [
+      {
+        confirmations:
+          confirmations === undefined
+            ? DEFAULT_VALUE
+            : confirmations === 0n
+              ? NIL_CONFIRMATIONS
+              : confirmations,
+        requiredDVNCount:
+          requiredDVNs === undefined
+            ? DEFAULT_VALUE
+            : requiredDVNs.length === 0
+              ? NIL_DVN_COUNT
+              : requiredDVNs.length,
+        optionalDVNCount:
+          optionalDVNs === undefined
+            ? DEFAULT_VALUE
+            : optionalDVNs.length === 0
+              ? NIL_DVN_COUNT
+              : optionalDVNs.length,
+        optionalDVNThreshold:
+          optionalDVNs === undefined || optionalDVNs.length === 0
+            ? 0
+            : optionalDVNThreshold,
+        requiredDVNs: requiredDVNs ?? [],
+        optionalDVNs: optionalDVNs ?? [],
+      },
+    ],
+  );
+}
+
+export function decodeLayerZeroV2AppUlnConfig(
+  confirmationsInput: BigNumberish,
+  requiredDVNCount: number,
+  optionalDVNCount: number,
+  optionalDVNThreshold: number,
+  requiredDVNsInput: Address[],
+  optionalDVNsInput: Address[],
+): LayerZeroV2UlnConfig {
+  const confirmations = BigNumber.from(confirmationsInput);
+  const requiredDVNs = decodeCount(
+    requiredDVNCount,
+    requiredDVNsInput,
+    'requiredDVNs',
+  );
+  const optionalDVNs = decodeCount(
+    optionalDVNCount,
+    optionalDVNsInput,
+    'optionalDVNs',
+  );
+  if (
+    (optionalDVNCount === DEFAULT_VALUE ||
+      optionalDVNCount === NIL_DVN_COUNT) &&
+    optionalDVNThreshold !== 0
+  ) {
+    throw new Error(
+      'optionalDVNThreshold must be 0 when optional DVNs use DEFAULT or NONE',
+    );
+  }
+  if (
+    confirmations.eq(DEFAULT_VALUE) &&
+    requiredDVNs === undefined &&
+    optionalDVNs === undefined
+  ) {
+    return { type: LayerZeroV2ConfigMode.Default };
+  }
+  return LayerZeroV2UlnConfigSchema.parse({
+    type: LayerZeroV2ConfigMode.Override,
+    ...(!confirmations.eq(DEFAULT_VALUE)
+      ? {
+          confirmations: confirmations.eq(NIL_CONFIRMATIONS)
+            ? 0n
+            : confirmations.toBigInt(),
+        }
+      : {}),
+    ...(requiredDVNs !== undefined ? { requiredDVNs } : {}),
+    ...(optionalDVNs !== undefined
+      ? { optionalDVNs, optionalDVNThreshold }
+      : {}),
+  });
+}
+
+export function decodeLayerZeroV2EffectiveUlnConfig(
+  encoded: string,
+): LayerZeroV2EffectiveUlnConfig {
+  const [config] = utils.defaultAbiCoder.decode([ULN_CONFIG_TYPE], encoded);
+  const requiredDVNCount = Number(config.requiredDVNCount);
+  const optionalDVNCount = Number(config.optionalDVNCount);
+  const optionalDVNThreshold = Number(config.optionalDVNThreshold);
+  if (requiredDVNCount !== config.requiredDVNs.length) {
+    throw new Error(
+      `Effective requiredDVNs count ${requiredDVNCount} does not match ${config.requiredDVNs.length} DVNs`,
+    );
+  }
+  if (optionalDVNCount !== config.optionalDVNs.length) {
+    throw new Error(
+      `Effective optionalDVNs count ${optionalDVNCount} does not match ${config.optionalDVNs.length} DVNs`,
+    );
+  }
+  if (
+    (optionalDVNCount === 0 && optionalDVNThreshold !== 0) ||
+    optionalDVNThreshold > optionalDVNCount
+  ) {
+    throw new Error('Effective optional DVN threshold is invalid');
+  }
+  if (requiredDVNCount === 0 && optionalDVNThreshold === 0) {
+    throw new Error('Effective ULN config must retain at least one DVN');
+  }
+  return LayerZeroV2EffectiveUlnConfigSchema.parse({
+    confirmations: BigNumber.from(config.confirmations).toBigInt(),
+    requiredDVNs: config.requiredDVNs,
+    optionalDVNs: config.optionalDVNs,
+    optionalDVNThreshold,
+  });
+}
+
+export function layerZeroV2SendConfigParams(
+  config: LayerZeroV2SendConfig,
+): Array<{ configType: 1 | 2; config: string }> {
+  return [
+    ...(config.executor.type === LayerZeroV2ConfigMode.Override
+      ? [
+          {
+            configType: LayerZeroV2ConfigType.Executor,
+            config: encodeLayerZeroV2ExecutorConfig(config.executor),
+          } as const,
+        ]
+      : []),
+    ...(config.uln.type === LayerZeroV2ConfigMode.Override
+      ? [
+          {
+            configType: LayerZeroV2ConfigType.Uln,
+            config: encodeLayerZeroV2UlnConfig(config.uln),
+          } as const,
+        ]
+      : []),
+  ];
+}
+
+export function layerZeroV2ReceiveConfigParams(
+  config: LayerZeroV2ReceiveConfig,
+): Array<{ configType: 2; config: string }> {
+  return config.uln.type === LayerZeroV2ConfigMode.Override
+    ? [
+        {
+          configType: LayerZeroV2ConfigType.Uln,
+          config: encodeLayerZeroV2UlnConfig(config.uln),
+        },
+      ]
+    : [];
+}

--- a/typescript/sdk/src/layerzero/types.ts
+++ b/typescript/sdk/src/layerzero/types.ts
@@ -1,0 +1,191 @@
+import { z } from 'zod';
+
+import { Address, isAddressEvm } from '@hyperlane-xyz/utils';
+
+import { ZBigNumberish, ZChainName } from '../metadata/customZodTypes.js';
+import { ChainMap, OwnableSchema } from '../types.js';
+
+export const LayerZeroV2Variant = {
+  Callback: 'layerZeroV2Callback',
+  CcipRead: 'layerZeroV2CcipRead',
+} as const;
+export type LayerZeroV2Variant =
+  (typeof LayerZeroV2Variant)[keyof typeof LayerZeroV2Variant];
+
+export const LayerZeroV2AddressSchema = z
+  .string()
+  .refine(isAddressEvm, 'must be a valid EVM address');
+
+const MAX_UINT128 = (1n << 128n) - 1n;
+export const LayerZeroV2CallbackGasLimitSchema = ZBigNumberish.refine(
+  (value) => value > 0n && value <= MAX_UINT128,
+  'callbackGasLimit must fit a nonzero uint128',
+);
+
+export const LayerZeroV2ConfigParamSchema = z.object({
+  configType: z.union([z.literal(1), z.literal(2)]),
+  config: z.string().regex(/^0x(?:[0-9a-fA-F]{2})+$/),
+});
+
+const LayerZeroV2ConfigParamsSchema = z
+  .array(LayerZeroV2ConfigParamSchema)
+  .default([])
+  .superRefine((params, ctx) => {
+    const seen = new Set<number>();
+    params.forEach((param, index) => {
+      if (seen.has(param.configType)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'configType'],
+          message: `Duplicate LayerZero config type ${param.configType}`,
+        });
+      }
+      seen.add(param.configType);
+    });
+  })
+  .transform((params) =>
+    [...params].sort((a, b) => a.configType - b.configType),
+  );
+
+const LayerZeroV2PathwayBaseSchema = z.object({
+  /** LayerZero calls this the remote Endpoint ID (EID). */
+  layerZeroDomainId: z.number().int().positive().max(0xffffffff),
+  sendLibrary: LayerZeroV2AddressSchema,
+  receiveLibrary: LayerZeroV2AddressSchema,
+  receiveLibraryGracePeriod: z.literal(0).default(0),
+  receiveLibraryTimeout: z
+    .object({
+      library: LayerZeroV2AddressSchema,
+      expiry: z.number().int().positive(),
+    })
+    .optional(),
+  sendConfig: LayerZeroV2ConfigParamsSchema,
+  receiveConfig: LayerZeroV2ConfigParamsSchema,
+});
+
+function validateLayerZeroV2Pathway(
+  pathway: z.infer<typeof LayerZeroV2PathwayBaseSchema>,
+  ctx: z.RefinementCtx,
+): void {
+  pathway.receiveConfig.forEach((param, index) => {
+    if (param.configType !== 2) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['receiveConfig', index, 'configType'],
+        message: 'LayerZero receive config only supports ULN config type 2',
+      });
+    }
+  });
+}
+
+export const LayerZeroV2PathwaySchema =
+  LayerZeroV2PathwayBaseSchema.superRefine(validateLayerZeroV2Pathway);
+
+export const LayerZeroV2RemoteRouterSchema =
+  LayerZeroV2PathwayBaseSchema.extend({
+    router: LayerZeroV2AddressSchema,
+    callbackGasLimit: LayerZeroV2CallbackGasLimitSchema.optional(),
+  }).superRefine(validateLayerZeroV2Pathway);
+
+export const LayerZeroV2HookIsmSchema = OwnableSchema.extend({
+  type: z.union([
+    z.literal(LayerZeroV2Variant.Callback),
+    z.literal(LayerZeroV2Variant.CcipRead),
+  ]),
+  mailbox: LayerZeroV2AddressSchema,
+  endpoint: LayerZeroV2AddressSchema,
+  /** Optional deployment-time assertion against Endpoint.eid(). */
+  layerZeroDomainId: z.number().int().positive().max(0xffffffff).optional(),
+  urls: z.array(z.string().url()).min(1).optional(),
+  remoteRouters: z.record(ZChainName, LayerZeroV2RemoteRouterSchema),
+}).superRefine((config, ctx) => {
+  if (config.type === LayerZeroV2Variant.CcipRead && !config.urls) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['urls'],
+      message: 'layerZeroV2CcipRead requires at least one URL',
+    });
+  }
+  if (config.type === LayerZeroV2Variant.Callback && config.urls) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['urls'],
+      message: 'urls is a layerZeroV2CcipRead field',
+    });
+  }
+  const layerZeroDomainIds = new Map<number, string>();
+  for (const [chain, remote] of Object.entries(config.remoteRouters)) {
+    const existing = layerZeroDomainIds.get(remote.layerZeroDomainId);
+    if (existing) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['remoteRouters', chain, 'layerZeroDomainId'],
+        message: `LayerZero domain ID ${remote.layerZeroDomainId} is already claimed by ${existing}`,
+      });
+    }
+    layerZeroDomainIds.set(remote.layerZeroDomainId, chain);
+    if (
+      config.type === LayerZeroV2Variant.Callback &&
+      (remote.callbackGasLimit === undefined ||
+        BigInt(remote.callbackGasLimit) === 0n)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['remoteRouters', chain, 'callbackGasLimit'],
+        message: 'callback variant requires a nonzero callbackGasLimit',
+      });
+    }
+    if (
+      config.type === LayerZeroV2Variant.CcipRead &&
+      remote.callbackGasLimit !== undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['remoteRouters', chain, 'callbackGasLimit'],
+        message: 'callbackGasLimit is a callback-only field',
+      });
+    }
+  }
+});
+
+export type LayerZeroV2HookIsmConfig = z.infer<typeof LayerZeroV2HookIsmSchema>;
+export type LayerZeroV2RemoteRouterConfig = z.infer<
+  typeof LayerZeroV2RemoteRouterSchema
+>;
+export type LayerZeroV2MeshConfig = ChainMap<LayerZeroV2HookIsmConfig>;
+export type DerivedLayerZeroV2HookIsmConfig = Omit<
+  LayerZeroV2HookIsmConfig,
+  'layerZeroDomainId' | 'remoteRouters'
+> & {
+  address: Address;
+  layerZeroDomainId: number;
+  remoteRouters: Record<string, LayerZeroV2RemoteRouterConfig>;
+};
+export type LayerZeroV2HookIsmAddresses = {
+  deployedRouter: Address;
+  mailbox: Address;
+};
+
+export function findAsymmetricLayerZeroV2Routes(
+  mesh: LayerZeroV2MeshConfig,
+): string[] {
+  const problems: string[] = [];
+  const chains = Object.keys(mesh);
+  for (const origin of chains) {
+    for (const destination of chains) {
+      if (origin === destination) continue;
+      if (!mesh[origin].remoteRouters[destination]) {
+        problems.push(`${origin} does not enroll ${destination}`);
+      }
+      if (!mesh[destination].remoteRouters[origin]) {
+        problems.push(`${destination} does not enroll ${origin}`);
+      }
+      if (mesh[origin].type !== mesh[destination].type) {
+        problems.push(
+          `${origin} is ${mesh[origin].type} but ${destination} is ${mesh[destination].type}`,
+        );
+      }
+    }
+  }
+  return [...new Set(problems)];
+}

--- a/typescript/sdk/src/layerzero/types.ts
+++ b/typescript/sdk/src/layerzero/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { Address, isAddressEvm } from '@hyperlane-xyz/utils';
+import { Address, isAddressEvm, isZeroishAddress } from '@hyperlane-xyz/utils';
 
 import { ZBigNumberish, ZChainName } from '../metadata/customZodTypes.js';
 import { ChainMap, OwnableSchema } from '../types.js';
@@ -16,36 +16,195 @@ export const LayerZeroV2AddressSchema = z
   .string()
   .refine(isAddressEvm, 'must be a valid EVM address');
 
+const LayerZeroV2ConfigAddressSchema = LayerZeroV2AddressSchema.refine(
+  (address) => !isZeroishAddress(address),
+  'must be a nonzero EVM address',
+);
+
 const MAX_UINT128 = (1n << 128n) - 1n;
+const MAX_UINT64 = (1n << 64n) - 1n;
 export const LayerZeroV2CallbackGasLimitSchema = ZBigNumberish.refine(
   (value) => value > 0n && value <= MAX_UINT128,
   'callbackGasLimit must fit a nonzero uint128',
 );
 
-export const LayerZeroV2ConfigParamSchema = z.object({
-  configType: z.union([z.literal(1), z.literal(2)]),
-  config: z.string().regex(/^0x(?:[0-9a-fA-F]{2})+$/),
-});
+export const LayerZeroV2ConfigMode = {
+  Default: 'default',
+  Override: 'override',
+} as const;
 
-const LayerZeroV2ConfigParamsSchema = z
-  .array(LayerZeroV2ConfigParamSchema)
-  .default([])
-  .superRefine((params, ctx) => {
-    const seen = new Set<number>();
-    params.forEach((param, index) => {
-      if (seen.has(param.configType)) {
+const LayerZeroV2DefaultConfigSchema = z
+  .object({
+    type: z.literal(LayerZeroV2ConfigMode.Default),
+  })
+  .strict();
+
+const LayerZeroV2ExecutorOverrideSchema = z
+  .object({
+    type: z.literal(LayerZeroV2ConfigMode.Override),
+    maxMessageSize: z.number().int().positive().max(0xffffffff).optional(),
+    executor: LayerZeroV2ConfigAddressSchema.optional(),
+  })
+  .strict()
+  .refine(
+    ({ maxMessageSize, executor }) =>
+      maxMessageSize !== undefined || executor !== undefined,
+    'Executor override must set maxMessageSize or executor',
+  );
+
+export const LayerZeroV2ExecutorConfigSchema = z.union([
+  LayerZeroV2DefaultConfigSchema,
+  LayerZeroV2ExecutorOverrideSchema,
+]);
+
+const LayerZeroV2DvnListSchema = z
+  .array(LayerZeroV2ConfigAddressSchema)
+  .max(127)
+  .superRefine((dvns, ctx) => {
+    const seen = new Set<string>();
+    dvns.forEach((dvn, index) => {
+      const normalized = dvn.toLowerCase();
+      if (seen.has(normalized)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: [index, 'configType'],
-          message: `Duplicate LayerZero config type ${param.configType}`,
+          path: [index],
+          message: `Duplicate LayerZero DVN ${dvn}`,
         });
       }
-      seen.add(param.configType);
+      seen.add(normalized);
     });
   })
-  .transform((params) =>
-    [...params].sort((a, b) => a.configType - b.configType),
+  .transform((dvns) =>
+    [...dvns].sort((a, b) => {
+      const left = BigInt(a.toLowerCase());
+      const right = BigInt(b.toLowerCase());
+      return left < right ? -1 : left > right ? 1 : 0;
+    }),
   );
+
+const LayerZeroV2UlnOverrideSchema = z
+  .object({
+    type: z.literal(LayerZeroV2ConfigMode.Override),
+    confirmations: ZBigNumberish.refine(
+      (value) => value <= MAX_UINT64,
+      'confirmations must fit uint64',
+    ).optional(),
+    requiredDVNs: LayerZeroV2DvnListSchema.optional(),
+    optionalDVNs: LayerZeroV2DvnListSchema.optional(),
+    optionalDVNThreshold: z.number().int().nonnegative().max(127).optional(),
+  })
+  .strict()
+  .superRefine((config, ctx) => {
+    if (
+      config.confirmations === undefined &&
+      config.requiredDVNs === undefined &&
+      config.optionalDVNs === undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'ULN override must configure at least one field',
+      });
+    }
+    if (config.optionalDVNs === undefined) {
+      if (config.optionalDVNThreshold !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['optionalDVNThreshold'],
+          message: 'optionalDVNThreshold requires optionalDVNs',
+        });
+      }
+      return;
+    }
+    const expectedThreshold = config.optionalDVNs.length === 0 ? 0 : undefined;
+    if (
+      expectedThreshold === 0 &&
+      config.optionalDVNThreshold !== undefined &&
+      config.optionalDVNThreshold !== 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['optionalDVNThreshold'],
+        message: 'Empty optionalDVNs requires threshold 0',
+      });
+    }
+    if (
+      config.optionalDVNs.length > 0 &&
+      (config.optionalDVNThreshold === undefined ||
+        config.optionalDVNThreshold === 0 ||
+        config.optionalDVNThreshold > config.optionalDVNs.length)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['optionalDVNThreshold'],
+        message: 'Optional DVN threshold must be between 1 and the DVN count',
+      });
+    }
+    if (config.requiredDVNs?.length === 0 && config.optionalDVNs.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'ULN config must retain at least one DVN',
+      });
+    }
+  })
+  .transform((config) =>
+    config.optionalDVNs?.length === 0 &&
+    config.optionalDVNThreshold === undefined
+      ? { ...config, optionalDVNThreshold: 0 }
+      : config,
+  );
+
+export const LayerZeroV2UlnConfigSchema = z.union([
+  LayerZeroV2DefaultConfigSchema,
+  LayerZeroV2UlnOverrideSchema,
+]);
+
+export const LayerZeroV2SendConfigSchema = z
+  .object({
+    executor: LayerZeroV2ExecutorConfigSchema.default(() => ({
+      type: LayerZeroV2ConfigMode.Default,
+    })),
+    uln: LayerZeroV2UlnConfigSchema.default(() => ({
+      type: LayerZeroV2ConfigMode.Default,
+    })),
+  })
+  .default(() => ({
+    executor: { type: LayerZeroV2ConfigMode.Default },
+    uln: { type: LayerZeroV2ConfigMode.Default },
+  }));
+
+export const LayerZeroV2ReceiveConfigSchema = z
+  .object({
+    uln: LayerZeroV2UlnConfigSchema.default(() => ({
+      type: LayerZeroV2ConfigMode.Default,
+    })),
+  })
+  .default(() => ({
+    uln: { type: LayerZeroV2ConfigMode.Default },
+  }));
+
+export const LayerZeroV2EffectiveExecutorConfigSchema = z.object({
+  maxMessageSize: z.number().int().positive().max(0xffffffff),
+  executor: LayerZeroV2AddressSchema,
+});
+
+export const LayerZeroV2EffectiveUlnConfigSchema = z.object({
+  confirmations: ZBigNumberish.refine(
+    (value) => value <= MAX_UINT64,
+    'confirmations must fit uint64',
+  ),
+  requiredDVNs: LayerZeroV2DvnListSchema,
+  optionalDVNs: LayerZeroV2DvnListSchema,
+  optionalDVNThreshold: z.number().int().nonnegative().max(127),
+});
+
+export const LayerZeroV2EffectiveSendConfigSchema = z.object({
+  executor: LayerZeroV2EffectiveExecutorConfigSchema,
+  uln: LayerZeroV2EffectiveUlnConfigSchema,
+});
+
+export const LayerZeroV2EffectiveReceiveConfigSchema = z.object({
+  uln: LayerZeroV2EffectiveUlnConfigSchema,
+});
 
 const LayerZeroV2PathwayBaseSchema = z.object({
   /** LayerZero calls this the remote Endpoint ID (EID). */
@@ -59,33 +218,21 @@ const LayerZeroV2PathwayBaseSchema = z.object({
       expiry: z.number().int().positive(),
     })
     .optional(),
-  sendConfig: LayerZeroV2ConfigParamsSchema,
-  receiveConfig: LayerZeroV2ConfigParamsSchema,
+  sendConfig: LayerZeroV2SendConfigSchema,
+  receiveConfig: LayerZeroV2ReceiveConfigSchema,
+  /** Effective values after LayerZero applies defaults; informational only. */
+  effectiveSendConfig: LayerZeroV2EffectiveSendConfigSchema.optional(),
+  /** Effective values after LayerZero applies defaults; informational only. */
+  effectiveReceiveConfig: LayerZeroV2EffectiveReceiveConfigSchema.optional(),
 });
 
-function validateLayerZeroV2Pathway(
-  pathway: z.infer<typeof LayerZeroV2PathwayBaseSchema>,
-  ctx: z.RefinementCtx,
-): void {
-  pathway.receiveConfig.forEach((param, index) => {
-    if (param.configType !== 2) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['receiveConfig', index, 'configType'],
-        message: 'LayerZero receive config only supports ULN config type 2',
-      });
-    }
-  });
-}
-
-export const LayerZeroV2PathwaySchema =
-  LayerZeroV2PathwayBaseSchema.superRefine(validateLayerZeroV2Pathway);
+export const LayerZeroV2PathwaySchema = LayerZeroV2PathwayBaseSchema;
 
 export const LayerZeroV2RemoteRouterSchema =
   LayerZeroV2PathwayBaseSchema.extend({
     router: LayerZeroV2AddressSchema,
     callbackGasLimit: LayerZeroV2CallbackGasLimitSchema.optional(),
-  }).superRefine(validateLayerZeroV2Pathway);
+  });
 
 export const LayerZeroV2HookIsmSchema = OwnableSchema.extend({
   type: z.union([
@@ -149,6 +296,20 @@ export const LayerZeroV2HookIsmSchema = OwnableSchema.extend({
 });
 
 export type LayerZeroV2HookIsmConfig = z.infer<typeof LayerZeroV2HookIsmSchema>;
+export type LayerZeroV2ExecutorConfig = z.infer<
+  typeof LayerZeroV2ExecutorConfigSchema
+>;
+export type LayerZeroV2UlnConfig = z.infer<typeof LayerZeroV2UlnConfigSchema>;
+export type LayerZeroV2SendConfig = z.infer<typeof LayerZeroV2SendConfigSchema>;
+export type LayerZeroV2ReceiveConfig = z.infer<
+  typeof LayerZeroV2ReceiveConfigSchema
+>;
+export type LayerZeroV2EffectiveExecutorConfig = z.infer<
+  typeof LayerZeroV2EffectiveExecutorConfigSchema
+>;
+export type LayerZeroV2EffectiveUlnConfig = z.infer<
+  typeof LayerZeroV2EffectiveUlnConfigSchema
+>;
 export type LayerZeroV2RemoteRouterConfig = z.infer<
   typeof LayerZeroV2RemoteRouterSchema
 >;

--- a/typescript/sdk/src/providers/MultiProvider.test.ts
+++ b/typescript/sdk/src/providers/MultiProvider.test.ts
@@ -7,12 +7,16 @@ import {
 } from 'zksync-ethers';
 
 import {
+  LayerZeroV2CallbackHookIsm__factory,
+  LayerZeroV2CcipReadHookIsm__factory,
   Mailbox__factory,
   ProxyAdmin__factory,
   TestRecipient__factory,
 } from '@hyperlane-xyz/core';
 import type { ZKSyncArtifact } from '@hyperlane-xyz/core';
 import {
+  LayerZeroV2CallbackHookIsm__factory as TronLayerZeroV2CallbackHookIsm__factory,
+  LayerZeroV2CcipReadHookIsm__factory as TronLayerZeroV2CcipReadHookIsm__factory,
   Mailbox__factory as TronMailbox__factory,
   ProxyAdmin__factory as TronProxyAdmin__factory,
   TronContractFactory,
@@ -49,6 +53,21 @@ describe('MultiProvider Tron factory resolution', () => {
     expect(resolved.constructor.name).to.equal(TronContractFactory.name);
     expect(resolved.bytecode).to.equal(
       new TronTestRecipient__factory().bytecode,
+    );
+  });
+
+  it('resolves both LayerZero variants to tron factories', async () => {
+    const callback = await mp.resolveTronFactory(
+      new LayerZeroV2CallbackHookIsm__factory(),
+    );
+    const ccipRead = await mp.resolveTronFactory(
+      new LayerZeroV2CcipReadHookIsm__factory(),
+    );
+    expect(callback.bytecode).to.equal(
+      new TronLayerZeroV2CallbackHookIsm__factory().bytecode,
+    );
+    expect(ccipRead.bytecode).to.equal(
+      new TronLayerZeroV2CcipReadHookIsm__factory().bytecode,
     );
   });
 

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -145,6 +145,8 @@ export const hookTypesToFilter: HookType[] = [
   HookType.DELAYED_FLOW_ROUTER,
   HookType.WORMHOLE_EXECUTOR,
   HookType.WORMHOLE_VAA,
+  HookType.LAYER_ZERO_V2_CALLBACK,
+  HookType.LAYER_ZERO_V2_CCIP_READ,
 ];
 export const DEFAULT_TOKEN_DECIMALS = 18;
 

--- a/typescript/sdk/src/token/warpCheck.test.ts
+++ b/typescript/sdk/src/token/warpCheck.test.ts
@@ -41,6 +41,7 @@ import {
   expandedDeployConfigToAltVmCheckConfig,
   getScaleViolations,
   normalizeAltVmDestinationGas,
+  removeLayerZeroEffectiveConfigs,
 } from './warpCheck.js';
 
 const MAILBOX = '0x000000000000000000000000000000000000b001';
@@ -949,6 +950,36 @@ describe('buildWarpRouteDiff', () => {
     });
 
     expect(diff).to.deep.equal({});
+  });
+});
+
+describe('removeLayerZeroEffectiveConfigs', () => {
+  it('removes informational effective values but preserves desired overrides', () => {
+    const config = {
+      interchainSecurityModule: {
+        remoteRouters: {
+          remote: {
+            effectiveSendConfig: { executor: { maxMessageSize: 10_000 } },
+            effectiveReceiveConfig: { uln: { confirmations: 12 } },
+            sendConfig: { executor: { type: 'default' } },
+            receiveConfig: { uln: { type: 'default' } },
+          },
+        },
+      },
+    };
+
+    removeLayerZeroEffectiveConfigs(config);
+
+    expect(config).to.deep.equal({
+      interchainSecurityModule: {
+        remoteRouters: {
+          remote: {
+            sendConfig: { executor: { type: 'default' } },
+            receiveConfig: { uln: { type: 'default' } },
+          },
+        },
+      },
+    });
   });
 });
 

--- a/typescript/sdk/src/token/warpCheck.ts
+++ b/typescript/sdk/src/token/warpCheck.ts
@@ -144,6 +144,18 @@ export interface WarpRouteCheckResult {
   violations: WarpRouteCheckViolation[];
 }
 
+/** Removes read-only LayerZero observations before desired-state comparison. */
+export function removeLayerZeroEffectiveConfigs(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(removeLayerZeroEffectiveConfigs);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  if ('effectiveSendConfig' in value) delete value.effectiveSendConfig;
+  if ('effectiveReceiveConfig' in value) delete value.effectiveReceiveConfig;
+  Object.values(value).forEach(removeLayerZeroEffectiveConfigs);
+}
+
 type ScaleValidationWarpRouteConfig = WarpRouteDeployConfigMailboxRequired &
   Record<string, Partial<HypTokenRouterVirtualConfig>>;
 
@@ -1061,6 +1073,9 @@ export function buildWarpRouteDiff({
         };
         return acc;
       }
+
+      removeLayerZeroEffectiveConfigs(expectedDeployedConfig);
+      removeLayerZeroEffectiveConfigs(currentDeployedConfig);
 
       if (typeof expectedDeployedConfig.hook === 'string') {
         currentDeployedConfig.hook = derivedHookAddress(currentDeployedConfig);

--- a/typescript/sdk/src/utils/ism.ts
+++ b/typescript/sdk/src/utils/ism.ts
@@ -17,6 +17,7 @@ import {
   DelayedFlowRouterHookIsmConfig,
   IsmConfig,
   IsmType,
+  LayerZeroV2IsmConfig,
   NetFlowRateLimitedHookIsmConfig,
   WormholeIsmConfig,
 } from '../ism/types.js';
@@ -114,6 +115,8 @@ function ismTreeSome(
     case IsmType.OFFCHAIN_LOOKUP:
     case IsmType.WORMHOLE_EXECUTOR:
     case IsmType.WORMHOLE_VAA:
+    case IsmType.LAYER_ZERO_V2_CALLBACK:
+    case IsmType.LAYER_ZERO_V2_CCIP_READ:
     case IsmType.UNKNOWN:
       return false;
     default: {
@@ -220,7 +223,10 @@ export type HybridHookIsmConfig =
 /** Combined hook/ISM leaves handled as opaque shared instances by generic
  * EVM reconciliation. Flow-control hybrids remain a narrower subset used by
  * the warp hybrid deployment planner. */
-export type CombinedHookIsmConfig = HybridHookIsmConfig | WormholeIsmConfig;
+export type CombinedHookIsmConfig =
+  | HybridHookIsmConfig
+  | WormholeIsmConfig
+  | LayerZeroV2IsmConfig;
 
 /**
  * True if a warp-route hybrid hook/ISM node (NET_FLOW_RATE_LIMITED or
@@ -278,7 +284,9 @@ export function isCombinedHookIsmNode(
   return (
     isRecord(node) &&
     (node.type === IsmType.WORMHOLE_EXECUTOR ||
-      node.type === IsmType.WORMHOLE_VAA)
+      node.type === IsmType.WORMHOLE_VAA ||
+      node.type === IsmType.LAYER_ZERO_V2_CALLBACK ||
+      node.type === IsmType.LAYER_ZERO_V2_CCIP_READ)
   );
 }
 function collectHybridIsmNodesFromUnknown(ism: unknown): HybridHookIsmConfig[] {


### PR DESCRIPTION
### Description

Adds SDK, TypeScript relayer, and CLI integration for the LayerZero V2 callback and CCIP-read hook/ISM variants:

- config schemas, readers, deployers, and atomic full-mesh enrollment/reconciliation;
- CCIP-read packet metadata support in the TypeScript relayer/offchain lookup server;
- CLI deploy/apply/check and end-to-end coverage for direct and warp-route use.

This PR is based on `xeno/wormhole-sdk-integration`. It depends on #9436. Its first commit contains the complete LayerZero contract change as one intentionally droppable commit after #9436 lands. It does not modify the Rust relayer.

### Drive-by changes

None.

### Related issues

- Contract implementation: #9436

### Backward compatibility

Yes. New LayerZero hook/ISM config types and relayer handling are additive. Existing deploy/apply flows and Rust relayer behavior are unchanged.

### Testing

- Solidity: 63 unit tests and 2 Ethereum mainnet fork tests passed.
- SDK: build/lint passed; 52 focused unit tests and 2 LayerZero Hardhat tests passed.
- Relayer/CCIP-read server: build/lint passed; 102 server tests and 2 relayer Hardhat tests passed.
- CLI E2E: 4 callback/CCIP-read self-relay tests and 2 callback/CCIP-read warp tests passed.
- Manual: live deployments and warp transfers succeeded for both variants.
