### PR TITLE
perf(scraper): reduce enrichment and sequence lookup work

### DIFF
--- a/rust/main/agents/scraper/src/db/block.rs
+++ b/rust/main/agents/scraper/src/db/block.rs
@@ -1,8 +1,12 @@
 use eyre::{Context, Result};
+use itertools::Itertools;
 use migration::OnConflict;
 use sea_orm::{
-    prelude::*, ActiveValue::*, DbErr, EntityTrait, FromQueryResult, Insert, QueryResult,
-    QuerySelect,
+    prelude::*,
+    sea_query::{Query, SelectStatement},
+    ActiveValue::*,
+    ConnectionTrait, DbErr, EntityTrait, FromQueryResult, Insert, QueryResult, QuerySelect,
+    QueryTrait,
 };
 use tracing::{debug, trace};
 
@@ -11,7 +15,7 @@ use hyperlane_core::{h256_to_bytes, BlockInfo, H256};
 use crate::date_time;
 use crate::db::ScraperDb;
 
-use super::generated::block;
+use super::generated::{block, transaction};
 
 /// A stripped down block model. This is so we can get just the information
 /// needed if the block is present in the Db already to inject into other
@@ -33,23 +37,21 @@ impl FromQueryResult for BasicBlock {
 }
 
 impl ScraperDb {
-    /// Retrieves the block number for a given block database ID
-    pub async fn retrieve_block_number(&self, block_id: i64) -> Result<Option<u64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Height,
-        }
-        let block_height = block::Entity::find()
-            .filter(block::Column::Id.eq(block_id))
+    /// Resolve a query selecting one event transaction id to its block height in
+    /// one database round trip. NULL/missing relations produce no height.
+    pub(super) async fn retrieve_block_number_by_tx_query(
+        &self,
+        tx_id_query: SelectStatement,
+    ) -> Result<Option<u64>> {
+        let height = transaction::Entity::find()
+            .filter(transaction::Column::Id.in_subquery(tx_id_query))
+            .inner_join(block::Entity)
             .select_only()
-            .column_as(block::Column::Height, QueryAs::Height)
-            .into_values::<i64, QueryAs>()
+            .column(block::Column::Height)
+            .into_tuple::<i64>()
             .one(&self.0)
             .await?;
-        match block_height {
-            Some(height) => Ok(Some(height.try_into()?)),
-            None => Ok(None),
-        }
+        height.map(u64::try_from).transpose().map_err(Into::into)
     }
 
     /// Get basic block data that can be used to insert a transaction or
@@ -59,28 +61,35 @@ impl ScraperDb {
         &self,
         hashes: impl Iterator<Item = &H256>,
     ) -> Result<Vec<BasicBlock>> {
-        // check database to see which blocks we already know and fetch their IDs
-        let blocks = block::Entity::find()
-            .filter(block::Column::Hash.is_in(hashes.map(h256_to_bytes)))
-            .select_only()
-            // these must align with the custom impl of FromQueryResult
-            .column_as(block::Column::Id, "id")
-            .column_as(block::Column::Hash, "hash")
-            .into_model::<BasicBlock>()
-            .all(&self.0)
-            .await
-            .context("When querying blocks")?;
+        let hashes = hashes.unique().collect_vec();
+        let mut blocks = Vec::new();
+        for hashes in hashes.chunks(Self::HASH_LOOKUP_CHUNK_SIZE) {
+            blocks.extend(
+                block::Entity::find()
+                    .filter(
+                        block::Column::Hash.is_in(hashes.iter().map(|hash| h256_to_bytes(hash))),
+                    )
+                    .select_only()
+                    // These must align with the custom impl of FromQueryResult.
+                    .column_as(block::Column::Id, "id")
+                    .column_as(block::Column::Hash, "hash")
+                    .into_model::<BasicBlock>()
+                    .all(&self.0)
+                    .await
+                    .context("When querying blocks")?,
+            );
+        }
 
         trace!(blocks = blocks.len(), "Queried block info for hashes");
         Ok(blocks)
     }
 
-    /// Store a new block (or update an existing one)
+    /// Store blocks and return the IDs/hashes of inserted rows. Conflicts are omitted.
     pub async fn store_blocks(
         &self,
         domain: u32,
         blocks: impl Iterator<Item = BlockInfo>,
-    ) -> Result<()> {
+    ) -> Result<Vec<BasicBlock>> {
         let models = blocks
             .map(|info| block::ActiveModel {
                 id: NotSet,
@@ -92,18 +101,22 @@ impl ScraperDb {
             })
             .collect::<Vec<_>>();
 
-        debug_assert!(!models.is_empty());
+        if models.is_empty() {
+            return Ok(Vec::new());
+        }
         debug!(blocks = models.len(), "Writing blocks to database");
         trace!(?models, "Writing blocks to database");
-        match Insert::many(models)
+        let mut query = Insert::many(models)
             .on_conflict(OnConflict::new().do_nothing().to_owned())
-            .exec(&self.0)
+            .into_query();
+        query.returning(Query::returning().columns([block::Column::Id, block::Column::Hash]));
+        self.0
+            .query_all(self.0.get_database_backend().build(&query))
             .await
-        {
-            Ok(_) => Ok(()),
-            Err(DbErr::RecordNotInserted) => Ok(()),
-            Err(e) => Err(e).context("When inserting blocks"),
-        }
+            .context("When inserting blocks")?
+            .iter()
+            .map(|row| BasicBlock::from_query_result(row, "").map_err(Into::into))
+            .collect()
     }
 }
 

--- a/rust/main/agents/scraper/src/db/block/tests.rs
+++ b/rust/main/agents/scraper/src/db/block/tests.rs
@@ -158,3 +158,47 @@ async fn test_store_blocks_real_postgres() -> Result<(), DbErr> {
 
     Ok(())
 }
+
+/// Resolved sequence lookups execute exactly one statement each. Invalid SQL
+/// heights and database failures must remain errors rather than missing data.
+#[tokio::test]
+async fn sequence_block_lookups_use_one_query_and_propagate_errors() {
+    use sea_orm::{DatabaseBackend, MockDatabase, RuntimeErr, Value};
+    use std::collections::BTreeMap;
+
+    let rows = [0_i64, 42, i64::MAX, -1]
+        .map(|height| [BTreeMap::from([("height", Value::BigInt(Some(height)))])]);
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(rows)
+        .append_query_errors([DbErr::Query(RuntimeErr::Internal("unavailable".to_owned()))])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    let address = H256::from_low_u64_be(1);
+    assert_eq!(
+        db.retrieve_dispatched_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        db.retrieve_delivered_message_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(42)
+    );
+    assert_eq!(
+        db.retrieve_payment_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(u64::try_from(i64::MAX).unwrap())
+    );
+    assert!(db
+        .retrieve_dispatched_block_number(1, &address, 7)
+        .await
+        .is_err());
+    assert!(db
+        .retrieve_payment_block_number(1, &address, 7)
+        .await
+        .is_err());
+    assert_eq!(db.0.into_transaction_log().len(), 5);
+}

