### PR TITLE
perf(rebalancer): load LiFi only when configured

### DIFF
--- a/.changeset/lazy-external-bridge.md
+++ b/.changeset/lazy-external-bridge.md
@@ -1,0 +1,5 @@
+---
+'@hyperlane-xyz/rebalancer': patch
+---
+
+Deferred LiFi SDK initialization until a configured external bridge was needed, reducing startup work for rebalancers without LiFi inventory execution.

--- a/typescript/rebalancer/docs/performance/lazy-lifi.md
+++ b/typescript/rebalancer/docs/performance/lazy-lifi.md
@@ -1,0 +1,52 @@
+# Load LiFi only when configured
+
+The factory imported LiFiBridge eagerly, initializing its SDK even for movable-only rebalancers. It now imports the module inside the configured LiFi branch of the existing awaited initialization chain. An external bridge override, including an empty override, still bypasses normal bridge construction. Configured LiFi initialization failures still abort service initialization before monitoring or execution starts.
+
+## Observed deployment coverage
+
+Read-only mainnet3 ConfigMap inspection on 2026-09-05 found 14 rebalancer configurations: four configured a LiFi integrator, ten did not. Nine of those ten had no inventory signer configuration; the other had inventory configuration without a LiFi bridge. No configuration, signer or workload was changed.
+
+## Local measurement
+
+Node 24.13.0, macOS, five alternating fresh-process pairs after one discarded warmup pair, same dependency installation. Each process imported the compiled RebalancerContextFactory module. The baseline was the parent compiled module preserved alongside the changed module so its relative dependencies resolved identically. Node module-load hooks counted LiFi files; no service, RPC, quote or signing operation was run.
+
+| Median                       | Parent     | Lazy import | Difference        |
+| ---------------------------- | ---------- | ----------- | ----------------- |
+| Factory import wall time     | 1484.18 ms | 1356.74 ms  | -127.44 ms / 8.6% |
+| Import CPU time              | 2016.92 ms | 1866.27 ms  | -150.65 ms / 7.5% |
+| Resident memory after import | 645.64 MiB | 629.75 MiB  | -15.89 MiB / 2.5% |
+| LiFi module loads            | 122        | 0           | -122 / 100%       |
+
+These are local unbundled module-import measurements on a shared host. RSS is current resident memory, not peak memory or retained heap. The percentages are neither deployed startup measurements nor steady-state fleet memory savings. Inventory configurations that need LiFi pay its import cost during initialization.
+
+## Reproduction
+
+Use separate parent and PR checkouts with the same Node version and frozen dependencies. Build workspace dependencies and the rebalancer package, then run the following from each repository root in alternating fresh processes. Discard the first pair and compare at least five pairs. The module-load hook requires a Node release supporting registerHooks (measurement used 24.13.0).
+
+```sh
+node --input-type=module <<'JS'
+import { registerHooks } from 'node:module';
+let lifiModules = 0;
+registerHooks({
+  load(url, context, nextLoad) {
+    if (url.includes('/@lifi/')) lifiModules++;
+    return nextLoad(url, context);
+  },
+});
+const started = performance.now();
+const cpu = process.cpuUsage();
+await import('./typescript/rebalancer/dist/factories/RebalancerContextFactory.js');
+console.log(JSON.stringify({
+  wallMs: performance.now() - started,
+  cpuMs: Object.values(process.cpuUsage(cpu)).reduce((a, b) => a + b, 0) / 1000,
+  rssMiB: process.memoryUsage().rss / 1048576,
+  lifiModules,
+}));
+JS
+```
+
+## Validation
+
+391 unit tests passed, including configured bridge construction and absent-configuration behavior. Package build and lint passed (three existing warnings). The normal production ncc bundle built and reached its expected missing-config guard with an empty environment, before external operations. A separate offline ncc fixture also exercises the dynamically imported bridge constructor, with empty chain metadata and no quote or signing call. No deployment was performed.
+
+Local runtime imports needed the previously identified ignored node_modules core-js compatibility entry for the pinned Provable SDK; no dependency or lockfile change is included.

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.test.ts
@@ -156,6 +156,52 @@ describe('RebalancerContextFactory', () => {
     sandbox.restore();
   });
 
