### PR TITLE
fix(scraper): bound delivery and payment database batches

### DIFF
--- a/rust/main/agents/scraper/src/db/block.rs
+++ b/rust/main/agents/scraper/src/db/block.rs
@@ -1,8 +1,8 @@
 use eyre::{Context, Result};
 use migration::OnConflict;
 use sea_orm::{
-    prelude::*, ActiveValue::*, DbErr, EntityTrait, FromQueryResult, Insert, QueryResult,
-    QuerySelect,
+    prelude::*, sea_query::SelectStatement, ActiveValue::*, DbErr, EntityTrait, FromQueryResult,
+    Insert, QueryResult, QuerySelect,
 };
 use tracing::{debug, trace};
 
@@ -11,7 +11,7 @@ use hyperlane_core::{h256_to_bytes, BlockInfo, H256};
 use crate::date_time;
 use crate::db::ScraperDb;
 
-use super::generated::block;
+use super::generated::{block, transaction};
 
 /// A stripped down block model. This is so we can get just the information
 /// needed if the block is present in the Db already to inject into other
@@ -33,23 +33,21 @@ impl FromQueryResult for BasicBlock {
 }
 
 impl ScraperDb {
-    /// Retrieves the block number for a given block database ID
-    pub async fn retrieve_block_number(&self, block_id: i64) -> Result<Option<u64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Height,
-        }
-        let block_height = block::Entity::find()
-            .filter(block::Column::Id.eq(block_id))
+    /// Resolve a query selecting one event transaction id to its block height in
+    /// one database round trip. NULL/missing relations produce no height.
+    pub(super) async fn retrieve_block_number_by_tx_query(
+        &self,
+        tx_id_query: SelectStatement,
+    ) -> Result<Option<u64>> {
+        let height = transaction::Entity::find()
+            .filter(transaction::Column::Id.in_subquery(tx_id_query))
+            .inner_join(block::Entity)
             .select_only()
-            .column_as(block::Column::Height, QueryAs::Height)
-            .into_values::<i64, QueryAs>()
+            .column(block::Column::Height)
+            .into_tuple::<i64>()
             .one(&self.0)
             .await?;
-        match block_height {
-            Some(height) => Ok(Some(height.try_into()?)),
-            None => Ok(None),
-        }
+        height.map(u64::try_from).transpose().map_err(Into::into)
     }
 
     /// Get basic block data that can be used to insert a transaction or

--- a/rust/main/agents/scraper/src/db/block/tests.rs
+++ b/rust/main/agents/scraper/src/db/block/tests.rs
@@ -158,3 +158,47 @@ async fn test_store_blocks_real_postgres() -> Result<(), DbErr> {
 
     Ok(())
 }
+
+/// Resolved sequence lookups execute exactly one statement each. Invalid SQL
+/// heights and database failures must remain errors rather than missing data.
+#[tokio::test]
+async fn sequence_block_lookups_use_one_query_and_propagate_errors() {
+    use sea_orm::{DatabaseBackend, MockDatabase, RuntimeErr, Value};
+    use std::collections::BTreeMap;
+
+    let rows = [0_i64, 42, i64::MAX, -1]
+        .map(|height| [BTreeMap::from([("height", Value::BigInt(Some(height)))])]);
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(rows)
+        .append_query_errors([DbErr::Query(RuntimeErr::Internal("unavailable".to_owned()))])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    let address = H256::from_low_u64_be(1);
+    assert_eq!(
+        db.retrieve_dispatched_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        db.retrieve_delivered_message_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(42)
+    );
+    assert_eq!(
+        db.retrieve_payment_block_number(1, &address, 7)
+            .await
+            .unwrap(),
+        Some(u64::try_from(i64::MAX).unwrap())
+    );
+    assert!(db
+        .retrieve_dispatched_block_number(1, &address, 7)
+        .await
+        .is_err());
+    assert!(db
+        .retrieve_payment_block_number(1, &address, 7)
+        .await
+        .is_err());
+    assert_eq!(db.0.into_transaction_log().len(), 5);
+}

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion.rs
@@ -1,6 +1,10 @@
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use migration::OnConflict;
-use sea_orm::{ActiveValue::*, ColumnTrait, EntityTrait, Insert, QueryFilter};
+use sea_orm::{
+    ActiveValue::*, ColumnTrait, DbErr, EntityTrait, Insert, QueryFilter, TransactionTrait,
+};
 
 use hyperlane_core::{address_to_bytes, h256_to_bytes, MerkleTreeInsertion, H256};
 
@@ -11,6 +15,10 @@ pub struct StorableMerkleTreeInsertion<'a> {
     pub block_number: u64,
 }
 
