### PR TITLE
perf(ccip-server): avoid duplicate error logs for pending attestations

### DIFF
--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -4,7 +4,8 @@
     "./tests/**/CallCommitmentsService.test.ts",
     "./tests/**/RateLimiting.test.ts",
     "./tests/**/cctpMessageMatcher.test.ts",
-    "./tests/**/CCTPService.test.ts"
+    "./tests/**/CCTPService.test.ts",
+    "./tests/**/AttestationPending.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -3,6 +3,8 @@ import { Logger } from 'pino';
 
 import { assert } from '@hyperlane-xyz/utils';
 
+import { AttestationPendingError } from '../utils/errors.js';
+
 import {
   PrometheusMetrics,
   UnhandledErrorReason,
@@ -153,7 +155,7 @@ class CCTPAttestationService {
           },
           'CCTP attestation not found',
         );
-        throw new Error(`CCTP attestation is pending`);
+        throw new AttestationPendingError();
       }
 
       // This should not happen according to the CCTP API spec, but we'll log it just in case
@@ -238,7 +240,7 @@ class CCTPAttestationService {
           { messageId, messageCount: json.messages.length },
           'Could not match Circle API messages to cctpMessage — treating as pending',
         );
-        throw new Error('CCTP attestation is pending');
+        throw new AttestationPendingError();
       }
       matchingMessage = found;
     }
@@ -268,9 +270,9 @@ class CCTPAttestationService {
           );
           break;
         default:
-          logger.info({ ...context, ...matchingMessage }, errorString);
+          logger.debug({ ...context, ...matchingMessage }, errorString);
       }
-      throw new Error(errorString);
+      throw new AttestationPendingError();
     }
 
     return [matchingMessage.message, matchingMessage.attestation];

--- a/typescript/ccip-server/src/utils/abiHandler.ts
+++ b/typescript/ccip-server/src/utils/abiHandler.ts
@@ -6,6 +6,8 @@ import { z } from 'zod';
 
 import { offchainLookupRequestMessageHash } from '@hyperlane-xyz/sdk';
 
