### PR TITLE
fix(scraper): bound block and transaction hash lookups

### DIFF
--- a/rust/main/agents/scraper/src/db/block.rs
+++ b/rust/main/agents/scraper/src/db/block.rs
@@ -1,4 +1,5 @@
 use eyre::{Context, Result};
+use itertools::Itertools;
 use migration::OnConflict;
 use sea_orm::{
     prelude::*, sea_query::SelectStatement, ActiveValue::*, DbErr, EntityTrait, FromQueryResult,
@@ -57,17 +58,24 @@ impl ScraperDb {
         &self,
         hashes: impl Iterator<Item = &H256>,
     ) -> Result<Vec<BasicBlock>> {
-        // check database to see which blocks we already know and fetch their IDs
-        let blocks = block::Entity::find()
-            .filter(block::Column::Hash.is_in(hashes.map(h256_to_bytes)))
-            .select_only()
-            // these must align with the custom impl of FromQueryResult
-            .column_as(block::Column::Id, "id")
-            .column_as(block::Column::Hash, "hash")
-            .into_model::<BasicBlock>()
-            .all(&self.0)
-            .await
-            .context("When querying blocks")?;
+        let hashes = hashes.unique().collect_vec();
+        let mut blocks = Vec::new();
+        for hashes in hashes.chunks(Self::HASH_LOOKUP_CHUNK_SIZE) {
+            blocks.extend(
+                block::Entity::find()
+                    .filter(
+                        block::Column::Hash.is_in(hashes.iter().map(|hash| h256_to_bytes(hash))),
+                    )
+                    .select_only()
+                    // These must align with the custom impl of FromQueryResult.
+                    .column_as(block::Column::Id, "id")
+                    .column_as(block::Column::Hash, "hash")
+                    .into_model::<BasicBlock>()
+                    .all(&self.0)
+                    .await
+                    .context("When querying blocks")?,
+            );
+        }
 
         trace!(blocks = blocks.len(), "Queried block info for hashes");
         Ok(blocks)

--- a/rust/main/agents/scraper/src/db/lookup_batches.rs
+++ b/rust/main/agents/scraper/src/db/lookup_batches.rs
@@ -1,0 +1,95 @@
+//! Hash lookup bounds, deduplication and error propagation.
+use std::collections::BTreeMap;
+
+use hyperlane_core::{h256_to_bytes, h512_to_bytes, H256, H512};
+use sea_orm::{DatabaseBackend, DbErr, MockDatabase, Value};
+
+use super::ScraperDb;
+
+fn row(id: usize, hash: Vec<u8>) -> BTreeMap<String, Value> {
+    BTreeMap::from([
+        ("id".to_owned(), Value::BigInt(Some(id as i64))),
+        ("hash".to_owned(), Value::Bytes(Some(Box::new(hash)))),
+    ])
+}
+
+#[tokio::test]
+async fn hash_lookups_bound_large_inputs_and_deduplicate_across_chunks() {
+    let blocks: Vec<_> = (0..66_000).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..66_000).map(H512::from_low_u64_be).collect();
+    let mut responses = Vec::new();
+    for chunk in blocks.chunks(ScraperDb::HASH_LOOKUP_CHUNK_SIZE) {
+        responses.push(vec![row(responses.len(), h256_to_bytes(&chunk[0]))]);
+    }
+    for chunk in txns.chunks(ScraperDb::HASH_LOOKUP_CHUNK_SIZE) {
+        responses.push(vec![row(responses.len(), h512_to_bytes(&chunk[0]))]);
+    }
+    let db = ScraperDb::with_connection(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(responses)
+            .into_connection(),
+    );
+    let found_blocks = db
+        .get_block_basic(blocks.iter().chain(blocks[..1].iter()))
+        .await
+        .unwrap();
+    let found_txns = db
+        .get_txn_ids(txns.iter().chain(txns[..1].iter()))
+        .await
+        .unwrap();
+    assert_eq!(found_blocks.len(), 2);
+    assert_eq!(found_txns.len(), 2);
+    for index in 0..2 {
+        assert_eq!(found_blocks[index].hash, blocks[index * 65_000]);
+        assert_eq!(found_blocks[index].id, index as i64);
+        assert_eq!(found_txns[&txns[index * 65_000]], (index + 2) as i64);
+    }
+    let log = db.0.into_transaction_log();
+    assert_eq!(log.len(), 4);
+    for (index, query) in log.iter().enumerate() {
+        let statement = &query.statements()[0];
+        let values = &statement.values.as_ref().unwrap().0;
+        assert_eq!(values.len(), if index % 2 == 1 { 1_000 } else { 65_000 });
+    }
+}
+
+#[tokio::test]
+async fn empty_hash_lookups_skip_database() {
+    let db =
+        ScraperDb::with_connection(MockDatabase::new(DatabaseBackend::Postgres).into_connection());
+    assert!(db
+        .get_block_basic(std::iter::empty())
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(db.get_txn_ids(std::iter::empty()).await.unwrap().is_empty());
+    assert!(db.0.into_transaction_log().is_empty());
+}
+
+#[tokio::test]
+async fn hash_lookups_propagate_failed_tail_without_partial_results() {
+    let blocks: Vec<_> = (0..65_001).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..65_001).map(H512::from_low_u64_be).collect();
+    for is_block in [true, false] {
+        let db = ScraperDb::with_connection(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![row(
+                    1,
+                    if is_block {
+                        h256_to_bytes(&blocks[0])
+                    } else {
+                        h512_to_bytes(&txns[0])
+                    },
+                )]])
+                .append_query_errors([DbErr::Custom("lookup tail failed".to_owned())])
+                .into_connection(),
+        );
+        let error = if is_block {
+            db.get_block_basic(blocks.iter()).await.unwrap_err()
+        } else {
+            db.get_txn_ids(txns.iter()).await.unwrap_err()
+        };
+        assert!(format!("{error:#}").contains("lookup tail failed"));
+        assert_eq!(db.0.into_transaction_log().len(), 2);
+    }
+}

