### PR TITLE
fix(svm): derive composite ISM recipient from warp router

### DIFF
--- a/.changeset/composite-ism-ratelimited-recipient.md
+++ b/.changeset/composite-ism-ratelimited-recipient.md
@@ -1,0 +1,20 @@
+---
+'@hyperlane-xyz/provider-sdk': minor
+'@hyperlane-xyz/deploy-sdk': minor
+'@hyperlane-xyz/sealevel-sdk': patch
+'@hyperlane-xyz/sdk': minor
+---
+
+A composite ISM's `rateLimited.recipient` was resolved from its warp router instead of being hand-written. Tooling derived the value on both deploy and apply because a wrong recipient failed at delivery time indistinguishably from a rate-limit trip. Resolution covered expanded compound artifacts such as `domainRoutingIsm.domains` and composite nodes nested under `aggregation`, `amountRouting`, and `routing`/`fallbackRouting` domain overrides. Exhaustive artifact traversal was added so future compound artifact types must declare their nested ISMs before compiling.
+
+`CompositeIsmConfigSchema` was changed to accept a `rateLimited` node without a `recipient` while continuing to reject an explicitly zero value. `WarpTokenWriter.create` was changed to reject any written-out recipient on a new composite ISM, since the router address only became available during deployment. `WarpTokenWriter.update` was changed to reject a recipient that differed from the router while accepting a matching value, preserving `warp read` → apply idempotency.
+
+AltVM warp routes were created without an ISM, then the configured ISM was resolved and attached through the regular update path, matching the existing fee flow. The high-level SDK preserved declarative AltVM ISM configs for this artifact path instead of pre-deploying them. NEW ISMs were deployed after the router address became available; DEPLOYED and UNDERIVED roots were reused without deployment.
+
+Nested artifact states within a NEW parent were preserved independently: NEW descendants were resolved and deployed, DEPLOYED descendants were validated and retained as references, and UNDERIVED descendants remained opaque. DEPLOYED roots were reused unchanged during warp creation and rejected if their declarative config contained a NEW descendant that would otherwise be silently ignored.
+
+A `rateLimited` node was rejected outright in a mailbox default ISM at two layers: `CoreConfigSchema` failed parsing, and `CoreWriter.create`/`CoreWriter.update` asserted before emitting a transaction. The SDK schema guard used one typed, exhaustive visitor across SDK ISM containers and composite-node containers, while retaining distinct predicates for EVM `rateLimitedIsm` and composite `rateLimited` nodes.
+
+`assertValidCompositeIsmArtifact` in sealevel-sdk continued requiring a non-zero recipient as the last line of defence, and its message was updated to explain automatic warp-route resolution.
+
+provider-sdk gained canonical `IsmType` discriminants plus contextual `resolveIsmArtifact`, `resolveRateLimitedIsmRecipients`, `assertRateLimitedIsmRecipientsUnset`, and `assertIsmSupportedAsMailboxDefault` from `@hyperlane-xyz/provider-sdk/ism`. Contextual address conversion used the shared protocol-detecting `addressToBytes32` utility, keeping provider-sdk free of Sealevel address assumptions.

--- a/.changeset/composite-ism-ratelimited-recipient.md
+++ b/.changeset/composite-ism-ratelimited-recipient.md
@@ -11,6 +11,8 @@ A composite ISM's `rateLimited.recipient` was resolved from its warp router inst
 
 AltVM warp routes were created without an ISM, then the configured ISM was resolved and attached through the regular update path, matching the existing fee flow. The high-level SDK preserved declarative AltVM ISM configs for this artifact path instead of pre-deploying them. NEW ISMs were deployed after the router address became available; DEPLOYED and UNDERIVED roots were reused without deployment.
 
+The generic warp writer retained signer ownership through deferred ISM and fee attachment, then transferred ownership to the configured owner as the final protocol-writer update. This kept direct Artifact API creation working when the configured owner differed from the signer.
+
 Nested artifact states within a NEW parent were preserved independently: NEW descendants were resolved and deployed, DEPLOYED descendants were validated and retained as references, and UNDERIVED descendants remained opaque. DEPLOYED roots were reused unchanged during warp creation and rejected if their declarative config contained a NEW descendant that would otherwise be silently ignored.
 
 A `rateLimited` node was rejected outright in a mailbox default ISM at two layers: `CoreConfigSchema` failed parsing, and `CoreWriter.create`/`CoreWriter.update` asserted before emitting a transaction. The SDK schema guard used one typed, exhaustive visitor across SDK ISM containers and composite-node containers, while retaining distinct predicates for EVM `rateLimitedIsm` and composite `rateLimited` nodes.

--- a/.github/workflows/test-cli-e2e.yml
+++ b/.github/workflows/test-cli-e2e.yml
@@ -567,6 +567,7 @@ jobs:
           - http-signer
           - hook-igp
           - warp-alt
+          - warp-composite-ism
           - warp-cross-collateral
           - warp-fee
           - warp-fee-apply

--- a/typescript/cli/src/tests/sealevel/warp/warp-composite-ism.e2e-test.ts
+++ b/typescript/cli/src/tests/sealevel/warp/warp-composite-ism.e2e-test.ts
@@ -1,0 +1,390 @@
+import { expect } from 'chai';
+
+import {
+  type ChainAddresses,
+  createWarpRouteConfigId,
+} from '@hyperlane-xyz/registry';
+import { SealevelSigner, createRpc } from '@hyperlane-xyz/sealevel-sdk';
+import { airdropSol } from '@hyperlane-xyz/sealevel-sdk/testing';
+import {
+  type CompositeIsmNodeConfig,
+  CompositeIsmNodeType,
+  IsmType,
+  TokenType,
+  type WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType, addressToBytes32, assert } from '@hyperlane-xyz/utils';
+
+import { readYamlOrJson, writeYamlOrJson } from '../../../utils/files.js';
+import { HyperlaneE2ECoreTestCommands } from '../../commands/core.js';
+import { syncWarpDeployConfigToRegistry } from '../../commands/warp-config-sync.js';
+import { HyperlaneE2EWarpTestCommands } from '../../commands/warp.js';
+import {
+  CORE_ADDRESSES_PATH_BY_PROTOCOL,
+  CORE_CONFIG_PATH_BY_PROTOCOL,
+  CORE_READ_CONFIG_PATH_BY_PROTOCOL,
+  HYP_KEY_BY_PROTOCOL,
+  REGISTRY_PATH,
+  TEMP_PATH,
+  TEST_CHAIN_METADATA_BY_PROTOCOL,
+  getWarpCoreConfigPath,
+} from '../../constants.js';
+
+const CHAIN_NAME = 'svmlocal1';
+const REMOTE_CHAIN_NAME = 'anvil1';
+const SVM_KEY = HYP_KEY_BY_PROTOCOL.sealevel;
+const WARP_DEPLOY_OUTPUT_PATH = `${TEMP_PATH}/svm-composite-ism-deploy.yaml`;
+
+// Each composite ISM is its own on-chain program, so this suite pays for
+// several program deploys on top of the warp routers themselves.
+const SVM_COMPOSITE_ISM_TIMEOUT = 600_000;
+
+const MAX_CAPACITY = '86400';
+
+const shortHexToBytes32 = (value: string) => `0x${value.padStart(64, '0')}`;
+
+// A syntactically valid H256 that is not any router deployed here.
+const WRONG_RECIPIENT = shortHexToBytes32('beef');
+
+// Included in the deploy config to prove ISM deferral preserves unrelated
+// router and gas configuration.
+const REMOTE_ROUTER_ADDRESS = shortHexToBytes32('cafe');
+const REMOTE_DESTINATION_GAS = '200000';
+
+function rateLimitedNode(
+  mailbox: string,
+  recipient?: string,
+): CompositeIsmNodeConfig {
+  return recipient === undefined
+    ? {
+        type: CompositeIsmNodeType.RATE_LIMITED,
+        maxCapacity: MAX_CAPACITY,
+        mailbox,
+      }
+    : {
+        type: CompositeIsmNodeType.RATE_LIMITED,
+        maxCapacity: MAX_CAPACITY,
+        mailbox,
+        recipient,
+      };
+}
+
+function expectedRecipient(routerAddress: string): string {
+  return addressToBytes32(routerAddress, ProtocolType.Sealevel).toLowerCase();
+}
+
+/** Narrows a read-back warp config down to its composite ISM root node. */
+function readCompositeIsmRoot(
+  config: WarpRouteDeployConfig,
+): CompositeIsmNodeConfig {
+  const chainConfig = config[CHAIN_NAME];
+  assert(chainConfig, `Expected a config entry for ${CHAIN_NAME}`);
+  const ism = chainConfig.interchainSecurityModule;
+  assert(
+    ism && typeof ism !== 'string',
+    'Expected an expanded ISM config, not an address reference',
+  );
+  assert(
+    ism.type === IsmType.COMPOSITE,
+    `Expected a ${IsmType.COMPOSITE}, got ${ism.type}`,
+  );
+  return ism.root;
+}
+
+describe('hyperlane warp composite ISM rateLimited recipient CLI e2e tests (Sealevel)', function () {
+  this.timeout(SVM_COMPOSITE_ISM_TIMEOUT);
+
+  let signer: Awaited<ReturnType<typeof SealevelSigner.connectWithSigner>>;
+  let mailboxAddress: string;
+  let rpc: ReturnType<typeof createRpc>;
+
+  const warpCommands = new HyperlaneE2EWarpTestCommands(
+    ProtocolType.Sealevel,
+    REGISTRY_PATH,
+    `${TEMP_PATH}/svm-composite-ism-read.yaml`,
+  );
+
+  before(async function () {
+    const rpcUrl = TEST_CHAIN_METADATA_BY_PROTOCOL.sealevel.CHAIN_NAME_1.rpcUrl;
+    rpc = createRpc(rpcUrl);
+    signer = await SealevelSigner.connectWithSigner(
+      TEST_CHAIN_METADATA_BY_PROTOCOL.sealevel.CHAIN_NAME_1,
+      SVM_KEY,
+    );
+
+    await airdropSol(rpc, signer.getSignerAddress(), 50_000_000_000n);
+
+    const hyperlaneCore = new HyperlaneE2ECoreTestCommands(
+      ProtocolType.Sealevel,
+      CHAIN_NAME,
+      REGISTRY_PATH,
+      CORE_CONFIG_PATH_BY_PROTOCOL.sealevel,
+      CORE_READ_CONFIG_PATH_BY_PROTOCOL.sealevel.CHAIN_NAME_1,
+    );
+
+    const coreConfig = readYamlOrJson(CORE_CONFIG_PATH_BY_PROTOCOL.sealevel);
+    writeYamlOrJson(
+      CORE_READ_CONFIG_PATH_BY_PROTOCOL.sealevel.CHAIN_NAME_1,
+      coreConfig,
+    );
+    hyperlaneCore.setCoreInputPath(
+      CORE_READ_CONFIG_PATH_BY_PROTOCOL.sealevel.CHAIN_NAME_1,
+    );
+    await hyperlaneCore.deploy(SVM_KEY);
+
+    const coreAddresses: ChainAddresses = readYamlOrJson(
+      CORE_ADDRESSES_PATH_BY_PROTOCOL.sealevel.CHAIN_NAME_1,
+    );
+    mailboxAddress = coreAddresses.mailbox;
+  });
+
+  describe('warp deploy', function () {
+    const SYMBOL = 'CIRL';
+    const warpRouteId = createWarpRouteConfigId(SYMBOL, CHAIN_NAME);
+    const warpCorePath = getWarpCoreConfigPath(SYMBOL, [CHAIN_NAME]);
+
+    it('deploys, resolves the recipient, and preserves the remaining config', async function () {
+      const ownerAddress = signer.getSignerAddress();
+      const deployConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME]: {
+          type: TokenType.native,
+          name: 'Composite Rate Limited Token',
+          symbol: SYMBOL,
+          decimals: 9,
+          mailbox: mailboxAddress,
+          owner: ownerAddress,
+          remoteRouters: {
+            [REMOTE_CHAIN_NAME]: { address: REMOTE_ROUTER_ADDRESS },
+          },
+          destinationGas: {
+            [REMOTE_CHAIN_NAME]: REMOTE_DESTINATION_GAS,
+          },
+          interchainSecurityModule: {
+            type: IsmType.COMPOSITE,
+            owner: ownerAddress,
+            root: {
+              type: CompositeIsmNodeType.AGGREGATION,
+              threshold: 1,
+              subIsms: [
+                { type: CompositeIsmNodeType.TEST, accept: true },
+                rateLimitedNode(mailboxAddress),
+              ],
+            },
+          },
+        },
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, deployConfig);
+
+      await warpCommands.deploy(SVM_KEY, warpRouteId, WARP_DEPLOY_OUTPUT_PATH);
+      const routerAddress = warpCommands.getDeployedWarpAddress(
+        CHAIN_NAME,
+        warpCorePath,
+      );
+      const readConfig = await warpCommands.readConfig(
+        CHAIN_NAME,
+        warpCorePath,
+      );
+      const root = readCompositeIsmRoot(readConfig);
+      assert(
+        root.type === CompositeIsmNodeType.AGGREGATION,
+        `Expected an aggregation root, got ${root.type}`,
+      );
+      const node = root.subIsms[1];
+      assert(
+        node.type === CompositeIsmNodeType.RATE_LIMITED,
+        `Expected a rateLimited sub-ISM, got ${node.type}`,
+      );
+      expect(node.recipient).to.equal(expectedRecipient(routerAddress));
+      expect(node.maxCapacity).to.equal(MAX_CAPACITY);
+      expect(node.mailbox).to.equal(mailboxAddress);
+      expect(
+        readConfig[CHAIN_NAME].remoteRouters?.[REMOTE_CHAIN_NAME],
+      ).to.deep.equal({ address: REMOTE_ROUTER_ADDRESS });
+      expect(
+        readConfig[CHAIN_NAME].destinationGas?.[REMOTE_CHAIN_NAME],
+      ).to.equal(REMOTE_DESTINATION_GAS);
+
+      const checkOutput = await warpCommands
+        .checkRaw({ warpRouteId })
+        .nothrow();
+      expect(checkOutput.exitCode).to.equal(0);
+
+      const reapplyConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME]: {
+          ...deployConfig[CHAIN_NAME],
+          ...readConfig[CHAIN_NAME],
+        },
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, reapplyConfig);
+      syncWarpDeployConfigToRegistry({
+        warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+        warpRouteId,
+        registryPath: REGISTRY_PATH,
+      });
+
+      const applyOutput = await warpCommands
+        .applyRaw({
+          warpRouteId,
+          privateKey: SVM_KEY,
+          skipConfirmationPrompts: true,
+        })
+        .nothrow();
+      expect(applyOutput.exitCode).to.equal(0);
+      expect(applyOutput.stdout).to.include(
+        'Warp config is the same as target. No updates needed.',
+      );
+
+      const afterApply = await warpCommands.readConfig(
+        CHAIN_NAME,
+        warpCorePath,
+      );
+      const afterRoot = readCompositeIsmRoot(afterApply);
+      assert(
+        afterRoot.type === CompositeIsmNodeType.AGGREGATION,
+        `Expected an aggregation root, got ${afterRoot.type}`,
+      );
+      const afterNode = afterRoot.subIsms[1];
+      assert(
+        afterNode.type === CompositeIsmNodeType.RATE_LIMITED,
+        `Expected a rateLimited sub-ISM, got ${afterNode.type}`,
+      );
+      expect(afterNode.recipient).to.equal(expectedRecipient(routerAddress));
+    });
+
+    it('rejects a hand-written recipient on deploy', async function () {
+      const REJECT_SYMBOL = 'CIRLBAD';
+      const rejectRouteId = createWarpRouteConfigId(REJECT_SYMBOL, CHAIN_NAME);
+      const ownerAddress = signer.getSignerAddress();
+      const rejectConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME]: {
+          type: TokenType.native,
+          name: 'Composite Rate Limited Reject Token',
+          symbol: REJECT_SYMBOL,
+          decimals: 9,
+          mailbox: mailboxAddress,
+          owner: ownerAddress,
+          interchainSecurityModule: {
+            type: IsmType.COMPOSITE,
+            owner: ownerAddress,
+            root: rateLimitedNode(mailboxAddress, WRONG_RECIPIENT),
+          },
+        },
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, rejectConfig);
+
+      const output = await warpCommands
+        .deployRaw({
+          privateKey: SVM_KEY,
+          skipConfirmationPrompts: true,
+          warpRouteId: rejectRouteId,
+          warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+        })
+        .nothrow();
+
+      expect(output.exitCode).to.not.equal(0);
+      expect(`${output.stdout}${output.stderr}`).to.include(
+        'rateLimited.recipient must not be set when deploying a new warp route',
+      );
+    });
+  });
+
+  describe('warp apply', function () {
+    const SYMBOL = 'CIRLAT';
+    const warpRouteId = createWarpRouteConfigId(SYMBOL, CHAIN_NAME);
+    const warpCorePath = getWarpCoreConfigPath(SYMBOL, [CHAIN_NAME]);
+
+    it('attaches, validates, and updates contextual composite ISMs', async function () {
+      const ownerAddress = signer.getSignerAddress();
+      const baseConfig: WarpRouteDeployConfig[string] = {
+        type: TokenType.native,
+        name: 'Composite Rate Limited Apply Token',
+        symbol: SYMBOL,
+        decimals: 9,
+        mailbox: mailboxAddress,
+        owner: ownerAddress,
+      };
+      writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, { [CHAIN_NAME]: baseConfig });
+
+      await warpCommands.deploy(SVM_KEY, warpRouteId, WARP_DEPLOY_OUTPUT_PATH);
+      const routerAddress = warpCommands.getDeployedWarpAddress(
+        CHAIN_NAME,
+        warpCorePath,
+      );
+      const applyIsm = (root: CompositeIsmNodeConfig) => {
+        const config: WarpRouteDeployConfig = {
+          [CHAIN_NAME]: {
+            ...baseConfig,
+            interchainSecurityModule: {
+              type: IsmType.COMPOSITE,
+              owner: signer.getSignerAddress(),
+              root,
+            },
+          },
+        };
+        writeYamlOrJson(WARP_DEPLOY_OUTPUT_PATH, config);
+        syncWarpDeployConfigToRegistry({
+          warpDeployPath: WARP_DEPLOY_OUTPUT_PATH,
+          warpRouteId,
+          registryPath: REGISTRY_PATH,
+        });
+        return warpCommands
+          .applyRaw({
+            warpRouteId,
+            privateKey: SVM_KEY,
+            skipConfirmationPrompts: true,
+          })
+          .nothrow();
+      };
+
+      const attachOutput = await applyIsm(
+        rateLimitedNode(mailboxAddress, expectedRecipient(routerAddress)),
+      );
+      expect(attachOutput.exitCode).to.equal(0);
+
+      const attachedConfig = await warpCommands.readConfig(
+        CHAIN_NAME,
+        warpCorePath,
+      );
+      const attachedRoot = readCompositeIsmRoot(attachedConfig);
+      assert(
+        attachedRoot.type === CompositeIsmNodeType.RATE_LIMITED,
+        `Expected a rateLimited root, got ${attachedRoot.type}`,
+      );
+      expect(attachedRoot.recipient).to.equal(expectedRecipient(routerAddress));
+
+      const mismatchOutput = await applyIsm(
+        rateLimitedNode(mailboxAddress, WRONG_RECIPIENT),
+      );
+
+      expect(mismatchOutput.exitCode).to.not.equal(0);
+      expect(`${mismatchOutput.stdout}${mismatchOutput.stderr}`).to.include(
+        'does not match the warp router it protects',
+      );
+
+      const routingOutput = await applyIsm({
+        type: CompositeIsmNodeType.ROUTING,
+        domains: {
+          [REMOTE_CHAIN_NAME]: rateLimitedNode(mailboxAddress),
+        },
+      });
+      expect(routingOutput.exitCode).to.equal(0);
+
+      const routingConfig = await warpCommands.readConfig(
+        CHAIN_NAME,
+        warpCorePath,
+      );
+      const routingRoot = readCompositeIsmRoot(routingConfig);
+      assert(
+        routingRoot.type === CompositeIsmNodeType.ROUTING,
+        `Expected a routing root, got ${routingRoot.type}`,
+      );
+      const domainNode = routingRoot.domains?.[REMOTE_CHAIN_NAME];
+      assert(domainNode, `Expected a domain override for ${REMOTE_CHAIN_NAME}`);
+      assert(
+        domainNode.type === CompositeIsmNodeType.RATE_LIMITED,
+        `Expected a rateLimited domain override, got ${domainNode.type}`,
+      );
+      expect(domainNode.recipient).to.equal(expectedRecipient(routerAddress));
+    });
+  });
+});

