### PR TITLE
perf(metrics): resolve xERC20 once per limit observation

### DIFF
--- a/.changeset/fresh-xerc20-observation.md
+++ b/.changeset/fresh-xerc20-observation.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/metrics': patch
+---
+
+Resolved the xERC20 address once per limit observation instead of repeating the same read for each limit and label. Preserved fresh address and limit reads on every monitoring cycle.

--- a/typescript/metrics/src/balance.test.ts
+++ b/typescript/metrics/src/balance.test.ts
@@ -1,0 +1,179 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import sinon from 'sinon';
+
+import {
+  MultiProtocolProvider,
+  Token,
+  TokenStandard,
+  WarpCore,
+} from '@hyperlane-xyz/sdk';
+
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import { getXERC20Info } from './balance.js';
+
+const abi = new ethers.utils.Interface([
+  'function wrappedToken() view returns (address)',
+  'function xERC20() view returns (address)',
+  'function mintingCurrentLimitOf(address) view returns (uint256)',
+  'function mintingMaxLimitOf(address) view returns (uint256)',
+  'function burningCurrentLimitOf(address) view returns (uint256)',
+  'function burningMaxLimitOf(address) view returns (uint256)',
+]);
+const router = `0x${'12'.repeat(20)}`;
+const underlying = `0x${'34'.repeat(20)}`;
+const updatedUnderlying = `0x${'56'.repeat(20)}`;
+
+function fixture(standard: TokenStandard) {
+  const provider = new ethers.providers.StaticJsonRpcProvider(undefined, {
+    chainId: 1,
+    name: 'test',
+  });
+  const multiProvider = new MultiProtocolProvider<{ mailbox?: string }>({
+    test: {
+      name: 'test',
+      chainId: 1,
+      domainId: 1,
+      protocol: standard.startsWith('Tron')
+        ? ProtocolType.Tron
+        : ProtocolType.Ethereum,
+      rpcUrls: [{ http: 'http://localhost:8545' }],
+    },
+  });
+  sinon.stub(multiProvider, 'getEthersV5Provider').returns(provider);
+  const token = new Token({
+    chainName: 'test',
+    standard,
+    addressOrDenom: router,
+    decimals: 2,
+    symbol: 'TOKEN',
+    name: 'Token',
+  });
+  const amounts: Record<string, number> = {
+    mintingCurrentLimitOf: 100,
+    mintingMaxLimitOf: 200,
+    burningCurrentLimitOf: 300,
+    burningMaxLimitOf: 400,
+  };
+  let address = underlying;
+  const calls: Array<{
+    method: string;
+    to: string | undefined;
+    bridge?: string;
+  }> = [];
+  const call = sinon.stub(provider, 'call').callsFake(async (transaction) => {
+    const decoded = abi.parseTransaction({
+      data: ethers.utils.hexlify((await transaction.data)!),
+    });
+    const to = await transaction.to;
+    calls.push({ method: decoded.name, to, bridge: decoded.args[0] });
+    const value =
+      decoded.name === 'wrappedToken' || decoded.name === 'xERC20'
+        ? address
+        : amounts[decoded.name];
+    return abi.encodeFunctionResult(decoded.name, [value]);
+  });
+  return {
+    token,
+    warpCore: new WarpCore(multiProvider, [token]),
+    call,
+    calls,
+    amounts,
+    setAddress: (value: string) => {
+      address = value;
+    },
+  };
+}
+
+describe('xERC20 metric acquisition', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  for (const standard of [
+    TokenStandard.EvmHypXERC20,
+    TokenStandard.EvmHypVSXERC20,
+    TokenStandard.EvmHypXERC20Lockbox,
+    TokenStandard.EvmHypVSXERC20Lockbox,
+    TokenStandard.TronHypXERC20,
+    TokenStandard.TronHypVSXERC20,
+    TokenStandard.TronHypXERC20Lockbox,
+    TokenStandard.TronHypVSXERC20Lockbox,
+  ]) {
+    it(`resolves one underlying address and reads all four current limits for ${standard}`, async () => {
+      const { warpCore, token, calls } = fixture(standard);
+      const result = await getXERC20Info(warpCore, token);
+      expect(result).to.deep.equal({
+        xERC20Address: underlying,
+        limits: { mint: 1, mintMax: 2, burn: 3, burnMax: 4 },
+      });
+      expect(calls).to.have.length(5);
+      expect(
+        calls.filter(
+          ({ method }) => method === 'wrappedToken' || method === 'xERC20',
+        ),
+      ).to.have.length(1);
+      const limitCalls = calls.filter(({ bridge }) => bridge !== undefined);
+      expect(limitCalls).to.have.length(4);
+      expect(
+        limitCalls.every(
+          ({ to, bridge }) =>
+            to?.toLowerCase() === underlying &&
+            bridge?.toLowerCase() === router,
+        ),
+      ).to.equal(true);
+    });
+  }
+
+  it('refreshes the address and every limit on each observation', async () => {
+    const { warpCore, token, calls, amounts, setAddress } = fixture(
+      TokenStandard.EvmHypXERC20,
+    );
+    await getXERC20Info(warpCore, token);
+    setAddress(updatedUnderlying);
+    amounts['mintingCurrentLimitOf'] = 500;
+    const result = await getXERC20Info(warpCore, token);
+    expect(result.xERC20Address).to.equal(updatedUnderlying);
+    expect(result.limits.mint).to.equal(5);
+    expect(calls).to.have.length(10);
+    expect(
+      calls.slice(6).every(({ to }) => to?.toLowerCase() === updatedUnderlying),
+    ).to.equal(true);
+  });
+
+  it('rejects a failed limit sample without substituting partial or cached values', async () => {
+    const { warpCore, token, call } = fixture(TokenStandard.EvmHypXERC20);
+    const failure = new Error('limit unavailable');
+    call.onCall(2).rejects(failure);
+    try {
+      await getXERC20Info(warpCore, token);
+      expect.fail('Expected limit failure');
+    } catch (error) {
+      expect(error).to.equal(failure);
+    }
+    expect((await getXERC20Info(warpCore, token)).limits).to.deep.equal({
+      mint: 1,
+      mintMax: 2,
+      burn: 3,
+      burnMax: 4,
+    });
+    expect(call.callCount).to.equal(10);
+  });
+
+  it('propagates read failures and retries fresh on the next observation', async () => {
+    const { warpCore, token, call } = fixture(
+      TokenStandard.EvmHypXERC20Lockbox,
+    );
+    const failure = new Error('RPC unavailable');
+    call.onCall(0).rejects(failure);
+    try {
+      await getXERC20Info(warpCore, token);
+      expect.fail('Expected read failure');
+    } catch (error) {
+      expect(error).to.equal(failure);
+    }
+    expect((await getXERC20Info(warpCore, token)).limits.mint).to.equal(1);
+    expect(call.callCount).to.equal(6);
+  });
+});

