### PR TITLE
perf(relayer): encode multisig metadata in one buffer

### DIFF
--- a/rust/main/agents/relayer/src/merkle_tree/builder.rs
+++ b/rust/main/agents/relayer/src/merkle_tree/builder.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use eyre::{Context, Result};
-use tracing::{error, instrument};
+use tracing::instrument;
 
 use hyperlane_base::db::DbError;
 use hyperlane_core::{

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -3,13 +3,12 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use derive_more::{AsRef, Deref};
 use derive_new::new;
-use ethers::abi::Token;
 
 use eyre::Result;
 use hyperlane_base::cache::FunctionCallCache;
 use hyperlane_base::settings::CheckpointSyncerBuildError;
 use hyperlane_base::MultisigCheckpointSyncer;
-use hyperlane_core::accumulator::merkle::Proof;
+use hyperlane_core::accumulator::{merkle::Proof, TREE_DEPTH};
 use hyperlane_core::{
     HyperlaneMessage, Metadata, ModuleType, MultisigIsm, MultisigSignedCheckpoint, H256,
 };
@@ -28,6 +27,56 @@ pub struct MultisigMetadata {
     merkle_leaf_index: u32,
     // optional because it's only used for MerkleRootMultisig
     proof: Option<Proof>,
+}
+
+impl MultisigMetadata {
+    fn format(&self, layout: &[MetadataToken]) -> Vec<u8> {
+        const SIGNATURE_LENGTH: usize = 65;
+        let size = layout.iter().fold(0usize, |size, token| {
+            size.saturating_add(match token {
+                MetadataToken::CheckpointMerkleRoot
+                | MetadataToken::CheckpointMerkleTreeHook
+                | MetadataToken::MessageId => H256::len_bytes(),
+                MetadataToken::MessageMerkleLeafIndex | MetadataToken::CheckpointIndex => {
+                    std::mem::size_of::<u32>()
+                }
+                MetadataToken::MerkleProof => TREE_DEPTH.saturating_mul(H256::len_bytes()),
+                MetadataToken::Signatures => self.signatures.len().saturating_mul(SIGNATURE_LENGTH),
+            })
+        });
+        let mut output = Vec::with_capacity(size);
+        for token in layout {
+            match token {
+                MetadataToken::CheckpointMerkleRoot => {
+                    output.extend_from_slice(self.checkpoint.root.as_bytes());
+                }
+                MetadataToken::MessageMerkleLeafIndex => {
+                    output.extend_from_slice(&self.merkle_leaf_index.to_be_bytes());
+                }
+                MetadataToken::CheckpointIndex => {
+                    output.extend_from_slice(&self.checkpoint.index.to_be_bytes());
+                }
+                MetadataToken::CheckpointMerkleTreeHook => {
+                    output.extend_from_slice(self.checkpoint.merkle_tree_hook_address.as_bytes());
+                }
+                MetadataToken::MessageId => {
+                    output.extend_from_slice(self.checkpoint.message_id.as_bytes());
+                }
+                MetadataToken::MerkleProof => {
+                    // ABI bytes32 values are already one word each: no offset, length or padding.
+                    for sibling in &self.proof.as_ref().expect("Metadata is missing proof").path {
+                        output.extend_from_slice(sibling.as_bytes());
+                    }
+                }
+                MetadataToken::Signatures => {
+                    for signature in &self.signatures {
+                        output.extend_from_slice(&<[u8; SIGNATURE_LENGTH]>::from(signature));
+                    }
+                }
+            }
+        }
+        output
+    }
 }
 
 #[derive(Debug, Display, PartialEq, Eq, Clone)]
@@ -55,48 +104,10 @@ pub trait MultisigIsmMetadataBuilder: AsRef<MessageMetadataBuilder> + Send + Syn
         checkpoint_syncer: &MultisigCheckpointSyncer,
     ) -> Result<Option<MultisigMetadata>, MetadataBuildError>;
 