--- a/rust/main/agents/scraper/src/db/mod.rs
+++ b/rust/main/agents/scraper/src/db/mod.rs
@@ -29,6 +29,9 @@ mod txn;
 pub struct ScraperDb(DbConn);
 
 impl ScraperDb {
+    // Hash lookups bind one parameter per hash; stay below PostgreSQL's 65,535 limit.
+    const HASH_LOOKUP_CHUNK_SIZE: usize = 65_000;
+
     #[instrument]
     pub async fn connect(url: &str) -> Result<Self> {
         let db = Database::connect(url).await?;
@@ -65,3 +68,6 @@ impl Clone for ScraperDb {
 
 #[cfg(test)]
 mod write_batches;
+
+#[cfg(test)]
+mod lookup_batches;

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use derive_more::Deref;
 use eyre::{eyre, Context, Result};
+use itertools::Itertools;
 use sea_orm::{
     prelude::*, sea_query::OnConflict, ActiveValue::*, DeriveColumn, EnumIter, Insert, NotSet,
     QuerySelect,
@@ -34,19 +35,25 @@ impl ScraperDb {
             Hash,
         }
 
-        // check database to see which txns we already know and fetch their IDs
-        let txns = transaction::Entity::find()
-            .filter(transaction::Column::Hash.is_in(hashes.map(h512_to_bytes)))
-            .select_only()
-            .column_as(transaction::Column::Id, QueryAs::Id)
-            .column_as(transaction::Column::Hash, QueryAs::Hash)
-            .into_values::<(i64, Vec<u8>), QueryAs>()
-            .all(&self.0)
-            .await
-            .context("When querying transactions")?
-            .into_iter()
-            .map(|(id, hash)| Ok((bytes_to_h512(&hash), id)))
-            .collect::<Result<HashMap<_, _>>>()?;
+        let hashes = hashes.unique().collect_vec();
+        let mut txns = HashMap::new();
+        for hashes in hashes.chunks(Self::HASH_LOOKUP_CHUNK_SIZE) {
+            let rows = transaction::Entity::find()
+                .filter(
+                    transaction::Column::Hash.is_in(hashes.iter().map(|hash| h512_to_bytes(hash))),
+                )
+                .select_only()
+                .column_as(transaction::Column::Id, QueryAs::Id)
+                .column_as(transaction::Column::Hash, QueryAs::Hash)
+                .into_values::<(i64, Vec<u8>), QueryAs>()
+                .all(&self.0)
+                .await
+                .context("When querying transactions")?;
+            txns.extend(
+                rows.into_iter()
+                    .map(|(id, hash)| (bytes_to_h512(&hash), id)),
+            );
+        }
 
         trace!(?txns, "Queried transaction info for hashes");
         Ok(txns)

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -431,3 +431,42 @@ async fn dispatch_chunks_preserve_owned_payloads_and_replay() -> eyre::Result<()
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn hash_lookups_read_both_chunks_without_duplicate_results_in_postgres() -> eyre::Result<()> {
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let first_tx = seed_transaction(&db, 0).await?;
+    let tail_tx = seed_transaction(&db, 65_000).await?;
+    db.store_blocks(
+        DOMAIN,
+        [BlockInfo {
+            hash: H256::from_low_u64_be(65_055),
+            timestamp: 1_700_000_001,
+            number: 501,
+        }]
+        .into_iter(),
+    )
+    .await?;
+    let blocks: Vec<_> = (0..66_000).map(H256::from_low_u64_be).collect();
+    let txns: Vec<_> = (0..66_000).map(H512::from_low_u64_be).collect();
+    let found_blocks = db
+        .get_block_basic(blocks.iter().chain(blocks[55..56].iter()))
+        .await?;
+    assert_eq!(found_blocks.len(), 2);
+    assert!(found_blocks.iter().any(|row| row.hash == blocks[55]));
+    assert!(found_blocks.iter().any(|row| row.hash == blocks[65_055]));
+    let found_txns = db
+        .get_txn_ids(txns.iter().chain(txns[66..67].iter()))
+        .await?;
+    assert_eq!(found_txns.len(), 2);
+    assert_eq!(found_txns[&txns[66]], first_tx);
+    assert_eq!(found_txns[&txns[65_066]], tail_tx);
+    Ok(())
+}


### PR DESCRIPTION
Consolidated into #9468 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Initial block/transaction enrichment lookups build one IN predicate for the complete hash set. The later 50-record enrichment chunks bound writes but do not protect these earlier reads from PostgreSQL's 65,535-parameter limit.

## Solution

Deduplicate hashes before splitting lookups into at most 65,000 parameters per SELECT. Accumulate the same result types, omit missing hashes as before and return an error for the complete call if any chunk fails. Empty input issues no query.

## Numerical impact

| Input per helper | Before → after | Evidence |
|---|---|---|
| 66,000 unique hashes | One invalid 66,000-bind SELECT → two SELECTs with 65,000 + 1,000 binds | Exact emitted SQL and real PostgreSQL regression |
| Repeated hashes | Repeated bind values → one bind per unique hash | Duplicate spanning chunk boundary verified |
| Empty input | One empty-result SELECT → zero queries | Regression |
| 1–65,000 unique hashes | One SELECT → one SELECT | Bound and code path |

65,000 retains 535 parameters of headroom without the extra round trips of a smaller arbitrary cap. This is a source-confirmed reliability variant, not an observed production lookup failure or measured latency gain. Deduplication adds set work for already-unique input; input/result collections still scale with batch size. Initial production callers already guard empty maps, so empty-input savings apply to direct helper calls.

## Verification and scope

- Four focused lookup tests passed, including real PostgreSQL with 66,000 unique hashes, stored records in both chunks, missing records and a repeated input hash. Mock SQL tests verify both exact bind counts, zero-query empty calls and failed-tail error propagation without partial results.
- Existing PostgreSQL block/restart regressions and strict production scraper Clippy passed; formatting, spellcheck and normal commit hooks passed.
- Root and independent validator reviews found no remaining blockers. Hash encoding and metadata-consistency checks are unchanged.
- Large reads now span multiple statement snapshots. Current production hash-to-ID storage is insert-only; consumers index by hash and enrich missing entries, with no cross-row snapshot invariant. No transaction-first shortcut or new cache is introduced.
- Completes the initial lookup variants identified alongside #9476/#9481. No overlap with the supplied RPC/cache/indexing performance DAGs.

Stack: follows #9484, #9481, #9476 and #9468.
