### PR TITLE
perf(ccip-server): reduce receipt, logging and startup overhead

### DIFF
--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -3,7 +3,8 @@
   "spec": [
     "./tests/**/CallCommitmentsService.test.ts",
     "./tests/**/RateLimiting.test.ts",
-    "./tests/**/cctpMessageMatcher.test.ts"
+    "./tests/**/cctpMessageMatcher.test.ts",
+    "./tests/**/CCTPService.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -4,7 +4,8 @@
     "./tests/**/CallCommitmentsService.test.ts",
     "./tests/**/RateLimiting.test.ts",
     "./tests/**/cctpMessageMatcher.test.ts",
-    "./tests/**/CCTPService.test.ts"
+    "./tests/**/CCTPService.test.ts",
+    "./tests/**/AttestationPending.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/.mocharc.json
+++ b/typescript/ccip-server/.mocharc.json
@@ -5,7 +5,8 @@
     "./tests/**/RateLimiting.test.ts",
     "./tests/**/cctpMessageMatcher.test.ts",
     "./tests/**/CCTPService.test.ts",
-    "./tests/**/AttestationPending.test.ts"
+    "./tests/**/AttestationPending.test.ts",
+    "./tests/**/moduleRegistry.test.ts"
   ],
   "exit": true
 }

--- a/typescript/ccip-server/benchmarks/README.md
+++ b/typescript/ccip-server/benchmarks/README.md
@@ -1,0 +1,21 @@
+# CCIP startup benchmark
+
+Build parent and head in separate checkouts with identical Node/dependency versions:
+
+```sh
+pnpm --filter @hyperlane-xyz/ccip-server build
+pnpm --filter @hyperlane-xyz/ccip-server bundle
+```
+
+Then compare the complete local bundle directories (not just copied index files):
+
+```sh
+python3 typescript/ccip-server/benchmarks/startup.py \
+  /path/to/parent/typescript/ccip-server/bundle/index.js \
+  /path/to/head/typescript/ccip-server/bundle/index.js \
+  --node /absolute/path/to/node --rounds 5
+```
+
+Requires Python 3, Node and POSIX signals. It alternates fresh processes with `cctp,callCommitments` enabled, creates a synthetic filesystem registry, disables outbound Node socket/fetch calls, and polls only loopback health/metrics endpoints. Each process uses temporary ports and is stopped after measurement. No database or remote chain service is queried. Port selection has the usual local bind/release race; rerun if another local process claims a selected port.
+
+Output includes all samples, median readiness (both health and metrics responding), heap/RSS after explicit GC, and complete bundle bytes/file counts. Readiness includes process spawning and 10ms HTTP polling granularity. Bundle builds, dependency installation and filesystem cache effects are outside the timed interval. These are local startup measurements, not production request latency, image-size savings, or transaction validation. Do not use production registry data or credentials for this benchmark.

--- a/typescript/ccip-server/benchmarks/startup.py
+++ b/typescript/ccip-server/benchmarks/startup.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import signal
+import shutil
 import socket
 import statistics
 import subprocess
@@ -19,6 +20,10 @@ parser.add_argument('--rounds', type=int, default=5)
 args = parser.parse_args()
 if args.rounds < 1:
     parser.error('--rounds must be positive')
+node_path = shutil.which(args.node)
+if node_path is None:
+    parser.error(f'Node executable not found: {args.node}')
+node = str(Path(node_path).resolve())
 workspace = tempfile.TemporaryDirectory(prefix='ccip-startup-benchmark-')
 base = Path(workspace.name)
 registry = base / 'registry'
@@ -28,7 +33,6 @@ chain.mkdir(parents=True)
 (chain / 'metadata.yaml').write_text(json.dumps({'name': 'ethereum', 'chainId': 1, 'domainId': 1, 'protocol': 'ethereum', 'rpcUrls': [{'http': 'http://127.0.0.1:9'}], 'nativeToken': {'name': 'Ether', 'symbol': 'ETH', 'decimals': 18}}))
 (chain / 'addresses.yaml').write_text(json.dumps({'interchainAccountRouter': '0x' + '11' * 20, 'mailbox': '0x' + '22' * 20}))
 (base / 'ccip-network-disabled.mjs').write_text("import net from 'node:net';\nnet.Socket.prototype.connect=function(){throw new Error('Outbound network disabled for bundle benchmark');};\nglobalThis.fetch=async()=>{throw new Error('Outbound fetch disabled for bundle benchmark');};\nprocess.on('SIGUSR2',()=>{global.gc?.();process.stdout.write('BENCH_MEMORY '+JSON.stringify(process.memoryUsage())+'\\n');});\n")