-    fn token_layout(&self) -> Vec<MetadataToken>;
+    fn token_layout(&self) -> &'static [MetadataToken];
 
     fn format_metadata(&self, metadata: MultisigMetadata) -> Result<Vec<u8>> {
-        let build_token = |token: &MetadataToken| -> Result<Vec<u8>> {
-            match token {
-                MetadataToken::CheckpointMerkleRoot => {
-                    Ok(metadata.checkpoint.root.to_fixed_bytes().into())
-                }
-                MetadataToken::MessageMerkleLeafIndex => {
-                    Ok(metadata.merkle_leaf_index.to_be_bytes().into())
-                }
-                MetadataToken::CheckpointIndex => {
-                    Ok(metadata.checkpoint.index.to_be_bytes().into())
-                }
-                MetadataToken::CheckpointMerkleTreeHook => Ok(metadata
-                    .checkpoint
-                    .merkle_tree_hook_address
-                    .to_fixed_bytes()
-                    .into()),
-                MetadataToken::MessageId => {
-                    Ok(metadata.checkpoint.message_id.to_fixed_bytes().into())
-                }
-                MetadataToken::MerkleProof => {
-                    let proof_tokens: Vec<Token> = metadata
-                        .proof
-                        .expect("Metadata is missing proof")
-                        .path
-                        .iter()
-                        .map(|x| Token::FixedBytes(x.to_fixed_bytes().into()))
-                        .collect();
-                    Ok(ethers::abi::encode(&proof_tokens))
-                }
-                MetadataToken::Signatures => Ok(metadata
-                    .signatures
-                    .iter()
-                    .map(|x| x.to_vec())
-                    .collect::<Vec<_>>()
-                    .concat()),
-            }
-        };
-        let metas: Result<Vec<Vec<u8>>> = self.token_layout().iter().map(build_token).collect();
-        Ok(metas?.into_iter().flatten().collect())
+        Ok(metadata.format(self.token_layout()))
     }
 
     /// Returns the validators and threshold for the given multisig ISM.
