### PR TITLE
perf(rebalancer): reuse gas quote within cost estimation

### DIFF
--- a/.changeset/quiet-gas-quote.md
+++ b/.changeset/quiet-gas-quote.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Reused the transfer gas quote within native-token cost estimation, avoiding a duplicate quote request while preserving fee reservations and standalone estimation behavior.

--- a/typescript/rebalancer/src/utils/gasEstimation.test.ts
+++ b/typescript/rebalancer/src/utils/gasEstimation.test.ts
@@ -7,7 +7,10 @@ import type { ChainName, MultiProvider, Token } from '@hyperlane-xyz/sdk';
 import { TokenStandard } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
-import { calculateTransferCosts } from './gasEstimation.js';
+import {
+  calculateTransferCosts,
+  estimateTransferRemoteGas,
+} from './gasEstimation.js';
 
 const testLogger = pino({ level: 'silent' });
 
@@ -34,23 +37,113 @@ describe('calculateTransferCosts — Tron vs Sealevel protocol path', () => {
       getHypAdapter: Sinon.stub().returns(mockAdapter),
     } as unknown as Token;
 
+    const mockProvider = {
+      estimateGas: Sinon.stub().resolves(BigNumber.from(200000)),
+      getFeeData: Sinon.stub().resolves({
+        maxFeePerGas: BigNumber.from(10_000_000_000n),
+        gasPrice: BigNumber.from(10_000_000_000n),
+      }),
+    };
     const multiProvider = {
       getDomainId: Sinon.stub().returns(42161),
       getProtocol: Sinon.stub().returns(protocol),
-      getProvider: Sinon.stub().returns({
-        estimateGas: Sinon.stub().resolves(BigNumber.from(200000)),
-        getFeeData: Sinon.stub().resolves({
-          maxFeePerGas: BigNumber.from(10_000_000_000n),
-          gasPrice: BigNumber.from(10_000_000_000n),
-        }),
-      }),
+      getProvider: Sinon.stub().returns(mockProvider),
     } as unknown as MultiProvider;
 
     const getTokenForChain = Sinon.stub().returns(mockToken);
     const isNativeTokenStandard = Sinon.stub().returns(true);
 
-    return { multiProvider, getTokenForChain, isNativeTokenStandard };
+    return {
+      multiProvider,
+      getTokenForChain,
+      isNativeTokenStandard,
+      mockAdapter,
+      mockProvider,
+    };
   }
