### PR TITLE
feat(metrics): attribute RPC requests by operation

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6545,6 +6545,7 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
+ "tokio",
  "url",
 ]
 
@@ -7570,6 +7571,7 @@ dependencies = [
  "hyperlane-base",
  "hyperlane-core",
  "hyperlane-ethereum",
+ "hyperlane-metric",
  "hyperlane-radix",
  "hyperlane-sealevel",
  "hyperlane-tron",

--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -26,6 +26,7 @@ use hyperlane_core::{
     MessageSubmissionData, Metadata, PendingOperation, PendingOperationResult,
     PendingOperationStatus, ReprepareReason, TryBatchAs, TxCostEstimate, TxOutcome, H256, U256,
 };
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use hyperlane_operation_verifier::ApplicationOperationVerifier;
 
 use crate::{
@@ -343,11 +344,11 @@ impl PendingOperation for PendingMessage {
         // If the message has already been processed, e.g. due to another relayer having
         // already processed, then mark it as already-processed, and move on to
         // the next tick.
-        let is_already_delivered = match self
-            .ctx
-            .destination_mailbox
-            .delivered(self.message.id())
-            .await
+        let is_already_delivered = match with_rpc_operation(
+            RpcOperation::RelayerDelivery,
+            self.ctx.destination_mailbox.delivered(self.message.id()),
+        )
+        .await
         {
             Ok(is_delivered) => is_delivered,
             Err(err) => {
@@ -363,10 +364,13 @@ impl PendingOperation for PendingMessage {
         }
 
         // We cannot deliver to an address that is not a contract so check and drop if it isn't.
-        let is_contract = match self.is_recipient_contract().await {
-            Ok(is_contract) => is_contract,
-            Err(reprepare_reason) => return reprepare_reason,
-        };
+        let is_contract =
+            match with_rpc_operation(RpcOperation::RelayerRecipient, self.is_recipient_contract())
+                .await
+            {
+                Ok(is_contract) => is_contract,
+                Err(reprepare_reason) => return reprepare_reason,
+            };
         if !is_contract {
             info!(
                 recipient=?self.message.recipient,
@@ -392,11 +396,13 @@ impl PendingOperation for PendingMessage {
         // re-fetched on every 1s poll cycle.
         let tx_cost_estimate = match self.metadata.as_ref() {
             Some(metadata) => {
-                match self
-                    .ctx
-                    .destination_mailbox
-                    .process_estimate_costs(&self.message, metadata)
-                    .await
+                match with_rpc_operation(
+                    RpcOperation::RelayerEstimate,
+                    self.ctx
+                        .destination_mailbox
+                        .process_estimate_costs(&self.message, metadata),
+                )
+                .await
                 {
                     Ok(s) => {
                         self.ica_reveal_attempts = 0;
@@ -420,7 +426,9 @@ impl PendingOperation for PendingMessage {
 
         match self.metadata.as_ref() {
             Some(_) => tracing::debug!(USE_CACHE_METADATA_LOG),
-            None => match self.build_metadata().await {
+            None => match with_rpc_operation(RpcOperation::RelayerMetadata, self.build_metadata())
+                .await
+            {
                 Ok(metadata) => self.metadata = Some(metadata),
                 Err(err) => return err,
             },
@@ -442,11 +450,13 @@ impl PendingOperation for PendingMessage {
                     message_id = ?self.message.id(),
                     "Dry-run simulating process call before submission"
                 );
-                match self
-                    .ctx
-                    .destination_mailbox
-                    .process_estimate_costs(&self.message, metadata)
-                    .await
+                match with_rpc_operation(
+                    RpcOperation::RelayerEstimate,
+                    self.ctx
+                        .destination_mailbox
+                        .process_estimate_costs(&self.message, metadata),
+                )
+                .await
                 {
                     Ok(cost) => {
                         self.ica_reveal_attempts = 0;
@@ -542,11 +552,13 @@ impl PendingOperation for PendingMessage {
                 message_id = ?self.message.id(),
                 "Dry-run simulating process call before submission"
             );
-            if let Err(e) = self
-                .ctx
-                .destination_mailbox
-                .process_estimate_costs(&self.message, metadata)
-                .await
+            if let Err(e) = with_rpc_operation(
+                RpcOperation::RelayerEstimate,
+                self.ctx
+                    .destination_mailbox
+                    .process_estimate_costs(&self.message, metadata),
+            )
+            .await
             {
                 warn!(
                     message_id = ?self.message.id(),
@@ -564,11 +576,13 @@ impl PendingOperation for PendingMessage {
 
         // We use the estimated gas limit from the prior call to
         // `process_estimate_costs` to avoid a second gas estimation.
-        let tx_outcome = self
-            .ctx
-            .destination_mailbox
-            .process(&self.message, &state.metadata, Some(gas_limit))
-            .await;
+        let tx_outcome = with_rpc_operation(
+            RpcOperation::TransactionLifecycle,
+            self.ctx
+                .destination_mailbox
+                .process(&self.message, &state.metadata, Some(gas_limit)),
+        )
+        .await;
         match tx_outcome {
             Ok(outcome) => {
                 self.set_operation_outcome(outcome, gas_limit).await;
@@ -598,11 +612,11 @@ impl PendingOperation for PendingMessage {
             return PendingOperationResult::NotReady;
         }
 
-        let is_delivered = match self
-            .ctx
-            .destination_mailbox
-            .delivered(self.message.id())
-            .await
+        let is_delivered = match with_rpc_operation(
+            RpcOperation::RelayerDelivery,
+            self.ctx.destination_mailbox.delivered(self.message.id()),
+        )
+        .await
         {
             Ok(is_delivered) => is_delivered,
             Err(err) => {
@@ -990,11 +1004,13 @@ impl PendingMessage {
         }
 
         // Fetch the recipient ISM address
-        let ism_address = match self
-            .ctx
-            .destination_mailbox
-            .recipient_ism(self.message.recipient)
-            .await
+        let ism_address = match with_rpc_operation(
+            RpcOperation::RelayerRecipient,
+            self.ctx
+                .destination_mailbox
+                .recipient_ism(self.message.recipient),
+        )
+        .await
         {
             Ok(ism_address) => ism_address,
             Err(err) => {

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -38,7 +38,10 @@ use hyperlane_core::{
     H256, U256,
 };
 use hyperlane_ethereum::{RpcConnectionConf, Signers, SingletonSigner, SingletonSignerHandle};
-use hyperlane_metric::prometheus_metric::RpcRole;
+use hyperlane_metric::{
+    prometheus_metric::RpcRole,
+    rpc_operation::{with_rpc_operation, RpcOperation},
+};
 
 use crate::merkle_tree_hook_sync::{
     merkle_tree_cursor_state, CheckpointingMerkleTreeStore, MerkleTreeHookWebSocketSync,
@@ -1421,16 +1424,24 @@ impl Validator {
         let mut tasks = vec![];
         tasks.push(tokio::spawn(
             async move {
-                backfill_submitter
-                    .backfill_checkpoint_submitter(backfill_target)
-                    .await
+                with_rpc_operation(
+                    RpcOperation::ValidatorCheckpoint,
+                    backfill_submitter.backfill_checkpoint_submitter(backfill_target),
+                )
+                .await
             }
             .instrument(info_span!("BackfillCheckpointSubmitter")),
         ));
 
         tasks.push(tokio::spawn(
-            async move { submitter.checkpoint_submitter(tip_tree.tree).await }
-                .instrument(info_span!("TipCheckpointSubmitter")),
+            async move {
+                with_rpc_operation(
+                    RpcOperation::ValidatorCheckpoint,
+                    submitter.checkpoint_submitter(tip_tree.tree),
+                )
+                .await
+            }
+            .instrument(info_span!("TipCheckpointSubmitter")),
         ));
 
         tasks

--- a/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
@@ -234,6 +234,7 @@ mod tests {
                         method,
                         status,
                         "primary",
+                        "unattributed",
                     ])
                     .get(),
                 1,

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -19,6 +19,7 @@ use hyperlane_core::{
     SequenceAwareIndexer,
 };
 use hyperlane_core::{Indexed, LogMeta, H512};
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 
 use crate::settings::IndexSettings;
 
@@ -275,7 +276,10 @@ where
                 .await;
             }
         };
-        let res = tokio::join!(tx_id_task, cursor_task);
+        let res = with_rpc_operation(RpcOperation::ContractSync, async {
+            tokio::join!(tx_id_task, cursor_task)
+        })
+        .await;
 
         // we should never reach this because the 2 tasks should never end
         tracing::error!(chain = chain_name, label, ?res, "contract sync loop exit");

--- a/rust/main/hyperlane-base/src/contract_sync/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/mod.rs
@@ -631,6 +631,10 @@ mod tests {
     #[async_trait]
     impl ContractSyncCursor<HyperlaneMessage> for PendingCursor {
         async fn next_action(&mut self) -> Result<(CursorAction, Duration)> {
+            assert_eq!(
+                hyperlane_metric::rpc_operation::current_rpc_operation(),
+                RpcOperation::ContractSync
+            );
             pending().await
         }
 

--- a/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
+++ b/rust/main/hyperlane-base/src/metrics/agent_metrics.rs
@@ -13,6 +13,7 @@ use hyperlane_core::HyperlaneDomain;
 use hyperlane_core::HyperlaneProvider;
 use hyperlane_core::NativeToken;
 use hyperlane_core::ReorgPeriod;
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use maplit::hashmap;
 use prometheus::GaugeVec;
 use prometheus::IntGaugeVec;
@@ -437,8 +438,11 @@ impl ChainSpecificMetricsUpdater {
             .name(&name)
             .spawn(
                 async move {
-                    self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL)
-                        .await;
+                    with_rpc_operation(
+                        RpcOperation::AgentMetrics,
+                        self.start_updating_on_interval(METRICS_SCRAPE_INTERVAL),
+                    )
+                    .await;
                 }
                 .instrument(info_span!("MetricsUpdater")),
             )

--- a/rust/main/hyperlane-metric/Cargo.toml
+++ b/rust/main/hyperlane-metric/Cargo.toml
@@ -15,4 +15,5 @@ maplit.workspace = true
 prometheus.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 url.workspace = true

--- a/rust/main/hyperlane-metric/src/lib.rs
+++ b/rust/main/hyperlane-metric/src/lib.rs
@@ -6,5 +6,7 @@
 
 /// Prometheus metric related code
 pub mod prometheus_metric;
+/// Fixed-cardinality RPC operation attribution.
+pub mod rpc_operation;
 /// utils for some metrics handling code
 pub mod utils;

--- a/rust/main/hyperlane-metric/src/prometheus_metric.rs
+++ b/rust/main/hyperlane-metric/src/prometheus_metric.rs
@@ -8,6 +8,7 @@ use prometheus::{CounterVec, HistogramVec, IntCounterVec};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::rpc_operation::current_rpc_operation;
 use crate::utils::url_to_host_info;
 
 /// Expected label names for the metric.
@@ -30,6 +31,7 @@ pub const REQUEST_COUNT_LABELS: &[&str] = &[
     "method",
     "status",
     "rpc_role",
+    "operation",
 ];
 /// Help string for the metric.
 pub const REQUEST_COUNT_HELP: &str = "Total number of requests made to this client";
@@ -42,6 +44,7 @@ pub const REQUEST_DURATION_SECONDS_LABELS: &[&str] = &[
     "method",
     "status",
     "rpc_role",
+    "operation",
 ];
 /// Help string for the metric.
 pub const REQUEST_DURATION_SECONDS_HELP: &str = "Total number of seconds spent making requests";
@@ -155,6 +158,7 @@ impl PrometheusClientMetrics {
             "method" => method,
             "status" => if success { "success" } else { "failure" },
             "rpc_role" => config.rpc_role.as_str(),
+            "operation" => current_rpc_operation().as_str(),
         };
         if let Some(counter) = &self.request_count {
             counter.with(&labels).inc()
@@ -356,9 +360,17 @@ impl PrometheusConfigExt for PrometheusConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
+    use prometheus::{IntCounterVec, Opts};
     use url::Url;
 
-    use super::{ChainInfo, ClientConnectionType, PrometheusConfig, PrometheusConfigExt};
+    use crate::rpc_operation::{with_rpc_operation, RpcOperation};
+
+    use super::{
+        ChainInfo, ClientConnectionType, PrometheusClientMetricsBuilder, PrometheusConfig,
+        PrometheusConfigExt, REQUEST_COUNT_LABELS,
+    };
 
     #[test]
     fn test_node_host() {
@@ -395,5 +407,60 @@ mod tests {
             let actual = config.node_host();
             assert_eq!(actual, expected);
         }
+    }
+
+    #[tokio::test]
+    async fn request_metrics_include_operation_scope() {
+        let request_count = IntCounterVec::new(
+            Opts::new("test_request_count", "test request count"),
+            REQUEST_COUNT_LABELS,
+        )
+        .expect("valid request metric");
+        let metrics = PrometheusClientMetricsBuilder::default()
+            .request_count(request_count.clone())
+            .build()
+            .expect("valid client metrics");
+        let config = PrometheusConfig::from_url(
+            &Url::parse("https://rpc.example.com").expect("valid URL"),
+            ClientConnectionType::Rpc,
+            Some(ChainInfo {
+                name: Some("test-chain".to_string()),
+            }),
+        );
+
+        with_rpc_operation(RpcOperation::RelayerDelivery, async {
+            metrics.increment_metrics(&config, "eth_call", Instant::now(), true);
+        })
+        .await;
+        metrics.increment_metrics(&config, "eth_call", Instant::now(), true);
+
+        assert_eq!(
+            request_count
+                .with_label_values(&[
+                    "rpc.example.com:443",
+                    "rpc",
+                    "test-chain",
+                    "eth_call",
+                    "success",
+                    "primary",
+                    "relayer_delivery",
+                ])
+                .get(),
+            1,
+        );
+        assert_eq!(
+            request_count
+                .with_label_values(&[
+                    "rpc.example.com:443",
+                    "rpc",
+                    "test-chain",
+                    "eth_call",
+                    "success",
+                    "primary",
+                    "unattributed",
+                ])
+                .get(),
+            1,
+        );
     }
 }

--- a/rust/main/hyperlane-metric/src/rpc_operation.rs
+++ b/rust/main/hyperlane-metric/src/rpc_operation.rs
@@ -1,0 +1,88 @@
+//! Fixed-cardinality attribution for RPC requests.
+
+use std::future::Future;
+
+tokio::task_local! {
+    static RPC_OPERATION: RpcOperation;
+}
+
+/// The bounded operation classes used to attribute physical RPC requests.
+///
+/// Keep this enum small. Values become Prometheus labels, so addresses, message IDs,
+/// function names, provider URLs, and other unbounded inputs do not belong here.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RpcOperation {
+    /// The request did not run inside an explicit operation scope.
+    #[default]
+    Unattributed,
+    /// Contract event cursor and range synchronization.
+    ContractSync,
+    /// Periodic agent balance, block, and gas metrics.
+    AgentMetrics,
+    /// Validator checkpoint correctness and submission reads.
+    ValidatorCheckpoint,
+    /// Relayer destination delivery-state reads.
+    RelayerDelivery,
+    /// Relayer recipient code and ISM discovery reads.
+    RelayerRecipient,
+    /// Relayer ISM and metadata construction reads.
+    RelayerMetadata,
+    /// Relayer process simulation and transaction-cost estimation.
+    RelayerEstimate,
+    /// Nonce, submission, receipt, inclusion, and finality reads or writes.
+    TransactionLifecycle,
+}
+
+impl RpcOperation {
+    /// Return the stable Prometheus label value for this operation class.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unattributed => "unattributed",
+            Self::ContractSync => "contract_sync",
+            Self::AgentMetrics => "agent_metrics",
+            Self::ValidatorCheckpoint => "validator_checkpoint",
+            Self::RelayerDelivery => "relayer_delivery",
+            Self::RelayerRecipient => "relayer_recipient",
+            Self::RelayerMetadata => "relayer_metadata",
+            Self::RelayerEstimate => "relayer_estimate",
+            Self::TransactionLifecycle => "transaction_lifecycle",
+        }
+    }
+}
+
+/// Run a future with a fixed RPC operation attribution value.
+pub async fn with_rpc_operation<F>(operation: RpcOperation, future: F) -> F::Output
+where
+    F: Future,
+{
+    RPC_OPERATION.scope(operation, future).await
+}
+
+/// Return the current RPC operation, or `Unattributed` outside an explicit scope.
+pub fn current_rpc_operation() -> RpcOperation {
+    RPC_OPERATION
+        .try_with(|operation| *operation)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn scopes_and_restores_operation() {
+        assert_eq!(current_rpc_operation(), RpcOperation::Unattributed);
+
+        with_rpc_operation(RpcOperation::ContractSync, async {
+            assert_eq!(current_rpc_operation(), RpcOperation::ContractSync);
+            with_rpc_operation(RpcOperation::RelayerDelivery, async {
+                assert_eq!(current_rpc_operation(), RpcOperation::RelayerDelivery);
+            })
+            .await;
+            assert_eq!(current_rpc_operation(), RpcOperation::ContractSync);
+        })
+        .await;
+
+        assert_eq!(current_rpc_operation(), RpcOperation::Unattributed);
+    }
+}

--- a/rust/main/lander/Cargo.toml
+++ b/rust/main/lander/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 [dependencies]
 hyperlane-base = { path = "../hyperlane-base", features = ["test-utils"] }
 hyperlane-core = { path = "../hyperlane-core" }
+hyperlane-metric = { path = "../hyperlane-metric" }
 
 hyperlane-aleo = { path = "../chains/hyperlane-aleo", optional = true }
 hyperlane-ethereum = { path = "../chains/hyperlane-ethereum" }

--- a/rust/main/lander/src/dispatcher/entrypoint.rs
+++ b/rust/main/lander/src/dispatcher/entrypoint.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use eyre::{eyre, Result};
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use tracing::info;
 
 use crate::{
@@ -74,7 +75,11 @@ impl Entrypoint for DispatcherEntrypoint {
         &self,
         payload: &FullPayload,
     ) -> Result<Option<GasLimit>, LanderError> {
-        self.inner.adapter.estimate_gas_limit(payload).await
+        with_rpc_operation(
+            RpcOperation::RelayerEstimate,
+            self.inner.adapter.estimate_gas_limit(payload),
+        )
+        .await
     }
 }
 

--- a/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
+++ b/rust/main/lander/src/dispatcher/stages/building_stage/building.rs
@@ -1,6 +1,7 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use derive_new::new;
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{error, info, instrument, warn};
 
@@ -47,7 +48,11 @@ impl BuildingStage {
     #[instrument(skip_all, fields(payload_and_message_ids = ?payloads.iter().map(|p| (p.details.uuid.to_string(), p.details.metadata.clone())).collect::<Vec<_>>()))]
     async fn build_transactions(&self, payloads: &Vec<FullPayload>) {
         info!(?payloads, "Building transactions from payloads");
-        let tx_building_results = self.state.adapter.build_transactions(payloads).await;
+        let tx_building_results = with_rpc_operation(
+            RpcOperation::TransactionLifecycle,
+            self.state.adapter.build_transactions(payloads),
+        )
+        .await;
 
         for tx_building_result in tx_building_results {
             // push payloads that failed to be processed (but didn't fail simulation)

--- a/rust/main/lander/src/dispatcher/stages/finality_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/finality_stage.rs
@@ -8,6 +8,7 @@ use std::{
 use derive_new::new;
 use eyre::{eyre, Result};
 use futures_util::{future::try_join_all, StreamExt};
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use tokio::{
     sync::{mpsc, Mutex},
     time::sleep,
@@ -276,7 +277,12 @@ impl FinalityStage {
                     .metrics
                     .observe_status_read_batch(STAGE_NAME, 1, &state.domain);
                 call_until_success_or_nonretryable_error(
-                    || state.adapter.tx_status(&tx),
+                    || {
+                        with_rpc_operation(
+                            RpcOperation::TransactionLifecycle,
+                            state.adapter.tx_status(&tx),
+                        )
+                    },
                     "Querying transaction status",
                     state,
                 )
@@ -308,7 +314,11 @@ impl FinalityStage {
                 // update tx status in db
                 update_tx_status(state, &mut tx, tx_status).await?;
                 Self::record_reverted_payloads(&mut tx, state).await?;
-                state.adapter.post_finalized().await?;
+                with_rpc_operation(
+                    RpcOperation::TransactionLifecycle,
+                    state.adapter.post_finalized(),
+                )
+                .await?;
                 state.notify_reprocess_txs_activity();
                 let tx_uuid = tx.uuid.clone();
                 info!(?tx_uuid, "Transaction is finalized");
@@ -339,7 +349,12 @@ impl FinalityStage {
         use PayloadStatus::Dropped;
 
         let reverted_payloads = call_until_success_or_nonretryable_error(
-            || state.adapter.reverted_payloads(tx),
+            || {
+                with_rpc_operation(
+                    RpcOperation::TransactionLifecycle,
+                    state.adapter.reverted_payloads(tx),
+                )
+            },
             "Checking reverted payloads",
             state,
         )

--- a/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
+++ b/rust/main/lander/src/dispatcher/stages/inclusion_stage.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use derive_new::new;
 use eyre::{eyre, Result};
 use futures_util::{future::try_join_all, try_join, StreamExt};
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::sleep;
 use tracing::{error, info, info_span, instrument, warn, Instrument};
@@ -339,7 +340,12 @@ impl InclusionStage {
                 "Checking for any transactions that needs reprocessing"
             );
 
-            let txs = match state.adapter.get_reprocess_txs().await {
+            let txs = match with_rpc_operation(
+                RpcOperation::TransactionLifecycle,
+                state.adapter.get_reprocess_txs(),
+            )
+            .await
+            {
                 Ok(s) => s,
                 Err(err) => {
                     poll_rate = base_poll_rate;
@@ -453,7 +459,12 @@ impl InclusionStage {
                 info!(tx_uuid = ?tx.uuid, ?tx_status, "Transaction is pending inclusion");
                 update_tx_status(state, &mut tx, tx_status.clone()).await?;
                 pool.lock().await.insert(tx.uuid.clone(), tx.clone());
-                if !state.adapter.tx_ready_for_resubmission(&tx).await {
+                if !with_rpc_operation(
+                    RpcOperation::TransactionLifecycle,
+                    state.adapter.tx_ready_for_resubmission(&tx),
+                )
+                .await
+                {
                     info!(?tx, "Transaction is not ready for resubmission");
                     return Ok(());
                 }
@@ -534,7 +545,7 @@ impl InclusionStage {
         call_until_success_or_nonretryable_error(
             || async {
                 let mut tx_guard = tx_shared.lock().await;
-                let submit_result = state.adapter.submit(&mut tx_guard).await;
+                let submit_result = with_rpc_operation(RpcOperation::TransactionLifecycle, state.adapter.submit(&mut tx_guard)).await;
 
                 match submit_result {
                     Ok(()) => Ok(()),
@@ -563,7 +574,11 @@ impl InclusionStage {
                 let tx_clone = tx.clone();
                 async move {
                     let mut tx_clone_inner = tx_clone;
-                    state.adapter.estimate_tx(&mut tx_clone_inner).await?;
+                    with_rpc_operation(
+                        RpcOperation::RelayerEstimate,
+                        state.adapter.estimate_tx(&mut tx_clone_inner),
+                    )
+                    .await?;
                     Ok(tx_clone_inner)
                 }
             },
@@ -588,7 +603,11 @@ impl InclusionStage {
                 let tx_clone = tx.clone();
                 async move {
                     let mut tx_clone_inner = tx_clone;
-                    let failed_payloads = state.adapter.simulate_tx(&mut tx_clone_inner).await?;
+                    let failed_payloads = with_rpc_operation(
+                        RpcOperation::RelayerEstimate,
+                        state.adapter.simulate_tx(&mut tx_clone_inner),
+                    )
+                    .await?;
                     Ok((tx_clone_inner, failed_payloads))
                 }
             },

--- a/rust/main/lander/src/dispatcher/stages/utils.rs
+++ b/rust/main/lander/src/dispatcher/stages/utils.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::{future::Future, time::Duration};
 
 use futures_util::{stream, Stream, StreamExt};
+use hyperlane_metric::rpc_operation::{with_rpc_operation, RpcOperation};
 use tokio::time::sleep;
 use tracing::{error, info, instrument};
 
@@ -84,7 +85,11 @@ pub(super) async fn read_transaction_status_batch(
     state
         .metrics
         .observe_status_read_batch(stage, query_txs.len(), &state.domain);
-    let queried_statuses = state.adapter.tx_statuses(&query_txs).await;
+    let queried_statuses = with_rpc_operation(
+        RpcOperation::TransactionLifecycle,
+        state.adapter.tx_statuses(&query_txs),
+    )
+    .await;
     assert_eq!(
         queried_statuses.len(),
         query_txs.len(),


### PR DESCRIPTION
## Summary

- add a fixed-cardinality `operation` label to RPC request count and duration metrics
- attribute contract sync, agent metrics, validator checkpoint, relayer preparation/delivery, and Lander transaction lifecycle calls
- retain `unattributed` as the default so every physical request remains counted and missing scopes are visible

## Why

This extends the current reliability/performance DAG with production attribution. We need production attribution before centralizing more reads or replacing polling: it tells us which loops create provider load, error amplification, and recovery pressure.

The operation set is deliberately bounded to nine labels, including `unattributed`. It contains no chain, address, message, provider URL, or function-derived values.

## Expected impact

This claims **0% independent RPC or runtime reduction**. It splits the existing request count and duration series into nine fixed operation classes while preserving their aggregate, giving canaries a direct attributed/unattributed percentage and a production basis for later changes.

## Reliability boundary

This changes attribution only. It does not change request execution, retry behavior, checkpoint signing, message preparation, or transaction submission. Unscoped and newly introduced request paths fail into `unattributed`, not into missing accounting.

Adding the label changes the Prometheus series identity. Rollout dashboards should aggregate or group by `operation` explicitly and compare the `unattributed` share before using the data to size later cutovers.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p hyperlane-metric -p hyperlane-base -p lander -p validator -p relayer`
- `cargo test -p hyperlane-metric -p lander --lib` — 355 passed, 1 ignored total
- `cargo clippy -p hyperlane-metric -p hyperlane-base -p lander -p validator -- -D warnings`
- `cargo clippy --offline -p hyperlane-metric -p hyperlane-base -p relayer -- -D warnings`
- final metric tests **3/3**, contract-sync tests **5/5**, cumulative scraper-proxy tests **85/85**, and final cumulative relayer WebSocket tests **82/82** passed
- the sync cancellation regression also asserts the `ContractSync` operation scope inside the owned cursor future

The #9452 base now passes strict Clippy. RPC attribution wraps both owned indexing futures without changing the parent cancellation boundary.

## Stack

- base: #9452 at `eba58f72ee463f74f749cb8f920a48d76f102100`
- DAG: https://gist.github.com/paulbalaji/40e5b85ecaa1476d61ed8273daba9edb
- exact head: `226599f9f98a6f7e735db52808e97bf591f0e550`