+// Each row binds five columns; conflict updates reference EXCLUDED and add no
+// parameters. Keep each statement below PostgreSQL's 65,535-parameter limit.
+const INSERT_CHUNK_SIZE: usize = 13_000;
+
 impl ScraperDb {
     pub async fn store_merkle_tree_insertions(
         &self,
@@ -19,35 +27,50 @@ impl ScraperDb {
         insertions: impl Iterator<Item = StorableMerkleTreeInsertion<'_>>,
     ) -> Result<u64> {
         let merkle_tree_hook = address_to_bytes(merkle_tree_hook);
+        // A single PostgreSQL upsert rejects repeated conflict keys. Preserve
+        // that rejection even when repeated leaves fall into different chunks.
+        let mut leaf_indices = HashSet::new();
         let models = insertions
-            .map(|row| merkle_tree_insertion::ActiveModel {
-                id: NotSet,
-                domain: Unchanged(domain as i32),
-                merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
-                leaf_index: Unchanged(row.insertion.index() as i32),
-                message_id: Set(h256_to_bytes(&row.insertion.message_id())),
-                block_number: Set(row.block_number as i64),
+            .map(|row| {
+                ensure!(
+                    leaf_indices.insert(row.insertion.index()),
+                    "Duplicate Merkle tree leaf index {} in one batch",
+                    row.insertion.index()
+                );
+                Ok(merkle_tree_insertion::ActiveModel {
+                    id: NotSet,
+                    domain: Unchanged(domain as i32),
+                    merkle_tree_hook: Unchanged(merkle_tree_hook.clone()),
+                    leaf_index: Unchanged(row.insertion.index() as i32),
+                    message_id: Set(h256_to_bytes(&row.insertion.message_id())),
+                    block_number: Set(row.block_number as i64),
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
+        drop(leaf_indices);
         let count = models.len() as u64;
         if models.is_empty() {
             return Ok(0);
         }
 
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([
-                    merkle_tree_insertion::Column::Domain,
-                    merkle_tree_insertion::Column::MerkleTreeHook,
-                    merkle_tree_insertion::Column::LeafIndex,
-                ])
-                .update_columns([
-                    merkle_tree_insertion::Column::MessageId,
-                    merkle_tree_insertion::Column::BlockNumber,
-                ])
-                .to_owned(),
-            )
-            .exec(&self.0)
+        if models.len() <= INSERT_CHUNK_SIZE {
+            insert_query(models).exec(&self.0).await?;
+            return Ok(count);
+        }
+
+        // A failed later chunk must roll back earlier writes: ContractSync can
+        // advance its cursor only after the entire fetched range is durable.
+        self.0
+            .transaction::<_, (), DbErr>(|txn| {
+                Box::pin(async move {
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models.by_ref().take(INSERT_CHUNK_SIZE).collect();
+                        insert_query(chunk).exec(txn).await?;
+                    }
+                    Ok(())
+                })
+            })
             .await?;
         Ok(count)
     }
@@ -76,3 +99,23 @@ impl ScraperDb {
         }))
     }
 }
+
+fn insert_query(
+    models: Vec<merkle_tree_insertion::ActiveModel>,
+) -> Insert<merkle_tree_insertion::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([
+            merkle_tree_insertion::Column::Domain,
+            merkle_tree_insertion::Column::MerkleTreeHook,
+            merkle_tree_insertion::Column::LeafIndex,
+        ])
+        .update_columns([
+            merkle_tree_insertion::Column::MessageId,
+            merkle_tree_insertion::Column::BlockNumber,
+        ])
+        .to_owned(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
+++ b/rust/main/agents/scraper/src/db/merkle_tree_insertion/tests.rs
@@ -1,0 +1,185 @@
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, MockDatabase, PaginatorTrait, Value};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use super::*;
+
+// Matches the observed 86,580-bind range: five parameters per insertion.
+const ROW_COUNT: u32 = 17_316;
+const DOMAIN: u32 = 1;
+
+fn insertions() -> Vec<MerkleTreeInsertion> {
+    (0..ROW_COUNT)
+        .map(|index| MerkleTreeInsertion::new(index, H256::from_low_u64_be(u64::from(index))))
+        .collect()
+}
+
+fn rows(
+    insertions: &[MerkleTreeInsertion],
+) -> impl Iterator<Item = StorableMerkleTreeInsertion<'_>> {
+    insertions
+        .iter()
+        .map(|insertion| StorableMerkleTreeInsertion {
+            insertion,
+            block_number: 20_000,
+        })
+}
+
+#[tokio::test]
+async fn merkle_insert_statements_stay_below_postgres_bind_limit() {
+    let connection = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results([
+            [BTreeMap::from([("id", Value::BigInt(Some(1)))])],
+            [BTreeMap::from([("id", Value::BigInt(Some(2)))])],
+        ])
+        .into_connection();
+    let db = ScraperDb::with_connection(connection);
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions()))
+            .await
+            .unwrap(),
+        u64::from(ROW_COUNT)
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1, "all chunks must share a transaction");
+    let statements = transactions[0].statements();
+    assert_eq!(statements.first().unwrap().sql, "BEGIN");
+    assert_eq!(statements.last().unwrap().sql, "COMMIT");
+    assert_eq!(statements.len(), 4);
+    let bind_counts: Vec<_> = statements
+        .iter()
+        .filter(|statement| statement.sql.starts_with("INSERT"))
+        .map(|statement| statement.values.as_ref().unwrap().0.len())
+        .collect();
+    assert_eq!(bind_counts, [65_000, 21_580]);
+    assert!(bind_counts
+        .iter()
+        .all(|count| *count <= usize::from(u16::MAX)));
+}
+
+#[tokio::test]
+async fn merkle_small_insert_keeps_one_statement_and_empty_insert_skips_sql() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[BTreeMap::from([("id", Value::BigInt(Some(1)))])]])
+            .into_connection(),
+    );
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[]))
+            .await
+            .unwrap(),
+        0
+    );
+    let insertion = MerkleTreeInsertion::new(1, H256::zero());
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&[insertion]))
+            .await
+            .unwrap(),
+        1
+    );
+    let transactions = db.0.into_transaction_log();
+    assert_eq!(transactions.len(), 1);
+    let statements = transactions[0].statements();
+    assert_eq!(statements.len(), 1);
+    assert!(statements[0].sql.starts_with("INSERT"));
+    assert_eq!(statements[0].values.as_ref().unwrap().0.len(), 5);
+}
+
+#[tokio::test]
+async fn merkle_duplicate_leaf_across_chunks_is_rejected_before_writes() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    let mut insertions = insertions();
+    insertions.push(insertions[0]);
+    let error = db
+        .store_merkle_tree_insertions(DOMAIN, &H256::zero(), rows(&insertions))
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Duplicate Merkle tree leaf index 0"));
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn merkle_bulk_insert_is_replayable_and_rolls_back_failed_tail() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let hook = H256::from_low_u64_be(1);
+    let insertions = insertions();
+
+    for _ in 0..2 {
+        assert_eq!(
+            db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+                .await?,
+            u64::from(ROW_COUNT)
+        );
+        assert_eq!(
+            merkle_tree_insertion::Entity::find().count(&db.0).await?,
+            u64::from(ROW_COUNT),
+            "replay must not duplicate rows"
+        );
+    }
+    for index in [0, 12_999, 13_000, ROW_COUNT - 1] {
+        assert_eq!(
+            db.retrieve_merkle_tree_insertion(DOMAIN, &hook, index)
+                .await?,
+            Some((insertions[usize::try_from(index)?], 20_000))
+        );
+    }
+
+    // Retain one existing row, then fail the first row of the second chunk.
+    // Both first-chunk inserts and updates must roll back with the failure.
+    db.0.execute_unprepared("TRUNCATE merkle_tree_insertion")
+        .await?;
+    let original = MerkleTreeInsertion::new(0, H256::repeat_byte(0xff));
+    db.store_merkle_tree_insertions(
+        DOMAIN,
+        &hook,
+        [StorableMerkleTreeInsertion {
+            insertion: &original,
+            block_number: 10_000,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    db.0.execute_unprepared(
+        "ALTER TABLE merkle_tree_insertion ADD CONSTRAINT reject_test_tail CHECK (leaf_index <> 13000)"
+    ).await?;
+    assert!(db
+        .store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+        .await
+        .is_err());
+    assert_eq!(merkle_tree_insertion::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((original, 10_000)),
+        "failed tail must also roll back updates to earlier existing rows"
+    );
+
+    db.0.execute_unprepared("ALTER TABLE merkle_tree_insertion DROP CONSTRAINT reject_test_tail")
+        .await?;
+    assert_eq!(
+        db.store_merkle_tree_insertions(DOMAIN, &hook, rows(&insertions))
+            .await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        merkle_tree_insertion::Entity::find().count(&db.0).await?,
+        u64::from(ROW_COUNT)
+    );
+    assert_eq!(
+        db.retrieve_merkle_tree_insertion(DOMAIN, &hook, 0).await?,
+        Some((insertions[0], 20_000))
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -3,7 +3,8 @@
 use eyre::Result;
 use itertools::Itertools;
 use sea_orm::{
-    prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, TransactionTrait,
+    prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, QueryTrait,
+    TransactionTrait,
 };
 use tracing::{debug, instrument, trace};
 
@@ -75,30 +76,28 @@ impl ScraperDb {
         }
     }
 
-    /// Get the tx id of a delivered message associated with a sequence.
+    /// Get the block height of a delivered message associated with a sequence.
     /// Also returns `None` for deliveries stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_delivered_message_tx_id(
+    pub async fn retrieve_delivered_message_block_number(
         &self,
         destination_domain: u32,
         destination_mailbox: &H256,
         sequence: u32,
-    ) -> Result<Option<i64>> {
-        if let Some(delivery) = delivered_message::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = delivered_message::Entity::find()
             .filter(delivered_message::Column::Domain.eq(destination_domain))
             .filter(
                 delivered_message::Column::DestinationMailbox
                     .eq(address_to_bytes(destination_mailbox)),
             )
             .filter(delivered_message::Column::Sequence.eq(sequence))
-            .one(&self.0)
-            .await?
-        {
-            Ok(delivery.destination_tx_id)
-        } else {
-            Ok(None)
-        }
+            .select_only()
+            .column(delivered_message::Column::DestinationTxId)
+            .limit(1)
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     async fn latest_deliveries_id(&self, domain: u32, destination_mailbox: Vec<u8>) -> Result<i64> {
@@ -237,34 +236,25 @@ impl ScraperDb {
         }
     }
 
-    /// Get the tx id associated with a dispatched message.
+    /// Get the block height associated with a dispatched message.
     /// Also returns `None` for messages stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_dispatched_tx_id(
+    pub async fn retrieve_dispatched_block_number(
         &self,
         origin_domain: u32,
         origin_mailbox: &H256,
         nonce: u32,
-    ) -> Result<Option<i64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            Nonce,
-        }
-
-        let tx_id = message::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = message::Entity::find()
             .filter(message::Column::Origin.eq(origin_domain))
             .filter(message::Column::OriginMailbox.eq(address_to_bytes(origin_mailbox)))
             .filter(message::Column::Nonce.eq(nonce))
             .select_only()
-            .column_as(message::Column::OriginTxId.max(), QueryAs::Nonce)
+            .column_as(message::Column::OriginTxId.max(), "tx_id")
             .group_by(message::Column::Origin)
-            // `origin_tx_id` is nullable (unresolvable on-chain transaction),
-            // so the MAX aggregate can be NULL even when a message row exists.
-            .into_values::<Option<i64>, QueryAs>()
-            .one(&self.0)
-            .await?;
-        Ok(tx_id.flatten())
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     async fn latest_dispatched_id(&self, domain: u32, origin_mailbox: Vec<u8>) -> Result<i64> {

--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)] // TODO: `rustc` 1.80.1 clippy issue
 
-use eyre::Result;
+use std::collections::HashSet;
+
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, DeriveColumn, EnumIter, Insert, QuerySelect, QueryTrait,
@@ -50,6 +52,9 @@ impl ScraperDb {
     /// u16::MAX (65_535u16) is the maximum amount of parameters we can
     /// have for Postgres. So 65000 / 20 = 3250
     const STORE_MESSAGE_CHUNK_SIZE: usize = 3250;
+
+    // Six bound columns per delivery; conflict expressions add no parameters.
+    const STORE_DELIVERY_CHUNK_SIZE: usize = 10_000;
 
     /// Get the delivered message associated with a sequence.
     #[instrument(skip(self))]
@@ -142,54 +147,57 @@ impl ScraperDb {
         deliveries: impl Iterator<Item = StorableDelivery<'_>>,
     ) -> Result<u64> {
         let destination_mailbox = address_to_bytes(&destination_mailbox);
-        let latest_id_before = self
-            .latest_deliveries_id(domain, destination_mailbox.clone())
-            .await?;
         // we have a race condition where a message may not have been scraped yet even
         // though we have received news of delivery on this chain, so the
         // message IDs are looked up in a separate "thread".
-        let models: Vec<delivered_message::ActiveModel> = deliveries
-            .map(|delivery| delivered_message::ActiveModel {
-                id: NotSet,
-                time_created: Set(date_time::now()),
-                msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
-                domain: Unchanged(domain as i32),
-                destination_mailbox: Unchanged(destination_mailbox.clone()),
-                destination_tx_id: Set(delivery.txn_id),
-                sequence: Set(delivery.sequence),
+        let mut message_ids = HashSet::new();
+        let models = deliveries
+            .map(|delivery| {
+                // Preserve single-upsert rejection across chunk boundaries.
+                ensure!(
+                    message_ids.insert(delivery.message_id),
+                    "Duplicate delivery message id in one batch"
+                );
+                Ok(delivered_message::ActiveModel {
+                    id: NotSet,
+                    time_created: Set(date_time::now()),
+                    msg_id: Unchanged(h256_to_bytes(&delivery.message_id)),
+                    domain: Unchanged(domain as i32),
+                    destination_mailbox: Unchanged(destination_mailbox.clone()),
+                    destination_tx_id: Set(delivery.txn_id),
+                    sequence: Set(delivery.sequence),
+                })
             })
-            .collect_vec();
+            .collect::<Result<Vec<_>>>()?;
+        drop(message_ids);
+        if models.is_empty() {
+            return Ok(0);
+        }
+        let latest_id_before = self
+            .latest_deliveries_id(domain, destination_mailbox.clone())
+            .await?;
 
         trace!(?models, "Writing delivered messages to database");
 
-        if models.is_empty() {
-            debug!("Wrote zero new delivered messages to database");
-            return Ok(0);
+        if models.len() <= Self::STORE_DELIVERY_CHUNK_SIZE {
+            delivery_insert_query(models).exec(&self.0).await?;
+        } else {
+            self.0
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        let mut models = models.into_iter();
+                        while !models.as_slice().is_empty() {
+                            let chunk = models
+                                .by_ref()
+                                .take(Self::STORE_DELIVERY_CHUNK_SIZE)
+                                .collect();
+                            delivery_insert_query(chunk).exec(txn).await?;
+                        }
+                        Ok(())
+                    })
+                })
+                .await?;
         }
-
-        Insert::many(models)
-            .on_conflict(
-                OnConflict::columns([delivered_message::Column::MsgId])
-                    // A fallback replay must not discard transaction metadata
-                    // that was resolved by an earlier scrape. This still lets
-                    // a later resolved scrape enrich an existing NULL row.
-                    .value(
-                        delivered_message::Column::DestinationTxId,
-                        Func::if_null(
-                            Expr::col((
-                                Alias::new("excluded"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                            Expr::col((
-                                Alias::new("delivered_message"),
-                                delivered_message::Column::DestinationTxId,
-                            )),
-                        ),
-                    )
-                    .to_owned(),
-            )
-            .exec(&self.0)
-            .await?;
 
         let new_deliveries_count = self
             .deliveries_count_since_id(domain, destination_mailbox, latest_id_before)
@@ -300,10 +308,6 @@ impl ScraperDb {
     ) -> Result<u64> {
         let origin_mailbox = address_to_bytes(origin_mailbox);
 
-        let latest_id_before = self
-            .latest_dispatched_id(domain, origin_mailbox.clone())
-            .await?;
-
         // we have a race condition where a message may not have been scraped yet even
         let models = messages
             .map(|storable| message::ActiveModel {
@@ -327,12 +331,14 @@ impl ScraperDb {
             })
             .collect_vec();
 
-        trace!(?models, "Writing messages to database");
-
         if models.is_empty() {
-            debug!("Wrote zero new messages to database");
             return Ok(0);
         }
+        let latest_id_before = self
+            .latest_dispatched_id(domain, origin_mailbox.clone())
+            .await?;
+
+        trace!(?models, "Writing messages to database");
 
         // ensure all chunks are inserted or none at all
         self.0
@@ -389,6 +395,31 @@ impl ScraperDb {
         );
         Ok(new_dispatch_count)
     }
+}
+
+fn delivery_insert_query(
+    models: Vec<delivered_message::ActiveModel>,
+) -> Insert<delivered_message::ActiveModel> {
+    Insert::many(models).on_conflict(
+        OnConflict::columns([delivered_message::Column::MsgId])
+            // A fallback replay must not discard transaction metadata
+            // that was resolved by an earlier scrape. This still lets
+            // a later resolved scrape enrich an existing NULL row.
+            .value(
+                delivered_message::Column::DestinationTxId,
+                Func::if_null(
+                    Expr::col((
+                        Alias::new("excluded"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                    Expr::col((
+                        Alias::new("delivered_message"),
+                        delivered_message::Column::DestinationTxId,
+                    )),
+                ),
+            )
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -62,3 +62,6 @@ impl Clone for ScraperDb {
         Self(conn)
     }
 }
+
+#[cfg(test)]
+mod write_batches;

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use eyre::Result;
 use itertools::Itertools;
 use sea_orm::{
-    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, Statement, TransactionTrait,
+    prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, QueryTrait, Statement,
+    TransactionTrait,
 };
 use tracing::{debug, instrument};
 
@@ -60,30 +61,28 @@ impl ScraperDb {
         }
     }
 
-    /// Get the transaction id of the gas payment associated with a sequence.
+    /// Get the block height of the gas payment associated with a sequence.
     /// Also returns `None` for payments stored with a NULL transaction id
     /// (unresolvable log meta fallback).
     #[instrument(skip(self))]
-    pub async fn retrieve_payment_tx_id(
+    pub async fn retrieve_payment_block_number(
         &self,
         origin: u32,
         interchain_gas_paymaster: &H256,
         sequence: u32,
-    ) -> Result<Option<i64>> {
-        if let Some(payment) = gas_payment::Entity::find()
+    ) -> Result<Option<u64>> {
+        let tx_id_query = gas_payment::Entity::find()
             .filter(gas_payment::Column::Origin.eq(origin))
             .filter(
                 gas_payment::Column::InterchainGasPaymaster
                     .eq(address_to_bytes(interchain_gas_paymaster)),
             )
             .filter(gas_payment::Column::Sequence.eq(sequence))
-            .one(&self.0)
-            .await?
-        {
-            Ok(payment.tx_id)
-        } else {
-            Ok(None)
-        }
+            .select_only()
+            .column(gas_payment::Column::TxId)
+            .limit(1)
+            .into_query();
+        self.retrieve_block_number_by_tx_query(tx_id_query).await
     }
 
     #[instrument(skip_all)]

--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use eyre::Result;
+use eyre::{ensure, Result};
 use itertools::Itertools;
 use sea_orm::{
     prelude::*, ActiveValue::*, ConnectionTrait, Insert, QuerySelect, QueryTrait, Statement,
@@ -29,6 +29,9 @@ pub struct StorablePayment<'a> {
 }
 
 impl ScraperDb {
+    // Eleven parameters per inserted row; reads add two scope parameters.
+    const PAYMENT_STORE_CHUNK_SIZE: usize = 5_000;
+
     const PAYMENT_STORE_LOCK_NAMESPACE: i32 = 0x4859_504C;
 
     /// Get the payment associated with a sequence.
@@ -92,6 +95,25 @@ impl ScraperDb {
         interchain_gas_paymaster: &H256,
         payments: &[StorablePayment<'_>],
     ) -> Result<u64> {
+        if payments.is_empty() {
+            return Ok(0);
+        }
+        // PostgreSQL rejects repeated non-NULL conflict keys in one upsert.
+        // Retain that rejection even if keys would land in different chunks.
+        let mut resolved_keys = HashSet::new();
+        for payment in payments {
+            if let Some(tx_id) = payment.txn_id {
+                ensure!(
+                    resolved_keys.insert((
+                        payment.payment.message_id,
+                        payment.meta.log_index.as_u64(),
+                        tx_id,
+                    )),
+                    "Duplicate resolved gas payment in one batch"
+                );
+            }
+        }
+        drop(resolved_keys);
         let interchain_gas_paymaster = address_to_bytes(interchain_gas_paymaster);
 
         // Postgres unique indexes treat NULLs as distinct, so the
@@ -127,20 +149,22 @@ impl ScraperDb {
         let payment_msg_ids = payments
             .iter()
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
+            .unique()
             .collect_vec();
-        let existing_payments = if payment_msg_ids.is_empty() {
-            Vec::new()
-        } else {
-            gas_payment::Entity::find()
-                .filter(gas_payment::Column::Domain.eq(domain))
-                .filter(
-                    gas_payment::Column::InterchainGasPaymaster
-                        .eq(interchain_gas_paymaster.clone()),
-                )
-                .filter(gas_payment::Column::MsgId.is_in(payment_msg_ids))
-                .all(&txn)
-                .await?
-        };
+        let mut existing_payments = Vec::new();
+        for message_ids in payment_msg_ids.chunks(Self::PAYMENT_STORE_CHUNK_SIZE) {
+            existing_payments.extend(
+                gas_payment::Entity::find()
+                    .filter(gas_payment::Column::Domain.eq(domain))
+                    .filter(
+                        gas_payment::Column::InterchainGasPaymaster
+                            .eq(interchain_gas_paymaster.clone()),
+                    )
+                    .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
+                    .all(&txn)
+                    .await?,
+            );
+        }
         let mut seen_fallback_payments: HashSet<(Vec<u8>, i64)> = existing_payments
             .iter()
             .map(|payment| (payment.msg_id.clone(), payment.log_index))
@@ -196,27 +220,34 @@ impl ScraperDb {
             debug!("Wrote zero new gas payments to database");
             0
         } else {
-            Insert::many(models)
-                .on_conflict(
-                    OnConflict::columns([
-                        // don't need domain because TxId includes it
-                        gas_payment::Column::MsgId,
-                        gas_payment::Column::TxId,
-                        gas_payment::Column::LogIndex,
-                    ])
-                    .update_columns([
-                        gas_payment::Column::TimeCreated,
-                        gas_payment::Column::Payment,
-                        gas_payment::Column::GasAmount,
-                        gas_payment::Column::Origin,
-                        gas_payment::Column::Destination,
-                        gas_payment::Column::InterchainGasPaymaster,
-                        gas_payment::Column::Sequence,
-                    ])
-                    .to_owned(),
-                )
-                .exec(&txn)
-                .await?;
+            let mut models = models.into_iter();
+            while !models.as_slice().is_empty() {
+                let chunk = models
+                    .by_ref()
+                    .take(Self::PAYMENT_STORE_CHUNK_SIZE)
+                    .collect::<Vec<_>>();
+                Insert::many(chunk)
+                    .on_conflict(
+                        OnConflict::columns([
+                            // don't need domain because TxId includes it
+                            gas_payment::Column::MsgId,
+                            gas_payment::Column::TxId,
+                            gas_payment::Column::LogIndex,
+                        ])
+                        .update_columns([
+                            gas_payment::Column::TimeCreated,
+                            gas_payment::Column::Payment,
+                            gas_payment::Column::GasAmount,
+                            gas_payment::Column::Origin,
+                            gas_payment::Column::Destination,
+                            gas_payment::Column::InterchainGasPaymaster,
+                            gas_payment::Column::Sequence,
+                        ])
+                        .to_owned(),
+                    )
+                    .exec(&txn)
+                    .await?;
+            }
 
             gas_payment::Entity::find()
                 .filter(gas_payment::Column::Domain.eq(domain))

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -22,21 +22,6 @@ pub struct StorableTxn {
 }
 
 impl ScraperDb {
-    pub async fn retrieve_block_id(&self, tx_id: i64) -> Result<Option<i64>> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            BlockId,
-        }
-        let block_id = transaction::Entity::find()
-            .filter(transaction::Column::Id.eq(tx_id))
-            .select_only()
-            .column_as(transaction::Column::BlockId, QueryAs::BlockId)
-            .into_values::<i64, QueryAs>()
-            .one(&self.0)
-            .await?;
-        Ok(block_id)
-    }
-
     /// Lookup transactions and find their ids. Any transactions which are not
     /// found be excluded from the hashmap.
     pub async fn get_txn_ids(

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -1,0 +1,380 @@
+//! Regression tests for PostgreSQL statement bounds and atomic event writes.
+
+use std::collections::BTreeMap;
+
+use migration::MigratorTrait;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, Database, DatabaseBackend, EntityTrait, MockDatabase,
+    MockExecResult, PaginatorTrait, QueryFilter, Value,
+};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+use hyperlane_core::{
+    BlockInfo, InterchainGasPayment, LogMeta, TxnInfo, TxnReceiptInfo, H256, H512, U256,
+};
+
+use super::{
+    generated::{delivered_message, gas_payment},
+    ScraperDb, StorableDelivery, StorablePayment, StorableTxn,
+};
+
+const DOMAIN: u32 = 1;
+
+fn result(key: &str, value: i64) -> Vec<BTreeMap<String, Value>> {
+    vec![BTreeMap::from([(
+        key.to_owned(),
+        Value::BigInt(Some(value)),
+    )])]
+}
+
+fn payments(count: u32) -> Vec<InterchainGasPayment> {
+    (0..count)
+        .map(|index| InterchainGasPayment {
+            message_id: H256::from_low_u64_be(u64::from(index)),
+            destination: DOMAIN,
+            payment: U256::from(1000),
+            gas_amount: U256::from(12345),
+        })
+        .collect()
+}
+
+fn payment_rows<'a>(
+    payments: &'a [InterchainGasPayment],
+    meta: &'a LogMeta,
+    txn_id: Option<i64>,
+) -> Vec<StorablePayment<'a>> {
+    payments
+        .iter()
+        .enumerate()
+        .map(|(index, payment)| StorablePayment {
+            payment,
+            sequence: Some(i64::try_from(index).unwrap()),
+            meta,
+            txn_id,
+        })
+        .collect()
+}
+
+fn deliveries(count: u32, meta: &LogMeta) -> impl Iterator<Item = StorableDelivery<'_>> {
+    (0..count).map(|index| StorableDelivery {
+        message_id: H256::from_low_u64_be(u64::from(index)),
+        sequence: Some(i64::from(index)),
+        meta,
+        txn_id: None,
+    })
+}
+
+#[tokio::test]
+async fn empty_event_writes_do_not_access_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert_eq!(
+        db.store_deliveries(DOMAIN, H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &H256::zero(), std::iter::empty())
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &H256::zero(), &[]).await.unwrap(),
+        0
+    );
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn delivery_batches_bound_binds_and_preserve_small_fast_path() {
+    for count in [1, 12_000] {
+        let chunks = if count == 1 { 1 } else { 2 };
+        let mut results = vec![result("max_id", 0)];
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(results)
+                .into_connection(),
+        );
+        assert_eq!(
+            db.store_deliveries(DOMAIN, H256::zero(), deliveries(count, &LogMeta::default()))
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        let statements: Vec<_> = log
+            .iter()
+            .flat_map(|transaction| transaction.statements())
+            .collect();
+        let binds: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .map(|statement| statement.values.as_ref().unwrap().0.len())
+            .collect();
+        assert_eq!(
+            binds,
+            if count == 1 {
+                vec![6]
+            } else {
+                vec![60_000, 12_000]
+            }
+        );
+        assert_eq!(statements.len(), if count == 1 { 3 } else { 6 });
+        if count > 1 {
+            assert_eq!(log[1].statements().first().unwrap().sql, "BEGIN");
+            assert_eq!(log[1].statements().last().unwrap().sql, "COMMIT");
+        }
+    }
+}
+
+#[tokio::test]
+async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
+    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERTs.
+    for count in [5_000_u32, 66_000] {
+        let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
+        let mut results = vec![result("max_id", 0)];
+        results.extend((0..chunks).map(|_| Vec::new()));
+        results.extend((0..chunks).map(|_| result("id", 1)));
+        results.push(result("num_items", i64::from(count)));
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_exec_results([MockExecResult {
+                    last_insert_id: 0,
+                    rows_affected: 1,
+                }])
+                .append_query_results(results)
+                .into_connection(),
+        );
+        let mut payments = payments(count);
+        payments.push(payments[0].clone()); // Prefetch and NULL-row identity must dedupe this.
+        let meta = LogMeta::default();
+        let rows = payment_rows(&payments, &meta, None);
+        assert_eq!(
+            db.store_payments(DOMAIN, &H256::zero(), &rows)
+                .await
+                .unwrap(),
+            u64::from(count)
+        );
+        let log = db.0.into_transaction_log();
+        assert_eq!(
+            log.len(),
+            1,
+            "one transaction must retain the advisory lock throughout"
+        );
+        let statements = log[0].statements();
+        assert_eq!(statements.first().unwrap().sql, "BEGIN");
+        assert_eq!(statements.last().unwrap().sql, "COMMIT");
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| statement.sql.contains("pg_advisory_xact_lock"))
+                .count(),
+            1
+        );
+        let reads: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.contains(" IN ("))
+            .collect();
+        assert_eq!(reads.len(), chunks);
+        assert!(reads
+            .iter()
+            .all(|statement| statement.values.as_ref().unwrap().0.len() <= 5_002));
+        let inserts: Vec<_> = statements
+            .iter()
+            .filter(|statement| statement.sql.starts_with("INSERT"))
+            .collect();
+        assert_eq!(inserts.len(), chunks);
+        assert_eq!(inserts[0].values.as_ref().unwrap().0.len(), 55_000);
+        assert!(statements.iter().all(|statement| statement
+            .values
+            .as_ref()
+            .map_or(true, |values| values.0.len() <= usize::from(u16::MAX))));
+    }
+}
+
+#[tokio::test]
+async fn duplicate_keys_across_chunks_are_rejected() {
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([result("max_id", 0)])
+            .into_connection(),
+    );
+    let meta = LogMeta::default();
+    let rows = deliveries(12_000, &meta).chain(deliveries(1, &meta));
+    assert!(db
+        .store_deliveries(DOMAIN, H256::zero(), rows)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate delivery"));
+    let mut payments = payments(6_000);
+    payments.push(payments[0].clone());
+    assert!(db
+        .store_payments(
+            DOMAIN,
+            &H256::zero(),
+            &payment_rows(&payments, &meta, Some(1))
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate resolved gas payment"));
+    let log = db.0.into_transaction_log();
+    assert!(log.is_empty());
+}
+
+async fn seed_transaction(db: &ScraperDb, index: u64) -> eyre::Result<i64> {
+    let hash = H256::from_low_u64_be(55);
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash,
+            timestamp: 1_700_000_000,
+            number: 500,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let block_id = db.get_block_basic([&hash].into_iter()).await?[0].id;
+    let tx_hash = H512::from_low_u64_be(66 + index);
+    db.store_txns(
+        [StorableTxn {
+            block_id,
+            info: TxnInfo {
+                hash: tx_hash,
+                gas_limit: U256::one(),
+                max_priority_fee_per_gas: None,
+                max_fee_per_gas: None,
+                gas_price: None,
+                nonce: 0,
+                sender: H256::zero(),
+                recipient: None,
+                receipt: Some(TxnReceiptInfo {
+                    gas_used: U256::one(),
+                    cumulative_gas_used: U256::one(),
+                    effective_gas_price: None,
+                }),
+                raw_input_data: None,
+            },
+        }]
+        .into_iter(),
+    )
+    .await?;
+    Ok(db.get_txn_ids([&tx_hash].into_iter()).await?[&tx_hash])
+}
+
+#[tokio::test]
+async fn bulk_events_replay_and_rollback_failed_tail_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        12_000
+    );
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        0
+    );
+    assert_eq!(
+        delivered_message::Entity::find().count(&db.0).await?,
+        12_000
+    );
+    db.0.execute_unprepared("TRUNCATE delivered_message")
+        .await?;
+    let original_tx = seed_transaction(&db, 0).await?;
+    let replacement_tx = seed_transaction(&db, 1).await?;
+    db.store_deliveries(
+        DOMAIN,
+        address,
+        deliveries(1, &meta).map(|mut row| {
+            row.txn_id = Some(original_tx);
+            row
+        }),
+    )
+    .await?;
+    db.0.execute_unprepared("ALTER TABLE delivered_message ADD CONSTRAINT reject_delivery_tail CHECK (sequence <> 10000)").await?;
+    assert!(db
+        .store_deliveries(
+            DOMAIN,
+            address,
+            deliveries(12_000, &meta).map(|mut row| {
+                row.txn_id = Some(replacement_tx);
+                row
+            })
+        )
+        .await
+        .is_err());
+    assert_eq!(delivered_message::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        delivered_message::Entity::find()
+            .one(&db.0)
+            .await?
+            .unwrap()
+            .destination_tx_id,
+        Some(original_tx)
+    );
+    db.0.execute_unprepared("ALTER TABLE delivered_message DROP CONSTRAINT reject_delivery_tail")
+        .await?;
+    assert_eq!(
+        db.store_deliveries(DOMAIN, address, deliveries(12_000, &meta))
+            .await?,
+        11_999
+    );
+
+    let payments = payments(6_000);
+    let fallback = payment_rows(&payments, &meta, None);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 6_000);
+    assert_eq!(db.store_payments(DOMAIN, &address, &fallback).await?, 0);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    db.0.execute_unprepared("TRUNCATE gas_payment").await?;
+    db.store_payments(DOMAIN, &address, &fallback[..1]).await?;
+    let tx_id = seed_transaction(&db, 0).await?;
+    let resolved = payment_rows(&payments, &meta, Some(tx_id));
+    db.0.execute_unprepared("ALTER TABLE gas_payment ADD CONSTRAINT reject_payment_tail CHECK (sequence <> 5000 OR tx_id IS NULL)").await?;
+    assert!(db
+        .store_payments(DOMAIN, &address, &resolved)
+        .await
+        .is_err());
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 1);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        1,
+        "failed tail must restore the deleted NULL fallback row"
+    );
+    db.0.execute_unprepared("ALTER TABLE gas_payment DROP CONSTRAINT reject_payment_tail")
+        .await?;
+    assert_eq!(db.store_payments(DOMAIN, &address, &resolved).await?, 6_000);
+    assert_eq!(gas_payment::Entity::find().count(&db.0).await?, 6_000);
+    assert_eq!(
+        gas_payment::Entity::find()
+            .filter(gas_payment::Column::TxId.is_null())
+            .count(&db.0)
+            .await?,
+        0
+    );
+    assert_eq!(
+        db.store_payments(DOMAIN, &address, &fallback).await?,
+        0,
+        "later fallback replay must preserve resolved rows"
+    );
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -134,7 +134,7 @@ async fn delivery_batches_bound_binds_and_preserve_small_fast_path() {
 
 #[tokio::test]
 async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
-    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERTs.
+    // 66,000 IDs exceed the old prefetch's 65,535 bind limit independently of INSERT statements.
     for count in [5_000_u32, 66_000] {
         let chunks = usize::try_from(count.div_ceil(5_000)).unwrap();
         let mut results = vec![result("max_id", 0)];

--- a/rust/main/agents/scraper/src/store/deliveries.rs
+++ b/rust/main/agents/scraper/src/store/deliveries.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 use eyre::Result;
 
 use hyperlane_core::{
-    unwrap_or_none_result, Delivery, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader,
-    Indexed, LogMeta, H512,
+    Delivery, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
 };
 
 use crate::db::StorableDelivery;
@@ -67,12 +66,12 @@ impl HyperlaneSequenceAwareIndexerStoreReader<Delivery> for HyperlaneDbStore {
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_delivered_message_tx_id(self.domain.id(), &self.mailbox_address, sequence)
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_delivered_message_block_number(
+                self.domain.id(),
+                &self.mailbox_address,
+                sequence,
+            )
+            .await
     }
 }

--- a/rust/main/agents/scraper/src/store/dispatches.rs
+++ b/rust/main/agents/scraper/src/store/dispatches.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use eyre::Result;
 use hyperlane_core::{
-    unwrap_or_none_result, HyperlaneLogStore, HyperlaneMessage,
-    HyperlaneSequenceAwareIndexerStoreReader, Indexed, LogMeta, H512,
+    HyperlaneLogStore, HyperlaneMessage, HyperlaneSequenceAwareIndexerStoreReader, Indexed,
+    LogMeta, H512,
 };
 use time::OffsetDateTime;
 use tracing::warn;
@@ -329,13 +329,9 @@ impl HyperlaneSequenceAwareIndexerStoreReader<HyperlaneMessage> for HyperlaneDbS
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_dispatched_tx_id(self.domain.id(), &self.mailbox_address, sequence)
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_dispatched_block_number(self.domain.id(), &self.mailbox_address, sequence)
+            .await
     }
 }
 

--- a/rust/main/agents/scraper/src/store/payments.rs
+++ b/rust/main/agents/scraper/src/store/payments.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 use tracing::debug;
 
 use hyperlane_core::{
-    unwrap_or_none_result, HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed,
-    InterchainGasPayment, LogMeta, H512,
+    HyperlaneLogStore, HyperlaneSequenceAwareIndexerStoreReader, Indexed, InterchainGasPayment,
+    LogMeta, H512,
 };
 
 use crate::db::StorablePayment;
@@ -88,16 +88,12 @@ impl HyperlaneSequenceAwareIndexerStoreReader<InterchainGasPayment> for Hyperlan
 
     /// Gets the block number at which the log occurred.
     async fn retrieve_log_block_number_by_sequence(&self, sequence: u32) -> Result<Option<u64>> {
-        let tx_id = unwrap_or_none_result!(
-            self.db
-                .retrieve_payment_tx_id(
-                    self.domain.id(),
-                    &self.interchain_gas_paymaster_address,
-                    sequence,
-                )
-                .await?
-        );
-        let block_id = unwrap_or_none_result!(self.db.retrieve_block_id(tx_id).await?);
-        Ok(self.db.retrieve_block_number(block_id).await?)
+        self.db
+            .retrieve_payment_block_number(
+                self.domain.id(),
+                &self.interchain_gas_paymaster_address,
+                sequence,
+            )
+            .await
     }
 }

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -110,7 +110,7 @@ impl HyperlaneDbStore {
             .map(|(txn_hash, block_id)| TxnWithBlockId { txn_hash, block_id });
         let txns_with_ids = self.ensure_txns(txn_hash_with_block_ids).await?;
 
-        Ok(txns_with_ids.map(move |TxnWithId { hash, id: txn_id }| TxnWithId { hash, id: txn_id }))
+        Ok(txns_with_ids)
     }
 
     /// Takes a list of transaction hashes and the block id the transaction is

