### PR TITLE
fix(lander): clear completed loader liveness

### DIFF
--- a/rust/main/lander/src/dispatcher/db/payload/loader.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/loader.rs
@@ -17,6 +17,7 @@ use super::PayloadDb;
 // Bound each synchronous chunk to at most 2,000 point reads and 1,000 derived
 // writes while amortizing one RocksDB commit across the whole chunk.
 const RECONCILIATION_BATCH_SIZE: u32 = 1_000;
+const TASK_NAME: &str = "PayloadDbLoader";
 
 #[derive(new)]
 pub struct PayloadDbLoader {
@@ -28,7 +29,7 @@ pub struct PayloadDbLoader {
 impl PayloadDbLoader {
     pub async fn load_from_db(&self, metrics: DispatcherMetrics) -> Result<(), LanderError> {
         let started_at = Instant::now();
-        metrics.update_liveness_metric("PayloadDbLoader", &self.domain);
+        metrics.update_liveness_metric(TASK_NAME, &self.domain);
 
         let checkpoint = self.db.pending_payload_index_checkpoint().await?;
         let requires_reconciliation = match checkpoint {
@@ -50,6 +51,7 @@ impl PayloadDbLoader {
                 domain = %self.domain,
                 "Loaded pending payload index"
             );
+            metrics.remove_liveness_metric(TASK_NAME, &self.domain);
             return Ok(());
         }
 
@@ -72,6 +74,7 @@ impl PayloadDbLoader {
                 .await?;
             pending_count = pending_count.saturating_add(payloads.len());
             self.building_stage_queue.extend(payloads).await;
+            metrics.update_liveness_metric(TASK_NAME, &self.domain);
 
             if first_index == 1 {
                 break;
@@ -87,6 +90,7 @@ impl PayloadDbLoader {
             domain = %self.domain,
             "Pending payload index backfill complete"
         );
+        metrics.remove_liveness_metric(TASK_NAME, &self.domain);
         Ok(())
     }
 }

--- a/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
+++ b/rust/main/lander/src/dispatcher/db/payload/payload_db.rs
@@ -537,10 +537,8 @@ mod tests {
 
         let queue = BuildingStageQueue::new();
         let loader = PayloadDbLoader::new(db.clone(), queue.clone(), "test".to_string());
-        loader
-            .load_from_db(DispatcherMetrics::dummy_instance())
-            .await
-            .unwrap();
+        let metrics = DispatcherMetrics::dummy_instance();
+        loader.load_from_db(metrics.clone()).await.unwrap();
 
         assert!(db
             .pending_payload_index_checkpoint()
@@ -552,6 +550,9 @@ mod tests {
             vec![payload.clone()]
         );
         assert_eq!(queue.pop_n(1).await, vec![payload]);
+        assert!(!String::from_utf8(metrics.gather().unwrap())
+            .unwrap()
+            .contains("PayloadDbLoader"));
     }
 
     #[tokio::test]

--- a/rust/main/lander/src/dispatcher/metrics.rs
+++ b/rust/main/lander/src/dispatcher/metrics.rs
@@ -240,6 +240,15 @@ impl DispatcherMetrics {
         );
     }
 
+    pub fn remove_liveness_metric(&self, stage: &str, domain: &str) {
+        if let Err(error) = self.task_liveness.remove_label_values(&[domain, stage]) {
+            warn!(
+                ?error,
+                stage, domain, "Failed to remove task liveness metric"
+            );
+        }
+    }
+
     pub fn update_queue_length_metric(&self, stage: &str, length: u64, domain: &str) {
         match stage {
             crate::dispatcher::building_stage::STAGE_NAME => self


### PR DESCRIPTION
## Problem

#9426 changed `PayloadDbLoader` from a perpetual polling task into a finite recovery operation, but it continued publishing a last-seen liveness timestamp after successful completion. The generic lost-liveness alert therefore paged every completed destination once that timestamp aged past the threshold.

## Fix

- keep refreshing the heartbeat after every 1,000-index reconciliation chunk, so stalled recovery remains observable
- remove the liveness series only after successful checkpoint load or reconciliation
- retain the series on error, so a failed loader still pages
- cover successful cleanup in the loader regression

## Production evidence

- all 67 constructed Lander destinations had completed the one-time reconciliation before PagerDuty fired; the relayer remained ready with zero restarts
- branch image `6e2a9dc-20260902-184618` (`sha256:fe650b8061ed792395541e85176f9dfd49b7749abee5cc0363769f518071917e`) was hot-deployed as Helm revision 607
- the restart loaded all 67 persisted indexes through the checkpoint path in 26–56 ms (40 ms average), with zero full backfills
- the live exporter contains no `PayloadDbLoader` liveness series after successful recovery
- the replacement pod is ready on the exact digest with zero restarts

## Verification

- agent image build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33669238404
- focused loader regression is covered by `lander-coverage`
- remaining CI continues independently of the production hotfix
