### PR TITLE
fix(aleo): coalesce concurrent JWT refreshes

### DIFF
--- a/rust/main/agents/relayer/src/msg/pending_message.rs
+++ b/rust/main/agents/relayer/src/msg/pending_message.rs
@@ -578,7 +578,7 @@ impl PendingOperation for PendingMessage {
             Err(e) => {
                 error!(error=?e, "Error when processing message");
                 self.clear_metadata();
-                return PendingOperationResult::Reprepare(ReprepareReason::ErrorSubmitting);
+                return self.on_reprepare::<String>(None, ReprepareReason::ErrorSubmitting);
             }
         }
     }
@@ -1537,6 +1537,7 @@ mod test {
     use hyperlane_base::tests::mock_hyperlane_db::MockHyperlaneDb as MockDb;
     use hyperlane_base::{cache::OptionalCache, db::*};
     use hyperlane_core::*;
+    use hyperlane_test::mocks::MockMailboxContract;
 
     use crate::test_utils::dummy_data::{dummy_message_context, dummy_metadata_builder};
 
@@ -2227,6 +2228,58 @@ mod test {
             .expect("Message status not found");
 
         assert_eq!(db_status, expected_status);
+    }
+
+    #[tokio::test]
+    async fn submit_failure_advances_retry_backoff() {
+        let origin_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Arbitrum);
+        let destination_domain = HyperlaneDomain::Known(KnownHyperlaneDomain::Optimism);
+        let cache = OptionalCache::new(None);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = DB::from_path(temp_dir.path()).unwrap();
+        let base_db = HyperlaneRocksDB::new(&origin_domain, db);
+        let base_metadata_builder =
+            dummy_metadata_builder(&origin_domain, &destination_domain, &base_db, cache.clone());
+        let mut message_context =
+            dummy_message_context(Arc::new(base_metadata_builder), &base_db, cache);
+
+        let mut mailbox = MockMailboxContract::new();
+        mailbox
+            .expect__domain()
+            .return_const(destination_domain.clone());
+        mailbox.expect_process().once().returning(|_, _, _| {
+            Err(ChainCommunicationError::from_other_str(
+                "delegated prover unavailable",
+            ))
+        });
+        message_context.destination_mailbox = Arc::new(mailbox);
+
+        let message = HyperlaneMessage {
+            origin: origin_domain.id(),
+            destination: destination_domain.id(),
+            ..Default::default()
+        };
+        let mut pending_message = PendingMessage::new(
+            message,
+            Arc::new(message_context),
+            PendingOperationStatus::ReadyToSubmit,
+            None,
+            DEFAULT_MAX_MESSAGE_RETRIES,
+        );
+        pending_message.submission_data = Some(Box::new(MessageSubmissionData {
+            metadata: Metadata::new(vec![]),
+            gas_limit: U256::zero(),
+        }));
+
+        let result = PendingOperation::submit(&mut pending_message).await;
+
+        assert!(matches!(
+            result,
+            PendingOperationResult::Reprepare(ReprepareReason::ErrorSubmitting)
+        ));
+        assert_eq!(pending_message.num_retries, 1);
+        assert!(pending_message.next_attempt_after > Some(Instant::now()));
     }
 
     #[test]

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -442,16 +442,12 @@ impl<C: AleoClient> AleoProvider<C> {
 
         // Check delegated prover availability before performing expensive local authorization.
         // This keeps an auth or service outage from repeatedly consuming memory and CPU.
-        let delegated_prover = match self.proving_service.as_ref() {
-            Some(client) => {
-                let public_key = client.get_public_key().await.map_err(|error| {
-                    warn!(%error, "Delegated proving preflight failed");
-                    error
-                })?;
-                Some((client, public_key))
-            }
-            None => None,
-        };
+        if let Some(client) = self.proving_service.as_ref() {
+            client.get_public_key().await.map_err(|error| {
+                warn!(%error, "Delegated proving preflight failed");
+                error
+            })?;
+        }
 
         // Prepare VM + Authorization for execution.
         let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) = self