--- a/rust/main/agents/scraper/src/store/tests.rs
+++ b/rust/main/agents/scraper/src/store/tests.rs
@@ -565,24 +565,60 @@ async fn test_fallback_events_persist_and_survive_restart() -> eyre::Result<()> 
     assert_eq!(
         store
             .db
-            .retrieve_dispatched_tx_id(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
+            .retrieve_dispatched_block_number(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
     assert_eq!(
         store
             .db
-            .retrieve_delivered_message_tx_id(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
+            .retrieve_delivered_message_block_number(TEST_DOMAIN_ID, &mailbox, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
     assert_eq!(
         store
             .db
-            .retrieve_payment_tx_id(TEST_DOMAIN_ID, &igp, SEQUENCE)
+            .retrieve_payment_block_number(TEST_DOMAIN_ID, &igp, SEQUENCE)
             .await?,
-        Some(transaction_db_id)
+        Some(resolved_meta.block_number)
     );
+    // Lookup scoping must survive SQL composition: another domain, address,
+    // or sequence cannot borrow this event's resolved block height.
+    for (domain, address, sequence) in [
+        (TEST_DESTINATION_DOMAIN_ID, mailbox, SEQUENCE),
+        (TEST_DOMAIN_ID, H256::from_low_u64_be(9999), SEQUENCE),
+        (TEST_DOMAIN_ID, mailbox, SEQUENCE + 100),
+    ] {
+        assert_eq!(
+            store
+                .db
+                .retrieve_dispatched_block_number(domain, &address, sequence)
+                .await?,
+            None
+        );
+        assert_eq!(
+            store
+                .db
+                .retrieve_delivered_message_block_number(domain, &address, sequence)
+                .await?,
+            None
+        );
+    }
+    for (origin, address, sequence) in [
+        (TEST_DESTINATION_DOMAIN_ID, igp, SEQUENCE),
+        (TEST_DOMAIN_ID, H256::from_low_u64_be(9999), SEQUENCE),
+        (TEST_DOMAIN_ID, igp, SEQUENCE + 100),
+    ] {
+        assert_eq!(
+            store
+                .db
+                .retrieve_payment_block_number(origin, &address, sequence)
+                .await?,
+            None
+        );
+    }
+
     let raw = store
         .db
         .retrieve_raw_message_dispatch_by_id(&message.id())


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Delivery and gas-payment INSERTs share the unbounded statement pattern found in the Base Merkle backfill failure (#9476). Payment prefetch also builds an unbounded IN list. These are source-confirmed variants; no delivery/payment production failure is claimed.

## Solution

Bound deliveries to 10,000 rows per INSERT, using one atomic transaction for larger batches. Bound payment INSERTs and deduplicated prefetch IDs to 5,000 per statement inside the existing advisory-locked transaction. Reject duplicate upsert keys across the complete batch to preserve single-statement PostgreSQL behavior. Keep NULL fallback reconciliation and resolved metadata precedence.

Skip all database work for empty delivery, dispatch and payment batches.

## Numerical impact

| Input | Before → after | Evidence |
|---|---|---|
| 12,000 deliveries | Invalid 72,000-bind INSERT → two INSERTs: 60,000 + 12,000 | Emitted SQL and real PostgreSQL write/replay |
| 6,000 payments | Invalid 66,000-bind INSERT → two INSERTs: 55,000 + 11,000 | Real PostgreSQL write/replay; bound verified in SQL tests |
| 66,000 unique payment IDs | Invalid 66,002-bind prefetch → 14 SELECTs, each ≤5,002 binds | Emitted SQL; duplicates add no prefetch parameters |
| Empty delivery / dispatch | One MAX query → zero SQL statements | Regression |
| Empty payment | BEGIN + lock + MAX + COMMIT → zero statements | Regression |

Small delivery calls remain MAX + INSERT + COUNT (three statements). A 12,000-row delivery call uses six statements including BEGIN/COMMIT. Large batches require more round trips to stay within the protocol limit; no latency improvement is claimed. Full model/existing-payment collections remain proportional to batch size.

## Verification and scope

- **5/5 new writer tests passed**: bind limits, deduplicated prefetch, empty calls, global duplicate rejection and real PostgreSQL replay/rollback. Failed tail restores earlier inserts, an existing delivery transaction update and a deleted NULL payment fallback row. Retry succeeds; later fallback preserves resolved metadata.
- Existing fallback/restart PostgreSQL regression passed **1/1**.
- Strict production scraper Clippy, formatting and normal commit hooks passed. Root and independent validator reviews found no remaining blockers.
- No cursor skipping, schema change, partial commits or production mutation. Existing advisory-lock scope retained.
- Other writers already bounded at their call sites remain unchanged. Initial block/transaction enrichment IN-list bounds are a separate residual opportunity.

Stack: follows #9476 and #9468.
