### PR TITLE
chore(infra): update mainnet and testnet agent images

### DIFF
--- a/typescript/infra/config/docker.ts
+++ b/typescript/infra/config/docker.ts
@@ -43,13 +43,13 @@ interface MainnetDockerTags extends BaseDockerTags {
 
 export const mainnetDockerTags: MainnetDockerTags = {
   // rust agents
-  relayer: 'c9a3852-20260902-193249',
-  relayerRC: 'c9a3852-20260902-193249',
-  relayerFastPath: 'c9a3852-20260902-193249',
-  validator: 'c35e861-20260831-121837',
-  validatorRC: 'c35e861-20260831-121837',
-  validatorFastPath: 'c35e861-20260831-121837',
-  scraper: 'c35e861-20260831-121837',
+  relayer: '9008ed6-20260903-002629',
+  relayerRC: '9008ed6-20260903-002629',
+  relayerFastPath: '9008ed6-20260903-002629',
+  validator: '9008ed6-20260903-002629',
+  validatorRC: '9008ed6-20260903-002629',
+  validatorFastPath: '9008ed6-20260903-002629',
+  scraper: '9008ed6-20260903-002629',
   // monorepo services
   checkWarpDeploy: 'main',
   validatorMonitor: '2c47a33-20260724-134609',
@@ -63,13 +63,13 @@ export const mainnetDockerTags: MainnetDockerTags = {
 
 export const testnetDockerTags: BaseDockerTags = {
   // rust agents
-  relayer: '14646bd-20260805-072134',
-  relayerRC: '14646bd-20260805-072134',
-  relayerFastPath: '14646bd-20260805-072134',
-  validator: '14646bd-20260805-072134',
-  validatorRC: '14646bd-20260805-072134',
-  validatorFastPath: '14646bd-20260805-072134',
-  scraper: '3fa7390-20260819-114148',
+  relayer: '9008ed6-20260903-002629',
+  relayerRC: '9008ed6-20260903-002629',
+  relayerFastPath: '9008ed6-20260903-002629',
+  validator: '9008ed6-20260903-002629',
+  validatorRC: '9008ed6-20260903-002629',
+  validatorFastPath: '9008ed6-20260903-002629',
+  scraper: '9008ed6-20260903-002629',
   // standalone services
   keyFunder: '5dc6aa4-20260714-184449',
 };


### PR DESCRIPTION
## Summary

- update every Rust-agent image tag in `mainnet3` and `testnet4` to `9008ed6-20260903-002629`
- cover relayer, validator, scraper, RC, and fast-path configuration slots
- roll the current image to the active relayers, scrapers, and validator fleet described below

## Why

This image is built from exact `main` SHA `9008ed66d6e323c8f26191a6c34d1128f5e847bd`. It includes the merged lightweight Sealevel block-info work (#9433), removal of redundant block-detail metrics reads (#9442), and Aleo mapping-key URL encoding (#9293).

Those changes are shared by Rust agents. Updating only the production relayer would leave validators and scrapers on the older provider/metrics paths. Using one immutable tag across mainnet and testnet configuration also removes version skew for the next deployment of any agent context.

## Deployed scope

Relayers and scrapers:
- mainnet production relayer, fast-path relayer, and scraper
- testnet production relayer, already-running fast-path relayer, and scraper

Validators were rolled GCP first and legacy second, with concurrency 10. This kept the legacy/GCP copies for a chain from restarting together.

| Environment / namespace | Active StatefulSets | Pods | Scope |
|---|---:|---:|---|
| `mainnet3` | 77 | 77 | 70 standard + 7 fast-path validators |
| `validator-mainnet3` | 80 | 80 | 73 standard + 7 fast-path validators |
| `testnet4` | 14 | 20 | all enabled standard validators |
| `validator-testnet4` | 14 | 14 | all enabled standard validators |
| **Total** | **185** | **191** | active standard and fast-path validator fleet |

Disabled, stale, and zero-replica StatefulSets were intentionally excluded. In particular, this did not touch disabled `nesa` or stale legacy `tempo` / `zircuit` releases. Disabled SVM chains (`soon`, `eclipsetestnet`, `sonicsvmtestnet`) also remained undeployed.

Legacy validator copies were changed with image-only StatefulSet rollouts because the current infra manager owns their GCP replacements; this avoided changing unrelated legacy Helm values. The committed Docker tags prevent a future managed deploy from reverting the image.

## Verification

- image build: https://github.com/hyperlane-xyz/hyperlane-monorepo/actions/runs/33699503901
- image source SHA: `9008ed66d6e323c8f26191a6c34d1128f5e847bd`
- GHCR/runtime digest: `sha256:599eff44900ab383444aafd4b9fde409215bb6c604b179a03fa8ca7ab4a31262`
- all 185 selected validator StatefulSets / 191 pods are Ready on the exact digest with zero restarts
- both `aleotestnet` validators changed from persistent HTTP-400 crashloops on their old images to Ready with zero restarts on this image, empirically validating #9293 in both legacy and GCP deployments
- root `pnpm install` succeeded; `pnpm turbo build` from `typescript/infra` passed 22/22 tasks
- `mainnet3` and `testnet4` agent-config CI passed; all current PR checks are green
- pre-commit gitleaks, oxlint, and oxfmt passed



## Post-merge follow-up

#9451 removes two inherited #9426 side effects from this deployed image: cross-destination relay admission deadlock risk and archived-WAL retention in non-relayer agent databases.