-node = args.node
 bundles = {'parent': args.parent_bundle.resolve(), 'head': args.head_bundle.resolve()}
 
 def free_port():

--- a/typescript/ccip-server/benchmarks/startup.py
+++ b/typescript/ccip-server/benchmarks/startup.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+import signal
+import socket
+import statistics
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+parser = argparse.ArgumentParser(description='Compare local CCIP bundles with synthetic registry data and outbound networking disabled')
+parser.add_argument('parent_bundle', type=Path)
+parser.add_argument('head_bundle', type=Path)
+parser.add_argument('--node', default='node')
+parser.add_argument('--rounds', type=int, default=5)
+args = parser.parse_args()
+if args.rounds < 1:
+    parser.error('--rounds must be positive')
+workspace = tempfile.TemporaryDirectory(prefix='ccip-startup-benchmark-')
+base = Path(workspace.name)
+registry = base / 'registry'
+chain = registry / 'chains' / 'ethereum'
+chain.mkdir(parents=True)
+(registry / 'deployments' / 'warp_routes').mkdir(parents=True)
+(chain / 'metadata.yaml').write_text(json.dumps({'name': 'ethereum', 'chainId': 1, 'domainId': 1, 'protocol': 'ethereum', 'rpcUrls': [{'http': 'http://127.0.0.1:9'}], 'nativeToken': {'name': 'Ether', 'symbol': 'ETH', 'decimals': 18}}))
+(chain / 'addresses.yaml').write_text(json.dumps({'interchainAccountRouter': '0x' + '11' * 20, 'mailbox': '0x' + '22' * 20}))
+(base / 'ccip-network-disabled.mjs').write_text("import net from 'node:net';\nnet.Socket.prototype.connect=function(){throw new Error('Outbound network disabled for bundle benchmark');};\nglobalThis.fetch=async()=>{throw new Error('Outbound fetch disabled for bundle benchmark');};\nprocess.on('SIGUSR2',()=>{global.gc?.();process.stdout.write('BENCH_MEMORY '+JSON.stringify(process.memoryUsage())+'\\n');});\n")
+node = args.node
+bundles = {'parent': args.parent_bundle.resolve(), 'head': args.head_bundle.resolve()}
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(('127.0.0.1', 0))
+        return sock.getsockname()[1]
+rows = []
+for repeat in range(args.rounds):
+    for mode, bundle in bundles.items():
+        port = free_port()
+        metrics = free_port()
+        env = {
+            'NODE_ENV': 'test',
+            'LOG_FORMAT': 'json',
+            'SERVER_PORT': str(port),
+            'PROMETHEUS_PORT': str(metrics),
+            'REGISTRY_URI': str(registry),
+            'SERVER_BASE_URL': f'http://127.0.0.1:{port}',
+            'ENABLED_MODULES': 'cctp,callCommitments',
+            'HYPERLANE_EXPLORER_URL': 'http://127.0.0.1:9',
+            'CCTP_ATTESTATION_URL': 'http://127.0.0.1:9',
+            'DATABASE_URL': 'postgresql://unused:unused@127.0.0.1:9/unused',
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            logpath = Path(tmp) / 'log'
+            log = logpath.open('w')
+            start = time.perf_counter()
+            proc = subprocess.Popen([node, '--expose-gc', '--import', str(base / 'ccip-network-disabled.mjs'), str(bundle)], env=env, cwd=registry, stdout=log, stderr=subprocess.STDOUT, text=True)
+            row = {'mode': mode}
+            try:
+                deadline = time.time() + 20
+                while time.time() < deadline and proc.poll() is None:
+                    try:
+                        with urllib.request.urlopen(f'http://127.0.0.1:{port}/health', timeout=0.1) as r:
+                            assert r.status == 200
+                        with urllib.request.urlopen(f'http://127.0.0.1:{metrics}/metrics', timeout=0.1) as r:
+                            assert r.status == 200
+                        row['readyMs'] = (time.perf_counter() - start) * 1000
+                        break
+                    except (urllib.error.URLError, TimeoutError):
+                        time.sleep(0.01)
+                if 'readyMs' not in row:
+                    raise RuntimeError(logpath.read_text()[-1500:])
+                proc.send_signal(signal.SIGUSR2)
+                deadline = time.time() + 5
+                while time.time() < deadline:
+                    samples = [line[13:] for line in logpath.read_text().splitlines() if line.startswith('BENCH_MEMORY ')]
+                    if samples:
+                        row.update(json.loads(samples[-1]))
+                        break
+                    time.sleep(0.01)
+                if 'heapUsed' not in row:
+                    raise RuntimeError('Missing memory sample')
+            finally:
+                if proc.poll() is None:
+                    proc.terminate()
+                try:
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                log.close()
+            rows.append(row)
+print(json.dumps({'samples': rows}))
+print(json.dumps({mode: {key: statistics.median((row[key] for row in rows if row['mode'] == mode)) for key in ['readyMs', 'heapUsed', 'rss']} for mode in bundles}))
+print(json.dumps({mode: {'files': sum((1 for p in bundle.parent.rglob('*') if p.is_file())), 'bytes': sum((p.stat().st_size for p in bundle.parent.rglob('*') if p.is_file()))} for mode, bundle in bundles.items()}))
+workspace.cleanup()

--- a/typescript/ccip-server/src/moduleRegistry.ts
+++ b/typescript/ccip-server/src/moduleRegistry.ts
@@ -1,0 +1,24 @@
+import type { ServiceFactory } from './services/BaseService.js';
+
+// Keep optional module dependencies out of startup until that module is enabled.
+export const moduleRegistry: Record<string, ServiceFactory> = {
+  callCommitments: {
+    async create(name) {
+      const { CallCommitmentsService } =
+        await import('./services/CallCommitmentsService.js');
+      return CallCommitmentsService.create(name);
+    },
+  },
+  cctp: {
+    async create(name) {
+      const { CCTPService } = await import('./services/CCTPService.js');
+      return CCTPService.create(name);
+    },
+  },
+  opstack: {
+    async create(name) {
+      const { OPStackService } = await import('./services/OPStackService.js');
+      return OPStackService.create(name);
+    },
+  },
+};

--- a/typescript/ccip-server/src/server.ts
+++ b/typescript/ccip-server/src/server.ts
@@ -5,27 +5,18 @@ import express from 'express';
 import { pinoHttp } from 'pino-http';
 import { Registry } from 'prom-client';
 
-import { startMetricsServer } from '@hyperlane-xyz/metrics';
+import { startMetricsServer } from '@hyperlane-xyz/metrics/dist/server.js';
 import { createServiceLogger } from '@hyperlane-xyz/utils';
 
 import { getEnabledModules } from './config.js';
-import { ServiceFactory } from './services/BaseService.js';
-import { CCTPService } from './services/CCTPService.js';
-import { CallCommitmentsService } from './services/CallCommitmentsService.js';
+import { moduleRegistry } from './moduleRegistry.js';
 import { HealthService } from './services/HealthService.js';
-import { OPStackService } from './services/OPStackService.js';
 import { configureTrustProxy } from './utils/http.js';
 import {
   PrometheusMetrics,
   UnhandledErrorReason,
   initializeMetrics,
 } from './utils/prometheus.js';
-
-export const moduleRegistry: Record<string, ServiceFactory> = {
-  callCommitments: CallCommitmentsService,
-  cctp: CCTPService,
-  opstack: OPStackService,
-};
 
 async function startServer() {
   const VERSION = process.env.SERVICE_VERSION || 'dev';

--- a/typescript/ccip-server/src/services/BaseService.ts
+++ b/typescript/ccip-server/src/services/BaseService.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import { DEFAULT_GITHUB_REGISTRY, IRegistry } from '@hyperlane-xyz/registry';
 import { getRegistry } from '@hyperlane-xyz/registry/fs';
-import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { MultiProvider } from '@hyperlane-xyz/sdk/providers/MultiProvider';
 
 export const REGISTRY_URI_SCHEMA = z
   .string()

--- a/typescript/ccip-server/src/services/CCTPAttestationService.ts
+++ b/typescript/ccip-server/src/services/CCTPAttestationService.ts
@@ -3,6 +3,8 @@ import { Logger } from 'pino';
 
 import { assert } from '@hyperlane-xyz/utils';
 
+import { AttestationPendingError } from '../utils/errors.js';
+
 import {
   PrometheusMetrics,
   UnhandledErrorReason,
@@ -153,7 +155,7 @@ class CCTPAttestationService {
           },
           'CCTP attestation not found',
         );
-        throw new Error(`CCTP attestation is pending`);
+        throw new AttestationPendingError();
       }
 
       // This should not happen according to the CCTP API spec, but we'll log it just in case
@@ -238,7 +240,7 @@ class CCTPAttestationService {
           { messageId, messageCount: json.messages.length },
           'Could not match Circle API messages to cctpMessage — treating as pending',
         );
-        throw new Error('CCTP attestation is pending');
+        throw new AttestationPendingError();
       }
       matchingMessage = found;
     }
