### PR TITLE
fix(aleo): contain delegated prover outages

### DIFF
--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -578,7 +578,7 @@ impl PendingOperation for PendingMessage {
             Err(e) => {
                 error!(error=?e, "Error when processing message");
                 self.clear_metadata();
-                return PendingOperationResult::Reprepare(ReprepareReason::ErrorSubmitting);
+                return self.on_reprepare::<String>(None, ReprepareReason::ErrorSubmitting);
             }
         }
     }
@@ -1537,6 +1537,7 @@ mod test {
     use hyperlane_base::tests::mock_hyperlane_db::MockHyperlaneDb as MockDb;
     use hyperlane_base::{cache::OptionalCache, db::*};
     use hyperlane_core::*;
+    use hyperlane_test::mocks::MockMailboxContract;
 
     use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
@@ -2227,6 +2228,58 @@ mod test {
             .expect("Message status not found");
 
         assert_eq!(db_status, expected_status);
+    }
+
+    #[tokio::test]
+    async fn submit_failure_advances_retry_backoff() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Optimism);
+        let cache = OptionalCache::new(None);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = DB::from_path(temp_dir.path()).unwrap();
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let mut message_context =
+            dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+
+        let mut mailbox = MockMailboxContract::new();
+        mailbox
+            .expect__domain()
+            .return_const(destination_domain.clone());
+        mailbox.expect_process().once().returning(|_, _, _| {
+            Err(ChainCommunicationError::from_other_str(
+                "delegated prover unavailable",
+            ))
+        });
+        message_context.destination_mailbox = Arc::new(mailbox);
+
+        let message = HyperlaneMessage {
+            origin: origin_domain.id(),
+            destination: destination_domain.id(),
+            ..Default::default()
+        };
+        let mut pending_message = PendingMessage::new(
+            message,
+            Arc::new(message_context),
+            PendingOperationStatus::ReadyToSubmit,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        pending_message.submission_data = Some(Box::new(MessageSubmissionData {
+            metadata: Metadata::new(vec![]),
+            gas_limit: U256::zero(),
+        }));
+
+        let result = PendingOperation::submit(&mut pending_message).await;
+
+        assert!(matches!(
+            result,
+            PendingOperationResult::Reprepare(ReprepareReason::ErrorSubmitting)
+        ));
+        assert_eq!(pending_message.num_retries, 1);
+        assert!(pending_message.next_attempt_after > Some(Instant::now()));
     }
 
     #[test]

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -442,16 +442,12 @@ impl<C: AleoClient> AleoProvider<C> {
 
         // Check delegated prover availability before performing expensive local authorization.
         // This keeps an auth or service outage from repeatedly consuming memory and CPU.
-        let delegated_prover = match self.proving_service.as_ref() {
-            Some(client) => {
-                let public_key = client.get_public_key().await.map_err(|error| {
-                    warn!(%error, "Delegated proving preflight failed");
-                    error
-                })?;
-                Some((client, public_key))
-            }
-            None => None,
-        };
+        if let Some(client) = self.proving_service.as_ref() {
+            client.get_public_key().await.map_err(|error| {
+                warn!(%error, "Delegated proving preflight failed");
+                error
+            })?;
+        }
 
         // Prepare VM + Authorization for execution.
         let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) = self
