### PR TITLE
perf(scraper-proxy): reuse cache key document metadata

### DIFF
--- a/typescript/scraper-proxy/benchmarks/README.md
+++ b/typescript/scraper-proxy/benchmarks/README.md
@@ -1,0 +1,36 @@
+# Cached GraphQL request benchmark
+
+`src/scripts/benchmark-cache-plugin.ts` exercises request normalization and Apollo execution with the production validation rule. Queries use one root field, no aliases and 50 or 250 total fields; both sizes are within production limits. Each variant warms 100 requests and times 1,000 cache hits, three times. Every result is checked and the resolver must execute exactly once per server.
+
+This is synthetic cached-request processing on Node 24.13.0, without HTTP transport, a database, realistic result sizes or concurrent clients. It does not measure deployed request latency or service capacity.
+
+## Reproduce
+
+After a frozen workspace install and building scraper-proxy dependencies, run from this package directory:
+
+```sh
+pnpm exec tsx src/scripts/benchmark-cache-plugin.ts
+```
+
+To compare the implementation before this change, temporarily place its module alongside its relative imports:
+
+```sh
+git show 58e16ce8:typescript/scraper-proxy/src/scraperdb/cache-plugin.ts > src/scraperdb/cache-plugin.benchmark-baseline.ts
+pnpm exec tsx src/scripts/benchmark-cache-plugin.ts src/scraperdb/cache-plugin.benchmark-baseline.ts
+rm src/scraperdb/cache-plugin.benchmark-baseline.ts
+```
+
+The optional argument loads a trusted local benchmark module. No production service imports this script.
+
+## Local measurements, 2026-09-05
+
+Elapsed milliseconds per 1,000 requests, including identical response assertions:
+
+| Total fields | Baseline runs          | Current runs           | Median reduction |
+| ------------ | ---------------------- | ---------------------- | ---------------- |
+| 50           | 205.30, 201.63, 200.37 | 79.05, 77.19, 74.89    | 61.7%            |
+| 250          | 816.16, 802.76, 813.01 | 298.48, 301.19, 300.61 | 63.0%            |
+
+The deterministic change is two cache-key reparses and two prints per reused document/request becoming zero after the first document preparation. Request normalization still parses/prints each request; variables still sort/serialize and hash on every request. Result-cache TTL, refresh and size limits remain unchanged.
+
+The WeakMap adds a normalized query string and used-variable set per reachable cached document. Entries become collectible with their documents, instead of retaining every query ever seen. Production document-cache eviction and result-cache hit rate determine the benefit; neither was measured here.

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.test.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.test.ts
@@ -228,3 +228,48 @@ async function cachedValue(server: ApolloServer, key: number): Promise<void> {
     variables: { key },
   });
 }
+
+void it('keeps variables and refresh dynamic when reusing a parsed document', async () => {
+  let calls = 0;
+  const server = cacheServer(() => ++calls, 'Int!');
+  await server.start();
+  try {
+    const query =
+      'query($key: Int!, $ttl: Int!, $refresh: Boolean!) @cached(ttl: $ttl, refresh: $refresh) { value(key: $key) }';
+    const request = (key: number, ttl = 10, refresh = false) =>
+      server.executeOperation({
+        query,
+        variables: { key, ttl, refresh },
+      });
+    assert.equal(value(await request(1)), 1);
+    assert.equal(value(await request(2)), 2);
+    assert.equal(value(await request(1, 20)), 1);
+    assert.equal(value(await request(1, 20, true)), 3);
+    assert.equal(value(await request(1)), 3);
+    assert.equal(value(await request(2)), 2);
+    assert.equal(calls, 3);
+  } finally {
+    await server.stop();
+  }
+});
+
+void it('separates named operations in the same reusable document', async () => {
+  let calls = 0;
+  const server = cacheServer(() => ++calls, 'Int!');
+  await server.start();
+  try {
+    const query = `
+      query First($key: Int!) @cached(ttl: 10) { value(key: $key) }
+      query Second($key: Int!) @cached(ttl: 10) { value(key: $key) }
+    `;
+    const request = (operationName: string) =>
+      server.executeOperation({ query, operationName, variables: { key: 1 } });
+    assert.equal(value(await request('First')), 1);
+    assert.equal(value(await request('Second')), 2);
+    assert.equal(value(await request('First')), 1);
+    assert.equal(value(await request('Second')), 2);
+    assert.equal(calls, 2);
+  } finally {
+    await server.stop();
+  }
+});

