### PR TITLE
perf(ccip-server): skip decoding unrelated receipt logs

### DIFF
--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -3,7 +3,8 @@
   "spec": [
     "./tests/**/CallCommitmentsService.test.ts",
     "./tests/**/RateLimiting.test.ts",
-    "./tests/**/cctpMessageMatcher.test.ts"
+    "./tests/**/cctpMessageMatcher.test.ts",
+    "./tests/**/CCTPService.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/src/services/CCTPService.ts
+++ b/typescript/ccip-server/src/services/CCTPService.ts
@@ -25,6 +25,13 @@ import { CCTPAttestationService } from './CCTPAttestationService.js';
 import { findMatchingCircleMessage } from './cctpMessageMatcher.js';
 import { HyperlaneService } from './HyperlaneService.js';
 
+const messageTransmitterInterface =
+  IMessageTransmitter__factory.createInterface();
+const messageSentEvent =
+  messageTransmitterInterface.getEvent('MessageSent(bytes)');
+const messageSentTopic =
+  messageTransmitterInterface.getEventTopic(messageSentEvent);
+
 const EnvSchema = z.object({
   HYPERLANE_EXPLORER_URL: z.url(),
   CCTP_ATTESTATION_URL: z.url(),
@@ -102,15 +109,15 @@ class CCTPService extends BaseService {
       'Extracting CCTP message from receipt',
     );
 
-    const iface = IMessageTransmitter__factory.createInterface();
-    const event = iface.events['MessageSent(bytes)'];
-
     const allMessages: string[] = [];
     for (const receiptLog of receipt.logs) {
+      // Most receipt logs belong to other contracts. Avoid ABI lookup and
+      // exception allocation for events that cannot contain a CCTP message.
+      if (receiptLog.topics[0]?.toLowerCase() !== messageSentTopic) continue;
       try {
-        const parsedLog = iface.parseLog(receiptLog);
+        const parsedLog = messageTransmitterInterface.parseLog(receiptLog);
         if (
-          parsedLog.name === event.name &&
+          parsedLog.name === messageSentEvent.name &&
           typeof parsedLog.args.message === 'string'
         ) {
           allMessages.push(parsedLog.args.message);

--- a/typescript/ccip-server/tests/services/CCTPService.test.ts
+++ b/typescript/ccip-server/tests/services/CCTPService.test.ts
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import pino from 'pino';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import { IMessageTransmitter__factory } from '@hyperlane-xyz/core';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { formatMessage } from '@hyperlane-xyz/utils';
+
+import { CCTPService } from '../../src/services/CCTPService.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+
+const iface = IMessageTransmitter__factory.createInterface();
+const event = iface.getEvent('MessageSent(bytes)');
+const address = `0x${'12'.repeat(20)}`;
+const hash = ethers.constants.HashZero;
+const logger = pino({ level: 'silent' });
+
+function log(data: string, topics: string[]): ethers.providers.Log {
+  return {
+    address,
+    data,
+    topics,
+    blockNumber: 1,
+    blockHash: hash,
+    transactionHash: hash,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
+function receipt(
+  logs: ethers.providers.Log[],
+): ethers.providers.TransactionReceipt {
+  return {
+    to: address,
+    from: address,
+    contractAddress: address,
+    transactionIndex: 0,
+    gasUsed: ethers.BigNumber.from(0),
+    logsBloom: '0x',
+    blockHash: hash,
+    transactionHash: hash,
+    logs,
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: ethers.BigNumber.from(0),
+    effectiveGasPrice: ethers.BigNumber.from(0),
+    byzantium: true,
+    type: 2,
+  };
+}
+
+function messageLog(message: string): ethers.providers.Log {
+  const encoded = iface.encodeEventLog(event, [message]);
+  return log(encoded.data, encoded.topics);
+}
+
+describe('CCTPService receipt decoding', () => {
+  let service: CCTPService;
+  beforeEach(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      HYPERLANE_EXPLORER_URL: 'https://example.com',
+      CCTP_ATTESTATION_URL: 'https://example.com',
+    });
+    initializeMetrics(new Registry());
+    service = new CCTPService({
+      serviceName: 'test',
+      multiProvider: new MultiProvider({}),
+    });
+  });
+  afterEach(() => sinon.restore());
+
+  it('decodes only MessageSent events in a receipt with unrelated and anonymous logs', async () => {
+    const parse = sinon.spy(ethers.utils.Interface.prototype, 'parseLog');
+    const unrelated = Array.from({ length: 100 }, () => log('0x', [hash]));
+    const result = await service.getCCTPMessageFromReceipt(
+      receipt([...unrelated, log('0x', []), messageLog('0x1234')]),
+      '0x',
+      hash,
+      logger,
+    );
+    expect(result).to.equal('0x1234');
+    expect(parse.callCount).to.equal(1);
+  });
+
+  it('retains case-insensitive topic matching and skips malformed matching logs', async () => {
+    const valid = messageLog('0x1234');
+    valid.topics = valid.topics.map(
+      (topic) => `0x${topic.slice(2).toUpperCase()}`,
+    );
+    const result = await service.getCCTPMessageFromReceipt(
+      receipt([log('0x', [iface.getEventTopic(event)]), valid]),
+      '0x',
+      hash,
+      logger,
+    );
+    expect(result).to.equal('0x1234');
+  });
+
+  it('preserves the error when no valid MessageSent event exists', async () => {
+    try {
+      await service.getCCTPMessageFromReceipt(
+        receipt([log('0x', [hash])]),
+        '0x',
+        hash,
+        logger,
+      );
+      expect.fail('Expected a missing-message error');
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      expect(error.message).to.equal(
+        'Unable to find MessageSent event in logs',
+      );
+    }
+  });
+
+  it('retains multi-message disambiguation after filtering unrelated events', async () => {
+    const hyperlaneMessage = formatMessage(3, 0, 1, address, 2, address, '0x');
+    const id = ethers.utils.keccak256(hyperlaneMessage);
+    const gmp = Buffer.alloc(180);
+    Buffer.from(id.slice(2), 'hex').copy(gmp, 148);
+    const matchingMessage = ethers.utils.hexlify(gmp);
+    const otherMessage = ethers.utils.hexlify(Buffer.alloc(180));
+    const result = await service.getCCTPMessageFromReceipt(
+      receipt([
+        messageLog(otherMessage),
+        log('0x', [hash]),
+        messageLog(matchingMessage),
+      ]),
+      hyperlaneMessage,
+      id,
+      logger,
+    );
+    expect(result).to.equal(matchingMessage);
+  });
+});


### PR DESCRIPTION
## Problem

CCTP receipt extraction rebuilt the ABI interface per request and attempted to decode every receipt log, allocating exceptions for unrelated events.

## Solution

Reused the immutable MessageTransmitter interface and filtered by the MessageSent topic before decoding. Preserved receipt ordering, malformed-event handling and multi-message matching; no RPC caching or freshness change.

## Performance evidence

A synthetic receipt with 100 unrelated logs, one anonymous log and one MessageSent now makes **1 ABI parse instead of 102 (99.0% fewer)**. Interface creation falls from once per extraction to once per module load. The operation-count regression fails against base (102 calls) and passes with this change (1 call), with the same extracted message. This measures work avoided, not end-to-end or production latency.

## Observed workload

Read-only mainnet3 snapshot on 2026-09-05 around 01:38 UTC: six-hour Prometheus increases were approximately 16 successful CCTP requests and 1,352 CCTP HTTP-500 responses, with expected attestation-pending errors dominating the bounded log sample. The service averaged approximately 0.00076 CPU cores over one hour. This confirms that the change is a small per-receipt CPU optimisation, not evidence of a CPU bottleneck or a production capacity improvement. Receipt-log operation counts above remain synthetic; the deployed image predates the change.

## Validation

58 CCIP tests passed, including malformed matching logs, mixed-case topics, missing events and multi-message disambiguation. Package build and workspace lint passed. Self-review traced the receipt caller and checked matching, ordering and error behavior. The package is private; no release changeset is needed.

Local test caveat: the frozen lockfile pairs `@provablehq/sdk@0.11.3` with `core-js@3.50.0`, whose removed `proposals/json-parse-with-source.js` entry prevents SDK imports. Tests used a local node_modules compatibility entry requiring the existing `esnext.json.{is-raw-json,parse,raw-json}` modules. No dependency changes are included; clean-install test CI remains to be checked. No deployment or live latency measurement.


---

Superseded by consolidated draft #9486: [perf(ccip-server): reduce receipt, logging and startup overhead](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9486). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
