### PR TITLE
perf(scraper): materialize chunks lazily and move dispatch models

### DIFF
--- a/rust/main/agents/scraper/src/db/message.rs
+++ b/rust/main/agents/scraper/src/db/message.rs
@@ -346,8 +346,13 @@ impl ScraperDb {
                 Box::pin(async move {
                     // insert messages in chunks, to not run into
                     // "Too many arguments" error
-                    for chunk in models.chunks(Self::STORE_MESSAGE_CHUNK_SIZE) {
-                        Insert::many(chunk.to_vec())
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models
+                            .by_ref()
+                            .take(Self::STORE_MESSAGE_CHUNK_SIZE)
+                            .collect();
+                        Insert::many(chunk)
                             .on_conflict(
                                 OnConflict::columns([
                                     message::Column::Origin,

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -378,3 +378,56 @@ async fn bulk_events_replay_and_rollback_failed_tail_in_postgres() -> eyre::Resu
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let rows = || {
+        (0..3_251u32).map(|nonce| super::StorableMessage {
+            msg: hyperlane_core::HyperlaneMessage {
+                nonce,
+                origin: DOMAIN,
+                destination: DOMAIN,
+                body: if nonce == 0 {
+                    vec![]
+                } else {
+                    vec![(nonce % 251) as u8; 1_024]
+                },
+                ..Default::default()
+            },
+            meta: &meta,
+            txn_id: None,
+            id_override: None,
+        })
+    };
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        3_251
+    );
+    assert_eq!(
+        db.store_dispatched_messages(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = super::generated::message::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), 3_251);
+    for row in stored {
+        let expected = if row.nonce == 0 {
+            None
+        } else {
+            Some(vec![(row.nonce % 251) as u8; 1_024])
+        };
+        assert_eq!(row.msg_body, expected);
+    }
+    Ok(())
+}

--- a/rust/main/agents/scraper/src/store/storage.rs
+++ b/rust/main/agents/scraper/src/store/storage.rs
@@ -7,7 +7,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use eyre::Result;
-use itertools::Itertools;
 use prometheus::IntCounterVec;
 use tracing::{trace, warn};
 
@@ -344,13 +343,60 @@ struct TxnWithBlockId {
     block_id: i64,
 }
 
-fn as_chunks<T>(iter: impl Iterator<Item = T>, chunk_size: usize) -> impl Iterator<Item = Vec<T>> {
-    // the itertools chunks function uses refcell which cannot be used across an
-    // await so this stabilizes the result by putting it into a vec of vecs and
-    // using that for iteration.
-    iter.chunks(chunk_size)
-        .into_iter()
-        .map(|chunk| chunk.into_iter().collect())
-        .collect_vec()
-        .into_iter()
+fn as_chunks<T>(
+    mut iter: impl Iterator<Item = T>,
+    chunk_size: usize,
+) -> impl Iterator<Item = Vec<T>> {
+    assert!(chunk_size > 0, "chunk size must be positive");
+    // Own just the current chunk across await points. itertools::chunks keeps
+    // a RefCell borrowed by each chunk, which cannot be held across awaits.
+    std::iter::from_fn(move || {
+        let chunk: Vec<_> = iter.by_ref().take(chunk_size).collect();
+        (!chunk.is_empty()).then_some(chunk)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::as_chunks;
+
+    #[test]
+    fn enrichment_chunks_only_consume_the_requested_batch() {
+        let consumed = Cell::new(0);
+        let input = (0..1_000).inspect(|_| consumed.set(consumed.get() + 1));
+        let mut chunks = as_chunks(input, 50);
+        assert_eq!(consumed.get(), 0);
+        assert_eq!(chunks.next(), Some((0..50).collect()));
+        assert_eq!(consumed.get(), 50);
+        assert_eq!(chunks.next(), Some((50..100).collect()));
+        assert_eq!(consumed.get(), 100);
+        drop(chunks);
+        assert_eq!(
+            consumed.get(),
+            100,
+            "dropping work must not consume later chunks"
+        );
+    }
+
+    #[test]
+    fn enrichment_chunks_preserve_order_and_partial_tail() {
+        assert_eq!(
+            as_chunks(0..5, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3], vec![4]]
+        );
+        assert_eq!(
+            as_chunks(0..4, 2).collect::<Vec<_>>(),
+            vec![vec![0, 1], vec![2, 3]]
+        );
+        assert_eq!(as_chunks(0..1, 2).collect::<Vec<_>>(), vec![vec![0]]);
+        assert_eq!(as_chunks(0..0, 2).next(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "chunk size must be positive")]
+    fn enrichment_chunks_reject_zero_chunk_size() {
+        let _ = as_chunks(0..1, 0);
+    }
 }


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Enrichment processes records in batches of 50 but eagerly materializes every batch before its first await. Dispatch insertion owns its models yet clones each 3,250-row chunk, including message bodies, into the SQL insert builder.

## Solution

Materialize only the next owned enrichment chunk. Move dispatch models into INSERTs instead of cloning them. Preserve chunk sizes, serial provider calls, statement counts, conflict handling and the surrounding transaction.

## Numerical impact

| Case | Before → after | Evidence |
|---|---|---|
| 1,000 missing enrichment records | 1,000 → 50 temporary buffered entries (95% fewer) | Source-derived; regression proves lazy consumption |
| Dispatch models | One deep clone per message → zero | Ownership change; bodies and address buffers move into INSERTs |
| 3,250 nonempty 1 KiB bodies plus one empty record | 3,328,000 extra body-copy bytes / 3,250 body allocations → zero from chunk cloning | Source-derived for the real PostgreSQL fixture |

Existing maps and model vectors still scale with total input size. SQL serialization still allocates; this is not a whole-process allocation or RSS claim. No RPC/query-count or measured latency improvement claimed. Empty message bodies remain SQL NULL.

## Verification and scope

- **6/6 chunk-related tests passed**, including lazy consumption/drop, order/full/partial/empty batches, prior duplicate-boundary coverage and a real PostgreSQL **3,251-row** dispatch insert/replay checking every payload across the 3,250-row boundary.
- Existing fallback/restart PostgreSQL regression passed **1/1**.
- Strict production scraper Clippy, formatting and normal commit hooks passed. Root and independent validator review completed.
- No schema, cursor, concurrency, transaction or fallback behavior changes. Whole-operation memory remains proportional to the input.
- Neither exclusion gist covers eager enrichment chunk vectors or owned dispatch model clones. No transaction-first enrichment shortcut is included; that would need separate metadata-consistency work.

Stack: follows #9481, #9476 and #9468.
