### PR TITLE
perf(validator): publish newest checkpoint before sibling retries finish

### DIFF
--- a/rust/main/agents/validator/src/submit.rs
+++ b/rust/main/agents/validator/src/submit.rs
@@ -489,17 +489,53 @@ impl ValidatorSubmitter {
         Ok(true)
     }
 
+    /// Publishes availability only after the highest checkpoint itself is durable.
+    async fn publish_latest_checkpoint_index(&self, index: u32) {
+        call_and_retry_indefinitely(|| {
+            let self_clone = self.clone();
+            Box::pin(async move {
+                let start = Instant::now();
+                let result = self_clone
+                    .checkpoint_syncer
+                    .update_latest_index(index)
+                    .await;
+                match result {
+                    Ok(()) => self_clone
+                        .readiness
+                        .mark_operation_ready("checkpoint_latest_index"),
+                    Err(error) => {
+                        let snapshot = self_clone
+                            .readiness
+                            .mark_operation_blocked("checkpoint_latest_index");
+                        warn!(
+                            operation = "checkpoint_latest_index",
+                            consecutive_failures = snapshot.consecutive_failures,
+                            failure_duration_ms = snapshot.failure_duration_ms,
+                            signing_blocked = snapshot.signing_blocked,
+                            "Validator latest checkpoint index update is blocked"
+                        );
+                        return Err(error.into());
+                    }
+                }
+                tracing::trace!(
+                    elapsed=?start.elapsed(),
+                    "Updated latest index",
+                );
+                Ok(())
+            })
+        })
+        .await;
+    }
+
     /// Signs and submits any previously unsubmitted checkpoints.
     async fn sign_and_submit_checkpoints(&self, mut checkpoints: Vec<CheckpointWithMessageId>) {
         // The checkpoints are ordered by index, so the last one is the highest index.
-        let last_checkpoint_index = match checkpoints.last() {
-            Some(c) => c.index,
+        let mut latest_index_to_publish = match checkpoints.last() {
+            Some(c) => Some(c.index),
             None => return,
         };
 
         let arc_self = Arc::new(self.clone());
-
-        let mut first_chunk = true;
 
         while !checkpoints.is_empty() {
             let start = Instant::now();
@@ -509,8 +545,7 @@ impl ValidatorSubmitter {
             // since those are the most likely to make messages become processable.
             // A side effect is that new checkpoints will also be submitted in reverse order.
 
-            // This logic is a bit awkward, but we want control over the chunks so we can also
-            // write the latest index to the checkpoint storage after the first chunk is successful.
+            // Keep bounded chunks so a storage/signing burst is paced before the next chunk.
             let mut chunk = Vec::with_capacity(self.max_sign_concurrency);
             for _ in 0..self.max_sign_concurrency {
                 if let Some(cp) = checkpoints.pop() {
@@ -524,41 +559,53 @@ impl ValidatorSubmitter {
 
             let futures = chunk.into_iter().map(|checkpoint| {
                 let self_clone = arc_self.clone();
-                let operation = format!("checkpoint_submission[{}]", checkpoint.index);
-                call_and_retry_indefinitely(move || {
-                    let self_clone = self_clone.clone();
-                    let operation = operation.clone();
-                    Box::pin(async move {
-                        let start = Instant::now();
-                        let checkpoint_index = checkpoint.index;
-                        let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
-                        let wrote_checkpoint = match result {
-                            Ok(wrote_checkpoint) => {
-                                self_clone.readiness.mark_operation_ready(&operation);
-                                wrote_checkpoint
-                            }
-                            Err(error) => {
-                                let snapshot =
-                                    self_clone.readiness.mark_operation_blocked(&operation);
-                                warn!(
-                                    operation,
-                                    consecutive_failures = snapshot.consecutive_failures,
-                                    failure_duration_ms = snapshot.failure_duration_ms,
-                                    signing_blocked = snapshot.signing_blocked,
-                                    "Validator checkpoint submission is blocked"
-                                );
-                                return Err(error);
-                            }
-                        };
-                        tracing::info!(
-                            index = checkpoint_index,
-                            wrote_checkpoint,
-                            elapsed=?start.elapsed(),
-                            "Processed checkpoint",
-                        );
-                        Ok(wrote_checkpoint)
+                // The first popped checkpoint alone owns publication, even if a caller
+                // supplied the same maximum index more than once.
+                let latest_index = latest_index_to_publish.take();
+                async move {
+                    let operation = format!("checkpoint_submission[{}]", checkpoint.index);
+                    let wrote_checkpoint = call_and_retry_indefinitely(|| {
+                        let self_clone = self_clone.clone();
+                        let operation = operation.clone();
+                        Box::pin(async move {
+                            let start = Instant::now();
+                            let checkpoint_index = checkpoint.index;
+                            let result = self_clone.sign_and_submit_checkpoint(checkpoint).await;
+                            let wrote_checkpoint = match result {
+                                Ok(wrote_checkpoint) => {
+                                    self_clone.readiness.mark_operation_ready(&operation);
+                                    wrote_checkpoint
+                                }
+                                Err(error) => {
+                                    let snapshot =
+                                        self_clone.readiness.mark_operation_blocked(&operation);
+                                    warn!(
+                                        operation,
+                                        consecutive_failures = snapshot.consecutive_failures,
+                                        failure_duration_ms = snapshot.failure_duration_ms,
+                                        signing_blocked = snapshot.signing_blocked,
+                                        "Validator checkpoint submission is blocked"
+                                    );
+                                    return Err(error);
+                                }
+                            };
+                            tracing::info!(
+                                index = checkpoint_index,
+                                wrote_checkpoint,
+                                elapsed=?start.elapsed(),
+                                "Processed checkpoint",
+                            );
+                            Ok(wrote_checkpoint)
+                        })
                     })
-                })
+                    .await;
+                    // Lower checkpoints may still be retrying. The latest index is an upper
+                    // bound, not a claim that every historical checkpoint has been uploaded.
+                    if let Some(index) = latest_index {
+                        self_clone.publish_latest_checkpoint_index(index).await;
+                    }
+                    wrote_checkpoint
+                }
             });
 
             let wrote_checkpoint = join_all(futures).await.into_iter().any(|wrote| wrote);
@@ -569,45 +616,6 @@ impl ValidatorSubmitter {
                 remaining_checkpoints = checkpoints.len(),
                 "Signed and submitted checkpoint chunk",
             );
-
-            // If it's the first chunk, update the latest index
-            if first_chunk {
-                call_and_retry_indefinitely(|| {
-                    let self_clone = self.clone();
-                    Box::pin(async move {
-                        let start = Instant::now();
-                        let result = self_clone
-                            .checkpoint_syncer
-                            .update_latest_index(last_checkpoint_index)
-                            .await;
-                        match result {
-                            Ok(()) => self_clone
-                                .readiness
-                                .mark_operation_ready("checkpoint_latest_index"),
-                            Err(error) => {
-                                let snapshot = self_clone
-                                    .readiness
-                                    .mark_operation_blocked("checkpoint_latest_index");
-                                warn!(
-                                    operation = "checkpoint_latest_index",
-                                    consecutive_failures = snapshot.consecutive_failures,
-                                    failure_duration_ms = snapshot.failure_duration_ms,
-                                    signing_blocked = snapshot.signing_blocked,
-                                    "Validator latest checkpoint index update is blocked"
-                                );
-                                return Err(error.into());
-                            }
-                        }
-                        tracing::trace!(
-                            elapsed=?start.elapsed(),
-                            "Updated latest index",
-                        );
-                        Ok(())
-                    })
-                })
-                .await;
-                first_chunk = false;
-            }
 
             // Pace storage/signing bursts between chunks without delaying the latest-index
             // update, throttling all-existing backfills, or adding a final-chunk tail.

--- a/rust/main/agents/validator/src/submit/tests.rs
+++ b/rust/main/agents/validator/src/submit/tests.rs
@@ -100,6 +100,183 @@ fn dummy_readiness() -> Arc<ValidatorReadiness> {
     Arc::new(ValidatorReadiness::default())
 }
 
+fn submission_test_submitter(
+    syncer: MockCheckpointSyncer,
+    readiness: Arc<ValidatorReadiness>,
+) -> ValidatorSubmitter {
+    let signer: Signers = ethers::signers::LocalWallet::new(&mut rand::thread_rng()).into();
+    ValidatorSubmitter::new(
+        Duration::from_secs(1),
+        ReorgPeriod::from_blocks(1),
+        Arc::new(MockMerkleTreeHook::new()),
+        Arc::new(MockMerkleTreeHook::new()),
+        dummy_singleton_handle(),
+        signer,
+        Arc::new(syncer),
+        Arc::new(MockDb::new()),
+        dummy_metrics(),
+        2,
+        Arc::new(MockReorgReporter::new()),
+        readiness,
+    )
+}
+
+fn submission_checkpoint(index: u32) -> CheckpointWithMessageId {
+    CheckpointWithMessageId {
+        checkpoint: Checkpoint {
+            root: H256::zero(),
+            merkle_tree_hook_address: H256::zero(),
+            mailbox_domain: 0,
+            index,
+        },
+        message_id: H256::zero(),
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_waits_for_newest_checkpoint_but_not_older_siblings() {
+    for failing_index in [7, 8] {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let failures = Arc::new(AtomicUsize::new(0));
+        let newest_written = Arc::new(AtomicBool::new(false));
+        let published = Arc::new(AtomicBool::new(false));
+        let mut syncer = MockCheckpointSyncer::new();
+        syncer
+            .expect_fetch_checkpoint()
+            .times(3)
+            .returning(|_| Ok(None));
+        syncer.expect_write_checkpoint().times(3).returning({
+            let attempts = Arc::clone(&attempts);
+            let failures = Arc::clone(&failures);
+            let newest_written = Arc::clone(&newest_written);
+            move |checkpoint| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                if checkpoint.value.index == failing_index
+                    && failures.fetch_add(1, Ordering::SeqCst) == 0
+                {
+                    return Err(eyre::eyre!("transient checkpoint upload failure"));
+                }
+                if checkpoint.value.index == 8 {
+                    newest_written.store(true, Ordering::SeqCst);
+                }
+                Ok(())
+            }
+        });
+        syncer
+            .expect_update_latest_index()
+            .with(mockall::predicate::eq(8))
+            .once()
+            .returning({
+                let newest_written = Arc::clone(&newest_written);
+                let published = Arc::clone(&published);
+                move |_| {
+                    assert!(newest_written.load(Ordering::SeqCst));
+                    published.store(true, Ordering::SeqCst);
+                    Ok(())
+                }
+            });
+        let readiness = dummy_readiness();
+        let submitter = submission_test_submitter(syncer, Arc::clone(&readiness));
+        let task = tokio::spawn(async move {
+            submitter
+                .sign_and_submit_checkpoints(vec![
+                    submission_checkpoint(7),
+                    submission_checkpoint(8),
+                ])
+                .await;
+        });
+        while attempts.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(published.load(Ordering::SeqCst), failing_index == 7);
+        assert!(
+            !task.is_finished(),
+            "the failed sibling must still be retried"
+        );
+        assert_eq!(
+            readiness.snapshot().blocked_operations,
+            vec![format!("checkpoint_submission[{failing_index}]")]
+        );
+        tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+        task.await.unwrap();
+        assert!(published.load(Ordering::SeqCst));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn latest_index_retry_does_not_repeat_checkpoint_upload() {
+    let updates = Arc::new(AtomicUsize::new(0));
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer
+        .expect_fetch_checkpoint()
+        .once()
+        .returning(|_| Ok(None));
+    syncer
+        .expect_write_checkpoint()
+        .once()
+        .returning(|_| Ok(()));
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(8))
+        .times(2)
+        .returning({
+            let updates = Arc::clone(&updates);
+            move |_| {
+                if updates.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(eyre::eyre!("latest index unavailable"))
+                } else {
+                    Ok(())
+                }
+            }
+        });
+    let readiness = dummy_readiness();
+    let submitter = submission_test_submitter(syncer, Arc::clone(&readiness));
+    let task = tokio::spawn(async move {
+        submitter
+            .sign_and_submit_checkpoints(vec![submission_checkpoint(8)])
+            .await;
+    });
+    while updates.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        readiness.snapshot().blocked_operations,
+        vec!["checkpoint_latest_index"]
+    );
+    tokio::time::advance(hyperlane_core::rpc_clients::RPC_RETRY_SLEEP_DURATION).await;
+    task.await.unwrap();
+    assert_eq!(updates.load(Ordering::SeqCst), 2);
+    assert_eq!(readiness.snapshot().state, ValidatorReadinessState::Ready);
+}
+
+#[tokio::test(start_paused = true)]
+async fn only_first_checkpoint_publishes_batch_maximum() {
+    let mut syncer = MockCheckpointSyncer::new();
+    syncer
+        .expect_fetch_checkpoint()
+        .times(3)
+        .returning(|_| Ok(None));
+    syncer
+        .expect_write_checkpoint()
+        .times(3)
+        .returning(|_| Ok(()));
+    syncer
+        .expect_update_latest_index()
+        .with(mockall::predicate::eq(8))
+        .once()
+        .returning(|_| Ok(()));
+    let submitter = submission_test_submitter(syncer, dummy_readiness());
+    submitter
+        .sign_and_submit_checkpoints(vec![
+            submission_checkpoint(7),
+            submission_checkpoint(8),
+            submission_checkpoint(8),
+        ])
+        .await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn single_checkpoint_chunk_has_no_throttle_tail() {
     let checkpoint = CheckpointWithMessageId {

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -528,24 +528,26 @@ impl ValidatorMultiRpcQuorumMerkleTreeHook {
     /// `latest_checkpoint_at_block()`, so there's a single place that ever calls
     /// `quorum_hooks` for a pinned-height root read.
     async fn tree_at_block_via_quorum(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
-        let results = join_all(
-            self.quorum_hooks
-                .iter()
-                .cloned()
-                .map(|(label, hook)| async move {
-                    (
-                        label,
-                        Self::with_call_timeout(hook.tree_at_block(height)).await,
-                    )
-                }),
-        )
-        .await;
-        let quorum_result = self.select_quorum_result(
-            results,
-            |a, b| a.tree == b.tree,
-            "Failed to reach quorum for merkle tree",
-        )?;
-        let base_result = self.base_hook.tree_at_block(height).await?;
+        // Both reads use the same explicit height and independently gate the result. Start
+        // them together so the base pool's latency does not follow the quorum's latency.
+        // Keep the futures owned here: an error or caller cancellation drops the other
+        // read, without leaving a background RPC task running.
+        let quorum_read = async {
+            let results = join_all(self.quorum_hooks.iter().map(|(label, hook)| async move {
+                (
+                    label.clone(),
+                    Self::with_call_timeout(hook.tree_at_block(height)).await,
+                )
+            }))
+            .await;
+            self.select_quorum_result(
+                results,
+                |a, b| a.tree == b.tree,
+                "Failed to reach quorum for merkle tree",
+            )
+        };
+        let (quorum_result, base_result) =
+            futures_util::try_join!(quorum_read, self.base_hook.tree_at_block(height),)?;
         Self::require_base_hook_agreement(
             &quorum_result,
             &base_result,
@@ -594,11 +596,11 @@ impl MerkleTreeHook for ValidatorMultiRpcQuorumMerkleTreeHook {
             return self.tree_at_block_via_quorum(height).await;
         }
 
-        let results = join_all(self.quorum_hooks.iter().cloned().map(|(label, hook)| {
+        let results = join_all(self.quorum_hooks.iter().map(|(label, hook)| {
             let reorg_period = reorg_period.clone();
             async move {
                 (
-                    label,
+                    label.clone(),
                     Self::with_call_timeout(hook.tree(&reorg_period)).await,
                 )
             }
@@ -2079,6 +2081,159 @@ mod tests {
 
     fn quorum_rpc(label: &str, hook: MockMerkleTreeHook) -> (String, Arc<dyn MerkleTreeHook>) {
         (label.to_string(), Arc::new(hook) as Arc<dyn MerkleTreeHook>)
+    }
+
+    /// Delays a mock response without blocking the executor, and tracks owned RPC futures.
+    #[derive(Debug)]
+    struct DelayedPinnedHook {
+        inner: MockMerkleTreeHook,
+        delay: Duration,
+        active: Arc<AtomicUsize>,
+    }
+
+    impl HyperlaneChain for DelayedPinnedHook {
+        fn domain(&self) -> &HyperlaneDomain {
+            self.inner.domain()
+        }
+
+        fn provider(&self) -> Box<dyn HyperlaneProvider> {
+            self.inner.provider()
+        }
+    }
+
+    impl HyperlaneContract for DelayedPinnedHook {
+        fn address(&self) -> H256 {
+            self.inner.address()
+        }
+    }
+
+    #[async_trait]
+    impl MerkleTreeHook for DelayedPinnedHook {
+        async fn tree(&self, period: &ReorgPeriod) -> ChainResult<IncrementalMerkleAtBlock> {
+            self.inner.tree(period).await
+        }
+
+        async fn count(&self, period: &ReorgPeriod) -> ChainResult<u32> {
+            self.inner.count(period).await
+        }
+
+        async fn latest_checkpoint(&self, period: &ReorgPeriod) -> ChainResult<CheckpointAtBlock> {
+            self.inner.latest_checkpoint(period).await
+        }
+
+        async fn latest_checkpoint_at_block(&self, height: u64) -> ChainResult<CheckpointAtBlock> {
+            self.inner.latest_checkpoint_at_block(height).await
+        }
+
+        async fn tree_at_block(&self, height: u64) -> ChainResult<IncrementalMerkleAtBlock> {
+            struct ActiveRead<'a>(&'a AtomicUsize);
+            impl Drop for ActiveRead<'_> {
+                fn drop(&mut self) {
+                    self.0.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+            self.active.fetch_add(1, Ordering::SeqCst);
+            let _active = ActiveRead(&self.active);
+            sleep(self.delay).await;
+            self.inner.tree_at_block(height).await
+        }
+    }
+
+    fn delayed_pinned_hook(
+        seconds: u64,
+        fail: bool,
+        active: &Arc<AtomicUsize>,
+    ) -> Arc<dyn MerkleTreeHook> {
+        let mut inner = MockMerkleTreeHook::new();
+        // Cancellation can prevent the delayed response from being reached.
+        inner
+            .expect_tree_at_block()
+            .times(0..=1)
+            .with(mockall::predicate::eq(42))
+            .return_once(move |height| {
+                if fail {
+                    Err(ChainCommunicationError::from_other_str("RPC unavailable"))
+                } else {
+                    Ok(IncrementalMerkleAtBlock {
+                        tree: tree_with_count(5),
+                        block_height: Some(height),
+                    })
+                }
+            });
+        Arc::new(DelayedPinnedHook {
+            inner,
+            delay: Duration::from_secs(seconds),
+            active: Arc::clone(active),
+        })
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pinned_base_and_quorum_reads_overlap() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: delayed_pinned_hook(7, false, &active),
+            quorum_hooks: vec![
+                ("rpc-a".into(), delayed_pinned_hook(5, false, &active)),
+                ("rpc-b".into(), delayed_pinned_hook(5, false, &active)),
+                ("rpc-c".into(), delayed_pinned_hook(5, false, &active)),
+            ],
+        };
+        let start = Instant::now();
+        let tree = hook.tree_at_block_via_quorum(42).await.unwrap();
+        assert_eq!(tree.tree, tree_with_count(5));
+        assert_eq!(tree.block_height, Some(42));
+        assert_eq!(start.elapsed(), Duration::from_secs(7));
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn pinned_read_failure_cancels_the_other_read_group() {
+        for base_fails in [false, true] {
+            let active = Arc::new(AtomicUsize::new(0));
+            let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+                base_hook: delayed_pinned_hook(
+                    if base_fails { 2 } else { 10 },
+                    base_fails,
+                    &active,
+                ),
+                quorum_hooks: vec![
+                    (
+                        "rpc-a".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                    (
+                        "rpc-b".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                    (
+                        "rpc-c".into(),
+                        delayed_pinned_hook(if base_fails { 10 } else { 2 }, !base_fails, &active),
+                    ),
+                ],
+            };
+            let start = Instant::now();
+            assert!(hook.tree_at_block_via_quorum(42).await.is_err());
+            assert_eq!(start.elapsed(), Duration::from_secs(2));
+            assert_eq!(active.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelling_pinned_read_drops_both_read_groups() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let hook = ValidatorMultiRpcQuorumMerkleTreeHook {
+            base_hook: delayed_pinned_hook(10, false, &active),
+            quorum_hooks: ["rpc-a", "rpc-b", "rpc-c"]
+                .into_iter()
+                .map(|label| (label.into(), delayed_pinned_hook(10, false, &active)))
+                .collect(),
+        };
+        assert!(
+            timeout(Duration::from_secs(1), hook.tree_at_block_via_quorum(42))
+                .await
+                .is_err()
+        );
+        assert_eq!(active.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/rust/main/hyperlane-base/src/types/s3_storage.rs
+++ b/rust/main/hyperlane-base/src/types/s3_storage.rs
@@ -96,13 +96,13 @@ impl fmt::Debug for S3Storage {
 }
 
 impl S3Storage {
-    async fn write_to_bucket(&self, key: String, body: &str) -> Result<()> {
+    async fn write_to_bucket(&self, key: String, body: Vec<u8>) -> Result<()> {
         self.authenticated_client()
             .await
             .put_object()
             .bucket(self.bucket.clone())
             .key(self.get_composite_key(key))
-            .body(Vec::from(body).into())
+            .body(body.into())
             .content_type("application/json")
             .send()
             .await?;
@@ -233,8 +233,8 @@ impl CheckpointSyncer for S3Storage {
     }
 
     async fn write_latest_index(&self, index: u32) -> Result<()> {
-        let serialized_index = serde_json::to_string(&index)?;
-        self.write_to_bucket(S3Storage::latest_index_key(), &serialized_index)
+        let serialized_index = serde_json::to_vec(&index)?;
+        self.write_to_bucket(S3Storage::latest_index_key(), serialized_index)
             .await?;
         Ok(())
     }
@@ -251,24 +251,27 @@ impl CheckpointSyncer for S3Storage {
         &self,
         signed_checkpoint: &SignedCheckpointWithMessageId,
     ) -> Result<()> {
-        let serialized_checkpoint = serde_json::to_string_pretty(signed_checkpoint)?;
+        let serialized_checkpoint = serde_json::to_vec(signed_checkpoint)?;
         self.write_to_bucket(
             S3Storage::checkpoint_key(signed_checkpoint.value.index),
-            &serialized_checkpoint,
+            serialized_checkpoint,
         )
         .await?;
         Ok(())
     }
 
     async fn write_metadata(&self, serialized_metadata: &str) -> Result<()> {
-        self.write_to_bucket(S3Storage::metadata_key(), serialized_metadata)
-            .await?;
+        self.write_to_bucket(
+            S3Storage::metadata_key(),
+            serialized_metadata.as_bytes().to_vec(),
+        )
+        .await?;
         Ok(())
     }
 
     async fn write_announcement(&self, signed_announcement: &SignedAnnouncement) -> Result<()> {
-        let serialized_announcement = serde_json::to_string_pretty(signed_announcement)?;
-        self.write_to_bucket(S3Storage::announcement_key(), &serialized_announcement)
+        let serialized_announcement = serde_json::to_vec_pretty(signed_announcement)?;
+        self.write_to_bucket(S3Storage::announcement_key(), serialized_announcement)
             .await?;
         Ok(())
     }
@@ -283,14 +286,14 @@ impl CheckpointSyncer for S3Storage {
     }
 
     async fn write_reorg_status(&self, reorged_event: &ReorgEvent) -> Result<()> {
-        let serialized_reorg = serde_json::to_string(reorged_event)?;
-        self.write_to_bucket(S3Storage::reorg_flag_key(), &serialized_reorg)
+        let serialized_reorg = serde_json::to_vec(reorged_event)?;
+        self.write_to_bucket(S3Storage::reorg_flag_key(), serialized_reorg)
             .await?;
         Ok(())
     }
 
     async fn write_reorg_rpc_responses(&self, reorg_log: String) -> Result<()> {
-        self.write_to_bucket(S3Storage::reorg_rpc_responses_key(), &reorg_log)
+        self.write_to_bucket(S3Storage::reorg_rpc_responses_key(), reorg_log.into_bytes())
             .await?;
         Ok(())
     }
@@ -393,6 +396,93 @@ mod tests {
             .credentials_provider(aws_sdk_s3::config::Credentials::for_tests())
             .build();
         Client::from_conf(config)
+    }
+
+    #[tokio::test]
+    async fn checkpoint_upload_uses_compact_json_and_preserves_signed_fields() {
+        use std::sync::Arc;
+
+        use hyper::{service::service_fn, Body, Response};
+        use hyperlane_core::{Checkpoint, CheckpointWithMessageId, HyperlaneSignerExt, H256};
+        use hyperlane_ethereum::Signers;
+
+        let signer: Signers = "01"
+            .repeat(32)
+            .parse::<ethers::signers::LocalWallet>()
+            .unwrap()
+            .into();
+        let checkpoint = signer
+            .sign(CheckpointWithMessageId {
+                checkpoint: Checkpoint {
+                    merkle_tree_hook_address: H256::repeat_byte(0x11),
+                    mailbox_domain: 42161,
+                    root: H256::repeat_byte(0x22),
+                    index: 2_500_000,
+                },
+                message_id: H256::repeat_byte(0x33),
+            })
+            .await
+            .unwrap();
+        let expected = serde_json::to_vec(&checkpoint).unwrap();
+        let pretty = serde_json::to_vec_pretty(&checkpoint).unwrap();
+        assert!(expected.len() < pretty.len());
+        println!(
+            "checkpoint bytes: pretty={}, compact={}",
+            pretty.len(),
+            expected.len()
+        );
+        let received = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_received = Arc::clone(&received);
+        let server = tokio::spawn(async move {
+            let (socket, _) = listener.accept().await.unwrap();
+            hyper::server::conn::Http::new()
+                .serve_connection(
+                    socket,
+                    service_fn(move |request: hyper::Request<Body>| {
+                        let received = Arc::clone(&server_received);
+                        async move {
+                            assert_eq!(request.method(), hyper::Method::PUT);
+                            assert_eq!(
+                                request.uri().path(),
+                                "/test-bucket/checkpoint_2500000_with_id.json"
+                            );
+                            assert_eq!(
+                                request.headers()[hyper::header::CONTENT_TYPE],
+                                "application/json"
+                            );
+                            let body = hyper::body::to_bytes(request.into_body()).await.unwrap();
+                            *received.lock().unwrap() = body.to_vec();
+                            Ok::<_, std::convert::Infallible>(
+                                Response::builder()
+                                    .header(hyper::header::CONNECTION, "close")
+                                    .body(Body::empty())
+                                    .unwrap(),
+                            )
+                        }
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+        let storage = S3Storage::new("test-bucket".into(), None, Region::new("us-east-1"), None);
+        storage
+            .authenticated_client
+            .set(test_client(address))
+            .unwrap();
+        storage.write_checkpoint(&checkpoint).await.unwrap();
+        server.await.unwrap();
+        let body = received.lock().unwrap();
+        assert_eq!(*body, expected);
+        let decoded: SignedCheckpointWithMessageId = serde_json::from_slice(&body).unwrap();
+        assert_eq!(decoded.value, checkpoint.value);
+        assert_eq!(decoded.signature, checkpoint.signature);
+        assert_eq!(decoded.recover().unwrap(), checkpoint.recover().unwrap());
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+            serde_json::from_slice::<serde_json::Value>(&pretty).unwrap()
+        );
     }
 
     /// Reads a mock HTTP server's request off `socket` up to the end of the headers. The


### PR DESCRIPTION
Consolidated into #9471 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

A successfully stored newest checkpoint remains undiscoverable through the latest-index pointer until every lower checkpoint in the first submission chunk succeeds. One lower checkpoint can retry indefinitely even though the newest checkpoint is ready for relayers.

## Solution

Give the first popped (highest) checkpoint sole responsibility for publishing latest-index immediately after its own successful upload or validated-existing checkpoint. Continue joining and retrying every sibling. Keep chunk concurrency, pacing, pointer retries and readiness reporting. Retrying the pointer does not repeat checkpoint signing/upload.

Latest-index already represents an upper bound, not contiguous history: older chunks remain pending in the current implementation. Readers still fetch and verify actual signed checkpoints. Exactly one future publishes even if input contains duplicate maximum indices.

## Numerical impact

| Case | Before → after | Evidence |
|---|---|---|
| Newest checkpoint ready at 1s; slower sibling at 30s | Discoverability at 30s → 1s, 96.7% shorter | Illustrative latency model, not production measurement |
| Lower sibling retries for 2s | Pointer waits for sibling → published before retry completes | Deterministic paused-time regression |
| Latest-index update fails once | Checkpoint upload stays at one; pointer retried independently | Regression test |
| Full batch completion / successful-path requests | No reduction claimed | Every sibling is still awaited |

No checkpoint-storage outage was found in the sampled production logs. This improves behavior under uneven storage latency; it is not a measured fleet throughput gain.

## Verification and scope

- Cumulative validator suite: **79/79 passed**, including quorum/reorg coverage, lower versus newest upload failure, pointer-only retries and duplicate-maximum single publisher.
- Strict production package Clippy passed: `cargo +1.93.0 clippy -p validator --bin validator --no-deps --locked -- -D warnings`.
- Formatting, normal commit hooks, self-review and independent relayer review completed. Review caught and fixed duplicate-maximum publication ownership.
- Existing `update_latest_index` is a non-atomic read/compare/write across tasks. This PR neither introduces nor solves that race, and does not claim global pointer monotonicity.
- #9448 snapshot publication remains after the complete backfill; checkpoint contents, signing and restore validation are unchanged. Existing polling, snapshot and storage-pooling PRs do not cover this first-chunk publication dependency.

Stack: follows #9472, which follows #9471.