+
+  it('uses one quote consistently for EVM-native reservation and estimation', async () => {
+    const {
+      multiProvider,
+      getTokenForChain,
+      isNativeTokenStandard,
+      mockAdapter,
+    } = createMockDeps(ProtocolType.Ethereum);
+    mockAdapter.quoteTransferRemoteGas
+      .onSecondCall()
+      .rejects(new Error('duplicate quote'));
+    const result = await calculateTransferCosts(
+      'ethereum',
+      'arbitrum',
+      3_000_000_000_000_000n,
+      3_000_000_000_000_000n,
+      multiProvider,
+      {},
+      getTokenForChain,
+      '0xInventorySigner',
+      isNativeTokenStandard,
+      testLogger,
+    );
+    expect(mockAdapter.quoteTransferRemoteGas.callCount).to.equal(1);
+    expect(
+      mockAdapter.populateTransferRemoteTx.firstCall.args[0].interchainGas,
+    ).to.equal(result.gasQuote);
+    expect(result.igpCost).to.equal(1000n);
+    expect(result.gasCost).to.equal(2_200_000_000_000_000n);
+    expect(result.totalCost).to.equal(2_200_000_000_001_000n);
+    expect(result.maxTransferable).to.equal(799_999_999_999_000n);
+    expect(result.minViableTransfer).to.equal(4_400_000_000_002_000n);
+  });
+
+  it('retains the fallback gas reserve when estimation fails', async () => {
+    const {
+      multiProvider,
+      getTokenForChain,
+      isNativeTokenStandard,
+      mockAdapter,
+      mockProvider,
+    } = createMockDeps(ProtocolType.Ethereum);
+    mockProvider.estimateGas.rejects(new Error('estimate unavailable'));
+    const result = await calculateTransferCosts(
+      'ethereum',
+      'arbitrum',
+      10_000_000_000_000_000n,
+      5_000_000_000_000_000n,
+      multiProvider,
+      {},
+      getTokenForChain,
+      '0xInventorySigner',
+      isNativeTokenStandard,
+      testLogger,
+    );
+    expect(mockAdapter.quoteTransferRemoteGas.callCount).to.equal(1);
+    expect(result.gasCost).to.equal(3_300_000_000_000_000n);
+    expect(result.igpCost).to.equal(1000n);
+  });
+
+  it('still obtains a quote for standalone gas estimation', async () => {
+    const { multiProvider, getTokenForChain, mockAdapter } = createMockDeps(
+      ProtocolType.Ethereum,
+    );
+    const estimate = await estimateTransferRemoteGas(
+      'ethereum',
+      'arbitrum',
+      100n,
+      multiProvider,
+      {},
+      getTokenForChain,
+      '0xInventorySigner',
+      testLogger,
+    );
+    expect(estimate).to.equal(200000n);
+    expect(mockAdapter.quoteTransferRemoteGas.callCount).to.equal(1);
+    expect(mockAdapter.quoteTransferRemoteGas.firstCall.args[0]).to.deep.equal({
+      destination: 42161,
+      sender: '0xInventorySigner',
+      recipient: '0xInventorySigner',
+      amount: 100n,
+    });
+  });
 
   it('Tron origin (EVM-like) produces non-zero gasCost for native tokens', async () => {
     const { multiProvider, getTokenForChain, isNativeTokenStandard } =

--- a/typescript/rebalancer/src/utils/gasEstimation.ts
+++ b/typescript/rebalancer/src/utils/gasEstimation.ts
@@ -60,6 +60,7 @@ export interface TransferCostEstimate {
  * @param getTokenForChain - Function to get token for a chain
  * @param inventorySigner - Address of the inventory signer
  * @param logger - Logger instance
+ * @param providedGasQuote - Quote already obtained for this exact transfer-cost calculation
  * @returns Estimated gas limit for the transaction
  */
 export async function estimateTransferRemoteGas(
@@ -71,6 +72,7 @@ export async function estimateTransferRemoteGas(
   getTokenForChain: (chain: ChainName) => Token | undefined,
   inventorySigner: string,
   logger: Logger,
+  providedGasQuote?: InterchainGasQuote,
 ): Promise<bigint> {
   const originToken = getTokenForChain(originChain);
   if (!originToken) {
@@ -85,13 +87,16 @@ export async function estimateTransferRemoteGas(
     const destinationDomain = multiProvider.getDomainId(destinationChain);
     const adapter = originToken.getHypAdapter(warpCoreMultiProvider);
 
-    // Quote the IGP gas first (needed for the full transaction)
-    const gasQuote = await adapter.quoteTransferRemoteGas({
-      destination: destinationDomain,
-      sender: inventorySigner,
-      recipient: inventorySigner,
-      amount,
-    });
+    // Reuse the quote from this cost calculation when supplied; standalone
+    // estimation still obtains a fresh quote for its own transfer parameters.
+    const gasQuote =
+      providedGasQuote ??
+      (await adapter.quoteTransferRemoteGas({
+        destination: destinationDomain,
+        sender: inventorySigner,
+        recipient: inventorySigner,
+        amount,
+      }));
 
     // Populate with minimal amount for gas estimation
     // Gas cost is independent of transfer size (just a require check in _transferFromSender),
@@ -251,6 +256,7 @@ export async function calculateTransferCosts(
     getTokenForChain,
     inventorySigner,
     logger,
+    gasQuote,
   );
   const bufferedGasLimit = addBufferToGasLimit(
     BigNumber.from(estimatedGasLimit.toString()),


### PR DESCRIPTION
## Problem

Native-token cost calculation gets a transfer gas quote, then the gas estimator repeats the same quote for the same origin, destination, sender, recipient and requested amount. This adds a second adapter quote call to every EVM-native cost calculation.

## Solution

Pass the quote already obtained by this calculation into gas estimation. The estimator's optional argument preserves standalone callers' fresh-quote behavior. Keep the existing minimum-amount transaction estimate, 10% gas buffer, 300,000-gas fallback, and native fee reservation. No quote is shared between calculations or cached across cycles. Included a patch changeset.

Stacked on #9465.

## Performance evidence

| Per EVM-native cost calculation | Before | After |
| --- | --- | --- |
| Adapter gas-quote invocations | 2 (source-traced) | 1 (unit-tested) |
| Duplicate quote work | 1 invocation | 0 invocations |

This removes 50% of adapter quote invocations for that path. Underlying RPC requests and latency depend on the adapter and are not measured here. Regression tests also assert the original buffered gas cost, maximum transferable amount and minimum viable amount.

Live workload limitation: the sampled ETH/viction service ran 120 cycles over 2 hours but performed no execution; it dropped routes below the configured minimum. This is a conditional execution-path improvement, not a claim of current fleet quota or latency savings. The observed metric log overhead is covered separately by shared metrics work.

## Validation

- Five focused gas-cost tests passed: single-quote use, exact reserves, fallback estimate, standalone quote, Tron/Sealevel paths.
- Full rebalancer suite: 389 passing.
- Package build/lint passed; three existing lint warnings in untouched tests.
- Differential self-review covered all changed files and EVM/Tron quote consumers.

Runtime tests use the same disclosed local ignored-node_modules core-js compatibility shim as #9465 because the frozen baseline cannot load @provablehq/sdk's missing proposal import. No dependency workaround committed. No live execution or deployment performed.


---

Superseded by consolidated draft #9507: [perf(rebalancer): eliminate duplicate reads and unused initialization](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9507). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
