### PR TITLE
perf(rebalancer): coalesce concurrent token price lookups

### DIFF
--- a/.changeset/tidy-prices-share.md
+++ b/.changeset/tidy-prices-share.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Coalesced concurrent CoinGecko lookups for the same token ID, reducing duplicate metrics price requests while preserving cache expiry and retries after failures.

--- a/typescript/rebalancer/src/metrics/PriceGetter.test.ts
+++ b/typescript/rebalancer/src/metrics/PriceGetter.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import Sinon from 'sinon';
+
+import { CoinGeckoTokenPriceGetter } from '@hyperlane-xyz/sdk';
+
+import { PriceGetter } from './PriceGetter.js';
+
+const logger = pino({ level: 'silent' });
+const response = (price = 1) =>
+  new Response(
+    JSON.stringify({
+      'usd-coin': { usd: price },
+      tether: { usd: price },
+    }),
+  );
+
+describe('PriceGetter concurrent lookups', () => {
+  afterEach(() => Sinon.restore());
+
+  it('reduces twelve concurrent same-ID HTTP requests to one', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const baseline = new CoinGeckoTokenPriceGetter({
+      chainMetadata: {},
+      sleepMsBetweenRequests: 0,
+    });
+    const before = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        baseline.getTokenPriceByIds(['usd-coin']),
+      ),
+    );
+    expect(fetch.callCount).to.equal(12);
+    fetch.resetHistory();
+
+    const getter = PriceGetter.create({}, logger, undefined, undefined, 0);
+    const after = await Promise.all(
+      Array.from({ length: 12 }, () => getter.getCoingeckoPrice('usd-coin')),
+    );
+    expect(fetch.callCount).to.equal(1);
+    expect(after).to.deep.equal(before.map((prices) => prices?.[0]));
+  });
+
+  it('looks up distinct IDs independently', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const getter = PriceGetter.create({}, logger, undefined, undefined, 0);
+    expect(
+      await Promise.all([
+        getter.getCoingeckoPrice('usd-coin'),
+        getter.getCoingeckoPrice('tether'),
+        getter.getCoingeckoPrice('usd-coin'),
+        getter.getCoingeckoPrice('tether'),
+      ]),
+    ).to.deep.equal([1, 1, 1, 1]);
+    expect(fetch.callCount).to.equal(2);
+  });
+
+  it('keeps the SDK cache behavior after a successful lookup', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch').callsFake(async () =>
+      response(),
+    );
+    const getter = PriceGetter.create({}, logger, undefined, 60, 0);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(fetch.callCount).to.equal(1);
+  });
+
+  it('does not retain settled results beyond the SDK cache lifetime', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch');
+    fetch.onFirstCall().resolves(response(1));
+    fetch.onSecondCall().resolves(response(2));
+    const getter = PriceGetter.create({}, logger, undefined, 0, 0);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(2);
+    expect(fetch.callCount).to.equal(2);
+  });
+
+  it('retries after an unavailable price instead of retaining undefined', async () => {
+    const fetch = Sinon.stub(globalThis, 'fetch');
+    fetch.onFirstCall().resolves(new Response('{}'));
+    fetch.onSecondCall().resolves(response());
+    const getter = PriceGetter.create({}, logger, undefined, undefined, 0);
+    expect(
+      await Promise.all([
+        getter.getCoingeckoPrice('usd-coin'),
+        getter.getCoingeckoPrice('usd-coin'),
+      ]),
+    ).to.deep.equal([undefined, undefined]);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(1);
+    expect(fetch.callCount).to.equal(2);
+  });
+
+  it('propagates rejected lookups to all callers and allows a retry', async () => {
+    const getter = PriceGetter.create({}, logger);
+    const lookup = Sinon.stub(getter, 'getTokenPriceByIds');
+    const error = new Error('price lookup rejected');
+    lookup.onFirstCall().rejects(error);
+    lookup.onSecondCall().resolves([2]);
+    const results = await Promise.allSettled([
+      getter.getCoingeckoPrice('usd-coin'),
+      getter.getCoingeckoPrice('usd-coin'),
+    ]);
+    expect(results).to.deep.equal([
+      { status: 'rejected', reason: error },
+      { status: 'rejected', reason: error },
+    ]);
+    expect(await getter.getCoingeckoPrice('usd-coin')).to.equal(2);
+    expect(lookup.callCount).to.equal(2);
+  });
+});

