### PR TITLE
perf(validator): restore merkle tree from snapshot, replay only tail

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -95,8 +95,6 @@ impl ValidatorSubmitter {
     /// Submits signed checkpoints from index 0 until the target checkpoint (inclusive).
     /// Runs idly forever once the target checkpoint is reached to avoid exiting the task.
     pub(crate) async fn backfill_checkpoint_submitter(self, target_checkpoint: CheckpointAtBlock) {
-        // Resume from a validated snapshot when possible: the ingest loop below
-        // replays only the tail from the local database instead of all history.
         let mut tree = self
             .restored_snapshot_tree(target_checkpoint.index)
             .await
@@ -104,8 +102,6 @@ impl ValidatorSubmitter {
         self.submit_checkpoints_until_correctness_checkpoint(&mut tree, &target_checkpoint)
             .await;
 
-        // Persist the completed tree for the next restart. Best-effort: a
-        // failed snapshot write only costs the next restart a full rebuild.
         match MerkleTreeSnapshot::capture(&tree) {
             Ok(snapshot) => {
                 if let Err(err) = self
@@ -432,12 +428,7 @@ impl ValidatorSubmitter {
         }
     }
 
-    /// Restores a previously persisted merkle-tree snapshot after proving it
-    /// still matches this validator's stored checkpoint at the snapshot index:
-    /// the checkpoint must exist, recover to this validator, and carry the
-    /// snapshot root. Anything else yields `None` (full rebuild as before).
-    /// A snapshot at or past the target is also discarded: replaying from it
-    /// would trip the tree-ahead-of-checkpoint assertion.
+    /// Restores a snapshot after validating it against the signed checkpoint.
     async fn restored_snapshot_tree(&self, target_index: u32) -> Option<IncrementalMerkle> {
         let snapshot = match self.checkpoint_syncer.read_merkle_snapshot().await {
             Ok(Some(snapshot)) => snapshot,
@@ -447,10 +438,10 @@ impl ValidatorSubmitter {
                 return None;
             }
         };
-        if snapshot.index >= target_index {
+        if snapshot.index > target_index {
             debug!(
                 snapshot_index = snapshot.index,
-                target_index, "Snapshot at or past target, rebuilding tree"
+                target_index, "Snapshot is ahead of target, rebuilding tree"
             );
             return None;
         }
@@ -469,7 +460,7 @@ impl ValidatorSubmitter {
             Ok(Some(existing)) => match existing.recover() {
                 Ok(signer)
                     if signer == self.signer.eth_address()
-                        && existing.value.root == snapshot.root =>
+                        && existing.value.checkpoint == self.checkpoint(&tree) =>
                 {
                     info!(
                         snapshot_index = snapshot.index,

--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -11,9 +11,9 @@ use hyperlane_base::db::HyperlaneDb;
 use hyperlane_base::{CheckpointSyncer, CoreMetrics};
 use hyperlane_core::rpc_clients::call_and_retry_indefinitely;
 use hyperlane_core::{
-    accumulator::incremental::IncrementalMerkle, Checkpoint, CheckpointAtBlock,
-    CheckpointWithMessageId, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
-    HyperlaneSignerExt, IncrementalMerkleAtBlock,
+    accumulator::incremental::{IncrementalMerkle, MerkleTreeSnapshot},
+    Checkpoint, CheckpointAtBlock, CheckpointWithMessageId, HyperlaneChain, HyperlaneContract,
+    HyperlaneDomain, HyperlaneSignerExt, IncrementalMerkleAtBlock,
 };
 use hyperlane_core::{
     ChainResult, HyperlaneSigner, MerkleTreeHook, ReorgEvent, ReorgPeriod, SignedType,
@@ -95,9 +95,35 @@ impl ValidatorSubmitter {
     /// Submits signed checkpoints from index 0 until the target checkpoint (inclusive).
     /// Runs idly forever once the target checkpoint is reached to avoid exiting the task.
     pub(crate) async fn backfill_checkpoint_submitter(self, target_checkpoint: CheckpointAtBlock) {
-        let mut tree = IncrementalMerkle::default();
+        // Resume from a validated snapshot when possible: the ingest loop below
+        // replays only the tail from the local database instead of all history.
+        let mut tree = self
+            .restored_snapshot_tree(target_checkpoint.index)
+            .await
+            .unwrap_or_default();
         self.submit_checkpoints_until_correctness_checkpoint(&mut tree, &target_checkpoint)
             .await;
+
+        // Persist the completed tree for the next restart. Best-effort: a
+        // failed snapshot write only costs the next restart a full rebuild.
+        match MerkleTreeSnapshot::capture(&tree) {
+            Ok(snapshot) => {
+                if let Err(err) = self
+                    .checkpoint_syncer
+                    .write_merkle_snapshot(&snapshot)
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        index = snapshot.index,
+                        "Failed to write merkle snapshot"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!(?err, "Failed to capture merkle snapshot");
+            }
+        }
 
         info!(
             ?target_checkpoint,
@@ -403,6 +429,77 @@ impl ValidatorSubmitter {
                 index = checkpoint.index,
                 "Signed all queued checkpoints until index"
             );
+        }
+    }
+
+    /// Restores a previously persisted merkle-tree snapshot after proving it
+    /// still matches this validator's stored checkpoint at the snapshot index:
+    /// the checkpoint must exist, recover to this validator, and carry the
+    /// snapshot root. Anything else yields `None` (full rebuild as before).
+    /// A snapshot at or past the target is also discarded: replaying from it
+    /// would trip the tree-ahead-of-checkpoint assertion.
+    async fn restored_snapshot_tree(&self, target_index: u32) -> Option<IncrementalMerkle> {
+        let snapshot = match self.checkpoint_syncer.read_merkle_snapshot().await {
+            Ok(Some(snapshot)) => snapshot,
+            Ok(None) => return None,
+            Err(err) => {
+                warn!(?err, "Failed to read merkle snapshot, rebuilding tree");
+                return None;
+            }
+        };
+        if snapshot.index >= target_index {
+            debug!(
+                snapshot_index = snapshot.index,
+                target_index, "Snapshot at or past target, rebuilding tree"
+            );
+            return None;
+        }
+        let tree = match snapshot.restore() {
+            Ok(tree) => tree,
+            Err(err) => {
+                warn!(?err, "Stored merkle snapshot is corrupt, rebuilding tree");
+                return None;
+            }
+        };
+        match self
+            .checkpoint_syncer
+            .fetch_checkpoint(snapshot.index)
+            .await
+        {
+            Ok(Some(existing)) => match existing.recover() {
+                Ok(signer)
+                    if signer == self.signer.eth_address()
+                        && existing.value.root == snapshot.root =>
+                {
+                    info!(
+                        snapshot_index = snapshot.index,
+                        "Restored merkle tree from validated snapshot"
+                    );
+                    Some(tree)
+                }
+                _ => {
+                    warn!(
+                        snapshot_index = snapshot.index,
+                        "Snapshot checkpoint mismatch, rebuilding tree"
+                    );
+                    None
+                }
+            },
+            Ok(None) => {
+                warn!(
+                    snapshot_index = snapshot.index,
+                    "Snapshot checkpoint missing, rebuilding tree"
+                );
+                None
+            }
+            Err(err) => {
+                warn!(
+                    ?err,
+                    snapshot_index = snapshot.index,
+                    "Snapshot checkpoint fetch failed, rebuilding tree"
+                );
+                None
+            }
         }
     }
 

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -1313,6 +1313,36 @@ async fn backfill_restores_validated_snapshot_and_replays_tail() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn backfill_restores_snapshot_at_target_without_replay() {
+    let (domain, _, checkpoint_at_snapshot, _, snapshot) = three_leaf_snapshot_fixture();
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let target = CheckpointAtBlock {
+        checkpoint: checkpoint_at_snapshot.checkpoint.clone(),
+        block_height: Some(1),
+    };
+    let signed_at_snapshot = signer.sign(checkpoint_at_snapshot).await.unwrap();
+
+    let db = MockDb::new();
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_read_merkle_snapshot()
+        .once()
+        .return_once(move || Ok(Some(snapshot)));
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .once()
+        .return_once(move |_| Ok(Some(signed_at_snapshot)));
+    checkpoint_syncer
+        .expect_write_merkle_snapshot()
+        .withf(|snapshot| snapshot.index == 1)
+        .once()
+        .returning(|_| Ok(()));
+
+    let submitter = snapshot_test_submitter(domain, signer, checkpoint_syncer, db);
+    submitter.backfill_checkpoint_submitter(target).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn backfill_rebuilds_tree_when_snapshot_is_corrupt() {
     let (domain, insertions, _, target, mut snapshot) = three_leaf_snapshot_fixture();
     snapshot.root = H256::from_low_u64_be(0xdead);

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -56,6 +56,8 @@ mockall::mock! {
 
     #[async_trait]
     impl CheckpointSyncer for CheckpointSyncer {
+        async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>>;
+        async fn write_merkle_snapshot(&self, snapshot: &MerkleTreeSnapshot) -> Result<()>;
         async fn latest_index(&self) -> Result<Option<u32>>;
         async fn write_latest_index(&self, index: u32) -> Result<()>;
         async fn update_latest_index(&self, index: u32) -> Result<()>;
@@ -1192,4 +1194,161 @@ async fn sign_and_submit_checkpoint_different_signature() {
         .await;
 
     logs_contain("Checkpoint already submitted, but with different signature, overwriting");
+}
+
+fn snapshot_test_submitter(
+    domain: HyperlaneDomain,
+    signer: Signers,
+    checkpoint_syncer: MockCheckpointSyncer,
+    db: MockDb,
+) -> ValidatorSubmitter {
+    let mut merkle_tree_hook = MockMerkleTreeHook::new();
+    merkle_tree_hook.expect_address().returning(H256::zero);
+    merkle_tree_hook
+        .expect_domain()
+        .return_const(domain.clone());
+    ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(merkle_tree_hook),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(checkpoint_syncer),
+        Arc::new(db),
+        dummy_metrics(),
+        50,
+        Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
+    )
+}
+
+fn three_leaf_snapshot_fixture() -> (
+    HyperlaneDomain,
+    Vec<MerkleTreeInsertion>,
+    CheckpointWithMessageId,
+    CheckpointAtBlock,
+    MerkleTreeSnapshot,
+) {
+    let domain = dummy_domain(0, "dummy_domain");
+    let insertions: Vec<MerkleTreeInsertion> = (0..3)
+        .map(|i| MerkleTreeInsertion::new(i, H256::from_low_u64_be(11 * (i as u64 + 1))))
+        .collect();
+
+    let mut tree = IncrementalMerkle::default();
+    for insertion in insertions.iter().take(2) {
+        tree.ingest(insertion.message_id());
+    }
+    let checkpoint_at_snapshot = CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: tree.root(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: domain.id(),
+            index: 1,
+        },
+        message_id: insertions[1].message_id(),
+    };
+    let snapshot = MerkleTreeSnapshot::capture(&tree).unwrap();
+    tree.ingest(insertions[2].message_id());
+    let target = CheckpointAtBlock {
+        checkpoint: Checkpoint {
+            root: tree.root(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: domain.id(),
+            index: 2,
+        },
+        block_height: Some(1),
+    };
+    (domain, insertions, checkpoint_at_snapshot, target, snapshot)
+}
+
+#[tokio::test(start_paused = true)]
+async fn backfill_restores_validated_snapshot_and_replays_tail() {
+    let (domain, insertions, checkpoint_at_snapshot, target, snapshot) =
+        three_leaf_snapshot_fixture();
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let signed_at_snapshot = signer.sign(checkpoint_at_snapshot).await.unwrap();
+
+    // Only the post-snapshot leaf is read from the local database.
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .with(mockall::predicate::eq(2))
+        .times(1)
+        .returning(move |_| Ok(Some(insertions[2])));
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_read_merkle_snapshot()
+        .times(1)
+        .return_once(move || Ok(Some(snapshot)));
+    // One validation read for the snapshot, one fetch for the tail checkpoint.
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(2)
+        .returning(move |index| {
+            if index == 1 {
+                Ok(Some(signed_at_snapshot.clone()))
+            } else {
+                Ok(None)
+            }
+        });
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .times(1)
+        .returning(|_| Ok(()));
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(2))
+        .once()
+        .returning(|_| Ok(()));
+    // The completed tree is persisted for the next restart.
+    checkpoint_syncer
+        .expect_write_merkle_snapshot()
+        .withf(|snapshot| snapshot.index == 2)
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let submitter = snapshot_test_submitter(domain, signer, checkpoint_syncer, db);
+    submitter.backfill_checkpoint_submitter(target).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn backfill_rebuilds_tree_when_snapshot_is_corrupt() {
+    let (domain, insertions, _, target, mut snapshot) = three_leaf_snapshot_fixture();
+    snapshot.root = H256::from_low_u64_be(0xdead);
+
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .times(3)
+        .returning(move |sequence| Ok(Some(insertions[*sequence as usize])));
+
+    let mut checkpoint_syncer = MockCheckpointSyncer::new();
+    checkpoint_syncer
+        .expect_read_merkle_snapshot()
+        .times(1)
+        .return_once(move || Ok(Some(snapshot)));
+    // No validation read happens for an undecodable snapshot; every checkpoint
+    // is fetched and written as in a cold backfill.
+    checkpoint_syncer
+        .expect_fetch_checkpoint()
+        .times(3)
+        .returning(|_| Ok(None));
+    checkpoint_syncer
+        .expect_write_checkpoint()
+        .times(3)
+        .returning(|_| Ok(()));
+    checkpoint_syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(2))
+        .once()
+        .returning(|_| Ok(()));
+    checkpoint_syncer
+        .expect_write_merkle_snapshot()
+        .withf(|snapshot| snapshot.index == 2)
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let submitter = snapshot_test_submitter(domain, signer, checkpoint_syncer, db);
+    submitter.backfill_checkpoint_submitter(target).await;
 }

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -1344,8 +1344,19 @@ async fn backfill_restores_snapshot_at_target_without_replay() {
 
 #[tokio::test(start_paused = true)]
 async fn backfill_rebuilds_tree_when_snapshot_is_corrupt() {
-    let (domain, insertions, _, target, mut snapshot) = three_leaf_snapshot_fixture();
+    let (_, _, _, _, mut snapshot) = three_leaf_snapshot_fixture();
     snapshot.root = H256::from_low_u64_be(0xdead);
+    assert_backfill_rebuilds_tree(Ok(Some(snapshot))).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn backfill_rebuilds_tree_when_snapshot_is_unavailable() {
+    assert_backfill_rebuilds_tree(Ok(None)).await;
+    assert_backfill_rebuilds_tree(Err(eyre::eyre!("Snapshot exceeds size limit"))).await;
+}
+
+async fn assert_backfill_rebuilds_tree(snapshot: Result<Option<MerkleTreeSnapshot>>) {
+    let (domain, insertions, _, target, _) = three_leaf_snapshot_fixture();
 
     let mut db = MockDb::new();
     db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
@@ -1356,8 +1367,8 @@ async fn backfill_rebuilds_tree_when_snapshot_is_corrupt() {
     checkpoint_syncer
         .expect_read_merkle_snapshot()
         .times(1)
-        .return_once(move || Ok(Some(snapshot)));
-    // No validation read happens for an undecodable snapshot; every checkpoint
+        .return_once(move || snapshot);
+    // No validation read happens without a usable snapshot; every checkpoint
     // is fetched and written as in a cold backfill.
     checkpoint_syncer
         .expect_fetch_checkpoint()

--- a/rust/main/hyperlane-base/src/traits/checkpoint_syncer.rs
+++ b/rust/main/hyperlane-base/src/traits/checkpoint_syncer.rs
@@ -4,12 +4,27 @@ use async_trait::async_trait;
 use eyre::{Report, Result};
 
 use hyperlane_core::{
-    ReorgEvent, ReorgEventResponse, SignedAnnouncement, SignedCheckpointWithMessageId,
+    accumulator::incremental::MerkleTreeSnapshot, ReorgEvent, ReorgEventResponse,
+    SignedAnnouncement, SignedCheckpointWithMessageId,
 };
 
 /// A generic trait to read/write Checkpoints offchain
 #[async_trait]
 pub trait CheckpointSyncer: Debug + Send + Sync {
+    /// Read the persisted merkle-tree snapshot, if any. The snapshot covers the
+    /// tree through `snapshot.index`; a restart restores it and replays only
+    /// the tail from the local database instead of re-ingesting all history.
+    ///
+    /// Defaults to `None` (no snapshot, full rebuild as before). Backends that
+    /// cannot persist the marker keep this default and safely degrade.
+    async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>> {
+        Ok(None)
+    }
+    /// Writes the merkle-tree snapshot. Best-effort: backends without durable
+    /// marker support keep the default no-op and degrade to full rebuilds.
+    async fn write_merkle_snapshot(&self, _snapshot: &MerkleTreeSnapshot) -> Result<()> {
+        Ok(())
+    }
     /// Read the highest index of this Syncer
     async fn latest_index(&self) -> Result<Option<u32>>;
     /// Writes the highest index of this Syncer

--- a/rust/main/hyperlane-base/src/types/gcs_storage.rs
+++ b/rust/main/hyperlane-base/src/types/gcs_storage.rs
@@ -3,8 +3,7 @@ use async_trait::async_trait;
 use derive_new::new;
 use eyre::{bail, Result};
 use hyperlane_core::{
-    accumulator::incremental::MerkleTreeSnapshot, ReorgEvent, ReorgEventResponse,
-    SignedAnnouncement, SignedCheckpointWithMessageId,
+    ReorgEvent, ReorgEventResponse, SignedAnnouncement, SignedCheckpointWithMessageId,
 };
 use std::fmt;
 use tracing::{error, info, instrument};
@@ -17,7 +16,6 @@ use ya_gcp::{
 };
 
 const LATEST_INDEX_KEY: &str = "gcsLatestIndexKey";
-const MERKLE_SNAPSHOT_KEY: &str = "gcsMerkleSnapshotKey";
 const METADATA_KEY: &str = "gcsMetadataKey";
 const ANNOUNCEMENT_KEY: &str = "gcsAnnouncementKey";
 const REORG_FLAG_KEY: &str = "gcsReorgFlagKey";
@@ -188,6 +186,8 @@ impl fmt::Debug for GcsStorageClient {
 
 #[async_trait]
 impl CheckpointSyncer for GcsStorageClient {
+    // Keep the trait's no-snapshot defaults: ya-gcp collects entire objects and
+    // cannot bound snapshot downloads before allocation. GCS uses cold replay.
     /// Read the highest index of this Syncer
     #[instrument(skip(self))]
     async fn latest_index(&self) -> Result<Option<u32>> {
@@ -213,32 +213,6 @@ impl CheckpointSyncer for GcsStorageClient {
     async fn write_latest_index(&self, index: u32) -> Result<()> {
         let data = serde_json::to_vec(&index)?;
         self.upload_and_log(&self.object_path(LATEST_INDEX_KEY), data)
-            .await
-    }
-
-    #[instrument(skip(self))]
-    async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>> {
-        match self
-            .inner
-            .get_object(&self.bucket, self.object_path(MERKLE_SNAPSHOT_KEY))
-            .await
-        {
-            Ok(data) => Ok(Some(serde_json::from_slice(data.as_ref())?)),
-            Err(e) => match e {
-                // never written before to this bucket
-                ObjectError::InvalidName(_) => Ok(None),
-                ObjectError::Failure(Error::HttpStatus(HttpStatusError(StatusCode::NOT_FOUND))) => {
-                    Ok(None)
-                }
-                _ => bail!(e),
-            },
-        }
-    }
-
-    #[instrument(skip(self, snapshot))]
-    async fn write_merkle_snapshot(&self, snapshot: &MerkleTreeSnapshot) -> Result<()> {
-        let data = serde_json::to_vec(snapshot)?;
-        self.upload_and_log(&self.object_path(MERKLE_SNAPSHOT_KEY), data)
             .await
     }
 
@@ -410,6 +384,29 @@ async fn object_path_is_unprefixed_without_a_folder() {
         client.announcement_location(),
         "gs://test-bucket/gcsAnnouncementKey"
     );
+}
+
+#[tokio::test]
+async fn merkle_snapshot_uses_cold_replay_without_gcs_access() {
+    use hyperlane_core::accumulator::incremental::{IncrementalMerkle, MerkleTreeSnapshot};
+
+    // An invalid bucket makes any accidental object request fail immediately.
+    let client = GcsStorageClientBuilder::new(AuthFlow::NoAuth)
+        .build("", None)
+        .await
+        .expect("unauthenticated client");
+    let mut tree = IncrementalMerkle::default();
+    tree.ingest(hyperlane_core::H256::from_low_u64_be(1));
+    let snapshot = MerkleTreeSnapshot::capture(&tree).expect("snapshot");
+
+    assert_eq!(
+        client.read_merkle_snapshot().await.expect("no snapshot"),
+        None
+    );
+    client
+        .write_merkle_snapshot(&snapshot)
+        .await
+        .expect("no-op write");
 }
 
 #[tokio::test]

--- a/rust/main/hyperlane-base/src/types/gcs_storage.rs
+++ b/rust/main/hyperlane-base/src/types/gcs_storage.rs
@@ -3,7 +3,8 @@ use async_trait::async_trait;
 use derive_new::new;
 use eyre::{bail, Result};
 use hyperlane_core::{
-    ReorgEvent, ReorgEventResponse, SignedAnnouncement, SignedCheckpointWithMessageId,
+    accumulator::incremental::MerkleTreeSnapshot, ReorgEvent, ReorgEventResponse,
+    SignedAnnouncement, SignedCheckpointWithMessageId,
 };
 use std::fmt;
 use tracing::{error, info, instrument};
@@ -16,6 +17,7 @@ use ya_gcp::{
 };
 
 const LATEST_INDEX_KEY: &str = "gcsLatestIndexKey";
+const MERKLE_SNAPSHOT_KEY: &str = "gcsMerkleSnapshotKey";
 const METADATA_KEY: &str = "gcsMetadataKey";
 const ANNOUNCEMENT_KEY: &str = "gcsAnnouncementKey";
 const REORG_FLAG_KEY: &str = "gcsReorgFlagKey";
@@ -211,6 +213,32 @@ impl CheckpointSyncer for GcsStorageClient {
     async fn write_latest_index(&self, index: u32) -> Result<()> {
         let data = serde_json::to_vec(&index)?;
         self.upload_and_log(&self.object_path(LATEST_INDEX_KEY), data)
+            .await
+    }
+
+    #[instrument(skip(self))]
+    async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>> {
+        match self
+            .inner
+            .get_object(&self.bucket, self.object_path(MERKLE_SNAPSHOT_KEY))
+            .await
+        {
+            Ok(data) => Ok(Some(serde_json::from_slice(data.as_ref())?)),
+            Err(e) => match e {
+                // never written before to this bucket
+                ObjectError::InvalidName(_) => Ok(None),
+                ObjectError::Failure(Error::HttpStatus(HttpStatusError(StatusCode::NOT_FOUND))) => {
+                    Ok(None)
+                }
+                _ => bail!(e),
+            },
+        }
+    }
+
+    #[instrument(skip(self, snapshot))]
+    async fn write_merkle_snapshot(&self, snapshot: &MerkleTreeSnapshot) -> Result<()> {
+        let data = serde_json::to_vec(snapshot)?;
+        self.upload_and_log(&self.object_path(MERKLE_SNAPSHOT_KEY), data)
             .await
     }
 

--- a/rust/main/hyperlane-base/src/types/local_storage.rs
+++ b/rust/main/hyperlane-base/src/types/local_storage.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use eyre::{Context, Result};
 use hyperlane_core::{
-    ReorgEvent, ReorgEventResponse, SignedAnnouncement, SignedCheckpointWithMessageId,
+    accumulator::incremental::MerkleTreeSnapshot, ReorgEvent, ReorgEventResponse,
+    SignedAnnouncement, SignedCheckpointWithMessageId,
 };
 use prometheus::IntGauge;
 use tracing::error;
@@ -35,6 +36,10 @@ impl LocalStorage {
 
     fn latest_index_file_path(&self) -> PathBuf {
         self.path.join("index.json")
+    }
+
+    fn merkle_snapshot_file_path(&self) -> PathBuf {
+        self.path.join("merkle_snapshot.json")
     }
 
     fn announcement_file_path(&self) -> PathBuf {
@@ -79,6 +84,23 @@ impl CheckpointSyncer for LocalStorage {
         tokio::fs::write(&path, index.to_string())
             .await
             .with_context(|| format!("Writing index to {path:?}"))?;
+        Ok(())
+    }
+
+    async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>> {
+        let Ok(data) = tokio::fs::read(self.merkle_snapshot_file_path()).await else {
+            return Ok(None);
+        };
+        let snapshot = serde_json::from_slice(&data)?;
+        Ok(Some(snapshot))
+    }
+
+    async fn write_merkle_snapshot(&self, snapshot: &MerkleTreeSnapshot) -> Result<()> {
+        let serialized_snapshot = serde_json::to_string(snapshot)?;
+        let path = self.merkle_snapshot_file_path();
+        tokio::fs::write(&path, &serialized_snapshot)
+            .await
+            .with_context(|| format!("Writing merkle snapshot to {path:?}"))?;
         Ok(())
     }
 

--- a/rust/main/hyperlane-base/src/types/local_storage.rs
+++ b/rust/main/hyperlane-base/src/types/local_storage.rs
@@ -7,9 +7,12 @@ use hyperlane_core::{
     SignedAnnouncement, SignedCheckpointWithMessageId,
 };
 use prometheus::IntGauge;
+use tokio::io::AsyncReadExt;
 use tracing::error;
 
 use crate::traits::CheckpointSyncer;
+
+use super::utils::MAX_CHECKPOINT_OBJECT_SIZE;
 
 #[derive(Debug, Clone)]
 /// Type for reading/write to LocalStorage
@@ -88,9 +91,18 @@ impl CheckpointSyncer for LocalStorage {
     }
 
     async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>> {
-        let Ok(data) = tokio::fs::read(self.merkle_snapshot_file_path()).await else {
-            return Ok(None);
+        let file = match tokio::fs::File::open(self.merkle_snapshot_file_path()).await {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
         };
+        let mut data = Vec::new();
+        file.take(MAX_CHECKPOINT_OBJECT_SIZE as u64)
+            .read_to_end(&mut data)
+            .await?;
+        if data.len() >= MAX_CHECKPOINT_OBJECT_SIZE {
+            eyre::bail!("Merkle snapshot exceeds the checkpoint object size limit");
+        }
         let snapshot = serde_json::from_slice(&data)?;
         Ok(Some(snapshot))
     }
@@ -190,5 +202,59 @@ impl CheckpointSyncer for LocalStorage {
             .await
             .with_context(|| format!("Writing log to {path:?}"))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperlane_core::{accumulator::incremental::IncrementalMerkle, H256};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn merkle_snapshot_reads_are_bounded_before_decoding() {
+        let directory = tempfile::tempdir().expect("temporary checkpoint directory");
+        let storage =
+            LocalStorage::new(directory.path().to_owned(), None).expect("local checkpoint storage");
+        assert_eq!(
+            storage.read_merkle_snapshot().await.expect("missing file"),
+            None
+        );
+
+        let mut tree = IncrementalMerkle::default();
+        tree.ingest(H256::from_low_u64_be(1));
+        let snapshot = MerkleTreeSnapshot::capture(&tree).expect("snapshot");
+        storage
+            .write_merkle_snapshot(&snapshot)
+            .await
+            .expect("write snapshot");
+        assert_eq!(
+            storage
+                .read_merkle_snapshot()
+                .await
+                .expect("valid snapshot"),
+            Some(snapshot.clone())
+        );
+
+        for size in [
+            MAX_CHECKPOINT_OBJECT_SIZE - 1,
+            MAX_CHECKPOINT_OBJECT_SIZE,
+            MAX_CHECKPOINT_OBJECT_SIZE + 1,
+        ] {
+            let mut bytes = serde_json::to_vec(&snapshot).expect("serialized snapshot");
+            bytes.resize(size, b' ');
+            tokio::fs::write(storage.merkle_snapshot_file_path(), bytes)
+                .await
+                .expect("write bounded fixture");
+            let result = storage.read_merkle_snapshot().await;
+            if size < MAX_CHECKPOINT_OBJECT_SIZE {
+                assert_eq!(result.expect("below limit"), Some(snapshot.clone()));
+            } else {
+                assert!(result
+                    .expect_err("oversized snapshot")
+                    .to_string()
+                    .contains("size limit"));
+            }
+        }
     }
 }

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -14,7 +14,8 @@ use tokio::sync::OnceCell;
 use tracing::error;
 
 use hyperlane_core::{
-    ReorgEvent, ReorgEventResponse, SignedAnnouncement, SignedCheckpointWithMessageId,
+    accumulator::incremental::MerkleTreeSnapshot, ReorgEvent, ReorgEventResponse,
+    SignedAnnouncement, SignedCheckpointWithMessageId,
 };
 
 use crate::CheckpointSyncer;
@@ -196,6 +197,10 @@ impl S3Storage {
         "checkpoint_latest_index.json".to_owned()
     }
 
+    fn merkle_snapshot_key() -> String {
+        "merkle_snapshot.json".to_owned()
+    }
+
     fn metadata_key() -> String {
         "metadata_latest.json".to_owned()
     }
@@ -235,6 +240,21 @@ impl CheckpointSyncer for S3Storage {
     async fn write_latest_index(&self, index: u32) -> Result<()> {
         let serialized_index = serde_json::to_string(&index)?;
         self.write_to_bucket(S3Storage::latest_index_key(), &serialized_index)
+            .await?;
+        Ok(())
+    }
+
+    async fn read_merkle_snapshot(&self) -> Result<Option<MerkleTreeSnapshot>> {
+        self.anonymously_read_from_bucket(S3Storage::merkle_snapshot_key())
+            .await?
+            .map(|data| serde_json::from_slice(&data))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn write_merkle_snapshot(&self, snapshot: &MerkleTreeSnapshot) -> Result<()> {
+        let serialized_snapshot = serde_json::to_string(snapshot)?;
+        self.write_to_bucket(S3Storage::merkle_snapshot_key(), &serialized_snapshot)
             .await?;
         Ok(())
     }

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -20,9 +20,11 @@ use hyperlane_core::{
 
 use crate::CheckpointSyncer;
 
+use super::utils::MAX_CHECKPOINT_OBJECT_SIZE;
+
 /// The timeout for all S3 operations.
 const S3_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-const S3_MAX_OBJECT_SIZE: i64 = 50 * 1024; // 50KiB
+const S3_MAX_OBJECT_SIZE: i64 = MAX_CHECKPOINT_OBJECT_SIZE as i64;
 
 #[derive(Clone, new)]
 /// Type for reading/writing to S3

--- a/rust/main/hyperlane-base/src/types/utils.rs
+++ b/rust/main/hyperlane-base/src/types/utils.rs
@@ -6,6 +6,9 @@ use rusoto_core::{HttpClient, HttpConfig};
 /// See https://github.com/hyperium/hyper/issues/2136#issuecomment-589488526
 pub const HYPER_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Exclusive byte limit for small checkpoint-storage objects.
+pub(super) const MAX_CHECKPOINT_OBJECT_SIZE: usize = 50 * 1024;
+
 /// Create a new HTTP client with a timeout for the connection pool.
 /// This is a workaround for https://github.com/hyperium/hyper/issues/2136#issuecomment-589345238
 pub fn http_client_with_timeout() -> Result<HttpClient> {

--- a/rust/main/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/main/hyperlane-core/src/accumulator/incremental.rs
@@ -130,7 +130,7 @@ impl MerkleTreeSnapshot {
             eyre::bail!("Cannot snapshot an empty merkle tree");
         }
         Ok(Self {
-            index: (tree.count() as u32).saturating_sub(1),
+            index: tree.index(),
             root: tree.root(),
             tree: borsh::to_vec(tree)?,
         })
@@ -141,7 +141,10 @@ impl MerkleTreeSnapshot {
     /// trusted checkpoint before replaying onto the restored tree.
     pub fn restore(&self) -> eyre::Result<IncrementalMerkle> {
         let tree: IncrementalMerkle = borsh::from_slice(&self.tree)?;
-        if tree.count() == 0 || (tree.count() as u32).saturating_sub(1) != self.index {
+        let decoded_index = u32::try_from(tree.count())
+            .ok()
+            .and_then(|count| count.checked_sub(1));
+        if decoded_index != Some(self.index) {
             eyre::bail!(
                 "Snapshot index {} does not match decoded tree count {}",
                 self.index,
@@ -211,6 +214,22 @@ mod test {
         let mut misindexed = snapshot.clone();
         misindexed.index += 1;
         assert!(misindexed.restore().is_err());
+
+        // `IncrementalMerkle` is limited to a 32-bit leaf count. On 64-bit
+        // hosts, a malformed count with the same low 32 bits produces the same
+        // root; reject it instead of allowing the index conversion to wrap.
+        #[cfg(target_pointer_width = "64")]
+        {
+            let mut oversized_tree = tree.clone();
+            oversized_tree.count += (u32::MAX as usize) + 1;
+            assert_eq!(oversized_tree.root(), tree.root());
+            let oversized = MerkleTreeSnapshot {
+                index: snapshot.index,
+                root: snapshot.root,
+                tree: borsh::to_vec(&oversized_tree).expect("oversized test tree should serialize"),
+            };
+            assert!(oversized.restore().is_err());
+        }
     }
 }
 

--- a/rust/main/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/main/hyperlane-core/src/accumulator/incremental.rs
@@ -107,6 +107,54 @@ impl IncrementalMerkle {
     }
 }
 
+/// A persisted snapshot of an `IncrementalMerkle`: just the O(depth) frontier
+/// plus the leaf count (about a kilobyte), not the full tree. A validator
+/// restart can restore this instead of re-ingesting every historical leaf from
+/// the local database, then replay only the tail and let the usual
+/// root-equality check against the correctness checkpoint prove the result.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MerkleTreeSnapshot {
+    /// Index of the last leaf covered by the snapshot (`count - 1`).
+    pub index: u32,
+    /// Tree root at the snapshot index.
+    pub root: H256,
+    /// Borsh-serialized `IncrementalMerkle`.
+    pub tree: Vec<u8>,
+}
+
+impl MerkleTreeSnapshot {
+    /// Capture the current tree state. Fails on an empty tree, which has no
+    /// meaningful index.
+    pub fn capture(tree: &IncrementalMerkle) -> eyre::Result<Self> {
+        if tree.count() == 0 {
+            eyre::bail!("Cannot snapshot an empty merkle tree");
+        }
+        Ok(Self {
+            index: (tree.count() as u32).saturating_sub(1),
+            root: tree.root(),
+            tree: borsh::to_vec(tree)?,
+        })
+    }
+
+    /// Restore the tree, verifying the bytes actually decode to the claimed
+    /// index and root. Callers must additionally check the root against a
+    /// trusted checkpoint before replaying onto the restored tree.
+    pub fn restore(&self) -> eyre::Result<IncrementalMerkle> {
+        let tree: IncrementalMerkle = borsh::from_slice(&self.tree)?;
+        if tree.count() == 0 || (tree.count() as u32).saturating_sub(1) != self.index {
+            eyre::bail!(
+                "Snapshot index {} does not match decoded tree count {}",
+                self.index,
+                tree.count(),
+            );
+        }
+        if tree.root() != self.root {
+            eyre::bail!("Snapshot root does not match decoded tree root");
+        }
+        Ok(tree)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -140,6 +188,29 @@ mod test {
         let serialized = borsh::to_vec(&tree).unwrap();
         let deserialized: IncrementalMerkle = borsh::from_slice(&serialized).unwrap();
         assert_eq!(tree, deserialized);
+    }
+
+    #[test]
+    fn snapshot_capture_restore_round_trip() {
+        let mut tree = IncrementalMerkle::default();
+        assert!(MerkleTreeSnapshot::capture(&tree).is_err());
+        for i in 0..17u64 {
+            tree.ingest(H256::from_low_u64_be(i));
+        }
+        let snapshot = MerkleTreeSnapshot::capture(&tree).unwrap();
+        assert_eq!(snapshot.index, 16);
+        assert_eq!(snapshot.root, tree.root());
+        // ~1 KiB frontier, not the full tree.
+        assert!(snapshot.tree.len() < 2048);
+        let restored = snapshot.restore().unwrap();
+        assert_eq!(restored, tree);
+
+        let mut tampered = snapshot.clone();
+        tampered.root = H256::from_low_u64_be(0xdead);
+        assert!(tampered.restore().is_err());
+        let mut misindexed = snapshot.clone();
+        misindexed.index += 1;
+        assert!(misindexed.restore().is_err());
     }
 }
 


### PR DESCRIPTION
## Outcome

Restore the validator Merkle frontier from bounded S3/local checkpoint storage and replay only the post-snapshot tail. Warm-restart work changes from total history `H` to tail `T`; an exact-tip restart has `T=0`.

## Change

| Step | Behaviour |
| --- | --- |
| Persist | Write `{ index, root, tree }` after successful backfill |
| Validate | Match signer plus checkpoint domain, hook, index and root |
| Restore | Replay and submit only `index + 1..target` |
| Fallback | Missing, corrupt, ahead or mismatched snapshots use the existing full rebuild |

`IncrementalMerkle` is only its O(depth) frontier plus count, so the snapshot is ~1 KiB. Local and S3 reads enforce the shared 50KiB object limit before decoding. The locked GCS client collects whole objects without a bounded download API, so GCS uses the trait’s no-snapshot defaults and full cold replay; it receives no snapshot acceleration. There is no steady-state writer or new RPC path.

## Expected impact

| Work per warm restart | Before | After |
| --- | ---: | ---: |
| Local point reads | `H` | `T` |
| Tree ingests | `H` | `T` |
| Checkpoint-storage reads | `H` | `T` + one validation read |
| ECDSA recoveries | Up to `H` | Up to `T` + one validation recovery |

At the observed Arbitrum history (`H≈2.5M`), an exact-tip restart changes each guaranteed per-leaf category from ~2.5M operations to zero. Eclipse similarly avoids ~326k operations/category. These are code-derived counts; restart latency and CPU remain unmeasured until canary.

This supersedes #9447. The snapshot already skips both tree ingestion and checkpoint verification below `S`; a second backfill-floor marker duplicated state without another gain.

## Correctness / verification

- Snapshot must decode to a non-zero 32-bit count and its claimed index/root.
- Final tree must still match the canonical correctness checkpoint before signing.
- Snapshot writes happen only after successful backfill; write failure only makes the next restart rebuild.
- Round-trip, size-bound, tamper, misindex, valid-tail, exact-target and corrupt-fallback tests passed via `cargo test -p validator submit::tests`; commit hooks passed.
- Local/GCS storage tests **2/2** and validator snapshot/backfill tests **4/4** passed, including missing/read-error cold replay; strict production base/validator Clippy and normal hooks passed.
- No schema/config change. Canary an S3/local validator, verify bounded snapshot write/read + validated restore + `backfill_complete=1`; GCS continues cold replay. Rollback is image-only.

Part of #9386.


Rebased on `main@06d8269ef1`; exact head `cb110e6b12`.