+import { AttestationPendingError } from './errors.js';
+
 const RelayerSignatureBodySchema = z.compile(
   z.object({
     sender: z.string().startsWith('0x').length(42, 'Invalid Ethereum address'),
@@ -121,14 +123,20 @@ export function createAbiHandler<
       handlerLogger.info({ reqBody: body, encoded }, 'Result encoded');
       return res.json({ data: encoded });
     } catch (err: any) {
-      handlerLogger.error(
-        {
-          reqBody: req.body,
-          error: err.message,
-          stack: err.stack,
-        },
-        `Error in ABI handler ${functionName}`,
-      );
+      if (err instanceof AttestationPendingError) {
+        // Expected polling state: keep the response contract and request metrics,
+        // but avoid repeatedly serializing calldata and stacks at error level.
+        handlerLogger.debug({ error: err.message }, 'CCTP attestation pending');
+      } else {
+        handlerLogger.error(
+          {
+            reqBody: req.body,
+            error: err.message,
+            stack: err.stack,
+          },
+          `Error in ABI handler ${functionName}`,
+        );
+      }
       return res.status(500).json({ error: err.message });
     }
   };

--- a/typescript/ccip-server/src/utils/errors.ts
+++ b/typescript/ccip-server/src/utils/errors.ts
@@ -1,0 +1,7 @@
+/** Circle has not produced an attestation yet; callers should retry. */
+export class AttestationPendingError extends Error {
+  constructor() {
+    super('CCTP attestation is pending');
+    this.name = 'AttestationPendingError';
+  }
+}

--- a/typescript/ccip-server/tests/services/AttestationPending.test.ts
+++ b/typescript/ccip-server/tests/services/AttestationPending.test.ts
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import express from 'express';
+import { pino } from 'pino';
+import pinoHttp from 'pino-http';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import { CctpService__factory } from '@hyperlane-xyz/core';
+
+import { CCTPAttestationService } from '../../src/services/CCTPAttestationService.js';
+import { createAbiHandler } from '../../src/utils/abiHandler.js';
+import { AttestationPendingError } from '../../src/utils/errors.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+
+function captureLogger(level = 'info') {
+  const lines: string[] = [];
+  const logger = pino(
+    { level },
+    {
+      write: (line: string) => {
+        lines.push(line);
+      },
+    },
+  );
+  return { logger, lines };
+}
+
+async function rejected(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error('Expected rejection');
+}
+
+describe('CCTP pending attestation logging', () => {
+  const cctpMessage = `0x${'00'.repeat(8)}`;
+  const transactionHash = `0x${'11'.repeat(32)}`;
+  const messageId = `0x${'22'.repeat(32)}`;
+  const service = new CCTPAttestationService('test', 'https://example.com');
+
+  beforeEach(() => {
+    initializeMetrics(new Registry());
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('retains retry errors while suppressing routine pending payload logs at info', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(
+        JSON.stringify({
+          messages: [{ message: cctpMessage, attestation: 'PENDING' }],
+        }),
+      ),
+    );
+    const { logger, lines } = captureLogger();
+    const error = await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(error).to.be.instanceOf(AttestationPendingError);
+    expect(error.message).to.equal('CCTP attestation is pending');
+    expect(lines).to.have.length(0);
+  });
+
+  it('keeps pending details available at debug level', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(
+        JSON.stringify({
+          messages: [{ message: cctpMessage, attestation: 'PENDING' }],
+        }),
+      ),
+    );
+    const { logger, lines } = captureLogger('debug');
+    await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(lines).to.have.length(1);
+    expect(lines[0]).to.include('CCTP attestation is pending');
+    expect(lines[0]).to.include(cctpMessage);
+  });
+
+  it('keeps actionable Circle delay reasons at error level', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              message: cctpMessage,
+              attestation: 'PENDING',
+              delayReason: 'insufficient_fee',
+            },
+          ],
+        }),
+      ),
+    );
+    const { logger, lines } = captureLogger();
+    const error = await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(error).to.be.instanceOf(AttestationPendingError);
+    expect(lines).to.have.length(1);
+    expect(lines[0]).to.include('"level":50');
+    expect(lines[0]).to.include('insufficient_fee');
+  });
+
+  it('classifies a not-yet-found attestation as pending', async () => {
+    sinon
+      .stub(globalThis, 'fetch')
+      .resolves(new Response(null, { status: 404 }));
+    const { logger } = captureLogger();
+    expect(
+      await rejected(
+        service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+      ),
+    ).to.be.instanceOf(AttestationPendingError);
+  });
+
+  it('does not suppress genuine upstream failures', async () => {
+    sinon
+      .stub(globalThis, 'fetch')
+      .resolves(new Response(null, { status: 500, statusText: 'Unavailable' }));
+    const { logger, lines } = captureLogger();
+    const error = await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(error).not.to.be.instanceOf(AttestationPendingError);
+    expect(error.message).to.equal(
+      'CCTP attestation request failed: Unavailable',
+    );
+    expect(lines[0]).to.include('"level":50');
+  });
+
+  for (const expected of [true, false]) {
+    it(`preserves HTTP status and body for ${expected ? 'typed pending' : 'ordinary'} errors`, async () => {
+      const { logger, lines } = captureLogger();
+      const error = expected
+        ? new AttestationPendingError()
+        : new Error('CCTP attestation is pending');
+      const app = express();
+      app.use(express.json());
+      app.use(pinoHttp({ logger }));
+      app.post(
+        '/',
+        createAbiHandler(CctpService__factory, 'getCCTPAttestation', () =>
+          Promise.reject(error),
+        ),
+      );
+      const server = app.listen(0);
+      await new Promise<void>((resolve) => {
+        server.once('listening', resolve);
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === 'string')
+          throw new Error('Expected TCP server');
+        const data = CctpService__factory.createInterface().encodeFunctionData(
+          'getCCTPAttestation',
+          ['0x1234'],
+        );
+        const response = await fetch(`http://127.0.0.1:${address.port}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ data }),
+        });
+        expect(response.status).to.equal(500);
+        expect(await response.json()).to.deep.equal({
+          error: 'CCTP attestation is pending',
+        });
+        const handlerErrors = lines.filter((line) =>
+          line.includes('Error in ABI handler'),
+        );
+        expect(handlerErrors).to.have.length(expected ? 0 : 1);
+        expect(
+          lines.some((line) => line.includes('Processing ABI handler request')),
+        ).to.equal(true);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Routine Circle attestation polling is logged twice: the service emits pending message bytes at INFO, then the generic ABI handler emits the same expected state at ERROR with calldata and a stack.

Read-only mainnet3 logs sampled on 2026-09-05 found **1,348 routine pending-detail records** within a six-hour query window. All 80 records in the bounded error sample were `CCTP attestation is pending`. The sampled deployment predates this change. CPU was only ~0.00076 cores, so this addresses log amplification and misleading error noise, not a demonstrated CPU bottleneck.

## Solution

Represent expected pending states with an internal `AttestationPendingError`. Log the handler's known pending state and routine Circle pending details at DEBUG. Preserve the exact HTTP 500 status/body, retry behavior, request/completion logs and request metrics. Actionable Circle delay reasons still emit ERROR and their existing counter; unexpected errors, even ordinary Errors with identical text, still use the original error path.

## Performance evidence

- **Deterministic:** the two targeted INFO/ERROR records per ordinary pending response become **0 at INFO level**; details remain available at DEBUG. Request-level logs are excluded from this count and remain.
- **Observed workload:** the 1,348 pending-detail records contained 1,126,144 bytes when serializing the selected message/messageId/CCTP fields as compact JSON. The new default log level would avoid those records for an equivalent workload; this is not a measurement of total ingested bytes or production savings. Handler stack/calldata records are additional unquantified savings.
- **Tests:** a real Pino sink confirms default-level suppression, debug visibility and retained actionable errors. HTTP integration tests confirm identical 500 JSON responses for both typed pending and unexpected same-text errors, while only the typed error skips the handler ERROR record.

## Validation

65 CCIP tests passed; package build/lint/format and independent review passed. No cache, timeout, status-code, attestation matching or API changes. The package is private. Local tests used the previously documented node_modules-only core-js compatibility entry required by the baseline Aleo SDK dependency; no dependency changes are included. No merge or deployment.

Stack: follows #9463.


---

Superseded by consolidated draft #9486: [perf(ccip-server): reduce receipt, logging and startup overhead](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9486). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