--- a/rust/main/agents/scraper/src/db/dispatch_transactions.rs
+++ b/rust/main/agents/scraper/src/db/dispatch_transactions.rs
@@ -1,0 +1,185 @@
+//! Single-statement atomicity and multi-chunk transaction boundaries.
+use std::collections::BTreeMap;
+
+use hyperlane_core::{HyperlaneMessage, LogMeta, H256};
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, MockExecResult, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::{ScraperDb, StorableMessage, StorableRawMessageDispatch};
+
+fn messages(count: u32) -> Vec<HyperlaneMessage> {
+    (0..count)
+        .map(|nonce| HyperlaneMessage {
+            version: 3,
+            nonce,
+            origin: 1,
+            destination: 1,
+            body: vec![1],
+            ..Default::default()
+        })
+        .collect()
+}
+
+async fn store(db: &ScraperDb, raw: bool, messages: &[HyperlaneMessage]) -> eyre::Result<u64> {
+    let meta = LogMeta::default();
+    if raw {
+        db.store_raw_message_dispatches(
+            1,
+            &H256::zero(),
+            messages
+                .iter()
+                .map(|msg| StorableRawMessageDispatch { msg, meta: &meta }),
+        )
+        .await
+    } else {
+        db.store_dispatched_messages(
+            1,
+            &H256::zero(),
+            messages.iter().cloned().map(|msg| StorableMessage {
+                msg,
+                meta: &meta,
+                txn_id: None,
+                id_override: None,
+            }),
+        )
+        .await
+    }
+}
+
+#[tokio::test]
+async fn dispatch_statement_counts_preserve_multi_chunk_transactions() {
+    for raw in [false, true] {
+        let bound = if raw { 2_954 } else { 3_250 };
+        for count in [0, 1, bound, bound + 1] {
+            let chunks = if count <= bound { 1 } else { 2 };
+            let row = |name: &str, value: i64| {
+                vec![BTreeMap::from([(
+                    name.to_owned(),
+                    Value::BigInt(Some(value)),
+                )])]
+            };
+            let db = if raw {
+                let mut results = vec![row("max_id", 0)];
+                results.extend((0..chunks).map(|_| row("id", 1)));
+                results.push(row("num_items", i64::from(count)));
+                ScraperDb::with_connection(
+                    MockDatabase::new(DatabaseBackend::Postgres)
+                        .append_query_results(results)
+                        .into_connection(),
+                )
+            } else {
+                // The enriched path inserts inside an explicit transaction and
+                // counts affected rows, so it consumes execution results
+                // rather than MAX/INSERT/COUNT query results.
+                let chunk_lens = (0..chunks).map(|i| {
+                    if i == 0 {
+                        count.min(bound)
+                    } else {
+                        count - bound
+                    }
+                });
+                ScraperDb::with_connection(
+                    MockDatabase::new(DatabaseBackend::Postgres)
+                        .append_exec_results(chunk_lens.map(|len| MockExecResult {
+                            last_insert_id: 0,
+                            rows_affected: u64::from(len),
+                        }))
+                        .into_connection(),
+                )
+            };
+            assert_eq!(
+                store(&db, raw, &messages(count)).await.unwrap(),
+                u64::from(count)
+            );
+            let log = db.0.into_transaction_log();
+            let sql: Vec<_> = log
+                .iter()
+                .flat_map(|transaction| transaction.statements())
+                .map(|statement| statement.sql.as_str())
+                .collect();
+            if count == 0 {
+                assert!(sql.is_empty());
+            } else if raw {
+                if count <= bound {
+                    assert_eq!(sql.len(), 3);
+                    assert!(sql[0].starts_with("SELECT MAX("));
+                    assert!(sql[1].starts_with("INSERT"));
+                    assert!(sql[2].starts_with("SELECT COUNT("));
+                } else {
+                    assert_eq!(sql.len(), 6);
+                    assert_eq!(sql[1], "BEGIN");
+                    assert!(sql[2].starts_with("INSERT"));
+                    assert!(sql[3].starts_with("INSERT"));
+                    assert_eq!(sql[4], "COMMIT");
+                }
+            } else if count <= bound {
+                assert_eq!(sql.len(), 3);
+                assert!(sql[1].starts_with("INSERT"));
+                assert_eq!(sql[2], "COMMIT");
+            } else {
+                assert_eq!(sql.len(), 2 + chunks);
+                assert_eq!(sql[0], "BEGIN");
+                assert!(sql[1..=chunks].iter().all(|s| s.starts_with("INSERT")));
+                assert_eq!(sql[chunks + 1], "COMMIT");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn dispatch_writes_preserve_atomicity_and_replay_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    for raw in [false, true] {
+        let (table, bound) = if raw {
+            ("raw_message_dispatch", 2_954)
+        } else {
+            ("message", 3_250)
+        };
+        for count in [2, bound + 1] {
+            db.0.execute_unprepared(&format!("TRUNCATE {table}"))
+                .await?;
+            let rows = messages(count);
+            assert_eq!(store(&db, raw, &rows[..1]).await?, 1);
+            // Keep an existing conflict row to prove failed batches roll back updates too.
+            db.0.execute_unprepared(&format!(
+                "UPDATE {table} SET msg_body = decode('09', 'hex')"
+            ))
+            .await?;
+            // A repeated conflict key must still reject the entire one-statement batch.
+            assert!(store(&db, raw, &[rows[0].clone(), rows[0].clone()])
+                .await
+                .is_err());
+            db.0.execute_unprepared(&format!(
+                "ALTER TABLE {table} ADD CONSTRAINT reject_dispatch_tail CHECK (nonce <> {})",
+                count - 1
+            ))
+            .await?;
+            assert!(store(&db, raw, &rows).await.is_err());
+            let stored = db.0.query_one(sea_orm::Statement::from_string(DatabaseBackend::Postgres, format!("SELECT COUNT(*) AS row_count, MIN(encode(msg_body, 'hex')) AS body FROM {table}"))).await?.unwrap();
+            assert_eq!(stored.try_get::<i64>("", "row_count")?, 1);
+            assert_eq!(stored.try_get::<String>("", "body")?, "09");
+            db.0.execute_unprepared(&format!(
+                "ALTER TABLE {table} DROP CONSTRAINT reject_dispatch_tail"
+            ))
+            .await?;
+            assert_eq!(store(&db, raw, &rows).await?, u64::from(count - 1));
+            assert_eq!(store(&db, raw, &rows).await?, 0);
+            let stored = db.0.query_one(sea_orm::Statement::from_string(DatabaseBackend::Postgres, format!("SELECT COUNT(*) AS row_count, COUNT(*) FILTER (WHERE msg_body = decode('01', 'hex')) AS expected_bodies FROM {table}"))).await?.unwrap();
+            assert_eq!(stored.try_get::<i64>("", "row_count")?, i64::from(count));
+            assert_eq!(
+                stored.try_get::<i64>("", "expected_bodies")?,
+                i64::from(count)
+            );
+        }
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/lookup_batches.rs
+++ b/rust/main/agents/scraper/src/db/lookup_batches.rs
@@ -1,0 +1,95 @@
+//! Hash lookup bounds, deduplication and error propagation.
+use std::collections::BTreeMap;
+
+use hyperlane_core::{h256_to_bytes, h512_to_bytes, H256, H512};
+use sea_orm::{DatabaseBackend, DbErr, MockDatabase, Value};
+
+use super::ScraperDb;
+
+fn row(id: usize, hash: Vec<u8>) -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        ("id".to_owned(), Value::BigInt(Some(id as i64))),
+        ("hash".to_owned(), Value::Bytes(Some(Box::new(hash)))),
+    ])
+}
+
+#[tokio::test]
+async fn hash_lookups_bound_large_inputs_and_deduplicate_across_chunks() {
+    let blocks: Vec<_> = (0..66_000).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..66_000).map(H512::from_low_u64_be).collect();
+    let mut responses = Vec::new();
+    for chunk in blocks.chunks(ScraperDb::HASH_LOOKUP_CHUNK_SIZE) {
+        responses.push(vec![row(responses.len(), h256_to_bytes(&chunk[0]))]);
+    }
+    for chunk in txns.chunks(ScraperDb::HASH_LOOKUP_CHUNK_SIZE) {
+        responses.push(vec![row(responses.len(), h512_to_bytes(&chunk[0]))]);
+    }
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(responses)
+            .into_connection(),
+    );
+    let found_blocks = db
+        .get_block_basic(blocks.iter().chain(blocks[..1].iter()))
+        .await
+        .unwrap();
+    let found_txns = db
+        .get_txn_ids(txns.iter().chain(txns[..1].iter()))
+        .await
+        .unwrap();
+    assert_eq!(found_blocks.len(), 2);
+    assert_eq!(found_txns.len(), 2);
+    for index in 0..2 {
+        assert_eq!(found_blocks[index].hash, blocks[index * 65_000]);
+        assert_eq!(found_blocks[index].id, index as i64);
+        assert_eq!(found_txns[&txns[index * 65_000]], (index + 2) as i64);
+    }
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 4);
+    for (index, query) in log.iter().enumerate() {
+        let statement = &query.statements()[0];
+        let values = &statement.values.as_ref().unwrap().0;
+        assert_eq!(values.len(), if index % 2 == 1 { 1_000 } else { 65_000 });
+    }
+}
+
+#[tokio::test]
+async fn empty_hash_lookups_skip_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert!(db
+        .get_block_basic(std::iter::empty())
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(db.get_txn_ids(std::iter::empty()).await.unwrap().is_empty());
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn hash_lookups_propagate_failed_tail_without_partial_results() {
+    let blocks: Vec<_> = (0..65_001).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..65_001).map(H512::from_low_u64_be).collect();
+    for is_block in [true, false] {
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![row(
+                    1,
+                    if is_block {
+                        h256_to_bytes(&blocks[0])
+                    } else {
+                        h512_to_bytes(&txns[0])
+                    },
+                )]])
+                .append_query_errors([DbErr::Custom("lookup tail failed".to_owned())])
+                .into_connection(),
+        );
+        let error = if is_block {
+            db.get_block_basic(blocks.iter()).await.unwrap_err()
+        } else {
+            db.get_txn_ids(txns.iter()).await.unwrap_err()
+        };
+        assert!(format!("{error:#}").contains("lookup tail failed"));
+        assert_eq!(db.0.into_transaction_log().len(), 2);
+    }
+}

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use eyre::{ensure, Result};
 use migration::OnConflict;
 use sea_orm::{
-    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, TransactionTrait,
+    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, QuerySelect,
+    TransactionTrait,
 };
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, MerkleTreeInsertion, H256};
@@ -82,19 +83,26 @@ impl ScraperDb {
         leaf_index: u32,
     ) -> Result<Option<(MerkleTreeInsertion, u64)>> {
         let row = merkle_tree_insertion::Entity::find()
+            .select_only()
+            .columns([
+                merkle_tree_insertion::Column::LeafIndex,
+                merkle_tree_insertion::Column::MessageId,
+                merkle_tree_insertion::Column::BlockNumber,
+            ])
             .filter(merkle_tree_insertion::Column::Domain.eq(domain))
             .filter(
                 merkle_tree_insertion::Column::MerkleTreeHook
                     .eq(address_to_bytes(merkle_tree_hook)),
             )
             .filter(merkle_tree_insertion::Column::LeafIndex.eq(leaf_index))
+            .into_tuple::<(i32, Vec<u8>, i64)>()
             .one(&self.0)
             .await?;
 
-        Ok(row.map(|row| {
+        Ok(row.map(|(leaf_index, message_id, block_number)| {
             (
-                MerkleTreeInsertion::new(row.leaf_index as u32, H256::from_slice(&row.message_id)),
-                row.block_number as u64,
+                MerkleTreeInsertion::new(leaf_index as u32, H256::from_slice(&message_id)),
+                block_number as u64,
             )
         }))
     }

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
@@ -1,6 +1,10 @@
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use migration::OnConflict;
-use sea_orm::{ActiveValue::*, ColumnTrait, EntityTrait, Insert, QueryFilter};
+use sea_orm::{
+    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, TransactionTrait,
+};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, MerkleTreeInsertion, H256};
 
@@ -11,6 +15,10 @@ pub struct StorableMerkleTreeInsertion<'a> {
     pub block_number: u64,
 }
 
+// Each row binds five columns; conflict updates reference EXCLUDED and add no
+// parameters. Keep each statement below PostgreSQL's 65,535-parameter limit.
+const INSERT_CHUNK_SIZE: usize = 13_000;
+
 impl ScraperDb {
     pub async fn store_merkle_tree_insertions(
         &self,
@@ -19,35 +27,50 @@ impl ScraperDb {
         insertions: impl Iterator<Item = StorableMerkleTreeInsertion<'_>>,
     ) -> Result<u64> {
         let merkle_tree_hook = address_to_bytes(merkle_tree_hook);
+        // A single PostgreSQL upsert rejects repeated conflict keys. Preserve
+        // that rejection even when repeated leaves fall into different chunks.
+        let mut leaf_indices = HashSet::new();
         let models = insertions
-            .map(|row| merkle_tree_insertion::ActiveModel {
-                id: NotSet,
-                domain: Unchanged(domain as i32),
-                merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
-                leaf_index: Unchanged(row.insertion.index() as i32),
-                message_id: Set(h256_to_bytes(&row.insertion.message_id())),
-                block_number: Set(row.block_number as i64),
+            .map(|row| {
+                ensure!(
+                    leaf_indices.insert(row.insertion.index()),
+                    "Duplicate Merkle tree leaf index {} in one batch",
+                    row.insertion.index()
+                );
+                Ok(merkle_tree_insertion::ActiveModel {
+                    id: NotSet,
+                    domain: Unchanged(domain as i32),
+                    merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
+                    leaf_index: Unchanged(row.insertion.index() as i32),
+                    message_id: Set(h256_to_bytes(&row.insertion.message_id())),
+                    block_number: Set(row.block_number as i64),
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
+        drop(leaf_indices);
         let count = models.len() as u64;
         if models.is_empty() {
             return Ok(0);
         }
 
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([
-                    merkle_tree_insertion::Column::Domain,
-                    merkle_tree_insertion::Column::MerkleTreeHook,
-                    merkle_tree_insertion::Column::LeafIndex,
-                ])
-                .update_columns([
-                    merkle_tree_insertion::Column::MessageId,
-                    merkle_tree_insertion::Column::BlockNumber,
-                ])
-                .to_owned(),
-            )
-            .exec(&self.0)
+        if models.len() <= INSERT_CHUNK_SIZE {
+            insert_query(models).exec(&self.0).await?;
+            return Ok(count);
+        }
+
+        // A failed later chunk must roll back earlier writes: ContractSync can
+        // advance its cursor only after the entire fetched range is durable.
+        self.0
+            .transaction::<_, (), DbErr>(|txn| {
+                Box::pin(async move {
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models.by_ref().take(INSERT_CHUNK_SIZE).collect();
+                        insert_query(chunk).exec(txn).await?;
+                    }
+                    Ok(())
+                })
+            })
             .await?;
         Ok(count)
     }
@@ -76,3 +99,23 @@ impl ScraperDb {
         }))
     }
 }
+
+fn insert_query(
+    models: Vec<merkle_tree_insertion::ActiveModel>,
+) -> Insert<merkle_tree_insertion::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([
+            merkle_tree_insertion::Column::Domain,
+            merkle_tree_insertion::Column::MerkleTreeHook,
+            merkle_tree_insertion::Column::LeafIndex,
+        ])
+        .update_columns([
+            merkle_tree_insertion::Column::MessageId,
+            merkle_tree_insertion::Column::BlockNumber,
+        ])
+        .to_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, PaginatorTrait, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+
+// Matches the observed 86,580-bind range: five parameters per insertion.
+const ROW_COUNT: u32 = 17_316;
+const DOMAIN: u32 = 1;
+
+fn insertions() -> Vec<MerkleTreeInsertion> {
+    (0..ROW_COUNT)
+        .map(|index| MerkleTreeInsertion::new(index, H256::from_low_u64_be(u64::from(index))))
+        .collect()
+}
+
+fn rows(
+    insertions: &[MerkleTreeInsertion],
+) -> impl Iterator<Item = StorableMerkleTreeInsertion<'_>> {
+    insertions
+        .iter()
+        .map(|insertion| StorableMerkleTreeInsertion {
+            insertion,
+            block_number: 20_000,
+        })
+}
+
+#[tokio::test]
+async fn merkle_insert_statements_stay_below_postgres_bind_limit() {
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([
+            [BTreeMap::from([("id", Value::BigInt(Some(1)))])],
+            [BTreeMap::from([("id", Value::BigInt(Some(2)))])],
+        ])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions()))
+            .await
+            .unwrap(),
+        u64::from(ROW_COUNT)
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1, "all chunks must share a transaction");
+    let statements = transactions[0].statements();
+    assert_eq!(statements.first().unwrap().sql, "BEGIN");
+    assert_eq!(statements.last().unwrap().sql, "COMMIT");
+    assert_eq!(statements.len(), 4);
+    let bind_counts: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("INSERT"))
+        .map(|statement| statement.values.as_ref().unwrap().0.len())
+        .collect();
+    assert_eq!(bind_counts, [65_000, 21_580]);
+    assert!(bind_counts
+        .iter()
+        .all(|count| *count <= usize::from(u16::MAX)));
+}
+
+#[tokio::test]
+async fn merkle_small_insert_keeps_one_statement_and_empty_insert_skips_sql() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[BTreeMap::from([("id", Value::BigInt(Some(1)))])]])
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[]))
+            .await
+            .unwrap(),
+        0
+    );
+    let insertion = MerkleTreeInsertion::new(1, H256::zero());
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[insertion]))
+            .await
+            .unwrap(),
+        1
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1);
+    let statements = transactions[0].statements();
+    assert_eq!(statements.len(), 1);
+    assert!(statements[0].sql.starts_with("INSERT"));
+    assert_eq!(statements[0].values.as_ref().unwrap().0.len(), 5);
+}
+
+#[tokio::test]
+async fn merkle_duplicate_leaf_across_chunks_is_rejected_before_writes() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    let mut insertions = insertions();
+    insertions.push(insertions[0]);
+    let error = db
+        .store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions))
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Duplicate Merkle tree leaf index 0"));
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn merkle_bulk_insert_is_replayable_and_rolls_back_failed_tail() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let hook = H256::from_low_u64_be(1);
+    let insertions = insertions();
+
+    for _ in 0..2 {
+        assert_eq!(
+            db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+                .await?,
+            u64::from(ROW_COUNT)
+        );
+        assert_eq!(
+            merkle_tree_insertion::Entity::find().count(&db.0).await?,
+            u64::from(ROW_COUNT),
+            "replay must not duplicate rows"
+        );
+    }
+    for index in [0, 12_999, 13_000, ROW_COUNT - 1] {
+        assert_eq!(
+            db.retrieve_merkle_tree_insertion(DOMAIN, &hook, index)
+                .await?,
+            Some((insertions[usize::try_from(index)?], 20_000))
+        );
+    }
+
+    // Retain one existing row, then fail the first row of the second chunk.
+    // Both first-chunk inserts and updates must roll back with the failure.
+    db.0.execute_unprepared("TRUNCATE merkle_tree_insertion")
+        .await?;
+    let original = MerkleTreeInsertion::new(0, H256::repeat_byte(0xff));
+    db.store_merkle_tree_insertions(
+        DOMAIN,
+        &hook,
+        [StorableMerkleTreeInsertion {
+            insertion: &original,
+            block_number: 10_000,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    db.0.execute_unprepared(
+        "ALTER TABLE merkle_tree_insertion ADD CONSTRAINT reject_test_tail CHECK (leaf_index <> 13000)"
+    ).await?;
+    assert!(db
+        .store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+        .await
+        .is_err());
+    assert_eq!(merkle_tree_insertion::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((original, 10_000)),
+        "failed tail must also roll back updates to earlier existing rows"
+    );
+
+    db.0.execute_unprepared("ALTER TABLE merkle_tree_insertion DROP CONSTRAINT reject_test_tail")
+        .await?;
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+            .await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        merkle_tree_insertion::Entity::find().count(&db.0).await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((insertions[0], 20_000))
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -4,9 +4,7 @@ use std::collections::HashSet;
 
 use eyre::{ensure, Result};
 use itertools::Itertools;
-use sea_orm::{
-    prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, TransactionTrait,
-};
+use sea_orm::{prelude::*, ActiveValue::*, Insert, QuerySelect, QueryTrait, TransactionTrait};
 use tracing::{debug, instrument, trace};
 
 use hyperlane_core::{
@@ -63,47 +61,48 @@ impl ScraperDb {
         destination_mailbox: &H256,
         sequence: u32,
     ) -> Result<Option<Delivery>> {
-        if let Some(delivery) = delivered_message::Entity::find()
+        if let Some(msg_id) = delivered_message::Entity::find()
+            .select_only()
+            .column(delivered_message::Column::MsgId)
             .filter(delivered_message::Column::Domain.eq(destination_domain))
             .filter(
                 delivered_message::Column::DestinationMailbox
                     .eq(address_to_bytes(destination_mailbox)),
             )
             .filter(delivered_message::Column::Sequence.eq(sequence))
+            .into_tuple::<Vec<u8>>()
             .one(&self.0)
             .await?
         {
-            let delivery = H256::from_slice(&delivery.msg_id);
+            let delivery = H256::from_slice(&msg_id);
             Ok(Some(delivery))
         } else {
             Ok(None)
         }
     }
 
-    /// Get the tx id of a delivered message associated with a sequence.
+    /// Get the block height of a delivered message associated with a sequence.
     /// Also returns `None` for deliveries stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_delivered_message_tx_id(
+    pub async fn retrieve_delivered_message_block_number(
         &self,
         destination_domain: u32,
         destination_mailbox: &H256,
         sequence: u32,
-    ) -> Result<Option<i64>> {
-        if let Some(delivery) = delivered_message::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = delivered_message::Entity::find()
             .filter(delivered_message::Column::Domain.eq(destination_domain))
             .filter(
                 delivered_message::Column::DestinationMailbox
                     .eq(address_to_bytes(destination_mailbox)),
             )
             .filter(delivered_message::Column::Sequence.eq(sequence))
-            .one(&self.0)
-            .await?
-        {
-            Ok(delivery.destination_tx_id)
-        } else {
-            Ok(None)
-        }
+            .select_only()
+            .column(delivered_message::Column::DestinationTxId)
+            .limit(1)
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     async fn latest_deliveries_id(&self, domain: u32, destination_mailbox: Vec<u8>) -> Result<i64> {
@@ -219,60 +218,57 @@ impl ScraperDb {
         origin_mailbox: &H256,
         nonce: u32,
     ) -> Result<Option<HyperlaneMessage>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Nonce,
-        }
-        if let Some(message) = message::Entity::find()
+        if let Some((origin, destination, nonce, sender, recipient, body)) = message::Entity::find()
+            .select_only()
+            .columns([
+                message::Column::Origin,
+                message::Column::Destination,
+                message::Column::Nonce,
+                message::Column::Sender,
+                message::Column::Recipient,
+                message::Column::MsgBody,
+            ])
             .filter(message::Column::Origin.eq(origin_domain))
             .filter(message::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)))
             .filter(message::Column::Nonce.eq(nonce))
+            .into_tuple::<(i32, i32, i32, Vec<u8>, Vec<u8>, Option<Vec<u8>>)>()
             .one(&self.0)
             .await?
         {
             Ok(Some(HyperlaneMessage {
                 // We do not write version to the DB.
                 version: 3,
-                origin: message.origin as u32,
-                destination: message.destination as u32,
-                nonce: message.nonce as u32,
-                sender: bytes_to_address(message.sender)?,
-                recipient: bytes_to_address(message.recipient)?,
-                body: message.msg_body.unwrap_or(Vec::new()),
+                origin: origin as u32,
+                destination: destination as u32,
+                nonce: nonce as u32,
+                sender: bytes_to_address(sender)?,
+                recipient: bytes_to_address(recipient)?,
+                body: body.unwrap_or(Vec::new()),
             }))
         } else {
             Ok(None)
         }
     }
 
-    /// Get the tx id associated with a dispatched message.
+    /// Get the block height associated with a dispatched message.
     /// Also returns `None` for messages stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_dispatched_tx_id(
+    pub async fn retrieve_dispatched_block_number(
         &self,
         origin_domain: u32,
         origin_mailbox: &H256,
         nonce: u32,
-    ) -> Result<Option<i64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Nonce,
-        }
-
-        let tx_id = message::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = message::Entity::find()
             .filter(message::Column::Origin.eq(origin_domain))
             .filter(message::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)))
             .filter(message::Column::Nonce.eq(nonce))
             .select_only()
