### PR TITLE
perf(metrics): avoid redundant block detail reads

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -720,9 +720,8 @@ impl<C: AleoClient> HyperlaneProvider for AleoProvider<C> {
     /// Fetch metrics related to this chain
     async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
         let height = self.get_latest_height().await?;
-        let info = self.get_block_by_height(height as u64).await?;
         Ok(Some(ChainInfo {
-            latest_block: info,
+            block_height: height.into(),
             min_gas_price: None,
         }))
     }

--- a/rust/main/chains/hyperlane-aleo/src/provider/tests.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/tests.rs
@@ -102,23 +102,14 @@ async fn test_get_balance() {
 }
 
 #[tokio::test]
-async fn test_get_chain_metrics() {
+async fn chain_metrics_only_fetch_block_height() {
     let provider = mock_provider();
     provider
         .deref()
         .register_file("block/height/latest", "latest_height.json")
         .unwrap();
-    provider
-        .deref()
-        .register_file("block/1", "block_1.json")
-        .unwrap();
-    let block_info = provider.get_chain_metrics().await.unwrap().unwrap();
-    assert_eq!(block_info.latest_block.number, 1);
-    assert_eq!(block_info.latest_block.timestamp, 1725479626);
-    assert_eq!(
-        block_info.latest_block.hash,
-        H256::from_str("2306b5c843f34abe2bbac9e6f2bcfdda0926b50cd6f736dfd419aceed6b7c710").unwrap()
-    );
+    let chain_info = provider.get_chain_metrics().await.unwrap().unwrap();
+    assert_eq!(chain_info.block_height, 1);
 }
 
 // Missing blocks or transactions are indicated by corresponding HTTP responses where Reqwest handles the errors.

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
@@ -318,15 +318,8 @@ impl<T: BuildableQueryClient> HyperlaneProvider for CosmosProvider<T> {
 
     async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
         let height = self.rpc().get_block_number().await?;
-        let response = self.rpc().get_block(height as u32).await?;
-        let hash = response.block.header.hash();
-        let block_info = BlockInfo {
-            hash: H256::from_slice(hash.as_bytes()),
-            timestamp: response.block.header.time.unix_timestamp() as u64,
-            number: height,
-        };
         Ok(Some(ChainInfo {
-            latest_block: block_info,
+            block_height: height,
             min_gas_price: None,
         }))
     }

--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/provider.rs
@@ -579,23 +579,12 @@ where
             return Ok(None);
         };
 
-        let block_hash = block
-            .hash
-            .ok_or_else(|| ChainCommunicationError::CustomError("Block hash missing".into()))?;
         let block_number = block
             .number
             .ok_or_else(|| ChainCommunicationError::CustomError("Block number missing".into()))?;
 
-        // Given the block is queried with `BlockNumber::Latest` rather than `BlockNumber::Pending`,
-        // if `block` is Some at this point, we're guaranteed to have its `hash` and `number` defined,
-        // so it's safe to unwrap below
-        // more info at <https://docs.rs/ethers/latest/ethers/core/types/struct.Block.html#structfield.number>
         let chain_metrics = ChainInfo::new(
-            BlockInfo {
-                hash: block_hash.into(),
-                timestamp: block.timestamp.as_u64(),
-                number: block_number.as_u64(),
-            },
+            block_number.as_u64(),
             block.base_fee_per_gas.map(Into::into),
         );
         Ok(Some(chain_metrics))