--- a/typescript/rebalancer/src/metrics/PriceGetter.ts
+++ b/typescript/rebalancer/src/metrics/PriceGetter.ts
@@ -9,6 +9,10 @@ import {
 
 export class PriceGetter extends CoinGeckoTokenPriceGetter {
   private readonly logger: Logger;
+  private readonly pendingPrices = new Map<
+    string,
+    Promise<number | undefined>
+  >();
 
   private constructor({
     chainMetadata,
@@ -67,8 +71,19 @@ export class PriceGetter extends CoinGeckoTokenPriceGetter {
   }
 
   async getCoingeckoPrice(coingeckoId: string): Promise<number | undefined> {
-    const prices = await this.getTokenPriceByIds([coingeckoId]);
-    if (!prices) return undefined;
-    return prices[0];
+    const pending = this.pendingPrices.get(coingeckoId);
+    if (pending) return pending;
+
+    // Multiple route tokens can share an ID. Share only the active lookup;
+    // the SDK remains responsible for cache freshness and failed-price handling.
+    const request = this.getTokenPriceByIds([coingeckoId]).then(
+      (prices) => prices?.[0],
+    );
+    this.pendingPrices.set(coingeckoId, request);
+    try {
+      return await request;
+    } finally {
+      this.pendingPrices.delete(coingeckoId);
+    }
   }
 }


### PR DESCRIPTION
## Problem

Rebalancer metrics fetch prices concurrently for each route token. When multiple chains use the same CoinGecko ID and its cache is cold/expired, the SDK checks cache freshness before its request delay, so all callers issue a separate HTTP request. A 12-reader same-ID fixture makes 12 requests for one price.

## Solution

Share active lookups by CoinGecko ID in the rebalancer's metrics PriceGetter. Clear each entry on success, unavailable price, or rejection so the SDK continues to control cache expiry and retry behavior. Different IDs remain independent. This changes metrics reads only; route quotes and transaction execution are unaffected. Included a patch changeset.

## Performance evidence

The regression test uses the actual SDK with mocked HTTP, running 12 concurrent cold-cache readers through the previous delegation pattern and the updated getter:

| Fixture | Before | After | Reduction |
| --- | --- | --- | --- |
| 12 readers, one CoinGecko ID | 12 HTTP calls | 1 HTTP call | 91.7% |
| 4 readers, two IDs | 4 HTTP calls (modeled) | 2 HTTP calls (measured) | 50% |

Returned same-ID prices match the baseline. Tests disable the SDK request delay for speed; its default 5-second delay is unchanged. These are fixture request counts, not measured production quota savings or cycle latency improvements.

## Validation

- Dependency build: 19 packages succeeded; rebalancer build passed.
- Full rebalancer suite: 386 passing.
- Six focused tests passed: HTTP call counts, independent IDs, fresh cache, expiry, unavailable-price retry, rejection propagation/retry.
- Package lint passed with three existing warnings in untouched tests.
- Differential self-review covered every changed file and the Metrics/orchestrator consumers.

Runtime-test limitation: the frozen baseline cannot load because @provablehq/sdk imports a missing core-js 3.50.0 proposal file. Local runtime tests used the existing hm2 compatibility shim copied into ignored node_modules; no dependency/source workaround is committed. Build passed without the shim. No live execution or deployment performed.


---

Superseded by consolidated draft #9507: [perf(rebalancer): eliminate duplicate reads and unused initialization](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9507). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