--- a/typescript/deploy-sdk/src/core/core-writer.test.ts
+++ b/typescript/deploy-sdk/src/core/core-writer.test.ts
@@ -21,9 +21,11 @@ import {
   IRawHookArtifactManager,
 } from '@hyperlane-xyz/provider-sdk/hook';
 import {
+  CompositeIsmNodeType,
   DeployedIsmArtifact,
   IRawIsmArtifactManager,
   IsmArtifactConfig,
+  IsmType,
 } from '@hyperlane-xyz/provider-sdk/ism';
 import {
   DeployedMailboxAddress,
@@ -93,7 +95,7 @@ describe('CoreWriter', () => {
   const mockIsm: DeployedIsmArtifact = {
     artifactState: ArtifactState.DEPLOYED,
     config: {
-      type: 'merkleRootMultisigIsm',
+      type: IsmType.MERKLE_ROOT_MULTISIG,
       validators: ['0xVALIDATOR1'],
       threshold: 1,
     },
@@ -918,6 +920,190 @@ describe('CoreWriter', () => {
     });
   });
 
+  describe('rateLimited default ISM rejection', () => {
+    // A rateLimited node meters an amount read from a fixed offset of the
+    // message body, which only holds for warp-route traffic — a mailbox
+    // default ISM sees every message.
+    const compositeIsmWithRateLimited: IsmArtifactConfig = {
+      type: IsmType.COMPOSITE,
+      owner: mockOwner,
+      root: {
+        type: CompositeIsmNodeType.AGGREGATION,
+        threshold: 1,
+        subIsms: [
+          { type: CompositeIsmNodeType.TEST, accept: true },
+          {
+            type: CompositeIsmNodeType.RATE_LIMITED,
+            maxCapacity: '86400',
+            mailbox: mockMailboxAddress,
+          },
+        ],
+      },
+    };
+
+    const routingIsmWithNestedRateLimited: IsmArtifactConfig = {
+      type: IsmType.ROUTING,
+      owner: mockOwner,
+      domains: {
+        [mockDomainId]: {
+          artifactState: ArtifactState.NEW,
+          config: compositeIsmWithRateLimited,
+        },
+      },
+    };
+
+    it('rejects it on create before anything is deployed', async () => {
+      // ARRANGE
+      const artifact: ArtifactNew<MailboxArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          owner: mockOwner,
+          defaultIsm: {
+            artifactState: ArtifactState.NEW,
+            config: compositeIsmWithRateLimited,
+          },
+          defaultHook: mockDefaultHook,
+          requiredHook: mockRequiredHook,
+        },
+      };
+
+      const ismCreateStub = sinon.stub();
+      Object.defineProperty(coreWriter, 'ismWriter', {
+        value: {
+          create: ismCreateStub,
+          update: sinon.stub(),
+          read: sinon.stub(),
+        },
+        writable: true,
+      });
+
+      // ACT & ASSERT
+      await expect(coreWriter.create(artifact)).to.be.rejectedWith(
+        /rateLimited/,
+      );
+      sinon.assert.notCalled(ismCreateStub);
+      sinon.assert.notCalled(createMailboxWriterStub);
+    });
+
+    it('rejects it when nested inside a routing artifact', async () => {
+      const artifact: ArtifactNew<MailboxArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          owner: mockOwner,
+          defaultIsm: {
+            artifactState: ArtifactState.NEW,
+            config: routingIsmWithNestedRateLimited,
+          },
+          defaultHook: mockDefaultHook,
+          requiredHook: mockRequiredHook,
+        },
+      };
+
+      const ismCreateStub = sinon.stub();
+      Object.defineProperty(coreWriter, 'ismWriter', {
+        value: {
+          create: ismCreateStub,
+          update: sinon.stub(),
+          read: sinon.stub(),
+        },
+        writable: true,
+      });
+
+      await expect(coreWriter.create(artifact)).to.be.rejectedWith(
+        /rateLimited/,
+      );
+      sinon.assert.notCalled(ismCreateStub);
+      sinon.assert.notCalled(createMailboxWriterStub);
+    });
+
+    it('rejects it on update before any transaction is built', async () => {
+      // ARRANGE
+      const readStub = sinon.stub(coreWriter, 'read');
+
+      const expectedArtifact: ArtifactDeployed<
+        MailboxArtifactConfig,
+        DeployedMailboxAddress
+      > = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: {
+          owner: mockOwner,
+          defaultIsm: {
+            artifactState: ArtifactState.NEW,
+            config: compositeIsmWithRateLimited,
+          },
+          defaultHook: mockDefaultHook,
+          requiredHook: mockRequiredHook,
+        },
+        deployed: { address: mockMailboxAddress, domainId: mockDomainId },
+      };
+
+      const ismCreateStub = sinon.stub();
+      const ismUpdateStub = sinon.stub();
+      Object.defineProperty(coreWriter, 'ismWriter', {
+        value: {
+          create: ismCreateStub,
+          update: ismUpdateStub,
+          read: sinon.stub(),
+        },
+        writable: true,
+      });
+
+      // ACT & ASSERT
+      await expect(coreWriter.update(expectedArtifact)).to.be.rejectedWith(
+        /rateLimited/,
+      );
+      sinon.assert.notCalled(readStub);
+      sinon.assert.notCalled(ismCreateStub);
+      sinon.assert.notCalled(ismUpdateStub);
+    });
+
+    it('accepts a composite default ISM without a rateLimited node', async () => {
+      // ARRANGE
+      const artifact: ArtifactNew<MailboxArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          owner: mockOwner,
+          defaultIsm: {
+            artifactState: ArtifactState.NEW,
+            config: {
+              type: IsmType.COMPOSITE,
+              owner: mockOwner,
+              root: { type: CompositeIsmNodeType.TEST, accept: true },
+            },
+          },
+          defaultHook: mockDefaultHook,
+          requiredHook: mockRequiredHook,
+        },
+      };
+
+      const ismCreateStub = sinon.stub().resolves([mockIsm, [mockReceipt]]);
+      Object.defineProperty(coreWriter, 'ismWriter', {
+        value: {
+          create: ismCreateStub,
+          update: sinon.stub(),
+          read: sinon.stub(),
+        },
+        writable: true,
+      });
+
+      const mockHookWriter = {
+        create: sinon.stub(),
+        update: sinon.stub().resolves([]),
+        read: sinon.stub(),
+      };
+      mockHookArtifactManager.createWriter = sinon
+        .stub()
+        .returns(mockHookWriter);
+
+      // ACT
+      const [result] = await coreWriter.create(artifact);
+
+      // ASSERT
+      expect(result.mailbox.deployed.address).to.equal(mockMailboxAddress);
+      sinon.assert.calledOnce(ismCreateStub);
+    });
+  });
+
   describe('update', () => {
     it('should handle ISM type change by deploying new ISM', async () => {
       // ARRANGE
@@ -937,7 +1123,7 @@ describe('CoreWriter', () => {
       const newIsm: DeployedIsmArtifact = {
         artifactState: ArtifactState.DEPLOYED,
         config: {
-          type: 'messageIdMultisigIsm',
+          type: IsmType.MESSAGE_ID_MULTISIG,
           validators: ['0xVALIDATOR2'],
           threshold: 1,
         },
@@ -993,7 +1179,7 @@ describe('CoreWriter', () => {
       sinon.assert.calledOnce(ismCreateStub);
       const createArg = ismCreateStub.firstCall.args[0];
       expect(createArg.artifactState).to.equal(ArtifactState.NEW);
-      expect(createArg.config.type).to.equal('messageIdMultisigIsm');
+      expect(createArg.config.type).to.equal(IsmType.MESSAGE_ID_MULTISIG);
     });
 
     it('should handle UNDERIVED ISM by using address as-is', async () => {
@@ -1133,7 +1319,7 @@ describe('CoreWriter', () => {
       const newIsm: DeployedIsmArtifact = {
         artifactState: ArtifactState.DEPLOYED,
         config: {
-          type: 'merkleRootMultisigIsm',
+          type: IsmType.MERKLE_ROOT_MULTISIG,
           validators: ['0xVALIDATOR1'],
           threshold: 1,
         },
@@ -1369,7 +1555,7 @@ describe('CoreWriter', () => {
       const newIsm: DeployedIsmArtifact = {
         artifactState: ArtifactState.DEPLOYED,
         config: {
-          type: 'messageIdMultisigIsm',
+          type: IsmType.MESSAGE_ID_MULTISIG,
           validators: ['0xVALIDATOR2'],
           threshold: 1,
         },

--- a/typescript/deploy-sdk/src/core/core-writer.ts
+++ b/typescript/deploy-sdk/src/core/core-writer.ts
@@ -25,6 +25,7 @@ import {
   DeployedIsmAddress,
   DeployedIsmArtifact,
   IsmArtifactConfig,
+  assertIsmSupportedAsMailboxDefault,
   mergeIsmArtifacts,
 } from '@hyperlane-xyz/provider-sdk/ism';
 import {
@@ -129,6 +130,11 @@ export class CoreWriter extends CoreArtifactReader {
     const { config } = artifact;
     const allReceipts: TxReceipt[] = [];
     const chainName = this.chainMetadata.name;
+
+    assertIsmSupportedAsMailboxDefault(
+      config.defaultIsm,
+      `the default ISM of ${chainName}`,
+    );
 
     this.logger.info(`Starting core deployment on ${chainName}`);
 
@@ -285,6 +291,11 @@ export class CoreWriter extends CoreArtifactReader {
     const { config: expectedConfig, deployed } = expectedArtifact;
     const { address: mailboxAddress } = deployed;
     const updateTxs: AnnotatedTx[] = [];
+
+    assertIsmSupportedAsMailboxDefault(
+      expectedConfig.defaultIsm,
+      `the default ISM of ${this.chainMetadata.name}`,
+    );
 
     // Read actual state (fully expanded)
     const currentArtifact = await this.read(mailboxAddress);

--- a/typescript/deploy-sdk/src/utils/validation.ts
+++ b/typescript/deploy-sdk/src/utils/validation.ts
@@ -19,18 +19,18 @@ import { IsmConfig, IsmType } from '@hyperlane-xyz/provider-sdk/ism';
  * every call site instead of removing it.
  */
 const SUPPORTED_ISM_TYPES: ReadonlySet<string> = new Set<IsmType>([
-  'domainRoutingIsm',
-  'merkleRootMultisigIsm',
-  'messageIdMultisigIsm',
-  'testIsm',
-  'compositeIsm',
+  IsmType.ROUTING,
+  IsmType.MERKLE_ROOT_MULTISIG,
+  IsmType.MESSAGE_ID_MULTISIG,
+  IsmType.TEST_ISM,
+  IsmType.COMPOSITE,
 ]);
 
 /** ISM types restricted to a single Alt-VM protocol (Sealevel program, no cross-VM equivalent). */
 const PROTOCOL_SPECIFIC_ISM_TYPES: Readonly<
   Partial<Record<string, ProtocolType>>
 > = {
-  compositeIsm: ProtocolType.Sealevel,
+  [IsmType.COMPOSITE]: ProtocolType.Sealevel,
 };
 
 /**
@@ -107,7 +107,7 @@ export function validateIsmConfig(
   validateIsmType(config.type, chain, context, protocol);
 
   // Recursively validate nested ISMs in routing configs
-  if (config.type === 'domainRoutingIsm') {
+  if (config.type === IsmType.ROUTING) {
     for (const [domain, domainConfig] of Object.entries(config.domains)) {
       validateIsmConfig(
         domainConfig,

--- a/typescript/deploy-sdk/src/warp/warp-writer.test.ts
+++ b/typescript/deploy-sdk/src/warp/warp-writer.test.ts
@@ -10,6 +10,7 @@ import type {
 import {
   ArtifactState,
   isArtifactDeployed,
+  isArtifactUnderived,
 } from '@hyperlane-xyz/provider-sdk/artifact';
 import type { ChainMetadataForAltVM } from '@hyperlane-xyz/provider-sdk/chain';
 import type {
@@ -17,9 +18,13 @@ import type {
   HookArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/hook';
 import type {
+  CompositeIsmArtifactConfig,
+  CompositeIsmNodeArtifactConfig,
   DeployedIsmArtifact,
   IsmArtifactConfig,
+  RoutingIsmArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/ism';
+import { CompositeIsmNodeType, IsmType } from '@hyperlane-xyz/provider-sdk/ism';
 import type {
   AnnotatedTx,
   TxReceipt,
@@ -378,7 +383,7 @@ describe('WarpTokenWriter', () => {
 
   describe('update() - ISM Updates', () => {
     const createIsmConfig = (
-      type: 'messageIdMultisigIsm',
+      type: typeof IsmType.MESSAGE_ID_MULTISIG,
       validators: string[],
     ): IsmArtifactConfig => ({
       type,
@@ -387,7 +392,7 @@ describe('WarpTokenWriter', () => {
     });
 
     it('should deploy new ISM', async () => {
-      const newIsmConfig = createIsmConfig('messageIdMultisigIsm', [
+      const newIsmConfig = createIsmConfig(IsmType.MESSAGE_ID_MULTISIG, [
         '0xVALIDATOR',
       ]);
 
@@ -434,7 +439,7 @@ describe('WarpTokenWriter', () => {
     });
 
     it('should update existing ISM in-place when type is unchanged', async () => {
-      const ismConfig = createIsmConfig('messageIdMultisigIsm', [
+      const ismConfig = createIsmConfig(IsmType.MESSAGE_ID_MULTISIG, [
         '0xVALIDATOR1',
       ]);
 
@@ -483,7 +488,7 @@ describe('WarpTokenWriter', () => {
 
     it('should replace existing ISM when type changes', async () => {
       // Setup current artifact with existing ISM
-      const currentIsmConfig = createIsmConfig('messageIdMultisigIsm', [
+      const currentIsmConfig = createIsmConfig(IsmType.MESSAGE_ID_MULTISIG, [
         '0xVALIDATOR1',
       ]);
 
@@ -504,7 +509,7 @@ describe('WarpTokenWriter', () => {
 
       // New ISM config
       const newIsmConfig: IsmArtifactConfig = {
-        type: 'merkleRootMultisigIsm',
+        type: IsmType.MERKLE_ROOT_MULTISIG,
         validators: ['0xVALIDATOR2'],
         threshold: 1,
       };
@@ -586,6 +591,551 @@ describe('WarpTokenWriter', () => {
       // Neither case should trigger ISM creation
       expect(mockIsmWriter.create.callCount).to.equal(createCountAfterNoIsm);
       expect(mockIsmWriter.create.callCount).to.equal(0);
+    });
+  });
+
+  describe('rateLimited recipient resolution', () => {
+    const COMPOSITE_OWNER = OWNER_ADDRESS;
+    const OTHER_RECIPIENT = `0x${'9999'.padStart(64, '0')}`;
+
+    const rateLimited = (recipient?: string): CompositeIsmNodeArtifactConfig =>
+      recipient === undefined
+        ? {
+            type: CompositeIsmNodeType.RATE_LIMITED,
+            maxCapacity: '86400',
+            mailbox: MAILBOX_ADDRESS,
+          }
+        : {
+            type: CompositeIsmNodeType.RATE_LIMITED,
+            maxCapacity: '86400',
+            mailbox: MAILBOX_ADDRESS,
+            recipient,
+          };
+
+    // Nested one level down so the tests exercise the recursive walk rather
+    // than a root-only special case.
+    const compositeWith = (
+      node: CompositeIsmNodeArtifactConfig,
+    ): CompositeIsmArtifactConfig => ({
+      type: IsmType.COMPOSITE,
+      owner: COMPOSITE_OWNER,
+      root: {
+        type: CompositeIsmNodeType.AGGREGATION,
+        threshold: 1,
+        subIsms: [{ type: CompositeIsmNodeType.TEST, accept: true }, node],
+      },
+    });
+
+    const extractRateLimited = (
+      config: IsmArtifactConfig,
+    ): CompositeIsmNodeArtifactConfig => {
+      assert(config.type === IsmType.COMPOSITE, 'expected compositeIsm');
+      assert(
+        config.root.type === CompositeIsmNodeType.AGGREGATION,
+        'expected aggregation root',
+      );
+      return config.root.subIsms[1];
+    };
+
+    const deployedCompositeIsm = (
+      config: CompositeIsmArtifactConfig,
+    ): DeployedIsmArtifact => ({
+      artifactState: ArtifactState.DEPLOYED,
+      config,
+      deployed: { address: ISM_ADDRESS },
+    });
+
+    const routingWith = (
+      nestedConfig: IsmArtifactConfig,
+    ): RoutingIsmArtifactConfig => ({
+      type: IsmType.ROUTING,
+      owner: COMPOSITE_OWNER,
+      domains: {
+        [REMOTE_DOMAIN_ID_1]: {
+          artifactState: ArtifactState.NEW,
+          config: nestedConfig,
+        },
+      },
+    });
+
+    const extractRoutingDomain = (
+      config: IsmArtifactConfig,
+    ): IsmArtifactConfig => {
+      assert(config.type === IsmType.ROUTING, 'expected domainRoutingIsm');
+      const domainIsm = config.domains[REMOTE_DOMAIN_ID_1];
+      assert(domainIsm, `expected domain ${REMOTE_DOMAIN_ID_1}`);
+      assert(!isArtifactUnderived(domainIsm), 'expected expanded domain ISM');
+      return domainIsm.config;
+    };
+
+    // Stub-typed view of MockRawWarpWriter so the ordering assertions below
+    // can reach Sinon's call bookkeeping.
+    interface StubbedRawWarpWriter {
+      read: Sinon.SinonStub;
+      create: Sinon.SinonStub;
+      update: Sinon.SinonStub;
+    }
+
+    let warpWriterStub: StubbedRawWarpWriter;
+    let sendStub: Sinon.SinonStub;
+
+    beforeEach(() => {
+      sendStub = Sinon.stub().resolves({});
+      Object.assign(mockSigner, { sendAndConfirmTransaction: sendStub });
+
+      warpWriterStub = {
+        read: Sinon.stub(),
+        create: Sinon.stub().resolves([
+          {
+            artifactState: ArtifactState.DEPLOYED,
+            config: actualConfig,
+            deployed: { address: TOKEN_ADDRESS },
+          },
+          [],
+        ]),
+        update: Sinon.stub().resolves([]),
+      } satisfies MockRawWarpWriter;
+      mockArtifactManager.createWriter.returns(warpWriterStub);
+      mockIsmWriter.update.resolves([]);
+    });
+
+    describe('create()', () => {
+      it('deploys the ISM after the router and points every recipient at it', async () => {
+        const ismConfig = compositeWith(rateLimited());
+        mockIsmWriter.create.resolves([deployedCompositeIsm(ismConfig), []]);
+
+        await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: ismConfig,
+            },
+          },
+        });
+
+        expect(mockIsmWriter.create.callCount).to.equal(1);
+        expect(warpWriterStub.create.calledBefore(mockIsmWriter.create)).to.be
+          .true;
+        expect(
+          extractRateLimited(mockIsmWriter.create.firstCall.args[0].config),
+        ).to.deep.equal(rateLimited(TOKEN_ADDRESS));
+      });
+
+      it('defers and resolves a composite nested inside a domainRoutingIsm artifact', async () => {
+        const routingConfig = routingWith(compositeWith(rateLimited()));
+        mockIsmWriter.create.resolves([
+          {
+            artifactState: ArtifactState.DEPLOYED,
+            config: routingConfig,
+            deployed: { address: ISM_ADDRESS },
+          },
+          [],
+        ]);
+
+        await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: routingConfig,
+            },
+          },
+        });
+
+        expect(warpWriterStub.create.calledBefore(mockIsmWriter.create)).to.be
+          .true;
+        const rawConfig = warpWriterStub.create.firstCall.args[0].config;
+        expect(rawConfig.interchainSecurityModule).to.be.undefined;
+        expect(rawConfig.remoteRouters).to.deep.equal(
+          actualConfig.remoteRouters,
+        );
+
+        const resolvedRouting = mockIsmWriter.create.firstCall.args[0].config;
+        const nestedComposite = extractRoutingDomain(resolvedRouting);
+        expect(extractRateLimited(nestedComposite)).to.deep.equal(
+          rateLimited(TOKEN_ADDRESS),
+        );
+      });
+
+      it('preserves a DEPLOYED descendant of a NEW routing ISM', async () => {
+        const deployedDomainIsm = deployedCompositeIsm(
+          compositeWith(rateLimited(TOKEN_ADDRESS)),
+        );
+        const routingConfig: RoutingIsmArtifactConfig = {
+          type: IsmType.ROUTING,
+          owner: COMPOSITE_OWNER,
+          domains: { [REMOTE_DOMAIN_ID_1]: deployedDomainIsm },
+        };
+        mockIsmWriter.create.resolves([
+          {
+            artifactState: ArtifactState.DEPLOYED,
+            config: routingConfig,
+            deployed: { address: ISM_ADDRESS },
+          },
+          [],
+        ]);
+
+        await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: routingConfig,
+            },
+          },
+        });
+
+        const resolved = mockIsmWriter.create.firstCall.args[0].config;
+        assert(resolved.type === IsmType.ROUTING, 'expected routing ISM');
+        expect(resolved.domains[REMOTE_DOMAIN_ID_1]).to.equal(
+          deployedDomainIsm,
+        );
+      });
+
+      it('preserves an UNDERIVED descendant of a NEW routing ISM', async () => {
+        const underivedDomainIsm = {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: ISM_ADDRESS },
+        } satisfies RoutingIsmArtifactConfig['domains'][number];
+        const routingConfig: RoutingIsmArtifactConfig = {
+          type: IsmType.ROUTING,
+          owner: COMPOSITE_OWNER,
+          domains: { [REMOTE_DOMAIN_ID_1]: underivedDomainIsm },
+        };
+        mockIsmWriter.create.resolves([
+          {
+            artifactState: ArtifactState.DEPLOYED,
+            config: routingConfig,
+            deployed: { address: ISM_ADDRESS },
+          },
+          [],
+        ]);
+
+        await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: routingConfig,
+            },
+          },
+        });
+
+        const resolved = mockIsmWriter.create.firstCall.args[0].config;
+        assert(resolved.type === IsmType.ROUTING, 'expected routing ISM');
+        expect(resolved.domains[REMOTE_DOMAIN_ID_1]).to.equal(
+          underivedDomainIsm,
+        );
+      });
+
+      it('validates a rateLimited descendant in a DEPLOYED routing ISM', async () => {
+        const deployedDomainIsm = deployedCompositeIsm(
+          compositeWith(rateLimited(TOKEN_ADDRESS)),
+        );
+        const routingIsm: DeployedIsmArtifact = {
+          artifactState: ArtifactState.DEPLOYED,
+          config: {
+            type: IsmType.ROUTING,
+            owner: COMPOSITE_OWNER,
+            domains: { [REMOTE_DOMAIN_ID_1]: deployedDomainIsm },
+          },
+          deployed: { address: ISM_ADDRESS },
+        };
+
+        const [deployed] = await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: routingIsm,
+          },
+        });
+
+        expect(mockIsmWriter.create.callCount).to.equal(0);
+        expect(mockIsmWriter.update.callCount).to.equal(0);
+        expect(deployed.config.interchainSecurityModule).to.equal(routingIsm);
+      });
+
+      it('rejects a mismatched rateLimited descendant in a DEPLOYED routing ISM', async () => {
+        const routingIsm: DeployedIsmArtifact = {
+          artifactState: ArtifactState.DEPLOYED,
+          config: {
+            type: IsmType.ROUTING,
+            owner: COMPOSITE_OWNER,
+            domains: {
+              [REMOTE_DOMAIN_ID_1]: deployedCompositeIsm(
+                compositeWith(rateLimited(OTHER_RECIPIENT)),
+              ),
+            },
+          },
+          deployed: { address: ISM_ADDRESS },
+        };
+
+        await expect(
+          writer.create({
+            artifactState: ArtifactState.NEW,
+            config: {
+              ...actualConfig,
+              interchainSecurityModule: routingIsm,
+            },
+          }),
+        ).to.be.rejectedWith(/does not match/);
+
+        expect(warpWriterStub.create.callCount).to.equal(1);
+        expect(mockIsmWriter.create.callCount).to.equal(0);
+      });
+
+      it('withholds the NEW ISM but preserves the router config', async () => {
+        const ismConfig = compositeWith(rateLimited());
+        mockIsmWriter.create.resolves([deployedCompositeIsm(ismConfig), []]);
+
+        const [deployed] = await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: ismConfig,
+            },
+          },
+        });
+
+        const rawConfig = warpWriterStub.create.firstCall.args[0].config;
+        expect(rawConfig.interchainSecurityModule).to.be.undefined;
+        expect(rawConfig.remoteRouters).to.deep.equal(
+          actualConfig.remoteRouters,
+        );
+        expect(rawConfig.destinationGas).to.deep.equal(
+          actualConfig.destinationGas,
+        );
+        expect(deployed.config.remoteRouters).to.deep.equal(
+          actualConfig.remoteRouters,
+        );
+        expect(deployed.config.destinationGas).to.deep.equal(
+          actualConfig.destinationGas,
+        );
+        expect(deployed.config.interchainSecurityModule).to.deep.equal(
+          deployedCompositeIsm(ismConfig),
+        );
+      });
+
+      it('rejects a hand-written recipient before deploying anything', async () => {
+        const ismConfig = compositeWith(rateLimited(TOKEN_ADDRESS));
+
+        await expect(
+          writer.create({
+            artifactState: ArtifactState.NEW,
+            config: {
+              ...actualConfig,
+              interchainSecurityModule: {
+                artifactState: ArtifactState.NEW,
+                config: ismConfig,
+              },
+            },
+          }),
+        ).to.be.rejectedWith(/recipient/);
+
+        expect(mockIsmWriter.create.callCount).to.equal(0);
+        expect(warpWriterStub.create.callCount).to.equal(0);
+      });
+
+      it('post-deploys a composite ISM without a rateLimited node', async () => {
+        const ismConfig: CompositeIsmArtifactConfig = {
+          type: IsmType.COMPOSITE,
+          owner: COMPOSITE_OWNER,
+          root: { type: CompositeIsmNodeType.TEST, accept: true },
+        };
+        mockIsmWriter.create.resolves([deployedCompositeIsm(ismConfig), []]);
+
+        await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: ismConfig,
+            },
+          },
+        });
+
+        expect(warpWriterStub.create.calledBefore(mockIsmWriter.create)).to.be
+          .true;
+        const rawConfig = warpWriterStub.create.firstCall.args[0].config;
+        expect(rawConfig.interchainSecurityModule).to.be.undefined;
+        expect(rawConfig.remoteRouters).to.deep.equal(
+          actualConfig.remoteRouters,
+        );
+      });
+
+      it('post-deploys a non-composite ISM', async () => {
+        const ismConfig: IsmArtifactConfig = { type: IsmType.TEST_ISM };
+        mockIsmWriter.create.resolves([
+          {
+            artifactState: ArtifactState.DEPLOYED,
+            config: ismConfig,
+            deployed: { address: ISM_ADDRESS },
+          },
+          [],
+        ]);
+
+        await writer.create({
+          artifactState: ArtifactState.NEW,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: ismConfig,
+            },
+          },
+        });
+
+        expect(warpWriterStub.create.calledBefore(mockIsmWriter.create)).to.be
+          .true;
+        const rawConfig = warpWriterStub.create.firstCall.args[0].config;
+        expect(rawConfig.interchainSecurityModule).to.be.undefined;
+        expect(rawConfig.destinationGas).to.deep.equal(
+          actualConfig.destinationGas,
+        );
+      });
+    });
+
+    describe('update()', () => {
+      it('fills an unset recipient with the existing router address', async () => {
+        const ismConfig = compositeWith(rateLimited());
+        mockIsmWriter.create.resolves([deployedCompositeIsm(ismConfig), []]);
+
+        await writer.update({
+          ...baseDeployedArtifact,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: ismConfig,
+            },
+          },
+        });
+
+        expect(mockIsmWriter.create.callCount).to.equal(1);
+        expect(
+          extractRateLimited(mockIsmWriter.create.firstCall.args[0].config),
+        ).to.deep.equal(rateLimited(TOKEN_ADDRESS));
+      });
+
+      it('resolves a composite nested inside a domainRoutingIsm artifact', async () => {
+        const routingConfig = routingWith(compositeWith(rateLimited()));
+        mockIsmWriter.create.resolves([
+          {
+            artifactState: ArtifactState.DEPLOYED,
+            config: routingConfig,
+            deployed: { address: ISM_ADDRESS },
+          },
+          [],
+        ]);
+
+        await writer.update({
+          ...baseDeployedArtifact,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: routingConfig,
+            },
+          },
+        });
+
+        const resolvedRouting = mockIsmWriter.create.firstCall.args[0].config;
+        const nestedComposite = extractRoutingDomain(resolvedRouting);
+        expect(extractRateLimited(nestedComposite)).to.deep.equal(
+          rateLimited(TOKEN_ADDRESS),
+        );
+      });
+
+      it('accepts attaching a new composite ISM whose recipient names the existing router', async () => {
+        const ismConfig = compositeWith(rateLimited(TOKEN_ADDRESS));
+        mockIsmWriter.create.resolves([deployedCompositeIsm(ismConfig), []]);
+
+        await writer.update({
+          ...baseDeployedArtifact,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.NEW,
+              config: ismConfig,
+            },
+          },
+        });
+
+        expect(mockIsmWriter.create.callCount).to.equal(1);
+        expect(
+          extractRateLimited(mockIsmWriter.create.firstCall.args[0].config),
+        ).to.deep.equal(rateLimited(TOKEN_ADDRESS));
+      });
+
+      it('accepts an already-deployed composite ISM whose recipient names the router', async () => {
+        const ismConfig = compositeWith(rateLimited(TOKEN_ADDRESS));
+        readStub.resolves({
+          ...baseDeployedArtifact,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: deployedCompositeIsm(ismConfig),
+          },
+        });
+
+        await writer.update({
+          ...baseDeployedArtifact,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: deployedCompositeIsm(ismConfig),
+          },
+        });
+
+        expect(mockIsmWriter.create.callCount).to.equal(0);
+        expect(mockIsmWriter.update.callCount).to.equal(1);
+        expect(
+          extractRateLimited(mockIsmWriter.update.firstCall.args[0].config),
+        ).to.deep.equal(rateLimited(TOKEN_ADDRESS));
+      });
+
+      it('rejects a recipient naming a different address', async () => {
+        const ismConfig = compositeWith(rateLimited(OTHER_RECIPIENT));
+
+        await expect(
+          writer.update({
+            ...baseDeployedArtifact,
+            config: {
+              ...actualConfig,
+              interchainSecurityModule: {
+                artifactState: ArtifactState.NEW,
+                config: ismConfig,
+              },
+            },
+          }),
+        ).to.be.rejectedWith(TOKEN_ADDRESS);
+
+        expect(mockIsmWriter.create.callCount).to.equal(0);
+        expect(mockIsmWriter.update.callCount).to.equal(0);
+      });
+
+      it('leaves an ISM referenced only by address alone', async () => {
+        const updateTxs = await writer.update({
+          ...baseDeployedArtifact,
+          config: {
+            ...actualConfig,
+            interchainSecurityModule: {
+              artifactState: ArtifactState.UNDERIVED,
+              deployed: { address: ISM_ADDRESS },
+            },
+          },
+        });
+
+        expect(mockIsmWriter.create.callCount).to.equal(0);
+        expect(mockIsmWriter.update.callCount).to.equal(0);
+        expect(updateTxs).to.deep.equal([]);
+      });
     });
   });
 
@@ -778,7 +1328,7 @@ describe('WarpTokenWriter', () => {
   describe('update() - Complex Scenarios', () => {
     it('should handle ISM + router updates in single call', async () => {
       const newIsmConfig: IsmArtifactConfig = {
-        type: 'messageIdMultisigIsm',
+        type: IsmType.MESSAGE_ID_MULTISIG,
         validators: ['0xVALIDATOR'],
         threshold: 1,
       };
@@ -841,7 +1391,7 @@ describe('WarpTokenWriter', () => {
     it('should handle ownership + ISM + router updates', async () => {
       const newOwner = '0x9999999999999999999999999999999999999999';
       const newIsmConfig: IsmArtifactConfig = {
-        type: 'messageIdMultisigIsm',
+        type: IsmType.MESSAGE_ID_MULTISIG,
         validators: ['0xVALIDATOR'],
         threshold: 1,
       };
@@ -934,7 +1484,7 @@ describe('WarpTokenWriter', () => {
 
     it('should create warp token with new ISM', async () => {
       const newIsmConfig: IsmArtifactConfig = {
-        type: 'messageIdMultisigIsm',
+        type: IsmType.MESSAGE_ID_MULTISIG,
         validators: ['0xVALIDATOR'],
         threshold: 1,
       };
@@ -955,19 +1505,20 @@ describe('WarpTokenWriter', () => {
       };
 
       mockIsmWriter.create.resolves([deployedIsm, []]);
+      mockIsmWriter.update.resolves([]);
 
-      const mockWriter: MockRawWarpWriter = {
+      const mockWriter = {
         read: Sinon.stub(),
         create: Sinon.stub().resolves([
           {
             artifactState: ArtifactState.DEPLOYED,
-            config: configWithIsm,
+            config: actualConfig,
             deployed: { address: TOKEN_ADDRESS },
           },
           [],
         ]),
-        update: Sinon.stub(),
-      };
+        update: Sinon.stub().resolves([]),
+      } satisfies MockRawWarpWriter;
 
       mockArtifactManager.createWriter.returns(mockWriter);
 
@@ -979,6 +1530,10 @@ describe('WarpTokenWriter', () => {
       const [deployed, receipts] = await writer.create(artifact);
 
       expect(mockIsmWriter.create.callCount).to.equal(1);
+      expect(mockWriter.create.calledBefore(mockIsmWriter.create)).to.be.true;
+      expect(
+        mockWriter.create.firstCall.args[0].config.interchainSecurityModule,
+      ).to.be.undefined;
       expect(deployed.artifactState).to.equal(ArtifactState.DEPLOYED);
       expect(deployed.deployed.address).to.equal(TOKEN_ADDRESS);
       expect(receipts).to.be.an('array');
@@ -986,7 +1541,7 @@ describe('WarpTokenWriter', () => {
 
     it('should create warp token with existing ISM', async () => {
       const existingIsmConfig: IsmArtifactConfig = {
-        type: 'messageIdMultisigIsm',
+        type: IsmType.MESSAGE_ID_MULTISIG,
         validators: ['0xVALIDATOR'],
         threshold: 1,
       };
@@ -1000,18 +1555,19 @@ describe('WarpTokenWriter', () => {
         },
       };
 
-      const mockWriter: MockRawWarpWriter = {
+      mockIsmWriter.update.resolves([]);
+      const mockWriter = {
         read: Sinon.stub(),
         create: Sinon.stub().resolves([
           {
             artifactState: ArtifactState.DEPLOYED,
-            config: configWithExistingIsm,
+            config: actualConfig,
             deployed: { address: TOKEN_ADDRESS },
           },
           [],
         ]),
-        update: Sinon.stub(),
-      };
+        update: Sinon.stub().resolves([]),
+      } satisfies MockRawWarpWriter;
 
       mockArtifactManager.createWriter.returns(mockWriter);
 
@@ -1024,6 +1580,17 @@ describe('WarpTokenWriter', () => {
 
       // Should not create new ISM
       expect(mockIsmWriter.create.called).to.be.false;
+      expect(mockIsmWriter.update.called).to.be.false;
+      expect(
+        mockWriter.create.firstCall.args[0].config.interchainSecurityModule,
+      ).to.be.undefined;
+      expect(mockWriter.update.callCount).to.equal(1);
+      expect(
+        mockWriter.update.firstCall.args[0].config.interchainSecurityModule,
+      ).to.deep.equal({
+        artifactState: ArtifactState.UNDERIVED,
+        deployed: { address: ISM_ADDRESS },
+      });
       expect(deployed.artifactState).to.equal(ArtifactState.DEPLOYED);
       expect(deployed.deployed.address).to.equal(TOKEN_ADDRESS);
       expect(receipts).to.be.an('array');
@@ -1223,9 +1790,7 @@ describe('WarpTokenWriter', () => {
     });
 
     beforeEach(() => {
-      // Singleton stubs so both createFeeWriter calls in create() — the
-      // explicit fee deploy and the one inside this.update() that attaches
-      // the fee to the warp — reference the same mocks.
+      // Singleton stubs for the fee deployment performed by create().
       mockFeeCreateStub = Sinon.stub().resolves([deployedFee, []]);
       mockFeeUpdateStubForCreate = Sinon.stub().resolves([]);
       currentFeeCreateManager = {
@@ -1270,11 +1835,12 @@ describe('WarpTokenWriter', () => {
         },
         [],
       ]);
+      const updateStub = Sinon.stub().resolves([]);
 
       mockArtifactManager.createWriter.returns({
         read: Sinon.stub(),
         create: createStub,
-        update: Sinon.stub().resolves([]),
+        update: updateStub,
       });
 
       const artifact: ArtifactNew<WarpArtifactConfig> = {
@@ -1294,13 +1860,14 @@ describe('WarpTokenWriter', () => {
       const feeArtifactArg = mockFeeCreateStub.firstCall.args[0];
       expect(feeArtifactArg.config.token).to.equal('uhyp');
 
-      // Attach goes through this.update(), which sees current.fee=undefined
-      // and expected.fee=DEPLOYED → emits the SetFee tx via the warp diff
-      // path and runs feeWriter.update for the fee-program diff (no-op
-      // here since the fee was just deployed).
-      expect(mockFeeUpdateStubForCreate.calledOnce).to.be.true;
-      const updateArtifactArg = mockFeeUpdateStubForCreate.firstCall.args[0];
-      expect(updateArtifactArg.deployed.address).to.equal(FEE_ADDRESS);
+      // Attach references the deployed fee by address. It must not mutate the
+      // freshly deployed fee program through feeWriter.update().
+      expect(mockFeeUpdateStubForCreate.called).to.be.false;
+      expect(updateStub.calledOnce).to.be.true;
+      expect(updateStub.firstCall.args[0].config.fee).to.deep.equal({
+        artifactState: ArtifactState.UNDERIVED,
+        deployed: { address: FEE_ADDRESS },
+      });
 
       // Returned artifact should include the deployed fee.
       expect(deployed.config.fee).to.not.be.undefined;

--- a/typescript/deploy-sdk/src/warp/warp-writer.test.ts
+++ b/typescript/deploy-sdk/src/warp/warp-writer.test.ts
@@ -1453,6 +1453,121 @@ describe('WarpTokenWriter', () => {
   });
 
   describe('create()', () => {
+    it('transfers ownership after create when no artifacts are deferred', async () => {
+      const signerAddress = '0x1111111111111111111111111111111111111111';
+      const finalOwner = '0x2222222222222222222222222222222222222222';
+      const transferOwnerTx = {
+        annotation: 'Transfer ownership',
+        to: TOKEN_ADDRESS,
+        data: '0x02',
+      };
+      const sendAndConfirmTransaction = Sinon.stub().resolves({});
+      Object.assign(mockSigner, {
+        getSignerAddress: () => signerAddress,
+        sendAndConfirmTransaction,
+      });
+
+      const rawConfig: CollateralWarpArtifactConfig = {
+        ...actualConfig,
+        owner: signerAddress,
+      };
+      const currentArtifact: DeployedWarpArtifact = {
+        ...baseDeployedArtifact,
+        config: rawConfig,
+      };
+      readStub.resolves(currentArtifact);
+
+      const mockWriter = {
+        read: Sinon.stub(),
+        create: Sinon.stub().resolves([currentArtifact, []]),
+        update: Sinon.stub().resolves([transferOwnerTx]),
+      } satisfies MockRawWarpWriter;
+      mockArtifactManager.createWriter.returns(mockWriter);
+
+      const [deployed] = await writer.create({
+        artifactState: ArtifactState.NEW,
+        config: { ...actualConfig, owner: finalOwner },
+      });
+
+      expect(mockWriter.create.firstCall.args[0].config.owner).to.equal(
+        signerAddress,
+      );
+      expect(mockWriter.update.firstCall.args[0].config.owner).to.equal(
+        finalOwner,
+      );
+      expect(sendAndConfirmTransaction.firstCall.args[0]).to.equal(
+        transferOwnerTx,
+      );
+      expect(deployed.config.owner).to.equal(finalOwner);
+    });
+
+    it('keeps signer ownership through ISM attachment and transfers it last', async () => {
+      const signerAddress = '0x1111111111111111111111111111111111111111';
+      const finalOwner = '0x2222222222222222222222222222222222222222';
+      const setIsmTx = {
+        annotation: 'Set ISM',
+        to: TOKEN_ADDRESS,
+        data: '0x01',
+      };
+      const transferOwnerTx = {
+        annotation: 'Transfer ownership',
+        to: TOKEN_ADDRESS,
+        data: '0x02',
+      };
+      const sendAndConfirmTransaction = Sinon.stub().resolves({});
+      Object.assign(mockSigner, {
+        getSignerAddress: () => signerAddress,
+        sendAndConfirmTransaction,
+      });
+
+      const rawConfig: CollateralWarpArtifactConfig = {
+        ...actualConfig,
+        owner: signerAddress,
+      };
+      const currentArtifact: DeployedWarpArtifact = {
+        ...baseDeployedArtifact,
+        config: rawConfig,
+      };
+      readStub.resolves(currentArtifact);
+
+      const mockWriter = {
+        read: Sinon.stub(),
+        create: Sinon.stub().resolves([currentArtifact, []]),
+        update: Sinon.stub().resolves([setIsmTx, transferOwnerTx]),
+      } satisfies MockRawWarpWriter;
+      mockArtifactManager.createWriter.returns(mockWriter);
+
+      const [deployed] = await writer.create({
+        artifactState: ArtifactState.NEW,
+        config: {
+          ...actualConfig,
+          owner: finalOwner,
+          interchainSecurityModule: {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: ISM_ADDRESS },
+          },
+        },
+      });
+
+      expect(mockWriter.create.firstCall.args[0].config.owner).to.equal(
+        signerAddress,
+      );
+      expect(mockWriter.update.firstCall.args[0].config.owner).to.equal(
+        finalOwner,
+      );
+      expect(
+        mockWriter.update.firstCall.args[0].config.interchainSecurityModule,
+      ).to.deep.equal({
+        artifactState: ArtifactState.UNDERIVED,
+        deployed: { address: ISM_ADDRESS },
+      });
+      expect(sendAndConfirmTransaction.firstCall.args[0]).to.equal(setIsmTx);
+      expect(sendAndConfirmTransaction.secondCall.args[0]).to.equal(
+        transferOwnerTx,
+      );
+      expect(deployed.config.owner).to.equal(finalOwner);
+    });
+
     it('should create warp token without ISM', async () => {
       const mockWriter = {
         read: Sinon.stub(),

--- a/typescript/deploy-sdk/src/warp/warp-writer.ts
+++ b/typescript/deploy-sdk/src/warp/warp-writer.ts
@@ -26,9 +26,13 @@ import {
   mergeHookArtifacts,
 } from '@hyperlane-xyz/provider-sdk/hook';
 import {
+  type ContextualAddress,
   DeployedIsmAddress,
   IsmArtifactConfig,
+  IsmArtifactResolutionOperation,
+  assertRateLimitedIsmRecipientsUnset,
   mergeIsmArtifacts,
+  resolveIsmArtifact,
 } from '@hyperlane-xyz/provider-sdk/ism';
 import { AnnotatedTx, TxReceipt } from '@hyperlane-xyz/provider-sdk/module';
 import {
@@ -40,13 +44,25 @@ import {
   buildFeeReadContextFromWarpArtifactConfig,
   resolveFeeTokenFromWarpArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/warp';
-import { assert, isNullish, rootLogger } from '@hyperlane-xyz/utils';
+import {
+  addressToBytes32,
+  assert,
+  isNullish,
+  rootLogger,
+} from '@hyperlane-xyz/utils';
 
 import { createFeeWriter } from '../fee/fee-writer.js';
 import { HookWriter, createHookWriter } from '../hook/hook-writer.js';
 import { IsmWriter, createIsmWriter } from '../ism/generic-ism-writer.js';
 
 import { WarpTokenReader } from './warp-reader.js';
+
+function warpRouterContext(address: string): ContextualAddress {
+  return {
+    address,
+    toBytes32: () => addressToBytes32(address).toLowerCase(),
+  };
+}
 
 /**
  * Factory function to create a WarpTokenWriter instance.
@@ -86,7 +102,7 @@ export function createWarpTokenWriter(
  * Key features:
  * - Extends WarpTokenReader to inherit read() functionality
  * - Works with pure Artifact API (WarpArtifactConfig)
- * - Handles nested ISM deployment before warp token deployment
+ * - Handles nested ISM deployment after warp token deployment
  * - Delegates to typed writers from artifact manager for specific warp token types
  * - Protocol-agnostic through artifact manager abstraction
  */
@@ -111,7 +127,8 @@ export class WarpTokenWriter
 
   /**
    * Creates a new warp token by deploying it on-chain.
-   * If the warp token has a nested ISM artifact, deploys the ISM first.
+   * If the warp token has a new nested ISM artifact, deploys it after the
+   * router so its config can use the router address.
    *
    * @param artifact The warp token configuration to deploy
    * @returns A tuple of [deployed artifact, transaction receipts]
@@ -128,21 +145,12 @@ export class WarpTokenWriter
       );
     }
 
-    // Deploy ISM if configured as a NEW artifact
-    let onChainIsmArtifact:
-      | ArtifactOnChain<IsmArtifactConfig, DeployedIsmAddress>
-      | undefined;
-    if (config.interchainSecurityModule) {
-      if (isArtifactNew(config.interchainSecurityModule)) {
-        const [deployedIsm, ismReceipts] = await this.ismWriter.create(
-          config.interchainSecurityModule,
-        );
-        allReceipts.push(...ismReceipts);
-
-        onChainIsmArtifact = deployedIsm;
-      } else {
-        onChainIsmArtifact = config.interchainSecurityModule;
-      }
+    const configuredIsm = config.interchainSecurityModule;
+    if (configuredIsm) {
+      assertRateLimitedIsmRecipientsUnset(
+        configuredIsm,
+        this.chainMetadata.name,
+      );
     }
 
     // Deploy Hook if configured as a NEW artifact
@@ -169,17 +177,13 @@ export class WarpTokenWriter
       }
     }
 
-    // Deploy warp WITHOUT fee — the fee is deployed and attached post-warp
-    // so that (a) the fee program can be initialized with the warp's
-    // settlement asset already known (e.g. SVM synthetic mints, which only
-    // exist post-deploy), and (b) the fee can be deployed with its real
-    // owner from the start rather than via a signer-as-initial-owner /
-    // TransferOwnership dance.
+    // Deploy warp WITHOUT an ISM or fee. Both are attached post-warp, and NEW
+    // artifacts are deployed first once the router address is available.
     const rawArtifact: ArtifactNew<RawWarpArtifactConfig> = {
       artifactState: ArtifactState.NEW,
       config: {
         ...config,
-        interchainSecurityModule: onChainIsmArtifact,
+        interchainSecurityModule: undefined,
         hook: onChainHookArtifact,
         fee: undefined,
       },
@@ -188,6 +192,30 @@ export class WarpTokenWriter
     const writer = this.artifactManager.createWriter(config.type, this.signer);
     const [deployed, tokenReceipts] = await writer.create(rawArtifact);
     allReceipts.push(...tokenReceipts);
+
+    // Deploy / resolve the ISM now that the warp address is known.
+    let onChainIsmArtifact:
+      | ArtifactOnChain<IsmArtifactConfig, DeployedIsmAddress>
+      | undefined;
+    if (configuredIsm) {
+      if (isArtifactUnderived(configuredIsm)) {
+        onChainIsmArtifact = configuredIsm;
+      } else {
+        const resolvedIsm = resolveIsmArtifact(configuredIsm, {
+          operation: IsmArtifactResolutionOperation.CREATE,
+          warpRouter: warpRouterContext(deployed.deployed.address),
+          context: this.chainMetadata.name,
+        });
+        if (isArtifactNew(resolvedIsm)) {
+          const [deployedIsm, ismReceipts] =
+            await this.ismWriter.create(resolvedIsm);
+          allReceipts.push(...ismReceipts);
+          onChainIsmArtifact = deployedIsm;
+        } else {
+          onChainIsmArtifact = resolvedIsm;
+        }
+      }
+    }
 
     // Deploy / resolve the fee now that the warp is on-chain and its
     // settlement asset is known.
@@ -219,18 +247,33 @@ export class WarpTokenWriter
       }
     }
 
-    // Attach the fee to the warp via the regular update path. The warp diff
-    // emits the SetTokenFeeConfig tx (current=no-fee, expected=fee); the
-    // fee writer's read sees current=expected since we just deployed it,
-    // so no fee-program diff txs are emitted.
-    if (onChainFeeArtifact) {
+    // Attach the ISM and fee to the warp via the regular update path.
+    if (onChainIsmArtifact || onChainFeeArtifact) {
+      const ismToAttach = onChainIsmArtifact
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: onChainIsmArtifact.deployed.address },
+          }
+        : undefined;
+      const feeToAttach = onChainFeeArtifact
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: onChainFeeArtifact.deployed.address },
+          }
+        : undefined;
+      const hookToAttach = onChainHookArtifact
+        ? {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: onChainHookArtifact.deployed.address },
+          }
+        : undefined;
       const attachTxs = await this.update({
         artifactState: ArtifactState.DEPLOYED,
         config: {
           ...config,
-          interchainSecurityModule: onChainIsmArtifact,
-          hook: onChainHookArtifact,
-          fee: onChainFeeArtifact,
+          interchainSecurityModule: ismToAttach,
+          hook: hookToAttach,
+          fee: feeToAttach,
         },
         deployed: deployed.deployed,
       });
@@ -314,8 +357,17 @@ export class WarpTokenWriter
       | undefined;
 
     if (expectedIsm && !isArtifactUnderived(expectedIsm)) {
+      // Resolve before merging: mergeIsmArtifacts returns a compositeIsm's
+      // expected config verbatim, so a router-derived recipient has to be in
+      // place already for both the NEW and the DEPLOYED branch below.
+      const resolvedIsm = resolveIsmArtifact(expectedIsm, {
+        operation: IsmArtifactResolutionOperation.UPDATE,
+        warpRouter: warpRouterContext(deployed.address),
+        context: this.chainMetadata.name,
+      });
+
       // NEW or DEPLOYED: Merge with current and decide deploy vs update
-      const mergedIsmConfig = mergeIsmArtifacts(currentIsm, expectedIsm);
+      const mergedIsmConfig = mergeIsmArtifacts(currentIsm, resolvedIsm);
 
       if (isArtifactNew(mergedIsmConfig)) {
         // Deploy new ISM

--- a/typescript/deploy-sdk/src/warp/warp-writer.ts
+++ b/typescript/deploy-sdk/src/warp/warp-writer.ts
@@ -47,6 +47,7 @@ import {
 import {
   addressToBytes32,
   assert,
+  eqAddress,
   isNullish,
   rootLogger,
 } from '@hyperlane-xyz/utils';
@@ -138,6 +139,7 @@ export class WarpTokenWriter
   ): Promise<[DeployedWarpArtifact, TxReceipt[]]> {
     const { config } = artifact;
     const allReceipts: TxReceipt[] = [];
+    const signerAddress = this.signer.getSignerAddress();
     if (config.hook) {
       assert(
         config.mailbox,
@@ -177,12 +179,14 @@ export class WarpTokenWriter
       }
     }
 
-    // Deploy warp WITHOUT an ISM or fee. Both are attached post-warp, and NEW
-    // artifacts are deployed first once the router address is available.
+    // Keep the signer as the temporary owner while post-create configuration
+    // is attached. Protocol writers transfer ownership during create, which
+    // would otherwise prevent this signer from submitting the deferred update.
     const rawArtifact: ArtifactNew<RawWarpArtifactConfig> = {
       artifactState: ArtifactState.NEW,
       config: {
         ...config,
+        owner: signerAddress,
         interchainSecurityModule: undefined,
         hook: onChainHookArtifact,
         fee: undefined,
@@ -247,26 +251,31 @@ export class WarpTokenWriter
       }
     }
 
-    // Attach the ISM and fee to the warp via the regular update path.
-    if (onChainIsmArtifact || onChainFeeArtifact) {
-      const ismToAttach = onChainIsmArtifact
-        ? {
-            artifactState: ArtifactState.UNDERIVED,
-            deployed: { address: onChainIsmArtifact.deployed.address },
-          }
-        : undefined;
-      const feeToAttach = onChainFeeArtifact
-        ? {
-            artifactState: ArtifactState.UNDERIVED,
-            deployed: { address: onChainFeeArtifact.deployed.address },
-          }
-        : undefined;
-      const hookToAttach = onChainHookArtifact
-        ? {
-            artifactState: ArtifactState.UNDERIVED,
-            deployed: { address: onChainHookArtifact.deployed.address },
-          }
-        : undefined;
+    const ismToAttach = onChainIsmArtifact
+      ? {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: onChainIsmArtifact.deployed.address },
+        }
+      : undefined;
+    const feeToAttach = onChainFeeArtifact
+      ? {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: onChainFeeArtifact.deployed.address },
+        }
+      : undefined;
+    const hookToAttach = onChainHookArtifact
+      ? {
+          artifactState: ArtifactState.UNDERIVED,
+          deployed: { address: onChainHookArtifact.deployed.address },
+        }
+      : undefined;
+    // Attach deferred artifacts and transfer ownership through one regular
+    // update. Protocol writers must place their ownership transaction last.
+    if (
+      onChainIsmArtifact ||
+      onChainFeeArtifact ||
+      !eqAddress(signerAddress, config.owner)
+    ) {
       const attachTxs = await this.update({
         artifactState: ArtifactState.DEPLOYED,
         config: {
@@ -288,6 +297,7 @@ export class WarpTokenWriter
         artifactState: ArtifactState.DEPLOYED,
         config: {
           ...deployed.config,
+          owner: config.owner,
           interchainSecurityModule: onChainIsmArtifact,
           hook: onChainHookArtifact,
           fee: onChainFeeArtifact,

--- a/typescript/provider-sdk/src/composite-ism.test.ts
+++ b/typescript/provider-sdk/src/composite-ism.test.ts
@@ -3,17 +3,32 @@ import { expect } from 'chai';
 import { assert } from '@hyperlane-xyz/utils';
 
 import { IsmType as AltVMIsmType } from './altvm.js';
-import { ArtifactNew, ArtifactState, isArtifactDeployed } from './artifact.js';
+import {
+  ArtifactNew,
+  ArtifactState,
+  ArtifactUnderived,
+  isArtifactDeployed,
+  isArtifactUnderived,
+} from './artifact.js';
 import { ChainLookup } from './chain.js';
 import {
+  CompositeIsmArtifactConfig,
   CompositeIsmConfig,
+  CompositeIsmNodeArtifactConfig,
+  CompositeIsmNodeType,
   DeployedIsmArtifact,
   DerivedIsmConfig,
   IsmArtifactConfig,
+  IsmArtifactResolutionOperation,
+  IsmType,
   altVMIsmTypeToProviderSdkType,
+  assertRateLimitedIsmRecipientsUnset,
+  assertIsmSupportedAsMailboxDefault,
   ismArtifactToDerivedConfig,
   ismConfigToArtifact,
   mergeIsmArtifacts,
+  resolveIsmArtifact,
+  resolveRateLimitedIsmRecipients,
 } from './ism.js';
 
 const chainLookup: ChainLookup = {
@@ -46,31 +61,31 @@ const OWNER = 'Vote111111111111111111111111111111111111111';
 describe('compositeIsm config <-> artifact conversion', () => {
   it('altVMIsmTypeToProviderSdkType maps COMPOSITE to compositeIsm', () => {
     expect(altVMIsmTypeToProviderSdkType(AltVMIsmType.COMPOSITE)).to.equal(
-      'compositeIsm',
+      IsmType.COMPOSITE,
     );
   });
 
   it('converts a nested tree from chain-name to domain-ID keyed domains', () => {
     const config: CompositeIsmConfig = {
-      type: 'compositeIsm',
+      type: IsmType.COMPOSITE,
       owner: OWNER,
       root: {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: 2,
         subIsms: [
-          { type: 'trustedRelayer', relayer: RELAYER },
+          { type: CompositeIsmNodeType.TRUSTED_RELAYER, relayer: RELAYER },
           {
-            type: 'routing',
+            type: CompositeIsmNodeType.ROUTING,
             domains: {
-              solanamainnet: { type: 'test', accept: true },
+              solanamainnet: { type: CompositeIsmNodeType.TEST, accept: true },
             },
           },
           {
-            type: 'amountRouting',
+            type: CompositeIsmNodeType.AMOUNT_ROUTING,
             threshold: '1000000',
-            lower: { type: 'pausable', paused: false },
+            lower: { type: CompositeIsmNodeType.PAUSABLE, paused: false },
             upper: {
-              type: 'rateLimited',
+              type: CompositeIsmNodeType.RATE_LIMITED,
               maxCapacity: '86400',
               mailbox: MAILBOX,
             },
@@ -82,37 +97,43 @@ describe('compositeIsm config <-> artifact conversion', () => {
     const artifact = ismConfigToArtifact(config, chainLookup);
     expect(artifact.artifactState).to.equal(ArtifactState.NEW);
 
-    assert(artifact.config.type === 'compositeIsm', 'expected compositeIsm');
+    assert(artifact.config.type === IsmType.COMPOSITE, 'expected compositeIsm');
     const artifactConfig = artifact.config;
-    expect(artifactConfig.type).to.equal('compositeIsm');
+    expect(artifactConfig.type).to.equal(IsmType.COMPOSITE);
     expect(artifactConfig.owner).to.equal(OWNER);
-    assert(artifactConfig.root.type === 'aggregation', 'expected aggregation');
+    assert(
+      artifactConfig.root.type === CompositeIsmNodeType.AGGREGATION,
+      'expected aggregation',
+    );
     expect(artifactConfig.root.threshold).to.equal(2);
 
     const [relayerNode, routingNode, amountRoutingNode] =
       artifactConfig.root.subIsms;
     expect(relayerNode).to.deep.equal({
-      type: 'trustedRelayer',
+      type: CompositeIsmNodeType.TRUSTED_RELAYER,
       relayer: RELAYER,
     });
 
-    assert(routingNode.type === 'routing', 'expected routing');
+    assert(
+      routingNode.type === CompositeIsmNodeType.ROUTING,
+      'expected routing',
+    );
     // chain name -> domain ID conversion happened
     expect(routingNode.domains).to.deep.equal({
-      1399811149: { type: 'test', accept: true },
+      1399811149: { type: CompositeIsmNodeType.TEST, accept: true },
     });
 
     assert(
-      amountRoutingNode.type === 'amountRouting',
+      amountRoutingNode.type === CompositeIsmNodeType.AMOUNT_ROUTING,
       'expected amountRouting',
     );
     expect(amountRoutingNode.threshold).to.equal('1000000');
     expect(amountRoutingNode.lower).to.deep.equal({
-      type: 'pausable',
+      type: CompositeIsmNodeType.PAUSABLE,
       paused: false,
     });
     expect(amountRoutingNode.upper).to.deep.equal({
-      type: 'rateLimited',
+      type: CompositeIsmNodeType.RATE_LIMITED,
       maxCapacity: '86400',
       mailbox: MAILBOX,
     });
@@ -120,21 +141,24 @@ describe('compositeIsm config <-> artifact conversion', () => {
 
   it('skips domains for unknown chain names, matching domainRoutingIsm', () => {
     const config: CompositeIsmConfig = {
-      type: 'compositeIsm',
+      type: IsmType.COMPOSITE,
       owner: OWNER,
       root: {
-        type: 'routing',
+        type: CompositeIsmNodeType.ROUTING,
         domains: {
-          solanamainnet: { type: 'test', accept: true },
-          unknownchain: { type: 'test', accept: false },
+          solanamainnet: { type: CompositeIsmNodeType.TEST, accept: true },
+          unknownchain: { type: CompositeIsmNodeType.TEST, accept: false },
         },
       },
     };
 
     const artifact = ismConfigToArtifact(config, chainLookup);
-    assert(artifact.config.type === 'compositeIsm', 'expected compositeIsm');
+    assert(artifact.config.type === IsmType.COMPOSITE, 'expected compositeIsm');
     const artifactConfig = artifact.config;
-    assert(artifactConfig.root.type === 'routing', 'expected routing');
+    assert(
+      artifactConfig.root.type === CompositeIsmNodeType.ROUTING,
+      'expected routing',
+    );
     expect(Object.keys(artifactConfig.root.domains ?? {})).to.deep.equal([
       '1399811149',
     ]);
@@ -144,13 +168,13 @@ describe('compositeIsm config <-> artifact conversion', () => {
     const deployedArtifact: DeployedIsmArtifact = {
       artifactState: ArtifactState.DEPLOYED,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: OWNER,
         root: {
-          type: 'fallbackRouting',
+          type: CompositeIsmNodeType.FALLBACK_ROUTING,
           fallbackIsm: RELAYER,
           domains: {
-            1399811149: { type: 'test', accept: true },
+            1399811149: { type: CompositeIsmNodeType.TEST, accept: true },
           },
         },
       },
@@ -159,14 +183,14 @@ describe('compositeIsm config <-> artifact conversion', () => {
 
     const derived = ismArtifactToDerivedConfig(deployedArtifact, chainLookup);
     const expected: DerivedIsmConfig = {
-      type: 'compositeIsm',
+      type: IsmType.COMPOSITE,
       owner: OWNER,
       address: PROGRAM_ADDRESS,
       root: {
-        type: 'fallbackRouting',
+        type: CompositeIsmNodeType.FALLBACK_ROUTING,
         fallbackIsm: RELAYER,
         domains: {
-          solanamainnet: { type: 'test', accept: true },
+          solanamainnet: { type: CompositeIsmNodeType.TEST, accept: true },
         },
       },
     };
@@ -177,13 +201,13 @@ describe('compositeIsm config <-> artifact conversion', () => {
     const deployedArtifact: DeployedIsmArtifact = {
       artifactState: ArtifactState.DEPLOYED,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: OWNER,
         root: {
-          type: 'routing',
+          type: CompositeIsmNodeType.ROUTING,
           domains: {
-            1399811149: { type: 'test', accept: true },
-            999999999: { type: 'test', accept: false },
+            1399811149: { type: CompositeIsmNodeType.TEST, accept: true },
+            999999999: { type: CompositeIsmNodeType.TEST, accept: false },
           },
         },
       },
@@ -192,7 +216,8 @@ describe('compositeIsm config <-> artifact conversion', () => {
 
     const derived = ismArtifactToDerivedConfig(deployedArtifact, chainLookup);
     assert(
-      derived.type === 'compositeIsm' && derived.root.type === 'routing',
+      derived.type === IsmType.COMPOSITE &&
+        derived.root.type === CompositeIsmNodeType.ROUTING,
       'expected compositeIsm/routing',
     );
     expect(Object.keys(derived.root.domains ?? {})).to.deep.equal([
@@ -204,9 +229,9 @@ describe('compositeIsm config <-> artifact conversion', () => {
     const currentArtifact: DeployedIsmArtifact = {
       artifactState: ArtifactState.DEPLOYED,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: OWNER,
-        root: { type: 'test', accept: true },
+        root: { type: CompositeIsmNodeType.TEST, accept: true },
       },
       deployed: { address: PROGRAM_ADDRESS },
     };
@@ -214,12 +239,12 @@ describe('compositeIsm config <-> artifact conversion', () => {
     const expectedArtifact: ArtifactNew<IsmArtifactConfig> = {
       artifactState: ArtifactState.NEW,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: OWNER,
         // Different tree — mergeIsmArtifacts should NOT try to reconcile
         // this itself; it just passes the expected config through, leaving
         // the actual diffing to SvmCompositeIsmWriter.update().
-        root: { type: 'pausable', paused: true },
+        root: { type: CompositeIsmNodeType.PAUSABLE, paused: true },
       },
     };
 
@@ -234,20 +259,806 @@ describe('compositeIsm config <-> artifact conversion', () => {
     const currentArtifact: DeployedIsmArtifact = {
       artifactState: ArtifactState.DEPLOYED,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: OWNER,
-        root: { type: 'test', accept: true },
+        root: { type: CompositeIsmNodeType.TEST, accept: true },
       },
       deployed: { address: PROGRAM_ADDRESS },
     };
 
     const expectedArtifact: ArtifactNew<IsmArtifactConfig> = {
       artifactState: ArtifactState.NEW,
-      config: { type: 'testIsm' },
+      config: { type: IsmType.TEST_ISM },
     };
 
     const result = mergeIsmArtifacts(currentArtifact, expectedArtifact);
     expect(result.artifactState).to.equal(ArtifactState.NEW);
-    expect(result.config).to.deep.equal({ type: 'testIsm' });
+    expect(result.config).to.deep.equal({ type: IsmType.TEST_ISM });
+  });
+});
+
+// Sealevel pubkey standing in for the deployed warp router the ISM protects,
+// and its 32-byte form. The expected hex is pinned rather than recomputed
+// from addressToBytes32 so the test also covers the base58 decoding itself.
+const WARP_ROUTER_BYTES32 = [
+  '0x06ddf6e1d765a193d9cbe146ceeb79ac',
+  '1cb485ed5f5b37913a8cf5857eff00a9',
+].join('');
+const WARP_ROUTER = {
+  address: PROGRAM_ADDRESS,
+  toBytes32: () => WARP_ROUTER_BYTES32,
+};
+const OTHER_BYTES32 = [
+  '0x7faee05ac5f8599a177feee8cf9b710f',
+  'fd41880c47a109cf020c4d9a95b0d27c',
+].join('');
+const CONTEXT = 'chain solanamainnet';
+
+const RATE_LIMITED_DOMAIN_ID = 1;
+
+function rateLimitedNode(recipient?: string): CompositeIsmNodeArtifactConfig {
+  return recipient === undefined
+    ? {
+        type: CompositeIsmNodeType.RATE_LIMITED,
+        maxCapacity: '86400',
+        mailbox: MAILBOX,
+      }
+    : {
+        type: CompositeIsmNodeType.RATE_LIMITED,
+        maxCapacity: '86400',
+        mailbox: MAILBOX,
+        recipient,
+      };
+}
+
+function compositeIsm(
+  root: CompositeIsmNodeArtifactConfig,
+): CompositeIsmArtifactConfig {
+  return { type: IsmType.COMPOSITE, owner: OWNER, root };
+}
+
+function domainRoutingIsm(nestedConfig: IsmArtifactConfig): IsmArtifactConfig {
+  return {
+    type: IsmType.ROUTING,
+    owner: OWNER,
+    domains: {
+      [RATE_LIMITED_DOMAIN_ID]: {
+        artifactState: ArtifactState.NEW,
+        config: nestedConfig,
+      },
+    },
+  };
+}
+
+function newIsmArtifact(
+  config: IsmArtifactConfig,
+): ArtifactNew<IsmArtifactConfig> {
+  return { artifactState: ArtifactState.NEW, config };
+}
+
+function extractDomainIsm(config: IsmArtifactConfig): IsmArtifactConfig {
+  assert(config.type === IsmType.ROUTING, 'expected domainRoutingIsm');
+  const domainIsm = config.domains[RATE_LIMITED_DOMAIN_ID];
+  assert(domainIsm, `expected domain ${RATE_LIMITED_DOMAIN_ID}`);
+  assert(!isArtifactUnderived(domainIsm), 'expected an expanded domain ISM');
+  return domainIsm.config;
+}
+
+interface NestingCase {
+  name: string;
+  /** Places `node` at the position under test within a fresh tree. */
+  wrap: (
+    node: CompositeIsmNodeArtifactConfig,
+  ) => CompositeIsmNodeArtifactConfig;
+  /** Pulls the same position back out of a resolved tree. */
+  extract: (
+    root: CompositeIsmNodeArtifactConfig,
+  ) => CompositeIsmNodeArtifactConfig;
+}
+
+const nestingCases: NestingCase[] = [
+  {
+    name: 'at the tree root',
+    wrap: (node) => node,
+    extract: (root) => root,
+  },
+  {
+    name: 'inside aggregation.subIsms',
+    wrap: (node) => ({
+      type: CompositeIsmNodeType.AGGREGATION,
+      threshold: 1,
+      subIsms: [{ type: CompositeIsmNodeType.TEST, accept: true }, node],
+    }),
+    extract: (root) => {
+      assert(
+        root.type === CompositeIsmNodeType.AGGREGATION,
+        'expected aggregation',
+      );
+      return root.subIsms[1];
+    },
+  },
+  {
+    name: 'inside amountRouting.lower',
+    wrap: (node) => ({
+      type: CompositeIsmNodeType.AMOUNT_ROUTING,
+      threshold: '1000000',
+      lower: node,
+      upper: { type: CompositeIsmNodeType.TEST, accept: true },
+    }),
+    extract: (root) => {
+      assert(
+        root.type === CompositeIsmNodeType.AMOUNT_ROUTING,
+        'expected amountRouting',
+      );
+      return root.lower;
+    },
+  },
+  {
+    name: 'inside amountRouting.upper',
+    wrap: (node) => ({
+      type: CompositeIsmNodeType.AMOUNT_ROUTING,
+      threshold: '1000000',
+      lower: { type: CompositeIsmNodeType.TEST, accept: true },
+      upper: node,
+    }),
+    extract: (root) => {
+      assert(
+        root.type === CompositeIsmNodeType.AMOUNT_ROUTING,
+        'expected amountRouting',
+      );
+      return root.upper;
+    },
+  },
+  {
+    name: 'inside a routing domain override',
+    wrap: (node) => ({
+      type: CompositeIsmNodeType.ROUTING,
+      domains: { [RATE_LIMITED_DOMAIN_ID]: node },
+    }),
+    extract: (root) => {
+      assert(root.type === CompositeIsmNodeType.ROUTING, 'expected routing');
+      const domain = root.domains?.[RATE_LIMITED_DOMAIN_ID];
+      assert(domain, `expected domain ${RATE_LIMITED_DOMAIN_ID}`);
+      return domain;
+    },
+  },
+  {
+    name: 'inside a fallbackRouting domain override',
+    wrap: (node) => ({
+      type: CompositeIsmNodeType.FALLBACK_ROUTING,
+      fallbackIsm: RELAYER,
+      domains: { [RATE_LIMITED_DOMAIN_ID]: node },
+    }),
+    extract: (root) => {
+      assert(
+        root.type === CompositeIsmNodeType.FALLBACK_ROUTING,
+        'expected fallbackRouting',
+      );
+      const domain = root.domains?.[RATE_LIMITED_DOMAIN_ID];
+      assert(domain, `expected domain ${RATE_LIMITED_DOMAIN_ID}`);
+      return domain;
+    },
+  },
+];
+
+describe('compositeIsm rateLimited recipient resolution', () => {
+  describe('resolveRateLimitedIsmRecipients', () => {
+    for (const testCase of nestingCases) {
+      it(`fills an unset recipient ${testCase.name}`, () => {
+        const resolved = resolveRateLimitedIsmRecipients(
+          compositeIsm(testCase.wrap(rateLimitedNode())),
+          WARP_ROUTER,
+          CONTEXT,
+        );
+        assert(resolved.type === IsmType.COMPOSITE, 'expected compositeIsm');
+        const node = testCase.extract(resolved.root);
+        assert(
+          node.type === CompositeIsmNodeType.RATE_LIMITED,
+          'expected rateLimited',
+        );
+        expect(node.recipient).to.equal(WARP_ROUTER_BYTES32);
+        expect(node.maxCapacity).to.equal('86400');
+        expect(node.mailbox).to.equal(MAILBOX);
+      });
+
+      it(`accepts a matching recipient ${testCase.name}`, () => {
+        const resolved = resolveRateLimitedIsmRecipients(
+          compositeIsm(
+            testCase.wrap(
+              rateLimitedNode(
+                `0x${WARP_ROUTER_BYTES32.slice(2).toUpperCase()}`,
+              ),
+            ),
+          ),
+          WARP_ROUTER,
+          CONTEXT,
+        );
+        assert(resolved.type === IsmType.COMPOSITE, 'expected compositeIsm');
+        const node = testCase.extract(resolved.root);
+        assert(
+          node.type === CompositeIsmNodeType.RATE_LIMITED,
+          'expected rateLimited',
+        );
+        expect(node.recipient).to.equal(WARP_ROUTER_BYTES32);
+      });
+
+      it(`rejects a mismatched recipient ${testCase.name}`, () => {
+        expect(() =>
+          resolveRateLimitedIsmRecipients(
+            compositeIsm(testCase.wrap(rateLimitedNode(OTHER_BYTES32))),
+            WARP_ROUTER,
+            CONTEXT,
+          ),
+        ).to.throw(WARP_ROUTER_BYTES32);
+      });
+    }
+
+    it('preserves every sibling field of the surrounding tree', () => {
+      const config = compositeIsm({
+        type: CompositeIsmNodeType.AGGREGATION,
+        threshold: 2,
+        subIsms: [
+          {
+            type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
+            validators: [RELAYER],
+            threshold: 1,
+          },
+          {
+            type: CompositeIsmNodeType.FALLBACK_ROUTING,
+            fallbackIsm: RELAYER,
+            domains: {
+              [RATE_LIMITED_DOMAIN_ID]: rateLimitedNode(),
+            },
+          },
+        ],
+      });
+
+      const resolved = resolveRateLimitedIsmRecipients(
+        config,
+        WARP_ROUTER,
+        CONTEXT,
+      );
+
+      expect(resolved).to.deep.equal(
+        compositeIsm({
+          type: CompositeIsmNodeType.AGGREGATION,
+          threshold: 2,
+          subIsms: [
+            {
+              type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
+              validators: [RELAYER],
+              threshold: 1,
+            },
+            {
+              type: CompositeIsmNodeType.FALLBACK_ROUTING,
+              fallbackIsm: RELAYER,
+              domains: {
+                [RATE_LIMITED_DOMAIN_ID]: rateLimitedNode(WARP_ROUTER_BYTES32),
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    it('passes through a router address that is already 32-byte hex', () => {
+      const hexRouter = [
+        '0x726F757465725F617070000000000000',
+        '00000000000001000000000000000000',
+      ].join('');
+      const resolved = resolveRateLimitedIsmRecipients(
+        compositeIsm(rateLimitedNode()),
+        { address: hexRouter, toBytes32: () => hexRouter },
+        CONTEXT,
+      );
+      assert(resolved.type === IsmType.COMPOSITE, 'expected compositeIsm');
+      assert(
+        resolved.root.type === CompositeIsmNodeType.RATE_LIMITED,
+        'expected a rateLimited root',
+      );
+      expect(resolved.root.recipient).to.equal(hexRouter.toLowerCase());
+    });
+
+    it('leaves a non-composite ISM untouched', () => {
+      const config: IsmArtifactConfig = { type: IsmType.TEST_ISM };
+      expect(
+        resolveRateLimitedIsmRecipients(config, WARP_ROUTER, CONTEXT),
+      ).to.equal(config);
+    });
+
+    it('keeps routing domain overrides without a rateLimited node intact', () => {
+      const config = compositeIsm({
+        type: CompositeIsmNodeType.ROUTING,
+        domains: {
+          [RATE_LIMITED_DOMAIN_ID]: {
+            type: CompositeIsmNodeType.TEST,
+            accept: true,
+          },
+        },
+      });
+      expect(
+        resolveRateLimitedIsmRecipients(config, WARP_ROUTER, CONTEXT),
+      ).to.deep.equal(config);
+    });
+
+    it('preserves omitted routing domains', () => {
+      for (const root of [
+        { type: CompositeIsmNodeType.ROUTING },
+        {
+          type: CompositeIsmNodeType.FALLBACK_ROUTING,
+          fallbackIsm: PROGRAM_ADDRESS,
+        },
+      ] satisfies CompositeIsmNodeArtifactConfig[]) {
+        const config = compositeIsm(root);
+        expect(
+          resolveRateLimitedIsmRecipients(config, WARP_ROUTER, CONTEXT),
+        ).to.deep.equal(config);
+      }
+    });
+
+    it('resolves a composite nested inside a domainRoutingIsm artifact', () => {
+      const resolved = resolveRateLimitedIsmRecipients(
+        domainRoutingIsm(compositeIsm(rateLimitedNode())),
+        WARP_ROUTER,
+        CONTEXT,
+      );
+      const nested = extractDomainIsm(resolved);
+      assert(nested.type === IsmType.COMPOSITE, 'expected compositeIsm');
+      assert(
+        nested.root.type === CompositeIsmNodeType.RATE_LIMITED,
+        'expected rateLimited',
+      );
+      expect(nested.root.recipient).to.equal(WARP_ROUTER_BYTES32);
+    });
+
+    it('preserves an implicit NEW nested artifact shape', () => {
+      const config: IsmArtifactConfig = {
+        type: IsmType.ROUTING,
+        owner: OWNER,
+        domains: {
+          [RATE_LIMITED_DOMAIN_ID]: {
+            config: compositeIsm(rateLimitedNode()),
+          },
+        },
+      };
+      const resolved = resolveRateLimitedIsmRecipients(
+        config,
+        WARP_ROUTER,
+        CONTEXT,
+      );
+      assert(resolved.type === IsmType.ROUTING, 'expected domainRoutingIsm');
+      const domainIsm = resolved.domains[RATE_LIMITED_DOMAIN_ID];
+      expect(Object.hasOwn(domainIsm, 'artifactState')).to.be.false;
+    });
+
+    it('preserves a nested DEPLOYED artifact while resolving its config', () => {
+      const config: IsmArtifactConfig = {
+        type: IsmType.ROUTING,
+        owner: OWNER,
+        domains: {
+          [RATE_LIMITED_DOMAIN_ID]: {
+            artifactState: ArtifactState.DEPLOYED,
+            config: compositeIsm(rateLimitedNode()),
+            deployed: { address: PROGRAM_ADDRESS },
+          },
+        },
+      };
+      const resolved = resolveRateLimitedIsmRecipients(
+        config,
+        WARP_ROUTER,
+        CONTEXT,
+      );
+      assert(resolved.type === IsmType.ROUTING, 'expected domainRoutingIsm');
+      const domainIsm = resolved.domains[RATE_LIMITED_DOMAIN_ID];
+      assert(isArtifactDeployed(domainIsm), 'expected a deployed domain ISM');
+      expect(domainIsm.deployed.address).to.equal(PROGRAM_ADDRESS);
+      assert(
+        domainIsm.config.type === IsmType.COMPOSITE,
+        'expected compositeIsm',
+      );
+      assert(
+        domainIsm.config.root.type === CompositeIsmNodeType.RATE_LIMITED,
+        'expected rateLimited',
+      );
+      expect(domainIsm.config.root.recipient).to.equal(WARP_ROUTER_BYTES32);
+    });
+
+    it('leaves an UNDERIVED nested artifact untouched', () => {
+      const config: IsmArtifactConfig = {
+        type: IsmType.ROUTING,
+        owner: OWNER,
+        domains: {
+          [RATE_LIMITED_DOMAIN_ID]: {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: PROGRAM_ADDRESS },
+          },
+        },
+      };
+      expect(
+        resolveRateLimitedIsmRecipients(config, WARP_ROUTER, CONTEXT),
+      ).to.deep.equal(config);
+    });
+  });
+
+  describe('resolveIsmArtifact', () => {
+    it('does not parse a router address when no contextual ISM needs it', () => {
+      const newRouting: ArtifactNew<IsmArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: {
+            [RATE_LIMITED_DOMAIN_ID]: newIsmArtifact({
+              type: IsmType.TEST_ISM,
+            }),
+          },
+        },
+      };
+      const deployedTest: DeployedIsmArtifact = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: { type: IsmType.TEST_ISM },
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      const resolutionContext = {
+        operation: IsmArtifactResolutionOperation.CREATE,
+        warpRouter: {
+          address: 'cosmos1deadbeef',
+          toBytes32: () => {
+            throw new Error('must remain lazy');
+          },
+        },
+        context: CONTEXT,
+      } as const;
+
+      expect(() =>
+        resolveIsmArtifact(newRouting, resolutionContext),
+      ).to.not.throw();
+      expect(() =>
+        resolveIsmArtifact(deployedTest, resolutionContext),
+      ).to.not.throw();
+    });
+
+    it('resolves NEW descendants of a NEW routing artifact', () => {
+      const artifact: ArtifactNew<IsmArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: domainRoutingIsm(compositeIsm(rateLimitedNode())),
+      };
+      const resolved = resolveIsmArtifact(artifact, {
+        operation: IsmArtifactResolutionOperation.CREATE,
+        warpRouter: WARP_ROUTER,
+        context: CONTEXT,
+      });
+      const nested = extractDomainIsm(resolved.config);
+      assert(nested.type === IsmType.COMPOSITE, 'expected compositeIsm');
+      assert(
+        nested.root.type === CompositeIsmNodeType.RATE_LIMITED,
+        'expected rateLimited',
+      );
+      expect(nested.root.recipient).to.equal(WARP_ROUTER_BYTES32);
+    });
+
+    it('validates and preserves DEPLOYED descendants of a NEW routing artifact', () => {
+      const deployedDomainIsm: DeployedIsmArtifact = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: compositeIsm(rateLimitedNode(WARP_ROUTER_BYTES32)),
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      const artifact: ArtifactNew<IsmArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: { [RATE_LIMITED_DOMAIN_ID]: deployedDomainIsm },
+        },
+      };
+      const resolved = resolveIsmArtifact(artifact, {
+        operation: IsmArtifactResolutionOperation.CREATE,
+        warpRouter: WARP_ROUTER,
+        context: CONTEXT,
+      });
+      assert(
+        resolved.config.type === IsmType.ROUTING,
+        'expected domainRoutingIsm',
+      );
+      expect(resolved.config.domains[RATE_LIMITED_DOMAIN_ID]).to.equal(
+        deployedDomainIsm,
+      );
+    });
+
+    it('rejects a mismatched DEPLOYED descendant of a NEW routing artifact', () => {
+      const artifact: ArtifactNew<IsmArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: {
+            [RATE_LIMITED_DOMAIN_ID]: {
+              artifactState: ArtifactState.DEPLOYED,
+              config: compositeIsm(rateLimitedNode(OTHER_BYTES32)),
+              deployed: { address: PROGRAM_ADDRESS },
+            },
+          },
+        },
+      };
+      expect(() =>
+        resolveIsmArtifact(artifact, {
+          operation: IsmArtifactResolutionOperation.CREATE,
+          warpRouter: WARP_ROUTER,
+          context: CONTEXT,
+        }),
+      ).to.throw(WARP_ROUTER_BYTES32);
+    });
+
+    it('preserves UNDERIVED descendants of a NEW routing artifact', () => {
+      const domainIsm: ArtifactUnderived<DeployedIsmArtifact['deployed']> = {
+        artifactState: ArtifactState.UNDERIVED,
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      const artifact: ArtifactNew<IsmArtifactConfig> = {
+        artifactState: ArtifactState.NEW,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: { [RATE_LIMITED_DOMAIN_ID]: domainIsm },
+        },
+      };
+      const resolved = resolveIsmArtifact(artifact, {
+        operation: IsmArtifactResolutionOperation.CREATE,
+        warpRouter: WARP_ROUTER,
+        context: CONTEXT,
+      });
+      assert(
+        resolved.config.type === IsmType.ROUTING,
+        'expected domainRoutingIsm',
+      );
+      expect(resolved.config.domains[RATE_LIMITED_DOMAIN_ID]).to.equal(
+        domainIsm,
+      );
+    });
+
+    it('validates and preserves a DEPLOYED routing root during warp create', () => {
+      const artifact: DeployedIsmArtifact = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: {
+            [RATE_LIMITED_DOMAIN_ID]: {
+              artifactState: ArtifactState.DEPLOYED,
+              config: compositeIsm(rateLimitedNode(WARP_ROUTER_BYTES32)),
+              deployed: { address: PROGRAM_ADDRESS },
+            },
+          },
+        },
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      expect(
+        resolveIsmArtifact(artifact, {
+          operation: IsmArtifactResolutionOperation.CREATE,
+          warpRouter: WARP_ROUTER,
+          context: CONTEXT,
+        }),
+      ).to.equal(artifact);
+    });
+
+    it('rejects a NEW descendant in a DEPLOYED routing root during warp create', () => {
+      const artifact: DeployedIsmArtifact = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: {
+            [RATE_LIMITED_DOMAIN_ID]: {
+              artifactState: ArtifactState.NEW,
+              config: compositeIsm(rateLimitedNode()),
+            },
+          },
+        },
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      expect(() =>
+        resolveIsmArtifact(artifact, {
+          operation: IsmArtifactResolutionOperation.CREATE,
+          warpRouter: WARP_ROUTER,
+          context: CONTEXT,
+        }),
+      ).to.throw(/DEPLOYED ISM.*NEW descendant/);
+    });
+
+    it('rejects a mismatched rateLimited descendant in a DEPLOYED routing root', () => {
+      const artifact: DeployedIsmArtifact = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: {
+            [RATE_LIMITED_DOMAIN_ID]: {
+              artifactState: ArtifactState.DEPLOYED,
+              config: compositeIsm(rateLimitedNode(OTHER_BYTES32)),
+              deployed: { address: PROGRAM_ADDRESS },
+            },
+          },
+        },
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      expect(() =>
+        resolveIsmArtifact(artifact, {
+          operation: IsmArtifactResolutionOperation.CREATE,
+          warpRouter: WARP_ROUTER,
+          context: CONTEXT,
+        }),
+      ).to.throw(WARP_ROUTER_BYTES32);
+    });
+
+    it('resolves DEPLOYED descendants when updating a DEPLOYED routing artifact', () => {
+      const artifact: DeployedIsmArtifact = {
+        artifactState: ArtifactState.DEPLOYED,
+        config: {
+          type: IsmType.ROUTING,
+          owner: OWNER,
+          domains: {
+            [RATE_LIMITED_DOMAIN_ID]: {
+              artifactState: ArtifactState.DEPLOYED,
+              config: compositeIsm(rateLimitedNode()),
+              deployed: { address: PROGRAM_ADDRESS },
+            },
+          },
+        },
+        deployed: { address: PROGRAM_ADDRESS },
+      };
+      const resolved = resolveIsmArtifact(artifact, {
+        operation: IsmArtifactResolutionOperation.UPDATE,
+        warpRouter: WARP_ROUTER,
+        context: CONTEXT,
+      });
+      const nested = extractDomainIsm(resolved.config);
+      assert(nested.type === IsmType.COMPOSITE, 'expected compositeIsm');
+      assert(
+        nested.root.type === CompositeIsmNodeType.RATE_LIMITED,
+        'expected rateLimited',
+      );
+      expect(nested.root.recipient).to.equal(WARP_ROUTER_BYTES32);
+    });
+  });
+
+  describe('assertRateLimitedIsmRecipientsUnset', () => {
+    for (const testCase of nestingCases) {
+      it(`rejects a recipient written out ${testCase.name}`, () => {
+        expect(() => {
+          assertRateLimitedIsmRecipientsUnset(
+            newIsmArtifact(
+              compositeIsm(testCase.wrap(rateLimitedNode(WARP_ROUTER_BYTES32))),
+            ),
+            CONTEXT,
+          );
+        }).to.throw(CONTEXT);
+      });
+
+      it(`accepts an unset recipient ${testCase.name}`, () => {
+        expect(() => {
+          assertRateLimitedIsmRecipientsUnset(
+            newIsmArtifact(compositeIsm(testCase.wrap(rateLimitedNode()))),
+            CONTEXT,
+          );
+        }).to.not.throw();
+      });
+    }
+
+    it('accepts a non-composite ISM', () => {
+      expect(() => {
+        assertRateLimitedIsmRecipientsUnset(
+          newIsmArtifact({ type: IsmType.TEST_ISM }),
+          CONTEXT,
+        );
+      }).to.not.throw();
+    });
+
+    it('rejects a recipient nested inside a domainRoutingIsm artifact', () => {
+      expect(() => {
+        assertRateLimitedIsmRecipientsUnset(
+          newIsmArtifact(
+            domainRoutingIsm(
+              compositeIsm(rateLimitedNode(WARP_ROUTER_BYTES32)),
+            ),
+          ),
+          CONTEXT,
+        );
+      }).to.throw(CONTEXT);
+    });
+
+    it('accepts a recipient in a DEPLOYED descendant', () => {
+      expect(() => {
+        assertRateLimitedIsmRecipientsUnset(
+          {
+            artifactState: ArtifactState.NEW,
+            config: {
+              type: IsmType.ROUTING,
+              owner: OWNER,
+              domains: {
+                [RATE_LIMITED_DOMAIN_ID]: {
+                  artifactState: ArtifactState.DEPLOYED,
+                  config: compositeIsm(rateLimitedNode(WARP_ROUTER_BYTES32)),
+                  deployed: { address: PROGRAM_ADDRESS },
+                },
+              },
+            },
+          },
+          CONTEXT,
+        );
+      }).to.not.throw();
+    });
+  });
+
+  describe('assertIsmSupportedAsMailboxDefault', () => {
+    for (const testCase of nestingCases) {
+      it(`rejects a rateLimited node ${testCase.name}`, () => {
+        expect(() => {
+          assertIsmSupportedAsMailboxDefault(
+            {
+              artifactState: ArtifactState.NEW,
+              config: compositeIsm(testCase.wrap(rateLimitedNode())),
+            },
+            CONTEXT,
+          );
+        }).to.throw(CONTEXT);
+      });
+    }
+
+    it('accepts a composite tree without a rateLimited node', () => {
+      expect(() => {
+        assertIsmSupportedAsMailboxDefault(
+          {
+            artifactState: ArtifactState.NEW,
+            config: compositeIsm({
+              type: CompositeIsmNodeType.AGGREGATION,
+              threshold: 1,
+              subIsms: [
+                {
+                  type: CompositeIsmNodeType.TRUSTED_RELAYER,
+                  relayer: RELAYER,
+                },
+              ],
+            }),
+          },
+          CONTEXT,
+        );
+      }).to.not.throw();
+    });
+
+    it('accepts a non-composite ISM', () => {
+      expect(() => {
+        assertIsmSupportedAsMailboxDefault(
+          {
+            artifactState: ArtifactState.NEW,
+            config: { type: IsmType.TEST_ISM },
+          },
+          CONTEXT,
+        );
+      }).to.not.throw();
+    });
+
+    it('rejects a rateLimited node nested inside a domainRoutingIsm artifact', () => {
+      expect(() => {
+        assertIsmSupportedAsMailboxDefault(
+          {
+            artifactState: ArtifactState.NEW,
+            config: domainRoutingIsm(compositeIsm(rateLimitedNode())),
+          },
+          CONTEXT,
+        );
+      }).to.throw(CONTEXT);
+    });
+
+    it('accepts an opaque UNDERIVED ISM address', () => {
+      expect(() => {
+        assertIsmSupportedAsMailboxDefault(
+          {
+            artifactState: ArtifactState.UNDERIVED,
+            deployed: { address: PROGRAM_ADDRESS },
+          },
+          CONTEXT,
+        );
+      }).to.not.throw();
+    });
   });
 });

--- a/typescript/provider-sdk/src/core.ts
+++ b/typescript/provider-sdk/src/core.ts
@@ -16,6 +16,7 @@ import type { DerivedIsmConfig, IsmConfig } from './ism.js';
 import {
   DeployedIsmAddress,
   IsmArtifactConfig,
+  IsmType,
   ismConfigToArtifact,
 } from './ism.js';
 import { DeployedMailboxArtifact, MailboxArtifactConfig } from './mailbox.js';
@@ -152,13 +153,13 @@ export function coreResultToDeployedAddresses(result: {
   if (isArtifactDeployed(ismArtifact)) {
     const ismAddress = ismArtifact.deployed.address;
     switch (ismArtifact.config.type) {
-      case 'merkleRootMultisigIsm':
+      case IsmType.MERKLE_ROOT_MULTISIG:
         addresses.staticMerkleRootMultisigIsmFactory = ismAddress;
         break;
-      case 'messageIdMultisigIsm':
+      case IsmType.MESSAGE_ID_MULTISIG:
         addresses.staticMessageIdMultisigIsmFactory = ismAddress;
         break;
-      case 'domainRoutingIsm':
+      case IsmType.ROUTING:
         addresses.domainRoutingIsmFactory = ismAddress;
         break;
     }

--- a/typescript/provider-sdk/src/ism.ts
+++ b/typescript/provider-sdk/src/ism.ts
@@ -30,36 +30,47 @@ export type IsmModuleType = {
   addresses: IsmModuleAddresses;
 };
 
+export const IsmType = {
+  ROUTING: 'domainRoutingIsm',
+  MERKLE_ROOT_MULTISIG: 'merkleRootMultisigIsm',
+  MESSAGE_ID_MULTISIG: 'messageIdMultisigIsm',
+  TEST_ISM: 'testIsm',
+  COMPOSITE: 'compositeIsm',
+} as const;
+
+export type IsmType = (typeof IsmType)[keyof typeof IsmType];
+
 export interface IsmConfigs {
-  domainRoutingIsm: DomainRoutingIsmConfig;
-  merkleRootMultisigIsm: MultisigIsmConfig;
-  messageIdMultisigIsm: MultisigIsmConfig;
-  testIsm: TestIsmConfig;
-  compositeIsm: CompositeIsmConfig;
+  [IsmType.ROUTING]: DomainRoutingIsmConfig;
+  [IsmType.MERKLE_ROOT_MULTISIG]: MultisigIsmConfig;
+  [IsmType.MESSAGE_ID_MULTISIG]: MultisigIsmConfig;
+  [IsmType.TEST_ISM]: TestIsmConfig;
+  [IsmType.COMPOSITE]: CompositeIsmConfig;
 }
 
-export type IsmType = keyof IsmConfigs;
 export type IsmConfig = IsmConfigs[IsmType];
 export type DerivedIsmConfig = WithAddress<IsmConfig>;
 
 export const STATIC_ISM_TYPES: IsmType[] = [
-  'testIsm',
-  'merkleRootMultisigIsm',
-  'messageIdMultisigIsm',
+  IsmType.TEST_ISM,
+  IsmType.MERKLE_ROOT_MULTISIG,
+  IsmType.MESSAGE_ID_MULTISIG,
 ];
 
 export interface MultisigIsmConfig {
-  type: 'merkleRootMultisigIsm' | 'messageIdMultisigIsm';
+  type:
+    | typeof IsmType.MERKLE_ROOT_MULTISIG
+    | typeof IsmType.MESSAGE_ID_MULTISIG;
   validators: string[];
   threshold: number;
 }
 
 export interface TestIsmConfig {
-  type: 'testIsm';
+  type: typeof IsmType.TEST_ISM;
 }
 
 export interface DomainRoutingIsmConfig {
-  type: 'domainRoutingIsm';
+  type: typeof IsmType.ROUTING;
   owner: string;
   domains: Record<string, IsmConfig | string>;
 }
@@ -90,36 +101,43 @@ export const CompositeIsmNodeType = {
  * (config-file-only; diffed into per-domain instructions by the writer).
  */
 export type CompositeIsmNodeConfig =
-  | { type: 'trustedRelayer'; relayer: string }
-  | { type: 'multisigMessageId'; validators: string[]; threshold: number }
+  | { type: typeof CompositeIsmNodeType.TRUSTED_RELAYER; relayer: string }
   | {
-      type: 'aggregation';
+      type: typeof CompositeIsmNodeType.MULTISIG_MESSAGE_ID;
+      validators: string[];
+      threshold: number;
+    }
+  | {
+      type: typeof CompositeIsmNodeType.AGGREGATION;
       threshold: number;
       subIsms: CompositeIsmNodeConfig[];
     }
-  | { type: 'test'; accept: boolean }
-  | { type: 'pausable'; paused: boolean }
+  | { type: typeof CompositeIsmNodeType.TEST; accept: boolean }
+  | { type: typeof CompositeIsmNodeType.PAUSABLE; paused: boolean }
   | {
-      type: 'amountRouting';
+      type: typeof CompositeIsmNodeType.AMOUNT_ROUTING;
       threshold: string;
       lower: CompositeIsmNodeConfig;
       upper: CompositeIsmNodeConfig;
     }
   | {
-      type: 'rateLimited';
+      type: typeof CompositeIsmNodeType.RATE_LIMITED;
       maxCapacity: string;
       mailbox: string;
       recipient?: string;
     }
-  | { type: 'routing'; domains?: Record<string, CompositeIsmNodeConfig> }
   | {
-      type: 'fallbackRouting';
+      type: typeof CompositeIsmNodeType.ROUTING;
+      domains?: Record<string, CompositeIsmNodeConfig>;
+    }
+  | {
+      type: typeof CompositeIsmNodeType.FALLBACK_ROUTING;
       fallbackIsm: string;
       domains?: Record<string, CompositeIsmNodeConfig>;
     };
 
 export interface CompositeIsmConfig {
-  type: 'compositeIsm';
+  type: typeof IsmType.COMPOSITE;
   owner: string;
   root: CompositeIsmNodeConfig;
 }
@@ -136,11 +154,11 @@ export interface DeployedIsmAddress {
 }
 
 export interface IsmArtifactConfigs {
-  domainRoutingIsm: RoutingIsmArtifactConfig;
-  merkleRootMultisigIsm: MultisigIsmConfig;
-  messageIdMultisigIsm: MultisigIsmConfig;
-  testIsm: TestIsmConfig;
-  compositeIsm: CompositeIsmArtifactConfig;
+  [IsmType.ROUTING]: RoutingIsmArtifactConfig;
+  [IsmType.MERKLE_ROOT_MULTISIG]: MultisigIsmConfig;
+  [IsmType.MESSAGE_ID_MULTISIG]: MultisigIsmConfig;
+  [IsmType.TEST_ISM]: TestIsmConfig;
+  [IsmType.COMPOSITE]: CompositeIsmArtifactConfig;
 }
 
 /**
@@ -168,7 +186,7 @@ export type IIsmArtifactManager = IArtifactManager<
 >;
 
 export interface RoutingIsmArtifactConfig {
-  type: 'domainRoutingIsm';
+  type: typeof IsmType.ROUTING;
   owner: string;
   domains: Record<number, Artifact<IsmArtifactConfig, DeployedIsmAddress>>;
 }
@@ -183,49 +201,53 @@ export type RawRoutingIsmArtifactConfig =
  * (unlike domainRoutingIsm, whose domains wrap nested Artifact<> objects).
  */
 export type CompositeIsmNodeArtifactConfig =
-  | { type: 'trustedRelayer'; relayer: string }
-  | { type: 'multisigMessageId'; validators: string[]; threshold: number }
+  | { type: typeof CompositeIsmNodeType.TRUSTED_RELAYER; relayer: string }
   | {
-      type: 'aggregation';
+      type: typeof CompositeIsmNodeType.MULTISIG_MESSAGE_ID;
+      validators: string[];
+      threshold: number;
+    }
+  | {
+      type: typeof CompositeIsmNodeType.AGGREGATION;
       threshold: number;
       subIsms: CompositeIsmNodeArtifactConfig[];
     }
-  | { type: 'test'; accept: boolean }
-  | { type: 'pausable'; paused: boolean }
+  | { type: typeof CompositeIsmNodeType.TEST; accept: boolean }
+  | { type: typeof CompositeIsmNodeType.PAUSABLE; paused: boolean }
   | {
-      type: 'amountRouting';
+      type: typeof CompositeIsmNodeType.AMOUNT_ROUTING;
       threshold: string;
       lower: CompositeIsmNodeArtifactConfig;
       upper: CompositeIsmNodeArtifactConfig;
     }
   | {
-      type: 'rateLimited';
+      type: typeof CompositeIsmNodeType.RATE_LIMITED;
       maxCapacity: string;
       mailbox: string;
       recipient?: string;
     }
   | {
-      type: 'routing';
+      type: typeof CompositeIsmNodeType.ROUTING;
       domains?: Record<number, CompositeIsmNodeArtifactConfig>;
     }
   | {
-      type: 'fallbackRouting';
+      type: typeof CompositeIsmNodeType.FALLBACK_ROUTING;
       fallbackIsm: string;
       domains?: Record<number, CompositeIsmNodeArtifactConfig>;
     };
 
 export interface CompositeIsmArtifactConfig {
-  type: 'compositeIsm';
+  type: typeof IsmType.COMPOSITE;
   owner: string;
   root: CompositeIsmNodeArtifactConfig;
 }
 
 export interface RawIsmArtifactConfigs {
-  domainRoutingIsm: RawRoutingIsmArtifactConfig;
-  merkleRootMultisigIsm: MultisigIsmConfig;
-  messageIdMultisigIsm: MultisigIsmConfig;
-  testIsm: TestIsmConfig;
-  compositeIsm: CompositeIsmArtifactConfig;
+  [IsmType.ROUTING]: RawRoutingIsmArtifactConfig;
+  [IsmType.MERKLE_ROOT_MULTISIG]: MultisigIsmConfig;
+  [IsmType.MESSAGE_ID_MULTISIG]: MultisigIsmConfig;
+  [IsmType.TEST_ISM]: TestIsmConfig;
+  [IsmType.COMPOSITE]: CompositeIsmArtifactConfig;
 }
 
 /**
@@ -347,7 +369,7 @@ export function mergeIsmArtifacts(
   // Composite ISM's tree is diffed by SvmCompositeIsmWriter.update() itself
   // (it re-reads on-chain state directly) rather than via this generic
   // Artifact recursion, since sub-nodes aren't separate deployments.
-  if (expectedConfig.type === 'compositeIsm') {
+  if (expectedConfig.type === IsmType.COMPOSITE) {
     const deployedAddress = isArtifactDeployed(expectedArtifact)
       ? expectedArtifact.deployed
       : currentArtifact.deployed;
@@ -360,8 +382,8 @@ export function mergeIsmArtifacts(
   }
 
   assert(
-    currentConfig.type === 'domainRoutingIsm' &&
-      expectedConfig.type === 'domainRoutingIsm',
+    currentConfig.type === IsmType.ROUTING &&
+      expectedConfig.type === IsmType.ROUTING,
     'Expected both configs to be of type domainRoutingIsm',
   );
 
@@ -407,7 +429,7 @@ export function mergeIsmArtifacts(
   return {
     artifactState: ArtifactState.DEPLOYED,
     config: {
-      type: 'domainRoutingIsm',
+      type: IsmType.ROUTING,
       owner: expectedConfig.owner,
       domains: mergedDomains,
     },
@@ -420,15 +442,15 @@ export function altVMIsmTypeToProviderSdkType(
 ): IsmType {
   switch (altVMType) {
     case AltVMIsmType.TEST_ISM:
-      return 'testIsm';
+      return IsmType.TEST_ISM;
     case AltVMIsmType.MERKLE_ROOT_MULTISIG:
-      return 'merkleRootMultisigIsm';
+      return IsmType.MERKLE_ROOT_MULTISIG;
     case AltVMIsmType.MESSAGE_ID_MULTISIG:
-      return 'messageIdMultisigIsm';
+      return IsmType.MESSAGE_ID_MULTISIG;
     case AltVMIsmType.ROUTING:
-      return 'domainRoutingIsm';
+      return IsmType.ROUTING;
     case AltVMIsmType.COMPOSITE:
-      return 'compositeIsm';
+      return IsmType.COMPOSITE;
     default:
       throw new Error(
         `Unsupported ISM type: AltVM ISM type ${altVMType} is not supported by the provider sdk`,
@@ -531,6 +553,537 @@ function compositeIsmNodeConfigToArtifact(
   }
 }
 
+/**
+ * Walks every node of a composite ISM tree, including the nodes nested in
+ * `aggregation.subIsms`, `amountRouting.lower`/`upper`, and the per-domain
+ * overrides of `routing`/`fallbackRouting`.
+ */
+function someCompositeIsmNode(
+  node: CompositeIsmNodeArtifactConfig,
+  predicate: (node: CompositeIsmNodeArtifactConfig) => boolean,
+): boolean {
+  if (predicate(node)) return true;
+  switch (node.type) {
+    case CompositeIsmNodeType.AGGREGATION:
+      return node.subIsms.some((sub) => someCompositeIsmNode(sub, predicate));
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
+      return (
+        someCompositeIsmNode(node.lower, predicate) ||
+        someCompositeIsmNode(node.upper, predicate)
+      );
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
+      return node.domains
+        ? Object.values(node.domains).some((domainNode) =>
+            someCompositeIsmNode(domainNode, predicate),
+          )
+        : false;
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+    case CompositeIsmNodeType.TEST:
+    case CompositeIsmNodeType.PAUSABLE:
+    case CompositeIsmNodeType.RATE_LIMITED:
+      return false;
+    default:
+      return assertNever(node, 'someCompositeIsmNode');
+  }
+}
+
+function assertCompositeIsmNodeSupportedAsMailboxDefault(
+  node: CompositeIsmNodeArtifactConfig,
+  context: string,
+): void {
+  switch (node.type) {
+    case CompositeIsmNodeType.AGGREGATION:
+      for (const subIsm of node.subIsms) {
+        assertCompositeIsmNodeSupportedAsMailboxDefault(subIsm, context);
+      }
+      return;
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
+      assertCompositeIsmNodeSupportedAsMailboxDefault(node.lower, context);
+      assertCompositeIsmNodeSupportedAsMailboxDefault(node.upper, context);
+      return;
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
+      if (!node.domains) return;
+      for (const domainIsm of Object.values(node.domains)) {
+        assertCompositeIsmNodeSupportedAsMailboxDefault(domainIsm, context);
+      }
+      return;
+    case CompositeIsmNodeType.RATE_LIMITED:
+      assert(
+        false,
+        `A compositeIsm 'rateLimited' node is only supported on a warp route, but one was configured for ${context}. Remove the rateLimited node.`,
+      );
+      return;
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+    case CompositeIsmNodeType.TEST:
+    case CompositeIsmNodeType.PAUSABLE:
+      return;
+    default:
+      return assertNever(
+        node,
+        'assertCompositeIsmNodeSupportedAsMailboxDefault',
+      );
+  }
+}
+
+function assertIsmConfigSupportedAsMailboxDefault(
+  config: IsmArtifactConfig,
+  context: string,
+): void {
+  switch (config.type) {
+    case IsmType.ROUTING:
+      for (const domainIsm of Object.values(config.domains)) {
+        if (!isArtifactUnderived(domainIsm)) {
+          assertIsmConfigSupportedAsMailboxDefault(domainIsm.config, context);
+        }
+      }
+      return;
+    case IsmType.COMPOSITE:
+      assertCompositeIsmNodeSupportedAsMailboxDefault(config.root, context);
+      return;
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.TEST_ISM:
+      return;
+    default:
+      return assertNever(config, 'assertIsmConfigSupportedAsMailboxDefault');
+  }
+}
+
+/**
+ * Validates every expanded ISM and composite node before using an artifact as
+ * a mailbox default ISM. UNDERIVED address references are intentionally opaque.
+ *
+ * A rate-limited node reads a transfer amount from a fixed offset of a warp
+ * TokenMessage body, so it cannot safely validate arbitrary mailbox traffic.
+ * Keep both recursive switches exhaustive so future ISM variants must declare
+ * their mailbox compatibility before compiling.
+ */
+export function assertIsmSupportedAsMailboxDefault(
+  artifact: Artifact<IsmArtifactConfig, DeployedIsmAddress>,
+  context: string,
+): void {
+  if (isArtifactUnderived(artifact)) return;
+  assertIsmConfigSupportedAsMailboxDefault(artifact.config, context);
+}
+
+function ismArtifactHasExplicitRateLimitedRecipient(
+  config: IsmArtifactConfig,
+): boolean {
+  switch (config.type) {
+    case IsmType.ROUTING:
+      return Object.values(config.domains).some(
+        (domainIsm) =>
+          isArtifactNew(domainIsm) &&
+          ismArtifactHasExplicitRateLimitedRecipient(domainIsm.config),
+      );
+    case IsmType.COMPOSITE:
+      return someCompositeIsmNode(
+        config.root,
+        (node) =>
+          node.type === CompositeIsmNodeType.RATE_LIMITED &&
+          !isNullish(node.recipient),
+      );
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.TEST_ISM:
+      return false;
+    default:
+      return assertNever(config, 'ismArtifactHasExplicitRateLimitedRecipient');
+  }
+}
+
+/**
+ * Rejects hand-written `rateLimited.recipient` values in the ISM artifacts
+ * that a warp create will deploy. DEPLOYED descendants are references to
+ * existing ISMs, so they are validated against the router after it exists.
+ */
+export function assertRateLimitedIsmRecipientsUnset(
+  artifact: Artifact<IsmArtifactConfig, DeployedIsmAddress>,
+  context: string,
+): void {
+  if (!isArtifactNew(artifact)) return;
+  const hasRecipient = ismArtifactHasExplicitRateLimitedRecipient(
+    artifact.config,
+  );
+  assert(
+    !hasRecipient,
+    `compositeIsm rateLimited.recipient must not be set when deploying a new warp route for ${context}: it is resolved to the router address being deployed. Remove the recipient field.`,
+  );
+}
+
+const RECIPIENT_BYTES32_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+/**
+ * Validates and normalizes the protocol-independent address representation
+ * stored in a Hyperlane message recipient field. Protocol backends must encode
+ * native addresses before invoking contextual ISM resolution.
+ */
+function normalizeRecipientBytes32(address: string): string {
+  assert(
+    RECIPIENT_BYTES32_REGEX.test(address),
+    `Expected a 32-byte Hyperlane address, got ${address}`,
+  );
+  return address.toLowerCase();
+}
+
+export interface ContextualAddress {
+  readonly address: string;
+  readonly toBytes32: () => string;
+}
+
+function assertCompositeIsmNodeRecipientMatches(
+  node: CompositeIsmNodeArtifactConfig,
+  warpRouter: ContextualAddress,
+  context: string,
+): void {
+  switch (node.type) {
+    case CompositeIsmNodeType.AGGREGATION:
+      for (const subIsm of node.subIsms) {
+        assertCompositeIsmNodeRecipientMatches(subIsm, warpRouter, context);
+      }
+      return;
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
+      assertCompositeIsmNodeRecipientMatches(node.lower, warpRouter, context);
+      assertCompositeIsmNodeRecipientMatches(node.upper, warpRouter, context);
+      return;
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
+      if (!node.domains) return;
+      for (const domainIsm of Object.values(node.domains)) {
+        assertCompositeIsmNodeRecipientMatches(domainIsm, warpRouter, context);
+      }
+      return;
+    case CompositeIsmNodeType.RATE_LIMITED: {
+      const recipient = normalizeRecipientBytes32(warpRouter.toBytes32());
+      assert(
+        !isNullish(node.recipient),
+        `Deployed compositeIsm rateLimited.recipient is missing for ${context}.`,
+      );
+      assert(
+        normalizeRecipientBytes32(node.recipient) === recipient,
+        `Deployed compositeIsm rateLimited.recipient ${node.recipient} does not match the warp router it protects (${recipient}) for ${context}.`,
+      );
+      return;
+    }
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+    case CompositeIsmNodeType.TEST:
+    case CompositeIsmNodeType.PAUSABLE:
+      return;
+    default:
+      return assertNever(node, 'assertCompositeIsmNodeRecipientMatches');
+  }
+}
+
+function assertIsmConfigRecipientsMatch(
+  config: IsmArtifactConfig,
+  warpRouter: ContextualAddress,
+  context: string,
+): void {
+  switch (config.type) {
+    case IsmType.ROUTING:
+      for (const domainIsm of Object.values(config.domains)) {
+        if (!isArtifactUnderived(domainIsm)) {
+          assertIsmConfigRecipientsMatch(domainIsm.config, warpRouter, context);
+        }
+      }
+      return;
+    case IsmType.COMPOSITE:
+      assertCompositeIsmNodeRecipientMatches(config.root, warpRouter, context);
+      return;
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.TEST_ISM:
+      return;
+    default:
+      return assertNever(config, 'assertIsmConfigRecipientsMatch');
+  }
+}
+
+function assertNoNewIsmDescendants(
+  config: IsmArtifactConfig,
+  context: string,
+): void {
+  switch (config.type) {
+    case IsmType.ROUTING:
+      for (const [domainId, domainIsm] of Object.entries(config.domains)) {
+        assert(
+          !isArtifactNew(domainIsm),
+          `A DEPLOYED ISM used while creating ${context} cannot contain a NEW descendant for domain ${domainId}. Update the deployed ISM first, or configure the root ISM as NEW.`,
+        );
+        if (isArtifactDeployed(domainIsm)) {
+          assertNoNewIsmDescendants(domainIsm.config, context);
+        }
+      }
+      return;
+    case IsmType.COMPOSITE:
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.TEST_ISM:
+      return;
+    default:
+      return assertNever(config, 'assertNoNewIsmDescendants');
+  }
+}
+
+function resolveCompositeIsmNodeRecipients(
+  node: CompositeIsmNodeArtifactConfig,
+  recipient: string,
+  context: string,
+): CompositeIsmNodeArtifactConfig {
+  switch (node.type) {
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
+      return { type: node.type, relayer: node.relayer };
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+      return {
+        type: node.type,
+        validators: node.validators,
+        threshold: node.threshold,
+      };
+    case CompositeIsmNodeType.TEST:
+      return { type: node.type, accept: node.accept };
+    case CompositeIsmNodeType.PAUSABLE:
+      return { type: node.type, paused: node.paused };
+    case CompositeIsmNodeType.AGGREGATION:
+      return {
+        type: node.type,
+        threshold: node.threshold,
+        subIsms: node.subIsms.map((sub) =>
+          resolveCompositeIsmNodeRecipients(sub, recipient, context),
+        ),
+      };
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
+      return {
+        type: node.type,
+        threshold: node.threshold,
+        lower: resolveCompositeIsmNodeRecipients(
+          node.lower,
+          recipient,
+          context,
+        ),
+        upper: resolveCompositeIsmNodeRecipients(
+          node.upper,
+          recipient,
+          context,
+        ),
+      };
+    case CompositeIsmNodeType.RATE_LIMITED: {
+      if (!isNullish(node.recipient)) {
+        assert(
+          normalizeRecipientBytes32(node.recipient) === recipient,
+          `compositeIsm rateLimited.recipient ${node.recipient} does not match the warp router it protects (${recipient}) for ${context}. Remove the recipient field to have it resolved automatically.`,
+        );
+      }
+      return {
+        type: node.type,
+        maxCapacity: node.maxCapacity,
+        mailbox: node.mailbox,
+        recipient,
+      };
+    }
+    case CompositeIsmNodeType.ROUTING: {
+      const domains = resolveCompositeIsmDomainRecipients(
+        node.domains,
+        recipient,
+        context,
+      );
+      return {
+        type: node.type,
+        ...(domains ? { domains } : {}),
+      };
+    }
+    case CompositeIsmNodeType.FALLBACK_ROUTING: {
+      const domains = resolveCompositeIsmDomainRecipients(
+        node.domains,
+        recipient,
+        context,
+      );
+      return {
+        type: node.type,
+        fallbackIsm: node.fallbackIsm,
+        ...(domains ? { domains } : {}),
+      };
+    }
+    default:
+      return assertNever(node, 'resolveCompositeIsmNodeRecipients');
+  }
+}
+
+function resolveCompositeIsmDomainRecipients(
+  domains: Record<number, CompositeIsmNodeArtifactConfig> | undefined,
+  recipient: string,
+  context: string,
+): Record<number, CompositeIsmNodeArtifactConfig> | undefined {
+  if (!domains) return undefined;
+  const resolved: Record<number, CompositeIsmNodeArtifactConfig> = {};
+  for (const [domainIdStr, domainNode] of Object.entries(domains)) {
+    resolved[Number(domainIdStr)] = resolveCompositeIsmNodeRecipients(
+      domainNode,
+      recipient,
+      context,
+    );
+  }
+  return resolved;
+}
+
+function resolveIsmArtifactRecipients(
+  artifact: Artifact<IsmArtifactConfig, DeployedIsmAddress>,
+  warpRouter: ContextualAddress,
+  context: string,
+): Artifact<IsmArtifactConfig, DeployedIsmAddress> {
+  if (isArtifactUnderived(artifact)) return artifact;
+  return {
+    ...artifact,
+    config: resolveRateLimitedIsmRecipients(
+      artifact.config,
+      warpRouter,
+      context,
+    ),
+  };
+}
+
+function resolveNewIsmConfigRecipients(
+  config: IsmArtifactConfig,
+  warpRouter: ContextualAddress,
+  context: string,
+): IsmArtifactConfig {
+  if (config.type !== IsmType.ROUTING) {
+    return resolveRateLimitedIsmRecipients(config, warpRouter, context);
+  }
+
+  const domains: RoutingIsmArtifactConfig['domains'] = {};
+  for (const [domainId, domainIsm] of Object.entries(config.domains)) {
+    if (isArtifactUnderived(domainIsm)) {
+      domains[Number(domainId)] = domainIsm;
+    } else if (isArtifactDeployed(domainIsm)) {
+      assertIsmConfigRecipientsMatch(domainIsm.config, warpRouter, context);
+      domains[Number(domainId)] = domainIsm;
+    } else if (isArtifactNew(domainIsm)) {
+      domains[Number(domainId)] = {
+        ...domainIsm,
+        config: resolveNewIsmConfigRecipients(
+          domainIsm.config,
+          warpRouter,
+          context,
+        ),
+      };
+    } else {
+      domains[Number(domainId)] = assertNever(
+        domainIsm,
+        'resolveNewIsmConfigRecipients',
+      );
+    }
+  }
+  return { type: config.type, owner: config.owner, domains };
+}
+
+export const IsmArtifactResolutionOperation = {
+  CREATE: 'create',
+  UPDATE: 'update',
+} as const;
+
+export type IsmArtifactResolutionOperation =
+  (typeof IsmArtifactResolutionOperation)[keyof typeof IsmArtifactResolutionOperation];
+
+export interface IsmArtifactResolutionContext {
+  operation: IsmArtifactResolutionOperation;
+  warpRouter: ContextualAddress;
+  context: string;
+}
+
+/**
+ * Resolves an ISM artifact using its surrounding deployment context. Creating
+ * a parent artifact deploys only NEW descendants; DEPLOYED descendants are
+ * validated and preserved as references. Updating a DEPLOYED parent may update
+ * its expanded DEPLOYED descendants recursively.
+ */
+export function resolveIsmArtifact(
+  artifact: ArtifactNew<IsmArtifactConfig> | DeployedIsmArtifact,
+  resolutionContext: IsmArtifactResolutionContext,
+): ArtifactNew<IsmArtifactConfig> | DeployedIsmArtifact {
+  const { context, operation, warpRouter } = resolutionContext;
+  if (isArtifactNew(artifact)) {
+    return {
+      ...artifact,
+      config: resolveNewIsmConfigRecipients(
+        artifact.config,
+        warpRouter,
+        context,
+      ),
+    };
+  }
+  if (operation === IsmArtifactResolutionOperation.CREATE) {
+    assertNoNewIsmDescendants(artifact.config, context);
+    assertIsmConfigRecipientsMatch(artifact.config, warpRouter, context);
+    return artifact;
+  }
+  return {
+    ...artifact,
+    config: resolveRateLimitedIsmRecipients(
+      artifact.config,
+      warpRouter,
+      context,
+    ),
+  };
+}
+
+/**
+ * Fills in every unset `rateLimited.recipient` in a composite ISM tree with
+ * the warp router the ISM protects, and rejects any hand-written recipient
+ * that names a different address.
+ *
+ * The on-chain program requires a specific non-zero recipient
+ * (rust/sealevel/programs/ism/composite-ism/src/processor.rs) but a wrong one
+ * fails only at delivery time, indistinguishably from a rate-limit trip — so
+ * the value is derived here rather than left to the config author.
+ *
+ * Compound ISM artifacts are traversed recursively. UNDERIVED children are
+ * returned unchanged because an address-only artifact has no config to
+ * resolve. The exhaustive switch ensures future compound artifact types must
+ * declare their child traversal when they are added to IsmArtifactConfig.
+ */
+export function resolveRateLimitedIsmRecipients(
+  config: IsmArtifactConfig,
+  warpRouter: ContextualAddress,
+  context: string,
+): IsmArtifactConfig {
+  switch (config.type) {
+    case IsmType.ROUTING: {
+      const domains: RoutingIsmArtifactConfig['domains'] = {};
+      for (const [domainId, domainIsm] of Object.entries(config.domains)) {
+        domains[Number(domainId)] = resolveIsmArtifactRecipients(
+          domainIsm,
+          warpRouter,
+          context,
+        );
+      }
+      return { type: config.type, owner: config.owner, domains };
+    }
+    case IsmType.COMPOSITE: {
+      const recipient = normalizeRecipientBytes32(warpRouter.toBytes32());
+      return {
+        type: config.type,
+        owner: config.owner,
+        root: resolveCompositeIsmNodeRecipients(
+          config.root,
+          recipient,
+          context,
+        ),
+      };
+    }
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.TEST_ISM:
+      return config;
+    default:
+      return assertNever(config, 'resolveRateLimitedIsmRecipients');
+  }
+}
+
 export function ismArtifactToDerivedConfig(
   artifact: DeployedIsmArtifact,
   chainLookup: ChainLookup,
@@ -539,7 +1092,7 @@ export function ismArtifactToDerivedConfig(
   const address = artifact.deployed.address;
 
   switch (config.type) {
-    case 'domainRoutingIsm': {
+    case IsmType.ROUTING: {
       // For routing ISMs, convert domain IDs back to chain names
       // and convert nested artifacts to IsmConfig or address strings
       const domains: Record<string, IsmConfig | string> = {};
@@ -571,31 +1124,31 @@ export function ismArtifactToDerivedConfig(
       }
 
       return {
-        type: 'domainRoutingIsm',
+        type: IsmType.ROUTING,
         owner: config.owner,
         domains,
         address,
       };
     }
 
-    case 'merkleRootMultisigIsm':
-    case 'messageIdMultisigIsm':
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
       // Multisig ISMs have identical structure between Artifact and Config APIs
       return {
         ...config,
         address,
       };
 
-    case 'testIsm':
+    case IsmType.TEST_ISM:
       // Test ISMs have identical structure between Artifact and Config APIs
       return {
         ...config,
         address,
       };
 
-    case 'compositeIsm':
+    case IsmType.COMPOSITE:
       return {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: config.owner,
         root: compositeIsmNodeArtifactToConfig(config.root, chainLookup),
         address,
@@ -643,7 +1196,7 @@ export function ismConfigToArtifact(
   chainLookup: ChainLookup,
 ): ArtifactNew<IsmArtifactConfig> {
   // Handle routing ISMs - need to convert chain names to domain IDs
-  if (config.type === 'domainRoutingIsm') {
+  if (config.type === IsmType.ROUTING) {
     const domains: Record<
       number,
       Artifact<IsmArtifactConfig, DeployedIsmAddress>
@@ -674,7 +1227,7 @@ export function ismConfigToArtifact(
     return {
       artifactState: ArtifactState.NEW,
       config: {
-        type: 'domainRoutingIsm',
+        type: IsmType.ROUTING,
         owner: config.owner,
         domains,
       },
@@ -682,11 +1235,11 @@ export function ismConfigToArtifact(
   }
 
   // Composite ISM - need to convert chain names to domain IDs throughout the tree
-  if (config.type === 'compositeIsm') {
+  if (config.type === IsmType.COMPOSITE) {
     return {
       artifactState: ArtifactState.NEW,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: config.owner,
         root: compositeIsmNodeConfigToArtifact(config.root, chainLookup),
       },

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -209,8 +209,7 @@ export const testStarknetChain: ChainMetadata = {
 
 // Address of the ENS DAO TimelockController contract on Ethereum mainnet,
 // used for integration tests that exercise the block explorer path.
-// Chosen because Base's Blockscout `getcontractcreation` endpoint has been
-// observed to hang in CI, while eth.blockscout.com is reliable.
+// Chosen because Routescan exposes both logs and contract creation data.
 export const KNOWN_ETHEREUM_TIMELOCK_CONTRACT =
   '0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7';
 
@@ -218,10 +217,10 @@ export const KNOWN_ETHEREUM_TIMELOCK_CONTRACT =
 export const ethereumTestChain: ChainMetadata = {
   blockExplorers: [
     {
-      apiUrl: 'https://eth.blockscout.com/api',
-      family: ExplorerFamily.Blockscout,
+      apiUrl: 'https://api.routescan.io/v2/network/mainnet/evm/1/etherscan/api',
+      family: ExplorerFamily.Routescan,
       name: 'Ethereum Explorer',
-      url: 'https://eth.blockscout.com',
+      url: 'https://routescan.io',
     },
   ],
   blocks: { confirmations: 3, estimateBlockTime: 12, reorgPeriod: 14 },

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -237,7 +237,6 @@ export const ethereumTestChain: ChainMetadata = {
   },
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
-    { http: 'https://rpc.mevblocker.io' },
     { http: 'https://ethereum-rpc.publicnode.com' },
     { http: 'https://eth.llamarpc.com' },
     { http: 'https://1rpc.io/eth' },

--- a/typescript/sdk/src/consts/testChains.ts
+++ b/typescript/sdk/src/consts/testChains.ts
@@ -237,6 +237,7 @@ export const ethereumTestChain: ChainMetadata = {
   },
   protocol: ProtocolType.Ethereum,
   rpcUrls: [
+    { http: 'https://rpc.mevblocker.io' },
     { http: 'https://ethereum-rpc.publicnode.com' },
     { http: 'https://eth.llamarpc.com' },
     { http: 'https://1rpc.io/eth' },

--- a/typescript/sdk/src/core/types.test.ts
+++ b/typescript/sdk/src/core/types.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { HookType, IgpVersion } from '../hook/types.js';
-import { IsmType } from '../ism/types.js';
+import { CompositeIsmNodeType, IsmType } from '../ism/types.js';
 
 import { CoreConfigSchema } from './types.js';
 
@@ -89,6 +89,132 @@ describe('CoreConfigSchema warp-only default ISM guard', () => {
     const result = CoreConfigSchema.safeParse(
       baseConfig({
         defaultIsm: { type: IsmType.TRUSTED_RELAYER, relayer: ADDRESS },
+      }),
+    );
+    expect(result.success).to.be.true;
+  });
+});
+
+describe('CoreConfigSchema rate-limited default ISM guard', () => {
+  // Composite ISM wire fields are base58 Sealevel pubkeys, unlike the
+  // EVM-style ADDRESS used everywhere else in this file.
+  const SEALEVEL_ADDRESS = '9bRSUPjfS3xS6n5EfkJzHFTRDa4AHLda8BU2pP4HoWnf';
+
+  const compositeIsm = (root: Record<string, unknown>) => ({
+    type: IsmType.COMPOSITE,
+    owner: SEALEVEL_ADDRESS,
+    root,
+  });
+
+  const rateLimitedNode = {
+    type: CompositeIsmNodeType.RATE_LIMITED,
+    maxCapacity: '86400',
+    mailbox: SEALEVEL_ADDRESS,
+  };
+
+  const trustedRelayerNode = {
+    type: CompositeIsmNodeType.TRUSTED_RELAYER,
+    relayer: SEALEVEL_ADDRESS,
+  };
+
+  // Empty for a successful parse, so asserting a message is present covers
+  // both "must be rejected" and "must be rejected for this reason".
+  const parseIssues = (defaultIsm: unknown): string[] => {
+    const result = CoreConfigSchema.safeParse(baseConfig({ defaultIsm }));
+    return result.success ? [] : result.error.issues.map((i) => i.message);
+  };
+
+  const RATE_LIMITED_ISM_MESSAGE =
+    'RateLimitedIsm cannot be used as a core default ISM';
+  const COMPOSITE_MESSAGE =
+    "A compositeIsm 'rateLimited' node cannot be used in a core default ISM";
+
+  it('rejects a rateLimitedIsm as the core default ISM', () => {
+    expect(
+      parseIssues({ type: IsmType.RATE_LIMITED, maxCapacity: '86400' }),
+    ).to.include(RATE_LIMITED_ISM_MESSAGE);
+  });
+
+  it('rejects a rateLimitedIsm nested in an aggregation', () => {
+    expect(
+      parseIssues({
+        type: IsmType.AGGREGATION,
+        threshold: 1,
+        modules: [{ type: IsmType.RATE_LIMITED, maxCapacity: '86400' }],
+      }),
+    ).to.include(RATE_LIMITED_ISM_MESSAGE);
+  });
+
+  interface CompositeCase {
+    name: string;
+    root: Record<string, unknown>;
+  }
+
+  const compositeCases: CompositeCase[] = [
+    { name: 'at the tree root', root: rateLimitedNode },
+    {
+      name: 'inside aggregation.subIsms',
+      root: {
+        type: CompositeIsmNodeType.AGGREGATION,
+        threshold: 1,
+        subIsms: [trustedRelayerNode, rateLimitedNode],
+      },
+    },
+    {
+      name: 'inside amountRouting.upper',
+      root: {
+        type: CompositeIsmNodeType.AMOUNT_ROUTING,
+        threshold: '1000000',
+        lower: trustedRelayerNode,
+        upper: rateLimitedNode,
+      },
+    },
+    {
+      name: 'inside a routing domain override',
+      root: {
+        type: CompositeIsmNodeType.ROUTING,
+        domains: { ethereum: rateLimitedNode },
+      },
+    },
+    {
+      name: 'inside a fallbackRouting domain override',
+      root: {
+        type: CompositeIsmNodeType.FALLBACK_ROUTING,
+        fallbackIsm: SEALEVEL_ADDRESS,
+        domains: { ethereum: rateLimitedNode },
+      },
+    },
+  ];
+
+  for (const compositeCase of compositeCases) {
+    it(`rejects a compositeIsm rateLimited node ${compositeCase.name}`, () => {
+      expect(parseIssues(compositeIsm(compositeCase.root))).to.include(
+        COMPOSITE_MESSAGE,
+      );
+    });
+  }
+
+  it('rejects a compositeIsm rateLimited node behind a routing ISM domain', () => {
+    expect(
+      parseIssues({
+        type: IsmType.ROUTING,
+        owner: ADDRESS,
+        domains: { ethereum: compositeIsm(rateLimitedNode) },
+      }),
+    ).to.include(COMPOSITE_MESSAGE);
+  });
+
+  it('still accepts a compositeIsm without a rateLimited node', () => {
+    const result = CoreConfigSchema.safeParse(
+      baseConfig({
+        defaultIsm: compositeIsm({
+          type: CompositeIsmNodeType.AGGREGATION,
+          threshold: 1,
+          subIsms: [
+            trustedRelayerNode,
+            { type: CompositeIsmNodeType.TEST, accept: true },
+          ],
+        }),
       }),
     );
     expect(result.success).to.be.true;

--- a/typescript/sdk/src/core/types.ts
+++ b/typescript/sdk/src/core/types.ts
@@ -18,6 +18,7 @@ import { IsmConfigSchema } from '../ism/types.js';
 import type { ChainName } from '../types.js';
 import { DeployedOwnableSchema, OwnableSchema } from '../types.js';
 import {
+  ismTreeContainsCompositeRateLimited,
   ismTreeContainsMailboxDefaultOrHybrid,
   ismTreeContainsRateLimited,
 } from '../utils/ism.js';
@@ -45,7 +46,7 @@ const CoreConfigBaseSchema = OwnableSchema.extend({
  * and meter its flow, which is meaningless for chain-wide default verification.
  */
 const rejectWarpOnlyDefaultIsm = (
-  val: { defaultIsm: unknown },
+  val: { defaultIsm: IsmConfig },
   ctx: z.RefinementCtx,
 ) => {
   if (ismTreeContainsMailboxDefaultOrHybrid(val.defaultIsm)) {
@@ -58,14 +59,28 @@ const rejectWarpOnlyDefaultIsm = (
   }
 };
 
+/**
+ * Rate limiting meters an amount read from a fixed offset of the message
+ * body, which only holds for warp-route traffic, whereas a default ISM sees
+ * every message. Both spellings are rejected: the EVM `rateLimitedIsm` and a
+ * `rateLimited` node inside a Sealevel `compositeIsm` tree.
+ */
 const rejectRateLimitedDefaultIsm = (
-  val: { defaultIsm: unknown },
+  val: { defaultIsm: IsmConfig },
   ctx: z.RefinementCtx,
 ) => {
   if (ismTreeContainsRateLimited(val.defaultIsm)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: 'RateLimitedIsm cannot be used as a core default ISM',
+      path: ['defaultIsm'],
+    });
+  }
+  if (ismTreeContainsCompositeRateLimited(val.defaultIsm)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "A compositeIsm 'rateLimited' node cannot be used in a core default ISM",
       path: ['defaultIsm'],
     });
   }

--- a/typescript/sdk/src/deploy/warp.ts
+++ b/typescript/sdk/src/deploy/warp.ts
@@ -7,7 +7,6 @@ import {
 import { buildArtifact as coreBuildArtifact } from '@hyperlane-xyz/core/buildArtifact.js';
 import {
   createHookWriter,
-  createIsmWriter,
   createWarpTokenWriter,
   validateIsmConfig,
 } from '@hyperlane-xyz/deploy-sdk';
@@ -19,10 +18,7 @@ import {
   HookConfig as ProviderHookConfig,
   hookConfigToArtifact,
 } from '@hyperlane-xyz/provider-sdk/hook';
-import {
-  IsmConfig as ProviderIsmConfig,
-  ismConfigToArtifact,
-} from '@hyperlane-xyz/provider-sdk/ism';
+import { IsmConfig as ProviderIsmConfig } from '@hyperlane-xyz/provider-sdk/ism';
 import { AnnotatedTx, TxReceipt } from '@hyperlane-xyz/provider-sdk/module';
 import {
   CollateralWarpConfig,
@@ -1101,16 +1097,18 @@ async function resolveWarpIsmAndHook(
         };
       }
 
-      const ism = await createWarpIsm({
-        ccipContractCache,
-        chain,
-        chainAddresses,
-        multiProvider,
-        altVmSigners,
-        contractVerifier,
-        ismFactoryDeployer,
-        warpConfig: config,
-      }); // TODO write test
+      const protocol = multiProvider.getProtocol(chain);
+      const ism =
+        protocol === ProtocolType.Ethereum || protocol === ProtocolType.Tron
+          ? await createWarpIsm({
+              ccipContractCache,
+              chain,
+              chainAddresses,
+              multiProvider,
+              contractVerifier,
+              warpConfig: config,
+            })
+          : config.interchainSecurityModule;
 
       const hook = await createWarpHook({
         ccipContractCache,
@@ -1146,7 +1144,6 @@ async function createWarpIsm({
   chain,
   chainAddresses,
   multiProvider,
-  altVmSigners,
   contractVerifier,
   warpConfig,
 }: {
@@ -1154,10 +1151,8 @@ async function createWarpIsm({
   chain: string;
   chainAddresses: Record<string, string>;
   multiProvider: MultiProvider;
-  altVmSigners: ChainMap<AltVM.ISigner<AnnotatedTx, TxReceipt>>;
   contractVerifier?: ContractVerifier;
   warpConfig: HypTokenRouterConfig;
-  ismFactoryDeployer: HyperlaneProxyFactoryDeployer;
 }): Promise<IsmConfig | undefined> {
   const { interchainSecurityModule } = warpConfig;
   if (
@@ -1195,38 +1190,22 @@ async function createWarpIsm({
     `Finished creating ${interchainSecurityModule.type} ISM for token on ${chain} chain.`,
   );
 
-  const protocolType = multiProvider.getProtocol(chain);
-
-  switch (protocolType) {
-    case ProtocolType.Tron:
-    case ProtocolType.Ethereum: {
-      const evmIsmModule = await EvmIsmModule.create({
-        chain,
-        mailbox: chainAddresses.mailbox,
-        multiProvider: multiProvider,
-        proxyFactoryFactories:
-          extractIsmAndHookFactoryAddresses(chainAddresses),
-        config: interchainSecurityModule,
-        ccipContractCache,
-        contractVerifier,
-      });
-      const { deployedIsm } = evmIsmModule.serialize();
-      return deployedIsm;
-    }
-    default: {
-      const signer = mustGet(altVmSigners, chain);
-      const chainLookup = altVmChainLookup(multiProvider);
-      const chainMetadata = chainLookup.getChainMetadata(chain);
-      const writer = createIsmWriter(chainMetadata, chainLookup, signer);
-      const artifact = ismConfigToArtifact(
-        // FIXME: not all ISM types are supported yet
-        interchainSecurityModule as ProviderIsmConfig,
-        chainLookup,
-      );
-      const [deployed] = await writer.create(artifact);
-      return deployed.deployed.address;
-    }
-  }
+  const protocol = multiProvider.getProtocol(chain);
+  assert(
+    protocol === ProtocolType.Ethereum || protocol === ProtocolType.Tron,
+    `Expected an Ethereum or Tron chain, got ${protocol} for ${chain}`,
+  );
+  const evmIsmModule = await EvmIsmModule.create({
+    chain,
+    mailbox: chainAddresses.mailbox,
+    multiProvider,
+    proxyFactoryFactories: extractIsmAndHookFactoryAddresses(chainAddresses),
+    config: interchainSecurityModule,
+    ccipContractCache,
+    contractVerifier,
+  });
+  const { deployedIsm } = evmIsmModule.serialize();
+  return deployedIsm;
 }
 
 async function createWarpHook({

--- a/typescript/sdk/src/ism/types.test.ts
+++ b/typescript/sdk/src/ism/types.test.ts
@@ -10,6 +10,7 @@ import {
   BlacklistIsmConfigSchema,
   type CompositeIsmConfig,
   CompositeIsmConfigSchema,
+  CompositeIsmNodeType,
   DelayedFlowRouterHookIsmConfigSchema,
   IsmConfigSchema,
   IsmType,
@@ -585,22 +586,25 @@ describe('CompositeIsmConfigSchema', () => {
     type: IsmType.COMPOSITE,
     owner: SEALEVEL_ADDRESS,
     root: {
-      type: 'aggregation',
+      type: CompositeIsmNodeType.AGGREGATION,
       threshold: 2,
       subIsms: [
-        { type: 'trustedRelayer', relayer: SEALEVEL_ADDRESS },
         {
-          type: 'routing',
+          type: CompositeIsmNodeType.TRUSTED_RELAYER,
+          relayer: SEALEVEL_ADDRESS,
+        },
+        {
+          type: CompositeIsmNodeType.ROUTING,
           domains: {
-            solanamainnet: { type: 'test', accept: true },
+            solanamainnet: { type: CompositeIsmNodeType.TEST, accept: true },
           },
         },
         {
-          type: 'amountRouting',
+          type: CompositeIsmNodeType.AMOUNT_ROUTING,
           threshold: '1000000',
-          lower: { type: 'pausable', paused: false },
+          lower: { type: CompositeIsmNodeType.PAUSABLE, paused: false },
           upper: {
-            type: 'rateLimited',
+            type: CompositeIsmNodeType.RATE_LIMITED,
             maxCapacity: '86400',
             mailbox: SEALEVEL_ADDRESS,
             recipient: H256_ADDRESS,
@@ -624,7 +628,7 @@ describe('CompositeIsmConfigSchema', () => {
       result.data !== null &&
       'type' in result.data
     ) {
-      expect(result.data.type).to.equal('compositeIsm');
+      expect(result.data.type).to.equal(IsmType.COMPOSITE);
     }
   });
 
@@ -640,9 +644,14 @@ describe('CompositeIsmConfigSchema', () => {
     const tooHigh = {
       ...sample,
       root: {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: 5,
-        subIsms: [{ type: 'trustedRelayer', relayer: SEALEVEL_ADDRESS }],
+        subIsms: [
+          {
+            type: CompositeIsmNodeType.TRUSTED_RELAYER,
+            relayer: SEALEVEL_ADDRESS,
+          },
+        ],
       },
     };
     expect(CompositeIsmConfigSchema.safeParse(tooHigh).success).to.be.false;
@@ -650,9 +659,14 @@ describe('CompositeIsmConfigSchema', () => {
     const tooLow = {
       ...sample,
       root: {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: 0,
-        subIsms: [{ type: 'trustedRelayer', relayer: SEALEVEL_ADDRESS }],
+        subIsms: [
+          {
+            type: CompositeIsmNodeType.TRUSTED_RELAYER,
+            relayer: SEALEVEL_ADDRESS,
+          },
+        ],
       },
     };
     expect(CompositeIsmConfigSchema.safeParse(tooLow).success).to.be.false;
@@ -662,7 +676,7 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'multisigMessageId',
+        type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         threshold: 1,
         validators: [SOME_ADDRESS, '0x' + SOME_ADDRESS.slice(2).toUpperCase()],
       },
@@ -674,7 +688,7 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'multisigMessageId',
+        type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         threshold: 3,
         validators: [SOME_ADDRESS, OTHER_ADDRESS],
       },
@@ -686,7 +700,7 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'multisigMessageId',
+        type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         threshold: 1.5,
         validators: [SOME_ADDRESS, OTHER_ADDRESS],
       },
@@ -698,7 +712,7 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'multisigMessageId',
+        type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         threshold: 1,
         validators: [SEALEVEL_ADDRESS],
       },
@@ -706,11 +720,11 @@ describe('CompositeIsmConfigSchema', () => {
     expect(CompositeIsmConfigSchema.safeParse(invalid).success).to.be.false;
   });
 
-  it('rejects a rateLimited node with a zero mailbox or missing/zero recipient', () => {
+  it('rejects a rateLimited node with a zero mailbox or zero recipient', () => {
     const zeroMailbox = {
       ...sample,
       root: {
-        type: 'rateLimited',
+        type: CompositeIsmNodeType.RATE_LIMITED,
         maxCapacity: '86400',
         mailbox: SEALEVEL_ZERO_ADDRESS,
         recipient: H256_ADDRESS,
@@ -718,21 +732,10 @@ describe('CompositeIsmConfigSchema', () => {
     };
     expect(CompositeIsmConfigSchema.safeParse(zeroMailbox).success).to.be.false;
 
-    const missingRecipient = {
-      ...sample,
-      root: {
-        type: 'rateLimited',
-        maxCapacity: '86400',
-        mailbox: SEALEVEL_ADDRESS,
-      },
-    };
-    expect(CompositeIsmConfigSchema.safeParse(missingRecipient).success).to.be
-      .false;
-
     const zeroRecipient = {
       ...sample,
       root: {
-        type: 'rateLimited',
+        type: CompositeIsmNodeType.RATE_LIMITED,
         maxCapacity: '86400',
         mailbox: SEALEVEL_ADDRESS,
         recipient: H256_ZERO,
@@ -742,11 +745,42 @@ describe('CompositeIsmConfigSchema', () => {
       .false;
   });
 
+  it('accepts a rateLimited node with an omitted recipient', () => {
+    const omittedRecipient = {
+      ...sample,
+      root: {
+        type: CompositeIsmNodeType.RATE_LIMITED,
+        maxCapacity: '86400',
+        mailbox: SEALEVEL_ADDRESS,
+      },
+    };
+    expect(CompositeIsmConfigSchema.safeParse(omittedRecipient).success).to.be
+      .true;
+  });
+
+  it('accepts a rateLimited node nested under a routing domain with an omitted recipient', () => {
+    const omittedRecipient = {
+      ...sample,
+      root: {
+        type: CompositeIsmNodeType.ROUTING,
+        domains: {
+          ethereum: {
+            type: CompositeIsmNodeType.RATE_LIMITED,
+            maxCapacity: '86400',
+            mailbox: SEALEVEL_ADDRESS,
+          },
+        },
+      },
+    };
+    expect(CompositeIsmConfigSchema.safeParse(omittedRecipient).success).to.be
+      .true;
+  });
+
   it('rejects a rateLimited node with maxCapacity above u64::MAX', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'rateLimited',
+        type: CompositeIsmNodeType.RATE_LIMITED,
         maxCapacity: (2n ** 64n).toString(),
         mailbox: SEALEVEL_ADDRESS,
         recipient: H256_ADDRESS,
@@ -759,10 +793,10 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'amountRouting',
+        type: CompositeIsmNodeType.AMOUNT_ROUTING,
         threshold: (2n ** 256n).toString(),
-        lower: { type: 'test', accept: true },
-        upper: { type: 'test', accept: false },
+        lower: { type: CompositeIsmNodeType.TEST, accept: true },
+        upper: { type: CompositeIsmNodeType.TEST, accept: false },
       },
     };
     expect(CompositeIsmConfigSchema.safeParse(invalid).success).to.be.false;
@@ -773,7 +807,7 @@ describe('CompositeIsmConfigSchema', () => {
       const invalid = {
         ...sample,
         root: {
-          type: 'rateLimited',
+          type: CompositeIsmNodeType.RATE_LIMITED,
           maxCapacity: badValue,
           mailbox: SEALEVEL_ADDRESS,
           recipient: H256_ADDRESS,
@@ -795,7 +829,7 @@ describe('CompositeIsmConfigSchema', () => {
     const invalidMultisig = {
       ...sample,
       root: {
-        type: 'multisigMessageId',
+        type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         threshold: 256,
         validators,
       },
@@ -806,9 +840,14 @@ describe('CompositeIsmConfigSchema', () => {
     const invalidAggregation = {
       ...sample,
       root: {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: 256,
-        subIsms: [{ type: 'trustedRelayer', relayer: SEALEVEL_ADDRESS }],
+        subIsms: [
+          {
+            type: CompositeIsmNodeType.TRUSTED_RELAYER,
+            relayer: SEALEVEL_ADDRESS,
+          },
+        ],
       },
     };
     expect(CompositeIsmConfigSchema.safeParse(invalidAggregation).success).to.be
@@ -818,7 +857,10 @@ describe('CompositeIsmConfigSchema', () => {
   it('rejects a trustedRelayer node with a zero relayer', () => {
     const invalid = {
       ...sample,
-      root: { type: 'trustedRelayer', relayer: SEALEVEL_ZERO_ADDRESS },
+      root: {
+        type: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: SEALEVEL_ZERO_ADDRESS,
+      },
     };
     expect(CompositeIsmConfigSchema.safeParse(invalid).success).to.be.false;
   });
@@ -826,7 +868,10 @@ describe('CompositeIsmConfigSchema', () => {
   it('rejects a trustedRelayer node with an EVM-style hex relayer', () => {
     const invalid = {
       ...sample,
-      root: { type: 'trustedRelayer', relayer: SOME_ADDRESS },
+      root: {
+        type: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: SOME_ADDRESS,
+      },
     };
     expect(CompositeIsmConfigSchema.safeParse(invalid).success).to.be.false;
   });
@@ -836,14 +881,20 @@ describe('CompositeIsmConfigSchema', () => {
     // range, but neither actually decodes to a 32-byte public key.
     const wrongAlphabetDensity = {
       ...sample,
-      root: { type: 'trustedRelayer', relayer: 'z'.repeat(32) },
+      root: {
+        type: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: 'z'.repeat(32),
+      },
     };
     expect(CompositeIsmConfigSchema.safeParse(wrongAlphabetDensity).success).to
       .be.false;
 
     const wrongWidth = {
       ...sample,
-      root: { type: 'trustedRelayer', relayer: '1'.repeat(33) },
+      root: {
+        type: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: '1'.repeat(33),
+      },
     };
     expect(CompositeIsmConfigSchema.safeParse(wrongWidth).success).to.be.false;
   });
@@ -852,12 +903,12 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: 1,
         subIsms: [
-          { type: 'routing', domains: {} },
+          { type: CompositeIsmNodeType.ROUTING, domains: {} },
           {
-            type: 'fallbackRouting',
+            type: CompositeIsmNodeType.FALLBACK_ROUTING,
             fallbackIsm: SEALEVEL_ADDRESS,
             domains: {},
           },
@@ -871,7 +922,7 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'fallbackRouting',
+        type: CompositeIsmNodeType.FALLBACK_ROUTING,
         fallbackIsm: SEALEVEL_ZERO_ADDRESS,
         domains: {},
       },
@@ -883,15 +934,18 @@ describe('CompositeIsmConfigSchema', () => {
     const invalid = {
       ...sample,
       root: {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: 2,
         subIsms: [
           {
-            type: 'fallbackRouting',
+            type: CompositeIsmNodeType.FALLBACK_ROUTING,
             fallbackIsm: SEALEVEL_ADDRESS,
             domains: {},
           },
-          { type: 'trustedRelayer', relayer: SEALEVEL_ADDRESS },
+          {
+            type: CompositeIsmNodeType.TRUSTED_RELAYER,
+            relayer: SEALEVEL_ADDRESS,
+          },
         ],
       },
     };
@@ -902,8 +956,10 @@ describe('CompositeIsmConfigSchema', () => {
     const nestedRouting = {
       ...sample,
       root: {
-        type: 'routing',
-        domains: { ethereum: { type: 'routing', domains: {} } },
+        type: CompositeIsmNodeType.ROUTING,
+        domains: {
+          ethereum: { type: CompositeIsmNodeType.ROUTING, domains: {} },
+        },
       },
     };
     expect(CompositeIsmConfigSchema.safeParse(nestedRouting).success).to.be
@@ -912,10 +968,10 @@ describe('CompositeIsmConfigSchema', () => {
     const nestedFallbackRouting = {
       ...sample,
       root: {
-        type: 'routing',
+        type: CompositeIsmNodeType.ROUTING,
         domains: {
           ethereum: {
-            type: 'fallbackRouting',
+            type: CompositeIsmNodeType.FALLBACK_ROUTING,
             fallbackIsm: SEALEVEL_ADDRESS,
             domains: {},
           },
@@ -928,8 +984,10 @@ describe('CompositeIsmConfigSchema', () => {
     const nestedPausable = {
       ...sample,
       root: {
-        type: 'routing',
-        domains: { ethereum: { type: 'pausable', paused: false } },
+        type: CompositeIsmNodeType.ROUTING,
+        domains: {
+          ethereum: { type: CompositeIsmNodeType.PAUSABLE, paused: false },
+        },
       },
     };
     expect(CompositeIsmConfigSchema.safeParse(nestedPausable).success).to.be
@@ -940,10 +998,10 @@ describe('CompositeIsmConfigSchema', () => {
     const valid = {
       ...sample,
       root: {
-        type: 'routing',
+        type: CompositeIsmNodeType.ROUTING,
         domains: {
           ethereum: {
-            type: 'multisigMessageId',
+            type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
             validators: [SOME_ADDRESS, OTHER_ADDRESS],
             threshold: 1,
           },
@@ -956,7 +1014,10 @@ describe('CompositeIsmConfigSchema', () => {
   it('accepts a second, distinct base58 pubkey for trustedRelayer', () => {
     const valid = {
       ...sample,
-      root: { type: 'trustedRelayer', relayer: OTHER_SEALEVEL_ADDRESS },
+      root: {
+        type: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: OTHER_SEALEVEL_ADDRESS,
+      },
     };
     expect(CompositeIsmConfigSchema.safeParse(valid).success).to.be.true;
   });

--- a/typescript/sdk/src/ism/types.ts
+++ b/typescript/sdk/src/ism/types.ts
@@ -704,6 +704,13 @@ export interface CompositeAmountRoutingNodeConfig {
   lower: CompositeIsmNodeConfig;
   upper: CompositeIsmNodeConfig;
 }
+/**
+ * Token-bucket node. Only supported inside a warp route's ISM: it meters an
+ * amount read from a fixed offset of the message body, so it is meaningless
+ * against non-warp traffic. `recipient` is the warp router the ISM protects,
+ * resolved by the deploy/apply tooling; supply it only when reproducing the
+ * output of `warp read`.
+ */
 export interface CompositeRateLimitedNodeConfig {
   type: typeof CompositeIsmNodeType.RATE_LIMITED;
   maxCapacity: string;
@@ -883,8 +890,11 @@ function validateCompositeIsmTree(
       if (isEmptyAddress(node.mailbox)) {
         addIssue('mailbox must be a non-zero address', [...path, 'mailbox']);
       }
-      if (!node.recipient || isEmptyAddress(node.recipient)) {
-        addIssue('recipient is required and must be a non-zero address', [
+      // Absence is legal: the deploy/apply tooling resolves recipient from
+      // the warp router the ISM protects. A written-out value only ever comes
+      // from round-tripping `warp read` output, and must still be non-zero.
+      if (node.recipient && isEmptyAddress(node.recipient)) {
+        addIssue('recipient must be a non-zero address', [
           ...path,
           'recipient',
         ]);

--- a/typescript/sdk/src/utils/ism.test.ts
+++ b/typescript/sdk/src/utils/ism.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'ethers';
 
 import { test1, test2, test3 } from '../consts/testChains.js';
-import { IsmConfig, IsmType } from '../ism/types.js';
+import { CompositeIsmNodeType, IsmConfig, IsmType } from '../ism/types.js';
 import { ChainMetadata } from '../metadata/chainMetadataTypes.js';
 import { MultiProvider } from '../providers/MultiProvider.js';
 
@@ -12,7 +12,10 @@ import {
   canonicalizeRemoteIsms,
   collectHybridIsmNodes,
   completeHybridIsmNodes,
+  ismTreeContainsCompositeRateLimited,
   ismTreeContainsHybridHookIsm,
+  ismTreeContainsMailboxDefaultOrHybrid,
+  ismTreeContainsRateLimited,
   prepareHybridIsmNodesForDeploy,
   resolveDelayedFlowRemoteIsms,
 } from './ism.js';
@@ -70,6 +73,73 @@ function aggregationOf(...modules: IsmConfig[]): IsmConfig {
     modules,
   };
 }
+
+describe('typed ISM tree traversal', () => {
+  it('finds EVM rate limiting through SDK containers only', () => {
+    const tree: IsmConfig = {
+      type: IsmType.AMOUNT_ROUTING,
+      threshold: 1,
+      lowerIsm: { type: IsmType.TEST_ISM },
+      upperIsm: aggregationOf({
+        type: IsmType.ROUTING,
+        owner: OWNER,
+        domains: {
+          test2: {
+            type: IsmType.RATE_LIMITED,
+            maxCapacity: '86400',
+            duration: 86400n,
+          },
+        },
+      }),
+    };
+
+    expect(ismTreeContainsRateLimited(tree)).to.be.true;
+    expect(ismTreeContainsCompositeRateLimited(tree)).to.be.false;
+  });
+
+  it('finds composite rate limiting through both container unions', () => {
+    const tree = aggregationOf({
+      type: IsmType.ROUTING,
+      owner: OWNER,
+      domains: {
+        test2: {
+          type: IsmType.COMPOSITE,
+          owner: OWNER,
+          root: {
+            type: CompositeIsmNodeType.AMOUNT_ROUTING,
+            threshold: '1',
+            lower: { type: CompositeIsmNodeType.TEST, accept: true },
+            upper: {
+              type: CompositeIsmNodeType.ROUTING,
+              domains: {
+                test3: {
+                  type: CompositeIsmNodeType.RATE_LIMITED,
+                  maxCapacity: '86400',
+                  mailbox: WARP_ROUTER,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ismTreeContainsRateLimited(tree)).to.be.false;
+    expect(ismTreeContainsCompositeRateLimited(tree)).to.be.true;
+  });
+
+  it('finds mailbox-incompatible ISMs through SDK containers', () => {
+    const tree: IsmConfig = {
+      type: IsmType.ROUTING,
+      owner: OWNER,
+      domains: {
+        test2: aggregationOf({ type: IsmType.MAILBOX_DEFAULT }),
+      },
+    };
+
+    expect(ismTreeContainsMailboxDefaultOrHybrid(tree)).to.be.true;
+  });
+});
 
 describe('hybrid hook/ISM tree helpers', () => {
   describe('ismTreeContainsHybridHookIsm', () => {

--- a/typescript/sdk/src/utils/ism.ts
+++ b/typescript/sdk/src/utils/ism.ts
@@ -12,6 +12,8 @@ import {
 import { multisigIsmVerifyCosts } from '../consts/multisigIsmVerifyCosts.js';
 import { TokenType } from '../token/config.js';
 import {
+  CompositeIsmNodeConfig,
+  CompositeIsmNodeType,
   DelayedFlowRouterHookIsmConfig,
   IsmConfig,
   IsmType,
@@ -26,29 +28,117 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+type IsmConfigNode = Exclude<IsmConfig, Address>;
+type IsmTreeNode = IsmConfigNode | CompositeIsmNodeConfig;
+
+/** True if any node of a compositeIsm tree satisfies `matches`. */
+function compositeIsmNodeSome(
+  node: CompositeIsmNodeConfig,
+  matches: (node: IsmTreeNode) => boolean,
+): boolean {
+  if (matches(node)) return true;
+  switch (node.type) {
+    case CompositeIsmNodeType.AGGREGATION:
+      return node.subIsms.some((subIsm) =>
+        compositeIsmNodeSome(subIsm, matches),
+      );
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
+      return (
+        compositeIsmNodeSome(node.lower, matches) ||
+        compositeIsmNodeSome(node.upper, matches)
+      );
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
+      return Object.values(node.domains ?? {}).some((domainNode) =>
+        compositeIsmNodeSome(domainNode, matches),
+      );
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+    case CompositeIsmNodeType.TEST:
+    case CompositeIsmNodeType.PAUSABLE:
+    case CompositeIsmNodeType.RATE_LIMITED:
+      return false;
+    default: {
+      const exhaustiveCheck: never = node;
+      return exhaustiveCheck;
+    }
+  }
+}
+
 /**
- * Extracts the ISM and Hook factory addresses from chain-specific registry addresses
- * @param registryAddresses The registry addresses for a specific chain
- * @returns The extracted ISM and Hook factory addresses
+ * True if any typed node in an ISM tree satisfies `matches`.
+ * Both switches are exhaustive so new container types must define traversal.
  */
-export function ismTreeContainsRateLimited(ism: unknown): boolean {
-  if (typeof ism !== 'object' || ism === null) return false;
-  const node = ism as Record<string, unknown>;
-  if (node.type === IsmType.RATE_LIMITED) return true;
-  if (Array.isArray(node.modules)) {
-    if (node.modules.some(ismTreeContainsRateLimited)) return true;
+function ismTreeSome(
+  ism: IsmConfig,
+  matches: (node: IsmTreeNode) => boolean,
+): boolean {
+  if (typeof ism === 'string') return false;
+  if (matches(ism)) return true;
+
+  switch (ism.type) {
+    case IsmType.AGGREGATION:
+    case IsmType.STORAGE_AGGREGATION:
+      return ism.modules.some((module) => ismTreeSome(module, matches));
+    case IsmType.ROUTING:
+    case IsmType.FALLBACK_ROUTING:
+    case IsmType.INCREMENTAL_ROUTING:
+      return Object.values(ism.domains).some((domainIsm) =>
+        ismTreeSome(domainIsm, matches),
+      );
+    case IsmType.AMOUNT_ROUTING:
+      return (
+        ismTreeSome(ism.lowerIsm, matches) || ismTreeSome(ism.upperIsm, matches)
+      );
+    case IsmType.COMPOSITE:
+      return compositeIsmNodeSome(ism.root, matches);
+    case IsmType.TEST_ISM:
+    case IsmType.OP_STACK:
+    case IsmType.PAUSABLE:
+    case IsmType.TRUSTED_RELAYER:
+    case IsmType.CCIP:
+    case IsmType.RATE_LIMITED:
+    case IsmType.BLACKLIST:
+    case IsmType.NET_FLOW_RATE_LIMITED:
+    case IsmType.DELAYED_FLOW_ROUTER:
+    case IsmType.MAILBOX_DEFAULT:
+    case IsmType.MERKLE_ROOT_MULTISIG:
+    case IsmType.MESSAGE_ID_MULTISIG:
+    case IsmType.STORAGE_MERKLE_ROOT_MULTISIG:
+    case IsmType.STORAGE_MESSAGE_ID_MULTISIG:
+    case IsmType.WEIGHTED_MERKLE_ROOT_MULTISIG:
+    case IsmType.WEIGHTED_MESSAGE_ID_MULTISIG:
+    case IsmType.INTERCHAIN_ACCOUNT_ROUTING:
+    case IsmType.ARB_L2_TO_L1:
+    case IsmType.OFFCHAIN_LOOKUP:
+    case IsmType.UNKNOWN:
+      return false;
+    default: {
+      const exhaustiveCheck: never = ism;
+      return exhaustiveCheck;
+    }
   }
-  if (node.domains !== null && typeof node.domains === 'object') {
-    if (
-      Object.values(node.domains as Record<string, unknown>).some(
-        ismTreeContainsRateLimited,
-      )
-    )
-      return true;
-  }
-  if (ismTreeContainsRateLimited(node.lowerIsm)) return true;
-  if (ismTreeContainsRateLimited(node.upperIsm)) return true;
-  return false;
+}
+
+export function ismTreeContainsRateLimited(ism: IsmConfig): boolean {
+  return ismTreeSome(ism, (node) => node.type === IsmType.RATE_LIMITED);
+}
+
+/**
+ * True if a `rateLimited` node appears anywhere inside a `compositeIsm` in
+ * the tree.
+ *
+ * Deliberately separate from {@link ismTreeContainsRateLimited} rather than
+ * folded into it: that predicate gates the EVM `rateLimitedIsm`'s
+ * deferred-deploy machinery, which asserts an Ethereum/Tron chain
+ * (`resolveWarpIsmAndHook` and its callers in `deploy/warp.ts`). A
+ * compositeIsm is a Sealevel program and must never enter those paths.
+ */
+export function ismTreeContainsCompositeRateLimited(ism: IsmConfig): boolean {
+  return ismTreeSome(
+    ism,
+    (node) => node.type === CompositeIsmNodeType.RATE_LIMITED,
+  );
 }
 
 /**
@@ -128,8 +218,16 @@ export type HybridHookIsmConfig =
  * True if a warp-route hybrid hook/ISM node (NET_FLOW_RATE_LIMITED or
  * DELAYED_FLOW_ROUTER) exists anywhere in the ISM config tree.
  */
-export function ismTreeContainsHybridHookIsm(ism: unknown): boolean {
-  return collectHybridIsmNodesFromUnknown(ism).length > 0;
+export function ismTreeContainsHybridHookIsm(
+  ism: IsmConfig | undefined,
+): boolean {
+  if (!ism) return false;
+  return ismTreeSome(
+    ism,
+    (node) =>
+      node.type === IsmType.NET_FLOW_RATE_LIMITED ||
+      node.type === IsmType.DELAYED_FLOW_ROUTER,
+  );
 }
 
 /**
@@ -137,10 +235,13 @@ export function ismTreeContainsHybridHookIsm(ism: unknown): boolean {
  * tree. Used to keep warp-route-only and self-referential ISM types out of
  * core default-ISM configs (see core/types.ts).
  */
-export function ismTreeContainsMailboxDefaultOrHybrid(ism: unknown): boolean {
-  return (
-    ismTreeContainsHybridHookIsm(ism) ||
-    ismTreeSome(ism, (node) => node.type === IsmType.MAILBOX_DEFAULT)
+export function ismTreeContainsMailboxDefaultOrHybrid(ism: IsmConfig): boolean {
+  return ismTreeSome(
+    ism,
+    (node) =>
+      node.type === IsmType.MAILBOX_DEFAULT ||
+      node.type === IsmType.NET_FLOW_RATE_LIMITED ||
+      node.type === IsmType.DELAYED_FLOW_ROUTER,
   );
 }
 
@@ -159,29 +260,6 @@ function isHybridIsmNode(node: unknown): node is HybridHookIsmConfig {
   return (
     node.type === IsmType.NET_FLOW_RATE_LIMITED ||
     node.type === IsmType.DELAYED_FLOW_ROUTER
-  );
-}
-
-/** True if any node in the tree satisfies `matches`. */
-function ismTreeSome(
-  ism: unknown,
-  matches: (node: Record<string, unknown>) => boolean,
-): boolean {
-  if (!isRecord(ism)) return false;
-  const node = ism;
-  if (matches(node)) return true;
-
-  if (Array.isArray(node.modules)) {
-    if (node.modules.some((module) => ismTreeSome(module, matches)))
-      return true;
-  }
-  if (isRecord(node.domains)) {
-    const domains = Object.values(node.domains);
-    if (domains.some((domainIsm) => ismTreeSome(domainIsm, matches)))
-      return true;
-  }
-  return (
-    ismTreeSome(node.lowerIsm, matches) || ismTreeSome(node.upperIsm, matches)
   );
 }
 

--- a/typescript/starknet-sdk/src/tests/read-warp-token.e2e-test.ts
+++ b/typescript/starknet-sdk/src/tests/read-warp-token.e2e-test.ts
@@ -18,7 +18,7 @@ const STARKNET_MAINNET_METADATA: ChainMetadataForAltVM = {
     name: 'StarkNet Token',
     symbol: 'STRK',
   },
-  rpcUrls: [{ http: 'https://rpc.starknet.lava.build:443/' }],
+  rpcUrls: [{ http: 'https://starknet-rpc.publicnode.com' }],
 };
 
 const PARADEX_MAINNET_METADATA: ChainMetadataForAltVM = {

--- a/typescript/svm-sdk/src/ism/composite-ism.ts
+++ b/typescript/svm-sdk/src/ism/composite-ism.ts
@@ -22,9 +22,11 @@ import {
   ArtifactState,
   type ArtifactWriter,
 } from '@hyperlane-xyz/provider-sdk/artifact';
-import type {
-  CompositeIsmArtifactConfig,
-  CompositeIsmNodeArtifactConfig,
+import {
+  CompositeIsmNodeType,
+  IsmType,
+  type CompositeIsmArtifactConfig,
+  type CompositeIsmNodeArtifactConfig,
 } from '@hyperlane-xyz/provider-sdk/ism';
 import {
   assert,
@@ -175,48 +177,51 @@ function ismNodeToArtifactConfig(
   domains: Record<number, IsmNode>,
 ): CompositeIsmNodeArtifactConfig {
   switch (node.kind) {
-    case 'trustedRelayer':
-      return { type: 'trustedRelayer', relayer: node.relayer };
-    case 'multisigMessageId':
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
       return {
-        type: 'multisigMessageId',
+        type: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: node.relayer,
+      };
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+      return {
+        type: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         validators: validatorBytesToHex(node.validators),
         threshold: node.threshold,
       };
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       return {
-        type: 'aggregation',
+        type: CompositeIsmNodeType.AGGREGATION,
         threshold: node.threshold,
         subIsms: node.subIsms.map((sub) =>
           ismNodeToArtifactConfig(sub, domains),
         ),
       };
-    case 'test':
-      return { type: 'test', accept: node.accept };
-    case 'pausable':
-      return { type: 'pausable', paused: node.paused };
-    case 'amountRouting':
+    case CompositeIsmNodeType.TEST:
+      return { type: CompositeIsmNodeType.TEST, accept: node.accept };
+    case CompositeIsmNodeType.PAUSABLE:
+      return { type: CompositeIsmNodeType.PAUSABLE, paused: node.paused };
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       return {
-        type: 'amountRouting',
+        type: CompositeIsmNodeType.AMOUNT_ROUTING,
         threshold: node.threshold.toString(),
         lower: ismNodeToArtifactConfig(node.lower, domains),
         upper: ismNodeToArtifactConfig(node.upper, domains),
       };
-    case 'rateLimited':
+    case CompositeIsmNodeType.RATE_LIMITED:
       return {
-        type: 'rateLimited',
+        type: CompositeIsmNodeType.RATE_LIMITED,
         maxCapacity: node.maxCapacity.toString(),
         mailbox: node.mailbox,
         recipient: node.recipient ? bytesToH256Hex(node.recipient) : undefined,
       };
-    case 'routing':
+    case CompositeIsmNodeType.ROUTING:
       return {
-        type: 'routing',
+        type: CompositeIsmNodeType.ROUTING,
         domains: convertDomainsToArtifactConfig(domains),
       };
-    case 'fallbackRouting':
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
       return {
-        type: 'fallbackRouting',
+        type: CompositeIsmNodeType.FALLBACK_ROUTING,
         fallbackIsm: node.fallbackIsm,
         domains: convertDomainsToArtifactConfig(domains),
       };
@@ -246,35 +251,38 @@ function artifactConfigToIsmNode(
   node: CompositeIsmNodeArtifactConfig,
 ): IsmNode {
   switch (node.type) {
-    case 'trustedRelayer':
-      return { kind: 'trustedRelayer', relayer: parseAddress(node.relayer) };
-    case 'multisigMessageId':
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
       return {
-        kind: 'multisigMessageId',
+        kind: CompositeIsmNodeType.TRUSTED_RELAYER,
+        relayer: parseAddress(node.relayer),
+      };
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
+      return {
+        kind: CompositeIsmNodeType.MULTISIG_MESSAGE_ID,
         validators: node.validators.map((v) => Uint8Array.from(encodeH160(v))),
         threshold: node.threshold,
       };
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       return {
-        kind: 'aggregation',
+        kind: CompositeIsmNodeType.AGGREGATION,
         threshold: node.threshold,
         subIsms: node.subIsms.map(artifactConfigToIsmNode),
       };
-    case 'test':
-      return { kind: 'test', accept: node.accept };
-    case 'pausable':
-      return { kind: 'pausable', paused: node.paused };
-    case 'amountRouting':
+    case CompositeIsmNodeType.TEST:
+      return { kind: CompositeIsmNodeType.TEST, accept: node.accept };
+    case CompositeIsmNodeType.PAUSABLE:
+      return { kind: CompositeIsmNodeType.PAUSABLE, paused: node.paused };
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       return {
-        kind: 'amountRouting',
+        kind: CompositeIsmNodeType.AMOUNT_ROUTING,
         threshold: BigInt(node.threshold),
         lower: artifactConfigToIsmNode(node.lower),
         upper: artifactConfigToIsmNode(node.upper),
       };
-    case 'rateLimited': {
+    case CompositeIsmNodeType.RATE_LIMITED: {
       const maxCapacity = BigInt(node.maxCapacity);
       return {
-        kind: 'rateLimited',
+        kind: CompositeIsmNodeType.RATE_LIMITED,
         maxCapacity,
         recipient: node.recipient
           ? Uint8Array.from(encodeH256(node.recipient))
@@ -286,11 +294,11 @@ function artifactConfigToIsmNode(
         mailbox: parseAddress(node.mailbox),
       };
     }
-    case 'routing':
-      return { kind: 'routing' };
-    case 'fallbackRouting':
+    case CompositeIsmNodeType.ROUTING:
+      return { kind: CompositeIsmNodeType.ROUTING };
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
       return {
-        kind: 'fallbackRouting',
+        kind: CompositeIsmNodeType.FALLBACK_ROUTING,
         fallbackIsm: parseAddress(node.fallbackIsm),
       };
   }
@@ -301,16 +309,16 @@ function extractDomains(
   node: CompositeIsmNodeArtifactConfig,
 ): Record<number, CompositeIsmNodeArtifactConfig> {
   switch (node.type) {
-    case 'routing':
-    case 'fallbackRouting':
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
       return node.domains ?? {};
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       for (const sub of node.subIsms) {
         const found = extractDomains(sub);
         if (Object.keys(found).length > 0) return found;
       }
       return {};
-    case 'amountRouting': {
+    case CompositeIsmNodeType.AMOUNT_ROUTING: {
       const lower = extractDomains(node.lower);
       if (Object.keys(lower).length > 0) return lower;
       return extractDomains(node.upper);
@@ -328,12 +336,12 @@ function extractDomains(
  */
 function containsRoutingNode(node: CompositeIsmNodeArtifactConfig): boolean {
   switch (node.type) {
-    case 'routing':
-    case 'fallbackRouting':
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
       return true;
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       return node.subIsms.some(containsRoutingNode);
-    case 'amountRouting':
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       return containsRoutingNode(node.lower) || containsRoutingNode(node.upper);
     default:
       return false;
@@ -345,11 +353,11 @@ function containsFallbackRoutingNode(
   node: CompositeIsmNodeArtifactConfig,
 ): boolean {
   switch (node.type) {
-    case 'fallbackRouting':
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
       return true;
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       return node.subIsms.some(containsFallbackRoutingNode);
-    case 'amountRouting':
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       return (
         containsFallbackRoutingNode(node.lower) ||
         containsFallbackRoutingNode(node.upper)
@@ -406,13 +414,13 @@ function assertValidCompositeIsmArtifactNode(
   programId?: Address,
 ): void {
   switch (node.type) {
-    case 'trustedRelayer':
+    case CompositeIsmNodeType.TRUSTED_RELAYER:
       assert(
         isAddress(node.relayer) && !isEmptyAddress(node.relayer),
         `trustedRelayer.relayer must be a non-zero Sealevel address, got: ${node.relayer}`,
       );
       break;
-    case 'multisigMessageId': {
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID: {
       assert(
         Number.isInteger(node.threshold) &&
           node.threshold >= 1 &&
@@ -436,7 +444,7 @@ function assertValidCompositeIsmArtifactNode(
       }
       break;
     }
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       assert(
         Number.isInteger(node.threshold) &&
           node.threshold >= 1 &&
@@ -459,7 +467,7 @@ function assertValidCompositeIsmArtifactNode(
         ),
       );
       break;
-    case 'amountRouting':
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       assert(
         isValidDecimalStringBoundedBy(node.threshold, ARTIFACT_U256_MAX),
         `amountRouting.threshold (${node.threshold}) must be a base-10 integer string not exceeding u256::MAX`,
@@ -477,7 +485,7 @@ function assertValidCompositeIsmArtifactNode(
         programId,
       );
       break;
-    case 'rateLimited':
+    case CompositeIsmNodeType.RATE_LIMITED:
       assert(
         isValidDecimalStringBoundedBy(node.maxCapacity, ARTIFACT_U64_MAX) &&
           BigInt(node.maxCapacity) > 0n,
@@ -489,7 +497,9 @@ function assertValidCompositeIsmArtifactNode(
       );
       assert(
         node.recipient,
-        'rateLimited.recipient is required and must be a non-zero 32-byte address',
+        'rateLimited.recipient is required and must be a non-zero 32-byte address. ' +
+          'Warp deploy and warp apply resolve it from the router the ISM protects, so it only has to be ' +
+          'written out when this ISM is deployed on its own.',
       );
       if (node.recipient) {
         try {
@@ -503,13 +513,13 @@ function assertValidCompositeIsmArtifactNode(
         );
       }
       break;
-    case 'routing':
-    case 'fallbackRouting':
+    case CompositeIsmNodeType.ROUTING:
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
       assert(
         !insideDomainIsm,
         `${node.type} is not allowed inside a domain override`,
       );
-      if (node.type === 'fallbackRouting') {
+      if (node.type === CompositeIsmNodeType.FALLBACK_ROUTING) {
         assert(
           isAddress(node.fallbackIsm) && !isEmptyAddress(node.fallbackIsm),
           `fallbackRouting.fallbackIsm must be a non-zero Sealevel address, got: ${node.fallbackIsm}`,
@@ -534,13 +544,13 @@ function assertValidCompositeIsmArtifactNode(
         assertValidCompositeIsmArtifactNode(domainNode, true, state, programId);
       }
       break;
-    case 'pausable':
+    case CompositeIsmNodeType.PAUSABLE:
       assert(
         !insideDomainIsm,
         'pausable is not allowed inside a domain override',
       );
       break;
-    case 'test':
+    case CompositeIsmNodeType.TEST:
       break;
   }
 }
@@ -622,7 +632,7 @@ export class SvmCompositeIsmReader implements ArtifactReader<
     return {
       artifactState: ArtifactState.DEPLOYED,
       config: {
-        type: 'compositeIsm',
+        type: IsmType.COMPOSITE,
         owner: storage.owner,
         root: ismNodeToArtifactConfig(storage.root, domains),
       },
@@ -962,16 +972,19 @@ function stripDomains(
   node: CompositeIsmNodeArtifactConfig,
 ): CompositeIsmNodeArtifactConfig {
   switch (node.type) {
-    case 'routing':
-      return { type: 'routing' };
-    case 'fallbackRouting':
-      return { type: 'fallbackRouting', fallbackIsm: node.fallbackIsm };
-    case 'aggregation':
+    case CompositeIsmNodeType.ROUTING:
+      return { type: CompositeIsmNodeType.ROUTING };
+    case CompositeIsmNodeType.FALLBACK_ROUTING:
+      return {
+        type: CompositeIsmNodeType.FALLBACK_ROUTING,
+        fallbackIsm: node.fallbackIsm,
+      };
+    case CompositeIsmNodeType.AGGREGATION:
       return {
         ...node,
         subIsms: node.subIsms.map(stripDomains),
       };
-    case 'amountRouting':
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       return {
         ...node,
         lower: stripDomains(node.lower),
@@ -1004,20 +1017,20 @@ function deepEqualNode(
  */
 function normalizeForCompare(node: CompositeIsmNodeArtifactConfig): unknown {
   switch (node.type) {
-    case 'multisigMessageId':
+    case CompositeIsmNodeType.MULTISIG_MESSAGE_ID:
       return {
         ...node,
         validators: [...node.validators].map((v) => v.toLowerCase()).sort(),
       };
-    case 'rateLimited':
+    case CompositeIsmNodeType.RATE_LIMITED:
       return {
         ...node,
         maxCapacity: BigInt(node.maxCapacity).toString(),
         recipient: node.recipient?.toLowerCase(),
       };
-    case 'aggregation':
+    case CompositeIsmNodeType.AGGREGATION:
       return { ...node, subIsms: node.subIsms.map(normalizeForCompare) };
-    case 'amountRouting':
+    case CompositeIsmNodeType.AMOUNT_ROUTING:
       return {
         ...node,
         threshold: BigInt(node.threshold).toString(),


### PR DESCRIPTION
### Description

- Deferred artifact-API ISM deployment until the warp router exists, then resolved contextual ISM data from that router before attachment.
- Traversed nested routing artifacts and every composite ISM container so `rateLimited.recipient` is resolved and validated throughout the tree.
- Preserved NEW, DEPLOYED, and UNDERIVED artifact boundaries; reused DEPLOYED roots unchanged and rejected invalid NEW descendants.
- Rejected composite rate limiters anywhere in mailbox default ISM trees.
- Added schema, writer, validation, and Sealevel CLI E2E coverage.

### Drive-by changes

None.

### Related issues

None.

### Backward compatibility

Yes. Existing read-back configs retain explicit recipients. New warp deployments may omit `rateLimited.recipient`; it is derived from the deployed router. EVM and Tron keep their legacy deployment path.

### Testing

- Lint and typechecks: provider-sdk, deploy-sdk, sdk, svm-sdk, CLI
- 444 focused provider/deploy/sdk/SVM unit tests
- `CLI_E2E_TEST=warp-composite-ism pnpm -C typescript/cli test:sealevel:e2e` — 3 passing
- `CLI_E2E_TEST=warp-fee pnpm -C typescript/cli test:sealevel:e2e` — 4 passing
- `CLI_E2E_TEST=warp-apply-ism-add-test-ism pnpm -C typescript/cli test:starknet:e2e` — 1 passing