-            .column_as(message::Column::OriginTxId.max(), QueryAs::Nonce)
+            .column_as(message::Column::OriginTxId.max(), "tx_id")
             .group_by(message::Column::Origin)
-            // `origin_tx_id` is nullable (unresolvable on-chain transaction),
-            // so the MAX aggregate can be NULL even when a message row exists.
-            .into_values::<Option<i64>, QueryAs>()
-            .one(&self.0)
-            .await?;
-        Ok(tx_id.flatten())
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     /// Store messages from a mailbox into the database (or update an existing

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)] // TODO: `rustc` 1.80.1 clippy issue
 
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, TransactionTrait,
@@ -49,6 +51,9 @@ impl ScraperDb {
     /// u16::MAX (65_535u16) is the maximum amount of parameters we can
     /// have for Postgres. So 65000 / 20 = 3250
     const STORE_MESSAGE_CHUNK_SIZE: usize = 3250;
+
+    // Six bound columns per delivery; conflict expressions add no parameters.
+    const STORE_DELIVERY_CHUNK_SIZE: usize = 10_000;
 
     /// Get the delivered message associated with a sequence.
     #[instrument(skip(self))]
@@ -143,54 +148,57 @@ impl ScraperDb {
         deliveries: impl Iterator<Item = StorableDelivery<'_>>,
     ) -> Result<u64> {
         let destination_mailbox = address_to_bytes(&destination_mailbox);
-        let latest_id_before = self
-            .latest_deliveries_id(domain, destination_mailbox.clone())
-            .await?;
         // we have a race condition where a message may not have been scraped yet even
         // though we have received news of delivery on this chain, so the
         // message IDs are looked up in a separate "thread".
-        let models: Vec<delivered_message::ActiveModel> = deliveries
-            .map(|delivery| delivered_message::ActiveModel {
-                id: NotSet,
-                time_created: Set(date_time::now()),
-                msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
-                domain: Unchanged(domain as i32),
-                destination_mailbox: Unchanged(destination_mailbox.clone()),
-                destination_tx_id: Set(delivery.txn_id),
-                sequence: Set(delivery.sequence),
+        let mut message_ids = HashSet::new();
+        let models = deliveries
+            .map(|delivery| {
+                // Preserve single-upsert rejection across chunk boundaries.
+                ensure!(
+                    message_ids.insert(delivery.message_id),
+                    "Duplicate delivery message id in one batch"
+                );
+                Ok(delivered_message::ActiveModel {
+                    id: NotSet,
+                    time_created: Set(date_time::now()),
+                    msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
+                    domain: Unchanged(domain as i32),
+                    destination_mailbox: Unchanged(destination_mailbox.clone()),
+                    destination_tx_id: Set(delivery.txn_id),
+                    sequence: Set(delivery.sequence),
+                })
             })
-            .collect_vec();
+            .collect::<Result<Vec<_>>>()?;
+        drop(message_ids);
+        if models.is_empty() {
+            return Ok(0);
+        }
+        let latest_id_before = self
+            .latest_deliveries_id(domain, destination_mailbox.clone())
+            .await?;
 
         trace!(?models, "Writing delivered messages to database");
 
-        if models.is_empty() {
-            debug!("Wrote zero new delivered messages to database");
-            return Ok(0);
+        if models.len() <= Self::STORE_DELIVERY_CHUNK_SIZE {
+            delivery_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_DELIVERY_CHUNK_SIZE)
+                                .collect();
+                            delivery_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
+                })
+                .await?;
         }
-
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([delivered_message::Column::MsgId])
-                    // A fallback replay must not discard transaction metadata
-                    // that was resolved by an earlier scrape. This still lets
-                    // a later resolved scrape enrich an existing NULL row.
-                    .value(
-                        delivered_message::Column::DestinationTxId,
-                        Func::if_null(
-                            Expr::col((
-                                Alias::new("excluded"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                            Expr::col((
-                                Alias::new("delivered_message"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                        ),
-                    )
-                    .to_owned(),
-            )
-            .exec(&self.0)
-            .await?;
 
         let new_deliveries_count = self
             .deliveries_count_since_id(domain, destination_mailbox, latest_id_before)
@@ -300,13 +308,9 @@ impl ScraperDb {
             })
             .collect_vec();
 
-        trace!(?models, "Writing messages to database");
-
         if models.is_empty() {
-            debug!("Wrote zero new messages to database");
             return Ok(0);
         }
-
         // ensure all chunks are inserted or none at all
         let new_dispatch_count = self
             .0
@@ -383,6 +387,31 @@ impl ScraperDb {
         );
         Ok(new_dispatch_count)
     }
+}
+
+fn delivery_insert_query(
+    models: Vec<delivered_message::ActiveModel>,
+) -> Insert<delivered_message::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([delivered_message::Column::MsgId])
+            // A fallback replay must not discard transaction metadata
+            // that was resolved by an earlier scrape. This still lets
+            // a later resolved scrape enrich an existing NULL row.
+            .value(
+                delivered_message::Column::DestinationTxId,
+                Func::if_null(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                    Expr::col((
+                        Alias::new("delivered_message"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                ),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -62,3 +62,9 @@ impl Clone for ScraperDb {
         Self(conn)
     }
 }
+
+#[cfg(test)]
+mod write_batches;
+
+#[cfg(test)]
+mod dispatch_transactions;

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -29,6 +29,9 @@ mod txn;
 pub struct ScraperDb(DbConn);
 
 impl ScraperDb {
+    // Hash lookups bind one parameter per hash; stay below PostgreSQL's 65,535 limit.
+    const HASH_LOOKUP_CHUNK_SIZE: usize = 65_000;
+
     #[instrument]
     pub async fn connect(url: &str) -> Result<Self> {
         let db = Database::connect(url).await?;
@@ -65,6 +68,12 @@ impl Clone for ScraperDb {
 
 #[cfg(test)]
 mod write_batches;
+
+#[cfg(test)]
+mod lookup_batches;
+
+#[cfg(test)]
+mod sequence_reads;
 
 #[cfg(test)]
 mod dispatch_transactions;

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use eyre::Result;
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, Statement, TransactionTrait,
@@ -8,7 +8,7 @@ use sea_orm::{
 use tracing::{debug, instrument};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, InterchainGasPayment, LogMeta, H256};
-use migration::OnConflict;
+use migration::{Expr, OnConflict};
 
 use crate::conversions::{decimal_to_u256, u256_to_decimal};
 use crate::date_time;
@@ -28,6 +28,9 @@ pub struct StorablePayment<'a> {
 }
 
 impl ScraperDb {
+    // Eleven parameters per inserted row; reads add two scope parameters.
+    const PAYMENT_STORE_CHUNK_SIZE: usize = 5_000;
+
     const PAYMENT_STORE_LOCK_NAMESPACE: i32 = 0x4859_504C;
 
     /// Get the payment associated with a sequence.
@@ -93,6 +96,25 @@ impl ScraperDb {
         interchain_gas_paymaster: &H256,
         payments: &[StorablePayment<'_>],
     ) -> Result<u64> {
+        if payments.is_empty() {
+            return Ok(0);
+        }
+        // PostgreSQL rejects repeated non-NULL conflict keys in one upsert.
+        // Retain that rejection even if keys would land in different chunks.
+        let mut resolved_keys = HashSet::new();
+        for payment in payments {
+            if let Some(tx_id) = payment.txn_id {
+                ensure!(
+                    resolved_keys.insert((
+                        payment.payment.message_id,
+                        payment.meta.log_index.as_u64(),
+                        tx_id,
+                    )),
+                    "Duplicate resolved gas payment in one batch"
+                );
+            }
+        }
+        drop(resolved_keys);
         let interchain_gas_paymaster = address_to_bytes(interchain_gas_paymaster);
 
         // Postgres unique indexes treat NULLs as distinct, so the
@@ -115,42 +137,38 @@ impl ScraperDb {
         ))
         .await?;
 
-        let latest_id_before = gas_payment::Entity::find()
-            .select_only()
-            .column_as(gas_payment::Column::Id.max(), "max_id")
-            .filter(gas_payment::Column::Domain.eq(domain))
-            .into_tuple::<Option<i64>>()
-            .one(&txn)
-            .await?
-            .flatten()
-            .unwrap_or(0);
-
         let payment_msg_ids = payments
             .iter()
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
+            .unique()
             .collect_vec();
-        let existing_payments = if payment_msg_ids.is_empty() {
-            Vec::new()
-        } else {
-            gas_payment::Entity::find()
+        let mut seen_fallback_payments = HashSet::new();
+        let mut existing_null_payments = HashSet::new();
+        for message_ids in payment_msg_ids.chunks(Self::PAYMENT_STORE_CHUNK_SIZE) {
+            let existing_payments = gas_payment::Entity::find()
+                .select_only()
+                .columns([
+                    gas_payment::Column::MsgId,
+                    gas_payment::Column::LogIndex,
+                    gas_payment::Column::TxId,
+                ])
                 .filter(gas_payment::Column::Domain.eq(domain))
                 .filter(
                     gas_payment::Column::InterchainGasPaymaster
                         .eq(interchain_gas_paymaster.clone()),
                 )
-                .filter(gas_payment::Column::MsgId.is_in(payment_msg_ids))
+                .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
+                .into_tuple::<(Vec<u8>, i64, Option<i64>)>()
                 .all(&txn)
-                .await?
-        };
-        let mut seen_fallback_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .iter()
-            .map(|payment| (payment.msg_id.clone(), payment.log_index))
-            .collect();
-        let mut existing_null_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .into_iter()
-            .filter(|payment| payment.tx_id.is_none())
-            .map(|payment| (payment.msg_id, payment.log_index))
-            .collect();
+                .await?;
+            for (msg_id, log_index, tx_id) in existing_payments {
+                let identity = (msg_id, log_index);
+                if tx_id.is_none() {
+                    existing_null_payments.insert(identity.clone());
+                }
+                seen_fallback_payments.insert(identity);
+            }
+        }
         let resolved_batch_payments: HashSet<(Vec<u8>, i64)> = payments
             .iter()
             .filter(|storable| storable.txn_id.is_some())
@@ -158,6 +176,7 @@ impl ScraperDb {
             .collect();
 
         let mut models = Vec::with_capacity(payments.len());
+        let mut fallback_replacements = Vec::new();
         for storable in payments {
             let identity = payment_identity(storable);
             if storable.txn_id.is_none() {
@@ -171,17 +190,7 @@ impl ScraperDb {
             } else if existing_null_payments.remove(&identity) {
                 // Replace an earlier fallback row instead of keeping both
                 // variants and double-counting it.
-                gas_payment::Entity::delete_many()
-                    .filter(gas_payment::Column::Domain.eq(domain))
-                    .filter(
-                        gas_payment::Column::InterchainGasPaymaster
-                            .eq(interchain_gas_paymaster.clone()),
-                    )
-                    .filter(gas_payment::Column::MsgId.eq(identity.0.clone()))
-                    .filter(gas_payment::Column::LogIndex.eq(identity.1))
-                    .filter(gas_payment::Column::TxId.is_null())
-                    .exec(&txn)
-                    .await?;
+                fallback_replacements.push(identity);
             }
 
             models.push(payment_model(
@@ -197,27 +206,70 @@ impl ScraperDb {
             debug!("Wrote zero new gas payments to database");
             0
         } else {
-            Insert::many(models)
-                .on_conflict(
-                    OnConflict::columns([
-                        // don't need domain because TxId includes it
-                        gas_payment::Column::MsgId,
-                        gas_payment::Column::TxId,
-                        gas_payment::Column::LogIndex,
-                    ])
-                    .update_columns([
-                        gas_payment::Column::TimeCreated,
-                        gas_payment::Column::Payment,
-                        gas_payment::Column::GasAmount,
-                        gas_payment::Column::Origin,
-                        gas_payment::Column::Destination,
-                        gas_payment::Column::InterchainGasPaymaster,
-                        gas_payment::Column::Sequence,
-                    ])
-                    .to_owned(),
-                )
-                .exec(&txn)
-                .await?;
+            let latest_id_before = gas_payment::Entity::find()
+                .select_only()
+                .column_as(gas_payment::Column::Id.max(), "max_id")
+                .filter(gas_payment::Column::Domain.eq(domain))
+                .into_tuple::<Option<i64>>()
+                .one(&txn)
+                .await?
+                .flatten()
+                .unwrap_or(0);
+
+            let mut fallback_replacements = fallback_replacements.into_iter();
+            while !fallback_replacements.as_slice().is_empty() {
+                // Two parameters per identity plus domain/IGP scope. Keep deletion
+                // inside the same transaction as the replacement inserts.
+                let identities: Vec<_> = fallback_replacements
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect();
+                gas_payment::Entity::delete_many()
+                    .filter(gas_payment::Column::Domain.eq(domain))
+                    .filter(
+                        gas_payment::Column::InterchainGasPaymaster
+                            .eq(interchain_gas_paymaster.clone()),
+                    )
+                    .filter(gas_payment::Column::TxId.is_null())
+                    .filter(
+                        Expr::tuple([
+                            Expr::col(gas_payment::Column::MsgId).into(),
+                            Expr::col(gas_payment::Column::LogIndex).into(),
+                        ])
+                        .in_tuples(identities),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+
+            let mut models = models.into_iter();
+            while !models.as_slice().is_empty() {
+                let chunk = models
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect::<Vec<_>>();
+                Insert::many(chunk)
+                    .on_conflict(
+                        OnConflict::columns([
+                            // don't need domain because TxId includes it
+                            gas_payment::Column::MsgId,
+                            gas_payment::Column::TxId,
+                            gas_payment::Column::LogIndex,
+                        ])
+                        .update_columns([
+                            gas_payment::Column::TimeCreated,
+                            gas_payment::Column::Payment,
+                            gas_payment::Column::GasAmount,
+                            gas_payment::Column::Origin,
+                            gas_payment::Column::Destination,
+                            gas_payment::Column::InterchainGasPaymaster,
+                            gas_payment::Column::Sequence,
+                        ])
+                        .to_owned(),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
 
             gas_payment::Entity::find()
                 .filter(gas_payment::Column::Domain.eq(domain))

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
-    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, Statement, TransactionTrait,
+    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, QueryTrait, Statement,
+    TransactionTrait,
 };
 use tracing::{debug, instrument};
 
@@ -41,21 +42,29 @@ impl ScraperDb {
         interchain_gas_paymaster: &H256,
         sequence: u32,
     ) -> Result<Option<InterchainGasPayment>> {
-        if let Some(payment) = gas_payment::Entity::find()
+        if let Some((msg_id, destination, payment, gas_amount)) = gas_payment::Entity::find()
+            .select_only()
+            .columns([
+                gas_payment::Column::MsgId,
+                gas_payment::Column::Destination,
+                gas_payment::Column::Payment,
+                gas_payment::Column::GasAmount,
+            ])
             .filter(gas_payment::Column::Origin.eq(origin))
             .filter(
                 gas_payment::Column::InterchainGasPaymaster
                     .eq(address_to_bytes(interchain_gas_paymaster)),
             )
             .filter(gas_payment::Column::Sequence.eq(sequence))
+            .into_tuple::<(Vec<u8>, i32, BigDecimal, BigDecimal)>()
             .one(&self.0)
             .await?
         {
             let payment = InterchainGasPayment {
-                message_id: H256::from_slice(&payment.msg_id),
-                destination: payment.destination as u32,
-                payment: decimal_to_u256(payment.payment),
-                gas_amount: decimal_to_u256(payment.gas_amount),
+                message_id: H256::from_slice(&msg_id),
+                destination: destination as u32,
+                payment: decimal_to_u256(payment),
+                gas_amount: decimal_to_u256(gas_amount),
             };
             Ok(Some(payment))
         } else {
@@ -63,30 +72,28 @@ impl ScraperDb {
         }
     }
 
-    /// Get the transaction id of the gas payment associated with a sequence.
+    /// Get the block height of the gas payment associated with a sequence.
     /// Also returns `None` for payments stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_payment_tx_id(
+    pub async fn retrieve_payment_block_number(
         &self,
         origin: u32,
         interchain_gas_paymaster: &H256,
         sequence: u32,
-    ) -> Result<Option<i64>> {
-        if let Some(payment) = gas_payment::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = gas_payment::Entity::find()
             .filter(gas_payment::Column::Origin.eq(origin))
             .filter(
                 gas_payment::Column::InterchainGasPaymaster
                     .eq(address_to_bytes(interchain_gas_paymaster)),
             )
             .filter(gas_payment::Column::Sequence.eq(sequence))
-            .one(&self.0)
-            .await?
-        {
-            Ok(payment.tx_id)
-        } else {
-            Ok(None)
-        }
+            .select_only()
+            .column(gas_payment::Column::TxId)
+            .limit(1)
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     #[instrument(skip_all)]

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -161,95 +161,26 @@ impl ScraperDb {
             .latest_raw_dispatch_id(origin_domain, origin_mailbox.clone())
             .await?;
 
-        // Ensure all chunks are inserted or none at all
-        self.0
-            .transaction::<_, (), DbErr>(|txn| {
-                Box::pin(async move {
-                    // Insert raw message dispatches in chunks, to not run into
-                    // "Too many arguments" error
-                    for chunk in models.chunks(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE) {
-                        Insert::many(chunk.to_vec())
-                            .on_conflict(
-                                OnConflict::column(raw_message_dispatch::Column::MsgId)
-                                    .update_columns([
-                                        raw_message_dispatch::Column::TimeUpdated,
-                                        raw_message_dispatch::Column::DestinationDomain,
-                                        raw_message_dispatch::Column::Sender,
-                                        raw_message_dispatch::Column::Recipient,
-                                        raw_message_dispatch::Column::MsgBody,
-                                    ])
-                                    // Preserve resolved hashes across a later
-                                    // basic-meta fallback, while still updating
-                                    // the body and other fields on legacy rows.
-                                    .value(
-                                        raw_message_dispatch::Column::OriginTxHash,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            ))
-                                            .ne(h512_to_bytes(&H512::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            )),
-                                        ),
-                                    )
-                                    .value(
-                                        raw_message_dispatch::Column::OriginBlockHash,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            ))
-                                            .ne(h256_to_bytes(&H256::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            )),
-                                        ),
-                                    )
-                                    .value(
-                                        raw_message_dispatch::Column::OriginBlockHeight,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            ))
-                                            .ne(h256_to_bytes(&H256::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHeight,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginBlockHeight,
-                                            )),
-                                        ),
-                                    )
-                                    .to_owned(),
-                            )
-                            .exec(txn)
-                            .await?;
-                    }
-                    Ok(())
+        // A single INSERT is atomic; multiple chunks need one shared transaction.
+        if models.len() <= Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE {
+            raw_dispatch_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE)
+                                .collect();
+                            raw_dispatch_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
                 })
-            })
-            .await?;
+                .await?;
+        }
 
         let new_dispatch_count = self
             .raw_dispatch_count_since_id(origin_domain, origin_mailbox, latest_id_before)
@@ -395,6 +326,79 @@ fn raw_dispatch_to_candidate(raw: raw_message_dispatch::Model) -> Result<RawDisp
             log_index: U256::zero(),
         },
     })
+}
+
+fn raw_dispatch_insert_query(
+    models: Vec<raw_message_dispatch::ActiveModel>,
+) -> Insert<raw_message_dispatch::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::column(raw_message_dispatch::Column::MsgId)
+            .update_columns([
+                raw_message_dispatch::Column::TimeUpdated,
+                raw_message_dispatch::Column::DestinationDomain,
+                raw_message_dispatch::Column::Sender,
+                raw_message_dispatch::Column::Recipient,
+                raw_message_dispatch::Column::MsgBody,
+            ])
+            // Preserve resolved hashes across a later
+            // basic-meta fallback, while still updating
+            // the body and other fields on legacy rows.
+            .value(
+                raw_message_dispatch::Column::OriginTxHash,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginTxHash,
+                    ))
+                    .ne(h512_to_bytes(&H512::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginTxHash,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginTxHash,
+                ))),
+            )
+            .value(
+                raw_message_dispatch::Column::OriginBlockHash,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    ))
+                    .ne(h256_to_bytes(&H256::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginBlockHash,
+                ))),
+            )
+            .value(
+                raw_message_dispatch::Column::OriginBlockHeight,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    ))
+                    .ne(h256_to_bytes(&H256::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHeight,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginBlockHeight,
+                ))),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/main/agents/scraper/src/db/sequence_reads.rs
+++ b/rust/main/agents/scraper/src/db/sequence_reads.rs
@@ -1,0 +1,106 @@
+//! Sequence lookups select only event reconstruction fields.
+use std::collections::BTreeMap;
+
+use hyperlane_core::H256;
+use sea_orm::{DatabaseBackend, DbErr, MockDatabase, Value};
+
+use super::ScraperDb;
+
+#[tokio::test]
+async fn sequence_readers_project_payload_columns_and_preserve_absence() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<BTreeMap<String, Value>>::new(); 4])
+            .into_connection(),
+    );
+    let address = H256::from_low_u64_be(42);
+    assert!(db
+        .retrieve_delivery_by_sequence(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_dispatched_message_by_nonce(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_payment_by_sequence(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(db
+        .retrieve_merkle_tree_insertion(1, &address, 7)
+        .await
+        .unwrap()
+        .is_none());
+
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 4);
+    for (query, (table, columns)) in log.iter().zip([
+        ("delivered_message", &["msg_id"][..]),
+        (
+            "message",
+            &[
+                "origin",
+                "destination",
+                "nonce",
+                "sender",
+                "recipient",
+                "msg_body",
+            ][..],
+        ),
+        (
+            "gas_payment",
+            &["msg_id", "destination", "payment", "gas_amount"][..],
+        ),
+        (
+            "merkle_tree_insertion",
+            &["leaf_index", "message_id", "block_number"][..],
+        ),
+    ]) {
+        assert_eq!(query.statements().len(), 1);
+        let statement = &query.statements()[0];
+        let projection = columns
+            .iter()
+            .map(|column| format!("\"{table}\".\"{column}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        assert!(
+            statement
+                .sql
+                .starts_with(&format!("SELECT {projection} FROM \"{table}\" WHERE ")),
+            "{}",
+            statement.sql
+        );
+        // Three original filter values and the existing LIMIT 1.
+        assert_eq!(statement.values.as_ref().unwrap().0.len(), 4);
+    }
+}
+
+#[tokio::test]
+async fn sequence_readers_propagate_database_errors() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_errors((0..4).map(|_| DbErr::Custom("sequence read failed".into())))
+            .into_connection(),
+    );
+    let address = H256::zero();
+    let errors = [
+        db.retrieve_delivery_by_sequence(1, &address, 7)
+            .await
+            .unwrap_err(),
+        db.retrieve_dispatched_message_by_nonce(1, &address, 7)
+            .await
+            .unwrap_err(),
+        db.retrieve_payment_by_sequence(1, &address, 7)
+            .await
+            .unwrap_err(),
+        db.retrieve_merkle_tree_insertion(1, &address, 7)
+            .await
+            .unwrap_err(),
+    ];
+    for error in errors {
+        assert!(error.to_string().contains("sequence read failed"));
+    }
+}

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -94,7 +94,7 @@ impl ScraperDb {
                     recipient: Set(txn.recipient.as_ref().map(address_to_bytes)),
                     max_fee_per_gas: Set(txn.max_fee_per_gas.map(u256_to_decimal)),
                     cumulative_gas_used: Set(u256_to_decimal(receipt.cumulative_gas_used)),
-                    raw_input_data: Set(txn.raw_input_data.clone()),
+                    raw_input_data: Set(txn.info.raw_input_data),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 
 use derive_more::Deref;
 use eyre::{eyre, Context, Result};
+use itertools::Itertools;
 use sea_orm::{
-    prelude::*, sea_query::OnConflict, ActiveValue::*, DeriveColumn, EnumIter, Insert, NotSet,
-    QuerySelect,
+    prelude::*,
+    sea_query::{OnConflict, Query},
+    ActiveValue::*,
+    ConnectionTrait, DeriveColumn, EnumIter, Insert, NotSet, QuerySelect, QueryTrait,
 };
 use tracing::{debug, instrument, trace};
 
@@ -22,21 +25,6 @@ pub struct StorableTxn {
 }
 
 impl ScraperDb {
-    pub async fn retrieve_block_id(&self, tx_id: i64) -> Result<Option<i64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            BlockId,
-        }
-        let block_id = transaction::Entity::find()
-            .filter(transaction::Column::Id.eq(tx_id))
-            .select_only()
-            .column_as(transaction::Column::BlockId, QueryAs::BlockId)
-            .into_values::<i64, QueryAs>()
-            .one(&self.0)
-            .await?;
-        Ok(block_id)
-    }
-
     /// Lookup transactions and find their ids. Any transactions which are not
     /// found be excluded from the hashmap.
     pub async fn get_txn_ids(
@@ -49,27 +37,36 @@ impl ScraperDb {
             Hash,
         }
 
-        // check database to see which txns we already know and fetch their IDs
-        let txns = transaction::Entity::find()
-            .filter(transaction::Column::Hash.is_in(hashes.map(h512_to_bytes)))
-            .select_only()
-            .column_as(transaction::Column::Id, QueryAs::Id)
-            .column_as(transaction::Column::Hash, QueryAs::Hash)
-            .into_values::<(i64, Vec<u8>), QueryAs>()
-            .all(&self.0)
-            .await
-            .context("When querying transactions")?
-            .into_iter()
-            .map(|(id, hash)| Ok((bytes_to_h512(&hash), id)))
-            .collect::<Result<HashMap<_, _>>>()?;
+        let hashes = hashes.unique().collect_vec();
+        let mut txns = HashMap::new();
+        for hashes in hashes.chunks(Self::HASH_LOOKUP_CHUNK_SIZE) {
+            let rows = transaction::Entity::find()
+                .filter(
+                    transaction::Column::Hash.is_in(hashes.iter().map(|hash| h512_to_bytes(hash))),
+                )
+                .select_only()
+                .column_as(transaction::Column::Id, QueryAs::Id)
+                .column_as(transaction::Column::Hash, QueryAs::Hash)
+                .into_values::<(i64, Vec<u8>), QueryAs>()
+                .all(&self.0)
+                .await
+                .context("When querying transactions")?;
+            txns.extend(
+                rows.into_iter()
+                    .map(|(id, hash)| (bytes_to_h512(&hash), id)),
+            );
+        }
 
         trace!(?txns, "Queried transaction info for hashes");
         Ok(txns)
     }
 
-    /// Store a new transaction into the database (or update an existing one).
+    /// Store transactions and return IDs by hash for inserted rows. Conflicts are omitted.
     #[instrument(skip_all)]
-    pub async fn store_txns(&self, txns: impl Iterator<Item = StorableTxn>) -> Result<()> {
+    pub async fn store_txns(
+        &self,
+        txns: impl Iterator<Item = StorableTxn>,
+    ) -> Result<HashMap<H512, i64>> {
         let models = txns
             .map(|txn| {
                 let receipt = txn
@@ -99,22 +96,32 @@ impl ScraperDb {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        debug_assert!(!models.is_empty());
+        if models.is_empty() {
+            return Ok(HashMap::new());
+        }
         debug!(txns = models.len(), "Writing txns to database");
         trace!(?models, "Writing txns to database");
-
-        match Insert::many(models)
+        let mut query = Insert::many(models)
             .on_conflict(
                 OnConflict::column(transaction::Column::Hash)
                     .do_nothing()
                     .to_owned(),
             )
-            .exec(&self.0)
+            .into_query();
+        query.returning(
+            Query::returning().columns([transaction::Column::Id, transaction::Column::Hash]),
+        );
+        self.0
+            .query_all(self.0.get_database_backend().build(&query))
             .await
-        {
-            Ok(_) => Ok(()),
-            Err(DbErr::RecordNotInserted) => Ok(()),
-            Err(e) => Err(e).context("When inserting transactions"),
-        }
+            .context("When inserting transactions")?
+            .iter()
+            .map(|row| {
+                Ok((
+                    bytes_to_h512(&row.try_get::<Vec<u8>>("", "hash")?),
+                    row.try_get("", "id")?,
+                ))
+            })
+            .collect()
     }
 }

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -1,0 +1,756 @@
+//! Regression tests for PostgreSQL statement bounds and atomic event writes.
+
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, Database, DatabaseBackend, EntityTrait, MockDatabase,
+    MockExecResult, PaginatorTrait, QueryFilter, Value,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use hyperlane_core::{
+    BlockInfo, InterchainGasPayment, LogMeta, TxnInfo, TxnReceiptInfo, H256, H512, U256,
+};
+
+use super::{
+    generated::{delivered_message, gas_payment},
+    ScraperDb, StorableDelivery, StorablePayment, StorableTxn,
+};
+
+const DOMAIN: u32 = 1;
+
+fn result(key: &str, value: i64) -> Vec<BTreeMap<String, Value>> {
+    vec![BTreeMap::from([(
+        key.to_owned(),
+        Value::BigInt(Some(value)),
+    )])]
+}
+
+fn payments(count: u32) -> Vec<InterchainGasPayment> {
+    (0..count)
+        .map(|index| InterchainGasPayment {
+            message_id: H256::from_low_u64_be(u64::from(index)),
+            destination: DOMAIN,
+            payment: U256::from(1000),
+            gas_amount: U256::from(12345),
+        })
+        .collect()
+}
+
+fn payment_rows<'a>(
+    payments: &'a [InterchainGasPayment],
+    meta: &'a LogMeta,
+    txn_id: Option<i64>,
+) -> Vec<StorablePayment<'a>> {
+    payments
+        .iter()
+        .enumerate()
+        .map(|(index, payment)| StorablePayment {
+            payment,
+            sequence: Some(i64::try_from(index).unwrap()),
+            meta,
+            txn_id,
+        })
+        .collect()
+}
+
+fn deliveries(count: u32, meta: &LogMeta) -> impl Iterator<Item = StorableDelivery<'_>> {
+    (0..count).map(|index| StorableDelivery {
+        message_id: H256::from_low_u64_be(u64::from(index)),
+        sequence: Some(i64::from(index)),
+        meta,
+        txn_id: None,
+    })
+}
+
+#[tokio::test]
+async fn empty_event_writes_do_not_access_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert_eq!(
+        db.store_deliveries(DOMAIN, H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &H256::zero(), &[]).await.unwrap(),
+        0
+    );
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn delivery_batches_bound_binds_and_preserve_small_fast_path() {
+    for count in [1, 12_000] {
+        let chunks = if count == 1 { 1 } else { 2 };
+        let mut results = vec![result("max_id", 0)];
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(results)
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_deliveries(DOMAIN, H256::zero(), deliveries(count, &LogMeta::default()))
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        let statements: Vec<_> = log
+            .iter()
+            .flat_map(|transaction| transaction.statements())
+            .collect();
+        let binds: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .map(|statement| statement.values.as_ref().unwrap().0.len())
+            .collect();
+        assert_eq!(
+            binds,
+            if count == 1 {
+                vec![6]
+            } else {
+                vec![60_000, 12_000]
+            }
+        );
+        assert_eq!(statements.len(), if count == 1 { 3 } else { 6 });
+        if count > 1 {
+            assert_eq!(log[1].statements().first().unwrap().sql, "BEGIN");
+            assert_eq!(log[1].statements().last().unwrap().sql, "COMMIT");
+        }
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
+    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERT statements.
+    for count in [5_000_u32, 66_000] {
+        let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
+        let mut results = (0..chunks).map(|_| Vec::new()).collect::<Vec<_>>();
+        results.push(result("max_id", 0));
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results(results)
+                .into_connection(),
+        );
+        let mut payments = payments(count);
+        payments.push(payments[0].clone()); // Prefetch and NULL-row identity must dedupe this.
+        let meta = LogMeta::default();
+        let rows = payment_rows(&payments, &meta, None);
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &rows)
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        assert_eq!(
+            log.len(),
+            1,
+            "one transaction must retain the advisory lock throughout"
+        );
+        let statements = log[0].statements();
+        assert_eq!(statements.first().unwrap().sql, "BEGIN");
+        assert_eq!(statements.last().unwrap().sql, "COMMIT");
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| statement.sql.contains("pg_advisory_xact_lock"))
+                .count(),
+            1
+        );
+        let reads: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.contains(" IN ("))
+            .collect();
+        assert_eq!(reads.len(), chunks);
+        assert!(reads.iter().all(|statement| statement.sql.starts_with(
+            "SELECT \"gas_payment\".\"msg_id\", \"gas_payment\".\"log_index\", \"gas_payment\".\"tx_id\" FROM"
+        )));
+        assert!(reads
+            .iter()
+            .all(|statement| statement.values.as_ref().unwrap().0.len() <= 5_002));
+        let inserts: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .collect();
+        assert_eq!(inserts.len(), chunks);
+        assert_eq!(inserts[0].values.as_ref().unwrap().0.len(), 55_000);
+        assert!(statements.iter().all(|statement| statement
+            .values
+            .as_ref()
+            .map_or(true, |values| values.0.len() <= usize::from(u16::MAX))));
+    }
+}
+
+#[tokio::test]
+async fn payment_fallback_replays_skip_count_baseline() {
+    for existing_tx_id in [None, Some(7)] {
+        let payments = payments(1);
+        let meta = LogMeta::default();
+        let existing = vec![BTreeMap::from([
+            (
+                "0".to_owned(),
+                Value::Bytes(Some(Box::new(hyperlane_core::h256_to_bytes(
+                    &payments[0].message_id,
+                )))),
+            ),
+            ("1".to_owned(), Value::BigInt(Some(0))),
+            ("2".to_owned(), Value::BigInt(existing_tx_id)),
+        ])];
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results([existing])
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &payment_rows(&payments, &meta, None))
+                .await
+                .unwrap(),
+            0
+        );
+        let log = db.0.into_transaction_log();
+        let statements = log[0].statements();
+        assert_eq!(statements.len(), 4);
+        assert_eq!(statements[0].sql, "BEGIN");
+        assert!(statements[1].sql.contains("pg_advisory_xact_lock"));
+        assert!(statements[2].sql.contains(" IN ("));
+        assert_eq!(statements[3].sql, "COMMIT");
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_baseline_errors_precede_writes() {
+    for fail_prefetch in [true, false] {
+        let mock =
+            MockDatabase::new(DatabaseBackend::Postgres).append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }]);
+        let mock = if fail_prefetch {
+            mock
+        } else {
+            mock.append_query_results([Vec::<BTreeMap<String, Value>>::new()])
+        };
+        let db = ScraperDb::with_connection(
+            mock.append_query_errors([sea_orm::DbErr::Custom("read failed".to_owned())])
+                .into_connection(),
+        );
+        let payments = payments(1);
+        let meta = LogMeta::default();
+        assert!(db
+            .store_payments(DOMAIN, &H256::zero(), &payment_rows(&payments, &meta, None))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("read failed"));
+        let log = db.0.into_transaction_log();
+        let statements = log[0].statements();
+        assert_eq!(statements.last().unwrap().sql, "ROLLBACK");
+        assert!(!statements
+            .iter()
+            .any(|s| s.sql.starts_with("INSERT") || s.sql.starts_with("DELETE")));
+    }
+}
+
+#[tokio::test]
+async fn duplicate_keys_across_chunks_are_rejected() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([result("max_id", 0)])
+            .into_connection(),
+    );
+    let meta = LogMeta::default();
+    let rows = deliveries(12_000, &meta).chain(deliveries(1, &meta));
+    assert!(db
+        .store_deliveries(DOMAIN, H256::zero(), rows)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate delivery"));
+    let mut payments = payments(6_000);
+    payments.push(payments[0].clone());
+    assert!(db
+        .store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate resolved gas payment"));
+    let log = db.0.into_transaction_log();
+    assert!(log.is_empty());
+}
+
+async fn seed_transaction(db: &ScraperDb, index: u64) -> eyre::Result<i64> {
+    let hash = H256::from_low_u64_be(55);
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash,
+            timestamp: 1_700_000_000,
+            number: 500,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let block_id = db.get_block_basic([&hash].into_iter()).await?[0].id;
+    let tx_hash = H512::from_low_u64_be(66 + index);
+    db.store_txns(
+        [StorableTxn {
+            block_id,
+            info: TxnInfo {
+                hash: tx_hash,
+                gas_limit: U256::one(),
+                max_priority_fee_per_gas: None,
+                max_fee_per_gas: None,
+                gas_price: None,
+                nonce: 0,
+                sender: H256::zero(),
+                recipient: None,
+                receipt: Some(TxnReceiptInfo {
+                    gas_used: U256::one(),
+                    cumulative_gas_used: U256::one(),
+                    effective_gas_price: None,
+                }),
+                raw_input_data: None,
+            },
+        }]
+        .into_iter(),
+    )
+    .await?;
+    Ok(db.get_txn_ids([&tx_hash].into_iter()).await?[&tx_hash])
+}
+
+#[tokio::test]
+async fn bulk_events_replay_and_rollback_failed_tail_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        12_000
+    );
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        0
+    );
+    assert_eq!(
+        delivered_message::Entity::find().count(&db.0).await?,
+        12_000
+    );
+    db.0.execute_unprepared("TRUNCATE delivered_message")
+        .await?;
+    let original_tx = seed_transaction(&db, 0).await?;
+    let replacement_tx = seed_transaction(&db, 1).await?;
+    db.store_deliveries(
+        DOMAIN,
+        address,
+        deliveries(1, &meta).map(|mut row| {
+            row.txn_id = Some(original_tx);
+            row
+        }),
+    )
+    .await?;
+    db.0.execute_unprepared("ALTER TABLE delivered_message ADD CONSTRAINT reject_delivery_tail CHECK (sequence <> 10000)").await?;
+    assert!(db
+        .store_deliveries(
+            DOMAIN,
+            address,
+            deliveries(12_000, &meta).map(|mut row| {
+                row.txn_id = Some(replacement_tx);
+                row
+            })
+        )
+        .await
+        .is_err());
+    assert_eq!(delivered_message::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        delivered_message::Entity::find()
+            .one(&db.0)
+            .await?
+            .unwrap()
+            .destination_tx_id,
+        Some(original_tx)
+    );
+    db.0.execute_unprepared("ALTER TABLE delivered_message DROP CONSTRAINT reject_delivery_tail")
+        .await?;
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        11_999
+    );
+
+    let payments = payments(6_000);
+    let fallback = payment_rows(&payments, &meta, None);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    db.0.execute_unprepared("TRUNCATE gas_payment").await?;
+    db.store_payments(DOMAIN, &address, &fallback[..1]).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let resolved = payment_rows(&payments, &meta, Some(tx_id));
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_payment_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        1,
+        "failed tail must restore the deleted NULL fallback row"
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_payment_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &address, &fallback).await?,
+        0,
+        "later fallback replay must preserve resolved rows"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let rows = || {
+        (0..3_251u32).map(|nonce| super::StorableMessage {
+            msg: hyperlane_core::HyperlaneMessage {
+                nonce,
+                origin: DOMAIN,
+                destination: DOMAIN,
+                body: if nonce == 0 {
+                    vec![]
+                } else {
+                    vec![(nonce % 251) as u8; 1_024]
+                },
+                ..Default::default()
+            },
+            meta: &meta,
+            txn_id: None,
+            id_override: None,
+        })
+    };
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        3_251
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = super::generated::message::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), 3_251);
+    for row in stored {
+        let expected = if row.nonce == 0 {
+            None
+        } else {
+            Some(vec![(row.nonce % 251) as u8; 1_024])
+        };
+        assert_eq!(row.msg_body, expected);
+    }
+    Ok(())
+}
+#[tokio::test]
+async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Result<()> {
+    use super::generated::{raw_message_dispatch, transaction};
+    use super::StorableRawMessageDispatch;
+    use hyperlane_core::HyperlaneMessage;
+
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let messages: Vec<_> = (0..2_955u32)
+        .map(|nonce| HyperlaneMessage {
+            nonce,
+            origin: DOMAIN,
+            destination: DOMAIN,
+            body: if nonce == 0 {
+                vec![]
+            } else {
+                vec![(nonce % 251) as u8; 1_024]
+            },
+            ..Default::default()
+        })
+        .collect();
+    let rows = || {
+        messages
+            .iter()
+            .map(|msg| StorableRawMessageDispatch { msg, meta: &meta })
+    };
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        2_955
+    );
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = raw_message_dispatch::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), messages.len());
+    for row in stored {
+        assert_eq!(
+            row.msg_body.as_ref(),
+            Some(&messages[row.nonce as usize].body)
+        );
+    }
+
+    seed_transaction(&db, 0).await?;
+    let block_id = db
+        .get_block_basic([&H256::from_low_u64_be(55)].into_iter())
+        .await?[0]
+        .id;
+    let inputs = [None, Some(vec![]), Some(vec![0xab; 4_096])];
+    let transactions = || {
+        inputs
+            .iter()
+            .enumerate()
+            .map(|(index, raw_input_data)| StorableTxn {
+                block_id,
+                info: TxnInfo {
+                    hash: H512::from_low_u64_be(100 + index as u64),
+                    gas_limit: U256::one(),
+                    max_priority_fee_per_gas: None,
+                    max_fee_per_gas: None,
+                    gas_price: None,
+                    nonce: 0,
+                    sender: H256::zero(),
+                    recipient: None,
+                    receipt: Some(TxnReceiptInfo {
+                        gas_used: U256::one(),
+                        cumulative_gas_used: U256::one(),
+                        effective_gas_price: None,
+                    }),
+                    raw_input_data: raw_input_data.clone(),
+                },
+            })
+    };
+    db.store_txns(transactions()).await?;
+    db.store_txns(transactions()).await?;
+    for (index, expected) in inputs.iter().enumerate() {
+        let row = transaction::Entity::find()
+            .filter(transaction::Column::Hash.eq(hyperlane_core::h512_to_bytes(
+                &H512::from_low_u64_be(100 + index as u64),
+            )))
+            .one(&db.0)
+            .await?
+            .unwrap();
+        assert_eq!(&row.raw_input_data, expected);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn payment_fallback_deletes_use_bounded_tuple_keys() {
+    let payments = payments(6_000);
+    let meta = LogMeta::default();
+    let mut results = Vec::new();
+    for chunk in payments.chunks(5_000) {
+        // MockDatabase reads tuples by sorted-key position, not SQL column name.
+        results.push(
+            chunk
+                .iter()
+                .map(|payment| {
+                    BTreeMap::from([
+                        (
+                            "0".to_owned(),
+                            Value::Bytes(Some(Box::new(hyperlane_core::h256_to_bytes(
+                                &payment.message_id,
+                            )))),
+                        ),
+                        ("1".to_owned(), Value::BigInt(Some(0))),
+                        ("2".to_owned(), Value::BigInt(None)),
+                    ])
+                })
+                .collect(),
+        );
+    }
+    results.push(result("max_id", 0));
+    results.extend([result("id", 1), result("id", 2), result("num_items", 6_000)]);
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results((0..3).map(|_| MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }))
+            .append_query_results(results)
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap(),
+        6_000
+    );
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 1);
+    let statements = log[0].statements();
+    assert_eq!(statements.len(), 11);
+    let deletes: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("DELETE"))
+        .collect();
+    assert_eq!(deletes.len(), 2);
+    assert_eq!(deletes[0].values.as_ref().unwrap().0.len(), 10_002);
+    assert_eq!(deletes[1].values.as_ref().unwrap().0.len(), 2_002);
+    for statement in deletes {
+        assert!(statement.sql.contains("\"tx_id\" IS NULL"));
+        assert!(statement.sql.contains("(\"msg_id\", \"log_index\") IN"));
+    }
+}
+
+#[tokio::test]
+async fn payment_fallback_deletes_preserve_neighbors_and_rollback_in_postgres() -> eyre::Result<()>
+{
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let mut neighbor_meta = LogMeta::default();
+    neighbor_meta.log_index = U256::one();
+    let address = H256::from_low_u64_be(1);
+    let other_address = H256::from_low_u64_be(2);
+    let payments = payments(6_000);
+    let mut fallback = payment_rows(&payments, &meta, None);
+    for row in fallback.iter_mut().skip(1).step_by(2) {
+        row.meta = &neighbor_meta;
+    }
+    db.store_payments(DOMAIN, &address, &fallback).await?;
+    db.store_payments(DOMAIN, &other_address, &fallback[..1])
+        .await?;
+    db.store_payments(
+        DOMAIN,
+        &address,
+        &payment_rows(&payments[..1], &neighbor_meta, None),
+    )
+    .await?;
+    let other_domain = super::generated::domain::Entity::find()
+        .filter(super::generated::domain::Column::Id.gt(1))
+        .one(&db.0)
+        .await?
+        .unwrap()
+        .id;
+    db.store_payments(u32::try_from(other_domain)?, &address, &fallback[..1])
+        .await?;
+    let other_tx_id = seed_transaction(&db, 1).await?;
+    db.0.execute(sea_orm::Statement::from_sql_and_values(DatabaseBackend::Postgres,
+        "INSERT INTO gas_payment (time_created,domain,msg_id,payment,gas_amount,tx_id,log_index,origin,destination,interchain_gas_paymaster,sequence) SELECT time_created,domain,msg_id,payment,gas_amount,$1,log_index,origin,destination,interchain_gas_paymaster,sequence FROM gas_payment ORDER BY id LIMIT 1",
+        [other_tx_id.into()],
+    )).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let mut resolved = payment_rows(&payments, &meta, Some(tx_id));
+    for row in resolved.iter_mut().skip(1).step_by(2) {
+        row.meta = &neighbor_meta;
+    }
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_repair_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_004);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        6_003
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_repair_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_004);
+    let neighbors = gas_payment::Entity::find()
+        .filter(gas_payment::Column::TxId.is_null())
+        .all(&db.0)
+        .await?;
+    assert_eq!(neighbors.len(), 3);
+    assert!(neighbors.iter().any(
+        |row| row.interchain_gas_paymaster == hyperlane_core::address_to_bytes(&other_address)
+    ));
+    assert!(neighbors.iter().any(|row| row.log_index == 1));
+    assert!(neighbors.iter().any(|row| row.domain == other_domain));
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.eq(other_tx_id))
+            .count(&db.0)
+            .await?,
+        1
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -496,6 +496,26 @@ async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()
             .await?,
         0
     );
