### PR TITLE
fix(scraper-proxy): avoid alerting on heartbeat cleanup

### DIFF
--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -5,7 +5,11 @@ import { after, before, it, type TestContext } from 'node:test';
 import { WebSocket } from 'ws';
 import type { QueryResultRow } from 'pg';
 
-import { metricsRegistry, websocketCatchUps } from '../metrics.js';
+import {
+  metricsRegistry,
+  websocketCatchUps,
+  websocketSendFailures,
+} from '../metrics.js';
 import type { EventDatabase, EventWebSocketServer } from './event-websocket.js';
 import { rawData } from './websocket-data.js';
 
@@ -1014,6 +1018,84 @@ void it('releases a peer-closed Explorer queue immediately', async (context) => 
   for (const complete of completions.splice(0)) complete();
 });
 
+void it('reports an active send failure once', async (context) => {
+  const socket = new WebSocket(messagesUrl);
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+  await waitFor(messages, 'ready');
+  const completions = delayServerSendCompletions(context);
+  const failuresBefore = await sendFailureCount();
+
+  try {
+    notify(
+      'scraper_explorer_event',
+      JSON.stringify({ messageId: msgId.slice(2) }),
+    );
+    await waitUntil(() => completions.length === 1);
+    completions.shift()?.(new Error('write failed'));
+    await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+
+    assert.equal(await sendFailureCount(), failuresBefore + 1);
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    if (socket.readyState !== WebSocket.CLOSED) socket.terminate();
+  }
+});
+
+void it('does not report heartbeat cleanup as a send failure', async (context) => {
+  let heartbeatNotify: (channel: string, payload?: string) => void;
+  const heartbeatDb: EventDatabase = {
+    listen: async (_channels, handler) => {
+      heartbeatNotify = handler;
+      return async () => undefined;
+    },
+    queryLive: db.queryLive,
+  };
+  const heartbeatHttp = createServer();
+  const { EventWebSocketServer } = await import('./event-websocket.js');
+  const heartbeatEvents = new EventWebSocketServer(heartbeatDb, {
+    heartbeatMs: 250,
+    maxExplorerClients: 1,
+  });
+  await new Promise<void>((resolve) =>
+    heartbeatHttp.listen(0, '127.0.0.1', resolve),
+  );
+  const address = heartbeatHttp.address();
+  assert(address && typeof address !== 'string');
+  await heartbeatEvents.start(heartbeatHttp);
+  const completions = delayServerSendCompletions(context);
+  const socket = new WebSocket(`ws://127.0.0.1:${address.port}/messages`, {
+    autoPong: false,
+  });
+  const messages: Record<string, unknown>[] = [];
+  socket.on('message', (data) => messages.push(parseRecord(rawData(data))));
+  const failuresBefore = await sendFailureCount();
+
+  try {
+    await waitFor(messages, 'ready');
+    heartbeatNotify(
+      'scraper_explorer_event',
+      JSON.stringify({ messageId: msgId.slice(2) }),
+    );
+    await waitUntil(() => completions.length === 1);
+    await waitUntil(() => socket.readyState === WebSocket.CLOSED);
+    completions.shift()?.(new Error('write ECANCELED'));
+    await waitUntil(
+      () => heartbeatEvents.metricsSnapshot().outboundPendingBytes === 0,
+    );
+
+    assert.equal(await sendFailureCount(), failuresBefore);
+    assert.equal(heartbeatEvents.metricsSnapshot().connections.messages, 0);
+  } finally {
+    for (const complete of completions.splice(0)) complete();
+    if (socket.readyState !== WebSocket.CLOSED) socket.terminate();
+    await heartbeatEvents.stop();
+    await new Promise<void>((resolve, reject) =>
+      heartbeatHttp.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
 void it('bounds aggregate Explorer outbound buffering', async () => {
   const sockets = Array.from({ length: 4 }, () => new WebSocket(messagesUrl));
   const messages: Record<string, unknown>[][] = sockets.map(() => []);
@@ -1077,8 +1159,10 @@ function liveAgent(messages: Record<string, unknown>[]): WebSocket {
   return socket;
 }
 
-function delayServerSendCompletions(context: TestContext): Array<() => void> {
-  const completions: Array<() => void> = [];
+function delayServerSendCompletions(
+  context: TestContext,
+): Array<(error?: Error) => void> {
+  const completions: Array<(error?: Error) => void> = [];
   // oxlint-disable-next-line typescript/unbound-method -- called with the socket receiver below.
   const originalSend = WebSocket.prototype.send;
   context.mock.method(
@@ -1101,7 +1185,8 @@ function delayServerSendCompletions(context: TestContext): Array<() => void> {
           message?.type === 'caught_up' ||
           message?.type === 'message_upsert');
       const completed = delay
-        ? (error?: Error) => completions.push(() => completion(error))
+        ? (error?: Error) =>
+            completions.push((override = error) => completion(override))
         : completion;
       if (typeof optionsOrCallback === 'function' || !optionsOrCallback) {
         originalSend.call(this, data, completed);
@@ -1207,6 +1292,14 @@ async function catchUpOutcome(outcome: string): Promise<number> {
   const metric = await websocketCatchUps.get();
   return (
     metric.values.find(({ labels }) => labels.outcome === outcome)?.value ?? 0
+  );
+}
+
+async function sendFailureCount(): Promise<number> {
+  const metric = await websocketSendFailures.get();
+  return (
+    metric.values.find(({ labels }) => labels.reason === 'send_error')?.value ??
+    0
   );
 }
 

--- a/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.integration.test.ts
@@ -1096,6 +1096,35 @@ void it('does not report heartbeat cleanup as a send failure', async (context) =
   }
 });
 
+void it('rejects out-of-range heartbeat intervals without starting timers', async () => {
+  const { EventWebSocketServer } = await import('./event-websocket.js');
+  for (const heartbeatMs of [
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    2_147_483_648,
+  ]) {
+    const invalidDb: EventDatabase = {
+      listen: async () => async () => undefined,
+      queryLive: db.queryLive,
+    };
+    const invalidHttp = createServer();
+    await new Promise<void>((resolve) =>
+      invalidHttp.listen(0, '127.0.0.1', resolve),
+    );
+    const invalidEvents = new EventWebSocketServer(invalidDb, {
+      heartbeatMs,
+    });
+    await assert.rejects(invalidEvents.start(invalidHttp), /heartbeatMs/);
+    await invalidEvents.stop();
+    await new Promise<void>((resolve, reject) =>
+      invalidHttp.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
 void it('bounds aggregate Explorer outbound buffering', async () => {
   const sockets = Array.from({ length: 4 }, () => new WebSocket(messagesUrl));
   const messages: Record<string, unknown>[][] = sockets.map(() => []);

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -86,6 +86,7 @@ type ExplorerClient = {
   sending: boolean;
 };
 type Limits = {
+  heartbeatMs: number;
   maxAgentClients: number;
   maxBufferedBytes: number;
   maxCatchUpMs: number;
@@ -147,7 +148,7 @@ const STREAMS: Record<EventType, Stream> = {
 export class EventWebSocketServer {
   private readonly logger = new Logger(EventWebSocketServer.name);
   private readonly clients = new Map<WebSocket, Client>();
-  private readonly failedSockets = new WeakSet<WebSocket>();
+  private readonly terminatedSockets = new WeakSet<WebSocket>();
   private readonly explorerClients = new Map<WebSocket, ExplorerClient>();
   private readonly explorerClientsByIp = new Map<string, number>();
   private readonly explorerNotifications = new Set<string>();
@@ -173,6 +174,7 @@ export class EventWebSocketServer {
     limits: Partial<Limits> = {},
   ) {
     this.limits = {
+      heartbeatMs: HEARTBEAT_MS,
       maxAgentClients: MAX_AGENT_CLIENTS,
       maxBufferedBytes: config.EVENT_STREAM_MAX_BUFFERED_BYTES,
       maxCatchUpMs: config.EVENT_STREAM_HISTORY_MAX_MS,
@@ -200,7 +202,10 @@ export class EventWebSocketServer {
     this.explorerServer.on('connection', (socket, request) =>
       this.connectExplorer(socket, request),
     );
-    this.heartbeatTimer = setInterval(() => this.heartbeat(), HEARTBEAT_MS);
+    this.heartbeatTimer = setInterval(
+      () => this.heartbeat(),
+      this.limits.heartbeatMs,
+    );
     this.logger.log(
       `event websockets listening on ${AGENT_PATH}, ${MESSAGE_PATH} batchSize=${config.EVENT_STREAM_BATCH_SIZE} maxBufferedBytes=${this.limits.maxBufferedBytes} maxTotalBufferedBytes=${this.limits.maxTotalBufferedBytes}`,
     );
@@ -1067,8 +1072,7 @@ export class EventWebSocketServer {
   ): void {
     for (const [socket, client] of clients) {
       if (!client.alive) {
-        this.disconnect(socket);
-        socket.terminate();
+        this.terminateSocket(socket);
         continue;
       }
       client.alive = false;
@@ -1107,7 +1111,10 @@ export class EventWebSocketServer {
     message: SerializedMessage,
     completed?: (sent: boolean) => void,
   ): boolean {
-    if (this.failedSockets.has(socket) || socket.readyState !== WebSocket.OPEN)
+    if (
+      this.terminatedSockets.has(socket) ||
+      socket.readyState !== WebSocket.OPEN
+    )
       return false;
     if (
       socket.bufferedAmount + message.bytes > this.limits.maxBufferedBytes ||
@@ -1122,25 +1129,32 @@ export class EventWebSocketServer {
       socket.send(message.text, (error) => {
         this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
         completed?.(!error);
-        if (error) {
-          websocketSendFailures.inc({ reason: 'send_error' });
-          this.failSocket(socket, `send failed: ${error.message}`);
-        }
+        if (error) this.failSend(socket, error.message);
       });
     } catch (error) {
       this.pendingBytes = Math.max(0, this.pendingBytes - message.bytes);
       completed?.(false);
-      websocketSendFailures.inc({ reason: 'send_error' });
-      this.failSocket(socket, `send failed: ${formatError(error)}`);
+      this.failSend(socket, formatError(error));
       return false;
     }
     return true;
   }
 
   private failSocket(socket: WebSocket, reason: string): void {
-    if (this.failedSockets.has(socket)) return;
-    this.failedSockets.add(socket);
+    if (this.terminatedSockets.has(socket)) return;
     this.logger.warn(`terminating websocket: ${reason}`);
+    this.terminateSocket(socket);
+  }
+
+  private failSend(socket: WebSocket, reason: string): void {
+    if (this.terminatedSockets.has(socket)) return;
+    websocketSendFailures.inc({ reason: 'send_error' });
+    this.failSocket(socket, `send failed: ${reason}`);
+  }
+
+  private terminateSocket(socket: WebSocket): void {
+    if (this.terminatedSockets.has(socket)) return;
+    this.terminatedSockets.add(socket);
     this.disconnect(socket);
     socket.terminate();
   }

--- a/typescript/scraper-proxy/src/live/event-websocket.ts
+++ b/typescript/scraper-proxy/src/live/event-websocket.ts
@@ -41,6 +41,10 @@ const MESSAGE_PATH = '/messages';
 const EVENT_CHANNEL = 'scraper_event';
 const EXPLORER_CHANNEL = 'scraper_explorer_event';
 const HEARTBEAT_MS = 30_000;
+// Node's setInterval() warns and clamps to 1 for non-positive values and
+// overflows above a signed 32-bit integer, so heartbeat overrides must stay
+// in this range.
+const MAX_INTERVAL_MS = 2_147_483_647;
 const LISTENER_RETRY_MS = 1_000;
 const NOTIFICATION_BATCH_MS = 100;
 const NOTIFICATION_BATCH_SIZE = 1_000;
@@ -187,6 +191,17 @@ export class EventWebSocketServer {
   }
 
   async start(server: Server): Promise<void> {
+    const { heartbeatMs } = this.limits;
+    if (
+      typeof heartbeatMs !== 'number' ||
+      !Number.isInteger(heartbeatMs) ||
+      heartbeatMs < 1 ||
+      heartbeatMs > MAX_INTERVAL_MS
+    ) {
+      throw new Error(
+        `Invalid heartbeatMs ${String(heartbeatMs)}: must be an integer between 1 and ${MAX_INTERVAL_MS}`,
+      );
+    }
     await this.connectListener();
     this.agentServer = new WebSocketServer({
       maxPayload: 4_096,
@@ -202,10 +217,7 @@ export class EventWebSocketServer {
     this.explorerServer.on('connection', (socket, request) =>
       this.connectExplorer(socket, request),
     );
-    this.heartbeatTimer = setInterval(
-      () => this.heartbeat(),
-      this.limits.heartbeatMs,
-    );
+    this.heartbeatTimer = setInterval(() => this.heartbeat(), heartbeatMs);
     this.logger.log(
       `event websockets listening on ${AGENT_PATH}, ${MESSAGE_PATH} batchSize=${config.EVENT_STREAM_BATCH_SIZE} maxBufferedBytes=${this.limits.maxBufferedBytes} maxTotalBufferedBytes=${this.limits.maxTotalBufferedBytes}`,
     );


### PR DESCRIPTION
### Description

A mainnet3 high-urgency alert fired on 2026-09-04 even though the scraper proxy had spare capacity and remained healthy. This changes WebSocket send-error accounting so server-initiated heartbeat cleanup cannot be reported as dropped work, while a genuine active send failure is still counted once and isolates that socket.

Incident evidence:

- Grafana's `Scraper proxy dropping or rejecting work` rule fired only through `increase(hyperlane_scraper_proxy_websocket_send_failures_total[5m]) > 0`. The GraphQL-capacity, WebSocket-capacity/listener, and catch-up-capacity arms were all zero.
- Three `/messages` sockets logged `write ECANCELED` within 1.4ms at `14:29:46Z`, while the raw `send_error` counter jumped from 0 to 6. Pending send callbacks were therefore counted twice per terminated socket before the existing socket-failure guard took effect.
- Listener readiness stayed at 1. Buffer-limit, per-client queue-limit, notification-overflow, connection-rejection, database-error, and GraphQL-error counters all stayed at zero.
- Peak per-client Explorer backlog was 135 / 2,000 messages (6.75%) and 384,602 / 16,777,216 bytes (2.29%). This was not queue saturation.
- The rule returned inactive once the five-minute window expired. The proxy pod remained ready with zero restarts.

Expected impact:

- For the observed heartbeat-cleanup shape, false `send_error` increments fall from 6 to 0: a 100% reduction, so this incident would not page.
- Genuine errors are capped at one counter increment per affected socket instead of one per canceled callback. The observed duplicate rate was two callbacks per socket, so equivalent genuine failures would produce 3 rather than 6 increments (50% fewer duplicates).
- Heartbeat timing, queue/buffer limits, client isolation, and message delivery behavior are unchanged.

The percentages above combine measured incident counts with modeled post-fix behavior. They are not post-deploy measurements.

### Production observation

Exact stacked image `2b7731d-20260907-013323` became Ready at about 01:38 UTC on 2026-09-07 and remained Ready with zero restarts through the 09:35 snapshot. It accepted 292 `/messages` connections; 11 remained active, while at least 281 ended with zero `send_error`, queue-overflow, listener-unavailable, or connection-capacity failures.

This is a clean no-recurrence signal, not proof that the exact heartbeat-cleanup race fired. The 100% false-increment and 50% duplicate-increment reductions above remain incident-derived models.

### Drive-by changes

None. A test-only heartbeat interval override keeps the regression deterministic; production retains the 30-second interval.

### Related issues

- PagerDuty: `Scraper proxy dropping or rejecting work` at 2026-09-04 15:32 BST.

### Backward compatibility

Yes. No public API, wire protocol, deployment config, or limit changes. The scraper-proxy package is private, so no changeset is required.

### Testing

- `pnpm -C typescript/utils build`
- `pnpm -C typescript/scraper-proxy test` (67 / 67)
- `pnpm -C typescript/scraper-proxy build`
- `pnpm -C typescript/scraper-proxy bundle`
- `pnpm -C typescript/scraper-proxy lint`
- `pnpm -C typescript/scraper-proxy format`
- `git diff --check`

Regression coverage proves heartbeat termination suppresses the resulting `ECANCELED` callback without incrementing `send_error`, and a failure on an active socket still increments exactly once and closes only that socket.
