### PR TITLE
perf(scraper): retry known raw dispatches directly

### DIFF
--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -12,11 +12,11 @@ use hyperlane_core::{
     rpc_clients::RPC_RETRY_SLEEP_DURATION, Delivery, HyperlaneDomain, HyperlaneLogStore,
     HyperlaneMessage, IndexMode, InterchainGasPayment, MerkleTreeInsertion, SameChainCcrSwap,
 };
-use prometheus::{IntGauge, IntGaugeVec};
+use prometheus::{HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
 use tokio::{
     sync::mpsc::Receiver as MpscReceiver,
     task::JoinHandle,
-    time::{interval, sleep, MissedTickBehavior},
+    time::{interval, sleep, Instant, MissedTickBehavior},
 };
 use tracing::{info, info_span, instrument, trace, warn, Instrument};
 
@@ -40,7 +40,114 @@ const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
 // recovery prompt while cutting steady-state anti-join scans by 80% relative to the old minute.
 const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(5 * 60);
 const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
+// A full sweep is only a correctness fallback for sequence commit-order races and old rows whose
+// body is populated after the incremental watermark passes them. Thirty minutes cuts historical
+// anti-joins by 83% while bounding those exceptional discoveries to half an hour.
+const RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL: Duration = Duration::from_secs(30 * 60);
+const RAW_DISPATCH_RECONCILIATION_RETRY_BATCH_SIZE: usize = 100;
 const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
+
+const RAW_DISPATCH_DISCOVERY_FRONTIER_KIND: &str = "discovery_frontier";
+const RAW_DISPATCH_DISCOVERY_PAGE_KIND: &str = "discovery_page";
+const RAW_DISPATCH_RETRY_PAGE_KIND: &str = "retry_page";
+const RAW_DISPATCH_SWEEP_FRONTIER_KIND: &str = "sweep_frontier";
+const RAW_DISPATCH_SWEEP_PAGE_KIND: &str = "sweep_page";
+
+#[derive(Debug, Clone, Copy)]
+struct RawDispatchScan {
+    after_id: i64,
+    through_id: i64,
+    next_page_at: Instant,
+}
+
+impl RawDispatchScan {
+    fn new(after_id: i64, through_id: i64, now: Instant) -> Option<Self> {
+        (through_id > after_id).then_some(Self {
+            after_id,
+            through_id,
+            next_page_at: now,
+        })
+    }
+
+    /// Returns true once the snapshot is exhausted. A full page advances only to the last row
+    /// returned; a short page proves that every candidate through the immutable frontier was read.
+    fn complete_page(&mut self, result: &RawDispatchReconciliationResult, now: Instant) -> bool {
+        if raw_dispatch_reconciliation_scan_complete(result) {
+            true
+        } else {
+            self.after_id = result.next_after_id;
+            self.next_page_at = instant_after(now, RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP);
+            false
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RawDispatchReconciliationMetrics {
+    operations: IntCounterVec,
+    duration: HistogramVec,
+    pending_retries: IntGaugeVec,
+    retry_capacity_overflows: IntCounterVec,
+}
+
+impl RawDispatchReconciliationMetrics {
+    fn new(metrics: &CoreMetrics) -> Self {
+        let operations = metrics
+            .new_int_counter(
+                "raw_message_dispatch_reconciliation_operations",
+                "Number of raw dispatch reconciliation operations",
+                &["chain", "kind"],
+            )
+            .expect("failed to register raw dispatch reconciliation operation metric");
+        let duration = metrics
+            .new_histogram(
+                "raw_message_dispatch_reconciliation_duration_seconds",
+                "Raw dispatch reconciliation operation duration",
+                &["chain", "kind"],
+                vec![0.01, 0.1, 0.5, 1.0, 5.0, 15.0, 30.0, 60.0, 120.0],
+            )
+            .expect("failed to register raw dispatch reconciliation duration metric");
+        let pending_retries = metrics
+            .new_int_gauge(
+                "raw_message_dispatch_reconciliation_pending_retries",
+                "Raw dispatch rows waiting for a direct retry",
+                &["chain"],
+            )
+            .expect("failed to register raw dispatch reconciliation retry metric");
+        let retry_capacity_overflows = metrics
+            .new_int_counter(
+                "raw_message_dispatch_reconciliation_retry_capacity_overflows",
+                "Number of missing raw dispatches left to the completeness sweep because the direct retry set was full",
+                &["chain"],
+            )
+            .expect("failed to register raw dispatch reconciliation retry overflow metric");
+        Self {
+            operations,
+            duration,
+            pending_retries,
+            retry_capacity_overflows,
+        }
+    }
+
+    fn start(&self, chain: &str, kind: &str) -> prometheus::HistogramTimer {
+        self.operations.with_label_values(&[chain, kind]).inc();
+        self.duration
+            .with_label_values(&[chain, kind])
+            .start_timer()
+    }
+
+    fn set_pending_retries(&self, chain: &str, count: usize) {
+        self.pending_retries
+            .with_label_values(&[chain])
+            .set(count.try_into().unwrap_or(i64::MAX));
+    }
+
+    fn add_retry_capacity_overflows(&self, chain: &str, count: usize) {
+        self.retry_capacity_overflows
+            .with_label_values(&[chain])
+            .inc_by(count as u64);
+    }
+}
 
 fn raw_dispatch_reconciliation_initial_delay(domain_id: u32) -> Duration {
     // Multiplication mixes small, sequential domain IDs before placing each chain in a stable
@@ -52,18 +159,139 @@ fn raw_dispatch_reconciliation_initial_delay(domain_id: u32) -> Duration {
     Duration::from_secs(offset)
 }
 
+fn instant_after(now: Instant, duration: Duration) -> Instant {
+    now.checked_add(duration).unwrap_or(now)
+}
+
+fn failed_lane_retry_at(now: Instant) -> Instant {
+    // Keep the failed lane asleep for two global cooldowns. When the first cooldown expires,
+    // another due lane gets a turn instead of the same failure monopolizing every wake.
+    let delay = RPC_RETRY_SLEEP_DURATION
+        .checked_mul(2)
+        .unwrap_or(Duration::MAX);
+    instant_after(now, delay)
+}
+
 fn raw_dispatch_reconciliation_scan_complete(result: &RawDispatchReconciliationResult) -> bool {
     result.candidate_count < RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize
 }
 
-fn raw_dispatch_reconciliation_sleep(result: &RawDispatchReconciliationResult) -> Duration {
-    if raw_dispatch_reconciliation_scan_complete(result) {
-        result
-            .next_retry_delay
-            .unwrap_or(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP)
-            .min(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP)
-    } else {
-        RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+fn raw_dispatch_scan_slot_available(
+    discovery_scan: Option<RawDispatchScan>,
+    full_sweep: Option<RawDispatchScan>,
+) -> bool {
+    discovery_scan.is_none() && full_sweep.is_none()
+}
+
+#[derive(Debug)]
+struct RawDispatchReconciliationSchedule {
+    discovery_watermark: i64,
+    discovery_scan: Option<RawDispatchScan>,
+    full_sweep: Option<RawDispatchScan>,
+    next_discovery_at: Instant,
+    next_full_sweep_at: Instant,
+    retry_not_before: Instant,
+    global_not_before: Instant,
+}
+
+impl RawDispatchReconciliationSchedule {
+    fn new(discovery_watermark: i64, now: Instant, global_not_before: Instant) -> Self {
+        Self {
+            discovery_watermark,
+            discovery_scan: None,
+            full_sweep: None,
+            next_discovery_at: instant_after(now, RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP),
+            next_full_sweep_at: now,
+            retry_not_before: now,
+            global_not_before,
+        }
+    }
+
+    fn scan_slot_available(&self) -> bool {
+        raw_dispatch_scan_slot_available(self.discovery_scan, self.full_sweep)
+    }
+
+    fn scans_are_serialized(&self) -> bool {
+        self.discovery_scan.is_none() || self.full_sweep.is_none()
+    }
+
+    fn start_discovery(&mut self, frontier: i64, now: Instant) {
+        debug_assert!(self.scan_slot_available());
+        self.discovery_scan = RawDispatchScan::new(self.discovery_watermark, frontier, now);
+        if self.discovery_scan.is_none() {
+            self.next_discovery_at = instant_after(now, RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP);
+        }
+    }
+
+    fn start_full_sweep(&mut self, frontier: i64, now: Instant) {
+        debug_assert!(self.scan_slot_available());
+        self.full_sweep = RawDispatchScan::new(0, frontier, now);
+        if self.full_sweep.is_none() {
+            self.next_full_sweep_at =
+                instant_after(now, RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL);
+        }
+    }
+
+    fn complete_discovery_page(
+        &mut self,
+        mut scan: RawDispatchScan,
+        result: &RawDispatchReconciliationResult,
+        now: Instant,
+    ) {
+        if scan.complete_page(result, now) {
+            self.discovery_watermark = self.discovery_watermark.max(scan.through_id);
+            self.discovery_scan = None;
+            self.next_discovery_at = instant_after(now, RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP);
+        } else {
+            self.discovery_scan = Some(scan);
+        }
+    }
+
+    fn complete_full_sweep_page(
+        &mut self,
+        mut scan: RawDispatchScan,
+        result: &RawDispatchReconciliationResult,
+        now: Instant,
+    ) {
+        if scan.complete_page(result, now) {
+            self.discovery_watermark = self.discovery_watermark.max(scan.through_id);
+            self.full_sweep = None;
+            self.next_full_sweep_at =
+                instant_after(now, RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL);
+        } else {
+            self.full_sweep = Some(scan);
+        }
+    }
+
+    fn defer_retry_lane(&mut self, now: Instant) {
+        self.global_not_before = instant_after(now, RPC_RETRY_SLEEP_DURATION);
+        self.retry_not_before = failed_lane_retry_at(now);
+    }
+
+    fn defer_discovery_frontier(&mut self, now: Instant) {
+        self.global_not_before = instant_after(now, RPC_RETRY_SLEEP_DURATION);
+        self.next_discovery_at = failed_lane_retry_at(now);
+    }
+
+    fn defer_discovery_page(&mut self, scan: RawDispatchScan, now: Instant) {
+        self.global_not_before = instant_after(now, RPC_RETRY_SLEEP_DURATION);
+        self.discovery_scan = Some(RawDispatchScan {
+            next_page_at: failed_lane_retry_at(now),
+            ..scan
+        });
+    }
+
+    fn defer_sweep_frontier(&mut self, now: Instant) {
+        self.global_not_before = instant_after(now, RPC_RETRY_SLEEP_DURATION);
+        self.next_full_sweep_at = failed_lane_retry_at(now);
+    }
+
+    fn defer_sweep_page(&mut self, scan: RawDispatchScan, now: Instant) {
+        self.global_not_before = instant_after(now, RPC_RETRY_SLEEP_DURATION);
+        self.full_sweep = Some(RawDispatchScan {
+            next_page_at: failed_lane_retry_at(now),
+            ..scan
+        });
     }
 }
 
@@ -110,6 +338,7 @@ pub struct Scraper {
     chain_metrics: ChainMetrics,
     runtime_metrics: RuntimeMetrics,
     raw_dispatch_unenriched_max_age: IntGaugeVec,
+    raw_dispatch_reconciliation_metrics: RawDispatchReconciliationMetrics,
 }
 
 #[derive(Debug)]
@@ -148,6 +377,7 @@ impl BaseAgent for Scraper {
                 &["chain"],
             )
             .expect("failed to register raw dispatch reconciliation age metric");
+        let raw_dispatch_reconciliation_metrics = RawDispatchReconciliationMetrics::new(&metrics);
 
         let scrapers = Self::build_chain_scrapers(
             &settings,
@@ -170,6 +400,7 @@ impl BaseAgent for Scraper {
             chain_metrics,
             runtime_metrics,
             raw_dispatch_unenriched_max_age,
+            raw_dispatch_reconciliation_metrics,
         })
     }
 
@@ -327,6 +558,7 @@ impl Scraper {
             domain.clone(),
             self.contract_sync_metrics.clone(),
             self.raw_dispatch_unenriched_max_age.clone(),
+            self.raw_dispatch_reconciliation_metrics.clone(),
             store.clone(),
         ));
 
@@ -467,6 +699,7 @@ impl Scraper {
         domain: HyperlaneDomain,
         contract_sync_metrics: Arc<ContractSyncMetrics>,
         raw_dispatch_unenriched_max_age: IntGaugeVec,
+        reconciliation_metrics: RawDispatchReconciliationMetrics,
         store: HyperlaneDbStore,
     ) -> JoinHandle<()> {
         let domain_name = domain.name().to_owned();
@@ -483,9 +716,7 @@ impl Scraper {
                 ]);
                 let max_age_metric =
                     raw_dispatch_unenriched_max_age.with_label_values(&[&domain_name]);
-                let mut next_after_id = 0;
                 let mut retry_backoff = RawDispatchRetryBackoff::default();
-                let mut max_age_seen_this_scan = 0_u64;
 
                 update_liveness_metric(&liveness_metric);
                 sleep_with_liveness(
@@ -494,79 +725,319 @@ impl Scraper {
                 )
                 .await;
 
+                let initial_frontier =
+                    AssertUnwindSafe(store.latest_reconcilable_raw_dispatch_id())
+                        .catch_unwind()
+                        .await;
+                let (discovery_watermark, global_not_before) = match initial_frontier {
+                    Ok(Ok(frontier)) => (frontier, Instant::now()),
+                    Ok(Err(err)) => {
+                        warn!(
+                            ?err,
+                            domain = domain_name,
+                            "Failed to initialize raw dispatch discovery watermark"
+                        );
+                        let now = Instant::now();
+                        (0, instant_after(now, RPC_RETRY_SLEEP_DURATION))
+                    }
+                    Err(_) => {
+                        warn!(
+                            domain = domain_name,
+                            "Raw dispatch discovery watermark initialization panicked; retrying"
+                        );
+                        let now = Instant::now();
+                        (0, instant_after(now, RPC_RETRY_SLEEP_DURATION))
+                    }
+                };
+                let now = Instant::now();
+                let mut schedule = RawDispatchReconciliationSchedule::new(
+                    discovery_watermark,
+                    now,
+                    global_not_before,
+                );
+
                 loop {
                     update_liveness_metric(&liveness_metric);
+                    let now = Instant::now();
+                    if schedule.global_not_before > now {
+                        sleep_with_liveness(
+                            schedule.global_not_before.saturating_duration_since(now),
+                            &liveness_metric,
+                        )
+                        .await;
+                        continue;
+                    }
+                    let mut cycle_failed = false;
 
-                    let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
-                        next_after_id,
-                        RAW_DISPATCH_RECONCILIATION_BATCH_SIZE,
-                        &mut retry_backoff,
-                    ))
-                    .catch_unwind()
-                    .await;
-
-                    match result {
-                        Ok(Ok(result)) if result.candidate_count == 0 && next_after_id > 0 => {
-                            next_after_id = 0;
-                            max_age_seen_this_scan = 0;
-                            sleep_with_liveness(
-                                raw_dispatch_reconciliation_sleep(&result),
-                                &liveness_metric,
-                            )
-                            .await;
-                        }
-                        Ok(Ok(result)) if result.candidate_count == 0 => {
-                            max_age_metric.set(0);
-                            max_age_seen_this_scan = 0;
-                            sleep_with_liveness(
-                                RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP,
-                                &liveness_metric,
-                            )
-                            .await;
-                        }
-                        Ok(Ok(result)) => {
-                            next_after_id = result.next_after_id;
-                            max_age_seen_this_scan =
-                                max_age_seen_this_scan.max(result.max_unenriched_age_seconds);
-                            max_age_metric
-                                .set(max_age_seen_this_scan.try_into().unwrap_or(i64::MAX));
-                            stored_events_metric.inc_by(result.stored_count.into());
-                            info!(
-                                candidates = result.candidate_count,
-                                attempted = result.attempted_count,
-                                skipped_backoff = result.skipped_backoff_count,
-                                stored = result.stored_count,
-                                next_after_id,
-                                max_unenriched_age_seconds = max_age_seen_this_scan,
-                                domain = domain_name,
-                                "Reconciled raw message dispatches"
-                            );
-                            if raw_dispatch_reconciliation_scan_complete(&result) {
-                                next_after_id = 0;
-                                max_age_seen_this_scan = 0;
+                    let due_raw_ids = retry_backoff.due_raw_ids(
+                        time::OffsetDateTime::now_utc(),
+                        RAW_DISPATCH_RECONCILIATION_RETRY_BATCH_SIZE,
+                    );
+                    if schedule.retry_not_before <= now && !due_raw_ids.is_empty() {
+                        let timer = reconciliation_metrics
+                            .start(&domain_name, RAW_DISPATCH_RETRY_PAGE_KIND);
+                        let result = AssertUnwindSafe(
+                            store.retry_raw_message_dispatches(&due_raw_ids, &mut retry_backoff),
+                        )
+                        .catch_unwind()
+                        .await;
+                        timer.observe_duration();
+                        match result {
+                            Ok(Ok(result)) => {
+                                stored_events_metric.inc_by(result.stored_count.into());
+                                info!(
+                                    kind = RAW_DISPATCH_RETRY_PAGE_KIND,
+                                    requested = due_raw_ids.len(),
+                                    candidates = result.candidate_count,
+                                    attempted = result.attempted_count,
+                                    stored = result.stored_count,
+                                    domain = domain_name,
+                                    "Reconciled raw message dispatches"
+                                );
                             }
-                            sleep_with_liveness(
-                                raw_dispatch_reconciliation_sleep(&result),
-                                &liveness_metric,
-                            )
-                            .await;
-                        }
-                        Ok(Err(err)) => {
-                            warn!(
-                                ?err,
-                                domain = domain_name,
-                                "Failed to reconcile raw message dispatches"
-                            );
-                            sleep(RPC_RETRY_SLEEP_DURATION).await;
-                        }
-                        Err(_) => {
-                            warn!(
-                                domain = domain_name,
-                                "Raw message dispatch reconciliation panicked; retrying"
-                            );
-                            sleep(RPC_RETRY_SLEEP_DURATION).await;
+                            Ok(Err(err)) => {
+                                warn!(
+                                    ?err,
+                                    kind = RAW_DISPATCH_RETRY_PAGE_KIND,
+                                    domain = domain_name,
+                                    "Failed to reconcile raw message dispatches"
+                                );
+                                schedule.defer_retry_lane(Instant::now());
+                                cycle_failed = true;
+                            }
+                            Err(_) => {
+                                warn!(
+                                    kind = RAW_DISPATCH_RETRY_PAGE_KIND,
+                                    domain = domain_name,
+                                    "Raw message dispatch reconciliation panicked; retrying"
+                                );
+                                schedule.defer_retry_lane(Instant::now());
+                                cycle_failed = true;
+                            }
                         }
                     }
+
+                    let now = Instant::now();
+                    if !cycle_failed
+                        && schedule.scan_slot_available()
+                        && schedule.next_discovery_at <= now
+                    {
+                        let timer = reconciliation_metrics
+                            .start(&domain_name, RAW_DISPATCH_DISCOVERY_FRONTIER_KIND);
+                        let frontier =
+                            AssertUnwindSafe(store.latest_reconcilable_raw_dispatch_id())
+                                .catch_unwind()
+                                .await;
+                        timer.observe_duration();
+                        match frontier {
+                            Ok(Ok(frontier)) => schedule.start_discovery(frontier, now),
+                            Ok(Err(err)) => {
+                                warn!(
+                                    ?err,
+                                    kind = RAW_DISPATCH_DISCOVERY_FRONTIER_KIND,
+                                    domain = domain_name,
+                                    "Failed to snapshot raw dispatch reconciliation frontier"
+                                );
+                                schedule.defer_discovery_frontier(Instant::now());
+                                cycle_failed = true;
+                            }
+                            Err(_) => {
+                                warn!(
+                                    kind = RAW_DISPATCH_DISCOVERY_FRONTIER_KIND,
+                                    domain = domain_name,
+                                    "Raw dispatch reconciliation frontier query panicked; retrying"
+                                );
+                                schedule.defer_discovery_frontier(Instant::now());
+                                cycle_failed = true;
+                            }
+                        }
+                    }
+
+                    if let Some(scan) = schedule
+                        .discovery_scan
+                        .filter(|scan| !cycle_failed && scan.next_page_at <= now)
+                    {
+                        let timer = reconciliation_metrics
+                            .start(&domain_name, RAW_DISPATCH_DISCOVERY_PAGE_KIND);
+                        let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
+                            scan.after_id,
+                            scan.through_id,
+                            RAW_DISPATCH_RECONCILIATION_BATCH_SIZE,
+                            &mut retry_backoff,
+                        ))
+                        .catch_unwind()
+                        .await;
+                        timer.observe_duration();
+                        match result {
+                            Ok(Ok(result)) => {
+                                stored_events_metric.inc_by(result.stored_count.into());
+                                info!(
+                                    kind = RAW_DISPATCH_DISCOVERY_PAGE_KIND,
+                                    candidates = result.candidate_count,
+                                    attempted = result.attempted_count,
+                                    skipped_backoff = result.skipped_backoff_count,
+                                    stored = result.stored_count,
+                                    retry_capacity_overflows = result.untracked_count,
+                                    after_id = scan.after_id,
+                                    through_id = scan.through_id,
+                                    domain = domain_name,
+                                    "Reconciled raw message dispatches"
+                                );
+                                reconciliation_metrics.add_retry_capacity_overflows(
+                                    &domain_name,
+                                    result.untracked_count,
+                                );
+                                schedule.complete_discovery_page(scan, &result, Instant::now());
+                            }
+                            Ok(Err(err)) => {
+                                warn!(
+                                    ?err,
+                                    kind = RAW_DISPATCH_DISCOVERY_PAGE_KIND,
+                                    domain = domain_name,
+                                    "Failed to reconcile raw message dispatches"
+                                );
+                                schedule.defer_discovery_page(scan, Instant::now());
+                                cycle_failed = true;
+                            }
+                            Err(_) => {
+                                warn!(
+                                    kind = RAW_DISPATCH_DISCOVERY_PAGE_KIND,
+                                    domain = domain_name,
+                                    "Raw message dispatch reconciliation panicked; retrying"
+                                );
+                                schedule.defer_discovery_page(scan, Instant::now());
+                                cycle_failed = true;
+                            }
+                        }
+                    }
+
+                    let now = Instant::now();
+                    if !cycle_failed
+                        && schedule.scan_slot_available()
+                        && schedule.next_full_sweep_at <= now
+                    {
+                        let timer = reconciliation_metrics
+                            .start(&domain_name, RAW_DISPATCH_SWEEP_FRONTIER_KIND);
+                        let frontier =
+                            AssertUnwindSafe(store.latest_reconcilable_raw_dispatch_id())
+                                .catch_unwind()
+                                .await;
+                        timer.observe_duration();
+                        match frontier {
+                            Ok(Ok(frontier)) => schedule.start_full_sweep(frontier, now),
+                            Ok(Err(err)) => {
+                                warn!(
+                                    ?err,
+                                    kind = RAW_DISPATCH_SWEEP_FRONTIER_KIND,
+                                    domain = domain_name,
+                                    "Failed to snapshot raw dispatch reconciliation frontier"
+                                );
+                                schedule.defer_sweep_frontier(Instant::now());
+                                cycle_failed = true;
+                            }
+                            Err(_) => {
+                                warn!(
+                                    kind = RAW_DISPATCH_SWEEP_FRONTIER_KIND,
+                                    domain = domain_name,
+                                    "Raw dispatch reconciliation frontier query panicked; retrying"
+                                );
+                                schedule.defer_sweep_frontier(Instant::now());
+                                cycle_failed = true;
+                            }
+                        }
+                    }
+
+                    if let Some(scan) = schedule
+                        .full_sweep
+                        .filter(|scan| !cycle_failed && scan.next_page_at <= now)
+                    {
+                        let timer = reconciliation_metrics
+                            .start(&domain_name, RAW_DISPATCH_SWEEP_PAGE_KIND);
+                        let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
+                            scan.after_id,
+                            scan.through_id,
+                            RAW_DISPATCH_RECONCILIATION_BATCH_SIZE,
+                            &mut retry_backoff,
+                        ))
+                        .catch_unwind()
+                        .await;
+                        timer.observe_duration();
+                        match result {
+                            Ok(Ok(result)) => {
+                                stored_events_metric.inc_by(result.stored_count.into());
+                                info!(
+                                    kind = RAW_DISPATCH_SWEEP_PAGE_KIND,
+                                    candidates = result.candidate_count,
+                                    attempted = result.attempted_count,
+                                    skipped_backoff = result.skipped_backoff_count,
+                                    stored = result.stored_count,
+                                    retry_capacity_overflows = result.untracked_count,
+                                    after_id = scan.after_id,
+                                    through_id = scan.through_id,
+                                    domain = domain_name,
+                                    "Reconciled raw message dispatches"
+                                );
+                                reconciliation_metrics.add_retry_capacity_overflows(
+                                    &domain_name,
+                                    result.untracked_count,
+                                );
+                                schedule.complete_full_sweep_page(scan, &result, Instant::now());
+                            }
+                            Ok(Err(err)) => {
+                                warn!(
+                                    ?err,
+                                    kind = RAW_DISPATCH_SWEEP_PAGE_KIND,
+                                    domain = domain_name,
+                                    "Failed to reconcile raw message dispatches"
+                                );
+                                schedule.defer_sweep_page(scan, Instant::now());
+                            }
+                            Err(_) => {
+                                warn!(
+                                    kind = RAW_DISPATCH_SWEEP_PAGE_KIND,
+                                    domain = domain_name,
+                                    "Raw message dispatch reconciliation panicked; retrying"
+                                );
+                                schedule.defer_sweep_page(scan, Instant::now());
+                            }
+                        }
+                    }
+
+                    reconciliation_metrics.set_pending_retries(&domain_name, retry_backoff.len());
+                    debug_assert!(schedule.scans_are_serialized());
+                    max_age_metric.set(
+                        retry_backoff
+                            .max_unenriched_age_seconds(time::OffsetDateTime::now_utc())
+                            .try_into()
+                            .unwrap_or(i64::MAX),
+                    );
+
+                    let now = Instant::now();
+                    let retry_delay = retry_backoff
+                        .next_retry_delay(time::OffsetDateTime::now_utc())
+                        .unwrap_or(Duration::MAX);
+                    let retry_delay = if schedule.retry_not_before > now {
+                        retry_delay.max(schedule.retry_not_before.saturating_duration_since(now))
+                    } else {
+                        retry_delay
+                    };
+                    let discovery_delay = schedule
+                        .discovery_scan
+                        .map(|scan| scan.next_page_at.saturating_duration_since(now))
+                        .unwrap_or_else(|| {
+                            schedule.next_discovery_at.saturating_duration_since(now)
+                        });
+                    let sweep_delay = schedule
+                        .full_sweep
+                        .map(|scan| scan.next_page_at.saturating_duration_since(now))
+                        .unwrap_or_else(|| {
+                            schedule.next_full_sweep_at.saturating_duration_since(now)
+                        });
+                    sleep_with_liveness(
+                        retry_delay.min(discovery_delay).min(sweep_delay),
+                        &liveness_metric,
+                    )
+                    .await;
                 }
             }
             .instrument(info_span!("RawDispatchReconciliation", chain=%span_domain_name)),
@@ -849,28 +1320,107 @@ mod test {
     }
 
     #[test]
-    fn raw_dispatch_scan_uses_backlog_delay_until_final_page() {
+    fn raw_dispatch_scan_distinguishes_full_and_final_pages() {
         let full_page = RawDispatchReconciliationResult {
             candidate_count: RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize,
-            next_retry_delay: Some(Duration::from_secs(900)),
             ..Default::default()
         };
         let final_page = RawDispatchReconciliationResult {
             candidate_count: 1,
-            next_retry_delay: Some(Duration::from_secs(900)),
             ..Default::default()
         };
 
         assert!(!raw_dispatch_reconciliation_scan_complete(&full_page));
-        assert_eq!(
-            raw_dispatch_reconciliation_sleep(&full_page),
-            RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
-        );
         assert!(raw_dispatch_reconciliation_scan_complete(&final_page));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn raw_dispatch_scan_advances_only_after_a_full_page() {
+        let started_at = Instant::now();
+        let mut scan = RawDispatchScan::new(10, 250, started_at)
+            .expect("frontier beyond the cursor should start a scan");
+        let full_page = RawDispatchReconciliationResult {
+            candidate_count: RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize,
+            next_after_id: 110,
+            ..Default::default()
+        };
+
+        assert!(!scan.complete_page(&full_page, started_at));
+        assert_eq!(scan.after_id, 110);
         assert_eq!(
-            raw_dispatch_reconciliation_sleep(&final_page),
-            RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP
+            scan.next_page_at,
+            instant_after(started_at, RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP)
         );
+
+        let final_page = RawDispatchReconciliationResult {
+            candidate_count: 0,
+            ..Default::default()
+        };
+        assert!(scan.complete_page(&final_page, scan.next_page_at));
+        assert_eq!(scan.through_id, 250);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn raw_dispatch_scan_uses_an_immutable_frontier() {
+        let now = Instant::now();
+
+        assert!(RawDispatchScan::new(50, 50, now).is_none());
+        let scan = RawDispatchScan::new(50, 75, now)
+            .expect("new rows beyond the watermark should start a scan");
+        assert_eq!(scan.after_id, 50);
+        assert_eq!(scan.through_id, 75);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn failed_lane_stays_backed_off_after_global_cooldown() {
+        let failure_at = Instant::now();
+        let global_retry_at = instant_after(failure_at, RPC_RETRY_SLEEP_DURATION);
+        let lane_retry_at = failed_lane_retry_at(failure_at);
+
+        tokio::time::advance(RPC_RETRY_SLEEP_DURATION).await;
+        let next_wake = Instant::now();
+
+        assert_eq!(next_wake, global_retry_at);
+        assert!(lane_retry_at > next_wake);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discovery_and_completeness_scans_share_one_slot() {
+        let now = Instant::now();
+        let active_scan = RawDispatchScan::new(0, 10, now);
+
+        assert!(raw_dispatch_scan_slot_available(None, None));
+        assert!(!raw_dispatch_scan_slot_available(active_scan, None));
+        assert!(!raw_dispatch_scan_slot_available(None, active_scan));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconciliation_schedule_preserves_progress_and_yields_failed_lanes() {
+        let started_at = Instant::now();
+        let mut schedule = RawDispatchReconciliationSchedule::new(50, started_at, started_at);
+
+        schedule.defer_retry_lane(started_at);
+        tokio::time::advance(RPC_RETRY_SLEEP_DURATION).await;
+        let after_global_cooldown = Instant::now();
+        assert!(schedule.retry_not_before > after_global_cooldown);
+
+        schedule.start_full_sweep(100, after_global_cooldown);
+        assert!(!schedule.scan_slot_available());
+        assert!(schedule.discovery_scan.is_none());
+        let sweep = schedule.full_sweep.expect("sweep should be active");
+
+        schedule.defer_sweep_page(sweep, after_global_cooldown);
+        let deferred = schedule
+            .full_sweep
+            .expect("failed sweep should retain its cursor");
+        assert_eq!(deferred.after_id, sweep.after_id);
+        assert_eq!(deferred.through_id, sweep.through_id);
+
+        let final_page = RawDispatchReconciliationResult::default();
+        schedule.complete_full_sweep_page(deferred, &final_page, deferred.next_page_at);
+        assert!(schedule.full_sweep.is_none());
+        assert_eq!(schedule.discovery_watermark, 100);
+        assert!(schedule.scans_are_serialized());
     }
 
     #[test]
@@ -895,16 +1445,7 @@ mod test {
         let task = tokio::spawn(async move {
             loop {
                 task_query_count.fetch_add(1, Ordering::SeqCst);
-                let final_page = RawDispatchReconciliationResult {
-                    candidate_count: 1,
-                    next_retry_delay: Some(Duration::from_secs(900)),
-                    ..Default::default()
-                };
-                sleep_with_liveness(
-                    raw_dispatch_reconciliation_sleep(&final_page),
-                    &task_liveness,
-                )
-                .await;
+                sleep_with_liveness(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP, &task_liveness).await;
             }
         });
 

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -211,15 +211,14 @@ impl RawDispatchReconciliationSchedule {
         raw_dispatch_scan_slot_available(self.discovery_scan, self.full_sweep)
     }
 
-    fn scans_are_serialized(&self) -> bool {
-        self.discovery_scan.is_none() || self.full_sweep.is_none()
+    fn discovery_slot_available(&self) -> bool {
+        self.discovery_scan.is_none()
     }
 
     fn discovery_delay(&self, now: Instant) -> Duration {
-        match (self.discovery_scan, self.full_sweep) {
-            (Some(scan), _) => scan.next_page_at.saturating_duration_since(now),
-            (None, Some(_)) => Duration::MAX,
-            (None, None) => self.next_discovery_at.saturating_duration_since(now),
+        match self.discovery_scan {
+            Some(scan) => scan.next_page_at.saturating_duration_since(now),
+            None => self.next_discovery_at.saturating_duration_since(now),
         }
     }
 
@@ -232,7 +231,7 @@ impl RawDispatchReconciliationSchedule {
     }
 
     fn start_discovery(&mut self, frontier: i64, now: Instant) {
-        debug_assert!(self.scan_slot_available());
+        debug_assert!(self.discovery_slot_available());
         self.discovery_scan = RawDispatchScan::new(self.discovery_watermark, frontier, now);
         if self.discovery_scan.is_none() {
             self.next_discovery_at = instant_after(now, RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP);
@@ -269,8 +268,14 @@ impl RawDispatchReconciliationSchedule {
         result: &RawDispatchReconciliationResult,
         now: Instant,
     ) {
-        if scan.complete_page(result, now) {
-            self.discovery_watermark = self.discovery_watermark.max(scan.through_id);
+        let complete = scan.complete_page(result, now);
+        let covered_through = if complete {
+            scan.through_id
+        } else {
+            scan.after_id
+        };
+        self.discovery_watermark = self.discovery_watermark.max(covered_through);
+        if complete {
             self.full_sweep = None;
             self.next_full_sweep_at =
                 instant_after(now, RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL);
@@ -835,7 +840,7 @@ impl Scraper {
 
                     let now = Instant::now();
                     if !cycle_failed
-                        && schedule.scan_slot_available()
+                        && schedule.discovery_slot_available()
                         && schedule.next_discovery_at <= now
                     {
                         let timer = reconciliation_metrics
@@ -963,10 +968,11 @@ impl Scraper {
                         }
                     }
 
-                    if let Some(scan) = schedule
-                        .full_sweep
-                        .filter(|scan| !cycle_failed && scan.next_page_at <= now)
-                    {
+                    if let Some(scan) = schedule.full_sweep.filter(|scan| {
+                        !cycle_failed
+                            && schedule.discovery_scan.is_none()
+                            && scan.next_page_at <= now
+                    }) {
                         let timer = reconciliation_metrics
                             .start(&domain_name, RAW_DISPATCH_SWEEP_PAGE_KIND);
                         let result = AssertUnwindSafe(store.reconcile_raw_message_dispatches(
@@ -1020,7 +1026,6 @@ impl Scraper {
                     }
 
                     reconciliation_metrics.set_pending_retries(&domain_name, retry_backoff.len());
-                    debug_assert!(schedule.scans_are_serialized());
                     max_age_metric.set(
                         retry_backoff
                             .max_unenriched_age_seconds(time::OffsetDateTime::now_utc())
@@ -1401,7 +1406,7 @@ mod test {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn active_scan_ignores_overdue_blocked_lane_deadline() {
+    async fn multi_page_full_sweep_yields_to_overdue_discovery() {
         let started_at = Instant::now();
         let mut schedule = RawDispatchReconciliationSchedule::new(0, started_at, started_at);
         tokio::time::advance(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await;
@@ -1411,13 +1416,28 @@ mod test {
         let sweep = schedule
             .full_sweep
             .expect("full sweep should own scan slot");
-        assert_eq!(schedule.discovery_delay(now), Duration::MAX);
-        assert_eq!(schedule.full_sweep_delay(now), Duration::ZERO);
+        let full_page = RawDispatchReconciliationResult {
+            candidate_count: RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize,
+            next_after_id: 100,
+            ..Default::default()
+        };
+        schedule.complete_full_sweep_page(sweep, &full_page, now);
 
-        schedule.full_sweep = Some(RawDispatchScan {
-            next_page_at: instant_after(now, RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP),
-            ..sweep
-        });
+        assert_eq!(schedule.discovery_delay(now), Duration::ZERO);
+        assert!(schedule.discovery_slot_available());
+        schedule.start_discovery(250, now);
+        assert_eq!(schedule.discovery_scan.map(|scan| scan.after_id), Some(100));
+        assert!(schedule.full_sweep.is_some());
+        assert_eq!(schedule.full_sweep_delay(now), Duration::MAX);
+
+        let discovery = schedule
+            .discovery_scan
+            .expect("discovery should preempt the parked sweep");
+        schedule.complete_discovery_page(
+            discovery,
+            &RawDispatchReconciliationResult::default(),
+            now,
+        );
         assert_eq!(
             schedule.full_sweep_delay(now),
             RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
@@ -1450,7 +1470,7 @@ mod test {
         schedule.complete_full_sweep_page(deferred, &final_page, deferred.next_page_at);
         assert!(schedule.full_sweep.is_none());
         assert_eq!(schedule.discovery_watermark, 100);
-        assert!(schedule.scans_are_serialized());
+        assert!(schedule.scan_slot_available());
     }
 
     #[test]

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -224,7 +224,8 @@ impl RawDispatchReconciliationSchedule {
 
     fn full_sweep_delay(&self, now: Instant) -> Duration {
         match (self.full_sweep, self.discovery_scan) {
-            (Some(scan), _) => scan.next_page_at.saturating_duration_since(now),
+            (Some(_), Some(_)) => Duration::MAX,
+            (Some(scan), None) => scan.next_page_at.saturating_duration_since(now),
             (None, Some(_)) => Duration::MAX,
             (None, None) => self.next_full_sweep_at.saturating_duration_since(now),
         }
@@ -1433,14 +1434,30 @@ mod test {
         let discovery = schedule
             .discovery_scan
             .expect("discovery should preempt the parked sweep");
+        let discovery_page = RawDispatchReconciliationResult {
+            candidate_count: RAW_DISPATCH_RECONCILIATION_BATCH_SIZE as usize,
+            next_after_id: 150,
+            ..Default::default()
+        };
+        schedule.complete_discovery_page(discovery, &discovery_page, now);
+        assert_eq!(
+            schedule.discovery_delay(now),
+            RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+        );
+        assert_eq!(schedule.full_sweep_delay(now), Duration::MAX);
+
+        let discovery = schedule
+            .discovery_scan
+            .expect("second discovery page should remain active");
+        let discovery_ready_at = discovery.next_page_at;
         schedule.complete_discovery_page(
             discovery,
             &RawDispatchReconciliationResult::default(),
-            now,
+            discovery_ready_at,
         );
         assert_eq!(
-            schedule.full_sweep_delay(now),
-            RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+            schedule.full_sweep_delay(discovery_ready_at),
+            Duration::ZERO
         );
     }
 

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -215,6 +215,22 @@ impl RawDispatchReconciliationSchedule {
         self.discovery_scan.is_none() || self.full_sweep.is_none()
     }
 
+    fn discovery_delay(&self, now: Instant) -> Duration {
+        match (self.discovery_scan, self.full_sweep) {
+            (Some(scan), _) => scan.next_page_at.saturating_duration_since(now),
+            (None, Some(_)) => Duration::MAX,
+            (None, None) => self.next_discovery_at.saturating_duration_since(now),
+        }
+    }
+
+    fn full_sweep_delay(&self, now: Instant) -> Duration {
+        match (self.full_sweep, self.discovery_scan) {
+            (Some(scan), _) => scan.next_page_at.saturating_duration_since(now),
+            (None, Some(_)) => Duration::MAX,
+            (None, None) => self.next_full_sweep_at.saturating_duration_since(now),
+        }
+    }
+
     fn start_discovery(&mut self, frontier: i64, now: Instant) {
         debug_assert!(self.scan_slot_available());
         self.discovery_scan = RawDispatchScan::new(self.discovery_watermark, frontier, now);
@@ -1021,18 +1037,8 @@ impl Scraper {
                     } else {
                         retry_delay
                     };
-                    let discovery_delay = schedule
-                        .discovery_scan
-                        .map(|scan| scan.next_page_at.saturating_duration_since(now))
-                        .unwrap_or_else(|| {
-                            schedule.next_discovery_at.saturating_duration_since(now)
-                        });
-                    let sweep_delay = schedule
-                        .full_sweep
-                        .map(|scan| scan.next_page_at.saturating_duration_since(now))
-                        .unwrap_or_else(|| {
-                            schedule.next_full_sweep_at.saturating_duration_since(now)
-                        });
+                    let discovery_delay = schedule.discovery_delay(now);
+                    let sweep_delay = schedule.full_sweep_delay(now);
                     sleep_with_liveness(
                         retry_delay.min(discovery_delay).min(sweep_delay),
                         &liveness_metric,
@@ -1392,6 +1398,30 @@ mod test {
         assert!(raw_dispatch_scan_slot_available(None, None));
         assert!(!raw_dispatch_scan_slot_available(active_scan, None));
         assert!(!raw_dispatch_scan_slot_available(None, active_scan));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn active_scan_ignores_overdue_blocked_lane_deadline() {
+        let started_at = Instant::now();
+        let mut schedule = RawDispatchReconciliationSchedule::new(0, started_at, started_at);
+        tokio::time::advance(RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP).await;
+        let now = Instant::now();
+
+        schedule.start_full_sweep(200, now);
+        let sweep = schedule
+            .full_sweep
+            .expect("full sweep should own scan slot");
+        assert_eq!(schedule.discovery_delay(now), Duration::MAX);
+        assert_eq!(schedule.full_sweep_delay(now), Duration::ZERO);
+
+        schedule.full_sweep = Some(RawDispatchScan {
+            next_page_at: instant_after(now, RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP),
+            ..sweep
+        });
+        assert_eq!(
+            schedule.full_sweep_delay(now),
+            RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -41,8 +41,8 @@ const RAW_DISPATCH_RECONCILIATION_BATCH_SIZE: u64 = 100;
 const RAW_DISPATCH_RECONCILIATION_IDLE_SLEEP: Duration = Duration::from_secs(5 * 60);
 const RAW_DISPATCH_RECONCILIATION_BACKLOG_SLEEP: Duration = Duration::from_secs(2);
 // A full sweep is only a correctness fallback for sequence commit-order races and old rows whose
-// body is populated after the incremental watermark passes them. Thirty minutes cuts historical
-// anti-joins by 83% while bounding those exceptional discoveries to half an hour.
+// body is populated after the incremental watermark passes them. Start sweeps on a fixed cadence
+// so a long-running generation does not add another full interval before its successor starts.
 const RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL: Duration = Duration::from_secs(30 * 60);
 const RAW_DISPATCH_RECONCILIATION_RETRY_BATCH_SIZE: usize = 100;
 const LIVENESS_UPDATE_INTERVAL: Duration = Duration::from_secs(30);
@@ -241,11 +241,9 @@ impl RawDispatchReconciliationSchedule {
 
     fn start_full_sweep(&mut self, frontier: i64, now: Instant) {
         debug_assert!(self.scan_slot_available());
+        self.next_full_sweep_at =
+            instant_after(now, RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL);
         self.full_sweep = RawDispatchScan::new(0, frontier, now);
-        if self.full_sweep.is_none() {
-            self.next_full_sweep_at =
-                instant_after(now, RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL);
-        }
     }
 
     fn complete_discovery_page(
@@ -278,8 +276,6 @@ impl RawDispatchReconciliationSchedule {
         self.discovery_watermark = self.discovery_watermark.max(covered_through);
         if complete {
             self.full_sweep = None;
-            self.next_full_sweep_at =
-                instant_after(now, RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL);
         } else {
             self.full_sweep = Some(scan);
         }
@@ -1459,6 +1455,31 @@ mod test {
             schedule.full_sweep_delay(discovery_ready_at),
             Duration::ZERO
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn overdue_successor_sweep_starts_without_an_extra_interval() {
+        let started_at = Instant::now();
+        let mut schedule = RawDispatchReconciliationSchedule::new(0, started_at, started_at);
+
+        schedule.start_full_sweep(200, started_at);
+        let sweep = schedule
+            .full_sweep
+            .expect("full sweep should own scan slot");
+
+        tokio::time::advance(
+            RAW_DISPATCH_RECONCILIATION_FULL_SWEEP_INTERVAL + Duration::from_secs(1),
+        )
+        .await;
+        let completed_at = Instant::now();
+        schedule.complete_full_sweep_page(
+            sweep,
+            &RawDispatchReconciliationResult::default(),
+            completed_at,
+        );
+
+        assert!(schedule.full_sweep.is_none());
+        assert_eq!(schedule.full_sweep_delay(completed_at), Duration::ZERO);
     }
 
     #[tokio::test(start_paused = true)]

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -393,6 +393,19 @@ mod tests {
     use crate::db::{ScraperDb, StorableMessage};
 
     #[tokio::test]
+    async fn store_dispatched_messages_empty_input_executes_no_queries() {
+        let mock_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let scraper_db = ScraperDb::with_connection(mock_db);
+
+        let stored = scraper_db
+            .store_dispatched_messages(0, &H256::zero(), std::iter::empty::<StorableMessage<'_>>())
+            .await
+            .expect("empty stores should be a no-op");
+
+        assert_eq!(stored, 0);
+    }
+
+    #[tokio::test]
     async fn test_store_dispatched_messages_transaction() {
         const MESSAGE_AMOUNT: usize = 10000;
         let results = (0..MESSAGE_AMOUNT)

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -76,6 +76,33 @@ impl ScraperDb {
             .unwrap_or(0))
     }
 
+    /// Get the latest raw dispatch that can become a reconciliation candidate.
+    ///
+    /// This snapshots a stable upper bound for a discovery or completeness scan.
+    /// Filtering on `msg_body` also lets Postgres use the reconciliation partial
+    /// index instead of walking raw rows that can never be enriched.
+    pub async fn latest_reconcilable_raw_dispatch_id(
+        &self,
+        origin_domain: u32,
+        origin_mailbox: &H256,
+    ) -> Result<i64> {
+        let result = raw_message_dispatch::Entity::find()
+            .select_only()
+            .column_as(raw_message_dispatch::Column::Id.max(), "max_id")
+            .filter(raw_message_dispatch::Column::OriginDomain.eq(origin_domain))
+            .filter(
+                raw_message_dispatch::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)),
+            )
+            .filter(raw_message_dispatch::Column::MsgBody.is_not_null())
+            .into_tuple::<Option<i64>>()
+            .one(&self.0)
+            .await?;
+
+        Ok(result
+            .ok_or_else(|| eyre::eyre!("Error getting latest reconcilable raw dispatch id"))?
+            .unwrap_or(0))
+    }
+
     /// Count raw message dispatches with ID greater than the given ID for a specific domain and mailbox.
     async fn raw_dispatch_count_since_id(
         &self,
@@ -241,6 +268,7 @@ impl ScraperDb {
         origin_domain: u32,
         origin_mailbox: &H256,
         after_id: i64,
+        through_id: i64,
         limit: u64,
     ) -> Result<Vec<RawDispatchForEnrichment>> {
         let origin_mailbox = address_to_bytes(origin_mailbox);
@@ -259,14 +287,60 @@ impl ScraperDb {
                   AND raw_message_dispatch.msg_body IS NOT NULL
                   AND "message".id IS NULL
                   AND raw_message_dispatch.id > $3
+                  AND raw_message_dispatch.id <= $4
                 ORDER BY raw_message_dispatch.id ASC
-                LIMIT $4
+                LIMIT $5
                 "#,
                 [
                     (origin_domain as i32).into(),
                     origin_mailbox.into(),
                     after_id.into(),
+                    through_id.into(),
                     (limit as i64).into(),
+                ],
+            ))
+            .all(&self.0)
+            .await?;
+
+        raw_dispatches
+            .into_iter()
+            .map(raw_dispatch_to_candidate)
+            .collect()
+    }
+
+    /// Re-read known retry rows by primary key while excluding rows that another
+    /// writer has already enriched. The retry batch is bounded by the caller.
+    pub async fn retrieve_unenriched_raw_dispatches_by_ids(
+        &self,
+        origin_domain: u32,
+        origin_mailbox: &H256,
+        raw_ids: &[i64],
+    ) -> Result<Vec<RawDispatchForEnrichment>> {
+        if raw_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let raw_dispatches = raw_message_dispatch::Entity::find()
+            .from_raw_sql(Statement::from_sql_and_values(
+                self.0.get_database_backend(),
+                r#"
+                SELECT raw_message_dispatch.*
+                FROM raw_message_dispatch
+                LEFT JOIN "message"
+                  ON "message".origin = raw_message_dispatch.origin_domain
+                 AND "message".origin_mailbox = raw_message_dispatch.origin_mailbox
+                 AND "message".nonce = raw_message_dispatch.nonce
+                WHERE raw_message_dispatch.origin_domain = $1
+                  AND raw_message_dispatch.origin_mailbox = $2
+                  AND raw_message_dispatch.msg_body IS NOT NULL
+                  AND "message".id IS NULL
+                  AND raw_message_dispatch.id = ANY($3)
+                ORDER BY raw_message_dispatch.id ASC
+                "#,
+                [
+                    (origin_domain as i32).into(),
+                    address_to_bytes(origin_mailbox).into(),
+                    raw_ids.to_vec().into(),
                 ],
             ))
             .all(&self.0)
@@ -796,17 +870,53 @@ mod tests {
             .await?;
 
         let candidates = scraper_db
-            .retrieve_unenriched_raw_dispatches(1, &H256::from_low_u64_be(999), 0, 100)
+            .retrieve_unenriched_raw_dispatches(1, &H256::from_low_u64_be(999), 0, i64::MAX, 100)
             .await?;
         assert_eq!(candidates.len(), MESSAGE_COUNT - 1);
         assert!(candidates.iter().any(|candidate| candidate.msg.nonce == 0));
         assert!(candidates.iter().all(|candidate| candidate.msg.nonce != 1));
+
+        let raw_zero = scraper_db
+            .retrieve_raw_message_dispatch_by_id(&messages[0].id())
+            .await?
+            .expect("pending raw row should exist");
+        let raw_one = scraper_db
+            .retrieve_raw_message_dispatch_by_id(&messages[1].id())
+            .await?
+            .expect("enriched raw row should exist");
+        let direct_candidates = scraper_db
+            .retrieve_unenriched_raw_dispatches_by_ids(
+                1,
+                &H256::from_low_u64_be(999),
+                &[raw_zero.id, raw_one.id],
+            )
+            .await?;
+        assert_eq!(direct_candidates.len(), 1);
+        assert_eq!(direct_candidates[0].raw_id, raw_zero.id);
+
+        let frontier = scraper_db
+            .latest_reconcilable_raw_dispatch_id(1, &H256::from_low_u64_be(999))
+            .await?;
+        assert_eq!(frontier, candidates.last().expect("candidate rows").raw_id);
+
+        let through_id = candidates[1].raw_id;
+        let bounded_candidates = scraper_db
+            .retrieve_unenriched_raw_dispatches(1, &H256::from_low_u64_be(999), 0, through_id, 100)
+            .await?;
+        assert!(bounded_candidates
+            .iter()
+            .all(|candidate| candidate.raw_id <= through_id));
+        assert_eq!(
+            bounded_candidates.last().expect("bounded rows").raw_id,
+            through_id
+        );
 
         let paged_candidates = scraper_db
             .retrieve_unenriched_raw_dispatches(
                 1,
                 &H256::from_low_u64_be(999),
                 candidates[0].raw_id,
+                i64::MAX,
                 1,
             )
             .await?;

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -402,7 +402,10 @@ mod tests {
     use migration::MigratorTrait;
     use std::collections::BTreeMap;
 
-    use sea_orm::{Database, DatabaseBackend, DbErr, MockDatabase, RuntimeErr, Value};
+    use sea_orm::{
+        ConnectionTrait, Database, DatabaseBackend, DbErr, MockDatabase, RuntimeErr, Statement,
+        Value,
+    };
     use testcontainers::runners::AsyncRunner;
     use testcontainers_modules::postgres::Postgres;
     use time::macros::{date, time};
@@ -893,6 +896,51 @@ mod tests {
             .await?;
         assert_eq!(direct_candidates.len(), 1);
         assert_eq!(direct_candidates[0].raw_id, raw_zero.id);
+
+        // A completeness page can pass an old row while its body is unavailable. Once an
+        // upsert supplies the body, only a successor sweep from zero can rediscover it.
+        db.execute(Statement::from_sql_and_values(
+            DatabaseBackend::Postgres,
+            "UPDATE raw_message_dispatch SET msg_body = NULL WHERE id = $1",
+            [raw_zero.id.into()],
+        ))
+        .await?;
+        let sweep_page = scraper_db
+            .retrieve_unenriched_raw_dispatches(1, &H256::from_low_u64_be(999), 0, i64::MAX, 10)
+            .await?;
+        assert_eq!(sweep_page.len(), 10);
+        let passed_id = sweep_page.last().expect("full sweep page").raw_id;
+        assert!(passed_id > raw_zero.id);
+
+        scraper_db
+            .store_raw_message_dispatches(
+                1,
+                &H256::from_low_u64_be(999),
+                [StorableRawMessageDispatch {
+                    msg: &messages[0],
+                    meta: &metas[0],
+                }]
+                .into_iter(),
+            )
+            .await?;
+        let same_sweep = scraper_db
+            .retrieve_unenriched_raw_dispatches(
+                1,
+                &H256::from_low_u64_be(999),
+                passed_id,
+                i64::MAX,
+                100,
+            )
+            .await?;
+        assert!(same_sweep
+            .iter()
+            .all(|candidate| candidate.raw_id != raw_zero.id));
+        let successor_sweep = scraper_db
+            .retrieve_unenriched_raw_dispatches(1, &H256::from_low_u64_be(999), 0, passed_id, 100)
+            .await?;
+        assert!(successor_sweep
+            .iter()
+            .any(|candidate| candidate.raw_id == raw_zero.id));
 
         let frontier = scraper_db
             .latest_reconcilable_raw_dispatch_id(1, &H256::from_low_u64_be(999))

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -19,46 +19,34 @@ use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore, TxnWithId};
 const RAW_MESSAGE_DISPATCH_LABEL: &str = "raw_message_dispatch";
 const RAW_DISPATCH_RETRY_INITIAL_BACKOFF_SECONDS: i64 = 60;
 const RAW_DISPATCH_RETRY_MAX_BACKOFF_SECONDS: i64 = 15 * 60;
+// At roughly 100 bytes per HashMap entry, 1,000 tracked retries per chain bounds the 76-chain
+// fleet near 8 MiB while still retaining more than fifteen current production poison rows per
+// affected chain. Overflow remains correct through the periodic completeness sweep.
+const RAW_DISPATCH_RETRY_TRACKED_LIMIT: usize = 1_000;
 
 #[derive(Debug, Default)]
 pub(crate) struct RawDispatchReconciliationResult {
     pub candidate_count: usize,
     pub attempted_count: usize,
     pub skipped_backoff_count: usize,
+    pub untracked_count: usize,
     pub stored_count: u32,
     pub next_after_id: i64,
-    pub max_unenriched_age_seconds: u64,
-    pub next_retry_delay: Option<Duration>,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct RawDispatchRetryBackoff {
     rows: HashMap<i64, RawDispatchRetry>,
-    current_scan: u64,
 }
 
 #[derive(Debug)]
 struct RawDispatchRetry {
     attempts: u32,
     next_retry_at: OffsetDateTime,
-    last_seen_scan: u64,
+    time_created: sea_orm::prelude::TimeDateTime,
 }
 
 impl RawDispatchRetryBackoff {
-    fn begin_scan(&mut self, after_id: i64) {
-        if after_id == 0 {
-            self.current_scan = self.current_scan.wrapping_add(1);
-        }
-    }
-
-    fn observe_candidates(&mut self, raw_ids: impl Iterator<Item = i64>) {
-        for raw_id in raw_ids {
-            if let Some(retry) = self.rows.get_mut(&raw_id) {
-                retry.last_seen_scan = self.current_scan;
-            }
-        }
-    }
-
     fn should_attempt(&self, raw_id: i64, now: OffsetDateTime) -> bool {
         match self.rows.get(&raw_id) {
             Some(retry) => retry.next_retry_at <= now,
@@ -66,14 +54,21 @@ impl RawDispatchRetryBackoff {
         }
     }
 
-    fn record_missing(&mut self, raw_id: i64, now: OffsetDateTime) -> u32 {
-        let current_scan = self.current_scan;
+    fn record_missing(
+        &mut self,
+        raw_id: i64,
+        time_created: sea_orm::prelude::TimeDateTime,
+        now: OffsetDateTime,
+    ) -> Option<u32> {
+        if !self.rows.contains_key(&raw_id) && self.rows.len() >= RAW_DISPATCH_RETRY_TRACKED_LIMIT {
+            return None;
+        }
         let retry = self.rows.entry(raw_id).or_insert(RawDispatchRetry {
             attempts: 0,
             next_retry_at: now,
-            last_seen_scan: current_scan,
+            time_created,
         });
-        retry.last_seen_scan = current_scan;
+        retry.time_created = time_created;
         retry.attempts = retry.attempts.saturating_add(1);
 
         let multiplier = 2_i64.pow(retry.attempts.saturating_sub(1).min(4));
@@ -81,14 +76,48 @@ impl RawDispatchRetryBackoff {
             .saturating_mul(multiplier)
             .min(RAW_DISPATCH_RETRY_MAX_BACKOFF_SECONDS);
         retry.next_retry_at = offset_by_seconds(now, backoff_seconds);
-        retry.attempts
+        Some(retry.attempts)
     }
 
     fn record_success(&mut self, raw_id: i64) {
         self.rows.remove(&raw_id);
     }
 
-    fn next_retry_delay(&self, now: OffsetDateTime) -> Option<Duration> {
+    pub(crate) fn due_raw_ids(&self, now: OffsetDateTime, limit: usize) -> Vec<i64> {
+        let mut due = self
+            .rows
+            .iter()
+            .filter(|(_, retry)| retry.next_retry_at <= now)
+            .map(|(raw_id, retry)| (*raw_id, retry.next_retry_at))
+            .collect::<Vec<_>>();
+        due.sort_unstable_by_key(|(raw_id, next_retry_at)| (*next_retry_at, *raw_id));
+        due.into_iter()
+            .take(limit)
+            .map(|(raw_id, _)| raw_id)
+            .collect()
+    }
+
+    fn remove_absent(&mut self, requested_raw_ids: &[i64], returned_raw_ids: &HashSet<i64>) {
+        for raw_id in requested_raw_ids {
+            if !returned_raw_ids.contains(raw_id) {
+                self.rows.remove(raw_id);
+            }
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub(crate) fn max_unenriched_age_seconds(&self, now: OffsetDateTime) -> u64 {
+        self.rows
+            .values()
+            .map(|retry| raw_dispatch_age_seconds(retry.time_created, now))
+            .max()
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn next_retry_delay(&self, now: OffsetDateTime) -> Option<Duration> {
         self.rows
             .values()
             .map(|retry| {
@@ -105,16 +134,6 @@ impl RawDispatchRetryBackoff {
                 }
             })
             .min()
-    }
-
-    fn finish_scan(&mut self, candidate_count: usize, limit: u64) {
-        if candidate_count as u64 >= limit {
-            return;
-        }
-
-        let current_scan = self.current_scan;
-        self.rows
-            .retain(|_, retry| retry.last_seen_scan == current_scan);
     }
 }
 
@@ -140,6 +159,12 @@ impl HyperlaneLogStore<HyperlaneMessage> for HyperlaneDbStore {
 }
 
 impl HyperlaneDbStore {
+    pub(crate) async fn latest_reconcilable_raw_dispatch_id(&self) -> Result<i64> {
+        self.db
+            .latest_reconcilable_raw_dispatch_id(self.domain.id(), &self.mailbox_address)
+            .await
+    }
+
     async fn store_raw_message_dispatches(
         &self,
         messages: &[(Indexed<HyperlaneMessage>, LogMeta)],
@@ -199,6 +224,7 @@ impl HyperlaneDbStore {
     pub(crate) async fn reconcile_raw_message_dispatches(
         &self,
         after_id: i64,
+        through_id: i64,
         limit: u64,
         retry_backoff: &mut RawDispatchRetryBackoff,
     ) -> Result<RawDispatchReconciliationResult> {
@@ -208,35 +234,52 @@ impl HyperlaneDbStore {
                 self.domain.id(),
                 &self.mailbox_address,
                 after_id,
+                through_id,
                 limit,
             )
             .await?;
-        let now = OffsetDateTime::now_utc();
-        retry_backoff.begin_scan(after_id);
-        retry_backoff.observe_candidates(
-            raw_dispatches
-                .iter()
-                .map(|raw_dispatch| raw_dispatch.raw_id),
-        );
-        let max_unenriched_age_seconds = raw_dispatches
+        self.reconcile_raw_message_dispatch_candidates(raw_dispatches, retry_backoff)
+            .await
+    }
+
+    pub(crate) async fn retry_raw_message_dispatches(
+        &self,
+        raw_ids: &[i64],
+        retry_backoff: &mut RawDispatchRetryBackoff,
+    ) -> Result<RawDispatchReconciliationResult> {
+        let raw_dispatches = self
+            .db
+            .retrieve_unenriched_raw_dispatches_by_ids(
+                self.domain.id(),
+                &self.mailbox_address,
+                raw_ids,
+            )
+            .await?;
+        let returned_raw_ids = raw_dispatches
             .iter()
-            .map(|raw_dispatch| raw_dispatch_age_seconds(raw_dispatch.time_created, now))
-            .max()
-            .unwrap_or_default();
+            .map(|raw_dispatch| raw_dispatch.raw_id)
+            .collect::<HashSet<_>>();
+        let result = self
+            .reconcile_raw_message_dispatch_candidates(raw_dispatches, retry_backoff)
+            .await?;
+        retry_backoff.remove_absent(raw_ids, &returned_raw_ids);
+        Ok(result)
+    }
+
+    async fn reconcile_raw_message_dispatch_candidates(
+        &self,
+        raw_dispatches: Vec<crate::db::RawDispatchForEnrichment>,
+        retry_backoff: &mut RawDispatchRetryBackoff,
+    ) -> Result<RawDispatchReconciliationResult> {
+        let now = OffsetDateTime::now_utc();
         if raw_dispatches.is_empty() {
-            retry_backoff.finish_scan(0, limit);
-            return Ok(RawDispatchReconciliationResult {
-                next_after_id: after_id,
-                max_unenriched_age_seconds,
-                next_retry_delay: retry_backoff.next_retry_delay(now),
-                ..Default::default()
-            });
+            return Ok(RawDispatchReconciliationResult::default());
         }
         let next_after_id = raw_dispatches
             .iter()
             .map(|raw_dispatch| raw_dispatch.raw_id)
             .max()
-            .unwrap_or(after_id);
+            .ok_or_else(|| eyre::eyre!("non-empty reconciliation page has no maximum raw id"))?;
         let skipped_backoff_count = raw_dispatches
             .iter()
             .filter(|raw_dispatch| !retry_backoff.should_attempt(raw_dispatch.raw_id, now))
@@ -247,13 +290,10 @@ impl HyperlaneDbStore {
             .collect::<Vec<_>>();
 
         if raw_dispatches_to_attempt.is_empty() {
-            retry_backoff.finish_scan(raw_dispatches.len(), limit);
             return Ok(RawDispatchReconciliationResult {
                 candidate_count: raw_dispatches.len(),
                 skipped_backoff_count,
                 next_after_id,
-                max_unenriched_age_seconds,
-                next_retry_delay: retry_backoff.next_retry_delay(now),
                 ..Default::default()
             });
         }
@@ -270,6 +310,7 @@ impl HyperlaneDbStore {
         let mut missing_tx_hashes = Vec::new();
         let mut unique_missing_tx_hashes = HashSet::new();
         let mut stored_raw_ids = Vec::new();
+        let mut missing_raw_dispatches = Vec::new();
         let storable = raw_dispatches_to_attempt
             .iter()
             .filter_map(
@@ -279,16 +320,11 @@ impl HyperlaneDbStore {
                         Some(raw_dispatch.storable_message(txn_id))
                     }
                     None => {
-                        let attempts = retry_backoff
-                            .record_missing(raw_dispatch.raw_id, attempt_completed_at);
+                        missing_raw_dispatches
+                            .push((raw_dispatch.raw_id, raw_dispatch.time_created));
                         if unique_missing_tx_hashes.insert(raw_dispatch.meta.transaction_id) {
                             missing_tx_hashes.push(raw_dispatch.meta.transaction_id);
                         }
-                        warn!(
-                            raw_id = raw_dispatch.raw_id,
-                            attempts,
-                            "Raw message dispatch transaction remains unavailable; backing off reconciliation"
-                        );
                         None
                     }
                 },
@@ -306,7 +342,19 @@ impl HyperlaneDbStore {
         for raw_id in stored_raw_ids {
             retry_backoff.record_success(raw_id);
         }
-        retry_backoff.finish_scan(raw_dispatches.len(), limit);
+        let mut untracked_count: usize = 0;
+        for (raw_id, time_created) in missing_raw_dispatches {
+            match retry_backoff.record_missing(raw_id, time_created, attempt_completed_at) {
+                Some(attempts) => warn!(
+                    raw_id,
+                    attempts,
+                    "Raw message dispatch transaction remains unavailable; backing off reconciliation"
+                ),
+                None => {
+                    untracked_count = untracked_count.saturating_add(1);
+                }
+            }
+        }
 
         if !missing_tx_hashes.is_empty() {
             warn!(
@@ -323,10 +371,9 @@ impl HyperlaneDbStore {
             candidate_count: raw_dispatches.len(),
             attempted_count: raw_dispatches_to_attempt.len(),
             skipped_backoff_count,
+            untracked_count,
             stored_count: stored as u32,
             next_after_id,
-            max_unenriched_age_seconds,
-            next_retry_delay: retry_backoff.next_retry_delay(OffsetDateTime::now_utc()),
         })
     }
 }
@@ -545,9 +592,10 @@ mod tests {
         let now = OffsetDateTime::now_utc();
         let raw_id = 7;
         let mut backoff = RawDispatchRetryBackoff::default();
+        let time_created = crate::date_time::now();
 
         assert!(backoff.should_attempt(raw_id, now));
-        assert_eq!(backoff.record_missing(raw_id, now), 1);
+        assert_eq!(backoff.record_missing(raw_id, time_created, now), Some(1));
         assert!(!backoff.should_attempt(raw_id, now));
         assert!(!backoff.should_attempt(
             raw_id,
@@ -571,8 +619,9 @@ mod tests {
         );
         let raw_id = 7;
         let mut backoff = RawDispatchRetryBackoff::default();
+        let time_created = crate::date_time::now();
 
-        backoff.record_missing(raw_id, attempt_completed_at);
+        backoff.record_missing(raw_id, time_created, attempt_completed_at);
 
         assert_eq!(
             backoff.next_retry_delay(attempt_completed_at),
@@ -594,8 +643,9 @@ mod tests {
         let now = OffsetDateTime::now_utc();
         let raw_id = 7;
         let mut backoff = RawDispatchRetryBackoff::default();
+        let time_created = crate::date_time::now();
 
-        backoff.record_missing(raw_id, now);
+        backoff.record_missing(raw_id, time_created, now);
         assert!(!backoff.should_attempt(raw_id, now));
 
         backoff.record_success(raw_id);
@@ -606,9 +656,10 @@ mod tests {
     fn raw_dispatch_retry_backoff_reports_earliest_retry() {
         let now = OffsetDateTime::now_utc();
         let mut backoff = RawDispatchRetryBackoff::default();
+        let time_created = crate::date_time::now();
 
-        backoff.record_missing(7, now);
-        backoff.record_missing(8, offset_by_seconds(now, 30));
+        backoff.record_missing(7, time_created, now);
+        backoff.record_missing(8, time_created, offset_by_seconds(now, 30));
 
         assert_eq!(
             backoff.next_retry_delay(now),
@@ -619,37 +670,47 @@ mod tests {
     }
 
     #[test]
-    fn scan_preserves_retry_that_became_due_after_its_page() {
-        let start = OffsetDateTime::now_utc();
-        let raw_id = 7;
+    fn due_raw_ids_are_bounded_and_ordered_by_deadline_then_id() {
+        let now = OffsetDateTime::now_utc();
         let mut backoff = RawDispatchRetryBackoff::default();
+        let time_created = crate::date_time::now();
 
-        backoff.begin_scan(0);
-        assert_eq!(backoff.record_missing(raw_id, start), 1);
+        backoff.record_missing(8, time_created, offset_by_seconds(now, -120));
+        backoff.record_missing(7, time_created, offset_by_seconds(now, -120));
+        backoff.record_missing(9, time_created, offset_by_seconds(now, -60));
 
-        backoff.begin_scan(0);
-        let page_time = offset_by_seconds(start, 50);
-        backoff.observe_candidates([raw_id].into_iter());
-        assert!(!backoff.should_attempt(raw_id, page_time));
-
-        backoff.finish_scan(1, 100);
-        let scan_end = offset_by_seconds(start, 70);
-        assert_eq!(backoff.next_retry_delay(scan_end), Some(Duration::ZERO));
-        assert_eq!(backoff.record_missing(raw_id, scan_end), 2);
+        assert_eq!(backoff.due_raw_ids(now, 2), vec![7, 8]);
     }
 
     #[test]
-    fn scan_drops_retry_rows_no_longer_returned_by_database() {
+    fn direct_retry_drops_requested_rows_absent_from_database() {
         let now = OffsetDateTime::now_utc();
-        let raw_id = 7;
+        let mut backoff = RawDispatchRetryBackoff::default();
+        let time_created = crate::date_time::now();
+
+        backoff.record_missing(7, time_created, now);
+        backoff.record_missing(8, time_created, now);
+        backoff.remove_absent(&[7, 8], &HashSet::from([8]));
+
+        assert_eq!(backoff.len(), 1);
+        assert_eq!(backoff.due_raw_ids(offset_by_seconds(now, 60), 10), vec![8]);
+    }
+
+    #[test]
+    fn raw_dispatch_retry_backoff_bounds_tracked_rows() {
+        let now = OffsetDateTime::now_utc();
+        let time_created = crate::date_time::now();
         let mut backoff = RawDispatchRetryBackoff::default();
 
-        backoff.begin_scan(0);
-        assert_eq!(backoff.record_missing(raw_id, now), 1);
-
-        backoff.begin_scan(0);
-        backoff.finish_scan(0, 100);
-
-        assert_eq!(backoff.record_missing(raw_id, now), 1);
+        for raw_id in 0..RAW_DISPATCH_RETRY_TRACKED_LIMIT as i64 {
+            assert_eq!(backoff.record_missing(raw_id, time_created, now), Some(1));
+        }
+        assert_eq!(backoff.len(), RAW_DISPATCH_RETRY_TRACKED_LIMIT);
+        assert_eq!(
+            backoff.record_missing(RAW_DISPATCH_RETRY_TRACKED_LIMIT as i64, time_created, now),
+            None
+        );
+        assert_eq!(backoff.len(), RAW_DISPATCH_RETRY_TRACKED_LIMIT);
+        assert_eq!(backoff.record_missing(0, time_created, now), Some(2));
     }
 }


### PR DESCRIPTION
## Outcome

Stop rediscovering known poison rows through historical anti-joins. This builds on merged #9226 and changes retries to bounded primary-key reads, while retaining a slower completeness sweep for correctness.

## #9226 baseline

| Settled metric | Latest hour |
| --- | ---: |
| Slow SQL | 97/hour |
| Slow reconciliation anti-joins | 65/hour |
| Logged slow-query wall time | 900 s/hour |
| Candidates / attempted / stored | ~755 / ~251 / 0 per hour |

#9226 already reduced uptime-matched slow SQL 725 → 211/hour (-70.9%), reconciliation SQL 567 → 129/hour (-77.2%), and query wall time 4,616 → 1,777 s/hour (-61.5%). CPU was 0.763 → 0.833 cores (+9.2%), so this PR does **not** claim a measured CPU win.

## Change

| Lane | Query | Schedule |
| --- | --- | --- |
| Discovery | Anti-join only within immutable `(watermark, frontier]` | Every 5m |
| Known retry | `raw_message_dispatch.id = ANY(...)`, still excluding concurrently enriched rows | Existing 1/2/4/8/15m backoff |
| Completeness | Serialized historical sweep | Fixed 30m start cadence; overdue successor starts after the active sweep |

Also:

- advance frontiers only after a short final page; retain cursors on errors/panics
- re-read retry rows, mutate retry state only after successful storage, and prune completed/deleted rows
- cap retries at 1,000 rows/chain; count overflow and recover it through completeness sweeps
- expose fixed-cardinality operation, duration, retry-set and overflow metrics
- give a failed lane two cooldowns while globally pausing for one, so another due lane gets the next turn
- ignore overdue deadlines for a blocked scan lane, preventing a zero-sleep scheduler spin while the other lane owns the slot
- park multi-page completeness sweeps between pages so an overdue 5-minute discovery scan can run, then resume the sweep from its cursor; parked sweep deadlines stay suppressed until discovery finishes, so the scheduler cannot busy-spin

No migration/index is required. Frontier/range reads use the existing partial `(origin_domain, origin_mailbox, id) WHERE msg_body IS NOT NULL` index; retries use the raw primary key.

## Why these numbers

| Value | Rationale |
| --- | --- |
| 5m discovery | Unchanged from #9226; preserves its measured behaviour and 80% idle-scan reduction |
| 30m sweep cadence | 6× fewer historical scan starts (**-83.3%**) when sweeps finish within the interval; an overdue successor starts immediately after a long active sweep. Recovery is not hard-bounded to 30m because scans remain serialized |
| 100-row pages | Existing reconciliation bound; lets retry, discovery and sweep each take a turn |
| 1,000 retries/chain | Well above the observed ~15 poison rows/affected chain; fleet memory stays roughly single-digit MiB |
| Two lane cooldowns / one global | Avoid backend hammering without letting one failure starve other lanes |
| 10ms–120s histogram | Covers fast PK reads through the observed 60–84s anti-join tail |

## Modelled impact

| Metric | #9226 baseline | Expected | Basis |
| --- | ---: | ---: | --- |
| Slow reconciliation anti-joins | 65/hour | **~7–13/hour** | Central estimate `65 / 6 = 10.8`; range allows traffic variance |
| Total slow SQL | 97/hour | **~39–45/hour** | Above range + ~32 unrelated queries/hour |
| CPU / memory | — | **Unknown** | Measure in canary; do not infer from SQL counts |

## Correctness / verification

- Snapshot boundaries cover normal arrivals; fixed-cadence successor sweeps cover commit-order and late-body races behind the watermark. A row passed mid-sweep waits for the successor to reach it, so recovery latency includes remaining active-sweep time and successor scan time.
- Discovery and completeness queries remain serialized; a multi-page completeness sweep yields between pages to overdue discovery without losing either cursor/frontier.
- Direct-ID lifecycle, retry ordering/cap, empty-store behaviour and deterministic scheduler transitions are covered.
- 41 non-Docker tests passed before the prior scheduler fixes. Focused scheduler and real-Postgres late-body regressions were added at this head; exact-head CI owns their execution plus the broader build and clippy gates. Local scraper formatting, `git diff --check`, and commit secret scanning passed.
- The real-Postgres test covers bounded scans, mixed pending/enriched `ANY(bigint[])` retries, and a late body becoming eligible behind an active sweep cursor; it awaits CI because Docker is unavailable locally.
- Three independent self-review lanes drove fixes for starvation, overlapping scans, overflow logging, panic handling and state-transition coverage; final rechecks were clean.

Canary the scraper and compare matched slow-query count/wall time, per-lane duration, retry set/overflow, CPU, memory, RPC failures, liveness and restarts. Rollback is image-only.


Rebased on `main@3d9ad7ef87`; exact head `2515f892c5`. Current main's atomic inserted-row accounting is retained; the empty-store regression remains as coverage rather than an incremental query-saving claim.