+    // Projected reads preserve both NULL/empty and nonempty bodies without transaction metadata.
+    for nonce in [0, 3_250] {
+        let mut expected = rows().nth(nonce as usize).unwrap().msg;
+        expected.version = 3; // Message versions are reconstructed, not stored.
+        assert_eq!(
+            db.retrieve_dispatched_message_by_nonce(DOMAIN, &address, nonce)
+                .await?,
+            Some(expected)
+        );
+    }
+    for (domain, mailbox, nonce) in [
+        (DOMAIN, address, 3_251),
+        (DOMAIN + 1, address, 0),
+        (DOMAIN, H256::from_low_u64_be(2), 0),
+    ] {
+        assert!(db
+            .retrieve_dispatched_message_by_nonce(domain, &mailbox, nonce)
+            .await?
+            .is_none());
+    }
     let stored = super::generated::message::Entity::find().all(&db.0).await?;
     assert_eq!(stored.len(), 3_251);
     for row in stored {
@@ -508,6 +528,46 @@ async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn hash_lookups_read_both_chunks_without_duplicate_results_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let first_tx = seed_transaction(&db, 0).await?;
+    let tail_tx = seed_transaction(&db, 65_000).await?;
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash: H256::from_low_u64_be(65_055),
+            timestamp: 1_700_000_001,
+            number: 501,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let blocks: Vec<_> = (0..66_000).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..66_000).map(H512::from_low_u64_be).collect();
+    let found_blocks = db
+        .get_block_basic(blocks.iter().chain(blocks[55..56].iter()))
+        .await?;
+    assert_eq!(found_blocks.len(), 2);
+    assert!(found_blocks.iter().any(|row| row.hash == blocks[55]));
+    assert!(found_blocks.iter().any(|row| row.hash == blocks[65_055]));
+    let found_txns = db
+        .get_txn_ids(txns.iter().chain(txns[66..67].iter()))
+        .await?;
+    assert_eq!(found_txns.len(), 2);
+    assert_eq!(found_txns[&txns[66]], first_tx);
+    assert_eq!(found_txns[&txns[65_066]], tail_tx);
+    Ok(())
+}
+
 #[tokio::test]
 async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Result<()> {
     use super::generated::{raw_message_dispatch, transaction};

--- a/rust/main/agents/scraper/src/store/deliveries.rs
+++ b/rust/main/agents/scraper/src/store/deliveries.rs
@@ -4,12 +4,11 @@ use async_trait::async_trait;
 use eyre::Result;
 
 use hyperlane_core::{
-    unwrap_or_none_result, Delivery, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader,
-    Indexed, LogMeta, H512,
+    Delivery, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
 };
 
 use crate::db::StorableDelivery;
-use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore, TxnWithId};
+use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore};
 
 #[async_trait]
 impl HyperlaneLogStore<Delivery> for HyperlaneDbStore {
@@ -22,10 +21,9 @@ impl HyperlaneLogStore<Delivery> for HyperlaneDbStore {
         if deliveries.is_empty() {
             return Ok(0);
         }
-        let txns: HashMap<H512, TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(deliveries.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         let storable = deliveries
             .iter()
@@ -67,12 +65,12 @@ impl HyperlaneSequenceAwareIndexerStoreReader<Delivery> for HyperlaneDbStore {
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_delivered_message_tx_id(self.domain.id(), &self.mailbox_address, sequence)
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_delivered_message_block_number(
+                self.domain.id(),
+                &self.mailbox_address,
+                sequence,
+            )
+            .await
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -6,14 +6,14 @@ use std::{
 use async_trait::async_trait;
 use eyre::Result;
 use hyperlane_core::{
-    unwrap_or_none_result, HyperlaneLogStore, HyperlaneMessage,
-    HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
+    HyperlaneLogStore, HyperlaneMessage, HyperlaneSequenceAwareIndexerStoreReader, Indexed,
+    LogMeta, H512,
 };
 use time::OffsetDateTime;
 use tracing::warn;
 
 use crate::db::{StorableMessage, StorableRawMessageDispatch};
-use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore, TxnWithId};
+use crate::store::storage::{txn_id_for_meta, HyperlaneDbStore};
 
 /// Label for raw message dispatch metrics
 const RAW_MESSAGE_DISPATCH_LABEL: &str = "raw_message_dispatch";
@@ -193,10 +193,9 @@ impl HyperlaneDbStore {
         &self,
         messages: &[(Indexed<HyperlaneMessage>, LogMeta)],
     ) -> Result<u32> {
-        let txns: HashMap<H512, TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(messages.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         let (storable, missing_txns) = storable_messages_for_available_txns(messages, &txns);
         let stored = self
@@ -298,10 +297,9 @@ impl HyperlaneDbStore {
             });
         }
 
-        let txns: HashMap<H512, TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(raw_dispatches_to_attempt.iter().map(|r| &r.meta))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         // Start retry delays after the enrichment attempt finishes. A slow RPC batch must
         // not consume the backoff before its missing rows are recorded.
@@ -400,7 +398,7 @@ struct MissingDispatchTxns {
 
 fn storable_messages_for_available_txns<'a>(
     messages: &'a [(Indexed<HyperlaneMessage>, LogMeta)],
-    txns: &HashMap<H512, TxnWithId>,
+    txns: &HashMap<H512, i64>,
 ) -> (Vec<StorableMessage<'a>>, Option<MissingDispatchTxns>) {
     let mut missing_dispatches: usize = 0;
     let mut missing_tx_hashes = Vec::new();
@@ -444,13 +442,9 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneDbS
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_dispatched_tx_id(self.domain.id(), &self.mailbox_address, sequence)
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_dispatched_block_number(self.domain.id(), &self.mailbox_address, sequence)
+            .await
     }
 }
 
@@ -479,13 +473,7 @@ mod tests {
             (indexed_message(0), log_meta(txn_hash)),
             (indexed_message(1), log_meta(txn_hash)),
         ];
-        let txns = HashMap::from([(
-            txn_hash,
-            TxnWithId {
-                hash: txn_hash,
-                id: 7,
-            },
-        )]);
+        let txns = HashMap::from([(txn_hash, 7)]);
 
         let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 
@@ -504,22 +492,7 @@ mod tests {
             (indexed_message(1), log_meta(missing_txn_hash)),
             (indexed_message(2), log_meta(later_found_txn_hash)),
         ];
-        let txns = HashMap::from([
-            (
-                found_txn_hash,
-                TxnWithId {
-                    hash: found_txn_hash,
-                    id: 7,
-                },
-            ),
-            (
-                later_found_txn_hash,
-                TxnWithId {
-                    hash: later_found_txn_hash,
-                    id: 8,
-                },
-            ),
-        ]);
+        let txns = HashMap::from([(found_txn_hash, 7), (later_found_txn_hash, 8)]);
 
         let (storable, missing_txns) = storable_messages_for_available_txns(&messages, &txns);
 

--- a/rust/main/agents/scraper/src/store/payments.rs
+++ b/rust/main/agents/scraper/src/store/payments.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use tracing::debug;
 
 use hyperlane_core::{
-    unwrap_or_none_result, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed,
-    InterchainGasPayment, LogMeta, H512,
+    HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed, InterchainGasPayment,
+    LogMeta, H512,
 };
 
 use crate::db::StorablePayment;
@@ -27,10 +27,9 @@ impl HyperlaneLogStore<InterchainGasPayment> for HyperlaneDbStore {
         if payments.is_empty() {
             return Ok(0);
         }
-        let txns: HashMap<H512, crate::store::storage::TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(payments.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
         let storable = payments
             .iter()
@@ -88,16 +87,12 @@ impl HyperlaneSequenceAwareIndexerStoreReader<InterchainGasPayment> for Hyperlan
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_payment_tx_id(
-                    self.domain.id(),
-                    &self.interchain_gas_paymaster_address,
-                    sequence,
-                )
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_payment_block_number(
+                self.domain.id(),
+                &self.interchain_gas_paymaster_address,
+                sequence,
+            )
+            .await
     }
 }

--- a/rust/main/agents/scraper/src/store/same_chain_ccr_swaps.rs
+++ b/rust/main/agents/scraper/src/store/same_chain_ccr_swaps.rs
@@ -15,10 +15,9 @@ impl HyperlaneLogStore<SameChainCcrSwap> for HyperlaneDbStore {
         if swaps.is_empty() {
             return Ok(0);
         }
-        let txns: HashMap<H512, crate::store::storage::TxnWithId> = self
+        let txns: HashMap<H512, i64> = self
             .ensure_blocks_and_txns(swaps.iter().map(|r| &r.1))
             .await?
-            .map(|t| (t.hash, t))
             .collect();
 
         // filter_map mirrors the dispatch/payment store_logs pattern: if
@@ -38,7 +37,7 @@ impl HyperlaneLogStore<SameChainCcrSwap> for HyperlaneDbStore {
                 txn.map(|t| StorableCcrSwap {
                     swap: swap.inner(),
                     meta,
-                    txn_id: t.id,
+                    txn_id: *t,
                 })
             })
             .collect();

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -7,7 +7,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use eyre::Result;
-use itertools::Itertools;
 use prometheus::IntCounterVec;
 use tracing::{trace, warn};
 
@@ -110,7 +109,7 @@ impl HyperlaneDbStore {
             .map(|(txn_hash, block_id)| TxnWithBlockId { txn_hash, block_id });
         let txns_with_ids = self.ensure_txns(txn_hash_with_block_ids).await?;
 
-        Ok(txns_with_ids.map(move |TxnWithId { hash, id: txn_id }| TxnWithId { hash, id: txn_id }))
+        Ok(txns_with_ids)
     }
 
     /// Takes a list of transaction hashes and the block id the transaction is
@@ -344,13 +343,60 @@ struct TxnWithBlockId {
     block_id: i64,
 }
 
-fn as_chunks<T>(iter: impl Iterator<Item = T>, chunk_size: usize) -> impl Iterator<Item = Vec<T>> {
-    // the itertools chunks function uses refcell which cannot be used across an
-    // await so this stabilizes the result by putting it into a vec of vecs and
-    // using that for iteration.
-    iter.chunks(chunk_size)
-        .into_iter()
-        .map(|chunk| chunk.into_iter().collect())
-        .collect_vec()
-        .into_iter()
+fn as_chunks<T>(
+    mut iter: impl Iterator<Item = T>,
+    chunk_size: usize,
+) -> impl Iterator<Item = Vec<T>> {
+    assert!(chunk_size > 0, "chunk size must be positive");
+    // Own just the current chunk across await points. itertools::chunks keeps
+    // a RefCell borrowed by each chunk, which cannot be held across awaits.
+    std::iter::from_fn(move || {
+        let chunk: Vec<_> = iter.by_ref().take(chunk_size).collect();
+        (!chunk.is_empty()).then_some(chunk)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::as_chunks;
+
+    #[test]
+    fn enrichment_chunks_only_consume_the_requested_batch() {
+        let consumed = Cell::new(0);
+        let input = (0..1_000).inspect(|_| consumed.set(consumed.get() + 1));
+        let mut chunks = as_chunks(input, 50);
+        assert_eq!(consumed.get(), 0);
+        assert_eq!(chunks.next(), Some((0..50).collect()));
+        assert_eq!(consumed.get(), 50);
+        assert_eq!(chunks.next(), Some((50..100).collect()));
+        assert_eq!(consumed.get(), 100);
+        drop(chunks);
+        assert_eq!(
+            consumed.get(),
+            100,
+            "dropping work must not consume later chunks"
+        );
+    }
+
+    #[test]
+    fn enrichment_chunks_preserve_order_and_partial_tail() {
+        assert_eq!(
+            as_chunks(0..5, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3], vec![4]]
+        );
+        assert_eq!(
+            as_chunks(0..4, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3]]
+        );
+        assert_eq!(as_chunks(0..1, 2).collect::<Vec<_>>(), vec![vec![0]]);
+        assert_eq!(as_chunks(0..0, 2).next(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "chunk size must be positive")]
+    fn enrichment_chunks_reject_zero_chunk_size() {
+        let _ = as_chunks(0..1, 0);
+    }
 }

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -82,7 +82,7 @@ impl HyperlaneDbStore {
     pub(crate) async fn ensure_blocks_and_txns(
         &self,
         log_meta: impl Iterator<Item = &LogMeta>,
-    ) -> Result<impl Iterator<Item = TxnWithId>> {
+    ) -> Result<impl Iterator<Item = (H512, i64)>> {
         let block_id_by_txn_hash: HashMap<H512, BlockId> = log_meta
             .filter(|meta| !meta.transaction_id.is_zero() && !meta.block_hash.is_zero())
             .map(|meta| {
@@ -98,14 +98,14 @@ impl HyperlaneDbStore {
         let blocks: HashMap<_, _> = self
             .ensure_blocks(block_id_by_txn_hash.values().copied())
             .await?
-            .map(|block| (block.hash, block))
+            .map(|block| (block.hash, block.id))
             .collect();
         trace!(?blocks, "Ensured blocks");
 
         // We ensure transactions only from blocks which are inserted into database
         let txn_hash_with_block_ids = block_id_by_txn_hash
             .into_iter()
-            .filter_map(move |(txn, block)| blocks.get(&block.hash).map(|b| (txn, b.id)))
+            .filter_map(move |(txn, block)| blocks.get(&block.hash).map(|id| (txn, *id)))
             .map(|(txn_hash, block_id)| TxnWithBlockId { txn_hash, block_id });
         let txns_with_ids = self.ensure_txns(txn_hash_with_block_ids).await?;
 
@@ -123,7 +123,7 @@ impl HyperlaneDbStore {
     async fn ensure_txns(
         &self,
         txns: impl Iterator<Item = TxnWithBlockId>,
-    ) -> Result<impl Iterator<Item = TxnWithId>> {
+    ) -> Result<impl Iterator<Item = (H512, i64)>> {
         // mapping of txn hash to (txn_id, block_id).
         let mut txns: HashMap<H512, (Option<i64>, i64)> = txns
             .map(|TxnWithBlockId { txn_hash, block_id }| (txn_hash, (None, block_id)))
@@ -173,8 +173,18 @@ impl HyperlaneDbStore {
                 continue;
             }
 
-            self.db.store_txns(txns_to_insert.drain(..)).await?;
-            let ids = self.db.get_txn_ids(hashes_to_insert.drain(..)).await?;
+            let mut ids = self.db.store_txns(txns_to_insert.drain(..)).await?;
+            // DO NOTHING can omit concurrent winners. Read those in a fresh statement
+            // after the INSERT, rather than the INSERT's earlier snapshot.
+            let existing = self
+                .db
+                .get_txn_ids(
+                    hashes_to_insert
+                        .drain(..)
+                        .filter(|hash| !ids.contains_key(*hash)),
+                )
+                .await?;
+            ids.extend(existing);
 
             for (hash, (txn_id, _block_id)) in chunk.iter_mut() {
                 *txn_id = ids.get(hash).copied();
@@ -183,8 +193,7 @@ impl HyperlaneDbStore {
 
         let ensured_txns = txns
             .into_iter()
-            .filter_map(|(hash, (txn_id, _))| txn_id.map(|id| (hash, id)))
-            .map(|(hash, id)| TxnWithId { hash, id });
+            .filter_map(|(hash, (txn_id, _))| txn_id.map(|id| (hash, id)));
 
         Ok(ensured_txns)
     }
@@ -201,14 +210,10 @@ impl HyperlaneDbStore {
         &self,
         block_ids: impl Iterator<Item = BlockId>,
     ) -> Result<impl Iterator<Item = BasicBlock>> {
-        // Mapping from block hash to block ids (hash and height)
-        let block_hash_to_block_id_map: HashMap<H256, BlockId> =
-            block_ids.map(|b| (b.hash, b)).collect();
-
-        // Mapping of block hash to `BasicBlock` which contains database block id and block hash.
-        let mut blocks: HashMap<H256, Option<BasicBlock>> = block_hash_to_block_id_map
-            .keys()
-            .map(|hash| (*hash, None))
+        // Keep the requested height beside its enrichment state. Duplicate
+        // hashes retain the last height, matching the input metadata map.
+        let mut blocks: HashMap<H256, (u64, Option<i64>)> = block_ids
+            .map(|block| (block.hash, (block.height, None)))
             .collect();
 
         let db_blocks: Vec<BasicBlock> = if !blocks.is_empty() {
@@ -222,29 +227,25 @@ impl HyperlaneDbStore {
             let _ = blocks
                 .get_mut(&block.hash)
                 .expect("We found a block that we did not request")
-                .insert(block);
+                .1
+                .insert(block.id);
         }
 
         // insert any blocks that were not known and get their IDs
         // use this vec as temporary list of mut refs so we can update their ids once we
         // have inserted them into the database.
-        // Block info is an option so we can move it, must always be Some before
-        // inserted into db.
+        // A temporary -1 id is excluded from the result unless the inserted
+        // block hash resolves to a database id on readback.
         let blocks_to_fetch = blocks
             .iter_mut()
-            .filter(|(_, block_info)| block_info.is_none());
+            .filter(|(_, (_, stored_id))| stored_id.is_none());
 
         for chunk in as_chunks(blocks_to_fetch, CHUNK_SIZE) {
             debug_assert!(!chunk.is_empty());
             let mut block_infos: Vec<BlockInfo> = Vec::with_capacity(CHUNK_SIZE);
-            let mut blocks_to_insert: Vec<&mut BasicBlock> = Vec::with_capacity(CHUNK_SIZE);
-            let mut hashes_to_insert: Vec<&H256> = Vec::with_capacity(CHUNK_SIZE);
-            for (hash, block_info) in chunk {
-                // We should have block_id in this map for every hashes
-                let block_id = block_hash_to_block_id_map
-                    .get(hash)
-                    .expect("Missing block id");
-                let block_height = block_id.height;
+            let mut blocks_to_insert: Vec<(&H256, &mut i64)> = Vec::with_capacity(CHUNK_SIZE);
+            for (hash, (block_height, stored_id)) in chunk {
+                let block_height = *block_height;
 
                 let info = match self.provider.get_block_by_height(block_height).await {
                     Ok(info) => info,
@@ -253,13 +254,9 @@ impl HyperlaneDbStore {
                         continue;
                     }
                 };
-                let basic_info_ref = block_info.insert(BasicBlock {
-                    id: -1,
-                    hash: *hash,
-                });
+                let block_id = stored_id.insert(-1);
                 block_infos.push(info);
-                blocks_to_insert.push(basic_info_ref);
-                hashes_to_insert.push(hash);
+                blocks_to_insert.push((hash, block_id));
             }
 
             // If we have no blocks to insert, we don't store them and we don't update
@@ -268,28 +265,36 @@ impl HyperlaneDbStore {
                 continue;
             }
 
-            self.db
-                .store_blocks(self.domain.id(), block_infos.into_iter())
-                .await?;
-
-            let hashes = self
+            let mut hashes: HashMap<_, _> = self
                 .db
-                .get_block_basic(hashes_to_insert.drain(..))
+                .store_blocks(self.domain.id(), block_infos.into_iter())
                 .await?
                 .into_iter()
-                .map(|b| (b.hash, b.id))
-                .collect::<HashMap<_, _>>();
+                .map(|block| (block.hash, block.id))
+                .collect();
+            // Query only requested hashes omitted by RETURNING, including conflicts
+            // and provider responses carrying a different hash than requested.
+            let existing = self
+                .db
+                .get_block_basic(
+                    blocks_to_insert
+                        .iter()
+                        .map(|(hash, _)| *hash)
+                        .filter(|hash| !hashes.contains_key(*hash)),
+                )
+                .await?;
+            hashes.extend(existing.into_iter().map(|block| (block.hash, block.id)));
 
-            for block_ref in blocks_to_insert {
-                if let Some(id) = hashes.get(&block_ref.hash) {
-                    block_ref.id = *id;
+            for (hash, block_id) in blocks_to_insert {
+                if let Some(id) = hashes.get(hash) {
+                    *block_id = *id;
                 }
             }
         }
 
-        let ensured_blocks = blocks
-            .into_iter()
-            .filter_map(|(hash, block_info)| block_info.filter(|b| b.id != -1));
+        let ensured_blocks = blocks.into_iter().filter_map(|(hash, (_, id))| {
+            id.filter(|id| *id != -1).map(|id| BasicBlock { id, hash })
+        });
 
         Ok(ensured_blocks)
     }
@@ -311,12 +316,6 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct TxnWithId {
-    pub hash: H512,
-    pub id: i64,
-}
-
 /// Resolves the database transaction id for a log's meta.
 ///
 /// - `Some(Some(id))` when the transaction was ensured in the database.
@@ -326,14 +325,11 @@ pub(crate) struct TxnWithId {
 ///   a NULL transaction relation so it remains retrievable by sequence.
 /// - `None` when the transaction could not be fetched; the event is skipped
 ///   and retried later.
-pub(crate) fn txn_id_for_meta(
-    txns: &HashMap<H512, TxnWithId>,
-    meta: &LogMeta,
-) -> Option<Option<i64>> {
+pub(crate) fn txn_id_for_meta(txns: &HashMap<H512, i64>, meta: &LogMeta) -> Option<Option<i64>> {
     if meta.transaction_id.is_zero() && meta.block_hash.is_zero() {
         Some(None)
     } else {
-        txns.get(&meta.transaction_id).map(|txn| Some(txn.id))
+        txns.get(&meta.transaction_id).copied().map(Some)
     }
 }
 
@@ -400,3 +396,9 @@ mod tests {
         let _ = as_chunks(0..1, 0);
     }
 }
+
+#[cfg(test)]
+mod block_tests;
+
+#[cfg(test)]
+mod returning_tests;

--- a/rust/main/agents/scraper/src/store/storage/block_tests.rs
+++ b/rust/main/agents/scraper/src/store/storage/block_tests.rs
@@ -1,0 +1,147 @@
+use std::sync::Mutex;
+
+use migration::MigratorTrait;
+use sea_orm::Database;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use hyperlane_core::{
+    ChainCommunicationError, ChainInfo, ChainResult, HyperlaneChain, HyperlaneDomainProtocol,
+    HyperlaneDomainTechnicalStack, HyperlaneDomainType, TxnInfo, U256,
+};
+
+use super::*;
+
+#[derive(Clone, Debug)]
+struct BlockProvider {
+    domain: HyperlaneDomain,
+    calls: Arc<Mutex<Vec<u64>>>,
+}
+
+impl HyperlaneChain for BlockProvider {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.domain
+    }
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.clone())
+    }
+}
+
+#[async_trait]
+impl HyperlaneProvider for BlockProvider {
+    async fn get_block_by_height(&self, height: u64) -> ChainResult<BlockInfo> {
+        self.calls.lock().unwrap().push(height);
+        let hash = match height {
+            3 => H256::from_low_u64_be(20),
+            4 => {
+                return Err(ChainCommunicationError::from_other_str(
+                    "missing provider block",
+                ))
+            }
+            // A provider returning a different hash must not invent a DB id for
+            // the requested hash when insertion readback cannot find it.
+            5 => H256::from_low_u64_be(99),
+            1_000..=1_050 => H256::from_low_u64_be(height),
+            _ => panic!("unexpected provider lookup at height {height}"),
+        };
+        Ok(BlockInfo {
+            hash,
+            number: height,
+            timestamp: 1_700_000_000,
+        })
+    }
+    async fn get_txn_by_hash(&self, _: &H512) -> ChainResult<TxnInfo> {
+        panic!("unexpected transaction lookup")
+    }
+    async fn is_contract(&self, _: &H256) -> ChainResult<bool> {
+        panic!("unexpected RPC")
+    }
+    async fn get_balance(&self, _: String) -> ChainResult<U256> {
+        panic!("unexpected RPC")
+    }
+    async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
+        panic!("unexpected RPC")
+    }
+}
+
+#[tokio::test]
+async fn block_enrichment_preserves_duplicate_heights_known_rows_and_failed_readbacks(
+) -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let domain = HyperlaneDomain::Unknown {
+        domain_id: 13375,
+        domain_name: "sealeveltest1".to_owned(),
+        domain_type: HyperlaneDomainType::LocalTestChain,
+        domain_protocol: HyperlaneDomainProtocol::Sealevel,
+        domain_technical_stack: HyperlaneDomainTechnicalStack::Other,
+    };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let store = HyperlaneDbStore::new(
+        db,
+        domain.clone(),
+        CoreContractAddresses::default(),
+        Arc::new(BlockProvider {
+            domain,
+            calls: calls.clone(),
+        }),
+        &IndexSettings::default(),
+        None,
+    )
+    .await?;
+    let known_hash = H256::from_low_u64_be(10);
+    store
+        .db
+        .store_blocks(
+            13375,
+            [BlockInfo {
+                hash: known_hash,
+                number: 10,
+                timestamp: 1_700_000_000,
+            }]
+            .into_iter(),
+        )
+        .await?;
+    let input = [
+        BlockId::new(known_hash, 999),
+        BlockId::new(H256::from_low_u64_be(20), 2),
+        BlockId::new(H256::from_low_u64_be(30), 4),
+        BlockId::new(H256::from_low_u64_be(40), 5),
+        BlockId::new(H256::from_low_u64_be(20), 3),
+    ];
+    let found: HashMap<_, _> = store
+        .ensure_blocks(input.into_iter())
+        .await?
+        .map(|block| (block.hash, block.id))
+        .collect();
+    assert_eq!(found.len(), 2);
+    assert!(found[&known_hash] > 0);
+    assert!(found[&H256::from_low_u64_be(20)] > 0);
+    let mut actual_calls = calls.lock().unwrap().clone();
+    actual_calls.sort_unstable();
+    assert_eq!(actual_calls, vec![3, 4, 5]);
+    let replay = [
+        BlockId::new(known_hash, 999),
+        BlockId::new(H256::from_low_u64_be(20), 888),
+    ];
+    assert_eq!(store.ensure_blocks(replay.into_iter()).await?.count(), 2);
+    assert_eq!(store.ensure_blocks(std::iter::empty()).await?.count(), 0);
+    assert_eq!(
+        calls.lock().unwrap().len(),
+        3,
+        "known and empty batches must not query the provider"
+    );
+    let across_chunks =
+        (1_000..=1_050).map(|height| BlockId::new(H256::from_low_u64_be(height), height));
+    let blocks: Vec<_> = store.ensure_blocks(across_chunks).await?.collect();
+    assert_eq!(blocks.len(), 51);
+    assert!(blocks.iter().all(|block| block.id > 0));
+    assert_eq!(calls.lock().unwrap().len(), 54);
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/store/storage/returning_tests.rs
+++ b/rust/main/agents/scraper/src/store/storage/returning_tests.rs
@@ -1,0 +1,258 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use migration::MigratorTrait;
+use sea_orm::{
+    ConnectionTrait, Database, DatabaseBackend, DbErr, MockDatabase, Statement, TransactionTrait,
+    Value,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+use hyperlane_core::{
+    ChainInfo, ChainResult, HyperlaneChain, KnownHyperlaneDomain, TxnInfo, TxnReceiptInfo, U256,
+};
+
+#[derive(Clone, Debug)]
+struct Provider(HyperlaneDomain);
+impl HyperlaneChain for Provider {
+    fn domain(&self) -> &HyperlaneDomain {
+        &self.0
+    }
+    fn provider(&self) -> Box<dyn HyperlaneProvider> {
+        Box::new(self.clone())
+    }
+}
+fn txn_info(hash: H512) -> TxnInfo {
+    TxnInfo {
+        hash,
+        gas_limit: U256::one(),
+        max_priority_fee_per_gas: None,
+        max_fee_per_gas: None,
+        gas_price: None,
+        nonce: 0,
+        sender: H256::zero(),
+        recipient: None,
+        receipt: Some(TxnReceiptInfo {
+            gas_used: U256::one(),
+            cumulative_gas_used: U256::one(),
+            effective_gas_price: None,
+        }),
+        raw_input_data: None,
+    }
+}
+#[async_trait]
+impl HyperlaneProvider for Provider {
+    async fn get_block_by_height(&self, height: u64) -> ChainResult<BlockInfo> {
+        Ok(BlockInfo {
+            hash: H256::from_low_u64_be(height),
+            number: height,
+            timestamp: 1_700_000_000,
+        })
+    }
+    async fn get_txn_by_hash(&self, hash: &H512) -> ChainResult<TxnInfo> {
+        Ok(txn_info(*hash))
+    }
+    async fn is_contract(&self, _: &H256) -> ChainResult<bool> {
+        panic!("unexpected RPC")
+    }
+    async fn get_balance(&self, _: String) -> ChainResult<U256> {
+        panic!("unexpected RPC")
+    }
+    async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
+        panic!("unexpected RPC")
+    }
+}
+async fn store(db: ScraperDb) -> eyre::Result<HyperlaneDbStore> {
+    let domain: HyperlaneDomain = KnownHyperlaneDomain::Ethereum.into();
+    HyperlaneDbStore::new(
+        db,
+        domain.clone(),
+        CoreContractAddresses::default(),
+        Arc::new(Provider(domain)),
+        &IndexSettings::default(),
+        None,
+    )
+    .await
+}
+fn row(id: i64, hash: Vec<u8>) -> BTreeMap<String, Value> {
+    BTreeMap::from([("id".into(), id.into()), ("hash".into(), hash.into())])
+}
+async fn ensure(
+    store: &HyperlaneDbStore,
+    txn: bool,
+    count: u64,
+) -> eyre::Result<HashMap<H512, i64>> {
+    if txn {
+        Ok(store
+            .ensure_txns((1..=count).map(|n| TxnWithBlockId {
+                txn_hash: H512::from_low_u64_be(n),
+                block_id: 1,
+            }))
+            .await?
+            .collect())
+    } else {
+        Ok(store
+            .ensure_blocks((1..=count).map(|n| BlockId::new(H256::from_low_u64_be(n), n)))
+            .await?
+            .map(|b| (H512::from_low_u64_be(b.hash.to_low_u64_be()), b.id))
+            .collect())
+    }
+}
+#[tokio::test]
+async fn enrichment_returning_only_queries_missing_hashes() -> eyre::Result<()> {
+    for txn in [false, true] {
+        for returned in [0, 1, 2] {
+            let hash = |n| {
+                if txn {
+                    hyperlane_core::h512_to_bytes(&H512::from_low_u64_be(n))
+                } else {
+                    hyperlane_core::h256_to_bytes(&H256::from_low_u64_be(n))
+                }
+            };
+            let mut results = vec![
+                vec![],
+                vec![],
+                (1..=returned).map(|n| row(n as i64, hash(n))).collect(),
+            ];
+            if returned < 2 {
+                results.push(
+                    ((returned + 1)..=2)
+                        .map(|n| row(n as i64, hash(n)))
+                        .collect(),
+                );
+            }
+            let db = ScraperDb::with_connection(
+                MockDatabase::new(DatabaseBackend::Postgres)
+                    .append_query_results(results)
+                    .into_connection(),
+            );
+            let store = store(db).await?;
+            assert_eq!(
+                ensure(&store, txn, 2).await?,
+                HashMap::from([(H512::from_low_u64_be(1), 1), (H512::from_low_u64_be(2), 2)])
+            );
+            let log = store.db.clone_connection().into_transaction_log();
+            // Exclude the cursor initialization SELECT.
+            assert_eq!(log.len() - 1, if returned == 2 { 2 } else { 3 });
+            let insert = &log[2].statements()[0];
+            assert!(
+                insert.sql.ends_with("RETURNING \"id\", \"hash\""),
+                "{}",
+                insert.sql
+            );
+            assert!(insert.sql.contains("DO NOTHING"));
+            if returned < 2 {
+                let lookup = &log[3].statements()[0];
+                assert_eq!(
+                    lookup.values.as_ref().unwrap().0.len(),
+                    (2 - returned) as usize
+                );
+                for n in (returned + 1)..=2 {
+                    assert!(lookup.values.as_ref().unwrap().0.contains(&hash(n).into()));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+#[tokio::test]
+async fn enrichment_returning_errors_and_empty_inputs_preserve_boundaries() -> eyre::Result<()> {
+    for txn in [false, true] {
+        for insertion_fails in [false, true] {
+            let mut db = MockDatabase::new(DatabaseBackend::Postgres).append_query_results(vec![
+                    Vec::<
+                        BTreeMap<String, Value>,
+                    >::new(
+                    );
+                    if insertion_fails {
+                        2
+                    } else {
+                        3
+                    }
+                ]);
+            db = db.append_query_errors([DbErr::Custom("enrichment read/write failed".into())]);
+            let store = store(ScraperDb::with_connection(db.into_connection())).await?;
+            assert!(ensure(&store, txn, 0).await?.is_empty());
+            assert!(store
+                .db
+                .store_blocks(1, std::iter::empty())
+                .await?
+                .is_empty());
+            assert!(store.db.store_txns(std::iter::empty()).await?.is_empty());
+            let error = ensure(&store, txn, 1).await.unwrap_err();
+            assert!(format!("{error:#}").contains("enrichment read/write failed"));
+            assert_eq!(
+                store.db.clone_connection().into_transaction_log().len(),
+                if insertion_fails { 3 } else { 4 }
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn enrichment_returning_observes_concurrent_conflict_winner_in_postgres() -> eyre::Result<()>
+{
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let store = store(ScraperDb::with_connection(connection)).await?;
+    let connection = store.db.clone_connection();
+    for txn in [false, true] {
+        let winner = connection.begin().await?;
+        let (table, sql) = if txn {
+            ("transaction", "INSERT INTO \"transaction\" (time_created,hash,block_id,gas_limit,nonce,sender,gas_used,cumulative_gas_used) VALUES (now(),$1,$2,1,0,$3,1,1) RETURNING id")
+        } else {
+            ("block", "INSERT INTO \"block\" (time_created,hash,domain,height,timestamp) VALUES (now(),$1,1,1,now()) RETURNING id")
+        };
+        let mut params: Vec<Value> =
+            vec![hyperlane_core::h256_to_bytes(&H256::from_low_u64_be(1)).into()];
+        if txn {
+            let block_id = store
+                .db
+                .get_block_basic([&H256::from_low_u64_be(1)].into_iter())
+                .await?[0]
+                .id;
+            params.extend([
+                block_id.into(),
+                hyperlane_core::address_to_bytes(&H256::zero()).into(),
+            ]);
+        }
+        let winner_id: i64 = winner
+            .query_one(Statement::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                sql,
+                params,
+            ))
+            .await?
+            .unwrap()
+            .try_get("", "id")?;
+        let waiting_insert = format!("INSERT INTO \"{table}\"%");
+        let commit_when_blocked = async {
+            tokio::time::timeout(Duration::from_secs(10), async {
+                loop {
+                    let row = connection.query_one(Statement::from_sql_and_values(DatabaseBackend::Postgres,
+                        "SELECT COUNT(*) AS waiting FROM pg_stat_activity WHERE wait_event_type = 'Lock' AND query LIKE $1", [waiting_insert.clone().into()])).await?.unwrap();
+                    if row.try_get::<i64>("", "waiting")? > 0 { break; }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Ok::<_, eyre::Report>(())
+            }).await??;
+            winner.commit().await?;
+            Ok::<_, eyre::Report>(())
+        };
+        let (found, ()) = tokio::try_join!(ensure(&store, txn, 1), commit_when_blocked)?;
+        assert_eq!(found[&H512::from_low_u64_be(1)], winner_id);
+        assert_eq!(
+            ensure(&store, txn, 1).await?,
+            found,
+            "replay keeps the winner ID"
+        );
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/store/tests.rs
+++ b/rust/main/agents/scraper/src/store/tests.rs
@@ -24,10 +24,7 @@ use crate::db::{
     StorableTxn,
 };
 
-use super::{
-    storage::{txn_id_for_meta, TxnWithId},
-    HyperlaneDbStore,
-};
+use super::{storage::txn_id_for_meta, HyperlaneDbStore};
 
 /// Domain id seeded by the domain table migration (`sealeveltest1`).
 const TEST_DOMAIN_ID: u32 = 13375;
@@ -394,13 +391,7 @@ fn null_transaction_relation_requires_exact_fallback_sentinel() {
         block_hash: H256::from_low_u64_be(1),
         ..fallback
     };
-    let txns = HashMap::from([(
-        tx_hash,
-        TxnWithId {
-            hash: tx_hash,
-            id: 7,
-        },
-    )]);
+    let txns = HashMap::from([(tx_hash, 7)]);
     assert_eq!(txn_id_for_meta(&txns, &resolved), Some(Some(7)));
 }
 
@@ -653,24 +644,60 @@ async fn test_fallback_events_persist_and_survive_restart() -> eyre::Result<()> 
     assert_eq!(
         store
             .db
-            .retrieve_dispatched_tx_id(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
+            .retrieve_dispatched_block_number(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
     assert_eq!(
         store
             .db
-            .retrieve_delivered_message_tx_id(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
+            .retrieve_delivered_message_block_number(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
     assert_eq!(
         store
             .db
-            .retrieve_payment_tx_id(TEST_DOMAIN_ID, &igp, SEQUENCE)
+            .retrieve_payment_block_number(TEST_DOMAIN_ID, &igp, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
+    // Lookup scoping must survive SQL composition: another domain, address,
+    // or sequence cannot borrow this event's resolved block height.
+    for (domain, address, sequence) in [
+        (TEST_DESTINATION_DOMAIN_ID, mailbox, SEQUENCE),
+        (TEST_DOMAIN_ID, H256::from_low_u64_be(9999), SEQUENCE),
+        (TEST_DOMAIN_ID, mailbox, SEQUENCE + 100),
+    ] {
+        assert_eq!(
+            store
+                .db
+                .retrieve_dispatched_block_number(domain, &address, sequence)
+                .await?,
+            None
+        );
+        assert_eq!(
+            store
+                .db
+                .retrieve_delivered_message_block_number(domain, &address, sequence)
+                .await?,
+            None
+        );
+    }
+    for (origin, address, sequence) in [
+        (TEST_DESTINATION_DOMAIN_ID, igp, SEQUENCE),
+        (TEST_DOMAIN_ID, H256::from_low_u64_be(9999), SEQUENCE),
+        (TEST_DOMAIN_ID, igp, SEQUENCE + 100),
+    ] {
+        assert_eq!(
+            store
+                .db
+                .retrieve_payment_block_number(origin, &address, sequence)
+                .await?,
+            None
+        );
+    }
+
     let raw = store
         .db
         .retrieve_raw_message_dispatch_by_id(&message.id())


### PR DESCRIPTION
## Problem

Scraper reads performed multiple queries to resolve sequence block heights, accepted unbounded hash lists, retained duplicate enrichment state, and reread identifiers immediately after successful inserts.

## Solution

Resolve sequence block heights with one joined query while preserving selection rules and missing-metadata behavior. Bound/dedupe hash lookups, project only sequence reconstruction fields, compact block/transaction maps, and reuse narrow INSERT RETURNING identifiers. Conflict winners omitted by DO NOTHING are still queried in a separate later statement, preserving concurrent-commit visibility. Missing-provider metadata, fallback sentinels, and event payloads retain their behavior.

Consolidates #9468, #9485, #9500, #9502, #9510, and #9515. Stacked on #9476's consolidated ingestion changes.

## Numerical evidence

- Sequence-to-block lookup: 3→1 SELECTs. Sequence event projections: delivery 7→1, message 11→6, payment 12→4, Merkle 6→3 columns; these are column counts, not byte or latency percentages.
- 66,000 unique hashes use two bounded SELECTs (65,000 binds maximum each); empty lookups use zero queries.
- Fresh enrichment within one chunk: 3→2 commands per entity, or 6→4 for both block and transaction. Conflict/mixed cases retain the fallback SELECT.
- Synthetic allocation probes of actual map layouts: 1,000 unique block states 315,408→116,744 requested bytes (inner-table probe, excluding the outer consumer map); 1,000 transaction consumer entries 560,684→298,796 bytes. These cover collection allocation traffic, not process RSS, and do not imply RPC savings.

## Validation

This consolidated intermediate tree passed 62 scraper tests (0 failures, 1 ignored; 27.66s). Actual PostgreSQL tests cover missing/duplicate hashes, wrong provider hashes, payload reconstruction, and a blocked unique-key insert followed by a committed concurrent winner. Mock tests verify SQL projection/count/bind/error boundaries.

New strict scraper production Clippy passed (40.61s), and normal commit hooks passed (exit 0).