@@ -487,14 +483,14 @@ impl<C: AleoClient> AleoProvider<C> {
         // prover failure is retried by the relayer; falling back here can saturate Tokio's
         // blocking pool and destabilize unrelated chains.
         let start = Instant::now();
-        let transaction = match delegated_prover {
-            Some((client, public_key)) => {
+        let transaction = match self.proving_service {
+            Some(ref client) => {
                 debug!(
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
                 client
-                    .proving_request(authorization, fee, public_key)
+                    .proving_request(authorization, fee)
                     .await
                     .map_err(|error| {
                         warn!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -439,6 +439,20 @@ impl<C: AleoClient> AleoProvider<C> {
         V: TryInto<Value<N>>,
     {
         debug!("Creating ZK-Proof for: {}/{}", program_id, function_name);
+
+        // Check delegated prover availability before performing expensive local authorization.
+        // This keeps an auth or service outage from repeatedly consuming memory and CPU.
+        let delegated_prover = match self.proving_service.as_ref() {
+            Some(client) => {
+                let public_key = client.get_public_key().await.map_err(|error| {
+                    warn!(%error, "Delegated proving preflight failed");
+                    error
+                })?;
+                Some((client, public_key))
+            }
+            None => None,
+        };
+
         // Prepare VM + Authorization for execution.
         let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) = self
             .prepare_authorization::<N, I, V>(program_id, function_name, input, vm)
@@ -473,14 +487,14 @@ impl<C: AleoClient> AleoProvider<C> {
         // prover failure is retried by the relayer; falling back here can saturate Tokio's
         // blocking pool and destabilize unrelated chains.
         let start = Instant::now();
-        let transaction = match self.proving_service {
-            Some(ref client) => {
+        let transaction = match delegated_prover {
+            Some((client, public_key)) => {
                 debug!(
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
                 client
-                    .proving_request(authorization, fee)
+                    .proving_request(authorization, fee, public_key)
                     .await
                     .map_err(|error| {
                         warn!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -518,13 +518,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn jwt_auth_preserves_http_status_errors() {
+    async fn jwt_auth_sends_content_length_and_preserves_status_errors() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut buffer = [0; 4096];
-            stream.read(&mut buffer).unwrap();
+            let length = stream.read(&mut buffer).unwrap();
+            request_tx
+                .send(String::from_utf8_lossy(&buffer[..length]).to_lowercase())
+                .unwrap();
             stream
                 .write_all(
                     b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
@@ -540,6 +544,10 @@ mod tests {
         let error = client.get_auth_token().await.unwrap_err();
 
         assert!(error.to_string().contains("429 Too Many Requests"));
+        assert!(request_rx
+            .recv()
+            .unwrap()
+            .contains("\r\ncontent-length: 0\r\n"));
         server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -8,7 +8,7 @@ use reqwest::header::{HeaderValue, AUTHORIZATION, CONTENT_LENGTH};
 use reqwest::Client as ReqwestClient;
 use reqwest_utils::parse_custom_rpc_headers;
 use serde::de::DeserializeOwned;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use url::Url;
 
 use hyperlane_core::{ChainCommunicationError, ChainResult};
@@ -153,6 +153,7 @@ pub struct JWTBaseHttpClient {
     base_url: Url,
     auth_url: String,
     auth_token: Arc<RwLock<Option<(HeaderValue, Instant)>>>,
+    auth_refresh: Arc<Mutex<()>>,
 }
 
 impl JWTBaseHttpClient {
@@ -176,19 +177,29 @@ impl JWTBaseHttpClient {
             client,
             base_url: append_network(url, network)?,
             auth_token: Default::default(),
+            auth_refresh: Default::default(),
             auth_url,
         })
     }
 
-    /// Gets the authentication token if it is still valid
-    pub async fn get_auth_token(&self) -> ChainResult<HeaderValue> {
-        {
-            let auth_token = self.auth_token.read().await;
-            if let Some((token, expires_at)) = &*auth_token {
-                if Instant::now() < *expires_at {
-                    return Ok(token.clone());
-                }
+    async fn cached_auth_token(&self) -> Option<HeaderValue> {
+        let auth_token = self.auth_token.read().await;
+        if let Some((token, expires_at)) = &*auth_token {
+            if Instant::now() < *expires_at {
+                return Some(token.clone());
             }
+        }
+        None
+    }
+
+    async fn refresh_auth_token(&self) -> ChainResult<HeaderValue> {
+        // Only serialize token refreshes. Requests with a valid cached token
+        // avoid this lock and unrelated API network work never holds it.
+        let _refresh_guard = self.auth_refresh.lock().await;
+
+        // Another caller may have refreshed the token while this caller waited.
+        if let Some(token) = self.cached_auth_token().await {
+            return Ok(token);
         }
 
         let response = self
@@ -212,7 +223,16 @@ impl JWTBaseHttpClient {
             .unwrap_or(Instant::now()); // Tokens last 15 minutes
         let mut auth_token = self.auth_token.write().await;
         *auth_token = Some((result.clone(), expires));
-        Ok(result.clone())
+        Ok(result)
+    }
+
+    /// Gets the authentication token if it is still valid
+    pub async fn get_auth_token(&self) -> ChainResult<HeaderValue> {
+        if let Some(token) = self.cached_auth_token().await {
+            return Ok(token);
+        }
+
+        self.refresh_auth_token().await
     }
 
     async fn clear_auth_token(&self) {
@@ -327,11 +347,14 @@ mod tests {
     use std::{
         io::{Read, Write},
         net::TcpListener,
-        sync::mpsc,
+        sync::{mpsc, Arc},
         thread,
+        time::{Duration, Instant},
     };
 
+    use reqwest::header::HeaderValue;
     use serde_json::{json, Value};
+    use tokio::sync::{oneshot, Barrier};
     use url::Url;
 
     use super::{append_network, append_path, BaseHttpClient, HttpClient, JWTBaseHttpClient};
@@ -529,5 +552,87 @@ mod tests {
             .expect("auth server joined")
             .to_ascii_lowercase()
             .contains("\r\ncontent-length: 0\r\n"));
+    }
+
+    #[tokio::test]
+    async fn jwt_auth_refresh_is_single_flight() {
+        const CALLERS: usize = 16;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = oneshot::channel();
+        let (response_tx, response_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 4096];
+            stream.read(&mut buffer).unwrap();
+            request_tx.send(()).unwrap();
+            response_rx.recv().unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nAuthorization: Bearer shared-token\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+        let url = Url::parse(&format!(
+            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
+        ))
+        .unwrap();
+        let client = JWTBaseHttpClient::new(url, 0).unwrap();
+        *client.auth_token.write().await = Some((
+            HeaderValue::from_static("Bearer expired-token"),
+            Instant::now() - Duration::from_secs(1),
+        ));
+        let start = Arc::new(Barrier::new(CALLERS));
+        let callers = (0..CALLERS)
+            .map(|_| {
+                let client = client.clone();
+                let start = start.clone();
+                tokio::spawn(async move {
+                    start.wait().await;
+                    client.get_auth_token().await
+                })
+            })
+            .collect::<Vec<_>>();
+
+        request_rx.await.unwrap();
+        response_tx.send(()).unwrap();
+
+        for caller in callers {
+            let token = caller.await.unwrap().unwrap();
+            assert_eq!(token, HeaderValue::from_static("Bearer shared-token"));
+        }
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn jwt_auth_retries_after_refresh_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            for response in [
+                b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .as_slice(),
+                b"HTTP/1.1 200 OK\r\nAuthorization: Bearer retry-token\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .as_slice(),
+            ] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buffer = [0; 4096];
+                stream.read(&mut buffer).unwrap();
+                stream.write_all(response).unwrap();
+            }
+        });
+        let url = Url::parse(&format!(
+            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
+        ))
+        .unwrap();
+        let client = JWTBaseHttpClient::new(url, 0).unwrap();
+
+        let error = client.get_auth_token().await.unwrap_err();
+        assert!(error.to_string().contains("429 Too Many Requests"));
+
+        let token = client.get_auth_token().await.unwrap();
+        assert_eq!(token, HeaderValue::from_static("Bearer retry-token"));
+        server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -517,35 +517,17 @@ mod tests {
 
     #[tokio::test]
     async fn jwt_auth_sends_content_length_and_preserves_status_errors() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-        let (request_tx, request_rx) = mpsc::channel();
-        let server = thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut buffer = [0; 4096];
-            let length = stream.read(&mut buffer).unwrap();
-            request_tx
-                .send(String::from_utf8_lossy(&buffer[..length]).to_lowercase())
-                .unwrap();
-            stream
-                .write_all(
-                    b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-                )
-                .unwrap();
-        });
-        let url = Url::parse(&format!(
-            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
-        ))
-        .unwrap();
-        let client = JWTBaseHttpClient::new(url, 0).unwrap();
+        let (client, server) = auth_server(
+            b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        );
 
-        let error = client.get_auth_token().await.unwrap_err();
+        let error = client.get_auth_token().await.expect_err("JWT should fail");
 
         assert!(error.to_string().contains("429 Too Many Requests"));
-        assert!(request_rx
-            .recv()
-            .unwrap()
+        assert!(server
+            .join()
+            .expect("auth server joined")
+            .to_ascii_lowercase()
             .contains("\r\ncontent-length: 0\r\n"));
-        server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -198,8 +198,6 @@ impl JWTBaseHttpClient {
             .header(CONTENT_LENGTH, "0")
             .send()
             .await
-            .map_err(HyperlaneAleoError::from)?
-            .error_for_status()
             .map_err(HyperlaneAleoError::from)?;
         let response = response
             .error_for_status()

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -201,6 +201,9 @@ impl JWTBaseHttpClient {
             .map_err(HyperlaneAleoError::from)?
             .error_for_status()
             .map_err(HyperlaneAleoError::from)?;
+        let response = response
+            .error_for_status()
+            .map_err(HyperlaneAleoError::from)?;
         let result = response
             .headers()
             .get(AUTHORIZATION)
@@ -511,6 +514,32 @@ mod tests {
             .unwrap();
 
         assert_eq!(response, None);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn jwt_auth_preserves_http_status_errors() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 4096];
+            stream.read(&mut buffer).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 429 Too Many Requests\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+        let url = Url::parse(&format!(
+            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
+        ))
+        .unwrap();
+        let client = JWTBaseHttpClient::new(url, 0).unwrap();
+
+        let error = client.get_auth_token().await.unwrap_err();
+
+        assert!(error.to_string().contains("429 Too Many Requests"));
         server.join().unwrap();
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -235,9 +235,14 @@ impl JWTBaseHttpClient {
         self.refresh_auth_token().await
     }
 
-    async fn clear_auth_token(&self) {
+    async fn clear_auth_token(&self, rejected_token: &HeaderValue) {
         let mut auth_token = self.auth_token.write().await;
-        *auth_token = None;
+        if auth_token
+            .as_ref()
+            .is_some_and(|(token, _)| token == rejected_token)
+        {
+            *auth_token = None;
+        }
     }
 }
 
@@ -255,15 +260,15 @@ impl HttpClient for JWTBaseHttpClient {
         let response = self
             .client
             .get(url)
-            .header(AUTHORIZATION, auth)
+            .header(AUTHORIZATION, auth.clone())
             .query(&query)
             .send()
             .await
             .map_err(HyperlaneAleoError::from)?;
 
-        // Two instances of the relayer might compete for the same JWT, if so clear the token early and request a new one
+        // Do not let a late rejection of an old token evict a token refreshed by another request.
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            self.clear_auth_token().await;
+            self.clear_auth_token(&auth).await;
         }
 
         let response = response
@@ -285,14 +290,14 @@ impl HttpClient for JWTBaseHttpClient {
         let response = self
             .client
             .get(url)
-            .header(AUTHORIZATION, auth)
+            .header(AUTHORIZATION, auth.clone())
             .query(&query)
             .send()
             .await
             .map_err(HyperlaneAleoError::from)?;
 
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            self.clear_auth_token().await;
+            self.clear_auth_token(&auth).await;
         }
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
@@ -316,15 +321,15 @@ impl HttpClient for JWTBaseHttpClient {
         let response = self
             .client
             .post(url)
-            .header(AUTHORIZATION, auth)
+            .header(AUTHORIZATION, auth.clone())
             .json(body)
             .send()
             .await
             .map_err(HyperlaneAleoError::from)?;
 
-        // Two instances of the relayer might compete for the same JWT, if so clear the token early and request a new one
+        // Do not let a late rejection of an old token evict a token refreshed by another request.
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
-            self.clear_auth_token().await;
+            self.clear_auth_token(&auth).await;
         }
 
         let response = response
@@ -634,5 +639,27 @@ mod tests {
         let token = client.get_auth_token().await.unwrap();
         assert_eq!(token, HeaderValue::from_static("Bearer retry-token"));
         server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn jwt_auth_stale_rejection_does_not_clear_refreshed_token() {
+        let client = JWTBaseHttpClient::new(Url::parse("http://localhost/v2").unwrap(), 0).unwrap();
+        let stale_token = HeaderValue::from_static("Bearer stale-token");
+        let refreshed_token = HeaderValue::from_static("Bearer refreshed-token");
+        *client.auth_token.write().await = Some((
+            refreshed_token.clone(),
+            Instant::now() + Duration::from_secs(60),
+        ));
+
+        client.clear_auth_token(&stale_token).await;
+
+        assert_eq!(
+            client.cached_auth_token().await,
+            Some(refreshed_token.clone())
+        );
+
+        client.clear_auth_token(&refreshed_token).await;
+
+        assert_eq!(client.cached_auth_token().await, None);
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -303,7 +303,6 @@ impl<Client: HttpClient> ProvingClient<Client> {
         &self,
         authorization: Authorization<N>,
         fee: Authorization<N>,
-        public_key: X25519PublicKey,
     ) -> ChainResult<Transaction<N>> {
         let plain_request = ProvingRequest::<N> {
             authorization,
@@ -315,8 +314,9 @@ impl<Client: HttpClient> ProvingClient<Client> {
             .to_bytes_le()
             .map_err(HyperlaneAleoError::from)?;
 
-        // Encrypt the ProvingRequest using the X25519 public key and send it to the proving
-        // service. The caller fetches the key before performing expensive local authorization.
+        // Fetch a fresh public key after authorization, then encrypt and submit the request.
+        // The caller performs an earlier preflight request to fail cheaply during outages.
+        let public_key = self.get_public_key().await?;
         let ciphertext = encrypt_message(&public_key.public_key, &bytes)?;
 
         let request = serde_json::to_value(EncryptedProvingRequest {

--- a/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/traits.rs
@@ -293,11 +293,17 @@ impl<Client: HttpClient> RpcClient<Client> {
 pub struct ProvingClient<Client: HttpClient>(Client);
 
 impl<Client: HttpClient> ProvingClient<Client> {
+    /// Requests a public key used to encrypt the proving request.
+    pub async fn get_public_key(&self) -> ChainResult<X25519PublicKey> {
+        self.0.request("pubkey", None).await
+    }
+
     /// Makes a POST request to the API
     pub async fn proving_request<N: Network>(
         &self,
         authorization: Authorization<N>,
         fee: Authorization<N>,
+        public_key: X25519PublicKey,
     ) -> ChainResult<Transaction<N>> {
         let plain_request = ProvingRequest::<N> {
             authorization,
@@ -309,10 +315,8 @@ impl<Client: HttpClient> ProvingClient<Client> {
             .to_bytes_le()
             .map_err(HyperlaneAleoError::from)?;
 
-        // 1. First request a new public key for encryption from the proving service
-        // 2. Encrypt the ProvingRequest using the X25519 public key
-        // 3. Send the encrypted request to the proving service and get back the decrypted response
-        let public_key: X25519PublicKey = self.0.request("pubkey", None).await?;
+        // Encrypt the ProvingRequest using the X25519 public key and send it to the proving
+        // service. The caller fetches the key before performing expensive local authorization.
         let ciphertext = encrypt_message(&public_key.public_key, &bytes)?;
 
         let request = serde_json::to_value(EncryptedProvingRequest {


### PR DESCRIPTION
## Summary

1. Coalesce successful concurrent JWT refreshes within each shared client: 16 callers → 1 auth POST in the test fixture.
2. Keep valid-token reads outside the refresh mutex.
3. Ignore stale 401 rejection when another request has already refreshed the token.

Failed refreshes remain retryable; no error cache or cooldown is added. The 16→1 reduction is fixture/model evidence, not a production measurement.

## Validation

- Reviewed head: `345acdf78b`; restacked onto #9456's duplicate-check fix.
- Singleflight, retry-after-error, and stale-rejection tests passed in the pre-fix cumulative provider run.
- Final-head CI pending. Muse: no blockers on the production tree; GLM/Kimi reviews pending.
- No post-fix local test run.

Stack: **2/4**, parent #9456; follow-ups #9459 → #9461.

Latest test-only follow-up: reused `auth_server` to read complete HTTP headers before asserting Content-Length and HTTP 429. Formatting, diff checks, and commit hooks passed; no new local test run.

<details>
<summary>Historical evidence and earlier validation (pre-restack; not current-head results)</summary>

### Description

Makes Aleo JWT refresh single-flight within each shared `JWTBaseHttpClient`:

- Keeps valid cached-token reads on the existing `RwLock` fast path.
- Serializes only refresh attempts with a dedicated mutex.
- Rechecks the cache after acquiring the refresh lock so waiters reuse the token fetched by the first caller.
- Does not hold the token-cache lock across the auth POST or unrelated Aleo API requests.
- Does not cache refresh failures; the guard is released and a later call can retry.
- Clears a rejected cached token only if it is still current, so a late 401 cannot evict a token another request refreshed.

### Expected improvement

For `N` simultaneous callers that observe an empty or expired token and a successful auth response:

- Auth POSTs: `N -> 1`.
- Avoided auth POSTs: `N - 1`.
- Expected reduction: `(N - 1) / N`.
- The deterministic test case models `16 -> 1`, avoiding 15 requests: `93.75%` fewer auth POSTs.
- At a burst of 100 callers, the same model is `100 -> 1`: `99%` fewer auth POSTs.

These are modeled per-client burst improvements, not production measurements. Failed refreshes remain retryable and are serialized, but this PR does not add a failure cooldown or cache auth errors.

### Backward compatibility

No external API or successful request semantics change. JWTs retain the existing 15-minute local lifetime, auth HTTP status errors remain visible, and the parent raw-wire `Content-Length: 0` behavior is preserved.

### Testing

- `cargo test -p hyperlane-aleo --lib` (80 passed)
- `cargo clippy -p hyperlane-aleo --lib -- -D warnings`
- Single-flight concurrency test repeated 20 times (all passed)
- Commit hooks passed, including gitleaks and full Rust formatting

### Stack

- Stacked on #9456


</details>
