### PR TITLE
chore(infra): update mainnet relayer image

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,9 +43,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '88b2092-20260902-181744',
-  relayerRC: '88b2092-20260902-181744',
-  relayerFastPath: '88b2092-20260902-181744',
+  relayer: '6e2a9dc-20260902-184618',
+  relayerRC: '6e2a9dc-20260902-184618',
+  relayerFastPath: '6e2a9dc-20260902-184618',
   validator: 'c35e861-20260831-121837',
   validatorRC: 'c35e861-20260831-121837',
   validatorFastPath: 'c35e861-20260831-121837',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,9 +43,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: '6e2a9dc-20260902-184618',
-  relayerRC: '6e2a9dc-20260902-184618',
-  relayerFastPath: '6e2a9dc-20260902-184618',
+  relayer: 'c9a3852-20260902-193249',
+  relayerRC: 'c9a3852-20260902-193249',
+  relayerFastPath: 'c9a3852-20260902-193249',
   validator: 'c35e861-20260831-121837',
   validatorRC: 'c35e861-20260831-121837',
   validatorFastPath: 'c35e861-20260831-121837',

--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,9 +43,9 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'fede1e2-20260901-191753',
-  relayerRC: 'fede1e2-20260901-191753',
-  relayerFastPath: 'fede1e2-20260901-191753',
+  relayer: '88b2092-20260902-181744',
+  relayerRC: '88b2092-20260902-181744',
+  relayerFastPath: '88b2092-20260902-181744',
   validator: 'c35e861-20260831-121837',
   validatorRC: 'c35e861-20260831-121837',
   validatorFastPath: 'c35e861-20260831-121837',


### PR DESCRIPTION
## Summary

- pin mainnet relayer, RC, and fast-path config to `c9a3852-20260902-193249`
- image was built from latest `main` at `c9a38529cfcaca1677231bae66df38e26c26f9a8`
- this image includes #9425, #9426, #9441, #9398, #9428, and #9429

## Verification

- agent image build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33673922029
- published and deployed digest: `sha256:a0f0f835b9335ba553d457e516567f7a16b30348e06442e00d730be381afbe39`
- commit hooks: gitleaks, oxlint, and oxfmt

## Rollout

- hot-deployed the `hyperlane` production relayer as Helm revision 608
- replacement pod is ready on the exact digest with zero restarts
- 67/67 pending indexes loaded from checkpoints in 42–146 ms, with zero full backfills
- successful recovery leaves no `PayloadDbLoader` liveness series
- RC and fast-path config are pinned for their next rollout but were not part of this hot deploy
