### PR TITLE
perf(validator): skip verified checkpoint history via backfill floor

### DIFF
--- a/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/db_loader.rs
@@ -23,6 +23,13 @@ use super::builder::MerkleTreeBuilder;
 
 const PREFIX: &str = "db_loader::merkle_tree";
 
+/// Maximum number of consecutive leaves ingested in a single tick.
+///
+/// A backlog previously cost one tick turn plus one prover write-lock
+/// acquisition per leaf. Batching amortizes that overhead while keeping the
+/// write-guard hold bounded; leaves are still ingested in strict index order.
+const MAX_LEAVES_PER_TICK: usize = 32;
+
 /// Finds unprocessed merkle tree insertions and adds them to the prover sync
 #[derive(new)]
 pub struct MerkleTreeDbLoader {
@@ -57,48 +64,55 @@ impl DbLoaderExt for MerkleTreeDbLoader {
     /// One round of processing, extracted from infinite work loop for
     /// testing purposes.
     async fn tick(&mut self) -> Result<()> {
-        if let Some(insertion) = self.next_unprocessed_leaf().await? {
-            // Feed the message to the prover sync
-
-            let begin = {
-                // drop the guard at the end of this block
-                let mut guard = self.prover_sync.write().await;
-                let begin = Instant::now();
-                guard.ingest_message_id(insertion.message_id())?;
-                begin
-            };
-
-            self.metrics
-                .merkle_tree_ingest_message_id_total_elapsed_micros
-                .inc_by(begin.elapsed().as_micros() as u64);
-            self.metrics.merkle_tree_ingest_message_ids_count.inc();
-
-            // Increase the leaf index to move on to the next leaf
-            self.leaf_index += 1;
-        } else {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+        // Collect a bounded run of consecutive leaves without holding the
+        // prover lock, so DB reads never block proof readers.
+        let mut insertions = Vec::new();
+        while insertions.len() < MAX_LEAVES_PER_TICK {
+            let index = self.leaf_index + insertions.len() as u32;
+            let begin = Instant::now();
+            match self.retrieve_at(index).await? {
+                Some(insertion) => {
+                    self.update_metrics(&insertion, &begin);
+                    insertions.push(insertion);
+                }
+                None => break,
+            }
         }
+
+        if insertions.is_empty() {
+            trace!(leaf_index=?self.leaf_index, "No merkle tree insertion found in DB for leaf index, waiting for it to be indexed");
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            return Ok(());
+        }
+
+        // Ingest the whole batch under a single write-guard acquisition.
+        // `leaf_index` advances only past successfully ingested leaves, so a
+        // mid-batch failure replays from the failed leaf exactly as before.
+        let begin = {
+            // drop the guard at the end of this block
+            let mut guard = self.prover_sync.write().await;
+            let begin = Instant::now();
+            for insertion in &insertions {
+                guard.ingest_message_id(insertion.message_id())?;
+                // Increase the leaf index to move on to the next leaf
+                self.leaf_index += 1;
+            }
+            begin
+        };
+
+        self.metrics
+            .merkle_tree_ingest_message_id_total_elapsed_micros
+            .inc_by(begin.elapsed().as_micros() as u64);
+        self.metrics
+            .merkle_tree_ingest_message_ids_count
+            .inc_by(insertions.len() as u64);
         Ok(())
     }
 }
 
 impl MerkleTreeDbLoader {
-    async fn next_unprocessed_leaf(&self) -> Result<Option<MerkleTreeInsertion>> {
-        let begin = Instant::now();
-        let leaf = if let Some(insertion) = self.retrieve().await? {
-            self.update_metrics(&insertion, &begin);
-            Some(insertion)
-        } else {
-            trace!(leaf_index=?self.leaf_index,"No merkle tree insertion found in DB for leaf index, waiting for it to be indexed");
-            None
-        };
-
-        Ok(leaf)
-    }
-
-    async fn retrieve(&self) -> Result<Option<MerkleTreeInsertion>> {
+    async fn retrieve_at(&self, index: u32) -> Result<Option<MerkleTreeInsertion>> {
         let db = self.db.clone();
-        let index = self.leaf_index;
         let name = format!("{}::retrieval::{}::{}", PREFIX, self.domain(), index);
         let insertion = tokio::task::Builder::new()
             .name(&name)
@@ -148,5 +162,90 @@ impl MerkleTreeDbLoaderMetrics {
                 .merkle_tree_ingest_message_ids_count()
                 .with_label_values(&[origin.name()]),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus::Registry;
+
+    use hyperlane_base::db::{HyperlaneDb, HyperlaneRocksDB, DB};
+    use hyperlane_base::CoreMetrics;
+    use hyperlane_core::{HyperlaneDomain, KnownHyperlaneDomain, MerkleTreeInsertion, H256};
+
+    use super::super::builder::MerkleTreeBuilder;
+    use super::*;
+    use crate::db_loader::DbLoaderExt;
+
+    fn test_loader(insertion_count: u32, port: u16) -> (tempfile::TempDir, MerkleTreeDbLoader) {
+        let dir = tempfile::tempdir().unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let db = HyperlaneRocksDB::new(&domain, DB::from_path(dir.path()).unwrap());
+        for i in 0..insertion_count {
+            db.store_merkle_tree_insertion_by_leaf_index(
+                &i,
+                &MerkleTreeInsertion::new(i, H256::from_low_u64_be(i as u64)),
+            )
+            .unwrap();
+        }
+        let core_metrics = CoreMetrics::new("test-merkle-loader", port, Registry::new()).unwrap();
+        let loader = MerkleTreeDbLoader::new(
+            db,
+            MerkleTreeDbLoaderMetrics::new(&core_metrics, &domain),
+            Arc::new(RwLock::new(MerkleTreeBuilder::new())),
+        );
+        (dir, loader)
+    }
+
+    #[tokio::test]
+    async fn tick_drains_backlog_in_batches_preserving_order() {
+        let (_dir, mut loader) = test_loader((MAX_LEAVES_PER_TICK as u32) + 5, 49101);
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, MAX_LEAVES_PER_TICK as u32);
+        assert_eq!(
+            loader.prover_sync.read().await.count(),
+            MAX_LEAVES_PER_TICK as u32
+        );
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, (MAX_LEAVES_PER_TICK as u32) + 5);
+        assert_eq!(
+            loader.prover_sync.read().await.count(),
+            (MAX_LEAVES_PER_TICK as u32) + 5
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_on_gap_advances_only_past_present_leaves() {
+        // Leaves 0,1 present; leaf 2 missing; leaf 3 present. The loader must
+        // stop at the gap and resume from it, never skipping leaf 2.
+        let dir = tempfile::tempdir().unwrap();
+        let domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Ethereum);
+        let db = HyperlaneRocksDB::new(&domain, DB::from_path(dir.path()).unwrap());
+        for i in [0u32, 1, 3] {
+            db.store_merkle_tree_insertion_by_leaf_index(
+                &i,
+                &MerkleTreeInsertion::new(i, H256::from_low_u64_be(i as u64)),
+            )
+            .unwrap();
+        }
+        let core_metrics =
+            CoreMetrics::new("test-merkle-loader-gap", 49102, Registry::new()).unwrap();
+        let mut loader = MerkleTreeDbLoader::new(
+            db.clone(),
+            MerkleTreeDbLoaderMetrics::new(&core_metrics, &domain),
+            Arc::new(RwLock::new(MerkleTreeBuilder::new())),
+        );
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, 2);
+        // Fill the gap; the next tick picks up exactly where it stopped.
+        db.store_merkle_tree_insertion_by_leaf_index(
+            &2,
+            &MerkleTreeInsertion::new(2, H256::from_low_u64_be(2)),
+        )
+        .unwrap();
+        loader.tick().await.unwrap();
+        assert_eq!(loader.leaf_index, 4);
+        assert_eq!(loader.prover_sync.read().await.count(), 4);
+        let _ = dir;
     }
 }

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -99,6 +99,26 @@ impl ValidatorSubmitter {
         self.submit_checkpoints_until_correctness_checkpoint(&mut tree, &target_checkpoint)
             .await;
 
+        // The full range `[0, target]` is now verified present and matching in
+        // storage (every queued checkpoint was either already matching or just
+        // written), so persist the floor: the next restart skips re-fetching
+        // and re-recovering history and resumes from the tail.
+        call_and_retry_indefinitely(|| {
+            let self_clone = self.clone();
+            let target_index = target_checkpoint.index;
+            Box::pin(async move {
+                match self_clone
+                    .checkpoint_syncer
+                    .write_backfill_floor_index(target_index)
+                    .await
+                {
+                    Ok(()) => Ok(()),
+                    Err(error) => Err(error.into()),
+                }
+            })
+        })
+        .await;
+
         info!(
             ?target_checkpoint,
             "Backfill checkpoint submitter successfully reached target checkpoint"
@@ -280,6 +300,24 @@ impl ValidatorSubmitter {
         let mut checkpoint_queue = vec![];
         let mut blocked_insertion_operation: Option<String> = None;
 
+        // A previous run may have fully verified every checkpoint up to the
+        // backfill floor. `latest_index` cannot serve this purpose: it advances
+        // after the first submitted chunk, before history is complete.
+        let floor_index = match self.checkpoint_syncer.backfill_floor_index().await {
+            Ok(floor) => floor,
+            Err(err) => {
+                warn!(
+                    ?err,
+                    "Failed to read backfill floor, submitting full history"
+                );
+                None
+            }
+        };
+        // Validate the floor against this run's tree at most at the target: a
+        // floor at or past the target still needs a check before trusting it.
+        let validation_index = floor_index.map(|floor| floor.min(correctness_checkpoint.index));
+        let mut expected_at_validation_index: Option<CheckpointWithMessageId> = None;
+
         // If the correctness checkpoint is ahead of the tree, we need to ingest more messages.
         //
         // tree.index() will panic if the tree is empty, so we use tree.count() instead
@@ -323,10 +361,16 @@ impl ValidatorSubmitter {
 
             let checkpoint = self.checkpoint(tree);
 
-            checkpoint_queue.push(CheckpointWithMessageId {
+            let queued = CheckpointWithMessageId {
                 checkpoint,
                 message_id,
-            });
+            };
+            // Capture what the checkpoint at the validation index must be, so
+            // the persisted floor can be checked against this run's tree.
+            if validation_index == Some(queued.index) {
+                expected_at_validation_index = Some(queued);
+            }
+            checkpoint_queue.push(queued);
         }
 
         info!(
@@ -385,6 +429,23 @@ impl ValidatorSubmitter {
             panic!("{panic_message}");
         }
 
+        // The tree root is verified above, so checkpoints at or below a validated
+        // floor need no re-fetch, re-sign, or rewrite: drop them before the
+        // per-checkpoint submission loop.
+        if let Some(floor) = self
+            .validated_backfill_floor(floor_index, validation_index, expected_at_validation_index)
+            .await
+        {
+            let queued = checkpoint_queue.len();
+            checkpoint_queue.retain(|checkpoint| checkpoint.index > floor);
+            info!(
+                floor,
+                skipped = queued - checkpoint_queue.len(),
+                remaining = checkpoint_queue.len(),
+                "Skipped checkpoints at or below the validated backfill floor"
+            );
+        }
+
         tracing::info!(
             elapsed=?start.elapsed(),
             checkpoint_queue_len = checkpoint_queue.len(),
@@ -403,6 +464,67 @@ impl ValidatorSubmitter {
                 index = checkpoint.index,
                 "Signed all queued checkpoints until index"
             );
+        }
+    }
+
+    /// Returns the persisted backfill floor if a single storage read proves it
+    /// still matches this run's tree: the stored checkpoint at the validation
+    /// index must exist, recover to this validator, and equal the locally
+    /// computed value. Anything else (missing, mismatched, unreadable floor)
+    /// yields `None`, i.e. submit the full history as before.
+    async fn validated_backfill_floor(
+        &self,
+        floor_index: Option<u32>,
+        validation_index: Option<u32>,
+        expected_at_validation_index: Option<CheckpointWithMessageId>,
+    ) -> Option<u32> {
+        let floor = floor_index?;
+        let validation_index = validation_index?;
+        let expected = expected_at_validation_index?;
+        match self
+            .checkpoint_syncer
+            .fetch_checkpoint(validation_index)
+            .await
+        {
+            Ok(Some(existing)) => match existing.recover() {
+                Ok(signer) if signer == self.signer.eth_address() && existing.value == expected => {
+                    Some(floor)
+                }
+                Ok(signer) => {
+                    warn!(
+                        floor,
+                        validation_index,
+                        ?signer,
+                        "Backfill floor checkpoint mismatch, submitting full history"
+                    );
+                    None
+                }
+                Err(err) => {
+                    warn!(
+                        floor,
+                        validation_index,
+                        ?err,
+                        "Backfill floor checkpoint recovery failed, submitting full history"
+                    );
+                    None
+                }
+            },
+            Ok(None) => {
+                warn!(
+                    floor,
+                    validation_index, "Backfill floor checkpoint missing, submitting full history"
+                );
+                None
+            }
+            Err(err) => {
+                warn!(
+                    floor,
+                    validation_index,
+                    ?err,
+                    "Backfill floor checkpoint fetch failed, submitting full history"
+                );
+                None
+            }
         }
     }
 
@@ -550,7 +672,7 @@ impl ValidatorSubmitter {
                                 return Err(error);
                             }
                         };
-                        tracing::info!(
+                        tracing::debug!(
                             index = checkpoint_index,
                             wrote_checkpoint,
                             elapsed=?start.elapsed(),

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -440,7 +440,7 @@ impl ValidatorSubmitter {
             checkpoint_queue.retain(|checkpoint| checkpoint.index > floor);
             info!(
                 floor,
-                skipped = queued - checkpoint_queue.len(),
+                skipped = queued.saturating_sub(checkpoint_queue.len()),
                 remaining = checkpoint_queue.len(),
                 "Skipped checkpoints at or below the validated backfill floor"
             );

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -56,6 +56,8 @@ mockall::mock! {
 
     #[async_trait]
     impl CheckpointSyncer for CheckpointSyncer {
+        async fn backfill_floor_index(&self) -> Result<Option<u32>>;
+        async fn write_backfill_floor_index(&self, index: u32) -> Result<()>;
         async fn latest_index(&self) -> Result<Option<u32>>;
         async fn write_latest_index(&self, index: u32) -> Result<()>;
         async fn update_latest_index(&self, index: u32) -> Result<()>;
@@ -264,6 +266,10 @@ async fn missing_merkle_insertion_blocks_readiness_until_indexer_recovers() {
         .return_const(domain.clone());
 
     let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_backfill_floor_index()
+        .times(1)
+        .returning(|| Ok(None));
     checkpoint_syncer
         .expect_fetch_checkpoint()
         .once()
@@ -901,6 +907,10 @@ async fn reorg_is_detected_and_persisted_to_checkpoint_storage() {
     // and not submit any checkpoints (this is checked implicitly, by not setting any `expect`s)
     let unix_timestamp = chrono::Utc::now().timestamp() as u64;
     let mut mock_checkpoint_syncer = MockCheckpointSyncer::new();
+    mock_checkpoint_syncer
+        .expect_backfill_floor_index()
+        .times(1)
+        .returning(|| Ok(None));
     let mock_onchain_merkle_tree_clone = mock_onchain_merkle_tree.clone();
     mock_checkpoint_syncer
         .expect_write_reorg_status()
@@ -1192,4 +1202,176 @@ async fn sign_and_submit_checkpoint_different_signature() {
         .await;
 
     logs_contain("Checkpoint already submitted, but with different signature, overwriting");
+}
+
+fn three_checkpoint_fixture() -> (
+    HyperlaneDomain,
+    Vec<MerkleTreeInsertion>,
+    CheckpointWithMessageId,
+    CheckpointAtBlock,
+) {
+    let domain = dummy_domain(0, "dummy_domain");
+    let insertions: Vec<MerkleTreeInsertion> = (0..3)
+        .map(|i| MerkleTreeInsertion::new(i, H256::from_low_u64_be(11 * (i as u64 + 1))))
+        .collect();
+
+    let mut tree = IncrementalMerkle::default();
+    for insertion in insertions.iter().take(2) {
+        tree.ingest(insertion.message_id());
+    }
+    let expected_at_floor = CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: tree.root(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: domain.id(),
+            index: 1,
+        },
+        message_id: insertions[1].message_id(),
+    };
+    tree.ingest(insertions[2].message_id());
+    let target = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: tree.root(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: domain.id(),
+            index: 2,
+        },
+        block_height: Some(1),
+    };
+    (domain, insertions, expected_at_floor, target)
+}
+
+fn floor_test_submitter(
+    domain: HyperlaneDomain,
+    signer: Signers,
+    checkpoint_syncer: MockCheckpointSyncer,
+    db: MockDb,
+) -> ValidatorSubmitter {
+    let mut merkle_tree_hook = MockMerkleTreeHook::new();
+    merkle_tree_hook.expect_address().returning(H256::zero);
+    merkle_tree_hook
+        .expect_domain()
+        .return_const(domain.clone());
+    ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(merkle_tree_hook),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(db),
+        dummy_metrics(),
+        50,
+        Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
+    )
+}
+
+#[tokio::test(start_paused = true)]
+async fn validated_floor_skips_verified_history() {
+    let (domain, insertions, expected_at_floor, target) = three_checkpoint_fixture();
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let signed_at_floor = signer.sign(expected_at_floor).await.unwrap();
+
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .times(3)
+        .returning(move |sequence| Ok(Some(insertions[*sequence as usize])));
+
+    let written = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_backfill_floor_index()
+        .times(1)
+        .returning(|| Ok(Some(1)));
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(2)
+        .returning(move |index| {
+            if index == 1 {
+                Ok(Some(signed_at_floor.clone()))
+            } else {
+                Ok(None)
+            }
+        });
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .times(1)
+        .returning({
+            let written = Arc::clone(&written);
+            move |signed| {
+                written.lock().unwrap().push(signed.value.index);
+                Ok(())
+            }
+        });
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(2))
+        .once()
+        .returning(|_| Ok(()));
+
+    let submitter = floor_test_submitter(domain, signer, checkpoint_syncer, db);
+    submitter
+        .submit_checkpoints_until_correctness_checkpoint(&mut IncrementalMerkle::default(), &target)
+        .await;
+
+    // Only the post-floor checkpoint is fetched, signed and written: a single
+    // validation read replaces the per-checkpoint fetch + recover loop.
+    assert_eq!(*written.lock().unwrap(), vec![2]);
+}
+
+#[tokio::test(start_paused = true)]
+async fn mismatched_floor_submits_full_history() {
+    let (domain, insertions, expected_at_floor, target) = three_checkpoint_fixture();
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let wrong_signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let wrongly_signed = wrong_signer.sign(expected_at_floor).await.unwrap();
+
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .times(3)
+        .returning(move |sequence| Ok(Some(insertions[*sequence as usize])));
+
+    let written = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_backfill_floor_index()
+        .times(1)
+        .returning(|| Ok(Some(1)));
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(4)
+        .returning(move |index| {
+            if index == 1 {
+                Ok(Some(wrongly_signed.clone()))
+            } else {
+                Ok(None)
+            }
+        });
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .times(3)
+        .returning({
+            let written = Arc::clone(&written);
+            move |signed| {
+                written.lock().unwrap().push(signed.value.index);
+                Ok(())
+            }
+        });
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(2))
+        .once()
+        .returning(|_| Ok(()));
+
+    let submitter = floor_test_submitter(domain, signer, checkpoint_syncer, db);
+    submitter
+        .submit_checkpoints_until_correctness_checkpoint(&mut IncrementalMerkle::default(), &target)
+        .await;
+
+    // A floor that fails validation submits everything, like today.
+    let mut written = written.lock().unwrap().clone();
+    written.sort_unstable();
+    assert_eq!(written, vec![0, 1, 2]);
 }

--- a/rust/main/hyperlane-base/src/traits/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/traits/checkpoint_syncer.rs
@@ -10,6 +10,25 @@ use hyperlane_core::{
 /// A generic trait to read/write Checkpoints offchain
 #[async_trait]
 pub trait CheckpointSyncer: Debug + Send + Sync {
+    /// Read the backfill floor of this Syncer: the highest checkpoint index such
+    /// that every checkpoint in `[0, floor]` was fully verified (fetched,
+    /// signature-recovered and value-matched, or written by this validator).
+    /// Unlike `latest_index` — which advances after the first submitted chunk,
+    /// before history is complete — the floor only advances once a full
+    /// backfill drain is verified, so restarts can skip re-submitting history.
+    ///
+    /// Defaults to `None` (no floor, full backfill as before). Backends that
+    /// cannot persist the marker keep this default and safely degrade to full
+    /// backfills.
+    async fn backfill_floor_index(&self) -> Result<Option<u32>> {
+        Ok(None)
+    }
+    /// Writes the backfill floor of this Syncer. Best-effort: backends without
+    /// durable marker support keep the default no-op and degrade to full
+    /// backfills on restart.
+    async fn write_backfill_floor_index(&self, _index: u32) -> Result<()> {
+        Ok(())
+    }
     /// Read the highest index of this Syncer
     async fn latest_index(&self) -> Result<Option<u32>>;
     /// Writes the highest index of this Syncer

--- a/rust/main/hyperlane-base/src/types/gcs_storage.rs
+++ b/rust/main/hyperlane-base/src/types/gcs_storage.rs
@@ -16,6 +16,7 @@ use ya_gcp::{
 };
 
 const LATEST_INDEX_KEY: &str = "gcsLatestIndexKey";
+const BACKFILL_FLOOR_KEY: &str = "gcsBackfillFloorKey";
 const METADATA_KEY: &str = "gcsMetadataKey";
 const ANNOUNCEMENT_KEY: &str = "gcsAnnouncementKey";
 const REORG_FLAG_KEY: &str = "gcsReorgFlagKey";
@@ -211,6 +212,32 @@ impl CheckpointSyncer for GcsStorageClient {
     async fn write_latest_index(&self, index: u32) -> Result<()> {
         let data = serde_json::to_vec(&index)?;
         self.upload_and_log(&self.object_path(LATEST_INDEX_KEY), data)
+            .await
+    }
+
+    #[instrument(skip(self))]
+    async fn backfill_floor_index(&self) -> Result<Option<u32>> {
+        match self
+            .inner
+            .get_object(&self.bucket, self.object_path(BACKFILL_FLOOR_KEY))
+            .await
+        {
+            Ok(data) => Ok(Some(serde_json::from_slice(data.as_ref())?)),
+            Err(e) => match e {
+                // never written before to this bucket
+                ObjectError::InvalidName(_) => Ok(None),
+                ObjectError::Failure(Error::HttpStatus(HttpStatusError(StatusCode::NOT_FOUND))) => {
+                    Ok(None)
+                }
+                _ => bail!(e),
+            },
+        }
+    }
+
+    #[instrument(skip(self, index))]
+    async fn write_backfill_floor_index(&self, index: u32) -> Result<()> {
+        let data = serde_json::to_vec(&index)?;
+        self.upload_and_log(&self.object_path(BACKFILL_FLOOR_KEY), data)
             .await
     }
 

--- a/rust/main/hyperlane-base/src/types/local_storage.rs
+++ b/rust/main/hyperlane-base/src/types/local_storage.rs
@@ -37,6 +37,10 @@ impl LocalStorage {
         self.path.join("index.json")
     }
 
+    fn backfill_floor_file_path(&self) -> PathBuf {
+        self.path.join("backfill_floor.json")
+    }
+
     fn announcement_file_path(&self) -> PathBuf {
         self.path.join("announcement.json")
     }
@@ -79,6 +83,26 @@ impl CheckpointSyncer for LocalStorage {
         tokio::fs::write(&path, index.to_string())
             .await
             .with_context(|| format!("Writing index to {path:?}"))?;
+        Ok(())
+    }
+
+    async fn backfill_floor_index(&self) -> Result<Option<u32>> {
+        match tokio::fs::read(self.backfill_floor_file_path())
+            .await
+            .and_then(|data| {
+                String::from_utf8(data)
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+            }) {
+            Ok(data) => Ok(Some(data.parse()?)),
+            _ => Ok(None),
+        }
+    }
+
+    async fn write_backfill_floor_index(&self, index: u32) -> Result<()> {
+        let path = self.backfill_floor_file_path();
+        tokio::fs::write(&path, index.to_string())
+            .await
+            .with_context(|| format!("Writing backfill floor to {path:?}"))?;
         Ok(())
     }
 

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -196,6 +196,10 @@ impl S3Storage {
         "checkpoint_latest_index.json".to_owned()
     }
 
+    fn backfill_floor_key() -> String {
+        "checkpoint_backfill_floor.json".to_owned()
+    }
+
     fn metadata_key() -> String {
         "metadata_latest.json".to_owned()
     }
@@ -235,6 +239,21 @@ impl CheckpointSyncer for S3Storage {
     async fn write_latest_index(&self, index: u32) -> Result<()> {
         let serialized_index = serde_json::to_string(&index)?;
         self.write_to_bucket(S3Storage::latest_index_key(), &serialized_index)
+            .await?;
+        Ok(())
+    }
+
+    async fn backfill_floor_index(&self) -> Result<Option<u32>> {
+        self.anonymously_read_from_bucket(S3Storage::backfill_floor_key())
+            .await?
+            .map(|data| serde_json::from_slice(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn write_backfill_floor_index(&self, index: u32) -> Result<()> {
+        let serialized_index = serde_json::to_string(&index)?;
+        self.write_to_bucket(S3Storage::backfill_floor_key(), &serialized_index)
             .await?;
         Ok(())
     }


### PR DESCRIPTION
## Superseded by #9448

This approach is consolidated into [#9448](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9448).

Restoring a validated Merkle snapshot at index `S` naturally starts both local tree ingestion and checkpoint submission at `S+1`. It therefore delivers this PR's O(history) -> O(tail) checkpoint-fetch/signing gain as well as removing the O(history) local rebuild.

Keeping a separate backfill-floor object would duplicate persisted state and validation without another performance gain. #9448 is the smaller operational model: one snapshot, one validation path, full-rebuild fallback.

Tracked in [#9386](https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/9386) and the private performance DAG.
