### PR TITLE
perf(metrics): reduce per-chain value-at-risk log amplification

### DIFF
--- a/.changeset/quiet-derived-risk-logs.md
+++ b/.changeset/quiet-derived-risk-logs.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+Moved per-chain value-at-risk success logs to debug level to reduce repeated log serialization and ingestion in warp monitors and rebalancers. Retained per-token balance/value observations at info level and preserved all metric series.

--- a/typescript/metrics/src/update.test.ts
+++ b/typescript/metrics/src/update.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import { pino } from 'pino';
+import { Registry } from 'prom-client';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+
+import { createWarpMetricsGauges } from './gauges.js';
+import { updateTokenBalanceMetrics } from './update.js';
+
+function collect(level: string, valueUSD: number | undefined) {
+  const registry = new Registry();
+  const records: string[] = [];
+  const logger = pino(
+    { level },
+    {
+      write: (record: string) => {
+        records.push(record);
+      },
+    },
+  );
+  const tokens = Array.from(
+    { length: 20 },
+    (_, index) =>
+      new Token({
+        chainName: `chain${index}`,
+        standard: TokenStandard.EvmHypCollateral,
+        addressOrDenom: `0x${String(index + 1).padStart(40, '0')}`,
+        decimals: 18,
+        symbol: 'TOKEN',
+        name: 'Token',
+      }),
+  );
+  const warpCore = new WarpCore(new MultiProtocolProvider({}), tokens);
+  updateTokenBalanceMetrics(
+    createWarpMetricsGauges(registry),
+    warpCore,
+    tokens[0]!,
+    { balance: 3, valueUSD, tokenAddress: tokens[0]!.addressOrDenom },
+    'TEST/metric-logging',
+    logger,
+  );
+  return { registry, records };
+}
+
+describe('value-at-risk log volume', () => {
+  it('retains every metric while emitting only per-token observations at info', async () => {
+    const info = collect('info', 12);
+    const debug = collect('debug', 12);
+    expect(info.records).to.have.length(2);
+    expect(debug.records).to.have.length(22);
+    expect(info.records[0]).to.include('Wallet balance updated for token');
+    expect(info.records[1]).to.include('Wallet value updated for token');
+    expect(
+      debug.records.filter((record) => record.includes('Value at risk on ')),
+    ).to.have.length(20);
+    expect(await info.registry.metrics()).to.equal(
+      await debug.registry.metrics(),
+    );
+    const values = (
+      await info.registry
+        .getSingleMetric('hyperlane_warp_route_value_at_risk')!
+        .get()
+    ).values;
+    expect(values).to.have.length(20);
+    expect(values.every(({ value }) => value === 12)).to.equal(true);
+  });
+
+  it('preserves zero USD values and the balance-only path without a price', async () => {
+    const zero = collect('info', 0);
+    const missing = collect('info', undefined);
+    expect(zero.records).to.have.length(2);
+    const zeroValues = (
+      await zero.registry
+        .getSingleMetric('hyperlane_warp_route_value_at_risk')!
+        .get()
+    ).values;
+    expect(zeroValues.every(({ value }) => value === 0)).to.equal(true);
+    expect(missing.records).to.have.length(1);
+    const missingValues = (
+      await missing.registry
+        .getSingleMetric('hyperlane_warp_route_value_at_risk')!
+        .get()
+    ).values;
+    expect(missingValues).to.have.length(0);
+  });
+});

--- a/typescript/metrics/src/update.ts
+++ b/typescript/metrics/src/update.ts
@@ -93,7 +93,9 @@ export function updateTokenBalanceMetrics(
       gauges.warpRouteValueAtRisk
         .labels({ ...labels })
         .set(balanceInfo.valueUSD);
-      logger.info(
+      // The per-token value above already records this observation at info.
+      // Per-chain copies are derived metric detail and can dominate fleet logs.
+      logger.debug(
         {
           labels,
           valueUSD: balanceInfo.valueUSD,


### PR DESCRIPTION
## Problem

Production warp-monitor logs repeat each observed token USD value once per route chain after already logging the token's balance and value. In a read-only 60-minute sample on 2026-09-05, these derived value-at-risk success messages accounted for **5,487 of 11,706 records (46.9%)** and **3,458,036 of 8,680,821 serialized bytes (39.8%)**. The sample was below its 20,000-line cap. Prometheus exposed 923 value-at-risk series for the centralized monitor.

## Solution

Move only per-chain value-at-risk success messages to debug in the shared metrics helper. Keep token balance/value observations at info, all warnings/errors, and every Prometheus series. No transaction/audit records or RPC behavior change. The shared helper also serves rebalancers. Includes a metrics patch changeset.

Stacked on #9464; this PR is the incremental logging slice.

## Performance evidence

| Work | Before | After |
| --- | ---: | ---: |
| Info records per priced token in a 20-chain fixture | 22 | 2 (-90.9%) |
| Value-at-risk metric series in that fixture | 20 | 20, identical values/labels |
| Detailed records with debug enabled | 22 | 22 |

The original source fails the new info-volume regression with 22 records; the changed source passes with 2. Full metric exports match between info and debug, including zero and missing-price behavior.

For the observed production log mix, moving the same messages out of info would avoid 5,487 records and 3.46 MB serialized text per hour. That is a workload-based estimate, not a deployed result or measured CPU/billing saving. Debug-enabled deployments retain detailed volume.

## Validation

- Shared metrics: 13 tests passed; warp-monitor: 42 tests passed.
- Metrics TypeScript build, Oxlint, Oxfmt and `git diff --check` passed.
- Focused reproduction: `pnpm -C typescript/metrics exec mocha --config .mocharc.json src/update.test.ts --exit`.
- Self-review traced shared consumers and existing log-dependent tests; retained their wallet-balance info event. No new abstractions or logging configuration.

Local tests used the node_modules-only core-js compatibility shim documented in #9464. No dependency lockfile changes, deployment or live post-change measurement.


---

Superseded by consolidated draft #9504: [perf(metrics): reduce warp monitoring reads and log volume](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9504). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
