### PR TITLE
fix(scraper): bound and streamline event ingestion

### DIFF
--- a/rust/main/agents/scraper/src/db/dispatch_transactions.rs
+++ b/rust/main/agents/scraper/src/db/dispatch_transactions.rs
@@ -1,0 +1,185 @@
+//! Single-statement atomicity and multi-chunk transaction boundaries.
+use std::collections::BTreeMap;
+
+use hyperlane_core::{HyperlaneMessage, LogMeta, H256};
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, MockExecResult, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::{ScraperDb, StorableMessage, StorableRawMessageDispatch};
+
+fn messages(count: u32) -> Vec<HyperlaneMessage> {
+    (0..count)
+        .map(|nonce| HyperlaneMessage {
+            version: 3,
+            nonce,
+            origin: 1,
+            destination: 1,
+            body: vec![1],
+            ..Default::default()
+        })
+        .collect()
+}
+
+async fn store(db: &ScraperDb, raw: bool, messages: &[HyperlaneMessage]) -> eyre::Result<u64> {
+    let meta = LogMeta::default();
+    if raw {
+        db.store_raw_message_dispatches(
+            1,
+            &H256::zero(),
+            messages
+                .iter()
+                .map(|msg| StorableRawMessageDispatch { msg, meta: &meta }),
+        )
+        .await
+    } else {
+        db.store_dispatched_messages(
+            1,
+            &H256::zero(),
+            messages.iter().cloned().map(|msg| StorableMessage {
+                msg,
+                meta: &meta,
+                txn_id: None,
+                id_override: None,
+            }),
+        )
+        .await
+    }
+}
+
+#[tokio::test]
+async fn dispatch_statement_counts_preserve_multi_chunk_transactions() {
+    for raw in [false, true] {
+        let bound = if raw { 2_954 } else { 3_250 };
+        for count in [0, 1, bound, bound + 1] {
+            let chunks = if count <= bound { 1 } else { 2 };
+            let row = |name: &str, value: i64| {
+                vec![BTreeMap::from([(
+                    name.to_owned(),
+                    Value::BigInt(Some(value)),
+                )])]
+            };
+            let db = if raw {
+                let mut results = vec![row("max_id", 0)];
+                results.extend((0..chunks).map(|_| row("id", 1)));
+                results.push(row("num_items", i64::from(count)));
+                ScraperDb::with_connection(
+                    MockDatabase::new(DatabaseBackend::Postgres)
+                        .append_query_results(results)
+                        .into_connection(),
+                )
+            } else {
+                // The enriched path inserts inside an explicit transaction and
+                // counts affected rows, so it consumes execution results
+                // rather than MAX/INSERT/COUNT query results.
+                let chunk_lens = (0..chunks).map(|i| {
+                    if i == 0 {
+                        count.min(bound)
+                    } else {
+                        count - bound
+                    }
+                });
+                ScraperDb::with_connection(
+                    MockDatabase::new(DatabaseBackend::Postgres)
+                        .append_exec_results(chunk_lens.map(|len| MockExecResult {
+                            last_insert_id: 0,
+                            rows_affected: u64::from(len),
+                        }))
+                        .into_connection(),
+                )
+            };
+            assert_eq!(
+                store(&db, raw, &messages(count)).await.unwrap(),
+                u64::from(count)
+            );
+            let log = db.0.into_transaction_log();
+            let sql: Vec<_> = log
+                .iter()
+                .flat_map(|transaction| transaction.statements())
+                .map(|statement| statement.sql.as_str())
+                .collect();
+            if count == 0 {
+                assert!(sql.is_empty());
+            } else if raw {
+                if count <= bound {
+                    assert_eq!(sql.len(), 3);
+                    assert!(sql[0].starts_with("SELECT MAX("));
+                    assert!(sql[1].starts_with("INSERT"));
+                    assert!(sql[2].starts_with("SELECT COUNT("));
+                } else {
+                    assert_eq!(sql.len(), 6);
+                    assert_eq!(sql[1], "BEGIN");
+                    assert!(sql[2].starts_with("INSERT"));
+                    assert!(sql[3].starts_with("INSERT"));
+                    assert_eq!(sql[4], "COMMIT");
+                }
+            } else if count <= bound {
+                assert_eq!(sql.len(), 3);
+                assert!(sql[1].starts_with("INSERT"));
+                assert_eq!(sql[2], "COMMIT");
+            } else {
+                assert_eq!(sql.len(), 2 + chunks);
+                assert_eq!(sql[0], "BEGIN");
+                assert!(sql[1..=chunks].iter().all(|s| s.starts_with("INSERT")));
+                assert_eq!(sql[chunks + 1], "COMMIT");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn dispatch_writes_preserve_atomicity_and_replay_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    for raw in [false, true] {
+        let (table, bound) = if raw {
+            ("raw_message_dispatch", 2_954)
+        } else {
+            ("message", 3_250)
+        };
+        for count in [2, bound + 1] {
+            db.0.execute_unprepared(&format!("TRUNCATE {table}"))
+                .await?;
+            let rows = messages(count);
+            assert_eq!(store(&db, raw, &rows[..1]).await?, 1);
+            // Keep an existing conflict row to prove failed batches roll back updates too.
+            db.0.execute_unprepared(&format!(
+                "UPDATE {table} SET msg_body = decode('09', 'hex')"
+            ))
+            .await?;
+            // A repeated conflict key must still reject the entire one-statement batch.
+            assert!(store(&db, raw, &[rows[0].clone(), rows[0].clone()])
+                .await
+                .is_err());
+            db.0.execute_unprepared(&format!(
+                "ALTER TABLE {table} ADD CONSTRAINT reject_dispatch_tail CHECK (nonce <> {})",
+                count - 1
+            ))
+            .await?;
+            assert!(store(&db, raw, &rows).await.is_err());
+            let stored = db.0.query_one(sea_orm::Statement::from_string(DatabaseBackend::Postgres, format!("SELECT COUNT(*) AS row_count, MIN(encode(msg_body, 'hex')) AS body FROM {table}"))).await?.unwrap();
+            assert_eq!(stored.try_get::<i64>("", "row_count")?, 1);
+            assert_eq!(stored.try_get::<String>("", "body")?, "09");
+            db.0.execute_unprepared(&format!(
+                "ALTER TABLE {table} DROP CONSTRAINT reject_dispatch_tail"
+            ))
+            .await?;
+            assert_eq!(store(&db, raw, &rows).await?, u64::from(count - 1));
+            assert_eq!(store(&db, raw, &rows).await?, 0);
+            let stored = db.0.query_one(sea_orm::Statement::from_string(DatabaseBackend::Postgres, format!("SELECT COUNT(*) AS row_count, COUNT(*) FILTER (WHERE msg_body = decode('01', 'hex')) AS expected_bodies FROM {table}"))).await?.unwrap();
+            assert_eq!(stored.try_get::<i64>("", "row_count")?, i64::from(count));
+            assert_eq!(
+                stored.try_get::<i64>("", "expected_bodies")?,
+                i64::from(count)
+            );
+        }
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
@@ -1,6 +1,10 @@
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use migration::OnConflict;
-use sea_orm::{ActiveValue::*, ColumnTrait, EntityTrait, Insert, QueryFilter};
+use sea_orm::{
+    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, TransactionTrait,
+};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, MerkleTreeInsertion, H256};
 
@@ -11,6 +15,10 @@ pub struct StorableMerkleTreeInsertion<'a> {
     pub block_number: u64,
 }
 
+// Each row binds five columns; conflict updates reference EXCLUDED and add no
+// parameters. Keep each statement below PostgreSQL's 65,535-parameter limit.
+const INSERT_CHUNK_SIZE: usize = 13_000;
+
 impl ScraperDb {
     pub async fn store_merkle_tree_insertions(
         &self,
@@ -19,35 +27,50 @@ impl ScraperDb {
         insertions: impl Iterator<Item = StorableMerkleTreeInsertion<'_>>,
     ) -> Result<u64> {
         let merkle_tree_hook = address_to_bytes(merkle_tree_hook);
+        // A single PostgreSQL upsert rejects repeated conflict keys. Preserve
+        // that rejection even when repeated leaves fall into different chunks.
+        let mut leaf_indices = HashSet::new();
         let models = insertions
-            .map(|row| merkle_tree_insertion::ActiveModel {
-                id: NotSet,
-                domain: Unchanged(domain as i32),
-                merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
-                leaf_index: Unchanged(row.insertion.index() as i32),
-                message_id: Set(h256_to_bytes(&row.insertion.message_id())),
-                block_number: Set(row.block_number as i64),
+            .map(|row| {
+                ensure!(
+                    leaf_indices.insert(row.insertion.index()),
+                    "Duplicate Merkle tree leaf index {} in one batch",
+                    row.insertion.index()
+                );
+                Ok(merkle_tree_insertion::ActiveModel {
+                    id: NotSet,
+                    domain: Unchanged(domain as i32),
+                    merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
+                    leaf_index: Unchanged(row.insertion.index() as i32),
+                    message_id: Set(h256_to_bytes(&row.insertion.message_id())),
+                    block_number: Set(row.block_number as i64),
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
+        drop(leaf_indices);
         let count = models.len() as u64;
         if models.is_empty() {
             return Ok(0);
         }
 
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([
-                    merkle_tree_insertion::Column::Domain,
-                    merkle_tree_insertion::Column::MerkleTreeHook,
-                    merkle_tree_insertion::Column::LeafIndex,
-                ])
-                .update_columns([
-                    merkle_tree_insertion::Column::MessageId,
-                    merkle_tree_insertion::Column::BlockNumber,
-                ])
-                .to_owned(),
-            )
-            .exec(&self.0)
+        if models.len() <= INSERT_CHUNK_SIZE {
+            insert_query(models).exec(&self.0).await?;
+            return Ok(count);
+        }
+
+        // A failed later chunk must roll back earlier writes: ContractSync can
+        // advance its cursor only after the entire fetched range is durable.
+        self.0
+            .transaction::<_, (), DbErr>(|txn| {
+                Box::pin(async move {
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models.by_ref().take(INSERT_CHUNK_SIZE).collect();
+                        insert_query(chunk).exec(txn).await?;
+                    }
+                    Ok(())
+                })
+            })
             .await?;
         Ok(count)
     }
@@ -76,3 +99,23 @@ impl ScraperDb {
         }))
     }
 }
+
+fn insert_query(
+    models: Vec<merkle_tree_insertion::ActiveModel>,
+) -> Insert<merkle_tree_insertion::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([
+            merkle_tree_insertion::Column::Domain,
+            merkle_tree_insertion::Column::MerkleTreeHook,
+            merkle_tree_insertion::Column::LeafIndex,
+        ])
+        .update_columns([
+            merkle_tree_insertion::Column::MessageId,
+            merkle_tree_insertion::Column::BlockNumber,
+        ])
+        .to_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, PaginatorTrait, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+
+// Matches the observed 86,580-bind range: five parameters per insertion.
+const ROW_COUNT: u32 = 17_316;
+const DOMAIN: u32 = 1;
+
+fn insertions() -> Vec<MerkleTreeInsertion> {
+    (0..ROW_COUNT)
+        .map(|index| MerkleTreeInsertion::new(index, H256::from_low_u64_be(u64::from(index))))
+        .collect()
+}
+
+fn rows(
+    insertions: &[MerkleTreeInsertion],
+) -> impl Iterator<Item = StorableMerkleTreeInsertion<'_>> {
+    insertions
+        .iter()
+        .map(|insertion| StorableMerkleTreeInsertion {
+            insertion,
+            block_number: 20_000,
+        })
+}
+
+#[tokio::test]
+async fn merkle_insert_statements_stay_below_postgres_bind_limit() {
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([
+            [BTreeMap::from([("id", Value::BigInt(Some(1)))])],
+            [BTreeMap::from([("id", Value::BigInt(Some(2)))])],
+        ])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions()))
+            .await
+            .unwrap(),
+        u64::from(ROW_COUNT)
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1, "all chunks must share a transaction");
+    let statements = transactions[0].statements();
+    assert_eq!(statements.first().unwrap().sql, "BEGIN");
+    assert_eq!(statements.last().unwrap().sql, "COMMIT");
+    assert_eq!(statements.len(), 4);
+    let bind_counts: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("INSERT"))
+        .map(|statement| statement.values.as_ref().unwrap().0.len())
+        .collect();
+    assert_eq!(bind_counts, [65_000, 21_580]);
+    assert!(bind_counts
+        .iter()
+        .all(|count| *count <= usize::from(u16::MAX)));
+}
+
+#[tokio::test]
+async fn merkle_small_insert_keeps_one_statement_and_empty_insert_skips_sql() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[BTreeMap::from([("id", Value::BigInt(Some(1)))])]])
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[]))
+            .await
+            .unwrap(),
+        0
+    );
+    let insertion = MerkleTreeInsertion::new(1, H256::zero());
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[insertion]))
+            .await
+            .unwrap(),
+        1
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1);
+    let statements = transactions[0].statements();
+    assert_eq!(statements.len(), 1);
+    assert!(statements[0].sql.starts_with("INSERT"));
+    assert_eq!(statements[0].values.as_ref().unwrap().0.len(), 5);
+}
+
+#[tokio::test]
+async fn merkle_duplicate_leaf_across_chunks_is_rejected_before_writes() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    let mut insertions = insertions();
+    insertions.push(insertions[0]);
+    let error = db
+        .store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions))
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Duplicate Merkle tree leaf index 0"));
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn merkle_bulk_insert_is_replayable_and_rolls_back_failed_tail() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let hook = H256::from_low_u64_be(1);
+    let insertions = insertions();
+
+    for _ in 0..2 {
+        assert_eq!(
+            db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+                .await?,
+            u64::from(ROW_COUNT)
+        );
+        assert_eq!(
+            merkle_tree_insertion::Entity::find().count(&db.0).await?,
+            u64::from(ROW_COUNT),
+            "replay must not duplicate rows"
+        );
+    }
+    for index in [0, 12_999, 13_000, ROW_COUNT - 1] {
+        assert_eq!(
+            db.retrieve_merkle_tree_insertion(DOMAIN, &hook, index)
+                .await?,
+            Some((insertions[usize::try_from(index)?], 20_000))
+        );
+    }
+
+    // Retain one existing row, then fail the first row of the second chunk.
+    // Both first-chunk inserts and updates must roll back with the failure.
+    db.0.execute_unprepared("TRUNCATE merkle_tree_insertion")
+        .await?;
+    let original = MerkleTreeInsertion::new(0, H256::repeat_byte(0xff));
+    db.store_merkle_tree_insertions(
+        DOMAIN,
+        &hook,
+        [StorableMerkleTreeInsertion {
+            insertion: &original,
+            block_number: 10_000,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    db.0.execute_unprepared(
+        "ALTER TABLE merkle_tree_insertion ADD CONSTRAINT reject_test_tail CHECK (leaf_index <> 13000)"
+    ).await?;
+    assert!(db
+        .store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+        .await
+        .is_err());
+    assert_eq!(merkle_tree_insertion::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((original, 10_000)),
+        "failed tail must also roll back updates to earlier existing rows"
+    );
+
+    db.0.execute_unprepared("ALTER TABLE merkle_tree_insertion DROP CONSTRAINT reject_test_tail")
+        .await?;
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+            .await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        merkle_tree_insertion::Entity::find().count(&db.0).await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((insertions[0], 20_000))
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)] // TODO: `rustc` 1.80.1 clippy issue
 
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, TransactionTrait,
@@ -49,6 +51,9 @@ impl ScraperDb {
     /// u16::MAX (65_535u16) is the maximum amount of parameters we can
     /// have for Postgres. So 65000 / 20 = 3250
     const STORE_MESSAGE_CHUNK_SIZE: usize = 3250;
+
+    // Six bound columns per delivery; conflict expressions add no parameters.
+    const STORE_DELIVERY_CHUNK_SIZE: usize = 10_000;
 
     /// Get the delivered message associated with a sequence.
     #[instrument(skip(self))]
@@ -143,54 +148,57 @@ impl ScraperDb {
         deliveries: impl Iterator<Item = StorableDelivery<'_>>,
     ) -> Result<u64> {
         let destination_mailbox = address_to_bytes(&destination_mailbox);
-        let latest_id_before = self
-            .latest_deliveries_id(domain, destination_mailbox.clone())
-            .await?;
         // we have a race condition where a message may not have been scraped yet even
         // though we have received news of delivery on this chain, so the
         // message IDs are looked up in a separate "thread".
-        let models: Vec<delivered_message::ActiveModel> = deliveries
-            .map(|delivery| delivered_message::ActiveModel {
-                id: NotSet,
-                time_created: Set(date_time::now()),
-                msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
-                domain: Unchanged(domain as i32),
-                destination_mailbox: Unchanged(destination_mailbox.clone()),
-                destination_tx_id: Set(delivery.txn_id),
-                sequence: Set(delivery.sequence),
+        let mut message_ids = HashSet::new();
+        let models = deliveries
+            .map(|delivery| {
+                // Preserve single-upsert rejection across chunk boundaries.
+                ensure!(
+                    message_ids.insert(delivery.message_id),
+                    "Duplicate delivery message id in one batch"
+                );
+                Ok(delivered_message::ActiveModel {
+                    id: NotSet,
+                    time_created: Set(date_time::now()),
+                    msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
+                    domain: Unchanged(domain as i32),
+                    destination_mailbox: Unchanged(destination_mailbox.clone()),
+                    destination_tx_id: Set(delivery.txn_id),
+                    sequence: Set(delivery.sequence),
+                })
             })
-            .collect_vec();
+            .collect::<Result<Vec<_>>>()?;
+        drop(message_ids);
+        if models.is_empty() {
+            return Ok(0);
+        }
+        let latest_id_before = self
+            .latest_deliveries_id(domain, destination_mailbox.clone())
+            .await?;
 
         trace!(?models, "Writing delivered messages to database");
 
-        if models.is_empty() {
-            debug!("Wrote zero new delivered messages to database");
-            return Ok(0);
+        if models.len() <= Self::STORE_DELIVERY_CHUNK_SIZE {
+            delivery_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_DELIVERY_CHUNK_SIZE)
+                                .collect();
+                            delivery_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
+                })
+                .await?;
         }
-
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([delivered_message::Column::MsgId])
-                    // A fallback replay must not discard transaction metadata
-                    // that was resolved by an earlier scrape. This still lets
-                    // a later resolved scrape enrich an existing NULL row.
-                    .value(
-                        delivered_message::Column::DestinationTxId,
-                        Func::if_null(
-                            Expr::col((
-                                Alias::new("excluded"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                            Expr::col((
-                                Alias::new("delivered_message"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                        ),
-                    )
-                    .to_owned(),
-            )
-            .exec(&self.0)
-            .await?;
 
         let new_deliveries_count = self
             .deliveries_count_since_id(domain, destination_mailbox, latest_id_before)
@@ -300,13 +308,9 @@ impl ScraperDb {
             })
             .collect_vec();
 
-        trace!(?models, "Writing messages to database");
-
         if models.is_empty() {
-            debug!("Wrote zero new messages to database");
             return Ok(0);
         }
-
         // ensure all chunks are inserted or none at all
         let new_dispatch_count = self
             .0
@@ -383,6 +387,31 @@ impl ScraperDb {
         );
         Ok(new_dispatch_count)
     }
+}
+
+fn delivery_insert_query(
+    models: Vec<delivered_message::ActiveModel>,
+) -> Insert<delivered_message::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([delivered_message::Column::MsgId])
+            // A fallback replay must not discard transaction metadata
+            // that was resolved by an earlier scrape. This still lets
+            // a later resolved scrape enrich an existing NULL row.
+            .value(
+                delivered_message::Column::DestinationTxId,
+                Func::if_null(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                    Expr::col((
+                        Alias::new("delivered_message"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                ),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -62,3 +62,9 @@ impl Clone for ScraperDb {
         Self(conn)
     }
 }
+
+#[cfg(test)]
+mod write_batches;
+
+#[cfg(test)]
+mod dispatch_transactions;

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use eyre::Result;
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, Statement, TransactionTrait,
@@ -8,7 +8,7 @@ use sea_orm::{
 use tracing::{debug, instrument};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, InterchainGasPayment, LogMeta, H256};
-use migration::OnConflict;
+use migration::{Expr, OnConflict};
 
 use crate::conversions::{decimal_to_u256, u256_to_decimal};
 use crate::date_time;
@@ -28,6 +28,9 @@ pub struct StorablePayment<'a> {
 }
 
 impl ScraperDb {
+    // Eleven parameters per inserted row; reads add two scope parameters.
+    const PAYMENT_STORE_CHUNK_SIZE: usize = 5_000;
+
     const PAYMENT_STORE_LOCK_NAMESPACE: i32 = 0x4859_504C;
 
     /// Get the payment associated with a sequence.
@@ -93,6 +96,25 @@ impl ScraperDb {
         interchain_gas_paymaster: &H256,
         payments: &[StorablePayment<'_>],
     ) -> Result<u64> {
+        if payments.is_empty() {
+            return Ok(0);
+        }
+        // PostgreSQL rejects repeated non-NULL conflict keys in one upsert.
+        // Retain that rejection even if keys would land in different chunks.
+        let mut resolved_keys = HashSet::new();
+        for payment in payments {
+            if let Some(tx_id) = payment.txn_id {
+                ensure!(
+                    resolved_keys.insert((
+                        payment.payment.message_id,
+                        payment.meta.log_index.as_u64(),
+                        tx_id,
+                    )),
+                    "Duplicate resolved gas payment in one batch"
+                );
+            }
+        }
+        drop(resolved_keys);
         let interchain_gas_paymaster = address_to_bytes(interchain_gas_paymaster);
 
         // Postgres unique indexes treat NULLs as distinct, so the
@@ -115,42 +137,38 @@ impl ScraperDb {
         ))
         .await?;
 
-        let latest_id_before = gas_payment::Entity::find()
-            .select_only()
-            .column_as(gas_payment::Column::Id.max(), "max_id")
-            .filter(gas_payment::Column::Domain.eq(domain))
-            .into_tuple::<Option<i64>>()
-            .one(&txn)
-            .await?
-            .flatten()
-            .unwrap_or(0);
-
         let payment_msg_ids = payments
             .iter()
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
+            .unique()
             .collect_vec();
-        let existing_payments = if payment_msg_ids.is_empty() {
-            Vec::new()
-        } else {
-            gas_payment::Entity::find()
+        let mut seen_fallback_payments = HashSet::new();
+        let mut existing_null_payments = HashSet::new();
+        for message_ids in payment_msg_ids.chunks(Self::PAYMENT_STORE_CHUNK_SIZE) {
+            let existing_payments = gas_payment::Entity::find()
+                .select_only()
+                .columns([
+                    gas_payment::Column::MsgId,
+                    gas_payment::Column::LogIndex,
+                    gas_payment::Column::TxId,
+                ])
                 .filter(gas_payment::Column::Domain.eq(domain))
                 .filter(
                     gas_payment::Column::InterchainGasPaymaster
                         .eq(interchain_gas_paymaster.clone()),
                 )
-                .filter(gas_payment::Column::MsgId.is_in(payment_msg_ids))
+                .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
+                .into_tuple::<(Vec<u8>, i64, Option<i64>)>()
                 .all(&txn)
-                .await?
-        };
-        let mut seen_fallback_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .iter()
-            .map(|payment| (payment.msg_id.clone(), payment.log_index))
-            .collect();
-        let mut existing_null_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .into_iter()
-            .filter(|payment| payment.tx_id.is_none())
-            .map(|payment| (payment.msg_id, payment.log_index))
-            .collect();
+                .await?;
+            for (msg_id, log_index, tx_id) in existing_payments {
+                let identity = (msg_id, log_index);
+                if tx_id.is_none() {
+                    existing_null_payments.insert(identity.clone());
+                }
+                seen_fallback_payments.insert(identity);
+            }
+        }
         let resolved_batch_payments: HashSet<(Vec<u8>, i64)> = payments
             .iter()
             .filter(|storable| storable.txn_id.is_some())
@@ -158,6 +176,7 @@ impl ScraperDb {
             .collect();
 
         let mut models = Vec::with_capacity(payments.len());
+        let mut fallback_replacements = Vec::new();
         for storable in payments {
             let identity = payment_identity(storable);
             if storable.txn_id.is_none() {
@@ -171,17 +190,7 @@ impl ScraperDb {
             } else if existing_null_payments.remove(&identity) {
                 // Replace an earlier fallback row instead of keeping both
                 // variants and double-counting it.
-                gas_payment::Entity::delete_many()
-                    .filter(gas_payment::Column::Domain.eq(domain))
-                    .filter(
-                        gas_payment::Column::InterchainGasPaymaster
-                            .eq(interchain_gas_paymaster.clone()),
-                    )
-                    .filter(gas_payment::Column::MsgId.eq(identity.0.clone()))
-                    .filter(gas_payment::Column::LogIndex.eq(identity.1))
-                    .filter(gas_payment::Column::TxId.is_null())
-                    .exec(&txn)
-                    .await?;
+                fallback_replacements.push(identity);
             }
 
             models.push(payment_model(
@@ -197,27 +206,70 @@ impl ScraperDb {
             debug!("Wrote zero new gas payments to database");
             0
         } else {
-            Insert::many(models)
-                .on_conflict(
-                    OnConflict::columns([
-                        // don't need domain because TxId includes it
-                        gas_payment::Column::MsgId,
-                        gas_payment::Column::TxId,
-                        gas_payment::Column::LogIndex,
-                    ])
-                    .update_columns([
-                        gas_payment::Column::TimeCreated,
-                        gas_payment::Column::Payment,
-                        gas_payment::Column::GasAmount,
-                        gas_payment::Column::Origin,
-                        gas_payment::Column::Destination,
-                        gas_payment::Column::InterchainGasPaymaster,
-                        gas_payment::Column::Sequence,
-                    ])
-                    .to_owned(),
-                )
-                .exec(&txn)
-                .await?;
+            let latest_id_before = gas_payment::Entity::find()
+                .select_only()
+                .column_as(gas_payment::Column::Id.max(), "max_id")
+                .filter(gas_payment::Column::Domain.eq(domain))
+                .into_tuple::<Option<i64>>()
+                .one(&txn)
+                .await?
+                .flatten()
+                .unwrap_or(0);
+
+            let mut fallback_replacements = fallback_replacements.into_iter();
+            while !fallback_replacements.as_slice().is_empty() {
+                // Two parameters per identity plus domain/IGP scope. Keep deletion
+                // inside the same transaction as the replacement inserts.
+                let identities: Vec<_> = fallback_replacements
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect();
+                gas_payment::Entity::delete_many()
+                    .filter(gas_payment::Column::Domain.eq(domain))
+                    .filter(
+                        gas_payment::Column::InterchainGasPaymaster
+                            .eq(interchain_gas_paymaster.clone()),
+                    )
+                    .filter(gas_payment::Column::TxId.is_null())
+                    .filter(
+                        Expr::tuple([
+                            Expr::col(gas_payment::Column::MsgId).into(),
+                            Expr::col(gas_payment::Column::LogIndex).into(),
+                        ])
+                        .in_tuples(identities),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
+
+            let mut models = models.into_iter();
+            while !models.as_slice().is_empty() {
+                let chunk = models
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect::<Vec<_>>();
+                Insert::many(chunk)
+                    .on_conflict(
+                        OnConflict::columns([
+                            // don't need domain because TxId includes it
+                            gas_payment::Column::MsgId,
+                            gas_payment::Column::TxId,
+                            gas_payment::Column::LogIndex,
+                        ])
+                        .update_columns([
+                            gas_payment::Column::TimeCreated,
+                            gas_payment::Column::Payment,
+                            gas_payment::Column::GasAmount,
+                            gas_payment::Column::Origin,
+                            gas_payment::Column::Destination,
+                            gas_payment::Column::InterchainGasPaymaster,
+                            gas_payment::Column::Sequence,
+                        ])
+                        .to_owned(),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
 
             gas_payment::Entity::find()
                 .filter(gas_payment::Column::Domain.eq(domain))

--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -161,95 +161,26 @@ impl ScraperDb {
             .latest_raw_dispatch_id(origin_domain, origin_mailbox.clone())
             .await?;
 
-        // Ensure all chunks are inserted or none at all
-        self.0
-            .transaction::<_, (), DbErr>(|txn| {
-                Box::pin(async move {
-                    // Insert raw message dispatches in chunks, to not run into
-                    // "Too many arguments" error
-                    for chunk in models.chunks(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE) {
-                        Insert::many(chunk.to_vec())
-                            .on_conflict(
-                                OnConflict::column(raw_message_dispatch::Column::MsgId)
-                                    .update_columns([
-                                        raw_message_dispatch::Column::TimeUpdated,
-                                        raw_message_dispatch::Column::DestinationDomain,
-                                        raw_message_dispatch::Column::Sender,
-                                        raw_message_dispatch::Column::Recipient,
-                                        raw_message_dispatch::Column::MsgBody,
-                                    ])
-                                    // Preserve resolved hashes across a later
-                                    // basic-meta fallback, while still updating
-                                    // the body and other fields on legacy rows.
-                                    .value(
-                                        raw_message_dispatch::Column::OriginTxHash,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            ))
-                                            .ne(h512_to_bytes(&H512::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginTxHash,
-                                            )),
-                                        ),
-                                    )
-                                    .value(
-                                        raw_message_dispatch::Column::OriginBlockHash,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            ))
-                                            .ne(h256_to_bytes(&H256::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            )),
-                                        ),
-                                    )
-                                    .value(
-                                        raw_message_dispatch::Column::OriginBlockHeight,
-                                        Expr::case(
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHash,
-                                            ))
-                                            .ne(h256_to_bytes(&H256::zero())),
-                                            Expr::col((
-                                                Alias::new("excluded"),
-                                                raw_message_dispatch::Column::OriginBlockHeight,
-                                            )),
-                                        )
-                                        .finally(
-                                            Expr::col((
-                                                Alias::new("raw_message_dispatch"),
-                                                raw_message_dispatch::Column::OriginBlockHeight,
-                                            )),
-                                        ),
-                                    )
-                                    .to_owned(),
-                            )
-                            .exec(txn)
-                            .await?;
-                    }
-                    Ok(())
+        // A single INSERT is atomic; multiple chunks need one shared transaction.
+        if models.len() <= Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE {
+            raw_dispatch_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE)
+                                .collect();
+                            raw_dispatch_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
                 })
-            })
-            .await?;
+                .await?;
+        }
 
         let new_dispatch_count = self
             .raw_dispatch_count_since_id(origin_domain, origin_mailbox, latest_id_before)
@@ -395,6 +326,79 @@ fn raw_dispatch_to_candidate(raw: raw_message_dispatch::Model) -> Result<RawDisp
             log_index: U256::zero(),
         },
     })
+}
+
+fn raw_dispatch_insert_query(
+    models: Vec<raw_message_dispatch::ActiveModel>,
+) -> Insert<raw_message_dispatch::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::column(raw_message_dispatch::Column::MsgId)
+            .update_columns([
+                raw_message_dispatch::Column::TimeUpdated,
+                raw_message_dispatch::Column::DestinationDomain,
+                raw_message_dispatch::Column::Sender,
+                raw_message_dispatch::Column::Recipient,
+                raw_message_dispatch::Column::MsgBody,
+            ])
+            // Preserve resolved hashes across a later
+            // basic-meta fallback, while still updating
+            // the body and other fields on legacy rows.
+            .value(
+                raw_message_dispatch::Column::OriginTxHash,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginTxHash,
+                    ))
+                    .ne(h512_to_bytes(&H512::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginTxHash,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginTxHash,
+                ))),
+            )
+            .value(
+                raw_message_dispatch::Column::OriginBlockHash,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    ))
+                    .ne(h256_to_bytes(&H256::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginBlockHash,
+                ))),
+            )
+            .value(
+                raw_message_dispatch::Column::OriginBlockHeight,
+                Expr::case(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHash,
+                    ))
+                    .ne(h256_to_bytes(&H256::zero())),
+                    Expr::col((
+                        Alias::new("excluded"),
+                        raw_message_dispatch::Column::OriginBlockHeight,
+                    )),
+                )
+                .finally(Expr::col((
+                    Alias::new("raw_message_dispatch"),
+                    raw_message_dispatch::Column::OriginBlockHeight,
+                ))),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -94,7 +94,7 @@ impl ScraperDb {
                     recipient: Set(txn.recipient.as_ref().map(address_to_bytes)),
                     max_fee_per_gas: Set(txn.max_fee_per_gas.map(u256_to_decimal)),
                     cumulative_gas_used: Set(u256_to_decimal(receipt.cumulative_gas_used)),
-                    raw_input_data: Set(txn.raw_input_data.clone()),
+                    raw_input_data: Set(txn.info.raw_input_data),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -1,0 +1,756 @@
+//! Regression tests for PostgreSQL statement bounds and atomic event writes.
+
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, Database, DatabaseBackend, EntityTrait, MockDatabase,
+    MockExecResult, PaginatorTrait, QueryFilter, Value,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use hyperlane_core::{
+    BlockInfo, InterchainGasPayment, LogMeta, TxnInfo, TxnReceiptInfo, H256, H512, U256,
+};
+
+use super::{
+    generated::{delivered_message, gas_payment},
+    ScraperDb, StorableDelivery, StorablePayment, StorableTxn,
+};
+
+const DOMAIN: u32 = 1;
+
+fn result(key: &str, value: i64) -> Vec<BTreeMap<String, Value>> {
+    vec![BTreeMap::from([(
+        key.to_owned(),
+        Value::BigInt(Some(value)),
+    )])]
+}
+
+fn payments(count: u32) -> Vec<InterchainGasPayment> {
+    (0..count)
+        .map(|index| InterchainGasPayment {
+            message_id: H256::from_low_u64_be(u64::from(index)),
+            destination: DOMAIN,
+            payment: U256::from(1000),
+            gas_amount: U256::from(12345),
+        })
+        .collect()
+}
+
+fn payment_rows<'a>(
+    payments: &'a [InterchainGasPayment],
+    meta: &'a LogMeta,
+    txn_id: Option<i64>,
+) -> Vec<StorablePayment<'a>> {
+    payments
+        .iter()
+        .enumerate()
+        .map(|(index, payment)| StorablePayment {
+            payment,
+            sequence: Some(i64::try_from(index).unwrap()),
+            meta,
+            txn_id,
+        })
+        .collect()
+}
+
+fn deliveries(count: u32, meta: &LogMeta) -> impl Iterator<Item = StorableDelivery<'_>> {
+    (0..count).map(|index| StorableDelivery {
+        message_id: H256::from_low_u64_be(u64::from(index)),
+        sequence: Some(i64::from(index)),
+        meta,
+        txn_id: None,
+    })
+}
+
+#[tokio::test]
+async fn empty_event_writes_do_not_access_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert_eq!(
+        db.store_deliveries(DOMAIN, H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &H256::zero(), &[]).await.unwrap(),
+        0
+    );
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn delivery_batches_bound_binds_and_preserve_small_fast_path() {
+    for count in [1, 12_000] {
+        let chunks = if count == 1 { 1 } else { 2 };
+        let mut results = vec![result("max_id", 0)];
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(results)
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_deliveries(DOMAIN, H256::zero(), deliveries(count, &LogMeta::default()))
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        let statements: Vec<_> = log
+            .iter()
+            .flat_map(|transaction| transaction.statements())
+            .collect();
+        let binds: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .map(|statement| statement.values.as_ref().unwrap().0.len())
+            .collect();
+        assert_eq!(
+            binds,
+            if count == 1 {
+                vec![6]
+            } else {
+                vec![60_000, 12_000]
+            }
+        );
+        assert_eq!(statements.len(), if count == 1 { 3 } else { 6 });
+        if count > 1 {
+            assert_eq!(log[1].statements().first().unwrap().sql, "BEGIN");
+            assert_eq!(log[1].statements().last().unwrap().sql, "COMMIT");
+        }
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
+    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERT statements.
+    for count in [5_000_u32, 66_000] {
+        let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
+        let mut results = (0..chunks).map(|_| Vec::new()).collect::<Vec<_>>();
+        results.push(result("max_id", 0));
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results(results)
+                .into_connection(),
+        );
+        let mut payments = payments(count);
+        payments.push(payments[0].clone()); // Prefetch and NULL-row identity must dedupe this.
+        let meta = LogMeta::default();
+        let rows = payment_rows(&payments, &meta, None);
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &rows)
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        assert_eq!(
+            log.len(),
+            1,
+            "one transaction must retain the advisory lock throughout"
+        );
+        let statements = log[0].statements();
+        assert_eq!(statements.first().unwrap().sql, "BEGIN");
+        assert_eq!(statements.last().unwrap().sql, "COMMIT");
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| statement.sql.contains("pg_advisory_xact_lock"))
+                .count(),
+            1
+        );
+        let reads: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.contains(" IN ("))
+            .collect();
+        assert_eq!(reads.len(), chunks);
+        assert!(reads.iter().all(|statement| statement.sql.starts_with(
+            "SELECT \"gas_payment\".\"msg_id\", \"gas_payment\".\"log_index\", \"gas_payment\".\"tx_id\" FROM"
+        )));
+        assert!(reads
+            .iter()
+            .all(|statement| statement.values.as_ref().unwrap().0.len() <= 5_002));
+        let inserts: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .collect();
+        assert_eq!(inserts.len(), chunks);
+        assert_eq!(inserts[0].values.as_ref().unwrap().0.len(), 55_000);
+        assert!(statements.iter().all(|statement| statement
+            .values
+            .as_ref()
+            .map_or(true, |values| values.0.len() <= usize::from(u16::MAX))));
+    }
+}
+
+#[tokio::test]
+async fn payment_fallback_replays_skip_count_baseline() {
+    for existing_tx_id in [None, Some(7)] {
+        let payments = payments(1);
+        let meta = LogMeta::default();
+        let existing = vec![BTreeMap::from([
+            (
+                "0".to_owned(),
+                Value::Bytes(Some(Box::new(hyperlane_core::h256_to_bytes(
+                    &payments[0].message_id,
+                )))),
+            ),
+            ("1".to_owned(), Value::BigInt(Some(0))),
+            ("2".to_owned(), Value::BigInt(existing_tx_id)),
+        ])];
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results([existing])
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &payment_rows(&payments, &meta, None))
+                .await
+                .unwrap(),
+            0
+        );
+        let log = db.0.into_transaction_log();
+        let statements = log[0].statements();
+        assert_eq!(statements.len(), 4);
+        assert_eq!(statements[0].sql, "BEGIN");
+        assert!(statements[1].sql.contains("pg_advisory_xact_lock"));
+        assert!(statements[2].sql.contains(" IN ("));
+        assert_eq!(statements[3].sql, "COMMIT");
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_baseline_errors_precede_writes() {
+    for fail_prefetch in [true, false] {
+        let mock =
+            MockDatabase::new(DatabaseBackend::Postgres).append_exec_results([MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }]);
+        let mock = if fail_prefetch {
+            mock
+        } else {
+            mock.append_query_results([Vec::<BTreeMap<String, Value>>::new()])
+        };
+        let db = ScraperDb::with_connection(
+            mock.append_query_errors([sea_orm::DbErr::Custom("read failed".to_owned())])
+                .into_connection(),
+        );
+        let payments = payments(1);
+        let meta = LogMeta::default();
+        assert!(db
+            .store_payments(DOMAIN, &H256::zero(), &payment_rows(&payments, &meta, None))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("read failed"));
+        let log = db.0.into_transaction_log();
+        let statements = log[0].statements();
+        assert_eq!(statements.last().unwrap().sql, "ROLLBACK");
+        assert!(!statements
+            .iter()
+            .any(|s| s.sql.starts_with("INSERT") || s.sql.starts_with("DELETE")));
+    }
+}
+
+#[tokio::test]
+async fn duplicate_keys_across_chunks_are_rejected() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([result("max_id", 0)])
+            .into_connection(),
+    );
+    let meta = LogMeta::default();
+    let rows = deliveries(12_000, &meta).chain(deliveries(1, &meta));
+    assert!(db
+        .store_deliveries(DOMAIN, H256::zero(), rows)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate delivery"));
+    let mut payments = payments(6_000);
+    payments.push(payments[0].clone());
+    assert!(db
+        .store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate resolved gas payment"));
+    let log = db.0.into_transaction_log();
+    assert!(log.is_empty());
+}
+
+async fn seed_transaction(db: &ScraperDb, index: u64) -> eyre::Result<i64> {
+    let hash = H256::from_low_u64_be(55);
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash,
+            timestamp: 1_700_000_000,
+            number: 500,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let block_id = db.get_block_basic([&hash].into_iter()).await?[0].id;
+    let tx_hash = H512::from_low_u64_be(66 + index);
+    db.store_txns(
+        [StorableTxn {
+            block_id,
+            info: TxnInfo {
+                hash: tx_hash,
+                gas_limit: U256::one(),
+                max_priority_fee_per_gas: None,
+                max_fee_per_gas: None,
+                gas_price: None,
+                nonce: 0,
+                sender: H256::zero(),
+                recipient: None,
+                receipt: Some(TxnReceiptInfo {
+                    gas_used: U256::one(),
+                    cumulative_gas_used: U256::one(),
+                    effective_gas_price: None,
+                }),
+                raw_input_data: None,
+            },
+        }]
+        .into_iter(),
+    )
+    .await?;
+    Ok(db.get_txn_ids([&tx_hash].into_iter()).await?[&tx_hash])
+}
+
+#[tokio::test]
+async fn bulk_events_replay_and_rollback_failed_tail_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        12_000
+    );
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        0
+    );
+    assert_eq!(
+        delivered_message::Entity::find().count(&db.0).await?,
+        12_000
+    );
+    db.0.execute_unprepared("TRUNCATE delivered_message")
+        .await?;
+    let original_tx = seed_transaction(&db, 0).await?;
+    let replacement_tx = seed_transaction(&db, 1).await?;
+    db.store_deliveries(
+        DOMAIN,
+        address,
+        deliveries(1, &meta).map(|mut row| {
+            row.txn_id = Some(original_tx);
+            row
+        }),
+    )
+    .await?;
+    db.0.execute_unprepared("ALTER TABLE delivered_message ADD CONSTRAINT reject_delivery_tail CHECK (sequence <> 10000)").await?;
+    assert!(db
+        .store_deliveries(
+            DOMAIN,
+            address,
+            deliveries(12_000, &meta).map(|mut row| {
+                row.txn_id = Some(replacement_tx);
+                row
+            })
+        )
+        .await
+        .is_err());
+    assert_eq!(delivered_message::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        delivered_message::Entity::find()
+            .one(&db.0)
+            .await?
+            .unwrap()
+            .destination_tx_id,
+        Some(original_tx)
+    );
+    db.0.execute_unprepared("ALTER TABLE delivered_message DROP CONSTRAINT reject_delivery_tail")
+        .await?;
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        11_999
+    );
+
+    let payments = payments(6_000);
+    let fallback = payment_rows(&payments, &meta, None);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    db.0.execute_unprepared("TRUNCATE gas_payment").await?;
+    db.store_payments(DOMAIN, &address, &fallback[..1]).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let resolved = payment_rows(&payments, &meta, Some(tx_id));
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_payment_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        1,
+        "failed tail must restore the deleted NULL fallback row"
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_payment_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &address, &fallback).await?,
+        0,
+        "later fallback replay must preserve resolved rows"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let rows = || {
+        (0..3_251u32).map(|nonce| super::StorableMessage {
+            msg: hyperlane_core::HyperlaneMessage {
+                nonce,
+                origin: DOMAIN,
+                destination: DOMAIN,
+                body: if nonce == 0 {
+                    vec![]
+                } else {
+                    vec![(nonce % 251) as u8; 1_024]
+                },
+                ..Default::default()
+            },
+            meta: &meta,
+            txn_id: None,
+            id_override: None,
+        })
+    };
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        3_251
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = super::generated::message::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), 3_251);
+    for row in stored {
+        let expected = if row.nonce == 0 {
+            None
+        } else {
+            Some(vec![(row.nonce % 251) as u8; 1_024])
+        };
+        assert_eq!(row.msg_body, expected);
+    }
+    Ok(())
+}
+#[tokio::test]
+async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Result<()> {
+    use super::generated::{raw_message_dispatch, transaction};
+    use super::StorableRawMessageDispatch;
+    use hyperlane_core::HyperlaneMessage;
+
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let messages: Vec<_> = (0..2_955u32)
+        .map(|nonce| HyperlaneMessage {
+            nonce,
+            origin: DOMAIN,
+            destination: DOMAIN,
+            body: if nonce == 0 {
+                vec![]
+            } else {
+                vec![(nonce % 251) as u8; 1_024]
+            },
+            ..Default::default()
+        })
+        .collect();
+    let rows = || {
+        messages
+            .iter()
+            .map(|msg| StorableRawMessageDispatch { msg, meta: &meta })
+    };
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        2_955
+    );
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = raw_message_dispatch::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), messages.len());
+    for row in stored {
+        assert_eq!(
+            row.msg_body.as_ref(),
+            Some(&messages[row.nonce as usize].body)
+        );
+    }
+
+    seed_transaction(&db, 0).await?;
+    let block_id = db
+        .get_block_basic([&H256::from_low_u64_be(55)].into_iter())
+        .await?[0]
+        .id;
+    let inputs = [None, Some(vec![]), Some(vec![0xab; 4_096])];
+    let transactions = || {
+        inputs
+            .iter()
+            .enumerate()
+            .map(|(index, raw_input_data)| StorableTxn {
+                block_id,
+                info: TxnInfo {
+                    hash: H512::from_low_u64_be(100 + index as u64),
+                    gas_limit: U256::one(),
+                    max_priority_fee_per_gas: None,
+                    max_fee_per_gas: None,
+                    gas_price: None,
+                    nonce: 0,
+                    sender: H256::zero(),
+                    recipient: None,
+                    receipt: Some(TxnReceiptInfo {
+                        gas_used: U256::one(),
+                        cumulative_gas_used: U256::one(),
+                        effective_gas_price: None,
+                    }),
+                    raw_input_data: raw_input_data.clone(),
+                },
+            })
+    };
+    db.store_txns(transactions()).await?;
+    db.store_txns(transactions()).await?;
+    for (index, expected) in inputs.iter().enumerate() {
+        let row = transaction::Entity::find()
+            .filter(transaction::Column::Hash.eq(hyperlane_core::h512_to_bytes(
+                &H512::from_low_u64_be(100 + index as u64),
+            )))
+            .one(&db.0)
+            .await?
+            .unwrap();
+        assert_eq!(&row.raw_input_data, expected);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn payment_fallback_deletes_use_bounded_tuple_keys() {
+    let payments = payments(6_000);
+    let meta = LogMeta::default();
+    let mut results = Vec::new();
+    for chunk in payments.chunks(5_000) {
+        // MockDatabase reads tuples by sorted-key position, not SQL column name.
+        results.push(
+            chunk
+                .iter()
+                .map(|payment| {
+                    BTreeMap::from([
+                        (
+                            "0".to_owned(),
+                            Value::Bytes(Some(Box::new(hyperlane_core::h256_to_bytes(
+                                &payment.message_id,
+                            )))),
+                        ),
+                        ("1".to_owned(), Value::BigInt(Some(0))),
+                        ("2".to_owned(), Value::BigInt(None)),
+                    ])
+                })
+                .collect(),
+        );
+    }
+    results.push(result("max_id", 0));
+    results.extend([result("id", 1), result("id", 2), result("num_items", 6_000)]);
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_exec_results((0..3).map(|_| MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }))
+            .append_query_results(results)
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap(),
+        6_000
+    );
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 1);
+    let statements = log[0].statements();
+    assert_eq!(statements.len(), 11);
+    let deletes: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("DELETE"))
+        .collect();
+    assert_eq!(deletes.len(), 2);
+    assert_eq!(deletes[0].values.as_ref().unwrap().0.len(), 10_002);
+    assert_eq!(deletes[1].values.as_ref().unwrap().0.len(), 2_002);
+    for statement in deletes {
+        assert!(statement.sql.contains("\"tx_id\" IS NULL"));
+        assert!(statement.sql.contains("(\"msg_id\", \"log_index\") IN"));
+    }
+}
+
+#[tokio::test]
+async fn payment_fallback_deletes_preserve_neighbors_and_rollback_in_postgres() -> eyre::Result<()>
+{
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let mut neighbor_meta = LogMeta::default();
+    neighbor_meta.log_index = U256::one();
+    let address = H256::from_low_u64_be(1);
+    let other_address = H256::from_low_u64_be(2);
+    let payments = payments(6_000);
+    let mut fallback = payment_rows(&payments, &meta, None);
+    for row in fallback.iter_mut().skip(1).step_by(2) {
+        row.meta = &neighbor_meta;
+    }
+    db.store_payments(DOMAIN, &address, &fallback).await?;
+    db.store_payments(DOMAIN, &other_address, &fallback[..1])
+        .await?;
+    db.store_payments(
+        DOMAIN,
+        &address,
+        &payment_rows(&payments[..1], &neighbor_meta, None),
+    )
+    .await?;
+    let other_domain = super::generated::domain::Entity::find()
+        .filter(super::generated::domain::Column::Id.gt(1))
+        .one(&db.0)
+        .await?
+        .unwrap()
+        .id;
+    db.store_payments(u32::try_from(other_domain)?, &address, &fallback[..1])
+        .await?;
+    let other_tx_id = seed_transaction(&db, 1).await?;
+    db.0.execute(sea_orm::Statement::from_sql_and_values(DatabaseBackend::Postgres,
+        "INSERT INTO gas_payment (time_created,domain,msg_id,payment,gas_amount,tx_id,log_index,origin,destination,interchain_gas_paymaster,sequence) SELECT time_created,domain,msg_id,payment,gas_amount,$1,log_index,origin,destination,interchain_gas_paymaster,sequence FROM gas_payment ORDER BY id LIMIT 1",
+        [other_tx_id.into()],
+    )).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let mut resolved = payment_rows(&payments, &meta, Some(tx_id));
+    for row in resolved.iter_mut().skip(1).step_by(2) {
+        row.meta = &neighbor_meta;
+    }
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_repair_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_004);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        6_003
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_repair_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_004);
+    let neighbors = gas_payment::Entity::find()
+        .filter(gas_payment::Column::TxId.is_null())
+        .all(&db.0)
+        .await?;
+    assert_eq!(neighbors.len(), 3);
+    assert!(neighbors.iter().any(
+        |row| row.interchain_gas_paymaster == hyperlane_core::address_to_bytes(&other_address)
+    ));
+    assert!(neighbors.iter().any(|row| row.log_index == 1));
+    assert!(neighbors.iter().any(|row| row.domain == other_domain));
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.eq(other_tx_id))
+            .count(&db.0)
+            .await?,
+        1
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -7,7 +7,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use eyre::Result;
-use itertools::Itertools;
 use prometheus::IntCounterVec;
 use tracing::{trace, warn};
 
