### PR TITLE
perf(scraper): project payment reconciliation identities

### DIFF
--- a/rust/main/agents/scraper/src/db/payment.rs
+++ b/rust/main/agents/scraper/src/db/payment.rs
@@ -151,29 +151,33 @@ impl ScraperDb {
             .map(|storable| h256_to_bytes(&storable.payment.message_id))
             .unique()
             .collect_vec();
-        let mut existing_payments = Vec::new();
+        let mut seen_fallback_payments = HashSet::new();
+        let mut existing_null_payments = HashSet::new();
         for message_ids in payment_msg_ids.chunks(Self::PAYMENT_STORE_CHUNK_SIZE) {
-            existing_payments.extend(
-                gas_payment::Entity::find()
-                    .filter(gas_payment::Column::Domain.eq(domain))
-                    .filter(
-                        gas_payment::Column::InterchainGasPaymaster
-                            .eq(interchain_gas_paymaster.clone()),
-                    )
-                    .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
-                    .all(&txn)
-                    .await?,
-            );
+            let existing_payments = gas_payment::Entity::find()
+                .select_only()
+                .columns([
+                    gas_payment::Column::MsgId,
+                    gas_payment::Column::LogIndex,
+                    gas_payment::Column::TxId,
+                ])
+                .filter(gas_payment::Column::Domain.eq(domain))
+                .filter(
+                    gas_payment::Column::InterchainGasPaymaster
+                        .eq(interchain_gas_paymaster.clone()),
+                )
+                .filter(gas_payment::Column::MsgId.is_in(message_ids.iter().cloned()))
+                .into_tuple::<(Vec<u8>, i64, Option<i64>)>()
+                .all(&txn)
+                .await?;
+            for (msg_id, log_index, tx_id) in existing_payments {
+                let identity = (msg_id, log_index);
+                if tx_id.is_none() {
+                    existing_null_payments.insert(identity.clone());
+                }
+                seen_fallback_payments.insert(identity);
+            }
         }
-        let mut seen_fallback_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .iter()
-            .map(|payment| (payment.msg_id.clone(), payment.log_index))
-            .collect();
-        let mut existing_null_payments: HashSet<(Vec<u8>, i64)> = existing_payments
-            .into_iter()
-            .filter(|payment| payment.tx_id.is_none())
-            .map(|payment| (payment.msg_id, payment.log_index))
-            .collect();
         let resolved_batch_payments: HashSet<(Vec<u8>, i64)> = payments
             .iter()
             .filter(|storable| storable.txn_id.is_some())

--- a/rust/main/agents/scraper/src/db/write_batches.rs
+++ b/rust/main/agents/scraper/src/db/write_batches.rs
@@ -181,6 +181,9 @@ async fn payment_prefetch_and_insert_statements_are_bounded_and_deduplicated() {
             .filter(|statement| statement.sql.contains(" IN ("))
             .collect();
         assert_eq!(reads.len(), chunks);
+        assert!(reads.iter().all(|statement| statement.sql.starts_with(
+            "SELECT \"gas_payment\".\"msg_id\", \"gas_payment\".\"log_index\", \"gas_payment\".\"tx_id\" FROM"
+        )));
         assert!(reads
             .iter()
             .all(|statement| statement.values.as_ref().unwrap().0.len() <= 5_002));


### PR DESCRIPTION
Consolidated into #9476 as part of the grouped Rust agent performance work. This PR is superseded; its original problem, measurements and validation are preserved below.

---

## Problem

Payment reconciliation fetches and decodes all 12 gas-payment columns, then uses only message ID, log index and transaction ID. It also retains a cumulative full-row vector and clones each message identity before discarding unused fields.

## Solution

Select the three required columns and populate the same global identity sets as each lookup chunk returns. Move identities into the seen set; clone only NULL-transaction identities needed in both sets. Complete all reads before reconciliation, within the same advisory-locked transaction.

## Numerical impact

| Work per existing row | Before → after | Evidence |
|---|---|---|
| Selected/decoded columns | 12 → 3 (75% fewer) | Generated entity schema and exact SQL projection test |
| Identity-buffer clones for resolved rows | One → zero | Owned tuple moved into set |
| Retained full-row collection across queries | All prior result rows → none | Each tuple batch consumed into required global sets |

75% is a column-count reduction, not a wire-byte or latency percentage. Lookup chunks contain 5,000 input IDs but may return more than 5,000 rows. Required global sets still scale with input/history; query count and lock scope remain unchanged.

## Verification and scope

- **Nine focused tests passed**: eight writer tests and the existing fallback/restart PostgreSQL regression. Coverage includes exact projection, 6,000-payment NULL/resolved replay and failed-tail restoration.
- Strict production scraper Clippy, formatting, spellcheck and normal commit hooks passed. Root and independent validator review found no blockers.
- Domain/paymaster filtering, global fallback identity semantics, duplicate handling and transaction ordering are unchanged.
- No overlap with #9449 raw-dispatch reconciliation work or the supplied acquisition/cache plans.

Stack: follows #9487 and the scraper stack rooted at #9468.