--- a/typescript/metrics/src/balance.ts
+++ b/typescript/metrics/src/balance.ts
@@ -163,28 +163,34 @@ export async function getXERC20Info(
   if (
     token.standard === TokenStandard.EvmHypXERC20 ||
     token.standard === TokenStandard.EvmHypVSXERC20 ||
-    token.standard == TokenStandard.TronHypVSXERC20 ||
-    token.standard == TokenStandard.TronHypXERC20
-  ) {
-    const adapter = token.getAdapter(
-      warpCore.multiProvider,
-    ) as EvmHypXERC20Adapter;
-    return {
-      limits: await getXERC20Limit(token, adapter),
-      xERC20Address: (await adapter.getXERC20()).address,
-    };
-  } else if (
+    token.standard === TokenStandard.TronHypVSXERC20 ||
+    token.standard === TokenStandard.TronHypXERC20 ||
     token.standard === TokenStandard.EvmHypXERC20Lockbox ||
     token.standard === TokenStandard.EvmHypVSXERC20Lockbox ||
     token.standard === TokenStandard.TronHypXERC20Lockbox ||
     token.standard === TokenStandard.TronHypVSXERC20Lockbox
   ) {
-    const adapter = token.getAdapter(
-      warpCore.multiProvider,
-    ) as EvmHypXERC20LockboxAdapter;
+    const adapter = token.getAdapter(warpCore.multiProvider) as
+      | EvmHypXERC20Adapter
+      | EvmHypXERC20LockboxAdapter;
+    // Resolve once for this observation; each adapter limit method would
+    // otherwise independently read the same wrapped-token address again.
+    const xerc20 = await adapter.getXERC20();
+    const bridgeAddress = adapter.contract.address;
+    const [mintCurrent, mintMax, burnCurrent, burnMax] = await Promise.all([
+      xerc20.mintingCurrentLimitOf(bridgeAddress),
+      xerc20.mintingMaxLimitOf(bridgeAddress),
+      xerc20.burningCurrentLimitOf(bridgeAddress),
+      xerc20.burningMaxLimitOf(bridgeAddress),
+    ]);
     return {
-      limits: await getXERC20Limit(token, adapter),
-      xERC20Address: (await adapter.getXERC20()).address,
+      limits: {
+        mint: formatBigInt(token, mintCurrent.toBigInt()),
+        mintMax: formatBigInt(token, mintMax.toBigInt()),
+        burn: formatBigInt(token, burnCurrent.toBigInt()),
+        burnMax: formatBigInt(token, burnMax.toBigInt()),
+      },
+      xERC20Address: xerc20.address,
     };
   }
 


### PR DESCRIPTION
## Problem

`getXERC20Info` resolved the underlying token separately inside each of four limit reads, then resolved it again for the address label: **5 identical address lookups per observation**. Current production warp-monitor metrics expose 204 regular xERC20 limit series, representing 51 bridge label sets with four limits each. Managed extra-lockbox series are excluded from that denominator.

## Solution

Resolve the xERC20 contract once per observation, read the same four current/max mint/burn limits in parallel, and use its address for the label. Preserve fresh address and limit reads on every invocation, supported EVM/Tron standards, units and error propagation. No cache or new public API. Retain the existing exported adapter-based `getXERC20Limit` API for downstream users.

Stacked on #9470; includes a patch changeset for the shared metrics package used by warp-monitor and rebalancer.

## Performance evidence

| Contract reads per regular xERC20 observation | Before | After |
| --- | ---: | ---: |
| Underlying token address | 5 | 1 |
| Four limit values | 4 | 4 |
| Total | 9 | 5 (-44.4%) |

The provider-call regression uses real SDK adapters and ABI processing for all eight supported EVM/Tron standards. It fails against original source with 9 calls and passes with 5, returning identical limits and address. Subsequent observations fetch changed addresses/values; failed reads do not leave cached or partial results.

Applied to one pass over the 51 observed regular bridge label sets, this models **204 avoided contract reads per pass**. This is an estimate from observed cardinality plus tested operation counts, not measured production RPC traffic. Shared labels can be updated by multiple routes, and transport batching/caching affects network totals. Managed extra-lockbox reads are unchanged. No production latency claim.

## Validation

- Metrics: 24 tests passed; warp-monitor: 42 tests passed.
- Metrics TypeScript build, Oxlint, Oxfmt and `git diff --check` passed.
- Focused reproduction: `pnpm -C typescript/metrics exec mocha --config .mocharc.json src/balance.test.ts --exit`.
- Self-reviewed adapter factories/implementations, both monitoring consumers, decimal conversion and error behavior.

Local tests use the node_modules-only core-js compatibility shim documented in #9464. No manifest/lockfile changes or deployment; production observations are pre-change.


---

Superseded by consolidated draft #9504: [perf(metrics): reduce warp monitoring reads and log volume](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9504). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