@@ -110,7 +109,7 @@ impl HyperlaneDbStore {
             .map(|(txn_hash, block_id)| TxnWithBlockId { txn_hash, block_id });
         let txns_with_ids = self.ensure_txns(txn_hash_with_block_ids).await?;
 
-        Ok(txns_with_ids.map(move |TxnWithId { hash, id: txn_id }| TxnWithId { hash, id: txn_id }))
+        Ok(txns_with_ids)
     }
 
     /// Takes a list of transaction hashes and the block id the transaction is
@@ -344,13 +343,60 @@ struct TxnWithBlockId {
     block_id: i64,
 }
 
-fn as_chunks<T>(iter: impl Iterator<Item = T>, chunk_size: usize) -> impl Iterator<Item = Vec<T>> {
-    // the itertools chunks function uses refcell which cannot be used across an
-    // await so this stabilizes the result by putting it into a vec of vecs and
-    // using that for iteration.
-    iter.chunks(chunk_size)
-        .into_iter()
-        .map(|chunk| chunk.into_iter().collect())
-        .collect_vec()
-        .into_iter()
+fn as_chunks<T>(
+    mut iter: impl Iterator<Item = T>,
+    chunk_size: usize,
+) -> impl Iterator<Item = Vec<T>> {
+    assert!(chunk_size > 0, "chunk size must be positive");
+    // Own just the current chunk across await points. itertools::chunks keeps
+    // a RefCell borrowed by each chunk, which cannot be held across awaits.
+    std::iter::from_fn(move || {
+        let chunk: Vec<_> = iter.by_ref().take(chunk_size).collect();
+        (!chunk.is_empty()).then_some(chunk)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::as_chunks;
+
+    #[test]
+    fn enrichment_chunks_only_consume_the_requested_batch() {
+        let consumed = Cell::new(0);
+        let input = (0..1_000).inspect(|_| consumed.set(consumed.get() + 1));
+        let mut chunks = as_chunks(input, 50);
+        assert_eq!(consumed.get(), 0);
+        assert_eq!(chunks.next(), Some((0..50).collect()));
+        assert_eq!(consumed.get(), 50);
+        assert_eq!(chunks.next(), Some((50..100).collect()));
+        assert_eq!(consumed.get(), 100);
+        drop(chunks);
+        assert_eq!(
+            consumed.get(),
+            100,
+            "dropping work must not consume later chunks"
+        );
+    }
+
+    #[test]
+    fn enrichment_chunks_preserve_order_and_partial_tail() {
+        assert_eq!(
+            as_chunks(0..5, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3], vec![4]]
+        );
+        assert_eq!(
+            as_chunks(0..4, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3]]
+        );
+        assert_eq!(as_chunks(0..1, 2).collect::<Vec<_>>(), vec![vec![0]]);
+        assert_eq!(as_chunks(0..0, 2).next(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "chunk size must be positive")]
+    fn enrichment_chunks_reject_zero_chunk_size() {
+        let _ = as_chunks(0..1, 0);
+    }
 }


### PR DESCRIPTION
## Problem

Large scraper event batches could exceed PostgreSQL's bind limit, and split upserts must remain atomic. The same ingestion paths also copied owned payload buffers and issued unnecessary transaction/count commands during smaller writes or replay.

## Solution

Bound Merkle, delivery, and payment statements; retain transactions around multi-statement writes, advisory locking and NULL-payment reconciliation, and whole-batch duplicate rejection. Bound and project payment prefetch, batch exact fallback identities for deletion, move owned model buffers, and materialize enrichment chunks lazily. Single-statement raw dispatch writes use PostgreSQL's statement atomicity; no-write payment replay skips the unused count baseline.

Main now supplies race-free inserted-row counting for enriched dispatches via #9446. This PR preserves that implementation rather than restoring its older MAX/count fast path.

Consolidates #9476, #9481, #9484, #9487, #9488, #9494, #9506, and #9519. Lookup/RETURNING changes follow in the next group.

## Numerical evidence

- Merkle inserts use at most 13,000 rows/65,000 binds per statement. Observed Base backfill batches contained 17,316 rows/86,580 binds and repeatedly failed; the bounded path uses two inserts in one transaction. No production deployment claim.
- Delivery/payment writes cap at 60,000/55,000 binds. Replacing 6,000 payment fallbacks uses 2 DELETEs instead of 6,000; the representative full operation falls from 6,009 to 11 commands.
- Payment prefetch projects 3 rather than 12 columns (75% fewer decoded columns, not a wire-byte percentage). A successful one-prefetch no-write replay uses 4 rather than 5 commands.
- Successful single-chunk raw dispatch writes use 3 rather than 5 commands. Enriched dispatch command accounting is supplied by #9446 on main and excluded from this PR's incremental claim.
- Payload-buffer moves eliminate the corresponding full-body copies; temporary enrichment references for 1,000 entries peak at 50 rather than 1,000. Maps and query results remain proportional to their input/result cardinality.

These are separate case-specific mechanisms; their percentages must not be added. No fleet latency/RSS estimate.

## Validation

The pre-rebase consolidated tree passed 51 scraper tests (0 failures, 1 ignored; 40.49s). PostgreSQL regressions cover chunk boundaries, duplicate rejection, failed-tail rollback of inserts/updates/fallback deletion, unrelated identities, NULL/resolved replay, and payload byte preservation.

The consolidation moves #9468's existing one-line identity-map cleanup into this group so its intermediate code passes strict Clippy; the remaining #9468 lookup changes follow separately.

Strict scraper production Clippy passed on the consolidated tree (46.42s), and its normal hooks passed. The current-main rebase passed `git diff --check`, targeted `rustfmt --check`, and semantic range-diff review; CI is authoritative for rebuilt tests.
