### PR TITLE
perf(validator): reduce checkpoint verification and backfill overhead

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -13,7 +13,7 @@ use hyperlane_core::rpc_clients::call_and_retry_indefinitely;
 use hyperlane_core::{
     accumulator::incremental::{IncrementalMerkle, MerkleTreeSnapshot},
     Checkpoint, CheckpointAtBlock, CheckpointWithMessageId, HyperlaneChain, HyperlaneContract,
-    HyperlaneDomain, HyperlaneSignerExt, IncrementalMerkleAtBlock,
+    HyperlaneDomain, HyperlaneSignerExt, IncrementalMerkleAtBlock, H256,
 };
 use hyperlane_core::{
     ChainResult, HyperlaneSigner, MerkleTreeHook, ReorgEvent, ReorgPeriod, SignedType,
@@ -24,6 +24,27 @@ use crate::reorg_reporter::ReorgReporter;
 use crate::server::ValidatorReadiness;
 
 const CHECKPOINT_SUBMISSION_CHUNK_INTERVAL: Duration = Duration::from_millis(100);
+
+// All queued checkpoints share the hook address and domain of the final verified
+// checkpoint. Retain only the fields that vary until that correctness gate passes.
+struct QueuedCheckpoint {
+    root: H256,
+    index: u32,
+    message_id: H256,
+}
+
+impl QueuedCheckpoint {
+    fn into_checkpoint(self, verified_checkpoint: Checkpoint) -> CheckpointWithMessageId {
+        CheckpointWithMessageId {
+            checkpoint: Checkpoint {
+                root: self.root,
+                index: self.index,
+                ..verified_checkpoint
+            },
+            message_id: self.message_id,
+        }
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct ValidatorSubmitter {
@@ -74,17 +95,17 @@ impl ValidatorSubmitter {
         }
     }
 
-    pub(crate) fn checkpoint(&self, tree: &IncrementalMerkle) -> Checkpoint {
+    fn checkpoint(&self, root: H256, index: u32) -> Checkpoint {
         Checkpoint {
             merkle_tree_hook_address: self.merkle_tree_hook.address(),
             mailbox_domain: self.merkle_tree_hook.domain().id(),
-            root: tree.root(),
-            index: tree.index(),
+            root,
+            index,
         }
     }
 
     pub(crate) fn checkpoint_at_block(&self, tree: &IncrementalMerkleAtBlock) -> CheckpointAtBlock {
-        let checkpoint = self.checkpoint(&tree.tree);
+        let checkpoint = self.checkpoint(tree.tree.root(), tree.tree.index());
 
         CheckpointAtBlock {
             checkpoint,
@@ -343,16 +364,19 @@ impl ValidatorSubmitter {
             let message_id = insertion.message_id();
             tree.ingest(message_id);
 
-            let checkpoint = self.checkpoint(tree);
-
-            checkpoint_queue.push(CheckpointWithMessageId {
-                checkpoint,
+            checkpoint_queue.push(QueuedCheckpoint {
+                root: tree.root(),
+                index: tree.index(),
                 message_id,
             });
         }
 
+        let root = checkpoint_queue
+            .last()
+            .map(|checkpoint| checkpoint.root)
+            .unwrap_or_else(|| tree.root());
         info!(
-            root = ?tree.root(),
+            ?root,
             queue_length = checkpoint_queue.len(),
             "Ingested leaves into in-memory merkle tree"
         );
@@ -366,13 +390,13 @@ impl ValidatorSubmitter {
             tree.index(),
         );
 
-        let checkpoint = self.checkpoint(tree);
+        let checkpoint = self.checkpoint(root, tree.index());
 
         // If the tree's checkpoint doesn't match the correctness checkpoint, something went wrong
         // and we bail loudly.
         if checkpoint != correctness_checkpoint.checkpoint {
             let reorg_event = ReorgEvent::new(
-                tree.root(),
+                root,
                 correctness_checkpoint.root,
                 checkpoint.index,
                 chrono::Utc::now().timestamp() as u64,
@@ -419,7 +443,12 @@ impl ValidatorSubmitter {
                 queue_len = checkpoint_queue.len(),
                 "Reached tree consistency"
             );
-            self.sign_and_submit_checkpoints(checkpoint_queue).await;
+            self.sign_and_submit_checkpoints(
+                checkpoint_queue
+                    .into_iter()
+                    .map(move |queued| queued.into_checkpoint(checkpoint)),
+            )
+            .await;
 
             info!(
                 index = checkpoint.index,
@@ -460,7 +489,8 @@ impl ValidatorSubmitter {
             Ok(Some(existing)) => match existing.recover() {
                 Ok(signer)
                     if signer == self.signer.eth_address()
-                        && existing.value.checkpoint == self.checkpoint(&tree) =>
+                        && existing.value.checkpoint
+                            == self.checkpoint(tree.root(), tree.index()) =>
                 {
                     info!(
                         snapshot_index = snapshot.index,
@@ -577,19 +607,61 @@ impl ValidatorSubmitter {
         Ok(true)
     }
 
+    /// Publishes availability only after the highest checkpoint itself is durable.
+    async fn publish_latest_checkpoint_index(self: &Arc<Self>, index: u32) {
+        call_and_retry_indefinitely(|| {
+            let self_clone = self.clone();
+            Box::pin(async move {
+                let start = Instant::now();
+                let result = self_clone
+                    .checkpoint_syncer
+                    .update_latest_index(index)
+                    .await;
+                match result {
+                    Ok(()) => self_clone
+                        .readiness
+                        .mark_operation_ready("checkpoint_latest_index"),
+                    Err(error) => {
+                        let snapshot = self_clone
+                            .readiness
+                            .mark_operation_blocked("checkpoint_latest_index");
+                        warn!(
+                            operation = "checkpoint_latest_index",
+                            consecutive_failures = snapshot.consecutive_failures,
+                            failure_duration_ms = snapshot.failure_duration_ms,
+                            signing_blocked = snapshot.signing_blocked,
+                            "Validator latest checkpoint index update is blocked"
+                        );
+                        return Err(error.into());
+                    }
+                }
+                tracing::trace!(
+                    elapsed=?start.elapsed(),
+                    "Updated latest index",
+                );
+                Ok(())
+            })
+        })
+        .await;
+    }
+
     /// Signs and submits any previously unsubmitted checkpoints.
-    async fn sign_and_submit_checkpoints(&self, mut checkpoints: Vec<CheckpointWithMessageId>) {
-        // The checkpoints are ordered by index, so the last one is the highest index.
-        let last_checkpoint_index = match checkpoints.last() {
-            Some(c) => c.index,
+    async fn sign_and_submit_checkpoints<I>(&self, checkpoints: I)
+    where
+        I: IntoIterator<Item = CheckpointWithMessageId>,
+        I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+    {
+        // Reconstruct compact queue entries only as their signing chunk is consumed.
+        // The input is ordered by index, so reversing starts with the highest index.
+        let mut checkpoints = checkpoints.into_iter().rev().peekable();
+        let mut latest_index_to_publish = match checkpoints.peek() {
+            Some(c) => Some(c.index),
             None => return,
         };
 
         let arc_self = Arc::new(self.clone());
 
-        let mut first_chunk = true;
-
-        while !checkpoints.is_empty() {
+        while checkpoints.len() > 0 {
             let start = Instant::now();
 
             // Take a chunk of checkpoints, starting with the highest index.
@@ -597,56 +669,58 @@ impl ValidatorSubmitter {
             // since those are the most likely to make messages become processable.
             // A side effect is that new checkpoints will also be submitted in reverse order.
 
-            // This logic is a bit awkward, but we want control over the chunks so we can also
-            // write the latest index to the checkpoint storage after the first chunk is successful.
-            let mut chunk = Vec::with_capacity(self.max_sign_concurrency);
-            for _ in 0..self.max_sign_concurrency {
-                if let Some(cp) = checkpoints.pop() {
-                    chunk.push(cp);
-                } else {
-                    break;
-                }
-            }
-
-            let chunk_len = chunk.len();
-
-            let futures = chunk.into_iter().map(|checkpoint| {
+            // Keep bounded chunks so a storage/signing burst is paced before the next chunk.
+            let chunk_len = checkpoints.len().min(self.max_sign_concurrency);
+            let chunk = checkpoints.by_ref().take(self.max_sign_concurrency);
+            let futures = chunk.map(|checkpoint| {
                 let self_clone = arc_self.clone();
-                let operation = format!("checkpoint_submission[{}]", checkpoint.index);
-                call_and_retry_indefinitely(move || {
-                    let self_clone = self_clone.clone();
-                    let operation = operation.clone();
-                    Box::pin(async move {
-                        let start = Instant::now();
-                        let checkpoint_index = checkpoint.index;
-                        let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
-                        let wrote_checkpoint = match result {
-                            Ok(wrote_checkpoint) => {
-                                self_clone.readiness.mark_operation_ready(&operation);
-                                wrote_checkpoint
-                            }
-                            Err(error) => {
-                                let snapshot =
-                                    self_clone.readiness.mark_operation_blocked(&operation);
-                                warn!(
-                                    operation,
-                                    consecutive_failures = snapshot.consecutive_failures,
-                                    failure_duration_ms = snapshot.failure_duration_ms,
-                                    signing_blocked = snapshot.signing_blocked,
-                                    "Validator checkpoint submission is blocked"
-                                );
-                                return Err(error);
-                            }
-                        };
-                        tracing::info!(
-                            index = checkpoint_index,
-                            wrote_checkpoint,
-                            elapsed=?start.elapsed(),
-                            "Processed checkpoint",
-                        );
-                        Ok(wrote_checkpoint)
+                // The first popped checkpoint alone owns publication, even if a caller
+                // supplied the same maximum index more than once.
+                let latest_index = latest_index_to_publish.take();
+                async move {
+                    let operation = format!("checkpoint_submission[{}]", checkpoint.index);
+                    let wrote_checkpoint = call_and_retry_indefinitely(|| {
+                        let self_clone = self_clone.clone();
+                        let operation = operation.clone();
+                        Box::pin(async move {
+                            let start = Instant::now();
+                            let checkpoint_index = checkpoint.index;
+                            let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
+                            let wrote_checkpoint = match result {
+                                Ok(wrote_checkpoint) => {
+                                    self_clone.readiness.mark_operation_ready(&operation);
+                                    wrote_checkpoint
+                                }
+                                Err(error) => {
+                                    let snapshot =
+                                        self_clone.readiness.mark_operation_blocked(&operation);
+                                    warn!(
+                                        operation,
+                                        consecutive_failures = snapshot.consecutive_failures,
+                                        failure_duration_ms = snapshot.failure_duration_ms,
+                                        signing_blocked = snapshot.signing_blocked,
+                                        "Validator checkpoint submission is blocked"
+                                    );
+                                    return Err(error);
+                                }
+                            };
+                            tracing::info!(
+                                index = checkpoint_index,
+                                wrote_checkpoint,
+                                elapsed=?start.elapsed(),
+                                "Processed checkpoint",
+                            );
+                            Ok(wrote_checkpoint)
+                        })
                     })
-                })
+                    .await;
+                    // Lower checkpoints may still be retrying. The latest index is an upper
+                    // bound, not a claim that every historical checkpoint has been uploaded.
+                    if let Some(index) = latest_index {
+                        self_clone.publish_latest_checkpoint_index(index).await;
+                    }
+                    wrote_checkpoint
+                }
             });
 
             let wrote_checkpoint = join_all(futures).await.into_iter().any(|wrote| wrote);
@@ -658,48 +732,9 @@ impl ValidatorSubmitter {
                 "Signed and submitted checkpoint chunk",
             );
 
-            // If it's the first chunk, update the latest index
-            if first_chunk {
-                call_and_retry_indefinitely(|| {
-                    let self_clone = self.clone();
-                    Box::pin(async move {
-                        let start = Instant::now();
-                        let result = self_clone
-                            .checkpoint_syncer
-                            .update_latest_index(last_checkpoint_index)
-                            .await;
-                        match result {
-                            Ok(()) => self_clone
-                                .readiness
-                                .mark_operation_ready("checkpoint_latest_index"),
-                            Err(error) => {
-                                let snapshot = self_clone
-                                    .readiness
-                                    .mark_operation_blocked("checkpoint_latest_index");
-                                warn!(
-                                    operation = "checkpoint_latest_index",
-                                    consecutive_failures = snapshot.consecutive_failures,
-                                    failure_duration_ms = snapshot.failure_duration_ms,
-                                    signing_blocked = snapshot.signing_blocked,
-                                    "Validator latest checkpoint index update is blocked"
-                                );
-                                return Err(error.into());
-                            }
-                        }
-                        tracing::trace!(
-                            elapsed=?start.elapsed(),
-                            "Updated latest index",
-                        );
-                        Ok(())
-                    })
-                })
-                .await;
-                first_chunk = false;
-            }
-
             // Pace storage/signing bursts between chunks without delaying the latest-index
             // update, throttling all-existing backfills, or adding a final-chunk tail.
-            if wrote_checkpoint && !checkpoints.is_empty() {
+            if wrote_checkpoint && checkpoints.len() > 0 {
                 sleep(CHECKPOINT_SUBMISSION_CHUNK_INTERVAL).await;
             }
         }

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -102,6 +102,380 @@ fn dummy_readiness() -> Arc<ValidatorReadiness> {
     Arc::new(ValidatorReadiness::default())
 }
 
+fn submission_test_submitter(
+    syncer: MockCheckpointSyncer,
+    readiness: Arc<ValidatorReadiness>,
+) -> ValidatorSubmitter {
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        2,
+        Arc::new(MockReorgReporter::new()),
+        readiness,
+    )
+}
+
+fn submission_checkpoint(index: u32) -> CheckpointWithMessageId {
+    CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index,
+        },
+        message_id: H256::zero(),
+    }
+}
+
+#[test]
+fn compact_checkpoint_queue_entry_layout() {
+    let full = std::mem::size_of::<CheckpointWithMessageId>();
+    let compact = std::mem::size_of::<QueuedCheckpoint>();
+    println!("checkpoint queue logical entry bytes: {full} -> {compact}");
+    assert!(compact < full);
+}
+
+#[tokio::test(start_paused = true)]
+async fn compact_queue_replays_exact_checkpoints_only_after_final_insertion() {
+    let namespace = Checkpoint {
+        root: H256::zero(),
+        merkle_tree_hook_address: H256::from_low_u64_be(123),
+        mailbox_domain: 17,
+        index: 0,
+    };
+    let mut tree = IncrementalMerkle::default();
+    let expected: Vec<_> = (0..5)
+        .map(|index| {
+            let message_id = H256::from_low_u64_be(u64::from(index) + 1);
+            tree.ingest(message_id);
+            CheckpointWithMessageId {
+                checkpoint: Checkpoint {
+                    root: tree.root(),
+                    index,
+                    ..namespace
+                },
+                message_id,
+            }
+        })
+        .collect();
+    let final_read = Arc::new(AtomicBool::new(false));
+    let mut db = MockDb::new();
+    db.expect_retrieve_merkle_tree_insertion_by_leaf_index()
+        .times(5)
+        .returning({
+            let expected = expected.clone();
+            let final_read = Arc::clone(&final_read);
+            move |index| {
+                let index = *index;
+                if index == 4 {
+                    final_read.store(true, Ordering::SeqCst);
+                }
+                Ok(Some(MerkleTreeInsertion::new(
+                    index,
+                    expected[index as usize].message_id,
+                )))
+            }
+        });
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    let signer_address = signer.eth_address();
+    let writes = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer.expect_fetch_checkpoint().times(5).returning({
+        let final_read = Arc::clone(&final_read);
+        move |_| {
+            assert!(final_read.load(Ordering::SeqCst));
+            Ok(None)
+        }
+    });
+    syncer.expect_write_checkpoint().times(5).returning({
+        let expected = expected.clone();
+        let writes = Arc::clone(&writes);
+        move |signed| {
+            assert_eq!(signed.value, expected[signed.value.index as usize]);
+            assert_eq!(signed.recover().unwrap(), signer_address);
+            writes.lock().unwrap().push(signed.value.index);
+            Ok(())
+        }
+    });
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(4))
+        .once()
+        .returning(|_| Ok(()));
+    let mut hook = MockMerkleTreeHook::new();
+    hook.expect_address()
+        .return_const(namespace.merkle_tree_hook_address);
+    hook.expect_domain()
+        .return_const(dummy_domain(17, "queue_domain"));
+    let submitter = ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(hook),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(syncer),
+        Arc::new(db),
+        dummy_metrics(),
+        2,
+        Arc::new(MockReorgReporter::new()),
+        dummy_readiness(),
+    );
+    submitter
+        .submit_checkpoints_until_correctness_checkpoint(
+            &mut IncrementalMerkle::default(),
+            &CheckpointAtBlock {
+                checkpoint: expected[4].checkpoint,
+                block_height: Some(1),
+            },
+        )
+        .await;
+    // Each chunk completes before the next starts; sibling completion order is unconstrained.
+    let writes = writes.lock().unwrap();
+    let mut first = writes[..2].to_vec();
+    first.sort_unstable();
+    let mut second = writes[2..4].to_vec();
+    second.sort_unstable();
+    assert_eq!(first, vec![3, 4]);
+    assert_eq!(second, vec![1, 2]);
+    assert_eq!(writes[4], 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn compact_queue_materializes_only_the_active_chunk() {
+    let materialized = Arc::new(AtomicUsize::new(0));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer.expect_fetch_checkpoint().times(2).returning({
+        let attempts = Arc::clone(&attempts);
+        move |_| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err(eyre::eyre!("storage temporarily unavailable"))
+        }
+    });
+    let submitter = submission_test_submitter(syncer, dummy_readiness());
+    let task = tokio::spawn({
+        let materialized = Arc::clone(&materialized);
+        async move {
+            submitter
+                .sign_and_submit_checkpoints((0..100).map(move |index| {
+                    materialized.fetch_add(1, Ordering::SeqCst);
+                    QueuedCheckpoint {
+                        root: H256::zero(),
+                        index,
+                        message_id: H256::zero(),
+                    }
+                    .into_checkpoint(submission_checkpoint(99).checkpoint)
+                }))
+                .await;
+        }
+    });
+    while attempts.load(Ordering::SeqCst) < 2 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(materialized.load(Ordering::SeqCst), 2);
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(materialized.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn checkpoint_chunks_preserve_boundaries_and_publication_across_join_all_threshold() {
+    for chunk_size in [1, 6, 30, 31, 50] {
+        let count = chunk_size * 2 + 1;
+        let writes = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_fetch_checkpoint()
+            .times(count)
+            .returning(|_| Ok(None));
+        syncer.expect_write_checkpoint().times(count).returning({
+            let writes = Arc::clone(&writes);
+            move |checkpoint| {
+                writes.lock().unwrap().push(checkpoint.value.index);
+                Ok(())
+            }
+        });
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq((count - 1) as u32))
+            .once()
+            .returning(|_| Ok(()));
+        let mut submitter = submission_test_submitter(syncer, dummy_readiness());
+        submitter.max_sign_concurrency = chunk_size;
+        let start = tokio::time::Instant::now();
+        submitter
+            .sign_and_submit_checkpoints((0..count as u32).map(submission_checkpoint))
+            .await;
+        assert_eq!(start.elapsed(), Duration::from_millis(200));
+        let writes = writes.lock().unwrap();
+        for (chunk, expected) in writes.chunks(chunk_size).zip(
+            (0..count as u32)
+                .rev()
+                .collect::<Vec<_>>()
+                .chunks(chunk_size),
+        ) {
+            let mut actual = chunk.to_vec();
+            actual.sort_unstable();
+            let mut expected = expected.to_vec();
+            expected.sort_unstable();
+            assert_eq!(actual, expected);
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_waits_for_newest_checkpoint_but_not_older_siblings() {
+    for failing_index in [7, 8] {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let failures = Arc::new(AtomicUsize::new(0));
+        let newest_written = Arc::new(AtomicBool::new(false));
+        let published = Arc::new(AtomicBool::new(false));
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_fetch_checkpoint()
+            .times(3)
+            .returning(|_| Ok(None));
+        syncer.expect_write_checkpoint().times(3).returning({
+            let attempts = Arc::clone(&attempts);
+            let failures = Arc::clone(&failures);
+            let newest_written = Arc::clone(&newest_written);
+            move |checkpoint| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                if checkpoint.value.index == failing_index
+                    && failures.fetch_add(1, Ordering::SeqCst) == 0
+                {
+                    return Err(eyre::eyre!("transient checkpoint upload failure"));
+                }
+                if checkpoint.value.index == 8 {
+                    newest_written.store(true, Ordering::SeqCst);
+                }
+                Ok(())
+            }
+        });
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq(8))
+            .once()
+            .returning({
+                let newest_written = Arc::clone(&newest_written);
+                let published = Arc::clone(&published);
+                move |_| {
+                    assert!(newest_written.load(Ordering::SeqCst));
+                    published.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            });
+        let readiness = dummy_readiness();
+        let submitter = submission_test_submitter(syncer, Arc::clone(&readiness));
+        let task = tokio::spawn(async move {
+            submitter
+                .sign_and_submit_checkpoints(vec![
+                    submission_checkpoint(7),
+                    submission_checkpoint(8),
+                ])
+                .await;
+        });
+        while attempts.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(published.load(Ordering::SeqCst), failing_index == 7);
+        assert!(
+            !task.is_finished(),
+            "the failed sibling must still be retried"
+        );
+        assert_eq!(
+            readiness.snapshot().blocked_operations,
+            vec![format!("checkpoint_submission[{failing_index}]")]
+        );
+        tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+        task.await.unwrap();
+        assert!(published.load(Ordering::SeqCst));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_retry_does_not_repeat_checkpoint_upload() {
+    let updates = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer
+        .expect_fetch_checkpoint()
+        .once()
+        .returning(|_| Ok(None));
+    syncer
+        .expect_write_checkpoint()
+        .once()
+        .returning(|_| Ok(()));
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(8))
+        .times(2)
+        .returning({
+            let updates = Arc::clone(&updates);
+            move |_| {
+                if updates.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(eyre::eyre!("latest index unavailable"))
+                } else {
+                    Ok(())
+                }
+            }
+        });
+    let readiness = dummy_readiness();
+    let submitter = submission_test_submitter(syncer, Arc::clone(&readiness));
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(vec![submission_checkpoint(8)])
+            .await;
+    });
+    while updates.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        readiness.snapshot().blocked_operations,
+        vec!["checkpoint_latest_index"]
+    );
+    tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+    task.await.unwrap();
+    assert_eq!(updates.load(Ordering::SeqCst), 2);
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+}
+
+#[tokio::test(start_paused = true)]
+async fn only_first_checkpoint_publishes_batch_maximum() {
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer
+        .expect_fetch_checkpoint()
+        .times(3)
+        .returning(|_| Ok(None));
+    syncer
+        .expect_write_checkpoint()
+        .times(3)
+        .returning(|_| Ok(()));
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(8))
+        .once()
+        .returning(|_| Ok(()));
+    let submitter = submission_test_submitter(syncer, dummy_readiness());
+    submitter
+        .sign_and_submit_checkpoints(vec![
+            submission_checkpoint(7),
+            submission_checkpoint(8),
+            submission_checkpoint(8),
+        ])
+        .await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn single_checkpoint_chunk_has_no_throttle_tail() {
     let checkpoint = CheckpointWithMessageId {
@@ -1392,4 +1766,126 @@ async fn assert_backfill_rebuilds_tree(snapshot: Result<Option<MerkleTreeSnapsho
     let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
     let submitter = snapshot_test_submitter(domain, signer, checkpoint_syncer, db);
     submitter.backfill_checkpoint_submitter(target).await;
+}
+
+#[tokio::test]
+async fn unchanged_tree_checkpoint_preserves_root_index_namespace_and_block() {
+    for leaf_count in [1, 5] {
+        let mut tree = IncrementalMerkle::default();
+        for index in 0..leaf_count {
+            tree.ingest(H256::from_low_u64_be(index + 1));
+        }
+        let expected = Checkpoint {
+            root: tree.root(),
+            index: tree.index(),
+            merkle_tree_hook_address: H256::from_low_u64_be(123),
+            mailbox_domain: 17,
+        };
+        let mut hook = MockMerkleTreeHook::new();
+        hook.expect_address()
+            .return_const(expected.merkle_tree_hook_address);
+        hook.expect_domain()
+            .return_const(dummy_domain(17, "root_reuse_domain"));
+        let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+        let submitter = ValidatorSubmitter::new(
+            Duration::from_secs(1),
+            ReorgPeriod::from_blocks(1),
+            Arc::new(hook),
+            Arc::new(MockMerkleTreeHook::new()),
+            dummy_singleton_handle(),
+            signer,
+            Arc::new(MockCheckpointSyncer::new()),
+            Arc::new(MockDb::new()),
+            dummy_metrics(),
+            2,
+            Arc::new(MockReorgReporter::new()),
+            dummy_readiness(),
+        );
+        let at_block = IncrementalMerkleAtBlock {
+            tree: tree.clone(),
+            block_height: Some(42),
+        };
+        let checkpoint = submitter.checkpoint_at_block(&at_block);
+        assert_eq!(checkpoint.checkpoint, expected);
+        assert_eq!(checkpoint.block_height, Some(42));
+        // No DB reads, signing/storage calls, or reorg reports are expected when
+        // the complete checkpoint already matches and no leaves are ingested.
+        submitter
+            .submit_checkpoints_until_correctness_checkpoint(&mut tree, &checkpoint)
+            .await;
+        assert_eq!(tree.root(), expected.root);
+        assert_eq!(tree.index(), expected.index);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_publication_reuses_submitter_handles_across_retries() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let syncer = Arc::new_cyclic(|weak: &std::sync::Weak<MockCheckpointSyncer>| {
+        let weak = weak.clone();
+        let attempts = Arc::clone(&attempts);
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq(8))
+            .times(2)
+            .returning(move |_| {
+                assert_eq!(
+                    weak.strong_count(),
+                    1,
+                    "publication must reuse the submitter, not clone its storage handle"
+                );
+                if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(eyre::eyre!("latest index unavailable"))
+                } else {
+                    Ok(())
+                }
+            });
+        syncer
+    });
+    let readiness = dummy_readiness();
+    let mut submitter =
+        submission_test_submitter(MockCheckpointSyncer::new(), Arc::clone(&readiness));
+    submitter.checkpoint_syncer = syncer;
+    let submitter = Arc::new(submitter);
+    let start = tokio::time::Instant::now();
+    submitter.publish_latest_checkpoint_index(8).await;
+    assert_eq!(
+        start.elapsed(),
+        hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION
+    );
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(Arc::strong_count(&submitter), 1);
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_publication_cancellation_stops_retry_and_releases_submitter() {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer.expect_update_latest_index().once().returning({
+        let attempts = Arc::clone(&attempts);
+        move |_| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err(eyre::eyre!("latest index unavailable"))
+        }
+    });
+    let readiness = dummy_readiness();
+    let submitter = Arc::new(submission_test_submitter(syncer, Arc::clone(&readiness)));
+    let task = tokio::spawn({
+        let submitter = Arc::clone(&submitter);
+        async move { submitter.publish_latest_checkpoint_index(8).await }
+    });
+    while attempts.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        readiness.snapshot().blocked_operations,
+        vec!["checkpoint_latest_index"]
+    );
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(Arc::strong_count(&submitter), 1);
+    tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -528,24 +528,26 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     /// `latest_checkpoint_at_block()`, so there's a single place that ever calls
     /// `quorum_hooks` for a pinned-height root read.
     async fn tree_at_block_via_quorum(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
-        let results = join_all(
-            self.quorum_hooks
-                .iter()
-                .cloned()
-                .map(|(label, hook)| async move {
-                    (
-                        label,
-                        Self::with_call_timeout(hook.tree_at_block(height)).await,
-                    )
-                }),
-        )
-        .await;
-        let quorum_result = self.select_quorum_result(
-            results,
-            |a, b| a.tree == b.tree,
-            "Failed to reach quorum for merkle tree",
-        )?;
-        let base_result = self.base_hook.tree_at_block(height).await?;
+        // Both reads use the same explicit height and independently gate the result. Start
+        // them together so the base pool's latency does not follow the quorum's latency.
+        // Keep the futures owned here: an error or caller cancellation drops the other
+        // read, without leaving a background RPC task running.
+        let quorum_read = async {
+            let results = join_all(self.quorum_hooks.iter().map(|(label, hook)| async move {
+                (
+                    label.clone(),
+                    Self::with_call_timeout(hook.tree_at_block(height)).await,
+                )
+            }))
+            .await;
+            self.select_quorum_result(
+                results,
+                |a, b| a.tree == b.tree,
+                "Failed to reach quorum for merkle tree",
+            )
+        };
+        let (quorum_result, base_result) =
+            futures_util::try_join!(quorum_read, self.base_hook.tree_at_block(height),)?;
         Self::require_base_hook_agreement(
             &quorum_result,
             &base_result,
@@ -594,11 +596,11 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             return self.tree_at_block_via_quorum(height).await;
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
+        let results = join_all(self.quorum_hooks.iter().map(|(label, hook)| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    label,
+                    label.clone(),
                     Self::with_call_timeout(hook.tree(&reorg_period)).await,
                 )
             }
@@ -2080,6 +2082,159 @@ mod tests {
 
     fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> (String, Arc<dyn MerkleTreeHook>) {
         (label.to_string(), Arc::new(hook) as Arc<dyn MerkleTreeHook>)
+    }
+
+    /// Delays a mock response without blocking the executor, and tracks owned RPC futures.
+    #[derive(Debug)]
+    struct DelayedPinnedHook {
+        inner: MockMerkleTreeHook,
+        delay: Duration,
+        active: Arc<AtomicUsize>,
+    }
+
+    impl HyperlaneChain for DelayedPinnedHook {
+        fn domain(&self) -> &HyperlaneDomain {
+            self.inner.domain()
+        }
+
+        fn provider(&self) -> Box<dyn HyperlaneProvider> {
+            self.inner.provider()
+        }
+    }
+
+    impl HyperlaneContract for DelayedPinnedHook {
+        fn address(&self) -> H256 {
+            self.inner.address()
+        }
+    }
+
+    #[async_trait]
+    impl MerkleTreeHook for DelayedPinnedHook {
+        async fn tree(&self, period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
+            self.inner.tree(period).await
+        }
+
+        async fn count(&self, period: &ReorgPeriod) -> ChainResult<u32> {
+            self.inner.count(period).await
+        }
+
+        async fn latest_checkpoint(&self, period: &ReorgPeriod) -> ChainResult<CheckpointAtBlock> {
+            self.inner.latest_checkpoint(period).await
+        }
+
+        async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
+            self.inner.latest_checkpoint_at_block(height).await
+        }
+
+        async fn tree_at_block(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
+            struct ActiveRead<'a>(&'a AtomicUsize);
+            impl Drop for ActiveRead<'_> {
+                fn drop(&mut self) {
+                    self.0.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+            self.active.fetch_add(1, Ordering::SeqCst);
+            let _active = ActiveRead(&self.active);
+            sleep(self.delay).await;
+            self.inner.tree_at_block(height).await
+        }
+    }
+
+    fn delayed_pinned_hook(
+        seconds: u64,
+        fail: bool,
+        active: &Arc<AtomicUsize>,
+    ) -> Arc<dyn MerkleTreeHook> {
+        let mut inner = MockMerkleTreeHook::new();
+        // Cancellation can prevent the delayed response from being reached.
+        inner
+            .expect_tree_at_block()
+            .times(0..=1)
+            .with(mockall::predicate::eq(42))
+            .return_once(move |height| {
+                if fail {
+                    Err(ChainCommunicationError::from_other_str("RPC unavailable"))
+                } else {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree: tree_with_count(5),
+                        block_height: Some(height),
+                    })
+                }
+            });
+        Arc::new(DelayedPinnedHook {
+            inner,
+            delay: Duration::from_secs(seconds),
+            active: Arc::clone(active),
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pinned_base_and_quorum_reads_overlap() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: delayed_pinned_hook(7, false, &active),
+            quorum_hooks: vec![
+                ("rpc-a".into(), delayed_pinned_hook(5, false, &active)),
+                ("rpc-b".into(), delayed_pinned_hook(5, false, &active)),
+                ("rpc-c".into(), delayed_pinned_hook(5, false, &active)),
+            ],
+        };
+        let start = Instant::now();
+        let tree = hook.tree_at_block_via_quorum(42).await.unwrap();
+        assert_eq!(tree.tree, tree_with_count(5));
+        assert_eq!(tree.block_height, Some(42));
+        assert_eq!(start.elapsed(), Duration::from_secs(7));
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pinned_read_failure_cancels_the_other_read_group() {
+        for base_fails in [false, true] {
+            let active = Arc::new(AtomicUsize::new(0));
+            let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+                base_hook: delayed_pinned_hook(
+                    if base_fails { 2 } else { 10 },
+                    base_fails,
+                    &active,
+                ),
+                quorum_hooks: vec![
+                    (
+                        "rpc-a".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                    (
+                        "rpc-b".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                    (
+                        "rpc-c".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                ],
+            };
+            let start = Instant::now();
+            assert!(hook.tree_at_block_via_quorum(42).await.is_err());
+            assert_eq!(start.elapsed(), Duration::from_secs(2));
+            assert_eq!(active.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelling_pinned_read_drops_both_read_groups() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: delayed_pinned_hook(10, false, &active),
+            quorum_hooks: ["rpc-a", "rpc-b", "rpc-c"]
+                .into_iter()
+                .map(|label| (label.into(), delayed_pinned_hook(10, false, &active)))
+                .collect(),
+        };
+        assert!(
+            timeout(Duration::from_secs(1), hook.tree_at_block_via_quorum(42))
+                .await
+                .is_err()
+        );
+        assert_eq!(active.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/rust/main/hyperlane-core/src/accumulator/incremental.rs
+++ b/rust/main/hyperlane-core/src/accumulator/incremental.rs
@@ -64,17 +64,27 @@ impl IncrementalMerkle {
 
     /// Calculate the current tree root
     pub fn root(&self) -> H256 {
-        let mut node: H256 = Default::default();
-        let mut size = self.count;
+        // Each low zero count bit hashes the empty subtree with itself. Those
+        // nodes are already precomputed, independently of the stored branch.
+        let skip = self.count.trailing_zeros() as usize;
+        if skip >= TREE_DEPTH {
+            return ZERO_HASHES[TREE_DEPTH];
+        }
+        let mut node = ZERO_HASHES[skip];
+        let mut size = self.count >> skip;
 
-        self.branch.iter().enumerate().for_each(|(i, elem)| {
-            node = if (size & 1) == 1 {
-                hash_concat(elem, node)
-            } else {
-                hash_concat(node, ZERO_HASHES[i])
-            };
-            size /= 2;
-        });
+        self.branch
+            .iter()
+            .enumerate()
+            .skip(skip)
+            .for_each(|(i, elem)| {
+                node = if (size & 1) == 1 {
+                    hash_concat(elem, node)
+                } else {
+                    hash_concat(node, ZERO_HASHES[i])
+                };
+                size /= 2;
+            });
 
         node
     }
@@ -161,6 +171,58 @@ impl MerkleTreeSnapshot {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn legacy_root(tree: &IncrementalMerkle) -> H256 {
+        let mut node: H256 = Default::default();
+        let mut size = tree.count;
+        for (i, elem) in tree.branch.iter().enumerate() {
+            node = if (size & 1) == 1 {
+                hash_concat(elem, node)
+            } else {
+                hash_concat(node, ZERO_HASHES[i])
+            };
+            size /= 2;
+        }
+        node
+    }
+
+    #[test]
+    fn root_zero_prefix_matches_legacy_for_arbitrary_branches_and_counts() {
+        let mut seed = 0x0123_4567_89ab_cdefu64;
+        let mut random = || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        let counts = (0..2048)
+            .chain((0..usize::BITS).flat_map(|bit| {
+                let count = 1usize << bit;
+                [count, count.saturating_sub(1), count.saturating_add(1)]
+            }))
+            .chain([usize::MAX, usize::MAX - 1]);
+        for count in counts {
+            let branch = std::array::from_fn(|_| {
+                let mut bytes = [0; 32];
+                for chunk in bytes.chunks_mut(8) {
+                    chunk.copy_from_slice(&random().to_be_bytes());
+                }
+                H256::from(bytes)
+            });
+            let tree = IncrementalMerkle { branch, count };
+            assert_eq!(tree.root(), legacy_root(&tree), "count={count}");
+        }
+    }
+
+    #[test]
+    fn root_zero_prefix_matches_legacy_through_sequential_ingestion() {
+        let mut tree = IncrementalMerkle::default();
+        for leaf in 0..8192 {
+            assert_eq!(tree.root(), legacy_root(&tree), "leaf count={leaf}");
+            tree.ingest(H256::from_low_u64_be(leaf));
+        }
+        assert_eq!(tree.root(), legacy_root(&tree));
+    }
 
     #[test]
     fn borsh_roundtrip() {


### PR DESCRIPTION
## Problem

Validator checkpoint verification performs independent reads sequentially, history replay retains repeated checkpoint fields, and publication waits behind slower sibling uploads. The same loop also recomputes roots and allocates temporary ownership buffers.

## Solution

Overlap the independent read groups at the same pinned block, retain the full correctness/signing gate, and publish the newest durable checkpoint while older siblings continue retrying. Keep compact per-entry history data until verification, reuse the final root within its ingestion call, skip precomputed empty Merkle subtrees, and remove transient chunk buffers and submitter clones. Bounded concurrency, retry delays, sibling durability, single maximum publisher and reorg reporting remain intact.

Consolidates #9471, #9477, #9499, #9514, #9516, #9520 and #9524. The original benchmark/test artifacts remain applicable to their individual mechanisms; this is one reordered squash commit with no implementation changes.

## Numerical evidence

| Mechanism | Evidence and scope |
|---|---|
| Independent pinned read groups | Synthetic 5s and 7s groups: 12s → 7s; same exact block. Production latency unmeasured. |
| Newest checkpoint discoverability | Modeled newest upload 1s, slow sibling 30s: 30s → 1s, excluding latest-index publication cost. Older retries still complete. |
| Historical queue | Logical entry size 104 → 68 bytes, 34.6% less. A sanitized observed 2,503,089-entry queue models 90.11 MB less logical entry storage; excludes Vec spare capacity/RSS. |
| Root reuse | Removes two root calculations per successful nonempty ingestion batch with INFO enabled, one when disabled. This is separate from the following per-root improvement. |
| Remaining Merkle root calculations | Exact-source optimized paired probe: 2.898% median per-call reduction for sequential counts 1..4096; odd-count cases near parity. Average approximately one of 32 hashes skipped. This applies only to root calls remaining after reuse. |
| Temporary chunk buffer | At default maximum concurrency 50, one allocation requesting 5,200 bytes removed per nonempty chunk. Actual checkpoint/join_all synthetic matrix: 135 cases without allocation regression; no actual signing-future layout claim. |
| Latest-index retry ownership | Actual attempt future layout 64 → 48 bytes. Separate GCP signer fixture avoids one 88-byte string allocation; local signer clone allocates nothing in either version. These are component measurements, not whole-attempt/fleet CPU totals. |

Successful-path RPC count is unchanged; a failure can start the other read group before cancellation, unlike the old sequential path.

Do not add these percentages or interpret them as measured whole-validator throughput. Snapshot #9448 reduces work count; these changes reduce remaining per-entry/per-call work. Latest index remains an upper bound, not proof of dense checkpoint history; the existing non-atomic storage monotonicity guard is unchanged.

## Validation

At the reordered boundary, the full validator suite passed 86 tests. The accumulator suite passed 20 tests using the exact emitted binary from the primary checkout for its existing .git-directory fixture; its first worktree-cwd attempt failed only that fixture lookup. Strict production validator Clippy passed. Qualified core Clippy passed with the unchanged cfg(dev) declaration and manual Filter::Default derivation baseline allowance; no source suppressions. Existing regression coverage includes cancellation/error behavior of pinned groups; newest-upload failure versus sibling failure; latest-index retries without reupload; exact queued roots, message IDs, namespace and recovered signer; mismatch-before-signing; active-chunk laziness; publication uniqueness with duplicate maximum input; 1/6/30/31/50 concurrency boundaries and exact pacing; arbitrary public Merkle branch/count states including high usize bits; and retry/cancellation ownership.

The committed final three-group stack has exact tree equality with the original validator head 58ea432c127226057bdde65bb3431f12a883da42. Shared-core changes also retain the integration merge requirements described in the encoding/storage child. No snapshot, provider pooling, polling or external signing authority work is duplicated.

Normal commit hooks and both Rust workspace formatting checks passed.

### 7 September restack

Rebased onto `main@3d9ad7ef`. The conflict with the newer validator snapshot/readiness work was resolved by retaining both behaviors. Exact-head `git diff --check` and Rust formatting passed; CI is rerunning for the rewritten head.