### PR TITLE
perf(relayer): batch merkle tree insertion ingestion per tick

### DIFF
--- a/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
@@ -23,11 +23,7 @@ use super::builder::MerkleTreeBuilder;
 
 const PREFIX: &str = "db_loader::merkle_tree";
 
-/// Maximum number of consecutive leaves ingested in a single tick.
-///
-/// A backlog previously cost one tick turn plus one prover write-lock
-/// acquisition per leaf. Batching amortizes that overhead while keeping the
-/// write-guard hold bounded; leaves are still ingested in strict index order.
+/// Maximum consecutive leaves ingested under one prover write lock.
 const MAX_LEAVES_PER_TICK: usize = 32;
 
 /// Finds unprocessed merkle tree insertions and adds them to the prover sync
@@ -64,8 +60,6 @@ impl DbLoaderExt for MerkleTreeDbLoader {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
-        // Collect a bounded run of consecutive leaves without holding the
-        // prover lock, so DB reads never block proof readers.
         let mut insertions = Vec::new();
         while insertions.len() < MAX_LEAVES_PER_TICK {
             let index = self.leaf_index + insertions.len() as u32;
@@ -85,16 +79,11 @@ impl DbLoaderExt for MerkleTreeDbLoader {
             return Ok(());
         }
 
-        // Ingest the whole batch under a single write-guard acquisition.
-        // `leaf_index` advances only past successfully ingested leaves, so a
-        // mid-batch failure replays from the failed leaf exactly as before.
         let begin = {
-            // drop the guard at the end of this block
             let mut guard = self.prover_sync.write().await;
             let begin = Instant::now();
             for insertion in &insertions {
                 guard.ingest_message_id(insertion.message_id())?;
-                // Increase the leaf index to move on to the next leaf
                 self.leaf_index += 1;
             }
             begin
@@ -216,8 +205,6 @@ mod tests {
 
     #[tokio::test]
     async fn tick_on_gap_advances_only_past_present_leaves() {
-        // Leaves 0,1 present; leaf 2 missing; leaf 3 present. The loader must
-        // stop at the gap and resume from it, never skipping leaf 2.
         let dir = tempfile::tempdir().unwrap();
         let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
         let db = HyperlaneRocksDB::new(&domain, DB::from_path(dir.path()).unwrap());
@@ -237,7 +224,6 @@ mod tests {
         );
         loader.tick().await.unwrap();
         assert_eq!(loader.leaf_index, 2);
-        // Fill the gap; the next tick picks up exactly where it stopped.
         db.store_merkle_tree_insertion_by_leaf_index(
             &2,
             &MerkleTreeInsertion::new(2, H256::from_low_u64_be(2)),

--- a/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
@@ -23,6 +23,13 @@ use super::builder::MerkleTreeBuilder;
 
 const PREFIX: &str = "db_loader::merkle_tree";
 
+/// Maximum number of consecutive leaves ingested in a single tick.
+///
+/// A backlog previously cost one tick turn plus one prover write-lock
+/// acquisition per leaf. Batching amortizes that overhead while keeping the
+/// write-guard hold bounded; leaves are still ingested in strict index order.
+const MAX_LEAVES_PER_TICK: usize = 32;
+
 /// Finds unprocessed merkle tree insertions and adds them to the prover sync
 #[derive(new)]
 pub struct MerkleTreeDbLoader {
@@ -57,48 +64,55 @@ impl DbLoaderExt for MerkleTreeDbLoader {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
-        if let Some(insertion) = self.next_unprocessed_leaf().await? {
-            // Feed the message to the prover sync
-
-            let begin = {
-                // drop the guard at the end of this block
-                let mut guard = self.prover_sync.write().await;
-                let begin = Instant::now();
-                guard.ingest_message_id(insertion.message_id())?;
-                begin
-            };
-
-            self.metrics
-                .merkle_tree_ingest_message_id_total_elapsed_micros
-                .inc_by(begin.elapsed().as_micros() as u64);
-            self.metrics.merkle_tree_ingest_message_ids_count.inc();
-
-            // Increase the leaf index to move on to the next leaf
-            self.leaf_index += 1;
-        } else {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+        // Collect a bounded run of consecutive leaves without holding the
+        // prover lock, so DB reads never block proof readers.
+        let mut insertions = Vec::new();
+        while insertions.len() < MAX_LEAVES_PER_TICK {
+            let index = self.leaf_index + insertions.len() as u32;
+            let begin = Instant::now();
+            match self.retrieve_at(index).await? {
+                Some(insertion) => {
+                    self.update_metrics(&insertion, &begin);
+                    insertions.push(insertion);
+                }
+                None => break,
+            }
         }
+
+        if insertions.is_empty() {
+            trace!(leaf_index=?self.leaf_index, "No merkle tree insertion found in DB for leaf index, waiting for it to be indexed");
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            return Ok(());
+        }
+
+        // Ingest the whole batch under a single write-guard acquisition.
+        // `leaf_index` advances only past successfully ingested leaves, so a
+        // mid-batch failure replays from the failed leaf exactly as before.
+        let begin = {
+            // drop the guard at the end of this block
+            let mut guard = self.prover_sync.write().await;
+            let begin = Instant::now();
+            for insertion in &insertions {
+                guard.ingest_message_id(insertion.message_id())?;
+                // Increase the leaf index to move on to the next leaf
+                self.leaf_index += 1;
+            }
+            begin
+        };
+
+        self.metrics
+            .merkle_tree_ingest_message_id_total_elapsed_micros
+            .inc_by(begin.elapsed().as_micros() as u64);
+        self.metrics
+            .merkle_tree_ingest_message_ids_count
+            .inc_by(insertions.len() as u64);
         Ok(())
     }
 }
 
 impl MerkleTreeDbLoader {
-    async fn next_unprocessed_leaf(&self) -> Result<Option<MerkleTreeInsertion>> {
-        let begin = Instant::now();
-        let leaf = if let Some(insertion) = self.retrieve().await? {
-            self.update_metrics(&insertion, &begin);
-            Some(insertion)
-        } else {
-            trace!(leaf_index=?self.leaf_index,"No merkle tree insertion found in DB for leaf index, waiting for it to be indexed");
-            None
-        };
-
-        Ok(leaf)
-    }
-
-    async fn retrieve(&self) -> Result<Option<MerkleTreeInsertion>> {
+    async fn retrieve_at(&self, index: u32) -> Result<Option<MerkleTreeInsertion>> {
         let db = self.db.clone();
-        let index = self.leaf_index;
         let name = format!("{}::retrieval::{}::{}", PREFIX, self.domain(), index);
         let insertion = tokio::task::Builder::new()
             .name(&name)
@@ -148,5 +162,90 @@ impl MerkleTreeDbLoaderMetrics {
                 .merkle_tree_ingest_message_ids_count()
                 .with_label_values(&[origin.name()]),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::Registry;
+
+    use hyperlane_base::db::{HyperlaneDb, HyperlaneRocksDB, DB};
+    use hyperlane_base::CoreMetrics;
+    use hyperlane_core::{HyperlaneDomain, KnownHyperlaneDomain, MerkleTreeInsertion, H256};
+
+    use super::super::builder::MerkleTreeBuilder;
+    use super::*;
+    use crate::db_loader::DbLoaderExt;
+
+    fn test_loader(insertion_count: u32, port: u16) -> (tempfile::TempDir, MerkleTreeDbLoader) {
+        let dir = tempfile::tempdir().unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let db = HyperlaneRocksDB::new(&domain, DB::from_path(dir.path()).unwrap());
+        for i in 0..insertion_count {
+            db.store_merkle_tree_insertion_by_leaf_index(
+                &i,
+                &MerkleTreeInsertion::new(i, H256::from_low_u64_be(i as u64)),
+            )
+            .unwrap();
+        }
+        let core_metrics = CoreMetrics::new("test-merkle-loader", port, Registry::new()).unwrap();
+        let loader = MerkleTreeDbLoader::new(
+            db,
+            MerkleTreeDbLoaderMetrics::new(&core_metrics, &domain),
+            Arc::new(RwLock::new(MerkleTreeBuilder::new())),
+        );
+        (dir, loader)
+    }
+
+    #[tokio::test]
+    async fn tick_drains_backlog_in_batches_preserving_order() {
+        let (_dir, mut loader) = test_loader((MAX_LEAVES_PER_TICK as u32) + 5, 49101);
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, MAX_LEAVES_PER_TICK as u32);
+        assert_eq!(
+            loader.prover_sync.read().await.count(),
+            MAX_LEAVES_PER_TICK as u32
+        );
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, (MAX_LEAVES_PER_TICK as u32) + 5);
+        assert_eq!(
+            loader.prover_sync.read().await.count(),
+            (MAX_LEAVES_PER_TICK as u32) + 5
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_on_gap_advances_only_past_present_leaves() {
+        // Leaves 0,1 present; leaf 2 missing; leaf 3 present. The loader must
+        // stop at the gap and resume from it, never skipping leaf 2.
+        let dir = tempfile::tempdir().unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let db = HyperlaneRocksDB::new(&domain, DB::from_path(dir.path()).unwrap());
+        for i in [0u32, 1, 3] {
+            db.store_merkle_tree_insertion_by_leaf_index(
+                &i,
+                &MerkleTreeInsertion::new(i, H256::from_low_u64_be(i as u64)),
+            )
+            .unwrap();
+        }
+        let core_metrics =
+            CoreMetrics::new("test-merkle-loader-gap", 49102, Registry::new()).unwrap();
+        let mut loader = MerkleTreeDbLoader::new(
+            db.clone(),
+            MerkleTreeDbLoaderMetrics::new(&core_metrics, &domain),
+            Arc::new(RwLock::new(MerkleTreeBuilder::new())),
+        );
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, 2);
+        // Fill the gap; the next tick picks up exactly where it stopped.
+        db.store_merkle_tree_insertion_by_leaf_index(
+            &2,
+            &MerkleTreeInsertion::new(2, H256::from_low_u64_be(2)),
+        )
+        .unwrap();
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, 4);
+        assert_eq!(loader.prover_sync.read().await.count(), 4);
+        let _ = dir;
     }
 }

--- a/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
@@ -60,7 +60,7 @@ impl DbLoaderExt for MerkleTreeDbLoader {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
-        let mut insertions = Vec::new();
+        let mut insertions = Vec::with_capacity(MAX_LEAVES_PER_TICK);
         while insertions.len() < MAX_LEAVES_PER_TICK {
             let index = self.leaf_index + insertions.len() as u32;
             let begin = Instant::now();
@@ -197,9 +197,30 @@ mod tests {
         );
         loader.tick().await.unwrap();
         assert_eq!(loader.leaf_index, (MAX_LEAVES_PER_TICK as u32) + 5);
+        let prover_sync = loader.prover_sync.read().await;
+        let insertion_count = (MAX_LEAVES_PER_TICK as u32) + 5;
+        assert_eq!(prover_sync.count(), insertion_count);
+        for index in 0..insertion_count {
+            assert_eq!(
+                prover_sync
+                    .get_proof(index, insertion_count - 1)
+                    .unwrap()
+                    .leaf,
+                H256::from_low_u64_be(index as u64)
+            );
+        }
+        drop(prover_sync);
         assert_eq!(
-            loader.prover_sync.read().await.count(),
-            (MAX_LEAVES_PER_TICK as u32) + 5
+            loader.metrics.merkle_tree_retrieve_insertions_count.get(),
+            insertion_count as u64
+        );
+        assert_eq!(
+            loader.metrics.merkle_tree_ingest_message_ids_count.get(),
+            insertion_count as u64
+        );
+        assert_eq!(
+            loader.metrics.latest_tree_insertion_index_gauge.get(),
+            (insertion_count - 1) as i64
         );
     }
 
@@ -231,7 +252,14 @@ mod tests {
         .unwrap();
         loader.tick().await.unwrap();
         assert_eq!(loader.leaf_index, 4);
-        assert_eq!(loader.prover_sync.read().await.count(), 4);
+        let prover_sync = loader.prover_sync.read().await;
+        assert_eq!(prover_sync.count(), 4);
+        for index in 0..4 {
+            assert_eq!(
+                prover_sync.get_proof(index, 3).unwrap().leaf,
+                H256::from_low_u64_be(index as u64)
+            );
+        }
         let _ = dir;
     }
 }


### PR DESCRIPTION
## Outcome

Batch consecutive Merkle leaves under one prover write lock. Backlog lock acquisitions fall from `N` to `ceil(N/32)` without changing leaf order, metrics, RPC usage or idle behaviour.

## Change

| | Before | After |
| --- | --- | --- |
| DB reads | One leaf at a time | Up to 32 consecutive leaves outside the lock |
| Prover write lock | Once per leaf | Once per batch |
| Gap handling | Stop at first missing leaf | Unchanged |
| Empty tick | Sleep 1s | Unchanged |

## Expected impact

| Case | Lock acquisitions | Reduction |
| --- | ---: | ---: |
| Full 32-leaf batch | 32 → 1 | **96.875%** |
| `N` consecutive leaves | `N` → `ceil(N/32)` | Up to **96.875%** |
| 37-leaf test backlog | 37 → 2 ticks | 32 + 5 leaves |

This is code-derived, not yet measured in production. The likely effect is faster prover catch-up and less `get_proof` contention; RPC volume is unchanged because this path is RocksDB + memory.

`32` gives the full 32× lock-amortization win while keeping each critical section explicitly bounded. It is a starting point, not a measured optimum; tune it only from guard-contention and drain-time data.

## Correctness / verification

- Strict leaf order; cursor advances only after each successful ingest.
- Retrieval/ingestion counters and latest-index gauge retain per-leaf semantics.
- Proofs remain correct across a 37-leaf two-tick drain; gap stop/resume is covered.
- `cargo test -p relayer merkle_tree::db_loader::tests` and commit hooks passed.
- No config/schema change. Rollback is image-only.

Part of #9386. Orthogonal to the message-loader stack: this changes `merkle_tree/db_loader.rs`, not `msg/db_loader.rs`.


Rebased on `main@06d8269ef1`; exact head `4c85d9d7d3`.