### PR TITLE
perf(scraper): move raw dispatch and transaction payload buffers

### DIFF
--- a/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
+++ b/rust/main/agents/scraper/src/db/raw_message_dispatch.rs
@@ -140,8 +140,13 @@ impl ScraperDb {
                 Box::pin(async move {
                     // Insert raw message dispatches in chunks, to not run into
                     // "Too many arguments" error
-                    for chunk in models.chunks(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE) {
-                        Insert::many(chunk.to_vec())
+                    let mut models = models.into_iter();
+                    while !models.as_slice().is_empty() {
+                        let chunk: Vec<_> = models
+                            .by_ref()
+                            .take(Self::STORE_RAW_MESSAGE_DISPATCH_CHUNK_SIZE)
+                            .collect();
+                        Insert::many(chunk)
                             .on_conflict(
                                 OnConflict::column(raw_message_dispatch::Column::MsgId)
                                     .update_columns([

--- a/rust/main/agents/scraper/src/db/txn.rs
+++ b/rust/main/agents/scraper/src/db/txn.rs
@@ -86,7 +86,7 @@ impl ScraperDb {
                     recipient: Set(txn.recipient.as_ref().map(address_to_bytes)),
                     max_fee_per_gas: Set(txn.max_fee_per_gas.map(u256_to_decimal)),
                     cumulative_gas_used: Set(u256_to_decimal(receipt.cumulative_gas_used)),
-                    raw_input_data: Set(txn.raw_input_data.clone()),
+                    raw_input_data: Set(txn.info.raw_input_data),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -470,3 +470,101 @@ async fn hash_lookups_read_both_chunks_without_duplicate_results_in_postgres() -
     assert_eq!(found_txns[&txns[65_066]], tail_tx);
     Ok(())
 }
+
+#[tokio::test]
+async fn owned_raw_payloads_and_transaction_inputs_survive_storage() -> eyre::Result<()> {
+    use super::generated::{raw_message_dispatch, transaction};
+    use super::StorableRawMessageDispatch;
+    use hyperlane_core::HyperlaneMessage;
+
+    let postgres = Postgres::default().start().await?;
+    let port = postgres.get_host_port_ipv4(5432).await?;
+    let connection = Database::connect(format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    migration::Migrator::up(&connection, None).await?;
+    let db = ScraperDb::with_connection(connection);
+    let meta = LogMeta::default();
+    let address = H256::from_low_u64_be(1);
+    let messages: Vec<_> = (0..2_955u32)
+        .map(|nonce| HyperlaneMessage {
+            nonce,
+            origin: DOMAIN,
+            destination: DOMAIN,
+            body: if nonce == 0 {
+                vec![]
+            } else {
+                vec![(nonce % 251) as u8; 1_024]
+            },
+            ..Default::default()
+        })
+        .collect();
+    let rows = || {
+        messages
+            .iter()
+            .map(|msg| StorableRawMessageDispatch { msg, meta: &meta })
+    };
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        2_955
+    );
+    assert_eq!(
+        db.store_raw_message_dispatches(DOMAIN, &address, rows())
+            .await?,
+        0
+    );
+    let stored = raw_message_dispatch::Entity::find().all(&db.0).await?;
+    assert_eq!(stored.len(), messages.len());
+    for row in stored {
+        assert_eq!(
+            row.msg_body.as_ref(),
+            Some(&messages[row.nonce as usize].body)
+        );
+    }
+
+    seed_transaction(&db, 0).await?;
+    let block_id = db
+        .get_block_basic([&H256::from_low_u64_be(55)].into_iter())
+        .await?[0]
+        .id;
+    let inputs = [None, Some(vec![]), Some(vec![0xab; 4_096])];
+    let transactions = || {
+        inputs
+            .iter()
+            .enumerate()
+            .map(|(index, raw_input_data)| StorableTxn {
+                block_id,
+                info: TxnInfo {
+                    hash: H512::from_low_u64_be(100 + index as u64),
+                    gas_limit: U256::one(),
+                    max_priority_fee_per_gas: None,
+                    max_fee_per_gas: None,
+                    gas_price: None,
+                    nonce: 0,
+                    sender: H256::zero(),
+                    recipient: None,
+                    receipt: Some(TxnReceiptInfo {
+                        gas_used: U256::one(),
+                        cumulative_gas_used: U256::one(),
+                        effective_gas_price: None,
+                    }),
+                    raw_input_data: raw_input_data.clone(),
+                },
+            })
+    };
+    db.store_txns(transactions()).await?;
+    db.store_txns(transactions()).await?;
+    for (index, expected) in inputs.iter().enumerate() {
+        let row = transaction::Entity::find()
+            .filter(transaction::Column::Hash.eq(hyperlane_core::h512_to_bytes(
+                &H512::from_low_u64_be(100 + index as u64),
+            )))
+            .one(&db.0)
+            .await?
+            .unwrap();
+        assert_eq!(&row.raw_input_data, expected);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Raw dispatch storage owns its models but clones every 2,954-row chunk, copying body and identifier buffers again. Transaction storage owns its input data yet clones it through StorableTxn's Deref.

## Solution

Move raw models into the existing INSERT chunks and move owned transaction input into its ActiveModel. Preserve SQL, chunk limits, transaction boundaries, conflict updates and replay behavior. The initial copy from borrowed raw events remains necessary.

## Numerical impact

| Fixture / operation | Before → after | Evidence |
|---|---|---|
| 2,954 nonempty 1 KiB raw bodies plus one empty record | 2,954 extra body allocations and 3,024,896 copied body bytes → zero from model chunk cloning | Source-derived; actual PostgreSQL boundary/replay fixture |
| One nonempty 4 KiB transaction input | One extra input allocation / 4,096 copied bytes → zero | Ownership change and PostgreSQL roundtrip |
| RPC / SQL statement count | Unchanged | Same calls, chunk boundaries and insert builder |

Identifier/address clones also disappear but are not included in the byte figures. SQL serialization and the initial borrowed-event copy still allocate. No production latency, RSS or whole-operation memory percentage is claimed.

## Verification and scope

- **15 focused tests passed**: new PostgreSQL payload regression, 13 existing raw-dispatch tests and existing fallback/restart coverage.
- All 2,955 raw payloads survive insert/replay across the 2,954-row boundary. Transaction None, Some(empty) and nonempty input retain their distinct representations.
- Strict production scraper Clippy, formatting, spellcheck and normal commit hooks passed. Root and independent validator reviews found no blockers.
- No schema, cursor, acquisition or conflict-handling changes. #9449 reconciliation queries are untouched; #9484 separately removed enriched-dispatch clones.

Stack: follows #9485, #9484, #9481, #9476 and #9468.