+  describe('external bridge initialization', () => {
+    async function factoryWithBridges(
+      externalBridges?: RebalancerConfig['externalBridges'],
+    ) {
+      const { multiProvider } = createMockMultiProvider([
+        { name: 'ethereum', protocol: ProtocolType.Ethereum },
+        { name: 'arbitrum', protocol: ProtocolType.Ethereum },
+      ]);
+      return createFactory(
+        { ...createMockConfig(), externalBridges },
+        multiProvider,
+        {
+          tokens: [
+            createToken(
+              'ethereum',
+              TEST_ADDRESSES.ethereum,
+              TokenStandard.EvmHypCollateral,
+            ),
+            createToken(
+              'arbitrum',
+              TEST_ADDRESSES.arbitrum,
+              TokenStandard.EvmHypCollateral,
+            ),
+          ],
+        },
+      );
+    }
+
+    it('returns no bridges when no external bridge is configured', async () => {
+      const factory = await factoryWithBridges();
+      expect(await factory['buildExternalBridgeRegistry']()).to.deep.equal({});
+    });
+
+    it('awaits the configured LiFi bridge before returning the registry', async () => {
+      const factory = await factoryWithBridges({
+        lifi: { integrator: 'test-rebalancer' },
+      });
+      const registry = await factory['buildExternalBridgeRegistry']();
+      expect(Object.keys(registry)).to.deep.equal(['lifi']);
+      expect(registry.lifi?.externalBridgeId).to.equal('lifi');
+      expect(registry.lifi?.getNativeTokenAddress?.()).to.equal(
+        '0x0000000000000000000000000000000000000000',
+      );
+    });
+  });
+
   describe('create() — non-EVM chain handling', () => {
     it('should skip provider initialization for StarkNet chains', async () => {
       const { multiProvider } = createMockMultiProvider([

--- a/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
+++ b/typescript/rebalancer/src/factories/RebalancerContextFactory.ts
@@ -19,7 +19,6 @@ import {
   objMap,
 } from '@hyperlane-xyz/utils';
 
-import { LiFiBridge } from '../bridges/LiFiBridge.js';
 import { type RebalancerConfig } from '../config/RebalancerConfig.js';
 import {
   ExecutionType,
@@ -528,7 +527,8 @@ export class RebalancerContextFactory {
     }
 
     const externalBridgeRegistry: Partial<ExternalBridgeRegistry> =
-      externalBridgeRegistryOverride ?? this.buildExternalBridgeRegistry();
+      externalBridgeRegistryOverride ??
+      (await this.buildExternalBridgeRegistry());
 
     if (Object.keys(externalBridgeRegistry).length === 0) {
       if (externalBridgeRegistryOverride !== undefined) {
@@ -627,7 +627,9 @@ export class RebalancerContextFactory {
     return { inventoryRebalancer, externalBridgeRegistry, inventoryConfig };
   }
 
-  private buildExternalBridgeRegistry(): Partial<ExternalBridgeRegistry> {
+  private async buildExternalBridgeRegistry(): Promise<
+    Partial<ExternalBridgeRegistry>
+  > {
     const { externalBridges } = this.config;
     const registry: Partial<ExternalBridgeRegistry> = {};
 
@@ -636,6 +638,7 @@ export class RebalancerContextFactory {
         case ExternalBridgeType.LiFi: {
           const lifiConfig = externalBridges?.lifi;
           if (lifiConfig?.integrator) {
+            const { LiFiBridge } = await import('../bridges/LiFiBridge.js');
             registry[ExternalBridgeType.LiFi] = new LiFiBridge(
               {
                 integrator: lifiConfig.integrator,


### PR DESCRIPTION
## Problem

RebalancerContextFactory eagerly imports LiFiBridge, loading the LiFi SDK even when no external bridge is configured. Read-only inspection found **10 of 14 deployed mainnet3 rebalancer configurations do not configure LiFi**.

## Solution

Dynamically import LiFiBridge inside the configured LiFi branch of the existing awaited initialization chain. Configured inventory execution still constructs the same bridge before the service starts; explicit bridge overrides continue to bypass normal construction.

Stacked on #9474 → #9465.

## Performance evidence

Five alternating fresh-process pairs after one warmup, Node24.13.0/macOS, same frozen dependencies, importing compiled factory modules:

| Median local measurement | Parent | This PR | Difference |
| --- | --- | --- | --- |
| Import wall time | 1484.18ms | 1356.74ms | −127.44ms / 8.6% |
| Import CPU time | 2016.92ms | 1866.27ms | −150.65ms / 7.5% |
| Resident memory after import | 645.64MiB | 629.75MiB | −15.89MiB / 2.5% |
| LiFi module loads | 122 | 0 | −122 / 100% |

These are **local unbundled module-import measurements**, not deployed startup latency or steady-state fleet memory savings. RSS is current resident memory, not peak memory. Configurations that need LiFi pay its import cost during awaited initialization. Shared-host timing varies. [Reproduction and limits](typescript/rebalancer/docs/performance/lazy-lifi.md).

## Validation

- 391 package unit tests passed, including absent/configured bridge construction.
- Package build and lint passed; three existing test assertion warnings remain.
- Production ncc bundle built and reached its expected missing-config guard in an empty environment.
- Separate offline ncc fixture successfully constructed the dynamically imported bridge; no network or signing operation.
- Independent source review verified awaited initialization, override semantics and failure propagation. Patch changeset included.

Local runtime validation used the previously identified ignored node_modules compatibility entry for the pinned Provable SDK/core-js mismatch. No dependency or lockfile change. No deployment performed.


---

Superseded by consolidated draft #9507: [perf(rebalancer): eliminate duplicate reads and unused initialization](https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/9507). Its combined change preserves this PR's implementation and numerical evidence. This draft is closed as superseded, without merging; the original branch and benchmark history remain available.