@@ -268,9 +270,9 @@ class CCTPAttestationService {
           );
           break;
         default:
-          logger.info({ ...context, ...matchingMessage }, errorString);
+          logger.debug({ ...context, ...matchingMessage }, errorString);
       }
-      throw new Error(errorString);
+      throw new AttestationPendingError();
     }
 
     return [matchingMessage.message, matchingMessage.attestation];

--- a/typescript/ccip-server/src/services/CCTPService.ts
+++ b/typescript/ccip-server/src/services/CCTPService.ts
@@ -25,6 +25,13 @@ import { CCTPAttestationService } from './CCTPAttestationService.js';
 import { findMatchingCircleMessage } from './cctpMessageMatcher.js';
 import { HyperlaneService } from './HyperlaneService.js';
 
+const messageTransmitterInterface =
+  IMessageTransmitter__factory.createInterface();
+const messageSentEvent =
+  messageTransmitterInterface.getEvent('MessageSent(bytes)');
+const messageSentTopic =
+  messageTransmitterInterface.getEventTopic(messageSentEvent);
+
 const EnvSchema = z.object({
   HYPERLANE_EXPLORER_URL: z.url(),
   CCTP_ATTESTATION_URL: z.url(),
@@ -102,15 +109,15 @@ class CCTPService extends BaseService {
       'Extracting CCTP message from receipt',
     );
 
-    const iface = IMessageTransmitter__factory.createInterface();
-    const event = iface.events['MessageSent(bytes)'];
-
     const allMessages: string[] = [];
     for (const receiptLog of receipt.logs) {
+      // Most receipt logs belong to other contracts. Avoid ABI lookup and
+      // exception allocation for events that cannot contain a CCTP message.
+      if (receiptLog.topics[0]?.toLowerCase() !== messageSentTopic) continue;
       try {
-        const parsedLog = iface.parseLog(receiptLog);
+        const parsedLog = messageTransmitterInterface.parseLog(receiptLog);
         if (
-          parsedLog.name === event.name &&
+          parsedLog.name === messageSentEvent.name &&
           typeof parsedLog.args.message === 'string'
         ) {
           allMessages.push(parsedLog.args.message);

--- a/typescript/ccip-server/src/services/CCTPService.ts
+++ b/typescript/ccip-server/src/services/CCTPService.ts
@@ -7,7 +7,7 @@ import {
   CctpService__factory,
   IMessageTransmitter__factory,
 } from '@hyperlane-xyz/core';
-import { MultiProvider } from '@hyperlane-xyz/sdk';
+import type { MultiProvider } from '@hyperlane-xyz/sdk/providers/MultiProvider';
 import { parseMessage } from '@hyperlane-xyz/utils';
 
 import { createAbiHandler } from '../utils/abiHandler.js';

--- a/typescript/ccip-server/src/services/CallCommitmentsService.ts
+++ b/typescript/ccip-server/src/services/CallCommitmentsService.ts
@@ -9,11 +9,9 @@ import {
   CommitmentReadIsmService__factory,
   InterchainAccountRouter__factory,
 } from '@hyperlane-xyz/core';
-import {
-  AccountConfig,
-  InterchainAccount,
-  MultiProvider,
-} from '@hyperlane-xyz/sdk';
+import { InterchainAccount } from '@hyperlane-xyz/sdk/middleware/account/InterchainAccount';
+import type { AccountConfig } from '@hyperlane-xyz/sdk/middleware/account/types';
+import type { MultiProvider } from '@hyperlane-xyz/sdk/providers/MultiProvider';
 import {
   PostCallsIcaType,
   PostCallsLegacyType,

--- a/typescript/ccip-server/src/utils/abiHandler.ts
+++ b/typescript/ccip-server/src/utils/abiHandler.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 
-import { offchainLookupRequestMessageHash } from '@hyperlane-xyz/sdk';
+import { offchainLookupRequestMessageHash } from '@hyperlane-xyz/sdk/ism/utils';
 
 import { AttestationPendingError } from './errors.js';
 

--- a/typescript/ccip-server/src/utils/abiHandler.ts
+++ b/typescript/ccip-server/src/utils/abiHandler.ts
@@ -6,6 +6,8 @@ import { z } from 'zod';
 
 import { offchainLookupRequestMessageHash } from '@hyperlane-xyz/sdk';
 
+import { AttestationPendingError } from './errors.js';
+
 const RelayerSignatureBodySchema = z.compile(
   z.object({
     sender: z.string().startsWith('0x').length(42, 'Invalid Ethereum address'),
@@ -121,14 +123,20 @@ export function createAbiHandler<
       handlerLogger.info({ reqBody: body, encoded }, 'Result encoded');
       return res.json({ data: encoded });
     } catch (err: any) {
-      handlerLogger.error(
-        {
-          reqBody: req.body,
-          error: err.message,
-          stack: err.stack,
-        },
-        `Error in ABI handler ${functionName}`,
-      );
+      if (err instanceof AttestationPendingError) {
+        // Expected polling state: keep the response contract and request metrics,
+        // but avoid repeatedly serializing calldata and stacks at error level.
+        handlerLogger.debug({ error: err.message }, 'CCTP attestation pending');
+      } else {
+        handlerLogger.error(
+          {
+            reqBody: req.body,
+            error: err.message,
+            stack: err.stack,
+          },
+          `Error in ABI handler ${functionName}`,
+        );
+      }
       return res.status(500).json({ error: err.message });
     }
   };

--- a/typescript/ccip-server/src/utils/errors.ts
+++ b/typescript/ccip-server/src/utils/errors.ts
@@ -1,0 +1,7 @@
+/** Circle has not produced an attestation yet; callers should retry. */
+export class AttestationPendingError extends Error {
+  constructor() {
+    super('CCTP attestation is pending');
+    this.name = 'AttestationPendingError';
+  }
+}

--- a/typescript/ccip-server/tests/services/AttestationPending.test.ts
+++ b/typescript/ccip-server/tests/services/AttestationPending.test.ts
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import express from 'express';
+import { pino } from 'pino';
+import pinoHttp from 'pino-http';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import { CctpService__factory } from '@hyperlane-xyz/core';
+
+import { CCTPAttestationService } from '../../src/services/CCTPAttestationService.js';
+import { createAbiHandler } from '../../src/utils/abiHandler.js';
+import { AttestationPendingError } from '../../src/utils/errors.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+
+function captureLogger(level = 'info') {
+  const lines: string[] = [];
+  const logger = pino(
+    { level },
+    {
+      write: (line: string) => {
+        lines.push(line);
+      },
+    },
+  );
+  return { logger, lines };
+}
+
+async function rejected(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error('Expected rejection');
+}
+
+describe('CCTP pending attestation logging', () => {
+  const cctpMessage = `0x${'00'.repeat(8)}`;
+  const transactionHash = `0x${'11'.repeat(32)}`;
+  const messageId = `0x${'22'.repeat(32)}`;
+  const service = new CCTPAttestationService('test', 'https://example.com');
+
+  beforeEach(() => {
+    initializeMetrics(new Registry());
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('retains retry errors while suppressing routine pending payload logs at info', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(
+        JSON.stringify({
+          messages: [{ message: cctpMessage, attestation: 'PENDING' }],
+        }),
+      ),
+    );
+    const { logger, lines } = captureLogger();
+    const error = await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(error).to.be.instanceOf(AttestationPendingError);
+    expect(error.message).to.equal('CCTP attestation is pending');
+    expect(lines).to.have.length(0);
+  });
+
+  it('keeps pending details available at debug level', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(
+        JSON.stringify({
+          messages: [{ message: cctpMessage, attestation: 'PENDING' }],
+        }),
+      ),
+    );
+    const { logger, lines } = captureLogger('debug');
+    await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(lines).to.have.length(1);
+    expect(lines[0]).to.include('CCTP attestation is pending');
+    expect(lines[0]).to.include(cctpMessage);
+  });
+
+  it('keeps actionable Circle delay reasons at error level', async () => {
+    sinon.stub(globalThis, 'fetch').resolves(
+      new Response(
+        JSON.stringify({
+          messages: [
+            {
+              message: cctpMessage,
+              attestation: 'PENDING',
+              delayReason: 'insufficient_fee',
+            },
+          ],
+        }),
+      ),
+    );
+    const { logger, lines } = captureLogger();
+    const error = await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(error).to.be.instanceOf(AttestationPendingError);
+    expect(lines).to.have.length(1);
+    expect(lines[0]).to.include('"level":50');
+    expect(lines[0]).to.include('insufficient_fee');
+  });
+
+  it('classifies a not-yet-found attestation as pending', async () => {
+    sinon
+      .stub(globalThis, 'fetch')
+      .resolves(new Response(null, { status: 404 }));
+    const { logger } = captureLogger();
+    expect(
+      await rejected(
+        service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+      ),
+    ).to.be.instanceOf(AttestationPendingError);
+  });
+
+  it('does not suppress genuine upstream failures', async () => {
+    sinon
+      .stub(globalThis, 'fetch')
+      .resolves(new Response(null, { status: 500, statusText: 'Unavailable' }));
+    const { logger, lines } = captureLogger();
+    const error = await rejected(
+      service.getAttestation(cctpMessage, transactionHash, messageId, logger),
+    );
+    expect(error).not.to.be.instanceOf(AttestationPendingError);
+    expect(error.message).to.equal(
+      'CCTP attestation request failed: Unavailable',
+    );
+    expect(lines[0]).to.include('"level":50');
+  });
+
+  for (const expected of [true, false]) {
+    it(`preserves HTTP status and body for ${expected ? 'typed pending' : 'ordinary'} errors`, async () => {
+      const { logger, lines } = captureLogger();
+      const error = expected
+        ? new AttestationPendingError()
+        : new Error('CCTP attestation is pending');
+      const app = express();
+      app.use(express.json());
+      app.use(pinoHttp({ logger }));
+      app.post(
+        '/',
+        createAbiHandler(CctpService__factory, 'getCCTPAttestation', () =>
+          Promise.reject(error),
+        ),
+      );
+      const server = app.listen(0);
+      await new Promise<void>((resolve) => {
+        server.once('listening', resolve);
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === 'string')
+          throw new Error('Expected TCP server');
+        const data = CctpService__factory.createInterface().encodeFunctionData(
+          'getCCTPAttestation',
+          ['0x1234'],
+        );
+        const response = await fetch(`http://127.0.0.1:${address.port}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ data }),
+        });
+        expect(response.status).to.equal(500);
+        expect(await response.json()).to.deep.equal({
+          error: 'CCTP attestation is pending',
+        });
+        const handlerErrors = lines.filter((line) =>
+          line.includes('Error in ABI handler'),
+        );
+        expect(handlerErrors).to.have.length(expected ? 0 : 1);
+        expect(
+          lines.some((line) => line.includes('Processing ABI handler request')),
+        ).to.equal(true);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+      }
+    });
+  }
+});

--- a/typescript/ccip-server/tests/services/CCTPService.test.ts
+++ b/typescript/ccip-server/tests/services/CCTPService.test.ts
@@ -1,0 +1,140 @@
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import pino from 'pino';
+import { Registry } from 'prom-client';
+import sinon from 'sinon';
+
+import { IMessageTransmitter__factory } from '@hyperlane-xyz/core';
+import { MultiProvider } from '@hyperlane-xyz/sdk';
+import { formatMessage } from '@hyperlane-xyz/utils';
+
+import { CCTPService } from '../../src/services/CCTPService.js';
+import { initializeMetrics } from '../../src/utils/prometheus.js';
+
+const iface = IMessageTransmitter__factory.createInterface();
+const event = iface.getEvent('MessageSent(bytes)');
+const address = `0x${'12'.repeat(20)}`;
+const hash = ethers.constants.HashZero;
+const logger = pino({ level: 'silent' });
+
+function log(data: string, topics: string[]): ethers.providers.Log {
+  return {
+    address,
+    data,
+    topics,
+    blockNumber: 1,
+    blockHash: hash,
+    transactionHash: hash,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
+function receipt(
+  logs: ethers.providers.Log[],
+): ethers.providers.TransactionReceipt {
+  return {
+    to: address,
+    from: address,
+    contractAddress: address,
+    transactionIndex: 0,
+    gasUsed: ethers.BigNumber.from(0),
+    logsBloom: '0x',
+    blockHash: hash,
+    transactionHash: hash,
+    logs,
+    blockNumber: 1,
+    confirmations: 1,
+    cumulativeGasUsed: ethers.BigNumber.from(0),
+    effectiveGasPrice: ethers.BigNumber.from(0),
+    byzantium: true,
+    type: 2,
+  };
+}
+
+function messageLog(message: string): ethers.providers.Log {
+  const encoded = iface.encodeEventLog(event, [message]);
+  return log(encoded.data, encoded.topics);
+}
+
+describe('CCTPService receipt decoding', () => {
+  let service: CCTPService;
+  beforeEach(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      HYPERLANE_EXPLORER_URL: 'https://example.com',
+      CCTP_ATTESTATION_URL: 'https://example.com',
+    });
+    initializeMetrics(new Registry());
+    service = new CCTPService({
+      serviceName: 'test',
+      multiProvider: new MultiProvider({}),
+    });
+  });
+  afterEach(() => sinon.restore());
+
+  it('decodes only MessageSent events in a receipt with unrelated and anonymous logs', async () => {
+    const parse = sinon.spy(ethers.utils.Interface.prototype, 'parseLog');
+    const unrelated = Array.from({ length: 100 }, () => log('0x', [hash]));
+    const result = await service.getCCTPMessageFromReceipt(
+      receipt([...unrelated, log('0x', []), messageLog('0x1234')]),
+      '0x',
+      hash,
+      logger,
+    );
+    expect(result).to.equal('0x1234');
+    expect(parse.callCount).to.equal(1);
+  });
+
+  it('retains case-insensitive topic matching and skips malformed matching logs', async () => {
+    const valid = messageLog('0x1234');
+    valid.topics = valid.topics.map(
+      (topic) => `0x${topic.slice(2).toUpperCase()}`,
+    );
+    const result = await service.getCCTPMessageFromReceipt(
+      receipt([log('0x', [iface.getEventTopic(event)]), valid]),
+      '0x',
+      hash,
+      logger,
+    );
+    expect(result).to.equal('0x1234');
+  });
+
+  it('preserves the error when no valid MessageSent event exists', async () => {
+    try {
+      await service.getCCTPMessageFromReceipt(
+        receipt([log('0x', [hash])]),
+        '0x',
+        hash,
+        logger,
+      );
+      expect.fail('Expected a missing-message error');
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      expect(error.message).to.equal(
+        'Unable to find MessageSent event in logs',
+      );
+    }
+  });
+
+  it('retains multi-message disambiguation after filtering unrelated events', async () => {
+    const hyperlaneMessage = formatMessage(3, 0, 1, address, 2, address, '0x');
+    const id = ethers.utils.keccak256(hyperlaneMessage);
+    const gmp = Buffer.alloc(180);
+    Buffer.from(id.slice(2), 'hex').copy(gmp, 148);
+    const matchingMessage = ethers.utils.hexlify(gmp);
+    const otherMessage = ethers.utils.hexlify(Buffer.alloc(180));
+    const result = await service.getCCTPMessageFromReceipt(
+      receipt([
+        messageLog(otherMessage),
+        log('0x', [hash]),
+        messageLog(matchingMessage),
+      ]),
+      hyperlaneMessage,
+      id,
+      logger,
+    );
+    expect(result).to.equal(matchingMessage);
+  });
+});

--- a/typescript/ccip-server/tests/services/moduleRegistry.test.ts
+++ b/typescript/ccip-server/tests/services/moduleRegistry.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import { moduleRegistry } from '../../src/moduleRegistry.js';
+
+describe('module registry', () => {
+  it('retains the known names and leaves unknown modules absent', () => {
+    expect(Object.keys(moduleRegistry)).to.deep.equal([
+      'callCommitments',
+      'cctp',
+      'opstack',
+    ]);
+    expect(moduleRegistry.unknown).to.equal(undefined);
+  });
+
+  for (const [name, requiredSetting] of [
+    ['callCommitments', 'SERVER_BASE_URL'],
+    ['cctp', 'HYPERLANE_EXPLORER_URL'],
+    ['opstack', 'HYPERLANE_EXPLORER_API'],
+  ] as const) {
+    it(`loads ${name} and preserves required configuration validation`, async () => {
+      const previous = process.env[requiredSetting];
+      delete process.env[requiredSetting];
+      let rejected: unknown;
+      try {
+        await moduleRegistry[name].create(name);
+      } catch (error) {
+        rejected = error;
+      } finally {
+        if (previous === undefined) delete process.env[requiredSetting];
+        else process.env[requiredSetting] = previous;
+      }
+      expect(rejected).to.have.property('name', 'ZodError');
+      expect(rejected).to.have.nested.property(
+        'issues[0].path[0]',
+        requiredSetting,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Problem

CCIP processing attempted ABI decoding for unrelated receipt logs, duplicated ordinary pending-attestation error records, and loaded unused startup dependencies.

## Solution

Reuse the receipt interface and filter matching topics, keep ordinary pending details at DEBUG while preserving HTTP 500/retry semantics and actionable errors, and load only enabled service modules through supported dependency imports.

Consolidates #9463, #9475, #9486. Earlier PRs retain their original descriptions and detailed benchmark references.

## Performance evidence

| Component | Evidence and scope |
| --- | --- |
| skip decoding unrelated receipt logs | 102 → 1 ABI parse in synthetic receipt (99.0% fewer) |
| avoid duplicate error logs for pending attestations | Ordinary pending response: 2 targeted INFO/ERROR records → 0 at INFO. Observed 1,348 detail records model 1.13 MB avoided selected-field JSON; HTTP 500 behavior retained. |
| load only required startup dependencies | Local offline bundled readiness: 489.8 → 413.4 ms; NCC output 72.13 → 29.19 MB. Synthetic registry; not deployed readiness or final image size. |

These measurements describe separate workloads and scopes. Percentages must not be added; local or modeled results are not deployed speedups. The individual benchmark artifacts remain in this branch.

## Validation

The unchanged cumulative source at bcd635d46f2afe21191df90b8e6cf65b830a1439 has 69 passing CCIP tests and successful builds, lint and offline bundled-startup checks. Tests cover matching/malformed logs, multiple messages, identical pending/error responses and logging behavior. Consolidation changes only PR scope and description; the cumulative source tree is unchanged and merges cleanly with current main.

No runtime behavior was added during consolidation. The PR remains a draft.

Reproduction: [startup benchmark instructions](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/bcd635d46f2afe21191df90b8e6cf65b830a1439/typescript/ccip-server/benchmarks/README.md), [startup runner](https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/bcd635d46f2afe21191df90b8e6cf65b830a1439/typescript/ccip-server/benchmarks/startup.py).
