### PR TITLE
perf(warp-monitor): skip unused reads for delegated metrics

### DIFF
--- a/typescript/warp-monitor/src/monitor-efficiency.test.ts
+++ b/typescript/warp-monitor/src/monitor-efficiency.test.ts
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { ExplorerPendingTransfersClient } from './explorer.js';
+import {
+  metricsRegister,
+  resetInventoryBalanceMetrics,
+  resetPendingDestinationMetrics,
+} from './metrics.js';
+import {
+  collectCoinGeckoIds,
+  runRouteCycle,
+  type RouteRuntime,
+  type SharedMonitorContext,
+} from './monitor.js';
+import { getLogger } from './utils.js';
+
+function fixture() {
+  const provider = new MultiProtocolProvider<{ mailbox?: string }>({
+    ethereum: {
+      name: 'ethereum',
+      chainId: 1,
+      domainId: 1,
+      protocol: ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+    },
+  });
+  const tokens = [
+    TokenStandard.EvmHypCollateral,
+    TokenStandard.EvmHypSynthetic,
+  ].map(
+    (standard, index) =>
+      new Token({
+        chainName: 'ethereum',
+        standard,
+        addressOrDenom: `0x${String(index + 1).padStart(40, '0')}`,
+        decimals: 0,
+        symbol: `TOKEN${index}`,
+        name: `Token ${index}`,
+        coinGeckoId: `price-${index}`,
+      }),
+  );
+  const supplyReads = tokens.map((token) => {
+    const adapter = token.getHypAdapter(provider);
+    sinon.stub(token, 'getHypAdapter').returns(adapter);
+    return sinon.stub(adapter, 'getBridgedSupply').resolves(3n);
+  });
+  const inventoryReads = tokens.map((token) => {
+    const adapter = token.getAdapter(provider);
+    sinon.stub(token, 'getAdapter').returns(adapter);
+    return sinon.stub(adapter, 'getBalance').resolves(7n);
+  });
+  const routerNodes = tokens.map((token) => ({
+    nodeId: `${token.symbol}|${token.chainName}|${token.addressOrDenom}`,
+    chainName: token.chainName,
+    domainId: 1,
+    routerAddress: token.addressOrDenom,
+    tokenAddress: token.addressOrDenom,
+    tokenName: token.name,
+    tokenSymbol: token.symbol,
+    tokenDecimals: token.decimals,
+    token,
+  }));
+  const pendingTransfersClient = new ExplorerPendingTransfersClient(
+    'http://localhost:8080',
+    routerNodes,
+    getLogger(),
+  );
+  const pendingReads = sinon
+    .stub(pendingTransfersClient, 'getPendingDestinationTransfers')
+    .resolves(
+      routerNodes.map((node) => ({
+        messageId: `message-${node.nodeId}`,
+        originDomainId: 1,
+        destinationDomainId: 1,
+        destinationChain: node.chainName,
+        destinationNodeId: node.nodeId,
+        destinationRouter: node.routerAddress,
+        amountBaseUnits: 5n,
+      })),
+    );
+  const priceRead = sinon.stub().resolves(2);
+  const ctx: SharedMonitorContext = {
+    multiProtocolProvider: provider,
+    chainMetadata: provider.metadata,
+    priceGetter: { tryGetTokenPrice: priceRead },
+    prefetchPrices: async () => {},
+  };
+  const route: RouteRuntime = {
+    warpRouteId: 'TEST/efficiency',
+    warpCore: new WarpCore(provider, tokens),
+    warpDeployConfig: null,
+    routerNodes,
+    pendingTransfersClient,
+    explorerQueryLimit: 200,
+    inventoryAddress: '0x0000000000000000000000000000000000000009',
+    skipSharedBalanceMetrics: false,
+  };
+  return { ctx, route, supplyReads, inventoryReads, pendingReads, priceRead };
+}
+
+async function monitorOnlyMetrics() {
+  return (await metricsRegister.metrics())
+    .split('\n')
+    .filter((line) =>
+      /^hyperlane_warp_route_(pending_destination_|projected_deficit|inventory_balance)/.test(
+        line,
+      ),
+    )
+    .sort();
+}
+
+describe('delegated shared balance collection', () => {
+  beforeEach(() => {
+    resetInventoryBalanceMetrics();
+    resetPendingDestinationMetrics();
+  });
+  afterEach(() => {
+    sinon.restore();
+    resetInventoryBalanceMetrics();
+    resetPendingDestinationMetrics();
+  });
+
+  it('skips synthetic supply but preserves monitor-only metrics and fresh reads', async () => {
+    const { ctx, route, supplyReads, inventoryReads, pendingReads, priceRead } =
+      fixture();
+    await runRouteCycle(ctx, route);
+    expect(supplyReads.map((read) => read.callCount)).to.deep.equal([1, 1]);
+    const expected = await monitorOnlyMetrics();
+    expect(expected).to.have.length(9); // Six pending, one deficit, two inventory.
+    expect(
+      expected.some(
+        (line) =>
+          line.startsWith('hyperlane_warp_route_projected_deficit{') &&
+          line.endsWith(' 2'),
+      ),
+    ).to.equal(true);
+    route.skipSharedBalanceMetrics = true;
+    for (let cycle = 0; cycle < 5; cycle++) {
+      await runRouteCycle(ctx, route);
+      expect(await monitorOnlyMetrics()).to.deep.equal(expected);
+    }
+    expect(supplyReads.map((read) => read.callCount)).to.deep.equal([6, 1]);
+    expect(inventoryReads.map((read) => read.callCount)).to.deep.equal([6, 6]);
+    expect(pendingReads.callCount).to.equal(6);
+    expect(priceRead.callCount).to.equal(1);
+    supplyReads[0].resolves(1n);
+    inventoryReads[1].resolves(9n);
+    await runRouteCycle(ctx, route);
+    const changed = await monitorOnlyMetrics();
+    expect(
+      changed.some(
+        (line) =>
+          line.startsWith('hyperlane_warp_route_projected_deficit{') &&
+          line.endsWith(' 4'),
+      ),
+    ).to.equal(true);
+    expect(
+      changed.some(
+        (line) =>
+          line.startsWith('hyperlane_warp_route_inventory_balance{') &&
+          line.includes('token_symbol="TOKEN1"') &&
+          line.endsWith(' 9'),
+      ),
+    ).to.equal(true);
+  });
+
+  it('prefetches prices only for routes that emit USD metrics, retaining shared IDs', () => {
+    const { route } = fixture();
+    const delegated = { ...route, skipSharedBalanceMetrics: true };
+    expect(collectCoinGeckoIds([delegated])).to.deep.equal([]);
+    expect(collectCoinGeckoIds([delegated, route])).to.deep.equal([
+      'price-0',
+      'price-1',
+    ]);
+    expect(collectCoinGeckoIds([route, delegated, route])).to.deep.equal([
+      'price-0',
+      'price-1',
+    ]);
+  });
+});