--- a/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scraperdb/cache-plugin.ts
@@ -18,9 +18,13 @@ const MAX_ENTRIES = 1_000;
 const MAX_ENTRY_BYTES = 1_000_000;
 const MAX_TOTAL_BYTES = 16_000_000;
 type Entry = { body: string; bytes: number; expires: number };
+type CacheDocument = { query: string; usedVariables: ReadonlySet<string> };
 
 export function scraperDbCachePlugin(): ApolloServerPlugin {
   const cache = new Map<string, Entry>();
+  // Apollo reuses parsed documents. Weak keys retain metadata only while the
+  // document is reachable, independently of response TTL and cache eviction.
+  const documents = new WeakMap<DocumentNode, CacheDocument>();
   let cacheBytes = 0;
   const remove = (key: string): void => {
     const entry = cache.get(key);
@@ -40,9 +44,14 @@ export function scraperDbCachePlugin(): ApolloServerPlugin {
             context.request.variables,
           );
           if (!directive) return null;
+          let document = documents.get(context.document);
+          if (!document) {
+            document = prepareCacheDocument(context.document);
+            documents.set(context.document, document);
+          }
           key = cacheKey(
             context.operationName,
-            context.document,
+            document,
             context.request.variables ?? {},
           );
           if (directive.refresh) {
@@ -98,11 +107,7 @@ export function scraperDbCachePlugin(): ApolloServerPlugin {
   };
 }
 
-function cacheKey(
-  operation: string | null,
-  document: DocumentNode,
-  variables: Record<string, unknown>,
-): string {
+function prepareCacheDocument(document: DocumentNode): CacheDocument {
   const query = stripUnusedVariableDefinitions(
     print(
       visit(document, {
@@ -116,6 +121,14 @@ function cacheKey(
       usedVariables.add(name.value);
     },
   });
+  return { query, usedVariables };
+}
+
+function cacheKey(
+  operation: string | null,
+  { query, usedVariables }: CacheDocument,
+  variables: Record<string, unknown>,
+): string {
   const dataVariables = Object.fromEntries(
     Object.entries(variables).filter(([name]) => usedVariables.has(name)),
   );

--- a/typescript/scraper-proxy/src/scripts/benchmark-cache-plugin.ts
+++ b/typescript/scraper-proxy/src/scripts/benchmark-cache-plugin.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { performance } from 'node:perf_hooks';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { ApolloServer, type ApolloServerPlugin } from '@apollo/server';
+import { ApolloServerPluginCacheControl } from '@apollo/server/plugin/cacheControl';
+
+import { scraperDbCachePlugin } from '../scraperdb/cache-plugin.js';
+import { normalizeGraphqlRequestBody } from '../scraperdb/request-compatibility.js';
+import { scraperProxyValidationRule } from '../scraperdb/validation.js';
+
+const variants: Array<{ name: string; plugin: () => ApolloServerPlugin }> = [];
+if (process.argv[2]) {
+  const baseline: typeof import('../scraperdb/cache-plugin.js') = await import(
+    pathToFileURL(resolve(process.argv[2])).href
+  );
+  variants.push({ name: 'baseline', plugin: baseline.scraperDbCachePlugin });
+}
+variants.push({ name: 'current', plugin: scraperDbCachePlugin });
+
+// Synthetic queries at two sizes within the production field/root/alias limits.
+// Includes request normalization and Apollo execution, excluding HTTP and DB IO.
+for (const fields of [50, 250]) {
+  const names = Array.from({ length: fields - 1 }, (_, i) => `f${i}`);
+  const payload = Object.fromEntries(names.map((name) => [name, 1]));
+  const expectedData = JSON.stringify({ value: payload });
+  const query = `query($key: Int!) @cached(ttl: 300) { value(key: $key) { ${names.join(' ')} } }`;
+  for (let run = 0; run < 3; run++) {
+    for (const { name, plugin } of variants) {
+      let calls = 0;
+      const server = new ApolloServer({
+        plugins: [
+          ApolloServerPluginCacheControl({ calculateHttpHeaders: false }),
+          plugin(),
+        ],
+        validationRules: [scraperProxyValidationRule],
+        typeDefs: `directive @cached(ttl: Int, refresh: Boolean) on QUERY
+          type Query { value(key: Int!): Value! }
+          type Value { ${names.map((field) => `${field}: Int!`).join(' ')} }`,
+        resolvers: {
+          Query: {
+            value: () => {
+              calls++;
+              return payload;
+            },
+          },
+        },
+      });
+      await server.start();
+      try {
+        const execute = async () => {
+          const request = { query, variables: { key: 1 } };
+          normalizeGraphqlRequestBody(request);
+          const response = await server.executeOperation(request);
+          assert(response.body.kind === 'single');
+          assert.equal(response.body.singleResult.errors, undefined);
+          assert.equal(
+            JSON.stringify(response.body.singleResult.data),
+            expectedData,
+          );
+        };
+        for (let i = 0; i < 100; i++) await execute();
+        const start = performance.now();
+        for (let i = 0; i < 1_000; i++) await execute();
+        console.log(
+          JSON.stringify({
+            name,
+            fields,
+            run,
+            requests: 1_000,
+            elapsedMs: performance.now() - start,
+          }),
+        );
+        assert.equal(calls, 1);
+      } finally {
+        await server.stop();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Cached GraphQL requests rebuild the same normalized cache-key query and used-variable set for every request: two reparses, two prints and repeated AST traversal, even when Apollo reuses the parsed document and the response is already cached.

## Solution

Prepare that metadata once per DocumentNode in a plugin-local WeakMap. Keep hashing the current operation name and sorted variable values each request, and evaluate TTL/refresh dynamically. Metadata becomes collectible with Apollo's document; response-cache expiry, error refusal, LRU and byte limits remain unchanged. This does not touch WebSocket delivery, heartbeat cleanup or durable cursors.

## Performance evidence

Synthetic Node 24.13.0 benchmark includes the existing request-normalization middleware function, Apollo execution and production validation rules; one root, no aliases, 50 or 250 total fields. Each variant has 100 warm-ups then 1,000 cached requests, repeated three times, with identical response assertions and exactly one resolver call per server.

| Query size | Baseline median / 1,000 requests | Current median | Reduction |
| --- | ---: | ---: | ---: |
| 50 fields | 201.63 ms | 77.19 ms | 61.7% |
| 250 fields | 813.01 ms | 300.61 ms | 63.0% |

For a reused document, cache-key reparses/prints fall from 2 each per request to 0 after initial preparation. Request normalization, variable serialization and hashing still run. These are local synthetic processing timings, excluding HTTP transport, database work, realistic result sizes and concurrent traffic; production latency/capacity remain unmeasured. Extra memory is one normalized query string and variable-name set per reachable document.

Reproduction: `typescript/scraper-proxy/src/scripts/benchmark-cache-plugin.ts`; exact baseline `58e16ce875e3e312ab7344810bb159a5540f253b`. Commands, raw measurements and limits: `typescript/scraper-proxy/benchmarks/README.md`.

## Validation

- Full scraper-proxy suite: 67/67 passed, including dynamic variables/TTL/refresh, operation partition, expiry, errors, count/byte eviction and oversized responses.
- Dependency build, service build, lint, format and bundle passed; normal commit hooks passed.
- Self-review and independent review found no blocking issue. Existing cache-key normalization is unchanged; only document-invariant preparation is reused.
- Package is private; no changeset. No merge or deployment.


---

Superseded by consolidated draft #9512: [perf(scraper-proxy): reuse query normalization and cache metadata](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9512). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
