### PR TITLE
feat(aleo): expose delegated prover phase metrics

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6245,6 +6245,7 @@ dependencies = [
  "hyperlane-warp-route",
  "indexmap 2.12.0",
  "num-traits",
+ "prometheus",
  "rand 0.10.2",
  "rand_chacha 0.10.0",
  "reqwest 0.11.27",

--- a/rust/main/chains/hyperlane-aleo/Cargo.toml
+++ b/rust/main/chains/hyperlane-aleo/Cargo.toml
@@ -51,3 +51,6 @@ rand = "0.10"
 rand_chacha = "0.10.0"
 sodiumbox = "0.1.0"
 base64.workspace = true
+
+[dev-dependencies]
+prometheus.workspace = true

--- a/rust/main/chains/hyperlane-aleo/src/error.rs
+++ b/rust/main/chains/hyperlane-aleo/src/error.rs
@@ -2,12 +2,30 @@ use std::{ffi::FromBytesUntilNulError, str::Utf8Error};
 
 use hyperlane_core::ChainCommunicationError;
 
+/// HTTP status error returned while authenticating with a delegated prover.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct DelegatedProverAuthError(#[source] reqwest::Error);
+
+impl DelegatedProverAuthError {
+    pub(crate) fn new(error: reqwest::Error) -> Self {
+        Self(error)
+    }
+
+    pub(crate) fn status(&self) -> Option<reqwest::StatusCode> {
+        self.0.status()
+    }
+}
+
 /// Errors from the crates specific to the hyperlane-aleo
 #[derive(Debug, thiserror::Error)]
 pub enum HyperlaneAleoError {
     /// Reqwest Errors
     #[error("{0}")]
     ReqwestError(#[from] reqwest::Error),
+    /// HTTP status errors from delegated prover authentication.
+    #[error("{0}")]
+    DelegatedProverAuth(#[from] DelegatedProverAuthError),
     /// Anyhow Errors
     #[error("{0}")]
     SnarkVmError(#[from] anyhow::Error),

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -33,8 +33,9 @@ use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
 
 use crate::{
     provider::{
-        fallback::FallbackHttpClient, AleoClient, BaseHttpClient, JWTBaseHttpClient, ProvingClient,
-        RpcClient,
+        fallback::FallbackHttpClient,
+        metric::{record_execution_phase, ExecutionPhase},
+        AleoClient, BaseHttpClient, JWTBaseHttpClient, ProvingClient, RpcClient,
     },
     utils::{get_tx_id, to_h256},
     AleoSigner, ConnectionConf, CurrentNetwork, FeeEstimate, HyperlaneAleoError,
@@ -51,6 +52,8 @@ struct FeeEstimateCacheKey {
 #[derive(Clone)]
 pub struct AleoProvider<C: AleoClient = FallbackHttpClient> {
     client: RpcClient<C>,
+    execution_metrics: PrometheusClientMetrics,
+    execution_metrics_config: hyperlane_metric::prometheus_metric::PrometheusConfig,
     domain: HyperlaneDomain,
     network: u16,
     proving_service: Option<ProvingClient<FallbackHttpClient<JWTBaseHttpClient>>>,
@@ -112,10 +115,15 @@ impl AleoProvider<FallbackHttpClient> {
         Ok(Self {
             client: RpcClient::new(FallbackHttpClient::new::<BaseHttpClient>(
                 conf.rpcs.clone(),
-                metrics,
-                chain,
+                metrics.clone(),
+                chain.clone(),
                 conf.chain_id,
             )?),
+            execution_metrics: metrics,
+            execution_metrics_config: hyperlane_metric::prometheus_metric::PrometheusConfig {
+                chain,
+                ..Default::default()
+            },
             domain,
             network: conf.chain_id,
             proving_service,
@@ -146,6 +154,8 @@ impl<C: AleoClient> AleoProvider<C> {
     ) -> Self {
         Self {
             client: RpcClient::new(client),
+            execution_metrics: Default::default(),
+            execution_metrics_config: Default::default(),
             domain,
             network: chain_id,
             proving_service: None,
@@ -443,16 +453,35 @@ impl<C: AleoClient> AleoProvider<C> {
         // Check delegated prover availability before performing expensive local authorization.
         // This keeps an auth or service outage from repeatedly consuming memory and CPU.
         if let Some(client) = self.proving_service.as_ref() {
-            client.get_public_key().await.map_err(|error| {
+            let preflight_start = Instant::now();
+            let preflight = client.get_public_key().await;
+            record_execution_phase(
+                &self.execution_metrics,
+                &self.execution_metrics_config,
+                ExecutionPhase::DelegatedProverPreflight,
+                preflight_start,
+                preflight.is_ok(),
+            );
+            preflight.map_err(|error| {
                 warn!(%error, "Delegated proving preflight failed");
                 error
             })?;
         }
 
         // Prepare VM + Authorization for execution.
-        let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) = self
+        let authorization_start = Instant::now();
+        let authorization = self
             .prepare_authorization::<N, I, V>(program_id, function_name, input, vm)
-            .await?;
+            .await;
+        record_execution_phase(
+            &self.execution_metrics,
+            &self.execution_metrics_config,
+            ExecutionPhase::Authorization,
+            authorization_start,
+            authorization.is_ok(),
+        );
+        let (authorization, program_id_parsed, function_name_parsed, private_key, mut rng) =
+            authorization?;
 
         // Calculate fees
         let base_fee = self
@@ -489,16 +518,19 @@ impl<C: AleoClient> AleoProvider<C> {
                     program_id,
                     function_name, "Starting delegated ZK proof generation"
                 );
-                client
-                    .proving_request(authorization, fee)
-                    .await
-                    .map_err(|error| {
-                        warn!(
-                            %error,
-                            "Delegated proving failed"
-                        );
-                        error
-                    })?
+                let proof_start = Instant::now();
+                let proof = client.proving_request(authorization, fee).await;
+                record_execution_phase(
+                    &self.execution_metrics,
+                    &self.execution_metrics_config,
+                    ExecutionPhase::DelegatedProverProof,
+                    proof_start,
+                    proof.is_ok(),
+                );
+                proof.map_err(|error| {
+                    warn!(%error, "Delegated proving failed");
+                    error
+                })?
             }
             None => {
                 debug!(

--- a/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/aleo.rs
@@ -98,7 +98,7 @@ impl AleoProvider<FallbackHttpClient> {
         chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
     ) -> ChainResult<Self> {
         let proving_service = if !conf.proving_service.is_empty() {
-            let client = FallbackHttpClient::new::<JWTBaseHttpClient>(
+            let client = FallbackHttpClient::new_delegated_prover(
                 conf.proving_service.clone(),
                 metrics.clone(),
                 chain.clone(),

--- a/rust/main/chains/hyperlane-aleo/src/provider/base.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/base.rs
@@ -14,7 +14,7 @@ use url::Url;
 use hyperlane_core::{ChainCommunicationError, ChainResult};
 
 use crate::provider::{HttpClient, HttpClientBuilder};
-use crate::HyperlaneAleoError;
+use crate::{DelegatedProverAuthError, HyperlaneAleoError};
 
 // Default timeouts
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -212,7 +212,7 @@ impl JWTBaseHttpClient {
             .map_err(HyperlaneAleoError::from)?;
         let response = response
             .error_for_status()
-            .map_err(HyperlaneAleoError::from)?;
+            .map_err(|error| HyperlaneAleoError::from(DelegatedProverAuthError::new(error)))?;
         let result = response
             .headers()
             .get(AUTHORIZATION)

--- a/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/fallback.rs
@@ -1,8 +1,10 @@
+use std::error::Error;
+
 use async_trait::async_trait;
 
 use hyperlane_core::{
     rpc_clients::{BlockNumberGetter, FallbackProvider},
-    ChainResult,
+    ChainCommunicationError, ChainResult,
 };
 use hyperlane_metric::prometheus_metric::{
     ClientConnectionType, PrometheusClientMetrics, PrometheusConfig,
@@ -11,13 +13,45 @@ use snarkvm_console_account::{DeserializeOwned, Itertools};
 use url::Url;
 
 use crate::provider::{
-    metric::MetricHttpClient, AleoClient, BaseHttpClient, HttpClient, HttpClientBuilder, RpcClient,
+    metric::MetricHttpClient, AleoClient, BaseHttpClient, HttpClient, HttpClientBuilder,
+    JWTBaseHttpClient, RpcClient,
 };
+use crate::DelegatedProverAuthError;
+
+#[derive(Clone, Copy, Debug)]
+enum RetryPolicy {
+    AllErrors,
+    DelegatedProver,
+}
+
+fn delegated_prover_auth_status(error: &ChainCommunicationError) -> Option<reqwest::StatusCode> {
+    let mut source: Option<&(dyn Error + 'static)> = Some(error);
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<DelegatedProverAuthError>() {
+            return error.status();
+        }
+        source = error.source();
+    }
+    None
+}
+
+fn should_retry_delegated_prover(error: &ChainCommunicationError) -> bool {
+    !matches!(
+        delegated_prover_auth_status(error),
+        Some(
+            reqwest::StatusCode::UNAUTHORIZED
+                | reqwest::StatusCode::FORBIDDEN
+                | reqwest::StatusCode::LENGTH_REQUIRED
+                | reqwest::StatusCode::TOO_MANY_REQUESTS
+        )
+    )
+}
 
 /// Fallback Http Client that tries multiple RpcClients in order
 #[derive(Clone, Debug)]
 pub struct FallbackHttpClient<C: AleoClient = BaseHttpClient> {
     fallback: FallbackProvider<RpcClient<MetricHttpClient<C>>, RpcClient<MetricHttpClient<C>>>,
+    retry_policy: RetryPolicy,
 }
 
 impl<C: AleoClient> FallbackHttpClient<C> {
@@ -27,6 +61,22 @@ impl<C: AleoClient> FallbackHttpClient<C> {
         metrics: PrometheusClientMetrics,
         chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
         network: u16,
+    ) -> ChainResult<Self> {
+        Self::new_with_retry_policy::<Builder>(
+            urls,
+            metrics,
+            chain,
+            network,
+            RetryPolicy::AllErrors,
+        )
+    }
+
+    fn new_with_retry_policy<Builder: HttpClientBuilder<Client = C>>(
+        urls: Vec<Url>,
+        metrics: PrometheusClientMetrics,
+        chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
+        network: u16,
+        retry_policy: RetryPolicy,
     ) -> ChainResult<Self> {
         let clients = urls
             .into_iter()
@@ -40,7 +90,29 @@ impl<C: AleoClient> FallbackHttpClient<C> {
             .map(RpcClient::new)
             .collect_vec();
         let fallback = FallbackProvider::new(clients);
-        Ok(Self { fallback })
+        Ok(Self {
+            fallback,
+            retry_policy,
+        })
+    }
+}
+
+impl FallbackHttpClient<JWTBaseHttpClient> {
+    /// Creates a fallback client for delegated proving. HTTP responses that an
+    /// immediate identical retry cannot fix are attempted once per endpoint.
+    pub fn new_delegated_prover(
+        urls: Vec<Url>,
+        metrics: PrometheusClientMetrics,
+        chain: Option<hyperlane_metric::prometheus_metric::ChainInfo>,
+        network: u16,
+    ) -> ChainResult<Self> {
+        Self::new_with_retry_policy::<JWTBaseHttpClient>(
+            urls,
+            metrics,
+            chain,
+            network,
+            RetryPolicy::DelegatedProver,
+        )
     }
 }
 
@@ -61,14 +133,20 @@ impl<C: AleoClient> HttpClient for FallbackHttpClient<C> {
         query: impl Into<Option<serde_json::Value>> + Send,
     ) -> ChainResult<T> {
         let query = query.into();
-        self.fallback
-            .call(|inner| {
-                let path = path.to_string();
-                let query = query.clone();
-                let future = async move { inner.request(&path, query).await };
-                Box::pin(future)
-            })
-            .await
+        let request = |inner: RpcClient<MetricHttpClient<C>>| {
+            let path = path.to_string();
+            let query = query.clone();
+            let future = async move { inner.request(&path, query).await };
+            Box::pin(future) as _
+        };
+        match self.retry_policy {
+            RetryPolicy::AllErrors => self.fallback.call(request).await,
+            RetryPolicy::DelegatedProver => {
+                self.fallback
+                    .call_with_retry_predicate(request, should_retry_delegated_prover)
+                    .await
+            }
+        }
     }
 
     async fn request_optional<T: DeserializeOwned + Send>(
@@ -93,13 +171,104 @@ impl<C: AleoClient> HttpClient for FallbackHttpClient<C> {
         path: &str,
         body: &serde_json::Value,
     ) -> ChainResult<T> {
-        self.fallback
-            .call(|inner| {
-                let path = path.to_string();
-                let body = body.clone();
-                let future = async move { inner.request_post(&path, &body).await };
-                Box::pin(future)
-            })
-            .await
+        let request = |inner: RpcClient<MetricHttpClient<C>>| {
+            let path = path.to_string();
+            let body = body.clone();
+            let future = async move { inner.request_post(&path, &body).await };
+            Box::pin(future) as _
+        };
+        match self.retry_policy {
+            RetryPolicy::AllErrors => self.fallback.call(request).await,
+            RetryPolicy::DelegatedProver => {
+                self.fallback
+                    .call_with_retry_predicate(request, should_retry_delegated_prover)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{ErrorKind, Read, Write},
+        net::TcpListener,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
+    use serde_json::Value;
+    use url::Url;
+
+    use super::{FallbackHttpClient, HttpClient, JWTBaseHttpClient};
+
+    async fn assert_auth_attempts(status: reqwest::StatusCode, expected_attempts: usize) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server_attempts = attempts.clone();
+        let server = thread::spawn(move || {
+            let started = Instant::now();
+            while started.elapsed() < Duration::from_secs(1) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream.set_nonblocking(false).unwrap();
+                        let mut buffer = [0; 4096];
+                        stream.read(&mut buffer).unwrap();
+                        server_attempts.fetch_add(1, Ordering::Relaxed);
+                        let response = format!(
+                            "HTTP/1.1 {} {}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            status.as_u16(),
+                            status.canonical_reason().unwrap()
+                        );
+                        stream.write_all(response.as_bytes()).unwrap();
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("test server failed: {error}"),
+                }
+            }
+        });
+        let url = Url::parse(&format!(
+            "http://{address}/v2?custom_rpc_header=x-auth-url:http%3A%2F%2F{address}%2Fauth"
+        ))
+        .unwrap();
+        let client = FallbackHttpClient::<JWTBaseHttpClient>::new_delegated_prover(
+            vec![url],
+            PrometheusClientMetrics::default(),
+            None,
+            0,
+        )
+        .unwrap();
+
+        let result = client.request::<Value>("pubkey", None).await;
+
+        assert!(result.is_err());
+        server.join().unwrap();
+        assert_eq!(attempts.load(Ordering::Relaxed), expected_attempts);
+    }
+
+    #[tokio::test]
+    async fn delegated_prover_does_not_immediately_retry_terminal_http_statuses() {
+        for status in [
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::FORBIDDEN,
+            reqwest::StatusCode::LENGTH_REQUIRED,
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+        ] {
+            assert_auth_attempts(status, 1).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn delegated_prover_retains_retries_for_server_errors() {
+        assert_auth_attempts(reqwest::StatusCode::INTERNAL_SERVER_ERROR, 4).await;
     }
 }

--- a/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
+++ b/rust/main/chains/hyperlane-aleo/src/provider/metric.rs
@@ -9,6 +9,34 @@ use hyperlane_metric::prometheus_metric::{PrometheusClientMetrics, PrometheusCon
 
 use crate::provider::{AleoClient, BaseHttpClient, HttpClient, HttpClientBuilder, RpcClient};
 
+#[derive(Clone, Copy)]
+pub enum ExecutionPhase {
+    DelegatedProverPreflight,
+    Authorization,
+    DelegatedProverProof,
+}
+
+impl ExecutionPhase {
+    const fn method(self) -> &'static str {
+        match self {
+            Self::DelegatedProverPreflight => "delegated_prover_preflight",
+            Self::Authorization => "aleo_authorization",
+            Self::DelegatedProverProof => "delegated_prover_proof",
+        }
+    }
+}
+
+/// Records a bounded high-level Aleo execution phase using the standard client metrics.
+pub fn record_execution_phase(
+    metrics: &PrometheusClientMetrics,
+    metrics_config: &PrometheusConfig,
+    phase: ExecutionPhase,
+    start: Instant,
+    success: bool,
+) {
+    metrics.increment_metrics(metrics_config, phase.method(), start, success);
+}
+
 /// Fallback Http Client that tries multiple RpcClients in order
 #[derive(Debug)]
 pub struct MetricHttpClient<C: AleoClient = BaseHttpClient> {
@@ -129,7 +157,14 @@ impl<C: AleoClient> HttpClient for MetricHttpClient<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::MetricHttpClient;
+    use std::time::Instant;
+
+    use hyperlane_metric::prometheus_metric::{
+        ChainInfo, PrometheusClientMetricsBuilder, REQUEST_COUNT_LABELS,
+    };
+    use prometheus::{IntCounterVec, Opts};
+
+    use super::{record_execution_phase, ExecutionPhase, MetricHttpClient};
     use crate::provider::BaseHttpClient;
 
     #[test]
@@ -146,5 +181,63 @@ mod tests {
             MetricHttpClient::<BaseHttpClient>::method("transaction/broadcast"),
             "transaction_broadcast"
         );
+    }
+
+    #[test]
+    fn execution_phase_metrics_use_a_fixed_phase_label() {
+        let request_count = IntCounterVec::new(
+            Opts::new("test_request_count", "test request count"),
+            REQUEST_COUNT_LABELS,
+        )
+        .expect("valid request metric");
+        let metrics = PrometheusClientMetricsBuilder::default()
+            .request_count(request_count.clone())
+            .build()
+            .expect("valid client metrics");
+        let metrics_config = hyperlane_metric::prometheus_metric::PrometheusConfig {
+            chain: Some(ChainInfo {
+                name: Some("aleo-testnet".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        for (phase, method, status) in [
+            (
+                ExecutionPhase::DelegatedProverPreflight,
+                "delegated_prover_preflight",
+                "failure",
+            ),
+            (
+                ExecutionPhase::Authorization,
+                "aleo_authorization",
+                "success",
+            ),
+            (
+                ExecutionPhase::DelegatedProverProof,
+                "delegated_prover_proof",
+                "success",
+            ),
+        ] {
+            record_execution_phase(
+                &metrics,
+                &metrics_config,
+                phase,
+                Instant::now(),
+                status == "success",
+            );
+            assert_eq!(
+                request_count
+                    .with_label_values(&[
+                        "unknown",
+                        "rpc",
+                        "aleo-testnet",
+                        method,
+                        status,
+                        "primary",
+                    ])
+                    .get(),
+                1,
+            );
+        }
     }
 }

--- a/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
+++ b/rust/main/hyperlane-core/src/rpc_clients/fallback.rs
@@ -302,16 +302,34 @@ where
     /// If all providers fail, return an error.
     pub async fn call<V>(
         &self,
+        f: impl FnMut(T) -> Pin<Box<dyn Future<Output = ChainResult<V>> + Send>>,
+    ) -> ChainResult<V> {
+        self.call_with_retry_predicate(f, |_| true).await
+    }
+
+    /// Call providers until one succeeds, without retrying a provider when
+    /// `should_retry` returns false for its error.
+    ///
+    /// Every provider is attempted once before terminal providers are excluded
+    /// from later retry rounds. This preserves fallback across independently
+    /// configured providers while avoiding repeated calls that cannot succeed.
+    pub async fn call_with_retry_predicate<V>(
+        &self,
         mut f: impl FnMut(T) -> Pin<Box<dyn Future<Output = ChainResult<V>> + Send>>,
+        should_retry: impl Fn(&crate::ChainCommunicationError) -> bool,
     ) -> ChainResult<V> {
         let mut errors = vec![];
+        let mut retryable_providers = vec![true; self.inner.providers.len()];
         // make sure we do at least 4 total retries.
-        while errors.len() <= 3 {
+        while errors.len() <= 3 && retryable_providers.iter().any(|retryable| *retryable) {
             if !errors.is_empty() {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
             let priorities_snapshot = self.take_priorities_snapshot().await;
             for (idx, priority) in priorities_snapshot.iter().enumerate() {
+                if !retryable_providers[priority.index] {
+                    continue;
+                }
                 let provider = &self.inner.providers[priority.index];
                 let resp = self.call_provider(priority, f(provider.clone())).await;
                 let _span =
@@ -323,6 +341,7 @@ where
                             error=?e,
                             "Got error from inner fallback provider",
                         );
+                        retryable_providers[priority.index] = should_retry(&e);
                         errors.push(e);
                     }
                 }
@@ -618,6 +637,37 @@ pub mod test {
             .map(|p| p.index)
             .collect();
         assert_eq!(expected, actual);
+    }
+
+    #[tokio::test]
+    async fn test_call_with_retry_predicate_skips_terminal_provider() {
+        let terminal_provider = ProviderMock::default();
+        terminal_provider.push("terminal", true);
+        let retryable_provider = ProviderMock::default();
+        retryable_provider.push("retryable", true);
+        let fallback_provider: FallbackProvider<ProviderMock, ProviderMock> =
+            FallbackProvider::new([terminal_provider.clone(), retryable_provider.clone()]);
+
+        let result: ChainResult<()> = fallback_provider
+            .call_with_retry_predicate(
+                |provider| {
+                    let response = provider.requests()[0].0.clone();
+                    provider.push("call", true);
+                    Box::pin(async move {
+                        if response == "terminal" {
+                            Err(crate::ChainCommunicationError::BatchingFailed)
+                        } else {
+                            Err(crate::ChainCommunicationError::TransactionTimeout)
+                        }
+                    })
+                },
+                |error| !matches!(error, crate::ChainCommunicationError::BatchingFailed),
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(terminal_provider.requests().len(), 2);
+        assert_eq!(retryable_provider.requests().len(), 4);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Record **3 execution phases** with existing request-count/duration metrics:

1. Delegated-prover preflight.
2. Local authorization.
3. Delegated proof generation.

Fixed phase labels; no message/program/error labels. **0 additional network calls** in this PR. Phase metrics include success/failure and do not change proving control flow.

## Validation

- Reviewed cumulative head: `c9d74bcf16`; includes #9456's duplicate-check fix.
- Pre-fix provider run: **24 passed, 1 failed**. The failure was the now-fixed duplicate auth-status check; metric tests passed.
- Final-head CI pending. Muse: no blockers on the production tree; GLM/Kimi reviews pending. No post-fix local test run.
- Rollout must verify auth/proof success, phase telemetry, and continued message delivery; this head is not claimed production-validated.

Stack: **4/4** — #9456 → #9458 → #9459 → #9461.

Latest test-only follow-up: reused `auth_server` to read complete HTTP headers before asserting Content-Length and HTTP 429. Formatting, diff checks, and commit hooks passed; no new local test run.

<details>
<summary>Historical evidence and earlier validation (pre-restack; not current-head results)</summary>

## Summary

- instrument the delegated-prover preflight, local authorization, and delegated-proof phases with the existing `hyperlane_request_count` and `hyperlane_request_duration_seconds` series
- use a closed three-value phase enum and existing `status` label; do not add program, function, message, or error labels
- add a focused metric-label test

## Measurement and expected impact

Measured: each attempt now emits one count and cumulative-duration sample for its completed phase, including failures. A failed preflight therefore records only `delegated_prover_preflight{status="failure"}`; it cannot be conflated with authorization or proof work.

Modelled: this is observability-only. It adds no network calls, proving work, retries, or control-flow changes. It enables dashboard/query decomposition of attempted volume, failure ratio, and cumulative time across the three phases to validate the outage-backoff change after rollout.

## Stack

Stacked on #9459 (`fe50d73ce5b2e0312011e59bd892c4a6cf7301ca`), which is stacked on #9458 (`b2f4df0784fa4a6b703e35c982dc1483401e9677`) and #9456 (`fb789a39d1d4bf1563739f69e3f039eb36a4623c`). Final order: #9456 -> #9458 -> #9459 -> #9461.

## Validation

- `cargo test -p hyperlane-aleo provider::metric::tests::execution_phase_metrics_use_a_fixed_phase_label`
- `cargo clippy -p hyperlane-aleo --lib -- -D warnings`
- `rustfmt --edition 2021 --check chains/hyperlane-aleo/src/provider/aleo.rs chains/hyperlane-aleo/src/provider/metric.rs`
- normal commit hooks: gitleaks, lint-staged, `cargo fmt --all --check` for `rust/main` and `rust/sealevel`

Note: `cargo clippy -p hyperlane-aleo --all-targets -- -D warnings` remains red on 181 pre-existing test-only lint violations outside this diff; the production-library clippy gate above is clean.

</details>