--- a/rust/main/chains/hyperlane-radix/src/provider/radix.rs
+++ b/rust/main/chains/hyperlane-radix/src/provider/radix.rs
@@ -825,8 +825,7 @@ impl HyperlaneProvider for RadixProvider {
     /// Fetch metrics related to this chain
     async fn get_chain_metrics(&self) -> ChainResult<Option<hyperlane_core::ChainInfo>> {
         let state_version = self.get_state_version(None).await?;
-        let block_info = self.get_block_by_height(state_version).await?;
-        Ok(Some(hyperlane_core::ChainInfo::new(block_info, None)))
+        Ok(Some(hyperlane_core::ChainInfo::new(state_version, None)))
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -856,9 +856,8 @@ impl HyperlaneProvider for SealevelProvider {
 
     async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
         let slot = self.rpc_client.get_slot_raw().await?;
-        let latest_block = self.block_info_by_height(slot).await?;
         let chain_info = ChainInfo {
-            latest_block,
+            block_height: slot,
             min_gas_price: None,
         };
         Ok(Some(chain_info))

--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -628,7 +628,7 @@ impl SealevelProvider {
     }
 
     async fn block_info_by_height(&self, slot: u64) -> Result<BlockInfo, ChainCommunicationError> {
-        let confirmed_block = self.rpc_client.get_block(slot).await?;
+        let confirmed_block = self.rpc_client.get_block_info(slot).await?;
 
         let block_hash = decode_h256(&confirmed_block.blockhash)?;
 

--- a/rust/main/chains/hyperlane-sealevel/src/provider.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/provider.rs
@@ -863,3 +863,86 @@ impl HyperlaneProvider for SealevelProvider {
         Ok(Some(chain_info))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use hyperlane_core::{rpc_clients::FallbackProvider, KnownHyperlaneDomain};
+    use serde_json::{json, Value};
+    use solana_client::{
+        client_error::Result as ClientResult,
+        nonblocking::rpc_client::RpcClient,
+        rpc_client::RpcClientConfig,
+        rpc_request::RpcRequest,
+        rpc_sender::{RpcSender, RpcTransportStats},
+    };
+
+    use super::*;
+    use crate::client::SealevelRpcClient;
+
+    #[derive(Clone)]
+    struct RecordingRpcSender {
+        calls: Arc<Mutex<Vec<(RpcRequest, Value)>>>,
+        slot: u64,
+    }
+
+    #[async_trait]
+    impl RpcSender for RecordingRpcSender {
+        async fn send(&self, request: RpcRequest, params: Value) -> ClientResult<Value> {
+            let response = match &request {
+                RpcRequest::GetSlot => json!(self.slot),
+                _ => Value::Null,
+            };
+            self.calls
+                .lock()
+                .expect("recording sender mutex should not be poisoned")
+                .push((request, params));
+            Ok(response)
+        }
+
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+
+        fn url(&self) -> String {
+            "recording://sealevel-provider-test".to_owned()
+        }
+    }
+
+    #[tokio::test]
+    async fn chain_metrics_only_fetch_finalized_slot() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let sender = RecordingRpcSender {
+            calls: calls.clone(),
+            slot: 42,
+        };
+        let rpc_client = RpcClient::new_sender(
+            sender,
+            RpcClientConfig::with_commitment(CommitmentConfig::processed()),
+        );
+        let client = SealevelRpcClient::from_rpc_client(Arc::new(rpc_client));
+        let fallback_provider = FallbackProvider::new(vec![client]);
+        let provider = SealevelProvider {
+            rpc_client: SealevelFallbackRpcClient::new(fallback_provider),
+            domain: HyperlaneDomain::Known(KnownHyperlaneDomain::SolanaMainnet),
+            native_token: NativeToken::default(),
+            recipient_provider: RecipientProvider::new(&[]),
+            alt_cache: Arc::new(RwLock::new(HashMap::new())),
+        };
+
+        let chain_info = provider
+            .get_chain_metrics()
+            .await
+            .expect("chain metrics request should succeed")
+            .expect("Sealevel should expose chain metrics");
+
+        assert_eq!(chain_info.block_height, 42);
+        assert_eq!(
+            *calls
+                .lock()
+                .expect("recording sender mutex should not be poisoned"),
+            vec![(RpcRequest::GetSlot, json!([CommitmentConfig::finalized()]),)]
+        );
+    }
+}

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client.rs
@@ -21,8 +21,8 @@ use solana_sdk::{
     transaction::{Transaction, VersionedTransaction},
 };
 use solana_transaction_status::{
-    EncodedConfirmedTransactionWithStatusMeta, TransactionStatus, UiConfirmedBlock,
-    UiTransactionEncoding,
+    EncodedConfirmedTransactionWithStatusMeta, TransactionDetails, TransactionStatus,
+    UiConfirmedBlock, UiTransactionEncoding,
 };
 
 use hyperlane_core::{rpc_clients::BlockNumberGetter, ChainCommunicationError, ChainResult, U256};
@@ -132,6 +132,16 @@ impl SealevelRpcClient {
     pub async fn get_block(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
         self.get_block_with_commitment(slot, CommitmentConfig::finalized())
             .await
+    }
+
+    /// Get block metadata without downloading transactions.
+    pub async fn get_block_info(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
+        self.0
+            .get_block_with_config(slot, block_info_config(CommitmentConfig::finalized()))
+            .await
+            .map_err(Box::new)
+            .map_err(HyperlaneSealevelError::ClientError)
+            .map_err(Into::into)
     }
 
     /// get block_height
@@ -411,6 +421,13 @@ fn block_config(commitment: CommitmentConfig) -> RpcBlockConfig {
         max_supported_transaction_version: Some(0),
         rewards: Some(false),
         ..Default::default()
+    }
+}
+
+fn block_info_config(commitment: CommitmentConfig) -> RpcBlockConfig {
+    RpcBlockConfig {
+        transaction_details: Some(TransactionDetails::None),
+        ..block_config(commitment)
     }
 }
 

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/client/tests.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
+use solana_transaction_status::TransactionDetails;
 
-use super::block_config;
+use super::{block_config, block_info_config};
 use crate::client::SealevelRpcClient;
 
 //#[tokio::test]
@@ -32,4 +33,12 @@ fn get_block_config_disables_rewards() {
     assert_eq!(config.rewards, Some(false));
     assert_eq!(config.max_supported_transaction_version, Some(0));
     assert_eq!(config.commitment, Some(CommitmentConfig::finalized()));
+}
+
+#[test]
+fn get_block_info_config_omits_transactions() {
+    let config = block_info_config(CommitmentConfig::finalized());
+
+    assert_eq!(config.transaction_details, Some(TransactionDetails::None));
+    assert_eq!(config.rewards, Some(false));
 }

--- a/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
+++ b/rust/main/chains/hyperlane-sealevel/src/rpc/fallback.rs
@@ -256,6 +256,16 @@ impl SealevelFallbackRpcClient {
         SealevelFallbackRpcClient::new(fallback)
     }
 
+    /// Requests block metadata without downloading transactions.
+    pub async fn get_block_info(&self, slot: u64) -> ChainResult<UiConfirmedBlock> {
+        self.fallback_provider
+            .call(move |client| {
+                let future = async move { client.get_block_info(slot).await };
+                Box::pin(future)
+            })
+            .await
+    }
+
     /// confirm transaction with given commitment
     pub async fn confirm_transaction_with_commitment(
         &self,

--- a/rust/main/chains/hyperlane-starknet/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-starknet/src/provider/client.rs
@@ -198,7 +198,6 @@ impl HyperlaneProvider for StarknetProvider {
             .block_number()
             .await
             .map_err(HyperlaneStarknetError::from)?;
-        let block_info = self.get_block_by_height(block_height).await?;
-        Ok(Some(hyperlane_core::ChainInfo::new(block_info, None)))
+        Ok(Some(hyperlane_core::ChainInfo::new(block_height, None)))
     }
 }

--- a/rust/main/chains/hyperlane-tron/src/provider/tron.rs
+++ b/rust/main/chains/hyperlane-tron/src/provider/tron.rs
@@ -520,7 +520,8 @@ impl HyperlaneProvider for TronProvider {
 
     async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
         let block = self.get_current_block().await?;
-        let chain_metrics = ChainInfo::new(Self::get_block_info(&block)?, None);
+        let block_height = block.block_header.raw_data.number as u64;
+        let chain_metrics = ChainInfo::new(block_height, None);
         Ok(Some(chain_metrics))
     }
 }

--- a/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
@@ -401,7 +401,7 @@ impl ChainSpecificMetricsUpdater {
             }
         };
 
-        let height = chain_metrics.latest_block.number as i64;
+        let height = chain_metrics.block_height as i64;
         trace!(chain, height, "Fetched block height for metrics");
         self.chain_metrics.set_block_height(chain, height);
 

--- a/rust/main/hyperlane-core/src/types/chain_data.rs
+++ b/rust/main/hyperlane-core/src/types/chain_data.rs
@@ -16,8 +16,8 @@ pub struct BlockInfo {
 /// Metrics about the chain.
 #[derive(Debug, Clone, Default, new)]
 pub struct ChainInfo {
-    /// Information about the latest block
-    pub latest_block: BlockInfo,
+    /// Height of the latest block
+    pub block_height: u64,
     /// The current gas price, in the lowest denomination (e.g. wei)
     /// Unless the chain implements an EIP-1559 style tx fee mechanism, this field will be `None`
     pub min_gas_price: Option<U256>,


### PR DESCRIPTION
## Problem

`ChainInfo` models full latest-block metadata, but its only production consumer reads the block height and optional gas price. Aleo, Cosmos, Radix, Sealevel, and Starknet therefore fetch the height and then make a second block-detail request only to populate an unused hash and timestamp.

Parent #9433 makes the Sealevel `getBlock` response metadata-only, but the periodic metrics path still issues the request. This follow-up removes that request rather than merely shrinking it.

## Solution

- replace `ChainInfo.latest_block: BlockInfo` with the data metrics actually consume: `block_height: u64`
- return the already-fetched height directly on Aleo, Cosmos, Radix, Sealevel, and Starknet
- keep Ethereum's latest-block request because it also supplies the base fee
- keep Tron's current-block request because that API is its source of the current height
- reserve `get_block_by_height` and #9433's metadata-only Sealevel request for real block consumers such as scraper persistence

This deliberately avoids fabricating a `BlockInfo` with zero hash/timestamp fields, which would make invalid metadata available to future consumers.

## Expected improvement

| Protocol | Before each metrics update | After | Guaranteed reduction |
|---|---|---|---|
| Sealevel | finalized `getSlot` + `getBlock` | finalized `getSlot` | 1 `getBlock` |
| Aleo | latest height + full block | latest height | 1 full-block request |
| Cosmos | block number + full block | block number | 1 full-block request |
| Radix | ledger state + transaction stream | ledger state | 1 transaction-stream request |
| Starknet | block number + full block | block number | 1 full-block request |
| Ethereum | latest block, also used for base fee | unchanged | 0 |
| Tron | current block, also supplies height | unchanged | 0 |

For the current production relayer, the measured Sealevel window contained exactly 35 periodic `getBlock` calls per chain over 35 minutes on `eclipsemainnet`, `solanamainnet`, and `sonicsvm`: 105 calls / 35 minutes, or **180 calls/hour** across those three chains. This PR removes 100% of those metrics-path calls. The four additional protocol reductions above follow directly from removing one second request per metrics update; no fleet-wide total is claimed without a matching production measurement.

No timing constant changes. The updater interval remains unchanged; the saving is one redundant detail request per update on each affected provider.

## Correctness

- the exported height still comes from each provider's existing latest/finalized-height request
- gas-price behavior is unchanged
- Sealevel keeps finalized commitment and fallback behavior
- actual block retrieval still returns real hash/timestamp metadata
- the type can no longer expose invented or unused block metadata through the metrics path

## Verification

- `cargo test -p hyperlane-sealevel chain_metrics_only_fetch_finalized_slot --lib` (1 passed; asserts the only request is finalized `getSlot`)
- `cargo test -p hyperlane-aleo chain_metrics_only_fetch_block_height --lib` (1 passed)
- `cargo check -p hyperlane-ethereum -p hyperlane-tron`
- `cargo check -p hyperlane-fuel` (generates bindings required by workspace formatting)
- `cargo fmt --all --check --manifest-path rust/main/Cargo.toml`
- `cargo fmt --all --check --manifest-path rust/sealevel/Cargo.toml`
- commit hooks, including gitleaks and staged-file checks
- fresh exact-head CI is running

Exact head: `b1ccc2edc2daf1decee34b494f4fb662ea91366d`

Stack parent: #9433 (`3efdb8860dc29843687cfdf9c887a9e45937a633`)

Master performance epic: #9386.