@@ -308,4 +319,109 @@ pub(crate) async fn build_from_known_validators<T: MultisigIsmMetadataBuilder>(
         .base_builder()
         .update_ism_metric(ism_build_metrics_params);
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers::abi::{encode, Token};
+    use hyperlane_core::{Checkpoint, CheckpointWithMessageId, Signature, U256};
+
+    use super::*;
+
+    // Retain the prior ABI-based encoder as an independent byte-layout oracle.
+    fn legacy_format(metadata: &MultisigMetadata, layout: &[MetadataToken]) -> Vec<u8> {
+        let fields: Vec<Vec<u8>> = layout
+            .iter()
+            .map(|token| match token {
+                MetadataToken::CheckpointMerkleRoot => metadata.checkpoint.root.as_bytes().to_vec(),
+                MetadataToken::CheckpointIndex => metadata.checkpoint.index.to_be_bytes().to_vec(),
+                MetadataToken::CheckpointMerkleTreeHook => metadata
+                    .checkpoint
+                    .merkle_tree_hook_address
+                    .as_bytes()
+                    .to_vec(),
+                MetadataToken::MessageId => metadata.checkpoint.message_id.as_bytes().to_vec(),
+                MetadataToken::MerkleProof => encode(
+                    &metadata
+                        .proof
+                        .expect("Merkle proof fixture")
+                        .path
+                        .iter()
+                        .map(|hash| Token::FixedBytes(hash.as_bytes().to_vec()))
+                        .collect::<Vec<_>>(),
+                ),
+                MetadataToken::MessageMerkleLeafIndex => {
+                    metadata.merkle_leaf_index.to_be_bytes().to_vec()
+                }
+                MetadataToken::Signatures => metadata
+                    .signatures
+                    .iter()
+                    .map(|signature| signature.to_vec())
+                    .collect::<Vec<_>>()
+                    .concat(),
+            })
+            .collect();
+        fields.into_iter().flatten().collect()
+    }
+
+    #[test]
+    fn packed_multisig_metadata_matches_legacy_abi_encoder() {
+        let message_id_layout = [
+            MetadataToken::CheckpointMerkleTreeHook,
+            MetadataToken::CheckpointMerkleRoot,
+            MetadataToken::CheckpointIndex,
+            MetadataToken::Signatures,
+        ];
+        let merkle_root_layout = [
+            MetadataToken::CheckpointMerkleTreeHook,
+            MetadataToken::MessageMerkleLeafIndex,
+            MetadataToken::MessageId,
+            MetadataToken::MerkleProof,
+            MetadataToken::CheckpointIndex,
+            MetadataToken::Signatures,
+        ];
+        for count in [0_u32, 1, 3, 50] {
+            for index in [0, 1, u32::MAX] {
+                for v in [0, 1, 27, 28, 255, 256, u64::MAX] {
+                    let mut metadata = MultisigMetadata::new(
+                        MultisigSignedCheckpoint {
+                            checkpoint: CheckpointWithMessageId {
+                                checkpoint: Checkpoint {
+                                    merkle_tree_hook_address: H256::repeat_byte(0x12),
+                                    mailbox_domain: 7,
+                                    root: H256::repeat_byte(0x34),
+                                    index,
+                                },
+                                message_id: H256::repeat_byte(0x56),
+                            },
+                            signatures: (0..count)
+                                .map(|i| Signature {
+                                    r: U256::from(i),
+                                    s: U256::max_value().saturating_sub(U256::from(i)),
+                                    v,
+                                })
+                                .collect(),
+                        },
+                        index.saturating_sub(1),
+                        None,
+                    );
+                    assert_eq!(
+                        metadata.format(&message_id_layout),
+                        legacy_format(&metadata, &message_id_layout)
+                    );
+                    metadata.proof = Some(Proof {
+                        leaf: H256::repeat_byte(0x78),
+                        index: 9,
+                        path: std::array::from_fn(|i| {
+                            H256::repeat_byte(u8::try_from(i).expect("proof depth fits u8"))
+                        }),
+                    });
+                    assert_eq!(
+                        metadata.format(&merkle_root_layout),
+                        legacy_format(&metadata, &merkle_root_layout)
+                    );
+                }
+            }
+        }
+    }
 }

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
@@ -22,8 +22,8 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
         ModuleType::MerkleRootMultisig
     }
 