--- a/typescript/warp-monitor/src/monitor.ts
+++ b/typescript/warp-monitor/src/monitor.ts
@@ -425,7 +425,7 @@ export async function updatePendingAndInventoryMetrics(
 }
 
 // Updates the metrics for a single token in a warp route. Always computes the
-// router collateral snapshot (needed for projected-deficit, a monitor-only
+// collateralized router snapshot (needed for projected-deficit, a monitor-only
 // metric) but skips emitting shared balance metrics when the route delegates
 // those to a rebalancer.
 async function updateTokenMetrics(
@@ -436,6 +436,10 @@ async function updateTokenMetrics(
   const logger = getLogger();
   const { warpCore, warpDeployConfig, warpRouteId, skipSharedBalanceMetrics } =
     route;
+  // Non-collateralized supply is only consumed by shared balance metrics.
+  // Pending and inventory collection runs separately for every router node.
+  if (skipSharedBalanceMetrics && !token.isCollateralized()) return null;
+
   let collateralSnapshot: RouterCollateralSnapshot | null = null;
 
   const promises = [
@@ -706,6 +710,8 @@ function getCachedTokenPrice(
 export function collectCoinGeckoIds(routes: RouteRuntime[]): string[] {
   const ids = new Set<string>();
   for (const route of routes) {
+    // Monitor-only metrics use base/token amounts, never USD prices.
+    if (route.skipSharedBalanceMetrics) continue;
     for (const token of route.warpCore.tokens) {
       if (token.coinGeckoId) ids.add(token.coinGeckoId);
     }


### PR DESCRIPTION
## Problem

Routes with `skipSharedBalanceMetrics` still fetched synthetic bridged supply and contributed CoinGecko IDs to each cycle's price prefetch. Their shared balance/USD metrics are emitted by a rebalancer, and monitor-only pending/inventory metrics consume neither synthetic supply nor USD prices.

## Solution

Skip non-collateralized supply collection when shared metrics are delegated. Keep collateralized supply reads for projected deficits, and keep pending-transfer/inventory collection for every router node. Exclude delegated routes from the existing price-ID collector; retain IDs also required by nondelegated routes. No new cache or stale-result reuse.

## Performance evidence

| Work measured | Before | After |
| --- | ---: | ---: |
| Supply reads over 5 delegated cycles, one collateral + one synthetic token | 10 | 5 (-50%) |
| Synthetic supply reads within those cycles | 5 | 0 |
| Price IDs for a delegated-only fixture with 2 distinct IDs | 2 | 0 |
| Monitor-only metric series in the mixed-token fixture | 9 | 9, identical values/labels |

Measured locally with stubbed SDK adapter reads and real token/metric logic. The regression fails against original production source with six total synthetic reads (one initial full cycle plus five delegated cycles), versus one after this change. All collateral, inventory and explorer reads continue every cycle, and later balance changes update deficit/inventory values.

The general saving is one supply read per delegated non-collateralized token per cycle. An all-delegated fleet's empty ID set also bypasses price prefetch; mixed-fleet CoinGecko request savings depend on batching and overlapping IDs. Production latency, fleet composition and external request totals are unmeasured.

## Validation

- `pnpm -C typescript/warp-monitor test`: 42 passing.
- Dependency build: 18 successful tasks; package TypeScript build, package Oxlint, Oxfmt, `git diff --check` and commit hooks passed.
- Reproduce focused evidence: `pnpm -C typescript/warp-monitor exec mocha --config .mocharc.json src/monitor-efficiency.test.ts --exit`.
- Self-reviewed the shared-metric consumers, projected-deficit condition, both monitor callers and per-route metric replacement/failure handling.

Environment caveat: a fresh frozen install fails test imports because `@provablehq/sdk@0.11.3` references a missing `core-js@3.50.0/proposals/json-parse-with-source.js`. Local tests used a node_modules-only compatibility shim loading the existing `esnext.json.is-raw-json`, `esnext.json.parse` and `esnext.json.raw-json` modules. No manifest or lockfile changes. Node 24.13.0 / pnpm 12.3.0. No deployment or live-RPC benchmark.


---

Superseded by consolidated draft #9504: [perf(metrics): reduce warp monitoring reads and log volume](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9504). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
