### PR TITLE
fix(aleo): avoid retrying terminal prover auth errors

### DIFF
--- a/rust/main/chains/hyperlane-aleo/src/error.rs
+++ b/rust/main/chains/hyperlane-aleo/src/error.rs
@@ -2,12 +2,30 @@ use std::{ffi::FromBytesUntilNulError, str::Utf8Error};
 
 use hyperlane_core::ChainCommunicationError;
 
+/// HTTP status error returned while authenticating with a delegated prover.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct DelegatedProverAuthError(#[source] reqwest::Error);
+
+impl DelegatedProverAuthError {
+    pub(crate) fn new(error: reqwest::Error) -> Self {
+        Self(error)
+    }
+
+    pub(crate) fn status(&self) -> Option<reqwest::StatusCode> {
+        self.0.status()
+    }
+}
+
 /// Errors from the crates specific to the hyperlane-aleo
 #[derive(Debug, thiserror::Error)]
 pub enum HyperlaneAleoError {
     /// Reqwest Errors
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
+    /// HTTP status errors from delegated prover authentication.
+    #[error("{0}")]
+    DelegatedProverAuth(#[from] DelegatedProverAuthError),
     /// Anyhow Errors
     #[error("{0}")]
     SnarkVmError(#[from] anyhow::Error),

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -98,7 +98,7 @@ impl AleoProvider<FallbackHttpClient> {
         chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
     ) -> ChainResult<Self> {
         let proving_service = if !conf.proving_service.is_empty() {
-            let client = FallbackHttpClient::new::<JWTBaseHttpClient>(
+            let client = FallbackHttpClient::new_delegated_prover(
                 conf.proving_service.clone(),
                 metrics.clone(),
                 chain.clone(),

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -14,7 +14,7 @@ use url::Url;
 use hyperlane_core::{ChainCommunicationError, ChainResult};
 
 use crate::provider::{HttpClient, HttpClientBuilder};
-use crate::HyperlaneAleoError;
+use crate::{DelegatedProverAuthError, HyperlaneAleoError};
 
 // Default timeouts
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -212,7 +212,7 @@ impl JWTBaseHttpClient {
             .map_err(HyperlaneAleoError::from)?;
         let response = response
             .error_for_status()
-            .map_err(HyperlaneAleoError::from)?;
+            .map_err(|error| HyperlaneAleoError::from(DelegatedProverAuthError::new(error)))?;
         let result = response
             .headers()
             .get(AUTHORIZATION)

--- a/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
@@ -1,8 +1,10 @@
+use std::error::Error;
+
 use async_trait::async_trait;
 
 use hyperlane_core::{
     rpc_clients::{BlockNumberGetter, FallbackProvider},
-    ChainResult,
+    ChainCommunicationError, ChainResult,
 };
 use hyperlane_metric::prometheus_metric::{
     ClientConnectionType, PrometheusClientMetrics, PrometheusConfig,
@@ -11,13 +13,45 @@ use snarkvm_console_account::{DeserializeOwned, Itertools};
 use url::Url;
 
 use crate::provider::{
-    metric::MetricHttpClient, AleoClient, BaseHttpClient, HttpClient, HttpClientBuilder, RpcClient,
+    metric::MetricHttpClient, AleoClient, BaseHttpClient, HttpClient, HttpClientBuilder,
+    JWTBaseHttpClient, RpcClient,
 };
+use crate::DelegatedProverAuthError;
+
+#[derive(Clone, Copy, Debug)]
+enum RetryPolicy {
+    AllErrors,
+    DelegatedProver,
+}
+
+fn delegated_prover_auth_status(error: &ChainCommunicationError) -> Option<reqwest::StatusCode> {
+    let mut source: Option<&(dyn Error + 'static)> = Some(error);
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<DelegatedProverAuthError>() {
+            return error.status();
+        }
+        source = error.source();
+    }
+    None
+}
+
+fn should_retry_delegated_prover(error: &ChainCommunicationError) -> bool {
+    !matches!(
+        delegated_prover_auth_status(error),
+        Some(
+            reqwest::StatusCode::UNAUTHORIZED
+                | reqwest::StatusCode::FORBIDDEN
+                | reqwest::StatusCode::LENGTH_REQUIRED
+                | reqwest::StatusCode::TOO_MANY_REQUESTS
+        )
+    )
+}
 
 /// Fallback Http Client that tries multiple RpcClients in order
 #[derive(Clone, Debug)]
 pub struct FallbackHttpClient<C: AleoClient = BaseHttpClient> {
     fallback: FallbackProvider<RpcClient<MetricHttpClient<C>>, RpcClient<MetricHttpClient<C>>>,
+    retry_policy: RetryPolicy,
 }
 
 impl<C: AleoClient> FallbackHttpClient<C> {
@@ -27,6 +61,22 @@ impl<C: AleoClient> FallbackHttpClient<C> {
         metrics: PrometheusClientMetrics,
         chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
         network: u16,
+    ) -> ChainResult<Self> {
+        Self::new_with_retry_policy::<Builder>(
+            urls,
+            metrics,
+            chain,
+            network,
+            RetryPolicy::AllErrors,
+        )
+    }
+
+    fn new_with_retry_policy<Builder: HttpClientBuilder<Client = C>>(
+        urls: Vec<Url>,
+        metrics: PrometheusClientMetrics,
+        chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
+        network: u16,
+        retry_policy: RetryPolicy,
     ) -> ChainResult<Self> {
         let clients = urls
             .into_iter()
@@ -40,7 +90,29 @@ impl<C: AleoClient> FallbackHttpClient<C> {
             .map(RpcClient::new)
             .collect_vec();
         let fallback = FallbackProvider::new(clients);
-        Ok(Self { fallback })
+        Ok(Self {
+            fallback,
+            retry_policy,
+        })
+    }
+}
+
+impl FallbackHttpClient<JWTBaseHttpClient> {
+    /// Creates a fallback client for delegated proving. HTTP responses that an
+    /// immediate identical retry cannot fix are attempted once per endpoint.
+    pub fn new_delegated_prover(
+        urls: Vec<Url>,
+        metrics: PrometheusClientMetrics,
+        chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
+        network: u16,
+    ) -> ChainResult<Self> {
+        Self::new_with_retry_policy::<JWTBaseHttpClient>(
+            urls,
+            metrics,
+            chain,
+            network,
+            RetryPolicy::DelegatedProver,
+        )
     }
 }
 
@@ -61,14 +133,20 @@ impl<C: AleoClient> HttpClient for FallbackHttpClient<C> {
         query: impl Into<Option<serde_json::Value>> + Send,
     ) -> ChainResult<T> {
         let query = query.into();
-        self.fallback
-            .call(|inner| {
-                let path = path.to_string();
-                let query = query.clone();
-                let future = async move { inner.request(&path, query).await };
-                Box::pin(future)
-            })
-            .await
+        let request = |inner: RpcClient<MetricHttpClient<C>>| {
+            let path = path.to_string();
+            let query = query.clone();
+            let future = async move { inner.request(&path, query).await };
+            Box::pin(future) as _
+        };
+        match self.retry_policy {
+            RetryPolicy::AllErrors => self.fallback.call(request).await,
+            RetryPolicy::DelegatedProver => {
+                self.fallback
+                    .call_with_retry_predicate(request, should_retry_delegated_prover)
+                    .await
+            }
+        }
     }
 
     async fn request_optional<T: DeserializeOwned + Send>(
@@ -93,13 +171,104 @@ impl<C: AleoClient> HttpClient for FallbackHttpClient<C> {
         path: &str,
         body: &serde_json::Value,
     ) -> ChainResult<T> {
-        self.fallback
-            .call(|inner| {
-                let path = path.to_string();
-                let body = body.clone();
-                let future = async move { inner.request_post(&path, &body).await };
-                Box::pin(future)
-            })
-            .await
+        let request = |inner: RpcClient<MetricHttpClient<C>>| {
+            let path = path.to_string();
+            let body = body.clone();
+            let future = async move { inner.request_post(&path, &body).await };
+            Box::pin(future) as _
+        };
+        match self.retry_policy {
+            RetryPolicy::AllErrors => self.fallback.call(request).await,
+            RetryPolicy::DelegatedProver => {
+                self.fallback
+                    .call_with_retry_predicate(request, should_retry_delegated_prover)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{ErrorKind, Read, Write},
+        net::TcpListener,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
+    use serde_json::Value;
+    use url::Url;
+
+    use super::{FallbackHttpClient, HttpClient, JWTBaseHttpClient};
+
+    async fn assert_auth_attempts(status: reqwest::StatusCode, expected_attempts: usize) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server_attempts = attempts.clone();
+        let server = thread::spawn(move || {
+            let started = Instant::now();
+            while started.elapsed() < Duration::from_secs(1) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        let mut buffer = [0; 4096];
+                        stream.read(&mut buffer).unwrap();
+                        server_attempts.fetch_add(1, Ordering::Relaxed);
+                        let response = format!(
+                            "HTTP/1.1 {} {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            status.as_u16(),
+                            status.canonical_reason().unwrap()
+                        );
+                        stream.write_all(response.as_bytes()).unwrap();
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("test server failed: {error}"),
+                }
+            }
+        });
+        let url = Url::parse(&format!(
+            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
+        ))
+        .unwrap();
+        let client = FallbackHttpClient::<JWTBaseHttpClient>::new_delegated_prover(
+            vec![url],
+            PrometheusClientMetrics::default(),
+            None,
+            0,
+        )
+        .unwrap();
+
+        let result = client.request::<Value>("pubkey", None).await;
+
+        assert!(result.is_err());
+        server.join().unwrap();
+        assert_eq!(attempts.load(Ordering::Relaxed), expected_attempts);
+    }
+
+    #[tokio::test]
+    async fn delegated_prover_does_not_immediately_retry_terminal_http_statuses() {
+        for status in [
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::LENGTH_REQUIRED,
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+        ] {
+            assert_auth_attempts(status, 1).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn delegated_prover_retains_retries_for_server_errors() {
+        assert_auth_attempts(reqwest::StatusCode::INTERNAL_SERVER_ERROR, 4).await;
     }
 }

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -302,16 +302,34 @@ where
     /// If all providers fail, return an error.
     pub async fn call<V>(
         &self,
+        f: impl FnMut(T) -> Pin<Box<dyn Future<Output = ChainResult<V>> + Send>>,
+    ) -> ChainResult<V> {
+        self.call_with_retry_predicate(f, |_| true).await
+    }
+
+    /// Call providers until one succeeds, without retrying a provider when
+    /// `should_retry` returns false for its error.
+    ///
+    /// Every provider is attempted once before terminal providers are excluded
+    /// from later retry rounds. This preserves fallback across independently
+    /// configured providers while avoiding repeated calls that cannot succeed.
+    pub async fn call_with_retry_predicate<V>(
+        &self,
         mut f: impl FnMut(T) -> Pin<Box<dyn Future<Output = ChainResult<V>> + Send>>,
+        should_retry: impl Fn(&crate::ChainCommunicationError) -> bool,
     ) -> ChainResult<V> {
         let mut errors = vec![];
+        let mut retryable_providers = vec![true; self.inner.providers.len()];
         // make sure we do at least 4 total retries.
-        while errors.len() <= 3 {
+        while errors.len() <= 3 && retryable_providers.iter().any(|retryable| *retryable) {
             if !errors.is_empty() {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
             let priorities_snapshot = self.take_priorities_snapshot().await;
             for (idx, priority) in priorities_snapshot.iter().enumerate() {
+                if !retryable_providers[priority.index] {
+                    continue;
+                }
                 let provider = &self.inner.providers[priority.index];
                 let resp = self.call_provider(priority, f(provider.clone())).await;
                 let _span =
@@ -323,6 +341,7 @@ where
                             error=?e,
                             "Got error from inner fallback provider",
                         );
+                        retryable_providers[priority.index] = should_retry(&e);
                         errors.push(e);
                     }
                 }
@@ -618,6 +637,37 @@ pub mod test {
             .map(|p| p.index)
             .collect();
         assert_eq!(expected, actual);
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_predicate_skips_terminal_provider() {
+        let terminal_provider = ProviderMock::default();
+        terminal_provider.push("terminal", true);
+        let retryable_provider = ProviderMock::default();
+        retryable_provider.push("retryable", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([terminal_provider.clone(), retryable_provider.clone()]);
+
+        let result: ChainResult<()> = fallback_provider
+            .call_with_retry_predicate(
+                |provider| {
+                    let response = provider.requests()[0].0.clone();
+                    provider.push("call", true);
+                    Box::pin(async move {
+                        if response == "terminal" {
+                            Err(crate::ChainCommunicationError::BatchingFailed)
+                        } else {
+                            Err(crate::ChainCommunicationError::TransactionTimeout)
+                        }
+                    })
+                },
+                |error| !matches!(error, crate::ChainCommunicationError::BatchingFailed),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(terminal_provider.requests().len(), 2);
+        assert_eq!(retryable_provider.requests().len(), 4);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

1. Attempt each delegated prover endpoint once when JWT authentication returns 401, 403, 411, or 429.
2. Preserve retries for transport/5xx failures and non-auth 401s.
3. Leave normal Aleo RPC fallback unchanged.

Single-endpoint model: **4 → 1 auth calls (75% fewer)** and **3 fewer 100 ms sleeps** per terminal auth failure. Not a production measurement.

## Validation

- Reviewed head: `988bbbef07`; includes #9456's duplicate-check fix.
- Rebase regression reproduced: terminal-auth test made 4 requests instead of 1.
- Fixed by retaining only the typed `DelegatedProverAuthError` status check; source verified after restacking.
- Final-head regression test/CI pending. Muse: no blockers on the production tree; GLM/Kimi reviews pending. No post-fix local test run.

Stack: **3/4**, parent #9458; follow-up #9461.

Latest test-only follow-up: reused `auth_server` to read complete HTTP headers before asserting Content-Length and HTTP 429. Formatting, diff checks, and commit hooks passed; no new local test run.

<details>
<summary>Historical evidence and earlier validation (pre-restack; not current-head results)</summary>

## Summary

- stop retrying the same delegated prover endpoint within one fallback call when its auth POST returns `401`, `403`, `411`, or `429`
- still try every configured prover endpoint once, and preserve the existing four-attempt behavior for transport and `5xx` failures
- keep non-auth `401`s retryable so a stale cached JWT can still be cleared and refreshed

## Expected impact

For the current single-prover configuration, the modeled auth traffic per terminal/rate-limited failure drops from **4 calls to 1 call: 75% fewer immediate auth requests**. That also removes three fixed 100 ms fallback sleeps, so the error returns about **300 ms sooner**, excluding network latency.

For `429`, this deliberately returns control to the relayer backoff added by the parent PR: the first retry is no sooner than **5 seconds**, instead of three extra requests within roughly **300 ms**. `Retry-After` is not available after `reqwest::Response::error_for_status()` converts the response to an error; threading response headers through the generic chain error would be a broader change than this incident needs.

These are expected/modelled improvements from the retry control flow and request-count tests, not production measurements.

## Boundaries

`411` remains terminal for an identical in-call retry because it signals a deterministic request-shape or middleware mismatch. The parent PR now sends `Content-Length: 0`, which fixes the observed Provable load-balancer case; this classification only prevents a future mismatch from being replayed immediately.

The status-aware policy is enabled only for delegated prover authentication. Normal Aleo RPC fallback behavior is unchanged.

## Validation

- `cargo test -p hyperlane-core --features async` — 61 passed, 2 ignored
- `cargo test -p hyperlane-aleo --lib` — 82 passed
- `cargo clippy -p hyperlane-aleo --lib -- -D warnings`
- targeted `rustfmt --edition 2021 --check` for all changed Rust files
- pre-rebase commit hooks passed, including gitleaks and Rust formatting

## Stack

- Stacked on #9458 (`pbio/aleo-jwt-singleflight`)
</details>