@@ -487,14 +483,14 @@ impl<C: AleoClient> AleoProvider<C> {
         // prover failure is retried by the relayer; falling back here can saturate Tokio's
         // blocking pool and destabilize unrelated chains.
         let start = Instant::now();
-        let transaction = match delegated_prover {
-            Some((client, public_key)) => {
+        let transaction = match self.proving_service {
+            Some(ref client) => {
                 debug!(
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
                 client
-                    .proving_request(authorization, fee, public_key)
+                    .proving_request(authorization, fee)
                     .await
                     .map_err(|error| {
                         warn!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -439,6 +439,20 @@ impl<C: AleoClient> AleoProvider<C> {
         V: TryInto<Value<N>>,
     {
         debug!("Creating ZK-Proof for: {}/{}", program_id, function_name);
+
+        // Check delegated prover availability before performing expensive local authorization.
+        // This keeps an auth or service outage from repeatedly consuming memory and CPU.
+        let delegated_prover = match self.proving_service.as_ref() {
+            Some(client) => {
+                let public_key = client.get_public_key().await.map_err(|error| {
+                    warn!(%error, "Delegated proving preflight failed");
+                    error
+                })?;
+                Some((client, public_key))
+            }
+            None => None,
+        };
+
         // Prepare VM + Authorization for execution.
         let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) = self
             .prepare_authorization::<N, I, V>(program_id, function_name, input, vm)
@@ -473,14 +487,14 @@ impl<C: AleoClient> AleoProvider<C> {
         // prover failure is retried by the relayer; falling back here can saturate Tokio's
         // blocking pool and destabilize unrelated chains.
         let start = Instant::now();
-        let transaction = match self.proving_service {
-            Some(ref client) => {
+        let transaction = match delegated_prover {
+            Some((client, public_key)) => {
                 debug!(
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
                 client
-                    .proving_request(authorization, fee)
+                    .proving_request(authorization, fee, public_key)
                     .await
                     .map_err(|error| {
                         warn!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -518,13 +518,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn jwt_auth_preserves_http_status_errors() {
+    async fn jwt_auth_sends_content_length_and_preserves_status_errors() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut buffer = [0; 4096];
-            stream.read(&mut buffer).unwrap();
+            let length = stream.read(&mut buffer).unwrap();
+            request_tx
+                .send(String::from_utf8_lossy(&buffer[..length]).to_lowercase())
+                .unwrap();
             stream
                 .write_all(
                     b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
@@ -540,6 +544,10 @@ mod tests {
         let error = client.get_auth_token().await.unwrap_err();
 
         assert!(error.to_string().contains("429 Too Many Requests"));
+        assert!(request_rx
+            .recv()
+            .unwrap()
+            .contains("\r\ncontent-length: 0\r\n"));
         server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -517,35 +517,17 @@ mod tests {
 
     #[tokio::test]
     async fn jwt_auth_sends_content_length_and_preserves_status_errors() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        let (request_tx, request_rx) = mpsc::channel();
-        let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buffer = [0; 4096];
-            let length = stream.read(&mut buffer).unwrap();
-            request_tx
-                .send(String::from_utf8_lossy(&buffer[..length]).to_lowercase())
-                .unwrap();
-            stream
-                .write_all(
-                    b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-                )
-                .unwrap();
-        });
-        let url = Url::parse(&format!(
-            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
-        ))
-        .unwrap();
-        let client = JWTBaseHttpClient::new(url, 0).unwrap();
+        let (client, server) = auth_server(
+            b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        );
 
-        let error = client.get_auth_token().await.unwrap_err();
+        let error = client.get_auth_token().await.expect_err("JWT should fail");
 
         assert!(error.to_string().contains("429 Too Many Requests"));
-        assert!(request_rx
-            .recv()
-            .unwrap()
+        assert!(server
+            .join()
+            .expect("auth server joined")
+            .to_ascii_lowercase()
             .contains("\r\ncontent-length: 0\r\n"));
-        server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -198,8 +198,6 @@ impl JWTBaseHttpClient {
             .header(CONTENT_LENGTH, "0")
             .send()
             .await
-            .map_err(HyperlaneAleoError::from)?
-            .error_for_status()
             .map_err(HyperlaneAleoError::from)?;
         let response = response
             .error_for_status()

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -201,6 +201,9 @@ impl JWTBaseHttpClient {
             .map_err(HyperlaneAleoError::from)?
             .error_for_status()
             .map_err(HyperlaneAleoError::from)?;
+        let response = response
+            .error_for_status()
+            .map_err(HyperlaneAleoError::from)?;
         let result = response
             .headers()
             .get(AUTHORIZATION)
@@ -511,6 +514,32 @@ mod tests {
             .unwrap();
 
         assert_eq!(response, None);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn jwt_auth_preserves_http_status_errors() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 4096];
+            stream.read(&mut buffer).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+        let url = Url::parse(&format!(
+            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
+        ))
+        .unwrap();
+        let client = JWTBaseHttpClient::new(url, 0).unwrap();
+
+        let error = client.get_auth_token().await.unwrap_err();
+
+        assert!(error.to_string().contains("429 Too Many Requests"));
         server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -303,7 +303,6 @@ impl<Client: HttpClient> ProvingClient<Client> {
         &self,
         authorization: Authorization<N>,
         fee: Authorization<N>,
-        public_key: X25519PublicKey,
     ) -> ChainResult<Transaction<N>> {
         let plain_request = ProvingRequest::<N> {
             authorization,
@@ -315,8 +314,9 @@ impl<Client: HttpClient> ProvingClient<Client> {
             .to_bytes_le()
             .map_err(HyperlaneAleoError::from)?;
 
-        // Encrypt the ProvingRequest using the X25519 public key and send it to the proving
-        // service. The caller fetches the key before performing expensive local authorization.
+        // Fetch a fresh public key after authorization, then encrypt and submit the request.
+        // The caller performs an earlier preflight request to fail cheaply during outages.
+        let public_key = self.get_public_key().await?;
         let ciphertext = encrypt_message(&public_key.public_key, &bytes)?;
 
         let request = serde_json::to_value(EncryptedProvingRequest {

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -293,11 +293,17 @@ impl<Client: HttpClient> RpcClient<Client> {
 pub struct ProvingClient<Client: HttpClient>(Client);
 
 impl<Client: HttpClient> ProvingClient<Client> {
+    /// Requests a public key used to encrypt the proving request.
+    pub async fn get_public_key(&self) -> ChainResult<X25519PublicKey> {
+        self.0.request("pubkey", None).await
+    }
+
     /// Makes a POST request to the API
     pub async fn proving_request<N: Network>(
         &self,
         authorization: Authorization<N>,
         fee: Authorization<N>,
+        public_key: X25519PublicKey,
     ) -> ChainResult<Transaction<N>> {
         let plain_request = ProvingRequest::<N> {
             authorization,
@@ -309,10 +315,8 @@ impl<Client: HttpClient> ProvingClient<Client> {
             .to_bytes_le()
             .map_err(HyperlaneAleoError::from)?;
 
-        // 1. First request a new public key for encryption from the proving service
-        // 2. Encrypt the ProvingRequest using the X25519 public key
-        // 3. Send the encrypted request to the proving service and get back the decrypted response
-        let public_key: X25519PublicKey = self.0.request("pubkey", None).await?;
+        // Encrypt the ProvingRequest using the X25519 public key and send it to the proving
+        // service. The caller fetches the key before performing expensive local authorization.
         let ciphertext = encrypt_message(&public_key.public_key, &bytes)?;
 
         let request = serde_json::to_value(EncryptedProvingRequest {


### PR DESCRIPTION
## Summary

1. Check delegated-prover availability before expensive Aleo authorization.
2. Fetch a fresh encryption key again immediately before proof submission: 1 extra GET per healthy submission.
3. Route Classic submit failures through existing retry accounting and persisted backoff.

JWT framing and HTTP-status propagation are already on main via #9540. This PR preserves them; `bb5be6469c` removed a duplicate status check introduced during rebase.

## Validation

- Reviewed head: `f92326e4bb`.
- Focused submit-backoff test: 1 passed on the pre-fix cumulative tree; the subsequent fix only removed 2 lines in Aleo auth.
- Final-head CI pending. Muse: no blockers on the production tree; GLM/Kimi reviews pending.
- No new local builds/tests for this review cycle.

Stack: **1/4** — #9456 → #9458 → #9459 → #9461.

Latest test-only follow-up: reused `auth_server` to read complete HTTP headers before asserting Content-Length and HTTP 429. Formatting, diff checks, and commit hooks passed; no new local test run.

<details>
<summary>Historical evidence and earlier validation (pre-restack; not current-head results)</summary>

### Description

Contains delegated Aleo prover outages without destabilizing the relayer:

- Sends `Content-Length: 0` on the empty JWT auth POST, restoring compatibility with Provable's updated load balancer.
- Runs a delegated-prover public-key preflight before expensive local authorization and fee construction. It discards the preflight key, then fetches a fresh encryption key immediately before proof submission; auth/public-key failures fail cheaply without widening the key freshness window.
- Routes Classic submit failures through normal retry accounting, restoring the existing 5s -> 10s -> 30s -> 60s -> 3m backoff.
- Preserves auth-server HTTP status errors instead of reporting every non-2xx response as `MissingAuthHeader`.

The currently deployed mainnet agent revision (`9008ed66d6e323c8f26191a6c34d1128f5e847bd`) includes #9412 and #9422. Those changes bounded transaction-status polling and removed local proving fallback, but the Classic path still repeated expensive authorization before discovering a delegated-prover auth outage and did not advance retry backoff after submission failure.

Provable confirmed they updated the `api.provable.com` load balancer at approximately 14:00 Lisbon time on 2026-09-04. Hyperlane's empty auth POST omitted both a body and `Content-Length`; the new load balancer returned HTTP 411. This matches the incident start. Reqwest does not add a length header for this empty POST, so this patch sets it explicitly.

#### Incident evidence and expected improvement

Observed after a planned mainnet relayer restart on 2026-09-04:

- 26 failed Aleo submission attempts in 5.5 minutes while the prover public-key request returned `MissingAuthHeader`.
- The underlying auth request was rejected with HTTP 411 on every attempt; the client previously hid that status behind `MissingAuthHeader`.
- RSS grew from approximately 2.47 GB to 7.43 GB in 6 minutes (+4.96 GB) during that retry loop.
- Blocking threads remained healthy and no local proof generation ran, narrowing the repeated expensive work to authorization/preparation.

Expected/modelled with this change, assuming the same sustained auth failure:

- Load-balancer HTTP 411 rejections caused by the missing length header: 100% removed (wire-level regression test asserts `Content-Length: 0`).
- Approximately 6 logical retries in the first 5.5 minutes instead of 26: about 77% fewer.
- Approximately 14 logical retries in 30 minutes instead of approximately 142 at the observed cadence: about 90% fewer.
- Expensive Aleo authorization/fee preparation for this public-key auth failure: 26 observed executions -> 0 expected, a 100% reduction on this failure path.
- Auth calls inherit the same approximately 77-90% reduction from outer retry backoff. A follow-up will reduce redundant inner fallback retries too.
- Healthy delegated submissions add one public-key GET preflight. This is a deliberate small network/auth overhead to avoid expensive authorization during outages while retaining a freshly fetched encryption key.

The patch removes the code path implicated in the linear RSS growth, but does not claim a specific GB reduction before canary/live verification.

### Drive-by changes

None. Follow-ups are intentionally separate:

- single-flight JWT refresh to prevent concurrent auth stampedes;
- status-aware fallback retry policy (`401`/`403`/`411`/`429` avoid immediate inner retries and return to outer backoff);
- phase metrics for prover preflight, authorization, and proof generation.

### Related issues

- Follow-up to #9422
- Related to #9412 and #9390

### Backward compatibility

Backward compatible. The auth request remains an empty POST but now declares its zero-byte length. Local proving behavior is unchanged when no delegated prover is configured. Successful delegated proving uses a freshly requested encryption key immediately before encryption. The outage preflight adds one public-key GET to healthy delegated submissions.

### Testing

- `cargo test -p hyperlane-aleo --lib` (77 passed)
- `cargo test -p relayer msg::pending_message::test` (11 passed)
- `cargo clippy -p hyperlane-aleo --lib -- -D warnings`
- `cargo clippy -p relayer --lib -- -D warnings`

`cargo clippy -p hyperlane-aleo --tests -- -D warnings` remains blocked by 180 pre-existing test-target lint errors; no changed production target errors.

### Live rollout validation

Deployed the exact reviewed image to the production Hyperlane relayer via Helm revision 613:

- Image: `fb789a3-20260904-145018`
- Digest: `sha256:c0049367f5abb894ef8bd5bc4ebfaf08e70f5dcb26adcfa0d10e3b82d32fac67`
- OCI revision: `fb789a39d1d4bf1563739f69e3f039eb36a4623c`
- Pod became Ready at 2026-09-04 15:00:22 UTC with zero restarts.
- From rollout through 15:57 UTC: zero `MissingAuthHeader`, HTTP 411, or delegated-preflight failures.
- Three delegated Aleo proofs completed; the incident ETH-to-Aleo message `0xc3dc49af1fce969929403ac32558f25f83646efeb2b228025026ff53186c0f55` reached `Operation submitted`.
- After the initial Aleo backlog drained, RSS was 5,497 MiB at 15:10 UTC and 5,539 MiB at 15:57 UTC: +42 MiB over approximately 47 minutes, with no recurrence of the incident's linear +4.96 GB / 6 minute growth.

</details>
