### PR TITLE
fix(agents): contain Lander recovery side effects

### DIFF
--- a/rust/main/agents/relayer/src/msg/message_processor.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor.rs
@@ -1,12 +1,14 @@
 #![allow(clippy::doc_markdown)] // TODO: `rustc` 1.80.1 clippy issue
 #![allow(clippy::doc_lazy_continuation)] // TODO: `rustc` 1.80.1 clippy issue
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::future::join_all;
 use futures_util::future::try_join_all;
+use futures_util::stream::{FuturesUnordered, StreamExt};
 use maplit::hashmap;
 use num_traits::Zero;
 use prometheus::{IntCounterVec, IntGaugeVec};
@@ -489,51 +491,109 @@ async fn get_batch_or_wait(queue: &mut OpQueue, batch_size: u32) -> Vec<QueueOpe
 
 async fn process_batch(
     domain: HyperlaneDomain,
-    mut batch: Vec<QueueOperation>,
+    batch: Vec<QueueOperation>,
     prepare_queue: &mut OpQueue,
     submit_queue: &OpQueue,
     confirm_queue: &OpQueue,
     metrics: &MessageProcessorMetrics,
 ) {
-    let mut task_prep_futures = vec![];
-    let op_refs = batch.iter_mut().map(|op| op.as_mut()).collect::<Vec<_>>();
-    for op in op_refs {
+    let mut next_sequence_by_origin = HashMap::<u32, usize>::new();
+    let mut prepare_futures = FuturesUnordered::new();
+
+    for mut op in batch {
         trace!(?op, "Preparing operation");
         debug_assert_eq!(*op.destination_domain(), domain);
-        task_prep_futures.push(op.prepare());
-    }
-    let res = join_all(task_prep_futures).await;
-    for (op, prepare_result) in batch.into_iter().zip(res.into_iter()) {
-        let app_context = op.app_context();
-        match prepare_result {
-            PendingOperationResult::Success => {
-                debug!(?op, "Operation prepared");
 
-                metrics.inc_prepared(app_context);
-                // TODO: push multiple messages at once
-                submit_queue
-                    .push(op, Some(PendingOperationStatus::ReadyToSubmit))
-                    .await;
-            }
-            PendingOperationResult::NotReady => {
-                prepare_queue.push(op, None).await;
-            }
-            PendingOperationResult::Reprepare(reason) => {
-                metrics.inc_failed(app_context);
-                prepare_queue
-                    .push(op, Some(PendingOperationStatus::Retry(reason)))
-                    .await;
-            }
-            PendingOperationResult::Drop => {
-                metrics.inc_dropped(app_context);
-                op.decrement_metric_if_exists();
-            }
-            PendingOperationResult::Confirm(reason) => {
-                debug!(?op, "Pushing operation to confirm queue");
-                confirm_queue
-                    .push(op, Some(PendingOperationStatus::Confirm(reason)))
-                    .await;
-            }
+        let origin = op.origin_domain_id();
+        let next_sequence = next_sequence_by_origin.entry(origin).or_default();
+        let sequence = *next_sequence;
+        *next_sequence = (*next_sequence).saturating_add(1);
+        prepare_futures.push(async move {
+            let result = op.prepare().await;
+            (origin, sequence, op, result)
+        });
+    }
+    let mut next_disposition_by_origin = HashMap::<u32, usize>::new();
+    let mut completed_by_origin =
+        HashMap::<u32, HashMap<usize, (QueueOperation, PendingOperationResult)>>::new();
+
+    while let Some((origin, sequence, op, result)) = prepare_futures.next().await {
+        // Route completed work immediately unless an earlier operation from the
+        // same origin is still preparing. Operations from other origins remain
+        // independent and can make progress in the meantime.
+        completed_by_origin
+            .entry(origin)
+            .or_default()
+            .insert(sequence, (op, result));
+
+        loop {
+            let next_sequence = *next_disposition_by_origin.entry(origin).or_default();
+            let Some((op, result)) = completed_by_origin
+                .get_mut(&origin)
+                .and_then(|completed| completed.remove(&next_sequence))
+            else {
+                break;
+            };
+
+            dispose_prepared_operation(
+                op,
+                result,
+                prepare_queue,
+                submit_queue,
+                confirm_queue,
+                metrics,
+            )
+            .await;
+            next_disposition_by_origin.insert(origin, next_sequence.saturating_add(1));
+        }
+    }
+
+    debug_assert!(completed_by_origin.values().all(HashMap::is_empty));
+}
+
+/// Routes a prepared operation and returns whether it remains unready.
+async fn dispose_prepared_operation(
+    op: QueueOperation,
+    prepare_result: PendingOperationResult,
+    prepare_queue: &mut OpQueue,
+    submit_queue: &OpQueue,
+    confirm_queue: &OpQueue,
+    metrics: &MessageProcessorMetrics,
+) -> bool {
+    let app_context = op.app_context();
+    match prepare_result {
+        PendingOperationResult::Success => {
+            debug!(?op, "Operation prepared");
+
+            metrics.inc_prepared(app_context);
+            // TODO: push multiple messages at once
+            submit_queue
+                .push(op, Some(PendingOperationStatus::ReadyToSubmit))
+                .await;
+            false
+        }
+        PendingOperationResult::NotReady => {
+            prepare_queue.push(op, None).await;
+            true
+        }
+        PendingOperationResult::Reprepare(reason) => {
+            metrics.inc_failed(app_context);
+            prepare_queue
+                .push(op, Some(PendingOperationStatus::Retry(reason)))
+                .await;
+            true
+        }
+        PendingOperationResult::Drop => {
+            metrics.inc_dropped(app_context);
+            op.decrement_metric_if_exists();
+            false
+        }
+        PendingOperationResult::Confirm(reason) => {
+            debug!(?op, "Pushing operation to confirm queue");
+            confirm_queue
+                .push(op, Some(PendingOperationStatus::Confirm(reason)))
+                .await;
+            false
         }
     }
 }

--- a/rust/main/agents/relayer/src/msg/message_processor/tests.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests.rs
@@ -85,3 +85,4 @@ async fn test_recovery_backpressures_message_processor_ingress() {
         .await
         .expect("receive task should stop when ingress closes");
 }
+mod tests_process_batch;

--- a/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
@@ -170,7 +170,9 @@ impl PendingOperation for TestOperation {
 
     fn set_next_attempt_after(&mut self, _delay: Duration) {}
 
-    fn reset_attempts(&mut self) {}
+    fn reset_attempts(&mut self) -> bool {
+        true
+    }
 
     fn set_retries(&mut self, _retries: u32) {}
 

--- a/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
+++ b/rust/main/agents/relayer/src/msg/message_processor/tests/tests_process_batch.rs
@@ -1,0 +1,450 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use prometheus::IntGauge;
+use serde::Serialize;
+use tokio::sync::{mpsc, Semaphore};
+
+use hyperlane_core::{
+    ChainResult, ConfirmReason, HyperlaneDomain, HyperlaneMessage, PendingOperation,
+    PendingOperationResult, PendingOperationStatus, QueueOperation, ReprepareReason, TryBatchAs,
+    TxOutcome, H256, U256,
+};
+
+use super::super::process_batch;
+use super::tests_common::{create_test_metrics, create_test_queue};
+
+#[derive(Debug, Default)]
+struct PrepareConcurrency {
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+}
+
+#[derive(Debug, Serialize)]
+struct TestOperation {
+    id: H256,
+    origin: u32,
+    destination: HyperlaneDomain,
+    status: PendingOperationStatus,
+    #[serde(skip_serializing)]
+    prepare_result: Option<PendingOperationResult>,
+    #[serde(skip_serializing)]
+    gate: Option<Arc<Semaphore>>,
+    #[serde(skip_serializing)]
+    started: mpsc::UnboundedSender<H256>,
+    #[serde(skip_serializing)]
+    completed: mpsc::UnboundedSender<H256>,
+    #[serde(skip_serializing)]
+    disposed: mpsc::UnboundedSender<H256>,
+    #[serde(skip_serializing)]
+    concurrency: Arc<PrepareConcurrency>,
+}
+
+impl TestOperation {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        id: u64,
+        origin: u32,
+        destination: HyperlaneDomain,
+        prepare_result: PendingOperationResult,
+        gate: Option<Arc<Semaphore>>,
+        started: mpsc::UnboundedSender<H256>,
+        completed: mpsc::UnboundedSender<H256>,
+        disposed: mpsc::UnboundedSender<H256>,
+        concurrency: Arc<PrepareConcurrency>,
+    ) -> Self {
+        Self {
+            id: H256::from_low_u64_be(id),
+            origin,
+            destination,
+            status: PendingOperationStatus::FirstPrepareAttempt,
+            prepare_result: Some(prepare_result),
+            gate,
+            started,
+            completed,
+            disposed,
+            concurrency,
+        }
+    }
+}
+
+#[async_trait]
+#[typetag::serialize]
+impl PendingOperation for TestOperation {
+    fn id(&self) -> H256 {
+        self.id
+    }
+
+    fn priority(&self) -> u32 {
+        self.id.to_low_u64_be() as u32
+    }
+
+    fn origin_domain_id(&self) -> u32 {
+        self.origin
+    }
+
+    fn retrieve_status_from_db(&self) -> Option<PendingOperationStatus> {
+        Some(self.status.clone())
+    }
+
+    fn destination_domain(&self) -> &HyperlaneDomain {
+        &self.destination
+    }
+
+    fn sender_address(&self) -> &H256 {
+        &self.id
+    }
+
+    fn recipient_address(&self) -> &H256 {
+        &self.id
+    }
+
+    fn body(&self) -> &[u8] {
+        &[]
+    }
+
+    fn app_context(&self) -> Option<String> {
+        None
+    }
+
+    fn get_metric(&self) -> Option<Arc<IntGauge>> {
+        None
+    }
+
+    fn set_metric(&mut self, _metric: Arc<IntGauge>) {
+        self.disposed.send(self.id).expect("disposition receiver");
+    }
+
+    fn status(&self) -> PendingOperationStatus {
+        self.status.clone()
+    }
+
+    fn set_status(&mut self, status: PendingOperationStatus) {
+        self.status = status;
+    }
+
+    async fn prepare(&mut self) -> PendingOperationResult {
+        let active = self.concurrency.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.concurrency
+            .max_active
+            .fetch_max(active, Ordering::SeqCst);
+        self.started.send(self.id).expect("started receiver");
+
+        if let Some(gate) = &self.gate {
+            gate.acquire().await.expect("gate open").forget();
+        }
+
+        self.completed.send(self.id).expect("completed receiver");
+        self.concurrency.active.fetch_sub(1, Ordering::SeqCst);
+        self.prepare_result.take().expect("single prepare call")
+    }
+
+    async fn submit(&mut self) -> PendingOperationResult {
+        unimplemented!()
+    }
+
+    fn set_submission_outcome(&mut self, _outcome: TxOutcome) {}
+
+    fn get_tx_cost_estimate(&self) -> Option<U256> {
+        None
+    }
+
+    async fn confirm(&mut self) -> PendingOperationResult {
+        unimplemented!()
+    }
+
+    async fn set_operation_outcome(
+        &mut self,
+        _submission_outcome: TxOutcome,
+        _submission_estimated_cost: U256,
+    ) {
+    }
+
+    fn next_attempt_after(&self) -> Option<Instant> {
+        None
+    }
+
+    fn set_next_attempt_after(&mut self, _delay: Duration) {}
+
+    fn reset_attempts(&mut self) {}
+
+    fn set_retries(&mut self, _retries: u32) {}
+
+    fn get_retries(&self) -> u32 {
+        0
+    }
+
+    async fn payload(&self) -> ChainResult<Vec<u8>> {
+        unimplemented!()
+    }
+
+    fn success_criteria(&self) -> ChainResult<Option<Vec<u8>>> {
+        unimplemented!()
+    }
+
+    fn on_reprepare(
+        &mut self,
+        _err_msg: Option<String>,
+        reason: ReprepareReason,
+    ) -> PendingOperationResult {
+        PendingOperationResult::Reprepare(reason)
+    }
+}
+
+impl TryBatchAs<HyperlaneMessage> for TestOperation {}
+
+struct TestHarness {
+    destination: HyperlaneDomain,
+    started_tx: mpsc::UnboundedSender<H256>,
+    started_rx: mpsc::UnboundedReceiver<H256>,
+    completed_tx: mpsc::UnboundedSender<H256>,
+    completed_rx: mpsc::UnboundedReceiver<H256>,
+    disposed_tx: mpsc::UnboundedSender<H256>,
+    disposed_rx: mpsc::UnboundedReceiver<H256>,
+    concurrency: Arc<PrepareConcurrency>,
+}
+
+impl TestHarness {
+    fn new() -> Self {
+        let (started_tx, started_rx) = mpsc::unbounded_channel();
+        let (completed_tx, completed_rx) = mpsc::unbounded_channel();
+        let (disposed_tx, disposed_rx) = mpsc::unbounded_channel();
+        Self {
+            destination: HyperlaneDomain::new_test_domain("test"),
+            started_tx,
+            started_rx,
+            completed_tx,
+            completed_rx,
+            disposed_tx,
+            disposed_rx,
+            concurrency: Arc::new(PrepareConcurrency::default()),
+        }
+    }
+
+    fn operation(
+        &self,
+        id: u64,
+        origin: u32,
+        result: PendingOperationResult,
+        gate: Option<Arc<Semaphore>>,
+    ) -> QueueOperation {
+        Box::new(TestOperation::new(
+            id,
+            origin,
+            self.destination.clone(),
+            result,
+            gate,
+            self.started_tx.clone(),
+            self.completed_tx.clone(),
+            self.disposed_tx.clone(),
+            self.concurrency.clone(),
+        ))
+    }
+}
+
+async fn run_process_batch(
+    destination: HyperlaneDomain,
+    batch: Vec<QueueOperation>,
+) -> (
+    super::super::OpQueue,
+    super::super::OpQueue,
+    super::super::OpQueue,
+    super::super::MessageProcessorMetrics,
+) {
+    let mut prepare_queue = create_test_queue();
+    let submit_queue = create_test_queue();
+    let confirm_queue = create_test_queue();
+    let metrics = create_test_metrics();
+
+    process_batch(
+        destination,
+        batch,
+        &mut prepare_queue,
+        &submit_queue,
+        &confirm_queue,
+        &metrics,
+    )
+    .await;
+
+    (prepare_queue, submit_queue, confirm_queue, metrics)
+}
+
+#[tokio::test]
+async fn slow_origin_does_not_block_fast_origin_disposition() {
+    let mut harness = TestHarness::new();
+    let slow_gate = Arc::new(Semaphore::new(0));
+    let slow_id = H256::from_low_u64_be(1);
+    let fast_id = H256::from_low_u64_be(2);
+    let batch = vec![
+        harness.operation(
+            1,
+            1000,
+            PendingOperationResult::Success,
+            Some(slow_gate.clone()),
+        ),
+        harness.operation(2, 2000, PendingOperationResult::Success, None),
+    ];
+
+    let task = tokio::spawn(run_process_batch(harness.destination.clone(), batch));
+
+    for _ in 0..2 {
+        harness.started_rx.recv().await.expect("prepare started");
+    }
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), harness.disposed_rx.recv())
+            .await
+            .expect("fast origin should be disposed")
+            .expect("disposition event"),
+        fast_id
+    );
+
+    slow_gate.add_permits(1);
+    assert_eq!(
+        harness.disposed_rx.recv().await.expect("slow disposition"),
+        slow_id
+    );
+    task.await.expect("process task");
+}
+
+#[tokio::test]
+async fn same_origin_dispositions_preserve_batch_order() {
+    let mut harness = TestHarness::new();
+    let first_gate = Arc::new(Semaphore::new(0));
+    let first_id = H256::from_low_u64_be(1);
+    let second_id = H256::from_low_u64_be(2);
+    let batch = vec![
+        harness.operation(
+            1,
+            1000,
+            PendingOperationResult::Success,
+            Some(first_gate.clone()),
+        ),
+        harness.operation(2, 1000, PendingOperationResult::Success, None),
+    ];
+
+    let task = tokio::spawn(run_process_batch(harness.destination.clone(), batch));
+
+    assert_eq!(
+        harness.completed_rx.recv().await.expect("completion event"),
+        second_id
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), harness.disposed_rx.recv())
+            .await
+            .is_err(),
+        "later same-origin operation must wait for its predecessor"
+    );
+
+    first_gate.add_permits(1);
+    assert_eq!(harness.disposed_rx.recv().await.unwrap(), first_id);
+    assert_eq!(harness.disposed_rx.recv().await.unwrap(), second_id);
+    task.await.expect("process task");
+}
+
+#[tokio::test]
+async fn preparation_concurrency_is_bounded_by_batch_size() {
+    let mut harness = TestHarness::new();
+    let gate = Arc::new(Semaphore::new(0));
+    let batch_size = 4;
+    let batch = (0..batch_size)
+        .map(|i| {
+            harness.operation(
+                i as u64 + 1,
+                i as u32 + 1,
+                PendingOperationResult::Success,
+                Some(gate.clone()),
+            )
+        })
+        .collect();
+
+    let task = tokio::spawn(run_process_batch(harness.destination.clone(), batch));
+    for _ in 0..batch_size {
+        harness.started_rx.recv().await.expect("prepare started");
+    }
+    assert_eq!(
+        harness.concurrency.max_active.load(Ordering::SeqCst),
+        batch_size
+    );
+
+    gate.add_permits(batch_size);
+    task.await.expect("process task");
+    assert_eq!(harness.concurrency.active.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn completed_results_keep_existing_dispositions_and_metrics() {
+    let harness = TestHarness::new();
+    let success_id = H256::from_low_u64_be(1);
+    let not_ready_id = H256::from_low_u64_be(2);
+    let reprepare_id = H256::from_low_u64_be(3);
+    let confirm_id = H256::from_low_u64_be(5);
+    let batch = vec![
+        harness.operation(1, 1, PendingOperationResult::Success, None),
+        harness.operation(2, 2, PendingOperationResult::NotReady, None),
+        harness.operation(
+            3,
+            3,
+            PendingOperationResult::Reprepare(ReprepareReason::Manual),
+            None,
+        ),
+        harness.operation(4, 4, PendingOperationResult::Drop, None),
+        harness.operation(
+            5,
+            5,
+            PendingOperationResult::Confirm(ConfirmReason::AlreadySubmitted),
+            None,
+        ),
+    ];
+
+    let (mut prepare_queue, mut submit_queue, mut confirm_queue, metrics) =
+        run_process_batch(harness.destination, batch).await;
+
+    let submitted = submit_queue.pop_many(10).await;
+    assert_eq!(submitted.len(), 1);
+    assert_eq!(submitted[0].id(), success_id);
+    assert_eq!(submitted[0].status(), PendingOperationStatus::ReadyToSubmit);
+
+    let prepared = prepare_queue.pop_many(10).await;
+    assert_eq!(prepared.len(), 2);
+    assert!(prepared.iter().any(|op| {
+        op.id() == not_ready_id && op.status() == PendingOperationStatus::FirstPrepareAttempt
+    }));
+    assert!(prepared.iter().any(|op| {
+        op.id() == reprepare_id
+            && op.status() == PendingOperationStatus::Retry(ReprepareReason::Manual)
+    }));
+
+    let confirmed = confirm_queue.pop_many(10).await;
+    assert_eq!(confirmed.len(), 1);
+    assert_eq!(confirmed[0].id(), confirm_id);
+    assert_eq!(
+        confirmed[0].status(),
+        PendingOperationStatus::Confirm(ConfirmReason::AlreadySubmitted)
+    );
+
+    assert_eq!(
+        metrics
+            .ops_prepared
+            .with_label_values(&["test", "prepared", "Unknown"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .ops_failed
+            .with_label_values(&["test", "failed", "Unknown"])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .ops_dropped
+            .with_label_values(&["test", "dropped", "Unknown"])
+            .get(),
+        1
+    );
+}

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -32,9 +32,16 @@ pub enum TxHashCacheError {
     CacheFull,
 }
 
+#[derive(Clone, Copy)]
+enum TxHashCacheEntry {
+    Reserved(u64),
+    Committed(Instant),
+}
+
 pub struct TxHashCache {
-    cache: HashMap<(String, String), Instant>,
+    cache: HashMap<(String, String), TxHashCacheEntry>,
     max_entries: usize,
+    next_reservation: u64,
     ttl: Duration,
 }
 
@@ -47,6 +54,7 @@ impl TxHashCache {
         Self {
             cache: HashMap::new(),
             max_entries,
+            next_reservation: 0,
             ttl,
         }
     }
@@ -60,28 +68,47 @@ impl TxHashCache {
             .unwrap_or(tx_hash)
             .to_lowercase();
         let key = (chain.to_owned(), normalized);
-        self.cache
-            .get(&key)
-            .is_some_and(|&ts| Instant::now().duration_since(ts) < self.ttl)
+        self.cache.get(&key).is_some_and(|entry| match entry {
+            TxHashCacheEntry::Reserved(_) => true,
+            TxHashCacheEntry::Committed(timestamp) => {
+                Instant::now().duration_since(*timestamp) < self.ttl
+            }
+        })
     }
 
-    /// Remove a previously inserted entry (used to roll back a reservation on handler error).
-    pub fn remove(&mut self, chain: &str, tx_hash: &str) {
+    fn key(chain: &str, tx_hash: &str) -> (String, String) {
         let normalized = tx_hash
             .strip_prefix("0x")
             .or_else(|| tx_hash.strip_prefix("0X"))
             .unwrap_or(tx_hash)
             .to_lowercase();
-        self.cache.remove(&(chain.to_owned(), normalized));
+        (chain.to_owned(), normalized)
+    }
+
+    fn remove_reservation(&mut self, chain: &str, tx_hash: &str, token: u64) {
+        let key = Self::key(chain, tx_hash);
+        if matches!(self.cache.get(&key), Some(TxHashCacheEntry::Reserved(current)) if *current == token)
+        {
+            self.cache.remove(&key);
+        }
+    }
+
+    fn commit_reservation(&mut self, chain: &str, tx_hash: &str, token: u64) {
+        let key = Self::key(chain, tx_hash);
+        if matches!(self.cache.get(&key), Some(TxHashCacheEntry::Reserved(current)) if *current == token)
+        {
+            self.cache
+                .insert(key, TxHashCacheEntry::Committed(Instant::now()));
+        }
     }
 
     /// Check if tx_hash was recently submitted and insert if not.
-    /// Returns `Ok(())` if new, `Err(TxHashCacheError)` if duplicate or cache full.
+    /// Returns a reservation token if new, or an error if duplicate/cache full.
     pub fn check_and_insert(
         &mut self,
         chain: String,
         tx_hash: String,
-    ) -> Result<(), TxHashCacheError> {
+    ) -> Result<u64, TxHashCacheError> {
         let now = Instant::now();
         let normalized = tx_hash
             .strip_prefix("0x")
@@ -93,15 +120,17 @@ impl TxHashCache {
         // Clean expired entries if cache is getting large (75% threshold)
         if self.cache.len() > self.max_entries.saturating_mul(3) / 4 {
             let ttl = self.ttl;
-            self.cache
-                .retain(|_, &mut timestamp| now.duration_since(timestamp) < ttl);
+            self.cache.retain(|_, entry| match entry {
+                TxHashCacheEntry::Reserved(_) => true,
+                TxHashCacheEntry::Committed(timestamp) => now.duration_since(*timestamp) < ttl,
+            });
         }
 
-        // Check for duplicate within TTL
-        if let Some(&timestamp) = self.cache.get(&key) {
-            if now.duration_since(timestamp) < self.ttl {
-                return Err(TxHashCacheError::Duplicate);
-            }
+        if self.cache.get(&key).is_some_and(|entry| match entry {
+            TxHashCacheEntry::Reserved(_) => true,
+            TxHashCacheEntry::Committed(timestamp) => now.duration_since(*timestamp) < self.ttl,
+        }) {
+            return Err(TxHashCacheError::Duplicate);
         }
 
         if self.cache.len() >= self.max_entries {
@@ -113,8 +142,10 @@ impl TxHashCache {
             return Err(TxHashCacheError::CacheFull);
         }
 
-        self.cache.insert(key, now);
-        Ok(())
+        let token = self.next_reservation;
+        self.next_reservation = self.next_reservation.wrapping_add(1);
+        self.cache.insert(key, TxHashCacheEntry::Reserved(token));
+        Ok(token)
     }
 }
 
@@ -128,30 +159,32 @@ pub struct TxHashReservation {
     cache: Arc<Mutex<TxHashCache>>,
     chain: String,
     tx_hash: String,
-    committed: bool,
+    token: u64,
 }
 
 impl TxHashReservation {
-    fn new(cache: Arc<Mutex<TxHashCache>>, chain: String, tx_hash: String) -> Self {
+    fn new(cache: Arc<Mutex<TxHashCache>>, chain: String, tx_hash: String, token: u64) -> Self {
         Self {
             cache,
             chain,
             tx_hash,
-            committed: false,
+            token,
         }
     }
 
-    /// Mark this reservation as permanent. Drop will no longer remove the entry.
-    pub fn commit(mut self) {
-        self.committed = true;
+    /// Commit the reservation and start its duplicate-detection TTL.
+    pub fn commit(self) {
+        self.cache
+            .lock()
+            .commit_reservation(&self.chain, &self.tx_hash, self.token);
     }
 }
 
 impl Drop for TxHashReservation {
     fn drop(&mut self) {
-        if !self.committed {
-            self.cache.lock().remove(&self.chain, &self.tx_hash);
-        }
+        self.cache
+            .lock()
+            .remove_reservation(&self.chain, &self.tx_hash, self.token);
     }
 }
 
@@ -443,10 +476,11 @@ async fn create_relay(
             .lock()
             .check_and_insert(req.origin_chain.clone(), req.tx_hash.clone())
         {
-            Ok(()) => Some(TxHashReservation::new(
+            Ok(token) => Some(TxHashReservation::new(
                 cache.clone(),
                 req.origin_chain.clone(),
                 req.tx_hash.clone(),
+                token,
             )),
             Err(TxHashCacheError::Duplicate) => {
                 state.record_failure("duplicate_tx");
@@ -910,4 +944,52 @@ async fn relay_work(
     Ok(Json(RelayResponse {
         messages: processed_messages,
     }))
+}
+
+#[cfg(test)]
+mod tx_hash_cache_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn commit_starts_ttl_and_stale_guard_cannot_remove_replacement() {
+        let ttl = Duration::from_millis(5);
+        let cache = Arc::new(Mutex::new(TxHashCache::new_with_ttl(10, ttl)));
+        let first_token = cache
+            .lock()
+            .check_and_insert("ethereum".to_owned(), "0x01".to_owned())
+            .expect("first reservation");
+        let first = TxHashReservation::new(
+            cache.clone(),
+            "ethereum".to_owned(),
+            "0x01".to_owned(),
+            first_token,
+        );
+
+        cache
+            .lock()
+            .remove_reservation("ethereum", "0x01", first_token);
+        let second_token = cache
+            .lock()
+            .check_and_insert("ethereum".to_owned(), "0x01".to_owned())
+            .expect("replacement reservation");
+        let second = TxHashReservation::new(
+            cache.clone(),
+            "ethereum".to_owned(),
+            "0x01".to_owned(),
+            second_token,
+        );
+
+        drop(first);
+        assert!(cache.lock().contains("ethereum", "0x01"));
+        tokio::time::sleep(ttl + ttl).await;
+        assert!(
+            cache.lock().contains("ethereum", "0x01"),
+            "an in-flight reservation must not expire"
+        );
+
+        second.commit();
+        assert!(cache.lock().contains("ethereum", "0x01"));
+        tokio::time::sleep(ttl + ttl).await;
+        assert!(!cache.lock().contains("ethereum", "0x01"));
+    }
 }

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -954,10 +954,12 @@ mod tx_hash_cache_tests {
     async fn commit_starts_ttl_and_stale_guard_cannot_remove_replacement() {
         let ttl = Duration::from_millis(5);
         let cache = Arc::new(Mutex::new(TxHashCache::new_with_ttl(10, ttl)));
-        let first_token = cache
+        let Ok(first_token) = cache
             .lock()
             .check_and_insert("ethereum".to_owned(), "0x01".to_owned())
-            .expect("first reservation");
+        else {
+            panic!("first reservation");
+        };
         let first = TxHashReservation::new(
             cache.clone(),
             "ethereum".to_owned(),
@@ -968,10 +970,12 @@ mod tx_hash_cache_tests {
         cache
             .lock()
             .remove_reservation("ethereum", "0x01", first_token);
-        let second_token = cache
+        let Ok(second_token) = cache
             .lock()
             .check_and_insert("ethereum".to_owned(), "0x01".to_owned())
-            .expect("replacement reservation");
+        else {
+            panic!("replacement reservation");
+        };
         let second = TxHashReservation::new(
             cache.clone(),
             "ethereum".to_owned(),

--- a/rust/main/agents/relayer/src/relay_api/handlers.rs
+++ b/rust/main/agents/relayer/src/relay_api/handlers.rs
@@ -806,6 +806,7 @@ async fn relay_work(
         nonce: u32,
     }
 
+    // Canonical permit order prevents cross-request AB/BA deadlocks.
     let mut batches: BTreeMap<u32, (Sender<QueueOperationBatch>, QueueOperationBatch)> =
         BTreeMap::new();
     let mut sent_messages = Vec::with_capacity(validated.len());

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -270,6 +270,61 @@ async fn make_state_multi_with_capacity(
     )
 }
 
+async fn make_state_with_distinct_channels(
+    indexer: Arc<dyn Indexer<HyperlaneMessage>>,
+    origin: u32,
+    dests: &[u32],
+    channel_capacity: usize,
+) -> (
+    ServerState,
+    HashMap<u32, mpsc::Sender<QueueOperationBatch>>,
+    HashMap<u32, mpsc::Receiver<QueueOperationBatch>>,
+    TempDir,
+) {
+    let tempdir = TempDir::new().unwrap();
+    let db = test_utils::setup_db(tempdir.path().to_str().unwrap().to_owned());
+    let domain = HyperlaneDomain::new_test_domain("relay_api_distinct_channels_test");
+    let rocks_db = HyperlaneRocksDB::new(&domain, db);
+    let mock_builder = build_mock_base_builder(domain.clone(), domain.clone());
+    let msg_ctx = Arc::new(MessageContext {
+        destination_mailbox: Arc::new(mock_mailbox()),
+        origin_db: Arc::new(rocks_db.clone()),
+        cache: OptionalCache::new(None),
+        metadata_builder: Arc::new(mock_builder),
+        origin_gas_payment_enforcer: Arc::new(RwLock::new(GasPaymentEnforcer::new(
+            [],
+            rocks_db.clone(),
+        ))),
+        transaction_gas_limit: None,
+        metrics: dummy_submission_metrics(),
+        application_operation_verifier: Arc::new(DummyApplicationOperationVerifier {}),
+    });
+    let mut indexers = HashMap::new();
+    indexers.insert("ethereum".to_string(), indexer);
+    let mut dbs = HashMap::new();
+    dbs.insert(origin, rocks_db);
+    let mut send_channels = HashMap::new();
+    let mut retained_senders = HashMap::new();
+    let mut receivers = HashMap::new();
+    let mut msg_ctxs = HashMap::new();
+    for &dest in dests {
+        let (tx, rx) = mpsc::channel(channel_capacity);
+        retained_senders.insert(dest, tx.clone());
+        send_channels.insert(dest, tx);
+        receivers.insert(dest, rx);
+        msg_ctxs.insert((origin, dest), msg_ctx.clone());
+    }
+    let state = ServerState::new(
+        indexers,
+        HashMap::new(),
+        dbs,
+        send_channels,
+        msg_ctxs,
+        RelayApiMetrics::new(&Registry::new()).unwrap(),
+    );
+    (state, retained_senders, receivers, tempdir)
+}
+
 fn relay_request(tx_hash: &str) -> Request<Body> {
     Request::builder()
         .method("POST")
@@ -680,6 +735,37 @@ async fn test_partial_send_failure_releases_dedup_for_retry() {
         StatusCode::TOO_MANY_REQUESTS,
         "after 500, same tx_hash must not be blocked by dedup cache"
     );
+}
+
+#[tokio::test]
+async fn test_multi_destination_capacity_is_reserved_in_domain_order() {
+    let low = DEST_ID;
+    let high = DEST_ID + 1;
+    let indexer = Arc::new(MockIndexer::with_messages(vec![
+        test_msg(ORIGIN_ID, high, 1),
+        test_msg(ORIGIN_ID, low, 2),
+    ]));
+    let (state, senders, mut receivers, _tempdir) =
+        make_state_with_distinct_channels(indexer, ORIGIN_ID, &[high, low], 1).await;
+    let low_sender = senders.get(&low).unwrap();
+    low_sender.send(Vec::new()).await.unwrap();
+
+    let relay = tokio::spawn(send_relay(state.router(), TX_HASH));
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(
+        senders.get(&high).unwrap().capacity(),
+        1,
+        "higher destination capacity must remain free while lower is blocked"
+    );
+
+    receivers.get_mut(&low).unwrap().recv().await.unwrap();
+    let status = tokio::time::timeout(Duration::from_secs(1), relay)
+        .await
+        .expect("relay should not deadlock")
+        .unwrap();
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(receivers.get(&low).unwrap().len(), 1);
+    assert_eq!(receivers.get(&high).unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/rust/main/agents/relayer/src/relay_api/tests.rs
+++ b/rust/main/agents/relayer/src/relay_api/tests.rs
@@ -460,6 +460,47 @@ async fn test_saturated_processor_returns_503_without_partial_enqueue() {
 }
 
 #[tokio::test]
+async fn test_blocked_reservation_does_not_expire_before_handoff() {
+    let messages = vec![test_msg(ORIGIN_ID, DEST_ID, 1)];
+    let (TestHarness { state, mut rx, .. }, tx) = make_state_multi_with_capacity(
+        Arc::new(MockIndexer::with_messages(messages)),
+        ORIGIN_ID,
+        vec![DEST_ID],
+        1,
+    )
+    .await;
+    tx.send(Vec::new()).await.expect("prefill should succeed");
+
+    let cache = Arc::new(Mutex::new(TxHashCache::new_with_ttl(
+        100,
+        Duration::from_millis(1),
+    )));
+    let router = state.with_tx_hash_cache(cache.clone()).router();
+    let blocked_router = router.clone();
+    let request = tokio::spawn(async move { send_relay(blocked_router, TX_HASH).await });
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !cache.lock().contains("ethereum", TX_HASH) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("request should reserve its tx hash");
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    assert_eq!(
+        send_relay(router, TX_HASH).await,
+        StatusCode::TOO_MANY_REQUESTS,
+        "retry must not replace an in-flight reservation after the TTL"
+    );
+
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+    assert!(!cache.lock().contains("ethereum", TX_HASH));
+    assert_eq!(rx.recv().await.expect("prefilled batch").len(), 0);
+}
+
+#[tokio::test]
 async fn test_duplicate_within_ttl_rejected() {
     let msg = test_msg(ORIGIN_ID, DEST_ID, 1);
     let TestHarness {

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -181,7 +181,7 @@ impl BaseAgent for Relayer {
         let cache = OptionalCache::new(inner_cache);
         debug!(elapsed = ?start_entity_init.elapsed(), event = "initialized cache", "Relayer startup duration measurement");
 
-        let db = DB::from_path(&settings.db)?;
+        let db = DB::from_path_with_rollback_wal(&settings.db)?;
 
         start_entity_init = Instant::now();
         let origins =

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -72,6 +72,16 @@ impl DB {
     /// Opens db at `db_path` and creates if missing
     #[tracing::instrument(err)]
     pub fn from_path(db_path: &Path) -> Result<DB> {
+        Self::from_path_with_options(db_path, false)
+    }
+
+    /// Opens a DB with archived WAL retained for rollback-derived index recovery.
+    #[tracing::instrument(err)]
+    pub fn from_path_with_rollback_wal(db_path: &Path) -> Result<DB> {
+        Self::from_path_with_options(db_path, true)
+    }
+
+    fn from_path_with_options(db_path: &Path, retain_rollback_wal: bool) -> Result<DB> {
         let path = {
             let mut path = db_path
                 .parent()
@@ -92,8 +102,10 @@ impl DB {
 
         let mut opts = Options::default();
         opts.create_if_missing(true);
-        opts.set_wal_ttl_seconds(ROLLBACK_WAL_RETENTION_SECONDS);
-        opts.set_wal_size_limit_mb(ROLLBACK_WAL_SIZE_LIMIT_MB);
+        if retain_rollback_wal {
+            opts.set_wal_ttl_seconds(ROLLBACK_WAL_RETENTION_SECONDS);
+            opts.set_wal_size_limit_mb(ROLLBACK_WAL_SIZE_LIMIT_MB);
+        }
 
         Rocks::open(&opts, &path)
             .map_err(|e| DbError::OpeningError {

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -64,7 +64,7 @@ fn remove_archived_wal_files(db_path: &Path) -> Result<()> {
                     entry.path().display()
                 ))
             })?;
-            removed += 1;
+            removed = removed.saturating_add(1);
         }
     }
     if removed > 0 {

--- a/rust/main/hyperlane-base/src/db/rocks/mod.rs
+++ b/rust/main/hyperlane-base/src/db/rocks/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc};
+use std::{fs, io::ErrorKind, path::Path, sync::Arc};
 
 use super::error::DbError;
 use rocksdb::{Direction, IteratorMode, Options, WriteBatch, WriteBatchIterator, DB as Rocks};
@@ -25,6 +25,53 @@ pub mod test_utils;
 const ROLLBACK_WAL_RETENTION_SECONDS: u64 = 7 * 24 * 60 * 60;
 // Cap the retained fast path so a high-write database cannot grow without bound.
 const ROLLBACK_WAL_SIZE_LIMIT_MB: u64 = 1_024;
+
+fn remove_archived_wal_files(db_path: &Path) -> Result<()> {
+    let archive_path = db_path.join("archive");
+    let entries = match fs::read_dir(&archive_path) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(DbError::Other(format!(
+                "Failed to inspect archived RocksDB WAL at {}: {err}",
+                archive_path.display()
+            )))
+        }
+    };
+    let mut removed = 0_u64;
+    for entry in entries {
+        let entry = entry.map_err(|err| {
+            DbError::Other(format!(
+                "Failed to inspect archived RocksDB WAL entry at {}: {err}",
+                archive_path.display()
+            ))
+        })?;
+        let file_type = entry.file_type().map_err(|err| {
+            DbError::Other(format!(
+                "Failed to inspect archived RocksDB WAL file {}: {err}",
+                entry.path().display()
+            ))
+        })?;
+        let is_wal = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.strip_suffix(".log"))
+            .is_some_and(|stem| !stem.is_empty() && stem.bytes().all(|byte| byte.is_ascii_digit()));
+        if file_type.is_file() && is_wal {
+            fs::remove_file(entry.path()).map_err(|err| {
+                DbError::Other(format!(
+                    "Failed to remove archived RocksDB WAL file {}: {err}",
+                    entry.path().display()
+                ))
+            })?;
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        info!(path=%archive_path.display(), removed, "Removed archived RocksDB WAL after disabling rollback retention");
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone)]
 /// A KV Store
@@ -107,13 +154,15 @@ impl DB {
             opts.set_wal_size_limit_mb(ROLLBACK_WAL_SIZE_LIMIT_MB);
         }
 
-        Rocks::open(&opts, &path)
-            .map_err(|e| DbError::OpeningError {
-                source: Box::new(e),
-                path: db_path.into(),
-                canonicalized: path,
-            })
-            .map(Into::into)
+        let rocks = Rocks::open(&opts, &path).map_err(|e| DbError::OpeningError {
+            source: Box::new(e),
+            path: db_path.into(),
+            canonicalized: path.clone(),
+        })?;
+        if !retain_rollback_wal {
+            remove_archived_wal_files(&path)?;
+        }
+        Ok(rocks.into())
     }
 
     /// Store a value in the DB
@@ -273,6 +322,8 @@ impl DbBatch {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use rocksdb::{Options, WriteBatch, DB as Rocks};
 
     use super::DB;
@@ -357,5 +408,22 @@ mod tests {
             Some(b"old-count".to_vec())
         );
         assert_eq!(db.retrieve(b"status").expect("read status"), None);
+    }
+
+    #[test]
+    fn default_reopen_removes_wal_archived_under_retention() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("db");
+        drop(DB::from_path_with_rollback_wal(&db_path).unwrap());
+
+        let archive_path = db_path.join("archive");
+        fs::create_dir_all(&archive_path).unwrap();
+        fs::write(archive_path.join("000001.log"), b"retained wal").unwrap();
+        fs::write(archive_path.join("keep.txt"), b"unrelated").unwrap();
+
+        drop(DB::from_path(&db_path).unwrap());
+
+        assert!(!archive_path.join("000001.log").exists());
+        assert!(archive_path.join("keep.txt").exists());
     }
 }

--- a/rust/main/lander/src/dispatcher/stages/state.rs
+++ b/rust/main/lander/src/dispatcher/stages/state.rs
@@ -138,7 +138,7 @@ impl DispatcherState {
     ) -> Result<Self> {
         let db = match settings.db {
             DatabaseOrPath::Database(db) => db,
-            DatabaseOrPath::Path(path) => DB::from_path(&path)?,
+            DatabaseOrPath::Path(path) => DB::from_path_with_rollback_wal(&path)?,
         };
         let rocksdb = Arc::new(HyperlaneRocksDB::new(&settings.domain, db));
         let adapter = AdapterFactory::build(


### PR DESCRIPTION
## Summary

- cap the six-PR relayer stack, inheriting from #9399 canonical multi-destination admission and its 250ms whole-request capacity bound
- keep in-flight tx-hash reservations non-expiring and generation-safe while admission is active; start duplicate TTL only after handoff commits
- make archived rollback WAL retention opt-in for relayer/Lander databases
- keep the shared database opener used by validators and scrapers on normal WAL behavior, and remove WAL files archived by the deployed retention config on default reopen

## Why it matters

The recovery rollout in #9426 made Lander state durable. #9399 removes the cross-destination AB/BA deadlock and bounds relay admission. This follow-up makes that timeout/cancellation boundary safe for deduplication: dropping a timed-out request releases only its own reservation generation, while an in-flight reservation cannot expire and admit a duplicate before handoff.

The shared RocksDB opener also enabled seven-day, 1 GiB archived-WAL retention for every agent database even though only Lander consumes rollback history. Explicit rollback-WAL openers retain recovery for the relayer and standalone Lander while avoiding unrelated validator/scraper disk retention.

## Expected improvement

- preserves #9399's at-most-250ms whole-request relay admission bound; no throughput claim
- removes 100% of #9426's added archived-WAL retention from non-relayer databases: configured ceiling goes from 1 GiB over seven days to 0 and a default reopen deletes already archived WAL files; actual disk savings remain workload-dependent
- relayer/Lander recovery behavior and active RocksDB WAL behavior are unchanged

## Verification

- inherited #9399 saturation regression proves a full/open processor channel returns 503 within the admission bound, enqueues nothing, and releases the tx-hash reservation
- blocked-capacity short-TTL regression proves an active reservation cannot expire before timeout/handoff; cancellation releases it
- stale-reservation-token, commit-time TTL, canonical destination-order, and retention-enabled-to-default-reopen regressions remain present
- saturating removal accounting satisfies `clippy::arithmetic_side_effects`
- `cargo fmt --package relayer --package hyperlane-base --package lander -- --check`
- exact rebase range reviewed with `git range-diff`; `git diff --check` passes
- exact-head CI is the remaining build/test gate

Stacked directly on #9388 (`46bd858e07`) so the retry, destination-index and prepare stack lands as one six-PR chain. Exact head: `d6286c03b9`.

Follow-up to #9426 and the deployed image pin in #9445. Part of #9386.