-    fn token_layout(&self) -> Vec<MetadataToken> {
-        vec![
+    fn token_layout(&self) -> &'static [MetadataToken] {
+        &[
             MetadataToken::CheckpointMerkleTreeHook,
             MetadataToken::MessageMerkleLeafIndex,
             MetadataToken::MessageId,

--- a/rust/main/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/message_id_multisig.rs
@@ -21,8 +21,8 @@ impl MultisigIsmMetadataBuilder for MessageIdMultisigMetadataBuilder {
         ModuleType::MessageIdMultisig
     }
 
-    fn token_layout(&self) -> Vec<MetadataToken> {
-        vec![
+    fn token_layout(&self) -> &'static [MetadataToken] {
+        &[
             MetadataToken::CheckpointMerkleTreeHook,
             MetadataToken::CheckpointMerkleRoot,
             MetadataToken::CheckpointIndex,

--- a/rust/main/agents/relayer/src/prover.rs
+++ b/rust/main/agents/relayer/src/prover.rs
@@ -7,7 +7,7 @@ use hyperlane_core::accumulator::{
     TREE_DEPTH,
 };
 use hyperlane_core::H256;
-use tracing::{error, instrument};
+use tracing::instrument;
 
 /// A depth-32 sparse Merkle tree capable of producing proofs for arbitrary
 /// elements.

--- a/rust/main/hyperlane-core/src/matching_list.rs
+++ b/rust/main/hyperlane-core/src/matching_list.rs
@@ -3,6 +3,7 @@
 //! ANY CHANGES HERE NEED TO BE REFLECTED IN THE TYPESCRIPT SDK.
 
 use std::{
+    cell::OnceCell,
     fmt,
     fmt::{Debug, Display, Formatter},
     marker::PhantomData,
@@ -280,6 +281,21 @@ pub struct ListElement {
     body_regex: Option<RegexWrapper>,
 }
 
+impl ListElement {
+    fn matches_route(
+        &self,
+        src_domain: u32,
+        src_addr: &H256,
+        dst_domain: u32,
+        dst_addr: &H256,
+    ) -> bool {
+        self.origin_domain.matches(&src_domain)
+            && self.sender_address.matches(src_addr)
+            && self.destination_domain.matches(&dst_domain)
+            && self.recipient_address.matches(dst_addr)
+    }
+}
+
 impl Display for ListElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
@@ -352,7 +368,31 @@ impl MatchingList {
     /// Check if a message matches any of the rules.
     /// - `default`: What to return if the matching list is empty.
     pub fn msg_matches(&self, msg: &HyperlaneMessage, default: bool) -> bool {
-        self.matches(msg.into(), default)
+        let Some(rules) = &self.0 else {
+            return default;
+        };
+        // Most lists filter only addresses/domains. Hash and encode the body only
+        // when a candidate rule needs them, once per matching attempt.
+        let message_id = OnceCell::new();
+        let body = OnceCell::new();
+        rules.iter().any(|rule| {
+            rule.matches_route(msg.origin, &msg.sender, msg.destination, &msg.recipient)
+                && match &rule.message_id {
+                    Filter::Wildcard => true,
+                    Filter::Enumerated(ids) => {
+                        !ids.is_empty() && ids.contains(message_id.get_or_init(|| msg.id()))
+                    }
+                }
+                && rule
+                    .body_regex
+                    .as_ref()
+                    .map(|regex| {
+                        regex
+                            .0
+                            .is_match(body.get_or_init(|| hex::encode(&msg.body)))
+                    })
+                    .unwrap_or(true)
+        })
     }
 
     /// Check if a match info matches any of the rules.
@@ -369,10 +409,12 @@ impl MatchingList {
 fn matches_any_rule<'a>(mut rules: impl Iterator<Item = &'a ListElement>, info: MatchInfo) -> bool {
     rules.any(|rule| {
         rule.message_id.matches(&info.src_msg_id)
-            && rule.origin_domain.matches(&info.src_domain)
-            && rule.sender_address.matches(info.src_addr)
-            && rule.destination_domain.matches(&info.dst_domain)
-            && rule.recipient_address.matches(info.dst_addr)
+            && rule.matches_route(
+                info.src_domain,
+                info.src_addr,
+                info.dst_domain,
+                info.dst_addr,
+            )
             && rule
                 .body_regex
                 .as_ref()
@@ -408,6 +450,66 @@ mod test {
     use crate::{H160, H256};
 
     use super::{Filter::*, MatchInfo, MatchingList};
+
+    #[test]
+    fn message_matching_preserves_eager_results() {
+        let messages: Vec<_> = [vec![], vec![0, 0xab, 0xff], vec![0x42; 4096]]
+            .into_iter()
+            .flat_map(|body| {
+                [0, 1]
+                    .into_iter()
+                    .map(move |origin| crate::HyperlaneMessage {
+                        origin,
+                        destination: 2,
+                        sender: H256::repeat_byte(3),
+                        recipient: H256::repeat_byte(4),
+                        body: body.clone(),
+                        ..Default::default()
+                    })
+            })
+            .collect();
+        let mut lists = vec![MatchingList(None), MatchingList(Some(vec![]))];
+        for config in [
+            r"[{}]",
+            r#"[{"origindomain":1,"destinationdomain":2}]"#,
+            r#"[{"bodyregex":"^00abff$"}]"#,
+            r#"[{"bodyregex":"^$"}]"#,
+            r#"[{"bodyregex":"^0x00abff$"}]"#,
+            r#"[{"bodyregex":"^no$"},{"bodyregex":"^00abff$"}]"#,
+            r#"[{"origindomain":99,"bodyregex":".*"}, {"destinationdomain":2}]"#,
+            r#"[{}, {"bodyregex":".*"}]"#,
+            r#"[{"messageid":[]}]"#,
+        ] {
+            lists.push(serde_json::from_str(config).unwrap());
+        }
+        for field in ["senderaddress", "recipientaddress"] {
+            for address in [H256::repeat_byte(3), H256::repeat_byte(4)] {
+                lists.push(
+                    serde_json::from_value(serde_json::json!([
+                        {field: format!("{address:?}")}
+                    ]))
+                    .unwrap(),
+                );
+            }
+        }
+        lists.push(MatchingList::with_message_id(messages[0].id()));
+        lists.push(MatchingList::with_message_id(messages[3].id()));
+        lists.push(serde_json::from_str(&format!(
+            r#"[{{"messageid":"{:?}","bodyregex":"^no$"}},{{"messageid":"{:?}","bodyregex":"^00abff$"}}]"#,
+            messages[3].id(), messages[3].id(),
+        )).unwrap());
+        for list in lists {
+            for message in &messages {
+                for default in [false, true] {
+                    assert_eq!(
+                        list.msg_matches(message, default),
+                        list.matches(message.into(), default),
+                        "list {list:?}, message {message:?}, default {default}",
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn basic_config() {


### PR DESCRIPTION
Consolidated into #9469 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Multisig metadata formatting allocates a fixed token-layout Vec, temporary field/signature buffers and a final flattened buffer on every build. Merkle proofs additionally create 32 separately allocated ABI tokens and invoke the generic encoder for fixed bytes32 siblings.

## Solution

Use static token layouts and append every field into one exactly sized Vec. Append proof siblings directly in their existing order and use the existing 65-byte signature representation. Wire bytes, signature normalization, validation and provider requests remain unchanged.

## Numerical impact

Synthetic counting-allocator probe, three signatures; outputs are byte-identical:

| Layout | Output bytes | Alloc/realloc calls | Total requested allocation bytes |
|---|---:|---:|---:|
| Merkle root multisig | 1,291 | 53 → 1 (98.1% fewer) | 41,448 → 1,291 (96.9% less) |
| Message ID multisig | 263 | 14 → 1 (92.9% fewer) | 1,117 → 263 (76.5% less) |

The probe uses the parent formatter and this formatter with actual core types/ABI encoder, 100 warmup plus 100 measured calls, covering 0/1/3/50 signatures. These are allocator-traffic counts, not retained memory, RSS or timing. No RPC savings. Live metadata volume was low in the sampled window (top app about 0.042 builds/sec), so these percentages are not fleet CPU estimates.

## Verification and scope

- **6/6 multisig tests passed**, including 168 comparisons against the previous ABI encoder: two layouts, four signature counts, three indices and seven recovery IDs. Ordered proof siblings/signatures and no-proof message-ID inputs covered.
- `cargo +1.93.0 test -p relayer msg::metadata::multisig --locked --offline`.
- Strict package Clippy passed: `cargo +1.93.0 clippy -p relayer --lib --locked --no-deps -- -D warnings`. Removed two unused `tracing::error` imports exposed by this check.
- Formatting and normal commit hooks passed; self-review and independent scraper/validator reviews found no remaining blockers.
- No dependency, verification, signing, caching or public API changes. Missing-proof behavior is preserved.
- The exclusion DAGs and open PRs do not cover this serializer. #5220 changes Ethereum ISM gas estimation, not encoding. Parent #9469 optimizes message filtering separately.

Stack: follows #9469.
